### PR TITLE
⚡️ perf(agent): cache heterogeneous quota snapshots

### DIFF
--- a/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
@@ -47,6 +47,10 @@ import { buildBrowserMcpTools } from '@/modules/heterogeneousAgent/browserMcpToo
 import { fetchClaudeCodeQuota } from '@/modules/heterogeneousAgent/claudeCodeQuota';
 import { fetchCodexQuota } from '@/modules/heterogeneousAgent/codexQuota';
 import { createLambdaFileStorePort } from '@/modules/heterogeneousAgent/fileStorePort';
+import {
+  createQuotaCacheKey,
+  QuotaSnapshotCache,
+} from '@/modules/heterogeneousAgent/quotaSnapshotCache';
 import type {
   HeterogeneousAgentBuildPlan,
   HeterogeneousAgentImageAttachment,
@@ -190,10 +194,12 @@ interface GetSessionInfoParams {
 interface GetCodexQuotaParams {
   command?: string;
   env?: Record<string, string>;
+  force?: boolean;
 }
 
 interface GetClaudeCodeQuotaParams {
   env?: Record<string, string>;
+  force?: boolean;
 }
 
 interface SessionInfo {
@@ -289,6 +295,8 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
   /** Lazy single MCP server, started on first claude-code prompt. */
   private builtinMcpServer?: LobeBuiltinMcpServer;
   private builtinMcpStartPromise?: Promise<LobeBuiltinMcpServer>;
+  private readonly claudeCodeQuotaCache = new QuotaSnapshotCache<ClaudeCodeQuotaSnapshot>();
+  private readonly codexQuotaCache = new QuotaSnapshotCache<CodexQuotaSnapshot>();
 
   private get remoteServerConfigCtr() {
     return this.app.getController(RemoteServerConfigCtr);
@@ -1493,17 +1501,28 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
   @IpcMethod()
   async getCodexQuota(params: GetCodexQuotaParams = {}): Promise<CodexQuotaSnapshot> {
     const command = params.command?.trim() || 'codex';
-    const status = await detectHeterogeneousCliCommand('codex', command);
-    const env = {
-      ...(status.resolvedPathEnv ? { PATH: status.resolvedPathEnv } : {}),
+    const sourceEnv = {
       ...buildProxyEnv(this.app.storeManager.get('networkProxy')),
       ...params.env,
     };
+    const sourceKey = createQuotaCacheKey('codex', command, sourceEnv);
 
-    return fetchCodexQuota({
-      command: status.available && status.path ? status.path : command,
-      env: Object.keys(env).length > 0 ? env : undefined,
-    });
+    return this.codexQuotaCache.get(
+      sourceKey,
+      async () => {
+        const status = await detectHeterogeneousCliCommand('codex', command);
+        const env = {
+          ...(status.resolvedPathEnv ? { PATH: status.resolvedPathEnv } : {}),
+          ...sourceEnv,
+        };
+
+        return fetchCodexQuota({
+          command: status.available && status.path ? status.path : command,
+          env: Object.keys(env).length > 0 ? env : undefined,
+        });
+      },
+      { force: params.force },
+    );
   }
 
   /**
@@ -1515,7 +1534,13 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
   async getClaudeCodeQuota(
     params: GetClaudeCodeQuotaParams = {},
   ): Promise<ClaudeCodeQuotaSnapshot> {
-    return fetchClaudeCodeQuota({ env: params.env });
+    const sourceKey = createQuotaCacheKey('claude-code', params.env);
+
+    return this.claudeCodeQuotaCache.get(
+      sourceKey,
+      () => fetchClaudeCodeQuota({ env: params.env }),
+      { force: params.force },
+    );
   }
 
   /**

--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
@@ -339,6 +339,43 @@ describe('HeterogeneousAgentCtr', () => {
         }),
       });
     });
+
+    it('reuses automatic quota reads while explicit refresh bypasses the cache', async () => {
+      execFileMock.mockImplementation(
+        (
+          _file: string,
+          _args: string[],
+          optionsOrCallback: unknown,
+          callback?: (error: Error | null, result: { stderr: string; stdout: string }) => void,
+        ) => {
+          const resolvedCallback =
+            typeof optionsOrCallback === 'function' ? optionsOrCallback : callback;
+          resolvedCallback?.(null, { stderr: '', stdout: 'codex-cli 0.99.0' });
+        },
+      );
+      fetchCodexQuotaMock.mockResolvedValue({
+        error: null,
+        provider: 'codex',
+        session: { resetsAt: null, usedPercent: 8, windowMinutes: 300 },
+        status: 'ok',
+        updatedAt: Date.now(),
+        weekly: null,
+      });
+      const ctr = new HeterogeneousAgentCtr({
+        appStoragePath,
+        storeManager: { get: vi.fn() },
+      } as any);
+      const params = { command: '/custom/bin/codex', env: { CODEX_HOME: '/tmp/codex-home' } };
+
+      await ctr.getCodexQuota(params);
+      await ctr.getCodexQuota(params);
+
+      expect(fetchCodexQuotaMock).toHaveBeenCalledTimes(1);
+
+      await ctr.getCodexQuota({ ...params, force: true });
+
+      expect(fetchCodexQuotaMock).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('sendPrompt (claude-code)', () => {

--- a/apps/desktop/src/main/modules/heterogeneousAgent/quotaSnapshotCache.test.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/quotaSnapshotCache.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createQuotaCacheKey, QuotaSnapshotCache } from './quotaSnapshotCache';
+
+interface TestQuotaSnapshot {
+  error: string | null;
+  session: number | null;
+  status: 'error' | 'ok' | 'unavailable';
+  updatedAt: number;
+}
+
+const NOW = new Date('2026-07-14T12:00:00Z').getTime();
+
+const snapshot = (overrides: Partial<TestQuotaSnapshot> = {}): TestQuotaSnapshot => ({
+  error: null,
+  session: 10,
+  status: 'ok',
+  updatedAt: Date.now(),
+  ...overrides,
+});
+
+describe('QuotaSnapshotCache', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('creates stable source keys without exposing environment values', () => {
+    const left = createQuotaCacheKey('claude-code', {
+      CLAUDE_CONFIG_DIR: '/profile',
+      SECRET_TOKEN: 'sensitive-value',
+    });
+    const right = createQuotaCacheKey('claude-code', {
+      SECRET_TOKEN: 'sensitive-value',
+      CLAUDE_CONFIG_DIR: '/profile',
+    });
+
+    expect(left).toBe(right);
+    expect(left).not.toContain('sensitive-value');
+    expect(createQuotaCacheKey('claude-code', { CLAUDE_CONFIG_DIR: '/other' })).not.toBe(left);
+  });
+
+  it('coalesces concurrent reads and reuses a fresh automatic snapshot', async () => {
+    const cache = new QuotaSnapshotCache<TestQuotaSnapshot>();
+    let resolveRequest: ((value: TestQuotaSnapshot) => void) | undefined;
+    const fetchSnapshot = vi.fn(
+      () =>
+        new Promise<TestQuotaSnapshot>((resolve) => {
+          resolveRequest = resolve;
+        }),
+    );
+
+    const first = cache.get('source', fetchSnapshot);
+    const second = cache.get('source', fetchSnapshot);
+
+    expect(fetchSnapshot).toHaveBeenCalledTimes(1);
+    resolveRequest?.(snapshot());
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+
+    await expect(cache.get('source', fetchSnapshot)).resolves.toMatchObject({ status: 'ok' });
+    expect(fetchSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets an explicit refresh bypass freshness', async () => {
+    const cache = new QuotaSnapshotCache<TestQuotaSnapshot>();
+    const fetchSnapshot = vi.fn().mockResolvedValue(snapshot());
+
+    await cache.get('source', fetchSnapshot);
+    await cache.get('source', fetchSnapshot, { force: true });
+
+    expect(fetchSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts entries after their inactivity TTL expires', async () => {
+    const cache = new QuotaSnapshotCache<TestQuotaSnapshot>({
+      entryTtlMs: 1_000,
+      freshMs: 10_000,
+    });
+    const fetchSnapshot = vi.fn(async () => snapshot());
+
+    await cache.get('source', fetchSnapshot);
+    vi.advanceTimersByTime(1_001);
+    await cache.get('source', fetchSnapshot);
+
+    expect(fetchSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps expired entries while in flight and evicts them after they settle', async () => {
+    const cache = new QuotaSnapshotCache<TestQuotaSnapshot>({ entryTtlMs: 1_000 });
+    let resolveRequest: ((value: TestQuotaSnapshot) => void) | undefined;
+    const fetchSnapshot = vi
+      .fn<() => Promise<TestQuotaSnapshot>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise<TestQuotaSnapshot>((resolve) => {
+            resolveRequest = resolve;
+          }),
+      )
+      .mockImplementation(async () => snapshot());
+    const fetchOtherSnapshot = vi.fn(async () => snapshot());
+
+    const first = cache.get('source', fetchSnapshot);
+    vi.advanceTimersByTime(1_001);
+    await cache.get('other', fetchOtherSnapshot);
+
+    const joined = cache.get('source', fetchSnapshot);
+    expect(fetchSnapshot).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1_001);
+    await cache.get('another', fetchOtherSnapshot);
+    resolveRequest?.(snapshot());
+    await Promise.all([first, joined]);
+
+    await cache.get('source', fetchSnapshot);
+    expect(fetchSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps recent successful data during an error cooldown', async () => {
+    const cache = new QuotaSnapshotCache<TestQuotaSnapshot>();
+    const fetchSnapshot = vi
+      .fn<() => Promise<TestQuotaSnapshot>>()
+      .mockResolvedValueOnce(snapshot({ session: 25 }))
+      .mockResolvedValueOnce(
+        snapshot({ error: 'upstream returned 429', session: null, status: 'error' }),
+      );
+
+    const successful = await cache.get('source', fetchSnapshot);
+    vi.advanceTimersByTime(5 * 60_000);
+    const stale = await cache.get('source', fetchSnapshot);
+
+    expect(stale).toEqual({
+      ...successful,
+      error: 'upstream returned 429',
+      status: 'error',
+    });
+
+    await expect(cache.get('source', fetchSnapshot)).resolves.toEqual(stale);
+    expect(fetchSnapshot).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/main/modules/heterogeneousAgent/quotaSnapshotCache.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/quotaSnapshotCache.ts
@@ -1,0 +1,149 @@
+import { createHash } from 'node:crypto';
+
+const DEFAULT_ERROR_COOLDOWN_MS = 60_000;
+const DEFAULT_ENTRY_TTL_MS = 30 * 60_000;
+const DEFAULT_FRESH_MS = 5 * 60_000;
+const DEFAULT_STALE_MS = 30 * 60_000;
+
+interface CacheableQuotaSnapshot {
+  error: string | null;
+  status: 'error' | 'ok' | 'unavailable';
+  updatedAt: number;
+}
+
+interface QuotaSnapshotCacheEntry<S> {
+  inFlight?: Promise<S>;
+  lastAccessedAt: number;
+  lastResult?: S;
+  lastSuccessful?: S;
+  retryAt: number;
+}
+
+export interface QuotaSnapshotCacheConfig {
+  entryTtlMs?: number;
+  errorCooldownMs?: number;
+  freshMs?: number;
+  staleMs?: number;
+}
+
+export interface GetQuotaSnapshotOptions {
+  force?: boolean;
+}
+
+type QuotaSourcePart = Record<string, string | undefined> | string | null | undefined;
+
+const normalizeQuotaSourcePart = (part: QuotaSourcePart) => {
+  if (!part || typeof part === 'string') return part ?? null;
+
+  return Object.entries(part)
+    .filter(([, value]) => value !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right));
+};
+
+/**
+ * Build a stable cache key without retaining auth tokens or other environment
+ * values as plaintext Map keys in the long-lived desktop process.
+ */
+export const createQuotaCacheKey = (...parts: QuotaSourcePart[]) =>
+  createHash('sha256')
+    .update(JSON.stringify(parts.map((part) => normalizeQuotaSourcePart(part))))
+    .digest('hex');
+
+/**
+ * Main-process quota cache shared by every renderer instance of one provider.
+ * Automatic reads reuse recent data and transient failures enter a cooldown;
+ * explicit refreshes bypass those timers while still joining an in-flight read.
+ */
+export class QuotaSnapshotCache<S extends CacheableQuotaSnapshot> {
+  private readonly entries = new Map<string, QuotaSnapshotCacheEntry<S>>();
+  private readonly entryTtlMs: number;
+  private readonly errorCooldownMs: number;
+  private readonly freshMs: number;
+  private readonly staleMs: number;
+
+  constructor(config: QuotaSnapshotCacheConfig = {}) {
+    this.entryTtlMs = config.entryTtlMs ?? DEFAULT_ENTRY_TTL_MS;
+    this.errorCooldownMs = config.errorCooldownMs ?? DEFAULT_ERROR_COOLDOWN_MS;
+    this.freshMs = config.freshMs ?? DEFAULT_FRESH_MS;
+    this.staleMs = config.staleMs ?? DEFAULT_STALE_MS;
+  }
+
+  async get(
+    key: string,
+    fetchSnapshot: () => Promise<S>,
+    options: GetQuotaSnapshotOptions = {},
+  ): Promise<S> {
+    const now = Date.now();
+    this.evictExpiredEntries(now);
+
+    const entry = this.entries.get(key) ?? { lastAccessedAt: now, retryAt: 0 };
+    entry.lastAccessedAt = now;
+    this.entries.set(key, entry);
+
+    if (entry.inFlight) return entry.inFlight;
+
+    if (!options.force && entry.lastResult) {
+      if (entry.retryAt > now) return entry.lastResult;
+
+      if (entry.lastResult.status !== 'error' && now - entry.lastResult.updatedAt < this.freshMs) {
+        return entry.lastResult;
+      }
+    }
+
+    const request = this.fetchAndUpdate(entry, fetchSnapshot);
+    entry.inFlight = request;
+
+    try {
+      return await request;
+    } finally {
+      if (entry.inFlight === request) delete entry.inFlight;
+      this.evictExpiredEntries(Date.now());
+    }
+  }
+
+  private evictExpiredEntries(now: number) {
+    for (const [key, entry] of this.entries) {
+      if (!entry.inFlight && now - entry.lastAccessedAt >= this.entryTtlMs) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  private async fetchAndUpdate(
+    entry: QuotaSnapshotCacheEntry<S>,
+    fetchSnapshot: () => Promise<S>,
+  ): Promise<S> {
+    const fresh = await fetchSnapshot();
+
+    if (fresh.status === 'ok') {
+      entry.lastResult = fresh;
+      entry.lastSuccessful = fresh;
+      entry.retryAt = 0;
+      return fresh;
+    }
+
+    if (fresh.status === 'unavailable') {
+      entry.lastResult = fresh;
+      entry.lastSuccessful = undefined;
+      entry.retryAt = 0;
+      return fresh;
+    }
+
+    const now = Date.now();
+    entry.retryAt = now + this.errorCooldownMs;
+    const lastSuccessful = entry.lastSuccessful;
+
+    if (lastSuccessful && now - lastSuccessful.updatedAt <= this.staleMs) {
+      const staleResult = {
+        ...lastSuccessful,
+        error: fresh.error,
+        status: 'error' as const,
+      };
+      entry.lastResult = staleResult;
+      return staleResult;
+    }
+
+    entry.lastResult = fresh;
+    return fresh;
+  }
+}

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/ClaudeCodeQuotaMenu.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/ClaudeCodeQuotaMenu.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 
 import { heterogeneousAgentService } from '@/services/electron/heterogeneousAgent';
 
-import type { QuotaWindowItem } from './QuotaMenu';
+import type { FetchQuotaOptions, QuotaWindowItem } from './QuotaMenu';
 import QuotaMenu, { createQuotaSourceKey } from './QuotaMenu';
 
 const createErrorSnapshot = (error: unknown): ClaudeCodeQuotaSnapshot => ({
@@ -30,7 +30,11 @@ const ClaudeCodeQuotaMenu = memo<ClaudeCodeQuotaMenuProps>(({ env }) => {
   const sourceKey = createQuotaSourceKey('claude-code', env);
 
   const fetchQuota = useCallback(
-    () => heterogeneousAgentService.getClaudeCodeQuota({ env }),
+    (options?: FetchQuotaOptions) =>
+      heterogeneousAgentService.getClaudeCodeQuota({
+        env,
+        ...(options?.force ? { force: true } : {}),
+      }),
     [env],
   );
 

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/CodexQuotaMenu.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/CodexQuotaMenu.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 
 import { heterogeneousAgentService } from '@/services/electron/heterogeneousAgent';
 
-import type { QuotaMenuHelpers, QuotaWindowItem } from './QuotaMenu';
+import type { FetchQuotaOptions, QuotaMenuHelpers, QuotaWindowItem } from './QuotaMenu';
 import QuotaMenu, { createQuotaSourceKey } from './QuotaMenu';
 
 const styles = createStaticStyles(({ css }) => ({
@@ -39,7 +39,12 @@ const CodexQuotaMenu = memo<CodexQuotaMenuProps>(({ command, env }) => {
   const sourceKey = createQuotaSourceKey('codex', command, env);
 
   const fetchQuota = useCallback(
-    () => heterogeneousAgentService.getCodexQuota({ command, env }),
+    (options?: FetchQuotaOptions) =>
+      heterogeneousAgentService.getCodexQuota({
+        command,
+        env,
+        ...(options?.force ? { force: true } : {}),
+      }),
     [command, env],
   );
 

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu.test.tsx
@@ -150,6 +150,27 @@ describe('ClaudeCodeQuotaMenu', () => {
 
     fireEvent.click(screen.getByTestId('refresh'));
     expect(mockService.getClaudeCodeQuota).toHaveBeenCalledTimes(2);
+    expect(mockService.getClaudeCodeQuota).toHaveBeenLastCalledWith({
+      env: undefined,
+      force: true,
+    });
+  });
+
+  it('keeps cached windows visible when the main-process refresh is rate-limited', async () => {
+    mockService.getClaudeCodeQuota.mockResolvedValue(
+      claudeSnapshot({
+        error: 'Anthropic usage API returned 429',
+        session: { resetsAt: null, usedPercent: 8, windowMinutes: 300 },
+        status: 'error',
+        updatedAt: Date.now() - 5 * 60_000,
+      }),
+    );
+
+    render(<ClaudeCodeQuotaMenu />);
+
+    expect(await screen.findByText('heteroAgent.quota.left:92')).toBeTruthy();
+    expect(screen.getByText('heteroAgent.claudeQuota.refreshRateLimited')).toBeTruthy();
+    expect(screen.queryByText('heteroAgent.claudeQuota.errorRateLimited')).toBeNull();
   });
 
   it('renders an error snapshot when the quota request rejects', async () => {
@@ -310,6 +331,14 @@ describe('CodexQuotaMenu', () => {
     expect(await screen.findByText('heteroAgent.quota.left:81')).toBeTruthy();
     expect(screen.getByText('heteroAgent.codexQuota.resetCredits:4')).toBeTruthy();
     expect(mockService.getCodexQuota).toHaveBeenCalledWith({ command: 'codex', env: undefined });
+
+    fireEvent.click(screen.getByTestId('refresh'));
+    await waitFor(() => expect(mockService.getCodexQuota).toHaveBeenCalledTimes(2));
+    expect(mockService.getCodexQuota).toHaveBeenLastCalledWith({
+      command: 'codex',
+      env: undefined,
+      force: true,
+    });
   });
 
   it('renders the credits-unavailable footer when the RPC omits credits', async () => {

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu.tsx
@@ -128,9 +128,13 @@ export interface QuotaMenuHelpers {
   now: number;
 }
 
+export interface FetchQuotaOptions {
+  force?: boolean;
+}
+
 interface QuotaMenuProps<S extends QuotaSnapshotBase> {
   createErrorSnapshot: (error: unknown) => S;
-  fetchQuota: () => Promise<S>;
+  fetchQuota: (options?: FetchQuotaOptions) => Promise<S>;
   /** Localized explanation for `status: 'error'`; falls back to `error`. */
   getErrorText?: (quota: S) => string | undefined;
   /** Localized explanation for a manual refresh error when stale data is preserved. */
@@ -235,7 +239,7 @@ const QuotaMenu = <S extends QuotaSnapshotBase>({
       setLoading(true);
 
       try {
-        const nextQuota = await fetchQuota();
+        const nextQuota = await fetchQuota(options.manual ? { force: true } : undefined);
         applyQuotaResult(nextQuota, options, requestId, requestSourceKey);
       } catch (error) {
         console.error('Failed to fetch agent quota:', error);
@@ -317,8 +321,13 @@ const QuotaMenu = <S extends QuotaSnapshotBase>({
   const firstWindow = windows.find((item) => item.window)?.window;
   const compactLeftPercent = firstWindow ? clampPercent(100 - firstWindow.usedPercent) : undefined;
   const hasQuotaData = hasQuotaDataForSnapshot(quota);
-  const refreshErrorText =
+  const manualRefreshErrorText =
     refreshError && (getRefreshErrorText?.(refreshError) || t('heteroAgent.quota.refreshFailed'));
+  const staleSnapshotErrorText =
+    quota?.status === 'error' && hasQuotaData
+      ? getRefreshErrorText?.(quota) || t('heteroAgent.quota.refreshFailed')
+      : undefined;
+  const refreshErrorText = manualRefreshErrorText || staleSnapshotErrorText;
 
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
@@ -396,7 +405,7 @@ const QuotaMenu = <S extends QuotaSnapshotBase>({
         <div className={styles.emptyState}>
           {getUnavailableText?.(quota) || quota.error || t('heteroAgent.quota.unavailable')}
         </div>
-      ) : quota?.status === 'error' ? (
+      ) : quota?.status === 'error' && !hasQuotaData ? (
         <div className={styles.error}>
           {getErrorText?.(quota) || quota.error || t('heteroAgent.quota.unavailable')}
         </div>

--- a/src/services/electron/heterogeneousAgent.test.ts
+++ b/src/services/electron/heterogeneousAgent.test.ts
@@ -32,7 +32,7 @@ describe('heterogeneousAgentService', () => {
     };
     mockHeterogeneousAgent.getClaudeCodeQuota.mockResolvedValue(snapshot);
 
-    const params = { env: { CLAUDE_CONFIG_DIR: '/custom/claude' } };
+    const params = { env: { CLAUDE_CONFIG_DIR: '/custom/claude' }, force: true };
     await expect(heterogeneousAgentService.getClaudeCodeQuota(params)).resolves.toEqual(snapshot);
     expect(mockHeterogeneousAgent.getClaudeCodeQuota).toHaveBeenCalledWith(params);
   });
@@ -50,7 +50,11 @@ describe('heterogeneousAgentService', () => {
     };
     mockHeterogeneousAgent.getCodexQuota.mockResolvedValue(snapshot);
 
-    const params = { command: '/usr/local/bin/codex', env: { CODEX_HOME: '/tmp/codex' } };
+    const params = {
+      command: '/usr/local/bin/codex',
+      env: { CODEX_HOME: '/tmp/codex' },
+      force: true,
+    };
     await expect(heterogeneousAgentService.getCodexQuota(params)).resolves.toEqual(snapshot);
     expect(mockHeterogeneousAgent.getCodexQuota).toHaveBeenCalledWith(params);
   });

--- a/src/services/electron/heterogeneousAgent.ts
+++ b/src/services/electron/heterogeneousAgent.ts
@@ -55,12 +55,14 @@ class HeterogeneousAgentService {
   async getCodexQuota(params?: {
     command?: string;
     env?: Record<string, string>;
+    force?: boolean;
   }): Promise<CodexQuotaSnapshot> {
     return this.ipc.heterogeneousAgent.getCodexQuota(params);
   }
 
   async getClaudeCodeQuota(params?: {
     env?: Record<string, string>;
+    force?: boolean;
   }): Promise<ClaudeCodeQuotaSnapshot> {
     return this.ipc.heterogeneousAgent.getClaudeCodeQuota(params);
   }


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [x] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No matching issue found.

#### 🔀 Description of Change

- Cache Claude Code and Codex quota snapshots in the Electron main process by provider configuration.
- Coalesce concurrent quota reads and reuse fresh snapshots to reduce upstream quota requests.
- Preserve recent successful quota data during transient refresh failures and apply a retry cooldown.
- Allow explicit user refreshes to bypass snapshot freshness while still joining an in-flight request.
- Keep stale quota windows visible with a refresh error instead of replacing them with an empty error state.

#### 🧪 How to Test

Run the focused repository check for the ten changed files. It validates lint and the related Electron controller, cache, service, and quota menu tests.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Result: `✓ 10 files · lint clean · tests 68 passed`

#### 📸 Screenshots / Videos

Not applicable. This changes quota refresh and transient-error behavior without changing the visual layout.

#### 📝 Additional Information

The cache key hashes command and environment inputs so long-lived in-memory keys do not retain credentials or other environment values as plaintext.
