### PR TITLE
🐛 fix(settings): align OAuth app grouping across settings

### DIFF
--- a/src/features/WorkspaceSetting/SideBar/Body.tsx
+++ b/src/features/WorkspaceSetting/SideBar/Body.tsx
@@ -37,6 +37,7 @@ const Body = memo(() => {
           WorkspaceSettingsGroupKey.General,
           WorkspaceSettingsGroupKey.Subscription,
           WorkspaceSettingsGroupKey.Agent,
+          WorkspaceSettingsGroupKey.Developer,
           WorkspaceSettingsGroupKey.Admin,
         ]}
       >

--- a/src/features/WorkspaceSetting/hooks/useCategory.test.tsx
+++ b/src/features/WorkspaceSetting/hooks/useCategory.test.tsx
@@ -61,7 +61,20 @@ describe('workspace settings useCategory', () => {
       },
     });
 
-    expect(getItemKeys()).toContain(WorkspaceSettingsTabs.OAuthApps);
+    const { result } = renderHook(() => useWorkspaceSettingCategory());
+    const developerGroup = result.current.find(
+      (group) => group.key === WorkspaceSettingsGroupKey.Developer,
+    );
+    const agentGroup = result.current.find(
+      (group) => group.key === WorkspaceSettingsGroupKey.Agent,
+    );
+
+    expect(developerGroup?.items.map((item) => item.key)).toContain(
+      WorkspaceSettingsTabs.OAuthApps,
+    );
+    expect(agentGroup?.items.map((item) => item.key)).not.toContain(
+      WorkspaceSettingsTabs.OAuthApps,
+    );
   });
 
   it('places API Key in the owner-only Admin group', () => {

--- a/src/features/WorkspaceSetting/hooks/useCategory.tsx
+++ b/src/features/WorkspaceSetting/hooks/useCategory.tsx
@@ -27,6 +27,7 @@ import { WorkspaceSettingsTabs } from '@/types/workspaceSettings';
 export enum WorkspaceSettingsGroupKey {
   Admin = 'admin',
   Agent = 'agent',
+  Developer = 'developer',
   General = 'general',
   Subscription = 'subscription',
 }
@@ -134,11 +135,6 @@ export const useWorkspaceSettingCategory = (): WorkspaceSettingCategoryGroup[] =
               key: WorkspaceSettingsTabs.Creds,
               label: t('tab.creds'),
             },
-            enableOAuthApps && {
-              icon: AppWindowIcon,
-              key: WorkspaceSettingsTabs.OAuthApps,
-              label: tAuth('tab.oauthApps'),
-            },
             // Messenger (chat platform) is intentionally omitted from workspace
             // settings: the System Bot binding is a per-user/personal identity
             // (the link is owned by `userId`, not the workspace), and reaching a
@@ -147,6 +143,17 @@ export const useWorkspaceSettingCategory = (): WorkspaceSettingCategoryGroup[] =
           ].filter(Boolean) as WorkspaceSettingCategoryItem[],
           key: WorkspaceSettingsGroupKey.Agent,
           title: t('workspaceSetting.group.agent'),
+        },
+        enableOAuthApps && {
+          items: [
+            {
+              icon: AppWindowIcon,
+              key: WorkspaceSettingsTabs.OAuthApps,
+              label: tAuth('tab.oauthApps'),
+            },
+          ],
+          key: WorkspaceSettingsGroupKey.Developer,
+          title: t('group.developer'),
         },
         // The Admin group is owner-only — managing shared infra and audit
         // surfaces is an owner action.

--- a/src/routes/(main)/settings/hooks/useCategory.test.tsx
+++ b/src/routes/(main)/settings/hooks/useCategory.test.tsx
@@ -7,7 +7,7 @@ import { SettingsTabs } from '@/store/global/initialState';
 import { initServerConfigStore, Provider } from '@/store/serverConfig/store';
 import { useUserStore } from '@/store/user';
 
-import { useCategory } from './useCategory';
+import { SettingsGroupKey, useCategory } from './useCategory';
 
 vi.hoisted(() => {
   Object.defineProperty(globalThis, 'localStorage', {
@@ -89,6 +89,13 @@ describe('settings useCategory', () => {
       },
     });
 
-    expect(getItemKeys()).toContain(SettingsTabs.OAuthApps);
+    const { result } = renderHook(() => useCategory(), {
+      wrapper: createWrapper(true),
+    });
+    const developerGroup = result.current.find((group) => group.key === SettingsGroupKey.Developer);
+    const systemGroup = result.current.find((group) => group.key === SettingsGroupKey.System);
+
+    expect(developerGroup?.items.map((item) => item.key)).toContain(SettingsTabs.OAuthApps);
+    expect(systemGroup?.items.map((item) => item.key)).not.toContain(SettingsTabs.OAuthApps);
   });
 });

--- a/src/routes/(mobile)/me/settings/features/useCategory.test.tsx
+++ b/src/routes/(mobile)/me/settings/features/useCategory.test.tsx
@@ -7,7 +7,7 @@ import { SettingsTabs } from '@/store/global/initialState';
 import { initServerConfigStore, Provider } from '@/store/serverConfig/store';
 import { useUserStore } from '@/store/user';
 
-import { useCategory } from './useCategory';
+import { SettingsGroupKey, useCategory } from './useCategory';
 
 vi.hoisted(() => {
   Object.defineProperty(globalThis, 'localStorage', {
@@ -110,8 +110,10 @@ describe('mobile settings useCategory', () => {
       wrapper: createWrapper(true),
     });
 
-    const keys = result.current.flatMap((group) => group.items.map((item) => item.key));
+    const developerGroup = result.current.find((group) => group.key === SettingsGroupKey.Developer);
+    const systemGroup = result.current.find((group) => group.key === SettingsGroupKey.System);
 
-    expect(keys).toContain(SettingsTabs.OAuthApps);
+    expect(developerGroup?.items.map((item) => item.key)).toContain(SettingsTabs.OAuthApps);
+    expect(systemGroup?.items.map((item) => item.key)).not.toContain(SettingsTabs.OAuthApps);
   });
 });

--- a/src/routes/(mobile)/me/settings/features/useCategory.tsx
+++ b/src/routes/(mobile)/me/settings/features/useCategory.tsx
@@ -35,6 +35,7 @@ import { userGeneralSettingsSelectors } from '@/store/user/slices/settings/selec
 
 export enum SettingsGroupKey {
   Agent = 'agent',
+  Developer = 'developer',
   General = 'general',
   Subscription = 'subscription',
   System = 'system',
@@ -121,16 +122,19 @@ export const useCategory = (): CategoryGroup[] => {
         makeItem({ icon: KeyIcon, key: SettingsTabs.APIKey, label: t('auth:tab.apikey') }),
     ].filter((item): item is CategoryItem => Boolean(item));
 
-    const system: CategoryItem[] = [
-      makeItem({ icon: Database, key: SettingsTabs.Storage, label: t('setting:tab.storage') }),
-      isDevMode &&
-        makeItem({ icon: KeyIcon, key: SettingsTabs.APIKey, label: t('auth:tab.apikey') }),
+    const developer: CategoryItem[] = [
       enableOAuthApps &&
         makeItem({
           icon: AppWindowIcon,
           key: SettingsTabs.OAuthApps,
           label: t('auth:tab.oauthApps'),
         }),
+    ].filter((item): item is CategoryItem => Boolean(item));
+
+    const system: CategoryItem[] = [
+      makeItem({ icon: Database, key: SettingsTabs.Storage, label: t('setting:tab.storage') }),
+      isDevMode &&
+        makeItem({ icon: KeyIcon, key: SettingsTabs.APIKey, label: t('auth:tab.apikey') }),
       makeItem({
         icon: EllipsisIcon,
         key: SettingsTabs.Advanced,
@@ -148,6 +152,11 @@ export const useCategory = (): CategoryGroup[] => {
       },
       { items: agent, key: SettingsGroupKey.Agent, title: t('setting:group.aiConfig') },
       { items: system, key: SettingsGroupKey.System, title: t('setting:group.system') },
+      {
+        items: developer,
+        key: SettingsGroupKey.Developer,
+        title: t('setting:group.developer'),
+      },
     ].filter((group) => group.items.length > 0);
   }, [
     t,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Follow-up to #17393.

#### 🔀 Description of Change

The primary settings sidebar now places OAuth Apps under the Developer group, but the workspace and mobile settings surfaces still classified the same capability under Agent and System respectively.

This change:

- moves workspace OAuth Apps from Agent to a conditional Developer group;
- moves mobile OAuth Apps from System to a conditional Developer group;
- preserves the existing Labs preference gate and workspace permissions;
- adds behavioral assertions for the personal, workspace, and mobile grouping.

Users now find OAuth application management under the same semantic group across all settings surfaces.

#### 🧪 How to Test

Enable **OAuth Apps** in Labs, then verify that OAuth Apps appears under **Developer** in personal, workspace, and mobile settings and no longer appears under Agent or System.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation:

```text
bun run check <6 changed files>
✓ 6 files · lint clean · tests 12 passed
```

#### 📸 Screenshots / Videos

Not included. The change only relocates an existing navigation item into the existing Developer group.

#### 📝 Additional Information

No API, data model, permission, or migration changes.
