### PR TITLE
💄 style(ui): replace Space.Compact button groups with Flexbox gaps

### DIFF
--- a/src/features/AgentSetting/AgentOpening/OpeningQuestions.tsx
+++ b/src/features/AgentSetting/AgentOpening/OpeningQuestions.tsx
@@ -2,7 +2,6 @@
 
 import { ActionIcon, Empty, Flexbox, Input, SortableList } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
-import { Space } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { MessageCircle, PlusIcon, Trash } from 'lucide-react';
 import { memo, useCallback, useMemo, useState } from 'react';
@@ -98,7 +97,7 @@ const OpeningQuestions = memo(() => {
   return (
     <Flexbox gap={8} width={'100%'}>
       <Flexbox gap={4} width={'100%'}>
-        <Space.Compact style={{ width: '100%' }}>
+        <Flexbox horizontal align={'center'} gap={8} width={'100%'}>
           <Input
             disabled={disabled}
             placeholder={t('settingOpening.openingQuestions.placeholder')}
@@ -113,7 +112,7 @@ const OpeningQuestions = memo(() => {
             icon={PlusIcon}
             onClick={addQuestion}
           />
-        </Space.Compact>
+        </Flexbox>
 
         {isRepeat && (
           <p className={styles.repeatError}>{t('settingOpening.openingQuestions.repeat')}</p>

--- a/src/features/AgentSetting/AgentPlugin/index.tsx
+++ b/src/features/AgentSetting/AgentPlugin/index.tsx
@@ -4,7 +4,6 @@ import { getActivePluginIds } from '@lobechat/types';
 import { type FormGroupItemType } from '@lobehub/ui';
 import { Avatar, Center, Empty, Flexbox, Form, Tag, Tooltip } from '@lobehub/ui';
 import { Button, Switch } from '@lobehub/ui/base-ui';
-import { Space } from 'antd';
 import isEqual from 'fast-deep-equal';
 import { BlocksIcon, LucideTrash2, Store } from 'lucide-react';
 import { memo, useCallback } from 'react';
@@ -109,7 +108,7 @@ const AgentPlugin = memo(() => {
   const loadingSkeleton = LoadingList();
 
   const extra = (
-    <Space.Compact style={{ width: 'auto' }}>
+    <Flexbox horizontal gap={4}>
       <AddPluginButton />
       {hasDeprecated ? (
         <Tooltip title={t('plugin.clearDeprecated')}>
@@ -140,7 +139,7 @@ const AgentPlugin = memo(() => {
           />
         </Tooltip>
       ) : null}
-    </Space.Compact>
+    </Flexbox>
   );
 
   const empty = (

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailRunPauseAction.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailRunPauseAction.tsx
@@ -1,6 +1,5 @@
 import { DropdownMenu, Flexbox, Text } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
-import { Space } from 'antd';
 import { CalendarOffIcon, ChevronDown, PlayIcon, RotateCcwIcon } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -138,7 +137,7 @@ const TaskDetailRunPauseAction = memo(() => {
   if (isScheduled) {
     return (
       <Flexbox horizontal align={'center'} gap={12}>
-        <Space.Compact>
+        <Flexbox horizontal gap={4}>
           <Button
             disabled={!canEditTask || isRunningNow}
             icon={CalendarOffIcon}
@@ -166,7 +165,7 @@ const TaskDetailRunPauseAction = memo(() => {
               title={canEditTask ? undefined : reason}
             />
           </DropdownMenu>
-        </Space.Compact>
+        </Flexbox>
         {countdownText && (
           <Text fontSize={12} type={'secondary'}>
             {t('taskDetail.nextRunCountdown', { countdown: countdownText })}

--- a/src/features/LocalFile/LocalFile.tsx
+++ b/src/features/LocalFile/LocalFile.tsx
@@ -1,6 +1,5 @@
 import { Flexbox, Popover } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
-import { Space } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { ExternalLink, FolderOpen } from 'lucide-react';
 import React from 'react';
@@ -87,7 +86,7 @@ export const LocalFile = ({
 
   // File: show popover with two actions
   const popoverContent = (
-    <Space.Compact>
+    <Flexbox horizontal gap={4} padding={4}>
       <Button
         icon={ExternalLink}
         size="small"
@@ -104,7 +103,7 @@ export const LocalFile = ({
       >
         {t('LocalFile.action.showInFolder')}
       </Button>
-    </Space.Compact>
+    </Flexbox>
   );
 
   return (

--- a/src/features/Portal/Artifacts/Body/Renderer/SVG.tsx
+++ b/src/features/Portal/Artifacts/Body/Renderer/SVG.tsx
@@ -3,7 +3,7 @@ import { copyImageToClipboard, sanitizeSVGContent } from '@lobechat/utils/client
 import { Center, DropdownMenu, Flexbox, Tooltip } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { snapdom } from '@zumer/snapdom';
-import { App, Space } from 'antd';
+import { App } from 'antd';
 import { css, cx } from 'antd-style';
 import { CopyIcon, DownloadIcon } from 'lucide-react';
 import { useMemo } from 'react';
@@ -97,39 +97,37 @@ const SVGRenderer = ({ content }: SVGRendererProps) => {
         dangerouslySetInnerHTML={{ __html: sanitizedContent }}
         id={DOM_ID}
       />
-      <Flexbox className={cx(actions)}>
-        <Space.Compact>
-          <DropdownMenu
-            items={[
-              {
-                key: 'png',
-                label: t('artifacts.svg.download.png'),
-                onClick: () => downloadImage('png'),
-              },
-              {
-                key: 'svg',
-                label: t('artifacts.svg.download.svg'),
-                onClick: () => downloadImage('svg'),
-              },
-            ]}
-          >
-            <Button icon={DownloadIcon} />
-          </DropdownMenu>
-          <Tooltip title={t('artifacts.svg.copyAsImage')}>
-            <Button
-              icon={CopyIcon}
-              onClick={async () => {
-                const dataUrl = await generatePng();
-                try {
-                  await copyImageToClipboard(dataUrl);
-                  message.success(t('artifacts.svg.copySuccess'));
-                } catch (e) {
-                  message.error(t('artifacts.svg.copyFail', { error: e }));
-                }
-              }}
-            />
-          </Tooltip>
-        </Space.Compact>
+      <Flexbox horizontal className={cx(actions)} gap={4}>
+        <DropdownMenu
+          items={[
+            {
+              key: 'png',
+              label: t('artifacts.svg.download.png'),
+              onClick: () => downloadImage('png'),
+            },
+            {
+              key: 'svg',
+              label: t('artifacts.svg.download.svg'),
+              onClick: () => downloadImage('svg'),
+            },
+          ]}
+        >
+          <Button icon={DownloadIcon} />
+        </DropdownMenu>
+        <Tooltip title={t('artifacts.svg.copyAsImage')}>
+          <Button
+            icon={CopyIcon}
+            onClick={async () => {
+              const dataUrl = await generatePng();
+              try {
+                await copyImageToClipboard(dataUrl);
+                message.success(t('artifacts.svg.copySuccess'));
+              } catch (e) {
+                message.error(t('artifacts.svg.copyFail', { error: e }));
+              }
+            }}
+          />
+        </Tooltip>
       </Flexbox>
     </Flexbox>
   );

--- a/src/routes/(main)/community/features/LikeButton.tsx
+++ b/src/routes/(main)/community/features/LikeButton.tsx
@@ -1,6 +1,5 @@
 import { Flexbox, Icon, Tooltip, TooltipGroup } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
-import { Space } from 'antd';
 import { ThumbsDownIcon, ThumbsUpIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -25,7 +24,7 @@ const LikeButton = memo<LikeButtonProps>(
     if (showDislike)
       return (
         <TooltipGroup>
-          <Space.Compact style={{ flex: 1.75 }}>
+          <Flexbox horizontal flex={1.75} gap={4}>
             <Tooltip title={t('like')}>
               <Button
                 block
@@ -49,7 +48,7 @@ const LikeButton = memo<LikeButtonProps>(
                 onClick={() => onDislikeClick?.(!isDisliked)}
               />
             </Tooltip>
-          </Space.Compact>
+          </Flexbox>
         </TooltipGroup>
       );
 

--- a/src/routes/(main)/settings/provider/features/ModelList/EmptyModels.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/EmptyModels.tsx
@@ -69,7 +69,7 @@ const EmptyState = memo<{ provider: string }>(({ provider }) => {
       </Flexbox>
 
       <Flexbox horizontal gap={8}>
-        <Tooltip title={canManageProvider ? '' : reason}>
+        <Tooltip title={canManageProvider ? undefined : reason}>
           <Button
             disabled={!canManageProvider}
             icon={PlusIcon}
@@ -86,7 +86,7 @@ const EmptyState = memo<{ provider: string }>(({ provider }) => {
             {t('providerModels.list.addNew')}
           </Button>
         </Tooltip>
-        <Tooltip title={canManageProvider ? '' : reason}>
+        <Tooltip title={canManageProvider ? undefined : reason}>
           <Button
             disabled={!canManageProvider}
             icon={<Icon icon={LucideRefreshCcwDot} />}

--- a/src/routes/(main)/settings/provider/features/ModelList/ModelTitle/index.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/ModelTitle/index.tsx
@@ -116,7 +116,7 @@ const ModelTitle = memo<ModelFetcherProps>(
               )}
               <Flexbox horizontal gap={4}>
                 {showModelFetcher && (
-                  <Tooltip title={canManageProvider ? '' : reason}>
+                  <Tooltip title={canManageProvider ? undefined : reason}>
                     <Button
                       disabled={!canManageProvider}
                       icon={LucideRefreshCcwDot}
@@ -152,7 +152,7 @@ const ModelTitle = memo<ModelFetcherProps>(
                   </Tooltip>
                 )}
                 {showAddNewModel && (
-                  <Tooltip title={canManageProvider ? '' : reason}>
+                  <Tooltip title={canManageProvider ? undefined : reason}>
                     <Button
                       disabled={!canManageProvider}
                       icon={PlusIcon}

--- a/src/routes/(main)/settings/provider/features/ModelList/ModelTitle/index.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/ModelTitle/index.tsx
@@ -1,6 +1,6 @@
 import { ActionIcon, DropdownMenu, Flexbox, Skeleton, Text, Tooltip } from '@lobehub/ui';
 import { Button, confirmModal } from '@lobehub/ui/base-ui';
-import { App, Space } from 'antd';
+import { App } from 'antd';
 import { cssVar } from 'antd-style';
 import { CircleX, EllipsisVertical, LucideRefreshCcwDot, PlusIcon } from 'lucide-react';
 import { memo, use, useEffect, useState } from 'react';
@@ -105,7 +105,7 @@ const ModelTitle = memo<ModelFetcherProps>(
           {isLoading ? (
             <Skeleton.Button active size={'small'} style={{ width: 120 }} />
           ) : isEmpty ? null : (
-            <Flexbox horizontal gap={8}>
+            <Flexbox horizontal align={'center'} gap={8}>
               {!mobile && (
                 <Search
                   value={searchKeyword}
@@ -114,7 +114,7 @@ const ModelTitle = memo<ModelFetcherProps>(
                   }}
                 />
               )}
-              <Space.Compact>
+              <Flexbox horizontal gap={4}>
                 {showModelFetcher && (
                   <Tooltip title={canManageProvider ? '' : reason}>
                     <Button
@@ -191,7 +191,7 @@ const ModelTitle = memo<ModelFetcherProps>(
                 >
                   <Button icon={EllipsisVertical} size={'small'} />
                 </DropdownMenu>
-              </Space.Compact>
+              </Flexbox>
             </Flexbox>
           )}
         </Flexbox>

--- a/src/routes/(main)/settings/proxy/features/ProxyForm.test.tsx
+++ b/src/routes/(main)/settings/proxy/features/ProxyForm.test.tsx
@@ -163,6 +163,7 @@ vi.mock('@lobehub/ui', async () => {
   );
 
   return {
+    Flexbox: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
     Form: GroupedForm,
     Skeleton: () => <div>loading</div>,
     toast: {

--- a/src/routes/(main)/settings/proxy/features/ProxyForm.tsx
+++ b/src/routes/(main)/settings/proxy/features/ProxyForm.tsx
@@ -2,9 +2,9 @@
 
 import { type NetworkProxySettings } from '@lobechat/electron-client-ipc';
 import { type FormGroupItemType } from '@lobehub/ui';
-import { Form, Skeleton, toast } from '@lobehub/ui';
+import { Flexbox, Form, Skeleton, toast } from '@lobehub/ui';
 import { Button, Switch } from '@lobehub/ui/base-ui';
-import { Form as AntdForm, Input, Radio, Space } from 'antd';
+import { Form as AntdForm, Input, Radio } from 'antd';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -295,7 +295,7 @@ const ProxyForm = () => {
     children: [
       {
         children: (
-          <Space.Compact style={{ width: '100%' }}>
+          <Flexbox horizontal align={'center'} gap={8} width={'100%'}>
             <Input
               placeholder={t('proxy.testUrlPlaceholder')}
               style={{ flex: 1 }}
@@ -305,7 +305,7 @@ const ProxyForm = () => {
             <Button loading={isTesting} type="default" onClick={handleTest}>
               {t('proxy.testButton')}
             </Button>
-          </Space.Compact>
+          </Flexbox>
         ),
         desc: t('proxy.testDescription'),
         label: t('proxy.testUrl'),

--- a/src/routes/(main)/settings/skill/features/Actions.tsx
+++ b/src/routes/(main)/settings/skill/features/Actions.tsx
@@ -1,6 +1,5 @@
 import { DropdownMenu, Flexbox, Icon, stopPropagation } from '@lobehub/ui';
 import { Button, confirmModal } from '@lobehub/ui/base-ui';
-import { Space } from 'antd';
 import { MoreHorizontalIcon, Trash2 } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -74,7 +73,7 @@ const Actions = memo<ActionsProps>(({ identifier, type, isMCP }) => {
     <>
       <Flexbox horizontal align={'center'} gap={8} onClick={stopPropagation}>
         {installed ? (
-          <Space.Compact>
+          <Flexbox horizontal gap={4}>
             {showConfigureButton &&
               (isCustomPlugin ? (
                 <EditCustomPlugin identifier={identifier} open={showModal} onOpenChange={setModal}>
@@ -111,7 +110,7 @@ const Actions = memo<ActionsProps>(({ identifier, type, isMCP }) => {
             >
               <Button icon={<Icon icon={MoreHorizontalIcon} />} loading={installing} />
             </DropdownMenu>
-          </Space.Compact>
+          </Flexbox>
         ) : (
           <Button
             disabled={!canCreate || !canEdit}

--- a/src/routes/(main)/settings/skill/features/AgentSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/AgentSkillItem.tsx
@@ -4,7 +4,6 @@ import { type BuiltinSkill, type SkillListItem } from '@lobechat/types';
 import { Avatar, DropdownMenu, Flexbox, Icon, stopPropagation } from '@lobehub/ui';
 import { Button, confirmModal, createModal } from '@lobehub/ui/base-ui';
 import { SkillsIcon } from '@lobehub/ui/icons';
-import { Space } from 'antd';
 import { cssVar } from 'antd-style';
 import { DownloadIcon, MoreHorizontalIcon, Plus, Trash2 } from 'lucide-react';
 import { lazy, memo, Suspense, useState } from 'react';
@@ -137,7 +136,7 @@ const AgentSkillItem = memo<AgentSkillItemProps>(({ skill, isSelected, onSelect 
     }
 
     return (
-      <Space.Compact>
+      <Flexbox horizontal gap={4}>
         <Button disabled={!canEdit} onClick={() => setEditOpen(true)}>
           {tp('store.actions.configure')}
         </Button>
@@ -167,7 +166,7 @@ const AgentSkillItem = memo<AgentSkillItemProps>(({ skill, isSelected, onSelect 
         >
           <Button disabled={!canEdit} icon={<Icon icon={MoreHorizontalIcon} />} loading={loading} />
         </DropdownMenu>
-      </Space.Compact>
+      </Flexbox>
     );
   };
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Follow-up to #16909, #16596 and #16936, which migrated `Button` call sites to `@lobehub/ui/base-ui`.

#### 🔀 Description of Change

antd's `Space.Compact` works through an antd-internal React context that only antd components consume (it squares off inner corners and collapses shared borders). The base-ui `Button` doesn't read that context, so every `Space.Compact` group that received a base-ui Button during the migrations degraded into fully-rounded buttons squeezed together with zero gap — most visibly on the provider model list toolbar (`Fetch models` / `+` / `⋮`), and earlier on the skill settings and proxy settings pages.

base-ui control heights are also hardcoded (small 24px / middle 32px) and don't follow the antd `controlHeight` token (27px / 36px with LobeHub's theme), so the buttons additionally sat 3–4px shorter than adjacent antd inputs.

This PR drops the joined-group form entirely and replaces all 10 `Space.Compact` usages with `Flexbox` spacing:

- Button clusters → `<Flexbox horizontal gap={4}>` (provider model toolbar, skill configure/more pairs, task schedule actions, agent plugin extras, artifact SVG overlay actions, community like/dislike pair, local file popover — the popover also gains `padding={4}` since its content padding was 0 for the flush compact look)
- Input + button rows → `<Flexbox horizontal align={'center'} gap={8} width={'100%'}>` (opening questions, proxy test URL)
- The provider toolbar row gets `align={'center'}` so the height difference against the antd `SearchBar` is visually neutralized; the real fix (base-ui sizes reading the `controlHeight` token) belongs in `@lobehub/ui`

Unused `Space` imports are removed, and the `@lobehub/ui` mock in `ProxyForm.test.tsx` now exports `Flexbox`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check` (lint + related tests) and `bun run check --type` pass. Visual spots to eyeball: provider model list toolbar, skill settings list actions, proxy connection test row, agent opening-questions input row, artifact SVG hover actions.

#### 📝 Additional Information

Library-level follow-up for `@lobehub/ui`: base-ui `Button`/controls should derive heights from the antd `controlHeight` token (24 vs 27 / 32 vs 36 today) so mixed rows align without per-page centering.