### PR TITLE
✨ feat(search): honor searchCategories in Firecrawl search provider

### DIFF
--- a/apps/server/src/services/search/impls/firecrawl/index.test.ts
+++ b/apps/server/src/services/search/impls/firecrawl/index.test.ts
@@ -1,0 +1,233 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FirecrawlImpl } from './index';
+
+const createMockResponse = (body: object, ok = true, status = 200, statusText = 'OK') =>
+  ({
+    ok,
+    status,
+    statusText,
+    json: vi.fn().mockResolvedValue(body),
+    text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+  }) as unknown as Response;
+
+const makeFirecrawlResponse = (data: {
+  images?: object[];
+  news?: object[];
+  web?: object[];
+}) => ({
+  data,
+  success: true,
+});
+
+const getRequestBody = () =>
+  JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+
+describe('FirecrawlImpl', () => {
+  let impl: FirecrawlImpl;
+
+  beforeEach(() => {
+    impl = new FirecrawlImpl();
+    vi.stubGlobal('fetch', vi.fn());
+    process.env.FIRECRAWL_API_KEY = 'test-firecrawl-api-key';
+    delete process.env.FIRECRAWL_URL;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.FIRECRAWL_API_KEY;
+    delete process.env.FIRECRAWL_URL;
+  });
+
+  describe('query', () => {
+    it('should map web, news and image results', async () => {
+      const response = makeFirecrawlResponse({
+        images: [
+          {
+            imageUrl: 'https://example.com/pic.png',
+            title: 'An image',
+            url: 'https://example.com/gallery',
+          },
+        ],
+        news: [
+          {
+            snippet: 'Breaking news content',
+            title: 'News Title',
+            url: 'https://news.example.com/story',
+          },
+        ],
+        web: [
+          {
+            description: 'Web description',
+            title: 'Web Title',
+            url: 'https://example.com/page',
+          },
+        ],
+      });
+
+      vi.mocked(fetch).mockResolvedValueOnce(createMockResponse(response));
+
+      const result = await impl.query('test query');
+
+      expect(result.query).toBe('test query');
+      expect(result.resultNumbers).toBe(3);
+      expect(result.results).toHaveLength(3);
+
+      expect(result.results[0]).toMatchObject({
+        category: 'general',
+        content: 'Web description',
+        engines: ['firecrawl'],
+        parsedUrl: 'example.com',
+        title: 'Web Title',
+        url: 'https://example.com/page',
+      });
+      expect(result.results[1]).toMatchObject({
+        category: 'news',
+        content: 'Breaking news content',
+        engines: ['firecrawl'],
+        title: 'News Title',
+        url: 'https://news.example.com/story',
+      });
+      expect(result.results[2]).toMatchObject({
+        category: 'images',
+        engines: ['firecrawl'],
+        title: 'An image',
+        // Images map their url to the imageUrl field
+        url: 'https://example.com/pic.png',
+      });
+    });
+
+    it('should return empty results when data groups are missing', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(createMockResponse(makeFirecrawlResponse({})));
+
+      const result = await impl.query('empty query');
+
+      expect(result.resultNumbers).toBe(0);
+      expect(result.results).toHaveLength(0);
+    });
+
+    it('should default to web and news sources when no categories are provided', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(createMockResponse(makeFirecrawlResponse({})));
+
+      await impl.query('test');
+
+      expect(getRequestBody().sources).toEqual([{ type: 'web' }, { type: 'news' }]);
+    });
+
+    it('should derive sources from searchCategories', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(createMockResponse(makeFirecrawlResponse({})));
+
+      await impl.query('test', { searchCategories: ['news', 'images'] });
+
+      expect(getRequestBody().sources).toEqual([{ type: 'news' }, { type: 'images' }]);
+    });
+
+    it('should map the general category to the web source', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(createMockResponse(makeFirecrawlResponse({})));
+
+      await impl.query('test', { searchCategories: ['general'] });
+
+      expect(getRequestBody().sources).toEqual([{ type: 'web' }]);
+    });
+
+    it('should fall back to default sources for unsupported categories', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(createMockResponse(makeFirecrawlResponse({})));
+
+      await impl.query('test', { searchCategories: ['science', 'videos'] });
+
+      expect(getRequestBody().sources).toEqual([{ type: 'web' }, { type: 'news' }]);
+    });
+
+    it('should map searchTimeRange to the tbs parameter', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(createMockResponse(makeFirecrawlResponse({})));
+
+      await impl.query('test', { searchTimeRange: 'week' });
+
+      expect(getRequestBody().tbs).toBe('qdr:w');
+    });
+
+    it('should not set tbs for anytime', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(createMockResponse(makeFirecrawlResponse({})));
+
+      await impl.query('test', { searchTimeRange: 'anytime' });
+
+      expect(getRequestBody().tbs).toBeUndefined();
+    });
+
+    it('should include Bearer token in authorization header', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(createMockResponse(makeFirecrawlResponse({})));
+
+      await impl.query('test');
+
+      const options = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+      expect((options.headers as Record<string, string>)['Authorization']).toBe(
+        'Bearer test-firecrawl-api-key',
+      );
+    });
+
+    it('should use empty string in authorization header when API key not set', async () => {
+      delete process.env.FIRECRAWL_API_KEY;
+
+      vi.mocked(fetch).mockResolvedValueOnce(createMockResponse(makeFirecrawlResponse({})));
+
+      await impl.query('test');
+
+      const options = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+      expect((options.headers as Record<string, string>)['Authorization']).toBe('');
+    });
+
+    it('should target the search endpoint of the configured base url', async () => {
+      process.env.FIRECRAWL_URL = 'https://firecrawl.example.com/v2';
+
+      vi.mocked(fetch).mockResolvedValueOnce(createMockResponse(makeFirecrawlResponse({})));
+
+      await impl.query('test');
+
+      expect(vi.mocked(fetch).mock.calls[0][0]).toBe('https://firecrawl.example.com/v2/search');
+    });
+
+    it('should throw SERVICE_UNAVAILABLE when fetch throws a network error', async () => {
+      vi.mocked(fetch).mockRejectedValue(new Error('ECONNREFUSED'));
+
+      await expect(impl.query('test')).rejects.toMatchObject({
+        code: 'SERVICE_UNAVAILABLE',
+        message: 'Failed to connect to Firecrawl.',
+      });
+    });
+
+    it('should throw SERVICE_UNAVAILABLE when response is not ok', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        createMockResponse({ error: 'Too Many Requests' }, false, 429, 'Too Many Requests'),
+      );
+
+      await expect(impl.query('test')).rejects.toMatchObject({
+        code: 'SERVICE_UNAVAILABLE',
+        message: 'Firecrawl request failed: Too Many Requests',
+      });
+    });
+
+    it('should throw INTERNAL_SERVER_ERROR when response JSON parsing fails', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockRejectedValue(new Error('JSON error')),
+        text: vi.fn().mockResolvedValue('bad json'),
+      } as unknown as Response);
+
+      await expect(impl.query('test')).rejects.toMatchObject({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to parse Firecrawl response.',
+      });
+    });
+
+    it('should include costTime in the response', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(createMockResponse(makeFirecrawlResponse({})));
+
+      const result = await impl.query('test');
+
+      expect(typeof result.costTime).toBe('number');
+      expect(result.costTime).toBeGreaterThanOrEqual(0);
+    });
+  });
+});

--- a/apps/server/src/services/search/impls/firecrawl/index.ts
+++ b/apps/server/src/services/search/impls/firecrawl/index.ts
@@ -8,7 +8,11 @@ import debug from 'debug';
 import urlJoin from 'url-join';
 
 import { type SearchServiceImpl } from '../type';
-import { type FirecrawlResponse, type FirecrawlSearchParameters } from './type';
+import {
+  type FirecrawlResponse,
+  type FirecrawlSearchParameters,
+  type FirecrawlSource,
+} from './type';
 
 const log = debug('lobe-search:Firecrawl');
 
@@ -18,6 +22,17 @@ const timeRangeMapping = {
   week: 'qdr:w',
   year: 'qdr:y',
 };
+
+// Map LobeHub search categories to Firecrawl sources. Categories without a
+// Firecrawl equivalent (e.g. science, videos) are ignored, falling back to the
+// default web + news sources below.
+const categorySourceMapping: Record<string, FirecrawlSource> = {
+  general: { type: 'web' },
+  images: { type: 'images' },
+  news: { type: 'news' },
+};
+
+const defaultSources: FirecrawlSource[] = [{ type: 'web' }, { type: 'news' }];
 
 /**
  * Firecrawl implementation of the search service
@@ -37,6 +52,10 @@ export class FirecrawlImpl implements SearchServiceImpl {
     log('Starting Firecrawl query with query: "%s", params: %o', query, params);
     const endpoint = urlJoin(this.baseUrl, '/search');
 
+    const requestedSources = params?.searchCategories
+      ?.map((category) => categorySourceMapping[category])
+      .filter((source): source is FirecrawlSource => Boolean(source));
+
     const defaultQueryParams: FirecrawlSearchParameters = {
       limit: 20,
       query,
@@ -45,7 +64,7 @@ export class FirecrawlImpl implements SearchServiceImpl {
         formats: ["markdown"]
       },
       */
-      sources: [{ type: 'web' }, { type: 'news' }],
+      sources: requestedSources?.length ? requestedSources : defaultSources,
     };
 
     const body: FirecrawlSearchParameters = {

--- a/apps/server/src/services/search/impls/firecrawl/type.ts
+++ b/apps/server/src/services/search/impls/firecrawl/type.ts
@@ -7,7 +7,7 @@ interface FirecrawlScrapeOptions {
   removeBase64Images?: boolean;
 }
 
-type FirecrawlSource =
+export type FirecrawlSource =
   | { location?: string; tbs?: string; type: 'web' }
   | { type: 'images' }
   | { type: 'news' };


### PR DESCRIPTION
## Summary

Firecrawl is already integrated in this repo in two places — a web-search provider (`apps/server/.../search/impls/firecrawl`) and a web crawler (`packages/web-crawler/.../crawImpl/firecrawl.ts`), both against the Firecrawl v2 REST API. Rather than duplicate any of that, this PR closes a small, real gap in how the **search provider** is consumed.

The web-browsing builtin tool lets the model request search categories (`general`, `images`, `news`, `science`, `videos`), and the sibling providers **Exa**, **Tavily** and **SearXNG** all honor `searchCategories`. The Firecrawl provider ignored it entirely — it hard-coded `sources: [web, news]`, so:

- asking for `images` never returned images, and
- a `news`-only request still returned web results.

This change maps the app's search categories to Firecrawl's native `sources`, mirroring the existing Exa/Tavily approach, and falls back to the original `web + news` default when no supported category is present (e.g. `science`/`videos`, which have no Firecrawl source equivalent).

### Changes
- `impls/firecrawl/index.ts` — derive `sources` from `searchCategories` (`general→web`, `news→news`, `images→images`); default unchanged when none match.
- `impls/firecrawl/type.ts` — `export` the existing `FirecrawlSource` type so the impl can reference it (one-word change, no restructure).
- `impls/firecrawl/index.test.ts` — **new** unit tests for the provider (it had none), covering web/news/image result mapping and category→source selection, following the existing `tavily`/`exa` test style.

No new env vars, no dependency changes, no changes to the crawler or to any other provider. `FIRECRAWL_URL` / `FIRECRAWL_API_KEY` continue to be read exactly as before (docs in `docs/self-hosting/advanced/online-search.mdx` remain accurate). Firecrawl uses the REST API here (consistent with all keyed providers), so there is no SDK version to bump.

## Verification (done)

- **Live Firecrawl requests** with a real API key against `https://api.firecrawl.dev/v2/search` ✅ — confirmed the v2 response shape (`data.web[].description`, `data.news[].snippet`, `data.images[].imageUrl`) the mapping relies on, and confirmed `sources` is honored: `sources:[{type:images}]` returns only the `images` group and `sources:[{type:news}]` returns only the `news` group (`success: true` on both), exactly matching the new category mapping.
- **New provider unit tests** ✅ — `vitest run apps/server/src/services/search/impls/firecrawl/index.test.ts` → **15/15 pass**.
- **Full server test suite** ✅ — `pnpm install && vitest run --dir apps/server` → **6406 passed**, 12 skipped, 1 todo. The only failures are pre-existing DB-backed `aiAgent` integration tests (`src/routers/lambda/__tests__/integration/aiAgent/*`) that time out in `beforeEach → getTestDB()` when no Postgres test DB is provisioned locally — unrelated to this change, and expected to pass on CI where the DB service is available.
- **Type-check** ✅ — `tsc --noEmit` reports **no errors in `apps/server`** (or the firecrawl files).
- **Lint** ✅ — `eslint` on the three changed files is clean.

## Human follow-up

- Set `FIRECRAWL_API_KEY` (and optionally `FIRECRAWL_URL`) as a deploy/CI secret to exercise the provider end-to-end through the web-browsing tool.

## Other opportunities noted (not done here, to keep this PR minimal)
- The `type.ts` in `packages/web-crawler` narrows `CrawlUrlRule.impls` to `'naive' | 'jina' | 'browserless' | 'search1api'`, omitting `firecrawl`/`exa`/`tavily` that are valid crawlers elsewhere — possibly worth widening, but out of scope here.
