### PR TITLE
✨ feat(labs): add experimental description to Labs settings header

### DIFF
--- a/locales/en-US/labs.json
+++ b/locales/en-US/labs.json
@@ -1,4 +1,5 @@
 {
+  "description": "These features are experimental. We might remove them, and they might have bugs. We'd love your feedback while using them.",
   "features.agentGraphConfig.desc": "Show graph runtime configuration in an agent profile advanced settings.",
   "features.agentGraphConfig.title": "Agent Graph Runtime Configuration",
   "features.agentSelfIteration.desc": "Allow the agent to reflect, build self-awareness, and continuously iterate through ongoing attempts and interactions.",

--- a/locales/zh-CN/labs.json
+++ b/locales/zh-CN/labs.json
@@ -1,4 +1,5 @@
 {
+  "description": "这些功能仍处于实验阶段，可能会被移除，也可能存在问题。欢迎在使用过程中向我们提供反馈。",
   "features.agentGraphConfig.desc": "在助理档案的进阶设置中显示 Graph 运行时配置。",
   "features.agentGraphConfig.title": "Agent Graph 运行时配置",
   "features.agentSelfIteration.desc": "允许助理自我反思、自我感知，并在持续的尝试与交互中不断自我迭代。",

--- a/packages/locales/src/default/labs.ts
+++ b/packages/locales/src/default/labs.ts
@@ -1,4 +1,6 @@
 export default {
+  'description':
+    "These features are experimental. We might remove them, and they might have bugs. We'd love your feedback while using them.",
   'features.agentGraphConfig.desc':
     'Show graph runtime configuration in an agent profile advanced settings.',
   'features.agentGraphConfig.title': 'Agent Graph Runtime Configuration',

--- a/src/routes/(main)/settings/features/SettingHeader.tsx
+++ b/src/routes/(main)/settings/features/SettingHeader.tsx
@@ -3,17 +3,21 @@ import { Divider } from 'antd';
 import { type FC, type ReactNode } from 'react';
 
 interface SettingHeaderProps {
+  description?: ReactNode;
   extra?: ReactNode;
   title: ReactNode;
 }
 
-const SettingHeader: FC<SettingHeaderProps> = ({ title, extra }) => {
+const SettingHeader: FC<SettingHeaderProps> = ({ title, description, extra }) => {
   return (
     <Flexbox gap={24} style={{ paddingTop: 12 }}>
       <Flexbox horizontal align={'center'} justify={'space-between'}>
-        <Text strong fontSize={24}>
-          {title}
-        </Text>
+        <Flexbox gap={4}>
+          <Text strong fontSize={24}>
+            {title}
+          </Text>
+          {description && <Text type={'secondary'}>{description}</Text>}
+        </Flexbox>
         {extra}
       </Flexbox>
       <Divider style={{ margin: 0 }} />

--- a/src/routes/(main)/settings/labs/index.test.tsx
+++ b/src/routes/(main)/settings/labs/index.test.tsx
@@ -66,7 +66,12 @@ vi.mock('@lobehub/ui/base-ui', () => ({
 }));
 
 vi.mock('@/routes/(main)/settings/features/SettingHeader', () => ({
-  default: ({ title }: { title: string }) => <h1>{title}</h1>,
+  default: ({ description, title }: { description?: string; title: string }) => (
+    <header>
+      <h1>{title}</h1>
+      {description}
+    </header>
+  ),
 }));
 
 const createWrapper = () => {
@@ -94,6 +99,12 @@ afterEach(() => {
 });
 
 describe('Labs settings page', () => {
+  it('explains that Labs features are experimental', () => {
+    renderPage();
+
+    expect(screen.getByText('description')).toBeDefined();
+  });
+
   it('splits experiments into General and Desktop groups', () => {
     renderPage();
 

--- a/src/routes/(main)/settings/labs/index.tsx
+++ b/src/routes/(main)/settings/labs/index.tsx
@@ -253,7 +253,7 @@ const Page = memo(() => {
 
   return (
     <>
-      <SettingHeader title={tLabs('title')} />
+      <SettingHeader description={tLabs('description')} title={tLabs('title')} />
       <Form
         collapsible={false}
         items={items}


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Add an experimental disclaimer description to the Labs settings page header so users understand these features are experimental, may be removed, and may contain bugs.

- Extend `SettingHeader` to accept an optional `description` prop, rendered as secondary text beneath the title.
- Add a `description` i18n key to the `labs` namespace (en-US source + zh-CN translation).
- Pass `tLabs("description")` into the Labs page `SettingHeader`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- Open **Settings → Labs** and verify the experimental description appears below the title.
- Run `bun run check --test src/routes/(main)/settings/labs/index.tsx` — 6 tests pass, including the new "explains that Labs features are experimental" regression test.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| _todo_ | _todo_ |

#### 📝 Additional Information

The `description` prop on `SettingHeader` is optional, so existing call sites are unaffected.
