### PR TITLE
✨ feat(cli): wire installed acceptance skill into harness dirs and .gitignore

### DIFF
--- a/apps/cli/src/commands/acceptanceRun.ts
+++ b/apps/cli/src/commands/acceptanceRun.ts
@@ -8,6 +8,8 @@ import pc from 'picocolors';
 import { getTrpcClient } from '../api/client';
 import { confirm, outputJson, printTable, timeAgo, truncate } from '../utils/format';
 import { log } from '../utils/logger';
+import type { IgnoreResult, LinkResult } from '../utils/skillWiring';
+import { ensureSkillIgnored, linkHarnessSkills } from '../utils/skillWiring';
 import { uploadLocalFile } from '../utils/uploadLocalFile';
 import {
   type Decision,
@@ -42,6 +44,7 @@ import {
 interface InstallOptions {
   dir?: string;
   force?: boolean;
+  gitignore?: boolean;
   json?: boolean | string;
   skill: string;
 }
@@ -76,7 +79,13 @@ async function installAction(options: InstallOptions): Promise<void> {
     written.push(rel);
   }
 
-  const result = { dir: skillDir, skill: bundle.identifier, skipped, written };
+  const link = linkHarnessSkills(baseDir, bundle.identifier);
+  const ignored =
+    options.gitignore === false
+      ? []
+      : ensureSkillIgnored(baseDir, bundle.identifier, link.kind === 'linked');
+
+  const result = { dir: skillDir, ignored, link, skill: bundle.identifier, skipped, written };
   if (options.json !== undefined) {
     outputJson(result, typeof options.json === 'string' ? options.json : undefined);
     return;
@@ -86,6 +95,36 @@ async function installAction(options: InstallOptions): Promise<void> {
   );
   console.log(`  ${written.length} written${skipped.length ? `, ${skipped.length} skipped` : ''}`);
   if (skipped.length > 0) console.log(pc.dim(`  (skipped existing — pass --force to overwrite)`));
+  printWiring(link, ignored);
+}
+
+function printWiring(link: LinkResult, ignored: IgnoreResult[]): void {
+  const arrow = pc.dim('  ↳');
+  switch (link.kind) {
+    case 'linked':
+    case 'linked-single': {
+      console.log(`${arrow} linked ${link.link} → ${pc.dim(link.target)}`);
+      break;
+    }
+    case 'already': {
+      console.log(`${arrow} ${pc.dim(`${link.link} already linked`)}`);
+      break;
+    }
+    case 'skipped': {
+      console.log(`${arrow} ${pc.yellow(`skipped ${link.link}: ${link.reason}`)}`);
+      break;
+    }
+    default: {
+      break;
+    }
+  }
+
+  for (const entry of ignored) {
+    if (entry.kind !== 'added') continue;
+    console.log(
+      `${arrow} ignored ${entry.entry} in ${pc.dim(path.relative(process.cwd(), entry.file))}`,
+    );
+  }
 }
 
 // ── run ──
@@ -710,6 +749,7 @@ function withInstallOptions(cmd: Command): Command {
     .option('--dir <path>', 'Target working directory (default: current dir)')
     .option('--skill <id>', 'Skill identifier to pull', 'acceptance')
     .option('--force', 'Overwrite existing skill files')
+    .option('--no-gitignore', 'Do not record the installed skill in .gitignore')
     .option('--json [fields]', 'Output JSON');
 }
 
@@ -822,6 +862,12 @@ export function attachAcceptanceRunCommands(acceptance: Command): void {
         'Install the acceptance skill skeleton into .agents/skills/acceptance (pulled from the server)',
       ),
   ).action(installAction);
+
+  withInstallOptions(
+    acceptance
+      .command('update')
+      .description('Re-pull the acceptance skill, overwriting local files and re-wiring harnesses'),
+  ).action((options: InstallOptions) => installAction({ ...options, force: true }));
 
   const run = acceptance
     .command('run')

--- a/apps/cli/src/utils/skillWiring.test.ts
+++ b/apps/cli/src/utils/skillWiring.test.ts
@@ -1,0 +1,166 @@
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { detectClaudeHarness, ensureSkillIgnored, linkHarnessSkills } from './skillWiring';
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), 'skill-wiring-'));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function gitInit(dir: string) {
+  execFileSync('git', ['init', '-q'], { cwd: dir, stdio: 'ignore' });
+}
+
+describe('detectClaudeHarness', () => {
+  it('detects CLAUDE.md', () => {
+    writeFileSync(path.join(root, 'CLAUDE.md'), '# project');
+    expect(detectClaudeHarness(root)).toBe(true);
+  });
+
+  it('detects an existing .claude directory', () => {
+    mkdirSync(path.join(root, '.claude'));
+    expect(detectClaudeHarness(root)).toBe(true);
+  });
+
+  it('reports no harness when neither exists', () => {
+    expect(detectClaudeHarness(root)).toBe(false);
+  });
+});
+
+describe('linkHarnessSkills', () => {
+  it('does nothing when no Claude harness is present', () => {
+    expect(linkHarnessSkills(root, 'acceptance')).toEqual({ kind: 'none' });
+    expect(existsSync(path.join(root, '.claude'))).toBe(false);
+  });
+
+  it('creates a relative .claude/skills symlink onto .agents/skills', () => {
+    writeFileSync(path.join(root, 'CLAUDE.md'), '# project');
+
+    const result = linkHarnessSkills(root, 'acceptance');
+
+    expect(result).toEqual({
+      kind: 'linked',
+      link: path.join('.claude', 'skills'),
+      target: path.join('..', '.agents', 'skills'),
+    });
+    const link = path.join(root, '.claude', 'skills');
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(link)).toBe(path.join('..', '.agents', 'skills'));
+  });
+
+  it('is idempotent when the symlink already points at .agents/skills', () => {
+    mkdirSync(path.join(root, '.claude'), { recursive: true });
+    symlinkSync(path.join('..', '.agents', 'skills'), path.join(root, '.claude', 'skills'), 'dir');
+
+    expect(linkHarnessSkills(root, 'acceptance')).toEqual({
+      kind: 'already',
+      link: path.join('.claude', 'skills'),
+    });
+  });
+
+  it('leaves a symlink pointing somewhere else alone', () => {
+    mkdirSync(path.join(root, '.claude'), { recursive: true });
+    symlinkSync(path.join('..', 'elsewhere'), path.join(root, '.claude', 'skills'), 'dir');
+
+    const result = linkHarnessSkills(root, 'acceptance');
+
+    expect(result.kind).toBe('skipped');
+    expect(readlinkSync(path.join(root, '.claude', 'skills'))).toBe(path.join('..', 'elsewhere'));
+  });
+
+  it('links the single skill inside an existing real .claude/skills directory', () => {
+    mkdirSync(path.join(root, '.claude', 'skills', 'my-own-skill'), { recursive: true });
+
+    const result = linkHarnessSkills(root, 'acceptance');
+
+    expect(result).toEqual({
+      kind: 'linked-single',
+      link: path.join('.claude', 'skills', 'acceptance'),
+      target: path.join('..', '..', '.agents', 'skills', 'acceptance'),
+    });
+    expect(existsSync(path.join(root, '.claude', 'skills', 'my-own-skill'))).toBe(true);
+  });
+});
+
+describe('ensureSkillIgnored', () => {
+  it('skips entirely outside a git repository', () => {
+    expect(ensureSkillIgnored(root, 'acceptance', false)).toEqual([
+      { kind: 'skipped', reason: 'not a git repository' },
+    ]);
+    expect(existsSync(path.join(root, '.gitignore'))).toBe(false);
+  });
+
+  it('records the skill in a nested .agents/skills/.gitignore', () => {
+    gitInit(root);
+
+    const results = ensureSkillIgnored(root, 'acceptance', false);
+
+    expect(results[0]).toMatchObject({ entry: '/acceptance/', kind: 'added' });
+    const nested = path.join(root, '.agents', 'skills', '.gitignore');
+    expect(readFileSync(nested, 'utf8')).toBe('/acceptance/\n');
+    expect(existsSync(path.join(root, '.gitignore'))).toBe(false);
+  });
+
+  it('does not duplicate an entry on re-run', () => {
+    gitInit(root);
+    ensureSkillIgnored(root, 'acceptance', false);
+
+    const results = ensureSkillIgnored(root, 'acceptance', false);
+
+    expect(results[0]).toMatchObject({ entry: '/acceptance/', kind: 'present' });
+    expect(readFileSync(path.join(root, '.agents', 'skills', '.gitignore'), 'utf8')).toBe(
+      '/acceptance/\n',
+    );
+  });
+
+  it('adds the root .gitignore line when we created the link and git does not ignore it', () => {
+    gitInit(root);
+    writeFileSync(path.join(root, '.gitignore'), 'node_modules\n');
+
+    ensureSkillIgnored(root, 'acceptance', true);
+
+    expect(readFileSync(path.join(root, '.gitignore'), 'utf8')).toBe(
+      'node_modules\n/.claude/skills\n',
+    );
+  });
+
+  it('leaves the root .gitignore alone when .claude is already ignored', () => {
+    gitInit(root);
+    writeFileSync(path.join(root, '.gitignore'), '.claude/\n');
+
+    ensureSkillIgnored(root, 'acceptance', true);
+
+    expect(readFileSync(path.join(root, '.gitignore'), 'utf8')).toBe('.claude/\n');
+  });
+
+  it('appends a missing trailing newline before the new entry', () => {
+    gitInit(root);
+    writeFileSync(path.join(root, '.gitignore'), 'node_modules');
+
+    ensureSkillIgnored(root, 'acceptance', true);
+
+    expect(readFileSync(path.join(root, '.gitignore'), 'utf8')).toBe(
+      'node_modules\n/.claude/skills\n',
+    );
+  });
+});

--- a/apps/cli/src/utils/skillWiring.test.ts
+++ b/apps/cli/src/utils/skillWiring.test.ts
@@ -110,15 +110,47 @@ describe('ensureSkillIgnored', () => {
     expect(existsSync(path.join(root, '.gitignore'))).toBe(false);
   });
 
-  it('records the skill in a nested .agents/skills/.gitignore', () => {
+  it('records the skill in a nested .agents/skills/.gitignore that also ignores itself', () => {
     gitInit(root);
 
     const results = ensureSkillIgnored(root, 'acceptance', false);
 
     expect(results[0]).toMatchObject({ entry: '/acceptance/', kind: 'added' });
     const nested = path.join(root, '.agents', 'skills', '.gitignore');
-    expect(readFileSync(nested, 'utf8')).toBe('/acceptance/\n');
+    expect(readFileSync(nested, 'utf8')).toBe('/.gitignore\n/acceptance/\n');
     expect(existsSync(path.join(root, '.gitignore'))).toBe(false);
+  });
+
+  it('leaves git status clean after wiring a fresh project', () => {
+    gitInit(root);
+    writeFileSync(path.join(root, 'CLAUDE.md'), '# project');
+    mkdirSync(path.join(root, '.agents', 'skills', 'acceptance'), { recursive: true });
+    writeFileSync(path.join(root, '.agents', 'skills', 'acceptance', 'SKILL.md'), '# skill');
+
+    const link = linkHarnessSkills(root, 'acceptance');
+    ensureSkillIgnored(root, 'acceptance', link.kind === 'linked');
+    execFileSync('git', ['add', '.gitignore', 'CLAUDE.md'], { cwd: root, stdio: 'ignore' });
+
+    const status = execFileSync('git', ['status', '--porcelain', '--untracked-files=all'], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+
+    expect(status).not.toContain('.agents/skills/.gitignore');
+    expect(status).not.toContain('.agents/skills/acceptance');
+    expect(status).not.toContain('.claude/skills');
+  });
+
+  it('does not seed the self-ignore into a pre-existing nested file', () => {
+    gitInit(root);
+    mkdirSync(path.join(root, '.agents', 'skills'), { recursive: true });
+    writeFileSync(path.join(root, '.agents', 'skills', '.gitignore'), '/legacy/\n');
+
+    ensureSkillIgnored(root, 'acceptance', false);
+
+    expect(readFileSync(path.join(root, '.agents', 'skills', '.gitignore'), 'utf8')).toBe(
+      '/legacy/\n/acceptance/\n',
+    );
   });
 
   it('does not duplicate an entry on re-run', () => {
@@ -129,7 +161,7 @@ describe('ensureSkillIgnored', () => {
 
     expect(results[0]).toMatchObject({ entry: '/acceptance/', kind: 'present' });
     expect(readFileSync(path.join(root, '.agents', 'skills', '.gitignore'), 'utf8')).toBe(
-      '/acceptance/\n',
+      '/.gitignore\n/acceptance/\n',
     );
   });
 

--- a/apps/cli/src/utils/skillWiring.ts
+++ b/apps/cli/src/utils/skillWiring.ts
@@ -1,0 +1,141 @@
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+
+export const AGENTS_SKILLS_DIR = path.join('.agents', 'skills');
+
+export type LinkResult =
+  | { kind: 'already'; link: string }
+  | { kind: 'linked'; link: string; target: string }
+  | { kind: 'linked-single'; link: string; target: string }
+  | { kind: 'none' }
+  | { kind: 'skipped'; link: string; reason: string };
+
+export type IgnoreResult =
+  | { kind: 'added'; entry: string; file: string }
+  | { kind: 'present'; entry: string; file: string }
+  | { kind: 'skipped'; reason: string };
+
+export function detectClaudeHarness(baseDir: string): boolean {
+  return existsSync(path.join(baseDir, 'CLAUDE.md')) || existsSync(path.join(baseDir, '.claude'));
+}
+
+function isSymlink(target: string): boolean {
+  try {
+    return lstatSync(target).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * `.agents/skills` is the single materialized copy; every other harness dir is a
+ * symlink onto it, so one install/update reaches all of them.
+ */
+export function linkHarnessSkills(baseDir: string, skillId: string): LinkResult {
+  if (!detectClaudeHarness(baseDir)) return { kind: 'none' };
+
+  const claudeDir = path.join(baseDir, '.claude');
+  const link = path.join(claudeDir, 'skills');
+  const rel = path.join('.claude', 'skills');
+
+  if (isSymlink(link)) {
+    const current = readlinkSync(link);
+    const resolved = path.resolve(claudeDir, current);
+    if (resolved === path.join(baseDir, AGENTS_SKILLS_DIR)) return { kind: 'already', link: rel };
+    return {
+      kind: 'skipped',
+      link: rel,
+      reason: `already a symlink to ${current} — leaving it alone`,
+    };
+  }
+
+  mkdirSync(claudeDir, { recursive: true });
+
+  // A real directory means the user keeps Claude-only skills there; never clobber
+  // it — link just this one skill inside instead.
+  if (existsSync(link)) {
+    const single = path.join(link, skillId);
+    if (isSymlink(single) || existsSync(single))
+      return { kind: 'already', link: path.join(rel, skillId) };
+    const target = path.join('..', '..', AGENTS_SKILLS_DIR, skillId);
+    try {
+      symlinkSync(target, single, 'dir');
+    } catch (error) {
+      return { kind: 'skipped', link: path.join(rel, skillId), reason: (error as Error).message };
+    }
+    return { kind: 'linked-single', link: path.join(rel, skillId), target };
+  }
+
+  const target = path.join('..', AGENTS_SKILLS_DIR);
+  try {
+    symlinkSync(target, link, 'dir');
+  } catch (error) {
+    return { kind: 'skipped', link: rel, reason: (error as Error).message };
+  }
+  return { kind: 'linked', link: rel, target };
+}
+
+function findGitRoot(startDir: string): string | undefined {
+  let dir = startDir;
+  while (true) {
+    if (existsSync(path.join(dir, '.git'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+}
+
+function isIgnoredByGit(baseDir: string, relPath: string): boolean {
+  try {
+    execFileSync('git', ['check-ignore', '-q', '--', relPath], { cwd: baseDir, stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function appendIgnoreEntry(file: string, entry: string): IgnoreResult {
+  const existing = existsSync(file) ? readFileSync(file, 'utf8') : '';
+  if (existing.split('\n').some((line) => line.trim() === entry)) {
+    return { entry, file, kind: 'present' };
+  }
+  const prefix = existing.length > 0 && !existing.endsWith('\n') ? '\n' : '';
+  writeFileSync(file, `${existing}${prefix}${entry}\n`, 'utf8');
+  return { entry, file, kind: 'added' };
+}
+
+/**
+ * Nested `.agents/skills/.gitignore` owns the list of materialized skills, so the
+ * project's root file stays untouched — it only gains a line when we created the
+ * `.claude/skills` symlink and git isn't ignoring it already.
+ */
+export function ensureSkillIgnored(
+  baseDir: string,
+  skillId: string,
+  createdRootLink: boolean,
+): IgnoreResult[] {
+  if (!findGitRoot(baseDir)) return [{ kind: 'skipped', reason: 'not a git repository' }];
+
+  const results: IgnoreResult[] = [];
+  const skillsDir = path.join(baseDir, AGENTS_SKILLS_DIR);
+  mkdirSync(skillsDir, { recursive: true });
+  results.push(appendIgnoreEntry(path.join(skillsDir, '.gitignore'), `/${skillId}/`));
+
+  if (createdRootLink) {
+    const rel = '.claude/skills';
+    if (!isIgnoredByGit(baseDir, rel)) {
+      results.push(appendIgnoreEntry(path.join(baseDir, '.gitignore'), `/${rel}`));
+    }
+  }
+
+  return results;
+}

--- a/apps/cli/src/utils/skillWiring.ts
+++ b/apps/cli/src/utils/skillWiring.ts
@@ -128,7 +128,14 @@ export function ensureSkillIgnored(
   const results: IgnoreResult[] = [];
   const skillsDir = path.join(baseDir, AGENTS_SKILLS_DIR);
   mkdirSync(skillsDir, { recursive: true });
-  results.push(appendIgnoreEntry(path.join(skillsDir, '.gitignore'), `/${skillId}/`));
+
+  // A file we generate must not itself become untracked noise. Git still reads an
+  // ignore file that ignores itself, so seeding this line keeps `git status`
+  // clean. Only when we create it — an existing file is the project's own.
+  const nested = path.join(skillsDir, '.gitignore');
+  if (!existsSync(nested)) appendIgnoreEntry(nested, '/.gitignore');
+
+  results.push(appendIgnoreEntry(nested, `/${skillId}/`));
 
   if (createdRootLink) {
     const rel = '.claude/skills';


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

`lh acceptance install` materialized the skill into `.agents/skills/<id>` and stopped there. Two consequences:

- Claude Code reads skills from `.claude/skills`, so it never saw the installed skill.
- The materialized artifact showed up as untracked noise in the project's git status.

This adds a wiring step after the files are written.

**`.agents/skills` stays the single materialized copy.** Every other harness directory is a symlink onto it, so one install/update reaches all of them.

`linkHarnessSkills` detects a Claude harness (`CLAUDE.md` or `.claude/`) and handles four states of `.claude/skills`:

| State | Action |
| --- | --- |
| missing | create relative symlink → `../.agents/skills` |
| symlink already pointing at `.agents/skills` | no-op |
| a **real directory** (user keeps Claude-only skills there) | never clobber — link just `.claude/skills/<id>` → `../../.agents/skills/<id>` |
| symlink pointing elsewhere | warn, leave alone |

A failed `symlinkSync` (Windows without privileges) returns a `skipped` result instead of aborting the install — the files under `.agents/` are still there.

`ensureSkillIgnored` keeps the ignore list self-contained: the installed skill goes into a nested `.agents/skills/.gitignore` (`/<id>/`), so a project whose own `.agents/skills/*` are tracked — as in this repo — is unaffected. The root `.gitignore` gains `/.claude/skills` **only** when we created that symlink ourselves *and* `git check-ignore` says git isn't already ignoring it. Outside a git repository the whole step is skipped. `--no-gitignore` opts out.

`lh acceptance update` is added — the same action with `force: true`, so it re-pulls the skill and re-runs the wiring (an install predating this PR gets its symlink backfilled). The deprecated `lh verify init` / `lh verify install` aliases inherit all of it since they share `withInstallOptions` + `installAction`.

New logic lives in `apps/cli/src/utils/skillWiring.ts` rather than growing `acceptanceRun.ts` (already ~38KB); `installAction` only orchestrates.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

`apps/cli/src/utils/skillWiring.test.ts` — 14 cases over tmpdir fixtures covering every branch above: no harness detected, fresh symlink creation, idempotent re-run, symlink pointing elsewhere, pre-existing real `.claude/skills` directory, outside a git repo, root `.gitignore` already ignoring `.claude/`, and a `.gitignore` missing its trailing newline.

```
✓ src/utils/skillWiring.test.ts (14 tests)
✓ src/commands/verify.test.ts (52 tests)
```

Type-check passes with no errors in `apps/cli`.

#### 📸 Screenshots / Videos

No UI changes. CLI output gains a wiring section:

```
✓ Acceptance skill → .agents/skills/acceptance
  12 written
  ↳ linked .claude/skills → ../.agents/skills
  ↳ ignored /acceptance/ in .agents/skills/.gitignore
```

The `--json` output gains `link` and `ignored` fields alongside the existing `written` / `skipped`.

#### 📝 Additional Information

Only Claude is detected for now. `linkHarnessSkills` is shaped so other harnesses (Cursor, Codex) can be added as additional detect→link pairs without touching the caller.

Not included, and worth a separate PR: an audit of `packages/builtin-skills/src/` turned up ~29 sites where the English prose uses the Chinese character 端 to mean "surface", an unclosed `<artifacts_guides>` tag in `artifacts/content.ts`, literal backslash escapes in `task/SKILL.md`, and several `lobehub/references/*.ts` command docs that no longer match the CLI.