### PR TITLE
✨ feat(home): mark-all-read for the daily brief section

### DIFF
--- a/apps/server/src/routers/lambda/brief.ts
+++ b/apps/server/src/routers/lambda/brief.ts
@@ -210,4 +210,24 @@ export const briefRouter = router({
         });
       }
     }),
+
+  // Bulk "mark all read" from the home inbox news section. Always resolves
+  // with the neutral `read` action — never `approve` — so clearing a pile of
+  // reports can't complete their tasks as a side effect.
+  resolveManyAsRead: briefWriteProcedure
+    .input(z.object({ ids: z.array(z.string()).min(1).max(100) }))
+    .mutation(async ({ input, ctx }) => {
+      try {
+        const model = new BriefModel(ctx.serverDB, ctx.userId, ctx.workspaceId ?? undefined);
+        const resolvedIds = await model.resolveManyAsRead(input.ids);
+        return { data: resolvedIds, success: true };
+      } catch (error) {
+        console.error('[brief:resolveManyAsRead]', error);
+        throw new TRPCError({
+          cause: error,
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to resolve briefs',
+        });
+      }
+    }),
 });

--- a/locales/ar/home.json
+++ b/locales/ar/home.json
@@ -45,6 +45,7 @@
   "homePromoBanner.dismiss": "تجاهل",
   "homePromoBanner.label": "{{model}} متاح الآن",
   "inbox.needsYou.title": "يحتاج إليك",
+  "inbox.news.markAllRead": "تحديد الكل كمقروء",
   "inbox.news.subtitle": "لا شيء لتقرره - مجرد نظرة",
   "inbox.news.title": "الملخص اليومي",
   "inbox.running.title": "{{count}} مهمة قيد التشغيل",

--- a/locales/bg-BG/home.json
+++ b/locales/bg-BG/home.json
@@ -45,6 +45,7 @@
   "homePromoBanner.dismiss": "Затвори",
   "homePromoBanner.label": "{{model}} вече е наличен",
   "inbox.needsYou.title": "Има нужда от вас",
+  "inbox.news.markAllRead": "Отбележи всички като прочетени",
   "inbox.news.subtitle": "Няма какво да решавате — просто погледнете",
   "inbox.news.title": "Ежедневен бюлетин",
   "inbox.running.title": "{{count}} задача в процес",

--- a/locales/de-DE/home.json
+++ b/locales/de-DE/home.json
@@ -45,6 +45,7 @@
   "homePromoBanner.dismiss": "Schließen",
   "homePromoBanner.label": "{{model}} ist jetzt verfügbar",
   "inbox.needsYou.title": "Braucht dich",
+  "inbox.news.markAllRead": "Alle als gelesen markieren",
   "inbox.news.subtitle": "Nichts zu entscheiden – nur ein Blick",
   "inbox.news.title": "Tägliche Zusammenfassung",
   "inbox.running.title": "{{count}} Aufgabe läuft",

--- a/locales/en-US/home.json
+++ b/locales/en-US/home.json
@@ -45,6 +45,7 @@
   "homePromoBanner.dismiss": "Dismiss",
   "homePromoBanner.label": "{{model}} is now available",
   "inbox.needsYou.title": "Needs you",
+  "inbox.news.markAllRead": "Mark all read",
   "inbox.news.subtitle": "Nothing to decide — just a glance",
   "inbox.news.title": "Daily brief",
   "inbox.running.title": "{{count}} task running",

--- a/locales/es-ES/home.json
+++ b/locales/es-ES/home.json
@@ -45,6 +45,7 @@
   "homePromoBanner.dismiss": "Cerrar",
   "homePromoBanner.label": "{{model}} ya está disponible",
   "inbox.needsYou.title": "Te necesita",
+  "inbox.news.markAllRead": "Marcar todo como leído",
   "inbox.news.subtitle": "Nada que decidir — solo un vistazo",
   "inbox.news.title": "Resumen diario",
   "inbox.running.title": "{{count}} tarea en ejecución",

--- a/locales/fa-IR/home.json
+++ b/locales/fa-IR/home.json
@@ -45,6 +45,7 @@
   "homePromoBanner.dismiss": "بستن",
   "homePromoBanner.label": "{{model}} اکنون در دسترس است",
   "inbox.needsYou.title": "به شما نیاز دارد",
+  "inbox.news.markAllRead": "علامت‌گذاری همه به‌عنوان خوانده‌شده",
   "inbox.news.subtitle": "چیزی برای تصمیم‌گیری نیست — فقط یک نگاه",
   "inbox.news.title": "خلاصه روزانه",
   "inbox.running.title": "{{count}} وظیفه در حال اجرا",

--- a/locales/fr-FR/home.json
+++ b/locales/fr-FR/home.json
@@ -45,6 +45,7 @@
   "homePromoBanner.dismiss": "Fermer",
   "homePromoBanner.label": "{{model}} est maintenant disponible",
   "inbox.needsYou.title": "A besoin de vous",
+  "inbox.news.markAllRead": "Marquer tout comme lu",
   "inbox.news.subtitle": "Rien à décider — juste un coup d'œil",
   "inbox.news.title": "Résumé quotidien",
   "inbox.running.title": "{{count}} tâche en cours",

--- a/locales/it-IT/home.json
+++ b/locales/it-IT/home.json
@@ -45,6 +45,7 @@
   "homePromoBanner.dismiss": "Chiudi",
   "homePromoBanner.label": "{{model}} è ora disponibile",
   "inbox.needsYou.title": "Ha bisogno di te",
+  "inbox.news.markAllRead": "Segna tutto come letto",
   "inbox.news.subtitle": "Niente da decidere — solo uno sguardo",
   "inbox.news.title": "Riepilogo quotidiano",
   "inbox.running.title": "{{count}} attività in corso",

--- a/locales/ja-JP/home.json
+++ b/locales/ja-JP/home.json
@@ -45,6 +45,7 @@
   "homePromoBanner.dismiss": "閉じる",
   "homePromoBanner.label": "{{model}}が利用可能になりました",
   "inbox.needsYou.title": "あなたが必要です",
+  "inbox.news.markAllRead": "すべて既読にする",
   "inbox.news.subtitle": "決めることはありません — ただ一目見るだけ",
   "inbox.news.title": "デイリーブリーフ",
   "inbox.running.title": "{{count}} 件のタスクが実行中",

--- a/locales/ko-KR/home.json
+++ b/locales/ko-KR/home.json
@@ -45,6 +45,7 @@
   "homePromoBanner.dismiss": "닫기",
   "homePromoBanner.label": "{{model}}이(가) 이제 사용 가능합니다",
   "inbox.needsYou.title": "당신이 필요합니다",
+  "inbox.news.markAllRead": "모두 읽음으로 표시",
   "inbox.news.subtitle": "결정할 필요 없음 — 한눈에 보기",
   "inbox.news.title": "일일 요약",
   "inbox.running.title": "{{count}}개의 작업 실행 중",

--- a/locales/nl-NL/home.json
+++ b/locales/nl-NL/home.json
@@ -45,6 +45,7 @@
   "homePromoBanner.dismiss": "Sluiten",
   "homePromoBanner.label": "{{model}} is nu beschikbaar",
   "inbox.needsYou.title": "Heeft je nodig",
+  "inbox.news.markAllRead": "Alles als gelezen markeren",
   "inbox.news.subtitle": "Niets te beslissen — gewoon een blik",
   "inbox.news.title": "Dagelijks overzicht",
   "inbox.running.title": "{{count}} taak actief",

--- a/locales/pl-PL/home.json
+++ b/locales/pl-PL/home.json
@@ -45,6 +45,7 @@
   "homePromoBanner.dismiss": "Zamknij",
   "homePromoBanner.label": "{{model}} jest już dostępny",
   "inbox.needsYou.title": "Potrzebuje Cię",
+  "inbox.news.markAllRead": "Oznacz wszystkie jako przeczytane",
   "inbox.news.subtitle": "Nic do zdecydowania — tylko rzut oka",
   "inbox.news.title": "Codzienny przegląd",
   "inbox.running.title": "{{count}} zadanie w toku",

--- a/locales/pt-BR/home.json
+++ b/locales/pt-BR/home.json
@@ -45,6 +45,7 @@
   "homePromoBanner.dismiss": "Fechar",
   "homePromoBanner.label": "{{model}} já está disponível",
   "inbox.needsYou.title": "Precisa de você",
+  "inbox.news.markAllRead": "Marcar tudo como lido",
   "inbox.news.subtitle": "Nada para decidir — apenas um olhar",
   "inbox.news.title": "Resumo diário",
   "inbox.running.title": "{{count}} tarefa em execução",

--- a/locales/ru-RU/home.json
+++ b/locales/ru-RU/home.json
@@ -45,6 +45,7 @@
   "homePromoBanner.dismiss": "Закрыть",
   "homePromoBanner.label": "{{model}} теперь доступен",
   "inbox.needsYou.title": "Нуждается в вас",
+  "inbox.news.markAllRead": "Отметить все как прочитанные",
   "inbox.news.subtitle": "Ничего решать — просто взгляд",
   "inbox.news.title": "Ежедневная сводка",
   "inbox.running.title": "{{count}} задача выполняется",

--- a/locales/tr-TR/home.json
+++ b/locales/tr-TR/home.json
@@ -45,6 +45,7 @@
   "homePromoBanner.dismiss": "Kapat",
   "homePromoBanner.label": "{{model}} artık mevcut",
   "inbox.needsYou.title": "Sana ihtiyaç var",
+  "inbox.news.markAllRead": "Tümünü okundu olarak işaretle",
   "inbox.news.subtitle": "Karar vermeye gerek yok — sadece bir bakış",
   "inbox.news.title": "Günlük özet",
   "inbox.running.title": "{{count}} görev çalışıyor",

--- a/locales/vi-VN/home.json
+++ b/locales/vi-VN/home.json
@@ -45,6 +45,7 @@
   "homePromoBanner.dismiss": "Bỏ qua",
   "homePromoBanner.label": "{{model}} hiện đã có sẵn",
   "inbox.needsYou.title": "Cần bạn",
+  "inbox.news.markAllRead": "Đánh dấu tất cả là đã đọc",
   "inbox.news.subtitle": "Không có gì cần quyết định — chỉ cần nhìn qua",
   "inbox.news.title": "Tóm tắt hàng ngày",
   "inbox.running.title": "{{count}} nhiệm vụ đang chạy",

--- a/locales/zh-CN/home.json
+++ b/locales/zh-CN/home.json
@@ -45,6 +45,7 @@
   "homePromoBanner.dismiss": "关闭",
   "homePromoBanner.label": "{{model}} 现已上线",
   "inbox.needsYou.title": "需要你处理",
+  "inbox.news.markAllRead": "全部已读",
   "inbox.news.subtitle": "不需要你做决定，扫一眼就行",
   "inbox.news.title": "今日简报",
   "inbox.running.title": "{{count}} 个任务正在执行",

--- a/locales/zh-TW/home.json
+++ b/locales/zh-TW/home.json
@@ -45,6 +45,7 @@
   "homePromoBanner.dismiss": "關閉",
   "homePromoBanner.label": "{{model}} 現已推出",
   "inbox.needsYou.title": "需要您",
+  "inbox.news.markAllRead": "全部標記為已讀",
   "inbox.news.subtitle": "無需決定 — 只需一瞥",
   "inbox.news.title": "每日簡報",
   "inbox.running.title": "{{count}} 項任務正在執行",

--- a/packages/database/src/models/__tests__/brief.test.ts
+++ b/packages/database/src/models/__tests__/brief.test.ts
@@ -607,6 +607,66 @@ describe('BriefModel', () => {
     });
   });
 
+  describe('resolveManyAsRead', () => {
+    it('should resolve the given briefs with the read action and return their ids', async () => {
+      const model = new BriefModel(serverDB, userId);
+      const a = await model.create({ summary: 'A', title: 'Report A', type: 'result' });
+      const b = await model.create({ summary: 'B', title: 'Report B', type: 'insight' });
+
+      const resolvedIds = await model.resolveManyAsRead([a.id, b.id]);
+      expect(resolvedIds.sort()).toEqual([a.id, b.id].sort());
+
+      for (const id of [a.id, b.id]) {
+        const found = await model.findById(id);
+        expect(found!.resolvedAt).not.toBeNull();
+        expect(found!.readAt).not.toBeNull();
+        expect(found!.resolvedAction).toBe('read');
+      }
+    });
+
+    it('should skip already-resolved briefs and keep their original action', async () => {
+      const model = new BriefModel(serverDB, userId);
+      const approved = await model.create({ summary: 'A', title: 'Delivery', type: 'result' });
+      await model.resolve(approved.id, { action: 'approve' });
+      const fresh = await model.create({ summary: 'B', title: 'Report', type: 'result' });
+
+      const resolvedIds = await model.resolveManyAsRead([approved.id, fresh.id]);
+      expect(resolvedIds).toEqual([fresh.id]);
+
+      const kept = await model.findById(approved.id);
+      expect(kept!.resolvedAction).toBe('approve');
+    });
+
+    it('should preserve the first-read timestamp of an already-read brief', async () => {
+      const model = new BriefModel(serverDB, userId);
+      const brief = await model.create({ summary: 'A', title: 'Report', type: 'result' });
+      const read = await model.markRead(brief.id);
+
+      await model.resolveManyAsRead([brief.id]);
+
+      const found = await model.findById(brief.id);
+      expect(found!.readAt).toEqual(read!.readAt);
+      expect(found!.resolvedAt).not.toBeNull();
+    });
+
+    it('should not resolve briefs owned by another user', async () => {
+      const otherModel = new BriefModel(serverDB, userId2);
+      const foreign = await otherModel.create({ summary: 'X', title: 'Foreign', type: 'result' });
+
+      const model = new BriefModel(serverDB, userId);
+      const resolvedIds = await model.resolveManyAsRead([foreign.id]);
+      expect(resolvedIds).toEqual([]);
+
+      const untouched = await otherModel.findById(foreign.id);
+      expect(untouched!.resolvedAt).toBeNull();
+    });
+
+    it('should return empty for an empty id list', async () => {
+      const model = new BriefModel(serverDB, userId);
+      await expect(model.resolveManyAsRead([])).resolves.toEqual([]);
+    });
+  });
+
   describe('delete', () => {
     it('should delete brief', async () => {
       const model = new BriefModel(serverDB, userId);

--- a/packages/database/src/models/brief.ts
+++ b/packages/database/src/models/brief.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNull, notInArray, type SQL, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, notInArray, type SQL, sql } from 'drizzle-orm';
 
 import { agents } from '../schemas/agent';
 import type { BriefItem, NewBrief } from '../schemas/task';
@@ -243,6 +243,34 @@ export class BriefModel {
       .returning();
 
     return result[0] || null;
+  }
+
+  /**
+   * Bulk "mark all read": resolves the given briefs with a neutral `read`
+   * action so they leave the unresolved feed. Deliberately bypasses
+   * `BriefService.resolve()` — a bulk dismissal must never trigger the
+   * approve-completes-task lifecycle; only a single explicit `approve` may.
+   * Already-resolved briefs are skipped so a stale client list cannot
+   * overwrite an earlier, more meaningful resolution.
+   *
+   * Returns the ids that were actually resolved.
+   */
+  async resolveManyAsRead(ids: string[]): Promise<string[]> {
+    if (ids.length === 0) return [];
+
+    const now = new Date();
+    const rows = await this.db
+      .update(briefs)
+      .set({
+        // Keep the first-read timestamp when the brief was already opened.
+        readAt: sql`COALESCE(${briefs.readAt}, ${now})`,
+        resolvedAction: 'read',
+        resolvedAt: now,
+      })
+      .where(and(inArray(briefs.id, ids), this.ownership(), isNull(briefs.resolvedAt)))
+      .returning({ id: briefs.id });
+
+    return rows.map((row) => row.id);
   }
 
   /**

--- a/packages/locales/src/default/home.ts
+++ b/packages/locales/src/default/home.ts
@@ -47,6 +47,7 @@ export default {
   'homePromoBanner.dismiss': 'Dismiss',
   'homePromoBanner.label': '{{model}} is now available',
   'inbox.needsYou.title': 'Needs you',
+  'inbox.news.markAllRead': 'Mark all read',
   'inbox.news.subtitle': 'Nothing to decide — just a glance',
   'inbox.news.title': 'Daily brief',
   'inbox.running.title': '{{count}} task running',

--- a/src/features/HomeInbox/MarkAllReadButton.tsx
+++ b/src/features/HomeInbox/MarkAllReadButton.tsx
@@ -1,0 +1,45 @@
+import { Button } from '@lobehub/ui/base-ui';
+import { CheckCheckIcon } from 'lucide-react';
+import { memo, useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { type BriefItem } from '@/features/DailyBrief/types';
+import { useBriefStore } from '@/store/brief';
+
+interface MarkAllReadButtonProps {
+  news: BriefItem[];
+}
+
+/**
+ * Clears the whole news pile in one click. Resolution happens with the neutral
+ * `read` action — reports are knowledge, so dismissing them wholesale must
+ * never accept a delivery or complete a task.
+ */
+const MarkAllReadButton = memo<MarkAllReadButtonProps>(({ news }) => {
+  const { t } = useTranslation('home');
+  const resolveBriefsAsRead = useBriefStore((s) => s.resolveBriefsAsRead);
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = useCallback(async () => {
+    setLoading(true);
+    try {
+      await resolveBriefsAsRead(news.map((brief) => brief.id));
+    } finally {
+      setLoading(false);
+    }
+  }, [news, resolveBriefsAsRead]);
+
+  return (
+    <Button
+      disabled={loading}
+      icon={CheckCheckIcon}
+      size={'small'}
+      type={'text'}
+      onClick={handleClick}
+    >
+      {t('inbox.news.markAllRead')}
+    </Button>
+  );
+});
+
+export default MarkAllReadButton;

--- a/src/features/HomeInbox/index.tsx
+++ b/src/features/HomeInbox/index.tsx
@@ -15,6 +15,7 @@ import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/slices/auth/selectors';
 
 import InboxBriefCard from './InboxBriefCard';
+import MarkAllReadButton from './MarkAllReadButton';
 import NewsList from './NewsList';
 import RunningTasksCard from './RunningTasksCard';
 import { splitBriefs } from './splitBriefs';
@@ -36,6 +37,8 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 }));
 
 interface InboxSection {
+  /** Header action revealed on hover (GroupBlock's action slot). */
+  action?: ReactNode;
   key: string;
   node: ReactNode;
   /** Omitted when the section labels itself (the running card names its own count). */
@@ -55,14 +58,15 @@ const titleWithCount = (label: string, count: number, subtitle?: string): ReactN
  * The home inbox: everything the agents did while you were away, sorted by
  * whether it needs you.
  *
- * - **Needs you** — briefs blocking an agent (decide / review / fix). Errors sink
- *   to the bottom: a stuck decision blocks work right now, a failed run has
- *   already stopped.
+ * - **Needs you** — briefs blocking an agent (decide / fix). Errors sink to the
+ *   bottom: a stuck decision blocks work right now, a failed run has already
+ *   stopped.
  * - **Unread** — runs that finished while you were away, each showing the agent's
  *   last reply so the answer is right there.
  * - **Running** — collapsed to one line, showing who is working; a healthy run
  *   needs nothing from you.
- * - **News** — `insight` briefs; read them or don't.
+ * - **News** — `insight` + `result` briefs (reports of finished work); read them
+ *   or don't.
  *
  * Sections are siblings, never nested: each names itself and carries its own
  * count, and one absent section never hides another's heading.
@@ -159,6 +163,7 @@ const HomeInbox = memo(() => {
 
   if (news.length > 0)
     sections.push({
+      action: <MarkAllReadButton news={news} />,
       key: 'news',
       node: <NewsList news={news} />,
       title: titleWithCount(t('inbox.news.title'), news.length, t('inbox.news.subtitle')),
@@ -182,9 +187,9 @@ const HomeInbox = memo(() => {
 
   return (
     <Flexbox gap={32}>
-      {sections.map(({ key, node, title }) =>
+      {sections.map(({ action, key, node, title }) =>
         title ? (
-          <GroupBlock key={key} title={title}>
+          <GroupBlock action={action} key={key} title={title}>
             {node}
           </GroupBlock>
         ) : (

--- a/src/features/HomeInbox/splitBriefs.test.ts
+++ b/src/features/HomeInbox/splitBriefs.test.ts
@@ -7,11 +7,8 @@ import { splitBriefs } from './splitBriefs';
 const brief = (id: string, type: BriefItem['type']): BriefItem =>
   ({ id, summary: '', title: id, type }) as BriefItem;
 
-const scheduledResult = (id: string): BriefItem =>
-  ({ ...brief(id, 'result'), taskStatus: 'scheduled' }) as BriefItem;
-
 describe('splitBriefs', () => {
-  it('routes insight briefs to news and everything else to needsYou', () => {
+  it('routes insight and result briefs to news, decision and error to needsYou', () => {
     const { needsYou, news } = splitBriefs([
       brief('a', 'decision'),
       brief('b', 'insight'),
@@ -19,28 +16,33 @@ describe('splitBriefs', () => {
       brief('d', 'error'),
     ]);
 
-    expect(needsYou.map((b) => b.id)).toEqual(['a', 'c', 'd']);
-    expect(news.map((b) => b.id)).toEqual(['b']);
+    expect(needsYou.map((b) => b.id)).toEqual(['a', 'd']);
+    expect(news.map((b) => b.id)).toEqual(['b', 'c']);
   });
 
-  it('routes scheduled task results to news instead of needsYou', () => {
-    const recurringReport = scheduledResult('run-now-scheduled-task-report');
-    const oneOffDelivery = brief('one-off-delivery', 'result');
+  it('routes results to news regardless of the parent task runtime status', () => {
+    const scheduledReport = { ...brief('scheduled-report', 'result'), taskStatus: 'scheduled' };
+    const pausedTaskReport = { ...brief('paused-task-report', 'result'), taskStatus: 'paused' };
+    const detachedResult = brief('detached-result', 'result');
 
-    const { needsYou, news } = splitBriefs([recurringReport, oneOffDelivery]);
+    const { needsYou, news } = splitBriefs([
+      scheduledReport,
+      pausedTaskReport,
+      detachedResult,
+    ] as BriefItem[]);
 
-    expect(needsYou.map((item) => item.id)).toEqual(['one-off-delivery']);
-    expect(news.map((item) => item.id)).toEqual(['run-now-scheduled-task-report']);
+    expect(needsYou).toEqual([]);
+    expect(news.map((item) => item.id)).toEqual([
+      'scheduled-report',
+      'paused-task-report',
+      'detached-result',
+    ]);
   });
 
   it('sinks errors to the bottom of needsYou', () => {
-    const { needsYou } = splitBriefs([
-      brief('err', 'error'),
-      brief('res', 'result'),
-      brief('dec', 'decision'),
-    ]);
+    const { needsYou } = splitBriefs([brief('err', 'error'), brief('dec', 'decision')]);
 
-    expect(needsYou.map((b) => b.id)).toEqual(['dec', 'res', 'err']);
+    expect(needsYou.map((b) => b.id)).toEqual(['dec', 'err']);
   });
 
   it('preserves server order within the same rank', () => {

--- a/src/features/HomeInbox/splitBriefs.ts
+++ b/src/features/HomeInbox/splitBriefs.ts
@@ -7,29 +7,29 @@ import { type BriefItem } from '@/features/DailyBrief/types';
 const NEEDS_YOU_ORDER: Record<string, number> = {
   decision: 0,
   error: 9,
-  result: 1,
 };
 
 export interface SplitBriefs {
   /** Briefs the user must act on — grouped as "Needs you", errors last. */
   needsYou: BriefItem[];
-  /** `insight` briefs: nothing to decide, just worth a glance. */
+  /** `insight` + `result` briefs: nothing to decide, just worth a glance. */
   news: BriefItem[];
 }
 
 /**
- * Results belonging to scheduled tasks are recurring reports, including an
- * ad-hoc "Run now" invocation. They remain `result` briefs, but reading the
- * report is enough — they do not require explicit acceptance.
+ * A `result` brief is a completion report: the work already happened, reading
+ * it is enough. Splitting on the parent task's *runtime* status proved fragile
+ * (a paused/completed recurring task flipped its whole report history back
+ * into the to-do pile), so results are news unconditionally — accepting a
+ * one-off delivery stays available from the task page.
  */
 const isNewsBrief = (brief: BriefItem): boolean =>
-  brief.type === 'insight' || (brief.type === 'result' && brief.taskStatus === 'scheduled');
+  brief.type === 'insight' || brief.type === 'result';
 
 /**
  * Splits the unresolved brief feed by whether the user has to *do* something.
- * `decision` / one-off `result` / `error` block an agent until answered;
- * `insight` and recurring-run results are pure knowledge and belong in a
- * scannable list, not in a to-do pile.
+ * `decision` / `error` block an agent until answered; `insight` and `result`
+ * are pure knowledge and belong in a scannable list, not in a to-do pile.
  *
  * The server already sorts by priority then recency, so we only re-order within
  * "Needs you" — a stable sort keeps that ordering inside each rank.

--- a/src/services/brief.ts
+++ b/src/services/brief.ts
@@ -16,6 +16,10 @@ class BriefService {
   resolve = async (id: string, params?: { action?: string; comment?: string }) => {
     return lambdaClient.brief.resolve.mutate({ id, ...params });
   };
+
+  resolveManyAsRead = async (ids: string[]) => {
+    return lambdaClient.brief.resolveManyAsRead.mutate({ ids });
+  };
 }
 
 export const briefService = new BriefService();

--- a/src/store/brief/slices/list/action.ts
+++ b/src/store/brief/slices/list/action.ts
@@ -48,6 +48,23 @@ export class BriefListActionImpl {
     this.internal_updateBrief(id, { readAt: new Date().toISOString() });
   };
 
+  // "Mark all read" over the news section: resolves the briefs with the
+  // neutral `read` action (server-side, never `approve` — bulk dismissal must
+  // not complete tasks) and drops them from the feed, mirroring what the next
+  // unresolved-only fetch would return. Only the ids the server actually
+  // resolved are removed, so a brief resolved elsewhere in the meantime keeps
+  // its own resolution.
+  resolveBriefsAsRead = async (ids: string[]) => {
+    if (ids.length === 0) return;
+
+    const result = await briefService.resolveManyAsRead(ids);
+    const resolvedIds = new Set(result.data);
+    if (resolvedIds.size === 0) return;
+
+    const briefs = this.#get().briefs.filter((b) => !resolvedIds.has(b.id));
+    this.#set({ briefs }, false, n('resolveBriefsAsRead'));
+  };
+
   resolveBrief = async (id: string, action?: string, comment?: string) => {
     await briefService.resolve(id, { action, comment });
     this.internal_updateBrief(id, {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Follow-up to #17235.

#### 🔀 Description of Change

**1. Route all `result` briefs to the daily brief section (fix)**

#17235 routed a `result` brief to the news section only when its parent task's *runtime* status was `scheduled`. That discriminator proved fragile: once a recurring task pauses (failure fuse), completes (execution cap), or is mid-run, its entire unresolved report history flips back into the "Needs you" pile — even though nothing about those reports changed. A `result` brief is a completion report: the work already happened and reading it is enough, so results now go to news unconditionally. "Needs you" keeps only `decision` and `error` briefs. Accepting a one-off delivery (approve → task completed) stays available from the task page.

**2. Mark-all-read on the news section (feat)**

News briefs only ever got read one by one, so unresolved reports piled up in the capped (20) home feed with no way to clear them. The news section header now exposes a hover-revealed **Mark all read** action:

- `BriefModel.resolveManyAsRead(ids)` bulk-resolves with a neutral `read` action, skips already-resolved briefs (never overwrites an earlier `approve`/`feedback` resolution), preserves the first-read timestamp, and is ownership-scoped.
- New `brief.resolveManyAsRead` TRPC mutation (ids capped at 100). It deliberately bypasses `BriefService.resolve()` — bulk dismissal must never trigger the approve-completes-task lifecycle.
- The store removes only the ids the server actually resolved, mirroring the next unresolved-only fetch.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `splitBriefs` unit tests cover the unconditional result→news routing (including `paused` / missing task status).
- `BriefModel.resolveManyAsRead` model tests cover bulk resolve, skipping already-resolved briefs, first-read timestamp preservation, cross-user isolation, and the empty-list no-op.
- Manual: home inbox → hover the "Daily brief" section header → "Mark all read" clears the pile; recurring-task reports appear under "Daily brief" instead of "Needs you".

#### 📝 Additional Information

The `read` resolved action is a new `resolvedAction` value; nothing filters on specific action values server-side except `approve`, so it is inert for lifecycle logic by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)