### PR TITLE
🐛 fix(task): restore scheduled action split button

### DIFF
--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailRunPauseAction.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailRunPauseAction.tsx
@@ -1,6 +1,6 @@
-import { DropdownMenu, Flexbox, Text } from '@lobehub/ui';
-import { Button } from '@lobehub/ui/base-ui';
-import { CalendarOffIcon, ChevronDown, PlayIcon, RotateCcwIcon } from 'lucide-react';
+import { Flexbox, Text } from '@lobehub/ui';
+import { Button, SplitButton } from '@lobehub/ui/base-ui';
+import { CalendarOffIcon, PlayIcon, RotateCcwIcon } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -137,8 +137,8 @@ const TaskDetailRunPauseAction = memo(() => {
   if (isScheduled) {
     return (
       <Flexbox horizontal align={'center'} gap={12}>
-        <Flexbox horizontal gap={4}>
-          <Button
+        <SplitButton disabled={!canEditTask || isCancellingSchedule} loading={isRunningNow}>
+          <SplitButton.Main
             disabled={!canEditTask || isRunningNow}
             icon={CalendarOffIcon}
             loading={isCancellingSchedule}
@@ -146,8 +146,8 @@ const TaskDetailRunPauseAction = memo(() => {
             onClick={handleCancelSchedule}
           >
             {t('taskDetail.cancelSchedule')}
-          </Button>
-          <DropdownMenu
+          </SplitButton.Main>
+          <SplitButton.Menu
             items={[
               {
                 disabled: !canEditTask || isRunningNow || isCancellingSchedule,
@@ -157,15 +157,8 @@ const TaskDetailRunPauseAction = memo(() => {
                 onClick: handleRunNow,
               },
             ]}
-          >
-            <Button
-              disabled={!canEditTask || isCancellingSchedule}
-              icon={ChevronDown}
-              loading={isRunningNow}
-              title={canEditTask ? undefined : reason}
-            />
-          </DropdownMenu>
-        </Flexbox>
+          />
+        </SplitButton>
         {countdownText && (
           <Text fontSize={12} type={'secondary'}>
             {t('taskDetail.nextRunCountdown', { countdown: countdownText })}


### PR DESCRIPTION
## Summary

- replace the separated scheduled-task action buttons with the canonical base-ui `SplitButton`
- restore a continuous border and joined inner corners between “Cancel schedule” and the dropdown trigger
- preserve independent loading and disabled states for canceling the schedule and running the task immediately

## Root cause

A recent migration from `Space.Compact` to `Flexbox gap={4}` introduced visible spacing between two controls that semantically form one split action.

## Impact

Scheduled task actions now read as one coherent control while retaining the existing primary action and “Run now” menu behavior.

## Validation

- `bun run check src/features/AgentTasks/AgentTaskDetail/TaskDetailRunPauseAction.tsx`
- `git diff --check origin/canary...HEAD`
- browser verification through the local debug proxy on a scheduled task:
  - joined 1 px seam with no gap or double border
  - outer radii at 6 px and inner radii at 0
  - dropdown opens and renders “Run now”
  - no Vite/Next error overlay or `SplitButton`-related console warning