### PR TITLE
📝 docs(builtin-skills): purge stray Chinese from English skill prose

### DIFF
--- a/packages/builtin-skills/src/acceptance/SKILL.md
+++ b/packages/builtin-skills/src/acceptance/SKILL.md
@@ -64,13 +64,13 @@ this point — that's expected.) Exact shapes:
 The criterion's `hint` usually implies the surface. Match the change you made to
 the cheapest surface that can actually prove it, and escalate only if needed:
 
-| What your task changed                                         | Surface                                                  | Why                                                                        | Guide                                             |
-| -------------------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------- |
-| Backend / CLI / library / data logic                           | **CLI** 端                                               | Fastest, text-assertable, zero UI flakiness — upload stdout as `text`      | [surfaces/cli.md](surfaces/cli.md)                |
-| Web app frontend / styles / interactions                       | **Web** 端 (agent-browser → running web app)             | The product shape users see; screenshot/DOM the rendered result            | [surfaces/web.md](surfaces/web.md)                |
-| New/changed API **plus** the UI consuming it                   | **Web** 端，full-stack (agent-browser + network capture) | One surface where request/response and rendered result are both observable | [surfaces/web.md](surfaces/web.md#web-full-stack) |
-| Desktop (Electron) app behavior                                | **Electron** 端 (agent-browser `--cdp`)                  | Only the real desktop shell exercises desktop-only code paths              | [surfaces/electron.md](surfaces/electron.md)      |
-| Native macOS app / OS-level behavior agent-browser can't reach | **Native** 端 (Computer Use: osascript + screencapture)  | The only way to drive non-Chromium apps and OS chrome (local macOS only)   | [surfaces/native.md](surfaces/native.md)          |
+| What your task changed                                         | Surface                                               | Why                                                                        | Guide                                             |
+| -------------------------------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------- |
+| Backend / CLI / library / data logic                           | **CLI**                                               | Fastest, text-assertable, zero UI flakiness — upload stdout as `text`      | [surfaces/cli.md](surfaces/cli.md)                |
+| Web app frontend / styles / interactions                       | **Web** (agent-browser → running web app)             | The product shape users see; screenshot/DOM the rendered result            | [surfaces/web.md](surfaces/web.md)                |
+| New/changed API **plus** the UI consuming it                   | **Web**, full-stack (agent-browser + network capture) | One surface where request/response and rendered result are both observable | [surfaces/web.md](surfaces/web.md#web-full-stack) |
+| Desktop (Electron) app behavior                                | **Electron** (agent-browser `--cdp`)                  | Only the real desktop shell exercises desktop-only code paths              | [surfaces/electron.md](surfaces/electron.md)      |
+| Native macOS app / OS-level behavior agent-browser can't reach | **Native** (Computer Use: osascript + screencapture)  | The only way to drive non-Chromium apps and OS chrome (local macOS only)   | [surfaces/native.md](surfaces/native.md)          |
 
 Rules of thumb:
 
@@ -81,10 +81,10 @@ Rules of thumb:
   browser against the app's dev server or deployed URL. Use **Electron** only when
   the criterion depends on desktop-only behavior (native windows, IPC, the
   packaged shell, OS integration) — that code path doesn't exist in a plain web
-  page. Switching conditions per 端: [surfaces/web.md](surfaces/web.md) and
+  page. Switching conditions per surface: [surfaces/web.md](surfaces/web.md) and
   [surfaces/electron.md](surfaces/electron.md).
-- **Auth is a gate, scoped to the 端.** If the state under test is behind a
-  login, authenticate that 端 first or every capture lands on the sign-in
+- **Auth is a gate, scoped to the surface.** If the state under test is behind a
+  login, authenticate that surface first or every capture lands on the sign-in
   page. Recipes and boundaries: [references/auth.md](references/auth.md).
 
 ## Step 3 — Capture, then submit each artifact
@@ -143,7 +143,7 @@ OP="$LOBE_OPERATION_ID"
 # 1. discover: find this item's checkItemId + required evidence
 lh verify plan state "$OP" --json # → item id vci_settings, requires screenshot
 
-# 2. 端 = web (frontend change). Auth the session if needed (see references/auth.md).
+# 2. surface = web (frontend change). Auth the session if needed (see references/auth.md).
 agent-browser --session app open "http://localhost:3000/settings"
 agent-browser --session app wait --text "Beta features"
 agent-browser --session app screenshot ./proof/settings-beta.png
@@ -172,13 +172,13 @@ lh acceptance run evidence list vcr_77 --json          # → one screenshot pres
 
 ```
 verify/
-├── SKILL.md                      # this router: the loop + 端 decision + example
-├── surfaces/                     # 不同端的验收方案 — pick one per criterion
-│   ├── cli.md                    # backend / CLI 端 → text evidence from command output
-│   ├── web.md                    # web 端 (frontend / full-stack) via agent-browser
-│   ├── electron.md               # desktop 端 (Electron) via agent-browser --cdp
-│   └── native.md                 # native macOS app / OS-level 端 via Computer Use
-└── references/                   # 跨端共享知识
+├── SKILL.md                      # this router: the loop + surface decision + example
+├── surfaces/                     # per-surface acceptance recipes — pick one per criterion
+│   ├── cli.md                    # backend / CLI surface → text evidence from command output
+│   ├── web.md                    # web surface (frontend / full-stack) via agent-browser
+│   ├── electron.md               # desktop surface (Electron) via agent-browser --cdp
+│   └── native.md                 # native macOS app / OS-level surface via Computer Use
+└── references/                   # cross-surface shared knowledge
     ├── plan-format.md            # verify contract: plan shape + checkItemId↔checkResultId join
     ├── evidence.md               # evidence type → capture recipe; upload; coverage; portability
     ├── agent-browser.md          # full agent-browser CLI reference (any Chromium app)

--- a/packages/builtin-skills/src/acceptance/references/agent-browser.md
+++ b/packages/builtin-skills/src/acceptance/references/agent-browser.md
@@ -2,7 +2,7 @@
 
 Generic reference for the `agent-browser` CLI — automate Chromium-based apps
 (Electron, Chrome, web) via Chrome DevTools Protocol. This is the capture engine
-for all UI evidence in this skill. Per - 端 patterns live in
+for all UI evidence in this skill. Per-surface patterns live in
 [../surfaces/web.md](../surfaces/web.md) and
 [../surfaces/electron.md](../surfaces/electron.md); auth recipes in
 [auth.md](./auth.md).

--- a/packages/builtin-skills/src/acceptance/references/evidence.md
+++ b/packages/builtin-skills/src/acceptance/references/evidence.md
@@ -3,7 +3,7 @@
 The goal is an artifact a human (and the review agent) can open and believe. Pick
 the lightest capture that proves the criterion, and prefer engine-level capture so
 it works the same locally and headless/cloud. UI capture uses `agent-browser`
-([agent-browser.md](./agent-browser.md)) on the 端 you chose
+([agent-browser.md](./agent-browser.md)) on the surface you chose
 ([web](../surfaces/web.md) / [electron](../surfaces/electron.md); backend/CLI →
 [cli](../surfaces/cli.md)).
 
@@ -75,10 +75,10 @@ Tag how the artifact was produced so the reviewer can weigh it:
 
 ## Headless / cloud portability
 
-The decisive constraint per 端 is **how a screenshot is captured**: engine-level
+The decisive constraint per surface is **how a screenshot is captured**: engine-level
 capture (CDP) needs no display; OS-level capture is macOS-only.
 
-| 端         | macOS (local) | Linux / cloud (headless)                                        | Screenshot mechanism                             |
+| Surface    | macOS (local) | Linux / cloud (headless)                                        | Screenshot mechanism                             |
 | ---------- | ------------- | --------------------------------------------------------------- | ------------------------------------------------ |
 | CLI / text | ✅            | ✅                                                              | n/a — text output                                |
 | Web        | ✅            | ✅ headless Chromium works natively                             | CDP — no display needed                          |

--- a/packages/builtin-skills/src/acceptance/surfaces/cli.md
+++ b/packages/builtin-skills/src/acceptance/surfaces/cli.md
@@ -1,4 +1,4 @@
-# CLI /backend 端验收
+# CLI / backend surface
 
 The default surface for backend, CLI, library, and data-logic changes. The proof
 is the command's own output — text, not pixels. This is the cheapest and strongest

--- a/packages/builtin-skills/src/acceptance/surfaces/electron.md
+++ b/packages/builtin-skills/src/acceptance/surfaces/electron.md
@@ -1,4 +1,4 @@
-# 桌面端 (Electron) 验收
+# Desktop (Electron) surface
 
 Use this surface for **desktop-only behavior** — native windows, IPC / main-process
 code, tray/menu, auto-update, OS integration, or a packaged-only path. That code

--- a/packages/builtin-skills/src/acceptance/surfaces/native.md
+++ b/packages/builtin-skills/src/acceptance/surfaces/native.md
@@ -1,12 +1,12 @@
-# 原生 macOS 应用端验收 (Computer Use)
+# Native macOS app surface (Computer Use)
 
-Use this 端 when the thing under test is a **native macOS app** that `agent-browser`
+Use this surface when the thing under test is a **native macOS app** that `agent-browser`
 can't drive — anything not Chromium-based: a native desktop app, a chat client you
 verify against (Slack/WeChat/…), Finder/system UI, or any OS-level behavior. You
 drive it with macOS Computer Use (osascript + screencapture) — the toolkit is in
 [../references/computer-use.md](../references/computer-use.md).
 
-Prefer the other 端 when they can reach the target: [web.md](./web.md) /
+Prefer the other surfaces when they can reach the target: [web.md](./web.md) /
 [electron.md](./electron.md) for Chromium UIs, [cli.md](./cli.md) for backend.
 Native is the **local-macOS escape hatch** — it is not cloud-portable (needs a real
 display + Accessibility permission), so reach for it only when CDP can't.
@@ -38,12 +38,12 @@ lh acceptance run result submit --operation "$LOBE_OPERATION_ID" --item "$CHECK_
   --desc "Native app shows the expected state after the change"
 ```
 
-## Mid-flow use from another 端
+## Mid-flow use from another surface
 
-You don't have to commit the whole run to this 端. A web or Electron flow can drop
+You don't have to commit the whole run to this surface. A web or Electron flow can drop
 into Computer Use for a single OS-level step it can't script — a native file picker,
 a system permission prompt, a Save dialog — then hand control back to agent-browser.
-Capture the proof on whichever 端 owns the criterion.
+Capture the proof on whichever surface owns the criterion.
 
 ## Boundaries
 

--- a/packages/builtin-skills/src/acceptance/surfaces/web.md
+++ b/packages/builtin-skills/src/acceptance/surfaces/web.md
@@ -1,4 +1,4 @@
-# Web 端验收
+# Web surface
 
 Default surface for frontend and full-stack changes — the browser is the one place
 network requests and rendered UI are observable together, so you can assert both

--- a/packages/builtin-skills/src/lobehub/references/bot-feishu.ts
+++ b/packages/builtin-skills/src/lobehub/references/bot-feishu.ts
@@ -105,7 +105,7 @@ lh bot connect <botId>
 
 ## Notes
 
-- **WebSocket mode** (长连接) skips the need for a public URL and is the fastest to set up
+- **WebSocket mode** skips the need for a public URL and is the fastest to set up
 - Every change to permissions, events, or app info requires creating a new version and re-publishing
 - \`im.message.receive_v1\` is the key event — without it the bot receives no messages
 - Feishu does not render Markdown — use plain text or Feishu's card format for rich messages

--- a/packages/builtin-skills/src/lobehub/references/bot-wechat.ts
+++ b/packages/builtin-skills/src/lobehub/references/bot-wechat.ts
@@ -17,7 +17,7 @@ WeChat uses **polling** mode (long-polling) — no webhook URL or WebSocket setu
 WeChat requires a QR code scan to link your account, which is only supported through the LobeHub Web UI:
 
 1. Open your agent in LobeHub
-2. In the left sidebar, click **消息频道** (Message Channel)
+2. In the left sidebar, click **Message Channel** (消息频道)
 3. Select **WeChat** from the platform list on the right
 4. A QR code is displayed — scan it with WeChat to authenticate
 5. Once scanned, credentials are saved automatically and the bot connects


### PR DESCRIPTION
#### 💻 Change Type

- [x] 📝 docs

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

The skill documents under `packages/builtin-skills/src/` ship to users as English, but the character **端** had been used throughout `acceptance/` as an ordinary English word meaning "surface" (the thing under test: CLI / Web / Electron / Native).

It was internally inconsistent, not just untranslated:

- `SKILL.md` has a table whose header column reads **`Surface`** while every cell in it read `**CLI** 端`, `**Web** 端`, `**Electron** 端`, `**Native** 端`.
- `surfaces/electron.md` opens `# 桌面端 (Electron) 验收` and then says "Use this **surface** for desktop-only behavior" in the very next line.
- All four `surfaces/*.md` H1s were fully Chinese while all six `references/*.md` H1s were clean English.

29 sites in total. This replaces every one with "surface" and gives the four surface files uniform English titles.

Also fixed, same origin:

- a full-width comma (U+FF0C) in `**Web** 端，full-stack`
- `Per - 端 patterns live in` in `references/agent-browser.md` — a dangling hyphen left behind when `Per-端` got line-wrapped
- `bot-feishu.ts`: dropped the bare `(长连接)` gloss dropped into English prose
- `bot-wechat.ts`: `**消息频道** (Message Channel)` → `**Message Channel** (消息频道)`. That is LobeHub's own i18n'd UI, not a Chinese-only vendor console, so an English-locale reader sees the English label — it should lead.

**Deliberate Chinese is untouched:**

- `references/computer-use.md` — the `"Your long or 中文 / emoji message"` osascript example (the example *is about* non-ASCII clipboard handling) and the `` `微信` vs `WeChat` `` locale-dependent app-name note
- `lobehub/` — the Feishu and QQ console labels (those consoles are Chinese-only, and each is already glossed in English), the `飞书` / `微信` product names, and the Chinese activation triggers in `lobehub/index.ts`, which exist so the skill fires for Chinese-speaking users

#### 🧪 How to Test

- [x] Tested locally
- [x] No tests needed

Prose-only; no code paths touched. Verification:

```
$ grep -rn '[一-龥]' packages/builtin-skills/src/acceptance/
references/computer-use.md:44:osascript -e 'set the clipboard to "Your long or 中文 / emoji message"'
references/computer-use.md:126:- **App name varies by locale** — e.g. `微信` vs `WeChat`; handle the name the
```

Only the two intentional hits remain. `bun run check` is lint-clean on the changed files.

Relative links were checked before renaming the four H1s: the only `{#...}` custom anchors in the tree (`auth.md#desktop`, `web.md#web-full-stack`) sit on H2s that were not touched, and nothing links to a surface H1 anchor — so the renames break no links.

#### 📸 Screenshots / Videos

No UI changes.

#### 📝 Additional Information

Found while investigating why `端` appeared in an English skill. A broader audit of `packages/builtin-skills/` turned up further issues left out of this PR to keep it prose-only:

- `artifacts/content.ts` opens `<artifacts_guides>` but closes `</artifacts_info>` — the prompt block is never terminated
- `task/SKILL.md` ships literal backslash escapes (`\<task_skill_guides>`), a prettier markdown-escaping artifact emitted verbatim into the prompt
- `lobehub/references/eval.ts` documents eight commands, five of which fail as written against the current CLI (`--run-id` was normalized to `--id`; the group names are singular, not plural)
- `acceptance/SKILL.md`'s H1 still reads `# Verify` and its file-tree diagram is rooted at `verify/`, left over from the rename to `acceptance`
- the `task` and `artifacts` skill descriptions state capabilities but no trigger conditions