### PR TITLE
🐛 fix(auth): restore filled social sign-in buttons

### DIFF
--- a/src/features/Auth/SignIn/SignInEmailStep.tsx
+++ b/src/features/Auth/SignIn/SignInEmailStep.tsx
@@ -25,7 +25,12 @@ export const USERNAME_REGEX = /^\w+$/;
 
 // Pin both the provider logo and the loading spinner to the same spot so the
 // spinner doesn't jump when a social button enters its loading state.
-const PROVIDER_ICON_STYLE: CSSProperties = { left: 12, position: 'absolute', top: 13 };
+const PROVIDER_ICON_STYLE: CSSProperties = {
+  insetInlineStart: 12,
+  position: 'absolute',
+  top: '50%',
+  transform: 'translateY(-50%)',
+};
 
 // Turn a provider id into a display name, e.g. "google" -> "Google".
 const getProviderName = (provider: string) =>
@@ -97,10 +102,12 @@ export const SignInEmailStep = ({
             const button = (
               <Button
                 block
-                icon={<Icon icon={AuthIcons(provider, 18)} style={PROVIDER_ICON_STYLE} />}
+                icon={<Icon icon={AuthIcons(provider, 18)} />}
                 key={provider}
                 loading={socialLoading === provider}
                 size="large"
+                styles={{ icon: PROVIDER_ICON_STYLE }}
+                type="fill"
                 onClick={() =>
                   continueWithAgreement(() => {
                     onSocialSignIn(provider);


### PR DESCRIPTION
## Summary

- restore the filled appearance of social sign-in buttons after the base-ui migration
- vertically center provider icons through the Button icon slot
- keep provider icons and loading indicators anchored to the same position

## Root cause

The previous `@lobehub/ui` Button selected a filled variant automatically in dark mode. After migration to `@lobehub/ui/base-ui`, the default appearance became outlined, while the provider icon retained a fixed `top: 13px` offset that no longer matched the new button geometry.

## User impact

Google, GitHub, and Apple sign-in buttons now retain the intended filled visual hierarchy. Their 18px provider icons are centered consistently in the 40px button, including the Apple logo.

## UI verification

<img width="1340" height="1188" alt="Verified zh-CN sign-in page with filled social buttons and vertically centered provider icons" src="https://github.com/user-attachments/assets/5baa6448-87bb-4aa2-a012-07e72efbb18b" />

## Validation

- `bun run check src/features/Auth/SignIn/SignInEmailStep.tsx`
- rebased onto the latest `origin/canary`
- verified the zh-CN auth SPA in a browser with Google, GitHub, and Apple enabled
- confirmed all three buttons use a filled background with transparent borders
- confirmed all three provider icons have a 0px vertical center offset
- confirmed the upstream agreement checkbox remains rendered
- confirmed no browser error overlay or console errors
