### PR TITLE
🐛 fix(ollama): distinguish request failures from service unavailability

### DIFF
--- a/packages/model-runtime/src/providers/ollama/index.test.ts
+++ b/packages/model-runtime/src/providers/ollama/index.test.ts
@@ -183,26 +183,48 @@ describe('LobeOllamaAI', () => {
       );
     });
 
-    it('should throw OllamaServiceUnavailable when fetch fails', async () => {
-      const errorMock = { message: 'fetch failed' };
+    it('should throw ProviderNetworkError when fetch fails but Ollama is reachable', async () => {
+      const errorMock = { message: 'Failed to fetch' };
       vi.mocked(Ollama.prototype.chat).mockRejectedValue(errorMock);
+      vi.mocked(Ollama.prototype.list).mockResolvedValue({ models: [] });
 
       const payload = {
         messages: [{ content: 'Hello', role: 'user' }],
         model: 'model-id',
       };
 
-      try {
-        await ollamaAI.chat(payload as any);
-      } catch (e) {
-        expect(e).toEqual(
-          AgentRuntimeError.chat({
-            error: { message: 'please check whether your ollama service is available' },
-            errorType: AgentRuntimeErrorType.OllamaServiceUnavailable,
-            provider: ModelProvider.Ollama,
-          }),
-        );
-      }
+      await expect(ollamaAI.chat(payload as any)).rejects.toEqual(
+        AgentRuntimeError.chat({
+          error: {
+            message: errorMock.message,
+            name: undefined,
+            status_code: undefined,
+          },
+          errorType: AgentRuntimeErrorType.ProviderNetworkError,
+          provider: ModelProvider.Ollama,
+        }),
+      );
+      expect(Ollama.prototype.list).toHaveBeenCalledOnce();
+    });
+
+    it('should throw OllamaServiceUnavailable when fetch fails and Ollama is unreachable', async () => {
+      const errorMock = { message: 'fetch failed' };
+      vi.mocked(Ollama.prototype.chat).mockRejectedValue(errorMock);
+      vi.mocked(Ollama.prototype.list).mockRejectedValue(new Error('fetch failed'));
+
+      const payload = {
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'model-id',
+      };
+
+      await expect(ollamaAI.chat(payload as any)).rejects.toEqual(
+        AgentRuntimeError.chat({
+          error: { message: 'please check whether your ollama service is available' },
+          errorType: AgentRuntimeErrorType.OllamaServiceUnavailable,
+          provider: ModelProvider.Ollama,
+        }),
+      );
+      expect(Ollama.prototype.list).toHaveBeenCalledOnce();
     });
 
     it('should handle error with string error field', async () => {

--- a/packages/model-runtime/src/providers/ollama/index.ts
+++ b/packages/model-runtime/src/providers/ollama/index.ts
@@ -92,23 +92,38 @@ export class LobeOllamaAI implements LobeRuntimeAI {
         name: string;
         status_code: number;
       };
-      if (e.message === 'fetch failed') {
+      const errorDetail = {
+        ...(typeof e.error !== 'string' ? e.error : undefined),
+        message: String(e.error?.message || e.message),
+        name: e.name,
+        status_code: e.status_code,
+      };
+
+      const fetchErrorMessage = e.message?.toLowerCase();
+      if (fetchErrorMessage === 'fetch failed' || fetchErrorMessage === 'failed to fetch') {
+        // A long-running chat request can fail even while the local Ollama service remains healthy.
+        // See https://github.com/lobehub/lobehub/issues/17316
+        try {
+          await this.client.list();
+        } catch {
+          throw AgentRuntimeError.chat({
+            error: {
+              message: 'please check whether your ollama service is available',
+            },
+            errorType: AgentRuntimeErrorType.OllamaServiceUnavailable,
+            provider: ModelProvider.Ollama,
+          });
+        }
+
         throw AgentRuntimeError.chat({
-          error: {
-            message: 'please check whether your ollama service is available',
-          },
-          errorType: AgentRuntimeErrorType.OllamaServiceUnavailable,
+          error: errorDetail,
+          errorType: AgentRuntimeErrorType.ProviderNetworkError,
           provider: ModelProvider.Ollama,
         });
       }
 
       throw AgentRuntimeError.chat({
-        error: {
-          ...(typeof e.error !== 'string' ? e.error : undefined),
-          message: String(e.error?.message || e.message),
-          name: e.name,
-          status_code: e.status_code,
-        },
+        error: errorDetail,
         errorType: AgentRuntimeErrorType.OllamaBizError,
         provider: ModelProvider.Ollama,
       });


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #17316

#### 🔀 Description of Change

Ollama chat failures reported as `fetch failed` or `Failed to fetch` were treated as evidence that the local Ollama service was unavailable. For slow local inference, the chat request can fail while Ollama is still running, which caused LobeHub to show the misleading installation guide.

This change:

- probes the Ollama model-list endpoint after an ambiguous fetch failure;
- reports `ProviderNetworkError` when Ollama remains reachable, reusing the existing retryable network/timeout error UI;
- preserves `OllamaServiceUnavailable` and the setup guide when the probe also fails;
- covers both Node and browser/Electron fetch error messages with regression tests.

The request timeout itself is unchanged.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check packages/model-runtime/src/providers/ollama/index.ts packages/model-runtime/src/providers/ollama/index.test.ts
```

Result: 57 related tests passed. The check reports two existing lint warnings in unchanged lines of the test file and no errors.

A repository-wide `bun run type-check` was also attempted, but it is currently blocked by unrelated baseline errors in other packages and generated files. Neither changed file appeared in that error output.

#### 📸 Screenshots / Videos

Not included. This reuses existing error UI, and the original Windows/Electron scenario has not been manually reproduced locally.

#### 📝 Additional Information

No dependency, API, configuration, or localization changes are included.