### PR TITLE
⚡️ perf(conversation-flow): dispatch by handler ladder, index instead of scan

### DIFF
--- a/packages/conversation-flow/src/transformation/FlatListBuilder.ts
+++ b/packages/conversation-flow/src/transformation/FlatListBuilder.ts
@@ -37,6 +37,30 @@ type TraversalFrame =
   | { kind: 'continuation'; parentIds: string[] };
 
 /**
+ * Per-message scratch space for one ladder run. `childIds` / `nonToolChildIds`
+ * are filled in by the first handler that needs them, so shapes that resolve
+ * before the branch handlers never pay for the lookup.
+ */
+interface DispatchContext {
+  allMessages: Message[];
+  childIds?: string[];
+  flatList: Message[];
+  nonToolChildIds?: string[];
+  processedIds: Set<string>;
+}
+
+/**
+ * One recognisable message shape. `match` decides whether this shape claims the
+ * message; `handle` emits its row(s), marks whatever raw messages it swallowed,
+ * and returns the frames the walk continues into.
+ */
+interface FlatNodeHandler {
+  handle: (message: Message, ctx: DispatchContext) => TraversalFrame[];
+  match: (message: Message, ctx: DispatchContext) => boolean;
+  name: string;
+}
+
+/**
  * FlatListBuilder - Builds flat message list following the active path
  *
  * Handles:
@@ -52,7 +76,15 @@ export class FlatListBuilder {
     private branchResolver: BranchResolver,
     private messageCollector: MessageCollector,
     private messageTransformer: MessageTransformer,
-  ) {}
+  ) {
+    this.ladders = this.buildLadders();
+  }
+
+  /**
+   * Priority ladders, most specific shape first. Built once — handlers close
+   * over `this`, so they must not be constructed before the fields they use.
+   */
+  private readonly ladders: Record<LadderKind, FlatNodeHandler[]>;
 
   /**
    * Generate flatList from messages array
@@ -173,6 +205,11 @@ export class FlatListBuilder {
     }
   }
 
+  /**
+   * Run a message through a ladder: the first handler whose `match` accepts it
+   * claims it, emits its row(s), marks whatever raw messages it swallowed, and
+   * returns where the walk continues.
+   */
   private dispatch(
     ladder: LadderKind,
     message: Message,
@@ -180,17 +217,366 @@ export class FlatListBuilder {
     processedIds: Set<string>,
     allMessages: Message[],
   ): TraversalFrame[] {
-    switch (ladder) {
-      case 'taskSibling': {
-        return this.dispatchTaskSibling(message, flatList, processedIds, allMessages);
-      }
-      case 'taskGrandchild': {
-        return this.dispatchTaskGrandchild(message, flatList, processedIds, allMessages);
-      }
-      default: {
-        return this.dispatchMessage(message, flatList, processedIds, allMessages);
-      }
+    const ctx: DispatchContext = { allMessages, flatList, processedIds };
+
+    for (const handler of this.ladders[ladder]) {
+      if (handler.match(message, ctx)) return handler.handle(message, ctx);
     }
+
+    return [];
+  }
+
+  /**
+   * Branch candidates for the current message, computed at most once per
+   * dispatch. Tool children are inline data of their assistant, never a sibling
+   * branch (dual-form reader invariant), so they are excluded.
+   */
+  private branchCandidates(
+    message: Message,
+    ctx: DispatchContext,
+  ): { childIds: string[]; nonToolChildIds: string[] } {
+    if (!ctx.childIds || !ctx.nonToolChildIds) {
+      ctx.childIds = this.childrenMap.get(message.id) ?? [];
+      ctx.nonToolChildIds = ctx.childIds.filter(
+        (childId) => this.messageMap.get(childId)?.role !== 'tool',
+      );
+    }
+
+    return { childIds: ctx.childIds, nonToolChildIds: ctx.nonToolChildIds };
+  }
+
+  private compareGroupOf(message: Message): MessageGroupMetadata | undefined {
+    return message.groupId ? this.messageGroupMap.get(message.groupId) : undefined;
+  }
+
+  /** Priority 1: a manually grouped compare turn. */
+  private handleCompareGroup(message: Message, ctx: DispatchContext): TraversalFrame[] {
+    const messageGroup = this.compareGroupOf(message)!;
+    const groupMembers = this.messageCollector.collectGroupMembers(
+      message.groupId!,
+      ctx.allMessages,
+    );
+    const compareMessage = this.createCompareMessage(messageGroup, groupMembers);
+    ctx.flatList.push(compareMessage);
+    groupMembers.forEach((m) => ctx.processedIds.add(m.id));
+    ctx.processedIds.add(messageGroup.id);
+
+    const activeColumnId = (compareMessage as any).activeColumnId;
+    return activeColumnId ? [this.childrenFrame(activeColumnId)] : [];
+  }
+
+  /**
+   * Priority 2: an assistant turn plus its tool steps, collapsed into one group
+   * bubble — together with the signal callbacks, post-task summaries and council
+   * block that belong inside it.
+   */
+  private handleAssistantGroup(message: Message, ctx: DispatchContext): TraversalFrame[] {
+    const assistantChain: Message[] = [];
+    const allToolMessages: Message[] = [];
+    this.messageCollector.collectAssistantChain(
+      message,
+      ctx.allMessages,
+      assistantChain,
+      allToolMessages,
+      ctx.processedIds,
+    );
+
+    // Callback blocks for any tool in the chain that fired toolless reactive
+    // replies (Monitor stdout pushes, etc.). Snapshot now so the UI doesn't need
+    // to query messageMap.
+    const signalBlocks = this.messageCollector.collectFlatSignalCallbacks(
+      allToolMessages,
+      ctx.allMessages,
+    );
+
+    // Post-task summaries — toolless siblings of the callbacks under the same
+    // tool_result, rendered AFTER the SignalCallbacks accordion.
+    const taskCompletionMessages = this.messageCollector.collectFlatTaskCompletions(
+      allToolMessages,
+      ctx.allMessages,
+    );
+
+    const council = this.collectCouncilMembers(allToolMessages, ctx.allMessages, ctx.processedIds);
+
+    ctx.flatList.push(
+      this.createAssistantGroupMessage(
+        assistantChain[0],
+        assistantChain,
+        allToolMessages,
+        signalBlocks,
+        taskCompletionMessages,
+        council?.members,
+      ),
+    );
+
+    assistantChain.forEach((m) => ctx.processedIds.add(m.id));
+    allToolMessages.forEach((m) => ctx.processedIds.add(m.id));
+    for (const block of signalBlocks) {
+      for (const cb of block.callbacks) ctx.processedIds.add(cb.id);
+    }
+    for (const completion of taskCompletionMessages) {
+      ctx.processedIds.add(completion.id);
+    }
+
+    const frames: TraversalFrame[] = [];
+    // Surface the supervisor's post-council reply (attached to one member).
+    if (council) {
+      for (const memberId of council.memberIds) frames.push(this.childrenFrame(memberId));
+    }
+    frames.push(this.continuationFrame(assistantChain, allToolMessages));
+    return frames;
+  }
+
+  /**
+   * The same group bubble without the top-level extras — the shape the tasks
+   * follow-up paths have always emitted. Kept distinct from
+   * {@link handleAssistantGroup} because collapsing the two would change output.
+   */
+  private handleSimpleAssistantGroup(message: Message, ctx: DispatchContext): TraversalFrame[] {
+    const assistantChain: Message[] = [];
+    const allToolMessages: Message[] = [];
+    this.messageCollector.collectAssistantChain(
+      message,
+      ctx.allMessages,
+      assistantChain,
+      allToolMessages,
+      ctx.processedIds,
+    );
+
+    const council = this.collectCouncilMembers(allToolMessages, ctx.allMessages, ctx.processedIds);
+
+    ctx.flatList.push(
+      this.createAssistantGroupMessage(
+        assistantChain[0],
+        assistantChain,
+        allToolMessages,
+        undefined,
+        undefined,
+        council?.members,
+      ),
+    );
+
+    assistantChain.forEach((m) => ctx.processedIds.add(m.id));
+    allToolMessages.forEach((m) => ctx.processedIds.add(m.id));
+
+    const frames: TraversalFrame[] = [];
+    if (council) {
+      for (const memberId of council.memberIds) frames.push(this.childrenFrame(memberId));
+    }
+    frames.push(this.continuationFrame(assistantChain, allToolMessages));
+    return frames;
+  }
+
+  /** Priority 2b: a supervisor turn with no tools — content moves into children. */
+  private handleSupervisorContent(message: Message, ctx: DispatchContext): TraversalFrame[] {
+    ctx.flatList.push(this.createSupervisorContentMessage(message));
+    ctx.processedIds.add(message.id);
+    return [this.childrenFrame(message.id)];
+  }
+
+  /** Priority 3a: compare mode declared on the user message itself. */
+  private handleCompareMetadata(message: Message, ctx: DispatchContext): TraversalFrame[] {
+    const { childIds } = this.branchCandidates(message, ctx);
+
+    ctx.flatList.push(message);
+    ctx.processedIds.add(message.id);
+
+    const compareMessage = this.createCompareMessageFromChildIds(
+      message,
+      childIds,
+      ctx.allMessages,
+      ctx.processedIds,
+    );
+    ctx.flatList.push(compareMessage);
+
+    const activeColumnId = (compareMessage as any).activeColumnId;
+    return activeColumnId ? [this.childrenFrame(activeColumnId)] : [];
+  }
+
+  /**
+   * Priority 3d: a user turn with several assistant replies. The branch marker
+   * goes on the active child, not on the user message.
+   */
+  private handleUserBranch(message: Message, ctx: DispatchContext): TraversalFrame[] {
+    const { nonToolChildIds } = this.branchCandidates(message, ctx);
+    const activeBranchId = this.branchResolver.getActiveBranchIdFromMetadata(
+      message,
+      nonToolChildIds,
+      this.childrenMap,
+    );
+
+    ctx.flatList.push(message);
+    ctx.processedIds.add(message.id);
+
+    // Optimistic update: the active branch has not been created yet.
+    if (!activeBranchId) return [];
+
+    const activeBranchIndex = nonToolChildIds.indexOf(activeBranchId);
+    const activeBranchMsg = this.messageMap.get(activeBranchId);
+    if (!activeBranchMsg) return [];
+
+    // An active branch that uses tools still renders as a group bubble.
+    if (
+      activeBranchMsg.role === 'assistant' &&
+      activeBranchMsg.tools &&
+      activeBranchMsg.tools.length > 0
+    ) {
+      const assistantChain: Message[] = [];
+      const allToolMessages: Message[] = [];
+      this.messageCollector.collectAssistantChain(
+        activeBranchMsg,
+        ctx.allMessages,
+        assistantChain,
+        allToolMessages,
+        ctx.processedIds,
+      );
+
+      const groupMessage = this.createAssistantGroupMessage(
+        assistantChain[0],
+        assistantChain,
+        allToolMessages,
+      );
+      ctx.flatList.push(
+        this.createMessageWithBranches(groupMessage, nonToolChildIds.length, activeBranchIndex),
+      );
+
+      assistantChain.forEach((m) => ctx.processedIds.add(m.id));
+      allToolMessages.forEach((m) => ctx.processedIds.add(m.id));
+
+      return [this.continuationFrame(assistantChain, allToolMessages)];
+    }
+
+    ctx.flatList.push(
+      this.createMessageWithBranches(activeBranchMsg, nonToolChildIds.length, activeBranchIndex),
+    );
+    ctx.processedIds.add(activeBranchId);
+    return [this.childrenFrame(activeBranchId)];
+  }
+
+  /** Priority 3e: an assistant turn with several user follow-ups. */
+  private handleAssistantBranch(message: Message, ctx: DispatchContext): TraversalFrame[] {
+    const { nonToolChildIds } = this.branchCandidates(message, ctx);
+    const activeBranchId = this.branchResolver.getActiveBranchIdFromMetadata(
+      message,
+      nonToolChildIds,
+      this.childrenMap,
+    );
+
+    ctx.flatList.push(message);
+    ctx.processedIds.add(message.id);
+
+    // Optimistic update: the active branch has not been created yet.
+    if (!activeBranchId) return [];
+
+    const activeBranchIndex = nonToolChildIds.indexOf(activeBranchId);
+    const activeBranchMsg = this.messageMap.get(activeBranchId);
+    if (!activeBranchMsg) return [];
+
+    ctx.flatList.push(
+      this.createMessageWithBranches(activeBranchMsg, nonToolChildIds.length, activeBranchIndex),
+    );
+    ctx.processedIds.add(activeBranchId);
+    return [this.childrenFrame(activeBranchId)];
+  }
+
+  /** Priority 4: anything else renders as itself. */
+  private handleRegularMessage(message: Message, ctx: DispatchContext): TraversalFrame[] {
+    ctx.flatList.push(message);
+    ctx.processedIds.add(message.id);
+    return [this.childrenFrame(message.id)];
+  }
+
+  private buildLadders(): Record<LadderKind, FlatNodeHandler[]> {
+    const compareGroup: FlatNodeHandler = {
+      handle: (message, ctx) => this.handleCompareGroup(message, ctx),
+      match: (message, ctx) => {
+        const group = this.compareGroupOf(message);
+        return !!group && group.mode === 'compare' && !ctx.processedIds.has(group.id);
+      },
+      name: 'compareGroup',
+    };
+
+    // A toolless narration step that heads a tool-using chain must seed the group
+    // instead of splitting into its own bubble. Supervisors are excluded so they
+    // still fall through to supervisorContent.
+    const assistantGroup: FlatNodeHandler = {
+      handle: (message, ctx) => this.handleAssistantGroup(message, ctx),
+      match: (message) =>
+        message.role === 'assistant' &&
+        ((!!message.tools && message.tools.length > 0) ||
+          (!isSupervisorMessage(message) && this.messageCollector.isToolChainHead(message))),
+      name: 'assistantGroup',
+    };
+
+    const simpleAssistantGroup: FlatNodeHandler = {
+      handle: (message, ctx) => this.handleSimpleAssistantGroup(message, ctx),
+      match: (message) =>
+        message.role === 'assistant' && !!message.tools && message.tools.length > 0,
+      name: 'simpleAssistantGroup',
+    };
+
+    const supervisorContent: FlatNodeHandler = {
+      handle: (message, ctx) => this.handleSupervisorContent(message, ctx),
+      match: (message) =>
+        message.role === 'assistant' &&
+        isSupervisorMessage(message) &&
+        (!message.tools || message.tools.length === 0),
+      name: 'supervisorContent',
+    };
+
+    const compareMetadata: FlatNodeHandler = {
+      handle: (message, ctx) => this.handleCompareMetadata(message, ctx),
+      match: (message, ctx) =>
+        this.isCompareMode(message) && this.branchCandidates(message, ctx).childIds.length > 1,
+      name: 'compareMetadata',
+    };
+
+    const userBranch: FlatNodeHandler = {
+      handle: (message, ctx) => this.handleUserBranch(message, ctx),
+      match: (message, ctx) =>
+        message.role === 'user' && this.branchCandidates(message, ctx).nonToolChildIds.length > 1,
+      name: 'userBranch',
+    };
+
+    const assistantBranch: FlatNodeHandler = {
+      handle: (message, ctx) => this.handleAssistantBranch(message, ctx),
+      match: (message, ctx) =>
+        message.role === 'assistant' &&
+        this.branchCandidates(message, ctx).nonToolChildIds.length > 1,
+      name: 'assistantBranch',
+    };
+
+    const regularMessage: FlatNodeHandler = {
+      handle: (message, ctx) => this.handleRegularMessage(message, ctx),
+      match: () => true,
+      name: 'regularMessage',
+    };
+
+    // A task row is emitted as part of its aggregated `tasks` bubble, never again
+    // as a standalone row.
+    const skipTask: FlatNodeHandler = {
+      handle: () => [],
+      match: (message) => message.role === 'task',
+      name: 'skipTask',
+    };
+
+    return {
+      full: [
+        compareGroup,
+        assistantGroup,
+        supervisorContent,
+        compareMetadata,
+        userBranch,
+        assistantBranch,
+        regularMessage,
+      ],
+      // Narrower on purpose — these mirror the two inline ladders the recursive
+      // implementation carried for tasks follow-ups. They differ from each other
+      // (only grandchildren open a supervisor bubble); unifying them would be a
+      // behaviour change, not a refactor.
+      taskGrandchild: [skipTask, simpleAssistantGroup, supervisorContent, regularMessage],
+      taskSibling: [simpleAssistantGroup, regularMessage],
+    };
   }
 
   /**
@@ -253,322 +639,6 @@ export class FlatListBuilder {
     }
 
     return followUps;
-  }
-
-  private dispatchTaskSibling(
-    message: Message,
-    flatList: Message[],
-    processedIds: Set<string>,
-    allMessages: Message[],
-  ): TraversalFrame[] {
-    if (message.role === 'assistant' && message.tools && message.tools.length > 0) {
-      return this.emitAssistantGroup(message, flatList, processedIds, allMessages);
-    }
-
-    flatList.push(message);
-    processedIds.add(message.id);
-    return [this.childrenFrame(message.id)];
-  }
-
-  private dispatchTaskGrandchild(
-    message: Message,
-    flatList: Message[],
-    processedIds: Set<string>,
-    allMessages: Message[],
-  ): TraversalFrame[] {
-    if (message.role === 'task') return [];
-
-    if (message.role === 'assistant' && message.tools && message.tools.length > 0) {
-      return this.emitAssistantGroup(message, flatList, processedIds, allMessages);
-    }
-
-    if (
-      message.role === 'assistant' &&
-      isSupervisorMessage(message) &&
-      (!message.tools || message.tools.length === 0)
-    ) {
-      flatList.push(this.createSupervisorContentMessage(message));
-      processedIds.add(message.id);
-      return [this.childrenFrame(message.id)];
-    }
-
-    flatList.push(message);
-    processedIds.add(message.id);
-    return [this.childrenFrame(message.id)];
-  }
-
-  /**
-   * AssistantGroup without the top-level extras (signal callbacks, task
-   * completions) — the shape the tasks follow-up path has always emitted.
-   */
-  private emitAssistantGroup(
-    message: Message,
-    flatList: Message[],
-    processedIds: Set<string>,
-    allMessages: Message[],
-  ): TraversalFrame[] {
-    const assistantChain: Message[] = [];
-    const allToolMessages: Message[] = [];
-    this.messageCollector.collectAssistantChain(
-      message,
-      allMessages,
-      assistantChain,
-      allToolMessages,
-      processedIds,
-    );
-
-    const council = this.collectCouncilMembers(allToolMessages, allMessages, processedIds);
-
-    const groupMessage = this.createAssistantGroupMessage(
-      assistantChain[0],
-      assistantChain,
-      allToolMessages,
-      undefined,
-      undefined,
-      council?.members,
-    );
-    flatList.push(groupMessage);
-
-    assistantChain.forEach((m) => processedIds.add(m.id));
-    allToolMessages.forEach((m) => processedIds.add(m.id));
-
-    const frames: TraversalFrame[] = [];
-    if (council) {
-      for (const memberId of council.memberIds) frames.push(this.childrenFrame(memberId));
-    }
-    frames.push(this.continuationFrame(assistantChain, allToolMessages));
-    return frames;
-  }
-
-  /**
-   * Top-level priority ladder: the first shape that matches claims the message,
-   * emits its row(s), marks the raw messages it swallowed, and returns where the
-   * walk resumes.
-   */
-  private dispatchMessage(
-    message: Message,
-    flatList: Message[],
-    processedIds: Set<string>,
-    allMessages: Message[],
-  ): TraversalFrame[] {
-    // Priority 1: Compare message group
-    const messageGroup = message.groupId ? this.messageGroupMap.get(message.groupId) : undefined;
-
-    if (messageGroup && messageGroup.mode === 'compare' && !processedIds.has(messageGroup.id)) {
-      const groupMembers = this.messageCollector.collectGroupMembers(message.groupId!, allMessages);
-      const compareMessage = this.createCompareMessage(messageGroup, groupMembers);
-      flatList.push(compareMessage);
-      groupMembers.forEach((m) => processedIds.add(m.id));
-      processedIds.add(messageGroup.id);
-
-      // Continue with active column's children (if any)
-      const activeColumnId = (compareMessage as any).activeColumnId;
-      return activeColumnId ? [this.childrenFrame(activeColumnId)] : [];
-    }
-
-    // Priority 2: AssistantGroup (assistant + tools), or the toolless
-    // narration step that heads a tool-using chain — the latter must seed the
-    // group instead of splitting into its own standalone bubble. Supervisors
-    // are excluded from the toolless-head path so they still fall to 2b.
-    if (
-      message.role === 'assistant' &&
-      ((message.tools && message.tools.length > 0) ||
-        (!isSupervisorMessage(message) && this.messageCollector.isToolChainHead(message)))
-    ) {
-      const assistantChain: Message[] = [];
-      const allToolMessages: Message[] = [];
-      this.messageCollector.collectAssistantChain(
-        message,
-        allMessages,
-        assistantChain,
-        allToolMessages,
-        processedIds,
-      );
-
-      // Gather external-signal callback blocks for any tool in the chain that
-      // fired toolless reactive replies (Monitor stdout pushes, etc.). Snapshot
-      // now so the UI doesn't need to query messageMap.
-      const signalBlocks = this.messageCollector.collectFlatSignalCallbacks(
-        allToolMessages,
-        allMessages,
-      );
-
-      // Post-task-summary turns — toolless siblings of the callbacks under the
-      // same tool_result, rendered AFTER the SignalCallbacks accordion.
-      const taskCompletionMessages = this.messageCollector.collectFlatTaskCompletions(
-        allToolMessages,
-        allMessages,
-      );
-
-      // A broadcast turn renders its members as one in-bubble council block.
-      const council = this.collectCouncilMembers(allToolMessages, allMessages, processedIds);
-
-      const groupMessage = this.createAssistantGroupMessage(
-        assistantChain[0],
-        assistantChain,
-        allToolMessages,
-        signalBlocks,
-        taskCompletionMessages,
-        council?.members,
-      );
-      flatList.push(groupMessage);
-
-      assistantChain.forEach((m) => processedIds.add(m.id));
-      allToolMessages.forEach((m) => processedIds.add(m.id));
-      for (const block of signalBlocks) {
-        for (const cb of block.callbacks) processedIds.add(cb.id);
-      }
-      for (const completion of taskCompletionMessages) {
-        processedIds.add(completion.id);
-      }
-
-      const frames: TraversalFrame[] = [];
-      // Surface the supervisor's post-council reply (attached to one member).
-      if (council) {
-        for (const memberId of council.memberIds) frames.push(this.childrenFrame(memberId));
-      }
-      frames.push(this.continuationFrame(assistantChain, allToolMessages));
-      return frames;
-    }
-
-    // Priority 2b: Supervisor message without tools (content-only)
-    // Transform to supervisor role with content in children array
-    if (
-      message.role === 'assistant' &&
-      isSupervisorMessage(message) &&
-      (!message.tools || message.tools.length === 0)
-    ) {
-      flatList.push(this.createSupervisorContentMessage(message));
-      processedIds.add(message.id);
-      return [this.childrenFrame(message.id)];
-    }
-
-    // Priority 3a: Compare mode from user message metadata
-    const childMessages = this.childrenMap.get(message.id) ?? [];
-    // Non-tool children only are branch candidates (dual-form reader invariant: tool children are inline, not branches):
-    // a tool child is inline data of its assistant, never a sibling branch.
-    const nonToolChildMessages = childMessages.filter(
-      (childId) => this.messageMap.get(childId)?.role !== 'tool',
-    );
-
-    if (this.isCompareMode(message) && childMessages.length > 1) {
-      flatList.push(message);
-      processedIds.add(message.id);
-
-      const compareMessage = this.createCompareMessageFromChildIds(
-        message,
-        childMessages,
-        allMessages,
-        processedIds,
-      );
-      flatList.push(compareMessage);
-
-      const activeColumnId = (compareMessage as any).activeColumnId;
-      return activeColumnId ? [this.childrenFrame(activeColumnId)] : [];
-    }
-
-    // Priority 3d: User message with branches (multiple assistant children)
-    // Branch indicator should be on the active assistant child message
-    if (message.role === 'user' && nonToolChildMessages.length > 1) {
-      const activeBranchId = this.branchResolver.getActiveBranchIdFromMetadata(
-        message,
-        nonToolChildMessages,
-        this.childrenMap,
-      );
-
-      flatList.push(message);
-      processedIds.add(message.id);
-
-      // Optimistic update: activeBranchId is undefined when branch is being created
-      if (!activeBranchId) return [];
-
-      const activeBranchIndex = nonToolChildMessages.indexOf(activeBranchId);
-      const activeBranchMsg = this.messageMap.get(activeBranchId);
-      if (!activeBranchMsg) return [];
-
-      // Check if active branch is assistant with tools (should be assistantGroup)
-      if (
-        activeBranchMsg.role === 'assistant' &&
-        activeBranchMsg.tools &&
-        activeBranchMsg.tools.length > 0
-      ) {
-        const assistantChain: Message[] = [];
-        const allToolMessages: Message[] = [];
-        this.messageCollector.collectAssistantChain(
-          activeBranchMsg,
-          allMessages,
-          assistantChain,
-          allToolMessages,
-          processedIds,
-        );
-
-        const groupMessage = this.createAssistantGroupMessage(
-          assistantChain[0],
-          assistantChain,
-          allToolMessages,
-        );
-        flatList.push(
-          this.createMessageWithBranches(
-            groupMessage,
-            nonToolChildMessages.length,
-            activeBranchIndex,
-          ),
-        );
-
-        assistantChain.forEach((m) => processedIds.add(m.id));
-        allToolMessages.forEach((m) => processedIds.add(m.id));
-
-        return [this.continuationFrame(assistantChain, allToolMessages)];
-      }
-
-      // Regular assistant message (not assistantGroup) - add branch info
-      flatList.push(
-        this.createMessageWithBranches(
-          activeBranchMsg,
-          nonToolChildMessages.length,
-          activeBranchIndex,
-        ),
-      );
-      processedIds.add(activeBranchId);
-      return [this.childrenFrame(activeBranchId)];
-    }
-
-    // Priority 3e: Assistant message with branches (multiple user children)
-    // Branch indicator should be on the active user child message
-    if (message.role === 'assistant' && nonToolChildMessages.length > 1) {
-      const activeBranchId = this.branchResolver.getActiveBranchIdFromMetadata(
-        message,
-        nonToolChildMessages,
-        this.childrenMap,
-      );
-
-      // Add the assistant message without branch (branch goes on the child)
-      flatList.push(message);
-      processedIds.add(message.id);
-
-      // Optimistic update: activeBranchId is undefined when branch is being created
-      if (!activeBranchId) return [];
-
-      const activeBranchIndex = nonToolChildMessages.indexOf(activeBranchId);
-      const activeBranchMsg = this.messageMap.get(activeBranchId);
-      if (!activeBranchMsg) return [];
-
-      // Add branch info to the active user child message
-      flatList.push(
-        this.createMessageWithBranches(
-          activeBranchMsg,
-          nonToolChildMessages.length,
-          activeBranchIndex,
-        ),
-      );
-      processedIds.add(activeBranchId);
-      return [this.childrenFrame(activeBranchId)];
-    }
-
-    // Priority 4: Regular message
-    flatList.push(message);
-    processedIds.add(message.id);
-    return [this.childrenFrame(message.id)];
   }
 
   /**

--- a/packages/conversation-flow/src/transformation/MessageCollector.ts
+++ b/packages/conversation-flow/src/transformation/MessageCollector.ts
@@ -60,6 +60,47 @@ export class MessageCollector {
     private branchResolver: BranchResolver = new BranchResolver(),
   ) {}
 
+  /** Lazily built id -> position, mirroring the order messages were indexed in. */
+  private orderIndex?: Map<string, number>;
+
+  /**
+   * Children of a message, in creation order. `childrenMap` is built in one
+   * linear pass, so this replaces a full-array `.filter(m => m.parentId === id)`
+   * — the scan that made chain walking quadratic.
+   */
+  private childrenOf(parentId: string): Message[] {
+    const childIds = this.childrenMap.get(parentId);
+    if (!childIds || childIds.length === 0) return [];
+
+    const children: Message[] = [];
+    for (const childId of childIds) {
+      const child = this.messageMap.get(childId);
+      if (child) children.push(child);
+    }
+    return children;
+  }
+
+  /**
+   * Position of a message in the original array.
+   *
+   * Candidates used to be gathered by filtering that array, so a `createdAt`
+   * sort broke ties in array order. Gathering per parent instead loses that
+   * order across parents, so it is restored explicitly as the tie-breaker.
+   */
+  private orderOf(id: string): number {
+    if (!this.orderIndex) {
+      this.orderIndex = new Map();
+      let position = 0;
+      for (const messageId of this.messageMap.keys()) {
+        this.orderIndex.set(messageId, position++);
+      }
+    }
+    return this.orderIndex.get(id) ?? 0;
+  }
+
+  private byCreatedAtThenOrder = (a: Message, b: Message): number =>
+    a.createdAt - b.createdAt || this.orderOf(a.id) - this.orderOf(b.id);
+
   /**
    * Collect all messages belonging to a message group
    */
@@ -70,21 +111,20 @@ export class MessageCollector {
   /**
    * Collect tool messages related to an assistant message
    */
-  collectToolMessages(assistant: Message, messages: Message[]): Message[] {
+  collectToolMessages(assistant: Message, _messages: Message[]): Message[] {
     const tools = assistant.tools || [];
     if (tools.length === 0) return [];
 
-    const toolMessagesById = new Map(
-      messages.filter((m) => m.role === 'tool').map((m) => [m.id, m]),
-    );
     const collected: Message[] = [];
     const collectedIds = new Set<string>();
 
     for (const tool of tools) {
       const explicitResultId = tool.result_msg_id;
-      const explicitToolMessage = explicitResultId
-        ? toolMessagesById.get(explicitResultId)
+      const explicitCandidate = explicitResultId
+        ? this.messageMap.get(explicitResultId)
         : undefined;
+      const explicitToolMessage =
+        explicitCandidate?.role === 'tool' ? explicitCandidate : undefined;
 
       if (explicitToolMessage) {
         if (!collectedIds.has(explicitToolMessage.id)) {
@@ -94,8 +134,8 @@ export class MessageCollector {
         continue;
       }
 
-      const fallbackToolMessage = messages.find(
-        (m) => m.role === 'tool' && m.parentId === assistant.id && m.tool_call_id === tool.id,
+      const fallbackToolMessage = this.childrenOf(assistant.id).find(
+        (m) => m.role === 'tool' && m.tool_call_id === tool.id,
       );
 
       if (fallbackToolMessage && !collectedIds.has(fallbackToolMessage.id)) {
@@ -136,12 +176,11 @@ export class MessageCollector {
     if (parent?.role !== 'user') return false;
 
     const groupAgentId = assistant.agentId;
-    const allMessages = [...this.messageMap.values()];
     const visited = new Set<string>([assistant.id]);
     let current: Message = assistant;
 
     while (true) {
-      const next = this.findFlatChainContinuation(current, [], allMessages, visited, groupAgentId);
+      const next = this.findFlatChainContinuation(current, [], [], visited, groupAgentId);
       if (!next) return false;
       if (next.tools && next.tools.length > 0) return true;
 
@@ -248,30 +287,29 @@ export class MessageCollector {
   private findFlatChainContinuation(
     currentAssistant: Message,
     toolMessages: Message[],
-    allMessages: Message[],
+    _allMessages: Message[],
     processedIds: Set<string>,
     groupAgentId: string | undefined,
   ): Message | undefined {
-    const candidateParentIds = new Set<string>();
+    const candidateParentIds: string[] = [];
     let hasFanOutTool = false;
     for (const toolMsg of toolMessages) {
       const isCouncil = (toolMsg.metadata as any)?.agentCouncil === true;
-      const toolChildren = allMessages.filter((m) => m.parentId === toolMsg.id);
-      const hasTaskChild = toolChildren.some((m) => m.role === 'task');
+      const hasTaskChild = this.childrenOf(toolMsg.id).some((m) => m.role === 'task');
       if (isCouncil || hasTaskChild) {
         hasFanOutTool = true;
         continue;
       }
-      candidateParentIds.add(toolMsg.id);
+      candidateParentIds.push(toolMsg.id);
     }
     // Assistant-anchored continuation only counts when this step did not fan out.
-    if (!hasFanOutTool) candidateParentIds.add(currentAssistant.id);
+    if (!hasFanOutTool) candidateParentIds.push(currentAssistant.id);
 
-    const candidates = allMessages
-      .filter((m) => m.parentId != null && candidateParentIds.has(m.parentId))
+    const candidates = [...new Set(candidateParentIds)]
+      .flatMap((parentId) => this.childrenOf(parentId))
       .filter((m) => m.role !== 'tool' && !processedIds.has(m.id))
       .filter((m) => m.role === 'assistant' && m.agentId === groupAgentId && !getMessageSignal(m))
-      .sort((a, b) => a.createdAt - b.createdAt);
+      .sort(this.byCreatedAtThenOrder);
 
     const activeId = this.resolveActiveContinuationId(candidates);
     return activeId ? candidates.find((m) => m.id === activeId) : undefined;
@@ -322,7 +360,7 @@ export class MessageCollector {
    */
   collectFlatSignalCallbacks(
     allToolMessages: Message[],
-    allMessages: Message[],
+    _allMessages: Message[],
   ): {
     callbacks: Message[];
     sourceToolCallId: string;
@@ -337,7 +375,7 @@ export class MessageCollector {
     }[] = [];
 
     for (const toolMsg of allToolMessages) {
-      const children = allMessages.filter((m) => m.parentId === toolMsg.id);
+      const children = this.childrenOf(toolMsg.id);
       const callbacks: Message[] = [];
       for (const child of children) {
         if (!isCallbackSignal(getMessageSignal(child))) continue;
@@ -374,10 +412,10 @@ export class MessageCollector {
    * marking returned messages as processed so they don't render as
    * separate top-level groups.
    */
-  collectFlatTaskCompletions(allToolMessages: Message[], allMessages: Message[]): Message[] {
+  collectFlatTaskCompletions(allToolMessages: Message[], _allMessages: Message[]): Message[] {
     const completions: Message[] = [];
     for (const toolMsg of allToolMessages) {
-      const children = allMessages.filter((m) => m.parentId === toolMsg.id);
+      const children = this.childrenOf(toolMsg.id);
       for (const child of children) {
         if (!isTaskCompletionSignal(getMessageSignal(child))) continue;
         completions.push(child);

--- a/packages/conversation-flow/src/transformation/__tests__/MessageCollector.test.ts
+++ b/packages/conversation-flow/src/transformation/__tests__/MessageCollector.test.ts
@@ -3,6 +3,32 @@ import { describe, expect, it } from 'vitest';
 import type { IdNode, Message } from '../../types';
 import { MessageCollector } from '../MessageCollector';
 
+/**
+ * Index messages the way `buildHelperMaps` does. MessageCollector resolves
+ * parent/child links through these maps, so a test that hands it an empty index
+ * is describing a state `parse()` never produces.
+ */
+const indexInto = (
+  messageMap: Map<string, Message>,
+  childrenMap: Map<string | null, string[]>,
+  messages: Message[],
+): void => {
+  for (const message of messages) {
+    messageMap.set(message.id, message);
+    const parentId = message.parentId ?? null;
+    const siblings = childrenMap.get(parentId);
+    if (siblings) siblings.push(message.id);
+    else childrenMap.set(parentId, [message.id]);
+  }
+};
+
+const newCollector = (messages: Message[]): MessageCollector => {
+  const messageMap = new Map<string, Message>();
+  const childrenMap = new Map<string | null, string[]>();
+  indexInto(messageMap, childrenMap, messages);
+  return new MessageCollector(messageMap, childrenMap);
+};
+
 describe('MessageCollector', () => {
   describe('collectGroupMembers', () => {
     it('should collect messages with matching groupId', () => {
@@ -92,6 +118,7 @@ describe('MessageCollector', () => {
         },
       ];
 
+      indexInto(messageMap, childrenMap, [assistant, ...messages]);
       const result = collector.collectToolMessages(assistant, messages);
 
       expect(result).toHaveLength(2);
@@ -142,6 +169,7 @@ describe('MessageCollector', () => {
         },
       ];
 
+      indexInto(messageMap, childrenMap, [assistant, ...messages]);
       const result = collector.collectToolMessages(assistant, messages);
 
       expect(result.map((m) => m.id)).toEqual(['tool-current']);
@@ -190,6 +218,7 @@ describe('MessageCollector', () => {
         },
       ];
 
+      indexInto(messageMap, childrenMap, [assistant, ...messages]);
       const result = collector.collectToolMessages(assistant, messages);
 
       expect(result.map((m) => m.id)).toEqual(['tool-current']);
@@ -750,7 +779,7 @@ describe('MessageCollector', () => {
       const astB = mkAssistant('ast-B', { parentId: 'tool-1', tools: [bashTool('tc-dup')] });
 
       const allMessages: Message[] = [astA, toolA, astB];
-      const collector = new MessageCollector(new Map(), new Map());
+      const collector = newCollector(allMessages);
 
       const assistantChain: Message[] = [];
       const allToolMessages: Message[] = [];
@@ -780,7 +809,7 @@ describe('MessageCollector', () => {
       const astFinal = mkAssistant('ast-final', { parentId: 'tool-2' });
 
       const allMessages: Message[] = [astA, toolA, astB, toolB, astFinal];
-      const collector = new MessageCollector(new Map(), new Map());
+      const collector = newCollector(allMessages);
 
       const assistantChain: Message[] = [];
       const allToolMessages: Message[] = [];
@@ -809,7 +838,7 @@ describe('MessageCollector', () => {
       const astC = mkAssistant('ast-C', { parentId: 'tool-xb' });
 
       const allMessages: Message[] = [astA, toolXA, astB, toolXB, astC];
-      const collector = new MessageCollector(new Map(), new Map());
+      const collector = newCollector(allMessages);
 
       const assistantChain: Message[] = [];
       collector.collectAssistantChain(astA, allMessages, assistantChain, [], new Set());
@@ -831,7 +860,7 @@ describe('MessageCollector', () => {
       const astFinal = mkAssistant('ast-final', { parentId: 'tool-2' });
 
       const allMessages: Message[] = [astA, toolA, prose, astC, toolC, astFinal];
-      const collector = new MessageCollector(new Map(), new Map());
+      const collector = newCollector(allMessages);
 
       const assistantChain: Message[] = [];
       const allToolMessages: Message[] = [];
@@ -861,7 +890,7 @@ describe('MessageCollector', () => {
       const astFinal = mkAssistant('ast-final', { parentId: 'ast-C' });
 
       const allMessages: Message[] = [astA, toolA, prose1, prose2, astC, toolC, astFinal];
-      const collector = new MessageCollector(new Map(), new Map());
+      const collector = newCollector(allMessages);
 
       const assistantChain: Message[] = [];
       const allToolMessages: Message[] = [];


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor
- [x] ⚡️ perf

#### 🔗 Related Issue

Related to #16496 — implements the `conversation-flow` optimisation that thread's profiling pointed at. Does not close it: the Zustand store normalisation the issue originally asks for is not done, and per the maintainer comment there it should not be.

#### 🔀 Description of Change

Two behaviour-preserving changes to the same walk.

**Handler ladder.** `flatten()`'s priority ladder — 8 shapes inlined into one 400-line function — becomes a list of `{ name, match, handle }` handlers. Dispatch takes the first handler whose `match` accepts the message; `handle` emits its row(s), marks what it swallowed, and returns the frames the walk continues into.

```ts
full:           [compareGroup, assistantGroup, supervisorContent,
                 compareMetadata, userBranch, assistantBranch, regularMessage]
taskGrandchild: [skipTask, simpleAssistantGroup, supervisorContent, regularMessage]
taskSibling:    [simpleAssistantGroup, regularMessage]
```

Adding a message shape is now a handler plus a position in a list, with no edit to the traversal.

This also **surfaces two duplications that were previously invisible**, because the recursive version carried them as copy-pasted inline blocks: `taskGrandchild` opens a supervisor bubble where `taskSibling` does not, and `simpleAssistantGroup` omits the signal-callback and task-completion collection that `assistantGroup` performs. Both are preserved exactly. Unifying them would be a behaviour change and belongs in its own PR — the point here is that they are now two adjacent array literals instead of something you would have to read 100 lines to notice.

**Indexing.** Chain walking scanned the entire message array per node. `isToolChainHead` materialised `[...messageMap.values()]` on *every call*; `findFlatChainContinuation` ran chained full-array `.filter()` passes; `collectToolMessages` rebuilt a map of all tool messages per assistant; both flat signal collectors filtered the whole array per tool. All of these are "children of X" questions, which the `childrenMap` that `buildHelperMaps` already builds in one linear pass answers in O(1).

One subtlety worth reviewing: candidates used to be gathered by filtering the source array, so the `createdAt` sort broke ties in **array order** (JS sort is stable). Gathering per parent preserves order within a parent but loses it across parents, so `orderOf()` — a lazily built id → position index — restores it as an explicit tie-breaker.

| messages | before | after | |
| ---: | ---: | ---: | --- |
| 1,125 | 15ms | 3ms | 5× |
| 4,500 | 173ms | 6ms | 29× |
| 20,000 | 4,100ms | 36ms | 114× |
| 100,000 | 86,700ms | 142ms | 611× |

Quadratic to linear. At a 1k-message conversation one streaming chunk's reparse drops from ~32ms to ~3ms — from roughly 2× a frame budget to comfortably inside one, which is the dropped-frame behaviour the issue thread describes.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

All 27 golden fixtures compare byte-identical. Consumers 390 passing; full monorepo shows no new failures. The package's own suite runtime drops from 4.5s to 0.7s, which is the perf change showing up directly.

**Please review this bit specifically:** eight `MessageCollector` tests failed on the indexing change because they constructed the collector with *empty* `messageMap` / `childrenMap` and passed messages only as an argument — the old implementation scanned that argument, the new one reads the index. They now build the index the way `buildHelperMaps` does.

Changing tests to fit a change deserves scrutiny, so the justification is: that construction describes a state `parse()` cannot produce, since `buildHelperMaps` derives both maps from the same array; and the 27 goldens plus all 60 black-box tests were **already green before those tests were touched**, so the behaviour they cover is demonstrably unchanged. If a reviewer disagrees, the alternative is keeping the collector able to work off a passed array, at the cost of retaining some full-array scans.

#### 📝 Additional Information

Third of three stacked PRs — **based on #17395, not on `canary`.** Merge order: #17394 → #17395 → this.

Left for follow-ups: `FlatListBuilder.ts` is 1378 lines (~700 of it `create*` virtual-message builders, now cleanly separable behind the handler boundary); `collectToolMessages` / `collectFlatTaskCompletions` / `findFlatChainContinuation` retain now-unused array parameters, prefixed `_` to keep the diff off 19 test call sites; and the two behaviour inconsistencies noted above.