### PR TITLE
♻️ refactor: migrate client context compression transport

### DIFF
--- a/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -15,6 +15,7 @@ type PublishedStreamEvent = Omit<StreamEvent, 'operationId' | 'timestamp'>;
 type PublishStreamEventCall = [string, PublishedStreamEvent];
 
 const mockCreateCompressionGroup = vi.fn();
+const mockCancelCompression = vi.fn();
 const mockFinalizeCompression = vi.fn();
 const mockBuiltinModels = vi.hoisted(() => [
   {
@@ -62,6 +63,7 @@ vi.mock('@/server/modules/ModelRuntime', () => ({
 
 vi.mock('@/server/services/message', () => ({
   MessageService: vi.fn().mockImplementation(() => ({
+    cancelCompression: mockCancelCompression,
     createCompressionGroup: mockCreateCompressionGroup,
     finalizeCompression: mockFinalizeCompression,
   })),
@@ -145,7 +147,9 @@ describe('RuntimeExecutors', { timeout: 60_000 }, () => {
     vi.clearAllMocks();
     vi.mocked(initModelRuntimeFromDB).mockReset();
     mockCreateCompressionGroup.mockReset();
+    mockCancelCompression.mockReset();
     mockFinalizeCompression.mockReset();
+    mockCancelCompression.mockResolvedValue({ messages: [], success: true });
     mockCreateCompressionGroup.mockResolvedValue({
       messageGroupId: 'group-123',
       messagesToSummarize: [],
@@ -1466,7 +1470,7 @@ describe('RuntimeExecutors', { timeout: 60_000 }, () => {
 
       const result = await executors.compress_context!(instruction, state);
 
-      expect(mockCreateCompressionGroup).toHaveBeenCalledTimes(1);
+      expect(mockCreateCompressionGroup).not.toHaveBeenCalled();
       expect(mockFinalizeCompression).not.toHaveBeenCalled();
       expect(result.nextContext?.payload as any).toMatchObject({
         compressedMessages: [{ content: 'history', role: 'user' }],
@@ -1649,6 +1653,10 @@ describe('RuntimeExecutors', { timeout: 60_000 }, () => {
       const result = await executors.compress_context!(instruction, state);
 
       expect(mockFinalizeCompression).not.toHaveBeenCalled();
+      expect(mockCancelCompression).toHaveBeenCalledWith(
+        'group-123',
+        expect.objectContaining({ topicId: 'topic-123' }),
+      );
       expect((result.nextContext?.payload as any).skipped).toBe(true);
       expect(result.events).toContainEqual(
         expect.objectContaining({

--- a/apps/server/src/modules/AgentRuntime/adapters/ServerCompressionTransport.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerCompressionTransport.ts
@@ -3,6 +3,8 @@ import type {
   CompressionGroupCreateResult,
   CompressionGroupFinalizeInput,
   CompressionGroupFinalizeResult,
+  CompressionGroupRollbackInput,
+  CompressionGroupRollbackResult,
   CompressionPromptInput,
   CompressionPromptResult,
   CompressionTransport,
@@ -24,7 +26,7 @@ export class ServerCompressionTransport implements CompressionTransport {
   ) {}
 
   async buildPrompt(input: CompressionPromptInput): Promise<CompressionPromptResult> {
-    const payload = chainCompressContext(input.messages);
+    const payload = chainCompressContext(input.messages, input.existingSummary);
     return { messages: payload.messages! };
   }
 
@@ -58,6 +60,20 @@ export class ServerCompressionTransport implements CompressionTransport {
     return {
       messages: result.messages,
     };
+  }
+
+  async rollbackGroup(
+    input: CompressionGroupRollbackInput,
+  ): Promise<CompressionGroupRollbackResult> {
+    const service = this.createService(input.workspaceId);
+    const result = await service.cancelCompression(input.messageGroupId, {
+      agentId: input.agentId,
+      groupId: input.groupId,
+      threadId: input.threadId,
+      topicId: input.topicId,
+    } as any);
+
+    return { messages: result.messages };
   }
 
   private createService(workspaceId?: string) {

--- a/apps/server/src/modules/AgentRuntime/adapters/ServerCompressionTransport.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerCompressionTransport.ts
@@ -53,6 +53,7 @@ export class ServerCompressionTransport implements CompressionTransport {
     const result = await service.finalizeCompression(input.messageGroupId, input.content, {
       agentId: input.agentId,
       groupId: input.groupId,
+      sourceGroupIds: input.sourceGroupIds,
       threadId: input.threadId,
       topicId: input.topicId,
     } as any);

--- a/apps/server/src/routers/lambda/message.ts
+++ b/apps/server/src/routers/lambda/message.ts
@@ -148,6 +148,7 @@ export const messageRouter = router({
         agentId: z.string(),
         groupId: z.string().nullish(),
         messageGroupId: z.string(),
+        sourceGroupIds: z.array(z.string()).optional(),
         threadId: z.string().nullish(),
         topicId: z.string(),
       }),

--- a/apps/server/src/services/message/index.ts
+++ b/apps/server/src/services/message/index.ts
@@ -477,14 +477,20 @@ export class MessageService {
     params: {
       agentId: string;
       groupId?: string | null;
+      sourceGroupIds?: string[];
       threadId?: string | null;
       topicId: string;
     },
   ): Promise<{ messages?: UIChatMessage[]; success: boolean }> {
-    const { agentId, groupId, threadId, topicId } = params;
+    const { agentId, groupId, sourceGroupIds, threadId, topicId } = params;
 
-    // 1. Update compression group with actual content
-    await this.compressionRepository.updateCompressionContent(messageGroupId, content);
+    // 1. Update the new group and atomically replace prior compression groups.
+    await this.compressionRepository.finalizeCompressionGroup({
+      content,
+      groupId: messageGroupId,
+      sourceGroupIds,
+      topicId,
+    });
 
     // 2. Query final messages
     const queryOptions = { agentId, groupId, threadId, topicId };

--- a/packages/agent-runtime/src/agents/GeneralChatAgent.ts
+++ b/packages/agent-runtime/src/agents/GeneralChatAgent.ts
@@ -363,19 +363,20 @@ export class GeneralChatAgent implements Agent {
    * Looks for MessageGroup with type 'compression' and extracts its content
    */
   private findExistingSummary(messages: any[]): string | undefined {
-    // Look for compression group summary in messages
-    // The summary is typically stored as a system message with compression metadata
-    // or as a MessageGroup content field
+    const compressedGroupSummaries = messages
+      .filter(
+        (message) =>
+          (message.role === 'compressedGroup' || message.messageGroupType === 'compression') &&
+          message.content,
+      )
+      .map((message) => message.content as string);
+
+    if (compressedGroupSummaries.length > 0) return compressedGroupSummaries.join('\n\n');
+
+    // Keep compatibility with the legacy system-message summary representation.
     for (let index = messages.length - 1; index >= 0; index--) {
       const msg = messages[index];
       if (msg.role === 'system' && msg.metadata?.compressionSummary) {
-        return msg.content;
-      }
-      // Check both persisted compressedGroup rows and legacy compression metadata.
-      if (
-        (msg.role === 'compressedGroup' || msg.messageGroupType === 'compression') &&
-        msg.content
-      ) {
         return msg.content;
       }
     }

--- a/packages/agent-runtime/src/agents/GeneralChatAgent.ts
+++ b/packages/agent-runtime/src/agents/GeneralChatAgent.ts
@@ -366,12 +366,16 @@ export class GeneralChatAgent implements Agent {
     // Look for compression group summary in messages
     // The summary is typically stored as a system message with compression metadata
     // or as a MessageGroup content field
-    for (const msg of messages) {
+    for (let index = messages.length - 1; index >= 0; index--) {
+      const msg = messages[index];
       if (msg.role === 'system' && msg.metadata?.compressionSummary) {
         return msg.content;
       }
-      // Check for MessageGroup type compression
-      if (msg.messageGroupType === 'compression' && msg.content) {
+      // Check both persisted compressedGroup rows and legacy compression metadata.
+      if (
+        (msg.role === 'compressedGroup' || msg.messageGroupType === 'compression') &&
+        msg.content
+      ) {
         return msg.content;
       }
     }

--- a/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
+++ b/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
@@ -213,7 +213,7 @@ describe('GeneralChatAgent', () => {
       expect(result).toEqual({
         payload: {
           currentTokenCount: expect.any(Number),
-          existingSummary: 'Earlier decisions and constraints',
+          existingSummary: 'Outdated decisions\n\nEarlier decisions and constraints',
           messages: state.messages,
         },
         type: 'compress_context',

--- a/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
+++ b/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
@@ -187,6 +187,39 @@ describe('GeneralChatAgent', () => {
       expect(result).toEqual(expectCompressionInstruction(state.messages));
     });
 
+    it('should carry a persisted compressedGroup summary into incremental compression', async () => {
+      const agent = createCompressionAgent();
+      const state = createMockState({
+        messages: [
+          {
+            content: 'Outdated decisions',
+            id: 'compressed-group-old',
+            role: 'compressedGroup',
+          },
+          {
+            content: 'Earlier decisions and constraints',
+            id: 'compressed-group-current',
+            role: 'compressedGroup',
+          },
+          { content: 'A new follow-up question', id: 'user-message', role: 'user' },
+        ] as any,
+      });
+
+      const result = await agent.runner(
+        createMockContext('init', { model: 'gpt-4o-mini', provider: 'openai' }),
+        state,
+      );
+
+      expect(result).toEqual({
+        payload: {
+          currentTokenCount: expect.any(Number),
+          existingSummary: 'Earlier decisions and constraints',
+          messages: state.messages,
+        },
+        type: 'compress_context',
+      });
+    });
+
     // Bug B: state.tools must feed into the compression budget,
     // otherwise large tool manifests (16-22K tokens observed on openrouter)
     // slip past the threshold and overflow the model context window.

--- a/packages/agent-runtime/src/executors/compressContext.test.ts
+++ b/packages/agent-runtime/src/executors/compressContext.test.ts
@@ -76,6 +76,8 @@ describe('compressContext executor', () => {
   let compressionCreateGroup: ReturnType<typeof vi.fn>;
   let compressionBuildPrompt: ReturnType<typeof vi.fn>;
   let compressionFinalizeGroup: ReturnType<typeof vi.fn>;
+  let compressionRollbackGroup: ReturnType<typeof vi.fn>;
+  let compressionUpdateGroup: ReturnType<typeof vi.fn>;
   let llmStream: ReturnType<typeof vi.fn>;
   let lifecycleDispatch: ReturnType<typeof vi.fn>;
 
@@ -89,6 +91,8 @@ describe('compressContext executor', () => {
       messages: [{ content: 'summarize', role: 'user' }],
     });
     compressionFinalizeGroup = vi.fn().mockResolvedValue({});
+    compressionRollbackGroup = vi.fn().mockResolvedValue({});
+    compressionUpdateGroup = vi.fn();
     llmStream = vi.fn().mockResolvedValue({ content: 'summary' });
     lifecycleDispatch = vi.fn().mockResolvedValue(undefined);
 
@@ -109,6 +113,8 @@ describe('compressContext executor', () => {
           buildPrompt: compressionBuildPrompt,
           createGroup: compressionCreateGroup,
           finalizeGroup: compressionFinalizeGroup,
+          rollbackGroup: compressionRollbackGroup,
+          updateGroup: compressionUpdateGroup,
         },
         llm: {
           stream: llmStream,
@@ -140,13 +146,17 @@ describe('compressContext executor', () => {
       messageGroupId: 'group-123',
       messagesToSummarize: [{ content: 'history', id: 'msg-history', role: 'user' }],
     });
-    llmStream.mockResolvedValue({
-      content: 'summary',
-      usage: {
-        totalInputTokens: 10,
-        totalOutputTokens: 5,
-        totalTokens: 15,
-      },
+    llmStream.mockImplementation(async (_payload, handlers) => {
+      handlers?.onText?.('sum');
+      handlers?.onText?.('mary');
+      return {
+        content: 'summary',
+        usage: {
+          totalInputTokens: 10,
+          totalOutputTokens: 5,
+          totalTokens: 15,
+        },
+      };
     });
     compressionFinalizeGroup.mockResolvedValue({
       messages: [{ content: 'summary', id: 'group-123', role: 'compressedGroup' }],
@@ -177,11 +187,23 @@ describe('compressContext executor', () => {
       existingSummary: undefined,
       messages: [{ content: 'history', id: 'msg-history', role: 'user' }],
     });
-    expect(llmStream).toHaveBeenCalledWith({
-      messages: [{ content: 'summarize', role: 'user' }],
-      model: 'gpt-4',
-      provider: 'openai',
-      stream: true,
+    expect(llmStream).toHaveBeenCalledWith(
+      {
+        messages: [{ content: 'summarize', role: 'user' }],
+        model: 'gpt-4',
+        provider: 'openai',
+        stream: true,
+      },
+      expect.objectContaining({ onText: expect.any(Function) }),
+      undefined,
+    );
+    expect(compressionUpdateGroup).toHaveBeenNthCalledWith(1, {
+      content: 'sum',
+      messageGroupId: 'group-123',
+    });
+    expect(compressionUpdateGroup).toHaveBeenNthCalledWith(2, {
+      content: 'summary',
+      messageGroupId: 'group-123',
     });
     expect(compressionFinalizeGroup).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -215,7 +237,7 @@ describe('compressContext executor', () => {
     );
   });
 
-  it('skips without compression side effects when topic or user context is missing', async () => {
+  it('skips without compression side effects when topic context is missing', async () => {
     const state = createState({
       metadata: { agentId: 'agent-123' },
       messages: [{ content: 'history', role: 'user' }],
@@ -233,6 +255,46 @@ describe('compressContext executor', () => {
     expect(compressionCreateGroup).not.toHaveBeenCalled();
     expect(llmStream).not.toHaveBeenCalled();
     expect((result.nextContext?.payload as any).skipped).toBe(true);
+  });
+
+  it('runs with client transports when userId is absent', async () => {
+    messagesQuery.mockResolvedValue([{ content: 'history', id: 'msg-history', role: 'user' }]);
+    compressionCreateGroup.mockResolvedValue({
+      messageGroupId: 'group-123',
+      messagesToSummarize: [{ content: 'history', id: 'msg-history', role: 'user' }],
+    });
+    compressionFinalizeGroup.mockResolvedValue({
+      messages: [{ content: 'summary', id: 'group-123', role: 'compressedGroup' }],
+    });
+    host.operation.userId = undefined;
+    host.lifecycle = undefined;
+
+    const state = createState({
+      messages: [{ content: 'history', id: 'msg-history', role: 'user' }],
+    });
+    const result = await compressContext(host)(createInstruction(state.messages), state);
+
+    expect(compressionCreateGroup).toHaveBeenCalledTimes(1);
+    expect((result.nextContext?.payload as any).skipped).not.toBe(true);
+  });
+
+  it('skips before creating a group when model config is unavailable', async () => {
+    messagesQuery.mockResolvedValue([
+      { content: 'history', id: 'msg-history', role: 'user' },
+      { content: 'loading', id: 'assistant-existing', role: 'assistant' },
+    ]);
+    const state = createState({
+      messages: [{ content: 'history', id: 'msg-history', role: 'user' }],
+      modelRuntimeConfig: undefined,
+    });
+
+    const result = await compressContext(host)(createInstruction(state.messages), state);
+
+    expect(compressionCreateGroup).not.toHaveBeenCalled();
+    expect(result.nextContext?.payload as any).toMatchObject({
+      parentMessageId: 'assistant-existing',
+      skipped: true,
+    });
   });
 
   it('continues with skipped compression and dispatches onCompactError when compression fails', async () => {
@@ -253,5 +315,53 @@ describe('compressContext executor', () => {
         type: 'onCompactError',
       }),
     );
+  });
+
+  it('rolls back a created group when summary generation fails', async () => {
+    messagesQuery.mockResolvedValue([{ content: 'history', id: 'msg-history', role: 'user' }]);
+    compressionCreateGroup.mockResolvedValue({
+      messageGroupId: 'group-123',
+      messagesToSummarize: [{ content: 'history', id: 'msg-history', role: 'user' }],
+    });
+    llmStream.mockRejectedValue(new Error('summary failed'));
+
+    const state = createState({
+      messages: [{ content: 'history', id: 'msg-history', role: 'user' }],
+    });
+    const result = await compressContext(host)(createInstruction(state.messages), state);
+
+    expect(compressionRollbackGroup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({ message: 'summary failed' }),
+        messageGroupId: 'group-123',
+      }),
+    );
+    expect(compressionFinalizeGroup).not.toHaveBeenCalled();
+    expect((result.nextContext?.payload as any).skipped).toBe(true);
+  });
+
+  it('rolls back instead of finalizing when the compression signal is aborted', async () => {
+    const controller = new AbortController();
+    messagesQuery.mockResolvedValue([{ content: 'history', id: 'msg-history', role: 'user' }]);
+    compressionCreateGroup.mockResolvedValue({
+      messageGroupId: 'group-123',
+      messagesToSummarize: [{ content: 'history', id: 'msg-history', role: 'user' }],
+      signal: controller.signal,
+    });
+    llmStream.mockImplementation(async () => {
+      controller.abort();
+      return { content: 'partial summary' };
+    });
+
+    const state = createState({
+      messages: [{ content: 'history', id: 'msg-history', role: 'user' }],
+    });
+    const result = await compressContext(host)(createInstruction(state.messages), state);
+
+    expect(compressionRollbackGroup).toHaveBeenCalledWith(
+      expect.objectContaining({ messageGroupId: 'group-123' }),
+    );
+    expect(compressionFinalizeGroup).not.toHaveBeenCalled();
+    expect((result.nextContext?.payload as any).skipped).toBe(true);
   });
 });

--- a/packages/agent-runtime/src/executors/compressContext.test.ts
+++ b/packages/agent-runtime/src/executors/compressContext.test.ts
@@ -278,6 +278,95 @@ describe('compressContext executor', () => {
     expect((result.nextContext?.payload as any).skipped).not.toBe(true);
   });
 
+  it('supersedes prior compressed groups without duplicating their summaries', async () => {
+    const sourceGroup1 = {
+      content: 'First prior summary',
+      id: 'source-group-1',
+      lastMessageId: 'assistant-in-source-1',
+      role: 'compressedGroup',
+    };
+    const sourceGroup2 = {
+      content: 'Second prior summary',
+      id: 'source-group-2',
+      lastMessageId: 'assistant-in-source-2',
+      role: 'compressedGroup',
+    };
+    messagesQuery.mockResolvedValue([
+      sourceGroup1,
+      sourceGroup2,
+      { content: 'recent question', id: 'msg-recent', role: 'user' },
+      { content: 'recent answer', id: 'assistant-recent', role: 'assistant' },
+    ]);
+    compressionCreateGroup.mockResolvedValue({
+      messageGroupId: 'group-123',
+      messages: [
+        sourceGroup1,
+        sourceGroup2,
+        { content: '...', id: 'group-123', role: 'compressedGroup' },
+      ],
+      messagesToSummarize: [{ content: 'recent question', id: 'msg-recent', role: 'user' }],
+    });
+    compressionFinalizeGroup.mockResolvedValue({
+      messages: [{ content: 'combined summary', id: 'group-123', role: 'compressedGroup' }],
+    });
+    llmStream.mockResolvedValue({ content: 'combined summary' });
+    const state = createState({
+      messages: [
+        sourceGroup1,
+        sourceGroup2,
+        { content: 'recent question', id: 'msg-recent', role: 'user' },
+        { content: 'recent answer', id: 'assistant-recent', role: 'assistant' },
+      ],
+    });
+
+    const result = await compressContext(host)(createInstruction(state.messages), state);
+
+    expect(compressionBuildPrompt).toHaveBeenCalledWith({
+      existingSummary: 'First prior summary\n\nSecond prior summary',
+      messages: [{ content: 'recent question', id: 'msg-recent', role: 'user' }],
+    });
+    expect(compressionFinalizeGroup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageGroupId: 'group-123',
+        sourceGroupIds: ['source-group-1', 'source-group-2'],
+      }),
+    );
+    expect((result.nextContext?.payload as any).compressedMessages).toEqual([
+      { content: 'combined summary', id: 'group-123', role: 'compressedGroup' },
+    ]);
+    expect((result.nextContext?.payload as any).parentMessageId).toBe('assistant-recent');
+  });
+
+  it('can recompress summaries when there are no new persisted messages', async () => {
+    const sourceGroup = {
+      content: 'Prior summary',
+      id: 'source-group',
+      lastMessageId: 'assistant-in-source',
+      role: 'compressedGroup',
+    };
+    messagesQuery.mockResolvedValue([sourceGroup]);
+    compressionCreateGroup.mockResolvedValue({
+      messageGroupId: 'group-123',
+      messages: [sourceGroup, { content: '...', id: 'group-123', role: 'compressedGroup' }],
+      messagesToSummarize: [],
+    });
+    compressionFinalizeGroup.mockResolvedValue({
+      messages: [{ content: 'shorter summary', id: 'group-123', role: 'compressedGroup' }],
+    });
+    llmStream.mockResolvedValue({ content: 'shorter summary' });
+    const state = createState({ messages: [sourceGroup] });
+
+    const result = await compressContext(host)(createInstruction(state.messages), state);
+
+    expect(compressionCreateGroup).toHaveBeenCalledWith(
+      expect.objectContaining({ messageIds: [] }),
+    );
+    expect(compressionFinalizeGroup).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceGroupIds: ['source-group'] }),
+    );
+    expect((result.nextContext?.payload as any).parentMessageId).toBe('assistant-in-source');
+  });
+
   it('skips before creating a group when model config is unavailable', async () => {
     messagesQuery.mockResolvedValue([
       { content: 'history', id: 'msg-history', role: 'user' },
@@ -318,7 +407,15 @@ describe('compressContext executor', () => {
   });
 
   it('rolls back a created group when summary generation fails', async () => {
-    messagesQuery.mockResolvedValue([{ content: 'history', id: 'msg-history', role: 'user' }]);
+    const sourceGroup = {
+      content: 'Existing summary',
+      id: 'source-group',
+      role: 'compressedGroup',
+    };
+    messagesQuery.mockResolvedValue([
+      sourceGroup,
+      { content: 'history', id: 'msg-history', role: 'user' },
+    ]);
     compressionCreateGroup.mockResolvedValue({
       messageGroupId: 'group-123',
       messagesToSummarize: [{ content: 'history', id: 'msg-history', role: 'user' }],
@@ -326,7 +423,7 @@ describe('compressContext executor', () => {
     llmStream.mockRejectedValue(new Error('summary failed'));
 
     const state = createState({
-      messages: [{ content: 'history', id: 'msg-history', role: 'user' }],
+      messages: [sourceGroup, { content: 'history', id: 'msg-history', role: 'user' }],
     });
     const result = await compressContext(host)(createInstruction(state.messages), state);
 
@@ -337,7 +434,10 @@ describe('compressContext executor', () => {
       }),
     );
     expect(compressionFinalizeGroup).not.toHaveBeenCalled();
-    expect((result.nextContext?.payload as any).skipped).toBe(true);
+    expect(result.nextContext?.payload as any).toMatchObject({
+      compressedMessages: expect.arrayContaining([sourceGroup]),
+      skipped: true,
+    });
   });
 
   it('rolls back instead of finalizing when the compression signal is aborted', async () => {

--- a/packages/agent-runtime/src/executors/compressContext.ts
+++ b/packages/agent-runtime/src/executors/compressContext.ts
@@ -8,22 +8,6 @@ import type {
   InstructionExecutor,
 } from '../types';
 
-const requireCompressionTransport = (host: AgentRuntimeHost) => {
-  const compression = host.transports.compression;
-  if (!compression) {
-    throw new Error('CompressionTransport is required for compress_context executor');
-  }
-  return compression;
-};
-
-const requireLLMTransport = (host: AgentRuntimeHost) => {
-  const llm = host.transports.llm;
-  if (!llm) {
-    throw new Error('LLMTransport is required for compress_context executor');
-  }
-  return llm;
-};
-
 const getErrorMessage = (error: unknown): string => {
   if (error instanceof Error && error.message) return error.message;
   if (typeof error === 'string' && error) return error;
@@ -65,6 +49,11 @@ export const compressContext =
     const newState = structuredClone(state);
     const topicId = state.metadata?.topicId ?? operation.topicId;
     const workspaceId = state.metadata?.workspaceId ?? operation.workspaceId;
+    const agentId = operation.agentId ?? state.metadata?.agentId;
+    const groupId = operation.groupId ?? state.metadata?.groupId;
+    const threadId = operation.threadId ?? state.metadata?.threadId;
+    const compression = transports.compression;
+    const llm = transports.llm;
     const lastMessage = messages.at(-1);
     const preservedMessages =
       messages.length > 1 && lastMessage?.role === 'user' ? [lastMessage] : [];
@@ -106,7 +95,7 @@ export const compressContext =
       }),
     });
 
-    if (!topicId || !userId) {
+    if (!topicId || !agentId || !compression || !llm) {
       return skippedResult();
     }
 
@@ -123,15 +112,14 @@ export const compressContext =
       state.metadata?._hooks,
     );
 
-    try {
-      const compression = requireCompressionTransport(host);
-      const llm = requireLLMTransport(host);
+    let createdGroupId: string | undefined;
 
+    try {
       const dbMessages = await transports.messages.query(
         {
-          agentId: state.metadata?.agentId,
-          groupId: state.metadata?.groupId,
-          threadId: state.metadata?.threadId,
+          agentId,
+          groupId,
+          threadId,
           topicId,
         },
         { resolveAssetUrls: true },
@@ -151,15 +139,6 @@ export const compressContext =
       }
 
       const latestAssistantMessage = dbMessages.findLast((message) => message.role === 'assistant');
-      const compressionResult = await compression.createGroup({
-        agentId: state.metadata?.agentId,
-        groupId: state.metadata?.groupId,
-        messageIds,
-        threadId: state.metadata?.threadId,
-        topicId,
-        workspaceId,
-      });
-
       const compressionModel =
         newState.modelRuntimeConfig?.compressionModel || newState.modelRuntimeConfig;
 
@@ -167,24 +146,53 @@ export const compressContext =
         return skippedResult(latestAssistantMessage?.id);
       }
 
+      const compressionResult = await compression.createGroup({
+        agentId,
+        groupId,
+        messageIds,
+        threadId,
+        topicId,
+        workspaceId,
+      });
+      createdGroupId = compressionResult.messageGroupId;
+
       const compressionPayload = await compression.buildPrompt({
         existingSummary,
         messages: compressionResult.messagesToSummarize,
       });
 
-      const summaryResult = await llm.stream({
-        messages: compressionPayload.messages,
-        model: compressionModel.model,
-        provider: compressionModel.provider,
-        stream: true,
-      });
+      let streamedSummary = '';
+      const summaryResult = await llm.stream(
+        {
+          messages: compressionPayload.messages,
+          model: compressionModel.model,
+          provider: compressionModel.provider,
+          stream: true,
+        },
+        {
+          onText: (text) => {
+            streamedSummary += text;
+            compression.updateGroup?.({
+              content: streamedSummary,
+              messageGroupId: compressionResult.messageGroupId,
+            });
+          },
+        },
+        compressionResult.signal,
+      );
+
+      if (compressionResult.signal?.aborted) {
+        const abortError = new Error('Context compression cancelled');
+        abortError.name = 'AbortError';
+        throw abortError;
+      }
 
       const finalCompression = await compression.finalizeGroup({
-        agentId: state.metadata?.agentId,
+        agentId,
         content: summaryResult.content,
-        groupId: state.metadata?.groupId,
+        groupId,
         messageGroupId: compressionResult.messageGroupId,
-        threadId: state.metadata?.threadId,
+        threadId,
         topicId,
         workspaceId,
       });
@@ -261,6 +269,22 @@ export const compressContext =
         },
       };
     } catch (error) {
+      if (createdGroupId && compression.rollbackGroup) {
+        try {
+          await compression.rollbackGroup({
+            agentId,
+            error,
+            groupId,
+            messageGroupId: createdGroupId,
+            threadId,
+            topicId,
+            workspaceId,
+          });
+        } catch (rollbackError) {
+          console.error('Failed to rollback context compression', rollbackError);
+        }
+      }
+
       dispatchLifecycle(
         host,
         'onCompactError',

--- a/packages/agent-runtime/src/executors/compressContext.ts
+++ b/packages/agent-runtime/src/executors/compressContext.ts
@@ -125,6 +125,17 @@ export const compressContext =
         { resolveAssetUrls: true },
       );
 
+      const sourceCompressionGroups = dbMessages.filter(
+        (message) => message.role === 'compressedGroup' && Boolean(message.id),
+      );
+      const sourceGroupIds = sourceCompressionGroups
+        .map((message) => message.id)
+        .filter((id): id is string => Boolean(id));
+      const persistedExistingSummary = sourceCompressionGroups
+        .map((message) => (typeof message.content === 'string' ? message.content.trim() : ''))
+        .filter(Boolean)
+        .join('\n\n');
+
       const messageIds = dbMessages
         .filter(
           (message) =>
@@ -134,16 +145,22 @@ export const compressContext =
         )
         .map((message) => message.id);
 
-      if (messageIds.length === 0 || messagesToCompress.length === 0) {
+      if (
+        (messageIds.length === 0 && sourceGroupIds.length === 0) ||
+        messagesToCompress.length === 0
+      ) {
         return skippedResult();
       }
 
       const latestAssistantMessage = dbMessages.findLast((message) => message.role === 'assistant');
+      const parentMessageId =
+        latestAssistantMessage?.id ??
+        (sourceCompressionGroups.at(-1) as { lastMessageId?: string } | undefined)?.lastMessageId;
       const compressionModel =
         newState.modelRuntimeConfig?.compressionModel || newState.modelRuntimeConfig;
 
       if (!compressionModel?.model || !compressionModel?.provider) {
-        return skippedResult(latestAssistantMessage?.id);
+        return skippedResult(parentMessageId);
       }
 
       const compressionResult = await compression.createGroup({
@@ -157,7 +174,7 @@ export const compressContext =
       createdGroupId = compressionResult.messageGroupId;
 
       const compressionPayload = await compression.buildPrompt({
-        existingSummary,
+        existingSummary: persistedExistingSummary || existingSummary,
         messages: compressionResult.messagesToSummarize,
       });
 
@@ -192,13 +209,24 @@ export const compressContext =
         content: summaryResult.content,
         groupId,
         messageGroupId: compressionResult.messageGroupId,
+        sourceGroupIds,
         threadId,
         topicId,
         workspaceId,
       });
 
+      const sourceGroupIdSet = new Set(sourceGroupIds);
+      const finalizedMessagesFallback = compressionResult.messages
+        ?.filter((message) => !sourceGroupIdSet.has(message.id))
+        .map((message) =>
+          message.id === compressionResult.messageGroupId
+            ? { ...message, content: summaryResult.content }
+            : message,
+        );
       const compressedMessagesBase =
-        finalCompression.messages || compressionResult.messagesToSummarize;
+        finalCompression.messages ??
+        finalizedMessagesFallback ??
+        compressionResult.messagesToSummarize;
       const compressedMessages = [...compressedMessagesBase];
 
       for (const preservedMessage of preservedMessages) {
@@ -232,7 +260,7 @@ export const compressContext =
 
       events.push({
         groupId: compressionResult.messageGroupId,
-        parentMessageId: latestAssistantMessage?.id,
+        parentMessageId,
         type: 'compression_complete',
       });
 
@@ -258,7 +286,7 @@ export const compressContext =
           ...createNextContext({
             compressedMessages,
             groupId: compressionResult.messageGroupId,
-            parentMessageId: latestAssistantMessage?.id,
+            parentMessageId,
           }),
           session: {
             messageCount: compressedMessages.length,

--- a/packages/agent-runtime/src/transport/compression.ts
+++ b/packages/agent-runtime/src/transport/compression.ts
@@ -30,6 +30,7 @@ export interface CompressionGroupFinalizeInput {
   content: string;
   groupId?: string;
   messageGroupId: string;
+  sourceGroupIds?: string[];
   threadId?: string;
   topicId: string;
   workspaceId?: string;

--- a/packages/agent-runtime/src/transport/compression.ts
+++ b/packages/agent-runtime/src/transport/compression.ts
@@ -13,6 +13,7 @@ export interface CompressionGroupCreateResult {
   messageGroupId: string;
   messages?: UIChatMessage[];
   messagesToSummarize: UIChatMessage[];
+  signal?: AbortSignal;
 }
 
 export interface CompressionPromptInput {
@@ -38,6 +39,25 @@ export interface CompressionGroupFinalizeResult {
   messages?: UIChatMessage[];
 }
 
+export interface CompressionGroupUpdateInput {
+  content: string;
+  messageGroupId: string;
+}
+
+export interface CompressionGroupRollbackInput {
+  agentId?: string;
+  error: unknown;
+  groupId?: string;
+  messageGroupId: string;
+  threadId?: string;
+  topicId: string;
+  workspaceId?: string;
+}
+
+export interface CompressionGroupRollbackResult {
+  messages?: UIChatMessage[];
+}
+
 /**
  * Persistence + prompt-preparation port for context compression.
  *
@@ -50,4 +70,6 @@ export interface CompressionTransport {
   buildPrompt: (input: CompressionPromptInput) => Promise<CompressionPromptResult>;
   createGroup: (input: CompressionGroupCreateInput) => Promise<CompressionGroupCreateResult>;
   finalizeGroup: (input: CompressionGroupFinalizeInput) => Promise<CompressionGroupFinalizeResult>;
+  rollbackGroup?: (input: CompressionGroupRollbackInput) => Promise<CompressionGroupRollbackResult>;
+  updateGroup?: (input: CompressionGroupUpdateInput) => void;
 }

--- a/packages/database/src/repositories/compression/index.test.ts
+++ b/packages/database/src/repositories/compression/index.test.ts
@@ -176,6 +176,87 @@ describe('CompressionRepository', () => {
     });
   });
 
+  describe('finalizeCompressionGroup', () => {
+    it('should supersede prior groups without deleting their messages', async () => {
+      await serverDB.insert(messages).values([
+        { content: 'Old question', id: 'msg-old-user', role: 'user', topicId, userId },
+        { content: 'Old answer', id: 'msg-old-assistant', role: 'assistant', topicId, userId },
+        { content: 'Recent question', id: 'msg-new-user', role: 'user', topicId, userId },
+        { content: 'Recent answer', id: 'msg-new-assistant', role: 'assistant', topicId, userId },
+      ]);
+      const oldGroupId = await compressionRepo.createCompressionGroup({
+        content: 'Old summary',
+        messageIds: ['msg-old-user', 'msg-old-assistant'],
+        metadata: { originalMessageCount: 2 },
+        topicId,
+      });
+      const newGroupId = await compressionRepo.createCompressionGroup({
+        content: '...',
+        messageIds: ['msg-new-user', 'msg-new-assistant'],
+        metadata: { originalMessageCount: 2 },
+        topicId,
+      });
+
+      await compressionRepo.finalizeCompressionGroup({
+        content: 'Combined summary',
+        groupId: newGroupId,
+        sourceGroupIds: [oldGroupId],
+        topicId,
+      });
+
+      const groups = await compressionRepo.getCompressionGroups(topicId);
+      expect(groups).toHaveLength(1);
+      expect(groups[0]).toMatchObject({ content: 'Combined summary', id: newGroupId });
+
+      const compressedMessages = await compressionRepo.getCompressedMessages(newGroupId);
+      expect(compressedMessages.map((message) => message.id)).toEqual(
+        expect.arrayContaining([
+          'msg-old-user',
+          'msg-old-assistant',
+          'msg-new-user',
+          'msg-new-assistant',
+        ]),
+      );
+      expect(compressedMessages).toHaveLength(4);
+    });
+
+    it('should not supersede groups outside the target topic', async () => {
+      await serverDB.insert(topics).values({ id: 'other-topic', userId });
+      await serverDB.insert(messages).values([
+        { content: 'Target', id: 'msg-target', role: 'user', topicId, userId },
+        {
+          content: 'Other topic',
+          id: 'msg-other-topic',
+          role: 'user',
+          topicId: 'other-topic',
+          userId,
+        },
+      ]);
+      const otherGroupId = await compressionRepo.createCompressionGroup({
+        content: 'Other summary',
+        messageIds: ['msg-other-topic'],
+        metadata: { originalMessageCount: 1 },
+        topicId: 'other-topic',
+      });
+      const targetGroupId = await compressionRepo.createCompressionGroup({
+        content: '...',
+        messageIds: ['msg-target'],
+        metadata: { originalMessageCount: 1 },
+        topicId,
+      });
+
+      await compressionRepo.finalizeCompressionGroup({
+        content: 'Target summary',
+        groupId: targetGroupId,
+        sourceGroupIds: [otherGroupId],
+        topicId,
+      });
+
+      expect(await compressionRepo.getCompressionGroups('other-topic')).toHaveLength(1);
+      expect(await compressionRepo.getCompressedMessages(otherGroupId)).toHaveLength(1);
+    });
+  });
+
   describe('updateMetadata', () => {
     it('should update metadata jsonb column on a compression group', async () => {
       const groupId = await compressionRepo.createCompressionGroup({

--- a/packages/database/src/repositories/compression/index.ts
+++ b/packages/database/src/repositories/compression/index.ts
@@ -15,6 +15,13 @@ export interface CreateCompressionGroupParams {
   topicId: string;
 }
 
+export interface FinalizeCompressionGroupParams {
+  content: string;
+  groupId: string;
+  sourceGroupIds?: string[];
+  topicId: string;
+}
+
 export interface CompressionGroupResult {
   content: string | null;
   createdAt: Date;
@@ -138,6 +145,69 @@ export class CompressionRepository {
       .update(messageGroups)
       .set(updateData)
       .where(and(eq(messageGroups.id, groupId), this.groupsOwnership()));
+  }
+
+  /**
+   * Finalize a new compression group and atomically supersede prior groups.
+   * Source messages move before their old groups are deleted so the cascade
+   * never removes conversation history.
+   */
+  async finalizeCompressionGroup(params: FinalizeCompressionGroupParams): Promise<void> {
+    const { content, groupId, topicId } = params;
+    const requestedSourceGroupIds = [
+      ...new Set((params.sourceGroupIds ?? []).filter((id) => id !== groupId)),
+    ];
+
+    await this.db.transaction(async (trx) => {
+      const finalizedGroups = await trx
+        .update(messageGroups)
+        .set({ content, updatedAt: new Date() })
+        .where(
+          and(
+            eq(messageGroups.id, groupId),
+            eq(messageGroups.topicId, topicId),
+            eq(messageGroups.type, MessageGroupType.Compression),
+            this.groupsOwnership(),
+          ),
+        )
+        .returning({ id: messageGroups.id });
+
+      if (finalizedGroups.length === 0) {
+        throw new Error(`Compression group not found: ${groupId}`);
+      }
+
+      if (requestedSourceGroupIds.length === 0) return;
+
+      const sourceGroups = await trx
+        .select({ id: messageGroups.id })
+        .from(messageGroups)
+        .where(
+          and(
+            inArray(messageGroups.id, requestedSourceGroupIds),
+            eq(messageGroups.topicId, topicId),
+            eq(messageGroups.type, MessageGroupType.Compression),
+            this.groupsOwnership(),
+          ),
+        );
+      const sourceGroupIds = sourceGroups.map((group) => group.id);
+
+      if (sourceGroupIds.length === 0) return;
+
+      await trx
+        .update(messages)
+        .set({ messageGroupId: groupId })
+        .where(
+          and(
+            this.messagesOwnership(),
+            eq(messages.topicId, topicId),
+            inArray(messages.messageGroupId, sourceGroupIds),
+          ),
+        );
+
+      await trx
+        .delete(messageGroups)
+        .where(and(this.groupsOwnership(), inArray(messageGroups.id, sourceGroupIds)));
+    });
   }
 
   /**

--- a/packages/prompts/src/chains/compressContext.ts
+++ b/packages/prompts/src/chains/compressContext.ts
@@ -10,14 +10,17 @@ import {
  * Chain for compressing conversation context into a summary
  * Used when conversation history exceeds token threshold
  */
-export const chainCompressContext = (messages: UIChatMessage[]): Partial<ChatStreamPayload> => ({
+export const chainCompressContext = (
+  messages: UIChatMessage[],
+  existingSummary?: string,
+): Partial<ChatStreamPayload> => ({
   messages: [
     {
       content: compressContextSystemPrompt,
       role: 'system',
     },
     {
-      content: `${chatHistoryPrompts(messages)}
+      content: `${existingSummary ? `Existing conversation summary:\n${existingSummary}\n\nNew conversation history:\n` : ''}${chatHistoryPrompts(messages)}
 
 ${compressContextUserPrompt}`,
       role: 'user',

--- a/src/services/message/index.ts
+++ b/src/services/message/index.ts
@@ -350,6 +350,7 @@ export class MessageService {
     content: string;
     groupId?: string | null;
     messageGroupId: string;
+    sourceGroupIds?: string[];
     threadId?: string | null;
     topicId: string;
   }): Promise<{ messages?: UIChatMessage[] }> => {

--- a/src/store/chat/agents/createAgentExecutors.ts
+++ b/src/store/chat/agents/createAgentExecutors.ts
@@ -1,12 +1,10 @@
 import type {
   AgentEvent,
   AgentInstruction,
-  AgentInstructionCompressContext,
   AgentInstructionExecSubAgent,
   AgentInstructionExecSubAgents,
   AgentRuntimeContext,
   AgentRuntimeHost,
-  GeneralAgentCompressionResultPayload,
   InstructionExecutor,
   SubAgentResultPayload,
   SubAgentsBatchResultPayload,
@@ -15,37 +13,24 @@ import type {
 import {
   callLlm as createCallLlmExecutor,
   callTool as createCallToolExecutor,
+  compressContext as createCompressContextExecutor,
   finish as createFinishExecutor,
   requestHumanApprove as createRequestHumanApproveExecutor,
   resolveAbortedTools as createResolveAbortedToolsExecutor,
 } from '@lobechat/agent-runtime';
-import { countContextTokens, type ToolsEngine } from '@lobechat/context-engine';
-import { chainCompressContext } from '@lobechat/prompts';
+import { type ToolsEngine } from '@lobechat/context-engine';
 import { type MessageMetadata } from '@lobechat/types';
 import debug from 'debug';
 import pMap from 'p-map';
 
 import { aiAgentService } from '@/services/aiAgent';
-import { chatService } from '@/services/chat';
 import { type ResolvedAgentConfig } from '@/services/chat/mecha';
-import { messageService } from '@/services/message';
 import { type ChatStore } from '@/store/chat/store';
-import { getCompressionCandidateMessageIds } from '@/store/chat/utils/compression';
 import { sleep } from '@/utils/sleep';
 
 import { buildClientRuntimeHost } from './transports/buildClientRuntimeHost';
 
 const log = debug('lobe-store:agent-executors');
-
-const isAbortError = (error: unknown, abortController?: AbortController) =>
-  !!abortController?.signal.aborted ||
-  (error instanceof Error &&
-    (error.name === 'AbortError' ||
-      error.message.includes('aborted') ||
-      error.message.includes('cancelled')));
-
-const createAbortError = () =>
-  Object.assign(new Error('Compression cancelled'), { name: 'AbortError' });
 
 const formatSubAgentBatchResultContent = (
   tasks: SubAgentTask[],
@@ -94,23 +79,6 @@ export const createAgentExecutors = (context: {
     return operation.context;
   };
 
-  /**
-   * Get effective agentId for message creation - depends on scope
-   * - scope: 'sub_agent': agentId stays unchanged (subAgentId only for config/display)
-   * - Other scopes with subAgentId: use subAgentId for message ownership (e.g., Group mode)
-   * - Default: use agentId
-   */
-  const getEffectiveAgentId = () => {
-    const opContext = getOperationContext();
-
-    // Use subAgentId for message ownership except in sub_agent scope
-    // - sub_agent scope: callAgent scenario, message.agentId should stay unchanged
-    // - Other scopes with subAgentId: Group mode, message.agentId should be subAgentId
-    return opContext.subAgentId && opContext.scope !== 'sub_agent'
-      ? opContext.subAgentId
-      : opContext.agentId;
-  };
-
   const usePackageExecutor =
     (factory: (host: AgentRuntimeHost) => InstructionExecutor): InstructionExecutor =>
     (instruction, state, runtimeContext) =>
@@ -131,6 +99,8 @@ export const createAgentExecutors = (context: {
     call_llm: usePackageExecutor(createCallLlmExecutor),
 
     call_tool: usePackageExecutor(createCallToolExecutor),
+
+    compress_context: usePackageExecutor(createCompressContextExecutor),
 
     finish: usePackageExecutor(createFinishExecutor),
 
@@ -710,265 +680,6 @@ export const createAgentExecutors = (context: {
           },
         } as AgentRuntimeContext,
       };
-    },
-
-    /**
-     * Context compression executor
-     * Compresses ALL messages into a single MessageGroup summary to reduce token usage
-     */
-    compress_context: async (instruction, state) => {
-      const sessionLogId = `${state.operationId}:${state.stepCount}`;
-      const stagePrefix = `[${sessionLogId}][compress_context]`;
-
-      const { messages, currentTokenCount } = (instruction as AgentInstructionCompressContext)
-        .payload;
-
-      // Get topicId from operation context (same as agentId)
-      const { topicId } = getOperationContext();
-
-      log(
-        `${stagePrefix} Starting compression. displayMessages=%d, tokens=%d`,
-        messages.length,
-        currentTokenCount,
-      );
-
-      const events: AgentEvent[] = [];
-
-      // Get message IDs from dbMessagesMap (raw db messages)
-      const dbMessages = context.get().dbMessagesMap[context.messageKey] || [];
-      const messageIds = getCompressionCandidateMessageIds(dbMessages);
-
-      if (!topicId || messageIds.length === 0) {
-        // No topicId or no messages, skip compression
-        log(
-          `${stagePrefix} Skipping compression: topicId=%s, messageIds=%d`,
-          topicId,
-          messageIds.length,
-        );
-        return {
-          events: [],
-          newState: state,
-          nextContext: {
-            payload: {
-              compressedMessages: messages,
-              compressedTokenCount: currentTokenCount,
-              groupId: '',
-              originalTokenCount: currentTokenCount,
-              skipped: true,
-            } as GeneralAgentCompressionResultPayload,
-            phase: 'compression_result',
-            session: {
-              messageCount: state.messages.length,
-              sessionId: state.operationId,
-              status: 'running',
-              stepCount: state.stepCount + 1,
-            },
-          } as AgentRuntimeContext,
-        };
-      }
-
-      // Find the latest assistant message to attach the compression operation
-      const latestAssistantMessage = dbMessages.findLast((m) => m.role === 'assistant');
-      const assistantMessageId = latestAssistantMessage?.id;
-
-      log(
-        `${stagePrefix} Compressing %d db messages (display: %d), assistantMsgId=%s`,
-        messageIds.length,
-        messages.length,
-        assistantMessageId,
-      );
-
-      // Create compress_context operation and attach to the assistant message
-      const { operationId: compressOperationId } = context.get().startOperation({
-        context: { ...getOperationContext(), messageId: assistantMessageId },
-        metadata: {
-          messageCount: messageIds.length,
-          startTime: Date.now(),
-        },
-        parentOperationId: state.operationId,
-        type: 'contextCompression',
-      });
-
-      try {
-        const opContext = getOperationContext();
-        // agentId is guaranteed to exist in compression context
-        const agentId = getEffectiveAgentId()!;
-
-        // 1. Create compression group with placeholder content
-        const result = await messageService.createCompressionGroup({
-          agentId,
-          messageIds,
-          topicId,
-        });
-        const { messageGroupId, messages: initialCompressedMessages, messagesToSummarize } = result;
-
-        // 2. Update UI with compressed messages immediately
-        context.get().replaceMessages(initialCompressedMessages, { context: opContext });
-
-        // 3. Get model/provider from compressionModel config
-        const { model, provider } = state.modelRuntimeConfig?.compressionModel || {};
-
-        log(
-          `${stagePrefix} Created group=%s, generating summary for %d messages by %s`,
-          messageGroupId,
-          messagesToSummarize.length,
-          `${provider}/${model}`,
-        );
-
-        // 4. Build compression prompt and generate summary with streaming UI updates
-        const compressionPayload = chainCompressContext(messagesToSummarize);
-        let summaryContent = '';
-
-        // Start generateSummary operation attached to the compressed group message
-        const { abortController: summaryAbortController, operationId: summaryOperationId } = context
-          .get()
-          .startOperation({
-            context: { ...getOperationContext(), messageId: messageGroupId },
-            type: 'generateSummary',
-            parentOperationId: compressOperationId,
-          });
-
-        await chatService.fetchPresetTaskResult({
-          abortController: summaryAbortController,
-          params: { ...compressionPayload, model, provider },
-          onMessageHandle: (chunk) => {
-            if (chunk.type === 'text') {
-              summaryContent += chunk.text || '';
-              // Stream update the compression group message content
-              context
-                .get()
-                .internal_dispatchMessage(
-                  { id: messageGroupId, type: 'updateMessage', value: { content: summaryContent } },
-                  { operationId: summaryOperationId },
-                );
-            }
-          },
-          onError: (e) => {
-            console.error(e);
-            context.get().completeOperation(summaryOperationId, {
-              error: { message: String(e), type: 'summary_generation_failed' },
-            });
-          },
-        });
-
-        if (summaryAbortController.signal.aborted) throw createAbortError();
-
-        log(`${stagePrefix} Generated summary: %d chars`, summaryContent.length);
-
-        // 5. Finalize compression with actual content
-        const finalResult = await messageService.finalizeCompression({
-          agentId,
-          content: summaryContent,
-          messageGroupId,
-          topicId,
-        });
-        // Complete the generateSummary operation
-        context.get().completeOperation(summaryOperationId);
-
-        const compressedMessages = finalResult.messages || initialCompressedMessages;
-        const groupId = messageGroupId;
-        // Use the latest assistant message ID (before compression) as parentMessageId for next call_llm
-        const parentMessageId = assistantMessageId;
-
-        // 6. Update UI with finalized messages (includes compressedGroup with summary)
-        context.get().replaceMessages(compressedMessages, { context: opContext });
-
-        log(
-          `${stagePrefix} Compression complete. groupId=%s, parentMessageId=%s`,
-          groupId,
-          parentMessageId,
-        );
-
-        // Complete the compress_context operation
-        context.get().completeOperation(compressOperationId, { groupId, parentMessageId });
-
-        events.push({ type: 'compression_complete', groupId, parentMessageId });
-
-        // Calculate new token count
-        const compressedTokenCount = countContextTokens({
-          messages: compressedMessages,
-        }).rawTotal;
-
-        return {
-          events,
-          newState: { ...state, messages: compressedMessages },
-          nextContext: {
-            payload: {
-              compressedMessages,
-              compressedTokenCount,
-              groupId,
-              originalTokenCount: currentTokenCount,
-              parentMessageId,
-            } as GeneralAgentCompressionResultPayload,
-            phase: 'compression_result',
-            session: {
-              messageCount: compressedMessages.length,
-              sessionId: state.operationId,
-              status: 'running',
-              stepCount: state.stepCount + 1,
-            },
-          } as AgentRuntimeContext,
-        };
-      } catch (error) {
-        if (isAbortError(error)) {
-          log(`${stagePrefix} Compression cancelled`);
-
-          if (context.get().operations[compressOperationId]?.status === 'running') {
-            context.get().completeOperation(compressOperationId, { cancelled: true });
-          }
-
-          events.push({ type: 'compression_error', error });
-
-          return {
-            events,
-            newState: state,
-            nextContext: {
-              payload: {
-                compressedMessages: messages,
-                skipped: true,
-              } as GeneralAgentCompressionResultPayload,
-              phase: 'compression_result',
-              session: {
-                messageCount: state.messages.length,
-                sessionId: state.operationId,
-                status: 'running',
-                stepCount: state.stepCount + 1,
-              },
-            } as AgentRuntimeContext,
-          };
-        }
-
-        log(`${stagePrefix} Compression failed: %O`, error);
-
-        // Complete the compress_context operation with error
-        context.get().completeOperation(compressOperationId, {
-          error: {
-            message: error instanceof Error ? error.message : String(error),
-            type: 'compression_failed',
-          },
-        });
-
-        // On error, continue without compression
-        events.push({ type: 'compression_error', error });
-
-        return {
-          events,
-          newState: state,
-          nextContext: {
-            payload: {
-              compressedMessages: messages,
-              skipped: true,
-            } as GeneralAgentCompressionResultPayload,
-            phase: 'compression_result',
-            session: {
-              messageCount: state.messages.length,
-              sessionId: state.operationId,
-              status: 'running',
-              stepCount: state.stepCount + 1,
-            },
-          } as AgentRuntimeContext,
-        };
-      }
     },
   };
 

--- a/src/store/chat/agents/transports/ClientCompressionTransport.test.ts
+++ b/src/store/chat/agents/transports/ClientCompressionTransport.test.ts
@@ -98,6 +98,7 @@ describe('ClientCompressionTransport', () => {
       ...createGroupInput,
       content: 'Summary',
       messageGroupId: created.messageGroupId,
+      sourceGroupIds: ['previous-compressed-group'],
     });
 
     expect(messageService.createCompressionGroup).toHaveBeenCalledWith(createGroupInput);
@@ -130,6 +131,15 @@ describe('ClientCompressionTransport', () => {
     );
     expect(store.replaceMessages).toHaveBeenNthCalledWith(2, finalMessages, {
       context: expect.objectContaining(operationContext),
+    });
+    expect(messageService.finalizeCompression).toHaveBeenCalledWith({
+      agentId: 'agent-1',
+      content: 'Summary',
+      groupId: 'group-1',
+      messageGroupId: 'compressed-group',
+      sourceGroupIds: ['previous-compressed-group'],
+      threadId: 'thread-1',
+      topicId: 'topic-1',
     });
     expect(store.completeOperation).toHaveBeenNthCalledWith(1, 'child-operation-2');
     expect(store.completeOperation).toHaveBeenNthCalledWith(2, 'child-operation-1', {

--- a/src/store/chat/agents/transports/ClientCompressionTransport.test.ts
+++ b/src/store/chat/agents/transports/ClientCompressionTransport.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { messageService } from '@/services/message';
+import type { ChatStore } from '@/store/chat/store';
+
+import { ClientCompressionTransport } from './ClientCompressionTransport';
+
+const createStore = () => {
+  let operationIndex = 0;
+  const operations: Record<string, any> = {
+    'root-operation': {
+      abortController: new AbortController(),
+      context: {
+        agentId: 'agent-1',
+        groupId: 'group-1',
+        threadId: 'thread-1',
+        topicId: 'topic-1',
+      },
+      metadata: { startTime: Date.now() },
+      status: 'running',
+      type: 'execAgentRuntime',
+    },
+  };
+  const store = {
+    cancelOperation: vi.fn((operationId: string) => {
+      operations[operationId].abortController.abort();
+      operations[operationId].status = 'cancelled';
+    }),
+    completeOperation: vi.fn((operationId: string) => {
+      operations[operationId].status = 'completed';
+    }),
+    dbMessagesMap: {
+      'message-key': [
+        { content: 'Question', id: 'user-message', role: 'user' },
+        { content: 'Answer', id: 'assistant-message', role: 'assistant' },
+      ],
+    },
+    failOperation: vi.fn((operationId: string) => {
+      operations[operationId].status = 'failed';
+    }),
+    internal_dispatchMessage: vi.fn(),
+    operations,
+    replaceMessages: vi.fn(),
+    startOperation: vi.fn((params: any) => {
+      const operationId = `child-operation-${++operationIndex}`;
+      const abortController = new AbortController();
+      operations[operationId] = {
+        abortController,
+        context: params.context,
+        metadata: { startTime: Date.now(), ...params.metadata },
+        parentOperationId: params.parentOperationId,
+        status: 'running',
+        type: params.type,
+      };
+      return { abortController, operationId };
+    }),
+  } as unknown as ChatStore;
+
+  return { operations, store };
+};
+
+const createGroupInput = {
+  agentId: 'agent-1',
+  groupId: 'group-1',
+  messageIds: ['user-message', 'assistant-message'],
+  threadId: 'thread-1',
+  topicId: 'topic-1',
+};
+const operationContext = {
+  agentId: 'agent-1',
+  groupId: 'group-1',
+  threadId: 'thread-1',
+  topicId: 'topic-1',
+};
+
+describe('ClientCompressionTransport', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates the visible group, streams updates, and finalizes both operations', async () => {
+    const { store } = createStore();
+    const initialMessages = [{ content: '', id: 'compressed-group', role: 'compressedGroup' }];
+    const finalMessages = [{ content: 'Summary', id: 'compressed-group', role: 'compressedGroup' }];
+    vi.spyOn(messageService, 'createCompressionGroup').mockResolvedValue({
+      messageGroupId: 'compressed-group',
+      messages: initialMessages as any,
+      messagesToSummarize: [{ content: 'Question', id: 'user-message', role: 'user' }] as any,
+    });
+    vi.spyOn(messageService, 'finalizeCompression').mockResolvedValue({
+      messages: finalMessages as any,
+    });
+    const transport = new ClientCompressionTransport(() => store, 'message-key', 'root-operation');
+
+    const created = await transport.createGroup(createGroupInput);
+    transport.updateGroup({ content: 'Part', messageGroupId: created.messageGroupId });
+    const finalized = await transport.finalizeGroup({
+      ...createGroupInput,
+      content: 'Summary',
+      messageGroupId: created.messageGroupId,
+    });
+
+    expect(messageService.createCompressionGroup).toHaveBeenCalledWith(createGroupInput);
+    expect(store.startOperation).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        context: expect.objectContaining({ messageId: 'assistant-message' }),
+        parentOperationId: 'root-operation',
+        type: 'contextCompression',
+      }),
+    );
+    expect(store.startOperation).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        context: expect.objectContaining({ messageId: 'compressed-group' }),
+        parentOperationId: 'child-operation-1',
+        type: 'generateSummary',
+      }),
+    );
+    expect(store.replaceMessages).toHaveBeenNthCalledWith(1, initialMessages, {
+      context: expect.objectContaining(operationContext),
+    });
+    expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
+      {
+        id: 'compressed-group',
+        type: 'updateMessage',
+        value: { content: 'Part' },
+      },
+      { operationId: 'child-operation-2' },
+    );
+    expect(store.replaceMessages).toHaveBeenNthCalledWith(2, finalMessages, {
+      context: expect.objectContaining(operationContext),
+    });
+    expect(store.completeOperation).toHaveBeenNthCalledWith(1, 'child-operation-2');
+    expect(store.completeOperation).toHaveBeenNthCalledWith(2, 'child-operation-1', {
+      groupId: 'compressed-group',
+      parentMessageId: 'assistant-message',
+    });
+    expect(created.signal).toBeInstanceOf(AbortSignal);
+    expect(finalized.messages).toEqual(finalMessages);
+  });
+
+  it('restores messages and fails child operations when summary generation fails', async () => {
+    const { operations, store } = createStore();
+    const restoredMessages = [
+      { content: 'Question', id: 'user-message', role: 'user' },
+      { content: 'Answer', id: 'assistant-message', role: 'assistant' },
+    ];
+    vi.spyOn(messageService, 'createCompressionGroup').mockResolvedValue({
+      messageGroupId: 'compressed-group',
+      messages: [] as any,
+      messagesToSummarize: restoredMessages as any,
+    });
+    vi.spyOn(messageService, 'cancelCompression').mockResolvedValue({
+      messages: restoredMessages as any,
+    });
+    const transport = new ClientCompressionTransport(() => store, 'message-key', 'root-operation');
+
+    await transport.createGroup(createGroupInput);
+    await transport.rollbackGroup({
+      ...createGroupInput,
+      error: new Error('summary failed'),
+      messageGroupId: 'compressed-group',
+    });
+
+    expect(messageService.cancelCompression).toHaveBeenCalledWith({
+      agentId: 'agent-1',
+      groupId: 'group-1',
+      messageGroupId: 'compressed-group',
+      threadId: 'thread-1',
+      topicId: 'topic-1',
+    });
+    expect(store.replaceMessages).toHaveBeenLastCalledWith(restoredMessages, {
+      context: expect.objectContaining(operationContext),
+    });
+    expect(store.failOperation).toHaveBeenCalledWith('child-operation-2', {
+      message: 'summary failed',
+      type: 'summary_generation_failed',
+    });
+    expect(store.failOperation).toHaveBeenCalledWith('child-operation-1', {
+      message: 'summary failed',
+      type: 'compression_failed',
+    });
+    expect(operations['child-operation-1'].status).toBe('failed');
+  });
+
+  it('keeps cancellation status while restoring the original messages', async () => {
+    const { store } = createStore();
+    vi.spyOn(messageService, 'createCompressionGroup').mockResolvedValue({
+      messageGroupId: 'compressed-group',
+      messages: [] as any,
+      messagesToSummarize: [] as any,
+    });
+    vi.spyOn(messageService, 'cancelCompression').mockResolvedValue({ messages: [] });
+    const transport = new ClientCompressionTransport(() => store, 'message-key', 'root-operation');
+    const created = await transport.createGroup(createGroupInput);
+    store.cancelOperation('child-operation-2', 'User cancelled');
+    const abortError = new Error('Context compression cancelled');
+    abortError.name = 'AbortError';
+
+    await transport.rollbackGroup({
+      ...createGroupInput,
+      error: abortError,
+      messageGroupId: created.messageGroupId,
+    });
+
+    expect(store.cancelOperation).toHaveBeenCalledWith(
+      'child-operation-1',
+      'Context compression cancelled',
+    );
+    expect(store.failOperation).not.toHaveBeenCalled();
+  });
+
+  it('includes the existing summary in the compression prompt', async () => {
+    const { store } = createStore();
+    const transport = new ClientCompressionTransport(() => store, 'message-key', 'root-operation');
+
+    const result = await transport.buildPrompt({
+      existingSummary: 'Earlier decisions',
+      messages: [{ content: 'New question', id: 'user-message', role: 'user' }] as any,
+    });
+
+    expect(result.messages[1].content).toContain('Existing conversation summary:');
+    expect(result.messages[1].content).toContain('Earlier decisions');
+    expect(result.messages[1].content).toContain('New conversation history:');
+  });
+});

--- a/src/store/chat/agents/transports/ClientCompressionTransport.ts
+++ b/src/store/chat/agents/transports/ClientCompressionTransport.ts
@@ -136,6 +136,7 @@ export class ClientCompressionTransport implements CompressionTransport {
       content: input.content,
       groupId: operationContext.groupId,
       messageGroupId: input.messageGroupId,
+      sourceGroupIds: input.sourceGroupIds,
       threadId: operationContext.threadId,
       topicId: input.topicId,
     });

--- a/src/store/chat/agents/transports/ClientCompressionTransport.ts
+++ b/src/store/chat/agents/transports/ClientCompressionTransport.ts
@@ -1,0 +1,242 @@
+import type {
+  CompressionGroupCreateInput,
+  CompressionGroupCreateResult,
+  CompressionGroupFinalizeInput,
+  CompressionGroupFinalizeResult,
+  CompressionGroupRollbackInput,
+  CompressionGroupRollbackResult,
+  CompressionGroupUpdateInput,
+  CompressionPromptInput,
+  CompressionPromptResult,
+  CompressionTransport,
+} from '@lobechat/agent-runtime';
+import { chainCompressContext } from '@lobechat/prompts';
+
+import { messageService } from '@/services/message';
+import type { ChatStore } from '@/store/chat/store';
+
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : typeof error === 'string' ? error : String(error);
+
+const isAbortError = (error: unknown) =>
+  error instanceof Error &&
+  (error.name === 'AbortError' ||
+    error.message.includes('aborted') ||
+    error.message.includes('cancelled'));
+
+interface ActiveCompression {
+  compressionOperationId: string;
+  messageGroupId?: string;
+  parentMessageId?: string;
+  summaryOperationId?: string;
+}
+
+export class ClientCompressionTransport implements CompressionTransport {
+  private activeCompression?: ActiveCompression;
+
+  constructor(
+    private readonly get: () => ChatStore,
+    private readonly messageKey: string,
+    private readonly rootOperationId: string,
+  ) {}
+
+  async buildPrompt(input: CompressionPromptInput): Promise<CompressionPromptResult> {
+    const payload = chainCompressContext(input.messages, input.existingSummary);
+    return { messages: payload.messages! };
+  }
+
+  async createGroup(input: CompressionGroupCreateInput): Promise<CompressionGroupCreateResult> {
+    const store = this.get();
+    const rootOperation = store.operations[this.rootOperationId];
+    if (!rootOperation) throw new Error(`Operation not found: ${this.rootOperationId}`);
+
+    const agentId = input.agentId ?? rootOperation.context.agentId;
+    if (!agentId) throw new Error('Client context compression requires an agent id');
+
+    const operationContext = {
+      ...rootOperation.context,
+      agentId,
+      groupId: input.groupId ?? rootOperation.context.groupId,
+      threadId: input.threadId ?? rootOperation.context.threadId,
+      topicId: input.topicId,
+    };
+    const latestAssistantMessage = (store.dbMessagesMap[this.messageKey] ?? []).findLast(
+      (message) => message.role === 'assistant',
+    );
+    const compressionOperation = store.startOperation({
+      context: { ...operationContext, messageId: latestAssistantMessage?.id },
+      metadata: { messageCount: input.messageIds.length, startTime: Date.now() },
+      parentOperationId: this.rootOperationId,
+      type: 'contextCompression',
+    });
+
+    this.activeCompression = {
+      compressionOperationId: compressionOperation.operationId,
+      parentMessageId: latestAssistantMessage?.id,
+    };
+
+    let result: Awaited<ReturnType<typeof messageService.createCompressionGroup>> | undefined;
+
+    try {
+      result = await messageService.createCompressionGroup({
+        agentId,
+        groupId: operationContext.groupId,
+        messageIds: input.messageIds,
+        threadId: operationContext.threadId,
+        topicId: input.topicId,
+      });
+
+      this.activeCompression.messageGroupId = result.messageGroupId;
+      store.replaceMessages(result.messages, { context: operationContext });
+
+      const summaryOperation = store.startOperation({
+        context: { ...operationContext, messageId: result.messageGroupId },
+        parentOperationId: compressionOperation.operationId,
+        type: 'generateSummary',
+      });
+      this.activeCompression.summaryOperationId = summaryOperation.operationId;
+
+      if (compressionOperation.abortController.signal.aborted) {
+        summaryOperation.abortController.abort(compressionOperation.abortController.signal.reason);
+      }
+
+      return {
+        messageGroupId: result.messageGroupId,
+        messages: result.messages,
+        messagesToSummarize: result.messagesToSummarize,
+        signal: summaryOperation.abortController.signal,
+      };
+    } catch (error) {
+      if (result) {
+        try {
+          const rollback = await messageService.cancelCompression({
+            agentId,
+            groupId: operationContext.groupId,
+            messageGroupId: result.messageGroupId,
+            threadId: operationContext.threadId,
+            topicId: input.topicId,
+          });
+          store.replaceMessages(rollback.messages, { context: operationContext });
+        } catch (rollbackError) {
+          console.error('Failed to rollback client context compression', rollbackError);
+        }
+      }
+
+      this.failActiveOperations(error);
+      throw error;
+    }
+  }
+
+  async finalizeGroup(
+    input: CompressionGroupFinalizeInput,
+  ): Promise<CompressionGroupFinalizeResult> {
+    const operationContext = this.getOperationContext(input);
+    const result = await messageService.finalizeCompression({
+      agentId: operationContext.agentId,
+      content: input.content,
+      groupId: operationContext.groupId,
+      messageGroupId: input.messageGroupId,
+      threadId: operationContext.threadId,
+      topicId: input.topicId,
+    });
+    const store = this.get();
+
+    if (result.messages) store.replaceMessages(result.messages, { context: operationContext });
+    if (this.activeCompression?.summaryOperationId) {
+      store.completeOperation(this.activeCompression.summaryOperationId);
+    }
+    if (this.activeCompression) {
+      store.completeOperation(this.activeCompression.compressionOperationId, {
+        groupId: input.messageGroupId,
+        parentMessageId: this.activeCompression.parentMessageId,
+      });
+    }
+
+    return result;
+  }
+
+  async rollbackGroup(
+    input: CompressionGroupRollbackInput,
+  ): Promise<CompressionGroupRollbackResult> {
+    const operationContext = this.getOperationContext(input);
+
+    try {
+      const result = await messageService.cancelCompression({
+        agentId: operationContext.agentId,
+        groupId: operationContext.groupId,
+        messageGroupId: input.messageGroupId,
+        threadId: operationContext.threadId,
+        topicId: input.topicId,
+      });
+      this.get().replaceMessages(result.messages, { context: operationContext });
+      return result;
+    } finally {
+      this.failActiveOperations(input.error);
+    }
+  }
+
+  updateGroup(input: CompressionGroupUpdateInput): void {
+    const operationId =
+      this.activeCompression?.summaryOperationId ??
+      this.activeCompression?.compressionOperationId ??
+      this.rootOperationId;
+
+    this.get().internal_dispatchMessage(
+      { id: input.messageGroupId, type: 'updateMessage', value: { content: input.content } },
+      { operationId },
+    );
+  }
+
+  private failActiveOperations(error: unknown) {
+    if (!this.activeCompression) return;
+
+    const store = this.get();
+    const operationIds = [
+      this.activeCompression.summaryOperationId,
+      this.activeCompression.compressionOperationId,
+    ].filter((operationId): operationId is string => Boolean(operationId));
+    const aborted =
+      isAbortError(error) ||
+      operationIds.some((operationId) =>
+        Boolean(store.operations[operationId]?.abortController.signal.aborted),
+      );
+
+    for (const operationId of operationIds) {
+      const operation = store.operations[operationId];
+      if (!operation || operation.status !== 'running') continue;
+
+      if (aborted) {
+        store.cancelOperation(operationId, 'Context compression cancelled');
+      } else {
+        store.failOperation(operationId, {
+          message: getErrorMessage(error),
+          type:
+            operationId === this.activeCompression.summaryOperationId
+              ? 'summary_generation_failed'
+              : 'compression_failed',
+        });
+      }
+    }
+  }
+
+  private getOperationContext(input: {
+    agentId?: string;
+    groupId?: string;
+    threadId?: string;
+    topicId: string;
+  }) {
+    const rootOperation = this.get().operations[this.rootOperationId];
+    if (!rootOperation) throw new Error(`Operation not found: ${this.rootOperationId}`);
+
+    const agentId = input.agentId ?? rootOperation.context.agentId;
+    if (!agentId) throw new Error('Client context compression requires an agent id');
+
+    return {
+      ...rootOperation.context,
+      agentId,
+      groupId: input.groupId ?? rootOperation.context.groupId,
+      threadId: input.threadId ?? rootOperation.context.threadId,
+      topicId: input.topicId,
+    };
+  }
+}

--- a/src/store/chat/agents/transports/buildClientRuntimeHost.ts
+++ b/src/store/chat/agents/transports/buildClientRuntimeHost.ts
@@ -10,6 +10,7 @@ import type { MessageMetadata } from '@lobechat/types';
 import type { ResolvedAgentConfig } from '@/services/chat/mecha';
 import type { ChatStore } from '@/store/chat/store';
 
+import { ClientCompressionTransport } from './ClientCompressionTransport';
 import { ClientContextBuilder } from './ClientContextBuilder';
 import { ClientLLMTransport } from './ClientLLMTransport';
 import { ClientMessageTransport } from './ClientMessageTransport';
@@ -54,6 +55,11 @@ export const buildClientRuntimeHost = (context: {
       topicId: topicId ?? undefined,
     },
     transports: {
+      compression: new ClientCompressionTransport(
+        context.get,
+        context.messageKey,
+        context.operationId,
+      ),
       context: new ClientContextBuilder({
         agentConfig: context.agentConfig,
         get: context.get,


### PR DESCRIPTION
## Summary

- route client `compress_context` through the package executor with a dedicated `ClientCompressionTransport`
- preserve pending-group UI, streaming summary updates, operation nesting, cancellation, and rollback restoration
- reuse existing summaries for incremental compression and add server rollback parity
- remove the legacy client compression orchestration from `createAgentExecutors`

## Tests

- `bun run check <12 changed files>` (221 tests passed)
- `bun run check --type`

Closes LOBE-11785