### PR TITLE
♻️ refactor(terminal): graduate built-in terminal out of Labs

### DIFF
--- a/locales/ar/labs.json
+++ b/locales/ar/labs.json
@@ -7,8 +7,6 @@
   "features.artifactDeployment.title": "نشر العناصر",
   "features.assistantMessageGroup.desc": "تجميع رسائل الوكيل ونتائج استدعاء الأدوات معًا للعرض",
   "features.assistantMessageGroup.title": "تجميع رسائل الوكيل",
-  "features.builtinTerminal.desc": "عرض زر الطرفية في صفحة الدردشة يفتح لوحة طرفية مدمجة في الأسفل، مع علامات تبويب لكل موضوع تعمل في الصدفة المحلية لديك.",
-  "features.builtinTerminal.title": "الطرفية المدمجة",
   "features.claudeCodeSdk.desc": "قم بتشغيل جلسات Claude Code من خلال Claude Agent SDK بدلاً من تشغيل واجهة سطر الأوامر (CLI). يتيح ذلك بثًا أكثر ثراءً وتحكمًا أفضل في الجلسات.",
   "features.claudeCodeSdk.title": "وقت تشغيل Claude Code SDK",
   "features.groupChat.desc": "تمكين تنسيق الدردشة الجماعية متعددة الوكلاء.",

--- a/locales/bg-BG/labs.json
+++ b/locales/bg-BG/labs.json
@@ -7,8 +7,6 @@
   "features.artifactDeployment.title": "Деплоймент на артефакти",
   "features.assistantMessageGroup.desc": "Групиране на съобщенията от агента и резултатите от извикванията на инструменти заедно за показване",
   "features.assistantMessageGroup.title": "Групиране на съобщения от агент",
-  "features.builtinTerminal.desc": "Показване на бутон за терминал на страницата за чат, който отваря вградения панел на терминала в долната част, с раздели за всяка тема, работещи във вашата локална обвивка.",
-  "features.builtinTerminal.title": "Вграден терминал",
   "features.claudeCodeSdk.desc": "Изпълнявайте сесии на Claude Code чрез Claude Agent SDK вместо да стартирате CLI. Осигурява по-богато стрийминг изживяване и контрол на сесиите.",
   "features.claudeCodeSdk.title": "Claude Code SDK Runtime",
   "features.groupChat.desc": "Активиране на координация в групов чат с множество агенти.",

--- a/locales/de-DE/labs.json
+++ b/locales/de-DE/labs.json
@@ -7,8 +7,6 @@
   "features.artifactDeployment.title": "Artefaktbereitstellungen",
   "features.assistantMessageGroup.desc": "Agenten-Nachrichten und deren Tool-Ergebnisse gemeinsam anzeigen",
   "features.assistantMessageGroup.title": "Agenten-Nachrichten gruppieren",
-  "features.builtinTerminal.desc": "Zeigt eine Terminal-Schaltfläche auf der Chat-Seite an, die ein integriertes Terminal-Panel am unteren Rand öffnet, mit themenspezifischen Tabs, die in Ihrer lokalen Shell ausgeführt werden.",
-  "features.builtinTerminal.title": "Integriertes Terminal",
   "features.claudeCodeSdk.desc": "Führen Sie Claude Code-Sitzungen über das Claude Agent SDK aus, anstatt die CLI zu starten. Ermöglicht reichhaltigeres Streaming und Sitzungssteuerung.",
   "features.claudeCodeSdk.title": "Claude Code SDK-Laufzeit",
   "features.groupChat.desc": "Koordination von Gruppenchats mit mehreren Agenten aktivieren.",

--- a/locales/en-US/labs.json
+++ b/locales/en-US/labs.json
@@ -8,8 +8,6 @@
   "features.artifactDeployment.title": "Artifact Deployments",
   "features.assistantMessageGroup.desc": "Group agent messages and their tool call results together for display",
   "features.assistantMessageGroup.title": "Agent Message Grouping",
-  "features.builtinTerminal.desc": "Show a terminal button on the chat page that opens a built-in terminal panel at the bottom, with per-topic tabs running in your local shell.",
-  "features.builtinTerminal.title": "Built-in Terminal",
   "features.claudeCodeSdk.desc": "Run Claude Code sessions through the Claude Agent SDK instead of spawning the CLI. Enables richer streaming and session control.",
   "features.claudeCodeSdk.title": "Claude Code SDK Runtime",
   "features.groupChat.desc": "Enable multi-agent group chat coordination.",

--- a/locales/es-ES/labs.json
+++ b/locales/es-ES/labs.json
@@ -7,8 +7,6 @@
   "features.artifactDeployment.title": "Despliegues de Artefactos",
   "features.assistantMessageGroup.desc": "Agrupa los mensajes del agente y los resultados de sus herramientas para mostrarlos juntos",
   "features.assistantMessageGroup.title": "Agrupación de Mensajes del Agente",
-  "features.builtinTerminal.desc": "Mostrar un botón de terminal en la página de chat que abre un panel de terminal integrado en la parte inferior, con pestañas por tema que se ejecutan en tu shell local.",
-  "features.builtinTerminal.title": "Terminal Integrado",
   "features.claudeCodeSdk.desc": "Ejecuta sesiones de Claude Code a través del SDK de Claude Agent en lugar de iniciar la CLI. Permite una transmisión más rica y un mejor control de las sesiones.",
   "features.claudeCodeSdk.title": "Entorno de Ejecución del SDK de Claude Code",
   "features.groupChat.desc": "Activa la coordinación de chat grupal con múltiples agentes.",

--- a/locales/fa-IR/labs.json
+++ b/locales/fa-IR/labs.json
@@ -7,8 +7,6 @@
   "features.artifactDeployment.title": "انتشار مصنوعات",
   "features.assistantMessageGroup.desc": "نمایش گروهی پیام‌های عامل و نتایج ابزارهای فراخوانی‌شده به‌صورت یکجا",
   "features.assistantMessageGroup.title": "گروه‌بندی پیام‌های عامل",
-  "features.builtinTerminal.desc": "نمایش دکمه ترمینال در صفحه چت که یک پانل ترمینال داخلی را در پایین باز می‌کند، با زبانه‌های مربوط به هر موضوع که در شل محلی شما اجرا می‌شوند.",
-  "features.builtinTerminal.title": "ترمینال داخلی",
   "features.claudeCodeSdk.desc": "اجرای جلسات Claude Code از طریق Claude Agent SDK به جای اجرای CLI. امکان پخش غنی‌تر و کنترل جلسات را فراهم می‌کند.",
   "features.claudeCodeSdk.title": "محیط اجرایی Claude Code SDK",
   "features.groupChat.desc": "فعال‌سازی هماهنگی گفت‌وگوی گروهی چندعاملی.",

--- a/locales/fr-FR/labs.json
+++ b/locales/fr-FR/labs.json
@@ -7,8 +7,6 @@
   "features.artifactDeployment.title": "Déploiements d'artefacts",
   "features.assistantMessageGroup.desc": "Regroupez les messages de l'agent et les résultats de leurs appels d'outils pour les afficher ensemble",
   "features.assistantMessageGroup.title": "Regroupement des messages de l'agent",
-  "features.builtinTerminal.desc": "Afficher un bouton de terminal sur la page de chat qui ouvre un panneau de terminal intégré en bas, avec des onglets par sujet exécutés dans votre shell local.",
-  "features.builtinTerminal.title": "Terminal intégré",
   "features.claudeCodeSdk.desc": "Exécutez des sessions Claude Code via le SDK Claude Agent au lieu de lancer l'interface en ligne de commande. Permet un streaming plus riche et un meilleur contrôle des sessions.",
   "features.claudeCodeSdk.title": "Runtime SDK Claude Code",
   "features.groupChat.desc": "Activez la coordination de discussions de groupe multi-agents.",

--- a/locales/it-IT/labs.json
+++ b/locales/it-IT/labs.json
@@ -7,8 +7,6 @@
   "features.artifactDeployment.title": "Distribuzioni di Artefatti",
   "features.assistantMessageGroup.desc": "Raggruppa i messaggi dell'agente e i risultati delle chiamate agli strumenti per una visualizzazione unificata",
   "features.assistantMessageGroup.title": "Raggruppamento Messaggi Agente",
-  "features.builtinTerminal.desc": "Mostra un pulsante terminale nella pagina della chat che apre un pannello terminale integrato nella parte inferiore, con schede per argomento che funzionano nella tua shell locale.",
-  "features.builtinTerminal.title": "Terminale Integrato",
   "features.claudeCodeSdk.desc": "Esegui sessioni Claude Code tramite il Claude Agent SDK invece di avviare il CLI. Consente uno streaming più ricco e un controllo delle sessioni più avanzato.",
   "features.claudeCodeSdk.title": "Runtime SDK di Claude Code",
   "features.groupChat.desc": "Abilita il coordinamento della chat di gruppo con più agenti.",

--- a/locales/ja-JP/labs.json
+++ b/locales/ja-JP/labs.json
@@ -7,8 +7,6 @@
   "features.artifactDeployment.title": "アーティファクトデプロイメント",
   "features.assistantMessageGroup.desc": "アシスタントのメッセージとそのツール呼び出し結果をグループ化して表示します",
   "features.assistantMessageGroup.title": "アシスタントメッセージのグループ化表示",
-  "features.builtinTerminal.desc": "チャットページにターミナルボタンを表示し、下部に組み込みのターミナルパネルを開きます。各トピックごとにタブがあり、ローカルシェルで実行されます。",
-  "features.builtinTerminal.title": "組み込みターミナル",
   "features.claudeCodeSdk.desc": "Claude Agent SDKを使用してClaude Codeセッションを実行し、CLIを起動する代わりに利用します。より豊かなストリーミングとセッション管理を可能にします。",
   "features.claudeCodeSdk.title": "Claude Code SDKランタイム",
   "features.groupChat.desc": "複数のAIアシスタントによるグループチャット機能を有効にします。",

--- a/locales/ko-KR/labs.json
+++ b/locales/ko-KR/labs.json
@@ -7,8 +7,6 @@
   "features.artifactDeployment.title": "아티팩트 배포",
   "features.assistantMessageGroup.desc": "도우미 메시지와 해당 도구 호출 결과를 그룹으로 묶어 표시합니다",
   "features.assistantMessageGroup.title": "도우미 메시지 그룹화",
-  "features.builtinTerminal.desc": "채팅 페이지에 터미널 버튼을 표시하여 하단에 내장된 터미널 패널을 열고, 각 주제별 탭에서 로컬 셸을 실행합니다.",
-  "features.builtinTerminal.title": "내장 터미널",
   "features.claudeCodeSdk.desc": "Claude Agent SDK를 통해 Claude Code 세션을 실행하여 CLI를 생성하는 대신 사용합니다. 더 풍부한 스트리밍과 세션 제어를 가능하게 합니다.",
   "features.claudeCodeSdk.title": "Claude Code SDK 런타임",
   "features.groupChat.desc": "다중 도우미 그룹 채팅 조정 기능을 활성화합니다.",

--- a/locales/nl-NL/labs.json
+++ b/locales/nl-NL/labs.json
@@ -7,8 +7,6 @@
   "features.artifactDeployment.title": "Artefactimplementaties",
   "features.assistantMessageGroup.desc": "Groepeer berichten van de agent en de resultaten van hun tool-aanroepen samen voor weergave",
   "features.assistantMessageGroup.title": "Agentberichtengroepering",
-  "features.builtinTerminal.desc": "Toon een terminalknop op de chatpagina die een ingebouwd terminalpaneel opent aan de onderkant, met tabs per onderwerp die in je lokale shell draaien.",
-  "features.builtinTerminal.title": "Ingebouwde Terminal",
   "features.claudeCodeSdk.desc": "Voer Claude Code-sessies uit via de Claude Agent SDK in plaats van de CLI te starten. Biedt rijkere streaming en sessiebeheer.",
   "features.claudeCodeSdk.title": "Claude Code SDK Runtime",
   "features.groupChat.desc": "Schakel coördinatie van groepschats met meerdere agenten in.",

--- a/locales/pl-PL/labs.json
+++ b/locales/pl-PL/labs.json
@@ -7,8 +7,6 @@
   "features.artifactDeployment.title": "Wdrożenia Artefaktów",
   "features.assistantMessageGroup.desc": "Grupuj wiadomości agenta i wyniki wywołań narzędzi razem do wyświetlenia",
   "features.assistantMessageGroup.title": "Grupowanie Wiadomości Agenta",
-  "features.builtinTerminal.desc": "Wyświetl przycisk terminala na stronie czatu, który otwiera wbudowany panel terminala na dole, z zakładkami dla każdego tematu działającymi w lokalnej powłoce.",
-  "features.builtinTerminal.title": "Wbudowany Terminal",
   "features.claudeCodeSdk.desc": "Uruchamiaj sesje Claude Code za pomocą Claude Agent SDK zamiast uruchamiania CLI. Umożliwia bardziej zaawansowane przesyłanie strumieniowe i kontrolę sesji.",
   "features.claudeCodeSdk.title": "Środowisko wykonawcze Claude Code SDK",
   "features.groupChat.desc": "Włącz koordynację czatu grupowego z wieloma agentami.",

--- a/locales/pt-BR/labs.json
+++ b/locales/pt-BR/labs.json
@@ -7,8 +7,6 @@
   "features.artifactDeployment.title": "Implantações de Artefatos",
   "features.assistantMessageGroup.desc": "Agrupe mensagens do agente e os resultados das chamadas de ferramentas para exibição conjunta",
   "features.assistantMessageGroup.title": "Agrupamento de Mensagens do Agente",
-  "features.builtinTerminal.desc": "Exibe um botão de terminal na página de chat que abre um painel de terminal integrado na parte inferior, com abas por tópico executando no seu shell local.",
-  "features.builtinTerminal.title": "Terminal Integrado",
   "features.claudeCodeSdk.desc": "Execute sessões do Claude Code através do Claude Agent SDK em vez de iniciar o CLI. Permite streaming mais rico e controle de sessão.",
   "features.claudeCodeSdk.title": "Runtime do SDK Claude Code",
   "features.groupChat.desc": "Ative a coordenação de bate-papo em grupo com múltiplos agentes.",

--- a/locales/ru-RU/labs.json
+++ b/locales/ru-RU/labs.json
@@ -7,8 +7,6 @@
   "features.artifactDeployment.title": "Развертывание артефактов",
   "features.assistantMessageGroup.desc": "Группируйте сообщения агента и результаты вызова инструментов для совместного отображения",
   "features.assistantMessageGroup.title": "Группировка сообщений агента",
-  "features.builtinTerminal.desc": "Показать кнопку терминала на странице чата, которая открывает встроенную панель терминала внизу с вкладками для каждой темы, работающими в вашем локальном shell.",
-  "features.builtinTerminal.title": "Встроенный терминал",
   "features.claudeCodeSdk.desc": "Запускайте сеансы Claude Code через Claude Agent SDK вместо запуска CLI. Обеспечивает более богатую потоковую передачу и управление сеансами.",
   "features.claudeCodeSdk.title": "Среда выполнения Claude Code SDK",
   "features.groupChat.desc": "Включите координацию группового чата с несколькими агентами.",

--- a/locales/tr-TR/labs.json
+++ b/locales/tr-TR/labs.json
@@ -7,8 +7,6 @@
   "features.artifactDeployment.title": "Artifakt Dağıtımları",
   "features.assistantMessageGroup.desc": "Temsilci mesajlarını ve bunlara ait araç çağrısı sonuçlarını birlikte gruplayarak görüntüleyin",
   "features.assistantMessageGroup.title": "Temsilci Mesaj Gruplama",
-  "features.builtinTerminal.desc": "Sohbet sayfasında, alt kısımda yerel kabuğunuzda çalışan konuya özel sekmelerle yerleşik bir terminal paneli açan bir terminal düğmesi gösterin.",
-  "features.builtinTerminal.title": "Yerleşik Terminal",
   "features.claudeCodeSdk.desc": "Claude Agent SDK aracılığıyla Claude Code oturumlarını çalıştırın, CLI başlatmak yerine. Daha zengin akış ve oturum kontrolü sağlar.",
   "features.claudeCodeSdk.title": "Claude Code SDK Çalışma Zamanı",
   "features.groupChat.desc": "Çoklu temsilci grup sohbeti koordinasyonunu etkinleştirin.",

--- a/locales/vi-VN/labs.json
+++ b/locales/vi-VN/labs.json
@@ -7,8 +7,6 @@
   "features.artifactDeployment.title": "Triển khai Hiện vật",
   "features.assistantMessageGroup.desc": "Nhóm các tin nhắn của tác nhân và kết quả gọi công cụ lại với nhau để hiển thị",
   "features.assistantMessageGroup.title": "Nhóm Tin Nhắn Tác Nhân",
-  "features.builtinTerminal.desc": "Hiển thị nút terminal trên trang trò chuyện, mở bảng điều khiển terminal tích hợp ở phía dưới, với các tab theo từng chủ đề chạy trong shell cục bộ của bạn.",
-  "features.builtinTerminal.title": "Terminal Tích Hợp",
   "features.claudeCodeSdk.desc": "Chạy các phiên Claude Code thông qua Claude Agent SDK thay vì khởi chạy CLI. Cho phép truyền tải phong phú hơn và kiểm soát phiên làm việc.",
   "features.claudeCodeSdk.title": "Thời gian chạy Claude Code SDK",
   "features.groupChat.desc": "Kích hoạt phối hợp trò chuyện nhóm với nhiều tác nhân.",

--- a/locales/zh-CN/labs.json
+++ b/locales/zh-CN/labs.json
@@ -8,8 +8,6 @@
   "features.artifactDeployment.title": "Artifact 部署",
   "features.assistantMessageGroup.desc": "将代理消息及其工具调用结果组合在一起显示",
   "features.assistantMessageGroup.title": "代理消息分组",
-  "features.builtinTerminal.desc": "在会话页显示终端按钮，从底部展开内置终端面板，多标签页与话题绑定，运行本地 Shell。",
-  "features.builtinTerminal.title": "内置终端",
   "features.claudeCodeSdk.desc": "通过 Claude Agent SDK 运行 Claude Code 会话，替代 CLI 进程方式，提供更丰富的流式输出与会话控制。",
   "features.claudeCodeSdk.title": "Claude Code SDK 运行时",
   "features.groupChat.desc": "启用多代理协同群聊功能。",

--- a/locales/zh-TW/labs.json
+++ b/locales/zh-TW/labs.json
@@ -7,8 +7,6 @@
   "features.artifactDeployment.title": "工件部署",
   "features.assistantMessageGroup.desc": "將助手訊息及其工具調用結果彙整成群組顯示",
   "features.assistantMessageGroup.title": "助手訊息彙整群組",
-  "features.builtinTerminal.desc": "在聊天頁面顯示一個終端按鈕，該按鈕會在底部打開一個內建終端面板，並提供每個主題的標籤以在本地 Shell 中運行。",
-  "features.builtinTerminal.title": "內建終端",
   "features.claudeCodeSdk.desc": "透過 Claude Agent SDK 執行 Claude Code 會話，而非啟動 CLI。提供更豐富的串流和會話控制功能。",
   "features.claudeCodeSdk.title": "Claude Code SDK 執行環境",
   "features.groupChat.desc": "啟用多智能體群組聊天編排功能。",

--- a/packages/locales/src/default/labs.ts
+++ b/packages/locales/src/default/labs.ts
@@ -13,9 +13,6 @@ export default {
   'features.assistantMessageGroup.desc':
     'Group agent messages and their tool call results together for display',
   'features.assistantMessageGroup.title': 'Agent Message Grouping',
-  'features.builtinTerminal.desc':
-    'Show a terminal button on the chat page that opens a built-in terminal panel at the bottom, with per-topic tabs running in your local shell.',
-  'features.builtinTerminal.title': 'Built-in Terminal',
   'features.claudeCodeSdk.desc':
     'Run Claude Code sessions through the Claude Agent SDK instead of spawning the CLI. Enables richer streaming and session control.',
   'features.claudeCodeSdk.title': 'Claude Code SDK Runtime',

--- a/packages/types/src/user/preference.ts
+++ b/packages/types/src/user/preference.ts
@@ -95,10 +95,6 @@ export const UserLabSchema = z.object({
    */
   enableArtifactDeployment: z.boolean().optional(),
   /**
-   * show the built-in terminal panel on the chat page (desktop only)
-   */
-  enableBuiltinTerminal: z.boolean().optional(),
-  /**
    * run Claude Code hetero sessions through the Claude Agent SDK instead of CLI spawn
    */
   enableClaudeCodeSdk: z.boolean().optional(),

--- a/src/features/ChatTerminal/index.tsx
+++ b/src/features/ChatTerminal/index.tsx
@@ -7,8 +7,6 @@ import { lazy, memo, Suspense } from 'react';
 
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
-import { useUserStore } from '@/store/user';
-import { labPreferSelectors } from '@/store/user/selectors';
 
 // Content pulls in @xterm/xterm — keep it out of the main bundle until the
 // panel is actually opened.
@@ -16,17 +14,16 @@ const Content = lazy(() => import('./Content'));
 
 /**
  * Codex-style built-in terminal: a full-width bottom panel on the chat page
- * with per-topic tab groups. Desktop-only, gated behind the Labs toggle.
+ * with per-topic tab groups. Desktop-only.
  */
 const ChatTerminalPanel = memo(() => {
-  const enableBuiltinTerminal = useUserStore(labPreferSelectors.enableBuiltinTerminal);
   const [show, height, updateSystemStatus] = useGlobalStore((s) => [
     systemStatusSelectors.showTerminalPanel(s),
     systemStatusSelectors.terminalPanelHeight(s),
     s.updateSystemStatus,
   ]);
 
-  if (!isDesktop || !enableBuiltinTerminal || !show) return null;
+  if (!isDesktop || !show) return null;
 
   return (
     <DraggablePanel

--- a/src/routes/(main)/agent/features/Conversation/Header/TerminalToggle/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/TerminalToggle/index.tsx
@@ -9,13 +9,10 @@ import { useLocation } from 'react-router';
 
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
-import { useUserStore } from '@/store/user';
-import { labPreferSelectors } from '@/store/user/selectors';
 
 const TerminalToggle = memo(() => {
   const { t } = useTranslation('chat');
   const { pathname } = useLocation();
-  const enableBuiltinTerminal = useUserStore(labPreferSelectors.enableBuiltinTerminal);
   const [toggleTerminalPanel, isStatusInit] = useGlobalStore((s) => [
     s.toggleTerminalPanel,
     systemStatusSelectors.isStatusInit(s),
@@ -25,7 +22,7 @@ const TerminalToggle = memo(() => {
   // button that does nothing visible.
   if (pathname.startsWith('/popup')) return null;
 
-  if (!isDesktop || !enableBuiltinTerminal) return null;
+  if (!isDesktop) return null;
 
   // Defer render until status hydrates — updateSystemStatus is a no-op while
   // !isStatusInit, so clicks here would otherwise be silently dropped.

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
@@ -186,9 +186,8 @@ const AgentWorkingSidebar = memo(() => {
   // The in-app browser pages are main-process WebContentsViews — desktop only,
   // and gated behind the Labs toggle while the feature matures.
   const enableInAppBrowser = useUserStore(labPreferSelectors.enableInAppBrowser);
-  const enableBuiltinTerminal = useUserStore(labPreferSelectors.enableBuiltinTerminal);
   const browserAvailable = isDesktop && enableInAppBrowser;
-  const terminalAvailable = isDesktop && enableBuiltinTerminal;
+  const terminalAvailable = isDesktop;
   // Must mint the same key the browser tools do (`sessionIdOf` in
   // builtin-tool-browser), or the user and the agent would be looking at two
   // different pages. A draft topic has no id yet, but the panel is openable

--- a/src/routes/(main)/settings/labs/index.tsx
+++ b/src/routes/(main)/settings/labs/index.tsx
@@ -41,7 +41,6 @@ const Page = memo(() => {
     enableOAuthApps,
     enableInAppBrowser,
     enableArtifactDeployment,
-    enableBuiltinTerminal,
     enableTopicAcceptance,
     updateLab,
   ] = useUserStore((s) => [
@@ -59,7 +58,6 @@ const Page = memo(() => {
     labPreferSelectors.enableOAuthApps(s),
     labPreferSelectors.enableInAppBrowser(s),
     labPreferSelectors.enableArtifactDeployment(s),
-    labPreferSelectors.enableBuiltinTerminal(s),
     labPreferSelectors.enableTopicAcceptance(s),
     s.updateLab,
   ]);
@@ -180,8 +178,7 @@ const Page = memo(() => {
   ];
 
   // Desktop-only experiments: iMessage bridge, the Claude Code SDK runtime, and
-  // the in-app browser / built-in terminal (both main-process WebContentsViews /
-  // PTY sessions).
+  // the in-app browser (main-process WebContentsViews).
   const desktopItems: FormItemProps[] = [
     {
       children: (
@@ -235,19 +232,6 @@ const Page = memo(() => {
       className: styles.labItem,
       desc: tLabs('features.inAppBrowser.desc'),
       label: tLabs('features.inAppBrowser.title'),
-      minWidth: undefined,
-    },
-    {
-      children: (
-        <Switch
-          checked={enableBuiltinTerminal}
-          loading={!isPreferenceInit}
-          onChange={(checked: boolean) => updateLab({ enableBuiltinTerminal: checked })}
-        />
-      ),
-      className: styles.labItem,
-      desc: tLabs('features.builtinTerminal.desc'),
-      label: tLabs('features.builtinTerminal.title'),
       minWidth: undefined,
     },
   ];

--- a/src/store/user/slices/preference/selectors/labPrefer.ts
+++ b/src/store/user/slices/preference/selectors/labPrefer.ts
@@ -11,8 +11,6 @@ export const labPreferSelectors = {
     s.preference.lab?.enableAgentSelfIteration ?? false,
   enableArtifactDeployment: (s: UserState): boolean =>
     s.preference.lab?.enableArtifactDeployment ?? false,
-  enableBuiltinTerminal: (s: UserState): boolean =>
-    s.preference.lab?.enableBuiltinTerminal ?? false,
   enableClaudeCodeSdk: (s: UserState): boolean => s.preference.lab?.enableClaudeCodeSdk ?? false,
   enableHeteroSessionImport: (s: UserState): boolean =>
     s.preference.lab?.enableHeteroSessionImport ?? false,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

The built-in terminal is no longer an experiment, so this PR graduates it out of Labs and makes it a regular desktop feature:

- Remove the "Built-in Terminal" switch from the Labs settings page (Desktop group).
- Make the terminal panel (`ChatTerminal`), the conversation header toggle (`TerminalToggle`), and the working-sidebar terminal tab unconditionally available on desktop — the only remaining gate is `isDesktop`.
- Delete the `enableBuiltinTerminal` field from the user preference schema in `packages/types`, along with `labPreferSelectors.enableBuiltinTerminal`.
- Remove the `features.builtinTerminal.*` locale keys from the default locale source and all 18 `locales/*/labs.json` files.

Stale `enableBuiltinTerminal` keys in existing user preferences are silently dropped by the zod schema, so no migration is needed.

#### 🧪 How to Test

Open LobeHub Desktop → the terminal button in the conversation header and the terminal tab in the working sidebar appear without enabling anything in Settings → Labs, and the Labs page no longer lists "Built-in Terminal".

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📝 Additional Information

`bun run check` (lint + related tests) and the full type-check pass on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)