### PR TITLE
🐛 fix(cli): bare --json flag crashes with fields.split is not a function

### DIFF
--- a/apps/cli/src/utils/format.test.ts
+++ b/apps/cli/src/utils/format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { formatCost, formatNumber, printBoxTable } from './format';
+import { formatCost, formatNumber, outputJson, printBoxTable } from './format';
 
 describe('formatNumber', () => {
   it('should format numbers with commas', () => {
@@ -15,6 +15,43 @@ describe('formatCost', () => {
     expect(formatCost(0)).toBe('$0.00');
     expect(formatCost(1.5)).toBe('$1.50');
     expect(formatCost(123.456)).toBe('$123.46');
+  });
+});
+
+describe('outputJson', () => {
+  const capture = () => {
+    const output: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...args: any[]) => {
+      output.push(args.join(' '));
+    });
+    return output;
+  };
+
+  it('prints full JSON when --json is passed without a value (fields === true)', () => {
+    const output = capture();
+
+    expect(() => outputJson({ id: '1', name: 'a' }, true)).not.toThrow();
+    expect(JSON.parse(output.join('\n'))).toEqual({ id: '1', name: 'a' });
+
+    vi.restoreAllMocks();
+  });
+
+  it('filters fields when --json receives a field list', () => {
+    const output = capture();
+
+    outputJson({ extra: true, id: '1', name: 'a' }, 'id, name');
+    expect(JSON.parse(output.join('\n'))).toEqual({ id: '1', name: 'a' });
+
+    vi.restoreAllMocks();
+  });
+
+  it('prints full JSON when fields is undefined', () => {
+    const output = capture();
+
+    outputJson([{ id: '1' }]);
+    expect(JSON.parse(output.join('\n'))).toEqual([{ id: '1' }]);
+
+    vi.restoreAllMocks();
   });
 });
 

--- a/apps/cli/src/utils/format.ts
+++ b/apps/cli/src/utils/format.ts
@@ -239,8 +239,8 @@ export function pickFields(obj: Record<string, any>, fields: string[]): Record<s
   return result;
 }
 
-export function outputJson(data: unknown, fields?: string) {
-  if (fields) {
+export function outputJson(data: unknown, fields?: boolean | string) {
+  if (typeof fields === 'string' && fields.trim()) {
     const fieldList = fields.split(',').map((f) => f.trim());
     if (Array.isArray(data)) {
       console.log(


### PR DESCRIPTION
## What

`lh task create --json`, `lh task view <id> --json` (and every other command passing `options.json` straight into `outputJson`) crash with `fields.split is not a function` when `--json` is used without a field list — commander's `--json [fields]` yields `true` in that case.

Found while dry-running the generic agent-testing skill in an external repo (#17280 follow-up): the skill's subject-creation path (`lh task create`) is a natural place for agents to pass bare `--json`.

## Fix

- `outputJson(data, fields?: boolean | string)` now guards with `typeof fields === 'string' && fields.trim()`; bare `--json` prints the full JSON.
- Existing per-call-site ternary guards (e.g. `task/index.ts:596`, `verifyInstall.ts`) keep working and are no longer load-bearing.

## Testing

- New regression tests in `format.test.ts`: bare `--json` (fails with the exact TypeError before this fix), field-list filtering, and undefined fields. 8/8 green; lint clean.