### PR TITLE
🐛 fix(agent): split Claude quota status by scope

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/ClaudeCodeQuotaMenu.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/ClaudeCodeQuotaMenu.tsx
@@ -40,11 +40,25 @@ const ClaudeCodeQuotaMenu = memo<ClaudeCodeQuotaMenuProps>(({ env }) => {
 
   const getWindows = useCallback(
     (quota: ClaudeCodeQuotaSnapshot): QuotaWindowItem[] => [
-      { key: 'session', label: t('heteroAgent.quota.session'), window: quota.session },
-      { key: 'weekly', label: t('heteroAgent.quota.weekly'), window: quota.weekly },
+      {
+        compactGroup: 'global',
+        compactLabel: t('heteroAgent.quota.session'),
+        key: 'session',
+        label: t('heteroAgent.quota.session'),
+        window: quota.session,
+      },
+      {
+        compactGroup: 'global',
+        compactLabel: t('heteroAgent.quota.weekly'),
+        key: 'weekly',
+        label: t('heteroAgent.quota.weekly'),
+        window: quota.weekly,
+      },
       ...(quota.scopedWeekly
         ? [
             {
+              compactGroup: 'scopedWeekly',
+              compactLabel: quota.scopedWeekly.modelName,
               key: 'scopedWeekly',
               label: t('heteroAgent.claudeQuota.scopedWeekly', {
                 model: quota.scopedWeekly.modelName,

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu.test.tsx
@@ -151,15 +151,46 @@ describe('ClaudeCodeQuotaMenu', () => {
     expect(await screen.findByText('heteroAgent.quota.session')).toBeTruthy();
     expect(screen.getByText('heteroAgent.quota.weekly')).toBeTruthy();
     expect(screen.getByText('heteroAgent.claudeQuota.scopedWeekly:Fable')).toBeTruthy();
-    // The compact trigger surfaces the most binding window.
     expect(screen.getByText('heteroAgent.quota.left:92')).toBeTruthy();
-    expect(screen.getByText('heteroAgent.quota.compactLeft:76')).toBeTruthy();
+    const trigger = screen.getByRole('button', { name: 'heteroAgent.claudeQuota.tooltip' });
+    expect(trigger.textContent).toContain(
+      'heteroAgent.quota.weekly heteroAgent.quota.compactLeft:87',
+    );
+    expect(trigger.textContent).toContain('Fable heteroAgent.quota.compactLeft:76');
     expect(mockService.getClaudeCodeQuota).toHaveBeenCalledWith({
       env: { CLAUDE_CONFIG_DIR: '/custom' },
     });
   });
 
-  it('warns below 15 percent and labels zero quota as exhausted', async () => {
+  it('shows the tightest global window and Fable as separate compact values', async () => {
+    mockService.getClaudeCodeQuota.mockResolvedValue(
+      claudeSnapshot({
+        scopedWeekly: {
+          modelName: 'Fable',
+          window: { resetsAt: null, usedPercent: 100, windowMinutes: 10_080 },
+        },
+        session: { resetsAt: null, usedPercent: 49, windowMinutes: 300 },
+        weekly: { resetsAt: null, usedPercent: 53, windowMinutes: 10_080 },
+      }),
+    );
+
+    render(<ClaudeCodeQuotaMenu />);
+
+    expect(await screen.findByText('heteroAgent.quota.exhausted')).toBeTruthy();
+    const trigger = screen.getByRole('button', { name: 'heteroAgent.claudeQuota.tooltip' });
+    expect(trigger.textContent).toContain(
+      'heteroAgent.quota.weekly heteroAgent.quota.compactLeft:47',
+    );
+    expect(trigger.textContent).toContain('Fable heteroAgent.quota.compactLeft:0');
+    expect(trigger.textContent).not.toContain('heteroAgent.quota.exhausted');
+    expect(
+      [...trigger.querySelectorAll('[data-quota-level]')].map((item) =>
+        item.getAttribute('data-quota-level'),
+      ),
+    ).toEqual(['normal', 'low']);
+  });
+
+  it('warns below 15 percent and keeps compact zero quota numeric', async () => {
     mockService.getClaudeCodeQuota.mockResolvedValue(
       claudeSnapshot({
         session: { resetsAt: null, usedPercent: 100, windowMinutes: 300 },
@@ -169,8 +200,11 @@ describe('ClaudeCodeQuotaMenu', () => {
 
     render(<ClaudeCodeQuotaMenu />);
 
-    expect(await screen.findAllByText('heteroAgent.quota.exhausted')).toHaveLength(2);
+    expect(await screen.findAllByText('heteroAgent.quota.exhausted')).toHaveLength(1);
     expect(screen.getByText('heteroAgent.quota.left:14')).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'heteroAgent.claudeQuota.tooltip' }).textContent,
+    ).toContain('heteroAgent.quota.session heteroAgent.quota.compactLeft:0');
     expect(document.querySelectorAll('[data-quota-level="low"]')).toHaveLength(3);
   });
 
@@ -384,6 +418,11 @@ describe('CodexQuotaMenu', () => {
     expect(await screen.findByText('heteroAgent.quota.left:81')).toBeTruthy();
     expect(screen.getByText('heteroAgent.quota.left:12')).toBeTruthy();
     expect(screen.getByText('heteroAgent.quota.compactLeft:12')).toBeTruthy();
+    expect(
+      screen
+        .getByRole('button', { name: 'heteroAgent.codexQuota.tooltip' })
+        .getAttribute('data-quota-level'),
+    ).toBe('low');
     expect(screen.getByText('heteroAgent.codexQuota.fiveHour')).toBeTruthy();
     expect(screen.getByText('heteroAgent.quota.weekly')).toBeTruthy();
     expect(

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu.tsx
@@ -12,6 +12,21 @@ const QUOTA_STALE_MS = 60_000;
 const QUOTA_RETRY_COOLDOWN_MS = 60_000;
 
 const styles = createStaticStyles(({ css }) => ({
+  compactItem: css`
+    color: inherit;
+
+    &[data-quota-level='low'] {
+      color: ${cssVar.colorWarningText};
+    }
+  `,
+  compactItems: css`
+    display: inline-flex;
+    gap: 4px;
+    align-items: center;
+  `,
+  compactSeparator: css`
+    color: ${cssVar.colorTextQuaternary};
+  `,
   emptyState: css`
     padding-block: 10px;
     font-size: 12px;
@@ -132,9 +147,19 @@ export interface QuotaSnapshotBase {
 }
 
 export interface QuotaWindowItem {
+  /** Windows in the same compact group collapse to their tightest remaining value. */
+  compactGroup?: string;
+  /** Optional scope label shown before this window's compact percentage. */
+  compactLabel?: string;
   key: string;
   label: string;
   window: HeteroQuotaWindow | null;
+}
+
+interface CompactQuotaItem {
+  key: string;
+  label?: string;
+  leftPercent: number;
 }
 
 export interface QuotaMenuHelpers<S> {
@@ -171,8 +196,8 @@ interface LoadQuotaOptions {
 }
 
 /**
- * Shared quota popover for local CLI agents: gauge trigger with the most
- * binding window's remaining percent, plus per-window progress bars and
+ * Shared quota popover for local CLI agents: gauge trigger with the tightest
+ * remaining percent in each compact group, plus per-window progress bars and
  * reset countdowns. Agent specifics come in through the props.
  */
 const QuotaMenu = <S extends QuotaSnapshotBase>({
@@ -349,11 +374,23 @@ const QuotaMenu = <S extends QuotaSnapshotBase>({
   );
 
   const windows = quota ? getWindows(quota) : [];
-  const compactLeftPercent = windows.reduce<number | undefined>((mostBinding, item) => {
-    if (!item.window) return mostBinding;
+  const compactItemsByGroup = new Map<string, CompactQuotaItem>();
+  for (const item of windows) {
+    if (!item.window) continue;
+
     const leftPercent = clampPercent(100 - item.window.usedPercent);
-    return mostBinding === undefined ? leftPercent : Math.min(mostBinding, leftPercent);
-  }, undefined);
+    const compactGroup = item.compactGroup ?? 'default';
+    const existing = compactItemsByGroup.get(compactGroup);
+
+    if (!existing || leftPercent < existing.leftPercent) {
+      compactItemsByGroup.set(compactGroup, {
+        key: compactGroup,
+        label: item.compactLabel,
+        leftPercent,
+      });
+    }
+  }
+  const compactItems = [...compactItemsByGroup.values()];
   const hasQuotaData = hasQuotaDataForSnapshot(quota);
   const manualRefreshErrorText =
     refreshError && (getRefreshErrorText?.(refreshError) || t('heteroAgent.quota.refreshFailed'));
@@ -470,19 +507,40 @@ const QuotaMenu = <S extends QuotaSnapshotBase>({
       className={cx(styles.trigger, open && styles.triggerOpen)}
       type="button"
       data-quota-level={
-        compactLeftPercent === undefined
-          ? undefined
-          : isLowQuota(compactLeftPercent)
+        compactItems.length === 1
+          ? isLowQuota(compactItems[0].leftPercent)
             ? 'low'
             : 'normal'
+          : undefined
       }
     >
       <Icon icon={GaugeIcon} size={14} />
-      {compactLeftPercent !== undefined && (
-        <span>
-          {compactLeftPercent === 0
-            ? t('heteroAgent.quota.exhausted')
-            : t('heteroAgent.quota.compactLeft', { percent: compactLeftPercent })}
+      {compactItems.length > 0 && (
+        <span className={styles.compactItems}>
+          {compactItems.map((item, index) => (
+            <span key={item.key}>
+              {index > 0 && (
+                <span aria-hidden className={styles.compactSeparator}>
+                  {' · '}
+                </span>
+              )}
+              <span
+                className={styles.compactItem}
+                data-quota-level={
+                  compactItems.length > 1
+                    ? isLowQuota(item.leftPercent)
+                      ? 'low'
+                      : 'normal'
+                    : undefined
+                }
+              >
+                {item.label && `${item.label} `}
+                {item.leftPercent === 0 && !item.label
+                  ? t('heteroAgent.quota.exhausted')
+                  : t('heteroAgent.quota.compactLeft', { percent: item.leftPercent })}
+              </span>
+            </span>
+          ))}
         </span>
       )}
       <Icon icon={ChevronDownIcon} size={12} />


### PR DESCRIPTION
## Summary

- split the Claude Code compact quota indicator into the tightest global window and the scoped weekly window
- show Fable quota independently with per-segment warning styling
- preserve the existing single-indicator behavior for Codex
- add regression coverage for exhausted scoped quota and Codex compatibility

## Root cause

The shared compact indicator reduced every Claude quota window to one minimum value. When the Fable-scoped weekly quota was exhausted, it made the whole trigger read as exhausted even though the session and global weekly quotas were still available.

## User impact

A state such as 47% global weekly remaining with 0% Fable remaining now renders as two scoped values instead of a misleading global exhausted state.

## Validation

- `bun run check <3 changed files>`
- lint clean
- 18 related tests passed
