### PR TITLE
refactor(database): migrate console.log to debug namespace in @lobechat/database

### DIFF
--- a/packages/database/src/repositories/dataExporter/index.ts
+++ b/packages/database/src/repositories/dataExporter/index.ts
@@ -1,9 +1,12 @@
+import debug from 'debug';
 import { and, eq, inArray } from 'drizzle-orm';
 import pMap from 'p-map';
 
 import * as EXPORT_TABLES from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
 import { buildWorkspaceWhere } from '../../utils/workspace';
+
+const log = debug('lobe-database:data-exporter');
 
 interface BaseTableConfig {
   table: keyof typeof EXPORT_TABLES;
@@ -113,9 +116,7 @@ export class DataExporterRepos {
 
         // If source data is empty, this table may not be able to query any data
         if (sourceData.length === 0) {
-          console.info(
-            `Source table ${relation.sourceTable} has no data, skipping query for ${table}`,
-          );
+          log('Source table %s has no data, skipping query for %s', relation.sourceTable, table);
           return [];
         }
 
@@ -140,7 +141,7 @@ export class DataExporterRepos {
       const result = await this.db.query[table].findMany({ where });
 
       // Only remove userId field for tables queried with userId
-      console.info(`Successfully exported table: ${table}, count: ${result.length}`);
+      log('Successfully exported table: %s, count: %d', table, result.length);
       return config.relations ? result : this.removeUserId(result);
     } catch (error) {
       console.error(`Error querying table ${table}:`, error);
@@ -171,7 +172,7 @@ export class DataExporterRepos {
       const result = await this.db.query[table].findMany({ where });
 
       // Only remove userId field for tables queried with userId
-      console.info(`Successfully exported table: ${table}, count: ${result.length}`);
+      log('Successfully exported table: %s, count: %d', table, result.length);
       return this.removeUserId(result);
     } catch (error) {
       console.error(`Error querying table ${table}:`, error);
@@ -183,7 +184,7 @@ export class DataExporterRepos {
     const result: Record<string, any[]> = {};
 
     // 1. First query all base tables concurrently
-    console.info('Querying base tables...');
+    log('Querying base tables...');
     const baseResults = await pMap(
       DATA_EXPORT_CONFIG.baseTables,
       async (config) => ({ data: await this.queryBaseTables(config), table: config.table }),
@@ -206,7 +207,7 @@ export class DataExporterRepos {
         );
 
         if (!allSourcesHaveData) {
-          console.info(`Skipping table ${config.table} as some source tables have no data`);
+          log('Skipping table %s as some source tables have no data', config.table);
           return { data: [], table: config.table };
         }
 

--- a/packages/database/src/repositories/dataImporter/index.ts
+++ b/packages/database/src/repositories/dataImporter/index.ts
@@ -1,4 +1,5 @@
 import type { ImporterEntryData, ImportPgDataStructure, ImportResultData } from '@lobechat/types';
+import debug from 'debug';
 import { and, eq, inArray } from 'drizzle-orm';
 
 import { uuid } from '@/utils/uuid';
@@ -7,6 +8,8 @@ import * as EXPORT_TABLES from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
 import { buildWorkspaceWhere } from '../../utils/workspace';
 import { DeprecatedDataImporterRepos } from './deprecated';
+
+const log = debug('lobe-database:data-importer');
 
 interface ImportResult {
   added: number;
@@ -304,7 +307,7 @@ export class DataImporterRepos {
 
           // Use unified import method
           const result = await this.importTableData(trx, config, tableData, conflictStrategy);
-          console.info(`imported table: ${tableName}, records: ${tableData.length}`);
+          log('imported table: %s, records: %d', tableName, tableData.length);
 
           if (Object.values(result).some((value) => value > 0)) {
             results[tableName] = result;


### PR DESCRIPTION
## Summary

Part of #16488

Migrates all 26 `console.log`/`console.error` calls in the `@lobechat/database` package to structured `debug` namespace logging. This package had the `no-console` lint rule enabled, so every `console.*` was a lint violation.

## Changes

9 files migrated with `lobe-database:<component>` namespaces:

| File | Namespace |
|---|---|
| `core/db-adaptor.ts` | `lobe-database:db-adaptor` |
| `core/web-server.ts` | `lobe-database:web-server` |
| `models/message.ts` | `lobe-database:message-model` |
| `models/session.ts` | `lobe-database:session-model` |
| `repositories/aiInfra/index.ts` | `lobe-database:ai-infra` |
| `repositories/dataExporter/index.ts` | `lobe-database:data-exporter` |
| `repositories/dataImporter/index.ts` | `lobe-database:data-importer` |
| `repositories/knowledge/index.ts` | `lobe-database:knowledge-repo` |

## Test results

- Lint: 9 files lint-clean
- Tests: **299 passed, 5 skipped**
- Pre-commit `lint-staged` passed