### PR TITLE
🐛 fix(resource): make file-backed documents preview and download correctly

### DIFF
--- a/apps/server/src/routers/lambda/document.ts
+++ b/apps/server/src/routers/lambda/document.ts
@@ -75,7 +75,6 @@ const documentProcedure = wsCompatProcedure.use(serverDatabase).use(async (opts)
       documentModel: new DocumentModel(ctx.serverDB, ctx.userId, wsId),
       documentService: new DocumentService(ctx.serverDB, ctx.userId, wsId),
       fileModel: new FileModel(ctx.serverDB, ctx.userId, wsId),
-      fileService: new FileService(ctx.serverDB, ctx.userId, wsId),
       messageModel: new MessageModel(ctx.serverDB, ctx.userId, wsId),
     },
   });
@@ -262,9 +261,10 @@ export const documentRouter = router({
       // `source` is a storage key for file-backed documents; sign it so PDF viewers
       // and downloads receive a usable URL. Absolute URLs (web sources) pass through.
       if (!doc?.source || /^https?:\/\//i.test(doc.source)) return doc;
+      const fileService = new FileService(ctx.serverDB, ctx.userId, ctx.workspaceId ?? undefined);
       return {
         ...doc,
-        source: await ctx.fileService.getFileAccessUrl({
+        source: await fileService.getFileAccessUrl({
           fileId: doc.fileId ?? undefined,
           id: doc.id,
           url: doc.source,

--- a/apps/server/src/routers/lambda/document.ts
+++ b/apps/server/src/routers/lambda/document.ts
@@ -14,6 +14,7 @@ import { DEFAULT_RESOURCE_ACCESS_LEVELS } from '@/database/schemas';
 import { router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { DocumentService } from '@/server/services/document';
+import { FileService } from '@/server/services/file';
 import {
   assertCanEditResource,
   assertCanPerformResourceAction,
@@ -74,6 +75,7 @@ const documentProcedure = wsCompatProcedure.use(serverDatabase).use(async (opts)
       documentModel: new DocumentModel(ctx.serverDB, ctx.userId, wsId),
       documentService: new DocumentService(ctx.serverDB, ctx.userId, wsId),
       fileModel: new FileModel(ctx.serverDB, ctx.userId, wsId),
+      fileService: new FileService(ctx.serverDB, ctx.userId, wsId),
       messageModel: new MessageModel(ctx.serverDB, ctx.userId, wsId),
     },
   });
@@ -256,7 +258,18 @@ export const documentRouter = router({
   getDocumentById: documentProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
-      return ctx.documentService.getDocumentById(input.id);
+      const doc = await ctx.documentService.getDocumentById(input.id);
+      // `source` is a storage key for file-backed documents; sign it so PDF viewers
+      // and downloads receive a usable URL. Absolute URLs (web sources) pass through.
+      if (!doc?.source || /^https?:\/\//i.test(doc.source)) return doc;
+      return {
+        ...doc,
+        source: await ctx.fileService.getFileAccessUrl({
+          fileId: doc.fileId ?? undefined,
+          id: doc.id,
+          url: doc.source,
+        }),
+      };
     }),
 
   listDocumentHistory: documentProcedure

--- a/src/features/FileViewer/fileType.test.ts
+++ b/src/features/FileViewer/fileType.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { isPdfFile } from './fileType';
+
+describe('isPdfFile', () => {
+  it('detects PDF files by MIME type', () => {
+    expect(isPdfFile({ fileType: 'pdf' })).toBe(true);
+    expect(isPdfFile({ fileType: 'application/pdf' })).toBe(true);
+    expect(isPdfFile({ fileType: 'application/pdf; charset=utf-8' })).toBe(true);
+    expect(isPdfFile({ fileType: 'APPLICATION/PDF' })).toBe(true);
+    expect(isPdfFile({ fileType: 'application/x-pdf' })).toBe(true);
+  });
+
+  it('detects PDF files by filename or path extension', () => {
+    expect(isPdfFile({ fileName: 'report.PDF' })).toBe(true);
+    expect(isPdfFile({ path: '/tmp/demo.pdf' })).toBe(true);
+    expect(isPdfFile({ fileName: 'untitled', path: '/tmp/demo.pdf' })).toBe(true);
+    expect(isPdfFile({ fileName: '国内大模型蒸馏风波的来龙去脉 (1).pdf' })).toBe(true);
+  });
+
+  it('detects PDF documents whose fileType is a MIME string and name has no extension', () => {
+    expect(
+      isPdfFile({ fileName: '国内大模型蒸馏风波的来龙去脉', fileType: 'application/pdf' }),
+    ).toBe(true);
+  });
+
+  it('detects PDF documents whose fileType is generic but source path ends with .pdf', () => {
+    expect(
+      isPdfFile({
+        fileName: '国内大模型蒸馏风波的来龙去脉',
+        fileType: 'custom/document',
+        path: 'assets/495734/a3bedf85-3ccb-43c0-9e94-b526fb435bac.pdf',
+      }),
+    ).toBe(true);
+  });
+
+  it('detects PDF via signed URL path with query string', () => {
+    expect(
+      isPdfFile({
+        fileName: '国内大模型蒸馏风波的来龙去脉',
+        fileType: 'custom/document',
+        path: 'https://lobechat-cloud.example.r2.cloudflarestorage.com/assets/495734/a3bedf85.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc',
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects non-PDF files', () => {
+    expect(isPdfFile({ fileName: 'report.docx', fileType: 'application/msword' })).toBe(false);
+    expect(isPdfFile({ path: '/tmp/notes.txt' })).toBe(false);
+    expect(isPdfFile({ fileType: 'custom/document' })).toBe(false);
+    expect(isPdfFile({})).toBe(false);
+  });
+});

--- a/src/features/FileViewer/fileType.ts
+++ b/src/features/FileViewer/fileType.ts
@@ -1,0 +1,31 @@
+const PDF_FILE_EXTENSIONS = ['.pdf'];
+const PDF_FILE_TYPES = new Set(['pdf', 'application/pdf', 'application/x-pdf']);
+
+const normalizeFileType = (fileType?: string | null) =>
+  fileType?.split(';')[0].trim().toLowerCase();
+
+// Signed storage URLs carry `?X-Amz-...` query strings; strip query and fragment
+// before extension matching so `.pdf?...` still resolves to `.pdf`.
+const stripUrlSuffix = (candidate: string) => candidate.split(/[?#]/)[0];
+
+interface PdfFileFields {
+  fileName?: string | null;
+  fileType?: string | null;
+  path?: string | null;
+}
+
+export const isPdfFile = ({ fileName, fileType, path }: PdfFileFields): boolean => {
+  const normalizedFileType = normalizeFileType(fileType);
+
+  if (normalizedFileType && PDF_FILE_TYPES.has(normalizedFileType)) return true;
+
+  const candidates = [fileName, path].flatMap((candidate) =>
+    candidate ? [stripUrlSuffix(candidate).toLowerCase()] : [],
+  );
+
+  if (candidates.length === 0) return false;
+
+  return candidates.some((candidate) =>
+    PDF_FILE_EXTENSIONS.some((extension) => candidate.endsWith(extension)),
+  );
+};

--- a/src/features/FileViewer/index.tsx
+++ b/src/features/FileViewer/index.tsx
@@ -7,6 +7,7 @@ import { memo } from 'react';
 import { isHtmlFile } from '@/components/HtmlPreview';
 import { type FileListItem } from '@/types/files';
 
+import { isPdfFile } from './fileType';
 import NotSupport from './NotSupport';
 import CodeViewer from './Renderer/Code';
 import HTMLViewer from './Renderer/HTML';
@@ -206,6 +207,8 @@ const ARCHIVE_MIME_TYPES = new Set([
 ]);
 
 // Helper function to check file type
+// Note: fileType is matched exactly against the MIME set; substring matching would let
+// generic values like `custom/document` bleed into MSDoc via the `doc` substring.
 const matchesFileType = (
   fileType: string | undefined,
   fileName: string | undefined,
@@ -215,17 +218,10 @@ const matchesFileType = (
   const lowerFileType = fileType?.toLowerCase();
   const lowerFileName = fileName?.toLowerCase();
 
-  // Check MIME type
   if (lowerFileType && mimeTypes.has(lowerFileType)) {
     return true;
   }
 
-  // Check file extension in fileType
-  if (lowerFileType && extensions.some((ext) => lowerFileType.includes(ext.slice(1)))) {
-    return true;
-  }
-
-  // Check file extension in fileName
   if (lowerFileName && extensions.some((ext) => lowerFileName.endsWith(ext))) {
     return true;
   }
@@ -243,7 +239,7 @@ interface FileViewerProps extends FileListItem {
  */
 const FileViewer = memo<FileViewerProps>(({ id, style, fileType, url, name }) => {
   // PDF files
-  if (fileType?.toLowerCase() === 'pdf' || name?.toLowerCase().endsWith('.pdf')) {
+  if (isPdfFile({ fileName: name, fileType, path: url })) {
     return <PDFViewer fileId={id} url={url} />;
   }
 

--- a/src/features/ResourceManager/components/Editor/index.tsx
+++ b/src/features/ResourceManager/components/Editor/index.tsx
@@ -10,7 +10,6 @@ import { useTranslation } from 'react-i18next';
 
 import NavHeader from '@/features/NavHeader';
 import { PageAgentProvider } from '@/features/PageEditor/PageAgentProvider';
-import { lambdaQuery } from '@/libs/trpc/client';
 import FileDetailComponent from '@/routes/(main)/resource/features/FileDetail';
 import { useResourceManagerStore } from '@/routes/(main)/resource/features/store';
 import { fileManagerSelectors, useFileStore } from '@/store/file';
@@ -36,10 +35,8 @@ const FileDetailSkeleton = () => (
 const FileDetailModalContent = memo(() => {
   const currentViewItemId = useResourceManagerStore((s) => s.currentViewItemId);
   const fromStore = useFileStore(fileManagerSelectors.getFileById(currentViewItemId));
-  const { data: fromQuery } = lambdaQuery.file.getFileItemById.useQuery(
-    { id: currentViewItemId ?? '' },
-    { enabled: !fromStore && !!currentViewItemId },
-  );
+  const useFetchKnowledgeItem = useFileStore((s) => s.useFetchKnowledgeItem);
+  const { data: fromQuery } = useFetchKnowledgeItem(!fromStore ? currentViewItemId : undefined);
   const fileDetail = fromStore ?? fromQuery;
   return (
     <Flexbox style={{ minHeight: 260 }}>
@@ -69,7 +66,10 @@ const FileEditorCanvas = memo<FileEditorProps>(({ onBack }) => {
 
   const currentViewItemId = useResourceManagerStore((s) => s.currentViewItemId);
 
-  const fileDetail = useFileStore(fileManagerSelectors.getFileById(currentViewItemId));
+  const fromStore = useFileStore(fileManagerSelectors.getFileById(currentViewItemId));
+  const useFetchKnowledgeItem = useFileStore((s) => s.useFetchKnowledgeItem);
+  const { data: fromFetch } = useFetchKnowledgeItem(!fromStore ? currentViewItemId : undefined);
+  const fileDetail = fromStore ?? fromFetch;
 
   return (
     <Flexbox horizontal height={'100%'} width={'100%'}>

--- a/src/routes/(main)/resource/features/hooks/useInitFileCheck.ts
+++ b/src/routes/(main)/resource/features/hooks/useInitFileCheck.ts
@@ -4,6 +4,7 @@ import { CUSTOM_DOCUMENT_FILE_TYPE, DERIVED_DOCUMENT_SOURCE_TYPE } from '@lobech
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router';
 
+import { isPdfFile } from '@/features/FileViewer/fileType';
 import { documentSelectors, useFileStore } from '@/store/file';
 
 import { useResourceManagerStore } from '../store';
@@ -32,13 +33,16 @@ export const useInitFileCheck = () => {
 
       if (fileData || documentData) {
         const isPDF =
-          fileData?.fileType?.toLowerCase() === 'pdf' ||
-          fileData?.fileType?.toLowerCase() === 'application/pdf' ||
-          fileData?.name?.toLowerCase().endsWith('.pdf') ||
-          documentData?.fileType?.toLowerCase() === 'pdf' ||
-          documentData?.fileType?.toLowerCase() === 'application/pdf' ||
-          documentData?.filename?.toLowerCase().endsWith('.pdf') ||
-          documentData?.source?.toLowerCase().endsWith('.pdf');
+          isPdfFile({
+            fileName: fileData?.name,
+            fileType: fileData?.fileType,
+            path: fileData?.url,
+          }) ||
+          isPdfFile({
+            fileName: documentData?.filename,
+            fileType: documentData?.fileType,
+            path: documentData?.source,
+          });
 
         const isPage =
           !isPDF &&


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

Fixes an end-to-end break for previewing and downloading file-backed documents (\`docs_\` prefixed resources that wrap a PDF or similar upload). Three linked bugs, addressed together:

1. **PDF preview routed to MSDoc.** \`FileViewer\` only matched \`fileType === 'pdf'\` while documents may carry \`application/pdf\` or fall back to \`custom/document\`; \`matchesFileType\` also matched extensions against \`fileType\` via \`.includes\`, so any \`fileType\` containing the substring \`doc\` (e.g. \`custom/document\`) was misrouted to the MSDoc viewer (and to Code via the \`.c\` substring).
2. **File detail / download button missing for \`docs_\` items.** \`FileEditorCanvas\` and \`FileDetailModalContent\` read from the file store only, which does not hold \`docs_\` prefixed items — so \`fileDetail\` was undefined, hiding the download button and the info modal content.
3. **Storage key returned instead of a signed URL.** \`document.getDocumentById\` returned \`source\` as a raw storage key (\`assets/…/*.pdf\`). The client used it directly as \`url\`, the browser resolved it relative to the app origin, and the SPA fallback returned HTML — hence \`Warning: InvalidPDFException: Invalid PDF structure\` in the viewer and HTML content from the download button.

**Fixes:**

- Extract PDF detection into \`src/features/FileViewer/fileType.ts\` (\`isPdfFile\`), mirroring the shape of \`isHtmlFile\`. Handles \`pdf\` / \`application/pdf\` MIME (with \`; charset\` suffix), \`.pdf\` extension on \`fileName\` / \`path\`, and strips \`?query\`/\`#hash\` from paths so signed URLs (\`.pdf?X-Amz-…\`) still match.
- Use \`isPdfFile\` in both \`FileViewer\` and \`useInitFileCheck\` so there is a single source of truth for PDF detection.
- Remove the substring extension check on \`fileType\` in \`matchesFileType\`. The MIME set already covers exact extension values (e.g. \`'doc'\`); substring matching only leaked generic types into unrelated viewers.
- \`FileEditorCanvas\` and \`FileDetailModalContent\` now fall back to \`useFetchKnowledgeItem\` (which is already \`docs_\` / \`file_\` prefix-aware) instead of calling \`file.getFileItemById\` directly, so title, download URL, and detail modal populate for documents.
- On the server, \`document.getDocumentById\` now signs \`source\` via \`fileService.getFileAccessUrl\` before returning. Absolute URLs (web-derived documents) pass through unchanged. The update path does not carry \`source\`, so no signed-URL round-trip pollution.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- \`bun run check\` passes (lint clean, all touched tests pass).
- New unit tests in \`fileType.test.ts\` cover: exact MIME (\`application/pdf\`), extension via \`fileName\`/\`path\`, MIME with charset suffix, generic \`custom/document\` \`fileType\` + \`.pdf\` path, signed R2 URL with query string.
- Manual verification: open a PDF document under Resource, confirm PDFViewer renders, download button appears next to the info button, and downloading yields the real PDF (not the SPA HTML fallback).

#### 📸 Screenshots / Videos

n/a

#### 📝 Additional Information

The server-side signing change means \`document.getDocumentById\` now returns a signed URL for \`source\` (previously a raw storage key). Only two client call sites read \`source\`, and both treat it as a URL — no callers depend on the raw key form, and the update path doesn't accept \`source\` as input, so there is no risk of writing signed URLs back to the DB.