### PR TITLE
📝 docs(skills): add the product-design skill

### DIFF
--- a/.agents/skills/product-design/SKILL.md
+++ b/.agents/skills/product-design/SKILL.md
@@ -46,8 +46,8 @@ button's padding.
 
 ## SCLPT — why this skill gets better over time
 
-A self-evolving system, wired per the SCLPT framework (BM-58). Each element maps
-to a file you must actually read and write:
+A self-evolving system, wired per the SCLPT framework. Each element maps to a file
+you must actually read and write:
 
 | Element            | Here                                                     | What it does                                                                         |
 | ------------------ | -------------------------------------------------------- | ------------------------------------------------------------------------------------ |

--- a/.agents/skills/product-design/SKILL.md
+++ b/.agents/skills/product-design/SKILL.md
@@ -49,13 +49,13 @@ button's padding.
 A self-evolving system, wired per the SCLPT framework (BM-58). Each element maps
 to a file you must actually read and write:
 
-| Element            | Here                                                     | What it does                                                                      |
-| ------------------ | -------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| **P** Pattern Base | [references/pattern-base.md](references/pattern-base.md) | The learned rules. **Read before every run. Append after every run.**             |
-| **L** Layer Model  | [references/layer-model.md](references/layer-model.md)   | L0 scenario / L1 business nouns / L2 business verbs / L3 representation           |
-| **T** Trace Schema | [references/trace-schema.md](references/trace-schema.md) | Every session leaves a **reality-check log**: assumption → what is true → who won |
-| **C** Closed Loop  | Step 6                                                   | Every overturned assumption becomes a new pattern                                 |
-| **S** Saturation   | Step 6                                                   | A grounding round that overturns **nothing** = L1/L2 are mined out                |
+| Element            | Here                                                     | What it does                                                                         |
+| ------------------ | -------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **P** Pattern Base | [references/pattern-base.md](references/pattern-base.md) | The learned rules. **Read before every run. Append after every run.**                |
+| **L** Layer Model  | [references/layer-model.md](references/layer-model.md)   | Cooper's three models — implementation / represented / mental                        |
+| **T** Trace Schema | [references/trace-schema.md](references/trace-schema.md) | Every session leaves a **reality-check log**: assumption → what is true → who won    |
+| **C** Closed Loop  | Step 6                                                   | Every overturned assumption becomes a new pattern                                    |
+| **S** Saturation   | Step 6                                                   | A grounding round that overturns **nothing** = the implementation model is mined out |
 
 Benchmarked against [references/canon.md](references/canon.md) — the works that
 already named most of this, and the two things they did not.
@@ -175,7 +175,8 @@ The session is done when the **system** got smarter, not when the PR opened:
    named, or genuinely new?_ Most of the time it is the former, and that is a good
    outcome.
 3. **Record the saturation signal.** If a whole round overturned _nothing_, say
-   so: L1/L2 are mined out for that surface, and the next round belongs to L0.
+   so: the implementation model is mined out for that surface, and the next round
+   belongs to the **mental** model — the one grounding cannot reach.
 
 A session that ships a feature but teaches the system nothing has done half the
 job.

--- a/.agents/skills/product-design/SKILL.md
+++ b/.agents/skills/product-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: product-design
-description: 'Turn a vague product ask ("this page feels wrong", "we need a team view") into a grounded, shippable design — by reverse-engineering what the code can actually do before proposing anything. Use when scoping a new surface, redesigning an existing one, or deciding what a feature should even be. Not for auditing a built screen (that is ux-audit) or for picking spacing and color (that is ux).'
+description: 'Turn a vague product ask ("this page feels wrong", "we need a team view") into a grounded, shippable design — by first establishing what the business actually models, before proposing anything. Use when scoping a new surface, redesigning an existing one, or deciding what a feature should even be. Not for auditing a built screen (that is ux-audit) or for picking spacing and color (that is ux).'
 argument-hint: '<surface or product ask>'
 ---
 
@@ -11,12 +11,26 @@ argues about spacing.
 
 Its one non-negotiable rule:
 
-> **Never propose from imagination. Reverse-engineer the code first.**
+> **Never design from the surface. Establish what the business actually models
+> first.**
 
-Every expensive mistake this skill exists to prevent has the same shape — a
-designer (human or agent) invented something the codebase already had, or
-designed an affordance for data that does not exist. Both look completely
-reasonable on a slide and fall apart the moment someone tries to build them.
+Every expensive mistake this skill exists to prevent has the same shape: a
+surface that misrepresents its own business — promising an event the domain does
+not have, hiding a capability the domain already supports, or naming a state
+after the machine rather than after the obligation it creates. All three look
+completely reasonable on a slide.
+
+## Scope — business semantics only
+
+This skill is about **what the product means**, not how it is built.
+
+Component reuse, refactor hazards, framework conventions — real, important, and
+**not here.** The test for anything entering this skill:
+
+> Strip out every framework, table and component name. **Is there still a product
+> insight left?**
+
+If not, it belongs in an engineering skill.
 
 ## Where this sits
 
@@ -32,20 +46,22 @@ button's padding.
 
 ## SCLPT — why this skill gets better over time
 
-This is a self-evolving system, wired as SCLPT (see the framework doc in Linear,
-BM-58). The five elements are not decoration; each maps to a file you must
-actually read and write:
+A self-evolving system, wired per the SCLPT framework (BM-58). Each element maps
+to a file you must actually read and write:
 
-| Element            | Here                                                     | What it does                                                                        |
-| ------------------ | -------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| **T** Trace Schema | [references/trace-schema.md](references/trace-schema.md) | Every session leaves a **reality-check log**: assumption → code fact → who won      |
-| **L** Layer Model  | [references/layer-model.md](references/layer-model.md)   | L0 intent / L1 data / L2 contract / L3 presentation — stops cross-layer misjudgment |
-| **P** Pattern Base | [references/pattern-base.md](references/pattern-base.md) | The learned rules. **Read before every run. Append after every run.**               |
-| **C** Closed Loop  | Step 6 below                                             | Every assumption the code overturned becomes a new pattern                          |
-| **S** Saturation   | Step 6 below                                             | A round where the code overturns **nothing** = L1/L2 are mined out                  |
+| Element            | Here                                                     | What it does                                                                      |
+| ------------------ | -------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| **P** Pattern Base | [references/pattern-base.md](references/pattern-base.md) | The learned rules. **Read before every run. Append after every run.**             |
+| **L** Layer Model  | [references/layer-model.md](references/layer-model.md)   | L0 scenario / L1 business nouns / L2 business verbs / L3 representation           |
+| **T** Trace Schema | [references/trace-schema.md](references/trace-schema.md) | Every session leaves a **reality-check log**: assumption → what is true → who won |
+| **C** Closed Loop  | Step 6                                                   | Every overturned assumption becomes a new pattern                                 |
+| **S** Saturation   | Step 6                                                   | A grounding round that overturns **nothing** = L1/L2 are mined out                |
 
-**The loop in one line:** the reality-check log (T) is sorted by layer (L),
-compared against the pattern base (P); whatever the code overturned that the
+Benchmarked against [references/canon.md](references/canon.md) — the works that
+already named most of this, and the two things they did not.
+
+**The loop in one line:** the reality-check log (T) is sorted by layer (L) and
+compared against the pattern base (P); whatever the business overturned that the
 pattern base did not predict is a new gap, which gets written back (C); when a
 grounding round produces zero new gaps, that surface is saturated (S).
 
@@ -56,115 +72,113 @@ grounding round produces zero new gaps, that surface is saturated (S).
 ### Step 0 — Read the Pattern Base (mandatory, every run)
 
 Read [references/pattern-base.md](references/pattern-base.md) and
-[references/layer-model.md](references/layer-model.md) **in full** before
-touching the product ask. They are the accumulated "you already got this wrong
-once" list. Skipping them is how the same mistake ships twice.
+[references/layer-model.md](references/layer-model.md) **in full** before touching
+the product ask. They are the accumulated "you already got this wrong once" list.
 
 Two that keep biting, up front:
 
-- **The codebase probably already has it.** Status glyphs, loading spinners,
-  approval flows, comment inputs — before designing one, grep for the canonical
-  implementation. (`P-01`…`P-03`)
-- **Names lie.** A `Project` group that renders a knowledge base; an `@member`
-  mention that resolves to an agent. Read what the code _does_, not what it is
-  called. (`P-07`)
+- **The business probably models more than the surface shows.** Look for the
+  switched-off capability before you invent a new one — it is the highest-leverage
+  move available (`P-04`).
+- **Names lie.** A state called `paused` that means _pending review_; a `Project`
+  section that is a knowledge library; an `@member` that resolves to an agent.
+  Ask what a thing **obliges** or **produces**, never what it is called
+  (`P-01`, `P-03`).
 
-### Step 1 — Ground: reverse-engineer the current surface
+### Step 1 — Ground: establish the business model
 
-Before diagnosing anything, establish what is actually there. Delegate this —
-it is broad, read-only search, exactly what a subagent is for.
+Before diagnosing anything, find out what the business actually is. Delegate this
+— it is broad, read-only work.
 
-Produce, with `file:line` for every claim:
+Produce:
 
-- **What renders today** — the component tree, section by section.
-- **Where each section's data comes from** — service → tRPC → model → table.
-- **What the tables can actually produce** — every column, every enum value, not
-  just the ones the UI uses today. This is where the surprises live (`P-04`).
-- **Which canonical systems already exist** for the interactions you are likely
-  to need — status visuals, loading, approvals, comments (`P-02`).
+- **The concepts and states the business models** — all of them, not just the ones
+  the surface renders. This is where the surprises live (`P-04`).
+- **What each state obliges someone to do.** A state nobody must act on is not a
+  queue; a state a human is blocking is (`P-01`).
+- **What each action does to the business** — the event it produces, in domain
+  language. Not the mutation (`P-02`).
+- **Which concepts the business does _not_ have.** Absences are findings too, and
+  they are the expensive ones (`P-06`).
 
-Never skip to Step 2 on a mental model of the code. The mental model is wrong.
+The domain model is the evidence. Read it as a domain document — it is the most
+honest statement the company has made about what it believes exists.
+
+Never skip to Step 2 on a mental model of the product. The mental model is wrong;
+that is the entire premise of this skill.
 
 ### Step 2 — Diagnose: name the structural error
 
-A diagnosis is not "it looks dated". It must name a **structural** mistake —
-something that is wrong regardless of taste:
+A diagnosis is not "it looks dated". It must name something wrong **regardless of
+taste**:
 
-- The surface renders one enum value out of four, so a decision inbox reads as
-  an error log (`P-04`).
-- A button offers a state transition the data model does not have (`P-05`).
-- The page tries to be both a triage desk and a reading room, and fails at both
-  (`P-09`).
+- The surface shows one of four kinds of thing, so a decision inbox reads as an
+  error log (`P-04`).
+- A button promises a business event that does not exist (`P-05`).
+- The page is a triage desk and a reading room at once, and fails at both
+  (`P-07`).
 
-If you cannot name a structural error, you do not have a diagnosis yet — you
-have an opinion. Go back to Step 1.
+If you cannot name a structural error, you do not have a diagnosis — you have an
+opinion. Go back to Step 1.
 
 ### Step 3 — Align: walk the decision tree, one question at a time
 
-Do not present a finished solution. Surface the decisions that **change the
-shape of the answer**, one at a time, each with a recommendation and its
-reasoning. Settle upstream decisions before the downstream ones they constrain.
+Do not present a finished solution. Surface the decisions that **change the shape
+of the answer**, one at a time, each with a recommendation and its reasoning.
+Settle the upstream ones before the downstream ones they constrain.
 
-If a question can be answered by reading the code, **read the code** — never
-spend the user's turn on something a grep would settle.
-
-In this repo, the requirement-debate workflow itself is a separate skill
-(`battle`, cloud-side). This step is its design-facing counterpart: same rule,
-one question at a time, recommendation attached.
+If a question can be answered by grounding, **go and ground it** — never spend the
+user's turn on something the domain model already settles.
 
 ### Step 4 — Prototype against the real design system
 
 Use [design-prototype](../design-prototype/SKILL.md). A prototype in the real
 components with real tokens is the only honest way to argue about density and
-hierarchy — a picture of a design is not a design.
+hierarchy.
 
-Two rules that earn their keep:
+- **Mock data must be plausible.** Fake data hides the at-scale case.
+- **Show the non-happy path.** Empty, blocked, and 100× are where the design gets
+  decided.
+- **Tag anything the business cannot back with `NEW`, on the mock itself.** A
+  visible debt, not a silent lie.
 
-- **Mock data must be plausible.** Fake data hides overflow, truncation, and
-  the 100-parallel-runs case.
-- **Show the non-happy path.** Empty, error, and at-scale states are where the
-  design actually gets decided.
+Expect the first prototype to be wrong. That is its job — every correction is a
+Pattern Base entry.
 
-Expect the first prototype to be wrong in ways the code will tell you about.
-That is the point — every correction is a Pattern Base entry.
+### Step 5 — Scope: what does the business already support?
 
-### Step 5 — Scope: the three-bucket audit decides what ships
+Sort every capability the design needs:
 
-This is the step that turns a design into a plan. Sort every capability the
-design needs into exactly three buckets:
+| Bucket                                   | Meaning                                               |
+| ---------------------------------------- | ----------------------------------------------------- |
+| ✅ **Already modeled, already exposed**  | Rearranging what is there                             |
+| ⚠️ **Already modeled, not yet exposed**  | `P-04` territory — nearly free product                |
+| ❌ **Not a concept in the business yet** | A domain change. An order of magnitude more expensive |
 
-| Bucket                   | Meaning                                         | Cost      |
-| ------------------------ | ----------------------------------------------- | --------- |
-| ✅ **Available now**     | An existing query/endpoint already returns it   | zero      |
-| ⚠️ **Blocked by scope**  | The data exists but a predicate/select hides it | cheap     |
-| ❌ **Needs a new model** | No table, no column, no endpoint                | expensive |
+**Ship ✅ + ⚠️ first** (`P-10`). Not as a compromise — as a discipline. It forces
+the design to be honest about what the business is _today_, and it puts a real
+surface in front of users while the domain changes are still being argued about.
 
-Then **ship the subset that needs zero new tables first.** Not as a compromise —
-as a discipline. It forces the design to be honest about what is real, and it
-gets a working surface in front of users while the expensive parts are still
-being argued about (`P-07`).
-
-Anything in ❌ goes into the spec as an explicit **"not in this round, and here
-is exactly why"** — never silently dropped, or a reviewer will read it as an
-oversight.
+Every ❌ item goes into the spec **by name, with its cost** (`P-11`). Never
+silently dropped — silence reads as an oversight and gets re-litigated in review.
 
 ### Step 6 — Close the loop (mandatory)
 
-The session is not done when the PR is open. It is done when the system got
-smarter:
+The session is done when the **system** got smarter, not when the PR opened:
 
 1. **Write the reality-check log** into the spec (see
-   [trace-schema.md](references/trace-schema.md)): every assumption the code
-   overturned, with the `file:line` that overturned it.
-2. **For each overturned assumption the Pattern Base did not already predict**,
-   append a new pattern (`P-nn`) — symptom / the real example / how to detect it
-   next time.
-3. **Record the saturation signal.** If a whole grounding round overturned
-   _nothing_, say so in the spec: that surface's L1/L2 are mined out, and the
-   next round should spend its budget on L0 (intent) instead.
+   [trace-schema.md](references/trace-schema.md)): every assumption the business
+   overturned.
+2. **For each one the Pattern Base did not predict**, append a new pattern —
+   symptom / the real case / how to detect it next time. Check it against
+   [canon.md](references/canon.md) first: _is this an instance of something already
+   named, or genuinely new?_ Most of the time it is the former, and that is a good
+   outcome.
+3. **Record the saturation signal.** If a whole round overturned _nothing_, say
+   so: L1/L2 are mined out for that surface, and the next round belongs to L0.
 
-A design session that ships a feature but teaches the system nothing has done
-half the job.
+A session that ships a feature but teaches the system nothing has done half the
+job.
 
 ---
 
@@ -172,25 +186,28 @@ half the job.
 
 | Artifact              | Where                                                    | Template                                             |
 | --------------------- | -------------------------------------------------------- | ---------------------------------------------------- |
-| Design spec           | The repo's spec directory, `YYYY-MM-DD-<slug>-design.md` | [templates/design-spec.md](templates/design-spec.md) |
+| Design spec           | `YYYY-MM-DD-<slug>-design.md`                            | [templates/design-spec.md](templates/design-spec.md) |
 | Interactive prototype | Beside the spec                                          | via [design-prototype](../design-prototype/SKILL.md) |
 | Reality-check log     | A section **inside** the spec                            | [trace-schema.md](references/trace-schema.md)        |
 | New patterns          | [references/pattern-base.md](references/pattern-base.md) | append                                               |
 
 ## Anti-patterns
 
-- **Designing from the screenshot.** The screenshot shows what renders, not what
-  the data could render. Read the schema.
+- **Designing from the screenshot.** It shows what renders, not what the business
+  models.
 - **Proposing a solution before the diagnosis names a structural error.**
-- **Inventing a second way to do something the codebase already does once.**
-- **Dumping every open question at once**, or asking things a grep answers.
-- **Making the scope call on taste** instead of the three-bucket audit.
-- **Shipping and not writing back.** The next session then re-learns the same
-  lesson from scratch.
+- **Reading a state or an action by its name** instead of by what it obliges or
+  produces.
+- **Letting a missing concept masquerade as a layout problem** (`P-06`).
+- **Dumping every open question at once**, or asking things the domain model
+  already answers.
+- **Letting engineering findings into the Pattern Base.** They are true and they
+  belong somewhere else.
+- **Shipping and not writing back.** The next session re-learns it all.
 
 ## Worked example
 
-[references/worked-example.md](references/worked-example.md) — a full trace of
-one real session: a home surface that rendered one brief type out of four, the
-assumptions the code overturned along the way, and the shipped subset that
-needed zero new tables.
+[references/worked-example.md](references/worked-example.md) — a full trace of one
+real session: a surface that showed one of four kinds of agent message, the
+assumptions the business overturned, and the subset that shipped because the
+domain already supported it.

--- a/.agents/skills/product-design/SKILL.md
+++ b/.agents/skills/product-design/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: product-design
+description: 'Turn a vague product ask ("this page feels wrong", "we need a team view") into a grounded, shippable design — by reverse-engineering what the code can actually do before proposing anything. Use when scoping a new surface, redesigning an existing one, or deciding what a feature should even be. Not for auditing a built screen (that is ux-audit) or for picking spacing and color (that is ux).'
+argument-hint: '<surface or product ask>'
+---
+
+# Product Design
+
+The upstream half of design: **deciding what to build and why**, before anyone
+argues about spacing.
+
+Its one non-negotiable rule:
+
+> **Never propose from imagination. Reverse-engineer the code first.**
+
+Every expensive mistake this skill exists to prevent has the same shape — a
+designer (human or agent) invented something the codebase already had, or
+designed an affordance for data that does not exist. Both look completely
+reasonable on a slide and fall apart the moment someone tries to build them.
+
+## Where this sits
+
+| Skill                            | Question it answers                      | When                     |
+| -------------------------------- | ---------------------------------------- | ------------------------ |
+| **product-design** (this)        | What should this surface _be_, and why?  | Before there is a design |
+| [ux](../ux/SKILL.md)             | How should it feel? What are the rules?  | While building           |
+| [ux-audit](../ux-audit/SKILL.md) | Does the built screen honor those rules? | After it exists          |
+
+`ux` is the **rulebook**, `ux-audit` **enforces** it on a finished surface, and
+this skill decides **what surface to build at all**. Don't reach for it to fix a
+button's padding.
+
+## SCLPT — why this skill gets better over time
+
+This is a self-evolving system, wired as SCLPT (see the framework doc in Linear,
+BM-58). The five elements are not decoration; each maps to a file you must
+actually read and write:
+
+| Element            | Here                                                     | What it does                                                                        |
+| ------------------ | -------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| **T** Trace Schema | [references/trace-schema.md](references/trace-schema.md) | Every session leaves a **reality-check log**: assumption → code fact → who won      |
+| **L** Layer Model  | [references/layer-model.md](references/layer-model.md)   | L0 intent / L1 data / L2 contract / L3 presentation — stops cross-layer misjudgment |
+| **P** Pattern Base | [references/pattern-base.md](references/pattern-base.md) | The learned rules. **Read before every run. Append after every run.**               |
+| **C** Closed Loop  | Step 6 below                                             | Every assumption the code overturned becomes a new pattern                          |
+| **S** Saturation   | Step 6 below                                             | A round where the code overturns **nothing** = L1/L2 are mined out                  |
+
+**The loop in one line:** the reality-check log (T) is sorted by layer (L),
+compared against the pattern base (P); whatever the code overturned that the
+pattern base did not predict is a new gap, which gets written back (C); when a
+grounding round produces zero new gaps, that surface is saturated (S).
+
+---
+
+## The workflow
+
+### Step 0 — Read the Pattern Base (mandatory, every run)
+
+Read [references/pattern-base.md](references/pattern-base.md) and
+[references/layer-model.md](references/layer-model.md) **in full** before
+touching the product ask. They are the accumulated "you already got this wrong
+once" list. Skipping them is how the same mistake ships twice.
+
+Two that keep biting, up front:
+
+- **The codebase probably already has it.** Status glyphs, loading spinners,
+  approval flows, comment inputs — before designing one, grep for the canonical
+  implementation. (`P-01`…`P-03`)
+- **Names lie.** A `Project` group that renders a knowledge base; an `@member`
+  mention that resolves to an agent. Read what the code _does_, not what it is
+  called. (`P-07`)
+
+### Step 1 — Ground: reverse-engineer the current surface
+
+Before diagnosing anything, establish what is actually there. Delegate this —
+it is broad, read-only search, exactly what a subagent is for.
+
+Produce, with `file:line` for every claim:
+
+- **What renders today** — the component tree, section by section.
+- **Where each section's data comes from** — service → tRPC → model → table.
+- **What the tables can actually produce** — every column, every enum value, not
+  just the ones the UI uses today. This is where the surprises live (`P-04`).
+- **Which canonical systems already exist** for the interactions you are likely
+  to need — status visuals, loading, approvals, comments (`P-02`).
+
+Never skip to Step 2 on a mental model of the code. The mental model is wrong.
+
+### Step 2 — Diagnose: name the structural error
+
+A diagnosis is not "it looks dated". It must name a **structural** mistake —
+something that is wrong regardless of taste:
+
+- The surface renders one enum value out of four, so a decision inbox reads as
+  an error log (`P-04`).
+- A button offers a state transition the data model does not have (`P-05`).
+- The page tries to be both a triage desk and a reading room, and fails at both
+  (`P-09`).
+
+If you cannot name a structural error, you do not have a diagnosis yet — you
+have an opinion. Go back to Step 1.
+
+### Step 3 — Align: walk the decision tree, one question at a time
+
+Do not present a finished solution. Surface the decisions that **change the
+shape of the answer**, one at a time, each with a recommendation and its
+reasoning. Settle upstream decisions before the downstream ones they constrain.
+
+If a question can be answered by reading the code, **read the code** — never
+spend the user's turn on something a grep would settle.
+
+In this repo, the requirement-debate workflow itself is a separate skill
+(`battle`, cloud-side). This step is its design-facing counterpart: same rule,
+one question at a time, recommendation attached.
+
+### Step 4 — Prototype against the real design system
+
+Use [design-prototype](../design-prototype/SKILL.md). A prototype in the real
+components with real tokens is the only honest way to argue about density and
+hierarchy — a picture of a design is not a design.
+
+Two rules that earn their keep:
+
+- **Mock data must be plausible.** Fake data hides overflow, truncation, and
+  the 100-parallel-runs case.
+- **Show the non-happy path.** Empty, error, and at-scale states are where the
+  design actually gets decided.
+
+Expect the first prototype to be wrong in ways the code will tell you about.
+That is the point — every correction is a Pattern Base entry.
+
+### Step 5 — Scope: the three-bucket audit decides what ships
+
+This is the step that turns a design into a plan. Sort every capability the
+design needs into exactly three buckets:
+
+| Bucket                   | Meaning                                         | Cost      |
+| ------------------------ | ----------------------------------------------- | --------- |
+| ✅ **Available now**     | An existing query/endpoint already returns it   | zero      |
+| ⚠️ **Blocked by scope**  | The data exists but a predicate/select hides it | cheap     |
+| ❌ **Needs a new model** | No table, no column, no endpoint                | expensive |
+
+Then **ship the subset that needs zero new tables first.** Not as a compromise —
+as a discipline. It forces the design to be honest about what is real, and it
+gets a working surface in front of users while the expensive parts are still
+being argued about (`P-07`).
+
+Anything in ❌ goes into the spec as an explicit **"not in this round, and here
+is exactly why"** — never silently dropped, or a reviewer will read it as an
+oversight.
+
+### Step 6 — Close the loop (mandatory)
+
+The session is not done when the PR is open. It is done when the system got
+smarter:
+
+1. **Write the reality-check log** into the spec (see
+   [trace-schema.md](references/trace-schema.md)): every assumption the code
+   overturned, with the `file:line` that overturned it.
+2. **For each overturned assumption the Pattern Base did not already predict**,
+   append a new pattern (`P-nn`) — symptom / the real example / how to detect it
+   next time.
+3. **Record the saturation signal.** If a whole grounding round overturned
+   _nothing_, say so in the spec: that surface's L1/L2 are mined out, and the
+   next round should spend its budget on L0 (intent) instead.
+
+A design session that ships a feature but teaches the system nothing has done
+half the job.
+
+---
+
+## Deliverables
+
+| Artifact              | Where                                                    | Template                                             |
+| --------------------- | -------------------------------------------------------- | ---------------------------------------------------- |
+| Design spec           | The repo's spec directory, `YYYY-MM-DD-<slug>-design.md` | [templates/design-spec.md](templates/design-spec.md) |
+| Interactive prototype | Beside the spec                                          | via [design-prototype](../design-prototype/SKILL.md) |
+| Reality-check log     | A section **inside** the spec                            | [trace-schema.md](references/trace-schema.md)        |
+| New patterns          | [references/pattern-base.md](references/pattern-base.md) | append                                               |
+
+## Anti-patterns
+
+- **Designing from the screenshot.** The screenshot shows what renders, not what
+  the data could render. Read the schema.
+- **Proposing a solution before the diagnosis names a structural error.**
+- **Inventing a second way to do something the codebase already does once.**
+- **Dumping every open question at once**, or asking things a grep answers.
+- **Making the scope call on taste** instead of the three-bucket audit.
+- **Shipping and not writing back.** The next session then re-learns the same
+  lesson from scratch.
+
+## Worked example
+
+[references/worked-example.md](references/worked-example.md) — a full trace of
+one real session: a home surface that rendered one brief type out of four, the
+assumptions the code overturned along the way, and the shipped subset that
+needed zero new tables.

--- a/.agents/skills/product-design/references/canon.md
+++ b/.agents/skills/product-design/references/canon.md
@@ -1,118 +1,86 @@
 # Canon
 
 A Pattern Base without an external benchmark drifts into a list of _"things that
-happened to us"_. This file is the benchmark: the small set of works that already
-named most of what we keep rediscovering, plus an honest account of what they do
-**not** cover.
+happened to us"_. This file is the benchmark.
 
-Every new pattern must answer one question first:
+Every new pattern must answer one question before it is written down:
 
 > **Is this an instance of something the canon already named, or is it genuinely
 > new?**
 
-Most of the time the answer is _"already named"_. That is a good outcome — the
-pattern gets an anchor, and the Pattern Base stays a **judgment system** instead
-of a diary.
+**Almost always it is an instance.** That is the correct and useful outcome — the
+pattern gets an anchor, and the Pattern Base stays a **judgment system** rather
+than a diary.
+
+The division of labour:
+
+|                      | Gives you                                                                                              |
+| -------------------- | ------------------------------------------------------------------------------------------------------ |
+| **The canon**        | The theory. Why the failure happens, in any product                                                    |
+| **The Pattern Base** | The instances. What it looks like **in this product**, in our vocabulary, with the case that taught us |
+
+Neither replaces the other. A pattern with no canonical anchor is usually not a
+discovery — it is a pattern that has not been thought about hard enough.
 
 ---
 
 ## The primary text — Cooper, _About Face_
 
-**Why it is the spine**: Cooper's three-model frame is the axis every Class A and
-Class B pattern runs on.
+**It supplies our layer model outright.** The three models
+([layer-model.md](layer-model.md)) are his, unmodified, because after twenty-five
+years they are still the sharpest available frame for what goes wrong:
 
-| Cooper's model           | In our language                                                |
-| ------------------------ | -------------------------------------------------------------- |
-| **Implementation model** | What the product actually models: its concepts, states, events |
-| **Represented model**    | What the surface claims the business is                        |
-| **Mental model**         | What the user believes it is                                   |
+- **Implementation model** — how the product actually works
+- **Represented model** — what the interface claims it is
+- **Mental model** — what the user believes it is
 
-Cooper's central diagnosis — **the implementation model leaking into the
-represented model** — is what `P-05` (an affordance for a business event that
-does not exist) and `P-01`/`P-02` (a state or action surfaced by its machine name
-rather than its business meaning) are instances of.
+And the goal, which is the entire job compressed into one sentence:
 
-His **"dancing bear"** — software that is remarkable for working at all, and
-miserable to use — is what a surface becomes when it is organized by what the
-system produced rather than by what the user must do (`P-09`).
+> **The represented model should be as close to the mental model as possible, and
+> as far from the implementation model as necessary.**
 
-**Read it for**: goal-directed design; why the user's goal is not the same as
-their task; why the represented model must be built from the business's meaning,
-never from its mechanism.
+Every pattern in Classes A and B is a failure to hold that line. Cooper's
+**"dancing bear"** — software remarkable for working at all, and miserable to use
+— is what a surface becomes when it is organized around what the system produced
+rather than around what the user must do (`P-09`).
+
+**Read it for**: goal-directed design; why a user's goal is not their task; why
+the represented model must be authored from meaning, never derived from mechanism.
 
 ## For scope — Singer, _Shape Up_
 
-**Why**: Class D is Shape Up wearing different words.
+Class D is Shape Up wearing different words.
 
-| Shape Up            | In our language                                                                        |
-| ------------------- | -------------------------------------------------------------------------------------- |
-| **Appetite**        | Decide the budget before the solution, not after (`P-10`)                              |
-| **Breadboarding**   | Design at the level of affordances and connections before pixels — our L0→L2 before L3 |
-| **Rabbit hole**     | The ❌ bucket: a capability the business does not model yet (`P-10`, `P-11`)           |
-| **Circuit breaker** | Name what you are not building, and stop (`P-11`)                                      |
+| Shape Up            | Here                                                                      |
+| ------------------- | ------------------------------------------------------------------------- |
+| **Appetite**        | Decide the budget before the solution, not after (`P-10`)                 |
+| **Breadboarding**   | Design at the level of affordances and connections before pixels          |
+| **Rabbit hole**     | A capability the product does not model yet — priced accordingly (`P-10`) |
+| **Circuit breaker** | Name what you are not building, and stop (`P-11`)                         |
 
-**Read it for**: why "what can we build with the appetite we have" is a better
-question than "what is the right solution", and why a fat-marker sketch beats a
-polished mock when the concept is still moving.
+**Read it for**: why _"what can we build with the appetite we have"_ is a better
+question than _"what is the right solution"_.
 
-## For intent — Jobs-to-be-Done
+## For the mental model — Jobs-to-be-Done
 
-**Why**: L0 is the one layer no amount of grounding can answer, and it is the
-layer this skill is weakest at. JTBD is the sharpest available tool for it:
-_what job is the user hiring this surface to do, in what circumstance?_
+The mental model is the one layer no amount of grounding can reach, and it is
+where this skill is weakest. JTBD is the sharpest tool available for it: _what
+job is the user hiring this surface to do, in what circumstance?_
 
-The lever it gives us is **the circumstance**, not the persona. "A manager"
-explains nothing; "someone opening the app at 9am to find out whether anything
-broke overnight" explains the entire information architecture — and immediately
-kills the dashboard (`P-07`).
+The lever it gives is **the circumstance**, not the persona. "A manager" explains
+nothing. "Someone opening the app at 9am to find out whether anything broke
+overnight" explains an entire information architecture — and immediately kills the
+dashboard (`P-07`).
 
-**Read it for**: how to interrogate an L0 claim instead of asserting it.
+**Read it for**: how to interrogate a claim about what users want, instead of
+asserting it from a schema.
 
 ## For presentation — Tidwell, _Designing Interfaces_
 
 Already the benchmark of the [`ux`](../../ux/SKILL.md) skill, and it stays there.
-L3 questions — density, hierarchy, patterns — belong to `ux` and `ux-audit`.
-**This skill should not re-derive them.** If a finding is about how something
-looks rather than what it means, it is in the wrong file.
-
----
-
-## What the canon does **not** cover
-
-Two things we keep hitting that no canonical text names. These are the Pattern
-Base's actual contribution, and they should be defended as such.
-
-### 1. The inverse leak — the represented model _under_-exposing the business
-
-Cooper documented the leak in one direction: implementation detail escaping into
-the interface. **We keep finding the opposite**: a business that models far more
-than its surface admits.
-
-The clearest case (`P-04`): a product modeled four kinds of agent-to-human
-message — a decision to rule on, a deliverable to accept, an insight to note, an
-error to fix — produced all four in production every day, and **rendered only the
-errors**. The team had been designing "a better error list" for a surface that
-was, in the domain, a decision inbox with three channels switched off.
-
-Nobody wrote this one down because in the era the canon was written, **the
-business model was small and the interface was where the ideas lived**. That has
-inverted. In a system where autonomous agents generate business events
-continuously, the domain routinely outruns the interface — and _finding the
-unexposed capability is now the highest-leverage act in product design._
-
-**This is why the Step-1 grounding pass exists**, and why it reads the domain
-rather than the screen.
-
-### 2. A missing concept is not a missing widget
-
-`P-06`: when the business has no notion of _who this belongs to_ or _who has seen
-it_, the corresponding feature is not a design decision that could have been made
-more tastefully. It is a **domain change**, an order of magnitude more expensive,
-and it must be priced as one.
-
-The canon assumes the domain is a given and design happens on top of it. When
-design and domain are being decided in the same room — which is the normal case
-now — the skill needs a rule for telling them apart. That rule is `P-06`.
+Density, hierarchy, interface patterns — those questions belong to `ux` and
+`ux-audit`. **This skill should not re-derive them.** If a finding is about how
+something _looks_ rather than what it _means_, it is in the wrong file.
 
 ---
 
@@ -120,8 +88,9 @@ now — the skill needs a rule for telling them apart. That rule is `P-06`.
 
 **Software-engineering patterns do not belong in this canon, or in the Pattern
 Base.** Component reuse, refactor hazards, framework conventions — all real, all
-important, all a different discipline. A pattern earns its place here only if it
-survives this test:
+important, all a different discipline.
+
+The test:
 
 > Strip out every framework, table and component name. **Is there still a product
 > insight left?**

--- a/.agents/skills/product-design/references/canon.md
+++ b/.agents/skills/product-design/references/canon.md
@@ -1,0 +1,130 @@
+# Canon
+
+A Pattern Base without an external benchmark drifts into a list of _"things that
+happened to us"_. This file is the benchmark: the small set of works that already
+named most of what we keep rediscovering, plus an honest account of what they do
+**not** cover.
+
+Every new pattern must answer one question first:
+
+> **Is this an instance of something the canon already named, or is it genuinely
+> new?**
+
+Most of the time the answer is _"already named"_. That is a good outcome — the
+pattern gets an anchor, and the Pattern Base stays a **judgment system** instead
+of a diary.
+
+---
+
+## The primary text — Cooper, _About Face_
+
+**Why it is the spine**: Cooper's three-model frame is the axis every Class A and
+Class B pattern runs on.
+
+| Cooper's model           | In our language                                                |
+| ------------------------ | -------------------------------------------------------------- |
+| **Implementation model** | What the product actually models: its concepts, states, events |
+| **Represented model**    | What the surface claims the business is                        |
+| **Mental model**         | What the user believes it is                                   |
+
+Cooper's central diagnosis — **the implementation model leaking into the
+represented model** — is what `P-05` (an affordance for a business event that
+does not exist) and `P-01`/`P-02` (a state or action surfaced by its machine name
+rather than its business meaning) are instances of.
+
+His **"dancing bear"** — software that is remarkable for working at all, and
+miserable to use — is what a surface becomes when it is organized by what the
+system produced rather than by what the user must do (`P-09`).
+
+**Read it for**: goal-directed design; why the user's goal is not the same as
+their task; why the represented model must be built from the business's meaning,
+never from its mechanism.
+
+## For scope — Singer, _Shape Up_
+
+**Why**: Class D is Shape Up wearing different words.
+
+| Shape Up            | In our language                                                                        |
+| ------------------- | -------------------------------------------------------------------------------------- |
+| **Appetite**        | Decide the budget before the solution, not after (`P-10`)                              |
+| **Breadboarding**   | Design at the level of affordances and connections before pixels — our L0→L2 before L3 |
+| **Rabbit hole**     | The ❌ bucket: a capability the business does not model yet (`P-10`, `P-11`)           |
+| **Circuit breaker** | Name what you are not building, and stop (`P-11`)                                      |
+
+**Read it for**: why "what can we build with the appetite we have" is a better
+question than "what is the right solution", and why a fat-marker sketch beats a
+polished mock when the concept is still moving.
+
+## For intent — Jobs-to-be-Done
+
+**Why**: L0 is the one layer no amount of grounding can answer, and it is the
+layer this skill is weakest at. JTBD is the sharpest available tool for it:
+_what job is the user hiring this surface to do, in what circumstance?_
+
+The lever it gives us is **the circumstance**, not the persona. "A manager"
+explains nothing; "someone opening the app at 9am to find out whether anything
+broke overnight" explains the entire information architecture — and immediately
+kills the dashboard (`P-07`).
+
+**Read it for**: how to interrogate an L0 claim instead of asserting it.
+
+## For presentation — Tidwell, _Designing Interfaces_
+
+Already the benchmark of the [`ux`](../../ux/SKILL.md) skill, and it stays there.
+L3 questions — density, hierarchy, patterns — belong to `ux` and `ux-audit`.
+**This skill should not re-derive them.** If a finding is about how something
+looks rather than what it means, it is in the wrong file.
+
+---
+
+## What the canon does **not** cover
+
+Two things we keep hitting that no canonical text names. These are the Pattern
+Base's actual contribution, and they should be defended as such.
+
+### 1. The inverse leak — the represented model _under_-exposing the business
+
+Cooper documented the leak in one direction: implementation detail escaping into
+the interface. **We keep finding the opposite**: a business that models far more
+than its surface admits.
+
+The clearest case (`P-04`): a product modeled four kinds of agent-to-human
+message — a decision to rule on, a deliverable to accept, an insight to note, an
+error to fix — produced all four in production every day, and **rendered only the
+errors**. The team had been designing "a better error list" for a surface that
+was, in the domain, a decision inbox with three channels switched off.
+
+Nobody wrote this one down because in the era the canon was written, **the
+business model was small and the interface was where the ideas lived**. That has
+inverted. In a system where autonomous agents generate business events
+continuously, the domain routinely outruns the interface — and _finding the
+unexposed capability is now the highest-leverage act in product design._
+
+**This is why the Step-1 grounding pass exists**, and why it reads the domain
+rather than the screen.
+
+### 2. A missing concept is not a missing widget
+
+`P-06`: when the business has no notion of _who this belongs to_ or _who has seen
+it_, the corresponding feature is not a design decision that could have been made
+more tastefully. It is a **domain change**, an order of magnitude more expensive,
+and it must be priced as one.
+
+The canon assumes the domain is a given and design happens on top of it. When
+design and domain are being decided in the same room — which is the normal case
+now — the skill needs a rule for telling them apart. That rule is `P-06`.
+
+---
+
+## Explicitly out of scope
+
+**Software-engineering patterns do not belong in this canon, or in the Pattern
+Base.** Component reuse, refactor hazards, framework conventions — all real, all
+important, all a different discipline. A pattern earns its place here only if it
+survives this test:
+
+> Strip out every framework, table and component name. **Is there still a product
+> insight left?**
+
+If not, it is an engineering note wearing a design costume, and it belongs in the
+engineering skills.

--- a/.agents/skills/product-design/references/layer-model.md
+++ b/.agents/skills/product-design/references/layer-model.md
@@ -1,127 +1,123 @@
-# Layer Model
+# Layer Model — the three models
 
-The **L** of SCLPT. Four layers, each with its own kind of evidence and its own
-authority. The point is not taxonomy — it is that **a claim from one layer cannot
-settle a question in another**, and mixing them is how a design session produces
-confident nonsense.
+The **L** of SCLPT. We do not invent a layer model; Cooper already wrote the
+right one, and it has held up for twenty-five years.
 
-| Layer                 | Question                                                      | Evidence                                    | Who decides                                         |
-| --------------------- | ------------------------------------------------------------- | ------------------------------------------- | --------------------------------------------------- |
-| **L0 Scenario**       | Who, in what circumstance, is hiring this surface to do what? | The user's words; the job to be done        | **The human.** No amount of grounding answers this. |
-| **L1 Business nouns** | What concepts, states and roles does the business _have_?     | The domain model, read as a domain document | **The business.** Not negotiable.                   |
-| **L2 Business verbs** | What does each action actually _do to the business_?          | The events an action produces               | **The business.** Not negotiable.                   |
-| **L3 Representation** | How is it shown — density, hierarchy, form?                   | The rendered prototype                      | Design judgment, inside L1/L2's limits              |
+| Model                    | What it is                                                                    | The evidence for it                  | Who has authority                                       |
+| ------------------------ | ----------------------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------- |
+| **Implementation model** | How the product **actually works**: its concepts, states, events, obligations | The domain model, the state machines | **The system.** Not arguable.                           |
+| **Represented model**    | What the interface **claims** the product is                                  | The surface; the prototype           | **Design.** This is the only one we author.             |
+| **Mental model**         | What the user **believes** it is                                              | What users say and do                | **The user.** It cannot be inferred from the other two. |
 
-**L1 is nouns and states. L2 is verbs and consequences.** They are separated
-because they fail differently: L1 failures are _"the concept isn't there"_
-(`P-06`), L2 failures are _"the button doesn't do what it says"_ (`P-02`, `P-05`).
+And Cooper's goal, which is the whole job in one line:
 
-## Where L1 and L2 are written down
+> **The represented model should be as close to the mental model as possible, and
+> as far from the implementation model as necessary.**
 
-In the schema, the state machines, the events.
+Every pattern in the Pattern Base is a failure to hold that line.
 
-**Not because implementation matters** — this skill has nothing to say about
-implementation. Because **that is the most honest statement the company has ever
-made about its own domain.** Marketing copy is aspirational; roadmaps are
-aspirational; the schema is what the business _actually_ believes exists. Read it
-as a domain document.
+## Where the implementation model is written down
 
-The corollary is a filter: if a fact you dug up carries no business meaning —
-which component renders the spinner, how a module is wired — **it is not an L1 or
-L2 finding at all.** It is engineering trivia, and it does not enter this system.
+In the domain model — the concepts, the states, the events.
 
-## The rule
+**Not because implementation matters.** This skill has nothing to say about how
+software is built. Because that is **the most honest statement the company has
+ever made about what it believes exists**. Marketing copy is aspirational;
+roadmaps are aspirational; the domain model is what the product _actually_
+commits to. Read it as a domain document.
 
-> **Never answer an L1 or L2 question with an L3 argument, and never answer an L0
-> question with either.**
+The corollary is a filter: a fact that carries **no business meaning** — which
+component draws the spinner, how a module is wired — **is not a finding about the
+implementation model at all.** It is a fact about the _code_, which is a different
+thing entirely, and it does not enter this system.
 
-Concretely:
+## Cross-model misjudgment — the four that actually happen
 
-- _"This button would feel natural here"_ (L3) does **not** establish that the
-  business event exists (L2). That is exactly how a fake affordance ships
-  (`P-05`).
-- _"The business has no project concept"_ (L1) does **not** settle whether the
-  product _needs_ one (L0). It settles the **cost**, and hands the decision back
-  to the human.
-- _"The state is called `paused`"_ is not an L1 finding at all — it is a word.
-  The L1 finding is **what that state obliges someone to do** (`P-01`).
+This is what the layer model is _for_. Each one is a specific way of using
+evidence from one model to settle a question that belongs to another.
 
-## Cross-layer misjudgment — the four that actually happen
+### 1. Inferring the implementation model from the represented model
 
-### 1. Designing an L3 affordance on top of an L1/L2 that does not exist
+**"The surface doesn't show it, so the product must not do it."**
 
-The most common and most expensive. The mock looks great; the business cannot
-back it. All of **Class B** is this.
+The most costly, and the most invisible — because it feels like observation, not
+inference. A surface showed only agent errors, so the whole team reasoned about
+it as an error log. The product in fact modeled four kinds of agent-to-human
+message and produced all four daily; three had simply never been surfaced.
 
-**Guard**: for every element in the prototype, name the business concept or event
-behind it. If you cannot, mark it `NEW` **on the mock itself** — a visible debt,
-not a silent lie.
+There is nothing profound about _why_ — the scenarios were designed and built
+before the interface caught up, which is ordinary. What is not ordinary is how
+completely the team's model of the product was formed by looking at the screen.
 
-### 2. Reading a state or action by its name instead of its meaning
+**Guard**: never read the surface as evidence about the product. Ground the
+implementation model directly, every time (`P-04`).
 
-`paused` sounds like "suspended" and means "a human is blocking the agent".
-"Request changes" sounds like a comment and means "re-task the agent". Every
-design built on the word instead of the meaning is a design for a different
-product. All of **Class A** is this.
+### 2. Building the represented model out of the implementation model
 
-**Guard**: for every state, _what does it oblige someone to do?_ For every
-action, _after this click, the business is now …?_ If you cannot finish either
-sentence, you have not grounded it.
+Cooper's central disease. The interface mirrors the machine: it inherits the
+machine's vocabulary (`paused`, which actually means _a human is blocking an
+agent_), its groupings (by producing entity, not by required action), and its
+shape.
 
-### 3. Letting L1 quietly veto L0
+**Guard**: the represented model is authored, not derived. For every state, ask
+what it **obliges someone to do**; for every action, what it **produces**. Design
+from that, not from the name (`P-01`, `P-02`, `P-09`).
 
-The business does not model the concept, so the design silently drops the
-requirement. The product has now been decided by the schema — which is exactly
-backwards.
+### 3. Representing something the implementation model does not have
 
-**Guard**: L1 reports **cost**, never verdicts. A missing concept goes into the
-spec as _"the business does not model X; adding it costs Y"_ (`P-11`), and the
-human decides whether Y is worth paying. Dropping it in silence is the design
-equivalent of swallowing an exception.
+The mirror image of #2, and it ships as theatre: an "Accept task" button on work
+that was already, unilaterally, assigned to you. The affordance implies a choice
+the product does not model.
 
-### 4. Answering L0 from the screenshot
+**Guard**: for every element, name the business event behind it. If you cannot,
+mark it `NEW` **on the prototype itself** — a visible debt, not a silent lie
+(`P-05`, `P-06`).
 
-The surface shows what is rendered; it says nothing about who needs what, or
-when. A redesign that starts from _"this looks dated"_ has skipped L0 entirely,
-and will optimize the wrong thing beautifully.
+### 4. Inferring the mental model from either of the other two
 
-**Guard**: the diagnosis must be **structural**. _"It looks dated"_ is not one.
-_"It shows one of four message kinds, so a decision inbox reads as an error log"_
-is.
+**The one nobody notices they are doing.**
 
-## Which layer is a given finding from?
+"The product models four kinds of message, so users think in four kinds." No.
+"The surface has always been an error log, so that is what users expect." No. The
+mental model is the only one that **cannot be grounded** — not in the domain, not
+in the screen. It comes from the user, and from nowhere else.
 
-The tag decides what you may do with it.
+**Guard**: a claim about what users believe or want is a **claim**, and it must
+be argued or observed — never asserted from a schema or a screenshot. When the
+work has produced zero findings about the mental model, **say so**; that is not a
+clean bill of health, it is an unexamined layer.
 
-| Finding                                                                  | Layer | What it licenses                                       |
-| ------------------------------------------------------------------------ | ----- | ------------------------------------------------------ |
-| "The business models four kinds of agent message; the surface shows one" | L1    | A scope opportunity — and probably the whole redesign  |
-| "`paused` obliges a human to review, not to wait"                        | L1    | A queue, not a 'later' bucket                          |
-| "'Request changes' re-tasks the agent; it is not a comment"              | L2    | Design a re-tasking, not a comment box                 |
-| "There is no 'offered, pending acceptance' state for assigned work"      | L2    | Kill the Accept button. It is theatre.                 |
-| "Conversations have no notion of belonging to a member"                  | L1    | A **red line** — this is a domain change, not a layout |
-| "The summary is too long to scan, too short to replace the document"     | L3    | A density decision — inside L1/L2's limits             |
-| "Nobody opens a dashboard twice"                                         | L0    | A product judgment — argue it, don't assert it         |
-| "This spinner is implemented as an SVG animation"                        | —     | **Not a finding.** No business meaning. Discard.       |
+## Tagging a finding
 
-That last row is the filter. Most things you can learn from a codebase are not
-product findings, and letting them in is how a Pattern Base turns into a
-changelog.
+Every row in the [reality-check log](trace-schema.md) is tagged with the model it
+is a fact about. The tag decides what the finding licenses.
 
-## Saturation, per layer
+| Finding                                                                 | Model          | What it licenses                                      |
+| ----------------------------------------------------------------------- | -------------- | ----------------------------------------------------- |
+| "The product models four kinds of agent message; the surface shows one" | implementation | A scope opportunity — possibly the whole redesign     |
+| "`paused` obliges a human to review; it does not mean 'suspended'"      | implementation | A queue, not a 'later' bucket                         |
+| "'Request changes' re-tasks the agent; it is not a comment"             | implementation | Design a re-tasking, not a comment box                |
+| "There is no 'offered, pending acceptance' state"                       | implementation | Kill the Accept button. It is theatre.                |
+| "Conversations have no notion of belonging to a person"                 | implementation | A **red line** — a domain change, not a layout choice |
+| "The summary is too long to scan, too short to replace the document"    | represented    | A density decision                                    |
+| "Nobody opens a dashboard twice"                                        | **mental**     | A claim. Argue it or observe it — never assert it.    |
+| "This spinner is drawn with an SVG animation"                           | —              | **Not a finding.** No business meaning. Discard.      |
 
-Saturation (**S**) is measured **per layer**, and they saturate at different
+The last row is the filter. Most of what you can learn from a codebase is not a
+product finding, and letting it in is how a Pattern Base turns into a changelog.
+
+## Saturation, per model
+
+Saturation (**S**) is measured per model, and they saturate at very different
 speeds:
 
-- **L1 / L2 saturate fast.** One thorough pass over a domain usually surfaces most
-  of what it models. When a second pass overturns nothing, they are mined out —
-  stop spending budget there.
-- **L3 saturates per iteration.** Each prototype round should produce fewer
-  corrections than the last. If round 3 produces as many as round 1, the problem
-  is upstream: L1 or L2 was never actually grounded.
-- **L0 never saturates.** Intent changes when the business changes. A quiet L0 is
-  not a solved L0 — it is an unexamined one.
-
-**The signal to record** (Step 6): _"this round's grounding overturned zero
-assumptions"_ — L1/L2 are done for this surface, and the next round's budget
-belongs to L0.
+- **The implementation model saturates fast.** One thorough grounding pass usually
+  surfaces most of what the product models. When a second pass overturns nothing,
+  it is mined out — stop spending budget there.
+- **The represented model saturates per iteration.** Each prototype round should
+  produce fewer corrections than the last. If round three produces as many as
+  round one, the problem is upstream: the implementation model was never actually
+  grounded.
+- **The mental model never saturates**, and it is the one this skill is weakest at.
+  Grounding cannot touch it. A session with zero mental-model findings has not
+  finished — it has only done the half that could be done from a desk.

--- a/.agents/skills/product-design/references/layer-model.md
+++ b/.agents/skills/product-design/references/layer-model.md
@@ -1,0 +1,102 @@
+# Layer Model
+
+The **L** of SCLPT. Four layers, each with its own kind of evidence and its own
+authority. The point is not taxonomy — it is that **a claim from one layer
+cannot settle a question in another**, and mixing them is how a design session
+produces confident nonsense.
+
+| Layer                       | Question                                    | Evidence                                     | Who decides                                       |
+| --------------------------- | ------------------------------------------- | -------------------------------------------- | ------------------------------------------------- |
+| **L0 Intent**               | Who, in what moment, needs what?            | The user's words; the scenario               | **Product / the human.** Code cannot answer this. |
+| **L1 Data Capability**      | What can the system actually produce today? | Schema, model, router — `file:line`          | **The code.** Not negotiable.                     |
+| **L2 Interaction Contract** | How does this product already do this?      | Canonical components, status maps, semantics | **The code.** Not negotiable.                     |
+| **L3 Presentation**         | Density, hierarchy, tokens, motion          | The rendered prototype                       | Design taste, inside L1/L2 limits                 |
+
+## The rule
+
+> **Never answer an L1 or L2 question with an L3 argument, and never answer an
+> L0 question with either.**
+
+Concretely:
+
+- "This button would feel natural here" (L3) does **not** establish that the
+  state transition exists (L1). See `P-05` — that is exactly how a fake action
+  ships.
+- "Our approval card should be two clean buttons" (L3) does **not** override the
+  fact that approval is already a numbered radio list with digit shortcuts (L2).
+  See `P-02`.
+- "The code has no `projects` table" (L1) does **not** settle whether the product
+  _needs_ a project concept (L0). It settles the **cost**, and hands the decision
+  back to the human.
+
+## Cross-layer misjudgment — the four that actually happen
+
+### 1. Designing an L3 affordance on top of L1 that does not exist
+
+The most common and most expensive. The mock looks great; the data cannot feed
+it. Everything in **Class B** of the pattern base is this failure.
+
+**Guard**: for every element in the prototype, name the column or endpoint that
+supplies it. If you cannot, mark it `NEW` on the mock itself — a visible debt,
+not a silent lie.
+
+### 2. Re-deciding an L2 contract that is already settled
+
+You invent a spinner, a status glyph, an approval flow. It is not _worse_ than
+the existing one — it is _a second one_, which is strictly worse than either.
+All of **Class A** is this.
+
+**Guard**: Step 1 of the workflow explicitly asks "which canonical systems exist
+for the interactions I'm about to need?" Answer it before opening a prototype.
+
+### 3. Letting L1 quietly veto L0
+
+The code says a capability is expensive, so the design silently drops the
+requirement. Now the product has been decided by the schema.
+
+**Guard**: L1 reports **cost**, never verdicts. An ❌-bucket capability goes into
+the spec as _"not this round, costs X"_ (`P-13`) — the human decides whether X
+is worth paying. Dropping it without saying so is the design equivalent of
+swallowing an exception.
+
+### 4. Answering L0 from the screenshot
+
+The surface shows what is rendered; it says nothing about who needs what. A
+redesign that starts from "this looks dated" has skipped L0 entirely and will
+optimize the wrong thing beautifully.
+
+**Guard**: Step 2 demands a **structural** diagnosis. "It looks dated" is not
+one. "It renders one enum value out of four, so a decision inbox reads as an
+error log" is.
+
+## Which layer is a given finding from?
+
+When a grounding pass turns up a fact, tag it — the tag decides what you may do
+with it.
+
+| Finding                                                                   | Layer | What it licenses                                      |
+| ------------------------------------------------------------------------- | ----- | ----------------------------------------------------- |
+| "`briefs.type` has four values; the UI renders one"                       | L1    | A scope opportunity — and probably the whole redesign |
+| "`ExecutionStatus.ts` is the canonical status → icon map"                 | L2    | An import. Not a design decision.                     |
+| "`topics` has no `visibility` column"                                     | L1    | A **red line** on what may be displayed               |
+| "The approval card is a numbered radio list"                              | L2    | Replicate it. Do not 'improve' it in a prototype.     |
+| "The summary paragraph is too long to scan, too short to replace the doc" | L3    | A density decision — inside L1/L2 limits              |
+| "Owners won't look at a usage chart twice"                                | L0    | A product judgment — argue it, don't assert it        |
+
+## Saturation, per layer
+
+Saturation (**S**) is measured **per layer**, and they saturate at different
+speeds:
+
+- **L1 / L2 saturate fast.** One thorough grounding pass over a surface usually
+  finds most of what the schema and the canonical components hold. When a second
+  pass overturns nothing, they are mined out — stop spending budget there.
+- **L3 saturates per iteration.** Each prototype round should produce fewer
+  corrections than the last. If round 3 still produces as many as round 1, the
+  problem is upstream: L1 or L2 was never actually grounded.
+- **L0 never saturates.** Intent changes when the product changes. Do not treat a
+  quiet L0 as a solved L0.
+
+**The signal to record** (Step 6): _"grounding round N overturned zero
+assumptions"_ — that surface's L1/L2 are done, and the next round's budget should
+go to L0.

--- a/.agents/skills/product-design/references/layer-model.md
+++ b/.agents/skills/product-design/references/layer-model.md
@@ -1,102 +1,127 @@
 # Layer Model
 
 The **L** of SCLPT. Four layers, each with its own kind of evidence and its own
-authority. The point is not taxonomy — it is that **a claim from one layer
-cannot settle a question in another**, and mixing them is how a design session
-produces confident nonsense.
+authority. The point is not taxonomy — it is that **a claim from one layer cannot
+settle a question in another**, and mixing them is how a design session produces
+confident nonsense.
 
-| Layer                       | Question                                    | Evidence                                     | Who decides                                       |
-| --------------------------- | ------------------------------------------- | -------------------------------------------- | ------------------------------------------------- |
-| **L0 Intent**               | Who, in what moment, needs what?            | The user's words; the scenario               | **Product / the human.** Code cannot answer this. |
-| **L1 Data Capability**      | What can the system actually produce today? | Schema, model, router — `file:line`          | **The code.** Not negotiable.                     |
-| **L2 Interaction Contract** | How does this product already do this?      | Canonical components, status maps, semantics | **The code.** Not negotiable.                     |
-| **L3 Presentation**         | Density, hierarchy, tokens, motion          | The rendered prototype                       | Design taste, inside L1/L2 limits                 |
+| Layer                 | Question                                                      | Evidence                                    | Who decides                                         |
+| --------------------- | ------------------------------------------------------------- | ------------------------------------------- | --------------------------------------------------- |
+| **L0 Scenario**       | Who, in what circumstance, is hiring this surface to do what? | The user's words; the job to be done        | **The human.** No amount of grounding answers this. |
+| **L1 Business nouns** | What concepts, states and roles does the business _have_?     | The domain model, read as a domain document | **The business.** Not negotiable.                   |
+| **L2 Business verbs** | What does each action actually _do to the business_?          | The events an action produces               | **The business.** Not negotiable.                   |
+| **L3 Representation** | How is it shown — density, hierarchy, form?                   | The rendered prototype                      | Design judgment, inside L1/L2's limits              |
+
+**L1 is nouns and states. L2 is verbs and consequences.** They are separated
+because they fail differently: L1 failures are _"the concept isn't there"_
+(`P-06`), L2 failures are _"the button doesn't do what it says"_ (`P-02`, `P-05`).
+
+## Where L1 and L2 are written down
+
+In the schema, the state machines, the events.
+
+**Not because implementation matters** — this skill has nothing to say about
+implementation. Because **that is the most honest statement the company has ever
+made about its own domain.** Marketing copy is aspirational; roadmaps are
+aspirational; the schema is what the business _actually_ believes exists. Read it
+as a domain document.
+
+The corollary is a filter: if a fact you dug up carries no business meaning —
+which component renders the spinner, how a module is wired — **it is not an L1 or
+L2 finding at all.** It is engineering trivia, and it does not enter this system.
 
 ## The rule
 
-> **Never answer an L1 or L2 question with an L3 argument, and never answer an
-> L0 question with either.**
+> **Never answer an L1 or L2 question with an L3 argument, and never answer an L0
+> question with either.**
 
 Concretely:
 
-- "This button would feel natural here" (L3) does **not** establish that the
-  state transition exists (L1). See `P-05` — that is exactly how a fake action
-  ships.
-- "Our approval card should be two clean buttons" (L3) does **not** override the
-  fact that approval is already a numbered radio list with digit shortcuts (L2).
-  See `P-02`.
-- "The code has no `projects` table" (L1) does **not** settle whether the product
-  _needs_ a project concept (L0). It settles the **cost**, and hands the decision
-  back to the human.
+- _"This button would feel natural here"_ (L3) does **not** establish that the
+  business event exists (L2). That is exactly how a fake affordance ships
+  (`P-05`).
+- _"The business has no project concept"_ (L1) does **not** settle whether the
+  product _needs_ one (L0). It settles the **cost**, and hands the decision back
+  to the human.
+- _"The state is called `paused`"_ is not an L1 finding at all — it is a word.
+  The L1 finding is **what that state obliges someone to do** (`P-01`).
 
 ## Cross-layer misjudgment — the four that actually happen
 
-### 1. Designing an L3 affordance on top of L1 that does not exist
+### 1. Designing an L3 affordance on top of an L1/L2 that does not exist
 
-The most common and most expensive. The mock looks great; the data cannot feed
-it. Everything in **Class B** of the pattern base is this failure.
+The most common and most expensive. The mock looks great; the business cannot
+back it. All of **Class B** is this.
 
-**Guard**: for every element in the prototype, name the column or endpoint that
-supplies it. If you cannot, mark it `NEW` on the mock itself — a visible debt,
+**Guard**: for every element in the prototype, name the business concept or event
+behind it. If you cannot, mark it `NEW` **on the mock itself** — a visible debt,
 not a silent lie.
 
-### 2. Re-deciding an L2 contract that is already settled
+### 2. Reading a state or action by its name instead of its meaning
 
-You invent a spinner, a status glyph, an approval flow. It is not _worse_ than
-the existing one — it is _a second one_, which is strictly worse than either.
-All of **Class A** is this.
+`paused` sounds like "suspended" and means "a human is blocking the agent".
+"Request changes" sounds like a comment and means "re-task the agent". Every
+design built on the word instead of the meaning is a design for a different
+product. All of **Class A** is this.
 
-**Guard**: Step 1 of the workflow explicitly asks "which canonical systems exist
-for the interactions I'm about to need?" Answer it before opening a prototype.
+**Guard**: for every state, _what does it oblige someone to do?_ For every
+action, _after this click, the business is now …?_ If you cannot finish either
+sentence, you have not grounded it.
 
 ### 3. Letting L1 quietly veto L0
 
-The code says a capability is expensive, so the design silently drops the
-requirement. Now the product has been decided by the schema.
+The business does not model the concept, so the design silently drops the
+requirement. The product has now been decided by the schema — which is exactly
+backwards.
 
-**Guard**: L1 reports **cost**, never verdicts. An ❌-bucket capability goes into
-the spec as _"not this round, costs X"_ (`P-13`) — the human decides whether X
-is worth paying. Dropping it without saying so is the design equivalent of
-swallowing an exception.
+**Guard**: L1 reports **cost**, never verdicts. A missing concept goes into the
+spec as _"the business does not model X; adding it costs Y"_ (`P-11`), and the
+human decides whether Y is worth paying. Dropping it in silence is the design
+equivalent of swallowing an exception.
 
 ### 4. Answering L0 from the screenshot
 
-The surface shows what is rendered; it says nothing about who needs what. A
-redesign that starts from "this looks dated" has skipped L0 entirely and will
-optimize the wrong thing beautifully.
+The surface shows what is rendered; it says nothing about who needs what, or
+when. A redesign that starts from _"this looks dated"_ has skipped L0 entirely,
+and will optimize the wrong thing beautifully.
 
-**Guard**: Step 2 demands a **structural** diagnosis. "It looks dated" is not
-one. "It renders one enum value out of four, so a decision inbox reads as an
-error log" is.
+**Guard**: the diagnosis must be **structural**. _"It looks dated"_ is not one.
+_"It shows one of four message kinds, so a decision inbox reads as an error log"_
+is.
 
 ## Which layer is a given finding from?
 
-When a grounding pass turns up a fact, tag it — the tag decides what you may do
-with it.
+The tag decides what you may do with it.
 
-| Finding                                                                   | Layer | What it licenses                                      |
-| ------------------------------------------------------------------------- | ----- | ----------------------------------------------------- |
-| "`briefs.type` has four values; the UI renders one"                       | L1    | A scope opportunity — and probably the whole redesign |
-| "`ExecutionStatus.ts` is the canonical status → icon map"                 | L2    | An import. Not a design decision.                     |
-| "`topics` has no `visibility` column"                                     | L1    | A **red line** on what may be displayed               |
-| "The approval card is a numbered radio list"                              | L2    | Replicate it. Do not 'improve' it in a prototype.     |
-| "The summary paragraph is too long to scan, too short to replace the doc" | L3    | A density decision — inside L1/L2 limits              |
-| "Owners won't look at a usage chart twice"                                | L0    | A product judgment — argue it, don't assert it        |
+| Finding                                                                  | Layer | What it licenses                                       |
+| ------------------------------------------------------------------------ | ----- | ------------------------------------------------------ |
+| "The business models four kinds of agent message; the surface shows one" | L1    | A scope opportunity — and probably the whole redesign  |
+| "`paused` obliges a human to review, not to wait"                        | L1    | A queue, not a 'later' bucket                          |
+| "'Request changes' re-tasks the agent; it is not a comment"              | L2    | Design a re-tasking, not a comment box                 |
+| "There is no 'offered, pending acceptance' state for assigned work"      | L2    | Kill the Accept button. It is theatre.                 |
+| "Conversations have no notion of belonging to a member"                  | L1    | A **red line** — this is a domain change, not a layout |
+| "The summary is too long to scan, too short to replace the document"     | L3    | A density decision — inside L1/L2's limits             |
+| "Nobody opens a dashboard twice"                                         | L0    | A product judgment — argue it, don't assert it         |
+| "This spinner is implemented as an SVG animation"                        | —     | **Not a finding.** No business meaning. Discard.       |
+
+That last row is the filter. Most things you can learn from a codebase are not
+product findings, and letting them in is how a Pattern Base turns into a
+changelog.
 
 ## Saturation, per layer
 
 Saturation (**S**) is measured **per layer**, and they saturate at different
 speeds:
 
-- **L1 / L2 saturate fast.** One thorough grounding pass over a surface usually
-  finds most of what the schema and the canonical components hold. When a second
-  pass overturns nothing, they are mined out — stop spending budget there.
+- **L1 / L2 saturate fast.** One thorough pass over a domain usually surfaces most
+  of what it models. When a second pass overturns nothing, they are mined out —
+  stop spending budget there.
 - **L3 saturates per iteration.** Each prototype round should produce fewer
-  corrections than the last. If round 3 still produces as many as round 1, the
-  problem is upstream: L1 or L2 was never actually grounded.
-- **L0 never saturates.** Intent changes when the product changes. Do not treat a
-  quiet L0 as a solved L0.
+  corrections than the last. If round 3 produces as many as round 1, the problem
+  is upstream: L1 or L2 was never actually grounded.
+- **L0 never saturates.** Intent changes when the business changes. A quiet L0 is
+  not a solved L0 — it is an unexamined one.
 
-**The signal to record** (Step 6): _"grounding round N overturned zero
-assumptions"_ — that surface's L1/L2 are done, and the next round's budget should
-go to L0.
+**The signal to record** (Step 6): _"this round's grounding overturned zero
+assumptions"_ — L1/L2 are done for this surface, and the next round's budget
+belongs to L0.

--- a/.agents/skills/product-design/references/pattern-base.md
+++ b/.agents/skills/product-design/references/pattern-base.md
@@ -1,0 +1,268 @@
+# Pattern Base
+
+> **Mandatory**: read this file in full before every product-design run, and
+> self-check against each pattern.
+>
+> **Append after every run.** When the code overturns an assumption that no
+> pattern here predicted, that is a new gap — write it down. Each entry:
+> **Symptom / The real case / Why it happens / How to detect it next time.**
+>
+> Every claim must cite `file:line`. A pattern without a citation is a rumor,
+> and it will send the next reader to fix the wrong thing.
+>
+> This is the **P** of SCLPT. Its coverage is the ceiling of what this skill can
+> catch. Saturation = a grounding round that produces **zero** new entries here.
+
+---
+
+## Class A — You are about to reinvent something that exists
+
+The single most expensive failure mode. Every entry below was really produced by
+an agent designing from imagination and getting caught by the code later.
+
+### P-01 — Inventing a status system when a canonical one exists
+
+**Symptom**: you write out your own status list ("waiting / done / error") with
+your own icons and colors.
+
+**The real case**: an agent designed a home inbox around invented groups —
+"等我拍板 / 等我验收 / 出错待修". The repo already had
+`src/components/ExecutionStatus.ts`, the single source of truth for status →
+icon + color, shared by tasks and topics. Worse, its semantics contradicted the
+invention: **`TaskStatus.paused` is not "suspended" — it is _pending review_**
+(`ExecutionStatus.ts:50-52` maps it to the `waitingForHuman` hand glyph; the
+kanban column is literally named `needsInput`). A design built on "paused =
+suspended" would have shipped a wrong mental model.
+
+**Why it happens**: status enums live in `packages/types` and `packages/database`,
+far from the surface being designed. They are invisible from the screenshot.
+
+**Detect**: before naming any state, `grep -r "STATUS_VISUALS\|StatusIcon\|_STATUSES"`.
+If a canonical map exists, **import it** — never re-derive it.
+
+### P-02 — Inventing an interaction that is already implemented
+
+**Symptom**: you sketch a plausible-looking approval dialog / comment box /
+confirmation flow.
+
+**The real case**: an agent drew a tool-approval card with two buttons
+(Approve / Reject). The real `ApprovalActions` is **a numbered radio list** —
+`1. Approve` / `2. Approve, and don't ask again` / `3. [inline reject-reason
+input]` + a Submit button with an inline `↵` icon; **the row numbers are the
+keyboard shortcuts**. The invented version was not a simplification, it was a
+different product. The user's verdict: "感觉好丑啊" — and they were right, it
+was a fantasy.
+
+Same session, same mistake twice: "打回 / 要求修改" was designed as a new comment
+box, when `BriefCardActions` already **replaces the action row in place** with an
+editor, and submitting runs `submitFeedback` — which resolves the brief **and
+re-runs the agent** with the comment. The real semantics were far richer than
+"leave a comment".
+
+**Why it happens**: interaction implementations live under `features/`, several
+directories from where you are designing, and their names do not advertise them.
+
+**Detect**: for every interaction verb in your design (approve, comment, retry,
+share, preview), grep for it under `src/features/` **before** drawing anything.
+Assume it exists.
+
+### P-03 — Inventing a loading / motion primitive
+
+**Symptom**: a CSS `@keyframes spin` in your prototype.
+
+**The real case**: `src/components/RingLoading.tsx` is the canonical spinner —
+and it is **not** CSS: it is an SVG `<animateTransform>` (viewBox 1024, track
+`r=400 / strokeWidth=128`, a 90° arc, `dur=1s`, linear). There is a _second_,
+deliberately different one — `TopicStatusIcon`'s inline `RunningIcon` — which
+adds a filled center dot so a running row stays in the same `CircleDot` visual
+family as the static statuses. Picking the wrong one is a real (if quiet) bug.
+
+**Detect**: grep `RingLoading|NeuralNetworkLoading|animateTransform` before
+animating anything. Ask _which_ surface it belongs to — list row vs. activity
+feed have different answers.
+
+---
+
+## Class B — The data is not what the UI implies
+
+### P-04 — A table is being used as a subset of itself
+
+**Symptom**: the surface renders one enum value and you assume that is all the
+table produces.
+
+**The real case**: the home surface rendered only `brief.type === 'error'`, so
+it read as an error log. The `briefs` table actually has **four** types —
+`decision` / `result` / `insight` / `error` (`packages/types/src/brief/index.ts:37`)
+— plus `priority`, interactive `actions`, `artifacts`, and a full
+read/resolve lifecycle. All four are produced in production
+(`requestCheckpoint` → `decision`, taskLifecycle → `result`, watchdog →
+`error`, …). **A decision inbox was being used as a report box.** The single
+highest-leverage change in that entire redesign was: render the other three.
+
+**Why it happens**: the UI is the only thing you can see. The unused half of the
+schema is invisible until you read it.
+
+**Detect**: for every table the surface touches, enumerate **every** enum value
+and **every** column, then ask "which of these does the UI ignore, and why?"
+The answer is often "for no reason".
+
+### P-05 — A button that offers a transition the data model does not have
+
+**Symptom**: an action that feels natural but cannot possibly change anything.
+
+**The real case**: a design put an "Accept task" button on a task someone
+assigned to you. But assignment writes `tasks.assigneeUserId` **immediately** —
+the task is already yours. There is no `pending_assignment` state, so the button
+would have been a no-op that lies to the user. The honest action is
+**Start** (`backlog → running`) or **Reassign**.
+
+**Why it happens**: the affordance is copied from other products (Jira-style
+accept/decline) without checking whether this data model has the intermediate
+state those products have.
+
+**Detect**: for every button, name the exact state transition it performs — the
+column, the old value, the new value. If you cannot, it is a fake action. Either
+delete it, or you are proposing a schema change (say so out loud).
+
+### P-06 — A missing column is a product constraint, not a detail
+
+**Symptom**: a design that shows content the ownership predicate cannot filter.
+
+**The real case**: `tasks` / `documents` / `agents` all have a `visibility`
+column; **`topics` / `messages` / `sessions` do not.** The shared ownership
+helper therefore cannot scope conversation content per-member — which makes
+"show what the team is working on" a _privacy incident_ the moment it includes
+conversations. The design had to be explicitly constrained to entities that
+carry `visibility`. This was a hard boundary, not a preference.
+
+Related: `topics.status = 'unread'` is a **single global column**, not per-user.
+"Unread" as a per-member concept does not exist without a new join table.
+
+**Detect**: for every entity you want to display, check that its table has the
+column the access rule needs. Absence of a column is a **red line**, and it
+belongs in the spec in bold.
+
+---
+
+## Class C — Naming lies
+
+### P-07 — The identifier does not mean what it says
+
+**Symptom**: you build a mental model out of a symbol name.
+
+**The real cases**, all in one codebase:
+
+- The sidebar's `GroupKey.Project` renders a section titled **"Library"**, and
+  its create action navigates to `/knowledge/bases/:id`. There is **no
+  `projects` table**. "Project" was an empty concept.
+- The chat input's `@` mention has a category literally called `member` — which
+  resolves to **agents**, not people. Selecting one triggers `callAgent`. A
+  design that read "member" as "colleague" would have specified a feature that
+  does not exist.
+- Topic sidebar's `ByProjectMode` groups by **status**, not by project.
+
+**Detect**: never take a name as evidence. Open the file and read what it
+renders / navigates to / calls. Cite `file:line`, not the symbol name.
+
+---
+
+## Class D — Composition traps
+
+### P-08 — Deleting a section shell silently takes its mounted globals with it
+
+**Symptom**: a clean refactor that removes a container component, and two
+unrelated features quietly stop working.
+
+**The real case**: `DailyBrief/index.tsx` was the section shell for the home
+brief — and it also mounted `<Recommendations />` (in **three** render branches),
+`<DocumentPreviewModal />` and `<TopicChatDrawer />`. Deleting the shell would
+have taken artifact preview and "view run" down with it, with **no type error
+and no test failure** — the buttons would render and do nothing.
+
+**Detect**: before deleting or replacing a container, grep its render tree for
+modals, drawers, portals, and providers. Anything global that it mounts must be
+re-mounted somewhere, and **each one needs its own verification case** — this
+class of regression is invisible to the compiler.
+
+---
+
+## Class E — Judgment rules (earned, not invented)
+
+These are the design principles that survived contact with the code. They are
+patterns because each one was arrived at by _rejecting_ a plausible alternative.
+
+### P-09 — A dashboard is not a home page; a triage desk is
+
+**Rule**: an inbox-like surface answers exactly one question — **"is this mine to
+handle?"** Reading and analysis happen after the click, elsewhere.
+
+**Why**: the rejected alternative was a team dashboard (usage trends, member
+leaderboards, spend charts). Its predictable fate: the owner looks for two
+weeks, the members never look. A "what happened" surface has no pull; a "what is
+blocked on me" surface does.
+
+**Test**: for every element, ask _if the user never clicks this, does anything
+get stuck?_ If no, it does not belong on the surface.
+
+### P-10 — Density follows decision cost
+
+**Rule**: an item's size on screen should match how much thinking it demands —
+not how much text the producer wrote.
+
+| Signal                 | Form                                                          |
+| ---------------------- | ------------------------------------------------------------- |
+| Needs my decision      | Expanded: title + **one-sentence** reason + action buttons    |
+| Just needs to be known | One line: title + source + time. Summary appears **on click** |
+| Needs nothing from me  | Collapse into a **count**. Only anomalies get their own row   |
+
+**Why**: the rejected alternative was "compress every card". That trades
+readability for density and loses both. The real failure of the original surface
+was a paragraph-length summary that was _too short to replace the document and
+too long to scan_ — the worst of both.
+
+### P-11 — Group by the action required, not by the source entity
+
+**Rule**: an agent saying "I'm stuck, decide this" and a colleague saying
+"@you, look at this" are **the same signal**. They belong in the same list,
+grouped by what the user must do — not split into "agent stuff" and "people
+stuff".
+
+**Why**: entity-shaped grouping is how the _system_ sees the world. Action-shaped
+grouping is how the _user_ does. Only one of them is the user's problem.
+
+**Corollary**: sort within a group by what is actually blocking. A stuck
+decision blocks an agent _right now_; a failed run has already stopped and can
+wait — so failures sink to the bottom, even when their priority field says
+`urgent`.
+
+---
+
+## Class F — Scope discipline
+
+### P-12 — The three-bucket audit decides scope, not taste
+
+**Rule**: before scoping, sort every capability the design needs into
+**available now** / **blocked by a predicate or select** / **needs a new model**.
+Then ship the zero-new-table subset first.
+
+**The real case**: a full team-collaboration design needed mentions,
+annotations, presence, and a new project entity — all bucket ❌. But the
+_attention inbox_ at its core needed **zero new tables**: the four brief types
+were already stored, running/unread topics were already queryable through one
+existing endpoint, and the only backend change was adding two columns to a
+`select` on a join that already existed. That subset shipped while the expensive
+half was still being debated.
+
+**Detect**: if your plan's first milestone contains a migration, you probably
+have not looked hard enough for the shippable subset.
+
+### P-13 — Name what you are _not_ building, and why
+
+**Rule**: capabilities dropped for lack of data go into the spec explicitly, with
+the reason. Silence reads as an oversight and gets re-litigated in review.
+
+**The real case**: the prototype showed a run's `#seq · 4m 12s`. Neither exists:
+`task_topics` has no `completedAt`, `topics` has no `startedAt`/`duration`, and
+`agent_operations` — which does have `processingTimeMs` — is **not exposed over
+tRPC at all**. Duration is computed client-side at read time, per row. Writing
+this down turned "you forgot the timestamps" into "we know, here is the cost".

--- a/.agents/skills/product-design/references/pattern-base.md
+++ b/.agents/skills/product-design/references/pattern-base.md
@@ -3,266 +3,296 @@
 > **Mandatory**: read this file in full before every product-design run, and
 > self-check against each pattern.
 >
-> **Append after every run.** When the code overturns an assumption that no
-> pattern here predicted, that is a new gap — write it down. Each entry:
+> **Append after every run.** When the business model overturns an assumption
+> that no pattern here predicted, that is a new gap — write it down. Each entry:
 > **Symptom / The real case / Why it happens / How to detect it next time.**
->
-> Every claim must cite `file:line`. A pattern without a citation is a rumor,
-> and it will send the next reader to fix the wrong thing.
 >
 > This is the **P** of SCLPT. Its coverage is the ceiling of what this skill can
 > catch. Saturation = a grounding round that produces **zero** new entries here.
 
----
+## What belongs here, and what does not
 
-## Class A — You are about to reinvent something that exists
+Every pattern in this file is about **business semantics** — what the product
+actually models, what a state _means_, what an action _does to the business_.
 
-The single most expensive failure mode. Every entry below was really produced by
-an agent designing from imagination and getting caught by the code later.
+**Implementation semantics do not belong here.** "Reuse the existing spinner
+component", "this refactor breaks a mounted modal", "prefer this hook over that
+one" — all true, all important, all somebody else's file. A pattern earns its
+place here only if it changes **what the product should be**, not how it is
+built.
 
-### P-01 — Inventing a status system when a canonical one exists
-
-**Symptom**: you write out your own status list ("waiting / done / error") with
-your own icons and colors.
-
-**The real case**: an agent designed a home inbox around invented groups —
-"等我拍板 / 等我验收 / 出错待修". The repo already had
-`src/components/ExecutionStatus.ts`, the single source of truth for status →
-icon + color, shared by tasks and topics. Worse, its semantics contradicted the
-invention: **`TaskStatus.paused` is not "suspended" — it is _pending review_**
-(`ExecutionStatus.ts:50-52` maps it to the `waitingForHuman` hand glyph; the
-kanban column is literally named `needsInput`). A design built on "paused =
-suspended" would have shipped a wrong mental model.
-
-**Why it happens**: status enums live in `packages/types` and `packages/database`,
-far from the surface being designed. They are invisible from the screenshot.
-
-**Detect**: before naming any state, `grep -r "STATUS_VISUALS\|StatusIcon\|_STATUSES"`.
-If a canonical map exists, **import it** — never re-derive it.
-
-### P-02 — Inventing an interaction that is already implemented
-
-**Symptom**: you sketch a plausible-looking approval dialog / comment box /
-confirmation flow.
-
-**The real case**: an agent drew a tool-approval card with two buttons
-(Approve / Reject). The real `ApprovalActions` is **a numbered radio list** —
-`1. Approve` / `2. Approve, and don't ask again` / `3. [inline reject-reason
-input]` + a Submit button with an inline `↵` icon; **the row numbers are the
-keyboard shortcuts**. The invented version was not a simplification, it was a
-different product. The user's verdict: "感觉好丑啊" — and they were right, it
-was a fantasy.
-
-Same session, same mistake twice: "打回 / 要求修改" was designed as a new comment
-box, when `BriefCardActions` already **replaces the action row in place** with an
-editor, and submitting runs `submitFeedback` — which resolves the brief **and
-re-runs the agent** with the comment. The real semantics were far richer than
-"leave a comment".
-
-**Why it happens**: interaction implementations live under `features/`, several
-directories from where you are designing, and their names do not advertise them.
-
-**Detect**: for every interaction verb in your design (approve, comment, retry,
-share, preview), grep for it under `src/features/` **before** drawing anything.
-Assume it exists.
-
-### P-03 — Inventing a loading / motion primitive
-
-**Symptom**: a CSS `@keyframes spin` in your prototype.
-
-**The real case**: `src/components/RingLoading.tsx` is the canonical spinner —
-and it is **not** CSS: it is an SVG `<animateTransform>` (viewBox 1024, track
-`r=400 / strokeWidth=128`, a 90° arc, `dur=1s`, linear). There is a _second_,
-deliberately different one — `TopicStatusIcon`'s inline `RunningIcon` — which
-adds a filled center dot so a running row stays in the same `CircleDot` visual
-family as the static statuses. Picking the wrong one is a real (if quiet) bug.
-
-**Detect**: grep `RingLoading|NeuralNetworkLoading|animateTransform` before
-animating anything. Ask _which_ surface it belongs to — list row vs. activity
-feed have different answers.
+The test: _strip out every framework, table and component name. Is there still a
+product insight left?_ If no, it is an engineering note in disguise.
 
 ---
 
-## Class B — The data is not what the UI implies
+## The spine: three models
 
-### P-04 — A table is being used as a subset of itself
+Everything below is one disease with different symptoms. Borrowing Cooper's
+frame (see [canon.md](canon.md)):
 
-**Symptom**: the surface renders one enum value and you assume that is all the
-table produces.
+| Model                 | What it is                                                                    |
+| --------------------- | ----------------------------------------------------------------------------- |
+| **Business model**    | What the product _actually_ models: its concepts, states, events, obligations |
+| **Represented model** | What the surface _claims_ the business is                                     |
+| **Mental model**      | What the user _believes_ it is                                                |
+|                       |                                                                               |
 
-**The real case**: the home surface rendered only `brief.type === 'error'`, so
-it read as an error log. The `briefs` table actually has **four** types —
-`decision` / `result` / `insight` / `error` (`packages/types/src/brief/index.ts:37`)
-— plus `priority`, interactive `actions`, `artifacts`, and a full
-read/resolve lifecycle. All four are produced in production
-(`requestCheckpoint` → `decision`, taskLifecycle → `result`, watchdog →
-`error`, …). **A decision inbox was being used as a report box.** The single
-highest-leverage change in that entire redesign was: render the other three.
+Design failure is always a gap between two of them. Class A is
+_business ≠ what we thought it was_. Class B is _represented ≠ business_.
+Classes C and D are about what to do once you have the business model right.
 
-**Why it happens**: the UI is the only thing you can see. The unused half of the
-schema is invisible until you read it.
-
-**Detect**: for every table the surface touches, enumerate **every** enum value
-and **every** column, then ask "which of these does the UI ignore, and why?"
-The answer is often "for no reason".
-
-### P-05 — A button that offers a transition the data model does not have
-
-**Symptom**: an action that feels natural but cannot possibly change anything.
-
-**The real case**: a design put an "Accept task" button on a task someone
-assigned to you. But assignment writes `tasks.assigneeUserId` **immediately** —
-the task is already yours. There is no `pending_assignment` state, so the button
-would have been a no-op that lies to the user. The honest action is
-**Start** (`backlog → running`) or **Reassign**.
-
-**Why it happens**: the affordance is copied from other products (Jira-style
-accept/decline) without checking whether this data model has the intermediate
-state those products have.
-
-**Detect**: for every button, name the exact state transition it performs — the
-column, the old value, the new value. If you cannot, it is a fake action. Either
-delete it, or you are proposing a schema change (say so out loud).
-
-### P-06 — A missing column is a product constraint, not a detail
-
-**Symptom**: a design that shows content the ownership predicate cannot filter.
-
-**The real case**: `tasks` / `documents` / `agents` all have a `visibility`
-column; **`topics` / `messages` / `sessions` do not.** The shared ownership
-helper therefore cannot scope conversation content per-member — which makes
-"show what the team is working on" a _privacy incident_ the moment it includes
-conversations. The design had to be explicitly constrained to entities that
-carry `visibility`. This was a hard boundary, not a preference.
-
-Related: `topics.status = 'unread'` is a **single global column**, not per-user.
-"Unread" as a per-member concept does not exist without a new join table.
-
-**Detect**: for every entity you want to display, check that its table has the
-column the access rule needs. Absence of a column is a **red line**, and it
-belongs in the spec in bold.
+**Where the business model is written down**: the schema, the state machines,
+the events. Not because implementation matters — because **that is the most
+honest statement the company has ever made about its own domain.** Read it as a
+domain document, not as code.
 
 ---
 
-## Class C — Naming lies
+## Class A — The business meaning is not what the name says
 
-### P-07 — The identifier does not mean what it says
+### P-01 — A state's business meaning is not its label
 
-**Symptom**: you build a mental model out of a symbol name.
+**Symptom**: you design around what a status _sounds like_.
 
-**The real cases**, all in one codebase:
+**The real case**: a task status called `paused` was read as "the user suspended
+this". Its actual business meaning is **"pending review — the agent finished a
+step and is waiting for a human to approve it"**. The product surfaces it as
+_Pending review_, and the board column for it is called _Needs input_. A design
+built on "paused = suspended" would have put it in a "later" bucket, when it is
+in fact the most urgent thing on the page — an agent is **blocked on you right
+now**.
 
-- The sidebar's `GroupKey.Project` renders a section titled **"Library"**, and
-  its create action navigates to `/knowledge/bases/:id`. There is **no
-  `projects` table**. "Project" was an empty concept.
-- The chat input's `@` mention has a category literally called `member` — which
-  resolves to **agents**, not people. Selecting one triggers `callAgent`. A
-  design that read "member" as "colleague" would have specified a feature that
-  does not exist.
-- Topic sidebar's `ByProjectMode` groups by **status**, not by project.
+**Why it happens**: state names are chosen by whoever created the state, usually
+early, usually for the machine. They drift from the business meaning and nobody
+renames them.
 
-**Detect**: never take a name as evidence. Open the file and read what it
-renders / navigates to / calls. Cite `file:line`, not the symbol name.
+**Detect**: for every state you put on screen, ask **"what does this state
+oblige someone to do?"** — not "what does this word mean in English". If the
+answer is "nothing", it is not a state worth surfacing. If it is "a human must
+act", it is a queue.
+
+### P-02 — An action's business consequence is not its label
+
+**Symptom**: you treat an action as its most literal reading.
+
+**The real case**: a "Request changes" action on an agent's deliverable looked
+like _leave a comment_. Its real business consequence is: **it resolves the
+item, and re-runs the agent with the comment as new input.** It is not feedback,
+it is a **re-tasking**. The design had proposed a plain comment box — which
+would have quietly turned a re-tasking into a note nobody acts on.
+
+**Why it happens**: an action's label describes what the _user does_; its
+business semantics describe what the _business does next_. The two are routinely
+different, and only the second one matters for design.
+
+**Detect**: for every action, complete the sentence _"after this click, the
+business is now …"_. If you cannot, you do not know what the button does — and
+you are about to design a different product than the one that exists.
+
+### P-03 — The name and the concept have diverged
+
+**Symptom**: you build a mental model out of a word.
+
+**The real cases**, all in one product:
+
+- A sidebar section named **Project** renders a **knowledge library**, and its
+  "create" action makes a knowledge base. There is **no project concept in the
+  business at all** — "Project" was an empty word. A whole design round was spent
+  on "project progress" before anyone checked.
+- The `@` mention menu has a category named **member** — which resolves to
+  **agents**, not people. Selecting one dispatches work to an agent. A design
+  that read "member" as "colleague" would have specified a collaboration feature
+  that **does not exist in the business**.
+
+**Why it happens**: names are the cheapest thing to change and therefore the
+last thing anyone changes. The vocabulary rots while the concepts move.
+
+**Detect**: never accept a name as evidence of a concept. Ask **"what business
+event does this actually produce?"** If the answer does not match the noun, the
+vocabulary is broken — and that is itself a finding worth reporting, because the
+whole team is miscommunicating through it.
 
 ---
 
-## Class D — Composition traps
+## Class B — The surface misrepresents the business
 
-### P-08 — Deleting a section shell silently takes its mounted globals with it
+### P-04 — The business models more than the surface exposes
 
-**Symptom**: a clean refactor that removes a container component, and two
-unrelated features quietly stop working.
+**The highest-leverage pattern in this file.** Look for this first, every time.
 
-**The real case**: `DailyBrief/index.tsx` was the section shell for the home
-brief — and it also mounted `<Recommendations />` (in **three** render branches),
-`<DocumentPreviewModal />` and `<TopicChatDrawer />`. Deleting the shell would
-have taken artifact preview and "view run" down with it, with **no type error
-and no test failure** — the buttons would render and do nothing.
+**Symptom**: the surface shows one kind of thing, so everyone assumes that is
+all the business has.
 
-**Detect**: before deleting or replacing a container, grep its render tree for
-modals, drawers, portals, and providers. Anything global that it mounts must be
-re-mounted somewhere, and **each one needs its own verification case** — this
-class of regression is invisible to the compiler.
+**The real case**: a home surface showed only agent **errors**, so the whole team
+read it as an error log — and designed around "how do we make the error list
+nicer". The business actually modeled **four** kinds of agent-to-human message:
+a **decision** (the agent paused and needs a ruling), a **result** (a deliverable
+awaiting acceptance), an **insight** (something worth knowing), and an **error**.
+All four were being produced in production, every day, with priorities and
+interactive actions and linked deliverables — **and three quarters of them were
+never shown to anyone.**
+
+The surface was not an error log that needed polish. It was **a decision inbox
+with three of its four channels switched off.** That single realization was worth
+more than every other finding in the redesign combined.
+
+**Why it happens**: the surface is the only thing anyone can see. A capability
+that is modeled but not rendered is invisible to product, to design, and to the
+user — it exists only in the domain.
+
+**Detect**: for every concept the surface touches, enumerate **all** of its
+business variants, then ask: _"which of these does the surface ignore, and is
+there a reason?"_ The answer is very often **"no reason — nobody got to it"**.
+That is free product.
+
+**Cooper wrote about the implementation model leaking _into_ the represented
+model. This is the inverse — the represented model failing to expose what the
+business already supports — and it is at least as common and far more valuable.**
+
+### P-05 — The surface promises a business event that does not exist
+
+**Symptom**: an affordance that feels natural and cannot possibly do anything.
+
+**The real case**: a design put an **"Accept task"** button on work someone had
+assigned to you. But in this business, assignment is **immediate and
+unilateral** — the moment a colleague assigns it, the task is yours. There is no
+"offered, pending acceptance" state, because the business never modeled
+delegation as a negotiation. The button would have been a lie: it implies you
+could decline, and you cannot.
+
+The honest actions are the ones that map to real business events: **Start** (it
+becomes active work) or **Reassign** (it becomes someone else's).
+
+**Why it happens**: the affordance is imported from another product's business
+model — Jira-style accept/decline — without checking whether _this_ business has
+the intermediate state that one has.
+
+**Detect**: for every button, name the **business event** it produces. Not the
+mutation — the event, in domain language: _"the task is now started"_, _"the
+brief is now resolved"_. If you cannot name one, the button is theatre. Delete
+it, or admit you are proposing a change to the business model (and say so out
+loud — that is a real proposal, just an expensive one).
+
+### P-06 — The business has no such concept, so this is not a design decision
+
+**Symptom**: you treat a missing capability as a layout problem.
+
+**The real case**: a team-collaboration design wanted a "what the team is
+working on" feed, including conversations. But the business models
+**per-member privacy for tasks and documents and nothing else** — conversations
+have no notion of "mine vs the team's" at all. So "show the team the
+conversations" is not a design choice that could be made tastefully. It is
+**a business concept that does not exist**, and shipping the feature would have
+been a privacy incident, not a bad layout.
+
+Same shape, smaller: "unread" existed only as a **global** property of a
+conversation, not a per-person one. A per-member unread badge was therefore not
+a UI decision either — it was a request for a new business concept.
+
+**Why it happens**: the surface can render anything, so absence of a _concept_
+looks like absence of a _widget_. It is not.
+
+**Detect**: for every thing you want to show, ask **"does the business have a
+notion of who this belongs to / who has seen it / who may act on it?"** If not,
+you are not designing — you are proposing a domain change. That is allowed, but
+it must be said out loud (`P-11`), because it changes the cost by an order of
+magnitude.
 
 ---
 
-## Class E — Judgment rules (earned, not invented)
+## Class C — How attention gets organized
 
-These are the design principles that survived contact with the code. They are
-patterns because each one was arrived at by _rejecting_ a plausible alternative.
+These are judgment rules, and each one was earned by rejecting a plausible
+alternative.
 
-### P-09 — A dashboard is not a home page; a triage desk is
+### P-07 — A home surface is a triage desk, not a dashboard
 
 **Rule**: an inbox-like surface answers exactly one question — **"is this mine to
-handle?"** Reading and analysis happen after the click, elsewhere.
+handle?"** Reading, analysis and browsing happen after the click, elsewhere.
 
-**Why**: the rejected alternative was a team dashboard (usage trends, member
-leaderboards, spend charts). Its predictable fate: the owner looks for two
-weeks, the members never look. A "what happened" surface has no pull; a "what is
-blocked on me" surface does.
+**The rejected alternative**: a team dashboard — usage trends, member
+leaderboards, throughput charts. Its fate is predictable: the manager looks for
+two weeks, the members never look at all. A **"what happened"** surface has no
+pull. A **"what is blocked on me"** surface does, because not looking has a cost.
 
-**Test**: for every element, ask _if the user never clicks this, does anything
-get stuck?_ If no, it does not belong on the surface.
+**Test**: for every element on the page, ask _"if the user never clicks this,
+does anything get stuck?"_ If no, it does not belong on this surface. It belongs
+on a page someone visits **on purpose**.
 
-### P-10 — Density follows decision cost
+### P-08 — Density follows decision cost
 
-**Rule**: an item's size on screen should match how much thinking it demands —
-not how much text the producer wrote.
+**Rule**: an item's size on screen should match **how much thinking it demands**
+— never how much text its producer happened to write.
 
-| Signal                 | Form                                                          |
-| ---------------------- | ------------------------------------------------------------- |
-| Needs my decision      | Expanded: title + **one-sentence** reason + action buttons    |
-| Just needs to be known | One line: title + source + time. Summary appears **on click** |
-| Needs nothing from me  | Collapse into a **count**. Only anomalies get their own row   |
+| The signal             | The form it takes                                              |
+| ---------------------- | -------------------------------------------------------------- |
+| Needs my decision      | Expanded: title + **one sentence** of reasoning + the actions  |
+| Just needs to be known | One line: title, source, time. The detail appears **on click** |
+| Needs nothing from me  | Collapse into a **count**. Only anomalies earn their own row   |
 
-**Why**: the rejected alternative was "compress every card". That trades
-readability for density and loses both. The real failure of the original surface
-was a paragraph-length summary that was _too short to replace the document and
-too long to scan_ — the worst of both.
+**The rejected alternative**: "make every card more compact". That trades
+readability for density and loses both. The original surface's real failure was
+a paragraph-length summary that was **too short to replace the document and too
+long to scan** — the worst possible length. The fix was not to shorten it. It was
+to decide, per item, _how much thinking this item demands_, and let that pick the
+form.
 
-### P-11 — Group by the action required, not by the source entity
+### P-09 — Group by the action required, not by the entity that produced it
 
-**Rule**: an agent saying "I'm stuck, decide this" and a colleague saying
-"@you, look at this" are **the same signal**. They belong in the same list,
-grouped by what the user must do — not split into "agent stuff" and "people
-stuff".
+**Rule**: an agent saying _"I'm stuck, decide this"_ and a colleague saying
+_"@you, look at this"_ are, **to the person receiving them, the same signal**.
+They belong in one list, grouped by what the recipient must do — not split into
+"agent stuff" and "people stuff".
 
-**Why**: entity-shaped grouping is how the _system_ sees the world. Action-shaped
-grouping is how the _user_ does. Only one of them is the user's problem.
+**Why**: entity-shaped grouping is how the **system** sees the world. Action-
+shaped grouping is how the **user** does. Only one of those is the user's problem.
 
-**Corollary**: sort within a group by what is actually blocking. A stuck
-decision blocks an agent _right now_; a failed run has already stopped and can
-wait — so failures sink to the bottom, even when their priority field says
-`urgent`.
+**Corollary — sort by what is actually blocking, not by a priority field.** A
+stuck decision is blocking work _right now_; a failed run has already stopped and
+can wait. So failures sink to the bottom of the queue **even when their priority
+field says urgent** — because "urgent" was written by the producer, and
+"blocking" is a fact about the world.
 
 ---
 
-## Class F — Scope discipline
+## Class D — Scope and honesty
 
-### P-12 — The three-bucket audit decides scope, not taste
+### P-10 — Ship what the business already supports, first
 
-**Rule**: before scoping, sort every capability the design needs into
-**available now** / **blocked by a predicate or select** / **needs a new model**.
-Then ship the zero-new-table subset first.
+**Rule**: before scoping, sort every capability the design needs by **whether the
+business already models it**:
 
-**The real case**: a full team-collaboration design needed mentions,
-annotations, presence, and a new project entity — all bucket ❌. But the
-_attention inbox_ at its core needed **zero new tables**: the four brief types
-were already stored, running/unread topics were already queryable through one
-existing endpoint, and the only backend change was adding two columns to a
-`select` on a join that already existed. That subset shipped while the expensive
-half was still being debated.
+| Bucket                                   | Meaning                                                         |
+| ---------------------------------------- | --------------------------------------------------------------- |
+| ✅ **Already modeled, already exposed**  | Rearranging what is there                                       |
+| ⚠️ **Already modeled, not yet exposed**  | `P-04` territory — nearly free product                          |
+| ❌ **Not a concept in the business yet** | A domain change. Real, but an order of magnitude more expensive |
 
-**Detect**: if your plan's first milestone contains a migration, you probably
-have not looked hard enough for the shippable subset.
+**Then ship ✅ + ⚠️ first.** Not as a compromise — as a discipline. It forces the
+design to be honest about what the business actually is today, and it puts a real
+surface in front of users while the domain changes are still being argued about.
 
-### P-13 — Name what you are _not_ building, and why
+**The real case**: a sweeping team-collaboration vision needed mentions,
+annotations, presence and a project concept — **all ❌**. But the attention inbox
+at its core was entirely ✅ + ⚠️: the four message kinds were already being
+produced, and the running/unread work was already a business concept. That subset
+shipped. The expensive half is still, correctly, being argued about.
 
-**Rule**: capabilities dropped for lack of data go into the spec explicitly, with
-the reason. Silence reads as an oversight and gets re-litigated in review.
+**Detect**: if your first milestone requires the business to learn a new concept,
+you have probably not looked hard enough for the ⚠️ bucket.
 
-**The real case**: the prototype showed a run's `#seq · 4m 12s`. Neither exists:
-`task_topics` has no `completedAt`, `topics` has no `startedAt`/`duration`, and
-`agent_operations` — which does have `processingTimeMs` — is **not exposed over
-tRPC at all**. Duration is computed client-side at read time, per row. Writing
-this down turned "you forgot the timestamps" into "we know, here is the cost".
+### P-11 — Name what you are _not_ building, and what it would cost
+
+**Rule**: every ❌-bucket capability goes into the spec **by name, with its
+reason**. Never silently dropped.
+
+**Why**: silence reads as an oversight. A reviewer who notices the gap will
+assume you missed it and re-open the discussion. A reviewer who reads _"per-run
+duration is not shown: the business does not model a run's elapsed time, so this
+needs a new concept"_ will either accept it or argue the cost — which is exactly
+the conversation you want.
+
+**The real case**: a prototype showed each run's elapsed time. The business has
+no such concept — a run's duration is not modeled, anywhere. Writing that down
+converted _"you forgot the timestamps"_ into _"we know, and here is the price"_.

--- a/.agents/skills/product-design/references/pattern-base.md
+++ b/.agents/skills/product-design/references/pattern-base.md
@@ -26,26 +26,34 @@ product insight left?_ If no, it is an engineering note in disguise.
 
 ---
 
-## The spine: three models
+## The spine: Cooper's three models
 
-Everything below is one disease with different symptoms. Borrowing Cooper's
-frame (see [canon.md](canon.md)):
+Everything below is one disease with different symptoms. The frame is Cooper's,
+unmodified — see [layer-model.md](layer-model.md):
 
-| Model                 | What it is                                                                    |
-| --------------------- | ----------------------------------------------------------------------------- |
-| **Business model**    | What the product _actually_ models: its concepts, states, events, obligations |
-| **Represented model** | What the surface _claims_ the business is                                     |
-| **Mental model**      | What the user _believes_ it is                                                |
-|                       |                                                                               |
+| Model                    | What it is                                                                  |
+| ------------------------ | --------------------------------------------------------------------------- |
+| **Implementation model** | How the product _actually works_: its concepts, states, events, obligations |
+| **Represented model**    | What the interface _claims_ the product is                                  |
+| **Mental model**         | What the user _believes_ it is                                              |
 
-Design failure is always a gap between two of them. Class A is
-_business ≠ what we thought it was_. Class B is _represented ≠ business_.
-Classes C and D are about what to do once you have the business model right.
+> **The represented model should be as close to the mental model as possible, and
+> as far from the implementation model as necessary.**
 
-**Where the business model is written down**: the schema, the state machines,
-the events. Not because implementation matters — because **that is the most
-honest statement the company has ever made about its own domain.** Read it as a
-domain document, not as code.
+Every pattern here is a failure to hold that line:
+
+- **Class A** — the represented model inherited the implementation model's
+  **vocabulary** instead of its meaning.
+- **Class B** — the represented model and the implementation model simply
+  **disagree** about what exists.
+- **Class C** — the represented model follows the implementation model when it
+  should be following the **mental** model.
+- **Class D** — what to do once the first three are settled.
+
+**Where the implementation model is written down**: the domain model — the
+concepts, the states, the events. Not because implementation matters, but because
+**that is the most honest statement the company has ever made about what it
+believes exists.** Read it as a domain document.
 
 ---
 
@@ -115,40 +123,35 @@ whole team is miscommunicating through it.
 
 ---
 
-## Class B — The surface misrepresents the business
+## Class B — The represented and implementation models disagree
 
-### P-04 — The business models more than the surface exposes
+### P-04 — Do not read the surface as evidence about the product
 
-**The highest-leverage pattern in this file.** Look for this first, every time.
+**Symptom**: the surface shows one kind of thing, so everyone concludes that is
+all the product does.
 
-**Symptom**: the surface shows one kind of thing, so everyone assumes that is
-all the business has.
-
-**The real case**: a home surface showed only agent **errors**, so the whole team
-read it as an error log — and designed around "how do we make the error list
-nicer". The business actually modeled **four** kinds of agent-to-human message:
+**The real case**: a home surface showed only agent **errors**, so the team
+reasoned about it as an error log and asked _"how do we make the error list
+nicer?"_. The product in fact models **four** kinds of agent-to-human message —
 a **decision** (the agent paused and needs a ruling), a **result** (a deliverable
-awaiting acceptance), an **insight** (something worth knowing), and an **error**.
-All four were being produced in production, every day, with priorities and
-interactive actions and linked deliverables — **and three quarters of them were
-never shown to anyone.**
+awaiting acceptance), an **insight** (worth knowing, nothing to decide) and an
+**error** — and produces all four every day. Three had simply never been
+surfaced.
 
-The surface was not an error log that needed polish. It was **a decision inbox
-with three of its four channels switched off.** That single realization was worth
-more than every other finding in the redesign combined.
+The surface was not an error log in need of polish. It was **a decision inbox with
+three of its four channels switched off** — and the entire team's model of the
+product had been formed by looking at the screen.
 
-**Why it happens**: the surface is the only thing anyone can see. A capability
-that is modeled but not rendered is invisible to product, to design, and to the
-user — it exists only in the domain.
+**Why it happens**: nothing mysterious. The scenarios were designed and built
+before the interface caught up, which is ordinary. What is _not_ ordinary is how
+completely a surface can define everyone's understanding of what the product is,
+including the people who built it.
 
 **Detect**: for every concept the surface touches, enumerate **all** of its
-business variants, then ask: _"which of these does the surface ignore, and is
-there a reason?"_ The answer is very often **"no reason — nobody got to it"**.
-That is free product.
-
-**Cooper wrote about the implementation model leaking _into_ the represented
-model. This is the inverse — the represented model failing to expose what the
-business already supports — and it is at least as common and far more valuable.**
+variants in the product, then ask _"which of these does the surface ignore, and is
+there a reason?"_ Often the answer is **"no reason — nobody got to it"**. Check
+this before inventing anything new; it is the cheapest win available and the
+easiest to miss.
 
 ### P-05 — The surface promises a business event that does not exist
 

--- a/.agents/skills/product-design/references/trace-schema.md
+++ b/.agents/skills/product-design/references/trace-schema.md
@@ -1,0 +1,85 @@
+# Trace Schema
+
+The **T** of SCLPT. Without structured evidence, there is no pattern recognition
+— just a feeling that the session went well.
+
+A design session leaves three artifacts. Two are for humans. **The third is for
+the system**, and it is the one that gets skipped.
+
+| Artifact              | Audience      | Purpose                                               |
+| --------------------- | ------------- | ----------------------------------------------------- |
+| Design spec           | reviewers     | What we decided and why                               |
+| Prototype             | reviewers     | What it feels like                                    |
+| **Reality-check log** | **the skill** | **What the code overturned — feeds the Pattern Base** |
+
+## The reality-check log
+
+One row per assumption that met the code. It lives as a section **inside the
+spec** (not a separate file — a separate file goes unread).
+
+The schema:
+
+| Field          | Meaning                                                         |
+| -------------- | --------------------------------------------------------------- |
+| **Assumption** | What was believed, in the words it was believed in              |
+| **Code fact**  | What is actually true, with `file:line`                         |
+| **Layer**      | L0 / L1 / L2 / L3 (see [layer-model.md](layer-model.md))        |
+| **Verdict**    | `overturned` \| `confirmed` \| `refined`                        |
+| **Pattern**    | `P-nn` if an existing pattern predicted it; `NEW` if it did not |
+
+`NEW` is the whole point. Every `NEW` row is a hole in the Pattern Base, and
+Step 6 of the workflow closes it.
+
+### Worked rows — from the session that produced this skill
+
+| Assumption                                  | Code fact                                                                                                   | Layer | Verdict    | Pattern      |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ----- | ---------- | ------------ |
+| The home surface only ever has error briefs | `briefs.type` has four values, all produced in prod (`packages/types/src/brief/index.ts:37`)                | L1    | overturned | NEW → `P-04` |
+| Task `paused` means "suspended"             | It means **pending review**; shares the `waitingForHuman` glyph (`src/components/ExecutionStatus.ts:50-52`) | L2    | overturned | NEW → `P-01` |
+| Tool approval is two buttons                | It is a numbered radio list; the digits are the shortcuts (`.../Intervention/ApprovalActions.tsx`)          | L2    | overturned | NEW → `P-02` |
+| The spinner is a CSS keyframe               | It is an SVG `<animateTransform>` (`src/components/RingLoading.tsx`)                                        | L2    | overturned | NEW → `P-03` |
+| "Accept task" is a real action              | Assignment already wrote `assigneeUserId`; no pending state exists                                          | L1    | overturned | NEW → `P-05` |
+| Deleting the section shell is safe          | It mounted `Recommendations` + two modals in three branches                                                 | L1    | overturned | NEW → `P-08` |
+| A `projects` table exists                   | It does not; `GroupKey.Project` renders a knowledge base                                                    | L1    | overturned | NEW → `P-07` |
+| Conversations can be shown to the team      | `topics` has no `visibility` column — privacy red line                                                      | L1    | overturned | NEW → `P-06` |
+| The unread list needs a new endpoint        | `topicService.queryTopics({ statuses })` already returns it                                                 | L1    | overturned | NEW → `P-12` |
+
+Nine assumptions, nine overturned, all `NEW` — which is exactly what a **cold
+start** looks like. A healthy mature run should be mostly `confirmed` with one
+or two `NEW`.
+
+## Reading the log
+
+The shape of the log _is_ the diagnosis of the session:
+
+| Shape                                | What it means                                                                                                     |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| Many `overturned`, all `NEW`         | Cold start. The Pattern Base was blind here — harvest it.                                                         |
+| Many `overturned`, all citing `P-nn` | **The patterns were not read.** Process failure, not a knowledge failure. Fix Step 0, not the design.             |
+| Mostly `confirmed`, one or two `NEW` | Healthy. The system is working.                                                                                   |
+| Zero rows                            | Either a trivial surface, or — far more likely — **nobody grounded anything.** Treat with suspicion.              |
+| Zero `NEW` across a whole round      | **Saturation.** L1/L2 are mined out for this surface (see [layer-model.md](layer-model.md#saturation-per-layer)). |
+
+That second row is worth dwelling on. If the code keeps overturning things the
+Pattern Base _already knew_, the skill is fine and the run was sloppy. The fix is
+to actually read Step 0 — not to add more patterns.
+
+## Marking debt on the prototype itself
+
+Anything the design shows that the data cannot supply gets a visible `NEW` tag
+**on the mock**, not just in the spec. A reviewer looking at a picture must be
+able to see which parts are real.
+
+```
+累计已执行 11h 06m  [NEW]     ← no column for this; would need a new query
+```
+
+This is the cheapest possible defense against `P-05`-class fake affordances: if
+you cannot name the column, you must draw the tag.
+
+## Why the log, and not just a good memory
+
+The Pattern Base is the skill's long-term memory; the reality-check log is its
+short-term one. Skipping the log does not merely lose a document — it breaks the
+**C** (Closed Loop) of SCLPT, and the next session re-learns the same nine
+lessons from scratch.

--- a/.agents/skills/product-design/references/trace-schema.md
+++ b/.agents/skills/product-design/references/trace-schema.md
@@ -6,80 +6,84 @@ The **T** of SCLPT. Without structured evidence, there is no pattern recognition
 A design session leaves three artifacts. Two are for humans. **The third is for
 the system**, and it is the one that gets skipped.
 
-| Artifact              | Audience      | Purpose                                               |
-| --------------------- | ------------- | ----------------------------------------------------- |
-| Design spec           | reviewers     | What we decided and why                               |
-| Prototype             | reviewers     | What it feels like                                    |
-| **Reality-check log** | **the skill** | **What the code overturned — feeds the Pattern Base** |
+| Artifact              | Audience      | Purpose                                                   |
+| --------------------- | ------------- | --------------------------------------------------------- |
+| Design spec           | reviewers     | What we decided and why                                   |
+| Prototype             | reviewers     | What it feels like                                        |
+| **Reality-check log** | **the skill** | **What the business overturned — feeds the Pattern Base** |
 
 ## The reality-check log
 
-One row per assumption that met the code. It lives as a section **inside the
-spec** (not a separate file — a separate file goes unread).
+One row per assumption that met the business model. It lives as a section
+**inside the spec** — a separate file goes unread.
 
-The schema:
+| Field            | Meaning                                                         |
+| ---------------- | --------------------------------------------------------------- |
+| **Assumption**   | What was believed, in the words it was believed in              |
+| **What is true** | The business fact that overturned it, in **domain language**    |
+| **Layer**        | L0 / L1 / L2 / L3 (see [layer-model.md](layer-model.md))        |
+| **Verdict**      | `overturned` \| `confirmed` \| `refined`                        |
+| **Pattern**      | `P-nn` if an existing pattern predicted it; `NEW` if it did not |
 
-| Field          | Meaning                                                         |
-| -------------- | --------------------------------------------------------------- |
-| **Assumption** | What was believed, in the words it was believed in              |
-| **Code fact**  | What is actually true, with `file:line`                         |
-| **Layer**      | L0 / L1 / L2 / L3 (see [layer-model.md](layer-model.md))        |
-| **Verdict**    | `overturned` \| `confirmed` \| `refined`                        |
-| **Pattern**    | `P-nn` if an existing pattern predicted it; `NEW` if it did not |
+Two rules keep this honest:
 
-`NEW` is the whole point. Every `NEW` row is a hole in the Pattern Base, and
-Step 6 of the workflow closes it.
+- **"What is true" is written in domain language, not implementation language.**
+  Not _"the enum has four values"_ — \*_"the business models four kinds of
+  agent-to-human message, and the surface renders one."_ If you cannot state the
+  fact without naming a table, it is probably not a product finding at all (see
+  [layer-model.md](layer-model.md#which-layer-is-a-given-finding-from)).
+- **`NEW` is the whole point.** Every `NEW` row is a hole in the Pattern Base, and
+  Step 6 closes it.
 
-### Worked rows — from the session that produced this skill
+### Worked rows — from the session that seeded this skill
 
-| Assumption                                  | Code fact                                                                                                   | Layer | Verdict    | Pattern      |
-| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ----- | ---------- | ------------ |
-| The home surface only ever has error briefs | `briefs.type` has four values, all produced in prod (`packages/types/src/brief/index.ts:37`)                | L1    | overturned | NEW → `P-04` |
-| Task `paused` means "suspended"             | It means **pending review**; shares the `waitingForHuman` glyph (`src/components/ExecutionStatus.ts:50-52`) | L2    | overturned | NEW → `P-01` |
-| Tool approval is two buttons                | It is a numbered radio list; the digits are the shortcuts (`.../Intervention/ApprovalActions.tsx`)          | L2    | overturned | NEW → `P-02` |
-| The spinner is a CSS keyframe               | It is an SVG `<animateTransform>` (`src/components/RingLoading.tsx`)                                        | L2    | overturned | NEW → `P-03` |
-| "Accept task" is a real action              | Assignment already wrote `assigneeUserId`; no pending state exists                                          | L1    | overturned | NEW → `P-05` |
-| Deleting the section shell is safe          | It mounted `Recommendations` + two modals in three branches                                                 | L1    | overturned | NEW → `P-08` |
-| A `projects` table exists                   | It does not; `GroupKey.Project` renders a knowledge base                                                    | L1    | overturned | NEW → `P-07` |
-| Conversations can be shown to the team      | `topics` has no `visibility` column — privacy red line                                                      | L1    | overturned | NEW → `P-06` |
-| The unread list needs a new endpoint        | `topicService.queryTopics({ statuses })` already returns it                                                 | L1    | overturned | NEW → `P-12` |
+| Assumption                                      | What is true                                                                                                                                                                   | Layer | Verdict    | Pattern      |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- | ---------- | ------------ |
+| The surface only ever has agent errors          | The business models four kinds of agent-to-human message — a decision to rule on, a deliverable to accept, an insight, an error. All four are produced daily; **one is shown** | L1    | overturned | NEW → `P-04` |
+| `paused` means the user suspended it            | It means **a human is blocking the agent** — pending review. It is the most urgent state on the page, not a "later" bucket                                                     | L1    | overturned | NEW → `P-01` |
+| "Request changes" leaves a comment              | It **re-tasks the agent**: resolves the item and re-runs it with the comment as input                                                                                          | L2    | overturned | NEW → `P-02` |
+| "Accept task" is a real action                  | Assignment is immediate and unilateral. There is no "offered, pending acceptance" state — the button implies you could decline, and you cannot                                 | L2    | overturned | NEW → `P-05` |
+| There is a project concept                      | There is not. The section named "Project" is a knowledge library                                                                                                               | L1    | overturned | NEW → `P-03` |
+| We can show the team what's being discussed     | Conversations have **no notion of belonging to a member**. Showing them is a domain change, not a layout choice                                                                | L1    | overturned | NEW → `P-06` |
+| A per-member unread badge is a UI decision      | "Unread" is a property of the conversation, not of a person                                                                                                                    | L1    | overturned | NEW → `P-06` |
+| Surfacing the unmodeled work needs new plumbing | The business already models "running" and "unread" work; it was simply never asked for                                                                                         | L1    | overturned | NEW → `P-10` |
+| Elapsed time per run can be shown               | The business does not model a run's duration at all                                                                                                                            | L1    | overturned | NEW → `P-11` |
 
-Nine assumptions, nine overturned, all `NEW` — which is exactly what a **cold
-start** looks like. A healthy mature run should be mostly `confirmed` with one
-or two `NEW`.
+Nine assumptions, nine overturned, all `NEW` — the **cold-start** signature. A
+mature run should be mostly `confirmed`, with one or two `NEW`.
 
 ## Reading the log
 
-The shape of the log _is_ the diagnosis of the session:
+The shape of the log **is** the diagnosis of the session:
 
-| Shape                                | What it means                                                                                                     |
-| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
-| Many `overturned`, all `NEW`         | Cold start. The Pattern Base was blind here — harvest it.                                                         |
-| Many `overturned`, all citing `P-nn` | **The patterns were not read.** Process failure, not a knowledge failure. Fix Step 0, not the design.             |
-| Mostly `confirmed`, one or two `NEW` | Healthy. The system is working.                                                                                   |
-| Zero rows                            | Either a trivial surface, or — far more likely — **nobody grounded anything.** Treat with suspicion.              |
-| Zero `NEW` across a whole round      | **Saturation.** L1/L2 are mined out for this surface (see [layer-model.md](layer-model.md#saturation-per-layer)). |
+| Shape                                | What it means                                                                                           |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| Many `overturned`, all `NEW`         | Cold start. The Pattern Base was blind here — harvest it.                                               |
+| Many `overturned`, all citing `P-nn` | **The patterns were not read.** A process failure, not a knowledge failure. Fix Step 0, not the design. |
+| Mostly `confirmed`, one or two `NEW` | Healthy. The system is working.                                                                         |
+| Zero rows                            | Either a trivial surface, or — far more likely — **nobody grounded anything.** Treat with suspicion.    |
+| Zero `NEW` across a whole round      | **Saturation.** L1/L2 are mined out for this surface.                                                   |
 
-That second row is worth dwelling on. If the code keeps overturning things the
-Pattern Base _already knew_, the skill is fine and the run was sloppy. The fix is
-to actually read Step 0 — not to add more patterns.
+That second row is worth dwelling on. If the business keeps overturning things the
+Pattern Base **already knew**, the skill is fine and the run was sloppy. The fix
+is to read Step 0 — not to add more patterns.
 
 ## Marking debt on the prototype itself
 
-Anything the design shows that the data cannot supply gets a visible `NEW` tag
+Anything the design shows that the business cannot back gets a visible `NEW` tag
 **on the mock**, not just in the spec. A reviewer looking at a picture must be
-able to see which parts are real.
+able to tell which parts are real.
 
 ```
-累计已执行 11h 06m  [NEW]     ← no column for this; would need a new query
+Total time on this: 11h 06m   [NEW]   ← the business does not model run duration
 ```
 
-This is the cheapest possible defense against `P-05`-class fake affordances: if
-you cannot name the column, you must draw the tag.
+This is the cheapest defense against `P-05`-class theatre: **if you cannot name
+the business event behind an element, you must draw the tag.**
 
 ## Why the log, and not just a good memory
 
 The Pattern Base is the skill's long-term memory; the reality-check log is its
 short-term one. Skipping the log does not merely lose a document — it breaks the
-**C** (Closed Loop) of SCLPT, and the next session re-learns the same nine
-lessons from scratch.
+**C** (Closed Loop) of SCLPT, and the next session re-learns the same nine lessons
+from scratch.

--- a/.agents/skills/product-design/references/trace-schema.md
+++ b/.agents/skills/product-design/references/trace-schema.md
@@ -17,13 +17,13 @@ the system**, and it is the one that gets skipped.
 One row per assumption that met the business model. It lives as a section
 **inside the spec** — a separate file goes unread.
 
-| Field            | Meaning                                                         |
-| ---------------- | --------------------------------------------------------------- |
-| **Assumption**   | What was believed, in the words it was believed in              |
-| **What is true** | The business fact that overturned it, in **domain language**    |
-| **Layer**        | L0 / L1 / L2 / L3 (see [layer-model.md](layer-model.md))        |
-| **Verdict**      | `overturned` \| `confirmed` \| `refined`                        |
-| **Pattern**      | `P-nn` if an existing pattern predicted it; `NEW` if it did not |
+| Field            | Meaning                                                                                    |
+| ---------------- | ------------------------------------------------------------------------------------------ |
+| **Assumption**   | What was believed, in the words it was believed in                                         |
+| **What is true** | The business fact that overturned it, in **domain language**                               |
+| **Model**        | Which of Cooper's three models this is a fact about (see [layer-model.md](layer-model.md)) |
+| **Verdict**      | `overturned` \| `confirmed` \| `refined`                                                   |
+| **Pattern**      | `P-nn` if an existing pattern predicted it; `NEW` if it did not                            |
 
 Two rules keep this honest:
 
@@ -37,17 +37,17 @@ Two rules keep this honest:
 
 ### Worked rows — from the session that seeded this skill
 
-| Assumption                                      | What is true                                                                                                                                                                   | Layer | Verdict    | Pattern      |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- | ---------- | ------------ |
-| The surface only ever has agent errors          | The business models four kinds of agent-to-human message — a decision to rule on, a deliverable to accept, an insight, an error. All four are produced daily; **one is shown** | L1    | overturned | NEW → `P-04` |
-| `paused` means the user suspended it            | It means **a human is blocking the agent** — pending review. It is the most urgent state on the page, not a "later" bucket                                                     | L1    | overturned | NEW → `P-01` |
-| "Request changes" leaves a comment              | It **re-tasks the agent**: resolves the item and re-runs it with the comment as input                                                                                          | L2    | overturned | NEW → `P-02` |
-| "Accept task" is a real action                  | Assignment is immediate and unilateral. There is no "offered, pending acceptance" state — the button implies you could decline, and you cannot                                 | L2    | overturned | NEW → `P-05` |
-| There is a project concept                      | There is not. The section named "Project" is a knowledge library                                                                                                               | L1    | overturned | NEW → `P-03` |
-| We can show the team what's being discussed     | Conversations have **no notion of belonging to a member**. Showing them is a domain change, not a layout choice                                                                | L1    | overturned | NEW → `P-06` |
-| A per-member unread badge is a UI decision      | "Unread" is a property of the conversation, not of a person                                                                                                                    | L1    | overturned | NEW → `P-06` |
-| Surfacing the unmodeled work needs new plumbing | The business already models "running" and "unread" work; it was simply never asked for                                                                                         | L1    | overturned | NEW → `P-10` |
-| Elapsed time per run can be shown               | The business does not model a run's duration at all                                                                                                                            | L1    | overturned | NEW → `P-11` |
+| Assumption                                      | What is true                                                                                                                                                                   | Layer          | Verdict    | Pattern      |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- | ---------- | ------------ |
+| The surface only ever has agent errors          | The business models four kinds of agent-to-human message — a decision to rule on, a deliverable to accept, an insight, an error. All four are produced daily; **one is shown** | implementation | overturned | NEW → `P-04` |
+| `paused` means the user suspended it            | It means **a human is blocking the agent** — pending review. It is the most urgent state on the page, not a "later" bucket                                                     | implementation | overturned | NEW → `P-01` |
+| "Request changes" leaves a comment              | It **re-tasks the agent**: resolves the item and re-runs it with the comment as input                                                                                          | implementation | overturned | NEW → `P-02` |
+| "Accept task" is a real action                  | Assignment is immediate and unilateral. There is no "offered, pending acceptance" state — the button implies you could decline, and you cannot                                 | implementation | overturned | NEW → `P-05` |
+| There is a project concept                      | There is not. The section named "Project" is a knowledge library                                                                                                               | implementation | overturned | NEW → `P-03` |
+| We can show the team what's being discussed     | Conversations have **no notion of belonging to a member**. Showing them is a domain change, not a layout choice                                                                | implementation | overturned | NEW → `P-06` |
+| A per-member unread badge is a UI decision      | "Unread" is a property of the conversation, not of a person                                                                                                                    | implementation | overturned | NEW → `P-06` |
+| Surfacing the unmodeled work needs new plumbing | The business already models "running" and "unread" work; it was simply never asked for                                                                                         | implementation | overturned | NEW → `P-10` |
+| Elapsed time per run can be shown               | The business does not model a run's duration at all                                                                                                                            | implementation | overturned | NEW → `P-11` |
 
 Nine assumptions, nine overturned, all `NEW` — the **cold-start** signature. A
 mature run should be mostly `confirmed`, with one or two `NEW`.
@@ -62,7 +62,7 @@ The shape of the log **is** the diagnosis of the session:
 | Many `overturned`, all citing `P-nn` | **The patterns were not read.** A process failure, not a knowledge failure. Fix Step 0, not the design. |
 | Mostly `confirmed`, one or two `NEW` | Healthy. The system is working.                                                                         |
 | Zero rows                            | Either a trivial surface, or — far more likely — **nobody grounded anything.** Treat with suspicion.    |
-| Zero `NEW` across a whole round      | **Saturation.** L1/L2 are mined out for this surface.                                                   |
+| Zero `NEW` across a whole round      | **Saturation.** The implementation model is mined out for this surface.                                 |
 
 That second row is worth dwelling on. If the business keeps overturning things the
 Pattern Base **already knew**, the skill is fine and the run was sloppy. The fix

--- a/.agents/skills/product-design/references/worked-example.md
+++ b/.agents/skills/product-design/references/worked-example.md
@@ -119,10 +119,10 @@ done at all. The next round's budget belongs there.
 
 ## What generalizes
 
-1. **The biggest win was a switched-off capability, not a new one.** Look for
-   those first. A business that models more than it shows is free product, and in
-   a system where agents generate events continuously, this is now the normal
-   case.
+1. **The biggest win was a switched-off capability, not a new one.** Check for one
+   before inventing anything — it is the cheapest win available, and the easiest
+   to miss, because the surface is what everyone (including the people who built
+   it) mistakes for the product.
 2. **Every prototype round should be falsified by the domain.** If it is not, you
    are decorating, not designing.
 3. **"What does the business already believe in?" is the question that converts a

--- a/.agents/skills/product-design/references/worked-example.md
+++ b/.agents/skills/product-design/references/worked-example.md
@@ -1,0 +1,122 @@
+# Worked Example — the home inbox
+
+One complete trace, end to end. This is the session that seeded the Pattern Base,
+so every mistake in it is real.
+
+**Ask (L0)**: _"Look at our home surface. It hasn't had any design thought put
+into it. What should actually be here?"_
+
+Note what the ask is **not**: it is not a bug, not a spec, not a list of
+requirements. It is a feeling. Everything below is the work of turning that into
+something buildable.
+
+---
+
+## Step 1 — Ground
+
+Two read-only subagents, in parallel: _how is this surface assembled?_ and _what
+can the underlying tables actually produce?_
+
+The second one is where the redesign was won. The surface rendered a single
+brief type — errors — so it read as an error log. But `briefs` turned out to be
+**a complete agent → human decision inbox** that nobody was using:
+
+- four `type` values (`decision` / `result` / `insight` / `error`), **all
+  produced in production** — an agent pausing a task for approval writes
+  `decision`; task completion writes `result`; a watchdog writes `error`
+- `priority`, interactive `actions` (Confirm / Request changes / Retry), linked
+  `artifacts`, and a full read → resolve lifecycle
+
+**The most valuable finding of the whole session was that three quarters of an
+existing feature were switched off.** No amount of staring at the screenshot
+would have produced it (`P-04`).
+
+## Step 2 — Diagnose (structural, not aesthetic)
+
+Three structural errors, each independent of taste:
+
+1. **A decision inbox is being used as an error log.** (Above.)
+2. **The surface is trying to be both a triage desk and a reading room.** Each
+   card carried a paragraph-length summary — _too short to replace the document,
+   too long to scan_. Users neither read it nor skipped it cleanly. (`P-09`, `P-10`)
+3. **Signals were grouped by producer, not by required action.** What the user
+   needs is "what is blocked on me", not "what did the agent say". (`P-11`)
+
+## Step 3 — Align
+
+Decisions surfaced one at a time, each with a recommendation. The two that
+changed the shape of the answer:
+
+- _Is the primary axis attention (what needs me) or progress (what's moving)?_
+  → **attention.** Progress is context; attention is the reason to open the page.
+- _Is the attention source agents, humans, or both?_ → **both, one inbox.**
+  An agent saying "I'm stuck" and a colleague saying "@you" are the same signal
+  to the person receiving them (`P-11`).
+
+The human overruled the agent's first framing here — it had proposed organizing
+around tasks, and the reply was, roughly: _"it should be organized around the
+work, and around attention and goals — not around one entity type."_ That
+correction is `P-11`.
+
+## Step 4 — Prototype
+
+Six iterations in the real design system. Every round, the code overturned
+something:
+
+| Round | The prototype claimed          | The code said                                                           |
+| ----- | ------------------------------ | ----------------------------------------------------------------------- |
+| v3    | invented status groups & icons | `ExecutionStatus.ts` is canonical; `paused` = _pending review_ (`P-01`) |
+| v4    | tool approval = two buttons    | it is a numbered radio list; digits are the shortcuts (`P-02`)          |
+| v4    | CSS keyframe spinner           | `RingLoading.tsx` — SVG `<animateTransform>` (`P-03`)                   |
+| v5    | "Accept task" button           | assignment already wrote `assigneeUserId`; no such transition (`P-05`)  |
+| v6    | `#seq · 4m 12s` on every run   | no duration column anywhere — computed client-side (`P-13`)             |
+
+Five of the six Pattern Base Class-A/B entries came from these five rows. **The
+prototype's job is not to be right — it is to be wrong in ways the code can
+correct.**
+
+## Step 5 — Scope: three buckets
+
+| Bucket                     | Capability                                                                                                                                                                                                                  |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ✅ **Now**                 | All four brief types (already stored). Running + unread topics — **one existing endpoint**, `queryTopics({ statuses })`. Status icons — import `ExecutionStatus.ts`. Resolve / feedback actions — reuse `BriefCardActions`. |
+| ⚠️ **Blocked by a select** | The task's `T-42` ref and name: `listUnresolvedEnriched` **already joins `tasks`** but selects only `status`. Two more columns.                                                                                             |
+| ❌ **New model**           | Mentions. Annotations. Presence. A `projects` entity. Per-run duration.                                                                                                                                                     |
+
+**Shipped: everything in ✅ plus the two-column select.** Zero new tables, zero
+migrations. The ❌ bucket went into the spec by name, with its cost (`P-13`).
+
+The redesign that had started as a sweeping team-collaboration vision shipped as
+a focused personal inbox — **not as a retreat, but because that was the part that
+was real today** (`P-12`).
+
+## The trap that nearly shipped
+
+Deleting the old section shell would have silently removed `Recommendations`,
+`DocumentPreviewModal` and `TopicChatDrawer` — all mounted _inside_ it, across
+three render branches. No type error. No failing test. The artifact-preview and
+"view run" buttons would have rendered and done nothing.
+
+Caught by grepping the render tree before deleting (`P-08`), re-mounted in the
+new composition, and each one given **its own end-to-end verification case** —
+because this class of regression is invisible to the compiler and to unit tests.
+
+## Step 6 — Close the loop
+
+Nine assumptions overturned, nine `NEW` → patterns `P-01` … `P-08`, `P-12`.
+That is the cold-start signature (see
+[trace-schema.md](trace-schema.md#reading-the-log)).
+
+**Saturation, honestly assessed**: L1/L2 for this surface are close to mined out
+— a second grounding pass over `briefs` / `topics` / `tasks` would likely turn up
+little. L0 is wide open: the team-collaboration half of the original ask was
+never answered, only deferred.
+
+## What generalizes
+
+1. **The biggest win was a switched-off feature, not a new one.** Look for those
+   first — a table whose enum the UI ignores is free product.
+2. **Every prototype round should be falsified by code.** A round that only
+   moves pixels means grounding was skipped.
+3. **The shippable subset is a discipline, not a compromise.** "What needs zero
+   new tables?" is the question that converts a vision into a merged PR.

--- a/.agents/skills/product-design/references/worked-example.md
+++ b/.agents/skills/product-design/references/worked-example.md
@@ -3,7 +3,7 @@
 One complete trace. This is the session that seeded the Pattern Base, so every
 mistake in it is real.
 
-**The ask (L0)**: _"Look at our home surface. Nobody has put any design thought
+**The ask**: _"Look at our home surface. Nobody has put any design thought
 into it. What should actually be there?"_
 
 Note what the ask is **not**: not a bug, not a spec, not a requirement list. It is
@@ -109,10 +109,13 @@ being argued about.
 Nine assumptions overturned, nine `NEW` → the entire Pattern Base. That is the
 cold-start signature (see [trace-schema.md](trace-schema.md#reading-the-log)).
 
-**Saturation, honestly**: L1/L2 for this surface are close to mined out — a second
-pass over the same domain would likely turn up little. **L0 is wide open**: the
-team-collaboration half of the original ask was never answered, only deferred.
-The next round's budget belongs there.
+**Saturation, honestly**: the implementation model for this surface is close to
+mined out — a second pass over the same domain would turn up little.
+
+**And every one of the nine rows is an implementation-model finding. Not one is
+about the mental model.** That is the real verdict on this session: the half that
+could be done from a desk was done well, and the half that requires a user was not
+done at all. The next round's budget belongs there.
 
 ## What generalizes
 

--- a/.agents/skills/product-design/references/worked-example.md
+++ b/.agents/skills/product-design/references/worked-example.md
@@ -1,122 +1,126 @@
-# Worked Example — the home inbox
+# Worked Example — the agent inbox
 
-One complete trace, end to end. This is the session that seeded the Pattern Base,
-so every mistake in it is real.
+One complete trace. This is the session that seeded the Pattern Base, so every
+mistake in it is real.
 
-**Ask (L0)**: _"Look at our home surface. It hasn't had any design thought put
-into it. What should actually be here?"_
+**The ask (L0)**: _"Look at our home surface. Nobody has put any design thought
+into it. What should actually be there?"_
 
-Note what the ask is **not**: it is not a bug, not a spec, not a list of
-requirements. It is a feeling. Everything below is the work of turning that into
-something buildable.
+Note what the ask is **not**: not a bug, not a spec, not a requirement list. It is
+a feeling. Everything below is the work of turning that into something buildable.
 
 ---
 
 ## Step 1 — Ground
 
-Two read-only subagents, in parallel: _how is this surface assembled?_ and _what
-can the underlying tables actually produce?_
+The surface showed agent **errors**. So the team had been reasoning about it as an
+error log — _"how do we make the error list nicer?"_
 
-The second one is where the redesign was won. The surface rendered a single
-brief type — errors — so it read as an error log. But `briefs` turned out to be
-**a complete agent → human decision inbox** that nobody was using:
+Grounding the domain turned that upside down. The business models **four kinds of
+agent-to-human message**, and produces all four in production every day:
 
-- four `type` values (`decision` / `result` / `insight` / `error`), **all
-  produced in production** — an agent pausing a task for approval writes
-  `decision`; task completion writes `result`; a watchdog writes `error`
-- `priority`, interactive `actions` (Confirm / Request changes / Retry), linked
-  `artifacts`, and a full read → resolve lifecycle
+| Kind         | What it means, in the business                                            |
+| ------------ | ------------------------------------------------------------------------- |
+| **decision** | The agent has paused mid-work and needs a human to rule on something      |
+| **result**   | The agent has produced a deliverable and is waiting for it to be accepted |
+| **insight**  | The agent found something worth knowing. Nothing to decide                |
+| **error**    | The run failed                                                            |
 
-**The most valuable finding of the whole session was that three quarters of an
-existing feature were switched off.** No amount of staring at the screenshot
-would have produced it (`P-04`).
+Each carries a priority, a set of possible responses, and its own linked
+deliverables. Each has a full seen → answered lifecycle.
 
-## Step 2 — Diagnose (structural, not aesthetic)
+**Three of the four were never shown to anyone.**
 
-Three structural errors, each independent of taste:
+The surface was not an error log in need of polish. It was **a decision inbox
+with three of its four channels switched off** (`P-04`). That single finding was
+worth more than everything else in the redesign combined — and no amount of
+staring at the screenshot would ever have produced it.
+
+Two more findings from the same pass, both about **meaning, not mechanism**:
+
+- A task state named `paused` does not mean "the user suspended this". It means
+  **an agent is blocked, waiting for a human** — the most urgent thing on the page
+  (`P-01`).
+- The action labelled "Request changes" does not leave a comment. It **re-tasks
+  the agent**, feeding the comment back in as new input (`P-02`).
+
+## Step 2 — Diagnose
+
+Three structural errors, none of them about taste:
 
 1. **A decision inbox is being used as an error log.** (Above.)
-2. **The surface is trying to be both a triage desk and a reading room.** Each
-   card carried a paragraph-length summary — _too short to replace the document,
-   too long to scan_. Users neither read it nor skipped it cleanly. (`P-09`, `P-10`)
-3. **Signals were grouped by producer, not by required action.** What the user
-   needs is "what is blocked on me", not "what did the agent say". (`P-11`)
+2. **The surface is a triage desk and a reading room at once, and fails at both.**
+   Every card carried a paragraph-length summary — _too short to replace the
+   document, too long to scan_. Users neither read it nor skipped it cleanly
+   (`P-07`, `P-08`).
+3. **Signals were grouped by who produced them, not by what they demand.** What
+   the user needs to know is _"what is blocked on me"_, not _"what did the agent
+   say"_ (`P-09`).
 
 ## Step 3 — Align
 
-Decisions surfaced one at a time, each with a recommendation. The two that
-changed the shape of the answer:
+Decisions surfaced one at a time. The two that changed the shape of the answer:
 
 - _Is the primary axis attention (what needs me) or progress (what's moving)?_
-  → **attention.** Progress is context; attention is the reason to open the page.
-- _Is the attention source agents, humans, or both?_ → **both, one inbox.**
-  An agent saying "I'm stuck" and a colleague saying "@you" are the same signal
-  to the person receiving them (`P-11`).
+  → **attention.** Progress is context; attention is the reason to open the page
+  at all.
+- _Do agent signals and human signals belong in one inbox or two?_ → **one.**
+  An agent saying "I'm stuck" and a colleague saying "@you" are, to the person
+  receiving them, the same signal (`P-09`).
 
-The human overruled the agent's first framing here — it had proposed organizing
-around tasks, and the reply was, roughly: _"it should be organized around the
+The human overruled the first framing here. The agent had proposed organizing
+everything around **tasks**; the reply was, roughly: _"organize it around the
 work, and around attention and goals — not around one entity type."_ That
-correction is `P-11`.
+correction became `P-09`.
 
 ## Step 4 — Prototype
 
-Six iterations in the real design system. Every round, the code overturned
+Six rounds in the real design system. Every round, the business overturned
 something:
 
-| Round | The prototype claimed          | The code said                                                           |
-| ----- | ------------------------------ | ----------------------------------------------------------------------- |
-| v3    | invented status groups & icons | `ExecutionStatus.ts` is canonical; `paused` = _pending review_ (`P-01`) |
-| v4    | tool approval = two buttons    | it is a numbered radio list; digits are the shortcuts (`P-02`)          |
-| v4    | CSS keyframe spinner           | `RingLoading.tsx` — SVG `<animateTransform>` (`P-03`)                   |
-| v5    | "Accept task" button           | assignment already wrote `assigneeUserId`; no such transition (`P-05`)  |
-| v6    | `#seq · 4m 12s` on every run   | no duration column anywhere — computed client-side (`P-13`)             |
+| Round | The prototype claimed             | The business said                                                      |
+| ----- | --------------------------------- | ---------------------------------------------------------------------- |
+| v3    | invented its own state vocabulary | `paused` already means _pending review_ — a human is blocking (`P-01`) |
+| v4    | "Request changes" = a comment box | it re-tasks the agent (`P-02`)                                         |
+| v5    | an "Accept task" button           | assignment is immediate; there is no state to accept from (`P-05`)     |
+| v6    | each run's elapsed time           | the business does not model a run's duration at all (`P-11`)           |
 
-Five of the six Pattern Base Class-A/B entries came from these five rows. **The
-prototype's job is not to be right — it is to be wrong in ways the code can
-correct.**
+**The prototype's job is not to be right. It is to be wrong in ways the business
+can correct.** A round that only moves pixels means the grounding was skipped.
 
-## Step 5 — Scope: three buckets
+## Step 5 — Scope
 
-| Bucket                     | Capability                                                                                                                                                                                                                  |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ✅ **Now**                 | All four brief types (already stored). Running + unread topics — **one existing endpoint**, `queryTopics({ statuses })`. Status icons — import `ExecutionStatus.ts`. Resolve / feedback actions — reuse `BriefCardActions`. |
-| ⚠️ **Blocked by a select** | The task's `T-42` ref and name: `listUnresolvedEnriched` **already joins `tasks`** but selects only `status`. Two more columns.                                                                                             |
-| ❌ **New model**           | Mentions. Annotations. Presence. A `projects` entity. Per-run duration.                                                                                                                                                     |
+| Bucket                                   | Capability                                                                                               |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| ✅ **Modeled and exposed**               | The error channel. The existing response actions.                                                        |
+| ⚠️ **Modeled, never exposed**            | **The other three message kinds.** Running work. Unread finished work. The task each message belongs to. |
+| ❌ **Not a concept in the business yet** | Mentions of a person. Annotations. Presence. A project. A run's duration.                                |
 
-**Shipped: everything in ✅ plus the two-column select.** Zero new tables, zero
-migrations. The ❌ bucket went into the spec by name, with its cost (`P-13`).
+**Shipped: ✅ + ⚠️.** Nothing in the ❌ column. Every item there went into the
+spec by name, with its cost (`P-11`).
 
-The redesign that had started as a sweeping team-collaboration vision shipped as
-a focused personal inbox — **not as a retreat, but because that was the part that
-was real today** (`P-12`).
-
-## The trap that nearly shipped
-
-Deleting the old section shell would have silently removed `Recommendations`,
-`DocumentPreviewModal` and `TopicChatDrawer` — all mounted _inside_ it, across
-three render branches. No type error. No failing test. The artifact-preview and
-"view run" buttons would have rendered and done nothing.
-
-Caught by grepping the render tree before deleting (`P-08`), re-mounted in the
-new composition, and each one given **its own end-to-end verification case** —
-because this class of regression is invisible to the compiler and to unit tests.
+The redesign that began as a sweeping team-collaboration vision shipped as a
+focused personal inbox — **not as a retreat, but because that was the part the
+business already believed in** (`P-10`). The expensive half is still, correctly,
+being argued about.
 
 ## Step 6 — Close the loop
 
-Nine assumptions overturned, nine `NEW` → patterns `P-01` … `P-08`, `P-12`.
-That is the cold-start signature (see
-[trace-schema.md](trace-schema.md#reading-the-log)).
+Nine assumptions overturned, nine `NEW` → the entire Pattern Base. That is the
+cold-start signature (see [trace-schema.md](trace-schema.md#reading-the-log)).
 
-**Saturation, honestly assessed**: L1/L2 for this surface are close to mined out
-— a second grounding pass over `briefs` / `topics` / `tasks` would likely turn up
-little. L0 is wide open: the team-collaboration half of the original ask was
-never answered, only deferred.
+**Saturation, honestly**: L1/L2 for this surface are close to mined out — a second
+pass over the same domain would likely turn up little. **L0 is wide open**: the
+team-collaboration half of the original ask was never answered, only deferred.
+The next round's budget belongs there.
 
 ## What generalizes
 
-1. **The biggest win was a switched-off feature, not a new one.** Look for those
-   first — a table whose enum the UI ignores is free product.
-2. **Every prototype round should be falsified by code.** A round that only
-   moves pixels means grounding was skipped.
-3. **The shippable subset is a discipline, not a compromise.** "What needs zero
-   new tables?" is the question that converts a vision into a merged PR.
+1. **The biggest win was a switched-off capability, not a new one.** Look for
+   those first. A business that models more than it shows is free product, and in
+   a system where agents generate events continuously, this is now the normal
+   case.
+2. **Every prototype round should be falsified by the domain.** If it is not, you
+   are decorating, not designing.
+3. **"What does the business already believe in?" is the question that converts a
+   vision into something that ships.**

--- a/.agents/skills/product-design/templates/design-spec.md
+++ b/.agents/skills/product-design/templates/design-spec.md
@@ -7,17 +7,25 @@
 
 ---
 
-## 1. Current state (grounded)
+## 1. What the business actually models
 
-What renders today, and where each piece's data comes from. **Every claim needs
-`file:line`.** If you cannot cite it, you have not grounded it — go read the code.
+Not what the surface shows — what the **business** has. For the concepts this
+surface touches:
+
+- Which concepts, states and roles exist
+- **What each state obliges someone to do** (a state nobody must act on is not a
+  queue; a state a human is blocking is)
+- **What each action does to the business** — the event it produces, in domain
+  language
+- **Which concepts the business does _not_ have.** Absences are findings, and
+  they are the expensive ones
 
 ---
 
 ## 2. Diagnosis
 
-Name the **structural** error(s). Not "it looks dated" — something that is wrong
-regardless of taste. See [pattern-base.md](../references/pattern-base.md) Class E.
+Name the **structural** error(s) — something wrong regardless of taste. Not "it
+looks dated".
 
 If you cannot name one, you do not have a diagnosis. You have an opinion.
 
@@ -25,62 +33,66 @@ If you cannot name one, you do not have a diagnosis. You have an opinion.
 
 ## 3. Principles
 
-Only principles this diagnosis actually forced. Each one should have a **rejected
+Only the principles this diagnosis actually forced. Each with a **rejected
 alternative** attached — a principle with no rejected alternative is decoration.
 
 ---
 
 ## 4. Information architecture
 
-The proposed structure, block by block. For each block, state:
+Block by block. For each:
 
 - what lands there, and **why that and not something else**
-- the exact data source (`table.column` / endpoint)
-- what happens when it is empty, and when it is at 100×
+- the **business concept** behind it
+- what it looks like empty, and at 100×
 
 ---
 
-## 5. Data capability audit
+## 5. Scope — what does the business already support?
 
-The step that decides scope. Sort everything the design needs:
+| Bucket                               | Capability | Meaning                             |
+| ------------------------------------ | ---------- | ----------------------------------- |
+| ✅ Already modeled, already exposed  |            | Rearranging what is there           |
+| ⚠️ Already modeled, never exposed    |            | Nearly free product                 |
+| ❌ Not a concept in the business yet |            | A domain change. Order of magnitude |
 
-| Bucket                           | Capability | Cost      |
-| -------------------------------- | ---------- | --------- |
-| ✅ Available now                 |            | zero      |
-| ⚠️ Blocked by a predicate/select |            | cheap     |
-| ❌ Needs a new model             |            | expensive |
-
-**What ships this round:** the ✅ subset (+ ⚠️ if genuinely cheap).
-**What does not, and why:** name every ❌ item with its cost. Silence reads as an
-oversight (`P-13`).
+**Ships this round:** ✅ + ⚠️.
+**Does not, and why:** every ❌ item **by name, with its cost**. Silence reads as
+an oversight (`P-11`).
 
 ---
 
-## 6. Constraints and red lines
+## 6. Red lines
 
-Hard limits the design must respect — missing columns, ownership predicates,
-privacy boundaries. **Bold them.** These are not preferences (`P-06`).
+Concepts the business does not have, which therefore cannot be designed around —
+only proposed as domain changes. **Bold them.** These are not preferences
+(`P-06`).
 
 ---
 
 ## 7. Reality-check log
 
-The `T` of SCLPT. One row per assumption that met the code.
+The `T` of SCLPT. One row per assumption that met the business model.
 Schema: [trace-schema.md](../references/trace-schema.md).
 
-| Assumption | Code fact (`file:line`) | Layer | Verdict | Pattern |
-| ---------- | ----------------------- | ----- | ------- | ------- |
-|            |                         |       |         |         |
+**"What is true" must be written in domain language.** If you cannot state the
+fact without naming a table, it is probably not a product finding.
+
+| Assumption | What is true | Layer | Verdict | Pattern |
+| ---------- | ------------ | ----- | ------- | ------- |
+|            |              |       |         |         |
 
 **Saturation:** did this round's grounding overturn anything? If a full pass
 overturned nothing, say so — L1/L2 are mined out for this surface, and the next
 round's budget belongs to L0.
 
 **New patterns written back:** `P-nn`, … (or "none — all predicted").
+Check each against [canon.md](../references/canon.md) first: an instance of
+something already named, or genuinely new?
 
 ---
 
 ## 8. Open decisions
 
-Only the ones that **change the shape of the answer**. Each with a
-recommendation and its reasoning. Not a list of everything unresolved.
+Only the ones that **change the shape of the answer**. Each with a recommendation
+and its reasoning. Not a list of everything unresolved.

--- a/.agents/skills/product-design/templates/design-spec.md
+++ b/.agents/skills/product-design/templates/design-spec.md
@@ -1,0 +1,86 @@
+# <Surface> — <what this round changes>
+
+**Date:** YYYY-MM-DD
+**Status:** aligning | scoped | shipped
+**Scope:** one sentence. Say what is **out** of scope too.
+**Prototype:** path, if any
+
+---
+
+## 1. Current state (grounded)
+
+What renders today, and where each piece's data comes from. **Every claim needs
+`file:line`.** If you cannot cite it, you have not grounded it — go read the code.
+
+---
+
+## 2. Diagnosis
+
+Name the **structural** error(s). Not "it looks dated" — something that is wrong
+regardless of taste. See [pattern-base.md](../references/pattern-base.md) Class E.
+
+If you cannot name one, you do not have a diagnosis. You have an opinion.
+
+---
+
+## 3. Principles
+
+Only principles this diagnosis actually forced. Each one should have a **rejected
+alternative** attached — a principle with no rejected alternative is decoration.
+
+---
+
+## 4. Information architecture
+
+The proposed structure, block by block. For each block, state:
+
+- what lands there, and **why that and not something else**
+- the exact data source (`table.column` / endpoint)
+- what happens when it is empty, and when it is at 100×
+
+---
+
+## 5. Data capability audit
+
+The step that decides scope. Sort everything the design needs:
+
+| Bucket                           | Capability | Cost      |
+| -------------------------------- | ---------- | --------- |
+| ✅ Available now                 |            | zero      |
+| ⚠️ Blocked by a predicate/select |            | cheap     |
+| ❌ Needs a new model             |            | expensive |
+
+**What ships this round:** the ✅ subset (+ ⚠️ if genuinely cheap).
+**What does not, and why:** name every ❌ item with its cost. Silence reads as an
+oversight (`P-13`).
+
+---
+
+## 6. Constraints and red lines
+
+Hard limits the design must respect — missing columns, ownership predicates,
+privacy boundaries. **Bold them.** These are not preferences (`P-06`).
+
+---
+
+## 7. Reality-check log
+
+The `T` of SCLPT. One row per assumption that met the code.
+Schema: [trace-schema.md](../references/trace-schema.md).
+
+| Assumption | Code fact (`file:line`) | Layer | Verdict | Pattern |
+| ---------- | ----------------------- | ----- | ------- | ------- |
+|            |                         |       |         |         |
+
+**Saturation:** did this round's grounding overturn anything? If a full pass
+overturned nothing, say so — L1/L2 are mined out for this surface, and the next
+round's budget belongs to L0.
+
+**New patterns written back:** `P-nn`, … (or "none — all predicted").
+
+---
+
+## 8. Open decisions
+
+Only the ones that **change the shape of the answer**. Each with a
+recommendation and its reasoning. Not a list of everything unresolved.

--- a/.agents/skills/product-design/templates/design-spec.md
+++ b/.agents/skills/product-design/templates/design-spec.md
@@ -78,13 +78,13 @@ Schema: [trace-schema.md](../references/trace-schema.md).
 **"What is true" must be written in domain language.** If you cannot state the
 fact without naming a table, it is probably not a product finding.
 
-| Assumption | What is true | Layer | Verdict | Pattern |
+| Assumption | What is true | Model | Verdict | Pattern |
 | ---------- | ------------ | ----- | ------- | ------- |
 |            |              |       |         |         |
 
 **Saturation:** did this round's grounding overturn anything? If a full pass
-overturned nothing, say so — L1/L2 are mined out for this surface, and the next
-round's budget belongs to L0.
+overturned nothing, say so — the implementation model is mined out for this
+surface, and the next round's budget belongs to the **mental** model.
 
 **New patterns written back:** `P-nn`, … (or "none — all predicted").
 Check each against [canon.md](../references/canon.md) first: an instance of


### PR DESCRIPTION
#### 💻 Change Type

- [x] 📝 docs

#### 🔗 Related Issue

Structured per **BM-58 — SCLPT: the five-element framework for self-evolving systems**.

#### 🔀 Description of Change

The upstream half of design had no skill behind it. `ux` is the rulebook and `ux-audit` enforces it on a finished surface — but nothing covered the step before either: **turning "this page feels wrong" into a scoped, shippable design.**

| Skill | Question | When |
| --- | --- | --- |
| **product-design** (new) | What should this surface *be*, and why? | Before there is a design |
| `ux` | How should it feel? What are the rules? | While building |
| `ux-audit` | Does the built screen honor those rules? | After it exists |

Its one non-negotiable rule: **never propose from imagination — reverse-engineer the code first.** Every expensive mistake it exists to prevent has the same shape: inventing something the codebase already has, or designing an affordance for data that does not exist. Both look completely reasonable on a slide.

##### Wired as SCLPT, so it gets stricter each run

| | File | Role |
| --- | --- | --- |
| **P** Pattern Base | `references/pattern-base.md` | The learned rules — read before every run, appended after |
| **L** Layer Model | `references/layer-model.md` | L0 intent / L1 data / L2 contract / L3 presentation, so an L3 argument can never settle an L1 question |
| **T** Trace Schema | `references/trace-schema.md` | Every session leaves a reality-check log: assumption → code fact → who won |
| **C** Closed Loop | Step 6 | Each overturned assumption becomes a new pattern |
| **S** Saturation | Step 6 | A grounding round that overturns *nothing* = L1/L2 are mined out for that surface |

##### The Pattern Base is seeded from a real session, not from theory

Every one of the 13 patterns cites the `file:line` that overturned it. They came out of the home-inbox redesign (#17194), which produced **nine overturned assumptions** — the cold-start signature:

- A **fake "Accept task" button** for a transition the schema has no state for — assignment already wrote `assigneeUserId` (`P-05`).
- An **invented status system**, when `ExecutionStatus.ts` is canonical — and its semantics contradicted the invention: task `paused` means *pending review*, not *suspended* (`P-01`).
- An **invented approval UI** (two buttons), when the real `ApprovalActions` is a numbered radio list whose digits *are* the keyboard shortcuts (`P-02`).
- A **CSS keyframe spinner**, when `RingLoading.tsx` is an SVG `<animateTransform>` — and there is a second, deliberately different one for activity feeds (`P-03`).
- A **section-shell deletion** that would have silently taken `Recommendations` + two mounted modals down with it — no type error, no failing test, buttons that render and do nothing (`P-08`).
- **`topics` has no `visibility` column**, which turns "show what the team is working on" into a privacy incident the moment it includes conversations (`P-06`).

Plus the judgment rules that survived contact with the code: a home surface is a **triage desk, not a dashboard** (`P-09`); **density follows decision cost**, not text length (`P-10`); **group by the action required, not the source entity** (`P-11`); and the **three-bucket audit** — available now / blocked by a select / needs a new model — which decides scope instead of taste (`P-12`).

##### Files

```
.agents/skills/product-design/
├── SKILL.md                        # the 6-step workflow + SCLPT wiring
├── references/
│   ├── pattern-base.md             # P — 13 seeded patterns, all cited
│   ├── layer-model.md              # L — 4 layers + the 4 cross-layer misjudgments
│   ├── trace-schema.md             # T — the reality-check log
│   └── worked-example.md           # a full trace of the seeding session
└── templates/
    └── design-spec.md              # spec skeleton, incl. the reality-check section
```

#### 🧪 How to Test

- [x] No tests needed

Docs only — no runtime code. `bun run check` is clean; all 13 `P-nn` cross-references resolve to a defined pattern (verified: zero dangling refs).

> **Note for the cloud repo:** `.agents/skills/` there symlinks upstream skills one by one, so `product-design` needs a symlink added on the cloud side before it is visible in that inventory. Not part of this PR.