### PR TITLE
🐛 fix(agent): guide visual fallback for text-only models

### DIFF
--- a/packages/context-engine/src/engine/messages/MessagesEngine.ts
+++ b/packages/context-engine/src/engine/messages/MessagesEngine.ts
@@ -253,6 +253,10 @@ export class MessagesEngine {
         displayName: modelDisplayName,
         knowledgeCutoff: modelKnowledgeCutoff,
         modelId: model,
+        nativeMediaCapabilities: {
+          video: capabilities?.isCanUseVideo?.(model, provider),
+          vision: capabilities?.isCanUseVision?.(model, provider),
+        },
       }),
       // Skill context (available skills list + activated skill content).
       // Disabled in chat mode — pairs with the tools-engine gate so the LLM

--- a/packages/context-engine/src/engine/messages/__tests__/MessagesEngine.test.ts
+++ b/packages/context-engine/src/engine/messages/__tests__/MessagesEngine.test.ts
@@ -317,6 +317,47 @@ describe('MessagesEngine', () => {
       expect(isCanUseVision).toHaveBeenCalled();
     });
 
+    it('should make visual fallback requirements explicit for non-vision models', async () => {
+      const messages: UIChatMessage[] = [
+        {
+          content: 'Which models are shown in this image?',
+          createdAt: Date.now(),
+          id: 'msg-vision',
+          imageList: [
+            {
+              alt: 'models.png',
+              id: 'image-1',
+              url: 'https://example.com/models.png',
+            },
+          ],
+          role: 'user',
+          updatedAt: Date.now(),
+        } as UIChatMessage,
+      ];
+      const params = createBasicParams({
+        capabilities: {
+          isCanUseVideo: () => false,
+          isCanUseVision: () => false,
+        },
+        messages,
+        model: 'deepseek-v4-flash',
+        modelDisplayName: 'DeepSeek V4 Flash',
+        provider: 'deepseek',
+      });
+      const engine = new MessagesEngine(params);
+
+      const result = await engine.process();
+
+      const systemContent = String(result.messages.find(({ role }) => role === 'system')?.content);
+      const userContent = JSON.stringify(
+        result.messages.find(({ role }) => role === 'user')?.content,
+      );
+      expect(systemContent).toContain('Native media input capabilities: vision=false, video=false');
+      expect(userContent).toContain('Do not infer or describe the image');
+      expect(userContent).toContain('use an available visual-analysis tool before answering');
+      expect(userContent).toMatch(/ref=\\"msg_[^"]+\.image_1\\"/);
+    });
+
     it('should default to true for isCanUseFC when not provided', async () => {
       const params = createBasicParams({
         toolsConfig: { tools: ['tool1'] },

--- a/packages/context-engine/src/processors/MessageContent.ts
+++ b/packages/context-engine/src/processors/MessageContent.ts
@@ -26,7 +26,8 @@ const log = debug('context-engine:processor:MessageContentProcessor');
  * in the payload causes provider-side 400s (e.g. DeepSeek rejects the
  * `image_url` variant outright — see ).
  */
-export const VISION_DOWNGRADE_PLACEHOLDER = '[image omitted: not supported by this model]';
+export const VISION_DOWNGRADE_PLACEHOLDER =
+  '[image omitted: native vision is not supported. Do not infer or describe the image. If the request depends on it, use an available visual-analysis tool before answering; otherwise state that the image cannot be inspected.]';
 
 /**
  * Deserialize content string to message content parts

--- a/packages/context-engine/src/providers/ModelInfoProvider.ts
+++ b/packages/context-engine/src/providers/ModelInfoProvider.ts
@@ -19,6 +19,11 @@ export interface ModelInfoProviderConfig {
   knowledgeCutoff?: string;
   /** Model runtime id, e.g. `claude-fable-5`. */
   modelId?: string;
+  /** Native media inputs accepted directly by the active model. */
+  nativeMediaCapabilities?: {
+    video?: boolean;
+    vision?: boolean;
+  };
 }
 
 /**
@@ -48,6 +53,7 @@ export class ModelInfoProvider extends BaseSystemRoleProvider {
     const modelId = this.config.modelId?.trim();
     const displayName = this.config.displayName?.trim();
     const knowledgeCutoff = this.config.knowledgeCutoff?.trim();
+    const { video, vision } = this.config.nativeMediaCapabilities ?? {};
 
     // Only surface identity when we know the model's real name (resolved from the
     // model bank). The id rides along in parens. A bare runtime id without a name
@@ -57,10 +63,16 @@ export class ModelInfoProvider extends BaseSystemRoleProvider {
         ? `${displayName} (${modelId})`
         : displayName
       : undefined;
+    const nativeMediaCapabilities = [
+      typeof vision === 'boolean' && `vision=${vision}`,
+      typeof video === 'boolean' && `video=${video}`,
+    ].filter(Boolean);
 
     const lines = [
       modelLabel && `Current model: ${modelLabel}`,
       knowledgeCutoff && `Model knowledge cutoff: ${knowledgeCutoff}`,
+      nativeMediaCapabilities.length > 0 &&
+        `Native media input capabilities: ${nativeMediaCapabilities.join(', ')}`,
     ].filter(Boolean);
 
     if (lines.length === 0) {

--- a/packages/context-engine/src/providers/__tests__/ModelInfoProvider.test.ts
+++ b/packages/context-engine/src/providers/__tests__/ModelInfoProvider.test.ts
@@ -39,6 +39,22 @@ describe('ModelInfoProvider', () => {
     expect(result.metadata.modelInfoInjected).toBe(true);
   });
 
+  it('should inject native media input capabilities', async () => {
+    const provider = new ModelInfoProvider({
+      displayName: 'DeepSeek V4 Flash',
+      modelId: 'deepseek-v4-flash',
+      nativeMediaCapabilities: { video: false, vision: false },
+    });
+    const context = createContext([]);
+
+    const result = await provider.process(context);
+
+    expect(result.messages[0].content).toBe(
+      'Current model: DeepSeek V4 Flash (deepseek-v4-flash)\nNative media input capabilities: vision=false, video=false',
+    );
+    expect(result.metadata.modelInfoInjected).toBe(true);
+  });
+
   it('should skip the model line when displayName is missing (bare id only)', async () => {
     const provider = new ModelInfoProvider({ modelId: 'claude-fable-5' });
     const context = createContext([

--- a/src/services/chat/chat.test.ts
+++ b/src/services/chat/chat.test.ts
@@ -665,7 +665,7 @@ describe('ChatService', () => {
                     // downgraded to a placeholder (see ).
                     text: `Hello
 
-[image omitted: not supported by this model]
+[image omitted: native vision is not supported. Do not infer or describe the image. If the request depends on it, use an available visual-analysis tool before answering; otherwise state that the image cannot be inspected.]
 
 <!-- SYSTEM CONTEXT (NOT PART OF USER QUERY) -->
 <context.instruction>following part contains context information injected by the system. Please follow these instructions:

--- a/src/services/chat/mecha/contextEngineering.test.ts
+++ b/src/services/chat/mecha/contextEngineering.test.ts
@@ -410,7 +410,7 @@ describe('contextEngineering', () => {
               // model still sees that an image was sent (see ).
               text: `Hello
 
-[image omitted: not supported by this model]
+[image omitted: native vision is not supported. Do not infer or describe the image. If the request depends on it, use an available visual-analysis tool before answering; otherwise state that the image cannot be inspected.]
 
 <!-- SYSTEM CONTEXT (NOT PART OF USER QUERY) -->
 <context.instruction>following part contains context information injected by the system. Please follow these instructions:


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-12200

#### 🔀 Description of Change

- Strengthen the image downgrade placeholder for text-only models so they do not infer unseen image content and use an available visual-analysis tool when the request depends on the image.
- Inject the active model's native `vision` and `video` input capabilities into the system context.
- Add regression coverage for the final MessagesEngine payload, including the capability hint, fallback instruction, and stable visual file reference.

#### 🧭 Key Decisions / Non-goals

- Keep visual fallback model-driven in this change. It does not automatically pre-run visual analysis for every attached image, avoiding unconditional latency and cost.
- Keep the downgrade instruction generic instead of coupling Context Engine to a specific builtin tool identifier.
- Native multimodal models continue receiving image content directly.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check \
  lobehub/packages/context-engine/src/processors/MessageContent.ts \
  lobehub/packages/context-engine/src/providers/ModelInfoProvider.ts \
  lobehub/packages/context-engine/src/engine/messages/MessagesEngine.ts \
  lobehub/packages/context-engine/src/providers/__tests__/ModelInfoProvider.test.ts \
  lobehub/packages/context-engine/src/engine/messages/__tests__/MessagesEngine.test.ts \
  --lint --test
```

Result: 5 files lint clean, 82 tests passed.

CI follow-up updated the two integration expectations for the strengthened placeholder and reconciled terminal font settings with #17459, which had already graduated the built-in terminal out of Labs. Final follow-up validation: 6 files lint clean, 74 related tests passed, and the full type-check is clean.

#### 📸 Screenshots / Videos

N/A — system-context behavior only.

#### 📝 Additional Information

No migration, configuration, or rollout action is required.
