### PR TITLE
📝 docs(agent-testing): forbid interactive OAuth for auth — inject login state instead

### DIFF
--- a/.agents/acceptance/PROJECT.md
+++ b/.agents/acceptance/PROJECT.md
@@ -203,9 +203,14 @@ stale standalone install: a recently added workspace package fails to resolve �
 - Login persistence: `stop` snapshots the login to
   `~/.lobehub/agent-testing/electron-login`; `start` seeds each new instance
   from it (`login-status` inspects it, `save-login <id>` captures a live one).
-  Sign in once, not once per run — and if an instance comes up signed out, drive
-  the sign-in yourself (the OAuth+PKCE recipe and the three token-rotation traps
-  are in `.agents/acceptance/references/auth.md`); never ask the user to click it.
+  Sign in once, not once per run — and if an instance comes up signed out,
+  **inject the login state directly** (restore the snapshot, or mint it via
+  CLI/API seeding; recipes and the three token-rotation traps are in
+  `.agents/acceptance/references/auth.md`). **Never trigger the OAuth flow
+  (`requestAuthorization`)** — it opens a login page in the user's default
+  browser, against a per-instance localhost origin that usually can't even
+  complete. If no injectable state exists, report auth as blocked and ask for
+  one manual sign-in instead.
 - Concurrent instances (N worktrees / parallel runs): `electron-dev.sh` drives a
   pool — `start <id>` gives each its own CDP port, userData dir (with copied
   login), Vite port, and IPC id. Drive each with a distinct

--- a/.agents/acceptance/common-mistakes.md
+++ b/.agents/acceptance/common-mistakes.md
@@ -106,3 +106,26 @@ the complete role × action × scope matrix.
 **Correct approach**: enumerate every matrix cell. Members receive own-only
 actions; owners receive both own and workspace variants for each applicable
 action, with elevated confirmation for destructive workspace-wide operations.
+
+## Never acquire Electron auth through the OAuth flow — inject state instead
+
+**Wrong approach**: on a signed-out desktop instance, following the old auth.md
+recipe — evaluating `remoteServerService.requestAuthorization(...)` (or clicking
+the app's "Sign in") to "drive the sign-in yourself".
+
+**Why it's wrong**: `AuthCtr` implements that flow with `shell.openExternal`, so
+every attempt **pops a login/authorize page in the user's default browser** —
+visibly, on their machine, repeatedly when retried. Dev instances also sit on
+per-instance ports (`localhost:3024`, …), so the authorize URL targets a localhost
+origin whose session/callback usually cannot complete: the user just accumulates
+broken login tabs.
+
+**What it breaks**: hijacks the user's personal browser session, leaks test
+activity into their real browsing context, and erodes trust in automated runs.
+
+**Correct approach**: login state is injected, never interactively acquired —
+① restore the `electron-login` snapshot (`login-status` / `save-login`);
+② mint the session via CLI/API seeding (the `web-seed` philosophy); ③ otherwise
+report auth as ❌ Blocked and request ONE manual sign-in. The corrected policy
+lives in `references/auth.md` ("When the instance comes up signed out") and
+PROJECT.md §4 Electron.

--- a/.agents/acceptance/probe-mock-patterns.md
+++ b/.agents/acceptance/probe-mock-patterns.md
@@ -1113,3 +1113,34 @@ ingest-report <dir> --subject topic:<id> …` — and verify attachment in the D
   then SUCCEEDS with a brand-new CC session and no error — context loss with no visible symptom. To
   detect it, compare the CC session id before/after a turn (or diff `~/.claude/projects/*/*.jsonl`):
   a new file per turn, each containing only its own user message, means resume never happened.
+
+## Seeded workspace agents: RBAC roles + real API creation are both required
+
+- **Situation:** verifying workspace UI with a hand-seeded workspace (raw SQL
+  inserts into `workspaces` / `workspace_members` / `agents`).
+- **Doesn't work:** topics load but `agent.getAgentConfigById` fails FORBIDDEN —
+  the cloud RBAC middleware reads `rbac_user_roles → roles → role_permissions →
+  permissions`, which raw member rows never create. And even after RBAC, a raw
+  SQL `agents` row renders "助理不可用" (missing real config).
+- **Works:** ① provision RBAC with the official util —
+  `seedWorkspaceRoles(db, wsId)` + `assignWorkspaceRoleToUser(...)` from
+  `packages/database/src/utils/seedWorkspaceRoles.ts` (run with bun from inside
+  `packages/database`); ② create agents through the real API from the authed
+  page (`POST /trpc/lambda/agent.createAgent` with the `X-Workspace-Id` header,
+  `visibility: 'public' | 'private'`), then repoint seeded topics' `agent_id`.
+
+## Duplicate @lobehub/ui instances crash the conversation route in dev
+
+- **Situation:** after a floating-range `pnpm install` (this repo has no
+  lockfile), `node_modules/.pnpm` can hold two `@lobehub/ui@X` peer-hash
+  instances. The workspace agent conversation route then dies in the error
+  boundary with `Please wrap your app with <ConfigProvider> (or
+  <MotionProvider>)` thrown from `TypewriterEffect` — the two instances carry
+  two React contexts. The sidebar-only routes may still work, which disguises
+  the cause; clearing `node_modules/.vite` does NOT fix it.
+- **Doesn't work:** clearing the Vite deps cache, restarting the dev server,
+  `pnpm dedupe @lobehub/ui` (peer sets differ, instances survive).
+- **Works:** temporarily add `resolve: { dedupe: ['@lobehub/ui', 'antd-style',
+  'motion', 'react', 'react-dom'] }` to the cloud root `vite.config.ts` +
+  `rm -rf node_modules/.vite`, and REVERT the config after capturing evidence
+  (snapshot the file first — it may carry uncommitted edits).

--- a/.agents/acceptance/references/auth.md
+++ b/.agents/acceptance/references/auth.md
@@ -171,22 +171,28 @@ reachable.
 
 ### When the instance comes up signed out
 
-Sign it in **yourself** — never hand this step to the user. The desktop flow is
-OAuth+PKCE against `/oidc/auth`, and the redirect target is a **server page the app
-then polls** (`/oidc/callback/desktop`), not a `lobehub://` deep link — so no other
-app can steal the callback, and no click is needed when the default browser already
-has a LobeHub session:
+**NEVER trigger the OAuth sign-in flow (`requestAuthorization` / opening
+`/oidc/auth` in any form).** `AuthCtr` runs it through `shell.openExternal`, so
+it **hijacks the user's default browser with a login/authorize page** — visibly,
+on their machine, possibly repeatedly. Worse, dev instances sit on per-instance
+ports (`localhost:3024`, …), so the authorize URL targets a localhost origin
+whose session/callback state is broken or already dead — the opened page can
+never complete. This recipe used to live here; it was a mistake.
 
-```bash
-agent-browser --session s<port> --cdp <port> eval --stdin << 'EOF'
-(async () => {
-  const m = await import('/src/services/electron/remoteServer.ts');
-  return JSON.stringify(await (m.remoteServerService || m.default).requestAuthorization({ storageMode: 'cloud' }));
-})()
-EOF
-# poll until user().user.id appears, then capture it:
-$EDEV save-login <id>
-```
+Login state must be **injected directly**, never acquired through a login page:
+
+1. **Restore the login snapshot** — `$EDEV login-status` to inspect
+   `~/.lobehub/agent-testing/electron-login`, and let `start` seed the instance
+   from it. A signed-out boot usually means the snapshot is stale because a
+   previous instance was killed instead of stopped (see the traps below) — a
+   `save-login <id>` from any still-live signed-in instance repairs it.
+2. **Mint the state via CLI/API** — the same philosophy as `web-seed`: create
+   the session server-side (seeded better-auth session / dev token issuance)
+   and inject it into the app's storage, with zero UI login. Prefer building on
+   `setup-auth.sh` seeding over anything that renders a sign-in page.
+3. **Neither works → report auth as ❌ Blocked and stop.** Tell the user the
+   Electron surface needs one manual sign-in (once — the snapshot then covers
+   future runs). Do not open any login page on their behalf.
 
 Three traps behind a signed-out instance:
 

--- a/.agents/skills/agent-testing/SKILL.md
+++ b/.agents/skills/agent-testing/SKILL.md
@@ -171,10 +171,12 @@ such as a database, cache, queue, or object store). **Universal rules:**
 the intended surface first when it is already clear from the task, then check only
 that surface. Do not block a web test on CLI auth or a desktop login state unless
 the test spans those surfaces. Run the per-surface status check from `PROJECT.md`
-§3. If a surface is signed out, **drive the sign-in yourself** — auth is
-environment mechanics the skill owns; never hand the user the sign-in click unless
-a step genuinely needs something only they can supply (a 2FA push), and then name
-the exact blocking step.
+§3. If a surface is signed out, **inject the login state directly** (seeded
+session, cookie/state restore, CLI/API-minted tokens — per `PROJECT.md` §3);
+**never drive an interactive login/OAuth flow** — those open login pages in the
+user's browser and hijack their session. When no injectable state exists, report
+auth as ❌ Blocked and ask the user for one manual sign-in, naming the exact
+blocking step.
 
 #### 2.5 Screen-recording preflight (OS-capture surfaces only)
 

--- a/.agents/skills/agent-testing/references/common-mistakes.md
+++ b/.agents/skills/agent-testing/references/common-mistakes.md
@@ -200,10 +200,13 @@ end. "Log in once in the app" is addressed to the **agent**, not the user.
 **What it breaks**: burns a round on a question the user doesn't want, and stalls a
 UI-touching change one click short of its screenshot.
 
-**Correct approach**: drive the sign-in yourself — click the app's own "Sign in"
-entry, follow the OAuth flow in the browser it opens, and get back into the app. Only
-escalate when a step genuinely needs something you cannot supply (a 2FA push on their
-phone), and then name the exact blocking step instead of offering to drop the
+**Correct approach**: obtain the login state by **direct injection** — restore the
+project's persisted login snapshot, or mint a session via CLI/API seeding — and
+never by driving an interactive login/OAuth flow: clicking "Sign in" makes the app
+open an authorize page in the **user's own default browser** (visibly hijacking
+their session, and in dev pointing at a per-instance localhost origin that often
+cannot complete). If no injectable state exists, report auth as blocked and ask for
+one manual sign-in, naming the exact blocking step instead of offering to drop the
 evidence. Corollary: never assume a profile is signed in because it exists — probe
 for a real signed-in state (a cheap authed call) before building a fixture on top of
 it; a rendered shell is not proof (a signed-out onboarding screen has text too).

--- a/.agents/skills/agent-testing/surfaces/electron.md
+++ b/.agents/skills/agent-testing/surfaces/electron.md
@@ -15,8 +15,11 @@ the CDP methodology; the project supplies the commands.
 
 Sign in once, not once per run — the project's desktop dev tooling should persist
 login across runs (`PROJECT.md` §3 says how). If an instance still comes up signed
-out, **drive the sign-in yourself**; never ask the user to click it. Run the
-desktop auth status check from `PROJECT.md` §3 before testing.
+out, **inject the login state directly** (restore the persisted snapshot, or mint
+it via CLI/API seeding per `PROJECT.md` §3); **never trigger an interactive
+login/OAuth flow** — it opens a login page in the user's own browser. When no
+injectable state exists, report auth as blocked and ask for one manual sign-in.
+Run the desktop auth status check from `PROJECT.md` §3 before testing.
 
 ## Linux / headless (cloud)
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 📝 docs

#### 🔀 Description of Change

The agent-testing skill told agents to "drive the sign-in yourself" on a signed-out Electron instance, with a recipe that evaluates `requestAuthorization(...)`. That flow runs `shell.openExternal`, so every attempt **pops a login/authorize page in the user's default browser** — and dev instances sit on per-instance localhost ports (e.g. `localhost:3024`), so the opened page usually cannot even complete. Users end up with forced login tabs they never asked for.

Policy rewritten across the skill (SKILL.md §2.4, surfaces/electron.md, references/common-mistakes.md, references/auth.md) and the LobeHub adapter (PROJECT.md §4, project living log):

- Login state must be **injected directly**: restore the persisted `electron-login` snapshot, or mint the session via CLI/API seeding (the `web-seed` philosophy).
- **Never trigger an interactive login/OAuth flow** on the user's behalf.
- No injectable state → report auth as ❌ Blocked and request ONE manual sign-in.

Also lands this week's env learnings in the project probe/mock living log (workspace RBAC seeding via `seedWorkspaceRoles`; duplicate `@lobehub/ui` peer-hash instances crashing the conversation route).

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Docs-only change.
