### PR TITLE
🐛 fix(search): surface marketplace agent failures

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/search.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/search.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UserModel } from '@/database/models/user';
+import { DiscoverService } from '@/server/services/discover';
+
+import { searchRouter } from '../search';
+
+vi.mock('@/database/core/db-adaptor', () => ({
+  getServerDB: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@/database/repositories/search', () => ({
+  SearchRepo: vi.fn(),
+}));
+
+vi.mock('@/database/models/user', () => ({
+  UserModel: Object.assign(vi.fn(), { findById: vi.fn() }),
+}));
+
+vi.mock('@/server/services/discover', () => ({
+  DiscoverService: vi.fn(),
+}));
+
+describe('searchRouter', () => {
+  const getAssistantList = vi.fn();
+  const getUserSettings = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAssistantList.mockReset();
+    getUserSettings.mockResolvedValue({ market: { accessToken: 'market-token' } });
+    vi.mocked(UserModel.findById).mockResolvedValue({
+      email: 'user@example.com',
+      fullName: 'Test User',
+    } as any);
+    vi.mocked(UserModel).mockImplementation(() => ({ getUserSettings }) as any);
+    vi.mocked(DiscoverService).mockImplementation(
+      () => ({ getAssistantList }) as unknown as DiscoverService,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns an empty community agent result when the market search succeeds with no matches', async () => {
+    getAssistantList.mockResolvedValue({
+      currentPage: 1,
+      items: [],
+      pageSize: 5,
+      totalCount: 0,
+      totalPages: 0,
+    });
+    const caller = searchRouter.createCaller({ userId: 'test-user' } as any);
+
+    const result = await caller.query({ query: 'missing', type: 'communityAgent' });
+
+    expect(result).toEqual([]);
+    expect(DiscoverService).toHaveBeenCalledWith({
+      accessToken: 'market-token',
+      userInfo: {
+        email: 'user@example.com',
+        name: 'Test User',
+        userId: 'test-user',
+      },
+    });
+    expect(getAssistantList).toHaveBeenCalledWith(
+      {
+        includeAgentGroup: true,
+        locale: undefined,
+        pageSize: 5,
+        q: 'missing',
+      },
+      { throwOnError: true },
+    );
+  });
+
+  it('returns a typed error when the community agent market search fails', async () => {
+    const marketError = new Error('Market unavailable');
+    getAssistantList.mockRejectedValue(marketError);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const caller = searchRouter.createCaller({ userId: 'test-user' } as any);
+
+    await expect(
+      caller.query({ query: 'assistant', type: 'communityAgent' }),
+    ).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Marketplace agent search is currently unavailable',
+    });
+  });
+});

--- a/apps/server/src/routers/lambda/__tests__/search.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/search.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { UserModel } from '@/database/models/user';
+import { SearchRepo } from '@/database/repositories/search';
 import { DiscoverService } from '@/server/services/discover';
 
 import { searchRouter } from '../search';
@@ -25,16 +26,19 @@ vi.mock('@/server/services/discover', () => ({
 describe('searchRouter', () => {
   const getAssistantList = vi.fn();
   const getUserSettings = vi.fn();
+  const search = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
     getAssistantList.mockReset();
     getUserSettings.mockResolvedValue({ market: { accessToken: 'market-token' } });
+    search.mockResolvedValue([]);
     vi.mocked(UserModel.findById).mockResolvedValue({
       email: 'user@example.com',
       fullName: 'Test User',
     } as any);
     vi.mocked(UserModel).mockImplementation(() => ({ getUserSettings }) as any);
+    vi.mocked(SearchRepo).mockImplementation(() => ({ search }) as unknown as SearchRepo);
     vi.mocked(DiscoverService).mockImplementation(
       () => ({ getAssistantList }) as unknown as DiscoverService,
     );
@@ -74,6 +78,17 @@ describe('searchRouter', () => {
       },
       { throwOnError: true },
     );
+  });
+
+  it('does not load market identity for a local-only search', async () => {
+    const caller = searchRouter.createCaller({ userId: 'test-user' } as any);
+
+    const result = await caller.query({ query: 'local message', type: 'message' });
+
+    expect(result).toEqual([]);
+    expect(search).toHaveBeenCalledWith({ query: 'local message', type: 'message' });
+    expect(UserModel.findById).not.toHaveBeenCalled();
+    expect(getUserSettings).not.toHaveBeenCalled();
   });
 
   it('returns a typed error when the community agent market search fails', async () => {

--- a/apps/server/src/routers/lambda/__tests__/search.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/search.test.ts
@@ -25,12 +25,16 @@ vi.mock('@/server/services/discover', () => ({
 
 describe('searchRouter', () => {
   const getAssistantList = vi.fn();
+  const getMcpList = vi.fn();
+  const getPluginList = vi.fn();
   const getUserSettings = vi.fn();
   const search = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
     getAssistantList.mockReset();
+    getMcpList.mockResolvedValue({ items: [] });
+    getPluginList.mockResolvedValue({ items: [] });
     getUserSettings.mockResolvedValue({ market: { accessToken: 'market-token' } });
     search.mockResolvedValue([]);
     vi.mocked(UserModel.findById).mockResolvedValue({
@@ -40,7 +44,7 @@ describe('searchRouter', () => {
     vi.mocked(UserModel).mockImplementation(() => ({ getUserSettings }) as any);
     vi.mocked(SearchRepo).mockImplementation(() => ({ search }) as unknown as SearchRepo);
     vi.mocked(DiscoverService).mockImplementation(
-      () => ({ getAssistantList }) as unknown as DiscoverService,
+      () => ({ getAssistantList, getMcpList, getPluginList }) as unknown as DiscoverService,
     );
   });
 
@@ -89,6 +93,26 @@ describe('searchRouter', () => {
     expect(search).toHaveBeenCalledWith({ query: 'local message', type: 'message' });
     expect(UserModel.findById).not.toHaveBeenCalled();
     expect(getUserSettings).not.toHaveBeenCalled();
+  });
+
+  it('preserves global search results when the community agent search rejects', async () => {
+    const localResult = { id: 'local-agent', title: 'Local Agent', type: 'agent' };
+    search.mockResolvedValue([localResult]);
+    getAssistantList.mockRejectedValue(new Error('Market unavailable'));
+    const caller = searchRouter.createCaller({ userId: 'test-user' } as any);
+
+    const result = await caller.query({ query: 'assistant' });
+
+    expect(result).toEqual([localResult]);
+    expect(getAssistantList).toHaveBeenCalledWith(
+      {
+        includeAgentGroup: true,
+        locale: undefined,
+        pageSize: 5,
+        q: 'assistant',
+      },
+      { throwOnError: false },
+    );
   });
 
   it('returns a typed error when the community agent market search fails', async () => {

--- a/apps/server/src/routers/lambda/search.ts
+++ b/apps/server/src/routers/lambda/search.ts
@@ -4,8 +4,10 @@ import { z } from 'zod';
 import { wsCompatProcedure } from '@/business/server/trpc-middlewares/workspaceAuth';
 import { SearchRepo } from '@/database/repositories/search';
 import { router } from '@/libs/trpc/lambda';
-import { marketUserInfo, serverDatabase } from '@/libs/trpc/lambda/middleware';
+import { resolveMarketUserContext, serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { DiscoverService } from '@/server/services/discover';
+
+const MARKETPLACE_SEARCH_TYPES = new Set(['communityAgent', 'mcp', 'plugin']);
 
 /**
  * Calculate relevance score for marketplace items
@@ -21,23 +23,26 @@ function calculateMarketplaceRelevance(query: string, title: string): number {
   return 4;
 }
 
-const searchProcedure = wsCompatProcedure
-  .use(serverDatabase)
-  .use(marketUserInfo)
-  .use(async (opts) => {
-    const { ctx } = opts;
-    const wsId = ctx.workspaceId ?? undefined;
+const searchProcedure = wsCompatProcedure.use(serverDatabase).use(async (opts) => {
+  const { ctx } = opts;
+  const rawInput = (await opts.getRawInput()) as { type?: unknown } | undefined;
+  const type = typeof rawInput?.type === 'string' ? rawInput.type : undefined;
+  const wsId = ctx.workspaceId ?? undefined;
+  const marketContext =
+    !type || MARKETPLACE_SEARCH_TYPES.has(type)
+      ? await resolveMarketUserContext(ctx)
+      : { marketAccessToken: undefined, marketUserInfo: undefined };
 
-    return opts.next({
-      ctx: {
-        discoverService: new DiscoverService({
-          accessToken: ctx.marketAccessToken,
-          userInfo: ctx.marketUserInfo,
-        }),
-        searchRepo: new SearchRepo(ctx.serverDB, ctx.userId, wsId),
-      },
-    });
+  return opts.next({
+    ctx: {
+      discoverService: new DiscoverService({
+        accessToken: marketContext.marketAccessToken ?? ctx.marketAccessToken,
+        userInfo: marketContext.marketUserInfo,
+      }),
+      searchRepo: new SearchRepo(ctx.serverDB, ctx.userId, wsId),
+    },
   });
+});
 
 /**
  * The unified search router for all entities in the database.

--- a/apps/server/src/routers/lambda/search.ts
+++ b/apps/server/src/routers/lambda/search.ts
@@ -205,6 +205,8 @@ export const searchRouter = router({
               })),
             )
             .catch((error) => {
+              if (type !== 'communityAgent') return [];
+
               console.error('[search:communityAgent]', error);
               throw new TRPCError({
                 cause: error,

--- a/apps/server/src/routers/lambda/search.ts
+++ b/apps/server/src/routers/lambda/search.ts
@@ -1,9 +1,10 @@
+import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
 import { wsCompatProcedure } from '@/business/server/trpc-middlewares/workspaceAuth';
 import { SearchRepo } from '@/database/repositories/search';
 import { router } from '@/libs/trpc/lambda';
-import { serverDatabase } from '@/libs/trpc/lambda/middleware';
+import { marketUserInfo, serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { DiscoverService } from '@/server/services/discover';
 
 /**
@@ -20,17 +21,23 @@ function calculateMarketplaceRelevance(query: string, title: string): number {
   return 4;
 }
 
-const searchProcedure = wsCompatProcedure.use(serverDatabase).use(async (opts) => {
-  const { ctx } = opts;
-  const wsId = ctx.workspaceId ?? undefined;
+const searchProcedure = wsCompatProcedure
+  .use(serverDatabase)
+  .use(marketUserInfo)
+  .use(async (opts) => {
+    const { ctx } = opts;
+    const wsId = ctx.workspaceId ?? undefined;
 
-  return opts.next({
-    ctx: {
-      discoverService: new DiscoverService({ accessToken: ctx.marketAccessToken }),
-      searchRepo: new SearchRepo(ctx.serverDB, ctx.userId, wsId),
-    },
+    return opts.next({
+      ctx: {
+        discoverService: new DiscoverService({
+          accessToken: ctx.marketAccessToken,
+          userInfo: ctx.marketUserInfo,
+        }),
+        searchRepo: new SearchRepo(ctx.serverDB, ctx.userId, wsId),
+      },
+    });
   });
-});
 
 /**
  * The unified search router for all entities in the database.
@@ -163,12 +170,15 @@ export const searchRouter = router({
       if (!type || type === 'communityAgent') {
         searchPromises.push(
           ctx.discoverService
-            .getAssistantList({
-              includeAgentGroup: true,
-              locale,
-              pageSize: limitPerType,
-              q: query,
-            })
+            .getAssistantList(
+              {
+                includeAgentGroup: true,
+                locale,
+                pageSize: limitPerType,
+                q: query,
+              },
+              { throwOnError: type === 'communityAgent' },
+            )
             .then((response) =>
               response.items.slice(0, limitPerType).map((item: any) => ({
                 author:
@@ -189,7 +199,14 @@ export const searchRouter = router({
                 updatedAt: new Date(item.updatedAt || Date.now()),
               })),
             )
-            .catch(() => []),
+            .catch((error) => {
+              console.error('[search:communityAgent]', error);
+              throw new TRPCError({
+                cause: error,
+                code: 'INTERNAL_SERVER_ERROR',
+                message: 'Marketplace agent search is currently unavailable',
+              });
+            }),
         );
       }
 

--- a/apps/server/src/services/discover/index.test.ts
+++ b/apps/server/src/services/discover/index.test.ts
@@ -326,6 +326,49 @@ describe('DiscoverService', () => {
       );
     });
 
+    it('getAssistantList should preserve a successful empty response in strict mode', async () => {
+      mockMarket.agents.getAgentList.mockResolvedValue({
+        currentPage: 1,
+        items: [],
+        pageSize: 20,
+        totalCount: 0,
+        totalPages: 0,
+      });
+
+      const result = await service.getAssistantList({ q: 'missing' }, { throwOnError: true });
+
+      expect(result).toEqual({
+        currentPage: 1,
+        items: [],
+        pageSize: 20,
+        totalCount: 0,
+        totalPages: 0,
+      });
+    });
+
+    it('getAssistantList should rethrow market errors in strict mode', async () => {
+      const marketError = new Error('Market unavailable');
+      mockMarket.agents.getAgentList.mockRejectedValue(marketError);
+
+      await expect(
+        service.getAssistantList({ q: 'assistant' }, { throwOnError: true }),
+      ).rejects.toBe(marketError);
+    });
+
+    it('getAssistantList should retain the empty fallback by default', async () => {
+      mockMarket.agents.getAgentList.mockRejectedValue(new Error('Market unavailable'));
+
+      const result = await service.getAssistantList({ q: 'assistant' });
+
+      expect(result).toEqual({
+        currentPage: 1,
+        items: [],
+        pageSize: 20,
+        totalCount: 0,
+        totalPages: 0,
+      });
+    });
+
     it('getAssistantDetail should fetch from market SDK by default', async () => {
       const result = await service.getAssistantDetail({
         identifier: 'market-assistant-1',

--- a/apps/server/src/services/discover/index.ts
+++ b/apps/server/src/services/discover/index.ts
@@ -669,7 +669,10 @@ export class DiscoverService {
     }
   };
 
-  getAssistantList = async (params: AssistantQueryParams = {}): Promise<AssistantListResponse> => {
+  getAssistantList = async (
+    params: AssistantQueryParams = {},
+    options: { throwOnError?: boolean } = {},
+  ): Promise<AssistantListResponse> => {
     log('getAssistantList: params=%O', params);
     const { source, ...rest } = params;
     if (this.isLegacySource(source)) {
@@ -780,6 +783,8 @@ export class DiscoverService {
       return result;
     } catch (error) {
       log('getAssistantList: error fetching from market SDK: %O', error);
+      if (options.throwOnError) throw error;
+
       return {
         currentPage: page,
         items: [],

--- a/packages/trpc/src/lambda/middleware/marketUserInfo.ts
+++ b/packages/trpc/src/lambda/middleware/marketUserInfo.ts
@@ -12,28 +12,21 @@ interface ContextWithServerDB {
   workspaceId?: string | null;
 }
 
-/**
- * Middleware that fetches user info for Market trusted client authentication
- * This requires serverDatabase middleware to be applied first
- */
-export const marketUserInfo = trpc.middleware(async (opts) => {
-  const ctx = opts.ctx as ContextWithServerDB;
+interface MarketUserContext {
+  marketAccessToken?: string;
+  marketUserInfo?: TrustedClientUserInfo;
+}
 
+export const resolveMarketUserContext = async (
+  ctx: ContextWithServerDB,
+): Promise<MarketUserContext> => {
   // If userId or serverDB is not available, skip fetching user info
-  if (!ctx.userId || !ctx.serverDB) {
-    return opts.next({
-      ctx: { marketUserInfo: undefined },
-    });
-  }
+  if (!ctx.userId || !ctx.serverDB) return { marketUserInfo: undefined };
 
   try {
     const user = await UserModel.findById(ctx.serverDB, ctx.userId);
 
-    if (!user || !user.email) {
-      return opts.next({
-        ctx: { marketUserInfo: undefined },
-      });
-    }
+    if (!user || !user.email) return { marketUserInfo: undefined };
 
     const marketUserInfo: TrustedClientUserInfo = {
       email: user.email,
@@ -49,19 +42,24 @@ export const marketUserInfo = trpc.middleware(async (opts) => {
     const userSettings = await userModel.getUserSettings();
     const marketTokenFromDB = (userSettings?.market as any)?.accessToken;
 
-    // Prioritize database token over cookie token
-    const marketAccessToken = marketTokenFromDB || ctx.marketAccessToken;
-
-    return opts.next({
-      ctx: {
-        marketAccessToken,
-        marketUserInfo,
-      },
-    });
+    return {
+      // Prioritize database token over cookie token
+      marketAccessToken: marketTokenFromDB || ctx.marketAccessToken,
+      marketUserInfo,
+    };
   } catch {
     // If fetching user info fails, continue without it
-    return opts.next({
-      ctx: { marketUserInfo: undefined },
-    });
+    return { marketUserInfo: undefined };
   }
+};
+
+/**
+ * Middleware that fetches user info for Market trusted client authentication
+ * This requires serverDatabase middleware to be applied first
+ */
+export const marketUserInfo = trpc.middleware(async (opts) => {
+  const ctx = opts.ctx as ContextWithServerDB;
+  const marketContext = await resolveMarketUserContext(ctx);
+
+  return opts.next({ ctx: marketContext });
 });


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [x] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No matching issue found.

#### 🔀 Description of Change

Fixes `lh search --type communityAgent` treating marketplace authentication, network, and SDK failures as successful empty results.

- Load trusted-client Market user information for untyped and Marketplace-specific searches.
- Skip Market identity database reads for local-only search types.
- Pass the Market access token and user identity to `DiscoverService`.
- Add opt-in strict error handling for marketplace agent listing.
- Preserve `[]` for genuine successful zero-match searches.
- Surface explicit community-agent marketplace failures as a typed tRPC error.
- Keep partial-result degradation for untyped global searches.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Focused router/service checks: 44 tests passed.
Full TypeScript type-check passed.
Pre-commit Stylelint, ESLint, and Prettier checks passed.

#### 📸 Screenshots / Videos

Not applicable; server/CLI behavior only.

#### 📝 Additional Information

Production online verification requires deployment because the current production route does not yet load the Market trusted-client identity.

Dedicated Command Menu error UX is outside this CLI-focused fix. Its existing empty-state behavior is unchanged and should be addressed separately together with SWR retry behavior and localized inline error copy.