### PR TITLE
♻️ refactor: add support contacts to emails

### DIFF
--- a/apps/server/src/services/email/index.test.ts
+++ b/apps/server/src/services/email/index.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { EMAIL_SUPPORT_REPLY_TO } from '@/libs/email/support';
+
 import { createEmailServiceImpl, EmailImplType } from './impls';
 import { EmailService } from './index';
 
@@ -57,10 +59,9 @@ describe('EmailService', () => {
 
       const result = await emailService.sendMail(payload);
 
-      expect(mockEmailImpl.sendMail).toHaveBeenCalledWith({
-        ...payload,
-        replyTo: 'support@lobehub.com',
-      });
+      expect(mockEmailImpl.sendMail).toHaveBeenCalledWith(
+        EMAIL_SUPPORT_REPLY_TO ? { ...payload, replyTo: EMAIL_SUPPORT_REPLY_TO } : payload,
+      );
       expect(result).toBe(mockResponse);
     });
 
@@ -79,10 +80,9 @@ describe('EmailService', () => {
 
       await emailService.sendMail(payload);
 
-      expect(mockEmailImpl.sendMail).toHaveBeenCalledWith({
-        ...payload,
-        replyTo: 'support@lobehub.com',
-      });
+      expect(mockEmailImpl.sendMail).toHaveBeenCalledWith(
+        EMAIL_SUPPORT_REPLY_TO ? { ...payload, replyTo: EMAIL_SUPPORT_REPLY_TO } : payload,
+      );
     });
 
     it('should support attachments', async () => {
@@ -106,10 +106,9 @@ describe('EmailService', () => {
 
       await emailService.sendMail(payload);
 
-      expect(mockEmailImpl.sendMail).toHaveBeenCalledWith({
-        ...payload,
-        replyTo: 'support@lobehub.com',
-      });
+      expect(mockEmailImpl.sendMail).toHaveBeenCalledWith(
+        EMAIL_SUPPORT_REPLY_TO ? { ...payload, replyTo: EMAIL_SUPPORT_REPLY_TO } : payload,
+      );
     });
 
     it('should support reply-to address', async () => {

--- a/apps/server/src/services/email/index.test.ts
+++ b/apps/server/src/services/email/index.test.ts
@@ -3,6 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createEmailServiceImpl, EmailImplType } from './impls';
 import { EmailService } from './index';
 
+vi.mock('@/envs/email', () => ({
+  emailEnv: { EMAIL_SERVICE_PROVIDER: undefined },
+}));
+
 // Mock dependencies
 vi.mock('./impls');
 
@@ -53,7 +57,10 @@ describe('EmailService', () => {
 
       const result = await emailService.sendMail(payload);
 
-      expect(mockEmailImpl.sendMail).toHaveBeenCalledWith(payload);
+      expect(mockEmailImpl.sendMail).toHaveBeenCalledWith({
+        ...payload,
+        replyTo: 'support@lobehub.com',
+      });
       expect(result).toBe(mockResponse);
     });
 
@@ -72,7 +79,10 @@ describe('EmailService', () => {
 
       await emailService.sendMail(payload);
 
-      expect(mockEmailImpl.sendMail).toHaveBeenCalledWith(payload);
+      expect(mockEmailImpl.sendMail).toHaveBeenCalledWith({
+        ...payload,
+        replyTo: 'support@lobehub.com',
+      });
     });
 
     it('should support attachments', async () => {
@@ -96,7 +106,10 @@ describe('EmailService', () => {
 
       await emailService.sendMail(payload);
 
-      expect(mockEmailImpl.sendMail).toHaveBeenCalledWith(payload);
+      expect(mockEmailImpl.sendMail).toHaveBeenCalledWith({
+        ...payload,
+        replyTo: 'support@lobehub.com',
+      });
     });
 
     it('should support reply-to address', async () => {

--- a/apps/server/src/services/email/index.ts
+++ b/apps/server/src/services/email/index.ts
@@ -26,10 +26,9 @@ export class EmailService {
    * Send an email
    */
   async sendMail(payload: EmailPayload): Promise<EmailResponse> {
-    return this.emailImpl.sendMail({
-      ...payload,
-      replyTo: payload.replyTo || EMAIL_SUPPORT_REPLY_TO,
-    });
+    const replyTo = payload.replyTo || EMAIL_SUPPORT_REPLY_TO;
+
+    return this.emailImpl.sendMail(replyTo ? { ...payload, replyTo } : payload);
   }
 
   /**

--- a/apps/server/src/services/email/index.ts
+++ b/apps/server/src/services/email/index.ts
@@ -1,4 +1,5 @@
 import { emailEnv } from '@/envs/email';
+import { EMAIL_SUPPORT_REPLY_TO } from '@/libs/email/support';
 
 import { type EmailPayload, type EmailResponse, type EmailServiceImpl } from './impls';
 import { createEmailServiceImpl, EmailImplType } from './impls';
@@ -25,7 +26,10 @@ export class EmailService {
    * Send an email
    */
   async sendMail(payload: EmailPayload): Promise<EmailResponse> {
-    return this.emailImpl.sendMail(payload);
+    return this.emailImpl.sendMail({
+      ...payload,
+      replyTo: payload.replyTo || EMAIL_SUPPORT_REPLY_TO,
+    });
   }
 
   /**

--- a/locales/en-US/notification.json
+++ b/locales/en-US/notification.json
@@ -13,6 +13,8 @@
   "credit_balance_low": "Your credit balance is running low — about {{balance}} in credits remaining. Turn on auto top-up so your balance refills automatically and your work is never interrupted.",
   "credit_balance_low_action": "Set up auto top-up",
   "credit_balance_low_title": "Your credit balance is running low",
+  "email.footer.contactSupport": "Contact support",
+  "email.footer.joinDiscord": "Join Discord",
   "email.footer.manage": "Manage notifications",
   "email.footer.preference": "You received this email because of your notification settings on LobeHub.",
   "email.footer.system": "This is an important account notification from LobeHub.",

--- a/locales/zh-CN/notification.json
+++ b/locales/zh-CN/notification.json
@@ -13,6 +13,8 @@
   "credit_balance_low": "您的积分余额即将用尽，当前约剩余 {{balance}} 的积分。建议开启自动充值，余额不足时自动续费，让你的工作不被中断。",
   "credit_balance_low_action": "开启自动充值",
   "credit_balance_low_title": "您的积分余额即将用尽",
+  "email.footer.contactSupport": "联系支持",
+  "email.footer.joinDiscord": "加入 Discord",
   "email.footer.manage": "管理通知",
   "email.footer.preference": "你收到这封邮件是因为你在 LobeHub 的通知设置。",
   "email.footer.system": "这是一封来自 LobeHub 的重要账户通知。",

--- a/packages/business/const/src/branding.test.ts
+++ b/packages/business/const/src/branding.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import { BRANDING_EMAIL } from './branding';
+
+describe('BRANDING_EMAIL', () => {
+  it('leaves Reply-To unset by default for self-hosted deployments', () => {
+    expect(BRANDING_EMAIL.replyTo).toBeUndefined();
+  });
+});

--- a/packages/business/const/src/branding.ts
+++ b/packages/business/const/src/branding.ts
@@ -31,6 +31,7 @@ export const FILE_URL = {
 
 export const BRANDING_EMAIL = {
   business: 'hello@lobehub.com',
+  replyTo: undefined,
   support: 'support@lobehub.com',
 };
 

--- a/packages/locales/src/default/notification.ts
+++ b/packages/locales/src/default/notification.ts
@@ -16,6 +16,8 @@ export default {
     'Your credit balance is running low — about {{balance}} in credits remaining. Turn on auto top-up so your balance refills automatically and your work is never interrupted.',
   'credit_balance_low_action': 'Set up auto top-up',
   'credit_balance_low_title': 'Your credit balance is running low',
+  'email.footer.contactSupport': 'Contact support',
+  'email.footer.joinDiscord': 'Join Discord',
   'email.footer.manage': 'Manage notifications',
   'email.footer.preference':
     'You received this email because of your notification settings on LobeHub.',

--- a/src/libs/better-auth/email-templates/change-email.ts
+++ b/src/libs/better-auth/email-templates/change-email.ts
@@ -1,3 +1,5 @@
+import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
+
 /**
  * Change email verification template
  * Sent to users when they request to change their email address
@@ -94,6 +96,9 @@ export const getChangeEmailVerificationTemplate = (params: {
 
     <!-- Footer -->
     <div style="text-align: center; margin-top: 32px;">
+      <p style="font-size: 13px; margin: 0 0 8px 0;">
+        ${getEmailSupportHtml()}
+      </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
         © 2026 LobeHub. All rights reserved.
       </p>
@@ -103,6 +108,6 @@ export const getChangeEmailVerificationTemplate = (params: {
 </html>
     `,
     subject: 'Confirm Your New Email - LobeHub',
-    text: `You requested to change your LobeHub account email. Please confirm by clicking this link: ${url}\n\nThis link will expire in ${expirationText}.\n\nIf you didn't request this change, you can safely ignore this email.`,
+    text: `You requested to change your LobeHub account email. Please confirm by clicking this link: ${url}\n\nThis link will expire in ${expirationText}.\n\nIf you didn't request this change, you can safely ignore this email.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/index.test.ts
+++ b/src/libs/better-auth/email-templates/index.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getChangeEmailVerificationTemplate,
+  getMagicLinkEmailTemplate,
+  getResetPasswordEmailTemplate,
+  getVerificationEmailTemplate,
+  getVerificationOTPEmailTemplate,
+  getWorkspaceInviteEmailTemplate,
+  getWorkspaceMemberRemovedEmailTemplate,
+} from './index';
+
+const templates = [
+  getChangeEmailVerificationTemplate({
+    expiresInSeconds: 3600,
+    url: 'https://example.com/change-email',
+  }),
+  getMagicLinkEmailTemplate({
+    expiresInSeconds: 600,
+    url: 'https://example.com/sign-in',
+  }),
+  getResetPasswordEmailTemplate({ url: 'https://example.com/reset-password' }),
+  getVerificationEmailTemplate({
+    expiresInSeconds: 3600,
+    url: 'https://example.com/verify-email',
+  }),
+  getVerificationOTPEmailTemplate({ expiresInSeconds: 600, otp: '123456' }),
+  getWorkspaceInviteEmailTemplate({
+    expiresInDays: 7,
+    role: 'member',
+    url: 'https://example.com/invite',
+    workspaceName: 'Example Workspace',
+  }),
+  getWorkspaceMemberRemovedEmailTemplate({
+    reason: 'removed_by_owner',
+    workspaceName: 'Example Workspace',
+  }),
+];
+
+describe('email templates', () => {
+  it.each(templates)(
+    'includes support email and Discord links in HTML and plain text',
+    (template) => {
+      expect(template.html).toContain('href="mailto:support@lobehub.com"');
+      expect(template.html).toContain('https://discord.gg/');
+      expect(template.text).toContain('support@lobehub.com');
+      expect(template.text).toContain('https://discord.gg/');
+    },
+  );
+});

--- a/src/libs/better-auth/email-templates/magic-link.ts
+++ b/src/libs/better-auth/email-templates/magic-link.ts
@@ -1,3 +1,5 @@
+import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
+
 /**
  * Magic link sign-in email template
  * Sent when user requests passwordless login
@@ -84,6 +86,9 @@ export const getMagicLinkEmailTemplate = (params: { expiresInSeconds: number; ur
 
     <!-- Footer -->
     <div style="text-align: center; margin-top: 32px;">
+      <p style="font-size: 13px; margin: 0 0 8px 0;">
+        ${getEmailSupportHtml()}
+      </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
         © ${new Date().getFullYear()} LobeHub. All rights reserved.
       </p>
@@ -93,6 +98,6 @@ export const getMagicLinkEmailTemplate = (params: { expiresInSeconds: number; ur
 </html>
     `,
     subject: 'Your LobeHub sign-in link',
-    text: `Use this link to sign in: ${url}\n\nThis link expires in ${expirationText}.`,
+    text: `Use this link to sign in: ${url}\n\nThis link expires in ${expirationText}.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/reset-password.ts
+++ b/src/libs/better-auth/email-templates/reset-password.ts
@@ -1,3 +1,5 @@
+import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
+
 /**
  * Password reset email template
  * Sent to users when they request a password reset
@@ -77,6 +79,9 @@ export const getResetPasswordEmailTemplate = (params: { url: string }) => {
 
     <!-- Footer -->
     <div style="text-align: center; margin-top: 32px;">
+      <p style="font-size: 13px; margin: 0 0 8px 0;">
+        ${getEmailSupportHtml()}
+      </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
         © ${new Date().getFullYear()} LobeHub. All rights reserved.
       </p>
@@ -86,6 +91,6 @@ export const getResetPasswordEmailTemplate = (params: { url: string }) => {
 </html>
     `,
     subject: 'Reset Your Password - LobeHub',
-    text: `Reset your password by clicking this link: ${url}`,
+    text: `Reset your password by clicking this link: ${url}\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/verification-otp.ts
+++ b/src/libs/better-auth/email-templates/verification-otp.ts
@@ -1,3 +1,5 @@
+import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
+
 /**
  * Email OTP verification template for mobile
  * Sent to users when they need to verify their email using OTP code
@@ -92,6 +94,9 @@ export const getVerificationOTPEmailTemplate = (params: {
 
     <!-- Footer -->
     <div style="text-align: center; margin-top: 32px;">
+      <p style="font-size: 13px; margin: 0 0 8px 0;">
+        ${getEmailSupportHtml()}
+      </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
         © 2026 LobeHub. All rights reserved.
       </p>
@@ -101,6 +106,6 @@ export const getVerificationOTPEmailTemplate = (params: {
 </html>
     `,
     subject: 'Verify Your Email - LobeHub',
-    text: `Your verification code is: ${otp}\n\nThis code will expire in ${expirationText}.\n\nIf you didn't request this code, you can safely ignore this email.`,
+    text: `Your verification code is: ${otp}\n\nThis code will expire in ${expirationText}.\n\nIf you didn't request this code, you can safely ignore this email.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/verification.ts
+++ b/src/libs/better-auth/email-templates/verification.ts
@@ -1,3 +1,5 @@
+import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
+
 /**
  * Email verification template
  * Sent to users when they sign up to verify their email address
@@ -94,6 +96,9 @@ export const getVerificationEmailTemplate = (params: {
 
     <!-- Footer -->
     <div style="text-align: center; margin-top: 32px;">
+      <p style="font-size: 13px; margin: 0 0 8px 0;">
+        ${getEmailSupportHtml()}
+      </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
         © 2026 LobeHub. All rights reserved.
       </p>
@@ -103,6 +108,6 @@ export const getVerificationEmailTemplate = (params: {
 </html>
     `,
     subject: 'Verify Your Email - LobeHub',
-    text: `Please verify your email by clicking this link: ${url}\n\nThis link will expire in ${expirationText}.`,
+    text: `Please verify your email by clicking this link: ${url}\n\nThis link will expire in ${expirationText}.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/workspace-invite.ts
+++ b/src/libs/better-auth/email-templates/workspace-invite.ts
@@ -1,3 +1,5 @@
+import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
+
 /**
  * Workspace invitation email template
  * Sent when a workspace owner invites someone (by email) to join their workspace.
@@ -94,6 +96,9 @@ export const getWorkspaceInviteEmailTemplate = (params: {
 
     <!-- Footer -->
     <div style="text-align: center; margin-top: 32px;">
+      <p style="font-size: 13px; margin: 0 0 8px 0;">
+        ${getEmailSupportHtml()}
+      </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
         If you weren't expecting this invitation, you can safely ignore this email.
       </p>
@@ -103,6 +108,6 @@ export const getWorkspaceInviteEmailTemplate = (params: {
 </html>
     `,
     subject,
-    text: `${inviterByline} has invited you to join the "${workspaceName}" workspace on LobeHub as ${roleLabel}.\n\nAccept the invitation: ${url}\n\nThis invitation will expire in ${expiresInDays} day${expiresInDays > 1 ? 's' : ''}.\n\nIf you weren't expecting this invitation, you can safely ignore this email.`,
+    text: `${inviterByline} has invited you to join the "${workspaceName}" workspace on LobeHub as ${roleLabel}.\n\nAccept the invitation: ${url}\n\nThis invitation will expire in ${expiresInDays} day${expiresInDays > 1 ? 's' : ''}.\n\nIf you weren't expecting this invitation, you can safely ignore this email.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/workspace-member-removed.ts
+++ b/src/libs/better-auth/email-templates/workspace-member-removed.ts
@@ -1,3 +1,5 @@
+import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
+
 export const getWorkspaceMemberRemovedEmailTemplate = (params: {
   reason: 'downgrade' | 'removed_by_owner';
   workspaceName: string;
@@ -75,6 +77,9 @@ export const getWorkspaceMemberRemovedEmailTemplate = (params: {
 
     <!-- Footer -->
     <div style="text-align: center; margin-top: 32px;">
+      <p style="font-size: 13px; margin: 0 0 8px 0;">
+        ${getEmailSupportHtml()}
+      </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
         This is an automated message from LobeHub.
       </p>
@@ -85,7 +90,7 @@ export const getWorkspaceMemberRemovedEmailTemplate = (params: {
     `,
     subject,
     text: isDowngrade
-      ? `The workspace "${workspaceName}" has been downgraded, and all team members have been removed as a result. Your personal data and workspaces are not affected. If you believe this was a mistake, please contact the workspace owner.`
-      : `The owner of "${workspaceName}" has removed you from the workspace. Your personal data and workspaces are not affected. If you believe this was a mistake, please contact the workspace owner.`,
+      ? `The workspace "${workspaceName}" has been downgraded, and all team members have been removed as a result. Your personal data and workspaces are not affected. If you believe this was a mistake, please contact the workspace owner.\n\n${getEmailSupportText()}`
+      : `The owner of "${workspaceName}" has removed you from the workspace. Your personal data and workspaces are not affected. If you believe this was a mistake, please contact the workspace owner.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/email/support.test.ts
+++ b/src/libs/email/support.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { EMAIL_SUPPORT_REPLY_TO, getEmailSupportHtml, getEmailSupportText } from './support';
+
+describe('email support helpers', () => {
+  it('renders actionable support links for HTML and plain-text emails', () => {
+    const html = getEmailSupportHtml();
+    const text = getEmailSupportText();
+
+    expect(EMAIL_SUPPORT_REPLY_TO).toBe('support@lobehub.com');
+    expect(html).toContain('href="mailto:support@lobehub.com"');
+    expect(html).toContain('https://discord.gg/');
+    expect(text).toContain('support@lobehub.com');
+    expect(text).toContain('https://discord.gg/');
+  });
+
+  it('escapes localized labels before rendering HTML', () => {
+    const html = getEmailSupportHtml({
+      contactSupport: '<script>alert("support")</script>',
+      joinDiscord: '<strong>Discord</strong>',
+    });
+
+    expect(html).not.toContain('<script>');
+    expect(html).not.toContain('<strong>');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('&lt;strong&gt;');
+  });
+});

--- a/src/libs/email/support.test.ts
+++ b/src/libs/email/support.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { EMAIL_SUPPORT_REPLY_TO, getEmailSupportHtml, getEmailSupportText } from './support';
+import { EMAIL_SUPPORT_ADDRESS, getEmailSupportHtml, getEmailSupportText } from './support';
 
 describe('email support helpers', () => {
   it('renders actionable support links for HTML and plain-text emails', () => {
     const html = getEmailSupportHtml();
     const text = getEmailSupportText();
 
-    expect(EMAIL_SUPPORT_REPLY_TO).toBe('support@lobehub.com');
+    expect(EMAIL_SUPPORT_ADDRESS).toBe('support@lobehub.com');
     expect(html).toContain('href="mailto:support@lobehub.com"');
     expect(html).toContain('https://discord.gg/');
     expect(text).toContain('support@lobehub.com');

--- a/src/libs/email/support.ts
+++ b/src/libs/email/support.ts
@@ -18,13 +18,14 @@ const escapeHtml = (value: string) =>
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&#39;');
 
-export const EMAIL_SUPPORT_REPLY_TO = BRANDING_EMAIL.support;
+export const EMAIL_SUPPORT_ADDRESS = BRANDING_EMAIL.support;
+export const EMAIL_SUPPORT_REPLY_TO = BRANDING_EMAIL.replyTo;
 
 export const getEmailSupportHtml = ({
   contactSupport = DEFAULT_SUPPORT_COPY.contactSupport,
   joinDiscord = DEFAULT_SUPPORT_COPY.joinDiscord,
 }: EmailSupportCopy = {}) => {
-  const supportEmail = escapeHtml(EMAIL_SUPPORT_REPLY_TO);
+  const supportEmail = escapeHtml(EMAIL_SUPPORT_ADDRESS);
   const discordUrl = escapeHtml(SOCIAL_URL.discord);
 
   return `<a href="mailto:${supportEmail}" style="color: #6b7280; text-decoration: underline;">${escapeHtml(contactSupport)}</a><span style="color: #a1a1aa;"> · </span><a href="${discordUrl}" target="_blank" rel="noopener noreferrer" style="color: #6b7280; text-decoration: underline;">${escapeHtml(joinDiscord)}</a>`;
@@ -34,4 +35,4 @@ export const getEmailSupportText = ({
   contactSupport = DEFAULT_SUPPORT_COPY.contactSupport,
   joinDiscord = DEFAULT_SUPPORT_COPY.joinDiscord,
 }: EmailSupportCopy = {}) =>
-  `${contactSupport}: ${EMAIL_SUPPORT_REPLY_TO} | ${joinDiscord}: ${SOCIAL_URL.discord}`;
+  `${contactSupport}: ${EMAIL_SUPPORT_ADDRESS} | ${joinDiscord}: ${SOCIAL_URL.discord}`;

--- a/src/libs/email/support.ts
+++ b/src/libs/email/support.ts
@@ -1,0 +1,37 @@
+import { BRANDING_EMAIL, SOCIAL_URL } from '@lobechat/business-const';
+
+interface EmailSupportCopy {
+  contactSupport?: string;
+  joinDiscord?: string;
+}
+
+const DEFAULT_SUPPORT_COPY = {
+  contactSupport: 'Contact support',
+  joinDiscord: 'Join Discord',
+} satisfies Required<EmailSupportCopy>;
+
+const escapeHtml = (value: string) =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+
+export const EMAIL_SUPPORT_REPLY_TO = BRANDING_EMAIL.support;
+
+export const getEmailSupportHtml = ({
+  contactSupport = DEFAULT_SUPPORT_COPY.contactSupport,
+  joinDiscord = DEFAULT_SUPPORT_COPY.joinDiscord,
+}: EmailSupportCopy = {}) => {
+  const supportEmail = escapeHtml(EMAIL_SUPPORT_REPLY_TO);
+  const discordUrl = escapeHtml(SOCIAL_URL.discord);
+
+  return `<a href="mailto:${supportEmail}" style="color: #6b7280; text-decoration: underline;">${escapeHtml(contactSupport)}</a><span style="color: #a1a1aa;"> · </span><a href="${discordUrl}" target="_blank" rel="noopener noreferrer" style="color: #6b7280; text-decoration: underline;">${escapeHtml(joinDiscord)}</a>`;
+};
+
+export const getEmailSupportText = ({
+  contactSupport = DEFAULT_SUPPORT_COPY.contactSupport,
+  joinDiscord = DEFAULT_SUPPORT_COPY.joinDiscord,
+}: EmailSupportCopy = {}) =>
+  `${contactSupport}: ${EMAIL_SUPPORT_REPLY_TO} | ${joinDiscord}: ${SOCIAL_URL.discord}`;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] 💄 style
- [x] ♻️ refactor
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore
- [ ] 👷 ci

#### 🔗 Related Issue

N/A — no matching GitHub issue was found.

#### 🔀 Description of Change

- Add a shared support contact renderer backed by the business branding contract.
- Add support email and Discord links to authentication and workspace email HTML and plain-text bodies.
- Let `EmailService` apply an optional deployment-specific Reply-To while preserving explicit caller overrides.
- Add localized notification footer labels and regression coverage for every affected template.

#### 🧭 Key Decisions / Non-goals

- Keep the shared capability generic and public; cloud-specific notification composition remains in the cloud repository.
- Keep Reply-To opt-in at the deployment branding layer. The OSS default remains unset so self-hosted replies are not routed to LobeHub.
- Reuse business branding constants instead of hard-coding contact addresses.
- This does not redesign the email visual system or localize all authentication email content.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check --lint --test --type` — 8 files checked, lint clean, 17 tests passed, types clean.

#### 📸 Screenshots / Videos

N/A — footer markup, plain-text content, and Reply-To behavior are covered by tests.

#### 📝 Additional Information

No migration or runtime configuration changes are required.
