### PR TITLE
✨ feat(cli): output verification URL after evidence submit

### DIFF
--- a/apps/cli/src/commands/acceptanceRun.ts
+++ b/apps/cli/src/commands/acceptanceRun.ts
@@ -6,6 +6,7 @@ import type { Command } from 'commander';
 import pc from 'picocolors';
 
 import { getTrpcClient } from '../api/client';
+import { resolveServerUrl } from '../settings';
 import { confirm, outputJson, printTable, timeAgo, truncate } from '../utils/format';
 import { log } from '../utils/logger';
 import type { IgnoreResult, LinkResult } from '../utils/skillWiring';
@@ -322,8 +323,14 @@ async function submitAction(options: SubmitOptions): Promise<void> {
     verdict: options.verdict as any,
     verifyRunId: options.run,
   });
+  const verifyRunId = res.checkResult.verifyRunId ?? options.run;
+  if (!verifyRunId) {
+    log.error('Submitted result did not resolve to a verification run');
+    process.exit(1);
+  }
+  const url = new URL(`/verify/${verifyRunId}`, resolveServerUrl()).toString();
   if (options.json !== undefined) {
-    outputJson(res, typeof options.json === 'string' ? options.json : undefined);
+    outputJson({ ...res, url }, typeof options.json === 'string' ? options.json : undefined);
     return;
   }
   console.log(
@@ -331,6 +338,7 @@ async function submitAction(options: SubmitOptions): Promise<void> {
       `${res.checkResult.verdict ? ` (${res.checkResult.verdict})` : ''}` +
       `${res.evidence.length > 0 ? ` +${res.evidence.length} evidence` : ''}`,
   );
+  console.log(`${pc.bold('report')}: ${url}`);
 }
 
 async function decisionAction(resultId: string, decision: Decision): Promise<void> {

--- a/apps/cli/src/commands/verify.test.ts
+++ b/apps/cli/src/commands/verify.test.ts
@@ -39,6 +39,7 @@ const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
 }));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
+vi.mock('../settings', () => ({ resolveServerUrl: () => 'https://app.lobehub.com' }));
 vi.mock('../utils/logger', () => ({
   log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
   setVerbose: vi.fn(),
@@ -793,6 +794,12 @@ describe('lh acceptance — canonical run tree', () => {
   beforeEach(() => {
     consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     mockGetTrpcClient.mockResolvedValue(mockTrpcClient);
+    (mockTrpcClient.verify as Record<string, any>).submitCheckEvidence = {
+      mutate: vi.fn().mockResolvedValue({
+        checkResult: { id: 'result_1', verifyRunId: 'run_1' },
+        evidence: [{ id: 'evidence_1' }],
+      }),
+    };
   });
   afterEach(() => consoleSpy.mockRestore());
 
@@ -809,6 +816,45 @@ describe('lh acceptance — canonical run tree', () => {
     mockTrpcClient.verify.deleteRun.mutate.mockReset().mockResolvedValue({ id: 'run_1' });
     await run(['run', 'delete', 'run_1', '--yes']);
     expect(mockTrpcClient.verify.deleteRun.mutate).toHaveBeenCalledWith({ verifyRunId: 'run_1' });
+  });
+
+  it('prints the full verification report URL after submitting evidence', async () => {
+    await run([
+      'run',
+      'result',
+      'submit',
+      '--operation',
+      'op_1',
+      '--item',
+      'check_1',
+      '--type',
+      'text',
+      '--content',
+      'passed',
+    ]);
+
+    const lines = consoleSpy.mock.calls.map((call) => String(call[0]));
+    expect(lines).toContain('report: https://app.lobehub.com/verify/run_1');
+  });
+
+  it('includes the verification report URL in JSON output', async () => {
+    await run([
+      'run',
+      'result',
+      'submit',
+      '--operation',
+      'op_1',
+      '--item',
+      'check_1',
+      '--type',
+      'text',
+      '--content',
+      'passed',
+      '--json',
+    ]);
+
+    const output = JSON.parse(consoleSpy.mock.calls.map((call) => String(call[0])).join(''));
+    expect(output.url).toBe('https://app.lobehub.com/verify/run_1');
   });
 
   it('exposes `acceptance install` defaulting to the acceptance skill', async () => {

--- a/packages/builtin-skills/src/acceptance/SKILL.md
+++ b/packages/builtin-skills/src/acceptance/SKILL.md
@@ -112,7 +112,8 @@ lh acceptance run result submit --operation "$LOBE_OPERATION_ID" --item "$CHECK_
 `--file` for binaries, `--content` for text — exactly one. Submit one artifact per
 call; call again for each additional one (same `--item` reuses the row). Leave the
 pass/fail **verdict** to the review step — only add `--verdict` if your task
-explicitly asks you to self-assert the outcome.
+explicitly asks you to self-assert the outcome. Every successful submit prints the
+full `/verify/<verifyRunId>` report URL. Preserve that URL for the final handoff.
 
 ## Step 4 — Self-check coverage (do not skip)
 
@@ -131,6 +132,17 @@ must appear at least once in its evidence list. Report it explicitly, e.g.
 `coverage: 2/2 criteria, all required evidence uploaded`. If a type is missing, go
 back to Step 3 — a missing artifact holds the delivery at `uncertain` no matter
 how good the work is.
+
+### Final handoff (mandatory)
+
+The final response MUST include the full report URL printed by
+`lh acceptance run result submit`, together with the explicit coverage result.
+Do not finish with only a check-result id, local artifact path, or prose claim.
+
+```text
+Verification report: https://app.lobehub.com/verify/<verifyRunId>
+Coverage: 2/2 criteria, all required evidence uploaded
+```
 
 ## Worked example (web criterion, one screenshot)
 
@@ -152,6 +164,7 @@ agent-browser --session app screenshot ./proof/settings-beta.png
 lh acceptance run result submit --operation "$OP" --item vci_settings --type screenshot \
   --file ./proof/settings-beta.png --by agent-browser \
   --desc "Settings page renders the new Beta features toggle"
+# → report: https://app.lobehub.com/verify/<verifyRunId>
 
 # 4. self-check
 lh acceptance run result list --operation "$OP" --json # → { checkItemId: vci_settings, id: vcr_77 }


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Print the full server-aware verification report URL after `lh acceptance run result submit`.
- Include the report URL in `--json` output.
- Require the built-in acceptance skill to return the report URL and evidence coverage in its final handoff.
- Add regression coverage for both text and JSON output.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check apps/cli/src/commands/acceptanceRun.ts apps/cli/src/commands/verify.test.ts packages/builtin-skills/src/acceptance/SKILL.md
```

Result: 3 files lint clean, 57 tests passed.

#### 📸 Screenshots / Videos

N/A — CLI and skill behavior only.

#### 📝 Additional Information

No migration or breaking API change.