### PR TITLE
🐛 fix: run workspace-shared Composio tools under the account owner entity

### DIFF
--- a/apps/server/src/routers/lambda/composio.ts
+++ b/apps/server/src/routers/lambda/composio.ts
@@ -309,6 +309,9 @@ export const composioRouter = router({
               appSlug,
               authConfigId,
               connectedAccountId: connReq.id,
+              // The user entity the account was linked under — used at runtime as
+              // the Composio `userId` (see ComposioConnectorMetadata.linkedByUserId).
+              linkedByUserId: userId,
               redirectUrl: connReq.redirectUrl,
               status: 'PENDING',
             },
@@ -329,6 +332,7 @@ export const composioRouter = router({
           appSlug,
           authConfigId,
           connectedAccountId: connReq.id,
+          linkedByUserId: userId,
           redirectUrl: connReq.redirectUrl,
           status: 'PENDING',
         },
@@ -478,7 +482,17 @@ export const composioRouter = router({
       };
 
       const customParams = {
-        composio: { appSlug, authConfigId, connectedAccountId, redirectUrl, status },
+        composio: {
+          appSlug,
+          authConfigId,
+          connectedAccountId,
+          // Refresh the link owner on every (re)connect: a workspace owner may
+          // reconnect a member-created row, moving the Composio entity to the
+          // owner even though the row's userId (creator) stays put.
+          linkedByUserId: ctx.userId,
+          redirectUrl,
+          status,
+        },
       };
 
       // Personal-only plugin projection: skip for agent connections (see
@@ -502,7 +516,14 @@ export const composioRouter = router({
       // table. `tools` already carries the full manifest from the client.
       await upsertComposioConnector(ctx.connectorModel, ctx.connectorToolModel, {
         agentId,
-        composio: { appSlug, authConfigId, connectedAccountId, redirectUrl, status },
+        composio: {
+          appSlug,
+          authConfigId,
+          connectedAccountId,
+          linkedByUserId: ctx.userId,
+          redirectUrl,
+          status,
+        },
         identifier,
         label,
         replaceTools: true,

--- a/apps/server/src/routers/tools/composio.ts
+++ b/apps/server/src/routers/tools/composio.ts
@@ -43,9 +43,15 @@ export const composioToolsRouter = router({
       // connections created before the connector projection existed.
       const [connector] = await ctx.connectorModel.queryByIdentifiers([input.identifier]);
       let connectedAccountId = connector?.metadata?.composio?.connectedAccountId;
+      // The Composio user entity that OWNS the account (linked it via
+      // `connectedAccounts.link(ownerUserId, …)`), NOT the caller. In a workspace
+      // the resolved row may belong to another member; passing the caller's id
+      // fails Composio's account/entity validation.
+      let ownerUserId: string | undefined = connector?.userId;
       if (!connectedAccountId) {
         const plugin = await ctx.pluginModel.findById(input.identifier);
         connectedAccountId = plugin?.customParams?.composio?.connectedAccountId;
+        ownerUserId = plugin?.userId;
       }
 
       if (!connectedAccountId) {
@@ -61,7 +67,7 @@ export const composioToolsRouter = router({
         // Toolkit version resolves to "latest"; allow manual execution without a
         // pinned version (Composio otherwise throws ComposioToolVersionRequiredError).
         dangerouslySkipVersionCheck: true,
-        userId: ctx.userId,
+        userId: ownerUserId ?? ctx.userId,
       });
 
       if (!result) {

--- a/apps/server/src/routers/tools/composio.ts
+++ b/apps/server/src/routers/tools/composio.ts
@@ -42,16 +42,20 @@ export const composioToolsRouter = router({
       // Connector metadata first (new path); plugin customParams as fallback for
       // connections created before the connector projection existed.
       const [connector] = await ctx.connectorModel.queryByIdentifiers([input.identifier]);
-      let connectedAccountId = connector?.metadata?.composio?.connectedAccountId;
-      // The Composio user entity that OWNS the account (linked it via
-      // `connectedAccounts.link(ownerUserId, …)`), NOT the caller. In a workspace
-      // the resolved row may belong to another member; passing the caller's id
-      // fails Composio's account/entity validation.
-      let ownerUserId: string | undefined = connector?.userId;
+      const connectorComposio = connector?.metadata?.composio;
+      let connectedAccountId = connectorComposio?.connectedAccountId;
+      // The Composio user entity that OWNS the account (linked it), NOT the
+      // caller. In a workspace the resolved row may belong to another member;
+      // passing the caller's id fails Composio's account/entity validation.
+      // `linkedByUserId` tracks the true linker (diverges from the row creator
+      // when a workspace owner reconnects a member's row); fall back to the row
+      // creator for legacy rows without it.
+      let ownerUserId: string | undefined = connectorComposio?.linkedByUserId ?? connector?.userId;
       if (!connectedAccountId) {
         const plugin = await ctx.pluginModel.findById(input.identifier);
-        connectedAccountId = plugin?.customParams?.composio?.connectedAccountId;
-        ownerUserId = plugin?.userId;
+        const pluginComposio = plugin?.customParams?.composio;
+        connectedAccountId = pluginComposio?.connectedAccountId;
+        ownerUserId = pluginComposio?.linkedByUserId ?? plugin?.userId;
       }
 
       if (!connectedAccountId) {

--- a/apps/server/src/services/composio/index.test.ts
+++ b/apps/server/src/services/composio/index.test.ts
@@ -201,6 +201,34 @@ describe('ComposioService.executeComposioTool', () => {
     );
   });
 
+  it('prefers metadata.composio.linkedByUserId over the row creator (owner reconnected a member row)', async () => {
+    // A workspace owner reconnected Gmail on a member-created connector row:
+    // upsertComposioConnector refreshes metadata (incl. linkedByUserId=owner) but
+    // keeps userId=member (the row creator, for manage-rights). The account is now
+    // linked under the owner, so execute must run under linkedByUserId, NOT userId.
+    mocks.connectorQueryByIdentifiers.mockResolvedValue([
+      activeConnectorRow({
+        metadata: {
+          composio: {
+            connectedAccountId: 'ca-connector',
+            linkedByUserId: 'owner-reconnector',
+            status: 'ACTIVE',
+          },
+        },
+        userId: 'member-creator',
+      }),
+    ]);
+    mocks.toolsExecute.mockResolvedValue({ data: 'sent' });
+
+    const result = await service().executeComposioTool(params);
+
+    expect(result.success).toBe(true);
+    expect(mocks.toolsExecute).toHaveBeenCalledWith(
+      'GMAIL_SEND_EMAIL',
+      expect.objectContaining({ connectedAccountId: 'ca-connector', userId: 'owner-reconnector' }),
+    );
+  });
+
   it('falls back to plugin customParams when the connector has no account', async () => {
     mocks.connectorQueryByIdentifiers.mockResolvedValue([]);
     mocks.pluginFindById.mockResolvedValue({

--- a/apps/server/src/services/composio/index.test.ts
+++ b/apps/server/src/services/composio/index.test.ts
@@ -181,10 +181,31 @@ describe('ComposioService.executeComposioTool', () => {
     expect(mocks.pluginFindById).not.toHaveBeenCalled();
   });
 
+  it('executes under the account OWNER entity, not the caller (workspace-shared connector)', async () => {
+    // Regression: a workspace member runs a shared agent whose Composio connector
+    // was linked by another user (openomy). buildWorkspaceWhere resolves that
+    // owner's row; the connected account is bound to the owner's Composio entity,
+    // so execute MUST pass the owner's userId — passing the caller's ('user-1')
+    // failed Composio's account/entity validation ("Error executing the tool").
+    mocks.connectorQueryByIdentifiers.mockResolvedValue([
+      activeConnectorRow({ userId: 'owner-openomy' }),
+    ]);
+    mocks.toolsExecute.mockResolvedValue({ data: 'sent' });
+
+    const result = await service().executeComposioTool(params);
+
+    expect(result.success).toBe(true);
+    expect(mocks.toolsExecute).toHaveBeenCalledWith(
+      'GMAIL_SEND_EMAIL',
+      expect.objectContaining({ connectedAccountId: 'ca-connector', userId: 'owner-openomy' }),
+    );
+  });
+
   it('falls back to plugin customParams when the connector has no account', async () => {
     mocks.connectorQueryByIdentifiers.mockResolvedValue([]);
     mocks.pluginFindById.mockResolvedValue({
       customParams: { composio: { connectedAccountId: 'ca-plugin' } },
+      userId: 'owner-plugin',
     });
     mocks.toolsExecute.mockResolvedValue({ data: 'sent' });
 
@@ -193,7 +214,7 @@ describe('ComposioService.executeComposioTool', () => {
     expect(result.success).toBe(true);
     expect(mocks.toolsExecute).toHaveBeenCalledWith(
       'GMAIL_SEND_EMAIL',
-      expect.objectContaining({ connectedAccountId: 'ca-plugin' }),
+      expect.objectContaining({ connectedAccountId: 'ca-plugin', userId: 'owner-plugin' }),
     );
   });
 

--- a/apps/server/src/services/composio/index.ts
+++ b/apps/server/src/services/composio/index.ts
@@ -180,12 +180,13 @@ export class ComposioService {
    * plugin customParams as fallback (old connections without a connector
    * projection).
    *
-   * `ownerUserId` is the row's `userId` — the user who linked the account
-   * (`connectedAccounts.link(ownerUserId, …)`). It is the Composio entity the
-   * account is bound to and MUST be the `userId` passed to `tools.execute`. In a
-   * workspace a member runs a shared agent whose connector belongs to another
-   * user; resolving off `buildWorkspaceWhere` returns that owner's row, and its
-   * `userId` is the correct entity — the caller's would not match.
+   * `ownerUserId` is the Composio entity the account is bound to and MUST be the
+   * `userId` passed to `tools.execute`. In a workspace a member runs a shared
+   * agent whose connector belongs to another user; the caller's id would not
+   * match. It is read from `metadata.composio.linkedByUserId` (the user who
+   * actually linked the current account) and falls back to the row creator
+   * (`userId`) for rows written before that field existed — the two diverge when
+   * a workspace owner reconnects a member-created connector.
    */
   private async resolveComposioAccount(
     identifier: string,
@@ -193,17 +194,23 @@ export class ComposioService {
   ): Promise<{ connectedAccountId: string; ownerUserId: string } | undefined> {
     if (this.connectorModel) {
       const [connector] = await this.connectorModel.resolveByIdentifiers([identifier], agentId);
-      const fromConnector = connector?.metadata?.composio?.connectedAccountId;
-      if (fromConnector) {
-        return { connectedAccountId: fromConnector, ownerUserId: connector.userId ?? this.userId! };
+      const composio = connector?.metadata?.composio;
+      if (composio?.connectedAccountId) {
+        return {
+          connectedAccountId: composio.connectedAccountId,
+          ownerUserId: composio.linkedByUserId ?? connector.userId ?? this.userId!,
+        };
       }
     }
 
     if (this.pluginModel) {
       const plugin = await this.pluginModel.findById(identifier);
-      const fromPlugin = plugin?.customParams?.composio?.connectedAccountId;
-      if (fromPlugin) {
-        return { connectedAccountId: fromPlugin, ownerUserId: plugin.userId ?? this.userId! };
+      const composio = plugin?.customParams?.composio;
+      if (composio?.connectedAccountId) {
+        return {
+          connectedAccountId: composio.connectedAccountId,
+          ownerUserId: composio.linkedByUserId ?? plugin?.userId ?? this.userId!,
+        };
       }
     }
 

--- a/apps/server/src/services/composio/index.ts
+++ b/apps/server/src/services/composio/index.ts
@@ -99,8 +99,8 @@ export class ComposioService {
     }
 
     try {
-      const connectedAccountId = await this.resolveConnectedAccountId(identifier, agentId);
-      if (!connectedAccountId) {
+      const account = await this.resolveComposioAccount(identifier, agentId);
+      if (!account) {
         return {
           content: `Composio configuration not found for server "${identifier}"`,
           error: {
@@ -111,9 +111,12 @@ export class ComposioService {
         };
       }
 
+      const { connectedAccountId, ownerUserId } = account;
+
       log(
-        'executeComposioTool: calling Composio API with connectedAccountId=%s',
+        'executeComposioTool: calling Composio API with connectedAccountId=%s, ownerUserId=%s',
         connectedAccountId,
+        ownerUserId,
       );
 
       const composioClient = getComposioClient();
@@ -123,7 +126,13 @@ export class ComposioService {
         // Toolkit version resolves to "latest"; allow manual execution without a
         // pinned version (Composio otherwise throws ComposioToolVersionRequiredError).
         dangerouslySkipVersionCheck: true,
-        userId: this.userId,
+        // The Composio user entity that OWNS this connected account — the user who
+        // linked it (`connectedAccounts.link(ownerUserId, …)` at connection time),
+        // NOT the caller. In a workspace, a member running a shared agent resolves
+        // another user's connector; passing the caller's id would fail Composio's
+        // account/entity validation ("Error executing the tool"). See
+        // resolveComposioAccount.
+        userId: ownerUserId,
       });
 
       log('executeComposioTool: response: %O', result);
@@ -165,24 +174,37 @@ export class ComposioService {
   }
 
   /**
-   * Resolve the Composio `connectedAccountId` for an identifier.
-   * Connector metadata first (new path), preferring the agent-owned row when an
-   * `agentId` is given (Agent > Workspace/Personal); plugin customParams as
-   * fallback (old connections without a connector projection).
+   * Resolve the Composio connected account for an identifier, together with the
+   * user entity that OWNS it. Connector metadata first (new path), preferring the
+   * agent-owned row when an `agentId` is given (Agent > Workspace/Personal);
+   * plugin customParams as fallback (old connections without a connector
+   * projection).
+   *
+   * `ownerUserId` is the row's `userId` — the user who linked the account
+   * (`connectedAccounts.link(ownerUserId, …)`). It is the Composio entity the
+   * account is bound to and MUST be the `userId` passed to `tools.execute`. In a
+   * workspace a member runs a shared agent whose connector belongs to another
+   * user; resolving off `buildWorkspaceWhere` returns that owner's row, and its
+   * `userId` is the correct entity — the caller's would not match.
    */
-  private async resolveConnectedAccountId(
+  private async resolveComposioAccount(
     identifier: string,
     agentId?: string,
-  ): Promise<string | undefined> {
+  ): Promise<{ connectedAccountId: string; ownerUserId: string } | undefined> {
     if (this.connectorModel) {
       const [connector] = await this.connectorModel.resolveByIdentifiers([identifier], agentId);
       const fromConnector = connector?.metadata?.composio?.connectedAccountId;
-      if (fromConnector) return fromConnector;
+      if (fromConnector) {
+        return { connectedAccountId: fromConnector, ownerUserId: connector.userId ?? this.userId! };
+      }
     }
 
     if (this.pluginModel) {
       const plugin = await this.pluginModel.findById(identifier);
-      return plugin?.customParams?.composio?.connectedAccountId;
+      const fromPlugin = plugin?.customParams?.composio?.connectedAccountId;
+      if (fromPlugin) {
+        return { connectedAccountId: fromPlugin, ownerUserId: plugin.userId ?? this.userId! };
+      }
     }
 
     return undefined;

--- a/packages/database/src/schemas/connector.ts
+++ b/packages/database/src/schemas/connector.ts
@@ -113,6 +113,16 @@ export interface ComposioConnectorMetadata {
   appSlug: string;
   authConfigId: string;
   connectedAccountId: string;
+  /**
+   * The user entity that LINKED this connected account
+   * (`connectedAccounts.link(linkedByUserId, …)`). This is the Composio entity
+   * the account is bound to and MUST be passed as `userId` when executing tools —
+   * NOT the caller (a workspace member runs another user's connector) and NOT the
+   * row creator (`user_connectors.userId`), which can diverge when a workspace
+   * owner reconnects a member-created connector. Absent on rows created before
+   * this field existed; runtime falls back to the row creator for those.
+   */
+  linkedByUserId?: string;
   redirectUrl?: string;
   /** 'PENDING' | 'ACTIVE' | 'FAILED' — Composio-side connection status */
   status: string;

--- a/packages/types/src/tool/plugin.ts
+++ b/packages/types/src/tool/plugin.ts
@@ -20,6 +20,12 @@ export interface CustomPluginParams {
     appSlug: string;
     authConfigId: string;
     connectedAccountId: string;
+    /**
+     * The user entity that linked this connected account — passed as the Composio
+     * `userId` at runtime so a workspace member runs the owner's connection.
+     * Falls back to the row creator for rows written before this field existed.
+     */
+    linkedByUserId?: string;
     redirectUrl?: string;
     status: string;
   };


### PR DESCRIPTION
## Summary

Follow-up to #17220. Workspace-shared Composio connectors resolved and displayed correctly, but **executing** one as a non-creator member failed with `Error executing the tool …`.

### Root cause

A Composio connected account is linked under the **connector owner's** user entity — `connectedAccounts.link(ownerUserId, …)` at connection time. At runtime the execute call passed the **caller's** `userId` as the Composio entity instead:

- `services/composio/index.ts` (agent-runtime path — the LLM invoking the tool)
- `routers/tools/composio.ts` (manual `executeAction`)

When a workspace member runs a shared agent whose Gmail connector belongs to another member, `buildWorkspaceWhere` resolves the **owner's** connector row (correct), but the connected account is bound to the **owner's** Composio entity. Passing the caller's id fails Composio's account/entity validation. The agent creator only worked because `caller == owner`.

### Fix

Resolve the account owner's `userId` alongside `connectedAccountId` (from the connector row, plugin row as fallback) and pass **that** as the Composio `userId` entity in both execution paths. Personal mode is unchanged (`caller == owner`).

## Repro

1. Owner `A` configures their Gmail Composio connector on a workspace agent.
2. Member `B` opens the same agent and asks it to read Gmail.
3. Before: `Error executing the tool GMAIL_FETCH_EMAILS`. After: runs off `A`'s connected account.

## Tests

- `services/composio/index.test.ts`: new regression — execute uses the **owner** entity (`owner-openomy`), not the caller (`user-1`); plugin-fallback path asserts `owner-plugin`.
- All 13 composio service/router tests green; type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
