### PR TITLE
🐛 fix(topic): clear the rate-limit error card when a scheduled continuation dispatches

### DIFF
--- a/apps/server/src/workflows-hono/task/handlers/__tests__/scheduledTopicDispatch.test.ts
+++ b/apps/server/src/workflows-hono/task/handlers/__tests__/scheduledTopicDispatch.test.ts
@@ -151,7 +151,7 @@ describe('scheduledTopicDispatch', () => {
     );
   });
 
-  it('clears the rate-limit error card once the continuation is accepted, keeping preserved work', async () => {
+  it('clears the rate-limit error card before dispatch, keeping preserved work', async () => {
     mocks.getDueScheduledTopics.mockResolvedValue([topic(resumeAfterRateLimit)]);
     // The failed step streamed content before dying → keep it, only drop the error.
     mocks.findById.mockResolvedValue({
@@ -164,47 +164,52 @@ describe('scheduledTopicDispatch', () => {
 
     expect(mocks.updateMessage).toHaveBeenCalledWith('assistant-failed', { error: null });
     expect(mocks.deleteMessage).not.toHaveBeenCalled();
+    // Cleanup runs first — the continuation must never stream in above a stale card.
+    expect(mocks.updateMessage.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.execAgent.mock.invocationCallOrder[0],
+    );
+    expect(mocks.execAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ parentMessageId: 'assistant-failed' }),
+    );
   });
 
-  it('deletes an error-only failed step after dispatch, instead of leaving an empty block', async () => {
+  it('deletes an error-only failed step and anchors the continuation on its parent', async () => {
     mocks.getDueScheduledTopics.mockResolvedValue([topic(resumeAfterRateLimit)]);
     // Nothing but the error (content is the loading placeholder, no tools).
     mocks.findById.mockResolvedValue({
       content: '...',
       error: { body: { code: 'rate_limit' } },
       id: 'assistant-failed',
+      parentId: 'user-message',
     });
 
     await dispatch();
 
     expect(mocks.deleteMessage).toHaveBeenCalledWith('assistant-failed');
     expect(mocks.updateMessage).not.toHaveBeenCalled();
+    expect(mocks.deleteMessage.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.execAgent.mock.invocationCallOrder[0],
+    );
+    // The deleted step can't anchor anything — chain onto its parent.
+    expect(mocks.execAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ parentMessageId: 'user-message', resume: true }),
+    );
   });
 
-  it('keeps the error card intact when dispatch fails, so retry entry points survive', async () => {
+  it('retries from the user turn when the failed message is already gone', async () => {
+    // A prior tick cleaned the error-only step but its dispatch failed (device
+    // offline). The retry must not error out — it falls back to the user turn
+    // recorded in the payload.
     mocks.getDueScheduledTopics.mockResolvedValue([topic(resumeAfterRateLimit)]);
-    mocks.execAgent.mockResolvedValue({ error: 'device offline', success: false });
-
-    await dispatch();
-
-    expect(mocks.updateMessage).not.toHaveBeenCalled();
-    expect(mocks.deleteMessage).not.toHaveBeenCalled();
-  });
-
-  it('still dispatches successfully when the post-dispatch cleanup write fails', async () => {
-    // The run is already live — a cleanup failure must not leave the topic
-    // `scheduled`, or the next tick would fire a duplicate continuation.
-    mocks.getDueScheduledTopics.mockResolvedValue([topic(resumeAfterRateLimit)]);
-    mocks.updateMessage.mockRejectedValue(new Error('db write failed'));
+    mocks.findById.mockResolvedValue(undefined);
 
     const response = await dispatch();
 
     await expect(response.json()).resolves.toMatchObject({ dispatched: 1 });
-    expect(mocks.clearScheduledRun).toHaveBeenCalledWith(
-      {},
-      'topic-1',
-      'running',
-      expect.any(String),
+    expect(mocks.updateMessage).not.toHaveBeenCalled();
+    expect(mocks.deleteMessage).not.toHaveBeenCalled();
+    expect(mocks.execAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ parentMessageId: 'user-message', resume: true }),
     );
   });
 

--- a/apps/server/src/workflows-hono/task/handlers/__tests__/scheduledTopicDispatch.test.ts
+++ b/apps/server/src/workflows-hono/task/handlers/__tests__/scheduledTopicDispatch.test.ts
@@ -6,10 +6,12 @@ import { scheduledTopicDispatch } from '../scheduledTopicDispatch';
 const mocks = vi.hoisted(() => ({
   claimScheduledTopic: vi.fn(),
   clearScheduledRun: vi.fn(),
+  deleteMessage: vi.fn(),
   execAgent: vi.fn(),
   findById: vi.fn(),
   getDueScheduledTopics: vi.fn(),
   getServerDB: vi.fn(),
+  updateMessage: vi.fn(),
 }));
 
 vi.mock('@/database/server', () => ({ getServerDB: mocks.getServerDB }));
@@ -25,6 +27,8 @@ vi.mock('@/database/models/topic', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: class {
     findById = mocks.findById;
+    update = mocks.updateMessage;
+    deleteMessage = mocks.deleteMessage;
   },
 }));
 
@@ -144,6 +148,63 @@ describe('scheduledTopicDispatch', () => {
         parentMessageId: 'assistant-failed',
         resume: true,
       }),
+    );
+  });
+
+  it('clears the rate-limit error card once the continuation is accepted, keeping preserved work', async () => {
+    mocks.getDueScheduledTopics.mockResolvedValue([topic(resumeAfterRateLimit)]);
+    // The failed step streamed content before dying → keep it, only drop the error.
+    mocks.findById.mockResolvedValue({
+      content: 'partial answer',
+      error: { body: { code: 'rate_limit' } },
+      id: 'assistant-failed',
+    });
+
+    await dispatch();
+
+    expect(mocks.updateMessage).toHaveBeenCalledWith('assistant-failed', { error: null });
+    expect(mocks.deleteMessage).not.toHaveBeenCalled();
+  });
+
+  it('deletes an error-only failed step after dispatch, instead of leaving an empty block', async () => {
+    mocks.getDueScheduledTopics.mockResolvedValue([topic(resumeAfterRateLimit)]);
+    // Nothing but the error (content is the loading placeholder, no tools).
+    mocks.findById.mockResolvedValue({
+      content: '...',
+      error: { body: { code: 'rate_limit' } },
+      id: 'assistant-failed',
+    });
+
+    await dispatch();
+
+    expect(mocks.deleteMessage).toHaveBeenCalledWith('assistant-failed');
+    expect(mocks.updateMessage).not.toHaveBeenCalled();
+  });
+
+  it('keeps the error card intact when dispatch fails, so retry entry points survive', async () => {
+    mocks.getDueScheduledTopics.mockResolvedValue([topic(resumeAfterRateLimit)]);
+    mocks.execAgent.mockResolvedValue({ error: 'device offline', success: false });
+
+    await dispatch();
+
+    expect(mocks.updateMessage).not.toHaveBeenCalled();
+    expect(mocks.deleteMessage).not.toHaveBeenCalled();
+  });
+
+  it('still dispatches successfully when the post-dispatch cleanup write fails', async () => {
+    // The run is already live — a cleanup failure must not leave the topic
+    // `scheduled`, or the next tick would fire a duplicate continuation.
+    mocks.getDueScheduledTopics.mockResolvedValue([topic(resumeAfterRateLimit)]);
+    mocks.updateMessage.mockRejectedValue(new Error('db write failed'));
+
+    const response = await dispatch();
+
+    await expect(response.json()).resolves.toMatchObject({ dispatched: 1 });
+    expect(mocks.clearScheduledRun).toHaveBeenCalledWith(
+      {},
+      'topic-1',
+      'running',
+      expect.any(String),
     );
   });
 

--- a/apps/server/src/workflows-hono/task/handlers/__tests__/scheduledTopicDispatch.test.ts
+++ b/apps/server/src/workflows-hono/task/handlers/__tests__/scheduledTopicDispatch.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   findById: vi.fn(),
   getDueScheduledTopics: vi.fn(),
   getServerDB: vi.fn(),
+  repointScheduledRunFailedMessage: vi.fn(),
   updateMessage: vi.fn(),
 }));
 
@@ -21,6 +22,7 @@ vi.mock('@/database/models/topic', () => ({
     claimScheduledTopic: mocks.claimScheduledTopic,
     clearScheduledRun: mocks.clearScheduledRun,
     getDueScheduledTopics: mocks.getDueScheduledTopics,
+    repointScheduledRunFailedMessage: mocks.repointScheduledRunFailedMessage,
   },
 }));
 
@@ -196,6 +198,30 @@ describe('scheduledTopicDispatch', () => {
     );
   });
 
+  it('re-points the schedule at the dispatch-failure bubble so the retry cleans it too', async () => {
+    // A failed dispatch leaves a `ServerAgentRuntimeError` bubble on the
+    // placeholder execAgent created (finalizeHeteroDispatchError). Without
+    // re-pointing, the next successful retry would strand that bubble forever —
+    // the same stale-card bug this handler's cleanup exists to prevent.
+    mocks.getDueScheduledTopics.mockResolvedValue([topic(resumeAfterRateLimit)]);
+    mocks.execAgent.mockResolvedValue({
+      assistantMessageId: 'assistant-dispatch-failed',
+      error: 'device offline',
+      success: false,
+    });
+
+    const response = await dispatch();
+
+    await expect(response.json()).resolves.toMatchObject({ dispatched: 0 });
+    expect(mocks.repointScheduledRunFailedMessage).toHaveBeenCalledWith(
+      {},
+      'topic-1',
+      'assistant-dispatch-failed',
+    );
+    // The topic itself stays scheduled — the next tick retries.
+    expect(mocks.clearScheduledRun).not.toHaveBeenCalled();
+  });
+
   it('retries from the user turn when the failed message is already gone', async () => {
     // A prior tick cleaned the error-only step but its dispatch failed (device
     // offline). The retry must not error out — it falls back to the user turn
@@ -221,6 +247,8 @@ describe('scheduledTopicDispatch', () => {
 
     await expect(response.json()).resolves.toMatchObject({ claimed: 1, dispatched: 0 });
     expect(mocks.clearScheduledRun).not.toHaveBeenCalled();
+    // Only the resume kind has a cleanup phase to hand the bubble to.
+    expect(mocks.repointScheduledRunFailedMessage).not.toHaveBeenCalled();
   });
 
   it('dispatches a continuation parked by the pre-`kind` version, rather than discarding it', async () => {

--- a/apps/server/src/workflows-hono/task/handlers/__tests__/scheduledTopicDispatch.test.ts
+++ b/apps/server/src/workflows-hono/task/handlers/__tests__/scheduledTopicDispatch.test.ts
@@ -213,10 +213,13 @@ describe('scheduledTopicDispatch', () => {
     const response = await dispatch();
 
     await expect(response.json()).resolves.toMatchObject({ dispatched: 0 });
+    // Fenced on the dispatcher's claim lease — a stale attempt must not
+    // re-point a newer scheduled run.
     expect(mocks.repointScheduledRunFailedMessage).toHaveBeenCalledWith(
       {},
       'topic-1',
       'assistant-dispatch-failed',
+      mocks.claimScheduledTopic.mock.calls[0][2].id,
     );
     // The topic itself stays scheduled — the next tick retries.
     expect(mocks.clearScheduledRun).not.toHaveBeenCalled();

--- a/apps/server/src/workflows-hono/task/handlers/scheduledRunKinds.ts
+++ b/apps/server/src/workflows-hono/task/handlers/scheduledRunKinds.ts
@@ -4,6 +4,7 @@ import type { ExecAgentResult, TopicScheduledRun, TopicScheduledRunKind } from '
 import { RequestTrigger } from '@lobechat/types';
 
 import { MessageModel } from '@/database/models/message';
+import { TopicModel } from '@/database/models/topic';
 import type { TopicItem } from '@/database/schemas/topic';
 import { AiAgentService } from '@/server/services/aiAgent';
 
@@ -57,7 +58,7 @@ const runResumeAfterRateLimit: ScheduledRunHandlers['resume_after_rate_limit'] =
     }
   }
 
-  return new AiAgentService(db, topic.userId, { workspaceId }).execAgent({
+  const result = await new AiAgentService(db, topic.userId, { workspaceId }).execAgent({
     agentId: topic.agentId ?? undefined,
     appContext: { topicId: topic.id },
     parentMessageId,
@@ -65,6 +66,18 @@ const runResumeAfterRateLimit: ScheduledRunHandlers['resume_after_rate_limit'] =
     resume: true,
     trigger: RequestTrigger.Cron,
   });
+
+  // A dispatch that fails inside execAgent (device offline, access denied, …)
+  // leaves its own error bubble on the placeholder it created
+  // (`finalizeHeteroDispatchError`) — the user still sees why the continuation
+  // didn't fire. Track that bubble as the run's failed message so the next
+  // tick's pre-dispatch cleanup clears it exactly like the original card;
+  // otherwise every failed attempt would strand one more stale error card.
+  if (!result.success && result.assistantMessageId) {
+    await TopicModel.repointScheduledRunFailedMessage(db, topic.id, result.assistantMessageId);
+  }
+
+  return result;
 };
 
 /**

--- a/apps/server/src/workflows-hono/task/handlers/scheduledRunKinds.ts
+++ b/apps/server/src/workflows-hono/task/handlers/scheduledRunKinds.ts
@@ -1,4 +1,4 @@
-import { HETERO_CONTINUE_PROMPT } from '@lobechat/const';
+import { HETERO_CONTINUE_PROMPT, LOADING_FLAT } from '@lobechat/const';
 import type { LobeChatDatabase } from '@lobechat/database';
 import type { ExecAgentResult, TopicScheduledRun, TopicScheduledRunKind } from '@lobechat/types';
 import { RequestTrigger } from '@lobechat/types';
@@ -25,8 +25,12 @@ type ScheduledRunHandlers = {
  *
  * Mirrors `continueHeteroAfterError`: resume the surviving CLI session from the
  * assistant-chain tail with the shared continuation instruction. The failed turn
- * is deliberately NOT deleted before dispatch — a dispatch failure must leave the
- * user's error card and retry entry intact.
+ * is deliberately NOT touched before dispatch — a dispatch failure must leave the
+ * user's error card and retry entry intact. Only after execAgent accepts the run
+ * is the stale rate-limit card removed: a step that preserved work (streamed
+ * content / tool calls) keeps its body and just drops the error; an error-only
+ * step would render as an empty block, so it is deleted outright (`deleteMessage`
+ * reparents the already-created continuation placeholder onto its parent).
  */
 const runResumeAfterRateLimit: ScheduledRunHandlers['resume_after_rate_limit'] = async (
   run,
@@ -36,7 +40,7 @@ const runResumeAfterRateLimit: ScheduledRunHandlers['resume_after_rate_limit'] =
   const failedMessage = await messageModel.findById(run.failedAssistantMessageId);
   if (!failedMessage) throw new Error('Scheduled continuation message no longer exists');
 
-  return new AiAgentService(db, topic.userId, { workspaceId }).execAgent({
+  const result = await new AiAgentService(db, topic.userId, { workspaceId }).execAgent({
     agentId: topic.agentId ?? undefined,
     appContext: { topicId: topic.id },
     parentMessageId: failedMessage.id,
@@ -44,6 +48,31 @@ const runResumeAfterRateLimit: ScheduledRunHandlers['resume_after_rate_limit'] =
     resume: true,
     trigger: RequestTrigger.Cron,
   });
+
+  if (result.success) {
+    const hasSalvageableWork =
+      (Array.isArray(failedMessage.tools) && failedMessage.tools.length > 0) ||
+      (!!failedMessage.content && failedMessage.content !== LOADING_FLAT);
+
+    // Cleanup is best-effort: the run is already live, so a failure here must
+    // not fail the dispatch (the dispatcher would leave the topic `scheduled`
+    // and the next tick would fire a duplicate continuation).
+    try {
+      if (hasSalvageableWork) {
+        await messageModel.update(failedMessage.id, { error: null });
+      } else {
+        await messageModel.deleteMessage(failedMessage.id);
+      }
+    } catch (err) {
+      console.error(
+        '[scheduled-topic-dispatch] failed to clear rate-limit error card message=%s: %O',
+        failedMessage.id,
+        err,
+      );
+    }
+  }
+
+  return result;
 };
 
 /**

--- a/apps/server/src/workflows-hono/task/handlers/scheduledRunKinds.ts
+++ b/apps/server/src/workflows-hono/task/handlers/scheduledRunKinds.ts
@@ -23,14 +23,17 @@ type ScheduledRunHandlers = {
 /**
  * Resume a heterogeneous turn that was parked when the provider rate-limited it.
  *
- * Mirrors `continueHeteroAfterError`: resume the surviving CLI session from the
- * assistant-chain tail with the shared continuation instruction. The failed turn
- * is deliberately NOT touched before dispatch — a dispatch failure must leave the
- * user's error card and retry entry intact. Only after execAgent accepts the run
- * is the stale rate-limit card removed: a step that preserved work (streamed
- * content / tool calls) keeps its body and just drops the error; an error-only
- * step would render as an empty block, so it is deleted outright (`deleteMessage`
- * reparents the already-created continuation placeholder onto its parent).
+ * Mirrors `continueHeteroAfterError` — including its ordering: the stale
+ * rate-limit card is cleared BEFORE dispatch. A step that preserved work
+ * (streamed content / tool calls) keeps its body and only drops the error; an
+ * error-only step would render as an empty block, so it is deleted and the
+ * continuation anchors on its parent instead. Then the surviving CLI session is
+ * resumed from that anchor with the shared continuation instruction.
+ *
+ * If dispatch fails (e.g. device offline) the topic stays `scheduled` and the
+ * next tick retries; by then the failed message may already be cleaned or gone,
+ * so a missing message is not an error — the retry falls back to anchoring on
+ * the user turn recorded in the payload.
  */
 const runResumeAfterRateLimit: ScheduledRunHandlers['resume_after_rate_limit'] = async (
   run,
@@ -38,41 +41,30 @@ const runResumeAfterRateLimit: ScheduledRunHandlers['resume_after_rate_limit'] =
 ) => {
   const messageModel = new MessageModel(db, topic.userId, workspaceId);
   const failedMessage = await messageModel.findById(run.failedAssistantMessageId);
-  if (!failedMessage) throw new Error('Scheduled continuation message no longer exists');
 
-  const result = await new AiAgentService(db, topic.userId, { workspaceId }).execAgent({
-    agentId: topic.agentId ?? undefined,
-    appContext: { topicId: topic.id },
-    parentMessageId: failedMessage.id,
-    prompt: HETERO_CONTINUE_PROMPT,
-    resume: true,
-    trigger: RequestTrigger.Cron,
-  });
-
-  if (result.success) {
+  let parentMessageId = run.userMessageId;
+  if (failedMessage) {
     const hasSalvageableWork =
       (Array.isArray(failedMessage.tools) && failedMessage.tools.length > 0) ||
       (!!failedMessage.content && failedMessage.content !== LOADING_FLAT);
 
-    // Cleanup is best-effort: the run is already live, so a failure here must
-    // not fail the dispatch (the dispatcher would leave the topic `scheduled`
-    // and the next tick would fire a duplicate continuation).
-    try {
-      if (hasSalvageableWork) {
-        await messageModel.update(failedMessage.id, { error: null });
-      } else {
-        await messageModel.deleteMessage(failedMessage.id);
-      }
-    } catch (err) {
-      console.error(
-        '[scheduled-topic-dispatch] failed to clear rate-limit error card message=%s: %O',
-        failedMessage.id,
-        err,
-      );
+    if (hasSalvageableWork) {
+      await messageModel.update(failedMessage.id, { error: null });
+      parentMessageId = failedMessage.id;
+    } else {
+      await messageModel.deleteMessage(failedMessage.id);
+      parentMessageId = failedMessage.parentId ?? run.userMessageId;
     }
   }
 
-  return result;
+  return new AiAgentService(db, topic.userId, { workspaceId }).execAgent({
+    agentId: topic.agentId ?? undefined,
+    appContext: { topicId: topic.id },
+    parentMessageId,
+    prompt: HETERO_CONTINUE_PROMPT,
+    resume: true,
+    trigger: RequestTrigger.Cron,
+  });
 };
 
 /**

--- a/apps/server/src/workflows-hono/task/handlers/scheduledRunKinds.ts
+++ b/apps/server/src/workflows-hono/task/handlers/scheduledRunKinds.ts
@@ -9,6 +9,8 @@ import type { TopicItem } from '@/database/schemas/topic';
 import { AiAgentService } from '@/server/services/aiAgent';
 
 export interface ScheduledRunContext {
+  /** The dispatcher's claim lease id — fences post-dispatch writes against stale attempts. */
+  claimId: string;
   db: LobeChatDatabase;
   topic: TopicItem;
   workspaceId?: string;
@@ -38,7 +40,7 @@ type ScheduledRunHandlers = {
  */
 const runResumeAfterRateLimit: ScheduledRunHandlers['resume_after_rate_limit'] = async (
   run,
-  { db, topic, workspaceId },
+  { claimId, db, topic, workspaceId },
 ) => {
   const messageModel = new MessageModel(db, topic.userId, workspaceId);
   const failedMessage = await messageModel.findById(run.failedAssistantMessageId);
@@ -73,8 +75,15 @@ const runResumeAfterRateLimit: ScheduledRunHandlers['resume_after_rate_limit'] =
   // didn't fire. Track that bubble as the run's failed message so the next
   // tick's pre-dispatch cleanup clears it exactly like the original card;
   // otherwise every failed attempt would strand one more stale error card.
+  // Fenced on our claim lease: an attempt that outlived it (or whose schedule
+  // was cancelled and re-armed) must not re-point a newer run.
   if (!result.success && result.assistantMessageId) {
-    await TopicModel.repointScheduledRunFailedMessage(db, topic.id, result.assistantMessageId);
+    await TopicModel.repointScheduledRunFailedMessage(
+      db,
+      topic.id,
+      result.assistantMessageId,
+      claimId,
+    );
   }
 
   return result;

--- a/apps/server/src/workflows-hono/task/handlers/scheduledTopicDispatch.ts
+++ b/apps/server/src/workflows-hono/task/handlers/scheduledTopicDispatch.ts
@@ -94,7 +94,12 @@ export async function scheduledTopicDispatch(c: Context) {
 
       const workspaceId = topic.workspaceId ?? undefined;
       try {
-        const result = await dispatchScheduledRun(run, { db, topic, workspaceId });
+        const result = await dispatchScheduledRun(run, {
+          claimId: claim.id,
+          db,
+          topic,
+          workspaceId,
+        });
         if (!result.success) {
           throw new Error(result.error || result.message || 'Scheduled run dispatch failed');
         }

--- a/packages/database/src/models/__tests__/topic.test.ts
+++ b/packages/database/src/models/__tests__/topic.test.ts
@@ -877,7 +877,10 @@ describe('TopicModel', () => {
         .select()
         .from(topics)
         .where(eq(topics.id, 'scheduled-reclaimed'));
-      expect(row.metadata?.scheduledRun?.failedAssistantMessageId).toBe('assistant-failed');
+      expect(row.metadata?.scheduledRun).toMatchObject({
+        claim: { id: 'new' },
+        failedAssistantMessageId: 'assistant-failed',
+      });
     });
 
     it('does not resurrect a cancelled schedule when re-pointing', async () => {

--- a/packages/database/src/models/__tests__/topic.test.ts
+++ b/packages/database/src/models/__tests__/topic.test.ts
@@ -838,6 +838,7 @@ describe('TopicModel', () => {
         serverDB,
         'scheduled-repoint',
         'assistant-retry-1',
+        'claim-1',
       );
 
       const [row] = await serverDB.select().from(topics).where(eq(topics.id, 'scheduled-repoint'));
@@ -850,6 +851,33 @@ describe('TopicModel', () => {
         runAt: scheduledRun.runAt,
         userMessageId: 'user-message',
       });
+    });
+
+    it('does not let a stale dispatch attempt re-point a re-armed schedule', async () => {
+      // The failed attempt's claim lease expired and the user (or a newer tick)
+      // re-armed / re-claimed the schedule — the old writer must lose.
+      await serverDB.insert(topics).values({
+        id: 'scheduled-reclaimed',
+        metadata: {
+          scheduledRun: { ...scheduledRun, claim: { claimedAt: '', expiresAt: '', id: 'new' } },
+        },
+        status: 'scheduled',
+        title: 'reclaimed',
+        userId,
+      });
+
+      await TopicModel.repointScheduledRunFailedMessage(
+        serverDB,
+        'scheduled-reclaimed',
+        'assistant-stale-attempt',
+        'old',
+      );
+
+      const [row] = await serverDB
+        .select()
+        .from(topics)
+        .where(eq(topics.id, 'scheduled-reclaimed'));
+      expect(row.metadata?.scheduledRun?.failedAssistantMessageId).toBe('assistant-failed');
     });
 
     it('does not resurrect a cancelled schedule when re-pointing', async () => {
@@ -865,6 +893,7 @@ describe('TopicModel', () => {
         serverDB,
         'scheduled-cancelled',
         'assistant-retry-2',
+        'claim-1',
       );
 
       const [row] = await serverDB

--- a/packages/database/src/models/__tests__/topic.test.ts
+++ b/packages/database/src/models/__tests__/topic.test.ts
@@ -822,5 +822,57 @@ describe('TopicModel', () => {
       expect(cleared.status).toBe('running');
       expect(cleared.metadata?.scheduledRun).toBeNull();
     });
+
+    it('re-points a pending run at a new failed message, preserving the claim and payload', async () => {
+      await serverDB.insert(topics).values({
+        id: 'scheduled-repoint',
+        metadata: {
+          scheduledRun: { ...scheduledRun, claim: { claimedAt: '', expiresAt: '', id: 'claim-1' } },
+        },
+        status: 'scheduled',
+        title: 'repoint',
+        userId,
+      });
+
+      await TopicModel.repointScheduledRunFailedMessage(
+        serverDB,
+        'scheduled-repoint',
+        'assistant-retry-1',
+      );
+
+      const [row] = await serverDB.select().from(topics).where(eq(topics.id, 'scheduled-repoint'));
+      // Only the failed-message pointer moves — the lease and the rest of the
+      // payload must survive the merge.
+      expect(row.metadata?.scheduledRun).toMatchObject({
+        claim: { id: 'claim-1' },
+        failedAssistantMessageId: 'assistant-retry-1',
+        kind: 'resume_after_rate_limit',
+        runAt: scheduledRun.runAt,
+        userMessageId: 'user-message',
+      });
+    });
+
+    it('does not resurrect a cancelled schedule when re-pointing', async () => {
+      await serverDB.insert(topics).values({
+        id: 'scheduled-cancelled',
+        metadata: { scheduledRun: null },
+        status: 'active',
+        title: 'cancelled',
+        userId,
+      });
+
+      await TopicModel.repointScheduledRunFailedMessage(
+        serverDB,
+        'scheduled-cancelled',
+        'assistant-retry-2',
+      );
+
+      const [row] = await serverDB
+        .select()
+        .from(topics)
+        .where(eq(topics.id, 'scheduled-cancelled'));
+      expect(row.metadata?.scheduledRun).toBeNull();
+      expect(row.status).toBe('active');
+    });
   });
 });

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -1468,4 +1468,45 @@ export class TopicModel {
         .where(eq(topics.id, id));
     });
   }
+
+  /**
+   * Re-point a still-pending scheduled run at a new failed-attempt message. A
+   * dispatch that fails inside execAgent leaves its own error bubble on the
+   * placeholder it created; tracking that bubble as the run's
+   * `failedAssistantMessageId` lets the next tick's pre-dispatch cleanup clear
+   * it the same way it clears the original card, so retries don't strand one
+   * stale error bubble per failed attempt. No-ops when the schedule was
+   * cancelled or already cleared in the meantime.
+   */
+  static async repointScheduledRunFailedMessage(
+    db: LobeChatDatabase,
+    id: string,
+    failedAssistantMessageId: string,
+  ): Promise<void> {
+    await db.transaction(async (tx) => {
+      const [row] = await tx
+        .select({ metadata: topics.metadata, status: topics.status })
+        .from(topics)
+        .where(eq(topics.id, id))
+        .for('update');
+      if (!row || row.status !== 'scheduled') return;
+
+      const scheduledRun = row.metadata?.scheduledRun;
+      if (!scheduledRun) return;
+
+      await tx
+        .update(topics)
+        .set({
+          metadata: {
+            ...row.metadata,
+            scheduledRun: {
+              ...scheduledRun,
+              failedAssistantMessageId,
+              updatedAt: new Date().toISOString(),
+            },
+          } as ChatTopicMetadata,
+        })
+        .where(eq(topics.id, id));
+    });
+  }
 }

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -1475,13 +1475,20 @@ export class TopicModel {
    * placeholder it created; tracking that bubble as the run's
    * `failedAssistantMessageId` lets the next tick's pre-dispatch cleanup clear
    * it the same way it clears the original card, so retries don't strand one
-   * stale error bubble per failed attempt. No-ops when the schedule was
-   * cancelled or already cleared in the meantime.
+   * stale error bubble per failed attempt.
+   *
+   * `expectedClaimId` fences stale writers the same way it does in
+   * {@link TopicModel.clearScheduledRun}: a dispatch attempt that outlived its
+   * claim lease — or one whose schedule the user cancelled and re-armed — must
+   * not overwrite the pointer of a NEWER scheduled run, or the next cleanup
+   * would delete / anchor against an unrelated message. No-ops when the
+   * schedule was cleared or the claim no longer matches.
    */
   static async repointScheduledRunFailedMessage(
     db: LobeChatDatabase,
     id: string,
     failedAssistantMessageId: string,
+    expectedClaimId: string,
   ): Promise<void> {
     await db.transaction(async (tx) => {
       const [row] = await tx
@@ -1493,6 +1500,7 @@ export class TopicModel {
 
       const scheduledRun = row.metadata?.scheduledRun;
       if (!scheduledRun) return;
+      if (scheduledRun.claim?.id !== expectedClaimId) return;
 
       await tx
         .update(topics)


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

When a rate-limited hetero run is parked with "Continue after reset" and the scheduled continuation later fires, the resumed turn streamed in **below a stale rate-limit error card** — nothing ever cleared the `error` on the failed assistant message. The manual retry paths (`continueHeteroAfterError`) clean it up; the scheduled path (`runResumeAfterRateLimit`) never did.

**1. Clear the card before dispatch, mirroring `continueHeteroAfterError`:**

- A failed step that preserved work (streamed content / tool calls) keeps its body and only drops the `error`, and stays the resume anchor.
- An error-only step (loading-placeholder content, no tools) would render as an empty block, so it is deleted and the continuation anchors on its parent.
- If the failed message is already gone (cleaned by a prior tick whose dispatch then failed), the retry falls back to anchoring on the `userMessageId` recorded in the payload instead of throwing forever.

Hetero adapters (Claude Code / Codex) don't ship `assistantMessage.id` on `stream_start`, so the gateway handler's `fetchAndReplaceMessages` refetch picks the cleaned message up as soon as the resumed run starts streaming — the card disappears live in an open client too.

**2. Don't strand dispatch-failure bubbles either:**

A dispatch that fails inside `execAgent` (device offline, access denied, …) leaves its own `ServerAgentRuntimeError` bubble via `finalizeHeteroDispatchError` — that's the user-visible failure signal, and the topic stays `scheduled` for the next tick. But nothing referenced that bubble, so every failed attempt would strand one more stale error card after a later successful retry. New `TopicModel.repointScheduledRunFailedMessage` (same `SELECT … FOR UPDATE` merge pattern as `claimScheduledTopic` / `clearScheduledRun`, preserving the claim lease and payload) re-points `scheduledRun.failedAssistantMessageId` at the bubble, so the next tick's pre-dispatch cleanup clears it exactly like the original card. No-ops when the schedule was cancelled meanwhile.

#### 🧪 How to Test

- `apps/server` handler tests: cleanup runs before `execAgent` (asserted via mock invocation order), error-only step deletion + parent re-anchor, fallback to the user turn when the failed message is gone, dispatch-failure re-pointing, and `delayed_start` staying untouched.
- `packages/database` model tests: re-point preserves the claim lease + payload; a cancelled schedule is not resurrected.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📝 Additional Information

`delayed_start` dispatch failures leave the same per-attempt error bubble but have no cleanup phase to hand it to; if that accumulation matters in practice it can get the same treatment in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)