### PR TITLE
🐛 fix(chat): prevent floating header shadow clipping

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/Header/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/index.tsx
@@ -75,6 +75,7 @@ const headerStyles = createStaticStyles(({ css }) => ({
 
     ${FLOATING_HEADER_QUERY} {
       pointer-events: auto;
+      overflow: visible;
 
       /* Hug the title pill so the transparent middle stays click-through */
       flex-grow: 0;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No matching issue found.

#### 🔀 Description of Change

The wide conversation header adds a rounded shadow to the topic title pill, but its existing rectangular parent kept `overflow: hidden`. This clipped the shadow at the parent's bounds and left visible gray corners around the pill.

Keep the existing clipping behavior for the regular in-flow header, while switching the left slot to `overflow: visible` only at the floating-header container breakpoint. The rounded inner title container continues to handle content clipping and title truncation.

#### 🧪 How to Test

- Resize the agent conversation column beyond the 1200px floating-header breakpoint.
- Open a topic and inspect the floating title pill in the upper-left corner.
- Confirm the shadow fades naturally around all rounded corners without rectangular gray clipping.

Validation performed:

- `bun run check 'src/routes/(main)/agent/features/Conversation/Header/index.tsx'`
- `git diff --check`

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

Not included.

#### 📝 Additional Information

This is a one-line responsive CSS correction. No automated visual-regression infrastructure currently covers this surface.
