### PR TITLE
🐛 fix: reset client-mode topic status out of running when viewing

### DIFF
--- a/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.test.ts
@@ -182,6 +182,37 @@ describe('buildRunLifecycle.completeRun — client resets a viewed topic out of 
     );
   });
 
+  it('client success on a VIEWED group topic routes the reset to the group bucket (scope: group)', async () => {
+    // A group run's start-write passes scope: 'group'; the reset must too, or the
+    // optimistic patch derives `group_agent` and misses the visible group row.
+    const { get, store } = makeStore();
+    const groupContext = {
+      agentId: 'a1',
+      groupId: 'g1',
+      scope: 'group',
+      topicId: 't1',
+    } as ConversationContext;
+    await buildRunLifecycle(get, {
+      context: groupContext,
+      parentMessageId: 'u1',
+      parentMessageType: 'user',
+      runId: OP,
+      runScope: 'top_level',
+      runtimeType: 'client',
+    }).completeRun({
+      context: groupContext,
+      operationId: OP,
+      runId: OP,
+      runScope: 'top_level',
+      runtimeStatus: 'done',
+      runtimeType: 'client',
+    });
+
+    expect(store.updateTopicStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: 'group', status: 'active', topicId: 't1' }),
+    );
+  });
+
   it('client success while NOT viewing leaves the reset to markTopicUnread (no `active` write)', async () => {
     const { get, store } = makeStore();
     store.activeTopicId = 'other-topic';

--- a/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.test.ts
@@ -63,6 +63,7 @@ const makeStore = (afterCompletionCallbacks?: Array<() => void>) => {
     summaryTopicTitle: vi.fn(),
     // topicDataMap / messagesMap reads default to empty (no topic, no messages).
     topicDataMap: {},
+    updateTopicStatus: vi.fn(async () => {}),
   };
   return { get: (() => store) as unknown as () => ChatStore, store };
 };
@@ -163,6 +164,58 @@ describe('buildRunLifecycle.completeRun — transport-driven disposition', () =>
     await lifecycle('hetero', get).completeRun(completeEvent('hetero', { status: 'completed' }));
 
     expect(cb).toHaveBeenCalledTimes(1);
+  });
+});
+
+// The client transport persists `status: 'running'` at run start; without a
+// terminal reset for the topic the user is viewing, both the sidebar spinner and
+// the home "running" card would stay stuck after the reply finished (the
+// `markTopicUnread` reset early-returns on the active topic). Mirrors gateway's
+// onSessionComplete `viewing || !succeeded → 'active'` rule.
+describe('buildRunLifecycle.completeRun — client resets a viewed topic out of `running`', () => {
+  it('client success while VIEWING the topic force-resets its status to `active`', async () => {
+    const { get, store } = makeStore(); // activeTopicId === 't1' (viewing)
+    await lifecycle('client', get).completeRun(completeEvent('client', { runtimeStatus: 'done' }));
+
+    expect(store.updateTopicStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: 'a1', status: 'active', topicId: 't1' }),
+    );
+  });
+
+  it('client success while NOT viewing leaves the reset to markTopicUnread (no `active` write)', async () => {
+    const { get, store } = makeStore();
+    store.activeTopicId = 'other-topic';
+    await lifecycle('client', get).completeRun(completeEvent('client', { runtimeStatus: 'done' }));
+
+    expect(store.markTopicUnread).toHaveBeenCalled();
+    expect(store.updateTopicStatus).not.toHaveBeenCalled();
+  });
+
+  it('client failure resets the topic to `active` even when not viewing (error is never left `running`)', async () => {
+    const { get, store } = makeStore();
+    store.activeTopicId = 'other-topic';
+    await lifecycle('client', get).completeRun(completeEvent('client', { runtimeStatus: 'error' }));
+
+    expect(store.failOperation).toHaveBeenCalled();
+    expect(store.updateTopicStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'active', topicId: 't1' }),
+    );
+  });
+
+  it('gateway success while viewing does NOT reset via the shared lifecycle (gateway owns its own reset)', async () => {
+    const { get, store } = makeStore();
+    await lifecycle('gateway', get).completeRun(completeEvent('gateway', { status: 'completed' }));
+
+    expect(store.updateTopicStatus).not.toHaveBeenCalled();
+  });
+
+  it('a client sub_agent success does NOT reset the shared topic (sub-agents never wrote `running`)', async () => {
+    const { get, store } = makeStore();
+    await lifecycle('client', get, 'sub_agent').completeRun(
+      completeEvent('client', { runScope: 'sub_agent', runtimeStatus: 'done' }),
+    );
+
+    expect(store.updateTopicStatus).not.toHaveBeenCalled();
   });
 });
 

--- a/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
@@ -341,7 +341,19 @@ export const buildRunLifecycle = (
         // Not-viewing clean success is owned by `markTopicUnread` (→ 'unread');
         // skip so the two never race over the status field.
         if (!viewing && disposition === 'success') return;
-        void get().updateTopicStatus?.({ agentId, groupId, status: 'active', topicId });
+        // Carry the group scope through, exactly like the start-write does. Without
+        // it `updateTopicStatus` auto-derives `group_agent` from agentId+groupId and
+        // the optimistic in-memory patch lands in the wrong bucket, leaving the
+        // VISIBLE group topic's sidebar spinner stuck until the next refetch.
+        void get().updateTopicStatus?.({
+          agentId,
+          groupId,
+          ...(context.scope === 'group' || context.scope === 'group_agent'
+            ? { scope: context.scope }
+            : {}),
+          status: 'active',
+          topicId,
+        });
       };
 
       // 1. afterCompletion callbacks — fire on ALL terminal states (tools that

--- a/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
@@ -323,6 +323,27 @@ export const buildRunLifecycle = (
         }
       };
 
+      // The client transport persists `status: 'running'` at run start
+      // (streamingExecutor) but, unlike gateway (see gateway.ts onSessionComplete),
+      // had no terminal write that flips it back for the topic the user is
+      // watching — `markTopicUnread` early-returns on the active topic, so the
+      // persisted status stayed `running` forever and stuck both the sidebar
+      // spinner and the home "任务正在执行" card. Mirror gateway's rule here: a
+      // clean completion the user isn't watching is owned by `markTopicUnread`
+      // (status: 'unread'); every OTHER case (viewing, error, abort) force-resets
+      // to 'active'. Client + top-level + real topic only — sub-agents never wrote
+      // 'running', and gateway/hetero own their own reset.
+      const resetActiveTopicRunningStatus = () => {
+        if (adapter.runtimeType !== 'client') return;
+        if (adapter.runScope === 'sub_agent') return;
+        if (!topicId) return;
+        const viewing = get().activeTopicId === topicId;
+        // Not-viewing clean success is owned by `markTopicUnread` (→ 'unread');
+        // skip so the two never race over the status field.
+        if (!viewing && disposition === 'success') return;
+        void get().updateTopicStatus?.({ agentId, groupId, status: 'active', topicId });
+      };
+
       // 1. afterCompletion callbacks — fire on ALL terminal states (tools that
       //    registered post-run actions: speak / broadcast / delegate).
       const operation = get().operations[operationId];
@@ -410,6 +431,10 @@ export const buildRunLifecycle = (
         // Parked states never reach `completeRun` — the executor routes them to
         // `onRunParked`.
       }
+
+      // Runs past the requeue early-return, so a run that continues into a queued
+      // follow-up (which writes 'running' again) is never reset mid-flight.
+      resetActiveTopicRunningStatus();
 
       emitComplete(operationId, runtimeStatus);
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- No matching GitHub issue found. -->

#### 🔀 Description of Change

When gateway mode is **off** (client transport), sending a message left the sidebar topic spinning forever and the home inbox stuck at "N 个任务正在执行", even though the assistant reply had already finished.

**Root cause:** since #17194 the client transport persists `topic.status = 'running'` at run start (so the home inbox / Fleet board can see client-driven runs). But it had no terminal write to flip it back for the topic the user is **currently viewing** — the only client reset, `completeSuccess → markTopicUnread`, early-returns when `activeTopicId === topicId`. So the persisted status stayed `running` forever, which drives both the sidebar spinner (`status === 'running'`) and the home running card (`topics.filter(t => t.status === 'running')`).

**Fix:** in `buildRunLifecycle.completeRun`, add `resetActiveTopicRunningStatus()` mirroring the gateway transport's `onSessionComplete` rule — for a client, top-level run on a real topic, write `status: 'active'` whenever `viewing || disposition !== 'success'`. The not-viewing clean-success case stays owned by `markTopicUnread` (→ `'unread'`) so the two never race over the status field. Called **after** the requeue early-return, so a run that continues into a queued follow-up (which re-writes `running`) is never reset mid-flight. Gateway/hetero own their own reset and are untouched; sub-agents never wrote `running`.

#### 🧪 How to Test

Turn off gateway mode, open a topic, send a message. After the reply finishes: the sidebar spinner stops and the home inbox no longer shows the topic as running.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

New regression tests in `buildRunLifecycle.test.ts` ("client resets a viewed topic out of `running`"): client success while viewing → resets to `active`; client failure while not viewing → resets to `active`; client success while not viewing → left to `markTopicUnread`; gateway / client-sub-agent → not reset by the shared lifecycle. Verified the two positive tests fail with the reset call removed.

#### 📝 Additional Information

Follow-up to #17194 (client-run visibility in the home inbox). No schema or API changes.