### PR TITLE
✨ feat(codex): identify agent-browser commands

### DIFF
--- a/locales/en-US/plugin.json
+++ b/locales/en-US/plugin.json
@@ -16,6 +16,7 @@
   "builtins.codex.collabTool.sendInput": "Message subagent",
   "builtins.codex.collabTool.spawnAgent": "Spawn subagent",
   "builtins.codex.collabTool.wait": "Wait for subagents",
+  "builtins.codex.commandExecution.agentBrowser": "Operate browser in background",
   "builtins.codex.commandExecution.gitOperation": "Git operation",
   "builtins.codex.commandExecution.grep": "Search",
   "builtins.codex.commandExecution.noResults": "No results",

--- a/locales/en-US/plugin.json
+++ b/locales/en-US/plugin.json
@@ -16,7 +16,7 @@
   "builtins.codex.collabTool.sendInput": "Message subagent",
   "builtins.codex.collabTool.spawnAgent": "Spawn subagent",
   "builtins.codex.collabTool.wait": "Wait for subagents",
-  "builtins.codex.commandExecution.agentBrowser": "Operate browser in background",
+  "builtins.codex.commandExecution.agentBrowser": "Operate browser",
   "builtins.codex.commandExecution.gitOperation": "Git operation",
   "builtins.codex.commandExecution.grep": "Search",
   "builtins.codex.commandExecution.noResults": "No results",

--- a/locales/zh-CN/plugin.json
+++ b/locales/zh-CN/plugin.json
@@ -16,6 +16,7 @@
   "builtins.codex.collabTool.sendInput": "发送消息给子代理",
   "builtins.codex.collabTool.spawnAgent": "启动子代理",
   "builtins.codex.collabTool.wait": "等待子代理",
+  "builtins.codex.commandExecution.agentBrowser": "后台浏览器操作",
   "builtins.codex.commandExecution.gitOperation": "git 操作",
   "builtins.codex.commandExecution.grep": "搜索",
   "builtins.codex.commandExecution.noResults": "没有结果",

--- a/locales/zh-CN/plugin.json
+++ b/locales/zh-CN/plugin.json
@@ -16,7 +16,7 @@
   "builtins.codex.collabTool.sendInput": "发送消息给子代理",
   "builtins.codex.collabTool.spawnAgent": "启动子代理",
   "builtins.codex.collabTool.wait": "等待子代理",
-  "builtins.codex.commandExecution.agentBrowser": "后台浏览器操作",
+  "builtins.codex.commandExecution.agentBrowser": "操作浏览器",
   "builtins.codex.commandExecution.gitOperation": "git 操作",
   "builtins.codex.commandExecution.grep": "搜索",
   "builtins.codex.commandExecution.noResults": "没有结果",

--- a/packages/builtin-tools/src/codex/CommandExecutionInspector.tsx
+++ b/packages/builtin-tools/src/codex/CommandExecutionInspector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SiGit, SiNodedotjs, SiPython } from '@icons-pack/react-simple-icons';
+import { SiGit, SiGooglechrome, SiNodedotjs, SiPython } from '@icons-pack/react-simple-icons';
 import {
   createGrepContentInspector,
   createReadLocalFileInspector,
@@ -28,9 +28,13 @@ const PROGRAM_DISPLAY: Record<
   CodexCommandProgram,
   { icon: ComponentType<{ className?: string; size?: number }>; translationKey: string }
 > = {
-  git: { icon: SiGit, translationKey: 'builtins.codex.commandExecution.gitOperation' },
-  node: { icon: SiNodedotjs, translationKey: 'builtins.codex.commandExecution.runNode' },
-  python: { icon: SiPython, translationKey: 'builtins.codex.commandExecution.runPython' },
+  'agent-browser': {
+    icon: SiGooglechrome,
+    translationKey: 'builtins.codex.commandExecution.agentBrowser',
+  },
+  'git': { icon: SiGit, translationKey: 'builtins.codex.commandExecution.gitOperation' },
+  'node': { icon: SiNodedotjs, translationKey: 'builtins.codex.commandExecution.runNode' },
+  'python': { icon: SiPython, translationKey: 'builtins.codex.commandExecution.runPython' },
 };
 const SharedGrepInspector = createGrepContentInspector({
   noResultsKey: GREP_NO_RESULTS_KEY,

--- a/packages/builtin-tools/src/codex/commandExecutionUtils.test.ts
+++ b/packages/builtin-tools/src/codex/commandExecutionUtils.test.ts
@@ -101,6 +101,15 @@ describe('getCodexGrepCommandDisplay', () => {
 });
 
 describe('getCodexCommandProgram', () => {
+  it('classifies agent-browser commands', () => {
+    expect(
+      getCodexCommandProgram('agent-browser --session host9253 --cdp 9253 snapshot -i -C'),
+    ).toBe('agent-browser');
+    expect(getCodexCommandProgram('/usr/local/bin/agent-browser open example.com')).toBe(
+      'agent-browser',
+    );
+  });
+
   it('classifies node commands', () => {
     expect(getCodexCommandProgram('node packages/cli/dist/index.js message-gateway stats')).toBe(
       'node',
@@ -122,6 +131,9 @@ describe('getCodexCommandProgram', () => {
   it('unwraps shell wrappers and skips env assignments', () => {
     expect(getCodexCommandProgram('bash -lc "git log --oneline"')).toBe('git');
     expect(getCodexCommandProgram('NODE_ENV=production node app.js')).toBe('node');
+    expect(
+      getCodexCommandProgram('AB_TARGET="--session host9253 --cdp 9253" agent-browser snapshot -i'),
+    ).toBe('agent-browser');
   });
 
   it('returns undefined for unknown or empty programs', () => {

--- a/packages/builtin-tools/src/codex/commandExecutionUtils.ts
+++ b/packages/builtin-tools/src/codex/commandExecutionUtils.ts
@@ -283,13 +283,14 @@ export const getCodexGrepCommandDisplay = (
 };
 
 /** Program families we give a dedicated label + brand icon instead of the generic terminal chip. */
-export type CodexCommandProgram = 'git' | 'node' | 'python';
+export type CodexCommandProgram = 'agent-browser' | 'git' | 'node' | 'python';
 
 const PROGRAM_BY_BASENAME: Record<string, CodexCommandProgram> = {
-  git: 'git',
-  node: 'node',
-  python: 'python',
-  python3: 'python',
+  'agent-browser': 'agent-browser',
+  'git': 'git',
+  'node': 'node',
+  'python': 'python',
+  'python3': 'python',
 };
 
 const ENV_ASSIGNMENT_PATTERN = /^[A-Z_]\w*=/i;

--- a/packages/locales/src/default/plugin.ts
+++ b/packages/locales/src/default/plugin.ts
@@ -116,6 +116,7 @@ export default {
   'builtins.codex.collabTool.sendInput': 'Message subagent',
   'builtins.codex.collabTool.spawnAgent': 'Spawn subagent',
   'builtins.codex.collabTool.wait': 'Wait for subagents',
+  'builtins.codex.commandExecution.agentBrowser': 'Operate browser in background',
   'builtins.codex.commandExecution.gitOperation': 'Git operation',
   'builtins.codex.commandExecution.grep': 'Search',
   'builtins.codex.commandExecution.noResults': 'No results',

--- a/packages/locales/src/default/plugin.ts
+++ b/packages/locales/src/default/plugin.ts
@@ -116,7 +116,7 @@ export default {
   'builtins.codex.collabTool.sendInput': 'Message subagent',
   'builtins.codex.collabTool.spawnAgent': 'Spawn subagent',
   'builtins.codex.collabTool.wait': 'Wait for subagents',
-  'builtins.codex.commandExecution.agentBrowser': 'Operate browser in background',
+  'builtins.codex.commandExecution.agentBrowser': 'Operate browser',
   'builtins.codex.commandExecution.gitOperation': 'Git operation',
   'builtins.codex.commandExecution.grep': 'Search',
   'builtins.codex.commandExecution.noResults': 'No results',


### PR DESCRIPTION
### Summary

- classify `agent-browser` command executions as a dedicated program family
- render the Google Chrome icon and a localized browser-operation label
- cover direct, absolute-path, and environment-prefixed command forms

### Testing

- `bun run check` on the six changed files: lint clean, 16 tests passed
- Electron agent-testing: real `agent-browser --help` execution rendered the dedicated icon and label
- Verification report: https://app.lobehub.com/verify/e3346a43-efa2-4b1c-94eb-760bcc8d1531