### PR TITLE
✨ feat: workspace invite feature-flag gating & null-snapshot cache opt-out

### DIFF
--- a/apps/server/src/featureFlags/index.test.ts
+++ b/apps/server/src/featureFlags/index.test.ts
@@ -16,13 +16,28 @@ describe('applyDevelopmentFeatureFlagDefaults', () => {
     );
   });
 
-  it('preserves the runtime Workspace flag when the development force-enable is disabled', () => {
+  it('preserves an explicitly configured Workspace flag when the development force-enable is disabled', () => {
     vi.stubEnv('NODE_ENV', 'development');
     vi.stubEnv('FORCE_ENABLE_WORKSPACE_IN_DEV', 'false');
 
     expect(
-      applyDevelopmentFeatureFlagDefaults({ workspace: ['production-user'] }).workspace,
+      applyDevelopmentFeatureFlagDefaults(
+        { workspace: ['production-user'] },
+        {
+          workspace: ['production-user'],
+        },
+      ).workspace,
     ).toEqual(['production-user']);
+  });
+
+  it('disables Workspace when the development force-enable is disabled and no runtime config sets it', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('FORCE_ENABLE_WORKSPACE_IN_DEV', 'false');
+
+    // The merged flags carry the isDev schema default (true); opting out must
+    // neutralize it so the disabled path is testable locally.
+    expect(applyDevelopmentFeatureFlagDefaults({ workspace: true }, {}).workspace).toBe(false);
+    expect(applyDevelopmentFeatureFlagDefaults({ workspace: true }).workspace).toBe(false);
   });
 
   it('preserves the runtime Workspace flag outside development', () => {

--- a/apps/server/src/featureFlags/index.test.ts
+++ b/apps/server/src/featureFlags/index.test.ts
@@ -9,10 +9,20 @@ afterEach(() => {
 describe('applyDevelopmentFeatureFlagDefaults', () => {
   it('enables Workspace in development when runtime config contains an allowlist', () => {
     vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('FORCE_ENABLE_WORKSPACE_IN_DEV', 'true');
 
     expect(applyDevelopmentFeatureFlagDefaults({ workspace: ['production-user'] }).workspace).toBe(
       true,
     );
+  });
+
+  it('preserves the runtime Workspace flag when the development force-enable is disabled', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('FORCE_ENABLE_WORKSPACE_IN_DEV', 'false');
+
+    expect(
+      applyDevelopmentFeatureFlagDefaults({ workspace: ['production-user'] }).workspace,
+    ).toEqual(['production-user']);
   });
 
   it('preserves the runtime Workspace flag outside development', () => {

--- a/apps/server/src/featureFlags/index.ts
+++ b/apps/server/src/featureFlags/index.ts
@@ -5,7 +5,7 @@ import type { IFeatureFlags } from '@/config/featureFlags';
 import {
   DEFAULT_FEATURE_FLAGS,
   FeatureFlagsSchema,
-  getServerFeatureFlagsValue,
+  getExplicitServerFeatureFlags,
   mapFeatureFlagsEnvToState,
 } from '@/config/featureFlags';
 import type {
@@ -65,8 +65,10 @@ export const applyDevelopmentFeatureFlagDefaults = (
 const getFeatureFlagsProvider = () => {
   featureFlagsProvider ??= new CompositeRuntimeConfigProvider(
     new RedisRuntimeConfigProvider(FEATURE_FLAGS_DOMAIN),
+    // Expose only explicitly-configured env flags; schema defaults are merged in
+    // getMergedFeatureFlags, so the snapshot stays distinguishable from defaults.
     new EnvRuntimeConfigProvider(FEATURE_FLAGS_DOMAIN, {
-      getSnapshotData: () => getServerFeatureFlagsValue(),
+      getSnapshotData: () => getExplicitServerFeatureFlags(),
     }),
   );
 

--- a/apps/server/src/featureFlags/index.ts
+++ b/apps/server/src/featureFlags/index.ts
@@ -31,6 +31,7 @@ const FEATURE_FLAGS_DOMAIN: RuntimeConfigDomain<IFeatureFlags> = {
 };
 
 const FEATURE_FLAG_OVERRIDE_DOMAIN: RuntimeConfigDomain<Record<string, boolean>> = {
+  cacheNullSnapshots: false,
   cacheTtlMs: 30_000,
   getStorageKey: (selector?: RuntimeConfigSelector) => {
     if (!selector || selector.scope !== 'user')
@@ -46,7 +47,9 @@ let featureFlagsProvider: RuntimeConfigProvider<IFeatureFlags> | null = null;
 let featureFlagsOverrideProvider: RuntimeConfigProvider<Record<string, boolean>> | null = null;
 
 export const applyDevelopmentFeatureFlagDefaults = (flags: IFeatureFlags) =>
-  process.env.NODE_ENV === 'development' ? { ...flags, workspace: true } : flags;
+  process.env.NODE_ENV === 'development' && process.env.FORCE_ENABLE_WORKSPACE_IN_DEV !== 'false'
+    ? { ...flags, workspace: true }
+    : flags;
 
 const getFeatureFlagsProvider = () => {
   featureFlagsProvider ??= new CompositeRuntimeConfigProvider(

--- a/apps/server/src/featureFlags/index.ts
+++ b/apps/server/src/featureFlags/index.ts
@@ -46,10 +46,21 @@ const FEATURE_FLAG_OVERRIDE_DOMAIN: RuntimeConfigDomain<Record<string, boolean>>
 let featureFlagsProvider: RuntimeConfigProvider<IFeatureFlags> | null = null;
 let featureFlagsOverrideProvider: RuntimeConfigProvider<Record<string, boolean>> | null = null;
 
-export const applyDevelopmentFeatureFlagDefaults = (flags: IFeatureFlags) =>
-  process.env.NODE_ENV === 'development' && process.env.FORCE_ENABLE_WORKSPACE_IN_DEV !== 'false'
-    ? { ...flags, workspace: true }
-    : flags;
+export const applyDevelopmentFeatureFlagDefaults = (
+  flags: IFeatureFlags,
+  snapshot?: Partial<IFeatureFlags>,
+) => {
+  if (process.env.NODE_ENV !== 'development') return flags;
+
+  if (process.env.FORCE_ENABLE_WORKSPACE_IN_DEV === 'false') {
+    // Opting out must also neutralize the isDev schema default, otherwise the
+    // disabled path is untestable locally; an explicit value from the shared
+    // runtime config still wins.
+    return snapshot && 'workspace' in snapshot ? flags : { ...flags, workspace: false };
+  }
+
+  return { ...flags, workspace: true };
+};
 
 const getFeatureFlagsProvider = () => {
   featureFlagsProvider ??= new CompositeRuntimeConfigProvider(
@@ -75,6 +86,7 @@ const getMergedFeatureFlags = async (userId?: string) => {
   // Apply development defaults after the global snapshot; user-specific overrides below still win.
   const globalFlags = applyDevelopmentFeatureFlagDefaults(
     merge(DEFAULT_FEATURE_FLAGS, globalSnapshot?.data || {}),
+    globalSnapshot?.data,
   );
 
   if (!userId) {

--- a/apps/server/src/runtimeConfig/providers/RedisRuntimeConfigProvider.test.ts
+++ b/apps/server/src/runtimeConfig/providers/RedisRuntimeConfigProvider.test.ts
@@ -75,6 +75,37 @@ describe('RedisRuntimeConfigProvider', () => {
     expect(getMock).toHaveBeenCalledTimes(1);
   });
 
+  it('should re-read missing snapshots when null caching is disabled', async () => {
+    const getMock = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          data: { enabled: true },
+          updatedAt: '2026-07-22T00:00:00.000Z',
+          version: 1,
+        }),
+      );
+
+    getRedisConfigMock.mockReturnValue({ enabled: true });
+    initializeRedisMock.mockResolvedValue({ get: getMock });
+
+    const provider = new RedisRuntimeConfigProvider({
+      ...testDomain,
+      cacheNullSnapshots: false,
+    });
+
+    await expect(provider.getSnapshot({ id: 'user-1', scope: 'user' })).resolves.toBeNull();
+    await expect(provider.getSnapshot({ id: 'user-1', scope: 'user' })).resolves.toEqual({
+      data: { enabled: true },
+      updatedAt: '2026-07-22T00:00:00.000Z',
+      version: 1,
+    });
+
+    expect(initializeRedisMock).toHaveBeenCalledTimes(2);
+    expect(getMock).toHaveBeenCalledTimes(2);
+  });
+
   it('should proactively evict expired selector cache entries', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-04-23T00:00:00.000Z'));

--- a/apps/server/src/runtimeConfig/providers/RedisRuntimeConfigProvider.ts
+++ b/apps/server/src/runtimeConfig/providers/RedisRuntimeConfigProvider.ts
@@ -142,7 +142,9 @@ export class RedisRuntimeConfigProvider<T> implements RuntimeConfigProvider<T> {
       const raw = await redis.get(key);
 
       if (!raw) {
-        this.setCacheRecord(null, selector);
+        if (this.domain.cacheNullSnapshots !== false) {
+          this.setCacheRecord(null, selector);
+        }
         return null;
       }
 

--- a/apps/server/src/runtimeConfig/types.ts
+++ b/apps/server/src/runtimeConfig/types.ts
@@ -18,6 +18,12 @@ export interface VersionedSnapshot<T> {
 }
 
 export interface RuntimeConfigDomain<T> {
+  /**
+   * Whether a missing snapshot should be cached. Disable this for sparse,
+   * dynamically-created selector data where a later write must be visible
+   * immediately (for example, per-user feature-flag overrides).
+   */
+  cacheNullSnapshots?: boolean;
   cacheTtlMs: number;
   getStorageKey: (selector?: RuntimeConfigSelector) => string;
   getVersionKey?: (selector?: RuntimeConfigSelector) => string;

--- a/locales/ar/setting.json
+++ b/locales/ar/setting.json
@@ -2275,6 +2275,7 @@
   "workspace.invitePage.expiredSubtitle": "انتهت صلاحية هذه الدعوة. اطلب من مالك الفريق إرسال دعوة جديدة.",
   "workspace.invitePage.expiredTitle": "انتهت صلاحية الدعوة",
   "workspace.invitePage.expiresLabel": "تنتهي صلاحيتها",
+  "workspace.invitePage.featureNotEnabledNotice": "المساحات في مرحلة تجريبية محدودة وليست مفتوحة للأعضاء الجدد حاليًا. يرجى المحاولة مرة أخرى لاحقًا، أو اطلب من الشخص الذي دعاك التواصل مع الدعم.",
   "workspace.invitePage.goHome": "الذهاب إلى الصفحة الرئيسية",
   "workspace.invitePage.goToWorkspace": "الذهاب إلى مساحة العمل",
   "workspace.invitePage.invitedAs": "مدعو كـ",

--- a/locales/bg-BG/setting.json
+++ b/locales/bg-BG/setting.json
@@ -2275,6 +2275,7 @@
   "workspace.invitePage.expiredSubtitle": "Тази покана е изтекла. Помолете собственика на екипа да изпрати нова.",
   "workspace.invitePage.expiredTitle": "Поканата е изтекла",
   "workspace.invitePage.expiresLabel": "Изтича",
+  "workspace.invitePage.featureNotEnabledNotice": "Работните пространства са в ограничена бета версия и в момента не са отворени за нови членове. Моля, опитайте отново по-късно или помолете човека, който ви е поканил, да се свърже с поддръжката.",
   "workspace.invitePage.goHome": "Отидете на началната страница",
   "workspace.invitePage.goToWorkspace": "Отидете в работното пространство",
   "workspace.invitePage.invitedAs": "Поканен като",

--- a/locales/de-DE/setting.json
+++ b/locales/de-DE/setting.json
@@ -2275,6 +2275,7 @@
   "workspace.invitePage.expiredSubtitle": "Diese Einladung ist abgelaufen. Bitten Sie den Teambesitzer, eine neue zu senden.",
   "workspace.invitePage.expiredTitle": "Einladung abgelaufen",
   "workspace.invitePage.expiresLabel": "Läuft ab",
+  "workspace.invitePage.featureNotEnabledNotice": "Arbeitsbereiche befinden sich in einer begrenzten Beta-Phase und sind derzeit nicht für neue Mitglieder geöffnet. Bitte versuchen Sie es später erneut oder bitten Sie die Person, die Sie eingeladen hat, den Support zu kontaktieren.",
   "workspace.invitePage.goHome": "Zur Startseite",
   "workspace.invitePage.goToWorkspace": "Zum Arbeitsbereich",
   "workspace.invitePage.invitedAs": "Eingeladen als",

--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -2275,6 +2275,7 @@
   "workspace.invitePage.expiredSubtitle": "This invitation has expired. Ask the team owner to send a new one.",
   "workspace.invitePage.expiredTitle": "Invitation Expired",
   "workspace.invitePage.expiresLabel": "Expires",
+  "workspace.invitePage.featureNotEnabledNotice": "Workspaces are in a limited beta and not open to new members right now. Please try again later, or ask the person who invited you to reach out to support.",
   "workspace.invitePage.goHome": "Go Home",
   "workspace.invitePage.goToWorkspace": "Go to Workspace",
   "workspace.invitePage.invitedAs": "Invited as",

--- a/locales/es-ES/setting.json
+++ b/locales/es-ES/setting.json
@@ -2275,6 +2275,7 @@
   "workspace.invitePage.expiredSubtitle": "Esta invitación ha expirado. Pide al propietario del equipo que envíe una nueva.",
   "workspace.invitePage.expiredTitle": "Invitación expirada",
   "workspace.invitePage.expiresLabel": "Expira",
+  "workspace.invitePage.featureNotEnabledNotice": "Los espacios de trabajo están en una beta limitada y no están abiertos a nuevos miembros en este momento. Por favor, inténtalo de nuevo más tarde o pide a la persona que te invitó que se comunique con el soporte.",
   "workspace.invitePage.goHome": "Ir a inicio",
   "workspace.invitePage.goToWorkspace": "Ir al espacio de trabajo",
   "workspace.invitePage.invitedAs": "Invitado como",

--- a/locales/fa-IR/setting.json
+++ b/locales/fa-IR/setting.json
@@ -2275,6 +2275,7 @@
   "workspace.invitePage.expiredSubtitle": "این دعوت منقضی شده است. از مالک تیم بخواهید دعوت جدیدی ارسال کند.",
   "workspace.invitePage.expiredTitle": "دعوت منقضی شده است",
   "workspace.invitePage.expiresLabel": "منقضی می‌شود",
+  "workspace.invitePage.featureNotEnabledNotice": "فضاهای کاری در مرحله آزمایشی محدود هستند و در حال حاضر برای اعضای جدید باز نیستند. لطفاً بعداً دوباره تلاش کنید، یا از شخصی که شما را دعوت کرده بخواهید با پشتیبانی تماس بگیرد.",
   "workspace.invitePage.goHome": "بازگشت به خانه",
   "workspace.invitePage.goToWorkspace": "رفتن به فضای کاری",
   "workspace.invitePage.invitedAs": "دعوت شده به عنوان",

--- a/locales/fr-FR/setting.json
+++ b/locales/fr-FR/setting.json
@@ -2275,6 +2275,7 @@
   "workspace.invitePage.expiredSubtitle": "Cette invitation a expiré. Demandez au propriétaire de l'équipe d'en envoyer une nouvelle.",
   "workspace.invitePage.expiredTitle": "Invitation expirée",
   "workspace.invitePage.expiresLabel": "Expire",
+  "workspace.invitePage.featureNotEnabledNotice": "Les espaces de travail sont en version bêta limitée et ne sont pas ouverts à de nouveaux membres pour le moment. Veuillez réessayer plus tard ou demandez à la personne qui vous a invité de contacter le support.",
   "workspace.invitePage.goHome": "Aller à l'accueil",
   "workspace.invitePage.goToWorkspace": "Aller à l'espace de travail",
   "workspace.invitePage.invitedAs": "Invité en tant que",

--- a/locales/it-IT/setting.json
+++ b/locales/it-IT/setting.json
@@ -2275,6 +2275,7 @@
   "workspace.invitePage.expiredSubtitle": "Questo invito è scaduto. Chiedi al proprietario del team di inviarne uno nuovo.",
   "workspace.invitePage.expiredTitle": "Invito Scaduto",
   "workspace.invitePage.expiresLabel": "Scade",
+  "workspace.invitePage.featureNotEnabledNotice": "I workspace sono in una beta limitata e non sono aperti a nuovi membri al momento. Per favore, riprova più tardi o chiedi alla persona che ti ha invitato di contattare il supporto.",
   "workspace.invitePage.goHome": "Vai alla Home",
   "workspace.invitePage.goToWorkspace": "Vai al Workspace",
   "workspace.invitePage.invitedAs": "Invitato come",

--- a/locales/ja-JP/setting.json
+++ b/locales/ja-JP/setting.json
@@ -2275,6 +2275,7 @@
   "workspace.invitePage.expiredSubtitle": "この招待は期限切れです。チーム所有者に新しい招待を送るよう依頼してください。",
   "workspace.invitePage.expiredTitle": "招待が期限切れ",
   "workspace.invitePage.expiresLabel": "有効期限",
+  "workspace.invitePage.featureNotEnabledNotice": "ワークスペースは現在限定ベータ版で、新しいメンバーの参加は受け付けていません。後ほど再度お試しいただくか、招待した方にサポートへ連絡するようお伝えください。",
   "workspace.invitePage.goHome": "ホームに戻る",
   "workspace.invitePage.goToWorkspace": "ワークスペースに移動",
   "workspace.invitePage.invitedAs": "招待された役割",

--- a/locales/ko-KR/setting.json
+++ b/locales/ko-KR/setting.json
@@ -2275,6 +2275,7 @@
   "workspace.invitePage.expiredSubtitle": "이 초대는 만료되었습니다. 팀 소유자에게 새 초대를 요청하세요.",
   "workspace.invitePage.expiredTitle": "초대 만료됨",
   "workspace.invitePage.expiresLabel": "만료",
+  "workspace.invitePage.featureNotEnabledNotice": "워크스페이스는 현재 제한된 베타 버전으로 운영되고 있으며, 지금은 새로운 멤버를 받을 수 없습니다. 나중에 다시 시도해주시거나, 초대한 사람에게 지원팀에 문의해달라고 요청하세요.",
   "workspace.invitePage.goHome": "홈으로 이동",
   "workspace.invitePage.goToWorkspace": "워크스페이스로 이동",
   "workspace.invitePage.invitedAs": "초대됨",

--- a/locales/nl-NL/setting.json
+++ b/locales/nl-NL/setting.json
@@ -2275,6 +2275,7 @@
   "workspace.invitePage.expiredSubtitle": "Deze uitnodiging is verlopen. Vraag de team-eigenaar om een nieuwe te sturen.",
   "workspace.invitePage.expiredTitle": "Uitnodiging Verlopen",
   "workspace.invitePage.expiresLabel": "Verloopt",
+  "workspace.invitePage.featureNotEnabledNotice": "Werkruimtes bevinden zich in een beperkte bètafase en zijn momenteel niet open voor nieuwe leden. Probeer het later opnieuw, of vraag de persoon die je heeft uitgenodigd om contact op te nemen met de ondersteuning.",
   "workspace.invitePage.goHome": "Ga naar Startpagina",
   "workspace.invitePage.goToWorkspace": "Ga naar Werkruimte",
   "workspace.invitePage.invitedAs": "Uitgenodigd als",

--- a/locales/pl-PL/setting.json
+++ b/locales/pl-PL/setting.json
@@ -2275,6 +2275,7 @@
   "workspace.invitePage.expiredSubtitle": "To zaproszenie wygasło. Poproś właściciela zespołu o wysłanie nowego.",
   "workspace.invitePage.expiredTitle": "Zaproszenie wygasło",
   "workspace.invitePage.expiresLabel": "Wygasa",
+  "workspace.invitePage.featureNotEnabledNotice": "Przestrzenie robocze są w ograniczonej wersji beta i obecnie nie są dostępne dla nowych członków. Spróbuj ponownie później lub poproś osobę, która Cię zaprosiła, aby skontaktowała się z pomocą techniczną.",
   "workspace.invitePage.goHome": "Przejdź do strony głównej",
   "workspace.invitePage.goToWorkspace": "Przejdź do workspace",
   "workspace.invitePage.invitedAs": "Zaproszony jako",

--- a/locales/pt-BR/setting.json
+++ b/locales/pt-BR/setting.json
@@ -2275,6 +2275,7 @@
   "workspace.invitePage.expiredSubtitle": "Este convite expirou. Peça ao proprietário da equipe para enviar um novo.",
   "workspace.invitePage.expiredTitle": "Convite Expirado",
   "workspace.invitePage.expiresLabel": "Expira em",
+  "workspace.invitePage.featureNotEnabledNotice": "Os Workspaces estão em beta limitado e não estão abertos para novos membros no momento. Por favor, tente novamente mais tarde ou peça à pessoa que o convidou para entrar em contato com o suporte.",
   "workspace.invitePage.goHome": "Ir para Início",
   "workspace.invitePage.goToWorkspace": "Ir para o Workspace",
   "workspace.invitePage.invitedAs": "Convidado como",

--- a/locales/ru-RU/setting.json
+++ b/locales/ru-RU/setting.json
@@ -2275,6 +2275,7 @@
   "workspace.invitePage.expiredSubtitle": "Это приглашение истекло. Попросите владельца команды отправить новое.",
   "workspace.invitePage.expiredTitle": "Приглашение истекло",
   "workspace.invitePage.expiresLabel": "Истекает",
+  "workspace.invitePage.featureNotEnabledNotice": "Рабочие пространства находятся в ограниченной бета-версии и в настоящее время недоступны для новых участников. Пожалуйста, попробуйте позже или попросите человека, который вас пригласил, связаться с поддержкой.",
   "workspace.invitePage.goHome": "На главную",
   "workspace.invitePage.goToWorkspace": "Перейти в рабочую область",
   "workspace.invitePage.invitedAs": "Приглашен как",

--- a/locales/tr-TR/setting.json
+++ b/locales/tr-TR/setting.json
@@ -2275,6 +2275,7 @@
   "workspace.invitePage.expiredSubtitle": "Bu davetin süresi dolmuş. Ekip sahibinden yenisini göndermesini isteyin.",
   "workspace.invitePage.expiredTitle": "Davetin Süresi Doldu",
   "workspace.invitePage.expiresLabel": "Sona eriyor",
+  "workspace.invitePage.featureNotEnabledNotice": "Çalışma alanları şu anda sınırlı bir beta sürümünde ve yeni üyelere açık değil. Lütfen daha sonra tekrar deneyin veya sizi davet eden kişiden destek ekibiyle iletişime geçmesini isteyin.",
   "workspace.invitePage.goHome": "Ana Sayfaya Git",
   "workspace.invitePage.goToWorkspace": "Çalışma Alanına Git",
   "workspace.invitePage.invitedAs": "Davet edilen rol",

--- a/locales/vi-VN/setting.json
+++ b/locales/vi-VN/setting.json
@@ -2275,6 +2275,7 @@
   "workspace.invitePage.expiredSubtitle": "Lời mời này đã hết hạn. Hãy yêu cầu chủ sở hữu nhóm gửi một lời mời mới.",
   "workspace.invitePage.expiredTitle": "Lời mời đã hết hạn",
   "workspace.invitePage.expiresLabel": "Hết hạn",
+  "workspace.invitePage.featureNotEnabledNotice": "Không gian làm việc đang trong giai đoạn thử nghiệm giới hạn và hiện không mở cửa cho thành viên mới. Vui lòng thử lại sau hoặc yêu cầu người đã mời bạn liên hệ với bộ phận hỗ trợ.",
   "workspace.invitePage.goHome": "Về trang chủ",
   "workspace.invitePage.goToWorkspace": "Đi đến không gian làm việc",
   "workspace.invitePage.invitedAs": "Được mời làm",

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -2275,6 +2275,7 @@
   "workspace.invitePage.expiredSubtitle": "此邀请已过期。请团队所有者发送一个新的邀请。",
   "workspace.invitePage.expiredTitle": "邀请已过期",
   "workspace.invitePage.expiresLabel": "到期",
+  "workspace.invitePage.featureNotEnabledNotice": "Workspace 目前处于小范围内测阶段，暂未向新成员开放。请稍后再试，或让邀请你的人联系支持团队。",
   "workspace.invitePage.goHome": "返回首页",
   "workspace.invitePage.goToWorkspace": "进入工作区",
   "workspace.invitePage.invitedAs": "邀请为",

--- a/locales/zh-TW/setting.json
+++ b/locales/zh-TW/setting.json
@@ -2275,6 +2275,7 @@
   "workspace.invitePage.expiredSubtitle": "此邀請已過期。請要求團隊擁有者發送新的邀請。",
   "workspace.invitePage.expiredTitle": "邀請已過期",
   "workspace.invitePage.expiresLabel": "到期",
+  "workspace.invitePage.featureNotEnabledNotice": "工作區目前處於有限測試階段，暫時不開放新成員加入。請稍後再試，或請邀請您的人聯繫客服支援。",
   "workspace.invitePage.goHome": "返回首頁",
   "workspace.invitePage.goToWorkspace": "前往工作區",
   "workspace.invitePage.invitedAs": "邀請為",

--- a/packages/app-config/src/featureFlags/index.ts
+++ b/packages/app-config/src/featureFlags/index.ts
@@ -16,6 +16,12 @@ const env = createEnv({
   },
 });
 
+/**
+ * Only the flags explicitly configured via the FEATURE_FLAGS env var,
+ * without schema defaults merged in.
+ */
+export const getExplicitServerFeatureFlags = () => parseFeatureFlag(env.FEATURE_FLAGS);
+
 export const getServerFeatureFlagsValue = () => {
   const flags = parseFeatureFlag(env.FEATURE_FLAGS);
 

--- a/packages/locales/src/default/setting.ts
+++ b/packages/locales/src/default/setting.ts
@@ -2472,6 +2472,8 @@ When I am ___, I need ___
     'This invitation has expired. Ask the team owner to send a new one.',
   'workspace.invitePage.expiredTitle': 'Invitation Expired',
   'workspace.invitePage.expiresLabel': 'Expires',
+  'workspace.invitePage.featureNotEnabledNotice':
+    'Workspaces are in a limited beta and not open to new members right now. Please try again later, or ask the person who invited you to reach out to support.',
   'workspace.invitePage.goHome': 'Go Home',
   'workspace.invitePage.goToWorkspace': 'Go to Workspace',
   'workspace.invitePage.invitedAs': 'Invited as',


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

<!-- internal rollout task -->

#### 🔀 Description of Change

1. **Feature-flag gating for the workspace invite flow**
   - `applyDevelopmentFeatureFlagDefaults` now respects `FORCE_ENABLE_WORKSPACE_IN_DEV=false`, so dev environments can opt out of the forced `workspace: true` default.
   - Adds the `workspace.invitePage.featureNotEnabledNotice` locale key (all 18 locales) shown when the workspace feature is not enabled for the invitee.

2. **`cacheNullSnapshots` option for `RuntimeConfigDomain`**
   - `RedisRuntimeConfigProvider` previously cached "no snapshot" results for the full `cacheTtlMs`, which delays visibility of newly-written sparse selector data (e.g. per-user feature-flag overrides).
   - Domains can now set `cacheNullSnapshots: false` to skip negative caching; the feature-flag override domain opts out.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

`bun run check` on changed files: lint clean, 71 tests passed; type-check clean.

#### 📝 Additional Information

No breaking changes. Default behavior of `RedisRuntimeConfigProvider` is unchanged (`cacheNullSnapshots` defaults to caching, as before).