### PR TITLE
🔨 chore(models): add LongCat-2.0 to SiliconCloud & update DeepSeek-V4-Pro pricing

### DIFF
--- a/packages/model-bank/src/aiModels/siliconcloud.ts
+++ b/packages/model-bank/src/aiModels/siliconcloud.ts
@@ -13,8 +13,35 @@ const siliconcloudChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_048_576,
     description:
+      'LongCat-2.0 is a large-scale MoE language model from Meituan with 1.6 trillion total parameters and ~48B activated per token. It features LongCat Sparse Attention and is trained on hundreds of billions of tokens of 1M-context data, giving it strong performance on coding, agentic, and long-context tasks. It supports tool use and function calling.',
+    displayName: 'LongCat-2.0',
+    family: 'longcat',
+    generation: 'longcat-2.0',
+    id: 'meituan-longcat/LongCat-2.0',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 20, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-06-30',
+    settings: {
+      extendParams: ['enableReasoning'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 1_048_576,
+    description:
       "GLM-5.2 is Z.ai's latest flagship model designed for long-horizon task scenarios, offering significant improvements in long-horizon task capabilities compared to GLM-5.1. This 753B MoE model supports a stable 1M-token context window, features stronger programming capabilities, and supports multiple thinking effort levels for a flexible balance between performance and latency.",
     displayName: 'GLM-5.2',
+    enabled: true,
     family: 'glm',
     generation: 'glm-5.2',
     id: 'zai-org/GLM-5.2',
@@ -76,9 +103,9 @@ const siliconcloudChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
-        { name: 'textInput_cacheRead', rate: 0.025, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 6, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 12, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 24, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2026-04-24',

--- a/packages/model-bank/src/aiModels/siliconcloud.ts
+++ b/packages/model-bank/src/aiModels/siliconcloud.ts
@@ -55,7 +55,7 @@ const siliconcloudChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2026-06-17',
     settings: {
-      extendParams: ['deepseekV4ReasoningEffort', 'reasoningBudgetToken'],
+      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
     },
     type: 'chat',
   },


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Add **LongCat-2.0** (`meituan-longcat/LongCat-2.0`) model to SiliconCloud provider with function call & reasoning abilities, 1M context window, CNY pricing, and i18n descriptions (en-US + zh-CN hand-written, others auto-filled)
- Enable **GLM-5.2** by default (`enabled: true`)
- Update **DeepSeek-V4-Pro** pricing to reflect current rates

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed (model metadata only)

#### 📸 Screenshots / Videos

N/A — model card data only, no UI changes.

#### 📝 Additional Information

Model reference: [SiliconCloud LongCat-2.0](https://siliconflow.cn/zh-cn/models)