### PR TITLE
🔒 fix(mcp): stop leaking server process.env to stdio pre-check subprocess

### DIFF
--- a/src/libs/mcp/__tests__/index.test.ts
+++ b/src/libs/mcp/__tests__/index.test.ts
@@ -90,6 +90,54 @@ describe('MCPClient', () => {
     );
   });
 
+  // Regression for https://github.com/lobehub/lobehub/issues/17307:
+  // the stdio pre-check must NOT spread the full server process.env into the
+  // spawned subprocess, otherwise server-side secrets leak to the MCP process.
+  describe('Stdio pre-check env isolation (#17307)', () => {
+    const TIMEOUT = 120_000;
+
+    it(
+      'does not leak server process.env secrets to the pre-check subprocess',
+      async () => {
+        const SECRET_KEY = 'LOBE_TEST_SECRET_LEAK';
+        const SECRET_VALUE = 'super-secret-should-not-leak-1234';
+        const ALLOWED_KEY = 'LOBE_TEST_USER_ENV';
+        const ALLOWED_VALUE = 'user-configured-value';
+
+        process.env[SECRET_KEY] = SECRET_VALUE;
+        try {
+          const mcpClient = new MCPClient({
+            id: 'env-leak-test',
+            name: 'Env Leak Test',
+            type: 'stdio',
+            command: process.execPath,
+            // Dump the child env to stderr then exit non-zero: the main transport
+            // connect fails, which triggers the pre-check path we are guarding.
+            args: ['-e', 'console.error(JSON.stringify(process.env)); process.exit(1);'],
+            env: { [ALLOWED_KEY]: ALLOWED_VALUE },
+          } as any);
+
+          let thrown: any;
+          try {
+            await mcpClient.initialize();
+          } catch (error) {
+            thrown = error;
+          }
+
+          expect(thrown).toBeDefined();
+          const errorLog: string = thrown?.data?.metadata?.errorLog ?? '';
+          // the child env dumped to stderr must not contain the server secret
+          expect(errorLog).not.toContain(SECRET_VALUE);
+          // sanity: user-configured env vars are still forwarded to the subprocess
+          expect(errorLog).toContain(ALLOWED_VALUE);
+        } finally {
+          delete process.env[SECRET_KEY];
+        }
+      },
+      TIMEOUT,
+    );
+  });
+
   // Error Handling tests remain the same...
   describe('Error Handling', () => {
     it('should throw error for unsupported connection type', () => {

--- a/src/libs/mcp/__tests__/index.test.ts
+++ b/src/libs/mcp/__tests__/index.test.ts
@@ -91,10 +91,43 @@ describe('MCPClient', () => {
   });
 
   // Regression for https://github.com/lobehub/lobehub/issues/17307:
-  // the stdio pre-check must NOT spread the full server process.env into the
-  // spawned subprocess, otherwise server-side secrets leak to the MCP process.
-  describe('Stdio pre-check env isolation (#17307)', () => {
+  // neither the main stdio transport nor the failure-path pre-check may spread
+  // the full server process.env into the spawned subprocess, otherwise
+  // server-side secrets leak to the MCP process.
+  describe('Stdio env isolation (#17307)', () => {
     const TIMEOUT = 120_000;
+
+    it('does not pass server process.env secrets to the main stdio transport', () => {
+      const SECRET_KEY = 'LOBE_TEST_SECRET_LEAK';
+      const SECRET_VALUE = 'super-secret-should-not-leak-1234';
+      const ALLOWED_KEY = 'LOBE_TEST_USER_ENV';
+      const ALLOWED_VALUE = 'user-configured-value';
+
+      process.env[SECRET_KEY] = SECRET_VALUE;
+      try {
+        const mcpClient = new MCPClient({
+          id: 'env-leak-transport-test',
+          name: 'Env Leak Transport Test',
+          type: 'stdio',
+          command: process.execPath,
+          args: ['-e', ''],
+          env: { [ALLOWED_KEY]: ALLOWED_VALUE },
+        } as any);
+
+        // The SDK stores the env we hand it verbatim on the transport's server
+        // params (default inherited vars are only merged later, at spawn time).
+        const transportEnv: Record<string, string> = (mcpClient as any).transport?._serverParams
+          ?.env;
+
+        expect(transportEnv).toBeDefined();
+        // server secret from process.env must NOT be handed to the transport
+        expect(transportEnv[SECRET_KEY]).toBeUndefined();
+        // user-configured env vars are still forwarded
+        expect(transportEnv[ALLOWED_KEY]).toBe(ALLOWED_VALUE);
+      } finally {
+        delete process.env[SECRET_KEY];
+      }
+    });
 
     it(
       'does not leak server process.env secrets to the pre-check subprocess',

--- a/src/libs/mcp/__tests__/index.test.ts
+++ b/src/libs/mcp/__tests__/index.test.ts
@@ -106,14 +106,17 @@ describe('MCPClient', () => {
 
         process.env[SECRET_KEY] = SECRET_VALUE;
         try {
+          // Print ONLY the two probed keys to stderr (never the whole env), then
+          // exit non-zero so the main transport connect fails and the pre-check
+          // path we are guarding runs. Keeping the dump narrow avoids writing
+          // unrelated CI/server secrets into errorLog if this test ever fails.
+          const childScript = `console.error('${SECRET_KEY}=' + (process.env.${SECRET_KEY} ?? '') + '\\n${ALLOWED_KEY}=' + (process.env.${ALLOWED_KEY} ?? '')); process.exit(1);`;
           const mcpClient = new MCPClient({
             id: 'env-leak-test',
             name: 'Env Leak Test',
             type: 'stdio',
             command: process.execPath,
-            // Dump the child env to stderr then exit non-zero: the main transport
-            // connect fails, which triggers the pre-check path we are guarding.
-            args: ['-e', 'console.error(JSON.stringify(process.env)); process.exit(1);'],
+            args: ['-e', childScript],
             env: { [ALLOWED_KEY]: ALLOWED_VALUE },
           } as any);
 

--- a/src/libs/mcp/client.ts
+++ b/src/libs/mcp/client.ts
@@ -43,8 +43,11 @@ async function preCheckStdioCommand(params: {
     log('Pre-checking stdio command: %s with args: %O', params.command, params.args);
 
     const child = spawn(params.command, params.args, {
+      // Do NOT spread the full process.env here: it would leak server-side secrets
+      // (DATABASE_URL, KEY_VAULTS_SECRET, provider API keys, OAuth/JWT secrets, ...)
+      // into the spawned MCP subprocess. Match the main StdioClientTransport below,
+      // which only exposes the safe default environment plus user-configured vars.
       env: {
-        ...process.env,
         ...getDefaultEnvironment(),
         ...params.env,
       },

--- a/src/libs/mcp/client.ts
+++ b/src/libs/mcp/client.ts
@@ -42,15 +42,19 @@ async function preCheckStdioCommand(params: {
   return new Promise((resolve) => {
     log('Pre-checking stdio command: %s with args: %O', params.command, params.args);
 
+    // Do NOT spread the full process.env here: it would leak server-side secrets
+    // (DATABASE_URL, KEY_VAULTS_SECRET, provider API keys, OAuth/JWT secrets, ...)
+    // into the spawned MCP subprocess. Match the main StdioClientTransport below,
+    // which only exposes the safe default environment plus user-configured vars.
+    // The cast is required because this repo augments NodeJS.ProcessEnv with
+    // required app keys that a restricted env intentionally omits.
+    const env = {
+      ...getDefaultEnvironment(),
+      ...params.env,
+    } as NodeJS.ProcessEnv;
+
     const child = spawn(params.command, params.args, {
-      // Do NOT spread the full process.env here: it would leak server-side secrets
-      // (DATABASE_URL, KEY_VAULTS_SECRET, provider API keys, OAuth/JWT secrets, ...)
-      // into the spawned MCP subprocess. Match the main StdioClientTransport below,
-      // which only exposes the safe default environment plus user-configured vars.
-      env: {
-        ...getDefaultEnvironment(),
-        ...params.env,
-      },
+      env,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 


### PR DESCRIPTION
### 💻 变更类型 | Change Type

- [x] 🔒 security fix

### 🔀 变更说明 | Description of Change

The stdio pre-check path in `src/libs/mcp/client.ts` (`preCheckStdioCommand`) spawned the MCP subprocess with the **full server `process.env`** spread into its environment:

```ts
env: { ...process.env, ...getDefaultEnvironment(), ...params.env }
```

On a stdio MCP connection failure (which triggers the pre-check), this leaks server-side secrets — `DATABASE_URL`, `KEY_VAULTS_SECRET`, LLM provider API keys, OAuth/JWT secrets, cloud-storage credentials — to the spawned MCP process.

The main `StdioClientTransport` in the same file already restricts the env to `getDefaultEnvironment()` + user-configured vars. This PR makes the pre-check match, closing the inconsistency.

Note: the desktop client (`apps/desktop/src/main/libs/mcp/client.ts`) never had this pattern, so it is unaffected.

### 📝 补充信息 | Additional Information

Added a regression test that sets a sentinel secret on `process.env`, forces the pre-check path, and asserts the child env dumped to stderr does **not** contain the secret while still forwarding user-configured env vars. Verified the test fails before the fix and passes after.

Fixes #17307