### PR TITLE
💄 style(chat-input): align action menu entries

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -457,6 +457,7 @@
   "knowledgeBase.library.action.detail": "Details",
   "knowledgeBase.library.action.remove": "Remove",
   "knowledgeBase.library.title": "Files / Libraries",
+  "knowledgeBase.related.empty": "No related files or libraries",
   "knowledgeBase.relativeFilesOrLibraries": "Related Files/Libraries",
   "knowledgeBase.title": "Library",
   "knowledgeBase.uploadGuide": "Uploaded files can be viewed in the 'Resources' section.",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -457,6 +457,7 @@
   "knowledgeBase.library.action.detail": "详情",
   "knowledgeBase.library.action.remove": "移除",
   "knowledgeBase.library.title": "文件 / 资源库",
+  "knowledgeBase.related.empty": "暂无关联文件或资源库",
   "knowledgeBase.relativeFilesOrLibraries": "关联文件 / 资源库",
   "knowledgeBase.title": "资源库",
   "knowledgeBase.uploadGuide": "上传的文件可以在「资源」中查看",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -450,6 +450,7 @@ export default {
   'knowledgeBase.library.title': 'Files / Libraries',
   'knowledgeBase.files': 'Files',
   'knowledgeBase.libraries': 'Libraries',
+  'knowledgeBase.related.empty': 'No related files or libraries',
   'knowledgeBase.relativeFilesOrLibraries': 'Related Files/Libraries',
   'knowledgeBase.title': 'Library',
   'knowledgeBase.uploadGuide': "Uploaded files can be viewed in the 'Resources' section.",

--- a/src/features/ChatInput/ActionBar/Knowledge/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Knowledge/useControls.tsx
@@ -24,7 +24,7 @@ const styles = createStaticStyles(({ css }) => ({
     cursor: pointer;
 
     display: flex;
-    gap: 8px;
+    gap: 12px;
     align-items: center;
 
     /* width 320 + margin-inline -12 anchors the submenu to 320px (matching the skill
@@ -127,19 +127,20 @@ export const useControls = ({
     ...fileItems,
   ];
 
-  const footer = (
-    <button
-      className={cx(styles.viewMore)}
-      type="button"
-      onClick={(event) => {
-        event.stopPropagation();
-        openAttachKnowledgeModal();
-      }}
-    >
-      <Icon icon={LibraryBig} size={16} />
-      <span className={cx(styles.viewMoreLabel)}>{t('knowledgeBase.viewMore')}</span>
-    </button>
-  );
+  const footer =
+    relatedGroups.length > 0 ? (
+      <button
+        className={cx(styles.viewMore)}
+        type="button"
+        onClick={(event) => {
+          event.stopPropagation();
+          openAttachKnowledgeModal();
+        }}
+      >
+        <Icon color={cssVar.colorTextSecondary} icon={LibraryBig} size={14} />
+        <span className={cx(styles.viewMoreLabel)}>{t('knowledgeBase.viewMore')}</span>
+      </button>
+    ) : null;
 
   return { enabledCount, footer, items: relatedGroups } satisfies KnowledgeControls;
 };

--- a/src/features/ChatInput/ActionBar/Plus/index.tsx
+++ b/src/features/ChatInput/ActionBar/Plus/index.tsx
@@ -585,6 +585,7 @@ const PlusAction = memo(() => {
                   onClick: () => handleSelectSearch('provider'),
                 },
               ],
+              extra: <Icon className="lobe-submenu-chevron" icon={ChevronRight} size={16} />,
               icon: activeIcon(
                 activeSearchOption === 'off' ? GlobeOffIcon : Globe,
                 activeSearchOption !== 'off',
@@ -653,7 +654,13 @@ const PlusAction = memo(() => {
               ...uploadItems,
               ...(knowledgeItems.length > 0
                 ? [{ type: 'divider' as const }, ...knowledgeItems]
-                : []),
+                : [
+                    {
+                      disabled: true,
+                      key: 'knowledge-empty',
+                      label: t('knowledgeBase.related.empty'),
+                    },
+                  ]),
             ],
             // Trailing chevron (replaces base-ui's default triangle submenu arrow,
             // which is hidden via the .lobe-submenu-chevron rule in ActionDropdown).

--- a/src/features/ChatInput/ActionBar/Upload/index.tsx
+++ b/src/features/ChatInput/ActionBar/Upload/index.tsx
@@ -252,21 +252,28 @@ const FileUpload = memo(() => {
     });
   }
 
-  // Always add the "View More" option
-  knowledgeItems.push(
-    {
-      type: 'divider',
-    },
-    {
-      extra: <Icon icon={ArrowRight} />,
-      icon: <Icon icon={LibraryBig} size={MENU_ICON_SIZE} />,
-      key: 'knowledge-base-store',
-      label: t('knowledgeBase.viewMore'),
-      onClick: () => {
-        openAttachKnowledgeModal();
+  if (knowledgeItems.length > 0) {
+    knowledgeItems.push(
+      {
+        type: 'divider',
       },
-    },
-  );
+      {
+        extra: <Icon icon={ArrowRight} />,
+        icon: <Icon icon={LibraryBig} size={MENU_ICON_SIZE} />,
+        key: 'knowledge-base-store',
+        label: t('knowledgeBase.viewMore'),
+        onClick: () => {
+          openAttachKnowledgeModal();
+        },
+      },
+    );
+  } else {
+    knowledgeItems.push({
+      disabled: true,
+      key: 'knowledge-empty',
+      label: t('knowledgeBase.related.empty'),
+    });
+  }
 
   const items: ActionDropdownMenuItems = [
     ...uploadItems,

--- a/src/features/ChatInput/ActionBar/components/ActionDropdown.tsx
+++ b/src/features/ChatInput/ActionBar/components/ActionDropdown.tsx
@@ -113,9 +113,16 @@ const SubmenuScrollStyle = createGlobalStyle`
   }
 
   /* Submenu triggers that opt into a custom trailing chevron (the Plus menu's
-     Skills / Attachments rows mark their extra icon with .lobe-submenu-chevron)
+     Skills / Web Search / Attachments rows mark their extra icon with .lobe-submenu-chevron)
      render that chevron themselves; hide base-ui's default triangle submenu arrow
      — always the last child of the trigger's content — so the two don't stack. */
+  .lobe-submenu-chevron {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+  }
+
   [role='menuitem']:has(.lobe-submenu-chevron) > * > *:last-child {
     display: none;
   }


### PR DESCRIPTION
Polishes the chat input action menus so attachment and submenu affordances use one visual language.

<!-- linear:table-colwidths:400,400 -->
| Before | After |
| -- | -- |
| “View More” used mismatched icon sizing/color and stayed visible for an empty attachment list. | The icon matches other rows; empty lists show a localized hint and omit the footer divider/action. |
| Web Search used the default triangle while sibling submenus used custom chevrons. | Web Search, Skills, and Attachments share the same centered 16px chevron. |

Automated validation:

* `bun run check` on all changed TSX and locale files
* Pre-commit lint-staged checks passed

Manual scenario: open the chat input Plus menu and compare Web Search, Skills, and Attachments; then inspect Attachments with and without related files/libraries.