### PR TITLE
✨ feat(skill): add market comments & rating distribution APIs, enrich skill detail

### DIFF
--- a/apps/server/src/routers/lambda/market/skill.test.ts
+++ b/apps/server/src/routers/lambda/market/skill.test.ts
@@ -49,23 +49,15 @@ const rawDetail = {
   name: 'Skill A',
 };
 
-const listItem = (identifier: string) => ({ identifier, name: identifier });
-
 describe('skillRouter.getSkillDetail', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
     mockGetSkillDetail.mockResolvedValue(rawDetail);
     mockGetSkillDownloadUrl.mockReturnValue('https://market.example/skills/skill-a/download');
-    mockSearchSkill.mockResolvedValue({
-      items: [
-        listItem('github.acme.skill-a'),
-        ...Array.from({ length: 7 }, (_, i) => listItem(`github.acme.other-${i}`)),
-      ],
-    });
   });
 
-  it('enriches the raw detail with downloadUrl and related skills', async () => {
+  it('enriches the raw detail with downloadUrl', async () => {
     const caller = await createCaller();
 
     const result = await caller.getSkillDetail({
@@ -77,18 +69,20 @@ describe('skillRouter.getSkillDetail', () => {
       locale: 'en-US',
       version: undefined,
     });
-    expect(mockSearchSkill).toHaveBeenCalledWith({
-      category: 'productivity-tasks',
-      locale: 'en-US',
-      page: 1,
-      pageSize: 7,
-      sort: 'recommended',
-    });
     expect(result.downloadUrl).toBe('https://market.example/skills/skill-a/download');
-    // Capped at 6 and never includes the skill itself
-    expect(result.related).toHaveLength(6);
-    expect(result.related?.map((i) => i.identifier)).not.toContain('github.acme.skill-a');
     expect(result.name).toBe('Skill A');
+  });
+
+  it('stays a single upstream request — never fans out to the skill list', async () => {
+    // The detail query also backs per-skill icon/metadata lookups (one per
+    // installed skill in the chat tools panel). Related skills must be
+    // composed client-side from getSkillList, not aggregated here.
+    const caller = await createCaller();
+
+    await caller.getSkillDetail({ identifier: 'github.acme.skill-a' });
+
+    expect(mockGetSkillDetail).toHaveBeenCalledTimes(1);
+    expect(mockSearchSkill).not.toHaveBeenCalled();
   });
 
   it('passes the requested version through to detail and download URL', async () => {
@@ -101,27 +95,6 @@ describe('skillRouter.getSkillDetail', () => {
       version: '1.2.0',
     });
     expect(mockGetSkillDownloadUrl).toHaveBeenCalledWith('github.acme.skill-a', '1.2.0');
-  });
-
-  it('returns the detail without related when the related lookup fails', async () => {
-    mockSearchSkill.mockRejectedValue(new Error('market unavailable'));
-    const caller = await createCaller();
-
-    const result = await caller.getSkillDetail({ identifier: 'github.acme.skill-a' });
-
-    expect(result.name).toBe('Skill A');
-    expect(result.related).toBeUndefined();
-    expect(result.downloadUrl).toBe('https://market.example/skills/skill-a/download');
-  });
-
-  it('skips the related lookup when the skill has no category', async () => {
-    mockGetSkillDetail.mockResolvedValue({ ...rawDetail, category: undefined });
-    const caller = await createCaller();
-
-    const result = await caller.getSkillDetail({ identifier: 'github.acme.skill-a' });
-
-    expect(mockSearchSkill).not.toHaveBeenCalled();
-    expect(result.related).toBeUndefined();
   });
 
   it('wraps detail failures into an internal server error', async () => {

--- a/apps/server/src/routers/lambda/market/skill.test.ts
+++ b/apps/server/src/routers/lambda/market/skill.test.ts
@@ -1,0 +1,206 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockGetSkillComments,
+  mockGetSkillDetail,
+  mockGetSkillDownloadUrl,
+  mockGetSkillRatingDistribution,
+  mockSearchSkill,
+} = vi.hoisted(() => ({
+  mockGetSkillComments: vi.fn(),
+  mockGetSkillDetail: vi.fn(),
+  mockGetSkillDownloadUrl: vi.fn(),
+  mockGetSkillRatingDistribution: vi.fn(),
+  mockSearchSkill: vi.fn(),
+}));
+
+vi.mock('@/libs/trpc/lambda/middleware', () => ({
+  marketUserInfo: vi.fn((opts: any) =>
+    opts.next({
+      ctx: {
+        ...opts.ctx,
+        marketUserInfo: { email: 'actor@example.com', name: 'Actor', userId: 'user-1' },
+      },
+    }),
+  ),
+  serverDatabase: vi.fn((opts: any) => opts.next(opts)),
+}));
+
+vi.mock('@/server/services/market', () => ({
+  MarketService: vi.fn(() => ({
+    getSkillComments: mockGetSkillComments,
+    getSkillDetail: mockGetSkillDetail,
+    getSkillDownloadUrl: mockGetSkillDownloadUrl,
+    getSkillRatingDistribution: mockGetSkillRatingDistribution,
+    searchSkill: mockSearchSkill,
+  })),
+}));
+
+const createCaller = async () => {
+  const { skillRouter } = await import('./skill');
+  return skillRouter.createCaller({ userId: 'user-1' } as any);
+};
+
+const rawDetail = {
+  category: 'productivity-tasks',
+  content: '# SKILL.md',
+  identifier: 'github.acme.skill-a',
+  name: 'Skill A',
+};
+
+const listItem = (identifier: string) => ({ identifier, name: identifier });
+
+describe('skillRouter.getSkillDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockGetSkillDetail.mockResolvedValue(rawDetail);
+    mockGetSkillDownloadUrl.mockReturnValue('https://market.example/skills/skill-a/download');
+    mockSearchSkill.mockResolvedValue({
+      items: [
+        listItem('github.acme.skill-a'),
+        ...Array.from({ length: 7 }, (_, i) => listItem(`github.acme.other-${i}`)),
+      ],
+    });
+  });
+
+  it('enriches the raw detail with downloadUrl and related skills', async () => {
+    const caller = await createCaller();
+
+    const result = await caller.getSkillDetail({
+      identifier: 'github.acme.skill-a',
+      locale: 'en-US',
+    });
+
+    expect(mockGetSkillDetail).toHaveBeenCalledWith('github.acme.skill-a', {
+      locale: 'en-US',
+      version: undefined,
+    });
+    expect(mockSearchSkill).toHaveBeenCalledWith({
+      category: 'productivity-tasks',
+      locale: 'en-US',
+      page: 1,
+      pageSize: 7,
+      sort: 'recommended',
+    });
+    expect(result.downloadUrl).toBe('https://market.example/skills/skill-a/download');
+    // Capped at 6 and never includes the skill itself
+    expect(result.related).toHaveLength(6);
+    expect(result.related?.map((i) => i.identifier)).not.toContain('github.acme.skill-a');
+    expect(result.name).toBe('Skill A');
+  });
+
+  it('passes the requested version through to detail and download URL', async () => {
+    const caller = await createCaller();
+
+    await caller.getSkillDetail({ identifier: 'github.acme.skill-a', version: '1.2.0' });
+
+    expect(mockGetSkillDetail).toHaveBeenCalledWith('github.acme.skill-a', {
+      locale: undefined,
+      version: '1.2.0',
+    });
+    expect(mockGetSkillDownloadUrl).toHaveBeenCalledWith('github.acme.skill-a', '1.2.0');
+  });
+
+  it('returns the detail without related when the related lookup fails', async () => {
+    mockSearchSkill.mockRejectedValue(new Error('market unavailable'));
+    const caller = await createCaller();
+
+    const result = await caller.getSkillDetail({ identifier: 'github.acme.skill-a' });
+
+    expect(result.name).toBe('Skill A');
+    expect(result.related).toBeUndefined();
+    expect(result.downloadUrl).toBe('https://market.example/skills/skill-a/download');
+  });
+
+  it('skips the related lookup when the skill has no category', async () => {
+    mockGetSkillDetail.mockResolvedValue({ ...rawDetail, category: undefined });
+    const caller = await createCaller();
+
+    const result = await caller.getSkillDetail({ identifier: 'github.acme.skill-a' });
+
+    expect(mockSearchSkill).not.toHaveBeenCalled();
+    expect(result.related).toBeUndefined();
+  });
+
+  it('wraps detail failures into an internal server error', async () => {
+    mockGetSkillDetail.mockRejectedValue(new Error('boom'));
+    const caller = await createCaller();
+
+    await expect(caller.getSkillDetail({ identifier: 'github.acme.skill-a' })).rejects.toThrow(
+      'Failed to fetch skill detail',
+    );
+  });
+});
+
+describe('skillRouter.getSkillComments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('forwards pagination params and returns the comment page', async () => {
+    const response = {
+      currentPage: 2,
+      items: [{ content: 'Great skill', id: 1 }],
+      pageSize: 10,
+      totalCount: 11,
+      totalPages: 2,
+    };
+    mockGetSkillComments.mockResolvedValue(response);
+    const caller = await createCaller();
+
+    const result = await caller.getSkillComments({
+      identifier: 'github.acme.skill-a',
+      order: 'desc',
+      page: 2,
+      pageSize: 10,
+      sort: 'createdAt',
+    });
+
+    expect(mockGetSkillComments).toHaveBeenCalledWith('github.acme.skill-a', {
+      order: 'desc',
+      page: 2,
+      pageSize: 10,
+      sort: 'createdAt',
+    });
+    expect(result).toEqual(response);
+  });
+
+  it('wraps comment failures into an internal server error', async () => {
+    mockGetSkillComments.mockRejectedValue(new Error('boom'));
+    const caller = await createCaller();
+
+    await expect(caller.getSkillComments({ identifier: 'github.acme.skill-a' })).rejects.toThrow(
+      'Failed to fetch skill comments',
+    );
+  });
+});
+
+describe('skillRouter.getSkillRatingDistribution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the rating distribution for a skill', async () => {
+    const distribution = { 1: 0, 2: 1, 3: 2, 4: 10, 5: 30, totalCount: 43 };
+    mockGetSkillRatingDistribution.mockResolvedValue(distribution);
+    const caller = await createCaller();
+
+    const result = await caller.getSkillRatingDistribution({
+      identifier: 'github.acme.skill-a',
+    });
+
+    expect(mockGetSkillRatingDistribution).toHaveBeenCalledWith('github.acme.skill-a');
+    expect(result).toEqual(distribution);
+  });
+
+  it('wraps distribution failures into an internal server error', async () => {
+    mockGetSkillRatingDistribution.mockRejectedValue(new Error('boom'));
+    const caller = await createCaller();
+
+    await expect(
+      caller.getSkillRatingDistribution({ identifier: 'github.acme.skill-a' }),
+    ).rejects.toThrow('Failed to fetch skill rating distribution');
+  });
+});

--- a/apps/server/src/routers/lambda/market/skill.ts
+++ b/apps/server/src/routers/lambda/market/skill.ts
@@ -9,9 +9,6 @@ import { SkillSorts } from '@/types/discover';
 
 const log = debug('lambda-router:market:skill');
 
-/** How many related skills the detail endpoint returns alongside the skill itself */
-const RELATED_SKILLS_COUNT = 6;
-
 // Public procedure with optional user info for trusted client token
 const marketProcedure = publicProcedure
   .use(serverDatabase)
@@ -88,33 +85,18 @@ export const skillRouter = router({
       log('getSkillDetail input: %O', input);
 
       try {
+        // Keep this path lean: it also backs per-skill icon/metadata lookups
+        // (e.g. the chat tools panel renders one detail query per installed
+        // skill), so it must stay a single upstream request. Related skills
+        // are composed client-side from getSkillList (useFetchRelatedSkills).
         const detail = await ctx.marketService.getSkillDetail(input.identifier, {
           locale: input.locale,
           version: input.version,
         });
 
-        // Related skills are decoration — never fail the detail because of them
-        const related = detail.category
-          ? await ctx.marketService
-              .searchSkill({
-                category: detail.category,
-                locale: input.locale,
-                page: 1,
-                pageSize: 7,
-                sort: 'recommended',
-              })
-              .then((list) =>
-                list.items
-                  .filter((item) => item.identifier !== detail.identifier)
-                  .slice(0, RELATED_SKILLS_COUNT),
-              )
-              .catch(() => undefined)
-          : undefined;
-
         return {
           ...detail,
           downloadUrl: ctx.marketService.getSkillDownloadUrl(input.identifier, input.version),
-          related,
         };
       } catch (error) {
         log('Error fetching skill detail: %O', error);

--- a/apps/server/src/routers/lambda/market/skill.ts
+++ b/apps/server/src/routers/lambda/market/skill.ts
@@ -9,6 +9,9 @@ import { SkillSorts } from '@/types/discover';
 
 const log = debug('lambda-router:market:skill');
 
+/** How many related skills the detail endpoint returns alongside the skill itself */
+const RELATED_SKILLS_COUNT = 6;
+
 // Public procedure with optional user info for trusted client token
 const marketProcedure = publicProcedure
   .use(serverDatabase)
@@ -48,6 +51,31 @@ export const skillRouter = router({
       }
     }),
 
+  getSkillComments: marketProcedure
+    .input(
+      z.object({
+        identifier: z.string(),
+        order: z.enum(['asc', 'desc']).optional(),
+        page: z.number().optional(),
+        pageSize: z.number().optional(),
+        sort: z.enum(['createdAt', 'upvotes']).optional(),
+      }),
+    )
+    .query(async ({ input, ctx }) => {
+      log('getSkillComments input: %O', input);
+
+      try {
+        const { identifier, ...params } = input;
+        return await ctx.marketService.getSkillComments(identifier, params);
+      } catch (error) {
+        log('Error fetching skill comments: %O', error);
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to fetch skill comments',
+        });
+      }
+    }),
+
   getSkillDetail: marketProcedure
     .input(
       z.object({
@@ -60,10 +88,34 @@ export const skillRouter = router({
       log('getSkillDetail input: %O', input);
 
       try {
-        return await ctx.marketService.getSkillDetail(input.identifier, {
+        const detail = await ctx.marketService.getSkillDetail(input.identifier, {
           locale: input.locale,
           version: input.version,
         });
+
+        // Related skills are decoration — never fail the detail because of them
+        const related = detail.category
+          ? await ctx.marketService
+              .searchSkill({
+                category: detail.category,
+                locale: input.locale,
+                page: 1,
+                pageSize: 7,
+                sort: 'recommended',
+              })
+              .then((list) =>
+                list.items
+                  .filter((item) => item.identifier !== detail.identifier)
+                  .slice(0, RELATED_SKILLS_COUNT),
+              )
+              .catch(() => undefined)
+          : undefined;
+
+        return {
+          ...detail,
+          downloadUrl: ctx.marketService.getSkillDownloadUrl(input.identifier, input.version),
+          related,
+        };
       } catch (error) {
         log('Error fetching skill detail: %O', error);
         throw new TRPCError({
@@ -97,6 +149,22 @@ export const skillRouter = router({
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',
           message: 'Failed to fetch skill list',
+        });
+      }
+    }),
+
+  getSkillRatingDistribution: marketProcedure
+    .input(z.object({ identifier: z.string() }))
+    .query(async ({ input, ctx }) => {
+      log('getSkillRatingDistribution input: %O', input);
+
+      try {
+        return await ctx.marketService.getSkillRatingDistribution(input.identifier);
+      } catch (error) {
+        log('Error fetching skill rating distribution: %O', error);
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to fetch skill rating distribution',
         });
       }
     }),

--- a/apps/server/src/services/market/index.test.ts
+++ b/apps/server/src/services/market/index.test.ts
@@ -35,7 +35,9 @@ vi.mock('@lobehub/market-sdk', () => {
     marketSkills: {
       downloadSkill: vi.fn(),
       getCategories: vi.fn(),
+      getComments: vi.fn(),
       getDownloadUrl: vi.fn(),
+      getRatingDistribution: vi.fn(),
       getSkillDetail: vi.fn(),
       getSkillList: vi.fn(),
     },
@@ -668,6 +670,38 @@ describe('MarketService', () => {
       const manifests = await service.getLobehubSkillManifests();
       expect(manifests).toHaveLength(1);
       expect(manifests[0].identifier).toBe('working');
+    });
+  });
+
+  describe('skill comments & ratings', () => {
+    it('getSkillComments delegates to marketSkills.getComments with params', async () => {
+      const service = new MarketService();
+      const response = { currentPage: 1, items: [], pageSize: 10, totalCount: 0, totalPages: 0 };
+      (service.market.marketSkills.getComments as any).mockResolvedValue(response);
+
+      const result = await service.getSkillComments('github.acme.skill-a', {
+        page: 2,
+        sort: 'upvotes',
+      });
+
+      expect(service.market.marketSkills.getComments).toHaveBeenCalledWith('github.acme.skill-a', {
+        page: 2,
+        sort: 'upvotes',
+      });
+      expect(result).toEqual(response);
+    });
+
+    it('getSkillRatingDistribution delegates to marketSkills.getRatingDistribution', async () => {
+      const service = new MarketService();
+      const distribution = { 1: 0, 2: 0, 3: 1, 4: 2, 5: 3, totalCount: 6 };
+      (service.market.marketSkills.getRatingDistribution as any).mockResolvedValue(distribution);
+
+      const result = await service.getSkillRatingDistribution('github.acme.skill-a');
+
+      expect(service.market.marketSkills.getRatingDistribution).toHaveBeenCalledWith(
+        'github.acme.skill-a',
+      );
+      expect(result).toEqual(distribution);
     });
   });
 

--- a/apps/server/src/services/market/index.ts
+++ b/apps/server/src/services/market/index.ts
@@ -433,6 +433,7 @@ export class MarketService {
       | 'forks'
       | 'installCount'
       | 'name'
+      | 'recommended'
       | 'relevance'
       | 'stars'
       | 'updatedAt'
@@ -458,6 +459,32 @@ export class MarketService {
     log('getSkillDetail response: %O', result);
 
     return result;
+  }
+
+  /**
+   * Get skill comments from market
+   */
+  async getSkillComments(
+    identifier: string,
+    params?: {
+      order?: 'asc' | 'desc';
+      page?: number;
+      pageSize?: number;
+      sort?: 'createdAt' | 'upvotes';
+    },
+  ) {
+    log('getSkillComments: %s, params: %O', identifier, params);
+
+    return this.market.marketSkills.getComments(identifier, params);
+  }
+
+  /**
+   * Get skill rating distribution from market
+   */
+  async getSkillRatingDistribution(identifier: string) {
+    log('getSkillRatingDistribution: %s', identifier);
+
+    return this.market.marketSkills.getRatingDistribution(identifier);
   }
 
   /**

--- a/packages/types/src/discover/skills.ts
+++ b/packages/types/src/discover/skills.ts
@@ -47,6 +47,7 @@ export enum SkillSorts {
   CreatedAt = 'createdAt',
   InstallCount = 'installCount',
   Name = 'name',
+  Recommended = 'recommended',
   Relevance = 'relevance',
   Stars = 'stars',
   UpdatedAt = 'updatedAt',
@@ -77,6 +78,14 @@ export interface SkillQueryParams {
   sort?: SkillSorts;
 }
 
+export interface SkillCommentsQueryParams {
+  identifier: string;
+  order?: 'asc' | 'desc';
+  page?: number;
+  pageSize?: number;
+  sort?: 'createdAt' | 'upvotes';
+}
+
 export interface SkillListResponse extends MarketSkillListResponse {
   categories?: SkillCategoryItem[];
 }
@@ -94,3 +103,9 @@ export interface DiscoverSkillDetail extends MarketSkillDetail {
 }
 
 export type SkillCategoryItem = MarketSkillCategory;
+
+export type {
+  SkillCommentItem,
+  SkillCommentListResponse,
+  SkillRatingDistribution,
+} from '@lobehub/market-sdk';

--- a/src/libs/swr/keys.ts
+++ b/src/libs/swr/keys.ts
@@ -406,6 +406,11 @@ export const discoverKeys = {
     locale,
     params,
   ]),
+  skillComments: def('discover:skillComments', (identifier: string, params: unknown) => [
+    'discover:skillComments',
+    identifier,
+    params,
+  ]),
   skillDetail: def(
     'discover:skillDetail',
     (locale: string, identifier: string, version?: string) => [
@@ -419,6 +424,10 @@ export const discoverKeys = {
     'discover:skillList',
     locale,
     params,
+  ]),
+  skillRatingDistribution: def('discover:skillRatingDistribution', (identifier: string) => [
+    'discover:skillRatingDistribution',
+    identifier,
   ]),
   userProfile: def('discover:userProfile', (locale: string, username: string) => [
     'discover:userProfile',

--- a/src/libs/swr/keys.ts
+++ b/src/libs/swr/keys.ts
@@ -429,6 +429,15 @@ export const discoverKeys = {
     'discover:skillRatingDistribution',
     identifier,
   ]),
+  skillRelated: def(
+    'discover:skillRelated',
+    (locale: string, category: string, identifier: string) => [
+      'discover:skillRelated',
+      locale,
+      category,
+      identifier,
+    ],
+  ),
   userProfile: def('discover:userProfile', (locale: string, username: string) => [
     'discover:userProfile',
     locale,

--- a/src/services/discover.ts
+++ b/src/services/discover.ts
@@ -36,8 +36,11 @@ import {
   type ProviderListResponse,
   type ProviderQueryParams,
   type SkillCategoryItem,
+  type SkillCommentListResponse,
+  type SkillCommentsQueryParams,
   type SkillListResponse,
   type SkillQueryParams,
+  type SkillRatingDistribution,
 } from '@/types/discover';
 import { type MCPPluginListParams } from '@/types/plugins';
 import { cleanObject } from '@/utils/object';
@@ -542,6 +545,9 @@ class DiscoverService {
     });
   };
 
+  getSkillComments = async (params: SkillCommentsQueryParams): Promise<SkillCommentListResponse> =>
+    lambdaClient.market.skill.getSkillComments.query(params);
+
   getSkillDetail = async (params: {
     identifier: string;
     locale?: string;
@@ -563,6 +569,9 @@ class DiscoverService {
       pageSize: params.pageSize ? Number(params.pageSize) : 20,
     });
   };
+
+  getSkillRatingDistribution = async (identifier: string): Promise<SkillRatingDistribution> =>
+    lambdaClient.market.skill.getSkillRatingDistribution.query({ identifier });
 
   reportSkillEvent = async (eventData: { event: string; identifier: string; source?: string }) => {
     const allow = userGeneralSettingsSelectors.telemetry(useUserStore.getState());

--- a/src/store/discover/slices/skill/action.test.ts
+++ b/src/store/discover/slices/skill/action.test.ts
@@ -1,0 +1,89 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { discoverService } from '@/services/discover';
+import { globalHelpers } from '@/store/global/helpers';
+import { SkillSorts } from '@/types/discover';
+
+import { useDiscoverStore as useStore } from '../../store';
+
+vi.mock('zustand/traditional');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const listItem = (identifier: string) => ({ identifier, name: identifier }) as any;
+
+describe('SkillAction', () => {
+  describe('useFetchRelatedSkills', () => {
+    it('fetches same-category recommended skills, dropping the skill itself and capping at 6', async () => {
+      vi.spyOn(globalHelpers, 'getCurrentLanguage').mockReturnValue('en-US');
+      vi.spyOn(discoverService, 'getSkillList').mockResolvedValue({
+        items: [
+          listItem('github.acme.skill-a'),
+          ...Array.from({ length: 6 }, (_, i) => listItem(`github.acme.other-${i}`)),
+        ],
+      } as any);
+
+      const { result } = renderHook(() =>
+        useStore.getState().useFetchRelatedSkills({
+          category: 'productivity-tasks',
+          identifier: 'github.acme.skill-a',
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.data).toHaveLength(6);
+      });
+
+      expect(discoverService.getSkillList).toHaveBeenCalledWith({
+        category: 'productivity-tasks',
+        page: 1,
+        pageSize: 7,
+        sort: SkillSorts.Recommended,
+      });
+      expect(result.current.data?.map((i) => i.identifier)).not.toContain('github.acme.skill-a');
+    });
+
+    it('caps at 6 even when the skill itself is not in the page', async () => {
+      vi.spyOn(globalHelpers, 'getCurrentLanguage').mockReturnValue('en-US');
+      vi.spyOn(discoverService, 'getSkillList').mockResolvedValue({
+        items: Array.from({ length: 7 }, (_, i) => listItem(`github.acme.other-${i}`)),
+      } as any);
+
+      const { result } = renderHook(() =>
+        useStore.getState().useFetchRelatedSkills({
+          category: 'productivity-tasks',
+          identifier: 'github.acme.skill-a',
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.data).toHaveLength(6);
+      });
+    });
+
+    it('does not fetch without a category', async () => {
+      const getSkillList = vi.spyOn(discoverService, 'getSkillList');
+
+      renderHook(() =>
+        useStore.getState().useFetchRelatedSkills({ identifier: 'github.acme.skill-a' }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(getSkillList).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch without an identifier', async () => {
+      const getSkillList = vi.spyOn(discoverService, 'getSkillList');
+
+      renderHook(() =>
+        useStore.getState().useFetchRelatedSkills({ category: 'productivity-tasks' }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(getSkillList).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/store/discover/slices/skill/action.ts
+++ b/src/store/discover/slices/skill/action.ts
@@ -10,8 +10,11 @@ import { type StoreSetter } from '@/store/types';
 import {
   type DiscoverSkillDetail,
   type SkillCategoryItem,
+  type SkillCommentListResponse,
+  type SkillCommentsQueryParams,
   type SkillListResponse,
   type SkillQueryParams,
+  type SkillRatingDistribution,
 } from '@/types/discover';
 
 type Setter = StoreSetter<DiscoverStore>;
@@ -48,6 +51,16 @@ export class SkillActionImpl {
     );
   };
 
+  useFetchSkillComments = ({
+    identifier,
+    ...params
+  }: Partial<SkillCommentsQueryParams>): SWRResponse<SkillCommentListResponse> => {
+    return useClientDataSWR(
+      identifier ? discoverKeys.skillComments(identifier, params) : null,
+      async () => discoverService.getSkillComments({ identifier: identifier!, ...params }),
+    );
+  };
+
   useFetchSkillList = (params: SkillQueryParams): SWRResponse<SkillListResponse> => {
     const locale = globalHelpers.getCurrentLanguage();
     return useClientDataSWR(discoverKeys.skillList(locale, params), async () =>
@@ -56,6 +69,13 @@ export class SkillActionImpl {
         page: params.page ? Number(params.page) : 1,
         pageSize: params.pageSize ? Number(params.pageSize) : 21,
       }),
+    );
+  };
+
+  useFetchSkillRatingDistribution = (identifier?: string): SWRResponse<SkillRatingDistribution> => {
+    return useClientDataSWR(
+      identifier ? discoverKeys.skillRatingDistribution(identifier) : null,
+      async () => discoverService.getSkillRatingDistribution(identifier!),
     );
   };
 

--- a/src/store/discover/slices/skill/action.ts
+++ b/src/store/discover/slices/skill/action.ts
@@ -9,15 +9,20 @@ import { globalHelpers } from '@/store/global/helpers';
 import { type StoreSetter } from '@/store/types';
 import {
   type DiscoverSkillDetail,
+  type DiscoverSkillItem,
   type SkillCategoryItem,
   type SkillCommentListResponse,
   type SkillCommentsQueryParams,
   type SkillListResponse,
   type SkillQueryParams,
   type SkillRatingDistribution,
+  SkillSorts,
 } from '@/types/discover';
 
 type Setter = StoreSetter<DiscoverStore>;
+
+/** How many related skills the detail view shows alongside the skill itself */
+const RELATED_SKILLS_COUNT = 6;
 
 export const createSkillSlice = (set: Setter, get: () => DiscoverStore, _api?: unknown) =>
   new SkillActionImpl(set, get, _api);
@@ -48,6 +53,37 @@ export class SkillActionImpl {
     return useClientDataSWR(
       !isMarketIdentifier ? null : discoverKeys.skillDetail(locale, identifier, version),
       async () => discoverService.getSkillDetail({ identifier: identifier!, version }),
+    );
+  };
+
+  /**
+   * Related skills for the detail view, composed client-side from the list
+   * endpoint. Kept out of `getSkillDetail` on purpose: that query also backs
+   * per-skill icon/metadata lookups (one per installed skill in the chat tools
+   * panel), which must not pay for an extra upstream list request.
+   */
+  useFetchRelatedSkills = ({
+    category,
+    identifier,
+  }: {
+    category?: string;
+    identifier?: string;
+  }): SWRResponse<DiscoverSkillItem[]> => {
+    const locale = globalHelpers.getCurrentLanguage();
+    return useClientDataSWR(
+      category && identifier ? discoverKeys.skillRelated(locale, category, identifier) : null,
+      async (): Promise<DiscoverSkillItem[]> => {
+        const list = await discoverService.getSkillList({
+          category,
+          page: 1,
+          // Fetch one extra so the cap still holds after dropping the skill itself
+          pageSize: RELATED_SKILLS_COUNT + 1,
+          sort: SkillSorts.Recommended,
+        });
+        return list.items
+          .filter((item) => item.identifier !== identifier)
+          .slice(0, RELATED_SKILLS_COUNT);
+      },
     );
   };
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

First of two PRs for turning the community skill detail into a modal with a redesigned, App Store-style layout (reference: lobehub-landing PR #476). This PR lands the data layer only; the UI refactor follows in a second PR.

**Server**

- `MarketService`: new `getSkillComments` / `getSkillRatingDistribution` passthroughs to `@lobehub/market-sdk` (`marketSkills.getComments` / `getRatingDistribution`), and `searchSkill` now accepts `sort: 'recommended'`.
- `market.skill` TRPC router:
  - New `getSkillComments` procedure (paginated: `page` / `pageSize` / `sort: createdAt|upvotes` / `order`).
  - New `getSkillRatingDistribution` procedure (star histogram for the Reviews view).
  - `getSkillDetail` now also returns `downloadUrl` (built via the existing `getSkillDownloadUrl`, plain URL construction — no extra upstream request).

**Client (data layer only, no UI change)**

- `discoverService.getSkillComments` / `getSkillRatingDistribution`.
- Discover store hooks `useFetchSkillComments` / `useFetchSkillRatingDistribution` + new SWR keys.
- `useFetchRelatedSkills({ category, identifier })`: related skills for the detail view, composed client-side from the existing `getSkillList` (`sort: recommended`, same category, self excluded, capped at 6).
- Types: `SkillSorts.Recommended`, `SkillCommentsQueryParams`, and re-exports of the SDK comment/rating types. `DiscoverSkillDetail` already declared `comments` / `ratingDistribution` / `related` / `downloadUrl` as optional, so no consumer-facing type break.

**Design note — why `getSkillDetail` stays a single upstream request**: that query also backs per-skill icon/metadata lookups (`MarketSkillIcon` renders one detail query per installed skill in the chat tools panel). Aggregating related skills server-side would double upstream traffic and add latency to every icon lookup, so related data lives in a separate lazy query instead — same reasoning as keeping comments/distribution out of the detail payload. A router test pins this (`searchSkill` must not be called on the detail path).

**Intentional behavior change**: the existing skill detail page conditionally renders the download button — it was silently hidden because the server never populated `downloadUrl`. With this PR it starts showing up. This is expected, not a side effect.

#### 🧪 How to Test

- Router tests in `apps/server/src/routers/lambda/market/skill.test.ts`: detail enrichment with `downloadUrl`, version passthrough, the single-upstream-request guarantee (no `searchSkill` fan-out from the detail path), comment pagination param forwarding, and error wrapping for all three procedures.
- Store tests in `src/store/discover/slices/skill/action.test.ts`: `useFetchRelatedSkills` drops the skill itself, caps at 6, and does not fetch without `category` / `identifier`.
- `apps/server/src/services/market/index.test.ts` pins the SDK method wiring (`getComments` / `getRatingDistribution`) so a renamed SDK method can't slip past the mocked router tests.
- Verified against lobehub-market source that `GET /api/v1/skills/:identifier/comments` and `GET /api/v1/skills/:identifier/ratings/distribution` exist and are public reads; the new procedures reuse the exact same `marketProcedure` auth chain as the already-working `getSkillDetail` / `getSkillList`.
- `bun run check --lint --test --type`: lint clean, all tests pass. The type-check reports 8 pre-existing errors from duplicated `next@16.3.0-preview.5/.6` installs (reproduced on a clean `canary` tree, unrelated to this change).

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

No UI changes in this PR (data layer only).

#### 📝 Additional Information

Follow-up PR will: port `CommentList` / `RatingOverview` / `Rate` from lobehub-landing, rebuild the detail content (header stats bar + Overview / Install / Reviews / Info tabs), and open it as a modal from the community skill list (keeping `/community/skill/:slug` as a deep link). Comments, rating distribution, and related skills are all separate lazy queries so the future modal renders the primary detail fast.