### PR TITLE
✨ feat(topic): show creator avatar for others' topics in workspace sidebar

### DIFF
--- a/src/features/TopicCreatorAvatar/index.test.tsx
+++ b/src/features/TopicCreatorAvatar/index.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import TopicCreatorAvatar from './index';
+
+const CURRENT_USER_ID = 'me';
+
+const useAuthorInfoMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/business/client/hooks/useAuthorInfo', () => ({
+  useAuthorInfo: useAuthorInfoMock,
+}));
+
+// `useUserStore(selector)` → run the selector against a fixed state so the
+// component sees a stable current user id.
+vi.mock('@/store/user', () => ({
+  useUserStore: (selector: (s: { userId: string }) => unknown) =>
+    selector({ userId: CURRENT_USER_ID }),
+}));
+
+vi.mock('@/store/user/selectors', () => ({
+  userProfileSelectors: { userId: (s: { userId: string }) => s.userId },
+}));
+
+vi.mock('@lobehub/ui', () => ({
+  Avatar: ({ avatar, title }: { avatar?: string; title?: string }) => (
+    <span data-avatar={avatar ?? ''} data-testid="avatar" data-title={title ?? ''} />
+  ),
+  Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+
+describe('TopicCreatorAvatar', () => {
+  it("renders another member's avatar for topics they created", () => {
+    useAuthorInfoMock.mockReturnValue({ avatar: 'https://x/y.png', fullName: 'Alice' });
+
+    const { getByTestId } = render(<TopicCreatorAvatar userId="someone-else" />);
+
+    // The slot is queried with the *creator* id (not the current user).
+    expect(useAuthorInfoMock).toHaveBeenCalledWith('someone-else');
+    const avatar = getByTestId('avatar');
+    expect(avatar.getAttribute('data-avatar')).toBe('https://x/y.png');
+    expect(avatar.getAttribute('data-title')).toBe('Alice');
+  });
+
+  it("renders nothing for the current user's own topics", () => {
+    useAuthorInfoMock.mockReturnValue(undefined);
+
+    const { queryByTestId } = render(<TopicCreatorAvatar userId={CURRENT_USER_ID} />);
+
+    // Own topic → slot is called with undefined so it never resolves a profile.
+    expect(useAuthorInfoMock).toHaveBeenCalledWith(undefined);
+    expect(queryByTestId('avatar')).toBeNull();
+  });
+
+  it('renders nothing when the creator is not a resolvable workspace member', () => {
+    useAuthorInfoMock.mockReturnValue(undefined);
+
+    const { queryByTestId } = render(<TopicCreatorAvatar userId="ghost" />);
+
+    expect(queryByTestId('avatar')).toBeNull();
+  });
+
+  it('renders nothing when no userId is provided (personal / default topic)', () => {
+    useAuthorInfoMock.mockReturnValue(undefined);
+
+    const { queryByTestId } = render(<TopicCreatorAvatar />);
+
+    expect(useAuthorInfoMock).toHaveBeenCalledWith(undefined);
+    expect(queryByTestId('avatar')).toBeNull();
+  });
+});

--- a/src/features/TopicCreatorAvatar/index.test.tsx
+++ b/src/features/TopicCreatorAvatar/index.test.tsx
@@ -7,23 +7,10 @@ import { describe, expect, it, vi } from 'vitest';
 
 import TopicCreatorAvatar from './index';
 
-const CURRENT_USER_ID = 'me';
-
 const useAuthorInfoMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@/business/client/hooks/useAuthorInfo', () => ({
   useAuthorInfo: useAuthorInfoMock,
-}));
-
-// `useUserStore(selector)` → run the selector against a fixed state so the
-// component sees a stable current user id.
-vi.mock('@/store/user', () => ({
-  useUserStore: (selector: (s: { userId: string }) => unknown) =>
-    selector({ userId: CURRENT_USER_ID }),
-}));
-
-vi.mock('@/store/user/selectors', () => ({
-  userProfileSelectors: { userId: (s: { userId: string }) => s.userId },
 }));
 
 vi.mock('@lobehub/ui', () => ({
@@ -34,37 +21,29 @@ vi.mock('@lobehub/ui', () => ({
 }));
 
 describe('TopicCreatorAvatar', () => {
-  it("renders another member's avatar for topics they created", () => {
+  it("renders a workspace member's avatar (including the current user's own topics)", () => {
+    // In a workspace `useAuthorInfo` resolves the creator profile from members —
+    // for every topic, not just other members'.
     useAuthorInfoMock.mockReturnValue({ avatar: 'https://x/y.png', fullName: 'Alice' });
 
-    const { getByTestId } = render(<TopicCreatorAvatar userId="someone-else" />);
+    const { getByTestId } = render(<TopicCreatorAvatar userId="any-member" />);
 
-    // The slot is queried with the *creator* id (not the current user).
-    expect(useAuthorInfoMock).toHaveBeenCalledWith('someone-else');
+    expect(useAuthorInfoMock).toHaveBeenCalledWith('any-member');
     const avatar = getByTestId('avatar');
     expect(avatar.getAttribute('data-avatar')).toBe('https://x/y.png');
     expect(avatar.getAttribute('data-title')).toBe('Alice');
   });
 
-  it("renders nothing for the current user's own topics", () => {
+  it('renders nothing in personal mode / when the creator is not a resolvable member', () => {
+    // No active workspace → the slot resolves to undefined → no avatar.
     useAuthorInfoMock.mockReturnValue(undefined);
 
-    const { queryByTestId } = render(<TopicCreatorAvatar userId={CURRENT_USER_ID} />);
-
-    // Own topic → slot is called with undefined so it never resolves a profile.
-    expect(useAuthorInfoMock).toHaveBeenCalledWith(undefined);
-    expect(queryByTestId('avatar')).toBeNull();
-  });
-
-  it('renders nothing when the creator is not a resolvable workspace member', () => {
-    useAuthorInfoMock.mockReturnValue(undefined);
-
-    const { queryByTestId } = render(<TopicCreatorAvatar userId="ghost" />);
+    const { queryByTestId } = render(<TopicCreatorAvatar userId="someone" />);
 
     expect(queryByTestId('avatar')).toBeNull();
   });
 
-  it('renders nothing when no userId is provided (personal / default topic)', () => {
+  it('renders nothing when no userId is provided (default / temp topic)', () => {
     useAuthorInfoMock.mockReturnValue(undefined);
 
     const { queryByTestId } = render(<TopicCreatorAvatar />);

--- a/src/features/TopicCreatorAvatar/index.tsx
+++ b/src/features/TopicCreatorAvatar/index.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Avatar, Tooltip } from '@lobehub/ui';
+import { memo } from 'react';
+
+import { useAuthorInfo } from '@/business/client/hooks/useAuthorInfo';
+import { useUserStore } from '@/store/user';
+import { userProfileSelectors } from '@/store/user/selectors';
+
+interface TopicCreatorAvatarProps {
+  /** Size of the avatar in px. */
+  size?: number;
+  /** Creator (author) of the topic. */
+  userId?: string;
+}
+
+/**
+ * In a workspace the topic list mixes topics from every member. Show the
+ * creator's avatar for topics authored by someone *other* than the current
+ * user so the list reads as a shared space.
+ *
+ * Renders nothing for own / personal topics: `useAuthorInfo` is a business slot
+ * that resolves to a no-op (open-source) or the active workspace member profile
+ * (cloud), and we pass `undefined` for the current user so it never resolves.
+ */
+const TopicCreatorAvatar = memo<TopicCreatorAvatarProps>(({ userId, size = 16 }) => {
+  const currentUserId = useUserStore(userProfileSelectors.userId);
+  const isOther = !!userId && userId !== currentUserId;
+  const author = useAuthorInfo(isOther ? userId : undefined);
+
+  if (!author) return null;
+
+  return (
+    <Tooltip title={author.fullName}>
+      <Avatar
+        avatar={author.avatar ?? undefined}
+        size={size}
+        style={{ flex: 'none' }}
+        title={author.fullName ?? undefined}
+      />
+    </Tooltip>
+  );
+});
+
+TopicCreatorAvatar.displayName = 'TopicCreatorAvatar';
+
+export default TopicCreatorAvatar;

--- a/src/features/TopicCreatorAvatar/index.tsx
+++ b/src/features/TopicCreatorAvatar/index.tsx
@@ -4,8 +4,6 @@ import { Avatar, Tooltip } from '@lobehub/ui';
 import { memo } from 'react';
 
 import { useAuthorInfo } from '@/business/client/hooks/useAuthorInfo';
-import { useUserStore } from '@/store/user';
-import { userProfileSelectors } from '@/store/user/selectors';
 
 interface TopicCreatorAvatarProps {
   /** Size of the avatar in px. */
@@ -15,18 +13,17 @@ interface TopicCreatorAvatarProps {
 }
 
 /**
- * In a workspace the topic list mixes topics from every member. Show the
- * creator's avatar for topics authored by someone *other* than the current
- * user so the list reads as a shared space.
+ * In a workspace the topic list mixes topics from every member. Show each
+ * topic's creator avatar as a trailing indicator — including the current user's
+ * own topics — so the list reads as a shared space.
  *
- * Renders nothing for own / personal topics: `useAuthorInfo` is a business slot
- * that resolves to a no-op (open-source) or the active workspace member profile
- * (cloud), and we pass `undefined` for the current user so it never resolves.
+ * `useAuthorInfo` is a business slot that resolves the creator profile from the
+ * *active workspace* members (cloud) or a no-op (open-source). It returns
+ * `undefined` when there is no active workspace, so this renders nothing in
+ * personal mode.
  */
 const TopicCreatorAvatar = memo<TopicCreatorAvatarProps>(({ userId, size = 16 }) => {
-  const currentUserId = useUserStore(userProfileSelectors.userId);
-  const isOther = !!userId && userId !== currentUserId;
-  const author = useAuthorInfo(isOther ? userId : undefined);
+  const author = useAuthorInfo(userId);
 
   if (!author) return null;
 

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/AllTopicsDrawer/Content.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/AllTopicsDrawer/Content.tsx
@@ -191,6 +191,7 @@ const Content = memo<ContentProps>(({ open, searchKeyword }) => {
             status={topic.status}
             threadId={activeThreadId}
             title={topic.title}
+            userId={topic.userId}
           />
         </Flexbox>
       ))}

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -23,6 +23,7 @@ import DirIcon from '@/features/ChatInput/ControlBar/DirIcon';
 import { useHasDraft } from '@/features/ChatInput/draftStorage';
 import { startTopicDrag } from '@/features/ChatInput/InputEditor/ReferTopic/topicDragData';
 import NavItem from '@/features/NavPanel/components/NavItem';
+import TopicCreatorAvatar from '@/features/TopicCreatorAvatar';
 import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
 import { getWorkingDirectoryName } from '@/helpers/workingDirectoryPath';
 import { getPlatformIcon } from '@/routes/(main)/agent/channel/const';
@@ -145,10 +146,12 @@ interface TopicItemProps {
   status?: ChatTopicStatus | null;
   threadId?: string;
   title: string;
+  /** Creator of the topic; drives the workspace creator avatar. */
+  userId?: string;
 }
 
 const TopicItem = memo<TopicItemProps>(
-  ({ id, title, fav, active, threadId, metadata, status, showWorkingDirectory }) => {
+  ({ id, title, fav, active, threadId, metadata, status, showWorkingDirectory, userId }) => {
     const { t } = useTranslation('topic');
     const { isDarkMode } = useTheme();
     const activeAgentId = useAgentStore((s) => s.activeAgentId);
@@ -359,7 +362,6 @@ const TopicItem = memo<TopicItemProps>(
         draggable={!editing}
         extra={<RunningElapsedTime agentId={activeAgentId} topicId={id} />}
         href={href}
-        slots={{ titlePrefix: draftPrefix }}
         title={title === '...' ? <DotsLoading gap={3} size={4} /> : title}
         titleColor={cssVar.colorText}
         icon={(() => {
@@ -444,6 +446,14 @@ const TopicItem = memo<TopicItemProps>(
             />
           );
         })()}
+        slots={{
+          titlePrefix: (
+            <>
+              <TopicCreatorAvatar userId={userId} />
+              {draftPrefix}
+            </>
+          ),
+        }}
         onClick={handleClick}
         onDoubleClick={() => void handleDoubleClick()}
         onDragStart={handleDragStart}

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -360,10 +360,16 @@ const TopicItem = memo<TopicItemProps>(
         description={workingDirectoryNode}
         disabled={editing}
         draggable={!editing}
-        extra={<RunningElapsedTime agentId={activeAgentId} topicId={id} />}
         href={href}
+        slots={{ titlePrefix: draftPrefix }}
         title={title === '...' ? <DotsLoading gap={3} size={4} /> : title}
         titleColor={cssVar.colorText}
+        extra={
+          <>
+            <RunningElapsedTime agentId={activeAgentId} topicId={id} />
+            <TopicCreatorAvatar userId={userId} />
+          </>
+        }
         icon={(() => {
           // A scheduled topic hasn't run yet — nothing else can be true of it,
           // so its clock outranks the other states.
@@ -446,14 +452,6 @@ const TopicItem = memo<TopicItemProps>(
             />
           );
         })()}
-        slots={{
-          titlePrefix: (
-            <>
-              <TopicCreatorAvatar userId={userId} />
-              {draftPrefix}
-            </>
-          ),
-        }}
         onClick={handleClick}
         onDoubleClick={() => void handleDoubleClick()}
         onDragStart={handleDragStart}

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
@@ -284,6 +284,7 @@ const GroupItem = memo<GroupItemComponentProps>(
               status={topic.status}
               threadId={activeThreadId}
               title={topic.title}
+              userId={topic.userId}
             />
           ))}
         </Flexbox>

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByStatusMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByStatusMode/GroupItem.tsx
@@ -52,6 +52,7 @@ const GroupItem = memo<GroupItemComponentProps>(({ group, activeTopicId, activeT
             status={topic.status}
             threadId={activeThreadId}
             title={topic.title}
+            userId={topic.userId}
           />
         ))}
       </Flexbox>

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByTimeMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByTimeMode/GroupItem.tsx
@@ -39,6 +39,7 @@ const GroupItem = memo<GroupItemComponentProps>(({ group, activeTopicId, activeT
             status={topic.status}
             threadId={activeThreadId}
             title={topic.title}
+            userId={topic.userId}
           />
         ))}
       </Flexbox>

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/FlatMode/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/FlatMode/index.tsx
@@ -52,6 +52,7 @@ const FlatMode = memo(() => {
           status={topic.status}
           threadId={activeThreadId}
           title={topic.title}
+          userId={topic.userId}
         />
       ))}
       {isExpandingPageSize && <SkeletonList rows={3} />}

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/SearchResult/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/SearchResult/index.tsx
@@ -39,6 +39,7 @@ const SearchResult = memo(() => {
           metadata={topic.metadata}
           status={topic.status}
           title={topic.title}
+          userId={topic.userId}
         />
       ))}
     </>

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -279,6 +279,7 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
         active={active && !threadId}
         contextMenuItems={dropdownMenu}
         disabled={editing}
+        extra={<TopicCreatorAvatar userId={userId} />}
         href={!editing ? href : undefined}
         title={title === '...' ? <DotsLoading gap={3} size={4} /> : title}
         titleColor={cssVar.colorText}
@@ -314,12 +315,7 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
         })()}
         slots={{
           iconPostfix: unreadNode,
-          titlePrefix: (
-            <>
-              <TopicCreatorAvatar userId={userId} />
-              {draftPrefix}
-            </>
-          ),
+          titlePrefix: draftPrefix,
         }}
         onClick={handleClick}
         onDoubleClick={() => void handleDoubleClick()}

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -14,6 +14,7 @@ import RingLoadingIcon from '@/components/RingLoading';
 import { isDesktop } from '@/const/version';
 import { useHasDraft } from '@/features/ChatInput/draftStorage';
 import NavItem from '@/features/NavPanel/components/NavItem';
+import TopicCreatorAvatar from '@/features/TopicCreatorAvatar';
 import { useFocusTopicPopup } from '@/features/TopicPopupGuard/useTopicPopupsRegistry';
 import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
 import { useAgentGroupStore } from '@/store/agentGroup';
@@ -83,9 +84,11 @@ interface TopicItemProps {
   status?: ChatTopicStatus | null;
   threadId?: string;
   title: string;
+  /** Creator of the topic; drives the workspace creator avatar. */
+  userId?: string;
 }
 
-const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, status }) => {
+const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, status, userId }) => {
   const { t } = useTranslation('topic');
   const { isDarkMode } = useTheme();
   // Same live-running ring as the agent sidebar topic rows (see List/Item there).
@@ -311,7 +314,12 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
         })()}
         slots={{
           iconPostfix: unreadNode,
-          titlePrefix: draftPrefix,
+          titlePrefix: (
+            <>
+              <TopicCreatorAvatar userId={userId} />
+              {draftPrefix}
+            </>
+          ),
         }}
         onClick={handleClick}
         onDoubleClick={() => void handleDoubleClick()}

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ByTimeMode/GroupItem.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ByTimeMode/GroupItem.tsx
@@ -45,6 +45,7 @@ const GroupItem = memo<GroupItemProps>(({ group, activeTopicId, activeThreadId }
             status={topic.status}
             threadId={activeThreadId}
             title={topic.title}
+            userId={topic.userId}
           />
         ))}
       </Flexbox>

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/FlatMode/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/FlatMode/index.tsx
@@ -48,6 +48,7 @@ const FlatMode = memo(() => {
           status={topic.status}
           threadId={activeThreadId}
           title={topic.title}
+          userId={topic.userId}
         />
       ))}
       {isExpandingPageSize && <SkeletonList rows={3} />}


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

In a workspace, the topic list mixes topics from every member. This surfaces the **creator's avatar** for topics authored by **someone other than the current user**, so the list reads as a shared space. Your own (and personal-mode) topics are unchanged.

**Implementation (UI-only)**

- New shared component `src/features/TopicCreatorAvatar` — resolves the creator profile via the existing `useAuthorInfo` business slot (cloud → active workspace member `{ avatar, fullName }`; open-source → no-op). Renders a small avatar + name tooltip, and nothing for own/personal topics or when the creator isn't a resolvable member.
- Wired into **both** workspace topic sidebars:
  - **agent** sidebar `TopicItem` + all mappers (FlatMode, ByTime, ByProject, ByStatus, SearchResult, AllTopicsDrawer)
  - **group** sidebar `TopicItem` + mappers

The creator `userId` is already returned by `TopicModel.query` (LOBE-11543), so no server change is needed. Workspace members are preloaded by `bootstrapWorkspaceData`, so no extra fetch. No new i18n keys (the tooltip shows member data, not translated copy).

#### 🧪 How to Test

- [x] Added/updated tests
- [x] Tested locally

- `cd lobehub && bunx vitest run 'src/features/TopicCreatorAvatar/index.test.tsx'` — avatar renders for other members; renders nothing for self / non-member / no-id.
- Manually: open a workspace agent/group whose topic list has topics from multiple members — other members' rows show their avatar, your own rows don't.

#### 📸 Screenshots / Videos

See the linked verify report for automated evidence.
