### PR TITLE
💚 build: make work registry migration idempotent

### DIFF
--- a/packages/database/migrations/0121_add_work_registry_tables.sql
+++ b/packages/database/migrations/0121_add_work_registry_tables.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "work_versions" (
+CREATE TABLE IF NOT EXISTS "work_versions" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"work_id" text NOT NULL,
 	"version" integer NOT NULL,
@@ -23,7 +23,7 @@ CREATE TABLE "work_versions" (
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-CREATE TABLE "works" (
+CREATE TABLE IF NOT EXISTS "works" (
 	"id" text PRIMARY KEY NOT NULL,
 	"type" text NOT NULL,
 	"current_version_id" uuid,
@@ -46,31 +46,41 @@ CREATE TABLE "works" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
+ALTER TABLE "work_versions" DROP CONSTRAINT IF EXISTS "work_versions_work_id_works_id_fk";--> statement-breakpoint
 ALTER TABLE "work_versions" ADD CONSTRAINT "work_versions_work_id_works_id_fk" FOREIGN KEY ("work_id") REFERENCES "public"."works"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "work_versions" DROP CONSTRAINT IF EXISTS "work_versions_topic_id_topics_id_fk";--> statement-breakpoint
 ALTER TABLE "work_versions" ADD CONSTRAINT "work_versions_topic_id_topics_id_fk" FOREIGN KEY ("topic_id") REFERENCES "public"."topics"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "work_versions" DROP CONSTRAINT IF EXISTS "work_versions_thread_id_threads_id_fk";--> statement-breakpoint
 ALTER TABLE "work_versions" ADD CONSTRAINT "work_versions_thread_id_threads_id_fk" FOREIGN KEY ("thread_id") REFERENCES "public"."threads"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "work_versions" DROP CONSTRAINT IF EXISTS "work_versions_message_id_messages_id_fk";--> statement-breakpoint
 ALTER TABLE "work_versions" ADD CONSTRAINT "work_versions_message_id_messages_id_fk" FOREIGN KEY ("message_id") REFERENCES "public"."messages"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "work_versions" DROP CONSTRAINT IF EXISTS "work_versions_agent_id_agents_id_fk";--> statement-breakpoint
 ALTER TABLE "work_versions" ADD CONSTRAINT "work_versions_agent_id_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "works" DROP CONSTRAINT IF EXISTS "works_origin_topic_id_topics_id_fk";--> statement-breakpoint
 ALTER TABLE "works" ADD CONSTRAINT "works_origin_topic_id_topics_id_fk" FOREIGN KEY ("origin_topic_id") REFERENCES "public"."topics"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "works" DROP CONSTRAINT IF EXISTS "works_origin_thread_id_threads_id_fk";--> statement-breakpoint
 ALTER TABLE "works" ADD CONSTRAINT "works_origin_thread_id_threads_id_fk" FOREIGN KEY ("origin_thread_id") REFERENCES "public"."threads"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "works" DROP CONSTRAINT IF EXISTS "works_origin_agent_id_agents_id_fk";--> statement-breakpoint
 ALTER TABLE "works" ADD CONSTRAINT "works_origin_agent_id_agents_id_fk" FOREIGN KEY ("origin_agent_id") REFERENCES "public"."agents"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "works" DROP CONSTRAINT IF EXISTS "works_user_id_users_id_fk";--> statement-breakpoint
 ALTER TABLE "works" ADD CONSTRAINT "works_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "works" DROP CONSTRAINT IF EXISTS "works_workspace_id_workspaces_id_fk";--> statement-breakpoint
 ALTER TABLE "works" ADD CONSTRAINT "works_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-CREATE UNIQUE INDEX "work_versions_work_id_version_unique" ON "work_versions" USING btree ("work_id","version");--> statement-breakpoint
-CREATE UNIQUE INDEX "work_versions_work_id_tool_call_id_unique" ON "work_versions" USING btree ("work_id","tool_call_id") WHERE "work_versions"."tool_call_id" is not null;--> statement-breakpoint
-CREATE INDEX "work_versions_thread_id_idx" ON "work_versions" USING btree ("thread_id");--> statement-breakpoint
-CREATE INDEX "work_versions_message_id_idx" ON "work_versions" USING btree ("message_id");--> statement-breakpoint
-CREATE INDEX "work_versions_agent_id_idx" ON "work_versions" USING btree ("agent_id");--> statement-breakpoint
-CREATE INDEX "work_versions_root_operation_created_at_idx" ON "work_versions" USING btree ("root_operation_id","created_at");--> statement-breakpoint
-CREATE INDEX "work_versions_topic_created_at_idx" ON "work_versions" USING btree ("topic_id","created_at");--> statement-breakpoint
-CREATE INDEX "work_versions_topic_thread_created_at_idx" ON "work_versions" USING btree ("topic_id","thread_id","created_at");--> statement-breakpoint
-CREATE UNIQUE INDEX "works_resource_user_unique" ON "works" USING btree ("resource_type","resource_id","user_id") WHERE "works"."workspace_id" is null;--> statement-breakpoint
-CREATE UNIQUE INDEX "works_resource_workspace_unique" ON "works" USING btree ("workspace_id","resource_type","resource_id") WHERE "works"."workspace_id" is not null;--> statement-breakpoint
-CREATE INDEX "works_user_id_idx" ON "works" USING btree ("user_id");--> statement-breakpoint
-CREATE INDEX "works_workspace_id_idx" ON "works" USING btree ("workspace_id");--> statement-breakpoint
-CREATE INDEX "works_workspace_visibility_idx" ON "works" USING btree ("workspace_id","visibility","user_id");--> statement-breakpoint
-CREATE INDEX "works_user_updated_at_id_idx" ON "works" USING btree ("user_id","updated_at","id") WHERE "works"."workspace_id" is null;--> statement-breakpoint
-CREATE INDEX "works_workspace_updated_at_id_idx" ON "works" USING btree ("workspace_id","updated_at","id") WHERE "works"."workspace_id" is not null;--> statement-breakpoint
-CREATE INDEX "works_origin_topic_id_idx" ON "works" USING btree ("origin_topic_id");--> statement-breakpoint
-CREATE INDEX "works_origin_thread_id_idx" ON "works" USING btree ("origin_thread_id");--> statement-breakpoint
-CREATE INDEX "works_origin_agent_id_idx" ON "works" USING btree ("origin_agent_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "work_versions_work_id_version_unique" ON "work_versions" USING btree ("work_id","version");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "work_versions_work_id_tool_call_id_unique" ON "work_versions" USING btree ("work_id","tool_call_id") WHERE "work_versions"."tool_call_id" is not null;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_versions_thread_id_idx" ON "work_versions" USING btree ("thread_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_versions_message_id_idx" ON "work_versions" USING btree ("message_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_versions_agent_id_idx" ON "work_versions" USING btree ("agent_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_versions_root_operation_created_at_idx" ON "work_versions" USING btree ("root_operation_id","created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_versions_topic_created_at_idx" ON "work_versions" USING btree ("topic_id","created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_versions_topic_thread_created_at_idx" ON "work_versions" USING btree ("topic_id","thread_id","created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "works_resource_user_unique" ON "works" USING btree ("resource_type","resource_id","user_id") WHERE "works"."workspace_id" is null;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "works_resource_workspace_unique" ON "works" USING btree ("workspace_id","resource_type","resource_id") WHERE "works"."workspace_id" is not null;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "works_user_id_idx" ON "works" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "works_workspace_id_idx" ON "works" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "works_workspace_visibility_idx" ON "works" USING btree ("workspace_id","visibility","user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "works_user_updated_at_id_idx" ON "works" USING btree ("user_id","updated_at","id") WHERE "works"."workspace_id" is null;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "works_workspace_updated_at_id_idx" ON "works" USING btree ("workspace_id","updated_at","id") WHERE "works"."workspace_id" is not null;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "works_origin_topic_id_idx" ON "works" USING btree ("origin_topic_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "works_origin_thread_id_idx" ON "works" USING btree ("origin_thread_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "works_origin_agent_id_idx" ON "works" USING btree ("origin_agent_id");


### PR DESCRIPTION
#### 💻 Change Type

- [x] 👷 build

#### 🔗 Related Issue

Related to #17193

#### 🔀 Description of Change

Migration `0121_add_work_registry_tables.sql` (from #17193) shipped without idempotent clauses, so re-running it against a database where the work registry objects already exist fails and breaks the Vercel build.

This PR hardens every statement to be safe to re-run, matching the established style of migrations `0112` / `0119`:

- `CREATE TABLE` → `CREATE TABLE IF NOT EXISTS`
- `ADD CONSTRAINT` → preceded by `DROP CONSTRAINT IF EXISTS` (PostgreSQL has no `ADD CONSTRAINT IF NOT EXISTS`)
- `CREATE [UNIQUE] INDEX` → `CREATE [UNIQUE] INDEX IF NOT EXISTS`

No schema shape change — the resulting objects are identical.

#### 🧪 How to Test

- [x] No tests needed

SQL-only idempotency hardening; verify via the Vercel deploy on this PR (migration re-run succeeds).