### PR TITLE
🐛 fix(chat): read new-topic title context from the event's topic key

### DIFF
--- a/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.test.ts
@@ -346,6 +346,47 @@ describe('buildRunLifecycle.afterUserMessagePersisted — topic title (all runti
     expect(store.summaryTopicTitle).toHaveBeenCalledWith('t1', messages);
   });
 
+  it('new topic (gateway, no caller messages) reads the store under the EVENT topicId, not the stale send-time context', async () => {
+    // Regression (#16289 follow-up): the adapter is built with the send-time
+    // `operationContext`, whose topicId is still null for a brand-new topic.
+    // Gateway/hetero omit `event.messages` and persist the conversation under
+    // the REAL topicId (carried on `event.context`). Reading the store with the
+    // stale adapter context lands on an empty bucket, so the model summarizes
+    // nothing and emits a degenerate "空对话标题" title.
+    const { get, store } = makeStore();
+    const storedMessages = [{ content: 'hello there', id: 'm1', role: 'user' } as any];
+    // Send-time context: new topic not created yet, so no topicId.
+    const sendContext = { agentId: 'a1', workspaceSlug: 'team' } as ConversationContext;
+    // Event context: the freshly-created topic id the messages were persisted under.
+    const eventContext = {
+      agentId: 'a1',
+      topicId: 't1',
+      workspaceSlug: 'team',
+    } as ConversationContext;
+    store.messagesMap = { [messageMapKey(eventContext)]: storedMessages };
+
+    const runLifecycle = buildRunLifecycle(get, {
+      context: sendContext,
+      parentMessageId: 'u1',
+      parentMessageType: 'user',
+      runId: OP,
+      runScope: 'top_level',
+      runtimeType: 'gateway',
+    });
+
+    await runLifecycle.afterUserMessagePersisted({
+      context: eventContext,
+      isCreateNewTopic: true,
+      operationId: OP,
+      runId: OP,
+      runScope: 'top_level',
+      runtimeType: 'gateway',
+      topicId: 't1',
+    });
+
+    expect(store.summaryTopicTitle).toHaveBeenCalledWith('t1', storedMessages);
+  });
+
   it('does NOT title for a sub_agent run', async () => {
     const { get, store } = makeStore();
 

--- a/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
@@ -209,12 +209,16 @@ export const buildRunLifecycle = (
         console.info('[dev] sliced topic title (NEXT_PUBLIC_DEV_DISABLE_AUTO_TOPIC=1):', title);
       };
 
-      // Use the full conversation context (incl. groupId/threadId) so group
-      // topics read their real messages instead of an empty main-scope bucket —
-      // an empty read makes topic-title generation summarize nothing and emit a
-      // degenerate "空对话标题" title.
+      // Key off the EVENT's context, not the adapter's send-time `context`.
+      // `context` (= operationContext captured at dispatch) still carries a null
+      // topicId for a just-created topic, so its key points at the empty
+      // main-scope bucket; gateway/hetero persist the conversation under the real
+      // topicId (`event.context` — `{ ...operationContext, topicId }`). Reading
+      // the stale key summarizes nothing and emits a degenerate "空对话标题"
+      // title. `event.context` also carries groupId/threadId, so group topics
+      // keep reading their real messages (the #16289 fix).
       const readStoreChats = () =>
-        displayMessageSelectors.getDisplayMessagesByKey(messageMapKey(context))(get());
+        displayMessageSelectors.getDisplayMessagesByKey(messageMapKey(event.context))(get());
 
       // New topic → always title. Use caller-provided messages when present
       // (client's freshly-created rows aren't in the store under topicId yet);


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

Regression from #16289: newly created gateway/hetero topics get auto-titled as a degenerate "空对话标题" ("empty conversation title").

`buildRunLifecycle.afterUserMessagePersisted`'s `readStoreChats` keyed the store read off the adapter's send-time `operationContext`, whose `topicId` is still `null` for a topic created by this very run — the key resolves to the empty `main_<agent>_new` bucket. Gateway/hetero persist the conversation under the real topicId (`event.context` = `{ ...operationContext, topicId }`) and omit `event.messages`, so title generation summarized an empty conversation and the model emitted the degenerate title.

Fix: key the read off `event.context`, which carries the fresh topicId **and** the groupId/threadId that #16289 added for group conversations — both fixes hold.

The client path was unaffected (it passes `event.messages` explicitly); only gateway/hetero new topics regressed.

#### 📝 Additional Information

Regression test added: gateway new-topic event with no caller-provided messages, conversation stored under the real topicId bucket. It fails on the pre-fix code (`summaryTopicTitle` called with an empty array) and passes with the fix. All 22 tests in `buildRunLifecycle.test.ts` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)