### PR TITLE
🐛 fix(swr): serve cached message list on topic switch without waiting for network

### DIFF
--- a/src/libs/swr/useClientDataSWRWithSync.race.test.tsx
+++ b/src/libs/swr/useClientDataSWRWithSync.race.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Guards the store-sync contract of `useClientDataSWRWithSync`.
+ *
+ * This is the exact path that drives the conversation `messagesInit` gate:
+ *   ChatList → useFetchMessages → useClientDataSWRWithSync(key, fetcher, { onData })
+ *   onData sets `messagesInit: true`.
+ * SWR fires `onSuccess` only for a completed network fetch (with the fetched
+ * value), never for a cache hit — so `onData` must be driven from `response.data`.
+ * A switch to a topic whose messages are already in the SWR cache must fire
+ * `onData` from cache — otherwise the skeleton stays up until the network fetch
+ * lands (cached data not shown first). A single `data`-keyed effect does this
+ * with no two-effect ordering race and no render-phase write.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createElement, type PropsWithChildren, StrictMode } from 'react';
+import { type Cache, SWRConfig, unstable_serialize } from 'swr';
+import useSWR from 'swr';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createStore, useStore } from 'zustand';
+
+import { useClientDataSWRWithSync } from './useClientDataSWRWithSync';
+
+const KEY_A = ['message:list', 'topic-A'];
+const KEY_B = ['message:list', 'topic-B'];
+const DATA_A = [{ id: 'a1' }];
+const DATA_B = [{ id: 'b1' }];
+
+// A single shared SWR cache Map, mimicking the app-level tiered provider once it
+// has been hydrated from IndexedDB (data is present synchronously).
+const makeSharedProvider = () => {
+  const map = new Map<string, unknown>();
+  return { map, provider: () => map };
+};
+
+const wrapper =
+  (provider: () => Map<string, unknown>, strict = false) =>
+  ({ children }: PropsWithChildren) => {
+    const tree = createElement(
+      SWRConfig,
+      { value: { provider: provider as unknown as (c: Readonly<Cache>) => Cache } },
+      children,
+    );
+    return strict ? createElement(StrictMode, null, tree) : tree;
+  };
+
+// Warm the shared cache for a key by running one real fetch through SWR, then
+// unmounting. The provider Map keeps the entry afterwards.
+const warm = async (provider: () => Map<string, unknown>, key: unknown, data: unknown) => {
+  const r = renderHook(() => useSWR(key, () => Promise.resolve(data)), {
+    wrapper: wrapper(provider),
+  });
+  await waitFor(() => expect(r.result.current.data).toEqual(data));
+  r.unmount();
+};
+
+const neverFetch = () => new Promise<any>(() => {});
+
+describe('useClientDataSWRWithSync — cache-first store sync', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('serves both topics synchronously from the warmed provider (sanity)', async () => {
+    const { map, provider } = makeSharedProvider();
+    await warm(provider, KEY_A, DATA_A);
+    await warm(provider, KEY_B, DATA_B);
+
+    expect(map.has(unstable_serialize(KEY_A))).toBe(true);
+    expect(map.has(unstable_serialize(KEY_B))).toBe(true);
+  });
+
+  it('fires onData for cached data immediately on a topic switch (no network)', async () => {
+    const { provider } = makeSharedProvider();
+    await warm(provider, KEY_A, DATA_A);
+    await warm(provider, KEY_B, DATA_B);
+
+    const synced: unknown[] = [];
+
+    // Mimic the real call site: a fresh `onData` closure every render (it is an
+    // inline arrow in the store action).
+    const { rerender } = renderHook(
+      ({ key }: { key: unknown }) =>
+        useClientDataSWRWithSync<any>(key, neverFetch, {
+          onData: (data) => synced.push(data),
+        }),
+      { initialProps: { key: KEY_A as unknown }, wrapper: wrapper(provider) },
+    );
+
+    // Topic A synced from cache.
+    expect(synced).toContainEqual(DATA_A);
+
+    // Extra renders on A — the old two-effect version left a `hasSyncedRef` at
+    // `true` here, which then dropped the switch. The data-keyed effect must not.
+    act(() => rerender({ key: KEY_A }));
+    act(() => rerender({ key: KEY_A }));
+
+    const before = synced.length;
+
+    // Switch to topic B (already cached). onData(DATA_B) must fire from cache,
+    // WITHOUT the never-resolving fetcher ever completing.
+    act(() => rerender({ key: KEY_B }));
+    expect(synced.slice(before)).toContainEqual(DATA_B);
+  });
+
+  it('does not re-fire onData for a stable cached snapshot across re-renders', async () => {
+    const { provider } = makeSharedProvider();
+    await warm(provider, KEY_A, DATA_A);
+
+    const onData = vi.fn();
+    const { rerender } = renderHook(
+      () => useClientDataSWRWithSync<any>(KEY_A, neverFetch, { onData }),
+      { wrapper: wrapper(provider) },
+    );
+
+    expect(onData).toHaveBeenCalledTimes(1);
+    act(() => rerender());
+    act(() => rerender());
+    // Same key, same cached reference → no duplicate deliveries.
+    expect(onData).toHaveBeenCalledTimes(1);
+  });
+
+  it('delivers cached data exactly once under StrictMode double-invoke', async () => {
+    const { provider } = makeSharedProvider();
+    await warm(provider, KEY_A, DATA_A);
+
+    const onData = vi.fn();
+    renderHook(() => useClientDataSWRWithSync<any>(KEY_A, neverFetch, { onData }), {
+      wrapper: wrapper(provider, true),
+    });
+
+    await waitFor(() => expect(onData).toHaveBeenCalled());
+    expect(onData).toHaveBeenCalledTimes(1);
+    expect(onData).toHaveBeenCalledWith(DATA_A);
+  });
+
+  it('is safe to sync into a real zustand store (no update-in-render warning)', async () => {
+    const { provider } = makeSharedProvider();
+    await warm(provider, KEY_A, DATA_A);
+
+    // A real external store consumed via useSyncExternalStore, exactly like the
+    // conversation store: onData flips a store flag, a subscriber re-reads it.
+    const store = createStore<{ init: boolean; setInit: (v: boolean) => void }>((set) => ({
+      init: false,
+      setInit: (v) => set({ init: v }),
+    }));
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const useHarness = () => {
+      const init = useStore(store, (s) => s.init);
+      useClientDataSWRWithSync<any>(KEY_A, neverFetch, {
+        onData: () => store.getState().setInit(true),
+      });
+      return init;
+    };
+
+    const { result } = renderHook(useHarness, { wrapper: wrapper(provider, true) });
+
+    await waitFor(() => expect(result.current).toBe(true));
+
+    const updateInRenderWarning = errorSpy.mock.calls.find((args) =>
+      String(args[0]).includes('Cannot update a component'),
+    );
+    expect(updateInRenderWarning).toBeUndefined();
+  });
+});

--- a/src/libs/swr/useClientDataSWRWithSync.ts
+++ b/src/libs/swr/useClientDataSWRWithSync.ts
@@ -7,6 +7,18 @@
  * Persistence (localStorage vs IndexedDB) is handled transparently by the
  * tier-aware SWR cache provider (see `localStorageProvider.ts`) based on the
  * SWR key — consumers never need to opt in per call.
+ *
+ * Why a `data`-keyed effect and not `onSuccess` alone: SWR only fires
+ * `onSuccess` when a *network fetch* resolves, and with the *fetched* value — it
+ * never fires for a cache hit (verified: a warm cache serves `response.data`
+ * synchronously while `onSuccess` stays at 0 calls, and with
+ * `revalidateIfStale: false` it never fires at all). So the cached snapshot can
+ * only reach the store by reading `response.data`. We do that in one effect
+ * deduped on the data reference: a key change yields a new data reference and
+ * re-syncs automatically, so there is no second "reset on key change" effect to
+ * order against — that two-effect ordering was the original skeleton-stuck bug.
+ * An effect (not a render-phase write) keeps this safe under concurrent React,
+ * where a render can be discarded before commit.
  */
 
 import { useEffect, useRef } from 'react';
@@ -51,36 +63,24 @@ export function useClientDataSWRWithSync<T>(
   fetcher: (() => Promise<T>) | null,
   options?: UseClientDataSWRWithSyncOptions<T>,
 ): SWRResponse<T> {
-  const { onData, skipSync, onSuccess, ...swrOptions } = options || {};
-  const hasSyncedRef = useRef(false);
+  const { onData, skipSync, ...swrOptions } = options || {};
 
-  const response = useClientDataSWR<T>(key, fetcher, {
-    ...swrOptions,
-    onSuccess: (data, key, config) => {
-      // Call original onSuccess
-      onSuccess?.(data, key, config);
-      // Also sync via onData
-      if (onData && !skipSync) {
-        onData(data);
-        hasSyncedRef.current = true;
-      }
-    },
-  });
+  const response = useClientDataSWR<T>(key, fetcher, swrOptions);
 
   const { data } = response;
 
-  // When cached data is available, sync to store immediately
+  // Single source of delivery, keyed on the data reference. Covers both a cache
+  // hit (data present on mount / after a key switch) and a fresh fetch (data
+  // reference changes when SWR commits the new value). Dedupe on the reference
+  // so a stable snapshot / re-render never re-fires, and StrictMode's double
+  // effect invoke delivers exactly once.
+  const syncedDataRef = useRef<T | undefined>(undefined);
   useEffect(() => {
-    if (data && onData && !skipSync && !hasSyncedRef.current) {
-      onData(data);
-      hasSyncedRef.current = true;
-    }
-  }, [data, onData, skipSync]);
-
-  // Reset sync state when key changes
-  useEffect(() => {
-    hasSyncedRef.current = false;
-  }, [key?.toString()]);
+    if (data === undefined || skipSync || !onData) return;
+    if (syncedDataRef.current === data) return;
+    syncedDataRef.current = data;
+    onData(data);
+  }, [data, skipSync, onData]);
 
   return response;
 }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

Switching to a topic whose messages are already cached still showed a skeleton for the full duration of a network round-trip, instead of painting the cached data first.

Root cause is in `useClientDataSWRWithSync`. SWR only fires `onSuccess` when a **network fetch** completes (with the fetched value) — it never fires for a cache hit (verified: a warm cache serves `response.data` synchronously while `onSuccess` stays at 0 calls; with `revalidateIfStale: false` it never fires at all). So the cached snapshot reached the store only through a `useEffect` reading `response.data`, deduped by a `hasSyncedRef` boolean that a **second** effect reset on key change. The reset effect was declared *after* the sync effect, so on a topic switch the sync effect ran first, read the previous topic's stale `true`, and **dropped the already-cached data** — leaving the surface on a skeleton (`messagesInit` never flips) until the network revalidation landed.

Fix: collapse the two effects into **one**, keyed on the data reference. A key change yields a new data reference and re-syncs automatically, so there is no second effect to race against (that two-effect ordering was the bug). Delivery stays in an effect rather than a render-phase write, keeping it safe under concurrent React where a render can be discarded before commit. The caller's own `onSuccess` is now forwarded to SWR natively.

Behavior is otherwise unchanged: cached data is still delivered to the store, exactly as before — only the switch-time race is removed.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

New regression tests in `src/libs/swr/useClientDataSWRWithSync.race.test.tsx`:
- fires `onData` for cached data immediately on a topic switch (never-resolving fetcher ⇒ proves it comes from cache, not network)
- does not re-fire `onData` for a stable cached snapshot across re-renders
- delivers cached data exactly once under StrictMode double-invoke
- safe to sync into a real zustand store (no "update during render" warning)

Regression suite green (123 tests): `cacheProvider.integration`, `Conversation/store/slices/data/action`, `ConversationProvider`, `store/chat/slices/message/action`, `store/home/slices/recent/action`. `bun run check` clean.

#### 📝 Additional Information

A residual ~1-frame skeleton flash on switch remains, but it comes from `StoreUpdater` resetting `messagesInit` in a `useLayoutEffect` on context change — a separate layer, out of scope here.