### PR TITLE
🐛 fix: agent transfer recency/visibility & chat input action gating

### DIFF
--- a/packages/database/src/models/__tests__/agentTransfer.test.ts
+++ b/packages/database/src/models/__tests__/agentTransfer.test.ts
@@ -5,12 +5,17 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { getTestDB } from '../../core/getTestDB';
 import {
   agentBotProviders,
+  agentCronJobs,
   agents,
+  agentsFiles,
+  agentsKnowledgeBases,
   agentsToSessions,
   briefs,
   chatGroups,
   chatGroupsAgents,
   documents,
+  files,
+  knowledgeBases,
   messages,
   sessionGroups,
   sessions,
@@ -19,6 +24,7 @@ import {
   taskDocuments,
   tasks,
   taskTopics,
+  threads,
   topics,
   users,
   workspaces,
@@ -173,6 +179,175 @@ describe('AgentModel.transferAgent', () => {
 
     const [msg] = await serverDB.select().from(messages).where(eq(messages.id, 'msg-1'));
     expect(msg.workspaceId).toBe(wsId1);
+  });
+
+  it('should preserve content timestamps while transferring ownership', async () => {
+    const originalUpdatedAt = new Date('2024-01-02T03:04:05.000Z');
+    const model = new AgentModel(serverDB, userId);
+    const agent = await model.create({ title: 'Historical Agent' });
+
+    await serverDB
+      .update(agents)
+      .set({ updatedAt: originalUpdatedAt })
+      .where(eq(agents.id, agent.id));
+    await serverDB.insert(sessions).values({
+      id: 'timestamp-session',
+      type: 'agent',
+      updatedAt: originalUpdatedAt,
+      userId,
+    });
+    await serverDB.insert(agentsToSessions).values({
+      agentId: agent.id,
+      sessionId: 'timestamp-session',
+      userId,
+    });
+    await serverDB.insert(topics).values({
+      agentId: agent.id,
+      id: 'timestamp-topic',
+      sessionId: 'timestamp-session',
+      updatedAt: originalUpdatedAt,
+      userId,
+    });
+    await serverDB.insert(messages).values({
+      agentId: agent.id,
+      id: 'timestamp-message',
+      role: 'assistant',
+      sessionId: 'timestamp-session',
+      topicId: 'timestamp-topic',
+      updatedAt: originalUpdatedAt,
+      userId,
+    });
+    await serverDB.insert(threads).values({
+      agentId: agent.id,
+      id: 'timestamp-thread',
+      topicId: 'timestamp-topic',
+      type: 'continuation',
+      updatedAt: originalUpdatedAt,
+      userId,
+    });
+    await serverDB.insert(files).values({
+      fileType: 'text/plain',
+      id: 'timestamp-file',
+      name: 'historical.txt',
+      size: 1,
+      url: 'https://example.com/historical.txt',
+      userId,
+    });
+    await serverDB.insert(agentsFiles).values({
+      agentId: agent.id,
+      fileId: 'timestamp-file',
+      updatedAt: originalUpdatedAt,
+      userId,
+    });
+    await serverDB.insert(knowledgeBases).values({
+      id: 'timestamp-kb',
+      name: 'Historical Knowledge Base',
+      userId,
+    });
+    await serverDB.insert(agentsKnowledgeBases).values({
+      agentId: agent.id,
+      knowledgeBaseId: 'timestamp-kb',
+      updatedAt: originalUpdatedAt,
+      userId,
+    });
+    await serverDB.insert(agentCronJobs).values({
+      agentId: agent.id,
+      content: 'Run later',
+      cronPattern: '0 * * * *',
+      id: 'timestamp-cron',
+      updatedAt: originalUpdatedAt,
+      userId,
+    });
+    await serverDB.insert(tasks).values({
+      assigneeAgentId: agent.id,
+      createdByUserId: userId,
+      id: 'timestamp-task',
+      identifier: 'T-timestamp',
+      instruction: 'Keep the original recency',
+      seq: 1,
+      updatedAt: originalUpdatedAt,
+    });
+    await serverDB.insert(taskTopics).values({
+      seq: 1,
+      status: 'completed',
+      taskId: 'timestamp-task',
+      topicId: 'timestamp-topic',
+      updatedAt: originalUpdatedAt,
+      userId,
+    });
+    await serverDB.insert(taskComments).values({
+      content: 'Historical comment',
+      id: 'timestamp-comment',
+      taskId: 'timestamp-task',
+      updatedAt: originalUpdatedAt,
+      userId,
+    });
+    await serverDB.insert(agentBotProviders).values({
+      agentId: agent.id,
+      applicationId: 'timestamp-app',
+      platform: 'discord',
+      updatedAt: originalUpdatedAt,
+      userId,
+    });
+
+    await model.transferAgent(agent.id, wsId1, userId, 'private');
+
+    const timestampRows = await Promise.all([
+      serverDB.select({ updatedAt: agents.updatedAt }).from(agents).where(eq(agents.id, agent.id)),
+      serverDB
+        .select({ updatedAt: sessions.updatedAt })
+        .from(sessions)
+        .where(eq(sessions.id, 'timestamp-session')),
+      serverDB
+        .select({ updatedAt: topics.updatedAt })
+        .from(topics)
+        .where(eq(topics.id, 'timestamp-topic')),
+      serverDB
+        .select({ updatedAt: messages.updatedAt })
+        .from(messages)
+        .where(eq(messages.id, 'timestamp-message')),
+      serverDB
+        .select({ updatedAt: threads.updatedAt })
+        .from(threads)
+        .where(eq(threads.id, 'timestamp-thread')),
+      serverDB
+        .select({ updatedAt: agentsFiles.updatedAt })
+        .from(agentsFiles)
+        .where(eq(agentsFiles.agentId, agent.id)),
+      serverDB
+        .select({ updatedAt: agentsKnowledgeBases.updatedAt })
+        .from(agentsKnowledgeBases)
+        .where(eq(agentsKnowledgeBases.agentId, agent.id)),
+      serverDB
+        .select({ updatedAt: agentCronJobs.updatedAt })
+        .from(agentCronJobs)
+        .where(eq(agentCronJobs.id, 'timestamp-cron')),
+      serverDB
+        .select({ updatedAt: tasks.updatedAt })
+        .from(tasks)
+        .where(eq(tasks.id, 'timestamp-task')),
+      serverDB
+        .select({ updatedAt: taskTopics.updatedAt })
+        .from(taskTopics)
+        .where(eq(taskTopics.taskId, 'timestamp-task')),
+      serverDB
+        .select({ updatedAt: taskComments.updatedAt })
+        .from(taskComments)
+        .where(eq(taskComments.id, 'timestamp-comment')),
+      serverDB
+        .select({ updatedAt: agentBotProviders.updatedAt })
+        .from(agentBotProviders)
+        .where(eq(agentBotProviders.agentId, agent.id)),
+    ]);
+
+    expect(timestampRows).toHaveLength(12);
+    for (const [row] of timestampRows) expect(row.updatedAt).toEqual(originalUpdatedAt);
+
+    const [transferredAgent] = await serverDB
+      .select({ workspaceId: agents.workspaceId })
+      .from(agents)
+      .where(eq(agents.id, agent.id));
+    expect(transferredAgent.workspaceId).toBe(wsId1);
   });
 
   it('should update bot providers', async () => {

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -1529,7 +1529,9 @@ export class AgentModel {
           agencyConfig: nextAgencyConfig,
           sessionGroupId: null,
           slug,
-          updatedAt: new Date(),
+          // A scope transfer does not make the agent's content newer. Keep the
+          // original recency so home/search ordering is not reshuffled.
+          updatedAt: agents.updatedAt,
         })
         .where(eq(agents.id, agentId));
 
@@ -1546,7 +1548,7 @@ export class AgentModel {
         // `sessionGroupId`: folders stay in the source scope.
         await trx
           .update(sessions)
-          .set({ ...ownershipUpdate, groupId: null })
+          .set({ ...ownershipUpdate, groupId: null, updatedAt: sessions.updatedAt })
           .where(inArray(sessions.id, sessionIds));
       }
 
@@ -1560,31 +1562,43 @@ export class AgentModel {
         sessionIds.length > 0
           ? or(inArray(topics.sessionId, sessionIds), eq(topics.agentId, agentId))
           : eq(topics.agentId, agentId);
-      await trx.update(topics).set(ownershipUpdate).where(topicCondition!);
+      await trx
+        .update(topics)
+        .set({ ...ownershipUpdate, updatedAt: topics.updatedAt })
+        .where(topicCondition!);
 
       // 7. Update messages (linked via sessionId or agentId)
       const messageCondition =
         sessionIds.length > 0
           ? or(inArray(messages.sessionId, sessionIds), eq(messages.agentId, agentId))
           : eq(messages.agentId, agentId);
-      await trx.update(messages).set(ownershipUpdate).where(messageCondition!);
+      await trx
+        .update(messages)
+        .set({ ...ownershipUpdate, updatedAt: messages.updatedAt })
+        .where(messageCondition!);
 
       // 8. Update threads (linked via agentId)
-      await trx.update(threads).set(ownershipUpdate).where(eq(threads.agentId, agentId));
+      await trx
+        .update(threads)
+        .set({ ...ownershipUpdate, updatedAt: threads.updatedAt })
+        .where(eq(threads.agentId, agentId));
 
       // 9. Update agent files associations
-      await trx.update(agentsFiles).set(ownershipUpdate).where(eq(agentsFiles.agentId, agentId));
+      await trx
+        .update(agentsFiles)
+        .set({ ...ownershipUpdate, updatedAt: agentsFiles.updatedAt })
+        .where(eq(agentsFiles.agentId, agentId));
 
       // 10. Update agent knowledge base associations
       await trx
         .update(agentsKnowledgeBases)
-        .set(ownershipUpdate)
+        .set({ ...ownershipUpdate, updatedAt: agentsKnowledgeBases.updatedAt })
         .where(eq(agentsKnowledgeBases.agentId, agentId));
 
       // 11. Update agent cron jobs
       await trx
         .update(agentCronJobs)
-        .set(ownershipUpdate)
+        .set({ ...ownershipUpdate, updatedAt: agentCronJobs.updatedAt })
         .where(eq(agentCronJobs.agentId, agentId));
 
       // 12. Update tasks assigned to or created by this agent. The scheduled
@@ -1599,7 +1613,7 @@ export class AgentModel {
         .update(tasks)
         .set({
           createdByUserId: targetUserId,
-          updatedAt: new Date(),
+          updatedAt: tasks.updatedAt,
           workspaceId: targetWorkspaceId,
           ...visibilityUpdate,
         })
@@ -1618,11 +1632,11 @@ export class AgentModel {
           .where(inArray(taskDocuments.taskId, movedTaskIds));
         await trx
           .update(taskTopics)
-          .set({ ...ownershipUpdate, ...visibilityUpdate })
+          .set({ ...ownershipUpdate, ...visibilityUpdate, updatedAt: taskTopics.updatedAt })
           .where(inArray(taskTopics.taskId, movedTaskIds));
         await trx
           .update(taskComments)
-          .set({ ...ownershipUpdate, ...visibilityUpdate })
+          .set({ ...ownershipUpdate, ...visibilityUpdate, updatedAt: taskComments.updatedAt })
           .where(inArray(taskComments.taskId, movedTaskIds));
         await trx.update(briefs).set(ownershipUpdate).where(inArray(briefs.taskId, movedTaskIds));
       }
@@ -1632,7 +1646,7 @@ export class AgentModel {
       // 13. Update agent bot providers (transfer, not delete)
       await trx
         .update(agentBotProviders)
-        .set(ownershipUpdate)
+        .set({ ...ownershipUpdate, updatedAt: agentBotProviders.updatedAt })
         .where(eq(agentBotProviders.agentId, agentId));
 
       // 14. Remove chat group associations (groups belong to source workspace context)

--- a/packages/database/src/repositories/home/index.test.ts
+++ b/packages/database/src/repositories/home/index.test.ts
@@ -3,6 +3,7 @@ import { DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE, INBOX_SESSION_ID } from '@lo
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../core/getTestDB';
+import { AgentModel } from '../../models/agent';
 import { agents } from '../../schemas/agent';
 import { chatGroups, chatGroupsAgents } from '../../schemas/chatGroup';
 import { agentsToSessions } from '../../schemas/relations';
@@ -520,6 +521,36 @@ describe('HomeRepository', () => {
       expect(result.privateGroups).toEqual([]);
       expect(result.privateUngrouped).toHaveLength(1);
       expect(result.privateUngrouped[0]).toMatchObject({ title: 'Transferred Agent' });
+    });
+
+    it('should show a workspace-private agent after transferring it to personal scope', async () => {
+      const workspaceId = 'private-agent-source-ws';
+      await serverDB.insert(workspaces).values({
+        id: workspaceId,
+        name: 'Private Agent Source',
+        primaryOwnerId: userId,
+        slug: workspaceId,
+      });
+      const workspaceAgentModel = new AgentModel(serverDB, userId, workspaceId);
+      const agent = await workspaceAgentModel.create({
+        title: 'Transferred Private Agent',
+        virtual: false,
+        visibility: 'private',
+      });
+
+      await workspaceAgentModel.transferAgent(agent.id, null, userId);
+
+      const result = await homeRepo.getSidebarAgentList();
+
+      expect(result.privateGroups).toEqual([]);
+      expect(result.privateUngrouped).toEqual([]);
+      expect(result.ungrouped).toEqual([
+        expect.objectContaining({
+          id: agent.id,
+          title: 'Transferred Private Agent',
+          visibility: 'public',
+        }),
+      ]);
     });
   });
 

--- a/packages/database/src/repositories/home/index.ts
+++ b/packages/database/src/repositories/home/index.ts
@@ -51,6 +51,13 @@ export class HomeRepository {
     return { userId: this.userId, workspaceId: this.workspaceId };
   }
 
+  private normalizeVisibility(visibility: 'private' | 'public'): 'private' | 'public' {
+    // Personal rows are all implicitly owner-private. The separate private
+    // bucket only exists inside a workspace, so personal rows must stay in the
+    // regular list even if they retain `visibility = 'private'` after a transfer.
+    return this.workspaceId ? visibility : 'public';
+  }
+
   /**
    * Get sidebar agent list with pinned, grouped, and ungrouped items
    */
@@ -260,6 +267,7 @@ export class HomeRepository {
           { avatar: a.avatar, title: a.title },
           { slug: a.slug },
         );
+        const visibility = this.normalizeVisibility(a.visibility);
 
         return {
           avatar: meta.avatar,
@@ -268,7 +276,7 @@ export class HomeRepository {
           groupId: a.agentSessionGroupId ?? a.sessionGroupId,
           heterogeneousType: a.agencyConfig?.heterogeneousProvider?.type ?? null,
           id: a.id,
-          isPrivate: a.visibility === 'private',
+          isPrivate: visibility === 'private',
           pinned: a.pinned ?? a.sessionPinned ?? false,
           sessionId: a.sessionId,
           slug: a.slug,
@@ -277,27 +285,31 @@ export class HomeRepository {
           unreadCount: agentUnread.get(a.id) ?? 0,
           updatedAt: a.updatedAt,
           userId: a.agentUserId,
-          visibility: a.visibility,
+          visibility,
         };
       }),
-      ...chatGroupItems.map((g): EnrichedItem => ({
-        // If group has custom avatar, use it (string); otherwise fallback to member avatars (array)
-        avatar: g.avatar || (memberAvatarsMap.get(g.id) ?? null),
-        backgroundColor: g.backgroundColor,
-        description: g.description,
-        groupAvatar: g.avatar,
-        groupId: g.groupId,
-        id: g.id,
-        isPrivate: g.visibility === 'private',
-        pinned: g.pinned ?? false,
-        sessionId: null,
-        title: g.title,
-        type: 'group' as const,
-        unreadCount: groupUnread.get(g.id) ?? 0,
-        updatedAt: g.updatedAt,
-        userId: g.groupUserId,
-        visibility: g.visibility,
-      })),
+      ...chatGroupItems.map((g): EnrichedItem => {
+        const visibility = this.normalizeVisibility(g.visibility);
+
+        return {
+          // If group has custom avatar, use it (string); otherwise fallback to member avatars (array)
+          avatar: g.avatar || (memberAvatarsMap.get(g.id) ?? null),
+          backgroundColor: g.backgroundColor,
+          description: g.description,
+          groupAvatar: g.avatar,
+          groupId: g.groupId,
+          id: g.id,
+          isPrivate: visibility === 'private',
+          pinned: g.pinned ?? false,
+          sessionId: null,
+          title: g.title,
+          type: 'group' as const,
+          unreadCount: groupUnread.get(g.id) ?? 0,
+          updatedAt: g.updatedAt,
+          userId: g.groupUserId,
+          visibility,
+        };
+      }),
     ];
 
     // Sort all items by updatedAt descending
@@ -319,7 +331,8 @@ export class HomeRepository {
     const groupIds = new Set<string>();
     const privateGroupIds = new Set<string>();
     for (const g of groupItems) {
-      (g.visibility === 'private' ? privateGroupIds : groupIds).add(g.id);
+      const visibility = this.normalizeVisibility(g.visibility);
+      (visibility === 'private' ? privateGroupIds : groupIds).add(g.id);
     }
 
     for (const item of allItems) {
@@ -350,14 +363,15 @@ export class HomeRepository {
     const groups: SidebarGroup[] = [];
     const privateGroups: SidebarGroup[] = [];
     for (const g of groupItems) {
-      const target = g.visibility === 'private' ? privateGroups : groups;
-      const itemsMap = g.visibility === 'private' ? privateGroupedMap : groupedMap;
+      const visibility = this.normalizeVisibility(g.visibility);
+      const target = visibility === 'private' ? privateGroups : groups;
+      const itemsMap = visibility === 'private' ? privateGroupedMap : groupedMap;
       target.push({
         id: g.id,
         items: itemsMap.get(g.id) || [],
         name: g.name,
         sort: g.sort,
-        visibility: g.visibility,
+        visibility,
       });
     }
 
@@ -437,6 +451,7 @@ export class HomeRepository {
           { avatar: a.avatar, title: a.title },
           { slug: a.slug },
         );
+        const visibility = this.normalizeVisibility(a.visibility);
 
         return cleanObject({
           avatar: meta.avatar,
@@ -449,11 +464,13 @@ export class HomeRepository {
           type: 'agent' as const,
           updatedAt: a.updatedAt,
           userId: a.userId,
-          visibility: a.visibility,
+          visibility,
         });
       }),
-      ...chatGroupResults.map((g) =>
-        cleanObject({
+      ...chatGroupResults.map((g) => {
+        const visibility = this.normalizeVisibility(g.visibility);
+
+        return cleanObject({
           avatar: g.avatar || (memberAvatarsMap.get(g.id) ?? null),
           backgroundColor: g.backgroundColor,
           description: g.description,
@@ -463,9 +480,9 @@ export class HomeRepository {
           type: 'group' as const,
           updatedAt: g.updatedAt,
           userId: g.userId,
-          visibility: g.visibility,
-        }),
-      ),
+          visibility,
+        });
+      }),
     ] as SidebarAgentItem[];
 
     // Sort by updatedAt descending

--- a/src/features/ChatInput/ActionBar/Clear/index.tsx
+++ b/src/features/ChatInput/ActionBar/Clear/index.tsx
@@ -9,7 +9,7 @@ import { useChatStore } from '@/store/chat';
 import { useFileStore } from '@/store/file';
 
 import { useChatInputResourceAccess } from '../../hooks/useChatInputResourceAccess';
-import Action from '../components/Action';
+import { ChatInputAction } from '../components/ChatInputAction';
 
 export const useClearCurrentMessages = () => {
   const clearMessage = useChatStore((s) => s.clearMessage);
@@ -57,7 +57,7 @@ const Clear = memo(() => {
         updateConfirmOpened(open);
       }}
     >
-      <Action
+      <ChatInputAction
         icon={Eraser}
         title={actionTitle}
         tooltipProps={{

--- a/src/features/ChatInput/ActionBar/History/index.tsx
+++ b/src/features/ChatInput/ActionBar/History/index.tsx
@@ -8,7 +8,7 @@ import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selec
 
 import { useAgentId } from '../../hooks/useAgentId';
 import { useUpdateAgentConfig } from '../../hooks/useUpdateAgentConfig';
-import Action from '../components/Action';
+import { ChatInputAction } from '../components/ChatInputAction';
 import Controls from './Controls';
 
 const History = memo(() => {
@@ -29,7 +29,7 @@ const History = memo(() => {
     ];
   });
 
-  if (isLoading) return <Action disabled icon={TimerOff} />;
+  if (isLoading) return <ChatInputAction disabled icon={TimerOff} />;
 
   const title = t(
     enableHistoryCount
@@ -39,7 +39,7 @@ const History = memo(() => {
   );
 
   return (
-    <Action
+    <ChatInputAction
       icon={enableHistoryCount ? Timer : TimerOff}
       loading={updating}
       showTooltip={false}

--- a/src/features/ChatInput/ActionBar/Memory/index.tsx
+++ b/src/features/ChatInput/ActionBar/Memory/index.tsx
@@ -10,7 +10,7 @@ import { agentByIdSelectors } from '@/store/agent/selectors';
 
 import { useAgentId } from '../../hooks/useAgentId';
 import { useUpdateAgentConfig } from '../../hooks/useUpdateAgentConfig';
-import Action from '../components/Action';
+import { ChatInputAction } from '../components/ChatInputAction';
 import Controls from './Controls';
 import { useMemoryEnabled } from './useMemoryEnabled';
 
@@ -22,10 +22,10 @@ const Memory = memo(() => {
   const isEnabled = useMemoryEnabled(agentId);
   const isMobile = useIsMobile();
 
-  if (isLoading) return <Action disabled icon={Brain} />;
+  if (isLoading) return <ChatInputAction disabled icon={Brain} />;
 
   return (
-    <Action
+    <ChatInputAction
       color={isEnabled ? cssVar.colorInfo : undefined}
       icon={isEnabled ? Brain : BrainOffIcon}
       showTooltip={false}

--- a/src/features/ChatInput/ActionBar/Mention/index.tsx
+++ b/src/features/ChatInput/ActionBar/Mention/index.tsx
@@ -9,7 +9,7 @@ import { useSessionStore } from '@/store/session';
 import { sessionSelectors } from '@/store/session/selectors';
 import { type LobeGroupSession } from '@/types/session';
 
-import Action from '../components/Action';
+import { ChatInputAction } from '../components/ChatInputAction';
 
 const Mention = memo(() => {
   const { t } = useTranslation('chat');
@@ -53,7 +53,7 @@ const Mention = memo(() => {
   if (!items.length) return null;
 
   return (
-    <Action
+    <ChatInputAction
       icon={AtSign}
       title={t('mention.title')}
       dropdown={{

--- a/src/features/ChatInput/ActionBar/Params/index.tsx
+++ b/src/features/ChatInput/ActionBar/Params/index.tsx
@@ -6,7 +6,7 @@ import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 
 import { useAgentId } from '../../hooks/useAgentId';
-import Action from '../components/Action';
+import { ChatInputAction } from '../components/ChatInputAction';
 import Controls from './Controls';
 
 const Params = memo(() => {
@@ -17,10 +17,10 @@ const Params = memo(() => {
   const [updating, setUpdating] = useState(false);
   const { t } = useTranslation('setting');
 
-  if (isLoading) return <Action disabled icon={Settings2Icon} />;
+  if (isLoading) return <ChatInputAction disabled icon={Settings2Icon} />;
 
   return (
-    <Action
+    <ChatInputAction
       icon={Settings2Icon}
       showTooltip={false}
       title={t('settingModel.params.title')}

--- a/src/features/ChatInput/ActionBar/Plus/index.tsx
+++ b/src/features/ChatInput/ActionBar/Plus/index.tsx
@@ -55,8 +55,8 @@ import { useAgentId } from '../../hooks/useAgentId';
 import { useChatInputResourceAccess } from '../../hooks/useChatInputResourceAccess';
 import { useUpdateAgentConfig } from '../../hooks/useUpdateAgentConfig';
 import { useChatInputStore } from '../../store';
-import Action from '../components/Action';
 import { type ActionDropdownMenuItems } from '../components/ActionDropdown';
+import { ChatInputAction } from '../components/ChatInputAction';
 import { useControls as useKnowledgeControls } from '../Knowledge/useControls';
 import { useMemoryEnabled } from '../Memory/useMemoryEnabled';
 import { useControls as useToolsControls } from '../Tools/useControls';
@@ -786,7 +786,7 @@ const PlusAction = memo(() => {
 
   return (
     <>
-      <Action
+      <ChatInputAction
         icon={PlusIcon}
         open={dropdownOpen}
         size={{ blockSize: 32, borderRadius: 16, size: 18 }}
@@ -809,7 +809,7 @@ PlusAction.displayName = 'PlusAction';
 const Plus = memo(() => (
   <Suspense
     fallback={
-      <Action
+      <ChatInputAction
         disabled
         icon={PlusIcon}
         size={{ blockSize: 32, borderRadius: 16, size: 18 }}

--- a/src/features/ChatInput/ActionBar/PromptTransform/index.tsx
+++ b/src/features/ChatInput/ActionBar/PromptTransform/index.tsx
@@ -5,6 +5,7 @@ import { memo, useCallback } from 'react';
 import PromptTransformAction from '@/features/PromptTransform/PromptTransformAction';
 
 import { useChatInputStore } from '../../store';
+import { ChatInputAction } from '../components/ChatInputAction';
 
 const PromptTransform = memo(() => {
   const [editor, markdownContent] = useChatInputStore((s) => [s.editor, s.markdownContent]);
@@ -21,6 +22,7 @@ const PromptTransform = memo(() => {
   // Image mode expands vague inputs; text mode forbids expansion.
   return (
     <PromptTransformAction
+      ActionComponent={ChatInputAction}
       mode={'image'}
       prompt={markdownContent}
       onPromptChange={onPromptChange}

--- a/src/features/ChatInput/ActionBar/Search/index.tsx
+++ b/src/features/ChatInput/ActionBar/Search/index.tsx
@@ -11,7 +11,7 @@ import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selec
 import { useAgentEnableSearch } from '../../hooks/useAgentEnableSearch';
 import { useAgentId } from '../../hooks/useAgentId';
 import { useUpdateAgentConfig } from '../../hooks/useUpdateAgentConfig';
-import Action from '../components/Action';
+import { ChatInputAction } from '../components/ChatInputAction';
 import Controls from './Controls';
 
 const Search = memo(() => {
@@ -25,10 +25,10 @@ const Search = memo(() => {
   const isAgentEnableSearch = useAgentEnableSearch();
   const isMobile = useIsMobile();
 
-  if (isLoading) return <Action disabled icon={GlobeOffIcon} />;
+  if (isLoading) return <ChatInputAction disabled icon={GlobeOffIcon} />;
 
   return (
-    <Action
+    <ChatInputAction
       color={isAgentEnableSearch ? cssVar.colorInfo : undefined}
       icon={isAgentEnableSearch ? Globe : GlobeOffIcon}
       showTooltip={false}

--- a/src/features/ChatInput/ActionBar/Tools/index.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/index.tsx
@@ -8,7 +8,7 @@ import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 
 import { useAgentId } from '../../hooks/useAgentId';
-import Action from '../components/Action';
+import { ChatInputAction } from '../components/ChatInputAction';
 import PopoverContent from './PopoverContent';
 import { useControls } from './useControls';
 
@@ -27,11 +27,13 @@ const Tools = memo(() => {
   }, []);
 
   if (!enableFC)
-    return <Action disabled icon={Blocks} showTooltip={true} title={t('tools.disabled')} />;
+    return (
+      <ChatInputAction disabled icon={Blocks} showTooltip={true} title={t('tools.disabled')} />
+    );
 
   return (
-    <Suspense fallback={<Action disabled icon={Blocks} title={t('tools.title')} />}>
-      <Action
+    <Suspense fallback={<ChatInputAction disabled icon={Blocks} title={t('tools.title')} />}>
+      <ChatInputAction
         icon={Blocks}
         showTooltip={false}
         title={t('tools.title')}

--- a/src/features/ChatInput/ActionBar/Typo/index.tsx
+++ b/src/features/ChatInput/ActionBar/Typo/index.tsx
@@ -3,14 +3,14 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useChatInputStore } from '../../store';
-import Action from '../components/Action';
+import { ChatInputAction } from '../components/ChatInputAction';
 
 const Typo = memo(() => {
   const { t } = useTranslation('editor');
   const [showTypoBar, setShowTypoBar] = useChatInputStore((s) => [s.showTypoBar, s.setShowTypoBar]);
 
   return (
-    <Action
+    <ChatInputAction
       active={showTypoBar}
       icon={TypeIcon}
       title={t(showTypoBar ? 'actions.typobar.off' : 'actions.typobar.on')}

--- a/src/features/ChatInput/ActionBar/Upload/index.tsx
+++ b/src/features/ChatInput/ActionBar/Upload/index.tsx
@@ -24,8 +24,8 @@ import { preferenceSelectors } from '@/store/user/selectors';
 
 import { useAgentId } from '../../hooks/useAgentId';
 import { useChatInputStore } from '../../store';
-import Action from '../components/Action';
 import { type ActionDropdownMenuItems } from '../components/ActionDropdown';
+import { ChatInputAction } from '../components/ChatInputAction';
 import CheckboxItem from '../components/CheckboxWithLoading';
 
 const hotArea = css`
@@ -91,7 +91,12 @@ const FileUpload = memo(() => {
   if (!canUpload) {
     return (
       <Tooltip title={reason}>
-        <Action disabled icon={Paperclip} showTooltip={false} title={t('upload.action.tooltip')} />
+        <ChatInputAction
+          disabled
+          icon={Paperclip}
+          showTooltip={false}
+          title={t('upload.action.tooltip')}
+        />
       </Tooltip>
     );
   }
@@ -281,7 +286,7 @@ const FileUpload = memo(() => {
   ];
 
   const content = (
-    <Action
+    <ChatInputAction
       icon={Paperclip}
       loading={updating}
       open={dropdownOpen}
@@ -299,7 +304,9 @@ const FileUpload = memo(() => {
   );
 
   return (
-    <Suspense fallback={<Action disabled icon={Paperclip} title={t('upload.action.tooltip')} />}>
+    <Suspense
+      fallback={<ChatInputAction disabled icon={Paperclip} title={t('upload.action.tooltip')} />}
+    >
       {showTip ? (
         <TipGuide
           open={showTip}

--- a/src/features/ChatInput/ActionBar/components/Action.tsx
+++ b/src/features/ChatInput/ActionBar/components/Action.tsx
@@ -1,23 +1,21 @@
 'use client';
 
-import { type ActionIconProps, type PopoverTrigger } from '@lobehub/ui';
+import type { ActionIconProps, PopoverTrigger } from '@lobehub/ui';
 import { ActionIcon } from '@lobehub/ui';
 import { isUndefined } from 'es-toolkit/compat';
 import { memo } from 'react';
-import { useTranslation } from 'react-i18next';
 import useMergeState from 'use-merge-value';
 
 import { usePermission } from '@/hooks/usePermission';
 import { useServerConfigStore } from '@/store/serverConfig';
 
-import { useChatInputResourceAccess } from '../../hooks/useChatInputResourceAccess';
 import { useActionBarContext } from '../context';
-import { type ActionDropdownProps } from './ActionDropdown';
+import type { ActionDropdownProps } from './ActionDropdown';
 import ActionDropdown from './ActionDropdown';
-import { type ActionPopoverProps } from './ActionPopover';
+import type { ActionPopoverProps } from './ActionPopover';
 import ActionPopover from './ActionPopover';
 
-interface ActionProps extends Omit<ActionIconProps, 'popover'> {
+export interface ActionProps extends Omit<ActionIconProps, 'popover'> {
   dropdown?: Omit<ActionDropdownProps, 'children'>;
   onOpenChange?: (open: boolean) => void;
   open?: boolean;
@@ -49,17 +47,8 @@ const Action = memo<ActionProps>(
     const mobile = useServerConfigStore((s) => s.isMobile);
     const { actionSize, dropdownPlacement } = useActionBarContext();
     const { allowed: canUseChatInputAction, reason } = usePermission('create_content');
-    // View-only General access makes the whole input read-only: every action
-    // either sends or writes shared agent config, so the trigger goes inert
-    // (disabled, not hidden) — matching the editor/send-button gating.
-    const { canUseResource, isGroupContext } = useChatInputResourceAccess();
-    const { t } = useTranslation('chat');
-    const blocked = disabled || !canUseChatInputAction || !canUseResource;
-    const tooltipTitle = !canUseChatInputAction
-      ? reason
-      : canUseResource
-        ? title
-        : t(isGroupContext ? 'input.viewOnlyGroup' : 'input.viewOnlyAgent');
+    const blocked = disabled || !canUseChatInputAction;
+    const tooltipTitle = canUseChatInputAction ? title : reason;
     const iconNode = (
       <ActionIcon
         disabled={blocked}

--- a/src/features/ChatInput/ActionBar/components/ChatInputAction.tsx
+++ b/src/features/ChatInput/ActionBar/components/ChatInputAction.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useChatInputResourceAccess } from '../../hooks/useChatInputResourceAccess';
+import type { ActionProps } from './Action';
+import Action from './Action';
+
+export const ChatInputAction = memo<ActionProps>(({ disabled, title, ...rest }) => {
+  const { canUseResource, isGroupContext } = useChatInputResourceAccess();
+  const { t } = useTranslation('chat');
+
+  return (
+    <Action
+      {...rest}
+      disabled={disabled || !canUseResource}
+      title={
+        canUseResource ? title : t(isGroupContext ? 'input.viewOnlyGroup' : 'input.viewOnlyAgent')
+      }
+    />
+  );
+});
+
+ChatInputAction.displayName = 'ChatInputAction';

--- a/src/features/PromptTransform/PromptTransformAction.tsx
+++ b/src/features/PromptTransform/PromptTransformAction.tsx
@@ -1,21 +1,24 @@
 'use client';
 
 import { Languages, Lightbulb, Sparkles } from 'lucide-react';
+import type { ComponentType } from 'react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import type { ActionProps } from '@/features/ChatInput/ActionBar/components/Action';
 import Action from '@/features/ChatInput/ActionBar/components/Action';
 
 import { usePromptTransform } from './usePromptTransform';
 
 interface PromptTransformActionProps {
+  ActionComponent?: ComponentType<ActionProps>;
   mode: 'image' | 'video' | 'text';
   onPromptChange: (prompt: string) => void;
   prompt?: string | null;
 }
 
 const PromptTransformAction = memo<PromptTransformActionProps>(
-  ({ mode, onPromptChange, prompt }) => {
+  ({ ActionComponent = Action, mode, onPromptChange, prompt }) => {
     const { t } = useTranslation('common');
 
     const {
@@ -67,7 +70,7 @@ const PromptTransformAction = memo<PromptTransformActionProps>(
     const isActionDisabled = isTransformDisabled || isTransforming;
 
     return (
-      <Action
+      <ActionComponent
         disabled={isActionDisabled}
         dropdown={dropdown}
         icon={primaryIcon}

--- a/src/features/Workspace/__tests__/workspaceAwarePath.test.ts
+++ b/src/features/Workspace/__tests__/workspaceAwarePath.test.ts
@@ -86,7 +86,6 @@ describe('buildWorkspaceAwarePath', () => {
     expect(buildWorkspaceAwarePath('/settings/devices', 'acme')).toBe('/acme/settings/devices');
     expect(buildWorkspaceAwarePath('/settings/audit-log', 'acme')).toBe('/acme/settings/audit-log');
     expect(buildWorkspaceAwarePath('/settings/storage', 'acme')).toBe('/acme/settings/storage');
-    expect(buildWorkspaceAwarePath('/settings/messenger', 'acme')).toBe('/acme/settings/messenger');
     expect(buildWorkspaceAwarePath('/settings/credential', 'acme')).toBe(
       '/acme/settings/credential',
     );
@@ -107,6 +106,7 @@ describe('buildWorkspaceAwarePath', () => {
     expect(buildWorkspaceAwarePath('/settings/profile', 'acme')).toBe('/settings/profile');
     expect(buildWorkspaceAwarePath('/settings/llm', 'acme')).toBe('/settings/llm');
     expect(buildWorkspaceAwarePath('/settings/memory', 'acme')).toBe('/settings/memory');
+    expect(buildWorkspaceAwarePath('/settings/messenger', 'acme')).toBe('/settings/messenger');
     expect(buildWorkspaceAwarePath('/settings/referral', 'acme')).toBe('/settings/referral');
     expect(buildWorkspaceAwarePath('/settings/system-tools', 'acme')).toBe(
       '/settings/system-tools',

--- a/src/features/Workspace/workspaceAwarePath.ts
+++ b/src/features/Workspace/workspaceAwarePath.ts
@@ -25,9 +25,9 @@ const isPersonalPath = (to: string): boolean => PERSONAL_PATH_REGEX.test(to);
  * the SPA routers. Kept in sync with the workspace settings subtree in
  * `src/spa/router/{desktopRouter.config,desktopRouter.config.desktop,mobileRouter.config}.tsx`.
  *
- * Tabs absent from this set (profile, llm, referral, system-tools, security,
- * sync, plugin, tts, hotkey, agent, about, common, system-agent, ...) are
- * personal-only and never prefixed.
+ * Tabs absent from this set (profile, llm, messenger, referral, system-tools,
+ * security, sync, plugin, tts, hotkey, agent, about, common, system-agent, ...)
+ * are personal-only and never prefixed.
  */
 export const WORKSPACE_SETTINGS_TABS: ReadonlySet<string> = new Set([
   'apikey',
@@ -42,7 +42,6 @@ export const WORKSPACE_SETTINGS_TABS: ReadonlySet<string> = new Set([
   'devices',
   'general',
   'members',
-  'messenger',
   'oauth-apps',
   'plans',
   'provider',

--- a/src/routes/(main)/(create)/features/GenerationInput/GenerationMediaModeSegment.test.tsx
+++ b/src/routes/(main)/(create)/features/GenerationInput/GenerationMediaModeSegment.test.tsx
@@ -5,6 +5,7 @@ import { act, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
+import ConfigAction from './ConfigAction';
 import GenerationMediaModeSegment from './GenerationMediaModeSegment';
 
 interface SegmentedCapture {
@@ -20,6 +21,9 @@ const componentMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@lobehub/ui', () => ({
+  ActionIcon: ({ title }: { title?: ReactNode }) => (
+    <button aria-label={typeof title === 'string' ? title : 'action'} type="button" />
+  ),
   Flexbox: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Icon: () => <span data-testid="mode-icon" />,
 }));
@@ -51,8 +55,26 @@ vi.mock('@/features/Workspace/useWorkspaceAwareNavigate', () => ({
   useWorkspaceAwareNavigate: () => componentMocks.navigate,
 }));
 
+vi.mock('@/features/ChatInput/ActionBar/components/ActionDropdown', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/features/ChatInput/ActionBar/components/ActionPopover', () => ({
+  default: ({ children, content }: { children: ReactNode; content?: ReactNode }) => (
+    <div>
+      {children}
+      {content}
+    </div>
+  ),
+}));
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/store/serverConfig', () => ({
+  useServerConfigStore: <T,>(selector: (state: { isMobile: boolean }) => T) =>
+    selector({ isMobile: false }),
 }));
 
 describe('GenerationMediaModeSegment', () => {
@@ -82,5 +104,14 @@ describe('GenerationMediaModeSegment', () => {
 
     expect(screen.getByTestId('mode-select')).toBeInTheDocument();
     expect(screen.queryByTestId('mode-toggle-group')).not.toBeInTheDocument();
+  });
+});
+
+describe('generation toolbar actions', () => {
+  it('renders without a ChatInputProvider', () => {
+    render(<ConfigAction content={<span>config-content</span>} title="config-title" />);
+
+    expect(screen.getByRole('button', { name: 'config-title' })).toBeInTheDocument();
+    expect(screen.getByText('config-content')).toBeInTheDocument();
   });
 });

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/HeteroPlus.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/HeteroPlus.tsx
@@ -14,8 +14,8 @@ import {
 import { memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import Action from '@/features/ChatInput/ActionBar/components/Action';
 import { type ActionDropdownMenuItems } from '@/features/ChatInput/ActionBar/components/ActionDropdown';
+import { ChatInputAction } from '@/features/ChatInput/ActionBar/components/ChatInputAction';
 import { useChatInputStore } from '@/features/ChatInput/store';
 import { useConversationStore } from '@/features/Conversation';
 import { useGoalArmStore } from '@/features/Conversation/ChatInput/VerifyTray/goalArmStore';
@@ -138,7 +138,7 @@ const HeteroPlus = memo(() => {
   ]);
 
   return (
-    <Action
+    <ChatInputAction
       icon={PlusIcon}
       open={open}
       size={{ blockSize: 32, borderRadius: 16, size: 18 }}

--- a/src/spa/router/desktopRouter.sync.test.tsx
+++ b/src/spa/router/desktopRouter.sync.test.tsx
@@ -161,7 +161,7 @@ describe('desktopRouter config sync', () => {
     expect(syncSource).toContain("redirectElement('../settings/plans')");
   });
 
-  it('workspace-aware navigation recognizes every registered workspace settings tab', () => {
+  it('keeps workspace-aware settings tabs aligned with registered workspace routes', () => {
     const rootRoute = desktopRoutes.find((route) => route.path === '/');
     const workspaceRoute = rootRoute?.children?.find((route) => route.path === ':workspaceSlug');
     const settingsRoute = workspaceRoute?.children?.find((route) => route.path === 'settings');
@@ -174,15 +174,19 @@ describe('desktopRouter config sync', () => {
           ? [route.path, ...collectPaths(route.children ?? [])]
           : collectPaths(route.children ?? []),
       );
-    const registeredTabs = collectPaths(settingsRoute?.children ?? []).map(
-      (registeredPath) => registeredPath.split('/')[0],
-    );
-    const missingTabs = registeredTabs.filter((tab) => !WORKSPACE_SETTINGS_TABS.has(tab));
+    const registeredTabs = [
+      ...new Set(
+        collectPaths(settingsRoute?.children ?? []).map(
+          (registeredPath) => registeredPath.split('/')[0],
+        ),
+      ),
+    ].sort();
+    const workspaceAwareTabs = [...WORKSPACE_SETTINGS_TABS].sort();
 
     expect(
-      missingTabs,
-      `Add workspace settings tabs to WORKSPACE_SETTINGS_TABS: ${missingTabs.join(', ')}`,
-    ).toEqual([]);
+      workspaceAwareTabs,
+      'WORKSPACE_SETTINGS_TABS must exactly match the registered workspace settings routes',
+    ).toEqual(registeredTabs);
   });
 
   it('workspace OAuth apps list and detail routes are registered', () => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- internal fix batch -->

#### 🔀 Description of Change

Three related fixes:

1. **Agent transfer no longer reshuffles recency ordering** — `AgentModel` scope-transfer used to stamp `updatedAt: new Date()` (or rely on column defaults) on agents, sessions, topics, messages, threads, tasks and association rows. A transfer doesn't make content newer, so all ownership updates now preserve the original `updatedAt`, keeping home/search ordering stable.
2. **Personal scope no longer shows a phantom "private" bucket** — after transferring a workspace-private agent/group back to personal, rows could retain `visibility = 'private'`. `HomeRepository` now normalizes visibility to `public` when there is no `workspaceId`, since the private bucket only exists inside a workspace.
3. **Image generation error from chat-only resource gating** — `useChatInputResourceAccess` was baked into the shared `Action` component, breaking non-chat surfaces (image/video generation media mode). Split into a base `Action` (permission gating only) and a chat-scoped `ChatInputAction` wrapper that adds view-only resource gating; chat ActionBar items migrated to the wrapper. Also removed the stale `messenger` tab from `WORKSPACE_SETTINGS_TABS`.

#### 🧪 How to Test

- [x] Added/updated tests

- `packages/database/src/models/__tests__/agentTransfer.test.ts` — updatedAt preservation across transfer
- `packages/database/src/repositories/home/index.test.ts` — personal-scope visibility normalization
- `GenerationMediaModeSegment.test.tsx` / `desktopRouter.sync.test.tsx` — media mode segment renders without chat context

#### 📝 Additional Information

Key decision: transferred-back personal rows keep `visibility='private'` in the DB; normalization happens at read time in `HomeRepository`, avoiding a data migration.