### PR TITLE
🐛 fix(model-runtime): enable prompt cache keys for Grok

### DIFF
--- a/packages/model-runtime/src/providers/superGrok/index.ts
+++ b/packages/model-runtime/src/providers/superGrok/index.ts
@@ -37,6 +37,7 @@ export const LobeSuperGrokAI = createOpenAICompatibleRuntime({
 
     return processModelList(modelList, MODEL_LIST_CONFIGS.xai, 'supergrok');
   },
+  promptCacheKeyModels: [/^grok-/],
   provider: ModelProvider.SuperGrok,
   responses: {
     handlePayload: handleXAIResponsesPayload,

--- a/packages/model-runtime/src/providers/xai/index.test.ts
+++ b/packages/model-runtime/src/providers/xai/index.test.ts
@@ -4,6 +4,7 @@ import type { Mock } from 'vitest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { testProvider } from '../../providerTestUtils';
+import { LobeSuperGrokAI } from '../superGrok';
 import type { XAIModelCard } from './index';
 import { LobeXAI } from './index';
 
@@ -33,6 +34,37 @@ describe('LobeXAI - custom features', () => {
   });
 
   describe('Responses API routing', () => {
+    it('should add a stable prompt cache key for Grok requests with a user', async () => {
+      await instance.chat(
+        {
+          messages: [{ content: 'Hello', role: 'user' }],
+          model: 'grok-4.5',
+        },
+        { user: 'user-1' },
+      );
+
+      const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+
+      expect(createCall.prompt_cache_key).toBe('lobe:user-1:grok-4.5');
+    });
+
+    it('should add a stable prompt cache key for SuperGrok requests with a user', async () => {
+      const superGrok = new LobeSuperGrokAI({ apiKey: 'test_api_key' });
+      const create = vi
+        .spyOn(superGrok['client'].responses, 'create')
+        .mockResolvedValue(new ReadableStream() as any);
+
+      await superGrok.chat(
+        {
+          messages: [{ content: 'Hello', role: 'user' }],
+          model: 'grok-4.5',
+        },
+        { user: 'user-1' },
+      );
+
+      expect(create.mock.calls[0][0].prompt_cache_key).toBe('lobe:user-1:grok-4.5');
+    });
+
     it('should ignore chatCompletion apiMode and remove camelCase penalty parameters', async () => {
       await instance.chat({
         apiMode: 'chatCompletion',

--- a/packages/model-runtime/src/providers/xai/index.ts
+++ b/packages/model-runtime/src/providers/xai/index.ts
@@ -155,6 +155,7 @@ export const LobeXAI = createOpenAICompatibleRuntime({
 
     return processModelList(modelList, MODEL_LIST_CONFIGS.xai, 'xai');
   },
+  promptCacheKeyModels: [/^grok-/],
   provider: ModelProvider.XAI,
   responses: {
     handlePayload: handleXAIResponsesPayload,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Enable provider-specific prompt cache keys for `grok-*` models on xAI.
- Apply the same cache-key behavior to SuperGrok.
- Add regression coverage for both providers' Responses API requests.

Grok Responses requests previously did not opt into the shared prompt-cache-key logic, so unchanged prompt prefixes could be routed without a stable cache key. Requests that include a user now use the existing stable format:

```text
lobe:{userId}:{model}
```

#### 🧪 How to Test

AI test scenario: send a `grok-4.5` Responses request through xAI or SuperGrok with `user: "user-1"`, then verify the payload includes `prompt_cache_key: "lobe:user-1:grok-4.5"`.

```bash
bun run check packages/model-runtime/src/providers/xai/index.ts packages/model-runtime/src/providers/xai/index.test.ts packages/model-runtime/src/providers/superGrok/index.ts
bun run check --type
```

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

Not applicable; this changes model runtime request payloads only.

#### 📝 Additional Information

No breaking changes or migrations.
