### PR TITLE
✨ feat(server): expose message.getMessagesByCursor tRPC procedure

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/message.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/message.test.ts
@@ -160,6 +160,35 @@ describe('messageRouter', () => {
     expect(result).toEqual([{ id: 'msg1' }]);
   });
 
+  it('should handle getMessagesByCursor', async () => {
+    const page = {
+      hasMore: true,
+      messages: [{ id: 'msg2' }],
+      nextCursor: { createdAt: '2023-01-01T00:00:00.000Z', id: 'u1' },
+    };
+    const mockCursor = vi.fn().mockResolvedValue(page);
+    const mockGetFileAccessUrl = vi.fn().mockResolvedValue('url');
+
+    vi.mocked(MessageModel).mockImplementation(
+      () => ({ queryTopicMessagesByCursor: mockCursor }) as any,
+    );
+    vi.mocked(FileService).mockImplementation(
+      () => ({ getFileAccessUrl: mockGetFileAccessUrl }) as any,
+    );
+
+    const input = { roundLimit: 2, topicId: 'topic1' };
+    const ctx = {
+      messageModel: new MessageModel({} as any, 'user1'),
+    };
+
+    const result = await ctx.messageModel.queryTopicMessagesByCursor(input, {
+      postProcessUrl: mockGetFileAccessUrl,
+    });
+
+    expect(mockCursor).toHaveBeenCalledWith(input, expect.any(Object));
+    expect(result).toEqual(page);
+  });
+
   it('should handle getAllMessages', async () => {
     const mockQueryAll = vi.fn().mockResolvedValue([
       {

--- a/apps/server/src/routers/lambda/message.ts
+++ b/apps/server/src/routers/lambda/message.ts
@@ -366,6 +366,67 @@ export const messageRouter = router({
       });
     }),
 
+  /**
+   * Round-boundary cursor pagination for a topic's mainline conversation. Used by
+   * callers that only DISPLAY history (server-runtime / hetero); legacy client
+   * mode keeps using `getMessages` (full fetch) because it resends the session.
+   * Omit `cursor` for the newest page; pass a prior `nextCursor` to load older.
+   */
+  getMessagesByCursor: publicProcedure
+    .use(cloudWorkspaceAuth)
+    .use(serverDatabase)
+    .input(
+      z.object({
+        agentId: z.string().nullish(),
+        countBudget: z.number().optional(),
+        cursor: z.object({ createdAt: z.string(), id: z.string() }).nullish(),
+        roundLimit: z.number().optional(),
+        sessionId: z.string().nullish(),
+        skipWorks: z.boolean().optional(),
+        topicId: z.string(),
+        topicShareId: z.string().optional(),
+      }),
+    )
+    .query(async ({ input, ctx }) => {
+      const { topicShareId, ...queryParams } = input;
+
+      // Public access via topicShareId
+      if (topicShareId) {
+        const share = await TopicShareModel.findByShareIdWithAccessCheck(
+          ctx.serverDB,
+          topicShareId,
+          ctx.userId ?? undefined,
+        );
+
+        const shareWorkspaceId = share.workspaceId ?? undefined;
+        const messageModel = new MessageModel(ctx.serverDB, share.ownerId, shareWorkspaceId);
+        const fileService = new FileService(ctx.serverDB, share.ownerId, shareWorkspaceId);
+
+        return messageModel.queryTopicMessagesByCursor(
+          // Force skipWorks: Work summaries join LIVE task/version state, so serving
+          // them here would leak post-share mutations to anonymous visitors.
+          { ...queryParams, skipWorks: true, topicId: share.topicId },
+          {
+            postProcessUrl: (path, file) =>
+              fileService.getFileAccessUrl({ id: file.id, url: path }),
+          },
+        );
+      }
+
+      // Authenticated access - require userId
+      if (!ctx.userId) {
+        throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Authentication required' });
+      }
+
+      const wsId = ctx.workspaceId ?? undefined;
+      const messageModel = new MessageModel(ctx.serverDB, ctx.userId, wsId);
+      const fileService = new FileService(ctx.serverDB, ctx.userId, wsId);
+
+      return messageModel.queryTopicMessagesByCursor(queryParams, {
+        postProcessUrl: (path, file) => fileService.getFileAccessUrl({ id: file.id, url: path }),
+      });
+    }),
+
   rankModels: messageProcedure.query(async ({ ctx }) => {
     return ctx.messageModel.rankModels();
   }),


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Part of LOBE-12011 (stage 2, server layer).

⚠️ **Stacked on #17337** (DB layer) — base is `feat/lobe-12011-cursor-db`, not `canary`. Merge #17337 first; GitHub will retarget this to `canary` once it lands.

#### 🔀 Description of Change

Wires `MessageModel.queryTopicMessagesByCursor` through a new `message.getMessagesByCursor` lambda procedure for round-boundary cursor pagination.

- Mirrors `getMessages`' auth (`cloudWorkspaceAuth` / `serverDatabase`), `topicShareId` public-access branch, and file-URL post-processing.
- Forces `skipWorks` on shared topics, same as `getMessages` (Work summaries join live task/version state and would leak post-share mutations).
- `getMessages` is untouched — legacy client-mode full fetch keeps working.

#### 🧪 How to Test

- [x] Added/updated tests

Added a `getMessagesByCursor` router test alongside the existing `getMessages` one (18 passed). Type-check clean.

#### 📸 Screenshots / Videos

N/A — API surface only.

#### 📝 Additional Information

The client-side runtimeType-gated fetch (client → full `getMessages`; gateway/hetero → this cursor procedure) lands in the next stacked PR.