### PR TITLE
💄 style(working-panel): move deployment tab to the end of the tab strip

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
@@ -44,6 +44,10 @@ const reviewState = vi.hoisted(() => ({
   workingDirectory: undefined as string | undefined,
 }));
 
+const businessTabs = vi.hoisted(() => ({
+  current: [] as { key: string; label: string; pane: ReactNode }[],
+}));
+
 const globalStore = vi.hoisted(() => ({
   updateSystemStatus: vi.fn(),
   toggleRightPanel: vi.fn(),
@@ -104,7 +108,7 @@ vi.mock('@/store/electron', () => ({ useElectronStore: () => undefined }));
 vi.mock('@/store/chat', () => ({ useChatStore: () => undefined }));
 
 vi.mock('@/business/client/features/WorkingSidebarTabs', () => ({
-  useBusinessWorkingSidebarTabs: () => [],
+  useBusinessWorkingSidebarTabs: () => businessTabs.current,
 }));
 
 vi.mock('@/features/ChatInput/ControlBar/useRepoType', async () => {
@@ -153,6 +157,7 @@ vi.mock('antd-style', () => ({
 }));
 
 beforeEach(() => {
+  businessTabs.current = [];
   agentStore.activeAgentId = undefined;
   agentStore.isHeterogeneous = false;
   agentStore.rawAgencyConfig = undefined;
@@ -373,5 +378,24 @@ describe('AgentWorkingSidebar — tab strip', () => {
 
     expect(screen.getByRole('button', { name: 'workingPanel.review.title' })).toBeInTheDocument();
     expect(scrollIntoView).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders business tabs after the built-in ones', () => {
+    businessTabs.current = [
+      { key: 'deployments', label: 'workingPanel.deployments.tab', pane: <div /> },
+    ];
+
+    render(<AgentWorkingSidebar />);
+    const labels = screen
+      .getAllByRole('button')
+      .map((button) => button.textContent)
+      .filter(Boolean);
+
+    expect(labels).toEqual([
+      'workingPanel.space',
+      'workingPanel.works.title',
+      'settingModel.params.panel.tab',
+      'workingPanel.deployments.tab',
+    ]);
   });
 });

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
@@ -267,17 +267,6 @@ const AgentWorkingSidebar = memo(() => {
           paddingInline={4}
         >
           <div className={styles.tabs} ref={tabsRef}>
-            {businessTabs.map((tab) => (
-              <button
-                aria-pressed={activeTab === tab.key}
-                className={`${styles.tab} ${activeTab === tab.key ? styles.tabActive : ''}`}
-                key={tab.key}
-                type="button"
-                onClick={() => setWorkingSidebarTab(tab.key)}
-              >
-                {tab.label}
-              </button>
-            ))}
             <button
               aria-pressed={activeTab === 'resources'}
               className={`${styles.tab} ${activeTab === 'resources' ? styles.tabActive : ''}`}
@@ -334,6 +323,17 @@ const AgentWorkingSidebar = memo(() => {
                 {t('settingModel.params.panel.tab', { ns: 'setting' })}
               </button>
             )}
+            {businessTabs.map((tab) => (
+              <button
+                aria-pressed={activeTab === tab.key}
+                className={`${styles.tab} ${activeTab === tab.key ? styles.tabActive : ''}`}
+                key={tab.key}
+                type="button"
+                onClick={() => setWorkingSidebarTab(tab.key)}
+              >
+                {tab.label}
+              </button>
+            ))}
           </div>
           <ActionIcon
             className={styles.close}


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

Fixes LOBE-12160

#### 🔀 Description of Change

Business-injected tabs in the agent working panel (currently only **Deployments**) were rendered before every built-in tab, so the strip opened as `Deployments · Space · Works · Review · Files · Browser · Params`. That put a conditional, cloud-only tab in the most prominent slot and pushed the everyday tabs rightwards — at the 300px minimum panel width the built-in tabs were the first to scroll out of view.

Business tabs are now rendered after the built-in ones: `Space · Works · Review · Files · Browser · Params · Deployments`.

Only the tab-button order changes. Pane rendering, active-tab resolution, and the persisted-tab fallback are untouched.

#### 🧪 How to Test

- [x] Added/updated tests

`WorkingSidebar/__tests__/index.test.tsx` gains an order regression test: the business-tabs mock is now mutable, and the test asserts the rendered label sequence ends with the business tab. Restoring the old render position fails it.

```
bun run check "src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx" "src/routes/(main)/agent/features/Conversation/WorkingSidebar/__tests__/index.test.tsx"
# 2 files · lint clean · tests 13 passed
```

The Deployments tab itself is injected by the cloud build, so the visual change only shows there; OSS builds render an unchanged strip.