### PR TITLE
🐛 fix(topic): refresh the linked PR state when the meta hover card opens

### DIFF
--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/MetaHoverCard.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/MetaHoverCard.test.tsx
@@ -3,12 +3,19 @@
  */
 import type { ChatTopicMetadata } from '@lobechat/types';
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import MetaHoverCard from './MetaHoverCard';
 
+const fetchTopicLinkedPullRequestMock = vi.hoisted(() => vi.fn());
+
 vi.mock('@lobehub/ui', () => ({
   Icon: () => <span data-testid="meta-card-icon" />,
+}));
+
+vi.mock('@/store/chat', () => ({
+  useChatStore: (selector: (state: unknown) => unknown) =>
+    selector({ useFetchTopicLinkedPullRequest: fetchTopicLinkedPullRequestMock }),
 }));
 
 vi.mock('antd-style', () => ({
@@ -43,7 +50,49 @@ vi.mock('@/features/ChatInput/ControlBar/DirIcon', () => ({
   default: ({ size }: { size?: number }) => <span data-size={size} data-testid="dir-icon" />,
 }));
 
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
 describe('MetaHoverCard', () => {
+  it('re-fetches the linked PR state on mount (popover open) for the hovered topic', () => {
+    const metadata: ChatTopicMetadata = {
+      workingDirectory: '/repo',
+      workingDirectoryConfig: {
+        git: {
+          branch: 'fix/cold-hydration-cache-inject',
+          github: {
+            pullRequest: {
+              number: 17_392,
+              state: 'open',
+              title: 'keep the hydration gate up',
+              url: 'https://github.com/lobehub/lobehub/pull/17392',
+            },
+            pullRequestStatus: 'ok',
+          },
+        },
+        path: '/repo',
+        repoType: 'github',
+      },
+    };
+
+    render(<MetaHoverCard metadata={metadata} title="Topic" topicId="topic-1" />);
+
+    // The card mounts only while the hover popover is open, so wiring the SWR
+    // hook to the topic id is what turns "open the card" into a PR refresh —
+    // background topics otherwise keep their last persisted snapshot forever.
+    expect(fetchTopicLinkedPullRequestMock).toHaveBeenCalledWith('topic-1', metadata);
+  });
+
+  it('still mounts the refresh hook when the topic has no git context', () => {
+    const { container } = render(<MetaHoverCard metadata={undefined} title="Topic" />);
+
+    // No git context → nothing renders, but the hook is still called
+    // unconditionally (rules of hooks); it no-ops via a null SWR key.
+    expect(container).toBeEmptyDOMElement();
+    expect(fetchTopicLinkedPullRequestMock).toHaveBeenCalledWith(undefined, undefined);
+  });
+
   it('shows persisted git context without the branch explanation note', () => {
     const metadata: ChatTopicMetadata = {
       workingDirectory: '/repo-fix',

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/MetaHoverCard.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/MetaHoverCard.tsx
@@ -15,6 +15,7 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import DirIcon from '@/features/ChatInput/ControlBar/DirIcon';
+import { useChatStore } from '@/store/chat';
 
 import { getPullRequestState, getTopicMetaCard, PR_STATE_VISUAL } from './metaCardData';
 
@@ -139,6 +140,8 @@ interface MetaHoverCardProps {
   metadata: ChatTopicMetadata | undefined;
   time?: ReactNode;
   title: string;
+  /** Enables the open-time PR/CI refresh below; without it the card is a pure snapshot reader. */
+  topicId?: string;
 }
 
 /**
@@ -146,8 +149,16 @@ interface MetaHoverCardProps {
  * branch / worktree / linked-PR / CI context on the right of the sidebar without
  * cluttering the row itself.
  */
-const MetaHoverCard = memo<MetaHoverCardProps>(({ metadata, title, time }) => {
+const MetaHoverCard = memo<MetaHoverCardProps>(({ metadata, title, time, topicId }) => {
   const { t } = useTranslation('topic');
+  // The card only mounts while the popover is open, so hosting the linked-PR
+  // SWR hook here re-fetches the persisted PR/CI snapshot exactly when the
+  // user is looking at it (the hook dedupes to once a minute per PR).
+  // ChatHydration runs the same hook for the active topic only — without this,
+  // a background topic's badge stays frozen on whatever was last persisted.
+  const useFetchTopicLinkedPullRequest = useChatStore((s) => s.useFetchTopicLinkedPullRequest);
+  useFetchTopicLinkedPullRequest(topicId, metadata);
+
   const card = getTopicMetaCard(metadata);
   if (!card) return null;
 

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -463,7 +463,7 @@ const TopicItem = memo<TopicItemProps>(
         {metaCard ? (
           <Popover
             arrow={false}
-            content={<MetaHoverCard metadata={metadata} title={title} />}
+            content={<MetaHoverCard metadata={metadata} title={title} topicId={id} />}
             mouseEnterDelay={0.8}
             placement={'right'}
             styles={META_HOVER_CARD_STYLES}


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

The sidebar meta hover card (repo / branch / worktree / PR / CI) renders straight from the topic's persisted `workingDirectoryConfig.git.github.pullRequest` snapshot. The only thing that ever re-fetches that snapshot is `useFetchTopicLinkedPullRequest`, which `ChatHydration` mounts for the **active topic only** — so a background topic's PR badge stays frozen on whatever was last persisted. Merging a PR on GitHub left the row showing a green "Open" badge (and a stale "No CI checks") until the topic was clicked open.

This PR hosts the same linked-PR SWR hook inside `MetaHoverCard` itself:

- The card only mounts while the hover popover is open, so opening the card is exactly the moment the PR state re-fetches — no background polling added.
- The hook's existing `dedupingInterval: 60s` (shared SWR key with `ChatHydration`) keeps repeated hovers to at most one `gh`/TRPC lookup per minute per PR.
- The hook's `onData → internal_updateTopicLinkedPullRequest` path does an optimistic store dispatch + metadata persist, so the row's leading PR icon and the card's PR/CI rows update reactively while you're looking at them.
- `TopicItem` now passes `topicId` into the card; without it the card stays a pure snapshot reader (unchanged behavior).

#### 🧪 How to Test

1. Link a topic to an open PR (e.g. have the agent run `gh pr create` in a worktree topic).
2. Merge the PR on GitHub while the topic sits idle in the sidebar (not active).
3. Hover the topic row until the meta card opens: the PR row should flip to the purple "Merged" state within a second, and the row's leading icon follows.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Regression tests: `MetaHoverCard.test.tsx` now asserts the card mounts the refresh hook with the hovered topic's id + metadata, and still calls it (as a no-op) when the topic has no git context.

#### 📸 Screenshots / Videos

None — behavior change only; visuals of the card are untouched.

#### 📝 Additional Information

The refresh reuses the existing on-demand pipeline (`gitService.getLinkedPullRequest` → desktop IPC / `device.gitLinkedPullRequest` TRPC → `gh pr view`), including its 8s timeout and `shouldRetryOnError: false`, so a device that is offline or missing `gh` degrades to the persisted snapshot exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)