### PR TITLE
refactor(trpc): share onError logger across lambda/mobile/tools routes

### DIFF
--- a/apps/server/src/routers/lambda/aiChat.ts
+++ b/apps/server/src/routers/lambda/aiChat.ts
@@ -19,6 +19,7 @@ import { ThreadModel } from '@/database/models/thread';
 import { TopicModel } from '@/database/models/topic';
 import { router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
+import { markSilentTRPCErrorLog } from '@/libs/trpc/utils/errorLogger';
 import { resolveContext } from '@/server/routers/lambda/_helpers/resolveContext';
 import { AiChatService } from '@/server/services/aiChat';
 import { AiGenerationService } from '@/server/services/aiGeneration';
@@ -29,8 +30,6 @@ const log = debug('lobe-lambda-router:ai-chat');
 const { createPrefixedTimingContext, logTiming, runTimedStage } = createTimingHelpers(
   'lobe-server:chat:lobehub:timing',
 );
-const SILENT_TRPC_ERROR_LOG_KEY = '__lobeSilentTRPCErrorLog';
-
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 type TRPCStatusCode = Parameters<typeof getStatusKeyFromCode>[0];
 
@@ -49,19 +48,6 @@ const getTRPCErrorCodeFromStatus = (status: number): TRPCErrorCode => {
   if (status >= 400) return 'BAD_REQUEST';
 
   return 'INTERNAL_SERVER_ERROR';
-};
-
-const markSilentTRPCErrorLog = (error: unknown) => {
-  if (!error || typeof error !== 'object') return;
-
-  try {
-    Object.defineProperty(error, SILENT_TRPC_ERROR_LOG_KEY, {
-      configurable: true,
-      value: true,
-    });
-  } catch {
-    // Best-effort logging hint; never let it mask the original runtime error.
-  }
 };
 
 const createRuntimeTRPCError = (

--- a/packages/trpc/src/utils/errorLogger.test.ts
+++ b/packages/trpc/src/utils/errorLogger.test.ts
@@ -1,0 +1,49 @@
+import { TRPCError } from '@trpc/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createTRPCErrorLogger, markSilentTRPCErrorLog } from './errorLogger';
+
+describe('createTRPCErrorLogger', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('logs errors with the endpoint scope', () => {
+    const onError = createTRPCErrorLogger('mobile');
+    const error = new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'boom' });
+
+    onError({ error, path: 'aiChat.outputJSON', type: 'mutation' });
+
+    expect(console.info).toHaveBeenCalledWith(
+      'Error in tRPC handler (mobile) on path: aiChat.outputJSON, type: mutation',
+    );
+    expect(console.error).toHaveBeenCalledWith(error);
+  });
+
+  it('skips UNAUTHORIZED errors', () => {
+    const onError = createTRPCErrorLogger('lambda');
+    const error = new TRPCError({ code: 'UNAUTHORIZED' });
+
+    onError({ error, path: 'session.getSessions', type: 'query' });
+
+    expect(console.info).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('skips errors whose cause was marked via markSilentTRPCErrorLog', () => {
+    const onError = createTRPCErrorLogger('lambda');
+    const cause = new Error('rate limited');
+    markSilentTRPCErrorLog(cause);
+    const error = new TRPCError({ cause, code: 'TOO_MANY_REQUESTS', message: 'rate limited' });
+
+    onError({ error, path: 'aiChat.outputJSON', type: 'mutation' });
+
+    expect(console.info).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+});

--- a/packages/trpc/src/utils/errorLogger.ts
+++ b/packages/trpc/src/utils/errorLogger.ts
@@ -1,0 +1,52 @@
+import type { TRPCError } from '@trpc/server';
+
+/**
+ * Routers can stamp this key on `error.cause` to tell the HTTP handler to
+ * skip logging the error — used for expected user-channel 4xx failures
+ * (e.g. input-completion provider rejections) that would otherwise pollute
+ * error monitoring. Write it via `markSilentTRPCErrorLog` below; this file
+ * is the single home for both halves of the contract.
+ */
+export const SILENT_TRPC_ERROR_LOG_KEY = '__lobeSilentTRPCErrorLog';
+
+/**
+ * Stamp the silent-log marker on an error so `createTRPCErrorLogger` skips
+ * it. Best-effort: never throws, so it can't mask the original error.
+ */
+export const markSilentTRPCErrorLog = (error: unknown) => {
+  if (!error || typeof error !== 'object') return;
+
+  try {
+    Object.defineProperty(error, SILENT_TRPC_ERROR_LOG_KEY, {
+      configurable: true,
+      value: true,
+    });
+  } catch {
+    // Best-effort logging hint; never let it mask the original runtime error.
+  }
+};
+
+const shouldSkipTRPCErrorLog = (cause: unknown): boolean =>
+  Boolean(
+    cause &&
+    typeof cause === 'object' &&
+    (cause as Record<string, unknown>)[SILENT_TRPC_ERROR_LOG_KEY],
+  );
+
+/**
+ * Shared `onError` for tRPC fetch handlers. Skips UNAUTHORIZED (normal
+ * client behavior — the frontend prompts the user to log in) and
+ * silent-marked errors, so every user-facing endpoint applies the same log
+ * hygiene. Used by the lambda / mobile / tools routes; the async route
+ * intentionally keeps its own handler (background jobs have no user to
+ * prompt, so UNAUTHORIZED there is a real anomaly worth logging).
+ */
+export const createTRPCErrorLogger =
+  (endpoint: string) =>
+  ({ error, path, type }: { error: TRPCError; path?: string; type: string }) => {
+    if (error.code === 'UNAUTHORIZED') return;
+    if (shouldSkipTRPCErrorLog(error.cause)) return;
+
+    console.info(`Error in tRPC handler (${endpoint}) on path: ${path}, type: ${type}`);
+    console.error(error);
+  };

--- a/src/app/(backend)/trpc/lambda/[trpc]/route.ts
+++ b/src/app/(backend)/trpc/lambda/[trpc]/route.ts
@@ -2,18 +2,10 @@ import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
 import { type NextRequest } from 'next/server';
 
 import { createLambdaContext } from '@/libs/trpc/lambda/context';
+import { createTRPCErrorLogger } from '@/libs/trpc/utils/errorLogger';
 import { prepareRequestForTRPC } from '@/libs/trpc/utils/request-adapter';
 import { createResponseMeta } from '@/libs/trpc/utils/responseMeta';
 import { lambdaRouter } from '@/server/routers/lambda';
-
-const SILENT_TRPC_ERROR_LOG_KEY = '__lobeSilentTRPCErrorLog';
-
-const shouldSkipTRPCErrorLog = (cause: unknown): boolean =>
-  Boolean(
-    cause &&
-    typeof cause === 'object' &&
-    (cause as Record<string, unknown>)[SILENT_TRPC_ERROR_LOG_KEY],
-  );
 
 const handler = (req: NextRequest) => {
   // Clone the request to avoid "Response body object should not be disturbed or locked" error
@@ -28,15 +20,7 @@ const handler = (req: NextRequest) => {
 
     endpoint: '/trpc/lambda',
 
-    onError: ({ error, path, type }) => {
-      // Filter out the error of UNAUTHORIZED, because this is normal behavior
-      // And it has been displayed at the front end to let the user login
-      if (error.code === 'UNAUTHORIZED') return;
-      if (shouldSkipTRPCErrorLog(error.cause)) return;
-
-      console.info(`Error in tRPC handler (lambda) on path: ${path}, type: ${type}`);
-      console.error(error);
-    },
+    onError: createTRPCErrorLogger('lambda'),
 
     req: preparedReq,
     responseMeta: createResponseMeta,

--- a/src/app/(backend)/trpc/mobile/[trpc]/route.ts
+++ b/src/app/(backend)/trpc/mobile/[trpc]/route.ts
@@ -2,6 +2,7 @@ import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
 import { type NextRequest } from 'next/server';
 
 import { createLambdaContext } from '@/libs/trpc/lambda/context';
+import { createTRPCErrorLogger } from '@/libs/trpc/utils/errorLogger';
 import { prepareRequestForTRPC } from '@/libs/trpc/utils/request-adapter';
 import { createResponseMeta } from '@/libs/trpc/utils/responseMeta';
 import { mobileRouter } from '@/server/routers/mobile';
@@ -19,10 +20,7 @@ const handler = (req: NextRequest) => {
 
     endpoint: '/trpc/mobile',
 
-    onError: ({ error, path, type }) => {
-      console.info(`Error in tRPC handler (mobile) on path: ${path}, type: ${type}`);
-      console.error(error);
-    },
+    onError: createTRPCErrorLogger('mobile'),
 
     req: preparedReq,
     responseMeta: createResponseMeta,

--- a/src/app/(backend)/trpc/tools/[trpc]/route.ts
+++ b/src/app/(backend)/trpc/tools/[trpc]/route.ts
@@ -2,6 +2,7 @@ import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
 import { type NextRequest } from 'next/server';
 
 import { createLambdaContext } from '@/libs/trpc/lambda/context';
+import { createTRPCErrorLogger } from '@/libs/trpc/utils/errorLogger';
 import { prepareRequestForTRPC } from '@/libs/trpc/utils/request-adapter';
 import { createResponseMeta } from '@/libs/trpc/utils/responseMeta';
 import { toolsRouter } from '@/server/routers/tools';
@@ -19,10 +20,7 @@ const handler = (req: NextRequest) => {
 
     endpoint: '/trpc/tools',
 
-    onError: ({ error, path, type }) => {
-      console.error(`Error in tRPC handler (tools) on path: ${path}, type: ${type}`);
-      console.error(error);
-    },
+    onError: createTRPCErrorLogger('tools'),
 
     req: preparedReq,
     responseMeta: createResponseMeta,


### PR DESCRIPTION
### 背景 | Background

While investigating [LOBE-11914](https://linear.app/lobehub/issue/LOBE-11914) (mobile `aiChat.outputJSON` errors polluting 500 monitoring), we found the four tRPC fetch route handlers each hand-roll their `onError`:

- `/trpc/lambda` filters `UNAUTHORIZED` and silent-marked errors (added in #15692);
- `/trpc/mobile` logs **everything unconditionally** — expired tokens and other normal client behavior land in error monitoring, making mobile paths much noisier than web;
- `/trpc/tools` has a third inline variant with inconsistent formatting;
- the `__lobeSilentTRPCErrorLog` marker's writer (`aiChat.ts`) and reader (route handler) each hardcode the same magic string in different files.

### 改动 | Changes

- Add `packages/trpc/src/utils/errorLogger.ts` exporting `createTRPCErrorLogger(endpoint)` — one shared onError with the UNAUTHORIZED / silent-marker filters and the existing log format.
- Wire it into the `lambda`, `mobile` and `tools` routes. `lambda` is behavior-unchanged (pure refactor); `mobile` and `tools` gain the filters.
- Make the new file the single home of the silent-marker contract: it exports `SILENT_TRPC_ERROR_LOG_KEY` and the `markSilentTRPCErrorLog` writer; `aiChat.ts` now imports them instead of redefining.
- Unit tests covering the writer→reader contract.

The `async` route intentionally keeps its own handler: background jobs (QStash) have no user to prompt for login, so `UNAUTHORIZED` there is a genuine anomaly worth logging.

### 验证 | Verification

- `packages/trpc` `errorLogger.test.ts`: 3/3 ✅
- `apps/server` `aiChat.test.ts` (exercises the moved `markSilentTRPCErrorLog`): 31/31 ✅
- Touched files type-check clean.

Linear: [LOBE-11929](https://linear.app/lobehub/issue/LOBE-11929)

🤖 Generated with [Claude Code](https://claude.com/claude-code)