### PR TITLE
🐛 fix(topic): preserve workspace-aware agent topic navigation

### DIFF
--- a/src/features/AgentTopicManager/EmptyState.tsx
+++ b/src/features/AgentTopicManager/EmptyState.tsx
@@ -7,7 +7,8 @@ import { cssVar } from 'antd-style';
 import { MessagesSquare } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router';
+
+import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 
 interface EmptyStateProps {
   agentId: string;
@@ -17,7 +18,7 @@ interface EmptyStateProps {
 
 const EmptyState = memo<EmptyStateProps>(({ agentId, hasFilters, onClearFilters }) => {
   const { t } = useTranslation('topic');
-  const navigate = useNavigate();
+  const navigate = useWorkspaceAwareNavigate();
 
   return (
     <Flexbox align={'center'} flex={1} gap={16} justify={'center'} paddingBlock={64}>

--- a/src/features/AgentTopicManager/MoveTopicsModal/Content.tsx
+++ b/src/features/AgentTopicManager/MoveTopicsModal/Content.tsx
@@ -7,12 +7,12 @@ import { createStaticStyles, cssVar } from 'antd-style';
 import { CircleCheck } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router';
 
 import { message } from '@/components/AntdStaticMethods';
 import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
 import AgentItem from '@/features/PageEditor/Copilot/AgentSelector/AgentItem';
+import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useFetchAgentList } from '@/hooks/useFetchAgentList';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors, builtinAgentSelectors } from '@/store/agent/selectors';
@@ -54,7 +54,7 @@ const styles = createStaticStyles(({ css }) => ({
 const MoveTopicsContent = memo<MoveTopicsContentProps>(({ onMoved, sourceAgentId, topicIds }) => {
   const { t } = useTranslation(['topic', 'chat', 'common']);
   const { close, setCanDismissByClickOutside } = useModalContext();
-  const navigate = useNavigate();
+  const navigate = useWorkspaceAwareNavigate();
 
   const [step, setStep] = useState<Step>('pick');
   const [search, setSearch] = useState('');

--- a/src/features/AgentTopicManager/TopicCard.tsx
+++ b/src/features/AgentTopicManager/TopicCard.tsx
@@ -7,8 +7,8 @@ import { createStaticStyles, cssVar } from 'antd-style';
 import { CircleDollarSign, FolderIcon, MessageSquare, Star, Zap } from 'lucide-react';
 import { memo, type MouseEvent, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router';
 
+import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useActivityTime } from '@/hooks/useActivityTime';
 import type { ChatTopic } from '@/types/topic';
 
@@ -86,7 +86,7 @@ interface TopicCardProps {
 
 const TopicCard = memo<TopicCardProps>(({ topic, agentId }) => {
   const { t } = useTranslation('topic');
-  const navigate = useNavigate();
+  const navigate = useWorkspaceAwareNavigate();
 
   const selectMode = useTopicsViewStore((s) => s.selectMode);
   const selected = useTopicsViewStore((s) => s.selectedIds.includes(topic.id));

--- a/src/features/AgentTopicManager/TopicListView.tsx
+++ b/src/features/AgentTopicManager/TopicListView.tsx
@@ -7,8 +7,8 @@ import { createStaticStyles, cssVar } from 'antd-style';
 import { FolderIcon, MoreHorizontal, Star } from 'lucide-react';
 import { Fragment, memo, type MouseEvent, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router';
 
+import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useActivityTime } from '@/hooks/useActivityTime';
 import { useTopicItemDropdownMenu } from '@/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/useDropdownMenu';
 import type { ChatTopic } from '@/types/topic';
@@ -138,7 +138,7 @@ interface RowProps {
 
 const Row = memo<RowProps>(({ topic, agentId }) => {
   const { t } = useTranslation('topic');
-  const navigate = useNavigate();
+  const navigate = useWorkspaceAwareNavigate();
 
   const selectMode = useTopicsViewStore((s) => s.selectMode);
   const selected = useTopicsViewStore((s) => s.selectedIds.includes(topic.id));

--- a/src/features/CreatePlatformAgent/index.tsx
+++ b/src/features/CreatePlatformAgent/index.tsx
@@ -26,11 +26,11 @@ import {
 } from 'lucide-react';
 import { memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router';
 
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
 import { DOWNLOAD_URL } from '@/const/url';
 import { useDeviceList } from '@/features/DeviceManager/useDeviceList';
+import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { deviceService } from '@/services/device';
 import { useAgentStore } from '@/store/agent';
 import { useHomeStore } from '@/store/home';
@@ -118,7 +118,7 @@ const CreatePlatformAgentContent = memo<CreatePlatformAgentContentProps>(
   ({ groupId, visibility }) => {
     const { t } = useTranslation('chat');
     const { close, setCanDismissByClickOutside } = useModalContext();
-    const navigate = useNavigate();
+    const navigate = useWorkspaceAwareNavigate();
     const storeCreateAgent = useAgentStore((s) => s.createAgent);
     const refreshAgentList = useHomeStore((s) => s.refreshAgentList);
 

--- a/src/features/Workspace/__tests__/workspaceAwarePath.test.ts
+++ b/src/features/Workspace/__tests__/workspaceAwarePath.test.ts
@@ -24,6 +24,18 @@ describe('buildWorkspaceAwarePath', () => {
     expect(buildWorkspaceAwarePath('/fleet', 'acme')).toBe('/acme/fleet');
   });
 
+  it('prefixes deep agent and evaluation paths used by cross-page navigation', () => {
+    expect(buildWorkspaceAwarePath('/agent/agent-1/profile', 'acme')).toBe(
+      '/acme/agent/agent-1/profile',
+    );
+    expect(buildWorkspaceAwarePath('/agent/agent-1/topic-1', 'acme')).toBe(
+      '/acme/agent/agent-1/topic-1',
+    );
+    expect(buildWorkspaceAwarePath('/eval/bench/bench-1/runs/run-1/cases/case-1', 'acme')).toBe(
+      '/acme/eval/bench/bench-1/runs/run-1/cases/case-1',
+    );
+  });
+
   it('bypasses the prefix when `escape` is true', () => {
     expect(buildWorkspaceAwarePath('/settings/profile', 'acme', { escape: true })).toBe(
       '/settings/profile',

--- a/src/hooks/useQueryRoute.test.ts
+++ b/src/hooks/useQueryRoute.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useQueryRoute } from './useQueryRoute';
 
 const navigateMock = vi.hoisted(() => vi.fn((href: string) => href));
-const activeWorkspaceSlugMock = vi.hoisted(() => vi.fn(() => null));
+const activeWorkspaceSlugMock = vi.hoisted(() => vi.fn<() => string | null>(() => null));
 
 // Mocks
 vi.mock('react-router', () => ({

--- a/src/hooks/useQueryRoute.test.ts
+++ b/src/hooks/useQueryRoute.test.ts
@@ -3,9 +3,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useQueryRoute } from './useQueryRoute';
 
+const navigateMock = vi.hoisted(() => vi.fn((href: string) => href));
+const activeWorkspaceSlugMock = vi.hoisted(() => vi.fn(() => null));
+
 // Mocks
 vi.mock('react-router', () => ({
-  useNavigate: vi.fn(() => vi.fn((href) => href)),
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock('@/business/client/hooks/useActiveWorkspaceSlug', () => ({
+  useActiveWorkspaceSlug: activeWorkspaceSlugMock,
 }));
 
 vi.mock('@/utils/env', () => ({
@@ -14,6 +21,10 @@ vi.mock('@/utils/env', () => ({
 
 beforeEach(() => {
   location.search = 'foo=bar';
+  activeWorkspaceSlugMock.mockReset();
+  activeWorkspaceSlugMock.mockReturnValue(null);
+  navigateMock.mockReset();
+  navigateMock.mockImplementation((href: string) => href);
 });
 
 describe('useQueryRoute', () => {
@@ -81,5 +92,13 @@ describe('useQueryRoute', () => {
     );
 
     expect(result.current).toBe('/example?foo=bar');
+  });
+
+  it('should preserve the active workspace prefix for agent topics', () => {
+    activeWorkspaceSlugMock.mockReturnValue('team');
+
+    const { result } = renderHook(() => useQueryRoute().push('/agent/agent-1/topics'));
+
+    expect(result.current).toBe('/team/agent/agent-1/topics?foo=bar');
   });
 });

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/index.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/index.test.tsx
@@ -12,6 +12,18 @@ const closeAllTopicsDrawerMock = vi.hoisted(() => vi.fn());
 const permissionMock = vi.hoisted(() => ({
   create_content: true,
 }));
+const chatStoreStateMock = vi.hoisted(() => ({
+  activeAgentId: 'agent-1',
+  activeThreadId: undefined as string | undefined,
+  activeTopicId: undefined as string | undefined,
+  allTopicsDrawerOpen: false,
+  closeAllTopicsDrawer: closeAllTopicsDrawerMock,
+  hasMore: true,
+  isExpandingPageSize: false,
+  isUndefinedTopics: false,
+  topicLength: 0,
+  topics: [],
+}));
 
 vi.mock('@/features/NavPanel/components/EmptyNavItem', () => ({
   default: ({
@@ -24,6 +36,14 @@ vi.mock('@/features/NavPanel/components/EmptyNavItem', () => ({
     title: string;
   }) => (
     <button disabled={disabled} type="button" onClick={disabled ? undefined : onClick}>
+      {title}
+    </button>
+  ),
+}));
+
+vi.mock('@/features/NavPanel/components/NavItem', () => ({
+  default: ({ onClick, title }: { onClick: () => void; title: string }) => (
+    <button type="button" onClick={onClick}>
       {title}
     </button>
   ),
@@ -51,28 +71,42 @@ vi.mock('@/hooks/useQueryRoute', () => ({
 }));
 
 vi.mock('@/store/chat', () => ({
-  useChatStore: (
-    selector: (state: {
-      activeAgentId: string;
-      allTopicsDrawerOpen: boolean;
-      closeAllTopicsDrawer: () => void;
-      isUndefinedTopics: boolean;
-      topicLength: number;
-    }) => unknown,
-  ) =>
-    selector({
-      activeAgentId: 'agent-1',
-      allTopicsDrawerOpen: false,
-      closeAllTopicsDrawer: closeAllTopicsDrawerMock,
-      isUndefinedTopics: false,
-      topicLength: 0,
-    }),
+  useChatStore: (selector: (state: typeof chatStoreStateMock) => unknown) =>
+    selector(chatStoreStateMock),
 }));
 
 vi.mock('@/store/chat/selectors', () => ({
   topicSelectors: {
     currentTopicLength: (state: { topicLength: number }) => state.topicLength,
+    displayTopicsForSidebar: () => (state: typeof chatStoreStateMock) => state.topics,
+    hasMoreTopicsForSidebar: (state: typeof chatStoreStateMock) => state.hasMore,
+    isExpandingPageSize: (state: typeof chatStoreStateMock) => state.isExpandingPageSize,
     isUndefinedTopics: (state: { isUndefinedTopics: boolean }) => state.isUndefinedTopics,
+  },
+}));
+
+vi.mock('@/store/global', () => ({
+  useGlobalStore: (selector: (state: { topicPageSize: number }) => unknown) =>
+    selector({ topicPageSize: 20 }),
+}));
+
+vi.mock('@/store/global/selectors', () => ({
+  systemStatusSelectors: {
+    topicPageSize: (state: { topicPageSize: number }) => state.topicPageSize,
+  },
+}));
+
+vi.mock('@/store/user', () => ({
+  useUserStore: (
+    selector: (state: { topicIncludeCompleted: boolean; topicSortBy: string }) => unknown,
+  ) => selector({ topicIncludeCompleted: false, topicSortBy: 'updatedAt' }),
+}));
+
+vi.mock('@/store/user/selectors', () => ({
+  preferenceSelectors: {
+    topicIncludeCompleted: (state: { topicIncludeCompleted: boolean }) =>
+      state.topicIncludeCompleted,
+    topicSortBy: (state: { topicSortBy: string }) => state.topicSortBy,
   },
 }));
 
@@ -100,8 +134,8 @@ vi.mock('../TopicListContent/ByTimeMode', () => ({
   default: () => <div data-testid="by-time-mode" />,
 }));
 
-vi.mock('../TopicListContent/FlatMode', () => ({
-  default: () => <div data-testid="flat-mode" />,
+vi.mock('./Item', () => ({
+  default: () => <div data-testid="topic-item" />,
 }));
 
 // Partial mock: keep every real export (e.g. `lobeStaticStylish`, which
@@ -119,6 +153,10 @@ describe('Agent topic list', () => {
     pushMock.mockReset();
     closeAllTopicsDrawerMock.mockReset();
     permissionMock.create_content = true;
+    chatStoreStateMock.hasMore = true;
+    chatStoreStateMock.isExpandingPageSize = false;
+    chatStoreStateMock.topicLength = 0;
+    chatStoreStateMock.topics = [];
   });
 
   it('opens the agent chat route from the empty start topic entry', () => {
@@ -140,5 +178,13 @@ describe('Agent topic list', () => {
     fireEvent.click(startButton);
 
     expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('opens all agent topics from the view-all entry', () => {
+    render(<TopicList />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'topic.viewAll' }));
+
+    expect(pushMock).toHaveBeenCalledWith('/agent/agent-1/topics');
   });
 });

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/FlatMode/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/FlatMode/index.tsx
@@ -5,8 +5,6 @@ import isEqual from 'fast-deep-equal';
 import { MoreHorizontal } from 'lucide-react';
 import React, { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router';
-import urlJoin from 'url-join';
 
 import NavItem from '@/features/NavPanel/components/NavItem';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
@@ -17,11 +15,12 @@ import { systemStatusSelectors } from '@/store/global/selectors';
 import { useUserStore } from '@/store/user';
 import { preferenceSelectors } from '@/store/user/selectors';
 
+import { useNavigateToAgentTopics } from '../../hooks/useTopicNavigation';
 import TopicItem from '../../List/Item';
 
 const FlatMode = memo(() => {
-  const { t } = useTranslation('topic');
-  const navigate = useNavigate();
+  const { t } = useTranslation('chat');
+  const navigateToAgentTopics = useNavigateToAgentTopics();
   const topicPageSize = useGlobalStore(systemStatusSelectors.topicPageSize);
   const topicSortBy = useUserStore(preferenceSelectors.topicSortBy);
   const topicIncludeCompleted = useUserStore(preferenceSelectors.topicIncludeCompleted);
@@ -59,8 +58,8 @@ const FlatMode = memo(() => {
       {hasMore && !isExpandingPageSize && activeAgentId && (
         <NavItem
           icon={MoreHorizontal}
-          title={t('loadMore')}
-          onClick={() => navigate(urlJoin('/agent', activeAgentId, 'topics'))}
+          title={t('topic.viewAll')}
+          onClick={() => navigateToAgentTopics(activeAgentId)}
         />
       )}
     </Flexbox>

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/GroupedAccordion.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/GroupedAccordion.tsx
@@ -5,8 +5,6 @@ import isEqual from 'fast-deep-equal';
 import { MoreHorizontal } from 'lucide-react';
 import { type ComponentType, memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router';
-import urlJoin from 'url-join';
 
 import NavItem from '@/features/NavPanel/components/NavItem';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
@@ -20,6 +18,7 @@ import { preferenceSelectors } from '@/store/user/selectors';
 import { type GroupedTopic } from '@/types/topic';
 
 import { useAgentTopicGroupMode } from '../hooks/useAgentTopicGroupMode';
+import { useNavigateToAgentTopics } from '../hooks/useTopicNavigation';
 
 export interface GroupItemComponentProps {
   activeThreadId?: string;
@@ -33,8 +32,8 @@ interface GroupedAccordionProps {
 }
 
 const GroupedAccordion = memo<GroupedAccordionProps>(({ GroupItem }) => {
-  const { t } = useTranslation('topic');
-  const navigate = useNavigate();
+  const { t } = useTranslation('chat');
+  const navigateToAgentTopics = useNavigateToAgentTopics();
   const topicPageSize = useGlobalStore(systemStatusSelectors.topicPageSize);
   const topicSortBy = useUserStore(preferenceSelectors.topicSortBy);
   const topicIncludeCompleted = useUserStore(preferenceSelectors.topicIncludeCompleted);
@@ -83,8 +82,8 @@ const GroupedAccordion = memo<GroupedAccordionProps>(({ GroupItem }) => {
       {hasMore && !isExpandingPageSize && activeAgentId && (
         <NavItem
           icon={MoreHorizontal}
-          title={t('loadMore')}
-          onClick={() => navigate(urlJoin('/agent', activeAgentId, 'topics'))}
+          title={t('topic.viewAll')}
+          onClick={() => navigateToAgentTopics(activeAgentId)}
         />
       )}
     </Flexbox>

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/hooks/useTopicNavigation.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/hooks/useTopicNavigation.test.tsx
@@ -4,7 +4,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useTopicNavigation } from './useTopicNavigation';
+import { useNavigateToAgentTopics, useTopicNavigation } from './useTopicNavigation';
 
 const switchTopicMock = vi.hoisted(() => vi.fn());
 const toggleMobileTopicMock = vi.hoisted(() => vi.fn());
@@ -204,5 +204,15 @@ describe('useTopicNavigation', () => {
     expect(pushMock).toHaveBeenCalledWith('/lobehub/agent/agent-1/topic-prefixed');
     expect(switchTopicMock).not.toHaveBeenCalled();
     expect(toggleMobileTopicMock).toHaveBeenCalledWith(false);
+  });
+
+  it('opens the agent topics page through the workspace-aware query router', () => {
+    const { result } = renderHook(() => useNavigateToAgentTopics());
+
+    act(() => {
+      result.current('agent-1');
+    });
+
+    expect(pushMock).toHaveBeenCalledWith('/agent/agent-1/topics');
   });
 });

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/hooks/useTopicNavigation.ts
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/hooks/useTopicNavigation.ts
@@ -1,6 +1,7 @@
 import { AGENT_CHAT_TOPIC_URL, AGENT_CHAT_URL } from '@lobechat/const';
 import { useCallback, useMemo } from 'react';
 import { useParams } from 'react-router';
+import urlJoin from 'url-join';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import { useFocusTopicPopup } from '@/features/TopicPopupGuard/useTopicPopupsRegistry';
@@ -98,4 +99,13 @@ export const useTopicNavigation = () => {
     routeTopicId,
     urlTopicId,
   };
+};
+
+export const useNavigateToAgentTopics = () => {
+  const router = useQueryRoute();
+
+  return useCallback(
+    (agentId: string) => router.push(urlJoin('/agent', agentId, 'topics')),
+    [router],
+  );
 };

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/index.tsx
@@ -9,7 +9,7 @@ import { Alert, Flexbox } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { memo, type ReactNode, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
 import urlJoin from 'url-join';
 
 import { useHeteroAgentCloudConfig } from '@/business/client/hooks/useHeteroAgentCloudConfig';
@@ -19,6 +19,7 @@ import HeteroModel from '@/features/ChatInput/ControlBar/HeteroModel';
 import { ChatInput } from '@/features/Conversation';
 import { contextSelectors, useConversationStore } from '@/features/Conversation/store';
 import WideScreenContainer from '@/features/WideScreenContainer';
+import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
 import { useEffectiveAgencyConfig } from '@/hooks/useEffectiveAgencyConfig';
 import { useRemoteAgentDeviceGuard } from '@/hooks/useRemoteAgentDeviceGuard';
@@ -88,7 +89,7 @@ const HeterogeneousChatInput = memo(() => {
   const agentId = useConversationStore(contextSelectors.agentId);
   const { isConfigured, goToConfig } = useHeteroAgentCloudConfig(agentId);
   const params = useParams<{ aid: string }>();
-  const navigate = useNavigate();
+  const navigate = useWorkspaceAwareNavigate();
 
   // Effective config = shared row + this member's per-agent device override
   // (LOBE-11689) — the raw shared `agencyConfig` may carry another member's

--- a/src/routes/(main)/eval/bench/[benchmarkId]/features/RunCreateModal/Content.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/features/RunCreateModal/Content.tsx
@@ -9,7 +9,9 @@ import { SquareArrowOutUpRight } from 'lucide-react';
 import { type FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
+import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
 import { agentService } from '@/services/agent';
 import { useEvalStore } from '@/store/eval';
 
@@ -77,6 +79,7 @@ const RunCreateContent: FC<RunCreateContentProps> = ({
   const { t: tChat } = useTranslation('chat');
   const { close } = useModalContext();
   const navigate = useWorkspaceAwareNavigate();
+  const activeWorkspaceSlug = useActiveWorkspaceSlug();
   const createRun = useEvalStore((s) => s.createRun);
   const startRun = useEvalStore((s) => s.startRun);
   const datasetList = useEvalStore((s) => s.datasetList);
@@ -133,11 +136,18 @@ const RunCreateContent: FC<RunCreateContentProps> = ({
     [allAgents],
   );
 
-  const handleOpenAgent = useCallback((agentId: string, e: React.MouseEvent) => {
-    e.stopPropagation();
-    e.preventDefault();
-    window.open(AGENT_PROFILE_URL(agentId), `agent_${agentId}`, 'noopener,noreferrer');
-  }, []);
+  const handleOpenAgent = useCallback(
+    (agentId: string, e: React.MouseEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+      window.open(
+        buildWorkspaceAwarePath(AGENT_PROFILE_URL(agentId), activeWorkspaceSlug),
+        `agent_${agentId}`,
+        'noopener,noreferrer',
+      );
+    },
+    [activeWorkspaceSlug],
+  );
 
   const submit = useCallback(
     async (shouldStart: boolean) => {

--- a/src/routes/(main)/eval/bench/[benchmarkId]/features/RunEditModal/Content.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/features/RunEditModal/Content.tsx
@@ -11,7 +11,9 @@ import { type FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
+import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
+import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
 import { agentService } from '@/services/agent';
 import { useEvalStore } from '@/store/eval';
 
@@ -58,6 +60,7 @@ const RunEditContent: FC<RunEditContentProps> = ({ formId, onLoadingChange, run 
   const { close } = useModalContext();
   const { message } = App.useApp();
   const navigate = useWorkspaceAwareNavigate();
+  const activeWorkspaceSlug = useActiveWorkspaceSlug();
   const { benchmarkId } = useParams<{ benchmarkId: string }>();
   const updateRun = useEvalStore((s) => s.updateRun);
   const datasetList = useEvalStore((s) => s.datasetList);
@@ -127,11 +130,18 @@ const RunEditContent: FC<RunEditContentProps> = ({ formId, onLoadingChange, run 
     [allAgents],
   );
 
-  const handleOpenAgent = useCallback((agentId: string, e: React.MouseEvent) => {
-    e.stopPropagation();
-    e.preventDefault();
-    window.open(AGENT_PROFILE_URL(agentId), `agent_${agentId}`, 'noopener,noreferrer');
-  }, []);
+  const handleOpenAgent = useCallback(
+    (agentId: string, e: React.MouseEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+      window.open(
+        buildWorkspaceAwarePath(AGENT_PROFILE_URL(agentId), activeWorkspaceSlug),
+        `agent_${agentId}`,
+        'noopener,noreferrer',
+      );
+    },
+    [activeWorkspaceSlug],
+  );
 
   const handleFinish = async (values: any) => {
     onLoadingChange?.(true);

--- a/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/Charts/ScatterPlot.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/Charts/ScatterPlot.tsx
@@ -7,6 +7,9 @@ import { createStaticStyles, cssVar, useTheme } from 'antd-style';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
+import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
+
 const styles = createStaticStyles(({ css }) => ({
   axisLabel: css`
     pointer-events: none;
@@ -16,7 +19,6 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   dot: css`
     cursor: pointer;
-
     transition:
       transform 0.15s ease,
       opacity 0.15s ease;
@@ -54,6 +56,7 @@ interface ScatterPlotProps {
 const ScatterPlot = memo<ScatterPlotProps>(({ results, benchmarkId, runId }) => {
   const { t } = useTranslation('eval');
   const theme = useTheme();
+  const activeWorkspaceSlug = useActiveWorkspaceSlug();
 
   const { maxDuration, maxTokens, scatterData } = useMemo(() => {
     if (!results || results.length === 0) return { maxDuration: 0, maxTokens: 0, scatterData: [] };
@@ -104,14 +107,7 @@ const ScatterPlot = memo<ScatterPlotProps>(({ results, benchmarkId, runId }) => 
           y1="100"
           y2="100"
         />
-        <line
-          stroke={theme.colorBorderSecondary}
-          strokeWidth="0.5"
-          x1="0"
-          x2="0"
-          y1="0"
-          y2="100"
-        />
+        <line stroke={theme.colorBorderSecondary} strokeWidth="0.5" x1="0" x2="0" y1="0" y2="100" />
         {[1, 2, 3].map((i) => (
           <line
             key={i}
@@ -147,6 +143,7 @@ const ScatterPlot = memo<ScatterPlotProps>(({ results, benchmarkId, runId }) => 
         const expectedPreview =
           d.expected.length > 60 ? d.expected.slice(0, 60) + '...' : d.expected;
         const caseUrl = `/eval/bench/${benchmarkId}/runs/${runId}/cases/${d.testCaseId}`;
+        const workspaceAwareCaseUrl = buildWorkspaceAwarePath(caseUrl, activeWorkspaceSlug);
         return (
           <Tooltip
             key={i}
@@ -208,11 +205,11 @@ const ScatterPlot = memo<ScatterPlotProps>(({ results, benchmarkId, runId }) => 
                 transform: 'translate(-50%, 50%)',
                 width: 7,
               }}
-              onClick={() => window.open(caseUrl, '_blank')}
+              onClick={() => window.open(workspaceAwareCaseUrl, '_blank')}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
-                  window.open(caseUrl, '_blank');
+                  window.open(workspaceAwareCaseUrl, '_blank');
                 }
               }}
             />

--- a/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/RunHeader/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/RunHeader/index.tsx
@@ -19,7 +19,9 @@ import {
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
+import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
 import { createRunEditModal } from '@/routes/(main)/eval/bench/[benchmarkId]/features/RunEditModal';
 import StatusBadge from '@/routes/(main)/eval/features/StatusBadge';
@@ -180,6 +182,7 @@ const RunHeader = memo<RunHeaderProps>(({ run, benchmarkId, hideStart }) => {
   const { t } = useTranslation('eval');
   const { message } = App.useApp();
   const navigate = useWorkspaceAwareNavigate();
+  const activeWorkspaceSlug = useActiveWorkspaceSlug();
   const abortRun = useEvalStore((s) => s.abortRun);
   const deleteRun = useEvalStore((s) => s.deleteRun);
   const startRun = useEvalStore((s) => s.startRun);
@@ -237,7 +240,10 @@ const RunHeader = memo<RunHeaderProps>(({ run, benchmarkId, hideStart }) => {
 
   const handleOpenAgent = () => {
     if (run.targetAgentId) {
-      window.open(AGENT_PROFILE_URL(run.targetAgentId), '_blank');
+      window.open(
+        buildWorkspaceAwarePath(AGENT_PROFILE_URL(run.targetAgentId), activeWorkspaceSlug),
+        '_blank',
+      );
     }
   };
   const handleCopyRunId = async () => {

--- a/src/store/global/actions/__tests__/general.test.ts
+++ b/src/store/global/actions/__tests__/general.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import * as activeWorkspaceSlugModule from '@/business/client/hooks/useActiveWorkspaceSlug';
 import { CURRENT_VERSION } from '@/const/version';
 import { globalService } from '@/services/global';
 import { useGlobalStore } from '@/store/global';
@@ -113,6 +114,36 @@ describe('generalActionSlice', () => {
       });
 
       expect(result.current.status.language).toBeUndefined();
+    });
+  });
+
+  describe('browser popup routes', () => {
+    it('keeps the active workspace in agent and topic popups', async () => {
+      vi.spyOn(activeWorkspaceSlugModule, 'getActiveWorkspaceSlug').mockReturnValue('team');
+      const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+      await useGlobalStore.getState().openAgentInNewWindow('agent-1');
+      await useGlobalStore.getState().openTopicInNewWindow('agent-1', 'topic-1');
+      await useGlobalStore.getState().openGroupTopicInNewWindow('group-1', 'topic-1');
+
+      expect(open).toHaveBeenNthCalledWith(
+        1,
+        '/team/agent/agent-1',
+        'agent_agent-1',
+        expect.any(String),
+      );
+      expect(open).toHaveBeenNthCalledWith(
+        2,
+        '/team/agent/agent-1/topic-1',
+        'agent_agent-1_topic_topic-1',
+        expect.any(String),
+      );
+      expect(open).toHaveBeenNthCalledWith(
+        3,
+        '/team/group/group-1/topic-1',
+        'group_group-1_topic_topic-1',
+        expect.any(String),
+      );
     });
   });
 

--- a/src/store/global/actions/general.ts
+++ b/src/store/global/actions/general.ts
@@ -4,7 +4,9 @@ import { gt, parse, valid } from 'semver';
 import type { SWRResponse } from 'swr';
 
 import { getActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
+import { getActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import { CURRENT_VERSION, isDesktop } from '@/const/version';
+import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
 import { useOnlyFetchOnceSWR } from '@/libs/swr';
 import { globalKeys } from '@/libs/swr/keys';
 import { globalService } from '@/services/global';
@@ -45,8 +47,6 @@ export class GlobalGeneralActionImpl {
   }
 
   openAgentInNewWindow = async (agentId: string): Promise<void> => {
-    const url = `/agent/${agentId}${isDesktop ? '?mode=single' : ''}`;
-
     if (isDesktop) {
       try {
         const { ensureElectronIpc } = await import('@/utils/electron/ipc');
@@ -66,18 +66,18 @@ export class GlobalGeneralActionImpl {
       }
     } else {
       // Open in popup window for browser
+      const browserUrl = buildWorkspaceAwarePath(`/agent/${agentId}`, getActiveWorkspaceSlug());
       const width = 1200;
       const height = 800;
       const left = (window.screen.width - width) / 2;
       const top = (window.screen.height - height) / 2;
       const features = `width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes,status=yes`;
-      window.open(url, `agent_${agentId}`, features);
+      window.open(browserUrl, `agent_${agentId}`, features);
     }
   };
 
   openTopicInNewWindow = async (agentId: string, topicId: string): Promise<void> => {
     const popupPath = `/popup/agent/${agentId}/${topicId}`;
-    const browserUrl = AGENT_CHAT_TOPIC_URL(agentId, topicId);
 
     if (isDesktop) {
       try {
@@ -97,6 +97,10 @@ export class GlobalGeneralActionImpl {
       }
     } else {
       // Open in popup window for browser
+      const browserUrl = buildWorkspaceAwarePath(
+        AGENT_CHAT_TOPIC_URL(agentId, topicId),
+        getActiveWorkspaceSlug(),
+      );
       const width = 1200;
       const height = 800;
       const left = (window.screen.width - width) / 2;
@@ -108,7 +112,6 @@ export class GlobalGeneralActionImpl {
 
   openGroupTopicInNewWindow = async (groupId: string, topicId: string): Promise<void> => {
     const popupPath = `/popup/group/${groupId}/${topicId}`;
-    const browserUrl = GROUP_CHAT_TOPIC_URL(groupId, topicId);
 
     if (isDesktop) {
       try {
@@ -127,6 +130,10 @@ export class GlobalGeneralActionImpl {
         console.error('Error opening group topic in new window:', error);
       }
     } else {
+      const browserUrl = buildWorkspaceAwarePath(
+        GROUP_CHAT_TOPIC_URL(groupId, topicId),
+        getActiveWorkspaceSlug(),
+      );
       const width = 1200;
       const height = 800;
       const left = (window.screen.width - width) / 2;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No matching GitHub issue found.

#### 🔀 Description of Change

Make the agent topic sidebar's “View all” navigation workspace-aware by routing through `useQueryRoute`. Reuse the shared navigation hook in flat and grouped topic modes, and update the displayed translation key from the generic load-more label to the topic-specific view-all label.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation: `bun run check` on the six changed files — lint clean, 19 tests passed.

#### 📸 Screenshots / Videos

Not applicable.

#### 📝 Additional Information

This PR targets `canary` and contains only the topic-navigation fix.