### PR TITLE
✅ test(conversation-flow): harden the parse() characterization net

### DIFF
--- a/packages/conversation-flow/src/__tests__/edgeCases.test.ts
+++ b/packages/conversation-flow/src/__tests__/edgeCases.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { parse } from '../parse';
+import { inputs } from './fixtures';
+
+/**
+ * Characterization tests for flatten() paths the hand-written scenario fixtures
+ * never reached. Each case targets a specific uncovered branch in
+ * FlatListBuilder; assertions pin the observable shape so a traversal rewrite
+ * has to reproduce it.
+ */
+describe('flatList edge cases', () => {
+  it('should treat the first message as virtual root when every message has a parent', () => {
+    const result = parse(inputs.edgeCases.orphanThreadRoot);
+
+    expect(result.flatList.map((m) => m.id)).toEqual([
+      'msg-thread-user-1',
+      'msg-thread-assistant-1',
+      'msg-thread-user-2',
+      'msg-thread-assistant-2',
+    ]);
+  });
+
+  it('should fold a task-completion signal turn into the assistant group', () => {
+    const result = parse(inputs.edgeCases.taskCompletionSignal);
+
+    expect(result.flatList).toHaveLength(2);
+    expect(result.flatList[0].role).toBe('user');
+
+    const group = result.flatList[1] as any;
+    expect(group.role).toBe('assistantGroup');
+    expect(group.children.map((c: any) => c.id)).toEqual(['msg-assistant-1']);
+    // the post-task summary rides in its own field, rendered after the group body
+    expect(group.taskCompletions.map((c: any) => c.id)).toEqual(['msg-completion-1']);
+  });
+
+  it('should emit an assistant group sibling alongside aggregated tasks', () => {
+    const result = parse(inputs.edgeCases.tasksWithAssistantGroupSibling);
+
+    const roles = result.flatList.map((m) => m.role);
+    expect(roles).toEqual(['user', 'assistantGroup', 'tasks', 'assistantGroup']);
+    expect((result.flatList[2] as any).tasks).toHaveLength(2);
+    expect((result.flatList[3] as any).children.map((c: any) => c.id)).toEqual([
+      'msg-assistant-followup',
+    ]);
+  });
+
+  it('should surface a supervisor summary parented to a task message', () => {
+    const result = parse(inputs.edgeCases.taskChildSupervisorSummary);
+
+    const summary = result.flatList.find((m) => m.id === 'msg-supervisor-summary');
+    expect(summary).toBeDefined();
+    expect(summary!.role).toBe('supervisor');
+    expect(summary!.content).toBe('');
+    expect((summary as any).children).toHaveLength(1);
+    expect((summary as any).children[0].content).toContain('Both audits are in');
+  });
+
+  it('should drop branch metadata when the active assistant branch is not created yet', () => {
+    const result = parse(inputs.edgeCases.optimisticAssistantBranch);
+
+    expect(result.flatList.map((m) => m.id)).toEqual(['msg-user-1', 'msg-assistant-1']);
+    expect((result.flatList[1] as any).branches).toBeUndefined();
+  });
+});

--- a/packages/conversation-flow/src/__tests__/fixtures/index.ts
+++ b/packages/conversation-flow/src/__tests__/fixtures/index.ts
@@ -1,22 +1,7 @@
 import type { Message, ParseResult } from '../../types';
-// Input fixtures
-import { agentCouncil as agentCouncilInputs } from './inputs/agentCouncil';
-import { agentGroup as agentGroupInputs } from './inputs/agentGroup';
-import assistantChainWithFollowupInput from './inputs/assistant-chain-with-followup.json';
-import { assistantGroup as assistantGroupInputs } from './inputs/assistantGroup';
-import { branch as branchInputs } from './inputs/branch';
-import { compare as compareInputs } from './inputs/compare';
-import linearConversationInput from './inputs/linear-conversation.json';
-import { tasks as tasksInputs } from './inputs/tasks';
-// Output fixtures
-import { agentCouncil as agentCouncilOutputs } from './outputs/agentCouncil';
-import { agentGroup as agentGroupOutputs } from './outputs/agentGroup';
-import assistantChainWithFollowupOutput from './outputs/assistant-chain-with-followup.json';
-import { assistantGroup as assistantGroupOutputs } from './outputs/assistantGroup';
-import { branch as branchOutputs } from './outputs/branch';
-import { compare as compareOutputs } from './outputs/compare';
-import linearConversationOutput from './outputs/linear-conversation.json';
-import { tasks as tasksOutputs } from './outputs/tasks';
+
+export { inputs } from './inputs';
+export { outputs } from './outputs';
 
 /**
  * Serialized parse result type
@@ -26,31 +11,3 @@ export interface SerializedParseResult {
   flatList: ParseResult['flatList'];
   messageMap: Record<string, Message>;
 }
-
-/**
- * Test input fixtures - raw messages from database
- */
-export const inputs = {
-  agentCouncil: agentCouncilInputs,
-  agentGroup: agentGroupInputs,
-  assistantChainWithFollowup: assistantChainWithFollowupInput as Message[],
-  assistantGroup: assistantGroupInputs,
-  branch: branchInputs,
-  compare: compareInputs,
-  linearConversation: linearConversationInput as Message[],
-  tasks: tasksInputs,
-};
-
-/**
- * Test output fixtures - expected parse results
- */
-export const outputs = {
-  agentCouncil: agentCouncilOutputs,
-  agentGroup: agentGroupOutputs,
-  assistantChainWithFollowup: assistantChainWithFollowupOutput as unknown as SerializedParseResult,
-  assistantGroup: assistantGroupOutputs,
-  branch: branchOutputs,
-  compare: compareOutputs,
-  linearConversation: linearConversationOutput as unknown as SerializedParseResult,
-  tasks: tasksOutputs,
-};

--- a/packages/conversation-flow/src/__tests__/fixtures/inputs/compression/index.ts
+++ b/packages/conversation-flow/src/__tests__/fixtures/inputs/compression/index.ts
@@ -1,11 +1,12 @@
+import type { Message } from '../../../../types';
 import mixedGroups from './mixed-groups.json';
 import multipleCompressions from './multiple-compressions.json';
 import parallelGroup from './parallel-group.json';
 import simpleCompression from './simple-compression.json';
 
 export const compression = {
-  mixedGroups,
-  multipleCompressions,
-  parallelGroup,
-  simpleCompression,
+  mixedGroups: mixedGroups as unknown as Message[],
+  multipleCompressions: multipleCompressions as Message[],
+  parallelGroup: parallelGroup as unknown as Message[],
+  simpleCompression: simpleCompression as Message[],
 };

--- a/packages/conversation-flow/src/__tests__/fixtures/inputs/edgeCases/index.ts
+++ b/packages/conversation-flow/src/__tests__/fixtures/inputs/edgeCases/index.ts
@@ -1,0 +1,14 @@
+import type { Message } from '../../../../types';
+import optimisticAssistantBranch from './optimistic-assistant-branch.json';
+import orphanThreadRoot from './orphan-thread-root.json';
+import taskChildSupervisorSummary from './task-child-supervisor-summary.json';
+import taskCompletionSignal from './task-completion-signal.json';
+import tasksWithAssistantGroupSibling from './tasks-with-assistant-group-sibling.json';
+
+export const edgeCases = {
+  optimisticAssistantBranch: optimisticAssistantBranch as Message[],
+  orphanThreadRoot: orphanThreadRoot as Message[],
+  taskChildSupervisorSummary: taskChildSupervisorSummary as Message[],
+  taskCompletionSignal: taskCompletionSignal as Message[],
+  tasksWithAssistantGroupSibling: tasksWithAssistantGroupSibling as Message[],
+};

--- a/packages/conversation-flow/src/__tests__/fixtures/inputs/edgeCases/optimistic-assistant-branch.json
+++ b/packages/conversation-flow/src/__tests__/fixtures/inputs/edgeCases/optimistic-assistant-branch.json
@@ -1,0 +1,39 @@
+[
+  {
+    "id": "msg-user-1",
+    "role": "user",
+    "content": "What is the fastest way to seed the database?",
+    "parentId": null,
+    "createdAt": 1735526559000,
+    "updatedAt": 1735526559000
+  },
+  {
+    "id": "msg-assistant-1",
+    "role": "assistant",
+    "content": "Use the bulk loader rather than per-row inserts.",
+    "parentId": "msg-user-1",
+    "model": "gpt-4",
+    "provider": "openai",
+    "createdAt": 1735526560000,
+    "updatedAt": 1735526560000,
+    "metadata": {
+      "activeBranchIndex": 2
+    }
+  },
+  {
+    "id": "msg-user-followup-a",
+    "role": "user",
+    "content": "How large a batch should I use?",
+    "parentId": "msg-assistant-1",
+    "createdAt": 1735526561000,
+    "updatedAt": 1735526561000
+  },
+  {
+    "id": "msg-user-followup-b",
+    "role": "user",
+    "content": "Does that work on a read replica?",
+    "parentId": "msg-assistant-1",
+    "createdAt": 1735526562000,
+    "updatedAt": 1735526562000
+  }
+]

--- a/packages/conversation-flow/src/__tests__/fixtures/inputs/edgeCases/orphan-thread-root.json
+++ b/packages/conversation-flow/src/__tests__/fixtures/inputs/edgeCases/orphan-thread-root.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "msg-thread-user-1",
+    "role": "user",
+    "content": "Continue the discussion in this thread.",
+    "parentId": "msg-outside-window",
+    "threadId": "thd_orphan",
+    "createdAt": 1735526559000,
+    "updatedAt": 1735526559000
+  },
+  {
+    "id": "msg-thread-assistant-1",
+    "role": "assistant",
+    "content": "Picking up from where the parent conversation left off.",
+    "parentId": "msg-thread-user-1",
+    "threadId": "thd_orphan",
+    "model": "gpt-4",
+    "provider": "openai",
+    "createdAt": 1735526560000,
+    "updatedAt": 1735526560000
+  },
+  {
+    "id": "msg-thread-user-2",
+    "role": "user",
+    "content": "Good, keep going.",
+    "parentId": "msg-thread-assistant-1",
+    "threadId": "thd_orphan",
+    "createdAt": 1735526561000,
+    "updatedAt": 1735526561000
+  },
+  {
+    "id": "msg-thread-assistant-2",
+    "role": "assistant",
+    "content": "Here is the rest of the analysis.",
+    "parentId": "msg-thread-user-2",
+    "threadId": "thd_orphan",
+    "model": "gpt-4",
+    "provider": "openai",
+    "createdAt": 1735526562000,
+    "updatedAt": 1735526562000
+  }
+]

--- a/packages/conversation-flow/src/__tests__/fixtures/inputs/edgeCases/task-child-supervisor-summary.json
+++ b/packages/conversation-flow/src/__tests__/fixtures/inputs/edgeCases/task-child-supervisor-summary.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "msg-user-1",
+    "role": "user",
+    "content": "Dispatch the group and summarise when they are all done.",
+    "parentId": null,
+    "createdAt": 1735526559000,
+    "updatedAt": 1735526559000
+  },
+  {
+    "id": "msg-supervisor-1",
+    "role": "assistant",
+    "content": "Dispatching two agents.",
+    "parentId": "msg-user-1",
+    "agentId": "supervisor",
+    "model": "gpt-4",
+    "provider": "openai",
+    "createdAt": 1735526560000,
+    "updatedAt": 1735526560000,
+    "metadata": {
+      "isSupervisor": true,
+      "orchestrationRole": "supervisor"
+    },
+    "tools": [
+      {
+        "id": "call_group_1",
+        "type": "builtin",
+        "apiName": "callSubAgents",
+        "arguments": "{\"tasks\": [{\"description\": \"Frontend audit\"}, {\"description\": \"Backend audit\"}]}",
+        "identifier": "lobe-group-management",
+        "result_msg_id": "msg-tool-1"
+      }
+    ]
+  },
+  {
+    "id": "msg-tool-1",
+    "role": "tool",
+    "content": "Triggered 2 async tasks",
+    "parentId": "msg-supervisor-1",
+    "tool_call_id": "call_group_1",
+    "createdAt": 1735526561000,
+    "updatedAt": 1735526561000
+  },
+  {
+    "id": "msg-task-frontend",
+    "role": "task",
+    "content": "# Frontend audit\n\nNo blocking issues.",
+    "parentId": "msg-tool-1",
+    "agentId": "agent-frontend",
+    "createdAt": 1735526562000,
+    "updatedAt": 1735526570000,
+    "taskDetail": {
+      "duration": 8000,
+      "status": "completed",
+      "threadId": "thd_frontend",
+      "title": "Frontend audit",
+      "totalCost": 0.01,
+      "totalMessages": 6,
+      "totalTokens": 24000
+    }
+  },
+  {
+    "id": "msg-task-backend",
+    "role": "task",
+    "content": "# Backend audit\n\nTwo slow queries found.",
+    "parentId": "msg-tool-1",
+    "agentId": "agent-backend",
+    "createdAt": 1735526563000,
+    "updatedAt": 1735526571000,
+    "taskDetail": {
+      "duration": 9000,
+      "status": "completed",
+      "threadId": "thd_backend",
+      "title": "Backend audit",
+      "totalCost": 0.012,
+      "totalMessages": 7,
+      "totalTokens": 26000
+    }
+  },
+  {
+    "id": "msg-supervisor-summary",
+    "role": "assistant",
+    "content": "Both audits are in — the backend needs query work, the frontend is clear.",
+    "parentId": "msg-task-backend",
+    "agentId": "supervisor",
+    "model": "gpt-4",
+    "provider": "openai",
+    "createdAt": 1735526580000,
+    "updatedAt": 1735526580000,
+    "metadata": {
+      "isSupervisor": true,
+      "orchestrationRole": "supervisor"
+    }
+  }
+]

--- a/packages/conversation-flow/src/__tests__/fixtures/inputs/edgeCases/task-completion-signal.json
+++ b/packages/conversation-flow/src/__tests__/fixtures/inputs/edgeCases/task-completion-signal.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "msg-user-1",
+    "role": "user",
+    "content": "Kick off the long-running migration and tell me when it lands.",
+    "parentId": null,
+    "createdAt": 1735526559000,
+    "updatedAt": 1735526559000
+  },
+  {
+    "id": "msg-assistant-1",
+    "role": "assistant",
+    "content": "Starting the migration now.",
+    "parentId": "msg-user-1",
+    "model": "gpt-4",
+    "provider": "openai",
+    "createdAt": 1735526560000,
+    "updatedAt": 1735526560000,
+    "tools": [
+      {
+        "id": "call_migrate_1",
+        "type": "builtin",
+        "apiName": "runMigration",
+        "arguments": "{\"target\": \"postgres\"}",
+        "identifier": "lobe-monitor",
+        "result_msg_id": "msg-tool-1"
+      }
+    ]
+  },
+  {
+    "id": "msg-tool-1",
+    "role": "tool",
+    "content": "Migration started, running in background.",
+    "parentId": "msg-assistant-1",
+    "tool_call_id": "call_migrate_1",
+    "createdAt": 1735526561000,
+    "updatedAt": 1735526561000
+  },
+  {
+    "id": "msg-completion-1",
+    "role": "assistant",
+    "content": "The migration finished successfully — 14 tables moved.",
+    "parentId": "msg-tool-1",
+    "model": "gpt-4",
+    "provider": "openai",
+    "createdAt": 1735526562000,
+    "updatedAt": 1735526562000,
+    "metadata": {
+      "signal": {
+        "sequence": 1,
+        "sourceToolCallId": "call_migrate_1",
+        "sourceToolName": "runMigration",
+        "type": "task-completion"
+      }
+    }
+  }
+]

--- a/packages/conversation-flow/src/__tests__/fixtures/inputs/edgeCases/tasks-with-assistant-group-sibling.json
+++ b/packages/conversation-flow/src/__tests__/fixtures/inputs/edgeCases/tasks-with-assistant-group-sibling.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "msg-user-1",
+    "role": "user",
+    "content": "Run two research tasks, then look up the changelog.",
+    "parentId": null,
+    "createdAt": 1735526559000,
+    "updatedAt": 1735526559000
+  },
+  {
+    "id": "msg-assistant-1",
+    "role": "assistant",
+    "content": "Spawning two tasks.",
+    "parentId": "msg-user-1",
+    "model": "gpt-4",
+    "provider": "openai",
+    "createdAt": 1735526560000,
+    "updatedAt": 1735526560000,
+    "tools": [
+      {
+        "id": "call_exec_tasks_1",
+        "type": "builtin",
+        "apiName": "callSubAgents",
+        "arguments": "{\"tasks\": [{\"description\": \"Research A\"}, {\"description\": \"Research B\"}]}",
+        "identifier": "lobe-agent",
+        "result_msg_id": "msg-tool-1"
+      }
+    ]
+  },
+  {
+    "id": "msg-tool-1",
+    "role": "tool",
+    "content": "Triggered 2 async tasks",
+    "parentId": "msg-assistant-1",
+    "tool_call_id": "call_exec_tasks_1",
+    "createdAt": 1735526561000,
+    "updatedAt": 1735526561000
+  },
+  {
+    "id": "msg-task-a",
+    "role": "task",
+    "content": "# Research A\n\nFindings for A.",
+    "parentId": "msg-tool-1",
+    "createdAt": 1735526562000,
+    "updatedAt": 1735526570000,
+    "taskDetail": {
+      "duration": 8000,
+      "status": "completed",
+      "threadId": "thd_a",
+      "title": "Research A",
+      "totalCost": 0.01,
+      "totalMessages": 5,
+      "totalTokens": 20000
+    }
+  },
+  {
+    "id": "msg-task-b",
+    "role": "task",
+    "content": "# Research B\n\nFindings for B.",
+    "parentId": "msg-tool-1",
+    "createdAt": 1735526563000,
+    "updatedAt": 1735526571000,
+    "taskDetail": {
+      "duration": 8000,
+      "status": "completed",
+      "threadId": "thd_b",
+      "title": "Research B",
+      "totalCost": 0.01,
+      "totalMessages": 5,
+      "totalTokens": 20000
+    }
+  },
+  {
+    "id": "msg-assistant-followup",
+    "role": "assistant",
+    "content": "Both tasks are done — now checking the changelog.",
+    "parentId": "msg-tool-1",
+    "model": "gpt-4",
+    "provider": "openai",
+    "createdAt": 1735526580000,
+    "updatedAt": 1735526580000,
+    "tools": [
+      {
+        "id": "call_changelog_1",
+        "type": "default",
+        "apiName": "readChangelog",
+        "arguments": "{\"repo\": \"lobehub\"}",
+        "identifier": "lobe-web-browsing",
+        "result_msg_id": "msg-tool-changelog"
+      }
+    ]
+  },
+  {
+    "id": "msg-tool-changelog",
+    "role": "tool",
+    "content": "v1.2.0 — shipped the new parser.",
+    "parentId": "msg-assistant-followup",
+    "tool_call_id": "call_changelog_1",
+    "createdAt": 1735526581000,
+    "updatedAt": 1735526581000
+  }
+]

--- a/packages/conversation-flow/src/__tests__/fixtures/outputs/agentCouncil/simple.json
+++ b/packages/conversation-flow/src/__tests__/fixtures/outputs/agentCouncil/simple.json
@@ -5,17 +5,18 @@
       "type": "message"
     },
     {
-      "id": "msg-supervisor-1",
-      "type": "assistantGroup",
       "children": [
         {
           "id": "msg-supervisor-1",
           "type": "message",
           "tools": ["msg-broadcast-tool-1"]
         }
-      ]
+      ],
+      "id": "msg-supervisor-1",
+      "type": "assistantGroup"
     },
     {
+      "id": "agentCouncil-msg-broadcast-tool-1-msg-agent-backend-1-msg-agent-devops-1-msg-agent-architect-1",
       "members": [
         {
           "id": "msg-agent-backend-1",
@@ -30,7 +31,6 @@
           "type": "message"
         }
       ],
-      "id": "agentCouncil-msg-broadcast-tool-1-msg-agent-backend-1-msg-agent-devops-1-msg-agent-architect-1",
       "messageId": "msg-broadcast-tool-1",
       "type": "agentCouncil"
     }
@@ -54,8 +54,8 @@
       "updatedAt": 1704067201000,
       "children": [
         {
-          "id": "msg-supervisor-1",
           "content": "",
+          "id": "msg-supervisor-1",
           "tools": [
             {
               "id": "call_broadcast_1",
@@ -67,86 +67,80 @@
               "identifier": "lobe-group-management",
               "apiName": "broadcast",
               "result": {
-                "id": "msg-broadcast-tool-1",
-                "content": "Broadcasting to 3 agents..."
+                "content": "Broadcasting to 3 agents...",
+                "id": "msg-broadcast-tool-1"
               },
               "result_msg_id": "msg-broadcast-tool-1"
             }
           ]
+        },
+        {
+          "content": "",
+          "council": [
+            {
+              "id": "msg-agent-backend-1",
+              "role": "assistant",
+              "agentId": "agent-backend",
+              "content": "**From a Backend Developer's Perspective:**\n\n**Pros:**\n- Independent deployment of services\n- Technology flexibility per service\n- Better fault isolation\n- Easier to scale specific services\n\n**Cons:**\n- Increased complexity in service communication\n- Data consistency challenges\n- More complex debugging and monitoring\n- Network latency between services",
+              "parentId": "msg-broadcast-tool-1",
+              "model": "gpt-4",
+              "provider": "openai",
+              "createdAt": 1704067205000,
+              "updatedAt": 1704067205000,
+              "metadata": {
+                "totalInputTokens": 50,
+                "totalOutputTokens": 120,
+                "totalTokens": 170,
+                "tps": 45,
+                "ttft": 350,
+                "duration": 2667,
+                "latency": 3017
+              }
+            },
+            {
+              "id": "msg-agent-devops-1",
+              "role": "assistant",
+              "agentId": "agent-devops",
+              "content": "**From a DevOps Engineer's Perspective:**\n\n**Pros:**\n- CI/CD pipelines can be service-specific\n- Container orchestration fits naturally\n- Auto-scaling at service level\n- Blue-green deployments are easier\n\n**Cons:**\n- Complex infrastructure management\n- More services = more monitoring overhead\n- Configuration management complexity\n- Increased resource consumption (each service needs its own runtime)",
+              "parentId": "msg-broadcast-tool-1",
+              "model": "claude-3-5-sonnet-20241022",
+              "provider": "anthropic",
+              "createdAt": 1704067205500,
+              "updatedAt": 1704067205500,
+              "metadata": {
+                "totalInputTokens": 50,
+                "totalOutputTokens": 130,
+                "totalTokens": 180,
+                "tps": 52,
+                "ttft": 280,
+                "duration": 2500,
+                "latency": 2780
+              }
+            },
+            {
+              "id": "msg-agent-architect-1",
+              "role": "assistant",
+              "agentId": "agent-architect",
+              "content": "**From a Software Architect's Perspective:**\n\n**Pros:**\n- Clear service boundaries and ownership\n- Supports domain-driven design\n- Teams can work independently\n- Easier to understand individual services\n\n**Cons:**\n- Requires careful API versioning strategy\n- Cross-cutting concerns need special handling\n- Service discovery and load balancing complexity\n- Initial design requires significant upfront investment",
+              "parentId": "msg-broadcast-tool-1",
+              "model": "gpt-4",
+              "provider": "openai",
+              "createdAt": 1704067206000,
+              "updatedAt": 1704067206000,
+              "metadata": {
+                "totalInputTokens": 50,
+                "totalOutputTokens": 125,
+                "totalTokens": 175,
+                "tps": 48,
+                "ttft": 320,
+                "duration": 2604,
+                "latency": 2924
+              }
+            }
+          ],
+          "id": "council-msg-supervisor-1"
         }
       ]
-    },
-    {
-      "content": "",
-      "createdAt": 1704067205000,
-      "extra": {
-        "parentMessageId": "msg-broadcast-tool-1"
-      },
-      "id": "agentCouncil-msg-broadcast-tool-1-msg-agent-backend-1-msg-agent-devops-1-msg-agent-architect-1",
-      "members": [
-        {
-          "id": "msg-agent-backend-1",
-          "role": "assistant",
-          "agentId": "agent-backend",
-          "content": "**From a Backend Developer's Perspective:**\n\n**Pros:**\n- Independent deployment of services\n- Technology flexibility per service\n- Better fault isolation\n- Easier to scale specific services\n\n**Cons:**\n- Increased complexity in service communication\n- Data consistency challenges\n- More complex debugging and monitoring\n- Network latency between services",
-          "parentId": "msg-broadcast-tool-1",
-          "model": "gpt-4",
-          "provider": "openai",
-          "createdAt": 1704067205000,
-          "updatedAt": 1704067205000,
-          "metadata": {
-            "totalInputTokens": 50,
-            "totalOutputTokens": 120,
-            "totalTokens": 170,
-            "tps": 45,
-            "ttft": 350,
-            "duration": 2667,
-            "latency": 3017
-          }
-        },
-        {
-          "id": "msg-agent-devops-1",
-          "role": "assistant",
-          "agentId": "agent-devops",
-          "content": "**From a DevOps Engineer's Perspective:**\n\n**Pros:**\n- CI/CD pipelines can be service-specific\n- Container orchestration fits naturally\n- Auto-scaling at service level\n- Blue-green deployments are easier\n\n**Cons:**\n- Complex infrastructure management\n- More services = more monitoring overhead\n- Configuration management complexity\n- Increased resource consumption (each service needs its own runtime)",
-          "parentId": "msg-broadcast-tool-1",
-          "model": "claude-3-5-sonnet-20241022",
-          "provider": "anthropic",
-          "createdAt": 1704067205500,
-          "updatedAt": 1704067205500,
-          "metadata": {
-            "totalInputTokens": 50,
-            "totalOutputTokens": 130,
-            "totalTokens": 180,
-            "tps": 52,
-            "ttft": 280,
-            "duration": 2500,
-            "latency": 2780
-          }
-        },
-        {
-          "id": "msg-agent-architect-1",
-          "role": "assistant",
-          "agentId": "agent-architect",
-          "content": "**From a Software Architect's Perspective:**\n\n**Pros:**\n- Clear service boundaries and ownership\n- Supports domain-driven design\n- Teams can work independently\n- Easier to understand individual services\n\n**Cons:**\n- Requires careful API versioning strategy\n- Cross-cutting concerns need special handling\n- Service discovery and load balancing complexity\n- Initial design requires significant upfront investment",
-          "parentId": "msg-broadcast-tool-1",
-          "model": "gpt-4",
-          "provider": "openai",
-          "createdAt": 1704067206000,
-          "updatedAt": 1704067206000,
-          "metadata": {
-            "totalInputTokens": 50,
-            "totalOutputTokens": 125,
-            "totalTokens": 175,
-            "tps": 48,
-            "ttft": 320,
-            "duration": 2604,
-            "latency": 2924
-          }
-        }
-      ],
-      "role": "agentCouncil",
-      "updatedAt": 1704067206000
     }
   ],
   "messageMap": {

--- a/packages/conversation-flow/src/__tests__/fixtures/outputs/agentCouncil/with-supervisor-reply.json
+++ b/packages/conversation-flow/src/__tests__/fixtures/outputs/agentCouncil/with-supervisor-reply.json
@@ -5,17 +5,18 @@
       "type": "message"
     },
     {
-      "id": "msg-supervisor-1",
-      "type": "assistantGroup",
       "children": [
         {
           "id": "msg-supervisor-1",
           "type": "message",
           "tools": ["msg-broadcast-tool-1"]
         }
-      ]
+      ],
+      "id": "msg-supervisor-1",
+      "type": "assistantGroup"
     },
     {
+      "id": "agentCouncil-msg-broadcast-tool-1-msg-agent-backend-1-msg-agent-devops-1-msg-agent-architect-1",
       "members": [
         {
           "id": "msg-agent-backend-1",
@@ -30,7 +31,6 @@
           "type": "message"
         }
       ],
-      "id": "agentCouncil-msg-broadcast-tool-1-msg-agent-backend-1-msg-agent-devops-1-msg-agent-architect-1",
       "messageId": "msg-broadcast-tool-1",
       "type": "agentCouncil"
     },
@@ -56,17 +56,10 @@
       "parentId": "msg-user-1",
       "createdAt": 1704067201000,
       "updatedAt": 1704067201000,
-      "metadata": {
-        "isSupervisor": true,
-        "orchestrationRole": "supervisor"
-      },
       "children": [
         {
-          "id": "msg-supervisor-1",
           "content": "",
-          "metadata": {
-            "isSupervisor": true
-          },
+          "id": "msg-supervisor-1",
           "tools": [
             {
               "id": "call_broadcast_1",
@@ -78,59 +71,60 @@
               "identifier": "lobe-group-management",
               "apiName": "broadcast",
               "result": {
-                "id": "msg-broadcast-tool-1",
-                "content": "Broadcasting to 3 agents..."
+                "content": "Broadcasting to 3 agents...",
+                "id": "msg-broadcast-tool-1"
               },
               "result_msg_id": "msg-broadcast-tool-1"
             }
-          ]
-        }
-      ]
-    },
-    {
-      "content": "",
-      "createdAt": 1704067205000,
-      "extra": {
-        "parentMessageId": "msg-broadcast-tool-1"
-      },
-      "id": "agentCouncil-msg-broadcast-tool-1-msg-agent-backend-1-msg-agent-devops-1-msg-agent-architect-1",
-      "members": [
-        {
-          "id": "msg-agent-backend-1",
-          "role": "assistant",
-          "agentId": "agent-backend",
-          "content": "**From a Backend Developer's Perspective:**\n\n**Pros:**\n- Independent deployment\n- Technology flexibility\n\n**Cons:**\n- Service communication complexity\n- Data consistency challenges",
-          "parentId": "msg-broadcast-tool-1",
-          "model": "gpt-4",
-          "provider": "openai",
-          "createdAt": 1704067205000,
-          "updatedAt": 1704067205000
+          ],
+          "metadata": {
+            "isSupervisor": true
+          }
         },
         {
-          "id": "msg-agent-devops-1",
-          "role": "assistant",
-          "agentId": "agent-devops",
-          "content": "**From a DevOps Engineer's Perspective:**\n\n**Pros:**\n- CI/CD pipelines can be service-specific\n- Auto-scaling at service level\n\n**Cons:**\n- Complex infrastructure management\n- More monitoring overhead",
-          "parentId": "msg-broadcast-tool-1",
-          "model": "claude-3-5-sonnet-20241022",
-          "provider": "anthropic",
-          "createdAt": 1704067205500,
-          "updatedAt": 1704067205500
-        },
-        {
-          "id": "msg-agent-architect-1",
-          "role": "assistant",
-          "agentId": "agent-architect",
-          "content": "**From a Software Architect's Perspective:**\n\n**Pros:**\n- Clear service boundaries\n- Teams can work independently\n\n**Cons:**\n- API versioning complexity\n- Service discovery challenges",
-          "parentId": "msg-broadcast-tool-1",
-          "model": "gpt-4",
-          "provider": "openai",
-          "createdAt": 1704067206000,
-          "updatedAt": 1704067206000
+          "content": "",
+          "council": [
+            {
+              "id": "msg-agent-backend-1",
+              "role": "assistant",
+              "agentId": "agent-backend",
+              "content": "**From a Backend Developer's Perspective:**\n\n**Pros:**\n- Independent deployment\n- Technology flexibility\n\n**Cons:**\n- Service communication complexity\n- Data consistency challenges",
+              "parentId": "msg-broadcast-tool-1",
+              "model": "gpt-4",
+              "provider": "openai",
+              "createdAt": 1704067205000,
+              "updatedAt": 1704067205000
+            },
+            {
+              "id": "msg-agent-devops-1",
+              "role": "assistant",
+              "agentId": "agent-devops",
+              "content": "**From a DevOps Engineer's Perspective:**\n\n**Pros:**\n- CI/CD pipelines can be service-specific\n- Auto-scaling at service level\n\n**Cons:**\n- Complex infrastructure management\n- More monitoring overhead",
+              "parentId": "msg-broadcast-tool-1",
+              "model": "claude-3-5-sonnet-20241022",
+              "provider": "anthropic",
+              "createdAt": 1704067205500,
+              "updatedAt": 1704067205500
+            },
+            {
+              "id": "msg-agent-architect-1",
+              "role": "assistant",
+              "agentId": "agent-architect",
+              "content": "**From a Software Architect's Perspective:**\n\n**Pros:**\n- Clear service boundaries\n- Teams can work independently\n\n**Cons:**\n- API versioning complexity\n- Service discovery challenges",
+              "parentId": "msg-broadcast-tool-1",
+              "model": "gpt-4",
+              "provider": "openai",
+              "createdAt": 1704067206000,
+              "updatedAt": 1704067206000
+            }
+          ],
+          "id": "council-msg-supervisor-1"
         }
       ],
-      "role": "agentCouncil",
-      "updatedAt": 1704067206000
+      "metadata": {
+        "isSupervisor": true,
+        "orchestrationRole": "supervisor"
+      }
     },
     {
       "id": "msg-supervisor-summary",
@@ -142,19 +136,19 @@
       "provider": "openai",
       "createdAt": 1704067210000,
       "updatedAt": 1704067210000,
-      "metadata": {
-        "isSupervisor": true,
-        "orchestrationRole": "supervisor"
-      },
       "children": [
         {
-          "id": "msg-supervisor-summary",
           "content": "## Summary\n\nBased on the discussion from our team:\n\n**Key Pros:**\n- Independent deployment and scaling\n- Technology flexibility\n- Clear service boundaries\n\n**Key Cons:**\n- Increased complexity in communication and infrastructure\n- Data consistency and monitoring challenges\n\nI recommend starting with a modular monolith and gradually extracting services as needed.",
+          "id": "msg-supervisor-summary",
           "metadata": {
             "isSupervisor": true
           }
         }
-      ]
+      ],
+      "metadata": {
+        "isSupervisor": true,
+        "orchestrationRole": "supervisor"
+      }
     }
   ],
   "messageMap": {

--- a/packages/conversation-flow/src/__tests__/fixtures/outputs/agentGroup/index.ts
+++ b/packages/conversation-flow/src/__tests__/fixtures/outputs/agentGroup/index.ts
@@ -1,6 +1,10 @@
 import type { SerializedParseResult } from '../..';
 import speakDifferentAgent from './speak-different-agent.json';
+import supervisorAfterMultiTasks from './supervisor-after-multi-tasks.json';
+import supervisorContentOnly from './supervisor-content-only.json';
 
 export const agentGroup = {
   speakDifferentAgent: speakDifferentAgent as unknown as SerializedParseResult,
+  supervisorAfterMultiTasks: supervisorAfterMultiTasks as unknown as SerializedParseResult,
+  supervisorContentOnly: supervisorContentOnly as unknown as SerializedParseResult,
 };

--- a/packages/conversation-flow/src/__tests__/fixtures/outputs/agentGroup/supervisor-after-multi-tasks.json
+++ b/packages/conversation-flow/src/__tests__/fixtures/outputs/agentGroup/supervisor-after-multi-tasks.json
@@ -1,0 +1,257 @@
+{
+  "contextTree": [
+    {
+      "id": "msg-user-1",
+      "type": "message"
+    },
+    {
+      "children": [
+        {
+          "id": "msg-supervisor-1",
+          "type": "message",
+          "tools": ["msg-tool-1"]
+        }
+      ],
+      "id": "msg-supervisor-1",
+      "type": "assistantGroup"
+    },
+    {
+      "children": [
+        {
+          "id": "msg-task-1",
+          "type": "message"
+        },
+        {
+          "id": "msg-task-2",
+          "type": "message"
+        }
+      ],
+      "id": "tasks-msg-tool-1-msg-task-1-msg-task-2",
+      "messageId": "msg-tool-1",
+      "type": "tasks"
+    },
+    {
+      "id": "msg-supervisor-summary",
+      "type": "message"
+    }
+  ],
+  "flatList": [
+    {
+      "id": "msg-user-1",
+      "role": "user",
+      "content": "帮我调研下 clawdbot",
+      "parentId": null,
+      "createdAt": 1704067200000,
+      "updatedAt": 1704067200000
+    },
+    {
+      "id": "msg-supervisor-1",
+      "role": "supervisor",
+      "agentId": "supervisor",
+      "content": "",
+      "parentId": "msg-user-1",
+      "createdAt": 1704067201000,
+      "updatedAt": 1704067201000,
+      "children": [
+        {
+          "content": "我会安排团队成员进行调研。",
+          "id": "msg-supervisor-1",
+          "tools": [
+            {
+              "id": "call_tasks_1",
+              "type": "builtin",
+              "apiName": "executeAgentTasks",
+              "arguments": "{\"tasks\":[{\"agentId\":\"agent-1\",\"title\":\"任务1\"},{\"agentId\":\"agent-2\",\"title\":\"任务2\"}]}",
+              "identifier": "lobe-group-management",
+              "result": {
+                "content": "Triggered 2 tasks.",
+                "id": "msg-tool-1"
+              },
+              "result_msg_id": "msg-tool-1"
+            }
+          ],
+          "metadata": {
+            "isSupervisor": true
+          }
+        }
+      ],
+      "metadata": {
+        "isSupervisor": true,
+        "orchestrationRole": "supervisor"
+      }
+    },
+    {
+      "content": "",
+      "createdAt": 1704067203000,
+      "extra": {
+        "parentMessageId": "msg-tool-1"
+      },
+      "id": "groupTasks-msg-tool-1-msg-task-1-msg-task-2",
+      "role": "groupTasks",
+      "tasks": [
+        {
+          "id": "msg-task-1",
+          "role": "task",
+          "content": "调研结果1...",
+          "parentId": "msg-tool-1",
+          "agentId": "agent-1",
+          "createdAt": 1704067203000,
+          "updatedAt": 1704067203000,
+          "metadata": {
+            "taskTitle": "任务1"
+          },
+          "taskDetail": {
+            "status": "completed",
+            "threadId": "thd_xxx1",
+            "title": "任务1"
+          }
+        },
+        {
+          "id": "msg-task-2",
+          "role": "task",
+          "content": "调研结果2...",
+          "parentId": "msg-tool-1",
+          "agentId": "agent-2",
+          "createdAt": 1704067204000,
+          "updatedAt": 1704067204000,
+          "metadata": {
+            "taskTitle": "任务2"
+          },
+          "taskDetail": {
+            "status": "completed",
+            "threadId": "thd_xxx2",
+            "title": "任务2"
+          }
+        }
+      ],
+      "updatedAt": 1704067204000
+    },
+    {
+      "id": "msg-supervisor-summary",
+      "role": "supervisor",
+      "agentId": "supervisor",
+      "content": "",
+      "parentId": "msg-task-2",
+      "createdAt": 1704067210000,
+      "updatedAt": 1704067210000,
+      "model": "claude-sonnet-4",
+      "provider": "anthropic",
+      "children": [
+        {
+          "content": "调研完成！这是综合汇总报告...",
+          "id": "msg-supervisor-summary",
+          "performance": {
+            "tps": 78.99
+          },
+          "usage": {
+            "cost": 0.208
+          },
+          "metadata": {
+            "isSupervisor": true
+          }
+        }
+      ],
+      "performance": {
+        "tps": 78.99
+      },
+      "usage": {
+        "cost": 0.208
+      },
+      "metadata": {
+        "isSupervisor": true,
+        "orchestrationRole": "supervisor"
+      }
+    }
+  ],
+  "messageMap": {
+    "msg-user-1": {
+      "id": "msg-user-1",
+      "role": "user",
+      "content": "帮我调研下 clawdbot",
+      "parentId": null,
+      "createdAt": 1704067200000,
+      "updatedAt": 1704067200000
+    },
+    "msg-supervisor-1": {
+      "id": "msg-supervisor-1",
+      "role": "supervisor",
+      "agentId": "supervisor",
+      "content": "我会安排团队成员进行调研。",
+      "parentId": "msg-user-1",
+      "tools": [
+        {
+          "id": "call_tasks_1",
+          "type": "builtin",
+          "apiName": "executeAgentTasks",
+          "arguments": "{\"tasks\":[{\"agentId\":\"agent-1\",\"title\":\"任务1\"},{\"agentId\":\"agent-2\",\"title\":\"任务2\"}]}",
+          "identifier": "lobe-group-management"
+        }
+      ],
+      "createdAt": 1704067201000,
+      "updatedAt": 1704067201000,
+      "metadata": {
+        "isSupervisor": true
+      }
+    },
+    "msg-tool-1": {
+      "id": "msg-tool-1",
+      "role": "tool",
+      "content": "Triggered 2 tasks.",
+      "parentId": "msg-supervisor-1",
+      "tool_call_id": "call_tasks_1",
+      "createdAt": 1704067202000,
+      "updatedAt": 1704067202000
+    },
+    "msg-task-1": {
+      "id": "msg-task-1",
+      "role": "task",
+      "content": "调研结果1...",
+      "parentId": "msg-tool-1",
+      "agentId": "agent-1",
+      "createdAt": 1704067203000,
+      "updatedAt": 1704067203000,
+      "metadata": {
+        "taskTitle": "任务1"
+      },
+      "taskDetail": {
+        "status": "completed",
+        "threadId": "thd_xxx1",
+        "title": "任务1"
+      }
+    },
+    "msg-task-2": {
+      "id": "msg-task-2",
+      "role": "task",
+      "content": "调研结果2...",
+      "parentId": "msg-tool-1",
+      "agentId": "agent-2",
+      "createdAt": 1704067204000,
+      "updatedAt": 1704067204000,
+      "metadata": {
+        "taskTitle": "任务2"
+      },
+      "taskDetail": {
+        "status": "completed",
+        "threadId": "thd_xxx2",
+        "title": "任务2"
+      }
+    },
+    "msg-supervisor-summary": {
+      "id": "msg-supervisor-summary",
+      "role": "supervisor",
+      "agentId": "supervisor",
+      "content": "调研完成！这是综合汇总报告...",
+      "parentId": "msg-task-2",
+      "tools": null,
+      "createdAt": 1704067210000,
+      "updatedAt": 1704067210000,
+      "metadata": {
+        "isSupervisor": true,
+        "tps": 78.99,
+        "cost": 0.208
+      },
+      "model": "claude-sonnet-4",
+      "provider": "anthropic"
+    }
+  }
+}

--- a/packages/conversation-flow/src/__tests__/fixtures/outputs/agentGroup/supervisor-content-only.json
+++ b/packages/conversation-flow/src/__tests__/fixtures/outputs/agentGroup/supervisor-content-only.json
@@ -1,0 +1,204 @@
+{
+  "contextTree": [
+    {
+      "id": "msg-user-1",
+      "type": "message"
+    },
+    {
+      "children": [
+        {
+          "id": "msg-supervisor-1",
+          "type": "message",
+          "tools": ["msg-tool-1"]
+        }
+      ],
+      "id": "msg-supervisor-1",
+      "type": "assistantGroup"
+    },
+    {
+      "id": "msg-tool-1",
+      "type": "message"
+    },
+    {
+      "id": "msg-task-1",
+      "type": "message"
+    },
+    {
+      "id": "msg-supervisor-summary",
+      "type": "message"
+    }
+  ],
+  "flatList": [
+    {
+      "id": "msg-user-1",
+      "role": "user",
+      "content": "帮我调研下 clawdbot",
+      "parentId": null,
+      "createdAt": 1704067200000,
+      "updatedAt": 1704067200000
+    },
+    {
+      "id": "msg-supervisor-1",
+      "role": "supervisor",
+      "agentId": "supervisor",
+      "content": "",
+      "parentId": "msg-user-1",
+      "createdAt": 1704067201000,
+      "updatedAt": 1704067201000,
+      "children": [
+        {
+          "content": "我会安排团队成员进行调研。",
+          "id": "msg-supervisor-1",
+          "tools": [
+            {
+              "id": "call_tasks_1",
+              "type": "builtin",
+              "apiName": "executeAgentTasks",
+              "arguments": "{\"tasks\":[{\"agentId\":\"agent-1\",\"title\":\"调研任务\"}]}",
+              "identifier": "lobe-group-management",
+              "result": {
+                "content": "Triggered 1 task.",
+                "id": "msg-tool-1"
+              },
+              "result_msg_id": "msg-tool-1"
+            }
+          ],
+          "metadata": {
+            "isSupervisor": true
+          }
+        }
+      ],
+      "metadata": {
+        "isSupervisor": true,
+        "orchestrationRole": "supervisor"
+      }
+    },
+    {
+      "id": "msg-task-1",
+      "role": "task",
+      "content": "调研结果内容...",
+      "parentId": "msg-tool-1",
+      "agentId": "agent-1",
+      "createdAt": 1704067203000,
+      "updatedAt": 1704067203000,
+      "metadata": {
+        "taskTitle": "调研任务"
+      },
+      "taskDetail": {
+        "status": "completed",
+        "threadId": "thd_xxx",
+        "title": "调研任务"
+      }
+    },
+    {
+      "id": "msg-supervisor-summary",
+      "role": "supervisor",
+      "agentId": "supervisor",
+      "content": "",
+      "parentId": "msg-task-1",
+      "createdAt": 1704067210000,
+      "updatedAt": 1704067210000,
+      "model": "claude-sonnet-4",
+      "provider": "anthropic",
+      "children": [
+        {
+          "content": "调研完成！这是综合汇总报告...",
+          "id": "msg-supervisor-summary",
+          "performance": {
+            "tps": 78.99
+          },
+          "usage": {
+            "cost": 0.208
+          },
+          "metadata": {
+            "isSupervisor": true
+          }
+        }
+      ],
+      "performance": {
+        "tps": 78.99
+      },
+      "usage": {
+        "cost": 0.208
+      },
+      "metadata": {
+        "isSupervisor": true,
+        "orchestrationRole": "supervisor"
+      }
+    }
+  ],
+  "messageMap": {
+    "msg-user-1": {
+      "id": "msg-user-1",
+      "role": "user",
+      "content": "帮我调研下 clawdbot",
+      "parentId": null,
+      "createdAt": 1704067200000,
+      "updatedAt": 1704067200000
+    },
+    "msg-supervisor-1": {
+      "id": "msg-supervisor-1",
+      "role": "supervisor",
+      "agentId": "supervisor",
+      "content": "我会安排团队成员进行调研。",
+      "parentId": "msg-user-1",
+      "tools": [
+        {
+          "id": "call_tasks_1",
+          "type": "builtin",
+          "apiName": "executeAgentTasks",
+          "arguments": "{\"tasks\":[{\"agentId\":\"agent-1\",\"title\":\"调研任务\"}]}",
+          "identifier": "lobe-group-management"
+        }
+      ],
+      "createdAt": 1704067201000,
+      "updatedAt": 1704067201000,
+      "metadata": {
+        "isSupervisor": true
+      }
+    },
+    "msg-tool-1": {
+      "id": "msg-tool-1",
+      "role": "tool",
+      "content": "Triggered 1 task.",
+      "parentId": "msg-supervisor-1",
+      "tool_call_id": "call_tasks_1",
+      "createdAt": 1704067202000,
+      "updatedAt": 1704067202000
+    },
+    "msg-task-1": {
+      "id": "msg-task-1",
+      "role": "task",
+      "content": "调研结果内容...",
+      "parentId": "msg-tool-1",
+      "agentId": "agent-1",
+      "createdAt": 1704067203000,
+      "updatedAt": 1704067203000,
+      "metadata": {
+        "taskTitle": "调研任务"
+      },
+      "taskDetail": {
+        "status": "completed",
+        "threadId": "thd_xxx",
+        "title": "调研任务"
+      }
+    },
+    "msg-supervisor-summary": {
+      "id": "msg-supervisor-summary",
+      "role": "supervisor",
+      "agentId": "supervisor",
+      "content": "调研完成！这是综合汇总报告...",
+      "parentId": "msg-task-1",
+      "tools": null,
+      "createdAt": 1704067210000,
+      "updatedAt": 1704067210000,
+      "metadata": {
+        "isSupervisor": true,
+        "tps": 78.99,
+        "cost": 0.208
+      },
+      "model": "claude-sonnet-4",
+      "provider": "anthropic"
+    }
+  }
+}

--- a/packages/conversation-flow/src/__tests__/fixtures/outputs/compression/index.ts
+++ b/packages/conversation-flow/src/__tests__/fixtures/outputs/compression/index.ts
@@ -1,0 +1,12 @@
+import type { SerializedParseResult } from '../..';
+import mixedGroups from './mixed-groups.json';
+import multipleCompressions from './multiple-compressions.json';
+import parallelGroup from './parallel-group.json';
+import simpleCompression from './simple-compression.json';
+
+export const compression = {
+  mixedGroups: mixedGroups as unknown as SerializedParseResult,
+  multipleCompressions: multipleCompressions as unknown as SerializedParseResult,
+  parallelGroup: parallelGroup as unknown as SerializedParseResult,
+  simpleCompression: simpleCompression as unknown as SerializedParseResult,
+};

--- a/packages/conversation-flow/src/__tests__/fixtures/outputs/compression/mixed-groups.json
+++ b/packages/conversation-flow/src/__tests__/fixtures/outputs/compression/mixed-groups.json
@@ -1,0 +1,184 @@
+{
+  "contextTree": [
+    {
+      "id": "comp-group-1",
+      "type": "message"
+    },
+    {
+      "id": "msg-compare-trigger",
+      "type": "message"
+    },
+    {
+      "id": "parallel-group-state",
+      "type": "message"
+    },
+    {
+      "id": "msg-decision",
+      "type": "message"
+    },
+    {
+      "id": "msg-implementation",
+      "type": "message"
+    }
+  ],
+  "flatList": [
+    {
+      "id": "comp-group-1",
+      "role": "compressedGroup",
+      "content": "Summary: Initial project discussion about building a chat application.",
+      "parentId": null,
+      "createdAt": 1704060000000,
+      "updatedAt": 1704060000000,
+      "meta": {},
+      "pinnedMessages": [
+        {
+          "id": "pinned-architecture",
+          "role": "assistant",
+          "content": "Key architecture decision: React + tRPC + PostgreSQL",
+          "createdAt": "2024-01-01T08:00:00.000Z",
+          "model": "gpt-4",
+          "provider": "openai"
+        }
+      ]
+    },
+    {
+      "id": "msg-compare-trigger",
+      "role": "user",
+      "content": "Which state management should I use: Redux, Zustand, or Jotai?",
+      "parentId": null,
+      "createdAt": 1704067200000,
+      "updatedAt": 1704067200000,
+      "meta": {}
+    },
+    {
+      "id": "parallel-group-state",
+      "role": "compareGroup",
+      "content": null,
+      "parentId": null,
+      "createdAt": 1704067205000,
+      "updatedAt": 1704067205000,
+      "meta": {},
+      "children": [
+        {
+          "id": "resp-redux",
+          "role": "assistant",
+          "content": "Redux: Best for large-scale apps with complex state logic...",
+          "createdAt": "2024-01-01T10:00:05.000Z",
+          "model": "gpt-4",
+          "provider": "openai"
+        },
+        {
+          "id": "resp-zustand",
+          "role": "assistant",
+          "content": "Zustand: Lightweight and simple, great for most React apps...",
+          "createdAt": "2024-01-01T10:00:06.000Z",
+          "model": "claude-3-5-sonnet",
+          "provider": "anthropic"
+        }
+      ]
+    },
+    {
+      "id": "msg-decision",
+      "role": "user",
+      "content": "I'll go with Zustand then. Let's start implementation.",
+      "parentId": null,
+      "createdAt": 1704067210000,
+      "updatedAt": 1704067210000,
+      "meta": {}
+    },
+    {
+      "id": "msg-implementation",
+      "role": "assistant",
+      "content": "Great choice! Here's how to set up Zustand with TypeScript...",
+      "parentId": "msg-decision",
+      "createdAt": 1704067215000,
+      "updatedAt": 1704067215000,
+      "meta": {},
+      "metadata": {
+        "totalInputTokens": 300,
+        "totalOutputTokens": 450,
+        "totalTokens": 750
+      }
+    }
+  ],
+  "messageMap": {
+    "comp-group-1": {
+      "id": "comp-group-1",
+      "role": "compressedGroup",
+      "content": "Summary: Initial project discussion about building a chat application.",
+      "parentId": null,
+      "createdAt": 1704060000000,
+      "updatedAt": 1704060000000,
+      "meta": {},
+      "pinnedMessages": [
+        {
+          "id": "pinned-architecture",
+          "role": "assistant",
+          "content": "Key architecture decision: React + tRPC + PostgreSQL",
+          "createdAt": "2024-01-01T08:00:00.000Z",
+          "model": "gpt-4",
+          "provider": "openai"
+        }
+      ]
+    },
+    "msg-compare-trigger": {
+      "id": "msg-compare-trigger",
+      "role": "user",
+      "content": "Which state management should I use: Redux, Zustand, or Jotai?",
+      "parentId": null,
+      "createdAt": 1704067200000,
+      "updatedAt": 1704067200000,
+      "meta": {}
+    },
+    "parallel-group-state": {
+      "id": "parallel-group-state",
+      "role": "compareGroup",
+      "content": null,
+      "parentId": null,
+      "createdAt": 1704067205000,
+      "updatedAt": 1704067205000,
+      "meta": {},
+      "children": [
+        {
+          "id": "resp-redux",
+          "role": "assistant",
+          "content": "Redux: Best for large-scale apps with complex state logic...",
+          "createdAt": "2024-01-01T10:00:05.000Z",
+          "model": "gpt-4",
+          "provider": "openai"
+        },
+        {
+          "id": "resp-zustand",
+          "role": "assistant",
+          "content": "Zustand: Lightweight and simple, great for most React apps...",
+          "createdAt": "2024-01-01T10:00:06.000Z",
+          "model": "claude-3-5-sonnet",
+          "provider": "anthropic"
+        }
+      ]
+    },
+    "msg-decision": {
+      "id": "msg-decision",
+      "role": "user",
+      "content": "I'll go with Zustand then. Let's start implementation.",
+      "parentId": null,
+      "createdAt": 1704067210000,
+      "updatedAt": 1704067210000,
+      "meta": {}
+    },
+    "msg-implementation": {
+      "id": "msg-implementation",
+      "role": "assistant",
+      "content": "Great choice! Here's how to set up Zustand with TypeScript...",
+      "parentId": "msg-decision",
+      "createdAt": 1704067215000,
+      "updatedAt": 1704067215000,
+      "meta": {},
+      "metadata": {
+        "totalInputTokens": 300,
+        "totalOutputTokens": 450,
+        "totalTokens": 750
+      }
+    }
+  }
+}

--- a/packages/conversation-flow/src/__tests__/fixtures/outputs/compression/multiple-compressions.json
+++ b/packages/conversation-flow/src/__tests__/fixtures/outputs/compression/multiple-compressions.json
@@ -1,0 +1,162 @@
+{
+  "contextTree": [
+    {
+      "id": "comp-group-1",
+      "type": "message"
+    },
+    {
+      "id": "msg-middle-001",
+      "type": "message"
+    },
+    {
+      "id": "msg-middle-002",
+      "type": "message"
+    },
+    {
+      "id": "comp-group-2",
+      "type": "message"
+    },
+    {
+      "id": "msg-recent-001",
+      "type": "message"
+    },
+    {
+      "id": "msg-recent-002",
+      "type": "message"
+    }
+  ],
+  "flatList": [
+    {
+      "id": "comp-group-1",
+      "role": "compressedGroup",
+      "content": "Summary: Early conversation about project setup and initial requirements.",
+      "parentId": null,
+      "createdAt": 1704060000000,
+      "updatedAt": 1704060000000,
+      "meta": {},
+      "pinnedMessages": [
+        {
+          "id": "pinned-1-1",
+          "role": "assistant",
+          "content": "Key decision: Use TypeScript with strict mode",
+          "createdAt": "2024-01-01T08:00:00.000Z",
+          "model": "gpt-4",
+          "provider": "openai"
+        }
+      ]
+    },
+    {
+      "id": "msg-middle-001",
+      "role": "user",
+      "content": "Let's discuss the database schema",
+      "parentId": null,
+      "createdAt": 1704063600000,
+      "updatedAt": 1704063600000,
+      "meta": {}
+    },
+    {
+      "id": "msg-middle-002",
+      "role": "assistant",
+      "content": "Here's my suggested schema design...",
+      "parentId": "msg-middle-001",
+      "createdAt": 1704063605000,
+      "updatedAt": 1704063605000,
+      "meta": {}
+    },
+    {
+      "id": "comp-group-2",
+      "role": "compressedGroup",
+      "content": "Summary: Database schema discussions concluded with PostgreSQL + Drizzle ORM decision.",
+      "parentId": null,
+      "createdAt": 1704067200000,
+      "updatedAt": 1704067200000,
+      "meta": {},
+      "pinnedMessages": []
+    },
+    {
+      "id": "msg-recent-001",
+      "role": "user",
+      "content": "Now let's implement the API endpoints",
+      "parentId": null,
+      "createdAt": 1704070800000,
+      "updatedAt": 1704070800000,
+      "meta": {}
+    },
+    {
+      "id": "msg-recent-002",
+      "role": "assistant",
+      "content": "I'll create RESTful endpoints for CRUD operations...",
+      "parentId": "msg-recent-001",
+      "createdAt": 1704070805000,
+      "updatedAt": 1704070805000,
+      "meta": {}
+    }
+  ],
+  "messageMap": {
+    "comp-group-1": {
+      "id": "comp-group-1",
+      "role": "compressedGroup",
+      "content": "Summary: Early conversation about project setup and initial requirements.",
+      "parentId": null,
+      "createdAt": 1704060000000,
+      "updatedAt": 1704060000000,
+      "meta": {},
+      "pinnedMessages": [
+        {
+          "id": "pinned-1-1",
+          "role": "assistant",
+          "content": "Key decision: Use TypeScript with strict mode",
+          "createdAt": "2024-01-01T08:00:00.000Z",
+          "model": "gpt-4",
+          "provider": "openai"
+        }
+      ]
+    },
+    "msg-middle-001": {
+      "id": "msg-middle-001",
+      "role": "user",
+      "content": "Let's discuss the database schema",
+      "parentId": null,
+      "createdAt": 1704063600000,
+      "updatedAt": 1704063600000,
+      "meta": {}
+    },
+    "msg-middle-002": {
+      "id": "msg-middle-002",
+      "role": "assistant",
+      "content": "Here's my suggested schema design...",
+      "parentId": "msg-middle-001",
+      "createdAt": 1704063605000,
+      "updatedAt": 1704063605000,
+      "meta": {}
+    },
+    "comp-group-2": {
+      "id": "comp-group-2",
+      "role": "compressedGroup",
+      "content": "Summary: Database schema discussions concluded with PostgreSQL + Drizzle ORM decision.",
+      "parentId": null,
+      "createdAt": 1704067200000,
+      "updatedAt": 1704067200000,
+      "meta": {},
+      "pinnedMessages": []
+    },
+    "msg-recent-001": {
+      "id": "msg-recent-001",
+      "role": "user",
+      "content": "Now let's implement the API endpoints",
+      "parentId": null,
+      "createdAt": 1704070800000,
+      "updatedAt": 1704070800000,
+      "meta": {}
+    },
+    "msg-recent-002": {
+      "id": "msg-recent-002",
+      "role": "assistant",
+      "content": "I'll create RESTful endpoints for CRUD operations...",
+      "parentId": "msg-recent-001",
+      "createdAt": 1704070805000,
+      "updatedAt": 1704070805000,
+      "meta": {}
+    }
+  }
+}

--- a/packages/conversation-flow/src/__tests__/fixtures/outputs/compression/parallel-group.json
+++ b/packages/conversation-flow/src/__tests__/fixtures/outputs/compression/parallel-group.json
@@ -1,0 +1,110 @@
+{
+  "contextTree": [
+    {
+      "id": "msg-user-001",
+      "type": "message"
+    },
+    {
+      "id": "parallel-group-1",
+      "type": "message"
+    },
+    {
+      "id": "msg-user-002",
+      "type": "message"
+    }
+  ],
+  "flatList": [
+    {
+      "id": "msg-user-001",
+      "role": "user",
+      "content": "Compare REST vs GraphQL for my use case",
+      "parentId": null,
+      "createdAt": 1704067200000,
+      "updatedAt": 1704067200000,
+      "meta": {}
+    },
+    {
+      "id": "parallel-group-1",
+      "role": "compareGroup",
+      "content": null,
+      "parentId": null,
+      "createdAt": 1704067205000,
+      "updatedAt": 1704067205000,
+      "meta": {},
+      "children": [
+        {
+          "id": "parallel-resp-gpt4",
+          "role": "assistant",
+          "content": "From GPT-4's perspective: REST is simpler and well-suited for CRUD operations...",
+          "createdAt": "2024-01-01T10:00:05.000Z",
+          "model": "gpt-4",
+          "provider": "openai"
+        },
+        {
+          "id": "parallel-resp-claude",
+          "role": "assistant",
+          "content": "From Claude's perspective: GraphQL offers more flexibility with its query language...",
+          "createdAt": "2024-01-01T10:00:06.000Z",
+          "model": "claude-3-5-sonnet",
+          "provider": "anthropic"
+        }
+      ]
+    },
+    {
+      "id": "msg-user-002",
+      "role": "user",
+      "content": "Thanks for the comparison!",
+      "parentId": null,
+      "createdAt": 1704067210000,
+      "updatedAt": 1704067210000,
+      "meta": {}
+    }
+  ],
+  "messageMap": {
+    "msg-user-001": {
+      "id": "msg-user-001",
+      "role": "user",
+      "content": "Compare REST vs GraphQL for my use case",
+      "parentId": null,
+      "createdAt": 1704067200000,
+      "updatedAt": 1704067200000,
+      "meta": {}
+    },
+    "parallel-group-1": {
+      "id": "parallel-group-1",
+      "role": "compareGroup",
+      "content": null,
+      "parentId": null,
+      "createdAt": 1704067205000,
+      "updatedAt": 1704067205000,
+      "meta": {},
+      "children": [
+        {
+          "id": "parallel-resp-gpt4",
+          "role": "assistant",
+          "content": "From GPT-4's perspective: REST is simpler and well-suited for CRUD operations...",
+          "createdAt": "2024-01-01T10:00:05.000Z",
+          "model": "gpt-4",
+          "provider": "openai"
+        },
+        {
+          "id": "parallel-resp-claude",
+          "role": "assistant",
+          "content": "From Claude's perspective: GraphQL offers more flexibility with its query language...",
+          "createdAt": "2024-01-01T10:00:06.000Z",
+          "model": "claude-3-5-sonnet",
+          "provider": "anthropic"
+        }
+      ]
+    },
+    "msg-user-002": {
+      "id": "msg-user-002",
+      "role": "user",
+      "content": "Thanks for the comparison!",
+      "parentId": null,
+      "createdAt": 1704067210000,
+      "updatedAt": 1704067210000,
+      "meta": {}
+    }
+  }
+}

--- a/packages/conversation-flow/src/__tests__/fixtures/outputs/compression/simple-compression.json
+++ b/packages/conversation-flow/src/__tests__/fixtures/outputs/compression/simple-compression.json
@@ -1,0 +1,122 @@
+{
+  "contextTree": [
+    {
+      "id": "comp-group-1",
+      "type": "message"
+    },
+    {
+      "id": "msg-recent-001",
+      "type": "message"
+    },
+    {
+      "id": "msg-recent-002",
+      "type": "message"
+    }
+  ],
+  "flatList": [
+    {
+      "id": "comp-group-1",
+      "role": "compressedGroup",
+      "content": "Summary: User asked about prime numbers. Assistant provided implementation and test cases.",
+      "parentId": null,
+      "createdAt": 1704067205000,
+      "updatedAt": 1704067205000,
+      "meta": {},
+      "lastMessageId": "msg-compressed-last",
+      "pinnedMessages": [
+        {
+          "id": "pinned-msg-001",
+          "role": "assistant",
+          "content": "Here's a prime number checker function...",
+          "createdAt": "2024-01-01T10:01:00.000Z",
+          "model": "gpt-4",
+          "provider": "openai"
+        },
+        {
+          "id": "pinned-msg-002",
+          "role": "user",
+          "content": "Can you add documentation?",
+          "createdAt": "2024-01-01T10:02:00.000Z",
+          "model": null,
+          "provider": null
+        }
+      ]
+    },
+    {
+      "id": "msg-recent-001",
+      "role": "user",
+      "content": "Now let's optimize it further",
+      "parentId": null,
+      "createdAt": 1704067210000,
+      "updatedAt": 1704067210000,
+      "meta": {}
+    },
+    {
+      "id": "msg-recent-002",
+      "role": "assistant",
+      "content": "Sure! Here's an optimized version using the Sieve of Eratosthenes...",
+      "parentId": "msg-recent-001",
+      "createdAt": 1704067215000,
+      "updatedAt": 1704067215000,
+      "meta": {},
+      "metadata": {
+        "totalInputTokens": 200,
+        "totalOutputTokens": 150,
+        "totalTokens": 350
+      }
+    }
+  ],
+  "messageMap": {
+    "comp-group-1": {
+      "id": "comp-group-1",
+      "role": "compressedGroup",
+      "content": "Summary: User asked about prime numbers. Assistant provided implementation and test cases.",
+      "parentId": null,
+      "createdAt": 1704067205000,
+      "updatedAt": 1704067205000,
+      "meta": {},
+      "lastMessageId": "msg-compressed-last",
+      "pinnedMessages": [
+        {
+          "id": "pinned-msg-001",
+          "role": "assistant",
+          "content": "Here's a prime number checker function...",
+          "createdAt": "2024-01-01T10:01:00.000Z",
+          "model": "gpt-4",
+          "provider": "openai"
+        },
+        {
+          "id": "pinned-msg-002",
+          "role": "user",
+          "content": "Can you add documentation?",
+          "createdAt": "2024-01-01T10:02:00.000Z",
+          "model": null,
+          "provider": null
+        }
+      ]
+    },
+    "msg-recent-001": {
+      "id": "msg-recent-001",
+      "role": "user",
+      "content": "Now let's optimize it further",
+      "parentId": null,
+      "createdAt": 1704067210000,
+      "updatedAt": 1704067210000,
+      "meta": {}
+    },
+    "msg-recent-002": {
+      "id": "msg-recent-002",
+      "role": "assistant",
+      "content": "Sure! Here's an optimized version using the Sieve of Eratosthenes...",
+      "parentId": "msg-recent-001",
+      "createdAt": 1704067215000,
+      "updatedAt": 1704067215000,
+      "meta": {},
+      "metadata": {
+        "totalInputTokens": 200,
+        "totalOutputTokens": 150,
+        "totalTokens": 350
+      }
+    }
+  }
+}

--- a/packages/conversation-flow/src/__tests__/fixtures/outputs/index.ts
+++ b/packages/conversation-flow/src/__tests__/fixtures/outputs/index.ts
@@ -1,4 +1,4 @@
-import type { Message } from '../../../types';
+import type { SerializedParseResult } from '..';
 import { agentCouncil } from './agentCouncil';
 import { agentGroup } from './agentGroup';
 import assistantChainWithFollowup from './assistant-chain-with-followup.json';
@@ -6,19 +6,17 @@ import { assistantGroup } from './assistantGroup';
 import { branch } from './branch';
 import { compare } from './compare';
 import { compression } from './compression';
-import { edgeCases } from './edgeCases';
 import linearConversation from './linear-conversation.json';
 import { tasks } from './tasks';
 
-export const inputs = {
+export const outputs = {
   agentCouncil,
   agentGroup,
-  assistantChainWithFollowup: assistantChainWithFollowup as Message[],
+  assistantChainWithFollowup: assistantChainWithFollowup as unknown as SerializedParseResult,
   assistantGroup,
   branch,
   compare,
   compression,
-  edgeCases,
-  linearConversation: linearConversation as Message[],
+  linearConversation: linearConversation as unknown as SerializedParseResult,
   tasks,
 };

--- a/packages/conversation-flow/src/__tests__/fixtures/outputs/tasks/index.ts
+++ b/packages/conversation-flow/src/__tests__/fixtures/outputs/tasks/index.ts
@@ -1,10 +1,14 @@
 import type { SerializedParseResult } from '../../index';
+import multiTasksWithSummary from './multi-tasks-with-summary.json';
 import simple from './simple.json';
 import singleTaskWithToolChain from './single-task-with-tool-chain.json';
+import withAssistantGroup from './with-assistant-group.json';
 import withSummary from './with-summary.json';
 
 export const tasks = {
+  multiTasksWithSummary: multiTasksWithSummary as unknown as SerializedParseResult,
   simple: simple as unknown as SerializedParseResult,
   singleTaskWithToolChain: singleTaskWithToolChain as unknown as SerializedParseResult,
+  withAssistantGroup: withAssistantGroup as unknown as SerializedParseResult,
   withSummary: withSummary as unknown as SerializedParseResult,
 };

--- a/packages/conversation-flow/src/__tests__/fixtures/outputs/tasks/multi-tasks-with-summary.json
+++ b/packages/conversation-flow/src/__tests__/fixtures/outputs/tasks/multi-tasks-with-summary.json
@@ -1,0 +1,592 @@
+{
+  "contextTree": [
+    {
+      "id": "msg-user-1",
+      "type": "message"
+    },
+    {
+      "children": [
+        {
+          "id": "msg-assistant-1",
+          "type": "message",
+          "tools": ["msg-tool-1"]
+        }
+      ],
+      "id": "msg-assistant-1",
+      "type": "assistantGroup"
+    },
+    {
+      "children": [
+        {
+          "id": "msg-task-1",
+          "type": "message"
+        },
+        {
+          "id": "msg-task-2",
+          "type": "message"
+        },
+        {
+          "id": "msg-task-3",
+          "type": "message"
+        },
+        {
+          "id": "msg-task-4",
+          "type": "message"
+        },
+        {
+          "id": "msg-task-5",
+          "type": "message"
+        },
+        {
+          "id": "msg-task-6",
+          "type": "message"
+        },
+        {
+          "id": "msg-task-7",
+          "type": "message"
+        },
+        {
+          "id": "msg-task-8",
+          "type": "message"
+        },
+        {
+          "id": "msg-task-9",
+          "type": "message"
+        },
+        {
+          "id": "msg-task-10",
+          "type": "message"
+        }
+      ],
+      "id": "tasks-msg-tool-1-msg-task-1-msg-task-2-msg-task-3-msg-task-4-msg-task-5-msg-task-6-msg-task-7-msg-task-8-msg-task-9-msg-task-10",
+      "messageId": "msg-tool-1",
+      "type": "tasks"
+    },
+    {
+      "id": "msg-assistant-summary",
+      "type": "message"
+    }
+  ],
+  "flatList": [
+    {
+      "id": "msg-user-1",
+      "role": "user",
+      "content": "Process these files in 10 parallel tasks and give me a summary.",
+      "parentId": null,
+      "createdAt": 1735526559382,
+      "updatedAt": 1735526559382
+    },
+    {
+      "id": "msg-assistant-1",
+      "role": "assistantGroup",
+      "content": "",
+      "parentId": "msg-user-1",
+      "createdAt": 1735526560163,
+      "updatedAt": 1735526585550,
+      "model": "gpt-4",
+      "provider": "openai",
+      "children": [
+        {
+          "content": "I'll process these files in 10 parallel tasks.",
+          "id": "msg-assistant-1",
+          "tools": [
+            {
+              "id": "call_exec_tasks_1",
+              "type": "builtin",
+              "apiName": "callSubAgents",
+              "arguments": "{\"tasks\": [{\"description\": \"Task 1\"}, {\"description\": \"Task 2\"}, {\"description\": \"Task 3\"}, {\"description\": \"Task 4\"}, {\"description\": \"Task 5\"}, {\"description\": \"Task 6\"}, {\"description\": \"Task 7\"}, {\"description\": \"Task 8\"}, {\"description\": \"Task 9\"}, {\"description\": \"Task 10\"}]}",
+              "identifier": "lobe-agent",
+              "result": {
+                "content": "Triggered 10 async tasks",
+                "id": "msg-tool-1",
+                "state": {
+                  "type": "execSubAgents",
+                  "tasks": [
+                    {
+                      "description": "Task 1"
+                    },
+                    {
+                      "description": "Task 2"
+                    },
+                    {
+                      "description": "Task 3"
+                    },
+                    {
+                      "description": "Task 4"
+                    },
+                    {
+                      "description": "Task 5"
+                    },
+                    {
+                      "description": "Task 6"
+                    },
+                    {
+                      "description": "Task 7"
+                    },
+                    {
+                      "description": "Task 8"
+                    },
+                    {
+                      "description": "Task 9"
+                    },
+                    {
+                      "description": "Task 10"
+                    }
+                  ],
+                  "parentMessageId": "msg-tool-1"
+                }
+              },
+              "result_msg_id": "msg-tool-1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "content": "",
+      "createdAt": 1735526594643,
+      "extra": {
+        "parentMessageId": "msg-tool-1"
+      },
+      "id": "tasks-msg-tool-1-msg-task-1-msg-task-2-msg-task-3-msg-task-4-msg-task-5-msg-task-6-msg-task-7-msg-task-8-msg-task-9-msg-task-10",
+      "role": "tasks",
+      "tasks": [
+        {
+          "id": "msg-task-1",
+          "role": "task",
+          "content": "Task 1 completed with results...",
+          "parentId": "msg-tool-1",
+          "createdAt": 1735526594643,
+          "updatedAt": 1735526756262,
+          "taskDetail": {
+            "duration": 120000,
+            "status": "completed",
+            "threadId": "thd_task_1",
+            "title": "Task 1",
+            "totalCost": 0.015,
+            "totalMessages": 15,
+            "totalTokens": 100000
+          }
+        },
+        {
+          "id": "msg-task-2",
+          "role": "task",
+          "content": "Task 2 completed with results...",
+          "parentId": "msg-tool-1",
+          "createdAt": 1735526595000,
+          "updatedAt": 1735526757000,
+          "taskDetail": {
+            "duration": 121000,
+            "status": "completed",
+            "threadId": "thd_task_2",
+            "title": "Task 2",
+            "totalCost": 0.016,
+            "totalMessages": 16,
+            "totalTokens": 101000
+          }
+        },
+        {
+          "id": "msg-task-3",
+          "role": "task",
+          "content": "Task 3 completed with results...",
+          "parentId": "msg-tool-1",
+          "createdAt": 1735526596000,
+          "updatedAt": 1735526758000,
+          "taskDetail": {
+            "duration": 122000,
+            "status": "completed",
+            "threadId": "thd_task_3",
+            "title": "Task 3",
+            "totalCost": 0.017,
+            "totalMessages": 17,
+            "totalTokens": 102000
+          }
+        },
+        {
+          "id": "msg-task-4",
+          "role": "task",
+          "content": "Task 4 completed with results...",
+          "parentId": "msg-tool-1",
+          "createdAt": 1735526597000,
+          "updatedAt": 1735526759000,
+          "taskDetail": {
+            "duration": 123000,
+            "status": "completed",
+            "threadId": "thd_task_4",
+            "title": "Task 4",
+            "totalCost": 0.018,
+            "totalMessages": 18,
+            "totalTokens": 103000
+          }
+        },
+        {
+          "id": "msg-task-5",
+          "role": "task",
+          "content": "Task 5 completed with results...",
+          "parentId": "msg-tool-1",
+          "createdAt": 1735526598000,
+          "updatedAt": 1735526760000,
+          "taskDetail": {
+            "duration": 124000,
+            "status": "completed",
+            "threadId": "thd_task_5",
+            "title": "Task 5",
+            "totalCost": 0.019,
+            "totalMessages": 19,
+            "totalTokens": 104000
+          }
+        },
+        {
+          "id": "msg-task-6",
+          "role": "task",
+          "content": "Task 6 completed with results...",
+          "parentId": "msg-tool-1",
+          "createdAt": 1735526599000,
+          "updatedAt": 1735526761000,
+          "taskDetail": {
+            "duration": 125000,
+            "status": "completed",
+            "threadId": "thd_task_6",
+            "title": "Task 6",
+            "totalCost": 0.02,
+            "totalMessages": 20,
+            "totalTokens": 105000
+          }
+        },
+        {
+          "id": "msg-task-7",
+          "role": "task",
+          "content": "Task 7 completed with results...",
+          "parentId": "msg-tool-1",
+          "createdAt": 1735526600000,
+          "updatedAt": 1735526762000,
+          "taskDetail": {
+            "duration": 126000,
+            "status": "completed",
+            "threadId": "thd_task_7",
+            "title": "Task 7",
+            "totalCost": 0.021,
+            "totalMessages": 21,
+            "totalTokens": 106000
+          }
+        },
+        {
+          "id": "msg-task-8",
+          "role": "task",
+          "content": "Task 8 completed with results...",
+          "parentId": "msg-tool-1",
+          "createdAt": 1735526601000,
+          "updatedAt": 1735526763000,
+          "taskDetail": {
+            "duration": 127000,
+            "status": "completed",
+            "threadId": "thd_task_8",
+            "title": "Task 8",
+            "totalCost": 0.022,
+            "totalMessages": 22,
+            "totalTokens": 107000
+          }
+        },
+        {
+          "id": "msg-task-9",
+          "role": "task",
+          "content": "Task 9 completed with results...",
+          "parentId": "msg-tool-1",
+          "createdAt": 1735526602000,
+          "updatedAt": 1735526764000,
+          "taskDetail": {
+            "duration": 128000,
+            "status": "completed",
+            "threadId": "thd_task_9",
+            "title": "Task 9",
+            "totalCost": 0.023,
+            "totalMessages": 23,
+            "totalTokens": 108000
+          }
+        },
+        {
+          "id": "msg-task-10",
+          "role": "task",
+          "content": "Task 10 completed with results...",
+          "parentId": "msg-tool-1",
+          "createdAt": 1735526603000,
+          "updatedAt": 1735526765000,
+          "taskDetail": {
+            "duration": 129000,
+            "status": "completed",
+            "threadId": "thd_task_10",
+            "title": "Task 10",
+            "totalCost": 0.024,
+            "totalMessages": 24,
+            "totalTokens": 109000
+          }
+        }
+      ],
+      "updatedAt": 1735526765000
+    },
+    {
+      "id": "msg-assistant-summary",
+      "role": "assistant",
+      "content": "All 10 tasks completed successfully! Here's the comprehensive summary...",
+      "parentId": "msg-task-10",
+      "createdAt": 1735526810000,
+      "updatedAt": 1735526820000,
+      "model": "gpt-4",
+      "provider": "openai"
+    }
+  ],
+  "messageMap": {
+    "msg-user-1": {
+      "id": "msg-user-1",
+      "role": "user",
+      "content": "Process these files in 10 parallel tasks and give me a summary.",
+      "parentId": null,
+      "createdAt": 1735526559382,
+      "updatedAt": 1735526559382
+    },
+    "msg-assistant-1": {
+      "id": "msg-assistant-1",
+      "role": "assistant",
+      "content": "I'll process these files in 10 parallel tasks.",
+      "parentId": "msg-user-1",
+      "createdAt": 1735526560163,
+      "updatedAt": 1735526585550,
+      "model": "gpt-4",
+      "provider": "openai",
+      "tools": [
+        {
+          "id": "call_exec_tasks_1",
+          "type": "builtin",
+          "apiName": "callSubAgents",
+          "arguments": "{\"tasks\": [{\"description\": \"Task 1\"}, {\"description\": \"Task 2\"}, {\"description\": \"Task 3\"}, {\"description\": \"Task 4\"}, {\"description\": \"Task 5\"}, {\"description\": \"Task 6\"}, {\"description\": \"Task 7\"}, {\"description\": \"Task 8\"}, {\"description\": \"Task 9\"}, {\"description\": \"Task 10\"}]}",
+          "identifier": "lobe-agent"
+        }
+      ]
+    },
+    "msg-tool-1": {
+      "id": "msg-tool-1",
+      "role": "tool",
+      "content": "Triggered 10 async tasks",
+      "parentId": "msg-assistant-1",
+      "tool_call_id": "call_exec_tasks_1",
+      "createdAt": 1735526588116,
+      "updatedAt": 1735526591337,
+      "pluginState": {
+        "type": "execSubAgents",
+        "tasks": [
+          {
+            "description": "Task 1"
+          },
+          {
+            "description": "Task 2"
+          },
+          {
+            "description": "Task 3"
+          },
+          {
+            "description": "Task 4"
+          },
+          {
+            "description": "Task 5"
+          },
+          {
+            "description": "Task 6"
+          },
+          {
+            "description": "Task 7"
+          },
+          {
+            "description": "Task 8"
+          },
+          {
+            "description": "Task 9"
+          },
+          {
+            "description": "Task 10"
+          }
+        ],
+        "parentMessageId": "msg-tool-1"
+      }
+    },
+    "msg-task-1": {
+      "id": "msg-task-1",
+      "role": "task",
+      "content": "Task 1 completed with results...",
+      "parentId": "msg-tool-1",
+      "createdAt": 1735526594643,
+      "updatedAt": 1735526756262,
+      "taskDetail": {
+        "duration": 120000,
+        "status": "completed",
+        "threadId": "thd_task_1",
+        "title": "Task 1",
+        "totalCost": 0.015,
+        "totalMessages": 15,
+        "totalTokens": 100000
+      }
+    },
+    "msg-task-2": {
+      "id": "msg-task-2",
+      "role": "task",
+      "content": "Task 2 completed with results...",
+      "parentId": "msg-tool-1",
+      "createdAt": 1735526595000,
+      "updatedAt": 1735526757000,
+      "taskDetail": {
+        "duration": 121000,
+        "status": "completed",
+        "threadId": "thd_task_2",
+        "title": "Task 2",
+        "totalCost": 0.016,
+        "totalMessages": 16,
+        "totalTokens": 101000
+      }
+    },
+    "msg-task-3": {
+      "id": "msg-task-3",
+      "role": "task",
+      "content": "Task 3 completed with results...",
+      "parentId": "msg-tool-1",
+      "createdAt": 1735526596000,
+      "updatedAt": 1735526758000,
+      "taskDetail": {
+        "duration": 122000,
+        "status": "completed",
+        "threadId": "thd_task_3",
+        "title": "Task 3",
+        "totalCost": 0.017,
+        "totalMessages": 17,
+        "totalTokens": 102000
+      }
+    },
+    "msg-task-4": {
+      "id": "msg-task-4",
+      "role": "task",
+      "content": "Task 4 completed with results...",
+      "parentId": "msg-tool-1",
+      "createdAt": 1735526597000,
+      "updatedAt": 1735526759000,
+      "taskDetail": {
+        "duration": 123000,
+        "status": "completed",
+        "threadId": "thd_task_4",
+        "title": "Task 4",
+        "totalCost": 0.018,
+        "totalMessages": 18,
+        "totalTokens": 103000
+      }
+    },
+    "msg-task-5": {
+      "id": "msg-task-5",
+      "role": "task",
+      "content": "Task 5 completed with results...",
+      "parentId": "msg-tool-1",
+      "createdAt": 1735526598000,
+      "updatedAt": 1735526760000,
+      "taskDetail": {
+        "duration": 124000,
+        "status": "completed",
+        "threadId": "thd_task_5",
+        "title": "Task 5",
+        "totalCost": 0.019,
+        "totalMessages": 19,
+        "totalTokens": 104000
+      }
+    },
+    "msg-task-6": {
+      "id": "msg-task-6",
+      "role": "task",
+      "content": "Task 6 completed with results...",
+      "parentId": "msg-tool-1",
+      "createdAt": 1735526599000,
+      "updatedAt": 1735526761000,
+      "taskDetail": {
+        "duration": 125000,
+        "status": "completed",
+        "threadId": "thd_task_6",
+        "title": "Task 6",
+        "totalCost": 0.02,
+        "totalMessages": 20,
+        "totalTokens": 105000
+      }
+    },
+    "msg-task-7": {
+      "id": "msg-task-7",
+      "role": "task",
+      "content": "Task 7 completed with results...",
+      "parentId": "msg-tool-1",
+      "createdAt": 1735526600000,
+      "updatedAt": 1735526762000,
+      "taskDetail": {
+        "duration": 126000,
+        "status": "completed",
+        "threadId": "thd_task_7",
+        "title": "Task 7",
+        "totalCost": 0.021,
+        "totalMessages": 21,
+        "totalTokens": 106000
+      }
+    },
+    "msg-task-8": {
+      "id": "msg-task-8",
+      "role": "task",
+      "content": "Task 8 completed with results...",
+      "parentId": "msg-tool-1",
+      "createdAt": 1735526601000,
+      "updatedAt": 1735526763000,
+      "taskDetail": {
+        "duration": 127000,
+        "status": "completed",
+        "threadId": "thd_task_8",
+        "title": "Task 8",
+        "totalCost": 0.022,
+        "totalMessages": 22,
+        "totalTokens": 107000
+      }
+    },
+    "msg-task-9": {
+      "id": "msg-task-9",
+      "role": "task",
+      "content": "Task 9 completed with results...",
+      "parentId": "msg-tool-1",
+      "createdAt": 1735526602000,
+      "updatedAt": 1735526764000,
+      "taskDetail": {
+        "duration": 128000,
+        "status": "completed",
+        "threadId": "thd_task_9",
+        "title": "Task 9",
+        "totalCost": 0.023,
+        "totalMessages": 23,
+        "totalTokens": 108000
+      }
+    },
+    "msg-task-10": {
+      "id": "msg-task-10",
+      "role": "task",
+      "content": "Task 10 completed with results...",
+      "parentId": "msg-tool-1",
+      "createdAt": 1735526603000,
+      "updatedAt": 1735526765000,
+      "taskDetail": {
+        "duration": 129000,
+        "status": "completed",
+        "threadId": "thd_task_10",
+        "title": "Task 10",
+        "totalCost": 0.024,
+        "totalMessages": 24,
+        "totalTokens": 109000
+      }
+    },
+    "msg-assistant-summary": {
+      "id": "msg-assistant-summary",
+      "role": "assistant",
+      "content": "All 10 tasks completed successfully! Here's the comprehensive summary...",
+      "parentId": "msg-task-10",
+      "createdAt": 1735526810000,
+      "updatedAt": 1735526820000,
+      "model": "gpt-4",
+      "provider": "openai"
+    }
+  }
+}

--- a/packages/conversation-flow/src/__tests__/fixtures/outputs/tasks/with-assistant-group.json
+++ b/packages/conversation-flow/src/__tests__/fixtures/outputs/tasks/with-assistant-group.json
@@ -1,0 +1,392 @@
+{
+  "contextTree": [
+    {
+      "id": "msg-user-1",
+      "type": "message"
+    },
+    {
+      "children": [
+        {
+          "id": "msg-assistant-1",
+          "type": "message",
+          "tools": ["msg-tool-1"]
+        }
+      ],
+      "id": "msg-assistant-1",
+      "type": "assistantGroup"
+    },
+    {
+      "children": [
+        {
+          "id": "msg-task-llm",
+          "type": "message"
+        },
+        {
+          "id": "msg-task-agents",
+          "type": "message"
+        },
+        {
+          "id": "msg-task-rag",
+          "type": "message"
+        }
+      ],
+      "id": "tasks-msg-tool-1-msg-task-llm-msg-task-agents-msg-task-rag",
+      "messageId": "msg-tool-1",
+      "type": "tasks"
+    },
+    {
+      "children": [
+        {
+          "id": "msg-assistant-after-task",
+          "type": "message",
+          "tools": ["msg-tool-list-files"]
+        },
+        {
+          "id": "msg-assistant-final",
+          "type": "message"
+        }
+      ],
+      "id": "msg-assistant-after-task",
+      "type": "assistantGroup"
+    }
+  ],
+  "flatList": [
+    {
+      "id": "msg-user-1",
+      "role": "user",
+      "content": "Create three parallel tasks to research AI topics.",
+      "parentId": null,
+      "createdAt": 1735526559382,
+      "updatedAt": 1735526559382
+    },
+    {
+      "id": "msg-assistant-1",
+      "role": "assistantGroup",
+      "content": "",
+      "parentId": "msg-user-1",
+      "createdAt": 1735526560163,
+      "updatedAt": 1735526585550,
+      "model": "gpt-4",
+      "provider": "openai",
+      "children": [
+        {
+          "content": "Creating three parallel research tasks.",
+          "id": "msg-assistant-1",
+          "tools": [
+            {
+              "id": "call_exec_tasks_1",
+              "type": "builtin",
+              "apiName": "callSubAgents",
+              "arguments": "{\"tasks\": [{\"description\": \"Research LLM architectures\"}, {\"description\": \"Research AI agents\"}, {\"description\": \"Research RAG systems\"}]}",
+              "identifier": "lobe-agent",
+              "result": {
+                "content": "Triggered 3 async tasks",
+                "id": "msg-tool-1",
+                "state": {
+                  "type": "execSubAgents",
+                  "tasks": [
+                    {
+                      "description": "Research LLM architectures"
+                    },
+                    {
+                      "description": "Research AI agents"
+                    },
+                    {
+                      "description": "Research RAG systems"
+                    }
+                  ],
+                  "parentMessageId": "msg-tool-1"
+                }
+              },
+              "result_msg_id": "msg-tool-1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "content": "",
+      "createdAt": 1735526594643,
+      "extra": {
+        "parentMessageId": "msg-tool-1"
+      },
+      "id": "tasks-msg-tool-1-msg-task-llm-msg-task-agents-msg-task-rag",
+      "role": "tasks",
+      "tasks": [
+        {
+          "id": "msg-task-llm",
+          "role": "task",
+          "content": "# LLM Architectures\n\nTransformer-based models dominate...",
+          "parentId": "msg-tool-1",
+          "createdAt": 1735526594643,
+          "updatedAt": 1735526756262,
+          "taskDetail": {
+            "duration": 120000,
+            "status": "completed",
+            "threadId": "thd_llm",
+            "title": "Research LLM architectures",
+            "totalCost": 0.015,
+            "totalMessages": 15,
+            "totalTokens": 100000
+          }
+        },
+        {
+          "id": "msg-task-agents",
+          "role": "task",
+          "content": "# AI Agents\n\nAutonomous agents using LLMs...",
+          "parentId": "msg-tool-1",
+          "createdAt": 1735526595647,
+          "updatedAt": 1735526792430,
+          "taskDetail": {
+            "duration": 150000,
+            "status": "completed",
+            "threadId": "thd_agents",
+            "title": "Research AI agents",
+            "totalCost": 0.018,
+            "totalMessages": 20,
+            "totalTokens": 120000
+          }
+        },
+        {
+          "id": "msg-task-rag",
+          "role": "task",
+          "content": "# RAG Systems\n\nRetrieval Augmented Generation combines...",
+          "parentId": "msg-tool-1",
+          "createdAt": 1735526596000,
+          "updatedAt": 1735526800000,
+          "taskDetail": {
+            "duration": 130000,
+            "status": "completed",
+            "threadId": "thd_rag",
+            "title": "Research RAG systems",
+            "totalCost": 0.016,
+            "totalMessages": 18,
+            "totalTokens": 110000
+          }
+        }
+      ],
+      "updatedAt": 1735526800000
+    },
+    {
+      "id": "msg-assistant-after-task",
+      "role": "assistantGroup",
+      "content": "",
+      "parentId": "msg-task-rag",
+      "createdAt": 1735526810000,
+      "updatedAt": 1735526815000,
+      "agentId": "agent-main",
+      "model": "gpt-4",
+      "provider": "openai",
+      "children": [
+        {
+          "content": "All tasks completed. Let me check the analysis files created.",
+          "id": "msg-assistant-after-task",
+          "tools": [
+            {
+              "id": "call_list_files",
+              "type": "builtin",
+              "apiName": "listFiles",
+              "arguments": "{\"path\": \"/analysis\"}",
+              "identifier": "lobe-local-system",
+              "result": {
+                "content": "./ANALYSIS_1.md\n./ANALYSIS_2.md\n./ANALYSIS_3.md",
+                "id": "msg-tool-list-files",
+                "state": {
+                  "result": {
+                    "output": "./ANALYSIS_1.md\n./ANALYSIS_2.md\n./ANALYSIS_3.md",
+                    "success": true
+                  }
+                }
+              },
+              "result_msg_id": "msg-tool-list-files"
+            }
+          ],
+          "usage": {
+            "cost": 0.001,
+            "totalInputTokens": 100,
+            "totalOutputTokens": 50,
+            "totalTokens": 150
+          }
+        },
+        {
+          "content": "I found 3 analysis files. Let me summarize the findings for you.",
+          "id": "msg-assistant-final",
+          "usage": {
+            "cost": 0.002,
+            "totalInputTokens": 200,
+            "totalOutputTokens": 80,
+            "totalTokens": 280
+          }
+        }
+      ],
+      "usage": {
+        "totalInputTokens": 300,
+        "totalOutputTokens": 130,
+        "totalTokens": 430,
+        "cost": 0.003
+      }
+    }
+  ],
+  "messageMap": {
+    "msg-user-1": {
+      "id": "msg-user-1",
+      "role": "user",
+      "content": "Create three parallel tasks to research AI topics.",
+      "parentId": null,
+      "createdAt": 1735526559382,
+      "updatedAt": 1735526559382
+    },
+    "msg-assistant-1": {
+      "id": "msg-assistant-1",
+      "role": "assistant",
+      "content": "Creating three parallel research tasks.",
+      "parentId": "msg-user-1",
+      "createdAt": 1735526560163,
+      "updatedAt": 1735526585550,
+      "model": "gpt-4",
+      "provider": "openai",
+      "tools": [
+        {
+          "id": "call_exec_tasks_1",
+          "type": "builtin",
+          "apiName": "callSubAgents",
+          "arguments": "{\"tasks\": [{\"description\": \"Research LLM architectures\"}, {\"description\": \"Research AI agents\"}, {\"description\": \"Research RAG systems\"}]}",
+          "identifier": "lobe-agent"
+        }
+      ]
+    },
+    "msg-tool-1": {
+      "id": "msg-tool-1",
+      "role": "tool",
+      "content": "Triggered 3 async tasks",
+      "parentId": "msg-assistant-1",
+      "tool_call_id": "call_exec_tasks_1",
+      "createdAt": 1735526588116,
+      "updatedAt": 1735526591337,
+      "pluginState": {
+        "type": "execSubAgents",
+        "tasks": [
+          {
+            "description": "Research LLM architectures"
+          },
+          {
+            "description": "Research AI agents"
+          },
+          {
+            "description": "Research RAG systems"
+          }
+        ],
+        "parentMessageId": "msg-tool-1"
+      }
+    },
+    "msg-task-llm": {
+      "id": "msg-task-llm",
+      "role": "task",
+      "content": "# LLM Architectures\n\nTransformer-based models dominate...",
+      "parentId": "msg-tool-1",
+      "createdAt": 1735526594643,
+      "updatedAt": 1735526756262,
+      "taskDetail": {
+        "duration": 120000,
+        "status": "completed",
+        "threadId": "thd_llm",
+        "title": "Research LLM architectures",
+        "totalCost": 0.015,
+        "totalMessages": 15,
+        "totalTokens": 100000
+      }
+    },
+    "msg-task-agents": {
+      "id": "msg-task-agents",
+      "role": "task",
+      "content": "# AI Agents\n\nAutonomous agents using LLMs...",
+      "parentId": "msg-tool-1",
+      "createdAt": 1735526595647,
+      "updatedAt": 1735526792430,
+      "taskDetail": {
+        "duration": 150000,
+        "status": "completed",
+        "threadId": "thd_agents",
+        "title": "Research AI agents",
+        "totalCost": 0.018,
+        "totalMessages": 20,
+        "totalTokens": 120000
+      }
+    },
+    "msg-task-rag": {
+      "id": "msg-task-rag",
+      "role": "task",
+      "content": "# RAG Systems\n\nRetrieval Augmented Generation combines...",
+      "parentId": "msg-tool-1",
+      "createdAt": 1735526596000,
+      "updatedAt": 1735526800000,
+      "taskDetail": {
+        "duration": 130000,
+        "status": "completed",
+        "threadId": "thd_rag",
+        "title": "Research RAG systems",
+        "totalCost": 0.016,
+        "totalMessages": 18,
+        "totalTokens": 110000
+      }
+    },
+    "msg-assistant-after-task": {
+      "id": "msg-assistant-after-task",
+      "role": "assistant",
+      "content": "All tasks completed. Let me check the analysis files created.",
+      "parentId": "msg-task-rag",
+      "createdAt": 1735526810000,
+      "updatedAt": 1735526815000,
+      "agentId": "agent-main",
+      "model": "gpt-4",
+      "provider": "openai",
+      "tools": [
+        {
+          "id": "call_list_files",
+          "type": "builtin",
+          "apiName": "listFiles",
+          "arguments": "{\"path\": \"/analysis\"}",
+          "identifier": "lobe-local-system"
+        }
+      ],
+      "metadata": {
+        "totalInputTokens": 100,
+        "totalOutputTokens": 50,
+        "totalTokens": 150,
+        "cost": 0.001
+      }
+    },
+    "msg-tool-list-files": {
+      "id": "msg-tool-list-files",
+      "role": "tool",
+      "content": "./ANALYSIS_1.md\n./ANALYSIS_2.md\n./ANALYSIS_3.md",
+      "parentId": "msg-assistant-after-task",
+      "tool_call_id": "call_list_files",
+      "createdAt": 1735526816000,
+      "updatedAt": 1735526817000,
+      "pluginState": {
+        "result": {
+          "output": "./ANALYSIS_1.md\n./ANALYSIS_2.md\n./ANALYSIS_3.md",
+          "success": true
+        }
+      }
+    },
+    "msg-assistant-final": {
+      "id": "msg-assistant-final",
+      "role": "assistant",
+      "content": "I found 3 analysis files. Let me summarize the findings for you.",
+      "parentId": "msg-tool-list-files",
+      "createdAt": 1735526820000,
+      "updatedAt": 1735526825000,
+      "agentId": "agent-main",
+      "model": "gpt-4",
+      "provider": "openai",
+      "metadata": {
+        "totalInputTokens": 200,
+        "totalOutputTokens": 80,
+        "totalTokens": 280,
+        "cost": 0.002
+      }
+    }
+  }
+}

--- a/packages/conversation-flow/src/__tests__/parse.test.ts
+++ b/packages/conversation-flow/src/__tests__/parse.test.ts
@@ -435,6 +435,8 @@ describe('parse', () => {
         'msg-agent-devops-1',
         'msg-agent-architect-1',
       ]);
+
+      expect(serializeParseResult(result)).toEqual(outputs.agentCouncil.simple);
     });
 
     // Regression (server runtime tree): the server-side group orchestration parents
@@ -520,6 +522,8 @@ describe('parse', () => {
       // No separate agentCouncil message; the council is a block with 3 members.
       expect(result.flatList.some((m) => m.role === 'agentCouncil')).toBe(false);
       expect(findCouncilBlock(result)?.council).toHaveLength(3);
+
+      expect(serializeParseResult(result)).toEqual(outputs.agentCouncil.withSupervisorReply);
     });
 
     // Regression: the supervisor's post-council reply must surface no matter which council
@@ -793,6 +797,8 @@ describe('parse', () => {
       expect((supervisorSummary as any)?.children[0].content).toBe('调研完成！这是综合汇总报告...');
       // The top-level content should be empty
       expect(supervisorSummary?.content).toBe('');
+
+      expect(serializeParseResult(result)).toEqual(outputs.agentGroup.supervisorContentOnly);
     });
 
     it('should handle supervisor summary after multiple tasks (content folded into children)', () => {
@@ -815,6 +821,8 @@ describe('parse', () => {
       expect(supervisorSummary.content).toBe(''); // content should be empty
       expect((supervisorSummary as any).children).toHaveLength(1);
       expect((supervisorSummary as any).children[0].content).toBe('调研完成！这是综合汇总报告...');
+
+      expect(serializeParseResult(result)).toEqual(outputs.agentGroup.supervisorAfterMultiTasks);
     });
   });
 
@@ -881,6 +889,8 @@ describe('parse', () => {
       // 4. The summary message should be present and accessible
       expect(result.flatList[3].id).toBe('msg-assistant-summary');
       expect(result.flatList[3].content).toContain('All 10 tasks completed');
+
+      expect(serializeParseResult(result)).toEqual(outputs.tasks.multiTasksWithSummary);
     });
 
     it('should handle single sub-agent (callSubAgent) with tool chain after completion', () => {
@@ -909,10 +919,36 @@ describe('parse', () => {
       expect(lastGroup.children[0].tools).toBeDefined();
       expect(lastGroup.children[0].tools[0].result_msg_id).toBe('msg-tool-list-files');
       expect(lastGroup.children[1].id).toBe('msg-assistant-final');
+
+      expect(serializeParseResult(result)).toEqual(outputs.tasks.withAssistantGroup);
     });
   });
 
   describe('Compression', () => {
+    it('should parse a simple compressedGroup with follow-up turn', () => {
+      const result = parse(inputs.compression.simpleCompression);
+
+      expect(serializeParseResult(result)).toEqual(outputs.compression.simpleCompression);
+    });
+
+    it('should parse multiple compressedGroups in one conversation', () => {
+      const result = parse(inputs.compression.multipleCompressions);
+
+      expect(serializeParseResult(result)).toEqual(outputs.compression.multipleCompressions);
+    });
+
+    it('should parse a standalone parallel compareGroup', () => {
+      const result = parse(inputs.compression.parallelGroup);
+
+      expect(serializeParseResult(result)).toEqual(outputs.compression.parallelGroup);
+    });
+
+    it('should parse compressedGroup and compareGroup mixed in one conversation', () => {
+      const result = parse(inputs.compression.mixedGroups);
+
+      expect(serializeParseResult(result)).toEqual(outputs.compression.mixedGroups);
+    });
+
     it('should keep follow-up chain visible after compressedGroup from recursive tool result', () => {
       // Data provenance:
       // - The compressedGroup + nested assistant/tool structure is abstracted from the


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✅ test

#### 🔗 Related Issue

Related to #16496 — this is the safety net for the two PRs stacked on top of it, which address the profiling findings in that thread. It does not close the issue: the store normalisation the issue originally asks for is not done here.

#### 🔀 Description of Change

`packages/conversation-flow` is the engine behind every rendered conversation, and its test net had two holes that made any refactor of it unsafe.

**Fixtures wired to nothing.** Ten fixture files were imported by a barrel but referenced by zero tests — the four `compression` inputs, and both `agentCouncil` outputs. Four more inputs (`agentGroup` supervisor cases, `tasks` multi/with-assistant-group) had no golden output at all and were checked only by a handful of spot assertions.

**A golden that had been unhooked.** The two `agentCouncil` goldens did not match current output. Council rendering moved in-bubble at some point — `flatList` no longer carries a separate `role: 'agentCouncil'` row, it is a `council` block inside the assistant group — and rather than regenerating the fixture, the assertion was replaced with spot checks. Reconnecting them fails immediately; they are regenerated here to record current behaviour.

**Paths no fixture reached.** Five new inputs cover branches of `flatten()` that nothing exercised: orphan/thread root (every message has a parent), `task-completion` signal turns, tasks aggregation with an assistantGroup sibling, a supervisor summary parented to a task, and an optimistic assistant branch (`activeBranchIndex === children.length`).

Also folds the hand-copied input list in `fixtures/index.ts` into the existing `inputs` barrel and adds a matching `outputs` barrel — the copy had already drifted, which is how the `compression` fixtures ended up orphaned.

Full-shape golden assertions (`contextTree` + `flatList` + `messageMap` compared field by field) go from **17 to 27**.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

`cd packages/conversation-flow && bunx vitest run` — 190 passing.

**No source files are touched in this PR.** Every generated golden records the behaviour of unmodified `parse()`, which is what makes it a characterization net rather than a change.

#### 📝 Additional Information

First of three stacked PRs:

1. **this PR** — test net (no source changes)
2. #17395 — recursion → explicit stack (fixes a `RangeError` crash)
3. #17396 — handler ladder + O(N²) → linear

Deliberately not addressed: `CompressedGroupNode` is declared in `types/contextTree.ts` and included in the `ContextNode` union, but no code path constructs it — `compressedGroup` rows emit `type: 'message'`. The new compression goldens freeze that as-is; whether to implement it or delete the type is a separate question.
