### PR TITLE
🐛 fix: prevent empty TTS updates

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/integration/message.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/message.integration.test.ts
@@ -1430,6 +1430,28 @@ describe('Message Router Integration Tests', () => {
       expect(ttsRecord.fileId).toBe(file.id);
     });
 
+    it('should ignore empty TTS updates for an existing record', async () => {
+      const caller = messageRouter.createCaller(createTestContext(userId));
+
+      const msg = await caller.createMessage({
+        content: 'Message with existing TTS',
+        role: 'assistant',
+        sessionId: testSessionId,
+      });
+
+      await caller.updateTTS({
+        id: msg.id,
+        value: { voice: 'en-US-neural' },
+      });
+
+      await expect(caller.updateTTS({ id: msg.id, value: {} })).resolves.toBeUndefined();
+
+      const { messageTTS } = await import('@/database/schemas');
+      const [ttsRecord] = await serverDB.select().from(messageTTS).where(eq(messageTTS.id, msg.id));
+
+      expect(ttsRecord.voice).toBe('en-US-neural');
+    });
+
     it('should delete TTS when value is false', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -3029,18 +3029,22 @@ export class MessageModel {
   };
 
   updateTTS = async (id: string, tts: Partial<ChatTTS>) => {
+    const { contentMd5, file, voice } = tts;
+    // Older clients sent an empty payload when starting TTS, so keep this backward-compatible.
+    if ([contentMd5, file, voice].every((value) => value === undefined)) return;
+
     const result = await this.db.query.messageTTS.findFirst({
       where: and(eq(messageTTS.id, id), this.ttsOwnership()),
     });
 
-    // If the message does not exist in the translate table, insert it
+    // If the message does not exist in the TTS table, insert it
     if (!result) {
       return this.db.insert(messageTTS).values({
-        contentMd5: tts.contentMd5,
-        fileId: tts.file,
+        contentMd5,
+        fileId: file,
         id,
         userId: this.userId,
-        voice: tts.voice,
+        voice,
         workspaceId: this.workspaceId ?? null,
       });
     }
@@ -3048,7 +3052,7 @@ export class MessageModel {
     // or just update the existing one
     return this.db
       .update(messageTTS)
-      .set({ contentMd5: tts.contentMd5, fileId: tts.file, voice: tts.voice })
+      .set({ contentMd5, fileId: file, voice })
       .where(and(eq(messageTTS.id, id), this.ttsOwnership()));
   };
 

--- a/src/features/Conversation/Messages/components/Extras/TTS/FilePlayer.tsx
+++ b/src/features/Conversation/Messages/components/Extras/TTS/FilePlayer.tsx
@@ -9,13 +9,13 @@ import Player from './Player';
 
 const FilePlayer = memo<TTSProps>(({ file, id }) => {
   const useFetchTTSFile = useFileStore((s) => s.useFetchTTSFile);
-  const clearTTS = useConversationStore((s) => s.clearTTS);
+  const clearMessageTTS = useConversationStore((s) => s.clearMessageTTS);
   const { data, isLoading: isFileLoading } = useFetchTTSFile(file || null);
   const { isLoading, ...audio } = useAudioPlayer({ src: data ? data.url : '' });
 
   const handleDelete = useCallback(() => {
-    clearTTS(id);
-  }, [id, clearTTS]);
+    clearMessageTTS(id);
+  }, [id, clearMessageTTS]);
 
   if (!audio || isFileLoading) return;
 

--- a/src/features/Conversation/Messages/components/Extras/TTS/InitPlayer.tsx
+++ b/src/features/Conversation/Messages/components/Extras/TTS/InitPlayer.tsx
@@ -22,7 +22,10 @@ const InitPlayer = memo<TTSProps>(({ id, content, contentMd5, file }) => {
   const uploadTTS = useFileStore((s) => s.uploadTTSByArrayBuffers);
   const { t } = useTranslation('chat');
 
-  const [ttsMessage, clearTTS] = useConversationStore((s) => [s.ttsMessage, s.clearTTS]);
+  const [saveMessageTTS, clearMessageTTS] = useConversationStore((s) => [
+    s.saveMessageTTS,
+    s.clearMessageTTS,
+  ]);
 
   const setDefaultError = useCallback(
     (err?: any) => {
@@ -56,8 +59,8 @@ const InitPlayer = memo<TTSProps>(({ id, content, contentMd5, file }) => {
     onUpload: async (currentVoice, arrayBuffers) => {
       if (isDeletedRef.current) return;
       const fileID = await uploadTTS(id, arrayBuffers);
-      if (isDeletedRef.current) return;
-      ttsMessage(id, { contentMd5, file: fileID, voice: currentVoice });
+      if (isDeletedRef.current || !fileID || !contentMd5) return;
+      await saveMessageTTS(id, { contentMd5, file: fileID, voice: currentVoice });
     },
   });
 
@@ -70,8 +73,8 @@ const InitPlayer = memo<TTSProps>(({ id, content, contentMd5, file }) => {
   const handleDelete = useCallback(() => {
     isDeletedRef.current = true;
     stop();
-    clearTTS(id);
-  }, [stop, id, clearTTS]);
+    clearMessageTTS(id);
+  }, [stop, id, clearMessageTTS]);
 
   const handleRetry = useCallback(() => {
     setError(undefined);

--- a/src/features/Conversation/Messages/components/MessageActionBar/actions/tts.ts
+++ b/src/features/Conversation/Messages/components/MessageActionBar/actions/tts.ts
@@ -9,16 +9,16 @@ export const ttsAction = defineAction({
   key: 'tts',
   useBuild: (ctx) => {
     const { t } = useTranslation('chat');
-    const ttsMessage = useConversationStore((s) => s.ttsMessage);
+    const startMessageTTS = useConversationStore((s) => s.startMessageTTS);
 
     return useMemo(
       () => ({
-        handleClick: () => ttsMessage(ctx.id),
+        handleClick: () => startMessageTTS(ctx.id),
         icon: Play,
         key: 'tts',
         label: t('tts.action'),
       }),
-      [t, ctx.id, ttsMessage],
+      [t, ctx.id, startMessageTTS],
     );
   },
 });

--- a/src/features/Conversation/hooks/useChatItemContextMenu.tsx
+++ b/src/features/Conversation/hooks/useChatItemContextMenu.tsx
@@ -92,7 +92,7 @@ export const useChatItemContextMenu = ({
     regenerateUserMessage,
     regenerateAssistantMessage,
     translateMessage,
-    ttsMessage,
+    startMessageTTS,
     delAndRegenerateMessage,
     copyMessage,
     openThreadCreator,
@@ -106,7 +106,7 @@ export const useChatItemContextMenu = ({
     s.regenerateUserMessage,
     s.regenerateAssistantMessage,
     s.translateMessage,
-    s.ttsMessage,
+    s.startMessageTTS,
     s.delAndRegenerateMessage,
     s.copyMessage,
     s.openThreadCreator,
@@ -317,7 +317,7 @@ export const useChatItemContextMenu = ({
         }
         case 'tts': {
           if (!canCreate) break;
-          ttsMessage(id);
+          startMessageTTS(id);
           break;
         }
         case 'share': {
@@ -356,7 +356,7 @@ export const useChatItemContextMenu = ({
       toggleMessageEditing,
       topic,
       translateMessage,
-      ttsMessage,
+      startMessageTTS,
     ],
   );
 

--- a/src/features/Conversation/store/slices/generation/action.ts
+++ b/src/features/Conversation/store/slices/generation/action.ts
@@ -2,6 +2,7 @@ import { AgentManagementIdentifier } from '@lobechat/builtin-tool-agent-manageme
 import { HETERO_CONTINUE_PROMPT, LOADING_FLAT } from '@lobechat/const';
 import type {
   ChatImageItem,
+  ChatTTS,
   ConversationContext,
   HeterogeneousProviderConfig,
 } from '@lobechat/types';
@@ -263,6 +264,12 @@ export interface GenerationAction {
   cancelScheduledRun: () => Promise<void>;
 
   /**
+   * Clear TTS for a message
+   * @deprecated Temporary bridge to ChatStore
+   */
+  clearMessageTTS: (messageId: string) => Promise<void>;
+
+  /**
    * Clear all operations
    */
   clearOperations: () => void;
@@ -272,12 +279,6 @@ export interface GenerationAction {
    * @deprecated Temporary bridge to ChatStore
    */
   clearTranslate: (messageId: string) => Promise<void>;
-
-  /**
-   * Clear TTS for a message
-   * @deprecated Temporary bridge to ChatStore
-   */
-  clearTTS: (messageId: string) => Promise<void>;
 
   /**
    * Continue generation from a message
@@ -374,7 +375,19 @@ export interface GenerationAction {
    */
   resetHeteroOverloadRetry: (scopeId: string) => void;
 
+  /**
+   * Save TTS metadata for a message
+   * @deprecated Temporary bridge to ChatStore
+   */
+  saveMessageTTS: (messageId: string, data: Required<ChatTTS>) => Promise<void>;
+
   scheduleHeteroContinuation: (params: HeteroContinuationScheduleParams) => Promise<void>;
+
+  /**
+   * Start TTS for a message
+   * @deprecated Temporary bridge to ChatStore
+   */
+  startMessageTTS: (messageId: string) => void;
 
   /**
    * Stop current generation
@@ -386,15 +399,6 @@ export interface GenerationAction {
    * @deprecated Temporary bridge to ChatStore
    */
   translateMessage: (messageId: string, targetLang: string) => Promise<void>;
-
-  /**
-   * TTS a message
-   * @deprecated Temporary bridge to ChatStore
-   */
-  ttsMessage: (
-    messageId: string,
-    state?: { contentMd5?: string; file?: string; voice?: string },
-  ) => Promise<void>;
 }
 
 export const generationSlice: StateCreator<
@@ -474,9 +478,9 @@ export const generationSlice: StateCreator<
     // Operations are now managed by ChatStore, nothing to clear locally
   },
 
-  clearTTS: async (messageId: string) => {
+  clearMessageTTS: async (messageId: string) => {
     const chatStore = useChatStore.getState();
-    await chatStore.clearTTS(messageId);
+    await chatStore.clearMessageTTS(messageId);
   },
 
   clearTranslate: async (messageId: string) => {
@@ -1081,11 +1085,13 @@ export const generationSlice: StateCreator<
     await chatStore.translateMessage(messageId, targetLang);
   },
 
-  ttsMessage: async (
-    messageId: string,
-    state?: { contentMd5?: string; file?: string; voice?: string },
-  ) => {
+  saveMessageTTS: async (messageId: string, data: Required<ChatTTS>) => {
     const chatStore = useChatStore.getState();
-    await chatStore.ttsMessage(messageId, state);
+    await chatStore.saveMessageTTS(messageId, data);
+  },
+
+  startMessageTTS: (messageId: string) => {
+    const chatStore = useChatStore.getState();
+    chatStore.startMessageTTS(messageId);
   },
 });

--- a/src/store/chat/slices/tts/action.test.ts
+++ b/src/store/chat/slices/tts/action.test.ts
@@ -2,10 +2,10 @@ import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { messageService } from '@/services/message';
+import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 
 import { useChatStore } from '../../store';
 
-// Mock messageService 和 chatService
 vi.mock('@/services/message', () => ({
   messageService: {
     updateMessageTTS: vi.fn(),
@@ -14,49 +14,73 @@ vi.mock('@/services/message', () => ({
   },
 }));
 
-vi.mock('@/services/chat', () => ({
-  chatService: {
-    fetchPresetTaskResult: vi.fn(),
-  },
-}));
-
-vi.mock('@/chains/langDetect', () => ({
-  chainLangDetect: vi.fn(),
-}));
-
-vi.mock('@/chains/translate', () => ({
-  chainTranslate: vi.fn(),
-}));
-
-// Mock supportLocales
-vi.mock('@/locales/options', () => ({
-  supportLocales: ['en-US', 'zh-CN'],
-}));
+const agentId = 'agent-id';
+const messageId = 'message-id';
+const messagesKey = messageMapKey({ agentId });
 
 beforeEach(() => {
   vi.clearAllMocks();
-  useChatStore.setState(
-    {
-      // ... 初始状态
+  useChatStore.setState({
+    activeAgentId: agentId,
+    dbMessagesMap: {
+      [messagesKey]: [
+        {
+          content: 'Message content',
+          createdAt: Date.now(),
+          id: messageId,
+          role: 'assistant',
+          updatedAt: Date.now(),
+        },
+      ],
     },
-    false,
-  );
+    messagesMap: {},
+  });
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('ChatEnhanceAction', () => {
-  describe('clearTTS', () => {
-    it('should clear TTS for a message and refresh messages', async () => {
+describe('ChatTTSAction', () => {
+  describe('startMessageTTS', () => {
+    it('should start TTS locally without persisting an empty payload', () => {
       const { result } = renderHook(() => useChatStore());
-      const messageId = 'message-id';
 
-      await act(async () => {
-        await result.current.clearTTS(messageId);
+      act(() => {
+        result.current.startMessageTTS(messageId);
       });
 
+      const message = useChatStore.getState().dbMessagesMap[messagesKey][0];
+      expect(message.extra?.tts).toEqual({});
+      expect(messageService.updateMessageTTS).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('saveMessageTTS', () => {
+    it('should update local state and persist complete TTS metadata', async () => {
+      const { result } = renderHook(() => useChatStore());
+      const data = { contentMd5: 'content-md5', file: 'file-id', voice: 'voice-id' };
+
+      await act(async () => {
+        await result.current.saveMessageTTS(messageId, data);
+      });
+
+      const message = useChatStore.getState().dbMessagesMap[messagesKey][0];
+      expect(message.extra?.tts).toEqual(data);
+      expect(messageService.updateMessageTTS).toHaveBeenCalledWith(messageId, data);
+    });
+  });
+
+  describe('clearMessageTTS', () => {
+    it('should clear local TTS state and persist the deletion', async () => {
+      const { result } = renderHook(() => useChatStore());
+
+      await act(async () => {
+        await result.current.clearMessageTTS(messageId);
+      });
+
+      const message = useChatStore.getState().dbMessagesMap[messagesKey][0];
+      expect(message.extra?.tts).toBeUndefined();
       expect(messageService.updateMessageTTS).toHaveBeenCalledWith(messageId, false);
     });
   });

--- a/src/store/chat/slices/tts/action.ts
+++ b/src/store/chat/slices/tts/action.ts
@@ -1,4 +1,4 @@
-import { type ChatTTS } from '@lobechat/types';
+import type { ChatTTS } from '@lobechat/types';
 
 import { messageService } from '@/services/message';
 import { type ChatStore } from '@/store/chat/store';
@@ -21,18 +21,7 @@ export class ChatTTSActionImpl {
     this.#get = get;
   }
 
-  clearTTS = async (id: string): Promise<void> => {
-    await this.#get().updateMessageTTS(id, false);
-  };
-
-  ttsMessage = async (
-    id: string,
-    state: { contentMd5?: string; file?: string; voice?: string } = {},
-  ): Promise<void> => {
-    await this.#get().updateMessageTTS(id, state);
-  };
-
-  updateMessageTTS = async (id: string, data: Partial<ChatTTS> | false): Promise<void> => {
+  #updateMessageTTS = async (id: string, data: Required<ChatTTS> | false): Promise<void> => {
     // Optimistic update
     this.#get().internal_dispatchMessage({
       id,
@@ -43,6 +32,23 @@ export class ChatTTSActionImpl {
 
     // Persist to database
     await messageService.updateMessageTTS(id, data);
+  };
+
+  clearMessageTTS = async (id: string): Promise<void> => {
+    await this.#updateMessageTTS(id, false);
+  };
+
+  saveMessageTTS = async (id: string, data: Required<ChatTTS>): Promise<void> => {
+    await this.#updateMessageTTS(id, data);
+  };
+
+  startMessageTTS = (id: string): void => {
+    this.#get().internal_dispatchMessage({
+      id,
+      key: 'tts',
+      type: 'updateMessageExtra',
+      value: {},
+    });
   };
 }
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

- Fixes LOBE-12047

#### 🔀 Description of Change

- Split the overloaded TTS action into explicit start, save, and clear operations.
- Keep the start operation local so it no longer persists an empty payload.
- Persist TTS metadata only after a successful upload with complete metadata.
- Treat empty TTS updates as a backward-compatible no-op for older clients.

#### 🧭 Key Decisions / Non-goals

- Empty payloads remain accepted as a no-op instead of becoming a validation error, preventing older clients from receiving server errors.
- The fix requires no database migration or data backfill.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

##### Automated Tests

- `bun run check --lint --test <changed files>` — lint clean, 85 tests passed.
