### PR TITLE
🐛 fix(agent): time out stalled connected skill calls

### DIFF
--- a/apps/server/src/services/market/index.test.ts
+++ b/apps/server/src/services/market/index.test.ts
@@ -263,10 +263,14 @@ describe('MarketService', () => {
         toolName: 'search',
       });
 
-      expect(mockCallTool).toHaveBeenCalledWith('my-provider', {
-        args: { query: 'test' },
-        tool: 'search',
-      });
+      expect(mockCallTool).toHaveBeenCalledWith(
+        'my-provider',
+        {
+          args: { query: 'test' },
+          tool: 'search',
+        },
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
       expect(result).toEqual({ content: 'tool result', success: true });
     });
 
@@ -302,6 +306,42 @@ describe('MarketService', () => {
         error: { code: 'LOBEHUB_SKILL_ERROR', message: 'Network error' },
         success: false,
       });
+    });
+
+    it('should abort and return an error when skill execution times out', async () => {
+      vi.useFakeTimers();
+      const service = new MarketService();
+      let signal: AbortSignal | undefined;
+      const mockCallTool = vi
+        .fn()
+        .mockImplementation((_provider: string, _params: unknown, options?: RequestInit) => {
+          signal = options?.signal ?? undefined;
+          return new Promise(() => {});
+        });
+      (service as any).market.skills.callTool = mockCallTool;
+
+      try {
+        const resultPromise = service.executeLobehubSkill({
+          args: {},
+          provider: 'github',
+          timeoutMs: 1000,
+          toolName: 'runCommand',
+        });
+
+        await vi.advanceTimersByTimeAsync(1000);
+
+        await expect(resultPromise).resolves.toEqual({
+          content: 'LobeHub Skill execution timed out after 1000ms',
+          error: {
+            code: 'LOBEHUB_SKILL_TIMEOUT',
+            message: 'LobeHub Skill execution timed out after 1000ms',
+          },
+          success: false,
+        });
+        expect(signal?.aborted).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('should return error result when the skill call response is unsuccessful', async () => {

--- a/apps/server/src/services/market/index.ts
+++ b/apps/server/src/services/market/index.ts
@@ -12,6 +12,7 @@ const log = debug('lobe-server:market-service');
 
 const MARKET_BASE_URL = process.env.MARKET_BASE_URL || 'https://market.lobehub.com';
 export const LOBEHUB_SKILL_DISCOVERY_TIMEOUT_MS = 3_000;
+export const LOBEHUB_SKILL_EXECUTION_TIMEOUT_MS = 120_000;
 
 // ============================== Helper Functions ==============================
 
@@ -32,6 +33,7 @@ export interface LobehubSkillExecuteParams {
     topicId?: string;
   };
   provider: string;
+  timeoutMs?: number;
   toolName: string;
 }
 
@@ -519,16 +521,34 @@ export class MarketService {
    */
   async executeLobehubSkill(params: LobehubSkillExecuteParams): Promise<LobehubSkillExecuteResult> {
     const { provider, toolName, args, context } = params;
+    const timeoutMs = params.timeoutMs ?? LOBEHUB_SKILL_EXECUTION_TIMEOUT_MS;
+    const abortController = new AbortController();
+    let timeout: ReturnType<typeof setTimeout> | undefined;
 
     log('executeLobehubSkill: %s/%s with args: %O, context: %O', provider, toolName, args, context);
 
     try {
-      const response = await this.market.skills.callTool(provider, {
-        args,
-        // @ts-ignore
-        topicId: context?.topicId,
-        tool: toolName,
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          const error = new Error(`LobeHub Skill execution timed out after ${timeoutMs}ms`);
+          error.name = 'TimeoutError';
+          reject(error);
+          abortController.abort(error);
+        }, timeoutMs);
       });
+      const response = await Promise.race([
+        this.market.skills.callTool(
+          provider,
+          {
+            args,
+            // @ts-ignore
+            topicId: context?.topicId,
+            tool: toolName,
+          },
+          { signal: abortController.signal },
+        ),
+        timeoutPromise,
+      ]);
 
       log('executeLobehubSkill: response: %O', response);
 
@@ -562,6 +582,14 @@ export class MarketService {
       const err = error as Error;
       console.error('MarketService.executeLobehubSkill error %s/%s: %O', provider, toolName, err);
 
+      if (err.name === 'TimeoutError') {
+        return {
+          content: err.message,
+          error: { code: 'LOBEHUB_SKILL_TIMEOUT', message: err.message },
+          success: false,
+        };
+      }
+
       // MarketAPIError carries the full error response body from the API,
       // including structured details (command, exitCode, stdout, stderr).
       // Extract it so the content is not empty on failure.
@@ -577,6 +605,8 @@ export class MarketService {
         },
         success: false,
       };
+    } finally {
+      if (timeout) clearTimeout(timeout);
     }
   }
 

--- a/apps/server/src/services/toolExecution/__tests__/builtin.test.ts
+++ b/apps/server/src/services/toolExecution/__tests__/builtin.test.ts
@@ -217,7 +217,7 @@ describe('BuiltinToolsExecutor truncated arguments', () => {
         source: 'lobehubSkill',
         type: 'default' as any,
       },
-      { ...context, topicId: 'topic-1' },
+      { ...context, executionTimeoutMs: 45_000, topicId: 'topic-1' },
     );
 
     expect(result.success).toBe(true);
@@ -225,6 +225,7 @@ describe('BuiltinToolsExecutor truncated arguments', () => {
       args: { id: 'LOBE-10966', state: 'In Progress' },
       context: { topicId: 'topic-1' },
       provider: 'linear',
+      timeoutMs: 45_000,
       toolName: 'save_issue',
     });
     // The executor no longer writes the Work — it hands the runtime an intent

--- a/apps/server/src/services/toolExecution/builtin.ts
+++ b/apps/server/src/services/toolExecution/builtin.ts
@@ -113,6 +113,7 @@ export class BuiltinToolsExecutor implements IToolExecutor {
           topicId: context.topicId,
         },
         provider: identifier,
+        timeoutMs: context.executionTimeoutMs,
         toolName: apiName,
       });
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A — found while investigating a production topic whose final connected-skill tool call never returned.

#### 🔀 Description of Change

Connected LobeHub Skill calls currently await the Market SDK indefinitely. If the provider or transport stalls, the agent cannot receive a tool result or continue to its next model step.

This change:

- propagates the Agent Runtime's resolved per-call timeout into the LobeHub Skill execution path;
- races the Market SDK call against a hard timeout and aborts the underlying request through `AbortSignal`;
- falls back to a 120-second execution timeout when no runtime budget is supplied;
- returns a structured `LOBEHUB_SKILL_TIMEOUT` failure so the agent loop can recover instead of remaining pending forever.

The existing retry policy is unchanged; the timeout applies to each execution attempt.

#### 🧪 How to Test

- Added a regression test with a Market SDK call that never settles.
- Verified the call resolves with `LOBEHUB_SKILL_TIMEOUT` at the deadline.
- Verified the SDK request signal is aborted.
- Verified the runtime-resolved timeout is forwarded through `BuiltinToolsExecutor`.

```text
bun run check apps/server/src/services/market/index.ts apps/server/src/services/market/index.test.ts apps/server/src/services/toolExecution/builtin.ts apps/server/src/services/toolExecution/__tests__/builtin.test.ts
✓ 4 files · lint clean · tests 57 passed

bun run check --type
✓ types clean
```

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

Not applicable — no UI changes.

#### 📝 Additional Information

No API migration or breaking change. This PR intentionally does not change Gateway terminal reconciliation, abandoned-operation finalization, or unresolved tool-call persistence; those concerns can be addressed independently.
