### PR TITLE
🐛 fix(auth): preserve OIDC consent form values

### DIFF
--- a/e2e/src/steps/auth/oidc-device-flow.steps.ts
+++ b/e2e/src/steps/auth/oidc-device-flow.steps.ts
@@ -148,26 +148,27 @@ When('用户授权该设备', async function (this: CustomWorld) {
 });
 
 Then('应进入 OIDC 授权交互', async function (this: CustomWorld) {
-  await expect(
-    this.page.locator('form[action="/oidc/consent"] button[name="consent"][value="accept"]'),
-  ).toBeVisible();
+  const consentForm = this.page.locator('form[action="/oidc/consent"]');
+
+  await expect(consentForm.getByTestId('oauth-consent-accept')).toBeVisible();
+  await expect(consentForm.locator('input[name="consent"]')).toHaveValue('accept');
 });
 
 When('用户同意 CLI 的权限请求', async function (this: CustomWorld) {
-  const acceptButton = this.page.locator(
-    'form[action="/oidc/consent"] button[name="consent"][value="accept"]',
-  );
-  const denyButton = this.page.locator(
-    'form[action="/oidc/consent"] button[name="consent"][value="deny"]',
-  );
+  const consentForm = this.page.locator('form[action="/oidc/consent"]');
+  const consentInput = consentForm.locator('input[name="consent"]');
+  const acceptButton = consentForm.getByTestId('oauth-consent-accept');
+  const denyButton = consentForm.getByTestId('oauth-consent-deny');
 
   // Some provider sessions require an account confirmation before the consent prompt.
   // Advance that interaction when present, then require the explicit allow/deny prompt.
   if (!(await denyButton.isVisible())) {
+    await expect(consentInput).toHaveValue('accept');
     await acceptButton.click();
     await expect(denyButton).toBeVisible();
   }
 
+  await expect(consentInput).toHaveValue('accept');
   await expect(acceptButton).toBeEnabled();
   await acceptButton.click();
   await expect(this.page).toHaveURL(/\/oauth\/device\/success(?:\?|$)/);

--- a/src/features/Auth/OAuthConsent/Consent/index.tsx
+++ b/src/features/Auth/OAuthConsent/Consent/index.tsx
@@ -2,7 +2,7 @@
 
 import { Block, Flexbox, Text } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
-import React, { memo, useState } from 'react';
+import React, { memo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import AuthCard from '@/features/AuthCard';
@@ -32,11 +32,12 @@ const ConsentClient = memo<ClientProps>(({ uid, clientId, scopes, clientMetadata
   const { t } = useTranslation('oauth');
 
   const [isLoading, setIsLoading] = useState(false);
+  const consentInputRef = useRef<HTMLInputElement>(null);
 
   const clientDisplayName = clientMetadata?.clientName || clientId;
 
   if (BUILTIN_CLIENTS.has(clientId)) {
-    return <BuiltinConsent uid={clientId} />;
+    return <BuiltinConsent uid={uid} />;
   }
 
   return (
@@ -52,21 +53,29 @@ const ConsentClient = memo<ClientProps>(({ uid, clientId, scopes, clientMetadata
         footer={
           <form action="/oidc/consent" method="post" style={{ width: '100%' }}>
             <input name="uid" type="hidden" value={uid} />
+            <input defaultValue="accept" name="consent" ref={consentInputRef} type="hidden" />
             <Flexbox gap={12}>
               <Button
+                data-testid="oauth-consent-accept"
                 htmlType="submit"
                 loading={isLoading}
-                name="consent"
                 size={'large'}
                 type="primary"
-                value="accept"
                 onClick={() => {
+                  if (consentInputRef.current) consentInputRef.current.value = 'accept';
                   setIsLoading(true);
                 }}
               >
                 {t('consent.buttons.accept')}
               </Button>
-              <Button htmlType="submit" name="consent" size={'large'} value="deny">
+              <Button
+                data-testid="oauth-consent-deny"
+                htmlType="submit"
+                size={'large'}
+                onClick={() => {
+                  if (consentInputRef.current) consentInputRef.current.value = 'deny';
+                }}
+              >
                 {t('consent.buttons.deny')}
               </Button>
             </Flexbox>

--- a/src/features/Auth/OAuthConsent/Login.tsx
+++ b/src/features/Auth/OAuthConsent/Login.tsx
@@ -51,17 +51,16 @@ const LoginConfirmClient = memo<LoginConfirmProps>(({ uid, clientMetadata }) => 
           >
             {/* Adjust action URL */}
             <input name="uid" type="hidden" value={uid} />
-            <input name="choice" type="hidden" value={'accept'} />
+            <input name="consent" type="hidden" value="accept" />
             {/* Single confirmation button */}
             <Button
               block
+              data-testid="oauth-consent-accept"
               disabled={!isUserStateInit}
               htmlType="submit"
               loading={isLoading}
-              name="consent"
               size="large"
               type="primary"
-              value="accept"
             >
               {buttonText}
             </Button>


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-11555

#### 🔀 Description of Change

- Submit the OIDC consent decision through an explicit hidden input because the Base UI button does not provide native `name` / `value` form semantics.
- Forward the authorization request `uid` to built-in consent instead of the client identifier.
- Add stable consent test IDs and update the device-flow Cucumber selectors.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check`
- `bun run check --type`
- Complete the local OAuth authorization flow and confirm it reaches `/oauth/callback/success`.

#### 📸 Screenshots / Videos

No visual changes.

#### 📝 Additional Information

Discovered while validating the full Cloud/Desktop development environment. The complete `@oidc` Cucumber scenario was not run because it mutates test-user OIDC records; the form behavior was verified through the real local authorization flow.