### PR TITLE
🐛 fix(terminal): remove obsolete Labs flag references

### DIFF
--- a/src/features/Settings/Appearance/Terminal/index.test.tsx
+++ b/src/features/Settings/Appearance/Terminal/index.test.tsx
@@ -88,6 +88,7 @@ vi.mock('@/services/electron/system', () => ({
 const initialUserStoreState = useUserStore.getState();
 
 beforeEach(() => {
+  vi.clearAllMocks();
   vi.mocked(electronSystemService.getSystemMonospaceFonts).mockResolvedValue([
     { label: 'Courier New', value: '"Courier New"' },
     { label: 'Menlo', value: 'Menlo' },
@@ -100,21 +101,9 @@ afterEach(() => {
 });
 
 describe('Terminal appearance settings', () => {
-  it('stays hidden and does not query fonts until the built-in terminal feature is enabled', () => {
-    useUserStore.setState({
-      preference: { lab: { enableBuiltinTerminal: false } },
-    });
-
-    render(<Terminal />);
-
-    expect(screen.queryByText('settingAppearance.terminal.title')).toBeNull();
-    expect(electronSystemService.getSystemMonospaceFonts).not.toHaveBeenCalled();
-  });
-
   it('shows installed monospace fonts and persists the selection', async () => {
     const updatePreference = vi.fn();
     useUserStore.setState({
-      preference: { lab: { enableBuiltinTerminal: true } },
       updatePreference,
     });
 
@@ -135,7 +124,7 @@ describe('Terminal appearance settings', () => {
   it('stores an empty value when the application default is selected', async () => {
     const updatePreference = vi.fn();
     useUserStore.setState({
-      preference: { lab: { enableBuiltinTerminal: true }, terminalFontFamily: 'Menlo' },
+      preference: { terminalFontFamily: 'Menlo' },
       updatePreference,
     });
 

--- a/src/features/Settings/Appearance/Terminal/index.tsx
+++ b/src/features/Settings/Appearance/Terminal/index.tsx
@@ -14,7 +14,7 @@ import { useSaveState } from '@/hooks/useSaveState';
 import type { SystemMonospaceFont } from '@/services/electron/system';
 import { electronSystemService } from '@/services/electron/system';
 import { useUserStore } from '@/store/user';
-import { labPreferSelectors, preferenceSelectors } from '@/store/user/selectors';
+import { preferenceSelectors } from '@/store/user/selectors';
 
 const APPLICATION_DEFAULT_FONT = '__application_default__';
 
@@ -124,9 +124,7 @@ const TerminalSettings = memo(() => {
 });
 
 const Terminal = memo(() => {
-  const enableBuiltinTerminal = useUserStore(labPreferSelectors.enableBuiltinTerminal);
-
-  if (!isDesktop || !enableBuiltinTerminal) return null;
+  if (!isDesktop) return null;
 
   return <TerminalSettings />;
 });

--- a/src/features/SettingsSearch/items.ts
+++ b/src/features/SettingsSearch/items.ts
@@ -2,7 +2,6 @@ import { SettingsTabs } from '@/store/global/initialState';
 
 export interface SettingsSearchContext {
   disableEmailPassword: boolean;
-  enableBuiltinTerminal: boolean;
   enableBusinessFeatures: boolean;
   enableComposio: boolean;
   enableGatewayMode: boolean;
@@ -302,7 +301,7 @@ export const SETTINGS_SEARCH_ITEMS: SettingsSearchItem[] = [
     keywords: ['terminal font', 'monospace', 'font family'],
     labelKey: 'settingAppearance.terminal.fontFamily.title',
     tab: SettingsTabs.Appearance,
-    visible: (ctx) => ctx.isDesktop && ctx.enableBuiltinTerminal,
+    visible: (ctx) => ctx.isDesktop,
   },
   // Advanced
   {

--- a/src/features/SettingsSearch/useSettingsSearch.ts
+++ b/src/features/SettingsSearch/useSettingsSearch.ts
@@ -12,7 +12,7 @@ import {
   useServerConfigStore,
 } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
-import { authSelectors, labPreferSelectors, userProfileSelectors } from '@/store/user/selectors';
+import { authSelectors, userProfileSelectors } from '@/store/user/selectors';
 
 import {
   SETTINGS_SEARCH_ITEMS,
@@ -83,7 +83,6 @@ export const useSettingsSearch = (
   const enableComposio = useServerConfigStore(serverConfigSelectors.enableComposio);
   const disableEmailPassword = useServerConfigStore(serverConfigSelectors.disableEmailPassword);
   const isLogin = useUserStore(authSelectors.isLogin);
-  const enableBuiltinTerminal = useUserStore(labPreferSelectors.enableBuiltinTerminal);
   const hasEmail = useUserStore((s) => !!userProfileSelectors.userProfile(s)?.email);
   const [pinyin, setPinyin] = useState<{ settled: boolean; texts: PinyinTexts | null }>({
     settled: false,
@@ -96,7 +95,6 @@ export const useSettingsSearch = (
     const ctx: SettingsSearchContext = {
       disableEmailPassword: !!disableEmailPassword,
       enableBusinessFeatures: !!enableBusinessFeatures,
-      enableBuiltinTerminal,
       enableComposio: !!enableComposio,
       enableGatewayMode: !!enableGatewayMode,
       enableSTT: !!enableSTT,
@@ -220,7 +218,6 @@ export const useSettingsSearch = (
     t,
     disableEmailPassword,
     enableBusinessFeatures,
-    enableBuiltinTerminal,
     enableComposio,
     enableGatewayMode,
     enableSTT,


### PR DESCRIPTION
## Summary

- remove the obsolete `enableBuiltinTerminal` selector from terminal appearance settings
- expose terminal font settings on desktop without the retired Labs preference
- align settings search visibility with the graduated desktop terminal feature
- remove the obsolete Labs-gating test and stale preference fixtures

## Root cause

The built-in terminal was graduated from Labs and its preference field and selector were removed. A subsequent terminal font settings change still referenced the deleted selector, causing `tsgo --noEmit` failures in the component, settings search, and test fixtures.

## Impact

Desktop users retain access to terminal font settings and can find them through settings search without requiring a removed Labs flag.

## Validation

- `bun run check src/features/Settings/Appearance/Terminal/index.tsx src/features/Settings/Appearance/Terminal/index.test.tsx src/features/SettingsSearch/items.ts src/features/SettingsSearch/useSettingsSearch.ts`
- `tsgo --noEmit`
