### PR TITLE
💄 style(subscription): align premium plan description

### DIFF
--- a/locales/en-US/subscription.json
+++ b/locales/en-US/subscription.json
@@ -395,7 +395,7 @@
   "plans.plan.free.title": "Free",
   "plans.plan.hobby.desc": "For users with their own API who pay as they go",
   "plans.plan.hobby.title": "Hobby",
-  "plans.plan.premium.desc": "Designed for professional users who frequently use AI",
+  "plans.plan.premium.desc": "For professional users who frequently use AI",
   "plans.plan.premium.title": "Premium",
   "plans.plan.starter.desc": "For occasional AI users",
   "plans.plan.starter.title": "Starter",

--- a/locales/zh-CN/subscription.json
+++ b/locales/zh-CN/subscription.json
@@ -395,7 +395,7 @@
   "plans.plan.free.title": "免费版",
   "plans.plan.hobby.desc": "适合拥有自定义 API、按量付费的用户",
   "plans.plan.hobby.title": "自助版",
-  "plans.plan.premium.desc": "为频繁使用 AI 的专业用户设计",
+  "plans.plan.premium.desc": "适合频繁使用 AI 的专业用户",
   "plans.plan.premium.title": "进阶版",
   "plans.plan.starter.desc": "适合偶尔使用 AI 的用户",
   "plans.plan.starter.title": "基础版",

--- a/packages/locales/src/default/subscription.ts
+++ b/packages/locales/src/default/subscription.ts
@@ -461,7 +461,7 @@ export default {
   'plans.plan.free.title': 'Free',
   'plans.plan.hobby.desc': 'For users with their own API who pay as they go',
   'plans.plan.hobby.title': 'Hobby',
-  'plans.plan.premium.desc': 'Designed for professional users who frequently use AI',
+  'plans.plan.premium.desc': 'For professional users who frequently use AI',
   'plans.plan.premium.title': 'Premium',
   'plans.plan.starter.desc': 'For occasional AI users',
   'plans.plan.starter.title': 'Starter',


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A — requested directly during product UI review.

#### 🔀 Description of Change

- Remove the inconsistent “Designed” prefix from the Premium plan description.
- Keep the English source, en-US preview, and zh-CN preview copy aligned.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

- `bun run check --lint --test lobehub/packages/locales/src/default/subscription.ts lobehub/locales/en-US/subscription.json lobehub/locales/zh-CN/subscription.json`

#### 📸 Screenshots / Videos

N/A — copy-only change; the related cloud PR contains the UI verification context.

#### 📝 Additional Information

- `bun run i18n` was attempted, but the local translation step requires an OpenAI API key that is not available in this environment. It left no unrelated file changes. This PR remains a draft until the remaining locales are regenerated.
