### PR TITLE
📝 docs(agent-testing): define dual text evidence

### DIFF
--- a/.agents/skills/agent-testing/SKILL.md
+++ b/.agents/skills/agent-testing/SKILL.md
@@ -373,6 +373,16 @@ Hard rules worth front-loading:
 - **Visual evidence lives in `result.json`, NOT in `report.md`.** Attach each
   screenshot/GIF to its case via `cases[].evidence`; the page renders it next to
   the check. Do NOT embed images/GIFs in `report.md`.
+- **Non-visual behavioral claims use dual text evidence.** Attach two separate
+  text artifacts to the same case: a reviewer-facing **reasoning** document and
+  an audit-facing **execution** document. The reasoning artifact explains the
+  claim, setup/threat model, method, pass criteria, interpretation, and limits.
+  The execution artifact preserves the exact command/request plus relevant raw
+  observations, then maps those observations back to the claim. Neither prose
+  without observed values nor an unexplained log dump is sufficient. Keep both
+  artifacts in the current round; never require a reviewer to join explanation
+  from one immutable round with logs from another. See
+  [references/report.md](./references/report.md#dual-text-evidence-for-non-visual-behavior).
 - **Final replies link ONLY the published `/acceptance/<id>` page — never a
   `/verify/<id>` URL. Put no images or local file links in the chat reply.**
   The acceptance page is the stable cross-round decision surface and renders

--- a/.agents/skills/agent-testing/references/common-mistakes.md
+++ b/.agents/skills/agent-testing/references/common-mistakes.md
@@ -543,3 +543,29 @@ decision page without the business goal against which all rounds are judged.
 
 **Correct approach**: supply `--requirement` or the object subject form on the
 first ingest. State the cross-round business goal, not the current round's scope.
+
+---
+
+## M27 — Treating explanation and raw output as interchangeable text evidence
+
+**Wrong approach**: attaching only a polished explanation with no concrete
+observations, attaching only a green test transcript and expecting the reviewer
+to infer the security or product claim, or putting the explanation in one round
+and the logs in a later round.
+
+**Why it's wrong**: non-visual behavioral evidence has two different jobs. The
+reasoning must make the test design and inference understandable; the execution
+record must make the observations auditable. Combining them into an undifferentiated
+wall of text makes both harder to read, while splitting them across immutable
+rounds makes the latest decision snapshot incomplete.
+
+**What it breaks**: reviewers cannot tell whether the probe actually tests the
+claimed boundary, auditors cannot find the exact values that support the verdict,
+and follow-up rounds require manual cross-round reconstruction.
+
+**Correct approach**: attach two ordered text artifacts to every non-visual
+behavioral case. The first is a reasoning document: claim, setup/threat model,
+attempt, pass criteria, interpretation, and limitations. The second is an
+execution document: exact command/request, relevant raw output and observed state,
+plus a short mapping from those values to the criteria. Republish both halves in
+every follow-up round so the round remains self-contained.

--- a/.agents/skills/agent-testing/references/report.md
+++ b/.agents/skills/agent-testing/references/report.md
@@ -112,9 +112,62 @@ table — those double up on the page. It carries only the non-duplicate narrati
        on each side, so the two captions read as a comparison rather than repeating
        the case title.
 
-   - CLI: exact command + trimmed output (`<cli> <command> | tee "$DIR/assets/x.txt"`).
+   - CLI: use the dual-text evidence format below. Preserve the exact command +
+     trimmed output (`<cli> <command> | tee "$DIR/assets/x-execution.txt"`) in
+     the execution artifact, and attach a separate reasoning artifact.
 
    - Network: `agent-browser network requests` dumps or HAR files.
+
+### Dual text evidence for non-visual behavior
+
+For CLI, API, backend, policy, security, migration, and other non-visual
+behavioral checks, one text file rarely serves both audiences well. A reviewer
+needs to understand why the check is meaningful; an auditor needs the concrete
+observations. Attach **two separate text artifacts** to the same case, in this
+order:
+
+1. **Reasoning evidence** (`<check>-reasoning.md`) — concise, reviewer-facing:
+   - claim / behavior being verified;
+   - setup or threat model;
+   - action or attempted bypass;
+   - explicit pass/fail criteria;
+   - why the chosen observations support the verdict;
+   - limitations and what remains unproven.
+2. **Execution evidence** (`<check>-execution.txt` or `.md`) — audit-facing:
+   - exact command, request, or probe;
+   - relevant raw stdout/stderr, response body/status, exit code, filesystem or
+     server-side observations;
+   - a short annotation mapping each observed value to the pass/fail criteria.
+
+The split is semantic, not cosmetic. Do not duplicate the same prose into both
+files, and do not turn the execution artifact into a second high-level summary.
+Trim unrelated noise, but retain values that make the outcome independently
+auditable (for example exit codes, error text, file existence, response status,
+or server receive counts).
+
+```json
+{
+  "evidence": ["assets/write-boundary-reasoning.md", "assets/write-boundary-execution.txt"],
+  "id": "write-boundary",
+  "name": "approved writes succeed and escape attempts are denied",
+  "observation": "control exit=0; four escape attempts exit non-zero and created no files",
+  "status": "pass"
+}
+```
+
+This is a hard default for non-visual behavioral claims, with two narrow
+exceptions:
+
+- a text artifact is only ancillary metadata for primary visual evidence (for
+  example a screenshot plus a small DOM dump);
+- the evidence is intrinsically self-explanatory and contains no behavioral
+  inference (for example a generated schema file whose exact contents are the
+  claim).
+
+If a follow-up round corrects either half, publish both halves again in that
+round. Every immutable round must be a self-contained decision snapshot; never
+ask the reviewer to combine reasoning from an older round with execution logs
+from the current one.
 
 3. **Write `plan[]` BEFORE you run anything.** The approved plan from Step 1 is part
    of the report, not scaffolding you throw away: each item is
@@ -319,7 +372,8 @@ report body.
 
 - **No evidence, no claim** — every `pass`/`fail` in `cases[]` must link at least
   one asset. UI cases must attach their primary screenshot/GIF as evidence;
-  non-visual CLI/network cases may link transcripts, HAR files, or logs.
+  non-visual behavioral cases must attach both reasoning and execution text;
+  transcripts, HAR files, and logs belong in the execution half.
 - **Screenshots must be visually verified** with the Read tool before being cited.
 - **Report failures faithfully** — a failing case with clear evidence is a good
   report; a vague green one is not.


### PR DESCRIPTION
## Summary

- require non-visual behavioral checks to attach separate reasoning and execution evidence
- document the content and ordering of both artifacts with a reusable `result.json` example
- keep follow-up acceptance rounds self-contained instead of splitting explanation and logs across rounds
- add a common-mistake entry covering explanation-only, log-only, and cross-round evidence

## Validation

- `bun run check .agents/skills/agent-testing/SKILL.md .agents/skills/agent-testing/references/report.md .agents/skills/agent-testing/references/common-mistakes.md`
- `git diff --check`