### PR TITLE
🐛 fix: avoid whole-file Codex diffs for missing snapshots

### DIFF
--- a/packages/heterogeneous-agents/src/spawn/codexFileChangeTracker.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/codexFileChangeTracker.test.ts
@@ -114,6 +114,45 @@ describe('CodexFileChangeTracker', () => {
     expect(enriched.item.changes?.[0]).not.toHaveProperty('diffText');
   });
 
+  it('does not synthesize a whole-file diff when an update snapshot says the file is missing', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'codex-file-change-tracker-'));
+    tempDirs.push(dir);
+
+    const updatePath = path.join(dir, 'large-existing.md');
+    const tracker = new CodexFileChangeTracker();
+
+    await tracker.track({
+      item: {
+        changes: [{ kind: 'update', path: updatePath }],
+        id: 'item_missing_file_snapshot',
+        type: 'file_change',
+      },
+      type: 'item.started',
+    });
+
+    const originalContent = Array.from({ length: 1200 }, (_, index) => `line ${index + 1}`).join(
+      '\n',
+    );
+    await writeFile(updatePath, `${originalContent}\nnew 1\nnew 2\nnew 3\nnew 4\nnew 5\n`, 'utf8');
+
+    const enriched = await tracker.track({
+      item: {
+        changes: [{ kind: 'update', linesAdded: 5, linesDeleted: 0, path: updatePath }],
+        id: 'item_missing_file_snapshot',
+        type: 'file_change',
+      },
+      type: 'item.completed',
+    });
+
+    expect(enriched.item).toMatchObject({
+      changes: [{ kind: 'update', linesAdded: 5, linesDeleted: 0, path: updatePath }],
+      linesAdded: 5,
+      linesDeleted: 0,
+    });
+    expect(enriched.item).not.toHaveProperty('diffText');
+    expect(enriched.item.changes?.[0]).not.toHaveProperty('diffText');
+  });
+
   it('treats rename changes as metadata-only and keeps line stats at zero', async () => {
     const dir = await mkdtemp(path.join(tmpdir(), 'codex-file-change-tracker-'));
     tempDirs.push(dir);

--- a/packages/heterogeneous-agents/src/spawn/codexFileChangeTracker.ts
+++ b/packages/heterogeneous-agents/src/spawn/codexFileChangeTracker.ts
@@ -149,16 +149,16 @@ const computeFileChangeDiff = async (
     return buildFileChangeDiff(filePath, previousContent, '');
   }
 
-  if (!snapshot) {
+  // An update diff is only trustworthy when the pre-change file was read successfully.
+  // Treating a missing or unreadable snapshot as empty content turns a small edit into a
+  // synthetic whole-file addition (for example, +5 lines can be reported as +1205).
+  if (!snapshot?.exists || snapshot.content === undefined) {
     return {
       linesAdded: change.linesAdded ?? 0,
       linesDeleted: change.linesDeleted ?? 0,
     };
   }
 
-  if (!snapshot?.exists && !current.exists) return { linesAdded: 0, linesDeleted: 0 };
-
-  if (snapshot?.exists && snapshot.content === undefined) return { linesAdded: 0, linesDeleted: 0 };
   if (current.exists && current.content === undefined) return { linesAdded: 0, linesDeleted: 0 };
 
   return buildFileChangeDiff(filePath, previousContent, nextContent);


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Follow-up to #16823.

#### 🔀 Description of Change

Prevents Codex file-change tracking from synthesizing a whole-file addition when an update starts with a snapshot that exists as tracker state but reports the file as missing or unreadable.

Previously, the missing snapshot content was treated as an empty string, so a five-line edit to a 1,200-line file could be rendered as `+1205 -0`. Updates now require a successfully read pre-change snapshot before generating a filesystem diff; otherwise the tracker preserves Codex upstream line statistics and omits the untrustworthy diff body.

Adds a regression test matching the observed sequence: missing file at `item.started`, a 1,205-line file at `item.completed`, and upstream stats of `+5 -0`.

#### 🧪 How to Test

```bash
bun run --cwd packages/heterogeneous-agents test --run src/spawn/codexFileChangeTracker.test.ts
```

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

Not applicable; behavior is covered by the tracker regression test.

#### 📝 Additional Information

This is the safety fallback for cases where a trustworthy pre-edit snapshot is unavailable. A future enhancement can consume Codex native unified patches directly when the protocol exposes them to the file-change pipeline.