### PR TITLE
✨ feat(agent): bridge device-local media into analyzeVisualMedia via auto-upload

### DIFF
--- a/apps/cli/src/tools/index.test.ts
+++ b/apps/cli/src/tools/index.test.ts
@@ -18,11 +18,21 @@ vi.mock('../utils/logger', () => ({
   },
 }));
 
+const mockUploadLocalFile = vi.hoisted(() => vi.fn());
+vi.mock('../utils/uploadLocalFile', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, uploadLocalFile: (...args: any[]) => mockUploadLocalFile(...args) };
+});
+vi.mock('../api/client', () => ({
+  getTrpcClient: vi.fn().mockResolvedValue({}),
+}));
+
 describe('executeToolCall', () => {
   const tmpDir = path.join(os.tmpdir(), 'cli-tool-dispatch-test-' + process.pid);
 
   beforeEach(async () => {
     await mkdir(tmpDir, { recursive: true });
+    mockUploadLocalFile.mockClear();
   });
 
   afterEach(() => {
@@ -132,6 +142,41 @@ describe('executeToolCall', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain('Unknown tool API');
+  });
+
+  it('should dispatch uploadFiles and carry per-file state', async () => {
+    const filePath = path.join(tmpDir, 'frame.png');
+    await writeFile(filePath, 'not-really-png-bytes');
+    mockUploadLocalFile.mockResolvedValue({ id: 'file-xyz', url: 'files/2026/hash.png' });
+
+    const result = await executeToolCall('uploadFiles', JSON.stringify({ paths: [filePath] }));
+
+    expect(result.success).toBe(true);
+    expect(mockUploadLocalFile).toHaveBeenCalledWith(expect.anything(), filePath);
+    expect((result.state as { files: any[] }).files[0]).toMatchObject({
+      fileId: 'file-xyz',
+      mimeType: 'image/png',
+      name: 'frame.png',
+      url: 'files/2026/hash.png',
+    });
+  });
+
+  it('should reject non-media files in uploadFiles without failing the whole batch', async () => {
+    const badPath = path.join(tmpDir, 'notes.txt');
+    await writeFile(badPath, 'text');
+
+    const result = await executeToolCall('uploadFiles', JSON.stringify({ paths: [badPath] }));
+
+    expect(result.success).toBe(false);
+    expect(mockUploadLocalFile).not.toHaveBeenCalled();
+    expect((result.state as { files: any[] }).files[0].error).toContain('Unsupported media type');
+  });
+
+  it('should error when uploadFiles receives no paths', async () => {
+    const result = await executeToolCall('uploadFiles', JSON.stringify({ paths: [] }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('non-empty');
   });
 
   it('should carry structured state on file reads', async () => {

--- a/apps/cli/src/tools/index.ts
+++ b/apps/cli/src/tools/index.ts
@@ -4,6 +4,7 @@ import { getAgentProfile } from './getAgentProfile';
 import { cancelHeteroTask, runHeteroTask } from './heteroTask';
 import { executeToolCallInWorker, shouldRunInWorker } from './isolatedWorker';
 import { runLocalSystemTool } from './localSystemRuntime';
+import { uploadFiles } from './uploadFiles';
 
 /**
  * CLI-only tools (platform agents). File/shell tools are handled separately by
@@ -42,6 +43,14 @@ export async function executeToolCall(
     typeof timeout === 'number' && Number.isFinite(timeout) && !('timeout' in args)
       ? { ...args, timeout }
       : args;
+
+  // Server-internal media upload bridge (visual-analysis local-media path).
+  // Returns a full envelope with per-file `state`, so it bypasses both the
+  // local-system runtime and the raw-payload `methodMap` serialization below.
+  if (apiName === 'uploadFiles') {
+    const { content, error, state, success } = await uploadFiles(finalArgs);
+    return { content, error, state, success };
+  }
 
   try {
     // File/shell tools route through LocalSystemExecutionRuntime so `content` is

--- a/apps/cli/src/tools/uploadFiles.ts
+++ b/apps/cli/src/tools/uploadFiles.ts
@@ -1,0 +1,120 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { getTrpcClient } from '../api/client';
+import { detectMimeType, uploadLocalFile } from '../utils/uploadLocalFile';
+
+/**
+ * Per-file result shape mirroring the desktop gateway's `uploadFiles` handler
+ * and `UploadedLocalFileResult` in `@lobechat/builtin-tool-local-system`. A
+ * `error` entry means the other fields are unset for that path.
+ */
+interface UploadedLocalFileResult {
+  error?: string;
+  fileId?: string;
+  mimeType?: string;
+  name: string;
+  path: string;
+  size?: number;
+  url?: string;
+}
+
+/** Per-file cap for server-requested media uploads (matches the desktop path). */
+const UPLOAD_LOCAL_FILE_MAX_BYTES = 100 * 1024 * 1024;
+
+/** Only image/video media may be pulled off the device by a server tool. */
+const isSupportedVisualMediaMime = (mimeType: string) =>
+  mimeType.startsWith('image/') || mimeType.startsWith('video/');
+
+/**
+ * Server-internal `uploadFiles` tool for the `lh connect` daemon: uploads
+ * device-local media into the LobeHub file store so a server-side tool (the
+ * visual-analysis bridge) can reach it by URL. Mirrors the desktop
+ * `GatewayConnectionCtr.uploadLocalFilesForServer` contract — per-file errors
+ * so one bad path does not fail the batch — but uses the CLI's real tRPC file
+ * client instead of the Electron lambda-fetch port.
+ *
+ * Not registered in the LLM-facing manifest; only dispatched server-side.
+ */
+export const uploadFiles = async (args: {
+  paths?: unknown;
+}): Promise<{
+  content: string;
+  error?: string;
+  state: { files: UploadedLocalFileResult[] };
+  success: boolean;
+}> => {
+  const paths = Array.isArray(args?.paths)
+    ? args.paths.filter((p): p is string => typeof p === 'string' && p.length > 0)
+    : [];
+
+  if (paths.length === 0) {
+    return {
+      content: 'uploadFiles requires a non-empty "paths" array.',
+      error: 'uploadFiles requires a non-empty "paths" array.',
+      state: { files: [] },
+      success: false,
+    };
+  }
+
+  const client = await getTrpcClient();
+
+  const files = await Promise.all(
+    paths.map(async (rawPath): Promise<UploadedLocalFileResult> => {
+      const resolvedPath = rawPath.startsWith('~/')
+        ? path.join(os.homedir(), rawPath.slice(2))
+        : rawPath;
+      const name = path.basename(resolvedPath);
+
+      try {
+        const stat = await fs.promises.stat(resolvedPath);
+        if (!stat.isFile()) return { error: 'Not a regular file.', name, path: rawPath };
+        if (stat.size > UPLOAD_LOCAL_FILE_MAX_BYTES) {
+          return {
+            error: `File is ${stat.size} bytes, exceeding the ${UPLOAD_LOCAL_FILE_MAX_BYTES} byte upload limit.`,
+            name,
+            path: rawPath,
+          };
+        }
+
+        const mimeType = detectMimeType(name);
+        if (!isSupportedVisualMediaMime(mimeType)) {
+          return {
+            error: `Unsupported media type "${mimeType}". Only image/video files can be uploaded.`,
+            name,
+            path: rawPath,
+          };
+        }
+
+        const record = (await uploadLocalFile(client, resolvedPath)) as { id: string; url: string };
+
+        return {
+          fileId: record.id,
+          mimeType,
+          name,
+          path: rawPath,
+          size: stat.size,
+          url: record.url,
+        };
+      } catch (error) {
+        return {
+          error: error instanceof Error ? error.message : String(error),
+          name,
+          path: rawPath,
+        };
+      }
+    }),
+  );
+
+  const failed = files.filter((f) => f.error);
+
+  return {
+    content: JSON.stringify({ files }),
+    ...(failed.length > 0 && {
+      error: `${failed.length}/${files.length} file(s) failed to upload.`,
+    }),
+    state: { files },
+    success: failed.length === 0,
+  };
+};

--- a/apps/cli/src/tools/uploadFiles.ts
+++ b/apps/cli/src/tools/uploadFiles.ts
@@ -60,52 +60,58 @@ export const uploadFiles = async (args: {
 
   const client = await getTrpcClient();
 
-  const files = await Promise.all(
-    paths.map(async (rawPath): Promise<UploadedLocalFileResult> => {
-      const resolvedPath = rawPath.startsWith('~/')
-        ? path.join(os.homedir(), rawPath.slice(2))
-        : rawPath;
-      const name = path.basename(resolvedPath);
+  const uploadOne = async (rawPath: string): Promise<UploadedLocalFileResult> => {
+    const resolvedPath = rawPath.startsWith('~/')
+      ? path.join(os.homedir(), rawPath.slice(2))
+      : rawPath;
+    const name = path.basename(resolvedPath);
 
-      try {
-        const stat = await fs.promises.stat(resolvedPath);
-        if (!stat.isFile()) return { error: 'Not a regular file.', name, path: rawPath };
-        if (stat.size > UPLOAD_LOCAL_FILE_MAX_BYTES) {
-          return {
-            error: `File is ${stat.size} bytes, exceeding the ${UPLOAD_LOCAL_FILE_MAX_BYTES} byte upload limit.`,
-            name,
-            path: rawPath,
-          };
-        }
-
-        const mimeType = detectMimeType(name);
-        if (!isSupportedVisualMediaMime(mimeType)) {
-          return {
-            error: `Unsupported media type "${mimeType}". Only image/video files can be uploaded.`,
-            name,
-            path: rawPath,
-          };
-        }
-
-        const record = (await uploadLocalFile(client, resolvedPath)) as { id: string; url: string };
-
+    try {
+      const stat = await fs.promises.stat(resolvedPath);
+      if (!stat.isFile()) return { error: 'Not a regular file.', name, path: rawPath };
+      if (stat.size > UPLOAD_LOCAL_FILE_MAX_BYTES) {
         return {
-          fileId: record.id,
-          mimeType,
-          name,
-          path: rawPath,
-          size: stat.size,
-          url: record.url,
-        };
-      } catch (error) {
-        return {
-          error: error instanceof Error ? error.message : String(error),
+          error: `File is ${stat.size} bytes, exceeding the ${UPLOAD_LOCAL_FILE_MAX_BYTES} byte upload limit.`,
           name,
           path: rawPath,
         };
       }
-    }),
-  );
+
+      const mimeType = detectMimeType(name);
+      if (!isSupportedVisualMediaMime(mimeType)) {
+        return {
+          error: `Unsupported media type "${mimeType}". Only image/video files can be uploaded.`,
+          name,
+          path: rawPath,
+        };
+      }
+
+      const record = (await uploadLocalFile(client, resolvedPath)) as { id: string; url: string };
+
+      return {
+        fileId: record.id,
+        mimeType,
+        name,
+        path: rawPath,
+        size: stat.size,
+        url: record.url,
+      };
+    } catch (error) {
+      return {
+        error: error instanceof Error ? error.message : String(error),
+        name,
+        path: rawPath,
+      };
+    }
+  };
+
+  // Upload sequentially so a multi-file request keeps at most one file (bounded
+  // by the 100 MB/file cap) resident in memory at a time, rather than reading
+  // every file up front via Promise.all.
+  const files: UploadedLocalFileResult[] = [];
+  for (const rawPath of paths) {
+    files.push(await uploadOne(rawPath));
+  }
 
   const failed = files.filter((f) => f.error);
 

--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -691,54 +691,61 @@ export default class GatewayConnectionCtr extends ControllerModule {
       return { content: message, error: { code: 'NO_FILE_STORE', message }, success: false };
     }
 
-    const files: UploadedLocalFileResult[] = await Promise.all(
-      paths.map(async (rawPath): Promise<UploadedLocalFileResult> => {
-        const resolvedPath = rawPath.startsWith('~/')
-          ? path.join(os.homedir(), rawPath.slice(2))
-          : rawPath;
-        const name = path.basename(resolvedPath);
+    const uploadOne = async (rawPath: string): Promise<UploadedLocalFileResult> => {
+      const resolvedPath = rawPath.startsWith('~/')
+        ? path.join(os.homedir(), rawPath.slice(2))
+        : rawPath;
+      const name = path.basename(resolvedPath);
 
-        try {
-          const stat = await fs.promises.stat(resolvedPath);
-          if (!stat.isFile()) {
-            return { error: 'Not a regular file.', name, path: rawPath };
-          }
-          if (stat.size > UPLOAD_LOCAL_FILE_MAX_BYTES) {
-            return {
-              error: `File is ${stat.size} bytes, exceeding the ${UPLOAD_LOCAL_FILE_MAX_BYTES} byte upload limit.`,
-              name,
-              path: rawPath,
-            };
-          }
-
-          const ext = path.extname(resolvedPath).slice(1).toLowerCase();
-          const mimeType = UPLOAD_LOCAL_FILE_MIME_BY_EXT[ext];
-          if (!mimeType) {
-            return {
-              error: `Unsupported media type ".${ext}". Only image/video files can be uploaded.`,
-              name,
-              path: rawPath,
-            };
-          }
-
-          const buffer = await fs.promises.readFile(resolvedPath);
-          const { fileId, url } = await uploadBufferToFileStore(port, {
-            buffer,
-            fileName: name,
-            mimeType,
-          });
-
-          return { fileId, mimeType, name, path: rawPath, size: stat.size, url };
-        } catch (error) {
-          logger.error(`uploadFiles failed for ${resolvedPath}:`, error);
+      try {
+        const stat = await fs.promises.stat(resolvedPath);
+        if (!stat.isFile()) {
+          return { error: 'Not a regular file.', name, path: rawPath };
+        }
+        if (stat.size > UPLOAD_LOCAL_FILE_MAX_BYTES) {
           return {
-            error: error instanceof Error ? error.message : String(error),
+            error: `File is ${stat.size} bytes, exceeding the ${UPLOAD_LOCAL_FILE_MAX_BYTES} byte upload limit.`,
             name,
             path: rawPath,
           };
         }
-      }),
-    );
+
+        const ext = path.extname(resolvedPath).slice(1).toLowerCase();
+        const mimeType = UPLOAD_LOCAL_FILE_MIME_BY_EXT[ext];
+        if (!mimeType) {
+          return {
+            error: `Unsupported media type ".${ext}". Only image/video files can be uploaded.`,
+            name,
+            path: rawPath,
+          };
+        }
+
+        const buffer = await fs.promises.readFile(resolvedPath);
+        const { fileId, url } = await uploadBufferToFileStore(port, {
+          buffer,
+          fileName: name,
+          mimeType,
+        });
+
+        return { fileId, mimeType, name, path: rawPath, size: stat.size, url };
+      } catch (error) {
+        logger.error(`uploadFiles failed for ${resolvedPath}:`, error);
+        return {
+          error: error instanceof Error ? error.message : String(error),
+          name,
+          path: rawPath,
+        };
+      }
+    };
+
+    // Upload sequentially: each file is read fully into memory before the store
+    // PUT, so with the 100 MB/file cap and 8-URL server cap, a multi-video
+    // request could otherwise read ~800 MB into the Electron main process at
+    // once. Serial keeps at most one file resident.
+    const files: UploadedLocalFileResult[] = [];
+    for (const rawPath of paths) {
+      files.push(await uploadOne(rawPath));
+    }
 
     const failed = files.filter((f) => f.error);
     const content = JSON.stringify({ files });

--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -24,8 +24,10 @@ import type {
   RunCommandParams,
   WriteLocalFileParams,
 } from '@lobechat/electron-client-ipc';
+import { uploadBufferToFileStore } from '@lobechat/heterogeneous-agents/spawn';
 import { type ILocalSystemService, LocalSystemExecutionRuntime } from '@lobechat/tool-runtime';
 
+import { createLambdaFileStorePort } from '@/modules/heterogeneousAgent/fileStorePort';
 import GatewayConnectionService from '@/services/gatewayConnectionSrv';
 import ImessageBridgeService from '@/services/imessageBridgeSrv';
 import { createLogger } from '@/utils/logger';
@@ -103,6 +105,53 @@ interface BuiltinServerRuntimeOutput {
   state?: unknown;
   success: boolean;
 }
+
+/**
+ * Local mirrors of the `uploadFiles` shapes in
+ * `@lobechat/builtin-tool-local-system` (server-internal API — see the zero
+ * builtin-tool-deps note on `BrowserIdentifier` above for why not imported).
+ */
+interface UploadLocalFilesParams {
+  paths?: string[];
+}
+
+interface UploadedLocalFileResult {
+  error?: string;
+  fileId?: string;
+  mimeType?: string;
+  name: string;
+  path: string;
+  size?: number;
+  url?: string;
+}
+
+/** Per-file cap for server-requested media uploads (matches vision use cases). */
+const UPLOAD_LOCAL_FILE_MAX_BYTES = 100 * 1024 * 1024;
+
+/**
+ * Media types the server-side visual bridge can consume. Deliberately narrow:
+ * this API exists so server tools can look at device media, not as a generic
+ * file exfiltration channel.
+ */
+const UPLOAD_LOCAL_FILE_MIME_BY_EXT: Record<string, string> = {
+  avi: 'video/x-msvideo',
+  bmp: 'image/bmp',
+  gif: 'image/gif',
+  heic: 'image/heic',
+  jpeg: 'image/jpeg',
+  jpg: 'image/jpeg',
+  m4v: 'video/x-m4v',
+  mkv: 'video/x-matroska',
+  mov: 'video/quicktime',
+  mp4: 'video/mp4',
+  mpeg: 'video/mpeg',
+  mpg: 'video/mpeg',
+  png: 'image/png',
+  svg: 'image/svg+xml',
+  tiff: 'image/tiff',
+  webm: 'video/webm',
+  webp: 'image/webp',
+};
 
 /**
  * Legacy API name aliases used by older gateway versions. Normalized to the
@@ -596,12 +645,115 @@ export default class GatewayConnectionCtr extends ControllerModule {
         return { content: json, state: safeJsonParse(json), success: true };
       }
 
+      case 'uploadFiles': {
+        return this.uploadLocalFilesForServer(args as UploadLocalFilesParams);
+      }
+
       default: {
         throw new Error(
           `Tool "${apiName}" is not available on this device. It may not be supported in the current desktop version. Please skip this tool and try alternative approaches.`,
         );
       }
     }
+  }
+
+  /**
+   * Upload device-local media files into the LobeHub file store, on behalf of
+   * a server-side tool (the visual-analysis local-media bridge). The server
+   * can't reach this disk, so it tunnels an `uploadFiles` call here; we read
+   * the bytes, push them through the presign/PUT/createFile flow, and hand
+   * back `{ fileId, url }` refs the server resolves into access URLs.
+   *
+   * Per-file failures land as `error` entries so the model can fix a single
+   * bad path without the whole batch failing.
+   */
+  private async uploadLocalFilesForServer(
+    params: UploadLocalFilesParams,
+  ): Promise<BuiltinServerRuntimeOutput> {
+    const paths = Array.isArray(params?.paths)
+      ? params.paths.filter((p): p is string => typeof p === 'string' && p.length > 0)
+      : [];
+
+    if (paths.length === 0) {
+      const message = 'uploadFiles requires a non-empty "paths" array.';
+      return { content: message, error: { code: 'INVALID_ARGUMENTS', message }, success: false };
+    }
+
+    const remoteServerConfigCtr = this.app.getController(RemoteServerConfigCtr);
+    const port = await createLambdaFileStorePort({
+      getAccessToken: () => remoteServerConfigCtr.getAccessToken(),
+      getServerUrl: async () => (await remoteServerConfigCtr.getRemoteServerUrl()) ?? null,
+    });
+
+    if (!port) {
+      const message =
+        'This device is not signed in to a remote LobeHub server, so it cannot upload files.';
+      return { content: message, error: { code: 'NO_FILE_STORE', message }, success: false };
+    }
+
+    const files: UploadedLocalFileResult[] = await Promise.all(
+      paths.map(async (rawPath): Promise<UploadedLocalFileResult> => {
+        const resolvedPath = rawPath.startsWith('~/')
+          ? path.join(os.homedir(), rawPath.slice(2))
+          : rawPath;
+        const name = path.basename(resolvedPath);
+
+        try {
+          const stat = await fs.promises.stat(resolvedPath);
+          if (!stat.isFile()) {
+            return { error: 'Not a regular file.', name, path: rawPath };
+          }
+          if (stat.size > UPLOAD_LOCAL_FILE_MAX_BYTES) {
+            return {
+              error: `File is ${stat.size} bytes, exceeding the ${UPLOAD_LOCAL_FILE_MAX_BYTES} byte upload limit.`,
+              name,
+              path: rawPath,
+            };
+          }
+
+          const ext = path.extname(resolvedPath).slice(1).toLowerCase();
+          const mimeType = UPLOAD_LOCAL_FILE_MIME_BY_EXT[ext];
+          if (!mimeType) {
+            return {
+              error: `Unsupported media type ".${ext}". Only image/video files can be uploaded.`,
+              name,
+              path: rawPath,
+            };
+          }
+
+          const buffer = await fs.promises.readFile(resolvedPath);
+          const { fileId, url } = await uploadBufferToFileStore(port, {
+            buffer,
+            fileName: name,
+            mimeType,
+          });
+
+          return { fileId, mimeType, name, path: rawPath, size: stat.size, url };
+        } catch (error) {
+          logger.error(`uploadFiles failed for ${resolvedPath}:`, error);
+          return {
+            error: error instanceof Error ? error.message : String(error),
+            name,
+            path: rawPath,
+          };
+        }
+      }),
+    );
+
+    const failed = files.filter((f) => f.error);
+    const content = JSON.stringify({ files });
+
+    return {
+      content,
+      ...(failed.length > 0 && {
+        error: {
+          code: 'UPLOAD_PARTIAL_FAILURE',
+          message: `${failed.length}/${files.length} file(s) failed to upload.`,
+        },
+      }),
+      state: { files },
+      success: failed.length === 0,
+    };
   }
 
   /**

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts
@@ -642,6 +642,28 @@ describe('lobeAgentRuntime', () => {
     expect(mockChat).not.toHaveBeenCalled();
   });
 
+  it('should reject an unsupported local modality BEFORE dispatching the device upload', async () => {
+    mockToolsEnv.VISUAL_UNDERSTANDING_MODEL = 'image-only-model';
+    const deviceContext: ToolExecutionContext = { ...baseContext, activeDeviceId: 'device-1' };
+    const runtime = lobeAgentRuntime.factory(deviceContext);
+
+    const result = await runtime.analyzeVisualMedia(
+      {
+        question: 'what is in the video?',
+        urls: ['file:///Users/me/clip.mp4'],
+      },
+      deviceContext,
+    );
+
+    expect(result).toMatchObject({
+      error: { code: 'VISUAL_MODEL_VIDEO_UNSUPPORTED' },
+      success: false,
+    });
+    // The whole point: no bytes leave the device when the model can't use them.
+    expect(mockDeviceExecuteToolCall).not.toHaveBeenCalled();
+    expect(mockChat).not.toHaveBeenCalled();
+  });
+
   describe('callSubAgent', () => {
     it('rejects nested sub-agent execution without calling the injected runner', async () => {
       const runtime = lobeAgentRuntime.factory(baseContext);

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts
@@ -14,6 +14,7 @@ const mockMessageModelQuery = vi.hoisted(() => vi.fn());
 const mockChat = vi.hoisted(() => vi.fn());
 const mockInitModelRuntimeFromDB = vi.hoisted(() => vi.fn());
 const mockConsumeStreamUntilDone = vi.hoisted(() => vi.fn());
+const mockDeviceExecuteToolCall = vi.hoisted(() => vi.fn());
 const mockBuiltinModels = vi.hoisted(() => [
   {
     abilities: { video: true, vision: true },
@@ -40,8 +41,16 @@ vi.mock('@/database/models/message', () => ({
 
 vi.mock('@/server/services/file', () => ({
   FileService: vi.fn().mockImplementation(() => ({
+    getFileAccessUrl: ({ id }: { id?: string | null }) =>
+      Promise.resolve(`https://files.test/${id}`),
     getFullFileUrl: (path: string | null) => Promise.resolve(path || ''),
   })),
+}));
+
+vi.mock('@/server/services/deviceGateway', () => ({
+  deviceGateway: {
+    executeToolCall: (...args: any[]) => mockDeviceExecuteToolCall(...args),
+  },
 }));
 
 vi.mock('@/server/modules/ModelRuntime', () => ({
@@ -287,6 +296,134 @@ describe('lobeAgentRuntime', () => {
     expect(result.content).toContain(`At most ${MAX_VISUAL_MEDIA_URLS} URLs are supported`);
     expect(mockMessageModelQueryByIds).not.toHaveBeenCalled();
     expect(mockChat).not.toHaveBeenCalled();
+  });
+
+  it('should reject local file paths when the run has no active device', async () => {
+    const runtime = lobeAgentRuntime.factory(baseContext);
+
+    const result = await runtime.analyzeVisualMedia(
+      {
+        question: 'what is this?',
+        urls: ['file:///Users/me/frame.png'],
+      },
+      baseContext,
+    );
+
+    expect(result).toMatchObject({
+      error: { code: 'LOCAL_VISUAL_MEDIA_NO_DEVICE' },
+      success: false,
+    });
+    expect(result.content).toContain('file:///Users/me/frame.png');
+    expect(mockDeviceExecuteToolCall).not.toHaveBeenCalled();
+    expect(mockChat).not.toHaveBeenCalled();
+  });
+
+  it('should upload local file paths through the active device and analyze them', async () => {
+    mockDeviceExecuteToolCall.mockResolvedValue({
+      content: '',
+      state: {
+        files: [
+          {
+            fileId: 'file-abc',
+            mimeType: 'image/png',
+            name: 'frame.png',
+            path: '/Users/me/frame.png',
+            size: 123,
+            url: 'files/2026-07-16/hash.png',
+          },
+        ],
+      },
+      success: true,
+    });
+    const deviceContext: ToolExecutionContext = { ...baseContext, activeDeviceId: 'device-1' };
+    const runtime = lobeAgentRuntime.factory(deviceContext);
+
+    const result = await runtime.analyzeVisualMedia(
+      {
+        question: 'what is this?',
+        urls: ['file:///Users/me/frame.png', 'https://example.com/remote.png'],
+      },
+      deviceContext,
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockDeviceExecuteToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({ deviceId: 'device-1', userId: 'user-1' }),
+      expect.objectContaining({
+        apiName: 'uploadFiles',
+        arguments: JSON.stringify({ paths: ['/Users/me/frame.png'] }),
+        identifier: 'lobe-local-system',
+      }),
+      expect.any(Number),
+    );
+    expect(result.state).toMatchObject({
+      files: [
+        { name: 'remote.png', ref: 'url_1', type: 'image' },
+        { id: 'file-abc', name: 'frame.png', ref: 'local_1', type: 'image' },
+      ],
+    });
+    expect(mockChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          expect.objectContaining({
+            content: expect.arrayContaining([
+              expect.objectContaining({
+                image_url: { detail: 'auto', url: 'https://files.test/file-abc' },
+                type: 'image_url',
+              }),
+            ]),
+          }),
+        ],
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('should surface per-file device upload failures', async () => {
+    mockDeviceExecuteToolCall.mockResolvedValue({
+      content: '',
+      state: {
+        files: [{ error: 'File not found.', name: 'missing.png', path: '/Users/me/missing.png' }],
+      },
+      success: false,
+    });
+    const deviceContext: ToolExecutionContext = { ...baseContext, activeDeviceId: 'device-1' };
+    const runtime = lobeAgentRuntime.factory(deviceContext);
+
+    const result = await runtime.analyzeVisualMedia(
+      {
+        question: 'what is this?',
+        urls: ['/Users/me/missing.png'],
+      },
+      deviceContext,
+    );
+
+    expect(result).toMatchObject({
+      error: { code: 'LOCAL_VISUAL_MEDIA_UPLOAD_FAILED' },
+      success: false,
+    });
+    expect(result.content).toContain('/Users/me/missing.png (File not found.)');
+    expect(mockChat).not.toHaveBeenCalled();
+  });
+
+  it('should surface a device dispatch failure as an upload error', async () => {
+    mockDeviceExecuteToolCall.mockRejectedValue(new Error('Device is offline'));
+    const deviceContext: ToolExecutionContext = { ...baseContext, activeDeviceId: 'device-1' };
+    const runtime = lobeAgentRuntime.factory(deviceContext);
+
+    const result = await runtime.analyzeVisualMedia(
+      {
+        question: 'what is this?',
+        urls: ['~/Desktop/frame.png'],
+      },
+      deviceContext,
+    );
+
+    expect(result).toMatchObject({
+      error: { code: 'LOCAL_VISUAL_MEDIA_UPLOAD_FAILED' },
+      success: false,
+    });
+    expect(result.content).toContain('Device is offline');
   });
 
   it('should allow http and visual data direct media urls', async () => {

--- a/apps/server/src/services/toolExecution/serverRuntimes/lobeAgent.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/lobeAgent.ts
@@ -9,12 +9,21 @@ import {
   createVisualFileItems,
   formatVisualMediaUrlValidationError,
   hasUserVisualFiles,
+  inferVisualTypeFromMimeType,
   LobeAgentIdentifier,
+  MAX_VISUAL_MEDIA_URLS,
   normalizeAnalyzeVisualMediaInput,
+  partitionLocalVisualMediaUrls,
   PlanExecutionRuntime,
   selectVisualFileItems,
+  toLocalVisualMediaPath,
   validateVisualMediaUrls,
 } from '@lobechat/builtin-tool-lobe-agent';
+import {
+  LocalSystemApiName,
+  LocalSystemIdentifier,
+  type UploadLocalFilesState,
+} from '@lobechat/builtin-tool-local-system';
 import { UserInteractionExecutionRuntime } from '@lobechat/builtin-tool-user-interaction/executionRuntime';
 import type { LobeChatDatabase } from '@lobechat/database';
 import type { ChatStreamPayload } from '@lobechat/model-runtime';
@@ -25,10 +34,12 @@ import { RequestTrigger } from '@lobechat/types';
 import { MessageModel } from '@/database/models/message';
 import { toolsEnv } from '@/envs/tools';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
+import { deviceGateway } from '@/server/services/deviceGateway';
 import { FileService } from '@/server/services/file';
 
 import type { ToolExecutionContext } from '../types';
 import { createServerPlanRuntimeService } from './lobeAgentPlan';
+import { resolveRunWorkspaceId } from './resolveWorkspaceScope';
 import type { ServerRuntimeRegistration } from './types';
 
 interface AnalyzeVisualMediaParams {
@@ -60,6 +71,12 @@ const buildError = (content: string, code: string): BuiltinServerRuntimeOutput =
   error: { code, message: content },
   success: false,
 });
+
+/**
+ * Media uploads move whole files off the device, so give them more headroom
+ * than a regular tool round-trip regardless of the step's own timeout.
+ */
+const DEVICE_VISUAL_UPLOAD_TIMEOUT_MS = 120_000;
 
 const getModelAbilities = async (model: string, provider: string) => {
   const { loadModels } = await import('@/business/client/model-bank/loadModels');
@@ -236,8 +253,90 @@ class LobeAgentExecutionRuntime {
     return Promise.resolve([sourceMessage]);
   };
 
+  /**
+   * Bridge device-local media into the file store so the vision model can see
+   * it: tunnel an `uploadFiles` call to the run's active device (which reads
+   * the bytes and pushes them through the presign/PUT/createFile flow), then
+   * swap each local path for the uploaded file's access URL. Without this,
+   * every route from a server-side tool to a device file is a dead end —
+   * `file://` is unfetchable, the device's localhost is SSRF-blocked, and
+   * data-URL round-trips blow up tool-call payloads.
+   */
+  private uploadLocalVisualMedia = async (
+    localPaths: string[],
+    ctx?: ToolExecutionContext,
+  ): Promise<{ error: BuiltinServerRuntimeOutput } | { items: VisualFileItem[] }> => {
+    if (!ctx?.activeDeviceId) {
+      return {
+        error: buildError(
+          `Local file paths (${localPaths.join(', ')}) can only be analyzed when this run has an active device, and none is active. ` +
+            'Pass http(s) URLs or visual file refs instead, or ask the user to connect their device.',
+          'LOCAL_VISUAL_MEDIA_NO_DEVICE',
+        ),
+      };
+    }
+
+    const uploadError = (detail: string) => ({
+      error: buildError(
+        `Failed to upload local visual media from the device: ${detail}`,
+        'LOCAL_VISUAL_MEDIA_UPLOAD_FAILED',
+      ),
+    });
+
+    let result;
+    try {
+      result = await deviceGateway.executeToolCall(
+        {
+          deviceId: ctx.activeDeviceId,
+          operationId: ctx.operationId,
+          userId: this.userId,
+          workspaceId: await resolveRunWorkspaceId(ctx),
+        },
+        {
+          apiName: LocalSystemApiName.uploadFiles,
+          arguments: JSON.stringify({ paths: localPaths.map(toLocalVisualMediaPath) }),
+          identifier: LocalSystemIdentifier,
+        },
+        Math.max(ctx.executionTimeoutMs ?? 0, DEVICE_VISUAL_UPLOAD_TIMEOUT_MS),
+      );
+    } catch (e) {
+      return uploadError(e instanceof Error ? e.message : String(e));
+    }
+
+    const files = (result.state as UploadLocalFilesState | undefined)?.files;
+
+    if (!files || files.length === 0) {
+      return uploadError(
+        typeof result.content === 'string' && result.content ? result.content : 'unknown error',
+      );
+    }
+
+    const failed = files.filter((file) => file.error || !file.fileId);
+    if (failed.length > 0) {
+      return uploadError(
+        failed.map((file) => `${file.path} (${file.error ?? 'no file record'})`).join('; '),
+      );
+    }
+
+    const fileService = new FileService(this.db, this.userId, this.workspaceId);
+    const items = await Promise.all(
+      files.map(async (file, index): Promise<VisualFileItem> => ({
+        description: file.name,
+        id: file.fileId,
+        localRef: `local_${index + 1}`,
+        name: file.name,
+        ref: `local_${index + 1}`,
+        type: inferVisualTypeFromMimeType(file.mimeType),
+        uri: await fileService.getFileAccessUrl({ id: file.fileId, url: file.url ?? null }),
+      })),
+    );
+
+    return { items };
+  };
+
   analyzeVisualMedia = async (
     params: AnalyzeVisualMediaParams,
+    ctx?: ToolExecutionContext,
   ): Promise<BuiltinServerRuntimeOutput> => {
     const provider = toolsEnv.VISUAL_UNDERSTANDING_PROVIDER;
     const model = toolsEnv.VISUAL_UNDERSTANDING_MODEL;
@@ -263,13 +362,30 @@ class LobeAgentExecutionRuntime {
       );
     }
 
-    const urlValidation = validateVisualMediaUrls(requestedUrls);
+    // Device-local entries (file://, absolute or ~/ paths) can never be
+    // fetched from the server — split them off and bridge them through the
+    // run's active device instead of failing URL validation.
+    const { localPaths, remoteUrls } = partitionLocalVisualMediaUrls(requestedUrls);
+
+    const urlValidation = validateVisualMediaUrls(remoteUrls);
+    urlValidation.totalUrls = requestedUrls.length;
+    urlValidation.tooManyUrls = requestedUrls.length > MAX_VISUAL_MEDIA_URLS;
     const urlValidationError = formatVisualMediaUrlValidationError(urlValidation);
     if (urlValidationError) {
       return buildError(urlValidationError, 'UNSUPPORTED_VISUAL_MEDIA_URLS');
     }
 
-    const selectedUrlItems = createUrlVisualFileItems(urlValidation.validUrls);
+    let localFileItems: VisualFileItem[] = [];
+    if (localPaths.length > 0) {
+      const bridged = await this.uploadLocalVisualMedia(localPaths, ctx);
+      if ('error' in bridged) return bridged.error;
+      localFileItems = bridged.items;
+    }
+
+    const selectedUrlItems = [
+      ...createUrlVisualFileItems(urlValidation.validUrls),
+      ...localFileItems,
+    ];
     let selectedRefItems: VisualFileItem[] = [];
 
     if (requestedRefs.length > 0) {

--- a/apps/server/src/services/toolExecution/serverRuntimes/lobeAgent.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/lobeAgent.ts
@@ -10,6 +10,7 @@ import {
   formatVisualMediaUrlValidationError,
   hasUserVisualFiles,
   inferVisualTypeFromMimeType,
+  inferVisualTypeFromUrl,
   LobeAgentIdentifier,
   MAX_VISUAL_MEDIA_URLS,
   normalizeAnalyzeVisualMediaInput,
@@ -86,6 +87,37 @@ const getModelAbilities = async (model: string, provider: string) => {
     builtinModels.find((item) => item.id === model && item.providerId === provider) ??
     builtinModels.find((item) => item.id === model)
   )?.abilities;
+};
+
+/**
+ * Guard the configured visual-understanding model against the modalities about
+ * to be analyzed. Returns an error output when the model cannot handle one of
+ * them, so the caller can bail before doing expensive work (e.g. uploading a
+ * device-local file that would only be rejected afterwards).
+ */
+const checkVisualModelSupportsTypes = (
+  types: Iterable<VisualFileItem['type']>,
+  abilities: { video?: boolean; vision?: boolean } | undefined,
+  provider: string,
+  model: string,
+): BuiltinServerRuntimeOutput | undefined => {
+  const typeSet = new Set(types);
+
+  if (typeSet.has('image') && abilities?.vision === false) {
+    return buildError(
+      `Configured visual understanding model "${provider}/${model}" does not support image vision.`,
+      'VISUAL_MODEL_IMAGE_UNSUPPORTED',
+    );
+  }
+
+  if (typeSet.has('video') && abilities?.video === false) {
+    return buildError(
+      `Configured visual understanding model "${provider}/${model}" does not support video understanding.`,
+      'VISUAL_MODEL_VIDEO_UNSUPPORTED',
+    );
+  }
+
+  return undefined;
 };
 
 interface ServerVisualSourceMessage extends VisualSourceMessage {
@@ -375,8 +407,23 @@ class LobeAgentExecutionRuntime {
       return buildError(urlValidationError, 'UNSUPPORTED_VISUAL_MEDIA_URLS');
     }
 
+    const abilities = await getModelAbilities(model, provider);
+
     let localFileItems: VisualFileItem[] = [];
     if (localPaths.length > 0) {
+      // Guard the model's modality against the local files BEFORE dispatching
+      // the device upload — inferring type from the path extension (the same
+      // allowlist the device upload enforces). Otherwise an unsupported local
+      // file (e.g. a video for an image-only model) would be read and uploaded
+      // up to 100 MB only to be rejected by the ability check below.
+      const localTypeError = checkVisualModelSupportsTypes(
+        localPaths.map(inferVisualTypeFromUrl),
+        abilities,
+        provider,
+        model,
+      );
+      if (localTypeError) return localTypeError;
+
       const bridged = await this.uploadLocalVisualMedia(localPaths, ctx);
       if ('error' in bridged) return bridged.error;
       localFileItems = bridged.items;
@@ -448,23 +495,13 @@ class LobeAgentExecutionRuntime {
       return buildError('No visual files selected.', 'NO_VISUAL_FILES_SELECTED');
     }
 
-    const abilities = await getModelAbilities(model, provider);
-    const hasImages = selectedItems.some((item) => item.type === 'image');
-    const hasVideos = selectedItems.some((item) => item.type === 'video');
-
-    if (hasImages && abilities?.vision === false) {
-      return buildError(
-        `Configured visual understanding model "${provider}/${model}" does not support image vision.`,
-        'VISUAL_MODEL_IMAGE_UNSUPPORTED',
-      );
-    }
-
-    if (hasVideos && abilities?.video === false) {
-      return buildError(
-        `Configured visual understanding model "${provider}/${model}" does not support video understanding.`,
-        'VISUAL_MODEL_VIDEO_UNSUPPORTED',
-      );
-    }
+    const typeError = checkVisualModelSupportsTypes(
+      selectedItems.map((item) => item.type),
+      abilities,
+      provider,
+      model,
+    );
+    if (typeError) return typeError;
 
     let content = '';
     let usage: unknown;

--- a/packages/builtin-tool-lobe-agent/src/manifest.ts
+++ b/packages/builtin-tool-lobe-agent/src/manifest.ts
@@ -27,7 +27,8 @@ export const LobeAgentManifest: BuiltinToolManifest = {
             type: 'array',
           },
           urls: {
-            description: 'Direct image or video URLs to analyze when no message file ref exists.',
+            description:
+              'Direct image or video URLs to analyze when no message file ref exists. When the run has an active device, absolute local file paths or file:// URLs on that device are also accepted — they are uploaded automatically.',
             items: {
               type: 'string',
             },

--- a/packages/builtin-tool-lobe-agent/src/visualMedia.test.ts
+++ b/packages/builtin-tool-lobe-agent/src/visualMedia.test.ts
@@ -8,10 +8,14 @@ import {
   filterAllowedVisualMediaUrls,
   formatVisualMediaUrlValidationError,
   hasUserVisualFiles,
+  inferVisualTypeFromMimeType,
+  isLocalVisualMediaPath,
   MAX_VISUAL_MEDIA_URL_LENGTH,
   MAX_VISUAL_MEDIA_URLS,
   normalizeStringArray,
+  partitionLocalVisualMediaUrls,
   selectVisualFileItems,
+  toLocalVisualMediaPath,
   validateVisualMediaUrls,
 } from './visualMedia';
 
@@ -186,5 +190,46 @@ describe('visualMedia', () => {
         role: 'assistant',
       }),
     ).toBe(false);
+  });
+
+  it('should detect device-local visual media paths', () => {
+    expect(isLocalVisualMediaPath('file:///Users/me/frame.png')).toBe(true);
+    expect(isLocalVisualMediaPath('/Users/me/frame.png')).toBe(true);
+    expect(isLocalVisualMediaPath('~/Desktop/frame.png')).toBe(true);
+    expect(isLocalVisualMediaPath('C:\\Users\\me\\frame.png')).toBe(true);
+    expect(isLocalVisualMediaPath('D:/media/frame.png')).toBe(true);
+
+    expect(isLocalVisualMediaPath('https://example.com/frame.png')).toBe(false);
+    expect(isLocalVisualMediaPath('data:image/png;base64,abcd')).toBe(false);
+    expect(isLocalVisualMediaPath('frame.png')).toBe(false);
+  });
+
+  it('should convert file urls to plain device paths', () => {
+    expect(toLocalVisualMediaPath('file:///Users/me/my%20frame.png')).toBe(
+      '/Users/me/my frame.png',
+    );
+    expect(toLocalVisualMediaPath('file:///C:/media/frame.png')).toBe('C:/media/frame.png');
+    expect(toLocalVisualMediaPath('/Users/me/frame.png')).toBe('/Users/me/frame.png');
+    expect(toLocalVisualMediaPath('~/Desktop/frame.png')).toBe('~/Desktop/frame.png');
+  });
+
+  it('should partition local paths from remote urls', () => {
+    expect(
+      partitionLocalVisualMediaUrls([
+        'https://example.com/frame.png',
+        'file:///Users/me/frame.png',
+        '/Users/me/other.png',
+        'data:image/png;base64,abcd',
+      ]),
+    ).toEqual({
+      localPaths: ['file:///Users/me/frame.png', '/Users/me/other.png'],
+      remoteUrls: ['https://example.com/frame.png', 'data:image/png;base64,abcd'],
+    });
+  });
+
+  it('should infer visual type from mime type', () => {
+    expect(inferVisualTypeFromMimeType('video/mp4')).toBe('video');
+    expect(inferVisualTypeFromMimeType('image/png')).toBe('image');
+    expect(inferVisualTypeFromMimeType(undefined)).toBe('image');
   });
 });

--- a/packages/builtin-tool-lobe-agent/src/visualMedia.ts
+++ b/packages/builtin-tool-lobe-agent/src/visualMedia.ts
@@ -23,6 +23,8 @@ const VIDEO_URL_PATTERN = /\.(?:mp4|m4v|mov|webm|mpeg|mpg|avi|mkv)(?:[?#]|$)/i;
 const VISUAL_DATA_URL_PATTERN = /^data:(?:image|video)\//i;
 const ALLOWED_REMOTE_VISUAL_MEDIA_URL_PROTOCOLS = new Set(['http:', 'https:']);
 const ANALYZE_VISUAL_MEDIA_ARGUMENT_KEYS = new Set(['question', 'refs', 'urls']);
+const WINDOWS_DRIVE_PATH_PATTERN = /^[A-Z]:[\\/]/i;
+const FILE_URL_WINDOWS_PATH_PATTERN = /^\/(?=[A-Z]:[\\/])/i;
 
 export const MAX_VISUAL_MEDIA_URLS = 8;
 export const MAX_VISUAL_MEDIA_URL_LENGTH = 2_000_000;
@@ -61,6 +63,44 @@ export const normalizeAnalyzeVisualMediaInput = (
 
 export const getUnexpectedAnalyzeVisualMediaArgumentKeys = (params: Record<PropertyKey, unknown>) =>
   Object.keys(params).filter((key) => !ANALYZE_VISUAL_MEDIA_ARGUMENT_KEYS.has(key));
+
+/**
+ * A "local" visual media entry points at the executing device's disk instead of
+ * a fetchable URL: `file://` URLs, POSIX absolute / home-relative paths, or
+ * Windows drive paths. These can never be fetched by the server — they must be
+ * uploaded from the device first (see the server runtime's device bridge).
+ */
+export const isLocalVisualMediaPath = (value: string) => {
+  if (value.startsWith('file://')) return true;
+  if (value.startsWith('/') || value.startsWith('~/')) return true;
+
+  return WINDOWS_DRIVE_PATH_PATTERN.test(value);
+};
+
+/** Convert a `file://` URL into the plain absolute path the device expects. */
+export const toLocalVisualMediaPath = (value: string) => {
+  if (!value.startsWith('file://')) return value;
+
+  try {
+    const pathname = decodeURIComponent(new URL(value).pathname);
+
+    // `file:///C:/...` parses to a pathname of `/C:/...` — drop the leading slash.
+    return pathname.replace(FILE_URL_WINDOWS_PATH_PATTERN, '');
+  } catch {
+    return value.replace(/^file:\/\//, '');
+  }
+};
+
+export const partitionLocalVisualMediaUrls = (urls: string[]) => {
+  const localPaths: string[] = [];
+  const remoteUrls: string[] = [];
+
+  for (const url of urls) {
+    (isLocalVisualMediaPath(url) ? localPaths : remoteUrls).push(url);
+  }
+
+  return { localPaths, remoteUrls };
+};
 
 export const isAllowedVisualMediaUrl = (url: string) => {
   try {
@@ -189,6 +229,9 @@ export const createVisualFileItems = (
     };
   }),
 ];
+
+export const inferVisualTypeFromMimeType = (mimeType?: string): VisualFileItem['type'] =>
+  mimeType?.toLowerCase().startsWith('video/') ? 'video' : 'image';
 
 export const inferVisualTypeFromUrl = (url: string): VisualFileItem['type'] => {
   if (/^data:video\//i.test(url)) return 'video';

--- a/packages/builtin-tool-local-system/src/index.ts
+++ b/packages/builtin-tool-local-system/src/index.ts
@@ -15,4 +15,7 @@ export {
   LocalSystemApiName,
   LocalSystemIdentifier,
   type RunCommandState,
+  type UploadedLocalFileResult,
+  type UploadLocalFilesParams,
+  type UploadLocalFilesState,
 } from './types';

--- a/packages/builtin-tool-local-system/src/types.ts
+++ b/packages/builtin-tool-local-system/src/types.ts
@@ -25,8 +25,34 @@ export const LocalSystemApiName = {
   readFile: 'readFile',
   runCommand: 'runCommand',
   searchFiles: 'searchFiles',
+  // Server-internal API (not in the LLM-facing manifest): uploads device-local
+  // files to the LobeHub file store so server-side tools (e.g. visual analysis)
+  // can access them by URL. Dispatched directly via the device gateway.
+  uploadFiles: 'uploadFiles',
   writeFile: 'writeFile',
 } as const;
+
+// ==================== uploadFiles (server-internal) ====================
+
+export interface UploadLocalFilesParams {
+  paths: string[];
+}
+
+export interface UploadedLocalFileResult {
+  /** Per-file failure reason; the other fields are unset when present. */
+  error?: string;
+  fileId?: string;
+  mimeType?: string;
+  name: string;
+  path: string;
+  size?: number;
+  /** The stored file record's url (S3 pathname), resolvable via FileService. */
+  url?: string;
+}
+
+export interface UploadLocalFilesState {
+  files: UploadedLocalFileResult[];
+}
 
 export interface FileResult {
   contentType?: string;

--- a/packages/heterogeneous-agents/src/spawn/fileStoreImageUploader.ts
+++ b/packages/heterogeneous-agents/src/spawn/fileStoreImageUploader.ts
@@ -31,6 +31,63 @@ export interface FileStorePort {
   createS3PreSignedUrl: (input: { pathname: string }) => Promise<string | { url: string }>;
 }
 
+export interface UploadBufferToFileStoreParams {
+  buffer: Buffer;
+  /** File name recorded on the file record (display name, not the S3 key). */
+  fileName: string;
+  mimeType: string;
+}
+
+/**
+ * Content-addressed upload of a buffer through a {@link FileStorePort}:
+ * SHA-256 hash → `checkFileHash` dedup → presigned PUT → `createFile`.
+ * Returns the created file record's `{ fileId, url }` (`url` is the stored
+ * pathname, resolvable server-side via FileService).
+ */
+export const uploadBufferToFileStore = async (
+  port: FileStorePort,
+  { buffer, fileName, mimeType }: UploadBufferToFileStoreParams,
+): Promise<{ fileId: string; url: string }> => {
+  const hash = crypto.createHash('sha256').update(buffer).digest('hex');
+  const ext = fileName.includes('.') ? fileName.split('.').pop()! : 'bin';
+  const date = new Date().toLocaleDateString('en-CA'); // YYYY-MM-DD
+
+  // Dedup: if the same bytes are already stored (and the object still
+  // exists), skip the S3 upload entirely and reuse the existing pathname.
+  const existing = await port.checkFileHash({ hash });
+
+  let pathname: string;
+  if (existing?.isExist && existing.url) {
+    pathname = existing.url;
+  } else {
+    pathname = `files/${date}/${hash}.${ext}`;
+    const presigned = await port.createS3PreSignedUrl({ pathname });
+    const presignedUrl = typeof presigned === 'string' ? presigned : presigned.url;
+
+    const uploadRes = await fetch(presignedUrl, {
+      // Buffer<ArrayBufferLike> isn't assignable to BodyInit, but a Buffer is
+      // always a valid fetch body at runtime.
+      body: buffer as unknown as BodyInit,
+      headers: { 'Content-Type': mimeType },
+      method: 'PUT',
+    });
+    if (!uploadRes.ok) {
+      throw new Error(`Upload failed: ${uploadRes.status} ${uploadRes.statusText}`);
+    }
+  }
+
+  const record = await port.createFile({
+    fileType: mimeType,
+    hash,
+    metadata: { date, dirname: '', filename: fileName, path: pathname },
+    name: fileName,
+    size: buffer.length,
+    url: pathname,
+  });
+
+  return { fileId: record.id, url: record.url };
+};
+
 /**
  * Build the {@link UploadHeterogeneousImage} hook `AgentStreamPipeline` calls
  * for each base64 image a tool_result echoes (CC `Read` on an image file).
@@ -46,41 +103,11 @@ export const createFileStoreImageUploader =
     if (!port) return undefined;
 
     const buffer = Buffer.from(data, 'base64');
-    const hash = crypto.createHash('sha256').update(buffer).digest('hex');
     const ext = IMAGE_EXT_BY_MEDIA_TYPE[mediaType] ?? 'png';
-    const fileName = `cc-read-image.${ext}`;
-    const date = new Date().toLocaleDateString('en-CA'); // YYYY-MM-DD
 
-    // Dedup: if the same bytes are already stored (and the object still
-    // exists), skip the S3 upload entirely and reuse the existing pathname.
-    const existing = await port.checkFileHash({ hash });
-
-    let pathname: string;
-    if (existing?.isExist && existing.url) {
-      pathname = existing.url;
-    } else {
-      pathname = `files/${date}/${hash}.${ext}`;
-      const presigned = await port.createS3PreSignedUrl({ pathname });
-      const presignedUrl = typeof presigned === 'string' ? presigned : presigned.url;
-
-      const uploadRes = await fetch(presignedUrl, {
-        body: buffer,
-        headers: { 'Content-Type': mediaType },
-        method: 'PUT',
-      });
-      if (!uploadRes.ok) {
-        throw new Error(`Upload failed: ${uploadRes.status} ${uploadRes.statusText}`);
-      }
-    }
-
-    const record = await port.createFile({
-      fileType: mediaType,
-      hash,
-      metadata: { date, dirname: '', filename: fileName, path: pathname },
-      name: fileName,
-      size: buffer.length,
-      url: pathname,
+    return uploadBufferToFileStore(port, {
+      buffer,
+      fileName: `cc-read-image.${ext}`,
+      mimeType: mediaType,
     });
-
-    return { fileId: record.id, url: record.url };
   };

--- a/packages/heterogeneous-agents/src/spawn/index.ts
+++ b/packages/heterogeneous-agents/src/spawn/index.ts
@@ -47,6 +47,8 @@ export {
   createFileStoreImageUploader,
   type FileStoreCreateFileInput,
   type FileStorePort,
+  uploadBufferToFileStore,
+  type UploadBufferToFileStoreParams,
 } from './fileStoreImageUploader';
 export {
   type AgentContentBlock,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

When a server-run agent op calls `analyzeVisualMedia` with device-local paths, **every route to the media is currently a dead end**, observed live in topic `tpc_Wgp7cswLAtwT` (48 min, 120 steps, $18.9 burned, no video produced):

1. `file:///Users/...` → rejected by URL validation ("Unsupported visual media URLs")
2. local HTTP server (`http://127.0.0.1:8931/...`) → SSRF-blocked server-side
3. data-URL fallback → giant base64 blows up the tool-call arguments

The model burned ~40 steps (~14 min) probing each route, then fell back to blind OCR + pixel heuristics for camera choreography.

This PR adds the missing bridge:

- **Server runtime** (`lobeAgent.ts`): partitions local paths (`file://`, absolute, `~/`, Windows drive) out of `urls`; when the run has an active device, tunnels an internal `uploadFiles` call to it via `deviceGateway.executeToolCall`, then swaps each path for the uploaded file's access URL (`FileService.getFileAccessUrl`) before running the vision request. Without an active device it returns a dedicated `LOCAL_VISUAL_MEDIA_NO_DEVICE` error that steers the model toward refs/http URLs instead of the generic "unsupported URL" wall.
- **Desktop main** (`GatewayConnectionCtr`): handles the new server-internal `uploadFiles` apiName — reads the files, pushes them through the existing `checkFileHash`/presign/PUT/`createFile` flow (`createLambdaFileStorePort`), returns `{ fileId, url }` refs with per-file error entries. Media-only allowlist (image/video MIME), 100 MB per-file cap.
- **Shared** : `uploadBufferToFileStore` extracted from `createFileStoreImageUploader` (same content-addressed flow, now reusable); local-path partition/convert helpers in `visualMedia.ts`; `urls` manifest description now tells the model local device paths are accepted.

`uploadFiles` is deliberately **not** in the LLM-facing manifest — it is only dispatched server-side by the visual bridge. Older desktop builds hit the existing "Tool not available on this device" default branch, which surfaces as the upload-failed error.

#### 🧪 How to Test

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `packages/builtin-tool-lobe-agent`: local-path detection/partition/file-URL conversion tests (12 ✓)
- `apps/server` `lobeAgent.test.ts`: no-device error, device upload + URL swap into the vision payload, per-file failure surfacing, dispatch failure (27 ✓)
- `packages/heterogeneous-agents`: existing uploader suite passes against the extracted helper (101 ✓)
- Repo root `bun run type-check` clean; desktop type-check error count identical to clean canary (277 pre-existing)

E2E scenario: bound-device run → ask the agent to describe frames extracted to a local folder → `analyzeVisualMedia` with `file:///...` paths should upload via the device and answer, with `state.files` showing `local_N` refs.

#### 📸 Screenshots / Videos

N/A (no UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)