### PR TITLE
🐛 fix(conversation-flow): stop parse() overflowing the stack on long conversations

### DIFF
--- a/packages/conversation-flow/src/__tests__/deepChain.test.ts
+++ b/packages/conversation-flow/src/__tests__/deepChain.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+
+import { parse } from '../parse';
+import type { Message } from '../types';
+
+/**
+ * Production topology: every user turn chains off the previous assistant
+ * (publicApi.ts sets parentId = lastDisplayMessageId), so the message "tree" is
+ * really a linked list whose depth equals the conversation length. Traversal
+ * must not consume stack proportional to that depth.
+ */
+const linkedChain = (turns: number, opts: { tools?: boolean } = {}): Message[] => {
+  const messages: Message[] = [];
+  let previousAssistantId: string | undefined;
+
+  for (let turn = 0; turn < turns; turn++) {
+    const userId = `u-${turn}`;
+    const assistantId = `a-${turn}`;
+
+    messages.push({
+      content: `question ${turn}`,
+      createdAt: turn * 10,
+      id: userId,
+      parentId: previousAssistantId ?? null,
+      role: 'user',
+      updatedAt: turn * 10,
+    } as Message);
+
+    const assistant = {
+      content: `answer ${turn}`,
+      createdAt: turn * 10 + 1,
+      id: assistantId,
+      parentId: userId,
+      role: 'assistant',
+      updatedAt: turn * 10 + 1,
+    } as Message;
+
+    if (opts.tools && turn % 4 === 0) {
+      const toolCallId = `call-${turn}`;
+      const toolMessageId = `t-${turn}`;
+      (assistant as any).tools = [
+        {
+          apiName: 'search',
+          arguments: '{}',
+          id: toolCallId,
+          identifier: 'bench-plugin',
+          result_msg_id: toolMessageId,
+          type: 'default',
+        },
+      ];
+      messages.push(assistant, {
+        content: `tool result ${turn}`,
+        createdAt: turn * 10 + 2,
+        id: toolMessageId,
+        parentId: assistantId,
+        role: 'tool',
+        tool_call_id: toolCallId,
+        updatedAt: turn * 10 + 2,
+      } as Message);
+    } else {
+      messages.push(assistant);
+    }
+
+    previousAssistantId = assistantId;
+  }
+
+  return messages;
+};
+
+/**
+ * 3000 turns / 6000 rows sits well clear of every stack ceiling this engine has
+ * had: the fully recursive walk died around 1.6k rows, and converting only
+ * FlatListBuilder moved that to roughly 2.4k. Anything that reintroduces
+ * depth-per-message in any of the three walks (structuring, contextTree,
+ * flatList) fails here.
+ */
+const TURNS = 3000;
+
+/**
+ * A single unbroken agent run: every step calls a tool and the next step hangs
+ * off that tool's result, so the whole thing collapses into ONE assistant group.
+ * Chain collection walks step by step, so its cost must not be stack depth.
+ */
+const singleToolChain = (steps: number): Message[] => {
+  const messages: Message[] = [
+    {
+      content: 'do the long thing',
+      createdAt: 0,
+      id: 'user-1',
+      parentId: null,
+      role: 'user',
+      updatedAt: 0,
+    } as unknown as Message,
+  ];
+
+  let parentId = 'user-1';
+  for (let step = 0; step < steps; step++) {
+    const assistantId = `ast-${step}`;
+    const toolMessageId = `tool-${step}`;
+    const toolCallId = `call-${step}`;
+
+    messages.push({
+      agentId: 'agent-1',
+      content: `step ${step}`,
+      createdAt: step * 2 + 1,
+      id: assistantId,
+      parentId,
+      role: 'assistant',
+      tools: [
+        {
+          apiName: 'run',
+          arguments: '{}',
+          id: toolCallId,
+          identifier: 'shell',
+          result_msg_id: toolMessageId,
+          type: 'default',
+        },
+      ],
+      updatedAt: step * 2 + 1,
+    } as unknown as Message);
+
+    messages.push({
+      content: `result ${step}`,
+      createdAt: step * 2 + 2,
+      id: toolMessageId,
+      parentId: assistantId,
+      role: 'tool',
+      tool_call_id: toolCallId,
+      updatedAt: step * 2 + 2,
+    } as Message);
+
+    parentId = toolMessageId;
+  }
+
+  return messages;
+};
+
+/**
+ * Every assistant carries two user replies, so each turn nests a branch inside
+ * the previous branch's subtree — i.e. the user regenerated at every turn.
+ *
+ * This is the one walk still bounded by stack depth: a branch node's output is
+ * itself nested (`branches: ContextNode[][]`), so `createBranchNode` re-enters
+ * the linear walk per branch. It holds to roughly 800 levels and fails around
+ * 1600; 500 here guards against that ceiling dropping.
+ */
+const nestedBranches = (levels: number): Message[] => {
+  const messages: Message[] = [
+    {
+      content: 'q',
+      createdAt: 0,
+      id: 'u0',
+      parentId: null,
+      role: 'user',
+      updatedAt: 0,
+    } as unknown as Message,
+  ];
+
+  let parentId = 'u0';
+  for (let level = 0; level < levels; level++) {
+    messages.push({
+      content: 'r',
+      createdAt: level * 3 + 1,
+      id: `a${level}`,
+      metadata: { activeBranchIndex: 0 },
+      parentId,
+      role: 'assistant',
+      updatedAt: level * 3 + 1,
+    } as unknown as Message);
+    messages.push({
+      content: 'follow-up',
+      createdAt: level * 3 + 2,
+      id: `u${level}x`,
+      parentId: `a${level}`,
+      role: 'user',
+      updatedAt: level * 3 + 2,
+    } as Message);
+    messages.push({
+      content: 'regenerated follow-up',
+      createdAt: level * 3 + 3,
+      id: `u${level}y`,
+      parentId: `a${level}`,
+      role: 'user',
+      updatedAt: level * 3 + 3,
+    } as Message);
+    parentId = `u${level}x`;
+  }
+
+  return messages;
+};
+
+describe('deep chain traversal', () => {
+  it('should parse deeply nested branches', () => {
+    expect(() => parse(nestedBranches(500))).not.toThrow();
+  });
+
+  it('should collect one very long assistant run without exhausting the stack', () => {
+    const messages = singleToolChain(3000);
+
+    expect(() => parse(messages)).not.toThrow();
+
+    const result = parse(messages);
+    // user row + one group bubble holding every step
+    expect(result.flatList).toHaveLength(2);
+    expect((result.flatList[1] as any).children).toHaveLength(3000);
+  });
+
+  it('should parse a deep linked chain without exhausting the stack', () => {
+    const messages = linkedChain(TURNS);
+    expect(messages).toHaveLength(TURNS * 2);
+
+    expect(() => parse(messages)).not.toThrow();
+    expect(parse(messages).flatList).toHaveLength(TURNS * 2);
+  });
+
+  it('should parse a deep tool-bearing chain without exhausting the stack', () => {
+    const messages = linkedChain(TURNS, { tools: true });
+
+    expect(() => parse(messages)).not.toThrow();
+  });
+
+  it('should keep chain order stable across the whole conversation', () => {
+    const result = parse(linkedChain(TURNS));
+    const ids = result.flatList.map((m) => m.id);
+
+    expect(ids[0]).toBe('u-0');
+    expect(ids[1]).toBe('a-0');
+    expect(ids.at(-2)).toBe(`u-${TURNS - 1}`);
+    expect(ids.at(-1)).toBe(`a-${TURNS - 1}`);
+  });
+
+  it('should build a contextTree for a deep chain', () => {
+    const result = parse(linkedChain(TURNS));
+
+    expect(result.contextTree).toHaveLength(TURNS * 2);
+  });
+});

--- a/packages/conversation-flow/src/structuring.ts
+++ b/packages/conversation-flow/src/structuring.ts
@@ -11,20 +11,28 @@ import type { HelperMaps, IdNode } from './types';
 export function buildIdTree(helperMaps: HelperMaps): IdNode[] {
   const { childrenMap, messageMap } = helperMaps;
 
-  // Build tree recursively starting from root messages (parentId = null)
-  const buildTree = (messageId: string): IdNode => {
-    const childIds = childrenMap.get(messageId) ?? [];
+  // Iterative build: a conversation's depth equals its length (each turn parents
+  // off the previous one), so recursing per node overflows the stack on long
+  // chains. Nodes are created on the way down, then filled from an explicit stack.
+  const buildTree = (rootId: string): IdNode => {
+    const root: IdNode = { children: [], id: rootId };
+    const pending: IdNode[] = [root];
 
-    // Filter children to only include those in main flow (not in threads)
-    const mainFlowChildIds = childIds.filter((childId) => {
-      const child = messageMap.get(childId);
-      return child && !child.threadId;
-    });
+    while (pending.length > 0) {
+      const node = pending.pop()!;
 
-    return {
-      children: mainFlowChildIds.map((childId) => buildTree(childId)),
-      id: messageId,
-    };
+      // Filter children to only include those in main flow (not in threads)
+      for (const childId of childrenMap.get(node.id) ?? []) {
+        const child = messageMap.get(childId);
+        if (!child || child.threadId) continue;
+
+        const childNode: IdNode = { children: [], id: childId };
+        node.children.push(childNode);
+        pending.push(childNode);
+      }
+    }
+
+    return root;
   };
 
   // Get root message IDs (messages with parentId = null and no threadId)

--- a/packages/conversation-flow/src/transformation/ContextTreeBuilder.ts
+++ b/packages/conversation-flow/src/transformation/ContextTreeBuilder.ts
@@ -37,19 +37,35 @@ export class ContextTreeBuilder {
   transformAll(idNodes: IdNode[]): ContextNode[] {
     const contextTree: ContextNode[] = [];
 
-    for (const idNode of idNodes) {
-      this.transformToLinear(idNode, contextTree);
-    }
+    this.runLinear(idNodes, contextTree);
 
     return contextTree;
   }
 
   /**
-   * Transform a single IdNode and append to contextTree array
+   * Depth-first drive of `transformToLinear` over an explicit stack.
+   *
+   * A conversation's tree depth equals its length (each turn parents off the
+   * previous one), so recursing per node overflows the stack on long chains.
+   * Continuations are returned in visit order and pushed reversed.
    */
-  private transformToLinear(idNode: IdNode, contextTree: ContextNode[]): void {
+  private runLinear(seed: IdNode[], contextTree: ContextNode[]): void {
+    const stack: IdNode[] = [];
+    for (let i = seed.length - 1; i >= 0; i--) stack.push(seed[i]);
+
+    while (stack.length > 0) {
+      const next = this.transformToLinear(stack.pop()!, contextTree);
+      for (let i = next.length - 1; i >= 0; i--) stack.push(next[i]);
+    }
+  }
+
+  /**
+   * Transform a single IdNode, append its node(s) to contextTree, and return the
+   * nodes the walk continues into (in visit order).
+   */
+  private transformToLinear(idNode: IdNode, contextTree: ContextNode[]): IdNode[] {
     const message = this.messageMap.get(idNode.id);
-    if (!message) return;
+    if (!message) return [];
 
     // Priority 1: Compare mode from user message metadata
     if (this.isCompareMode(message) && idNode.children.length > 1) {
@@ -68,10 +84,10 @@ export class ContextTreeBuilder {
           (child) => child.id === compareNode.activeColumnId,
         );
         if (activeColumnIdNode && activeColumnIdNode.children.length > 0) {
-          this.transformToLinear(activeColumnIdNode.children[0], contextTree);
+          return [activeColumnIdNode.children[0]];
         }
       }
-      return;
+      return [];
     }
 
     // Priority 2: Compare mode (from messageGroup metadata)
@@ -89,10 +105,10 @@ export class ContextTreeBuilder {
           (child) => child.id === compareNode.activeColumnId,
         );
         if (activeColumnIdNode && activeColumnIdNode.children.length > 0) {
-          this.transformToLinear(activeColumnIdNode.children[0], contextTree);
+          return [activeColumnIdNode.children[0]];
         }
       }
-      return;
+      return [];
     }
 
     // Priority 3: AgentCouncil mode (from message metadata, typically on tool messages)
@@ -109,12 +125,9 @@ export class ContextTreeBuilder {
       // the reply. Only the member carrying it has children, so iterating every member emits
       // it exactly once and keeps contextTree in agreement with flatList (FlatListBuilder
       // applies the same all-member continuation).
-      for (const child of idNode.children) {
-        if (child.children.length > 0) {
-          this.transformToLinear(child.children[0], contextTree);
-        }
-      }
-      return;
+      return idNode.children
+        .filter((child) => child.children.length > 0)
+        .map((child) => child.children[0]);
     }
 
     // Priority 3b: Tasks aggregation (multiple task children with same parent)
@@ -128,25 +141,20 @@ export class ContextTreeBuilder {
         return childMsg?.role !== 'task';
       });
 
-      for (const nonTaskChild of nonTaskChildren) {
-        this.transformToLinear(nonTaskChild, contextTree);
-      }
-
       // Also check for children of task messages (e.g., summary as child of last task)
       const taskChildren = idNode.children.filter((child) => {
         const childMsg = this.messageMap.get(child.id);
         return childMsg?.role === 'task';
       });
 
-      for (const taskChild of taskChildren) {
-        for (const taskGrandchild of taskChild.children) {
+      const taskGrandchildren = taskChildren.flatMap((taskChild) =>
+        taskChild.children.filter((taskGrandchild) => {
           const taskGrandchildMsg = this.messageMap.get(taskGrandchild.id);
-          if (taskGrandchildMsg && taskGrandchildMsg.role !== 'task') {
-            this.transformToLinear(taskGrandchild, contextTree);
-          }
-        }
-      }
-      return;
+          return taskGrandchildMsg && taskGrandchildMsg.role !== 'task';
+        }),
+      );
+
+      return [...nonTaskChildren, ...taskGrandchildren];
     }
 
     // Priority 4: AssistantGroup (assistant + tools)
@@ -156,10 +164,7 @@ export class ContextTreeBuilder {
 
       // Find the next message after tools
       const nextMessage = this.messageCollector.findNextAfterTools(message, idNode);
-      if (nextMessage) {
-        this.transformToLinear(nextMessage, contextTree);
-      }
-      return;
+      return nextMessage ? [nextMessage] : [];
     }
 
     // Priority 6: Branch — multiple NON-TOOL children (dual-form reader invariant: tool children are inline data, not branch candidates).
@@ -178,7 +183,7 @@ export class ContextTreeBuilder {
       contextTree.push(branchNode);
 
       // Don't continue after branch - branch is an end point
-      return;
+      return [];
     }
 
     // Priority 7: Regular message
@@ -186,9 +191,7 @@ export class ContextTreeBuilder {
     contextTree.push(messageNode);
 
     // Continue with single child
-    if (idNode.children.length === 1) {
-      this.transformToLinear(idNode.children[0], contextTree);
-    }
+    return idNode.children.length === 1 ? [idNode.children[0]] : [];
   }
 
   /**
@@ -285,7 +288,7 @@ export class ContextTreeBuilder {
     // Each branch is a tree starting from that child
     const branches = idNode.children.map((child) => {
       const branchTree: ContextNode[] = [];
-      this.transformToLinear(child, branchTree);
+      this.runLinear([child], branchTree);
       return branchTree;
     });
 

--- a/packages/conversation-flow/src/transformation/FlatListBuilder.ts
+++ b/packages/conversation-flow/src/transformation/FlatListBuilder.ts
@@ -15,10 +15,32 @@ const isSupervisorMessage = (message: Message | undefined): boolean =>
   message?.metadata?.orchestrationRole === 'supervisor' || !!message?.metadata?.isSupervisor;
 
 /**
+ * Which priority ladder a frame's children run through. The tasks-aggregation
+ * follow-ups use narrower ladders than the top level — see `tryTasksAggregation`.
+ */
+type LadderKind = 'full' | 'taskSibling' | 'taskGrandchild';
+
+/**
+ * A unit of pending traversal work.
+ *
+ * `children` walks `childIds` from `index`; `continuation` repeatedly drains the
+ * next unprocessed child hanging off a finished assistant group.
+ */
+type TraversalFrame =
+  | {
+      childIds: string[];
+      index: number;
+      kind: 'children';
+      ladder: LadderKind;
+      parentId: string | null;
+    }
+  | { kind: 'continuation'; parentIds: string[] };
+
+/**
  * FlatListBuilder - Builds flat message list following the active path
  *
  * Handles:
- * 1. Recursive traversal following active branches
+ * 1. Explicit-stack traversal following active branches
  * 2. Creating virtual messages for Compare and AssistantGroup
  * 3. Processing different message types with priority
  */
@@ -52,433 +74,239 @@ export class FlatListBuilder {
       rootParentId = messages[0].parentId ?? null;
     }
 
-    // Build the active path by traversing from root
-    this.buildFlatListRecursive(rootParentId, flatList, processedIds, messages);
+    this.runTraversal(rootParentId, flatList, processedIds, messages);
 
     return flatList;
   }
 
+  private childrenFrame(parentId: string | null, childIds?: string[]): TraversalFrame {
+    return {
+      childIds: childIds ?? this.childrenMap.get(parentId) ?? [],
+      index: 0,
+      kind: 'children',
+      ladder: 'full',
+      parentId,
+    };
+  }
+
+  private continuationFrame(assistantChain: Message[], allToolMessages: Message[]): TraversalFrame {
+    const lastAssistant = assistantChain.at(-1);
+    return {
+      kind: 'continuation',
+      parentIds: [
+        ...(lastAssistant ? [lastAssistant.id] : []),
+        ...allToolMessages.map((toolMessage) => toolMessage.id),
+      ],
+    };
+  }
+
   /**
-   * Recursively build flatList following the active path
+   * Explicit-stack walk of the active path.
+   *
+   * Every user turn parents off the previous assistant, so a conversation's tree
+   * depth equals its length — a recursive walk overflows the stack on long chains
+   * (RangeError past ~1.5k messages). Frames live on the heap instead.
+   *
+   * Frames pop LIFO; dispatch helpers return follow-ups in visit order and
+   * `pushAll` reverses them so the first entry is visited first.
    */
-  private buildFlatListRecursive(
-    parentId: string | null,
+  private runTraversal(
+    rootParentId: string | null,
     flatList: Message[],
     processedIds: Set<string>,
     allMessages: Message[],
   ): void {
-    const children = this.childrenMap.get(parentId) ?? [];
+    const stack: TraversalFrame[] = [this.childrenFrame(rootParentId)];
 
-    // Broadcast councils now render in-bubble (a `council` block inside the
-    // supervisor's assistant group), so there is no separate agentCouncil message
-    // to emit when recursing into a council tool — its members were already
-    // collected and marked processed by collectCouncilMembers.
-    if (parentId) {
-      const parentMessage = this.messageMap.get(parentId);
+    const pushAll = (frames: TraversalFrame[]): void => {
+      for (let i = frames.length - 1; i >= 0; i--) stack.push(frames[i]);
+    };
 
-      // Pre-loop check: Tasks aggregation (multiple task messages with same parentId)
-      // This handles the case when multiple async tasks are spawned from the same tool message
-      if (parentMessage && children.length > 0) {
-        const taskChildren = children.filter((childId) => {
-          const child = this.messageMap.get(childId);
-          return child?.role === 'task';
-        });
+    while (stack.length > 0) {
+      const frame = stack.at(-1);
+      if (!frame) break;
 
-        if (taskChildren.length > 1) {
-          // Get non-task children (e.g., summary assistant message)
-          const nonTaskChildren = children.filter((childId) => {
-            const child = this.messageMap.get(childId);
-            return child?.role !== 'task';
-          });
+      if (frame.kind === 'continuation') {
+        const next = this.findNextUnprocessedChild(frame.parentIds, processedIds);
+        if (!next) {
+          stack.pop();
+          continue;
+        }
 
-          // Check if tasks have different agentIds (groupTasks) or same agentId (tasks)
-          const taskAgentIds = new Set(
-            taskChildren.map((childId) => this.messageMap.get(childId)?.agentId).filter(Boolean),
-          );
-          const isGroupTasks = taskAgentIds.size > 1;
+        stack.push(
+          this.shouldDrainParentContinuations(next.parentId, processedIds)
+            ? this.childrenFrame(next.parentId)
+            : this.childrenFrame(next.parentId, [next.child.id]),
+        );
+        continue;
+      }
 
-          // Create appropriate virtual message based on agent diversity
-          const tasksMessage = isGroupTasks
-            ? this.createGroupTasksMessage(parentMessage, taskChildren, processedIds)
-            : this.createTasksMessage(parentMessage, taskChildren, processedIds);
-          flatList.push(tasksMessage);
-
-          // Continue with non-task children (e.g., final summary from assistant)
-          for (const nonTaskChildId of nonTaskChildren) {
-            if (!processedIds.has(nonTaskChildId)) {
-              const nonTaskChild = this.messageMap.get(nonTaskChildId);
-              if (nonTaskChild) {
-                // Check if it's an AssistantGroup (assistant with tools)
-                if (
-                  nonTaskChild.role === 'assistant' &&
-                  nonTaskChild.tools &&
-                  nonTaskChild.tools.length > 0
-                ) {
-                  this.processAssistantGroup(nonTaskChild, flatList, processedIds, allMessages);
-                } else {
-                  flatList.push(nonTaskChild);
-                  processedIds.add(nonTaskChildId);
-                  this.buildFlatListRecursive(nonTaskChildId, flatList, processedIds, allMessages);
-                }
-              }
-            }
-          }
-
-          // Also check for children of task messages (e.g., summary as child of last task)
-          for (const taskChildId of taskChildren) {
-            const taskChildrenIds = this.childrenMap.get(taskChildId) ?? [];
-            for (const taskGrandchildId of taskChildrenIds) {
-              if (!processedIds.has(taskGrandchildId)) {
-                const taskGrandchild = this.messageMap.get(taskGrandchildId);
-                if (taskGrandchild && taskGrandchild.role !== 'task') {
-                  // Check if it's an AssistantGroup (assistant with tools)
-                  if (
-                    taskGrandchild.role === 'assistant' &&
-                    taskGrandchild.tools &&
-                    taskGrandchild.tools.length > 0
-                  ) {
-                    this.processAssistantGroup(taskGrandchild, flatList, processedIds, allMessages);
-                  } else if (
-                    // Check if it's a supervisor message without tools (content-only)
-                    taskGrandchild.role === 'assistant' &&
-                    isSupervisorMessage(taskGrandchild) &&
-                    (!taskGrandchild.tools || taskGrandchild.tools.length === 0)
-                  ) {
-                    const supervisorMessage = this.createSupervisorContentMessage(taskGrandchild);
-                    flatList.push(supervisorMessage);
-                    processedIds.add(taskGrandchildId);
-                    this.buildFlatListRecursive(
-                      taskGrandchildId,
-                      flatList,
-                      processedIds,
-                      allMessages,
-                    );
-                  } else {
-                    flatList.push(taskGrandchild);
-                    processedIds.add(taskGrandchildId);
-                    this.buildFlatListRecursive(
-                      taskGrandchildId,
-                      flatList,
-                      processedIds,
-                      allMessages,
-                    );
-                  }
-                }
-              }
-            }
-          }
-          return;
+      // Tasks aggregation reads the parent's children as a set, before any single
+      // child is visited, and replaces the whole frame when it fires.
+      if (frame.index === 0 && frame.ladder === 'full') {
+        const aggregated = this.tryTasksAggregation(
+          frame.parentId,
+          frame.childIds,
+          flatList,
+          processedIds,
+        );
+        if (aggregated) {
+          stack.pop();
+          pushAll(aggregated);
+          continue;
         }
       }
-    }
 
-    for (const childId of children) {
+      if (frame.index >= frame.childIds.length) {
+        stack.pop();
+        continue;
+      }
+
+      const childId = frame.childIds[frame.index];
+      frame.index += 1;
+
       if (processedIds.has(childId)) continue;
-
       const message = this.messageMap.get(childId);
       if (!message) continue;
 
-      // Priority 1: Compare message group
-      const messageGroup = message.groupId ? this.messageGroupMap.get(message.groupId) : undefined;
-
-      if (messageGroup && messageGroup.mode === 'compare' && !processedIds.has(messageGroup.id)) {
-        const groupMembers = this.messageCollector.collectGroupMembers(
-          message.groupId!,
-          allMessages,
-        );
-        const compareMessage = this.createCompareMessage(messageGroup, groupMembers);
-        flatList.push(compareMessage);
-        groupMembers.forEach((m) => processedIds.add(m.id));
-        processedIds.add(messageGroup.id);
-
-        // Continue with active column's children (if any)
-        if ((compareMessage as any).activeColumnId) {
-          this.buildFlatListRecursive(
-            (compareMessage as any).activeColumnId,
-            flatList,
-            processedIds,
-            allMessages,
-          );
-        }
-        continue;
-      }
-
-      // Priority 2: AssistantGroup (assistant + tools), or the toolless
-      // narration step that heads a tool-using chain — the latter must seed the
-      // group instead of splitting into its own standalone bubble. Supervisors
-      // are excluded from the toolless-head path so they still fall to 2b.
-      if (
-        message.role === 'assistant' &&
-        ((message.tools && message.tools.length > 0) ||
-          (!isSupervisorMessage(message) && this.messageCollector.isToolChainHead(message)))
-      ) {
-        // Collect the entire assistant group chain
-        const assistantChain: Message[] = [];
-        const allToolMessages: Message[] = [];
-        this.messageCollector.collectAssistantChain(
-          message,
-          allMessages,
-          assistantChain,
-          allToolMessages,
-          processedIds,
-        );
-
-        // Gather external-signal callback blocks () for any
-        // tool in the chain that fired toolless reactive replies
-        // (Monitor stdout pushes, etc.). Snapshot now so the UI doesn't
-        // need to query messageMap; mark callback messages as processed
-        // so they don't render as separate top-level bubbles.
-        const signalBlocks = this.messageCollector.collectFlatSignalCallbacks(
-          allToolMessages,
-          allMessages,
-        );
-
-        // Post-task-summary turns () — toolless siblings of
-        // the callbacks under the same tool_result, tagged with
-        // `signal.type === 'task-completion'`. Belong inside the same
-        // AssistantGroup, rendered AFTER the SignalCallbacks accordion.
-        const taskCompletionMessages = this.messageCollector.collectFlatTaskCompletions(
-          allToolMessages,
-          allMessages,
-        );
-
-        // A broadcast turn renders its members as one in-bubble council block.
-        // Gather them before building the group so they embed inside it.
-        const council = this.collectCouncilMembers(allToolMessages, allMessages, processedIds);
-
-        // Create assistantGroup virtual message
-        const groupMessage = this.createAssistantGroupMessage(
-          assistantChain[0],
-          assistantChain,
-          allToolMessages,
-          signalBlocks,
-          taskCompletionMessages,
-          council?.members,
-        );
-        flatList.push(groupMessage);
-
-        // Mark all as processed
-        assistantChain.forEach((m) => processedIds.add(m.id));
-        allToolMessages.forEach((m) => processedIds.add(m.id));
-        for (const block of signalBlocks) {
-          for (const cb of block.callbacks) processedIds.add(cb.id);
-        }
-        for (const completion of taskCompletionMessages) {
-          processedIds.add(completion.id);
-        }
-
-        // Surface the supervisor's post-council reply (attached to one member).
-        if (council) {
-          for (const memberId of council.memberIds) {
-            this.buildFlatListRecursive(memberId, flatList, processedIds, allMessages);
-          }
-        }
-
-        this.continueAfterAssistantGroup(
-          assistantChain,
-          allToolMessages,
-          flatList,
-          processedIds,
-          allMessages,
-        );
-        continue;
-      }
-
-      // Priority 2b: Supervisor message without tools (content-only)
-      // Transform to supervisor role with content in children array
-      if (
-        message.role === 'assistant' &&
-        isSupervisorMessage(message) &&
-        (!message.tools || message.tools.length === 0)
-      ) {
-        const supervisorMessage = this.createSupervisorContentMessage(message);
-        flatList.push(supervisorMessage);
-        processedIds.add(message.id);
-
-        // Continue with children
-        this.buildFlatListRecursive(message.id, flatList, processedIds, allMessages);
-        continue;
-      }
-
-      // Priority 3a: Compare mode from user message metadata
-      const childMessages = this.childrenMap.get(message.id) ?? [];
-      // Non-tool children only are branch candidates (dual-form reader invariant: tool children are inline, not branches):
-      // a tool child is inline data of its assistant, never a sibling branch.
-      const nonToolChildMessages = childMessages.filter(
-        (childId) => this.messageMap.get(childId)?.role !== 'tool',
-      );
-      if (this.isCompareMode(message) && childMessages.length > 1) {
-        // Add user message
-        flatList.push(message);
-        processedIds.add(message.id);
-
-        // Create compare virtual message with proper handling of AssistantGroups
-        const compareMessage = this.createCompareMessageFromChildIds(
-          message,
-          childMessages,
-          allMessages,
-          processedIds,
-        );
-        flatList.push(compareMessage);
-
-        // Continue with active column's children (if any)
-        if ((compareMessage as any).activeColumnId) {
-          this.buildFlatListRecursive(
-            (compareMessage as any).activeColumnId,
-            flatList,
-            processedIds,
-            allMessages,
-          );
-        }
-        continue;
-      }
-
-      // Priority 3d: User message with branches (multiple assistant children)
-      // Branch indicator should be on the active assistant child message
-      if (message.role === 'user' && nonToolChildMessages.length > 1) {
-        const activeBranchId = this.branchResolver.getActiveBranchIdFromMetadata(
-          message,
-          nonToolChildMessages,
-          this.childrenMap,
-        );
-
-        // Optimistic update: activeBranchId is undefined when branch is being created
-        // In this case, just add user message without branch info and continue
-        if (!activeBranchId) {
-          flatList.push(message);
-          processedIds.add(message.id);
-          continue;
-        }
-
-        // Add user message without branch (branch goes on the child)
-        flatList.push(message);
-        processedIds.add(message.id);
-
-        const activeBranchIndex = nonToolChildMessages.indexOf(activeBranchId);
-
-        // Continue with active branch - check if it's an assistantGroup
-        const activeBranchMsg = this.messageMap.get(activeBranchId);
-        if (activeBranchMsg) {
-          // Check if active branch is assistant with tools (should be assistantGroup)
-          if (
-            activeBranchMsg.role === 'assistant' &&
-            activeBranchMsg.tools &&
-            activeBranchMsg.tools.length > 0
-          ) {
-            // Collect the entire assistant group chain
-            const assistantChain: Message[] = [];
-            const allToolMessages: Message[] = [];
-            this.messageCollector.collectAssistantChain(
-              activeBranchMsg,
-              allMessages,
-              assistantChain,
-              allToolMessages,
-              processedIds,
-            );
-
-            // Create assistantGroup virtual message with branch metadata
-            const groupMessage = this.createAssistantGroupMessage(
-              assistantChain[0],
-              assistantChain,
-              allToolMessages,
-            );
-            // Add branch info to the assistantGroup message
-            const groupMessageWithBranches = this.createMessageWithBranches(
-              groupMessage,
-              nonToolChildMessages.length,
-              activeBranchIndex,
-            );
-            flatList.push(groupMessageWithBranches);
-
-            // Mark all as processed
-            assistantChain.forEach((m) => processedIds.add(m.id));
-            allToolMessages.forEach((m) => processedIds.add(m.id));
-
-            this.continueAfterAssistantGroup(
-              assistantChain,
-              allToolMessages,
-              flatList,
-              processedIds,
-              allMessages,
-            );
-          } else {
-            // Regular assistant message (not assistantGroup) - add branch info
-            const activeBranchWithBranches = this.createMessageWithBranches(
-              activeBranchMsg,
-              nonToolChildMessages.length,
-              activeBranchIndex,
-            );
-            flatList.push(activeBranchWithBranches);
-            processedIds.add(activeBranchId);
-
-            // Continue with active branch's children
-            this.buildFlatListRecursive(activeBranchId, flatList, processedIds, allMessages);
-          }
-        }
-        continue;
-      }
-
-      // Priority 3e: Assistant message with branches (multiple user children)
-      // Branch indicator should be on the active user child message
-      if (message.role === 'assistant' && nonToolChildMessages.length > 1) {
-        const activeBranchId = this.branchResolver.getActiveBranchIdFromMetadata(
-          message,
-          nonToolChildMessages,
-          this.childrenMap,
-        );
-
-        // Optimistic update: activeBranchId is undefined when branch is being created
-        // In this case, just add assistant message without branch info and continue
-        if (!activeBranchId) {
-          flatList.push(message);
-          processedIds.add(message.id);
-          continue;
-        }
-
-        // Add the assistant message without branch (branch goes on the child)
-        flatList.push(message);
-        processedIds.add(message.id);
-
-        const activeBranchIndex = nonToolChildMessages.indexOf(activeBranchId);
-
-        // Continue with active branch and add branch info to the user child
-        const activeBranchMsg = this.messageMap.get(activeBranchId);
-        if (activeBranchMsg) {
-          // Add branch info to the active user child message
-          const activeBranchWithBranches = this.createMessageWithBranches(
-            activeBranchMsg,
-            nonToolChildMessages.length,
-            activeBranchIndex,
-          );
-          flatList.push(activeBranchWithBranches);
-          processedIds.add(activeBranchId);
-
-          // Continue with active branch's children
-          this.buildFlatListRecursive(activeBranchId, flatList, processedIds, allMessages);
-        }
-        continue;
-      }
-
-      // Priority 4: Regular message
-      flatList.push(message);
-      processedIds.add(message.id);
-
-      // Continue with children
-      this.buildFlatListRecursive(message.id, flatList, processedIds, allMessages);
+      pushAll(this.dispatch(frame.ladder, message, flatList, processedIds, allMessages));
     }
   }
 
-  /**
-   * Process an assistant message with tools into an AssistantGroup
-   * Extracted to avoid code duplication in task children handling
-   */
-  private processAssistantGroup(
+  private dispatch(
+    ladder: LadderKind,
     message: Message,
     flatList: Message[],
     processedIds: Set<string>,
     allMessages: Message[],
-  ): void {
-    // Collect the entire assistant group chain
+  ): TraversalFrame[] {
+    switch (ladder) {
+      case 'taskSibling': {
+        return this.dispatchTaskSibling(message, flatList, processedIds, allMessages);
+      }
+      case 'taskGrandchild': {
+        return this.dispatchTaskGrandchild(message, flatList, processedIds, allMessages);
+      }
+      default: {
+        return this.dispatchMessage(message, flatList, processedIds, allMessages);
+      }
+    }
+  }
+
+  /**
+   * More than one `task` child under a parent collapses into a single virtual
+   * tasks row; the frame is then replaced by its follow-ups — non-task siblings
+   * first, then each task's own children.
+   *
+   * The follow-up ladders are deliberately narrower than the top-level one: a
+   * task sibling never opens a supervisor content bubble, a task grandchild does.
+   */
+  private tryTasksAggregation(
+    parentId: string | null,
+    children: string[],
+    flatList: Message[],
+    processedIds: Set<string>,
+  ): TraversalFrame[] | undefined {
+    if (!parentId || children.length === 0) return undefined;
+
+    const parentMessage = this.messageMap.get(parentId);
+    if (!parentMessage) return undefined;
+
+    const taskChildren = children.filter(
+      (childId) => this.messageMap.get(childId)?.role === 'task',
+    );
+    if (taskChildren.length <= 1) return undefined;
+
+    const nonTaskChildren = children.filter(
+      (childId) => this.messageMap.get(childId)?.role !== 'task',
+    );
+
+    const taskAgentIds = new Set(
+      taskChildren.map((childId) => this.messageMap.get(childId)?.agentId).filter(Boolean),
+    );
+    const isGroupTasks = taskAgentIds.size > 1;
+
+    flatList.push(
+      isGroupTasks
+        ? this.createGroupTasksMessage(parentMessage, taskChildren, processedIds)
+        : this.createTasksMessage(parentMessage, taskChildren, processedIds),
+    );
+
+    const followUps: TraversalFrame[] = [
+      {
+        childIds: nonTaskChildren,
+        index: 0,
+        kind: 'children',
+        ladder: 'taskSibling',
+        parentId,
+      },
+    ];
+
+    for (const taskChildId of taskChildren) {
+      followUps.push({
+        childIds: this.childrenMap.get(taskChildId) ?? [],
+        index: 0,
+        kind: 'children',
+        ladder: 'taskGrandchild',
+        parentId: taskChildId,
+      });
+    }
+
+    return followUps;
+  }
+
+  private dispatchTaskSibling(
+    message: Message,
+    flatList: Message[],
+    processedIds: Set<string>,
+    allMessages: Message[],
+  ): TraversalFrame[] {
+    if (message.role === 'assistant' && message.tools && message.tools.length > 0) {
+      return this.emitAssistantGroup(message, flatList, processedIds, allMessages);
+    }
+
+    flatList.push(message);
+    processedIds.add(message.id);
+    return [this.childrenFrame(message.id)];
+  }
+
+  private dispatchTaskGrandchild(
+    message: Message,
+    flatList: Message[],
+    processedIds: Set<string>,
+    allMessages: Message[],
+  ): TraversalFrame[] {
+    if (message.role === 'task') return [];
+
+    if (message.role === 'assistant' && message.tools && message.tools.length > 0) {
+      return this.emitAssistantGroup(message, flatList, processedIds, allMessages);
+    }
+
+    if (
+      message.role === 'assistant' &&
+      isSupervisorMessage(message) &&
+      (!message.tools || message.tools.length === 0)
+    ) {
+      flatList.push(this.createSupervisorContentMessage(message));
+      processedIds.add(message.id);
+      return [this.childrenFrame(message.id)];
+    }
+
+    flatList.push(message);
+    processedIds.add(message.id);
+    return [this.childrenFrame(message.id)];
+  }
+
+  /**
+   * AssistantGroup without the top-level extras (signal callbacks, task
+   * completions) — the shape the tasks follow-up path has always emitted.
+   */
+  private emitAssistantGroup(
+    message: Message,
+    flatList: Message[],
+    processedIds: Set<string>,
+    allMessages: Message[],
+  ): TraversalFrame[] {
     const assistantChain: Message[] = [];
     const allToolMessages: Message[] = [];
     this.messageCollector.collectAssistantChain(
@@ -489,10 +317,8 @@ export class FlatListBuilder {
       processedIds,
     );
 
-    // A broadcast turn embeds its members as an in-bubble council block.
     const council = this.collectCouncilMembers(allToolMessages, allMessages, processedIds);
 
-    // Create assistantGroup virtual message
     const groupMessage = this.createAssistantGroupMessage(
       assistantChain[0],
       assistantChain,
@@ -503,55 +329,246 @@ export class FlatListBuilder {
     );
     flatList.push(groupMessage);
 
-    // Mark all as processed
     assistantChain.forEach((m) => processedIds.add(m.id));
     allToolMessages.forEach((m) => processedIds.add(m.id));
 
+    const frames: TraversalFrame[] = [];
     if (council) {
-      for (const memberId of council.memberIds) {
-        this.buildFlatListRecursive(memberId, flatList, processedIds, allMessages);
-      }
+      for (const memberId of council.memberIds) frames.push(this.childrenFrame(memberId));
     }
-
-    this.continueAfterAssistantGroup(
-      assistantChain,
-      allToolMessages,
-      flatList,
-      processedIds,
-      allMessages,
-    );
+    frames.push(this.continuationFrame(assistantChain, allToolMessages));
+    return frames;
   }
 
-  private continueAfterAssistantGroup(
-    assistantChain: Message[],
-    allToolMessages: Message[],
+  /**
+   * Top-level priority ladder: the first shape that matches claims the message,
+   * emits its row(s), marks the raw messages it swallowed, and returns where the
+   * walk resumes.
+   */
+  private dispatchMessage(
+    message: Message,
     flatList: Message[],
     processedIds: Set<string>,
     allMessages: Message[],
-  ): void {
-    const lastAssistant = assistantChain.at(-1);
-    const parentIds = [
-      ...(lastAssistant ? [lastAssistant.id] : []),
-      ...allToolMessages.map((toolMessage) => toolMessage.id),
-    ];
+  ): TraversalFrame[] {
+    // Priority 1: Compare message group
+    const messageGroup = message.groupId ? this.messageGroupMap.get(message.groupId) : undefined;
 
-    while (true) {
-      const nextContinuation = this.findNextUnprocessedChild(parentIds, processedIds);
-      if (!nextContinuation) return;
+    if (messageGroup && messageGroup.mode === 'compare' && !processedIds.has(messageGroup.id)) {
+      const groupMembers = this.messageCollector.collectGroupMembers(message.groupId!, allMessages);
+      const compareMessage = this.createCompareMessage(messageGroup, groupMembers);
+      flatList.push(compareMessage);
+      groupMembers.forEach((m) => processedIds.add(m.id));
+      processedIds.add(messageGroup.id);
 
-      if (this.shouldDrainParentContinuations(nextContinuation.parentId, processedIds)) {
-        this.buildFlatListRecursive(nextContinuation.parentId, flatList, processedIds, allMessages);
-        continue;
-      }
+      // Continue with active column's children (if any)
+      const activeColumnId = (compareMessage as any).activeColumnId;
+      return activeColumnId ? [this.childrenFrame(activeColumnId)] : [];
+    }
 
-      this.buildFlatListRecursiveForChild(
-        nextContinuation.parentId,
-        nextContinuation.child.id,
-        flatList,
+    // Priority 2: AssistantGroup (assistant + tools), or the toolless
+    // narration step that heads a tool-using chain — the latter must seed the
+    // group instead of splitting into its own standalone bubble. Supervisors
+    // are excluded from the toolless-head path so they still fall to 2b.
+    if (
+      message.role === 'assistant' &&
+      ((message.tools && message.tools.length > 0) ||
+        (!isSupervisorMessage(message) && this.messageCollector.isToolChainHead(message)))
+    ) {
+      const assistantChain: Message[] = [];
+      const allToolMessages: Message[] = [];
+      this.messageCollector.collectAssistantChain(
+        message,
+        allMessages,
+        assistantChain,
+        allToolMessages,
         processedIds,
+      );
+
+      // Gather external-signal callback blocks for any tool in the chain that
+      // fired toolless reactive replies (Monitor stdout pushes, etc.). Snapshot
+      // now so the UI doesn't need to query messageMap.
+      const signalBlocks = this.messageCollector.collectFlatSignalCallbacks(
+        allToolMessages,
         allMessages,
       );
+
+      // Post-task-summary turns — toolless siblings of the callbacks under the
+      // same tool_result, rendered AFTER the SignalCallbacks accordion.
+      const taskCompletionMessages = this.messageCollector.collectFlatTaskCompletions(
+        allToolMessages,
+        allMessages,
+      );
+
+      // A broadcast turn renders its members as one in-bubble council block.
+      const council = this.collectCouncilMembers(allToolMessages, allMessages, processedIds);
+
+      const groupMessage = this.createAssistantGroupMessage(
+        assistantChain[0],
+        assistantChain,
+        allToolMessages,
+        signalBlocks,
+        taskCompletionMessages,
+        council?.members,
+      );
+      flatList.push(groupMessage);
+
+      assistantChain.forEach((m) => processedIds.add(m.id));
+      allToolMessages.forEach((m) => processedIds.add(m.id));
+      for (const block of signalBlocks) {
+        for (const cb of block.callbacks) processedIds.add(cb.id);
+      }
+      for (const completion of taskCompletionMessages) {
+        processedIds.add(completion.id);
+      }
+
+      const frames: TraversalFrame[] = [];
+      // Surface the supervisor's post-council reply (attached to one member).
+      if (council) {
+        for (const memberId of council.memberIds) frames.push(this.childrenFrame(memberId));
+      }
+      frames.push(this.continuationFrame(assistantChain, allToolMessages));
+      return frames;
     }
+
+    // Priority 2b: Supervisor message without tools (content-only)
+    // Transform to supervisor role with content in children array
+    if (
+      message.role === 'assistant' &&
+      isSupervisorMessage(message) &&
+      (!message.tools || message.tools.length === 0)
+    ) {
+      flatList.push(this.createSupervisorContentMessage(message));
+      processedIds.add(message.id);
+      return [this.childrenFrame(message.id)];
+    }
+
+    // Priority 3a: Compare mode from user message metadata
+    const childMessages = this.childrenMap.get(message.id) ?? [];
+    // Non-tool children only are branch candidates (dual-form reader invariant: tool children are inline, not branches):
+    // a tool child is inline data of its assistant, never a sibling branch.
+    const nonToolChildMessages = childMessages.filter(
+      (childId) => this.messageMap.get(childId)?.role !== 'tool',
+    );
+
+    if (this.isCompareMode(message) && childMessages.length > 1) {
+      flatList.push(message);
+      processedIds.add(message.id);
+
+      const compareMessage = this.createCompareMessageFromChildIds(
+        message,
+        childMessages,
+        allMessages,
+        processedIds,
+      );
+      flatList.push(compareMessage);
+
+      const activeColumnId = (compareMessage as any).activeColumnId;
+      return activeColumnId ? [this.childrenFrame(activeColumnId)] : [];
+    }
+
+    // Priority 3d: User message with branches (multiple assistant children)
+    // Branch indicator should be on the active assistant child message
+    if (message.role === 'user' && nonToolChildMessages.length > 1) {
+      const activeBranchId = this.branchResolver.getActiveBranchIdFromMetadata(
+        message,
+        nonToolChildMessages,
+        this.childrenMap,
+      );
+
+      flatList.push(message);
+      processedIds.add(message.id);
+
+      // Optimistic update: activeBranchId is undefined when branch is being created
+      if (!activeBranchId) return [];
+
+      const activeBranchIndex = nonToolChildMessages.indexOf(activeBranchId);
+      const activeBranchMsg = this.messageMap.get(activeBranchId);
+      if (!activeBranchMsg) return [];
+
+      // Check if active branch is assistant with tools (should be assistantGroup)
+      if (
+        activeBranchMsg.role === 'assistant' &&
+        activeBranchMsg.tools &&
+        activeBranchMsg.tools.length > 0
+      ) {
+        const assistantChain: Message[] = [];
+        const allToolMessages: Message[] = [];
+        this.messageCollector.collectAssistantChain(
+          activeBranchMsg,
+          allMessages,
+          assistantChain,
+          allToolMessages,
+          processedIds,
+        );
+
+        const groupMessage = this.createAssistantGroupMessage(
+          assistantChain[0],
+          assistantChain,
+          allToolMessages,
+        );
+        flatList.push(
+          this.createMessageWithBranches(
+            groupMessage,
+            nonToolChildMessages.length,
+            activeBranchIndex,
+          ),
+        );
+
+        assistantChain.forEach((m) => processedIds.add(m.id));
+        allToolMessages.forEach((m) => processedIds.add(m.id));
+
+        return [this.continuationFrame(assistantChain, allToolMessages)];
+      }
+
+      // Regular assistant message (not assistantGroup) - add branch info
+      flatList.push(
+        this.createMessageWithBranches(
+          activeBranchMsg,
+          nonToolChildMessages.length,
+          activeBranchIndex,
+        ),
+      );
+      processedIds.add(activeBranchId);
+      return [this.childrenFrame(activeBranchId)];
+    }
+
+    // Priority 3e: Assistant message with branches (multiple user children)
+    // Branch indicator should be on the active user child message
+    if (message.role === 'assistant' && nonToolChildMessages.length > 1) {
+      const activeBranchId = this.branchResolver.getActiveBranchIdFromMetadata(
+        message,
+        nonToolChildMessages,
+        this.childrenMap,
+      );
+
+      // Add the assistant message without branch (branch goes on the child)
+      flatList.push(message);
+      processedIds.add(message.id);
+
+      // Optimistic update: activeBranchId is undefined when branch is being created
+      if (!activeBranchId) return [];
+
+      const activeBranchIndex = nonToolChildMessages.indexOf(activeBranchId);
+      const activeBranchMsg = this.messageMap.get(activeBranchId);
+      if (!activeBranchMsg) return [];
+
+      // Add branch info to the active user child message
+      flatList.push(
+        this.createMessageWithBranches(
+          activeBranchMsg,
+          nonToolChildMessages.length,
+          activeBranchIndex,
+        ),
+      );
+      processedIds.add(activeBranchId);
+      return [this.childrenFrame(activeBranchId)];
+    }
+
+    // Priority 4: Regular message
+    flatList.push(message);
+    processedIds.add(message.id);
+    return [this.childrenFrame(message.id)];
   }
 
   /**
@@ -610,23 +627,6 @@ export class FlatListBuilder {
     for (const anchorId of this.childrenMap.get(councilTool.id) ?? []) processedIds.add(anchorId);
 
     return { memberIds, members: (councilVirtual as { members?: Message[] }).members ?? [] };
-  }
-
-  private buildFlatListRecursiveForChild(
-    parentId: string,
-    childId: string,
-    flatList: Message[],
-    processedIds: Set<string>,
-    allMessages: Message[],
-  ): void {
-    const childIds = this.childrenMap.get(parentId) ?? [];
-    this.childrenMap.set(parentId, [childId]);
-
-    try {
-      this.buildFlatListRecursive(parentId, flatList, processedIds, allMessages);
-    } finally {
-      this.childrenMap.set(parentId, childIds);
-    }
   }
 
   private findNextUnprocessedChild(

--- a/packages/conversation-flow/src/transformation/MessageCollector.ts
+++ b/packages/conversation-flow/src/transformation/MessageCollector.ts
@@ -162,75 +162,67 @@ export class MessageCollector {
     allToolMessages: Message[],
     processedIds: Set<string>,
   ): void {
-    if (processedIds.has(currentAssistant.id)) return;
+    let current: Message | undefined = currentAssistant;
 
-    // Mark visited up front so duplicated tool_call_ids (the same tool result
-    // reachable from multiple assistants) can't recurse forever.
-    processedIds.add(currentAssistant.id);
+    // A run is a chain, so its length is the step count — walking it with
+    // recursion would cost stack depth per step.
+    while (current) {
+      if (processedIds.has(current.id)) return;
 
-    // Add current assistant to chain
-    assistantChain.push(currentAssistant);
+      // Mark visited up front so duplicated tool_call_ids (the same tool result
+      // reachable from multiple assistants) can't loop forever.
+      processedIds.add(current.id);
 
-    // Get the agentId of the first assistant in the chain (the group owner)
-    const groupAgentId = assistantChain[0].agentId;
+      // Add current assistant to chain
+      assistantChain.push(current);
 
-    // Collect its tool messages
-    const toolMessages = this.collectToolMessages(currentAssistant, allMessages);
-    allToolMessages.push(...toolMessages);
+      // Get the agentId of the first assistant in the chain (the group owner)
+      const groupAgentId = assistantChain[0].agentId;
 
-    // Find the next step's assistant. Role-aware dual-form walk:
-    // the continuation may hang off this assistant directly (assistant-anchored
-    // / new form) OR off one of its tool results (tool-anchored / old form).
-    const continuation = this.findFlatChainContinuation(
-      currentAssistant,
-      toolMessages,
-      allMessages,
-      processedIds,
-      groupAgentId,
-    );
-    if (!continuation) return;
+      // Collect its tool messages
+      const toolMessages = this.collectToolMessages(current, allMessages);
+      allToolMessages.push(...toolMessages);
 
-    if (continuation.tools && continuation.tools.length > 0) {
-      // Continue the chain (recursion marks it processed at the top)
-      this.collectAssistantChain(
-        continuation,
-        allMessages,
-        assistantChain,
-        allToolMessages,
-        processedIds,
-      );
-      return;
-    }
-
-    // Toolless continuations are still part of the same hetero-agent run. The
-    // model can emit several prose-only progress updates before the next tool
-    // call, so keep walking until the chain either ends in a toolless final
-    // answer or reaches the next tool-using assistant.
-    let toollessContinuation: Message | undefined = continuation;
-    while (
-      toollessContinuation &&
-      (!toollessContinuation.tools || toollessContinuation.tools.length === 0)
-    ) {
-      assistantChain.push(toollessContinuation);
-      processedIds.add(toollessContinuation.id);
-
-      toollessContinuation = this.findFlatChainContinuation(
-        toollessContinuation,
-        [], // a toolless step owns no tool results
+      // Find the next step's assistant. Role-aware dual-form walk:
+      // the continuation may hang off this assistant directly (assistant-anchored
+      // / new form) OR off one of its tool results (tool-anchored / old form).
+      const continuation = this.findFlatChainContinuation(
+        current,
+        toolMessages,
         allMessages,
         processedIds,
         groupAgentId,
       );
-    }
+      if (!continuation) return;
 
-    if (toollessContinuation) {
-      this.collectAssistantChain(
-        toollessContinuation,
-        allMessages,
-        assistantChain,
-        allToolMessages,
-        processedIds,
-      );
+      if (continuation.tools && continuation.tools.length > 0) {
+        // Continue the chain (the loop head marks it processed)
+        current = continuation;
+        continue;
+      }
+
+      // Toolless continuations are still part of the same hetero-agent run. The
+      // model can emit several prose-only progress updates before the next tool
+      // call, so keep walking until the chain either ends in a toolless final
+      // answer or reaches the next tool-using assistant.
+      let toollessContinuation: Message | undefined = continuation;
+      while (
+        toollessContinuation &&
+        (!toollessContinuation.tools || toollessContinuation.tools.length === 0)
+      ) {
+        assistantChain.push(toollessContinuation);
+        processedIds.add(toollessContinuation.id);
+
+        toollessContinuation = this.findFlatChainContinuation(
+          toollessContinuation,
+          [], // a toolless step owns no tool results
+          allMessages,
+          processedIds,
+          groupAgentId,
+        );
+      }
+
+      current = toollessContinuation;
     }
   }
 
@@ -408,29 +400,35 @@ export class MessageCollector {
     // Get the agentId of the first assistant in the group (the group owner)
     const agentId = groupAgentId ?? message.agentId;
 
-    // Get tool message IDs if this assistant has tools
-    const toolIds = idNode.children
-      .filter((child) => {
-        const childMsg = this.messageMap.get(child.id);
-        return childMsg?.role === 'tool';
-      })
-      .map((child) => child.id);
+    let currentMessage: Message | undefined = message;
+    let currentNode: IdNode | undefined = idNode;
 
-    // Add current assistant message node
-    const messageNode: MessageNode = {
-      id: message.id,
-      type: 'message',
-    };
-    if (toolIds.length > 0) {
-      messageNode.tools = toolIds;
-    }
-    children.push(messageNode);
+    // Walked as a loop, not recursion: a run's depth is its step count.
+    while (currentMessage && currentNode) {
+      // Get tool message IDs if this assistant has tools
+      const toolIds = currentNode.children
+        .filter((child) => {
+          const childMsg = this.messageMap.get(child.id);
+          return childMsg?.role === 'tool';
+        })
+        .map((child) => child.id);
 
-    // Find the next step's assistant (dual-form aware, see findChainContinuationNode)
-    const nextNode = this.findChainContinuationNode(idNode, agentId);
-    if (nextNode) {
-      const nextMsg = this.messageMap.get(nextNode.id)!;
-      this.collectAssistantGroupMessages(nextMsg, nextNode, children, agentId);
+      // Add current assistant message node
+      const messageNode: MessageNode = {
+        id: currentMessage.id,
+        type: 'message',
+      };
+      if (toolIds.length > 0) {
+        messageNode.tools = toolIds;
+      }
+      children.push(messageNode);
+
+      // Find the next step's assistant (dual-form aware, see findChainContinuationNode)
+      const nextNode = this.findChainContinuationNode(currentNode, agentId);
+      if (!nextNode) return;
+
+      currentMessage = this.messageMap.get(nextNode.id);
+      currentNode = nextNode;
     }
   }
 
@@ -501,60 +499,80 @@ export class MessageCollector {
     const blocks: SignalCallbacksNode[] = [];
     const visited = new Set<string>();
 
-    const walk = (node: IdNode): void => {
-      if (visited.has(node.id)) return;
-      visited.add(node.id);
+    const emitBlockFor = (toolNode: IdNode): void => {
+      // Gather callback-typed signal toolless siblings among this
+      // tool's children. `getMessageSignal` already returns undefined
+      // for tool-using assistants and non-assistants; `task-completion`
+      // turns are excluded here so they render outside the accordion
+      // (see `collectTaskCompletions`).
+      const callbacks: Message[] = [];
+      for (const toolChild of toolNode.children) {
+        const toolChildMsg = this.messageMap.get(toolChild.id);
+        if (!toolChildMsg) continue;
+        if (!isCallbackSignal(getMessageSignal(toolChildMsg))) continue;
+        callbacks.push(toolChildMsg);
+      }
 
-      for (const child of node.children) {
+      if (callbacks.length === 0) return;
+
+      // Sort by sequence; missing sequence sorts to the end.
+      callbacks.sort((a, b) => {
+        const sa = getMessageSignal(a)?.sequence ?? Number.POSITIVE_INFINITY;
+        const sb = getMessageSignal(b)?.sequence ?? Number.POSITIVE_INFINITY;
+        return sa - sb;
+      });
+      const first = getMessageSignal(callbacks[0])!;
+      blocks.push({
+        callbacks: callbacks.map((m) => ({ id: m.id, type: 'message' as const })),
+        id: `signalCallbacks-${toolNode.id}`,
+        sourceToolCallId: first.sourceToolCallId,
+        sourceToolMessageId: toolNode.id,
+        sourceToolName: first.sourceToolName,
+        type: 'signalCallbacks',
+      });
+    };
+
+    // Explicit task stack rather than recursion — a run's depth is its step
+    // count. Emitting a tool's block and descending into its follower are
+    // separate tasks so the original pre-order interleaving is preserved when a
+    // step owns more than one tool.
+    type SignalTask = { kind: 'emit'; toolNode: IdNode } | { kind: 'walk'; node: IdNode };
+    const stack: SignalTask[] = [{ kind: 'walk', node: idNode }];
+
+    while (stack.length > 0) {
+      const task = stack.pop()!;
+
+      if (task.kind === 'emit') {
+        emitBlockFor(task.toolNode);
+        continue;
+      }
+
+      if (visited.has(task.node.id)) continue;
+      visited.add(task.node.id);
+
+      const scheduled: SignalTask[] = [];
+      for (const child of task.node.children) {
         const childMsg = this.messageMap.get(child.id);
         if (childMsg?.role !== 'tool') continue;
 
-        // Gather callback-typed signal toolless siblings among this
-        // tool's children. `getMessageSignal` already returns undefined
-        // for tool-using assistants and non-assistants; `task-completion`
-        // turns are excluded here so they render outside the accordion
-        // (see `collectTaskCompletions`).
-        const callbacks: Message[] = [];
-        for (const toolChild of child.children) {
-          const toolChildMsg = this.messageMap.get(toolChild.id);
-          if (!toolChildMsg) continue;
-          if (!isCallbackSignal(getMessageSignal(toolChildMsg))) continue;
-          callbacks.push(toolChildMsg);
-        }
+        scheduled.push({ kind: 'emit', toolNode: child });
 
-        if (callbacks.length > 0) {
-          // Sort by sequence; missing sequence sorts to the end.
-          callbacks.sort((a, b) => {
-            const sa = getMessageSignal(a)?.sequence ?? Number.POSITIVE_INFINITY;
-            const sb = getMessageSignal(b)?.sequence ?? Number.POSITIVE_INFINITY;
-            return sa - sb;
-          });
-          const first = getMessageSignal(callbacks[0])!;
-          blocks.push({
-            callbacks: callbacks.map((m) => ({ id: m.id, type: 'message' as const })),
-            id: `signalCallbacks-${child.id}`,
-            sourceToolCallId: first.sourceToolCallId,
-            sourceToolMessageId: child.id,
-            sourceToolName: first.sourceToolName,
-            type: 'signalCallbacks',
-          });
-        }
-
-        // Continue walking the main chain — recurse into the next
-        // main-chain follower under this tool (skipping signal
-        // callbacks, just like `collectAssistantGroupMessages` does).
+        // Continue walking the main chain — descend into the next main-chain
+        // follower under this tool (skipping signal callbacks, just like
+        // `collectAssistantGroupMessages` does).
         for (const nextChild of child.children) {
           const nextMsg = this.messageMap.get(nextChild.id);
           if (nextMsg?.role !== 'assistant') continue;
           if (nextMsg.agentId !== groupAgentId) continue;
           if (getMessageSignal(nextMsg)) continue;
-          walk(nextChild);
+          scheduled.push({ kind: 'walk', node: nextChild });
           break;
         }
       }
-    };
 
-    walk(idNode);
+      for (let i = scheduled.length - 1; i >= 0; i--) stack.push(scheduled[i]);
+    }
+
     return blocks;
   }
 
@@ -580,37 +598,54 @@ export class MessageCollector {
     const nodes: MessageNode[] = [];
     const visited = new Set<string>();
 
-    const walk = (node: IdNode): void => {
-      if (visited.has(node.id)) return;
-      visited.add(node.id);
+    const emitCompletionsFor = (toolNode: IdNode): void => {
+      for (const toolChild of toolNode.children) {
+        const toolChildMsg = this.messageMap.get(toolChild.id);
+        if (!toolChildMsg) continue;
+        if (toolChildMsg.agentId !== groupAgentId) continue;
+        if (!isTaskCompletionSignal(getMessageSignal(toolChildMsg))) continue;
+        nodes.push({ id: toolChildMsg.id, type: 'message' });
+      }
+    };
 
-      for (const child of node.children) {
+    // Explicit task stack rather than recursion — see collectSignalCallbacks for
+    // why emit and descend are separate tasks.
+    type CompletionTask = { kind: 'emit'; toolNode: IdNode } | { kind: 'walk'; node: IdNode };
+    const stack: CompletionTask[] = [{ kind: 'walk', node: idNode }];
+
+    while (stack.length > 0) {
+      const task = stack.pop()!;
+
+      if (task.kind === 'emit') {
+        emitCompletionsFor(task.toolNode);
+        continue;
+      }
+
+      if (visited.has(task.node.id)) continue;
+      visited.add(task.node.id);
+
+      const scheduled: CompletionTask[] = [];
+      for (const child of task.node.children) {
         const childMsg = this.messageMap.get(child.id);
         if (childMsg?.role !== 'tool') continue;
 
-        for (const toolChild of child.children) {
-          const toolChildMsg = this.messageMap.get(toolChild.id);
-          if (!toolChildMsg) continue;
-          if (toolChildMsg.agentId !== groupAgentId) continue;
-          if (!isTaskCompletionSignal(getMessageSignal(toolChildMsg))) continue;
-          nodes.push({ id: toolChildMsg.id, type: 'message' });
-        }
+        scheduled.push({ kind: 'emit', toolNode: child });
 
-        // Continue walking the main chain into the next non-signal
-        // follower under this tool (same skip rule as
-        // `collectAssistantGroupMessages`).
+        // Continue walking the main chain into the next non-signal follower
+        // under this tool (same skip rule as `collectAssistantGroupMessages`).
         for (const nextChild of child.children) {
           const nextMsg = this.messageMap.get(nextChild.id);
           if (nextMsg?.role !== 'assistant') continue;
           if (nextMsg.agentId !== groupAgentId) continue;
           if (getMessageSignal(nextMsg)) continue;
-          walk(nextChild);
+          scheduled.push({ kind: 'walk', node: nextChild });
           break;
         }
       }
-    };
 
-    walk(idNode);
+      for (let i = scheduled.length - 1; i >= 0; i--) stack.push(scheduled[i]);
+    }
+
     return nodes;
   }
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Related to #16496 — addresses the crash reported in the profiling comment on that thread. Does not close it; the store normalisation the issue asks for is a separate question.

#### 🔀 Description of Change

Every user turn parents off the previous assistant (`publicApi.ts` sets `parentId = lastDisplayMessageId`), so a conversation's message "tree" is really a linked list whose **depth equals its length**. Seven walks recursed per node, and `parse()` threw `RangeError: Maximum call stack size exceeded` at roughly **1.6k messages** — reachable from a default 1k-row page plus a live streaming session.

Converted to explicit stacks / loops:

| walk | shape |
| --- | --- |
| `FlatListBuilder.flatten` | frame stack |
| `structuring.buildIdTree` | node stack |
| `ContextTreeBuilder.transformToLinear` | returns continuations, driven by a stack |
| `MessageCollector.collectAssistantChain` | tail recursion → loop |
| `MessageCollector.collectAssistantGroupMessages` | tail recursion → loop |
| `MessageCollector.collectSignalCallbacks` | task stack |
| `MessageCollector.collectTaskCompletions` | task stack |

The last two needed care: their inner `walk` resumes its sibling loop *after* descending, so it is not a tail call. Pushing nodes directly would reorder output from `emit(c0) → subtree(c0) → emit(c1)` to `emit(c0) → emit(c1) → subtree(c0)`. Emit and descend are separate task kinds so the original pre-order interleaving is exact.

This also deletes `buildFlatListRecursiveForChild`, which expressed "recurse into just this one child" by temporarily overwriting the shared `childrenMap` and restoring it in a `finally`. A frame carrying an explicit `childIds` array says the same thing without mutating a shared index mid-traversal.

**Result:** a normal conversation parses at **100k messages**; a single unbroken tool run at **3k steps**.

**One bounded walk remains,** deliberately. A branch node's output is itself nested (`branches: ContextNode[][]`), so `createBranchNode` re-enters the linear walk per branch. It holds to ~800 nesting levels — i.e. regenerating at 800 consecutive turns — and fails around 1600. Converting it means restructuring output assembly, not just traversal, for a topology far less likely than the plain long conversation this PR fixes. The test pins 500 levels so the ceiling cannot silently drop, with the measured numbers in a comment.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

`deepChain.test.ts` fails on the parent commit with `RangeError` and passes here. It covers a 6k-row linked chain, the same with tools, chain ordering, contextTree construction, a 3k-step single run, and the nested-branch ceiling.

Behaviour is unchanged: **all 27 full-shape golden fixtures compare byte-identical.** Consumers (`src/features/Conversation/store`, `src/store/chat/slices/message`) 390 passing; full monorepo shows no new failures.

#### 📝 Additional Information

Second of three stacked PRs — **based on #17394, not on `canary`.** Please merge that one first; GitHub should retarget this to `canary` automatically when it does.

Worth noting the original issue thread named only `FlatListBuilder.buildFlatListRecursive`. Fixing just that one moves the ceiling from ~1.6k to ~2.4k messages; the other six are what actually get you to 100k.