### PR TITLE
🐛 fix(agent-runtime): don't trust output tokens as proof of a non-empty completion

### DIFF
--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.ts
@@ -277,6 +277,7 @@ export class ServerCallLlmAttempt {
     if (
       isEmptyModelCompletion({
         content: this.streamSink.content,
+        hasGrounding: !!this.grounding,
         imageCount: this.imageList.length,
         outputTokens: this.usage?.totalOutputTokens,
         reasoning: this.streamSink.thinkingContent,

--- a/packages/model-runtime/src/errors/modelEmptyCompletion.test.ts
+++ b/packages/model-runtime/src/errors/modelEmptyCompletion.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { isEmptyModelCompletion } from './modelEmptyCompletion';
+
+describe('isEmptyModelCompletion', () => {
+  const base = {
+    content: '',
+    imageCount: 0,
+    outputTokens: 0,
+    reasoning: '',
+    toolCallCount: 0,
+  };
+
+  it('treats a turn with real text content as non-empty', () => {
+    expect(isEmptyModelCompletion({ ...base, content: 'hello' })).toBe(false);
+  });
+
+  it('treats a reasoning-only turn as non-empty', () => {
+    expect(isEmptyModelCompletion({ ...base, reasoning: 'thinking...' })).toBe(false);
+  });
+
+  it('treats a tool-call turn as non-empty', () => {
+    expect(isEmptyModelCompletion({ ...base, toolCallCount: 1 })).toBe(false);
+  });
+
+  it('treats an image turn as non-empty', () => {
+    expect(isEmptyModelCompletion({ ...base, imageCount: 1 })).toBe(false);
+  });
+
+  it('flags a truly blank turn (no content, ~0 output tokens) as empty', () => {
+    expect(isEmptyModelCompletion({ ...base, outputTokens: 1 })).toBe(true);
+  });
+
+  it('flags a blank turn with undefined output tokens as empty', () => {
+    expect(isEmptyModelCompletion({ ...base, outputTokens: undefined })).toBe(true);
+  });
+
+  // The regression this guard closes: a post-tool answer turn where the model
+  // generated tens of thousands of output tokens but the streamed text was
+  // dropped before it reached `content`. Without a grounding signal, a high
+  // output-token count must NOT be trusted as a real reply — otherwise the turn
+  // silently finalizes to `done` with a blank, still-billed assistant message.
+  it('flags empty content with high output tokens as empty when no grounding is present', () => {
+    expect(
+      isEmptyModelCompletion({ ...base, outputTokens: 25_220, reasoning: '', content: '' }),
+    ).toBe(true);
+  });
+
+  it('does not flag empty content with high output tokens when grounding IS present', () => {
+    // Grounding/citation metadata legitimately consumes tokens without emitting
+    // text we accumulate — keep the original escape hatch for that case only.
+    expect(isEmptyModelCompletion({ ...base, outputTokens: 25_220, hasGrounding: true })).toBe(
+      false,
+    );
+  });
+
+  it('ignores grounding when it did not consume output tokens', () => {
+    expect(isEmptyModelCompletion({ ...base, outputTokens: 1, hasGrounding: true })).toBe(true);
+  });
+});

--- a/packages/model-runtime/src/errors/modelEmptyCompletion.ts
+++ b/packages/model-runtime/src/errors/modelEmptyCompletion.ts
@@ -62,22 +62,36 @@ const EMPTY_COMPLETION_MAX_OUTPUT_TOKENS = 1;
  */
 export const isEmptyModelCompletion = (params: {
   content: string;
+  hasGrounding?: boolean;
   imageCount: number;
   outputTokens: number | undefined;
   reasoning: string;
   toolCallCount: number;
 }): boolean => {
-  const { content, reasoning, toolCallCount, imageCount, outputTokens } = params;
+  const { content, reasoning, toolCallCount, imageCount, outputTokens, hasGrounding } = params;
 
   if (content.trim().length > 0) return false;
   if (reasoning.trim().length > 0) return false;
   if (toolCallCount > 0) return false;
   if (imageCount > 0) return false;
 
-  // When the provider reports output tokens, only treat as empty if it's ~0.
-  // Guards against rare cases where structured output we don't accumulate into
-  // `content`/`reasoning` here (e.g. grounding) still consumed real tokens.
-  if (typeof outputTokens === 'number' && outputTokens > EMPTY_COMPLETION_MAX_OUTPUT_TOKENS) {
+  // A turn can legitimately burn output tokens without producing any text we
+  // accumulate into `content`/`reasoning` — grounding/citation metadata is the
+  // known case. Only *that* signal justifies treating a positive token count as
+  // a non-empty completion.
+  //
+  // A high output-token count WITHOUT such a signal is not proof of a real
+  // reply — it means the model generated text we failed to capture (e.g. a
+  // post-tool answer turn whose streamed content was dropped by the sink). If we
+  // trusted the token count there, we would silently finalize to `done` with a
+  // blank assistant message the user still gets billed for. So we only take the
+  // token escape hatch when a real no-text output signal is present; otherwise
+  // fall through to `empty` and let the caller retry.
+  if (
+    hasGrounding &&
+    typeof outputTokens === 'number' &&
+    outputTokens > EMPTY_COMPLETION_MAX_OUTPUT_TOKENS
+  ) {
     return false;
   }
 

--- a/src/store/chat/agents/transports/ClientLLMTransport.test.ts
+++ b/src/store/chat/agents/transports/ClientLLMTransport.test.ts
@@ -1,0 +1,125 @@
+import { ModelEmptyError } from '@lobechat/model-runtime';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ChatStore } from '../../store';
+import { ClientLLMTransport } from './ClientLLMTransport';
+
+// A grounding-only completion streams no text into `content`, but carries
+// citation metadata and burns real output tokens. The stream (driven via
+// `chatService.getChatCompletion`) finishes with `grounding` + `usage`, and the
+// StreamingHandler surfaces the grounding as `metadata.search`.
+const grounding = { citations: ['https://example.com'] } as any;
+const usage = { totalOutputTokens: 25_220 } as any;
+
+let finishGrounding: unknown = grounding;
+
+vi.mock('@/services/chat', () => ({
+  chatService: {
+    getChatCompletion: vi.fn(async (_params: any, options: any) => {
+      await options.onFinish?.('', {
+        grounding: finishGrounding,
+        traceId: 'trace-1',
+        type: 'stop',
+        usage,
+      });
+    }),
+  },
+}));
+
+vi.mock('@/store/file/store', () => ({ getFileStoreState: () => ({}) }));
+
+vi.mock('../StreamingHandler', () => ({
+  StreamingHandler: class {
+    handleFinish(finishData: any) {
+      return {
+        content: '',
+        finishType: finishData.type,
+        isFunctionCall: false,
+        metadata: { search: finishData.grounding ?? undefined, usage: finishData.usage },
+        toolCalls: [],
+        tools: [],
+        usage: finishData.usage,
+      };
+    }
+    getOutput() {
+      return '';
+    }
+    getThinkingContent() {
+      return '';
+    }
+    getContentParts() {
+      return [];
+    }
+    getReasoningParts() {
+      return [];
+    }
+    handleChunk() {}
+    hasContentImages() {
+      return false;
+    }
+    hasReasoningImages() {
+      return false;
+    }
+  },
+}));
+
+const createTransport = () => {
+  const operation = {
+    abortController: new AbortController(),
+    context: { agentId: 'agent-1', topicId: 'topic-1' },
+    status: 'running',
+  };
+  const store = {
+    associateMessageWithOperation: vi.fn(),
+    completeOperation: vi.fn(),
+    internal_dispatchMessage: vi.fn(),
+    internal_toggleToolCallingStreaming: vi.fn(),
+    internal_transformToolCalls: vi.fn((calls: unknown) => calls),
+    operations: { 'op-1': operation },
+    startOperation: vi.fn(() => ({ operationId: 'reasoning-op' })),
+  } as unknown as ChatStore;
+
+  return new ClientLLMTransport({
+    get: () => store,
+    operationId: 'op-1',
+    session: { assistantMessageId: 'msg-1' } as any,
+  });
+};
+
+const input = {
+  attempt: 1,
+  context: {
+    messages: [],
+    modelParameters: { options: {}, params: {} },
+    resolvedTools: { tools: [] },
+  },
+  events: [],
+  maxAttempts: 3,
+  model: 'gpt-5.6-sol',
+  provider: 'lobehub',
+  state: {},
+} as any;
+
+describe('ClientLLMTransport.runAttempt · empty-completion grounding guard', () => {
+  beforeEach(() => {
+    finishGrounding = grounding;
+  });
+
+  it('keeps a grounding-only completion (empty content, positive output tokens) as a success', async () => {
+    finishGrounding = grounding;
+    const result = await createTransport().runAttempt(input);
+
+    expect(result.ok).toBe(true);
+    expect(result.output.grounding).toEqual(grounding);
+  });
+
+  it('still flags a truly empty completion (no content, no grounding) as ModelEmptyError', async () => {
+    finishGrounding = null;
+    const result = await createTransport().runAttempt(input);
+
+    expect(result.ok).toBe(false);
+    if (result.ok === false) {
+      expect(result.error).toBeInstanceOf(ModelEmptyError);
+    }
+  });
+});

--- a/src/store/chat/agents/transports/ClientLLMTransport.ts
+++ b/src/store/chat/agents/transports/ClientLLMTransport.ts
@@ -307,6 +307,7 @@ export class ClientLLMTransport implements LLMTransport {
     if (
       isEmptyModelCompletion({
         content: output.content,
+        hasGrounding: !!output.grounding,
         imageCount: output.imageList.length + (output.hasContentImages ? 1 : 0),
         outputTokens: output.usage?.totalOutputTokens,
         reasoning: output.thinkingContent,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix

#### 🔀 变更说明 | Description of Change

**Problem**: A new user ran a multi-step "server deployment" task inside a single topic and drained their entire $30 balance without finishing. Investigation showed that any `call_llm` turn that runs (parallel) tool calls and then generates the final answer **within the same operation** persisted its answer text as `content=''` (an empty bubble) — even though the model actually produced 11k–25k output tokens and billed for them.

The discriminator is 100% clean: a `call_llm` at the START step (or right after another `call_llm`) persists its content fine; only when the previous step is a same-operation `call_tool` does the answer text get lost. Seeing an empty bubble, the user kept re-asking ("where's the answer?"), and each re-ask forked a fresh operation that re-prefilled the whole (by then 500k–900k token) context — snowballing into the runaway bill.

**What this PR fixes**: There is already a backstop — `assertNonEmptyCompletion()` → `isEmptyModelCompletion()` — that should throw `ModelEmptyError` on an empty turn so the caller retries (a retry usually recovers the real content). But that check had an escape hatch: any turn reporting `outputTokens > 1` was treated as non-empty and not retried. That escape hatch was added for grounding / structured output (tokens consumed but no text we accumulate), yet it also waved through this lost-content bug — so the turn silently finalized to `done` with a blank, still-billed assistant message.

Change: scope the token escape hatch to turns that carry a genuine no-text output signal (grounding). Without such a signal, a high output-token count with empty content is treated as empty, so the caller retries instead of committing an empty message.

> This is a new instance of the "post-tool answer collapse / empty shell" bug family, this time on the **server-side durable runtime** path. This PR is the safety-net layer (stop the bleeding + trigger a retry). The deeper root cause — why the answer text is dropped before reaching the stream sink on post-tool turns — will be tracked separately.

#### 📝 补充信息 | Additional Information

- Adds `packages/model-runtime/src/errors/modelEmptyCompletion.test.ts` (9 cases, including the regression: `outputTokens: 25220` + empty content + no grounding ⇒ flagged empty).
- The single call site in `serverCallLlmAttempt.ts` now passes `hasGrounding: !!this.grounding`.