### PR TITLE
🐛 fix(cli): move verify vocabulary to @lobechat/const/verify

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lobehub/cli",
-  "version": "0.0.40",
+  "version": "0.0.42",
   "type": "module",
   "bin": {
     "lh": "./dist/index.js",
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@lobechat/agent-gateway-client": "workspace:*",
+    "@lobechat/const": "workspace:*",
     "@lobechat/device-control": "workspace:*",
     "@lobechat/device-gateway-client": "workspace:*",
     "@lobechat/device-identity": "workspace:*",

--- a/apps/cli/src/commands/verify.ts
+++ b/apps/cli/src/commands/verify.ts
@@ -2,8 +2,12 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
-import type { VerifyRunOrigin, VerifySurface } from '@lobechat/types';
-import { normalizeVerifySurface, verifyEvidenceTypes, verifySurfaces } from '@lobechat/types';
+import type { VerifyRunOrigin, VerifySurface } from '@lobechat/const/verify';
+import {
+  normalizeVerifySurface,
+  verifyEvidenceTypes,
+  verifySurfaces,
+} from '@lobechat/const/verify';
 import type { Command } from 'commander';
 import pc from 'picocolors';
 

--- a/apps/server/src/routers/lambda/verify.ts
+++ b/apps/server/src/routers/lambda/verify.ts
@@ -1,6 +1,6 @@
 import { VerifySkill } from '@lobechat/builtin-skills';
+import { normalizeVerifySurface, verifySurfaces } from '@lobechat/const/verify';
 import type { VerifyCheckItem } from '@lobechat/types';
-import { normalizeVerifySurface, verifySurfaces } from '@lobechat/types';
 import { TRPCError } from '@trpc/server';
 import { asc, eq } from 'drizzle-orm';
 import { z } from 'zod';

--- a/apps/server/src/services/verify/repairService.ts
+++ b/apps/server/src/services/verify/repairService.ts
@@ -1,5 +1,5 @@
+import { DEFAULT_MAX_REPAIR_ROUNDS } from '@lobechat/const/verify';
 import type { VerifyCheckItem, VerifyRunMetadata } from '@lobechat/types';
-import { DEFAULT_MAX_REPAIR_ROUNDS } from '@lobechat/types';
 import debug from 'debug';
 
 import { AgentOperationModel } from '@/database/models/agentOperation';

--- a/packages/builtin-tool-lobe-delivery-checker/src/client/Portal/RubricConfig.tsx
+++ b/packages/builtin-tool-lobe-delivery-checker/src/client/Portal/RubricConfig.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DEFAULT_MAX_REPAIR_ROUNDS } from '@lobechat/types';
+import { DEFAULT_MAX_REPAIR_ROUNDS } from '@lobechat/const/verify';
 import { Flexbox, Icon, Input, InputNumber } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { RefreshCw, Type } from 'lucide-react';

--- a/packages/const/package.json
+++ b/packages/const/package.json
@@ -9,6 +9,7 @@
     "./hotkeys": "./src/hotkeys.ts",
     "./rbac": "./src/rbac.ts",
     "./url": "./src/url.ts",
+    "./verify": "./src/verify.ts",
     "./visualRef": "./src/visualRef.ts"
   },
   "main": "./src/index.ts",

--- a/packages/const/src/verify.test.ts
+++ b/packages/const/src/verify.test.ts
@@ -1,0 +1,78 @@
+import type {
+  VerifierType,
+  VerifyCheckResultStatus,
+  VerifyEvidenceCapturedBy,
+  VerifyEvidenceType,
+  VerifyOnFailStrategy,
+  VerifyRunOrigin as VerifyRunOriginType,
+  VerifyRunScenario,
+  VerifyRunSource,
+  VerifyRunStatus,
+  VerifySurface,
+  VerifyUserDecision,
+  VerifyVerdict,
+} from '@lobechat/types';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import type {
+  verifierTypes,
+  verifyCheckResultStatuses,
+  verifyEvidenceCapturedBy,
+  verifyEvidenceTypes,
+  verifyOnFailStrategies,
+  VerifyRunOrigin,
+  verifyRunScenarios,
+  verifyRunSources,
+  verifyRunStatuses,
+  verifySurfaces,
+  verifyUserDecisions,
+  verifyVerdicts,
+} from './verify';
+import { normalizeVerifySurface } from './verify';
+
+/**
+ * `@lobechat/types` declares these unions independently — it cannot import them
+ * from here, because it must stay free of a dependency on `@lobechat/const`
+ * (which already type-imports from it). These assertions are what stops the two
+ * hand-maintained sides from drifting: adding a member on one side only is a
+ * type error, caught by `bun run check --type`, not a silent divergence.
+ */
+describe('verify vocabulary', () => {
+  it('matches the unions declared in @lobechat/types', () => {
+    expectTypeOf<(typeof verifierTypes)[number]>().toEqualTypeOf<VerifierType>();
+    expectTypeOf<(typeof verifyOnFailStrategies)[number]>().toEqualTypeOf<VerifyOnFailStrategy>();
+    expectTypeOf<
+      (typeof verifyCheckResultStatuses)[number]
+    >().toEqualTypeOf<VerifyCheckResultStatus>();
+    expectTypeOf<(typeof verifyVerdicts)[number]>().toEqualTypeOf<VerifyVerdict>();
+    expectTypeOf<(typeof verifyUserDecisions)[number]>().toEqualTypeOf<VerifyUserDecision>();
+    expectTypeOf<(typeof verifyRunStatuses)[number]>().toEqualTypeOf<VerifyRunStatus>();
+    expectTypeOf<(typeof verifyRunSources)[number]>().toEqualTypeOf<VerifyRunSource>();
+    expectTypeOf<(typeof verifyRunScenarios)[number]>().toEqualTypeOf<VerifyRunScenario>();
+    expectTypeOf<(typeof verifySurfaces)[number]>().toEqualTypeOf<VerifySurface>();
+    expectTypeOf<(typeof verifyEvidenceTypes)[number]>().toEqualTypeOf<VerifyEvidenceType>();
+    expectTypeOf<
+      (typeof verifyEvidenceCapturedBy)[number]
+    >().toEqualTypeOf<VerifyEvidenceCapturedBy>();
+    expectTypeOf<VerifyRunOrigin>().toEqualTypeOf<VerifyRunOriginType>();
+  });
+});
+
+describe('normalizeVerifySurface', () => {
+  it('accepts a canonical surface, case- and space-insensitively', () => {
+    expect(normalizeVerifySurface('cli')).toBe('cli');
+    expect(normalizeVerifySurface('  Desktop ')).toBe('desktop');
+  });
+
+  it('resolves the unambiguous historical spellings', () => {
+    expect(normalizeVerifySurface('electron')).toBe('desktop');
+    expect(normalizeVerifySurface('browser')).toBe('web');
+    expect(normalizeVerifySurface('ios')).toBe('mobile');
+  });
+
+  it('rejects a test kind — those name what was run, not where', () => {
+    expect(normalizeVerifySurface('unit')).toBeNull();
+    expect(normalizeVerifySurface('backend')).toBeNull();
+    expect(normalizeVerifySurface('packaged build')).toBeNull();
+  });
+});

--- a/packages/const/src/verify.ts
+++ b/packages/const/src/verify.ts
@@ -1,0 +1,160 @@
+/**
+ * Verify vocabulary — the closed sets every layer agrees on (schema, server,
+ * CLI, store, UI), plus the small shapes that travel with them.
+ *
+ * Deliberately kept here rather than in `@lobechat/types`: these are runtime
+ * values, and `@lobechat/types` is replaced by a hand-written stub inside the
+ * isolated desktop workspace (`apps/desktop/stubs/types`), so a value imported
+ * from it is unreachable for members of that workspace — `@lobehub/cli` among
+ * them. This module has no imports, so it resolves from every workspace.
+ *
+ * The domain model built on top of this vocabulary (plan items, Toulmin
+ * narrative, evidence, reports) lives in `packages/types/src/verify.ts`, which
+ * re-exports the derived types below.
+ */
+
+/**
+ * How a single criterion is judged.
+ * - program: run a deterministic command / script
+ * - agent:   spawn a sub agent_operations to investigate
+ * - llm:     call generateObject and let an LLM judge produce a Toulmin verdict
+ */
+export const verifierTypes = ['program', 'agent', 'llm'] as const;
+export type VerifierType = (typeof verifierTypes)[number];
+
+/** What to do when a check item fails. */
+export const verifyOnFailStrategies = ['manual', 'auto_repair'] as const;
+export type VerifyOnFailStrategy = (typeof verifyOnFailStrategies)[number];
+
+/**
+ * Lifecycle of a single check result.
+ * - errored: the verifier could not run (infra / startup failure) — NOT a
+ *   delivery judgment. Kept distinct from `failed` so a broken verifier never
+ *   reads as a rejected delivery and never seeds an auto-repair round.
+ */
+export const verifyCheckResultStatuses = [
+  'pending',
+  'running',
+  'passed',
+  'failed',
+  'errored',
+  'skipped',
+] as const;
+export type VerifyCheckResultStatus = (typeof verifyCheckResultStatuses)[number];
+
+/** Toulmin Claim — the verifier's judgement. */
+export const verifyVerdicts = ['passed', 'failed', 'uncertain'] as const;
+export type VerifyVerdict = (typeof verifyVerdicts)[number];
+
+/** Human feedback on a result, feeding the data flywheel. */
+export const verifyUserDecisions = ['accepted', 'rejected', 'overridden'] as const;
+export type VerifyUserDecision = (typeof verifyUserDecisions)[number];
+
+/**
+ * Denormalized rollup of a verification session's pipeline state — mirrors the
+ * legacy `agent_operations.verify_status` set so the two stay interchangeable
+ * while results/reports migrate from being operation-anchored to run-anchored.
+ */
+export const verifyRunStatuses = [
+  'unverified',
+  'planned',
+  'verifying',
+  'passed',
+  'failed',
+  // At least one required check errored (verifier couldn't run) and none
+  // genuinely failed — verification is inconclusive, not a rejected delivery.
+  'errored',
+  'repairing',
+  'delivered',
+] as const;
+export type VerifyRunStatus = (typeof verifyRunStatuses)[number];
+
+/**
+ * What produced a verification session.
+ * - agent:         verifying a real Agent Run (`verify_runs.operation_id` set)
+ * - agent-testing: a standalone session ingested from the agent-testing harness
+ *   (no Agent Run — `operation_id` is null)
+ */
+export const verifyRunSources = ['agent', 'agent-testing'] as const;
+export type VerifyRunSource = (typeof verifyRunSources)[number];
+
+/**
+ * The kind of thing a verification session checks. Orthogonal to `source` (which
+ * records what *produced* the run): `scenario` drives how the report renders its
+ * scope header and scenario-specific detail. Open-ended — new scenarios add a
+ * value here plus their own `VerifyRunContext` shape.
+ * - coding: verifying a software change (branch / commit / surfaces under test).
+ */
+export const verifyRunScenarios = ['coding'] as const;
+export type VerifyRunScenario = (typeof verifyRunScenarios)[number];
+
+/**
+ * The product surface a check was exercised on — *where* it ran, never *what
+ * kind* of test it was. `unit` / `backend` / `type-check` are test kinds and do
+ * not belong here; a backend change verified through the CLI has surface `cli`.
+ *
+ * A closed set on purpose: free-form surfaces drifted into 76 distinct values
+ * (long prose, runtime modes, tool names), which no viewer can render as a
+ * legible badge. Runtime detail ("packaged build", "CDP dev instance") belongs
+ * on the plan item's `method`, not here.
+ */
+export const verifySurfaces = ['web', 'desktop', 'cli', 'mobile', 'bot'] as const;
+export type VerifySurface = (typeof verifySurfaces)[number];
+
+/**
+ * Historical spellings that name a surface in this set. Only unambiguous
+ * synonyms — anything else is a rejected value, not a guess.
+ */
+const VERIFY_SURFACE_ALIASES: Record<string, VerifySurface> = {
+  android: 'mobile',
+  browser: 'web',
+  electron: 'desktop',
+  ios: 'mobile',
+  terminal: 'cli',
+};
+
+/** Canonical surface for a raw value, or null when it names no known surface. */
+export const normalizeVerifySurface = (value: string): VerifySurface | null => {
+  const key = value.trim().toLowerCase();
+  if ((verifySurfaces as readonly string[]).includes(key)) return key as VerifySurface;
+  return VERIFY_SURFACE_ALIASES[key] ?? null;
+};
+
+/** The medium of a captured evidence artifact. */
+export const verifyEvidenceTypes = [
+  'screenshot',
+  'gif',
+  'video',
+  'text',
+  'dom_snapshot',
+  'transcript',
+] as const;
+export type VerifyEvidenceType = (typeof verifyEvidenceTypes)[number];
+
+/** Who / what captured an evidence artifact (provenance). */
+export const verifyEvidenceCapturedBy = [
+  'agent-browser',
+  'cdp',
+  'cli',
+  'program',
+  'llm_judge',
+] as const;
+export type VerifyEvidenceCapturedBy = (typeof verifyEvidenceCapturedBy)[number];
+
+/** Default cap on automatic repair rounds when a rubric doesn't override it. */
+export const DEFAULT_MAX_REPAIR_ROUNDS = 3;
+
+/**
+ * The LobeHub conversation an ingested report was authored in. Lets the report
+ * link back to (and later resume) the agent session that produced it. Lives here
+ * because the CLI authors it (from the child env the runtime echoes in) before
+ * any other layer sees it.
+ */
+export interface VerifyRunOrigin {
+  /** The agent that ran the verification. */
+  agentId?: string;
+  /** The agent operation (one execution) that produced the report. */
+  operationId?: string;
+  /** The topic to reopen to continue from this report. */
+  topicId?: string;
+}

--- a/packages/const/src/verify.ts
+++ b/packages/const/src/verify.ts
@@ -1,16 +1,17 @@
 /**
- * Verify vocabulary — the closed sets every layer agrees on (schema, server,
- * CLI, store, UI), plus the small shapes that travel with them.
+ * Verify vocabulary — the runtime closed sets every layer agrees on (schema,
+ * server, CLI, store, UI), plus the small shapes that travel with them.
  *
  * Deliberately kept here rather than in `@lobechat/types`: these are runtime
  * values, and `@lobechat/types` is replaced by a hand-written stub inside the
  * isolated desktop workspace (`apps/desktop/stubs/types`), so a value imported
  * from it is unreachable for members of that workspace — `@lobehub/cli` among
- * them. This module has no imports, so it resolves from every workspace.
+ * them. This module imports nothing, so it resolves from every workspace.
  *
- * The domain model built on top of this vocabulary (plan items, Toulmin
- * narrative, evidence, reports) lives in `packages/types/src/verify.ts`, which
- * re-exports the derived types below.
+ * `packages/types/src/verify.ts` declares the same unions independently (it must
+ * not depend on `@lobechat/const`) and owns the domain model built on top of them
+ * — plan items, Toulmin narrative, evidence, reports. The two sides are pinned
+ * together by `./verify.test.ts`, which fails the type-check on any drift.
  */
 
 /**

--- a/packages/database/src/schemas/agentOperations.ts
+++ b/packages/database/src/schemas/agentOperations.ts
@@ -1,5 +1,5 @@
+import { verifyRunStatuses } from '@lobechat/const/verify';
 import type { VerifyCheckItem } from '@lobechat/types';
-import { verifyRunStatuses } from '@lobechat/types';
 import { boolean, index, integer, jsonb, pgTable, text } from 'drizzle-orm/pg-core';
 
 import { amountNumeric, timestamps, timestamptz } from './_helpers';
@@ -84,7 +84,7 @@ export const agentOperations = pgTable(
     // longer read or written by the verify pipeline and are dropped in a later
     // cleanup migration.
     // Denormalized rollup of the verify (delivery checker) state. Shares the
-    // single `verifyRunStatuses` set from `@lobechat/types` so it can't drift
+    // single `verifyRunStatuses` set from `@lobechat/const/verify` so it can't drift
     // from `verify_runs.status`.
     /** @deprecated read from verify_runs.status */
     verifyStatus: text('verify_status', { enum: verifyRunStatuses }),

--- a/packages/database/src/schemas/verify.ts
+++ b/packages/database/src/schemas/verify.ts
@@ -1,11 +1,3 @@
-import type {
-  ToulminVerdict,
-  VerifyCheckItem,
-  VerifyRubricConfig,
-  VerifyRunContext,
-  VerifyRunMetadata,
-  VerifyRunScenario,
-} from '@lobechat/types';
 import {
   verifierTypes,
   verifyCheckResultStatuses,
@@ -16,6 +8,14 @@ import {
   verifyRunStatuses,
   verifyUserDecisions,
   verifyVerdicts,
+} from '@lobechat/const/verify';
+import type {
+  ToulminVerdict,
+  VerifyCheckItem,
+  VerifyRubricConfig,
+  VerifyRunContext,
+  VerifyRunMetadata,
+  VerifyRunScenario,
 } from '@lobechat/types';
 import {
   boolean,

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -17,9 +17,6 @@
     "type-fest": "^4.41.0",
     "zustand": "5.0.4"
   },
-  "devDependencies": {
-    "@lobechat/const": "workspace:*"
-  },
   "peerDependencies": {
     "@lobehub/ui": "^5",
     "react": "*",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -17,6 +17,9 @@
     "type-fest": "^4.41.0",
     "zustand": "5.0.4"
   },
+  "devDependencies": {
+    "@lobechat/const": "workspace:*"
+  },
   "peerDependencies": {
     "@lobehub/ui": "^5",
     "react": "*",

--- a/packages/types/src/verify.ts
+++ b/packages/types/src/verify.ts
@@ -3,113 +3,41 @@
  * shape, Toulmin narrative, and rubric run-policy config. Kept here (not in the
  * DB schema) so every layer — schema, services, store, UI — depends on one
  * source of truth without reaching into the database package.
- */
-
-/**
- * How a single criterion is judged.
- * - program: run a deterministic command / script
- * - agent:   spawn a sub agent_operations to investigate
- * - llm:     call generateObject and let an LLM judge produce a Toulmin verdict
- */
-export const verifierTypes = ['program', 'agent', 'llm'] as const;
-export type VerifierType = (typeof verifierTypes)[number];
-
-/** What to do when a check item fails. */
-export const verifyOnFailStrategies = ['manual', 'auto_repair'] as const;
-export type VerifyOnFailStrategy = (typeof verifyOnFailStrategies)[number];
-
-/**
- * Lifecycle of a single check result.
- * - errored: the verifier could not run (infra / startup failure) — NOT a
- *   delivery judgment. Kept distinct from `failed` so a broken verifier never
- *   reads as a rejected delivery and never seeds an auto-repair round.
- */
-export const verifyCheckResultStatuses = [
-  'pending',
-  'running',
-  'passed',
-  'failed',
-  'errored',
-  'skipped',
-] as const;
-export type VerifyCheckResultStatus = (typeof verifyCheckResultStatuses)[number];
-
-/** Toulmin Claim — the verifier's judgement. */
-export const verifyVerdicts = ['passed', 'failed', 'uncertain'] as const;
-export type VerifyVerdict = (typeof verifyVerdicts)[number];
-
-/** Human feedback on a result, feeding the data flywheel. */
-export const verifyUserDecisions = ['accepted', 'rejected', 'overridden'] as const;
-export type VerifyUserDecision = (typeof verifyUserDecisions)[number];
-
-/**
- * Denormalized rollup of a verification session's pipeline state — mirrors the
- * legacy `agent_operations.verify_status` set so the two stay interchangeable
- * while results/reports migrate from being operation-anchored to run-anchored.
- */
-export const verifyRunStatuses = [
-  'unverified',
-  'planned',
-  'verifying',
-  'passed',
-  'failed',
-  // At least one required check errored (verifier couldn't run) and none
-  // genuinely failed — verification is inconclusive, not a rejected delivery.
-  'errored',
-  'repairing',
-  'delivered',
-] as const;
-export type VerifyRunStatus = (typeof verifyRunStatuses)[number];
-
-/**
- * What produced a verification session.
- * - agent:         verifying a real Agent Run (`verify_runs.operation_id` set)
- * - agent-testing: a standalone session ingested from the agent-testing harness
- *   (no Agent Run — `operation_id` is null)
- */
-export const verifyRunSources = ['agent', 'agent-testing'] as const;
-export type VerifyRunSource = (typeof verifyRunSources)[number];
-
-/**
- * The kind of thing a verification session checks. Orthogonal to `source` (which
- * records what *produced* the run): `scenario` drives how the report renders its
- * scope header and scenario-specific detail. Open-ended — new scenarios add a
- * value here plus their own {@link VerifyRunContext} shape.
- * - coding: verifying a software change (branch / commit / surfaces under test).
- */
-export const verifyRunScenarios = ['coding'] as const;
-export type VerifyRunScenario = (typeof verifyRunScenarios)[number];
-
-/**
- * The product surface a check was exercised on — *where* it ran, never *what
- * kind* of test it was. `unit` / `backend` / `type-check` are test kinds and do
- * not belong here; a backend change verified through the CLI has surface `cli`.
  *
- * A closed set on purpose: free-form surfaces drifted into 76 distinct values
- * (long prose, runtime modes, tool names), which no viewer can render as a
- * legible badge. Runtime detail ("packaged build", "CDP dev instance") belongs
- * on the plan item's `method`, not here.
+ * The closed sets (verifier types, statuses, verdicts, surfaces, evidence media)
+ * are runtime values, and this package is replaced by a hand-written stub inside
+ * the isolated desktop workspace — so they live in `@lobechat/const/verify`,
+ * which every workspace can resolve. Their derived types are re-exported here so
+ * `@lobechat/types` stays the one-stop vocabulary for the domain.
  */
-export const verifySurfaces = ['web', 'desktop', 'cli', 'mobile', 'bot'] as const;
-export type VerifySurface = (typeof verifySurfaces)[number];
+import type {
+  VerifierType,
+  VerifyCheckResultStatus,
+  VerifyEvidenceCapturedBy,
+  VerifyEvidenceType,
+  VerifyOnFailStrategy,
+  VerifyRunOrigin,
+  VerifyRunScenario,
+  VerifyRunSource,
+  VerifyRunStatus,
+  VerifySurface,
+  VerifyUserDecision,
+  VerifyVerdict,
+} from '@lobechat/const/verify';
 
-/**
- * Historical spellings that name a surface in this set. Only unambiguous
- * synonyms — anything else is a rejected value, not a guess.
- */
-const VERIFY_SURFACE_ALIASES: Record<string, VerifySurface> = {
-  android: 'mobile',
-  browser: 'web',
-  electron: 'desktop',
-  ios: 'mobile',
-  terminal: 'cli',
-};
-
-/** Canonical surface for a raw value, or null when it names no known surface. */
-export const normalizeVerifySurface = (value: string): VerifySurface | null => {
-  const key = value.trim().toLowerCase();
-  if ((verifySurfaces as readonly string[]).includes(key)) return key as VerifySurface;
-  return VERIFY_SURFACE_ALIASES[key] ?? null;
+export type {
+  VerifierType,
+  VerifyCheckResultStatus,
+  VerifyEvidenceCapturedBy,
+  VerifyEvidenceType,
+  VerifyOnFailStrategy,
+  VerifyRunOrigin,
+  VerifyRunScenario,
+  VerifyRunSource,
+  VerifyRunStatus,
+  VerifySurface,
+  VerifyUserDecision,
+  VerifyVerdict,
 };
 
 /**
@@ -189,9 +117,6 @@ export interface VerifyInteractionCost {
   waitSeconds: number;
 }
 
-/** Default cap on automatic repair rounds when a rubric doesn't override it. */
-export const DEFAULT_MAX_REPAIR_ROUNDS = 3;
-
 /**
  * Run-policy knobs for a rubric — applied to every run that mounts it. Lives in
  * one bag (not columns) so new policy switches can be added without a migration.
@@ -203,19 +128,6 @@ export interface VerifyRubricConfig {
    * runaway repair loops. Defaults to {@link DEFAULT_MAX_REPAIR_ROUNDS}.
    */
   maxRepairRounds?: number;
-}
-
-/**
- * The LobeHub conversation an ingested report was authored in. Lets the report
- * link back to (and later resume) the agent session that produced it.
- */
-export interface VerifyRunOrigin {
-  /** The agent that ran the verification. */
-  agentId?: string;
-  /** The agent operation (one execution) that produced the report. */
-  operationId?: string;
-  /** The topic to reopen to continue from this report. */
-  topicId?: string;
 }
 
 /**
@@ -316,27 +228,6 @@ export interface ToulminVerdict {
 // ============================================
 // Evidence — first-class artifacts a verifier produces (screenshots, logs, …)
 // ============================================
-
-/** The medium of a captured evidence artifact. */
-export const verifyEvidenceTypes = [
-  'screenshot',
-  'gif',
-  'video',
-  'text',
-  'dom_snapshot',
-  'transcript',
-] as const;
-export type VerifyEvidenceType = (typeof verifyEvidenceTypes)[number];
-
-/** Who / what captured an evidence artifact (provenance). */
-export const verifyEvidenceCapturedBy = [
-  'agent-browser',
-  'cdp',
-  'cli',
-  'program',
-  'llm_judge',
-] as const;
-export type VerifyEvidenceCapturedBy = (typeof verifyEvidenceCapturedBy)[number];
 
 /**
  * Declares that a criterion is evidence-driven: it cannot pass on the

--- a/packages/types/src/verify.ts
+++ b/packages/types/src/verify.ts
@@ -4,41 +4,108 @@
  * DB schema) so every layer — schema, services, store, UI — depends on one
  * source of truth without reaching into the database package.
  *
- * The closed sets (verifier types, statuses, verdicts, surfaces, evidence media)
- * are runtime values, and this package is replaced by a hand-written stub inside
- * the isolated desktop workspace — so they live in `@lobechat/const/verify`,
- * which every workspace can resolve. Their derived types are re-exported here so
- * `@lobechat/types` stays the one-stop vocabulary for the domain.
+ * The unions below are declared here, and their runtime counterparts (the `as
+ * const` arrays a schema or a `<Select>` iterates) live in
+ * `@lobechat/const/verify`. The duplication is deliberate: this package is
+ * replaced by a hand-written stub inside the isolated desktop workspace, so a
+ * runtime value exported from here is unreachable for members of that workspace
+ * (`@lobehub/cli`), while `@lobechat/types` must stay dependency-free of
+ * `@lobechat/const`. `packages/const/src/verify.test.ts` fails the type-check the
+ * moment the two sides drift apart.
  */
-import type {
-  VerifierType,
-  VerifyCheckResultStatus,
-  VerifyEvidenceCapturedBy,
-  VerifyEvidenceType,
-  VerifyOnFailStrategy,
-  VerifyRunOrigin,
-  VerifyRunScenario,
-  VerifyRunSource,
-  VerifyRunStatus,
-  VerifySurface,
-  VerifyUserDecision,
-  VerifyVerdict,
-} from '@lobechat/const/verify';
 
-export type {
-  VerifierType,
-  VerifyCheckResultStatus,
-  VerifyEvidenceCapturedBy,
-  VerifyEvidenceType,
-  VerifyOnFailStrategy,
-  VerifyRunOrigin,
-  VerifyRunScenario,
-  VerifyRunSource,
-  VerifyRunStatus,
-  VerifySurface,
-  VerifyUserDecision,
-  VerifyVerdict,
-};
+/**
+ * How a single criterion is judged.
+ * - program: run a deterministic command / script
+ * - agent:   spawn a sub agent_operations to investigate
+ * - llm:     call generateObject and let an LLM judge produce a Toulmin verdict
+ */
+export type VerifierType = 'program' | 'agent' | 'llm';
+
+/** What to do when a check item fails. */
+export type VerifyOnFailStrategy = 'manual' | 'auto_repair';
+
+/**
+ * Lifecycle of a single check result.
+ * - errored: the verifier could not run (infra / startup failure) — NOT a
+ *   delivery judgment. Kept distinct from `failed` so a broken verifier never
+ *   reads as a rejected delivery and never seeds an auto-repair round.
+ */
+export type VerifyCheckResultStatus =
+  'pending' | 'running' | 'passed' | 'failed' | 'errored' | 'skipped';
+
+/** Toulmin Claim — the verifier's judgement. */
+export type VerifyVerdict = 'passed' | 'failed' | 'uncertain';
+
+/** Human feedback on a result, feeding the data flywheel. */
+export type VerifyUserDecision = 'accepted' | 'rejected' | 'overridden';
+
+/**
+ * Denormalized rollup of a verification session's pipeline state — mirrors the
+ * legacy `agent_operations.verify_status` set so the two stay interchangeable
+ * while results/reports migrate from being operation-anchored to run-anchored.
+ *
+ * `errored`: at least one required check errored (verifier couldn't run) and none
+ * genuinely failed — verification is inconclusive, not a rejected delivery.
+ */
+export type VerifyRunStatus =
+  | 'unverified'
+  | 'planned'
+  | 'verifying'
+  | 'passed'
+  | 'failed'
+  | 'errored'
+  | 'repairing'
+  | 'delivered';
+
+/**
+ * What produced a verification session.
+ * - agent:         verifying a real Agent Run (`verify_runs.operation_id` set)
+ * - agent-testing: a standalone session ingested from the agent-testing harness
+ *   (no Agent Run — `operation_id` is null)
+ */
+export type VerifyRunSource = 'agent' | 'agent-testing';
+
+/**
+ * The kind of thing a verification session checks. Orthogonal to `source` (which
+ * records what *produced* the run): `scenario` drives how the report renders its
+ * scope header and scenario-specific detail. Open-ended — new scenarios add a
+ * value here plus their own {@link VerifyRunContext} shape.
+ * - coding: verifying a software change (branch / commit / surfaces under test).
+ */
+export type VerifyRunScenario = 'coding';
+
+/**
+ * The product surface a check was exercised on — *where* it ran, never *what
+ * kind* of test it was. `unit` / `backend` / `type-check` are test kinds and do
+ * not belong here; a backend change verified through the CLI has surface `cli`.
+ *
+ * A closed set on purpose: free-form surfaces drifted into 76 distinct values
+ * (long prose, runtime modes, tool names), which no viewer can render as a
+ * legible badge. Runtime detail ("packaged build", "CDP dev instance") belongs
+ * on the plan item's `method`, not here.
+ */
+export type VerifySurface = 'web' | 'desktop' | 'cli' | 'mobile' | 'bot';
+
+/** The medium of a captured evidence artifact. */
+export type VerifyEvidenceType =
+  'screenshot' | 'gif' | 'video' | 'text' | 'dom_snapshot' | 'transcript';
+
+/** Who / what captured an evidence artifact (provenance). */
+export type VerifyEvidenceCapturedBy = 'agent-browser' | 'cdp' | 'cli' | 'program' | 'llm_judge';
+
+/**
+ * The LobeHub conversation an ingested report was authored in. Lets the report
+ * link back to (and later resume) the agent session that produced it.
+ */
+export interface VerifyRunOrigin {
+  /** The agent that ran the verification. */
+  agentId?: string;
+  /** The agent operation (one execution) that produced the report. */
+  operationId?: string;
+  /** The topic to reopen to continue from this report. */
+  topicId?: string;
+}
 
 /**
  * Coding-scenario scope: where the code under test came from and how it ran.

--- a/src/features/AgentTasks/AgentTaskDetail/VerifyCriterionModal/VerifyCriterionForm.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/VerifyCriterionModal/VerifyCriterionForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type VerifierType, verifierTypes } from '@lobechat/types';
+import { type VerifierType, verifierTypes } from '@lobechat/const/verify';
 import { Flexbox, Input, Text, TextArea } from '@lobehub/ui';
 import { Button, Select, Switch, useModalContext } from '@lobehub/ui/base-ui';
 import { useMemo, useState } from 'react';

--- a/src/features/Verify/utils.ts
+++ b/src/features/Verify/utils.ts
@@ -1,5 +1,5 @@
-import type { VerifyCheckItem, VerifyCodingScope, VerifySurface } from '@lobechat/types';
-import { normalizeVerifySurface } from '@lobechat/types';
+import { normalizeVerifySurface, type VerifySurface } from '@lobechat/const/verify';
+import type { VerifyCheckItem, VerifyCodingScope } from '@lobechat/types';
 
 import type { VerifyStatus } from '@/database/models/agentOperation';
 import type { VerifyCheckResultItem } from '@/database/schemas/verify';


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Follow-up to #17166.

#### 🔀 Description of Change

`@lobehub/cli`'s build is broken on canary HEAD with three `MISSING_EXPORT` errors:

```
[MISSING_EXPORT] "normalizeVerifySurface" is not exported by "../desktop/stubs/types/src/index.ts".
[MISSING_EXPORT] "verifyEvidenceTypes"    is not exported by "../desktop/stubs/types/src/index.ts".
[MISSING_EXPORT] "verifySurfaces"         is not exported by "../desktop/stubs/types/src/index.ts".
```

**Why.** `apps/cli` is a member of the isolated desktop workspace (`apps/desktop/pnpm-workspace.yaml` lists `../cli`), so inside it `@lobechat/types` resolves to the hand-written stub at `apps/desktop/stubs/types` — not the real package. The stub only mirrors the runtime exports that workspace actually needs. #17166 added three **value** imports from `@lobechat/types` to the CLI's verify command, and they are unreachable there. The two `import type` symbols on the same line (`VerifySurface`, `VerifyRunOrigin`) were missing from the stub too — erased by the bundler, but `tsc` failed on them.

**Fix — split the vocabulary along the runtime/type line.**

- **`@lobechat/const/verify`** (new, **imports nothing**) owns the runtime `as const` arrays a schema or a `<Select>` iterates: `verifierTypes`, `verifyOnFailStrategies`, `verifyCheckResultStatuses`, `verifyVerdicts`, `verifyUserDecisions`, `verifyRunStatuses`, `verifyRunSources`, `verifyRunScenarios`, `verifySurfaces`, `verifyEvidenceTypes`, `verifyEvidenceCapturedBy`, plus `normalizeVerifySurface` and `DEFAULT_MAX_REPAIR_ROUNDS`. `@lobechat/const` is already a member of both workspaces, and a zero-import module resolves from either — including the stubbed one.
- **`@lobechat/types`** keeps the domain model (`VerifyCheckItem`, `ToulminVerdict`, `VerifyEvidence`, `VerifyReport`, the config bags) and **declares the unions itself**. It does *not* import from `@lobechat/const`: `const` already type-imports from `types` in ~10 files, so that edge would close a package-level cycle. Type-only consumers (server services, `ReportViewer.tsx`) import exactly what they did before.

The two hand-maintained sides are pinned by **`packages/const/src/verify.test.ts`** — `expectTypeOf<(typeof verifySurfaces)[number]>().toEqualTypeOf<VerifySurface>()` for each set. Adding a member to one side alone is a type error, not a silent divergence.

The **whole** vocabulary moves, not just the two symbols the CLI happened to import. Splitting on what one consumer needs is an accident of consumption, not a boundary — nobody would later be able to say why `verifierTypes` stayed behind.

Mirroring the three symbols into the stub instead would also have unbroken the build, but leaves a hand-copied closed set with nothing guarding it.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

| Check | Result |
| --- | --- |
| `bun run build` (apps/cli, tsdown) | passes — 3 `MISSING_EXPORT` gone |
| `tsc --noEmit` (apps/cli) | 25 → 20 errors: exactly the 5 `TS2305` removed, none added |
| `bun run check` | lint clean, tests pass |
| `bun run check --type` | types clean |
| **drift guard fires** | added `'watch'` to `verifySurfaces` alone → `verify.test.ts(52): error TS2344: Expected: literal string: bot, Actual: literal string: watch`; same for `verifyVerdicts += 'inconclusive'`. Reverted. |

The 20 remaining CLI `tsc` errors are pre-existing standalone-typecheck noise (`@/server/routers/lambda` doesn't resolve outside the app build), identical before and after.

#### 📝 Additional Information

- **No migration.** The Drizzle columns are `text({ enum })`, which is TS-only; the enum values are unchanged, only the import source is.
- **No new package dependency edges** beyond `apps/cli → @lobechat/const`. `packages/types` gains none.
- Bundles the pending `@lobehub/cli` version bump `0.0.40 → 0.0.42`, which was already in the working tree — this fix is what unblocks that release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)