### PR TITLE
🐛 fix(image): warn and disable generation when selected model is unavailable

### DIFF
--- a/locales/en-US/image.json
+++ b/locales/en-US/image.json
@@ -63,6 +63,8 @@
   "notSupportGuide.features.multiProviders.desc": "Supports multiple AI image generation providers, including OpenAI gpt-image-1, Google Imagen, FAL.ai, and more, offering a wide selection of models.",
   "notSupportGuide.features.multiProviders.title": "Multi-Provider Support",
   "notSupportGuide.title": "Current Deployment Mode Does Not Support AI Image Generation",
+  "notice.modelRemoved": "The current model is no longer available from {{name}}. Please switch to an available model.",
+  "notice.providerDisabled": "The provider {{name}} for the current model is disabled. Please enable it or switch to an available model.",
   "topic.createNew": "Create New Topic",
   "topic.createdBy": "Created by {{name}}",
   "topic.deleteConfirm": "Delete Generation Topic",

--- a/locales/en-US/video.json
+++ b/locales/en-US/video.json
@@ -26,6 +26,8 @@
   "generation.status.failed": "Generation Failed",
   "generation.status.generating": "Generating...",
   "generation.validation.endFrameRequiresStartFrame": "End frame cannot be used without a start frame. Please set a start frame first.",
+  "notice.modelRemoved": "The current model is no longer available from {{name}}. Please switch to an available model.",
+  "notice.providerDisabled": "The provider {{name}} for the current model is disabled. Please enable it or switch to an available model.",
   "topic.createNew": "Create New Topic",
   "topic.createdBy": "Created by {{name}}",
   "topic.deleteConfirm": "Delete Video Topic",

--- a/locales/zh-CN/image.json
+++ b/locales/zh-CN/image.json
@@ -63,6 +63,8 @@
   "notSupportGuide.features.multiProviders.desc": "支持多种 AI 绘画服务商，包括 OpenAI、Google Imagen、FAL.ai 等。提供丰富的模型选择",
   "notSupportGuide.features.multiProviders.title": "多服务商支持",
   "notSupportGuide.title": "当前部署模式不支持 AI 绘画",
+  "notice.modelRemoved": "当前模型已不在 {{name}} 的模型列表中，请先切换可用模型",
+  "notice.providerDisabled": "当前模型所属的服务商 {{name}} 未启用，请先启用或切换可用模型",
   "topic.createNew": "创作新主题",
   "topic.createdBy": "由 {{name}} 创建",
   "topic.deleteConfirm": "删除生成主题",

--- a/locales/zh-CN/video.json
+++ b/locales/zh-CN/video.json
@@ -26,6 +26,8 @@
   "generation.status.failed": "生成失败",
   "generation.status.generating": "生成中...",
   "generation.validation.endFrameRequiresStartFrame": "使用结束画面前需先设置起始画面。请先设置起始画面。",
+  "notice.modelRemoved": "当前模型已不在 {{name}} 的模型列表中，请先切换可用模型",
+  "notice.providerDisabled": "当前模型所属的服务商 {{name}} 未启用，请先启用或切换可用模型",
   "topic.createNew": "创作新主题",
   "topic.createdBy": "由 {{name}} 创建",
   "topic.deleteConfirm": "删除视频主题",

--- a/packages/locales/src/default/image.ts
+++ b/packages/locales/src/default/image.ts
@@ -69,6 +69,10 @@ export default {
     'Supports multiple AI image generation providers, including OpenAI gpt-image-1, Google Imagen, FAL.ai, and more, offering a wide selection of models.',
   'notSupportGuide.features.multiProviders.title': 'Multi-Provider Support',
   'notSupportGuide.title': 'Current Deployment Mode Does Not Support AI Image Generation',
+  'notice.modelRemoved':
+    'The current model is no longer available from {{name}}. Please switch to an available model.',
+  'notice.providerDisabled':
+    'The provider {{name}} for the current model is disabled. Please enable it or switch to an available model.',
   'topic.createNew': 'Create New Topic',
   'topic.createdBy': 'Created by {{name}}',
   'topic.deleteConfirm': 'Delete Generation Topic',

--- a/packages/locales/src/default/video.ts
+++ b/packages/locales/src/default/video.ts
@@ -27,6 +27,10 @@ export default {
     'End frame cannot be used without a start frame. Please set a start frame first.',
   'generation.status.failed': 'Generation Failed',
   'generation.status.generating': 'Generating...',
+  'notice.modelRemoved':
+    'The current model is no longer available from {{name}}. Please switch to an available model.',
+  'notice.providerDisabled':
+    'The provider {{name}} for the current model is disabled. Please enable it or switch to an available model.',
   'topic.createNew': 'Create New Topic',
   'topic.createdBy': 'Created by {{name}}',
   'topic.deleteConfirm': 'Delete Video Topic',

--- a/src/routes/(main)/(create)/features/GenerationInput/GenerationModelNotice/index.tsx
+++ b/src/routes/(main)/(create)/features/GenerationInput/GenerationModelNotice/index.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { Alert } from '@lobehub/ui';
+import { createStaticStyles, cx } from 'antd-style';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useProviderName } from '@/hooks/useProviderName';
+
+import { type GenerationModelNotice as GenerationModelNoticeType } from './useGenerationModelNotice';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  alert: css`
+    flex: 0 1 auto;
+
+    /* Keep the icon centered against the single-line title. */
+    align-items: center !important;
+
+    min-width: 0;
+    max-width: min(560px, 52vw);
+    padding-block: 4px !important;
+    padding-inline: 8px 10px !important;
+    border-radius: ${cssVar.borderRadius};
+
+    .ant-alert-content {
+      min-width: 0;
+    }
+
+    .ant-alert-message,
+    .ant-alert-title {
+      overflow: hidden;
+
+      font-size: 12px;
+      line-height: 18px !important;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .ant-alert-icon {
+      flex: none;
+      height: 18px !important;
+      margin-inline-end: 6px !important;
+    }
+
+    @media (width <= 768px) {
+      max-width: 100%;
+    }
+  `,
+}));
+
+interface GenerationModelNoticeProps {
+  notice: GenerationModelNoticeType | undefined;
+  /** i18n namespace the notice key resolves against. */
+  ns: 'image' | 'video';
+}
+
+const GenerationModelNotice = memo<GenerationModelNoticeProps>(({ notice, ns }) => {
+  const { t } = useTranslation(ns);
+  // Hooks must run unconditionally; `useProviderName('')` falls back to the raw id.
+  const providerName = useProviderName(notice?.provider ?? '');
+
+  if (!notice) return null;
+
+  return (
+    <Alert
+      classNames={{ alert: cx(styles.alert) }}
+      style={{ fontSize: 12 }}
+      title={t(notice.key, { name: providerName })}
+      type={notice.type}
+      variant={'borderless'}
+    />
+  );
+});
+
+GenerationModelNotice.displayName = 'GenerationModelNotice';
+
+export default GenerationModelNotice;

--- a/src/routes/(main)/(create)/features/GenerationInput/GenerationModelNotice/useGenerationModelNotice.test.tsx
+++ b/src/routes/(main)/(create)/features/GenerationInput/GenerationModelNotice/useGenerationModelNotice.test.tsx
@@ -1,0 +1,221 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  resolveGenerationModelNotice,
+  useImageGenerationModelNotice,
+  useVideoGenerationModelNotice,
+} from './useGenerationModelNotice';
+
+interface TestModel {
+  id: string;
+}
+
+interface TestProviderWithModels {
+  children: TestModel[];
+  id: string;
+}
+
+const testState = vi.hoisted(() => ({
+  aiInfra: {
+    enabledImageModelList: [] as TestProviderWithModels[],
+    enabledVideoModelList: [] as TestProviderWithModels[],
+    isInitAiProviderRuntimeState: false,
+  },
+  // Mirrors the buggy default: falls back to the Google provider even when Google
+  // is disabled (lobehub/lobehub#17400).
+  image: { model: 'gemini-3.1-flash-image-preview:image', provider: 'google' },
+  video: { model: 'veo-3.1', provider: 'google' },
+}));
+
+type StoreSelector<T = unknown, S = Record<PropertyKey, unknown>> = (state: S) => T;
+
+vi.mock('@/store/image', () => ({
+  useImageStore: <T,>(selector: StoreSelector<T, typeof testState.image>) =>
+    selector(testState.image),
+}));
+
+vi.mock('@/store/image/selectors', () => ({
+  imageGenerationConfigSelectors: {
+    model: (s: typeof testState.image) => s.model,
+    provider: (s: typeof testState.image) => s.provider,
+  },
+}));
+
+vi.mock('@/store/video', () => ({
+  useVideoStore: <T,>(selector: StoreSelector<T, typeof testState.video>) =>
+    selector(testState.video),
+}));
+
+vi.mock('@/store/video/selectors', () => ({
+  videoGenerationConfigSelectors: {
+    model: (s: typeof testState.video) => s.model,
+    provider: (s: typeof testState.video) => s.provider,
+  },
+}));
+
+vi.mock('@/store/aiInfra', () => ({
+  aiProviderSelectors: {
+    enabledImageModelList: (s: typeof testState.aiInfra) => s.enabledImageModelList,
+    enabledVideoModelList: (s: typeof testState.aiInfra) => s.enabledVideoModelList,
+    isInitAiProviderRuntimeState: (s: typeof testState.aiInfra) => s.isInitAiProviderRuntimeState,
+  },
+  useAiInfraStore: <T,>(selector: StoreSelector<T, typeof testState.aiInfra>) =>
+    selector(testState.aiInfra),
+}));
+
+describe('resolveGenerationModelNotice', () => {
+  it('does not return a notice before the model runtime config is ready', () => {
+    expect(
+      resolveGenerationModelNotice({
+        enabledModelList: [],
+        isModelConfigReady: false,
+        model: 'gemini-3.1-flash-image-preview:image',
+        provider: 'google',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('does not return a notice when the current model is present in the enabled list', () => {
+    expect(
+      resolveGenerationModelNotice({
+        enabledModelList: [{ children: [{ id: 'gpt-image-1' }], id: 'openai' }],
+        isModelConfigReady: true,
+        model: 'gpt-image-1',
+        provider: 'openai',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('returns providerDisabled when the provider group is absent from the enabled list', () => {
+    expect(
+      resolveGenerationModelNotice({
+        enabledModelList: [{ children: [{ id: 'gpt-image-1' }], id: 'openai' }],
+        isModelConfigReady: true,
+        model: 'gemini-3.1-flash-image-preview:image',
+        provider: 'google',
+      }),
+    ).toEqual({ key: 'notice.providerDisabled', provider: 'google', type: 'warning' });
+  });
+
+  it('returns modelRemoved when the provider exists but the model is not among its children', () => {
+    expect(
+      resolveGenerationModelNotice({
+        enabledModelList: [{ children: [{ id: 'gemini-2.5-flash-image' }], id: 'google' }],
+        isModelConfigReady: true,
+        model: 'gemini-3.1-flash-image-preview:image',
+        provider: 'google',
+      }),
+    ).toEqual({ key: 'notice.modelRemoved', provider: 'google', type: 'warning' });
+  });
+});
+
+describe('useImageGenerationModelNotice', () => {
+  beforeEach(() => {
+    testState.aiInfra.enabledImageModelList = [];
+    testState.aiInfra.isInitAiProviderRuntimeState = false;
+    testState.image = { model: 'gemini-3.1-flash-image-preview:image', provider: 'google' };
+  });
+
+  it('does not flag the model before the model runtime config is ready', () => {
+    const { result } = renderHook(() => useImageGenerationModelNotice());
+
+    expect(result.current.isModelUnavailable).toBe(false);
+    expect(result.current.notice).toBeUndefined();
+  });
+
+  it('does not flag the model when the current model is in the enabled list', () => {
+    testState.aiInfra.isInitAiProviderRuntimeState = true;
+    testState.aiInfra.enabledImageModelList = [
+      { children: [{ id: 'gemini-3.1-flash-image-preview:image' }], id: 'google' },
+    ];
+
+    const { result } = renderHook(() => useImageGenerationModelNotice());
+
+    expect(result.current.isModelUnavailable).toBe(false);
+    expect(result.current.notice).toBeUndefined();
+  });
+
+  it('flags providerDisabled when the disabled google default provider is absent from the enabled list', () => {
+    testState.aiInfra.isInitAiProviderRuntimeState = true;
+    testState.aiInfra.enabledImageModelList = [{ children: [{ id: 'gpt-image-1' }], id: 'openai' }];
+
+    const { result } = renderHook(() => useImageGenerationModelNotice());
+
+    expect(result.current.isModelUnavailable).toBe(true);
+    expect(result.current.notice).toEqual({
+      key: 'notice.providerDisabled',
+      provider: 'google',
+      type: 'warning',
+    });
+  });
+
+  it('flags modelRemoved when the provider is enabled but no longer lists the model', () => {
+    testState.aiInfra.isInitAiProviderRuntimeState = true;
+    testState.aiInfra.enabledImageModelList = [
+      { children: [{ id: 'gemini-2.5-flash-image' }], id: 'google' },
+    ];
+
+    const { result } = renderHook(() => useImageGenerationModelNotice());
+
+    expect(result.current.isModelUnavailable).toBe(true);
+    expect(result.current.notice).toEqual({
+      key: 'notice.modelRemoved',
+      provider: 'google',
+      type: 'warning',
+    });
+  });
+});
+
+describe('useVideoGenerationModelNotice', () => {
+  beforeEach(() => {
+    testState.aiInfra.enabledVideoModelList = [];
+    testState.aiInfra.isInitAiProviderRuntimeState = false;
+    testState.video = { model: 'veo-3.1', provider: 'google' };
+  });
+
+  it('does not flag the model before the model runtime config is ready', () => {
+    const { result } = renderHook(() => useVideoGenerationModelNotice());
+
+    expect(result.current.isModelUnavailable).toBe(false);
+    expect(result.current.notice).toBeUndefined();
+  });
+
+  it('does not flag the model when the current model is in the enabled list', () => {
+    testState.aiInfra.isInitAiProviderRuntimeState = true;
+    testState.aiInfra.enabledVideoModelList = [{ children: [{ id: 'veo-3.1' }], id: 'google' }];
+
+    const { result } = renderHook(() => useVideoGenerationModelNotice());
+
+    expect(result.current.isModelUnavailable).toBe(false);
+    expect(result.current.notice).toBeUndefined();
+  });
+
+  it('flags providerDisabled when the provider group is absent from the enabled list', () => {
+    testState.aiInfra.isInitAiProviderRuntimeState = true;
+    testState.aiInfra.enabledVideoModelList = [{ children: [{ id: 'kling-v2' }], id: 'fal' }];
+
+    const { result } = renderHook(() => useVideoGenerationModelNotice());
+
+    expect(result.current.isModelUnavailable).toBe(true);
+    expect(result.current.notice).toEqual({
+      key: 'notice.providerDisabled',
+      provider: 'google',
+      type: 'warning',
+    });
+  });
+
+  it('flags modelRemoved when the provider is enabled but no longer lists the model', () => {
+    testState.aiInfra.isInitAiProviderRuntimeState = true;
+    testState.aiInfra.enabledVideoModelList = [{ children: [{ id: 'veo-2' }], id: 'google' }];
+
+    const { result } = renderHook(() => useVideoGenerationModelNotice());
+
+    expect(result.current.isModelUnavailable).toBe(true);
+    expect(result.current.notice).toEqual({
+      key: 'notice.modelRemoved',
+      provider: 'google',
+      type: 'warning',
+    });
+  });
+});

--- a/src/routes/(main)/(create)/features/GenerationInput/GenerationModelNotice/useGenerationModelNotice.ts
+++ b/src/routes/(main)/(create)/features/GenerationInput/GenerationModelNotice/useGenerationModelNotice.ts
@@ -1,0 +1,103 @@
+import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
+import { useImageStore } from '@/store/image';
+import { imageGenerationConfigSelectors } from '@/store/image/selectors';
+import { useVideoStore } from '@/store/video';
+import { videoGenerationConfigSelectors } from '@/store/video/selectors';
+
+/**
+ * Minimal structural shape the resolver reads — a provider group id plus its child
+ * model ids. Decoupled from the full `EnabledProviderWithModels` so callers can pass
+ * the store list (structurally assignable) while tests build lightweight fixtures.
+ */
+interface EnabledModelGroup {
+  children: { id: string }[];
+  id: string;
+}
+
+interface ResolveGenerationModelNoticeParams {
+  enabledModelList: EnabledModelGroup[];
+  isModelConfigReady: boolean;
+  model: string;
+  provider: string;
+}
+
+/**
+ * Pure resolver for the "current model unavailable" notice on the image/video
+ * generation pages. Distinguishes the two distinct root causes so the UI can show
+ * precise copy (both keys interpolate the provider display name via `{{name}}`):
+ *
+ * - `notice.providerDisabled`: the provider group is absent from the enabled list
+ *   entirely (provider disabled or removed).
+ * - `notice.modelRemoved`: the provider group exists but no longer lists the
+ *   selected model id among its children.
+ *
+ * We gate on `isModelConfigReady` (aiProvider runtime state initialized) so we do
+ * NOT flash a false warning while the provider runtime config is still loading and
+ * the enabled model list is transiently empty. This matters for the default state
+ * where the store falls back to `provider=google,
+ * model='gemini-3.1-flash-image-preview:image'`: once config is ready and Google is
+ * disabled, the notice reads as `providerDisabled` instead of silently generating
+ * against a disabled provider (see lobehub/lobehub#17400).
+ */
+export const resolveGenerationModelNotice = ({
+  enabledModelList,
+  isModelConfigReady,
+  model,
+  provider,
+}: ResolveGenerationModelNoticeParams) => {
+  if (!isModelConfigReady) return;
+
+  // Match the provider group by id first, mirroring `findEnabledChatModel` in the
+  // chat input notice.
+  const providerGroup = enabledModelList.find((item) => item.id === provider);
+  if (!providerGroup) return { key: 'notice.providerDisabled', provider, type: 'warning' } as const;
+
+  const currentModel = providerGroup.children.find((item) => item.id === model);
+  if (!currentModel) return { key: 'notice.modelRemoved', provider, type: 'warning' } as const;
+};
+
+/** Union of every notice shape `resolveGenerationModelNotice` can return. */
+export type GenerationModelNotice = NonNullable<ReturnType<typeof resolveGenerationModelNotice>>;
+
+export interface UseGenerationModelNoticeResult {
+  /** Whether the currently selected model is unavailable (notice present). */
+  isModelUnavailable: boolean;
+  /** The resolved notice, or undefined when the model is available / config not ready. */
+  notice: GenerationModelNotice | undefined;
+}
+
+export const useImageGenerationModelNotice = (): UseGenerationModelNoticeResult => {
+  const model = useImageStore(imageGenerationConfigSelectors.model);
+  const provider = useImageStore(imageGenerationConfigSelectors.provider);
+  const enabledModelList = useAiInfraStore(aiProviderSelectors.enabledImageModelList);
+  const isModelConfigReady = useAiInfraStore((s) =>
+    aiProviderSelectors.isInitAiProviderRuntimeState(s),
+  );
+
+  const notice = resolveGenerationModelNotice({
+    enabledModelList,
+    isModelConfigReady,
+    model,
+    provider,
+  });
+
+  return { isModelUnavailable: Boolean(notice), notice };
+};
+
+export const useVideoGenerationModelNotice = (): UseGenerationModelNoticeResult => {
+  const model = useVideoStore(videoGenerationConfigSelectors.model);
+  const provider = useVideoStore(videoGenerationConfigSelectors.provider);
+  const enabledModelList = useAiInfraStore(aiProviderSelectors.enabledVideoModelList);
+  const isModelConfigReady = useAiInfraStore((s) =>
+    aiProviderSelectors.isInitAiProviderRuntimeState(s),
+  );
+
+  const notice = resolveGenerationModelNotice({
+    enabledModelList,
+    isModelConfigReady,
+    model,
+    provider,
+  });
+
+  return { isModelUnavailable: Boolean(notice), notice };
+};

--- a/src/routes/(main)/(create)/features/GenerationInput/index.ts
+++ b/src/routes/(main)/(create)/features/GenerationInput/index.ts
@@ -1,6 +1,11 @@
 export { default as ConfigAction } from './ConfigAction';
 export { default as GenerationInvalidAPIKey } from './GenerationInvalidAPIKey';
 export { default as GenerationMediaModeSegment } from './GenerationMediaModeSegment';
+export { default as GenerationModelNotice } from './GenerationModelNotice';
+export {
+  useImageGenerationModelNotice,
+  useVideoGenerationModelNotice,
+} from './GenerationModelNotice/useGenerationModelNotice';
 export { default as GenerationPromptInput } from './GenerationPromptInput';
 export { default as GenerationVisibilitySelector } from './GenerationVisibilitySelector';
 export { default as ImagePreviewHeader } from './ImagePreviewHeader';

--- a/src/routes/(main)/(create)/image/features/PromptInput/index.tsx
+++ b/src/routes/(main)/(create)/image/features/PromptInput/index.tsx
@@ -230,7 +230,10 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
       // 2. Config not ready: the resolver returns undefined (so `isModelUnavailable`
       //    is `false`) while the aiProvider runtime state is still loading, which would
       //    auto-fire against a possibly-disabled provider. Wait until it settles.
-      if (modelParam || !isModelConfigReady) return;
+      // 3. Generation config not initialized: before `initializeImageConfig` finishes,
+      //    the selection is still the hard-coded default, so availability would be
+      //    evaluated against a model the init step is about to replace.
+      if (modelParam || !isModelConfigReady || !isInit) return;
 
       const decodedPrompt = decodeURIComponent(promptParam);
       setValue(decodedPrompt);
@@ -256,6 +259,7 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
     isLogin,
     canCreate,
     isModelConfigReady,
+    isInit,
     isModelUnavailable,
     setValue,
     setPromptParam,

--- a/src/routes/(main)/(create)/image/features/PromptInput/index.tsx
+++ b/src/routes/(main)/(create)/image/features/PromptInput/index.tsx
@@ -19,9 +19,11 @@ import { useQueryState } from '@/hooks/useQueryParam';
 import {
   ConfigAction,
   GenerationMediaModeSegment,
+  GenerationModelNotice,
   GenerationPromptInput,
   GenerationVisibilitySelector,
   InlineImageReference,
+  useImageGenerationModelNotice,
 } from '@/routes/(main)/(create)/features/GenerationInput';
 import {
   CfgSliderInput,
@@ -174,6 +176,7 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
   const isSupportWebSearch = useImageStore(isSupportedParamSelector('webSearch'));
   const isLogin = useUserStore(authSelectors.isLogin);
   const enabledImageModelList = useAiInfraStore(aiProviderSelectors.enabledImageModelList);
+  const { notice: modelNotice, isModelUnavailable } = useImageGenerationModelNotice();
   const { showDimensionControl } = useDimensionControl();
 
   useFetchAiImageConfig();
@@ -218,6 +221,11 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
       hasProcessedPrompt.current = true;
       setPromptParam(null);
 
+      // Skip the auto-generate when the selected model is unavailable — this path
+      // bypasses the generate button, so without the guard it would fire a request
+      // against a disabled provider (see lobehub/lobehub#17400).
+      if (isModelUnavailable) return;
+
       const timeoutId = window.setTimeout(async () => {
         await createImage();
       }, 100);
@@ -226,7 +234,7 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
         window.clearTimeout(timeoutId);
       };
     }
-  }, [promptParam, isLogin, canCreate, setValue, setPromptParam, createImage]);
+  }, [promptParam, isLogin, canCreate, isModelUnavailable, setValue, setPromptParam, createImage]);
 
   const showInlineRef = canDropImage;
   const hasRefImages = imagePreviewUrls.length > 0;
@@ -242,8 +250,9 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
   return (
     <Flexbox gap={32} width={'100%'}>
       {showTitle && <PromptTitle />}
+      <GenerationModelNotice notice={modelNotice} ns={'image'} />
       <GenerationPromptInput
-        disableGenerate={!isInit}
+        disableGenerate={!isInit || isModelUnavailable}
         disabled={!canCreate}
         generateLabel={t('generation.actions.generate')}
         generatingLabel={t('generation.status.generating')}

--- a/src/routes/(main)/(create)/image/features/PromptInput/index.tsx
+++ b/src/routes/(main)/(create)/image/features/PromptInput/index.tsx
@@ -176,6 +176,9 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
   const isSupportWebSearch = useImageStore(isSupportedParamSelector('webSearch'));
   const isLogin = useUserStore(authSelectors.isLogin);
   const enabledImageModelList = useAiInfraStore(aiProviderSelectors.enabledImageModelList);
+  const isModelConfigReady = useAiInfraStore((s) =>
+    aiProviderSelectors.isInitAiProviderRuntimeState(s),
+  );
   const { notice: modelNotice, isModelUnavailable } = useImageGenerationModelNotice();
   const { showDimensionControl } = useDimensionControl();
 
@@ -216,12 +219,25 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
 
   useEffect(() => {
     if (promptParam && !hasProcessedPrompt.current && isLogin && canCreate) {
+      // Bail WITHOUT consuming the param while the model deep-link is still settling
+      // or the provider runtime config isn't ready — otherwise a valid deep link
+      // permanently skips auto-generate (see lobehub/lobehub#17400):
+      // 1. `?model=` still present: the model effect hasn't applied it yet, so
+      //    `isModelUnavailable` in this closure is stale (from the pre-model render).
+      //    Consuming now would set `hasProcessedPrompt` / clear the param before the
+      //    model resolves. Instead we wait; once the model effect clears `modelParam`
+      //    this effect re-runs with a fresh `isModelUnavailable` for the applied model.
+      // 2. Config not ready: the resolver returns undefined (so `isModelUnavailable`
+      //    is `false`) while the aiProvider runtime state is still loading, which would
+      //    auto-fire against a possibly-disabled provider. Wait until it settles.
+      if (modelParam || !isModelConfigReady) return;
+
       const decodedPrompt = decodeURIComponent(promptParam);
       setValue(decodedPrompt);
       hasProcessedPrompt.current = true;
       setPromptParam(null);
 
-      // Skip the auto-generate when the selected model is unavailable — this path
+      // Config is ready and the selected model is genuinely unavailable — this path
       // bypasses the generate button, so without the guard it would fire a request
       // against a disabled provider (see lobehub/lobehub#17400).
       if (isModelUnavailable) return;
@@ -234,7 +250,17 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
         window.clearTimeout(timeoutId);
       };
     }
-  }, [promptParam, isLogin, canCreate, isModelUnavailable, setValue, setPromptParam, createImage]);
+  }, [
+    promptParam,
+    modelParam,
+    isLogin,
+    canCreate,
+    isModelConfigReady,
+    isModelUnavailable,
+    setValue,
+    setPromptParam,
+    createImage,
+  ]);
 
   const showInlineRef = canDropImage;
   const hasRefImages = imagePreviewUrls.length > 0;

--- a/src/routes/(main)/(create)/video/features/PromptInput/index.tsx
+++ b/src/routes/(main)/(create)/video/features/PromptInput/index.tsx
@@ -392,7 +392,10 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
       // 2. Config not ready: the resolver returns undefined (so `isModelUnavailable`
       //    is `false`) while the aiProvider runtime state is still loading, which would
       //    auto-fire against a possibly-disabled provider. Wait until it settles.
-      if (modelParam || !isModelConfigReady) return;
+      // 3. Generation config not initialized: before `initializeVideoConfig` finishes,
+      //    the selection is still the hard-coded default, so availability would be
+      //    evaluated against a model the init step is about to replace.
+      if (modelParam || !isModelConfigReady || !isInit) return;
 
       const decodedPrompt = decodeURIComponent(promptParam);
 
@@ -421,6 +424,7 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
     isLogin,
     canCreate,
     isModelConfigReady,
+    isInit,
     isModelUnavailable,
     setValue,
     setPromptParam,

--- a/src/routes/(main)/(create)/video/features/PromptInput/index.tsx
+++ b/src/routes/(main)/(create)/video/features/PromptInput/index.tsx
@@ -321,6 +321,9 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
   const currentModel = useVideoStore(videoGenerationConfigSelectors.model);
   const currentProvider = useVideoStore(videoGenerationConfigSelectors.provider);
   const enabledVideoModelList = useAiInfraStore(aiProviderSelectors.enabledVideoModelList);
+  const isModelConfigReady = useAiInfraStore((s) =>
+    aiProviderSelectors.isInitAiProviderRuntimeState(s),
+  );
   const { notice: modelNotice, isModelUnavailable } = useVideoGenerationModelNotice();
   const isInit = useVideoStore((s) => s.isInit);
   const isSupportImageUrl = useVideoStore(isSupportedParamSelector('imageUrl'));
@@ -378,6 +381,19 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
   // Auto-fill and auto-send when prompt query parameter is present
   useEffect(() => {
     if (promptParam && !hasProcessedPrompt.current && isLogin && canCreate) {
+      // Bail WITHOUT consuming the param while the model deep-link is still settling
+      // or the provider runtime config isn't ready — otherwise a valid deep link
+      // permanently skips auto-generate (see lobehub/lobehub#17400):
+      // 1. `?model=` still present: the model effect hasn't applied it yet, so
+      //    `isModelUnavailable` in this closure is stale (from the pre-model render).
+      //    Consuming now would set `hasProcessedPrompt` / clear the param before the
+      //    model resolves. Instead we wait; once the model effect clears `modelParam`
+      //    this effect re-runs with a fresh `isModelUnavailable` for the applied model.
+      // 2. Config not ready: the resolver returns undefined (so `isModelUnavailable`
+      //    is `false`) while the aiProvider runtime state is still loading, which would
+      //    auto-fire against a possibly-disabled provider. Wait until it settles.
+      if (modelParam || !isModelConfigReady) return;
+
       const decodedPrompt = decodeURIComponent(promptParam);
 
       setValue(decodedPrompt);
@@ -386,7 +402,7 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
 
       setPromptParam(null);
 
-      // Skip the auto-generate when the selected model is unavailable — this path
+      // Config is ready and the selected model is genuinely unavailable — this path
       // bypasses the generate button, so without the guard it would fire a request
       // against a disabled provider (see lobehub/lobehub#17400).
       if (isModelUnavailable) return;
@@ -399,7 +415,17 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
         window.clearTimeout(timeoutId);
       };
     }
-  }, [promptParam, isLogin, canCreate, isModelUnavailable, setValue, setPromptParam, createVideo]);
+  }, [
+    promptParam,
+    modelParam,
+    isLogin,
+    canCreate,
+    isModelConfigReady,
+    isModelUnavailable,
+    setValue,
+    setPromptParam,
+    createVideo,
+  ]);
 
   const showInlineFrames = isSupportImageUrl || isSupportImageUrls || isSupportEndImageUrl;
   const framePreviewUrls = useMemo(

--- a/src/routes/(main)/(create)/video/features/PromptInput/index.tsx
+++ b/src/routes/(main)/(create)/video/features/PromptInput/index.tsx
@@ -20,9 +20,11 @@ import { useQueryState } from '@/hooks/useQueryParam';
 import {
   ConfigAction,
   GenerationMediaModeSegment,
+  GenerationModelNotice,
   GenerationPromptInput,
   GenerationVisibilitySelector,
   InlineVideoFrames,
+  useVideoGenerationModelNotice,
 } from '@/routes/(main)/(create)/features/GenerationInput';
 import { AspectRatioSelect } from '@/routes/(main)/(create)/image/features/ConfigPanel';
 import Select from '@/routes/(main)/(create)/image/features/ConfigPanel/components/Select';
@@ -319,6 +321,7 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
   const currentModel = useVideoStore(videoGenerationConfigSelectors.model);
   const currentProvider = useVideoStore(videoGenerationConfigSelectors.provider);
   const enabledVideoModelList = useAiInfraStore(aiProviderSelectors.enabledVideoModelList);
+  const { notice: modelNotice, isModelUnavailable } = useVideoGenerationModelNotice();
   const isInit = useVideoStore((s) => s.isInit);
   const isSupportImageUrl = useVideoStore(isSupportedParamSelector('imageUrl'));
   const isSupportImageUrls = useVideoStore(isSupportedParamSelector('imageUrls'));
@@ -383,6 +386,11 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
 
       setPromptParam(null);
 
+      // Skip the auto-generate when the selected model is unavailable — this path
+      // bypasses the generate button, so without the guard it would fire a request
+      // against a disabled provider (see lobehub/lobehub#17400).
+      if (isModelUnavailable) return;
+
       const timeoutId = window.setTimeout(async () => {
         await createVideo();
       }, 100);
@@ -391,7 +399,7 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
         window.clearTimeout(timeoutId);
       };
     }
-  }, [promptParam, isLogin, canCreate, setValue, setPromptParam, createVideo]);
+  }, [promptParam, isLogin, canCreate, isModelUnavailable, setValue, setPromptParam, createVideo]);
 
   const showInlineFrames = isSupportImageUrl || isSupportImageUrls || isSupportEndImageUrl;
   const framePreviewUrls = useMemo(
@@ -473,9 +481,10 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
   return (
     <Flexbox gap={32} width={'100%'}>
       {showTitle && <PromptTitle />}
+      <GenerationModelNotice notice={modelNotice} ns={'video'} />
       <Flexbox gap={8}>
         <GenerationPromptInput
-          disableGenerate={!isInit}
+          disableGenerate={!isInit || isModelUnavailable}
           disabled={!canCreate}
           generateLabel={t('generation.actions.generate')}
           generatingLabel={t('generation.status.generating')}


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes #17400

#### 🔀 Description of Change

The image/video generation pages hardcode a default selection (`provider=google`, `model='gemini-3.1-flash-image-preview:image'`). When the persisted last-selected model cannot be restored (e.g. the model id was renamed/removed from its provider), `_initializeDefaultImageConfig` leaves that default in place **even when the Google provider is disabled**. Users then generate against a disabled provider and get a confusing "use custom Google API Key" error — the exact scenario in #17400, where a NewAPI-only self-hosted user kept being asked for a Google key.

This PR adds a purely derived guard (no store init/fallback changes), mirroring the chat input's `ChatInputNotice` pattern:

- New `GenerationModelNotice` (shared by image/video): a pure resolver + `useImageGenerationModelNotice` / `useVideoGenerationModelNotice` hooks that check the selected model+provider against the enabled model list, gated on `isInitAiProviderRuntimeState` to avoid a false "unavailable" flash while provider config is loading.
- Two precise reasons instead of one vague message, with the provider display name interpolated:
  - `notice.providerDisabled` — provider group absent from the enabled list ("The provider Google for the current model is disabled…")
  - `notice.modelRemoved` — provider enabled but the model id is gone from its list
- Both `PromptInput`s render the notice above the input and set `disableGenerate` while unavailable.
- The `?prompt=` deep-link auto-generate effect is guarded too — it bypasses the generate button and would otherwise still fire a doomed request. The prompt param is only consumed after the `?model=` deep-link (if any) has been applied and the provider runtime config is ready, so availability is always evaluated against the final model (addresses Codex review).

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Unit: `useGenerationModelNotice.test.tsx` (12 cases — both surfaces × providerDisabled / modelRemoved / config-not-ready / available).

E2E (local web, store-probe driven): unavailable state shows the warning + disabled generate on both `/image` and `/video`; provider name interpolates as display name ("Google", not `google`); no flash during config load; `?prompt=` param fills the input but schedules no generation (0 vs 1 in the available-state control).

#### 📝 Additional Information

- Key decision: on restore failure we intentionally do NOT auto-fall back to another enabled model — silently switching models changes pricing/params without consent. Explicit notice + disabled button keeps the state visible.
- Locales: en-US + zh-CN are hand-filled; `bun run i18n` could not run (translation API balance insufficient). Remaining locales fall back to English until the next i18n fill.
- ~~Known edge (accepted): if a `?prompt=` deep link fires before provider config finishes loading, the guard can't engage~~ — fixed: the prompt param now waits for config readiness (and `?model=` settlement) before being consumed, so the guard always sees the final availability.
