### PR TITLE
♻️ refactor(assistant-message): inline reaction into action bar, move reaction display to actionAddon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ docs/superpowers/
 
 # Kagura agent runtime
 .kagura/
+
+# Amp agent runtime
+.amp/

--- a/src/features/Conversation/ChatItem/ChatItem.tsx
+++ b/src/features/Conversation/ChatItem/ChatItem.tsx
@@ -20,6 +20,7 @@ const ChatItem = memo<ChatItemProps>(
     avatarProps,
     customAvatarRender,
     afterActions,
+    actionAddon,
     actions,
     className,
     loading,
@@ -122,7 +123,9 @@ const ChatItem = memo<ChatItemProps>(
         {id && conversationKey && (
           <FollowUpChips conversationKey={conversationKey} messageId={id} />
         )}
-        {actions && <Actions actions={actions} placement={placement} />}
+        {(actionAddon || actions) && (
+          <Actions actionAddon={actionAddon} actions={actions} placement={placement} />
+        )}
         {afterActions && (
           <Flexbox
             style={{

--- a/src/features/Conversation/ChatItem/components/Actions.tsx
+++ b/src/features/Conversation/ChatItem/components/Actions.tsx
@@ -9,11 +9,12 @@ import { contextSelectors, useConversationStore } from '../../store';
 import { type ChatItemProps } from '../type';
 
 export interface ActionsProps {
+  actionAddon?: ChatItemProps['actionAddon'];
   actions: ChatItemProps['actions'];
   placement?: ChatItemProps['placement'];
 }
 
-const Actions = memo<ActionsProps>(({ placement, actions }) => {
+const Actions = memo<ActionsProps>(({ placement, actionAddon, actions }) => {
   const onboardingAgentId = useAgentStore(builtinAgentSelectors.webOnboardingAgentId);
   const conversationAgentId = useConversationStore(contextSelectors.agentId);
   if (!isDev && onboardingAgentId && conversationAgentId === onboardingAgentId) return null;
@@ -29,7 +30,8 @@ const Actions = memo<ActionsProps>(({ placement, actions }) => {
         alignSelf: isUser ? 'flex-end' : 'flex-start',
       }}
     >
-      {actions}
+      {actionAddon}
+      {actions && <Flexbox role="menubar">{actions}</Flexbox>}
     </Flexbox>
   );
 });

--- a/src/features/Conversation/ChatItem/type.ts
+++ b/src/features/Conversation/ChatItem/type.ts
@@ -4,6 +4,7 @@ import { type ReactNode } from 'react';
 
 export interface ChatItemProps extends Omit<FlexboxProps, 'children' | 'onChange'> {
   aboveMessage?: ReactNode;
+  actionAddon?: ReactNode;
   actions?: ReactNode;
   actionsWrapWidth?: number;
   afterActions?: ReactNode;

--- a/src/features/Conversation/Messages/Assistant/Actions/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Actions/index.tsx
@@ -1,6 +1,5 @@
 import { LOADING_FLAT } from '@lobechat/const';
 import { type UIChatMessage } from '@lobechat/types';
-import { Flexbox } from '@lobehub/ui';
 import { memo, useMemo } from 'react';
 
 import { ReactionPicker } from '../../../components/Reaction';
@@ -56,14 +55,12 @@ export const AssistantActionsBar = memo<AssistantActionsBarProps>(({ actionsConf
   const defaultBar = tools ? DEFAULT_BAR_WITH_TOOLS : DEFAULT_BAR;
 
   return (
-    <Flexbox horizontal align={'center'} gap={8}>
-      <ReactionPicker messageId={id} />
-      <MessageActionBar
-        bar={actionsConfig?.bar ?? defaultBar}
-        ctx={ctx}
-        menu={actionsConfig?.menu ?? DEFAULT_MENU}
-      />
-    </Flexbox>
+    <MessageActionBar
+      bar={actionsConfig?.bar ?? defaultBar}
+      ctx={ctx}
+      leading={<ReactionPicker messageId={id} />}
+      menu={actionsConfig?.menu ?? DEFAULT_MENU}
+    />
   );
 });
 

--- a/src/features/Conversation/Messages/Assistant/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/Assistant/components/MessageContent.tsx
@@ -1,12 +1,8 @@
 import { LOADING_FLAT } from '@lobechat/const';
 import { type UIChatMessage } from '@lobechat/types';
 import { Flexbox } from '@lobehub/ui';
-import { memo, useCallback, useMemo } from 'react';
+import { memo } from 'react';
 
-import { useUserStore } from '@/store/user';
-import { userProfileSelectors } from '@/store/user/selectors';
-
-import { ReactionDisplay } from '../../../components/Reaction';
 import { messageStateSelectors, useConversationStore } from '../../../store';
 import { CollapsedMessage } from '../../AssistantGroup/components/CollapsedMessage';
 import DisplayContent from '../../components/DisplayContent';
@@ -24,9 +20,6 @@ const MessageContent = memo<UIChatMessage>(
     const isCreating = useConversationStore(messageStateSelectors.isMessageCreating(id));
     const isCollapsed = useConversationStore(messageStateSelectors.isMessageCollapsed(id));
     const isReasoning = useConversationStore(messageStateSelectors.isMessageInReasoning(id));
-    const addReaction = useConversationStore((s) => s.addReaction);
-    const removeReaction = useConversationStore((s) => s.removeReaction);
-    const userId = useUserStore(userProfileSelectors.userId)!;
 
     const isLoading = generating || isCreating;
     const isToolCallGenerating = isLoading && (content === LOADING_FLAT || !content) && !!tools;
@@ -41,28 +34,6 @@ const MessageContent = memo<UIChatMessage>(
       (!props.reasoning && isReasoning);
 
     const showFileChunks = !!chunksList && chunksList.length > 0;
-
-    const reactions = useMemo(() => metadata?.reactions || [], [metadata?.reactions]);
-
-    const handleReactionClick = useCallback(
-      (emoji: string) => {
-        const existing = reactions.find((r) => r.emoji === emoji);
-        if (existing && existing.users.includes(userId)) {
-          removeReaction(id, emoji);
-        } else {
-          addReaction(id, emoji);
-        }
-      },
-      [id, reactions, userId, addReaction, removeReaction],
-    );
-
-    const isActive = useCallback(
-      (emoji: string) => {
-        const reaction = reactions.find((r) => r.emoji === emoji);
-        return !!reaction && reaction.users.includes(userId);
-      },
-      [reactions, userId],
-    );
 
     if (isCollapsed) return <CollapsedMessage content={content} id={id} />;
 
@@ -90,14 +61,6 @@ const MessageContent = memo<UIChatMessage>(
           tempDisplayContent={metadata?.tempDisplayContent}
         />
         {showImageItems && <ImageFileListViewer items={imageList} />}
-        {reactions.length > 0 && (
-          <ReactionDisplay
-            isActive={isActive}
-            messageId={id}
-            reactions={reactions}
-            onReactionClick={handleReactionClick}
-          />
-        )}
       </Flexbox>
     );
   },

--- a/src/features/Conversation/Messages/Assistant/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/index.tsx
@@ -1,15 +1,17 @@
 'use client';
 
 import { LOADING_FLAT } from '@lobechat/const';
+import type { EmojiReaction } from '@lobechat/types';
 import isEqual from 'fast-deep-equal';
 import type { MouseEventHandler, ReactNode } from 'react';
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 
 import { MESSAGE_ACTION_BAR_PORTAL_ATTRIBUTES } from '@/const/messageActionPortal';
 import { ChatItem } from '@/features/Conversation/ChatItem';
 import { useUserStore } from '@/store/user';
-import { userGeneralSettingsSelectors } from '@/store/user/selectors';
+import { userGeneralSettingsSelectors, userProfileSelectors } from '@/store/user/selectors';
 
+import { ReactionDisplay } from '../../components/Reaction';
 import ErrorMessageExtra, { useErrorContent } from '../../Error';
 import { useAgentMeta, useDoubleClickEdit } from '../../hooks';
 import { dataSelectors, messageStateSelectors, useConversationStore } from '../../store';
@@ -64,6 +66,33 @@ const AssistantMessage = memo<AssistantMessageProps>(
     const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
     const isCreating = useConversationStore(messageStateSelectors.isMessageCreating(id));
     const interrupted = useConversationStore(messageStateSelectors.isMessageInterrupted(id));
+    const addReaction = useConversationStore((s) => s.addReaction);
+    const removeReaction = useConversationStore((s) => s.removeReaction);
+    const userId = useUserStore(userProfileSelectors.userId)!;
+    const reactions = useMemo<EmojiReaction[]>(
+      () => metadata?.reactions || [],
+      [metadata?.reactions],
+    );
+
+    const handleReactionClick = useCallback(
+      (emoji: string) => {
+        const existing = reactions.find((reaction) => reaction.emoji === emoji);
+        if (existing?.users.includes(userId)) {
+          removeReaction(id, emoji);
+        } else {
+          addReaction(id, emoji);
+        }
+      },
+      [addReaction, id, reactions, removeReaction, userId],
+    );
+
+    const isReactionActive = useCallback(
+      (emoji: string) => {
+        const reaction = reactions.find((item) => item.emoji === emoji);
+        return !!reaction && reaction.users.includes(userId);
+      },
+      [reactions, userId],
+    );
 
     const errorContent = useErrorContent(error);
 
@@ -97,17 +126,26 @@ const AssistantMessage = memo<AssistantMessageProps>(
         aboveMessage={null}
         avatar={avatar}
         belowMessage={hasEmptyErrorMessage ? footerRender : undefined}
-        customErrorRender={(error) => <ErrorMessageExtra data={item} error={error} />}
-        error={errorContent && error ? errorContent : undefined}
-        editing={editing}
         // ChatItem renders this as the primary block when the message is empty,
         // or inside messageExtra (below the content) when the turn streamed
         // content before erroring — so don't gate it on empty content.
+        customErrorRender={(error) => <ErrorMessageExtra data={item} error={error} />}
+        editing={editing}
+        error={errorContent && error ? errorContent : undefined}
         id={id}
         loading={generating || isCreating}
         message={message}
         placement={'left'}
         time={createdAt}
+        actionAddon={
+          reactions.length > 0 ? (
+            <ReactionDisplay
+              isActive={isReactionActive}
+              reactions={reactions}
+              onReactionClick={handleReactionClick}
+            />
+          ) : undefined
+        }
         actions={
           <>
             {isDevMode && branch && (

--- a/src/features/Conversation/Messages/AssistantGroup/Actions/index.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Actions/index.test.tsx
@@ -9,24 +9,30 @@ import { GroupActionsBar } from './index';
 
 const storeMock = vi.hoisted(() => ({ isGenerating: false }));
 
-// Flexbox → passthrough so we can read the inner MessageActionBar stub.
-vi.mock('@lobehub/ui', () => ({
-  Flexbox: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-}));
-
 // Stub the action bar to expose the resolved `bar` / `menu` slots verbatim.
 vi.mock('../../components/MessageActionBar', () => ({
-  MessageActionBar: ({ bar, menu }: { bar?: string[]; menu?: string[] }) => (
+  MessageActionBar: ({
+    bar,
+    leading,
+    menu,
+  }: {
+    bar?: string[];
+    leading?: React.ReactNode;
+    menu?: string[];
+  }) => (
     <div
       data-bar={(bar ?? []).join(',')}
+      data-has-leading={!!leading}
       data-menu={(menu ?? []).join(',')}
       data-testid="action-bar"
-    />
+    >
+      {leading}
+    </div>
   ),
 }));
 
 vi.mock('../../../components/Reaction', () => ({
-  ReactionPicker: () => null,
+  ReactionPicker: () => <span data-testid="reaction-picker" />,
 }));
 
 // isAssistantGroupItemGenerating(id) is called through useConversationStore; the
@@ -74,5 +80,7 @@ describe('GroupActionsBar — hetero (assistantGroup) forward/select gating', ()
     expect(menu.split(',')).toContain('select');
     expect(menu.split(',')).toContain('share');
     expect(menu.split(',')).toContain('edit');
+    expect(bar).toHaveAttribute('data-has-leading', 'true');
+    expect(screen.getByTestId('reaction-picker')).toBeInTheDocument();
   });
 });

--- a/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
@@ -1,5 +1,4 @@
 import { type AssistantContentBlock, type UIChatMessage } from '@lobechat/types';
-import { Flexbox } from '@lobehub/ui';
 import { memo, useMemo } from 'react';
 
 import { ReactionPicker } from '../../../components/Reaction';
@@ -67,14 +66,12 @@ export const GroupActionsBar = memo<GroupActionsProps>(
     const defaultBar = data.tools ? DEFAULT_BAR_WITH_TOOLS : DEFAULT_BAR;
 
     return (
-      <Flexbox horizontal align={'center'} gap={8}>
-        <ReactionPicker messageId={id} />
-        <MessageActionBar
-          bar={actionsConfig?.bar ?? defaultBar}
-          ctx={ctx}
-          menu={actionsConfig?.menu ?? DEFAULT_MENU}
-        />
-      </Flexbox>
+      <MessageActionBar
+        bar={actionsConfig?.bar ?? defaultBar}
+        ctx={ctx}
+        leading={<ReactionPicker messageId={id} />}
+        menu={actionsConfig?.menu ?? DEFAULT_MENU}
+      />
     );
   },
 );

--- a/src/features/Conversation/Messages/AssistantGroup/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/index.tsx
@@ -146,7 +146,10 @@ const GroupMessage = memo<GroupMessageProps>(
     const addReaction = useConversationStore((s) => s.addReaction);
     const removeReaction = useConversationStore((s) => s.removeReaction);
     const userId = useUserStore(userProfileSelectors.userId)!;
-    const reactions: EmojiReaction[] = metadata?.reactions || [];
+    const reactions = useMemo<EmojiReaction[]>(
+      () => metadata?.reactions || [],
+      [metadata?.reactions],
+    );
 
     const handleReactionClick = useCallback(
       (emoji: string) => {
@@ -157,7 +160,7 @@ const GroupMessage = memo<GroupMessageProps>(
           addReaction(id, emoji);
         }
       },
-      [id, reactions, addReaction, removeReaction],
+      [addReaction, id, reactions, removeReaction, userId],
     );
 
     const isReactionActive = useCallback(
@@ -165,7 +168,7 @@ const GroupMessage = memo<GroupMessageProps>(
         const reaction = reactions.find((r) => r.emoji === emoji);
         return !!reaction && reaction.users.includes(userId);
       },
-      [reactions],
+      [reactions, userId],
     );
 
     const setMessageItemActionElementPortialContext =
@@ -193,7 +196,7 @@ const GroupMessage = memo<GroupMessageProps>(
       } else {
         openChatSettings();
       }
-    }, [isInbox]);
+    }, [isInbox, openChatSettings, toggleSystemRole]);
 
     return (
       <ChatItem
@@ -203,6 +206,15 @@ const GroupMessage = memo<GroupMessageProps>(
         placement={'left'}
         time={createdAt}
         titleAddon={isSupervisor ? <Tag>{t('supervisor.label')}</Tag> : undefined}
+        actionAddon={
+          reactions.length > 0 ? (
+            <ReactionDisplay
+              isActive={isReactionActive}
+              reactions={reactions}
+              onReactionClick={handleReactionClick}
+            />
+          ) : undefined
+        }
         actions={
           !disableEditing && (
             <>
@@ -249,10 +261,10 @@ const GroupMessage = memo<GroupMessageProps>(
               blocks={children}
               content={lastAssistantMsg?.content}
               contentId={contentId}
-              disableEditing={disableEditing}
               // Folding a finished turn's process is the default behavior now
               // (graduated from Labs) — always on for the conversation.
               defaultWorkflowExpandLevel={defaultWorkflowExpandLevel}
+              disableEditing={disableEditing}
               id={id}
               isLatestItem={isLatestItem}
               messageIndex={index}
@@ -283,14 +295,6 @@ const GroupMessage = memo<GroupMessageProps>(
           <Usage model={model} performance={performance} provider={provider!} usage={usage} />
         )}
         {footerRender}
-        {reactions.length > 0 && (
-          <ReactionDisplay
-            isActive={isReactionActive}
-            messageId={id}
-            reactions={reactions}
-            onReactionClick={handleReactionClick}
-          />
-        )}
         <Suspense fallback={null}>
           {editing && contentId && <EditState content={lastAssistantMsg?.content} id={contentId} />}
         </Suspense>

--- a/src/features/Conversation/Messages/components/MessageActionBar/index.test.tsx
+++ b/src/features/Conversation/Messages/components/MessageActionBar/index.test.tsx
@@ -15,15 +15,24 @@ vi.mock('@lobehub/ui', () => ({
   ActionIconGroup: ({
     items,
     menu,
+    style,
+    variant,
   }: {
     items: { key?: string }[];
     menu?: { key?: string; type?: string }[];
+    style?: React.CSSProperties;
+    variant?: string;
   }) => (
     <div
       data-items={items.map((item) => item.key).join(',')}
       data-menu={menu?.map((item) => item.key || item.type).join(',') ?? ''}
       data-testid="action-group"
+      data-variant={variant}
+      style={style}
     />
+  ),
+  Block: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="action-container">{children}</div>
   ),
 }));
 
@@ -41,6 +50,28 @@ vi.mock('./useBuildActions', () => ({
 }));
 
 describe('MessageActionBar', () => {
+  it('renders a leading control inside the shared action container', () => {
+    permissionMock.canEdit = true;
+
+    render(
+      <MessageActionBar
+        bar={['edit', 'copy']}
+        leading={<button>Reaction</button>}
+        ctx={{
+          data: { content: 'hello', role: 'assistant' } as UIChatMessage,
+          id: 'message-1',
+          role: 'assistant',
+        }}
+      />,
+    );
+
+    const container = screen.getByTestId('action-container');
+    expect(container).toContainElement(screen.getByRole('button', { name: 'Reaction' }));
+    const actionGroup = screen.getByTestId('action-group');
+    expect(actionGroup).toHaveAttribute('data-variant', 'borderless');
+    expect(actionGroup).toHaveStyle({ background: 'transparent', borderRadius: '0' });
+  });
+
   it('limits workspace viewers to copy only', () => {
     permissionMock.canEdit = false;
 

--- a/src/features/Conversation/Messages/components/MessageActionBar/index.tsx
+++ b/src/features/Conversation/Messages/components/MessageActionBar/index.tsx
@@ -1,5 +1,6 @@
 import type { ActionIconGroupEvent, ActionIconGroupItemType } from '@lobehub/ui';
-import { ActionIconGroup } from '@lobehub/ui';
+import { ActionIconGroup, Block } from '@lobehub/ui';
+import type { ReactNode } from 'react';
 import { memo, useCallback, useMemo } from 'react';
 
 import { usePermission } from '@/hooks/usePermission';
@@ -67,6 +68,8 @@ interface MessageActionBarProps {
   bar: MessageActionSlot[];
   /** Runtime context passed to every action's builder */
   ctx: MessageActionContext;
+  /** Custom control rendered first inside the shared action container */
+  leading?: ReactNode;
   /** Menu slots (shown in the overflow dropdown); defaults to `bar` when omitted */
   menu?: MessageActionSlot[];
 }
@@ -75,7 +78,7 @@ interface MessageActionBarProps {
  * Universal action bar. Resolves declarative slot keys (`'copy'`, `'edit'`,
  * `'divider'`, ...) against the registry and renders an ActionIconGroup.
  */
-export const MessageActionBar = memo<MessageActionBarProps>(({ ctx, bar, menu }) => {
+export const MessageActionBar = memo<MessageActionBarProps>(({ ctx, bar, leading, menu }) => {
   const built = useBuildActions(ctx);
   const { allowed: canEdit } = usePermission('edit_own_content');
 
@@ -117,7 +120,25 @@ export const MessageActionBar = memo<MessageActionBarProps>(({ ctx, bar, menu })
     [allActions],
   );
 
-  return <ActionIconGroup items={items} menu={menuStripped} onActionClick={handleAction} />;
+  const actionGroup = (
+    <ActionIconGroup items={items} menu={menuStripped} onActionClick={handleAction} />
+  );
+
+  if (!leading) return actionGroup;
+
+  return (
+    <Block horizontal align={'center'} padding={2}>
+      {leading}
+      <ActionIconGroup
+        items={items}
+        menu={menuStripped}
+        padding={0}
+        style={{ background: 'transparent', border: 'none', borderRadius: 0, boxShadow: 'none' }}
+        variant={'borderless'}
+        onActionClick={handleAction}
+      />
+    </Block>
+  );
 });
 
 MessageActionBar.displayName = 'MessageActionBar';

--- a/src/features/Conversation/components/Reaction/ReactionDisplay.tsx
+++ b/src/features/Conversation/components/Reaction/ReactionDisplay.tsx
@@ -7,8 +7,6 @@ import { memo } from 'react';
 
 import { usePermission } from '@/hooks/usePermission';
 
-import ReactionPicker from './ReactionPicker';
-
 const styles = createStaticStyles(({ css, cssVar }) => ({
   active: css`
     background: ${cssVar.colorFillTertiary};
@@ -53,10 +51,6 @@ interface ReactionDisplayProps {
    */
   isActive?: (emoji: string) => boolean;
   /**
-   * The message ID for adding reactions via the inline picker
-   */
-  messageId?: string;
-  /**
    * Callback when a reaction is clicked
    */
   onReactionClick?: (emoji: string) => void;
@@ -66,30 +60,27 @@ interface ReactionDisplayProps {
   reactions: EmojiReaction[];
 }
 
-const ReactionDisplay = memo<ReactionDisplayProps>(
-  ({ reactions, onReactionClick, messageId, isActive }) => {
-    const { allowed: canEdit } = usePermission('edit_own_content');
+const ReactionDisplay = memo<ReactionDisplayProps>(({ reactions, onReactionClick, isActive }) => {
+  const { allowed: canEdit } = usePermission('edit_own_content');
 
-    if (reactions.length === 0) return null;
+  if (reactions.length === 0) return null;
 
-    return (
-      <Flexbox horizontal align={'center'} className={styles.container}>
-        {reactions.map((reaction) => (
-          <div
-            className={cx(styles.reactionTag, isActive?.(reaction.emoji) && styles.active)}
-            key={reaction.emoji}
-            style={{ cursor: canEdit ? undefined : 'default' }}
-            onClick={canEdit ? () => onReactionClick?.(reaction.emoji) : undefined}
-          >
-            <span>{reaction.emoji}</span>
-            {reaction.count > 1 && <span className={styles.count}>{reaction.count}</span>}
-          </div>
-        ))}
-        {canEdit && messageId && <ReactionPicker messageId={messageId} />}
-      </Flexbox>
-    );
-  },
-);
+  return (
+    <Flexbox horizontal align={'center'} className={styles.container}>
+      {reactions.map((reaction) => (
+        <div
+          className={cx(styles.reactionTag, isActive?.(reaction.emoji) && styles.active)}
+          key={reaction.emoji}
+          style={{ cursor: canEdit ? undefined : 'default' }}
+          onClick={canEdit ? () => onReactionClick?.(reaction.emoji) : undefined}
+        >
+          <span>{reaction.emoji}</span>
+          {reaction.count > 1 && <span className={styles.count}>{reaction.count}</span>}
+        </div>
+      ))}
+    </Flexbox>
+  );
+});
 
 ReactionDisplay.displayName = 'ReactionDisplay';
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor

#### 🔗 Related Issue

<!-- No related issue found -->

#### 🔀 Description of Change

Refactors the assistant message reaction UI so that reactions are part of the action bar area instead of a separate block below the message content.

**Key changes:**

- **`ChatItem`**: Add a new `actionAddon` prop that renders before the actions in the `Actions` component. Both `actionAddon` and `actions` are now gated by the same container.
- **`MessageActionBar`**: Add a `leading` prop that renders a custom control (e.g. `ReactionPicker`) inside a shared `Block` container alongside the `ActionIconGroup`. When `leading` is present, the action group is rendered borderless to blend seamlessly.
- **`AssistantMessage` / `GroupMessage`**: Hoist reaction state (`addReaction`, `removeReaction`, `userId`, `reactions`, `handleReactionClick`, `isReactionActive`) from `MessageContent` up to the message component. Pass `ReactionDisplay` via `actionAddon` instead of rendering it inside the message body.
- **`MessageContent`**: Remove reaction logic and `ReactionDisplay` — it now only handles content rendering.
- **`ReactionDisplay`**: Remove the `messageId` prop and the inline `ReactionPicker` — the picker is now composed externally via `MessageActionBar`'s `leading` slot.
- **`AssistantActionsBar` / `GroupActionsBar`**: Pass `ReactionPicker` as `leading` to `MessageActionBar` instead of wrapping both in an external `Flexbox`.
- **`.gitignore`**: Add `.amp/` to ignore the Amp agent runtime directory.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Tests updated:
- `AssistantGroup/Actions/index.test.tsx` — verifies `ReactionPicker` is rendered as `leading` inside the action bar.
- `MessageActionBar/index.test.tsx` — verifies the `leading` control renders inside the shared action container with borderless variant.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

This is a pure refactor — no behavior change to reaction add/remove logic. The reaction display moves from below the message content to inline with the action bar, and the reaction picker is composed into the action bar via a new `leading` slot rather than being a sibling element.
