### PR TITLE
✨ feat(verify): open the run scenario contract beyond coding

### DIFF
--- a/apps/cli/src/commands/verify.test.ts
+++ b/apps/cli/src/commands/verify.test.ts
@@ -7,11 +7,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   deriveReportVerdict,
+  genericContextFromResult,
   originFromEnv,
   parseSubjectRef,
   planFromResult,
   registerVerifyCommand,
   reportEvidence,
+  scenarioFromResult,
   subjectFromEnv,
   subjectFromResult,
   surfacesFromResult,
@@ -500,6 +502,43 @@ describe('verify ingest-report — every run is an immutable acceptance round', 
     });
   });
 
+  it('passes a non-coding scenario and its context bag through to the run', async () => {
+    const verify = mockTrpcClient.verify as Record<string, any>;
+    writeFileSync(
+      path.join(dir, 'result.json'),
+      JSON.stringify({
+        cases: [],
+        context: { question: 'How mature is X?', sourceCount: 8 },
+        scenario: 'research',
+      }),
+    );
+
+    await run(['ingest-report', dir, '--json']);
+
+    expect(verify.createRun.mutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({ question: 'How mature is X?', sourceCount: 8 }),
+        scenario: 'research',
+      }),
+    );
+  });
+
+  it('rejects an unknown scenario instead of silently tagging the run coding', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit ${code}`);
+    }) as never);
+    writeFileSync(path.join(dir, 'result.json'), JSON.stringify({ cases: [], scenario: 'poetry' }));
+
+    try {
+      await expect(run(['ingest-report', dir, '--json'])).rejects.toThrow('process.exit 1');
+      expect(
+        (mockTrpcClient.verify as Record<string, any>).createRun.mutate,
+      ).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
   it('creates another run when the same report directory is ingested again', async () => {
     const verify = mockTrpcClient.verify as Record<string, any>;
     verify.createRun.mutate
@@ -518,6 +557,44 @@ describe('verify ingest-report — every run is an immutable acceptance round', 
       acceptanceId: 'acceptance-1',
       verifyRunId: 'run-second',
     });
+  });
+});
+
+describe('scenarioFromResult / genericContextFromResult — non-coding scenarios', () => {
+  it('defaults to coding and passes any known scenario through', () => {
+    expect(scenarioFromResult({})).toBe('coding');
+    expect(scenarioFromResult({ scenario: 'research' })).toBe('research');
+    expect(scenarioFromResult({ scenario: 'writing' })).toBe('writing');
+    expect(scenarioFromResult({ scenario: 'generic' })).toBe('generic');
+  });
+
+  it('hard-errors on a scenario nothing renders', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit ${code}`);
+    }) as never);
+
+    try {
+      expect(() => scenarioFromResult({ scenario: 'poetry' })).toThrow('process.exit 1');
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('lifts shared provenance defaults but lets explicit context keys win', () => {
+    expect(
+      genericContextFromResult({
+        context: { testedAt: '2026-07-16T10:00:00Z', wordCount: 82_000, work: '长夜' },
+        createdAt: '2026-07-15T00:00:00Z',
+        entry: 'lh doc export',
+      }),
+    ).toEqual({
+      entry: 'lh doc export',
+      testedAt: '2026-07-16T10:00:00Z',
+      wordCount: 82_000,
+      work: '长夜',
+    });
+
+    expect(genericContextFromResult({})).toBeUndefined();
   });
 });
 

--- a/apps/cli/src/commands/verify.test.ts
+++ b/apps/cli/src/commands/verify.test.ts
@@ -523,6 +523,29 @@ describe('verify ingest-report — every run is an immutable acceptance round', 
     );
   });
 
+  it('finishes the human (non-json) output path for a non-coding report', async () => {
+    // Regression: `pullRequest` was block-scoped inside the coding branch while
+    // the text success output still read it, so every non-json ingest crashed
+    // with a ReferenceError AFTER creating the run.
+    const verify = mockTrpcClient.verify as Record<string, any>;
+    writeFileSync(
+      path.join(dir, 'result.json'),
+      JSON.stringify({
+        cases: [],
+        context: { question: 'How mature is X?' },
+        scenario: 'research',
+      }),
+    );
+
+    await run(['ingest-report', dir]);
+
+    expect(verify.createRun.mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ scenario: 'research' }),
+    );
+    // The success tail printed — the command reached past the run creation.
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('verifyRunId'));
+  });
+
   it('rejects an unknown scenario instead of silently tagging the run coding', async () => {
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
       throw new Error(`process.exit ${code}`);

--- a/apps/cli/src/commands/verify.ts
+++ b/apps/cli/src/commands/verify.ts
@@ -1431,13 +1431,16 @@ export function registerVerifyCommand(program: Command) {
         // The scenario's context for the report's scope header. Coding lifts the
         // well-known top-level fields (branch / commit / surfaces / PR); every
         // other scenario passes result.json `context` through as its own bag.
+        // `pullRequest` is hoisted: the success output (text and --json) prints
+        // the PR link after the ingest, whatever the scenario resolved to.
         let context: Record<string, unknown> | undefined;
+        let pullRequest: ReturnType<typeof pullRequestFromResult>;
         if (scenario === 'coding') {
           const branch = typeof result.branch === 'string' ? result.branch : undefined;
           const surfaces = surfacesFromResult(result);
           // An authored PR wins; otherwise ask `gh` what the branch's PR is, so the
           // report links to it without the author having to remember the field.
-          const pullRequest = pullRequestFromResult(result) ?? pullRequestFromBranch(branch);
+          pullRequest = pullRequestFromResult(result) ?? pullRequestFromBranch(branch);
           const contextEntries = Object.entries({
             branch,
             commit: typeof result.commit === 'string' ? result.commit : undefined,
@@ -1630,7 +1633,7 @@ export function registerVerifyCommand(program: Command) {
               inlined,
               origin,
               planItems: plan?.length ?? 0,
-              pullRequest: context?.pullRequest,
+              pullRequest,
               scenario,
               subject: subject.ref,
               unplanned,

--- a/apps/cli/src/commands/verify.ts
+++ b/apps/cli/src/commands/verify.ts
@@ -2,11 +2,17 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
-import type { AcceptanceSubjectType, VerifyRunOrigin, VerifySurface } from '@lobechat/const/verify';
+import type {
+  AcceptanceSubjectType,
+  VerifyRunOrigin,
+  VerifyRunScenario,
+  VerifySurface,
+} from '@lobechat/const/verify';
 import {
   acceptanceSubjectTypes,
   normalizeVerifySurface,
   verifyEvidenceTypes,
+  verifyRunScenarios,
   verifySurfaces,
 } from '@lobechat/const/verify';
 import type { Command } from 'commander';
@@ -257,6 +263,45 @@ export function surfacesFromResult(result: Record<string, unknown>): VerifySurfa
   }
 
   return canonical.length > 0 ? canonical : undefined;
+}
+
+/**
+ * What kind of delivery the report verified. Defaults to `coding` — the
+ * agent-testing harness's home turf — and rejects an unknown value rather than
+ * storing a scenario nothing renders (mirrors the strict surface policy: the
+ * author still has the context to fix it).
+ */
+export function scenarioFromResult(result: Record<string, unknown>): VerifyRunScenario {
+  const raw = result.scenario;
+  if (raw === undefined) return 'coding';
+  if (typeof raw === 'string' && (verifyRunScenarios as readonly string[]).includes(raw)) {
+    return raw as VerifyRunScenario;
+  }
+
+  log.error(
+    `result.json "scenario" must be one of: ${verifyRunScenarios.join(', ')} — rejected: ${JSON.stringify(raw)}`,
+  );
+  process.exit(1);
+}
+
+/**
+ * A non-coding scenario's scope, passed through from result.json `context` as
+ * the scenario's own bag (the server stores it as-is; known shapes live in
+ * `@lobechat/types`). Top-level `entry` / `createdAt` are lifted as defaults so
+ * every scenario gets the shared provenance fields for free; explicit `context`
+ * keys win.
+ */
+export function genericContextFromResult(
+  result: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const bag = objectValue(result.context) ?? {};
+  const entries = Object.entries({
+    entry: firstString(result.entry),
+    testedAt: firstString(result.createdAt),
+    ...bag,
+  }).filter(([, v]) => v !== undefined);
+
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
 /** Reject an out-of-vocabulary plan value rather than storing a word nothing reads. */
@@ -1380,30 +1425,35 @@ export function registerVerifyCommand(program: Command) {
         const reportMdPath = path.join(dir, 'report.md');
         const content = existsSync(reportMdPath) ? readFileSync(reportMdPath, 'utf8') : undefined;
 
-        // The scenario's context for the report's scope header, lifted from
-        // result.json's top-level fields. Drop empty keys so the bag stays clean.
-        const branch = typeof result.branch === 'string' ? result.branch : undefined;
-        const surfaces = surfacesFromResult(result);
-        // An authored PR wins; otherwise ask `gh` what the branch's PR is, so the
-        // report links to it without the author having to remember the field.
-        const pullRequest = pullRequestFromResult(result) ?? pullRequestFromBranch(branch);
-        const contextEntries = Object.entries({
-          branch,
-          commit: typeof result.commit === 'string' ? result.commit : undefined,
-          entry: typeof result.entry === 'string' ? result.entry : undefined,
-          pullRequest,
-          surfaces,
-          testedAt: typeof result.createdAt === 'string' ? result.createdAt : undefined,
-        }).filter(([, v]) => v !== undefined);
-        const context = contextEntries.length > 0 ? Object.fromEntries(contextEntries) : undefined;
+        // What kind of delivery this report verified (default: coding).
+        const scenario = scenarioFromResult(result);
+
+        // The scenario's context for the report's scope header. Coding lifts the
+        // well-known top-level fields (branch / commit / surfaces / PR); every
+        // other scenario passes result.json `context` through as its own bag.
+        let context: Record<string, unknown> | undefined;
+        if (scenario === 'coding') {
+          const branch = typeof result.branch === 'string' ? result.branch : undefined;
+          const surfaces = surfacesFromResult(result);
+          // An authored PR wins; otherwise ask `gh` what the branch's PR is, so the
+          // report links to it without the author having to remember the field.
+          const pullRequest = pullRequestFromResult(result) ?? pullRequestFromBranch(branch);
+          const contextEntries = Object.entries({
+            branch,
+            commit: typeof result.commit === 'string' ? result.commit : undefined,
+            entry: typeof result.entry === 'string' ? result.entry : undefined,
+            pullRequest,
+            surfaces,
+            testedAt: typeof result.createdAt === 'string' ? result.createdAt : undefined,
+          }).filter(([, v]) => v !== undefined);
+          context = contextEntries.length > 0 ? Object.fromEntries(contextEntries) : undefined;
+        } else {
+          context = genericContextFromResult(result);
+        }
 
         // What the run set out to check, written before it ran. Paired with the
         // results by `id`, so the report can show a planned item that never ran.
         const plan = planFromResult(result);
-
-        // The harness verifies software changes; tag the run so the viewer renders
-        // the coding scope header. Overridable via result.json `scenario`.
-        const scenario = result.scenario === 'coding' ? 'coding' : ('coding' as const);
 
         // Every agent-testing report belongs to an acceptance. Explicit CLI input
         // wins, then result.json, then the authoring topic echoed by the runtime.
@@ -1580,7 +1630,8 @@ export function registerVerifyCommand(program: Command) {
               inlined,
               origin,
               planItems: plan?.length ?? 0,
-              pullRequest,
+              pullRequest: context?.pullRequest,
+              scenario,
               subject: subject.ref,
               unplanned,
               verifyRunId: runId,

--- a/apps/server/src/routers/lambda/__tests__/verify.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/verify.test.ts
@@ -6,6 +6,7 @@ import type * as VerifyServiceModule from '@/server/services/verify';
 
 const modelMocks = vi.hoisted(() => ({
   createEvidence: vi.fn(),
+  createRun: vi.fn(),
   deleteResult: vi.fn(),
   deleteRun: vi.fn(),
   findRunByOperation: vi.fn(),
@@ -31,6 +32,7 @@ vi.mock('@/database/models/verifyCheckResult', () => ({
 
 vi.mock('@/database/models/verifyRun', () => ({
   VerifyRunModel: vi.fn(() => ({
+    create: modelMocks.createRun,
     delete: modelMocks.deleteRun,
     findByOperation: modelMocks.findRunByOperation,
     findById: modelMocks.findRunById,
@@ -227,6 +229,55 @@ describe('verifyRouter', () => {
 
       expect(modelMocks.findRunById).not.toHaveBeenCalled();
       expect(modelMocks.updateRun).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createRun — scenario-aware context contract', () => {
+    it('preserves a non-coding scenario context as its own bag', async () => {
+      modelMocks.createRun.mockResolvedValueOnce({ id: 'run-research' });
+
+      await createCaller().createRun({
+        context: {
+          question: 'What changed in the EU AI Act enforcement in 2026?',
+          sourceCount: 12,
+          sources: [{ title: 'EUR-Lex', url: 'https://eur-lex.europa.eu' }],
+        },
+        scenario: 'research',
+        title: 'research acceptance round',
+      });
+
+      // The bag must land as-is: an ordered union with the (all-optional,
+      // stripping) coding schema would silently swallow these fields.
+      expect(modelMocks.createRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: {
+            question: 'What changed in the EU AI Act enforcement in 2026?',
+            sourceCount: 12,
+            sources: [{ title: 'EUR-Lex', url: 'https://eur-lex.europa.eu' }],
+          },
+          scenario: 'research',
+        }),
+      );
+    });
+
+    it('still canonicalizes coding surfaces when scenario is absent (legacy contract)', async () => {
+      modelMocks.createRun.mockResolvedValueOnce({ id: 'run-coding' });
+
+      await createCaller().createRun({
+        context: { branch: 'feat/x', surfaces: ['electron'] },
+      });
+
+      expect(modelMocks.createRun).toHaveBeenCalledWith(
+        expect.objectContaining({ context: { branch: 'feat/x', surfaces: ['desktop'] } }),
+      );
+    });
+
+    it('rejects an unknown scenario before touching the database', async () => {
+      await expect(
+        createCaller().createRun({ scenario: 'poetry' as any, title: 'nope' }),
+      ).rejects.toThrow();
+
+      expect(modelMocks.createRun).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/src/routers/lambda/verify.ts
+++ b/apps/server/src/routers/lambda/verify.ts
@@ -1,6 +1,6 @@
 import { VerifySkill } from '@lobechat/builtin-skills';
-import { normalizeVerifySurface, verifySurfaces } from '@lobechat/const/verify';
-import type { VerifyCheckItem } from '@lobechat/types';
+import { normalizeVerifySurface, verifyRunScenarios, verifySurfaces } from '@lobechat/const/verify';
+import type { VerifyCheckItem, VerifyRunContext, VerifyRunScenario } from '@lobechat/types';
 import { TRPCError } from '@trpc/server';
 import { asc, eq } from 'drizzle-orm';
 import { z } from 'zod';
@@ -109,8 +109,9 @@ const omitUndefined = <T extends Record<string, unknown>>(value: T): Partial<T> 
     Object.entries(value).filter(([, field]) => field !== undefined),
   ) as Partial<T>;
 
-// The scenario's context (coding scope), rendered as the report's scope header.
-// Shared by createRun and updateRun so a re-ingest can refresh the scope in place.
+// The scenario's context, rendered as the report's scope header. Shared by
+// createRun and updateRun so a re-ingest can refresh the scope in place.
+// Validated per scenario at the door (see `withScenarioContext`).
 const webUrlSchema = z
   .string()
   .url()
@@ -147,7 +148,7 @@ const surfaceSchema = z.string().transform((value, ctx) => {
   return z.NEVER;
 });
 
-const runContextSchema = z.object({
+const codingRunContextSchema = z.object({
   branch: z.string().optional(),
   commit: z.string().optional(),
   entry: z.string().optional(),
@@ -156,19 +157,64 @@ const runContextSchema = z.object({
   testedAt: z.string().optional(),
 });
 
+/**
+ * Non-coding scenarios store the scope as an open bag. The known shapes live in
+ * `@lobechat/types` (`VerifyRunContext`); the server deliberately does not
+ * enumerate their fields, so a new scenario — or a new scope field on an
+ * existing one — never requires a server redeploy. Only `coding` gets strict
+ * validation, because its scope needs canonicalization at the door (surfaces).
+ */
+const genericRunContextSchema = z.record(z.string(), z.unknown());
+
+const scenarioSchema = z.enum(verifyRunScenarios);
+
+/**
+ * Validate `context` by its sibling `scenario`. Absent scenario defaults to
+ * `coding` (the legacy contract — an older `lh` posts a coding scope with no
+ * scenario field), so callers setting a non-coding context MUST send `scenario`
+ * in the same payload or the coding schema strips their fields. Applied as a
+ * transform (not a plain union) for two reasons: the coding path canonicalizes
+ * surfaces in place, and an ordered union of all-optional stripping objects
+ * would silently swallow a non-coding scope into the first match.
+ */
+const withScenarioContext = <T extends { context?: unknown; scenario?: VerifyRunScenario }>(
+  schema: z.ZodType<T>,
+) =>
+  schema.transform((value, ctx) => {
+    if (value.context === undefined) return { ...value, context: undefined };
+
+    const contextSchema =
+      (value.scenario ?? 'coding') === 'coding' ? codingRunContextSchema : genericRunContextSchema;
+    const parsed = contextSchema.safeParse(value.context);
+    if (!parsed.success) {
+      for (const issue of parsed.error.issues) {
+        ctx.addIssue({
+          code: 'custom',
+          message: issue.message,
+          path: ['context', ...issue.path],
+        });
+      }
+      return z.NEVER;
+    }
+
+    return { ...value, context: parsed.data as VerifyRunContext };
+  });
+
 const runMetadataSchema = z.record(z.string(), z.unknown());
 
 const updateRunInputSchema = verifyRunIdInputSchema.extend({
   // Every field optional — a re-ingest may refresh only the context/goal while
   // keeping the original title, so nothing here is required.
-  value: z.object({
-    context: runContextSchema.optional(),
-    goal: z.string().optional(),
-    metadata: runMetadataSchema.optional(),
-    plan: z.array(checkItemSchema).optional(),
-    scenario: z.enum(['coding']).optional(),
-    title: z.string().trim().min(1).max(200).optional(),
-  }),
+  value: withScenarioContext(
+    z.object({
+      context: z.unknown().optional(),
+      goal: z.string().optional(),
+      metadata: runMetadataSchema.optional(),
+      plan: z.array(checkItemSchema).optional(),
+      scenario: scenarioSchema.optional(),
+      title: z.string().trim().min(1).max(200).optional(),
+    }),
+  ),
 });
 
 // Cursor-paginated report list. `cursor` is the opaque token from the previous
@@ -577,19 +623,21 @@ export const verifyRouter = router({
   // report — all keyed by verifyRunId.
   createRun: verifyWriteProcedure
     .input(
-      z.object({
-        // The active scenario's context, rendered as the report's scope header.
-        context: runContextSchema.optional(),
-        goal: z.string().optional(),
-        metadata: runMetadataSchema.optional(),
-        operationId: z.string().optional(),
-        // The checks the run set out to make, authored before it ran. Kept next
-        // to the results so a planned-but-never-executed item stays visible.
-        plan: z.array(checkItemSchema).optional(),
-        scenario: z.enum(['coding']).optional(),
-        source: runSourceSchema.optional(),
-        title: z.string().optional(),
-      }),
+      withScenarioContext(
+        z.object({
+          // The active scenario's context, rendered as the report's scope header.
+          context: z.unknown().optional(),
+          goal: z.string().optional(),
+          metadata: runMetadataSchema.optional(),
+          operationId: z.string().optional(),
+          // The checks the run set out to make, authored before it ran. Kept next
+          // to the results so a planned-but-never-executed item stays visible.
+          plan: z.array(checkItemSchema).optional(),
+          scenario: scenarioSchema.optional(),
+          source: runSourceSchema.optional(),
+          title: z.string().optional(),
+        }),
+      ),
     )
     .mutation(async ({ ctx, input }) =>
       ctx.runModel.create({

--- a/packages/const/src/verify.ts
+++ b/packages/const/src/verify.ts
@@ -84,9 +84,12 @@ export type VerifyRunSource = (typeof verifyRunSources)[number];
  * records what *produced* the run): `scenario` drives how the report renders its
  * scope header and scenario-specific detail. Open-ended — new scenarios add a
  * value here plus their own `VerifyRunContext` shape.
- * - coding: verifying a software change (branch / commit / surfaces under test).
+ * - coding:   verifying a software change (branch / commit / surfaces under test).
+ * - writing:  verifying a written deliverable (manuscript / chapters / documents).
+ * - research: verifying a research deliverable (question / sources / claims).
+ * - generic:  any other delivery — no modeled scope; context is an open bag.
  */
-export const verifyRunScenarios = ['coding'] as const;
+export const verifyRunScenarios = ['coding', 'writing', 'research', 'generic'] as const;
 export type VerifyRunScenario = (typeof verifyRunScenarios)[number];
 
 /**

--- a/packages/types/src/verify.ts
+++ b/packages/types/src/verify.ts
@@ -135,9 +135,12 @@ export type VerifyRunSource = 'agent' | 'agent-testing';
  * records what *produced* the run): `scenario` drives how the report renders its
  * scope header and scenario-specific detail. Open-ended — new scenarios add a
  * value here plus their own {@link VerifyRunContext} shape.
- * - coding: verifying a software change (branch / commit / surfaces under test).
+ * - coding:   verifying a software change (branch / commit / surfaces under test).
+ * - writing:  verifying a written deliverable (manuscript / chapters / documents).
+ * - research: verifying a research deliverable (question / sources / claims).
+ * - generic:  any other delivery — no modeled scope; context is an open bag.
  */
-export type VerifyRunScenario = 'coding';
+export type VerifyRunScenario = 'coding' | 'writing' | 'research' | 'generic';
 
 /**
  * The product surface a check was exercised on — *where* it ran, never *what
@@ -218,15 +221,75 @@ export interface VerifyCodingScope {
 }
 
 /**
+ * Writing-scenario scope: what manuscript this round verified. Every field is
+ * optional — the viewer renders whatever the round recorded.
+ */
+export interface VerifyWritingScope {
+  /** Chapters covered by this round (delivered so far / in this batch). */
+  chapters?: number;
+  /** Documents holding the deliverable under verification. */
+  documentIds?: string[];
+  /** Entry point / command exercised, e.g. "lh doc export". */
+  entry?: string;
+  /** Genre / form of the work, e.g. "长篇小说". */
+  genre?: string;
+  /** When the round was executed (ISO 8601) — distinct from ingest time. */
+  testedAt?: string;
+  /** Word count of the manuscript under verification. */
+  wordCount?: number;
+  /** Title of the work under verification. */
+  work?: string;
+}
+
+/** One source backing a research deliverable. */
+export interface VerifyResearchSource {
+  title?: string;
+  url?: string;
+}
+
+/**
+ * Research-scenario scope: what question the deliverable answers and what it
+ * stands on.
+ */
+export interface VerifyResearchScope {
+  /** Entry point / command exercised. */
+  entry?: string;
+  /** The research question the deliverable answers. */
+  question?: string;
+  /** Count of distinct sources consulted (when listing them all is too long). */
+  sourceCount?: number;
+  /** Key sources backing the deliverable. */
+  sources?: VerifyResearchSource[];
+  /** When the round was executed (ISO 8601) — distinct from ingest time. */
+  testedAt?: string;
+  /** Time range the research covers, e.g. "2024–2026". */
+  timeRange?: string;
+}
+
+/**
+ * Catch-all scope for scenarios without a modeled shape yet. An open bag on
+ * purpose: the server stores non-coding context as-is, so a new scenario can
+ * ship its own scope fields without a server change.
+ */
+export interface VerifyGenericScope {
+  [key: string]: unknown;
+  /** Entry point / command exercised. */
+  entry?: string;
+  /** When the round was executed (ISO 8601) — distinct from ingest time. */
+  testedAt?: string;
+}
+
+/**
  * The scenario's context — its scope/provenance, discriminated by the run's
- * `scenario`. Kept in one jsonb (not columns) so each scenario can carry its own
- * shape and the viewer can render per scenario without a migration. Today only
- * `coding`; as scenarios grow this becomes a union (`VerifyCodingScope | …`).
+ * `scenario` (a sibling column, so the shapes need no inline discriminant).
+ * Kept in one jsonb (not columns) so each scenario can carry its own shape and
+ * the viewer can render per scenario without a migration.
  *
- * Distinct from a future generic `metadata` bag (reserved for cross-scenario
+ * Distinct from the generic `metadata` bag (reserved for cross-scenario
  * extension) — `context` is specifically the active scenario's input.
  */
-export type VerifyRunContext = VerifyCodingScope;
+export type VerifyRunContext =
+  VerifyCodingScope | VerifyWritingScope | VerifyResearchScope | VerifyGenericScope;
 
 export interface VerifyInteractionCostOperators {
   H?: number;

--- a/src/features/Conversation/Markdown/plugins/Link/Render/InternalEntityPreview.tsx
+++ b/src/features/Conversation/Markdown/plugins/Link/Render/InternalEntityPreview.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { VerifyCodingScope } from '@lobechat/types';
 import { Avatar, Flexbox, Icon, Popover, Skeleton, Text } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import type { TFunction } from 'i18next';
@@ -168,11 +169,15 @@ const getPreviewData = async (
             uncertain: report.uncertainChecks ?? 0,
           })
         : null;
-      const context = run.context;
+      // Branch/commit chips only exist on a coding scope (a run with no
+      // scenario predates the column and is coding); testedAt is shared.
+      const codingScope =
+        (run.scenario ?? 'coding') === 'coding' ? (run.context as VerifyCodingScope | null) : null;
+      const testedAt = (run.context as { testedAt?: string } | null)?.testedAt;
       const scope = [
-        context?.branch,
-        context?.commit?.slice(0, 10),
-        context?.testedAt ? new Date(context.testedAt).toLocaleString() : null,
+        codingScope?.branch,
+        codingScope?.commit?.slice(0, 10),
+        testedAt ? new Date(testedAt).toLocaleString() : null,
       ].filter(Boolean);
 
       return {

--- a/src/features/Verify/Acceptance/index.tsx
+++ b/src/features/Verify/Acceptance/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { VerifyCodingScope } from '@lobechat/types';
 import {
   ActionIcon,
   Center,
@@ -214,7 +215,12 @@ const AcceptancePage = memo<AcceptancePageProps>(({ acceptanceId: explicitAccept
   const { acceptance, checks, latestReport, rounds, subject } = data;
   const currentRound = rounds.at(-1);
   // The scope header comes from the latest round that carries a coding context.
-  const scope = [...rounds].reverse().find((round) => round.run.context)?.run.context;
+  // A round with no scenario predates the column and is a coding round; a
+  // non-coding round's context carries none of the chips this header renders.
+  const scope = [...rounds]
+    .reverse()
+    .find((round) => (round.run.scenario ?? 'coding') === 'coding' && round.run.context)?.run
+    .context as VerifyCodingScope | null | undefined;
 
   const groupKeys = groupChecks(checks, t('acceptance.group.uncategorized')).map(
     (group) => group.key,

--- a/src/features/Verify/ReportViewer.tsx
+++ b/src/features/Verify/ReportViewer.tsx
@@ -1877,7 +1877,12 @@ const ReportViewer = memo<ReportViewerProps>(({ runId: explicitRunId }) => {
             {!isCodingReport && run.goal && <Text className={styles.summary}>{run.goal}</Text>}
             {report?.summary && <Text className={styles.summary}>{report.summary}</Text>}
 
-            {isCodingReport && <CodingScopeCard context={run.context} origin={origin} />}
+            {isCodingReport && (
+              <CodingScopeCard
+                context={run.context as VerifyCodingScope | null | undefined}
+                origin={origin}
+              />
+            )}
 
             {liveStatus && (
               <div className={styles.liveBanner}>


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

The verify/acceptance pipeline is scenario-agnostic at the data-model level (`verify_runs.scenario` + jsonb `context`), but the contract layer still hard-wired `coding` everywhere, so non-coding deliveries (writing, research, …) could not enter the pipeline at all. This PR opens that contract so any agent delivery can reuse the same verify → acceptance loop:

- **Scenario vocabulary**: `verifyRunScenarios` / `VerifyRunScenario` grows from `coding` to `coding | writing | research | generic` (both deliberate copies — `@lobechat/const` runtime array and `@lobechat/types` union — updated in sync; the const drift test guards them).
- **Per-scenario context shapes**: `VerifyRunContext` becomes a union — `VerifyCodingScope | VerifyWritingScope | VerifyResearchScope | VerifyGenericScope`. New scopes model the writing scenario (work / genre / wordCount / chapters / documentIds) and the research scenario (question / sources / sourceCount / timeRange), plus an open generic bag.
- **Server (`createRun` / `updateRun`)**: `context` is now validated by its sibling `scenario`. `coding` keeps the existing strict schema (surface canonicalization at the door); every other scenario stores its scope as an open bag, so a new scenario — or a new scope field — never requires a server redeploy. Implemented as a transform rather than a zod union because the all-optional coding schema would silently strip a non-coding scope's fields on first match. Absent scenario still defaults to `coding` (legacy `lh` clients keep working unchanged).
- **CLI (`lh verify ingest-report`)**: removes the hard-coded `scenario='coding'` (previously `result.scenario === 'coding' ? 'coding' : 'coding'`). `result.json.scenario` now passes through, an unknown value hard-errors at ingest (mirroring the strict surface policy), and non-coding reports carry `result.json.context` as the scenario's own scope with shared provenance defaults (`entry`, `testedAt`) lifted from top-level fields.
- **UI consumers**: `ReportViewer`, the acceptance page scope header, and the internal-link verify preview narrow coding-only chips (branch / commit / PR) behind the scenario gate instead of assuming every context is a coding scope; non-coding reports degrade gracefully (goal + summary). Scenario-specific scope cards for writing/research are follow-up work.

No DB migration: `verify_runs.scenario` is a plain text column typed via `$type`.

#### 🧪 How to Test

- Server: `verify.test.ts` adds a `createRun` scenario-contract suite — a `research` context bag lands as-is (regression: the old enum rejected it), a scenario-less coding context still canonicalizes `electron → desktop`, and an unknown scenario is rejected before touching the DB.
- CLI: `verify.test.ts` adds ingest-report cases — `result.json.scenario` passes through with its context bag, an unknown scenario exits 1 without creating a run, and `scenarioFromResult` / `genericContextFromResult` unit coverage (defaults, explicit-context-wins).
- Full type-check clean; targeted `bun run check` on all 9 touched files passes (lint clean, 78 tests).

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📝 Additional Information

Contract-only slice of the "generalize verify/acceptance beyond coding" track. Not included (follow-ups): a non-operation `verify plan generate` entry, per-scenario scope cards in the report viewer, and executing `program` verifiers (still v1 placeholders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)