### PR TITLE
💄 style: refine notification center

### DIFF
--- a/locales/ar/notification.json
+++ b/locales/ar/notification.json
@@ -19,6 +19,7 @@
   "email.viewDetails": "عرض التفاصيل",
   "image_generation_completed": "الصورة الخاصة بك \"{{prompt}}\" جاهزة.",
   "image_generation_completed_title": "اكتملت عملية إنشاء الصورة",
+  "inbox.archive": "أرشيف",
   "inbox.archiveAll": "أرشفة الكل",
   "inbox.empty": "لا توجد إشعارات بعد",
   "inbox.emptyUnread": "لا توجد إشعارات غير مقروءة",

--- a/locales/bg-BG/notification.json
+++ b/locales/bg-BG/notification.json
@@ -19,6 +19,7 @@
   "email.viewDetails": "Преглед на подробности",
   "image_generation_completed": "Вашето изображение \"{{prompt}}\" е готово.",
   "image_generation_completed_title": "Генерирането на изображението завърши",
+  "inbox.archive": "Архивиране",
   "inbox.archiveAll": "Архивирай всички",
   "inbox.empty": "Все още няма известия",
   "inbox.emptyUnread": "Няма непрочетени известия",

--- a/locales/de-DE/notification.json
+++ b/locales/de-DE/notification.json
@@ -19,6 +19,7 @@
   "email.viewDetails": "Details anzeigen",
   "image_generation_completed": "Ihr Bild „{{prompt}}“ ist fertig.",
   "image_generation_completed_title": "Bilderstellung abgeschlossen",
+  "inbox.archive": "Archivieren",
   "inbox.archiveAll": "Alle archivieren",
   "inbox.empty": "Noch keine Benachrichtigungen",
   "inbox.emptyUnread": "Keine ungelesenen Benachrichtigungen",

--- a/locales/en-US/notification.json
+++ b/locales/en-US/notification.json
@@ -21,6 +21,7 @@
   "email.viewDetails": "View Details",
   "image_generation_completed": "Your image \"{{prompt}}\" is ready.",
   "image_generation_completed_title": "Image generation completed",
+  "inbox.archive": "Archive",
   "inbox.archiveAll": "Archive all",
   "inbox.empty": "No notifications yet",
   "inbox.emptyUnread": "No unread notifications",

--- a/locales/es-ES/notification.json
+++ b/locales/es-ES/notification.json
@@ -19,6 +19,7 @@
   "email.viewDetails": "Ver detalles",
   "image_generation_completed": "Tu imagen \"{{prompt}}\" está lista.",
   "image_generation_completed_title": "Generación de imagen completada",
+  "inbox.archive": "Archivar",
   "inbox.archiveAll": "Archivar todo",
   "inbox.empty": "Aún no hay notificaciones",
   "inbox.emptyUnread": "No hay notificaciones sin leer",

--- a/locales/fa-IR/notification.json
+++ b/locales/fa-IR/notification.json
@@ -19,6 +19,7 @@
   "email.viewDetails": "مشاهده جزئیات",
   "image_generation_completed": "تصویر شما با موضوع «{{prompt}}» آماده است.",
   "image_generation_completed_title": "تولید تصویر تکمیل شد",
+  "inbox.archive": "بایگانی",
   "inbox.archiveAll": "بایگانی همه",
   "inbox.empty": "هنوز هیچ اعلانی وجود ندارد",
   "inbox.emptyUnread": "هیچ اعلان خوانده‌نشده‌ای وجود ندارد",

--- a/locales/fr-FR/notification.json
+++ b/locales/fr-FR/notification.json
@@ -19,6 +19,7 @@
   "email.viewDetails": "Voir les détails",
   "image_generation_completed": "Votre image « {{prompt}} » est prête.",
   "image_generation_completed_title": "Génération d’image terminée",
+  "inbox.archive": "Archiver",
   "inbox.archiveAll": "Archiver tout",
   "inbox.empty": "Aucune notification pour le moment",
   "inbox.emptyUnread": "Aucune notification non lue",

--- a/locales/it-IT/notification.json
+++ b/locales/it-IT/notification.json
@@ -19,6 +19,7 @@
   "email.viewDetails": "Visualizza dettagli",
   "image_generation_completed": "La tua immagine \"{{prompt}}\" è pronta.",
   "image_generation_completed_title": "Generazione immagine completata",
+  "inbox.archive": "Archivia",
   "inbox.archiveAll": "Archivia tutto",
   "inbox.empty": "Nessuna notifica al momento",
   "inbox.emptyUnread": "Nessuna notifica non letta",

--- a/locales/ja-JP/notification.json
+++ b/locales/ja-JP/notification.json
@@ -19,6 +19,7 @@
   "email.viewDetails": "詳細を見る",
   "image_generation_completed": "画像「{{prompt}}」の生成が完了しました。",
   "image_generation_completed_title": "画像生成が完了しました",
+  "inbox.archive": "アーカイブ",
   "inbox.archiveAll": "すべてをアーカイブ",
   "inbox.empty": "通知はまだありません",
   "inbox.emptyUnread": "未読の通知はありません",

--- a/locales/ko-KR/notification.json
+++ b/locales/ko-KR/notification.json
@@ -19,6 +19,7 @@
   "email.viewDetails": "자세히 보기",
   "image_generation_completed": "이미지 \"{{prompt}}\"이(가) 준비되었습니다.",
   "image_generation_completed_title": "이미지 생성 완료",
+  "inbox.archive": "보관",
   "inbox.archiveAll": "모두 보관",
   "inbox.empty": "알림이 아직 없습니다",
   "inbox.emptyUnread": "읽지 않은 알림이 없습니다",

--- a/locales/nl-NL/notification.json
+++ b/locales/nl-NL/notification.json
@@ -19,6 +19,7 @@
   "email.viewDetails": "Bekijk details",
   "image_generation_completed": "Uw afbeelding \"{{prompt}}\" is klaar.",
   "image_generation_completed_title": "Afbeeldingsgeneratie voltooid",
+  "inbox.archive": "Archiveren",
   "inbox.archiveAll": "Alles archiveren",
   "inbox.empty": "Nog geen meldingen",
   "inbox.emptyUnread": "Geen ongelezen meldingen",

--- a/locales/pl-PL/notification.json
+++ b/locales/pl-PL/notification.json
@@ -19,6 +19,7 @@
   "email.viewDetails": "Zobacz szczegóły",
   "image_generation_completed": "Twój obraz \"{{prompt}}\" jest gotowy.",
   "image_generation_completed_title": "Generowanie obrazu zakończone",
+  "inbox.archive": "Archiwizuj",
   "inbox.archiveAll": "Zarchiwizuj wszystko",
   "inbox.empty": "Brak powiadomień",
   "inbox.emptyUnread": "Brak nieprzeczytanych powiadomień",

--- a/locales/pt-BR/notification.json
+++ b/locales/pt-BR/notification.json
@@ -19,6 +19,7 @@
   "email.viewDetails": "Ver detalhes",
   "image_generation_completed": "Sua imagem \"{{prompt}}\" está pronta.",
   "image_generation_completed_title": "Geração de imagem concluída",
+  "inbox.archive": "Arquivar",
   "inbox.archiveAll": "Arquivar tudo",
   "inbox.empty": "Nenhuma notificação ainda",
   "inbox.emptyUnread": "Nenhuma notificação não lida",

--- a/locales/ru-RU/notification.json
+++ b/locales/ru-RU/notification.json
@@ -19,6 +19,7 @@
   "email.viewDetails": "Просмотреть детали",
   "image_generation_completed": "Ваше изображение «{{prompt}}» готово.",
   "image_generation_completed_title": "Создание изображения завершено",
+  "inbox.archive": "Архивировать",
   "inbox.archiveAll": "Архивировать все",
   "inbox.empty": "Уведомлений пока нет",
   "inbox.emptyUnread": "Нет непрочитанных уведомлений",

--- a/locales/tr-TR/notification.json
+++ b/locales/tr-TR/notification.json
@@ -19,6 +19,7 @@
   "email.viewDetails": "Detayları Görüntüle",
   "image_generation_completed": "\"{{prompt}}\" adlı görseliniz hazır.",
   "image_generation_completed_title": "Görsel oluşturma tamamlandı",
+  "inbox.archive": "Arşivle",
   "inbox.archiveAll": "Tümünü arşivle",
   "inbox.empty": "Henüz bildirim yok",
   "inbox.emptyUnread": "Okunmamış bildirim yok",

--- a/locales/vi-VN/notification.json
+++ b/locales/vi-VN/notification.json
@@ -19,6 +19,7 @@
   "email.viewDetails": "Xem chi tiết",
   "image_generation_completed": "Hình ảnh \"{{prompt}}\" của bạn đã sẵn sàng.",
   "image_generation_completed_title": "Hoàn tất tạo hình ảnh",
+  "inbox.archive": "Lưu trữ",
   "inbox.archiveAll": "Lưu trữ tất cả",
   "inbox.empty": "Chưa có thông báo nào",
   "inbox.emptyUnread": "Không có thông báo chưa đọc",

--- a/locales/zh-CN/notification.json
+++ b/locales/zh-CN/notification.json
@@ -21,6 +21,7 @@
   "email.viewDetails": "查看详情",
   "image_generation_completed": "图片「{{prompt}}」已生成。",
   "image_generation_completed_title": "图片生成完成",
+  "inbox.archive": "归档",
   "inbox.archiveAll": "全部归档",
   "inbox.empty": "暂无通知",
   "inbox.emptyUnread": "没有未读通知",

--- a/locales/zh-TW/notification.json
+++ b/locales/zh-TW/notification.json
@@ -19,6 +19,7 @@
   "email.viewDetails": "查看詳情",
   "image_generation_completed": "您的圖片「{{prompt}}」已完成。",
   "image_generation_completed_title": "圖片生成完成",
+  "inbox.archive": "封存",
   "inbox.archiveAll": "全部歸檔",
   "inbox.empty": "尚無通知",
   "inbox.emptyUnread": "沒有未讀通知",

--- a/packages/locales/src/default/notification.ts
+++ b/packages/locales/src/default/notification.ts
@@ -25,6 +25,7 @@ export default {
   'email.viewDetails': 'View Details',
   'image_generation_completed': 'Your image "{{prompt}}" is ready.',
   'image_generation_completed_title': 'Image generation completed',
+  'inbox.archive': 'Archive',
   'inbox.archiveAll': 'Archive all',
   'inbox.empty': 'No notifications yet',
   'inbox.emptyUnread': 'No unread notifications',

--- a/src/routes/(main)/home/_layout/Header/components/InboxDrawer/NotificationItem.tsx
+++ b/src/routes/(main)/home/_layout/Header/components/InboxDrawer/NotificationItem.tsx
@@ -1,38 +1,28 @@
 'use client';
 
-import { ActionIcon, Block, Flexbox, Icon, Text } from '@lobehub/ui';
+import { Block, Flexbox, Icon, Text } from '@lobehub/ui';
+import { ContextMenuTrigger } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import dayjs from 'dayjs';
 import { ArchiveIcon, BellIcon, ImageIcon, MegaphoneIcon, VideoIcon } from 'lucide-react';
 import { memo, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 
 import { createNotificationDetailModal } from './NotificationDetailModal';
 
-const ACTION_CLASS_NAME = 'notification-item-actions';
-
 const styles = createStaticStyles(({ css }) => ({
   container: css`
     cursor: pointer;
     user-select: none;
-
-    .${ACTION_CLASS_NAME} {
-      opacity: 0;
-      transition: opacity 0.2s ${cssVar.motionEaseOut};
-    }
-
-    &:hover {
-      .${ACTION_CLASS_NAME} {
-        opacity: 1;
-      }
-    }
   `,
   unreadDot: css`
     flex-shrink: 0;
 
     width: 8px;
     height: 8px;
+    margin-block-start: 7px;
     border-radius: 50%;
 
     background: ${cssVar.colorPrimary};
@@ -71,6 +61,7 @@ const NotificationItem = memo<NotificationItemProps>(
     onMarkAsRead,
     onArchive,
   }) => {
+    const { t } = useTranslation('notification');
     const navigate = useWorkspaceAwareNavigate();
     const TypeIcon = TYPE_ICON_MAP[type] || BellIcon;
 
@@ -94,61 +85,48 @@ const NotificationItem = memo<NotificationItemProps>(
       });
     }, [id, isRead, actionUrl, onMarkAsRead, navigate, category, content, createdAt, title]);
 
-    const handleArchive = useCallback(
-      (e: React.MouseEvent) => {
-        e.stopPropagation();
-        onArchive(id);
-      },
-      [id, onArchive],
-    );
+    const handleArchive = useCallback(() => onArchive(id), [id, onArchive]);
 
     return (
-      <Block
-        clickable
-        className={styles.container}
-        gap={4}
-        paddingBlock={8}
-        paddingInline={12}
-        variant="borderless"
-        onClick={handleClick}
+      <ContextMenuTrigger
+        items={[
+          {
+            icon: ArchiveIcon,
+            key: 'archive',
+            label: t('inbox.archive'),
+            onClick: handleArchive,
+          },
+        ]}
       >
-        <Flexbox horizontal align="flex-start" gap={8}>
-          <Icon
-            color={cssVar.colorTextDescription}
-            icon={TypeIcon}
-            size={18}
-            style={{ flexShrink: 0, marginTop: 2 }}
-          />
-          <Flexbox flex={1} gap={4} style={{ overflow: 'hidden' }}>
-            <Flexbox horizontal align="center" gap={4} justify="space-between">
-              <Flexbox horizontal align="center" flex={1} gap={6} style={{ overflow: 'hidden' }}>
-                {!isRead && <span className={styles.unreadDot} />}
-                <Text
-                  ellipsis={{ tooltipWhenOverflow: true }}
-                  style={{ fontWeight: isRead ? 400 : 600 }}
-                >
-                  {title}
-                </Text>
-              </Flexbox>
-              <Flexbox horizontal align="center" gap={2} style={{ flexShrink: 0 }}>
-                <span className={ACTION_CLASS_NAME}>
-                  <ActionIcon
-                    icon={ArchiveIcon}
-                    size={{ blockSize: 24, size: 14 }}
-                    onClick={handleArchive}
-                  />
-                </span>
-                <Text fontSize={12} style={{ flexShrink: 0 }} type="secondary">
+        <Block
+          clickable
+          aria-label={title}
+          className={styles.container}
+          gap={4}
+          paddingBlock={8}
+          paddingInline={12}
+          variant="borderless"
+          onClick={handleClick}
+        >
+          <Flexbox horizontal align="flex-start" gap={8}>
+            <Icon
+              color={cssVar.colorTextDescription}
+              icon={TypeIcon}
+              size={18}
+              style={{ flexShrink: 0, marginTop: 2 }}
+            />
+            <Flexbox horizontal align="flex-start" flex={1} gap={6} style={{ overflow: 'hidden' }}>
+              {!isRead && <span className={styles.unreadDot} />}
+              <Flexbox flex={1} gap={4} style={{ overflow: 'hidden' }}>
+                <Text style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{content}</Text>
+                <Text fontSize={12} type="secondary">
                   {dayjs(createdAt).fromNow()}
                 </Text>
               </Flexbox>
             </Flexbox>
-            <Text ellipsis={{ rows: 3 }} fontSize={12} type="secondary">
-              {content}
-            </Text>
           </Flexbox>
-        </Flexbox>
-      </Block>
+        </Block>
+      </ContextMenuTrigger>
     );
   },
 );

--- a/src/routes/(main)/home/_layout/Header/components/InboxDrawer/index.tsx
+++ b/src/routes/(main)/home/_layout/Header/components/InboxDrawer/index.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { ActionIcon, Flexbox } from '@lobehub/ui';
-import { ArchiveIcon, CheckCheckIcon, ListFilterIcon } from 'lucide-react';
+import { ActionIcon, Flexbox, Text } from '@lobehub/ui';
+import { DropdownMenu } from '@lobehub/ui/base-ui';
+import { ArchiveIcon, CheckCheckIcon, ListFilterIcon, MoreHorizontalIcon } from 'lucide-react';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { DESKTOP_HEADER_ICON_SIZE } from '@/const/layoutTokens';
+import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
 import SideBarDrawer from '@/features/NavPanel/SideBarDrawer';
 import dynamic from '@/libs/next/dynamic';
@@ -69,29 +70,44 @@ const InboxDrawer = memo<InboxDrawerProps>(({ open, onClose }) => {
   return (
     <SideBarDrawer
       open={open}
-      title={t('inbox.title')}
       action={
-        <>
-          <ActionIcon
-            icon={ArchiveIcon}
-            size={DESKTOP_HEADER_ICON_SIZE}
-            title={t('inbox.archiveAll')}
-            onClick={handleArchiveAll}
-          />
-          <ActionIcon
-            icon={CheckCheckIcon}
-            size={DESKTOP_HEADER_ICON_SIZE}
-            title={t('inbox.markAllRead')}
-            onClick={handleMarkAllAsRead}
-          />
-          <ActionIcon
-            active={unreadOnly}
-            icon={ListFilterIcon}
-            size={DESKTOP_HEADER_ICON_SIZE}
-            title={t('inbox.filterUnread')}
-            onClick={handleToggleFilter}
-          />
-        </>
+        <ActionIcon
+          active={unreadOnly}
+          icon={ListFilterIcon}
+          size={DESKTOP_HEADER_ICON_SMALL_SIZE}
+          title={t('inbox.filterUnread')}
+          onClick={handleToggleFilter}
+        />
+      }
+      title={
+        <Flexbox horizontal align="center" gap={2} style={{ paddingInlineStart: 8 }}>
+          <Text ellipsis fontSize={14} style={{ fontWeight: 600 }} weight={400}>
+            {t('inbox.title')}
+          </Text>
+          <DropdownMenu
+            placement="bottomLeft"
+            items={[
+              {
+                icon: ArchiveIcon,
+                key: 'archive-all',
+                label: t('inbox.archiveAll'),
+                onClick: handleArchiveAll,
+              },
+              {
+                icon: CheckCheckIcon,
+                key: 'mark-all-read',
+                label: t('inbox.markAllRead'),
+                onClick: handleMarkAllAsRead,
+              },
+            ]}
+          >
+            <ActionIcon
+              icon={MoreHorizontalIcon}
+              size={DESKTOP_HEADER_ICON_SMALL_SIZE}
+              title={t('more', { ns: 'common' })}
+            />
+          </DropdownMenu>
+        </Flexbox>
       }
       onClose={onClose}
     >


### PR DESCRIPTION
Refines the notification center hierarchy and reduces persistent action chrome.

<!-- linear:table-colwidths:400,400 -->
<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td><img src="https://github.com/user-attachments/assets/d321670d-8fce-4139-a180-f47499753604 " alt="image" width="596" data-linear-height="531" /></td>
<td><img src="https://github.com/user-attachments/assets/19ec16f5-5b91-4c0e-9180-9d716f29d01b " alt="image" width="617" data-linear-height="580" /></td>
</tr>
</tbody>
</table>
