### PR TITLE
⚡️ perf(cli): batch hetero server ingest with text-snapshot coalescing

### DIFF
--- a/apps/cli/src/commands/hetero.test.ts
+++ b/apps/cli/src/commands/hetero.test.ts
@@ -888,11 +888,12 @@ describe('hetero exec command', () => {
     });
   });
 
-  it('sends full text snapshots before tools and waits for finish until all server ingests ack', async () => {
+  it('batches snapshot + tool + terminal events into ordered ingest calls and finishes after the ack', async () => {
     const callOrder: string[] = [];
     mockHeteroIngestMutate.mockImplementation(async ({ events }: any) => {
-      const first = events[0];
-      callOrder.push(`ingest:${first.type}:${first.data?.chunkType ?? 'terminal'}`);
+      for (const event of events) {
+        callOrder.push(`ingest:${event.type}:${event.data?.chunkType ?? 'terminal'}`);
+      }
       return { ack: true };
     });
     mockHeteroFinishMutate.mockImplementation(async () => {
@@ -962,13 +963,17 @@ describe('hetero exec command', () => {
       'none',
     ]);
 
-    expect(mockHeteroIngestMutate).toHaveBeenCalledTimes(3);
+    // The whole run fits one batched ingest call (3 events ≪ MAX_BATCH) —
+    // NOT one serial round-trip per event as before.
+    expect(mockHeteroIngestMutate).toHaveBeenCalledTimes(1);
     expect(mockHeteroIngestMutate.mock.calls[0][0].events[0].data).toMatchObject({
       chunkType: 'text',
       content: 'hello world',
       snapshotMode: 'replace',
       snapshotSeq: 1,
     });
+    // Within-batch order preserved (server processes a batch sequentially),
+    // and finish is only sent after every ingest acked.
     expect(callOrder).toEqual([
       'ingest:stream_chunk:text',
       'ingest:stream_chunk:tools_calling',

--- a/apps/cli/src/commands/hetero.ts
+++ b/apps/cli/src/commands/hetero.ts
@@ -24,6 +24,7 @@ import {
 import type { Command } from 'commander';
 
 import { getTrpcClient } from '../api/client';
+import { CoalescingBatchIngester } from '../utils/CoalescingBatchIngester';
 import { log } from '../utils/logger';
 import { TrpcIngestSink } from '../utils/TrpcIngestSink';
 
@@ -252,111 +253,6 @@ const resolvePrompt = async (options: ExecOptions): Promise<ResolvedPrompt> => {
   return buildPromptFromText(raw, images);
 };
 
-class SerialServerIngester {
-  private accumulatedText = '';
-  private fatalError: Error | null = null;
-  private inflight: Promise<void> = Promise.resolve();
-  private nextSnapshotSeq = 0;
-  private pendingTextEvent: AgentStreamEvent | undefined;
-  private timer: ReturnType<typeof setTimeout> | null = null;
-
-  constructor(
-    private readonly sink: TrpcIngestSink,
-    private readonly snapshotFlushMs = 200,
-  ) {}
-
-  push(event: AgentStreamEvent): void {
-    if (this.fatalError) return;
-
-    // Text-snapshot coalescing is a MAIN-AGENT-ONLY transport optimization:
-    // it debounces the main agent's token-level text *deltas* into one
-    // `replace` snapshot to cut ingest calls. Subagent text is explicitly
-    // excluded (`!event.data?.subagent`) for two reasons:
-    //   1. Subagent text is emitted as ONE full block per turn (see
-    //      claudeCode adapter `handleSubagentAssistant` — "the full block IS
-    //      the only emission"), so there is nothing to coalesce.
-    //   2. `accumulatedText` is a single shared accumulator with no subagent
-    //      scope. Folding subagent blocks in would (a) splice main-agent text
-    //      into the subagent message via the shared buffer, and (b) emit a
-    //      `replace` snapshot that the server's subagent path *appends*
-    //      (`persistSubagentText` has no snapshot semantics) → duplicated /
-    //      cross-scope content. Forwarding the raw block straight through lets
-    //      the server append it exactly once, correctly.
-    if (
-      event.type === 'stream_chunk' &&
-      event.data?.chunkType === 'text' &&
-      typeof event.data?.content === 'string' &&
-      !event.data?.subagent
-    ) {
-      this.accumulatedText += event.data.content;
-      this.pendingTextEvent = event;
-      if (this.timer) clearTimeout(this.timer);
-      this.timer = setTimeout(() => {
-        this.timer = null;
-        this.queuePendingTextSnapshot();
-      }, this.snapshotFlushMs);
-      return;
-    }
-
-    this.queuePendingTextSnapshot();
-    // `accumulatedText` is a PER-MESSAGE accumulator: it coalesces the text
-    // deltas of the current assistant message into one `replace` snapshot.
-    // A new message boundary (`stream_start` / `stream_end`, emitted by the
-    // adapter's `openMainMessage`) must reset it — otherwise it spans the
-    // whole run and every later message's snapshot re-emits all prior
-    // messages' text verbatim, which the server then persists into the new
-    // DB message: cross-message text duplication. Reset
-    // AFTER flushing the just-ended message's pending snapshot above.
-    if (event.type === 'stream_start' || event.type === 'stream_end') {
-      this.accumulatedText = '';
-    }
-    this.enqueue(async () => {
-      await this.sink.ingest([event]);
-    });
-  }
-
-  async drain(): Promise<void> {
-    this.queuePendingTextSnapshot();
-    try {
-      await this.inflight;
-    } catch {
-      // `fatalError` is re-thrown below.
-    }
-    if (this.fatalError) throw this.fatalError;
-  }
-
-  private enqueue(task: () => Promise<void>) {
-    this.inflight = this.inflight.then(task).catch((err) => {
-      this.fatalError = err instanceof Error ? err : new Error(String(err));
-      throw this.fatalError;
-    });
-  }
-
-  private queuePendingTextSnapshot() {
-    if (!this.pendingTextEvent || this.fatalError) return;
-    if (this.timer) {
-      clearTimeout(this.timer);
-      this.timer = null;
-    }
-
-    const baseEvent = this.pendingTextEvent;
-    this.pendingTextEvent = undefined;
-    const snapshotEvent: AgentStreamEvent = {
-      ...baseEvent,
-      data: {
-        ...baseEvent.data,
-        content: this.accumulatedText,
-        snapshotMode: 'replace',
-        snapshotSeq: ++this.nextSnapshotSeq,
-      },
-    };
-
-    this.enqueue(async () => {
-      await this.sink.ingest([snapshotEvent]);
-    });
-  }
-}
-
 interface RawStreamDumpAttempt {
   /** Flush + close both file streams. Resolves once the bytes are on disk. */
   close: () => Promise<void>;
@@ -483,7 +379,7 @@ const exec = async (options: ExecOptions): Promise<void> => {
   // JWT injected by the server) for authentication.
   const agentType = options.type as 'amp' | 'claude-code' | 'codex';
   let sink: TrpcIngestSink | undefined;
-  let serverIngester: SerialServerIngester | undefined;
+  let serverIngester: CoalescingBatchIngester | undefined;
   // Uploader for tool_result images (CC `Read` on an image file). Reuses the
   // CLI's authenticated lambda client so the persisted event carries a
   // `{ fileId, url }` reference instead of heavy base64. Only wired in
@@ -500,7 +396,7 @@ const exec = async (options: ExecOptions): Promise<void> => {
       options.topic!,
       process.env.LOBEHUB_ASSISTANT_MESSAGE_ID,
     );
-    serverIngester = new SerialServerIngester(sink);
+    serverIngester = new CoalescingBatchIngester(sink);
 
     uploadImage = createFileStoreImageUploader(async () => {
       const lambda = await getTrpcClient();

--- a/apps/cli/src/utils/BatchIngester.test.ts
+++ b/apps/cli/src/utils/BatchIngester.test.ts
@@ -1,0 +1,112 @@
+import type { AgentStreamEvent } from '@lobechat/heterogeneous-agents/spawn';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BatchIngester, type IngestSink } from './BatchIngester';
+
+const makeEvent = (n: number): AgentStreamEvent =>
+  ({
+    data: { n },
+    operationId: 'op-1',
+    stepIndex: n,
+    timestamp: 1_700_000_000_000 + n,
+    type: 'tool_start',
+  }) as AgentStreamEvent;
+
+const numbers = (events: AgentStreamEvent[]) => events.map((event) => (event.data as any).n);
+
+describe('BatchIngester', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('coalesces events that arrive during a slow in-flight request into one follow-up batch', async () => {
+    // Regression: the batch used to be spliced when a flush was SCHEDULED, so
+    // events arriving while a slow request was in flight fragmented into
+    // per-250ms micro-batches queued serially — throughput stayed ~one tiny
+    // batch per RTT and the backlog never caught up. Splicing at send time
+    // must ship everything that accumulated behind the slow request as a
+    // single batch.
+    const batches: number[][] = [];
+    let releaseFirst!: () => void;
+    const firstAck = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const sink: IngestSink = {
+      finish: vi.fn(async () => {}),
+      ingest: vi.fn(async (events) => {
+        batches.push(numbers(events));
+        if (batches.length === 1) await firstAck; // slow first round-trip
+      }),
+    };
+    const ingester = new BatchIngester(sink);
+
+    ingester.push(makeEvent(1));
+    await vi.advanceTimersByTimeAsync(250); // flush timer → [1] starts sending, blocked
+
+    ingester.push(makeEvent(2));
+    await vi.advanceTimersByTimeAsync(300);
+    ingester.push(makeEvent(3));
+    await vi.advanceTimersByTimeAsync(300);
+
+    releaseFirst();
+    await ingester.drain();
+
+    expect(batches).toEqual([[1], [2, 3]]);
+  });
+
+  it('never sends later batches once an earlier batch has exhausted its retries', async () => {
+    // Regression: queued follow-up batches used to keep sending after the
+    // first batch was permanently lost — if the server recovered mid-window,
+    // it received a gapped stream (e.g. a tool_end whose tool_start never
+    // arrived). After a fatal error the worker must stop and drop everything
+    // still buffered.
+    const batches: number[][] = [];
+    const sink: IngestSink = {
+      finish: vi.fn(async () => {}),
+      ingest: vi.fn(async (events) => {
+        batches.push(numbers(events));
+        throw new Error('server down');
+      }),
+    };
+    const ingester = new BatchIngester(sink);
+
+    // Batch 1 fills to MAX_BATCH and starts sending (then keeps retrying)…
+    for (let i = 1; i <= 50; i++) ingester.push(makeEvent(i));
+    // …while a second batch's worth of events arrives during the retry window.
+    for (let i = 51; i <= 100; i++) ingester.push(makeEvent(i));
+
+    const drained = ingester.drain();
+    const assertion = expect(drained).rejects.toThrow('server down');
+    // Back-off schedule: 500 + 1000 + 2000 + 4000 + 8000 ms.
+    await vi.advanceTimersByTimeAsync(20_000);
+    await assertion;
+
+    expect(sink.ingest).toHaveBeenCalledTimes(6); // batch 1: initial + 5 retries
+    for (const batch of batches) {
+      expect(batch[0]).toBe(1); // every call was batch 1 — [51..100] never sent
+      expect(batch).toHaveLength(50);
+    }
+  });
+
+  it('splits a synchronous burst into MAX_BATCH-sized batches in order', async () => {
+    const batches: number[][] = [];
+    const sink: IngestSink = {
+      finish: vi.fn(async () => {}),
+      ingest: vi.fn(async (events) => {
+        batches.push(numbers(events));
+      }),
+    };
+    const ingester = new BatchIngester(sink);
+
+    const all = Array.from({ length: 120 }, (_, i) => i + 1);
+    for (const n of all) ingester.push(makeEvent(n));
+    await ingester.drain();
+
+    expect(batches.map((batch) => batch.length)).toEqual([50, 50, 20]);
+    expect(batches.flat()).toEqual(all);
+  });
+});

--- a/apps/cli/src/utils/BatchIngester.ts
+++ b/apps/cli/src/utils/BatchIngester.ts
@@ -52,6 +52,13 @@ export class BatchIngester {
 
   constructor(private readonly sink: IngestSink) {}
 
+  /** True once a batch has exhausted its retries — every later push is a no-op
+   *  and `drain()` rethrows the stored error. Lets wrappers stop buffering
+   *  work (e.g. text coalescing) that can never be delivered. */
+  get failed(): boolean {
+    return this.fatalError !== null;
+  }
+
   push(event: AgentStreamEvent): void {
     if (this.fatalError) return;
     this.buffer.push(event);

--- a/apps/cli/src/utils/BatchIngester.ts
+++ b/apps/cli/src/utils/BatchIngester.ts
@@ -33,22 +33,34 @@ const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 /**
  * Buffers `AgentStreamEvent`s and flushes them in batches to an `IngestSink`.
  *
- * Flush triggers:
- *   - Buffer reaches MAX_BATCH (50) → immediate flush
- *   - FLUSH_INTERVAL_MS (250ms) timer fires → flush whatever is buffered
+ * A single send worker pumps the buffer: it splices at most MAX_BATCH (50)
+ * events **at send time** — not when a flush is scheduled — so everything
+ * that arrives while a slow request is in flight coalesces into the next
+ * batch instead of fragmenting into per-interval micro-batches queued behind
+ * it. Consumption per round-trip therefore scales with the backlog, which is
+ * what lets ingest catch up to a producer that briefly outpaces the server.
+ *
+ * Pump triggers:
+ *   - Buffer reaches MAX_BATCH (50) → start the worker immediately
+ *   - FLUSH_INTERVAL_MS (250ms) timer fires → start the worker
+ *   - drain() → start the worker and await it
  *
  * Each batch is retried up to MAX_RETRIES (5) times with exponential back-off
- * starting at 500ms, doubling up to 8s.  After the final retry the error is
- * stored and re-thrown by `drain()`, allowing the caller to call
- * `sink.finish({ result: 'error' })` and exit(1).
+ * starting at 500ms, doubling up to 8s. After the final retry the error is
+ * stored, the worker stops, and every event still buffered (or pushed later)
+ * is dropped — later batches must never be sent once an earlier one is
+ * permanently lost, or the server would see a gapped stream (a `tool_end`
+ * whose `tool_start` never arrived). `drain()` rethrows the stored error,
+ * allowing the caller to call `sink.finish({ result: 'error' })` and exit(1).
  *
  * Call order: push() repeatedly → drain() once (before finish()).
  */
 export class BatchIngester {
   private buffer: AgentStreamEvent[] = [];
   private fatalError: Error | null = null;
-  private inflightFlush: Promise<void> = Promise.resolve();
+  private pumping = false;
   private timer: ReturnType<typeof setTimeout> | null = null;
+  private worker: Promise<void> = Promise.resolve();
 
   constructor(private readonly sink: IngestSink) {}
 
@@ -62,29 +74,55 @@ export class BatchIngester {
   push(event: AgentStreamEvent): void {
     if (this.fatalError) return;
     this.buffer.push(event);
+    if (this.pumping) return; // the worker picks the event up after its current send
     if (this.buffer.length >= MAX_BATCH) {
       if (this.timer) {
         clearTimeout(this.timer);
         this.timer = null;
       }
-      this.triggerFlush();
+      this.startPump();
     } else if (!this.timer) {
       this.timer = setTimeout(() => {
         this.timer = null;
-        this.triggerFlush();
+        this.startPump();
       }, FLUSH_INTERVAL_MS);
     }
   }
 
-  /** Flush remaining buffer and wait for all in-flight sends to settle. */
+  /** Flush remaining buffer and wait for the worker to settle. */
   async drain(): Promise<void> {
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = null;
     }
-    this.triggerFlush();
-    await this.inflightFlush;
+    this.startPump();
+    await this.worker;
     if (this.fatalError) throw this.fatalError;
+  }
+
+  private startPump(): void {
+    if (this.pumping || this.fatalError || this.buffer.length === 0) return;
+    this.pumping = true;
+    this.worker = this.pump();
+  }
+
+  /**
+   * Single-worker send loop. The batch is spliced right before each send, so
+   * the buffer keeps growing while a request is in flight and the backlog
+   * ships as few large batches. A fatal error (retries exhausted) breaks the
+   * loop with the remaining buffer unsent — dropped, never gapped.
+   */
+  private async pump(): Promise<void> {
+    try {
+      while (!this.fatalError && this.buffer.length > 0) {
+        const batch = this.buffer.splice(0, MAX_BATCH);
+        await this.sendWithRetry(batch);
+      }
+    } catch {
+      // fatalError is already set; drain() re-throws it.
+    } finally {
+      this.pumping = false;
+    }
   }
 
   private async sendWithRetry(batch: AgentStreamEvent[]): Promise<void> {
@@ -102,15 +140,5 @@ export class BatchIngester {
         delay = Math.min(delay * 2, 8_000);
       }
     }
-  }
-
-  private triggerFlush(): void {
-    if (this.fatalError || this.buffer.length === 0) return;
-    const batch = this.buffer.splice(0);
-    this.inflightFlush = this.inflightFlush
-      .then(() => this.sendWithRetry(batch))
-      .catch(() => {
-        // fatalError is already set; drain() re-throws it
-      });
   }
 }

--- a/apps/cli/src/utils/CoalescingBatchIngester.test.ts
+++ b/apps/cli/src/utils/CoalescingBatchIngester.test.ts
@@ -177,4 +177,36 @@ describe('CoalescingBatchIngester', () => {
 
     expect(ingest).toHaveBeenCalledTimes(6); // initial + 5 retries
   });
+
+  it('stops accumulating text once the batcher has failed (no undeliverable retention)', async () => {
+    // Mirrors the serial ingester's fatal short-circuit: after retries are
+    // exhausted nothing can be delivered, so later text deltas must be
+    // dropped instead of retained in `accumulatedText` until process exit.
+    const ingest = vi.fn(async () => {
+      throw new Error('server down');
+    });
+    const ingester = new CoalescingBatchIngester({ finish: vi.fn(), ingest });
+
+    ingester.push(toolEvent(1));
+    const drained = ingester.drain();
+    const assertion = expect(drained).rejects.toThrow('server down');
+    await vi.advanceTimersByTimeAsync(20_000);
+    await assertion;
+
+    ingester.push(textEvent('undeliverable '));
+    ingester.push(textEvent('response'));
+    await vi.advanceTimersByTimeAsync(1000);
+
+    // White-box on purpose — the regression IS the internal retention: the
+    // accumulator stays empty, no snapshot is pending, no debounce armed.
+    expect((ingester as any).accumulatedText).toBe('');
+    expect((ingester as any).pendingTextEvent).toBeUndefined();
+    expect((ingester as any).timer).toBeNull();
+
+    // And nothing new ever reaches the sink; drain keeps rethrowing.
+    const redrained = expect(ingester.drain()).rejects.toThrow('server down');
+    await vi.advanceTimersByTimeAsync(20_000);
+    await redrained;
+    expect(ingest).toHaveBeenCalledTimes(6); // unchanged after the failure
+  });
 });

--- a/apps/cli/src/utils/CoalescingBatchIngester.test.ts
+++ b/apps/cli/src/utils/CoalescingBatchIngester.test.ts
@@ -10,6 +10,9 @@ const makeEvent = (type: string, data: Record<string, unknown> = {}): AgentStrea
 const textEvent = (content: string, extra: Record<string, unknown> = {}) =>
   makeEvent('stream_chunk', { chunkType: 'text', content, ...extra });
 
+const reasoningEvent = (reasoning: string, extra: Record<string, unknown> = {}) =>
+  makeEvent('stream_chunk', { chunkType: 'reasoning', reasoning, ...extra });
+
 const toolEvent = (i: number) => makeEvent('tool_start', { toolCallId: `tc-${i}` });
 
 const createSink = () => {
@@ -108,6 +111,69 @@ describe('CoalescingBatchIngester', () => {
     // Second snapshot carries ONLY its own message, with a fresh seq.
     expect(batch[0].data).toMatchObject({ content: 'first message', snapshotSeq: 1 });
     expect(batch[3].data).toMatchObject({ content: 'second message', snapshotSeq: 2 });
+  });
+
+  it('coalesces reasoning deltas into a replace snapshot ordered before the text snapshot', async () => {
+    // Reasoning gets the same snapshot treatment as text: `replace` is
+    // idempotent under batch redelivery, whereas raw deltas re-append and
+    // durably duplicate the thinking content on a cold-replica retry.
+    const { batches, ingest, sink } = createSink();
+    const ingester = new CoalescingBatchIngester(sink);
+
+    ingester.push(reasoningEvent('thinking '));
+    ingester.push(reasoningEvent('hard'));
+    ingester.push(textEvent('the answer'));
+    ingester.push(makeEvent('stream_chunk', { chunkType: 'tools_calling', toolsCalling: [] }));
+    await ingester.drain();
+
+    expect(ingest).toHaveBeenCalledTimes(1);
+    const [batch] = batches;
+    // Emission order preserved: reasoning → text → tools.
+    expect(batch.map((event) => (event.data as any).chunkType)).toEqual([
+      'reasoning',
+      'text',
+      'tools_calling',
+    ]);
+    expect(batch[0].data).toMatchObject({
+      reasoning: 'thinking hard',
+      snapshotMode: 'replace',
+      snapshotSeq: 1,
+    });
+    expect(batch[1].data).toMatchObject({
+      content: 'the answer',
+      snapshotMode: 'replace',
+      snapshotSeq: 1, // per-kind counters are independent
+    });
+  });
+
+  it('resets the reasoning accumulator at stream boundaries', async () => {
+    const { batches, sink } = createSink();
+    const ingester = new CoalescingBatchIngester(sink);
+
+    ingester.push(reasoningEvent('first thought'));
+    ingester.push(makeEvent('stream_end'));
+    ingester.push(makeEvent('stream_start', { newStep: true }));
+    ingester.push(reasoningEvent('second thought'));
+    await ingester.drain();
+
+    const batch = batches.flat();
+    expect(batch[0].data).toMatchObject({ reasoning: 'first thought', snapshotSeq: 1 });
+    expect(batch[3].data).toMatchObject({ reasoning: 'second thought', snapshotSeq: 2 });
+  });
+
+  it('forwards subagent reasoning verbatim without snapshot conversion', async () => {
+    const { batches, sink } = createSink();
+    const ingester = new CoalescingBatchIngester(sink);
+
+    const subagent = { parentToolCallId: 'task-1', subagentMessageId: 'msg-sub-1' };
+    ingester.push(reasoningEvent('main think '));
+    ingester.push(reasoningEvent('sub think', { subagent }));
+    await ingester.drain();
+
+    const batch = batches.flat();
+    expect(batch[0].data).toMatchObject({ reasoning: 'main think ', snapshotMode: 'replace' });
+    expect(batch[1].data).toMatchObject({ reasoning: 'sub think', subagent });
+    expect((batch[1].data as any).snapshotMode).toBeUndefined();
   });
 
   it('forwards subagent text verbatim — no snapshot conversion, no accumulator pollution', async () => {

--- a/apps/cli/src/utils/CoalescingBatchIngester.test.ts
+++ b/apps/cli/src/utils/CoalescingBatchIngester.test.ts
@@ -1,0 +1,180 @@
+import type { AgentStreamEvent } from '@lobechat/heterogeneous-agents/spawn';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { IngestSink } from './BatchIngester';
+import { CoalescingBatchIngester } from './CoalescingBatchIngester';
+
+const makeEvent = (type: string, data: Record<string, unknown> = {}): AgentStreamEvent =>
+  ({ data, operationId: 'op-1', stepIndex: 0, timestamp: 1, type }) as AgentStreamEvent;
+
+const textEvent = (content: string, extra: Record<string, unknown> = {}) =>
+  makeEvent('stream_chunk', { chunkType: 'text', content, ...extra });
+
+const toolEvent = (i: number) => makeEvent('tool_start', { toolCallId: `tc-${i}` });
+
+const createSink = () => {
+  const batches: AgentStreamEvent[][] = [];
+  const ingest = vi.fn(async (events: AgentStreamEvent[]) => {
+    batches.push([...events]);
+  });
+  const sink: IngestSink = { finish: vi.fn(async () => {}), ingest };
+  return { batches, ingest, sink };
+};
+
+describe('CoalescingBatchIngester', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('batches a tool-heavy run into ≤50-event calls instead of one call per event', async () => {
+    // Regression for the serial single-event ingester (#15197 → this change):
+    // a 178-command Codex run produced ~700 events, each a separate serial
+    // tRPC round-trip — the upload queue kept draining for ~13 minutes AFTER
+    // the agent had already finished. Batching must collapse call count by
+    // ~MAX_BATCH while preserving completeness and order.
+    const { batches, ingest, sink } = createSink();
+    const ingester = new CoalescingBatchIngester(sink);
+
+    const events = Array.from({ length: 120 }, (_, i) => toolEvent(i));
+    for (const event of events) ingester.push(event);
+    await ingester.drain();
+
+    expect(ingest).toHaveBeenCalledTimes(3); // 50 + 50 + 20, NOT 120
+    expect(batches.map((batch) => batch.length)).toEqual([50, 50, 20]);
+    expect(batches.flat().map((event) => (event.data as any).toolCallId)).toEqual(
+      events.map((event) => (event.data as any).toolCallId),
+    );
+  });
+
+  it('coalesces main-agent text deltas into one replace snapshot ordered before the next event', async () => {
+    const { batches, ingest, sink } = createSink();
+    const ingester = new CoalescingBatchIngester(sink);
+
+    ingester.push(textEvent('hello '));
+    ingester.push(textEvent('world'));
+    ingester.push(makeEvent('stream_chunk', { chunkType: 'tools_calling', toolsCalling: [] }));
+    await ingester.drain();
+
+    // One batch: [snapshot, tools_calling] — the snapshot must not be
+    // overtaken by the event that followed it (the server processes a batch
+    // sequentially, so within-batch order IS the wire order).
+    expect(ingest).toHaveBeenCalledTimes(1);
+    const [batch] = batches;
+    expect(batch.map((event) => (event.data as any).chunkType)).toEqual(['text', 'tools_calling']);
+    expect(batch[0].data).toMatchObject({
+      content: 'hello world',
+      snapshotMode: 'replace',
+      snapshotSeq: 1,
+    });
+  });
+
+  it('flushes a pending snapshot on the debounce timer without needing a following event', async () => {
+    const { batches, ingest, sink } = createSink();
+    const ingester = new CoalescingBatchIngester(sink);
+
+    ingester.push(textEvent('streaming…'));
+    await vi.advanceTimersByTimeAsync(200); // snapshot debounce
+    await vi.advanceTimersByTimeAsync(250); // batch flush interval
+
+    expect(ingest).toHaveBeenCalledTimes(1);
+    expect(batches[0][0].data).toMatchObject({
+      content: 'streaming…',
+      snapshotMode: 'replace',
+      snapshotSeq: 1,
+    });
+  });
+
+  it('resets the per-message accumulator at stream boundaries (no cross-message duplication)', async () => {
+    const { batches, sink } = createSink();
+    const ingester = new CoalescingBatchIngester(sink);
+
+    ingester.push(textEvent('first message'));
+    ingester.push(makeEvent('stream_end'));
+    ingester.push(makeEvent('stream_start', { newStep: true }));
+    ingester.push(textEvent('second message'));
+    await ingester.drain();
+
+    const batch = batches.flat();
+    expect(batch.map((event) => event.type)).toEqual([
+      'stream_chunk',
+      'stream_end',
+      'stream_start',
+      'stream_chunk',
+    ]);
+    // Second snapshot carries ONLY its own message, with a fresh seq.
+    expect(batch[0].data).toMatchObject({ content: 'first message', snapshotSeq: 1 });
+    expect(batch[3].data).toMatchObject({ content: 'second message', snapshotSeq: 2 });
+  });
+
+  it('forwards subagent text verbatim — no snapshot conversion, no accumulator pollution', async () => {
+    const { batches, sink } = createSink();
+    const ingester = new CoalescingBatchIngester(sink);
+
+    const subagent = { parentToolCallId: 'task-1', subagentMessageId: 'msg-sub-1' };
+    ingester.push(textEvent('main '));
+    ingester.push(textEvent('I checked the files.', { subagent }));
+    await ingester.drain();
+
+    const batch = batches.flat();
+    // Main snapshot flushed first (order preserved), untainted by the block.
+    expect(batch[0].data).toMatchObject({ content: 'main ', snapshotMode: 'replace' });
+    // Subagent block passes through untouched: same content, no snapshot
+    // fields (the server's subagent path appends — replace semantics would
+    // duplicate content there).
+    expect(batch[1].data).toMatchObject({ content: 'I checked the files.', subagent });
+    expect((batch[1].data as any).snapshotMode).toBeUndefined();
+    expect((batch[1].data as any).snapshotSeq).toBeUndefined();
+  });
+
+  it('retries a failed batch with an identical payload, then keeps delivering later events', async () => {
+    // Same-batch redelivery contract: `HeterogeneousPersistenceHandler.ingest`
+    // marks events processed only on success and dedupes redelivered ones, so
+    // the producer MUST re-send the failed batch as-is. The serial ingester
+    // had dropped this retry entirely — one transient failure discarded every
+    // subsequent event of the run.
+    const batches: AgentStreamEvent[][] = [];
+    const ingest = vi
+      .fn(async (events: AgentStreamEvent[]) => {
+        batches.push([...events]);
+      })
+      .mockRejectedValueOnce(new Error('ECONNRESET'));
+    const ingester = new CoalescingBatchIngester({ finish: vi.fn(), ingest });
+
+    ingester.push(toolEvent(1));
+    ingester.push(toolEvent(2));
+    const drained = ingester.drain();
+    await vi.advanceTimersByTimeAsync(500); // first retry back-off
+    await drained;
+
+    expect(ingest).toHaveBeenCalledTimes(2);
+    expect(ingest.mock.calls[1][0]).toEqual(ingest.mock.calls[0][0]);
+
+    ingester.push(toolEvent(3));
+    await ingester.drain();
+    expect(batches.flat().map((event) => (event.data as any).toolCallId)).toEqual([
+      'tc-1',
+      'tc-2',
+      'tc-3',
+    ]);
+  });
+
+  it('drain rethrows once retries are exhausted so the CLI can finish(result: error)', async () => {
+    const ingest = vi.fn(async () => {
+      throw new Error('server down');
+    });
+    const ingester = new CoalescingBatchIngester({ finish: vi.fn(), ingest });
+
+    ingester.push(toolEvent(1));
+    const drained = ingester.drain();
+    const assertion = expect(drained).rejects.toThrow('server down');
+    // Back-off schedule: 500 + 1000 + 2000 + 4000 + 8000 ms.
+    await vi.advanceTimersByTimeAsync(20_000);
+    await assertion;
+
+    expect(ingest).toHaveBeenCalledTimes(6); // initial + 5 retries
+  });
+});

--- a/apps/cli/src/utils/CoalescingBatchIngester.ts
+++ b/apps/cli/src/utils/CoalescingBatchIngester.ts
@@ -33,6 +33,20 @@ export class CoalescingBatchIngester {
   }
 
   push(event: AgentStreamEvent): void {
+    // Mirror the previous serial ingester's fatal short-circuit: once the
+    // batcher has exhausted its retries nothing can ever be delivered, so
+    // drop later events — including text deltas — instead of retaining an
+    // undeliverable response in `accumulatedText` until the process exits.
+    if (this.batcher.failed) {
+      this.accumulatedText = '';
+      this.pendingTextEvent = undefined;
+      if (this.timer) {
+        clearTimeout(this.timer);
+        this.timer = null;
+      }
+      return;
+    }
+
     // Text-snapshot coalescing is a MAIN-AGENT-ONLY transport optimization:
     // it debounces the main agent's token-level text *deltas* into one
     // `replace` snapshot to cut ingest volume. Subagent text is explicitly

--- a/apps/cli/src/utils/CoalescingBatchIngester.ts
+++ b/apps/cli/src/utils/CoalescingBatchIngester.ts
@@ -3,10 +3,10 @@ import type { AgentStreamEvent } from '@lobechat/heterogeneous-agents/spawn';
 import { BatchIngester, type IngestSink } from './BatchIngester';
 
 /**
- * Server ingester for `lh hetero exec`: coalesces main-agent text deltas into
- * `replace` snapshots, then ships every event through `BatchIngester`
- * (≤50 events/batch, 250 ms flush, 5-retry back-off) instead of one serial
- * tRPC round-trip per event.
+ * Server ingester for `lh hetero exec`: coalesces main-agent text and
+ * reasoning deltas into `replace` snapshots, then ships every event through
+ * `BatchIngester` (≤50 events/batch, lazy-splice worker, 5-retry back-off)
+ * instead of one serial tRPC round-trip per event.
  *
  * History: #15197 replaced the original `BatchIngester` wiring with a
  * single-event serial ingester while introducing the snapshot semantics. That
@@ -17,12 +17,22 @@ import { BatchIngester, type IngestSink } from './BatchIngester';
  * its ordering/reset semantics are preserved here, and the server contract
  * (`HeterogeneousPersistenceHandler.ingest`) has always accepted ordered
  * event arrays and expected a retrying batch producer.
+ *
+ * Reasoning gets the same snapshot treatment as text (this change): `replace`
+ * snapshots are idempotent under batch redelivery — including a retry landing
+ * on a cold replica whose in-memory publish/persistence latches are empty —
+ * whereas raw deltas re-append and durably duplicate content.
  */
 export class CoalescingBatchIngester {
+  private accumulatedReasoning = '';
   private accumulatedText = '';
   private readonly batcher: BatchIngester;
-  private nextSnapshotSeq = 0;
+  private nextReasoningSnapshotSeq = 0;
+  private nextTextSnapshotSeq = 0;
+  private pendingReasoningEvent: AgentStreamEvent | undefined;
   private pendingTextEvent: AgentStreamEvent | undefined;
+  // Shared debounce: at most ONE kind is pending at a time — a delta of the
+  // other kind flushes it first (see push) — so one timer covers both.
   private timer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(
@@ -35,80 +45,112 @@ export class CoalescingBatchIngester {
   push(event: AgentStreamEvent): void {
     // Mirror the previous serial ingester's fatal short-circuit: once the
     // batcher has exhausted its retries nothing can ever be delivered, so
-    // drop later events — including text deltas — instead of retaining an
-    // undeliverable response in `accumulatedText` until the process exits.
+    // drop later events — including text/reasoning deltas — instead of
+    // retaining an undeliverable response in memory until the process exits.
     if (this.batcher.failed) {
+      this.accumulatedReasoning = '';
       this.accumulatedText = '';
+      this.pendingReasoningEvent = undefined;
       this.pendingTextEvent = undefined;
-      if (this.timer) {
-        clearTimeout(this.timer);
-        this.timer = null;
-      }
+      this.clearTimer();
       return;
     }
 
-    // Text-snapshot coalescing is a MAIN-AGENT-ONLY transport optimization:
-    // it debounces the main agent's token-level text *deltas* into one
-    // `replace` snapshot to cut ingest volume. Subagent text is explicitly
-    // excluded (`!event.data?.subagent`) for two reasons:
+    // Snapshot coalescing is a MAIN-AGENT-ONLY transport optimization: it
+    // debounces the main agent's token-level text/reasoning *deltas* into one
+    // `replace` snapshot to cut ingest volume — and `replace` makes the
+    // content idempotent under batch redelivery. Subagent chunks are
+    // explicitly excluded (`!event.data?.subagent`) for two reasons:
     //   1. Subagent text is emitted as ONE full block per turn (see
     //      claudeCode adapter `handleSubagentAssistant` — "the full block IS
     //      the only emission"), so there is nothing to coalesce.
-    //   2. `accumulatedText` is a single shared accumulator with no subagent
+    //   2. The accumulators are single shared buffers with no subagent
     //      scope. Folding subagent blocks in would (a) splice main-agent text
     //      into the subagent message via the shared buffer, and (b) emit a
     //      `replace` snapshot that the server's subagent path *appends*
     //      (`persistSubagentText` has no snapshot semantics) → duplicated /
     //      cross-scope content. Forwarding the raw block straight through lets
     //      the server append it exactly once, correctly.
-    if (
-      event.type === 'stream_chunk' &&
-      event.data?.chunkType === 'text' &&
-      typeof event.data?.content === 'string' &&
-      !event.data?.subagent
-    ) {
+    if (this.isMainDelta(event, 'text')) {
+      // Reasoning precedes text within a message — flush a pending reasoning
+      // snapshot first so within-batch order matches emission order.
+      this.flushPendingReasoningSnapshot();
       this.accumulatedText += event.data.content;
       this.pendingTextEvent = event;
-      if (this.timer) clearTimeout(this.timer);
-      this.timer = setTimeout(() => {
-        this.timer = null;
-        this.flushPendingTextSnapshot();
-      }, this.snapshotFlushMs);
+      this.armTimer();
       return;
     }
 
-    // Flush the pending snapshot BEFORE the incoming event enters the batch,
+    if (this.isMainDelta(event, 'reasoning')) {
+      this.flushPendingTextSnapshot();
+      this.accumulatedReasoning += event.data.reasoning;
+      this.pendingReasoningEvent = event;
+      this.armTimer();
+      return;
+    }
+
+    // Flush pending snapshots BEFORE the incoming event enters the batch,
     // so within-batch order matches emission order (the server processes a
     // batch sequentially — a boundary or tool event must not overtake the
-    // text snapshot that preceded it).
+    // snapshot that preceded it). Reasoning first: it precedes text in the
+    // adapters' emission order, and the two land in separate message fields
+    // so the relative order between them cannot corrupt state.
+    this.flushPendingReasoningSnapshot();
     this.flushPendingTextSnapshot();
-    // `accumulatedText` is a PER-MESSAGE accumulator: it coalesces the text
-    // deltas of the current assistant message into one `replace` snapshot.
-    // A new message boundary (`stream_start` / `stream_end`, emitted by the
-    // adapter's `openMainMessage`) must reset it — otherwise it spans the
+    // The accumulators are PER-MESSAGE: they coalesce the deltas of the
+    // current assistant message into one `replace` snapshot each. A new
+    // message boundary (`stream_start` / `stream_end`, emitted by the
+    // adapter's `openMainMessage`) must reset them — otherwise they span the
     // whole run and every later message's snapshot re-emits all prior
-    // messages' text verbatim, which the server then persists into the new
-    // DB message: cross-message text duplication. Reset AFTER flushing the
-    // just-ended message's pending snapshot above.
+    // messages' content verbatim, which the server then persists into the new
+    // DB message: cross-message duplication. Reset AFTER flushing the
+    // just-ended message's pending snapshots above.
     if (event.type === 'stream_start' || event.type === 'stream_end') {
+      this.accumulatedReasoning = '';
       this.accumulatedText = '';
     }
     this.batcher.push(event);
   }
 
-  /** Flush any pending snapshot + buffered batches; rethrows the batcher's
+  /** Flush any pending snapshots + buffered batches; rethrows the batcher's
    *  fatal error after its retries are exhausted. Call before `sink.finish`. */
   async drain(): Promise<void> {
+    this.flushPendingReasoningSnapshot();
     this.flushPendingTextSnapshot();
     await this.batcher.drain();
   }
 
-  private flushPendingTextSnapshot() {
-    if (!this.pendingTextEvent) return;
+  private isMainDelta(
+    event: AgentStreamEvent,
+    kind: 'reasoning' | 'text',
+  ): event is AgentStreamEvent & { data: Record<string, any> } {
+    return (
+      event.type === 'stream_chunk' &&
+      event.data?.chunkType === kind &&
+      typeof event.data?.[kind === 'text' ? 'content' : 'reasoning'] === 'string' &&
+      !event.data?.subagent
+    );
+  }
+
+  private armTimer(): void {
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.flushPendingReasoningSnapshot();
+      this.flushPendingTextSnapshot();
+    }, this.snapshotFlushMs);
+  }
+
+  private clearTimer(): void {
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = null;
     }
+  }
+
+  private flushPendingTextSnapshot() {
+    if (!this.pendingTextEvent) return;
+    this.clearTimer();
 
     const baseEvent = this.pendingTextEvent;
     this.pendingTextEvent = undefined;
@@ -118,7 +160,24 @@ export class CoalescingBatchIngester {
         ...baseEvent.data,
         content: this.accumulatedText,
         snapshotMode: 'replace',
-        snapshotSeq: ++this.nextSnapshotSeq,
+        snapshotSeq: ++this.nextTextSnapshotSeq,
+      },
+    });
+  }
+
+  private flushPendingReasoningSnapshot() {
+    if (!this.pendingReasoningEvent) return;
+    this.clearTimer();
+
+    const baseEvent = this.pendingReasoningEvent;
+    this.pendingReasoningEvent = undefined;
+    this.batcher.push({
+      ...baseEvent,
+      data: {
+        ...baseEvent.data,
+        reasoning: this.accumulatedReasoning,
+        snapshotMode: 'replace',
+        snapshotSeq: ++this.nextReasoningSnapshotSeq,
       },
     });
   }

--- a/apps/cli/src/utils/CoalescingBatchIngester.ts
+++ b/apps/cli/src/utils/CoalescingBatchIngester.ts
@@ -1,0 +1,111 @@
+import type { AgentStreamEvent } from '@lobechat/heterogeneous-agents/spawn';
+
+import { BatchIngester, type IngestSink } from './BatchIngester';
+
+/**
+ * Server ingester for `lh hetero exec`: coalesces main-agent text deltas into
+ * `replace` snapshots, then ships every event through `BatchIngester`
+ * (≤50 events/batch, 250 ms flush, 5-retry back-off) instead of one serial
+ * tRPC round-trip per event.
+ *
+ * History: #15197 replaced the original `BatchIngester` wiring with a
+ * single-event serial ingester while introducing the snapshot semantics. That
+ * made ingest throughput ~1 event per server round-trip — slower than agents
+ * emit events — so long tool-heavy runs kept uploading for many minutes after
+ * the CLI agent had already finished (`drain()` must clear the queue before
+ * `heteroFinish`). Batching restores throughput; the snapshot coalescing and
+ * its ordering/reset semantics are preserved here, and the server contract
+ * (`HeterogeneousPersistenceHandler.ingest`) has always accepted ordered
+ * event arrays and expected a retrying batch producer.
+ */
+export class CoalescingBatchIngester {
+  private accumulatedText = '';
+  private readonly batcher: BatchIngester;
+  private nextSnapshotSeq = 0;
+  private pendingTextEvent: AgentStreamEvent | undefined;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    sink: IngestSink,
+    private readonly snapshotFlushMs = 200,
+  ) {
+    this.batcher = new BatchIngester(sink);
+  }
+
+  push(event: AgentStreamEvent): void {
+    // Text-snapshot coalescing is a MAIN-AGENT-ONLY transport optimization:
+    // it debounces the main agent's token-level text *deltas* into one
+    // `replace` snapshot to cut ingest volume. Subagent text is explicitly
+    // excluded (`!event.data?.subagent`) for two reasons:
+    //   1. Subagent text is emitted as ONE full block per turn (see
+    //      claudeCode adapter `handleSubagentAssistant` — "the full block IS
+    //      the only emission"), so there is nothing to coalesce.
+    //   2. `accumulatedText` is a single shared accumulator with no subagent
+    //      scope. Folding subagent blocks in would (a) splice main-agent text
+    //      into the subagent message via the shared buffer, and (b) emit a
+    //      `replace` snapshot that the server's subagent path *appends*
+    //      (`persistSubagentText` has no snapshot semantics) → duplicated /
+    //      cross-scope content. Forwarding the raw block straight through lets
+    //      the server append it exactly once, correctly.
+    if (
+      event.type === 'stream_chunk' &&
+      event.data?.chunkType === 'text' &&
+      typeof event.data?.content === 'string' &&
+      !event.data?.subagent
+    ) {
+      this.accumulatedText += event.data.content;
+      this.pendingTextEvent = event;
+      if (this.timer) clearTimeout(this.timer);
+      this.timer = setTimeout(() => {
+        this.timer = null;
+        this.flushPendingTextSnapshot();
+      }, this.snapshotFlushMs);
+      return;
+    }
+
+    // Flush the pending snapshot BEFORE the incoming event enters the batch,
+    // so within-batch order matches emission order (the server processes a
+    // batch sequentially — a boundary or tool event must not overtake the
+    // text snapshot that preceded it).
+    this.flushPendingTextSnapshot();
+    // `accumulatedText` is a PER-MESSAGE accumulator: it coalesces the text
+    // deltas of the current assistant message into one `replace` snapshot.
+    // A new message boundary (`stream_start` / `stream_end`, emitted by the
+    // adapter's `openMainMessage`) must reset it — otherwise it spans the
+    // whole run and every later message's snapshot re-emits all prior
+    // messages' text verbatim, which the server then persists into the new
+    // DB message: cross-message text duplication. Reset AFTER flushing the
+    // just-ended message's pending snapshot above.
+    if (event.type === 'stream_start' || event.type === 'stream_end') {
+      this.accumulatedText = '';
+    }
+    this.batcher.push(event);
+  }
+
+  /** Flush any pending snapshot + buffered batches; rethrows the batcher's
+   *  fatal error after its retries are exhausted. Call before `sink.finish`. */
+  async drain(): Promise<void> {
+    this.flushPendingTextSnapshot();
+    await this.batcher.drain();
+  }
+
+  private flushPendingTextSnapshot() {
+    if (!this.pendingTextEvent) return;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+
+    const baseEvent = this.pendingTextEvent;
+    this.pendingTextEvent = undefined;
+    this.batcher.push({
+      ...baseEvent,
+      data: {
+        ...baseEvent.data,
+        content: this.accumulatedText,
+        snapshotMode: 'replace',
+        snapshotSeq: ++this.nextSnapshotSeq,
+      },
+    });
+  }
+}

--- a/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
+++ b/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
@@ -268,7 +268,11 @@ export class HeterogeneousPersistenceHandler {
    * See `OperationState.publishedKeys` for why this gate is separate from
    * the persistence dedupe. Without state (already finished, or a retry on
    * a cold replica) every event is treated as unpublished — degrading to
-   * republish-all, which text consumers de-dup via `snapshotSeq`.
+   * republish-all. Main-agent text/reasoning survive that via their
+   * `replace`-snapshot seq guards; the accepted cross-replica residuals are
+   * subagent text (append semantics), tool lifecycle replays (benign client
+   * upserts), and a duplicate trace fold — closing those needs a durable
+   * publish identity (tracked follow-up), not a bigger in-memory map.
    */
   filterUnpublishedEvents(operationId: string, events: AgentStreamEvent[]): AgentStreamEvent[] {
     const state = operationStates.get(operationId);

--- a/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
+++ b/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
@@ -121,6 +121,15 @@ interface OperationState {
   operationId: string;
   processedKeys: Set<string>;
   /**
+   * Publish gate, peer of `processedKeys` but for the live-stream sink.
+   * Persistence and publish fail independently: a batch can persist fully
+   * yet die inside the publish loop — its retry must republish ONLY the
+   * unpublished tail — while a batch whose tRPC response was lost after
+   * full success must republish nothing. Keyed by `eventKey`, latched only
+   * after the event's XADD succeeds.
+   */
+  publishedKeys: Set<string>;
+  /**
    * Run-global DB index for every tool message in the topic, keyed by
    * `tool_call_id`. Main and subagent reducers keep only their per-turn maps;
    * this map lets a `tool_result` land even when its `tools_calling` was
@@ -251,6 +260,25 @@ export class HeterogeneousPersistenceHandler {
     // picking up this operation always sees the latest content in the DB,
     // even if it never processes a step boundary or terminal event.
     await this.flushBatchContent(state);
+  }
+
+  /**
+   * Events of the batch not yet successfully published to the live stream.
+   * See `OperationState.publishedKeys` for why this gate is separate from
+   * the persistence dedupe. Without state (already finished, or a retry on
+   * a cold replica) every event is treated as unpublished — degrading to
+   * republish-all, which text consumers de-dup via `snapshotSeq`.
+   */
+  filterUnpublishedEvents(operationId: string, events: AgentStreamEvent[]): AgentStreamEvent[] {
+    const state = operationStates.get(operationId);
+    if (!state) return events;
+
+    return events.filter((event) => !state.publishedKeys.has(eventKey(event)));
+  }
+
+  /** Latch an event as published so a batch retry skips its XADD. */
+  markEventPublished(operationId: string, event: AgentStreamEvent): void {
+    operationStates.get(operationId)?.publishedKeys.add(eventKey(event));
   }
 
   /**
@@ -428,6 +456,7 @@ export class HeterogeneousPersistenceHandler {
       main: createMainAgentRunState(currentAssistantMessageId),
       operationId,
       processedKeys: new Set(),
+      publishedKeys: new Set(),
       toolMsgIdByCallId: new Map(),
       topicId,
     };

--- a/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
+++ b/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
@@ -85,6 +85,7 @@ interface AssistantDbSnapshot {
   parentId: string | null | undefined;
   provider: string | undefined;
   reasoning: string;
+  reasoningSnapshotSeq: number;
   textSnapshotSeq: number;
   tools: ChatToolPayload[];
 }
@@ -488,6 +489,7 @@ export class HeterogeneousPersistenceHandler {
       any
     >;
     const textSnapshotSeq = Number(metadata.heteroTextSnapshotSeq ?? 0);
+    const reasoningSnapshotSeq = Number(metadata.heteroReasoningSnapshotSeq ?? 0);
     return {
       content: rawContent === LOADING_FLAT ? '' : rawContent,
       metadata,
@@ -495,6 +497,7 @@ export class HeterogeneousPersistenceHandler {
       parentId: message?.parentId,
       provider: message?.provider,
       reasoning: (message?.reasoning as { content?: string } | null)?.content ?? '',
+      reasoningSnapshotSeq: Number.isFinite(reasoningSnapshotSeq) ? reasoningSnapshotSeq : 0,
       textSnapshotSeq: Number.isFinite(textSnapshotSeq) ? textSnapshotSeq : 0,
       tools: (message?.tools ?? []) as ChatToolPayload[],
     };
@@ -579,7 +582,12 @@ export class HeterogeneousPersistenceHandler {
       }
     }
 
-    if (snapshot.reasoning.length > state.main.accReasoning.length) {
+    // Seq-guarded reasoning restore mirrors the text path above; the length
+    // heuristic stays as the fallback for legacy rows without a stamped seq.
+    if (snapshot.reasoningSnapshotSeq > state.main.lastReasoningSnapshotSeq) {
+      state.main.accReasoning = snapshot.reasoning;
+      state.main.lastReasoningSnapshotSeq = snapshot.reasoningSnapshotSeq;
+    } else if (snapshot.reasoning.length > state.main.accReasoning.length) {
       state.main.accReasoning = snapshot.reasoning;
     }
 
@@ -769,6 +777,7 @@ export class HeterogeneousPersistenceHandler {
       accContent: '',
       accReasoning: '',
       currentAssistantId: authoritativeAssistantMessageId,
+      lastReasoningSnapshotSeq: 0,
       lastTextSnapshotSeq: 0,
       toolState: this.createEmptyMainToolState(),
       turnMetadata: {},

--- a/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.test.ts
@@ -361,6 +361,53 @@ describe('HeterogeneousPersistenceHandler', () => {
       expect(asst.metadata?.heteroTextSnapshotSeq).toBe(2);
     });
 
+    it('replaces reasoning snapshots idempotently instead of re-appending on redelivery', async () => {
+      const h = createHarness({
+        assistantMessageId: 'asst-1',
+        operationId: 'op-1',
+        topicId: 'topic-1',
+      });
+
+      await h.handler.ingest({
+        events: [
+          buildEvent('stream_chunk', 0, {
+            chunkType: 'reasoning',
+            reasoning: 'thinking hard',
+            snapshotMode: 'replace',
+            snapshotSeq: 1,
+          }),
+        ],
+        operationId: 'op-1',
+        topicId: 'topic-1',
+      });
+
+      // Redelivery reaching the reducer (a cold replica has an empty
+      // processedKeys map — simulated here with a different timestamp so the
+      // in-memory dedupe does not swallow the event first). A raw delta would
+      // re-append and durably double the reasoning; the snapshot must not.
+      await h.handler.ingest({
+        events: [
+          buildEvent(
+            'stream_chunk',
+            0,
+            {
+              chunkType: 'reasoning',
+              reasoning: 'thinking hard',
+              snapshotMode: 'replace',
+              snapshotSeq: 1,
+            },
+            1_700_000_000_999,
+          ),
+        ],
+        operationId: 'op-1',
+        topicId: 'topic-1',
+      });
+
+      const asst = h.messages.get('asst-1')!;
+      expect(asst.reasoning?.content).toBe('thinking hard'); // NOT doubled
+      expect(asst.metadata?.heteroReasoningSnapshotSeq).toBe(1);
+    });
+
     it('drops events with the same (stepIndex, type, timestamp, dataFingerprint) key', async () => {
       const h = createHarness({
         assistantMessageId: 'asst-1',

--- a/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.test.ts
@@ -391,6 +391,35 @@ describe('HeterogeneousPersistenceHandler', () => {
       expect(h.messageModel.create.mock.calls.length).toBe(createCallsAfterFirst);
     });
 
+    it('gates publishing per operation and releases the gate when the operation finishes', async () => {
+      const h = createHarness({
+        assistantMessageId: 'asst-1',
+        operationId: 'op-1',
+        topicId: 'topic-1',
+      });
+      const first = buildEvent('stream_chunk', 0, { chunkType: 'text', content: 'x' });
+      const second = buildEvent('stream_chunk', 1, { chunkType: 'text', content: 'y' });
+
+      // Without operation state (nothing ingested yet, or a cold replica):
+      // treat everything as unpublished and latch nothing — degraded
+      // republish-all rather than silently dropping events.
+      expect(h.handler.filterUnpublishedEvents('op-1', [first, second])).toEqual([first, second]);
+      h.handler.markEventPublished('op-1', first);
+      expect(h.handler.filterUnpublishedEvents('op-1', [first, second])).toEqual([first, second]);
+
+      await h.handler.ingest({ events: [first, second], operationId: 'op-1', topicId: 'topic-1' });
+
+      // Latch per event: only unlatched events remain.
+      h.handler.markEventPublished('op-1', first);
+      expect(h.handler.filterUnpublishedEvents('op-1', [first, second])).toEqual([second]);
+      h.handler.markEventPublished('op-1', second);
+      expect(h.handler.filterUnpublishedEvents('op-1', [first, second])).toEqual([]);
+
+      // finish() drops the per-operation state — the gate goes with it.
+      await h.handler.finish({ operationId: 'op-1', result: 'success' });
+      expect(h.handler.filterUnpublishedEvents('op-1', [first, second])).toEqual([first, second]);
+    });
+
     it('does NOT collide bursty events sharing (stepIndex, type, timestamp) when their data differs', async () => {
       // Producer-side reality: CC adapters stamp every event with `Date.now()`,
       // so multiple `stream_chunk` events within the same step burst through

--- a/apps/server/src/services/heterogeneousAgent/__tests__/index.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/__tests__/index.test.ts
@@ -41,9 +41,21 @@ const createFakeStreamManager = () => {
 };
 
 const createFakePersistenceHandler = () => {
+  // Faithful publish-gate fake: same latch semantics as the real handler
+  // (filter by event identity, latch per event) so batch-retry tests exercise
+  // the real skip/resume behavior instead of a stub that returns everything.
+  const publishedKeys = new Set<string>();
+  const gateKey = (event: AgentStreamEvent) =>
+    `${event.stepIndex}:${event.type}:${event.timestamp}`;
   const handler = {
+    filterUnpublishedEvents: vi.fn((_operationId: string, events: AgentStreamEvent[]) =>
+      events.filter((event) => !publishedKeys.has(gateKey(event))),
+    ),
     finish: vi.fn(async () => {}),
     ingest: vi.fn(async () => {}),
+    markEventPublished: vi.fn((_operationId: string, event: AgentStreamEvent) => {
+      publishedKeys.add(gateKey(event));
+    }),
   };
   return handler as unknown as HeterogeneousPersistenceHandler & typeof handler;
 };
@@ -145,6 +157,99 @@ describe('HeterogeneousAgentService', () => {
       ).rejects.toThrow('redis down');
     });
 
+    it('republishes nothing and skips the trace fold when an identical batch is redelivered', async () => {
+      // Response lost after a fully successful attempt → the CLI BatchIngester
+      // redelivers the same batch. Live subscribers must not see duplicates,
+      // and the execution-trace snapshot must not double-fold.
+      const appendBatch = vi
+        .spyOn(HeteroTraceRecorder.prototype, 'appendBatch')
+        .mockResolvedValue();
+      const { manager, published, service } = createService();
+      const events: AgentStreamEvent[] = [
+        buildEvent('stream_chunk', 0, { chunkType: 'text', content: 'hi' }),
+        buildEvent('tool_start', 1, { toolCallId: 'tc-1' }),
+      ];
+
+      await service.heteroIngest({
+        agentType: 'codex',
+        events,
+        operationId: 'op-test',
+        topicId: 'topic-1',
+      });
+      expect(published).toHaveLength(2);
+
+      await service.heteroIngest({
+        agentType: 'codex',
+        events,
+        operationId: 'op-test',
+        topicId: 'topic-1',
+      });
+
+      expect(manager.publishStreamEvent).toHaveBeenCalledTimes(2);
+      expect(published).toHaveLength(2);
+      expect(appendBatch).toHaveBeenCalledTimes(1);
+      appendBatch.mockRestore();
+    });
+
+    it('a retried batch resumes publishing from the first unpublished event (no duplicates, no loss)', async () => {
+      // Publish dies mid-loop on the first attempt: the head is delivered and
+      // latched, the tail is not. The retry must publish ONLY the tail —
+      // republishing the head would duplicate live events, skipping the tail
+      // would lose them.
+      const appendBatch = vi
+        .spyOn(HeteroTraceRecorder.prototype, 'appendBatch')
+        .mockResolvedValue();
+      const published: any[] = [];
+      let failOnSecondPublish = true;
+      const manager: Partial<IStreamEventManager> = {
+        publishStreamEvent: vi.fn(async (_operationId, event) => {
+          if (failOnSecondPublish && published.length === 1) {
+            failOnSecondPublish = false;
+            throw new Error('redis down');
+          }
+          published.push(event);
+          return `id-${published.length}`;
+        }),
+      };
+      const persistenceHandler = createFakePersistenceHandler();
+      const service = new HeterogeneousAgentService({} as any, 'user-test', {
+        persistenceHandler,
+        streamEventManager: manager as IStreamEventManager,
+      });
+      const events: AgentStreamEvent[] = [
+        buildEvent('stream_start', 0, { assistantMessage: { id: 'asst-1' } }),
+        buildEvent('stream_chunk', 1, { chunkType: 'text', content: 'hello' }),
+        buildEvent('agent_runtime_end', 2, { reason: 'success' }),
+      ];
+
+      await expect(
+        service.heteroIngest({
+          agentType: 'codex',
+          events,
+          operationId: 'op-test',
+          topicId: 'topic-1',
+        }),
+      ).rejects.toThrow('redis down');
+      expect(published.map((event) => event.type)).toEqual(['stream_start']);
+
+      await service.heteroIngest({
+        agentType: 'codex',
+        events,
+        operationId: 'op-test',
+        topicId: 'topic-1',
+      });
+
+      // Every event delivered exactly once across both attempts.
+      expect(published.map((event) => event.type)).toEqual([
+        'stream_start',
+        'stream_chunk',
+        'agent_runtime_end',
+      ]);
+      // The recorder folds once — on the attempt that delivered new events.
+      expect(appendBatch).toHaveBeenCalledTimes(1);
+      appendBatch.mockRestore();
+    });
+
     it('persists before publishing — DB is the source of truth fetchAndReplace reads', async () => {
       const callOrder: string[] = [];
       const manager: Partial<IStreamEventManager> = {
@@ -154,10 +259,14 @@ describe('HeterogeneousAgentService', () => {
         }),
       };
       const persistenceHandler = {
+        filterUnpublishedEvents: vi.fn(
+          (_operationId: string, events: AgentStreamEvent[]) => events,
+        ),
         finish: vi.fn(async () => {}),
         ingest: vi.fn(async () => {
           callOrder.push('persist');
         }),
+        markEventPublished: vi.fn(),
       } as unknown as HeterogeneousPersistenceHandler;
       const service = new HeterogeneousAgentService({} as any, 'user-test', {
         persistenceHandler,

--- a/apps/server/src/services/heterogeneousAgent/index.ts
+++ b/apps/server/src/services/heterogeneousAgent/index.ts
@@ -150,10 +150,24 @@ export class HeterogeneousAgentService {
       throw err;
     }
 
-    // Sequential publish preserves stepIndex ordering — Redis XADD itself is
-    // serialized but awaiting in-order avoids interleaving with concurrent
-    // ingest batches sharing the same operationId.
-    for (const event of events) {
+    // Publish only events not yet delivered to the stream. The publish gate
+    // (`publishedKeys`, peer of the persistence dedupe) makes a BatchIngester
+    // retry invisible to live subscribers: a batch that fully succeeded but
+    // lost its tRPC response republishes nothing, while one that died
+    // mid-publish resumes from the first unpublished event — each event is
+    // latched only after its own XADD succeeds. Sequential publish preserves
+    // stepIndex ordering — Redis XADD itself is serialized but awaiting
+    // in-order avoids interleaving with concurrent ingest batches sharing the
+    // same operationId.
+    const unpublished = this.persistenceHandler.filterUnpublishedEvents(operationId, events);
+    if (unpublished.length < events.length) {
+      log(
+        'heteroIngest: skip %d already-published events op=%s',
+        events.length - unpublished.length,
+        operationId,
+      );
+    }
+    for (const event of unpublished) {
       // Each event already carries operationId; pass through unchanged so the
       // wire shape on the WS side is identical to gateway-driven runs.
       await this.streamEventManager.publishStreamEvent(operationId, {
@@ -161,15 +175,18 @@ export class HeterogeneousAgentService {
         stepIndex: event.stepIndex,
         type: event.type,
       });
+      this.persistenceHandler.markEventPublished(operationId, event);
     }
 
     // Accumulate the execution-trace snapshot LAST. The recorder has no
     // per-event idempotency, so it must run only after every step that can throw
     // and trigger a BatchIngester retry of this same batch — otherwise a publish
     // failure above would re-fold these events and double-count the snapshot.
-    // It's the final statement and best-effort (never throws), so it folds each
-    // batch exactly once (on the attempt that gets this far).
-    await this.traceRecorder.appendBatch(operationId, events);
+    // Gating on the publish gate also skips the pure-redelivery batch (full
+    // success whose response was lost), which would otherwise double-fold here.
+    if (unpublished.length > 0) {
+      await this.traceRecorder.appendBatch(operationId, events);
+    }
   }
 
   async heteroFinish(params: HeterogeneousFinishParams): Promise<void> {

--- a/packages/agent-gateway-client/src/types.ts
+++ b/packages/agent-gateway-client/src/types.ts
@@ -78,6 +78,18 @@ export interface StreamChunkData {
   images?: any[];
   reasoning?: string;
   reasoningParts?: Array<{ text: string; type: 'text' } | { image: string; type: 'image' }>;
+  /**
+   * `lh hetero exec` coalesces main-agent text deltas into full-text
+   * snapshots: `content` carries the WHOLE message so far and must replace
+   * the accumulated text, not append to it. Absent on plain deltas.
+   */
+  snapshotMode?: 'replace';
+  /**
+   * Operation-monotonic sequence for `replace` snapshots. Consumers drop a
+   * snapshot whose seq is ≤ the last applied one — that is a redelivery
+   * (producer batch retry) or an out-of-order duplicate.
+   */
+  snapshotSeq?: number;
   toolsCalling?: any[];
 }
 

--- a/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.test.ts
+++ b/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.test.ts
@@ -121,6 +121,31 @@ describe('main agent reducer', () => {
     expect(state.lastTextSnapshotSeq).toBe(3);
   });
 
+  it('replaces reasoning snapshots and drops stale or redelivered seqs', () => {
+    const snapshot = (reasoning: string, snapshotSeq: number) => ({
+      data: { chunkType: 'reasoning', reasoning, snapshotMode: 'replace', snapshotSeq },
+      type: 'stream_chunk',
+    });
+    const { state, steps } = run([
+      snapshot('thinking', 1),
+      snapshot('thinking done', 2),
+      // Redelivered seq 2 (batch retry on a cold replica) — must be a no-op,
+      // not an append: appending would duplicate the reasoning durably.
+      snapshot('thinking done', 2),
+      // Stale out-of-order snapshot — dropped.
+      snapshot('thinking', 1),
+    ]);
+
+    expect(steps[1]).toEqual([
+      { kind: 'streamContent', messageId: 'A0', reasoning: 'thinking done' },
+    ]);
+    expect(steps[2]).toEqual([]);
+    expect(steps[3]).toEqual([]);
+    expect(state.accReasoning).toBe('thinking done');
+    expect(state.lastReasoningSnapshotSeq).toBe(2);
+    expect(state.turnMetadata.heteroReasoningSnapshotSeq).toBe(2);
+  });
+
   it('accumulates reasoning separately', () => {
     const { steps, state } = run([reasoningEvent('think '), reasoningEvent('more')]);
     expect(steps[1]).toEqual([{ kind: 'streamContent', messageId: 'A0', reasoning: 'think more' }]);

--- a/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.ts
+++ b/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.ts
@@ -163,6 +163,7 @@ const openTurn = (state: MainAgentRunState, data: any, ctx: MainAgentReduceCtx):
   next.currentMainMessageId = mainMessageId;
   next.accContent = '';
   next.accReasoning = '';
+  next.lastReasoningSnapshotSeq = 0;
   next.lastTextSnapshotSeq = 0;
   next.turnMetadata = {};
   next.toolState = emptyToolState();
@@ -222,9 +223,23 @@ const reduceTextChunk = (state: MainAgentRunState, data: any): ReduceResult => {
 };
 
 const reduceReasoningChunk = (state: MainAgentRunState, data: any): ReduceResult => {
-  if (!data?.reasoning) return { intents: [], state };
   const next = copyState(state);
-  next.accReasoning = state.accReasoning + data.reasoning;
+  const snapshotMode = data?.snapshotMode;
+  const snapshotSeq = typeof data?.snapshotSeq === 'number' ? data.snapshotSeq : undefined;
+
+  // Mirrors `reduceTextChunk`: `replace` snapshots are idempotent under batch
+  // redelivery (a raw delta re-append would durably duplicate reasoning on a
+  // cold-replica retry), and the seq guard drops stale/out-of-order ones.
+  if (snapshotMode === 'replace' && snapshotSeq !== undefined) {
+    if (snapshotSeq <= state.lastReasoningSnapshotSeq) return { intents: [], state }; // stale snapshot
+    next.lastReasoningSnapshotSeq = snapshotSeq;
+    next.turnMetadata = { ...next.turnMetadata, heteroReasoningSnapshotSeq: snapshotSeq };
+    next.accReasoning = data.reasoning;
+  } else {
+    if (!data?.reasoning) return { intents: [], state };
+    next.accReasoning = state.accReasoning + data.reasoning;
+  }
+
   return {
     intents: [
       { kind: 'streamContent', messageId: next.currentAssistantId, reasoning: next.accReasoning },

--- a/packages/heterogeneous-agents/src/mainAgentCoordinator/types.ts
+++ b/packages/heterogeneous-agents/src/mainAgentCoordinator/types.ts
@@ -81,6 +81,8 @@ export interface MainAgentRunState {
   currentMainMessageId: string | undefined;
   /** Set once a terminal event has been reduced (idempotent finalize). */
   ended: boolean;
+  /** Highest seen reasoning snapshot sequence (replace-mode de-dup). */
+  lastReasoningSnapshotSeq: number;
   /**
    * Chain rule: the most recent NON-tool, NON-signal
    * main-thread message — the run's spine. The next NORMAL turn's assistant
@@ -126,6 +128,7 @@ export const createMainAgentRunState = (seedAssistantId: string): MainAgentRunSt
   currentMainMessageId: undefined,
   ended: false,
   lastSpineMessageId: seedAssistantId,
+  lastReasoningSnapshotSeq: 0,
   lastTextSnapshotSeq: 0,
   lastToolMsgIdEver: undefined,
   subagents: createSubagentRunsState(),

--- a/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
@@ -237,6 +237,80 @@ describe('createGatewayEventHandler', () => {
       );
     });
 
+    it('applies replace snapshots and drops redelivered snapshot seqs', async () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      // `lh hetero exec` sends full-text snapshots: each carries the WHOLE
+      // message so far and must replace, not append.
+      handler(
+        makeEvent('stream_chunk', {
+          chunkType: 'text',
+          content: 'Hello',
+          snapshotMode: 'replace',
+          snapshotSeq: 1,
+        }),
+      );
+      handler(
+        makeEvent('stream_chunk', {
+          chunkType: 'text',
+          content: 'Hello world',
+          snapshotMode: 'replace',
+          snapshotSeq: 2,
+        }),
+      );
+      // Redelivery of seq 2 (server-side batch retry) — must be dropped, not
+      // appended: appending would render "Hello worldHello world".
+      handler(
+        makeEvent('stream_chunk', {
+          chunkType: 'text',
+          content: 'Hello world',
+          snapshotMode: 'replace',
+          snapshotSeq: 2,
+        }),
+      );
+      await flush();
+
+      expect(store.internal_dispatchMessage).toHaveBeenLastCalledWith(
+        {
+          id: 'msg-initial',
+          type: 'updateMessage',
+          value: { content: 'Hello world' },
+        },
+        { operationId: 'op-1' },
+      );
+      const textDispatches = store.internal_dispatchMessage.mock.calls.filter(
+        ([action]: any[]) => action.type === 'updateMessage' && 'content' in action.value,
+      );
+      expect(textDispatches).toHaveLength(2); // the redelivered snapshot dispatched nothing
+    });
+
+    it('a snapshot replaces text accumulated from plain deltas', async () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'Hel' }));
+      handler(
+        makeEvent('stream_chunk', {
+          chunkType: 'text',
+          content: 'Hello world',
+          snapshotMode: 'replace',
+          snapshotSeq: 1,
+        }),
+      );
+      await flush();
+
+      // Replace, not append — appending would render "HelHello world".
+      expect(store.internal_dispatchMessage).toHaveBeenLastCalledWith(
+        {
+          id: 'msg-initial',
+          type: 'updateMessage',
+          value: { content: 'Hello world' },
+        },
+        { operationId: 'op-1' },
+      );
+    });
+
     it('should accumulate reasoning content', async () => {
       const store = createMockStore();
       const handler = createHandler(store);

--- a/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
@@ -285,6 +285,46 @@ describe('createGatewayEventHandler', () => {
       expect(textDispatches).toHaveLength(2); // the redelivered snapshot dispatched nothing
     });
 
+    it('applies reasoning replace snapshots and drops redelivered seqs', async () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(
+        makeEvent('stream_chunk', {
+          chunkType: 'reasoning',
+          reasoning: 'thinking',
+          snapshotMode: 'replace',
+          snapshotSeq: 1,
+        }),
+      );
+      handler(
+        makeEvent('stream_chunk', {
+          chunkType: 'reasoning',
+          reasoning: 'thinking done',
+          snapshotMode: 'replace',
+          snapshotSeq: 2,
+        }),
+      );
+      // Redelivered seq 2 — appending it would render "thinking donethinking done".
+      handler(
+        makeEvent('stream_chunk', {
+          chunkType: 'reasoning',
+          reasoning: 'thinking done',
+          snapshotMode: 'replace',
+          snapshotSeq: 2,
+        }),
+      );
+      await flush();
+
+      const reasoningDispatches = store.internal_dispatchMessage.mock.calls.filter(
+        ([action]: any[]) => action.type === 'updateMessage' && 'reasoning' in action.value,
+      );
+      expect(reasoningDispatches).toHaveLength(2); // duplicate dropped
+      expect(reasoningDispatches.at(-1)?.[0].value).toEqual({
+        reasoning: { content: 'thinking done' },
+      });
+    });
+
     it('a snapshot replaces text accumulated from plain deltas', async () => {
       const store = createMockStore();
       const handler = createHandler(store);

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
@@ -416,10 +416,11 @@ export const createGatewayEventHandler = (
   // Accumulated content from stream chunks (reset on each stream_start)
   let accumulatedContent = '';
   let accumulatedReasoning = '';
-  // Last applied `replace`-snapshot seq. Operation-monotonic (the producer
-  // never resets it across messages), so unlike the accumulators it is NOT
-  // reset on stream boundaries — a seq ≤ this is a redelivered duplicate.
+  // Last applied `replace`-snapshot seqs. Operation-monotonic (the producer
+  // never resets them across messages), so unlike the accumulators they are
+  // NOT reset on stream boundaries — a seq ≤ these is a redelivered duplicate.
   let lastTextSnapshotSeq = 0;
+  let lastReasoningSnapshotSeq = 0;
 
   // Tracks whether any server-confirmed state has actually arrived
   // (server-assigned assistant id, streamed text/reasoning/tools, or a SoT
@@ -636,17 +637,35 @@ export const createGatewayEventHandler = (
           }
 
           if (data.chunkType === 'reasoning' && data.reasoning) {
-            startReasoningIfNeeded();
-            accumulatedReasoning += data.reasoning;
-            hasStreamedContent = true;
-            get().internal_dispatchMessage(
-              {
-                id: currentAssistantMessageId,
-                type: 'updateMessage',
-                value: { reasoning: { content: accumulatedReasoning } },
-              },
-              dispatchContext,
-            );
+            // Same snapshot semantics as text above: `lh hetero exec`
+            // coalesces reasoning into `replace` snapshots; redelivered seqs
+            // are dropped instead of appended (which would duplicate the
+            // thinking text on a server-side batch retry).
+            const snapshotSeq =
+              data.snapshotMode === 'replace' && typeof data.snapshotSeq === 'number'
+                ? data.snapshotSeq
+                : undefined;
+
+            if (snapshotSeq !== undefined && snapshotSeq <= lastReasoningSnapshotSeq) {
+              // Redelivered snapshot — already applied.
+            } else {
+              startReasoningIfNeeded();
+              if (snapshotSeq === undefined) {
+                accumulatedReasoning += data.reasoning;
+              } else {
+                lastReasoningSnapshotSeq = snapshotSeq;
+                accumulatedReasoning = data.reasoning;
+              }
+              hasStreamedContent = true;
+              get().internal_dispatchMessage(
+                {
+                  id: currentAssistantMessageId,
+                  type: 'updateMessage',
+                  value: { reasoning: { content: accumulatedReasoning } },
+                },
+                dispatchContext,
+              );
+            }
           }
 
           if (data.chunkType === 'tools_calling' && data.toolsCalling) {

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
@@ -416,6 +416,10 @@ export const createGatewayEventHandler = (
   // Accumulated content from stream chunks (reset on each stream_start)
   let accumulatedContent = '';
   let accumulatedReasoning = '';
+  // Last applied `replace`-snapshot seq. Operation-monotonic (the producer
+  // never resets it across messages), so unlike the accumulators it is NOT
+  // reset on stream boundaries — a seq ≤ this is a redelivered duplicate.
+  let lastTextSnapshotSeq = 0;
 
   // Tracks whether any server-confirmed state has actually arrived
   // (server-assigned assistant id, streamed text/reasoning/tools, or a SoT
@@ -599,19 +603,36 @@ export const createGatewayEventHandler = (
           if (!data) return;
 
           if (data.chunkType === 'text' && data.content) {
-            // Text after reasoning marks the end of the thinking pass — see
-            // `StreamingHandler.handleText` for the same transition.
-            endReasoningIfNeeded();
-            accumulatedContent += data.content;
-            hasStreamedContent = true;
-            get().internal_dispatchMessage(
-              {
-                id: currentAssistantMessageId,
-                type: 'updateMessage',
-                value: { content: accumulatedContent },
-              },
-              dispatchContext,
-            );
+            // `lh hetero exec` coalesces main-agent text into full-text
+            // `replace` snapshots; native gateway runs stream plain deltas.
+            const snapshotSeq =
+              data.snapshotMode === 'replace' && typeof data.snapshotSeq === 'number'
+                ? data.snapshotSeq
+                : undefined;
+
+            if (snapshotSeq !== undefined && snapshotSeq <= lastTextSnapshotSeq) {
+              // Redelivered snapshot (producer batch retry / duplicate on the
+              // stream) — already applied, appending it would duplicate text.
+            } else {
+              // Text after reasoning marks the end of the thinking pass — see
+              // `StreamingHandler.handleText` for the same transition.
+              endReasoningIfNeeded();
+              if (snapshotSeq === undefined) {
+                accumulatedContent += data.content;
+              } else {
+                lastTextSnapshotSeq = snapshotSeq;
+                accumulatedContent = data.content;
+              }
+              hasStreamedContent = true;
+              get().internal_dispatchMessage(
+                {
+                  id: currentAssistantMessageId,
+                  type: 'updateMessage',
+                  value: { content: accumulatedContent },
+                },
+                dispatchContext,
+              );
+            }
           }
 
           if (data.chunkType === 'reasoning' && data.reasoning) {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [x] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to #15197 (restores the batching that PR replaced, while keeping everything it fixed).

#### 🔀 Description of Change

##### Background: a real 27-minute run, of which 13 minutes were pure upload backlog

A production trace of a Codex run through `lh hetero exec` (op `op_1784301666852…`, 2026-07-17) breaks down as:

| Phase | Wall clock | Duration |
| --- | --- | --- |
| Gateway dispatch → CLI spawn | 08:21:03 | — |
| Codex actually working (178 command executions, 1 auto-compaction) | 08:21:07 → 08:35:05 | **~14 min** |
| Codex **finished**, LobeHub still uploading queued events | 08:35:05 → 08:48:14 | **~13 min** |

The evidence chain: codex's native rollout shows `task_complete` at 08:35:05 and the raw stdout dump stops there, yet the desktop log shows `spawnLhHeteroExec: exited code=0` only at 08:48:14. In between, DB messages kept appearing one-by-one (~8s median gap). The user watched a finished run "hang" for 13 minutes.

##### Root cause: one serial tRPC round-trip per event

`SerialServerIngester` (in `hetero.ts`) sends **every non-text event as its own `aiAgent.heteroIngest` call, strictly serialized**: `sink.ingest([event])`. A tool-heavy run emits ~4 events per tool call (`tools_calling` chunk, `tool_start`, `tool_result`, `tool_end`) → ~700 round-trips for this run at ~2.2s each (each request also runs the server's full per-request state refresh: workspace lookup, tool-message index, main + subagent state, content flush). Codex produces events ~2× faster than that drains, so the queue grows linearly and `drain()` must clear it before `heteroFinish` can be sent.

##### History: how the serialization got here (#15197)

#15197 fixed a real bug — the first ingest could land on a cold Lambda that read `topic.metadata.runningOperation` from a lagging replica, hard-threw, and exhausted the then-`BatchIngester`'s 5 retries, leaving the assistant stuck in LOADING_FLAT. The actual fix was threading `assistantMessageId` through the `LOBEHUB_ASSISTANT_MESSAGE_ID` env var so `loadOrCreateState` skips that DB read entirely. The same PR also introduced text-delta → `replace`-snapshot coalescing (with a monotonic `snapshotSeq` stale-guard in the shared reducer), making text writes idempotent under redelivery.

Replacing `BatchIngester` with a single-event serial ingester was collateral in that PR, not the fix itself — and it also silently dropped the retry/back-off logic. The server's `HeterogeneousPersistenceHandler.ingest` contract still documents and expects a **retrying batch producer** (events are marked processed only on success, redelivered events are deduped), and `heteroIngest` has always accepted `events: z.array(...)`.

##### This PR

Restores batching **and** keeps everything #15197 fixed:

- New `CoalescingBatchIngester` (`apps/cli/src/utils/`): coalesces main-agent text deltas into `replace` snapshots (200ms debounce, unchanged semantics), then ships **all** events through the existing `BatchIngester` (≤50 events/batch, 250ms flush, 5-retry exponential back-off).
- `lh hetero exec` swaps `SerialServerIngester` → `CoalescingBatchIngester`. Call sites (`push`/`drain`-before-`finish`, including the SIGINT/SIGTERM and error paths) are unchanged.
- The `assistantMessageId` env-var path, snapshot `snapshotSeq` semantics, per-message accumulator reset at `stream_start`/`stream_end`, and subagent text passthrough are all preserved verbatim.
- Bonus robustness: a transient ingest failure now retries with an identical batch instead of silently discarding every subsequent event of the run (the serial ingester's `fatalError` behavior).

Expected impact on the traced run: ~700 round-trips → ~15, so ingest keeps up with the agent in real time and `drain()` after agent exit completes in seconds instead of ~13 minutes.

##### Why batching cannot regress #15197

1. The replica-lag race fix is the env var, which this PR does not touch.
2. Ordering: `BatchIngester` serializes flushes; the server processes a batch sequentially; the coalescer flushes a pending snapshot **before** any following event enters the buffer — end-to-end order is identical to serial.
3. Text idempotency under redelivery is guaranteed by the `replace`-snapshot + `snapshotSeq` guard that #15197 itself added; non-text redelivery relies on the same server dedupe contract the original batch design was built for.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `apps/cli/src/utils/CoalescingBatchIngester.test.ts` (new, 7 cases): 120 events → exactly 3 batched calls (50/50/20) with order + completeness preserved; snapshot coalescing ordered before the next event; debounce flush; per-message accumulator reset; subagent passthrough; **same-batch redelivery** (failed batch retried with identical payload, later events still delivered); drain rethrows after retries exhausted.
- `apps/cli/src/commands/hetero.test.ts`: command-level test updated — the run now lands in **one** batched ingest call with within-batch order asserted, `finish` only after the ack; boundary-reset and subagent tests pass unchanged.
- `bun run check` (lint + 43 tests) and full type-check are clean.

#### 📝 Additional Information

Server side needs no change: `heteroIngest` already accepts event arrays, and batching amortizes its per-request state refreshes (~50× fewer). The stale `agentRun.ts` comment describing the pipeline as "spawn → adapt → BatchIngester → server ingest" becomes accurate again with this PR.

---

#### 🔁 Review round 2: closing the redelivery-visibility family (not patch-by-patch)

Codex review correctly flagged that restoring retry re-opens a **latent** gap: each event has three sinks — DB persistence (idempotent via `processedKeys`), the execution-trace recorder (already ordered last for exactly-once), and the **Redis live publish, which had no dedupe at all**. On a batch retry the server republished every event, and the browser's gateway handler appends text without honoring the `replace`-snapshot semantics #15197 introduced — so a retried batch could duplicate live text and replay tool lifecycle events (DB stays correct; a refresh heals it).

Instead of spot-fixing, this round closes the whole family with two structural pieces:

1. **Server publish gate** (`publishedKeys`, peer of `processedKeys` on the per-operation state): each event is latched only after its own XADD succeeds; `heteroIngest` publishes only unlatched events. This makes every retry shape correct by construction — persistence-failure retry republishes everything (nothing was published), mid-publish-failure retry resumes from the first unpublished event (no duplicates, no loss), and a fully-successful batch whose tRPC response was lost republishes **nothing**. The trace recorder folds only when the attempt delivered something new, which also fixes its pre-existing double-fold on the lost-response retry. Note the gate is deliberately keyed on *publish* success, not on "newly persisted" — gating on the persistence dedupe would silently drop the head of a batch whose first attempt died during persistence.
2. **Client snapshot semantics** (`gatewayEventHandler`): text chunks with `snapshotMode: 'replace'` now replace the accumulated content, gated by the operation-monotonic `snapshotSeq` (stale/duplicate seqs are dropped). This is the client half of #15197's snapshot design that was never implemented on the live path, and it doubles as the cross-replica backstop: the in-memory publish gate cannot dedupe a retry that lands on a cold replica, but text — the only visibly-corrupting duplicate — is now idempotent end-to-end. `StreamChunkData` gains the optional `snapshotMode`/`snapshotSeq` fields the wire has carried since #15197.

Known limit (accepted, documented in code): a retry landing on a **different replica** starts with an empty publish gate and republishes the batch; non-text replays are benign for subscribers (tool upserts by id), and text is covered by the seq guard above.

Round-2 regression coverage: identical-batch redelivery publishes nothing and skips the trace fold; mid-publish failure resumes from the first unpublished event; publish-gate latch/release lifecycle on the real handler (state-less defaults, per-event latch, release on finish); gateway replace-snapshot application, stale-seq drop, and snapshot-over-deltas replacement. Also from round 1: the CLI ingester now stops accumulating text once the batcher is fatally failed (mirrors the old serial ingester's short-circuit).

---

#### 🔁 Review round 3: lazy-splice send worker (fixes two latent `BatchIngester` flaws this PR re-activated)

External review found two P1s in the restored `BatchIngester`, both pre-existing in the class but re-activated on the main path by this PR:

1. **Slow-RTT backlogs never coalesced.** `triggerFlush()` spliced the buffer when a flush was *scheduled*, so events arriving while a slow request was in flight fragmented into per-250ms micro-batches queued serially — throughput stayed ~one tiny batch per RTT. With Codex's real emission pattern (a burst of 2 events per command state transition), the old code only turned "one request per event" into "one request per state transition", not backlog-sized batches.
2. **A permanently-failed batch didn't stop the stream.** The flush chain's `.catch(() => {})` recovered the chain, and `sendWithRetry` never checked `fatalError` — batches queued during the ~15.5s retry window still sent after the first batch was permanently lost. If the server recovered mid-window it received a **gapped** stream (a `tool_end` whose `tool_start` never arrived); server dedupe protects same-batch redelivery, not a missing earlier batch.

Both are fixed by one structural change (reviewer's suggestion, adopted): a **single send worker that splices at send time**. The buffer keeps growing while a request is in flight; each ACK splices the next ≤50 events, so batch size scales with the backlog and consumption throughput rises to meet the producer. On a fatal error the worker stops with the rest of the buffer unsent — dropped wholesale (the old serial semantics), never gapped.

This also corrects the expected-impact framing: steady-state batches are small (≈ producer rate × RTT), so the win is not a fixed "~50× fewer calls" — it is that consumption per round-trip now scales with backlog, so ingest keeps pace with the agent in real time and `drain()` after agent exit completes in ~one round-trip instead of ~13 minutes.

Round-3 regression coverage (`BatchIngester.test.ts`): events pushed during a blocked in-flight request ship as one follow-up batch (`[[1],[2,3]]`, not `[[1],[2],[3]]`); events queued during a failing batch's retry window are never sent after retries exhaust; synchronous 120-event burst still splits into ordered 50/50/20 batches.

---

#### 🔁 Review round 4: reasoning gets the same replace-snapshot semantics as text (cross-replica correction)

External review correctly noted the publish latch is in-memory, so a retry landing on a **cold replica** still republishes the batch — and round 2's claim that "text is the only visibly-corrupting duplicate" was wrong: **reasoning** chunks were raw appends on every layer. Worse than the live-view duplication the review named, `reduceReasoningChunk` re-appended on the server too, so a cold-replica redelivery would **durably double the thinking text in the DB** (`accReasoning + delta` → flush). Text never had this problem precisely because #15197 gave it `replace` snapshots — replace is naturally idempotent, seq or no seq.

This round extends that exact mechanism to reasoning, end to end:

- **CLI** (`CoalescingBatchIngester`): reasoning deltas coalesce into `replace` snapshots with their own operation-monotonic seq, flushed reasoning-before-text to preserve emission order (adapters emit thinking before the answer). Subagent reasoning still passes through raw. This also cuts event volume further — reasoning deltas are the chattiest chunk type — serving the PR's original goal.
- **Shared reducer** (`reduceReasoningChunk`): mirror of the text branch — replace + `lastReasoningSnapshotSeq` guard + `turnMetadata.heteroReasoningSnapshotSeq` stamped for rehydration.
- **Server rehydration** (`HeterogeneousPersistenceHandler`): cold replicas recover the reasoning seq from message metadata (seq-guarded restore, length heuristic kept as legacy fallback).
- **Client** (`gatewayEventHandler`): reasoning snapshots replace instead of append; redelivered seqs are dropped.

Remaining cross-replica residuals — tool lifecycle replays (benign client upserts by tool id) and a duplicate trace fold (telemetry only) — are accepted and documented in code; making publish exactly-once across replicas needs durable publish identity (e.g. deterministic stream ids), which is deliberately out of scope here and tracked as a follow-up.

Round-4 regression coverage: reducer replace/stale-drop/redelivery-idempotency; handler-level DB assertion that a redelivered reasoning snapshot does **not** double `reasoning.content` (timestamp-varied to bypass the in-memory dedupe, simulating a cold replica); gateway replace + duplicate-drop; coalescer reasoning→text→tools ordering, per-kind seq independence, boundary reset, and subagent passthrough.

---

#### 🔁 Review round 5: two dispositions, no code churn

Two further review comments; both were assessed and deliberately answered with documentation/tracking rather than more code:

1. **"Keep snapshot ingestion compatible with released clients"** — assessed as valid-in-principle, negligible-in-practice, and mostly pre-existing. Text `replace` snapshots have been on the wire since #15197 (two months in production) with released clients appending them; the reason nothing misrenders today is that both current producers emit effectively **one snapshot per message** (Codex text arrives as a single complete `agent_message`; CC's cloud path emits full blocks), where append and replace are indistinguishable. The reasoning snapshots added here follow the same single-chunk-per-message pattern, so a pre-deploy browser renders them identically. The residual window — a stale tab watching a hypothetical multi-snapshot message — is transient and self-heals on the next `fetchAndReplaceMessages` trigger. A capability/version negotiation for that window would be protocol complexity with no observable payoff, so none is added; this paragraph is the compatibility rationale.

2. **"Persist the publish dedupe across retry replicas"** — this restates the cross-replica limitation already documented and deferred in rounds 2/4, with one genuinely new datum: **subagent text** (raw passthrough, server-side append) is also in the residual set and would durably duplicate on a cold-replica redelivery. The publish-gate docstring now names the exact residual set (subagent text, tool lifecycle replays, duplicate trace fold), and the tracked follow-up for durable publish identity (deterministic stream ids / Redis-backed latch / producer eventSeq) has been updated to include subagent-text idempotency in its scope and acceptance tests. Building distributed publish state is intentionally out of scope for this PR.
