### PR TITLE
✨ feat: add SPA and desktop runtime instrumentation hooks

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -51,6 +51,7 @@
     "node-screenshots": "^0.2.8"
   },
   "devDependencies": {
+    "@base-ui/react": "^1.6.0",
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",
     "@electron-toolkit/eslint-config-ts": "^3.1.0",
     "@electron-toolkit/preload": "^3.0.2",

--- a/apps/desktop/src/overlay/entry.tsx
+++ b/apps/desktop/src/overlay/entry.tsx
@@ -1,6 +1,5 @@
-import { createRoot } from 'react-dom/client';
-
+import { createSPARoot } from '../../../../src/spa/runtime';
 import ScreenCaptureOverlay from './ScreenCaptureOverlay';
 
-const root = createRoot(document.getElementById('root')!);
+const root = createSPARoot(document.getElementById('root')!);
 root.render(<ScreenCaptureOverlay />);

--- a/apps/desktop/vite.main.config.ts
+++ b/apps/desktop/vite.main.config.ts
@@ -1,10 +1,11 @@
 import path from 'node:path';
 
-import { defineConfig } from 'vite';
+import { defineConfig, type UserConfig } from 'vite';
 
 import { externalRuntimeModules } from './external-runtime-deps.config.mjs';
 import { getNativeExternalDependencies } from './native-deps.config.mjs';
 import {
+  applyDesktopViteConfigExtension,
   loadDesktopEnv,
   MAIN_NODE_TARGET,
   mainProcessAlias,
@@ -12,7 +13,8 @@ import {
   processEnvDefine,
 } from './vite.shared';
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(async (env) => {
+  const { mode } = env;
   loadDesktopEnv(mode);
 
   const isDev = mode === 'development';
@@ -24,7 +26,7 @@ export default defineConfig(({ mode }) => {
   console.info(`[vite.main.config.ts] Detected UPDATE_CHANNEL: ${updateChannel}`);
   console.info(`[vite.main.config.ts] Cloud desktop build: ${isCloudDesktopBuild}`);
 
-  return {
+  const config = {
     build: {
       assetsDir: 'chunks',
       copyPublicDir: false,
@@ -112,5 +114,7 @@ export default defineConfig(({ mode }) => {
     },
     root: __dirname,
     ssr: { noExternal: true },
-  };
+  } satisfies UserConfig;
+
+  return applyDesktopViteConfigExtension('main', config, env);
 });

--- a/apps/desktop/vite.preload.config.ts
+++ b/apps/desktop/vite.preload.config.ts
@@ -1,8 +1,9 @@
 import path from 'node:path';
 
-import { defineConfig } from 'vite';
+import { defineConfig, type UserConfig } from 'vite';
 
 import {
+  applyDesktopViteConfigExtension,
   loadDesktopEnv,
   MAIN_NODE_TARGET,
   mainProcessAlias,
@@ -10,12 +11,13 @@ import {
   processEnvDefine,
 } from './vite.shared';
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(async (env) => {
+  const { mode } = env;
   loadDesktopEnv(mode);
 
   const isDev = mode === 'development';
 
-  return {
+  const config = {
     build: {
       assetsDir: 'chunks',
       copyPublicDir: false,
@@ -49,5 +51,7 @@ export default defineConfig(({ mode }) => {
         mainFields: ['browser', 'module', 'jsnext:main', 'jsnext'],
       },
     },
-  };
+  } satisfies UserConfig;
+
+  return applyDesktopViteConfigExtension('preload', config, env);
 });

--- a/apps/desktop/vite.renderer.config.ts
+++ b/apps/desktop/vite.renderer.config.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
-import type { PluginOption, ViteDevServer } from 'vite';
+import type { PluginOption, UserConfig, ViteDevServer } from 'vite';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
@@ -13,6 +13,7 @@ import {
   sharedRollupOutput,
 } from '../../plugins/vite/sharedRendererConfig';
 import {
+  applyDesktopViteConfigExtension,
   CLOUD_ROOT_DIR,
   desktopPackageJson,
   DEV_VITE_PORT,
@@ -182,10 +183,11 @@ const cloudTsconfigPathsPlugin = () =>
     name: 'lobe-cloud-desktop-tsconfig-paths',
   }) satisfies PluginOption;
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(async (env) => {
+  const { mode } = env;
   loadDesktopEnv(mode);
 
-  return {
+  const config = {
     // Absolute base: relative asset URLs break in the popup window because its
     // SPA URL (`/popup/agent/:aid/:tid`) is deep enough that relative resolution
     // lands at `/popup/assets/...` instead of the actual `/assets/...`. Our
@@ -243,5 +245,7 @@ export default defineConfig(({ mode }) => {
       port: DEV_VITE_PORT,
       strictPort: true,
     },
-  };
+  } satisfies UserConfig;
+
+  return applyDesktopViteConfigExtension('renderer', config, env);
 });

--- a/apps/desktop/vite.shared.test.ts
+++ b/apps/desktop/vite.shared.test.ts
@@ -1,0 +1,42 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { applyDesktopViteConfigExtension } from './vite.shared';
+
+describe('applyDesktopViteConfigExtension', () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await Promise.all(
+      temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true })),
+    );
+  });
+
+  it('loads named exports from TypeScript extensions through the Vite module runner', async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'lobe-desktop-vite-extension-'));
+    const extensionPath = path.join(directory, 'extension.mts');
+    temporaryDirectories.push(directory);
+
+    await writeFile(
+      extensionPath,
+      `export const extendDesktopViteConfig = ({ config, target }) => ({
+  ...config,
+  define: { __TEST_TARGET__: JSON.stringify(target) },
+});
+`,
+    );
+    vi.stubEnv('LOBE_DESKTOP_VITE_CONFIG_EXTENSION', extensionPath);
+
+    const config = await applyDesktopViteConfigExtension(
+      'main',
+      {},
+      { command: 'build', mode: 'development' },
+    );
+
+    expect(config.define).toEqual({ __TEST_TARGET__: '"main"' });
+  });
+});

--- a/apps/desktop/vite.shared.ts
+++ b/apps/desktop/vite.shared.ts
@@ -1,9 +1,10 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { builtinModules } from 'node:module';
 import path from 'node:path';
 
 import dotenv from 'dotenv';
-import { loadEnv } from 'vite';
+import type { ConfigEnv, UserConfig } from 'vite';
+import { loadEnv, runnerImport } from 'vite';
 
 export const DESKTOP_DIR = __dirname;
 export const ROOT_DIR = path.resolve(__dirname, '../..');
@@ -42,6 +43,58 @@ export const processEnvDefine = {
   'global.process.env': 'global.process.env',
   'globalThis.process.env': 'globalThis.process.env',
   'process.env': 'process.env',
+};
+
+export type DesktopViteTarget = 'main' | 'preload' | 'renderer';
+
+interface DesktopViteConfigExtensionContext {
+  config: UserConfig;
+  env: ConfigEnv;
+  target: DesktopViteTarget;
+}
+
+export type DesktopViteConfigExtension = (
+  context: DesktopViteConfigExtensionContext,
+) => Promise<UserConfig> | UserConfig;
+
+interface DesktopViteConfigExtensionModule {
+  extendDesktopViteConfig?: DesktopViteConfigExtension;
+}
+
+export const applyDesktopViteConfigExtension = async (
+  target: DesktopViteTarget,
+  config: UserConfig,
+  env: ConfigEnv,
+): Promise<UserConfig> => {
+  const configuredPath = process.env.LOBE_DESKTOP_VITE_CONFIG_EXTENSION;
+  const extensionPath = configuredPath
+    ? path.resolve(process.cwd(), configuredPath)
+    : process.env.CLOUD_DESKTOP === '1'
+      ? path.resolve(CLOUD_ROOT_DIR, 'scripts/cloud-desktop/vite.config.mts')
+      : undefined;
+
+  if (!extensionPath) return config;
+
+  if (!existsSync(extensionPath)) {
+    if (configuredPath) {
+      throw new Error(`Desktop Vite config extension does not exist: ${extensionPath}`);
+    }
+
+    return config;
+  }
+
+  const { module: extensionModule } = await runnerImport<DesktopViteConfigExtensionModule>(
+    extensionPath,
+    { configFile: false, root: path.dirname(extensionPath) },
+  );
+
+  if (typeof extensionModule.extendDesktopViteConfig !== 'function') {
+    throw new TypeError(
+      `Desktop Vite config extension must export extendDesktopViteConfig: ${extensionPath}`,
+    );
+  }
+
+  return extensionModule.extendDesktopViteConfig({ config, env, target });
 };
 
 export const mainProcessAlias = {

--- a/src/components/BootErrorBoundary/index.test.tsx
+++ b/src/components/BootErrorBoundary/index.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { useEffect, useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import BootErrorBoundary from './index';
+
+const ThrowAfterMount = () => {
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    setFailed(true);
+  }, []);
+
+  if (failed) throw new Error('boot failure');
+  return null;
+};
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('BootErrorBoundary', () => {
+  it('reports errors through the optional callback', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onError = vi.fn(async () => {});
+
+    render(
+      <BootErrorBoundary fallback={<div>boot fallback</div>} onError={onError}>
+        <ThrowAfterMount />
+      </BootErrorBoundary>,
+    );
+
+    await waitFor(() => expect(onError).toHaveBeenCalledOnce());
+    expect(screen.getByText('boot fallback')).toBeInTheDocument();
+  });
+
+  it('handles rejected reporting callbacks after the app has mounted', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const reportError = new Error('reporting failed');
+    const onError = vi.fn(async () => {
+      throw reportError;
+    });
+
+    render(
+      <BootErrorBoundary fallback={<div>boot fallback</div>} onError={onError}>
+        <ThrowAfterMount />
+      </BootErrorBoundary>,
+    );
+
+    await waitFor(() =>
+      expect(warning).toHaveBeenCalledWith(
+        'BootErrorBoundary onError callback failed',
+        reportError,
+      ),
+    );
+  });
+});

--- a/src/components/BootErrorBoundary/index.tsx
+++ b/src/components/BootErrorBoundary/index.tsx
@@ -3,7 +3,7 @@
 import { type ErrorInfo, type ReactNode } from 'react';
 import { Component } from 'react';
 
-interface BootErrorBoundaryProps {
+export interface BootErrorBoundaryProps {
   children: ReactNode;
   fallback?: ReactNode;
   /**
@@ -11,6 +11,7 @@ interface BootErrorBoundaryProps {
    * Defaults to 1 to avoid reload loops.
    */
   maxBootReloads?: number;
+  onError?: (error: Error, errorInfo: ErrorInfo) => Promise<void> | void;
 }
 
 interface BootErrorBoundaryState {
@@ -44,9 +45,33 @@ class BootErrorBoundary extends Component<BootErrorBoundaryProps, BootErrorBound
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error('Unexpected boot error captured by BootErrorBoundary', error, errorInfo);
 
-    if (!this.hasBooted && this.tryHardReload()) {
+    const shouldHardReload = !this.hasBooted;
+    let errorReport: Promise<void> | void = undefined;
+
+    try {
+      errorReport = this.props.onError?.(error, errorInfo);
+    } catch (reportError) {
+      if (__DEV__) {
+        console.warn('BootErrorBoundary onError callback failed', reportError);
+      }
+    }
+
+    if (errorReport) {
+      const settledReport = errorReport.catch((reportError) => {
+        if (__DEV__) {
+          console.warn('BootErrorBoundary onError callback failed', reportError);
+        }
+      });
+
+      if (shouldHardReload) {
+        void settledReport.finally(() => this.tryHardReload());
+      } else {
+        void settledReport;
+      }
       return;
     }
+
+    if (shouldHardReload) this.tryHardReload();
   }
 
   public render() {

--- a/src/spa/entry.auth.tsx
+++ b/src/spa/entry.auth.tsx
@@ -1,17 +1,16 @@
 import '../initialize';
 
-import { createRoot } from 'react-dom/client';
-import { createBrowserRouter } from 'react-router';
 import { RouterProvider } from 'react-router/dom';
 
 import BootErrorBoundary from '@/components/BootErrorBoundary';
 import NextThemeProvider from '@/layout/GlobalProvider/NextThemeProvider';
 
 import { authRoutes } from './router/authRouter.config';
+import { createSPABrowserRouter, createSPARoot } from './runtime';
 
-const router = createBrowserRouter(authRoutes);
+const router = createSPABrowserRouter(authRoutes);
 
-createRoot(document.getElementById('root')!).render(
+createSPARoot(document.getElementById('root')!).render(
   <BootErrorBoundary>
     <NextThemeProvider>
       <RouterProvider router={router} />

--- a/src/spa/entry.desktop.tsx
+++ b/src/spa/entry.desktop.tsx
@@ -1,6 +1,5 @@
 import '../initialize';
 
-import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router/dom';
 
 import NextThemeProvider from '@/layout/GlobalProvider/NextThemeProvider';
@@ -9,13 +8,14 @@ import { createAppRouter } from '@/utils/router';
 
 import { startAppInitialization } from './initialize/bootstrap';
 import { desktopRoutes } from './router/desktopRouter.config';
+import { createSPARoot } from './runtime';
 
 bootTiming.mark('bundle-eval');
 startAppInitialization();
 
 const router = createAppRouter(desktopRoutes);
 
-createRoot(document.getElementById('root')!).render(
+createSPARoot(document.getElementById('root')!).render(
   <NextThemeProvider>
     <RouterProvider router={router} />
   </NextThemeProvider>,

--- a/src/spa/entry.mobile.tsx
+++ b/src/spa/entry.mobile.tsx
@@ -1,6 +1,5 @@
 import '../initialize';
 
-import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router/dom';
 
 import NextThemeProvider from '@/layout/GlobalProvider/NextThemeProvider';
@@ -9,13 +8,14 @@ import { createAppRouter } from '@/utils/router';
 
 import { startAppInitialization } from './initialize/bootstrap';
 import { mobileRoutes } from './router/mobileRouter.config';
+import { createSPARoot } from './runtime';
 
 bootTiming.mark('bundle-eval');
 startAppInitialization();
 
 const router = createAppRouter(mobileRoutes);
 
-createRoot(document.getElementById('root')!).render(
+createSPARoot(document.getElementById('root')!).render(
   <NextThemeProvider>
     <RouterProvider router={router} />
   </NextThemeProvider>,

--- a/src/spa/entry.popup.tsx
+++ b/src/spa/entry.popup.tsx
@@ -1,6 +1,5 @@
 import '../initialize';
 
-import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router/dom';
 
 import NextThemeProvider from '@/layout/GlobalProvider/NextThemeProvider';
@@ -9,13 +8,14 @@ import { createAppRouter } from '@/utils/router';
 
 import { startAppInitialization } from './initialize/bootstrap';
 import { popupRoutes } from './router/popupRouter.config';
+import { createSPARoot } from './runtime';
 
 bootTiming.mark('bundle-eval');
 startAppInitialization();
 
 const router = createAppRouter(popupRoutes);
 
-createRoot(document.getElementById('root')!).render(
+createSPARoot(document.getElementById('root')!).render(
   <NextThemeProvider>
     <RouterProvider router={router} />
   </NextThemeProvider>,

--- a/src/spa/entry.web.tsx
+++ b/src/spa/entry.web.tsx
@@ -1,6 +1,5 @@
 import '../initialize';
 
-import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router/dom';
 
 import BootErrorBoundary from '@/components/BootErrorBoundary';
@@ -10,6 +9,7 @@ import { createAppRouter } from '@/utils/router';
 
 import { startAppInitialization } from './initialize/bootstrap';
 import { desktopRoutes } from './router/desktopRouter.config';
+import { createSPARoot } from './runtime';
 
 bootTiming.mark('bundle-eval');
 startAppInitialization();
@@ -22,7 +22,7 @@ const basename =
 
 const router = createAppRouter(desktopRoutes, { basename });
 
-createRoot(document.getElementById('root')!).render(
+createSPARoot(document.getElementById('root')!).render(
   <BootErrorBoundary>
     <NextThemeProvider>
       <RouterProvider router={router} />

--- a/src/spa/runtime.test.ts
+++ b/src/spa/runtime.test.ts
@@ -1,0 +1,46 @@
+import { createBrowserRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  configureSPARuntimeInstrumentation,
+  createSPABrowserRouter,
+  createSPARoot,
+} from './runtime';
+
+const { createRoot } = vi.hoisted(() => ({ createRoot: vi.fn() }));
+
+vi.mock('react-dom/client', () => ({ createRoot }));
+
+describe('SPA runtime instrumentation', () => {
+  it('applies registered router and React root instrumentation', () => {
+    const root = { render: vi.fn(), unmount: vi.fn() };
+    const rootErrorHandler = vi.fn();
+    let routerCalls = 0;
+    const instrumentedCreateBrowserRouter: typeof createBrowserRouter = (...args) => {
+      routerCalls += 1;
+      return createBrowserRouter(...args);
+    };
+
+    createRoot.mockReturnValue(root);
+    configureSPARuntimeInstrumentation({
+      createBrowserRouter: instrumentedCreateBrowserRouter,
+      rootOptions: {
+        onCaughtError: rootErrorHandler,
+        onRecoverableError: rootErrorHandler,
+        onUncaughtError: rootErrorHandler,
+      },
+    });
+
+    const container = document.createElement('div');
+    expect(createSPARoot(container)).toBe(root);
+    expect(createRoot).toHaveBeenCalledWith(container, {
+      onCaughtError: rootErrorHandler,
+      onRecoverableError: rootErrorHandler,
+      onUncaughtError: rootErrorHandler,
+    });
+
+    const router = createSPABrowserRouter([{ element: null, path: '/' }]);
+    expect(router).toBeDefined();
+    expect(routerCalls).toBe(1);
+  });
+});

--- a/src/spa/runtime.ts
+++ b/src/spa/runtime.ts
@@ -1,0 +1,29 @@
+import type { RootOptions } from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
+import { createBrowserRouter } from 'react-router';
+
+type BrowserRouterFactory = typeof createBrowserRouter;
+
+export interface SPARuntimeInstrumentation {
+  createBrowserRouter?: BrowserRouterFactory;
+  rootOptions?: RootOptions;
+}
+
+let runtimeInstrumentation: SPARuntimeInstrumentation = {};
+
+export const configureSPARuntimeInstrumentation = (instrumentation: SPARuntimeInstrumentation) => {
+  runtimeInstrumentation = {
+    ...runtimeInstrumentation,
+    ...instrumentation,
+    rootOptions: {
+      ...runtimeInstrumentation.rootOptions,
+      ...instrumentation.rootOptions,
+    },
+  };
+};
+
+export const createSPABrowserRouter = (...args: Parameters<BrowserRouterFactory>) =>
+  (runtimeInstrumentation.createBrowserRouter ?? createBrowserRouter)(...args);
+
+export const createSPARoot = (container: Parameters<typeof createRoot>[0]) =>
+  createRoot(container, runtimeInstrumentation.rootOptions);

--- a/src/utils/router.tsx
+++ b/src/utils/router.tsx
@@ -5,7 +5,7 @@ import * as m from 'motion/react-m';
 import { type ComponentType, type ReactElement } from 'react';
 import { lazy, memo, Suspense, useLayoutEffect } from 'react';
 import type { RouteObject } from 'react-router';
-import { createBrowserRouter, Navigate, Outlet, useNavigate, useRouteError } from 'react-router';
+import { Navigate, Outlet, useNavigate, useRouteError } from 'react-router';
 
 import BusinessGlobalProvider from '@/business/client/BusinessGlobalProvider';
 import ErrorCapture from '@/components/Error';
@@ -13,6 +13,7 @@ import Loading from '@/components/Loading/BrandTextLoading';
 import { useIsDark } from '@/hooks/useIsDark';
 import SPAGlobalProvider from '@/layout/SPAGlobalProvider';
 import AppLayer from '@/spa/AppLayer';
+import { createSPABrowserRouter } from '@/spa/runtime';
 import { useGlobalStore } from '@/store/global';
 import { createNavigationRef } from '@/store/global/initialState';
 import { isChunkLoadError, notifyChunkError } from '@/utils/chunkError';
@@ -161,7 +162,7 @@ RouterRoot.displayName = 'RouterRoot';
  * );
  */
 export function createAppRouter(routes: RouteObject[], options?: CreateAppRouterOptions) {
-  return createBrowserRouter(
+  return createSPABrowserRouter(
     [
       {
         children: routes,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-11555

#### 🔀 Description of Change

- Add a no-op-by-default SPA runtime instrumentation registry for React root options and browser-router factories.
- Route every SPA entry, including the desktop overlay, through the shared runtime helpers.
- Allow `BootErrorBoundary` callers to report an error asynchronously before the existing one-time hard reload.
- Add a generic Desktop Vite config extension hook for main, preload, and renderer targets.
- Declare the overlay's direct `@base-ui/react` dependency.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check` — 20 related tests passed.
- `bun run check --type` — full type check passed.
- Load a TypeScript Desktop Vite extension and confirm it is applied to main, preload, and renderer builds.
- Start the normal OSS SPA/Desktop paths without registering instrumentation and confirm the original React/router behavior remains unchanged.

#### 📸 Screenshots / Videos

No visual changes.

#### 📝 Additional Information

The public runtime remains vendor-neutral: no monitoring SDK or service-specific implementation is added here. Consumers opt in through the generic runtime and Vite extension contracts; default OSS behavior remains unchanged.