### PR TITLE
🐛 fix(chat): preserve gateway subtopic context

### DIFF
--- a/apps/server/src/routers/lambda/aiAgent.ts
+++ b/apps/server/src/routers/lambda/aiAgent.ts
@@ -211,7 +211,6 @@ const ExecAgentSchema = z
           .optional(),
         newThread: z
           .object({
-            parentThreadId: z.string().optional(),
             sourceMessageId: z.string().optional(),
             title: z.string().optional(),
             type: z.enum([ThreadType.Continuation, ThreadType.Standalone, ThreadType.Isolation]),

--- a/apps/server/src/routers/lambda/aiAgent.ts
+++ b/apps/server/src/routers/lambda/aiAgent.ts
@@ -209,6 +209,14 @@ const ExecAgentSchema = z
             workingDirectoryConfig: workingDirConfigSchema.optional(),
           })
           .optional(),
+        newThread: z
+          .object({
+            parentThreadId: z.string().optional(),
+            sourceMessageId: z.string().optional(),
+            title: z.string().optional(),
+            type: z.enum([ThreadType.Continuation, ThreadType.Standalone, ThreadType.Isolation]),
+          })
+          .optional(),
         /**
          * Group orchestration role of the run, stamped onto the assistant
          * message's `metadata.orchestrationRole` so the supervisor/member
@@ -867,6 +875,7 @@ export const aiAgentRouter = router({
         db: ctx.serverDB,
         messageIds: [
           ...existingMessageIds,
+          appContext?.newThread?.sourceMessageId,
           parentMessageId,
           resumeApproval?.parentMessageId,
           resumeToolResult?.parentMessageId,

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
@@ -7,6 +7,8 @@ const {
   mockDeviceFindWorkspaceDeviceById,
   mockDispatchAgentRun,
   mockMessageCreate,
+  mockMessageFindById,
+  mockMessageQuery,
   mockResolveAttachmentsByFileIds,
   mockSpawnHeteroSandbox,
   mockIngestAttachment,
@@ -18,6 +20,8 @@ const {
   mockDispatchAgentRun: vi.fn().mockResolvedValue({ success: true }),
   mockIngestAttachment: vi.fn(),
   mockMessageCreate: vi.fn(),
+  mockMessageFindById: vi.fn(),
+  mockMessageQuery: vi.fn(),
   mockPublishAgentRuntimeEnd: vi.fn().mockResolvedValue('end-event-id'),
   mockPublishAgentRuntimeInit: vi.fn().mockResolvedValue('init-event-id'),
   mockResolveAttachmentsByFileIds: vi.fn(),
@@ -67,9 +71,10 @@ vi.mock('@/libs/trpc/utils/internalJwt', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(() => ({
     create: mockMessageCreate,
+    findById: mockMessageFindById,
     getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
     getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
-    query: vi.fn().mockResolvedValue([]),
+    query: mockMessageQuery,
     update: vi.fn().mockResolvedValue({}),
   })),
 }));
@@ -123,7 +128,7 @@ vi.mock('@/database/models/topic', () => ({
 
 vi.mock('@/database/models/thread', () => ({
   ThreadModel: vi.fn().mockImplementation(() => ({
-    create: vi.fn(),
+    create: vi.fn().mockResolvedValue({ id: 'thread-created' }),
     findById: vi.fn(),
     update: vi.fn(),
   })),
@@ -204,6 +209,12 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
     topicMock.findById.mockResolvedValue(undefined);
     topicMock.updateMetadata.mockResolvedValue(undefined);
     mockMessageCreate.mockResolvedValue({ id: 'msg-1' });
+    mockMessageFindById.mockResolvedValue({
+      id: 'source-message-1',
+      threadId: null,
+      topicId: 'topic-1',
+    });
+    mockMessageQuery.mockResolvedValue([]);
     mockResolveAttachmentsByFileIds.mockResolvedValue({ ...emptyResolvedAttachments });
     mockSpawnHeteroSandbox.mockResolvedValue(undefined);
     mockDispatchAgentRun.mockResolvedValue({ success: true });
@@ -286,6 +297,36 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
 
     const userCall = findUserMessageCreate();
     expect(userCall![0].files).toBeUndefined();
+  });
+
+  it('returns and loads authoritative thread context for a gateway-created hetero thread', async () => {
+    mockMessageQuery.mockResolvedValue([
+      { content: 'Earlier context', id: 'source-message-1', role: 'assistant', threadId: null },
+      { content: 'Current prompt', id: 'msg-1', role: 'user', threadId: 'thread-created' },
+    ]);
+
+    const result = await service.execAgent({
+      agentId: 'agent-1',
+      appContext: {
+        newThread: {
+          sourceMessageId: 'source-message-1',
+          type: 'continuation',
+        },
+        topicId: 'topic-1',
+      },
+      existingMessageIds: ['source-message-1'],
+      prompt: 'Continue in a subtopic',
+    });
+
+    expect(result.createdThreadId).toBe('thread-created');
+    expect(mockMessageQuery).toHaveBeenCalledWith({
+      pageSize: 200,
+      threadId: 'thread-created',
+      topicId: 'topic-1',
+    });
+    expect(mockSpawnHeteroSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({ resumeSessionId: undefined }),
+    );
   });
 
   it('should pass resolved Claude Code model and effort args to sandbox dispatch', async () => {

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.threadId.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.threadId.test.ts
@@ -337,27 +337,29 @@ describe('AiAgentService.execAgent - threadId handling', () => {
       expect(mockThreadCreate).not.toHaveBeenCalled();
     });
 
-    it('rejects a threaded source when its parent thread is omitted', async () => {
+    it('infers the parent thread from a threaded source when the client omits it', async () => {
       mockMessageFindById.mockResolvedValue({
         id: 'source-message-1',
         threadId: 'parent-thread-1',
         topicId: 'topic-1',
       });
 
-      await expect(
-        service.execAgent({
-          agentId: 'agent-1',
-          appContext: {
-            newThread: {
-              sourceMessageId: 'source-message-1',
-              type: ThreadType.Continuation,
-            },
-            topicId: 'topic-1',
+      await service.execAgent({
+        agentId: 'agent-1',
+        appContext: {
+          newThread: {
+            sourceMessageId: 'source-message-1',
+            type: ThreadType.Continuation,
           },
-          prompt: 'Continue in a nested subtopic',
-        }),
-      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
-      expect(mockThreadCreate).not.toHaveBeenCalled();
+          topicId: 'topic-1',
+        },
+        prompt: 'Continue in a nested subtopic',
+      });
+
+      expect(mockThreadFindById).toHaveBeenCalledWith('parent-thread-1');
+      expect(mockThreadCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ parentThreadId: 'parent-thread-1' }),
+      );
     });
 
     it('rejects a source message from a different parent thread', async () => {

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.threadId.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.threadId.test.ts
@@ -1,11 +1,22 @@
+import { ThreadType } from '@lobechat/types';
 import type * as ModelBankModule from 'model-bank';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AiAgentService } from '../index';
 
 // Use vi.hoisted to ensure mock functions are available before vi.mock runs
-const { mockMessageCreate } = vi.hoisted(() => ({
+const {
+  mockMessageCreate,
+  mockMessageFindById,
+  mockMessageQuery,
+  mockThreadCreate,
+  mockThreadFindById,
+} = vi.hoisted(() => ({
   mockMessageCreate: vi.fn(),
+  mockMessageFindById: vi.fn(),
+  mockMessageQuery: vi.fn(),
+  mockThreadCreate: vi.fn(),
+  mockThreadFindById: vi.fn(),
 }));
 
 // Mock trusted client to avoid server-side env access
@@ -18,9 +29,10 @@ vi.mock('@/libs/trusted-client', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(() => ({
     create: mockMessageCreate,
+    findById: mockMessageFindById,
     getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
     getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
-    query: vi.fn().mockResolvedValue([]),
+    query: mockMessageQuery,
     update: vi.fn().mockResolvedValue({}),
   })),
 }));
@@ -77,8 +89,8 @@ vi.mock('@/database/models/topic', () => ({
 // Mock ThreadModel
 vi.mock('@/database/models/thread', () => ({
   ThreadModel: vi.fn().mockImplementation(() => ({
-    create: vi.fn(),
-    findById: vi.fn(),
+    create: mockThreadCreate,
+    findById: mockThreadFindById,
     update: vi.fn(),
   })),
 }));
@@ -172,6 +184,14 @@ describe('AiAgentService.execAgent - threadId handling', () => {
     // Explicitly clear the shared mock to prevent state pollution between tests
     mockMessageCreate.mockClear();
     mockMessageCreate.mockResolvedValue({ id: 'msg-1' });
+    mockMessageFindById.mockResolvedValue({
+      id: 'source-message-1',
+      threadId: null,
+      topicId: 'topic-1',
+    });
+    mockMessageQuery.mockResolvedValue([]);
+    mockThreadCreate.mockResolvedValue({ id: 'thread-created' });
+    mockThreadFindById.mockResolvedValue({ id: 'parent-thread-1', topicId: 'topic-1' });
 
     service = new AiAgentService(mockDb, userId);
   });
@@ -225,6 +245,143 @@ describe('AiAgentService.execAgent - threadId handling', () => {
         threadId: 'thread-123',
         topicId: 'topic-1',
       });
+    });
+  });
+
+  describe('when newThread is provided in appContext', () => {
+    it('creates the thread before persisting both messages in its scope', async () => {
+      const result = await service.execAgent({
+        agentId: 'agent-1',
+        appContext: {
+          newThread: {
+            sourceMessageId: 'source-message-1',
+            type: ThreadType.Continuation,
+          },
+          topicId: 'topic-1',
+        },
+        existingMessageIds: ['source-message-1'],
+        prompt: 'Continue in a subtopic',
+      });
+
+      expect(mockThreadCreate).toHaveBeenCalledWith({
+        parentThreadId: undefined,
+        sourceMessageId: 'source-message-1',
+        title: undefined,
+        topicId: 'topic-1',
+        type: ThreadType.Continuation,
+      });
+
+      const userMessageCall = mockMessageCreate.mock.calls.find((call) => call[0].role === 'user');
+      const assistantMessageCall = mockMessageCreate.mock.calls.find(
+        (call) => call[0].role === 'assistant',
+      );
+      expect(userMessageCall![0].threadId).toBe('thread-created');
+      expect(userMessageCall![0].parentId).toBe('source-message-1');
+      expect(assistantMessageCall![0].threadId).toBe('thread-created');
+      expect(result.createdThreadId).toBe('thread-created');
+      expect(mockMessageQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ threadId: 'thread-created', topicId: 'topic-1' }),
+        expect.any(Object),
+      );
+    });
+
+    it('creates a source-less standalone thread with a root user message', async () => {
+      await service.execAgent({
+        agentId: 'agent-1',
+        appContext: {
+          newThread: { type: ThreadType.Standalone },
+          topicId: 'topic-1',
+        },
+        prompt: 'Start a standalone subtopic',
+      });
+
+      const userMessageCall = mockMessageCreate.mock.calls.find((call) => call[0].role === 'user');
+      expect(userMessageCall![0].parentId).toBeUndefined();
+    });
+
+    it('rejects a source message from another topic before creating the thread', async () => {
+      mockMessageFindById.mockResolvedValue({ id: 'source-message-1', topicId: 'other-topic' });
+
+      await expect(
+        service.execAgent({
+          agentId: 'agent-1',
+          appContext: {
+            newThread: {
+              sourceMessageId: 'source-message-1',
+              type: ThreadType.Continuation,
+            },
+            topicId: 'topic-1',
+          },
+          prompt: 'Continue in a subtopic',
+        }),
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+      expect(mockThreadCreate).not.toHaveBeenCalled();
+    });
+
+    it('rejects a parent thread from another topic before creating the thread', async () => {
+      mockThreadFindById.mockResolvedValue({ id: 'parent-thread-1', topicId: 'other-topic' });
+
+      await expect(
+        service.execAgent({
+          agentId: 'agent-1',
+          appContext: {
+            newThread: {
+              parentThreadId: 'parent-thread-1',
+              type: ThreadType.Isolation,
+            },
+            topicId: 'topic-1',
+          },
+          prompt: 'Start a nested subtopic',
+        }),
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+      expect(mockThreadCreate).not.toHaveBeenCalled();
+    });
+
+    it('rejects a threaded source when its parent thread is omitted', async () => {
+      mockMessageFindById.mockResolvedValue({
+        id: 'source-message-1',
+        threadId: 'parent-thread-1',
+        topicId: 'topic-1',
+      });
+
+      await expect(
+        service.execAgent({
+          agentId: 'agent-1',
+          appContext: {
+            newThread: {
+              sourceMessageId: 'source-message-1',
+              type: ThreadType.Continuation,
+            },
+            topicId: 'topic-1',
+          },
+          prompt: 'Continue in a nested subtopic',
+        }),
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+      expect(mockThreadCreate).not.toHaveBeenCalled();
+    });
+
+    it('rejects a source message from a different parent thread', async () => {
+      mockMessageFindById.mockResolvedValue({
+        id: 'source-message-1',
+        threadId: 'other-parent-thread',
+        topicId: 'topic-1',
+      });
+
+      await expect(
+        service.execAgent({
+          agentId: 'agent-1',
+          appContext: {
+            newThread: {
+              parentThreadId: 'parent-thread-1',
+              sourceMessageId: 'source-message-1',
+              type: ThreadType.Continuation,
+            },
+            topicId: 'topic-1',
+          },
+          prompt: 'Continue in a nested subtopic',
+        }),
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+      expect(mockThreadCreate).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.threadId.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.threadId.test.ts
@@ -5,19 +5,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AiAgentService } from '../index';
 
 // Use vi.hoisted to ensure mock functions are available before vi.mock runs
-const {
-  mockMessageCreate,
-  mockMessageFindById,
-  mockMessageQuery,
-  mockThreadCreate,
-  mockThreadFindById,
-} = vi.hoisted(() => ({
-  mockMessageCreate: vi.fn(),
-  mockMessageFindById: vi.fn(),
-  mockMessageQuery: vi.fn(),
-  mockThreadCreate: vi.fn(),
-  mockThreadFindById: vi.fn(),
-}));
+const { mockMessageCreate, mockMessageFindById, mockMessageQuery, mockThreadCreate } = vi.hoisted(
+  () => ({
+    mockMessageCreate: vi.fn(),
+    mockMessageFindById: vi.fn(),
+    mockMessageQuery: vi.fn(),
+    mockThreadCreate: vi.fn(),
+  }),
+);
 
 // Mock trusted client to avoid server-side env access
 vi.mock('@/libs/trusted-client', () => ({
@@ -90,7 +85,6 @@ vi.mock('@/database/models/topic', () => ({
 vi.mock('@/database/models/thread', () => ({
   ThreadModel: vi.fn().mockImplementation(() => ({
     create: mockThreadCreate,
-    findById: mockThreadFindById,
     update: vi.fn(),
   })),
 }));
@@ -191,7 +185,6 @@ describe('AiAgentService.execAgent - threadId handling', () => {
     });
     mockMessageQuery.mockResolvedValue([]);
     mockThreadCreate.mockResolvedValue({ id: 'thread-created' });
-    mockThreadFindById.mockResolvedValue({ id: 'parent-thread-1', topicId: 'topic-1' });
 
     service = new AiAgentService(mockDb, userId);
   });
@@ -318,63 +311,18 @@ describe('AiAgentService.execAgent - threadId handling', () => {
       expect(mockThreadCreate).not.toHaveBeenCalled();
     });
 
-    it('rejects a parent thread from another topic before creating the thread', async () => {
-      mockThreadFindById.mockResolvedValue({ id: 'parent-thread-1', topicId: 'other-topic' });
-
-      await expect(
-        service.execAgent({
-          agentId: 'agent-1',
-          appContext: {
-            newThread: {
-              parentThreadId: 'parent-thread-1',
-              type: ThreadType.Isolation,
-            },
-            topicId: 'topic-1',
-          },
-          prompt: 'Start a nested subtopic',
-        }),
-      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
-      expect(mockThreadCreate).not.toHaveBeenCalled();
-    });
-
-    it('infers the parent thread from a threaded source when the client omits it', async () => {
+    it('rejects branching from a message inside an existing thread', async () => {
       mockMessageFindById.mockResolvedValue({
         id: 'source-message-1',
         threadId: 'parent-thread-1',
         topicId: 'topic-1',
       });
 
-      await service.execAgent({
-        agentId: 'agent-1',
-        appContext: {
-          newThread: {
-            sourceMessageId: 'source-message-1',
-            type: ThreadType.Continuation,
-          },
-          topicId: 'topic-1',
-        },
-        prompt: 'Continue in a nested subtopic',
-      });
-
-      expect(mockThreadFindById).toHaveBeenCalledWith('parent-thread-1');
-      expect(mockThreadCreate).toHaveBeenCalledWith(
-        expect.objectContaining({ parentThreadId: 'parent-thread-1' }),
-      );
-    });
-
-    it('rejects a source message from a different parent thread', async () => {
-      mockMessageFindById.mockResolvedValue({
-        id: 'source-message-1',
-        threadId: 'other-parent-thread',
-        topicId: 'topic-1',
-      });
-
       await expect(
         service.execAgent({
           agentId: 'agent-1',
           appContext: {
             newThread: {
-              parentThreadId: 'parent-thread-1',
               sourceMessageId: 'source-message-1',
               type: ThreadType.Continuation,
             },
@@ -384,6 +332,7 @@ describe('AiAgentService.execAgent - threadId handling', () => {
         }),
       ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
       expect(mockThreadCreate).not.toHaveBeenCalled();
+      expect(mockMessageCreate).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1579,6 +1579,8 @@ export class AiAgentService {
 
     // 3. Handle topic creation: if no topicId provided, create a new topic; otherwise reuse existing
     let topicId = appContext?.topicId;
+    let threadId = appContext?.threadId ?? undefined;
+    let createdThreadId: string | undefined;
     const isNewTopic = !topicId;
     const isFixedExecutionTargetSelection =
       !!this.workspaceId && agentConfig.agencyConfig?.executionTargetSelectionPolicy === 'fixed';
@@ -1645,6 +1647,47 @@ export class AiAgentService {
       );
     } else {
       log('execAgent: reusing existing topic %s', topicId);
+    }
+
+    if (appContext?.newThread) {
+      const { parentThreadId, sourceMessageId } = appContext.newThread;
+      const sourceMessage = sourceMessageId
+        ? await this.messageModel.findById(sourceMessageId)
+        : undefined;
+      if (sourceMessageId && (!sourceMessage || sourceMessage.topicId !== topicId)) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Thread source message does not belong to the target topic',
+        });
+      }
+      if (parentThreadId) {
+        const parentThread = await this.threadModel.findById(parentThreadId);
+        if (!parentThread || parentThread.topicId !== topicId) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Parent thread does not belong to the target topic',
+          });
+        }
+      }
+      if (sourceMessage && (sourceMessage.threadId ?? undefined) !== parentThreadId) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Thread source message does not belong to the parent thread',
+        });
+      }
+
+      const thread = await this.threadModel.create({
+        parentThreadId,
+        sourceMessageId,
+        title: appContext.newThread.title,
+        topicId,
+        type: appContext.newThread.type,
+      });
+      if (!thread) throw new Error('Failed to create thread for agent execution');
+
+      threadId = thread.id;
+      createdThreadId = thread.id;
+      log('execAgent: created thread %s for topic %s', threadId, topicId);
     }
 
     await throwIfExecutionAborted('topic setup');
@@ -1721,12 +1764,19 @@ export class AiAgentService {
     const resolveUserMessageParentId = async () => {
       if (runFromHistory) return undefined;
       if (parentMessageId) return parentMessageId;
+      if (appContext?.newThread) return appContext.newThread.sourceMessageId;
 
-      const threadId = appContext?.threadId ?? null;
-      const spineId = await this.messageModel.getLatestSpineMessageId({ threadId, topicId });
+      const historyThreadId = threadId ?? null;
+      const spineId = await this.messageModel.getLatestSpineMessageId({
+        threadId: historyThreadId,
+        topicId,
+      });
       if (spineId) return spineId;
 
-      const fallbackId = await this.messageModel.getLatestNonToolMessageId({ threadId, topicId });
+      const fallbackId = await this.messageModel.getLatestNonToolMessageId({
+        threadId: historyThreadId,
+        topicId,
+      });
       if (fallbackId) {
         log(
           'execAgent: no spine head for topic %s, anchoring user turn on latest non-tool message %s',
@@ -1750,7 +1800,7 @@ export class AiAgentService {
           metadata: requestTriggerMetadata,
           parentId: userMessageParentId,
           role: 'user',
-          threadId: appContext?.threadId ?? undefined,
+          threadId,
           topicId,
         });
     if (userMessageRecord) {
@@ -1789,7 +1839,7 @@ export class AiAgentService {
       parentId: userMessageRecord?.id ?? parentMessageId,
       provider: isHeteroAgent ? heteroType : provider,
       role: 'assistant',
-      threadId: appContext?.threadId ?? undefined,
+      threadId,
       topicId,
     });
     selfMessageIds.add(assistantMessageRecord.id);
@@ -1811,7 +1861,7 @@ export class AiAgentService {
             agentId: resolvedAgentId,
             message: prompt,
             messageId: userMessageRecord.id,
-            threadId: appContext?.threadId ?? undefined,
+            threadId,
             topicId,
             trigger,
           },
@@ -1866,7 +1916,7 @@ export class AiAgentService {
           parentOperationId,
           provider: heteroType,
           taskId: operationTaskId ?? null,
-          threadId: appContext?.threadId ?? null,
+          threadId: threadId ?? null,
           topicId,
           trigger,
         });
@@ -1878,7 +1928,12 @@ export class AiAgentService {
       const heteroService = new HeterogeneousAgentService(this.db, this.userId, {
         workspaceId: this.workspaceId,
       });
-      const resumeSessionId = await heteroService.getHeterogeneousResumeSessionId(topicId);
+      // A newly-created thread is a distinct conversation scope. Reusing the
+      // topic-level native CLI session would restore context from the main
+      // conversation and bypass the thread's continuation/standalone semantics.
+      const resumeSessionId = appContext?.newThread
+        ? undefined
+        : await heteroService.getHeterogeneousResumeSessionId(topicId);
       // Sign an operation-scoped JWT so the CLI can authenticate against
       // heteroIngest / heteroFinish without full user credentials.
       let operationJwt: string;
@@ -1920,17 +1975,23 @@ export class AiAgentService {
       // When resuming, inject the recent conversation turns as context so CC can
       // orient itself even if the native session file was cleared (sandbox recycled
       // or context overflow caused the CLI to start a fresh session).
-      // Only fetch when there IS a stored session id — for first-turn runs CC has
-      // no prior history to inject.
+      // A resumed main-topic run gets fallback context for a missing native
+      // session file. A newly-created thread always gets its authoritative
+      // parent history because its native session intentionally starts fresh.
       let conversationHistory: ConversationHistoryEntry[] | undefined;
-      if (resumeSessionId) {
+      if (resumeSessionId || (appContext?.newThread && threadId)) {
         try {
-          const recentMsgs = await this.messageModel.query({ topicId, pageSize: 200 });
+          const recentMsgs = await this.messageModel.query({
+            pageSize: 200,
+            threadId: appContext?.newThread ? threadId : undefined,
+            topicId,
+          });
           const turns = recentMsgs
             .filter(
               (m) =>
                 (m.role === 'user' || m.role === 'assistant') &&
-                !m.threadId &&
+                !selfMessageIds.has(m.id) &&
+                (appContext?.newThread || !m.threadId) &&
                 m.content &&
                 m.content !== LOADING_FLAT,
             )
@@ -2015,7 +2076,7 @@ export class AiAgentService {
             : undefined),
           operationId,
           scope: appContext?.scope ?? undefined,
-          threadId: appContext?.threadId ?? undefined,
+          threadId,
         },
       });
 
@@ -2046,6 +2107,7 @@ export class AiAgentService {
             assistantMessageId: assistantMessageRecord.id,
             autoStarted: false,
             createdAt: new Date().toISOString(),
+            createdThreadId,
             error: 'Device access denied',
             message: 'Remote hetero agent requires device access',
             operationId,
@@ -2071,6 +2133,7 @@ export class AiAgentService {
             assistantMessageId: assistantMessageRecord.id,
             autoStarted: false,
             createdAt: new Date().toISOString(),
+            createdThreadId,
             error: 'No bound device',
             message: 'Remote hetero agent requires boundDeviceId',
             operationId,
@@ -2136,6 +2199,7 @@ export class AiAgentService {
             assistantMessageId: assistantMessageRecord.id,
             autoStarted: false,
             createdAt: new Date().toISOString(),
+            createdThreadId,
             error: result.error,
             message: 'Remote hetero agent dispatch failed',
             operationId,
@@ -2220,6 +2284,7 @@ export class AiAgentService {
               assistantMessageId: assistantMessageRecord.id,
               autoStarted: false,
               createdAt: new Date().toISOString(),
+              createdThreadId,
               error: 'No bound device',
               message: 'Hetero agent requires a bound device',
               operationId,
@@ -2301,6 +2366,7 @@ export class AiAgentService {
               assistantMessageId: assistantMessageRecord.id,
               autoStarted: false,
               createdAt: new Date().toISOString(),
+              createdThreadId,
               error: result.error,
               message: 'Hetero agent device dispatch failed',
               operationId,
@@ -2327,6 +2393,7 @@ export class AiAgentService {
               assistantMessageId: assistantMessageRecord.id,
               autoStarted: false,
               createdAt: new Date().toISOString(),
+              createdThreadId,
               error: message,
               message,
               operationId,
@@ -2393,6 +2460,7 @@ export class AiAgentService {
         assistantMessageId: assistantMessageRecord.id,
         autoStarted: true,
         createdAt: new Date().toISOString(),
+        createdThreadId,
         message: 'Hetero agent dispatched successfully',
         operationId,
         status: 'created',
@@ -2489,11 +2557,26 @@ export class AiAgentService {
     const loadHistoryMessages = async () => {
       if (historyMessagesCache) return historyMessagesCache;
 
-      if (existingMessageIds.length > 0) {
+      if (appContext?.newThread && threadId) {
+        // The persisted thread is the source of truth for parent-history
+        // semantics: continuation includes the main spine through its source,
+        // standalone includes only its source, and isolation/source-less
+        // threads include no parent messages. Do not trust a caller-supplied ID
+        // list to decide the new thread's context.
+        const messages = await this.messageModel.query(
+          {
+            sessionId: appContext.sessionId,
+            threadId,
+            topicId,
+          },
+          { postProcessUrl },
+        );
+        historyMessagesCache = messages.filter((msg) => !selfMessageIds.has(msg.id));
+      } else if (existingMessageIds.length > 0) {
         const messages = await this.messageModel.query(
           {
             sessionId: appContext?.sessionId,
-            threadId: appContext?.threadId,
+            threadId,
             topicId: appContext?.topicId ?? undefined,
           },
           { postProcessUrl },
@@ -2508,7 +2591,7 @@ export class AiAgentService {
         const messages = await this.messageModel.query(
           {
             sessionId: appContext?.sessionId,
-            threadId: appContext?.threadId,
+            threadId,
             topicId: appContext?.topicId,
           },
           { postProcessUrl },
@@ -2546,7 +2629,7 @@ export class AiAgentService {
         appContext?.topicId
       ) {
         const tree = await this.messageModel.queryTopicMessageTree({
-          threadId: appContext.threadId,
+          threadId,
           topicId: appContext.topicId,
         });
         historyMessagesCache = pruneRegeneratedBranch(historyMessagesCache, tree, parentMessageId);
@@ -2923,7 +3006,12 @@ export class AiAgentService {
           },
         });
         throw new TRPCError({
-          cause: { data: { code: 'FixedAgentDeviceUnavailable' } },
+          cause: {
+            data: {
+              code: 'FixedAgentDeviceUnavailable',
+              createdThreadId,
+            },
+          },
           code: 'PRECONDITION_FAILED',
           message: detail,
         });
@@ -4013,7 +4101,7 @@ export class AiAgentService {
           // loop can stream its running totals down the parent's gateway channel.
           subAgentProgress: appContext?.subAgentProgress,
           taskId: operationTaskId,
-          threadId: appContext?.threadId,
+          threadId,
           topicId,
           trigger,
         },
@@ -4058,7 +4146,7 @@ export class AiAgentService {
           assistantMessageId: assistantMessageRecord.id,
           operationId,
           scope: appContext?.scope ?? undefined,
-          threadId: appContext?.threadId ?? undefined,
+          threadId,
         },
       });
 
@@ -4075,6 +4163,7 @@ export class AiAgentService {
         assistantMessageId: assistantMessageRecord.id,
         autoStarted: result.autoStarted,
         createdAt: new Date().toISOString(),
+        createdThreadId,
         message: 'Agent operation created successfully',
         messageId: result.messageId,
         operationId,
@@ -4117,6 +4206,7 @@ export class AiAgentService {
         assistantMessageId: assistantMessageRecord.id,
         autoStarted: false,
         createdAt: new Date().toISOString(),
+        createdThreadId,
         error: errorMessage,
         message: 'Agent operation failed to start',
         operationId,

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1650,7 +1650,7 @@ export class AiAgentService {
     }
 
     if (appContext?.newThread) {
-      const { parentThreadId: requestedParentThreadId, sourceMessageId } = appContext.newThread;
+      const { sourceMessageId } = appContext.newThread;
       const sourceMessage = sourceMessageId
         ? await this.messageModel.findById(sourceMessageId)
         : undefined;
@@ -1660,32 +1660,18 @@ export class AiAgentService {
           message: 'Thread source message does not belong to the target topic',
         });
       }
-      // The current thread UI only carries the source message when forking.
-      // Derive its parent thread from that server-authoritative message while
-      // still rejecting callers that explicitly provide a contradictory one.
-      const parentThreadId = requestedParentThreadId ?? sourceMessage?.threadId ?? undefined;
-      if (parentThreadId) {
-        const parentThread = await this.threadModel.findById(parentThreadId);
-        if (!parentThread || parentThread.topicId !== topicId) {
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: 'Parent thread does not belong to the target topic',
-          });
-        }
-      }
-      if (
-        sourceMessage &&
-        requestedParentThreadId !== undefined &&
-        (sourceMessage.threadId ?? undefined) !== requestedParentThreadId
-      ) {
+      // User-created threads branch from the main topic only. Nested thread
+      // ancestry is not part of MessageModel's history contract: continuation
+      // history deliberately walks the main-topic spine, not parentThreadId.
+      if (sourceMessage?.threadId) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
-          message: 'Thread source message does not belong to the parent thread',
+          message: 'Nested thread branching is not supported',
         });
       }
 
       const thread = await this.threadModel.create({
-        parentThreadId,
+        parentThreadId: undefined,
         sourceMessageId,
         title: appContext.newThread.title,
         topicId,

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1650,7 +1650,7 @@ export class AiAgentService {
     }
 
     if (appContext?.newThread) {
-      const { parentThreadId, sourceMessageId } = appContext.newThread;
+      const { parentThreadId: requestedParentThreadId, sourceMessageId } = appContext.newThread;
       const sourceMessage = sourceMessageId
         ? await this.messageModel.findById(sourceMessageId)
         : undefined;
@@ -1660,6 +1660,10 @@ export class AiAgentService {
           message: 'Thread source message does not belong to the target topic',
         });
       }
+      // The current thread UI only carries the source message when forking.
+      // Derive its parent thread from that server-authoritative message while
+      // still rejecting callers that explicitly provide a contradictory one.
+      const parentThreadId = requestedParentThreadId ?? sourceMessage?.threadId ?? undefined;
       if (parentThreadId) {
         const parentThread = await this.threadModel.findById(parentThreadId);
         if (!parentThread || parentThread.topicId !== topicId) {
@@ -1669,7 +1673,11 @@ export class AiAgentService {
           });
         }
       }
-      if (sourceMessage && (sourceMessage.threadId ?? undefined) !== parentThreadId) {
+      if (
+        sourceMessage &&
+        requestedParentThreadId !== undefined &&
+        (sourceMessage.threadId ?? undefined) !== requestedParentThreadId
+      ) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: 'Thread source message does not belong to the parent thread',

--- a/packages/types/src/agentExecution/index.ts
+++ b/packages/types/src/agentExecution/index.ts
@@ -102,7 +102,6 @@ export interface ExecAgentAppContext {
    * the server instead of through the client aiChat path.
    */
   newThread?: {
-    parentThreadId?: string;
     sourceMessageId?: string;
     title?: string;
     type: ChatThreadType;

--- a/packages/types/src/agentExecution/index.ts
+++ b/packages/types/src/agentExecution/index.ts
@@ -1,6 +1,7 @@
 import type { WorkingDirConfig } from '../device';
 import type { TaskDetail, UIChatMessage } from '../message';
 import type { ChatTopic } from '../topic';
+import type { ChatThreadType } from '../topic/thread';
 
 export type AgentSignalOperationKind =
   'memory' | 'nightly-review' | 'self-feedback-intent' | 'self-reflection' | 'skill';
@@ -95,6 +96,17 @@ export interface ExecAgentAppContext {
    * recursive sub-agent dispatch.
    */
   isSubAgent?: boolean;
+  /**
+   * Create a thread before persisting this run's messages. Used by gateway
+   * executions, where message persistence and runtime startup both happen on
+   * the server instead of through the client aiChat path.
+   */
+  newThread?: {
+    parentThreadId?: string;
+    sourceMessageId?: string;
+    title?: string;
+    type: ChatThreadType;
+  };
   /**
    * Orchestration role of the agent for this group run. `'supervisor'` for the
    * group's coordinating agent (execGroupAgent), `'member'` for delegated members
@@ -238,6 +250,8 @@ export interface ExecAgentResult {
   autoStarted: boolean;
   /** Timestamp when operation was created */
   createdAt: string;
+  /** The thread created for this operation, when requested */
+  createdThreadId?: string;
   /** Error message if operation failed to start */
   error?: string;
   /** Status message */

--- a/src/features/Conversation/Messages/components/MessageActionBar/actions/branching.test.ts
+++ b/src/features/Conversation/Messages/components/MessageActionBar/actions/branching.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import type { UIChatMessage } from '@lobechat/types';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MessageActionContext } from '../types';
+import { branchingAction } from './branching';
+
+const openThreadCreator = vi.fn();
+const warning = vi.fn();
+
+vi.mock('@/store/chat', () => ({
+  useChatStore: (selector: (state: any) => any) =>
+    selector({ activeTopicId: 'topic-1', openThreadCreator }),
+}));
+
+vi.mock('antd', () => ({
+  App: { useApp: () => ({ message: { warning } }) },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const build = (data: Partial<UIChatMessage>) =>
+  renderHook(() =>
+    branchingAction.useBuild({
+      data: data as UIChatMessage,
+      id: 'message-1',
+      role: 'assistant' as MessageActionContext['role'],
+    }),
+  ).result.current;
+
+describe('branchingAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens the thread creator for a main-topic message', () => {
+    build({})!.handleClick!();
+
+    expect(openThreadCreator).toHaveBeenCalledWith('message-1');
+  });
+
+  it('is unavailable for a message that already belongs to a thread', () => {
+    expect(build({ threadId: 'thread-1' })).toBeNull();
+    expect(openThreadCreator).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/Conversation/Messages/components/MessageActionBar/actions/branching.ts
+++ b/src/features/Conversation/Messages/components/MessageActionBar/actions/branching.ts
@@ -14,7 +14,7 @@ export const branchingAction = defineAction({
     const { message } = App.useApp();
     const [topic, openThreadCreator] = useChatStore((s) => [s.activeTopicId, s.openThreadCreator]);
 
-    return useMemo(
+    const action = useMemo(
       () => ({
         handleClick: () => {
           if (!topic) {
@@ -29,5 +29,9 @@ export const branchingAction = defineAction({
       }),
       [t, ctx.id, topic, openThreadCreator, message],
     );
+
+    // User-created threads branch from main-topic messages only. The message
+    // history model does not define recursive ancestry for nested threads.
+    return ctx.data.threadId ? null : action;
   },
 });

--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
@@ -1545,7 +1545,6 @@ describe('ConversationLifecycle actions', () => {
 
         expect(executeGatewayAgent).toHaveBeenCalledWith(
           expect.objectContaining({
-            existingMessageIds: ['source-message-1'],
             newThread: {
               sourceMessageId: 'source-message-1',
               type: 'continuation',

--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
@@ -9,6 +9,7 @@ import { chatService } from '@/services/chat';
 import { messageService } from '@/services/message';
 import * as agentGroupStore from '@/store/agentGroup';
 import { setPendingTopicRepos } from '@/store/chat/pendingTopicRepos';
+import { PortalViewType } from '@/store/chat/slices/portal/initialState';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 import { topicMapKey } from '@/store/chat/utils/topicMapKey';
 import { getSessionStoreState } from '@/store/session';
@@ -1484,6 +1485,122 @@ describe('ConversationLifecycle actions', () => {
             context: expect.not.objectContaining({ documentId: expect.anything() }),
           }),
         );
+      });
+    });
+
+    describe('gateway thread creation', () => {
+      it('forwards the staged thread request and returns the created thread id', async () => {
+        const { result } = renderHook(() => useChatStore());
+        const executeGatewayAgent = vi.fn().mockResolvedValue({
+          assistantMessageId: TEST_IDS.ASSISTANT_MESSAGE_ID,
+          createdThreadId: 'thread-created',
+          operationId: 'op-thread',
+          topicId: TEST_IDS.TOPIC_ID,
+          userMessageId: TEST_IDS.USER_MESSAGE_ID,
+        });
+
+        act(() => {
+          useChatStore.setState({
+            executeGatewayAgent,
+            isGatewayModeEnabled: () => true,
+          });
+        });
+
+        let sendResult;
+        await act(async () => {
+          sendResult = await result.current.sendMessage({
+            context: {
+              agentId: TEST_IDS.SESSION_ID,
+              isNew: true,
+              scope: 'thread',
+              sourceMessageId: 'source-message-1',
+              threadType: 'continuation',
+              topicId: TEST_IDS.TOPIC_ID,
+            },
+            message: 'Continue in a subtopic',
+            messages: [createMockMessage({ id: 'source-message-1', role: 'assistant' })],
+          });
+        });
+
+        expect(executeGatewayAgent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            existingMessageIds: ['source-message-1'],
+            newThread: {
+              sourceMessageId: 'source-message-1',
+              type: 'continuation',
+            },
+          }),
+        );
+        expect(sendResult).toEqual({
+          assistantMessageId: TEST_IDS.ASSISTANT_MESSAGE_ID,
+          createdThreadId: 'thread-created',
+          userMessageId: TEST_IDS.USER_MESSAGE_ID,
+        });
+      });
+
+      it('switches the staged portal to a server-created thread when gateway startup fails', async () => {
+        const { result } = renderHook(() => useChatStore());
+        const stagedThreadKey = messageMapKey({
+          agentId: TEST_IDS.SESSION_ID,
+          isNew: true,
+          scope: 'thread',
+          topicId: TEST_IDS.TOPIC_ID,
+        });
+        const createdThreadKey = messageMapKey({
+          agentId: TEST_IDS.SESSION_ID,
+          isNew: true,
+          scope: 'thread',
+          threadId: 'thread-created',
+          topicId: TEST_IDS.TOPIC_ID,
+        });
+        const queuedMessage = {
+          content: 'queued while the gateway request was starting',
+          createdAt: Date.now(),
+          id: 'queued-before-thread-created',
+          interruptMode: 'soft' as const,
+        };
+        const gatewayError = Object.assign(new Error('Fixed agent device unavailable'), {
+          data: {
+            errorData: {
+              code: 'FixedAgentDeviceUnavailable',
+              createdThreadId: 'thread-created',
+            },
+          },
+        });
+
+        act(() => {
+          useChatStore.setState({
+            executeGatewayAgent: vi.fn().mockRejectedValue(gatewayError),
+            isGatewayModeEnabled: () => true,
+            portalStack: [{ startMessageId: 'source-message-1', type: PortalViewType.Thread }],
+            queuedMessages: { [stagedThreadKey]: [queuedMessage] },
+          });
+        });
+
+        await act(async () => {
+          await result.current.sendMessage({
+            context: {
+              agentId: TEST_IDS.SESSION_ID,
+              isNew: true,
+              scope: 'thread',
+              sourceMessageId: 'source-message-1',
+              threadType: 'continuation',
+              topicId: TEST_IDS.TOPIC_ID,
+            },
+            message: 'Continue in a subtopic',
+            messages: [createMockMessage({ id: 'source-message-1', role: 'assistant' })],
+          });
+        });
+
+        expect(result.current.portalThreadId).toBe('thread-created');
+        expect(result.current.startToForkThread).toBe(false);
+        expect(result.current.queuedMessages[stagedThreadKey] ?? []).toEqual([]);
+        expect(result.current.queuedMessages[createdThreadKey]).toEqual([queuedMessage]);
+        expect(result.current.portalStack.at(-1)).toMatchObject({
+          startMessageId: 'source-message-1',
+          threadId: 'thread-created',
+          type: 'thread',
+        });
       });
     });
 

--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
@@ -1491,6 +1491,25 @@ describe('ConversationLifecycle actions', () => {
     describe('gateway thread creation', () => {
       it('forwards the staged thread request and returns the created thread id', async () => {
         const { result } = renderHook(() => useChatStore());
+        const stagedThreadKey = messageMapKey({
+          agentId: TEST_IDS.SESSION_ID,
+          isNew: true,
+          scope: 'thread',
+          topicId: TEST_IDS.TOPIC_ID,
+        });
+        const createdThreadKey = messageMapKey({
+          agentId: TEST_IDS.SESSION_ID,
+          isNew: true,
+          scope: 'thread',
+          threadId: 'thread-created',
+          topicId: TEST_IDS.TOPIC_ID,
+        });
+        const queuedMessage = {
+          content: 'queued while the gateway request was starting',
+          createdAt: Date.now(),
+          id: 'queued-before-thread-created',
+          interruptMode: 'soft' as const,
+        };
         const executeGatewayAgent = vi.fn().mockResolvedValue({
           assistantMessageId: TEST_IDS.ASSISTANT_MESSAGE_ID,
           createdThreadId: 'thread-created',
@@ -1503,6 +1522,8 @@ describe('ConversationLifecycle actions', () => {
           useChatStore.setState({
             executeGatewayAgent,
             isGatewayModeEnabled: () => true,
+            portalStack: [{ startMessageId: 'source-message-1', type: PortalViewType.Thread }],
+            queuedMessages: { [stagedThreadKey]: [queuedMessage] },
           });
         });
 
@@ -1535,6 +1556,15 @@ describe('ConversationLifecycle actions', () => {
           assistantMessageId: TEST_IDS.ASSISTANT_MESSAGE_ID,
           createdThreadId: 'thread-created',
           userMessageId: TEST_IDS.USER_MESSAGE_ID,
+        });
+        expect(result.current.portalThreadId).toBe('thread-created');
+        expect(result.current.startToForkThread).toBe(false);
+        expect(result.current.queuedMessages[stagedThreadKey] ?? []).toEqual([]);
+        expect(result.current.queuedMessages[createdThreadKey]).toEqual([queuedMessage]);
+        expect(result.current.portalStack.at(-1)).toMatchObject({
+          startMessageId: 'source-message-1',
+          threadId: 'thread-created',
+          type: PortalViewType.Thread,
         });
       });
 

--- a/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
@@ -648,6 +648,62 @@ describe('GatewayActionImpl', () => {
       );
     });
 
+    it('should forward new thread context and use the created thread for the gateway operation', async () => {
+      const { action, startOperation } = createExecuteTestAction();
+
+      vi.mocked(aiAgentService.execAgentTask).mockResolvedValue({
+        agentId: 'agent-1',
+        assistantMessageId: 'ast-1',
+        autoStarted: true,
+        createdAt: new Date().toISOString(),
+        createdThreadId: 'thread-created',
+        message: 'ok',
+        operationId: 'server-op-1',
+        status: 'created',
+        success: true,
+        timestamp: new Date().toISOString(),
+        token: 'test-token',
+        topicId: 'topic-1',
+        userMessageId: 'usr-1',
+      });
+
+      const result = await action.executeGatewayAgent({
+        context: {
+          agentId: 'agent-1',
+          isNew: true,
+          scope: 'thread',
+          topicId: 'topic-1',
+        },
+        existingMessageIds: ['source-message-1'],
+        message: 'Continue in a subtopic',
+        newThread: {
+          sourceMessageId: 'source-message-1',
+          type: 'continuation',
+        },
+      });
+
+      expect(aiAgentService.execAgentTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appContext: expect.objectContaining({
+            newThread: {
+              sourceMessageId: 'source-message-1',
+              type: 'continuation',
+            },
+            threadId: undefined,
+            topicId: 'topic-1',
+          }),
+          existingMessageIds: ['source-message-1'],
+        }),
+        expect.anything(),
+      );
+      expect(startOperation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: expect.objectContaining({ threadId: 'thread-created', topicId: 'topic-1' }),
+        }),
+      );
+      expect(result.createdThreadId).toBe('thread-created');
+    });
+
     it('should move queued follow-ups from the new-topic key to the server-created topic key', async () => {
       const { action, moveQueuedMessages } = createExecuteTestAction();
       const context = { agentId: 'agent-1', topicId: null, threadId: null };

--- a/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
@@ -674,7 +674,6 @@ describe('GatewayActionImpl', () => {
           scope: 'thread',
           topicId: 'topic-1',
         },
-        existingMessageIds: ['source-message-1'],
         message: 'Continue in a subtopic',
         newThread: {
           sourceMessageId: 'source-message-1',
@@ -692,7 +691,6 @@ describe('GatewayActionImpl', () => {
             threadId: undefined,
             topicId: 'topic-1',
           }),
-          existingMessageIds: ['source-message-1'],
         }),
         expect.anything(),
       );

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -1065,6 +1065,7 @@ export class ConversationLifecycleActionImpl {
         // and the send button would flicker back to "send".
         const result = await this.#get().executeGatewayAgent({
           context: operationContext,
+          existingMessageIds: newThread ? messages.map((item) => item.id) : undefined,
           fileIds: fileIdList,
           message,
           metadata: requestMetadata,
@@ -1083,6 +1084,7 @@ export class ConversationLifecycleActionImpl {
           // reaches here). Non-group only — group @member mentions are handled by
           // the group orchestration path, not agent-management delegation.
           mentionedAgents: hasMentionedAgents ? mentionedAgents : undefined,
+          newThread,
           // Pass temp message IDs so the UI doesn't show a blank loading
           // state while waiting for the first step_start event to replace
           // messages with the server's real IDs.
@@ -1125,6 +1127,7 @@ export class ConversationLifecycleActionImpl {
 
         return {
           assistantMessageId: result.assistantMessageId,
+          createdThreadId: result.createdThreadId,
           userMessageId: result.userMessageId,
         };
       } catch (e) {
@@ -1135,6 +1138,24 @@ export class ConversationLifecycleActionImpl {
         if (op?.status === 'cancelled') {
           rollbackOptimisticTopic('sendMessage/rollbackOptimisticTopic');
           return;
+        }
+
+        const errorThreadId = (e as { data?: { errorData?: { createdThreadId?: unknown } } }).data
+          ?.errorData?.createdThreadId;
+        if (typeof errorThreadId === 'string') {
+          this.#get().updateOperationMetadata(operationId, { createdThreadId: errorThreadId });
+          this.#get().moveQueuedMessages(
+            currentContextKey,
+            messageMapKey({ ...operationContext, threadId: errorThreadId }),
+          );
+
+          const currentPortalViewType = chatPortalSelectors.currentViewType(this.#get());
+          if (currentPortalViewType === PortalViewType.Thread) {
+            this.#get().openThreadInPortal(errorThreadId, context.sourceMessageId);
+          } else {
+            this.#get().syncThreadInPortal(errorThreadId, context.sourceMessageId);
+          }
+          this.#get().refreshThreads();
         }
 
         console.error('[Gateway] Failed to start server-side agent:', e);

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -1065,7 +1065,6 @@ export class ConversationLifecycleActionImpl {
         // and the send button would flicker back to "send".
         const result = await this.#get().executeGatewayAgent({
           context: operationContext,
-          existingMessageIds: newThread ? messages.map((item) => item.id) : undefined,
           fileIds: fileIdList,
           message,
           metadata: requestMetadata,

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -1091,6 +1091,24 @@ export class ConversationLifecycleActionImpl {
           tempMessageIds: [tempAssistantId],
         });
 
+        if (result.createdThreadId) {
+          this.#get().updateOperationMetadata(operationId, {
+            createdThreadId: result.createdThreadId,
+          });
+          this.#get().moveQueuedMessages(
+            currentContextKey,
+            messageMapKey({ ...operationContext, threadId: result.createdThreadId }),
+          );
+
+          const currentPortalViewType = chatPortalSelectors.currentViewType(this.#get());
+          if (currentPortalViewType === PortalViewType.Thread) {
+            this.#get().openThreadInPortal(result.createdThreadId, context.sourceMessageId);
+          } else {
+            this.#get().syncThreadInPortal(result.createdThreadId, context.sourceMessageId);
+          }
+          this.#get().refreshThreads();
+        }
+
         // Topic title: gateway-created topics had no LLM-summarized
         // title. executeGatewayAgent has already replaced messages + switched to
         // the new topic, so the shared hook reads the persisted conversation from

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -372,8 +372,6 @@ export class GatewayActionImpl {
    */
   executeGatewayAgent = async (params: {
     context: ConversationContext;
-    /** Existing context messages to include when creating a thread. */
-    existingMessageIds?: string[];
     /** File IDs of already-uploaded attachments to attach to the new user message */
     fileIds?: string[];
     message: string;
@@ -440,7 +438,6 @@ export class GatewayActionImpl {
   }): Promise<ExecAgentResult> => {
     const {
       context,
-      existingMessageIds,
       fileIds,
       message,
       metadata,
@@ -534,7 +531,6 @@ export class GatewayActionImpl {
           topicId: context.topicId,
         },
         deviceId: localDeviceId,
-        existingMessageIds,
         fileIds,
         mentionedAgents,
         parentMessageId,

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -5,6 +5,7 @@ import {
   type ConnectionStatus,
 } from '@lobechat/agent-gateway-client';
 import type {
+  ChatThreadType,
   ChatTopicMetadata,
   ConversationContext,
   ExecAgentResult,
@@ -371,11 +372,18 @@ export class GatewayActionImpl {
    */
   executeGatewayAgent = async (params: {
     context: ConversationContext;
+    /** Existing context messages to include when creating a thread. */
+    existingMessageIds?: string[];
     /** File IDs of already-uploaded attachments to attach to the new user message */
     fileIds?: string[];
     message: string;
     /** Request metadata carried from the originating user message. */
     metadata?: Pick<MessageMetadata, 'trigger'>;
+    /** Create a thread before the gateway run persists its messages. */
+    newThread?: {
+      sourceMessageId: string;
+      type: ChatThreadType;
+    };
     /** Called when the gateway session completes (agent finished running) */
     onComplete?: () => void;
     /** Temporary sidebar topic inserted by sendMessage before the server creates the real topic. */
@@ -432,9 +440,11 @@ export class GatewayActionImpl {
   }): Promise<ExecAgentResult> => {
     const {
       context,
+      existingMessageIds,
       fileIds,
       message,
       metadata,
+      newThread,
       onComplete,
       optimisticTopic,
       parentMessageId,
@@ -517,12 +527,14 @@ export class GatewayActionImpl {
           // supervisor turn loses its role on the step_start snapshot / refetch
           // and renders as a generic assistant.
           orchestrationRole: context.orchestrationRole,
+          newThread,
           scope: context.scope,
           taskId,
           threadId: context.threadId,
           topicId: context.topicId,
         },
         deviceId: localDeviceId,
+        existingMessageIds,
         fileIds,
         mentionedAgents,
         parentMessageId,
@@ -593,7 +605,11 @@ export class GatewayActionImpl {
     }
 
     // Use the server-created topicId for the execution context
-    const execContext = { ...context, topicId: result.topicId };
+    const execContext = {
+      ...context,
+      threadId: result.createdThreadId ?? context.threadId,
+      topicId: result.topicId,
+    };
     this.#get().moveQueuedMessages(messageMapKey(context), messageMapKey(execContext));
 
     if (result.topicId) {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No matching issue found.

#### 🔀 Description of Change

Gateway-backed agent runs dropped the staged `newThread` context when sending the first message in a subtopic. The server consequently persisted the user and assistant messages on the main topic instead of creating and targeting the requested thread.

This change:

- forwards new-thread context through the Gateway execution contract;
- creates and validates the thread before persisting the user and assistant messages;
- derives continuation, standalone, and isolation history from the persisted thread rather than caller-provided message IDs;
- preserves `createdThreadId` across normal, heterogeneous-agent, and fixed-device-offline paths;
- pivots the staged Thread portal and migrates queued follow-ups to the persisted thread;
- validates source-message and parent-thread topic/ancestry relationships.

#### 🧪 How to Test

- Create a continuation subtopic while Gateway mode is enabled and verify both new messages have the created `threadId`.
- Create standalone and isolation threads and verify their history scopes.
- Trigger a fixed-device-offline failure and verify the UI opens the persisted thread containing the assistant error.
- Queue a follow-up during Gateway startup and verify it moves to the created thread.
- Exercise a heterogeneous Gateway agent and verify its thread history and returned `createdThreadId`.

Validation run:

```text
✓ 9 files · lint clean · tests 157 passed
✓ types clean
```

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

Not applicable; this fixes execution and persistence behavior without visual changes.

#### 📝 Additional Information

No database migration or API breaking change is required. Existing incorrectly scoped historical messages are not modified.
