### PR TITLE
✨ feat(database): expose runStartedAt for running topics in queryTopics

### DIFF
--- a/packages/database/src/models/__tests__/topic.test.ts
+++ b/packages/database/src/models/__tests__/topic.test.ts
@@ -3,7 +3,15 @@ import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../core/getTestDB';
-import { agents, chatGroups, messages, sessions, topics, users } from '../../schemas';
+import {
+  agentOperations,
+  agents,
+  chatGroups,
+  messages,
+  sessions,
+  topics,
+  users,
+} from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
 import { TopicModel } from '../topic';
 
@@ -408,6 +416,74 @@ describe('TopicModel', () => {
       });
 
       expect(topic.lastAssistantMessage).toBe(`${'x'.repeat(2000)}…`);
+    });
+
+    it('resolves runStartedAt from the latest top-level running operation', async () => {
+      await serverDB.insert(topics).values([
+        { id: 't-run', status: 'running', title: 'run', userId },
+        { id: 't-no-op', status: 'running', title: 'no op', userId },
+      ]);
+      await serverDB.insert(agentOperations).values([
+        // Abandoned row from a crashed earlier run — the live (later) one wins.
+        {
+          id: 'op-stale',
+          startedAt: new Date('2026-01-01T00:00:00Z'),
+          status: 'running',
+          topicId: 't-run',
+          userId,
+        },
+        {
+          id: 'op-live',
+          startedAt: new Date('2026-01-02T00:00:00Z'),
+          status: 'running',
+          topicId: 't-run',
+          userId,
+        },
+        // Sub-operation spawned later must not restart the clock.
+        {
+          id: 'op-sub',
+          parentOperationId: 'op-live',
+          startedAt: new Date('2026-01-03T00:00:00Z'),
+          status: 'running',
+          topicId: 't-run',
+          userId,
+        },
+        // Finished op of the same topic is not the current run.
+        {
+          id: 'op-done',
+          startedAt: new Date('2026-01-04T00:00:00Z'),
+          status: 'done',
+          topicId: 't-run',
+          userId,
+        },
+      ]);
+
+      const result = await topicModel.queryTopics({ statuses: ['running'] });
+      const byId = Object.fromEntries(result.map((t) => [t.id, t]));
+
+      expect(byId['t-run'].runStartedAt).toEqual(new Date('2026-01-02T00:00:00Z'));
+      // A run that never wrote an operation row (e.g. client-mode) stays null.
+      expect(byId['t-no-op'].runStartedAt).toBeNull();
+    });
+
+    it('never resurrects a timer for a non-running topic with a stale running op', async () => {
+      await serverDB
+        .insert(topics)
+        .values({ id: 't-unread', status: 'unread', title: 'u', userId });
+      await serverDB.insert(agentOperations).values({
+        id: 'op-leftover',
+        startedAt: new Date('2026-01-01T00:00:00Z'),
+        status: 'running',
+        topicId: 't-unread',
+        userId,
+      });
+
+      const [topic] = await topicModel.queryTopics({
+        statuses: ['unread'],
+        withLastMessage: true,
+      });
+
+      expect(topic.runStartedAt).toBeNull();
     });
   });
 

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -23,6 +23,7 @@ import {
   gt,
   gte,
   inArray,
+  isNotNull,
   isNull,
   lte,
   ne,
@@ -32,7 +33,15 @@ import {
 } from 'drizzle-orm';
 
 import type { TopicItem } from '../schemas';
-import { agents, messagePlugins, messages, threads, topicDocuments, topics } from '../schemas';
+import {
+  agentOperations,
+  agents,
+  messagePlugins,
+  messages,
+  threads,
+  topicDocuments,
+  topics,
+} from '../schemas';
 import type { LobeChatDatabase } from '../type';
 import { sanitizeBm25Query } from '../utils/bm25';
 import { genEndDateWhere, genRangeWhere, genStartDateWhere, genWhere } from '../utils/genWhere';
@@ -56,6 +65,13 @@ const LAST_MESSAGE_PREVIEW_LENGTH = 2000;
 export interface TopicListItem extends TopicItem {
   /** The topic's last non-empty assistant reply, truncated with a trailing `…`. Only set when `queryTopics` is called with `withLastMessage`. */
   lastAssistantMessage?: string | null;
+  /**
+   * When the topic's current run started (`agent_operations.startedAt` of its
+   * latest top-level running operation). Only computed for `running` topics;
+   * null for everything else, and for runs that never wrote an operation row
+   * (e.g. client-mode runs) — callers must keep a fallback.
+   */
+  runStartedAt?: Date | null;
 }
 
 export interface CreateTopicParams {
@@ -615,9 +631,40 @@ export class TopicModel {
         : undefined,
     );
 
+    // When the topic's current run started, so a list can show live elapsed
+    // time instead of `updatedAt` (which moves on every message write). The
+    // latest *top-level* running operation is the current run: sub-operations
+    // (callAgent) would restart the clock at their own spawn time, and an
+    // abandoned `running` row from a crashed earlier run sorts below the live
+    // one. Not scoped by `ownership()` — in a workspace the run may have been
+    // started by another member, and the topic join is already ownership-gated.
+    const runStartedAtSubquery = this.db
+      .select({ value: agentOperations.startedAt })
+      .from(agentOperations)
+      .where(
+        and(
+          eq(agentOperations.topicId, topics.id),
+          eq(agentOperations.status, 'running'),
+          isNull(agentOperations.parentOperationId),
+          isNotNull(agentOperations.startedAt),
+        ),
+      )
+      .orderBy(desc(agentOperations.startedAt))
+      .limit(1);
+
+    // CASE-gated so only rows that are actually running pay for the lookup —
+    // and a stale running op under a finished topic can't resurrect a timer.
+    const runStartedAtColumn =
+      sql<Date | null>`CASE WHEN ${topics.status} = 'running' THEN (${runStartedAtSubquery}) ELSE NULL END`
+        .mapWith(agentOperations.startedAt)
+        .as('run_started_at');
+
     if (!withLastMessage) {
       return this.db
-        .select()
+        .select({
+          ...getTableColumns(topics),
+          runStartedAt: runStartedAtColumn,
+        })
         .from(topics)
         .where(where)
         .orderBy(desc(topics.updatedAt))
@@ -654,6 +701,7 @@ export class TopicModel {
         lastAssistantMessage: sql<string | null>`(${lastAssistantMessageSubquery})`.as(
           'last_assistant_message',
         ),
+        runStartedAt: runStartedAtColumn,
       })
       .from(topics)
       .where(where)

--- a/src/services/topic/index.ts
+++ b/src/services/topic/index.ts
@@ -24,6 +24,12 @@ import {
 export interface TopicListItem extends ChatTopic {
   agentId?: string | null;
   lastAssistantMessage?: string | null;
+  /**
+   * Start time of the topic's current run (latest top-level running
+   * `agent_operations` row). Only set for `running` topics; null when the run
+   * never wrote an operation row (e.g. client-mode) — keep a fallback.
+   */
+  runStartedAt?: Date | null;
 }
 
 export type TopicBatchDeleteScope = 'own' | 'workspace';


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None — groundwork for showing live elapsed time on running topics in the home inbox.

#### 🔀 Description of Change

The home inbox running card currently shows `updatedAt` as a relative time, which moves on every message write and doesn't tell the user how long a run has actually been going. The sidebar's live timer can't be reused there: it reads the local chat store's operation `startTime`, which only exists for runs executing in the current browser session.

This PR adds a server-side `runStartedAt` field to `TopicModel.queryTopics`, resolved from `agent_operations.startedAt`:

- A scalar subquery picks the **latest top-level running operation** per topic (`status = 'running'`, `parent_operation_id IS NULL`, ordered by `started_at DESC`). Latest-wins keeps an abandoned `running` row from a crashed earlier run from producing a wildly wrong elapsed time, and excluding sub-operations (callAgent) keeps them from restarting the clock at their own spawn time.
- The subquery is `CASE`-gated on `topics.status = 'running'`, so non-running rows pay nothing and a stale running op under a finished topic can never resurrect a timer.
- The subquery is deliberately not scoped by `ownership()`: in a workspace the run may have been started by another member, and the outer topic query is already ownership-gated.
- `TopicListItem` (model + client service) declares `runStartedAt?: Date | null`. It stays null for runs that never wrote an operation row (e.g. client-mode), so consumers must keep a fallback to `updatedAt`.

The lambda router passes the model result through unchanged, and superjson preserves the `Date` over the wire — no router changes needed. Client UI (the actual elapsed timer in the home inbox) lands separately.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

New cases in `packages/database/src/models/__tests__/topic.test.ts` cover: latest top-level running op wins over a stale earlier one, sub-operations and finished ops are ignored, topics without an op row return null, and a non-running topic with a leftover running op returns null. Full `topic.test.ts` (50) and `topics/topic.query.test.ts` (68) pass; type-check clean.

#### 📝 Additional Information

Query cost is one indexed subquery (`agent_operations_topic_id_idx`) per running row only, thanks to the `CASE` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)