### PR TITLE
🐛 fix(moonshot): drop unsupported reasoning_effort values for Kimi K3

### DIFF
--- a/packages/model-runtime/src/providers/moonshot/index.test.ts
+++ b/packages/model-runtime/src/providers/moonshot/index.test.ts
@@ -413,6 +413,22 @@ describe('LobeMoonshotOpenAI', () => {
         expect(payload.reasoning_effort).toBe('max');
       });
 
+      it.each(['low', 'medium', 'high'])(
+        "should drop a non-'max' reasoning_effort (%s) for kimi-k3",
+        async (effort) => {
+          await instance.chat({
+            messages: [{ content: 'Hello', role: 'user' }],
+            model: 'kimi-k3',
+            reasoning_effort: effort,
+          } as any);
+
+          const payload = getLastRequestPayload();
+          // K3 only accepts reasoning_effort 'max' (also the server default); other values
+          // would be rejected, so they are dropped instead of failing the request.
+          expect('reasoning_effort' in payload).toBe(false);
+        },
+      );
+
       it('should force reasoning_content on assistant messages for kimi-k3', async () => {
         await instance.chat({
           messages: [

--- a/packages/model-runtime/src/providers/moonshot/index.ts
+++ b/packages/model-runtime/src/providers/moonshot/index.ts
@@ -204,21 +204,25 @@ const buildMoonshotOpenAIPayload = (
   const moonshotTools = appendSearchTool(tools, enabledSearch);
 
   // K3+ replaced the `thinking` param with the top-level OpenAI-style `reasoning_effort`
-  // (currently only 'max', which is also the server default — passed through from the
-  // payload as-is) and fixes temperature/top_p/n/penalties server-side; the docs advise
-  // not to send them. `max_tokens` is documented as `max_completion_tokens` (default
-  // 131072, up to 1048576). https://platform.kimi.ai/docs/guide/kimi-k3-quickstart
+  // and fixes temperature/top_p/n/penalties server-side; the docs advise not to send
+  // them. `max_tokens` is documented as `max_completion_tokens` (default 131072, up to
+  // 1048576). https://platform.kimi.ai/docs/guide/kimi-k3-quickstart
   if (isKimiReasoningEffortModel(model)) {
     const {
       frequency_penalty: _frequencyPenalty,
       max_tokens,
       presence_penalty: _presencePenalty,
+      reasoning_effort,
       top_p: _topP,
       ...effortRest
     } = rest;
 
     return {
       ...effortRest,
+      // K3 currently only accepts reasoning_effort 'max' (also the server default);
+      // a saved generic effort (the UI offers low/medium/high) would be rejected, so
+      // drop anything else instead of failing the whole request
+      ...(reasoning_effort === 'max' ? { reasoning_effort } : {}),
       ...(max_tokens === undefined ? {} : { max_completion_tokens: max_tokens }),
       messages: normalizedMessages,
       model,

--- a/packages/model-runtime/src/providers/opencodeCodingPlan/index.test.ts
+++ b/packages/model-runtime/src/providers/opencodeCodingPlan/index.test.ts
@@ -177,7 +177,7 @@ describe('buildOpenAIPayload Kimi thinking semantics', () => {
   });
 
   describe('native-thinking K3 models (kimi-k3)', () => {
-    it('should drop a saved thinking:disabled and keep reasoning_effort + forced reasoning_content', async () => {
+    it("should drop a saved thinking:disabled and keep reasoning_effort 'max' + forced reasoning_content", async () => {
       await instance.chat({
         messages: [
           { content: 'Hello', role: 'user' },
@@ -185,7 +185,7 @@ describe('buildOpenAIPayload Kimi thinking semantics', () => {
           { content: 'Follow-up', role: 'user' },
         ],
         model: 'kimi-k3',
-        reasoning_effort: 'high',
+        reasoning_effort: 'max',
         thinking: { type: 'disabled' },
       } as any);
 
@@ -193,10 +193,24 @@ describe('buildOpenAIPayload Kimi thinking semantics', () => {
 
       // K3 rejects the `thinking` param entirely: no key must be emitted.
       expect('thinking' in payload).toBe(false);
-      // disabled is ignored for native-thinking models, so reasoning_effort passes through.
-      expect(payload.reasoning_effort).toBe('high');
+      // disabled is ignored for native-thinking models; K3 accepts reasoning_effort 'max'.
+      expect(payload.reasoning_effort).toBe('max');
       // assistant messages still get reasoning_content forced (fallback ' ').
       expect(findAssistantMessage(payload)?.reasoning_content).toBe(' ');
+    });
+
+    it("should drop a non-'max' reasoning_effort for kimi-k3", async () => {
+      await instance.chat({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'kimi-k3',
+        reasoning_effort: 'high',
+      } as any);
+
+      const payload = getLastRequestPayload();
+
+      // K3 only accepts reasoning_effort 'max' (server default); other values are dropped
+      // rather than sent and rejected.
+      expect('reasoning_effort' in payload).toBe(false);
     });
 
     it('should not emit thinking even when thinking:enabled is provided', async () => {
@@ -231,6 +245,19 @@ describe('buildOpenAIPayload Kimi thinking semantics', () => {
       // Native-thinking models cannot turn reasoning off; disabled must not be re-emitted.
       expect('thinking' in payload).toBe(false);
       expect(findAssistantMessage(payload)?.reasoning_content).toBe(' ');
+    });
+
+    it("should pass through a non-'max' reasoning_effort unchanged (non-K3 model)", async () => {
+      await instance.chat({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'kimi-k2.7-code',
+        reasoning_effort: 'high',
+      } as any);
+
+      const payload = getLastRequestPayload();
+
+      // Only K3+ (isKimiReasoningEffortModel) drops non-'max' efforts; k2.7-code keeps full passthrough.
+      expect(payload.reasoning_effort).toBe('high');
     });
   });
 

--- a/packages/model-runtime/src/providers/opencodeCodingPlan/index.ts
+++ b/packages/model-runtime/src/providers/opencodeCodingPlan/index.ts
@@ -385,7 +385,13 @@ const buildOpenAIPayload = (
     messages,
     response_format,
     tools,
-    ...(!thinkingExplicitlyDisabled && reasoning_effort ? { reasoning_effort } : {}),
+    // Kimi K3+ only accepts reasoning_effort 'max' (also the server default) — drop
+    // any other saved effort instead of sending a value the API rejects
+    ...(!thinkingExplicitlyDisabled &&
+    reasoning_effort &&
+    (!isKimiReasoningEffortModel(model) || reasoning_effort === 'max')
+      ? { reasoning_effort }
+      : {}),
     // K3+ models configure reasoning via top-level reasoning_effort only and
     // reject the K2.x-only `thinking` param; native-thinking models never get
     // `disabled` re-emitted (the toggle does not exist for them).


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

Kimi K3's API currently only accepts `reasoning_effort: "max"` (which is also the server default), but both the moonshot provider and the opencodeCodingPlan provider forwarded any saved `reasoning_effort` verbatim. Users with a generic saved effort (`low` / `medium` / `high` — exactly what the chat UI's reasoning-effort selector offers) would get every K3 request rejected.

Follow-up to #17267, addressing the Codex P1 finding on the cloud bump PR (lobehub-biz/lobehub-cloud#1108).

- `providers/moonshot/index.ts`: the K3 OpenAI branch now drops any non-`max` `reasoning_effort` instead of forwarding it (dropping is equivalent — K3 defaults to max reasoning).
- `providers/opencodeCodingPlan/index.ts`: same guard for K3-generation models (`isKimiReasoningEffortModel`); non-K3 models keep full passthrough.

#### 🧪 How to Test

- [x] Added/updated tests
- [x] Tested locally

New/updated cases: kimi-k3 keeps `reasoning_effort: 'max'`, drops `low`/`medium`/`high` (both providers); kimi-k2.7-code keeps full passthrough. `bun run check` green — 86 tests passed.

#### Key Decisions / Non-goals

- Non-`max` values are **dropped**, not coerced to `max`: the result is identical (server default is max) and avoids claiming support for a mapping Kimi may change once more effort tiers ship.
- The chat UI's effort selector (low/medium/high, no `max` option) is not touched here — hiding or extending it for K3 is a separate UI concern.