### PR TITLE
🐛 fix: enforce agent step execution deadlines

### DIFF
--- a/apps/server/src/agent-hono/handlers/__tests__/runStep.test.ts
+++ b/apps/server/src/agent-hono/handlers/__tests__/runStep.test.ts
@@ -352,12 +352,33 @@ describe('runStep handler', () => {
 
     expect(res.status).toBe(500);
     expect(mockGetServerDB).not.toHaveBeenCalled();
-    expect(JSON.parse(warnSpy.mock.calls.at(-1)![0])).toMatchObject({
+    const warnings = warnSpy.mock.calls.map(([warning]) => JSON.parse(warning));
+    const deadlineReachedIndex = warnings.findIndex(
+      ({ event }) => event === 'agent.run_step.deadline_reached',
+    );
+    const timeoutIndex = warnings.findIndex(({ event }) => event === 'agent.run_step.timeout');
+
+    expect(deadlineReachedIndex).toBeGreaterThanOrEqual(0);
+    expect(timeoutIndex).toBeGreaterThan(deadlineReachedIndex);
+    expect(warnings[deadlineReachedIndex]).toMatchObject({
+      deadlineAt: expect.any(Number),
+      elapsedMs: expect.any(Number),
+      operationId: 'op-1',
+      spanId: expect.any(String),
+      stage: 'metadata.load',
+      stageElapsedMs: expect.any(Number),
+      stepIndex: 2,
+      traceId: expect.any(String),
+    });
+    expect(warnings[timeoutIndex]).toMatchObject({
       event: 'agent.run_step.timeout',
       handled: false,
       operationId: 'op-1',
+      spanId: expect.any(String),
       stage: 'metadata.load',
+      stageElapsedMs: expect.any(Number),
       stepIndex: 2,
+      traceId: expect.any(String),
     });
     errorSpy.mockRestore();
     warnSpy.mockRestore();

--- a/apps/server/src/agent-hono/handlers/__tests__/runStep.test.ts
+++ b/apps/server/src/agent-hono/handlers/__tests__/runStep.test.ts
@@ -1,9 +1,13 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  AgentStepTimeoutError,
+  markAgentStepTimeoutHandled,
+} from '@/server/modules/AgentRuntime/stepDeadline';
 import { AiAgentService } from '@/server/services/aiAgent';
 
-import { runStep, runStepHealth } from '../runStep';
+import { createRunStepHandler, runStep, runStepHealth } from '../runStep';
 
 const mockGetOperationMetadata = vi.fn();
 const mockExecuteStep = vi.fn();
@@ -229,6 +233,30 @@ describe('runStep handler', () => {
     );
   });
 
+  it('forwards one shared deadline and AbortSignal to executeStep', async () => {
+    mockGetOperationMetadata.mockResolvedValue({ userId: 'user-1' });
+    mockExecuteStep.mockResolvedValue({
+      nextStepScheduled: false,
+      state: { cost: { total: 0 }, status: 'done', stepCount: 1 },
+      success: true,
+    });
+
+    const before = Date.now();
+    const { ctx } = buildContext({ body: validBody });
+    await runStep(ctx);
+
+    expect(mockExecuteStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deadlineAt: expect.any(Number),
+        onStage: expect.any(Function),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(mockExecuteStep.mock.calls[0][0].deadlineAt).toBeGreaterThanOrEqual(
+      before + 8 * 60 * 1000,
+    );
+  });
+
   it('unwraps QStash `body.payload` resume/intervention fields into executeStep', async () => {
     mockGetOperationMetadata.mockResolvedValue({ userId: 'user-1' });
     mockExecuteStep.mockResolvedValue({
@@ -311,6 +339,98 @@ describe('runStep handler', () => {
       operationId: 'op-1',
       stepIndex: 2,
     });
+  });
+
+  it('ACKs a handled step timeout with a stable error type and structured diagnostics', async () => {
+    mockGetOperationMetadata.mockResolvedValue({ userId: 'user-1' });
+    mockExecuteStep.mockImplementation(({ signal }) => {
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener(
+          'abort',
+          () => {
+            const error = signal.reason as AgentStepTimeoutError;
+            markAgentStepTimeoutHandled(error);
+            reject(error);
+          },
+          { once: true },
+        );
+      });
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handler = createRunStepHandler({ stepDeadlineMs: 10 });
+    const { ctx, getCaptures } = buildContext({
+      body: { ...validBody, timestamp: Date.now() - 125 },
+      messageId: 'qstash-1',
+      retried: '2',
+    });
+
+    const res = await handler(ctx);
+
+    expect(res.status).toBe(200);
+    expect(getCaptures()[0].body).toMatchObject({
+      errorType: 'AgentStepTimeout',
+      operationId: 'op-1',
+      stage: 'runtime.execute',
+      stepIndex: 2,
+      success: false,
+    });
+    expect(JSON.parse(warnSpy.mock.calls.at(-1)![0])).toMatchObject({
+      event: 'agent.run_step.timeout',
+      operationId: 'op-1',
+      qstashMessageId: 'qstash-1',
+      stage: 'runtime.execute',
+      stepIndex: 2,
+      upstashRetried: '2',
+    });
+    warnSpy.mockRestore();
+  });
+
+  it('keeps an unhandled timeout retryable with a 500 response', async () => {
+    mockGetOperationMetadata.mockResolvedValue({ userId: 'user-1' });
+    mockExecuteStep.mockRejectedValue(
+      new AgentStepTimeoutError({ deadlineAt: Date.now(), stage: 'state.load' }),
+    );
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { ctx } = buildContext({ body: validBody });
+
+    const res = await runStep(ctx);
+
+    expect(res.status).toBe(500);
+    expect(JSON.parse(warnSpy.mock.calls.at(-1)![0])).toMatchObject({
+      event: 'agent.run_step.timeout',
+      handled: false,
+      operationId: 'op-1',
+      stage: 'state.load',
+      stepIndex: 2,
+    });
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it('keeps a timeout retryable when persisting its terminal error state fails', async () => {
+    mockGetOperationMetadata.mockResolvedValue({ userId: 'user-1' });
+    const timeoutError = new AgentStepTimeoutError({
+      deadlineAt: Date.now(),
+      stage: 'state.error_save',
+    });
+    mockExecuteStep.mockRejectedValue(new Error('state save failed', { cause: timeoutError }));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { ctx } = buildContext({ body: validBody });
+
+    const res = await runStep(ctx);
+
+    expect(res.status).toBe(500);
+    expect(JSON.parse(warnSpy.mock.calls.at(-1)![0])).toMatchObject({
+      event: 'agent.run_step.timeout',
+      handled: false,
+      operationId: 'op-1',
+      stage: 'state.error_save',
+      stepIndex: 2,
+    });
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 });
 

--- a/apps/server/src/agent-hono/handlers/__tests__/runStep.test.ts
+++ b/apps/server/src/agent-hono/handlers/__tests__/runStep.test.ts
@@ -341,6 +341,28 @@ describe('runStep handler', () => {
     });
   });
 
+  it('keeps a stalled metadata lookup retryable when the step deadline expires', async () => {
+    mockGetOperationMetadata.mockImplementation(() => new Promise(() => {}));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handler = createRunStepHandler({ stepDeadlineMs: 10 });
+    const { ctx } = buildContext({ body: validBody });
+
+    const res = await handler(ctx);
+
+    expect(res.status).toBe(500);
+    expect(mockGetServerDB).not.toHaveBeenCalled();
+    expect(JSON.parse(warnSpy.mock.calls.at(-1)![0])).toMatchObject({
+      event: 'agent.run_step.timeout',
+      handled: false,
+      operationId: 'op-1',
+      stage: 'metadata.load',
+      stepIndex: 2,
+    });
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
   it('ACKs a handled step timeout with a stable error type and structured diagnostics', async () => {
     mockGetOperationMetadata.mockResolvedValue({ userId: 'user-1' });
     mockExecuteStep.mockImplementation(({ signal }) => {

--- a/apps/server/src/agent-hono/handlers/runStep.ts
+++ b/apps/server/src/agent-hono/handlers/runStep.ts
@@ -15,6 +15,7 @@ import {
   AgentStepTimeoutError,
   DEFAULT_AGENT_STEP_DEADLINE_MS,
   isAgentStepTimeoutError,
+  raceWithAgentStepSignal,
 } from '@/server/modules/AgentRuntime/stepDeadline';
 import { AiAgentService } from '@/server/services/aiAgent';
 
@@ -167,11 +168,17 @@ export const createRunStepHandler = ({
 
           reportStage('metadata.load');
           const coordinator = new AgentRuntimeCoordinator();
-          const metadata = await coordinator.getOperationMetadata(operationId);
+          const metadata = await raceWithAgentStepSignal(
+            coordinator.getOperationMetadata(operationId),
+            controller.signal,
+          );
 
           if (!metadata?.userId) {
             reportStage('metadata.diagnostic');
-            const dbRow = await getOperationRowDiagnostic(operationId);
+            const dbRow = await raceWithAgentStepSignal(
+              getOperationRowDiagnostic(operationId),
+              controller.signal,
+            );
             const diagnostic = {
               dbRow,
               event: 'agent.run_step.missing_operation_metadata',
@@ -189,7 +196,7 @@ export const createRunStepHandler = ({
           }
 
           reportStage('database.connect');
-          const serverDB = await getServerDB();
+          const serverDB = await raceWithAgentStepSignal(getServerDB(), controller.signal);
           // Step through AiAgentService so the runtime keeps its `execSubAgent`
           // fork callback (needed by `lobe-agent.callSubAgent`). In QStash mode every
           // step is a fresh HTTP request, and a bare AgentRuntimeService would lose the

--- a/apps/server/src/agent-hono/handlers/runStep.ts
+++ b/apps/server/src/agent-hono/handlers/runStep.ts
@@ -1,3 +1,9 @@
+import {
+  context as otelContext,
+  SpanStatusCode,
+  trace as otelTrace,
+} from '@lobechat/observability-otel/api';
+import { tracer as agentRuntimeTracer } from '@lobechat/observability-otel/modules/agent-runtime';
 import debug from 'debug';
 import { eq } from 'drizzle-orm';
 import type { Context } from 'hono';
@@ -5,6 +11,11 @@ import type { Context } from 'hono';
 import { getServerDB } from '@/database/core/db-adaptor';
 import { agentOperations } from '@/database/schemas/agentOperations';
 import { AgentRuntimeCoordinator } from '@/server/modules/AgentRuntime';
+import {
+  AgentStepTimeoutError,
+  DEFAULT_AGENT_STEP_DEADLINE_MS,
+  isAgentStepTimeoutError,
+} from '@/server/modules/AgentRuntime/stepDeadline';
 import { AiAgentService } from '@/server/services/aiAgent';
 
 const log = debug('lobe-server:agent:run-step');
@@ -19,6 +30,13 @@ const getQStashMessageId = (c: Context): string | undefined =>
   c.req.header('upstash-message-id') ??
   c.req.header('upstash-messageid') ??
   c.req.header('message-id');
+
+const resolveAgentStepTimeoutError = (error: unknown): AgentStepTimeoutError | undefined => {
+  if (isAgentStepTimeoutError(error)) return error;
+  if (error instanceof Error && isAgentStepTimeoutError(error.cause)) return error.cause;
+
+  return undefined;
+};
 
 async function getOperationRowDiagnostic(operationId: string) {
   try {
@@ -52,155 +70,264 @@ async function getOperationRowDiagnostic(operationId: string) {
   }
 }
 
+interface CreateRunStepHandlerOptions {
+  stepDeadlineMs?: number;
+}
+
 /**
  * Execute a single agent step. Invoked by QStash with the body
  * `{ operationId, stepIndex, context, humanInput?, approvedToolCall?, ... }`.
  *
  * Auth: `qstashAuth` on the route — QStash signature required.
  */
-export async function runStep(c: Context): Promise<Response> {
-  const startTime = Date.now();
+export const createRunStepHandler = ({
+  stepDeadlineMs = DEFAULT_AGENT_STEP_DEADLINE_MS,
+}: CreateRunStepHandlerOptions = {}) => {
+  return async (c: Context): Promise<Response> => {
+    const startTime = Date.now();
+    const deadlineAt = startTime + stepDeadlineMs;
+    const controller = new AbortController();
+    const qstashMessageId = getQStashMessageId(c);
+    const upstashRetried = c.req.header('upstash-retried') ?? null;
+    const externalRetryCount = Number(upstashRetried ?? 0) || 0;
+    let body: any;
+    let currentStage = 'request.parse';
+    let operationId: string | undefined;
+    let queueWaitMs: number | undefined;
+    let stepIndex = 0;
 
-  let body: any;
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400);
-  }
-
-  const externalRetryCount = Number(c.req.header('upstash-retried') ?? 0) || 0;
-
-  try {
-    // QStash nests resume/intervention fields under `body.payload` (see
-    // QStashQueueServiceImpl.scheduleMessage), while `operationId`/`stepIndex`/
-    // `context` stay at the top level. Merge so both shapes work — without this
-    // the QStash path reads `resumeAsyncTool`/`approvedToolCall`/… as undefined
-    // and never resumes a parked op. (The local queue spreads payload itself.)
-    const {
-      operationId,
-      stepIndex = 0,
-      context,
-      humanInput,
-      approvedToolCall,
-      rejectionReason,
-      rejectAndContinue,
-      resumeAsyncTool,
-      finishAfterAsyncTool,
-      groupMemberTimeout,
-      toolMessageId,
-      verifyAsyncToolBarrier,
-      asyncToolVerifyAttempt,
-    } = { ...body, ...body.payload };
-
-    if (!operationId) {
-      return c.json({ error: 'operationId is required' }, 400);
-    }
-
-    log(`[${operationId}] Starting step ${stepIndex}`);
-
-    // Get userId from operation metadata stored in Redis
-    const coordinator = new AgentRuntimeCoordinator();
-    const metadata = await coordinator.getOperationMetadata(operationId);
-
-    if (!metadata?.userId) {
-      const dbRow = await getOperationRowDiagnostic(operationId);
-      const diagnostic = {
-        dbRow,
-        event: 'agent.run_step.missing_operation_metadata',
-        metadataHasUserId: Boolean(metadata?.userId),
-        metadataPresent: Boolean(metadata),
-        operationId,
-        qstashMessageId: getQStashMessageId(c),
-        stepIndex,
-        upstashRetried: c.req.header('upstash-retried') ?? null,
-      };
-
-      log(`[${operationId}] Invalid operation or no userId found: %O`, diagnostic);
-      console.warn(JSON.stringify(diagnostic));
-      return c.json({ error: 'Invalid operation or unauthorized' }, 401);
-    }
-
-    const serverDB = await getServerDB();
-    // Step through AiAgentService so the runtime keeps its `execSubAgent`
-    // fork callback (needed by `lobe-agent.callSubAgent`). In QStash mode every
-    // step is a fresh HTTP request, and a bare AgentRuntimeService would lose the
-    // in-process callback → SUB_AGENT_UNAVAILABLE.
-    //
-    // Thread the operation's workspace through so the runtime's models stay
-    // workspace-scoped. Without it the worker is personal-scoped and the
-    // parent-message lookup misses workspace-scoped rows → ConversationParentMissing.
-    const aiAgentService = new AiAgentService(serverDB, metadata.userId, {
-      workspaceId: metadata.workspaceId,
-    });
-
-    const result = await aiAgentService.executeStep({
-      approvedToolCall,
-      asyncToolVerifyAttempt,
-      context,
-      externalRetryCount,
-      humanInput,
-      finishAfterAsyncTool,
-      groupMemberTimeout,
-      operationId,
-      rejectAndContinue,
-      rejectionReason,
-      resumeAsyncTool,
-      stepIndex,
-      toolMessageId,
-      verifyAsyncToolBarrier,
-    });
-
-    // A non-stale lock conflict means another delivery is still executing this
-    // operation. Keep the response retryable so QStash redelivers this step.
-    if (result.locked) {
-      log(`[${operationId}] Step ${stepIndex} locked by another instance, returning 429`);
-      return c.json(
-        { error: 'Step is currently being executed, retry later', operationId, stepIndex },
-        429,
-        { 'Retry-After': '37' },
-      );
-    }
-
-    const executionTime = Date.now() - startTime;
-
-    const responseData = {
-      completed: result.state.status === 'done',
-      error: result.state.status === 'error' ? result.state.error : undefined,
-      executionTime,
-      nextStepIndex: result.nextStepScheduled ? stepIndex + 1 : undefined,
-      nextStepScheduled: result.nextStepScheduled,
-      operationId,
-      pendingApproval: result.state.pendingToolsCalling,
-      pendingPrompt: result.state.pendingHumanPrompt,
-      pendingSelect: result.state.pendingHumanSelect,
-      status: result.state.status,
-      stepIndex,
-      success: result.success,
-      totalCost: result.state.cost?.total || 0,
-      totalSteps: result.state.stepCount,
-      waitingForHuman: result.state.status === 'waiting_for_human',
-    };
-
-    log(
-      `[${operationId}] Step ${stepIndex} completed (${executionTime}ms, status: ${result.state.status})`,
-    );
-
-    return c.json(responseData);
-  } catch (error: any) {
-    const executionTime = Date.now() - startTime;
-    console.error('Error in execution: %O', error);
-
-    return c.json(
-      {
-        error: error.message,
-        executionTime,
-        operationId: body?.operationId,
-        stepIndex: body?.stepIndex || 0,
+    const runStepSpan = agentRuntimeTracer.startSpan('agent.run_step', {
+      attributes: {
+        'agent.step.deadline_at': deadlineAt,
+        'agent.step.qstash_retried': externalRetryCount,
       },
-      500,
+    });
+    const runStepContext = otelTrace.setSpan(otelContext.active(), runStepSpan);
+    const reportStage = (stage: string) => {
+      currentStage = stage;
+      runStepSpan.addEvent('agent.run_step.stage', {
+        'agent.step.elapsed_ms': Date.now() - startTime,
+        'agent.step.stage': stage,
+      });
+    };
+    const timeoutId = setTimeout(
+      () => {
+        controller.abort(new AgentStepTimeoutError({ deadlineAt, stage: currentStage }));
+      },
+      Math.max(0, deadlineAt - Date.now()),
     );
-  }
-}
+
+    try {
+      return await otelContext.with(runStepContext, async () => {
+        try {
+          body = await c.req.json();
+        } catch {
+          return c.json({ error: 'Invalid JSON body' }, 400);
+        }
+
+        try {
+          // QStash nests resume/intervention fields under `body.payload` (see
+          // QStashQueueServiceImpl.scheduleMessage), while `operationId`/`stepIndex`/
+          // `context` stay at the top level. Merge so both shapes work — without this
+          // the QStash path reads `resumeAsyncTool`/`approvedToolCall`/… as undefined
+          // and never resumes a parked op. (The local queue spreads payload itself.)
+          const mergedBody = { ...body, ...body.payload };
+          const {
+            approvedToolCall,
+            asyncToolVerifyAttempt,
+            context,
+            finishAfterAsyncTool,
+            groupMemberTimeout,
+            humanInput,
+            rejectAndContinue,
+            rejectionReason,
+            resumeAsyncTool,
+            toolMessageId,
+            verifyAsyncToolBarrier,
+          } = mergedBody;
+          operationId = mergedBody.operationId;
+          stepIndex = mergedBody.stepIndex ?? 0;
+          queueWaitMs =
+            typeof body.timestamp === 'number' && Number.isFinite(body.timestamp)
+              ? Math.max(0, startTime - body.timestamp)
+              : undefined;
+
+          runStepSpan.setAttributes({
+            ...(operationId && { 'agent.operation.id': operationId }),
+            ...(qstashMessageId && { 'agent.step.qstash_message_id': qstashMessageId }),
+            ...(queueWaitMs !== undefined && { 'agent.step.queue_wait_ms': queueWaitMs }),
+            'agent.step.index': stepIndex,
+          });
+
+          if (!operationId) {
+            return c.json({ error: 'operationId is required' }, 400);
+          }
+
+          log(`[${operationId}] Starting step ${stepIndex}`);
+
+          reportStage('metadata.load');
+          const coordinator = new AgentRuntimeCoordinator();
+          const metadata = await coordinator.getOperationMetadata(operationId);
+
+          if (!metadata?.userId) {
+            reportStage('metadata.diagnostic');
+            const dbRow = await getOperationRowDiagnostic(operationId);
+            const diagnostic = {
+              dbRow,
+              event: 'agent.run_step.missing_operation_metadata',
+              metadataHasUserId: Boolean(metadata?.userId),
+              metadataPresent: Boolean(metadata),
+              operationId,
+              qstashMessageId,
+              stepIndex,
+              upstashRetried,
+            };
+
+            log(`[${operationId}] Invalid operation or no userId found: %O`, diagnostic);
+            console.warn(JSON.stringify(diagnostic));
+            return c.json({ error: 'Invalid operation or unauthorized' }, 401);
+          }
+
+          reportStage('database.connect');
+          const serverDB = await getServerDB();
+          // Step through AiAgentService so the runtime keeps its `execSubAgent`
+          // fork callback (needed by `lobe-agent.callSubAgent`). In QStash mode every
+          // step is a fresh HTTP request, and a bare AgentRuntimeService would lose the
+          // in-process callback → SUB_AGENT_UNAVAILABLE.
+          //
+          // Thread the operation's workspace through so the runtime's models stay
+          // workspace-scoped. Without it the worker is personal-scoped and the
+          // parent-message lookup misses workspace-scoped rows → ConversationParentMissing.
+          const aiAgentService = new AiAgentService(serverDB, metadata.userId, {
+            workspaceId: metadata.workspaceId,
+          });
+
+          reportStage('runtime.execute');
+          const result = await aiAgentService.executeStep({
+            approvedToolCall,
+            asyncToolVerifyAttempt,
+            context,
+            deadlineAt,
+            externalRetryCount,
+            finishAfterAsyncTool,
+            groupMemberTimeout,
+            humanInput,
+            onStage: reportStage,
+            operationId,
+            rejectAndContinue,
+            rejectionReason,
+            resumeAsyncTool,
+            signal: controller.signal,
+            stepIndex,
+            toolMessageId,
+            verifyAsyncToolBarrier,
+          });
+
+          // A non-stale lock conflict means another delivery is still executing this
+          // operation. Keep the response retryable so QStash redelivers this step.
+          if (result.locked) {
+            log(`[${operationId}] Step ${stepIndex} locked by another instance, returning 429`);
+            return c.json(
+              { error: 'Step is currently being executed, retry later', operationId, stepIndex },
+              429,
+              { 'Retry-After': '37' },
+            );
+          }
+
+          const executionTime = Date.now() - startTime;
+          const responseData = {
+            completed: result.state.status === 'done',
+            error: result.state.status === 'error' ? result.state.error : undefined,
+            executionTime,
+            nextStepIndex: result.nextStepScheduled ? stepIndex + 1 : undefined,
+            nextStepScheduled: result.nextStepScheduled,
+            operationId,
+            pendingApproval: result.state.pendingToolsCalling,
+            pendingPrompt: result.state.pendingHumanPrompt,
+            pendingSelect: result.state.pendingHumanSelect,
+            status: result.state.status,
+            stepIndex,
+            success: result.success,
+            totalCost: result.state.cost?.total || 0,
+            totalSteps: result.state.stepCount,
+            waitingForHuman: result.state.status === 'waiting_for_human',
+          };
+
+          log(
+            `[${operationId}] Step ${stepIndex} completed (${executionTime}ms, status: ${result.state.status})`,
+          );
+
+          return c.json(responseData);
+        } catch (error: unknown) {
+          const executionTime = Date.now() - startTime;
+          const timeoutError = resolveAgentStepTimeoutError(error);
+
+          if (timeoutError) {
+            const diagnostic = {
+              deadlineAt: timeoutError.deadlineAt,
+              elapsedMs: executionTime,
+              event: 'agent.run_step.timeout',
+              handled: timeoutError.handled,
+              operationId,
+              qstashMessageId,
+              queueWaitMs,
+              stage: timeoutError.stage,
+              stepIndex,
+              upstashRetried,
+            };
+            console.warn(JSON.stringify(diagnostic));
+          }
+
+          // A handled timeout has completed the service's durable error
+          // finalization and must ACK QStash. Unhandled timeouts (including an
+          // error-state save failure carried as `cause`) fall through to 500 so
+          // the same delivery remains retryable.
+          if (timeoutError?.handled) {
+            runStepSpan.recordException(timeoutError);
+            runStepSpan.setStatus({ code: SpanStatusCode.ERROR, message: timeoutError.message });
+
+            return c.json(
+              {
+                error: timeoutError.message,
+                errorType: timeoutError.errorType,
+                executionTime,
+                operationId,
+                stage: timeoutError.stage,
+                stepIndex,
+                success: false,
+              },
+              200,
+            );
+          }
+
+          console.error('Error in execution: %O', error);
+          const traceError = new Error('Agent step execution failed');
+          traceError.name = error instanceof Error ? error.name : 'Error';
+          runStepSpan.recordException(traceError);
+          runStepSpan.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: traceError.message,
+          });
+
+          return c.json(
+            {
+              error: error instanceof Error ? error.message : String(error),
+              executionTime,
+              operationId,
+              stepIndex,
+            },
+            500,
+          );
+        }
+      });
+    } finally {
+      clearTimeout(timeoutId);
+      runStepSpan.end();
+    }
+  };
+};
+
+export const runStep = createRunStepHandler();
 
 /**
  * Health check for the agent execution path.

--- a/apps/server/src/agent-hono/handlers/runStep.ts
+++ b/apps/server/src/agent-hono/handlers/runStep.ts
@@ -93,6 +93,7 @@ export const createRunStepHandler = ({
     const externalRetryCount = Number(upstashRetried ?? 0) || 0;
     let body: any;
     let currentStage = 'request.parse';
+    let currentStageStartedAt = startTime;
     let operationId: string | undefined;
     let queueWaitMs: number | undefined;
     let stepIndex = 0;
@@ -105,15 +106,46 @@ export const createRunStepHandler = ({
     });
     const runStepContext = otelTrace.setSpan(otelContext.active(), runStepSpan);
     const reportStage = (stage: string) => {
+      const now = Date.now();
       currentStage = stage;
+      currentStageStartedAt = now;
       runStepSpan.addEvent('agent.run_step.stage', {
-        'agent.step.elapsed_ms': Date.now() - startTime,
+        'agent.step.elapsed_ms': now - startTime,
         'agent.step.stage': stage,
       });
     };
     const timeoutId = setTimeout(
       () => {
-        controller.abort(new AgentStepTimeoutError({ deadlineAt, stage: currentStage }));
+        const now = Date.now();
+        const spanContext = runStepSpan.spanContext();
+        const timeoutError = new AgentStepTimeoutError({
+          deadlineAt,
+          stage: currentStage,
+          stageElapsedMs: now - currentStageStartedAt,
+        });
+
+        // Emit before aborting: some ownership-changing writes and post-commit
+        // cleanup are deliberately not promise-raced. If one never returns,
+        // the handler catch and span end below will not run before the platform
+        // hard timeout, so this is the last reliable execution snapshot.
+        console.warn(
+          JSON.stringify({
+            deadlineAt,
+            elapsedMs: now - startTime,
+            event: 'agent.run_step.deadline_reached',
+            operationId,
+            qstashMessageId,
+            queueWaitMs,
+            spanId: spanContext.spanId,
+            stage: currentStage,
+            stageElapsedMs: timeoutError.stageElapsedMs,
+            stepIndex,
+            traceId: spanContext.traceId,
+            upstashRetried,
+          }),
+        );
+
+        controller.abort(timeoutError);
       },
       Math.max(0, deadlineAt - Date.now()),
     );
@@ -270,6 +302,7 @@ export const createRunStepHandler = ({
           const timeoutError = resolveAgentStepTimeoutError(error);
 
           if (timeoutError) {
+            const spanContext = runStepSpan.spanContext();
             const diagnostic = {
               deadlineAt: timeoutError.deadlineAt,
               elapsedMs: executionTime,
@@ -278,8 +311,11 @@ export const createRunStepHandler = ({
               operationId,
               qstashMessageId,
               queueWaitMs,
+              spanId: spanContext.spanId,
               stage: timeoutError.stage,
+              stageElapsedMs: timeoutError.stageElapsedMs,
               stepIndex,
+              traceId: spanContext.traceId,
               upstashRetried,
             };
             console.warn(JSON.stringify(diagnostic));

--- a/apps/server/src/modules/AgentRuntime/__tests__/dispatchClientTool.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/dispatchClientTool.test.ts
@@ -2,6 +2,7 @@ import type { ChatToolPayload } from '@lobechat/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { dispatchClientTool } from '../dispatchClientTool';
+import { AgentStepTimeoutError } from '../stepDeadline';
 import type { IStreamEventManager } from '../types';
 
 // Mock Redis before importing the SUT so the module-level getter sees it.
@@ -293,7 +294,7 @@ describe('dispatchClientTool', () => {
       timeoutMs: 10_000_000,
     });
 
-    expect(sendToolExecute.mock.calls[0][1]).toMatchObject({ executionTimeoutMs: 800_000 });
+    expect(sendToolExecute.mock.calls[0][1]).toMatchObject({ executionTimeoutMs: 480_000 });
   });
 
   it('falls back to the 120s global default when ctx.timeoutMs is omitted', async () => {
@@ -311,5 +312,27 @@ describe('dispatchClientTool', () => {
     });
 
     expect(sendToolExecute.mock.calls[0][1]).toMatchObject({ executionTimeoutMs: 120_000 });
+  });
+
+  it('stops a client-tool Redis wait when the containing step is aborted', async () => {
+    const sendToolExecute = vi.fn().mockResolvedValue(undefined);
+    const streamManager = makeStreamManager(sendToolExecute);
+    const controller = new AbortController();
+    mockBlpop.mockImplementation(() => new Promise(() => {}));
+
+    const resultPromise = dispatchClientTool(makePayload(), {
+      operationId: 'op-1',
+      signal: controller.signal,
+      streamManager,
+    });
+    await vi.waitFor(() => expect(mockBlpop).toHaveBeenCalled());
+    const timeoutError = new AgentStepTimeoutError({
+      deadlineAt: Date.now(),
+      stage: 'tool.client.wait',
+    });
+    controller.abort(timeoutError);
+
+    await expect(resultPromise).rejects.toBe(timeoutError);
+    expect(mockDisconnect).toHaveBeenCalled();
   });
 });

--- a/apps/server/src/modules/AgentRuntime/__tests__/resolveToolTimeout.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/resolveToolTimeout.test.ts
@@ -1,5 +1,5 @@
 import { type LobeToolManifest } from '@lobechat/context-engine';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   GLOBAL_DEFAULT_TIMEOUT_MS,
@@ -118,5 +118,32 @@ describe('resolveToolTimeoutMs', () => {
     expect(resolveToolTimeoutMs({ apiName: 'runCommand', args: { timeout: 123_456.789 } })).toBe(
       123_456,
     );
+  });
+
+  it('never exceeds the remaining containing-step budget', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+
+    expect(
+      resolveToolTimeoutMs({
+        apiName: 'runCommand',
+        args: { timeout: 240_000 },
+        deadlineAt: 1_030_000,
+      }),
+    ).toBe(30_000);
+
+    nowSpy.mockRestore();
+  });
+
+  it('allows the remaining step budget to override the normal one-second floor', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+
+    expect(
+      resolveToolTimeoutMs({
+        apiName: 'runCommand',
+        deadlineAt: 1_000_250,
+      }),
+    ).toBe(250);
+
+    nowSpy.mockRestore();
   });
 });

--- a/apps/server/src/modules/AgentRuntime/adapters/ServerLLMTransport.test.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerLLMTransport.test.ts
@@ -1,0 +1,75 @@
+import type { LLMTraceInput } from '@lobechat/agent-runtime';
+import type * as AgentRuntimeObservability from '@lobechat/observability-otel/modules/agent-runtime';
+import { ATTR_GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK } from '@lobechat/observability-otel/modules/agent-runtime';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { RuntimeExecutorContext } from '../context';
+import { ServerLLMTransport } from './ServerLLMTransport';
+
+const mocks = vi.hoisted(() => {
+  const chatSpan = {
+    addEvent: vi.fn(),
+    end: vi.fn(),
+    recordException: vi.fn(),
+    setAttribute: vi.fn(),
+    setAttributes: vi.fn(),
+    setStatus: vi.fn(),
+  };
+
+  return {
+    chatSpan,
+    startSpan: vi.fn(() => chatSpan),
+  };
+});
+
+vi.mock('@lobechat/observability-otel/modules/agent-runtime', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentRuntimeObservability>();
+
+  return {
+    ...actual,
+    tracer: { startSpan: mocks.startSpan },
+  };
+});
+
+vi.mock('@/server/modules/ModelRuntime', () => ({
+  initModelRuntimeFromDB: vi.fn(),
+}));
+
+describe('ServerLLMTransport', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-23T00:00:00.000Z'));
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('records time to first chunk immediately even when the call never completes', () => {
+    const transport = new ServerLLMTransport({
+      operationId: 'operation-1',
+      stepIndex: 2,
+      streamManager: {},
+    } as RuntimeExecutorContext);
+    const trace = transport.createTrace({
+      assistantMessageId: 'message-1',
+      model: 'test-model',
+      provider: 'test-provider',
+    } satisfies LLMTraceInput);
+
+    vi.advanceTimersByTime(1250);
+    trace.onFirstChunk();
+    trace.onFirstChunk();
+
+    expect(mocks.chatSpan.setAttribute).toHaveBeenCalledOnce();
+    expect(mocks.chatSpan.setAttribute).toHaveBeenCalledWith(
+      ATTR_GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK,
+      1.25,
+    );
+    expect(mocks.chatSpan.addEvent).toHaveBeenCalledOnce();
+    expect(mocks.chatSpan.addEvent).toHaveBeenCalledWith('gen_ai.first_chunk', {
+      [ATTR_GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK]: 1.25,
+    });
+  });
+});

--- a/apps/server/src/modules/AgentRuntime/adapters/ServerLLMTransport.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerLLMTransport.ts
@@ -26,6 +26,7 @@ import {
   trace as otelTrace,
 } from '@lobechat/observability-otel/api';
 import {
+  ATTR_GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK,
   buildChatRequestAttributes,
   buildChatResponseAttributes,
   chatSpanName,
@@ -153,6 +154,11 @@ class ServerLLMTrace implements LLMTrace {
   onFirstChunk() {
     if (this.firstChunkAt === undefined) {
       this.firstChunkAt = Date.now() - this.llmStartTime;
+      const timeToFirstChunkSeconds = this.firstChunkAt / 1000;
+      this.chatSpan.setAttribute(ATTR_GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK, timeToFirstChunkSeconds);
+      this.chatSpan.addEvent('gen_ai.first_chunk', {
+        [ATTR_GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK]: timeToFirstChunkSeconds,
+      });
     }
   }
 

--- a/apps/server/src/modules/AgentRuntime/adapters/ServerLLMTransport.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerLLMTransport.ts
@@ -102,9 +102,9 @@ class ServerLLMRetryPolicy implements LLMRetryPolicy {
     return resolveLLMRetryBudget(provider, SERVER_LLM_RETRY_POLICY);
   }
 
-  async waitForRetry(delayMs: number): Promise<void> {
+  waitForRetry = async (delayMs: number): Promise<void> => {
     await raceWithAgentStepSignal(sleep(delayMs), this.ctx.signal);
-  }
+  };
 }
 
 class ServerLLMTrace implements LLMTrace {

--- a/apps/server/src/modules/AgentRuntime/adapters/ServerLLMTransport.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerLLMTransport.ts
@@ -37,6 +37,11 @@ import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
 import type { RuntimeExecutorContext } from '../context';
 import { log, sleep } from '../executorHelpers';
 import { classifyLLMError } from '../llmErrorClassification';
+import {
+  AGENT_STEP_TIMEOUT_ERROR_TYPE,
+  getAgentStepAbortReason,
+  raceWithAgentStepSignal,
+} from '../stepDeadline';
 import { createServerCallLlmAttempt } from './serverCallLlmAttempt';
 
 const getErrorMessage = (error: unknown): string => {
@@ -57,6 +62,14 @@ class ServerLLMRetryPolicy implements LLMRetryPolicy {
   constructor(private readonly ctx: RuntimeExecutorContext) {}
 
   classifyError(error: unknown) {
+    if (this.ctx.signal?.aborted) {
+      return {
+        code: AGENT_STEP_TIMEOUT_ERROR_TYPE,
+        kind: 'stop' as const,
+        message: getAgentStepAbortReason(this.ctx.signal).message,
+      };
+    }
+
     return classifyLLMError(error);
   }
 
@@ -84,11 +97,13 @@ class ServerLLMRetryPolicy implements LLMRetryPolicy {
   }
 
   resolveRetryBudget(provider: string) {
+    if (this.ctx.signal?.aborted) return 0;
+
     return resolveLLMRetryBudget(provider, SERVER_LLM_RETRY_POLICY);
   }
 
   async waitForRetry(delayMs: number): Promise<void> {
-    await sleep(delayMs);
+    await raceWithAgentStepSignal(sleep(delayMs), this.ctx.signal);
   }
 }
 
@@ -186,7 +201,11 @@ export class ServerLLMTransport implements LLMTransport {
   }
 
   async runAttempt(input: LLMAttemptInput): Promise<LLMAttemptExecution> {
-    const modelRuntime = await this.getModelRuntime(input.provider);
+    this.ctx.onStage?.('model.initialize');
+    const modelRuntime = await raceWithAgentStepSignal(
+      this.getModelRuntime(input.provider),
+      this.ctx.signal,
+    );
     return this.runAttemptWithRuntime(input, modelRuntime);
   }
 
@@ -194,30 +213,39 @@ export class ServerLLMTransport implements LLMTransport {
     payload: LLMStreamPayload,
     handlers?: Parameters<LLMTransport['stream']>[1],
   ): Promise<LLMStreamResult> {
-    const runtime = await this.createModelRuntime(payload.provider);
+    this.ctx.onStage?.('model.initialize');
+    const runtime = await raceWithAgentStepSignal(
+      this.createModelRuntime(payload.provider),
+      this.ctx.signal,
+    );
     const { provider: _provider, ...runtimePayload } = payload;
     let content = '';
     let usage: LLMStreamResult['usage'];
     let streamError: unknown;
 
-    const response = await runtime.chat(runtimePayload as any, {
-      callback: {
-        onCompletion: async (data: any) => {
-          if (data.usage) usage = data.usage;
+    this.ctx.onStage?.('model.call');
+    const response = await raceWithAgentStepSignal(
+      runtime.chat(runtimePayload as any, {
+        callback: {
+          onCompletion: async (data: any) => {
+            if (data.usage) usage = data.usage;
+          },
+          onError: async (errorData: unknown) => {
+            streamError = errorData;
+            handlers?.onError?.(errorData);
+          },
+          onText: async (text: string) => {
+            content += text;
+            handlers?.onText?.(text);
+          },
         },
-        onError: async (errorData: unknown) => {
-          streamError = errorData;
-          handlers?.onError?.(errorData);
-        },
-        onText: async (text: string) => {
-          content += text;
-          handlers?.onText?.(text);
-        },
-      },
-      user: this.ctx.userId,
-    });
+        signal: this.ctx.signal,
+        user: this.ctx.userId,
+      }),
+      this.ctx.signal,
+    );
 
-    await consumeStreamUntilDone(response);
+    await raceWithAgentStepSignal(consumeStreamUntilDone(response), this.ctx.signal);
 
     if (streamError) {
       throw new Error(getErrorMessage(streamError));
@@ -265,6 +293,7 @@ export class ServerLLMTransport implements LLMTransport {
       }),
     };
     const operationLogId = `${this.ctx.operationId}:${this.ctx.stepIndex}`;
+    this.ctx.onStage?.('model.call');
     const attempt = createServerCallLlmAttempt({
       attempt: input.attempt,
       blobStore: this.blobStore,

--- a/apps/server/src/modules/AgentRuntime/adapters/ServerToolTransport.test.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerToolTransport.test.ts
@@ -1,0 +1,159 @@
+import type { ToolRunContext } from '@lobechat/agent-runtime';
+import type * as AgentRuntimeObservability from '@lobechat/observability-otel/modules/agent-runtime';
+import {
+  ATTR_LOBEHUB_TOOL_EXECUTION_TARGET,
+  ATTR_LOBEHUB_TOOL_TIMEOUT_MS,
+} from '@lobechat/observability-otel/modules/agent-runtime';
+import type { ChatToolPayload } from '@lobechat/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { RuntimeExecutorContext } from '../context';
+import type * as ExecutorHelpers from '../executorHelpers';
+import { ServerToolTransport } from './ServerToolTransport';
+
+const mocks = vi.hoisted(() => {
+  const executeToolSpan = {
+    addEvent: vi.fn(),
+    end: vi.fn(),
+    recordException: vi.fn(),
+    setAttributes: vi.fn(),
+    setStatus: vi.fn(),
+  };
+
+  return {
+    archiveRuntimeToolResult: vi.fn(async (result) => result),
+    dispatchClientTool: vi.fn(),
+    executeToolSpan,
+    resolveToolTimeoutMs: vi.fn(() => 4321),
+    startSpan: vi.fn(() => executeToolSpan),
+  };
+});
+
+vi.mock('@lobechat/observability-otel/modules/agent-runtime', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentRuntimeObservability>();
+
+  return {
+    ...actual,
+    tracer: { startSpan: mocks.startSpan },
+  };
+});
+
+vi.mock('../dispatchClientTool', () => ({
+  dispatchClientTool: mocks.dispatchClientTool,
+}));
+
+vi.mock('../executorHelpers', async (importOriginal) => {
+  const actual = await importOriginal<typeof ExecutorHelpers>();
+
+  return {
+    ...actual,
+    archiveRuntimeToolResult: mocks.archiveRuntimeToolResult,
+  };
+});
+
+vi.mock('../resolveToolTimeout', () => ({
+  resolveToolTimeoutMs: mocks.resolveToolTimeoutMs,
+}));
+
+describe('ServerToolTransport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.dispatchClientTool.mockResolvedValue({
+      content: 'result',
+      executionTime: 12,
+      success: true,
+    });
+  });
+
+  it('records the client target, effective timeout, execution completion, and blocking stages', async () => {
+    const onStage = vi.fn();
+    const hookDispatcher = {
+      dispatch: vi.fn().mockResolvedValue(undefined),
+      dispatchBeforeToolCall: vi.fn().mockResolvedValue(null),
+    };
+    const transport = new ServerToolTransport({
+      hookDispatcher,
+      onStage,
+      operationId: 'operation-1',
+      serverDB: {},
+      stepIndex: 2,
+      streamManager: { sendToolExecute: vi.fn() },
+      toolExecutionService: {},
+      userId: 'user-1',
+    } as unknown as RuntimeExecutorContext);
+    const payload = {
+      apiName: 'search',
+      executor: 'client',
+      id: 'call-1',
+      identifier: 'workspace',
+    } as ChatToolPayload;
+    const context = {
+      callIndex: 0,
+      effectiveManifestMap: {},
+      parentMessageId: 'assistant-message-1',
+      parsedArgs: { query: 'docs' },
+      state: { metadata: {} },
+      toolMessageId: 'tool-message-1',
+      toolName: 'search',
+      toolResultMaxLength: 1000,
+      toolSource: 'builtin',
+    } as unknown as ToolRunContext;
+
+    await transport.run(payload, context);
+
+    expect(onStage.mock.calls.map(([stage]) => stage)).toEqual([
+      'hook.before_tool',
+      'tool.client.wait',
+      'tool.result.archive',
+    ]);
+    expect(mocks.executeToolSpan.setAttributes).toHaveBeenCalledWith({
+      [ATTR_LOBEHUB_TOOL_EXECUTION_TARGET]: 'client',
+      [ATTR_LOBEHUB_TOOL_TIMEOUT_MS]: 4321,
+    });
+    expect(mocks.executeToolSpan.addEvent).toHaveBeenCalledWith('tool.execute.complete', {
+      'lobehub.tool.attempts': 1,
+    });
+  });
+
+  it('does not report a deferred tool dispatch as execution complete', async () => {
+    mocks.dispatchClientTool.mockResolvedValue({
+      content: 'pending',
+      deferred: true,
+      executionTime: 12,
+      success: true,
+    });
+    const transport = new ServerToolTransport({
+      operationId: 'operation-1',
+      serverDB: {},
+      stepIndex: 2,
+      streamManager: { sendToolExecute: vi.fn() },
+      toolExecutionService: {},
+      userId: 'user-1',
+    } as unknown as RuntimeExecutorContext);
+
+    await transport.run(
+      {
+        apiName: 'call',
+        executor: 'client',
+        id: 'call-1',
+        identifier: 'async-tool',
+      } as ChatToolPayload,
+      {
+        callIndex: 0,
+        effectiveManifestMap: {},
+        parentMessageId: 'assistant-message-1',
+        parsedArgs: {},
+        state: { metadata: {} },
+        toolMessageId: 'tool-message-1',
+        toolName: 'call',
+        toolResultMaxLength: 1000,
+        toolSource: 'builtin',
+      } as unknown as ToolRunContext,
+    );
+
+    expect(mocks.executeToolSpan.addEvent).not.toHaveBeenCalledWith(
+      'tool.execute.complete',
+      expect.anything(),
+    );
+  });
+});

--- a/apps/server/src/modules/AgentRuntime/adapters/ServerToolTransport.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerToolTransport.ts
@@ -39,6 +39,7 @@ import {
 import { resolveRunActiveDeviceId } from '../executors/resolveRunActiveDeviceId';
 import { resolveRunProjectSkills } from '../executors/resolveRunProjectSkills';
 import { resolveToolTimeoutMs } from '../resolveToolTimeout';
+import { raceWithAgentStepSignal, throwIfAgentStepAborted } from '../stepDeadline';
 
 export class ServerToolTransport implements ToolTransport {
   maxRetries = TOOL_MAX_RETRIES;
@@ -116,6 +117,7 @@ export class ServerToolTransport implements ToolTransport {
     });
 
     try {
+      throwIfAgentStepAborted(this.ctx.signal);
       const hookResult = await this.dispatchBeforeToolCall(chatToolPayload, context);
       let toolCallMocked = false;
 
@@ -149,19 +151,23 @@ export class ServerToolTransport implements ToolTransport {
         typeof streamManager.sendToolExecute === 'function'
       ) {
         log(`[${operationLogId}] Dispatching tool ${context.toolName} to client via Agent Gateway`);
+        this.ctx.onStage?.('tool.client.wait');
         const timeoutMs = resolveToolTimeoutMs({
           apiName: chatToolPayload.apiName,
           args: context.parsedArgs,
+          deadlineAt: this.ctx.deadlineAt,
           manifest: context.effectiveManifestMap[chatToolPayload.identifier],
         });
         const dispatchResult = await dispatchClientTool(chatToolPayload, {
           agentId: context.state.metadata?.agentId,
           assistantMessageId: context.parentMessageId,
           documentId: context.state.metadata?.documentId,
+          deadlineAt: this.ctx.deadlineAt,
           groupId: context.state.metadata?.groupId,
           operationId,
           rootOperationId: operationId,
           scope: context.state.metadata?.scope,
+          signal: this.ctx.signal,
           sourceMessageId: context.state.metadata?.sourceMessageId,
           streamManager,
           taskId: context.state.metadata?.taskId,
@@ -178,64 +184,77 @@ export class ServerToolTransport implements ToolTransport {
         const timeoutMs = resolveToolTimeoutMs({
           apiName: chatToolPayload.apiName,
           args: context.parsedArgs,
+          deadlineAt: this.ctx.deadlineAt,
           manifest: context.effectiveManifestMap[chatToolPayload.identifier],
         });
         const agentVisibility = await this.resolveAgentVisibility(context);
 
         log(`[${operationLogId}] Executing tool ${context.toolName} ...`);
+        this.ctx.onStage?.(
+          isDeviceToolIdentifier(chatToolPayload.identifier) ||
+            Boolean(context.state.metadata?.activeDeviceId)
+            ? 'tool.device.execute'
+            : 'tool.server.execute',
+        );
         execution = await executeToolWithRetry(
           () =>
-            toolExecutionService.executeTool(chatToolPayload, {
-              activatedSkills: context.activatedSkills as any,
-              activeDeviceId: resolveRunActiveDeviceId(context.state.metadata),
-              activeDeviceScope: context.state.metadata?.activeDeviceScope,
-              agentId: context.state.metadata?.agentId,
-              agentMember: buildServerAgentMemberRunner(
-                this.ctx,
-                context.state,
-                chatToolPayload,
-                context.parentMessageId,
-              ),
-              ...(agentVisibility !== undefined && { agentVisibility }),
-              // Assistant message owning this tool call (≠ source user message).
-              assistantMessageId: context.parentMessageId,
-              deviceCapable: context.state.metadata?.executionPlan
-                ? isDeviceCapablePlan(context.state.metadata.executionPlan)
-                : undefined,
-              documentId: context.state.metadata?.documentId,
-              editingAgentId: context.state.metadata?.editingAgentId,
-              execSubAgent: this.ctx.execSubAgent,
-              executionTimeoutMs: timeoutMs,
-              groupId: context.state.metadata?.groupId,
-              isSubAgent: context.state.metadata?.isSubAgent === true,
-              memoryToolPermission:
-                context.state.metadata?.agentConfig?.chatConfig?.memory?.toolPermission,
-              messageId: context.state.metadata?.sourceMessageId,
-              operationId,
-              projectSkills: resolveRunProjectSkills(context.state.metadata),
-              rootOperationId: operationId,
-              scope: context.state.metadata?.scope,
-              serverDB,
-              skipResultTruncation: true,
-              subAgent: buildServerVirtualSubAgentRunner(
-                this.ctx,
-                context.state,
-                chatToolPayload,
-                context.parentMessageId,
-              ),
-              taskId: context.state.metadata?.taskId,
-              threadId: context.state.metadata?.threadId,
-              toolCallId: chatToolPayload.id,
-              toolManifestMap: context.effectiveManifestMap,
-              toolMessageId: context.toolMessageId,
-              toolResultMaxLength: context.toolResultMaxLength,
-              topicId: this.ctx.topicId,
-              userId,
-              workingDirectory: context.state.metadata?.deviceSystemInfo?.workingDirectory,
-              workspaceId: context.state.metadata?.workspaceId ?? this.ctx.workspaceId,
-            }),
+            raceWithAgentStepSignal(
+              toolExecutionService.executeTool(chatToolPayload, {
+                activatedSkills: context.activatedSkills as any,
+                activeDeviceId: resolveRunActiveDeviceId(context.state.metadata),
+                activeDeviceScope: context.state.metadata?.activeDeviceScope,
+                agentId: context.state.metadata?.agentId,
+                agentMember: buildServerAgentMemberRunner(
+                  this.ctx,
+                  context.state,
+                  chatToolPayload,
+                  context.parentMessageId,
+                ),
+                ...(agentVisibility !== undefined && { agentVisibility }),
+                // Assistant message owning this tool call (≠ source user message).
+                assistantMessageId: context.parentMessageId,
+                deadlineAt: this.ctx.deadlineAt,
+                deviceCapable: context.state.metadata?.executionPlan
+                  ? isDeviceCapablePlan(context.state.metadata.executionPlan)
+                  : undefined,
+                documentId: context.state.metadata?.documentId,
+                editingAgentId: context.state.metadata?.editingAgentId,
+                execSubAgent: this.ctx.execSubAgent,
+                executionTimeoutMs: timeoutMs,
+                groupId: context.state.metadata?.groupId,
+                isSubAgent: context.state.metadata?.isSubAgent === true,
+                memoryToolPermission:
+                  context.state.metadata?.agentConfig?.chatConfig?.memory?.toolPermission,
+                messageId: context.state.metadata?.sourceMessageId,
+                operationId,
+                projectSkills: resolveRunProjectSkills(context.state.metadata),
+                rootOperationId: operationId,
+                scope: context.state.metadata?.scope,
+                serverDB,
+                signal: this.ctx.signal,
+                skipResultTruncation: true,
+                subAgent: buildServerVirtualSubAgentRunner(
+                  this.ctx,
+                  context.state,
+                  chatToolPayload,
+                  context.parentMessageId,
+                ),
+                taskId: context.state.metadata?.taskId,
+                threadId: context.state.metadata?.threadId,
+                toolCallId: chatToolPayload.id,
+                toolManifestMap: context.effectiveManifestMap,
+                toolMessageId: context.toolMessageId,
+                toolResultMaxLength: context.toolResultMaxLength,
+                topicId: this.ctx.topicId,
+                userId,
+                workingDirectory: context.state.metadata?.deviceSystemInfo?.workingDirectory,
+                workspaceId: context.state.metadata?.workspaceId ?? this.ctx.workspaceId,
+              }),
+              this.ctx.signal,
+            ),
           {
-            isInterrupted: () => isOperationInterrupted(this.ctx),
+            isInterrupted: () =>
+              this.ctx.signal?.aborted ? Promise.resolve(true) : isOperationInterrupted(this.ctx),
             maxRetries: TOOL_MAX_RETRIES,
             onRetry: ({ attempt, kind, maxAttempts }) =>
               log(
@@ -249,6 +268,8 @@ export class ServerToolTransport implements ToolTransport {
           },
         );
       }
+
+      throwIfAgentStepAborted(this.ctx.signal);
 
       if (execution.result.deferred) {
         executeToolSpan.setAttributes(

--- a/apps/server/src/modules/AgentRuntime/adapters/ServerToolTransport.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerToolTransport.ts
@@ -8,6 +8,9 @@ import type {
 import { executeToolWithRetry } from '@lobechat/agent-runtime';
 import { SpanStatusCode } from '@lobechat/observability-otel/api';
 import {
+  ATTR_LOBEHUB_TOOL_ATTEMPTS,
+  ATTR_LOBEHUB_TOOL_EXECUTION_TARGET,
+  ATTR_LOBEHUB_TOOL_TIMEOUT_MS,
   buildExecuteToolAttributes,
   buildExecuteToolResultAttributes,
   executeToolSpanName,
@@ -118,6 +121,7 @@ export class ServerToolTransport implements ToolTransport {
 
     try {
       throwIfAgentStepAborted(this.ctx.signal);
+      if (this.ctx.hookDispatcher) this.ctx.onStage?.('hook.before_tool');
       const hookResult = await this.dispatchBeforeToolCall(chatToolPayload, context);
       let toolCallMocked = false;
 
@@ -158,6 +162,10 @@ export class ServerToolTransport implements ToolTransport {
           deadlineAt: this.ctx.deadlineAt,
           manifest: context.effectiveManifestMap[chatToolPayload.identifier],
         });
+        executeToolSpan.setAttributes({
+          [ATTR_LOBEHUB_TOOL_EXECUTION_TARGET]: 'client',
+          [ATTR_LOBEHUB_TOOL_TIMEOUT_MS]: timeoutMs,
+        });
         const dispatchResult = await dispatchClientTool(chatToolPayload, {
           agentId: context.state.metadata?.agentId,
           assistantMessageId: context.parentMessageId,
@@ -188,14 +196,20 @@ export class ServerToolTransport implements ToolTransport {
           manifest: context.effectiveManifestMap[chatToolPayload.identifier],
         });
         const agentVisibility = await this.resolveAgentVisibility(context);
+        const executionTarget =
+          isDeviceToolIdentifier(chatToolPayload.identifier) ||
+          Boolean(context.state.metadata?.activeDeviceId)
+            ? 'device'
+            : 'server';
 
         log(`[${operationLogId}] Executing tool ${context.toolName} ...`);
         this.ctx.onStage?.(
-          isDeviceToolIdentifier(chatToolPayload.identifier) ||
-            Boolean(context.state.metadata?.activeDeviceId)
-            ? 'tool.device.execute'
-            : 'tool.server.execute',
+          executionTarget === 'device' ? 'tool.device.execute' : 'tool.server.execute',
         );
+        executeToolSpan.setAttributes({
+          [ATTR_LOBEHUB_TOOL_EXECUTION_TARGET]: executionTarget,
+          [ATTR_LOBEHUB_TOOL_TIMEOUT_MS]: timeoutMs,
+        });
         execution = await executeToolWithRetry(
           () =>
             raceWithAgentStepSignal(
@@ -269,6 +283,11 @@ export class ServerToolTransport implements ToolTransport {
         );
       }
 
+      if (!execution.result.deferred) {
+        executeToolSpan.addEvent('tool.execute.complete', {
+          [ATTR_LOBEHUB_TOOL_ATTEMPTS]: execution.attempts,
+        });
+      }
       throwIfAgentStepAborted(this.ctx.signal);
 
       if (execution.result.deferred) {
@@ -282,6 +301,7 @@ export class ServerToolTransport implements ToolTransport {
         ...execution.result,
         executionTime: execution.result.executionTime ?? 0,
       };
+      this.ctx.onStage?.('tool.result.archive');
       const executionResult = await archiveRuntimeToolResult(resultWithExecutionTime, {
         agentId: context.state.metadata?.agentId,
         identifier: chatToolPayload.identifier,

--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.test.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.test.ts
@@ -4,6 +4,7 @@ import type { ChatMethodOptions, ModelRuntime } from '@lobechat/model-runtime';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { RuntimeExecutorContext } from '../context';
+import { AgentStepTimeoutError } from '../stepDeadline';
 import { createServerCallLlmAttempt } from './serverCallLlmAttempt';
 import type { ServerCallLlmTooling } from './serverCallLlmTooling';
 
@@ -43,6 +44,7 @@ const createAttempt = (
   runCallbacks: (options: ChatMethodOptions) => Promise<void>,
   blobStore?: BlobStore,
   attemptOverrides?: { clientIp?: string; userAgent?: string },
+  contextOverrides?: Partial<RuntimeExecutorContext>,
 ) => {
   const publishStreamChunk = vi.fn().mockResolvedValue('event-1');
   const streamManager = {
@@ -57,6 +59,7 @@ const createAttempt = (
     streamManager,
     toolExecutionService: {} as RuntimeExecutorContext['toolExecutionService'],
     userId: 'user-1',
+    ...contextOverrides,
   } satisfies RuntimeExecutorContext;
   const chat = vi.fn(async (_payload, options?: ChatMethodOptions) => {
     await runCallbacks(options!);
@@ -192,6 +195,24 @@ describe('ServerCallLlmAttempt', () => {
     const metadata = chat.mock.calls[0][1]!.metadata as Record<string, unknown>;
     expect(metadata.clientIp).toBeUndefined();
     expect(metadata.userAgent).toBeUndefined();
+  });
+
+  it('passes the step signal to model-runtime and rejects promptly when it aborts', async () => {
+    const controller = new AbortController();
+    const { attempt, chat } = createAttempt(() => new Promise(() => {}), undefined, undefined, {
+      signal: controller.signal,
+    });
+    const executionPromise = attempt.execute();
+    await vi.waitFor(() => expect(chat).toHaveBeenCalled());
+    expect(chat.mock.calls[0][1]?.signal).toBe(controller.signal);
+    const timeoutError = new AgentStepTimeoutError({
+      deadlineAt: Date.now(),
+      stage: 'model.call',
+    });
+
+    controller.abort(timeoutError);
+
+    await expect(executionPromise).rejects.toBe(timeoutError);
   });
 
   it('keeps partial output and usage readable after a stream error', async () => {

--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.test.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.test.ts
@@ -158,6 +158,23 @@ describe('ServerCallLlmAttempt', () => {
     );
   });
 
+  it('reports model finalization after the response stream is consumed', async () => {
+    const onStage = vi.fn();
+    const { attempt } = createAttempt(
+      async ({ callback }) => {
+        await callback?.onText?.('Answer');
+        await callback?.onCompletion?.({ text: '', usage: { totalOutputTokens: 1 } });
+      },
+      undefined,
+      undefined,
+      { onStage },
+    );
+
+    await attempt.execute();
+
+    expect(onStage).toHaveBeenCalledWith('model.finalize');
+  });
+
   it('forwards clientIp / userAgent into the chat call metadata when provided', async () => {
     const { attempt, chat } = createAttempt(
       async ({ callback }) => {

--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.ts
@@ -247,6 +247,7 @@ export class ServerCallLlmAttempt {
 
     if (this.streamError) throw createStreamExecutionError(this.streamError);
 
+    this.ctx.onStage?.('model.finalize');
     await this.streamSink.flushTextBuffer();
     await this.streamSink.flushReasoningBuffer();
     this.streamSink.clearBuffers();

--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.ts
@@ -18,6 +18,7 @@ import { pickString, toRecord } from '@lobechat/utils/object';
 
 import type { RuntimeExecutorContext } from '../context';
 import { isOperationInterrupted, log, timing } from '../executorHelpers';
+import { raceWithAgentStepSignal, throwIfAgentStepAborted } from '../stepDeadline';
 import {
   createServerCallLlmStreamSink,
   type ServerCallLlmStreamSink,
@@ -141,102 +142,108 @@ export class ServerCallLlmAttempt {
       this.chatPayload.tools?.length ?? 0,
     );
 
-    const response = await this.modelRuntime.chat(this.chatPayload, {
-      callback: {
-        onBase64Image: async ({ image }) => {
-          this.onFirstChunk();
-          await this.streamSink.appendBase64Image(image);
-        },
-        onCompletion: async (data) => {
-          if (data.usage) this.usage = data.usage;
-          if (data.speed) this.speed = data.speed;
-          if (data.finishReason) this.finishReason = data.finishReason;
-        },
-        onContentPart: async (part) => {
-          this.onFirstChunk();
-          await this.streamSink.appendContentPart(part);
-        },
-        onError: async (errorData) => {
-          this.streamError = errorData;
-          console.error(`[${this.operationLogId}][stream_error]`, errorData);
-        },
-        onGrounding: async (groundingData) => {
-          log(`[${this.operationLogId}][grounding] %O`, groundingData);
-          this.grounding = groundingData;
+    throwIfAgentStepAborted(this.ctx.signal);
+    const response = await raceWithAgentStepSignal(
+      this.modelRuntime.chat(this.chatPayload, {
+        callback: {
+          onBase64Image: async ({ image }) => {
+            this.onFirstChunk();
+            await this.streamSink.appendBase64Image(image);
+          },
+          onCompletion: async (data) => {
+            if (data.usage) this.usage = data.usage;
+            if (data.speed) this.speed = data.speed;
+            if (data.finishReason) this.finishReason = data.finishReason;
+          },
+          onContentPart: async (part) => {
+            this.onFirstChunk();
+            await this.streamSink.appendContentPart(part);
+          },
+          onError: async (errorData) => {
+            this.streamError = errorData;
+            console.error(`[${this.operationLogId}][stream_error]`, errorData);
+          },
+          onGrounding: async (groundingData) => {
+            log(`[${this.operationLogId}][grounding] %O`, groundingData);
+            this.grounding = groundingData;
 
-          await this.ctx.streamManager.publishStreamChunk(
-            this.ctx.operationId,
-            this.ctx.stepIndex,
-            {
-              chunkType: 'grounding',
-              grounding: groundingData,
-            },
-          );
-        },
-        onReasoningPart: async (part) => {
-          this.onFirstChunk();
-          await this.streamSink.appendReasoningPart(part);
-        },
-        onText: async (text) => {
-          this.onFirstChunk();
-          timing(
-            '[%s] onText received chunk at %d, length: %d',
-            this.operationLogId,
-            Date.now(),
-            text.length,
-          );
-          await this.streamSink.appendText(text);
-        },
-        onThinking: async (reasoning) => {
-          this.onFirstChunk();
-          timing(
-            '[%s] onThinking received chunk at %d, length: %d',
-            this.operationLogId,
-            Date.now(),
-            reasoning.length,
-          );
-          await this.streamSink.appendThinking(reasoning);
-        },
-        onToolsCalling: async ({ toolsCalling: raw }) => {
-          const resolvedCalls = new ToolNameResolver().resolve(
-            raw,
-            this.resolved.promptManifestMap,
-            this.resolved.tools.map((tool) => tool.function.name),
-          );
-          const payload = resolvedCalls.map((toolCall) => ({
-            ...toolCall,
-            executor: this.resolved.executorMap?.[toolCall.identifier],
-            source: this.resolved.sourceMap[toolCall.identifier],
-          }));
+            await this.ctx.streamManager.publishStreamChunk(
+              this.ctx.operationId,
+              this.ctx.stepIndex,
+              {
+                chunkType: 'grounding',
+                grounding: groundingData,
+              },
+            );
+          },
+          onReasoningPart: async (part) => {
+            this.onFirstChunk();
+            await this.streamSink.appendReasoningPart(part);
+          },
+          onText: async (text) => {
+            this.onFirstChunk();
+            timing(
+              '[%s] onText received chunk at %d, length: %d',
+              this.operationLogId,
+              Date.now(),
+              text.length,
+            );
+            await this.streamSink.appendText(text);
+          },
+          onThinking: async (reasoning) => {
+            this.onFirstChunk();
+            timing(
+              '[%s] onThinking received chunk at %d, length: %d',
+              this.operationLogId,
+              Date.now(),
+              reasoning.length,
+            );
+            await this.streamSink.appendThinking(reasoning);
+          },
+          onToolsCalling: async ({ toolsCalling: raw }) => {
+            const resolvedCalls = new ToolNameResolver().resolve(
+              raw,
+              this.resolved.promptManifestMap,
+              this.resolved.tools.map((tool) => tool.function.name),
+            );
+            const payload = resolvedCalls.map((toolCall) => ({
+              ...toolCall,
+              executor: this.resolved.executorMap?.[toolCall.identifier],
+              source: this.resolved.sourceMap[toolCall.identifier],
+            }));
 
-          this.toolsCalling = payload;
-          // Keep raw arguments through execution so malformed JSON can reach the
-          // tool error path and give the model a self-repair signal. Finalizers
-          // sanitize only the persisted DB and replay-state copies.
-          this.toolCalls = raw;
+            this.toolsCalling = payload;
+            // Keep raw arguments through execution so malformed JSON can reach the
+            // tool error path and give the model a self-repair signal. Finalizers
+            // sanitize only the persisted DB and replay-state copies.
+            this.toolCalls = raw;
 
-          await this.streamSink.flushTextBuffer();
-          await this.ctx.streamManager.publishStreamChunk(
-            this.ctx.operationId,
-            this.ctx.stepIndex,
-            {
-              chunkType: 'tools_calling',
-              toolsCalling: payload,
-            },
-          );
+            await this.streamSink.flushTextBuffer();
+            await this.ctx.streamManager.publishStreamChunk(
+              this.ctx.operationId,
+              this.ctx.stepIndex,
+              {
+                chunkType: 'tools_calling',
+                toolsCalling: payload,
+              },
+            );
+          },
         },
-      },
-      metadata: {
-        clientIp: this.clientIp,
-        operationId: this.ctx.operationId,
-        topicId: this.topicId,
-        trigger: this.trigger,
-        userAgent: this.userAgent,
-      },
-      user: this.ctx.userId,
-    });
+        metadata: {
+          clientIp: this.clientIp,
+          operationId: this.ctx.operationId,
+          topicId: this.topicId,
+          trigger: this.trigger,
+          userAgent: this.userAgent,
+        },
+        signal: this.ctx.signal,
+        user: this.ctx.userId,
+      }),
+      this.ctx.signal,
+    );
 
-    await consumeStreamUntilDone(response);
+    await raceWithAgentStepSignal(consumeStreamUntilDone(response), this.ctx.signal);
+    throwIfAgentStepAborted(this.ctx.signal);
 
     if (this.streamError) throw createStreamExecutionError(this.streamError);
 

--- a/apps/server/src/modules/AgentRuntime/context.ts
+++ b/apps/server/src/modules/AgentRuntime/context.ts
@@ -29,6 +29,8 @@ export interface RuntimeExecutorContext {
   allowEarlyFinalAnswerVisibleOutputEnd?: boolean;
   botContext?: unknown;
   botPlatformContext?: BotPlatformContext;
+  /** Absolute wall-clock deadline for the current delivered step. */
+  deadlineAt?: number;
   discordContext?: any;
   evalContext?: EvalContext;
   /**
@@ -52,8 +54,12 @@ export interface RuntimeExecutorContext {
   hookDispatcher?: HookDispatcher;
   loadAgentState?: (operationId: string) => Promise<AgentState | null>;
   messageModel: MessageModel;
+  /** Reports long-running model and tool stages to the step handler. */
+  onStage?: (stage: string) => void;
   operationId: string;
   serverDB: LobeChatDatabase;
+  /** Cooperative cancellation shared by all work within the current step. */
+  signal?: AbortSignal;
   stepIndex: number;
   stream?: boolean;
   streamManager: IStreamEventManager;

--- a/apps/server/src/modules/AgentRuntime/dispatchClientTool.ts
+++ b/apps/server/src/modules/AgentRuntime/dispatchClientTool.ts
@@ -5,6 +5,11 @@ import type { ToolExecutionResultResponse } from '@/server/services/toolExecutio
 
 import { getAgentRuntimeRedisClient } from './redis';
 import { GLOBAL_DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS, MIN_TIMEOUT_MS } from './resolveToolTimeout';
+import {
+  getAgentStepAbortReason,
+  raceWithAgentStepSignal,
+  throwIfAgentStepAborted,
+} from './stepDeadline';
 import type { ToolResultPayload } from './ToolResultWaiter';
 import { ToolResultWaiter } from './ToolResultWaiter';
 import type { IStreamEventManager } from './types';
@@ -15,11 +20,15 @@ interface DispatchContext {
   agentId?: string | null;
   /** Assistant message that carries this tool call. */
   assistantMessageId?: string;
+  /** Absolute deadline of the containing step. */
+  deadlineAt?: number;
   documentId?: string | null;
   groupId?: string | null;
   operationId: string;
   rootOperationId?: string;
   scope?: string | null;
+  /** Cooperative cancellation inherited from the containing step. */
+  signal?: AbortSignal;
   sourceMessageId?: string | null;
   streamManager: IStreamEventManager;
   taskId?: string | null;
@@ -27,16 +36,21 @@ interface DispatchContext {
   /**
    * Per-call execution budget in milliseconds, normally produced by
    * `resolveToolTimeoutMs`. When omitted, falls back to the global default
-   * (`GLOBAL_DEFAULT_TIMEOUT_MS`). Always clamped to
-   * `[MIN_TIMEOUT_MS, MAX_TIMEOUT_MS]` regardless of source — the client is
-   * a suggester, this dispatcher is the arbiter.
+   * (`GLOBAL_DEFAULT_TIMEOUT_MS`). Configuration is clamped to
+   * `[MIN_TIMEOUT_MS, MAX_TIMEOUT_MS]`, then reduced to the containing step's
+   * remaining budget when necessary.
    */
   timeoutMs?: number;
   topicId?: string | null;
 }
 
-const clampTimeout = (value: number): number =>
-  Math.min(Math.max(Math.trunc(value), MIN_TIMEOUT_MS), MAX_TIMEOUT_MS);
+const clampTimeout = (value: number, deadlineAt?: number): number => {
+  const configuredTimeout = Math.min(Math.max(Math.trunc(value), MIN_TIMEOUT_MS), MAX_TIMEOUT_MS);
+
+  if (deadlineAt === undefined) return configuredTimeout;
+
+  return Math.min(configuredTimeout, Math.max(1, Math.trunc(deadlineAt - Date.now())));
+};
 
 const buildTimeoutResult = (executionTime: number): ToolExecutionResultResponse => ({
   content: '',
@@ -74,6 +88,8 @@ export async function dispatchClientTool(
   const { operationId, streamManager } = ctx;
   const startedAt = Date.now();
 
+  throwIfAgentStepAborted(ctx.signal);
+
   if (typeof streamManager.sendToolExecute !== 'function') {
     return buildErrorResult(
       0,
@@ -96,7 +112,7 @@ export async function dispatchClientTool(
   const blockingClient = redis.duplicate();
   const waiter = new ToolResultWaiter(blockingClient, redis);
 
-  const timeoutMs = clampTimeout(ctx.timeoutMs ?? GLOBAL_DEFAULT_TIMEOUT_MS);
+  const timeoutMs = clampTimeout(ctx.timeoutMs ?? GLOBAL_DEFAULT_TIMEOUT_MS, ctx.deadlineAt);
 
   try {
     log(
@@ -108,25 +124,31 @@ export async function dispatchClientTool(
       timeoutMs,
     );
 
-    await streamManager.sendToolExecute(operationId, {
-      agentId: ctx.agentId,
-      apiName: chatToolPayload.apiName,
-      arguments: chatToolPayload.arguments,
-      assistantMessageId: ctx.assistantMessageId,
-      documentId: ctx.documentId,
-      executionTimeoutMs: timeoutMs,
-      groupId: ctx.groupId,
-      identifier: chatToolPayload.identifier,
-      rootOperationId: ctx.rootOperationId ?? operationId,
-      scope: ctx.scope,
-      sourceMessageId: ctx.sourceMessageId,
-      taskId: ctx.taskId,
-      threadId: ctx.threadId,
-      toolCallId: chatToolPayload.id,
-      topicId: ctx.topicId,
-    });
+    await raceWithAgentStepSignal(
+      streamManager.sendToolExecute(operationId, {
+        agentId: ctx.agentId,
+        apiName: chatToolPayload.apiName,
+        arguments: chatToolPayload.arguments,
+        assistantMessageId: ctx.assistantMessageId,
+        documentId: ctx.documentId,
+        executionTimeoutMs: timeoutMs,
+        groupId: ctx.groupId,
+        identifier: chatToolPayload.identifier,
+        rootOperationId: ctx.rootOperationId ?? operationId,
+        scope: ctx.scope,
+        sourceMessageId: ctx.sourceMessageId,
+        taskId: ctx.taskId,
+        threadId: ctx.threadId,
+        toolCallId: chatToolPayload.id,
+        topicId: ctx.topicId,
+      }),
+      ctx.signal,
+    );
 
-    const result = await waiter.waitForResult(chatToolPayload.id, timeoutMs);
+    const result = await raceWithAgentStepSignal(
+      waiter.waitForResult(chatToolPayload.id, timeoutMs),
+      ctx.signal,
+    );
     const executionTime = Date.now() - startedAt;
 
     if (!result) {
@@ -141,6 +163,8 @@ export async function dispatchClientTool(
 
     return projectToExecutionResult(result, executionTime);
   } catch (error) {
+    if (ctx.signal?.aborted) throw getAgentStepAbortReason(ctx.signal);
+
     const executionTime = Date.now() - startedAt;
     log('[%s] client tool dispatch failed: %O', operationId, error);
     return buildErrorResult(executionTime, error);

--- a/apps/server/src/modules/AgentRuntime/resolveToolTimeout.ts
+++ b/apps/server/src/modules/AgentRuntime/resolveToolTimeout.ts
@@ -1,4 +1,6 @@
-import { type LobeToolManifest } from '@lobechat/context-engine';
+import type { LobeToolManifest } from '@lobechat/context-engine';
+
+import { DEFAULT_AGENT_STEP_DEADLINE_MS } from './stepDeadline';
 
 /**
  * Global fallback when neither the LLM nor the tool manifest specifies a
@@ -14,10 +16,10 @@ export const MIN_TIMEOUT_MS = 1_000;
 
 /**
  * Hard ceiling enforced server-side regardless of what the LLM or manifest
- * asks for. Matches the cloud agent function window (800s) so a single
- * client-tool dispatch never outlives its containing run.
+ * asks for. A tool must leave enough room for the containing step to persist
+ * its terminal state and release execution resources.
  */
-export const MAX_TIMEOUT_MS = 800_000;
+export const MAX_TIMEOUT_MS = DEFAULT_AGENT_STEP_DEADLINE_MS;
 
 const clamp = (value: number): number =>
   Math.min(Math.max(Math.trunc(value), MIN_TIMEOUT_MS), MAX_TIMEOUT_MS);
@@ -35,6 +37,8 @@ export interface ResolveToolTimeoutInput {
    * takes top priority when present.
    */
   args?: Record<string, unknown> | null;
+  /** Absolute deadline of the containing step. */
+  deadlineAt?: number;
   /** Manifest for the tool being dispatched, looked up by identifier. */
   manifest?: LobeToolManifest;
 }
@@ -47,20 +51,23 @@ export interface ResolveToolTimeoutInput {
  *   2. `manifest.api[apiName].defaultTimeoutMs` — tool-author default (ms)
  *   3. `GLOBAL_DEFAULT_TIMEOUT_MS` (120_000)
  *
- * The result is always clamped to `[MIN_TIMEOUT_MS, MAX_TIMEOUT_MS]`. The
+ * Configuration is clamped to `[MIN_TIMEOUT_MS, MAX_TIMEOUT_MS]`, then reduced
+ * to the containing step's remaining budget when a deadline is present. The
  * client is a *suggester*; this function is the sole *arbiter*.
  */
 export const resolveToolTimeoutMs = ({
   apiName,
   args,
+  deadlineAt,
   manifest,
 }: ResolveToolTimeoutInput): number => {
   const argTimeout = readPositiveNumber(args?.timeout);
-  if (argTimeout !== undefined) return clamp(argTimeout);
-
-  const manifestApi = manifest?.api?.find((a) => a.name === apiName);
+  const manifestApi = manifest?.api?.find((item) => item.name === apiName);
   const manifestDefault = readPositiveNumber(manifestApi?.defaultTimeoutMs);
-  if (manifestDefault !== undefined) return clamp(manifestDefault);
+  const configuredTimeout = clamp(argTimeout ?? manifestDefault ?? GLOBAL_DEFAULT_TIMEOUT_MS);
 
-  return clamp(GLOBAL_DEFAULT_TIMEOUT_MS);
+  if (deadlineAt === undefined) return configuredTimeout;
+
+  const remainingStepBudget = Math.max(1, Math.trunc(deadlineAt - Date.now()));
+  return Math.min(configuredTimeout, remainingStepBudget);
 };

--- a/apps/server/src/modules/AgentRuntime/stepDeadline.ts
+++ b/apps/server/src/modules/AgentRuntime/stepDeadline.ts
@@ -51,10 +51,11 @@ export const throwIfAgentStepAborted = (signal?: AbortSignal): void => {
 };
 
 export const raceWithAgentStepSignal = async <T>(
-  promise: Promise<T>,
+  promise: PromiseLike<T> | T,
   signal?: AbortSignal,
 ): Promise<T> => {
-  if (!signal) return promise;
+  const pending = Promise.resolve(promise);
+  if (!signal) return pending;
 
   throwIfAgentStepAborted(signal);
 
@@ -62,7 +63,7 @@ export const raceWithAgentStepSignal = async <T>(
     const handleAbort = () => reject(getAgentStepAbortReason(signal));
     signal.addEventListener('abort', handleAbort, { once: true });
 
-    promise.then(resolve, reject).finally(() => {
+    pending.then(resolve, reject).finally(() => {
       signal.removeEventListener('abort', handleAbort);
     });
   });

--- a/apps/server/src/modules/AgentRuntime/stepDeadline.ts
+++ b/apps/server/src/modules/AgentRuntime/stepDeadline.ts
@@ -1,0 +1,69 @@
+export const AGENT_STEP_TIMEOUT_ERROR_TYPE = 'AgentStepTimeout';
+
+export const DEFAULT_AGENT_STEP_DEADLINE_MS = 8 * 60 * 1000;
+
+interface AgentStepTimeoutErrorOptions {
+  deadlineAt: number;
+  stage: string;
+}
+
+export class AgentStepTimeoutError extends Error {
+  readonly deadlineAt: number;
+  readonly errorType = AGENT_STEP_TIMEOUT_ERROR_TYPE;
+  handled = false;
+  readonly stage: string;
+
+  constructor({ deadlineAt, stage }: AgentStepTimeoutErrorOptions) {
+    super(`Agent step exceeded its deadline while in stage: ${stage}`);
+    this.name = AGENT_STEP_TIMEOUT_ERROR_TYPE;
+    this.deadlineAt = deadlineAt;
+    this.stage = stage;
+  }
+}
+
+export const isAgentStepTimeoutError = (error: unknown): error is AgentStepTimeoutError =>
+  error instanceof AgentStepTimeoutError ||
+  (typeof error === 'object' &&
+    error !== null &&
+    'errorType' in error &&
+    error.errorType === AGENT_STEP_TIMEOUT_ERROR_TYPE);
+
+export const markAgentStepTimeoutHandled = (error: AgentStepTimeoutError): void => {
+  error.handled = true;
+};
+
+export const getAgentStepAbortReason = (signal: AbortSignal): Error => {
+  if (signal.reason instanceof Error) return signal.reason;
+
+  return new Error(typeof signal.reason === 'string' ? signal.reason : 'Agent step aborted');
+};
+
+/**
+ * Preserve the exact abort reason instance rather than normalizing it through
+ * agentRuntime/abort.ts. The timeout instance is marked as handled only after
+ * its terminal state is durable, and the HTTP boundary reads that same marker
+ * to choose between QStash ACK and retry.
+ */
+export const throwIfAgentStepAborted = (signal?: AbortSignal): void => {
+  if (!signal?.aborted) return;
+
+  throw getAgentStepAbortReason(signal);
+};
+
+export const raceWithAgentStepSignal = async <T>(
+  promise: Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> => {
+  if (!signal) return promise;
+
+  throwIfAgentStepAborted(signal);
+
+  return new Promise<T>((resolve, reject) => {
+    const handleAbort = () => reject(getAgentStepAbortReason(signal));
+    signal.addEventListener('abort', handleAbort, { once: true });
+
+    promise.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', handleAbort);
+    });
+  });
+};

--- a/apps/server/src/modules/AgentRuntime/stepDeadline.ts
+++ b/apps/server/src/modules/AgentRuntime/stepDeadline.ts
@@ -5,6 +5,7 @@ export const DEFAULT_AGENT_STEP_DEADLINE_MS = 8 * 60 * 1000;
 interface AgentStepTimeoutErrorOptions {
   deadlineAt: number;
   stage: string;
+  stageElapsedMs?: number;
 }
 
 export class AgentStepTimeoutError extends Error {
@@ -12,12 +13,14 @@ export class AgentStepTimeoutError extends Error {
   readonly errorType = AGENT_STEP_TIMEOUT_ERROR_TYPE;
   handled = false;
   readonly stage: string;
+  readonly stageElapsedMs?: number;
 
-  constructor({ deadlineAt, stage }: AgentStepTimeoutErrorOptions) {
+  constructor({ deadlineAt, stage, stageElapsedMs }: AgentStepTimeoutErrorOptions) {
     super(`Agent step exceeded its deadline while in stage: ${stage}`);
     this.name = AGENT_STEP_TIMEOUT_ERROR_TYPE;
     this.deadlineAt = deadlineAt;
     this.stage = stage;
+    this.stageElapsedMs = stageElapsedMs;
   }
 }
 

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.test.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.test.ts
@@ -7,14 +7,11 @@ import type { MockInstance } from 'vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentOperationModel } from '@/database/models/agentOperation';
+import { AgentStepTimeoutError } from '@/server/modules/AgentRuntime/stepDeadline';
 
 import { AgentRuntimeService } from './AgentRuntimeService';
 import { hookDispatcher } from './hooks';
-import {
-  type AgentExecutionParams,
-  type OperationCreationParams,
-  type StartExecutionParams,
-} from './types';
+import type { AgentExecutionParams, OperationCreationParams, StartExecutionParams } from './types';
 
 vi.mock('@lobechat/model-runtime', () => ({
   // RuntimeExecutors (loaded transitively) resolves extend params via this
@@ -586,6 +583,45 @@ describe('AgentRuntimeService', () => {
 
       expect(mockCoordinator.saveStepResult).toHaveBeenCalled();
       expect(mockQueueService.scheduleMessage).toHaveBeenCalled();
+    });
+
+    it('should keep a committed done state when the deadline fires during saveStepResult', async () => {
+      const controller = new AbortController();
+      const timeoutError = new AgentStepTimeoutError({
+        deadlineAt: Date.now(),
+        stage: 'state.save',
+      });
+      const mockStepResult = {
+        events: [],
+        newState: { ...mockState, status: 'done', stepCount: 2 },
+        nextContext: null,
+      };
+      const mockRuntime = { step: vi.fn().mockResolvedValue(mockStepResult) };
+      vi.spyOn(service as any, 'createAgentRuntime').mockReturnValue({ runtime: mockRuntime });
+      mockCoordinator.saveStepResult.mockImplementationOnce(async () => {
+        controller.abort(timeoutError);
+      });
+
+      const result = await service.executeStep({
+        ...mockParams,
+        deadlineAt: timeoutError.deadlineAt,
+        signal: controller.signal,
+      });
+
+      expect(result).toMatchObject({
+        nextStepScheduled: false,
+        state: { status: 'done' },
+        success: true,
+      });
+      expect(timeoutError.handled).toBe(false);
+      expect(mockCoordinator.saveAgentState).not.toHaveBeenCalledWith(
+        'test-operation-1',
+        expect.objectContaining({ status: 'error' }),
+      );
+      expect(mockStreamManager.publishStreamEvent).not.toHaveBeenCalledWith(
+        'test-operation-1',
+        expect.objectContaining({ type: 'error' }),
+      );
     });
 
     it('should resume async tools with the last pending tool result as parentMessageId', async () => {

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.test.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.test.ts
@@ -624,6 +624,31 @@ describe('AgentRuntimeService', () => {
       );
     });
 
+    it('should stop waiting when state loading stalls past the step deadline', async () => {
+      const controller = new AbortController();
+      const timeoutError = new AgentStepTimeoutError({
+        deadlineAt: Date.now(),
+        stage: 'state.load',
+      });
+      mockCoordinator.loadAgentState.mockImplementationOnce(() => new Promise(() => {}));
+
+      const execution = service.executeStep({
+        ...mockParams,
+        deadlineAt: timeoutError.deadlineAt,
+        signal: controller.signal,
+      });
+      await vi.waitFor(() => expect(mockCoordinator.loadAgentState).toHaveBeenCalled());
+
+      controller.abort(timeoutError);
+
+      await expect(execution).rejects.toBe(timeoutError);
+      expect(timeoutError.handled).toBe(true);
+      expect(mockCoordinator.saveAgentState).toHaveBeenCalledWith(
+        'test-operation-1',
+        expect.objectContaining({ status: 'error' }),
+      );
+    });
+
     it('should resume async tools with the last pending tool result as parentMessageId', async () => {
       const pendingTools = [
         {

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -879,6 +879,7 @@ export class AgentRuntimeService {
         const stepStartUiMessages = await awaitStepWork(
           this.queryUiMessages(agentState, { skipWorks: true }),
         );
+        reportStage('gateway.publish_step_start');
         await awaitStepWork(
           this.streamManager.publishStreamEvent(operationId, {
             data: {
@@ -958,6 +959,7 @@ export class AgentRuntimeService {
 
           const reason = this.determineCompletionReason(agentState);
 
+          reportStage('completion.hooks');
           await this.completionLifecycle.emitSignalEvents(operationId, agentState, reason);
 
           // Dispatch completion hooks so consumers (e.g., bot local-mode promise) can finalize
@@ -975,6 +977,7 @@ export class AgentRuntimeService {
 
         // Dispatch beforeStep hooks
         try {
+          reportStage('hook.before_step');
           const beforeStepMetadata = agentState?.metadata || {};
           const beforeStepSignalEmission = await awaitStepWork(
             emitAgentSignalSourceEvent(
@@ -1223,6 +1226,7 @@ export class AgentRuntimeService {
 
         // Dispatch afterStep hooks (enriched with step presentation + tracking data)
         try {
+          reportStage('hook.after_step');
           const metadata = stepResult.newState?.metadata || {};
           const tracking = metadata._stepTracking || {};
           const elapsedMs = stepResult.newState?.createdAt
@@ -1330,6 +1334,7 @@ export class AgentRuntimeService {
 
           // Persist tracking state for next step
           stepResult.newState.metadata._stepTracking = updatedTracking;
+          reportStage('state.save_step_tracking');
           await this.coordinator.saveAgentState(operationId, stepResult.newState);
         }
 
@@ -1378,6 +1383,7 @@ export class AgentRuntimeService {
             buildInvokeAgentResultAttributes({ completionReason: reason }),
           );
 
+          reportStage('completion.hooks');
           const completionSignalEvents = await this.completionLifecycle.emitSignalEvents(
             operationId,
             stepResult.newState,
@@ -1411,6 +1417,7 @@ export class AgentRuntimeService {
           // recorder so propagated failures still write the canonical S3
           // snapshot instead of orphaning the partial ().
           const newStateError = stepResult.newState.error;
+          reportStage('trace.finalize');
           await this.traceRecorder.finalize(operationId, {
             appendEventsToLastStep: completionSignalEvents,
             completionReason: reason,

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -54,6 +54,7 @@ import {
 import {
   isAgentStepTimeoutError,
   markAgentStepTimeoutHandled,
+  raceWithAgentStepSignal,
   throwIfAgentStepAborted,
 } from '@/server/modules/AgentRuntime/stepDeadline';
 import { type IStreamEventManager } from '@/server/modules/AgentRuntime/types';
@@ -746,6 +747,8 @@ export class AgentRuntimeService {
       verifyAsyncToolBarrier,
     } = params;
     const reportStage = (stage: string) => onStage?.(stage);
+    const awaitStepWork = <T>(promise: Promise<T>): Promise<T> =>
+      raceWithAgentStepSignal(promise, signal);
 
     throwIfAgentStepAborted(signal);
 
@@ -866,23 +869,25 @@ export class AgentRuntimeService {
         // the contract that lets the client treat the pushed uiMessages as
         // the source of truth instead of doing its own refetch.
         reportStage('state.load');
-        const agentState = await this.coordinator.loadAgentState(operationId);
-        throwIfAgentStepAborted(signal);
+        const agentState = await awaitStepWork(this.coordinator.loadAgentState(operationId));
 
         if (!agentState) {
           throw new Error(`Agent state not found for operation ${operationId}`);
         }
 
         reportStage('messages.snapshot');
-        const stepStartUiMessages = await this.queryUiMessages(agentState, { skipWorks: true });
-        await this.streamManager.publishStreamEvent(operationId, {
-          data: {
-            ...(stepStartUiMessages !== undefined && { uiMessages: stepStartUiMessages }),
-          },
-          stepIndex,
-          type: 'step_start',
-        });
-        throwIfAgentStepAborted(signal);
+        const stepStartUiMessages = await awaitStepWork(
+          this.queryUiMessages(agentState, { skipWorks: true }),
+        );
+        await awaitStepWork(
+          this.streamManager.publishStreamEvent(operationId, {
+            data: {
+              ...(stepStartUiMessages !== undefined && { uiMessages: stepStartUiMessages }),
+            },
+            stepIndex,
+            type: 'step_start',
+          }),
+        );
 
         agentState.metadata = {
           ...agentState.metadata,
@@ -897,8 +902,7 @@ export class AgentRuntimeService {
         // needs to carry the (potentially multi-MB) `messages` array, which is
         // what trips Upstash's 10MB single-request limit and drops the op.
         reportStage('messages.rehydrate');
-        await this.rehydrateStateMessagesFromDB(agentState);
-        throwIfAgentStepAborted(signal);
+        await awaitStepWork(this.rehydrateStateMessagesFromDB(agentState));
 
         // Enrich invoke_agent span with agent identity now that state is loaded.
         const stateAgentConfig = agentState.metadata?.agentConfig as
@@ -972,40 +976,44 @@ export class AgentRuntimeService {
         // Dispatch beforeStep hooks
         try {
           const beforeStepMetadata = agentState?.metadata || {};
-          const beforeStepSignalEmission = await emitAgentSignalSourceEvent(
-            {
-              payload: {
-                agentId: beforeStepMetadata?.agentId,
-                operationId,
-                serializedContext: undefined,
-                stepIndex,
-                topicId: beforeStepMetadata?.topicId,
-                turnCount: agentState?.stepCount || 0,
+          const beforeStepSignalEmission = await awaitStepWork(
+            emitAgentSignalSourceEvent(
+              {
+                payload: {
+                  agentId: beforeStepMetadata?.agentId,
+                  operationId,
+                  serializedContext: undefined,
+                  stepIndex,
+                  topicId: beforeStepMetadata?.topicId,
+                  turnCount: agentState?.stepCount || 0,
+                },
+                sourceId: `${operationId}:before:${stepIndex}`,
+                sourceType: 'runtime.before_step',
               },
-              sourceId: `${operationId}:before:${stepIndex}`,
-              sourceType: 'runtime.before_step',
-            },
-            {
-              agentId: beforeStepMetadata?.agentId,
-              db: this.serverDB,
-              userId: beforeStepMetadata?.userId || this.userId,
-              workspaceId: this.workspaceId,
-            },
-            { ignoreError: true },
+              {
+                agentId: beforeStepMetadata?.agentId,
+                db: this.serverDB,
+                userId: beforeStepMetadata?.userId || this.userId,
+                workspaceId: this.workspaceId,
+              },
+              { ignoreError: true },
+            ),
           );
           beforeStepSignalEvents = toAgentSignalSnapshotEvents(beforeStepSignalEmission);
-          await hookDispatcher.dispatch(
-            operationId,
-            'beforeStep',
-            {
-              agentId: beforeStepMetadata?.agentId || '',
-              finalState: agentState,
+          await awaitStepWork(
+            hookDispatcher.dispatch(
               operationId,
-              stepIndex,
-              steps: agentState?.stepCount || 0,
-              userId: beforeStepMetadata?.userId || this.userId,
-            },
-            beforeStepMetadata._hooks,
+              'beforeStep',
+              {
+                agentId: beforeStepMetadata?.agentId || '',
+                finalState: agentState,
+                operationId,
+                stepIndex,
+                steps: agentState?.stepCount || 0,
+                userId: beforeStepMetadata?.userId || this.userId,
+              },
+              beforeStepMetadata._hooks,
+            ),
           );
         } catch (hookError) {
           log('[%s] beforeStep hook dispatch error: %O', operationId, hookError);
@@ -1026,31 +1034,34 @@ export class AgentRuntimeService {
         // Use agentState.metadata which contains the full app context (topicId, agentId, etc.)
         // operationMetadata only contains basic fields (agentConfig, modelRuntimeConfig, userId)
         reportStage('runtime.create');
-        const { runtime } = await this.createAgentRuntime({
-          deadlineAt,
-          metadata: agentState?.metadata,
-          onStage,
-          operationId,
-          signal,
-          stepIndex,
-          tracingContextEngine: (input, output) => {
-            contextEnginePayload = { input, output };
-          },
-        });
-        throwIfAgentStepAborted(signal);
+        const { runtime } = await awaitStepWork(
+          this.createAgentRuntime({
+            deadlineAt,
+            metadata: agentState?.metadata,
+            onStage,
+            operationId,
+            signal,
+            stepIndex,
+            tracingContextEngine: (input, output) => {
+              contextEnginePayload = { input, output };
+            },
+          }),
+        );
 
         // Handle human intervention
         let currentContext = context;
         let currentState = agentState;
 
         if (humanInput || approvedToolCall || rejectionReason) {
-          const interventionResult = await this.humanIntervention.process(currentState, {
-            approvedToolCall,
-            humanInput,
-            rejectAndContinue,
-            rejectionReason,
-            toolMessageId,
-          });
+          const interventionResult = await awaitStepWork(
+            this.humanIntervention.process(currentState, {
+              approvedToolCall,
+              humanInput,
+              rejectAndContinue,
+              rejectionReason,
+              toolMessageId,
+            }),
+          );
           currentState = interventionResult.newState;
           currentContext = interventionResult.nextContext;
         }
@@ -1060,7 +1071,7 @@ export class AgentRuntimeService {
         // the pending set, refresh messages from the DB (to pick up the tool
         // results written out-of-band), and re-enter the LLM with them.
         if (resumeAsyncTool && currentState.status === 'waiting_for_async_tool') {
-          const refreshed = await this.refreshMessagesFromDB(currentState);
+          const refreshed = await awaitStepWork(this.refreshMessagesFromDB(currentState));
           const pendingTools = (currentState.pendingToolsCalling ?? []) as ChatToolPayload[];
           const resumeParentMessageId = this.resolveAsyncToolResumeParentMessageId(
             refreshed,
@@ -1092,7 +1103,7 @@ export class AgentRuntimeService {
         // completion + dispatch hooks. Skips runtime.step entirely.
         let forcedFinishState: AgentState | undefined;
         if (finishAfterAsyncTool && currentState.status === 'waiting_for_async_tool') {
-          const refreshed = await this.refreshMessagesFromDB(currentState);
+          const refreshed = await awaitStepWork(this.refreshMessagesFromDB(currentState));
           currentState = structuredClone(currentState);
           currentState.messages = refreshed;
           currentState.pendingToolsCalling = [];
@@ -1111,7 +1122,7 @@ export class AgentRuntimeService {
         // Pre-step computation: extract device context from DB messages
         // Follows front-end computeStepContext pattern — computed at step boundary, not inside executors
         if (!currentState.metadata?.activeDeviceId) {
-          const deviceContext = await this.computeDeviceContext(currentState);
+          const deviceContext = await awaitStepWork(this.computeDeviceContext(currentState));
           if (deviceContext && currentState.metadata) {
             currentState.metadata.activeDeviceId = deviceContext.activeDeviceId;
             currentState.metadata.devicePlatform = deviceContext.devicePlatform;
@@ -1131,8 +1142,7 @@ export class AgentRuntimeService {
         const startAt = Date.now();
         const stepResult = forcedFinishState
           ? { events: [], newState: forcedFinishState, nextContext: undefined }
-          : await runtime.step(currentState, currentContext);
-        throwIfAgentStepAborted(signal);
+          : await awaitStepWork(runtime.step(currentState, currentContext));
 
         // Inner runtime.step() catches model-runtime exceptions and stuffs the
         // raw error into newState.error without re-throwing — so the outer
@@ -1146,8 +1156,7 @@ export class AgentRuntimeService {
         // Check if the operation was interrupted while the step was executing
         // (e.g., user clicked abort during a long LLM call)
         reportStage('state.refresh');
-        const latestState = await this.coordinator.loadAgentState(operationId);
-        throwIfAgentStepAborted(signal);
+        const latestState = await awaitStepWork(this.coordinator.loadAgentState(operationId));
         if (latestState?.status === 'interrupted') {
           stepResult.newState.status = 'interrupted';
           stepResult.newState.lastModified = new Date().toISOString();

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -51,6 +51,11 @@ import {
   createRuntimeExecutors,
   type RuntimeExecutorContext,
 } from '@/server/modules/AgentRuntime/RuntimeExecutors';
+import {
+  isAgentStepTimeoutError,
+  markAgentStepTimeoutHandled,
+  throwIfAgentStepAborted,
+} from '@/server/modules/AgentRuntime/stepDeadline';
 import { type IStreamEventManager } from '@/server/modules/AgentRuntime/types';
 import { emitAgentSignalSourceEvent } from '@/server/services/agentSignal';
 import { toAgentSignalTraceEvents } from '@/server/services/agentSignal/observability/traceEvents';
@@ -722,21 +727,27 @@ export class AgentRuntimeService {
    */
   async executeStep(params: AgentExecutionParams): Promise<AgentExecutionResult> {
     const {
-      operationId,
-      stepIndex,
-      context,
-      humanInput,
       approvedToolCall,
-      rejectionReason,
-      rejectAndContinue,
-      resumeAsyncTool,
+      asyncToolVerifyAttempt,
+      context,
+      deadlineAt,
+      externalRetryCount = 0,
       finishAfterAsyncTool,
       groupMemberTimeout,
+      humanInput,
+      onStage,
+      operationId,
+      rejectAndContinue,
+      rejectionReason,
+      resumeAsyncTool,
+      signal,
+      stepIndex,
       toolMessageId,
       verifyAsyncToolBarrier,
-      asyncToolVerifyAttempt,
-      externalRetryCount = 0,
     } = params;
+    const reportStage = (stage: string) => onStage?.(stage);
+
+    throwIfAgentStepAborted(signal);
 
     // Group member timeout watchdog: enforce a member's deadline without claiming
     // the step lock. No-op if the member already finished; otherwise interrupt it
@@ -772,6 +783,7 @@ export class AgentRuntimeService {
     }
 
     // ===== Distributed lock: prevent duplicate execution from QStash retries =====
+    reportStage('lock.claim');
     const stepLockOwner = createStepLockOwner(operationId, stepIndex);
     const claimed = await this.coordinator.tryClaimStep(
       operationId,
@@ -844,6 +856,7 @@ export class AgentRuntimeService {
 
     try {
       return await otelContext.with(invokeAgentCtx, async () => {
+        throwIfAgentStepAborted(signal);
         log('[%s][%d] Start step executing...', operationId, stepIndex);
 
         // Load agent state BEFORE publishing step_start so we can attach the
@@ -852,12 +865,15 @@ export class AgentRuntimeService {
         // the snapshot query here reflects strongly-consistent state — that's
         // the contract that lets the client treat the pushed uiMessages as
         // the source of truth instead of doing its own refetch.
+        reportStage('state.load');
         const agentState = await this.coordinator.loadAgentState(operationId);
+        throwIfAgentStepAborted(signal);
 
         if (!agentState) {
           throw new Error(`Agent state not found for operation ${operationId}`);
         }
 
+        reportStage('messages.snapshot');
         const stepStartUiMessages = await this.queryUiMessages(agentState, { skipWorks: true });
         await this.streamManager.publishStreamEvent(operationId, {
           data: {
@@ -866,6 +882,7 @@ export class AgentRuntimeService {
           stepIndex,
           type: 'step_start',
         });
+        throwIfAgentStepAborted(signal);
 
         agentState.metadata = {
           ...agentState.metadata,
@@ -879,7 +896,9 @@ export class AgentRuntimeService {
         // refresh below. With this in place the Redis-persisted state no longer
         // needs to carry the (potentially multi-MB) `messages` array, which is
         // what trips Upstash's 10MB single-request limit and drops the op.
+        reportStage('messages.rehydrate');
         await this.rehydrateStateMessagesFromDB(agentState);
+        throwIfAgentStepAborted(signal);
 
         // Enrich invoke_agent span with agent identity now that state is loaded.
         const stateAgentConfig = agentState.metadata?.agentConfig as
@@ -1006,14 +1025,19 @@ export class AgentRuntimeService {
         // Create Agent and Runtime instances
         // Use agentState.metadata which contains the full app context (topicId, agentId, etc.)
         // operationMetadata only contains basic fields (agentConfig, modelRuntimeConfig, userId)
+        reportStage('runtime.create');
         const { runtime } = await this.createAgentRuntime({
+          deadlineAt,
           metadata: agentState?.metadata,
+          onStage,
           operationId,
+          signal,
           stepIndex,
           tracingContextEngine: (input, output) => {
             contextEnginePayload = { input, output };
           },
         });
+        throwIfAgentStepAborted(signal);
 
         // Handle human intervention
         let currentContext = context;
@@ -1102,10 +1126,13 @@ export class AgentRuntimeService {
         }
 
         // Execute step (skipped when force-finishing a parked supervisor op).
+        reportStage('runtime.step');
+        throwIfAgentStepAborted(signal);
         const startAt = Date.now();
         const stepResult = forcedFinishState
           ? { events: [], newState: forcedFinishState, nextContext: undefined }
           : await runtime.step(currentState, currentContext);
+        throwIfAgentStepAborted(signal);
 
         // Inner runtime.step() catches model-runtime exceptions and stuffs the
         // raw error into newState.error without re-throwing — so the outer
@@ -1118,7 +1145,9 @@ export class AgentRuntimeService {
 
         // Check if the operation was interrupted while the step was executing
         // (e.g., user clicked abort during a long LLM call)
+        reportStage('state.refresh');
         const latestState = await this.coordinator.loadAgentState(operationId);
+        throwIfAgentStepAborted(signal);
         if (latestState?.status === 'interrupted') {
           stepResult.newState.status = 'interrupted';
           stepResult.newState.lastModified = new Date().toISOString();
@@ -1126,11 +1155,18 @@ export class AgentRuntimeService {
         }
 
         // Save state, coordinator will handle event sending automatically
+        reportStage('state.save');
         await this.coordinator.saveStepResult(operationId, {
           ...stepResult,
           executionTime: Date.now() - startAt,
           stepIndex, // placeholder
         });
+
+        // saveStepResult is the commit point for this step. Once it succeeds,
+        // finish the bounded cleanup path even if the deadline fires: turning a
+        // persisted `done` state into AgentStepTimeout would corrupt the terminal
+        // result, while the route's outer runtime window reserves time for this
+        // event/trace/hook/scheduling work.
 
         // Decide whether to schedule next step
         const shouldContinue = this.shouldContinueExecution(
@@ -1140,6 +1176,7 @@ export class AgentRuntimeService {
         let nextStepScheduled = false;
 
         // Publish step complete event
+        reportStage('gateway.publish_step_complete');
         await this.streamManager.publishStreamEvent(operationId, {
           data: {
             finalState: stepResult.newState,
@@ -1246,6 +1283,7 @@ export class AgentRuntimeService {
           log('[%s] afterStep hook dispatch error: %O', operationId, hookError);
         }
 
+        reportStage('trace.append');
         await this.traceRecorder.appendStep(operationId, {
           afterStepSignalEvents,
           agentState,
@@ -1287,6 +1325,7 @@ export class AgentRuntimeService {
         }
 
         if (shouldContinue && stepResult.nextContext && this.queueService) {
+          reportStage('next_step.schedule');
           const nextStepIndex = stepIndex + 1;
           const delay = this.calculateStepDelay(stepResult);
           const priority = this.calculatePriority(stepResult);
@@ -1411,6 +1450,7 @@ export class AgentRuntimeService {
       // that completion callbacks and webhooks can still fire.
       let finalStateWithError: any;
       try {
+        reportStage('error.publish');
         await this.streamManager.publishStreamEvent(operationId, {
           data: {
             error: formattedError.message,
@@ -1430,6 +1470,7 @@ export class AgentRuntimeService {
       }
 
       try {
+        reportStage('error.state_load');
         const errorState = await this.coordinator.loadAgentState(operationId);
         finalStateWithError = {
           ...errorState!,
@@ -1452,10 +1493,21 @@ export class AgentRuntimeService {
         };
       }
 
+      let errorStateSaveError: unknown;
       try {
+        reportStage('error.state_save');
         await this.coordinator.saveAgentState(operationId, finalStateWithError);
       } catch (saveError) {
+        errorStateSaveError = saveError;
         log('[%s] Failed to save error state (infra may be down): %O', operationId, saveError);
+        console.warn(
+          JSON.stringify({
+            event: 'agent.run_step.error_state_save_failed',
+            operationId,
+            stage: 'error.state_save',
+            stepIndex,
+          }),
+        );
       }
 
       await this.completionLifecycle.emitSignalEvents(operationId, finalStateWithError, 'error');
@@ -1476,6 +1528,7 @@ export class AgentRuntimeService {
       // success path could push it. Without this synthetic step, the
       // snapshot's step count would lag the assistant message that
       // triggered the failing call.
+      reportStage('error.trace_finalize');
       await this.traceRecorder.finalize(operationId, {
         completionReason: 'error',
         error: {
@@ -1497,6 +1550,21 @@ export class AgentRuntimeService {
         },
         state: finalStateWithError,
       });
+
+      if (isAgentStepTimeoutError(error)) {
+        // `handled` is the ACK contract with the HTTP/QStash boundary: only a
+        // durably persisted terminal timeout may return 2xx. A save failure
+        // stays unhandled and is rethrown so QStash can retry the delivery.
+        if (errorStateSaveError) {
+          const saveError =
+            errorStateSaveError instanceof Error
+              ? errorStateSaveError
+              : new Error(String(errorStateSaveError));
+          saveError.cause ??= error;
+          throw saveError;
+        }
+        markAgentStepTimeoutHandled(error);
+      }
 
       throw error;
     } finally {
@@ -2639,13 +2707,19 @@ export class AgentRuntimeService {
    * Create Agent Runtime instance
    */
   private async createAgentRuntime({
+    deadlineAt,
     metadata,
+    onStage,
     operationId,
+    signal,
     stepIndex,
     tracingContextEngine,
   }: {
+    deadlineAt?: number;
     metadata?: any;
+    onStage?: (stage: string) => void;
     operationId: string;
+    signal?: AbortSignal;
     stepIndex: number;
     tracingContextEngine?: (input: unknown, output: unknown) => void;
   }) {
@@ -2684,6 +2758,7 @@ export class AgentRuntimeService {
       allowEarlyFinalAnswerVisibleOutputEnd: agent instanceof GeneralChatAgent,
       botContext: metadata?.botContext,
       botPlatformContext: metadata?.botPlatformContext,
+      deadlineAt,
       discordContext: metadata?.discordContext,
       userTimezone: metadata?.userTimezone,
       evalContext: metadata?.evalContext,
@@ -2693,8 +2768,10 @@ export class AgentRuntimeService {
       hookDispatcher,
       loadAgentState: this.coordinator.loadAgentState.bind(this.coordinator),
       messageModel: this.messageModel,
+      onStage,
       operationId,
       serverDB: this.serverDB,
+      signal,
       stepIndex,
       stream: metadata?.stream,
       streamManager: this.streamManager,

--- a/apps/server/src/services/agentRuntime/__tests__/executeStep.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/executeStep.test.ts
@@ -4,6 +4,7 @@ import type { ReasoningGraph } from '@lobechat/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import { createRuntimeExecutors } from '@/server/modules/AgentRuntime/RuntimeExecutors';
+import { AgentStepTimeoutError } from '@/server/modules/AgentRuntime/stepDeadline';
 
 import { AgentRuntimeService } from '../AgentRuntimeService';
 import { hookDispatcher } from '../hooks';
@@ -193,6 +194,34 @@ describe('AgentRuntimeService.executeStep - early exit on terminal state', () =>
 
     expect(createRuntimeExecutors).toHaveBeenCalledWith(
       expect.objectContaining({ workspaceId: 'ws-1' }),
+    );
+  });
+
+  it('threads the step deadline, signal, and stage reporter into runtime executors', async () => {
+    vi.mocked(createRuntimeExecutors).mockClear();
+    const service = new AgentRuntimeService({} as any, 'user-1', { queueService: null });
+    const controller = new AbortController();
+    const onStage = vi.fn();
+
+    await (service as any).createAgentRuntime({
+      deadlineAt: 123_456,
+      metadata: {
+        agentConfig: {},
+        modelRuntimeConfig: { model: 'gpt-test', provider: 'lobehub' },
+        userId: 'user-1',
+      },
+      onStage,
+      operationId: 'op-deadline',
+      signal: controller.signal,
+      stepIndex: 0,
+    });
+
+    expect(createRuntimeExecutors).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deadlineAt: 123_456,
+        onStage,
+        signal: controller.signal,
+      }),
     );
   });
 
@@ -761,6 +790,87 @@ describe('AgentRuntimeService.executeStep - Redis failure in error handler', () 
 });
 
 describe('AgentRuntimeService.executeStep - error-path snapshot finalize ()', () => {
+  it('persists AgentStepTimeout as a terminal error before marking it handled', async () => {
+    const snapshotStore = {
+      get: vi.fn(),
+      getLatest: vi.fn(),
+      list: vi.fn(),
+      listPartials: vi.fn(),
+      loadPartial: vi.fn().mockResolvedValue(null),
+      removePartial: vi.fn().mockResolvedValue(undefined),
+      save: vi.fn().mockResolvedValue(undefined),
+      savePartial: vi.fn().mockResolvedValue(undefined),
+    };
+    const service = new AgentRuntimeService({} as any, 'user-1', {
+      queueService: null,
+      snapshotStore: snapshotStore as any,
+    });
+    const coordinator = (service as any).coordinator;
+    const streamManager = (service as any).streamManager;
+    const controller = new AbortController();
+    const onStage = vi.fn();
+    const timeoutError = new AgentStepTimeoutError({
+      deadlineAt: Date.now(),
+      stage: 'model.call',
+    });
+
+    coordinator.tryClaimStep = vi.fn().mockResolvedValue(true);
+    coordinator.releaseStepLock = vi.fn().mockResolvedValue(undefined);
+    coordinator.loadAgentState = vi.fn().mockResolvedValue({
+      lastModified: new Date().toISOString(),
+      messages: [],
+      metadata: {},
+      status: 'running',
+      stepCount: 0,
+    });
+    coordinator.saveAgentState = vi.fn().mockResolvedValue(undefined);
+    streamManager.publishStreamEvent = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(service as any, 'createAgentRuntime').mockResolvedValue({
+      runtime: {
+        step: vi.fn().mockImplementation(async () => {
+          controller.abort(timeoutError);
+          return {
+            events: [],
+            newState: { status: 'running', stepCount: 0 },
+            nextContext: undefined,
+          };
+        }),
+      },
+    });
+    const dispatchSpy = vi.spyOn(hookDispatcher, 'dispatch').mockResolvedValue(undefined);
+
+    await expect(
+      service.executeStep({
+        context: { phase: 'user_input' } as any,
+        deadlineAt: timeoutError.deadlineAt,
+        onStage,
+        operationId: 'op-timeout',
+        signal: controller.signal,
+        stepIndex: 0,
+      }),
+    ).rejects.toBe(timeoutError);
+
+    expect(timeoutError.handled).toBe(true);
+    expect(coordinator.saveAgentState).toHaveBeenCalledWith(
+      'op-timeout',
+      expect.objectContaining({
+        error: expect.objectContaining({ type: 'AgentStepTimeout' }),
+        status: 'error',
+      }),
+    );
+    expect(streamManager.publishStreamEvent).toHaveBeenCalledWith(
+      'op-timeout',
+      expect.objectContaining({
+        data: expect.objectContaining({ errorType: 'AgentStepTimeout' }),
+        type: 'error',
+      }),
+    );
+    expect(onStage).toHaveBeenCalledWith('error.state_save');
+    expect(coordinator.releaseStepLock).toHaveBeenCalled();
+
+    dispatchSpy.mockRestore();
+  });
+
   it('finalizes a snapshot with completionReason=error and a synthetic failed step when the executor throws', async () => {
     const snapshotStore = {
       get: vi.fn(),

--- a/apps/server/src/services/agentRuntime/types.ts
+++ b/apps/server/src/services/agentRuntime/types.ts
@@ -131,6 +131,8 @@ export interface AgentExecutionParams {
    */
   asyncToolVerifyAttempt?: number;
   context?: AgentRuntimeContext;
+  /** Absolute wall-clock deadline for this delivered step. */
+  deadlineAt?: number;
   externalRetryCount?: number;
   /**
    * Finish (rather than resume) a `waiting_for_async_tool` supervisor op after
@@ -149,6 +151,8 @@ export interface AgentExecutionParams {
    */
   groupMemberTimeout?: GroupMemberTimeoutParams;
   humanInput?: any;
+  /** Reports the active execution stage for tracing and timeout diagnostics. */
+  onStage?: (stage: string) => void;
   operationId: string;
   /**
    * Whether a rejection should resume execution by treating the rejected tool
@@ -163,6 +167,8 @@ export interface AgentExecutionParams {
    * via `tryResumeParentFromAsyncTool`.
    */
   resumeAsyncTool?: boolean;
+  /** Cooperative cancellation shared by the step's model and tool calls. */
+  signal?: AbortSignal;
   stepIndex: number;
   /** ID of the pending tool message targeted by the intervention. */
   toolMessageId?: string;

--- a/apps/server/src/services/sandbox/__tests__/serviceInit.test.ts
+++ b/apps/server/src/services/sandbox/__tests__/serviceInit.test.ts
@@ -105,6 +105,53 @@ describe('SandboxMiddlewareService file initialization', () => {
     expect(provider.callTool).toHaveBeenCalledWith('listFiles', {});
   });
 
+  it('enforces the server-resolved timeout at the provider boundary', async () => {
+    const provider = createProvider();
+    const service = new SandboxMiddlewareService(provider, {
+      ...baseOptions(),
+      executionTimeoutMs: 90_000,
+      serverDB: undefined,
+    });
+
+    await service.callTool('runCommand', { command: 'sleep 900', timeout: 900_000 });
+
+    expect(provider.callTool).toHaveBeenCalledWith('runCommand', {
+      command: 'sleep 900',
+      timeout: 90_000,
+    });
+  });
+
+  it('preserves a caller timeout shorter than the server-resolved budget', async () => {
+    const provider = createProvider();
+    const service = new SandboxMiddlewareService(provider, {
+      ...baseOptions(),
+      executionTimeoutMs: 90_000,
+      serverDB: undefined,
+    });
+
+    await service.callTool('runCommand', { command: 'sleep 5', timeout: 5000 });
+
+    expect(provider.callTool).toHaveBeenCalledWith('runCommand', {
+      command: 'sleep 5',
+      timeout: 5000,
+    });
+  });
+
+  it('does not add command timeout fields to non-command tools', async () => {
+    const provider = createProvider();
+    const service = new SandboxMiddlewareService(provider, {
+      ...baseOptions(),
+      executionTimeoutMs: 90_000,
+      serverDB: undefined,
+    });
+
+    await service.callTool('readFile', { path: '/mnt/data/report.txt' });
+
+    expect(provider.callTool).toHaveBeenCalledWith('readFile', {
+      path: '/mnt/data/report.txt',
+    });
+  });
+
   it('never blocks the tool call when the sync fails', async () => {
     findFilesToInitInSandbox.mockRejectedValue(new Error('db down'));
     const provider = createProvider();

--- a/apps/server/src/services/sandbox/providers/market.test.ts
+++ b/apps/server/src/services/sandbox/providers/market.test.ts
@@ -71,6 +71,29 @@ describe('MarketSandboxProvider', () => {
     });
   });
 
+  it('forwards the agent step signal to the Market SDK request', async () => {
+    const controller = new AbortController();
+    const runBuildInTool = vi.fn(async () => ({ data: { result: {} }, success: true }));
+    const marketService = {
+      getSDK: vi.fn(() => ({ plugins: { runBuildInTool } })),
+    } as unknown as MarketService;
+    const provider = new MarketSandboxProvider({
+      marketService,
+      signal: controller.signal,
+      topicId: 'topic-1',
+      userId: 'user-1',
+    });
+
+    await provider.callTool('runCommand', { command: 'sleep 900', timeout: 120_000 });
+
+    expect(runBuildInTool).toHaveBeenCalledWith(
+      'runCommand',
+      { command: 'sleep 900', timeout: 120_000 },
+      { topicId: 'topic-1', userId: 'user-1' },
+      { signal: controller.signal },
+    );
+  });
+
   it('preserves Market sandbox export error codes for authorization handling', async () => {
     const marketService = createMarketService({
       error: {

--- a/apps/server/src/services/sandbox/providers/market.ts
+++ b/apps/server/src/services/sandbox/providers/market.ts
@@ -49,12 +49,15 @@ export class MarketSandboxProvider implements SandboxProvider {
     );
 
     try {
-      const response = await marketService
-        .getSDK()
-        .plugins.runBuildInTool(toolName as CodeInterpreterToolName, params as never, {
+      const response = await marketService.getSDK().plugins.runBuildInTool(
+        toolName as CodeInterpreterToolName,
+        params as never,
+        {
           topicId,
           userId,
-        });
+        },
+        this.options.signal ? { signal: this.options.signal } : undefined,
+      );
 
       log('Sandbox tool %s response: %O', toolName, response);
 

--- a/apps/server/src/services/sandbox/providers/onlyboxes.test.ts
+++ b/apps/server/src/services/sandbox/providers/onlyboxes.test.ts
@@ -48,6 +48,7 @@ describe('OnlyboxesSandboxProvider', () => {
   });
 
   it('maps runCommand to the terminal command endpoint with a persistent session', async () => {
+    const controller = new AbortController();
     const fetchMock = vi.fn(async () => {
       return new Response(
         JSON.stringify({
@@ -64,6 +65,7 @@ describe('OnlyboxesSandboxProvider', () => {
     const { OnlyboxesSandboxProvider } = await import('./onlyboxes');
     const provider = new OnlyboxesSandboxProvider({
       marketService: {} as MarketService,
+      signal: controller.signal,
       topicId: 'topic-1',
       userId: 'user-1',
     });
@@ -85,6 +87,7 @@ describe('OnlyboxesSandboxProvider', () => {
           timeout_ms: 120_000,
         }),
         method: 'POST',
+        signal: controller.signal,
       }),
     );
     const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];

--- a/apps/server/src/services/sandbox/providers/onlyboxes.ts
+++ b/apps/server/src/services/sandbox/providers/onlyboxes.ts
@@ -660,6 +660,7 @@ export class OnlyboxesSandboxProvider implements SandboxProvider {
     const response = await fetch(`${this.baseUrl}${path}`, {
       ...init,
       headers,
+      ...(this.options.signal && { signal: this.options.signal }),
     });
     const body = await response.text();
     const json = body ? JSON.parse(body) : {};

--- a/apps/server/src/services/sandbox/service.ts
+++ b/apps/server/src/services/sandbox/service.ts
@@ -24,6 +24,8 @@ import type {
 
 const log = debug('lobe-server:sandbox:service');
 
+const TIMEOUT_AWARE_TOOL_NAMES = new Set(['execScript', 'runCommand']);
+
 export class SandboxMiddlewareService implements SandboxService {
   readonly capabilities: SandboxProviderCapabilities;
   readonly kind: SandboxProviderKind;
@@ -43,7 +45,23 @@ export class SandboxMiddlewareService implements SandboxService {
     params: Record<string, unknown>,
   ): Promise<SandboxCallToolResult> {
     await this.ensureFilesInitialized();
-    return this.provider.callTool(toolName, params);
+    const requestedTimeout =
+      typeof params.timeout === 'number' && Number.isFinite(params.timeout) && params.timeout > 0
+        ? params.timeout
+        : undefined;
+    const executionTimeoutMs = this.options.executionTimeoutMs;
+    const resolvedParams =
+      executionTimeoutMs === undefined || !TIMEOUT_AWARE_TOOL_NAMES.has(toolName)
+        ? params
+        : {
+            ...params,
+            timeout:
+              requestedTimeout === undefined
+                ? executionTimeoutMs
+                : Math.min(requestedTimeout, executionTimeoutMs),
+          };
+
+    return this.provider.callTool(toolName, resolvedParams);
   }
 
   /**

--- a/apps/server/src/services/sandbox/types.ts
+++ b/apps/server/src/services/sandbox/types.ts
@@ -15,10 +15,14 @@ export interface SandboxSessionContext {
 }
 
 export interface SandboxServiceOptions extends SandboxSessionContext {
+  /** Server-resolved timeout for the current tool execution. */
+  executionTimeoutMs?: number;
   fileService?: FileService;
   marketService: MarketService;
   /** Used to look up topic/session files when bootstrapping the sandbox. */
   serverDB?: LobeChatDatabase;
+  /** Cooperative cancellation inherited from the containing agent step. */
+  signal?: AbortSignal;
 }
 
 export interface SandboxProviderCapabilities {

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
@@ -210,6 +210,28 @@ describe('skillsRuntime', () => {
     expect(result.state).toMatchObject({ executionEnv: 'sandbox' });
   });
 
+  it('passes the resolved timeout and step signal into the cloud sandbox service', async () => {
+    const controller = new AbortController();
+    const { skillsRuntime } = await import('../skills');
+    const runtime = await skillsRuntime.factory({
+      executionTimeoutMs: 120_000,
+      serverDB: {} as never,
+      signal: controller.signal,
+      toolManifestMap: {},
+      topicId: 'topic-1',
+      userId: 'user-1',
+    });
+
+    await runtime.runCommand({ command: 'sleep 900' });
+
+    expect(mocks.createSandboxService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionTimeoutMs: 120_000,
+        signal: controller.signal,
+      }),
+    );
+  });
+
   it('passes workspace scope when preprocessing sandbox lh commands', async () => {
     mocks.preprocessLhCommand.mockResolvedValueOnce({
       command: 'LOBEHUB_WORKSPACE_ID=workspace-1 npx -y @lobehub/cli agent edit agt_123',

--- a/apps/server/src/services/toolExecution/serverRuntimes/cloudSandbox.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/cloudSandbox.ts
@@ -26,9 +26,11 @@ export const cloudSandboxRuntime: ServerRuntimeRegistration = {
     const marketService = new MarketService({ userInfo: { userId: context.userId } });
     const fileService = new FileService(context.serverDB, context.userId, context.workspaceId);
     const sandboxService = createSandboxService({
+      executionTimeoutMs: context.executionTimeoutMs,
       fileService,
       marketService,
       serverDB: context.serverDB,
+      signal: context.signal,
       topicId: context.topicId,
       userId: context.userId,
     });

--- a/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
@@ -101,6 +101,7 @@ const isLhCommand = (command: string) => LH_COMMAND_PATTERN.test(command);
 
 class SkillServerRuntimeService implements SkillRuntimeService {
   private agentId?: string;
+  private executionTimeoutMs?: number;
   private resourceService: SkillResourceService;
   private skillModel: AgentSkillModel;
   private marketService: MarketService;
@@ -112,6 +113,7 @@ class SkillServerRuntimeService implements SkillRuntimeService {
   private workspaceId?: string;
   private device?: SkillDeviceExecution;
   private disabledSkillIds: Set<string>;
+  private signal?: AbortSignal;
 
   constructor(options: {
     agentId?: string;
@@ -123,6 +125,7 @@ class SkillServerRuntimeService implements SkillRuntimeService {
      * its name, independent of whatever's listed in `<available_skills>`.
      */
     disabledSkillIds?: Set<string>;
+    executionTimeoutMs?: number;
     fileModel: FileModel;
     fileService: FileService;
     marketService: MarketService;
@@ -132,8 +135,10 @@ class SkillServerRuntimeService implements SkillRuntimeService {
     topicId?: string;
     userId: string;
     workspaceId?: string;
+    signal?: AbortSignal;
   }) {
     this.agentId = options.agentId;
+    this.executionTimeoutMs = options.executionTimeoutMs;
     this.skillModel = options.skillModel;
     this.resourceService = options.resourceService;
     this.marketService = options.marketService;
@@ -145,7 +150,19 @@ class SkillServerRuntimeService implements SkillRuntimeService {
     this.workspaceId = options.workspaceId;
     this.device = options.device;
     this.disabledSkillIds = options.disabledSkillIds ?? new Set();
+    this.signal = options.signal;
   }
+
+  private createSandbox = (topicId: string) =>
+    createSandboxService({
+      executionTimeoutMs: this.executionTimeoutMs,
+      fileService: this.fileService,
+      marketService: this.marketService,
+      serverDB: this.serverDB,
+      signal: this.signal,
+      topicId,
+      userId: this.userId,
+    });
 
   findAll = (): Promise<{ data: SkillListItem[]; total: number }> => {
     return this.skillModel.findAll();
@@ -212,13 +229,7 @@ class SkillServerRuntimeService implements SkillRuntimeService {
     }
 
     try {
-      const sandboxService = createSandboxService({
-        fileService: this.fileService,
-        marketService: this.marketService,
-        serverDB: this.serverDB,
-        topicId: this.topicId,
-        userId: this.userId,
-      });
+      const sandboxService = this.createSandbox(this.topicId);
       const response = await sandboxService.callTool('runCommand', { command: lhResult.command });
 
       log('runCommand response: %O', response);
@@ -521,13 +532,7 @@ class SkillServerRuntimeService implements SkillRuntimeService {
         );
       }
 
-      const sandboxService = createSandboxService({
-        fileService: this.fileService,
-        marketService: this.marketService,
-        serverDB: this.serverDB,
-        topicId: this.topicId,
-        userId: this.userId,
-      });
+      const sandboxService = this.createSandbox(this.topicId);
       const response = await sandboxService.callTool('execScript', enhancedParams);
 
       log('execScript response: %O', response);
@@ -569,12 +574,7 @@ class SkillServerRuntimeService implements SkillRuntimeService {
     }
 
     try {
-      const sandboxService = createSandboxService({
-        fileService: this.fileService,
-        marketService: this.marketService,
-        topicId: this.topicId,
-        userId: this.userId,
-      });
+      const sandboxService = this.createSandbox(this.topicId);
       const result = await sandboxService.exportAndUploadFile(path, filename);
 
       return {
@@ -674,6 +674,7 @@ export const skillsRuntime: ServerRuntimeRegistration = {
       agentId: context.agentId,
       device,
       disabledSkillIds,
+      executionTimeoutMs: context.executionTimeoutMs,
       fileModel,
       fileService,
       marketService,
@@ -683,6 +684,7 @@ export const skillsRuntime: ServerRuntimeRegistration = {
       topicId: context.topicId,
       userId: context.userId,
       workspaceId: context.workspaceId,
+      signal: context.signal,
     });
 
     // Surface this agent's skill-bundle documents as `BuiltinSkill`-shaped

--- a/apps/server/src/services/toolExecution/types.ts
+++ b/apps/server/src/services/toolExecution/types.ts
@@ -171,6 +171,8 @@ export interface ToolExecutionContext {
    * `messageId`.
    */
   assistantMessageId?: string;
+  /** Absolute wall-clock deadline inherited from the containing agent step. */
+  deadlineAt?: number;
   /**
    * Whether the run's execution plan is device-capable (`device` or
    * `device-unrouted`) — derived from `state.metadata.executionPlan` by the
@@ -235,6 +237,8 @@ export interface ToolExecutionContext {
   scope?: string | null;
   /** Server database for LobeHub Skills execution */
   serverDB?: LobeChatDatabase;
+  /** Cooperative cancellation inherited from the containing agent step. */
+  signal?: AbortSignal;
   /** Skip low-level result truncation so the AgentRuntime boundary can archive full content first. */
   skipResultTruncation?: boolean;
   /**

--- a/packages/observability-otel/src/modules/agent-runtime/semconv.ts
+++ b/packages/observability-otel/src/modules/agent-runtime/semconv.ts
@@ -83,8 +83,14 @@ export const ATTR_LOBEHUB_TOOL_SUCCESS = 'lobehub.tool.success' as const;
 /** Attempts taken to execute a tool (1 for first-try success). */
 export const ATTR_LOBEHUB_TOOL_ATTEMPTS = 'lobehub.tool.attempts' as const;
 
+/** Runtime target that executed the tool (`client` / `device` / `server`). */
+export const ATTR_LOBEHUB_TOOL_EXECUTION_TARGET = 'lobehub.tool.execution_target' as const;
+
 /** Internal LobeHub tool source (`builtin` / `client` / `mcp` / `composio` / `lobehubSkill`). */
 export const ATTR_LOBEHUB_TOOL_SOURCE = 'lobehub.tool.source' as const;
+
+/** Effective timeout assigned to the tool after clamping to the remaining step budget. */
+export const ATTR_LOBEHUB_TOOL_TIMEOUT_MS = 'lobehub.tool.timeout_ms' as const;
 
 /** Context engineering metadata. */
 export const ATTR_LOBEHUB_CONTEXT_MESSAGE_COUNT = 'lobehub.context.message_count' as const;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

- Related to [LOBE-11919](https://linear.app/lobehub/issue/LOBE-11919)

#### 🔀 Description of Change

- Add one shared 8-minute deadline and `AbortSignal` at the queued agent-step boundary.
- Propagate cooperative cancellation through model calls, retry waits, server tools, device tools, and client-tool waits.
- Persist a stable `AgentStepTimeout` terminal error before acknowledging a timed-out delivery. Persistence failures remain retryable with an HTTP 500 response.
- Clamp tool timeouts to the remaining step budget and add stage, queue-wait, retry, and message-id diagnostics to tracing.
- Treat `saveStepResult` as the commit point so a deadline firing during bounded post-save cleanup cannot overwrite a committed `done` state.
- Emit a structured `agent.run_step.deadline_reached` snapshot before aborting, including the current stage duration and OTel trace/span IDs.
- Refine blocking-stage visibility around gateway publication, lifecycle hooks, state tracking, trace finalization, model finalization, tool hooks, and tool-result archival.
- Record chat time-to-first-chunk immediately, even if the model stream later stalls or fails before normal span finalization.
- Annotate tool spans with execution target and effective timeout, and mark non-deferred tool-body completion before result archival.
- Enforce the server-resolved timeout at the cloud-sandbox boundary for `runCommand` and `execScript`, preserving shorter caller timeouts while rejecting longer ones.
- Forward the agent-step abort signal into Market SDK requests and Onlyboxes fetches so provider waits release with the containing step.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `APP_URL=http://localhost:3210 bun run check <11 observability files>` — lint clean, 123 tests passed.
- `bun run check <10 sandbox/tool-runtime files>` — lint clean, 51 tests passed.
- `bun run check --type` — types clean.
- CC quick single-pass reviews completed; all actionable findings were fixed and re-reviewed with no remaining blockers.

Regression coverage includes:

- deadline snapshot ordering before abort and the later timeout diagnostic;
- stage duration plus trace/span correlation fields;
- immediate, idempotent model first-chunk telemetry;
- model finalization and blocking tool stages;
- tool target/effective timeout attributes;
- no false `tool.execute.complete` event for deferred tools;
- sandbox command timeout clamping at the provider boundary;
- preservation of shorter caller timeouts and unchanged file-tool parameters;
- step signal forwarding into Market and Onlyboxes provider requests.

#### 📸 Screenshots / Videos

N/A — backend runtime change.

#### 📝 Additional Information

- The deadline is enforced at the delivered-step level, not by extending individual tool budgets.
- `agent.run_step.deadline_reached` means the 8-minute fuse fired and the pre-abort execution snapshot was emitted.
- `agent.run_step.timeout` means the abort propagated back to the handler, where the durable cleanup outcome is known. A `deadline_reached` event without a later `timeout` points to a non-raced write or cleanup path that did not return before the platform hard timeout.
- Pre-commit reads, event publication, and runtime work race the step signal so stalled infrastructure cannot hold the request until the platform timeout.
- Ownership-changing Redis writes such as step-lock claim/release are deliberately awaited instead of promise-raced. The Redis API is not cancelable, so a late successful claim after the caller returns would leave an orphan lock until its bounded TTL expires and delay QStash retries.
- `saveStepResult` and post-commit cleanup are deliberately awaited instead of raced: the persistence API is not cancelable, so returning early could let a late successful write conflict with a timeout state. The outer request window reserves time for this bounded commit path.
- Sandbox timeout injection is limited to command-execution tools; file APIs keep their existing parameter contract.
- Provider request cancellation releases the application wait. The server-enforced command timeout remains the durable upper bound for remote execution.
- The delivery platform timeout remains deployment-specific and is intentionally not configured in this public change.
- No background-task mechanism or delivery-timeout change is included.
