### PR TITLE
💄 style(i18n): add spend trigger locale for scheduled runs

### DIFF
--- a/locales/ar/spend.json
+++ b/locales/ar/spend.json
@@ -25,6 +25,7 @@
   "table.columns.trigger.enums.notify": "إشعار",
   "table.columns.trigger.enums.onboarding": "التسجيل",
   "table.columns.trigger.enums.openapi": "واجهة برمجة التطبيقات المفتوحة",
+  "table.columns.trigger.enums.scheduled": "تشغيل مجدول",
   "table.columns.trigger.enums.semantic_search": "بحث المعرفة",
   "table.columns.trigger.enums.signup_email_llm_review": "مراجعة بريد التسجيل الإلكتروني",
   "table.columns.trigger.enums.topic": "ملخص الموضوع",

--- a/locales/bg-BG/spend.json
+++ b/locales/bg-BG/spend.json
@@ -25,6 +25,7 @@
   "table.columns.trigger.enums.notify": "Известие",
   "table.columns.trigger.enums.onboarding": "Въвеждане",
   "table.columns.trigger.enums.openapi": "OpenAPI",
+  "table.columns.trigger.enums.scheduled": "Планирано изпълнение",
   "table.columns.trigger.enums.semantic_search": "Търсене на знания",
   "table.columns.trigger.enums.signup_email_llm_review": "Преглед на имейл за регистрация",
   "table.columns.trigger.enums.topic": "Резюме на тема",

--- a/locales/de-DE/spend.json
+++ b/locales/de-DE/spend.json
@@ -25,6 +25,7 @@
   "table.columns.trigger.enums.notify": "Benachrichtigung",
   "table.columns.trigger.enums.onboarding": "Einführung",
   "table.columns.trigger.enums.openapi": "OpenAPI",
+  "table.columns.trigger.enums.scheduled": "Geplanter Lauf",
   "table.columns.trigger.enums.semantic_search": "Wissenssuche",
   "table.columns.trigger.enums.signup_email_llm_review": "Anmelde-E-Mail-Überprüfung",
   "table.columns.trigger.enums.topic": "Themenzusammenfassung",

--- a/locales/en-US/spend.json
+++ b/locales/en-US/spend.json
@@ -25,6 +25,7 @@
   "table.columns.trigger.enums.notify": "Notification",
   "table.columns.trigger.enums.onboarding": "Onboarding",
   "table.columns.trigger.enums.openapi": "OpenAPI",
+  "table.columns.trigger.enums.scheduled": "Scheduled Run",
   "table.columns.trigger.enums.semantic_search": "Knowledge Search",
   "table.columns.trigger.enums.signup_email_llm_review": "Signup Email Review",
   "table.columns.trigger.enums.topic": "Topic Summary",

--- a/locales/es-ES/spend.json
+++ b/locales/es-ES/spend.json
@@ -25,6 +25,7 @@
   "table.columns.trigger.enums.notify": "Notificación",
   "table.columns.trigger.enums.onboarding": "Incorporación",
   "table.columns.trigger.enums.openapi": "OpenAPI",
+  "table.columns.trigger.enums.scheduled": "Ejecución programada",
   "table.columns.trigger.enums.semantic_search": "Búsqueda de Conocimiento",
   "table.columns.trigger.enums.signup_email_llm_review": "Revisión de Correo Electrónico de Registro",
   "table.columns.trigger.enums.topic": "Resumen de Tema",

--- a/locales/fa-IR/spend.json
+++ b/locales/fa-IR/spend.json
@@ -25,6 +25,7 @@
   "table.columns.trigger.enums.notify": "اعلان",
   "table.columns.trigger.enums.onboarding": "آموزش اولیه",
   "table.columns.trigger.enums.openapi": "OpenAPI",
+  "table.columns.trigger.enums.scheduled": "اجرای زمان‌بندی‌شده",
   "table.columns.trigger.enums.semantic_search": "جستجوی دانش",
   "table.columns.trigger.enums.signup_email_llm_review": "بررسی ایمیل ثبت‌نام",
   "table.columns.trigger.enums.topic": "خلاصه موضوع",

--- a/locales/fr-FR/spend.json
+++ b/locales/fr-FR/spend.json
@@ -25,6 +25,7 @@
   "table.columns.trigger.enums.notify": "Notification",
   "table.columns.trigger.enums.onboarding": "Intégration",
   "table.columns.trigger.enums.openapi": "OpenAPI",
+  "table.columns.trigger.enums.scheduled": "Exécution planifiée",
   "table.columns.trigger.enums.semantic_search": "Recherche de Connaissances",
   "table.columns.trigger.enums.signup_email_llm_review": "Examen de l'email d'inscription",
   "table.columns.trigger.enums.topic": "Résumé de Sujet",

--- a/locales/it-IT/spend.json
+++ b/locales/it-IT/spend.json
@@ -25,6 +25,7 @@
   "table.columns.trigger.enums.notify": "Notifica",
   "table.columns.trigger.enums.onboarding": "Onboarding",
   "table.columns.trigger.enums.openapi": "OpenAPI",
+  "table.columns.trigger.enums.scheduled": "Esecuzione programmata",
   "table.columns.trigger.enums.semantic_search": "Ricerca Conoscenza",
   "table.columns.trigger.enums.signup_email_llm_review": "Revisione Email di Registrazione",
   "table.columns.trigger.enums.topic": "Riepilogo Argomento",

--- a/locales/ja-JP/spend.json
+++ b/locales/ja-JP/spend.json
@@ -25,6 +25,7 @@
   "table.columns.trigger.enums.notify": "通知",
   "table.columns.trigger.enums.onboarding": "オンボーディング",
   "table.columns.trigger.enums.openapi": "OpenAPI",
+  "table.columns.trigger.enums.scheduled": "スケジュールされた実行",
   "table.columns.trigger.enums.semantic_search": "知識検索",
   "table.columns.trigger.enums.signup_email_llm_review": "サインアップメールレビュー",
   "table.columns.trigger.enums.topic": "トピック要約",

--- a/locales/ko-KR/spend.json
+++ b/locales/ko-KR/spend.json
@@ -25,6 +25,7 @@
   "table.columns.trigger.enums.notify": "알림",
   "table.columns.trigger.enums.onboarding": "온보딩",
   "table.columns.trigger.enums.openapi": "OpenAPI",
+  "table.columns.trigger.enums.scheduled": "예약 실행",
   "table.columns.trigger.enums.semantic_search": "지식 검색",
   "table.columns.trigger.enums.signup_email_llm_review": "가입 이메일 검토",
   "table.columns.trigger.enums.topic": "주제 요약",

--- a/locales/nl-NL/spend.json
+++ b/locales/nl-NL/spend.json
@@ -25,6 +25,7 @@
   "table.columns.trigger.enums.notify": "Melding",
   "table.columns.trigger.enums.onboarding": "Introductie",
   "table.columns.trigger.enums.openapi": "OpenAPI",
+  "table.columns.trigger.enums.scheduled": "Geplande uitvoering",
   "table.columns.trigger.enums.semantic_search": "Kenniszoekopdracht",
   "table.columns.trigger.enums.signup_email_llm_review": "Aanmeldings-e-mailbeoordeling",
   "table.columns.trigger.enums.topic": "Onderwerp Samenvatting",

--- a/locales/pl-PL/spend.json
+++ b/locales/pl-PL/spend.json
@@ -25,6 +25,7 @@
   "table.columns.trigger.enums.notify": "Powiadomienie",
   "table.columns.trigger.enums.onboarding": "Wprowadzenie",
   "table.columns.trigger.enums.openapi": "OpenAPI",
+  "table.columns.trigger.enums.scheduled": "Zaplanowane uruchomienie",
   "table.columns.trigger.enums.semantic_search": "Wyszukiwanie Wiedzy",
   "table.columns.trigger.enums.signup_email_llm_review": "Przegląd e-maila rejestracyjnego",
   "table.columns.trigger.enums.topic": "Podsumowanie Tematu",

--- a/locales/pt-BR/spend.json
+++ b/locales/pt-BR/spend.json
@@ -25,6 +25,7 @@
   "table.columns.trigger.enums.notify": "Notificação",
   "table.columns.trigger.enums.onboarding": "Integração",
   "table.columns.trigger.enums.openapi": "OpenAPI",
+  "table.columns.trigger.enums.scheduled": "Execução Agendada",
   "table.columns.trigger.enums.semantic_search": "Busca de Conhecimento",
   "table.columns.trigger.enums.signup_email_llm_review": "Revisão de E-mail de Cadastro",
   "table.columns.trigger.enums.topic": "Resumo de Tópico",

--- a/locales/ru-RU/spend.json
+++ b/locales/ru-RU/spend.json
@@ -25,6 +25,7 @@
   "table.columns.trigger.enums.notify": "Уведомление",
   "table.columns.trigger.enums.onboarding": "Введение",
   "table.columns.trigger.enums.openapi": "OpenAPI",
+  "table.columns.trigger.enums.scheduled": "Запланированный запуск",
   "table.columns.trigger.enums.semantic_search": "Поиск знаний",
   "table.columns.trigger.enums.signup_email_llm_review": "Обзор регистрационного письма",
   "table.columns.trigger.enums.topic": "Резюме темы",

--- a/locales/tr-TR/spend.json
+++ b/locales/tr-TR/spend.json
@@ -25,6 +25,7 @@
   "table.columns.trigger.enums.notify": "Bildirim",
   "table.columns.trigger.enums.onboarding": "Başlangıç",
   "table.columns.trigger.enums.openapi": "Açık API",
+  "table.columns.trigger.enums.scheduled": "Planlanmış Çalıştırma",
   "table.columns.trigger.enums.semantic_search": "Bilgi Arama",
   "table.columns.trigger.enums.signup_email_llm_review": "Kayıt E-postası İncelemesi",
   "table.columns.trigger.enums.topic": "Konu Özeti",

--- a/locales/vi-VN/spend.json
+++ b/locales/vi-VN/spend.json
@@ -25,6 +25,7 @@
   "table.columns.trigger.enums.notify": "Thông báo",
   "table.columns.trigger.enums.onboarding": "Hướng dẫn ban đầu",
   "table.columns.trigger.enums.openapi": "OpenAPI",
+  "table.columns.trigger.enums.scheduled": "Chạy theo lịch",
   "table.columns.trigger.enums.semantic_search": "Tìm kiếm Tri thức",
   "table.columns.trigger.enums.signup_email_llm_review": "Đánh giá Email Đăng ký",
   "table.columns.trigger.enums.topic": "Tóm tắt Chủ đề",

--- a/locales/zh-CN/spend.json
+++ b/locales/zh-CN/spend.json
@@ -25,6 +25,7 @@
   "table.columns.trigger.enums.notify": "通知",
   "table.columns.trigger.enums.onboarding": "引导流程",
   "table.columns.trigger.enums.openapi": "开放API",
+  "table.columns.trigger.enums.scheduled": "预约运行",
   "table.columns.trigger.enums.semantic_search": "知识搜索",
   "table.columns.trigger.enums.signup_email_llm_review": "注册邮件审核",
   "table.columns.trigger.enums.topic": "话题总结",

--- a/locales/zh-TW/spend.json
+++ b/locales/zh-TW/spend.json
@@ -25,6 +25,7 @@
   "table.columns.trigger.enums.notify": "通知",
   "table.columns.trigger.enums.onboarding": "入門指引",
   "table.columns.trigger.enums.openapi": "開放 API",
+  "table.columns.trigger.enums.scheduled": "排程執行",
   "table.columns.trigger.enums.semantic_search": "知識搜尋",
   "table.columns.trigger.enums.signup_email_llm_review": "註冊電子郵件審核",
   "table.columns.trigger.enums.topic": "主題摘要",

--- a/packages/locales/src/default/spend.ts
+++ b/packages/locales/src/default/spend.ts
@@ -25,6 +25,7 @@ export default {
   'table.columns.trigger.enums.notify': 'Notification',
   'table.columns.trigger.enums.onboarding': 'Onboarding',
   'table.columns.trigger.enums.openapi': 'OpenAPI',
+  'table.columns.trigger.enums.scheduled': 'Scheduled Run',
   'table.columns.trigger.enums.semantic_search': 'Knowledge Search',
   'table.columns.trigger.enums.signup_email_llm_review': 'Signup Email Review',
   'table.columns.trigger.enums.topic': 'Topic Summary',


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

Follow-up to #17127

#### 🔀 Description of Change

#17127 added `RequestTrigger.Scheduled = 'scheduled'` but no matching `table.columns.trigger.enums.scheduled` locale key, which breaks type-check for spend-table consumers that map every `RequestTrigger` value to a locale key. Adds the key to the default locale (en-US mirror, hand-translated zh-CN, `bun run i18n` for the rest).

#### 🧪 How to Test

- [x] No tests needed

Type-only/locale change; `tsgo --noEmit` over the spend-table consumers passes with the key present.

#### 📝 Additional Information

None.