### PR TITLE
♻️ refactor: thread per-generation billing handles through image async tasks

### DIFF
--- a/apps/server/src/routers/async/__tests__/image.test.ts
+++ b/apps/server/src/routers/async/__tests__/image.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment node
+import { resolveBusinessModelMapping } from '@lobechat/business-model-runtime';
+import { AsyncTaskStatus } from '@lobechat/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { chargeAfterGenerate } from '@/business/server/image-generation/chargeAfterGenerate';
+import { AsyncTaskModel } from '@/database/models/asyncTask';
+import { FileModel } from '@/database/models/file';
+import { GenerationModel } from '@/database/models/generation';
+import { GenerationBatchModel } from '@/database/models/generationBatch';
+import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
+import { GenerationService } from '@/server/services/generation';
+
+import { imageRouter } from '../image';
+
+// Constructor-based deps the route instantiates directly.
+vi.mock('@/database/models/asyncTask', () => ({ AsyncTaskModel: vi.fn() }));
+vi.mock('@/database/models/file', () => ({ FileModel: vi.fn() }));
+vi.mock('@/database/models/generation', () => ({ GenerationModel: vi.fn() }));
+vi.mock('@/database/models/generationBatch', () => ({ GenerationBatchModel: vi.fn() }));
+vi.mock('@/server/services/generation', () => ({ GenerationService: vi.fn() }));
+vi.mock('@/server/modules/ModelRuntime', () => ({ initModelRuntimeFromDB: vi.fn() }));
+
+// Business slots.
+vi.mock('@/business/server/getProviderContentPolicyErrorMessage', () => ({
+  getProviderContentPolicyErrorMessage: vi.fn(async () => undefined),
+}));
+vi.mock('@/business/server/image-generation/chargeAfterGenerate', () => ({
+  chargeAfterGenerate: vi.fn(),
+}));
+vi.mock('@/business/server/image-generation/notifyImageCompleted', () => ({
+  notifyImageCompleted: vi.fn(),
+}));
+vi.mock('@/business/server/trpc-middlewares/async', () => ({
+  createImageBusinessMiddleware: async (opts: any) => opts.next({ ctx: opts.ctx }),
+}));
+
+// The failure-reconciliation path is gated on ENABLE_BUSINESS_FEATURES, which is
+// false in the OSS default const package.
+vi.mock('@lobechat/business-const', async (importOriginal) => ({
+  ...((await importOriginal()) as any),
+  ENABLE_BUSINESS_FEATURES: true,
+}));
+
+vi.mock('@lobechat/business-model-runtime', async (importOriginal) => ({
+  ...((await importOriginal()) as any),
+  buildMappedBusinessModelFields: vi.fn(() => ({})),
+  resolveBusinessModelMapping: vi.fn(),
+}));
+
+vi.mock('@/libs/trpc/async', async () => {
+  const init = await vi.importActual<{ asyncTrpc: any }>('@/libs/trpc/async/init');
+  const { asyncTrpc } = init;
+  return {
+    asyncAuthedProcedure: asyncTrpc.procedure,
+    asyncRouter: asyncTrpc.router,
+    createAsyncCallerFactory: asyncTrpc.createCallerFactory,
+    publicProcedure: asyncTrpc.procedure,
+  };
+});
+
+describe('imageRouter.createImage — model mapping failure reconciles billing', () => {
+  const userId = 'user_test';
+  let mockCtx: any;
+  let asyncTaskModelMock: any;
+  let generationBatchModelMock: any;
+  let generationModelMock: any;
+  let generationServiceMock: any;
+
+  const createInput = (overrides = {}) => ({
+    generationBatchId: 'batch-1',
+    generationId: 'gen-1',
+    generationTopicId: 'topic-1',
+    model: 'some-model',
+    params: { prompt: 'a beautiful sunset' },
+    provider: 'test-provider',
+    taskId: 'task-1',
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    asyncTaskModelMock = { findById: vi.fn(), update: vi.fn() };
+    generationBatchModelMock = { findById: vi.fn() };
+    generationModelMock = { createAssetAndFile: vi.fn() };
+    generationServiceMock = {
+      transformImageForGeneration: vi.fn(),
+      uploadImageForGeneration: vi.fn(),
+    };
+
+    vi.mocked(AsyncTaskModel).mockImplementation(() => asyncTaskModelMock);
+    vi.mocked(GenerationBatchModel).mockImplementation(() => generationBatchModelMock);
+    vi.mocked(GenerationModel).mockImplementation(() => generationModelMock);
+    vi.mocked(GenerationService).mockImplementation(() => generationServiceMock);
+    vi.mocked(FileModel).mockImplementation(() => ({}) as any);
+    vi.mocked(initModelRuntimeFromDB).mockResolvedValue({} as any);
+
+    // The batch must exist so the route proceeds into the guarded section.
+    generationBatchModelMock.findById.mockResolvedValue({ id: 'batch-1', createdAt: new Date() });
+
+    mockCtx = { serverDB: {}, userId };
+  });
+
+  it('marks the task Error and reconciles the precharge handle when model mapping throws', async () => {
+    asyncTaskModelMock.findById.mockResolvedValue({
+      metadata: { precharge: { reservationKey: 'brk-1' } },
+    });
+    // Regression: this rejection previously happened before the outer try, so the
+    // mutation threw without marking the task Error or reconciling billing.
+    vi.mocked(resolveBusinessModelMapping).mockRejectedValue(new Error('mapping failed'));
+
+    const caller = imageRouter.createCaller(mockCtx);
+    const result = await caller.createImage(createInput());
+
+    // (c) resolves rather than throwing
+    expect(result).toMatchObject({ success: false });
+
+    // (a) task marked Error
+    expect(asyncTaskModelMock.update).toHaveBeenCalledWith(
+      'task-1',
+      expect.objectContaining({ status: AsyncTaskStatus.Error }),
+    );
+
+    // (b) billing reconciled once with the loaded precharge handle
+    expect(chargeAfterGenerate).toHaveBeenCalledTimes(1);
+    expect(chargeAfterGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isError: true,
+        prechargeResult: { reservationKey: 'brk-1' },
+      }),
+    );
+  });
+
+  it('threads undefined prechargeResult when the task has no precharge handle', async () => {
+    asyncTaskModelMock.findById.mockResolvedValue({ metadata: undefined });
+    vi.mocked(resolveBusinessModelMapping).mockRejectedValue(new Error('mapping failed'));
+
+    const caller = imageRouter.createCaller(mockCtx);
+    const result = await caller.createImage(createInput());
+
+    expect(result).toMatchObject({ success: false });
+    expect(chargeAfterGenerate).toHaveBeenCalledTimes(1);
+    expect(chargeAfterGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isError: true,
+        prechargeResult: undefined,
+      }),
+    );
+  });
+});

--- a/apps/server/src/routers/async/image.ts
+++ b/apps/server/src/routers/async/image.ts
@@ -115,6 +115,19 @@ export const imageRouter = router({
         throw new TRPCError({ code: 'FORBIDDEN', message: 'Invalid Request!' });
       }
 
+      // Resolve model mapping up front so both the success and error billing
+      // paths can reference the resolved model id.
+      const { requestedModelId, resolvedModelId } = await resolveBusinessModelMapping(
+        provider,
+        model,
+      );
+
+      // Opaque billing handle stored on the task at submission time; threaded to
+      // the completion charge so it can reconcile the pre-submission billing.
+      const asyncTask = await asyncTaskModel.findById(taskId);
+      const prechargeResult = (asyncTask?.metadata as { precharge?: unknown } | undefined)
+        ?.precharge;
+
       log('Updating task status to Processing: %s', taskId);
       await asyncTaskModel.update(taskId, { status: AsyncTaskStatus.Processing });
 
@@ -129,10 +142,6 @@ export const imageRouter = router({
       try {
         const imageGenerationPromise = async (signal: AbortSignal) => {
           log('Initializing agent runtime for provider: %s', provider);
-          const { requestedModelId, resolvedModelId } = await resolveBusinessModelMapping(
-            provider,
-            model,
-          );
 
           // Read user's provider config from database
           const modelRuntime = await initModelRuntimeFromDB(
@@ -279,6 +288,7 @@ export const imageRouter = router({
                 }),
               },
               modelUsage,
+              prechargeResult,
               pricingContext: runtimeOptions.pricingContext,
               provider,
               userId: ctx.userId,
@@ -337,6 +347,32 @@ export const imageRouter = router({
         });
 
         log('Task status updated to Error: %s, errorType: %s', taskId, errorType);
+
+        // Reconcile the pre-submission billing on failure. Wrapped so a billing
+        // error never masks the original failure report.
+        if (ENABLE_BUSINESS_FEATURES) {
+          try {
+            await chargeAfterGenerate({
+              isError: true,
+              metadata: {
+                asyncTaskId: taskId,
+                generationBatchId,
+                topicId: generationTopicId,
+                ...buildMappedBusinessModelFields({
+                  provider,
+                  requestedModelId,
+                  resolvedModelId,
+                }),
+              },
+              prechargeResult,
+              provider,
+              userId: ctx.userId,
+              workspaceId,
+            });
+          } catch (chargeError) {
+            console.error('[image-async] Failed to reconcile billing on error:', chargeError);
+          }
+        }
 
         return {
           message: `Image generation ${taskId} failed: ${errorMessage}`,

--- a/apps/server/src/routers/async/image.ts
+++ b/apps/server/src/routers/async/image.ts
@@ -115,18 +115,15 @@ export const imageRouter = router({
         throw new TRPCError({ code: 'FORBIDDEN', message: 'Invalid Request!' });
       }
 
-      // Resolve model mapping up front so both the success and error billing
-      // paths can reference the resolved model id.
-      const { requestedModelId, resolvedModelId } = await resolveBusinessModelMapping(
-        provider,
-        model,
-      );
-
-      // Opaque billing handle stored on the task at submission time; threaded to
-      // the completion charge so it can reconcile the pre-submission billing.
-      const asyncTask = await asyncTaskModel.findById(taskId);
-      const prechargeResult = (asyncTask?.metadata as { precharge?: unknown } | undefined)
-        ?.precharge;
+      // Billing context is loaded inside the guarded section below so that a
+      // failure (e.g. a stale model mapping) still marks the task as Error and
+      // reconciles the precharge handle; the error path falls back to identity
+      // mapping when resolution itself is what failed.
+      // requestedModelId is optional on the mapping result, so it must allow
+      // undefined even though it defaults to the raw model id.
+      let requestedModelId: string | undefined = model;
+      let resolvedModelId = model;
+      let prechargeResult: unknown;
 
       log('Updating task status to Processing: %s', taskId);
       await asyncTaskModel.update(taskId, { status: AsyncTaskStatus.Processing });
@@ -140,6 +137,20 @@ export const imageRouter = router({
         Boolean(params.imageUrls && params.imageUrls.length > 0);
 
       try {
+        // Opaque billing handle stored on the task at submission time; threaded
+        // to the completion charge so it can reconcile the pre-submission
+        // billing. Loaded before the model mapping so the handle is available
+        // for reconciliation even when mapping resolution throws.
+        const asyncTask = await asyncTaskModel.findById(taskId);
+        prechargeResult = (asyncTask?.metadata as { precharge?: unknown } | undefined)?.precharge;
+
+        // Resolve model mapping up front so both the success and error billing
+        // paths can reference the resolved model id.
+        ({ requestedModelId, resolvedModelId } = await resolveBusinessModelMapping(
+          provider,
+          model,
+        ));
+
         const imageGenerationPromise = async (signal: AbortSignal) => {
           log('Initializing agent runtime for provider: %s', provider);
 

--- a/apps/server/src/routers/async/image.ts
+++ b/apps/server/src/routers/async/image.ts
@@ -275,25 +275,32 @@ export const imageRouter = router({
           }
 
           if (ENABLE_BUSINESS_FEATURES) {
-            await chargeAfterGenerate({
-              metrics: { latency: duration },
-              metadata: {
-                asyncTaskId: taskId,
-                generationBatchId,
-                topicId: generationTopicId,
-                ...buildMappedBusinessModelFields({
-                  provider,
-                  requestedModelId,
-                  resolvedModelId,
-                }),
-              },
-              modelUsage,
-              prechargeResult,
-              pricingContext: runtimeOptions.pricingContext,
-              provider,
-              userId: ctx.userId,
-              workspaceId,
-            });
+            // Contain success-billing errors: the image is already delivered and
+            // the task marked Success, so a billing failure here must not fall
+            // into the outer catch and be reconciled as a generation failure.
+            try {
+              await chargeAfterGenerate({
+                metrics: { latency: duration },
+                metadata: {
+                  asyncTaskId: taskId,
+                  generationBatchId,
+                  topicId: generationTopicId,
+                  ...buildMappedBusinessModelFields({
+                    provider,
+                    requestedModelId,
+                    resolvedModelId,
+                  }),
+                },
+                modelUsage,
+                prechargeResult,
+                pricingContext: runtimeOptions.pricingContext,
+                provider,
+                userId: ctx.userId,
+                workspaceId,
+              });
+            } catch (chargeError) {
+              console.error('[image-async] success billing failed:', chargeError);
+            }
           }
 
           log('Async image generation completed successfully: %s', taskId);

--- a/apps/server/src/routers/lambda/image/index.test.ts
+++ b/apps/server/src/routers/lambda/image/index.test.ts
@@ -430,6 +430,38 @@ describe('imageRouter', () => {
       );
     });
 
+    it('threads per-generation prechargeItems into each asyncTask metadata', async () => {
+      mockChargeBeforeGenerate.mockResolvedValue({
+        prechargeItems: [{ reservationKey: 'k-1' }, { reservationKey: 'k-2' }],
+      });
+
+      const ctx = createMockCtx();
+      const input = createDefaultInput();
+
+      const caller = imageRouter.createCaller(ctx);
+      await caller.createImage(input);
+
+      // insertValues: [0] batch, [1] generations[], [2] task#1, [3] task#2
+      expect(mockInsertValues[2]).toEqual(
+        expect.objectContaining({ metadata: { precharge: { reservationKey: 'k-1' } } }),
+      );
+      expect(mockInsertValues[3]).toEqual(
+        expect.objectContaining({ metadata: { precharge: { reservationKey: 'k-2' } } }),
+      );
+    });
+
+    it('leaves asyncTask metadata unset when there are no prechargeItems', async () => {
+      mockChargeBeforeGenerate.mockResolvedValue({ prechargeItems: undefined });
+
+      const ctx = createMockCtx();
+      const input = createDefaultInput();
+
+      const caller = imageRouter.createCaller(ctx);
+      await caller.createImage(input);
+
+      expect(mockInsertValues[2]).toEqual(expect.objectContaining({ metadata: undefined }));
+    });
+
     it('should trigger async image generation tasks', async () => {
       const ctx = createMockCtx();
       const input = createDefaultInput();

--- a/apps/server/src/routers/lambda/image/index.test.ts
+++ b/apps/server/src/routers/lambda/image/index.test.ts
@@ -10,6 +10,7 @@ const {
   mockGetKeyFromFullUrl,
   mockGetFullFileUrl,
   mockAsyncTaskModelUpdate,
+  mockChargeAfterGenerate,
   mockChargeBeforeGenerate,
   mockCreateAsyncCaller,
   mockGenerationTopicFindById,
@@ -24,6 +25,7 @@ const {
   mockGetKeyFromFullUrl: vi.fn(),
   mockGetFullFileUrl: vi.fn(),
   mockAsyncTaskModelUpdate: vi.fn(),
+  mockChargeAfterGenerate: vi.fn(),
   mockChargeBeforeGenerate: vi.fn(),
   mockCreateAsyncCaller: vi.fn(),
   mockGenerationTopicFindById: vi.fn(),
@@ -73,6 +75,17 @@ vi.mock('@/database/models/user', () => ({
 // Mock chargeBeforeGenerate
 vi.mock('@/business/server/image-generation/chargeBeforeGenerate', () => ({
   chargeBeforeGenerate: (params: any) => mockChargeBeforeGenerate(params),
+}));
+
+vi.mock('@/business/server/image-generation/chargeAfterGenerate', () => ({
+  chargeAfterGenerate: (params: any) => mockChargeAfterGenerate(params),
+}));
+
+// The failure-reconciliation path is gated on ENABLE_BUSINESS_FEATURES, which
+// is false in the OSS default const package.
+vi.mock('@lobechat/business-const', async (importOriginal) => ({
+  ...((await importOriginal()) as any),
+  ENABLE_BUSINESS_FEATURES: true,
 }));
 
 vi.mock('@lobechat/business-model-runtime', async (importOriginal) => ({
@@ -503,6 +516,48 @@ describe('imageRouter', () => {
       expect(result.success).toBe(true);
       // Should update async task status to error
       expect(mockAsyncTaskModelUpdate).toHaveBeenCalled();
+    });
+
+    it('reconciles per-generation billing handles when async startup fails', async () => {
+      mockCreateAsyncCaller.mockRejectedValue(new Error('Caller creation failed'));
+      mockChargeBeforeGenerate.mockResolvedValue({
+        prechargeItems: [{ reservationKey: 'k-1' }, { reservationKey: 'k-2' }],
+      });
+
+      const ctx = createMockCtx();
+      const input = createDefaultInput();
+
+      const caller = imageRouter.createCaller(ctx);
+      await caller.createImage(input);
+
+      // The async router never runs for these tasks, so the billing handles
+      // must be reconciled here — one isError charge per generation.
+      expect(mockChargeAfterGenerate).toHaveBeenCalledTimes(2);
+      expect(mockChargeAfterGenerate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isError: true,
+          prechargeResult: { reservationKey: 'k-1' },
+        }),
+      );
+      expect(mockChargeAfterGenerate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isError: true,
+          prechargeResult: { reservationKey: 'k-2' },
+        }),
+      );
+    });
+
+    it('skips failure billing reconciliation when there are no precharge items', async () => {
+      mockCreateAsyncCaller.mockRejectedValue(new Error('Caller creation failed'));
+      mockChargeBeforeGenerate.mockResolvedValue(undefined);
+
+      const ctx = createMockCtx();
+      const input = createDefaultInput();
+
+      const caller = imageRouter.createCaller(ctx);
+      await caller.createImage(input);
+
+      expect(mockChargeAfterGenerate).not.toHaveBeenCalled();
     });
 
     it('should update all task statuses to error when async processing fails', async () => {

--- a/apps/server/src/routers/lambda/image/index.ts
+++ b/apps/server/src/routers/lambda/image/index.ts
@@ -1,4 +1,4 @@
-import { BRANDING_PROVIDER } from '@lobechat/business-const';
+import { BRANDING_PROVIDER, ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 import { isLobeHubModelAvailable } from '@lobechat/business-model-bank/model-config';
 import { resolveBusinessModelMapping } from '@lobechat/business-model-runtime';
 import { ChatErrorType } from '@lobechat/types';
@@ -7,6 +7,7 @@ import debug from 'debug';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 
+import { chargeAfterGenerate } from '@/business/server/image-generation/chargeAfterGenerate';
 import { chargeBeforeGenerate } from '@/business/server/image-generation/chargeBeforeGenerate';
 import { withScopedPermission } from '@/business/server/trpc-middlewares/rbacPermission';
 import { wsCompatProcedure } from '@/business/server/trpc-middlewares/workspaceAuth';
@@ -333,6 +334,34 @@ export const imageRouter = router({
           );
         } catch (batchUpdateError) {
           console.error('Failed to update batch task statuses:', batchUpdateError);
+        }
+
+        // The async router never ran for these tasks, so its failure billing
+        // reconciliation cannot fire — reconcile each generation's billing
+        // handle here instead of leaving it dangling.
+        if (ENABLE_BUSINESS_FEATURES && prechargeItems?.length) {
+          await Promise.allSettled(
+            generationsWithTasks.map(async ({ asyncTaskId }, index) => {
+              const prechargeItem = prechargeItems[index];
+              if (!prechargeItem) return;
+              try {
+                await chargeAfterGenerate({
+                  isError: true,
+                  metadata: {
+                    asyncTaskId,
+                    generationBatchId: createdBatch.id,
+                    topicId: generationTopicId,
+                  },
+                  prechargeResult: prechargeItem,
+                  provider,
+                  userId,
+                  workspaceId: wsId,
+                });
+              } catch (chargeError) {
+                console.error('Failed to reconcile billing for failed task:', chargeError);
+              }
+            }),
+          );
         }
       }
 

--- a/apps/server/src/routers/lambda/image/index.ts
+++ b/apps/server/src/routers/lambda/image/index.ts
@@ -247,11 +247,13 @@ export const imageRouter = router({
             createdGenerations.map(async (generation, index) => {
               // Create asyncTask directly in transaction, carrying this
               // generation's billing handle (if any) for the completion charge.
+              // Presence check (not truthiness): handles are opaque, so falsy
+              // values like 0 or '' must still be stored verbatim.
               const prechargeItem = prechargeItems?.[index];
               const [createdAsyncTask] = await tx
                 .insert(asyncTasks)
                 .values({
-                  metadata: prechargeItem ? { precharge: prechargeItem } : undefined,
+                  metadata: prechargeItem === undefined ? undefined : { precharge: prechargeItem },
                   status: AsyncTaskStatus.Pending,
                   type: AsyncTaskType.ImageGeneration,
                   userId,
@@ -343,13 +345,14 @@ export const imageRouter = router({
           await Promise.allSettled(
             generationsWithTasks.map(async ({ asyncTaskId }, index) => {
               const prechargeItem = prechargeItems[index];
-              if (!prechargeItem) return;
+              if (prechargeItem === undefined) return;
               try {
                 await chargeAfterGenerate({
                   isError: true,
                   metadata: {
                     asyncTaskId,
                     generationBatchId: createdBatch.id,
+                    modelId: model,
                     topicId: generationTopicId,
                   },
                   prechargeResult: prechargeItem,

--- a/apps/server/src/routers/lambda/image/index.ts
+++ b/apps/server/src/routers/lambda/image/index.ts
@@ -185,9 +185,15 @@ export const imageRouter = router({
         userId,
         workspaceId: wsId,
       });
-      if (chargeResult) {
+      // An error batch (insufficient budget / cooldown / frozen workspace) is
+      // returned to the client as-is.
+      if (chargeResult && 'data' in chargeResult) {
         return chargeResult;
       }
+      // Otherwise, opaque per-generation billing handles to thread through each
+      // asyncTask so the completion charge can reconcile against them.
+      const prechargeItems =
+        chargeResult && 'prechargeItems' in chargeResult ? chargeResult.prechargeItems : undefined;
 
       // Step 1: Atomically create all database records in a transaction
       const { batch: createdBatch, generationsWithTasks } = await serverDB.transaction(
@@ -237,11 +243,14 @@ export const imageRouter = router({
           // 3. Concurrently create asyncTask for each generation (within transaction)
           log('Creating async tasks for generations');
           const generationsWithTasks = await Promise.all(
-            createdGenerations.map(async (generation) => {
-              // Create asyncTask directly in transaction
+            createdGenerations.map(async (generation, index) => {
+              // Create asyncTask directly in transaction, carrying this
+              // generation's billing handle (if any) for the completion charge.
+              const prechargeItem = prechargeItems?.[index];
               const [createdAsyncTask] = await tx
                 .insert(asyncTasks)
                 .values({
+                  metadata: prechargeItem ? { precharge: prechargeItem } : undefined,
                   status: AsyncTaskStatus.Pending,
                   type: AsyncTaskType.ImageGeneration,
                   userId,

--- a/packages/business-server/src/image-generation/chargeAfterGenerate.ts
+++ b/packages/business-server/src/image-generation/chargeAfterGenerate.ts
@@ -3,6 +3,7 @@ import { type ModelPricingContext } from '@lobechat/model-runtime';
 import { type ModelPerformance, type ModelUsage } from '@/types/index';
 
 interface ChargeParams {
+  isError?: boolean;
   metadata: {
     asyncTaskId: string;
     generationBatchId: string;
@@ -11,6 +12,8 @@ interface ChargeParams {
   };
   metrics?: ModelPerformance;
   modelUsage?: ModelUsage;
+  /** Opaque billing handle passed through from `asyncTask.metadata.precharge`. */
+  prechargeResult?: unknown;
   pricingContext?: ModelPricingContext;
   provider: string;
   userId: string;

--- a/packages/business-server/src/image-generation/chargeBeforeGenerate.ts
+++ b/packages/business-server/src/image-generation/chargeBeforeGenerate.ts
@@ -21,6 +21,14 @@ type ChargeResult =
         generations: NewGeneration[];
       };
       success: true;
+    }
+  | {
+      /**
+       * Opaque per-generation billing handles, threaded back to
+       * `chargeAfterGenerate` via `asyncTask.metadata.precharge` (one entry per
+       * generation). Stored verbatim; the router never reads their fields.
+       */
+      prechargeItems?: unknown[];
     };
 
 export async function chargeBeforeGenerate(_params: ChargeParams): Promise<ChargeResult> {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor

#### 🔀 Description of Change

Image generation billing currently has no way to associate the pre-submission billing step with each generation's completion:

- `chargeBeforeGenerate`'s result is discarded — the completion charge in `async/image` cannot reconcile against it
- the failure path never notifies billing at all

This PR threads an opaque per-generation billing handle through the async task lifecycle, mirroring the existing video pattern (`asyncTask.metadata.precharge`):

- `business-server` image `chargeBeforeGenerate` slot: result may now carry `prechargeItems?: unknown[]` (one opaque handle per generation); default implementation unchanged
- `business-server` image `chargeAfterGenerate` slot: accepts optional `isError` and `prechargeResult` (opaque passthrough); default implementation unchanged
- `lambda/image`: stores each generation's handle verbatim on its async task (`metadata.precharge`)
- `async/image`: reads the handle back and passes it to `chargeAfterGenerate` on both the success path and (new) the failure path, so billing can reconcile either way; billing errors on the failure path are contained and never mask the original error report

The handles are opaque (`unknown`) — the router never reads their fields.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

`lambda/image/index.test.ts` covers per-generation handle threading into async task metadata and the no-handle case.