### PR TITLE
🐛 fix: skip auth terms confirmation once accepted on same browser

### DIFF
--- a/src/features/AuthShell/AuthAgreement.test.tsx
+++ b/src/features/AuthShell/AuthAgreement.test.tsx
@@ -27,6 +27,7 @@ vi.mock('react-i18next', async (importOriginal) => ({
 
 afterEach(() => {
   vi.restoreAllMocks();
+  localStorage.clear();
 });
 
 const expectLinksToOpenInNewTabs = () => {
@@ -158,5 +159,45 @@ describe('useAuthAgreement', () => {
 
     expect(requestConfirmation).not.toHaveBeenCalled();
     expect(continueAction).toHaveBeenCalledOnce();
+  });
+
+  it('should skip confirmation on later visits after consent was given once', () => {
+    const requestConfirmation = vi.fn((onConfirm: () => void) => onConfirm());
+    const continueAction = vi.fn();
+    const firstVisit = renderHook(() => useAuthAgreement(requestConfirmation));
+
+    act(() => {
+      firstVisit.result.current.continueWithAgreement(continueAction);
+    });
+    firstVisit.unmount();
+
+    // A fresh hook instance simulates the user returning to the sign-in page.
+    const secondVisit = renderHook(() => useAuthAgreement(requestConfirmation));
+
+    expect(secondVisit.result.current.agreementChecked).toBe(true);
+
+    act(() => {
+      secondVisit.result.current.continueWithAgreement(continueAction);
+    });
+
+    expect(requestConfirmation).toHaveBeenCalledOnce();
+    expect(continueAction).toHaveBeenCalledTimes(2);
+  });
+
+  it('should forget persisted consent once the agreement is unchecked', () => {
+    const requestConfirmation = vi.fn();
+    const firstVisit = renderHook(() => useAuthAgreement(requestConfirmation));
+
+    act(() => {
+      firstVisit.result.current.setAgreementChecked(true);
+    });
+    act(() => {
+      firstVisit.result.current.setAgreementChecked(false);
+    });
+    firstVisit.unmount();
+
+    const secondVisit = renderHook(() => useAuthAgreement(requestConfirmation));
+
+    expect(secondVisit.result.current.agreementChecked).toBe(false);
   });
 });

--- a/src/features/AuthShell/AuthAgreement.tsx
+++ b/src/features/AuthShell/AuthAgreement.tsx
@@ -8,6 +8,32 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import { PRIVACY_URL, TERMS_URL } from '@/const/url';
 
+/**
+ * Remembers that the user already accepted the terms & privacy policy on this
+ * browser, so returning users are not asked to confirm again on every sign-in.
+ */
+const AGREEMENT_ACCEPTED_KEY = 'lobehub:auth:agreement-accepted:v1';
+
+const readStoredAgreement = () => {
+  try {
+    return localStorage.getItem(AGREEMENT_ACCEPTED_KEY) === 'true';
+  } catch {
+    return false;
+  }
+};
+
+const persistAgreement = (accepted: boolean) => {
+  try {
+    if (accepted) {
+      localStorage.setItem(AGREEMENT_ACCEPTED_KEY, 'true');
+    } else {
+      localStorage.removeItem(AGREEMENT_ACCEPTED_KEY);
+    }
+  } catch {
+    // Ignore localStorage errors (e.g., quota exceeded, private mode)
+  }
+};
+
 const styles = createStaticStyles(({ css, cssVar }) => ({
   link: css`
     cursor: pointer;
@@ -69,7 +95,12 @@ const AgreementText = memo<AgreementTextProps>(({ i18nKey }) => {
 
 export const useAuthAgreement = (requestConfirmation?: RequestAgreementConfirmation) => {
   const { t } = useTranslation(['auth', 'common']);
-  const [agreementChecked, setAgreementChecked] = useState(false);
+  const [agreementChecked, setAgreementCheckedState] = useState(readStoredAgreement);
+
+  const setAgreementChecked = useCallback((checked: boolean) => {
+    setAgreementCheckedState(checked);
+    persistAgreement(checked);
+  }, []);
 
   const showConfirmation = useCallback(
     (onConfirm: ContinueWithAgreement) => {
@@ -101,7 +132,7 @@ export const useAuthAgreement = (requestConfirmation?: RequestAgreementConfirmat
         continueAction();
       });
     },
-    [agreementChecked, showConfirmation],
+    [agreementChecked, setAgreementChecked, showConfirmation],
   );
 
   return { agreementChecked, continueWithAgreement, setAgreementChecked };


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

#### 🔀 Description of Change

On the sign-in / sign-up pages, the terms & privacy confirmation modal popped up on **every** visit when clicking a social login button (or submitting the email form without checking the agreement checkbox), even if the user had already accepted before. The consent state (`agreementChecked` in `useAuthAgreement`) lived only in component state, so it reset on every page load.

This PR persists the acceptance in `localStorage` (`lobehub:auth:agreement-accepted:v1`, same key style as `lobehub:auth:last-provider:v1`):

- The checked state is initialized from storage, so returning users skip the confirmation modal on both the social and email paths (sign-in and sign-up share the same hook).
- Accepting via the confirm modal or checking the checkbox persists the consent; explicitly unchecking the checkbox clears it, so the confirmation is requested again.
- Storage access is wrapped in try/catch to tolerate private mode / quota errors.

Note: consent is remembered **per browser**, not per account — the confirmation is about the person on the device, and the social path has no email before OAuth completes. This flag only controls the front-end prompt and is not a consent record.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- Regression tests verified to fail before the fix and pass after: a fresh `useAuthAgreement` instance skips confirmation after consent was given once, and re-prompts after the checkbox is unchecked.
- `bun run check` — lint clean, 9 tests passed.