### PR TITLE
🐛 fix: hide model fetcher in provider empty state when showModelFetcher is false

### DIFF
--- a/src/routes/(main)/settings/provider/features/ModelList/EmptyModels.test.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/EmptyModels.test.tsx
@@ -29,29 +29,39 @@ vi.mock('./CreateNewModelModal', () => ({
   createCreateNewModelModal: vi.fn(),
 }));
 
-const renderEmptyModels = (showModelFetcher?: boolean) =>
+const renderEmptyModels = (context?: { showAddNewModel?: boolean; showModelFetcher?: boolean }) =>
   render(
     <App>
-      <ProviderSettingsContext value={{ showModelFetcher }}>
+      <ProviderSettingsContext value={context ?? {}}>
         <EmptyModels provider={'lobehub'} />
       </ProviderSettingsContext>
     </App>,
   );
 
 describe('EmptyModels', () => {
-  it('shows the fetch button by default', () => {
+  it('shows the fetch and add-model buttons by default', () => {
     renderEmptyModels();
 
     expect(screen.getByText('providerModels.list.fetcher.fetch')).toBeInTheDocument();
+    expect(screen.getByText('providerModels.list.addNew')).toBeInTheDocument();
   });
 
   it('hides the fetch button when showModelFetcher is false', () => {
     // Regression for LOBE-12051: providers like lobehub disable the model
     // fetcher, but the empty state still offered a fetch action that 500s
-    renderEmptyModels(false);
+    renderEmptyModels({ showModelFetcher: false });
 
     expect(screen.queryByText('providerModels.list.fetcher.fetch')).toBeNull();
     // the add-model action stays available
     expect(screen.getByText('providerModels.list.addNew')).toBeInTheDocument();
+  });
+
+  it('hides the add-model button when showAddNewModel is false', () => {
+    // providers like lobehub also disable hand-adding models; the empty state
+    // must gate the add action the same way ModelTitle does
+    renderEmptyModels({ showAddNewModel: false, showModelFetcher: false });
+
+    expect(screen.queryByText('providerModels.list.addNew')).toBeNull();
+    expect(screen.queryByText('providerModels.list.fetcher.fetch')).toBeNull();
   });
 });

--- a/src/routes/(main)/settings/provider/features/ModelList/EmptyModels.test.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/EmptyModels.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { App } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+
+import EmptyModels from './EmptyModels';
+import { ProviderSettingsContext } from './ProviderSettingsContext';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/hooks/usePermission', () => ({
+  usePermission: () => ({
+    allowed: true,
+    reason: undefined,
+  }),
+}));
+
+vi.mock('@/store/aiInfra', () => ({
+  useAiInfraStore: (selector: (s: any) => unknown) =>
+    selector({
+      fetchRemoteModelList: vi.fn(),
+    }),
+}));
+
+vi.mock('./CreateNewModelModal', () => ({
+  createCreateNewModelModal: vi.fn(),
+}));
+
+const renderEmptyModels = (showModelFetcher?: boolean) =>
+  render(
+    <App>
+      <ProviderSettingsContext value={{ showModelFetcher }}>
+        <EmptyModels provider={'lobehub'} />
+      </ProviderSettingsContext>
+    </App>,
+  );
+
+describe('EmptyModels', () => {
+  it('shows the fetch button by default', () => {
+    renderEmptyModels();
+
+    expect(screen.getByText('providerModels.list.fetcher.fetch')).toBeInTheDocument();
+  });
+
+  it('hides the fetch button when showModelFetcher is false', () => {
+    // Regression for LOBE-12051: providers like lobehub disable the model
+    // fetcher, but the empty state still offered a fetch action that 500s
+    renderEmptyModels(false);
+
+    expect(screen.queryByText('providerModels.list.fetcher.fetch')).toBeNull();
+    // the add-model action stays available
+    expect(screen.getByText('providerModels.list.addNew')).toBeInTheDocument();
+  });
+});

--- a/src/routes/(main)/settings/provider/features/ModelList/EmptyModels.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/EmptyModels.tsx
@@ -56,9 +56,14 @@ const EmptyState = memo<{ provider: string }>(({ provider }) => {
   const [fetchRemoteModelList] = useAiInfraStore((s) => [s.fetchRemoteModelList]);
 
   const [fetchRemoteModelsLoading, setFetchRemoteModelsLoading] = useState(false);
-  // Providers with showModelFetcher: false (e.g. lobehub) can't list models via
-  // /webapi/models/[provider], so the empty state must not offer the fetch action either
-  const { showDeployName, showModelFetcher = true } = use(ProviderSettingsContext);
+  // Providers with showModelFetcher / showAddNewModel disabled (e.g. lobehub) can't
+  // fetch or hand-add models, so the empty state must not offer those actions either
+  // (same gating as ModelTitle)
+  const {
+    showAddNewModel = true,
+    showDeployName,
+    showModelFetcher = true,
+  } = use(ProviderSettingsContext);
 
   return (
     <Center className={styles.container} gap={24} paddingBlock={40}>
@@ -71,23 +76,25 @@ const EmptyState = memo<{ provider: string }>(({ provider }) => {
       </Flexbox>
 
       <Flexbox horizontal gap={8}>
-        <Tooltip title={canManageProvider ? undefined : reason}>
-          <Button
-            disabled={!canManageProvider}
-            icon={PlusIcon}
-            onClick={() => {
-              if (!canManageProvider) return;
-              createCreateNewModelModal({
-                existingModelIds: useAiInfraStore
-                  .getState()
-                  .aiProviderModelList.map((model) => model.id),
-                showDeployName,
-              });
-            }}
-          >
-            {t('providerModels.list.addNew')}
-          </Button>
-        </Tooltip>
+        {showAddNewModel && (
+          <Tooltip title={canManageProvider ? undefined : reason}>
+            <Button
+              disabled={!canManageProvider}
+              icon={PlusIcon}
+              onClick={() => {
+                if (!canManageProvider) return;
+                createCreateNewModelModal({
+                  existingModelIds: useAiInfraStore
+                    .getState()
+                    .aiProviderModelList.map((model) => model.id),
+                  showDeployName,
+                });
+              }}
+            >
+              {t('providerModels.list.addNew')}
+            </Button>
+          </Tooltip>
+        )}
         {showModelFetcher && (
           <Tooltip title={canManageProvider ? undefined : reason}>
             <Button

--- a/src/routes/(main)/settings/provider/features/ModelList/EmptyModels.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/EmptyModels.tsx
@@ -56,7 +56,9 @@ const EmptyState = memo<{ provider: string }>(({ provider }) => {
   const [fetchRemoteModelList] = useAiInfraStore((s) => [s.fetchRemoteModelList]);
 
   const [fetchRemoteModelsLoading, setFetchRemoteModelsLoading] = useState(false);
-  const { showDeployName } = use(ProviderSettingsContext);
+  // Providers with showModelFetcher: false (e.g. lobehub) can't list models via
+  // /webapi/models/[provider], so the empty state must not offer the fetch action either
+  const { showDeployName, showModelFetcher = true } = use(ProviderSettingsContext);
 
   return (
     <Center className={styles.container} gap={24} paddingBlock={40}>
@@ -86,40 +88,42 @@ const EmptyState = memo<{ provider: string }>(({ provider }) => {
             {t('providerModels.list.addNew')}
           </Button>
         </Tooltip>
-        <Tooltip title={canManageProvider ? undefined : reason}>
-          <Button
-            disabled={!canManageProvider}
-            icon={<Icon icon={LucideRefreshCcwDot} />}
-            loading={fetchRemoteModelsLoading}
-            type={'primary'}
-            onClick={async () => {
-              if (!canManageProvider) return;
-              setFetchRemoteModelsLoading(true);
-              try {
-                await fetchRemoteModelList(provider);
-              } catch (error) {
-                console.error(error);
+        {showModelFetcher && (
+          <Tooltip title={canManageProvider ? undefined : reason}>
+            <Button
+              disabled={!canManageProvider}
+              icon={<Icon icon={LucideRefreshCcwDot} />}
+              loading={fetchRemoteModelsLoading}
+              type={'primary'}
+              onClick={async () => {
+                if (!canManageProvider) return;
+                setFetchRemoteModelsLoading(true);
+                try {
+                  await fetchRemoteModelList(provider);
+                } catch (error) {
+                  console.error(error);
 
-                const errorMessage =
-                  error instanceof Error
-                    ? error.message
-                    : t('providerModels.list.fetcher.errorFallback');
+                  const errorMessage =
+                    error instanceof Error
+                      ? error.message
+                      : t('providerModels.list.fetcher.errorFallback');
 
-                message.error(
-                  t('providerModels.list.fetcher.error', {
-                    message: errorMessage,
-                  }),
-                );
-              } finally {
-                setFetchRemoteModelsLoading(false);
-              }
-            }}
-          >
-            {fetchRemoteModelsLoading
-              ? t('providerModels.list.fetcher.fetching')
-              : t('providerModels.list.fetcher.fetch')}
-          </Button>
-        </Tooltip>
+                  message.error(
+                    t('providerModels.list.fetcher.error', {
+                      message: errorMessage,
+                    }),
+                  );
+                } finally {
+                  setFetchRemoteModelsLoading(false);
+                }
+              }}
+            >
+              {fetchRemoteModelsLoading
+                ? t('providerModels.list.fetcher.fetching')
+                : t('providerModels.list.fetcher.fetch')}
+            </Button>
+          </Tooltip>
+        )}
       </Flexbox>
     </Center>
   );


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Related to LOBE-12051

#### 🔀 Description of Change

The empty state of the provider model list (`EmptyModels`) always rendered a primary "Fetch model list" button, ignoring the provider's `showModelFetcher` setting. For providers that disable the model fetcher (e.g. `lobehub` sets `showModelFetcher: false` in model-bank), `/webapi/models/[provider]` is not a servable path, so clicking the button always surfaced an error toast.

This PR makes the empty-state fetch button respect `showModelFetcher` from `ProviderSettingsContext` (default remains shown). The "Add model" action stays available.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

`EmptyModels.test.tsx`: fetch button renders by default and is hidden when `showModelFetcher` is `false` while the add-model action remains.

#### 📝 Additional Information

The server-side half of LOBE-12051 (the 500 from the model-list endpoint itself) is fixed in the cloud repo separately.