### PR TITLE
♻️ refactor: remove redundant component display names

### DIFF
--- a/packages/builtin-tool-activator/src/client/Inspector/ActivateSkill/index.tsx
+++ b/packages/builtin-tool-activator/src/client/Inspector/ActivateSkill/index.tsx
@@ -106,5 +106,3 @@ export const ActivateSkillInspector = memo<
     </div>
   );
 });
-
-ActivateSkillInspector.displayName = 'ActivateSkillInspector';

--- a/packages/builtin-tool-activator/src/client/Inspector/ActivateTools/index.tsx
+++ b/packages/builtin-tool-activator/src/client/Inspector/ActivateTools/index.tsx
@@ -121,5 +121,3 @@ export const ActivateToolsInspector = memo<
     </Flexbox>
   );
 });
-
-ActivateToolsInspector.displayName = 'ActivateToolsInspector';

--- a/packages/builtin-tool-agent-builder/src/client/Inspector/GetAvailableModels/index.tsx
+++ b/packages/builtin-tool-agent-builder/src/client/Inspector/GetAvailableModels/index.tsx
@@ -61,6 +61,4 @@ export const GetAvailableModelsInspector = memo<
   );
 });
 
-GetAvailableModelsInspector.displayName = 'GetAvailableModelsInspector';
-
 export default GetAvailableModelsInspector;

--- a/packages/builtin-tool-agent-builder/src/client/Inspector/InstallPlugin/index.tsx
+++ b/packages/builtin-tool-agent-builder/src/client/Inspector/InstallPlugin/index.tsx
@@ -58,6 +58,4 @@ export const InstallPluginInspector = memo<
   );
 });
 
-InstallPluginInspector.displayName = 'InstallPluginInspector';
-
 export default InstallPluginInspector;

--- a/packages/builtin-tool-agent-builder/src/client/Inspector/SearchMarketTools/index.tsx
+++ b/packages/builtin-tool-agent-builder/src/client/Inspector/SearchMarketTools/index.tsx
@@ -59,6 +59,4 @@ export const SearchMarketToolsInspector = memo<
   );
 });
 
-SearchMarketToolsInspector.displayName = 'SearchMarketToolsInspector';
-
 export default SearchMarketToolsInspector;

--- a/packages/builtin-tool-agent-builder/src/client/Inspector/UpdateConfig/index.tsx
+++ b/packages/builtin-tool-agent-builder/src/client/Inspector/UpdateConfig/index.tsx
@@ -89,6 +89,4 @@ export const UpdateConfigInspector = memo<
   );
 });
 
-UpdateConfigInspector.displayName = 'UpdateConfigInspector';
-
 export default UpdateConfigInspector;

--- a/packages/builtin-tool-agent-builder/src/client/Inspector/UpdatePrompt/index.tsx
+++ b/packages/builtin-tool-agent-builder/src/client/Inspector/UpdatePrompt/index.tsx
@@ -91,6 +91,4 @@ export const UpdatePromptInspector = memo<
   );
 });
 
-UpdatePromptInspector.displayName = 'UpdatePromptInspector';
-
 export default UpdatePromptInspector;

--- a/packages/builtin-tool-agent-builder/src/client/Streaming/UpdatePrompt/index.tsx
+++ b/packages/builtin-tool-agent-builder/src/client/Streaming/UpdatePrompt/index.tsx
@@ -22,6 +22,4 @@ export const UpdatePromptStreaming = memo<BuiltinStreamingProps<UpdatePromptPara
   },
 );
 
-UpdatePromptStreaming.displayName = 'UpdatePromptStreaming';
-
 export default UpdatePromptStreaming;

--- a/packages/builtin-tool-agent-documents/src/client/Inspector/CopyDocument/index.tsx
+++ b/packages/builtin-tool-agent-documents/src/client/Inspector/CopyDocument/index.tsx
@@ -47,6 +47,4 @@ export const CopyDocumentInspector = memo<
   );
 });
 
-CopyDocumentInspector.displayName = 'CopyDocumentInspector';
-
 export default CopyDocumentInspector;

--- a/packages/builtin-tool-agent-documents/src/client/Inspector/CreateDocument/index.tsx
+++ b/packages/builtin-tool-agent-documents/src/client/Inspector/CreateDocument/index.tsx
@@ -49,6 +49,4 @@ export const CreateDocumentInspector = memo<
   );
 });
 
-CreateDocumentInspector.displayName = 'CreateDocumentInspector';
-
 export default CreateDocumentInspector;

--- a/packages/builtin-tool-agent-documents/src/client/Inspector/ListDocuments/index.tsx
+++ b/packages/builtin-tool-agent-documents/src/client/Inspector/ListDocuments/index.tsx
@@ -48,6 +48,4 @@ export const ListDocumentsInspector = memo<
   );
 });
 
-ListDocumentsInspector.displayName = 'ListDocumentsInspector';
-
 export default ListDocumentsInspector;

--- a/packages/builtin-tool-agent-documents/src/client/Inspector/ModifyNodes/index.tsx
+++ b/packages/builtin-tool-agent-documents/src/client/Inspector/ModifyNodes/index.tsx
@@ -57,6 +57,4 @@ export const ModifyNodesInspector = memo<
   );
 });
 
-ModifyNodesInspector.displayName = 'ModifyNodesInspector';
-
 export default ModifyNodesInspector;

--- a/packages/builtin-tool-agent-documents/src/client/Inspector/ReadDocument/index.tsx
+++ b/packages/builtin-tool-agent-documents/src/client/Inspector/ReadDocument/index.tsx
@@ -45,6 +45,4 @@ export const ReadDocumentInspector = memo<
   );
 });
 
-ReadDocumentInspector.displayName = 'ReadDocumentInspector';
-
 export default ReadDocumentInspector;

--- a/packages/builtin-tool-agent-documents/src/client/Inspector/RemoveDocument/index.tsx
+++ b/packages/builtin-tool-agent-documents/src/client/Inspector/RemoveDocument/index.tsx
@@ -51,6 +51,4 @@ export const RemoveDocumentInspector = memo<
   );
 });
 
-RemoveDocumentInspector.displayName = 'RemoveDocumentInspector';
-
 export default RemoveDocumentInspector;

--- a/packages/builtin-tool-agent-documents/src/client/Inspector/RenameDocument/index.tsx
+++ b/packages/builtin-tool-agent-documents/src/client/Inspector/RenameDocument/index.tsx
@@ -47,6 +47,4 @@ export const RenameDocumentInspector = memo<
   );
 });
 
-RenameDocumentInspector.displayName = 'RenameDocumentInspector';
-
 export default RenameDocumentInspector;

--- a/packages/builtin-tool-agent-documents/src/client/Inspector/ReplaceDocumentContent/index.tsx
+++ b/packages/builtin-tool-agent-documents/src/client/Inspector/ReplaceDocumentContent/index.tsx
@@ -49,6 +49,4 @@ export const ReplaceDocumentContentInspector = memo<
   );
 });
 
-ReplaceDocumentContentInspector.displayName = 'ReplaceDocumentContentInspector';
-
 export default ReplaceDocumentContentInspector;

--- a/packages/builtin-tool-agent-documents/src/client/Inspector/UpdateLoadRule/index.tsx
+++ b/packages/builtin-tool-agent-documents/src/client/Inspector/UpdateLoadRule/index.tsx
@@ -47,6 +47,4 @@ export const UpdateLoadRuleInspector = memo<
   );
 });
 
-UpdateLoadRuleInspector.displayName = 'UpdateLoadRuleInspector';
-
 export default UpdateLoadRuleInspector;

--- a/packages/builtin-tool-agent-documents/src/client/Streaming/CreateDocument/index.tsx
+++ b/packages/builtin-tool-agent-documents/src/client/Streaming/CreateDocument/index.tsx
@@ -68,6 +68,4 @@ export const CreateDocumentStreaming = memo<BuiltinStreamingProps<CreateDocument
   },
 );
 
-CreateDocumentStreaming.displayName = 'AgentDocumentsCreateDocumentStreaming';
-
 export default CreateDocumentStreaming;

--- a/packages/builtin-tool-agent-management/src/client/Inspector/CallAgent/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Inspector/CallAgent/index.tsx
@@ -77,6 +77,4 @@ export const CallAgentInspector = memo<BuiltinInspectorProps<CallAgentParams>>(
   },
 );
 
-CallAgentInspector.displayName = 'CallAgentInspector';
-
 export default CallAgentInspector;

--- a/packages/builtin-tool-agent-management/src/client/Inspector/CreateAgent/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Inspector/CreateAgent/index.tsx
@@ -65,6 +65,4 @@ export const CreateAgentInspector = memo<BuiltinInspectorProps<CreateAgentParams
   },
 );
 
-CreateAgentInspector.displayName = 'CreateAgentInspector';
-
 export default CreateAgentInspector;

--- a/packages/builtin-tool-agent-management/src/client/Inspector/DuplicateAgent/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Inspector/DuplicateAgent/index.tsx
@@ -55,6 +55,4 @@ export const DuplicateAgentInspector = memo<BuiltinInspectorProps<DuplicateAgent
   },
 );
 
-DuplicateAgentInspector.displayName = 'DuplicateAgentInspector';
-
 export default DuplicateAgentInspector;

--- a/packages/builtin-tool-agent-management/src/client/Inspector/GetAgentDetail/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Inspector/GetAgentDetail/index.tsx
@@ -74,6 +74,4 @@ export const GetAgentDetailInspector = memo<
   );
 });
 
-GetAgentDetailInspector.displayName = 'GetAgentDetailInspector';
-
 export default GetAgentDetailInspector;

--- a/packages/builtin-tool-agent-management/src/client/Inspector/InstallPlugin/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Inspector/InstallPlugin/index.tsx
@@ -54,6 +54,4 @@ export const InstallPluginInspector = memo<BuiltinInspectorProps<InstallPluginPa
   },
 );
 
-InstallPluginInspector.displayName = 'InstallPluginInspector';
-
 export default InstallPluginInspector;

--- a/packages/builtin-tool-agent-management/src/client/Inspector/SearchAgent/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Inspector/SearchAgent/index.tsx
@@ -69,6 +69,4 @@ export const SearchAgentInspector = memo<BuiltinInspectorProps<SearchAgentParams
   },
 );
 
-SearchAgentInspector.displayName = 'SearchAgentInspector';
-
 export default SearchAgentInspector;

--- a/packages/builtin-tool-agent-management/src/client/Inspector/UpdateAgent/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Inspector/UpdateAgent/index.tsx
@@ -54,6 +54,4 @@ export const UpdateAgentInspector = memo<BuiltinInspectorProps<UpdateAgentParams
   },
 );
 
-UpdateAgentInspector.displayName = 'UpdateAgentInspector';
-
 export default UpdateAgentInspector;

--- a/packages/builtin-tool-agent-management/src/client/Inspector/UpdatePrompt/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Inspector/UpdatePrompt/index.tsx
@@ -54,6 +54,4 @@ export const UpdatePromptInspector = memo<BuiltinInspectorProps<UpdatePromptPara
   },
 );
 
-UpdatePromptInspector.displayName = 'UpdatePromptInspector';
-
 export default UpdatePromptInspector;

--- a/packages/builtin-tool-agent-management/src/client/Render/CallAgent/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Render/CallAgent/index.tsx
@@ -33,6 +33,4 @@ export const CallAgentRender = memo<BuiltinRenderProps<CallAgentParams>>(({ args
   );
 });
 
-CallAgentRender.displayName = 'CallAgentRender';
-
 export default CallAgentRender;

--- a/packages/builtin-tool-agent-management/src/client/Render/CreateAgent/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Render/CreateAgent/index.tsx
@@ -151,6 +151,4 @@ export const CreateAgentRender = memo<BuiltinRenderProps<CreateAgentParams, Crea
   },
 );
 
-CreateAgentRender.displayName = 'CreateAgentRender';
-
 export default CreateAgentRender;

--- a/packages/builtin-tool-agent-management/src/client/Render/DuplicateAgent/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Render/DuplicateAgent/index.tsx
@@ -51,6 +51,4 @@ export const DuplicateAgentRender = memo<
   );
 });
 
-DuplicateAgentRender.displayName = 'DuplicateAgentRender';
-
 export default DuplicateAgentRender;

--- a/packages/builtin-tool-agent-management/src/client/Render/GetAgentDetail/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Render/GetAgentDetail/index.tsx
@@ -112,6 +112,4 @@ export const GetAgentDetailRender = memo<
   );
 });
 
-GetAgentDetailRender.displayName = 'GetAgentDetailRender';
-
 export default GetAgentDetailRender;

--- a/packages/builtin-tool-agent-management/src/client/Render/InstallPlugin/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Render/InstallPlugin/index.tsx
@@ -60,6 +60,4 @@ export const InstallPluginRender = memo<
   );
 });
 
-InstallPluginRender.displayName = 'InstallPluginRender';
-
 export default InstallPluginRender;

--- a/packages/builtin-tool-agent-management/src/client/Render/SearchAgent/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Render/SearchAgent/index.tsx
@@ -111,6 +111,4 @@ export const SearchAgentRender = memo<BuiltinRenderProps<SearchAgentParams, Sear
   },
 );
 
-SearchAgentRender.displayName = 'SearchAgentRender';
-
 export default SearchAgentRender;

--- a/packages/builtin-tool-agent-management/src/client/Render/UpdateAgent/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Render/UpdateAgent/index.tsx
@@ -88,6 +88,4 @@ export const UpdateAgentRender = memo<BuiltinRenderProps<UpdateAgentParams>>(({ 
   );
 });
 
-UpdateAgentRender.displayName = 'UpdateAgentRender';
-
 export default UpdateAgentRender;

--- a/packages/builtin-tool-agent-management/src/client/Render/UpdatePrompt/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Render/UpdatePrompt/index.tsx
@@ -38,6 +38,4 @@ export const UpdatePromptRender = memo<BuiltinRenderProps<UpdatePromptParams>>((
   );
 });
 
-UpdatePromptRender.displayName = 'UpdatePromptRender';
-
 export default UpdatePromptRender;

--- a/packages/builtin-tool-agent-management/src/client/Streaming/CreateAgent/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Streaming/CreateAgent/index.tsx
@@ -80,6 +80,4 @@ export const CreateAgentStreaming = memo<BuiltinStreamingProps<CreateAgentParams
   );
 });
 
-CreateAgentStreaming.displayName = 'CreateAgentStreaming';
-
 export default CreateAgentStreaming;

--- a/packages/builtin-tool-claude-code/src/client/Inspector/Agent.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/Agent.tsx
@@ -204,5 +204,3 @@ export const AgentInspector = memo<BuiltinInspectorProps<AgentArgs>>(
     );
   },
 );
-
-AgentInspector.displayName = 'ClaudeCodeAgentInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/AskUserQuestion.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/AskUserQuestion.tsx
@@ -59,5 +59,3 @@ export const AskUserQuestionInspector = memo<BuiltinInspectorProps<AskUserQuesti
     );
   },
 );
-
-AskUserQuestionInspector.displayName = 'ClaudeCodeAskUserQuestionInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/Edit.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/Edit.tsx
@@ -83,4 +83,3 @@ export const EditInspector = memo<BuiltinInspectorProps<CCEditArgs, SynthesizedE
     return <SharedInspector {...rest} args={args} pluginState={synthesized} />;
   },
 );
-EditInspector.displayName = 'ClaudeCodeEditInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/Monitor.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/Monitor.tsx
@@ -131,5 +131,3 @@ export const MonitorInspector = memo<BuiltinInspectorProps<MonitorArgs>>(
     );
   },
 );
-
-MonitorInspector.displayName = 'ClaudeCodeMonitorInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/Read.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/Read.tsx
@@ -35,4 +35,3 @@ const SharedInspector = createReadLocalFileInspector(ClaudeCodeApiName.Read);
 export const ReadInspector = memo<BuiltinInspectorProps<CCReadArgs>>((props) => (
   <SharedInspector {...props} args={mapArgs(props.args)} partialArgs={mapArgs(props.partialArgs)} />
 ));
-ReadInspector.displayName = 'ClaudeCodeReadInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/ScheduleWakeup.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/ScheduleWakeup.tsx
@@ -78,5 +78,3 @@ export const ScheduleWakeupInspector = memo<BuiltinInspectorProps<ScheduleWakeup
     );
   },
 );
-
-ScheduleWakeupInspector.displayName = 'ClaudeCodeScheduleWakeupInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/SendMessage.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/SendMessage.tsx
@@ -57,5 +57,3 @@ export const SendMessageInspector = memo<BuiltinInspectorProps<SendMessageArgs>>
     );
   },
 );
-
-SendMessageInspector.displayName = 'ClaudeCodeSendMessageInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/Skill.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/Skill.tsx
@@ -69,5 +69,3 @@ export const SkillInspector = memo<BuiltinInspectorProps<SkillArgs>>(
     );
   },
 );
-
-SkillInspector.displayName = 'ClaudeCodeSkillInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/Task.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/Task.tsx
@@ -337,5 +337,3 @@ export const TaskInspector = memo<BuiltinInspectorProps<TaskInspectorArgs, TaskP
     );
   },
 );
-
-TaskInspector.displayName = 'ClaudeCodeTaskInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/TaskGet.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/TaskGet.tsx
@@ -30,5 +30,3 @@ export const TaskGetInspector = memo<BuiltinInspectorProps<TaskGetArgs>>(
     );
   },
 );
-
-TaskGetInspector.displayName = 'ClaudeCodeTaskGetInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/TaskOutput.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/TaskOutput.tsx
@@ -57,5 +57,3 @@ export const TaskOutputInspector = memo<BuiltinInspectorProps<TaskOutputArgs>>(
     );
   },
 );
-
-TaskOutputInspector.displayName = 'ClaudeCodeTaskOutputInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/TaskStop.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/TaskStop.tsx
@@ -57,5 +57,3 @@ export const TaskStopInspector = memo<BuiltinInspectorProps<TaskStopArgs>>(
     );
   },
 );
-
-TaskStopInspector.displayName = 'ClaudeCodeTaskStopInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/TodoWrite.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/TodoWrite.tsx
@@ -140,5 +140,3 @@ export const TodoWriteInspector = memo<BuiltinInspectorProps<TodoWriteArgs>>(
     );
   },
 );
-
-TodoWriteInspector.displayName = 'ClaudeCodeTodoWriteInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/ToolSearch.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/ToolSearch.tsx
@@ -111,5 +111,3 @@ export const ToolSearchInspector = memo<BuiltinInspectorProps<ToolSearchArgs>>(
     );
   },
 );
-
-ToolSearchInspector.displayName = 'ClaudeCodeToolSearchInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/WebFetch.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/WebFetch.tsx
@@ -73,5 +73,3 @@ export const WebFetchInspector = memo<BuiltinInspectorProps<WebFetchArgs>>(
     );
   },
 );
-
-WebFetchInspector.displayName = 'ClaudeCodeWebFetchInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/WebSearch.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/WebSearch.tsx
@@ -37,5 +37,3 @@ export const WebSearchInspector = memo<BuiltinInspectorProps<WebSearchArgs>>(
     );
   },
 );
-
-WebSearchInspector.displayName = 'ClaudeCodeWebSearchInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/Worktree.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/Worktree.tsx
@@ -142,8 +142,6 @@ export const EnterWorktreeInspector = memo<BuiltinInspectorProps<EnterWorktreeAr
   },
 );
 
-EnterWorktreeInspector.displayName = 'ClaudeCodeEnterWorktreeInspector';
-
 export const ExitWorktreeInspector = memo<BuiltinInspectorProps<ExitWorktreeArgs>>(
   ({ args, partialArgs, isArgumentsStreaming, isLoading, result }) => {
     const { t } = useTranslation('plugin');
@@ -175,5 +173,3 @@ export const ExitWorktreeInspector = memo<BuiltinInspectorProps<ExitWorktreeArgs
     );
   },
 );
-
-ExitWorktreeInspector.displayName = 'ClaudeCodeExitWorktreeInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/Write.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/Write.tsx
@@ -30,4 +30,3 @@ const SharedInspector = createWriteLocalFileInspector(ClaudeCodeApiName.Write);
 export const WriteInspector = memo<BuiltinInspectorProps<CCWriteArgs>>((props) => (
   <SharedInspector {...props} args={mapArgs(props.args)} partialArgs={mapArgs(props.partialArgs)} />
 ));
-WriteInspector.displayName = 'ClaudeCodeWriteInspector';

--- a/packages/builtin-tool-cloud-sandbox/src/client/Inspector/ExecuteCode/index.tsx
+++ b/packages/builtin-tool-cloud-sandbox/src/client/Inspector/ExecuteCode/index.tsx
@@ -60,5 +60,3 @@ export const ExecuteCodeInspector = memo<
     </div>
   );
 });
-
-ExecuteCodeInspector.displayName = 'ExecuteCodeInspector';

--- a/packages/builtin-tool-cloud-sandbox/src/client/Inspector/ExportFile/index.tsx
+++ b/packages/builtin-tool-cloud-sandbox/src/client/Inspector/ExportFile/index.tsx
@@ -41,5 +41,3 @@ export const ExportFileInspector = memo<BuiltinInspectorProps<ExportFileArgs, Ex
     );
   },
 );
-
-ExportFileInspector.displayName = 'ExportFileInspector';

--- a/packages/builtin-tool-cloud-sandbox/src/client/Streaming/ExecuteCode/index.tsx
+++ b/packages/builtin-tool-cloud-sandbox/src/client/Streaming/ExecuteCode/index.tsx
@@ -37,5 +37,3 @@ export const ExecuteCodeStreaming = memo<BuiltinStreamingProps<ExecuteCodeParams
     </Highlighter>
   );
 });
-
-ExecuteCodeStreaming.displayName = 'ExecuteCodeStreaming';

--- a/packages/builtin-tool-cloud-sandbox/src/client/components/FilePathDisplay.tsx
+++ b/packages/builtin-tool-cloud-sandbox/src/client/components/FilePathDisplay.tsx
@@ -48,5 +48,3 @@ export const FilePathDisplay = memo<FilePathDisplayProps>(({ filePath, isDirecto
     </>
   );
 });
-
-FilePathDisplay.displayName = 'FilePathDisplay';

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/BatchCreateAgents/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/BatchCreateAgents/index.tsx
@@ -105,6 +105,4 @@ export const BatchCreateAgentsInspector = memo<
   );
 });
 
-BatchCreateAgentsInspector.displayName = 'BatchCreateAgentsInspector';
-
 export default BatchCreateAgentsInspector;

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/CreateAgent/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/CreateAgent/index.tsx
@@ -67,6 +67,4 @@ export const CreateAgentInspector = memo<
   );
 });
 
-CreateAgentInspector.displayName = 'CreateAgentInspector';
-
 export default CreateAgentInspector;

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/CreateGroup/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/CreateGroup/index.tsx
@@ -66,6 +66,4 @@ export const CreateGroupInspector = memo<
   );
 });
 
-CreateGroupInspector.displayName = 'CreateGroupInspector';
-
 export default CreateGroupInspector;

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/GetAgentInfo/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/GetAgentInfo/index.tsx
@@ -63,6 +63,4 @@ export const GetAgentInfoInspector = memo<
   );
 });
 
-GetAgentInfoInspector.displayName = 'GetAgentInfoInspector';
-
 export default GetAgentInfoInspector;

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/InviteAgent/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/InviteAgent/index.tsx
@@ -70,6 +70,4 @@ export const InviteAgentInspector = memo<
   );
 });
 
-InviteAgentInspector.displayName = 'InviteAgentInspector';
-
 export default InviteAgentInspector;

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/RemoveAgent/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/RemoveAgent/index.tsx
@@ -70,6 +70,4 @@ export const RemoveAgentInspector = memo<
   );
 });
 
-RemoveAgentInspector.displayName = 'RemoveAgentInspector';
-
 export default RemoveAgentInspector;

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/SearchAgent/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/SearchAgent/index.tsx
@@ -61,6 +61,4 @@ export const SearchAgentInspector = memo<
   );
 });
 
-SearchAgentInspector.displayName = 'SearchAgentInspector';
-
 export default SearchAgentInspector;

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/UpdateAgentPrompt/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/UpdateAgentPrompt/index.tsx
@@ -125,6 +125,4 @@ export const UpdateAgentPromptInspector = memo<
   );
 });
 
-UpdateAgentPromptInspector.displayName = 'UpdateAgentPromptInspector';
-
 export default UpdateAgentPromptInspector;

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/UpdateGroup/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/UpdateGroup/index.tsx
@@ -82,6 +82,4 @@ export const UpdateGroupInspector = memo<
   );
 });
 
-UpdateGroupInspector.displayName = 'UpdateGroupInspector';
-
 export default UpdateGroupInspector;

--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/UpdateGroupPrompt/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/UpdateGroupPrompt/index.tsx
@@ -94,6 +94,4 @@ export const UpdateGroupPromptInspector = memo<
   );
 });
 
-UpdateGroupPromptInspector.displayName = 'UpdateGroupPromptInspector';
-
 export default UpdateGroupPromptInspector;

--- a/packages/builtin-tool-group-agent-builder/src/client/Render/UpdateAgentPrompt/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Render/UpdateAgentPrompt/index.tsx
@@ -31,6 +31,4 @@ export const UpdateAgentPromptRender = memo<
   );
 });
 
-UpdateAgentPromptRender.displayName = 'UpdateAgentPromptRender';
-
 export default UpdateAgentPromptRender;

--- a/packages/builtin-tool-group-agent-builder/src/client/Render/UpdateGroupPrompt/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Render/UpdateGroupPrompt/index.tsx
@@ -31,6 +31,4 @@ export const UpdateGroupPromptRender = memo<
   );
 });
 
-UpdateGroupPromptRender.displayName = 'UpdateGroupPromptRender';
-
 export default UpdateGroupPromptRender;

--- a/packages/builtin-tool-group-agent-builder/src/client/Streaming/BatchCreateAgents/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Streaming/BatchCreateAgents/index.tsx
@@ -98,6 +98,4 @@ export const BatchCreateAgentsStreaming = memo<BuiltinStreamingProps<BatchCreate
   },
 );
 
-BatchCreateAgentsStreaming.displayName = 'BatchCreateAgentsStreaming';
-
 export default BatchCreateAgentsStreaming;

--- a/packages/builtin-tool-group-agent-builder/src/client/Streaming/UpdateAgentPrompt/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Streaming/UpdateAgentPrompt/index.tsx
@@ -22,6 +22,4 @@ export const UpdateAgentPromptStreaming = memo<BuiltinStreamingProps<UpdateAgent
   },
 );
 
-UpdateAgentPromptStreaming.displayName = 'UpdateAgentPromptStreaming';
-
 export default UpdateAgentPromptStreaming;

--- a/packages/builtin-tool-group-agent-builder/src/client/Streaming/UpdateGroupPrompt/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Streaming/UpdateGroupPrompt/index.tsx
@@ -30,6 +30,4 @@ export const UpdateGroupPromptStreaming = memo<BuiltinStreamingProps<UpdateGroup
   },
 );
 
-UpdateGroupPromptStreaming.displayName = 'UpdateGroupPromptStreaming';
-
 export default UpdateGroupPromptStreaming;

--- a/packages/builtin-tool-group-management/src/client/Inspector/Broadcast/index.tsx
+++ b/packages/builtin-tool-group-management/src/client/Inspector/Broadcast/index.tsx
@@ -84,6 +84,4 @@ export const BroadcastInspector = memo<BuiltinInspectorProps<BroadcastParams>>(
   },
 );
 
-BroadcastInspector.displayName = 'BroadcastInspector';
-
 export default BroadcastInspector;

--- a/packages/builtin-tool-group-management/src/client/Inspector/Speak/index.tsx
+++ b/packages/builtin-tool-group-management/src/client/Inspector/Speak/index.tsx
@@ -77,6 +77,4 @@ export const SpeakInspector = memo<BuiltinInspectorProps<SpeakParams>>(
   },
 );
 
-SpeakInspector.displayName = 'SpeakInspector';
-
 export default SpeakInspector;

--- a/packages/builtin-tool-group-management/src/client/Render/Broadcast/index.tsx
+++ b/packages/builtin-tool-group-management/src/client/Render/Broadcast/index.tsx
@@ -33,6 +33,4 @@ export const BroadcastRender = memo<BuiltinRenderProps<BroadcastParams>>(({ args
   );
 });
 
-BroadcastRender.displayName = 'BroadcastRender';
-
 export default BroadcastRender;

--- a/packages/builtin-tool-group-management/src/client/Render/Speak/index.tsx
+++ b/packages/builtin-tool-group-management/src/client/Render/Speak/index.tsx
@@ -33,6 +33,4 @@ export const SpeakRender = memo<BuiltinRenderProps<SpeakParams>>(({ args }) => {
   );
 });
 
-SpeakRender.displayName = 'SpeakRender';
-
 export default SpeakRender;

--- a/packages/builtin-tool-group-management/src/client/Streaming/Broadcast/index.tsx
+++ b/packages/builtin-tool-group-management/src/client/Streaming/Broadcast/index.tsx
@@ -35,6 +35,4 @@ export const BroadcastStreaming = memo<BuiltinStreamingProps<BroadcastParams>>((
   );
 });
 
-BroadcastStreaming.displayName = 'BroadcastStreaming';
-
 export default BroadcastStreaming;

--- a/packages/builtin-tool-group-management/src/client/Streaming/ExecuteTask/index.tsx
+++ b/packages/builtin-tool-group-management/src/client/Streaming/ExecuteTask/index.tsx
@@ -64,6 +64,4 @@ export const ExecuteTaskStreaming = memo<BuiltinStreamingProps<ExecuteTaskParams
   );
 });
 
-ExecuteTaskStreaming.displayName = 'ExecuteTaskStreaming';
-
 export default ExecuteTaskStreaming;

--- a/packages/builtin-tool-group-management/src/client/Streaming/ExecuteTasks/index.tsx
+++ b/packages/builtin-tool-group-management/src/client/Streaming/ExecuteTasks/index.tsx
@@ -82,6 +82,4 @@ export const ExecuteTasksStreaming = memo<BuiltinStreamingProps<ExecuteTasksPara
   );
 });
 
-ExecuteTasksStreaming.displayName = 'ExecuteTasksStreaming';
-
 export default ExecuteTasksStreaming;

--- a/packages/builtin-tool-group-management/src/client/Streaming/Speak/index.tsx
+++ b/packages/builtin-tool-group-management/src/client/Streaming/Speak/index.tsx
@@ -35,6 +35,4 @@ export const SpeakStreaming = memo<BuiltinStreamingProps<SpeakParams>>(({ args }
   );
 });
 
-SpeakStreaming.displayName = 'SpeakStreaming';
-
 export default SpeakStreaming;

--- a/packages/builtin-tool-knowledge-base/src/client/Inspector/ReadKnowledge/index.tsx
+++ b/packages/builtin-tool-knowledge-base/src/client/Inspector/ReadKnowledge/index.tsx
@@ -81,5 +81,3 @@ export const ReadKnowledgeInspector = memo<
     </div>
   );
 });
-
-ReadKnowledgeInspector.displayName = 'ReadKnowledgeInspector';

--- a/packages/builtin-tool-knowledge-base/src/client/Inspector/SearchKnowledgeBase/index.tsx
+++ b/packages/builtin-tool-knowledge-base/src/client/Inspector/SearchKnowledgeBase/index.tsx
@@ -60,5 +60,3 @@ export const SearchKnowledgeBaseInspector = memo<
     </div>
   );
 });
-
-SearchKnowledgeBaseInspector.displayName = 'SearchKnowledgeBaseInspector';

--- a/packages/builtin-tool-lobe-agent/src/client/Inspector/AnalyzeVisualMedia/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Inspector/AnalyzeVisualMedia/index.tsx
@@ -62,6 +62,4 @@ export const AnalyzeVisualMediaInspector = memo<
   );
 });
 
-AnalyzeVisualMediaInspector.displayName = 'AnalyzeVisualMediaInspector';
-
 export default AnalyzeVisualMediaInspector;

--- a/packages/builtin-tool-lobe-agent/src/client/Inspector/CallSubAgent/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Inspector/CallSubAgent/index.tsx
@@ -83,6 +83,4 @@ export const CallSubAgentInspector = memo<
   );
 });
 
-CallSubAgentInspector.displayName = 'CallSubAgentInspector';
-
 export default CallSubAgentInspector;

--- a/packages/builtin-tool-lobe-agent/src/client/Inspector/ClearTodos/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Inspector/ClearTodos/index.tsx
@@ -51,6 +51,4 @@ export const ClearTodosInspector = memo<BuiltinInspectorProps<ClearTodosParams, 
   },
 );
 
-ClearTodosInspector.displayName = 'ClearTodosInspector';
-
 export default ClearTodosInspector;

--- a/packages/builtin-tool-lobe-agent/src/client/Inspector/CreatePlan/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Inspector/CreatePlan/index.tsx
@@ -42,6 +42,4 @@ export const CreatePlanInspector = memo<BuiltinInspectorProps<CreatePlanParams, 
   },
 );
 
-CreatePlanInspector.displayName = 'CreatePlanInspector';
-
 export default CreatePlanInspector;

--- a/packages/builtin-tool-lobe-agent/src/client/Inspector/CreateTodos/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Inspector/CreateTodos/index.tsx
@@ -48,6 +48,4 @@ export const CreateTodosInspector = memo<
   );
 });
 
-CreateTodosInspector.displayName = 'CreateTodosInspector';
-
 export default CreateTodosInspector;

--- a/packages/builtin-tool-lobe-agent/src/client/Inspector/UpdatePlan/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Inspector/UpdatePlan/index.tsx
@@ -54,6 +54,4 @@ export const UpdatePlanInspector = memo<BuiltinInspectorProps<UpdatePlanParams, 
   },
 );
 
-UpdatePlanInspector.displayName = 'UpdatePlanInspector';
-
 export default UpdatePlanInspector;

--- a/packages/builtin-tool-lobe-agent/src/client/Inspector/UpdateTodos/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Inspector/UpdateTodos/index.tsx
@@ -118,6 +118,4 @@ export const UpdateTodosInspector = memo<
   );
 });
 
-UpdateTodosInspector.displayName = 'UpdateTodosInspector';
-
 export default UpdateTodosInspector;

--- a/packages/builtin-tool-lobe-agent/src/client/Render/CallSubAgent/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Render/CallSubAgent/index.tsx
@@ -136,6 +136,4 @@ export const CallSubAgentRender = memo<
   );
 });
 
-CallSubAgentRender.displayName = 'CallSubAgentRender';
-
 export default CallSubAgentRender;

--- a/packages/builtin-tool-lobe-agent/src/client/Render/TodoList/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Render/TodoList/index.tsx
@@ -108,8 +108,6 @@ const TodoListUI = memo<TodoListUIProps>(({ items }) => {
   );
 });
 
-TodoListUI.displayName = 'TodoListUI';
-
 /**
  * TodoList Render component for the lobe-agent tool
  * Read-only display of todo items matching the style of AddTodoIntervention

--- a/packages/builtin-tool-lobe-agent/src/client/Streaming/CallSubAgent/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Streaming/CallSubAgent/index.tsx
@@ -42,6 +42,4 @@ export const CallSubAgentStreaming = memo<BuiltinStreamingProps<CallSubAgentPara
   );
 });
 
-CallSubAgentStreaming.displayName = 'CallSubAgentStreaming';
-
 export default CallSubAgentStreaming;

--- a/packages/builtin-tool-lobe-agent/src/client/Streaming/CreatePlan/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Streaming/CreatePlan/index.tsx
@@ -66,6 +66,4 @@ export const CreatePlanStreaming = memo<BuiltinStreamingProps<CreatePlanParams>>
   );
 });
 
-CreatePlanStreaming.displayName = 'CreatePlanStreaming';
-
 export default CreatePlanStreaming;

--- a/packages/builtin-tool-lobe-agent/src/client/components/SubAgentStats.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/components/SubAgentStats.tsx
@@ -47,6 +47,4 @@ export const SubAgentStats = memo<SubAgentRunStats>(({ model, totalToolCalls, to
   return <span className={styles.root}>{items.join(' · ')}</span>;
 });
 
-SubAgentStats.displayName = 'SubAgentStats';
-
 export default SubAgentStats;

--- a/packages/builtin-tool-lobe-delivery-checker/src/client/Inspector/GenerateVerifyPlan/index.tsx
+++ b/packages/builtin-tool-lobe-delivery-checker/src/client/Inspector/GenerateVerifyPlan/index.tsx
@@ -61,6 +61,4 @@ export const GenerateVerifyPlanInspector = memo<
   );
 });
 
-GenerateVerifyPlanInspector.displayName = 'GenerateVerifyPlanInspector';
-
 export default GenerateVerifyPlanInspector;

--- a/packages/builtin-tool-local-system/src/client/Inspector/RenameLocalFile/index.tsx
+++ b/packages/builtin-tool-local-system/src/client/Inspector/RenameLocalFile/index.tsx
@@ -52,5 +52,3 @@ export const RenameLocalFileInspector = memo<
     </div>
   );
 });
-
-RenameLocalFileInspector.displayName = 'RenameLocalFileInspector';

--- a/packages/builtin-tool-local-system/src/client/Streaming/RunCommand/index.tsx
+++ b/packages/builtin-tool-local-system/src/client/Streaming/RunCommand/index.tsx
@@ -29,5 +29,3 @@ export const RunCommandStreaming = memo<BuiltinStreamingProps<RunCommandParams>>
     </Highlighter>
   );
 });
-
-RunCommandStreaming.displayName = 'RunCommandStreaming';

--- a/packages/builtin-tool-local-system/src/client/Streaming/WriteFile/index.tsx
+++ b/packages/builtin-tool-local-system/src/client/Streaming/WriteFile/index.tsx
@@ -39,5 +39,3 @@ export const WriteFileStreaming = memo<BuiltinStreamingProps<WriteLocalFileParam
     </Highlighter>
   );
 });
-
-WriteFileStreaming.displayName = 'WriteFileStreaming';

--- a/packages/builtin-tool-local-system/src/client/components/FilePathDisplay.tsx
+++ b/packages/builtin-tool-local-system/src/client/components/FilePathDisplay.tsx
@@ -65,5 +65,3 @@ export const FilePathDisplay = memo<FilePathDisplayProps>(({ filePath, isDirecto
     </>
   );
 });
-
-FilePathDisplay.displayName = 'FilePathDisplay';

--- a/packages/builtin-tool-memory/src/client/Inspector/AddContextMemory/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Inspector/AddContextMemory/index.tsx
@@ -55,6 +55,4 @@ export const AddContextMemoryInspector = memo<
   );
 });
 
-AddContextMemoryInspector.displayName = 'AddContextMemoryInspector';
-
 export default AddContextMemoryInspector;

--- a/packages/builtin-tool-memory/src/client/Inspector/AddExperienceMemory/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Inspector/AddExperienceMemory/index.tsx
@@ -55,6 +55,4 @@ export const AddExperienceMemoryInspector = memo<
   );
 });
 
-AddExperienceMemoryInspector.displayName = 'AddExperienceMemoryInspector';
-
 export default AddExperienceMemoryInspector;

--- a/packages/builtin-tool-memory/src/client/Inspector/AddIdentityMemory/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Inspector/AddIdentityMemory/index.tsx
@@ -55,6 +55,4 @@ export const AddIdentityMemoryInspector = memo<
   );
 });
 
-AddIdentityMemoryInspector.displayName = 'AddIdentityMemoryInspector';
-
 export default AddIdentityMemoryInspector;

--- a/packages/builtin-tool-memory/src/client/Inspector/AddPreferenceMemory/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Inspector/AddPreferenceMemory/index.tsx
@@ -55,6 +55,4 @@ export const AddPreferenceMemoryInspector = memo<
   );
 });
 
-AddPreferenceMemoryInspector.displayName = 'AddPreferenceMemoryInspector';
-
 export default AddPreferenceMemoryInspector;

--- a/packages/builtin-tool-memory/src/client/Inspector/QueryTaxonomyOptions/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Inspector/QueryTaxonomyOptions/index.tsx
@@ -69,6 +69,4 @@ export const QueryTaxonomyOptionsInspector = memo<
   );
 });
 
-QueryTaxonomyOptionsInspector.displayName = 'QueryTaxonomyOptionsInspector';
-
 export default QueryTaxonomyOptionsInspector;

--- a/packages/builtin-tool-memory/src/client/Inspector/RemoveIdentityMemory/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Inspector/RemoveIdentityMemory/index.tsx
@@ -55,6 +55,4 @@ export const RemoveIdentityMemoryInspector = memo<
   );
 });
 
-RemoveIdentityMemoryInspector.displayName = 'RemoveIdentityMemoryInspector';
-
 export default RemoveIdentityMemoryInspector;

--- a/packages/builtin-tool-memory/src/client/Inspector/SearchUserMemory/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Inspector/SearchUserMemory/index.tsx
@@ -67,6 +67,4 @@ export const SearchUserMemoryInspector = memo<
   );
 });
 
-SearchUserMemoryInspector.displayName = 'SearchUserMemoryInspector';
-
 export default SearchUserMemoryInspector;

--- a/packages/builtin-tool-memory/src/client/Inspector/UpdateIdentityMemory/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Inspector/UpdateIdentityMemory/index.tsx
@@ -37,6 +37,4 @@ export const UpdateIdentityMemoryInspector = memo<
   );
 });
 
-UpdateIdentityMemoryInspector.displayName = 'UpdateIdentityMemoryInspector';
-
 export default UpdateIdentityMemoryInspector;

--- a/packages/builtin-tool-memory/src/client/Streaming/AddExperienceMemory/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Streaming/AddExperienceMemory/index.tsx
@@ -12,6 +12,4 @@ export const AddExperienceMemoryStreaming = memo<BuiltinStreamingProps<AddExperi
   },
 );
 
-AddExperienceMemoryStreaming.displayName = 'AddExperienceMemoryStreaming';
-
 export default AddExperienceMemoryStreaming;

--- a/packages/builtin-tool-memory/src/client/Streaming/AddPreferenceMemory/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Streaming/AddPreferenceMemory/index.tsx
@@ -12,6 +12,4 @@ export const AddPreferenceMemoryStreaming = memo<BuiltinStreamingProps<AddPrefer
   },
 );
 
-AddPreferenceMemoryStreaming.displayName = 'AddPreferenceMemoryStreaming';
-
 export default AddPreferenceMemoryStreaming;

--- a/packages/builtin-tool-memory/src/client/components/ExperienceMemoryCard.tsx
+++ b/packages/builtin-tool-memory/src/client/components/ExperienceMemoryCard.tsx
@@ -231,6 +231,4 @@ export const ExperienceMemoryCard = memo<ExperienceMemoryCardProps>(({ data, loa
   );
 });
 
-ExperienceMemoryCard.displayName = 'ExperienceMemoryCard';
-
 export default ExperienceMemoryCard;

--- a/packages/builtin-tool-memory/src/client/components/PreferenceMemoryCard.tsx
+++ b/packages/builtin-tool-memory/src/client/components/PreferenceMemoryCard.tsx
@@ -358,6 +358,4 @@ export const PreferenceMemoryCard = memo<PreferenceMemoryCardProps>(({ data, loa
   );
 });
 
-PreferenceMemoryCard.displayName = 'PreferenceMemoryCard';
-
 export default PreferenceMemoryCard;

--- a/packages/builtin-tool-page-agent/src/client/Inspector/EditTitle/index.tsx
+++ b/packages/builtin-tool-page-agent/src/client/Inspector/EditTitle/index.tsx
@@ -35,6 +35,4 @@ export const EditTitleInspector = memo<BuiltinInspectorProps<EditTitleArgs, Edit
   },
 );
 
-EditTitleInspector.displayName = 'EditTitleInspector';
-
 export default EditTitleInspector;

--- a/packages/builtin-tool-page-agent/src/client/Inspector/GetPageContent/index.tsx
+++ b/packages/builtin-tool-page-agent/src/client/Inspector/GetPageContent/index.tsx
@@ -28,6 +28,4 @@ export const GetPageContentInspector = memo<BuiltinInspectorProps>(({ isArgument
   );
 });
 
-GetPageContentInspector.displayName = 'GetPageContentInspector';
-
 export default GetPageContentInspector;

--- a/packages/builtin-tool-page-agent/src/client/Inspector/InitPage/index.tsx
+++ b/packages/builtin-tool-page-agent/src/client/Inspector/InitPage/index.tsx
@@ -91,6 +91,4 @@ export const InitPageInspector = memo<BuiltinInspectorProps<InitDocumentArgs, In
   },
 );
 
-InitPageInspector.displayName = 'InitPageInspector';
-
 export default InitPageInspector;

--- a/packages/builtin-tool-page-agent/src/client/Inspector/ModifyNodes/index.tsx
+++ b/packages/builtin-tool-page-agent/src/client/Inspector/ModifyNodes/index.tsx
@@ -116,6 +116,4 @@ export const ModifyNodesInspector = memo<BuiltinInspectorProps<ModifyNodesArgs, 
   },
 );
 
-ModifyNodesInspector.displayName = 'ModifyNodesInspector';
-
 export default ModifyNodesInspector;

--- a/packages/builtin-tool-page-agent/src/client/Inspector/ReplaceText/index.tsx
+++ b/packages/builtin-tool-page-agent/src/client/Inspector/ReplaceText/index.tsx
@@ -71,6 +71,4 @@ export const ReplaceTextInspector = memo<BuiltinInspectorProps<ReplaceTextArgs, 
   },
 );
 
-ReplaceTextInspector.displayName = 'ReplaceTextInspector';
-
 export default ReplaceTextInspector;

--- a/packages/builtin-tool-page-agent/src/client/Render/ModifyNodes/index.tsx
+++ b/packages/builtin-tool-page-agent/src/client/Render/ModifyNodes/index.tsx
@@ -128,6 +128,4 @@ export const ModifyNodesRender = memo<BuiltinRenderProps<ModifyNodesArgs, Modify
   },
 );
 
-ModifyNodesRender.displayName = 'ModifyNodesRender';
-
 export default ModifyNodesRender;

--- a/packages/builtin-tool-page-agent/src/client/Streaming/InitPage/index.tsx
+++ b/packages/builtin-tool-page-agent/src/client/Streaming/InitPage/index.tsx
@@ -107,6 +107,4 @@ export const InitPageStreaming = memo<BuiltinStreamingProps<InitDocumentArgs>>((
   );
 });
 
-InitPageStreaming.displayName = 'PageAgentInitPageStreaming';
-
 export default InitPageStreaming;

--- a/packages/builtin-tool-page-agent/src/client/components/AnimatedNumber.tsx
+++ b/packages/builtin-tool-page-agent/src/client/components/AnimatedNumber.tsx
@@ -53,5 +53,3 @@ export const AnimatedNumber = memo<AnimatedNumberProps>(({ value, duration = 500
 
   return formatter ? formatter(displayValue) : Math.round(displayValue).toLocaleString();
 });
-
-AnimatedNumber.displayName = 'AnimatedNumber';

--- a/packages/builtin-tool-self-iteration/src/client/Inspector/DeclareSelfFeedbackIntent/index.tsx
+++ b/packages/builtin-tool-self-iteration/src/client/Inspector/DeclareSelfFeedbackIntent/index.tsx
@@ -111,6 +111,4 @@ export const DeclareSelfFeedbackIntentInspector = memo<
   );
 });
 
-DeclareSelfFeedbackIntentInspector.displayName = 'DeclareSelfFeedbackIntentInspector';
-
 export default DeclareSelfFeedbackIntentInspector;

--- a/packages/builtin-tool-skill-store/src/client/Inspector/ImportFromMarket/index.tsx
+++ b/packages/builtin-tool-skill-store/src/client/Inspector/ImportFromMarket/index.tsx
@@ -55,5 +55,3 @@ export const ImportFromMarketInspector = memo<
     </div>
   );
 });
-
-ImportFromMarketInspector.displayName = 'ImportFromMarketInspector';

--- a/packages/builtin-tool-skill-store/src/client/Inspector/ImportSkill/index.tsx
+++ b/packages/builtin-tool-skill-store/src/client/Inspector/ImportSkill/index.tsx
@@ -55,5 +55,3 @@ export const ImportSkillInspector = memo<
     </div>
   );
 });
-
-ImportSkillInspector.displayName = 'ImportSkillInspector';

--- a/packages/builtin-tool-skill-store/src/client/Inspector/SearchSkill/index.tsx
+++ b/packages/builtin-tool-skill-store/src/client/Inspector/SearchSkill/index.tsx
@@ -57,5 +57,3 @@ export const SearchSkillInspector = memo<
     </div>
   );
 });
-
-SearchSkillInspector.displayName = 'SearchSkillInspector';

--- a/packages/builtin-tool-skills/src/client/Inspector/ExecScript/index.tsx
+++ b/packages/builtin-tool-skills/src/client/Inspector/ExecScript/index.tsx
@@ -67,5 +67,3 @@ export const ExecScriptInspector = memo<BuiltinInspectorProps<ExecScriptParams, 
     );
   },
 );
-
-ExecScriptInspector.displayName = 'ExecScriptInspector';

--- a/packages/builtin-tool-skills/src/client/Inspector/ReadReference/index.tsx
+++ b/packages/builtin-tool-skills/src/client/Inspector/ReadReference/index.tsx
@@ -42,5 +42,3 @@ export const ReadReferenceInspector = memo<
     </div>
   );
 });
-
-ReadReferenceInspector.displayName = 'ReadReferenceInspector';

--- a/packages/builtin-tool-skills/src/client/Inspector/RunSkill/index.tsx
+++ b/packages/builtin-tool-skills/src/client/Inspector/RunSkill/index.tsx
@@ -121,5 +121,3 @@ export const RunSkillInspector = memo<
     </div>
   );
 });
-
-RunSkillInspector.displayName = 'RunSkillInspector';

--- a/packages/builtin-tool-task/src/client/Inspector/CreateTask/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/CreateTask/index.tsx
@@ -112,6 +112,4 @@ export const CreateTaskInspector = memo<BuiltinInspectorProps<CreateTaskParams, 
   },
 );
 
-CreateTaskInspector.displayName = 'CreateTaskInspector';
-
 export default CreateTaskInspector;

--- a/packages/builtin-tool-task/src/client/Inspector/CreateTasks/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/CreateTasks/index.tsx
@@ -101,6 +101,4 @@ export const CreateTasksInspector = memo<
   );
 });
 
-CreateTasksInspector.displayName = 'CreateTasksInspector';
-
 export default CreateTasksInspector;

--- a/packages/builtin-tool-task/src/client/Inspector/DeleteTask/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/DeleteTask/index.tsx
@@ -50,6 +50,4 @@ export const DeleteTaskInspector = memo<BuiltinInspectorProps<DeleteTaskParams, 
   },
 );
 
-DeleteTaskInspector.displayName = 'DeleteTaskInspector';
-
 export default DeleteTaskInspector;

--- a/packages/builtin-tool-task/src/client/Inspector/EditTask/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/EditTask/index.tsx
@@ -259,6 +259,4 @@ export const EditTaskInspector = memo<BuiltinInspectorProps<EditTaskParams, Edit
   },
 );
 
-EditTaskInspector.displayName = 'EditTaskInspector';
-
 export default EditTaskInspector;

--- a/packages/builtin-tool-task/src/client/Inspector/ListTasks/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/ListTasks/index.tsx
@@ -51,6 +51,4 @@ export const ListTasksInspector = memo<BuiltinInspectorProps<ListTasksParams, Li
   },
 );
 
-ListTasksInspector.displayName = 'ListTasksInspector';
-
 export default ListTasksInspector;

--- a/packages/builtin-tool-task/src/client/Inspector/RunTask/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/RunTask/index.tsx
@@ -93,6 +93,4 @@ export const RunTaskInspector = memo<BuiltinInspectorProps<RunTaskParams, RunTas
   },
 );
 
-RunTaskInspector.displayName = 'RunTaskInspector';
-
 export default RunTaskInspector;

--- a/packages/builtin-tool-task/src/client/Inspector/RunTasks/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/RunTasks/index.tsx
@@ -117,6 +117,4 @@ export const RunTasksInspector = memo<BuiltinInspectorProps<RunTasksParams, RunT
   },
 );
 
-RunTasksInspector.displayName = 'RunTasksInspector';
-
 export default RunTasksInspector;

--- a/packages/builtin-tool-task/src/client/Inspector/SetTaskSchedule/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/SetTaskSchedule/index.tsx
@@ -70,6 +70,4 @@ export const SetTaskScheduleInspector = memo<
   );
 });
 
-SetTaskScheduleInspector.displayName = 'SetTaskScheduleInspector';
-
 export default SetTaskScheduleInspector;

--- a/packages/builtin-tool-task/src/client/Inspector/SetTaskVerify/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/SetTaskVerify/index.tsx
@@ -46,6 +46,4 @@ export const SetTaskVerifyInspector = memo<
   );
 });
 
-SetTaskVerifyInspector.displayName = 'SetTaskVerifyInspector';
-
 export default SetTaskVerifyInspector;

--- a/packages/builtin-tool-task/src/client/Inspector/TaskComment/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/TaskComment/index.tsx
@@ -110,19 +110,14 @@ export const TaskCommentInspector = memo<TaskCommentInspectorProps>(
   },
 );
 
-TaskCommentInspector.displayName = 'TaskCommentInspector';
-
 export const AddTaskCommentInspector = (
   props: BuiltinInspectorProps<AddTaskCommentParams, AddTaskCommentState>,
 ) => <TaskCommentInspector {...props} apiName={TaskApiName.addTaskComment} />;
-AddTaskCommentInspector.displayName = 'AddTaskCommentInspector';
 
 export const UpdateTaskCommentInspector = (
   props: BuiltinInspectorProps<UpdateTaskCommentParams, UpdateTaskCommentState>,
 ) => <TaskCommentInspector {...props} apiName={TaskApiName.updateTaskComment} />;
-UpdateTaskCommentInspector.displayName = 'UpdateTaskCommentInspector';
 
 export const DeleteTaskCommentInspector = (
   props: BuiltinInspectorProps<DeleteTaskCommentParams, DeleteTaskCommentState>,
 ) => <TaskCommentInspector {...props} apiName={TaskApiName.deleteTaskComment} />;
-DeleteTaskCommentInspector.displayName = 'DeleteTaskCommentInspector';

--- a/packages/builtin-tool-task/src/client/Inspector/UpdateTaskStatus/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/UpdateTaskStatus/index.tsx
@@ -85,6 +85,4 @@ export const UpdateTaskStatusInspector = memo<
   );
 });
 
-UpdateTaskStatusInspector.displayName = 'UpdateTaskStatusInspector';
-
 export default UpdateTaskStatusInspector;

--- a/packages/builtin-tool-task/src/client/Inspector/ViewTask/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/ViewTask/index.tsx
@@ -46,6 +46,4 @@ export const ViewTaskInspector = memo<BuiltinInspectorProps<ViewTaskParams, View
   },
 );
 
-ViewTaskInspector.displayName = 'ViewTaskInspector';
-
 export default ViewTaskInspector;

--- a/packages/builtin-tool-task/src/client/Render/CreateTask/index.tsx
+++ b/packages/builtin-tool-task/src/client/Render/CreateTask/index.tsx
@@ -156,6 +156,4 @@ export const CreateTaskRender = memo<BuiltinRenderProps<CreateTaskParams, Create
   },
 );
 
-CreateTaskRender.displayName = 'CreateTaskRender';
-
 export default CreateTaskRender;

--- a/packages/builtin-tool-task/src/client/Render/CreateTasks/index.tsx
+++ b/packages/builtin-tool-task/src/client/Render/CreateTasks/index.tsx
@@ -155,6 +155,4 @@ export const CreateTasksRender = memo<BuiltinRenderProps<CreateTasksParams, Crea
   },
 );
 
-CreateTasksRender.displayName = 'CreateTasksRender';
-
 export default CreateTasksRender;

--- a/packages/builtin-tool-task/src/client/Render/EditTask/index.tsx
+++ b/packages/builtin-tool-task/src/client/Render/EditTask/index.tsx
@@ -150,6 +150,4 @@ export const EditTaskRender = memo<BuiltinRenderProps<EditTaskParams, EditTaskSt
   },
 );
 
-EditTaskRender.displayName = 'EditTaskRender';
-
 export default EditTaskRender;

--- a/packages/builtin-tool-task/src/client/Render/RunTask/index.tsx
+++ b/packages/builtin-tool-task/src/client/Render/RunTask/index.tsx
@@ -71,6 +71,4 @@ export const RunTaskRender = memo<BuiltinRenderProps<RunTaskParams, RunTaskState
   },
 );
 
-RunTaskRender.displayName = 'RunTaskRender';
-
 export default RunTaskRender;

--- a/packages/builtin-tool-task/src/client/Render/RunTasks/index.tsx
+++ b/packages/builtin-tool-task/src/client/Render/RunTasks/index.tsx
@@ -154,6 +154,4 @@ export const RunTasksRender = memo<BuiltinRenderProps<RunTasksParams, RunTasksSt
   },
 );
 
-RunTasksRender.displayName = 'RunTasksRender';
-
 export default RunTasksRender;

--- a/packages/builtin-tool-task/src/client/Render/SetTaskVerify/index.tsx
+++ b/packages/builtin-tool-task/src/client/Render/SetTaskVerify/index.tsx
@@ -80,6 +80,4 @@ export const SetTaskVerifyRender = memo<
   );
 });
 
-SetTaskVerifyRender.displayName = 'SetTaskVerifyRender';
-
 export default SetTaskVerifyRender;

--- a/packages/builtin-tool-task/src/client/Render/shared.tsx
+++ b/packages/builtin-tool-task/src/client/Render/shared.tsx
@@ -194,8 +194,6 @@ export const TaskResultCard = memo<TaskResultCardProps>(
   },
 );
 
-TaskResultCard.displayName = 'TaskResultCard';
-
 /** A scalar detail row: muted label followed by an inline value. */
 export const InlineField = memo<{ children: ReactNode; label: ReactNode }>(
   ({ children, label }) => (
@@ -206,8 +204,6 @@ export const InlineField = memo<{ children: ReactNode; label: ReactNode }>(
   ),
 );
 
-InlineField.displayName = 'InlineField';
-
 /** A stacked detail block: muted label above long-form content. */
 export const SectionField = memo<{ children: ReactNode; label: ReactNode }>(
   ({ children, label }) => (
@@ -217,8 +213,6 @@ export const SectionField = memo<{ children: ReactNode; label: ReactNode }>(
     </div>
   ),
 );
-
-SectionField.displayName = 'SectionField';
 
 /** An agent avatar + display name, resolved from the agent registry. */
 export const AssigneeInline = memo<{ agentId: string }>(({ agentId }) => {
@@ -232,7 +226,5 @@ export const AssigneeInline = memo<{ agentId: string }>(({ agentId }) => {
     </span>
   );
 });
-
-AssigneeInline.displayName = 'AssigneeInline';
 
 export const monoChipClassName = styles.mono;

--- a/packages/builtin-tool-user-interaction/src/client/Inspector/AskUserQuestion/index.tsx
+++ b/packages/builtin-tool-user-interaction/src/client/Inspector/AskUserQuestion/index.tsx
@@ -67,6 +67,4 @@ export const AskUserQuestionInspector = memo<BuiltinInspectorProps<AskUserQuesti
   },
 );
 
-AskUserQuestionInspector.displayName = 'AskUserQuestionInspector';
-
 export default AskUserQuestionInspector;

--- a/packages/builtin-tool-web-browsing/src/client/Inspector/CrawlMultiPages/index.tsx
+++ b/packages/builtin-tool-web-browsing/src/client/Inspector/CrawlMultiPages/index.tsx
@@ -50,6 +50,4 @@ export const CrawlMultiPagesInspector = memo<BuiltinInspectorProps<CrawlMultiPag
   },
 );
 
-CrawlMultiPagesInspector.displayName = 'CrawlMultiPagesInspector';
-
 export default CrawlMultiPagesInspector;

--- a/packages/builtin-tool-web-browsing/src/client/Inspector/CrawlSinglePage/index.tsx
+++ b/packages/builtin-tool-web-browsing/src/client/Inspector/CrawlSinglePage/index.tsx
@@ -38,6 +38,4 @@ export const CrawlSinglePageInspector = memo<BuiltinInspectorProps<CrawlSinglePa
   },
 );
 
-CrawlSinglePageInspector.displayName = 'CrawlSinglePageInspector';
-
 export default CrawlSinglePageInspector;

--- a/packages/builtin-tool-web-browsing/src/client/Inspector/Search/index.tsx
+++ b/packages/builtin-tool-web-browsing/src/client/Inspector/Search/index.tsx
@@ -55,6 +55,4 @@ export const SearchInspector = memo<BuiltinInspectorProps<SearchQuery, UniformSe
   },
 );
 
-SearchInspector.displayName = 'SearchInspector';
-
 export default SearchInspector;

--- a/packages/builtin-tool-web-onboarding/src/agentMarketplace/client/Inspector/ShowAgentMarketplace/index.tsx
+++ b/packages/builtin-tool-web-onboarding/src/agentMarketplace/client/Inspector/ShowAgentMarketplace/index.tsx
@@ -59,6 +59,4 @@ export const ShowAgentMarketplaceInspector = memo<
   );
 });
 
-ShowAgentMarketplaceInspector.displayName = 'ShowAgentMarketplaceInspector';
-
 export default ShowAgentMarketplaceInspector;

--- a/packages/builtin-tool-web-onboarding/src/agentMarketplace/client/Inspector/SubmitAgentPick/index.tsx
+++ b/packages/builtin-tool-web-onboarding/src/agentMarketplace/client/Inspector/SubmitAgentPick/index.tsx
@@ -45,6 +45,4 @@ export const SubmitAgentPickInspector = memo<
   );
 });
 
-SubmitAgentPickInspector.displayName = 'SubmitAgentPickInspector';
-
 export default SubmitAgentPickInspector;

--- a/packages/builtin-tool-web-onboarding/src/client/Inspector/FinishOnboarding/index.tsx
+++ b/packages/builtin-tool-web-onboarding/src/client/Inspector/FinishOnboarding/index.tsx
@@ -35,6 +35,4 @@ export const FinishOnboardingInspector = memo<
   );
 });
 
-FinishOnboardingInspector.displayName = 'FinishOnboardingInspector';
-
 export default FinishOnboardingInspector;

--- a/packages/builtin-tool-web-onboarding/src/client/Inspector/ReadDocument/index.tsx
+++ b/packages/builtin-tool-web-onboarding/src/client/Inspector/ReadDocument/index.tsx
@@ -48,6 +48,4 @@ export const ReadDocumentInspector = memo<
   );
 });
 
-ReadDocumentInspector.displayName = 'ReadDocumentInspector';
-
 export default ReadDocumentInspector;

--- a/packages/builtin-tool-web-onboarding/src/client/Inspector/SaveUserQuestion/index.tsx
+++ b/packages/builtin-tool-web-onboarding/src/client/Inspector/SaveUserQuestion/index.tsx
@@ -57,6 +57,4 @@ export const SaveUserQuestionInspector = memo<
   );
 });
 
-SaveUserQuestionInspector.displayName = 'SaveUserQuestionInspector';
-
 export default SaveUserQuestionInspector;

--- a/packages/builtin-tool-web-onboarding/src/client/Inspector/UpdateDocument/index.tsx
+++ b/packages/builtin-tool-web-onboarding/src/client/Inspector/UpdateDocument/index.tsx
@@ -52,6 +52,4 @@ export const UpdateDocumentInspector = memo<
   );
 });
 
-UpdateDocumentInspector.displayName = 'UpdateDocumentInspector';
-
 export default UpdateDocumentInspector;

--- a/packages/builtin-tool-web-onboarding/src/client/Inspector/WriteDocument/index.tsx
+++ b/packages/builtin-tool-web-onboarding/src/client/Inspector/WriteDocument/index.tsx
@@ -56,6 +56,4 @@ export const WriteDocumentInspector = memo<
   );
 });
 
-WriteDocumentInspector.displayName = 'WriteDocumentInspector';
-
 export default WriteDocumentInspector;

--- a/packages/shared-tool-ui/src/AskUserQuestion/AskUserQuestionView.tsx
+++ b/packages/shared-tool-ui/src/AskUserQuestion/AskUserQuestionView.tsx
@@ -175,6 +175,4 @@ export const AskUserQuestionView = memo<AskUserQuestionViewProps>((props) => {
   );
 });
 
-AskUserQuestionView.displayName = 'AskUserQuestionView';
-
 export default AskUserQuestionView;

--- a/packages/shared-tool-ui/src/AskUserQuestion/QuestionPanel.tsx
+++ b/packages/shared-tool-ui/src/AskUserQuestion/QuestionPanel.tsx
@@ -118,6 +118,4 @@ export const QuestionPanel = memo<QuestionPanelProps>(
   },
 );
 
-QuestionPanel.displayName = 'AskUserQuestionPanel';
-
 export default QuestionPanel;

--- a/packages/shared-tool-ui/src/Inspector/EditLocalFile/index.tsx
+++ b/packages/shared-tool-ui/src/Inspector/EditLocalFile/index.tsx
@@ -98,8 +98,6 @@ export const EditLocalFileInspector = memo<EditLocalFileInspectorProps>(
   },
 );
 
-EditLocalFileInspector.displayName = 'EditLocalFileInspector';
-
 export const createEditLocalFileInspector = (translationKey: string) => {
   const Inspector = memo<BuiltinInspectorProps<any, any>>((props) => (
     <EditLocalFileInspector {...props} translationKey={translationKey} />

--- a/packages/shared-tool-ui/src/Inspector/RunCommand/index.tsx
+++ b/packages/shared-tool-ui/src/Inspector/RunCommand/index.tsx
@@ -138,8 +138,6 @@ export const RunCommandInspector = memo<RunCommandInspectorProps>(
   },
 );
 
-RunCommandInspector.displayName = 'RunCommandInspector';
-
 /**
  * Factory to create a RunCommandInspector with a bound translation key.
  * Use this in each package's inspector registry to avoid wrapper components.

--- a/packages/shared-tool-ui/src/components/AnimatedNumber.tsx
+++ b/packages/shared-tool-ui/src/components/AnimatedNumber.tsx
@@ -67,5 +67,3 @@ export const AnimatedNumber = memo<AnimatedNumberProps>(({ value, duration = 500
 
   return formatter ? formatter(displayValue) : Math.round(displayValue).toLocaleString();
 });
-
-AnimatedNumber.displayName = 'AnimatedNumber';

--- a/packages/shared-tool-ui/src/components/FilePathDisplay.tsx
+++ b/packages/shared-tool-ui/src/components/FilePathDisplay.tsx
@@ -61,5 +61,3 @@ export const FilePathDisplay = memo<FilePathDisplayProps>(({ filePath, isDirecto
     </>
   );
 });
-
-FilePathDisplay.displayName = 'FilePathDisplay';

--- a/packages/shared-tool-ui/src/components/OptionCard.tsx
+++ b/packages/shared-tool-ui/src/components/OptionCard.tsx
@@ -107,6 +107,4 @@ export const OptionCard = memo<OptionCardProps>(
   ),
 );
 
-OptionCard.displayName = 'OptionCard';
-
 export default OptionCard;

--- a/src/components/Analytics/LobeAnalyticsProviderWrapper.tsx
+++ b/src/components/Analytics/LobeAnalyticsProviderWrapper.tsx
@@ -43,5 +43,3 @@ export const LobeAnalyticsProviderWrapper = memo<Props>(({ children }) => {
     </LobeAnalyticsProvider>
   );
 });
-
-LobeAnalyticsProviderWrapper.displayName = 'LobeAnalyticsProviderWrapper';

--- a/src/components/DragUploadZone/DragUploadProvider.tsx
+++ b/src/components/DragUploadZone/DragUploadProvider.tsx
@@ -99,5 +99,3 @@ export const DragUploadProvider = memo<DragUploadProviderProps>(({ children }) =
     </DragUploadContext>
   );
 });
-
-DragUploadProvider.displayName = 'DragUploadProvider';

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -49,8 +49,6 @@ const SafeBoundary = memo<SafeBoundaryProps>(
   },
 );
 
-SafeBoundary.displayName = 'SafeBoundary';
-
 export function withErrorBoundary<P extends object>(
   Component: ComponentType<P>,
   options?: { alertTitle?: string; minHeight?: number; variant?: ErrorBoundaryVariant },

--- a/src/features/AgentMockDevtools/CaseTrigger.tsx
+++ b/src/features/AgentMockDevtools/CaseTrigger.tsx
@@ -225,5 +225,3 @@ export const CaseTrigger = memo<CaseTriggerProps>(({ children, placement = 'bott
     </Popover>
   );
 });
-
-CaseTrigger.displayName = 'AgentMockCaseTrigger';

--- a/src/features/AgentMockDevtools/DevtoolsLayout.tsx
+++ b/src/features/AgentMockDevtools/DevtoolsLayout.tsx
@@ -163,5 +163,3 @@ export const DevtoolsLayout = memo(() => {
     </div>
   );
 });
-
-DevtoolsLayout.displayName = 'AgentMockDevtoolsLayout';

--- a/src/features/AgentMockDevtools/Fab.tsx
+++ b/src/features/AgentMockDevtools/Fab.tsx
@@ -99,5 +99,3 @@ export const Fab = memo(() => {
     </Tooltip>
   );
 });
-
-Fab.displayName = 'AgentMockFab';

--- a/src/features/AgentMockDevtools/Modal.tsx
+++ b/src/features/AgentMockDevtools/Modal.tsx
@@ -32,5 +32,3 @@ export const Modal = memo(() => {
 
   return null;
 });
-
-Modal.displayName = 'AgentMockModal';

--- a/src/features/AgentMockDevtools/Popover.tsx
+++ b/src/features/AgentMockDevtools/Popover.tsx
@@ -470,5 +470,3 @@ export const Popover = memo(() => {
     </div>
   );
 });
-
-Popover.displayName = 'AgentMockPopover';

--- a/src/features/AgentMockDevtools/Timeline/EventRow.tsx
+++ b/src/features/AgentMockDevtools/Timeline/EventRow.tsx
@@ -99,5 +99,3 @@ export const EventRow = memo<Props>(({ event, index, cumulativeMs, isActive, onC
     </div>
   );
 });
-
-EventRow.displayName = 'AgentMockEventRow';

--- a/src/features/AgentMockDevtools/components/StatsStrip.tsx
+++ b/src/features/AgentMockDevtools/components/StatsStrip.tsx
@@ -78,5 +78,3 @@ export const StatsStrip = memo(() => {
     </Flexbox>
   );
 });
-
-StatsStrip.displayName = 'AgentMockStatsStrip';

--- a/src/features/AgentMockDevtools/components/StatusPill.tsx
+++ b/src/features/AgentMockDevtools/components/StatusPill.tsx
@@ -67,5 +67,3 @@ export const StatusPill = memo<StatusPillProps>(({ playback, speed }) => {
     </Flexbox>
   );
 });
-
-StatusPill.displayName = 'AgentMockStatusPill';

--- a/src/features/AgentMockDevtools/components/TransportBar.tsx
+++ b/src/features/AgentMockDevtools/components/TransportBar.tsx
@@ -208,5 +208,3 @@ export const TransportBar = memo(() => {
     </Flexbox>
   );
 });
-
-TransportBar.displayName = 'AgentMockTransportBar';

--- a/src/features/AgentMockDevtools/views/FixtureView.tsx
+++ b/src/features/AgentMockDevtools/views/FixtureView.tsx
@@ -72,5 +72,3 @@ export const FixtureView = memo(() => {
     </div>
   );
 });
-
-FixtureView.displayName = 'AgentMockFixtureView';

--- a/src/features/AgentMockDevtools/views/TimelineView.tsx
+++ b/src/features/AgentMockDevtools/views/TimelineView.tsx
@@ -91,5 +91,3 @@ export const TimelineView = memo(() => {
     </div>
   );
 });
-
-TimelineView.displayName = 'AgentMockTimelineView';

--- a/src/features/AgentNotFound/index.tsx
+++ b/src/features/AgentNotFound/index.tsx
@@ -22,8 +22,6 @@ export const AgentNotFound = memo(() => {
   return <NotFound hideWatermark desc={t('agentNotFound.desc')} title={t('agentNotFound.title')} />;
 });
 
-AgentNotFound.displayName = 'AgentNotFound';
-
 /**
  * Replaces children with the 404 card when the routed agent (`:aid`) resolved
  * to not-found / no-access. Builtin slugs are skipped: they are not real agent
@@ -42,5 +40,3 @@ export const AgentNotFoundGuard: FC<PropsWithChildren> = memo(({ children }) => 
 
   return children;
 });
-
-AgentNotFoundGuard.displayName = 'AgentNotFoundGuard';

--- a/src/features/AgentTaskManager/TaskAgentProvider.tsx
+++ b/src/features/AgentTaskManager/TaskAgentProvider.tsx
@@ -100,5 +100,3 @@ export const TaskAgentProvider = memo<TaskAgentProviderProps>(({ children }) => 
     </TaskAgentSelectionContext>
   );
 });
-
-TaskAgentProvider.displayName = 'TaskAgentProvider';

--- a/src/features/ChatInput/ActionBar/Tools/ScrollSignalContext.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/ScrollSignalContext.tsx
@@ -55,8 +55,6 @@ export const ScrollSignalProvider = ({
   );
 };
 
-ScrollSignalProvider.displayName = 'ScrollSignalProvider';
-
 /**
  * Subscribe to scroll events of the nearest ScrollSignalProvider ancestor.
  * If no provider is present this is a no-op.

--- a/src/features/ChatInput/InputEditor/ActionTag/ActionMention.tsx
+++ b/src/features/ChatInput/InputEditor/ActionTag/ActionMention.tsx
@@ -105,5 +105,3 @@ export const ActionMention = memo<ActionMentionProps>(
     );
   },
 );
-
-ActionMention.displayName = 'ActionMention';

--- a/src/features/ChatInput/InputEditor/LocalFileTag/LocalFileTag.tsx
+++ b/src/features/ChatInput/InputEditor/LocalFileTag/LocalFileTag.tsx
@@ -342,5 +342,3 @@ export const LocalFileTag = memo<LocalFileTagProps>(({ className, editor, file, 
     </Popover>
   );
 });
-
-LocalFileTag.displayName = 'LocalFileTag';

--- a/src/features/ChatInput/InputEditor/ReferTopic/ReferTopicView.tsx
+++ b/src/features/ChatInput/InputEditor/ReferTopic/ReferTopicView.tsx
@@ -44,5 +44,3 @@ export const ReferTopicView = memo<ReferTopicViewProps>(({ topicId, fallbackTitl
     </span>
   );
 });
-
-ReferTopicView.displayName = 'ReferTopicView';

--- a/src/features/ChatMiniMap/MinimapIndicator.tsx
+++ b/src/features/ChatMiniMap/MinimapIndicator.tsx
@@ -26,5 +26,3 @@ export const MinimapIndicator = memo<MinimapIndicatorProps>(
     );
   },
 );
-
-MinimapIndicator.displayName = 'MinimapIndicator';

--- a/src/features/ChatMiniMap/MinimapPreview.tsx
+++ b/src/features/ChatMiniMap/MinimapPreview.tsx
@@ -43,5 +43,3 @@ export const MinimapPreview = memo<MinimapPreviewProps>(
     );
   },
 );
-
-MinimapPreview.displayName = 'MinimapPreview';

--- a/src/features/Conversation/ChatList/components/RefreshError.tsx
+++ b/src/features/Conversation/ChatList/components/RefreshError.tsx
@@ -49,5 +49,3 @@ export const RefreshError = memo<RefreshErrorProps>(({ error, onRetry, retrying 
     </Flexbox>
   );
 });
-
-RefreshError.displayName = 'ConversationRefreshError';

--- a/src/features/Conversation/ConversationProvider.tsx
+++ b/src/features/Conversation/ConversationProvider.tsx
@@ -128,5 +128,3 @@ export const ConversationProvider = memo<ConversationProviderProps>(
   },
   isEqual,
 );
-
-ConversationProvider.displayName = 'ConversationProvider';

--- a/src/features/Conversation/Markdown/plugins/Link/Render/InternalEntityLink.tsx
+++ b/src/features/Conversation/Markdown/plugins/Link/Render/InternalEntityLink.tsx
@@ -174,5 +174,3 @@ export const InternalEntityLink = memo<InternalEntityLinkProps>(({ href, label, 
     </InternalEntityPreview>
   );
 });
-
-InternalEntityLink.displayName = 'InternalEntityLink';

--- a/src/features/Conversation/Markdown/plugins/Link/Render/InternalEntityPreview.tsx
+++ b/src/features/Conversation/Markdown/plugins/Link/Render/InternalEntityPreview.tsx
@@ -243,5 +243,3 @@ export const InternalEntityPreview = memo<InternalEntityPreviewProps>(
     );
   },
 );
-
-InternalEntityPreview.displayName = 'InternalEntityPreview';

--- a/src/features/Conversation/Messages/Assistant/Actions/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Actions/index.tsx
@@ -66,5 +66,3 @@ export const AssistantActionsBar = memo<AssistantActionsBarProps>(({ actionsConf
     </Flexbox>
   );
 });
-
-AssistantActionsBar.displayName = 'AssistantActionsBar';

--- a/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
@@ -77,5 +77,3 @@ export const GroupActionsBar = memo<GroupActionsProps>(
     );
   },
 );
-
-GroupActionsBar.displayName = 'GroupActionsBar';

--- a/src/features/Conversation/Messages/Task/Actions/index.tsx
+++ b/src/features/Conversation/Messages/Task/Actions/index.tsx
@@ -60,5 +60,3 @@ export const AssistantActionsBar = memo<AssistantActionsBarProps>(({ actionsConf
     />
   );
 });
-
-AssistantActionsBar.displayName = 'TaskAssistantActionsBar';

--- a/src/features/Conversation/Messages/Tasks/shared/CompletedState.tsx
+++ b/src/features/Conversation/Messages/Tasks/shared/CompletedState.tsx
@@ -52,8 +52,6 @@ export const MetricItem = memo<MetricItemProps>(({ icon, label, value }) => (
   </Tag>
 ));
 
-MetricItem.displayName = 'MetricItem';
-
 interface MetricsRowProps {
   formattedCost?: string | null;
   formattedDuration?: string | null;

--- a/src/features/Conversation/Messages/Tool/ErrorBoundary/ErrorResult.tsx
+++ b/src/features/Conversation/Messages/Tool/ErrorBoundary/ErrorResult.tsx
@@ -39,5 +39,3 @@ export const ErrorDisplay = memo<ErrorDisplayProps>(({ error, identifier, apiNam
     />
   );
 });
-
-ErrorDisplay.displayName = 'ToolErrorDisplay';

--- a/src/features/Conversation/Messages/User/Actions/index.tsx
+++ b/src/features/Conversation/Messages/User/Actions/index.tsx
@@ -46,8 +46,6 @@ export const UserActionsBar = memo<UserActionsProps>(({ actionsConfig, id, data 
   );
 });
 
-UserActionsBar.displayName = 'UserActionsBar';
-
 interface ActionsProps {
   data: UIChatMessage;
   disableEditing?: boolean;

--- a/src/features/Conversation/Messages/components/MessageActionBar/index.tsx
+++ b/src/features/Conversation/Messages/components/MessageActionBar/index.tsx
@@ -120,7 +120,5 @@ export const MessageActionBar = memo<MessageActionBarProps>(({ ctx, bar, menu })
   return <ActionIconGroup items={items} menu={menuStripped} onActionClick={handleAction} />;
 });
 
-MessageActionBar.displayName = 'MessageActionBar';
-
 export type { MessageActionContext, MessageActionSlot } from './types';
 export { DIVIDER_KEY } from './types';

--- a/src/features/Conversation/Messages/components/RichContentRenderer.tsx
+++ b/src/features/Conversation/Messages/components/RichContentRenderer.tsx
@@ -30,5 +30,3 @@ export const RichContentRenderer = memo<RichContentRendererProps>(({ parts }) =>
     </Flexbox>
   );
 });
-
-RichContentRenderer.displayName = 'RichContentRenderer';

--- a/src/features/DailyBrief/BriefCardSkeleton.tsx
+++ b/src/features/DailyBrief/BriefCardSkeleton.tsx
@@ -43,6 +43,4 @@ const BriefCardSkeleton = memo(() => {
   );
 });
 
-BriefCardSkeleton.displayName = 'BriefCardSkeleton';
-
 export { BriefCardSkeleton };

--- a/src/features/DevPanel/RenderGallery/toolSurfaces.tsx
+++ b/src/features/DevPanel/RenderGallery/toolSurfaces.tsx
@@ -109,8 +109,6 @@ export const ToolInspectorSlot = memo<ToolInspectorSlotProps>(
   },
 );
 
-ToolInspectorSlot.displayName = 'ToolInspectorSlot';
-
 interface InterventionConversationHostProps {
   api: ApiEntry;
   children: ReactNode;
@@ -273,5 +271,3 @@ export const ToolBodySlot = memo<ToolBodySlotProps>(
     }
   },
 );
-
-ToolBodySlot.displayName = 'ToolBodySlot';

--- a/src/features/EditorCanvas/EditorCanvas.tsx
+++ b/src/features/EditorCanvas/EditorCanvas.tsx
@@ -196,6 +196,4 @@ export const EditorCanvas = memo<EditorCanvasWithEditorProps>(
   },
 );
 
-EditorCanvas.displayName = 'EditorCanvas';
-
 export default EditorCanvas;

--- a/src/features/EditorCanvas/LinearFilePlugin.tsx
+++ b/src/features/EditorCanvas/LinearFilePlugin.tsx
@@ -137,8 +137,6 @@ export const LinearFileCard = memo<LinearFileCardProps>(({ node }) => {
   );
 });
 
-LinearFileCard.displayName = 'LinearFileCard';
-
 interface LinearFilePluginProps {
   handleUpload: (file: File) => Promise<{ url: string }>;
   /**

--- a/src/features/Fleet/AgentColumn.tsx
+++ b/src/features/Fleet/AgentColumn.tsx
@@ -338,8 +338,6 @@ export const ColumnDragPreview = memo<{
   );
 });
 
-ColumnDragPreview.displayName = 'FleetColumnDragPreview';
-
 interface AgentColumnProps {
   column: FleetColumn;
   status: ChatTopicStatus | undefined;

--- a/src/features/GroupNotFound/index.tsx
+++ b/src/features/GroupNotFound/index.tsx
@@ -18,8 +18,6 @@ export const GroupNotFound = memo(() => {
   return <NotFound hideWatermark desc={t('groupNotFound.desc')} title={t('groupNotFound.title')} />;
 });
 
-GroupNotFound.displayName = 'GroupNotFound';
-
 /**
  * Replaces children with the 404 card when the routed group (`:gid`) resolved
  * to not-found / no-access. The flag is cleared by any later successful fetch
@@ -36,5 +34,3 @@ export const GroupNotFoundGuard: FC<PropsWithChildren> = memo(({ children }) => 
 
   return children;
 });
-
-GroupNotFoundGuard.displayName = 'GroupNotFoundGuard';

--- a/src/features/Messenger/IntegrationDetail/shared.tsx
+++ b/src/features/Messenger/IntegrationDetail/shared.tsx
@@ -109,7 +109,6 @@ export const ConnectionRow = memo<ConnectionRowProps>(
     );
   },
 );
-ConnectionRow.displayName = 'MessengerConnectionRow';
 
 const ConnectionsSkeleton = memo<{ withNestedContent?: boolean }>(
   ({ withNestedContent = false }) => (
@@ -166,7 +165,6 @@ export const IntegrationDetailSkeleton = memo<{ withNestedContent?: boolean }>(
     </Flexbox>
   ),
 );
-IntegrationDetailSkeleton.displayName = 'MessengerIntegrationDetailSkeleton';
 
 interface DetailLayoutProps {
   children?: ReactNode;
@@ -219,7 +217,6 @@ export const DetailLayout = memo<DetailLayoutProps>(
     );
   },
 );
-DetailLayout.displayName = 'MessengerDetailLayout';
 
 interface UserLinkLike {
   activeAgentId: string | null;
@@ -381,7 +378,6 @@ export const UserAgentConnection = memo<UserAgentConnectionProps>(
     );
   },
 );
-UserAgentConnection.displayName = 'MessengerUserAgentConnection';
 
 export const useMessengerData = (platform: MessengerPlatform) => {
   const linksSWR = useSWR(messengerKeys.listMyLinks(), () => messengerService.listMyLinks());

--- a/src/features/Messenger/Verify/Body/shared.tsx
+++ b/src/features/Messenger/Verify/Body/shared.tsx
@@ -120,7 +120,6 @@ export const IconRow = memo<{ platform: MessengerPlatform }>(({ platform }) => (
     <PlatformBubble platform={platform} />
   </div>
 ));
-IconRow.displayName = 'MessengerVerifyIconRow';
 
 export const Heading = memo<{ subtitle?: string; title: string }>(({ subtitle, title }) => (
   <Flexbox align="center" gap={12}>
@@ -138,7 +137,6 @@ export const Heading = memo<{ subtitle?: string; title: string }>(({ subtitle, t
     )}
   </Flexbox>
 ));
-Heading.displayName = 'MessengerVerifyHeading';
 
 export interface InfoRow {
   label: string;
@@ -324,7 +322,6 @@ export const ConfirmCard = memo<ConfirmCardProps>(
     );
   },
 );
-ConfirmCard.displayName = 'MessengerVerifyConfirmCard';
 
 export interface SuccessCardProps {
   /** Pre-built deep link back to the bot. When omitted, the CTA is hidden. */
@@ -354,7 +351,6 @@ export const SuccessCard = memo<SuccessCardProps>(({ openBotUrl, platformLabel }
     </Flexbox>
   );
 });
-SuccessCard.displayName = 'MessengerVerifySuccessCard';
 
 export interface PeekedToken {
   linkedToEmail?: string | null;

--- a/src/features/ModelSwitchPanel/components/List/ListItemRenderer.tsx
+++ b/src/features/ModelSwitchPanel/components/List/ListItemRenderer.tsx
@@ -252,5 +252,3 @@ export const ListItemRenderer = memo<ListItemRendererProps>(
     }
   },
 );
-
-ListItemRenderer.displayName = 'ListItemRenderer';

--- a/src/features/ModelSwitchPanel/components/List/MultipleProvidersModelItem.tsx
+++ b/src/features/ModelSwitchPanel/components/List/MultipleProvidersModelItem.tsx
@@ -162,5 +162,3 @@ export const MultipleProvidersModelItem = memo<MultipleProvidersModelItemProps>(
     );
   },
 );
-
-MultipleProvidersModelItem.displayName = 'MultipleProvidersModelItem';

--- a/src/features/ModelSwitchPanel/components/List/SingleProviderModelItem.tsx
+++ b/src/features/ModelSwitchPanel/components/List/SingleProviderModelItem.tsx
@@ -24,5 +24,3 @@ export const SingleProviderModelItem = memo<SingleProviderModelItemProps>(
     );
   },
 );
-
-SingleProviderModelItem.displayName = 'SingleProviderModelItem';

--- a/src/features/ModelSwitchPanel/components/Toolbar.tsx
+++ b/src/features/ModelSwitchPanel/components/Toolbar.tsx
@@ -74,5 +74,3 @@ export const Toolbar = memo<ToolbarProps>(
     );
   },
 );
-
-Toolbar.displayName = 'Toolbar';

--- a/src/features/PageEditor/History/HistoryListItem.tsx
+++ b/src/features/PageEditor/History/HistoryListItem.tsx
@@ -226,5 +226,3 @@ export const HistoryListItem = memo<HistoryListItemProps>(({ historyId, onCompar
     </div>
   );
 });
-
-HistoryListItem.displayName = 'HistoryListItem';

--- a/src/features/RecommendTaskTemplates/ConnectorAuthRow.tsx
+++ b/src/features/RecommendTaskTemplates/ConnectorAuthRow.tsx
@@ -65,6 +65,4 @@ export const ConnectorAuthRow = memo<ConnectorAuthRowProps>(({ disabled, spec, o
   );
 });
 
-ConnectorAuthRow.displayName = 'ConnectorAuthRow';
-
 export { ConnectorConnectionMarketAuthRequiredError, ConnectorConnectionPopupBlockedError };

--- a/src/features/RecommendTaskTemplates/DailyBriefRecommendationsView.tsx
+++ b/src/features/RecommendTaskTemplates/DailyBriefRecommendationsView.tsx
@@ -36,5 +36,3 @@ export const DailyBriefRecommendationsView = memo<DailyBriefRecommendationsViewP
     );
   },
 );
-
-DailyBriefRecommendationsView.displayName = 'DailyBriefRecommendationsView';

--- a/src/features/RecommendTaskTemplates/TaskTemplateCard.tsx
+++ b/src/features/RecommendTaskTemplates/TaskTemplateCard.tsx
@@ -157,5 +157,3 @@ export const TaskTemplateCard = memo<TaskTemplateCardProps>(
     );
   },
 );
-
-TaskTemplateCard.displayName = 'TaskTemplateCard';

--- a/src/features/RecommendTaskTemplates/TaskTemplateCardSkeleton.tsx
+++ b/src/features/RecommendTaskTemplates/TaskTemplateCardSkeleton.tsx
@@ -67,5 +67,3 @@ export const TaskTemplateCardSkeleton = memo<TaskTemplateCardSkeletonProps>(
     );
   },
 );
-
-TaskTemplateCardSkeleton.displayName = 'TaskTemplateCardSkeleton';

--- a/src/features/RecommendTaskTemplates/TemplateBriefIcon.tsx
+++ b/src/features/RecommendTaskTemplates/TemplateBriefIcon.tsx
@@ -46,5 +46,3 @@ export const TemplateBriefIcon = memo<TemplateBriefIconProps>(({ spec, tileSize 
     </Block>
   );
 });
-
-TemplateBriefIcon.displayName = 'TemplateBriefIcon';

--- a/src/features/RecommendTaskTemplates/index.tsx
+++ b/src/features/RecommendTaskTemplates/index.tsx
@@ -2,5 +2,3 @@ import { memo } from 'react';
 
 /** @deprecated Recommendations render inside Daily brief via `DailyBriefRecommendations`. */
 export const RecommendTaskTemplates = memo(() => null);
-
-RecommendTaskTemplates.displayName = 'RecommendTaskTemplates';

--- a/src/features/Recommendations/RecommendationCard.tsx
+++ b/src/features/Recommendations/RecommendationCard.tsx
@@ -91,5 +91,3 @@ export const RecommendationCard = memo<RecommendationCardProps>(
     );
   },
 );
-
-RecommendationCard.displayName = 'RecommendationCard';

--- a/src/features/ResourceManager/components/FolderTree/index.tsx
+++ b/src/features/ResourceManager/components/FolderTree/index.tsx
@@ -154,8 +154,6 @@ export const FolderTreeItemComponent = memo<FolderTreeItemProps>(
   },
 );
 
-FolderTreeItemComponent.displayName = 'FolderTreeItemComponent';
-
 interface FolderTreeProps {
   expandedFolders: Set<string>;
   items: FolderTreeItem[];

--- a/src/features/ResourceManager/components/KnowledgeBaseListProvider.tsx
+++ b/src/features/ResourceManager/components/KnowledgeBaseListProvider.tsx
@@ -17,8 +17,6 @@ export const KnowledgeBaseListProvider = memo<PropsWithChildren>(({ children }) 
   return <KnowledgeBaseListContext value={knowledgeBases}>{children}</KnowledgeBaseListContext>;
 });
 
-KnowledgeBaseListProvider.displayName = 'KnowledgeBaseListProvider';
-
 export const useKnowledgeBaseListContext = () => {
   const context = use(KnowledgeBaseListContext);
 

--- a/src/features/ResourceManager/components/LibraryHierarchy/HierarchyNode.tsx
+++ b/src/features/ResourceManager/components/LibraryHierarchy/HierarchyNode.tsx
@@ -360,5 +360,3 @@ export const HierarchyNode = memo<HierarchyNodeProps>(
     );
   },
 );
-
-HierarchyNode.displayName = 'HierarchyNode';

--- a/src/features/SettingsSearch/anchor.tsx
+++ b/src/features/SettingsSearch/anchor.tsx
@@ -59,8 +59,6 @@ export const SettingsSearchAnchor = memo<PropsWithChildren<{ id: string }>>(({ i
   </span>
 ));
 
-SettingsSearchAnchor.displayName = 'SettingsSearchAnchor';
-
 /**
  * Scroll the anchor into view and flash-highlight its enclosing form row (or
  * group header). Safe to call before the target tab finishes rendering.

--- a/src/features/SkillStore/SkillList/Community/index.tsx
+++ b/src/features/SkillStore/SkillList/Community/index.tsx
@@ -145,6 +145,4 @@ export const CommunityList = memo(() => {
   return renderContent();
 });
 
-CommunityList.displayName = 'CommunityList';
-
 export default CommunityList;

--- a/src/features/SkillStore/SkillList/Custom/index.tsx
+++ b/src/features/SkillStore/SkillList/Custom/index.tsx
@@ -64,6 +64,4 @@ export const CustomList = memo(() => {
   );
 });
 
-CustomList.displayName = 'CustomList';
-
 export default CustomList;

--- a/src/features/SkillStore/SkillList/LobeHub/index.tsx
+++ b/src/features/SkillStore/SkillList/LobeHub/index.tsx
@@ -216,6 +216,4 @@ export const LobeHubList = memo<LobeHubListProps>(({ keywords }) => {
   );
 });
 
-LobeHubList.displayName = 'LobeHubList';
-
 export default LobeHubList;

--- a/src/features/SkillStore/SkillList/MCP/index.tsx
+++ b/src/features/SkillStore/SkillList/MCP/index.tsx
@@ -93,6 +93,4 @@ export const MCPList = memo(() => {
   );
 });
 
-MCPList.displayName = 'MCPList';
-
 export default MCPList;

--- a/src/features/WorkspaceSetting/Layout.tsx
+++ b/src/features/WorkspaceSetting/Layout.tsx
@@ -34,8 +34,6 @@ const WorkspaceSettingsContentLayout: FC = memo(() => {
   );
 });
 
-WorkspaceSettingsContentLayout.displayName = 'WorkspaceSettingsContentLayout';
-
 export { WorkspaceSettingsContentLayout };
 
 export default WorkspaceSettingsLayout;

--- a/src/layout/AuthProvider/MarketAuth/ClaimResourcesModal.tsx
+++ b/src/layout/AuthProvider/MarketAuth/ClaimResourcesModal.tsx
@@ -217,6 +217,4 @@ export const ClaimResourcesModal = memo<ClaimResourcesModalProps>(
   },
 );
 
-ClaimResourcesModal.displayName = 'ClaimResourcesModal';
-
 export default ClaimResourcesModal;

--- a/src/layout/AuthProvider/MarketAuth/SocialConnectButton.tsx
+++ b/src/layout/AuthProvider/MarketAuth/SocialConnectButton.tsx
@@ -110,6 +110,4 @@ export const SocialConnectButton = memo<SocialConnectButtonProps>(
   },
 );
 
-SocialConnectButton.displayName = 'SocialConnectButton';
-
 export default SocialConnectButton;

--- a/src/layout/GlobalProvider/FaviconProvider.tsx
+++ b/src/layout/GlobalProvider/FaviconProvider.tsx
@@ -117,5 +117,3 @@ export const FaviconProvider = memo<{ children: ReactNode }>(({ children }) => {
     </FaviconStateContext>
   );
 });
-
-FaviconProvider.displayName = 'FaviconProvider';

--- a/src/routes/(main)/(create)/image/features/GenerationFeed/BatchItem.tsx
+++ b/src/routes/(main)/(create)/image/features/GenerationFeed/BatchItem.tsx
@@ -210,5 +210,3 @@ export const GenerationBatchItem = memo<GenerationBatchItemProps>(({ batch }) =>
     </Block>
   );
 });
-
-GenerationBatchItem.displayName = 'GenerationBatchItem';

--- a/src/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/ActionButtons.tsx
+++ b/src/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/ActionButtons.tsx
@@ -59,5 +59,3 @@ export const ActionButtons = memo<ActionButtonsProps>(
     );
   },
 );
-
-ActionButtons.displayName = 'ActionButtons';

--- a/src/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/ErrorState.tsx
+++ b/src/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/ErrorState.tsx
@@ -124,5 +124,3 @@ export const ErrorState = memo<ErrorStateProps>(
     );
   },
 );
-
-ErrorState.displayName = 'ErrorState';

--- a/src/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/LoadingState.tsx
+++ b/src/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/LoadingState.tsx
@@ -40,5 +40,3 @@ export const LoadingState = memo<LoadingStateProps>(
     );
   },
 );
-
-LoadingState.displayName = 'LoadingState';

--- a/src/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/SuccessState.tsx
+++ b/src/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/SuccessState.tsx
@@ -54,5 +54,3 @@ export const SuccessState = memo<SuccessStateProps>(
     );
   },
 );
-
-SuccessState.displayName = 'SuccessState';

--- a/src/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/index.tsx
+++ b/src/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/index.tsx
@@ -147,5 +147,3 @@ export const GenerationItem = memo<GenerationItemProps>(
     );
   },
 );
-
-GenerationItem.displayName = 'GenerationItem';

--- a/src/routes/(main)/(create)/image/features/GenerationFeed/ReferenceImages.tsx
+++ b/src/routes/(main)/(create)/image/features/GenerationFeed/ReferenceImages.tsx
@@ -81,5 +81,3 @@ export const ReferenceImages = memo<ReferenceImagesProps>(({ imageUrl, imageUrls
     </Image.PreviewGroup>
   );
 });
-
-ReferenceImages.displayName = 'ReferenceImages';

--- a/src/routes/(main)/(create)/video/features/GenerationFeed/BatchItem.tsx
+++ b/src/routes/(main)/(create)/video/features/GenerationFeed/BatchItem.tsx
@@ -293,5 +293,3 @@ export const VideoGenerationBatchItem = memo<VideoGenerationBatchItemProps>(({ b
     </Block>
   );
 });
-
-VideoGenerationBatchItem.displayName = 'VideoGenerationBatchItem';

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/FileItem.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/FileItem.tsx
@@ -303,8 +303,6 @@ export const FileItemHeader = memo<FileItemHeaderProps>(
   },
 );
 
-FileItemHeader.displayName = 'ReviewFileItemHeader';
-
 interface FileItemBodyProps {
   /** Whether the Collapse panel is expanded — gates the heavy PatchDiff render. */
   expanded: boolean;

--- a/src/routes/(main)/community/(detail)/user/features/SubmitRepoModal.tsx
+++ b/src/routes/(main)/community/(detail)/user/features/SubmitRepoModal.tsx
@@ -106,6 +106,4 @@ export const SubmitRepoModal = memo<SubmitRepoModalProps>(
   },
 );
 
-SubmitRepoModal.displayName = 'SubmitRepoModal';
-
 export default SubmitRepoModal;

--- a/src/routes/(main)/community/(detail)/workspace/features/WorkspaceProfileModal/Content.tsx
+++ b/src/routes/(main)/community/(detail)/workspace/features/WorkspaceProfileModal/Content.tsx
@@ -463,5 +463,3 @@ export const Content = memo<ContentProps>(({ user, onSuccess }) => {
     </Flexbox>
   );
 });
-
-Content.displayName = 'WorkspaceProfileModalContent';

--- a/src/routes/(main)/memory/features/MemoryAnalysis/Status.tsx
+++ b/src/routes/(main)/memory/features/MemoryAnalysis/Status.tsx
@@ -71,8 +71,6 @@ export const MemoryAnalysisStatus = memo<StatusProps>(({ task }) => {
   );
 });
 
-MemoryAnalysisStatus.displayName = 'MemoryAnalysisStatus';
-
 const Status = memo(() => {
   const { data } = useMemoryAnalysisAsyncTask();
 

--- a/src/routes/(main)/resource/features/DndContextWrapper.tsx
+++ b/src/routes/(main)/resource/features/DndContextWrapper.tsx
@@ -324,5 +324,3 @@ export const DndContextWrapper = memo<PropsWithChildren>(({ children }) => {
     </DragActiveContext>
   );
 });
-
-DndContextWrapper.displayName = 'DndContextWrapper';

--- a/src/routes/(main)/settings/provider/index.tsx
+++ b/src/routes/(main)/settings/provider/index.tsx
@@ -37,8 +37,6 @@ export const ProviderLayout = memo(() => {
   );
 });
 
-ProviderLayout.displayName = 'ProviderLayout';
-
 // Detail page component that receives providerId from route params
 export const ProviderDetailPage = memo(() => {
   const params = useParams<{ providerId: string }>();
@@ -55,8 +53,6 @@ export const ProviderDetailPage = memo(() => {
     />
   );
 });
-
-ProviderDetailPage.displayName = 'ProviderDetailPage';
 
 // Default export for backward compatibility (used by SettingsContent)
 type ProviderPageType = {

--- a/src/routes/(main)/settings/skill/index.tsx
+++ b/src/routes/(main)/settings/skill/index.tsx
@@ -110,8 +110,6 @@ export const ToolSettings = memo<ToolSettingsProps>(({ viewMode }) => {
   );
 });
 
-ToolSettings.displayName = 'ToolSettings';
-
 const Page = memo(() => <ToolSettings viewMode="skill" />);
 
 Page.displayName = 'SkillSettings';


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A — no related issue found; this is a mechanical cleanup.

#### 🔀 Description of Change

- Remove redundant displayName assignments from named-export React components.
- Rely on named component identifiers for React DevTools labels.
- Keep displayName assignments for anonymous wrappers and HOCs untouched.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

- bun run check --test — 152 tests passed.
- Full lint still reports the pre-existing restricted Button import in CallSubAgent.

#### 📸 Screenshots / Videos

N/A — no visual behavior changes.

#### 📝 Additional Information

No runtime behavior or public API changes.
