### PR TITLE
💄 style(chat): float the conversation header over the message stream on wide layouts

### DIFF
--- a/src/features/Conversation/ChatList/components/VirtualizedList.tsx
+++ b/src/features/Conversation/ChatList/components/VirtualizedList.tsx
@@ -53,6 +53,14 @@ const VirtualizedList = memo<VirtualizedListProps>(
     const scrollEndTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const lastUserScrollIntentAtRef = useRef(0);
 
+    // A header slot prepends one synthetic row to the VList, shifting every
+    // virtua row index off the message index. All index-based APIs exposed to
+    // the store (and the hooks that talk to virtua directly) work in MESSAGE
+    // index space; this offset translates at the virtua boundary.
+    const headerOffset = headerSlot ? 1 : 0;
+    const headerOffsetRef = useRef(headerOffset);
+    headerOffsetRef.current = headerOffset;
+
     // Per-topic scroll restoration. Provider does not remount on topic switch,
     // so we key the scroll snapshot by the message-map key derived from
     // ConversationStore's `context`.
@@ -60,6 +68,7 @@ const VirtualizedList = memo<VirtualizedListProps>(
     const { recordScroll } = useTopicScrollPersist({
       contextKey,
       dataSourceLength: dataSource.length,
+      headerOffset,
       virtuaRef,
     });
 
@@ -78,6 +87,7 @@ const VirtualizedList = memo<VirtualizedListProps>(
       spacerHeight,
     } = useConversationScroll({
       dataSource,
+      headerOffset,
       isSecondLastMessageFromUser,
       virtuaRef,
     });
@@ -137,8 +147,12 @@ const VirtualizedList = memo<VirtualizedListProps>(
         refForActive && typeof refForActive.findItemIndex === 'function'
           ? refForActive.findItemIndex(refForActive.scrollOffset + refForActive.viewportSize * 0.25)
           : null;
+      // findItemIndex returns a virtua row index — translate to message space
+      // (the header row clamps to the first message).
       const activeFromFind =
-        typeof activeFromFindRaw === 'number' && activeFromFindRaw >= 0 ? activeFromFindRaw : null;
+        typeof activeFromFindRaw === 'number' && activeFromFindRaw >= 0
+          ? Math.max(0, activeFromFindRaw - headerOffsetRef.current)
+          : null;
 
       if (activeFromFind !== activeIndex) setActiveIndex(activeFromFind);
 
@@ -179,21 +193,26 @@ const VirtualizedList = memo<VirtualizedListProps>(
     useEffect(() => {
       const ref = virtuaRef.current;
       if (ref) {
+        // Index-based methods accept MESSAGE indices; the header slot row is a
+        // private implementation detail translated away right here.
         registerVirtuaScrollMethods({
-          getItemOffset: (index) => ref.getItemOffset(index),
-          getItemSize: (index) => ref.getItemSize(index),
+          getItemOffset: (index) => ref.getItemOffset(index + headerOffsetRef.current),
+          getItemSize: (index) => ref.getItemSize(index + headerOffsetRef.current),
           getScrollOffset: () => ref.scrollOffset,
           getScrollSize: () => ref.scrollSize,
           getTotalCount: () => totalCountRef.current,
           getViewportSize: () => ref.viewportSize,
           scrollTo: (offset) => ref.scrollTo(offset),
-          scrollToIndex: (index, options) => ref.scrollToIndex(index, options),
+          scrollToIndex: (index, options) =>
+            ref.scrollToIndex(index + headerOffsetRef.current, options),
         });
 
         // Seed active index once on mount (avoid requiring user scroll)
         const initialActiveRaw = ref.findItemIndex(ref.scrollOffset + ref.viewportSize * 0.25);
         const initialActive =
-          typeof initialActiveRaw === 'number' && initialActiveRaw >= 0 ? initialActiveRaw : null;
+          typeof initialActiveRaw === 'number' && initialActiveRaw >= 0
+            ? Math.max(0, initialActiveRaw - headerOffsetRef.current)
+            : null;
         setActiveIndex(initialActive);
       }
 
@@ -268,10 +287,12 @@ const VirtualizedList = memo<VirtualizedListProps>(
     );
 
     // Mirror the latest data length into a ref so the scroll-methods registered
-    // once on mount can read the current total count (including spacer/footer)
-    // without re-registering on every render.
-    const totalCountRef = useRef(dataWithSlots.length);
-    totalCountRef.current = dataWithSlots.length;
+    // once on mount can read the current total count (including spacer/footer,
+    // but excluding the leading header row — the count stays in the same
+    // message-index space as the registered scrollToIndex) without
+    // re-registering on every render.
+    const totalCountRef = useRef(dataWithSlots.length - headerOffset);
+    totalCountRef.current = dataWithSlots.length - headerOffset;
 
     return (
       <div

--- a/src/features/Conversation/ChatList/hooks/useConversationScroll.test.ts
+++ b/src/features/Conversation/ChatList/hooks/useConversationScroll.test.ts
@@ -157,6 +157,7 @@ describe('useConversationScroll — pin behavior', () => {
 
   const renderScrollHook = (props: {
     dataSource: string[];
+    headerOffset?: number;
     isSecondLastMessageFromUser: boolean;
     fixture?: Partial<StoreFixture>;
   }) => {
@@ -173,7 +174,12 @@ describe('useConversationScroll — pin behavior', () => {
 
     const hook = renderHook(
       ({ dataSource, isSecondLastMessageFromUser }) =>
-        useConversationScroll({ dataSource, isSecondLastMessageFromUser, virtuaRef }),
+        useConversationScroll({
+          dataSource,
+          headerOffset: props.headerOffset,
+          isSecondLastMessageFromUser,
+          virtuaRef,
+        }),
       {
         initialProps: {
           dataSource: props.dataSource,
@@ -220,6 +226,23 @@ describe('useConversationScroll — pin behavior', () => {
 
     expect(scrollToIndex).toHaveBeenCalledTimes(1);
     expect(scrollToIndex).toHaveBeenCalledWith(2, { align: 'start', smooth: true });
+  });
+
+  it('translates the pin target by headerOffset when a header slot row is present', () => {
+    const { rerender } = renderScrollHook({
+      dataSource: [assistantId, 'prev'],
+      headerOffset: 1,
+      isSecondLastMessageFromUser: false,
+    });
+
+    rerender({
+      dataSource: ['m0', 'm1', userId, assistantId],
+      isSecondLastMessageFromUser: true,
+    });
+
+    // User message index 2 sits at virtua row 3 (header row 0 + messages).
+    expect(scrollToIndex).toHaveBeenCalledTimes(1);
+    expect(scrollToIndex).toHaveBeenCalledWith(3, { align: 'start', smooth: true });
   });
 
   it('does not scroll when only the assistant message is appended', () => {

--- a/src/features/Conversation/ChatList/hooks/useConversationScroll.ts
+++ b/src/features/Conversation/ChatList/hooks/useConversationScroll.ts
@@ -284,7 +284,13 @@ const useSpacerHeight = ({
 // ---------------------------------------------------------------------------
 type PinState = { index: number; seenActive: boolean } | null;
 
-const usePinController = ({ virtuaRef }: { virtuaRef: RefObject<VListHandle | null> }) => {
+const usePinController = ({
+  headerOffset,
+  virtuaRef,
+}: {
+  headerOffset: number;
+  virtuaRef: RefObject<VListHandle | null>;
+}) => {
   const pinRef = useRef<PinState>(null);
 
   const scrollToPinned = useCallback(
@@ -299,9 +305,10 @@ const usePinController = ({ virtuaRef }: { virtuaRef: RefObject<VListHandle | nu
       }
 
       log('scrollToPinned (%s) index=%d', reason, pin.index);
-      scrollToIndex(pin.index, { align: 'start', smooth: true });
+      // pin.index is a message index; the header slot row shifts virtua rows.
+      scrollToIndex(pin.index + headerOffset, { align: 'start', smooth: true });
     },
-    [virtuaRef],
+    [headerOffset, virtuaRef],
   );
 
   const clearPin = useCallback((reason: string) => {
@@ -403,6 +410,12 @@ const useScrollShrink = ({
 // ---------------------------------------------------------------------------
 export interface UseConversationScrollOptions {
   dataSource: string[];
+  /**
+   * Number of synthetic rows prepended to the VList before the messages
+   * (e.g. the headerSlot spacer). The pin targets message indices, so virtua
+   * calls translate by this offset.
+   */
+  headerOffset?: number;
   isSecondLastMessageFromUser: boolean;
   virtuaRef: RefObject<VListHandle | null>;
 }
@@ -424,6 +437,7 @@ export interface UseConversationScrollResult {
 
 export const useConversationScroll = ({
   dataSource,
+  headerOffset = 0,
   isSecondLastMessageFromUser,
   virtuaRef,
 }: UseConversationScrollOptions): UseConversationScrollResult => {
@@ -475,7 +489,7 @@ export const useConversationScroll = ({
     userMessageIndex,
   });
 
-  const { clearPin, pinRef, scrollToPinned } = usePinController({ virtuaRef });
+  const { clearPin, pinRef, scrollToPinned } = usePinController({ headerOffset, virtuaRef });
 
   const { onScrollOffset, prevScrollOffsetRef } = useScrollShrink({
     clearPin,

--- a/src/features/Conversation/ChatList/hooks/useTopicScrollPersist.test.ts
+++ b/src/features/Conversation/ChatList/hooks/useTopicScrollPersist.test.ts
@@ -65,6 +65,24 @@ describe('useTopicScrollPersist', () => {
       expect(handle.scrollTo).not.toHaveBeenCalled();
     });
 
+    it('translates the restore target by headerOffset when a header slot row is present', async () => {
+      const handle = createFakeVList({ scrollSize: 5000 });
+      renderHook(() =>
+        useTopicScrollPersist({
+          contextKey: 'main_agt_1_tpc_a',
+          dataSourceLength: 50,
+          headerOffset: 1,
+          virtuaRef: refOf(handle),
+        }),
+      );
+
+      await advanceFrames(2);
+
+      // Last message sits at virtua row 50 (header row 0 + 50 messages).
+      expect(handle.scrollToIndex).toHaveBeenCalledTimes(1);
+      expect(handle.scrollToIndex).toHaveBeenCalledWith(50, { align: 'end' });
+    });
+
     it('falls back to scrollToIndex(last, end) when snapshot.atBottom is true', async () => {
       saveScrollSnapshot('main_agt_1_tpc_a', {
         atBottom: true,

--- a/src/features/Conversation/ChatList/hooks/useTopicScrollPersist.ts
+++ b/src/features/Conversation/ChatList/hooks/useTopicScrollPersist.ts
@@ -25,6 +25,12 @@ interface PendingWrite {
 interface UseTopicScrollPersistOptions {
   contextKey: string;
   dataSourceLength: number;
+  /**
+   * Number of synthetic rows prepended to the VList before the messages
+   * (e.g. the headerSlot spacer). Added when targeting the last message so
+   * scrollToIndex lands on the right virtua row.
+   */
+  headerOffset?: number;
   virtuaRef: RefObject<VListHandle | null>;
 }
 
@@ -40,6 +46,7 @@ interface UseTopicScrollPersistOptions {
 export const useTopicScrollPersist = ({
   contextKey,
   dataSourceLength,
+  headerOffset = 0,
   virtuaRef,
 }: UseTopicScrollPersistOptions) => {
   const pendingWriteRef = useRef<PendingWrite | null>(null);
@@ -183,7 +190,7 @@ export const useTopicScrollPersist = ({
     const targetOffset = snapshot && !snapshot.atBottom ? snapshot.offset : null;
 
     if (targetOffset === null) {
-      virtuaRef.current.scrollToIndex(dataSourceLength - 1, { align: 'end' });
+      virtuaRef.current.scrollToIndex(headerOffset + dataSourceLength - 1, { align: 'end' });
       finalize(false);
       return;
     }
@@ -211,7 +218,7 @@ export const useTopicScrollPersist = ({
       requestAnimationFrame(tryScroll);
     };
     requestAnimationFrame(tryScroll);
-  }, [contextKey, dataSourceLength, flushNow, virtuaRef]);
+  }, [contextKey, dataSourceLength, flushNow, headerOffset, virtuaRef]);
 
   // One-shot housekeeping: drop expired entries and enforce the cap.
   useEffect(() => {

--- a/src/features/Conversation/store/slices/virtuaList/initialState.ts
+++ b/src/features/Conversation/store/slices/virtuaList/initialState.ts
@@ -1,5 +1,9 @@
 /**
- * Scroll methods exposed by VList, stored as callable functions
+ * Scroll methods exposed by VList, stored as callable functions.
+ *
+ * All index-based methods work in MESSAGE index space: VirtualizedList
+ * translates away any leading synthetic row (headerSlot spacer) before
+ * hitting virtua, so consumers can pass displayMessages indices directly.
  */
 export interface VirtuaScrollMethods {
   getItemOffset: (index: number) => number;
@@ -8,7 +12,8 @@ export interface VirtuaScrollMethods {
   getScrollSize: () => number;
   /**
    * Total number of items currently rendered by VList, including trailing
-   * synthetic items (spacer, footerSlot) that are not part of displayMessages.
+   * synthetic items (spacer, footerSlot) that are not part of displayMessages
+   * but excluding the leading header row (same index space as scrollToIndex).
    * Used by scrollToBottom to land on the true last index instead of the last
    * message, which would otherwise leave trailing items below the viewport.
    */

--- a/src/routes/(main)/agent/(chat)/_layout/index.tsx
+++ b/src/routes/(main)/agent/(chat)/_layout/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 import { Outlet } from 'react-router';
 
@@ -10,6 +11,17 @@ import AgentWorkingSidebar from '@/routes/(main)/agent/features/Conversation/Wor
 import Portal from '@/routes/(main)/agent/features/Portal';
 
 import HeaderSlot from './HeaderSlot';
+
+const styles = createStaticStyles(({ css }) => ({
+  // Named container queried by ChatHeader and the list top spacer: when this
+  // column is wide enough, the header floats above the full-bleed message
+  // stream instead of sitting in flow as a solid bar.
+  conversationColumn: css`
+    position: relative;
+    container-name: agent-chat-layout;
+    container-type: inline-size;
+  `,
+}));
 
 const ChatLayout = memo(() => {
   return (
@@ -21,7 +33,11 @@ const ChatLayout = memo(() => {
           style={{ minHeight: 0, overflow: 'hidden', position: 'relative' }}
           width={'100%'}
         >
-          <Flexbox flex={1} style={{ minHeight: 0, minWidth: 0 }}>
+          <Flexbox
+            className={styles.conversationColumn}
+            flex={1}
+            style={{ minHeight: 0, minWidth: 0 }}
+          >
             <ChatHeader />
             <Flexbox flex={1} style={{ minHeight: 0, position: 'relative' }}>
               <Outlet />

--- a/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { cssVar } from 'antd-style';
+import { createStaticStyles, cssVar } from 'antd-style';
 import debug from 'debug';
 import { memo, Suspense, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -33,6 +33,21 @@ import { useActionsBarConfig } from './useActionsBarConfig';
 import { useAgentContext } from './useAgentContext';
 
 const log = debug('lobe-render:agent:ConversationArea');
+
+const styles = createStaticStyles(({ css }) => ({
+  // When the chat column is wide enough for the header to float above the
+  // full-bleed list (see Conversation/Header), this in-list spacer keeps the
+  // first message clear of it while still letting content scroll underneath.
+  // A list row is used instead of scroller padding, which breaks virtua's
+  // offset math. Height matches the 44px NavHeader.
+  floatingHeaderSpacer: css`
+    height: 0;
+
+    @container agent-chat-layout (min-width: 1200px) {
+      height: 44px;
+    }
+  `,
+}));
 
 /**
  * ConversationArea
@@ -117,6 +132,7 @@ const Conversation = memo(() => {
       >
         <ChatList
           defaultWorkflowExpandLevel={isHeterogeneousAgent ? { streaming: 'full' } : undefined}
+          headerSlot={<div aria-hidden className={styles.floatingHeaderSpacer} />}
           welcome={<AgentHome />}
           footerSlot={
             isSubagentThread ? (

--- a/src/routes/(main)/agent/features/Conversation/Header/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/index.tsx
@@ -18,25 +18,75 @@ import Tags from './Tags';
 import TerminalToggle from './TerminalToggle';
 import WorkingPanelToggle from './WorkingPanelToggle';
 
+// Below this column width the header is a solid in-flow bar with a bottom
+// border; at or above it, the header floats above the full-bleed message
+// stream (Codex-style): the 960px reading column stays clear of the floating
+// slots, which keep their own opaque backing for when content scrolls under.
+const FLOATING_HEADER_QUERY = '@container agent-chat-layout (min-width: 1200px)';
+
 const headerStyles = createStaticStyles(({ css }) => ({
   container: css`
     position: relative;
+
     container-name: agent-conv-header;
     container-type: inline-size;
+
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+
+    background: ${cssVar.colorBgContainer};
+
+    ${FLOATING_HEADER_QUERY} {
+      pointer-events: none;
+
+      position: absolute;
+      z-index: 10;
+      inset-block-start: 0;
+      inset-inline: 0;
+
+      border-block-end: none;
+
+      background: transparent;
+    }
   `,
   leftContent: css`
     overflow: hidden;
     flex: 1 1 auto;
     min-width: 0;
+    background: ${cssVar.colorBgContainer};
+
+    ${FLOATING_HEADER_QUERY} {
+      flex-grow: 0;
+      border-radius: ${cssVar.borderRadius};
+      box-shadow: ${cssVar.boxShadowTertiary};
+    }
+  `,
+  rightContent: css`
+    background: ${cssVar.colorBgContainer};
+
+    ${FLOATING_HEADER_QUERY} {
+      border-radius: ${cssVar.borderRadius};
+      box-shadow: ${cssVar.boxShadowTertiary};
+    }
   `,
   slotLeft: css`
     overflow: hidden;
     flex: 1 1 auto;
     min-width: 0;
+
+    ${FLOATING_HEADER_QUERY} {
+      pointer-events: auto;
+
+      /* Hug the title pill so the transparent middle stays click-through */
+      flex-grow: 0;
+    }
   `,
   slotRight: css`
     flex: 0 0 auto;
     min-width: 0;
+
+    ${FLOATING_HEADER_QUERY} {
+      pointer-events: auto;
+    }
   `,
 }));
 
@@ -64,19 +114,13 @@ const Header = memo(() => {
             align={'center'}
             className={headerStyles.leftContent}
             gap={4}
-            style={{ backgroundColor: cssVar.colorBgContainer }}
           >
             <Tags />
             <HeaderActions />
           </Flexbox>
         }
         right={
-          <Flexbox
-            horizontal
-            align={'center'}
-            gap={4}
-            style={{ backgroundColor: cssVar.colorBgContainer }}
-          >
+          <Flexbox horizontal align={'center'} className={headerStyles.rightContent} gap={4}>
             {isLocalSystemEnabled && (
               <OpenInAppButton workingDirectory={effectiveWorkingDirectory} />
             )}


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

Codex-style dual-mode header for the agent conversation page, switched by a CSS container query (`agent-chat-layout`, declared on the chat column, breakpoint 1200px):

- **Narrow column (<1200px)**: the header stays a solid in-flow bar and gains a `1px` bottom border for separation.
- **Wide column (≥1200px)**: the header floats above the full-bleed message stream (`position: absolute`, transparent, no border, `z-index: 10`). The scroll area takes the full column height, the 960px reading column stays centered, and content scrolls under the header strip.
- The title/action pills keep an opaque `colorBgContainer` backing plus `borderRadius` and a subtle `boxShadowTertiary`, so they stay readable when content passes underneath.
- **Pointer-events layering**: the floating strip is `pointer-events: none` with the slots re-enabled, and `slotLeft` stops growing in wide mode so the transparent middle of the strip clicks through to the content below (verified with `elementFromPoint`).
- **Top clearance** uses a `headerSlot` spacer row (0 → 44px) inside the virtualized list instead of scroller `padding-top`, which virtua's offset math does not support. The spacer scrolls away with the content, preserving the full-bleed effect.

#### 🧪 How to Test

Verified end-to-end in the Electron app (isolated dev instance, live code, CDP-driven): both modes' computed styles, scroll-under behavior, top clearance, pointer-events layering, and the empty-conversation welcome state.

Full evidence report: https://app.lobehub.com/verify/44f779a6-42ae-4a8f-b79a-ca476a7838b3

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

All screenshots (narrow solid bar, wide floating header, scroll-under, top clearance, empty state) are attached to the verify report above.

#### 📝 Additional Information

The 1200px breakpoint is a first-pass value (960px reading column + room for the floating pills on both sides); easy to tune later. The container query no-ops on surfaces that don't declare the `agent-chat-layout` container (mobile/share), so those layouts are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
