### PR TITLE
🔨 chore(provider): bump @lobehub/icons to ^5.11.0 and drop the Grok suffix from xAI

### DIFF
--- a/package.json
+++ b/package.json
@@ -295,7 +295,7 @@
     "@lobehub/charts": "^5.2.1",
     "@lobehub/desktop-ipc-typings": "workspace:*",
     "@lobehub/editor": "^4.19.1",
-    "@lobehub/icons": "^5.10.0",
+    "@lobehub/icons": "^5.11.0",
     "@lobehub/market-sdk": "0.39.2",
     "@lobehub/tts": "^5.1.2",
     "@lobehub/ui": "^5.20.2",

--- a/packages/builtin-tools/package.json
+++ b/packages/builtin-tools/package.json
@@ -51,7 +51,7 @@
     "@lobechat/builtin-tool-web-browsing": "workspace:*",
     "@lobechat/builtin-tool-web-onboarding": "workspace:*",
     "@lobechat/const": "workspace:*",
-    "@lobehub/icons": "^5.10.0"
+    "@lobehub/icons": "^5.11.0"
   },
   "devDependencies": {
     "@lobechat/types": "workspace:*",

--- a/packages/heterogeneous-agents/package.json
+++ b/packages/heterogeneous-agents/package.json
@@ -22,7 +22,7 @@
     "@anthropic-ai/claude-agent-sdk": "0.3.204",
     "@anthropic-ai/sdk": "^0.93.0",
     "@lobechat/agent-gateway-client": "workspace:*",
-    "@lobehub/icons": "^5.10.0",
+    "@lobehub/icons": "^5.11.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "diff": "^8.0.4",
     "zod": "^4.4.3"

--- a/packages/model-bank/src/modelProviders/xai.ts
+++ b/packages/model-bank/src/modelProviders/xai.ts
@@ -9,7 +9,7 @@ const XAI: ModelProviderCard = {
   id: 'xai',
   modelList: { showModelFetcher: true },
   modelsUrl: 'https://docs.x.ai/docs#models',
-  name: 'xAI (Grok)',
+  name: 'xAI',
   settings: {
     disableBrowserRequest: true,
     proxyUrl: {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

Two small SuperGrok-launch follow-ups, split out of the closed #17141 so they can land independently:

1. **Bump `@lobehub/icons` to `^5.11.0`** (root, `packages/builtin-tools`, `packages/heterogeneous-agents` — all three references in the repo). 5.11.0 ships the SuperGrok brand assets; since this repo commits no lockfile, the spec bump also moves existing installs past the stale 5.10.x resolution that renders a placeholder icon for the SuperGrok provider.
2. **Rename the provider display name `xAI (Grok)` → `xAI`** in `packages/model-bank/src/modelProviders/xai.ts`. Now that SuperGrok exists as its own provider, keeping "Grok" in the xAI provider name reads as brand confusion.

#### 🧪 How to Test

- Open the settings provider list: the SuperGrok entry renders its real brand icon instead of a placeholder.
- The xAI provider is listed as "xAI" everywhere its display name appears.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

No screenshots — the change is a display-name string and an icon-asset version bump, with no layout changes.

#### 📝 Additional Information

Both changes are cherry-picked unmodified from #17141. `bun run check` passes (lint clean, no related tests).