### PR TITLE
🐛 fix: preserve boot reload attempts during async reporting

### DIFF
--- a/src/components/BootErrorBoundary/index.test.tsx
+++ b/src/components/BootErrorBoundary/index.test.tsx
@@ -4,6 +4,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import BootErrorBoundary from './index';
 
+const BOOT_RELOAD_SESSION_KEY = 'lobe:boot:hard-reload-attempts';
+
+const ThrowDuringRender = () => {
+  throw new Error('initial boot failure');
+};
+
 const ThrowAfterMount = () => {
   const [failed, setFailed] = useState(false);
 
@@ -17,10 +23,54 @@ const ThrowAfterMount = () => {
 
 afterEach(() => {
   cleanup();
+  window.sessionStorage.clear();
   vi.restoreAllMocks();
 });
 
 describe('BootErrorBoundary', () => {
+  it('clears reload attempts after a successful boot', () => {
+    window.sessionStorage.setItem(BOOT_RELOAD_SESSION_KEY, '1');
+
+    render(
+      <BootErrorBoundary>
+        <div>ready</div>
+      </BootErrorBoundary>,
+    );
+
+    expect(window.sessionStorage.getItem(BOOT_RELOAD_SESSION_KEY)).toBeNull();
+  });
+
+  it('preserves the reload limit while initial error reporting is pending', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let resolveReport: (() => void) | undefined;
+    const onError = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveReport = resolve;
+        }),
+    );
+    window.sessionStorage.setItem(BOOT_RELOAD_SESSION_KEY, '1');
+
+    render(
+      <BootErrorBoundary fallback={<div>boot fallback</div>} maxBootReloads={1} onError={onError}>
+        <ThrowDuringRender />
+      </BootErrorBoundary>,
+    );
+
+    await waitFor(() => expect(onError).toHaveBeenCalledOnce());
+    expect(window.sessionStorage.getItem(BOOT_RELOAD_SESSION_KEY)).toBe('1');
+
+    resolveReport?.();
+    await waitFor(() =>
+      expect(warning).toHaveBeenCalledWith(
+        'BootErrorBoundary reached max reload attempts',
+        expect.objectContaining({ attempts: 1, maxReloads: 1 }),
+      ),
+    );
+    expect(window.sessionStorage.getItem(BOOT_RELOAD_SESSION_KEY)).toBe('1');
+  });
+
   it('reports errors through the optional callback', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
     const onError = vi.fn(async () => {});

--- a/src/components/BootErrorBoundary/index.tsx
+++ b/src/components/BootErrorBoundary/index.tsx
@@ -33,6 +33,9 @@ class BootErrorBoundary extends Component<BootErrorBoundaryProps, BootErrorBound
   private hasBooted = false;
 
   public componentDidMount() {
+    // A fallback mount is not a successful boot; preserve the reload budget across reporting.
+    if (this.state.hasError) return;
+
     this.hasBooted = true;
     this.resetReloadAttempts();
     this.cleanForceReloadMarker();


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to #17234.

#### 🔀 Description of Change

Prevents `BootErrorBoundary` from treating an error fallback mount as a successful boot. Reload attempts are now cleared only after the initial child tree mounts successfully, so an asynchronous error reporter cannot erase the existing reload budget before `tryHardReload()` runs.

Successful boots continue to clear the reload counter and force-reload URL marker as before.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- Added a regression test with a pending asynchronous reporter and an exhausted reload budget.
- Confirmed the regression test fails on the previous implementation because the stored attempt becomes `null`.
- `bun run check` — lint clean and 4 related tests passed.
- `bun run check --type` — full type check passed.
- `git diff --check` — passed.

#### 📸 Screenshots / Videos

Not applicable; this is lifecycle and session-storage behavior.

#### 📝 Additional Information

Follow-up to the unresolved review thread on the already-merged #17234. The change is limited to generic boot recovery behavior and does not alter error-reporting integrations.