### PR TITLE
✨ feat(settings): add Developer settings group

### DIFF
--- a/locales/ar/labs.json
+++ b/locales/ar/labs.json
@@ -11,8 +11,6 @@
   "features.builtinTerminal.title": "الطرفية المدمجة",
   "features.claudeCodeSdk.desc": "قم بتشغيل جلسات Claude Code من خلال Claude Agent SDK بدلاً من تشغيل واجهة سطر الأوامر (CLI). يتيح ذلك بثًا أكثر ثراءً وتحكمًا أفضل في الجلسات.",
   "features.claudeCodeSdk.title": "وقت تشغيل Claude Code SDK",
-  "features.foldFinishedTurn.desc": "طي العملية (الاستدلال واستدعاءات الأدوات) للأدوار المكتملة وغير الأحدث تحت عنوان \"تمت المعالجة\". يبقى الجواب النهائي مرئيًا؛ انقر لتوسيع العملية.",
-  "features.foldFinishedTurn.title": "طي الأدوار المكتملة",
   "features.groupChat.desc": "تمكين تنسيق الدردشة الجماعية متعددة الوكلاء.",
   "features.groupChat.title": "دردشة جماعية (متعددة الوكلاء)",
   "features.imessage.desc": "ربط الوكلاء بـ iMessage من خلال جسر BlueBubbles المحلي لتطبيق LobeHub Desktop.",
@@ -29,5 +27,9 @@
   "features.platformAgent.title": "اتصال الوكيل",
   "features.taskVerify.desc": "أضف قسم قبول التسليم إلى تفاصيل المهمة: قم بوصف القبول في جملة واحدة ودع الذكاء الاصطناعي يولد معايير تحقق قابلة للتعديل.",
   "features.taskVerify.title": "قبول تسليم المهمة",
+  "features.topicAcceptance.desc": "قم بإنشاء قائمة تحقق للتسليم للموضوع الحالي مباشرة فوق المؤلف، بحيث يتم إجراء المحادثة وفقًا للمعايير التي يمكنك تعديلها في أي وقت.",
+  "features.topicAcceptance.title": "قبول الموضوع",
+  "group.desktop": "سطح المكتب",
+  "group.general": "عام",
   "title": "المختبرات"
 }

--- a/locales/ar/setting.json
+++ b/locales/ar/setting.json
@@ -400,6 +400,7 @@
   "downloads.title": "اكتشف المزيد من الطرق لاستخدام LobeHub",
   "group.aiConfig": "النموذج",
   "group.common": "عام",
+  "group.developer": "مطور",
   "group.profile": "الحساب",
   "group.subscription": "الاشتراك",
   "group.system": "النظام",

--- a/locales/bg-BG/labs.json
+++ b/locales/bg-BG/labs.json
@@ -11,8 +11,6 @@
   "features.builtinTerminal.title": "Вграден терминал",
   "features.claudeCodeSdk.desc": "Изпълнявайте сесии на Claude Code чрез Claude Agent SDK вместо да стартирате CLI. Осигурява по-богато стрийминг изживяване и контрол на сесиите.",
   "features.claudeCodeSdk.title": "Claude Code SDK Runtime",
-  "features.foldFinishedTurn.desc": "Свийте процеса (разсъждения и обаждания към инструменти) на завършени, не най-нови ходове на агента под заглавие \"Обработено\". Окончателният отговор остава видим; кликнете, за да разгънете процеса.",
-  "features.foldFinishedTurn.title": "Свиване на завършени ходове",
   "features.groupChat.desc": "Активиране на координация в групов чат с множество агенти.",
   "features.groupChat.title": "Групов чат (многоагентен)",
   "features.imessage.desc": "Свързване на агентите с iMessage чрез локалния LobeHub Desktop BlueBubbles мост.",
@@ -29,5 +27,9 @@
   "features.platformAgent.title": "Свържи агент",
   "features.taskVerify.desc": "Добавете секция за приемане на доставка към детайлите на задачата: опишете приемането с едно изречение и оставете AI да генерира редактиращи критерии за проверка.",
   "features.taskVerify.title": "Приемане на доставка на задача",
+  "features.topicAcceptance.desc": "Създайте контролен списък за доставка за текущата тема точно над композитора, така че разговорът да се провежда според стандартите, които можете да редактирате по всяко време.",
+  "features.topicAcceptance.title": "Приемане на тема",
+  "group.desktop": "Настолен компютър",
+  "group.general": "Общи",
   "title": "Лаборатория"
 }

--- a/locales/bg-BG/setting.json
+++ b/locales/bg-BG/setting.json
@@ -400,6 +400,7 @@
   "downloads.title": "Открийте повече начини за използване на LobeHub",
   "group.aiConfig": "Агент",
   "group.common": "Общи",
+  "group.developer": "Разработчик",
   "group.profile": "Акаунт",
   "group.subscription": "Абонамент",
   "group.system": "Система",

--- a/locales/de-DE/labs.json
+++ b/locales/de-DE/labs.json
@@ -11,8 +11,6 @@
   "features.builtinTerminal.title": "Integriertes Terminal",
   "features.claudeCodeSdk.desc": "Führen Sie Claude Code-Sitzungen über das Claude Agent SDK aus, anstatt die CLI zu starten. Ermöglicht reichhaltigeres Streaming und Sitzungssteuerung.",
   "features.claudeCodeSdk.title": "Claude Code SDK-Laufzeit",
-  "features.foldFinishedTurn.desc": "Klappen Sie den Prozess (Argumentation und Werkzeugaufrufe) abgeschlossener, nicht letzter Agenten-Züge unter einer \"Verarbeitet\"-Überschrift zusammen. Die endgültige Antwort bleibt sichtbar; klicken Sie, um den Prozess zu erweitern.",
-  "features.foldFinishedTurn.title": "Abgeschlossene Züge einklappen",
   "features.groupChat.desc": "Koordination von Gruppenchats mit mehreren Agenten aktivieren.",
   "features.groupChat.title": "Gruppenchat (Multi-Agenten)",
   "features.imessage.desc": "Verbinden Sie Agenten mit iMessage über die lokale LobeHub Desktop BlueBubbles-Bridge.",
@@ -29,5 +27,9 @@
   "features.platformAgent.title": "Agent verbinden",
   "features.taskVerify.desc": "Fügen Sie einen Abschnitt zur Lieferannahme in die Aufgabenbeschreibung hinzu: Beschreiben Sie die Annahme in einem Satz und lassen Sie die KI bearbeitbare Überprüfungskriterien erstellen.",
   "features.taskVerify.title": "Aufgabenlieferung und -annahme",
+  "features.topicAcceptance.desc": "Erstellen Sie eine Liefercheckliste für das aktuelle Thema direkt über dem Editor, damit die Unterhaltung den Standards entspricht, die Sie jederzeit bearbeiten können.",
+  "features.topicAcceptance.title": "Themenakzeptanz",
+  "group.desktop": "Desktop",
+  "group.general": "Allgemein",
   "title": "Labs"
 }

--- a/locales/de-DE/setting.json
+++ b/locales/de-DE/setting.json
@@ -400,6 +400,7 @@
   "downloads.title": "Entdecken Sie weitere Möglichkeiten, LobeHub zu nutzen",
   "group.aiConfig": "Agent",
   "group.common": "Allgemein",
+  "group.developer": "Entwickler",
   "group.profile": "Konto",
   "group.subscription": "Abonnement",
   "group.system": "System",

--- a/locales/en-US/labs.json
+++ b/locales/en-US/labs.json
@@ -29,5 +29,7 @@
   "features.taskVerify.title": "Task Delivery Acceptance",
   "features.topicAcceptance.desc": "Author a delivery checklist for the current topic right above the composer, so the conversation is held to standards you can edit any time.",
   "features.topicAcceptance.title": "Topic Acceptance",
+  "group.desktop": "Desktop",
+  "group.general": "General",
   "title": "Labs"
 }

--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -400,6 +400,7 @@
   "downloads.title": "Discover more ways to use LobeHub",
   "group.aiConfig": "Agent",
   "group.common": "General",
+  "group.developer": "Developer",
   "group.profile": "Account",
   "group.subscription": "Plans",
   "group.system": "System",

--- a/locales/es-ES/labs.json
+++ b/locales/es-ES/labs.json
@@ -11,8 +11,6 @@
   "features.builtinTerminal.title": "Terminal Integrado",
   "features.claudeCodeSdk.desc": "Ejecuta sesiones de Claude Code a través del SDK de Claude Agent en lugar de iniciar la CLI. Permite una transmisión más rica y un mejor control de las sesiones.",
   "features.claudeCodeSdk.title": "Entorno de Ejecución del SDK de Claude Code",
-  "features.foldFinishedTurn.desc": "Colapsa el proceso (razonamiento y llamadas a herramientas) de los turnos de agente finalizados y no más recientes bajo un encabezado \"Procesado\". La respuesta final permanece visible; haz clic para expandir el proceso.",
-  "features.foldFinishedTurn.title": "Colapsar Turnos Finalizados",
   "features.groupChat.desc": "Activa la coordinación de chat grupal con múltiples agentes.",
   "features.groupChat.title": "Chat Grupal (Multiagente)",
   "features.imessage.desc": "Conectar agentes a iMessage a través del puente local LobeHub Desktop BlueBubbles.",
@@ -29,5 +27,9 @@
   "features.platformAgent.title": "Conectar Agente",
   "features.taskVerify.desc": "Agrega una sección de aceptación de entrega a los detalles de la tarea: describe la aceptación en una frase y permite que la IA genere criterios de verificación editables.",
   "features.taskVerify.title": "Aceptación de Entrega de Tarea",
+  "features.topicAcceptance.desc": "Crea una lista de verificación de entrega para el tema actual justo encima del compositor, para que la conversación cumpla con los estándares que puedes editar en cualquier momento.",
+  "features.topicAcceptance.title": "Aceptación de Tema",
+  "group.desktop": "Escritorio",
+  "group.general": "General",
   "title": "Laboratorios"
 }

--- a/locales/es-ES/setting.json
+++ b/locales/es-ES/setting.json
@@ -400,6 +400,7 @@
   "downloads.title": "Descubre más formas de usar LobeHub",
   "group.aiConfig": "Agente",
   "group.common": "General",
+  "group.developer": "Desarrollador",
   "group.profile": "Cuenta",
   "group.subscription": "Suscripción",
   "group.system": "Sistema",

--- a/locales/fa-IR/labs.json
+++ b/locales/fa-IR/labs.json
@@ -11,8 +11,6 @@
   "features.builtinTerminal.title": "ترمینال داخلی",
   "features.claudeCodeSdk.desc": "اجرای جلسات Claude Code از طریق Claude Agent SDK به جای اجرای CLI. امکان پخش غنی‌تر و کنترل جلسات را فراهم می‌کند.",
   "features.claudeCodeSdk.title": "محیط اجرایی Claude Code SDK",
-  "features.foldFinishedTurn.desc": "فرآیند (استدلال و تماس‌های ابزار) نوبت‌های پایان‌یافته و غیرآخرین عامل را تحت عنوان \"پردازش شده\" جمع کنید. پاسخ نهایی قابل مشاهده باقی می‌ماند؛ برای گسترش فرآیند کلیک کنید.",
-  "features.foldFinishedTurn.title": "جمع کردن نوبت‌های پایان‌یافته",
   "features.groupChat.desc": "فعال‌سازی هماهنگی گفت‌وگوی گروهی چندعاملی.",
   "features.groupChat.title": "گفت‌وگوی گروهی (چندعاملی)",
   "features.imessage.desc": "اتصال نمایندگان به iMessage از طریق پل BlueBubbles دسکتاپ LobeHub محلی.",
@@ -29,5 +27,9 @@
   "features.platformAgent.title": "اتصال عامل",
   "features.taskVerify.desc": "یک بخش پذیرش تحویل به جزئیات وظیفه اضافه کنید: پذیرش را در یک جمله توضیح دهید و اجازه دهید هوش مصنوعی معیارهای قابل ویرایش تأیید را تولید کند.",
   "features.taskVerify.title": "پذیرش تحویل وظیفه",
+  "features.topicAcceptance.desc": "یک چک لیست تحویل برای موضوع فعلی درست بالای بخش نویسنده ایجاد کنید، تا مکالمه مطابق استانداردهایی که می‌توانید هر زمان ویرایش کنید، برگزار شود.",
+  "features.topicAcceptance.title": "پذیرش موضوع",
+  "group.desktop": "دسکتاپ",
+  "group.general": "عمومی",
   "title": "آزمایشگاه‌ها"
 }

--- a/locales/fa-IR/setting.json
+++ b/locales/fa-IR/setting.json
@@ -400,6 +400,7 @@
   "downloads.title": "راه‌های بیشتری برای استفاده از LobeHub کشف کنید",
   "group.aiConfig": "عامل",
   "group.common": "عمومی",
+  "group.developer": "توسعه‌دهنده",
   "group.profile": "حساب کاربری",
   "group.subscription": "اشتراک",
   "group.system": "سیستم",

--- a/locales/fr-FR/labs.json
+++ b/locales/fr-FR/labs.json
@@ -11,8 +11,6 @@
   "features.builtinTerminal.title": "Terminal intégré",
   "features.claudeCodeSdk.desc": "Exécutez des sessions Claude Code via le SDK Claude Agent au lieu de lancer l'interface en ligne de commande. Permet un streaming plus riche et un meilleur contrôle des sessions.",
   "features.claudeCodeSdk.title": "Runtime SDK Claude Code",
-  "features.foldFinishedTurn.desc": "Réduire le processus (raisonnement et appels d'outils) des tours d'agent terminés et non les plus récents sous un en-tête \"Traité\". La réponse finale reste visible ; cliquez pour développer le processus.",
-  "features.foldFinishedTurn.title": "Réduire les tours terminés",
   "features.groupChat.desc": "Activez la coordination de discussions de groupe multi-agents.",
   "features.groupChat.title": "Discussion de groupe (multi-agents)",
   "features.imessage.desc": "Connecter les agents à iMessage via le pont local LobeHub Desktop BlueBubbles.",
@@ -29,5 +27,9 @@
   "features.platformAgent.title": "Connecter un agent",
   "features.taskVerify.desc": "Ajoutez une section d'acceptation de livraison dans les détails de la tâche : décrivez l'acceptation en une phrase et laissez l'IA générer des critères de vérification modifiables.",
   "features.taskVerify.title": "Acceptation de Livraison de Tâche",
+  "features.topicAcceptance.desc": "Rédigez une liste de contrôle de livraison pour le sujet actuel juste au-dessus du compositeur, afin que la conversation respecte des normes que vous pouvez modifier à tout moment.",
+  "features.topicAcceptance.title": "Acceptation du sujet",
+  "group.desktop": "Bureau",
+  "group.general": "Général",
   "title": "Laboratoires"
 }

--- a/locales/fr-FR/setting.json
+++ b/locales/fr-FR/setting.json
@@ -400,6 +400,7 @@
   "downloads.title": "Découvrez plus de façons d'utiliser LobeHub",
   "group.aiConfig": "Agent",
   "group.common": "Général",
+  "group.developer": "Développeur",
   "group.profile": "Compte",
   "group.subscription": "Abonnement",
   "group.system": "Système",

--- a/locales/it-IT/labs.json
+++ b/locales/it-IT/labs.json
@@ -11,8 +11,6 @@
   "features.builtinTerminal.title": "Terminale Integrato",
   "features.claudeCodeSdk.desc": "Esegui sessioni Claude Code tramite il Claude Agent SDK invece di avviare il CLI. Consente uno streaming più ricco e un controllo delle sessioni più avanzato.",
   "features.claudeCodeSdk.title": "Runtime SDK di Claude Code",
-  "features.foldFinishedTurn.desc": "Comprimi il processo (ragionamento e chiamate agli strumenti) dei turni dell'agente completati e non più recenti sotto un'intestazione \"Elaborato\". La risposta finale rimane visibile; clicca per espandere il processo.",
-  "features.foldFinishedTurn.title": "Comprimi Turni Completati",
   "features.groupChat.desc": "Abilita il coordinamento della chat di gruppo con più agenti.",
   "features.groupChat.title": "Chat di Gruppo (Multi-Agente)",
   "features.imessage.desc": "Collega gli agenti a iMessage tramite il bridge locale LobeHub Desktop BlueBubbles.",
@@ -29,5 +27,9 @@
   "features.platformAgent.title": "Connetti Agente",
   "features.taskVerify.desc": "Aggiungi una sezione di accettazione della consegna al dettaglio del compito: descrivi l'accettazione in una frase e lascia che l'IA generi criteri di verifica modificabili.",
   "features.taskVerify.title": "Accettazione della Consegna del Compito",
+  "features.topicAcceptance.desc": "Crea una lista di controllo per la consegna dell'argomento corrente proprio sopra il compositore, in modo che la conversazione rispetti gli standard che puoi modificare in qualsiasi momento.",
+  "features.topicAcceptance.title": "Accettazione dell'argomento",
+  "group.desktop": "Desktop",
+  "group.general": "Generale",
   "title": "Laboratori"
 }

--- a/locales/it-IT/setting.json
+++ b/locales/it-IT/setting.json
@@ -400,6 +400,7 @@
   "downloads.title": "Scopri altri modi per utilizzare LobeHub",
   "group.aiConfig": "Agente",
   "group.common": "Generale",
+  "group.developer": "Sviluppatore",
   "group.profile": "Account",
   "group.subscription": "Abbonamento",
   "group.system": "Sistema",

--- a/locales/ja-JP/labs.json
+++ b/locales/ja-JP/labs.json
@@ -11,8 +11,6 @@
   "features.builtinTerminal.title": "組み込みターミナル",
   "features.claudeCodeSdk.desc": "Claude Agent SDKを使用してClaude Codeセッションを実行し、CLIを起動する代わりに利用します。より豊かなストリーミングとセッション管理を可能にします。",
   "features.claudeCodeSdk.title": "Claude Code SDKランタイム",
-  "features.foldFinishedTurn.desc": "完了した最新ではないエージェントのターンのプロセス（推論やツールの呼び出し）を「処理済み」ヘッダーの下に折りたたみます。最終的な回答は表示されたままです。プロセスを展開するにはクリックしてください。",
-  "features.foldFinishedTurn.title": "完了したターンを折りたたむ",
   "features.groupChat.desc": "複数のAIアシスタントによるグループチャット機能を有効にします。",
   "features.groupChat.title": "グループチャット（マルチアシスタント）",
   "features.imessage.desc": "LobeHub Desktop BlueBubblesブリッジを介してエージェントをiMessageに接続します。",
@@ -29,5 +27,9 @@
   "features.platformAgent.title": "エージェントを接続",
   "features.taskVerify.desc": "タスク詳細に納品受け入れセクションを追加: 受け入れ内容を1文で記述し、AIが編集可能な検証基準を生成します。",
   "features.taskVerify.title": "タスク納品受け入れ",
+  "features.topicAcceptance.desc": "現在のトピックのための配達チェックリストを作成し、コンポーザーのすぐ上に配置します。これにより、会話がいつでも編集可能な基準に従って行われます。",
+  "features.topicAcceptance.title": "トピック承認",
+  "group.desktop": "デスクトップ",
+  "group.general": "一般",
   "title": "ラボ"
 }

--- a/locales/ja-JP/setting.json
+++ b/locales/ja-JP/setting.json
@@ -400,6 +400,7 @@
   "downloads.title": "LobeHubを活用する方法をもっと発見",
   "group.aiConfig": "エージェント",
   "group.common": "共通",
+  "group.developer": "開発者",
   "group.profile": "アカウント",
   "group.subscription": "サブスクリプション",
   "group.system": "システム",

--- a/locales/ko-KR/labs.json
+++ b/locales/ko-KR/labs.json
@@ -11,8 +11,6 @@
   "features.builtinTerminal.title": "내장 터미널",
   "features.claudeCodeSdk.desc": "Claude Agent SDK를 통해 Claude Code 세션을 실행하여 CLI를 생성하는 대신 사용합니다. 더 풍부한 스트리밍과 세션 제어를 가능하게 합니다.",
   "features.claudeCodeSdk.title": "Claude Code SDK 런타임",
-  "features.foldFinishedTurn.desc": "완료된 비최신 에이전트 턴의 프로세스(추론 및 도구 호출)를 \"처리됨\" 헤더 아래로 축소합니다. 최종 답변은 계속 표시되며, 프로세스를 확장하려면 클릭하세요.",
-  "features.foldFinishedTurn.title": "완료된 턴 축소",
   "features.groupChat.desc": "다중 도우미 그룹 채팅 조정 기능을 활성화합니다.",
   "features.groupChat.title": "그룹 채팅 (다중 도우미)",
   "features.imessage.desc": "로컬 LobeHub Desktop BlueBubbles 브리지를 통해 에이전트를 iMessage에 연결합니다.",
@@ -29,5 +27,9 @@
   "features.platformAgent.title": "에이전트 연결",
   "features.taskVerify.desc": "작업 세부 정보에 배송 수락 섹션을 추가하세요: 수락을 한 문장으로 설명하고 AI가 편집 가능한 검증 기준을 생성하도록 합니다.",
   "features.taskVerify.title": "작업 배송 수락",
+  "features.topicAcceptance.desc": "현재 주제에 대한 전달 체크리스트를 작성하여 작곡기 바로 위에 배치하면 대화를 언제든지 편집 가능한 표준에 맞출 수 있습니다.",
+  "features.topicAcceptance.title": "주제 수락",
+  "group.desktop": "데스크탑",
+  "group.general": "일반",
   "title": "실험실"
 }

--- a/locales/ko-KR/setting.json
+++ b/locales/ko-KR/setting.json
@@ -400,6 +400,7 @@
   "downloads.title": "LobeHub을 사용하는 더 많은 방법 발견하기",
   "group.aiConfig": "에이전트",
   "group.common": "일반",
+  "group.developer": "개발자",
   "group.profile": "계정",
   "group.subscription": "구독",
   "group.system": "시스템",

--- a/locales/nl-NL/labs.json
+++ b/locales/nl-NL/labs.json
@@ -11,8 +11,6 @@
   "features.builtinTerminal.title": "Ingebouwde Terminal",
   "features.claudeCodeSdk.desc": "Voer Claude Code-sessies uit via de Claude Agent SDK in plaats van de CLI te starten. Biedt rijkere streaming en sessiebeheer.",
   "features.claudeCodeSdk.title": "Claude Code SDK Runtime",
-  "features.foldFinishedTurn.desc": "Vouw het proces (redenering en hulpmiddeloproepen) van voltooide, niet-laatste agentbeurten onder een kop \"Verwerkt\". Het uiteindelijke antwoord blijft zichtbaar; klik om het proces uit te vouwen.",
-  "features.foldFinishedTurn.title": "Vouw Voltooide Beurten",
   "features.groupChat.desc": "Schakel coördinatie van groepschats met meerdere agenten in.",
   "features.groupChat.title": "Groepschat (Meerdere Agenten)",
   "features.imessage.desc": "Verbind agents met iMessage via de lokale LobeHub Desktop BlueBubbles-bridge.",
@@ -29,5 +27,9 @@
   "features.platformAgent.title": "Agent Verbinden",
   "features.taskVerify.desc": "Voeg een sectie voor leveringsacceptatie toe aan de taakdetails: beschrijf de acceptatie in één zin en laat AI bewerkbare verificatiecriteria genereren.",
   "features.taskVerify.title": "Taak Leveringsacceptatie",
+  "features.topicAcceptance.desc": "Stel een leveringschecklist op voor het huidige onderwerp direct boven de editor, zodat het gesprek voldoet aan standaarden die je op elk moment kunt aanpassen.",
+  "features.topicAcceptance.title": "Onderwerpacceptatie",
+  "group.desktop": "Desktop",
+  "group.general": "Algemeen",
   "title": "Labs"
 }

--- a/locales/nl-NL/setting.json
+++ b/locales/nl-NL/setting.json
@@ -400,6 +400,7 @@
   "downloads.title": "Ontdek meer manieren om LobeHub te gebruiken",
   "group.aiConfig": "Agent",
   "group.common": "Algemeen",
+  "group.developer": "Ontwikkelaar",
   "group.profile": "Account",
   "group.subscription": "Abonnement",
   "group.system": "Systeem",

--- a/locales/pl-PL/labs.json
+++ b/locales/pl-PL/labs.json
@@ -11,8 +11,6 @@
   "features.builtinTerminal.title": "Wbudowany Terminal",
   "features.claudeCodeSdk.desc": "Uruchamiaj sesje Claude Code za pomocą Claude Agent SDK zamiast uruchamiania CLI. Umożliwia bardziej zaawansowane przesyłanie strumieniowe i kontrolę sesji.",
   "features.claudeCodeSdk.title": "Środowisko wykonawcze Claude Code SDK",
-  "features.foldFinishedTurn.desc": "Zwiń proces (rozumowanie i wywołania narzędzi) zakończonych, nie najnowszych tur agenta pod nagłówkiem „Przetworzone”. Ostateczna odpowiedź pozostaje widoczna; kliknij, aby rozwinąć proces.",
-  "features.foldFinishedTurn.title": "Zwiń Zakończone Tury",
   "features.groupChat.desc": "Włącz koordynację czatu grupowego z wieloma agentami.",
   "features.groupChat.title": "Czat Grupowy (Wielu Agentów)",
   "features.imessage.desc": "Połącz agentów z iMessage za pośrednictwem lokalnego mostka LobeHub Desktop BlueBubbles.",
@@ -29,5 +27,9 @@
   "features.platformAgent.title": "Połącz agenta",
   "features.taskVerify.desc": "Dodaj sekcję akceptacji dostawy do szczegółów zadania: opisz akceptację w jednym zdaniu i pozwól AI wygenerować edytowalne kryteria weryfikacji.",
   "features.taskVerify.title": "Akceptacja Dostawy Zadania",
+  "features.topicAcceptance.desc": "Utwórz listę kontrolną dostawy dla bieżącego tematu tuż nad edytorem, aby rozmowa była zgodna ze standardami, które możesz edytować w dowolnym momencie.",
+  "features.topicAcceptance.title": "Akceptacja Tematu",
+  "group.desktop": "Komputer stacjonarny",
+  "group.general": "Ogólne",
   "title": "Laboratorium"
 }

--- a/locales/pl-PL/setting.json
+++ b/locales/pl-PL/setting.json
@@ -400,6 +400,7 @@
   "downloads.title": "Odkryj więcej sposobów korzystania z LobeHub",
   "group.aiConfig": "Agent",
   "group.common": "Ogólne",
+  "group.developer": "Programista",
   "group.profile": "Konto",
   "group.subscription": "Subskrypcja",
   "group.system": "System",

--- a/locales/pt-BR/labs.json
+++ b/locales/pt-BR/labs.json
@@ -11,8 +11,6 @@
   "features.builtinTerminal.title": "Terminal Integrado",
   "features.claudeCodeSdk.desc": "Execute sessões do Claude Code através do Claude Agent SDK em vez de iniciar o CLI. Permite streaming mais rico e controle de sessão.",
   "features.claudeCodeSdk.title": "Runtime do SDK Claude Code",
-  "features.foldFinishedTurn.desc": "Colapse o processo (raciocínio e chamadas de ferramentas) de turnos finalizados e não mais recentes do agente sob um cabeçalho \"Processado\". A resposta final permanece visível; clique para expandir o processo.",
-  "features.foldFinishedTurn.title": "Colapsar Turnos Finalizados",
   "features.groupChat.desc": "Ative a coordenação de bate-papo em grupo com múltiplos agentes.",
   "features.groupChat.title": "Bate-Papo em Grupo (Multiagente)",
   "features.imessage.desc": "Conectar agentes ao iMessage através da ponte local LobeHub Desktop BlueBubbles.",
@@ -29,5 +27,9 @@
   "features.platformAgent.title": "Conectar Agente",
   "features.taskVerify.desc": "Adicione uma seção de aceitação de entrega aos detalhes da tarefa: descreva a aceitação em uma frase e deixe a IA gerar critérios de verificação editáveis.",
   "features.taskVerify.title": "Aceitação de Entrega da Tarefa",
+  "features.topicAcceptance.desc": "Crie uma lista de verificação de entrega para o tópico atual logo acima do compositor, para que a conversa siga os padrões que você pode editar a qualquer momento.",
+  "features.topicAcceptance.title": "Aceitação de Tópico",
+  "group.desktop": "Desktop",
+  "group.general": "Geral",
   "title": "Laboratórios"
 }

--- a/locales/pt-BR/setting.json
+++ b/locales/pt-BR/setting.json
@@ -400,6 +400,7 @@
   "downloads.title": "Descubra mais formas de usar o LobeHub",
   "group.aiConfig": "Agente",
   "group.common": "Geral",
+  "group.developer": "Desenvolvedor",
   "group.profile": "Conta",
   "group.subscription": "Assinatura",
   "group.system": "Sistema",

--- a/locales/ru-RU/labs.json
+++ b/locales/ru-RU/labs.json
@@ -11,8 +11,6 @@
   "features.builtinTerminal.title": "Встроенный терминал",
   "features.claudeCodeSdk.desc": "Запускайте сеансы Claude Code через Claude Agent SDK вместо запуска CLI. Обеспечивает более богатую потоковую передачу и управление сеансами.",
   "features.claudeCodeSdk.title": "Среда выполнения Claude Code SDK",
-  "features.foldFinishedTurn.desc": "Свернуть процесс (рассуждения и вызовы инструментов) завершённых, не последних ходов агента под заголовком «Обработано». Окончательный ответ остаётся видимым; нажмите, чтобы развернуть процесс.",
-  "features.foldFinishedTurn.title": "Свернуть завершённые ходы",
   "features.groupChat.desc": "Включите координацию группового чата с несколькими агентами.",
   "features.groupChat.title": "Групповой чат (мультиагентный)",
   "features.imessage.desc": "Подключайте агентов к iMessage через локальный мост LobeHub Desktop BlueBubbles.",
@@ -29,5 +27,9 @@
   "features.platformAgent.title": "Подключить агент",
   "features.taskVerify.desc": "Добавьте раздел приемки доставки в детали задачи: опишите приемку в одном предложении, и ИИ создаст редактируемые критерии проверки.",
   "features.taskVerify.title": "Приемка доставки задачи",
+  "features.topicAcceptance.desc": "Создайте контрольный список доставки для текущей темы прямо над редактором, чтобы разговор соответствовал стандартам, которые вы можете редактировать в любое время.",
+  "features.topicAcceptance.title": "Принятие темы",
+  "group.desktop": "Настольный компьютер",
+  "group.general": "Общие",
   "title": "Лаборатория"
 }

--- a/locales/ru-RU/setting.json
+++ b/locales/ru-RU/setting.json
@@ -400,6 +400,7 @@
   "downloads.title": "Откройте больше способов использовать LobeHub",
   "group.aiConfig": "Агент",
   "group.common": "Общие",
+  "group.developer": "Разработчик",
   "group.profile": "Аккаунт",
   "group.subscription": "Подписка",
   "group.system": "Система",

--- a/locales/tr-TR/labs.json
+++ b/locales/tr-TR/labs.json
@@ -11,8 +11,6 @@
   "features.builtinTerminal.title": "Yerleşik Terminal",
   "features.claudeCodeSdk.desc": "Claude Agent SDK aracılığıyla Claude Code oturumlarını çalıştırın, CLI başlatmak yerine. Daha zengin akış ve oturum kontrolü sağlar.",
   "features.claudeCodeSdk.title": "Claude Code SDK Çalışma Zamanı",
-  "features.foldFinishedTurn.desc": "Tamamlanmış, en son olmayan ajan dönüşlerinin sürecini (akıl yürütme ve araç çağrıları) \"İşlenmiş\" başlığı altında daraltın. Nihai cevap görünür kalır; süreci genişletmek için tıklayın.",
-  "features.foldFinishedTurn.title": "Tamamlanmış Dönüşleri Daralt",
   "features.groupChat.desc": "Çoklu temsilci grup sohbeti koordinasyonunu etkinleştirin.",
   "features.groupChat.title": "Grup Sohbeti (Çoklu Temsilci)",
   "features.imessage.desc": "Ajanları, yerel LobeHub Masaüstü BlueBubbles köprüsü aracılığıyla iMessage'a bağlayın.",
@@ -29,5 +27,9 @@
   "features.platformAgent.title": "Bağlantı Ajanı",
   "features.taskVerify.desc": "Görev detayına teslimat kabul bölümü ekleyin: kabulü bir cümleyle açıklayın ve düzenlenebilir doğrulama kriterlerini AI ile oluşturun.",
   "features.taskVerify.title": "Görev Teslimat Kabulü",
+  "features.topicAcceptance.desc": "Mevcut konu için bir teslimat kontrol listesi oluşturun ve bunu düzenleyiciye hemen üstüne yerleştirin, böylece konuşma her zaman düzenleyebileceğiniz standartlara uygun şekilde yapılır.",
+  "features.topicAcceptance.title": "Konu Kabulü",
+  "group.desktop": "Masaüstü",
+  "group.general": "Genel",
   "title": "Deneysel Özellikler"
 }

--- a/locales/tr-TR/setting.json
+++ b/locales/tr-TR/setting.json
@@ -400,6 +400,7 @@
   "downloads.title": "LobeHub'u kullanmanın daha fazla yolunu keşfedin",
   "group.aiConfig": "Ajans",
   "group.common": "Genel",
+  "group.developer": "Geliştirici",
   "group.profile": "Hesap",
   "group.subscription": "Abonelik",
   "group.system": "Sistem",

--- a/locales/vi-VN/labs.json
+++ b/locales/vi-VN/labs.json
@@ -11,8 +11,6 @@
   "features.builtinTerminal.title": "Terminal Tích Hợp",
   "features.claudeCodeSdk.desc": "Chạy các phiên Claude Code thông qua Claude Agent SDK thay vì khởi chạy CLI. Cho phép truyền tải phong phú hơn và kiểm soát phiên làm việc.",
   "features.claudeCodeSdk.title": "Thời gian chạy Claude Code SDK",
-  "features.foldFinishedTurn.desc": "Thu gọn quy trình (lập luận và các cuộc gọi công cụ) của các lượt tác nhân đã hoàn thành, không phải lượt mới nhất, dưới tiêu đề \"Đã xử lý\". Câu trả lời cuối cùng vẫn hiển thị; nhấp để mở rộng quy trình.",
-  "features.foldFinishedTurn.title": "Thu gọn các lượt đã hoàn thành",
   "features.groupChat.desc": "Kích hoạt phối hợp trò chuyện nhóm với nhiều tác nhân.",
   "features.groupChat.title": "Trò Chuyện Nhóm (Đa Tác Nhân)",
   "features.imessage.desc": "Kết nối các đại lý với iMessage thông qua cầu nối BlueBubbles LobeHub Desktop cục bộ.",
@@ -29,5 +27,9 @@
   "features.platformAgent.title": "Kết nối Agent",
   "features.taskVerify.desc": "Thêm phần chấp nhận giao hàng vào chi tiết nhiệm vụ: mô tả chấp nhận trong một câu và để AI tạo tiêu chí xác minh có thể chỉnh sửa.",
   "features.taskVerify.title": "Chấp Nhận Giao Nhiệm Vụ",
+  "features.topicAcceptance.desc": "Tạo danh sách kiểm tra giao hàng cho chủ đề hiện tại ngay phía trên trình soạn thảo, để cuộc trò chuyện tuân theo các tiêu chuẩn mà bạn có thể chỉnh sửa bất kỳ lúc nào.",
+  "features.topicAcceptance.title": "Chấp nhận Chủ đề",
+  "group.desktop": "Máy tính để bàn",
+  "group.general": "Chung",
   "title": "Phòng Thí Nghiệm"
 }

--- a/locales/vi-VN/setting.json
+++ b/locales/vi-VN/setting.json
@@ -400,6 +400,7 @@
   "downloads.title": "Khám phá thêm cách sử dụng LobeHub",
   "group.aiConfig": "Mô hình",
   "group.common": "Chung",
+  "group.developer": "Nhà phát triển",
   "group.profile": "Tài khoản",
   "group.subscription": "Gói đăng ký",
   "group.system": "Hệ thống",

--- a/locales/zh-CN/labs.json
+++ b/locales/zh-CN/labs.json
@@ -29,5 +29,7 @@
   "features.taskVerify.title": "任务交付验收",
   "features.topicAcceptance.desc": "在输入框上方为当前话题编写一份交付验收清单，让对话对照你随时可编辑的标准来交付。",
   "features.topicAcceptance.title": "话题验收",
+  "group.desktop": "桌面端",
+  "group.general": "通用",
   "title": "实验室"
 }

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -400,6 +400,7 @@
   "downloads.title": "探索 LobeHub 的更多使用方式",
   "group.aiConfig": "智能体",
   "group.common": "通用",
+  "group.developer": "开发者",
   "group.profile": "账号",
   "group.subscription": "套餐",
   "group.system": "系统",

--- a/locales/zh-TW/labs.json
+++ b/locales/zh-TW/labs.json
@@ -11,8 +11,6 @@
   "features.builtinTerminal.title": "內建終端",
   "features.claudeCodeSdk.desc": "透過 Claude Agent SDK 執行 Claude Code 會話，而非啟動 CLI。提供更豐富的串流和會話控制功能。",
   "features.claudeCodeSdk.title": "Claude Code SDK 執行環境",
-  "features.foldFinishedTurn.desc": "將已完成且非最新代理回合的過程（推理和工具調用）折疊到「已處理」標題下。最終答案保持可見；點擊以展開過程。",
-  "features.foldFinishedTurn.title": "折疊已完成回合",
   "features.groupChat.desc": "啟用多智能體群組聊天編排功能。",
   "features.groupChat.title": "群組聊天（多智能體）",
   "features.imessage.desc": "透過本地 LobeHub Desktop BlueBubbles 橋接，將代理連接至 iMessage。",
@@ -29,5 +27,9 @@
   "features.platformAgent.title": "連接代理",
   "features.taskVerify.desc": "在任務詳情中新增交付驗收部分：用一句話描述驗收內容，並讓 AI 生成可編輯的驗收標準。",
   "features.taskVerify.title": "任務交付驗收",
+  "features.topicAcceptance.desc": "在編輯器上方為當前主題撰寫交付清單，以確保對話符合標準，您可以隨時進行編輯。",
+  "features.topicAcceptance.title": "主題接受",
+  "group.desktop": "桌面",
+  "group.general": "一般",
   "title": "實驗室"
 }

--- a/locales/zh-TW/setting.json
+++ b/locales/zh-TW/setting.json
@@ -400,6 +400,7 @@
   "downloads.title": "探索更多使用 LobeHub 的方式",
   "group.aiConfig": "智能代理",
   "group.common": "通用",
+  "group.developer": "開發者",
   "group.profile": "帳號",
   "group.subscription": "訂閱",
   "group.system": "系統",

--- a/packages/locales/src/default/labs.ts
+++ b/packages/locales/src/default/labs.ts
@@ -43,5 +43,7 @@ export default {
   'features.topicAcceptance.desc':
     'Author a delivery checklist for the current topic right above the composer, so the conversation is held to standards you can edit any time.',
   'features.topicAcceptance.title': 'Topic Acceptance',
+  'group.desktop': 'Desktop',
+  'group.general': 'General',
   'title': 'Labs',
 };

--- a/packages/locales/src/default/setting.ts
+++ b/packages/locales/src/default/setting.ts
@@ -520,6 +520,7 @@ export default {
   'defaultAgent.title': 'New Agent',
   'group.aiConfig': 'Agent',
   'group.common': 'General',
+  'group.developer': 'Developer',
   'group.profile': 'Account',
   'group.subscription': 'Plans',
   'group.system': 'System',

--- a/src/features/SettingsSearch/items.ts
+++ b/src/features/SettingsSearch/items.ts
@@ -46,7 +46,7 @@ export interface SettingsSearchItem {
  */
 export const TAB_SEARCH_EN_KEYWORDS: Partial<Record<SettingsTabs, string[]>> = {
   [SettingsTabs.About]: ['about', 'version', 'changelog', 'feedback', 'help'],
-  [SettingsTabs.Advanced]: ['advanced', 'developer', 'labs', 'experiment', 'beta'],
+  [SettingsTabs.Advanced]: ['advanced', 'developer', 'diagnostics'],
   [SettingsTabs.APIKey]: ['api key', 'apikey', 'token', 'secret'],
   [SettingsTabs.Appearance]: [
     'appearance',
@@ -63,6 +63,7 @@ export const TAB_SEARCH_EN_KEYWORDS: Partial<Record<SettingsTabs, string[]>> = {
   [SettingsTabs.Creds]: ['credentials', 'secrets', 'oauth'],
   [SettingsTabs.Devices]: ['devices', 'sessions', 'logged in devices'],
   [SettingsTabs.Hotkey]: ['hotkey', 'shortcut', 'keyboard'],
+  [SettingsTabs.Labs]: ['labs', 'experiment', 'beta', 'preview', 'developer'],
   [SettingsTabs.Memory]: ['memory', 'memories', 'personalization'],
   [SettingsTabs.Messenger]: ['messenger', 'chat platform', 'bot'],
   [SettingsTabs.Notification]: ['notification', 'email', 'push', 'alerts'],
@@ -317,13 +318,6 @@ export const SETTINGS_SEARCH_ITEMS: SettingsSearchItem[] = [
     labelKey: 'tab.advanced.updateChannel.title',
     tab: SettingsTabs.Advanced,
     visible: (ctx) => ctx.isDesktop,
-  },
-  {
-    anchor: 'advanced-labs',
-    keywords: ['labs', 'experiment', 'beta', 'preview'],
-    labelKey: 'title',
-    ns: 'labs',
-    tab: SettingsTabs.Advanced,
   },
   // Service Model
   {

--- a/src/routes/(main)/settings/_layout/Body/index.tsx
+++ b/src/routes/(main)/settings/_layout/Body/index.tsx
@@ -37,6 +37,7 @@ const Body = memo(() => {
             SettingsGroupKey.Subscription,
             SettingsGroupKey.Agent,
             SettingsGroupKey.System,
+            SettingsGroupKey.Developer,
           ]}
         >
           {categoryGroups.map((group) => (

--- a/src/routes/(main)/settings/advanced/index.tsx
+++ b/src/routes/(main)/settings/advanced/index.tsx
@@ -17,7 +17,7 @@ import SettingHeader from '@/routes/(main)/settings/features/SettingHeader';
 import { autoUpdateService } from '@/services/electron/autoUpdate';
 import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
-import { labPreferSelectors, preferenceSelectors, settingsSelectors } from '@/store/user/selectors';
+import { settingsSelectors } from '@/store/user/selectors';
 
 type UpdateChannelValue = 'canary' | 'stable';
 
@@ -31,7 +31,6 @@ const styles = createStaticStyles(({ css }) => ({
 
 const Page = memo(() => {
   const { t } = useTranslation('setting');
-  const { t: tLabs } = useTranslation('labs');
 
   const general = useUserStore((s) => settingsSelectors.currentSettings(s).general, isEqual);
   const defaultAgentGatewayModeEnabled = useUserStore(
@@ -47,38 +46,7 @@ const Page = memo(() => {
     ]);
   const [loading, setLoading] = useState(false);
 
-  const [
-    isPreferenceInit,
-    enableAgentGraphConfig,
-    enableInputMarkdown,
-    enablePlatformAgent,
-    enableImessage,
-    enableClaudeCodeSdk,
-    enableMessageTextSelectionActions,
-    enableOAuthApps,
-    enableInAppBrowser,
-    enableArtifactDeployment,
-    enableBuiltinTerminal,
-    enableTopicAcceptance,
-    updateLab,
-  ] = useUserStore((s) => [
-    preferenceSelectors.isPreferenceInit(s),
-    labPreferSelectors.enableAgentGraphConfig(s),
-    labPreferSelectors.enableInputMarkdown(s),
-    labPreferSelectors.enablePlatformAgent(s),
-    labPreferSelectors.enableImessage(s),
-    labPreferSelectors.enableClaudeCodeSdk(s),
-    labPreferSelectors.enableMessageTextSelectionActions(s),
-    labPreferSelectors.enableOAuthApps(s),
-    labPreferSelectors.enableInAppBrowser(s),
-    labPreferSelectors.enableArtifactDeployment(s),
-    labPreferSelectors.enableBuiltinTerminal(s),
-    labPreferSelectors.enableTopicAcceptance(s),
-    s.updateLab,
-  ]);
-
   const enableGatewayMode = useServerConfigStore(serverConfigSelectors.enableGatewayMode);
-  const hasGatewayUrl = useServerConfigStore((s) => !!s.serverConfig.agentGatewayUrl);
 
   const [channel, setChannel] = useState<UpdateChannelValue>('stable');
 
@@ -179,174 +147,7 @@ const Page = memo(() => {
     title: t('tab.advanced.appUpdates.title'),
   };
 
-  const labItems: FormItemProps[] = [
-    {
-      children: (
-        <Switch
-          checked={enableAgentGraphConfig}
-          loading={!isPreferenceInit}
-          onChange={(checked: boolean) => updateLab({ enableAgentGraphConfig: checked })}
-        />
-      ),
-      className: styles.labItem,
-      desc: tLabs('features.agentGraphConfig.desc'),
-      label: tLabs('features.agentGraphConfig.title'),
-      minWidth: undefined,
-    } satisfies FormItemProps,
-    {
-      children: (
-        <Switch
-          checked={enableInputMarkdown}
-          loading={!isPreferenceInit}
-          onChange={(checked) => updateLab({ enableInputMarkdown: checked })}
-        />
-      ),
-      className: styles.labItem,
-      desc: tLabs('features.inputMarkdown.desc'),
-      label: tLabs('features.inputMarkdown.title'),
-      minWidth: undefined,
-    },
-    {
-      children: (
-        <Switch
-          checked={enableMessageTextSelectionActions}
-          loading={!isPreferenceInit}
-          onChange={(checked) => updateLab({ enableMessageTextSelectionActions: checked })}
-        />
-      ),
-      className: styles.labItem,
-      desc: tLabs('features.messageTextSelectionActions.desc'),
-      label: tLabs('features.messageTextSelectionActions.title'),
-      minWidth: undefined,
-    },
-    {
-      children: (
-        <Switch
-          checked={enableTopicAcceptance}
-          loading={!isPreferenceInit}
-          onChange={(checked) => updateLab({ enableTopicAcceptance: checked })}
-        />
-      ),
-      className: styles.labItem,
-      desc: tLabs('features.topicAcceptance.desc'),
-      label: tLabs('features.topicAcceptance.title'),
-      minWidth: undefined,
-    },
-    {
-      children: (
-        <Switch
-          checked={enableOAuthApps}
-          loading={!isPreferenceInit}
-          onChange={(checked) => updateLab({ enableOAuthApps: checked })}
-        />
-      ),
-      className: styles.labItem,
-      desc: tLabs('features.oauthApps.desc'),
-      label: tLabs('features.oauthApps.title'),
-      minWidth: undefined,
-    },
-    ...(isDesktop
-      ? [
-          {
-            children: (
-              <Switch
-                checked={enableImessage}
-                loading={!isPreferenceInit}
-                onChange={(checked: boolean) => updateLab({ enableImessage: checked })}
-              />
-            ),
-            className: styles.labItem,
-            desc: tLabs('features.imessage.desc'),
-            label: tLabs('features.imessage.title'),
-            minWidth: undefined,
-          } satisfies FormItemProps,
-          {
-            children: (
-              <Switch
-                checked={enableClaudeCodeSdk}
-                loading={!isPreferenceInit}
-                onChange={(checked: boolean) => updateLab({ enableClaudeCodeSdk: checked })}
-              />
-            ),
-            className: styles.labItem,
-            desc: tLabs('features.claudeCodeSdk.desc'),
-            label: tLabs('features.claudeCodeSdk.title'),
-            minWidth: undefined,
-          } satisfies FormItemProps,
-        ]
-      : []),
-    ...(hasGatewayUrl
-      ? [
-          {
-            children: (
-              <Switch
-                checked={enablePlatformAgent}
-                loading={!isPreferenceInit}
-                onChange={(checked: boolean) => updateLab({ enablePlatformAgent: checked })}
-              />
-            ),
-            className: styles.labItem,
-            desc: tLabs('features.platformAgent.desc'),
-            label: tLabs('features.platformAgent.title'),
-            minWidth: undefined,
-          } satisfies FormItemProps,
-        ]
-      : []),
-    // The in-app browser pages are main-process WebContentsViews — desktop only.
-    ...(isDesktop
-      ? [
-          {
-            children: (
-              <Switch
-                checked={enableInAppBrowser}
-                loading={!isPreferenceInit}
-                onChange={(checked: boolean) => updateLab({ enableInAppBrowser: checked })}
-              />
-            ),
-            className: styles.labItem,
-            desc: tLabs('features.inAppBrowser.desc'),
-            label: tLabs('features.inAppBrowser.title'),
-            minWidth: undefined,
-          } satisfies FormItemProps,
-          // The terminal runs PTY sessions in the Electron main process — desktop only.
-          {
-            children: (
-              <Switch
-                checked={enableBuiltinTerminal}
-                loading={!isPreferenceInit}
-                onChange={(checked: boolean) => updateLab({ enableBuiltinTerminal: checked })}
-              />
-            ),
-            className: styles.labItem,
-            desc: tLabs('features.builtinTerminal.desc'),
-            label: tLabs('features.builtinTerminal.title'),
-            minWidth: undefined,
-          } satisfies FormItemProps,
-        ]
-      : []),
-    {
-      children: (
-        <Switch
-          checked={enableArtifactDeployment}
-          loading={!isPreferenceInit}
-          onChange={(checked: boolean) => updateLab({ enableArtifactDeployment: checked })}
-        />
-      ),
-      className: styles.labItem,
-      desc: tLabs('features.artifactDeployment.desc'),
-      label: tLabs('features.artifactDeployment.title'),
-      minWidth: undefined,
-    } satisfies FormItemProps,
-  ];
-
-  const labsGroup: FormGroupItemType = {
-    children: labItems,
-    title: <SettingsSearchAnchor id={'advanced-labs'}>{tLabs('title')}</SettingsSearchAnchor>,
-  };
-
-  const items = isDesktop
-    ? [advancedGroup, updateChannelGroup, labsGroup]
-    : [advancedGroup, labsGroup];
+  const items = isDesktop ? [advancedGroup, updateChannelGroup] : [advancedGroup];
 
   return (
     <>

--- a/src/routes/(main)/settings/features/componentMap.desktop.ts
+++ b/src/routes/(main)/settings/features/componentMap.desktop.ts
@@ -14,6 +14,7 @@ import Connector from '../connector';
 import Creds from '../creds';
 import Devices from '../devices';
 import Hotkey from '../hotkey';
+import Labs from '../labs';
 import Memory from '../memory';
 import Messenger from '../messenger';
 import OAuthApps from '../oauth-apps';
@@ -29,6 +30,7 @@ import SystemTools from '../system-tools';
 
 export const componentMap = {
   [SettingsTabs.Advanced]: Advanced,
+  [SettingsTabs.Labs]: Labs,
   [SettingsTabs.Appearance]: Appearance,
   [SettingsTabs.Provider]: Provider,
   [SettingsTabs.ServiceModel]: ServiceModel,

--- a/src/routes/(main)/settings/features/componentMap.ts
+++ b/src/routes/(main)/settings/features/componentMap.ts
@@ -10,6 +10,9 @@ export const componentMap = {
   [SettingsTabs.Advanced]: dynamic(() => import('../advanced'), {
     loading: loading('Settings > Advanced'),
   }),
+  [SettingsTabs.Labs]: dynamic(() => import('../labs'), {
+    loading: loading('Settings > Labs'),
+  }),
   [SettingsTabs.Appearance]: dynamic(() => import('../appearance'), {
     loading: loading('Settings > Appearance'),
   }),

--- a/src/routes/(main)/settings/hooks/useCategory.tsx
+++ b/src/routes/(main)/settings/hooks/useCategory.tsx
@@ -13,6 +13,7 @@ import {
   Database,
   EllipsisIcon,
   EthernetPort,
+  FlaskConical,
   Gift,
   Info,
   KeyboardIcon,
@@ -43,6 +44,7 @@ import { userGeneralSettingsSelectors } from '@/store/user/slices/settings/selec
 
 export enum SettingsGroupKey {
   Agent = 'agent',
+  Developer = 'developer',
   General = 'general',
   Subscription = 'subscription',
   System = 'system',
@@ -65,6 +67,7 @@ export interface CategoryGroup {
 export const useCategory = () => {
   const { t } = useTranslation('setting');
   const { t: tAuth } = useTranslation('auth');
+  const { t: tLabs } = useTranslation('labs');
   const { t: tSubscription } = useTranslation('subscription');
   const mobile = useServerConfigStore((s) => s.isMobile);
   const { hideDocs, showApiKeyManage, showProvider } = useServerConfigStore(featureFlagsSelectors);
@@ -215,21 +218,6 @@ export const useCategory = () => {
         key: SettingsTabs.Storage,
         label: t('tab.storage'),
       },
-      isDevMode && {
-        icon: KeyIcon,
-        key: SettingsTabs.APIKey,
-        label: tAuth('tab.apikey'),
-      },
-      enableOAuthApps && {
-        icon: AppWindowIcon,
-        key: SettingsTabs.OAuthApps,
-        label: tAuth('tab.oauthApps'),
-      },
-      {
-        icon: EllipsisIcon,
-        key: SettingsTabs.Advanced,
-        label: t('tab.advanced'),
-      },
       !hideDocs && {
         icon: Info,
         key: SettingsTabs.About,
@@ -243,10 +231,42 @@ export const useCategory = () => {
       title: t('group.system'),
     });
 
+    // Developer group. Advanced comes first, followed by the system-level API
+    // Key (dev mode), OAuth apps (lab flag), and the Labs playground.
+    const developerItems: CategoryItem[] = [
+      {
+        icon: EllipsisIcon,
+        key: SettingsTabs.Advanced,
+        label: t('tab.advanced'),
+      },
+      isDevMode && {
+        icon: KeyIcon,
+        key: SettingsTabs.APIKey,
+        label: tAuth('tab.apikey'),
+      },
+      enableOAuthApps && {
+        icon: AppWindowIcon,
+        key: SettingsTabs.OAuthApps,
+        label: tAuth('tab.oauthApps'),
+      },
+      {
+        icon: FlaskConical,
+        key: SettingsTabs.Labs,
+        label: tLabs('title'),
+      },
+    ].filter(Boolean) as CategoryItem[];
+
+    groups.push({
+      items: developerItems,
+      key: SettingsGroupKey.Developer,
+      title: t('group.developer'),
+    });
+
     return groups;
   }, [
     t,
     tAuth,
+    tLabs,
     tSubscription,
     enableBusinessFeatures,
     hideDocs,

--- a/src/routes/(main)/settings/labs/index.test.tsx
+++ b/src/routes/(main)/settings/labs/index.test.tsx
@@ -58,24 +58,15 @@ vi.mock('@lobehub/ui', () => ({
       ))}
     </div>
   ),
-  Icon: () => null,
   Skeleton: () => <div>loading</div>,
 }));
 
 vi.mock('@lobehub/ui/base-ui', () => ({
-  Select: () => <button />,
   Switch: () => <button />,
 }));
 
 vi.mock('@/routes/(main)/settings/features/SettingHeader', () => ({
   default: ({ title }: { title: string }) => <h1>{title}</h1>,
-}));
-
-vi.mock('@/services/electron/autoUpdate', () => ({
-  autoUpdateService: {
-    getUpdateChannel: vi.fn(() => new Promise(() => {})),
-    setUpdateChannel: vi.fn(),
-  },
 }));
 
 const createWrapper = () => {
@@ -88,70 +79,50 @@ const createWrapper = () => {
 
 const initialUserStoreState = useUserStore.getState();
 
+const renderPage = () => {
+  useUserStore.setState({
+    isUserStateInit: true,
+    updateLab: vi.fn(),
+  });
+
+  return render(<Page />, { wrapper: createWrapper() });
+};
+
 afterEach(() => {
   cleanup();
   useUserStore.setState(initialUserStoreState, true);
 });
 
-describe('Advanced settings page', () => {
-  it('uses distinct group titles for tools and app updates', () => {
-    useUserStore.setState({
-      isUserStateInit: true,
-      setSettings: vi.fn(),
-      updateLab: vi.fn(),
-    });
+describe('Labs settings page', () => {
+  it('splits experiments into General and Desktop groups', () => {
+    renderPage();
 
-    render(<Page />, { wrapper: createWrapper() });
-
-    expect(screen.getByText('tab.advanced.toolsAndDiagnostics.title')).toBeDefined();
-    expect(screen.getByText('tab.advanced.appUpdates.title')).toBeDefined();
+    expect(screen.getByText('group.general')).toBeDefined();
+    // Desktop group only renders in the Electron shell (isDesktop mocked true).
+    expect(screen.getByText('group.desktop')).toBeDefined();
   });
 
   it('renders the message text selection actions lab toggle', () => {
-    useUserStore.setState({
-      isUserStateInit: true,
-      setSettings: vi.fn(),
-      updateLab: vi.fn(),
-    });
-
-    render(<Page />, { wrapper: createWrapper() });
+    renderPage();
 
     expect(screen.getByText('features.messageTextSelectionActions.title')).toBeDefined();
   });
 
   it('renders the OAuth Apps lab toggle', () => {
-    useUserStore.setState({
-      isUserStateInit: true,
-      setSettings: vi.fn(),
-      updateLab: vi.fn(),
-    });
-
-    render(<Page />, { wrapper: createWrapper() });
+    renderPage();
 
     expect(screen.getByText('features.oauthApps.title')).toBeDefined();
   });
 
-  it('does not render released task verify as a lab toggle', () => {
-    useUserStore.setState({
-      isUserStateInit: true,
-      setSettings: vi.fn(),
-      updateLab: vi.fn(),
-    });
-
-    render(<Page />, { wrapper: createWrapper() });
-
-    expect(screen.queryByText('features.taskVerify.title')).toBeNull();
-  });
-
   it('renders the topic acceptance (tray) lab toggle', () => {
-    useUserStore.setState({
-      isUserStateInit: true,
-      setSettings: vi.fn(),
-      updateLab: vi.fn(),
-    });
-
-    render(<Page />, { wrapper: createWrapper() });
+    renderPage();
 
     expect(screen.getByText('features.topicAcceptance.title')).toBeDefined();
+  });
+
+  it('does not render released task verify as a lab toggle', () => {
+    renderPage();
+
+    expect(screen.queryByText('features.taskVerify.title')).toBeNull();
   });
 });

--- a/src/routes/(main)/settings/labs/index.tsx
+++ b/src/routes/(main)/settings/labs/index.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import { isDesktop } from '@lobechat/const';
+import { type FormGroupItemType, type FormItemProps } from '@lobehub/ui';
+import { Form, Skeleton } from '@lobehub/ui';
+import { Switch } from '@lobehub/ui/base-ui';
+import { createStaticStyles } from 'antd-style';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import AsyncError from '@/components/AsyncError';
+import { FORM_STYLE } from '@/const/layoutTokens';
+import SettingHeader from '@/routes/(main)/settings/features/SettingHeader';
+import { useServerConfigStore } from '@/store/serverConfig';
+import { useUserStore } from '@/store/user';
+import { labPreferSelectors, preferenceSelectors } from '@/store/user/selectors';
+
+const styles = createStaticStyles(({ css }) => ({
+  labItem: css`
+    .ant-form-item-row {
+      align-items: center !important;
+    }
+  `,
+}));
+
+const Page = memo(() => {
+  const { t: tLabs } = useTranslation('labs');
+
+  const [
+    isPreferenceInit,
+    isUserStateInit,
+    isUserStateInitError,
+    refreshUserState,
+    enableAgentGraphConfig,
+    enableInputMarkdown,
+    enablePlatformAgent,
+    enableImessage,
+    enableClaudeCodeSdk,
+    enableMessageTextSelectionActions,
+    enableOAuthApps,
+    enableInAppBrowser,
+    enableArtifactDeployment,
+    enableBuiltinTerminal,
+    enableTopicAcceptance,
+    updateLab,
+  ] = useUserStore((s) => [
+    preferenceSelectors.isPreferenceInit(s),
+    s.isUserStateInit,
+    s.isUserStateInitError,
+    s.refreshUserState,
+    labPreferSelectors.enableAgentGraphConfig(s),
+    labPreferSelectors.enableInputMarkdown(s),
+    labPreferSelectors.enablePlatformAgent(s),
+    labPreferSelectors.enableImessage(s),
+    labPreferSelectors.enableClaudeCodeSdk(s),
+    labPreferSelectors.enableMessageTextSelectionActions(s),
+    labPreferSelectors.enableOAuthApps(s),
+    labPreferSelectors.enableInAppBrowser(s),
+    labPreferSelectors.enableArtifactDeployment(s),
+    labPreferSelectors.enableBuiltinTerminal(s),
+    labPreferSelectors.enableTopicAcceptance(s),
+    s.updateLab,
+  ]);
+
+  const hasGatewayUrl = useServerConfigStore((s) => !!s.serverConfig.agentGatewayUrl);
+
+  if (!isUserStateInit) {
+    // A failed user-state init must show error + Retry, not a permanent skeleton
+    if (isUserStateInitError)
+      return (
+        <AsyncError
+          error={isUserStateInitError}
+          variant={'block'}
+          onRetry={() => refreshUserState()}
+        />
+      );
+    return <Skeleton active paragraph={{ rows: 5 }} title={false} />;
+  }
+
+  const labItems: FormItemProps[] = [
+    {
+      children: (
+        <Switch
+          checked={enableAgentGraphConfig}
+          loading={!isPreferenceInit}
+          onChange={(checked: boolean) => updateLab({ enableAgentGraphConfig: checked })}
+        />
+      ),
+      className: styles.labItem,
+      desc: tLabs('features.agentGraphConfig.desc'),
+      label: tLabs('features.agentGraphConfig.title'),
+      minWidth: undefined,
+    } satisfies FormItemProps,
+    {
+      children: (
+        <Switch
+          checked={enableInputMarkdown}
+          loading={!isPreferenceInit}
+          onChange={(checked) => updateLab({ enableInputMarkdown: checked })}
+        />
+      ),
+      className: styles.labItem,
+      desc: tLabs('features.inputMarkdown.desc'),
+      label: tLabs('features.inputMarkdown.title'),
+      minWidth: undefined,
+    },
+    {
+      children: (
+        <Switch
+          checked={enableMessageTextSelectionActions}
+          loading={!isPreferenceInit}
+          onChange={(checked) => updateLab({ enableMessageTextSelectionActions: checked })}
+        />
+      ),
+      className: styles.labItem,
+      desc: tLabs('features.messageTextSelectionActions.desc'),
+      label: tLabs('features.messageTextSelectionActions.title'),
+      minWidth: undefined,
+    },
+    {
+      children: (
+        <Switch
+          checked={enableTopicAcceptance}
+          loading={!isPreferenceInit}
+          onChange={(checked) => updateLab({ enableTopicAcceptance: checked })}
+        />
+      ),
+      className: styles.labItem,
+      desc: tLabs('features.topicAcceptance.desc'),
+      label: tLabs('features.topicAcceptance.title'),
+      minWidth: undefined,
+    },
+    {
+      children: (
+        <Switch
+          checked={enableOAuthApps}
+          loading={!isPreferenceInit}
+          onChange={(checked) => updateLab({ enableOAuthApps: checked })}
+        />
+      ),
+      className: styles.labItem,
+      desc: tLabs('features.oauthApps.desc'),
+      label: tLabs('features.oauthApps.title'),
+      minWidth: undefined,
+    },
+    ...(isDesktop
+      ? [
+          {
+            children: (
+              <Switch
+                checked={enableImessage}
+                loading={!isPreferenceInit}
+                onChange={(checked: boolean) => updateLab({ enableImessage: checked })}
+              />
+            ),
+            className: styles.labItem,
+            desc: tLabs('features.imessage.desc'),
+            label: tLabs('features.imessage.title'),
+            minWidth: undefined,
+          } satisfies FormItemProps,
+          {
+            children: (
+              <Switch
+                checked={enableClaudeCodeSdk}
+                loading={!isPreferenceInit}
+                onChange={(checked: boolean) => updateLab({ enableClaudeCodeSdk: checked })}
+              />
+            ),
+            className: styles.labItem,
+            desc: tLabs('features.claudeCodeSdk.desc'),
+            label: tLabs('features.claudeCodeSdk.title'),
+            minWidth: undefined,
+          } satisfies FormItemProps,
+        ]
+      : []),
+    ...(hasGatewayUrl
+      ? [
+          {
+            children: (
+              <Switch
+                checked={enablePlatformAgent}
+                loading={!isPreferenceInit}
+                onChange={(checked: boolean) => updateLab({ enablePlatformAgent: checked })}
+              />
+            ),
+            className: styles.labItem,
+            desc: tLabs('features.platformAgent.desc'),
+            label: tLabs('features.platformAgent.title'),
+            minWidth: undefined,
+          } satisfies FormItemProps,
+        ]
+      : []),
+    // The in-app browser pages are main-process WebContentsViews — desktop only.
+    ...(isDesktop
+      ? [
+          {
+            children: (
+              <Switch
+                checked={enableInAppBrowser}
+                loading={!isPreferenceInit}
+                onChange={(checked: boolean) => updateLab({ enableInAppBrowser: checked })}
+              />
+            ),
+            className: styles.labItem,
+            desc: tLabs('features.inAppBrowser.desc'),
+            label: tLabs('features.inAppBrowser.title'),
+            minWidth: undefined,
+          } satisfies FormItemProps,
+          // The terminal runs PTY sessions in the Electron main process — desktop only.
+          {
+            children: (
+              <Switch
+                checked={enableBuiltinTerminal}
+                loading={!isPreferenceInit}
+                onChange={(checked: boolean) => updateLab({ enableBuiltinTerminal: checked })}
+              />
+            ),
+            className: styles.labItem,
+            desc: tLabs('features.builtinTerminal.desc'),
+            label: tLabs('features.builtinTerminal.title'),
+            minWidth: undefined,
+          } satisfies FormItemProps,
+        ]
+      : []),
+    {
+      children: (
+        <Switch
+          checked={enableArtifactDeployment}
+          loading={!isPreferenceInit}
+          onChange={(checked: boolean) => updateLab({ enableArtifactDeployment: checked })}
+        />
+      ),
+      className: styles.labItem,
+      desc: tLabs('features.artifactDeployment.desc'),
+      label: tLabs('features.artifactDeployment.title'),
+      minWidth: undefined,
+    } satisfies FormItemProps,
+  ];
+
+  const labsGroup: FormGroupItemType = {
+    children: labItems,
+    title: tLabs('title'),
+  };
+
+  return (
+    <>
+      <SettingHeader title={tLabs('title')} />
+      <Form
+        collapsible={false}
+        items={[labsGroup]}
+        itemsType={'group'}
+        variant={'filled'}
+        {...FORM_STYLE}
+      />
+    </>
+  );
+});
+
+export default Page;

--- a/src/routes/(main)/settings/labs/index.tsx
+++ b/src/routes/(main)/settings/labs/index.tsx
@@ -77,7 +77,9 @@ const Page = memo(() => {
     return <Skeleton active paragraph={{ rows: 5 }} title={false} />;
   }
 
-  const labItems: FormItemProps[] = [
+  // Cross-surface experiments. Platform-specific ones (Electron main-process
+  // features) live in the Desktop group below; everything else is General.
+  const generalItems: FormItemProps[] = [
     {
       children: (
         <Switch
@@ -143,36 +145,6 @@ const Page = memo(() => {
       label: tLabs('features.oauthApps.title'),
       minWidth: undefined,
     },
-    ...(isDesktop
-      ? [
-          {
-            children: (
-              <Switch
-                checked={enableImessage}
-                loading={!isPreferenceInit}
-                onChange={(checked: boolean) => updateLab({ enableImessage: checked })}
-              />
-            ),
-            className: styles.labItem,
-            desc: tLabs('features.imessage.desc'),
-            label: tLabs('features.imessage.title'),
-            minWidth: undefined,
-          } satisfies FormItemProps,
-          {
-            children: (
-              <Switch
-                checked={enableClaudeCodeSdk}
-                loading={!isPreferenceInit}
-                onChange={(checked: boolean) => updateLab({ enableClaudeCodeSdk: checked })}
-              />
-            ),
-            className: styles.labItem,
-            desc: tLabs('features.claudeCodeSdk.desc'),
-            label: tLabs('features.claudeCodeSdk.title'),
-            minWidth: undefined,
-          } satisfies FormItemProps,
-        ]
-      : []),
     ...(hasGatewayUrl
       ? [
           {
@@ -186,38 +158,6 @@ const Page = memo(() => {
             className: styles.labItem,
             desc: tLabs('features.platformAgent.desc'),
             label: tLabs('features.platformAgent.title'),
-            minWidth: undefined,
-          } satisfies FormItemProps,
-        ]
-      : []),
-    // The in-app browser pages are main-process WebContentsViews — desktop only.
-    ...(isDesktop
-      ? [
-          {
-            children: (
-              <Switch
-                checked={enableInAppBrowser}
-                loading={!isPreferenceInit}
-                onChange={(checked: boolean) => updateLab({ enableInAppBrowser: checked })}
-              />
-            ),
-            className: styles.labItem,
-            desc: tLabs('features.inAppBrowser.desc'),
-            label: tLabs('features.inAppBrowser.title'),
-            minWidth: undefined,
-          } satisfies FormItemProps,
-          // The terminal runs PTY sessions in the Electron main process — desktop only.
-          {
-            children: (
-              <Switch
-                checked={enableBuiltinTerminal}
-                loading={!isPreferenceInit}
-                onChange={(checked: boolean) => updateLab({ enableBuiltinTerminal: checked })}
-              />
-            ),
-            className: styles.labItem,
-            desc: tLabs('features.builtinTerminal.desc'),
-            label: tLabs('features.builtinTerminal.title'),
             minWidth: undefined,
           } satisfies FormItemProps,
         ]
@@ -237,17 +177,86 @@ const Page = memo(() => {
     } satisfies FormItemProps,
   ];
 
-  const labsGroup: FormGroupItemType = {
-    children: labItems,
-    title: tLabs('title'),
-  };
+  // Desktop-only experiments: iMessage bridge, the Claude Code SDK runtime, and
+  // the in-app browser / built-in terminal (both main-process WebContentsViews /
+  // PTY sessions).
+  const desktopItems: FormItemProps[] = [
+    {
+      children: (
+        <Switch
+          checked={enableImessage}
+          loading={!isPreferenceInit}
+          onChange={(checked: boolean) => updateLab({ enableImessage: checked })}
+        />
+      ),
+      className: styles.labItem,
+      desc: tLabs('features.imessage.desc'),
+      label: tLabs('features.imessage.title'),
+      minWidth: undefined,
+    } satisfies FormItemProps,
+    {
+      children: (
+        <Switch
+          checked={enableClaudeCodeSdk}
+          loading={!isPreferenceInit}
+          onChange={(checked: boolean) => updateLab({ enableClaudeCodeSdk: checked })}
+        />
+      ),
+      className: styles.labItem,
+      desc: tLabs('features.claudeCodeSdk.desc'),
+      label: tLabs('features.claudeCodeSdk.title'),
+      minWidth: undefined,
+    },
+    {
+      children: (
+        <Switch
+          checked={enableInAppBrowser}
+          loading={!isPreferenceInit}
+          onChange={(checked: boolean) => updateLab({ enableInAppBrowser: checked })}
+        />
+      ),
+      className: styles.labItem,
+      desc: tLabs('features.inAppBrowser.desc'),
+      label: tLabs('features.inAppBrowser.title'),
+      minWidth: undefined,
+    },
+    {
+      children: (
+        <Switch
+          checked={enableBuiltinTerminal}
+          loading={!isPreferenceInit}
+          onChange={(checked: boolean) => updateLab({ enableBuiltinTerminal: checked })}
+        />
+      ),
+      className: styles.labItem,
+      desc: tLabs('features.builtinTerminal.desc'),
+      label: tLabs('features.builtinTerminal.title'),
+      minWidth: undefined,
+    },
+  ];
+
+  const items: FormGroupItemType[] = [
+    {
+      children: generalItems,
+      title: tLabs('group.general'),
+    },
+  ];
+
+  // The Desktop group only renders in the Electron shell — all its experiments
+  // are main-process features that do not exist on web.
+  if (isDesktop) {
+    items.push({
+      children: desktopItems,
+      title: tLabs('group.desktop'),
+    });
+  }
 
   return (
     <>
       <SettingHeader title={tLabs('title')} />
       <Form
         collapsible={false}
-        items={[labsGroup]}
+        items={items}
         itemsType={'group'}
         variant={'filled'}
         {...FORM_STYLE}

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -67,6 +67,7 @@ export enum SettingsTabs {
   Hotkey = 'hotkey',
   /** @deprecated Use ServiceModel instead */
   Image = 'image',
+  Labs = 'labs',
   LLM = 'llm',
   Memory = 'memory',
   Messenger = 'messenger',


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

Adds a dedicated **Developer** group to the settings sidebar that collects developer-facing surfaces, and pulls the Labs playground out of the Advanced page into its own tab.

**Sidebar**
- New `Developer` group (always visible), items in order: **Advanced** (first) → **API Key** (system-level, `isDevMode`) → **OAuth Apps** (lab flag) → **Labs**.
- These three (Advanced / system-level API Key / OAuth Apps) moved out of the `System` group; System keeps Proxy / System Tools / Storage / About. The Agent group's own `showApiKeyManage` API Key entry is untouched.

**Advanced page**
- The Labs section is extracted into a new standalone `labs` settings tab (`/settings/labs`). Advanced now only holds **Tools & Diagnostics** and **App Updates**.

**Wiring**
- Registered the `Labs` tab in the web (`componentMap.ts`) and desktop (`componentMap.desktop.ts`) component maps.
- Settings search: Labs is auto-indexed at tab level; removed the now-redundant `advanced-labs` anchor and split the labs/experiment keywords onto the new tab.
- Added `group.developer` i18n key (en-US / zh-CN hand-written, other locales via `bun run i18n`).

#### 🧪 How to Test

Open Settings → confirm a **Developer** group appears at the bottom of the sidebar with Advanced / API Key / OAuth Apps / Labs; the Labs page renders all lab toggles and Advanced no longer shows the Labs section.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Labs section lived inside Advanced; API Key / OAuth Apps / Advanced sat in the System group | New Developer group with Advanced · API Key · OAuth Apps · standalone Labs page |

🤖 Generated with [Claude Code](https://claude.com/claude-code)