### PR TITLE
🐛 fix(auth): preserve OIDC native form submissions

### DIFF
--- a/src/features/Auth/OAuthConsent/Consent/index.tsx
+++ b/src/features/Auth/OAuthConsent/Consent/index.tsx
@@ -5,6 +5,7 @@ import { Button } from '@lobehub/ui/base-ui';
 import React, { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { submitNativeFormWithLoading } from '@/features/Auth/utils/submitNativeForm';
 import AuthCard from '@/features/AuthCard';
 import type { OidcClientMetadata } from '@/types/oidc';
 
@@ -60,9 +61,7 @@ const ConsentClient = memo<ClientProps>(({ uid, clientId, scopes, clientMetadata
                 size={'large'}
                 type="primary"
                 value="accept"
-                onClick={() => {
-                  setIsLoading(true);
-                }}
+                onClick={(event) => submitNativeFormWithLoading(event, setIsLoading)}
               >
                 {t('consent.buttons.accept')}
               </Button>

--- a/src/features/Auth/OAuthConsent/Login.tsx
+++ b/src/features/Auth/OAuthConsent/Login.tsx
@@ -5,6 +5,7 @@ import { Button } from '@lobehub/ui/base-ui';
 import React, { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { submitNativeFormWithLoading } from '@/features/Auth/utils/submitNativeForm';
 import AuthCard from '@/features/AuthCard';
 import { useSession } from '@/libs/better-auth/auth-client';
 import type { OidcClientMetadata } from '@/types/oidc';
@@ -43,12 +44,7 @@ const LoginConfirmClient = memo<LoginConfirmProps>(({ uid, clientMetadata }) => 
         subtitle={descriptionText}
         title={titleText}
         footer={
-          <form
-            action="/oidc/consent"
-            method="post"
-            style={{ width: '100%' }}
-            onSubmit={() => setIsLoading(true)}
-          >
+          <form action="/oidc/consent" method="post" style={{ width: '100%' }}>
             {/* Adjust action URL */}
             <input name="uid" type="hidden" value={uid} />
             <input name="choice" type="hidden" value={'accept'} />
@@ -62,6 +58,7 @@ const LoginConfirmClient = memo<LoginConfirmProps>(({ uid, clientMetadata }) => 
               size="large"
               type="primary"
               value="accept"
+              onClick={(event) => submitNativeFormWithLoading(event, setIsLoading)}
             >
               {buttonText}
             </Button>

--- a/src/features/Auth/OAuthDevice/DeviceCodeConfirm.tsx
+++ b/src/features/Auth/OAuthDevice/DeviceCodeConfirm.tsx
@@ -5,6 +5,7 @@ import { Button } from '@lobehub/ui/base-ui';
 import React, { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { submitNativeFormWithLoading } from '@/features/Auth/utils/submitNativeForm';
 import AuthCard from '@/features/AuthCard';
 
 interface DeviceCodeConfirmProps {
@@ -33,7 +34,7 @@ const DeviceCodeConfirm = memo<DeviceCodeConfirmProps>(({ xsrf, userCode, client
               loading={isLoading}
               size="large"
               type="primary"
-              onClick={() => setIsLoading(true)}
+              onClick={(event) => submitNativeFormWithLoading(event, setIsLoading)}
             >
               {t('device.confirm.authorize')}
             </Button>

--- a/src/features/Auth/utils/submitNativeForm.test.ts
+++ b/src/features/Auth/utils/submitNativeForm.test.ts
@@ -1,0 +1,51 @@
+import type { MouseEvent as ReactMouseEvent } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { submitNativeFormWithLoading } from './submitNativeForm';
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('submitNativeFormWithLoading', () => {
+  it('submits with the active submitter before loading disables it', () => {
+    const form = document.createElement('form');
+    const button = document.createElement('button');
+    button.name = 'consent';
+    button.type = 'submit';
+    button.value = 'accept';
+    form.append(button);
+    document.body.append(form);
+
+    const eventOrder: string[] = [];
+    let disabledAtSubmit: boolean | undefined;
+    let submittedConsent: FormDataEntryValue | null = null;
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      eventOrder.push('submit');
+
+      const submitter = (event as SubmitEvent).submitter as HTMLButtonElement;
+      disabledAtSubmit = submitter.disabled;
+      submittedConsent = new FormData(form, submitter).get('consent');
+    });
+
+    const preventDefault = vi.fn();
+    const setLoading = vi.fn(() => {
+      eventOrder.push('loading');
+      button.disabled = true;
+    });
+
+    submitNativeFormWithLoading(
+      { currentTarget: button, preventDefault } as unknown as ReactMouseEvent<HTMLButtonElement>,
+      setLoading,
+    );
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(eventOrder).toEqual(['submit', 'loading']);
+    expect(disabledAtSubmit).toBe(false);
+    expect(submittedConsent).toBe('accept');
+    expect(setLoading).toHaveBeenCalledWith(true);
+    expect(button.disabled).toBe(true);
+  });
+});

--- a/src/features/Auth/utils/submitNativeForm.ts
+++ b/src/features/Auth/utils/submitNativeForm.ts
@@ -1,0 +1,22 @@
+import type { MouseEvent } from 'react';
+
+/**
+ * Start the native submission before loading disables the submit button.
+ * This also preserves the submitter's name/value in the form payload.
+ */
+export const submitNativeFormWithLoading = (
+  event: MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
+  setLoading: (loading: boolean) => void,
+) => {
+  const submitter = event.currentTarget;
+
+  if (!(submitter instanceof HTMLButtonElement)) return;
+
+  const form = submitter.form;
+
+  if (!form) return;
+
+  event.preventDefault();
+  form.requestSubmit(submitter);
+  setLoading(true);
+};


### PR DESCRIPTION
## Summary

- submit native OIDC forms with the active submitter before base-ui loading disables the button
- apply the fix to device authorization, consent approval, and login confirmation
- add a behavior regression test covering submission order and submitter payload preservation

## Root cause

The base-ui Button maps `loading` to the native `disabled` state. The migrated OIDC handlers enabled loading before the browser completed its default form action, which either canceled the request entirely or removed the submitter's `name` and `value` from the POST body.

## User impact

Device authorization and OIDC consent actions now submit reliably while retaining loading feedback and preventing duplicate interaction.

## Verification

- `bun run check src/features/Auth/OAuthDevice/DeviceCodeConfirm.tsx src/features/Auth/OAuthConsent/Consent/index.tsx src/features/Auth/OAuthConsent/Login.tsx src/features/Auth/utils/submitNativeForm.ts src/features/Auth/utils/submitNativeForm.test.ts` — lint clean, 1 test passed
- Chromium POST verification preserved `uid=u1&consent=accept`
- `git diff --check origin/canary...HEAD`
- Full repository type-check remains blocked by unrelated baseline resolution errors for `@lobechat/artifact-template` and `pinyin-pro`; no type errors remain in the changed files
