### PR TITLE
fix: cleanup unhandled setTimeout timers to prevent memory leaks

### DIFF
--- a/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
+++ b/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
@@ -5,7 +5,7 @@ import type { MenuProps } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { FileTextIcon, Maximize2Icon, PenLineIcon, Trash2Icon } from 'lucide-react';
 import type { CSSProperties } from 'react';
-import { memo, useCallback, useMemo, useRef } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { KeyedMutator } from 'swr';
 
@@ -156,10 +156,16 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, onOpenDocumen
     [documents],
   );
 
+  const focusTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    return () => clearTimeout(focusTimerRef.current);
+  }, []);
+
   const focusNewRowForRename = useCallback((pendingId: string) => {
     // Defer past the current task so React commits the inserted row and the
     // tree adapter rebuilds its id→path map before we trigger rename.
-    setTimeout(() => {
+    focusTimerRef.current = setTimeout(() => {
       treeRef.current?.startRenaming(pendingId);
       // After pierre's input.select() runs in its own layout effect, narrow
       // selection to the stem so the `.md` extension stays intact.

--- a/src/features/AgentSkillEdit/SkillEditForm.tsx
+++ b/src/features/AgentSkillEdit/SkillEditForm.tsx
@@ -71,17 +71,24 @@ const SkillEditForm = memo<SkillEditFormProps>(
 
     useEffect(() => {
       if (!editor) return;
-      try {
-        setTimeout(() => {
+
+      let timer: ReturnType<typeof setTimeout>;
+
+      const setDoc = () => {
+        timer = setTimeout(() => {
           if (initialValues.content) {
             editor.setDocument('markdown', initialValues.content);
           }
         }, 100);
+      };
+
+      try {
+        setDoc();
       } catch {
-        setTimeout(() => {
-          editor.setDocument('markdown', initialValues.content);
-        }, 100);
+        setDoc();
       }
+
+      return () => clearTimeout(timer);
     }, [editor, initialValues.content]);
 
     const handleContentChange = useCallback(

--- a/src/features/ModelSwitchPanel/hooks/usePanelHandlers.ts
+++ b/src/features/ModelSwitchPanel/hooks/usePanelHandlers.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { usePermission } from '@/hooks/usePermission';
 import { useAgentStore } from '@/store/agent';
@@ -15,11 +15,17 @@ export const usePanelHandlers = ({
   const { allowed: canCreateContent } = usePermission('create_content');
   const updateAgentConfig = useAgentStore((s) => s.updateAgentConfig);
 
+  const modelChangeTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    return () => clearTimeout(modelChangeTimerRef.current);
+  }, []);
+
   const handleModelChange = useCallback(
     (modelId: string, providerId: string) => {
       // Defer store update so the panel close animation completes
       // before React re-renders with new data (prevents detail panel flash).
-      setTimeout(() => {
+      modelChangeTimerRef.current = setTimeout(() => {
         if (!canCreateContent) return;
 
         const params = { model: modelId, provider: providerId };

--- a/src/features/ResourceManager/components/Explorer/Header/SearchInput.tsx
+++ b/src/features/ResourceManager/components/Explorer/Header/SearchInput.tsx
@@ -24,10 +24,16 @@ const SearchInput = memo(() => {
     setSearchQuery(debouncedQuery || null);
   }, [debouncedQuery, expanded, setSearchQuery]);
 
+  const focusTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    return () => clearTimeout(focusTimerRef.current);
+  }, []);
+
   const handleExpand = useCallback(() => {
     setShowIcon(false);
     setExpanded(true);
-    setTimeout(() => inputRef.current?.focus(), 0);
+    focusTimerRef.current = setTimeout(() => inputRef.current?.focus(), 0);
   }, []);
 
   const handleCollapse = useCallback(() => {


### PR DESCRIPTION
## Summary

Fix unhandled setTimeout cleanup in four React components/hooks to prevent memory leaks and state-update-on-unmounted-component warnings.

Closes #16500

## Changes

- **DocumentExplorerTree.tsx**: Store focus timer in ref, clear on unmount via useEffect cleanup
- **usePanelHandlers.ts**: Store model-change timer in ref, clear on unmount via useEffect cleanup
- **SkillEditForm.tsx**: Return cleanup from useEffect to clear editor initialization timer
- **SearchInput.tsx**: Store focus timer in ref, clear on unmount via useEffect cleanup