### PR TITLE
♻️ refactor: replace antd Radio with lobe-ui RadioGroup

### DIFF
--- a/package.json
+++ b/package.json
@@ -299,7 +299,7 @@
     "@lobehub/icons": "^5.11.0",
     "@lobehub/market-sdk": "0.39.2",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "^5.20.3",
+    "@lobehub/ui": "^5.23.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@napi-rs/canvas": "^0.1.100",
     "@neondatabase/serverless": "^1.1.0",

--- a/src/features/PluginDevModal/MCPManifestForm/index.tsx
+++ b/src/features/PluginDevModal/MCPManifestForm/index.tsx
@@ -1,7 +1,7 @@
 import { Alert, Flexbox, FormItem, Input, InputPassword } from '@lobehub/ui';
-import { Button } from '@lobehub/ui/base-ui';
+import { Button, RadioGroup } from '@lobehub/ui/base-ui';
 import { type FormInstance } from 'antd';
-import { Divider, Form, Radio } from 'antd';
+import { Divider, Form } from 'antd';
 import isEqual from 'fast-deep-equal';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -253,7 +253,7 @@ const MCPManifestForm = ({
                 label={t('dev.mcp.auth.label')}
                 name={AUTH_TYPE}
               >
-                <Radio.Group
+                <RadioGroup
                   style={{ width: '100%' }}
                   options={[
                     {

--- a/src/routes/(main)/settings/proxy/features/ProxyForm.test.tsx
+++ b/src/routes/(main)/settings/proxy/features/ProxyForm.test.tsx
@@ -92,6 +92,35 @@ vi.mock('@lobehub/ui/base-ui', () => ({
       {children}
     </button>
   ),
+  RadioGroup: ({
+    disabled,
+    onChange,
+    options,
+    value,
+  }: {
+    disabled?: boolean;
+    onChange?: (value: string) => void;
+    options?: Array<string | { disabled?: boolean; label?: ReactNode; value: string }>;
+    value?: string;
+  }) => (
+    <div role="radiogroup">
+      {options?.map((option) => {
+        const item = typeof option === 'string' ? { label: option, value: option } : option;
+        return (
+          <label key={item.value}>
+            <input
+              checked={value === item.value}
+              disabled={disabled || item.disabled}
+              type="radio"
+              value={item.value}
+              onChange={() => onChange?.(item.value)}
+            />
+            {item.label}
+          </label>
+        );
+      })}
+    </div>
+  ),
   Switch: ({
     checked,
     disabled,

--- a/src/routes/(main)/settings/proxy/features/ProxyForm.tsx
+++ b/src/routes/(main)/settings/proxy/features/ProxyForm.tsx
@@ -3,8 +3,8 @@
 import { type NetworkProxySettings } from '@lobechat/electron-client-ipc';
 import { type FormGroupItemType } from '@lobehub/ui';
 import { Flexbox, Form, Skeleton, toast } from '@lobehub/ui';
-import { Button, Switch } from '@lobehub/ui/base-ui';
-import { Form as AntdForm, Input, Radio } from 'antd';
+import { Button, RadioGroup, Switch } from '@lobehub/ui/base-ui';
+import { Form as AntdForm, Input } from 'antd';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -227,11 +227,10 @@ const ProxyForm = () => {
     children: [
       {
         children: (
-          <Radio.Group disabled={!isEnableProxy}>
-            <Radio value="http">HTTP</Radio>
-            <Radio value="https">HTTPS</Radio>
-            <Radio value="socks5">SOCKS5</Radio>
-          </Radio.Group>
+          <RadioGroup
+            disabled={!isEnableProxy}
+            options={PROXY_TYPES.map((type) => ({ label: type.toUpperCase(), value: type }))}
+          />
         ),
         label: t('proxy.type'),
         minWidth: undefined,


### PR DESCRIPTION
### What

Replace the two remaining antd `Radio` usages with the new `RadioGroup` from `@lobehub/ui/base-ui` (added in lobe-ui v5.23.0, Base UI powered, Filled style consistent with the base-ui Checkbox family), and bump `@lobehub/ui` to `^5.23.0`.

- `MCPManifestForm/index.tsx` — auth type selector: swapped import only (`Radio.Group options` → `RadioGroup options`).
- `ProxyForm.tsx` — proxy type selector: rewrote children-style `<Radio value>` items as `options` derived from the existing `PROXY_TYPES` const; group-level `disabled` preserved.

Remaining grep hits for `Radio` are lucide icons (`Radio`, `RadioTowerIcon`) and are untouched.

### Why

Continues the antd → base-ui migration; drops the antd Radio dependency from these forms while keeping antd Form.Item injection intact (`RadioGroup` emits the raw string value, which `getValueFromEvent` accepts as-is).

### Verification

E2E-verified on the Electron desktop shell (5/5 cases passed): rendering, a11y semantics (`role=radio` / `aria-checked` / `disabled`), Form.Item value injection with SaveBar dirty state, `disabled` gating via the Enable Proxy toggle, dynamic `enableOAuth` option and API Key field reveal, zero console errors.

Report: https://app.lobehub.com/acceptance/21f24344-54f1-44c6-9ae8-b1035889f07a

Note: visual style changes from antd's ring-style dot to lobe-ui's filled dot — intended, consistent with the base-ui Checkbox family.