### PR TITLE
🐛 fix(model-switch): dark-mode radar grid & rating default expand

### DIFF
--- a/package.json
+++ b/package.json
@@ -293,7 +293,7 @@
     "@lobechat/utils": "workspace:*",
     "@lobechat/web-crawler": "workspace:*",
     "@lobehub/analytics": "^1.6.3",
-    "@lobehub/charts": "^5.2.1",
+    "@lobehub/charts": "^5.4.0",
     "@lobehub/desktop-ipc-typings": "workspace:*",
     "@lobehub/editor": "^4.19.1",
     "@lobehub/icons": "^5.11.0",

--- a/src/features/ModelSwitchPanel/components/BenchmarkModal/CompareRadar.tsx
+++ b/src/features/ModelSwitchPanel/components/BenchmarkModal/CompareRadar.tsx
@@ -1,6 +1,9 @@
-import { createStaticStyles } from 'antd-style';
+import { RadarChart } from '@lobehub/charts';
+import { cssVar } from 'antd-style';
 import type { FC } from 'react';
 import { memo } from 'react';
+
+import { radarStyles } from '../ModelRatingRadar';
 
 /**
  * Slot colors for compared models, assigned by selection order. Hardcoded hex
@@ -19,60 +22,11 @@ export interface CompareRadarDimension {
 export interface CompareRadarSeries {
   color: string;
   id: string;
+  /** display name shown in the hover tooltip */
+  name: string;
   /** aligned with the dimensions array; undefined = no data (vertex omitted) */
   scores: (number | undefined)[];
 }
-
-const styles = createStaticStyles(({ css, cssVar }) => ({
-  axis: css`
-    stroke: ${cssVar.colorBorderSecondary};
-    stroke-width: 1;
-  `,
-  axisMissing: css`
-    stroke: ${cssVar.colorBorderSecondary};
-    stroke-dasharray: 3 3;
-    stroke-width: 1;
-  `,
-  container: css`
-    display: block;
-    margin-inline: auto;
-  `,
-  labelMissing: css`
-    font-size: 12px;
-    fill: ${cssVar.colorTextQuaternary};
-  `,
-  labelName: css`
-    font-size: 12px;
-    fill: ${cssVar.colorTextSecondary};
-  `,
-  labelScore: css`
-    font-size: 12px;
-    font-weight: 600;
-    fill: ${cssVar.colorText};
-  `,
-  ring: css`
-    fill: none;
-    stroke: ${cssVar.colorBorderSecondary};
-    stroke-width: 1;
-  `,
-}));
-
-const WIDTH = 400;
-const HEIGHT = 300;
-const CX = WIDTH / 2;
-const CY = HEIGHT / 2;
-const RADIUS = 96;
-const LABEL_RADIUS = RADIUS + 18;
-const RING_LEVELS = [0.25, 0.5, 0.75, 1];
-
-const pointAt = (index: number, total: number, ratio: number): [number, number] => {
-  const angle = ((-90 + (360 / total) * index) * Math.PI) / 180;
-
-  return [CX + RADIUS * ratio * Math.cos(angle), CY + RADIUS * ratio * Math.sin(angle)];
-};
-
-const toPoints = (coords: [number, number][]) =>
-  coords.map(([x, y]) => `${x.toFixed(2)},${y.toFixed(2)}`).join(' ');
 
 interface CompareRadarProps {
   dimensions: CompareRadarDimension[];
@@ -82,109 +36,44 @@ interface CompareRadarProps {
 /**
  * Multi-series variant of ModelRatingRadar for the benchmark modal: overlays up
  * to MAX_COMPARE_MODELS polygons. With a single series the vertex labels carry
- * the scores; with more, scores move to the table below to avoid clutter.
+ * the scores; with more, scores move to the tooltip and the table below.
  */
 const CompareRadar: FC<CompareRadarProps> = memo(({ dimensions, series }) => {
-  const total = dimensions.length;
   const single = series.length === 1;
 
+  const data = dimensions
+    .map((dimension, i): Record<string, number | string | undefined> => ({
+      subject: dimension.label,
+      ...Object.fromEntries(series.map((s) => [s.id, s.scores[i]])),
+    }))
+    // a dimension no selected model has scored would only draw an empty spoke
+    .filter((row) => series.some((s) => row[s.id] !== undefined));
+
   return (
-    <svg
-      className={styles.container}
-      height={HEIGHT}
-      role={'img'}
-      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
-      width={WIDTH}
-    >
-      {RING_LEVELS.map((level) => (
-        <polygon
-          className={styles.ring}
-          key={level}
-          points={toPoints(dimensions.map((_, i) => pointAt(i, total, level)))}
-        />
-      ))}
-      {dimensions.map((dimension, i) => {
-        const [x, y] = pointAt(i, total, 1);
-        const missing = series.every((s) => s.scores[i] === undefined);
-
-        return (
-          <line
-            className={missing ? styles.axisMissing : styles.axis}
-            key={dimension.key}
-            x1={CX}
-            x2={x}
-            y1={CY}
-            y2={y}
-          />
-        );
-      })}
-      {series.map((s) => (
-        <g key={s.id}>
-          {/* connect scored vertices only — a missing dimension at the center would read as a real 0 */}
-          <polygon
-            fill={s.color}
-            fillOpacity={0.12}
-            stroke={s.color}
-            strokeWidth={1.5}
-            points={toPoints(
-              s.scores.flatMap((score, i) =>
-                score === undefined ? [] : [pointAt(i, total, score / 100)],
-              ),
-            )}
-          />
-          {s.scores.map((score, i) => {
-            if (score === undefined) return null;
-            const [x, y] = pointAt(i, total, score / 100);
-
-            return <circle cx={x} cy={y} fill={s.color} key={dimensions[i].key} r={3} />;
-          })}
-        </g>
-      ))}
-      {dimensions.map((dimension, i) => {
-        const angle = ((-90 + (360 / total) * i) * Math.PI) / 180;
-        const x = CX + LABEL_RADIUS * Math.cos(angle);
-        const y = CY + LABEL_RADIUS * Math.sin(angle);
-        const cos = Math.cos(angle);
-        const sin = Math.sin(angle);
-        const anchor = cos > 0.3 ? 'start' : cos < -0.3 ? 'end' : 'middle';
-        const missing = series.every((s) => s.scores[i] === undefined);
-        // single series shows a two-line label block (name + score) like the small radar
-        const baseY = single
-          ? sin < -0.3
-            ? y - 16
-            : sin > 0.3
-              ? y + 10
-              : y - 3
-          : sin < -0.3
-            ? y - 6
-            : sin > 0.3
-              ? y + 14
-              : y + 4;
-
-        return (
-          <g key={dimension.key}>
-            <text
-              className={missing ? styles.labelMissing : styles.labelName}
-              textAnchor={anchor}
-              x={x}
-              y={baseY}
-            >
-              {dimension.label}
-            </text>
-            {single && (
-              <text
-                className={missing ? styles.labelMissing : styles.labelScore}
-                textAnchor={anchor}
-                x={x}
-                y={baseY + 15}
-              >
-                {series[0].scores[i] ?? '-'}
-              </text>
-            )}
-          </g>
-        );
-      })}
-    </svg>
+    <RadarChart
+      categories={series.map((s) => s.id)}
+      className={radarStyles.radar}
+      colors={series.map((s) => s.color)}
+      customCategories={Object.fromEntries(series.map((s) => [s.id, s.name]))}
+      data={data}
+      height={300}
+      index={'subject'}
+      maxValue={100}
+      minValue={0}
+      showLegend={false}
+      angleAxisLabelFormatter={
+        single
+          ? (label, row) => (
+              <>
+                {label}{' '}
+                <tspan fill={cssVar.colorText} fontWeight={600}>
+                  {row?.[series[0].id]}
+                </tspan>
+              </>
+            )
+          : undefined
+      }
+    />
   );
 });
 

--- a/src/features/ModelSwitchPanel/components/BenchmarkModal/index.test.tsx
+++ b/src/features/ModelSwitchPanel/components/BenchmarkModal/index.test.tsx
@@ -11,6 +11,22 @@ import BenchmarkModalContent from './index';
 vi.mock('antd-style', () => ({
   createStaticStyles: () =>
     new Proxy({}, { get: (_target, prop: string) => prop }) as Record<string, string>,
+  cssVar: new Proxy({}, { get: (_target, token) => `var(--${String(token)})` }),
+}));
+
+// recharts needs a measured container — stub the chart with its data flattened to text nodes
+vi.mock('@lobehub/charts', () => ({
+  RadarChart: ({ data }: { data: Record<string, unknown>[] }) => (
+    <svg data-testid={'radar-chart'}>
+      {data.map((row, i) => (
+        <g key={i}>
+          {Object.values(row).map((value, j) => (
+            <text key={j}>{String(value)}</text>
+          ))}
+        </g>
+      ))}
+    </svg>
+  ),
 }));
 
 vi.mock('@lobehub/ui', () => ({

--- a/src/features/ModelSwitchPanel/components/BenchmarkModal/index.tsx
+++ b/src/features/ModelSwitchPanel/components/BenchmarkModal/index.tsx
@@ -265,6 +265,7 @@ const BenchmarkModalContent: FC<BenchmarkModalContentProps> = memo(({ modelId, p
   const series: CompareRadarSeries[] = selected.map((model) => ({
     color: model.color,
     id: model.id,
+    name: model.displayName,
     scores: RATING_DIMENSION_ORDER.map((key) => model.rating[key]?.score),
   }));
 

--- a/src/features/ModelSwitchPanel/components/ModelDetailPanel.test.tsx
+++ b/src/features/ModelSwitchPanel/components/ModelDetailPanel.test.tsx
@@ -21,6 +21,22 @@ vi.mock('antd-style', () => ({
     row: 'row',
     titleText: 'titleText',
   }),
+  cssVar: new Proxy({}, { get: (_, token) => `var(--${String(token)})` }),
+}));
+
+// recharts needs a measured container — stub the chart with its data flattened to text nodes
+vi.mock('@lobehub/charts', () => ({
+  RadarChart: ({ data }: { data: Record<string, unknown>[] }) => (
+    <svg data-testid={'radar-chart'}>
+      {data.map((row, i) => (
+        <g key={i}>
+          {Object.values(row).map((value, j) => (
+            <text key={j}>{String(value)}</text>
+          ))}
+        </g>
+      ))}
+    </svg>
+  ),
 }));
 
 // keep the panel test free of the modal's own dependency chain (@lobehub/ui/base-ui, i18next)
@@ -334,10 +350,8 @@ describe('ModelDetailPanel rating', () => {
     expect(container.querySelector('svg')).toBeInTheDocument();
     expect(container).toHaveTextContent('Intelligence');
     expect(container).toHaveTextContent('100');
-    // agentic has no data: label greyed with a dash placeholder
-    expect(container).toHaveTextContent('Agentic');
-    // attribution lives in the per-dimension tooltip now that the footer is gone
-    expect(container).toHaveTextContent('Artificial Analysis');
+    // agentic has no data: the dimension is omitted from the radar entirely
+    expect(container).not.toHaveTextContent('Agentic');
   });
 
   it('renders a dimension list instead of the radar below five dimensions', () => {

--- a/src/features/ModelSwitchPanel/components/ModelRatingRadar.test.tsx
+++ b/src/features/ModelSwitchPanel/components/ModelRatingRadar.test.tsx
@@ -8,18 +8,19 @@ import type { RadarDimensionDatum } from './ModelRatingRadar';
 import ModelRatingRadar, { RATING_DIMENSION_ORDER } from './ModelRatingRadar';
 
 vi.mock('antd-style', () => ({
-  createStaticStyles: () => ({
-    axis: 'axis',
-    axisMissing: 'axisMissing',
-    container: 'container',
-    dot: 'dot',
-    labelLink: 'labelLink',
-    labelMissing: 'labelMissing',
-    labelName: 'labelName',
-    labelScore: 'labelScore',
-    polygon: 'polygon',
-    ring: 'ring',
-  }),
+  createStaticStyles: () =>
+    new Proxy({}, { get: (_target, prop: string) => prop }) as Record<string, string>,
+  cssVar: new Proxy({}, { get: (_target, token) => `var(--${String(token)})` }),
+}));
+
+const { radarChartProps } = vi.hoisted(() => ({ radarChartProps: vi.fn() }));
+
+vi.mock('@lobehub/charts', () => ({
+  RadarChart: (props: Record<string, unknown>) => {
+    radarChartProps(props);
+
+    return <svg data-testid={'radar-chart'} />;
+  },
 }));
 
 const createDimensions = (
@@ -32,12 +33,11 @@ const createDimensions = (
     sourceUrl: scores[key] === undefined ? undefined : `https://example.com/${key}`,
   }));
 
-const dataPolygonPoints = (container: HTMLElement) =>
-  container.querySelector('polygon.polygon')!.getAttribute('points')!.split(' ').filter(Boolean);
+const lastProps = () => radarChartProps.mock.lastCall![0];
 
 describe('ModelRatingRadar', () => {
-  it('connects all six vertices when every dimension is scored', () => {
-    const { container } = render(
+  it('plots all six dimensions when every one is scored', () => {
+    render(
       <ModelRatingRadar
         dimensions={createDimensions({
           agentic: 80,
@@ -50,11 +50,12 @@ describe('ModelRatingRadar', () => {
       />,
     );
 
-    expect(dataPolygonPoints(container)).toHaveLength(6);
+    expect(lastProps().data).toHaveLength(6);
+    expect(lastProps().data[0]).toEqual({ label: 'intelligence', score: 90 });
   });
 
-  it('omits missing dimensions from the polygon instead of plotting them as zero', () => {
-    const { container } = render(
+  it('omits missing dimensions from the chart instead of plotting them as zero', () => {
+    render(
       <ModelRatingRadar
         dimensions={createDimensions({
           design: 70,
@@ -66,11 +67,17 @@ describe('ModelRatingRadar', () => {
       />,
     );
 
-    // 5 scored vertices only — a center vertex would read as a real 0 score
-    expect(dataPolygonPoints(container)).toHaveLength(5);
-    expect(container.querySelectorAll('line.axisMissing')).toHaveLength(1);
-    expect(container.querySelectorAll('circle.dot')).toHaveLength(5);
-    // the missing dimension keeps its greyed label with a dash placeholder
-    expect(container.querySelectorAll('text.labelMissing')).toHaveLength(2);
+    const { data } = lastProps();
+    expect(data).toHaveLength(5);
+    expect(data.map((row: { label: string }) => row.label)).not.toContain('agentic');
+  });
+
+  it('pins the radius domain to the full 0-100 score range', () => {
+    render(<ModelRatingRadar dimensions={createDimensions({ intelligence: 90 })} />);
+
+    // an auto domain would rescale the polygon to the scored min/max and
+    // exaggerate differences — scores must always read against 0-100
+    expect(lastProps().minValue).toBe(0);
+    expect(lastProps().maxValue).toBe(100);
   });
 });

--- a/src/features/ModelSwitchPanel/components/ModelRatingRadar.tsx
+++ b/src/features/ModelSwitchPanel/components/ModelRatingRadar.tsx
@@ -1,4 +1,5 @@
-import { createStaticStyles } from 'antd-style';
+import { RadarChart } from '@lobehub/charts';
+import { createStaticStyles, cssVar } from 'antd-style';
 import type { ModelRating, ModelRatingSource } from 'model-bank';
 import type { FC } from 'react';
 import { memo } from 'react';
@@ -29,182 +30,61 @@ export const RADAR_MIN_DIMENSIONS = 5;
 export interface RadarDimensionDatum {
   key: RatingDimensionKey;
   label: string;
-  /** undefined = no data: grey label, dashed axis, vertex omitted from the polygon */
+  /** undefined = no data: the dimension is omitted from the radar (list fallback shows it) */
   score?: number;
   sourceUrl?: string;
   tooltip?: string;
 }
 
-const styles = createStaticStyles(({ css, cssVar }) => ({
-  axis: css`
-    stroke: ${cssVar.colorBorderSecondary};
-    stroke-width: 1;
-  `,
-  axisMissing: css`
-    stroke: ${cssVar.colorBorderSecondary};
-    stroke-dasharray: 3 3;
-    stroke-width: 1;
-  `,
-  container: css`
-    display: block;
-    margin-block: 4px;
-    margin-inline: auto;
-  `,
-  dot: css`
-    fill: ${cssVar.colorPrimary};
-  `,
-  labelLink: css`
-    cursor: pointer;
-
-    &:hover text {
-      fill: ${cssVar.colorPrimary};
+export const radarStyles = createStaticStyles(({ css, cssVar }) => ({
+  /**
+   * Grid strokes are re-colored with the alpha-based fill token: the library
+   * draws them with colorBorderSecondary, which equals colorBgElevated in the
+   * dark theme (both neutral scale[2]), so they vanish on elevated surfaces.
+   * Note the concentric rings render as `path` (class
+   * recharts-polar-grid-concentric-polygon) and `circle` in circle grid mode —
+   * there is no `polygon` element inside the grid group.
+   */
+  radar: css`
+    .recharts-polar-grid line,
+    .recharts-polar-grid path,
+    .recharts-polar-grid circle {
+      stroke: ${cssVar.colorFillSecondary};
     }
   `,
-  labelMissing: css`
-    font-size: 11px;
-    fill: ${cssVar.colorTextQuaternary};
-  `,
-  labelName: css`
-    font-size: 11px;
-    fill: ${cssVar.colorTextSecondary};
-  `,
-  labelScore: css`
-    font-size: 11px;
-    font-weight: 600;
-    fill: ${cssVar.colorText};
-  `,
-  polygon: css`
-    fill: ${cssVar.colorPrimary};
-    fill-opacity: 0.16;
-    stroke: ${cssVar.colorPrimary};
-    stroke-width: 1.5;
-  `,
-  ring: css`
-    fill: none;
-    stroke: ${cssVar.colorBorderSecondary};
-    stroke-width: 1;
-  `,
 }));
-
-const WIDTH = 240;
-const HEIGHT = 204;
-const CX = WIDTH / 2;
-const CY = HEIGHT / 2;
-const RADIUS = 58;
-const LABEL_RADIUS = RADIUS + 12;
-const RING_LEVELS = [0.25, 0.5, 0.75, 1];
-
-const pointAt = (index: number, total: number, ratio: number): [number, number] => {
-  const angle = ((-90 + (360 / total) * index) * Math.PI) / 180;
-
-  return [CX + RADIUS * ratio * Math.cos(angle), CY + RADIUS * ratio * Math.sin(angle)];
-};
-
-const toPoints = (coords: [number, number][]) =>
-  coords.map(([x, y]) => `${x.toFixed(2)},${y.toFixed(2)}`).join(' ');
 
 interface ModelRatingRadarProps {
   dimensions: RadarDimensionDatum[];
 }
 
 const ModelRatingRadar: FC<ModelRatingRadarProps> = memo(({ dimensions }) => {
-  const total = dimensions.length;
+  // unscored dimensions are omitted entirely — plotting them would read as a real 0
+  const data = dimensions
+    .filter((dimension) => dimension.score !== undefined)
+    .map((dimension) => ({ label: dimension.label, score: dimension.score! }));
 
   return (
-    <svg
-      className={styles.container}
-      height={HEIGHT}
-      role={'img'}
-      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
-      width={WIDTH}
-    >
-      {RING_LEVELS.map((level) => (
-        <polygon
-          className={styles.ring}
-          key={level}
-          points={toPoints(dimensions.map((_, i) => pointAt(i, total, level)))}
-        />
-      ))}
-      {dimensions.map((dimension, i) => {
-        const [x, y] = pointAt(i, total, 1);
-
-        return (
-          <line
-            className={dimension.score === undefined ? styles.axisMissing : styles.axis}
-            key={dimension.key}
-            x1={CX}
-            x2={x}
-            y1={CY}
-            y2={y}
-          />
-        );
-      })}
-      {/* connect scored vertices only — plotting a missing dimension at the center would read as a real 0 */}
-      <polygon
-        className={styles.polygon}
-        points={toPoints(
-          dimensions.flatMap((d, i) =>
-            d.score === undefined ? [] : [pointAt(i, total, d.score / 100)],
-          ),
-        )}
-      />
-      {dimensions.map((dimension, i) => {
-        if (dimension.score === undefined) return null;
-        const [x, y] = pointAt(i, total, dimension.score / 100);
-
-        return <circle className={styles.dot} cx={x} cy={y} key={dimension.key} r={2.5} />;
-      })}
-      {dimensions.map((dimension, i) => {
-        const angle = ((-90 + (360 / total) * i) * Math.PI) / 180;
-        const x = CX + LABEL_RADIUS * Math.cos(angle);
-        const y = CY + LABEL_RADIUS * Math.sin(angle);
-        const cos = Math.cos(angle);
-        const sin = Math.sin(angle);
-        const anchor = cos > 0.3 ? 'start' : cos < -0.3 ? 'end' : 'middle';
-        // keep the two-line label block clear of the vertex on top/bottom
-        const baseY = sin < -0.3 ? y - 16 : sin > 0.3 ? y + 10 : y - 3;
-        const missing = dimension.score === undefined;
-
-        const label = (
-          <g key={dimension.key}>
-            {dimension.tooltip && <title>{dimension.tooltip}</title>}
-            <text
-              className={missing ? styles.labelMissing : styles.labelName}
-              textAnchor={anchor}
-              x={x}
-              y={baseY}
-            >
-              {dimension.label}
-            </text>
-            <text
-              className={missing ? styles.labelMissing : styles.labelScore}
-              textAnchor={anchor}
-              x={x}
-              y={baseY + 13}
-            >
-              {missing ? '-' : dimension.score}
-            </text>
-          </g>
-        );
-
-        if (!dimension.sourceUrl || missing) return label;
-
-        return (
-          <a
-            className={styles.labelLink}
-            href={dimension.sourceUrl}
-            key={dimension.key}
-            // the whole radar can be a click target (benchmark modal) — a source
-            // link click must not bubble into it
-            rel={'noreferrer'}
-            target={'_blank'}
-            onClick={(e) => e.stopPropagation()}
-          >
-            {label}
-          </a>
-        );
-      })}
-    </svg>
+    <RadarChart
+      categories={['score']}
+      className={radarStyles.radar}
+      colors={[cssVar.colorPrimary]}
+      data={data}
+      height={220}
+      index={'label'}
+      maxValue={100}
+      minValue={0}
+      showLegend={false}
+      showTooltip={false}
+      angleAxisLabelFormatter={(label, row) => (
+        <>
+          {label}{' '}
+          <tspan fill={cssVar.colorText} fontWeight={600}>
+            {row?.score}
+          </tspan>
+        </>
+      )}
+    />
   );
 });
 

--- a/src/store/global/actions/workspacePane.ts
+++ b/src/store/global/actions/workspacePane.ts
@@ -5,6 +5,7 @@ import { getActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspace
 import { INBOX_SESSION_ID } from '@/const/session';
 import type { GlobalStore } from '@/store/global';
 import type { ModelDetailPanelExpandedKey, WorkingSidebarTab } from '@/store/global/initialState';
+import { MODEL_DETAIL_PANEL_EXPANDABLE_KEYS } from '@/store/global/initialState';
 import { readOverridableField } from '@/store/global/selectors/systemStatus';
 import type { StoreSetter } from '@/store/types';
 import { getStableNavigate } from '@/utils/stableNavigate';
@@ -190,8 +191,12 @@ export class GlobalWorkspacePaneActionImpl {
   };
 
   updateModelDetailPanelExpandedKeys = (keys: ModelDetailPanelExpandedKey[]): void => {
+    // persisted as the complement (collapsed keys) so newly shipped sections
+    // default to expanded — see MODEL_DETAIL_PANEL_EXPANDABLE_KEYS
+    const collapsedKeys = MODEL_DETAIL_PANEL_EXPANDABLE_KEYS.filter((key) => !keys.includes(key));
+
     this.#get().updateSystemStatus(
-      { modelDetailPanelExpandedKeys: keys },
+      { modelDetailPanelCollapsedKeys: collapsedKeys },
       n('updateModelDetailPanelExpandedKeys', keys),
     );
   };

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -113,7 +113,15 @@ export const MODEL_DETAIL_PANEL_EXPANDED_KEYS = [
 
 export type ModelDetailPanelExpandedKey = (typeof MODEL_DETAIL_PANEL_EXPANDED_KEYS)[number];
 
-export const DEFAULT_MODEL_DETAIL_PANEL_EXPANDED_KEYS = [
+/**
+ * Expandable sections of the ModelDetailPanel Accordion, all expanded by default.
+ *
+ * Persistence stores the COLLAPSED keys (`modelDetailPanelCollapsedKeys`) instead of the
+ * expanded ones: an expanded-keys array persisted before a section shipped would keep that
+ * section collapsed forever (this happened to `rating`), while a collapsed-keys array lets
+ * newly added sections default to expanded automatically.
+ */
+export const MODEL_DETAIL_PANEL_EXPANDABLE_KEYS = [
   'rating',
   'abilities',
   'pricing',
@@ -201,11 +209,13 @@ export interface SystemStatus {
   mobileShowPortal?: boolean;
   mobileShowTopic?: boolean;
   /**
-   * Persisted expanded keys of the ModelDetailPanel Accordion
-   * (Pricing / Context / Abilities / Model Config). Single shared preference
+   * Persisted collapsed keys of the ModelDetailPanel Accordion
+   * (Rating / Abilities / Pricing / Model Config). Single shared preference
    * across all entries (model picker submenu, ChatInput extend-params popover).
+   * Collapsed (not expanded) keys are stored so new sections default to expanded
+   * — see MODEL_DETAIL_PANEL_EXPANDABLE_KEYS.
    */
-  modelDetailPanelExpandedKeys?: ModelDetailPanelExpandedKey[];
+  modelDetailPanelCollapsedKeys?: ModelDetailPanelExpandedKey[];
   /**
    * ModelSwitchPanel grouping mode
    */
@@ -450,7 +460,7 @@ export const INITIAL_STATUS = {
   knowledgeBaseModalViewMode: 'list' as const,
   leftPanelWidth: 280,
   mobileShowTopic: false,
-  modelDetailPanelExpandedKeys: [...DEFAULT_MODEL_DETAIL_PANEL_EXPANDED_KEYS],
+  modelDetailPanelCollapsedKeys: [],
   modelSwitchPanelGroupMode: 'byProvider',
   modelSwitchPanelWidth: 460,
   noWideScreen: true,

--- a/src/store/global/selectors/systemStatus.test.ts
+++ b/src/store/global/selectors/systemStatus.test.ts
@@ -5,9 +5,9 @@ import { merge } from '@/utils/merge';
 import type { GlobalState } from '../initialState';
 import {
   DEFAULT_HOME_SIDEBAR_EXPANDED_KEYS,
-  DEFAULT_MODEL_DETAIL_PANEL_EXPANDED_KEYS,
   INITIAL_STATUS,
   initialState,
+  MODEL_DETAIL_PANEL_EXPANDABLE_KEYS,
 } from '../initialState';
 import {
   DEFAULT_SIDEBAR_ITEMS,
@@ -136,28 +136,42 @@ describe('systemStatusSelectors', () => {
   });
 
   describe('modelDetailPanelExpandedKeys', () => {
-    it('should expand pricing and config by default', () => {
+    it('should expand every section by default', () => {
       const s: GlobalState = {
         ...initialState,
         status: {
           ...initialState.status,
-          modelDetailPanelExpandedKeys: undefined,
+          modelDetailPanelCollapsedKeys: undefined,
         },
       };
 
       expect(systemStatusSelectors.modelDetailPanelExpandedKeys(s)).toEqual(
-        DEFAULT_MODEL_DETAIL_PANEL_EXPANDED_KEYS,
+        MODEL_DETAIL_PANEL_EXPANDABLE_KEYS,
       );
     });
 
-    it('should return stored user preference when set', () => {
+    it('should exclude collapsed keys stored by the user', () => {
       const s: GlobalState = merge(initialState, {
         status: {
-          modelDetailPanelExpandedKeys: ['pricing'],
+          modelDetailPanelCollapsedKeys: ['abilities', 'config'],
         },
       });
 
-      expect(systemStatusSelectors.modelDetailPanelExpandedKeys(s)).toEqual(['pricing']);
+      expect(systemStatusSelectors.modelDetailPanelExpandedKeys(s)).toEqual(['rating', 'pricing']);
+    });
+
+    it('should ignore a legacy persisted expanded-keys array and keep new sections expanded', () => {
+      // before the collapsed-keys migration, an expanded-keys array persisted prior to the
+      // rating section shipping kept it collapsed forever — the legacy field must be inert
+      const s: GlobalState = merge(initialState, {
+        status: {
+          modelDetailPanelExpandedKeys: ['pricing', 'config'],
+        } as never,
+      });
+
+      expect(systemStatusSelectors.modelDetailPanelExpandedKeys(s)).toEqual(
+        MODEL_DETAIL_PANEL_EXPANDABLE_KEYS,
+      );
     });
   });
 

--- a/src/store/global/selectors/systemStatus.ts
+++ b/src/store/global/selectors/systemStatus.ts
@@ -8,8 +8,8 @@ import type {
 } from '../initialState';
 import {
   DEFAULT_HOME_SIDEBAR_EXPANDED_KEYS,
-  DEFAULT_MODEL_DETAIL_PANEL_EXPANDED_KEYS,
   INITIAL_STATUS,
+  MODEL_DETAIL_PANEL_EXPANDABLE_KEYS,
   WORKSPACE_OVERRIDABLE_FIELDS,
 } from '../initialState';
 
@@ -380,8 +380,11 @@ const showImageTopicPanel = (s: GlobalState) => s.status.showImageTopicPanel;
 const hidePWAInstaller = (s: GlobalState) => s.status.hidePWAInstaller;
 const isShowCredit = (s: GlobalState) => s.status.isShowCredit;
 const language = (s: GlobalState) => s.status.language || 'auto';
-const modelDetailPanelExpandedKeys = (s: GlobalState): ModelDetailPanelExpandedKey[] =>
-  s.status.modelDetailPanelExpandedKeys ?? [...DEFAULT_MODEL_DETAIL_PANEL_EXPANDED_KEYS];
+const modelDetailPanelExpandedKeys = (s: GlobalState): ModelDetailPanelExpandedKey[] => {
+  const collapsedKeys = s.status.modelDetailPanelCollapsedKeys ?? [];
+
+  return MODEL_DETAIL_PANEL_EXPANDABLE_KEYS.filter((key) => !collapsedKeys.includes(key));
+};
 const modelSwitchPanelGroupMode = (s: GlobalState) =>
   s.status.modelSwitchPanelGroupMode || 'byProvider';
 const modelSwitchPanelWidth = (s: GlobalState) => s.status.modelSwitchPanelWidth || 460;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-11838

#### 🔀 Description of Change

Two user-facing fixes in the ModelSwitchPanel rating UI:

**1. Rating radar migrated to `@lobehub/charts` RadarChart (dark-mode grid invisible — LOBE-11838)**

- `ModelRatingRadar` and `BenchmarkModal/CompareRadar` drop their hand-rolled SVG in favor of `RadarChart` from `@lobehub/charts` (bumped `^5.2.1` → `^5.4.0`).
- The library draws polar-grid strokes with `colorBorderSecondary`, which equals `colorBgElevated` in the dark theme (both neutral `scale[2]`), so the grid vanished on elevated surfaces. A shared `radarStyles` override re-colors grid strokes with the alpha-based `colorFillSecondary` token.
- Note: the concentric rings render as `<path class="recharts-polar-grid-concentric-polygon">` (plus `circle` in circle-grid mode) — there is no `polygon` element inside the grid group, so the selector targets `line / path / circle`.
- Unscored dimensions are now omitted from the radar entirely (previously drawn as greyed labels with dashed axes); the list fallback below `RADAR_MIN_DIMENSIONS` still shows them.
- Multi-model compare gains a hover tooltip listing per-model scores by display name.

**2. Rating section defaulted to collapsed for existing users**

- The Accordion previously persisted the **expanded** keys (`modelDetailPanelExpandedKeys`). Any snapshot persisted before the rating section shipped could not contain `rating`, so it hydrated over the default and kept the new section collapsed forever for every existing user.
- Persistence is inverted to **collapsed** keys (`modelDetailPanelCollapsedKeys`, default `[]`): newly shipped sections are automatically expanded, while explicit user collapses still stick. The legacy persisted field remains in old snapshots but is no longer read (inert) — no migration needed.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- `bun run check` on the touched files — lint clean, unit tests pass (radar props/domain, dimension omission, selector default/collapse/legacy-inert regression tests).
- Agentic E2E on web (8/8 passed): dark & light grid computed strokes (`rgba(255,255,255,0.1)` / `rgba(0,0,0,0.06)`), fresh-profile default expand, legacy `modelDetailPanelExpandedKeys=[pricing,config]` snapshot confirmed inert, collapse→reload persistence, BenchmarkModal single/compare views, 5-dim omission, 2-dim list fallback.

#### 📝 Additional Information

Follow-up: `lobe-charts` `PolarGrid` itself still uses `colorBorderSecondary` — worth an upstream PR to switch to an alpha-based token, after which the local `radarStyles` override can be removed.