### PR TITLE
✨ feat(cli): edit agencyConfig via `agent edit --agency-config-file`

### DIFF
--- a/apps/cli/src/commands/agent.test.ts
+++ b/apps/cli/src/commands/agent.test.ts
@@ -390,6 +390,70 @@ describe('agent command', () => {
       expect(exitSpy).toHaveBeenCalledWith(1);
       expect(mockTrpcClient.agent.updateAgentConfig.mutate).not.toHaveBeenCalled();
     });
+
+    it('should merge agencyConfig from a JSON file, clearing a nested key with null', async () => {
+      mockTrpcClient.agent.updateAgentConfig.mutate.mockResolvedValue({});
+      // `null` (not undefined) so the server-side deep-merge drops the nested key.
+      const agencyConfigFile = await writeGraphFixture({ heterogeneousProvider: null });
+
+      const program = createProgram();
+      await program.parseAsync([
+        'node',
+        'test',
+        'agent',
+        'edit',
+        'a1',
+        '--agency-config-file',
+        agencyConfigFile,
+      ]);
+
+      expect(mockTrpcClient.agent.updateAgentConfig.mutate).toHaveBeenCalledWith({
+        agentId: 'a1',
+        value: { agencyConfig: { heterogeneousProvider: null } },
+      });
+    });
+
+    it('should merge a plain-object agencyConfig from a JSON file', async () => {
+      mockTrpcClient.agent.updateAgentConfig.mutate.mockResolvedValue({});
+      const agencyConfigFile = await writeGraphFixture({ executionTarget: 'none' });
+
+      const program = createProgram();
+      await program.parseAsync([
+        'node',
+        'test',
+        'agent',
+        'edit',
+        'a1',
+        '--agency-config-file',
+        agencyConfigFile,
+      ]);
+
+      expect(mockTrpcClient.agent.updateAgentConfig.mutate).toHaveBeenCalledWith({
+        agentId: 'a1',
+        value: { agencyConfig: { executionTarget: 'none' } },
+      });
+    });
+
+    it('should reject a non-object agencyConfig file before updating', async () => {
+      const agencyConfigFile = await writeGraphFixture(['not', 'an', 'object']);
+
+      const program = createProgram();
+      await program.parseAsync([
+        'node',
+        'test',
+        'agent',
+        'edit',
+        'a1',
+        '--agency-config-file',
+        agencyConfigFile,
+      ]);
+
+      expect(log.error).toHaveBeenCalledWith(
+        expect.stringContaining('agencyConfig JSON must be a plain object'),
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(mockTrpcClient.agent.updateAgentConfig.mutate).not.toHaveBeenCalled();
+    });
   });
 
   describe('delete', () => {

--- a/apps/cli/src/commands/agent.ts
+++ b/apps/cli/src/commands/agent.ts
@@ -32,6 +32,17 @@ const readGraphConfig = async (graphFile: string): Promise<unknown> => {
   return result.data;
 };
 
+const readAgencyConfig = async (agencyConfigFile: string): Promise<Record<string, unknown>> => {
+  const content = await readFile(agencyConfigFile, 'utf8');
+  const parsed = JSON.parse(content);
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('agencyConfig JSON must be a plain object');
+  }
+
+  return parsed as Record<string, unknown>;
+};
+
 export function registerAgentCommand(program: Command) {
   const agent = program.command('agent').description('Manage agents');
   registerAgentSpaceFsCommand(agent);
@@ -172,10 +183,15 @@ export function registerAgentCommand(program: Command) {
     .option('--graph-file <path>', 'ReasoningGraph JSON file')
     .option('--enable-graph', 'Enable graph runtime')
     .option('--disable-graph', 'Disable graph runtime')
+    .option(
+      '--agency-config-file <path>',
+      'agencyConfig JSON file, deep-merged into the agent (send `null` to clear a nested key)',
+    )
     .action(
       async (
         agentIdArg: string | undefined,
         options: {
+          agencyConfigFile?: string;
           description?: string;
           disableGraph?: boolean;
           enableGraph?: boolean;
@@ -214,9 +230,21 @@ export function registerAgentCommand(program: Command) {
         }
         if (Object.keys(chatConfig).length > 0) value.chatConfig = chatConfig;
 
+        // agencyConfig is deep-merged server-side, so a nested key is removed by
+        // sending it as `null` (e.g. `{ "heterogeneousProvider": null }`); omitted keys are kept.
+        if (options.agencyConfigFile) {
+          try {
+            value.agencyConfig = await readAgencyConfig(options.agencyConfigFile);
+          } catch (error) {
+            log.error(`Failed to read agencyConfig JSON: ${(error as Error).message}`);
+            process.exit(1);
+            return;
+          }
+        }
+
         if (Object.keys(value).length === 0) {
           log.error(
-            'No changes specified. Use --title, --description, --model, --provider, --system-role, --graph-file, --enable-graph, or --disable-graph.',
+            'No changes specified. Use --title, --description, --model, --provider, --system-role, --graph-file, --enable-graph, --disable-graph, or --agency-config-file.',
           );
           process.exit(1);
           return;


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

`lh agent edit` had no way to touch an agent's `agencyConfig`, so there was no CLI path to fix an agent whose runtime config drifted — e.g. an inbox / normal agent that got a `heterogeneousProvider` set and now runs as a Claude Code / Codex / ACP agent instead of normal model chat.

This adds a single, general option:

- `--agency-config-file <path>` — reads a JSON file and deep-merges it into the agent's `agencyConfig`.

Because `agent.updateAgentConfig` deep-merges server-side (and the merge **skips `undefined` but persists `null`**), a nested key is *cleared* by sending it as `null`. So reverting a hetero agent back to normal chat is just:

```bash
echo '{ "heterogeneousProvider": null }' > clear-hetero.json
lh agent edit <agentId> --agency-config-file clear-hetero.json
```

Sibling keys under `agencyConfig` (`boundDeviceId`, `executionTarget`, `workingDirByDevice`, …) are preserved. Non-object JSON is rejected before any network call.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Unit tests in `apps/cli/src/commands/agent.test.ts` cover: clearing a nested key via `{ "heterogeneousProvider": null }`, merging a plain-object `agencyConfig`, and rejecting a non-object file before mutating. Full file suite passes (62 tests); `bun run check --lint` clean.

#### 📝 Additional Information

The `null`-clears-nested-key behavior mirrors the existing server-side merge semantics (`es-toolkit` `mergeWith`, arrays replaced, `undefined` skipped) — no server change needed.