### PR TITLE
✨ feat: show topic author avatar in workspace topic lists

### DIFF
--- a/.agents/skills/agent-testing/references/probe-mock-patterns.md
+++ b/.agents/skills/agent-testing/references/probe-mock-patterns.md
@@ -1396,3 +1396,36 @@ nodeintegration, plugins, disablewebsecurity, allowpopups, preload, …`). The h
 - **Works**: use client observables (`messages.model`, thread ids, and chat-store operations) for web;
   use CLI/server execution and `agent_operations` for the server runtime. A change affecting both paths
   needs evidence from both paths.
+
+### D21. Headed web-session `agent-browser screenshot` HANGS when the display is asleep — wake it; raw-CDP fallback can't attach past the daemon
+
+- **Situation**: `agent-browser --session <s> screenshot` on a HEADED web session hangs past the
+  command timeout and eventually fails with the D8 fingerprint (`Resource temporarily
+unavailable (os error 35)`), repeatedly, while `eval`/`get`/`open` on the same session work
+  fine. Restarting the daemon (`close --all` + re-seed) does not help — the fresh session's
+  screenshot hangs the same way.
+- **Cause (measured)**: the display was asleep. `check-screen-recording.sh` returned BLACK FRAME
+  with permission OK. A headed Chrome stops producing compositor frames when the display sleeps,
+  and the daemon's screenshot path waits on a fresh frame. D9's "CDP capture is immune to
+  display sleep" was verified for the Electron raw-CDP one-shot, and does NOT extend to the
+  daemon's screenshot on a headed web browser.
+- **Doesn't work**: raw-CDP fallback against the same browser. Both the `/devtools/page/<id>`
+  endpoint and the `/devtools/browser/<uuid>` endpoint accept the WebSocket but never answer
+  commands — the playwright daemon holds the (single-client) debugger connection. `Target.getTargets`
+  via a fresh browser-endpoint connection also stays silent.
+- **Works**: wake and hold the display — `caffeinate -u -t 3` then keep `caffeinate -dimsu &`
+  running for the capture session. The previously-hung screenshot RPC completes within seconds
+  of the display waking. Gate long headed-web capture runs on `check-screen-recording.sh` even
+  though no OS capture is involved.
+
+### D22. Hovering a nav row shifts its `extra`-slot targets — re-measure coordinates AFTER the row hover
+
+- **Situation**: hovering a small element (e.g. an avatar) sitting in a NavItem-style row's
+  `extra` slot via pre-measured coordinates. The row's hover-revealed actions expand from width
+  0 on hover, pushing the `extra` content leftward — so coordinates (and even a
+  covered-element check on the tagged node) measured before the hover point at the actions
+  button instead, and tooltip/hover assertions come back empty.
+- **Works**: two-step hover — first `mouse move` onto the row body (actions expand), then
+  re-read the target's `getBoundingClientRect()` and move to the fresh center. Note the app's
+  tooltips may render without `role=tooltip`; assert by scanning for the expected text node
+  (TreeWalker) rather than a role query.

--- a/packages/database/src/models/__tests__/topics/topic.query.test.ts
+++ b/packages/database/src/models/__tests__/topics/topic.query.test.ts
@@ -1,3 +1,4 @@
+import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../../core/getTestDB';
@@ -94,6 +95,67 @@ describe('TopicModel - Query', () => {
       ).resolves.toMatchObject({
         items: [expect.objectContaining({ id: 'workspace-topic' })],
         total: 1,
+      });
+    });
+
+    describe('author hydration', () => {
+      it('should attach each author profile to workspace topics', async () => {
+        await serverDB.insert(workspaces).values({
+          id: 'author-workspace',
+          name: 'Workspace',
+          primaryOwnerId: userId,
+          slug: 'author-workspace',
+        });
+        await serverDB
+          .update(users)
+          .set({ avatar: 'https://example.com/alice.png', fullName: 'Alice' })
+          .where(eq(users.id, userId));
+        await serverDB.update(users).set({ username: 'bob' }).where(eq(users.id, userId2));
+        await serverDB.insert(agents).values([{ id: 'author-agent', title: 'Agent', userId }]);
+        await serverDB.insert(topics).values([
+          {
+            agentId: 'author-agent',
+            id: 'author-mine',
+            updatedAt: new Date('2024-01-02'),
+            userId,
+            workspaceId: 'author-workspace',
+          },
+          {
+            agentId: 'author-agent',
+            id: 'author-teammate',
+            updatedAt: new Date('2024-01-01'),
+            userId: userId2,
+            workspaceId: 'author-workspace',
+          },
+        ]);
+
+        const result = await new TopicModel(serverDB, userId, 'author-workspace').query({
+          agentId: 'author-agent',
+        });
+
+        expect(result.items).toHaveLength(2);
+        expect(result.items[0]).toMatchObject({
+          author: {
+            avatar: 'https://example.com/alice.png',
+            fullName: 'Alice',
+            id: userId,
+            username: null,
+          },
+          id: 'author-mine',
+        });
+        expect(result.items[1]).toMatchObject({
+          author: { avatar: null, fullName: null, id: userId2, username: 'bob' },
+          id: 'author-teammate',
+        });
+      });
+
+      it('should skip author hydration in personal mode', async () => {
+        await serverDB.insert(topics).values([{ id: 'author-personal', sessionId, userId }]);
+
+        const result = await topicModel.query({ containerId: sessionId });
+
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0]).not.toHaveProperty('author');
       });
     });
 

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -1,4 +1,5 @@
 import type {
+  ChatTopicAuthor,
   ChatTopicMetadata,
   ChatTopicStatus,
   DBMessageItem,
@@ -32,7 +33,15 @@ import {
 } from 'drizzle-orm';
 
 import type { TopicItem } from '../schemas';
-import { agents, messagePlugins, messages, threads, topicDocuments, topics } from '../schemas';
+import {
+  agents,
+  messagePlugins,
+  messages,
+  threads,
+  topicDocuments,
+  topics,
+  users,
+} from '../schemas';
 import type { LobeChatDatabase } from '../type';
 import { sanitizeBm25Query } from '../utils/bm25';
 import { genEndDateWhere, genRangeWhere, genStartDateWhere, genWhere } from '../utils/genWhere';
@@ -231,6 +240,44 @@ export class TopicModel {
 
   private messageOwnership = () =>
     buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, messages);
+
+  /**
+   * Workspace topic lists mix rows from every member, so hydrate each row with
+   * its author's profile (avatar / names) for at-a-glance attribution — the
+   * topic-list counterpart of the message model's `sender` join. Personal mode
+   * returns rows untouched: every topic there belongs to the viewer, and the
+   * sidebar list is a hot path that shouldn't pay an extra lookup.
+   */
+  private attachAuthors = async <T extends { userId?: string | null }>(
+    items: T[],
+  ): Promise<(T & { author?: ChatTopicAuthor | null })[]> => {
+    if (!this.workspaceId || items.length === 0) return items;
+
+    const userIds = Array.from(
+      new Set(items.map((item) => item.userId).filter((id): id is string => !!id)),
+    );
+    if (userIds.length === 0) return items;
+
+    const authors = await this.db
+      .select({
+        avatar: users.avatar,
+        fullName: users.fullName,
+        id: users.id,
+        username: users.username,
+      })
+      .from(users)
+      .where(inArray(users.id, userIds));
+    const authorMap = new Map(authors.map((author) => [author.id, author]));
+
+    // LEFT-JOIN semantics: a deleted author collapses to `null` so the client
+    // can rely on `author?.id` as the presence check (same contract as the
+    // message model's `sender`).
+    return items.map((item) => ({
+      ...item,
+      author: item.userId ? (authorMap.get(item.userId) ?? null) : null,
+    }));
+  };
+
   // **************** Query *************** //
 
   query = async ({
@@ -365,6 +412,8 @@ export class TopicModel {
                 // rename/favorite edit still shows its real edit time. See rankTopics for
                 // the same activity-time pattern. (LOBE-11543)
                 sortUpdatedAt: topicActivityAt,
+                // Author attribution for workspace lists — see attachAuthors.
+                userId: topics.userId,
                 ...detailColumns,
               } as any)
               .from(topics)
@@ -387,7 +436,7 @@ export class TopicModel {
         stageMs: getDurationMs(queryStartedAt),
         total: totalResult[0].count,
       });
-      return { items, total: totalResult[0].count };
+      return { items: await this.attachAuthors(items), total: totalResult[0].count };
     }
 
     // If agentId is provided, match topics by `topics.agentId` directly. The
@@ -435,6 +484,8 @@ export class TopicModel {
                 // rename/favorite edit still shows its real edit time. See rankTopics for
                 // the same activity-time pattern. (LOBE-11543)
                 sortUpdatedAt: topicActivityAt,
+                // Author attribution for workspace lists — see attachAuthors.
+                userId: topics.userId,
                 ...detailColumns,
               } as any)
               .from(topics)
@@ -461,7 +512,7 @@ export class TopicModel {
         stageMs: getDurationMs(queryStartedAt),
         total: totalResult[0].count,
       });
-      return { items, total: totalResult[0].count };
+      return { items: await this.attachAuthors(items), total: totalResult[0].count };
     }
 
     // Fallback to containerId-based query (backward compatibility)
@@ -501,6 +552,8 @@ export class TopicModel {
               // rename/favorite edit still shows its real edit time. See rankTopics for
               // the same activity-time pattern. (LOBE-11543)
               sortUpdatedAt: topicActivityAt,
+              // Author attribution for workspace lists — see attachAuthors.
+              userId: topics.userId,
               ...detailColumns,
             } as any)
             .from(topics)
@@ -528,7 +581,7 @@ export class TopicModel {
       total: totalResult[0].count,
     });
 
-    return { items: cleanItems, total: totalResult[0].count };
+    return { items: await this.attachAuthors(cleanItems), total: totalResult[0].count };
   };
 
   findById = async (id: string) => {
@@ -696,7 +749,7 @@ export class TopicModel {
     ]);
     // If no topics found by message content, return topics matching by title
     if (topicIdsByMessages.length === 0) {
-      return topicsByTitle;
+      return this.attachAuthors(topicsByTitle);
     }
 
     // Query topics found by message content
@@ -720,8 +773,8 @@ export class TopicModel {
     }
 
     // Sort by update time
-    return allTopics.sort(
-      (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+    return this.attachAuthors(
+      allTopics.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()),
     );
   };
   count = async (params?: {

--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -461,7 +461,23 @@ export const chatTopicStatusSchema = z.enum(TOPIC_STATUSES);
 
 export type ChatTopicStatus = z.infer<typeof chatTopicStatusSchema>;
 
+/**
+ * Profile of the workspace member who created a topic. Hydrated server-side
+ * (LEFT-JOIN semantics: `null` when the author account was deleted) only in
+ * workspace mode — personal lists skip it, every topic there is the viewer's.
+ *
+ * Mirrors {@link MessageSender} for the user message bubble.
+ */
+export interface ChatTopicAuthor {
+  avatar?: string | null;
+  fullName?: string | null;
+  id: string;
+  username?: string | null;
+}
+
 export interface ChatTopic extends Omit<BaseDataModel, 'meta'> {
+  /** Workspace-only: profile of the member who created the topic. */
+  author?: ChatTopicAuthor | null;
   completedAt?: Date | null;
   /** Server-side mock until real cost aggregation lands. */
   cost?: number | null;

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/AllTopicsDrawer/Content.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/AllTopicsDrawer/Content.tsx
@@ -185,6 +185,7 @@ const Content = memo<ContentProps>(({ open, searchKeyword }) => {
         <Flexbox gap={1} key={topic.id} paddingInline={4}>
           <TopicItem
             active={activeTopicId === topic.id}
+            author={topic.author}
             fav={topic.favorite}
             id={topic.id}
             metadata={topic.metadata}

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx
@@ -15,8 +15,12 @@ const topicUnreadCompletedMock = vi.hoisted(() => ({ value: false }));
 const topicMetaCardMock = vi.hoisted(() => ({
   value: undefined as { pullRequest?: { state: string } } | undefined,
 }));
+const activeWorkspaceIdMock = vi.hoisted(() => ({ value: null as string | null }));
 
 vi.mock('@lobehub/ui', () => ({
+  Avatar: ({ avatar, title }: { avatar?: string; title?: string }) => (
+    <div data-avatar={avatar} data-testid="author-avatar" data-title={title} />
+  ),
   Flexbox: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
     <div {...props}>{children}</div>
   ),
@@ -97,8 +101,22 @@ vi.mock('@/components/RingLoading', () => ({
 vi.mock('@/features/ChatInput/ControlBar/DirIcon', () => ({
   default: () => <span data-testid="dir-icon" />,
 }));
+vi.mock('@/business/client/hooks/useActiveWorkspaceId', () => ({
+  useActiveWorkspaceId: () => activeWorkspaceIdMock.value,
+}));
 vi.mock('@/business/client/hooks/useActiveWorkspaceSlug', () => ({
   useActiveWorkspaceSlug: () => 'team',
+}));
+vi.mock('@/hooks/useUserAvatar', () => ({
+  useUserAvatar: () => 'https://example.com/self.png',
+}));
+vi.mock('@/store/user', () => ({
+  useUserStore: (selector: (state: unknown) => unknown) => selector({}),
+}));
+vi.mock('@/store/user/selectors', () => ({
+  userProfileSelectors: {
+    displayUserName: () => 'Viewer',
+  },
 }));
 vi.mock('@/routes/(main)/agent/channel/const', () => ({
   getPlatformIcon: () => null,
@@ -167,7 +185,65 @@ describe('TopicItem active state', () => {
     runningStartTimeMock.value = undefined;
     topicUnreadCompletedMock.value = false;
     topicMetaCardMock.value = undefined;
+    activeWorkspaceIdMock.value = null;
     vi.useRealTimers();
+  });
+
+  it('renders the topic author avatar in workspace context', () => {
+    activeWorkspaceIdMock.value = 'ws_test';
+    useTopicNavigationMock.mockReturnValue({
+      isInAgentSubRoute: false,
+      isInTopicContextRoute: false,
+      navigateToTopic: vi.fn(),
+      routeTopicId: undefined,
+    });
+
+    render(
+      <TopicItem
+        author={{ avatar: 'https://example.com/alice.png', fullName: 'Alice', id: 'user-alice' }}
+        id="tpc_test"
+        title="Topic"
+      />,
+    );
+
+    const avatar = screen.getByTestId('author-avatar');
+    expect(avatar).toHaveAttribute('data-avatar', 'https://example.com/alice.png');
+    expect(avatar).toHaveAttribute('data-title', 'Alice');
+  });
+
+  it('falls back to the viewer for workspace rows without a hydrated author', () => {
+    activeWorkspaceIdMock.value = 'ws_test';
+    useTopicNavigationMock.mockReturnValue({
+      isInAgentSubRoute: false,
+      isInTopicContextRoute: false,
+      navigateToTopic: vi.fn(),
+      routeTopicId: undefined,
+    });
+
+    render(<TopicItem id="tpc_test" title="Topic" />);
+
+    const avatar = screen.getByTestId('author-avatar');
+    expect(avatar).toHaveAttribute('data-avatar', 'https://example.com/self.png');
+    expect(avatar).toHaveAttribute('data-title', 'Viewer');
+  });
+
+  it('hides the author avatar outside workspaces', () => {
+    useTopicNavigationMock.mockReturnValue({
+      isInAgentSubRoute: false,
+      isInTopicContextRoute: false,
+      navigateToTopic: vi.fn(),
+      routeTopicId: undefined,
+    });
+
+    render(
+      <TopicItem
+        author={{ avatar: 'https://example.com/alice.png', fullName: 'Alice', id: 'user-alice' }}
+        id="tpc_test"
+        title="Topic"
+      />,
+    );
+
+    expect(screen.queryByTestId('author-avatar')).not.toBeInTheDocument();
   });
 
   it('keeps the current topic highlighted on topic page sub-routes', () => {

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -1,11 +1,11 @@
 import { AGENT_CHAT_TOPIC_URL } from '@lobechat/const';
-import type { ChatTopicMetadata, ChatTopicStatus } from '@lobechat/types';
+import type { ChatTopicAuthor, ChatTopicMetadata, ChatTopicStatus } from '@lobechat/types';
 import { formatElapsedClockTime } from '@lobechat/utils';
 import {
   getTopicMetadataWorkingDirectoryEffectivePath,
   getTopicMetadataWorkingDirectorySourcePath,
 } from '@lobechat/utils/client/topic';
-import { Flexbox, Icon, Popover, Skeleton, Tag, Text, Tooltip } from '@lobehub/ui';
+import { Avatar, Flexbox, Icon, Popover, Skeleton, Tag, Text, Tooltip } from '@lobehub/ui';
 import { createStaticStyles, cssVar, useTheme } from 'antd-style';
 import dayjs from 'dayjs';
 import { HashIcon, MessageSquareDashed } from 'lucide-react';
@@ -13,6 +13,7 @@ import type { CSSProperties, DragEvent } from 'react';
 import { memo, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import DotsLoading from '@/components/DotsLoading';
 import { TOPIC_STATUS_VISUALS } from '@/components/ExecutionStatus';
@@ -25,6 +26,7 @@ import { startTopicDrag } from '@/features/ChatInput/InputEditor/ReferTopic/topi
 import NavItem from '@/features/NavPanel/components/NavItem';
 import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
 import { getWorkingDirectoryName } from '@/helpers/workingDirectoryPath';
+import { useUserAvatar } from '@/hooks/useUserAvatar';
 import { getPlatformIcon } from '@/routes/(main)/agent/channel/const';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
@@ -32,6 +34,8 @@ import { useChatStore } from '@/store/chat';
 import { operationSelectors } from '@/store/chat/selectors';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 import { useElectronStore } from '@/store/electron';
+import { useUserStore } from '@/store/user';
+import { userProfileSelectors } from '@/store/user/selectors';
 
 import { useTopicNavigation } from '../../hooks/useTopicNavigation';
 import ThreadList from '../../TopicListContent/ThreadList';
@@ -131,8 +135,43 @@ const RunningElapsedTime = memo<RunningElapsedTimeProps>(({ agentId, topicId }) 
 
 RunningElapsedTime.displayName = 'RunningElapsedTime';
 
+interface AuthorAvatarProps {
+  author?: ChatTopicAuthor | null;
+}
+
+// In workspaces the sidebar mixes every member's topics, so each row carries
+// its author's avatar on the far right for at-a-glance attribution. Personal
+// mode renders nothing — every topic there is the viewer's. Rows without a
+// hydrated `author` (optimistic creates, deleted accounts) fall back to the
+// viewer, mirroring the user message bubble's sender fallback.
+const AuthorAvatar = memo<AuthorAvatarProps>(({ author }) => {
+  const activeWorkspaceId = useActiveWorkspaceId();
+  const selfAvatar = useUserAvatar();
+  const selfName = useUserStore(userProfileSelectors.displayUserName);
+
+  if (!activeWorkspaceId) return null;
+
+  const authorName = author?.fullName || author?.username || '';
+  const title = authorName || selfName || '';
+
+  return (
+    <Tooltip title={title}>
+      <Avatar
+        alt={title}
+        avatar={author?.avatar || authorName || selfAvatar}
+        size={20}
+        style={{ flex: 'none' }}
+        title={title}
+      />
+    </Tooltip>
+  );
+});
+
+AuthorAvatar.displayName = 'AuthorAvatar';
+
 interface TopicItemProps {
   active?: boolean;
+  author?: ChatTopicAuthor | null;
   fav?: boolean;
   id?: string;
   metadata?: ChatTopicMetadata;
@@ -148,7 +187,7 @@ interface TopicItemProps {
 }
 
 const TopicItem = memo<TopicItemProps>(
-  ({ id, title, fav, active, threadId, metadata, status, showWorkingDirectory }) => {
+  ({ id, title, fav, active, author, threadId, metadata, status, showWorkingDirectory }) => {
     const { t } = useTranslation('topic');
     const { isDarkMode } = useTheme();
     const activeAgentId = useAgentStore((s) => s.activeAgentId);
@@ -357,11 +396,16 @@ const TopicItem = memo<TopicItemProps>(
         description={workingDirectoryNode}
         disabled={editing}
         draggable={!editing}
-        extra={<RunningElapsedTime agentId={activeAgentId} topicId={id} />}
         href={href}
         slots={{ titlePrefix: draftPrefix }}
         title={title === '...' ? <DotsLoading gap={3} size={4} /> : title}
         titleColor={cssVar.colorText}
+        extra={
+          <>
+            <RunningElapsedTime agentId={activeAgentId} topicId={id} />
+            <AuthorAvatar author={author} />
+          </>
+        }
         icon={(() => {
           // A scheduled topic hasn't run yet — nothing else can be true of it,
           // so its clock outranks the other states.

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
@@ -277,6 +277,7 @@ const GroupItem = memo<GroupItemComponentProps>(
           {children.map((topic) => (
             <TopicItem
               active={activeTopicId === topic.id}
+              author={topic.author}
               fav={topic.favorite}
               id={topic.id}
               key={topic.id}

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByStatusMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByStatusMode/GroupItem.tsx
@@ -45,6 +45,7 @@ const GroupItem = memo<GroupItemComponentProps>(({ group, activeTopicId, activeT
           <TopicItem
             showWorkingDirectory
             active={activeTopicId === topic.id}
+            author={topic.author}
             fav={topic.favorite}
             id={topic.id}
             key={topic.id}

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByTimeMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByTimeMode/GroupItem.tsx
@@ -32,6 +32,7 @@ const GroupItem = memo<GroupItemComponentProps>(({ group, activeTopicId, activeT
         {children.map((topic) => (
           <TopicItem
             active={activeTopicId === topic.id}
+            author={topic.author}
             fav={topic.favorite}
             id={topic.id}
             key={topic.id}

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/FlatMode/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/FlatMode/index.tsx
@@ -46,6 +46,7 @@ const FlatMode = memo(() => {
       {activeTopicList?.map((topic) => (
         <TopicItem
           active={activeTopicId === topic.id}
+          author={topic.author}
           fav={topic.favorite}
           id={topic.id}
           key={topic.id}

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/SearchResult/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/SearchResult/index.tsx
@@ -33,6 +33,7 @@ const SearchResult = memo(() => {
       {topics.map((topic) => (
         <TopicItem
           active={activeTopicId === topic.id}
+          author={topic.author}
           fav={topic.favorite}
           id={topic.id}
           key={topic.id}


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Workspace topic lists mix rows from every member, but a row carries no attribution — you can't tell who created a topic. This PR hydrates workspace topic rows with their author's profile and renders a 20px author avatar (with name tooltip) at the far right of the topic list item, the topic-list counterpart of the user message bubble's `sender`.

- **Types**: new `ChatTopicAuthor` (mirrors `MessageSender`) + optional `author` field on `ChatTopic`.
- **`TopicModel`**: private `attachAuthors` batch-hydrates authors via a single `inArray(users.id, …)` lookup, applied to all three `query` paths and `queryByKeyword`. Runs **only in workspace mode** — personal lists are untouched and pay no extra query. LEFT-JOIN semantics: a deleted author collapses to `author: null`.
- **UI**: `AuthorAvatar` in `TopicItem`'s `extra` slot. Personal mode renders nothing; rows without a hydrated `author` (optimistic creates, deleted accounts) fall back to the viewer's own avatar/name, mirroring the sender fallback in message bubbles. All topic list callers (flat/time/status/project modes, search results, all-topics drawer) pass `author` through.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- `topic.query.test.ts`: workspace query hydrates `author`, personal query does not, deleted author → `null`.
- `Item/index.test.tsx`: avatar renders in workspace mode with tooltip, hidden in personal mode, viewer fallback when `author` is absent.
- `bun run check` (lint + test + type) green.
- End-to-end verified via agent-testing (headed web, isolated env): avatar + tooltip on workspace topic rows, absent in personal mode — report: https://app.lobehub.com/verify/37243ebc-f687-41c9-9e1b-b387514c305b

#### 📝 Additional Information

Second commit adds two generic agent-browser probe patterns (display-sleep screenshot hang, hover-shifted `extra`-slot targets) to the agent-testing living log, distilled from this feature's verification run.