### PR TITLE
♻️ refactor: clarify product design skill workflow

### DIFF
--- a/.agents/skills/product-design/SKILL.md
+++ b/.agents/skills/product-design/SKILL.md
@@ -1,214 +1,185 @@
 ---
 name: product-design
-description: 'Turn a vague product ask ("this page feels wrong", "we need a team view") into a grounded, shippable design — by first establishing what the business actually models, before proposing anything. Use when scoping a new surface, redesigning an existing one, or deciding what a feature should even be. Not for auditing a built screen (that is ux-audit) or for picking spacing and color (that is ux).'
-argument-hint: '<surface or product ask>'
+description: 'Turn a vague product ask ("this page feels wrong", "we need a team view") into a grounded, shippable design by establishing business semantics and the user task before proposing a surface. Use when scoping a new surface, redesigning an existing one, or deciding what a feature should be. Not for auditing a built screen (ux-audit) or choosing visual details (ux).'
 ---
 
 # Product Design
 
-The upstream half of design: **deciding what to build and why**, before anyone
-argues about spacing.
+Decide **what to build and why** before arguing about spacing.
 
-Its one non-negotiable rule:
+Two rules are non-negotiable:
 
 > **Never design from the surface. Establish what the business actually models
 > first.**
 
-Every expensive mistake this skill exists to prevent has the same shape: a
-surface that misrepresents its own business — promising an event the domain does
-not have, hiding a capability the domain already supports, or naming a state
-after the machine rather than after the obligation it creates. All three look
-completely reasonable on a slide.
+> **Never turn the business model into the information architecture. The domain
+> constrains what the surface may claim; the user's retrieval and decision task
+> determines how the surface is organized.** (`P-14`)
 
-## Scope — business semantics only
+This skill handles product meaning first. It may hand a grounded frame to `ux` or
+`design-prototype`, but discovery does not require implementation or a prototype.
+Strip out every framework, table and component name: if no product insight remains,
+the finding belongs in an engineering skill.
 
-This skill is about **what the product means**, not how it is built.
+## Relationship to other skills
 
-Component reuse, refactor hazards, framework conventions — real, important, and
-**not here.** The test for anything entering this skill:
+| Skill                                            | Question                                      | When                        |
+| ------------------------------------------------ | --------------------------------------------- | --------------------------- |
+| **product-design**                               | What should this surface be, and why?         | Before or during framing    |
+| [ux](../ux/SKILL.md)                             | How should the interaction behave and feel?   | While designing or building |
+| [ux-audit](../ux-audit/SKILL.md)                 | Does the built surface honor those rules?     | After it exists             |
+| [design-prototype](../design-prototype/SKILL.md) | How can a materialized interaction be tested? | When a prototype is useful  |
 
-> Strip out every framework, table and component name. **Is there still a product
-> insight left?**
+## Select the smallest run mode
 
-If not, it belongs in an engineering skill.
+| Mode            | Finish line                                                                  |
+| --------------- | ---------------------------------------------------------------------------- |
+| **Discover**    | Evidence map, business model, user-model hypotheses and structural diagnosis |
+| **Frame**       | Discover + view model, information architecture, scope and open decisions    |
+| **Materialize** | Frame + a requested spec and/or prototype                                    |
 
-## Where this sits
+Do not create or modify artifacts unless the user asked for a design artifact,
+prototype or repository change.
 
-| Skill                            | Question it answers                      | When                     |
-| -------------------------------- | ---------------------------------------- | ------------------------ |
-| **product-design** (this)        | What should this surface _be_, and why?  | Before there is a design |
-| [ux](../ux/SKILL.md)             | How should it feel? What are the rules?  | While building           |
-| [ux-audit](../ux-audit/SKILL.md) | Does the built screen honor those rules? | After it exists          |
+For a substantial run, read [references/pattern-base.md](references/pattern-base.md)
+and [references/layer-model.md](references/layer-model.md) in full. For a narrow
+question, inspect only the relevant patterns and state what scope was checked.
 
-`ux` is the **rulebook**, `ux-audit` **enforces** it on a finished surface, and
-this skill decides **what surface to build at all**. Don't reach for it to fix a
-button's padding.
+## Step 1 — Ground the business model
 
-## SCLPT — why this skill gets better over time
-
-A self-evolving system, wired per the SCLPT framework. Each element maps to a file
-you must actually read and write:
-
-| Element            | Here                                                     | What it does                                                                         |
-| ------------------ | -------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| **P** Pattern Base | [references/pattern-base.md](references/pattern-base.md) | The learned rules. **Read before every run. Append after every run.**                |
-| **L** Layer Model  | [references/layer-model.md](references/layer-model.md)   | Cooper's three models — implementation / represented / mental                        |
-| **T** Trace Schema | [references/trace-schema.md](references/trace-schema.md) | Every session leaves a **reality-check log**: assumption → what is true → who won    |
-| **C** Closed Loop  | Step 6                                                   | Every overturned assumption becomes a new pattern                                    |
-| **S** Saturation   | Step 6                                                   | A grounding round that overturns **nothing** = the implementation model is mined out |
-
-Benchmarked against [references/canon.md](references/canon.md) — the works that
-already named most of this, and the two things they did not.
-
-**The loop in one line:** the reality-check log (T) is sorted by layer (L) and
-compared against the pattern base (P); whatever the business overturned that the
-pattern base did not predict is a new gap, which gets written back (C); when a
-grounding round produces zero new gaps, that surface is saturated (S).
-
----
-
-## The workflow
-
-### Step 0 — Read the Pattern Base (mandatory, every run)
-
-Read [references/pattern-base.md](references/pattern-base.md) and
-[references/layer-model.md](references/layer-model.md) **in full** before touching
-the product ask. They are the accumulated "you already got this wrong once" list.
-
-Two that keep biting, up front:
-
-- **The business probably models more than the surface shows.** Look for the
-  switched-off capability before you invent a new one — it is the highest-leverage
-  move available (`P-04`).
-- **Names lie.** A state called `paused` that means _pending review_; a `Project`
-  section that is a knowledge library; an `@member` that resolves to an agent.
-  Ask what a thing **obliges** or **produces**, never what it is called
-  (`P-01`, `P-03`).
-
-### Step 1 — Ground: establish the business model
-
-Before diagnosing anything, find out what the business actually is. Delegate this
-— it is broad, read-only work.
+Establish what is true before diagnosing the surface. For broad repositories,
+parallelize independent evidence areas when delegation is available and useful;
+the primary agent remains responsible for reconciling contradictions.
 
 Produce:
 
-- **The concepts and states the business models** — all of them, not just the ones
-  the surface renders. This is where the surprises live (`P-04`).
-- **What each state obliges someone to do.** A state nobody must act on is not a
-  queue; a state a human is blocking is (`P-01`).
-- **What each action does to the business** — the event it produces, in domain
-  language. Not the mutation (`P-02`).
-- **Which concepts the business does _not_ have.** Absences are findings too, and
-  they are the expensive ones (`P-06`).
+- Concepts, roles and states, including variants the current surface hides (`P-04`).
+- Who produces the terminal business fact and what closes the lifecycle (`P-12`).
+- What each state obliges someone to do (`P-01`).
+- What business event each action produces (`P-02`).
+- Concepts the business does not have (`P-06`).
+- Evidence sources, contradictions and confidence.
 
-The domain model is the evidence. Read it as a domain document — it is the most
-honest statement the company has made about what it believes exists.
+Treat domain types and state machines as strong evidence, not the sole source of
+truth. Check relevant service behavior, permissions, policy, production facts and
+user evidence when available. Code can be stale, accidental or incomplete.
 
-Never skip to Step 2 on a mental model of the product. The mental model is wrong;
-that is the entire premise of this skill.
+Never proceed from the team's assumed model of the product. Treat it as a
+hypothesis until checked against domain and user evidence.
 
-### Step 2 — Diagnose: name the structural error
+## Step 2 — Frame the user's view model
 
-A diagnosis is not "it looks dated". It must name something wrong **regardless of
-taste**:
+Grounding constrains what the product may claim; it does not determine how a
+person should see it. Separate observed user evidence from design hypotheses:
 
-- The surface shows one of four kinds of thing, so a decision inbox reads as an
-  error log (`P-04`).
+- **Circumstance and job** — “When I open this, I need to …”.
+- **Lookup objects** — stable things the user scans, compares or inspects.
+- **Attached proof** — what verifies each object without reconstructing joins.
+- **First scan** — the 2–4 questions answered without a click.
+- **Secondary dimensions** — chronology, provenance, runs and internal states;
+  keep them as filters or drill-down unless the job is execution audit.
+- **Evidence and confidence** — mark claims as observed, reported or inferred;
+  state how consequential assumptions can be validated.
+
+| Model                 | Role in design                                                     |
+| --------------------- | ------------------------------------------------------------------ |
+| Business/domain model | Defines truth, validity, completeness and red lines                |
+| User view model       | Defines grouping, ordering, labels and default expansion           |
+| Execution model       | Supplies provenance and audit detail; never gets the page for free |
+
+Do not proceed while proposed top-level sections are merely domain or execution
+nouns such as `runs`, `reports`, evidence versions or table names. Rewrite them in
+the objects the user is trying to find (`P-14`).
+
+## Step 3 — Diagnose the structural error
+
+Name something wrong regardless of taste, for example:
+
+- A decision inbox exposes only errors, so it reads as an error log (`P-04`).
 - A button promises a business event that does not exist (`P-05`).
-- The page is a triage desk and a reading room at once, and fails at both
-  (`P-07`).
+- One page is both triage desk and reading room, and fails at both (`P-07`).
 
-If you cannot name a structural error, you do not have a diagnosis — you have an
-opinion. Go back to Step 1.
+If no structural error can be supported by evidence, report that instead of
+manufacturing a diagnosis.
 
-### Step 3 — Align: walk the decision tree, one question at a time
+## Step 4 — Align decisions by dependency
 
-Do not present a finished solution. Surface the decisions that **change the shape
-of the answer**, one at a time, each with a recommendation and its reasoning.
-Settle the upstream ones before the downstream ones they constrain.
+Surface only decisions that change the shape of the answer. For each, give a
+recommendation, evidence and consequence. Resolve upstream decisions before the
+downstream ones they constrain.
 
-If a question can be answered by grounding, **go and ground it** — never spend the
-user's turn on something the domain model already settles.
+Ask a blocking question separately when its answer would materially change the
+work; group independent decisions in one memo. When the user authorizes autonomous
+progress, proceed with the recommended default and label the assumption. Never ask
+the user for something available through grounding.
 
-### Step 4 — Prototype against the real design system
+For review, approval or acceptance surfaces, establish first whether the system or
+a human decision closes the lifecycle (`P-12`).
 
-Use [design-prototype](../design-prototype/SKILL.md). A prototype in the real
-components with real tokens is the only honest way to argue about density and
-hierarchy.
+## Step 5 — Prototype when it resolves uncertainty
 
-- **Mock data must be plausible.** Fake data hides the at-scale case.
-- **Show the non-happy path.** Empty, blocked, and 100× are where the design gets
-  decided.
-- **Tag anything the business cannot back with `NEW`, on the mock itself.** A
-  visible debt, not a silent lie.
+Use [design-prototype](../design-prototype/SKILL.md) only when the user requests a
+prototype or interaction, density or hierarchy cannot be resolved honestly in a
+written frame. This belongs to Materialize mode.
 
-Expect the first prototype to be wrong. That is its job — every correction is a
-Pattern Base entry.
+- Use plausible data and include empty, blocked and at-scale states.
+- Tag anything unsupported by the business with `NEW` on the mock.
+- Treat corrections as evidence. They become Pattern Base candidates only when
+  they generalize beyond the current surface.
 
-### Step 5 — Scope: what does the business already support?
+## Step 6 — Scope honestly
 
-Sort every capability the design needs:
+| Bucket                         | Meaning                                                     |
+| ------------------------------ | ----------------------------------------------------------- |
+| ✅ Already modeled and exposed | Rearranging an existing capability                          |
+| ⚠️ Modeled, not exposed        | Lower domain risk; engineering cost still needs validation  |
+| ❌ Not modeled                 | Requires domain expansion and explicit cost/risk assessment |
 
-| Bucket                                   | Meaning                                               |
-| ---------------------------------------- | ----------------------------------------------------- |
-| ✅ **Already modeled, already exposed**  | Rearranging what is there                             |
-| ⚠️ **Already modeled, not yet exposed**  | `P-04` territory — nearly free product                |
-| ❌ **Not a concept in the business yet** | A domain change. An order of magnitude more expensive |
+Prefer a coherent ✅ + ⚠️ slice when it solves a complete user job. Do not ship an
+incomplete or misleading slice merely because its concepts already exist. A ❌
+capability may be the right first investment when required for value, safety or
+semantic completeness (`P-10`).
 
-**Ship ✅ + ⚠️ first** (`P-10`). Not as a compromise — as a discipline. It forces
-the design to be honest about what the business is _today_, and it puts a real
-surface in front of users while the domain changes are still being argued about.
+Name every ❌ item and its likely cost drivers in the spec (`P-11`). Do not silently
+drop it, but do not pretend its cost can be inferred from the domain model alone.
 
-Every ❌ item goes into the spec **by name, with its cost** (`P-11`). Never
-silently dropped — silence reads as an oversight and gets re-litigated in review.
+## Close — record coverage and propose learning
 
-### Step 6 — Close the loop (mandatory)
+Close at the level authorized by the user:
 
-The session is done when the **system** got smarter, not when the PR opened:
+1. If producing a spec, include the reality-check log from
+   [references/trace-schema.md](references/trace-schema.md). For read-only work,
+   report important assumptions and evidence in the response instead of writing.
+2. Compare unexpected findings with [references/canon.md](references/canon.md) and
+   propose a Pattern Base candidate only when the lesson is general.
+3. Append to [references/pattern-base.md](references/pattern-base.md) only when
+   repository edits are authorized and the candidate is deduplicated and
+   reviewable.
+4. Record the coverage signal: sources and lifecycle areas checked, unavailable
+   evidence, remaining low-confidence claims, and whether a new gap was found.
 
-1. **Write the reality-check log** into the spec (see
-   [trace-schema.md](references/trace-schema.md)): every assumption the business
-   overturned.
-2. **For each one the Pattern Base did not predict**, append a new pattern —
-   symptom / the real case / how to detect it next time. Check it against
-   [canon.md](references/canon.md) first: _is this an instance of something already
-   named, or genuinely new?_ Most of the time it is the former, and that is a good
-   outcome.
-3. **Record the saturation signal.** If a whole round overturned _nothing_, say
-   so: the implementation model is mined out for that surface, and the next round
-   belongs to the **mental** model — the one grounding cannot reach.
-
-A session that ships a feature but teaches the system nothing has done half the
-job.
-
----
+Zero new gaps means only that none were found within the inspected scope. It does
+not prove that the implementation or mental model is exhausted.
 
 ## Deliverables
 
-| Artifact              | Where                                                    | Template                                             |
-| --------------------- | -------------------------------------------------------- | ---------------------------------------------------- |
-| Design spec           | `YYYY-MM-DD-<slug>-design.md`                            | [templates/design-spec.md](templates/design-spec.md) |
-| Interactive prototype | Beside the spec                                          | via [design-prototype](../design-prototype/SKILL.md) |
-| Reality-check log     | A section **inside** the spec                            | [trace-schema.md](references/trace-schema.md)        |
-| New patterns          | [references/pattern-base.md](references/pattern-base.md) | append                                               |
+| Artifact              | When                                       | Template/location                                                                      |
+| --------------------- | ------------------------------------------ | -------------------------------------------------------------------------------------- |
+| Design spec           | Requested in Materialize mode              | [templates/design-spec.md](templates/design-spec.md); use a user-specified path or ask |
+| Interactive prototype | Requested or needed to resolve uncertainty | Beside the spec, via `design-prototype`                                                |
+| Reality-check log     | Inside a produced spec                     | [references/trace-schema.md](references/trace-schema.md)                               |
+| Pattern candidate     | A general, unexpected lesson emerges       | In the spec/response; append only after review and authorization                       |
 
 ## Anti-patterns
 
-- **Designing from the screenshot.** It shows what renders, not what the business
-  models.
-- **Proposing a solution before the diagnosis names a structural error.**
-- **Reading a state or an action by its name** instead of by what it obliges or
-  produces.
-- **Letting a missing concept masquerade as a layout problem** (`P-06`).
-- **Dumping every open question at once**, or asking things the domain model
-  already answers.
-- **Letting engineering findings into the Pattern Base.** They are true and they
-  belong somewhere else.
-- **Shipping and not writing back.** The next session re-learns it all.
+- Designing from a screenshot or treating the domain model as the sitemap.
+- Reading a state or action by its label rather than its obligation or event.
+- Inferring the user model from code and presenting it as observed truth.
+- Treating a missing concept as a layout problem.
+- Asking questions the available evidence already answers.
+- Treating concept existence as an engineering cost estimate.
+- Automatically prototyping, writing a spec or mutating the Pattern Base.
+- Adding local corrections or engineering findings to shared product guidance.
 
-## Worked example
-
-[references/worked-example.md](references/worked-example.md) — a full trace of one
-real session: a surface that showed one of four kinds of agent message, the
-assumptions the business overturned, and the subset that shipped because the
-domain already supported it.
+For a complete example, read
+[references/worked-example.md](references/worked-example.md).

--- a/.agents/skills/product-design/references/layer-model.md
+++ b/.agents/skills/product-design/references/layer-model.md
@@ -106,18 +106,16 @@ is a fact about. The tag decides what the finding licenses.
 The last row is the filter. Most of what you can learn from a codebase is not a
 product finding, and letting it in is how a Pattern Base turns into a changelog.
 
-## Saturation, per model
+## Coverage, per model
 
-Saturation (**S**) is measured per model, and they saturate at very different
-speeds:
+Coverage is measured per model. A round with no new gaps is useful only when its
+inspected sources and lifecycle areas are recorded:
 
-- **The implementation model saturates fast.** One thorough grounding pass usually
-  surfaces most of what the product models. When a second pass overturns nothing,
-  it is mined out — stop spending budget there.
-- **The represented model saturates per iteration.** Each prototype round should
-  produce fewer corrections than the last. If round three produces as many as
-  round one, the problem is upstream: the implementation model was never actually
-  grounded.
-- **The mental model never saturates**, and it is the one this skill is weakest at.
-  Grounding cannot touch it. A session with zero mental-model findings has not
-  finished — it has only done the half that could be done from a desk.
+- **The implementation model is often bounded.** A thorough pass may find most of
+  the relevant concepts. A second pass with no new gaps can justify shifting effort
+  toward user evidence, but proves only that none was found in the recorded scope.
+- **The represented model stabilizes through validation.** Continued change can
+  reflect learning; record its cause rather than inferring process quality from
+  the number of corrections.
+- **The mental model remains provisional.** Grounding cannot establish it. Label
+  observed, reported and inferred claims separately, and record validation gaps.

--- a/.agents/skills/product-design/references/pattern-base.md
+++ b/.agents/skills/product-design/references/pattern-base.md
@@ -1,14 +1,14 @@
 # Pattern Base
 
-> **Mandatory**: read this file in full before every product-design run, and
-> self-check against each pattern.
+> Read this file in full before a substantial product-design run. For a narrow
+> question, inspect the relevant patterns and state the checked scope.
 >
-> **Append after every run.** When the business model overturns an assumption
-> that no pattern here predicted, that is a new gap — write it down. Each entry:
+> **Propose before appending.** When evidence overturns an assumption that no
+> pattern here predicted, record a candidate. Append only when repository edits
+> are authorized and the lesson is general, deduplicated and reviewable. Each entry:
 > **Symptom / The real case / Why it happens / How to detect it next time.**
 >
-> This is the **P** of SCLPT. Its coverage is the ceiling of what this skill can
-> catch. Saturation = a grounding round that produces **zero** new entries here.
+> This is the **P** of SCLPT. It is a reviewed aid, not an exhaustive truth set.
 
 ## What belongs here, and what does not
 
@@ -48,12 +48,13 @@ Every pattern here is a failure to hold that line:
   **disagree** about what exists.
 - **Class C** — the represented model follows the implementation model when it
   should be following the **mental** model.
-- **Class D** — what to do once the first three are settled.
+- **Class D** — how to scope once the first three are settled.
+- **Class E** — how human judgment relates to machine-produced evidence.
 
-**Where the implementation model is written down**: the domain model — the
-concepts, the states, the events. Not because implementation matters, but because
-**that is the most honest statement the company has ever made about what it
-believes exists.** Read it as a domain document.
+**Where to investigate the implementation model**: domain concepts, states and
+events are strong evidence, but not the only evidence. Reconcile them with actual
+service behavior, permissions, policy and production facts where relevant. Code
+can be stale, accidental or incomplete.
 
 ---
 
@@ -261,20 +262,20 @@ field says urgent** — because "urgent" was written by the producer, and
 
 ## Class D — Scope and honesty
 
-### P-10 — Ship what the business already supports, first
+### P-10 — Prefer coherent value with lower domain risk
 
 **Rule**: before scoping, sort every capability the design needs by **whether the
 business already models it**:
 
-| Bucket                                   | Meaning                                                         |
-| ---------------------------------------- | --------------------------------------------------------------- |
-| ✅ **Already modeled, already exposed**  | Rearranging what is there                                       |
-| ⚠️ **Already modeled, not yet exposed**  | `P-04` territory — nearly free product                          |
-| ❌ **Not a concept in the business yet** | A domain change. Real, but an order of magnitude more expensive |
+| Bucket                                   | Meaning                                                     |
+| ---------------------------------------- | ----------------------------------------------------------- |
+| ✅ **Already modeled, already exposed**  | Rearranging what is there                                   |
+| ⚠️ **Already modeled, not yet exposed**  | Lower domain risk; engineering cost still needs validation  |
+| ❌ **Not a concept in the business yet** | Requires domain expansion and explicit cost/risk assessment |
 
-**Then ship ✅ + ⚠️ first.** Not as a compromise — as a discipline. It forces the
-design to be honest about what the business actually is today, and it puts a real
-surface in front of users while the domain changes are still being argued about.
+**Prefer a coherent ✅ + ⚠️ slice when it completes the user's job.** Do not ship
+an incomplete or misleading slice merely because its concepts exist. A ❌ item can
+be the right first investment when required for value, safety or semantic integrity.
 
 **The real case**: a sweeping team-collaboration vision needed mentions,
 annotations, presence and a project concept — **all ❌**. But the attention inbox
@@ -282,8 +283,9 @@ at its core was entirely ✅ + ⚠️: the four message kinds were already being
 produced, and the running/unread work was already a business concept. That subset
 shipped. The expensive half is still, correctly, being argued about.
 
-**Detect**: if your first milestone requires the business to learn a new concept,
-you have probably not looked hard enough for the ⚠️ bucket.
+**Detect**: if the first milestone requires a new concept, check the ⚠️ bucket
+before committing. Then compare user value, risk, coherence and engineering cost
+instead of treating concept existence as the cost estimate.
 
 ### P-11 — Name what you are _not_ building, and what it would cost
 
@@ -299,3 +301,103 @@ the conversation you want.
 **The real case**: a prototype showed each run's elapsed time. The business has
 no such concept — a run's duration is not modeled, anywhere. Writing that down
 converted _"you forgot the timestamps"_ into _"we know, and here is the price"_.
+
+---
+
+## Class E — Human judgment and machine-produced evidence
+
+### P-12 — The actor who closes the lifecycle defines the surface
+
+**Symptom**: a surface called a report leads with the system's verdict, summary,
+counts and execution history, while the human action that creates the terminal
+business outcome is absent or secondary.
+
+**The real case**: delivery acceptance had rich verification runs and generated
+reports, so the first designs treated the surface as a finished report with
+evidence attached. In the business, however, an acceptance becomes terminal only
+when the user clicks **Accept delivery**. The verifier's `passed` result is advice;
+the user's acceptance is the event. The honest surface is therefore a decision
+workspace: what is safe to accept, what changed, what still deserves review, the
+evidence needed for that judgment, and the final action. The complete report is a
+drill-down, not the page's organizing principle.
+
+**Why it happens**: machine outputs are numerous, named and easy to render; the
+single human decision is often implemented later and looks like "just a button".
+Design inherits the volume of the implementation model and mistakes it for the
+importance of the business model.
+
+**Detect**: for every review, approval or acceptance surface, ask **"who is
+allowed to make this terminal, and what event does that action produce?"** If the
+answer is a human action, organize the surface around the decision it supports.
+Treat system verdicts as recommendations and evidence as decision material —
+never as a substitute for the terminal event.
+
+**Canonical anchor**: Cooper's goal-directed design and JTBD. The user's goal is
+to make a defensible decision in this circumstance, not to inspect everything the
+machine happened to produce.
+
+### P-13 — Execution history is an audit model, not the default review model
+
+**Symptom**: attempts, runs or evidence versions dominate the first screen because
+they are the clearest structure in storage.
+
+**The real case**: a multi-run acceptance was first represented as a Check × Run
+matrix followed by an "evidence evolution" gallery. Both were accurate and useful
+for deep investigation, but they made the user reconstruct the actual decision:
+what was fixed, what remains risky, and whether the delivery is safe to accept.
+The first screen instead needs exceptions and decision-relevant change: failed →
+fixed proof, missing or stale evidence, and anything carried forward without a
+rerun. Stable checks and their full run ledger remain available as audit detail.
+
+**Why it happens**: chronology is objective and readily available, while deciding
+which differences matter requires product judgment. Teams therefore expose the
+event log and call the reconstruction work "transparency".
+
+**Detect**: before putting chronology on the default surface, ask **"does the user
+need to understand every attempt to act, or only the exceptions and changes that
+alter today's decision?"** Default-expand the latter. Collapse unchanged success
+into a count; put the complete ledger behind deliberate exploration.
+
+**Canonical anchor**: Cooper's represented-vs-implementation model, plus JTBD's
+circumstance. Runs are how the system executed; acceptability and exceptions are
+how the user decides.
+
+### P-14 — The domain constrains truth; the user's lookup object organizes the view
+
+**Symptom**: every section is semantically correct, yet the user still cannot find
+the thing they came for without translating domain language, combining several
+modules or expanding hidden detail.
+
+**The real case**: an acceptance design progressed from report summary, to evidence
+gallery, to Check × Run ledger, to exception-first decision cards. Each correction
+made the business semantics more accurate, but the user still wanted something
+simpler: **the complete union of acceptance Check items, grouped by a familiar
+category, with each item's final evidence directly underneath it**. They needed to
+answer "Did Web interaction have a screenshot?" by scanning the Web check — not by
+interpreting a system judgment, an evidence-evolution module or a run matrix. Runs
+were useful only to show when a Check was introduced and where its final evidence
+came from.
+
+**Why it happens**: grounding the domain is hard and rewarding, so once the model
+is understood the designer over-promotes it into the interface. A second failure
+then follows: "user-centered" is interpreted as deciding what the user should care
+about (exceptions, risk, recommendations) rather than exposing the objects the user
+is actually trying to inspect. The result is curated but controlling — the system
+answers a nearby question and hides the requested inventory.
+
+**Detect**: before proposing sections, complete three sentences in the user's
+language:
+
+1. "I came here to find every \_\_\_."
+2. "For each one, I need to see \_\_\_ without another click."
+3. "I use \_\_\_ only to filter, explain provenance or investigate history."
+
+Make the first blank the repeated item contract, attach the second directly to each
+item, and demote the third. If users ask "does item X have proof?" and the proof is
+in another module, the information architecture is wrong even when every business
+fact is correct.
+
+**Canonical anchor**: Cooper's represented-vs-implementation model and JTBD. The
+domain model licenses claims; the circumstance reveals the user's retrieval object.
+Neither authorizes the designer to substitute a curated summary for the inventory
+the user came to inspect.

--- a/.agents/skills/product-design/references/trace-schema.md
+++ b/.agents/skills/product-design/references/trace-schema.md
@@ -56,17 +56,23 @@ mature run should be mostly `confirmed`, with one or two `NEW`.
 
 The shape of the log **is** the diagnosis of the session:
 
-| Shape                                | What it means                                                                                           |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| Many `overturned`, all `NEW`         | Cold start. The Pattern Base was blind here — harvest it.                                               |
-| Many `overturned`, all citing `P-nn` | **The patterns were not read.** A process failure, not a knowledge failure. Fix Step 0, not the design. |
-| Mostly `confirmed`, one or two `NEW` | Healthy. The system is working.                                                                         |
-| Zero rows                            | Either a trivial surface, or — far more likely — **nobody grounded anything.** Treat with suspicion.    |
-| Zero `NEW` across a whole round      | **Saturation.** The implementation model is mined out for this surface.                                 |
+| Shape                                | What it means                                                                                        |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| Many `overturned`, all `NEW`         | Cold start. The Pattern Base was blind here — harvest it.                                            |
+| Many `overturned`, all citing `P-nn` | Check whether the relevant patterns were read and applied; this may be a process gap.                |
+| Mostly `confirmed`, one or two `NEW` | Healthy. The system is working.                                                                      |
+| Zero rows                            | Either a trivial surface, or — far more likely — **nobody grounded anything.** Treat with suspicion. |
+| Zero `NEW` across a documented round | No new gap was found in the inspected scope; check coverage before shifting effort.                  |
 
-That second row is worth dwelling on. If the business keeps overturning things the
-Pattern Base **already knew**, the skill is fine and the run was sloppy. The fix
-is to read Step 0 — not to add more patterns.
+If evidence keeps overturning things the Pattern Base already covers, inspect the
+run's pattern selection and application before adding more patterns. Do not assume
+the guidance itself is complete or correctly scoped.
+
+## Recording coverage
+
+Name the sources and lifecycle areas checked, unavailable evidence,
+contradictions and low-confidence claims. Without this record, zero new findings
+is inconclusive rather than a saturation signal.
 
 ## Marking debt on the prototype itself
 
@@ -83,7 +89,7 @@ the business event behind an element, you must draw the tag.**
 
 ## Why the log, and not just a good memory
 
-The Pattern Base is the skill's long-term memory; the reality-check log is its
-short-term one. Skipping the log does not merely lose a document — it breaks the
-**C** (Closed Loop) of SCLPT, and the next session re-learns the same nine lessons
-from scratch.
+The Pattern Base is reviewed long-term guidance; the reality-check log is
+task-local evidence. Include the log in a requested spec, or summarize its
+material findings in a read-only response. Do not create an artifact solely to
+satisfy the process.

--- a/.agents/skills/product-design/references/worked-example.md
+++ b/.agents/skills/product-design/references/worked-example.md
@@ -44,7 +44,16 @@ Two more findings from the same pass, both about **meaning, not mechanism**:
 - The action labelled "Request changes" does not leave a comment. It **re-tasks
   the agent**, feeding the comment back in as new input (`P-02`).
 
-## Step 2 — Diagnose
+## Step 2 — Frame the user's view model
+
+The initial view model was a hypothesis, not a user fact: someone opens the home
+surface to find work blocked on their attention. The repeated lookup object was a
+signal requiring a response, with its source and consequence attached. This was
+supported by domain obligations but still required user validation; the later
+human correction from “tasks” to “work, attention and goals” supplied direct
+reported evidence.
+
+## Step 3 — Diagnose
 
 Three structural errors, none of them about taste:
 
@@ -57,7 +66,7 @@ Three structural errors, none of them about taste:
    the user needs to know is _"what is blocked on me"_, not _"what did the agent
    say"_ (`P-09`).
 
-## Step 3 — Align
+## Step 4 — Align
 
 Decisions surfaced one at a time. The two that changed the shape of the answer:
 
@@ -73,7 +82,7 @@ everything around **tasks**; the reply was, roughly: _"organize it around the
 work, and around attention and goals — not around one entity type."_ That
 correction became `P-09`.
 
-## Step 4 — Prototype
+## Step 5 — Prototype
 
 Six rounds in the real design system. Every round, the business overturned
 something:
@@ -88,7 +97,7 @@ something:
 **The prototype's job is not to be right. It is to be wrong in ways the business
 can correct.** A round that only moves pixels means the grounding was skipped.
 
-## Step 5 — Scope
+## Step 6 — Scope
 
 | Bucket                                   | Capability                                                                                               |
 | ---------------------------------------- | -------------------------------------------------------------------------------------------------------- |
@@ -96,7 +105,9 @@ can correct.** A round that only moves pixels means the grounding was skipped.
 | ⚠️ **Modeled, never exposed**            | **The other three message kinds.** Running work. Unread finished work. The task each message belongs to. |
 | ❌ **Not a concept in the business yet** | Mentions of a person. Annotations. Presence. A project. A run's duration.                                |
 
-**Shipped: ✅ + ⚠️.** Nothing in the ❌ column. Every item there went into the
+**Recommended and shipped in this case: ✅ + ⚠️.** Together they formed a coherent
+personal-inbox job. Nothing in the ❌ column was required for that slice. Every
+excluded item went into the
 spec by name, with its cost (`P-11`).
 
 The redesign that began as a sweeping team-collaboration vision shipped as a
@@ -104,13 +115,14 @@ focused personal inbox — **not as a retreat, but because that was the part the
 business already believed in** (`P-10`). The expensive half is still, correctly,
 being argued about.
 
-## Step 6 — Close the loop
+## Close — record coverage and propose learning
 
 Nine assumptions overturned, nine `NEW` → the entire Pattern Base. That is the
 cold-start signature (see [trace-schema.md](trace-schema.md#reading-the-log)).
 
-**Saturation, honestly**: the implementation model for this surface is close to
-mined out — a second pass over the same domain would turn up little.
+**Coverage signal**: the inspected message variants, task states, response actions
+and ownership concepts produced no further gaps late in the pass. That justified
+shifting the next round toward user evidence; it did not prove the model exhausted.
 
 **And every one of the nine rows is an implementation-model finding. Not one is
 about the mental model.** That is the real verdict on this session: the half that

--- a/.agents/skills/product-design/templates/design-spec.md
+++ b/.agents/skills/product-design/templates/design-spec.md
@@ -1,7 +1,7 @@
 # <Surface> — <what this round changes>
 
 **Date:** YYYY-MM-DD
-**Status:** aligning | scoped | shipped
+**Status:** discovery | aligning | scoped | validated
 **Scope:** one sentence. Say what is **out** of scope too.
 **Prototype:** path, if any
 
@@ -22,7 +22,17 @@ surface touches:
 
 ---
 
-## 2. Diagnosis
+## 2. User view model
+
+- Circumstance and job
+- Lookup objects and proof attached to each
+- First-scan questions and secondary dimensions
+- Evidence for each claim: observed | reported | inferred
+- Confidence and validation gaps
+
+---
+
+## 3. Diagnosis
 
 Name the **structural** error(s) — something wrong regardless of taste. Not "it
 looks dated".
@@ -31,14 +41,14 @@ If you cannot name one, you do not have a diagnosis. You have an opinion.
 
 ---
 
-## 3. Principles
+## 4. Principles
 
 Only the principles this diagnosis actually forced. Each with a **rejected
 alternative** attached — a principle with no rejected alternative is decoration.
 
 ---
 
-## 4. Information architecture
+## 5. Information architecture
 
 Block by block. For each:
 
@@ -48,21 +58,20 @@ Block by block. For each:
 
 ---
 
-## 5. Scope — what does the business already support?
+## 6. Scope — what does the business already support?
 
-| Bucket                               | Capability | Meaning                             |
-| ------------------------------------ | ---------- | ----------------------------------- |
-| ✅ Already modeled, already exposed  |            | Rearranging what is there           |
-| ⚠️ Already modeled, never exposed    |            | Nearly free product                 |
-| ❌ Not a concept in the business yet |            | A domain change. Order of magnitude |
+| Bucket                               | Capability | Meaning                                           |
+| ------------------------------------ | ---------- | ------------------------------------------------- |
+| ✅ Already modeled, already exposed  |            | Rearranging what is there                         |
+| ⚠️ Already modeled, never exposed    |            | Lower domain risk; validate implementation cost   |
+| ❌ Not a concept in the business yet |            | Domain expansion; assess cost and risk explicitly |
 
-**Ships this round:** ✅ + ⚠️.
-**Does not, and why:** every ❌ item **by name, with its cost**. Silence reads as
-an oversight (`P-11`).
+**Recommended coherent slice:** explain how it completes the user's job.
+**Does not, and why:** every excluded item by name, with likely cost drivers.
 
 ---
 
-## 6. Red lines
+## 7. Red lines
 
 Concepts the business does not have, which therefore cannot be designed around —
 only proposed as domain changes. **Bold them.** These are not preferences
@@ -70,7 +79,7 @@ only proposed as domain changes. **Bold them.** These are not preferences
 
 ---
 
-## 7. Reality-check log
+## 8. Reality-check log
 
 The `T` of SCLPT. One row per assumption that met the business model.
 Schema: [trace-schema.md](../references/trace-schema.md).
@@ -82,17 +91,16 @@ fact without naming a table, it is probably not a product finding.
 | ---------- | ------------ | ----- | ------- | ------- |
 |            |              |       |         |         |
 
-**Saturation:** did this round's grounding overturn anything? If a full pass
-overturned nothing, say so — the implementation model is mined out for this
-surface, and the next round's budget belongs to the **mental** model.
+**Coverage:** which sources, roles, permissions, states and lifecycle paths were
+checked? What evidence was unavailable? Which claims remain low-confidence? If no
+new gap was found, state only that none was found in this inspected scope.
 
-**New patterns written back:** `P-nn`, … (or "none — all predicted").
-Check each against [canon.md](../references/canon.md) first: an instance of
-something already named, or genuinely new?
+**Pattern candidates:** list candidates or “none”. Check each against
+[canon.md](../references/canon.md); append only after review and authorization.
 
 ---
 
-## 8. Open decisions
+## 9. Open decisions
 
 Only the ones that **change the shape of the answer**. Each with a recommendation
 and its reasoning. Not a list of everything unresolved.


### PR DESCRIPTION
## Summary

- promote the user view model into a formal workflow step and separate observed evidence from hypotheses
- introduce Discover, Frame, and Materialize modes so analysis does not automatically write specs or prototypes
- replace rigid write-back, cost, shipping, delegation, and saturation rules with evidence-based guidance
- align the pattern base, layer model, trace schema, worked example, and design spec template

## Validation

- `python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/product-design`
- Markdown commit hooks (`remark`, `prettier`)
- `git diff --check`