### PR TITLE
🐛 fix(agent): harden gateway run termination

### DIFF
--- a/apps/cli/src/commands/hetero.test.ts
+++ b/apps/cli/src/commands/hetero.test.ts
@@ -704,7 +704,7 @@ describe('hetero exec command', () => {
       topicId: 'topic-1',
     });
     expect(mockHeteroFinishMutate.mock.calls[0][0].error.body).toBeUndefined();
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
   it('finishes server-ingest runs with error when the agent event stream fails', async () => {
@@ -735,7 +735,7 @@ describe('hetero exec command', () => {
       topicId: 'topic-1',
     });
     expect(mockHeteroFinishMutate.mock.calls[0][0].error.body).toBeUndefined();
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
   it('classifies a spawn ENOENT stream failure as a structured cli_not_found error', async () => {
@@ -778,6 +778,29 @@ describe('hetero exec command', () => {
       topicId: 'topic-1',
     });
     expect(mockHeteroFinishMutate.mock.calls[0][0].error.message).toContain('was not found');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('exits non-zero when a clean server-ingest run cannot deliver heteroFinish', async () => {
+    mockSpawnAgent.mockReturnValue(createFakeHandle({ exitCode: 0 }));
+    mockHeteroFinishMutate.mockRejectedValue(new Error('terminal endpoint unavailable'));
+
+    await runCmd([
+      'hetero',
+      'exec',
+      '--type',
+      'codex',
+      '--prompt',
+      'hi',
+      '--topic',
+      'topic-1',
+      '--operation-id',
+      'op-terminal-failed',
+      '--render',
+      'none',
+    ]);
+
+    expect(mockHeteroFinishMutate).toHaveBeenCalledTimes(1);
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
@@ -816,7 +839,9 @@ describe('hetero exec command', () => {
       result: 'error',
       topicId: 'topic-1',
     });
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    // The server acknowledged the semantic error, so the wrapper reports a
+    // completed terminal handshake to its parent instead of triggering fallback.
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
   it('rejects --prompt + --input-json (mutually exclusive)', async () => {

--- a/apps/cli/src/commands/hetero.ts
+++ b/apps/cli/src/commands/hetero.ts
@@ -382,6 +382,12 @@ const exec = async (options: ExecOptions): Promise<void> => {
   const agentType = options.type as 'amp' | 'claude-code' | 'codex' | 'opencode';
   let sink: TrpcIngestSink | undefined;
   let serverIngester: CoalescingBatchIngester | undefined;
+  // In server-ingest mode, exit code is the parent/child terminal-handshake
+  // contract: once heteroFinish is acknowledged, the semantic result already
+  // lives on the server and the wrapper exits 0. A non-zero exit means the
+  // parent must deliver the terminal fallback.
+  let terminalDelivered = false;
+  let terminalDeliveryFailed = false;
   // Uploader for tool_result images (CC `Read` on an image file). Reuses the
   // CLI's authenticated lambda client so the persisted event carries a
   // `{ fileId, url }` reference instead of heavy base64. Only wired in
@@ -589,11 +595,12 @@ const exec = async (options: ExecOptions): Promise<void> => {
             error: buildFinishError(message, 'AgentRuntimeError'),
             result: 'error',
           });
+          terminalDelivered = true;
         } catch {
           // best-effort; process is exiting anyway
         }
       }
-      process.exit(1);
+      process.exit(terminalDelivered ? 0 : 1);
     }
 
     // Always collect stderr — used for resume-error detection AND for
@@ -696,12 +703,13 @@ const exec = async (options: ExecOptions): Promise<void> => {
             ),
             result: 'error',
           });
+          terminalDelivered = true;
         } catch {
           // best-effort
         }
       }
       await dumpAttempt?.close();
-      process.exit(1);
+      process.exit(terminalDelivered ? 0 : 1);
     } finally {
       process.off('SIGINT', onSigint);
       process.off('SIGTERM', onSigterm);
@@ -857,7 +865,9 @@ const exec = async (options: ExecOptions): Promise<void> => {
         result: result.cancelled ? 'cancelled' : exitedClean ? 'success' : 'error',
         sessionId,
       });
+      terminalDelivered = true;
     } catch (err) {
+      terminalDeliveryFailed = true;
       log.error('Failed to send heteroFinish:', err instanceof Error ? err.message : String(err));
     }
   }
@@ -872,6 +882,11 @@ const exec = async (options: ExecOptions): Promise<void> => {
   }
   if (askMcpConfigPath) await unlink(askMcpConfigPath).catch(() => {});
 
+  // The server has acknowledged the exact success/error/cancelled result. Do
+  // not make the parent synthesize a second generic error from the agent CLI's
+  // own exit code — older servers do not have terminal CAS protection.
+  if (terminalDelivered) process.exit(0);
+  if (terminalDeliveryFailed) process.exit(1);
   if (code !== null) process.exit(result.ingestError ? 1 : code);
   if (signal === 'SIGINT') process.exit(130);
   if (signal === 'SIGTERM') process.exit(143);

--- a/apps/cli/src/daemon/taskRegistry.ts
+++ b/apps/cli/src/daemon/taskRegistry.ts
@@ -4,7 +4,9 @@ import path from 'node:path';
 
 export interface TaskEntry {
   agentId?: string;
-  agentType: 'hermes' | 'openclaw';
+  agentType: 'amp' | 'claude-code' | 'codex' | 'hermes' | 'openclaw' | 'opencode';
+  /** Agent-run children stream through heteroFinish; platform tasks use notify. */
+  kind?: 'agent-run' | 'platform-task';
   operationId: string;
   pid: number;
   startedAt: string;

--- a/apps/cli/src/device/agentRun.test.ts
+++ b/apps/cli/src/device/agentRun.test.ts
@@ -4,14 +4,30 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { spawnHeteroAgentRun } from './agentRun';
 
-const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
+const { fallbackFinishMock, removeTaskMock, saveTaskMock, spawnMock } = vi.hoisted(() => ({
+  fallbackFinishMock: vi.fn().mockResolvedValue({ ack: true }),
+  removeTaskMock: vi.fn(),
+  saveTaskMock: vi.fn(),
+  spawnMock: vi.fn(),
+}));
 
 vi.mock('node:child_process', () => ({ spawn: spawnMock }));
+vi.mock('../api/client', () => ({
+  createLambdaClient: vi.fn(() => ({
+    aiAgent: { heteroFinish: { mutate: fallbackFinishMock } },
+  })),
+}));
+vi.mock('../daemon/taskRegistry', () => ({
+  removeTask: removeTaskMock,
+  saveTask: saveTaskMock,
+}));
 
 const makeFakeChild = () => {
   const child = new EventEmitter() as EventEmitter & {
+    pid: number;
     stdin: { end: ReturnType<typeof vi.fn>; write: ReturnType<typeof vi.fn> };
   };
+  child.pid = 1234;
   child.stdin = { end: vi.fn(), write: vi.fn() };
   return child;
 };
@@ -28,6 +44,9 @@ const baseParams = {
 describe('spawnHeteroAgentRun', () => {
   afterEach(() => {
     spawnMock.mockReset();
+    fallbackFinishMock.mockClear();
+    removeTaskMock.mockClear();
+    saveTaskMock.mockClear();
   });
 
   it('spawns `lh hetero exec` in server-ingest mode via the current CLI entry', async () => {
@@ -66,6 +85,7 @@ describe('spawnHeteroAgentRun', () => {
     ]);
     expect(opts).toMatchObject({
       cwd: '/work/dir',
+      detached: process.platform !== 'win32',
       env: expect.objectContaining({
         LOBEHUB_JWT: 'jwt-token',
         LOBEHUB_SERVER: 'https://app.lobehub.com',
@@ -79,6 +99,51 @@ describe('spawnHeteroAgentRun', () => {
     await expect(ackPromise).resolves.toEqual({ status: 'accepted' });
     expect(child.stdin.write).toHaveBeenCalledWith(JSON.stringify('hi'));
     expect(child.stdin.end).toHaveBeenCalledTimes(1);
+    expect(saveTaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'agent-run', pid: 1234, taskId: 'op-1' }),
+    );
+  });
+
+  it('removes the task entry and reports a terminal fallback after an accepted child exits abnormally', async () => {
+    const child = makeFakeChild();
+    spawnMock.mockReturnValue(child);
+
+    const ackPromise = spawnHeteroAgentRun({
+      ...baseParams,
+      agentType: 'opencode',
+      operationId: 'op-exit',
+    });
+    child.emit('spawn');
+    await ackPromise;
+    child.emit('exit', 2, null);
+    await vi.waitFor(() => expect(fallbackFinishMock).toHaveBeenCalledTimes(1));
+
+    expect(removeTaskMock).toHaveBeenCalledWith('op-exit');
+    expect(fallbackFinishMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operationId: 'op-exit',
+        result: 'error',
+        topicId: 'tpc',
+      }),
+    );
+  });
+
+  it('does not report a fallback after a clean exit with an acknowledged terminal handshake', async () => {
+    const child = makeFakeChild();
+    spawnMock.mockReturnValue(child);
+
+    const ackPromise = spawnHeteroAgentRun({
+      ...baseParams,
+      agentType: 'opencode',
+      operationId: 'op-clean-exit',
+    });
+    child.emit('spawn');
+    await ackPromise;
+    child.emit('exit', 0, null);
+    await Promise.resolve();
+
+    expect(removeTaskMock).toHaveBeenCalledWith('op-clean-exit');
+    expect(fallbackFinishMock).not.toHaveBeenCalled();
   });
 
   it('rejects (no stuck run) when the child errors before spawning, e.g. bad cwd', async () => {

--- a/apps/cli/src/device/agentRun.ts
+++ b/apps/cli/src/device/agentRun.ts
@@ -5,6 +5,9 @@ import {
   type HeteroExecImageRef,
 } from '@lobechat/heterogeneous-agents/protocol';
 
+import { createLambdaClient } from '../api/client';
+import { removeTask, saveTask } from '../daemon/taskRegistry';
+
 export interface SpawnHeteroAgentRunParams {
   agentType: string;
   /** Resolved `lh hetero exec` wrapper args. */
@@ -96,6 +99,7 @@ export function spawnHeteroAgentRun(
   const stdinPayload = buildHeteroExecStdinPayload({ imageList, prompt, systemContext });
 
   return new Promise<AgentRunAckResult>((resolve) => {
+    let accepted = false;
     let settled = false;
     const settle = (result: AgentRunAckResult) => {
       if (settled) return;
@@ -105,6 +109,9 @@ export function spawnHeteroAgentRun(
 
     const child = spawn(process.execPath, [...process.execArgv, ...cliArgs], {
       cwd: workDir,
+      // Give the wrapper and all agent/tool descendants their own Unix process
+      // group so cancelHeteroTask can stop the full tree rather than only `lh`.
+      detached: process.platform !== 'win32',
       env: {
         ...process.env,
         LOBEHUB_JWT: jwt,
@@ -118,21 +125,75 @@ export function spawnHeteroAgentRun(
       try {
         child.stdin?.write(stdinPayload);
         child.stdin?.end();
+        if (child.pid) {
+          try {
+            saveTask({
+              agentType: agentType as
+                'amp' | 'claude-code' | 'codex' | 'hermes' | 'openclaw' | 'opencode',
+              kind: 'agent-run',
+              operationId,
+              pid: child.pid,
+              startedAt: new Date().toISOString(),
+              taskId: operationId,
+              topicId,
+            });
+          } catch (err) {
+            logger?.error?.(
+              `hetero exec task registration failed (op=${operationId}): ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
+        accepted = true;
       } catch (err) {
-        logger?.error?.(
-          `hetero exec stdin write failed (op=${operationId}): ${(err as Error).message}`,
-        );
+        const reason = err instanceof Error ? err.message : String(err);
+        logger?.error?.(`hetero exec stdin write failed (op=${operationId}): ${reason}`);
+        child.kill('SIGTERM');
+        settle({ reason, status: 'rejected' });
+        return;
       }
       settle({ status: 'accepted' });
     });
 
-    child.once('error', (err) => {
+    child.once('error', (err: Error) => {
       logger?.error?.(`hetero exec spawn failed (op=${operationId}): ${err.message}`);
       settle({ reason: err.message, status: 'rejected' });
     });
 
     child.on('exit', (code, signal) => {
+      if (child.pid) {
+        try {
+          removeTask(operationId);
+        } catch {
+          // Registry cleanup is best-effort; a stale PID is handled by cancelHeteroTask.
+        }
+      }
       logger?.info?.(`hetero exec exited (op=${operationId}) code=${code} signal=${signal}`);
+
+      if (
+        accepted &&
+        (code !== 0 || signal !== null) &&
+        ['amp', 'claude-code', 'codex', 'opencode'].includes(agentType)
+      ) {
+        // In server-ingest mode the child exits 0 only after heteroFinish is
+        // acknowledged. Re-deliver a terminal error solely when that handshake
+        // did not complete (or the wrapper was killed before it could finish).
+        void createLambdaClient({ serverUrl, token: jwt, tokenType: 'jwt' })
+          .aiAgent.heteroFinish.mutate({
+            agentType: agentType as 'amp' | 'claude-code' | 'codex' | 'opencode',
+            error: {
+              message: `CLI child exited after acceptance (code=${code ?? 'null'}, signal=${signal ?? 'none'})`,
+              type: 'HeterogeneousAgentProcessExit',
+            },
+            operationId,
+            result: 'error',
+            topicId,
+          })
+          .catch((err: unknown) =>
+            logger?.error?.(
+              `hetero exec terminal fallback failed (op=${operationId}): ${err instanceof Error ? err.message : String(err)}`,
+            ),
+          );
+      }
     });
   });
 }

--- a/apps/cli/src/tools/__tests__/heteroTask.test.ts
+++ b/apps/cli/src/tools/__tests__/heteroTask.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getTrpcClient } from '../../api/client';
 import { removeTask, saveTask } from '../../daemon/taskRegistry';
-import { runHeteroTask } from '../heteroTask';
+import { cancelHeteroTask, runHeteroTask } from '../heteroTask';
 
 // ─── Mocks ───
 
@@ -302,5 +302,41 @@ describe('runHeteroTask (openclaw)', () => {
     for (const call of getTrpcClientMock.mock.calls) {
       expect(call[0]).toBe('ws-99');
     }
+  });
+});
+
+describe('cancelHeteroTask (gateway agent run)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of Object.keys(taskStore)) delete taskStore[key];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('kills a gateway child process group and escalates if it remains registered', async () => {
+    vi.useFakeTimers();
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    saveTask({
+      agentType: 'opencode',
+      kind: 'agent-run',
+      operationId: 'op-device-run',
+      pid: 4242,
+      startedAt: new Date().toISOString(),
+      taskId: 'op-device-run',
+      topicId: 'topic-1',
+    });
+
+    await expect(
+      cancelHeteroTask({ signal: 'SIGINT', taskId: 'op-device-run' }),
+    ).resolves.toContain('4242');
+    const targetPid = process.platform === 'win32' ? 4242 : -4242;
+    expect(killSpy).toHaveBeenCalledWith(targetPid, 'SIGINT');
+
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(killSpy).toHaveBeenCalledWith(targetPid, 'SIGKILL');
+
+    killSpy.mockRestore();
   });
 });

--- a/apps/cli/src/tools/heteroTask.ts
+++ b/apps/cli/src/tools/heteroTask.ts
@@ -6,7 +6,7 @@ import path from 'node:path';
 import type { RemoteHeterogeneousAgentType } from '@lobechat/heterogeneous-agents';
 
 import { getTrpcClient } from '../api/client';
-import { getTask, listTasks, removeTask, saveTask } from '../daemon/taskRegistry';
+import { getTask, listTasks, removeTask, saveTask, type TaskEntry } from '../daemon/taskRegistry';
 import { log } from '../utils/logger';
 
 // ─── Hermes session persistence ───
@@ -69,6 +69,22 @@ export interface RunHeteroTaskParams {
 export interface CancelHeteroTaskParams {
   signal?: 'SIGINT' | 'SIGKILL' | 'SIGTERM';
   taskId: string;
+}
+
+/** Signal the whole detached Unix group for gateway agent runs, with a direct-PID fallback. */
+function signalTaskProcess(
+  entry: TaskEntry,
+  signal: NonNullable<CancelHeteroTaskParams['signal']>,
+): void {
+  if (entry.kind === 'agent-run' && process.platform !== 'win32') {
+    try {
+      process.kill(-entry.pid, signal);
+      return;
+    } catch {
+      // Older registry entries may predate detached process groups.
+    }
+  }
+  process.kill(entry.pid, signal);
 }
 
 async function sendAutoNotify(
@@ -218,6 +234,7 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
     saveTask({
       agentId,
       agentType,
+      kind: 'platform-task',
       operationId,
       pid,
       startedAt: new Date().toISOString(),
@@ -359,22 +376,39 @@ export async function cancelHeteroTask(params: CancelHeteroTaskParams): Promise<
     return JSON.stringify({ message: `No task found with taskId: ${taskId}`, success: false });
   }
 
-  // Both openclaw and hermes: kill by PID and let the child's close handler send the notify.
+  // Platform tasks let their close handler send notify. Gateway agent runs own
+  // their terminal callback and are spawned in a detached process group.
   try {
-    process.kill(entry.pid, signal);
+    signalTaskProcess(entry, signal);
+
+    if (entry.kind === 'agent-run' && signal !== 'SIGKILL') {
+      // Some agent/tool descendants swallow graceful signals. Escalate only if
+      // the same registry entry is still active; the exit handler removes it.
+      setTimeout(() => {
+        const current = getTask(taskId);
+        if (current?.kind !== 'agent-run' || current.pid !== entry.pid) return;
+        try {
+          signalTaskProcess(current, 'SIGKILL');
+        } catch {
+          // The process exited between the registry read and signal delivery.
+        }
+      }, 3000).unref();
+    }
   } catch (err) {
     // Process already exited — exit handler won't fire; clean up manually.
     log.warn(
       `Failed to send ${signal} to pid ${entry.pid}: ${err instanceof Error ? err.message : String(err)}`,
     );
     removeTask(taskId);
-    await sendAutoNotify(
-      entry.topicId,
-      taskId,
-      'Task already completed or cancelled',
-      entry.agentId,
-      entry.workspaceId,
-    );
+    if (entry.kind !== 'agent-run') {
+      await sendAutoNotify(
+        entry.topicId,
+        taskId,
+        'Task already completed or cancelled',
+        entry.agentId,
+        entry.workspaceId,
+      );
+    }
   }
 
   return JSON.stringify({ pid: entry.pid, signal, taskId });

--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -1052,6 +1052,14 @@ export default class GatewayConnectionCtr extends ControllerModule {
 
   private async cancelHeteroTask(args: { signal?: string; taskId: string }): Promise<string> {
     const { signal = 'SIGINT', taskId } = args;
+    const gatewayRun = this.heterogeneousAgentCtr.cancelGatewayRun(
+      taskId,
+      signal as NodeJS.Signals,
+    );
+    if (gatewayRun.success) {
+      return JSON.stringify({ pid: gatewayRun.pid, signal, taskId });
+    }
+
     const entry = this.platformTasks.get(taskId);
 
     if (!entry) {

--- a/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
@@ -50,6 +50,7 @@ import type {
   ListHeterogeneousAgentModelsParams,
 } from '@lobechat/types';
 import { app as electronApp, BrowserWindow } from 'electron';
+import superjson from 'superjson';
 
 import { HETERO_AGENT_FILES_DIR, HETERO_AGENT_TRACING_DIR } from '@/const/heteroAgent';
 import { detectHeterogeneousCliCommand } from '@/modules/binaries';
@@ -317,10 +318,21 @@ interface InterventionSlot {
   tmpConfigPath: string;
 }
 
+interface GatewayRun {
+  agentType: string;
+  cancelled: boolean;
+  jwt: string;
+  process: ChildProcess;
+  serverUrl: string;
+  topicId: string;
+}
+
 export default class HeterogeneousAgentCtr extends ControllerModule {
   static override readonly groupName = 'heterogeneousAgent';
 
   private sessions = new Map<string, AgentSession>();
+  /** Gateway-dispatched embedded CLI children, keyed by server operation id. */
+  private gatewayRuns = new Map<string, GatewayRun>();
   /**
    * Per-operation AskUserQuestion bridge state. Keyed by `operationId` so the
    * `submitIntervention` IPC can route an answer to the right pending MCP
@@ -1752,6 +1764,66 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
     }
   }
 
+  /** Best-effort cancellation used by the device gateway cancelHeteroTask relay. */
+  cancelGatewayRun(
+    operationId: string,
+    signal: NodeJS.Signals = 'SIGINT',
+  ): { pid?: number; success: boolean } {
+    const run = this.gatewayRuns.get(operationId);
+    if (!run) return { success: false };
+
+    run.cancelled = true;
+    this.killProcessTree(run.process, signal);
+
+    // Give well-behaved CLIs a short graceful shutdown window, then ensure a
+    // wedged child tree cannot survive indefinitely on the user's machine.
+    const processRef = run.process;
+    setTimeout(() => {
+      if (this.gatewayRuns.get(operationId)?.process === processRef) {
+        this.killProcessTree(processRef, 'SIGKILL');
+      }
+    }, 3000).unref();
+
+    return { pid: run.process.pid, success: true };
+  }
+
+  /**
+   * Accepted-child fallback. The embedded CLI normally awaits heteroFinish
+   * itself; this duplicate callback is harmless because the server terminal
+   * transition is CAS-guarded, while a child that died before calling finish no
+   * longer leaves an operation permanently running.
+   */
+  private async reportGatewayRunExit(
+    operationId: string,
+    run: GatewayRun,
+    code: number | null,
+    signal: NodeJS.Signals | null,
+  ): Promise<void> {
+    const response = await fetch(
+      `${run.serverUrl.replace(/\/$/, '')}/trpc/lambda/aiAgent.heteroFinish`,
+      {
+        body: JSON.stringify(
+          superjson.serialize({
+            agentType: run.agentType,
+            error: {
+              message: `Embedded CLI exited after acceptance (code=${code ?? 'null'}, signal=${signal ?? 'none'})`,
+              type: 'HeterogeneousAgentProcessExit',
+            },
+            operationId,
+            result: 'error',
+            topicId: run.topicId,
+          }),
+        ),
+        headers: { 'Content-Type': 'application/json', 'Oidc-Auth': run.jwt },
+        method: 'POST',
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`heteroFinish fallback failed with HTTP ${response.status}`);
+    }
+  }
+
   /**
    * Cancel an ongoing session: SIGINT the CC tree, escalate to SIGKILL after
    * 2s if the CLI hasn't exited (some tool calls swallow SIGINT). The
@@ -1991,12 +2063,25 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
     // capability that the actual execution runtime does not support.
     const child = spawn(process.execPath, [cliScript, ...args], {
       cwd: workDir,
+      detached: process.platform !== 'win32',
       env,
       stdio: ['pipe', 'inherit', 'inherit'],
     });
 
+    let accepted = false;
     child.on('exit', (code, signal) => {
       logger.info('spawnLhHeteroExec: exited — op=%s code=%s signal=%s', operationId, code, signal);
+      const run = this.gatewayRuns.get(operationId);
+      if (run?.process === child) this.gatewayRuns.delete(operationId);
+      if (accepted && run && !run.cancelled && (code !== 0 || signal !== null)) {
+        void this.reportGatewayRunExit(operationId, run, code, signal).catch((err) => {
+          logger.error(
+            'spawnLhHeteroExec: terminal fallback failed — op=%s error=%s',
+            operationId,
+            err instanceof Error ? err.message : String(err),
+          );
+        });
+      }
     });
 
     return new Promise((resolve) => {
@@ -2020,6 +2105,15 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
         try {
           child.stdin.write(stdinPayload);
           child.stdin.end();
+          accepted = true;
+          this.gatewayRuns.set(operationId, {
+            agentType,
+            cancelled: false,
+            jwt,
+            process: child,
+            serverUrl,
+            topicId,
+          });
           settle({ status: 'accepted' });
         } catch (err) {
           const reason = err instanceof Error ? err.message : String(err);
@@ -2028,6 +2122,7 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
             operationId,
             reason,
           );
+          this.killProcessTree(child, 'SIGTERM');
           settle({ reason, status: 'rejected' });
         }
       });

--- a/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
@@ -243,6 +243,7 @@ const mockShellCommandCtr = {
 } as unknown as ShellCommandCtr;
 
 const mockHeterogeneousAgentCtr = {
+  cancelGatewayRun: vi.fn().mockReturnValue({ success: false }),
   sendPrompt: vi.fn().mockResolvedValue(undefined),
   spawnLhHeteroExec: vi.fn().mockResolvedValue({ status: 'accepted' }),
   startSession: vi.fn().mockResolvedValue({ sessionId: 'mock-session-id' }),
@@ -615,6 +616,33 @@ describe('GatewayConnectionCtr', () => {
           error: 'File not found',
           success: false,
         },
+      });
+    });
+
+    it('routes cancelHeteroTask to a gateway child keyed by operation id', async () => {
+      vi.mocked(mockHeterogeneousAgentCtr.cancelGatewayRun).mockReturnValueOnce({
+        pid: 4321,
+        success: true,
+      });
+      const client = await connectAndOpen();
+
+      client.simulateToolCallRequest(
+        'cancelHeteroTask',
+        { signal: 'SIGINT', taskId: 'op-device-run' },
+        'req-cancel',
+      );
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(mockHeterogeneousAgentCtr.cancelGatewayRun).toHaveBeenCalledWith(
+        'op-device-run',
+        'SIGINT',
+      );
+      expect(client.sendToolCallResponse).toHaveBeenCalledWith({
+        requestId: 'req-cancel',
+        result: expect.objectContaining({
+          content: expect.stringContaining('4321'),
+          success: true,
+        }),
       });
     });
 

--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
@@ -1354,6 +1354,9 @@ describe('HeterogeneousAgentCtr', () => {
       stdin.end = vi.fn();
       stdin.write = vi.fn(() => true);
       proc.stdin = stdin;
+      proc.kill = vi.fn();
+      proc.killed = false;
+      proc.pid = 4321;
       return proc;
     };
 
@@ -1460,6 +1463,81 @@ describe('HeterogeneousAgentCtr', () => {
       await expect(ack).resolves.toEqual({ status: 'accepted' });
 
       expect(() => proc.stdin.emit('error', new Error('write EPIPE'))).not.toThrow();
+    });
+
+    it('reports a server terminal fallback when an accepted child exits', async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue({ ok: true, status: 200 } as Response);
+      const proc = createGatewayCliProc();
+      nextFakeProc = proc;
+      const ctr = new HeterogeneousAgentCtr({
+        appStoragePath,
+        storeManager: { get: vi.fn() },
+      } as any);
+
+      const ack = ctr.spawnLhHeteroExec(params);
+      proc.emit('spawn');
+      await ack;
+      proc.emit('exit', 2, null);
+
+      await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+      expect(fetchSpy.mock.calls[0][0]).toBe(
+        'https://server.example.com/trpc/lambda/aiAgent.heteroFinish',
+      );
+      expect(fetchSpy.mock.calls[0][1]).toMatchObject({
+        headers: expect.objectContaining({ 'Oidc-Auth': 'device-jwt' }),
+        method: 'POST',
+      });
+      expect(String(fetchSpy.mock.calls[0][1]?.body)).toContain('op-gateway');
+      fetchSpy.mockRestore();
+    });
+
+    it('does not report a fallback after a clean child exit', async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue({ ok: true, status: 200 } as Response);
+      const proc = createGatewayCliProc();
+      nextFakeProc = proc;
+      const ctr = new HeterogeneousAgentCtr({
+        appStoragePath,
+        storeManager: { get: vi.fn() },
+      } as any);
+
+      const ack = ctr.spawnLhHeteroExec(params);
+      proc.emit('spawn');
+      await ack;
+      proc.emit('exit', 0, null);
+      await Promise.resolve();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      fetchSpy.mockRestore();
+    });
+
+    it('kills a registered gateway child without reporting an error fallback', async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue({ ok: true, status: 200 } as Response);
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+      const proc = createGatewayCliProc();
+      nextFakeProc = proc;
+      const ctr = new HeterogeneousAgentCtr({
+        appStoragePath,
+        storeManager: { get: vi.fn() },
+      } as any);
+
+      const ack = ctr.spawnLhHeteroExec(params);
+      proc.emit('spawn');
+      await ack;
+
+      expect(ctr.cancelGatewayRun('op-gateway')).toMatchObject({ pid: 4321, success: true });
+      expect(killSpy).toHaveBeenCalledWith(-4321, 'SIGINT');
+      proc.emit('exit', null, 'SIGINT');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(fetchSpy).not.toHaveBeenCalled();
+
+      killSpy.mockRestore();
+      fetchSpy.mockRestore();
     });
   });
 

--- a/apps/server/src/routers/lambda/__tests__/aiAgent.interruptTask.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.interruptTask.test.ts
@@ -1,6 +1,13 @@
 // @vitest-environment node
 import { type LobeChatDatabase } from '@lobechat/database';
-import { agents, chatGroups, sessions, threads, topics } from '@lobechat/database/schemas';
+import {
+  agentOperations,
+  agents,
+  chatGroups,
+  sessions,
+  threads,
+  topics,
+} from '@lobechat/database/schemas';
 import { getTestDB } from '@lobechat/database/test-utils';
 import { ThreadStatus, ThreadType } from '@lobechat/types';
 import { eq } from 'drizzle-orm';
@@ -16,12 +23,24 @@ vi.mock('@/database/core/db-adaptor', () => ({
 }));
 
 const mockInterruptOperation = vi.fn();
+const mockHeteroFinish = vi.fn();
+const mockExecuteToolCall = vi.hoisted(() => vi.fn());
 
 // Mock AgentRuntimeService
 vi.mock('@/server/services/agentRuntime', () => ({
   AgentRuntimeService: vi.fn().mockImplementation(() => ({
     interruptOperation: mockInterruptOperation,
   })),
+}));
+
+vi.mock('@/server/services/heterogeneousAgent', () => ({
+  HeterogeneousAgentService: vi.fn().mockImplementation(() => ({
+    heteroFinish: mockHeteroFinish,
+  })),
+}));
+
+vi.mock('@/server/services/deviceGateway', () => ({
+  deviceGateway: { executeToolCall: mockExecuteToolCall },
 }));
 
 // Mock AiChatService
@@ -43,6 +62,10 @@ describe('aiAgentRouter.interruptTask', () => {
     userId = await createTestUser(serverDB);
     mockInterruptOperation.mockReset();
     mockInterruptOperation.mockResolvedValue(true);
+    mockHeteroFinish.mockReset();
+    mockHeteroFinish.mockResolvedValue(undefined);
+    mockExecuteToolCall.mockReset();
+    mockExecuteToolCall.mockResolvedValue({});
 
     // Create test agent
     const [agent] = await serverDB
@@ -202,6 +225,62 @@ describe('aiAgentRouter.interruptTask', () => {
         .where(eq(threads.id, testThreadId));
 
       expect(updatedThread.status).toBe(ThreadStatus.Cancel);
+    });
+
+    it('authoritatively finalizes a device hetero operation without runtime coordinator state', async () => {
+      const operationId = 'op-device-opencode';
+      await serverDB.insert(agentOperations).values({
+        agentId: testAgentId,
+        id: operationId,
+        provider: 'opencode',
+        status: 'running',
+        topicId: testTopicId,
+        userId,
+      });
+      await serverDB
+        .update(topics)
+        .set({
+          metadata: {
+            runningOperation: {
+              assistantMessageId: 'asst-device',
+              deviceId: 'device-1',
+              heteroType: 'opencode',
+              operationId,
+            },
+          },
+        })
+        .where(eq(topics.id, testTopicId));
+      mockInterruptOperation.mockResolvedValue(false);
+      const callOrder: string[] = [];
+      mockHeteroFinish.mockImplementation(async () => {
+        callOrder.push('server-finish');
+      });
+      mockExecuteToolCall.mockImplementation(async () => {
+        callOrder.push('device-cancel');
+        return {};
+      });
+
+      const caller = aiAgentRouter.createCaller(createTestContext());
+      const result = await caller.interruptTask({ operationId, topicId: testTopicId });
+
+      expect(result).toMatchObject({ operationId, success: true });
+      expect(mockHeteroFinish).toHaveBeenCalledWith({
+        agentType: 'opencode',
+        operationId,
+        result: 'cancelled',
+        topicId: testTopicId,
+      });
+      expect(mockExecuteToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: 'device-1', userId }),
+        {
+          apiName: 'cancelHeteroTask',
+          arguments: JSON.stringify({ signal: 'SIGINT', taskId: operationId }),
+          identifier: 'cancelHeteroTask',
+        },
+        5000,
+      );
+      expect(callOrder).toEqual(['server-finish', 'device-cancel']);
+      expect(mockInterruptOperation).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
+++ b/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
@@ -189,7 +189,11 @@ export class CompletionLifecycle {
    * outage must never block hook dispatch or the executor's terminal
    * cleanup path.
    */
-  private async persistCompletion(operationId: string, state: any, reason: string): Promise<void> {
+  private async persistCompletion(
+    operationId: string,
+    state: any,
+    reason: string,
+  ): Promise<boolean> {
     const completionReason: any =
       reason === 'max_steps' ||
       reason === 'cost_limit' ||
@@ -235,37 +239,52 @@ export class CompletionLifecycle {
     };
 
     try {
-      await this.agentOperationModel.recordCompletion(operationId, {
-        completedAt,
-        completionReason,
-        cost: state?.cost ?? null,
-        error: state?.error ?? null,
-        interruption: state?.interruption ?? null,
-        llmCalls: add(state?.usage?.llm?.apiCalls, rollup?.llmCalls ?? 0),
-        // Backfill the executed model/provider when the terminal state carries
-        // them. The in-process runtime sets neither on `state` (the op already
-        // holds them from recordStart) so these stay undefined and recordCompletion
-        // skips them — a no-op. A heterogeneous run, which only learns its real
-        // model from the CLI stream, feeds them in via the synthetic state built in
-        // heteroFinish; the verify gate keys off op.model/provider, so dropping this
-        // backfill would leave op.model null and silently skip verify.
-        model: state?.model,
-        processingTimeMs,
-        provider: state?.provider,
-        status,
-        stepCount: state?.stepCount ?? null,
-        toolCalls: add(state?.usage?.tools?.totalCalls, rollup?.toolCalls ?? 0),
-        totalCost: add(state?.cost?.total, rollup?.totalCost ?? 0),
-        totalInputTokens: add(state?.usage?.llm?.tokens?.input, rollup?.totalInputTokens ?? 0),
-        totalOutputTokens: add(state?.usage?.llm?.tokens?.output, rollup?.totalOutputTokens ?? 0),
-        totalTokens: add(state?.usage?.llm?.tokens?.total, rollup?.totalTokens ?? 0),
-        traceS3Key,
-        // The `usage` / `cost` blobs stay the op's OWN accumulator, un-rolled-up:
-        // they are the runtime's counter, and the executor reads them back as state
-        // (the cost-limit gate compares `state.cost.total` against the budget). Only
-        // the scalar columns — the reporting surface — carry the whole tree.
-        usage: state?.usage ?? null,
-      });
+      const persisted = await this.agentOperationModel.recordCompletion(
+        operationId,
+        {
+          completedAt,
+          completionReason,
+          cost: state?.cost ?? null,
+          error: state?.error ?? null,
+          interruption: state?.interruption ?? null,
+          llmCalls: add(state?.usage?.llm?.apiCalls, rollup?.llmCalls ?? 0),
+          // Backfill the executed model/provider when the terminal state carries
+          // them. The in-process runtime sets neither on `state` (the op already
+          // holds them from recordStart) so these stay undefined and recordCompletion
+          // skips them — a no-op. A heterogeneous run, which only learns its real
+          // model from the CLI stream, feeds them in via the synthetic state built in
+          // heteroFinish; the verify gate keys off op.model/provider, so dropping this
+          // backfill would leave op.model null and silently skip verify.
+          model: state?.model,
+          processingTimeMs,
+          provider: state?.provider,
+          status,
+          stepCount: state?.stepCount ?? null,
+          toolCalls: add(state?.usage?.tools?.totalCalls, rollup?.toolCalls ?? 0),
+          totalCost: add(state?.cost?.total, rollup?.totalCost ?? 0),
+          totalInputTokens: add(state?.usage?.llm?.tokens?.input, rollup?.totalInputTokens ?? 0),
+          totalOutputTokens: add(state?.usage?.llm?.tokens?.output, rollup?.totalOutputTokens ?? 0),
+          totalTokens: add(state?.usage?.llm?.tokens?.total, rollup?.totalTokens ?? 0),
+          traceS3Key,
+          // The `usage` / `cost` blobs stay the op's OWN accumulator, un-rolled-up:
+          // they are the runtime's counter, and the executor reads them back as state
+          // (the cost-limit gate compares `state.cost.total` against the budget). Only
+          // the scalar columns — the reporting surface — carry the whole tree.
+          usage: state?.usage ?? null,
+        },
+        // Terminal callbacks are re-deliverable and can race (for example Stop
+        // followed by a late child-process error). First terminal writer wins.
+        { onlyIfActive: !isParkedStatus(status) },
+      );
+
+      if (!persisted) {
+        const existing = await this.agentOperationModel.findById(operationId);
+        // A missing start row is a tolerated tracing failure: keep dispatching
+        // hooks. An existing terminal row means this is a duplicate/late finish.
+        if (existing && !isParkedStatus(existing.status) && existing.status !== 'running') {
+          return false;
+        }
+      }
     } catch (error) {
       log('[%s] Failed to persist operation completion (non-fatal): %O', operationId, error);
     }
@@ -285,6 +304,8 @@ export class CompletionLifecycle {
         log('[%s] Failed to recompute topic usage rollup (non-fatal): %O', operationId, error);
       }
     }
+
+    return true;
   }
 
   /** Best-effort child-usage rollup — a DB hiccup must not fail the completion write. */
@@ -504,7 +525,7 @@ export class CompletionLifecycle {
    */
   async completeOperation(
     input: OperationCompletionInput,
-    reason: 'done' | 'error',
+    reason: 'done' | 'error' | 'interrupted',
     options?: CompleteOperationOptions,
   ): Promise<void> {
     await this.dispatchHooks(input.operationId, this.buildStateFromInput(input), reason, options);
@@ -539,7 +560,8 @@ export class CompletionLifecycle {
 
       // Finalize the agent_operations row before user hooks fire so
       // downstream consumers see the row in its terminal shape.
-      await this.persistCompletion(operationId, state, reason);
+      const isFirstTerminalTransition = await this.persistCompletion(operationId, state, reason);
+      if (isFirstTerminalTransition === false) return;
 
       if (isAsyncToolPark) return;
 

--- a/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
+++ b/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
@@ -522,13 +522,14 @@ export class CompletionLifecycle {
    * terminal op row, fire onComplete/onError hooks, and (on `done`) run the
    * delivery-checker verify gate. This is what makes those paths true lifecycle
    * peers instead of firing a stripped-down hooks-only funnel.
+   * Returns `false` only when another callback already owns the terminal CAS.
    */
   async completeOperation(
     input: OperationCompletionInput,
     reason: 'done' | 'error' | 'interrupted',
     options?: CompleteOperationOptions,
-  ): Promise<void> {
-    await this.dispatchHooks(input.operationId, this.buildStateFromInput(input), reason, options);
+  ): Promise<boolean> {
+    return this.dispatchHooks(input.operationId, this.buildStateFromInput(input), reason, options);
   }
 
   /**
@@ -536,13 +537,14 @@ export class CompletionLifecycle {
    * the global `hookDispatcher`. On the error path, also writes the error
    * back onto the assistant message row so the frontend can render it.
    * Fire-and-forget; always unregisters the operation from the dispatcher.
+   * Returns `false` only for a known duplicate/late terminal transition.
    */
   async dispatchHooks(
     operationId: string,
     state: any,
     reason: string,
     options?: CompleteOperationOptions,
-  ): Promise<void> {
+  ): Promise<boolean> {
     // `waiting_for_async_tool` parks the SAME operation: it persists the parked
     // status (the async-tool resume CAS reads it) but must NOT fire `onComplete`
     // or unregister hooks — the op resumes under this same id and reaches its
@@ -561,9 +563,9 @@ export class CompletionLifecycle {
       // Finalize the agent_operations row before user hooks fire so
       // downstream consumers see the row in its terminal shape.
       const isFirstTerminalTransition = await this.persistCompletion(operationId, state, reason);
-      if (isFirstTerminalTransition === false) return;
+      if (isFirstTerminalTransition === false) return false;
 
-      if (isAsyncToolPark) return;
+      if (isAsyncToolPark) return true;
 
       // `lastAssistantContent` comes off the Redis-backed `state.messages`,
       // while the assistant message row is persisted through a separate
@@ -667,6 +669,8 @@ export class CompletionLifecycle {
         this.verifyPlanInstantiations.delete(operationId);
       }
     }
+
+    return true;
   }
 
   /**

--- a/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
@@ -492,6 +492,23 @@ describe('CompletionLifecycle.dispatchHooks — error persistence', () => {
   });
 });
 
+describe('CompletionLifecycle.completeOperation — terminal claim', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns false and skips hooks when another callback already claimed the terminal CAS', async () => {
+    const lifecycle = buildLifecycle();
+    vi.spyOn(lifecycle as any, 'persistCompletion').mockResolvedValue(false);
+    const dispatchSpy = vi.spyOn(hookDispatcher, 'dispatch').mockResolvedValue(undefined as any);
+
+    const claimed = await lifecycle.completeOperation({ operationId: 'op-1' }, 'done');
+
+    expect(claimed).toBe(false);
+    expect(dispatchSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe('CompletionLifecycle.dispatchHooks — verify plan race', () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -151,7 +151,10 @@ import { getScopedOnlineDevices } from '@/server/services/deviceGateway/scopedDe
 import { DocumentService } from '@/server/services/document';
 import { FileService } from '@/server/services/file';
 import { resolveAttachmentsByFileIds } from '@/server/services/file/resolveAttachments';
-import { HeterogeneousAgentService } from '@/server/services/heterogeneousAgent';
+import {
+  HeterogeneousAgentService,
+  type HeterogeneousAgentType,
+} from '@/server/services/heterogeneousAgent';
 import type { ConversationHistoryEntry } from '@/server/services/heterogeneousAgent/cloudHeteroContext';
 import { buildCloudHeteroContext } from '@/server/services/heterogeneousAgent/cloudHeteroContext';
 import { buildRemoteDeviceHeteroContext } from '@/server/services/heterogeneousAgent/remoteDeviceHeteroContext';
@@ -2005,19 +2008,18 @@ export class AiAgentService {
       // operation, and so every terminal site (heteroFinish, agentNotify done,
       // dispatch failure) can re-fire the serialized hooks across a process
       // boundary in queue mode.
-      await this.topicModel.updateMetadata(topicId, {
-        runningOperation: {
-          assistantMessageId: assistantMessageRecord.id,
-          hooks: serializedHooks,
-          // Store deviceId + heteroType so interruptTask can cancel remote processes
-          ...(isRemoteHetero && remoteDeviceId
-            ? { deviceId: remoteDeviceId, heteroType }
-            : undefined),
-          operationId,
-          scope: appContext?.scope ?? undefined,
-          threadId: appContext?.threadId ?? undefined,
-        },
-      });
+      const runningOperation = {
+        assistantMessageId: assistantMessageRecord.id,
+        hooks: serializedHooks,
+        // Persist the runtime for every hetero operation. Device id is known
+        // immediately for remote agents and is backfilled after local planning.
+        ...(isRemoteHetero && remoteDeviceId ? { deviceId: remoteDeviceId } : undefined),
+        heteroType,
+        operationId,
+        scope: appContext?.scope ?? undefined,
+        threadId: appContext?.threadId ?? undefined,
+      };
+      await this.topicModel.updateMetadata(topicId, { runningOperation });
 
       // Remote hetero agents (openclaw / hermes) dispatch to the device identified
       // by agencyConfig.boundDeviceId and communicate back via agentNotify.notify.
@@ -2273,6 +2275,13 @@ export class AiAgentService {
             agentSystemContext: agentConfig.agencyConfig?.heterogeneousProvider?.systemContext,
             conversationHistory,
             cwd: deviceCwd,
+          });
+
+          // Stop routes through the existing cancelHeteroTask device relay with
+          // taskId=operationId. Persist the selected device before dispatch so
+          // cancellation remains routable after a page reload.
+          await this.topicModel.updateMetadata(topicId, {
+            runningOperation: { ...runningOperation, deviceId: dispatchDeviceId },
           });
 
           const result = await deviceGateway.dispatchAgentRun({
@@ -5042,6 +5051,7 @@ export class AiAgentService {
 
     // 1. Get operationId and thread
     let resolvedOperationId = operationId;
+    let resolvedTopicId = topicId;
     let thread;
 
     if (threadId) {
@@ -5050,50 +5060,96 @@ export class AiAgentService {
         throw new Error('Thread not found');
       }
       resolvedOperationId = resolvedOperationId || thread.metadata?.operationId;
+      resolvedTopicId = resolvedTopicId || thread.topicId;
     }
 
     if (!resolvedOperationId) {
       throw new Error('Operation ID not found');
     }
 
-    // 2. Cancel remote hetero process (openclaw / hermes) if applicable.
-    // Check topic.metadata.runningOperation for device + heteroType info seeded by execAgent.
-    // This runs regardless of whether interruptOperation succeeds — the remote process
-    // is independent of the local operation registry.
-    if (topicId) {
-      const topic = await this.topicModel.findById(topicId);
+    const operation = await this.agentOperationModel.findById(resolvedOperationId);
+    resolvedTopicId = resolvedTopicId || operation?.topicId || undefined;
+
+    // 2. Cancel a device child best-effort, then independently drive the
+    // authoritative server terminal transition. Device reachability must never
+    // decide whether Stop survives a refresh.
+    if (resolvedTopicId) {
+      let cancelDeviceChild: (() => Promise<unknown>) | undefined;
+      const topic = await this.topicModel.findById(resolvedTopicId);
       const runningOp = (topic?.metadata as any)?.runningOperation as
         { deviceId?: string; heteroType?: string; operationId?: string } | undefined;
+      const markerMatches = runningOp?.operationId === resolvedOperationId;
+      const operationMatchesTopic = operation?.topicId === resolvedTopicId;
+      const cliHeteroTypes: HeterogeneousAgentType[] = ['amp', 'claude-code', 'codex', 'opencode'];
+      const cliHeteroType = cliHeteroTypes.find(
+        (type) =>
+          (markerMatches && runningOp?.heteroType === type) ||
+          (operationMatchesTopic && operation?.provider === type),
+      );
 
-      if (
-        runningOp?.deviceId &&
-        runningOp.heteroType &&
-        isRemoteHeterogeneousType(runningOp.heteroType)
-      ) {
-        const taskId = runningOp.operationId ?? resolvedOperationId;
-        log(
-          'interruptTask: cancelling remote hetero process heteroType=%s deviceId=%s taskId=%s',
-          runningOp.heteroType,
-          runningOp.deviceId,
-          taskId,
-        );
-        const cancelWorkspaceId = await this.resolveDeviceWorkspaceId(runningOp.deviceId);
-        await deviceGateway
-          .executeToolCall(
-            {
-              deviceId: runningOp.deviceId,
-              userId: this.userId,
-              workspaceId: cancelWorkspaceId,
-            },
-            {
-              apiName: 'cancelHeteroTask',
-              arguments: JSON.stringify({ signal: 'SIGINT', taskId }),
-              identifier: 'cancelHeteroTask',
-            },
-            5_000,
-          )
-          .catch((err) => log('interruptTask: cancelHeteroTask dispatch failed: %O', err));
+      if (markerMatches && runningOp?.deviceId && runningOp.heteroType) {
+        const taskId = resolvedOperationId;
+        const deviceId = runningOp.deviceId;
+        const heteroType = runningOp.heteroType;
+        cancelDeviceChild = async () => {
+          log(
+            'interruptTask: cancelling device hetero process heteroType=%s deviceId=%s taskId=%s',
+            heteroType,
+            deviceId,
+            taskId,
+          );
+          const cancelWorkspaceId = await this.resolveDeviceWorkspaceId(deviceId);
+          return deviceGateway
+            .executeToolCall(
+              {
+                deviceId,
+                userId: this.userId,
+                workspaceId: cancelWorkspaceId,
+              },
+              {
+                apiName: 'cancelHeteroTask',
+                arguments: JSON.stringify({ signal: 'SIGINT', taskId }),
+                identifier: 'cancelHeteroTask',
+              },
+              5_000,
+            )
+            .catch((err) => log('interruptTask: cancelHeteroTask dispatch failed: %O', err));
+        };
       }
+
+      if (cliHeteroType) {
+        // Persist the authoritative terminal state BEFORE asking the device to
+        // kill its child. A CLI daemon reports child exit as an error fallback;
+        // dispatching the signal first would let that callback win the terminal
+        // CAS and turn an explicit user Stop into an error.
+        await new HeterogeneousAgentService(this.db, this.userId, {
+          workspaceId: this.workspaceId,
+        }).heteroFinish({
+          agentType: cliHeteroType,
+          operationId: resolvedOperationId,
+          result: 'cancelled',
+          topicId: resolvedTopicId,
+        });
+        await cancelDeviceChild?.();
+
+        if (thread) {
+          await this.threadModel.update(thread.id, {
+            metadata: {
+              ...thread.metadata,
+              completedAt: new Date().toISOString(),
+            },
+            status: ThreadStatus.Cancel,
+          });
+        }
+
+        return {
+          operationId: resolvedOperationId,
+          success: true,
+          threadId: thread?.id,
+        };
+      }
+
+      await cancelDeviceChild?.();
     }
 
     // 3. Interrupt the runtime operation first. Only mark the thread cancelled

--- a/apps/server/src/services/heterogeneousAgent/__tests__/index.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/__tests__/index.test.ts
@@ -474,6 +474,7 @@ describe('HeterogeneousAgentService', () => {
             signalFirstEntered();
             await firstBlocked;
           }
+          return true;
         });
 
       const first = service.heteroFinish({
@@ -502,7 +503,172 @@ describe('HeterogeneousAgentService', () => {
       findByIdSpy.mockRestore();
     });
 
-    it('ignores a late process-exit fallback after the operation is already interrupted', async () => {
+    it('publishes the durable interruption when a process-exit error loses the terminal CAS to Stop', async () => {
+      const topicModel = {
+        clearRunningOperation: vi.fn(async () => true),
+        findById: vi.fn(async () => ({
+          metadata: { runningOperation: { operationId: 'op-stop-wins' } },
+        })),
+      } as any;
+      const { manager } = createFakeStreamManager();
+      const service = new HeterogeneousAgentService({} as any, 'user-test', {
+        persistenceHandler: createFakePersistenceHandler(),
+        streamEventManager: manager,
+        topicModel,
+      });
+      const findByIdSpy = vi
+        .spyOn(AgentOperationModel.prototype, 'findById')
+        .mockResolvedValueOnce({ status: 'running' } as any)
+        .mockResolvedValueOnce({ status: 'running' } as any)
+        .mockResolvedValue({ error: null, status: 'interrupted' } as any);
+      const finalizeSpy = vi
+        .spyOn(HeteroTraceRecorder.prototype, 'finalize')
+        .mockResolvedValue(null);
+
+      let releaseWinner!: () => void;
+      let signalWinnerClaimed!: () => void;
+      const winnerClaimed = new Promise<void>((resolve) => {
+        signalWinnerClaimed = resolve;
+      });
+      const winnerBlocked = new Promise<void>((resolve) => {
+        releaseWinner = resolve;
+      });
+      const completionSpy = vi
+        .spyOn(CompletionLifecycle.prototype, 'completeOperation')
+        .mockImplementationOnce(async () => {
+          signalWinnerClaimed();
+          await winnerBlocked;
+          return true;
+        })
+        .mockResolvedValueOnce(false);
+
+      const stop = service.heteroFinish({
+        agentType: 'opencode',
+        operationId: 'op-stop-wins',
+        result: 'cancelled',
+        topicId: 'topic-stop-wins',
+      });
+      await winnerClaimed;
+
+      await service.heteroFinish({
+        agentType: 'opencode',
+        error: { message: 'child exited', type: 'HeterogeneousAgentProcessExit' },
+        operationId: 'op-stop-wins',
+        result: 'error',
+        topicId: 'topic-stop-wins',
+      });
+
+      expect(manager.publishStreamEvent).toHaveBeenCalledTimes(1);
+      expect(manager.publishStreamEvent).toHaveBeenLastCalledWith('op-stop-wins', {
+        data: {
+          agentType: 'opencode',
+          error: undefined,
+          operationId: 'op-stop-wins',
+          reason: 'cancelled',
+          sessionId: undefined,
+        },
+        stepIndex: 0,
+        type: 'agent_runtime_end',
+      });
+
+      releaseWinner();
+      await stop;
+      expect(
+        vi
+          .mocked(manager.publishStreamEvent)
+          .mock.calls.every(
+            ([, event]) => (event.data as { reason?: string }).reason === 'cancelled',
+          ),
+      ).toBe(true);
+
+      completionSpy.mockRestore();
+      finalizeSpy.mockRestore();
+      findByIdSpy.mockRestore();
+    });
+
+    it('publishes the durable error when Stop loses the terminal CAS to a CLI error', async () => {
+      const topicModel = {
+        clearRunningOperation: vi.fn(async () => true),
+        findById: vi.fn(async () => ({
+          metadata: { runningOperation: { operationId: 'op-error-wins' } },
+        })),
+      } as any;
+      const { manager } = createFakeStreamManager();
+      const service = new HeterogeneousAgentService({} as any, 'user-test', {
+        persistenceHandler: createFakePersistenceHandler(),
+        streamEventManager: manager,
+        topicModel,
+      });
+      const durableError = { message: 'auth required', type: 'AuthRequired' };
+      const findByIdSpy = vi
+        .spyOn(AgentOperationModel.prototype, 'findById')
+        .mockResolvedValueOnce({ status: 'running' } as any)
+        .mockResolvedValueOnce({ status: 'running' } as any)
+        .mockResolvedValue({ error: durableError, status: 'error' } as any);
+      const finalizeSpy = vi
+        .spyOn(HeteroTraceRecorder.prototype, 'finalize')
+        .mockResolvedValue(null);
+
+      let releaseWinner!: () => void;
+      let signalWinnerClaimed!: () => void;
+      const winnerClaimed = new Promise<void>((resolve) => {
+        signalWinnerClaimed = resolve;
+      });
+      const winnerBlocked = new Promise<void>((resolve) => {
+        releaseWinner = resolve;
+      });
+      const completionSpy = vi
+        .spyOn(CompletionLifecycle.prototype, 'completeOperation')
+        .mockImplementationOnce(async () => {
+          signalWinnerClaimed();
+          await winnerBlocked;
+          return true;
+        })
+        .mockResolvedValueOnce(false);
+
+      const finish = service.heteroFinish({
+        agentType: 'codex',
+        error: durableError,
+        operationId: 'op-error-wins',
+        result: 'error',
+        topicId: 'topic-error-wins',
+      });
+      await winnerClaimed;
+
+      await service.heteroFinish({
+        agentType: 'codex',
+        operationId: 'op-error-wins',
+        result: 'cancelled',
+        topicId: 'topic-error-wins',
+      });
+
+      expect(manager.publishStreamEvent).toHaveBeenCalledTimes(1);
+      expect(manager.publishStreamEvent).toHaveBeenLastCalledWith('op-error-wins', {
+        data: {
+          agentType: 'codex',
+          error: durableError,
+          operationId: 'op-error-wins',
+          reason: 'error',
+          sessionId: undefined,
+        },
+        stepIndex: 0,
+        type: 'agent_runtime_end',
+      });
+
+      releaseWinner();
+      await finish;
+      expect(
+        vi
+          .mocked(manager.publishStreamEvent)
+          .mock.calls.every(([, event]) => (event.data as { reason?: string }).reason === 'error'),
+      ).toBe(true);
+
+      completionSpy.mockRestore();
+      finalizeSpy.mockRestore();
+      findByIdSpy.mockRestore();
+    });
+
+    it('normalizes a late process-exit fallback after Stop and re-publishes the persisted terminal', async () => {
       const findByIdSpy = vi
         .spyOn(AgentOperationModel.prototype, 'findById')
         .mockResolvedValue({ status: 'interrupted' } as any);
@@ -531,7 +697,21 @@ describe('HeterogeneousAgentService', () => {
         sessionId: undefined,
         topicId: 'topic-interrupted',
       });
-      expect(manager.publishStreamEvent).not.toHaveBeenCalled();
+      // The end event mirrors the DURABLE interrupted result — not this
+      // callback's synthetic process-exit error — so gateway clients that
+      // missed the first publish still shut down without an error flash.
+      expect(manager.publishStreamEvent).toHaveBeenCalledTimes(1);
+      expect(manager.publishStreamEvent).toHaveBeenCalledWith('op-interrupted', {
+        data: {
+          agentType: 'opencode',
+          error: undefined,
+          operationId: 'op-interrupted',
+          reason: 'cancelled',
+          sessionId: undefined,
+        },
+        stepIndex: 0,
+        type: 'agent_runtime_end',
+      });
       expect(topicModel.clearRunningOperation).toHaveBeenCalledWith(
         'topic-interrupted',
         'op-interrupted',
@@ -568,7 +748,88 @@ describe('HeterogeneousAgentService', () => {
         sessionId: 'session-after-stop',
         topicId: 'topic-interrupted',
       });
-      expect(manager.publishStreamEvent).not.toHaveBeenCalled();
+      // Re-published end event mirrors the persisted interrupted result while
+      // still relaying the late native session id.
+      expect(manager.publishStreamEvent).toHaveBeenCalledWith('op-interrupted', {
+        data: {
+          agentType: 'claude-code',
+          error: undefined,
+          operationId: 'op-interrupted',
+          reason: 'cancelled',
+          sessionId: 'session-after-stop',
+        },
+        stepIndex: 0,
+        type: 'agent_runtime_end',
+      });
+      findByIdSpy.mockRestore();
+    });
+
+    it('re-publishes the durable terminal result when a fallback is redelivered after a failed publish', async () => {
+      // First delivery persisted `done` but its publishTerminal failed — the
+      // caller redelivers (process-exit fallback). The duplicate branch must
+      // still emit `agent_runtime_end`, or connected gateway clients spin
+      // forever; and it must mirror the durable success, not this callback's
+      // synthetic error.
+      const findByIdSpy = vi
+        .spyOn(AgentOperationModel.prototype, 'findById')
+        .mockResolvedValue({ error: null, status: 'done' } as any);
+      const topicModel = { clearRunningOperation: vi.fn(async () => true) } as any;
+      const { manager } = createFakeStreamManager();
+      const persistenceHandler = createFakePersistenceHandler();
+      const service = new HeterogeneousAgentService({} as any, 'user-test', {
+        persistenceHandler,
+        streamEventManager: manager,
+        topicModel,
+      });
+
+      await service.heteroFinish({
+        agentType: 'codex',
+        error: {
+          message: 'CLI child exited after acceptance (code=1, signal=none)',
+          type: 'HeterogeneousAgentProcessExit',
+        },
+        operationId: 'op-republish',
+        result: 'error',
+        topicId: 'topic-republish',
+      });
+
+      expect(manager.publishStreamEvent).toHaveBeenCalledTimes(1);
+      expect(manager.publishStreamEvent).toHaveBeenCalledWith('op-republish', {
+        data: {
+          agentType: 'codex',
+          error: undefined,
+          operationId: 'op-republish',
+          reason: 'success',
+          sessionId: undefined,
+        },
+        stepIndex: 0,
+        type: 'agent_runtime_end',
+      });
+      findByIdSpy.mockRestore();
+    });
+
+    it('rejects the duplicate delivery when the terminal re-publish fails, so the caller retries', async () => {
+      const findByIdSpy = vi
+        .spyOn(AgentOperationModel.prototype, 'findById')
+        .mockResolvedValue({ error: null, status: 'done' } as any);
+      const topicModel = { clearRunningOperation: vi.fn(async () => true) } as any;
+      const manager: Partial<IStreamEventManager> = {
+        publishStreamEvent: vi.fn().mockRejectedValue(new Error('redis down')),
+      };
+      const service = new HeterogeneousAgentService({} as any, 'user-test', {
+        persistenceHandler: createFakePersistenceHandler(),
+        streamEventManager: manager as IStreamEventManager,
+        topicModel,
+      });
+
+      await expect(
+        service.heteroFinish({
+          agentType: 'codex',
+          operationId: 'op-republish-fail',
+          result: 'success',
+          topicId: 'topic-republish',
+        }),
+      ).rejects.toThrow('redis down');
       findByIdSpy.mockRestore();
     });
 
@@ -653,7 +914,7 @@ describe('HeterogeneousAgentService', () => {
       } as any);
       const dispatchSpy = vi
         .spyOn(CompletionLifecycle.prototype, 'dispatchHooks')
-        .mockResolvedValue();
+        .mockResolvedValue(true);
 
       await service.heteroFinish({
         agentType: 'claude-code',
@@ -698,7 +959,7 @@ describe('HeterogeneousAgentService', () => {
         .mockResolvedValue();
       const dispatchSpy = vi
         .spyOn(CompletionLifecycle.prototype, 'dispatchHooks')
-        .mockResolvedValue();
+        .mockResolvedValue(true);
 
       await service.heteroFinish({
         agentType: 'claude-code',
@@ -735,7 +996,7 @@ describe('HeterogeneousAgentService', () => {
         .mockResolvedValue();
       const dispatchSpy = vi
         .spyOn(CompletionLifecycle.prototype, 'dispatchHooks')
-        .mockResolvedValue();
+        .mockResolvedValue(true);
 
       await service.heteroFinish({
         agentType: 'claude-code',

--- a/apps/server/src/services/heterogeneousAgent/__tests__/index.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/__tests__/index.test.ts
@@ -420,6 +420,88 @@ describe('HeterogeneousAgentService', () => {
       expect(topicModel.clearRunningOperation).toHaveBeenCalledWith('topic-cancel', 'op-cancel');
     });
 
+    it('retains serialized hooks until racing terminal callbacks reach the lifecycle CAS', async () => {
+      const serializedHooks: SerializedHook[] = [
+        {
+          id: 'task-on-complete',
+          type: 'onComplete',
+          webhook: {
+            body: { taskId: 'task-race' },
+            delivery: 'qstash',
+            url: '/api/workflows/task/on-topic-complete',
+          },
+        },
+      ];
+      let marker:
+        { assistantMessageId: string; hooks: SerializedHook[]; operationId: string } | undefined = {
+        assistantMessageId: 'asst-race',
+        hooks: serializedHooks,
+        operationId: 'op-race',
+      };
+      const topicModel = {
+        clearRunningOperation: vi.fn(async () => {
+          marker = undefined;
+          return true;
+        }),
+        findById: vi.fn(async () => ({
+          metadata: marker ? { runningOperation: marker } : {},
+        })),
+      } as any;
+      const { manager } = createFakeStreamManager();
+      const service = new HeterogeneousAgentService({} as any, 'user-test', {
+        persistenceHandler: createFakePersistenceHandler(),
+        streamEventManager: manager,
+        topicModel,
+      });
+      const findByIdSpy = vi
+        .spyOn(AgentOperationModel.prototype, 'findById')
+        .mockResolvedValue({ status: 'running' } as any);
+
+      let releaseFirst!: () => void;
+      let signalFirstEntered!: () => void;
+      const firstEntered = new Promise<void>((resolve) => {
+        signalFirstEntered = resolve;
+      });
+      const firstBlocked = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      const completionInputs: any[] = [];
+      const completionSpy = vi
+        .spyOn(CompletionLifecycle.prototype, 'completeOperation')
+        .mockImplementation(async (input) => {
+          completionInputs.push(input);
+          if (completionInputs.length === 1) {
+            signalFirstEntered();
+            await firstBlocked;
+          }
+        });
+
+      const first = service.heteroFinish({
+        agentType: 'opencode',
+        operationId: 'op-race',
+        result: 'cancelled',
+        topicId: 'topic-race',
+      });
+      await firstEntered;
+      expect(topicModel.clearRunningOperation).not.toHaveBeenCalled();
+
+      const second = service.heteroFinish({
+        agentType: 'opencode',
+        operationId: 'op-race',
+        result: 'cancelled',
+        topicId: 'topic-race',
+      });
+      await vi.waitFor(() => expect(completionInputs).toHaveLength(2));
+      releaseFirst();
+      await Promise.all([first, second]);
+
+      expect(completionInputs[0].serializedHooks).toEqual(serializedHooks);
+      expect(completionInputs[1].serializedHooks).toEqual(serializedHooks);
+
+      completionSpy.mockRestore();
+      findByIdSpy.mockRestore();
+    });
+
     it('ignores a late process-exit fallback after the operation is already interrupted', async () => {
       const findByIdSpy = vi
         .spyOn(AgentOperationModel.prototype, 'findById')

--- a/apps/server/src/services/heterogeneousAgent/__tests__/index.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/__tests__/index.test.ts
@@ -394,6 +394,102 @@ describe('HeterogeneousAgentService', () => {
       });
     });
 
+    it('clears the matching reconnect marker when a run is cancelled', async () => {
+      const topicModel = {
+        clearRunningOperation: vi.fn(async () => true),
+        findById: vi.fn(async () => ({
+          metadata: {
+            runningOperation: { assistantMessageId: 'asst-3', operationId: 'op-cancel' },
+          },
+        })),
+      } as any;
+      const { manager } = createFakeStreamManager();
+      const service = new HeterogeneousAgentService({} as any, 'user-test', {
+        persistenceHandler: createFakePersistenceHandler(),
+        streamEventManager: manager,
+        topicModel,
+      });
+
+      await service.heteroFinish({
+        agentType: 'opencode',
+        operationId: 'op-cancel',
+        result: 'cancelled',
+        topicId: 'topic-cancel',
+      });
+
+      expect(topicModel.clearRunningOperation).toHaveBeenCalledWith('topic-cancel', 'op-cancel');
+    });
+
+    it('ignores a late process-exit fallback after the operation is already interrupted', async () => {
+      const findByIdSpy = vi
+        .spyOn(AgentOperationModel.prototype, 'findById')
+        .mockResolvedValue({ status: 'interrupted' } as any);
+      const topicModel = {
+        clearRunningOperation: vi.fn(async () => true),
+      } as any;
+      const { manager } = createFakeStreamManager();
+      const persistenceHandler = createFakePersistenceHandler();
+      const service = new HeterogeneousAgentService({} as any, 'user-test', {
+        persistenceHandler,
+        streamEventManager: manager,
+        topicModel,
+      });
+
+      await service.heteroFinish({
+        agentType: 'opencode',
+        error: { message: 'child exited', type: 'HeterogeneousAgentProcessExit' },
+        operationId: 'op-interrupted',
+        result: 'error',
+        topicId: 'topic-interrupted',
+      });
+
+      expect(persistenceHandler.finish).toHaveBeenCalledWith({
+        operationId: 'op-interrupted',
+        result: 'cancelled',
+        sessionId: undefined,
+        topicId: 'topic-interrupted',
+      });
+      expect(manager.publishStreamEvent).not.toHaveBeenCalled();
+      expect(topicModel.clearRunningOperation).toHaveBeenCalledWith(
+        'topic-interrupted',
+        'op-interrupted',
+      );
+      findByIdSpy.mockRestore();
+    });
+
+    it('persists a late native session id and drains state after Stop won the terminal race', async () => {
+      const findByIdSpy = vi
+        .spyOn(AgentOperationModel.prototype, 'findById')
+        .mockResolvedValue({ status: 'interrupted' } as any);
+      const topicModel = {
+        clearRunningOperation: vi.fn(async () => true),
+      } as any;
+      const { manager } = createFakeStreamManager();
+      const persistenceHandler = createFakePersistenceHandler();
+      const service = new HeterogeneousAgentService({} as any, 'user-test', {
+        persistenceHandler,
+        streamEventManager: manager,
+        topicModel,
+      });
+
+      await service.heteroFinish({
+        agentType: 'claude-code',
+        operationId: 'op-interrupted',
+        result: 'success',
+        sessionId: 'session-after-stop',
+        topicId: 'topic-interrupted',
+      });
+
+      expect(persistenceHandler.finish).toHaveBeenCalledWith({
+        operationId: 'op-interrupted',
+        result: 'success',
+        sessionId: 'session-after-stop',
+        topicId: 'topic-interrupted',
+      });
+      expect(manager.publishStreamEvent).not.toHaveBeenCalled();
+      findByIdSpy.mockRestore();
+    });
+
     // The unified terminal funnel: heteroFinish must drive the run's lifecycle
     // hooks through the shared hookDispatcher (the same mechanism the normal LLM
     // path uses), which is what marks the owning task done/failed and fires any
@@ -575,7 +671,7 @@ describe('HeterogeneousAgentService', () => {
       dispatchSpy.mockRestore();
     });
 
-    it('does NOT fire hooks on a cancelled run (the real result fires them)', async () => {
+    it('finalizes a cancelled run as interrupted and unregisters its hooks', async () => {
       const { service } = createService();
       const { onComplete, onError } = registerHook('op-hook-cancelled');
 
@@ -586,11 +682,13 @@ describe('HeterogeneousAgentService', () => {
         topicId: 'topic-hook-3',
       });
 
-      expect(onComplete).not.toHaveBeenCalled();
+      expect(onComplete).toHaveBeenCalledTimes(1);
+      expect(onComplete.mock.calls[0][0]).toMatchObject({
+        operationId: 'op-hook-cancelled',
+        reason: 'interrupted',
+      });
       expect(onError).not.toHaveBeenCalled();
-      // Still registered — the subsequent success/error call will dispatch them.
-      expect(hookDispatcher.hasHooks('op-hook-cancelled')).toBe(true);
-      hookDispatcher.unregister('op-hook-cancelled');
+      expect(hookDispatcher.hasHooks('op-hook-cancelled')).toBe(false);
     });
   });
 

--- a/apps/server/src/services/heterogeneousAgent/index.ts
+++ b/apps/server/src/services/heterogeneousAgent/index.ts
@@ -299,10 +299,21 @@ export class HeterogeneousAgentService {
           : ownsMarker
             ? runningOperation.assistantMessageId
             : undefined;
-      await this.topicModel.clearRunningOperation(topicId, operationId);
     } catch (err) {
-      log('heteroFinish: failed to clear runningOperation (non-fatal): %O', err);
+      log('heteroFinish: failed to read runningOperation (non-fatal): %O', err);
     }
+
+    // Keep the queue-mode copy of serialized hooks until CompletionLifecycle
+    // has claimed the terminal CAS. Concurrent finish callbacks must all be
+    // able to capture the hooks; only the CAS winner dispatches them. Clearing
+    // before the CAS can let a callback without hooks win and strand the task.
+    const clearRunningOperation = async () => {
+      try {
+        await this.topicModel.clearRunningOperation(topicId, operationId);
+      } catch (err) {
+        log('heteroFinish: failed to clear runningOperation (non-fatal): %O', err);
+      }
+    };
 
     // The owning agentId is authoritatively encoded in the operationId
     // (op_<ts>_agt_<id>_tpc_<id>_<suffix>, built at dispatch from the resolved
@@ -325,6 +336,7 @@ export class HeterogeneousAgentService {
         },
         'interrupted',
       );
+      await clearRunningOperation();
       // Publish only after the durable operation + reconnect marker are terminal,
       // so a refresh triggered by this event cannot resurrect the run.
       await publishTerminal();
@@ -443,6 +455,7 @@ export class HeterogeneousAgentService {
       },
       completionReason,
     );
+    await clearRunningOperation();
     await publishTerminal();
     log('heteroFinish: dispatched completion lifecycle for op=%s result=%s', operationId, result);
   }

--- a/apps/server/src/services/heterogeneousAgent/index.ts
+++ b/apps/server/src/services/heterogeneousAgent/index.ts
@@ -202,39 +202,39 @@ export class HeterogeneousAgentService {
       sessionId ?? '<none>',
     );
 
+    const agentOperationModel = new AgentOperationModel(this.db, this.userId, this.workspaceId);
+
     // Terminal callbacks are re-deliverable: Desktop/CLI may send a process-exit
     // fallback after Stop already persisted `interrupted`. Never let that late
     // callback rewrite the terminal result or surface a contradictory error.
+    let persistedTerminal: Awaited<ReturnType<AgentOperationModel['findById']>> | null = null;
+    const publishPersistedTerminal = (terminal: NonNullable<typeof persistedTerminal>) =>
+      this.streamEventManager.publishStreamEvent(operationId, {
+        data: {
+          agentType,
+          error: terminal.error ?? undefined,
+          operationId,
+          reason:
+            terminal.status === 'done'
+              ? 'success'
+              : terminal.status === 'error'
+                ? 'error'
+                : 'cancelled',
+          sessionId,
+        },
+        stepIndex: 0,
+        type: 'agent_runtime_end',
+      });
+
     try {
-      const existing = await new AgentOperationModel(
-        this.db,
-        this.userId,
-        this.workspaceId,
-      ).findById(operationId);
+      const existing = await agentOperationModel.findById(operationId);
       if (
         existing &&
         (existing.status === 'done' ||
           existing.status === 'error' ||
           existing.status === 'interrupted')
       ) {
-        // The durable terminal result is immutable, but a same-replica callback
-        // may still own buffered ingest state (and the CLI's native session id).
-        // Drain that state before returning. Normalize a duplicate error to
-        // cancelled so a generic process-exit fallback cannot overwrite a richer
-        // message error or clear a valid resume id after another terminal path won.
-        await this.persistenceHandler.finish({
-          operationId,
-          result: result === 'error' ? 'cancelled' : result,
-          sessionId,
-          topicId,
-        });
-        await this.topicModel.clearRunningOperation(topicId, operationId).catch(() => false);
-        log(
-          'heteroFinish: ignore duplicate terminal callback op=%s status=%s',
-          operationId,
-          existing.status,
-        );
-        return;
+        persistedTerminal = existing;
       }
       if (!existing) {
         const topic = await this.topicModel.findById(topicId);
@@ -247,6 +247,40 @@ export class HeterogeneousAgentService {
       // Operation tracing is best-effort. If the start row is unavailable,
       // continue so the topic marker and UI stream still reach a terminal state.
       log('heteroFinish: terminal idempotency lookup failed (non-fatal): %O', err);
+    }
+
+    // Duplicate delivery: the durable terminal result is immutable, but this
+    // callback still owes side effects. Kept OUTSIDE the lookup try/catch so a
+    // failure below rejects the call and drives another redelivery, instead of
+    // being swallowed and falling through into the full terminal funnel.
+    if (persistedTerminal) {
+      // A same-replica callback may still own buffered ingest state (and the
+      // CLI's native session id) — drain it. Normalize a duplicate error to
+      // cancelled so a generic process-exit fallback cannot overwrite a richer
+      // message error or clear a valid resume id after another terminal path won.
+      await this.persistenceHandler.finish({
+        operationId,
+        result: result === 'error' ? 'cancelled' : result,
+        sessionId,
+        topicId,
+      });
+      await this.topicModel.clearRunningOperation(topicId, operationId).catch(() => false);
+      // Re-publish the terminal stream event. The first delivery publishes
+      // AFTER the durable writes, so a transient publish failure surfaces as a
+      // tRPC error and the caller redelivers this callback — acknowledging the
+      // retry without re-publishing would leave connected gateway clients with
+      // no `agent_runtime_end`, stuck on a running spinner. Mirror the DURABLE
+      // result (not this callback's payload) so a late process-exit fallback
+      // cannot flash an error over a run that actually succeeded. Gateway closes
+      // this operation's session on terminal delivery and completion side effects
+      // are idempotent, so a repeated publish is safe.
+      await publishPersistedTerminal(persistedTerminal);
+      log(
+        'heteroFinish: drained + re-published duplicate terminal callback op=%s status=%s',
+        operationId,
+        persistedTerminal.status,
+      );
+      return;
     }
 
     // Drain any pending state in the persistence handler — flushes trailing
@@ -315,6 +349,31 @@ export class HeterogeneousAgentService {
       }
     };
 
+    const publishClaimedTerminal = async (isFirstTerminalTransition: boolean) => {
+      await clearRunningOperation();
+      if (isFirstTerminalTransition) {
+        await publishTerminal();
+        return;
+      }
+
+      // Both Stop and the CLI finish can read `running` before either reaches
+      // the terminal CAS. The loser must mirror the winner's durable result;
+      // publishing its callback payload could otherwise flash success/error over
+      // an interrupted run (or cancellation over a completed run).
+      const terminal = await agentOperationModel.findById(operationId);
+      if (
+        !terminal ||
+        (terminal.status !== 'done' &&
+          terminal.status !== 'error' &&
+          terminal.status !== 'interrupted')
+      ) {
+        throw new Error(
+          `Terminal operation not found after losing completion claim: ${operationId}`,
+        );
+      }
+      await publishPersistedTerminal(terminal);
+    };
+
     // The owning agentId is authoritatively encoded in the operationId
     // (op_<ts>_agt_<id>_tpc_<id>_<suffix>, built at dispatch from the resolved
     // agent), so derive it from there. Reading it back off the final assistant
@@ -325,7 +384,11 @@ export class HeterogeneousAgentService {
     const agentId = parseOperationId(operationId)?.agentId;
 
     if (result === 'cancelled') {
-      await new CompletionLifecycle(this.db, this.userId, this.workspaceId).completeOperation(
+      const isFirstTerminalTransition = await new CompletionLifecycle(
+        this.db,
+        this.userId,
+        this.workspaceId,
+      ).completeOperation(
         {
           agentId,
           assistantMessageId,
@@ -336,10 +399,9 @@ export class HeterogeneousAgentService {
         },
         'interrupted',
       );
-      await clearRunningOperation();
       // Publish only after the durable operation + reconnect marker are terminal,
       // so a refresh triggered by this event cannot resurrect the run.
-      await publishTerminal();
+      await publishClaimedTerminal(isFirstTerminalTransition);
       log('heteroFinish: finalized cancellation for op=%s', operationId);
       return;
     }
@@ -425,7 +487,11 @@ export class HeterogeneousAgentService {
     // and on success the delivery-checker card + verify gate run against the task's
     // plan. `completeOperation` owns the (formerly hand-rolled) synthetic-state
     // build, so the goal+reply turns and trace aggregates are mapped in ONE place.
-    await new CompletionLifecycle(this.db, this.userId, this.workspaceId).completeOperation(
+    const isFirstTerminalTransition = await new CompletionLifecycle(
+      this.db,
+      this.userId,
+      this.workspaceId,
+    ).completeOperation(
       {
         agentId,
         assistantMessageId,
@@ -455,8 +521,7 @@ export class HeterogeneousAgentService {
       },
       completionReason,
     );
-    await clearRunningOperation();
-    await publishTerminal();
+    await publishClaimedTerminal(isFirstTerminalTransition);
     log('heteroFinish: dispatched completion lifecycle for op=%s result=%s', operationId, result);
   }
 

--- a/apps/server/src/services/heterogeneousAgent/index.ts
+++ b/apps/server/src/services/heterogeneousAgent/index.ts
@@ -202,6 +202,53 @@ export class HeterogeneousAgentService {
       sessionId ?? '<none>',
     );
 
+    // Terminal callbacks are re-deliverable: Desktop/CLI may send a process-exit
+    // fallback after Stop already persisted `interrupted`. Never let that late
+    // callback rewrite the terminal result or surface a contradictory error.
+    try {
+      const existing = await new AgentOperationModel(
+        this.db,
+        this.userId,
+        this.workspaceId,
+      ).findById(operationId);
+      if (
+        existing &&
+        (existing.status === 'done' ||
+          existing.status === 'error' ||
+          existing.status === 'interrupted')
+      ) {
+        // The durable terminal result is immutable, but a same-replica callback
+        // may still own buffered ingest state (and the CLI's native session id).
+        // Drain that state before returning. Normalize a duplicate error to
+        // cancelled so a generic process-exit fallback cannot overwrite a richer
+        // message error or clear a valid resume id after another terminal path won.
+        await this.persistenceHandler.finish({
+          operationId,
+          result: result === 'error' ? 'cancelled' : result,
+          sessionId,
+          topicId,
+        });
+        await this.topicModel.clearRunningOperation(topicId, operationId).catch(() => false);
+        log(
+          'heteroFinish: ignore duplicate terminal callback op=%s status=%s',
+          operationId,
+          existing.status,
+        );
+        return;
+      }
+      if (!existing) {
+        const topic = await this.topicModel.findById(topicId);
+        if (topic && topic.metadata?.runningOperation?.operationId !== operationId) {
+          log('heteroFinish: ignore stale callback without operation row op=%s', operationId);
+          return;
+        }
+      }
+    } catch (err) {
+      // Operation tracing is best-effort. If the start row is unavailable,
+      // continue so the topic marker and UI stream still reach a terminal state.
+      log('heteroFinish: terminal idempotency lookup failed (non-fatal): %O', err);
+    }
+
     // Drain any pending state in the persistence handler — flushes trailing
     // accumulated content / reasoning that the in-stream `agent_runtime_end`
     // already wrote (no-op when state is clean), persists the CLI's native
@@ -212,21 +259,18 @@ export class HeterogeneousAgentService {
     // triggers the client's message refetch.
     await this.persistenceHandler.finish({ error, operationId, result, sessionId, topicId });
 
-    // Always emit a terminal `agent_runtime_end` so renderer subscribers shut
-    // down even if the CLI stream missed it (process killed mid-flight,
-    // network drop on last batch). Idempotent on the renderer side: the
-    // gateway event handler latches `terminalState` on first end-event.
-    await this.streamEventManager.publishStreamEvent(operationId, {
-      data: {
-        agentType,
-        error,
-        operationId,
-        reason: result,
-        sessionId,
-      },
-      stepIndex: 0,
-      type: 'agent_runtime_end',
-    });
+    const publishTerminal = () =>
+      this.streamEventManager.publishStreamEvent(operationId, {
+        data: {
+          agentType,
+          error,
+          operationId,
+          reason: result,
+          sessionId,
+        },
+        stepIndex: 0,
+        type: 'agent_runtime_end',
+      });
 
     // Drive the run's lifecycle hooks (onComplete / onError) through the same
     // `hookDispatcher` the normal LLM runtime uses, so the task lifecycle
@@ -234,21 +278,15 @@ export class HeterogeneousAgentService {
     // fire uniformly. The hooks were registered in-memory (local mode) and
     // serialized onto runningOperation (queue mode) at dispatch time.
     //
-    // Skip on `cancelled` — heteroFinish may be called twice: first with
-    // result=cancelled (termination signal) then with result=success/error
-    // (normal process exit). We must NOT clear runningOperation or fire hooks on
-    // cancelled so the subsequent success/error call still finds the hooks +
-    // assistantMessageId and dispatches exactly once. (cancelled→interrupted is a
-    // no-op for the task lifecycle anyway — onTopicComplete has no interrupted
-    // branch — and suppresses a spurious bot "stopped" message before the real
-    // result lands.)
-    if (result === 'cancelled') return;
-
     let serializedHooks: SerializedHook[] | undefined;
     let assistantMessageId: string | undefined;
     try {
       const topic = await this.topicModel.findById(topicId);
-      serializedHooks = topic?.metadata?.runningOperation?.hooks as SerializedHook[] | undefined;
+      const runningOperation = topic?.metadata?.runningOperation;
+      const ownsMarker = runningOperation?.operationId === operationId;
+      serializedHooks = ownsMarker
+        ? (runningOperation.hooks as SerializedHook[] | undefined)
+        : undefined;
       // Prefer heteroCurrentMsgId — the persistence handler updates this pointer
       // on every step boundary, so it refers to the LAST assistant message with
       // the complete final content.  Fall back to the initial placeholder id
@@ -258,8 +296,10 @@ export class HeterogeneousAgentService {
       assistantMessageId =
         currentMsgRef?.operationId === operationId
           ? currentMsgRef.msgId
-          : topic?.metadata?.runningOperation?.assistantMessageId;
-      await this.topicModel.updateMetadata(topicId, { runningOperation: null });
+          : ownsMarker
+            ? runningOperation.assistantMessageId
+            : undefined;
+      await this.topicModel.clearRunningOperation(topicId, operationId);
     } catch (err) {
       log('heteroFinish: failed to clear runningOperation (non-fatal): %O', err);
     }
@@ -272,6 +312,25 @@ export class HeterogeneousAgentService {
     // runs, which dropped agentId and landed the trace snapshot under
     // agent-traces/unknown/... and left terminal hooks without an agentId.
     const agentId = parseOperationId(operationId)?.agentId;
+
+    if (result === 'cancelled') {
+      await new CompletionLifecycle(this.db, this.userId, this.workspaceId).completeOperation(
+        {
+          agentId,
+          assistantMessageId,
+          operationId,
+          serializedHooks,
+          topicId,
+          userId: this.userId,
+        },
+        'interrupted',
+      );
+      // Publish only after the durable operation + reconnect marker are terminal,
+      // so a refresh triggered by this event cannot resurrect the run.
+      await publishTerminal();
+      log('heteroFinish: finalized cancellation for op=%s', operationId);
+      return;
+    }
 
     // Still read the assistant message for its content so the bot-callback
     // handler has lastAssistantContent to render.
@@ -384,6 +443,7 @@ export class HeterogeneousAgentService {
       },
       completionReason,
     );
+    await publishTerminal();
     log('heteroFinish: dispatched completion lifecycle for op=%s result=%s', operationId, result);
   }
 

--- a/packages/database/src/models/__tests__/agentOperation.test.ts
+++ b/packages/database/src/models/__tests__/agentOperation.test.ts
@@ -208,6 +208,40 @@ describe('AgentOperationModel', () => {
       // The attacker cannot read the row either.
       expect(await attackerModel.findById(operationId)).toBeNull();
     });
+
+    it('keeps the first terminal result when onlyIfActive is enabled', async () => {
+      const model = new AgentOperationModel(serverDB, userId);
+      const operationId = 'op-terminal-cas';
+
+      await model.recordStart({ operationId });
+      await expect(
+        model.recordCompletion(
+          operationId,
+          {
+            completedAt: new Date(),
+            completionReason: 'interrupted',
+            status: 'interrupted',
+          },
+          { onlyIfActive: true },
+        ),
+      ).resolves.toBe(true);
+
+      await expect(
+        model.recordCompletion(
+          operationId,
+          {
+            completedAt: new Date(),
+            completionReason: 'error',
+            status: 'error',
+          },
+          { onlyIfActive: true },
+        ),
+      ).resolves.toBe(false);
+
+      const row = await model.findById(operationId);
+      expect(row?.status).toBe('interrupted');
+      expect(row?.completionReason).toBe('interrupted');
+    });
   });
 
   describe('sumChildUsage', () => {

--- a/packages/database/src/models/__tests__/topic.test.ts
+++ b/packages/database/src/models/__tests__/topic.test.ts
@@ -491,6 +491,23 @@ describe('TopicModel', () => {
         version: 1,
       });
     });
+
+    it('clears runningOperation only when the operation id still matches', async () => {
+      const topic = await topicModel.create({
+        metadata: {
+          runningOperation: { assistantMessageId: 'asst-new', operationId: 'op-new' },
+        },
+        title: 'running marker',
+      });
+
+      await expect(topicModel.clearRunningOperation(topic.id, 'op-old')).resolves.toBe(false);
+      expect((await topicModel.findById(topic.id))?.metadata?.runningOperation?.operationId).toBe(
+        'op-new',
+      );
+
+      await expect(topicModel.clearRunningOperation(topic.id, 'op-new')).resolves.toBe(true);
+      expect((await topicModel.findById(topic.id))?.metadata?.runningOperation).toBeNull();
+    });
   });
 
   describe('delete', () => {

--- a/packages/database/src/models/agentOperation.ts
+++ b/packages/database/src/models/agentOperation.ts
@@ -1,5 +1,5 @@
 import type { VerifyRunStatus } from '@lobechat/types';
-import { and, eq, gte, isNotNull, sql } from 'drizzle-orm';
+import { and, eq, gte, inArray, isNotNull, sql } from 'drizzle-orm';
 
 import { today } from '@/utils/time';
 
@@ -138,7 +138,8 @@ export class AgentOperationModel {
   async recordCompletion(
     operationId: string,
     params: RecordOperationCompletionParams,
-  ): Promise<void> {
+    options?: { onlyIfActive?: boolean },
+  ): Promise<boolean> {
     const updates: Partial<NewAgentOperation> = {
       completionReason: params.completionReason,
       status: params.status,
@@ -165,10 +166,25 @@ export class AgentOperationModel {
     if (params.interruption !== undefined) updates.interruption = params.interruption;
     if (params.traceS3Key !== undefined) updates.traceS3Key = params.traceS3Key;
 
-    await this.db
+    const updated = await this.db
       .update(agentOperations)
       .set(updates)
-      .where(and(eq(agentOperations.id, operationId), this.ownership()));
+      .where(
+        and(
+          eq(agentOperations.id, operationId),
+          this.ownership(),
+          options?.onlyIfActive
+            ? inArray(agentOperations.status, [
+                'running',
+                'waiting_for_human',
+                'waiting_for_async_tool',
+              ])
+            : undefined,
+        ),
+      )
+      .returning({ id: agentOperations.id });
+
+    return updated.length > 0;
   }
 
   /**

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -1264,6 +1264,32 @@ export class TopicModel {
   };
 
   /**
+   * Clear the reconnect marker only when it still belongs to `operationId`.
+   * A late terminal callback from an older run must never erase the marker for
+   * a newer run that has already started on the same topic.
+   */
+  clearRunningOperation = async (id: string, operationId: string): Promise<boolean> => {
+    return this.db.transaction(async (tx) => {
+      const [existing] = await tx
+        .select({ metadata: topics.metadata })
+        .from(topics)
+        .where(and(eq(topics.id, id), this.ownership()))
+        .for('update');
+
+      if (existing?.metadata?.runningOperation?.operationId !== operationId) return false;
+
+      await tx
+        .update(topics)
+        .set({
+          metadata: { ...existing.metadata, runningOperation: null } as ChatTopicMetadata,
+        })
+        .where(and(eq(topics.id, id), this.ownership()));
+
+      return true;
+    });
+  };
+
+  /**
    * Arm a scheduled run on an owned topic: writes `metadata.scheduledRun` and
    * flips the status to `scheduled` in a single update.
    *

--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -174,6 +174,10 @@ export interface ChatTopicMetadata {
    */
   runningOperation?: {
     assistantMessageId: string;
+    /** Device executing a gateway-dispatched heterogeneous CLI run. */
+    deviceId?: string;
+    /** Heterogeneous runtime used by this operation, for device cancellation. */
+    heteroType?: 'amp' | 'claude-code' | 'codex' | 'hermes' | 'openclaw' | 'opencode';
     /**
      * Serialized lifecycle hooks (onComplete / onError) registered for this run.
      *

--- a/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
@@ -1420,6 +1420,7 @@ describe('GatewayActionImpl', () => {
 
   describe('reconnectToGatewayOperation', () => {
     function createReconnectTestAction(assistantMessage: any) {
+      const onOperationCancel = vi.fn();
       const startOperation = vi.fn(() => ({ operationId: 'gw-op-reconnect' }));
       const mockClient = createMockClient();
       const state: Record<string, any> = {
@@ -1439,7 +1440,7 @@ describe('GatewayActionImpl', () => {
         associateMessageWithOperation: vi.fn(),
         connectToGateway: vi.fn(),
         internal_updateTopicLoading: vi.fn(),
-        onOperationCancel: vi.fn(),
+        onOperationCancel,
         startOperation,
       })) as any;
 
@@ -1456,7 +1457,7 @@ describe('GatewayActionImpl', () => {
       const action = new GatewayActionImpl(set as any, get, undefined);
       action.createClient = vi.fn(() => mockClient);
 
-      return { action, startOperation };
+      return { action, onOperationCancel, startOperation };
     }
 
     afterEach(() => {
@@ -1504,6 +1505,29 @@ describe('GatewayActionImpl', () => {
           metadata: expect.not.objectContaining({ startTime: expect.anything() }),
         }),
       );
+    });
+
+    it('passes topicId when a reconnected operation is stopped', async () => {
+      const { action, onOperationCancel } = createReconnectTestAction({
+        createdAt: 1,
+        id: 'ast-1',
+      });
+      const interruptTaskSpy = vi
+        .mocked(aiAgentService.interruptTask)
+        .mockResolvedValue({ operationId: 'server-op-1', success: true });
+
+      await action.reconnectToGatewayOperation({
+        assistantMessageId: 'ast-1',
+        operationId: 'server-op-1',
+        topicId: 'topic-1',
+      });
+
+      expect(onOperationCancel).toHaveBeenCalledWith('gw-op-reconnect', expect.any(Function));
+      await onOperationCancel.mock.calls[0][1]();
+      expect(interruptTaskSpy).toHaveBeenCalledWith({
+        operationId: 'server-op-1',
+        topicId: 'topic-1',
+      });
     });
 
     // Captures the onSessionComplete handed to connectToGateway so we can drive

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -847,7 +847,7 @@ export class GatewayActionImpl {
     // See note in executeGatewayAgent for details.
     this.#get().onOperationCancel(gatewayOpId, async () => {
       await aiAgentService
-        .interruptTask({ operationId })
+        .interruptTask({ operationId, topicId })
         .catch((err) => console.error('[Gateway] interruptTask failed:', err));
     });
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No matching issue found.

#### 🔀 Description of Change

Fix two P1 lifecycle failures for heterogeneous agents dispatched through Agent Gateway:

1. Make Stop a server-authoritative, durable terminal transition. The server now finalizes the operation as interrupted and clears only the matching `topic.metadata.runningOperation` marker before best-effort device cancellation, so refresh cannot resurrect a stopped run even when the device is offline or the cancel relay fails.
2. Prevent orphan operations after `agent_run_ack: accepted`. Desktop and CLI track embedded children by operation ID and report a terminal fallback when a child exits before completing the terminal handshake.

Additional safeguards:

- Use a first-terminal-writer-wins CAS for operation completion, preventing late process callbacks from changing done/interrupted operations to errors.
- Preserve newer topic markers when stale callbacks arrive.
- Kill the full detached process group for device-dispatched CLI runs, escalating to `SIGKILL` after the graceful timeout.
- Define server-ingest child exit code as a terminal-handshake contract: exit 0 only after `heteroFinish` is acknowledged; parent fallback runs only for non-zero/signal exits. This prevents clean successful runs from being polluted by duplicate generic errors on older self-hosted servers.
- Preserve late native session IDs and release per-operation persistence state after duplicate terminal callbacks.
- Include `topicId` when reconnecting Gateway runs register their Stop callback.

No new wire-protocol message or database migration is introduced; cancellation reuses `cancelHeteroTask` with `taskId = operationId`.

#### 🧪 How to Test

Focused regression suites:

- Server lifecycle / heterogeneous completion / interrupt: 73 tests passed
- CLI command / child fallback / cancellation: 57 tests passed
- Desktop gateway child tracking / cancellation: 125 tests passed
- Database operation CAS / topic marker cleanup: 63 tests passed
- Frontend Gateway reconnect cancellation: 49 tests passed
- Changed-file lint: 23 files clean
- `git diff --check`: clean

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

Not applicable; this change fixes backend and process lifecycle behavior without visual changes.

#### 📝 Additional Information

The repository-wide type-check currently reports pre-existing workspace resolution/type conflicts. Filtering the output to the touched lifecycle files found no new type errors; `apps/cli/src/commands/hetero.ts:190` remains an existing unrelated cast warning outside this diff.
