### PR TITLE
💄 fix(acceptance): inline send-back drafts into composer; keep pending evidence expanded

### DIFF
--- a/locales/en-US/verify.json
+++ b/locales/en-US/verify.json
@@ -28,6 +28,7 @@
   "acceptance.bar.progressZero": "{{total}} checks awaiting your review",
   "acceptance.bar.rejectComment": "Reject with comment",
   "acceptance.bar.rerun": "Send back & rerun",
+  "acceptance.bar.rerunDrafted": "Drafted into your composer — review and send it.",
   "acceptance.bar.rerunSent": "Sent to the origin conversation — the repair round is starting.",
   "acceptance.checks.copied": "Copied",
   "acceptance.checks.copySeq": "Copy the check label",

--- a/locales/zh-CN/verify.json
+++ b/locales/zh-CN/verify.json
@@ -28,6 +28,7 @@
   "acceptance.bar.progressZero": "共 {{total}} 项等待你的验收",
   "acceptance.bar.rejectComment": "评论并打回",
   "acceptance.bar.rerun": "打回重跑",
+  "acceptance.bar.rerunDrafted": "已填入对话框，检查后发送。",
   "acceptance.bar.rerunSent": "已发送到源会话，修复轮次启动中。",
   "acceptance.checks.copied": "已复制",
   "acceptance.checks.copySeq": "复制检查项序号",

--- a/packages/locales/src/default/verify.ts
+++ b/packages/locales/src/default/verify.ts
@@ -36,6 +36,7 @@ export default {
   'acceptance.bar.progressZero': '{{total}} checks awaiting your review',
   'acceptance.bar.rejectComment': 'Reject with comment',
   'acceptance.bar.rerun': 'Send back & rerun',
+  'acceptance.bar.rerunDrafted': 'Drafted into your composer — review and send it.',
   'acceptance.bar.rerunSent': 'Sent to the origin conversation — the repair round is starting.',
   'acceptance.checks.copied': 'Copied',
   'acceptance.checks.copySeq': 'Copy the check label',

--- a/src/features/Portal/Acceptance/Body.test.tsx
+++ b/src/features/Portal/Acceptance/Body.test.tsx
@@ -1,0 +1,58 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import Body from './Body';
+
+const mocks = vi.hoisted(() => ({
+  captured: { onDraftToComposer: undefined as undefined | ((text: string) => boolean) },
+  editor: { focus: vi.fn(), setDocument: vi.fn() } as { focus: any; setDocument: any } | null,
+  state: {} as { editor: unknown; updateInputMessage: (m: string) => void },
+  updateInputMessage: vi.fn(),
+}));
+
+vi.mock('@/store/chat', () => ({
+  useChatStore: (selector: (s: unknown) => unknown) => selector({}),
+}));
+
+vi.mock('@/store/chat/selectors', () => ({
+  chatPortalSelectors: { acceptancePortalId: () => 'acc-1' },
+}));
+
+vi.mock('@/features/Conversation/store', () => ({
+  useConversationStore: (selector: (s: typeof mocks.state) => unknown) => selector(mocks.state),
+}));
+
+vi.mock('@/features/Verify', () => ({
+  AcceptanceViewer: (props: { onDraftToComposer?: (text: string) => boolean }) => {
+    mocks.captured.onDraftToComposer = props.onDraftToComposer;
+    return null;
+  },
+}));
+
+describe('Portal Acceptance Body — draftToComposer', () => {
+  it('drafts into the composer AND syncs inputMessage so Send enables', () => {
+    const editor = { focus: vi.fn(), setDocument: vi.fn() };
+    mocks.state = { editor, updateInputMessage: mocks.updateInputMessage };
+    render(<Body />);
+
+    const ok = mocks.captured.onDraftToComposer?.('please fix X');
+
+    expect(ok).toBe(true);
+    expect(editor.setDocument).toHaveBeenCalledWith('markdown', 'please fix X');
+    // P1 regression: setDocument alone does not fire the change handler, leaving
+    // Send disabled — the owning input state must be synced explicitly.
+    expect(mocks.updateInputMessage).toHaveBeenCalledWith('please fix X');
+    expect(editor.focus).toHaveBeenCalled();
+  });
+
+  it('reports failure (so the caller skips its toast) when no composer is mounted', () => {
+    mocks.updateInputMessage.mockClear();
+    mocks.state = { editor: null, updateInputMessage: mocks.updateInputMessage };
+    render(<Body />);
+
+    const ok = mocks.captured.onDraftToComposer?.('please fix X');
+
+    expect(ok).toBe(false);
+    expect(mocks.updateInputMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/Portal/Acceptance/Body.tsx
+++ b/src/features/Portal/Acceptance/Body.tsx
@@ -1,13 +1,33 @@
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 
+import { useConversationStore } from '@/features/Conversation/store';
 import { AcceptanceViewer } from '@/features/Verify';
 import { useChatStore } from '@/store/chat';
 import { chatPortalSelectors } from '@/store/chat/selectors';
 
 const Body = memo(() => {
   const acceptanceId = useChatStore(chatPortalSelectors.acceptancePortalId);
+  // The portal renders beside the live conversation composer (inside its
+  // ConversationProvider), so a send-back can draft straight into that composer.
+  const editor = useConversationStore((s) => s.editor);
+  const updateInputMessage = useConversationStore((s) => s.updateInputMessage);
 
-  return <AcceptanceViewer acceptanceId={acceptanceId} />;
+  // Draft text into the composer AND sync ConversationStore.inputMessage — the
+  // send button reads that field, and `editor.setDocument` alone does not fire
+  // the change handler that keeps it in sync (see restoreToInput). Returns false
+  // when the composer isn't mounted so the caller can skip its success toast.
+  const draftToComposer = useCallback(
+    (text: string) => {
+      if (!editor) return false;
+      editor.setDocument('markdown', text);
+      updateInputMessage(text);
+      editor.focus();
+      return true;
+    },
+    [editor, updateInputMessage],
+  );
+
+  return <AcceptanceViewer acceptanceId={acceptanceId} onDraftToComposer={draftToComposer} />;
 });
 
 export default Body;

--- a/src/features/Verify/Acceptance/expandState.test.ts
+++ b/src/features/Verify/Acceptance/expandState.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { setAggregateEntry } from './expandState';
+
+describe('setAggregateEntry', () => {
+  // P2 regression: writing one aggregate's set must not wipe another's, so
+  // switching acceptances in the portal and returning keeps each one's toggles.
+  it('keeps each aggregate’s set isolated', () => {
+    let map = new Map<string, Set<string>>();
+    map = setAggregateEntry(map, 'A', new Set(['a1']));
+    map = setAggregateEntry(map, 'B', new Set(['b1']));
+
+    expect([...(map.get('A') ?? [])]).toEqual(['a1']);
+    expect([...(map.get('B') ?? [])]).toEqual(['b1']);
+  });
+
+  it('applies updater functions against the current aggregate entry', () => {
+    let map = new Map<string, Set<string>>([['A', new Set(['a1'])]]);
+    map = setAggregateEntry(map, 'A', (prev) => new Set(prev).add('a2'));
+
+    expect([...(map.get('A') ?? [])].sort()).toEqual(['a1', 'a2']);
+  });
+
+  it('returns the same map reference when the value is unchanged', () => {
+    const same = new Set(['x']);
+    const map = new Map<string, Set<string>>([['A', same]]);
+
+    expect(setAggregateEntry(map, 'A', same)).toBe(map);
+  });
+
+  it('treats a missing id as its own bucket', () => {
+    const map = setAggregateEntry(new Map(), undefined, new Set(['x']));
+    expect([...(map.get('') ?? [])]).toEqual(['x']);
+  });
+});

--- a/src/features/Verify/Acceptance/expandState.ts
+++ b/src/features/Verify/Acceptance/expandState.ts
@@ -1,0 +1,25 @@
+// Shared empty default — expand/collapse sets are never mutated in place (every
+// update builds a fresh Set), so one frozen instance is safe to hand out and
+// keeps `expanded`/`collapsedGroups` referentially stable for an unseeded id.
+export const EMPTY_ID_SET: Set<string> = new Set();
+
+/**
+ * Write one aggregate's expand/collapse set into a per-id map (useState-style).
+ * Expand state is kept PER aggregate because the portal embed swaps the active
+ * acceptance without remounting — a single shared set would bleed one
+ * aggregate's toggles onto the next and lose them on return. Returns the same
+ * map reference when the value is unchanged so React can skip a re-render.
+ */
+export const setAggregateEntry = (
+  map: Map<string, Set<string>>,
+  id: string | undefined,
+  update: Set<string> | ((prev: Set<string>) => Set<string>),
+): Map<string, Set<string>> => {
+  const key = id ?? '';
+  const prev = map.get(key) ?? EMPTY_ID_SET;
+  const next = typeof update === 'function' ? update(prev) : update;
+  if (next === prev) return map;
+  const nextMap = new Map(map);
+  nextMap.set(key, next);
+  return nextMap;
+};

--- a/src/features/Verify/Acceptance/index.tsx
+++ b/src/features/Verify/Acceptance/index.tsx
@@ -287,7 +287,23 @@ const AcceptancePage = memo<AcceptancePageProps>(({ acceptanceId: explicitAccept
           .map((group) => group.key),
       ),
     );
-  }, [data, acceptanceId, t]);
+    // First run (one round): nothing has been reviewed yet, so open on the whole
+    // list. Second round onward: the reviewer came back for what's still unsigned
+    // — land them on 未验收. A deep-link's explicit `?filter=` always wins.
+    const defaultFilter: CheckFilter = data.rounds.length > 1 ? 'pending' : 'all';
+    if (isEmbedded) {
+      setLocalFilter(defaultFilter);
+    } else if (!urlFilterRaw && defaultFilter !== 'all') {
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev);
+          params.set('filter', defaultFilter);
+          return params;
+        },
+        { replace: true },
+      );
+    }
+  }, [data, acceptanceId, t, isEmbedded, urlFilterRaw, setSearchParams]);
 
   const counts = useMemo(() => {
     const checks = data?.checks ?? [];

--- a/src/features/Verify/Acceptance/index.tsx
+++ b/src/features/Verify/Acceptance/index.tsx
@@ -33,7 +33,7 @@ import {
   RotateCcw,
   SquareArrowOutUpRight,
 } from 'lucide-react';
-import { memo, useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams, useSearchParams } from 'react-router';
 
@@ -44,6 +44,7 @@ import AgentProfilePopup from '@/features/AgentProfileCard/AgentProfilePopup';
 import { mutate as globalMutate } from '@/libs/swr';
 import { verifyKeys } from '@/libs/swr/keys';
 import { verifyService } from '@/services/verify';
+import { useChatStore } from '@/store/chat';
 
 import { useAcceptanceBundle } from '../hooks';
 import ReportViewer from '../ReportViewer';
@@ -230,7 +231,11 @@ const AcceptancePage = memo<AcceptancePageProps>(({ acceptanceId: explicitAccept
   const [roundFilter, setRoundFilter] = useState<number | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set());
-  const [seeded, setSeeded] = useState(false);
+  // Which aggregate the expand/collapse defaults were seeded for. Keyed by id
+  // (not a one-shot boolean) so switching aggregates — the portal embed swaps
+  // `acceptanceId` without remounting — re-seeds each one's defaults instead of
+  // leaving a later aggregate's evidence collapsed under the first's seed.
+  const seededIdRef = useRef<string | null>(null);
   const [highlightRound, setHighlightRound] = useState<number | null>(null);
   const [ledgerExpand, setLedgerExpand] = useState(!isEmbedded);
   // Entering the narrow regime closes the ledger (it would cover the report);
@@ -253,13 +258,17 @@ const AcceptancePage = memo<AcceptancePageProps>(({ acceptanceId: explicitAccept
     return () => clearInterval(timer);
   }, [status, mutate]);
 
-  // Exceptions and visually-evidenced checks start expanded (P-08) — once,
-  // on first load, so the user's own toggling is never overwritten. A check
-  // the user already accepted is settled business and stays folded regardless
-  // of its evidence; groups accepted in full start collapsed for the same
-  // reason.
+  // Exceptions and visually-evidenced checks start expanded (P-08) — a check
+  // still awaiting the user's review shows its evidence (screenshots included)
+  // up front, not folded away. Seeded once per aggregate (see `seededIdRef`),
+  // and only after its checks have arrived, so the user's own toggling is never
+  // overwritten and an aggregate whose checks stream in a beat late still seeds.
+  // A check the user already accepted is settled business and stays folded
+  // regardless of its evidence; groups accepted in full start collapsed too.
   useEffect(() => {
-    if (seeded || !data) return;
+    if (!data || data.checks.length === 0) return;
+    if (seededIdRef.current === acceptanceId) return;
+    seededIdRef.current = acceptanceId ?? null;
     setExpanded(
       new Set(
         data.checks
@@ -278,8 +287,7 @@ const AcceptancePage = memo<AcceptancePageProps>(({ acceptanceId: explicitAccept
           .map((group) => group.key),
       ),
     );
-    setSeeded(true);
-  }, [data, seeded, t]);
+  }, [data, acceptanceId, t]);
 
   const counts = useMemo(() => {
     const checks = data?.checks ?? [];
@@ -606,7 +614,23 @@ const AcceptancePage = memo<AcceptancePageProps>(({ acceptanceId: explicitAccept
   // agent reads the feedback itself via the CLI, no hand-summarizing. The
   // aggregate is stamped `repairing` so the page (and the list) show the
   // send-back took effect instead of sitting unchanged.
+  //
+  // Portal embed exception: the acceptance sits beside the live conversation, so
+  // a send-back drafts the prompt into the user's own composer (left) for them
+  // to review and send — never a silent backend post behind their back.
   const handleRerun = async () => {
+    if (isEmbedded) {
+      const editor = useChatStore.getState().mainInputEditor;
+      if (!editor) return;
+      editor.instance?.setDocument('markdown', repairPrompt);
+      editor.focus();
+      toast.success({
+        placement: 'bottom',
+        style: { marginBlockEnd: 88 },
+        title: t('acceptance.bar.rerunDrafted'),
+      });
+      return;
+    }
     if (!origin?.topic) return;
     setRerunPending(true);
     try {
@@ -961,7 +985,7 @@ const AcceptancePage = memo<AcceptancePageProps>(({ acceptanceId: explicitAccept
               needsFixCount={needsFixCount}
               pending={pending}
               repairing={acceptance.status === 'repairing'}
-              rerunAvailable={Boolean(origin?.topic)}
+              rerunAvailable={isEmbedded || Boolean(origin?.topic)}
               rerunPending={rerunPending}
               state={barState}
               statusText={barTexts.statusText}

--- a/src/features/Verify/Acceptance/index.tsx
+++ b/src/features/Verify/Acceptance/index.tsx
@@ -33,7 +33,7 @@ import {
   RotateCcw,
   SquareArrowOutUpRight,
 } from 'lucide-react';
-import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams, useSearchParams } from 'react-router';
 
@@ -44,7 +44,6 @@ import AgentProfilePopup from '@/features/AgentProfileCard/AgentProfilePopup';
 import { mutate as globalMutate } from '@/libs/swr';
 import { verifyKeys } from '@/libs/swr/keys';
 import { verifyService } from '@/services/verify';
-import { useChatStore } from '@/store/chat';
 
 import { useAcceptanceBundle } from '../hooks';
 import ReportViewer from '../ReportViewer';
@@ -59,6 +58,7 @@ import CheckList, {
   userReviewState,
 } from './CheckList';
 import DecisionBar from './DecisionBar';
+import { EMPTY_ID_SET, setAggregateEntry } from './expandState';
 import FeedbackDrawer, { type FeedbackListEntry } from './FeedbackDrawer';
 import LedgerPanel, { type AcceptanceRound } from './LedgerPanel';
 import { openAcceptModal, openRejectModal } from './modals';
@@ -184,883 +184,902 @@ interface AcceptancePageProps {
    * collapsed there.
    */
   acceptanceId?: string;
+  /**
+   * Portal embed only: draft text into the beside-it conversation composer
+   * (and sync its input state) instead of posting to the backend. Provided by
+   * the portal, which lives inside the ConversationProvider.
+   */
+  onDraftToComposer?: (text: string) => boolean;
 }
 
-const AcceptancePage = memo<AcceptancePageProps>(({ acceptanceId: explicitAcceptanceId }) => {
-  const params = useParams<{ acceptanceId: string }>();
-  const acceptanceId = explicitAcceptanceId ?? params.acceptanceId;
-  const isEmbedded = Boolean(explicitAcceptanceId);
-  const { t } = useTranslation('verify');
-  const { data, error, isLoading, mutate } = useAcceptanceBundle(acceptanceId ?? null);
-  // Below `lg` the report body and a 300px+ in-flow ledger cannot share the
-  // viewport — the ledger switches to a float overlay, closed by default (the
-  // same narrow regime the list panel uses).
-  const { lg = true } = useResponsive();
-  const isNarrowViewport = !lg;
-  // The portal embed is container-narrow even in a wide window — both regimes
-  // get the one-line compact toolbar.
-  const compactToolbar = isEmbedded || isNarrowViewport;
+const AcceptancePage = memo<AcceptancePageProps>(
+  ({ acceptanceId: explicitAcceptanceId, onDraftToComposer }) => {
+    const params = useParams<{ acceptanceId: string }>();
+    const acceptanceId = explicitAcceptanceId ?? params.acceptanceId;
+    const isEmbedded = Boolean(explicitAcceptanceId);
+    const { t } = useTranslation('verify');
+    const { data, error, isLoading, mutate } = useAcceptanceBundle(acceptanceId ?? null);
+    // Below `lg` the report body and a 300px+ in-flow ledger cannot share the
+    // viewport — the ledger switches to a float overlay, closed by default (the
+    // same narrow regime the list panel uses).
+    const { lg = true } = useResponsive();
+    const isNarrowViewport = !lg;
+    // The portal embed is container-narrow even in a wide window — both regimes
+    // get the one-line compact toolbar.
+    const compactToolbar = isEmbedded || isNarrowViewport;
 
-  // The checklist filter survives a refresh via a `?filter=` query param — but
-  // only on the standalone acceptance page. The portal embed rides the chat
-  // URL, so it keeps the filter in local state instead of hijacking that query.
-  const [searchParams, setSearchParams] = useSearchParams();
-  const [localFilter, setLocalFilter] = useState<CheckFilter>('all');
-  const urlFilterRaw = searchParams.get('filter');
-  const urlFilter: CheckFilter = (['all', 'pending', 'needsFix', 'accepted'] as const).includes(
-    urlFilterRaw as CheckFilter,
-  )
-    ? (urlFilterRaw as CheckFilter)
-    : 'all';
-  const filter = isEmbedded ? localFilter : urlFilter;
-  const setFilter = (next: CheckFilter) => {
-    if (isEmbedded) {
-      setLocalFilter(next);
-      return;
-    }
-    setSearchParams(
-      (prev) => {
-        const params = new URLSearchParams(prev);
-        if (next === 'all') params.delete('filter');
-        else params.set('filter', next);
-        return params;
-      },
-      { replace: true },
-    );
-  };
-  const [roundFilter, setRoundFilter] = useState<number | null>(null);
-  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
-  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set());
-  // Which aggregate the expand/collapse defaults were seeded for. Keyed by id
-  // (not a one-shot boolean) so switching aggregates — the portal embed swaps
-  // `acceptanceId` without remounting — re-seeds each one's defaults instead of
-  // leaving a later aggregate's evidence collapsed under the first's seed.
-  const seededIdRef = useRef<string | null>(null);
-  const [highlightRound, setHighlightRound] = useState<number | null>(null);
-  const [ledgerExpand, setLedgerExpand] = useState(!isEmbedded);
-  // Entering the narrow regime closes the ledger (it would cover the report);
-  // reopening is an explicit act via the corner toggle, as a float overlay.
-  useEffect(() => {
-    if (isNarrowViewport) setLedgerExpand(false);
-  }, [isNarrowViewport]);
-  const [reportRound, setReportRound] = useState<AcceptanceRound | null>(null);
-  const [pending, setPending] = useState(false);
-  const [rerunPending, setRerunPending] = useState(false);
-  const [actionError, setActionError] = useState<string>();
-  const [feedbackOpen, setFeedbackOpen] = useState(false);
-
-  const status = data?.acceptance.status;
-
-  // A chain still executing refreshes itself — same cadence as the report page.
-  useEffect(() => {
-    if (!status || !LIVE_STATUSES.has(status)) return;
-    const timer = setInterval(() => void mutate(), 5000);
-    return () => clearInterval(timer);
-  }, [status, mutate]);
-
-  // Exceptions and visually-evidenced checks start expanded (P-08) — a check
-  // still awaiting the user's review shows its evidence (screenshots included)
-  // up front, not folded away. Seeded once per aggregate (see `seededIdRef`),
-  // and only after its checks have arrived, so the user's own toggling is never
-  // overwritten and an aggregate whose checks stream in a beat late still seeds.
-  // A check the user already accepted is settled business and stays folded
-  // regardless of its evidence; groups accepted in full start collapsed too.
-  useEffect(() => {
-    if (!data || data.checks.length === 0) return;
-    if (seededIdRef.current === acceptanceId) return;
-    seededIdRef.current = acceptanceId ?? null;
-    setExpanded(
-      new Set(
-        data.checks
-          .filter(
-            (check) =>
-              userReviewState(check) !== 'accepted' &&
-              (isException(check) || hasVisualEvidence(check)),
-          )
-          .map((check) => check.id),
-      ),
-    );
-    setCollapsedGroups(
-      new Set(
-        groupChecks(data.checks, t('acceptance.group.uncategorized'))
-          .filter((group) => isGroupFullyAccepted(group.checks))
-          .map((group) => group.key),
-      ),
-    );
-    // First run (one round): nothing has been reviewed yet, so open on the whole
-    // list. Second round onward: the reviewer came back for what's still unsigned
-    // — land them on 未验收. A deep-link's explicit `?filter=` always wins.
-    const defaultFilter: CheckFilter = data.rounds.length > 1 ? 'pending' : 'all';
-    if (isEmbedded) {
-      setLocalFilter(defaultFilter);
-    } else if (!urlFilterRaw && defaultFilter !== 'all') {
+    // The checklist filter survives a refresh via a `?filter=` query param — but
+    // only on the standalone acceptance page. The portal embed rides the chat
+    // URL, so it keeps the filter in local state instead of hijacking that query.
+    const [searchParams, setSearchParams] = useSearchParams();
+    const [localFilter, setLocalFilter] = useState<CheckFilter>('all');
+    const urlFilterRaw = searchParams.get('filter');
+    const urlFilter: CheckFilter = (['all', 'pending', 'needsFix', 'accepted'] as const).includes(
+      urlFilterRaw as CheckFilter,
+    )
+      ? (urlFilterRaw as CheckFilter)
+      : 'all';
+    const filter = isEmbedded ? localFilter : urlFilter;
+    const setFilter = (next: CheckFilter) => {
+      if (isEmbedded) {
+        setLocalFilter(next);
+        return;
+      }
       setSearchParams(
         (prev) => {
           const params = new URLSearchParams(prev);
-          params.set('filter', defaultFilter);
+          if (next === 'all') params.delete('filter');
+          else params.set('filter', next);
           return params;
         },
         { replace: true },
       );
-    }
-  }, [data, acceptanceId, t, isEmbedded, urlFilterRaw, setSearchParams]);
-
-  const counts = useMemo(() => {
-    const checks = data?.checks ?? [];
-    return {
-      accepted: checks.filter((check) => checkFilterState(check) === 'accepted').length,
-      exceptions: checks.filter((check) => isException(check)).length,
-      failed: checks.filter((check) => check.state === 'failed').length,
-      needsFix: checks.filter((check) => checkFilterState(check) === 'needsFix').length,
-      notExecuted: checks.filter((check) => check.state === 'not_executed').length,
-      passed: checks.filter((check) => check.state === 'passed').length,
-      pending: checks.filter((check) => checkFilterState(check) === 'pending').length,
-      total: checks.length,
-      uncertain: checks.filter((check) => check.state === 'uncertain').length,
     };
-  }, [data]);
-
-  if (isLoading)
-    return (
-      <Center height={'100%'}>
-        <NeuralNetworkLoading size={48} />
-      </Center>
+    const [roundFilter, setRoundFilter] = useState<number | null>(null);
+    // Expand/collapse state is kept PER aggregate: the portal embed swaps
+    // `acceptanceId` without remounting, so a single shared set would bleed one
+    // aggregate's toggles onto the next (and revisiting would show the wrong
+    // rows). Deriving from a per-id map keeps each aggregate's choices intact
+    // across repeated portal navigation. The `set*` wrappers write the current
+    // aggregate's entry, so downstream call sites read like plain useState.
+    const [expandedById, setExpandedById] = useState<Map<string, Set<string>>>(() => new Map());
+    const [collapsedById, setCollapsedById] = useState<Map<string, Set<string>>>(() => new Map());
+    const expanded = expandedById.get(acceptanceId ?? '') ?? EMPTY_ID_SET;
+    const collapsedGroups = collapsedById.get(acceptanceId ?? '') ?? EMPTY_ID_SET;
+    const setExpanded = useCallback(
+      (update: Set<string> | ((prev: Set<string>) => Set<string>)) =>
+        setExpandedById((map) => setAggregateEntry(map, acceptanceId, update)),
+      [acceptanceId],
     );
-
-  if (error || !data)
-    return (
-      <Center height={'100%'}>
-        <Empty description={t('acceptance.error.description')} title={t('acceptance.error.title')}>
-          <Button onClick={() => void mutate()}>{t('report.actions.retry')}</Button>
-        </Empty>
-      </Center>
+    const setCollapsedGroups = useCallback(
+      (update: Set<string> | ((prev: Set<string>) => Set<string>)) =>
+        setCollapsedById((map) => setAggregateEntry(map, acceptanceId, update)),
+      [acceptanceId],
     );
+    // Which aggregates have had their one-time defaults (expand/collapse + filter)
+    // applied. A Set, not a single id, so returning to an already-seeded aggregate
+    // does NOT re-apply defaults and clobber the toggles the user made.
+    const seededIdsRef = useRef<Set<string>>(new Set());
+    const [highlightRound, setHighlightRound] = useState<number | null>(null);
+    const [ledgerExpand, setLedgerExpand] = useState(!isEmbedded);
+    // Entering the narrow regime closes the ledger (it would cover the report);
+    // reopening is an explicit act via the corner toggle, as a float overlay.
+    useEffect(() => {
+      if (isNarrowViewport) setLedgerExpand(false);
+    }, [isNarrowViewport]);
+    const [reportRound, setReportRound] = useState<AcceptanceRound | null>(null);
+    const [pending, setPending] = useState(false);
+    const [rerunPending, setRerunPending] = useState(false);
+    const [actionError, setActionError] = useState<string>();
+    const [feedbackOpen, setFeedbackOpen] = useState(false);
 
-  const { acceptance, checks, isOwner, latestReport, origin, rounds, subject } = data;
-  const currentRound = rounds.at(-1);
-  // Group-scoped feedback lives on each round's decision detail — flatten the
-  // chain into the derived per-entry view (roundIndex from the carrying run).
-  const groupFeedbackEntries = rounds.flatMap((round) =>
-    (round.run.decisionDetail?.groupFeedback ?? []).map((entry) => ({
-      ...entry,
-      roundIndex: round.run.roundIndex ?? 0,
-    })),
-  );
-  // The latest coding round's context — rendered with the latest report card
-  // (it describes what THAT round verified), not as aggregate-level identity.
-  // A round with no scenario predates the column and is a coding round; a
-  // non-coding round's context carries none of the chips the card renders.
-  const scope = [...rounds]
-    .reverse()
-    .find((round) => (round.run.scenario ?? 'coding') === 'coding' && round.run.context)?.run
-    .context as VerifyCodingScope | null | undefined;
+    const status = data?.acceptance.status;
 
-  const groupKeys = groupChecks(checks, t('acceptance.group.uncategorized')).map(
-    (group) => group.key,
-  );
-  const allGroupsCollapsed =
-    groupKeys.length > 0 && groupKeys.every((key) => collapsedGroups.has(key));
+    // A chain still executing refreshes itself — same cadence as the report page.
+    useEffect(() => {
+      if (!status || !LIVE_STATUSES.has(status)) return;
+      const timer = setInterval(() => void mutate(), 5000);
+      return () => clearInterval(timer);
+    }, [status, mutate]);
 
-  const countsText = [
-    t('acceptance.stats.passed', { count: counts.passed }),
-    counts.uncertain > 0 ? t('acceptance.stats.uncertain', { count: counts.uncertain }) : null,
-    counts.failed > 0 ? t('acceptance.stats.failed', { count: counts.failed }) : null,
-    counts.notExecuted > 0
-      ? t('acceptance.stats.notExecuted', { count: counts.notExecuted })
-      : null,
-  ]
-    .filter(Boolean)
-    .join(' · ');
+    // Exceptions and visually-evidenced checks start expanded (P-08) — a check
+    // still awaiting the user's review shows its evidence (screenshots included)
+    // up front, not folded away. Seeded once per aggregate (see `seededIdsRef`),
+    // and only after its checks have arrived, so the user's own toggling is never
+    // overwritten and an aggregate whose checks stream in a beat late still seeds.
+    // A check the user already accepted is settled business and stays folded
+    // regardless of its evidence; groups accepted in full start collapsed too.
+    useEffect(() => {
+      if (!data || data.checks.length === 0) return;
+      if (seededIdsRef.current.has(acceptanceId ?? '')) return;
+      seededIdsRef.current.add(acceptanceId ?? '');
+      setExpanded(
+        new Set(
+          data.checks
+            .filter(
+              (check) =>
+                userReviewState(check) !== 'accepted' &&
+                (isException(check) || hasVisualEvidence(check)),
+            )
+            .map((check) => check.id),
+        ),
+      );
+      setCollapsedGroups(
+        new Set(
+          groupChecks(data.checks, t('acceptance.group.uncategorized'))
+            .filter((group) => isGroupFullyAccepted(group.checks))
+            .map((group) => group.key),
+        ),
+      );
+      // First run (one round): nothing has been reviewed yet, so open on the whole
+      // list. Second round onward: the reviewer came back for what's still unsigned
+      // — land them on 未验收. A deep-link's explicit `?filter=` always wins.
+      const defaultFilter: CheckFilter = data.rounds.length > 1 ? 'pending' : 'all';
+      if (isEmbedded) {
+        setLocalFilter(defaultFilter);
+      } else if (!urlFilterRaw && defaultFilter !== 'all') {
+        setSearchParams(
+          (prev) => {
+            const params = new URLSearchParams(prev);
+            params.set('filter', defaultFilter);
+            return params;
+          },
+          { replace: true },
+        );
+      }
+    }, [
+      data,
+      acceptanceId,
+      t,
+      isEmbedded,
+      urlFilterRaw,
+      setSearchParams,
+      setExpanded,
+      setCollapsedGroups,
+    ]);
 
-  // The header's one-glance state: the lifecycle isn't over until the user
-  // closes it — a settled-but-undecided chain reads as "in progress", never
-  // as a green all-clear the user hasn't given.
-  const verdictMeta: {
-    bg: string;
-    color: string;
-    icon: typeof BadgeCheck;
-    label: string;
-    spin?: boolean;
-  } =
-    acceptance.status === 'repairing'
-      ? {
-          // A repair round is an in-progress TASK — warn-coloured spinning
-          // refresh, matching the system's task-process cue, not a neutral verify.
-          bg: cssVar.colorWarningBg,
-          color: cssVar.colorWarning,
-          icon: RefreshCw,
-          label: t('acceptance.status.repairing'),
-          spin: true,
-        }
-      : LIVE_STATUSES.has(acceptance.status)
+    const counts = useMemo(() => {
+      const checks = data?.checks ?? [];
+      return {
+        accepted: checks.filter((check) => checkFilterState(check) === 'accepted').length,
+        exceptions: checks.filter((check) => isException(check)).length,
+        failed: checks.filter((check) => check.state === 'failed').length,
+        needsFix: checks.filter((check) => checkFilterState(check) === 'needsFix').length,
+        notExecuted: checks.filter((check) => check.state === 'not_executed').length,
+        passed: checks.filter((check) => check.state === 'passed').length,
+        pending: checks.filter((check) => checkFilterState(check) === 'pending').length,
+        total: checks.length,
+        uncertain: checks.filter((check) => check.state === 'uncertain').length,
+      };
+    }, [data]);
+
+    if (isLoading)
+      return (
+        <Center height={'100%'}>
+          <NeuralNetworkLoading size={48} />
+        </Center>
+      );
+
+    if (error || !data)
+      return (
+        <Center height={'100%'}>
+          <Empty
+            description={t('acceptance.error.description')}
+            title={t('acceptance.error.title')}
+          >
+            <Button onClick={() => void mutate()}>{t('report.actions.retry')}</Button>
+          </Empty>
+        </Center>
+      );
+
+    const { acceptance, checks, isOwner, latestReport, origin, rounds, subject } = data;
+    const currentRound = rounds.at(-1);
+    // Group-scoped feedback lives on each round's decision detail — flatten the
+    // chain into the derived per-entry view (roundIndex from the carrying run).
+    const groupFeedbackEntries = rounds.flatMap((round) =>
+      (round.run.decisionDetail?.groupFeedback ?? []).map((entry) => ({
+        ...entry,
+        roundIndex: round.run.roundIndex ?? 0,
+      })),
+    );
+    // The latest coding round's context — rendered with the latest report card
+    // (it describes what THAT round verified), not as aggregate-level identity.
+    // A round with no scenario predates the column and is a coding round; a
+    // non-coding round's context carries none of the chips the card renders.
+    const scope = [...rounds]
+      .reverse()
+      .find((round) => (round.run.scenario ?? 'coding') === 'coding' && round.run.context)?.run
+      .context as VerifyCodingScope | null | undefined;
+
+    const groupKeys = groupChecks(checks, t('acceptance.group.uncategorized')).map(
+      (group) => group.key,
+    );
+    const allGroupsCollapsed =
+      groupKeys.length > 0 && groupKeys.every((key) => collapsedGroups.has(key));
+
+    const countsText = [
+      t('acceptance.stats.passed', { count: counts.passed }),
+      counts.uncertain > 0 ? t('acceptance.stats.uncertain', { count: counts.uncertain }) : null,
+      counts.failed > 0 ? t('acceptance.stats.failed', { count: counts.failed }) : null,
+      counts.notExecuted > 0
+        ? t('acceptance.stats.notExecuted', { count: counts.notExecuted })
+        : null,
+    ]
+      .filter(Boolean)
+      .join(' · ');
+
+    // The header's one-glance state: the lifecycle isn't over until the user
+    // closes it — a settled-but-undecided chain reads as "in progress", never
+    // as a green all-clear the user hasn't given.
+    const verdictMeta: {
+      bg: string;
+      color: string;
+      icon: typeof BadgeCheck;
+      label: string;
+      spin?: boolean;
+    } =
+      acceptance.status === 'repairing'
         ? {
-            bg: cssVar.colorInfoBg,
-            color: cssVar.colorInfo,
-            icon: Loader2,
-            label: t(`acceptance.status.${acceptance.status}`),
+            // A repair round is an in-progress TASK — warn-coloured spinning
+            // refresh, matching the system's task-process cue, not a neutral verify.
+            bg: cssVar.colorWarningBg,
+            color: cssVar.colorWarning,
+            icon: RefreshCw,
+            label: t('acceptance.status.repairing'),
             spin: true,
           }
-        : acceptance.status === 'accepted'
+        : LIVE_STATUSES.has(acceptance.status)
           ? {
-              bg: cssVar.colorSuccessBg,
-              color: cssVar.colorSuccess,
-              icon: BadgeCheck,
-              label: t('acceptance.status.accepted'),
+              bg: cssVar.colorInfoBg,
+              color: cssVar.colorInfo,
+              icon: Loader2,
+              label: t(`acceptance.status.${acceptance.status}`),
+              spin: true,
             }
-          : acceptance.status === 'rejected'
+          : acceptance.status === 'accepted'
             ? {
-                bg: cssVar.colorErrorBg,
-                color: cssVar.colorError,
-                icon: RotateCcw,
-                label: t('acceptance.status.rejected'),
+                bg: cssVar.colorSuccessBg,
+                color: cssVar.colorSuccess,
+                icon: BadgeCheck,
+                label: t('acceptance.status.accepted'),
               }
-            : acceptance.status === 'errored'
+            : acceptance.status === 'rejected'
               ? {
-                  bg: cssVar.colorWarningBg,
-                  color: cssVar.colorWarning,
-                  icon: HelpCircle,
-                  label: t('acceptance.status.errored'),
+                  bg: cssVar.colorErrorBg,
+                  color: cssVar.colorError,
+                  icon: RotateCcw,
+                  label: t('acceptance.status.rejected'),
                 }
-              : {
-                  bg: cssVar.colorInfoBg,
-                  color: cssVar.colorInfo,
-                  icon: CircleDashed,
-                  label: t('acceptance.verdict.inProgress'),
-                };
+              : acceptance.status === 'errored'
+                ? {
+                    bg: cssVar.colorWarningBg,
+                    color: cssVar.colorWarning,
+                    icon: HelpCircle,
+                    label: t('acceptance.status.errored'),
+                  }
+                : {
+                    bg: cssVar.colorInfoBg,
+                    color: cssVar.colorInfo,
+                    icon: CircleDashed,
+                    label: t('acceptance.verdict.inProgress'),
+                  };
 
-  const runAction = async (action: () => Promise<unknown>) => {
-    try {
-      setPending(true);
-      setActionError(undefined);
-      await action();
-      await mutate();
-      // The list panel derives its glyph from the same status — a decision
-      // here must not leave a stale icon there until a hard refresh.
-      void globalMutate(verifyKeys.acceptances());
-      return true;
-    } catch (cause) {
-      setActionError(cause instanceof Error ? cause.message : t('acceptance.actionError'));
-      return false;
-    } finally {
-      setPending(false);
-    }
-  };
+    const runAction = async (action: () => Promise<unknown>) => {
+      try {
+        setPending(true);
+        setActionError(undefined);
+        await action();
+        await mutate();
+        // The list panel derives its glyph from the same status — a decision
+        // here must not leave a stale icon there until a hard refresh.
+        void globalMutate(verifyKeys.acceptances());
+        return true;
+      } catch (cause) {
+        setActionError(cause instanceof Error ? cause.message : t('acceptance.actionError'));
+        return false;
+      } finally {
+        setPending(false);
+      }
+    };
 
-  const gotoRound = (round: number) => {
-    setHighlightRound(round);
-    setLedgerExpand(true);
-  };
+    const gotoRound = (round: number) => {
+      setHighlightRound(round);
+      setLedgerExpand(true);
+    };
 
-  // Per-check user review — accept settles a check for good; reject records
-  // the feedback the next verify round reads.
-  const handleReview = (input: CheckReviewInput) =>
-    runAction(() => verifyService.reviewChecks({ id: acceptance.id, ...input }));
+    // Per-check user review — accept settles a check for good; reject records
+    // the feedback the next verify round reads.
+    const handleReview = (input: CheckReviewInput) =>
+      runAction(() => verifyService.reviewChecks({ id: acceptance.id, ...input }));
 
-  // Group-scoped feedback — for concerns that belong to no single check (the
-  // checks themselves may be accepted) yet must reach the next round.
-  const handleGroupFeedback = (category: string, comment: string, fileIds: string[]) =>
-    runAction(() =>
-      verifyService.addGroupFeedback({
-        category,
-        comment,
-        fileIds: fileIds.length > 0 ? fileIds : undefined,
-        id: acceptance.id,
-      }),
-    );
+    // Group-scoped feedback — for concerns that belong to no single check (the
+    // checks themselves may be accepted) yet must reach the next round.
+    const handleGroupFeedback = (category: string, comment: string, fileIds: string[]) =>
+      runAction(() =>
+        verifyService.addGroupFeedback({
+          category,
+          comment,
+          fileIds: fileIds.length > 0 ? fileIds : undefined,
+          id: acceptance.id,
+        }),
+      );
 
-  // The floating bar's one-line state + supporting line — the old banner's
-  // content, relocated to where the decision actually happens.
-  const barState = LIVE_STATUSES.has(acceptance.status)
-    ? ('live' as const)
-    : acceptance.status === 'accepted'
-      ? ('accepted' as const)
-      : acceptance.status === 'rejected'
-        ? ('rejected' as const)
-        : ('settled' as const);
-  // Review progress — the bar's dial and wording track the user's own decisions,
-  // split the SAME way as the checklist chips (已验收 / 待修复 / 未验收) so the two
-  // never disagree. A rejected check is DECIDED (it belongs to 待修复), not
-  // "awaiting your acceptance" — only the untouched 未验收 checks are pending.
-  const reviewableChecks = checks.filter((check) => check.result);
-  const reviewTotal = reviewableChecks.length;
-  const acceptedCount = reviewableChecks.filter(
-    (check) => checkFilterState(check) === 'accepted',
-  ).length;
-  const needsFixCount = reviewableChecks.filter(
-    (check) => checkFilterState(check) === 'needsFix',
-  ).length;
-  const pendingCount = reviewTotal - acceptedCount - needsFixCount; // 未验收 (undecided)
-  const decidedCount = acceptedCount + needsFixCount;
-  // Per-round acceptance tally for the ledger: each reviewable check belongs to
-  // the round its current result came from, so the ledger can show that round's
-  // own 已验收 / 待验收 progress instead of a raw verification verdict.
-  const reviewByRound = (() => {
-    const map = new Map<number, { accepted: number; total: number }>();
-    for (const check of reviewableChecks) {
-      const round = check.resultRound;
-      if (round === undefined || round === null) continue;
-      const cur = map.get(round) ?? { accepted: 0, total: 0 };
-      cur.total += 1;
-      if (checkFilterState(check) === 'accepted') cur.accepted += 1;
-      map.set(round, cur);
-    }
-    return map;
-  })();
-  const barTexts = {
-    accepted: {
-      statusText: t('acceptance.banner.accepted', {
-        time: acceptance.completedAt
-          ? dayjs(acceptance.completedAt).format('YYYY-MM-DD HH:mm')
-          : '',
-      }),
-      subText: `${countsText} · ${t('acceptance.banner.acceptedHint', { count: rounds.length })}`,
-    },
-    live: {
-      statusText: t(`acceptance.status.${acceptance.status}` as any),
-      subText: t('acceptance.banner.liveHint'),
-    },
-    rejected: {
-      statusText: t('acceptance.banner.rejected'),
-      subText: currentRound?.run.decisionDetail?.comment ?? t('acceptance.banner.rejectedHint'),
-    },
-    // The status line stands alone in every settled state — a grey stats echo
-    // (`N 通过 · …`) under it read as an unresolved caveat and just added noise.
-    settled:
-      decidedCount === 0
-        ? // Nothing reviewed yet — a clean "not started" prompt (no "已完成 0/…").
-          {
-            statusText: t('acceptance.bar.progressZero', { total: reviewTotal }),
-            subText: undefined,
-          }
-        : pendingCount === 0
-          ? needsFixCount === 0
-            ? // Every check accepted — ready to accept the delivery.
-              {
-                statusText: t('acceptance.bar.progressDone', { total: reviewTotal }),
-                subText: undefined,
-              }
-            : // Fully reviewed, but some checks need a fix — NOT "awaiting acceptance".
-              {
-                statusText: t('acceptance.bar.needsFix', { count: needsFixCount }),
-                subText: undefined,
-              }
-          : // Mid-review — the remainder is the UNDECIDED (未验收) count, not total-accepted.
+    // The floating bar's one-line state + supporting line — the old banner's
+    // content, relocated to where the decision actually happens.
+    const barState = LIVE_STATUSES.has(acceptance.status)
+      ? ('live' as const)
+      : acceptance.status === 'accepted'
+        ? ('accepted' as const)
+        : acceptance.status === 'rejected'
+          ? ('rejected' as const)
+          : ('settled' as const);
+    // Review progress — the bar's dial and wording track the user's own decisions,
+    // split the SAME way as the checklist chips (已验收 / 待修复 / 未验收) so the two
+    // never disagree. A rejected check is DECIDED (it belongs to 待修复), not
+    // "awaiting your acceptance" — only the untouched 未验收 checks are pending.
+    const reviewableChecks = checks.filter((check) => check.result);
+    const reviewTotal = reviewableChecks.length;
+    const acceptedCount = reviewableChecks.filter(
+      (check) => checkFilterState(check) === 'accepted',
+    ).length;
+    const needsFixCount = reviewableChecks.filter(
+      (check) => checkFilterState(check) === 'needsFix',
+    ).length;
+    const pendingCount = reviewTotal - acceptedCount - needsFixCount; // 未验收 (undecided)
+    const decidedCount = acceptedCount + needsFixCount;
+    // Per-round acceptance tally for the ledger: each reviewable check belongs to
+    // the round its current result came from, so the ledger can show that round's
+    // own 已验收 / 待验收 progress instead of a raw verification verdict.
+    const reviewByRound = (() => {
+      const map = new Map<number, { accepted: number; total: number }>();
+      for (const check of reviewableChecks) {
+        const round = check.resultRound;
+        if (round === undefined || round === null) continue;
+        const cur = map.get(round) ?? { accepted: 0, total: 0 };
+        cur.total += 1;
+        if (checkFilterState(check) === 'accepted') cur.accepted += 1;
+        map.set(round, cur);
+      }
+      return map;
+    })();
+    const barTexts = {
+      accepted: {
+        statusText: t('acceptance.banner.accepted', {
+          time: acceptance.completedAt
+            ? dayjs(acceptance.completedAt).format('YYYY-MM-DD HH:mm')
+            : '',
+        }),
+        subText: `${countsText} · ${t('acceptance.banner.acceptedHint', { count: rounds.length })}`,
+      },
+      live: {
+        statusText: t(`acceptance.status.${acceptance.status}` as any),
+        subText: t('acceptance.banner.liveHint'),
+      },
+      rejected: {
+        statusText: t('acceptance.banner.rejected'),
+        subText: currentRound?.run.decisionDetail?.comment ?? t('acceptance.banner.rejectedHint'),
+      },
+      // The status line stands alone in every settled state — a grey stats echo
+      // (`N 通过 · …`) under it read as an unresolved caveat and just added noise.
+      settled:
+        decidedCount === 0
+          ? // Nothing reviewed yet — a clean "not started" prompt (no "已完成 0/…").
             {
-              statusText: t('acceptance.bar.progress', {
-                done: decidedCount,
-                rest: pendingCount,
-                total: reviewTotal,
-              }),
+              statusText: t('acceptance.bar.progressZero', { total: reviewTotal }),
               subText: undefined,
-            },
-  }[barState];
+            }
+          : pendingCount === 0
+            ? needsFixCount === 0
+              ? // Every check accepted — ready to accept the delivery.
+                {
+                  statusText: t('acceptance.bar.progressDone', { total: reviewTotal }),
+                  subText: undefined,
+                }
+              : // Fully reviewed, but some checks need a fix — NOT "awaiting acceptance".
+                {
+                  statusText: t('acceptance.bar.needsFix', { count: needsFixCount }),
+                  subText: undefined,
+                }
+            : // Mid-review — the remainder is the UNDECIDED (未验收) count, not total-accepted.
+              {
+                statusText: t('acceptance.bar.progress', {
+                  done: decidedCount,
+                  rest: pendingCount,
+                  total: reviewTotal,
+                }),
+                subText: undefined,
+              },
+    }[barState];
 
-  // Every feedback event, flattened for the clearing list: per-check rejects
-  // (each review event) + group/global notes, active vs consumed by round.
-  const currentRoundIndex = currentRound?.run.roundIndex ?? 0;
-  const feedbackEntries: FeedbackListEntry[] = [
-    ...checks.flatMap((check) =>
-      check.reviews
-        .filter((review) => review.action === 'reject')
-        .map((review) => ({
-          annotationCount: review.annotations?.length || undefined,
-          attachments: review.attachments,
-          checkId: check.id,
-          checkSeq: check.seq,
-          comment: review.comment ?? '',
-          createdAt: review.createdAt,
-          kind: 'check' as const,
-          roundIndex: review.roundIndex,
-          stale: review.roundIndex < currentRoundIndex,
-          title: check.title,
-        })),
-    ),
-    ...groupFeedbackEntries.map((entry) => ({
-      attachments: entry.attachments,
-      comment: entry.comment,
-      createdAt: entry.createdAt,
-      groupLabel: entry.category,
-      kind: 'group' as const,
-      roundIndex: entry.roundIndex,
-      stale: entry.roundIndex < currentRoundIndex,
-    })),
-  ].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
-  const activeFeedbackCount = feedbackEntries.filter((entry) => !entry.stale).length;
+    // Every feedback event, flattened for the clearing list: per-check rejects
+    // (each review event) + group/global notes, active vs consumed by round.
+    const currentRoundIndex = currentRound?.run.roundIndex ?? 0;
+    const feedbackEntries: FeedbackListEntry[] = [
+      ...checks.flatMap((check) =>
+        check.reviews
+          .filter((review) => review.action === 'reject')
+          .map((review) => ({
+            annotationCount: review.annotations?.length || undefined,
+            attachments: review.attachments,
+            checkId: check.id,
+            checkSeq: check.seq,
+            comment: review.comment ?? '',
+            createdAt: review.createdAt,
+            kind: 'check' as const,
+            roundIndex: review.roundIndex,
+            stale: review.roundIndex < currentRoundIndex,
+            title: check.title,
+          })),
+      ),
+      ...groupFeedbackEntries.map((entry) => ({
+        attachments: entry.attachments,
+        comment: entry.comment,
+        createdAt: entry.createdAt,
+        groupLabel: entry.category,
+        kind: 'group' as const,
+        roundIndex: entry.roundIndex,
+        stale: entry.roundIndex < currentRoundIndex,
+      })),
+    ].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    const activeFeedbackCount = feedbackEntries.filter((entry) => !entry.stale).length;
 
-  const jumpToCheck = (checkId: string) => {
-    setFeedbackOpen(false);
-    setExpanded((previous) => new Set(previous).add(checkId));
-    // Wait a paint so a collapsed group/row has rendered before scrolling.
-    setTimeout(() => {
-      document
-        .querySelector(`[data-check-row="${checkId}"]`)
-        ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }, 80);
-  };
+    const jumpToCheck = (checkId: string) => {
+      setFeedbackOpen(false);
+      setExpanded((previous) => new Set(previous).add(checkId));
+      // Wait a paint so a collapsed group/row has rendered before scrolling.
+      setTimeout(() => {
+        document
+          .querySelector(`[data-check-row="${checkId}"]`)
+          ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }, 80);
+    };
 
-  const handleAccept = () =>
-    openAcceptModal({
-      exceptions: checks.filter((check) => isException(check)).map((check) => check.title),
-      onConfirm: () => runAction(() => verifyService.acceptDelivery(acceptance.id)),
-      subjectTitle: subject.title ?? subject.id,
-    });
+    const handleAccept = () =>
+      openAcceptModal({
+        exceptions: checks.filter((check) => isException(check)).map((check) => check.title),
+        onConfirm: () => runAction(() => verifyService.acceptDelivery(acceptance.id)),
+        subjectTitle: subject.title ?? subject.id,
+      });
 
-  // The aggregate-level reject — the whole delivery goes back with a comment.
-  const handleRejectComment = () =>
-    openRejectModal({
-      onConfirm: (comment) => runAction(() => verifyService.rejectDelivery(acceptance.id, comment)),
-    });
+    // The aggregate-level reject — the whole delivery goes back with a comment.
+    const handleRejectComment = () =>
+      openRejectModal({
+        onConfirm: (comment) =>
+          runAction(() => verifyService.rejectDelivery(acceptance.id, comment)),
+      });
 
-  const repairPrompt = buildRepairPrompt(acceptance.id);
+    const repairPrompt = buildRepairPrompt(acceptance.id);
 
-  // Hand the repair prompt to the reviewer's clipboard — for pasting to any
-  // agent, not just the origin conversation.
-  const handleCopyReview = async () => {
-    await copyToClipboard(repairPrompt);
-    // Bottom-center, lifted clear of the sticky decision bar so it floats ABOVE
-    // the action row the click came from (not overlapping it).
-    toast.success({
-      placement: 'bottom',
-      style: { marginBlockEnd: 88 },
-      title: t('acceptance.bar.copied'),
-    });
-  };
-
-  // Dispatch the repair prompt straight into the origin conversation — the
-  // agent reads the feedback itself via the CLI, no hand-summarizing. The
-  // aggregate is stamped `repairing` so the page (and the list) show the
-  // send-back took effect instead of sitting unchanged.
-  //
-  // Portal embed exception: the acceptance sits beside the live conversation, so
-  // a send-back drafts the prompt into the user's own composer (left) for them
-  // to review and send — never a silent backend post behind their back.
-  const handleRerun = async () => {
-    if (isEmbedded) {
-      const editor = useChatStore.getState().mainInputEditor;
-      if (!editor) return;
-      editor.instance?.setDocument('markdown', repairPrompt);
-      editor.focus();
+    // Hand the repair prompt to the reviewer's clipboard — for pasting to any
+    // agent, not just the origin conversation.
+    const handleCopyReview = async () => {
+      await copyToClipboard(repairPrompt);
+      // Bottom-center, lifted clear of the sticky decision bar so it floats ABOVE
+      // the action row the click came from (not overlapping it).
       toast.success({
         placement: 'bottom',
         style: { marginBlockEnd: 88 },
-        title: t('acceptance.bar.rerunDrafted'),
+        title: t('acceptance.bar.copied'),
       });
-      return;
-    }
-    if (!origin?.topic) return;
-    setRerunPending(true);
-    try {
-      await verifyService.dispatchAcceptanceRepair({
-        agentId: origin.agent?.id,
-        content: repairPrompt,
-        topicId: origin.topic.id,
-      });
-      await verifyService.markAcceptanceRepairing(acceptance.id);
-      await mutate();
-      void globalMutate(verifyKeys.acceptances());
-      toast.success({
-        placement: 'bottom',
-        style: { marginBlockEnd: 88 },
-        title: t('acceptance.bar.rerunSent'),
-      });
-    } catch (cause) {
-      toast.error(cause instanceof Error ? cause.message : t('acceptance.actionError'));
-    } finally {
-      setRerunPending(false);
-    }
-  };
+    };
 
-  return (
-    <Flexbox horizontal className={styles.page}>
-      {/* The reopen affordance lives at the page corner — no edge handle tab. */}
-      {!ledgerExpand && (
-        <ActionIcon
-          className={styles.ledgerToggle}
-          icon={PanelRightOpen}
-          size={'small'}
-          title={t('acceptance.ledger.expand')}
-          onClick={() => setLedgerExpand(true)}
-        />
-      )}
-      <Flexbox flex={1} style={{ minWidth: 0, overflow: 'auto' }}>
-        <Flexbox
-          gap={16}
-          paddingBlock={20}
-          paddingInline={24}
-          style={{ margin: '0 auto', maxWidth: 920, width: '100%' }}
-        >
-          {/* Header — state first (the lifecycle isn't closed until the user
+    // Dispatch the repair prompt straight into the origin conversation — the
+    // agent reads the feedback itself via the CLI, no hand-summarizing. The
+    // aggregate is stamped `repairing` so the page (and the list) show the
+    // send-back took effect instead of sitting unchanged.
+    //
+    // Portal embed exception: the acceptance sits beside the live conversation, so
+    // a send-back drafts the prompt into the user's own composer (left) for them
+    // to review and send — never a silent backend post behind their back.
+    const handleRerun = async () => {
+      if (isEmbedded) {
+        // The portal handler drafts into the composer AND syncs its input state so
+        // Send enables; only toast once it actually landed (composer mounted).
+        if (onDraftToComposer?.(repairPrompt)) {
+          toast.success({
+            placement: 'bottom',
+            style: { marginBlockEnd: 88 },
+            title: t('acceptance.bar.rerunDrafted'),
+          });
+        }
+        return;
+      }
+      if (!origin?.topic) return;
+      setRerunPending(true);
+      try {
+        await verifyService.dispatchAcceptanceRepair({
+          agentId: origin.agent?.id,
+          content: repairPrompt,
+          topicId: origin.topic.id,
+        });
+        await verifyService.markAcceptanceRepairing(acceptance.id);
+        await mutate();
+        void globalMutate(verifyKeys.acceptances());
+        toast.success({
+          placement: 'bottom',
+          style: { marginBlockEnd: 88 },
+          title: t('acceptance.bar.rerunSent'),
+        });
+      } catch (cause) {
+        toast.error(cause instanceof Error ? cause.message : t('acceptance.actionError'));
+      } finally {
+        setRerunPending(false);
+      }
+    };
+
+    return (
+      <Flexbox horizontal className={styles.page}>
+        {/* The reopen affordance lives at the page corner — no edge handle tab. */}
+        {!ledgerExpand && (
+          <ActionIcon
+            className={styles.ledgerToggle}
+            icon={PanelRightOpen}
+            size={'small'}
+            title={t('acceptance.ledger.expand')}
+            onClick={() => setLedgerExpand(true)}
+          />
+        )}
+        <Flexbox flex={1} style={{ minWidth: 0, overflow: 'auto' }}>
+          <Flexbox
+            gap={16}
+            paddingBlock={20}
+            paddingInline={24}
+            style={{ margin: '0 auto', maxWidth: 920, width: '100%' }}
+          >
+            {/* Header — state first (the lifecycle isn't closed until the user
               closes it), then identity, then the origin conversation. */}
-          <Flexbox gap={10}>
-            <Flexbox horizontal align={'center'} gap={10} wrap={'wrap'}>
-              <span
-                className={styles.verdictPill}
-                style={{ background: verdictMeta.bg, color: verdictMeta.color }}
-              >
-                <Icon icon={verdictMeta.icon} size={13} spin={verdictMeta.spin} />
-                {verdictMeta.label}
-              </span>
-              <Text fontSize={12} type={'secondary'}>
-                {[
-                  countsText,
-                  t('acceptance.roundCount', { count: rounds.length }),
-                  currentRound
-                    ? t('acceptance.verdict.latestAt', {
-                        time: dayjs(currentRound.run.createdAt).format('MM-DD HH:mm'),
-                      })
-                    : null,
-                ]
-                  .filter(Boolean)
-                  .join(' · ')}
-              </Text>
-            </Flexbox>
+            <Flexbox gap={10}>
+              <Flexbox horizontal align={'center'} gap={10} wrap={'wrap'}>
+                <span
+                  className={styles.verdictPill}
+                  style={{ background: verdictMeta.bg, color: verdictMeta.color }}
+                >
+                  <Icon icon={verdictMeta.icon} size={13} spin={verdictMeta.spin} />
+                  {verdictMeta.label}
+                </span>
+                <Text fontSize={12} type={'secondary'}>
+                  {[
+                    countsText,
+                    t('acceptance.roundCount', { count: rounds.length }),
+                    currentRound
+                      ? t('acceptance.verdict.latestAt', {
+                          time: dayjs(currentRound.run.createdAt).format('MM-DD HH:mm'),
+                        })
+                      : null,
+                  ]
+                    .filter(Boolean)
+                    .join(' · ')}
+                </Text>
+              </Flexbox>
 
-            <Flexbox horizontal align={'center'} gap={10}>
-              <Text as={'h1'} style={{ fontSize: 18, margin: 0 }}>
-                {subject.title ?? subject.id}
-              </Text>
-              <Tag size={'small'}>{t(`acceptance.subject.${subject.type}`)}</Tag>
-            </Flexbox>
+              <Flexbox horizontal align={'center'} gap={10}>
+                <Text as={'h1'} style={{ fontSize: 18, margin: 0 }}>
+                  {subject.title ?? subject.id}
+                </Text>
+                <Tag size={'small'}>{t(`acceptance.subject.${subject.type}`)}</Tag>
+              </Flexbox>
 
-            {/* Origin — the conversation this acceptance belongs to (agent +
+              {/* Origin — the conversation this acceptance belongs to (agent +
                 topic). Owner-only: the server redacts it for shared links.
                 Hidden in the portal embed: that surface already lives inside
                 the origin conversation. */}
-            {!isEmbedded && (origin?.agent || origin?.topic) && (
-              <Flexbox horizontal align={'center'} gap={16} wrap={'wrap'}>
-                {origin.agent && (
-                  <AgentProfilePopup
-                    agentId={origin.agent.id}
-                    trigger={'hover'}
-                    agent={{
-                      avatar: origin.agent.avatar ?? undefined,
-                      backgroundColor: origin.agent.backgroundColor ?? undefined,
-                      title: origin.agent.title ?? undefined,
-                    }}
-                  >
+              {!isEmbedded && (origin?.agent || origin?.topic) && (
+                <Flexbox horizontal align={'center'} gap={16} wrap={'wrap'}>
+                  {origin.agent && (
+                    <AgentProfilePopup
+                      agentId={origin.agent.id}
+                      trigger={'hover'}
+                      agent={{
+                        avatar: origin.agent.avatar ?? undefined,
+                        backgroundColor: origin.agent.backgroundColor ?? undefined,
+                        title: origin.agent.title ?? undefined,
+                      }}
+                    >
+                      <Flexbox
+                        horizontal
+                        align={'center'}
+                        className={styles.scopeChip}
+                        gap={6}
+                        style={{ cursor: 'default', fontSize: 14 }}
+                      >
+                        <Avatar
+                          avatar={origin.agent.avatar ?? undefined}
+                          background={origin.agent.backgroundColor ?? undefined}
+                          size={18}
+                        />
+                        {origin.agent.title ?? t('acceptance.origin.agentFallback')}
+                      </Flexbox>
+                    </AgentProfilePopup>
+                  )}
+                  {origin.topic && (
                     <Flexbox
                       horizontal
                       align={'center'}
-                      className={styles.scopeChip}
-                      gap={6}
-                      style={{ cursor: 'default', fontSize: 14 }}
+                      className={cx(styles.scopeChip, styles.scopeLink)}
+                      gap={4}
+                      style={{ fontSize: 14 }}
+                      title={t('acceptance.origin.openTopic')}
+                      onClick={() =>
+                        window.open(
+                          // The canonical conversation route needs the agent;
+                          // without one, the legacy topic deep-link is the way in.
+                          origin.agent
+                            ? `/agent/${origin.agent.id}/${origin.topic!.id}`
+                            : `/chat?topic=${origin.topic!.id}`,
+                          '_blank',
+                        )
+                      }
                     >
-                      <Avatar
-                        avatar={origin.agent.avatar ?? undefined}
-                        background={origin.agent.backgroundColor ?? undefined}
-                        size={18}
-                      />
-                      {origin.agent.title ?? t('acceptance.origin.agentFallback')}
+                      <Icon icon={MessagesSquare} size={13} />
+                      {origin.topic.title ?? subject.title ?? origin.topic.id}
+                      <Icon icon={SquareArrowOutUpRight} size={12} />
                     </Flexbox>
-                  </AgentProfilePopup>
-                )}
-                {origin.topic && (
-                  <Flexbox
-                    horizontal
-                    align={'center'}
-                    className={cx(styles.scopeChip, styles.scopeLink)}
-                    gap={4}
-                    style={{ fontSize: 14 }}
-                    title={t('acceptance.origin.openTopic')}
-                    onClick={() =>
-                      window.open(
-                        // The canonical conversation route needs the agent;
-                        // without one, the legacy topic deep-link is the way in.
-                        origin.agent
-                          ? `/agent/${origin.agent.id}/${origin.topic!.id}`
-                          : `/chat?topic=${origin.topic!.id}`,
-                        '_blank',
-                      )
-                    }
-                  >
-                    <Icon icon={MessagesSquare} size={13} />
-                    {origin.topic.title ?? subject.title ?? origin.topic.id}
-                    <Icon icon={SquareArrowOutUpRight} size={12} />
-                  </Flexbox>
-                )}
-              </Flexbox>
-            )}
-          </Flexbox>
+                  )}
+                </Flexbox>
+              )}
+            </Flexbox>
 
-          {actionError && <Text type={'danger'}>{actionError}</Text>}
+            {actionError && <Text type={'danger'}>{actionError}</Text>}
 
-          {/* The acceptance goal — THE thing this delivery is judged against,
+            {/* The acceptance goal — THE thing this delivery is judged against,
               one prominent card. The latest report summary (and the chips
               describing what that round verified) is supporting context inside
               it, never the headline. */}
-          <Flexbox className={styles.card} gap={12} padding={16}>
-            <Flexbox gap={4}>
-              <Text className={styles.requirementLabel}>{t('acceptance.requirementLabel')}</Text>
-              <Text style={{ fontSize: 15, lineHeight: 1.7 }}>
-                {acceptance.requirement ?? t('acceptance.requirementEmpty')}
-              </Text>
-            </Flexbox>
-            {(latestReport?.summary || scope) && (
-              <Flexbox
-                gap={8}
-                paddingBlock={'12px 0'}
-                style={{ borderBlockStart: `1px solid ${cssVar.colorBorderSecondary}` }}
-              >
-                {/* label → the summary itself → provenance chips, all flush
+            <Flexbox className={styles.card} gap={12} padding={16}>
+              <Flexbox gap={4}>
+                <Text className={styles.requirementLabel}>{t('acceptance.requirementLabel')}</Text>
+                <Text style={{ fontSize: 15, lineHeight: 1.7 }}>
+                  {acceptance.requirement ?? t('acceptance.requirementEmpty')}
+                </Text>
+              </Flexbox>
+              {(latestReport?.summary || scope) && (
+                <Flexbox
+                  gap={8}
+                  paddingBlock={'12px 0'}
+                  style={{ borderBlockStart: `1px solid ${cssVar.colorBorderSecondary}` }}
+                >
+                  {/* label → the summary itself → provenance chips, all flush
                     left; the drawer entry is a quiet text link, not a button. */}
-                <Flexbox horizontal align={'center'} gap={8}>
-                  <Text fontSize={12} type={'secondary'}>
-                    {t('acceptance.latestSummary')}
-                    {currentRound
-                      ? ` · ${t('acceptance.round', { round: currentRound.run.roundIndex })}`
-                      : ''}
-                  </Text>
-                  <Flexbox flex={1} />
-                  {latestReport && (
-                    <span
-                      className={styles.viewReportLink}
-                      onClick={() =>
-                        setReportRound([...rounds].reverse().find((r) => r.report) ?? null)
-                      }
-                    >
-                      {t('acceptance.viewFullReport')}
-                    </span>
+                  <Flexbox horizontal align={'center'} gap={8}>
+                    <Text fontSize={12} type={'secondary'}>
+                      {t('acceptance.latestSummary')}
+                      {currentRound
+                        ? ` · ${t('acceptance.round', { round: currentRound.run.roundIndex })}`
+                        : ''}
+                    </Text>
+                    <Flexbox flex={1} />
+                    {latestReport && (
+                      <span
+                        className={styles.viewReportLink}
+                        onClick={() =>
+                          setReportRound([...rounds].reverse().find((r) => r.report) ?? null)
+                        }
+                      >
+                        {t('acceptance.viewFullReport')}
+                      </span>
+                    )}
+                  </Flexbox>
+                  {latestReport?.summary && (
+                    <Text className={styles.summaryClamp} fontSize={13} type={'secondary'}>
+                      {latestReport.summary}
+                    </Text>
                   )}
-                </Flexbox>
-                {latestReport?.summary && (
-                  <Text className={styles.summaryClamp} fontSize={13} type={'secondary'}>
-                    {latestReport.summary}
-                  </Text>
-                )}
-                {scope && (
-                  <Flexbox horizontal align={'center'} gap={16} wrap={'wrap'}>
-                    {scope.branch && (
-                      <Flexbox horizontal align={'center'} className={styles.scopeChip} gap={4}>
-                        <Icon icon={GitBranch} size={13} /> {scope.branch}
-                      </Flexbox>
-                    )}
-                    {scope.commit && (
-                      <Flexbox horizontal align={'center'} className={styles.scopeChip} gap={4}>
-                        <Icon icon={GitCommitHorizontal} size={13} /> {scope.commit.slice(0, 10)}
-                      </Flexbox>
-                    )}
-                    {scope.pullRequest?.number &&
-                      (scope.pullRequest.url ? (
-                        <a
-                          className={cx(styles.scopeChip, styles.scopeLink)}
-                          href={scope.pullRequest.url}
-                          rel={'noreferrer'}
-                          target={'_blank'}
-                          title={scope.pullRequest.title ?? scope.pullRequest.url}
-                        >
-                          <Flexbox horizontal align={'center'} gap={4}>
+                  {scope && (
+                    <Flexbox horizontal align={'center'} gap={16} wrap={'wrap'}>
+                      {scope.branch && (
+                        <Flexbox horizontal align={'center'} className={styles.scopeChip} gap={4}>
+                          <Icon icon={GitBranch} size={13} /> {scope.branch}
+                        </Flexbox>
+                      )}
+                      {scope.commit && (
+                        <Flexbox horizontal align={'center'} className={styles.scopeChip} gap={4}>
+                          <Icon icon={GitCommitHorizontal} size={13} /> {scope.commit.slice(0, 10)}
+                        </Flexbox>
+                      )}
+                      {scope.pullRequest?.number &&
+                        (scope.pullRequest.url ? (
+                          <a
+                            className={cx(styles.scopeChip, styles.scopeLink)}
+                            href={scope.pullRequest.url}
+                            rel={'noreferrer'}
+                            target={'_blank'}
+                            title={scope.pullRequest.title ?? scope.pullRequest.url}
+                          >
+                            <Flexbox horizontal align={'center'} gap={4}>
+                              <Icon icon={GitPullRequest} size={13} /> #{scope.pullRequest.number}
+                            </Flexbox>
+                          </a>
+                        ) : (
+                          <Flexbox horizontal align={'center'} className={styles.scopeChip} gap={4}>
                             <Icon icon={GitPullRequest} size={13} /> #{scope.pullRequest.number}
                           </Flexbox>
-                        </a>
-                      ) : (
-                        <Flexbox horizontal align={'center'} className={styles.scopeChip} gap={4}>
-                          <Icon icon={GitPullRequest} size={13} /> #{scope.pullRequest.number}
-                        </Flexbox>
-                      ))}
-                  </Flexbox>
-                )}
-              </Flexbox>
-            )}
-          </Flexbox>
+                        ))}
+                    </Flexbox>
+                  )}
+                </Flexbox>
+              )}
+            </Flexbox>
 
-          {/* Check union — the complete inventory, familiar sections (P-14).
+            {/* Check union — the complete inventory, familiar sections (P-14).
               Narrow surfaces (the chat portal embed, sub-lg viewports) trade
               the Segmented for a compact Select so the toolbar stays one
               line; wide viewports keep the glanceable Segmented. */}
-          <Flexbox horizontal align={'center'} gap={8} wrap={compactToolbar ? 'nowrap' : 'wrap'}>
-            <Text strong style={{ fontSize: 14, whiteSpace: 'nowrap' }}>
-              {t('acceptance.checks.title')}
-            </Text>
-            <span className={styles.countBadge}>{counts.total}</span>
-            <Flexbox flex={1} />
-            {compactToolbar ? (
-              <Select
-                size={'small'}
-                style={{ height: 34, width: 118 }}
-                value={filter}
-                variant={'filled'}
-                options={[
-                  { label: t('acceptance.filter.all', { count: counts.total }), value: 'all' },
-                  {
-                    label: t('acceptance.filter.pending', { count: counts.pending }),
-                    value: 'pending',
-                  },
-                  {
-                    label: t('acceptance.filter.needsFix', { count: counts.needsFix }),
-                    value: 'needsFix',
-                  },
-                  {
-                    label: t('acceptance.filter.accepted', { count: counts.accepted }),
-                    value: 'accepted',
-                  },
-                ]}
-                onChange={(value) => setFilter(value as CheckFilter)}
-              />
-            ) : (
-              <Segmented
-                size={'small'}
-                value={filter}
-                options={[
-                  { label: t('acceptance.filter.all', { count: counts.total }), value: 'all' },
-                  {
-                    label: t('acceptance.filter.pending', { count: counts.pending }),
-                    value: 'pending',
-                  },
-                  {
-                    label: t('acceptance.filter.needsFix', { count: counts.needsFix }),
-                    value: 'needsFix',
-                  },
-                  {
-                    label: t('acceptance.filter.accepted', { count: counts.accepted }),
-                    value: 'accepted',
-                  },
-                ]}
-                onChange={(value) => setFilter(value as CheckFilter)}
-              />
-            )}
-            {/* Which round touched a check — audit slicing, orthogonal to the
+            <Flexbox horizontal align={'center'} gap={8} wrap={compactToolbar ? 'nowrap' : 'wrap'}>
+              <Text strong style={{ fontSize: 14, whiteSpace: 'nowrap' }}>
+                {t('acceptance.checks.title')}
+              </Text>
+              <span className={styles.countBadge}>{counts.total}</span>
+              <Flexbox flex={1} />
+              {compactToolbar ? (
+                <Select
+                  size={'small'}
+                  style={{ height: 34, width: 118 }}
+                  value={filter}
+                  variant={'filled'}
+                  options={[
+                    { label: t('acceptance.filter.all', { count: counts.total }), value: 'all' },
+                    {
+                      label: t('acceptance.filter.pending', { count: counts.pending }),
+                      value: 'pending',
+                    },
+                    {
+                      label: t('acceptance.filter.needsFix', { count: counts.needsFix }),
+                      value: 'needsFix',
+                    },
+                    {
+                      label: t('acceptance.filter.accepted', { count: counts.accepted }),
+                      value: 'accepted',
+                    },
+                  ]}
+                  onChange={(value) => setFilter(value as CheckFilter)}
+                />
+              ) : (
+                <Segmented
+                  size={'small'}
+                  value={filter}
+                  options={[
+                    { label: t('acceptance.filter.all', { count: counts.total }), value: 'all' },
+                    {
+                      label: t('acceptance.filter.pending', { count: counts.pending }),
+                      value: 'pending',
+                    },
+                    {
+                      label: t('acceptance.filter.needsFix', { count: counts.needsFix }),
+                      value: 'needsFix',
+                    },
+                    {
+                      label: t('acceptance.filter.accepted', { count: counts.accepted }),
+                      value: 'accepted',
+                    },
+                  ]}
+                  onChange={(value) => setFilter(value as CheckFilter)}
+                />
+              )}
+              {/* Which round touched a check — audit slicing, orthogonal to the
                 review-state segments. */}
-            {rounds.length > 1 && (
-              <Select
+              {rounds.length > 1 && (
+                <Select
+                  size={'small'}
+                  // Filled + the Segmented's exact height so the two read as
+                  // one control family, not a stray bordered input.
+                  style={{ height: 34, width: 110 }}
+                  value={roundFilter === null ? 'all' : String(roundFilter)}
+                  variant={'filled'}
+                  options={[
+                    { label: t('acceptance.filter.roundAll'), value: 'all' },
+                    ...[...rounds].reverse().map((round) => ({
+                      label: t('acceptance.round', { round: round.run.roundIndex }),
+                      value: String(round.run.roundIndex),
+                    })),
+                  ]}
+                  onChange={(value) => setRoundFilter(value === 'all' ? null : Number(value))}
+                />
+              )}
+              <ActionIcon
+                icon={allGroupsCollapsed ? ChevronsUpDown : ChevronsDownUp}
                 size={'small'}
-                // Filled + the Segmented's exact height so the two read as
-                // one control family, not a stray bordered input.
-                style={{ height: 34, width: 110 }}
-                value={roundFilter === null ? 'all' : String(roundFilter)}
-                variant={'filled'}
-                options={[
-                  { label: t('acceptance.filter.roundAll'), value: 'all' },
-                  ...[...rounds].reverse().map((round) => ({
-                    label: t('acceptance.round', { round: round.run.roundIndex }),
-                    value: String(round.run.roundIndex),
-                  })),
-                ]}
-                onChange={(value) => setRoundFilter(value === 'all' ? null : Number(value))}
+                title={
+                  allGroupsCollapsed
+                    ? t('acceptance.group.expandAll')
+                    : t('acceptance.group.collapseAll')
+                }
+                onClick={() =>
+                  setCollapsedGroups(allGroupsCollapsed ? new Set() : new Set(groupKeys))
+                }
+              />
+            </Flexbox>
+
+            <CheckList
+              canReview={isOwner}
+              checks={checks}
+              collapsedGroups={collapsedGroups}
+              currentRound={currentRound?.run.roundIndex ?? 0}
+              expanded={expanded}
+              filter={filter}
+              groupFeedback={groupFeedbackEntries}
+              reviewPending={pending}
+              round={roundFilter}
+              onGroupFeedback={handleGroupFeedback}
+              onReview={handleReview}
+              onRound={gotoRound}
+              onToggleGroup={(key) =>
+                setCollapsedGroups((previous) => {
+                  const next = new Set(previous);
+                  if (next.has(key)) next.delete(key);
+                  else next.add(key);
+                  return next;
+                })
+              }
+              onToggleGroupItems={(ids, open) =>
+                setExpanded((previous) => {
+                  const next = new Set(previous);
+                  for (const id of ids) {
+                    if (open) next.add(id);
+                    else next.delete(id);
+                  }
+                  return next;
+                })
+              }
+              onToggleItem={(id) =>
+                setExpanded((previous) => {
+                  const next = new Set(previous);
+                  if (next.has(id)) next.delete(id);
+                  else next.add(id);
+                  return next;
+                })
+              }
+            />
+            {/* The floating decision strip — owner-only: closing the loop and
+              queueing feedback are the author's calls, never a visitor's. */}
+            {isOwner && (
+              <DecisionBar
+                acceptedCount={acceptedCount}
+                feedbackCount={activeFeedbackCount}
+                needsFixCount={needsFixCount}
+                pending={pending}
+                repairing={acceptance.status === 'repairing'}
+                rerunAvailable={isEmbedded || Boolean(origin?.topic)}
+                rerunPending={rerunPending}
+                state={barState}
+                statusText={barTexts.statusText}
+                subText={barTexts.subText}
+                totalCount={reviewTotal}
+                onAccept={handleAccept}
+                onCopyReview={handleCopyReview}
+                onOpenFeedback={() => setFeedbackOpen(true)}
+                onRejectComment={handleRejectComment}
+                onRerun={handleRerun}
               />
             )}
-            <ActionIcon
-              icon={allGroupsCollapsed ? ChevronsUpDown : ChevronsDownUp}
-              size={'small'}
-              title={
-                allGroupsCollapsed
-                  ? t('acceptance.group.expandAll')
-                  : t('acceptance.group.collapseAll')
-              }
-              onClick={() =>
-                setCollapsedGroups(allGroupsCollapsed ? new Set() : new Set(groupKeys))
-              }
-            />
+            <Flexbox style={{ height: 8 }} />
           </Flexbox>
-
-          <CheckList
-            canReview={isOwner}
-            checks={checks}
-            collapsedGroups={collapsedGroups}
-            currentRound={currentRound?.run.roundIndex ?? 0}
-            expanded={expanded}
-            filter={filter}
-            groupFeedback={groupFeedbackEntries}
-            reviewPending={pending}
-            round={roundFilter}
-            onGroupFeedback={handleGroupFeedback}
-            onReview={handleReview}
-            onRound={gotoRound}
-            onToggleGroup={(key) =>
-              setCollapsedGroups((previous) => {
-                const next = new Set(previous);
-                if (next.has(key)) next.delete(key);
-                else next.add(key);
-                return next;
-              })
-            }
-            onToggleGroupItems={(ids, open) =>
-              setExpanded((previous) => {
-                const next = new Set(previous);
-                for (const id of ids) {
-                  if (open) next.add(id);
-                  else next.delete(id);
-                }
-                return next;
-              })
-            }
-            onToggleItem={(id) =>
-              setExpanded((previous) => {
-                const next = new Set(previous);
-                if (next.has(id)) next.delete(id);
-                else next.add(id);
-                return next;
-              })
-            }
-          />
-          {/* The floating decision strip — owner-only: closing the loop and
-              queueing feedback are the author's calls, never a visitor's. */}
-          {isOwner && (
-            <DecisionBar
-              acceptedCount={acceptedCount}
-              feedbackCount={activeFeedbackCount}
-              needsFixCount={needsFixCount}
-              pending={pending}
-              repairing={acceptance.status === 'repairing'}
-              rerunAvailable={isEmbedded || Boolean(origin?.topic)}
-              rerunPending={rerunPending}
-              state={barState}
-              statusText={barTexts.statusText}
-              subText={barTexts.subText}
-              totalCount={reviewTotal}
-              onAccept={handleAccept}
-              onCopyReview={handleCopyReview}
-              onOpenFeedback={() => setFeedbackOpen(true)}
-              onRejectComment={handleRejectComment}
-              onRerun={handleRerun}
-            />
-          )}
-          <Flexbox style={{ height: 8 }} />
         </Flexbox>
-      </Flexbox>
 
-      <FeedbackDrawer
-        entries={feedbackEntries}
-        open={feedbackOpen}
-        onClose={() => setFeedbackOpen(false)}
-        onJumpToCheck={jumpToCheck}
-      />
+        <FeedbackDrawer
+          entries={feedbackEntries}
+          open={feedbackOpen}
+          onClose={() => setFeedbackOpen(false)}
+          onJumpToCheck={jumpToCheck}
+        />
 
-      {/* Round ledger — audit detail, off the decision path (P-13). No edge
+        {/* Round ledger — audit detail, off the decision path (P-13). No edge
           handle: opening happens from the page-corner toggle, closing from the
           ledger's own header action. On narrow viewports it opens as a masked
           drawer over the report — dismissable by tapping outside — instead of
           shrinking the report into an unreadable column. The panel's own
           fold icon is the close affordance (same as wide mode), so the Drawer's
           built-in close button is suppressed — one collapse handle, not two. */}
-      {isNarrowViewport ? (
-        <Drawer
-          noHeader
-          closable={false}
-          containerMaxWidth={'100%'}
-          open={ledgerExpand}
-          placement={'right'}
-          styles={{ body: { padding: 0 } }}
-          width={'min(340px, 88vw)'}
-          onClose={() => setLedgerExpand(false)}
-        >
-          <LedgerPanel
-            highlight={highlightRound}
-            reviewByRound={reviewByRound}
-            rounds={rounds}
-            onCollapse={() => setLedgerExpand(false)}
-            onOpenReport={setReportRound}
-          />
-        </Drawer>
-      ) : (
-        <DraggablePanel
-          defaultSize={{ width: 340 }}
-          expand={ledgerExpand}
-          minWidth={300}
-          placement={'right'}
-          style={{ flex: 'none', height: '100%' }}
-          onExpandChange={setLedgerExpand}
-        >
-          <Flexbox style={{ height: '100%', overflow: 'auto' }}>
+        {isNarrowViewport ? (
+          <Drawer
+            noHeader
+            closable={false}
+            containerMaxWidth={'100%'}
+            open={ledgerExpand}
+            placement={'right'}
+            styles={{ body: { padding: 0 } }}
+            width={'min(340px, 88vw)'}
+            onClose={() => setLedgerExpand(false)}
+          >
             <LedgerPanel
               highlight={highlightRound}
               reviewByRound={reviewByRound}
@@ -1068,37 +1087,56 @@ const AcceptancePage = memo<AcceptancePageProps>(({ acceptanceId: explicitAccept
               onCollapse={() => setLedgerExpand(false)}
               onOpenReport={setReportRound}
             />
-          </Flexbox>
-        </DraggablePanel>
-      )}
+          </Drawer>
+        ) : (
+          <DraggablePanel
+            defaultSize={{ width: 340 }}
+            expand={ledgerExpand}
+            minWidth={300}
+            placement={'right'}
+            style={{ flex: 'none', height: '100%' }}
+            onExpandChange={setLedgerExpand}
+          >
+            <Flexbox style={{ height: '100%', overflow: 'auto' }}>
+              <LedgerPanel
+                highlight={highlightRound}
+                reviewByRound={reviewByRound}
+                rounds={rounds}
+                onCollapse={() => setLedgerExpand(false)}
+                onOpenReport={setReportRound}
+              />
+            </Flexbox>
+          </DraggablePanel>
+        )}
 
-      {/* Per-round report drill-down — the full verify run view, not a
+        {/* Per-round report drill-down — the full verify run view, not a
           markdown excerpt: same content as /verify/:runId, opened in place.
           No drawer header: the report's own hero (title + verdict pill) is the
           header; the Drawer's OWN floating close renders even with noHeader,
           so no extra close button here (two would overlap). */}
-      <Drawer
-        destroyOnHidden
-        noHeader
-        containerMaxWidth={'100%'}
-        open={reportRound !== null}
-        placement={'right'}
-        width={'min(960px, 92vw)'}
-        styles={{
-          body: { height: '100%', padding: 0 },
-          bodyContent: { height: '100%', minHeight: 0, overflow: 'hidden' },
-        }}
-        onClose={() => setReportRound(null)}
-      >
-        {reportRound && (
-          <Flexbox style={{ height: '100%', position: 'relative' }}>
-            <ReportViewer runId={reportRound.run.id} />
-          </Flexbox>
-        )}
-      </Drawer>
-    </Flexbox>
-  );
-});
+        <Drawer
+          destroyOnHidden
+          noHeader
+          containerMaxWidth={'100%'}
+          open={reportRound !== null}
+          placement={'right'}
+          width={'min(960px, 92vw)'}
+          styles={{
+            body: { height: '100%', padding: 0 },
+            bodyContent: { height: '100%', minHeight: 0, overflow: 'hidden' },
+          }}
+          onClose={() => setReportRound(null)}
+        >
+          {reportRound && (
+            <Flexbox style={{ height: '100%', position: 'relative' }}>
+              <ReportViewer runId={reportRound.run.id} />
+            </Flexbox>
+          )}
+        </Drawer>
+      </Flexbox>
+    );
+  },
+);
 
 AcceptancePage.displayName = 'AcceptancePage';
 

--- a/src/features/Verify/hooks.ts
+++ b/src/features/Verify/hooks.ts
@@ -15,6 +15,15 @@ const VERIFY_REPORT_SWR_CONFIG = {
   revalidateOnReconnect: false,
 } as const;
 
+// The acceptance bundle is a LIVE decision surface — rounds run and reviews land
+// while the reviewer is away — so unlike the immutable report snapshots it
+// revalidates on focus/reconnect. Coming back to the tab shows the current state
+// without a manual refresh (focus is throttled by SWR's default 5s).
+const ACCEPTANCE_BUNDLE_SWR_CONFIG = {
+  revalidateOnFocus: true,
+  revalidateOnReconnect: true,
+} as const;
+
 /** Plan + rollup status for one Agent Run. Pass null operationId to skip. */
 export const useVerifyState = (operationId: string | null) =>
   useClientDataSWR(operationId ? verifyKeys.state(operationId) : null, () =>
@@ -40,7 +49,7 @@ export const useAcceptanceBundle = (acceptanceId: string | null) =>
   useClientDataSWR(
     acceptanceId ? verifyKeys.acceptanceBundle(acceptanceId) : null,
     () => verifyService.getAcceptanceBundle(acceptanceId!),
-    VERIFY_REPORT_SWR_CONFIG,
+    ACCEPTANCE_BUNDLE_SWR_CONFIG,
   );
 
 /** The caller's recent acceptance aggregates (with subject headers) — the list panel. */


### PR DESCRIPTION
## What & Why

Two acceptance/verify UX fixes.

### 1. Inline mode: send-back drafts into the left composer, not a backend post

In the portal embed (`isEmbedded` — the acceptance shown beside a live conversation), **打回重跑** used to call `verifyService.dispatchAcceptanceRepair`, which silently posts the repair prompt as a user message into the origin topic on the backend.

Inline, the user is *right there* in the conversation — so the send-back now drops the repair prompt into their own composer (`useChatStore` `mainInputEditor` → `setDocument` + `focus`, the same path the suggestion chips use) for them to review and send themselves. No silent backend post behind their back. The rerun action is always offered inline (`rerunAvailable = isEmbedded || …`).

The full-page acceptance route keeps the existing dispatch-to-origin behavior.

> Scope note: this changes **打回重跑** (the action that actually *posts a message*). **评论并打回** (`rejectDelivery`) and the per-check reject (`reviewChecks`) still record their verdicts to the backend, since those aren't "send a message" — happy to route them through the composer too if that's wanted.

### 2. Pending checks keep their image evidence expanded

Expand defaults (P-08: exceptions + visually-evidenced non-accepted checks start open) were seeded by a **one-shot boolean** on first data load. Two ways that left a pending check's screenshots folded:
- the portal embed swaps `acceptanceId` **without remounting**, so a second aggregate never re-seeded and inherited the first's seed;
- if checks streamed in a beat after the bundle, the effect seeded an empty set and then never ran again.

Now seeded **per aggregate** (keyed by `acceptanceId` via a ref) and **only once its checks exist** — so a pending check with image evidence reliably starts expanded, while the user's own toggling within one aggregate is still never overwritten.

## Test plan

- `bun run check` — lint clean (no unit tests on this file)
- Inline portal: a settled-with-feedback acceptance → **打回重跑** drafts the prompt into the left composer + focuses it (toast `已填入对话框`), no backend post
- Full page: **打回重跑** still dispatches to the origin conversation
- Open an acceptance with a pending, image-bearing check → it starts expanded; switch to another aggregate in the portal → that one's pending evidence is expanded too

> New i18n key `acceptance.bar.rerunDrafted` hand-written for en-US + zh-CN; run `bun run i18n` before merge for the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)