### PR TITLE
🐛 fix: prevent image/video generation page crash from reused ChatInput action

### DIFF
--- a/src/features/ChatInput/hooks/useChatInputResourceAccess.test.tsx
+++ b/src/features/ChatInput/hooks/useChatInputResourceAccess.test.tsx
@@ -1,0 +1,65 @@
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createStore, Provider } from '../store';
+import { useChatInputResourceAccess } from './useChatInputResourceAccess';
+
+// Isolate the test to the ChatInput-store access behavior: the peripheral
+// stores/permission hooks are stubbed so the only variable is whether a
+// ChatInput store Provider is present.
+const useResourceAccessMock = vi.fn(() => ({
+  canEditResource: true,
+  canManageResource: true,
+  canUseResource: true,
+  isAccessResolved: true,
+  isLoading: false,
+}));
+
+vi.mock('@/features/ResourcePermission/useResourceAccess', () => ({
+  useResourceAccess: (...args: unknown[]) => useResourceAccessMock(...(args as [])),
+}));
+
+vi.mock('@/hooks/usePermission', () => ({
+  usePermission: () => ({ allowed: true, reason: '' }),
+}));
+
+vi.mock('@/store/agent', () => ({ useAgentStore: () => undefined }));
+vi.mock('@/store/agent/selectors', () => ({
+  builtinAgentSelectors: { inboxAgentId: () => undefined },
+}));
+vi.mock('@/store/agentGroup', () => ({ useAgentGroupStore: () => undefined }));
+vi.mock('@/store/agentGroup/selectors', () => ({
+  agentGroupSelectors: { getGroupById: () => () => undefined },
+}));
+
+describe('useChatInputResourceAccess', () => {
+  afterEach(() => {
+    useResourceAccessMock.mockClear();
+  });
+
+  // Regression: the image/video generation prompt reuses ChatInput's <Action>,
+  // which reaches this hook, without wrapping it in a ChatInput store Provider.
+  // Reading the zustand-utils context store directly threw
+  // "...used zustand provider as an ancestor." and crashed the whole page.
+  it('does not throw when rendered without a ChatInput store Provider', () => {
+    const { result } = renderHook(() => useChatInputResourceAccess());
+
+    expect(result.current.canUseResource).toBe(true);
+    expect(result.current.isGroupContext).toBe(false);
+    // No bound agent to gate when there is no store.
+    expect(useResourceAccessMock).toHaveBeenLastCalledWith('agent', undefined);
+  });
+
+  it('reads the bound agentId from the store when a Provider is present', () => {
+    const store = createStore({ agentId: 'agent-1' });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <Provider createStore={() => store}>{children}</Provider>
+    );
+
+    const { result } = renderHook(() => useChatInputResourceAccess(), { wrapper });
+
+    expect(result.current.canUseResource).toBe(true);
+    expect(useResourceAccessMock).toHaveBeenLastCalledWith('agent', 'agent-1');
+  });
+});

--- a/src/features/ChatInput/hooks/useChatInputResourceAccess.ts
+++ b/src/features/ChatInput/hooks/useChatInputResourceAccess.ts
@@ -1,5 +1,8 @@
 'use client';
 
+import { useSyncExternalStore } from 'react';
+import type { StoreApi } from 'zustand';
+
 import { useResourceAccess } from '@/features/ResourcePermission/useResourceAccess';
 import { usePermission } from '@/hooks/usePermission';
 import { useAgentStore } from '@/store/agent';
@@ -7,7 +10,25 @@ import { builtinAgentSelectors } from '@/store/agent/selectors';
 import { useAgentGroupStore } from '@/store/agentGroup';
 import { agentGroupSelectors } from '@/store/agentGroup/selectors';
 
-import { useChatInputStore } from '../store';
+import { type State, useChatInputStoreApiOptional } from '../store';
+
+const EMPTY_SUBSCRIBE = () => () => {};
+
+/**
+ * Reads the bound `agentId` from the ChatInput store, reactively when a store
+ * Provider exists and falling back to `undefined` otherwise. This hook is
+ * reached from the shared <Action> component, which the image/video generation
+ * prompt reuses outside any ChatInput store — reading the store directly there
+ * would throw ("...used zustand provider as an ancestor.").
+ */
+const useChatInputAgentId = (): string | undefined => {
+  const storeApi = useChatInputStoreApiOptional() as StoreApi<State> | undefined;
+  return useSyncExternalStore(
+    storeApi ? storeApi.subscribe : EMPTY_SUBSCRIBE,
+    () => storeApi?.getState().agentId,
+    () => undefined,
+  );
+};
 
 /**
  * Per-resource General-access gating for the chat input: resolves which
@@ -18,7 +39,7 @@ import { useChatInputStore } from '../store';
  * loading defaults permissive — the server remains the enforcement point.
  */
 export const useChatInputResourceAccess = () => {
-  const chatInputAgentId = useChatInputStore((s) => s.agentId);
+  const chatInputAgentId = useChatInputAgentId();
   const inboxAgentId = useAgentStore(builtinAgentSelectors.inboxAgentId);
   const agentVisibility = useAgentStore((s) =>
     chatInputAgentId ? s.agentMap[chatInputAgentId]?.visibility : undefined,

--- a/src/features/ChatInput/store/index.ts
+++ b/src/features/ChatInput/store/index.ts
@@ -1,6 +1,13 @@
 'use client';
 
 import { type StoreApiWithSelector } from '@lobechat/types';
+import {
+  createContext as createReactContext,
+  createElement,
+  type ReactNode,
+  useContext,
+  useRef,
+} from 'react';
 import { subscribeWithSelector } from 'zustand/middleware';
 import { shallow } from 'zustand/shallow';
 import { createWithEqualityFn } from 'zustand/traditional';
@@ -15,10 +22,49 @@ export type { PublicState, State } from './initialState';
 export const createStore = (initState?: Partial<State>) =>
   createWithEqualityFn(subscribeWithSelector(store(initState)), shallow);
 
-export const {
+const {
   useStore: useChatInputStore,
   useStoreApi,
-  Provider,
+  Provider: BaseProvider,
 } = createContext<StoreApiWithSelector<Store>>();
+
+export { useChatInputStore, useStoreApi };
+
+/**
+ * Parallel context that mirrors the ChatInput store api. zustand-utils' own
+ * context throws ("...used zustand provider as an ancestor.") when read without
+ * a Provider, so it cannot answer "is there a store here?". Components reused
+ * outside a chat input — e.g. the image/video generation prompt reuses
+ * ChatInput's <Action> — read this to degrade gracefully instead of crashing.
+ */
+const ChatInputStoreApiContext = createReactContext<StoreApiWithSelector<Store> | undefined>(
+  undefined,
+);
+
+/** The ChatInput store api, or `undefined` when rendered outside a Provider. */
+export const useChatInputStoreApiOptional = (): StoreApiWithSelector<Store> | undefined =>
+  useContext(ChatInputStoreApiContext);
+
+/**
+ * Wraps zustand-utils' Provider and additionally publishes the same store
+ * instance through {@link ChatInputStoreApiContext} for optional reads. Keeps
+ * the exact `{ createStore, children }` API of the original export.
+ */
+export const Provider = ({
+  createStore: create,
+  children,
+}: {
+  children: ReactNode;
+  createStore: () => StoreApiWithSelector<Store>;
+}) => {
+  const storeRef = useRef<StoreApiWithSelector<Store> | undefined>(undefined);
+  if (!storeRef.current) storeRef.current = create();
+  const storeApi = storeRef.current;
+
+  return createElement(BaseProvider, {
+    children: createElement(ChatInputStoreApiContext.Provider, { children, value: storeApi }),
+    createStore: () => storeApi,
+  });
+};
 
 export { selectors } from './selectors';


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

The image/video generation pages (`/image`, `/video`) crashed on load with:

> Error: Seems like you have not used zustand provider as an ancestor.

**Root cause.** The generation prompt input reuses ChatInput's shared `<Action>` component (in the image/video `PromptInput`, and in `GenerationInput`'s `ConfigAction` / `ModelAction`). Since #17192, `<Action>` calls `useChatInputResourceAccess`, whose first line reads `useChatInputStore((s) => s.agentId)`. The ChatInput store is a `zustand-utils` **context** store, so reading it without a `ChatInputProvider` ancestor throws. The generation flow has no such provider, so the whole page crashed (only the main panel — the sidebar topic list rendered fine, which is what confirmed the reused `<Action>` as the culprit rather than the workspace RBAC hooks).

**Fix.** `useChatInputResourceAccess` now reads the bound `agentId` through an optional store api — reactive when a `Provider` exists, `undefined` otherwise. The ChatInput store module exposes `useChatInputStoreApiOptional()` via a parallel context that publishes the same store instance (zustand-utils' own context throws on read, so it can't answer "is there a store here?"). The public `useChatInputStore` / `useStoreApi` / `Provider` API is unchanged. This hardens the shared `<Action>` for any reuse outside a chat input, not just today's four call sites.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Added `useChatInputResourceAccess.test.tsx`: rendering the hook **without** a ChatInput `Provider` no longer throws and returns permissive access; **with** a `Provider` it reads the bound `agentId`. Verified the test fails on the pre-fix code (throws at `useChatInputStore`) and passes after. Full ChatInput suite (13 tests) green; lint clean.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| `/image` shows the "页面暂时不可用" error boundary with `Seems like you have not used zustand provider as an ancestor` | Generation page renders normally |

#### 📝 Additional Information

The reused `<Action>` was the only ChatInput component pulled into the generation tree, so this single hardening covers image and video.