### PR TITLE
🐛 fix(auth): focus agreement confirmation

### DIFF
--- a/src/features/AuthShell/AuthAgreement.tsx
+++ b/src/features/AuthShell/AuthAgreement.tsx
@@ -112,6 +112,7 @@ export const useAuthAgreement = (requestConfirmation?: RequestAgreementConfirmat
       confirmModal({
         cancelText: t('cancel', { ns: 'common' }),
         content: <AgreementText i18nKey={'agreement.confirm.content'} />,
+        okButtonProps: { autoFocus: true },
         okText: t('agreement.confirm.ok', { ns: 'auth' }),
         onOk: onConfirm,
         title: t('agreement.confirm.title', { ns: 'auth' }),


### PR DESCRIPTION
## Summary

- focus the "Agree and continue" action when the terms and privacy confirmation modal opens
- prevent a repeated Enter key press from dismissing the modal through its close button

## Root cause

The base-ui modal focuses its first focusable control by default. Because the header close button appears before the confirmation actions, keyboard users could open the agreement modal with Enter and immediately close it with a second Enter press.

## User impact

Keyboard sign-in now follows the intended confirmation path: the modal opens with focus on "Agree and continue", so pressing Enter confirms the agreement instead of dismissing the modal.

## Verification

- Browser verification on the production Auth SPA build:
  - opened `/signin` with the agreement unchecked
  - triggered the agreement modal from Next
  - confirmed `document.activeElement` was the "Agree and continue" button
  - pressed Enter and verified the modal closed and the agreement checkbox changed to checked
- `bun run check src/features/AuthShell/AuthAgreement.tsx`
  - lint clean
  - 9 existing tests passed
- `git diff --check`
