### PR TITLE
🐛 fix(minimax): strip unsupported image `detail` field to avoid 400 error

### DIFF
--- a/packages/model-runtime/src/providers/minimax/index.test.ts
+++ b/packages/model-runtime/src/providers/minimax/index.test.ts
@@ -418,6 +418,29 @@ describe('LobeMinimaxAI - handlePayload', () => {
     expect(result.messages[0].content).toBe(content);
   });
 
+  it('strips the `detail` field from image parts (MiniMax rejects detail: "auto")', () => {
+    const result = handlePayload({
+      messages: [
+        {
+          content: [
+            { text: 'what is this?', type: 'text' },
+            {
+              image_url: { detail: 'auto', url: 'https://example.com/image.png' },
+              type: 'image_url',
+            },
+          ],
+          role: 'user',
+        },
+      ],
+      model: 'MiniMax-M3',
+    } as any);
+
+    expect(result.messages[0].content).toEqual([
+      { text: 'what is this?', type: 'text' },
+      { image_url: { url: 'https://example.com/image.png' }, type: 'image_url' },
+    ]);
+  });
+
   it('keeps reasoning_split enabled for non-M3 MiniMax models', () => {
     const result = handlePayload({
       messages: [{ content: 'hi', role: 'user' }],

--- a/packages/model-runtime/src/providers/minimax/index.ts
+++ b/packages/model-runtime/src/providers/minimax/index.ts
@@ -107,6 +107,28 @@ export const buildMiniMaxAnthropicPayload = async (
   };
 };
 
+// MiniMax's OpenAI-compatible endpoint rejects the `detail` field on image
+// content parts, failing with `invalid params, invalid image detail: auto
+// (2013)`. Upstream context engineering always sets `detail: 'auto'`, a value
+// MiniMax does not accept, so strip `detail` from every `image_url` part before
+// sending. The original content reference is returned untouched when there is
+// nothing to strip. (#17252)
+const stripImageDetailFromContent = (content: any) => {
+  if (!Array.isArray(content)) return content;
+
+  let changed = false;
+  const next = content.map((part: any) => {
+    if (part?.type === 'image_url' && part.image_url && 'detail' in part.image_url) {
+      changed = true;
+      const { detail: _detail, ...imageUrl } = part.image_url;
+      return { ...part, image_url: imageUrl };
+    }
+    return part;
+  });
+
+  return changed ? next : content;
+};
+
 export const buildMiniMaxOpenAIPayload = (payload: ChatStreamPayload) => {
   const {
     enabledSearch: _enabledSearch,
@@ -147,12 +169,20 @@ export const buildMiniMaxOpenAIPayload = (payload: ChatStreamPayload) => {
     return message;
   });
 
+  // MiniMax rejects `detail: 'auto'` on image parts (see
+  // `stripImageDetailFromContent`), so sanitize multimodal content before use.
+  const sanitizedMessages = processedMessages.map((message: any) => {
+    if (!Array.isArray(message.content)) return message;
+    const content = stripImageDetailFromContent(message.content);
+    return content === message.content ? message : { ...message, content };
+  });
+
   // MiniMax API enforces `input_tokens + max_tokens <= context_window`,
   // so we must derive max_tokens dynamically from the actual input size
   // when the caller did not specify one. Estimate against the sanitized
   // messages (with stripped reasoning) — that's what we actually send.
   const safeMaxTokens = resolveSafeMaxTokens(
-    { ...payload, messages: processedMessages },
+    { ...payload, messages: sanitizedMessages },
     minimaxChatModels,
   );
 
@@ -193,7 +223,7 @@ export const buildMiniMaxOpenAIPayload = (payload: ChatStreamPayload) => {
   return {
     ...params,
     ...outputLimitParam,
-    messages: processedMessages,
+    messages: sanitizedMessages,
     reasoning_split: true,
     temperature: finalTemperature,
     ...finalThinking,


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes #17252

#### 🔀 Description of Change

**Problem** — When using the `minimax` provider (e.g. `MiniMax-M3`) and uploading an image, the chat request fails with a `400` from the upstream API:

```json
{
  "error": {
    "type": "bad_request_error",
    "message": "invalid params, invalid image detail: auto (2013)",
    "http_code": "400"
  }
}
```

**Root cause** — Context engineering always attaches `detail: 'auto'` to `image_url` content parts (`packages/context-engine/src/processors/MessageContent.ts`). This value is valid for OpenAI's vision API, but MiniMax's OpenAI-compatible endpoint rejects any `detail` on image parts. The MiniMax payload builder (`buildMiniMaxOpenAIPayload`) forwarded the messages untouched, so the unsupported field reached the API.

**Fix** — Strip the `detail` field from every `image_url` content part in `buildMiniMaxOpenAIPayload` before the payload is sent. The helper is a no-op (returns the original reference) when there is nothing to strip, so non-image and already-clean content is left exactly as-is and other part keys (e.g. `googleThoughtSignature`) are preserved.

#### 🧪 How to Test

- [x] Added/updated tests

Added a unit test in `packages/model-runtime/src/providers/minimax/index.test.ts` asserting that `detail` is removed from image parts while text parts are untouched. The existing "passes through multimodal user content" test still holds (content with no `detail` keeps its original reference).

- [x] Added/updated tests
