### PR TITLE
🐛 fix: guarantee generated tool names stay within 64 chars

### DIFF
--- a/packages/context-engine/src/engine/tools/ToolNameResolver.ts
+++ b/packages/context-engine/src/engine/tools/ToolNameResolver.ts
@@ -69,6 +69,17 @@ export class ToolNameResolver {
       if (toolName.length >= 64) {
         identifierName = this.hashComponent(identifier);
         toolName = identifierName + PLUGIN_SCHEMA_SEPARATOR + apiName + pluginType;
+
+        // Step 4: Both components are now hashed (20 chars each), so the only
+        // remaining unbounded part is the `type` suffix. If the name still
+        // exceeds 64, drop the suffix — otherwise `generate()` would return a
+        // name longer than the provider's limit and the whole tool-calling
+        // request is rejected ("can't call the tool"). `resolve()` recovers the
+        // type from the manifest when the suffix is absent (same path used when
+        // a model strips the suffix), so dropping it is lossless.
+        if (toolName.length >= 64) {
+          toolName = identifierName + PLUGIN_SCHEMA_SEPARATOR + apiName;
+        }
       }
     }
 

--- a/packages/context-engine/src/engine/tools/__tests__/ToolNameResolver.test.ts
+++ b/packages/context-engine/src/engine/tools/__tests__/ToolNameResolver.test.ts
@@ -72,6 +72,48 @@ describe('ToolNameResolver', () => {
       expect(result.length).toBeLessThan(64);
     });
 
+    // Regression: the `type` suffix is not shortened by the length reduction, so
+    // when both identifier and apiName are hashed (20 chars each) a long type
+    // used to push the result past 64 — a name the provider rejects, so the tool
+    // could not be called. generate() must always honor its <= 64 contract.
+    it('should stay within 64 chars even when the type suffix is long', () => {
+      const identifier = 'a-fairly-long-connector-identifier-value';
+      const apiName = 'someActionNameThatIsAlsoQuiteLongForGoodMeasure';
+      const longType = 'a-very-long-plugin-type-string-that-overflows';
+
+      const result = resolver.generate(identifier, apiName, longType);
+
+      expect(result.length).toBeLessThanOrEqual(64);
+      expect(result).toContain('MD5HASH_');
+      // The unbounded type suffix is dropped to fit; resolve() recovers it.
+      expect(result).not.toContain(longType);
+    });
+
+    it('should recover the dropped type suffix from the manifest on resolve', () => {
+      const identifier = 'a-fairly-long-connector-identifier-value';
+      const apiName = 'someActionNameThatIsAlsoQuiteLongForGoodMeasure';
+      const longType = 'a-very-long-plugin-type-string-that-overflows';
+
+      const toolName = resolver.generate(identifier, apiName, longType);
+      expect(toolName.length).toBeLessThanOrEqual(64);
+
+      const [resolved] = resolver.resolve(
+        [{ function: { arguments: '{}', name: toolName }, id: 'call_1', type: 'function' }],
+        {
+          [identifier]: {
+            api: [{ description: '', name: apiName, parameters: {} }],
+            identifier,
+            meta: {},
+            type: longType as any,
+          },
+        },
+      );
+
+      expect(resolved.identifier).toBe(identifier);
+      expect(resolved.apiName).toBe(apiName);
+      expect(resolved.type).toBe(longType);
+    });
+
     it('should handle edge case at exactly 64 characters', () => {
       // Create a name that's exactly 64 characters
       const identifier = 'short-id';


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-11966, part of LOBE-11964 (connector 的后续问题维护)

#### 🔀 Description of Change

**Investigation (reproduce first).** I probed the real `generate()` / `resolve()` across a grid of identifier/apiName/type lengths:

- **Roundtrip is always correct when the manifest is present** — so for a typical MCP connector (`buildConnectorManifests` sets `type: 'mcp'`), compression already roundtrips fine. That part of the "can't call" pain was the stale-manifest path (LOBE-11965, already shipped as background auto-refresh).
- **The one concrete correctness bug** is that `generate()` violates its own documented "max 64 characters" contract: the `type` suffix is never shortened by the length reduction. Steps 2–3 hash `apiName` then `identifier` (20 chars each → 48 with the `____` separator), but the trailing `____<type>` is appended unbounded. Any `type` ≥ ~13 chars yields a name **> 64**, e.g. probed length **88–93**. OpenAI's function-name limit is a hard 64, so the provider rejects the entire tool-calling request → the tool cannot be called.

**Fix.** Add a Step 4: when the fully-hashed name still exceeds 64, drop the `type` suffix. `resolve()` already recovers `type` from the manifest when the suffix is absent (`type ?? manifests[identifier]?.type`, the same fallback used when a model strips the suffix), so dropping it is lossless — the tool still resolves to the correct identifier/apiName/type.

#### 🧪 How to Test

- [x] Added/updated tests
- [x] Tested locally

Regression test `should stay within 64 chars even when the type suffix is long` fails before the fix (`expected 93 to be ≤ 64`) and passes after; a companion test asserts `resolve()` still recovers the dropped `type` from the manifest. `bun run check`: lint clean · types clean · 53 tests passed.

#### 📝 Additional Information

- Behavior is unchanged for all existing/short types (builtin/default/mcp/standalone/customPlugin ≤ 12 chars stay under 64 and keep their suffix) — only the previously-overflowing long-type case changes, and it changes from "invalid >64 name" to "valid ≤64 name".
- Scope: this closes the residual hard-overflow path of LOBE-11966. The readable-ID (LOBE-11967) and configurable/per-model compression (LOBE-11968) items are tracked separately.