### PR TITLE
🐛 fix(conversation): stop double "…is running" line under a settled inline tool

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
@@ -540,6 +540,30 @@ describe('Group', () => {
     expect(screen.getByTestId('tail-running')).toHaveAttribute('data-id', 'assistant-1');
   });
 
+  it('does not add a tail indicator when the inline segment ends on an empty placeholder', () => {
+    // The settled tool is followed by an empty LOADING_FLAT placeholder that
+    // stays inside the inline segment; that block renders its OWN running line,
+    // so the tail must NOT stack a second identical one on top.
+    mockIsGenerating = true;
+    render(
+      <Group
+        isLatestItem
+        id="assistant-1"
+        messageIndex={0}
+        blocks={[
+          blk({
+            content: '',
+            id: 'block-1',
+            tools: [{ apiName: 'bash', id: 'tool-1', result: { content: 'done' } } as any],
+          }),
+          blk({ content: LOADING_FLAT, id: 'block-2' }),
+        ]}
+      />,
+    );
+
+    expect(screen.queryByTestId('tail-running')).not.toBeInTheDocument();
+  });
+
   it('anchors the running indicator to the tool RESULT createdAt, not the tool-call block', () => {
     mockIsGenerating = true;
     // The tool result lands after the tool-call block; the tail timer must start

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
@@ -540,10 +540,10 @@ describe('Group', () => {
     expect(screen.getByTestId('tail-running')).toHaveAttribute('data-id', 'assistant-1');
   });
 
-  it('does not add a tail indicator when the inline segment ends on an empty placeholder', () => {
-    // The settled tool is followed by an empty LOADING_FLAT placeholder that
-    // stays inside the inline segment; that block renders its OWN running line,
-    // so the tail must NOT stack a second identical one on top.
+  it('does not add a tail indicator when the inline segment ends on a LOADING_FLAT placeholder', () => {
+    // The settled tool is followed by a LOADING_FLAT placeholder that stays
+    // inside the inline segment; that block mounts MessageContent and renders
+    // its OWN running line, so the tail must NOT stack a second identical one.
     mockIsGenerating = true;
     render(
       <Group
@@ -562,6 +562,31 @@ describe('Group', () => {
     );
 
     expect(screen.queryByTestId('tail-running')).not.toBeInTheDocument();
+  });
+
+  it('keeps the tail indicator when the trailing block is a blank content:"" shell', () => {
+    // The gateway emits an empty `content: ''` assistant shell on stream_start.
+    // ContentBlock does NOT mount MessageContent for it (no text/LOADING_FLAT/
+    // tools), so it renders no running line of its own — the tail must stay to
+    // fill the gap after the settled tool until the first content chunk lands.
+    mockIsGenerating = true;
+    render(
+      <Group
+        isLatestItem
+        id="assistant-1"
+        messageIndex={0}
+        blocks={[
+          blk({
+            content: '',
+            id: 'block-1',
+            tools: [{ apiName: 'bash', id: 'tool-1', result: { content: 'done' } } as any],
+          }),
+          blk({ content: '', id: 'block-2' }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId('tail-running')).toHaveAttribute('data-id', 'assistant-1');
   });
 
   it('anchors the running indicator to the tool RESULT createdAt, not the tool-call block', () => {

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -471,11 +471,18 @@ const Group = memo<GroupChildrenProps>(
     // fill it. Multi-tool segments keep their own chrome; a tool still executing
     // is covered by its own loading placeholder (areWorkflowToolsComplete=false).
     const lastSegment = segments.at(-1);
+    // …unless that inline segment already ends on an empty placeholder block:
+    // while generating, that block is kept and renders its OWN "…is running"
+    // line (MessageContent → ContentLoading), so a tail indicator here would
+    // stack a second identical line on top of it. Let the block own the gap.
+    const lastInlineBlock =
+      lastSegment?.kind === 'workflow' ? lastSegment.blocks.at(-1) : undefined;
     const showTailRunningIndicator =
       isGenerating &&
       lastSegment?.kind === 'workflow' &&
       shouldInlineWorkflowSegment(lastSegment.blocks) &&
-      areWorkflowToolsComplete(lastSegment.blocks.flatMap((block) => block.tools ?? []));
+      areWorkflowToolsComplete(lastSegment.blocks.flatMap((block) => block.tools ?? [])) &&
+      !(lastInlineBlock && isEmptyBlock(lastInlineBlock));
 
     if (isCollapsed) {
       return (

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -471,18 +471,23 @@ const Group = memo<GroupChildrenProps>(
     // fill it. Multi-tool segments keep their own chrome; a tool still executing
     // is covered by its own loading placeholder (areWorkflowToolsComplete=false).
     const lastSegment = segments.at(-1);
-    // …unless that inline segment already ends on an empty placeholder block:
-    // while generating, that block is kept and renders its OWN "…is running"
-    // line (MessageContent → ContentLoading), so a tail indicator here would
-    // stack a second identical line on top of it. Let the block own the gap.
+    // …unless that inline segment already ends on a LOADING_FLAT placeholder:
+    // that block mounts MessageContent, which renders its OWN "…is running" line
+    // (ContentBlock gates on text/LOADING_FLAT/tools), so the tail would stack a
+    // second identical line on top. Narrowly LOADING_FLAT (and tool-less): a
+    // blank `content: ''` shell — what the gateway emits on stream_start — does
+    // NOT mount MessageContent, so the tail must stay to fill the gap until the
+    // first content chunk lands.
     const lastInlineBlock =
       lastSegment?.kind === 'workflow' ? lastSegment.blocks.at(-1) : undefined;
+    const lastInlineRendersOwnLoading =
+      lastInlineBlock?.content === LOADING_FLAT && !lastInlineBlock.tools?.length;
     const showTailRunningIndicator =
       isGenerating &&
       lastSegment?.kind === 'workflow' &&
       shouldInlineWorkflowSegment(lastSegment.blocks) &&
       areWorkflowToolsComplete(lastSegment.blocks.flatMap((block) => block.tools ?? [])) &&
-      !(lastInlineBlock && isEmptyBlock(lastInlineBlock));
+      !lastInlineRendersOwnLoading;
 
     if (isCollapsed) {
       return (


### PR DESCRIPTION
## What & Why

In a heterogeneous-agent turn (e.g. Claude Code), when the turn ends on a single **inline tool** that has settled but the run is still generating, the message renders **two identical** running lines stacked:

```
Claude Code 正在运行… (3s)
Claude Code 正在运行… (3s)
```

### Root cause

Two independent `ContentLoading` instances resolve the same running op and both render:

- **Source A — group tail indicator** (`Group.tsx`, `showTailRunningIndicator`): fills the gap after a settled inline tool while the run waits for the next step.
- **Source B — block placeholder** (`MessageContent.tsx`): the turn's trailing **empty `LOADING_FLAT` placeholder block** renders its own loading line.

They aren't mutually exclusive. When tools are complete, `getPostToolAnswerSplitIndex` treats the empty trailing block as a foldable status line and keeps it *inside* the inline workflow segment. While generating, that block isn't skipped, so it renders its own `ContentLoading` — and the tail indicator stacks a second identical one on top.

### Fix

Suppress the tail indicator when the inline segment already ends on an empty placeholder block — that block owns the running line. One loader, not two. When the segment ends on the settled tool with no trailing placeholder, the tail still fills the gap as before.

## Test plan

- `bun run check` — lint clean, **17 Group tests pass** including a new regression test (`does not add a tail indicator when the inline segment ends on an empty placeholder`)
- Verified the new test **fails before** the fix and **passes after** (temporarily neutralized the fix clause → test red → restored → green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)