### PR TITLE
🐛 fix: scope connector/skill data to the active workspace

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/composio.personalMultiAccount.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/composio.personalMultiAccount.test.ts
@@ -1,0 +1,234 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentModel } from '@/database/models/agent';
+import { ConnectorModel } from '@/database/models/connector';
+import { ConnectorToolModel } from '@/database/models/connectorTool';
+import { PluginModel } from '@/database/models/plugin';
+
+import { composioRouter } from '../composio';
+
+const linkMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ id: 'acc-new', redirectUrl: 'http://redirect' }),
+);
+
+// Hoisted above the imports at runtime; kept below them for `import-x/first`.
+vi.mock('@/database/models/agent', () => ({ AgentModel: vi.fn() }));
+vi.mock('@/database/models/connector', () => ({ ConnectorModel: vi.fn() }));
+vi.mock('@/database/models/connectorTool', () => ({ ConnectorToolModel: vi.fn() }));
+vi.mock('@/database/models/plugin', () => ({ PluginModel: vi.fn() }));
+vi.mock('@/config/composio', () => ({ getServerComposioAuthConfigId: () => 'auth-cfg-1' }));
+vi.mock('@/libs/composio', () => ({
+  getComposioClient: () => ({
+    connectedAccounts: { delete: vi.fn(), link: linkMock },
+    tools: { getRawComposioTools: async () => ({ items: [] }) },
+  }),
+}));
+vi.mock('@/business/server/trpc-middlewares/workspaceAuth', async () => {
+  const mod = await vi.importActual<{ trpc: any }>('@/libs/trpc/lambda/init');
+  return {
+    requireWorkspaceRoleWhenScoped: () => mod.trpc.middleware(async (opts: any) => opts.next()),
+    wsCompatProcedure: mod.trpc.procedure,
+  };
+});
+vi.mock('@/libs/trpc/lambda/middleware', () => ({
+  serverDatabase: async (opts: any) =>
+    opts.next({ ctx: { ...opts.ctx, serverDB: opts.ctx.serverDB ?? {} } }),
+}));
+
+/**
+ * Personal multi-account (LOBE-12140): a user connecting a SECOND Gmail in
+ * personal scope. The first account keeps the legacy behavior (single-account
+ * default + legacy plugin-table row); additional ones pass allowMultiple and
+ * live only in user_connectors, so the legacy PK — (user_id, identifier), which
+ * can't hold two — is never asked to.
+ */
+describe('composioRouter — personal multi-account', () => {
+  let connectorModelMock: any;
+  let connectorToolModelMock: any;
+  let pluginModelMock: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    linkMock.mockResolvedValue({ id: 'acc-new', redirectUrl: 'http://redirect' });
+    connectorModelMock = {
+      create: vi.fn().mockResolvedValue({ id: 'conn-new' }),
+      delete: vi.fn(),
+      findScopedByComposioAccount: vi.fn().mockResolvedValue(null),
+      findScopedByIdentifier: vi.fn().mockResolvedValue(null),
+      query: vi.fn().mockResolvedValue([]),
+      update: vi.fn().mockResolvedValue(undefined),
+    };
+    connectorToolModelMock = {
+      deleteToolsNotIn: vi.fn(),
+      queryByConnectorIds: vi.fn().mockResolvedValue([]),
+      upsertMany: vi.fn(),
+    };
+    pluginModelMock = {
+      create: vi.fn(),
+      delete: vi.fn(),
+      findById: vi.fn().mockResolvedValue(null),
+      query: vi.fn().mockResolvedValue([]),
+      update: vi.fn(),
+    };
+    vi.mocked(ConnectorModel).mockImplementation(() => connectorModelMock);
+    vi.mocked(ConnectorToolModel).mockImplementation(() => connectorToolModelMock);
+    vi.mocked(PluginModel).mockImplementation(() => pluginModelMock);
+    vi.mocked(AgentModel).mockImplementation(() => ({ existsOwnedById: async () => true }) as any);
+  });
+
+  // Personal scope: no workspaceId, no agentId.
+  const personalCaller = () =>
+    composioRouter.createCaller({ serverDB: {}, userId: 'user_test', workspaceId: null } as any);
+
+  const input = { appSlug: 'gmail', identifier: 'gmail', label: 'Gmail' };
+
+  describe('createConnection', () => {
+    it('the FIRST personal account keeps the single-account default and writes the legacy row', async () => {
+      // No existing account anywhere → first account.
+      await personalCaller().createConnection(input);
+
+      expect(linkMock.mock.calls[0][2]).not.toHaveProperty('allowMultiple');
+      expect(pluginModelMock.create).toHaveBeenCalledWith(
+        expect.objectContaining({ identifier: 'gmail', source: 'composio' }),
+      );
+    });
+
+    it('a SECOND account (first already in user_connectors) passes allowMultiple and skips the legacy row', async () => {
+      // The first account already lives in the connector table (base row).
+      connectorModelMock.findScopedByIdentifier.mockResolvedValue({
+        id: 'conn-first',
+        userId: 'user_test',
+      });
+
+      await personalCaller().createConnection(input);
+
+      expect(linkMock).toHaveBeenCalledWith(
+        'user_test',
+        'auth-cfg-1',
+        expect.objectContaining({ allowMultiple: true }),
+      );
+      expect(pluginModelMock.create).not.toHaveBeenCalled();
+      // It still lands in user_connectors as its OWN new row.
+      expect(connectorModelMock.create).toHaveBeenCalled();
+    });
+
+    it('detects the second account even when the first exists only in the legacy table', async () => {
+      // Legacy-only first account (pre-dual-write), no connector row yet.
+      pluginModelMock.findById.mockResolvedValue({
+        customParams: { composio: { connectedAccountId: 'acc-old' } },
+        identifier: 'gmail',
+      });
+
+      await personalCaller().createConnection(input);
+
+      expect(linkMock.mock.calls[0][2]).toHaveProperty('allowMultiple', true);
+      // The legacy row (first account) must not be overwritten by the second.
+      expect(pluginModelMock.create).not.toHaveBeenCalled();
+    });
+
+    it('a new account creates its OWN connector row rather than overwriting a sibling', async () => {
+      // Second account: base row for a DIFFERENT account exists (isAdditional),
+      // but no row for THIS connectedAccountId yet.
+      connectorModelMock.findScopedByIdentifier.mockResolvedValue({ id: 'conn-first' });
+      connectorModelMock.findScopedByComposioAccount.mockResolvedValue(null);
+
+      await personalCaller().createConnection(input);
+
+      expect(connectorModelMock.create).toHaveBeenCalled();
+      expect(connectorModelMock.update).not.toHaveBeenCalled();
+    });
+
+    it('reconnecting the SAME account updates its row, not a create', async () => {
+      connectorModelMock.findScopedByIdentifier.mockResolvedValue({ id: 'conn-first' });
+      // A row for this exact connectedAccountId already exists → update it.
+      connectorModelMock.findScopedByComposioAccount.mockResolvedValue({ id: 'conn-existing' });
+
+      await personalCaller().createConnection(input);
+
+      expect(connectorModelMock.update).toHaveBeenCalledWith('conn-existing', expect.anything());
+      expect(connectorModelMock.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteConnection', () => {
+    it('deleting a SECOND account does not wipe the first account’s legacy row', async () => {
+      // Legacy row belongs to the FIRST account (acc-old); we delete acc-2.
+      pluginModelMock.findById.mockResolvedValue({
+        customParams: { composio: { connectedAccountId: 'acc-old' } },
+        identifier: 'gmail',
+      });
+      connectorModelMock.findScopedByComposioAccount.mockResolvedValue({ id: 'conn-2' });
+
+      await personalCaller().deleteConnection({
+        connectedAccountId: 'acc-2',
+        identifier: 'gmail',
+      });
+
+      expect(pluginModelMock.delete).not.toHaveBeenCalled();
+      // The connector-table row for acc-2 IS removed.
+      expect(connectorModelMock.delete).toHaveBeenCalledWith('conn-2');
+    });
+
+    it('deleting the FIRST account (the legacy one) removes its legacy row', async () => {
+      pluginModelMock.findById.mockResolvedValue({
+        customParams: { composio: { connectedAccountId: 'acc-old' } },
+        identifier: 'gmail',
+      });
+      connectorModelMock.findScopedByComposioAccount.mockResolvedValue({ id: 'conn-old' });
+
+      await personalCaller().deleteConnection({
+        connectedAccountId: 'acc-old',
+        identifier: 'gmail',
+      });
+
+      expect(pluginModelMock.delete).toHaveBeenCalledWith('gmail');
+    });
+  });
+
+  describe('getComposioPlugins — account-level dedup', () => {
+    it('collapses the legacy row and its connector-row twin (same account) into one', async () => {
+      pluginModelMock.query.mockResolvedValue([
+        {
+          customParams: { composio: { connectedAccountId: 'acc-1', status: 'ACTIVE' } },
+          identifier: 'gmail',
+          manifest: {},
+        },
+      ]);
+      connectorModelMock.query.mockResolvedValue([
+        {
+          id: 'conn-1',
+          identifier: 'gmail',
+          metadata: { composio: { connectedAccountId: 'acc-1', status: 'ACTIVE' } },
+          name: 'Gmail',
+        },
+      ]);
+
+      const result = await personalCaller().getComposioPlugins();
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('keeps a second, genuinely different account of the same identifier', async () => {
+      pluginModelMock.query.mockResolvedValue([
+        {
+          customParams: { composio: { connectedAccountId: 'acc-1', status: 'ACTIVE' } },
+          identifier: 'gmail',
+          manifest: {},
+        },
+      ]);
+      connectorModelMock.query.mockResolvedValue([
+        {
+          id: 'conn-2',
+          identifier: 'gmail',
+          metadata: { composio: { connectedAccountId: 'acc-2', status: 'ACTIVE' } },
+          name: 'Gmail',
+        },
+      ]);
+
+      const result = await personalCaller().getComposioPlugins();
+
+      expect(result).toHaveLength(2);
+    });
+  });
+});

--- a/apps/server/src/routers/lambda/__tests__/composio.workspaceBaseScope.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/composio.workspaceBaseScope.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentModel } from '@/database/models/agent';
+import { ConnectorModel } from '@/database/models/connector';
+import { ConnectorToolModel } from '@/database/models/connectorTool';
+import { PluginModel } from '@/database/models/plugin';
+
+import { composioRouter } from '../composio';
+
+const linkMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ id: 'acc-1', redirectUrl: 'http://redirect' }),
+);
+
+// Hoisted above the imports at runtime; kept below them for `import-x/first`.
+vi.mock('@/database/models/agent', () => ({ AgentModel: vi.fn() }));
+vi.mock('@/database/models/connector', () => ({ ConnectorModel: vi.fn() }));
+vi.mock('@/database/models/connectorTool', () => ({ ConnectorToolModel: vi.fn() }));
+vi.mock('@/database/models/plugin', () => ({ PluginModel: vi.fn() }));
+vi.mock('@/config/composio', () => ({ getServerComposioAuthConfigId: () => 'auth-cfg-1' }));
+vi.mock('@/libs/composio', () => ({
+  getComposioClient: () => ({
+    connectedAccounts: { delete: vi.fn(), link: linkMock },
+    tools: { getRawComposioTools: async () => ({ items: [] }) },
+  }),
+}));
+vi.mock('@/business/server/trpc-middlewares/workspaceAuth', async () => {
+  const mod = await vi.importActual<{ trpc: any }>('@/libs/trpc/lambda/init');
+  return {
+    requireWorkspaceRoleWhenScoped: () => mod.trpc.middleware(async (opts: any) => opts.next()),
+    wsCompatProcedure: mod.trpc.procedure,
+  };
+});
+vi.mock('@/libs/trpc/lambda/middleware', () => ({
+  serverDatabase: async (opts: any) =>
+    opts.next({ ctx: { ...opts.ctx, serverDB: opts.ctx.serverDB ?? {} } }),
+}));
+
+/**
+ * Workspace BASE connections (no agentId) — the scope that used to be treated
+ * as "personal" simply because it wasn't agent-scoped.
+ */
+describe('composioRouter — workspace base scope', () => {
+  let connectorModelMock: any;
+  let connectorToolModelMock: any;
+  let pluginModelMock: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    linkMock.mockResolvedValue({ id: 'acc-1', redirectUrl: 'http://redirect' });
+    connectorModelMock = {
+      create: vi.fn().mockResolvedValue({ id: 'conn-new' }),
+      findScopedByIdentifier: vi.fn().mockResolvedValue(null),
+      query: vi.fn().mockResolvedValue([]),
+      update: vi.fn().mockResolvedValue(undefined),
+    };
+    connectorToolModelMock = {
+      deleteToolsNotIn: vi.fn(),
+      queryByConnectorIds: vi.fn().mockResolvedValue([]),
+      upsertMany: vi.fn(),
+    };
+    pluginModelMock = {
+      create: vi.fn(),
+      delete: vi.fn(),
+      findById: vi.fn(),
+      query: vi.fn().mockResolvedValue([]),
+      update: vi.fn(),
+    };
+    vi.mocked(ConnectorModel).mockImplementation(() => connectorModelMock);
+    vi.mocked(ConnectorToolModel).mockImplementation(() => connectorToolModelMock);
+    vi.mocked(PluginModel).mockImplementation(() => pluginModelMock);
+    vi.mocked(AgentModel).mockImplementation(() => ({ existsOwnedById: async () => true }) as any);
+  });
+
+  const callerFor = (workspaceId?: string) =>
+    composioRouter.createCaller({
+      serverDB: {},
+      userId: 'user_test',
+      workspaceId: workspaceId ?? null,
+    } as any);
+
+  const input = { appSlug: 'gmail', identifier: 'gmail', label: 'Gmail' };
+
+  // Our Composio user entity is the bare userId, so a workspace connection is a
+  // SECOND account under the same (entity, auth config). Without allowMultiple
+  // Composio rejects it outright — "Multiple connected accounts found for user
+  // … Please use the allowMultiple option" — and connecting Gmail inside a
+  // workspace was impossible for anyone who had connected it personally.
+  it('asks Composio for an additional account when connecting inside a workspace', async () => {
+    await callerFor('ws-1').createConnection(input);
+
+    expect(linkMock).toHaveBeenCalledWith(
+      'user_test',
+      'auth-cfg-1',
+      expect.objectContaining({ allowMultiple: true }),
+    );
+  });
+
+  it('keeps the single-account default for a personal connection', async () => {
+    await callerFor().createConnection(input);
+
+    expect(linkMock.mock.calls[0][2]).not.toHaveProperty('allowMultiple');
+  });
+
+  // `user_installed_plugins` is keyed by (user_id, identifier), so a workspace
+  // write upserts onto the PERSONAL row — repointing the user's personal
+  // connection at the workspace's Composio account while leaving the workspace
+  // with no row. Workspace connections must skip the legacy projection.
+  it('does not touch the legacy plugin table for a workspace connection', async () => {
+    await callerFor('ws-1').createConnection(input);
+
+    expect(pluginModelMock.create).not.toHaveBeenCalled();
+    // It still lands in user_connectors, which IS workspace-dimensioned.
+    expect(connectorModelMock.create).toHaveBeenCalled();
+  });
+
+  it('still writes the legacy projection for a personal connection', async () => {
+    await callerFor().createConnection(input);
+
+    expect(pluginModelMock.create).toHaveBeenCalledWith(
+      expect.objectContaining({ identifier: 'gmail', source: 'composio' }),
+    );
+  });
+
+  it('leaves the personal plugin row alone when a workspace connection is deleted', async () => {
+    await callerFor('ws-1').deleteConnection({
+      connectedAccountId: 'acc-1',
+      identifier: 'gmail',
+    });
+
+    expect(pluginModelMock.delete).not.toHaveBeenCalled();
+  });
+
+  // Workspace connections live only in user_connectors, so the read path has to
+  // union both stores — otherwise the workspace's own connections render as
+  // "not connected" and the UI offers to redo an OAuth flow already completed.
+  it('surfaces connector-only (workspace) connections through getComposioPlugins', async () => {
+    connectorModelMock.query.mockResolvedValue([
+      {
+        id: 'conn-1',
+        identifier: 'gmail',
+        metadata: { composio: { appSlug: 'gmail', status: 'ACTIVE' } },
+        name: 'Gmail',
+      },
+    ]);
+    connectorToolModelMock.queryByConnectorIds.mockResolvedValue([
+      {
+        description: 'send',
+        inputSchema: undefined,
+        toolName: 'GMAIL_SEND',
+        userConnectorId: 'conn-1',
+      },
+    ]);
+
+    const result = await callerFor('ws-1').getComposioPlugins();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      customParams: { composio: { status: 'ACTIVE' } },
+      identifier: 'gmail',
+    });
+    expect(result[0].manifest?.api?.[0]).toMatchObject({ name: 'GMAIL_SEND' });
+  });
+
+  it('prefers the plugin row when both stores hold the same identifier', async () => {
+    pluginModelMock.query.mockResolvedValue([
+      { customParams: { composio: { status: 'ACTIVE' } }, identifier: 'gmail', manifest: {} },
+    ]);
+    connectorModelMock.query.mockResolvedValue([
+      {
+        id: 'conn-1',
+        identifier: 'gmail',
+        metadata: { composio: { status: 'PENDING' } },
+        name: 'Gmail',
+      },
+    ]);
+
+    const result = await callerFor().getComposioPlugins();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].customParams?.composio?.status).toBe('ACTIVE');
+  });
+});

--- a/apps/server/src/routers/lambda/__tests__/composio.workspaceBaseScope.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/composio.workspaceBaseScope.test.ts
@@ -50,6 +50,8 @@ describe('composioRouter — workspace base scope', () => {
     linkMock.mockResolvedValue({ id: 'acc-1', redirectUrl: 'http://redirect' });
     connectorModelMock = {
       create: vi.fn().mockResolvedValue({ id: 'conn-new' }),
+      delete: vi.fn(),
+      findScopedByComposioAccount: vi.fn().mockResolvedValue(null),
       findScopedByIdentifier: vi.fn().mockResolvedValue(null),
       query: vi.fn().mockResolvedValue([]),
       update: vi.fn().mockResolvedValue(undefined),

--- a/apps/server/src/routers/lambda/__tests__/composio.workspaceScope.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/composio.workspaceScope.test.ts
@@ -52,6 +52,8 @@ describe('composioRouter — workspace scoping (workspace-agent connector bug)',
     vi.clearAllMocks();
     connectorModelMock = {
       create: vi.fn().mockResolvedValue({ id: 'conn-new' }),
+      delete: vi.fn(),
+      findScopedByComposioAccount: vi.fn().mockResolvedValue(null),
       findScopedByIdentifier: vi.fn().mockResolvedValue(null),
       update: vi.fn().mockResolvedValue(undefined),
     };

--- a/apps/server/src/routers/lambda/__tests__/connector.startOAuth.workspaceScope.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/connector.startOAuth.workspaceScope.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ConnectorModel } from '@/database/models/connector';
+import { ConnectorToolModel } from '@/database/models/connectorTool';
+import { PluginModel } from '@/database/models/plugin';
+import { saveConnectorOAuthState } from '@/server/services/connector/stateStore';
+
+import { connectorRouter } from '../connector';
+
+// Same hoisting note as connector.syncPluginTools.test.ts: `vi.mock` is lifted
+// above the imports at runtime, so the mocks are active when the router module
+// evaluates. They sit below the imports to satisfy `import-x/first`.
+vi.mock('@/database/models/agent', () => ({ AgentModel: vi.fn() }));
+vi.mock('@/database/models/connector', () => ({ ConnectorModel: vi.fn() }));
+vi.mock('@/database/models/connectorTool', () => ({ ConnectorToolModel: vi.fn() }));
+vi.mock('@/database/models/plugin', () => ({ PluginModel: vi.fn() }));
+vi.mock('@/server/modules/KeyVaultsEncrypt', () => ({
+  KeyVaultsGateKeeper: { initWithEnvKey: async () => ({}) },
+}));
+vi.mock('@/business/server/trpc-middlewares/workspaceAuth', async () => {
+  const mod = await vi.importActual<{ trpc: any }>('@/libs/trpc/lambda/init');
+  return {
+    requireWorkspaceRoleWhenScoped: () => mod.trpc.middleware(async (opts: any) => opts.next()),
+    wsCompatProcedure: mod.trpc.procedure,
+  };
+});
+vi.mock('@/libs/trpc/lambda/middleware', () => ({
+  serverDatabase: async (opts: any) =>
+    opts.next({ ctx: { ...opts.ctx, serverDB: opts.ctx.serverDB ?? {} } }),
+}));
+vi.mock('@/server/services/connector/oauth', () => ({
+  buildAuthorizationUrl: vi
+    .fn()
+    .mockResolvedValue({ authorizationUrl: 'https://as/authorize', codeVerifier: 'verifier' }),
+  discoverConnectorOAuth: vi.fn().mockResolvedValue({
+    authorizationServerUrl: 'https://as',
+    metadata: {
+      authorization_endpoint: 'https://as/authorize',
+      registration_endpoint: 'https://as/register',
+      scopes_supported: ['read'],
+      token_endpoint: 'https://as/token',
+    },
+  }),
+  getConnectorRedirectUri: () => 'https://app.example.com/oauth/connector/callback',
+  registerDynamicClient: vi.fn(),
+}));
+vi.mock('@/server/services/connector/stateStore', () => ({
+  generateConnectorOAuthState: () => 'state-token',
+  saveConnectorOAuthState: vi.fn(),
+}));
+
+/**
+ * The OAuth callback is a browser redirect from the authorization server — it
+ * carries no `X-Workspace-Id` header, so the scope can only reach it through
+ * the Redis-backed state payload. If `startOAuth` omits it, the callback builds
+ * its models scope-less, `buildWorkspaceWhere` reads that as "personal only"
+ * (`workspace_id IS NULL`), and `findById` misses every workspace connector —
+ * authorization dies on `connector_not_found`. See the callback-side half in
+ * src/app/(backend)/oauth/connector/callback/route.test.ts.
+ */
+describe('connectorRouter.startOAuth — workspace scope survives the redirect', () => {
+  let connectorModelMock: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    connectorModelMock = {
+      findById: vi.fn().mockResolvedValue({
+        id: 'conn-1',
+        mcpServerUrl: 'https://mcp.example.com',
+        oidcConfig: { clientId: 'cid', scheme: 'pre_registration' },
+        userId: 'user_test',
+      }),
+      update: vi.fn(),
+    };
+
+    vi.mocked(ConnectorModel).mockImplementation(() => connectorModelMock);
+    vi.mocked(ConnectorToolModel).mockImplementation(() => ({}) as any);
+    vi.mocked(PluginModel).mockImplementation(() => ({}) as any);
+  });
+
+  const callerFor = (workspaceId?: string) =>
+    connectorRouter.createCaller({
+      serverDB: {},
+      userId: 'user_test',
+      workspaceId: workspaceId ?? null,
+    } as any);
+
+  const connectorId = '00000000-0000-4000-8000-000000000001';
+
+  it('stashes the active workspace id in the OAuth state', async () => {
+    await callerFor('ws-1').startOAuth({ id: connectorId });
+
+    expect(saveConnectorOAuthState).toHaveBeenCalledWith(
+      'state-token',
+      expect.objectContaining({ lobeUserId: 'user_test', workspaceId: 'ws-1' }),
+    );
+  });
+
+  it('leaves the workspace id undefined for a personal-scope flow', async () => {
+    await callerFor().startOAuth({ id: connectorId });
+
+    expect(saveConnectorOAuthState).toHaveBeenCalledWith(
+      'state-token',
+      expect.objectContaining({ lobeUserId: 'user_test', workspaceId: undefined }),
+    );
+  });
+});

--- a/apps/server/src/routers/lambda/composio.test.ts
+++ b/apps/server/src/routers/lambda/composio.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   connectedAccountsLink: vi.fn(),
   connectorCreate: vi.fn(),
   connectorDelete: vi.fn(),
+  connectorFindScopedByComposioAccount: vi.fn(),
   connectorFindScopedByIdentifier: vi.fn(),
   connectorToolDeleteToolsNotIn: vi.fn(),
   connectorToolUpsertMany: vi.fn(),
@@ -44,6 +45,7 @@ vi.mock('@/database/models/connector', () => ({
   ConnectorModel: vi.fn().mockImplementation(() => ({
     create: mocks.connectorCreate,
     delete: mocks.connectorDelete,
+    findScopedByComposioAccount: mocks.connectorFindScopedByComposioAccount,
     findScopedByIdentifier: mocks.connectorFindScopedByIdentifier,
     update: mocks.connectorUpdate,
   })),
@@ -69,6 +71,7 @@ const caller = () => composioRouter.createCaller({ userId: 'user-1' } as any);
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.connectorFindScopedByIdentifier.mockResolvedValue(null);
+  mocks.connectorFindScopedByComposioAccount.mockResolvedValue(null);
   mocks.connectorCreate.mockResolvedValue({ id: 'conn-new' });
   mocks.pluginFindById.mockResolvedValue(undefined);
 });
@@ -131,7 +134,8 @@ describe('composioRouter.updateComposioPlugin dual-write', () => {
   });
 
   it('updates an existing connector projection instead of duplicating it', async () => {
-    mocks.connectorFindScopedByIdentifier.mockResolvedValue({ id: 'conn-existing' });
+    // Idempotency is now by connected account, not identifier.
+    mocks.connectorFindScopedByComposioAccount.mockResolvedValue({ id: 'conn-existing' });
 
     await caller().updateComposioPlugin(input);
 
@@ -152,7 +156,7 @@ describe('composioRouter.updateComposioPlugin dual-write', () => {
   });
 
   it('prunes all connector tools when the refreshed list is empty', async () => {
-    mocks.connectorFindScopedByIdentifier.mockResolvedValue({ id: 'conn-existing' });
+    mocks.connectorFindScopedByComposioAccount.mockResolvedValue({ id: 'conn-existing' });
 
     await caller().updateComposioPlugin({ ...input, tools: [] });
 
@@ -174,7 +178,14 @@ describe('composioRouter delete paths clean up the connector projection', () => 
 
   it('deleteConnection deletes both plugin and connector', async () => {
     mocks.connectedAccountsDelete.mockResolvedValue(undefined);
-    mocks.connectorFindScopedByIdentifier.mockResolvedValue({ id: 'conn-existing' });
+    // The legacy row belongs to THIS account (matched by connectedAccountId), so
+    // deleting it removes the legacy projection too; the connector row is located
+    // by the same account id.
+    mocks.pluginFindById.mockResolvedValue({
+      customParams: { composio: { connectedAccountId: 'ca-1' } },
+      identifier: 'gmail',
+    });
+    mocks.connectorFindScopedByComposioAccount.mockResolvedValue({ id: 'conn-existing' });
 
     await caller().deleteConnection({ connectedAccountId: 'ca-1', identifier: 'gmail' });
 

--- a/apps/server/src/routers/lambda/composio.ts
+++ b/apps/server/src/routers/lambda/composio.ts
@@ -128,9 +128,17 @@ async function upsertComposioConnector(
         ? ConnectorStatus.error
         : ConnectorStatus.disconnected;
 
-  // Exact-scope idempotency: an agent connection updates/creates the agent's own
-  // row, a personal connection the base row — never crossing scopes.
-  const existing = await connectorModel.findScopedByIdentifier(params.identifier, params.agentId);
+  // Idempotency key is the connected ACCOUNT, not the identifier: a second
+  // account of the same identifier must create its OWN row, not overwrite the
+  // first one's. Falls back to scope+identifier only when no connectedAccountId
+  // is available (defensive — Composio rows always carry one). Scope is still
+  // honored (agent row vs base row) via the agentId passed through.
+  const existing = params.composio.connectedAccountId
+    ? await connectorModel.findScopedByComposioAccount(
+        params.composio.connectedAccountId,
+        params.agentId,
+      )
+    : await connectorModel.findScopedByIdentifier(params.identifier, params.agentId);
   let connectorId: string;
   if (existing) {
     await connectorModel.update(existing.id, {
@@ -176,13 +184,21 @@ async function upsertComposioConnector(
   }
 }
 
-/** Remove the connector projection for a Composio identifier (tools cascade). */
+/**
+ * Remove the connector projection for ONE Composio account (tools cascade).
+ * Prefers the exact-account lookup so deleting one account of a multi-account
+ * identifier can't remove a sibling; falls back to scope+identifier only when no
+ * connectedAccountId is supplied (e.g. removeComposioPlugin, which has none).
+ */
 async function deleteComposioConnector(
   connectorModel: ConnectorModel,
   identifier: string,
   agentId?: string,
+  connectedAccountId?: string,
 ): Promise<void> {
-  const existing = await connectorModel.findScopedByIdentifier(identifier, agentId);
+  const existing = connectedAccountId
+    ? await connectorModel.findScopedByComposioAccount(connectedAccountId, agentId)
+    : await connectorModel.findScopedByIdentifier(identifier, agentId);
   if (existing) await connectorModel.delete(existing.id);
 }
 
@@ -219,6 +235,21 @@ export const composioRouter = router({
       const { appSlug, identifier, label, agentId } = input;
       const { userId } = ctx;
       const isPersonalScope = !agentId && !ctx.workspaceId;
+
+      // Personal multi-account: is this a SECOND (or later) account of the same
+      // identifier in personal scope? The first personal connection keeps the
+      // legacy behavior (single-account default + legacy plugin-table
+      // projection); additional ones must ask Composio for an extra account
+      // (allowMultiple) and skip the legacy table — keyed by (user_id,
+      // identifier), it structurally can't hold two. See LOBE-12140.
+      let isAdditionalPersonalAccount = false;
+      if (isPersonalScope) {
+        const [existingLegacy, existingBase] = await Promise.all([
+          ctx.pluginModel.findById(identifier),
+          ctx.connectorModel.findScopedByIdentifier(identifier),
+        ]);
+        isAdditionalPersonalAccount = !!(existingLegacy || existingBase);
+      }
 
       if (agentId)
         await assertCanEditAgent(ctx.serverDB, userId, agentId, ctx.workspaceId ?? undefined);
@@ -265,11 +296,15 @@ export const composioRouter = router({
       // connectedAccountId. That applies to workspace connections exactly as it
       // does to agent ones; omitting it there made "connect Gmail inside a
       // workspace" fail outright for anyone who had already connected Gmail
-      // personally. Only a personal connection keeps the one-account default.
+      // personally. Only the FIRST personal connection keeps the one-account
+      // default; additional personal accounts pass allowMultiple too (LOBE-12140).
       const connReq = await (ctx.composioClient.connectedAccounts as any).link(
         userId,
         authConfigId,
-        { callbackUrl, ...(isPersonalScope ? {} : { allowMultiple: true }) },
+        {
+          callbackUrl,
+          ...(isPersonalScope && !isAdditionalPersonalAccount ? {} : { allowMultiple: true }),
+        },
       );
 
       let rawTools: any[] = [];
@@ -313,7 +348,10 @@ export const composioRouter = router({
       // workspace with no row at all. So workspace connections skip it, the way
       // agent connections already do, and resolve off the connector row's
       // metadata instead — see `getComposioPlugins`, which unions both sources.
-      if (isPersonalScope) {
+      // A personal SECOND+ account skips it for the same structural reason (the
+      // PK can't hold two per identifier); only the first personal account, which
+      // is the one that PK can hold, keeps the legacy projection (LOBE-12140).
+      if (isPersonalScope && !isAdditionalPersonalAccount) {
         await ctx.pluginModel.create({
           customParams: {
             composio: {
@@ -382,12 +420,24 @@ export const composioRouter = router({
         console.warn('[Composio] Failed to delete remote connection:', error);
       }
 
-      // Only personal connections have a plugin-table row (see createConnection);
-      // agent and workspace ones live solely in `user_connectors`. The delete is
-      // ownership-scoped so it would be a no-op elsewhere anyway, but keeping the
-      // condition aligned with the write side is what stops the two from drifting.
-      if (!input.agentId && !ctx.workspaceId) await ctx.pluginModel.delete(input.identifier);
-      await deleteComposioConnector(ctx.connectorModel, input.identifier, input.agentId);
+      // The legacy plugin-table row exists only for the FIRST personal account
+      // (see createConnection). Delete it only when the account being removed IS
+      // that one — matched by connectedAccountId. Deleting a personal SECOND+
+      // account (which lives only in user_connectors) must NOT wipe the first
+      // account's legacy row: the legacy delete is by identifier and can't tell
+      // the accounts apart, so gate it on the account id. See LOBE-12140.
+      if (!input.agentId && !ctx.workspaceId) {
+        const legacy = await ctx.pluginModel.findById(input.identifier);
+        if (legacy?.customParams?.composio?.connectedAccountId === input.connectedAccountId) {
+          await ctx.pluginModel.delete(input.identifier);
+        }
+      }
+      await deleteComposioConnector(
+        ctx.connectorModel,
+        input.identifier,
+        input.agentId,
+        input.connectedAccountId,
+      );
 
       return { success: true };
     }),
@@ -406,8 +456,12 @@ export const composioRouter = router({
    *   `/settings/connector` — and the connect button would restart an OAuth
    *   flow that has already been completed.
    *
-   * Plugin rows win on identifier collision: in personal scope both stores are
-   * written, and the plugin row is the one the legacy client shape came from.
+   * Plugin rows win on ACCOUNT collision: in personal scope the first account is
+   * written to both stores, and the plugin row is the one the legacy client shape
+   * came from. Dedup is by `connectedAccountId`, NOT identifier, so a second
+   * account of the same identifier (workspace, or a personal multi-account — only
+   * in `user_connectors`) is a distinct account and survives instead of being
+   * swallowed by the first one's plugin row. See LOBE-12140.
    */
   getComposioPlugins: composioProcedure.query(async ({ ctx }) => {
     const plugins = (await ctx.pluginModel.query()).filter(
@@ -419,7 +473,19 @@ export const composioRouter = router({
     );
     if (composioConnectors.length === 0) return plugins;
 
-    const seen = new Set(plugins.map((plugin) => plugin.identifier));
+    // Dedup by connected account. An account already surfaced from the legacy
+    // plugin table must not be re-projected from its connector-row twin (the
+    // personal dual-write), but a genuinely different account of the same
+    // identifier has a different connectedAccountId and is kept. Falls back to
+    // identifier when a row carries no connectedAccountId (defensive — collapses
+    // to the pre-multi-account behavior rather than risking a duplicate).
+    const accountKey = (
+      composio: { connectedAccountId?: string } | undefined,
+      identifier: string,
+    ) => composio?.connectedAccountId ?? identifier;
+    const seen = new Set(
+      plugins.map((plugin) => accountKey(plugin.customParams?.composio, plugin.identifier)),
+    );
     const tools = await ctx.connectorToolModel.queryByConnectorIds(
       composioConnectors.map((connector) => connector.id),
     );
@@ -433,7 +499,9 @@ export const composioRouter = router({
     // Project connector rows into the legacy plugin shape the client renders,
     // so the union is invisible to callers.
     const projected = composioConnectors
-      .filter((connector) => !seen.has(connector.identifier))
+      .filter(
+        (connector) => !seen.has(accountKey(connector.metadata?.composio, connector.identifier)),
+      )
       .map((connector) => ({
         customParams: { composio: connector.metadata!.composio },
         identifier: connector.identifier,

--- a/apps/server/src/routers/lambda/composio.ts
+++ b/apps/server/src/routers/lambda/composio.ts
@@ -218,6 +218,7 @@ export const composioRouter = router({
     .mutation(async ({ input, ctx }) => {
       const { appSlug, identifier, label, agentId } = input;
       const { userId } = ctx;
+      const isPersonalScope = !agentId && !ctx.workspaceId;
 
       if (agentId)
         await assertCanEditAgent(ctx.serverDB, userId, agentId, ctx.workspaceId ?? undefined);
@@ -256,16 +257,19 @@ export const composioRouter = router({
       // Composio-managed OAuth auth configs no longer support `initiate`; use
       // `link` (POST /api/v3/connected_accounts/link) to get the redirect URL.
       //
-      // `allowMultiple` for agent connections: Composio rejects a second linked
-      // account for the same (user entity, auth config) unless this is set. An
-      // agent connector is intentionally a *separate* account from the user's
-      // (and from other agents'), all under the same Composio user entity but
-      // distinguished by connectedAccountId — so agent links must allow multiple.
-      // Personal connections keep the default (one account per auth config).
+      // `allowMultiple`: Composio rejects a second linked account for the same
+      // (user entity, auth config) unless this is set. Our Composio user entity
+      // is the bare `userId` — it carries no workspace or agent dimension — so
+      // EVERY scope beyond the user's personal one is necessarily an additional
+      // account under that same entity, distinguished only by
+      // connectedAccountId. That applies to workspace connections exactly as it
+      // does to agent ones; omitting it there made "connect Gmail inside a
+      // workspace" fail outright for anyone who had already connected Gmail
+      // personally. Only a personal connection keeps the one-account default.
       const connReq = await (ctx.composioClient.connectedAccounts as any).link(
         userId,
         authConfigId,
-        { callbackUrl, ...(agentId ? { allowMultiple: true } : {}) },
+        { callbackUrl, ...(isPersonalScope ? {} : { allowMultiple: true }) },
       );
 
       let rawTools: any[] = [];
@@ -299,10 +303,17 @@ export const composioRouter = router({
         type: 'default',
       };
 
-      // Legacy plugin-table projection is personal-only (no agent_id column), so
-      // skip it for agent connections — the runtime resolves those off the
-      // agent-scoped connector row's metadata instead.
-      if (!agentId) {
+      // The legacy plugin-table projection is personal-only — and not merely by
+      // convention: `user_installed_plugins` is keyed by `(user_id,
+      // identifier)`, so it structurally cannot hold the same plugin twice for
+      // one user. Writing a workspace connection through it would upsert onto
+      // the PERSONAL row (the conflict target ignores workspace_id, and the
+      // update doesn't set it), silently repointing the user's personal
+      // connection at the workspace's Composio account while leaving the
+      // workspace with no row at all. So workspace connections skip it, the way
+      // agent connections already do, and resolve off the connector row's
+      // metadata instead — see `getComposioPlugins`, which unions both sources.
+      if (isPersonalScope) {
         await ctx.pluginModel.create({
           customParams: {
             composio: {
@@ -371,17 +382,80 @@ export const composioRouter = router({
         console.warn('[Composio] Failed to delete remote connection:', error);
       }
 
-      // Agent connections have no plugin-table row; only remove the base plugin
-      // projection for personal connections.
-      if (!input.agentId) await ctx.pluginModel.delete(input.identifier);
+      // Only personal connections have a plugin-table row (see createConnection);
+      // agent and workspace ones live solely in `user_connectors`. The delete is
+      // ownership-scoped so it would be a no-op elsewhere anyway, but keeping the
+      // condition aligned with the write side is what stops the two from drifting.
+      if (!input.agentId && !ctx.workspaceId) await ctx.pluginModel.delete(input.identifier);
       await deleteComposioConnector(ctx.connectorModel, input.identifier, input.agentId);
 
       return { success: true };
     }),
 
+  /**
+   * Composio connections visible in the caller's scope, unioned from BOTH
+   * stores — mirroring what the runtime already does in
+   * `loadConnectedComposioIds`:
+   *
+   * - `user_installed_plugins`: the legacy projection, personal connections
+   *   only (the table is keyed by `(user_id, identifier)` and has no workspace
+   *   or agent dimension).
+   * - `user_connectors`: everything else. Workspace connections are written
+   *   only here, so without this union a workspace's own Composio connections
+   *   would read as "not connected" in the skills dropdown, the skill store and
+   *   `/settings/connector` — and the connect button would restart an OAuth
+   *   flow that has already been completed.
+   *
+   * Plugin rows win on identifier collision: in personal scope both stores are
+   * written, and the plugin row is the one the legacy client shape came from.
+   */
   getComposioPlugins: composioProcedure.query(async ({ ctx }) => {
-    const allPlugins = await ctx.pluginModel.query();
-    return allPlugins.filter((plugin) => plugin.customParams?.composio);
+    const plugins = (await ctx.pluginModel.query()).filter(
+      (plugin) => plugin.customParams?.composio,
+    );
+
+    const composioConnectors = (await ctx.connectorModel.query()).filter(
+      (connector) => connector.metadata?.composio,
+    );
+    if (composioConnectors.length === 0) return plugins;
+
+    const seen = new Set(plugins.map((plugin) => plugin.identifier));
+    const tools = await ctx.connectorToolModel.queryByConnectorIds(
+      composioConnectors.map((connector) => connector.id),
+    );
+    const toolsByConnector = new Map<string, typeof tools>();
+    for (const tool of tools) {
+      const bucket = toolsByConnector.get(tool.userConnectorId) ?? [];
+      bucket.push(tool);
+      toolsByConnector.set(tool.userConnectorId, bucket);
+    }
+
+    // Project connector rows into the legacy plugin shape the client renders,
+    // so the union is invisible to callers.
+    const projected = composioConnectors
+      .filter((connector) => !seen.has(connector.identifier))
+      .map((connector) => ({
+        customParams: { composio: connector.metadata!.composio },
+        identifier: connector.identifier,
+        manifest: {
+          api: (toolsByConnector.get(connector.id) ?? []).map((tool) => ({
+            description: tool.description || '',
+            name: tool.toolName,
+            parameters: tool.inputSchema || { properties: {}, type: 'object' },
+          })),
+          identifier: connector.identifier,
+          meta: {
+            avatar: connector.metadata?.avatar || '🔌',
+            description: connector.metadata?.description || `Composio: ${connector.name}`,
+            title: connector.name,
+          },
+          type: 'default',
+        },
+        source: 'composio',
+        type: 'plugin',
+      }));
+
+    return [...plugins, ...projected] as typeof plugins;
   }),
 
   getConnection: composioProcedure
@@ -495,9 +569,11 @@ export const composioRouter = router({
         },
       };
 
-      // Personal-only plugin projection: skip for agent connections (see
-      // createConnection). The agent row's metadata is the runtime source.
-      if (!agentId) {
+      // Personal-only plugin projection: skip for agent AND workspace
+      // connections (see createConnection — the table is keyed by
+      // `(user_id, identifier)`, so a workspace write would land on the personal
+      // row). Their connector-row metadata is the source of truth.
+      if (!agentId && !ctx.workspaceId) {
         if (existingPlugin) {
           await ctx.pluginModel.update(identifier, { customParams, manifest });
         } else {

--- a/apps/server/src/routers/lambda/connector.ts
+++ b/apps/server/src/routers/lambda/connector.ts
@@ -606,6 +606,10 @@ export const connectorRouter = router({
         connectorId: input.id,
         lobeUserId: ctx.userId,
         returnTo: input.returnTo,
+        // Carry the scope across the redirect — the callback has no request
+        // header to derive it from. Trustworthy because this procedure already
+        // passed workspace auth + the member-role gate above.
+        workspaceId: ctx.workspaceId ?? undefined,
       });
 
       return { authorizationUrl };

--- a/apps/server/src/services/connector/stateStore.ts
+++ b/apps/server/src/services/connector/stateStore.ts
@@ -25,6 +25,15 @@ export interface ConnectorOAuthStatePayload {
   returnTo?: string;
   /** Issuance timestamp (ms epoch) for diagnostics. */
   ts: number;
+  /**
+   * Scope the connector row lives in, captured at authorize time. The callback
+   * is a browser redirect and carries no `X-Workspace-Id` header, so without
+   * this the model would be built scope-less — and `buildWorkspaceWhere` reads
+   * a missing workspaceId as "personal only" (`workspace_id IS NULL`), not
+   * "any scope". A workspace connector would then fail `findById` at exchange
+   * time. Undefined means the flow started in personal scope.
+   */
+  workspaceId?: string;
 }
 
 /** Generate an opaque, single-use state value to embed in the authorize URL. */

--- a/packages/database/src/models/__tests__/connectorAgentScope.test.ts
+++ b/packages/database/src/models/__tests__/connectorAgentScope.test.ts
@@ -196,6 +196,120 @@ describe('ConnectorModel agent-scoped resolution', () => {
     });
   });
 
+  // Multi-account resolution (LOBE-12140): one identifier may now have several
+  // connected accounts. `resolveAccountsByIdentifiers` / `resolveAllAccounts`
+  // keep every DISTINCT account (keyed by Composio connectedAccountId) while
+  // still collapsing scope COPIES of the SAME account (agent-owned shadows base).
+  const composioMeta = (connectedAccountId: string) => ({ composio: { connectedAccountId } });
+
+  describe('resolveAccountsByIdentifiers (multi-account)', () => {
+    it('keeps two distinct personal accounts of the same identifier side by side', async () => {
+      const work = await insertConnector({
+        identifier: 'gmail',
+        metadata: composioMeta('acc-work'),
+        name: 'Work Gmail',
+      });
+      const personal = await insertConnector({
+        identifier: 'gmail',
+        metadata: composioMeta('acc-personal'),
+        name: 'Personal Gmail',
+      });
+
+      const model = new ConnectorModel(serverDB, userId);
+
+      // The single-account resolver still collapses to one (unchanged behavior).
+      expect(await model.resolveByIdentifiers(['gmail'])).toHaveLength(1);
+
+      // The multi-account resolver returns both.
+      const accounts = await model.resolveAccountsByIdentifiers(['gmail']);
+      expect(accounts.map((r) => r.id).sort()).toEqual([work.id, personal.id].sort());
+    });
+
+    it('collapses scope copies of the same account (agent-owned shadows base)', async () => {
+      await insertConnector({
+        identifier: 'gmail',
+        metadata: composioMeta('acc-1'),
+        name: 'Base Gmail',
+      });
+      const agentRow = await insertConnector({
+        agentId: agentA,
+        identifier: 'gmail',
+        metadata: composioMeta('acc-1'),
+        name: 'Agent Gmail',
+      });
+
+      const model = new ConnectorModel(serverDB, userId);
+      const accounts = await model.resolveAccountsByIdentifiers(['gmail'], agentA);
+
+      expect(accounts).toHaveLength(1);
+      expect(accounts[0].id).toBe(agentRow.id);
+    });
+
+    it('mixes both rules: sibling account survives while the shadowed one collapses', async () => {
+      // acc-1: base + agent-owned copy → agent copy wins
+      await insertConnector({
+        identifier: 'gmail',
+        metadata: composioMeta('acc-1'),
+        name: 'Base acc-1',
+      });
+      const agentAcc1 = await insertConnector({
+        agentId: agentA,
+        identifier: 'gmail',
+        metadata: composioMeta('acc-1'),
+        name: 'Agent acc-1',
+      });
+      // acc-2: base only → survives as a sibling
+      const baseAcc2 = await insertConnector({
+        identifier: 'gmail',
+        metadata: composioMeta('acc-2'),
+        name: 'Base acc-2',
+      });
+
+      const model = new ConnectorModel(serverDB, userId);
+      const accounts = await model.resolveAccountsByIdentifiers(['gmail'], agentA);
+
+      expect(accounts.map((r) => r.id).sort()).toEqual([agentAcc1.id, baseAcc2.id].sort());
+    });
+
+    it('falls back to identifier grouping for non-Composio rows (multi-account is Composio-only)', async () => {
+      // No composio metadata → both keyed by identifier → collapse to one.
+      await insertConnector({ identifier: 'custom-mcp', name: 'Custom A' });
+      await insertConnector({ identifier: 'custom-mcp', name: 'Custom B' });
+
+      const model = new ConnectorModel(serverDB, userId);
+      const accounts = await model.resolveAccountsByIdentifiers(['custom-mcp']);
+
+      expect(accounts).toHaveLength(1);
+    });
+  });
+
+  describe('resolveAllAccounts (multi-account)', () => {
+    it('returns every sibling account across identifiers, collapsing same-account copies', async () => {
+      const work = await insertConnector({
+        identifier: 'gmail',
+        metadata: composioMeta('acc-work'),
+        name: 'Work Gmail',
+      });
+      const personal = await insertConnector({
+        identifier: 'gmail',
+        metadata: composioMeta('acc-personal'),
+        name: 'Personal Gmail',
+      });
+      const notion = await insertConnector({
+        identifier: 'notion',
+        metadata: composioMeta('acc-notion'),
+        name: 'Notion',
+      });
+
+      const model = new ConnectorModel(serverDB, userId);
+      const all = await model.resolveAllAccounts();
+
+      // resolveAll (single) would return 2 (one gmail + notion); accounts returns all 3.
+      expect(await model.resolveAll()).toHaveLength(2);
+      expect(all.map((r) => r.id).sort()).toEqual([work.id, personal.id, notion.id].sort());
+    });
+  });
+
   describe('queryByAgent', () => {
     it('returns only the given agent rows and excludes base + other-agent rows', async () => {
       await insertConnector({ identifier: 'gmail', name: 'Personal Gmail' });

--- a/packages/database/src/models/connector.ts
+++ b/packages/database/src/models/connector.ts
@@ -80,23 +80,61 @@ export class ConnectorModel {
   };
 
   /**
+   * Scope priority of a candidate row for the current run: agent-OWNED (2) >
+   * MOUNTED by this agent (1) > free base (0). Used to pick the winner among
+   * scope COPIES of one account.
+   */
+  private rank = (row: UserConnectorItem, agentId?: string): number => {
+    if (agentId && row.agentId === agentId) return 2;
+    if (agentId && row.metadata?.mountedByAgentId === agentId) return 1;
+    return 0;
+  };
+
+  /**
+   * Identity that collapses scope COPIES of one account while keeping DISTINCT
+   * accounts apart.
+   *
+   * A Composio row is keyed by its `connectedAccountId`: an agent-owned copy and
+   * its base original share it, so the copy still shadows the original — while
+   * two different Gmail accounts get different keys and BOTH survive. Non-Composio
+   * rows fall back to `identifier`, preserving today's one-row-per-identifier
+   * behavior (multi-account is Composio-only for now — see LOBE-12140).
+   */
+  private accountKey = (row: UserConnectorItem): string =>
+    row.metadata?.composio?.connectedAccountId ?? row.identifier;
+
+  /**
    * Reduce candidate rows to at most one per identifier by priority within the
    * current scope: agent-OWNED (2) > MOUNTED by this agent (1) > free base (0).
    * Resolution never crosses the base scope: a workspace run resolves within the
    * workspace, a personal run within personal — no cross-scope personal fallback.
    */
   private pickByPriority = (rows: UserConnectorItem[], agentId?: string): UserConnectorItem[] => {
-    const rank = (row: UserConnectorItem): number => {
-      if (agentId && row.agentId === agentId) return 2;
-      if (agentId && row.metadata?.mountedByAgentId === agentId) return 1;
-      return 0;
-    };
     const byIdentifier = new Map<string, UserConnectorItem>();
     for (const row of rows) {
       const current = byIdentifier.get(row.identifier);
-      if (!current || rank(row) > rank(current)) byIdentifier.set(row.identifier, row);
+      if (!current || this.rank(row, agentId) > this.rank(current, agentId))
+        byIdentifier.set(row.identifier, row);
     }
     return [...byIdentifier.values()];
+  };
+
+  /**
+   * Multi-account counterpart of {@link pickByPriority}: keeps EVERY distinct
+   * account, collapsing only the scope copies of the SAME account (agent-owned
+   * shadows its base original). Grouping is by {@link accountKey}, so two Gmail
+   * connections survive side by side while an agent's copy of one still wins over
+   * that one's base row.
+   */
+  private pickAllByAccount = (rows: UserConnectorItem[], agentId?: string): UserConnectorItem[] => {
+    const byAccount = new Map<string, UserConnectorItem>();
+    for (const row of rows) {
+      const key = this.accountKey(row);
+      const current = byAccount.get(key);
+      if (!current || this.rank(row, agentId) > this.rank(current, agentId))
+        byAccount.set(key, row);
+    }
+    return [...byAccount.values()];
   };
 
   create = async (
@@ -292,6 +330,44 @@ export class ConnectorModel {
   };
 
   /**
+   * Multi-account variant of {@link resolveByIdentifiers}: returns EVERY
+   * resolvable account for the given identifiers, not just one per identifier.
+   * Sibling accounts (e.g. two Gmail connections) both survive; only scope copies
+   * of the SAME account collapse (agent-owned shadows base). Runtime paths that
+   * must offer the model a choice between accounts use this; single-account
+   * callers keep {@link resolveByIdentifiers}. See LOBE-12140.
+   */
+  resolveAccountsByIdentifiers = async (
+    identifiers: string[],
+    agentId?: string,
+    gateKeeper: GateKeeper | undefined = this.gateKeeper,
+  ): Promise<DecryptedConnector[]> => {
+    if (identifiers.length === 0) return [];
+
+    const rows = await this.db
+      .select()
+      .from(userConnectors)
+      .where(and(this.scopePredicate(agentId), inArray(userConnectors.identifier, identifiers)));
+
+    return Promise.all(this.pickAllByAccount(rows, agentId).map((r) => decryptRow(r, gateKeeper)));
+  };
+
+  /**
+   * Multi-account variant of {@link resolveAll}: every resolvable account in the
+   * current scope, sibling accounts kept and same-account scope copies collapsed.
+   * Powers manifest building when an identifier may have several connected
+   * accounts. See LOBE-12140.
+   */
+  resolveAllAccounts = async (
+    agentId?: string,
+    gateKeeper: GateKeeper | undefined = this.gateKeeper,
+  ): Promise<DecryptedConnector[]> => {
+    const rows = await this.db.select().from(userConnectors).where(this.scopePredicate(agentId));
+
+    return Promise.all(this.pickAllByAccount(rows, agentId).map((r) => decryptRow(r, gateKeeper)));
+  };
+
+  /**
    * Exact-scope lookup for write-path idempotency: finds the row for one
    * specific scope — the given agent (`agent_id = agentId`) or, when `agentId`
    * is omitted, the base row (`agent_id IS NULL`). Unlike
@@ -312,6 +388,36 @@ export class ConnectorModel {
           this.ownership(),
           eq(userConnectors.identifier, identifier),
           agentId ? eq(userConnectors.agentId, agentId) : isNull(userConnectors.agentId),
+        ),
+      )
+      .limit(1);
+
+    if (!row) return null;
+    return decryptRow(row, gateKeeper);
+  };
+
+  /**
+   * Exact-scope lookup by Composio connected account. This is the multi-account
+   * idempotency key: unlike {@link findScopedByIdentifier}, which collapses all
+   * accounts of an identifier onto one row, this pins the ONE row for a specific
+   * `connectedAccountId` — so the Composio dual-write can update the right
+   * account's row and create a new one for a genuinely new account, instead of
+   * overwriting the first. Scope is the same (agent row when `agentId` is given,
+   * else the base row). See LOBE-12140.
+   */
+  findScopedByComposioAccount = async (
+    connectedAccountId: string,
+    agentId?: string,
+    gateKeeper: GateKeeper | undefined = this.gateKeeper,
+  ): Promise<DecryptedConnector | null> => {
+    const [row] = await this.db
+      .select()
+      .from(userConnectors)
+      .where(
+        and(
+          this.ownership(),
+          agentId ? eq(userConnectors.agentId, agentId) : isNull(userConnectors.agentId),
+          sql`${userConnectors.metadata} -> 'composio' ->> 'connectedAccountId' = ${connectedAccountId}`,
         ),
       )
       .limit(1);

--- a/packages/types/src/agent/pluginConfig.test.ts
+++ b/packages/types/src/agent/pluginConfig.test.ts
@@ -4,6 +4,7 @@ import {
   getActivePluginIds,
   getDisabledPluginIds,
   getPinnedPluginIds,
+  getPluginConnectorIds,
   getPluginMode,
   parsePluginEntry,
   upsertPluginMode,
@@ -34,6 +35,66 @@ describe('parsePluginEntry', () => {
       identifier: 'web-search',
       mode: 'pinned',
     });
+  });
+});
+
+describe('parsePluginEntry — connectorIds', () => {
+  it('is undefined for a legacy string entry', () => {
+    expect(parsePluginEntry('gmail').connectorIds).toBeUndefined();
+  });
+
+  it('is undefined for an object entry without the field', () => {
+    expect(parsePluginEntry({ identifier: 'gmail' }).connectorIds).toBeUndefined();
+  });
+
+  it('carries the restricted connector ids through', () => {
+    expect(
+      parsePluginEntry({ connectorIds: ['conn-1', 'conn-2'], identifier: 'gmail', mode: 'pinned' }),
+    ).toEqual({ connectorIds: ['conn-1', 'conn-2'], identifier: 'gmail', mode: 'pinned' });
+  });
+});
+
+describe('getPluginConnectorIds', () => {
+  it('returns undefined (all connections) when plugins is undefined', () => {
+    expect(getPluginConnectorIds(undefined, 'gmail')).toBeUndefined();
+  });
+
+  it('returns undefined when the identifier is absent — auto plugins use all connections', () => {
+    expect(getPluginConnectorIds(['other'], 'gmail')).toBeUndefined();
+  });
+
+  it('returns undefined for a legacy string entry', () => {
+    expect(getPluginConnectorIds(['gmail'], 'gmail')).toBeUndefined();
+  });
+
+  it('returns undefined for an object entry with no restriction', () => {
+    expect(
+      getPluginConnectorIds([{ identifier: 'gmail', mode: 'pinned' }], 'gmail'),
+    ).toBeUndefined();
+  });
+
+  it('returns the restricted ids when present', () => {
+    expect(
+      getPluginConnectorIds([{ connectorIds: ['conn-1', 'conn-2'], identifier: 'gmail' }], 'gmail'),
+    ).toEqual(['conn-1', 'conn-2']);
+  });
+
+  it('normalizes an empty restriction back to all-connections', () => {
+    expect(
+      getPluginConnectorIds([{ connectorIds: [], identifier: 'gmail' }], 'gmail'),
+    ).toBeUndefined();
+  });
+
+  it('resolves within a mixed-shape array', () => {
+    const plugins = [
+      'legacy-a',
+      { connectorIds: ['conn-x'], identifier: 'gmail', mode: 'pinned' as const },
+      { identifier: 'notion', mode: 'disabled' as const },
+    ];
+
+    expect(getPluginConnectorIds(plugins, 'gmail')).toEqual(['conn-x']);
+    expect(getPluginConnectorIds(plugins, 'legacy-a')).toBeUndefined();
+    expect(getPluginConnectorIds(plugins, 'notion')).toBeUndefined();
   });
 });
 
@@ -110,6 +171,14 @@ describe('upsertPluginMode', () => {
 
     expect(upsertPluginMode(plugins, 'a', 'disabled')).toEqual([
       { identifier: 'a', mode: 'disabled', extra: 'keep-me' },
+    ]);
+  });
+
+  it('preserves connectorIds when only the mode changes', () => {
+    const plugins = [{ connectorIds: ['conn-1'], identifier: 'gmail', mode: 'pinned' as const }];
+
+    expect(upsertPluginMode(plugins, 'gmail', 'disabled')).toEqual([
+      { connectorIds: ['conn-1'], identifier: 'gmail', mode: 'disabled' },
     ]);
   });
 

--- a/packages/types/src/agent/pluginConfig.ts
+++ b/packages/types/src/agent/pluginConfig.ts
@@ -12,6 +12,16 @@ import { z } from 'zod';
 export type AgentPluginMode = 'pinned' | 'auto' | 'disabled';
 
 export interface AgentPluginConfigItem {
+  /**
+   * Which specific connector rows of this identifier the agent may use.
+   *
+   * Absent = every connection of this identifier (today's behavior: one
+   * identifier resolves to whatever single connector wins). Present = restrict
+   * to exactly these `user_connectors.id`s. This is what turns the
+   * identifier→connector relationship from one-to-one into one-to-many without
+   * a schema change — it rides in the same JSONB column as `mode`.
+   */
+  connectorIds?: string[];
   identifier: string;
   /**
    * @default 'pinned' — absent on legacy string entries and on object
@@ -33,7 +43,11 @@ export const AgentPluginModeSchema = z.enum(['pinned', 'auto', 'disabled']);
  */
 export const AgentPluginEntrySchema: z.ZodType<AgentPluginEntry> = z.union([
   z.string(),
-  z.object({ identifier: z.string(), mode: AgentPluginModeSchema.optional() }),
+  z.object({
+    connectorIds: z.array(z.string()).optional(),
+    identifier: z.string(),
+    mode: AgentPluginModeSchema.optional(),
+  }),
 ]);
 
 /**
@@ -43,10 +57,14 @@ export const AgentPluginEntrySchema: z.ZodType<AgentPluginEntry> = z.union([
  */
 export const parsePluginEntry = (
   entry: AgentPluginEntry,
-): { identifier: string; mode: AgentPluginMode } =>
+): { connectorIds?: string[]; identifier: string; mode: AgentPluginMode } =>
   typeof entry === 'string'
     ? { identifier: entry, mode: 'pinned' }
-    : { identifier: entry.identifier, mode: entry.mode ?? 'pinned' };
+    : {
+        connectorIds: entry.connectorIds,
+        identifier: entry.identifier,
+        mode: entry.mode ?? 'pinned',
+      };
 
 /**
  * Resolves an identifier's mode. An identifier absent from `plugins`
@@ -60,6 +78,24 @@ export const getPluginMode = (
 ): AgentPluginMode => {
   const entry = plugins?.find((item) => parsePluginEntry(item).identifier === identifier);
   return entry ? parsePluginEntry(entry).mode : 'auto';
+};
+
+/**
+ * The connector rows `identifier` is restricted to, or `undefined` for "no
+ * restriction — every connection of this identifier is available". Legacy
+ * string entries and objects written before this field existed both return
+ * `undefined`, i.e. today's all-connections behavior.
+ *
+ * An empty array is normalized to `undefined`: "restricted to nothing" is not
+ * a state we want to persist or resolve, and reads as all-connections instead.
+ */
+export const getPluginConnectorIds = (
+  plugins: AgentPluginEntry[] | undefined,
+  identifier: string,
+): string[] | undefined => {
+  const entry = plugins?.find((item) => parsePluginEntry(item).identifier === identifier);
+  const ids = entry ? parsePluginEntry(entry).connectorIds : undefined;
+  return ids && ids.length > 0 ? ids : undefined;
 };
 
 const getPluginIdsByMode = (

--- a/src/app/(backend)/oauth/connector/callback/route.test.ts
+++ b/src/app/(backend)/oauth/connector/callback/route.test.ts
@@ -2,7 +2,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { GET } from './route';
 
-const { mockConsume, mockFindById, mockSync, mockUpdate } = vi.hoisted(() => ({
+const {
+  mockConnectorModelCtor,
+  mockConnectorToolModelCtor,
+  mockConsume,
+  mockFindById,
+  mockSync,
+  mockUpdate,
+} = vi.hoisted(() => ({
+  mockConnectorModelCtor: vi.fn(),
+  mockConnectorToolModelCtor: vi.fn(),
   mockConsume: vi.fn(),
   mockFindById: vi.fn(),
   mockSync: vi.fn(),
@@ -31,12 +40,16 @@ vi.mock('@/server/services/connector/stateStore', () => ({
   consumeConnectorOAuthState: mockConsume,
 }));
 vi.mock('@/database/models/connector', () => ({
-  ConnectorModel: vi
-    .fn()
-    .mockImplementation(() => ({ findById: mockFindById, update: mockUpdate })),
+  ConnectorModel: vi.fn().mockImplementation((...args: unknown[]) => {
+    mockConnectorModelCtor(...args);
+    return { findById: mockFindById, update: mockUpdate };
+  }),
 }));
 vi.mock('@/database/models/connectorTool', () => ({
-  ConnectorToolModel: vi.fn().mockImplementation(() => ({})),
+  ConnectorToolModel: vi.fn().mockImplementation((...args: unknown[]) => {
+    mockConnectorToolModelCtor(...args);
+    return {};
+  }),
 }));
 vi.mock('@/server/services/connector/sync', () => ({ syncConnectorToolsById: mockSync }));
 
@@ -79,5 +92,35 @@ describe('connector OAuth callback', () => {
 
     expect(body).toContain('"success":true');
     expect(body).toContain('"synced":true');
+  });
+
+  // The callback is a browser redirect with no `X-Workspace-Id` header, so the
+  // scope has to ride along in the OAuth state. Building the models without it
+  // scopes them to personal (`workspace_id IS NULL`) and `findById` misses
+  // every workspace connector — authorization would always end in
+  // `connector_not_found`.
+  it('scopes both models to the workspace captured in the OAuth state', async () => {
+    mockConsume.mockResolvedValue({
+      authorizationServerUrl: 'https://as',
+      codeVerifier: 'v',
+      connectorId: 'c1',
+      lobeUserId: 'u1',
+      workspaceId: 'ws-1',
+    });
+    mockSync.mockResolvedValue({ toolCount: 1 });
+
+    await GET(makeReq());
+
+    expect(mockConnectorModelCtor).toHaveBeenCalledWith({}, 'u1', 'ws-1', expect.anything());
+    expect(mockConnectorToolModelCtor).toHaveBeenCalledWith({}, 'u1', 'ws-1');
+  });
+
+  it('stays in personal scope when the OAuth state carries no workspace', async () => {
+    mockSync.mockResolvedValue({ toolCount: 1 });
+
+    await GET(makeReq());
+
+    expect(mockConnectorModelCtor).toHaveBeenCalledWith({}, 'u1', undefined, expect.anything());
+    expect(mockConnectorToolModelCtor).toHaveBeenCalledWith({}, 'u1', undefined);
   });
 });

--- a/src/app/(backend)/oauth/connector/callback/route.ts
+++ b/src/app/(backend)/oauth/connector/callback/route.ts
@@ -89,7 +89,18 @@ export const GET = async (req: NextRequest) => {
     }
 
     const gateKeeper = await KeyVaultsGateKeeper.initWithEnvKey();
-    const connectorModel = new ConnectorModel(serverDB, payload.lobeUserId, undefined, gateKeeper);
+    // Scope comes from the state payload, not the request: this is a browser
+    // redirect from the authorization server, so there is no `X-Workspace-Id`
+    // header to read. Passing `undefined` here would scope the model to
+    // personal (`workspace_id IS NULL`) and make `findById` miss every
+    // workspace connector — the exchange would die on `connector_not_found`.
+    const workspaceId = payload.workspaceId;
+    const connectorModel = new ConnectorModel(
+      serverDB,
+      payload.lobeUserId,
+      workspaceId,
+      gateKeeper,
+    );
 
     const connector = await connectorModel.findById(payload.connectorId);
     if (!connector) {
@@ -128,7 +139,7 @@ export const GET = async (req: NextRequest) => {
     // Sync the tool list server-side so the connector is immediately usable —
     // no dependency on the popup/postMessage round-trip. This also sets the
     // connector status (connected on success, error on failure).
-    const connectorToolModel = new ConnectorToolModel(serverDB, payload.lobeUserId);
+    const connectorToolModel = new ConnectorToolModel(serverDB, payload.lobeUserId, workspaceId);
     let synced = false;
     try {
       const { toolCount } = await syncConnectorToolsById(payload.connectorId, {

--- a/src/store/tool/initialState.ts
+++ b/src/store/tool/initialState.ts
@@ -19,6 +19,7 @@ import {
 } from './slices/lobehubSkillStore/initialState';
 import { initialMCPStoreState, type MCPStoreState } from './slices/mcpStore/initialState';
 import { initialPluginState, type PluginState } from './slices/plugin/initialState';
+import { initialToolBucketScopeState, type ToolBucketScopeState } from './workspaceScope';
 
 export type ToolStoreState = ConnectorState &
   PluginState &
@@ -28,9 +29,11 @@ export type ToolStoreState = ConnectorState &
   ComposioStoreState &
   LobehubSkillStoreState &
   AgentSkillsState &
-  AgentDocumentSkillsState;
+  AgentDocumentSkillsState &
+  ToolBucketScopeState;
 
 export const initialState: ToolStoreState = {
+  ...initialToolBucketScopeState,
   ...initialConnectorState,
   ...initialPluginState,
   ...initialCustomPluginState,

--- a/src/store/tool/slices/agentSkills/action.ts
+++ b/src/store/tool/slices/agentSkills/action.ts
@@ -19,6 +19,7 @@ import { type StoreSetter } from '@/store/types';
 import { setNamespace } from '@/utils/storeDebug';
 
 import { type ToolStore } from '../../store';
+import { markBucketScope } from '../../workspaceScope';
 import { type AgentSkillsState } from './initialState';
 
 const n = setNamespace('agentSkills');
@@ -108,7 +109,14 @@ export class AgentSkillsActionImpl {
 
   refreshAgentSkills = async (): Promise<void> => {
     const { data } = await agentSkillService.list();
-    this.#set({ agentSkills: data }, false, n('refreshAgentSkills'));
+    this.#set(
+      {
+        agentSkills: data,
+        toolBucketScopes: markBucketScope(this.#get().toolBucketScopes, 'agentSkills'),
+      },
+      false,
+      n('refreshAgentSkills'),
+    );
   };
 
   updateAgentSkill = async (params: UpdateSkillInput): Promise<SkillItem | undefined> => {
@@ -163,7 +171,14 @@ export class AgentSkillsActionImpl {
       },
       {
         onSuccess: (data) => {
-          this.#set({ agentSkills: data }, false, n('useFetchAgentSkills'));
+          this.#set(
+            {
+              agentSkills: data,
+              toolBucketScopes: markBucketScope(this.#get().toolBucketScopes, 'agentSkills'),
+            },
+            false,
+            n('useFetchAgentSkills'),
+          );
         },
         revalidateOnFocus: false,
       },

--- a/src/store/tool/slices/agentSkills/selectors.ts
+++ b/src/store/tool/slices/agentSkills/selectors.ts
@@ -1,19 +1,21 @@
 import type { LobeToolMeta, SkillItem, SkillListItem } from '@lobechat/types';
 
 import type { ToolStoreState } from '../../initialState';
+import { scopedBucket } from '../../workspaceScope';
 
-const getAgentSkills = (s: ToolStoreState): SkillListItem[] => s.agentSkills || [];
+const getAgentSkills = (s: ToolStoreState): SkillListItem[] =>
+  scopedBucket(s, 'agentSkills', s.agentSkills);
 
 const getMarketAgentSkills = (s: ToolStoreState): SkillListItem[] =>
-  (s.agentSkills || []).filter((skill) => skill.source === 'market');
+  getAgentSkills(s).filter((skill) => skill.source === 'market');
 
 const getUserAgentSkills = (s: ToolStoreState): SkillListItem[] =>
-  (s.agentSkills || []).filter((skill) => skill.source === 'user');
+  getAgentSkills(s).filter((skill) => skill.source === 'user');
 
 const getAgentSkillByIdentifier =
   (identifier: string) =>
   (s: ToolStoreState): SkillListItem | undefined =>
-    (s.agentSkills || []).find((skill) => skill.identifier === identifier);
+    getAgentSkills(s).find((skill) => skill.identifier === identifier);
 
 const getAgentSkillDetail =
   (id: string) =>
@@ -23,10 +25,10 @@ const getAgentSkillDetail =
 const isAgentSkill =
   (identifier: string) =>
   (s: ToolStoreState): boolean =>
-    (s.agentSkills || []).some((skill) => skill.identifier === identifier);
+    getAgentSkills(s).some((skill) => skill.identifier === identifier);
 
 const agentSkillMetaList = (s: ToolStoreState): LobeToolMeta[] =>
-  (s.agentSkills || []).map((skill) => {
+  getAgentSkills(s).map((skill) => {
     const author = skill.manifest?.author;
     const authorName = typeof author === 'string' ? author : author?.name || 'User';
 

--- a/src/store/tool/slices/composioStore/action.ts
+++ b/src/store/tool/slices/composioStore/action.ts
@@ -9,6 +9,7 @@ import { type StoreSetter } from '@/store/types';
 import { setNamespace } from '@/utils/storeDebug';
 
 import { type ToolStore } from '../../store';
+import { markBucketScope, type ToolBucketScopeState } from '../../workspaceScope';
 import { type ComposioStoreState } from './initialState';
 import {
   type CallComposioToolParams,
@@ -360,13 +361,15 @@ export class ComposioStoreActionImpl {
       {
         onSuccess: (data) => {
           this.#set(
-            produce((draft: ComposioStoreState) => {
-              if (data.length > 0) {
-                const existingIdentifiers = new Set(draft.composioServers.map((s) => s.identifier));
-                const newServers = data.filter((s) => !existingIdentifiers.has(s.identifier));
-                draft.composioServers = [...draft.composioServers, ...newServers];
-              }
+            produce((draft: ComposioStoreState & ToolBucketScopeState) => {
+              // Replace, don't merge. The response is the complete set for the
+              // active workspace, so appending would union it on top of another
+              // workspace's leftovers — and a connection removed remotely would
+              // never disappear. Stamping the scope in the same write keeps the
+              // data and the scope it belongs to from drifting apart.
+              draft.composioServers = data;
               draft.isComposioServersInit = true;
+              draft.toolBucketScopes = markBucketScope(draft.toolBucketScopes, 'composioServers');
             }),
             false,
             n('useFetchUserComposioConnections'),

--- a/src/store/tool/slices/composioStore/selectors.ts
+++ b/src/store/tool/slices/composioStore/selectors.ts
@@ -1,11 +1,19 @@
 import { type ToolStore } from '../../store';
+import { scopedBucket } from '../../workspaceScope';
 import { type ComposioServer, ComposioServerStatus } from './types';
 
+/**
+ * Every read goes through here so a bucket fetched under another workspace can
+ * never reach the UI — showing the user's PERSONAL Composio connections inside
+ * a workspace is what made the chat tool list and `/settings/connector` claim
+ * integrations that the workspace agent then failed to resolve at run time.
+ */
+const servers = (s: ToolStore): ComposioServer[] =>
+  scopedBucket(s, 'composioServers', s.composioServers);
+
 export const composioStoreSelectors = {
-  getAllServerIdentifiers: (s: ToolStore): Set<string> => {
-    const servers = s.composioServers || [];
-    return new Set(servers.map((server) => server.identifier));
-  },
+  getAllServerIdentifiers: (s: ToolStore): Set<string> =>
+    new Set(servers(s).map((server) => server.identifier)),
 
   getAllTools: (s: ToolStore) => {
     const connectedServers = composioStoreSelectors.getConnectedServers(s);
@@ -18,24 +26,20 @@ export const composioStoreSelectors = {
   },
 
   getConnectedServers: (s: ToolStore): ComposioServer[] =>
-    (s.composioServers || []).filter((server) => server.status === ComposioServerStatus.ACTIVE),
+    servers(s).filter((server) => server.status === ComposioServerStatus.ACTIVE),
 
   getPendingAuthServers: (s: ToolStore): ComposioServer[] =>
-    (s.composioServers || []).filter(
-      (server) => server.status === ComposioServerStatus.PENDING_AUTH,
-    ),
+    servers(s).filter((server) => server.status === ComposioServerStatus.PENDING_AUTH),
 
   getServerByIdentifier: (identifier: string) => (s: ToolStore) =>
-    s.composioServers?.find((server) => server.identifier === identifier),
+    servers(s).find((server) => server.identifier === identifier),
 
-  getServers: (s: ToolStore): ComposioServer[] => s.composioServers || [],
+  getServers: (s: ToolStore): ComposioServer[] => servers(s),
 
   isComposioServer:
     (identifier: string) =>
-    (s: ToolStore): boolean => {
-      const servers = s.composioServers || [];
-      return servers.some((server) => server.identifier === identifier);
-    },
+    (s: ToolStore): boolean =>
+      servers(s).some((server) => server.identifier === identifier),
 
   isServerLoading: (identifier: string) => (s: ToolStore) =>
     s.loadingComposioServerIds?.has(identifier) || false,
@@ -46,10 +50,9 @@ export const composioStoreSelectors = {
   },
 
   composioAsLobeTools: (s: ToolStore) => {
-    const servers = s.composioServers || [];
     const tools: any[] = [];
 
-    servers.forEach((server) => {
+    servers(s).forEach((server) => {
       if (!server.tools || server.status !== ComposioServerStatus.ACTIVE) return;
 
       const apis = server.tools.map((tool) => ({

--- a/src/store/tool/slices/connector/action.ts
+++ b/src/store/tool/slices/connector/action.ts
@@ -3,6 +3,7 @@ import { lambdaClient } from '@/libs/trpc/client';
 import type { StoreSetter } from '@/store/types';
 
 import type { ToolStore } from '../../store';
+import { markBucketScope } from '../../workspaceScope';
 
 type Setter = StoreSetter<ToolStore>;
 
@@ -21,7 +22,17 @@ export class ConnectorActionImpl {
 
   fetchConnectors = async (): Promise<void> => {
     const data = await lambdaClient.connector.list.query();
-    this.#set({ connectors: data as any, isConnectorsInit: true }, false, 'fetchConnectors');
+    this.#set(
+      {
+        connectors: data as any,
+        isConnectorsInit: true,
+        // Stamp the scope in the same write as the data, so selectors can tell
+        // a workspace's connectors from the ones left over from a previous one.
+        toolBucketScopes: markBucketScope(this.#get().toolBucketScopes, 'connectors'),
+      },
+      false,
+      'fetchConnectors',
+    );
   };
 
   /**
@@ -46,7 +57,11 @@ export class ConnectorActionImpl {
   fetchAgentBoundConnectors = async (): Promise<void> => {
     const data = await lambdaClient.connector.listAgentBound.query();
     this.#set(
-      { agentBoundConnectors: data as any, isAgentBoundInit: true },
+      {
+        agentBoundConnectors: data as any,
+        isAgentBoundInit: true,
+        toolBucketScopes: markBucketScope(this.#get().toolBucketScopes, 'connectors'),
+      },
       false,
       'fetchAgentBoundConnectors',
     );

--- a/src/store/tool/slices/connector/selectors.ts
+++ b/src/store/tool/slices/connector/selectors.ts
@@ -1,12 +1,17 @@
 import type { ToolStore } from '../../store';
+import { scopedBucket } from '../../workspaceScope';
 import type { AgentBoundConnector, ConnectorTool, ConnectorWithTools } from './types';
 
-// `?? []` tolerates a partially-initialized store (e.g. in unit-test mocks);
-// the real store always seeds `connectors: []` via initialState.
-const connectorList = (s: ToolStore): ConnectorWithTools[] => s.connectors ?? [];
+// Scoped read: connectors are dimension-scoped server-side (personal /
+// workspace / agent), so data fetched under one workspace must never render
+// under another. `scopedBucket` also tolerates a partially-initialized store
+// (e.g. unit-test mocks) the way the previous `?? []` did.
+const connectorList = (s: ToolStore): ConnectorWithTools[] =>
+  scopedBucket(s, 'connectors', s.connectors);
 
 /** All agent-owned connectors across agents, for the unified settings page. */
-const agentBoundConnectors = (s: ToolStore): AgentBoundConnector[] => s.agentBoundConnectors ?? [];
+const agentBoundConnectors = (s: ToolStore): AgentBoundConnector[] =>
+  scopedBucket(s, 'connectors', s.agentBoundConnectors);
 
 // By-id lookups span both pools: base connectors (`s.connectors`) and the
 // agent-bound aggregate (`s.agentBoundConnectors`). The unified settings page
@@ -15,8 +20,7 @@ const agentBoundConnectors = (s: ToolStore): AgentBoundConnector[] => s.agentBou
 const allById =
   (id: string) =>
   (s: ToolStore): ConnectorWithTools | undefined =>
-    (s.connectors ?? []).find((c) => c.id === id) ??
-    (s.agentBoundConnectors ?? []).find((c) => c.id === id);
+    connectorList(s).find((c) => c.id === id) ?? agentBoundConnectors(s).find((c) => c.id === id);
 
 const connectorById =
   (id: string) =>
@@ -26,20 +30,20 @@ const connectorById =
 const connectorByIdentifier =
   (identifier: string) =>
   (s: ToolStore): ConnectorWithTools | undefined =>
-    (s.connectors ?? []).find((c) => c.identifier === identifier);
+    connectorList(s).find((c) => c.identifier === identifier);
 
 const enabledConnectors = (s: ToolStore): ConnectorWithTools[] =>
-  (s.connectors ?? []).filter((c) => c.isEnabled);
+  connectorList(s).filter((c) => c.isEnabled);
 
 const connectedConnectors = (s: ToolStore): ConnectorWithTools[] =>
-  (s.connectors ?? []).filter((c) => c.status === 'connected');
+  connectorList(s).filter((c) => c.status === 'connected');
 
 /** User-added custom connectors (sourceType 'custom'), e.g. OAuth MCP servers. */
 const customConnectors = (s: ToolStore): ConnectorWithTools[] =>
-  (s.connectors ?? []).filter((c) => c.sourceType === 'custom');
+  connectorList(s).filter((c) => c.sourceType === 'custom');
 
 const notConnectedConnectors = (s: ToolStore): ConnectorWithTools[] =>
-  (s.connectors ?? []).filter((c) => c.status !== 'connected');
+  connectorList(s).filter((c) => c.status !== 'connected');
 
 interface GroupedTools {
   createTools: ConnectorTool[];
@@ -92,7 +96,7 @@ const agentToolBadge =
   (agentId: string, connector: ConnectorWithTools) =>
   (s: ToolStore): AgentToolBadge => {
     if (connector.agentId !== agentId) return 'linked'; // mounted user row
-    const hasUserSame = (s.connectors ?? []).some(
+    const hasUserSame = connectorList(s).some(
       (c) => c.identifier === connector.identifier && !c.agentId,
     );
     return hasUserSame ? 'copy' : 'agentOnly';

--- a/src/store/tool/slices/lobehubSkillStore/action.ts
+++ b/src/store/tool/slices/lobehubSkillStore/action.ts
@@ -11,6 +11,7 @@ import { authSelectors } from '@/store/user/selectors';
 import { setNamespace } from '@/utils/storeDebug';
 
 import { type ToolStore } from '../../store';
+import { markBucketScope, type ToolBucketScopeState } from '../../workspaceScope';
 import { type LobehubSkillStoreState } from './initialState';
 import {
   type CallLobehubSkillToolParams,
@@ -321,20 +322,24 @@ export class LobehubSkillStoreActionImpl {
       },
       {
         onSuccess: (data) => {
-          if (data.length > 0) {
-            this.#set(
-              produce((draft: LobehubSkillStoreState) => {
-                const existingIds = new Set(draft.lobehubSkillServers.map((s) => s.identifier));
-                const newServers = data.filter((s) => !existingIds.has(s.identifier));
-                draft.lobehubSkillServers = [...draft.lobehubSkillServers, ...newServers];
-              }),
-              false,
-              n('useFetchLobehubSkillConnections'),
-            );
+          this.#set(
+            produce((draft: LobehubSkillStoreState & ToolBucketScopeState) => {
+              // Replace unconditionally — including with an empty list. The old
+              // append-and-skip-when-empty shape meant a revoked connection (or
+              // a different workspace's smaller set) could never shrink the
+              // list, so entries accumulated across scopes and stayed forever.
+              draft.lobehubSkillServers = data;
+              draft.toolBucketScopes = markBucketScope(
+                draft.toolBucketScopes,
+                'lobehubSkillServers',
+              );
+            }),
+            false,
+            n('useFetchLobehubSkillConnections'),
+          );
 
-            for (const server of data) {
-              this.#get().refreshLobehubSkillTools(server.identifier);
-            }
+          for (const server of data) {
+            this.#get().refreshLobehubSkillTools(server.identifier);
           }
         },
         revalidateOnFocus: false,

--- a/src/store/tool/slices/lobehubSkillStore/selectors.ts
+++ b/src/store/tool/slices/lobehubSkillStore/selectors.ts
@@ -3,8 +3,18 @@ import urlJoin from 'url-join';
 import { OFFICIAL_SITE } from '@/const/url';
 
 import { type ToolStoreState } from '../../initialState';
+import { scopedBucket } from '../../workspaceScope';
 import { type LobehubSkillServer } from './types';
 import { LobehubSkillStatus } from './types';
+
+/**
+ * Single scoped read for every selector below. These connections come from the
+ * Market service keyed by the user's identity, so the same set comes back in
+ * every workspace; the scope stamp is what stops one workspace's fetch from
+ * being rendered inside another.
+ */
+const servers = (s: ToolStoreState): LobehubSkillServer[] =>
+  scopedBucket(s, 'lobehubSkillServers', s.lobehubSkillServers);
 
 /**
  * LobeHub Skill Store Selectors
@@ -13,10 +23,8 @@ export const lobehubSkillStoreSelectors = {
   /**
    * Get all LobeHub Skill server identifiers as a set
    */
-  getAllServerIdentifiers: (s: ToolStoreState): Set<string> => {
-    const servers = s.lobehubSkillServers || [];
-    return new Set(servers.map((server) => server.identifier));
-  },
+  getAllServerIdentifiers: (s: ToolStoreState): Set<string> =>
+    new Set(servers(s).map((server) => server.identifier)),
 
   /**
    * Get all available tools from all connected servers
@@ -35,21 +43,19 @@ export const lobehubSkillStoreSelectors = {
    * Get all connected servers
    */
   getConnectedServers: (s: ToolStoreState): LobehubSkillServer[] =>
-    (s.lobehubSkillServers || []).filter(
-      (server) => server.status === LobehubSkillStatus.CONNECTED,
-    ),
+    servers(s).filter((server) => server.status === LobehubSkillStatus.CONNECTED),
 
   /**
    * Get server by identifier
    * @param identifier - Provider identifier (e.g., 'linear')
    */
   getServerByIdentifier: (identifier: string) => (s: ToolStoreState) =>
-    s.lobehubSkillServers?.find((server) => server.identifier === identifier),
+    servers(s).find((server) => server.identifier === identifier),
 
   /**
    * Get all LobeHub Skill servers
    */
-  getServers: (s: ToolStoreState): LobehubSkillServer[] => s.lobehubSkillServers || [],
+  getServers: (s: ToolStoreState): LobehubSkillServer[] => servers(s),
 
   /**
    * Check if the given identifier is a LobeHub Skill server
@@ -57,10 +63,8 @@ export const lobehubSkillStoreSelectors = {
    */
   isLobehubSkillServer:
     (identifier: string) =>
-    (s: ToolStoreState): boolean => {
-      const servers = s.lobehubSkillServers || [];
-      return servers.some((server) => server.identifier === identifier);
-    },
+    (s: ToolStoreState): boolean =>
+      servers(s).some((server) => server.identifier === identifier),
 
   /**
    * Check if a server is loading
@@ -82,10 +86,9 @@ export const lobehubSkillStoreSelectors = {
    * Converts LobeHub Skill tools into the format expected by ToolNameResolver
    */
   lobehubSkillAsLobeTools: (s: ToolStoreState) => {
-    const servers = s.lobehubSkillServers || [];
     const tools: any[] = [];
 
-    for (const server of servers) {
+    for (const server of servers(s)) {
       if (!server.tools || server.status !== LobehubSkillStatus.CONNECTED) continue;
 
       const apis = server.tools.map((tool) => ({
@@ -123,10 +126,8 @@ export const lobehubSkillStoreSelectors = {
    * Get metadata list for all connected LobeHub Skill servers
    * Used by toolSelectors.metaList for unified tool metadata resolution
    */
-  metaList: (s: ToolStoreState) => {
-    const servers = s.lobehubSkillServers || [];
-
-    return servers
+  metaList: (s: ToolStoreState) =>
+    servers(s)
       .filter((server) => server.status === LobehubSkillStatus.CONNECTED)
       .map((server) => ({
         identifier: server.identifier,
@@ -135,6 +136,5 @@ export const lobehubSkillStoreSelectors = {
           description: `LobeHub Skill: ${server.name}`,
           title: server.name,
         },
-      }));
-  },
+      })),
 };

--- a/src/store/tool/workspaceScope.test.ts
+++ b/src/store/tool/workspaceScope.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
+
+import { composioStoreSelectors } from './slices/composioStore/selectors';
+import { ComposioServerStatus } from './slices/composioStore/types';
+import { connectorSelectors } from './slices/connector/selectors';
+import { lobehubSkillStoreSelectors } from './slices/lobehubSkillStore/selectors';
+import { LobehubSkillStatus } from './slices/lobehubSkillStore/types';
+import { isBucketInScope, markBucketScope, PERSONAL_SCOPE_KEY } from './workspaceScope';
+
+vi.mock('@/business/client/hooks/useActiveWorkspaceId', () => ({
+  getActiveWorkspaceId: vi.fn(() => null),
+  useActiveWorkspaceId: vi.fn(() => null),
+}));
+
+const inWorkspace = (id: string | null) => vi.mocked(getActiveWorkspaceId).mockReturnValue(id);
+
+beforeEach(() => {
+  inWorkspace(null);
+});
+
+describe('tool bucket scope keys', () => {
+  it('stamps the active workspace and treats personal as its own scope', () => {
+    inWorkspace(null);
+    const personal = markBucketScope({}, 'connectors');
+    expect(personal.connectors).toBe(PERSONAL_SCOPE_KEY);
+
+    inWorkspace('ws-1');
+    const workspace = markBucketScope({}, 'connectors');
+    expect(workspace.connectors).toBe('ws-1');
+
+    // The personal stamp must not read as in-scope inside a workspace —
+    // that confusion is the whole bug this guards against.
+    expect(isBucketInScope({ toolBucketScopes: personal }, 'connectors')).toBe(false);
+    expect(isBucketInScope({ toolBucketScopes: workspace }, 'connectors')).toBe(true);
+  });
+
+  it('reads an unstamped bucket as personal — usable there, hidden inside a workspace', () => {
+    inWorkspace(null);
+    expect(isBucketInScope({ toolBucketScopes: {} }, 'composioServers')).toBe(true);
+
+    inWorkspace('ws-1');
+    expect(isBucketInScope({ toolBucketScopes: {} }, 'composioServers')).toBe(false);
+  });
+});
+
+/**
+ * The regression that motivated all of this: the tool store is a module-level
+ * singleton that survives the workspace-switch remount, and correctness used to
+ * depend on someone remembering to register a reset hook. These cases simulate
+ * exactly that omission — data fetched in personal scope, still sitting in the
+ * store, while the user is now inside a workspace — and assert the selectors
+ * refuse it instead of rendering another scope's integrations.
+ */
+describe('selectors reject data fetched under a different workspace', () => {
+  const personalScopes = () => {
+    inWorkspace(null);
+    return {
+      agentSkills: markBucketScope({}, 'agentSkills').agentSkills,
+      composioServers: markBucketScope({}, 'composioServers').composioServers,
+      connectors: markBucketScope({}, 'connectors').connectors,
+      lobehubSkillServers: markBucketScope({}, 'lobehubSkillServers').lobehubSkillServers,
+    };
+  };
+
+  it('hides personal Composio connections once inside a workspace', () => {
+    const state = {
+      composioServers: [
+        { identifier: 'gmail', label: 'Gmail', status: ComposioServerStatus.ACTIVE, tools: [] },
+      ],
+      toolBucketScopes: personalScopes(),
+    } as any;
+
+    inWorkspace(null);
+    expect(composioStoreSelectors.getServers(state)).toHaveLength(1);
+    expect(composioStoreSelectors.isComposioServer('gmail')(state)).toBe(true);
+
+    inWorkspace('ws-1');
+    expect(composioStoreSelectors.getServers(state)).toEqual([]);
+    expect(composioStoreSelectors.getConnectedServers(state)).toEqual([]);
+    expect(composioStoreSelectors.isComposioServer('gmail')(state)).toBe(false);
+    expect(composioStoreSelectors.getServerByIdentifier('gmail')(state)).toBeUndefined();
+  });
+
+  it('hides personal LobeHub Skill connections once inside a workspace', () => {
+    const state = {
+      lobehubSkillServers: [
+        { identifier: 'github', name: 'GitHub', status: LobehubSkillStatus.CONNECTED },
+      ],
+      toolBucketScopes: personalScopes(),
+    } as any;
+
+    inWorkspace(null);
+    expect(lobehubSkillStoreSelectors.getServers(state)).toHaveLength(1);
+
+    inWorkspace('ws-1');
+    expect(lobehubSkillStoreSelectors.getServers(state)).toEqual([]);
+    expect(lobehubSkillStoreSelectors.getConnectedServers(state)).toEqual([]);
+    expect(lobehubSkillStoreSelectors.metaList(state)).toEqual([]);
+    expect(lobehubSkillStoreSelectors.isLobehubSkillServer('github')(state)).toBe(false);
+  });
+
+  it('hides personal connectors once inside a workspace', () => {
+    const state = {
+      agentBoundConnectors: [],
+      agentConnectors: {},
+      connectorSyncing: {},
+      connectors: [
+        { id: 'c1', identifier: 'gmail', sourceType: 'custom', status: 'connected', tools: [] },
+      ],
+      toolBucketScopes: personalScopes(),
+    } as any;
+
+    inWorkspace(null);
+    expect(connectorSelectors.connectorList(state)).toHaveLength(1);
+
+    inWorkspace('ws-1');
+    expect(connectorSelectors.connectorList(state)).toEqual([]);
+    expect(connectorSelectors.customConnectors(state)).toEqual([]);
+    expect(connectorSelectors.connectorById('c1')(state)).toBeUndefined();
+  });
+
+  it('returns a stable empty reference so out-of-scope reads do not re-render', () => {
+    const state = { composioServers: [{ identifier: 'gmail' }], toolBucketScopes: {} } as any;
+    inWorkspace('ws-1');
+    expect(composioStoreSelectors.getServers(state)).toBe(composioStoreSelectors.getServers(state));
+  });
+});

--- a/src/store/tool/workspaceScope.ts
+++ b/src/store/tool/workspaceScope.ts
@@ -1,0 +1,83 @@
+import { getActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
+
+/**
+ * Workspace scoping for the tool store.
+ *
+ * The tool store is a module-level singleton that survives the workspace-switch
+ * remount, while most of its buckets hold data the server already filtered by
+ * the active workspace. Keeping them correct used to rest entirely on a
+ * procedural convention: whoever adds a bucket must also register a reset hook
+ * (`registerWorkspaceScopedSlice`). Forgetting that made the store render the
+ * PREVIOUS workspace's data — a fail-OPEN default, and one that has already
+ * been missed for `connectors`, `composioServers` and `lobehubSkillServers`.
+ *
+ * So buckets now carry the scope they were fetched under, and selectors refuse
+ * data that does not match the active workspace. Forgetting to register a reset
+ * now degrades to an empty list that the next fetch fills in, instead of
+ * silently showing another workspace's integrations.
+ *
+ * The reset hooks are still worth registering — they clear stale data eagerly
+ * so the switch doesn't flash an empty panel — but they are an optimization
+ * now, not the thing correctness depends on.
+ */
+
+/** Scope key standing in for "no workspace", so a missing entry stays distinguishable. */
+export const PERSONAL_SCOPE_KEY = '__personal__';
+
+/** Tool-store buckets whose contents are workspace-dimensioned. */
+export type ScopedToolBucket =
+  'agentSkills' | 'composioServers' | 'connectors' | 'lobehubSkillServers';
+
+export interface ToolBucketScopeState {
+  /**
+   * Workspace each bucket's current contents were fetched under. An absent
+   * entry is read as personal scope — see {@link isBucketInScope}.
+   */
+  toolBucketScopes: Partial<Record<ScopedToolBucket, string>>;
+}
+
+export const initialToolBucketScopeState: ToolBucketScopeState = {
+  toolBucketScopes: {},
+};
+
+/** Scope key for the workspace the user is currently in. */
+export const currentScopeKey = (): string => getActiveWorkspaceId() ?? PERSONAL_SCOPE_KEY;
+
+/**
+ * Stamp a bucket with the scope its freshly-written contents belong to. Call
+ * this in the same `set` that writes the data, so the two can never drift.
+ */
+export const markBucketScope = (
+  scopes: ToolBucketScopeState['toolBucketScopes'],
+  bucket: ScopedToolBucket,
+): ToolBucketScopeState['toolBucketScopes'] => ({ ...scopes, [bucket]: currentScopeKey() });
+
+/**
+ * Whether a bucket's contents were fetched under the workspace now active.
+ *
+ * An unstamped bucket counts as personal. That keeps the guard aimed at the
+ * leak that actually happens — data fetched in one scope surfacing inside a
+ * DIFFERENT workspace — without making every state object that predates the
+ * stamp (open-source callers, existing test fixtures, the no-workspace
+ * deployment) read as empty. Data fetched in a workspace is always stamped, so
+ * it still cannot leak back into the personal view.
+ */
+export const isBucketInScope = (state: ToolBucketScopeState, bucket: ScopedToolBucket): boolean =>
+  (state.toolBucketScopes?.[bucket] ?? PERSONAL_SCOPE_KEY) === currentScopeKey();
+
+/**
+ * Shared empty result. Selectors must return a stable reference for
+ * out-of-scope buckets — a fresh `[]` each call would defeat zustand's
+ * equality check and re-render on every store update.
+ */
+const EMPTY: readonly never[] = Object.freeze([]);
+
+/**
+ * Read a bucket, or an empty list when its contents belong to another
+ * workspace. Wrap every selector that exposes scoped bucket data.
+ */
+export const scopedBucket = <T>(
+  state: ToolBucketScopeState,
+  bucket: ScopedToolBucket,
+  items: T[] | undefined,
+): T[] => (isBucketInScope(state, bucket) ? (items ?? (EMPTY as T[])) : (EMPTY as T[]));


### PR DESCRIPTION
Umbrella PR for the workspace-scoping gaps tracked in **LOBE-12123**. Landing incrementally — each sub-issue gets its own commit pushed onto this branch.

The invariant that ties all of them together: `buildWorkspaceWhere` treats a missing `workspaceId` as **personal only** (`workspace_id IS NULL`), never "any scope". So every path that forgets to thread the workspace id degrades to personal scope **silently** — no error, just the wrong rows.

## Landed

### S1 — connector OAuth callback lost the workspace scope (LOBE-12125)

The callback is a browser redirect from the authorization server, so it carries no `X-Workspace-Id` header. It built `ConnectorModel` with an explicit `undefined` workspace id, which scoped the lookup to personal rows only — `findById` could never see a workspace-scoped connector and the token exchange died on `connector_not_found`.

The scope wasn't merely dropped at the call site: the Redis state payload had **no workspace field at all**, so there was nothing for the callback to read.

- `stateStore.ts` — add `workspaceId?: string` to the state payload
- `connector.ts` `startOAuth` — capture `ctx.workspaceId` (trustworthy: the procedure already passed workspace auth + the member-role gate)
- `callback/route.ts` — build both `ConnectorModel` and `ConnectorToolModel` from it

**Impact:** a custom MCP connector created inside a workspace was impossible to authorize. Personal connectors were unaffected, which is why this went unnoticed.

**Compatibility:** absent `workspaceId` keeps meaning personal scope, so existing personal flows and in-flight states from before this change (10 min TTL) behave identically.

**Tests:** regression coverage on both halves — the router stashing the id, and the callback scoping both models to it. Verified red before the fix, green after.

## Still to come on this branch

- **S2** (LOBE-12126) — runtime `workspaceId` is caller-supplied at the gateway/worker entry points, never derived from the agent row
- **S6** (LOBE-12130) — tool store buckets carry no scope, so correctness rests on remembering to register a reset hook (fail-open)
- **S3** (LOBE-12127) — LobeHub Skill connections have no workspace dimension
- **S4** (LOBE-12128) — Skills dropdown + `/settings/connector` show no ownership at all
- **S5** (LOBE-12129) — SWR keys, plugin upsert conflict target

🤖 Generated with [Claude Code](https://claude.com/claude-code)