### PR TITLE
🐛 fix(profile): hide non-configurable tools

### DIFF
--- a/src/features/ProfileEditor/AgentTool.tsx
+++ b/src/features/ProfileEditor/AgentTool.tsx
@@ -2,7 +2,7 @@
 
 import { COMPOSIO_APP_TYPES, LOBEHUB_SKILL_PROVIDERS } from '@lobechat/const';
 import { getActivePluginIds, parsePluginEntry, upsertPluginMode } from '@lobechat/types';
-import { type ItemType } from '@lobehub/ui';
+import type { ItemType } from '@lobehub/ui';
 import { Avatar, Flexbox, Icon } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { McpIcon, SkillsIcon } from '@lobehub/ui/icons';
@@ -24,28 +24,25 @@ import MarketSkillIcon from '@/features/ChatInput/ActionBar/Tools/MarketSkillIco
 import ToolItem from '@/features/ChatInput/ActionBar/Tools/ToolItem';
 import ToolItemDetailPopover from '@/features/ChatInput/ActionBar/Tools/ToolItemDetailPopover';
 import { createSkillStoreModal } from '@/features/SkillStore';
-import { USER_HIDDEN_BUILTIN_SKILLS } from '@/helpers/skillFilters';
 import { useCheckPluginsIsInstalled } from '@/hooks/useCheckPluginsIsInstalled';
 import { useFetchInstalledPlugins } from '@/hooks/useFetchInstalledPlugins';
 import { usePermission } from '@/hooks/usePermission';
 import { useAgentStore } from '@/store/agent';
-import { agentSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
+import { agentSelectors } from '@/store/agent/selectors';
 import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useToolStore } from '@/store/tool';
 import {
   agentSkillsSelectors,
   builtinToolSelectors,
   composioStoreSelectors,
-  lobehubSkillStoreSelectors,
   pluginSelectors,
 } from '@/store/tool/selectors';
-import { type LobeToolMetaWithAvailability } from '@/store/tool/slices/builtin/selectors';
+import type { LobeToolMetaWithAvailability } from '@/store/tool/slices/builtin/selectors';
 import { connectorSelectors } from '@/store/tool/slices/connector';
 
 import PluginTag from './PluginTag';
 import PopoverContent from './PopoverContent';
-
-const WEB_BROWSING_IDENTIFIER = 'lobe-web-browsing';
+import { getVisibleProfileToolIds } from './profileToolVisibility';
 
 export interface AgentToolProps {
   /**
@@ -78,12 +75,7 @@ export interface AgentToolProps {
    */
   showAuthor?: boolean;
   /**
-   * Whether to show web browsing toggle functionality
-   * @default false
-   */
-  showWebBrowsing?: boolean;
-  /**
-   * Whether to use allMetaList (includes hidden tools) or metaList
+   * Whether to include installed hidden tools that remain profile-configurable
    * @default false
    */
   useAllMetaList?: boolean;
@@ -92,7 +84,6 @@ export interface AgentToolProps {
 const AgentTool = memo<AgentToolProps>(
   ({
     agentId,
-    showWebBrowsing = false,
     filterAvailableInWeb = false,
     useAllMetaList = false,
     excludeAgentConnectors = false,
@@ -103,6 +94,7 @@ const AgentTool = memo<AgentToolProps>(
     const activeAgentId = useAgentStore((s) => s.activeAgentId);
     const effectiveAgentId = agentId || activeAgentId || '';
     const config = useAgentStore(agentSelectors.getAgentConfigById(effectiveAgentId), isEqual);
+    const isManualSkillMode = config?.chatConfig?.skillActivateMode === 'manual';
 
     // Plugin state management — pinned identifiers only (a disabled entry
     // is a distinct, valid config state; this component has no tri-state UI
@@ -110,20 +102,31 @@ const AgentTool = memo<AgentToolProps>(
     const plugins = getActivePluginIds(config?.plugins);
 
     const updateAgentConfigById = useAgentStore((s) => s.updateAgentConfigById);
-    const updateAgentChatConfigById = useAgentStore((s) => s.updateAgentChatConfigById);
     const installedPluginList = useToolStore(pluginSelectors.installedPluginMetaList, isEqual);
 
-    // Use appropriate builtin list based on prop
-    // When useAllMetaList is true, use installedAllMetaList to include hidden/platform-specific
-    // tools but still exclude user-uninstalled tools
-    const builtinList = useToolStore(
+    // Keep the broad list for stale-config validation. The picker uses the
+    // narrower profile list below so runtime-owned tools never become choices.
+    const knownBuiltinList = useToolStore(
       useAllMetaList ? builtinToolSelectors.installedAllMetaList : builtinToolSelectors.metaList,
       isEqual,
     );
-
-    // Web browsing uses searchMode instead of plugins array - use byId selector
-    const isSearchEnabled = useAgentStore(
-      chatConfigByIdSelectors.isEnableSearchById(effectiveAgentId),
+    const profileBuiltinList = useToolStore(
+      useAllMetaList
+        ? builtinToolSelectors.installedProfileConfigurableMetaList({
+            isManualMode: isManualSkillMode,
+          })
+        : builtinToolSelectors.metaList,
+      isEqual,
+    );
+    const nonProfileConfigurableBuiltinToolIds = useToolStore(
+      builtinToolSelectors.nonProfileConfigurableBuiltinToolIds({
+        isManualMode: isManualSkillMode,
+      }),
+      isEqual,
+    );
+    const nonProfileConfigurableBuiltinToolIdentifiers = useMemo(
+      () => new Set(nonProfileConfigurableBuiltinToolIds),
+      [nonProfileConfigurableBuiltinToolIds],
     );
 
     // Composio-related state
@@ -131,7 +134,6 @@ const AgentTool = memo<AgentToolProps>(
     const isComposioEnabledInEnv = useServerConfigStore(serverConfigSelectors.enableComposio);
 
     // LobeHub Skill-related state
-    const allLobehubSkillServers = useToolStore(lobehubSkillStoreSelectors.getServers, isEqual);
     const isLobehubSkillEnabled = useServerConfigStore(serverConfigSelectors.enableLobehubSkill);
 
     // Agent Skills-related state
@@ -192,14 +194,6 @@ const AgentTool = memo<AgentToolProps>(
       if (!isConnectorsInit) fetchConnectors();
     }, [isConnectorsInit, fetchConnectors]);
 
-    // Toggle web browsing via searchMode - use byId action
-    const toggleWebBrowsing = useCallback(async () => {
-      if (!canEdit) return;
-      if (!effectiveAgentId) return;
-      const nextMode = isSearchEnabled ? 'off' : 'auto';
-      await updateAgentChatConfigById(effectiveAgentId, { searchMode: nextMode });
-    }, [canEdit, isSearchEnabled, updateAgentChatConfigById, effectiveAgentId]);
-
     // Toggle a plugin - use byId action
     const togglePlugin = useCallback(
       async (pluginId: string, state?: boolean) => {
@@ -219,43 +213,27 @@ const AgentTool = memo<AgentToolProps>(
       [canEdit, effectiveAgentId, plugins, config?.plugins, updateAgentConfigById],
     );
 
-    // Check if a tool is enabled (handles web browsing specially)
+    // Check if a profile-managed tool is pinned.
     const isToolEnabled = useCallback(
-      (identifier: string) => {
-        if (showWebBrowsing && identifier === WEB_BROWSING_IDENTIFIER) {
-          return isSearchEnabled;
-        }
-        return plugins.includes(identifier);
-      },
-      [plugins, isSearchEnabled, showWebBrowsing],
+      (identifier: string) => plugins.includes(identifier),
+      [plugins],
     );
 
-    // Toggle a tool (handles web browsing specially)
+    // Toggle a profile-managed tool.
     const handleToggleTool = useCallback(
       async (identifier: string) => {
-        if (!canEdit) return;
-
-        if (showWebBrowsing && identifier === WEB_BROWSING_IDENTIFIER) {
-          await toggleWebBrowsing();
-        } else {
-          await togglePlugin(identifier);
-        }
+        await togglePlugin(identifier);
       },
-      [canEdit, toggleWebBrowsing, togglePlugin, showWebBrowsing],
+      [togglePlugin],
     );
 
-    // Get connected server by identifier
-    const getServerByName = (identifier: string) => {
-      return allComposioServers.find((server) => server.identifier === identifier);
-    };
-
-    // Get all Composio server type identifiers (used to filter builtinList)
+    // Get all Composio server type identifiers (used to filter the builtin list)
     const allComposioTypeIdentifiers = useMemo(
       () => new Set(COMPOSIO_APP_TYPES.map((type) => type.identifier)),
       [],
     );
 
-    // Get all skill identifiers (used to filter builtinList)
+    // Get all skill identifiers (used to filter the builtin list)
     const allSkillIdentifiers = useMemo(() => {
       const ids = new Set<string>();
       for (const s of installedBuiltinSkills) ids.add(s.identifier);
@@ -264,12 +242,12 @@ const AgentTool = memo<AgentToolProps>(
       return ids;
     }, [installedBuiltinSkills, marketAgentSkills, userAgentSkills]);
 
-    // Filter out Composio tools and skills from builtinList (they are displayed separately)
+    // Filter out Composio tools and skills from profileBuiltinList (they are displayed separately)
     // Optionally filter out tools with availableInWeb: false based on config (e.g., LocalSystem is desktop-only)
     const filteredBuiltinList = useMemo(() => {
       // Cast to LobeToolMetaWithAvailability for type safety when filterAvailableInWeb is used
-      type ListType = typeof builtinList;
-      let list: ListType = builtinList;
+      type ListType = typeof profileBuiltinList;
+      let list: ListType = profileBuiltinList;
 
       // Filter by availableInWeb if requested (only makes sense when using allMetaList)
       if (filterAvailableInWeb && useAllMetaList) {
@@ -288,7 +266,7 @@ const AgentTool = memo<AgentToolProps>(
 
       return list;
     }, [
-      builtinList,
+      profileBuiltinList,
       allComposioTypeIdentifiers,
       isComposioEnabledInEnv,
       filterAvailableInWeb,
@@ -311,7 +289,9 @@ const AgentTool = memo<AgentToolProps>(
                   appSlug={type.appSlug}
                   identifier={type.identifier}
                   label={type.label}
-                  server={getServerByName(type.identifier)}
+                  server={allComposioServers.find(
+                    (server) => server.identifier === type.identifier,
+                  )}
                 />
               ),
               popoverContent: (
@@ -363,7 +343,7 @@ const AgentTool = memo<AgentToolProps>(
               ),
             }))
           : [],
-      [isLobehubSkillEnabled, allLobehubSkillServers, effectiveAgentId, t],
+      [isLobehubSkillEnabled, effectiveAgentId, t],
     );
 
     // Handle plugin remove via Tag close - use byId actions
@@ -377,12 +357,7 @@ const AgentTool = memo<AgentToolProps>(
         if (!canEdit) return;
 
         const identifier = typeof pluginId === 'string' ? pluginId : pluginId?.identifier;
-        if (showWebBrowsing && identifier === WEB_BROWSING_IDENTIFIER) {
-          if (!effectiveAgentId) return;
-          await updateAgentChatConfigById(effectiveAgentId, { searchMode: 'off' });
-        } else {
-          await togglePlugin(identifier, false);
-        }
+        await togglePlugin(identifier, false);
       };
 
     // Builtin Agent Skills list items (grouped under LobeHub)
@@ -565,8 +540,11 @@ const AgentTool = memo<AgentToolProps>(
     );
 
     // Distinguish community plugins from custom plugins
-    const communityPlugins = installedPluginList.filter((item) => item.type !== 'customPlugin');
-    const customPlugins = installedPluginList.filter((item) => item.type === 'customPlugin');
+    const profilePluginList = installedPluginList.filter(
+      (item) => !nonProfileConfigurableBuiltinToolIdentifiers.has(item.identifier),
+    );
+    const communityPlugins = profilePluginList.filter((item) => item.type !== 'customPlugin');
+    const customPlugins = profilePluginList.filter((item) => item.type === 'customPlugin');
 
     // Function to generate plugin list items
     const mapPluginToItem = useCallback(
@@ -735,7 +713,7 @@ const AgentTool = memo<AgentToolProps>(
       const all = new Set<string>();
 
       // 1. Builtin tools (includes Composio metas)
-      for (const tool of builtinList) all.add(tool.identifier);
+      for (const tool of knownBuiltinList) all.add(tool.identifier);
 
       // 2. Installed plugins
       for (const plugin of installedPluginList) all.add(plugin.identifier);
@@ -764,7 +742,7 @@ const AgentTool = memo<AgentToolProps>(
 
       return all;
     }, [
-      builtinList,
+      knownBuiltinList,
       installedPluginList,
       isComposioEnabledInEnv,
       isLobehubSkillEnabled,
@@ -811,18 +789,15 @@ const AgentTool = memo<AgentToolProps>(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [validIdentifiers]);
 
-    // Combine plugins and web browsing for display
+    // Only display tools that this profile surface actually manages. Runtime-
+    // managed entries remain untouched in config for compatibility with other
+    // flows, but do not inflate this section's count or render misleading chips.
     const allEnabledTools = useMemo(() => {
-      const tools = [...plugins];
-      // Add web browsing if enabled (it's not in plugins array)
-      if (showWebBrowsing && isSearchEnabled && !tools.includes(WEB_BROWSING_IDENTIFIER)) {
-        tools.unshift(WEB_BROWSING_IDENTIFIER);
-      }
-      return tools.filter(
-        (toolId) =>
-          !USER_HIDDEN_BUILTIN_SKILLS.has(toolId) && !agentConnectorIdentifiers?.has(toolId),
-      );
-    }, [plugins, isSearchEnabled, showWebBrowsing, agentConnectorIdentifiers]);
+      return getVisibleProfileToolIds(plugins, {
+        agentConnectorIdentifiers,
+        nonConfigurableBuiltinToolIdentifiers: nonProfileConfigurableBuiltinToolIdentifiers,
+      });
+    }, [plugins, agentConnectorIdentifiers, nonProfileConfigurableBuiltinToolIdentifiers]);
 
     return (
       <>

--- a/src/features/ProfileEditor/AgentUserTools/UserToolsSection.test.tsx
+++ b/src/features/ProfileEditor/AgentUserTools/UserToolsSection.test.tsx
@@ -21,9 +21,18 @@ const mocks = vi.hoisted(() => ({
       string,
       Array<{ agentId: string; id: string; identifier: string }>
     >,
+    builtinTools: [] as Array<{
+      hidden?: boolean;
+      identifier: string;
+      manifest: { api: never[]; identifier: string; meta: { title: string }; systemRole: string };
+      type: 'builtin';
+    }>,
     connectors: [] as unknown[],
   },
-  agentConfig: { plugins: [] as unknown[] },
+  agentConfig: { plugins: [] } as {
+    chatConfig?: { skillActivateMode?: 'auto' | 'manual' };
+    plugins: unknown[];
+  },
 }));
 
 vi.mock('react-i18next', () => ({
@@ -35,8 +44,8 @@ vi.mock('@/business/client/hooks/useActiveWorkspaceId', () => ({
   useActiveWorkspaceId: () => 'ws-1',
 }));
 
-// The chips themselves are rendered by AgentTool (covered separately); stub it
-// so this test isolates the header count wiring.
+// The chips themselves are rendered by AgentTool; stub it so this test isolates
+// the header count wiring. The shared visibility predicate has focused coverage.
 vi.mock('@/features/ProfileEditor/AgentTool', () => ({ default: () => null }));
 vi.mock('@/features/ProfileEditor/PluginTag', () => ({ default: () => null }));
 
@@ -74,9 +83,10 @@ const renderSection = () =>
 
 const labelText = () => screen.getByTestId('label').textContent;
 
-describe('UserToolsSection — base tool count excludes agent-owned connectors', () => {
+describe('UserToolsSection — Workspace/User tool count', () => {
   beforeEach(() => {
     mocks.toolState.agentConnectors = {};
+    mocks.toolState.builtinTools = [];
     mocks.toolState.connectors = [];
     mocks.agentConfig = { plugins: [] };
   });
@@ -104,6 +114,80 @@ describe('UserToolsSection — base tool count excludes agent-owned connectors',
     mocks.toolState.agentConnectors = {
       'agent-1': [{ agentId: 'agent-1', id: 'c1', identifier: 'google-drive' }],
     };
+
+    renderSection();
+
+    expect(labelText()).toContain('· 1');
+  });
+
+  it('does not count Web Browsing even when a legacy plugin entry is pinned', () => {
+    mocks.agentConfig = {
+      plugins: [
+        { identifier: 'lobe-web-browsing', mode: 'pinned' },
+        { identifier: 'some-user-plugin', mode: 'pinned' },
+      ],
+    };
+    mocks.toolState.builtinTools = [
+      {
+        hidden: true,
+        identifier: 'lobe-web-browsing',
+        manifest: {
+          api: [],
+          identifier: 'lobe-web-browsing',
+          meta: { title: 'Web Browsing' },
+          systemRole: '',
+        },
+        type: 'builtin',
+      },
+    ];
+
+    renderSection();
+
+    expect(labelText()).toContain('· 1');
+  });
+
+  it('does not count pinned Skill Store in auto activation mode', () => {
+    mocks.agentConfig = {
+      chatConfig: { skillActivateMode: 'auto' },
+      plugins: [{ identifier: 'lobe-skill-store', mode: 'pinned' }],
+    };
+    mocks.toolState.builtinTools = [
+      {
+        hidden: true,
+        identifier: 'lobe-skill-store',
+        manifest: {
+          api: [],
+          identifier: 'lobe-skill-store',
+          meta: { title: 'Skill Store' },
+          systemRole: '',
+        },
+        type: 'builtin',
+      },
+    ];
+
+    renderSection();
+
+    expect(labelText()).toContain('· 0');
+  });
+
+  it('counts pinned Skill Store in manual activation mode', () => {
+    mocks.agentConfig = {
+      chatConfig: { skillActivateMode: 'manual' },
+      plugins: [{ identifier: 'lobe-skill-store', mode: 'pinned' }],
+    };
+    mocks.toolState.builtinTools = [
+      {
+        hidden: true,
+        identifier: 'lobe-skill-store',
+        manifest: {
+          api: [],
+          identifier: 'lobe-skill-store',
+          meta: { title: 'Skill Store' },
+          systemRole: '',
+        },
+        type: 'builtin',
+      },
+    ];
 
     renderSection();
 

--- a/src/features/ProfileEditor/AgentUserTools/UserToolsSection.tsx
+++ b/src/features/ProfileEditor/AgentUserTools/UserToolsSection.tsx
@@ -8,11 +8,14 @@ import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
-import SharedAgentTool, { type AgentToolProps } from '@/features/ProfileEditor/AgentTool';
+import type { AgentToolProps } from '@/features/ProfileEditor/AgentTool';
+import SharedAgentTool from '@/features/ProfileEditor/AgentTool';
 import PluginTag from '@/features/ProfileEditor/PluginTag';
+import { getVisibleProfileToolIds } from '@/features/ProfileEditor/profileToolVisibility';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 import { useToolStore } from '@/store/tool';
+import { builtinToolSelectors } from '@/store/tool/selectors';
 import { connectorSelectors } from '@/store/tool/slices/connector';
 
 interface Props extends AgentToolProps {
@@ -44,6 +47,7 @@ const UserToolsSection = memo<Props>(
     const { t } = useTranslation('setting');
     const userConnectors = useToolStore(connectorSelectors.connectorList, isEqual);
     const config = useAgentStore(agentSelectors.getAgentConfigById(agentId), isEqual);
+    const isManualSkillMode = config?.chatConfig?.skillActivateMode === 'manual';
     // Agent-owned/linked connector identifiers are shown in the Agent Tools
     // section above (and excluded from this section's chips in `AgentTool`), so
     // exclude them from the count too — otherwise the header would count a tool
@@ -53,9 +57,20 @@ const UserToolsSection = memo<Props>(
       () => new Set(agentConnectors.map((c) => c.identifier)),
       [agentConnectors],
     );
-    const userToolCount = getActivePluginIds(config?.plugins).filter(
-      (id) => !agentConnectorIdentifiers.has(id),
-    ).length;
+    const nonProfileConfigurableBuiltinToolIds = useToolStore(
+      builtinToolSelectors.nonProfileConfigurableBuiltinToolIds({
+        isManualMode: isManualSkillMode,
+      }),
+      isEqual,
+    );
+    const nonProfileConfigurableBuiltinToolIdentifiers = useMemo(
+      () => new Set(nonProfileConfigurableBuiltinToolIds),
+      [nonProfileConfigurableBuiltinToolIds],
+    );
+    const userToolCount = getVisibleProfileToolIds(getActivePluginIds(config?.plugins), {
+      agentConnectorIdentifiers,
+      nonConfigurableBuiltinToolIdentifiers: nonProfileConfigurableBuiltinToolIdentifiers,
+    }).length;
     // In a workspace, this section's base tools are the WORKSPACE dimension
     // (`connector.list` is workspace-scoped), not the caller's personal tools —
     // label it so the user knows the tools are shared workspace-scoped, not

--- a/src/features/ProfileEditor/profileToolVisibility.test.ts
+++ b/src/features/ProfileEditor/profileToolVisibility.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { getVisibleProfileToolIds } from './profileToolVisibility';
+
+describe('getVisibleProfileToolIds', () => {
+  it('excludes runtime-managed builtins, internal skills, and agent connectors', () => {
+    const result = getVisibleProfileToolIds(
+      ['lobe-web-browsing', 'task', 'agent-connector', 'workspace-plugin'],
+      {
+        agentConnectorIdentifiers: new Set(['agent-connector']),
+        nonConfigurableBuiltinToolIdentifiers: new Set(['lobe-web-browsing']),
+      },
+    );
+
+    expect(result).toEqual(['workspace-plugin']);
+  });
+});

--- a/src/features/ProfileEditor/profileToolVisibility.ts
+++ b/src/features/ProfileEditor/profileToolVisibility.ts
@@ -1,0 +1,26 @@
+import { USER_HIDDEN_BUILTIN_SKILLS } from '@/helpers/skillFilters';
+
+interface ProfileToolVisibilityOptions {
+  agentConnectorIdentifiers?: ReadonlySet<string> | null;
+  nonConfigurableBuiltinToolIdentifiers: ReadonlySet<string>;
+}
+
+/**
+ * Keep the Agent Profile count and selected chips aligned with the tools this
+ * surface actually owns. Hidden config entries stay intact because another
+ * activation mode or runtime flow may still use them; this surface simply must
+ * not represent them as profile-managed Workspace Tools in the current mode.
+ */
+export const getVisibleProfileToolIds = (
+  toolIds: string[],
+  {
+    agentConnectorIdentifiers,
+    nonConfigurableBuiltinToolIdentifiers,
+  }: ProfileToolVisibilityOptions,
+): string[] =>
+  toolIds.filter(
+    (toolId) =>
+      !USER_HIDDEN_BUILTIN_SKILLS.has(toolId) &&
+      !nonConfigurableBuiltinToolIdentifiers.has(toolId) &&
+      !agentConnectorIdentifiers?.has(toolId),
+  );

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/AgentTool.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/AgentTool.tsx
@@ -5,12 +5,11 @@ import AgentUserTools from '@/features/ProfileEditor/AgentUserTools';
 /**
  * Tools area for the agent profile editor — an Agent Tools / User Tools tabbed
  * view (agent-scoped connectors vs the user's pinned tools).
- * - showWebBrowsing: Agent profile supports web browsing toggle
  * - filterAvailableInWeb: Filter out desktop-only tools in web version
- * - useAllMetaList: Use allMetaList to include hidden tools
+ * - useAllMetaList: Include eligible hidden tools
  */
 const AgentTool = () => {
-  return <AgentUserTools filterAvailableInWeb showWebBrowsing useAllMetaList />;
+  return <AgentUserTools filterAvailableInWeb useAllMetaList />;
 };
 
 export default AgentTool;

--- a/src/routes/(main)/group/profile/features/MemberProfile/AgentTool.tsx
+++ b/src/routes/(main)/group/profile/features/MemberProfile/AgentTool.tsx
@@ -5,14 +5,13 @@ import { useGroupProfileStore } from '@/store/groupProfile';
 
 /**
  * AgentTool for group profile editor
- * - showWebBrowsing: Group member profile supports web browsing toggle
  * - filterAvailableInWeb: Filter out desktop-only tools in web version
- * - useAllMetaList: Use allMetaList to include hidden tools
+ * - useAllMetaList: Include eligible hidden tools
  * - Passes agentId from group profile store to display the correct member's plugins
  */
 const AgentTool = () => {
   const agentId = useGroupProfileStore((s) => s.activeTabId);
-  return <SharedAgentTool filterAvailableInWeb showWebBrowsing useAllMetaList agentId={agentId} />;
+  return <SharedAgentTool filterAvailableInWeb useAllMetaList agentId={agentId} />;
 };
 
 export default AgentTool;

--- a/src/store/tool/slices/builtin/selectors.test.ts
+++ b/src/store/tool/slices/builtin/selectors.test.ts
@@ -210,4 +210,109 @@ describe('builtinToolSelectors', () => {
       expect(result.map((item) => item.identifier)).toEqual(['lobe-task', 'tool-1']);
     });
   });
+
+  describe('installedProfileConfigurableMetaList', () => {
+    it('should expose only builtin tools whose lifecycle is controlled by Agent Profile', () => {
+      const state = {
+        ...initialState,
+        builtinTools: [
+          {
+            hidden: true,
+            identifier: 'lobe-web-browsing',
+            manifest: {
+              api: [],
+              identifier: 'lobe-web-browsing',
+              meta: { title: 'Web Browsing' },
+              systemRole: '',
+            },
+            type: 'builtin',
+          },
+          {
+            discoverable: false,
+            hidden: true,
+            identifier: 'lobe-verify',
+            manifest: {
+              api: [],
+              identifier: 'lobe-verify',
+              meta: { title: 'Verifier' },
+              systemRole: '',
+            },
+            type: 'builtin',
+          },
+          {
+            hidden: true,
+            identifier: 'lobe-skill-store',
+            manifest: {
+              api: [],
+              identifier: 'lobe-skill-store',
+              meta: { title: 'Skill Store' },
+              systemRole: '',
+            },
+            type: 'builtin',
+          },
+          {
+            hidden: true,
+            identifier: 'lobe-agent-management',
+            manifest: {
+              api: [],
+              identifier: 'lobe-agent-management',
+              meta: { title: 'Agent Management' },
+              systemRole: '',
+            },
+            type: 'builtin',
+          },
+          {
+            identifier: 'profile-tool',
+            manifest: {
+              api: [],
+              identifier: 'profile-tool',
+              meta: { title: 'Profile Tool' },
+              systemRole: '',
+            },
+            type: 'builtin',
+          },
+          {
+            identifier: 'uninstalled-tool',
+            manifest: {
+              api: [],
+              identifier: 'uninstalled-tool',
+              meta: { title: 'Uninstalled Tool' },
+              systemRole: '',
+            },
+            type: 'builtin',
+          },
+        ],
+        uninstalledBuiltinTools: ['uninstalled-tool'],
+      } as ToolStoreState;
+
+      const autoVisible = builtinToolSelectors.installedProfileConfigurableMetaList({
+        isManualMode: false,
+      })(state);
+      const autoExcluded = builtinToolSelectors.nonProfileConfigurableBuiltinToolIds({
+        isManualMode: false,
+      })(state);
+      const manualVisible = builtinToolSelectors.installedProfileConfigurableMetaList({
+        isManualMode: true,
+      })(state);
+      const manualExcluded = builtinToolSelectors.nonProfileConfigurableBuiltinToolIds({
+        isManualMode: true,
+      })(state);
+
+      expect(autoVisible.map((item) => item.identifier)).toEqual([
+        'lobe-agent-management',
+        'profile-tool',
+      ]);
+      expect(autoExcluded).toEqual(
+        expect.arrayContaining(['lobe-web-browsing', 'lobe-verify', 'lobe-skill-store']),
+      );
+      expect(manualVisible.map((item) => item.identifier)).toEqual([
+        'lobe-skill-store',
+        'lobe-agent-management',
+        'profile-tool',
+      ]);
+      expect(manualExcluded).toEqual(expect.arrayContaining(['lobe-web-browsing', 'lobe-verify']));
+      expect(manualExcluded).not.toContain('lobe-skill-store');
+      expect(manualExcluded).not.toContain('lobe-agent-management');
+    });
+  });
 });

--- a/src/store/tool/slices/builtin/selectors.ts
+++ b/src/store/tool/slices/builtin/selectors.ts
@@ -4,14 +4,14 @@ import {
   manualModeExcludeToolIds,
   runtimeManagedToolIds,
 } from '@lobechat/builtin-tools';
-import { type BuiltinSkill, type LobeToolMeta } from '@lobechat/types';
+import type { BuiltinSkill, LobeToolMeta } from '@lobechat/types';
 
 import {
   isBuiltinSkillAvailableInCurrentEnv,
   isBuiltinToolAvailableInCurrentEnv,
 } from '@/helpers/toolAvailability';
 
-import { type ToolStoreState } from '../../initialState';
+import type { ToolStoreState } from '../../initialState';
 import { agentSkillsSelectors } from '../agentSkills/selectors';
 import { ComposioServerStatus } from '../composioStore';
 
@@ -74,6 +74,32 @@ const getComposioMetasWithAvailability = (s: ToolStoreState): LobeToolMetaWithAv
 
 // Set form for O(1) lookup inside the filter loop.
 const RUNTIME_MANAGED_TOOL_IDS = new Set(runtimeManagedToolIds);
+const ALWAYS_ON_TOOL_IDS = new Set(alwaysOnToolIds);
+const MANUAL_MODE_EXCLUDE_TOOL_IDS = new Set(manualModeExcludeToolIds);
+
+interface ProfileConfigurableToolOptions {
+  isManualMode: boolean;
+}
+
+/**
+ * Agent Profile only owns tools whose lifecycle can genuinely be controlled by
+ * the agent's plugin policy. Runtime-managed tools (for example Web Browsing),
+ * non-discoverable infrastructure, and system-fixed tools do not satisfy that
+ * contract. A default tool removed specifically by manual activation mode is
+ * the exception: an explicit profile pin genuinely adds it back.
+ */
+const isProfileConfigurableBuiltinTool = (
+  tool: ToolStoreState['builtinTools'][number],
+  { isManualMode }: ProfileConfigurableToolOptions,
+): boolean => {
+  if (tool.discoverable === false) return false;
+  if (RUNTIME_MANAGED_TOOL_IDS.has(tool.identifier)) return false;
+
+  return (
+    !ALWAYS_ON_TOOL_IDS.has(tool.identifier) ||
+    (isManualMode && MANUAL_MODE_EXCLUDE_TOOL_IDS.has(tool.identifier))
+  );
+};
 
 /**
  * Shared list builder for the chat-input Tools popover.
@@ -87,7 +113,7 @@ const RUNTIME_MANAGED_TOOL_IDS = new Set(runtimeManagedToolIds);
  *    selector both honor it).
  * 2. Tools listed in `runtimeManagedToolIds` — these have their enabled state forced
  *    by `AgentToolsEngine` runtime rules (e.g. cloud-sandbox is on iff cloud runtime,
- *    web-browsing is on iff search enabled, agent-documents is on iff agent has docs).
+ *    web-browsing is on iff search is enabled).
  *    Showing a toggle the user can't actually affect would be a UI lie.
  */
 const buildVisibleMetaList = (
@@ -141,18 +167,18 @@ const metaList = (s: ToolStoreState): LobeToolMeta[] =>
   buildVisibleMetaList(s, { includeHidden: false });
 
 /**
- * Same as `metaList` but also surfaces builtin tools that are normally hidden
- * (e.g. web-browsing, cloud-sandbox). Used by the chat-input Tools popover when
- * the agent is in manual skill-activate mode so users can explicitly enable or
- * disable tools the activator would otherwise auto-activate.
+ * Same as `metaList` but also surfaces eligible builtin tools that are normally
+ * hidden (e.g. task and agent-management). Used by the chat-input Tools popover
+ * when the agent is in manual skill-activate mode.
  *
- * Pure infrastructure tools (the activator itself, agent-builder helpers, etc.)
- * are still excluded — they are never user-toggleable.
+ * Pure infrastructure and runtime-managed tools are still excluded because the
+ * user's toggle cannot truthfully control them.
  */
 const metaListIncludingHidden = (s: ToolStoreState): LobeToolMeta[] =>
   buildVisibleMetaList(s, { includeHidden: true });
 
-// Tools that should never be exposed in agent profile configuration
+// Legacy exclusions for broad metadata inventories. Agent Profile visibility
+// is governed by `isProfileConfigurableBuiltinTool` instead.
 const EXCLUDED_TOOLS = new Set([
   'lobe-agent-builder',
   'lobe-group-agent-builder',
@@ -161,9 +187,9 @@ const EXCLUDED_TOOLS = new Set([
 ]);
 
 /**
- * Get all builtin tools meta list (includes hidden tools and platform-specific tools)
- * Used for agent profile tool configuration where all tools should be configurable
- * Returns availability info so UI can show hints for unavailable tools
+ * Get broad builtin-tool metadata (including hidden/platform-specific tools).
+ * Used by detail, lookup, and context-building surfaces rather than as a
+ * user-configurable Agent Profile list.
  */
 const allMetaList = (s: ToolStoreState): LobeToolMetaWithAvailability[] => {
   const builtinMetas = s.builtinTools
@@ -219,8 +245,9 @@ const discoverableMetaList = (s: ToolStoreState): LobeToolMeta[] => {
 };
 
 /**
- * Get installed builtin tools meta list (excludes uninstalled, includes hidden and platform-specific)
- * Used for agent profile tool configuration where only installed tools should be shown
+ * Get broad installed builtin-tool metadata (including hidden and
+ * platform-specific tools). This is an inventory/lookup selector; Agent
+ * Profile uses `installedProfileConfigurableMetaList` for its picker.
  */
 const installedAllMetaList = (s: ToolStoreState): LobeToolMetaWithAvailability[] => {
   const { uninstalledBuiltinTools } = s;
@@ -237,7 +264,37 @@ const installedAllMetaList = (s: ToolStoreState): LobeToolMetaWithAvailability[]
   return [...builtinMetas, ...getComposioMetasWithAvailability(s)];
 };
 
-const MANUAL_MODE_EXCLUDE_TOOL_IDS = new Set(manualModeExcludeToolIds);
+/**
+ * Installed builtin tools that Agent Profile can truthfully pin or unpin.
+ *
+ * This intentionally differs from `installedAllMetaList`, which is also used
+ * by inventory/detail surfaces and therefore contains runtime-managed and
+ * internal tools for lookup purposes.
+ */
+const installedProfileConfigurableMetaList =
+  (options: ProfileConfigurableToolOptions) =>
+  (s: ToolStoreState): LobeToolMetaWithAvailability[] => {
+    const { uninstalledBuiltinTools } = s;
+
+    const builtinMetas = s.builtinTools
+      .filter((tool) => isProfileConfigurableBuiltinTool(tool, options))
+      .filter((item) => !uninstalledBuiltinTools.includes(item.identifier))
+      .map(toBuiltinMetaWithAvailability);
+
+    return [...builtinMetas, ...getComposioMetasWithAvailability(s)];
+  };
+
+/**
+ * Builtin identifiers hidden from Agent Profile in the current activation
+ * mode. Their config entries remain intact so switching modes is reversible.
+ */
+const nonProfileConfigurableBuiltinToolIds =
+  (options: ProfileConfigurableToolOptions) =>
+  (s: ToolStoreState): string[] =>
+    s.builtinTools
+      .filter((tool) => !isProfileConfigurableBuiltinTool(tool, options))
+      .map((tool) => tool.identifier);
+
 const ACTIVATION_MODE_CONTROLLED_TOOL_IDS = new Set(activationModeControlledToolIds);
 
 /**
@@ -293,8 +350,10 @@ export const builtinToolSelectors = {
   fixedDisplayMetaList,
   installedAllMetaList,
   installedBuiltinSkills,
+  installedProfileConfigurableMetaList,
   isBuiltinToolInstalled,
   metaList,
   metaListIncludingHidden,
+  nonProfileConfigurableBuiltinToolIds,
   uninstalledBuiltinTools,
 };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No directly matching issue was found.

#### 🔀 Description of Change

- Remove the Web Browsing control from Agent Profile and Group Member Profile as intended.
- Exclude runtime-managed, non-discoverable, and system-fixed built-in tools from profile tool pickers.
- Keep Skill Store profile-configurable in manual activation mode while preserving hidden configuration entries across mode changes.
- Share one visibility predicate between selected chips and Workspace/User tool counts so the rendered tools and count stay aligned.
- Add regression coverage for runtime-managed tools, activation-mode behavior, internal skills, and agent-owned connectors.

#### 🧪 How to Test

- Run the focused check for the nine changed files; all 15 related tests should pass.
- Run the full TypeScript check with `bun run check --type`.
- Verify that Agent Profile and Group Member Profile no longer show Web Browsing or other non-configurable built-ins.
- Switch between automatic and manual skill activation and verify that Skill Store is only configurable in manual mode.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

Not included. This change removes non-configurable options and aligns existing counts without adding a new visual surface.

#### 📝 Additional Information

No API, database, or migration changes. Hidden runtime-managed configuration entries remain intact for compatibility with other flows.
