### PR TITLE
✅ test(cli): replace vi.mock with vi.spyOn in file/shell tool tests

### DIFF
--- a/apps/cli/src/tools/file.test.ts
+++ b/apps/cli/src/tools/file.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { log } from '../utils/logger';
 import {
   editLocalFile,
   globLocalFiles,
@@ -15,23 +16,19 @@ import {
   writeLocalFile,
 } from './file';
 
-vi.mock('../utils/logger', () => ({
-  log: {
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  },
-}));
-
 describe('file tools (integration wrapper)', () => {
   const tmpDir = path.join(os.tmpdir(), 'cli-file-test-' + process.pid);
 
   beforeEach(async () => {
+    vi.spyOn(log, 'debug').mockImplementation(() => {});
+    vi.spyOn(log, 'error').mockImplementation(() => {});
+    vi.spyOn(log, 'info').mockImplementation(() => {});
+    vi.spyOn(log, 'warn').mockImplementation(() => {});
     await mkdir(tmpDir, { recursive: true });
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     fs.rmSync(tmpDir, { force: true, recursive: true });
   });
 

--- a/apps/cli/src/tools/shell.test.ts
+++ b/apps/cli/src/tools/shell.test.ts
@@ -1,18 +1,18 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { log } from '../utils/logger';
 import { cleanupAllProcesses, getCommandOutput, killCommand, runCommand } from './shell';
 
-vi.mock('../utils/logger', () => ({
-  log: {
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  },
-}));
-
 describe('shell tools (integration wrapper)', () => {
+  beforeEach(() => {
+    vi.spyOn(log, 'debug').mockImplementation(() => {});
+    vi.spyOn(log, 'error').mockImplementation(() => {});
+    vi.spyOn(log, 'info').mockImplementation(() => {});
+    vi.spyOn(log, 'warn').mockImplementation(() => {});
+  });
+
   afterEach(() => {
+    vi.restoreAllMocks();
     cleanupAllProcesses();
   });
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✅ test

#### 🔗 Related Issue

Part of #16480.

#### 🔀 Description of Change

Converts `apps/cli/src/tools/file.test.ts` and `shell.test.ts` from a full-module `vi.mock('../utils/logger')` to `vi.spyOn` on the real logger, restored in `afterEach`.

Side note: spying on the real module surfaced that these suites previously only loaded because the mock hid the logger's `picocolors` import — with `vi.spyOn` the real dependency chain is exercised.

#### 🧪 How to Test

`cd apps/cli && npx vitest run src/tools/file.test.ts src/tools/shell.test.ts` — 12 tests pass.