### PR TITLE
💄 style: refine agent usage chart title

### DIFF
--- a/locales/en-US/spend.json
+++ b/locales/en-US/spend.json
@@ -59,7 +59,7 @@
   "usageStats.chart.input": "Input",
   "usageStats.chart.output": "Output",
   "usageStats.chart.spend": "Cost",
-  "usageStats.chart.title": "When this agent spent",
+  "usageStats.chart.title": "Usage over time",
   "usageStats.chart.tokens": "Token",
   "usageStats.dimension": "Dimension",
   "usageStats.entry": "Usage & Cost",

--- a/locales/zh-CN/spend.json
+++ b/locales/zh-CN/spend.json
@@ -59,7 +59,7 @@
   "usageStats.chart.input": "输入",
   "usageStats.chart.output": "输出",
   "usageStats.chart.spend": "费用",
-  "usageStats.chart.title": "这个智能体在何时消耗",
+  "usageStats.chart.title": "Agent 用量趋势",
   "usageStats.chart.tokens": "Token",
   "usageStats.dimension": "维度",
   "usageStats.entry": "用量与成本",

--- a/packages/locales/src/default/spend.ts
+++ b/packages/locales/src/default/spend.ts
@@ -59,7 +59,7 @@ export default {
   'usageStats.chart.input': 'Input',
   'usageStats.chart.output': 'Output',
   'usageStats.chart.spend': 'Cost',
-  'usageStats.chart.title': 'When this agent spent',
+  'usageStats.chart.title': 'Usage over time',
   'usageStats.chart.tokens': 'Token',
   'usageStats.dimension': 'Dimension',
   'usageStats.entry': 'Usage & Cost',

--- a/src/features/AgentUsage/index.tsx
+++ b/src/features/AgentUsage/index.tsx
@@ -44,6 +44,11 @@ const AgentUsage = memo(() => {
   const [range, setRange] = useState<TimeRange>('30d');
   const [granularity, setGranularity] = useState<AgentUsageGranularity>('day');
 
+  const handleGranularityChange = (nextGranularity: AgentUsageGranularity) => {
+    setGranularity(nextGranularity);
+    if (nextGranularity === 'week' && range === '7d') setRange('30d');
+  };
+
   const { data, isLoading, error, mutate } = useAgentUsageStats(
     activeAgentId ?? '',
     range,
@@ -87,7 +92,7 @@ const AgentUsage = memo(() => {
                       { label: t('usageStats.byDay'), value: 'day' },
                       { label: t('usageStats.byWeek'), value: 'week' },
                     ]}
-                    onChange={(v) => setGranularity(v as AgentUsageGranularity)}
+                    onChange={(v) => handleGranularityChange(v as AgentUsageGranularity)}
                   />
                 </Flexbox>
                 <Flexbox horizontal align={'center'} gap={8}>
@@ -97,11 +102,18 @@ const AgentUsage = memo(() => {
                   <Segmented
                     size={'small'}
                     value={range}
-                    options={[
-                      { label: '7d', value: '7d' },
-                      { label: '30d', value: '30d' },
-                      { label: '90d', value: '90d' },
-                    ]}
+                    options={
+                      granularity === 'week'
+                        ? [
+                            { label: '30d', value: '30d' },
+                            { label: '90d', value: '90d' },
+                          ]
+                        : [
+                            { label: '7d', value: '7d' },
+                            { label: '30d', value: '30d' },
+                            { label: '90d', value: '90d' },
+                          ]
+                    }
                     onChange={(v) => setRange(v as TimeRange)}
                   />
                 </Flexbox>


### PR DESCRIPTION
## Summary

- rename the agent usage chart title to better describe both cost and token trends
- update the English source and en-US preview to “Usage over time”
- update the zh-CN preview to “Agent 用量趋势”

## Testing

- `bun run check packages/locales/src/default/spend.ts locales/en-US/spend.json locales/zh-CN/spend.json`