### PR TITLE
🐛 fix(chat): prevent late empty assistant forks

### DIFF
--- a/.agents/acceptance/common-mistakes.md
+++ b/.agents/acceptance/common-mistakes.md
@@ -286,6 +286,21 @@ where the action key is actually enabled (grep each route's `leftActions` array,
 the component's imports) and capture evidence for every surface that enables it. Mark
 any surface you deliberately skip as untested.
 
+### L-E19 — Declaring a parent-chain fix complete without product UI evidence
+
+**Wrong approach:** verify a message-chain persistence fix only with reducer and
+model tests when the reported symptom is a user message disappearing from the
+conversation UI.
+
+**Why it fails:** unit and database tests prove guards independently, but do not
+prove that the renderer selects the repaired branch or that the new user message
+remains visible after hydration.
+
+**Correct approach:** distill the original heterogeneous-agent trace into a
+deterministic fixture and require paired evidence: a screenshot or GIF showing the
+new turn after reload, plus a database assertion showing its `parent_id` points to
+the valid spine rather than the empty assistant shell.
+
 ## Product and interaction contracts
 
 ### L-D1 — Rebuilding a canonical surface from visual impression

--- a/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
+++ b/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
@@ -935,7 +935,14 @@ export class HeterogeneousPersistenceHandler {
         await this.deps.messageModel.create(
           {
             agentId: intent.agentId ?? undefined,
-            content: '',
+            // Seed the in-flight placeholder the chat path uses, not '': the anchor
+            // queries treat a blank assistant as a dead shell to skip, and this row
+            // stays blank until its first chunk lands. Seeding '' made every batch's
+            // `refreshMainStateFromDb` resolve the spine to the PREVIOUS step and
+            // fork the run onto a stale node — the exact regression that method's
+            // comment says it exists to prevent. `toAssistantSnapshot` already
+            // normalizes LOADING_FLAT back to '' on read.
+            content: LOADING_FLAT,
             ...(Object.keys(createMetadata).length > 0 ? { metadata: createMetadata } : {}),
             model: intent.model,
             parentId: intent.parentId,

--- a/packages/database/src/models/__tests__/messages/message.query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.query.test.ts
@@ -3308,20 +3308,23 @@ describe('MessageModel Query Tests', () => {
           createdAt: new Date('2023-01-01T00:00:00'),
         },
         {
-          id: 'ghost',
-          userId,
-          topicId: 'topic1',
-          role: 'assistant',
-          content: '   ',
-          createdAt: new Date('2023-01-01T00:00:01'),
-        },
-        {
           id: 'reasoning-only',
           userId,
           topicId: 'topic1',
           role: 'assistant',
           content: '',
           reasoning: { content: 'thinking' },
+          createdAt: new Date('2023-01-01T00:00:01'),
+        },
+        {
+          // Newest on purpose: the ghost has to WIN the ordering for this case to
+          // discriminate. With it parked in the middle the query returns the right
+          // answer even without the guard, and the test passes for the wrong reason.
+          id: 'ghost',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: '   ',
           createdAt: new Date('2023-01-01T00:00:02'),
         },
       ]);

--- a/packages/database/src/models/__tests__/messages/message.query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.query.test.ts
@@ -3376,6 +3376,50 @@ describe('MessageModel Query Tests', () => {
       expect(await messageModel.getLatestNonToolMessageId({ topicId: 'topic1' })).toBe('errored');
     });
 
+    it('keeps an attachment-only assistant eligible as an anchor', async () => {
+      await serverDB.insert(sessions).values([{ id: 'session1', userId }]);
+      await serverDB.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);
+      await serverDB.insert(messages).values([
+        {
+          id: 'a1',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: 'real tail',
+          createdAt: new Date('2023-01-01T00:00:00'),
+        },
+        {
+          // A generated-image turn: the payload lives in messages_files, so every
+          // column checked above is empty. The query side joins those files back
+          // in as visible content, so this is a real turn to anchor to.
+          id: 'image-only',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: '',
+          createdAt: new Date('2023-01-01T00:00:01'),
+        },
+      ]);
+      await serverDB
+        .insert(files)
+        .values({
+          id: 'f-img',
+          userId,
+          url: 'abc',
+          name: 'gen.png',
+          fileType: 'image/png',
+          size: 1,
+        });
+      await serverDB
+        .insert(messagesFiles)
+        .values({ fileId: 'f-img', messageId: 'image-only', userId });
+
+      expect(await messageModel.getLatestSpineMessageId({ topicId: 'topic1' })).toBe('image-only');
+      expect(await messageModel.getLatestNonToolMessageId({ topicId: 'topic1' })).toBe(
+        'image-only',
+      );
+    });
+
     it('scopes the main thread to threadId IS NULL (ignores thread messages)', async () => {
       await serverDB.insert(sessions).values([{ id: 'session1', userId }]);
       await serverDB.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);

--- a/packages/database/src/models/__tests__/messages/message.query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.query.test.ts
@@ -1,4 +1,4 @@
-import { INBOX_SESSION_ID } from '@lobechat/const';
+import { INBOX_SESSION_ID, LOADING_FLAT } from '@lobechat/const';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -3400,16 +3400,14 @@ describe('MessageModel Query Tests', () => {
           createdAt: new Date('2023-01-01T00:00:01'),
         },
       ]);
-      await serverDB
-        .insert(files)
-        .values({
-          id: 'f-img',
-          userId,
-          url: 'abc',
-          name: 'gen.png',
-          fileType: 'image/png',
-          size: 1,
-        });
+      await serverDB.insert(files).values({
+        id: 'f-img',
+        userId,
+        url: 'abc',
+        name: 'gen.png',
+        fileType: 'image/png',
+        size: 1,
+      });
       await serverDB
         .insert(messagesFiles)
         .values({ fileId: 'f-img', messageId: 'image-only', userId });
@@ -3418,6 +3416,62 @@ describe('MessageModel Query Tests', () => {
       expect(await messageModel.getLatestNonToolMessageId({ topicId: 'topic1' })).toBe(
         'image-only',
       );
+    });
+
+    it('keeps a search-grounding-only assistant eligible as an anchor', async () => {
+      await serverDB.insert(sessions).values([{ id: 'session1', userId }]);
+      await serverDB.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);
+      await serverDB.insert(messages).values([
+        {
+          id: 'a1',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: 'real tail',
+          createdAt: new Date('2023-01-01T00:00:00'),
+        },
+        {
+          // MessageContent renders grounding independently of text, so citations
+          // alone still make this a turn the user sees.
+          id: 'search-only',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: '',
+          search: { citations: [{ title: 'src', url: 'https://example.com' }] } as any,
+          createdAt: new Date('2023-01-01T00:00:01'),
+        },
+      ]);
+
+      expect(await messageModel.getLatestSpineMessageId({ topicId: 'topic1' })).toBe('search-only');
+    });
+
+    it('keeps an in-flight assistant still holding the loading placeholder', async () => {
+      await serverDB.insert(sessions).values([{ id: 'session1', userId }]);
+      await serverDB.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);
+      await serverDB.insert(messages).values([
+        {
+          id: 'prev-step',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: 'previous step',
+          createdAt: new Date('2023-01-01T00:00:00'),
+        },
+        {
+          // Both runtimes seed this before the first chunk lands. Skipping it
+          // resolves the spine to the previous step and forks the run.
+          id: 'in-flight',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: LOADING_FLAT,
+          createdAt: new Date('2023-01-01T00:00:01'),
+        },
+      ]);
+
+      expect(await messageModel.getLatestSpineMessageId({ topicId: 'topic1' })).toBe('in-flight');
+      expect(await messageModel.getLatestNonToolMessageId({ topicId: 'topic1' })).toBe('in-flight');
     });
 
     it('scopes the main thread to threadId IS NULL (ignores thread messages)', async () => {

--- a/packages/database/src/models/__tests__/messages/message.query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.query.test.ts
@@ -3327,6 +3327,17 @@ describe('MessageModel Query Tests', () => {
           content: '   ',
           createdAt: new Date('2023-01-01T00:00:02'),
         },
+        {
+          // Tabs and newlines, not spaces: one-argument BTRIM only strips spaces,
+          // so a predicate written that way keeps this row while the ledger's
+          // String.trim() calls it empty. The two sides have to agree.
+          id: 'ghost-ws',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: '\n\t\r ',
+          createdAt: new Date('2023-01-01T00:00:03'),
+        },
       ]);
 
       expect(await messageModel.getLatestSpineMessageId({ topicId: 'topic1' })).toBe(
@@ -3475,6 +3486,14 @@ describe('MessageModel Query Tests', () => {
           role: 'assistant',
           content: '',
           createdAt: new Date('2023-01-01T00:00:01'),
+        },
+        {
+          id: 'ghost-ws',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: '\n\t\r ',
+          createdAt: new Date('2023-01-01T00:00:02'),
         },
       ]);
 

--- a/packages/database/src/models/__tests__/messages/message.query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.query.test.ts
@@ -3345,6 +3345,37 @@ describe('MessageModel Query Tests', () => {
       );
     });
 
+    it('keeps an error-only assistant eligible as an anchor', async () => {
+      await serverDB.insert(sessions).values([{ id: 'session1', userId }]);
+      await serverDB.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);
+      await serverDB.insert(messages).values([
+        {
+          id: 'a1',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: 'real tail',
+          createdAt: new Date('2023-01-01T00:00:00'),
+        },
+        {
+          // Failed before emitting text, so content/tools/reasoning are all empty —
+          // but the renderer shows an error card for it, so it is a real turn the
+          // next user message must anchor to. Excluding it would fork the reply
+          // onto a sibling branch and hide the error.
+          id: 'errored',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: '',
+          error: { message: 'boom', type: 'ProviderBizError' } as any,
+          createdAt: new Date('2023-01-01T00:00:01'),
+        },
+      ]);
+
+      expect(await messageModel.getLatestSpineMessageId({ topicId: 'topic1' })).toBe('errored');
+      expect(await messageModel.getLatestNonToolMessageId({ topicId: 'topic1' })).toBe('errored');
+    });
+
     it('scopes the main thread to threadId IS NULL (ignores thread messages)', async () => {
       await serverDB.insert(sessions).values([{ id: 'session1', userId }]);
       await serverDB.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);

--- a/packages/database/src/models/__tests__/messages/message.query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.query.test.ts
@@ -3295,6 +3295,42 @@ describe('MessageModel Query Tests', () => {
       expect(await messageModel.getLatestSpineMessageId({ topicId: 'topic1' })).toBe('a1');
     });
 
+    it('excludes a newer empty assistant leaf while retaining meaningful empty turns', async () => {
+      await serverDB.insert(sessions).values([{ id: 'session1', userId }]);
+      await serverDB.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);
+      await serverDB.insert(messages).values([
+        {
+          id: 'a1',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: 'real tail',
+          createdAt: new Date('2023-01-01T00:00:00'),
+        },
+        {
+          id: 'ghost',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: '   ',
+          createdAt: new Date('2023-01-01T00:00:01'),
+        },
+        {
+          id: 'reasoning-only',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: '',
+          reasoning: { content: 'thinking' },
+          createdAt: new Date('2023-01-01T00:00:02'),
+        },
+      ]);
+
+      expect(await messageModel.getLatestSpineMessageId({ topicId: 'topic1' })).toBe(
+        'reasoning-only',
+      );
+    });
+
     it('scopes the main thread to threadId IS NULL (ignores thread messages)', async () => {
       await serverDB.insert(sessions).values([{ id: 'session1', userId }]);
       await serverDB.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);
@@ -3416,6 +3452,32 @@ describe('MessageModel Query Tests', () => {
   // it a new user turn is persisted as a second root and the renderer emits the
   // newest reply above older messages.
   describe('getLatestNonToolMessageId', () => {
+    it('skips an empty assistant when falling back to a non-tool anchor', async () => {
+      await serverDB.insert(sessions).values([{ id: 'session1', userId }]);
+      await serverDB.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);
+      await serverDB.insert(messages).values([
+        {
+          id: 'sig-1',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: 'monitor callback',
+          metadata: { signal: { type: 'monitor' } } as any,
+          createdAt: new Date('2023-01-01T00:00:00'),
+        },
+        {
+          id: 'ghost',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: '',
+          createdAt: new Date('2023-01-01T00:00:01'),
+        },
+      ]);
+
+      expect(await messageModel.getLatestNonToolMessageId({ topicId: 'topic1' })).toBe('sig-1');
+    });
+
     it('returns a toolless signal turn that the spine query skips', async () => {
       await serverDB.insert(sessions).values([{ id: 'session1', userId }]);
       await serverDB.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -3298,7 +3298,7 @@ export class MessageModel {
           // to it creates a dead branch that the conversation-flow renderer drops.
           sql`NOT (
             ${messages.role} = 'assistant'
-            AND COALESCE(BTRIM(${messages.content}), '') = ''
+            AND COALESCE(${messages.content}, '') !~ '[^[:space:]]'
             AND (${messages.tools} IS NULL OR ${messages.tools} = '[]'::jsonb)
             AND ${messages.reasoning} IS NULL
           )`,
@@ -3343,7 +3343,7 @@ export class MessageModel {
           threadId ? eq(messages.threadId, threadId) : isNull(messages.threadId),
           sql`NOT (
             ${messages.role} = 'assistant'
-            AND COALESCE(BTRIM(${messages.content}), '') = ''
+            AND COALESCE(${messages.content}, '') !~ '[^[:space:]]'
             AND (${messages.tools} IS NULL OR ${messages.tools} = '[]'::jsonb)
             AND ${messages.reasoning} IS NULL
           )`,

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -3301,6 +3301,7 @@ export class MessageModel {
             AND COALESCE(${messages.content}, '') !~ '[^[:space:]]'
             AND (${messages.tools} IS NULL OR ${messages.tools} = '[]'::jsonb)
             AND ${messages.reasoning} IS NULL
+            AND ${messages.error} IS NULL
           )`,
           this.ownership(),
         ),
@@ -3346,6 +3347,7 @@ export class MessageModel {
             AND COALESCE(${messages.content}, '') !~ '[^[:space:]]'
             AND (${messages.tools} IS NULL OR ${messages.tools} = '[]'::jsonb)
             AND ${messages.reasoning} IS NULL
+            AND ${messages.error} IS NULL
           )`,
           this.ownership(),
         ),

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -388,6 +388,45 @@ const computeTopicMessageStats = (counts: number[]): TopicMessageStats => {
   };
 };
 
+/**
+ * Excludes an assistant row that never produced anything a user can see.
+ *
+ * A late-replayed heterogeneous-agent create can otherwise become the newest row
+ * in a topic despite carrying no payload, and it is not a valid conversation
+ * anchor: parenting the next user turn to it builds a dead branch that the
+ * conversation-flow renderer drops, so the turn disappears.
+ *
+ * The rule is an enumeration of every column a visible payload can land in, which
+ * makes it fragile in one specific direction: a payload kind that is not listed
+ * here is silently misread as "invisible", and the guard then HIDES real user
+ * content instead of dead rows. Reviews of #17474 caught four such misses
+ * (whitespace-only text, error-only turns, attachment-only turns, in-flight
+ * placeholders) before this list settled. So:
+ *
+ * **Adding a column or relation that renders on its own? Add it here too.**
+ *
+ * Deliberately NOT treated as empty:
+ * - `LOADING_FLAT` content — the in-flight marker both runtimes seed. A running
+ *   turn is the correct anchor; only the terminal-time ledger sweep in
+ *   `pendingCreateLedger` may treat the placeholder as empty.
+ * - rows with `error` — they render an error card.
+ * - rows with related `messages_files` — generated images/audio/files are joined
+ *   back in as visible content.
+ * - rows with `search` — `MessageContent` renders grounding independently of text.
+ */
+const notAnEmptyAssistantShell = () => sql`NOT (
+  ${messages.role} = 'assistant'
+  AND COALESCE(${messages.content}, '') !~ '[^[:space:]]'
+  AND (${messages.tools} IS NULL OR ${messages.tools} = '[]'::jsonb)
+  AND ${messages.reasoning} IS NULL
+  AND ${messages.error} IS NULL
+  AND ${messages.search} IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM ${messagesFiles}
+    WHERE ${messagesFiles.messageId} = ${messages.id}
+  )
+)`;
+
 export class MessageModel {
   private userId: string;
   private db: LobeChatDatabase;
@@ -3292,21 +3331,7 @@ export class MessageModel {
             COALESCE(jsonb_exists(${messages.metadata}, 'signal'), false)
             AND (${messages.tools} IS NULL OR ${messages.tools} = '[]'::jsonb)
           )`,
-          // A late-replayed heterogeneous-agent create can otherwise become the
-          // newest row despite never having produced any user-visible payload.
-          // It is not a valid conversation anchor: parenting the next user turn
-          // to it creates a dead branch that the conversation-flow renderer drops.
-          sql`NOT (
-            ${messages.role} = 'assistant'
-            AND COALESCE(${messages.content}, '') !~ '[^[:space:]]'
-            AND (${messages.tools} IS NULL OR ${messages.tools} = '[]'::jsonb)
-            AND ${messages.reasoning} IS NULL
-            AND ${messages.error} IS NULL
-            AND NOT EXISTS (
-              SELECT 1 FROM ${messagesFiles}
-              WHERE ${messagesFiles.messageId} = ${messages.id}
-            )
-          )`,
+          notAnEmptyAssistantShell(),
           this.ownership(),
         ),
       )
@@ -3346,17 +3371,7 @@ export class MessageModel {
           eq(messages.topicId, topicId),
           not(eq(messages.role, 'tool')),
           threadId ? eq(messages.threadId, threadId) : isNull(messages.threadId),
-          sql`NOT (
-            ${messages.role} = 'assistant'
-            AND COALESCE(${messages.content}, '') !~ '[^[:space:]]'
-            AND (${messages.tools} IS NULL OR ${messages.tools} = '[]'::jsonb)
-            AND ${messages.reasoning} IS NULL
-            AND ${messages.error} IS NULL
-            AND NOT EXISTS (
-              SELECT 1 FROM ${messagesFiles}
-              WHERE ${messagesFiles.messageId} = ${messages.id}
-            )
-          )`,
+          notAnEmptyAssistantShell(),
           this.ownership(),
         ),
       )

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -3292,6 +3292,16 @@ export class MessageModel {
             COALESCE(jsonb_exists(${messages.metadata}, 'signal'), false)
             AND (${messages.tools} IS NULL OR ${messages.tools} = '[]'::jsonb)
           )`,
+          // A late-replayed heterogeneous-agent create can otherwise become the
+          // newest row despite never having produced any user-visible payload.
+          // It is not a valid conversation anchor: parenting the next user turn
+          // to it creates a dead branch that the conversation-flow renderer drops.
+          sql`NOT (
+            ${messages.role} = 'assistant'
+            AND COALESCE(BTRIM(${messages.content}), '') = ''
+            AND (${messages.tools} IS NULL OR ${messages.tools} = '[]'::jsonb)
+            AND ${messages.reasoning} IS NULL
+          )`,
           this.ownership(),
         ),
       )
@@ -3331,6 +3341,12 @@ export class MessageModel {
           eq(messages.topicId, topicId),
           not(eq(messages.role, 'tool')),
           threadId ? eq(messages.threadId, threadId) : isNull(messages.threadId),
+          sql`NOT (
+            ${messages.role} = 'assistant'
+            AND COALESCE(BTRIM(${messages.content}), '') = ''
+            AND (${messages.tools} IS NULL OR ${messages.tools} = '[]'::jsonb)
+            AND ${messages.reasoning} IS NULL
+          )`,
           this.ownership(),
         ),
       )

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -3302,6 +3302,10 @@ export class MessageModel {
             AND (${messages.tools} IS NULL OR ${messages.tools} = '[]'::jsonb)
             AND ${messages.reasoning} IS NULL
             AND ${messages.error} IS NULL
+            AND NOT EXISTS (
+              SELECT 1 FROM ${messagesFiles}
+              WHERE ${messagesFiles.messageId} = ${messages.id}
+            )
           )`,
           this.ownership(),
         ),
@@ -3348,6 +3352,10 @@ export class MessageModel {
             AND (${messages.tools} IS NULL OR ${messages.tools} = '[]'::jsonb)
             AND ${messages.reasoning} IS NULL
             AND ${messages.error} IS NULL
+            AND NOT EXISTS (
+              SELECT 1 FROM ${messagesFiles}
+              WHERE ${messagesFiles.messageId} = ${messages.id}
+            )
           )`,
           this.ownership(),
         ),

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
@@ -3,6 +3,7 @@ import type {
   AgentInterventionResponseData,
   AgentStreamEvent,
 } from '@lobechat/agent-gateway-client';
+import { LOADING_FLAT } from '@lobechat/const';
 import type { HeterogeneousAgentSessionError } from '@lobechat/electron-client-ipc';
 import { HeterogeneousAgentSessionErrorCode } from '@lobechat/electron-client-ipc';
 import {
@@ -1493,7 +1494,10 @@ export const executeHeterogeneousAgent = async (
         if (intent.signal) createMetadata.signal = intent.signal;
         const messageToCreate = {
           agentId: intent.agentId ?? context.agentId,
-          content: '',
+          // See the server-side twin in HeterogeneousPersistenceHandler: a blank
+          // assistant reads as a dead shell to the anchor queries, so the row an
+          // in-flight step is about to fill must carry the loading placeholder.
+          content: LOADING_FLAT,
           id: intent.messageId,
           ...(Object.keys(createMetadata).length > 0 ? { metadata: createMetadata } : {}),
           model: intent.model,

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
@@ -1524,6 +1524,9 @@ export const executeHeterogeneousAgent = async (
         if (intent.provider) update.provider = intent.provider;
         if (intent.metadata) update.metadata = intent.metadata;
         if (Object.keys(update).length === 0) return;
+        if (intent.content?.trim() || intent.reasoning?.trim()) {
+          pendingCreateLedger.markHasPayload(intent.messageId);
+        }
         messageWriteBatcher.enqueueUpdateMessage(
           intent.messageId,
           update,
@@ -1566,6 +1569,9 @@ export const executeHeterogeneousAgent = async (
       }
 
       case 'persistToolBatch': {
+        if (intent.tools.length > 0) {
+          pendingCreateLedger.markHasPayload(intent.assistantMessageId);
+        }
         const buildUpdate = (withResult: boolean): Record<string, any> => {
           const update: Record<string, any> = {
             tools: intent.tools.map((x) =>

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
@@ -2255,6 +2255,14 @@ export const executeHeterogeneousAgent = async (
             // Order is load-bearing: rows first, in the order they were enqueued
             // (that is their FK dependency order), then the content patches —
             // an update against a row that does not exist yet matches zero rows.
+            // A failed create can sit here for the whole run. If that turn never
+            // produced content, reasoning, tools, or a child, replaying it only at
+            // terminal time would mint a late empty assistant with its original,
+            // now-stale parentId. The next user turn could then anchor to that
+            // newer dead leaf and disappear from the rendered conversation.
+            pendingCreateLedger.discardEmptyLeafAssistants((messageId) =>
+              pendingMainFlush.has(messageId),
+            );
             await pendingCreateLedger.drain();
 
             for (const [messageId, update] of pendingMainFlush) {

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.test.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.test.ts
@@ -120,4 +120,40 @@ describe('createPendingCreateLedger', () => {
       expect(ledger.size).toBe(1);
     });
   });
+
+  describe('discardEmptyLeafAssistants', () => {
+    it('drops a terminally replayed empty assistant with no dependent rows or updates', async () => {
+      const createMessage = vi.fn().mockResolvedValue(undefined);
+      const ledger = createPendingCreateLedger({
+        createMessage,
+        flush: vi.fn().mockResolvedValue(undefined),
+      });
+
+      ledger.add('ghost', row('ghost', 'stale-parent'));
+      ledger.discardEmptyLeafAssistants(() => false);
+      await ledger.drain();
+
+      expect(createMessage).not.toHaveBeenCalled();
+      expect(ledger.size).toBe(0);
+    });
+
+    it('preserves empty assistants that have a child or a pending content update', async () => {
+      const createMessage = vi.fn().mockResolvedValue(undefined);
+      const ledger = createPendingCreateLedger({
+        createMessage,
+        flush: vi.fn().mockResolvedValue(undefined),
+      });
+
+      ledger.add('parent', row('parent'));
+      ledger.add('child', row('child', 'parent'));
+      ledger.add('with-update', row('with-update'));
+      ledger.discardEmptyLeafAssistants((messageId) => messageId === 'with-update');
+      await ledger.drain();
+
+      expect(createMessage.mock.calls.map(([message]) => message.id)).toEqual([
+        'parent',
+        'with-update',
+      ]);
+    });
+  });
 });

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.test.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.test.ts
@@ -155,5 +155,22 @@ describe('createPendingCreateLedger', () => {
         'with-update',
       ]);
     });
+
+    it('preserves a failed empty create after its payload update has already settled', async () => {
+      const createMessage = vi.fn().mockResolvedValue(undefined);
+      const ledger = createPendingCreateLedger({
+        createMessage,
+        flush: vi.fn().mockResolvedValue(undefined),
+      });
+
+      ledger.markHasPayload('with-settled-output');
+      ledger.add('with-settled-output', row('with-settled-output'));
+      ledger.discardEmptyLeafAssistants(() => false);
+      await ledger.drain();
+
+      expect(createMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'with-settled-output' }),
+      );
+    });
   });
 });

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.test.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.test.ts
@@ -1,3 +1,4 @@
+import { LOADING_FLAT } from '@lobechat/const';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createPendingCreateLedger } from './pendingCreateLedger';
@@ -156,6 +157,24 @@ describe('createPendingCreateLedger', () => {
         'child',
         'with-update',
       ]);
+    });
+
+    it('discards a create still holding the loading placeholder at terminal time', async () => {
+      const createMessage = vi.fn().mockResolvedValue(undefined);
+      const ledger = createPendingCreateLedger({
+        createMessage,
+        flush: vi.fn().mockResolvedValue(undefined),
+      });
+
+      // The anchor queries keep LOADING_FLAT rows because they may be in flight.
+      // This sweep only runs once the run is over, so the placeholder means the
+      // step produced nothing at all.
+      ledger.add('seeded', { ...row('seeded', 'stale-parent'), content: LOADING_FLAT });
+      ledger.discardEmptyLeafAssistants(() => false);
+      await ledger.drain();
+
+      expect(createMessage).not.toHaveBeenCalled();
+      expect(ledger.size).toBe(0);
     });
 
     it('peels an entire chain of empty creates, not just its tail', async () => {

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.test.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.test.ts
@@ -137,7 +137,7 @@ describe('createPendingCreateLedger', () => {
       expect(ledger.size).toBe(0);
     });
 
-    it('preserves empty assistants that have a child or a pending content update', async () => {
+    it('preserves empty assistants that have a surviving child or a pending content update', async () => {
       const createMessage = vi.fn().mockResolvedValue(undefined);
       const ledger = createPendingCreateLedger({
         createMessage,
@@ -145,15 +145,37 @@ describe('createPendingCreateLedger', () => {
       });
 
       ledger.add('parent', row('parent'));
-      ledger.add('child', row('child', 'parent'));
+      // Carries real output, so it survives the sweep and keeps its parent anchored.
+      ledger.add('child', { ...row('child', 'parent'), content: 'answer' });
       ledger.add('with-update', row('with-update'));
       ledger.discardEmptyLeafAssistants((messageId) => messageId === 'with-update');
       await ledger.drain();
 
       expect(createMessage.mock.calls.map(([message]) => message.id)).toEqual([
         'parent',
+        'child',
         'with-update',
       ]);
+    });
+
+    it('peels an entire chain of empty creates, not just its tail', async () => {
+      const createMessage = vi.fn().mockResolvedValue(undefined);
+      const ledger = createPendingCreateLedger({
+        createMessage,
+        flush: vi.fn().mockResolvedValue(undefined),
+      });
+
+      // head <- middle <- tail, every link an empty assistant. Discarding only the
+      // tail would leave `head`/`middle` for drain() to replay as late empty
+      // assistants — the same disappearing-turn bug, one link up the chain.
+      ledger.add('head', row('head', 'stale-parent'));
+      ledger.add('middle', row('middle', 'head'));
+      ledger.add('tail', row('tail', 'middle'));
+      ledger.discardEmptyLeafAssistants(() => false);
+      await ledger.drain();
+
+      expect(createMessage).not.toHaveBeenCalled();
+      expect(ledger.size).toBe(0);
     });
 
     it('preserves a failed empty create after its payload update has already settled', async () => {

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.ts
@@ -39,6 +39,25 @@ export const createPendingCreateLedger = (deps: {
   return {
     add: (messageId: string, message: CreateMessageRow) => pending.set(messageId, message),
 
+    discardEmptyLeafAssistants: (hasPendingUpdate: (messageId: string) => boolean) => {
+      const parentIds = new Set(
+        [...pending.values()]
+          .map(({ parentId }) => parentId)
+          .filter((parentId): parentId is string => typeof parentId === 'string'),
+      );
+
+      for (const [messageId, message] of pending) {
+        const isEmptyAssistant =
+          message.role === 'assistant' &&
+          !message.content?.trim() &&
+          (message.tools?.length ?? 0) === 0;
+
+        if (isEmptyAssistant && !parentIds.has(messageId) && !hasPendingUpdate(messageId)) {
+          pending.delete(messageId);
+        }
+      }
+    },
+
     drain,
 
     /**

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.ts
@@ -19,6 +19,7 @@ export const createPendingCreateLedger = (deps: {
   flush: (reason: string) => Promise<void>;
 }) => {
   const pending = new Map<string, CreateMessageRow>();
+  const messageIdsWithPayload = new Set<string>();
 
   /**
    * Replay the ledger in insertion order (= FK dependency order). Best-effort: a
@@ -30,6 +31,7 @@ export const createPendingCreateLedger = (deps: {
       try {
         await deps.createMessage(message);
         pending.delete(messageId);
+        messageIdsWithPayload.delete(messageId);
       } catch (err) {
         console.error('[HeterogeneousAgent] Failed to replay message create:', err);
       }
@@ -52,13 +54,27 @@ export const createPendingCreateLedger = (deps: {
           !message.content?.trim() &&
           (message.tools?.length ?? 0) === 0;
 
-        if (isEmptyAssistant && !parentIds.has(messageId) && !hasPendingUpdate(messageId)) {
+        if (
+          isEmptyAssistant &&
+          !parentIds.has(messageId) &&
+          !hasPendingUpdate(messageId) &&
+          !messageIdsWithPayload.has(messageId)
+        ) {
           pending.delete(messageId);
+          messageIdsWithPayload.delete(messageId);
         }
       }
     },
 
     drain,
+
+    /**
+     * Remember output independently from the retry maps. Assistant creates are
+     * intentionally empty; their content/reasoning/tools land in later updates,
+     * which may report success (or match zero rows) and disappear from the
+     * pending-flush map before terminal cleanup inspects the failed create.
+     */
+    markHasPayload: (messageId: string) => messageIdsWithPayload.add(messageId),
 
     /**
      * Gate a straight-through write on its FK parent actually existing in the DB.

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.ts
@@ -1,3 +1,5 @@
+import { LOADING_FLAT } from '@lobechat/const';
+
 import type { MessageBatchOperation } from '@/services/message';
 
 type CreateMessageRow = Extract<MessageBatchOperation, { type: 'createMessage' }>['message'];
@@ -13,6 +15,9 @@ type CreateMessageRow = Extract<MessageBatchOperation, { type: 'createMessage' }
  * insertion order, so one in-order drain is correct with no knowledge of which
  * parent kind any given row uses.
  */
+const stripPlaceholder = (content: string | null | undefined) =>
+  content === LOADING_FLAT ? '' : (content ?? '');
+
 export const createPendingCreateLedger = (deps: {
   createMessage: (message: CreateMessageRow) => Promise<unknown>;
   /** The write batcher's flush. Resolves even when the writes inside it failed. */
@@ -52,9 +57,13 @@ export const createPendingCreateLedger = (deps: {
      * Terminates because every pass that sets `removed` shrinks `pending`.
      */
     discardEmptyLeafAssistants: (hasPendingUpdate: (messageId: string) => boolean) => {
+      // LOADING_FLAT counts as empty HERE and only here. It marks a row as
+      // in-flight, which is why the anchor queries keep it — but this sweep runs
+      // at terminal time, so a row still holding the placeholder is one that never
+      // produced anything at all.
       const isEmptyAssistant = (message: CreateMessageRow) =>
         message.role === 'assistant' &&
-        !message.content?.trim() &&
+        !stripPlaceholder(message.content).trim() &&
         (message.tools?.length ?? 0) === 0;
 
       let removed = true;

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.ts
@@ -41,27 +41,44 @@ export const createPendingCreateLedger = (deps: {
   return {
     add: (messageId: string, message: CreateMessageRow) => pending.set(messageId, message),
 
+    /**
+     * Peel empty leaves until none are left, recomputing the parent set each pass.
+     * A single pass is not enough: when a run fails several empty creates in a row
+     * they form a chain, and discarding the tail orphans its parent. Computing
+     * `parentIds` once would keep that head — still an empty assistant, still
+     * replayed by `drain()`, still able to become the newest anchor. That is the
+     * exact turn-swallowing this sweep exists to prevent, just one link up.
+     *
+     * Terminates because every pass that sets `removed` shrinks `pending`.
+     */
     discardEmptyLeafAssistants: (hasPendingUpdate: (messageId: string) => boolean) => {
-      const parentIds = new Set(
-        [...pending.values()]
-          .map(({ parentId }) => parentId)
-          .filter((parentId): parentId is string => typeof parentId === 'string'),
-      );
+      const isEmptyAssistant = (message: CreateMessageRow) =>
+        message.role === 'assistant' &&
+        !message.content?.trim() &&
+        (message.tools?.length ?? 0) === 0;
 
-      for (const [messageId, message] of pending) {
-        const isEmptyAssistant =
-          message.role === 'assistant' &&
-          !message.content?.trim() &&
-          (message.tools?.length ?? 0) === 0;
+      let removed = true;
 
-        if (
-          isEmptyAssistant &&
-          !parentIds.has(messageId) &&
-          !hasPendingUpdate(messageId) &&
-          !messageIdsWithPayload.has(messageId)
-        ) {
-          pending.delete(messageId);
-          messageIdsWithPayload.delete(messageId);
+      while (removed) {
+        removed = false;
+
+        const parentIds = new Set(
+          [...pending.values()]
+            .map(({ parentId }) => parentId)
+            .filter((parentId): parentId is string => typeof parentId === 'string'),
+        );
+
+        for (const [messageId, message] of pending) {
+          if (
+            isEmptyAssistant(message) &&
+            !parentIds.has(messageId) &&
+            !hasPendingUpdate(messageId) &&
+            !messageIdsWithPayload.has(messageId)
+          ) {
+            pending.delete(messageId);
+            messageIdsWithPayload.delete(messageId);
+            removed = true;
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary

A heterogeneous-agent run could mint a late empty assistant row that became the newest row in the topic. The next user turn anchored to it, landed on a dead branch, and disappeared from the rendered conversation.

- **Write side** — drop pending empty leaf assistant creates before the terminal drain, peeling whole chains rather than just the tail
- **Read side** — exclude persisted empty assistant shells from both spine and fallback parent selection
- Seed the in-flight loading placeholder in both heterogeneous runtimes so "blank" means "produced nothing", not "not yet"
- Regression coverage for the ledger retention rules and every anchor-selection case below

## Root cause

An assistant create that failed inside the write batcher was parked in `pendingCreateLedger` and replayed only at terminal drain. If that turn never produced content, the replayed row kept its now-stale `parentId` but carried the newest `createdAt`. `getLatestSpineMessageId` then handed that dead leaf to the next user message as its parent, and the conversation-flow renderer drops the whole dead branch.

## The tricky part: what counts as "empty"

The read-side guard decides visibility by enumerating every column a payload can land in. It only fails in one direction — an unlisted payload kind makes the guard **hide real user content**. Four review rounds surfaced six misses, all fixed here:

| Miss | Why it slipped |
| --- | --- |
| whitespace-only text | one-argument `BTRIM` strips spaces only, not tabs/newlines |
| chained empty creates | `parentIds` computed once, so discarding a leaf orphaned its parent |
| error-only turns | render an error card, so they are visible turns |
| attachment-only turns | generated images/audio live in `messages_files` |
| in-flight turns | hetero seeded `content: ''`, so a running step read as dead |
| search-only turns | `MessageContent` renders grounding independently of text |

The predicate is now a single documented `notAnEmptyAssistantShell()` — one source of truth, listing what is deliberately *not* empty and telling the next author to extend it when adding a renderable payload.

The in-flight miss was the worst of them: `refreshMainStateFromDb` runs on every event batch, so the guard resolved the spine to the *previous* step and forked the run onto a stale node — precisely the failure that method's own comment says it exists to prevent.

## Verification

- `bun run check`: 6 files, lint clean, types clean, 135 tests passed
- Ledger 12 tests, anchor-selection 81 tests; every new anchor case verified to fail against the unpatched predicate before passing with it
- Acceptance round 2: real LobeHub UI trace replay plus DB parent-chain evidence
  https://app.lobehub.com/acceptance/f1a3e7a2-ddca-4711-9b44-d7762314d7ab?r=2

## Context

Topic: tpc_7xFvrDxoupSU
