### PR TITLE
💄 style(topic): identity-first creator avatar in workspace topic rows

### DIFF
--- a/src/features/TopicCreatorAvatar/index.test.tsx
+++ b/src/features/TopicCreatorAvatar/index.test.tsx
@@ -5,7 +5,7 @@ import { render } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
-import TopicCreatorAvatar from './index';
+import TopicCreatorAvatar, { TopicCreatorCorner } from './index';
 
 const useAuthorInfoMock = vi.hoisted(() => vi.fn());
 
@@ -14,16 +14,19 @@ vi.mock('@/business/client/hooks/useAuthorInfo', () => ({
 }));
 
 vi.mock('@lobehub/ui', () => ({
-  Avatar: ({ avatar, title }: { avatar?: string; title?: string }) => (
-    <span data-avatar={avatar ?? ''} data-testid="avatar" data-title={title ?? ''} />
+  Avatar: ({ avatar, shape, title }: { avatar?: string; shape?: string; title?: string }) => (
+    <span
+      data-avatar={avatar ?? ''}
+      data-shape={shape ?? ''}
+      data-testid="avatar"
+      data-title={title ?? ''}
+    />
   ),
   Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
 }));
 
 describe('TopicCreatorAvatar', () => {
-  it("renders a workspace member's avatar (including the current user's own topics)", () => {
-    // In a workspace `useAuthorInfo` resolves the creator profile from members —
-    // for every topic, not just other members'.
+  it("renders a workspace member's round avatar (any member, including self)", () => {
     useAuthorInfoMock.mockReturnValue({ avatar: 'https://x/y.png', fullName: 'Alice' });
 
     const { getByTestId } = render(<TopicCreatorAvatar userId="any-member" />);
@@ -31,11 +34,11 @@ describe('TopicCreatorAvatar', () => {
     expect(useAuthorInfoMock).toHaveBeenCalledWith('any-member');
     const avatar = getByTestId('avatar');
     expect(avatar.getAttribute('data-avatar')).toBe('https://x/y.png');
+    expect(avatar.getAttribute('data-shape')).toBe('circle');
     expect(avatar.getAttribute('data-title')).toBe('Alice');
   });
 
   it('renders nothing in personal mode / when the creator is not a resolvable member', () => {
-    // No active workspace → the slot resolves to undefined → no avatar.
     useAuthorInfoMock.mockReturnValue(undefined);
 
     const { queryByTestId } = render(<TopicCreatorAvatar userId="someone" />);
@@ -49,6 +52,35 @@ describe('TopicCreatorAvatar', () => {
     const { queryByTestId } = render(<TopicCreatorAvatar />);
 
     expect(useAuthorInfoMock).toHaveBeenCalledWith(undefined);
+    expect(queryByTestId('avatar')).toBeNull();
+  });
+});
+
+describe('TopicCreatorCorner', () => {
+  it('overlays a mini round avatar on the wrapped identity icon', () => {
+    useAuthorInfoMock.mockReturnValue({ avatar: 'https://x/y.png', fullName: 'Alice' });
+
+    const { getByTestId } = render(
+      <TopicCreatorCorner userId="any-member">
+        <span data-testid="platform-icon" />
+      </TopicCreatorCorner>,
+    );
+
+    expect(getByTestId('platform-icon')).toBeTruthy();
+    const avatar = getByTestId('avatar');
+    expect(avatar.getAttribute('data-shape')).toBe('circle');
+  });
+
+  it('renders only the wrapped icon when the creator does not resolve', () => {
+    useAuthorInfoMock.mockReturnValue(undefined);
+
+    const { getByTestId, queryByTestId } = render(
+      <TopicCreatorCorner userId="ghost">
+        <span data-testid="platform-icon" />
+      </TopicCreatorCorner>,
+    );
+
+    expect(getByTestId('platform-icon')).toBeTruthy();
     expect(queryByTestId('avatar')).toBeNull();
   });
 });

--- a/src/features/TopicCreatorAvatar/index.test.tsx
+++ b/src/features/TopicCreatorAvatar/index.test.tsx
@@ -5,7 +5,7 @@ import { render } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
-import TopicCreatorAvatar, { TopicCreatorCorner } from './index';
+import TopicCreatorAvatar from './index';
 
 const useAuthorInfoMock = vi.hoisted(() => vi.fn());
 
@@ -38,12 +38,37 @@ describe('TopicCreatorAvatar', () => {
     expect(avatar.getAttribute('data-title')).toBe('Alice');
   });
 
+  it('keeps the avatar primary and shrinks the row icon into the corner badge', () => {
+    useAuthorInfoMock.mockReturnValue({ avatar: 'https://x/y.png', fullName: 'Alice' });
+
+    const { getByTestId } = render(
+      <TopicCreatorAvatar corner={<span data-testid="status-icon" />} userId="any-member" />,
+    );
+
+    // Both the full avatar and the corner-badged row icon render.
+    expect(getByTestId('avatar')).toBeTruthy();
+    expect(getByTestId('status-icon')).toBeTruthy();
+  });
+
+  it('renders the bare avatar when no corner node is provided', () => {
+    useAuthorInfoMock.mockReturnValue({ avatar: 'https://x/y.png', fullName: 'Alice' });
+
+    const { getByTestId, queryByTestId } = render(<TopicCreatorAvatar userId="any-member" />);
+
+    expect(getByTestId('avatar')).toBeTruthy();
+    expect(queryByTestId('status-icon')).toBeNull();
+  });
+
   it('renders nothing in personal mode / when the creator is not a resolvable member', () => {
     useAuthorInfoMock.mockReturnValue(undefined);
 
-    const { queryByTestId } = render(<TopicCreatorAvatar userId="someone" />);
+    const { queryByTestId } = render(
+      <TopicCreatorAvatar corner={<span data-testid="status-icon" />} userId="someone" />,
+    );
 
+    // No avatar AND no corner badge — the caller falls back to its own layout.
     expect(queryByTestId('avatar')).toBeNull();
+    expect(queryByTestId('status-icon')).toBeNull();
   });
 
   it('renders nothing when no userId is provided (default / temp topic)', () => {
@@ -52,35 +77,6 @@ describe('TopicCreatorAvatar', () => {
     const { queryByTestId } = render(<TopicCreatorAvatar />);
 
     expect(useAuthorInfoMock).toHaveBeenCalledWith(undefined);
-    expect(queryByTestId('avatar')).toBeNull();
-  });
-});
-
-describe('TopicCreatorCorner', () => {
-  it('overlays a mini round avatar on the wrapped identity icon', () => {
-    useAuthorInfoMock.mockReturnValue({ avatar: 'https://x/y.png', fullName: 'Alice' });
-
-    const { getByTestId } = render(
-      <TopicCreatorCorner userId="any-member">
-        <span data-testid="platform-icon" />
-      </TopicCreatorCorner>,
-    );
-
-    expect(getByTestId('platform-icon')).toBeTruthy();
-    const avatar = getByTestId('avatar');
-    expect(avatar.getAttribute('data-shape')).toBe('circle');
-  });
-
-  it('renders only the wrapped icon when the creator does not resolve', () => {
-    useAuthorInfoMock.mockReturnValue(undefined);
-
-    const { getByTestId, queryByTestId } = render(
-      <TopicCreatorCorner userId="ghost">
-        <span data-testid="platform-icon" />
-      </TopicCreatorCorner>,
-    );
-
-    expect(getByTestId('platform-icon')).toBeTruthy();
     expect(queryByTestId('avatar')).toBeNull();
   });
 });

--- a/src/features/TopicCreatorAvatar/index.tsx
+++ b/src/features/TopicCreatorAvatar/index.tsx
@@ -2,7 +2,7 @@
 
 import { Avatar, Tooltip } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
-import { memo, type PropsWithChildren } from 'react';
+import { memo, type ReactNode } from 'react';
 
 import { useAuthorInfo } from '@/business/client/hooks/useAuthorInfo';
 
@@ -15,6 +15,12 @@ import { useAuthorInfo } from '@/business/client/hooks/useAuthorInfo';
 export const useTopicCreator = (userId?: string) => useAuthorInfo(userId);
 
 interface TopicCreatorAvatarProps {
+  /**
+   * Optional mini node (execution status, bot platform icon, PR marker, …)
+   * overlaid at the avatar's bottom-right corner. The creator stays the
+   * primary visual; the row's own icon shrinks into the badge.
+   */
+  corner?: ReactNode;
   /** Size of the avatar in px. */
   size?: number;
   /** Creator (author) of the topic. */
@@ -27,12 +33,12 @@ interface TopicCreatorAvatarProps {
  * conversation list. Renders nothing when the creator doesn't resolve
  * (personal mode / unknown member).
  */
-const TopicCreatorAvatar = memo<TopicCreatorAvatarProps>(({ userId, size = 20 }) => {
+const TopicCreatorAvatar = memo<TopicCreatorAvatarProps>(({ userId, size = 20, corner }) => {
   const author = useTopicCreator(userId);
 
   if (!author) return null;
 
-  return (
+  const avatar = (
     <Tooltip title={author.fullName}>
       <Avatar
         avatar={author.avatar ?? undefined}
@@ -43,58 +49,47 @@ const TopicCreatorAvatar = memo<TopicCreatorAvatarProps>(({ userId, size = 20 })
       />
     </Tooltip>
   );
+
+  if (!corner) return avatar;
+
+  return (
+    <span style={{ display: 'inline-flex', lineHeight: 0, position: 'relative' }}>
+      {avatar}
+      <span
+        style={{
+          alignItems: 'center',
+          // Solid panel background so the badge glyph reads cleanly instead of
+          // colliding with the avatar underneath; the ring blends it into the
+          // sidebar like a Slack/Discord presence badge.
+          background: cssVar.colorBgLayout,
+          borderRadius: '50%',
+          bottom: -4,
+          boxShadow: `0 0 0 1.5px ${cssVar.colorBgLayout}`,
+          display: 'inline-flex',
+          height: 13,
+          justifyContent: 'center',
+          lineHeight: 0,
+          position: 'absolute',
+          right: -4,
+          width: 13,
+        }}
+      >
+        <span
+          style={{
+            alignItems: 'center',
+            display: 'inline-flex',
+            justifyContent: 'center',
+            transform: 'scale(0.75)',
+            transformOrigin: 'center',
+          }}
+        >
+          {corner}
+        </span>
+      </span>
+    </span>
+  );
 });
 
 TopicCreatorAvatar.displayName = 'TopicCreatorAvatar';
-
-interface TopicCreatorCornerProps extends PropsWithChildren {
-  /** Size of the corner avatar in px. */
-  size?: number;
-  /** Creator (author) of the topic. */
-  userId?: string;
-}
-
-/**
- * Wraps a topic row's own identity icon (bot platform, PR marker, …) and
- * overlays a mini round creator avatar at its bottom-right corner, so rows
- * that keep their original icon still carry the creator at a glance.
- */
-export const TopicCreatorCorner = memo<TopicCreatorCornerProps>(
-  ({ userId, size = 11, children }) => {
-    const author = useTopicCreator(userId);
-
-    if (!author) return children;
-
-    return (
-      <span style={{ display: 'inline-flex', lineHeight: 0, position: 'relative' }}>
-        {children}
-        <Tooltip title={author.fullName}>
-          <span
-            style={{
-              borderRadius: '50%',
-              bottom: -3,
-              // Ring the mini avatar with the panel background so it reads as
-              // an overlay instead of colliding with the icon underneath.
-              boxShadow: `0 0 0 1.5px ${cssVar.colorBgLayout}`,
-              display: 'inline-flex',
-              lineHeight: 0,
-              position: 'absolute',
-              right: -3,
-            }}
-          >
-            <Avatar
-              avatar={author.avatar ?? undefined}
-              shape={'circle'}
-              size={size}
-              title={author.fullName ?? undefined}
-            />
-          </span>
-        </Tooltip>
-      </span>
-    );
-  },
-);
-
-TopicCreatorCorner.displayName = 'TopicCreatorCorner';
 
 export default TopicCreatorAvatar;

--- a/src/features/TopicCreatorAvatar/index.tsx
+++ b/src/features/TopicCreatorAvatar/index.tsx
@@ -1,9 +1,18 @@
 'use client';
 
 import { Avatar, Tooltip } from '@lobehub/ui';
-import { memo } from 'react';
+import { cssVar } from 'antd-style';
+import { memo, type PropsWithChildren } from 'react';
 
 import { useAuthorInfo } from '@/business/client/hooks/useAuthorInfo';
+
+/**
+ * Resolves a topic creator's profile from the *active workspace* members.
+ * `useAuthorInfo` is a business slot: cloud resolves the member profile, the
+ * open-source build is a no-op — and it returns `undefined` without an active
+ * workspace, so all creator-avatar UI disappears in personal mode.
+ */
+export const useTopicCreator = (userId?: string) => useAuthorInfo(userId);
 
 interface TopicCreatorAvatarProps {
   /** Size of the avatar in px. */
@@ -13,17 +22,13 @@ interface TopicCreatorAvatarProps {
 }
 
 /**
- * In a workspace the topic list mixes topics from every member. Show each
- * topic's creator avatar as a trailing indicator — including the current user's
- * own topics — so the list reads as a shared space.
- *
- * `useAuthorInfo` is a business slot that resolves the creator profile from the
- * *active workspace* members (cloud) or a no-op (open-source). It returns
- * `undefined` when there is no active workspace, so this renders nothing in
- * personal mode.
+ * Round creator avatar for a workspace topic row's leading icon slot — it
+ * replaces the default `#` placeholder so the shared list reads like a
+ * conversation list. Renders nothing when the creator doesn't resolve
+ * (personal mode / unknown member).
  */
-const TopicCreatorAvatar = memo<TopicCreatorAvatarProps>(({ userId, size = 16 }) => {
-  const author = useAuthorInfo(userId);
+const TopicCreatorAvatar = memo<TopicCreatorAvatarProps>(({ userId, size = 20 }) => {
+  const author = useTopicCreator(userId);
 
   if (!author) return null;
 
@@ -31,6 +36,7 @@ const TopicCreatorAvatar = memo<TopicCreatorAvatarProps>(({ userId, size = 16 })
     <Tooltip title={author.fullName}>
       <Avatar
         avatar={author.avatar ?? undefined}
+        shape={'circle'}
         size={size}
         style={{ flex: 'none' }}
         title={author.fullName ?? undefined}
@@ -40,5 +46,55 @@ const TopicCreatorAvatar = memo<TopicCreatorAvatarProps>(({ userId, size = 16 })
 });
 
 TopicCreatorAvatar.displayName = 'TopicCreatorAvatar';
+
+interface TopicCreatorCornerProps extends PropsWithChildren {
+  /** Size of the corner avatar in px. */
+  size?: number;
+  /** Creator (author) of the topic. */
+  userId?: string;
+}
+
+/**
+ * Wraps a topic row's own identity icon (bot platform, PR marker, …) and
+ * overlays a mini round creator avatar at its bottom-right corner, so rows
+ * that keep their original icon still carry the creator at a glance.
+ */
+export const TopicCreatorCorner = memo<TopicCreatorCornerProps>(
+  ({ userId, size = 11, children }) => {
+    const author = useTopicCreator(userId);
+
+    if (!author) return children;
+
+    return (
+      <span style={{ display: 'inline-flex', lineHeight: 0, position: 'relative' }}>
+        {children}
+        <Tooltip title={author.fullName}>
+          <span
+            style={{
+              borderRadius: '50%',
+              bottom: -3,
+              // Ring the mini avatar with the panel background so it reads as
+              // an overlay instead of colliding with the icon underneath.
+              boxShadow: `0 0 0 1.5px ${cssVar.colorBgLayout}`,
+              display: 'inline-flex',
+              lineHeight: 0,
+              position: 'absolute',
+              right: -3,
+            }}
+          >
+            <Avatar
+              avatar={author.avatar ?? undefined}
+              shape={'circle'}
+              size={size}
+              title={author.fullName ?? undefined}
+            />
+          </span>
+        </Tooltip>
+      </span>
+    );
+  },
+);
+
+TopicCreatorCorner.displayName = 'TopicCreatorCorner';
 
 export default TopicCreatorAvatar;

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -450,19 +450,20 @@ const TopicItem = memo<TopicItemProps>(
       />
     );
 
-    // Workspace mode (creator resolvable): the leading slot carries identity —
-    // the creator's round avatar replaces `#`; rows with their own identity
-    // icon (Discord / WeChat / PR marker) keep it, with the creator shrunk to a
-    // bottom-right corner badge. Status moves to the trailing side. Personal
-    // mode keeps the original layout untouched.
+    // Workspace mode (creator resolvable): the row's own icon — execution
+    // status first, then identity icons (Discord / WeChat / PR marker) — keeps
+    // the leading slot with the creator shrunk to a bottom-right corner badge;
+    // only a plain `#` row is fully replaced by the creator's round avatar.
+    // Personal mode keeps the original layout untouched.
+    const ownIconNode = statusIconNode ?? identityIconNode;
     const leadingIconNode = author ? (
-      identityIconNode ? (
-        <TopicCreatorCorner userId={userId}>{identityIconNode}</TopicCreatorCorner>
+      ownIconNode ? (
+        <TopicCreatorCorner userId={userId}>{ownIconNode}</TopicCreatorCorner>
       ) : (
         <TopicCreatorAvatar userId={userId} />
       )
     ) : (
-      (statusIconNode ?? identityIconNode ?? hashIconNode)
+      (ownIconNode ?? hashIconNode)
     );
 
     const navItem = (
@@ -473,17 +474,12 @@ const TopicItem = memo<TopicItemProps>(
         description={workingDirectoryNode}
         disabled={editing}
         draggable={!editing}
+        extra={<RunningElapsedTime agentId={activeAgentId} topicId={id} />}
         href={href}
         icon={leadingIconNode}
         slots={{ titlePrefix: draftPrefix }}
         title={title === '...' ? <DotsLoading gap={3} size={4} /> : title}
         titleColor={cssVar.colorText}
-        extra={
-          <>
-            <RunningElapsedTime agentId={activeAgentId} topicId={id} />
-            {author ? statusIconNode : null}
-          </>
-        }
         onClick={handleClick}
         onDoubleClick={() => void handleDoubleClick()}
         onDragStart={handleDragStart}

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -23,10 +23,7 @@ import DirIcon from '@/features/ChatInput/ControlBar/DirIcon';
 import { useHasDraft } from '@/features/ChatInput/draftStorage';
 import { startTopicDrag } from '@/features/ChatInput/InputEditor/ReferTopic/topicDragData';
 import NavItem from '@/features/NavPanel/components/NavItem';
-import TopicCreatorAvatar, {
-  TopicCreatorCorner,
-  useTopicCreator,
-} from '@/features/TopicCreatorAvatar';
+import TopicCreatorAvatar, { useTopicCreator } from '@/features/TopicCreatorAvatar';
 import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
 import { getWorkingDirectoryName } from '@/helpers/workingDirectoryPath';
 import { getPlatformIcon } from '@/routes/(main)/agent/channel/const';
@@ -450,18 +447,14 @@ const TopicItem = memo<TopicItemProps>(
       />
     );
 
-    // Workspace mode (creator resolvable): the row's own icon — execution
-    // status first, then identity icons (Discord / WeChat / PR marker) — keeps
-    // the leading slot with the creator shrunk to a bottom-right corner badge;
-    // only a plain `#` row is fully replaced by the creator's round avatar.
-    // Personal mode keeps the original layout untouched.
+    // Workspace mode (creator resolvable): the creator's round avatar is the
+    // primary visual and always leads the row; the row's own icon — execution
+    // status first, then identity icons (Discord / WeChat / PR marker) —
+    // shrinks into a bottom-right corner badge. Personal mode keeps the
+    // original layout untouched.
     const ownIconNode = statusIconNode ?? identityIconNode;
     const leadingIconNode = author ? (
-      ownIconNode ? (
-        <TopicCreatorCorner userId={userId}>{ownIconNode}</TopicCreatorCorner>
-      ) : (
-        <TopicCreatorAvatar userId={userId} />
-      )
+      <TopicCreatorAvatar corner={ownIconNode} userId={userId} />
     ) : (
       (ownIconNode ?? hashIconNode)
     );

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -161,9 +161,16 @@ const TopicItem = memo<TopicItemProps>(
     const isHeterogeneousAgent = useAgentStore(agentSelectors.isCurrentAgentHeterogeneous);
     const addTab = useElectronStore((s) => s.addTab);
     const prefetchMessages = useChatStore((s) => s.prefetchMessages);
+    // A workspace-private agent is a purely personal conversation space even
+    // inside a workspace — its topics all belong to the viewer, so the creator
+    // avatar carries no information there. Only workspace-shared (`public`)
+    // agents get the avatar treatment.
+    const isSharedAgent = useAgentStore(
+      (s) => agentSelectors.currentAgentVisibility(s) === 'public',
+    );
     // Creator of the topic — resolves only inside an active workspace; drives
     // the identity-first icon layout below.
-    const author = useTopicCreator(userId);
+    const author = useTopicCreator(isSharedAgent ? userId : undefined);
 
     const loadingRingColor = isDarkMode
       ? cssVar.colorWarningBorder

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -23,7 +23,10 @@ import DirIcon from '@/features/ChatInput/ControlBar/DirIcon';
 import { useHasDraft } from '@/features/ChatInput/draftStorage';
 import { startTopicDrag } from '@/features/ChatInput/InputEditor/ReferTopic/topicDragData';
 import NavItem from '@/features/NavPanel/components/NavItem';
-import TopicCreatorAvatar from '@/features/TopicCreatorAvatar';
+import TopicCreatorAvatar, {
+  TopicCreatorCorner,
+  useTopicCreator,
+} from '@/features/TopicCreatorAvatar';
 import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
 import { getWorkingDirectoryName } from '@/helpers/workingDirectoryPath';
 import { getPlatformIcon } from '@/routes/(main)/agent/channel/const';
@@ -161,6 +164,9 @@ const TopicItem = memo<TopicItemProps>(
     const isHeterogeneousAgent = useAgentStore(agentSelectors.isCurrentAgentHeterogeneous);
     const addTab = useElectronStore((s) => s.addTab);
     const prefetchMessages = useChatStore((s) => s.prefetchMessages);
+    // Creator of the topic — resolves only inside an active workspace; drives
+    // the identity-first icon layout below.
+    const author = useTopicCreator(userId);
 
     const loadingRingColor = isDarkMode
       ? cssVar.colorWarningBorder
@@ -352,6 +358,113 @@ const TopicItem = memo<TopicItemProps>(
     // keeping the row itself clean.
     const metaCard = getTopicMetaCard(metadata);
 
+    // Execution / attention state. In workspace mode this moves to the row's
+    // trailing side so the leading slot can carry the creator identity.
+    const statusIconNode = (() => {
+      // A scheduled topic hasn't run yet — nothing else can be true of it,
+      // so its clock outranks the other states.
+      if (isScheduled) {
+        const visual = TOPIC_STATUS_VISUALS.scheduled;
+        const runAt = metadata?.scheduledRun?.runAt;
+        const icon = <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />;
+        return runAt ? (
+          <Tooltip title={t('scheduledStatusTip', { time: dayjs(runAt).format('MM-DD HH:mm') })}>
+            {icon}
+          </Tooltip>
+        ) : (
+          icon
+        );
+      }
+      if (isWaitingForHuman) {
+        const visual = TOPIC_STATUS_VISUALS.waitingForHuman;
+        return <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />;
+      }
+      if (shouldShowRunningIcon) {
+        return (
+          <RingLoadingIcon
+            ringColor={loadingRingColor}
+            size={14}
+            style={{ color: cssVar.colorWarning }}
+          />
+        );
+      }
+      if (isFailed) {
+        const visual = TOPIC_STATUS_VISUALS.failed;
+        return (
+          <Tooltip title={t('failedStatusTip')}>
+            <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />
+          </Tooltip>
+        );
+      }
+      // Unread is the third `pending` attention state (see `resolveStatusBucket`
+      // in `@lobechat/utils/client/topic`), so it ranks with its two siblings
+      // above — and above the PR marker, which shares this single icon slot.
+      if (hasUnread) return unreadIcon;
+      // Persisted execution state is the topic's primary status. Keep every
+      // non-idle state above git metadata so scheduled / paused / completed
+      // topics cannot be mistaken for merely open / merged / closed PRs.
+      // `running` is handled exclusively by shouldShowRunningIcon above so
+      // the masked post-output tail cannot fall back to a static running icon.
+      if (status && status !== 'active' && status !== 'running') {
+        const visual = TOPIC_STATUS_VISUALS[status];
+        return <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />;
+      }
+      return null;
+    })();
+
+    // Identity-flavored icons the row owns (bot platform, PR marker) — these
+    // keep the leading slot even in workspace mode, with the creator shrunk to
+    // a corner badge.
+    const identityIconNode = (() => {
+      // GitHub PR state marker (open=green, merged=purple, closed=red),
+      // like Codex. It is secondary metadata, so only an idle topic uses it
+      // as the leading icon.
+      if (metaCard?.pullRequest) {
+        const prVisual = PR_STATE_VISUAL[getPullRequestState(metaCard.pullRequest)];
+        return (
+          <Tooltip title={t(prVisual.labelKey)}>
+            <Icon icon={prVisual.icon} size={'small'} style={{ color: prVisual.color }} />
+          </Tooltip>
+        );
+      }
+      if (metadata?.bot?.platform) {
+        const ProviderIcon = getPlatformIcon(metadata.bot!.platform);
+        if (ProviderIcon) {
+          return <ProviderIcon color={cssVar.colorTextDescription} size={16} />;
+        }
+      }
+      return null;
+    })();
+
+    const hashIconNode = (
+      <Icon
+        icon={HashIcon}
+        size={'small'}
+        style={{
+          color: cssVar.colorTextDescription,
+          // Heterogeneous agents (Claude Code, Codex, …) have no chat-style
+          // topic semantics, so suppress the `#` glyph while keeping its
+          // box so the title stays aligned with sibling rows.
+          visibility: isHeterogeneousAgent ? 'hidden' : undefined,
+        }}
+      />
+    );
+
+    // Workspace mode (creator resolvable): the leading slot carries identity —
+    // the creator's round avatar replaces `#`; rows with their own identity
+    // icon (Discord / WeChat / PR marker) keep it, with the creator shrunk to a
+    // bottom-right corner badge. Status moves to the trailing side. Personal
+    // mode keeps the original layout untouched.
+    const leadingIconNode = author ? (
+      identityIconNode ? (
+        <TopicCreatorCorner userId={userId}>{identityIconNode}</TopicCreatorCorner>
+      ) : (
+        <TopicCreatorAvatar userId={userId} />
+      )
+    ) : (
+      (statusIconNode ?? identityIconNode ?? hashIconNode)
+    );
+
     const navItem = (
       <NavItem
         actions={<Actions dropdownMenu={dropdownMenu} />}
@@ -361,97 +474,16 @@ const TopicItem = memo<TopicItemProps>(
         disabled={editing}
         draggable={!editing}
         href={href}
+        icon={leadingIconNode}
         slots={{ titlePrefix: draftPrefix }}
         title={title === '...' ? <DotsLoading gap={3} size={4} /> : title}
         titleColor={cssVar.colorText}
         extra={
           <>
             <RunningElapsedTime agentId={activeAgentId} topicId={id} />
-            <TopicCreatorAvatar userId={userId} />
+            {author ? statusIconNode : null}
           </>
         }
-        icon={(() => {
-          // A scheduled topic hasn't run yet — nothing else can be true of it,
-          // so its clock outranks the other states.
-          if (isScheduled) {
-            const visual = TOPIC_STATUS_VISUALS.scheduled;
-            const runAt = metadata?.scheduledRun?.runAt;
-            const icon = <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />;
-            return runAt ? (
-              <Tooltip
-                title={t('scheduledStatusTip', { time: dayjs(runAt).format('MM-DD HH:mm') })}
-              >
-                {icon}
-              </Tooltip>
-            ) : (
-              icon
-            );
-          }
-          if (isWaitingForHuman) {
-            const visual = TOPIC_STATUS_VISUALS.waitingForHuman;
-            return <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />;
-          }
-          if (shouldShowRunningIcon) {
-            return (
-              <RingLoadingIcon
-                ringColor={loadingRingColor}
-                size={14}
-                style={{ color: cssVar.colorWarning }}
-              />
-            );
-          }
-          if (isFailed) {
-            const visual = TOPIC_STATUS_VISUALS.failed;
-            return (
-              <Tooltip title={t('failedStatusTip')}>
-                <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />
-              </Tooltip>
-            );
-          }
-          // Unread is the third `pending` attention state (see `resolveStatusBucket`
-          // in `@lobechat/utils/client/topic`), so it ranks with its two siblings
-          // above — and above the PR marker, which shares this single icon slot.
-          if (hasUnread) return unreadIcon;
-          // Persisted execution state is the topic's primary status. Keep every
-          // non-idle state above git metadata so scheduled / paused / completed
-          // topics cannot be mistaken for merely open / merged / closed PRs.
-          // `running` is handled exclusively by shouldShowRunningIcon above so
-          // the masked post-output tail cannot fall back to a static running icon.
-          if (status && status !== 'active' && status !== 'running') {
-            const visual = TOPIC_STATUS_VISUALS[status];
-            return <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />;
-          }
-          // GitHub PR state marker (open=green, merged=purple, closed=red),
-          // like Codex. It is secondary metadata, so only an idle topic uses it
-          // as the leading icon.
-          if (metaCard?.pullRequest) {
-            const prVisual = PR_STATE_VISUAL[getPullRequestState(metaCard.pullRequest)];
-            return (
-              <Tooltip title={t(prVisual.labelKey)}>
-                <Icon icon={prVisual.icon} size={'small'} style={{ color: prVisual.color }} />
-              </Tooltip>
-            );
-          }
-          if (metadata?.bot?.platform) {
-            const ProviderIcon = getPlatformIcon(metadata.bot!.platform);
-            if (ProviderIcon) {
-              return <ProviderIcon color={cssVar.colorTextDescription} size={16} />;
-            }
-          }
-          return (
-            <Icon
-              icon={HashIcon}
-              size={'small'}
-              style={{
-                color: cssVar.colorTextDescription,
-                // Heterogeneous agents (Claude Code, Codex, …) have no chat-style
-                // topic semantics, so suppress the `#` glyph while keeping its
-                // box so the title stays aligned with sibling rows.
-                visibility: isHeterogeneousAgent ? 'hidden' : undefined,
-              }}
-            />
-          );
-        })()}
         onClick={handleClick}
         onDoubleClick={() => void handleDoubleClick()}
         onDragStart={handleDragStart}

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -14,7 +14,7 @@ import RingLoadingIcon from '@/components/RingLoading';
 import { isDesktop } from '@/const/version';
 import { useHasDraft } from '@/features/ChatInput/draftStorage';
 import NavItem from '@/features/NavPanel/components/NavItem';
-import TopicCreatorAvatar from '@/features/TopicCreatorAvatar';
+import TopicCreatorAvatar, { useTopicCreator } from '@/features/TopicCreatorAvatar';
 import { useFocusTopicPopup } from '@/features/TopicPopupGuard/useTopicPopupsRegistry';
 import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
 import { useAgentGroupStore } from '@/store/agentGroup';
@@ -100,6 +100,9 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
   const addTab = useElectronStore((s) => s.addTab);
   const activeWorkspaceSlug = useActiveWorkspaceSlug();
   const focusTopicPopup = useFocusTopicPopup({ groupId: activeGroupId });
+  // Creator of the topic — resolves only inside an active workspace; drives
+  // the identity-first icon layout below.
+  const author = useTopicCreator(userId);
 
   // Construct href for cmd+click support
   const href = useMemo(() => {
@@ -272,6 +275,37 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
     );
   }
 
+  // Execution / attention state. In workspace mode this moves to the row's
+  // trailing side so the leading slot can carry the creator identity.
+  const statusIconNode = (() => {
+    if (isWaitingForHuman) {
+      const visual = TOPIC_STATUS_VISUALS.waitingForHuman;
+      return <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />;
+    }
+    if (isLoading || isRunning) {
+      return (
+        <RingLoadingIcon
+          ringColor={loadingRingColor}
+          size={14}
+          style={{ color: cssVar.colorWarning }}
+        />
+      );
+    }
+    if (isFailed) {
+      const visual = TOPIC_STATUS_VISUALS.failed;
+      return (
+        <Tooltip title={t('failedStatusTip')}>
+          <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />
+        </Tooltip>
+      );
+    }
+    if (isCompleted) {
+      const visual = TOPIC_STATUS_VISUALS.completed;
+      return <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />;
+    }
+    return null;
+  })();
+
   return (
     <Flexbox style={{ position: 'relative' }}>
       <NavItem
@@ -279,40 +313,22 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
         active={active && !threadId}
         contextMenuItems={dropdownMenu}
         disabled={editing}
-        extra={<TopicCreatorAvatar userId={userId} />}
+        extra={author ? statusIconNode : undefined}
         href={!editing ? href : undefined}
         title={title === '...' ? <DotsLoading gap={3} size={4} /> : title}
         titleColor={cssVar.colorText}
-        icon={(() => {
-          if (isWaitingForHuman) {
-            const visual = TOPIC_STATUS_VISUALS.waitingForHuman;
-            return <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />;
-          }
-          if (isLoading || isRunning) {
-            return (
-              <RingLoadingIcon
-                ringColor={loadingRingColor}
-                size={14}
-                style={{ color: cssVar.colorWarning }}
-              />
-            );
-          }
-          if (isFailed) {
-            const visual = TOPIC_STATUS_VISUALS.failed;
-            return (
-              <Tooltip title={t('failedStatusTip')}>
-                <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />
-              </Tooltip>
-            );
-          }
-          if (isCompleted) {
-            const visual = TOPIC_STATUS_VISUALS.completed;
-            return <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />;
-          }
-          return (
-            <Icon icon={HashIcon} size={'small'} style={{ color: cssVar.colorTextDescription }} />
-          );
-        })()}
+        icon={
+          // Workspace mode: creator identity leads (round avatar replaces `#`)
+          // and status moves to the trailing side. Personal mode keeps the
+          // original status-first layout.
+          author ? (
+            <TopicCreatorAvatar userId={userId} />
+          ) : (
+            (statusIconNode ?? (
+              <Icon icon={HashIcon} size={'small'} style={{ color: cssVar.colorTextDescription }} />
+            ))
+          )
+        }
         slots={{
           iconPostfix: unreadNode,
           titlePrefix: draftPrefix,

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -14,7 +14,10 @@ import RingLoadingIcon from '@/components/RingLoading';
 import { isDesktop } from '@/const/version';
 import { useHasDraft } from '@/features/ChatInput/draftStorage';
 import NavItem from '@/features/NavPanel/components/NavItem';
-import TopicCreatorAvatar, { useTopicCreator } from '@/features/TopicCreatorAvatar';
+import TopicCreatorAvatar, {
+  TopicCreatorCorner,
+  useTopicCreator,
+} from '@/features/TopicCreatorAvatar';
 import { useFocusTopicPopup } from '@/features/TopicPopupGuard/useTopicPopupsRegistry';
 import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
 import { useAgentGroupStore } from '@/store/agentGroup';
@@ -313,16 +316,20 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
         active={active && !threadId}
         contextMenuItems={dropdownMenu}
         disabled={editing}
-        extra={author ? statusIconNode : undefined}
         href={!editing ? href : undefined}
         title={title === '...' ? <DotsLoading gap={3} size={4} /> : title}
         titleColor={cssVar.colorText}
         icon={
-          // Workspace mode: creator identity leads (round avatar replaces `#`)
-          // and status moves to the trailing side. Personal mode keeps the
-          // original status-first layout.
+          // Workspace mode: the row's own status icon keeps the leading slot
+          // with the creator shrunk to a bottom-right corner badge; a plain
+          // `#` row is fully replaced by the creator's round avatar. Personal
+          // mode keeps the original status-first layout.
           author ? (
-            <TopicCreatorAvatar userId={userId} />
+            statusIconNode ? (
+              <TopicCreatorCorner userId={userId}>{statusIconNode}</TopicCreatorCorner>
+            ) : (
+              <TopicCreatorAvatar userId={userId} />
+            )
           ) : (
             (statusIconNode ?? (
               <Icon icon={HashIcon} size={'small'} style={{ color: cssVar.colorTextDescription }} />

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -14,10 +14,7 @@ import RingLoadingIcon from '@/components/RingLoading';
 import { isDesktop } from '@/const/version';
 import { useHasDraft } from '@/features/ChatInput/draftStorage';
 import NavItem from '@/features/NavPanel/components/NavItem';
-import TopicCreatorAvatar, {
-  TopicCreatorCorner,
-  useTopicCreator,
-} from '@/features/TopicCreatorAvatar';
+import TopicCreatorAvatar, { useTopicCreator } from '@/features/TopicCreatorAvatar';
 import { useFocusTopicPopup } from '@/features/TopicPopupGuard/useTopicPopupsRegistry';
 import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
 import { useAgentGroupStore } from '@/store/agentGroup';
@@ -320,16 +317,11 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
         title={title === '...' ? <DotsLoading gap={3} size={4} /> : title}
         titleColor={cssVar.colorText}
         icon={
-          // Workspace mode: the row's own status icon keeps the leading slot
-          // with the creator shrunk to a bottom-right corner badge; a plain
-          // `#` row is fully replaced by the creator's round avatar. Personal
-          // mode keeps the original status-first layout.
+          // Workspace mode: the creator's round avatar is the primary visual;
+          // the row's own status icon shrinks into a bottom-right corner
+          // badge. Personal mode keeps the original status-first layout.
           author ? (
-            statusIconNode ? (
-              <TopicCreatorCorner userId={userId}>{statusIconNode}</TopicCreatorCorner>
-            ) : (
-              <TopicCreatorAvatar userId={userId} />
-            )
+            <TopicCreatorAvatar corner={statusIconNode} userId={userId} />
           ) : (
             (statusIconNode ?? (
               <Icon icon={HashIcon} size={'small'} style={{ color: cssVar.colorTextDescription }} />

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -100,9 +100,16 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
   const addTab = useElectronStore((s) => s.addTab);
   const activeWorkspaceSlug = useActiveWorkspaceSlug();
   const focusTopicPopup = useFocusTopicPopup({ groupId: activeGroupId });
+  // A workspace-private group is a purely personal conversation space even
+  // inside a workspace — its topics all belong to the viewer, so the creator
+  // avatar carries no information there. Only workspace-shared (`public`)
+  // groups get the avatar treatment.
+  const isSharedGroup = useAgentGroupStore((s) =>
+    s.activeGroupId ? s.groupMap[s.activeGroupId]?.visibility === 'public' : false,
+  );
   // Creator of the topic — resolves only inside an active workspace; drives
   // the identity-first icon layout below.
-  const author = useTopicCreator(userId);
+  const author = useTopicCreator(isSharedGroup ? userId : undefined);
 
   // Construct href for cmd+click support
   const href = useMemo(() => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

Follow-up to #17386 (workspace topic creator avatar) — addresses team feedback.

#### 🔀 Description of Change

Identity-first layout for the workspace topic sidebar rows:

- The **round** creator avatar now **leads the row, replacing the default `#`**.
- Rows with their own identity icon (Discord / WeChat bot platform, PR marker) **keep that icon**, with the creator shrunk to a **mini round badge at the icon's bottom-right corner**.
- Execution status (running / failed / completed / scheduled / unread …) moves to the **trailing side** of the row in workspace mode.
- **Personal mode** (no active workspace) keeps the original status-first layout untouched — `useTopicCreator` resolves only inside an active workspace.

Applies to both the agent and group topic sidebars.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- `cd lobehub && bunx vitest run 'src/features/TopicCreatorAvatar/index.test.tsx'` — round avatar for any member; corner-badge wrapper keeps the identity icon; nothing in personal mode.
- Web (seeded 2-member workspace): plain rows lead with the round avatar; a `running` topic shows the ring at the row end; a Discord-bot topic keeps the Discord icon with a mini avatar corner badge; personal home unchanged.

#### 📸 Screenshots / Videos

See the acceptance round-3 report (verify platform) for rendered evidence.
