### PR TITLE
✨ feat(home): restore model shortcuts with click analytics

### DIFF
--- a/src/routes/(main)/home/features/InputArea/StarterList.tsx
+++ b/src/routes/(main)/home/features/InputArea/StarterList.tsx
@@ -12,8 +12,8 @@ import {
 } from '@/business/client/hooks/useBusinessAgentMode';
 import type { HomeNewModelItem } from '@/business/client/hooks/useHomeNewModels';
 import { useHomeNewModels } from '@/business/client/hooks/useHomeNewModels';
+import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { usePermission } from '@/hooks/usePermission';
-import { useStableNavigate } from '@/hooks/useStableNavigate';
 import { agentService } from '@/services/agent';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
@@ -50,7 +50,7 @@ const skeletonWidths = [112, 150, 126, 138];
 
 const StarterList = memo(() => {
   const { t } = useTranslation('home');
-  const navigate = useStableNavigate();
+  const navigate = useWorkspaceAwareNavigate();
   const { message } = App.useApp();
   const { agentId: activeAgentId } = useResolvedHomeAgentId();
   const { allowed: canCreateContent, reason } = usePermission('create_content');
@@ -113,8 +113,12 @@ const StarterList = memo(() => {
             return;
           }
 
-          await updateAgentConfigById(activeAgentId, nextConfig);
-          message.success(t('starter.modelSwitched', { name: item.title }));
+          try {
+            await updateAgentConfigById(activeAgentId, nextConfig, { rethrow: true });
+            message.success(t('starter.modelSwitched', { name: item.title }));
+          } catch {
+            // The agent store already reports persistence failures to the user.
+          }
         } finally {
           setSwitchingKey(null);
         }

--- a/src/routes/(main)/home/features/InputArea/StarterList.tsx
+++ b/src/routes/(main)/home/features/InputArea/StarterList.tsx
@@ -1,0 +1,185 @@
+import { ModelIcon } from '@lobehub/icons';
+import { Center, Skeleton, Tag, Tooltip } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
+import { App } from 'antd';
+import { createStaticStyles, cx } from 'antd-style';
+import { memo, useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import {
+  type BusinessModelModeConfig,
+  useBusinessModelModeConfig,
+} from '@/business/client/hooks/useBusinessAgentMode';
+import type { HomeNewModelItem } from '@/business/client/hooks/useHomeNewModels';
+import { useHomeNewModels } from '@/business/client/hooks/useHomeNewModels';
+import { usePermission } from '@/hooks/usePermission';
+import { useStableNavigate } from '@/hooks/useStableNavigate';
+import { agentService } from '@/services/agent';
+import { useAgentStore } from '@/store/agent';
+import { agentByIdSelectors } from '@/store/agent/selectors';
+
+import { useResolvedHomeAgentId } from '../AgentSelect/useResolvedHomeAgentId';
+import { trackHomeModelShortcutClicked } from './starterListAnalytics';
+import { useStarterModelDefaults } from './useStarterModelDefaults';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  button: css`
+    height: 40px;
+    border-color: ${cssVar.colorFillSecondary};
+    background: transparent;
+    box-shadow: none !important;
+
+    &:hover {
+      border-color: ${cssVar.colorFillSecondary} !important;
+      background: ${cssVar.colorBgElevated} !important;
+    }
+  `,
+  container: css`
+    flex-wrap: wrap;
+  `,
+  newTag: css`
+    padding-inline: 10px !important;
+    border-radius: 999px !important;
+  `,
+}));
+
+const getStarterItemKey = (item: HomeNewModelItem) => `${item.type}:${item.model}`;
+const getStarterItemProvider = (item: HomeNewModelItem, fallbackProvider: string) =>
+  item.provider ?? fallbackProvider;
+const skeletonWidths = [112, 150, 126, 138];
+
+const StarterList = memo(() => {
+  const { t } = useTranslation('home');
+  const navigate = useStableNavigate();
+  const { message } = App.useApp();
+  const { agentId: activeAgentId } = useResolvedHomeAgentId();
+  const { allowed: canCreateContent, reason } = usePermission('create_content');
+  const updateAgentConfigById = useAgentStore((s) => s.updateAgentConfigById);
+  const [switchingKey, setSwitchingKey] = useState<string | null>(null);
+  const { defaultHomeNewModels, fallbackChatProvider } = useStarterModelDefaults();
+  const { isLoading, items } = useHomeNewModels(defaultHomeNewModels);
+  const applyBusinessModelModeConfig = useBusinessModelModeConfig();
+
+  const handleClick = useCallback(
+    async (item: HomeNewModelItem) => {
+      if (!canCreateContent) return;
+
+      const key = getStarterItemKey(item);
+      const selectedProvider =
+        item.type === 'chat' ? getStarterItemProvider(item, fallbackChatProvider) : item.provider;
+      void trackHomeModelShortcutClicked({ item, provider: selectedProvider });
+
+      if (item.type === 'video') {
+        navigate(`/video?model=${item.model}`);
+        return;
+      }
+
+      if (item.type === 'image') {
+        navigate(`/image?model=${item.model}`);
+        return;
+      }
+
+      if (item.type === 'chat') {
+        if (!activeAgentId || switchingKey) return;
+        setSwitchingKey(key);
+        const provider = getStarterItemProvider(item, fallbackChatProvider);
+        try {
+          // Hydrate the agent's config before mutating so the optimistic update
+          // doesn't drop pre-existing fields the home input never loaded.
+          let agentState = useAgentStore.getState();
+          if (!agentState.agentMap[activeAgentId]) {
+            const config = await agentService.getAgentConfigById(activeAgentId);
+            if (config) agentState.internal_dispatchAgentMap(activeAgentId, config);
+            agentState = useAgentStore.getState();
+          }
+
+          const currentModel = agentByIdSelectors.getAgentModelById(activeAgentId)(agentState);
+          const currentProvider =
+            agentByIdSelectors.getAgentModelProviderById(activeAgentId)(agentState);
+          const nextConfig: BusinessModelModeConfig = applyBusinessModelModeConfig({
+            model: item.model,
+            provider,
+          });
+          const shouldUpdateAgentMode =
+            nextConfig.chatConfig?.enableAgentMode === false &&
+            agentByIdSelectors.getAgentEnableModeById(activeAgentId)(agentState);
+
+          if (
+            currentModel === item.model &&
+            currentProvider === provider &&
+            !shouldUpdateAgentMode
+          ) {
+            message.info(t('starter.modelInUse', { name: item.title }));
+            return;
+          }
+
+          await updateAgentConfigById(activeAgentId, nextConfig);
+          message.success(t('starter.modelSwitched', { name: item.title }));
+        } finally {
+          setSwitchingKey(null);
+        }
+        return;
+      }
+    },
+    [
+      canCreateContent,
+      navigate,
+      activeAgentId,
+      applyBusinessModelModeConfig,
+      updateAgentConfigById,
+      switchingKey,
+      fallbackChatProvider,
+      message,
+      t,
+    ],
+  );
+
+  return (
+    <Center horizontal className={styles.container} gap={8}>
+      <Tag className={styles.newTag} size={'small'}>
+        {t('starter.newLabel')}
+      </Tag>
+      {isLoading
+        ? defaultHomeNewModels.map((item, index) => (
+            <Skeleton.Button
+              active
+              key={getStarterItemKey(item)}
+              style={{
+                borderRadius: 999,
+                height: 40,
+                width: skeletonWidths[index] ?? 126,
+              }}
+            />
+          ))
+        : items.map((item) => {
+            const key = getStarterItemKey(item);
+            const isSwitching = switchingKey === key;
+            const button = (
+              <Button
+                className={cx(styles.button)}
+                disabled={!canCreateContent || (!!switchingKey && !isSwitching)}
+                icon={<ModelIcon model={item.iconModel ?? item.model} size={18} />}
+                key={key}
+                loading={isSwitching}
+                shape={'round'}
+                onClick={() => handleClick(item)}
+              >
+                {item.title}
+              </Button>
+            );
+
+            if (!canCreateContent) {
+              return (
+                <Tooltip key={key} title={reason}>
+                  <div>{button}</div>
+                </Tooltip>
+              );
+            }
+
+            return button;
+          })}
+    </Center>
+  );
+});
+
+export default StarterList;

--- a/src/routes/(main)/home/features/InputArea/index.tsx
+++ b/src/routes/(main)/home/features/InputArea/index.tsx
@@ -15,6 +15,7 @@ import { systemStatusSelectors } from '@/store/global/selectors';
 import { stripMarkdownLinks } from './hintFormat';
 import InputDragUpload from './InputDragUpload';
 import MessengerBanner, { MESSENGER_BANNER_ID } from './MessengerBanner';
+import StarterList from './StarterList';
 import { useSend } from './useSend';
 
 const leftActions: ActionKeys[] = ['agentMode', 'plus'];
@@ -117,8 +118,7 @@ const InputArea = () => {
         </InputDragUpload>
       </Flexbox>
 
-      {/* TODO: Remove the deprecated StarterList implementation after the home model shortcuts
-          have been retired permanently. */}
+      <StarterList />
     </Flexbox>
   );
 };

--- a/src/routes/(main)/home/features/InputArea/starterListAnalytics.test.ts
+++ b/src/routes/(main)/home/features/InputArea/starterListAnalytics.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  HOME_MODEL_SHORTCUT_CLICKED_EVENT,
+  trackHomeModelShortcutClicked,
+} from './starterListAnalytics';
+
+const trackProductUsageEvent = vi.hoisted(() => vi.fn());
+
+vi.mock('@/libs/analytics/productUsageEvent', () => ({
+  trackProductUsageEvent,
+}));
+
+describe('starter list analytics', () => {
+  beforeEach(() => {
+    trackProductUsageEvent.mockReset();
+  });
+
+  it('tracks a chat shortcut with its effective provider', async () => {
+    trackProductUsageEvent.mockResolvedValue(true);
+
+    const tracked = await trackHomeModelShortcutClicked({
+      item: {
+        model: 'glm-5.2',
+        title: 'GLM-5.2',
+        type: 'chat',
+      },
+      provider: 'zhipu',
+    });
+
+    expect(tracked).toBe(true);
+    expect(trackProductUsageEvent).toHaveBeenCalledWith(
+      {
+        name: HOME_MODEL_SHORTCUT_CLICKED_EVENT,
+        properties: {
+          model: 'glm-5.2',
+          model_type: 'chat',
+          provider: 'zhipu',
+          spm: 'homepage.model_shortcut.clicked',
+        },
+      },
+      { analytics: undefined },
+    );
+  });
+
+  it('tracks image shortcuts without an unavailable provider', async () => {
+    trackProductUsageEvent.mockResolvedValue(true);
+
+    await trackHomeModelShortcutClicked({
+      item: {
+        model: 'gpt-image-2',
+        title: 'GPT Image 2',
+        type: 'image',
+      },
+    });
+
+    expect(trackProductUsageEvent).toHaveBeenCalledWith(
+      {
+        name: HOME_MODEL_SHORTCUT_CLICKED_EVENT,
+        properties: {
+          model: 'gpt-image-2',
+          model_type: 'image',
+          spm: 'homepage.model_shortcut.clicked',
+        },
+      },
+      { analytics: undefined },
+    );
+  });
+});

--- a/src/routes/(main)/home/features/InputArea/starterListAnalytics.ts
+++ b/src/routes/(main)/home/features/InputArea/starterListAnalytics.ts
@@ -1,0 +1,30 @@
+import type { AnalyticsManager } from '@lobehub/analytics';
+
+import type { HomeNewModelItem } from '@/business/client/hooks/useHomeNewModels';
+import { trackProductUsageEvent } from '@/libs/analytics/productUsageEvent';
+
+export const HOME_MODEL_SHORTCUT_CLICKED_EVENT = 'home_model_shortcut_clicked';
+
+interface TrackHomeModelShortcutClickedParams {
+  analytics?: AnalyticsManager | null;
+  item: HomeNewModelItem;
+  provider?: string;
+}
+
+export const trackHomeModelShortcutClicked = ({
+  analytics,
+  item,
+  provider,
+}: TrackHomeModelShortcutClickedParams) =>
+  trackProductUsageEvent(
+    {
+      name: HOME_MODEL_SHORTCUT_CLICKED_EVENT,
+      properties: {
+        ...(provider && { provider }),
+        model: item.model,
+        model_type: item.type,
+        spm: 'homepage.model_shortcut.clicked',
+      },
+    },
+    { analytics },
+  );


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Restore the model shortcut list below the home chat input.
- Preserve chat-model switching and image/video generation navigation.
- Track `home_model_shortcut_clicked` with the selected model, model type, effective provider when available, and SPM context.
- Respect the user's anonymous usage telemetry preference and keep tracking non-blocking.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check "src/routes/(main)/home/features/InputArea/index.tsx" "src/routes/(main)/home/features/InputArea/StarterList.tsx" "src/routes/(main)/home/features/InputArea/starterListAnalytics.ts" "src/routes/(main)/home/features/InputArea/starterListAnalytics.test.ts" "src/routes/(main)/home/features/InputArea/useStarterModelDefaults.test.ts" --lint --test`

#### 📸 Screenshots / Videos

N/A — restores the previous model shortcut UI.

#### 📝 Additional Information

The click event is emitted before navigation or model configuration updates, so it does not affect the interaction flow.
