### PR TITLE
🐛 fix(git): scope linked PRs to remote owner

### DIFF
--- a/packages/local-file-shell/src/git/__tests__/info.test.ts
+++ b/packages/local-file-shell/src/git/__tests__/info.test.ts
@@ -25,6 +25,7 @@ const ok = (stdout: string) => ({ stderr: '', stdout });
 
 const PULL_REQUEST = {
   headRefName: 'feat/hetero-session-import-ui',
+  headRepositoryOwner: { login: 'lobehub' },
   isDraft: false,
   mergeStateStatus: 'CLEAN',
   mergeable: 'MERGEABLE',
@@ -60,12 +61,15 @@ interface ShellFixture {
   defaultBranch?: Record<string, string>;
   /** `gh pr list --head`. */
   prList?: unknown[];
+  /** `gh pr list` responses keyed by its exact `--head` value. */
+  prListsByHead?: Record<string, unknown[]>;
   /** `gh pr view <n>`. */
   prView?: unknown;
   /** Refs this repo pushed to — git writes `update by push` into their reflog. */
   pushedRefs?: string[];
   refsAt?: string[];
   remotes?: string[];
+  remoteUrls?: Record<string, string>;
   /** Remote refs a local branch tracks (`for-each-ref --format=%(upstream)`). */
   trackedRefs?: string[];
 }
@@ -88,16 +92,21 @@ const mockShell = ({
   commitPulls,
   defaultBranch = { origin: 'origin/canary' },
   prList = [],
+  prListsByHead,
   prView,
   pushedRefs = [],
   refsAt = [],
   remotes = ['origin'],
+  remoteUrls = { origin: 'https://github.com/lobehub/lobehub.git' },
   trackedRefs = [],
 }: ShellFixture) => {
   childProcessMocks.execFileAsync.mockImplementation(async (cmd: string, args: string[]) => {
     if (cmd === 'git') {
       const [subcommand] = args;
-      if (subcommand === 'remote') return ok(remotes.join('\n'));
+      if (subcommand === 'remote') {
+        if (args[1] === 'get-url') return ok(remoteUrls[args[2]] ?? '');
+        return ok(remotes.join('\n'));
+      }
       if (subcommand === 'merge-base') {
         // `--is-ancestor` reports through the exit status: 0 = contained, 1 = not.
         if (!commitOnDefault) throw Object.assign(new Error('not an ancestor'), { code: 1 });
@@ -125,7 +134,10 @@ const mockShell = ({
         if (!commitPulls) throw new Error('gh api failed');
         return ok(JSON.stringify(commitPulls));
       }
-      if (args[1] === 'list') return ok(JSON.stringify(prList));
+      if (args[1] === 'list') {
+        const head = args[args.indexOf('--head') + 1];
+        return ok(JSON.stringify(prListsByHead?.[head] ?? prList));
+      }
       if (args[1] === 'view') return ok(JSON.stringify(prView ?? {}));
     }
 
@@ -200,6 +212,31 @@ describe('getLinkedPullRequest', () => {
       branch: 'feat/hetero-session-import-ui',
       remote: 'origin',
     });
+  });
+
+  it('does not link a PR from another fork that uses the same branch name', async () => {
+    mockShell({
+      branchRef: 'sha1\torigin\trefs/remotes/origin/canary',
+      prListsByHead: {
+        canary: [
+          {
+            ...PULL_REQUEST,
+            headRefName: 'canary',
+            headRepositoryOwner: { login: 'another-fork' },
+            number: 17_244,
+          },
+        ],
+      },
+    });
+
+    const result = await getLinkedPullRequest({ branch: 'canary', path: '/repo' });
+
+    expect(result).toEqual({
+      pullRequest: null,
+      status: 'ok',
+      upstream: { branch: 'canary', remote: 'origin' },
+    });
+    expect(ghCalls().find((args) => args[1] === 'list')).toContain('canary');
   });
 
   it('recovers the PR by commit when the push left no local trace of the remote branch', async () => {

--- a/packages/local-file-shell/src/git/info.ts
+++ b/packages/local-file-shell/src/git/info.ts
@@ -14,7 +14,12 @@ import type {
   GitUpstreamRef,
   GitWorkingTreeStatus,
 } from './types';
-import { getDefaultRemote, isCommitSafeForPullRequestLookup, resolveUpstream } from './upstream';
+import {
+  getDefaultRemote,
+  getGithubRemoteOwner,
+  isCommitSafeForPullRequestLookup,
+  resolveUpstream,
+} from './upstream';
 
 const log = createLogger('local-file-shell:git');
 const execFileAsync = promisify(execFile);
@@ -28,6 +33,7 @@ type GithubStatusCheckRollupNode = {
 type GithubPullRequestPayload = {
   /** The PR's head branch ON GitHub — the authoritative remote ref for this branch. */
   headRefName?: string | null;
+  headRepositoryOwner?: { login?: string | null } | null;
   isDraft?: boolean;
   mergeable?: string | null;
   mergeStateStatus?: string | null;
@@ -41,7 +47,7 @@ type GithubPullRequestPayload = {
 };
 
 const GITHUB_PULL_REQUEST_FIELDS =
-  'number,url,title,state,isDraft,mergeable,mergeStateStatus,mergedAt,reviewDecision,statusCheckRollup,headRefName';
+  'number,url,title,state,isDraft,mergeable,mergeStateStatus,mergedAt,reviewDecision,statusCheckRollup,headRefName,headRepositoryOwner';
 
 const failureConclusions = new Set([
   'action_required',
@@ -203,8 +209,9 @@ const toUpstreamRef = async (
  * The PR linked to a branch, resolved cheapest-signal-first:
  *
  * 1. a saved PR number → `gh pr view` (the strongest link once one is known);
- * 2. the branch's REMOTE ref → `gh pr list --head`, including merged/closed PRs so
- *    stale topic snapshots refresh lifecycle state after GitHub changes outside the app;
+ * 2. the branch's REMOTE ref → `gh pr list --head`, filtered by head-repository
+ *    owner, including merged/closed PRs so stale topic snapshots refresh lifecycle
+ *    state after GitHub changes outside the app;
  * 3. nothing found and no remote ref was ever established → `gh` commit→PR lookup.
  *
  * Step 2 is the fix for the bug this chain existed to have: the head passed to
@@ -251,23 +258,32 @@ export const getLinkedPullRequest = async (payload: {
       };
     }
 
+    const queryBranch = localUpstream?.branch ?? branch;
+
     const { stdout } = await execFileAsync(
       'gh',
       [
         'pr',
         'list',
         '--head',
-        localUpstream?.branch ?? branch,
+        queryBranch,
         '--state',
         'all',
         '--limit',
-        '5',
+        '100',
         '--json',
         GITHUB_PULL_REQUEST_FIELDS,
       ],
       { cwd: dirPath, timeout: 8000 },
     );
-    const parsed = JSON.parse(stdout.trim() || '[]') as GithubPullRequestPayload[];
+    const candidates = JSON.parse(stdout.trim() || '[]') as GithubPullRequestPayload[];
+    const queryRemote = localUpstream?.remote ?? (await getDefaultRemote(dirPath));
+    const queryOwner = queryRemote ? await getGithubRemoteOwner(dirPath, queryRemote) : undefined;
+    const parsed = queryOwner
+      ? candidates
+          .filter((pr) => pr.headRepositoryOwner?.login?.toLowerCase() === queryOwner.toLowerCase())
+          .slice(0, 5)
+      : [];
 
     if (parsed.length > 0) {
       const [primaryRaw, ...rest] = parsed;

--- a/packages/local-file-shell/src/git/upstream.ts
+++ b/packages/local-file-shell/src/git/upstream.ts
@@ -268,6 +268,23 @@ export const getDefaultRemote = async (dirPath: string): Promise<string | undefi
   return remotes[0];
 };
 
+/** GitHub owner of a configured remote, for disambiguating same-named fork branches. */
+export const getGithubRemoteOwner = async (
+  dirPath: string,
+  remote: string,
+): Promise<string | undefined> => {
+  const remoteUrl = (await runGit(['remote', 'get-url', remote], dirPath))?.trim();
+  if (!remoteUrl) return undefined;
+
+  try {
+    const url = new URL(remoteUrl);
+    if (url.hostname.toLowerCase() !== 'github.com') return undefined;
+    return url.pathname.split('/').find(Boolean);
+  } catch {
+    return /^(?:[^@/]+@)?github\.com:([^/]+)\//i.exec(remoteUrl)?.[1];
+  }
+};
+
 /** Exit-status-only probe — `runGit` cannot tell success-with-no-output from failure. */
 const gitSucceeds = async (args: string[], cwd: string): Promise<boolean> => {
   try {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No matching issue found.

#### 🔀 Description of Change

Linked-PR discovery previously queried `gh pr list --head <branch>` and selected the first result. GitHub applies that filter across fork owners, so a common branch such as `canary` could incorrectly link a contributor fork's PR to the local `lobehub/lobehub:canary` checkout.

This change reads the GitHub owner from the branch's resolved Git remote, requests `headRepositoryOwner` from `gh`, and filters candidates by that owner before selecting the primary PR. It retains remote-branch resolution, merged/closed PR refreshes, and commit-based fallback behavior. The wider candidate limit allows owner filtering without losing the existing five-result display cap.

#### 🧪 How to Test

- Run `bun run check packages/local-file-shell/src/git/info.ts packages/local-file-shell/src/git/upstream.ts packages/local-file-shell/src/git/__tests__/info.test.ts`
- Verify a bare `canary` query containing a PR from another fork resolves to no linked PR for the `lobehub` remote owner
- Verify a matching `lobehub` head repository still resolves normally

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

Not applicable; this changes linked-PR discovery behavior without changing UI layout.

#### 📝 Additional Information

`gh pr list --head` does not support `<owner>:<branch>` syntax, so filtering is performed against the returned `headRepositoryOwner` instead.
