### PR TITLE
💄 style(provider): hide the roadmap footer on OAuth provider pages

### DIFF
--- a/packages/model-bank/src/modelProviders/index.test.ts
+++ b/packages/model-bank/src/modelProviders/index.test.ts
@@ -2,9 +2,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { type ModelProviderCard } from '@/types/llm';
 
-import { DEFAULT_MODEL_PROVIDER_LIST, isProviderDisableBrowserRequest } from './index';
+import {
+  DEFAULT_MODEL_PROVIDER_LIST,
+  isProviderDisableBrowserRequest,
+  isProviderOAuthDeviceFlow,
+} from './index';
 
-describe('isProviderDisableBrowserRequest', () => {
+describe('model provider predicates', () => {
   const originalProviders = [...DEFAULT_MODEL_PROVIDER_LIST];
 
   const createProvider = (overrides: Partial<ModelProviderCard>): ModelProviderCard => ({
@@ -21,6 +25,7 @@ describe('isProviderDisableBrowserRequest', () => {
     DEFAULT_MODEL_PROVIDER_LIST.push(
       createProvider({ id: 'root-disabled', disableBrowserRequest: true }),
       createProvider({ id: 'settings-disabled', settings: { disableBrowserRequest: true } }),
+      createProvider({ id: 'oauth-provider', settings: { authType: 'oauthDeviceFlow' } }),
       createProvider({ id: 'enabled-provider' }),
     );
   });
@@ -44,5 +49,12 @@ describe('isProviderDisableBrowserRequest', () => {
 
   it('returns false for unknown provider id', () => {
     expect(isProviderDisableBrowserRequest('not-exists')).toBe(false);
+  });
+
+  it('detects OAuth device flow providers', () => {
+    expect(isProviderOAuthDeviceFlow('oauth-provider')).toBe(true);
+    expect(isProviderOAuthDeviceFlow('enabled-provider')).toBe(false);
+    expect(isProviderOAuthDeviceFlow('not-exists')).toBe(false);
+    expect(isProviderOAuthDeviceFlow()).toBe(false);
   });
 });

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -239,6 +239,11 @@ export const isProviderDisableBrowserRequest = (id: string) => {
   return !!provider;
 };
 
+export const isProviderOAuthDeviceFlow = (id?: string) =>
+  DEFAULT_MODEL_PROVIDER_LIST.some(
+    (provider) => provider.id === id && provider.settings?.authType === 'oauthDeviceFlow',
+  );
+
 export { default as Ai21ProviderCard } from './ai21';
 export { default as Ai302ProviderCard } from './ai302';
 export { default as Ai360ProviderCard } from './ai360';

--- a/src/routes/(main)/[workspaceSlug]/settings/provider/index.test.tsx
+++ b/src/routes/(main)/[workspaceSlug]/settings/provider/index.test.tsx
@@ -1,12 +1,24 @@
 import { render, screen } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { MemoryRouter } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
 
 import WorkspaceProviderSetting from './index';
 
-vi.mock('@/routes/(main)/settings/provider/(list)', async () => {
+vi.mock('@/const/version', () => ({ isCustomBranding: false }));
+
+vi.mock('@/routes/(main)/settings/provider/_layout/Desktop', () => ({
+  default: ({ children }: PropsWithChildren) => <>{children}</>,
+}));
+
+vi.mock('@/routes/(main)/settings/provider/_layout/Mobile', () => ({
+  default: ({ children }: PropsWithChildren) => <>{children}</>,
+}));
+
+vi.mock('@/routes/(main)/settings/provider/detail', async () => {
   const { useSettingsContext } = await import('@/routes/(main)/settings/_layout/ContextProvider');
 
-  const ProviderList = () => {
+  const ProviderDetail = () => {
     const { showOpenAIApiKey, showOpenAIProxyUrl } = useSettingsContext();
 
     return (
@@ -16,13 +28,36 @@ vi.mock('@/routes/(main)/settings/provider/(list)', async () => {
     );
   };
 
-  return { default: ProviderList };
+  return { default: ProviderDetail };
 });
+
+vi.mock('@/routes/(main)/settings/provider/(list)/Footer', () => ({
+  default: () => <div data-testid="provider-footer" />,
+}));
+
+const renderPage = (providerId: string) =>
+  render(
+    <MemoryRouter initialEntries={[`/?provider=${providerId}`]}>
+      <WorkspaceProviderSetting />
+    </MemoryRouter>,
+  );
 
 describe('WorkspaceProviderSetting', () => {
   it('provides settings context for the reused provider settings page', () => {
-    render(<WorkspaceProviderSetting />);
+    renderPage('openai');
 
     expect(screen.getByTestId('provider-context')).toHaveTextContent('true:true');
+  });
+
+  it('hides the provider footer for OAuth device flow providers', () => {
+    renderPage('supergrok');
+
+    expect(screen.queryByTestId('provider-footer')).not.toBeInTheDocument();
+  });
+
+  it('shows the provider footer for regular providers', () => {
+    renderPage('openai');
+
+    expect(screen.getByTestId('provider-footer')).toBeInTheDocument();
   });
 });

--- a/src/routes/(main)/settings/provider/(list)/index.tsx
+++ b/src/routes/(main)/settings/provider/(list)/index.tsx
@@ -8,6 +8,7 @@ import { isCustomBranding } from '@/const/version';
 import DesktopLayout from '../_layout/Desktop';
 import MobileLayout from '../_layout/Mobile';
 import ProviderDetailPage from '../detail';
+import { shouldShowProviderFooter } from '../features/providerSettings';
 import Footer from './Footer';
 
 const Page = (props: { mobile?: boolean }) => {
@@ -28,7 +29,7 @@ const Page = (props: { mobile?: boolean }) => {
   return (
     <ProviderLayout onProviderSelect={setProvider}>
       {ProviderListPage}
-      {!isCustomBranding && <Footer />}
+      {shouldShowProviderFooter({ isCustomBranding, providerId: provider }) && <Footer />}
     </ProviderLayout>
   );
 };

--- a/src/routes/(main)/settings/provider/features/ProviderConfig/UpdateProviderInfo/normalizeProviderSettings.test.ts
+++ b/src/routes/(main)/settings/provider/features/ProviderConfig/UpdateProviderInfo/normalizeProviderSettings.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { isResponsesApiSupportedSdkType, normalizeProviderSettings } from '../../providerSettings';
+import {
+  isResponsesApiSupportedSdkType,
+  normalizeProviderSettings,
+  shouldShowProviderFooter,
+} from '../../providerSettings';
 
 describe('isResponsesApiSupportedSdkType', () => {
   it('should return true for openai and router sdk types', () => {
@@ -11,6 +15,27 @@ describe('isResponsesApiSupportedSdkType', () => {
   it('should return false for unsupported sdk types', () => {
     expect(isResponsesApiSupportedSdkType('anthropic')).toBe(false);
     expect(isResponsesApiSupportedSdkType(undefined)).toBe(false);
+  });
+});
+
+describe('shouldShowProviderFooter', () => {
+  it('should hide the footer for OAuth device flow providers', () => {
+    expect(shouldShowProviderFooter({ isCustomBranding: false, providerId: 'supergrok' })).toBe(
+      false,
+    );
+  });
+
+  it('should hide the footer for custom branding', () => {
+    expect(shouldShowProviderFooter({ isCustomBranding: true, providerId: 'openai' })).toBe(false);
+  });
+
+  it('should show the footer for regular providers', () => {
+    expect(shouldShowProviderFooter({ isCustomBranding: false, providerId: 'openai' })).toBe(true);
+  });
+
+  it('should show the footer on the provider list where no provider is selected', () => {
+    expect(shouldShowProviderFooter({ isCustomBranding: false, providerId: 'all' })).toBe(true);
+    expect(shouldShowProviderFooter({ isCustomBranding: false })).toBe(true);
   });
 });
 

--- a/src/routes/(main)/settings/provider/features/providerSettings.ts
+++ b/src/routes/(main)/settings/provider/features/providerSettings.ts
@@ -1,3 +1,5 @@
+import { isProviderOAuthDeviceFlow } from 'model-bank/modelProviders';
+
 import { type AiProviderSDKType, type AiProviderSettings } from '@/types/aiProvider';
 
 const RESPONSE_API_SUPPORTED_SDK_TYPES = new Set<AiProviderSDKType>(['openai', 'router']);
@@ -7,6 +9,18 @@ export const isResponsesApiSupportedSdkType = (sdkType?: AiProviderSDKType) => {
 
   return RESPONSE_API_SUPPORTED_SDK_TYPES.has(sdkType);
 };
+
+interface ShouldShowProviderFooterParams {
+  isCustomBranding: boolean;
+  providerId?: string;
+}
+
+// Subscription OAuth providers source models from the user's own account,
+// so the "more providers coming" footer reads as a misleading model roadmap there.
+export const shouldShowProviderFooter = ({
+  isCustomBranding,
+  providerId,
+}: ShouldShowProviderFooterParams) => !isCustomBranding && !isProviderOAuthDeviceFlow(providerId);
 
 interface NormalizeProviderSettingsParams {
   nextSettings?: AiProviderSettings;

--- a/src/routes/(main)/settings/provider/index.tsx
+++ b/src/routes/(main)/settings/provider/index.tsx
@@ -10,11 +10,13 @@ import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwar
 import DesktopLayoutContainer from './_layout/Desktop/Container';
 import Footer from './(list)/Footer';
 import ProviderDetailPageComponent from './detail';
+import { shouldShowProviderFooter } from './features/providerSettings';
 import ProviderMenu from './ProviderMenu';
 
 // Layout component that wraps provider pages with navigation
 export const ProviderLayout = memo(() => {
   const navigate = useWorkspaceAwareNavigate();
+  const { providerId } = useParams<{ providerId: string }>();
 
   const handleProviderSelect = (providerKey: string) => {
     navigate(`/settings/provider/${providerKey}`);
@@ -31,7 +33,7 @@ export const ProviderLayout = memo(() => {
       <ProviderMenu mobile={false} onProviderSelect={handleProviderSelect} />
       <DesktopLayoutContainer>
         <Outlet />
-        {!isCustomBranding && <Footer />}
+        {shouldShowProviderFooter({ isCustomBranding, providerId }) && <Footer />}
       </DesktopLayoutContainer>
     </Flexbox>
   );


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None. Split out of the closed #17141.

#### 🔀 Description of Change

On subscription-style OAuth providers (SuperGrok, GitHub Copilot — any `authType: 'oauthDeviceFlow'` provider), models come from the user's own subscription, so the "more providers coming" footer under the provider detail page reads as a misleading model roadmap. This PR hides the footer there.

Implementation:

- New `isProviderOAuthDeviceFlow(id?)` predicate in `packages/model-bank/src/modelProviders`, next to the existing `isProviderDisableBrowserRequest`.
- New `shouldShowProviderFooter({ isCustomBranding, providerId })` helper in the provider settings feature folder, so the rule lives in one place.
- Applied to **both** provider page implementations — the nested `/settings/provider/:providerId` route (`ProviderLayout`) and the legacy query-param page (`(list)/index.tsx`) that the workspace settings provider tab reuses. (Patching only one of the two was a review finding on #17141; here both are covered from the start.)

The provider list view (`providerId` of `all`/absent) keeps the footer, as does every non-OAuth provider. `isCustomBranding` behavior is unchanged.

#### 🧪 How to Test

Automated (all passing locally via `bun run check` — 19 tests):

- `packages/model-bank`: predicate unit tests.
- `normalizeProviderSettings.test.ts`: `shouldShowProviderFooter` unit tests, incl. the list-view (`all`/absent) edge.
- `[workspaceSlug]/settings/provider/index.test.tsx`: component tests asserting the footer is absent for `supergrok` and present for `openai` on the workspace provider page.

Manual: open `/settings/provider/supergrok` — no footer below the provider config; `/settings/provider/openai` and `/settings/provider/all` still show it. Same behavior on the workspace settings provider tab (`?provider=supergrok`).

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

No screenshots — the change removes one static footer block on OAuth provider detail pages; visibility rules are covered by the component tests above.

#### 📝 Additional Information

No i18n changes. Sibling PR from the same split: #17173 (SuperGrok icon assets + xAI rename).