### PR TITLE
✨ feat: extend AgentShareConfig and add AgentShareModel

### DIFF
--- a/packages/database/src/models/__tests__/agentShare.test.ts
+++ b/packages/database/src/models/__tests__/agentShare.test.ts
@@ -1,0 +1,416 @@
+// @vitest-environment node
+import type { TRPCError } from '@trpc/server';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getTestDB } from '../../core/getTestDB';
+import type { AgentShareConfig } from '../../schemas';
+import { agents, agentShares, users, workspaces } from '../../schemas';
+import type { LobeChatDatabase } from '../../type';
+import { AgentShareModel } from '../agentShare';
+
+const serverDB: LobeChatDatabase = await getTestDB();
+
+const userId = 'agent-share-test-user-id';
+const userId2 = 'agent-share-test-user-id-2';
+const agentId = 'agent-share-test-agent';
+const agentId2 = 'agent-share-test-agent-2';
+const user2AgentId = 'agent-share-test-user2-agent';
+
+const agentShareModel = new AgentShareModel(serverDB, userId);
+const agentShareModel2 = new AgentShareModel(serverDB, userId2);
+
+describe('AgentShareModel', () => {
+  beforeEach(async () => {
+    await serverDB.delete(users);
+
+    await serverDB.transaction(async (tx) => {
+      await tx.insert(users).values([{ id: userId }, { id: userId2 }]);
+      await tx.insert(agents).values([
+        { id: agentId, title: 'Test Agent', userId },
+        { id: agentId2, userId },
+        { id: user2AgentId, title: 'User 2 Agent', userId: userId2 },
+      ]);
+    });
+  });
+
+  afterEach(async () => {
+    await serverDB.delete(agentShares);
+    await serverDB.delete(agents);
+    await serverDB.delete(users);
+  });
+
+  describe('create', () => {
+    it('should create a share for an agent with default visibility', async () => {
+      const result = await agentShareModel.create(agentId);
+
+      expect(result).toBeDefined();
+      expect(result!.agentId).toBe(agentId);
+      expect(result!.visibility).toBe('private');
+      expect(result!.id).toBeDefined();
+    });
+
+    it('should create a share with link visibility', async () => {
+      const result = await agentShareModel.create(agentId, 'link');
+
+      expect(result!.visibility).toBe('link');
+    });
+
+    it('should throw error when agent does not exist', async () => {
+      await expect(agentShareModel.create('non-existent-agent')).rejects.toThrow(
+        'Agent not found or not owned by user',
+      );
+    });
+
+    it('should throw error when trying to share another users agent', async () => {
+      await expect(agentShareModel.create(user2AgentId)).rejects.toThrow(
+        'Agent not found or not owned by user',
+      );
+    });
+
+    it('should return existing share on conflict (duplicate agent)', async () => {
+      const first = await agentShareModel.create(agentId);
+      const second = await agentShareModel.create(agentId);
+
+      expect(second).toBeDefined();
+      expect(second!.agentId).toBe(agentId);
+      expect(second!.id).toBe(first!.id);
+    });
+
+    it('should keep a single share record per agent (unique constraint)', async () => {
+      await agentShareModel.create(agentId);
+      await agentShareModel.create(agentId, 'link');
+
+      const rows = await serverDB.query.agentShares.findMany({
+        where: (t, { eq }) => eq(t.agentId, agentId),
+      });
+      expect(rows).toHaveLength(1);
+      // Conflicting create must not overwrite the original visibility
+      expect(rows[0].visibility).toBe('private');
+    });
+  });
+
+  describe('getByAgentId', () => {
+    it('should get share info by agent id', async () => {
+      const created = await agentShareModel.create(agentId, 'link');
+
+      const result = await agentShareModel.getByAgentId(agentId);
+
+      expect(result).toBeDefined();
+      expect(result!.id).toBe(created!.id);
+      expect(result!.agentId).toBe(agentId);
+      expect(result!.visibility).toBe('link');
+    });
+
+    it('should return null when share does not exist', async () => {
+      const result = await agentShareModel.getByAgentId(agentId);
+
+      expect(result).toBeNull();
+    });
+
+    it('should not return other users share', async () => {
+      await agentShareModel2.create(user2AgentId);
+
+      const result = await agentShareModel.getByAgentId(user2AgentId);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('updateConfig', () => {
+    it('should write and read back the extended shareConfig fields', async () => {
+      await agentShareModel.create(agentId);
+
+      const config: AgentShareConfig = {
+        allowReadMemory: true,
+        enabledToolIds: ['web-browsing', 'dalle'],
+        filePermissionConfig: { agentFiles: 'read', knowledgeBase: 'none', uploadAllowed: false },
+        guestEnabled: true,
+        maxTopicsPerVisitor: 5,
+        maxTurnsPerTopic: 20,
+      };
+
+      const result = await agentShareModel.updateConfig(agentId, config);
+
+      expect(result).toBeDefined();
+      expect(result!.shareConfig).toEqual(config);
+
+      const readBack = await agentShareModel.getByAgentId(agentId);
+      expect(readBack!.shareConfig?.enabledToolIds).toEqual(['web-browsing', 'dalle']);
+      expect(readBack!.shareConfig?.maxTurnsPerTopic).toBe(20);
+      expect(readBack!.shareConfig?.maxTopicsPerVisitor).toBe(5);
+    });
+
+    it('should replace the whole config instead of merging', async () => {
+      await agentShareModel.create(agentId);
+      await agentShareModel.updateConfig(agentId, { guestEnabled: true, maxGuestTopics: 10 });
+
+      const result = await agentShareModel.updateConfig(agentId, { maxTurnsPerTopic: 8 });
+
+      expect(result!.shareConfig).toEqual({ maxTurnsPerTopic: 8 });
+    });
+
+    it('should return null when share does not exist', async () => {
+      const result = await agentShareModel.updateConfig(agentId, { guestEnabled: true });
+
+      expect(result).toBeNull();
+    });
+
+    it('should not update other users share config', async () => {
+      await agentShareModel2.create(user2AgentId);
+
+      const result = await agentShareModel.updateConfig(user2AgentId, { guestEnabled: true });
+
+      expect(result).toBeNull();
+
+      const share = await agentShareModel2.getByAgentId(user2AgentId);
+      expect(share!.shareConfig).toBeNull();
+    });
+  });
+
+  describe('updateVisibility', () => {
+    it('should update share visibility', async () => {
+      await agentShareModel.create(agentId, 'private');
+
+      const result = await agentShareModel.updateVisibility(agentId, 'link');
+
+      expect(result).toBeDefined();
+      expect(result!.visibility).toBe('link');
+    });
+
+    it('should switch a link share back to private', async () => {
+      await agentShareModel.create(agentId, 'link');
+
+      const result = await agentShareModel.updateVisibility(agentId, 'private');
+
+      expect(result!.visibility).toBe('private');
+    });
+
+    it('should return null when share does not exist', async () => {
+      const result = await agentShareModel.updateVisibility(agentId, 'link');
+
+      expect(result).toBeNull();
+    });
+
+    it('should not update other users share', async () => {
+      await agentShareModel2.create(user2AgentId, 'private');
+
+      const result = await agentShareModel.updateVisibility(user2AgentId, 'link');
+
+      expect(result).toBeNull();
+
+      const share = await agentShareModel2.getByAgentId(user2AgentId);
+      expect(share!.visibility).toBe('private');
+    });
+  });
+
+  describe('deleteByAgentId', () => {
+    it('should delete share by agent id', async () => {
+      await agentShareModel.create(agentId);
+
+      await agentShareModel.deleteByAgentId(agentId);
+
+      const share = await agentShareModel.getByAgentId(agentId);
+      expect(share).toBeNull();
+    });
+
+    it('should not delete other users share', async () => {
+      await agentShareModel2.create(user2AgentId);
+
+      await agentShareModel.deleteByAgentId(user2AgentId);
+
+      const share = await agentShareModel2.getByAgentId(user2AgentId);
+      expect(share).not.toBeNull();
+    });
+  });
+
+  describe('findByShareId (static)', () => {
+    it('should find share by share id with agent meta', async () => {
+      const created = await agentShareModel.create(agentId, 'link');
+
+      const result = await AgentShareModel.findByShareId(serverDB, created!.id);
+
+      expect(result).toBeDefined();
+      expect(result!.shareId).toBe(created!.id);
+      expect(result!.agentId).toBe(agentId);
+      expect(result!.agentTitle).toBe('Test Agent');
+      expect(result!.ownerId).toBe(userId);
+      expect(result!.visibility).toBe('link');
+      expect(result!.userViewCount).toBe(0);
+    });
+
+    it('should return null when share does not exist', async () => {
+      const result = await AgentShareModel.findByShareId(
+        serverDB,
+        '00000000-0000-0000-0000-000000000000',
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('should include shareConfig in the result', async () => {
+      const created = await agentShareModel.create(agentId, 'link');
+      await agentShareModel.updateConfig(agentId, { enabledToolIds: ['t1'], guestEnabled: true });
+
+      const result = await AgentShareModel.findByShareId(serverDB, created!.id);
+
+      expect(result!.shareConfig).toEqual({ enabledToolIds: ['t1'], guestEnabled: true });
+    });
+  });
+
+  describe('incrementUserViewCount (static)', () => {
+    it('should increment user view count', async () => {
+      const created = await agentShareModel.create(agentId);
+
+      await AgentShareModel.incrementUserViewCount(serverDB, created!.id);
+
+      const after = await serverDB.query.agentShares.findFirst({
+        where: (t, { eq }) => eq(t.id, created!.id),
+      });
+      expect(after!.userViewCount).toBe(1);
+    });
+
+    it('should increment user view count multiple times', async () => {
+      const created = await agentShareModel.create(agentId);
+
+      await AgentShareModel.incrementUserViewCount(serverDB, created!.id);
+      await AgentShareModel.incrementUserViewCount(serverDB, created!.id);
+      await AgentShareModel.incrementUserViewCount(serverDB, created!.id);
+
+      const result = await serverDB.query.agentShares.findFirst({
+        where: (t, { eq }) => eq(t.id, created!.id),
+      });
+      expect(result!.userViewCount).toBe(3);
+    });
+  });
+
+  describe('findByShareIdWithAccessCheck (static)', () => {
+    it('should return share for owner regardless of visibility', async () => {
+      const created = await agentShareModel.create(agentId, 'private');
+
+      const result = await AgentShareModel.findByShareIdWithAccessCheck(
+        serverDB,
+        created!.id,
+        userId,
+      );
+
+      expect(result).toBeDefined();
+      expect(result.shareId).toBe(created!.id);
+    });
+
+    it('should return share for anonymous user when visibility is link', async () => {
+      const created = await agentShareModel.create(agentId, 'link');
+
+      const result = await AgentShareModel.findByShareIdWithAccessCheck(
+        serverDB,
+        created!.id,
+        undefined,
+      );
+
+      expect(result).toBeDefined();
+      expect(result.shareId).toBe(created!.id);
+    });
+
+    it('should return share for another logged-in user when visibility is link', async () => {
+      const created = await agentShareModel.create(agentId, 'link');
+
+      const result = await AgentShareModel.findByShareIdWithAccessCheck(
+        serverDB,
+        created!.id,
+        userId2,
+      );
+
+      expect(result.shareId).toBe(created!.id);
+    });
+
+    it('should throw NOT_FOUND when share does not exist', async () => {
+      try {
+        await AgentShareModel.findByShareIdWithAccessCheck(
+          serverDB,
+          '00000000-0000-0000-0000-000000000000',
+          userId,
+        );
+        throw new Error('should not reach');
+      } catch (error) {
+        expect((error as TRPCError).code).toBe('NOT_FOUND');
+      }
+    });
+
+    it('should throw FORBIDDEN when visibility is private and user is not owner', async () => {
+      const created = await agentShareModel.create(agentId, 'private');
+
+      try {
+        await AgentShareModel.findByShareIdWithAccessCheck(serverDB, created!.id, userId2);
+        throw new Error('should not reach');
+      } catch (error) {
+        expect((error as TRPCError).code).toBe('FORBIDDEN');
+      }
+    });
+
+    it('should throw FORBIDDEN when visibility is private and user is anonymous', async () => {
+      const created = await agentShareModel.create(agentId, 'private');
+
+      try {
+        await AgentShareModel.findByShareIdWithAccessCheck(serverDB, created!.id, undefined);
+        throw new Error('should not reach');
+      } catch (error) {
+        expect((error as TRPCError).code).toBe('FORBIDDEN');
+      }
+    });
+  });
+
+  describe('workspace mode ownership', () => {
+    const workspaceId = 'agent-share-test-workspace';
+    const wsPublicAgentId = 'agent-share-ws-public-agent';
+    const wsPrivateAgentId = 'agent-share-ws-private-agent';
+
+    beforeEach(async () => {
+      await serverDB.insert(workspaces).values({
+        id: workspaceId,
+        name: 'Test Workspace',
+        primaryOwnerId: userId,
+        slug: 'agent-share-test-ws',
+      });
+      await serverDB.insert(agents).values([
+        { id: wsPublicAgentId, userId, visibility: 'public', workspaceId },
+        { id: wsPrivateAgentId, userId, visibility: 'private', workspaceId },
+      ]);
+    });
+
+    it('allows a workspace member to manage the share of a public workspace agent', async () => {
+      const memberModel = new AgentShareModel(serverDB, userId2, workspaceId);
+
+      const created = await memberModel.create(wsPublicAgentId, 'link');
+
+      expect(created).toBeDefined();
+      expect(created!.agentId).toBe(wsPublicAgentId);
+    });
+
+    it('rejects a workspace member managing the share of a private workspace agent', async () => {
+      const memberModel = new AgentShareModel(serverDB, userId2, workspaceId);
+
+      await expect(memberModel.create(wsPrivateAgentId)).rejects.toThrow(
+        'Agent not found or not owned by user',
+      );
+    });
+
+    it('keeps the agent creator as ownerId for access check', async () => {
+      const memberModel = new AgentShareModel(serverDB, userId2, workspaceId);
+      const created = await memberModel.create(wsPublicAgentId, 'private');
+
+      // Private share is scoped to the agent creator, not the member who created it
+      try {
+        await AgentShareModel.findByShareIdWithAccessCheck(serverDB, created!.id, userId2);
+        throw new Error('should not reach');
+      } catch (error) {
+        expect((error as TRPCError).code).toBe('FORBIDDEN');
+      }
+
+      const ownerResult = await AgentShareModel.findByShareIdWithAccessCheck(
+        serverDB,
+        created!.id,
+        userId,
+      );
+      expect(ownerResult.shareId).toBe(created!.id);
+    });
+  });
+});

--- a/packages/database/src/models/agentShare.ts
+++ b/packages/database/src/models/agentShare.ts
@@ -1,0 +1,204 @@
+import type { ShareVisibility } from '@lobechat/types';
+import { TRPCError } from '@trpc/server';
+import { and, eq, sql } from 'drizzle-orm';
+
+import type { AgentShareConfig } from '../schemas';
+import { agents, agentShares } from '../schemas';
+import type { LobeChatDatabase } from '../type';
+import { normalizeInboxAgentAvatar, normalizeInboxAgentTitle } from '../utils/inboxAgent';
+import { buildWorkspaceWhere } from '../utils/workspace';
+
+export type AgentShareData = NonNullable<
+  Awaited<ReturnType<(typeof AgentShareModel)['findByShareId']>>
+>;
+
+export class AgentShareModel {
+  private userId: string;
+  private db: LobeChatDatabase;
+  private workspaceId?: string;
+
+  constructor(db: LobeChatDatabase, userId: string, workspaceId?: string) {
+    this.userId = userId;
+    this.db = db;
+    this.workspaceId = workspaceId;
+  }
+
+  /**
+   * agent_shares has no userId/workspaceId columns — ownership is derived from
+   * the agent row. Resolve the agent through the workspace-aware predicate so
+   * every mutating method shares the same access rule.
+   */
+  private findOwnedAgent = async (agentId: string) => {
+    return this.db.query.agents.findFirst({
+      where: and(
+        eq(agents.id, agentId),
+        buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, agents),
+      ),
+    });
+  };
+
+  /**
+   * Create or get existing share for an agent.
+   * Each agent can only have one share record (enforced by unique constraint).
+   * If record already exists, returns the existing one.
+   */
+  create = async (agentId: string, visibility: ShareVisibility = 'private') => {
+    const agent = await this.findOwnedAgent(agentId);
+
+    if (!agent) {
+      throw new Error('Agent not found or not owned by user');
+    }
+
+    const [result] = await this.db
+      .insert(agentShares)
+      .values({ agentId, visibility })
+      .onConflictDoNothing({ target: agentShares.agentId })
+      .returning();
+
+    // If conflict occurred, return existing record
+    if (!result) {
+      return this.getByAgentId(agentId);
+    }
+
+    return result;
+  };
+
+  /**
+   * Get share info by agent ID (for the owner)
+   */
+  getByAgentId = async (agentId: string) => {
+    const agent = await this.findOwnedAgent(agentId);
+    if (!agent) return null;
+
+    const result = await this.db
+      .select({
+        agentId: agentShares.agentId,
+        id: agentShares.id,
+        shareConfig: agentShares.shareConfig,
+        userViewCount: agentShares.userViewCount,
+        visibility: agentShares.visibility,
+      })
+      .from(agentShares)
+      .where(eq(agentShares.agentId, agentId))
+      .limit(1);
+
+    return result[0] || null;
+  };
+
+  /**
+   * Replace the share config of an agent share.
+   */
+  updateConfig = async (agentId: string, config: AgentShareConfig) => {
+    const agent = await this.findOwnedAgent(agentId);
+    if (!agent) return null;
+
+    const [result] = await this.db
+      .update(agentShares)
+      .set({ shareConfig: config, updatedAt: new Date() })
+      .where(eq(agentShares.agentId, agentId))
+      .returning();
+
+    return result || null;
+  };
+
+  /**
+   * Update share visibility
+   */
+  updateVisibility = async (agentId: string, visibility: ShareVisibility) => {
+    const agent = await this.findOwnedAgent(agentId);
+    if (!agent) return null;
+
+    const [result] = await this.db
+      .update(agentShares)
+      .set({ updatedAt: new Date(), visibility })
+      .where(eq(agentShares.agentId, agentId))
+      .returning();
+
+    return result || null;
+  };
+
+  /**
+   * Delete a share by agent ID
+   */
+  deleteByAgentId = async (agentId: string) => {
+    const agent = await this.findOwnedAgent(agentId);
+    if (!agent) return;
+
+    return this.db.delete(agentShares).where(eq(agentShares.agentId, agentId));
+  };
+
+  /**
+   * Find shared agent by share ID.
+   * Returns share info including ownerId for permission checking by caller.
+   */
+  static findByShareId = async (db: LobeChatDatabase, shareId: string) => {
+    const result = await db
+      .select({
+        agentAvatar: agents.avatar,
+        agentBackgroundColor: agents.backgroundColor,
+        agentDescription: agents.description,
+        agentId: agentShares.agentId,
+        agentMarketIdentifier: agents.marketIdentifier,
+        agentSlug: agents.slug,
+        agentTitle: agents.title,
+        ownerId: agents.userId,
+        shareConfig: agentShares.shareConfig,
+        shareId: agentShares.id,
+        userViewCount: agentShares.userViewCount,
+        visibility: agentShares.visibility,
+        workspaceId: agents.workspaceId,
+      })
+      .from(agentShares)
+      .innerJoin(agents, eq(agentShares.agentId, agents.id))
+      .where(eq(agentShares.id, shareId))
+      .limit(1);
+
+    if (!result[0]) return null;
+
+    const share = result[0];
+
+    return {
+      ...share,
+      agentAvatar: normalizeInboxAgentAvatar(share.agentAvatar, { slug: share.agentSlug }),
+      agentTitle: normalizeInboxAgentTitle(share.agentTitle, { slug: share.agentSlug }),
+    };
+  };
+
+  /**
+   * Increment unique visitor count for a share.
+   * Should be called by the application layer when a new visitor session starts.
+   */
+  static incrementUserViewCount = async (db: LobeChatDatabase, shareId: string) => {
+    await db
+      .update(agentShares)
+      .set({ userViewCount: sql`${agentShares.userViewCount} + 1` })
+      .where(eq(agentShares.id, shareId));
+  };
+
+  /**
+   * Find shared agent by share ID with visibility check.
+   * Throws TRPCError if access is denied.
+   */
+  static findByShareIdWithAccessCheck = async (
+    db: LobeChatDatabase,
+    shareId: string,
+    accessUserId?: string,
+  ): Promise<AgentShareData> => {
+    const share = await AgentShareModel.findByShareId(db, shareId);
+
+    if (!share) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Share not found' });
+    }
+
+    const isOwner = accessUserId && share.ownerId === accessUserId;
+
+    // Only check visibility for non-owners
+    // 'private' - only the agent creator can view
+    // 'link' - anyone with the link can view
+    if (!isOwner && share.visibility === 'private') {
+      throw new TRPCError({ code: 'FORBIDDEN', message: 'This share is private' });
+    }
+
+    return share;
+  };
+}

--- a/packages/database/src/schemas/agentShare.ts
+++ b/packages/database/src/schemas/agentShare.ts
@@ -5,6 +5,8 @@ import { agents } from './agent';
 
 export interface AgentShareConfig {
   allowReadMemory?: boolean;
+  /** Tool whitelist — only the listed MCP/plugin/skill ids are exposed to visitors. */
+  enabledToolIds?: string[];
   filePermissionConfig?: {
     agentFiles?: 'none' | 'read';
     knowledgeBase?: 'none' | 'read';
@@ -12,6 +14,10 @@ export interface AgentShareConfig {
   };
   guestEnabled?: boolean;
   maxGuestTopics?: number;
+  /** Per-visitor cap: max share topics a single senderId can create. */
+  maxTopicsPerVisitor?: number;
+  /** Per-topic cap: max message turns within a single share topic. */
+  maxTurnsPerTopic?: number;
   // tipSplitRatio is platform-controlled, not configurable by the creator
 }
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Related to LOBE-11931 (A1 · shareConfig 接口扩展 + AgentShareModel 补全), part of LOBE-11930 (Agent Share System Epic). Builds on LOBE-9941 (DB schema, already merged).

#### 🔀 Description of Change

Business-layer groundwork for the agent share system, on top of the existing `agent_shares` table:

- **`AgentShareConfig` extension** (`packages/database/src/schemas/agentShare.ts`, jsonb-only — no DB migration):
  - `enabledToolIds?: string[]` — tool whitelist exposed to visitors
  - `maxTurnsPerTopic?: number` — per-topic message turn cap
  - `maxTopicsPerVisitor?: number` — per-visitor (senderId) topic cap
- **New `AgentShareModel`** (`packages/database/src/models/agentShare.ts`), following the `TopicShareModel` ownership/workspace pattern:
  - `create(agentId, visibility?)` — validates agent ownership; `onConflictDoNothing` keeps one share per agent and returns the existing record on conflict
  - `getByAgentId` / `updateConfig` / `updateVisibility` / `deleteByAgentId` — all gated by workspace-aware agent ownership (`buildWorkspaceWhere`), since `agent_shares` has no `userId` column
  - `static findByShareId(db, shareId)` — joins agent meta (avatar / title / description / backgroundColor, inbox-agent normalized) for the visitor landing page
  - `static incrementUserViewCount(db, shareId)`
  - `static findByShareIdWithAccessCheck(db, shareId, accessUserId?)` — `NOT_FOUND` for missing shares, `FORBIDDEN` for private shares accessed by non-owners (owner = agent creator, `agents.userId`)

#### Key Decisions / Non-goals

- **`agent_shares.id` stays uuid** (user-approved): the issue originally suggested nanoid(8) short ids, but the table already shipped with uuid via migration 0105 and nothing references the id yet; keeping uuid avoids a schema migration. Share links will be `/share/a/<uuid>`.
- `updateConfig` **replaces** the whole config rather than merging — the share config modal holds full config state, and replace keeps unset-field semantics predictable.
- Router layer (A3/A4), visitor routes (C-phase), and billing (D-phase, cloud repo) are out of scope for this PR.

#### 🧪 How to Test

- [x] Added/updated tests

`packages/database/src/models/__tests__/agentShare.test.ts` — 33 tests covering every model method, the one-share-per-agent unique constraint, read/write of the 3 new config fields, private-share FORBIDDEN access, and workspace-mode ownership (public agent manageable by members, private agent creator-only).

```bash
bun run check packages/database/src/models/agentShare.ts
```