### PR TITLE
🐛 fix(desktop): close expired session modal after login

### DIFF
--- a/src/features/Electron/AuthRequiredModal/index.test.tsx
+++ b/src/features/Electron/AuthRequiredModal/index.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, renderHook, screen } from '@testing-library/rea
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useAuthRequiredModal } from './index';
+import AuthRequiredModal, { useAuthRequiredModal } from './index';
 
 interface ModalProps {
   content?: ReactNode;
@@ -22,6 +22,9 @@ const modalInstance = vi.hoisted(() => ({
   update: vi.fn(),
 }));
 const translations = vi.hoisted(() => ({ current: {} as Record<string, string> }));
+const broadcastHandlers = vi.hoisted(
+  () => new Map<string, (payload?: { reason?: string }) => void>(),
+);
 const electronStore = vi.hoisted(() => ({
   current: {
     clearRemoteServerSyncError: vi.fn(),
@@ -34,7 +37,9 @@ const electronStore = vi.hoisted(() => ({
 }));
 
 vi.mock('@lobechat/electron-client-ipc', () => ({
-  useWatchBroadcast: vi.fn(),
+  useWatchBroadcast: (event: string, handler: (payload?: { reason?: string }) => void) => {
+    broadcastHandlers.set(event, handler);
+  },
 }));
 
 vi.mock('@lobehub/ui', () => ({
@@ -100,9 +105,28 @@ describe('useAuthRequiredModal', () => {
     createModalMock.mockClear();
     modalInstance.close.mockClear();
     modalInstance.update.mockClear();
+    broadcastHandlers.clear();
     electronStore.current.clearRemoteServerSyncError.mockClear();
     electronStore.current.connectRemoteServer.mockClear();
+    electronStore.current.refreshServerConfig.mockClear();
     translations.current = {};
+  });
+
+  it('closes the modal when desktop authorization succeeds', () => {
+    render(<AuthRequiredModal />);
+
+    act(() => {
+      broadcastHandlers.get('authorizationRequired')?.({ reason: 'refresh:invalid_grant' });
+    });
+
+    expect(createModalMock).toHaveBeenCalledOnce();
+
+    act(() => {
+      broadcastHandlers.get('authorizationSuccessful')?.();
+    });
+
+    expect(modalInstance.close).toHaveBeenCalledOnce();
+    expect(electronStore.current.refreshServerConfig).toHaveBeenCalledOnce();
   });
 
   it('renders the title from auth translations after the namespace becomes available', () => {

--- a/src/features/Electron/AuthRequiredModal/index.tsx
+++ b/src/features/Electron/AuthRequiredModal/index.tsx
@@ -15,35 +15,21 @@ const log = debug('lobe-client:auth-required-modal');
 
 interface AuthRequiredModalContentProps {
   onActionReady: (api: { signIn: () => Promise<void> }) => void;
-  onClose: () => void;
   onSigningInChange?: (isSigningIn: boolean) => void;
 }
 
 const AuthRequiredModalContent = memo<AuthRequiredModalContentProps>(
-  ({ onActionReady, onClose, onSigningInChange }) => {
+  ({ onActionReady, onSigningInChange }) => {
     const { t } = useTranslation('auth');
     const [isSigningIn, setIsSigningIn] = useState(false);
-    const isClosingRef = useRef(false);
 
-    const [dataSyncConfig, connectRemoteServer, refreshServerConfig, clearRemoteServerSyncError] =
-      useElectronStore((s) => [
-        s.dataSyncConfig,
-        s.connectRemoteServer,
-        s.refreshServerConfig,
-        s.clearRemoteServerSyncError,
-      ]);
+    const [dataSyncConfig, connectRemoteServer, clearRemoteServerSyncError] = useElectronStore(
+      (s) => [s.dataSyncConfig, s.connectRemoteServer, s.clearRemoteServerSyncError],
+    );
 
     useEffect(() => {
       onSigningInChange?.(isSigningIn);
     }, [isSigningIn, onSigningInChange]);
-
-    useWatchBroadcast('authorizationSuccessful', async () => {
-      if (isClosingRef.current) return;
-      isClosingRef.current = true;
-      setIsSigningIn(false);
-      onClose();
-      await refreshServerConfig();
-    });
 
     useWatchBroadcast('authorizationFailed', () => {
       setIsSigningIn(false);
@@ -101,19 +87,16 @@ AuthRequiredModalTitle.displayName = 'AuthRequiredModalTitle';
 export const useAuthRequiredModal = () => {
   const instanceRef = useRef<ModalInstance | null>(null);
 
+  const close = useCallback(() => {
+    instanceRef.current?.close();
+    instanceRef.current = null;
+  }, []);
+
   const open = useCallback(() => {
     if (instanceRef.current) return;
 
     let isSigningIn = false;
-    const isClosingRef = { current: false };
     let signIn: () => Promise<void> = async () => {};
-
-    const handleClose = () => {
-      if (isClosingRef.current) return;
-      isClosingRef.current = true;
-      instanceRef.current?.close();
-      instanceRef.current = null;
-    };
 
     const renderFooter = () => (
       <AuthRequiredFooter isSigningIn={isSigningIn} onSignIn={() => signIn()} />
@@ -122,7 +105,6 @@ export const useAuthRequiredModal = () => {
     instanceRef.current = createModal({
       content: (
         <AuthRequiredModalContent
-          onClose={handleClose}
           onActionReady={(api) => {
             signIn = api.signIn;
           }}
@@ -147,11 +129,24 @@ export const useAuthRequiredModal = () => {
     });
   }, []);
 
-  return { open };
+  return { close, open };
 };
 
 const AuthRequiredModal = memo(() => {
-  const { open } = useAuthRequiredModal();
+  const { close, open } = useAuthRequiredModal();
+  const [isRemoteServerActive, refreshServerConfig] = useElectronStore((s) => [
+    Boolean(s.dataSyncConfig?.active),
+    s.refreshServerConfig,
+  ]);
+
+  useEffect(() => {
+    if (isRemoteServerActive) close();
+  }, [close, isRemoteServerActive]);
+
+  useWatchBroadcast('authorizationSuccessful', () => {
+    close();
+    void refreshServerConfig();
+  });
 
   useWatchBroadcast('authorizationRequired', (payload) => {
     const reason = payload?.reason ?? 'unknown';


### PR DESCRIPTION
## Summary

- move the `authorizationSuccessful` listener from the imperative modal content to the always-mounted Desktop auth bridge
- close the Session Expired modal immediately after successful authorization and refresh the remote server configuration
- use the authenticated remote-server state as a convergence fallback
- add a regression test for the authorization-required → authorization-successful flow

## Root cause

The success listener was owned by the imperative modal content. Its subscription therefore depended on the modal content lifecycle, allowing a successful authorization event to be missed and leaving the modal open after login.

## User impact

After re-authenticating successfully in the Desktop app, the Session Expired modal now closes automatically and the remote-server state is synchronized.

## Validation

- `bun run check src/features/Electron/AuthRequiredModal/index.tsx src/features/Electron/AuthRequiredModal/index.test.tsx`
- `bun run check --type src/features/Electron/AuthRequiredModal/index.tsx src/features/Electron/AuthRequiredModal/index.test.tsx`
- `git diff --check`