### PR TITLE
🐛 fix(model-runtime): guard DeepSeek anthropic `</think>` leak into text channel

### DIFF
--- a/packages/model-runtime/src/core/streams/anthropic.test.ts
+++ b/packages/model-runtime/src/core/streams/anthropic.test.ts
@@ -917,4 +917,163 @@ describe('AnthropicStream', () => {
       ].map((item) => `${item}\n`),
     );
   });
+
+  describe('deepseek </think> leak guard', () => {
+    const collectEvents = async (
+      streams: any[],
+      model: string,
+    ): Promise<{ data: string; event: string }[]> => {
+      const mockReadableStream = new ReadableStream({
+        start(controller) {
+          streams.forEach((chunk) => controller.enqueue(chunk));
+          controller.close();
+        },
+      });
+
+      const protocolStream = AnthropicStream(mockReadableStream, {
+        payload: { model, provider: 'deepseek' },
+      });
+
+      const decoder = new TextDecoder();
+      const chunks: string[] = [];
+      // @ts-ignore
+      for await (const chunk of protocolStream) {
+        chunks.push(decoder.decode(chunk, { stream: true }));
+      }
+
+      // reassemble the line-based SSE output into { event, data } pairs
+      const events: { data: string; event: string }[] = [];
+      let currentEvent = '';
+      for (const line of chunks.join('').split('\n')) {
+        if (line.startsWith('event: ')) currentEvent = line.replace('event: ', '');
+        if (line.startsWith('data: '))
+          events.push({ data: line.replace('data: ', ''), event: currentEvent });
+      }
+      return events;
+    };
+
+    const messageStart = {
+      type: 'message_start',
+      message: {
+        id: 'msg_leak',
+        type: 'message',
+        role: 'assistant',
+        model: 'deepseek-v4-pro',
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 1 },
+      },
+    };
+
+    it('should split leaked reasoning terminated by a bare </think> into reasoning + text', async () => {
+      const events = await collectEvents(
+        [
+          messageStart,
+          // deepseek may emit an empty placeholder thinking block before the leak;
+          // it must not disarm the guard
+          {
+            type: 'content_block_start',
+            index: 0,
+            content_block: { type: 'thinking', thinking: '', signature: '' },
+          },
+          {
+            type: 'content_block_delta',
+            index: 1,
+            delta: {
+              type: 'text_delta',
+              text: 'Let me parse the refund policy first.</think>Dear user, here is the answer.',
+            },
+          },
+        ],
+        'deepseek-v4-pro',
+      );
+
+      expect(events).toContainEqual({
+        data: JSON.stringify('Let me parse the refund policy first.'),
+        event: 'reasoning',
+      });
+      expect(events).toContainEqual({
+        data: JSON.stringify('Dear user, here is the answer.'),
+        event: 'text',
+      });
+      expect(events.some(({ data }) => data.includes('</think>'))).toBe(false);
+    });
+
+    it('should split at the delta carrying </think> when the leak spans multiple deltas', async () => {
+      const events = await collectEvents(
+        [
+          messageStart,
+          {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'text_delta', text: 'leaked reasoning part one, ' },
+          },
+          {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'text_delta', text: 'part two.</think>The real answer.' },
+          },
+        ],
+        'deepseek-v4-pro',
+      );
+
+      // deltas before the tag were already emitted as text — only the tag-carrying
+      // delta can still be split, and the literal tag never surfaces
+      expect(events).toContainEqual({
+        data: JSON.stringify('leaked reasoning part one, '),
+        event: 'text',
+      });
+      expect(events).toContainEqual({ data: JSON.stringify('part two.'), event: 'reasoning' });
+      expect(events).toContainEqual({ data: JSON.stringify('The real answer.'), event: 'text' });
+      expect(events.some(({ data }) => data.includes('</think>'))).toBe(false);
+    });
+
+    it('should leave the tag untouched once real reasoning has been received', async () => {
+      const text = 'the closing tag is `</think>` in that template';
+      const events = await collectEvents(
+        [
+          messageStart,
+          {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'thinking_delta', thinking: 'real reasoning happened here' },
+          },
+          { type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text } },
+        ],
+        'deepseek-v4-pro',
+      );
+
+      expect(events).toContainEqual({ data: JSON.stringify(text), event: 'text' });
+    });
+
+    it('should leave content untouched when a literal <think> tag appeared first', async () => {
+      const opening = 'streaming shows `<think>` first, ';
+      const closing = 'then `</think>` at the end';
+      const events = await collectEvents(
+        [
+          messageStart,
+          { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: opening } },
+          { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: closing } },
+        ],
+        'deepseek-v4-pro',
+      );
+
+      expect(events).toContainEqual({ data: JSON.stringify(opening), event: 'text' });
+      expect(events).toContainEqual({ data: JSON.stringify(closing), event: 'text' });
+    });
+
+    it('should not apply the guard to non-deepseek models', async () => {
+      const text = 'to close a thinking span emit </think> as a single token';
+      const events = await collectEvents(
+        [
+          messageStart,
+          { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text } },
+        ],
+        'claude-sonnet-4-6',
+      );
+
+      expect(events).toContainEqual({ data: JSON.stringify(text), event: 'text' });
+    });
+  });
 });

--- a/packages/model-runtime/src/core/streams/anthropic.ts
+++ b/packages/model-runtime/src/core/streams/anthropic.ts
@@ -3,6 +3,7 @@ import type { Stream } from '@anthropic-ai/sdk/streaming';
 import type { ChatCitationItem } from '@lobechat/types';
 
 import type { ChatStreamCallbacks } from '../../types';
+import { isDeepSeekThinkingEligibleModel } from '../../utils/modelParse';
 import { convertAnthropicUsage } from '../usageConverters';
 import type {
   ChatPayloadForTransformStream,
@@ -105,6 +106,10 @@ export const transformAnthropicStream = (
         case 'thinking': {
           const thinkingChunk = chunk.content_block;
 
+          if (typeof thinkingChunk.thinking === 'string' && thinkingChunk.thinking.trim()) {
+            context.receivedNonEmptyReasoning = true;
+          }
+
           // if there is signature in the thinking block, return both thinking and signature
           if (!!thinkingChunk.signature) {
             return [
@@ -130,7 +135,41 @@ export const transformAnthropicStream = (
     case 'content_block_delta': {
       switch (chunk.delta.type) {
         case 'text_delta': {
-          return { data: chunk.delta.text, id: context.id, type: 'text' };
+          const text = chunk.delta.text;
+
+          // DeepSeek's anthropic-compatible endpoint prefills `<think>` server-side; when its
+          // parser fails to capture the reasoning into a thinking block, the raw tokens leak
+          // into the text channel as `reasoning…</think>answer` — closing tag only, thinking
+          // block empty. Split such deltas so the literal tag never reaches user-visible
+          // content. Gated to DeepSeek thinking models with no real reasoning received and no
+          // literal `<think>` seen, so ordinary content that merely mentions the closing tag
+          // (after a real thinking block, or alongside the opening tag) is left untouched.
+          if (
+            typeof text === 'string' &&
+            isDeepSeekThinkingEligibleModel(payload?.model) &&
+            !context.receivedNonEmptyReasoning &&
+            !context.sawLiteralThinkOpenTag
+          ) {
+            if (text.includes('<think>')) {
+              context.sawLiteralThinkOpenTag = true;
+            } else if (text.includes('</think>')) {
+              const [leakedReasoning, ...rest] = text.split('</think>');
+              const afterThink = rest.join('</think>');
+
+              // reasoning was emitted for this message now — disarm the guard so later
+              // occurrences of the tag are treated as ordinary content again
+              context.receivedNonEmptyReasoning = true;
+
+              const results: StreamProtocolChunk[] = [];
+              if (leakedReasoning)
+                results.push({ data: leakedReasoning, id: context.id, type: 'reasoning' });
+              if (afterThink) results.push({ data: afterThink, id: context.id, type: 'text' });
+
+              return results.length > 0 ? results : { data: '', id: context.id, type: 'text' };
+            }
+          }
+
+          return { data: text, id: context.id, type: 'text' };
         }
 
         case 'input_json_delta': {
@@ -158,6 +197,10 @@ export const transformAnthropicStream = (
         }
 
         case 'thinking_delta': {
+          if (typeof chunk.delta.thinking === 'string' && chunk.delta.thinking.trim()) {
+            context.receivedNonEmptyReasoning = true;
+          }
+
           return {
             data: chunk.delta.thinking,
             id: context.id,

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -24,6 +24,15 @@ export interface StreamContext {
   chunkIndex?: number;
   id: string;
   /**
+   * Whether any non-empty thinking/reasoning content has been received in the current
+   * message. DeepSeek's anthropic-compatible endpoint prefills `<think>` server-side;
+   * when its parser fails to capture the reasoning into a thinking block, the raw
+   * tokens leak into the text channel as `reasoning…</think>answer` — closing tag only,
+   * with the thinking block empty. A message that already produced real reasoning
+   * cannot be in that failure mode, so this flag disarms the leak guard.
+   */
+  receivedNonEmptyReasoning?: boolean;
+  /**
    * As pplx citations is in every chunk, but we only need to return it once
    * this flag is used to check if the pplx citation is returned,and then not return it again.
    * Same as Hunyuan and Wenxin
@@ -36,6 +45,12 @@ export interface StreamContext {
    * This array accumulates all citation items received during the streaming response.
    */
   returnedCitationArray?: ChatCitationItem[];
+  /**
+   * Whether a literal `<think>` tag has been seen in the text channel of the current
+   * message. Content that carries the opening tag (e.g. a user-visible discussion of
+   * think tags) is not the prefill-leak shape, so the leak guard must leave it intact.
+   */
+  sawLiteralThinkOpenTag?: boolean;
   /**
    * O series models need a condition to separate part
    */


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

DeepSeek's anthropic-compatible endpoint prefills `<think>` server-side. When its parser fails to capture the reasoning into a thinking block, the raw tokens leak into the **text channel** as `reasoning…</think>answer` — closing tag only (the prefilled opening tag never appears in the sampled tokens), with the thinking block empty. Our anthropic stream transform passed text deltas through verbatim, so the leaked reasoning and the literal `</think>` tag were persisted and rendered as assistant content.

Observed in production on `deepseek-v4-pro` (lobehub provider → `api.deepseek.com/anthropic`): the persisted assistant message contains the full private reasoning, a literal `</think>`, then the real answer, with the `reasoning` column NULL. The same fingerprint also reproduced on a BYOK NVIDIA-hosted `deepseek-ai/deepseek-v4-pro`, confirming it is upstream serving behavior, not something our pipeline injects — this PR adds a defensive guard on our side.

**Fix** (in `transformAnthropicStream`):

- Track `receivedNonEmptyReasoning` on the stream context (set by non-empty `thinking` block starts and `thinking_delta`s — whitespace-only placeholder blocks do **not** count, since the leak co-occurs with an empty/placeholder thinking block).
- In `text_delta`, when the model is DeepSeek thinking-eligible, no real reasoning has been received, and no literal `<think>` has been seen: split a delta containing `</think>` — the part before the tag is emitted as `reasoning`, the part after as `text`, and the literal tag never surfaces. The guard then disarms itself.

**Deliberately narrow gating** to avoid corrupting legitimate content that merely *mentions* the tag (there are real conversations discussing `<think>`/`</think>` in inline code — in all such sampled cases a real thinking block preceded the text, so the guard stays off):

- Only DeepSeek thinking models (`isDeepSeekThinkingEligibleModel`) — Claude and other anthropic-protocol models are untouched.
- Disarmed once any non-empty reasoning arrives, or once a literal `<think>` opening tag is seen in text.

**Known limitation**: in live streaming, text deltas that arrived *before* the tag-carrying delta were already emitted as text and cannot be reclassified retroactively — for multi-delta leaks the guard still guarantees the literal tag never surfaces and the tag-carrying delta's prefix is routed to reasoning. In the non-streaming path the whole text block arrives as a single delta, so the split is complete there.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`packages/model-runtime`: `vitest run src/core/streams/anthropic.test.ts` — 5 new cases covering: single-delta leak split, multi-delta leak (tag-carrying delta split, no literal tag surfaced), disarm after real reasoning, disarm on literal `<think>`, and non-DeepSeek models untouched. Full `src/core/streams` + `anthropicCompatibleFactory` + `providers/deepseek` suites pass (351 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)