### PR TITLE
🐛 fix(resource): preserve source metadata for parsed files

### DIFF
--- a/src/services/file/index.test.ts
+++ b/src/services/file/index.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { isPdfFile } from '@/features/FileViewer/fileType';
+
+import { FileService } from './index';
+
+const { mockGetDocumentById, mockGetFileItemById } = vi.hoisted(() => ({
+  mockGetDocumentById: vi.fn(),
+  mockGetFileItemById: vi.fn(),
+}));
+
+vi.mock('@/libs/trpc/client', () => ({
+  lambdaClient: {
+    document: {
+      getDocumentById: { query: mockGetDocumentById },
+    },
+    file: {
+      getFileItemById: { query: mockGetFileItemById },
+    },
+  },
+}));
+
+describe('FileService.getKnowledgeItem', () => {
+  const service = new FileService();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the backing file metadata when resolving a file-backed PDF document', async () => {
+    mockGetDocumentById.mockResolvedValue({
+      createdAt: new Date('2026-07-22T00:00:00.000Z'),
+      fileId: 'file_pdf',
+      fileType: 'custom/document',
+      filename: 'PDF title without extension',
+      id: 'docs_pdf',
+      source: 'https://app.lobehub.com/f/file_pdf',
+      sourceType: 'file',
+      title: 'PDF title without extension',
+      totalCharCount: 12_345,
+      updatedAt: new Date('2026-07-22T00:00:00.000Z'),
+    });
+    mockGetFileItemById.mockResolvedValue({
+      createdAt: new Date('2026-07-22T00:00:00.000Z'),
+      fileType: 'application/pdf',
+      id: 'file_pdf',
+      name: 'original.pdf',
+      size: 98_765,
+      sourceType: 'file',
+      updatedAt: new Date('2026-07-22T00:00:00.000Z'),
+      url: 'https://app.lobehub.com/f/file_pdf',
+    });
+
+    const result = await service.getKnowledgeItem('docs_pdf');
+
+    expect(result).toMatchObject({
+      fileId: 'file_pdf',
+      fileType: 'application/pdf',
+      id: 'docs_pdf',
+      name: 'original.pdf',
+      size: 98_765,
+      sourceType: 'document',
+      url: 'https://app.lobehub.com/f/file_pdf',
+    });
+    expect(
+      isPdfFile({ fileName: result?.name, fileType: result?.fileType, path: result?.url }),
+    ).toBe(true);
+  });
+
+  it('keeps native documents as pages without requesting backing file metadata', async () => {
+    mockGetDocumentById.mockResolvedValue({
+      createdAt: new Date('2026-07-22T00:00:00.000Z'),
+      fileId: null,
+      fileType: 'custom/document',
+      filename: 'Native page',
+      id: 'docs_page',
+      source: 'page',
+      sourceType: 'api',
+      title: 'Native page',
+      totalCharCount: 100,
+      updatedAt: new Date('2026-07-22T00:00:00.000Z'),
+    });
+
+    const result = await service.getKnowledgeItem('docs_page');
+
+    expect(mockGetFileItemById).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      fileId: null,
+      fileType: 'custom/document',
+      id: 'docs_page',
+      name: 'Native page',
+      sourceType: 'document',
+    });
+    expect(
+      isPdfFile({ fileName: result?.name, fileType: result?.fileType, path: result?.url }),
+    ).toBe(false);
+  });
+});

--- a/src/services/file/index.ts
+++ b/src/services/file/index.ts
@@ -91,6 +91,10 @@ export class FileService {
       const doc = await lambdaClient.document.getDocumentById.query({ id });
       if (!doc) return null;
 
+      const backingFile = doc.fileId
+        ? await lambdaClient.file.getFileItemById.query({ id: doc.fileId })
+        : undefined;
+
       // Convert document to FileListItem format
       return {
         chunkCount: null,
@@ -102,17 +106,17 @@ export class FileService {
         embeddingError: null,
         embeddingStatus: null,
         fileId: doc.fileId,
-        fileType: doc.fileType || CUSTOM_DOCUMENT_FILE_TYPE,
+        fileType: backingFile?.fileType || doc.fileType || CUSTOM_DOCUMENT_FILE_TYPE,
         finishEmbedding: false,
         id: doc.id,
         metadata: doc.metadata,
-        name: doc.title || doc.filename || 'Untitled',
+        name: backingFile?.name || doc.title || doc.filename || 'Untitled',
         parentId: doc.parentId,
-        size: doc.totalCharCount || 0,
+        size: backingFile?.size || doc.totalCharCount || 0,
         slug: doc.slug,
         sourceType: DERIVED_DOCUMENT_SOURCE_TYPE,
         updatedAt: doc.updatedAt ? new Date(doc.updatedAt) : new Date(),
-        url: doc.source || '',
+        url: backingFile?.url || doc.source || '',
       } as FileListItem;
     } else {
       // File - use dedicated file endpoint


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Follow-up to #17432.

#### 🔀 Description of Change

- Resolve the backing file record when a parsed document has a `fileId`.
- Preserve the original MIME type, filename, byte size, and access URL in the unified resource item.
- Keep the document ID and `document` source type so native pages retain their existing behavior.
- Restore PDF preview detection when production uses extensionless `/f/{fileId}` URLs.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check lobehub/src/services/file/index.ts lobehub/src/services/file/index.test.ts --lint --test --type`

Verified that file-backed PDF documents resolve as PDF resources and native documents remain pages.

#### 📝 Additional Information

File-backed documents perform one additional metadata query for their associated file. Native documents without a `fileId` do not issue that query.