### PR TITLE
fix(windows): preserve PATH order when resolving Claude/Codex CLI

### DIFF
--- a/apps/desktop/src/main/modules/binaries/__tests__/cliAgentBinaries.test.ts
+++ b/apps/desktop/src/main/modules/binaries/__tests__/cliAgentBinaries.test.ts
@@ -147,6 +147,26 @@ describe('cliAgentBinaries', () => {
       expect(execFileMock.mock.calls[1]![0]).toBe('C:\\tools\\foo.exe');
     });
 
+    it('preserves PATH order when npm .cmd precedes a later .exe (Vite+ case)', async () => {
+      callExecFile(
+        [
+          'C:\\Users\\hp\\AppData\\Roaming\\npm\\claude.cmd',
+          'C:\\Users\\hp\\.vite-plus\\bin\\claude.exe',
+        ].join('\r\n'),
+      );
+      callExec('1.2.3 (Claude Code)');
+
+      const { claudeCodeBinary } = await import('../cliAgentBinaries');
+      const status = await claudeCodeBinary.detect();
+
+      expect(status.available).toBe(true);
+      expect(status.path).toBe('C:\\Users\\hp\\AppData\\Roaming\\npm\\claude.cmd');
+      expect(execMock).toHaveBeenCalledTimes(1);
+      expect(execMock.mock.calls[0]![0]).toBe(
+        '"C:\\Users\\hp\\AppData\\Roaming\\npm\\claude.cmd" --version',
+      );
+    });
+
     it('reports unavailable when `where` only returns unrunnable matches (.ps1 / extensionless)', async () => {
       callExecFile(
         [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lobehub/lobehub",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "description": "LobeHub - an open-source,comprehensive AI Agent framework that supports speech synthesis, multimodal, and extensible Function Call plugin system. Supports one-click free deployment of your private ChatGPT/LLM web application.",
   "keywords": [
     "framework",

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
@@ -272,6 +272,27 @@ describe('resolveCliCommand', () => {
       expect(status.path).toBe('C:\\Users\\x\\AppData\\Roaming\\npm\\codex.cmd');
     });
 
+    it('preserves PATH order: earlier .cmd beats later .exe (Vite+ claude.exe case)', async () => {
+      // `where claude` lists every match in PATH order. npm's .cmd shim is
+      // earlier; Vite+ ships a later standalone claude.exe. Preferring every
+      // .exe over every .cmd would pick Vite+ and break the real install.
+      callExecFile(
+        [
+          'C:\\Users\\hp\\AppData\\Roaming\\npm\\claude.cmd',
+          'C:\\Users\\hp\\.vite-plus\\bin\\claude.exe',
+        ].join('\r\n'),
+      );
+      callExec('1.2.3 (Claude Code)');
+
+      const { detectValidatedCommand } = await importModule();
+      const status = await detectValidatedCommand('claude', {
+        validateKeywords: ['claude code'],
+      });
+
+      expect(status.available).toBe(true);
+      expect(status.path).toBe('C:\\Users\\hp\\AppData\\Roaming\\npm\\claude.cmd');
+    });
+
     it('rejects a command containing shell metacharacters', async () => {
       const { detectValidatedCommand } = await importModule();
       const status = await detectValidatedCommand('codex & calc.exe', {

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
@@ -60,18 +60,23 @@ let shellPathPromise: Promise<string | undefined> | undefined;
 // User-supplied custom commands flow through here via `detectHeterogeneousCliCommand`.
 const WINDOWS_SHELL_METAS = /[&|;<>^`!"]/;
 
-// Extensions we can actually execute on Windows, in preference order:
+// Extensions we can actually execute on Windows.
 // `.exe` runs directly via `execFile`, `.cmd` / `.bat` runs via `cmd.exe`.
 // `.ps1` and extensionless wrappers (npm sometimes drops a Unix shell script
 // next to the `.cmd` shim) are deliberately excluded — we can't run them.
+//
+// IMPORTANT: pick by PATH order (the order `where` returns), not by extension
+// rank. Preferring every `.exe` over every `.cmd` would skip an earlier npm
+// `claude.cmd` in favour of a later `claude.exe` from Vite+ (see #17376).
 const WINDOWS_RUNNABLE_EXTS = ['.exe', '.cmd', '.bat'] as const;
 
+const isWindowsRunnablePath = (line: string): boolean => {
+  const lower = line.toLowerCase();
+  return WINDOWS_RUNNABLE_EXTS.some((ext) => lower.endsWith(ext));
+};
+
 const pickWindowsRunnable = (lines: string[]): string | undefined => {
-  for (const ext of WINDOWS_RUNNABLE_EXTS) {
-    const match = lines.find((line) => line.toLowerCase().endsWith(ext));
-    if (match) return match;
-  }
-  return undefined;
+  return lines.find(isWindowsRunnablePath);
 };
 
 const getLoginShellPath = async (): Promise<string | undefined> => {
@@ -167,8 +172,8 @@ const resolveCommandPath = async (command: string): Promise<ResolvedCommand | un
 
   // Windows `where` lists every PATHEXT match (e.g. for `codex` npm ships
   // a Unix shell wrapper alongside `codex.cmd` and `codex.ps1`). Picking
-  // the first line can land us on something we can't execute, so prefer a
-  // runnable extension and bail otherwise.
+  // the first line can land us on something we can't execute, so walk the
+  // PATH-ordered list and take the first runnable extension.
   if (isWindows()) {
     const runnablePath = pickWindowsRunnable(lines);
     return runnablePath ? { path: runnablePath } : undefined;


### PR DESCRIPTION
## Summary
On Windows, Claude Code discovery could pick Vite+'s later `claude.exe` even when the npm `claude.cmd` shim appears earlier in `%PATH%` (as shown by `where claude`).

## Root cause
`pickWindowsRunnable()` ranked extensions globally (all `.exe` before any `.cmd`/`.bat`) instead of walking `where`'s PATH-ordered results and taking the first runnable match.

## Change
- Prefer the first PATH-ordered runnable path (`.exe` / `.cmd` / `.bat`)
- Keep existing same-directory PATHEXT behavior (npm extensionless + `.cmd` still resolves to `.cmd`)
- Add regression tests for the Vite+ case in both the shared resolver and desktop binary manager

## Test plan
- [x] New unit test: earlier `claude.cmd` beats later `.vite-plus/bin/claude.exe`
- [x] Existing same-dir PATHEXT tests still expect `.cmd` when `.exe` is not earlier
- [ ] Manual Windows: with npm Claude Code + Vite+ installed, LobeHub detects the npm shim

Fixes #17376.
