### PR TITLE
🐛 fix(agent-testing): improve target intake and reference IDs

### DIFF
--- a/.agents/skills/agent-testing/SKILL.md
+++ b/.agents/skills/agent-testing/SKILL.md
@@ -31,10 +31,33 @@ Finish unless the user explicitly asks to keep the environment running.
 Confirm what will run and whether the environment is ready before changing or
 starting anything.
 
-### Step 0 — Read the two living logs (mandatory, before every run)
+Skill-internal setup — loading this skill, reading the living logs and
+reference files — is silent preparation: never narrate it to the user ("I'll
+load the mandatory living logs first…" is noise). The first user-visible
+message of a session is about the user's test — the target confirmation
+(Step 0) or the Phase 1 approval gate — in one message, not a setup
+announcement followed by the same question again.
 
-Before doing anything else, read both of these in full and hold them in mind for
-this run:
+### Step 0 — Ground the target, then read the two living logs (mandatory)
+
+**A test target must exist before anything else happens.** When the invocation
+carries none (bare skill invocation, no pending ask in the conversation),
+ground it first — do NOT read the living logs or touch the environment yet:
+
+1. Take the target from the user's words in this conversation when they
+   exist — the task lives in their words, not in git (common-mistakes Case 3).
+2. Otherwise, infer the most likely candidate from observable context (current
+   branch, recent commits, working-tree changes) and confirm it with one
+   structured question — the candidate as the recommended option, clearly
+   labeled as a guess. Never start executing against an unconfirmed guess.
+3. Only when nothing is inferable, ask one direct open question. Asking "what
+   should I verify" is the one legitimate opening question (common-mistakes
+   Case 8) — but asking it open-ended when a candidate was inferable wastes
+   the user's turn.
+
+**Once the target is known**, read both of these in full and hold them in mind
+for this run. Reading them before a target exists wastes context that may be
+compacted away before Execute — they inform execution, not target selection:
 
 - [references/common-mistakes.md](./references/common-mistakes.md) — mistakes the
   user has called out. Two that keep biting:

--- a/.agents/skills/agent-testing/references/common-mistakes.md
+++ b/.agents/skills/agent-testing/references/common-mistakes.md
@@ -557,3 +557,30 @@ observed failure mode is not covered, stop the test immediately, revert any expe
 changes, summarize the exact checks and evidence collected, and ask the user for help before
 continuing. Do not repair the environment, switch surfaces, or invent a fallback without user
 direction.
+
+---
+
+## Case 22 — Bare invocation: narrating skill setup, then asking an open "what should I test?"
+
+**Wrong approach**: invoked with no test target, the agent sent "I'm using the
+agent-testing skill; I'll load its mandatory living logs first", read both
+living logs in full (\~1.9k lines), then sent a second message — "Agent-testing
+is loaded, including both mandatory living logs. What feature, change, PR, or
+user flow should I verify?" — an open question that ignored the visible
+candidate (the current feature branch and its recent commits).
+
+**Why it's wrong**: the living logs inform execution, not target selection —
+reading them before a target exists burns context that may be compacted away
+before the run starts. Narrating internal setup ("mandatory living logs") is
+compliance-reporting the user never asked for. And an open question pushes work
+onto the user that observable context could have pre-filled as a candidate.
+
+**What it breaks**: two user-visible turns whose combined value is one
+clarifying question, asked twice; the user must type the target from scratch.
+
+**Correct approach**: ground the target first (SKILL.md Step 0): the user's
+words in the conversation > an inferred candidate from branch/commits/working
+tree, confirmed via one structured question and labeled as a guess (never
+executed on unconfirmed — Case 3) > an open question only as last resort. Read
+the living logs once the target is known, and never narrate skill-internal
+setup — the first visible message is about the user's test.

--- a/.agents/skills/agent-testing/references/probe-mock-patterns.md
+++ b/.agents/skills/agent-testing/references/probe-mock-patterns.md
@@ -994,7 +994,7 @@ agents. Set` `agentRules: false` `in next.config to disable.` and leaves the wor
   overrides the ignore, or call `/usr/bin/grep` directly. Before asserting "X exists nowhere",
   re-run the search with an explicit path into the dependency tree.
 
-### E14. Electron `will-attach-webview` params carry NO custom attributes — identity via data-\* never arrives
+### E25. Electron `will-attach-webview` params carry NO custom attributes — identity via data-\* never arrives
 
 - **Situation**: a main-process controller needs to know WHICH renderer feature a mounting
   `<webview>` belongs to (e.g. a per-conversation session id), and the renderer put it in a
@@ -1097,7 +1097,7 @@ nodeintegration, plugins, disablewebsecurity, allowpopups, preload, …`). The h
   before opening the share page. Verify the fetch actually fired via
   `agent-browser network requests | grep getMessages`, not by waiting on the UI.
 
-### E15. ✅ Next dev does NOT hot-reload `apps/server/**` — you are testing STALE compiled server code
+### E26. ✅ Next dev does NOT hot-reload `apps/server/**` — you are testing STALE compiled server code
 
 - **Situation**: verifying a working-tree change inside `apps/server/src/**` (an agent-runtime
   service, a tool executor, a router) against a `bun run dev` server that was started before the
@@ -1114,7 +1114,7 @@ nodeintegration, plugins, disablewebsecurity, allowpopups, preload, …`). The h
   conclusion. If a run "should" have hit your code and didn't, prove the server is running your
   code FIRST — drop a `console.error` on the path and restart — before debugging the code itself.
 
-### E16. ✅ `source`-ing an unquoted JSON env var silently corrupts it (JWKS\_KEY → gateway auth\_failed)
+### E27. ✅ `source`-ing an unquoted JSON env var silently corrupts it (JWKS\_KEY → gateway auth\_failed)
 
 - **Situation**: writing an env file for the local gateway loop with
   `JWKS_KEY={"keys":[{"kty":"RSA",...}]}` on one line, then `set -a; source that-file`.
@@ -1134,7 +1134,7 @@ nodeintegration, plugins, disablewebsecurity, allowpopups, preload, …`). The h
   To diagnose an `auth_failed`, hook `ws.send` in the page and read the token the client actually
   sends — an empty string means the SERVER failed to sign, not that the gateway rejected a signature.
 
-### E17. The chat input silently refuses to send when the agent's model is retired
+### E28. The chat input silently refuses to send when the agent's model is retired
 
 - **Situation**: driving a real turn (store `sendMessage` or type+Enter). The call resolves, no error
   is thrown, `activeTopicId` stays `null`, and no `agent_operations` row appears. Nothing in the dev
@@ -1147,7 +1147,7 @@ nodeintegration, plugins, disablewebsecurity, allowpopups, preload, …`). The h
   and pick one from there. Also: a send that "resolves fine but creates no operation" is a UI-gate
   symptom; **screenshot the composer** instead of re-reading your store call.
 
-### E18. Fresh-worktree `seed-user` dies on `Cannot find module 'bcryptjs'` — NODE\_PATH into .pnpm fixes it
+### E29. Fresh-worktree `seed-user` dies on `Cannot find module 'bcryptjs'` — NODE\_PATH into .pnpm fixes it
 
 - **Situation**: in a fresh git-worktree install, `init-dev-env.sh seed-user`
   (which runs `node <<'NODE'` from the repo root) throws MODULE\_NOT\_FOUND for
@@ -1166,7 +1166,7 @@ nodeintegration, plugins, disablewebsecurity, allowpopups, preload, …`). The h
   the `os error 35` agent-browser daemon wedge (D8) recovers with
   `agent-browser close --all` + re-running `setup-auth.sh web-seed`.
 
-### C7. `document.body.innerText` is ALWAYS 0 in this app — probe `#root`, and use textContent to tell a wedge from a blank
+### C10. `document.body.innerText` is ALWAYS 0 in this app — probe `#root`, and use textContent to tell a wedge from a blank
 
 - **Situation**: asserting rendered text with `document.body.innerText.includes(...)`. It returns `""` / length 0 even on a fully rendered page, so every text assertion silently fails and reads as "the page is blank".
 - **Works**: probe `document.getElementById('root').innerText`. (Cause not established — some ancestor of `#root` makes body's inner-text computation collapse; `#root` itself is fine.)


### PR DESCRIPTION
## Summary

- Ground the test target before loading living logs or touching the test environment.
- Keep skill-internal setup silent and consolidate target confirmation into one user-facing message.
- Document the bare-invocation failure mode in the living mistakes log.
- Assign unique IDs to duplicate probe/mock reference entries.

## Why

A bare `agent-testing` invocation previously loaded about 1.9k lines of reference logs and emitted two setup-oriented messages before asking what to test, even when the current branch and commits provided a useful candidate. The probe/mock reference also contained duplicate IDs, making cross-references ambiguous.

## Impact

Agent-testing starts with a clearer, lower-cost intake flow and preserves stable, unambiguous reference identifiers. This PR does not change product runtime behavior.

## Checks

- `bun run check .agents/skills/agent-testing/SKILL.md .agents/skills/agent-testing/references/common-mistakes.md .agents/skills/agent-testing/references/probe-mock-patterns.md`
- Skill folder validation via `quick_validate.py`
- Duplicate pattern and case ID scans
- `git diff --check`
