### PR TITLE
🐛 fix: guard missing agent config in workspace profile editor

### DIFF
--- a/src/routes/(main)/agent/profile/features/ProfileEditor/WorkspaceAgentModelPolicy.test.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/WorkspaceAgentModelPolicy.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { WorkspaceAgentModelPolicy } from './WorkspaceAgentModelPolicy';
+
+const testState = vi.hoisted(() => ({
+  agent: {
+    agentMap: {
+      'agent-1': {
+        agencyConfig: {
+          modelSelectionPolicy: 'member' as const,
+        },
+        model: 'gpt-4',
+        visibility: 'public' as 'private' | 'public',
+        workspaceId: 'workspace-1',
+      },
+    } as Record<string, object>,
+    updateAgentConfigById: vi.fn(),
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/hooks/usePermission', () => ({
+  usePermission: () => ({ allowed: true }),
+}));
+
+vi.mock('@/features/ModelSelect', () => ({
+  default: () => <div data-testid="model-select" />,
+}));
+
+vi.mock('./WorkspaceAgentPolicyCard', () => ({
+  WorkspaceAgentPolicyCard: ({ children, title }: { children: ReactNode; title: string }) => (
+    <div>
+      <span>{title}</span>
+      {children}
+    </div>
+  ),
+  WorkspaceAgentSelectionPolicyMenu: () => <div data-testid="policy-menu" />,
+}));
+
+vi.mock('@/store/agent', () => ({
+  useAgentStore: (selector: (state: typeof testState.agent) => unknown) =>
+    selector(testState.agent),
+}));
+
+describe('WorkspaceAgentModelPolicy', () => {
+  it('renders the policy card for a loaded workspace agent', () => {
+    render(<WorkspaceAgentModelPolicy agentId="agent-1" />);
+
+    expect(screen.getByText('settingAgent.modelPolicy.title')).toBeTruthy();
+    expect(screen.getByTestId('model-select')).toBeTruthy();
+  });
+
+  it('renders nothing instead of crashing while the agent config is not loaded yet', () => {
+    const { container } = render(<WorkspaceAgentModelPolicy agentId="missing-agent" />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/WorkspaceAgentModelPolicy.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/WorkspaceAgentModelPolicy.tsx
@@ -26,9 +26,9 @@ export const WorkspaceAgentModelPolicy = memo<WorkspaceAgentModelPolicyProps>(({
   const config = useAgentStore(agentSelectors.getAgentConfigById(agentId), isEqual);
   const agent = useAgentStore(agentByIdSelectors.getAgentById(agentId));
   const updateAgentConfigById = useAgentStore((s) => s.updateAgentConfigById);
-  const isLocked = config.agencyConfig?.modelSelectionPolicy !== 'member';
+  if (!agent?.workspaceId || !config) return null;
 
-  if (!agent?.workspaceId) return null;
+  const isLocked = config.agencyConfig?.modelSelectionPolicy !== 'member';
 
   const labelKeys = getWorkspaceAgentSelectionPolicyLabelKeys(agent.visibility === 'private');
 

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/index.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/index.tsx
@@ -56,7 +56,7 @@ const ProfileEditor = memo(() => {
   const isWorkspaceAgent = useAgentStore(agentByIdSelectors.isWorkspaceAgentById(agentId));
   const updateAgentConfigById = useAgentStore((s) => s.updateAgentConfigById);
   const isHeterogeneous = useAgentStore(agentSelectors.isCurrentAgentHeterogeneous);
-  const heterogeneousProvider = config.agencyConfig?.heterogeneousProvider;
+  const heterogeneousProvider = config?.agencyConfig?.heterogeneousProvider;
 
   const updateHeterogeneousCommand = async (command: string) => {
     if (!canEdit) return;
@@ -80,7 +80,7 @@ const ProfileEditor = memo(() => {
 
   const updateBoundDeviceId = async (boundDeviceId: string) => {
     await updateAgentConfigById(agentId, {
-      agencyConfig: { ...config.agencyConfig, boundDeviceId, executionTarget: 'device' },
+      agencyConfig: { ...config?.agencyConfig, boundDeviceId, executionTarget: 'device' },
     });
   };
 
@@ -174,8 +174,8 @@ const ProfileEditor = memo(() => {
                   disabled={!canEdit}
                   popupWidth={400}
                   value={{
-                    model: config.model,
-                    provider: config.provider,
+                    model: config?.model,
+                    provider: config?.provider,
                   }}
                   onChange={(value) => {
                     if (!canEdit) return;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Follow-up to #17417 — addresses the Codex P2 finding on the cloud bump PR (https://github.com/lobehub-biz/lobehub-cloud/pull/1143).

#### 🔀 Description of Change

`agentSelectors.getAgentConfigById` returns `agentMap[agentId]`, which is `undefined` before the agent is loaded (or for a deleted/not-found agent), despite the selector's cast:

- `WorkspaceAgentModelPolicy` dereferenced `config.agencyConfig` **before** the `!agent?.workspaceId` guard, crashing the agent profile page during loading/404 states. The guard now runs first and also bails when `config` is missing.
- Same-class fixes in `ProfileEditor/index.tsx`: `config.agencyConfig?.heterogeneousProvider`, the `...config.agencyConfig` spread, and the `ModelSelect` value now use optional access.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

New `WorkspaceAgentModelPolicy.test.tsx` renders the card with an agent id missing from `agentMap` — crashes before this fix, renders null after.