### PR TITLE
🐛 fix(chat): prevent working sidebar tab overflow

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
@@ -1,4 +1,4 @@
-import { act, render } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -39,6 +39,7 @@ const filesProps = vi.hoisted(() => ({
 
 const reviewState = vi.hoisted(() => ({
   repoType: undefined as string | undefined,
+  setRepoType: undefined as ((repoType?: string) => void) | undefined,
   showTree: false,
   workingDirectory: undefined as string | undefined,
 }));
@@ -106,9 +107,17 @@ vi.mock('@/business/client/features/WorkingSidebarTabs', () => ({
   useBusinessWorkingSidebarTabs: () => [],
 }));
 
-vi.mock('@/features/ChatInput/ControlBar/useRepoType', () => ({
-  useRepoType: () => reviewState.repoType,
-}));
+vi.mock('@/features/ChatInput/ControlBar/useRepoType', async () => {
+  const { useState } = await import('react');
+
+  return {
+    useRepoType: () => {
+      const [repoType, setRepoType] = useState(reviewState.repoType);
+      reviewState.setRepoType = setRepoType;
+      return repoType;
+    },
+  };
+});
 vi.mock('@/hooks/useEffectiveWorkingDirectory', () => ({
   useEffectiveWorkingDirectory: () => reviewState.workingDirectory,
 }));
@@ -151,6 +160,7 @@ beforeEach(() => {
   effectiveConfig.workspaceScoped = false;
   filesProps.current = undefined;
   reviewState.repoType = undefined;
+  reviewState.setRepoType = undefined;
   reviewState.showTree = false;
   reviewState.workingDirectory = undefined;
   globalStore.status.workingSidebarWidth = 360;
@@ -163,6 +173,7 @@ beforeEach(() => {
 
 afterEach(() => {
   rightPanel.current = undefined;
+  vi.restoreAllMocks();
   vi.clearAllMocks();
 });
 
@@ -293,5 +304,74 @@ describe('AgentWorkingSidebar — controlled panel width', () => {
       deviceId: 'workspace-device',
       workingDirectory: '/workspace/project',
     });
+  });
+});
+
+describe('AgentWorkingSidebar — tab strip', () => {
+  // Regression: at the 300px minimum panel width, labels such as “Deployments”
+  // were allowed to shrink and wrap inside words. Tabs now stay on one line in a
+  // horizontal strip, so a persisted tab near the end must be brought into view.
+  it('scrolls an overflowed active tab into view', () => {
+    globalStore.status.workingSidebarTab = 'params';
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (
+      this: Element,
+    ) {
+      return this instanceof HTMLButtonElement && this.getAttribute('aria-pressed') === 'true'
+        ? ({ left: 220, right: 280 } as DOMRect)
+        : ({ left: 0, right: 200 } as DOMRect);
+    });
+    const scrollIntoView = vi
+      .spyOn(Element.prototype, 'scrollIntoView')
+      .mockImplementation(() => undefined);
+
+    render(<AgentWorkingSidebar />);
+    const paramsTab = screen.getByRole('button', { name: 'settingModel.params.panel.tab' });
+
+    expect(paramsTab).toHaveAttribute('aria-pressed', 'true');
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest', inline: 'nearest' });
+  });
+
+  it('exposes and reveals a persisted active Works tab', () => {
+    globalStore.status.workingSidebarTab = 'works';
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (
+      this: Element,
+    ) {
+      return this instanceof HTMLButtonElement && this.getAttribute('aria-pressed') === 'true'
+        ? ({ left: 220, right: 280 } as DOMRect)
+        : ({ left: 0, right: 200 } as DOMRect);
+    });
+    const scrollIntoView = vi
+      .spyOn(Element.prototype, 'scrollIntoView')
+      .mockImplementation(() => undefined);
+
+    render(<AgentWorkingSidebar />);
+    const worksTab = screen.getByRole('button', { name: 'workingPanel.works.title' });
+
+    expect(worksTab).toHaveAttribute('aria-pressed', 'true');
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest', inline: 'nearest' });
+  });
+
+  it('reveals the active tab again when an async tab becomes available', () => {
+    agentStore.activeAgentId = 'agent';
+    reviewState.workingDirectory = '/repo';
+    globalStore.status.workingSidebarTab = 'params';
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (
+      this: Element,
+    ) {
+      return this instanceof HTMLButtonElement && this.getAttribute('aria-pressed') === 'true'
+        ? ({ left: 220, right: 280 } as DOMRect)
+        : ({ left: 0, right: 200 } as DOMRect);
+    });
+    const scrollIntoView = vi
+      .spyOn(Element.prototype, 'scrollIntoView')
+      .mockImplementation(() => undefined);
+
+    render(<AgentWorkingSidebar />);
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+    act(() => reviewState.setRepoType?.('git'));
+
+    expect(screen.getByRole('button', { name: 'workingPanel.review.title' })).toBeInTheDocument();
+    expect(scrollIntoView).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
@@ -1,7 +1,7 @@
 import { ActionIcon, Flexbox } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { PanelRightCloseIcon } from 'lucide-react';
-import { lazy, memo, useEffect, useState } from 'react';
+import { lazy, memo, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useBusinessWorkingSidebarTabs } from '@/business/client/features/WorkingSidebarTabs';
@@ -39,8 +39,12 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     flex: 1;
     min-height: 0;
   `,
+  close: css`
+    flex-shrink: 0;
+  `,
   header: css`
     flex-shrink: 0;
+    min-width: 0;
   `,
   pane: css`
     overflow-y: auto;
@@ -53,13 +57,16 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   tab: css`
     cursor: pointer;
 
+    flex-shrink: 0;
+
     padding-block: 4px;
-    padding-inline: 10px;
+    padding-inline: 8px;
     border: none;
     border-radius: 6px;
 
-    font-size: 13px;
+    font-size: 12px;
     color: ${cssVar.colorTextTertiary};
+    white-space: nowrap;
 
     background: transparent;
 
@@ -76,9 +83,19 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     background: ${cssVar.colorFillTertiary};
   `,
   tabs: css`
+    scrollbar-width: none;
+
+    overflow-x: auto;
     display: flex;
+    flex: 1;
     gap: 4px;
     align-items: center;
+
+    min-width: 0;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
   `,
 }));
 
@@ -173,6 +190,7 @@ const AgentWorkingSidebar = memo(() => {
     ...(paramsAvailable ? ['params'] : []),
     ...businessTabs.map((tab) => tab.key),
   ]);
+  const availableTabsSignature = JSON.stringify([...availableTabs]);
 
   const resolveActiveTab = (): string => {
     if (storedTab && availableTabs.has(storedTab)) return storedTab;
@@ -189,6 +207,21 @@ const AgentWorkingSidebar = memo(() => {
     return 'resources';
   };
   const activeTab = resolveActiveTab();
+  const tabsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const tabs = tabsRef.current;
+    const activeTabButton = tabs?.querySelector<HTMLButtonElement>('button[aria-pressed="true"]');
+    if (!tabs || !activeTabButton) return;
+
+    const tabsRect = tabs.getBoundingClientRect();
+    const activeTabRect = activeTabButton.getBoundingClientRect();
+    const isVisible = activeTabRect.left >= tabsRect.left && activeTabRect.right <= tabsRect.right;
+
+    if (!isVisible) {
+      activeTabButton.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+    }
+  }, [activeTab, availableTabsSignature, storedWidth]);
 
   // Review's tree-nav rail lives here (not inside Review) so the panel can widen
   // when the two-pane layout is on. Hidden by default — the panel shows only the
@@ -228,13 +261,15 @@ const AgentWorkingSidebar = memo(() => {
           horizontal
           align={'center'}
           className={styles.header}
+          gap={4}
           height={44}
           justify={'space-between'}
           paddingInline={4}
         >
-          <div className={styles.tabs}>
+          <div className={styles.tabs} ref={tabsRef}>
             {businessTabs.map((tab) => (
               <button
+                aria-pressed={activeTab === tab.key}
                 className={`${styles.tab} ${activeTab === tab.key ? styles.tabActive : ''}`}
                 key={tab.key}
                 type="button"
@@ -244,6 +279,7 @@ const AgentWorkingSidebar = memo(() => {
               </button>
             ))}
             <button
+              aria-pressed={activeTab === 'resources'}
               className={`${styles.tab} ${activeTab === 'resources' ? styles.tabActive : ''}`}
               type="button"
               onClick={() => setWorkingSidebarTab('resources')}
@@ -251,6 +287,7 @@ const AgentWorkingSidebar = memo(() => {
               {t('workingPanel.space')}
             </button>
             <button
+              aria-pressed={activeTab === 'works'}
               className={`${styles.tab} ${activeTab === 'works' ? styles.tabActive : ''}`}
               type="button"
               onClick={() => setWorkingSidebarTab('works')}
@@ -259,6 +296,7 @@ const AgentWorkingSidebar = memo(() => {
             </button>
             {reviewAvailable && (
               <button
+                aria-pressed={activeTab === 'review'}
                 className={`${styles.tab} ${activeTab === 'review' ? styles.tabActive : ''}`}
                 type="button"
                 onClick={() => setWorkingSidebarTab('review')}
@@ -268,6 +306,7 @@ const AgentWorkingSidebar = memo(() => {
             )}
             {filesAvailable && (
               <button
+                aria-pressed={activeTab === 'files'}
                 className={`${styles.tab} ${activeTab === 'files' ? styles.tabActive : ''}`}
                 type="button"
                 onClick={() => setWorkingSidebarTab('files')}
@@ -277,6 +316,7 @@ const AgentWorkingSidebar = memo(() => {
             )}
             {browserAvailable && (
               <button
+                aria-pressed={activeTab === 'browser'}
                 className={`${styles.tab} ${activeTab === 'browser' ? styles.tabActive : ''}`}
                 type="button"
                 onClick={() => setWorkingSidebarTab('browser')}
@@ -286,6 +326,7 @@ const AgentWorkingSidebar = memo(() => {
             )}
             {paramsAvailable && (
               <button
+                aria-pressed={activeTab === 'params'}
                 className={`${styles.tab} ${activeTab === 'params' ? styles.tabActive : ''}`}
                 type="button"
                 onClick={() => setWorkingSidebarTab('params')}
@@ -295,6 +336,7 @@ const AgentWorkingSidebar = memo(() => {
             )}
           </div>
           <ActionIcon
+            className={styles.close}
             icon={PanelRightCloseIcon}
             size={DESKTOP_HEADER_ICON_SMALL_SIZE}
             onClick={() => toggleRightPanel(false)}


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Extracted from #17294 so the working-sidebar fix can be reviewed independently.

#### 🔀 Description of Change

- Keep working-sidebar tab labels on one line and allow the tab strip to scroll horizontally at narrow panel widths.
- Automatically reveal the active tab when the selected tab, available tabs, or panel width changes.
- Prevent the close action from shrinking out of view.
- Add regression coverage for persisted tabs and tabs that become available asynchronously.

The root cause was that tab buttons could shrink and wrap inside words while the tab strip and close action competed for the same constrained header width.

#### 🧪 How to Test

- Run `bun run check 'src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx' 'src/routes/(main)/agent/features/Conversation/WorkingSidebar/__tests__/index.test.tsx'`.
- Run `bun run check --type`.
- Open the working sidebar at its 300px minimum width, switch to a tab near the end of the strip, and verify that it remains single-line and scrolls into view while the close action stays visible.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Narrow sidebar labels could wrap inside words and push the close action out of view. | Tabs remain single-line, the active tab scrolls into view, and the close action remains visible. |

#### 📝 Additional Information

- Scope is limited to the working-sidebar component and its existing test file.
- Validation completed with lint clean, 12 related tests passed, and a clean full type-check.
- No breaking changes or migrations.
