### PR TITLE
🐛 fix(group): stabilize member order & add drag-to-sort UI

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -264,6 +264,8 @@
   "groupSidebar.members.orchestrator": "Orchestrator",
   "groupSidebar.members.orchestratorThinking": "Orchestrator is thinking...",
   "groupSidebar.members.removeMember": "Remove Member",
+  "groupSidebar.members.sortMember": "Sort Members",
+  "groupSidebar.members.sortModalTitle": "Sort Members",
   "groupSidebar.members.stopOrchestrator": "Stop",
   "groupSidebar.members.triggerOrchestrator": "Start",
   "groupSidebar.tabs.host": "Orchestrator",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -264,6 +264,8 @@
   "groupSidebar.members.orchestrator": "主持人",
   "groupSidebar.members.orchestratorThinking": "主持人思考中…",
   "groupSidebar.members.removeMember": "移除成员",
+  "groupSidebar.members.sortMember": "成员排序",
+  "groupSidebar.members.sortModalTitle": "成员排序",
   "groupSidebar.members.stopOrchestrator": "停止思考",
   "groupSidebar.members.triggerOrchestrator": "开始群聊",
   "groupSidebar.tabs.host": "主持人",

--- a/packages/database/src/models/__tests__/chatGroup.test.ts
+++ b/packages/database/src/models/__tests__/chatGroup.test.ts
@@ -1120,6 +1120,62 @@ describe('ChatGroupModel', () => {
       expect(result[1]?.agentId).toBe('agent-order-2'); // order: 2
       expect(result[2]?.agentId).toBe('agent-order-10'); // order: 10
     });
+
+    it('should be deterministic for legacy rows that tie on both order and createdAt', async () => {
+      // A single legacy multi-row insert stamps every row with the same
+      // `order` (default 0) AND the same `createdAt`, so those two keys alone
+      // still leave the order ambiguous. `agentId` (part of the PK) is the
+      // final guaranteed-unique tiebreak that keeps the roster from shuffling.
+      const sameCreatedAt = new Date('2024-01-01T00:00:00.000Z');
+      await serverDB.transaction(async (trx) => {
+        await trx.insert(chatGroups).values({
+          id: 'legacy-tie-group',
+          userId,
+          title: 'Legacy Tie Group',
+        });
+
+        await trx.insert(agentsTable).values([
+          { id: 'legacy-c', userId, title: 'Legacy C' },
+          { id: 'legacy-a', userId, title: 'Legacy A' },
+          { id: 'legacy-b', userId, title: 'Legacy B' },
+        ]);
+
+        await trx.insert(chatGroupsAgents).values([
+          {
+            chatGroupId: 'legacy-tie-group',
+            agentId: 'legacy-c',
+            userId,
+            order: 0,
+            createdAt: sameCreatedAt,
+          },
+          {
+            chatGroupId: 'legacy-tie-group',
+            agentId: 'legacy-a',
+            userId,
+            order: 0,
+            createdAt: sameCreatedAt,
+          },
+          {
+            chatGroupId: 'legacy-tie-group',
+            agentId: 'legacy-b',
+            userId,
+            order: 0,
+            createdAt: sameCreatedAt,
+          },
+        ]);
+      });
+
+      const first = toRelationAgents(await chatGroupModel.getGroupAgents('legacy-tie-group')).map(
+        (a) => a.agentId,
+      );
+      const second = toRelationAgents(await chatGroupModel.getGroupAgents('legacy-tie-group')).map(
+        (a) => a.agentId,
+      );
+
+      // Falls back to agentId ascending, and returns the same order every time.
+      expect(first).toEqual(['legacy-a', 'legacy-b', 'legacy-c']);
+      expect(second).toEqual(first);
+    });
   });
 
   describe('getEnabledGroupAgents', () => {

--- a/packages/database/src/models/__tests__/chatGroup.test.ts
+++ b/packages/database/src/models/__tests__/chatGroup.test.ts
@@ -542,6 +542,44 @@ describe('ChatGroupModel', () => {
       expect(result.existing).toHaveLength(0);
     });
 
+    it('should append new members after the current max order (never collapse to 0)', async () => {
+      await serverDB.transaction(async (trx) => {
+        await trx.insert(chatGroups).values({
+          id: 'order-add-group',
+          userId,
+          title: 'Order Add Group',
+        });
+
+        await trx.insert(agentsTable).values([
+          { id: 'oa-existing', userId, title: 'Existing' },
+          { id: 'oa-1', userId, title: 'A1' },
+          { id: 'oa-2', userId, title: 'A2' },
+          { id: 'oa-3', userId, title: 'A3' },
+        ]);
+
+        // Existing member sitting at the default order 0.
+        await trx.insert(chatGroupsAgents).values({
+          chatGroupId: 'order-add-group',
+          agentId: 'oa-existing',
+          userId,
+          order: 0,
+        });
+      });
+
+      // First batch appends after max existing order (0) → 1, 2.
+      const first = await chatGroupModel.addAgentsToGroup('order-add-group', ['oa-1', 'oa-2']);
+      expect(first.added.map((a) => a.order)).toEqual([1, 2]);
+
+      // Second batch continues after the new max (2) → 3.
+      const second = await chatGroupModel.addAgentsToGroup('order-add-group', ['oa-3']);
+      expect(second.added.map((a) => a.order)).toEqual([3]);
+
+      // Every member ends up with a unique order → the roster no longer shuffles.
+      const roster = await chatGroupModel.getGroupAgents('order-add-group');
+      const orders = roster.map((r) => r.order);
+      expect(new Set(orders).size).toBe(orders.length);
+    });
+
     it('should skip existing agents and only add new ones', async () => {
       // Create test data
       await serverDB.transaction(async (trx) => {

--- a/packages/database/src/models/chatGroup.ts
+++ b/packages/database/src/models/chatGroup.ts
@@ -84,7 +84,7 @@ export class ChatGroupModel {
       .from(chatGroupsAgents)
       .innerJoin(agents, eq(chatGroupsAgents.agentId, agents.id))
       .where(and(inArray(chatGroupsAgents.chatGroupId, groupIds), this.memberAgentVisibility()))
-      .orderBy(chatGroupsAgents.order);
+      .orderBy(chatGroupsAgents.order, chatGroupsAgents.createdAt);
 
     for (const { avatar, backgroundColor, chatGroupId, slug } of rows) {
       const list = map.get(chatGroupId) ?? [];
@@ -168,7 +168,7 @@ export class ChatGroupModel {
     if (!group) return null;
 
     const agents = await this.db.query.chatGroupsAgents.findMany({
-      orderBy: [chatGroupsAgents.order],
+      orderBy: [chatGroupsAgents.order, chatGroupsAgents.createdAt],
       where: and(
         eq(chatGroupsAgents.chatGroupId, groupId),
         this.agentsOwnership(),
@@ -374,10 +374,18 @@ export class ChatGroupModel {
       return { added: [], existing: existingIds };
     }
 
-    const newAgents: NewChatGroupAgent[] = newAgentIds.map((agentId) => ({
+    // Append new members after the current highest order so an incremental add
+    // never collapses everyone to the default `order = 0` (which would make the
+    // roster re-shuffle on every refetch). Supervisor rows sit at `order = -1`,
+    // so a group holding only a supervisor yields maxOrder = -1 → the first
+    // member gets order 0.
+    const maxOrder = existingAgents.reduce((max, agent) => Math.max(max, agent.order ?? 0), -1);
+
+    const newAgents: NewChatGroupAgent[] = newAgentIds.map((agentId, index) => ({
       agentId,
       chatGroupId: groupId,
       enabled: true,
+      order: maxOrder + 1 + index,
       userId: this.userId,
       workspaceId: this.workspaceId ?? null,
     }));
@@ -464,7 +472,7 @@ export class ChatGroupModel {
 
   async getGroupAgents(groupId: string): Promise<ChatGroupAgentItem[]> {
     return this.db.query.chatGroupsAgents.findMany({
-      orderBy: [chatGroupsAgents.order],
+      orderBy: [chatGroupsAgents.order, chatGroupsAgents.createdAt],
       where: and(
         eq(chatGroupsAgents.chatGroupId, groupId),
         this.agentsOwnership(),
@@ -511,12 +519,12 @@ export class ChatGroupModel {
           this.memberAgentVisibility(),
         ),
       )
-      .orderBy(chatGroupsAgents.order);
+      .orderBy(chatGroupsAgents.order, chatGroupsAgents.createdAt);
   }
 
   async getEnabledGroupAgents(groupId: string): Promise<ChatGroupAgentItem[]> {
     return this.db.query.chatGroupsAgents.findMany({
-      orderBy: [chatGroupsAgents.order],
+      orderBy: [chatGroupsAgents.order, chatGroupsAgents.createdAt],
       where: and(
         eq(chatGroupsAgents.chatGroupId, groupId),
         eq(chatGroupsAgents.enabled, true),

--- a/packages/database/src/models/chatGroup.ts
+++ b/packages/database/src/models/chatGroup.ts
@@ -84,7 +84,7 @@ export class ChatGroupModel {
       .from(chatGroupsAgents)
       .innerJoin(agents, eq(chatGroupsAgents.agentId, agents.id))
       .where(and(inArray(chatGroupsAgents.chatGroupId, groupIds), this.memberAgentVisibility()))
-      .orderBy(chatGroupsAgents.order, chatGroupsAgents.createdAt);
+      .orderBy(chatGroupsAgents.order, chatGroupsAgents.createdAt, chatGroupsAgents.agentId);
 
     for (const { avatar, backgroundColor, chatGroupId, slug } of rows) {
       const list = map.get(chatGroupId) ?? [];
@@ -168,7 +168,7 @@ export class ChatGroupModel {
     if (!group) return null;
 
     const agents = await this.db.query.chatGroupsAgents.findMany({
-      orderBy: [chatGroupsAgents.order, chatGroupsAgents.createdAt],
+      orderBy: [chatGroupsAgents.order, chatGroupsAgents.createdAt, chatGroupsAgents.agentId],
       where: and(
         eq(chatGroupsAgents.chatGroupId, groupId),
         this.agentsOwnership(),
@@ -472,7 +472,7 @@ export class ChatGroupModel {
 
   async getGroupAgents(groupId: string): Promise<ChatGroupAgentItem[]> {
     return this.db.query.chatGroupsAgents.findMany({
-      orderBy: [chatGroupsAgents.order, chatGroupsAgents.createdAt],
+      orderBy: [chatGroupsAgents.order, chatGroupsAgents.createdAt, chatGroupsAgents.agentId],
       where: and(
         eq(chatGroupsAgents.chatGroupId, groupId),
         this.agentsOwnership(),
@@ -519,12 +519,12 @@ export class ChatGroupModel {
           this.memberAgentVisibility(),
         ),
       )
-      .orderBy(chatGroupsAgents.order, chatGroupsAgents.createdAt);
+      .orderBy(chatGroupsAgents.order, chatGroupsAgents.createdAt, chatGroupsAgents.agentId);
   }
 
   async getEnabledGroupAgents(groupId: string): Promise<ChatGroupAgentItem[]> {
     return this.db.query.chatGroupsAgents.findMany({
-      orderBy: [chatGroupsAgents.order, chatGroupsAgents.createdAt],
+      orderBy: [chatGroupsAgents.order, chatGroupsAgents.createdAt, chatGroupsAgents.agentId],
       where: and(
         eq(chatGroupsAgents.chatGroupId, groupId),
         eq(chatGroupsAgents.enabled, true),

--- a/packages/database/src/repositories/agentGroup/index.ts
+++ b/packages/database/src/repositories/agentGroup/index.ts
@@ -338,10 +338,12 @@ export class AgentGroupRepository {
       .from(chatGroupsAgents)
       .innerJoin(agents, eq(chatGroupsAgents.agentId, agents.id))
       .where(eq(chatGroupsAgents.chatGroupId, groupId))
-      // `createdAt` is a deterministic tiebreak so rows sharing an `order`
-      // (e.g. legacy members left at the default 0) keep a stable, insertion-
-      // based order instead of shuffling on every refetch.
-      .orderBy(chatGroupsAgents.order, chatGroupsAgents.createdAt);
+      // `createdAt` then `agentId` are deterministic tiebreaks so rows sharing
+      // an `order` (e.g. legacy members left at the default 0) keep a stable
+      // order instead of shuffling on every refetch. `agentId` is the final,
+      // guaranteed-unique key (part of the PK) because a single multi-row insert
+      // stamps every row with the same `createdAt`, which alone can still tie.
+      .orderBy(chatGroupsAgents.order, chatGroupsAgents.createdAt, chatGroupsAgents.agentId);
 
     // 3. Extract agent items with isSupervisor flag and find supervisor
     const agentItems: AgentGroupMember[] = [];
@@ -633,7 +635,7 @@ export class AgentGroupRepository {
       .from(chatGroupsAgents)
       .innerJoin(agents, eq(chatGroupsAgents.agentId, agents.id))
       .where(eq(chatGroupsAgents.chatGroupId, groupId))
-      .orderBy(chatGroupsAgents.order, chatGroupsAgents.createdAt);
+      .orderBy(chatGroupsAgents.order, chatGroupsAgents.createdAt, chatGroupsAgents.agentId);
 
     // 3. Separate supervisor, virtual members, and non-virtual members
     let sourceSupervisor: (typeof groupAgentsWithDetails)[number] | undefined;
@@ -917,7 +919,7 @@ export class AgentGroupRepository {
       .from(chatGroupsAgents)
       .innerJoin(agents, eq(chatGroupsAgents.agentId, agents.id))
       .where(eq(chatGroupsAgents.chatGroupId, groupId))
-      .orderBy(chatGroupsAgents.order, chatGroupsAgents.createdAt);
+      .orderBy(chatGroupsAgents.order, chatGroupsAgents.createdAt, chatGroupsAgents.agentId);
 
     const sourceSupervisor = groupAgentsWithDetails.find((row) => row.role === 'supervisor');
     const sourceMembers = groupAgentsWithDetails.filter((row) => row.role !== 'supervisor');

--- a/packages/database/src/repositories/agentGroup/index.ts
+++ b/packages/database/src/repositories/agentGroup/index.ts
@@ -338,7 +338,10 @@ export class AgentGroupRepository {
       .from(chatGroupsAgents)
       .innerJoin(agents, eq(chatGroupsAgents.agentId, agents.id))
       .where(eq(chatGroupsAgents.chatGroupId, groupId))
-      .orderBy(chatGroupsAgents.order);
+      // `createdAt` is a deterministic tiebreak so rows sharing an `order`
+      // (e.g. legacy members left at the default 0) keep a stable, insertion-
+      // based order instead of shuffling on every refetch.
+      .orderBy(chatGroupsAgents.order, chatGroupsAgents.createdAt);
 
     // 3. Extract agent items with isSupervisor flag and find supervisor
     const agentItems: AgentGroupMember[] = [];
@@ -630,7 +633,7 @@ export class AgentGroupRepository {
       .from(chatGroupsAgents)
       .innerJoin(agents, eq(chatGroupsAgents.agentId, agents.id))
       .where(eq(chatGroupsAgents.chatGroupId, groupId))
-      .orderBy(chatGroupsAgents.order);
+      .orderBy(chatGroupsAgents.order, chatGroupsAgents.createdAt);
 
     // 3. Separate supervisor, virtual members, and non-virtual members
     let sourceSupervisor: (typeof groupAgentsWithDetails)[number] | undefined;
@@ -914,7 +917,7 @@ export class AgentGroupRepository {
       .from(chatGroupsAgents)
       .innerJoin(agents, eq(chatGroupsAgents.agentId, agents.id))
       .where(eq(chatGroupsAgents.chatGroupId, groupId))
-      .orderBy(chatGroupsAgents.order);
+      .orderBy(chatGroupsAgents.order, chatGroupsAgents.createdAt);
 
     const sourceSupervisor = groupAgentsWithDetails.find((row) => row.role === 'supervisor');
     const sourceMembers = groupAgentsWithDetails.filter((row) => row.role !== 'supervisor');

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -252,6 +252,8 @@ export default {
   'groupSidebar.members.orchestrator': 'Orchestrator',
   'groupSidebar.members.orchestratorThinking': 'Orchestrator is thinking...',
   'groupSidebar.members.removeMember': 'Remove Member',
+  'groupSidebar.members.sortMember': 'Sort Members',
+  'groupSidebar.members.sortModalTitle': 'Sort Members',
   'groupSidebar.members.stopOrchestrator': 'Stop',
   'groupSidebar.members.triggerOrchestrator': 'Start',
   'groupSidebar.tabs.host': 'Orchestrator',

--- a/src/routes/(main)/group/_layout/Sidebar/GroupConfig/SortMembersModal/MemberItem.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/GroupConfig/SortMembersModal/MemberItem.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { Avatar, SortableList, Tag } from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { DEFAULT_AVATAR } from '@/const/meta';
+
+const styles = createStaticStyles(({ css }) => ({
+  title: css`
+    overflow: hidden;
+    flex: 1;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+}));
+
+interface MemberItemProps {
+  avatar?: string;
+  background?: string;
+  disabled?: boolean;
+  isExternal?: boolean;
+  title: string;
+}
+
+const MemberItem = memo<MemberItemProps>(({ avatar, background, disabled, isExternal, title }) => {
+  const { t } = useTranslation('chat');
+
+  return (
+    <>
+      {!disabled && <SortableList.DragHandle />}
+      <Avatar
+        emojiScaleWithBackground
+        avatar={avatar || DEFAULT_AVATAR}
+        background={background}
+        size={24}
+        style={{ flex: 'none' }}
+      />
+      <span className={styles.title}>{title}</span>
+      {isExternal && (
+        <Tag size={'small'} style={{ flexShrink: 0 }}>
+          {t('group.profile.external')}
+        </Tag>
+      )}
+    </>
+  );
+});
+
+export default MemberItem;

--- a/src/routes/(main)/group/_layout/Sidebar/GroupConfig/SortMembersModal/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/GroupConfig/SortMembersModal/index.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { type AgentGroupMember } from '@lobechat/types';
+import { Flexbox, SortableList } from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
+import isEqual from 'fast-deep-equal';
+import { memo, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import ImperativeModal from '@/components/ImperativeModal';
+import { usePermission } from '@/hooks/usePermission';
+import { useAgentGroupStore } from '@/store/agentGroup';
+import { agentGroupSelectors } from '@/store/agentGroup/selectors';
+
+import MemberItem from './MemberItem';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  item: css`
+    height: 40px;
+    padding-inline: 8px;
+    border-radius: ${cssVar.borderRadius};
+    transition: background 0.2s ease-in-out;
+
+    &:hover {
+      background: ${cssVar.colorFillTertiary};
+    }
+  `,
+}));
+
+interface SortMembersModalProps {
+  groupId: string;
+  onCancel: () => void;
+  open: boolean;
+}
+
+/**
+ * Drag-to-reorder the group's member roster. Persists on drop via
+ * `reorderGroupMembers`, mirroring the session-group sort flow (ConfigGroupModal).
+ */
+const SortMembersModal = memo<SortMembersModalProps>(({ groupId, open, onCancel }) => {
+  const { t } = useTranslation('chat');
+  const { allowed: canEdit } = usePermission('edit_own_content');
+
+  const members = useAgentGroupStore(agentGroupSelectors.getGroupMembers(groupId), isEqual);
+  const reorderGroupMembers = useAgentGroupStore((s) => s.reorderGroupMembers);
+
+  // Local (optimistic) order so the list doesn't snap back while the reorder
+  // request + refetch are in flight. Re-seed from the persisted roster each time
+  // the modal opens.
+  const [list, setList] = useState<AgentGroupMember[]>(members);
+  useEffect(() => {
+    if (open) setList(members);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  return (
+    <ImperativeModal
+      footer={null}
+      open={open}
+      title={t('groupSidebar.members.sortModalTitle')}
+      width={400}
+      onCancel={onCancel}
+    >
+      <Flexbox gap={2}>
+        <SortableList
+          items={list}
+          renderItem={(item: AgentGroupMember) => (
+            <SortableList.Item
+              horizontal
+              align={'center'}
+              className={styles.item}
+              gap={8}
+              id={item.id}
+            >
+              <MemberItem
+                avatar={item.avatar || undefined}
+                background={item.backgroundColor ?? undefined}
+                disabled={!canEdit}
+                isExternal={!item.virtual}
+                title={item.title || t('defaultSession', { ns: 'common' })}
+              />
+            </SortableList.Item>
+          )}
+          onChange={(next: AgentGroupMember[]) => {
+            if (!canEdit) return;
+
+            setList(next);
+            reorderGroupMembers(
+              groupId,
+              next.map((member) => member.id),
+            );
+          }}
+        />
+      </Flexbox>
+    </ImperativeModal>
+  );
+});
+
+export default SortMembersModal;

--- a/src/routes/(main)/group/_layout/Sidebar/Members/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Members/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { AccordionItem, ActionIcon, Flexbox, Text } from '@lobehub/ui';
-import { Loader2Icon, UserPlus } from 'lucide-react';
+import { ArrowUpDown, Loader2Icon, UserPlus } from 'lucide-react';
 import { type MouseEvent } from 'react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -12,6 +12,7 @@ import { useAgentGroupStore } from '@/store/agentGroup';
 import { agentGroupSelectors } from '@/store/agentGroup/selectors';
 
 import GroupMember from '../GroupConfig/GroupMember';
+import SortMembersModal from '../GroupConfig/SortMembersModal';
 
 interface MembersProps {
   itemKey: string;
@@ -21,10 +22,14 @@ const Members = memo<MembersProps>(({ itemKey }) => {
   const { t } = useTranslation('chat');
   const { allowed: canEdit, reason } = usePermission('edit_own_content');
   const [addModalOpen, setAddModalOpen] = useState(false);
+  const [sortModalOpen, setSortModalOpen] = useState(false);
 
   const activeGroupId = useAgentGroupStore(agentGroupSelectors.activeGroupId);
   const membersCount = useAgentGroupStore(
     agentGroupSelectors.getGroupAgentCount(activeGroupId || ''),
+  );
+  const memberCount = useAgentGroupStore(
+    agentGroupSelectors.getGroupMemberCount(activeGroupId || ''),
   );
   const { isRevalidating } = useInitGroupConfig();
 
@@ -35,6 +40,13 @@ const Members = memo<MembersProps>(({ itemKey }) => {
     setAddModalOpen(true);
   };
 
+  const handleSortMember = (e: MouseEvent) => {
+    e.stopPropagation();
+    if (!canEdit) return;
+
+    setSortModalOpen(true);
+  };
+
   return (
     <AccordionItem
       itemKey={itemKey}
@@ -43,6 +55,15 @@ const Members = memo<MembersProps>(({ itemKey }) => {
       action={
         <>
           {isRevalidating && <ActionIcon loading icon={Loader2Icon} size={'small'} />}
+          {memberCount > 1 && (
+            <ActionIcon
+              disabled={!canEdit}
+              icon={ArrowUpDown}
+              size={'small'}
+              title={canEdit ? t('groupSidebar.members.sortMember') : reason}
+              onClick={handleSortMember}
+            />
+          )}
           <ActionIcon
             disabled={!canEdit}
             icon={UserPlus}
@@ -65,6 +86,13 @@ const Members = memo<MembersProps>(({ itemKey }) => {
           onAddModalOpenChange={setAddModalOpen}
         />
       </Flexbox>
+      {activeGroupId && (
+        <SortMembersModal
+          groupId={activeGroupId}
+          open={sortModalOpen}
+          onCancel={() => setSortModalOpen(false)}
+        />
+      )}
     </AccordionItem>
   );
 });


### PR DESCRIPTION
## 💻 变更类型 | Change Type

- [x] 🐛 fix
- [x] ✨ feat

## 🔀 变更说明 | Description

群组成员在改名 / 刷新后会被打乱、无法保持人为编排的顺序，且没有任何手动排序入口。

### 根因 | Root cause

- `addAgentsToGroup` 插入新成员时**未写入 `order`**，全部落到 schema 默认值 `0`。
- 成员名单读取仅按 `.orderBy(order)` 排序、**无兜底排序键**，当多行 `order` 相同（都为 0）时，PostgreSQL 返回顺序不确定，刷新 / 改名后即抖动（看起来像按字母乱排）。
- 代码里已存在 `reorderGroupMembers` action，但**从未接入任何 UI**，用户无法手动排序。

### 改动 | Changes

- **后端修复**
  - `addAgentsToGroup` 按 `max(existing order) + 1` 递增分配 `order`，增量添加不再塌缩为 0。
  - 名单 / 头像读取查询统一追加 `createdAt` 作为**确定性兜底排序键**，使历史遗留（仍停在 order 0）的成员也保持稳定、可预期的顺序。
- **排序 UI**（复用现有 `SortableList` 范式，对齐会话分组的 `ConfigGroupModal`）
  - 新增 `SortMembersModal`：拖拽排序，松手即落库（接入现成的 `reorderGroupMembers`），带乐观更新避免回弹。
  - 成员区表头「+」旁新增 `↕` 排序入口（成员数 > 1 时出现）。
- **i18n**：`groupSidebar.members.sortMember` / `sortModalTitle`（en-US 源 + zh-CN 手写）。
- **测试**：新增 `addAgentsToGroup` 增量分配递增且唯一 `order` 的回归测试。

## 📝 补充信息 | Additional Information

- Lint 通过；改动文件 type-check 通过。
- 其余语言文案待 `bun run i18n` 补齐。
