### PR TITLE
🐛 fix(verify): add missing acceptance.workspace.filters.empty.all locale key

### DIFF
--- a/locales/en-US/verify.json
+++ b/locales/en-US/verify.json
@@ -207,6 +207,7 @@
   "acceptance.workspace.filters.all": "All acceptances",
   "acceptance.workspace.filters.completed": "Completed",
   "acceptance.workspace.filters.empty.active": "No acceptances in progress.",
+  "acceptance.workspace.filters.empty.all": "No acceptances yet.",
   "acceptance.workspace.filters.empty.completed": "No completed acceptances.",
   "acceptance.workspace.filters.noSearchResults": "No acceptances match “{{query}}”.",
   "acceptance.workspace.filters.showAll": "Show all acceptances",

--- a/locales/zh-CN/verify.json
+++ b/locales/zh-CN/verify.json
@@ -207,6 +207,7 @@
   "acceptance.workspace.filters.all": "全部验收",
   "acceptance.workspace.filters.completed": "已完成",
   "acceptance.workspace.filters.empty.active": "暂无进行中的验收。",
+  "acceptance.workspace.filters.empty.all": "暂无验收。",
   "acceptance.workspace.filters.empty.completed": "暂无已完成的验收。",
   "acceptance.workspace.filters.noSearchResults": "没有与「{{query}}」匹配的验收。",
   "acceptance.workspace.filters.showAll": "显示全部验收",

--- a/packages/locales/src/default/verify.ts
+++ b/packages/locales/src/default/verify.ts
@@ -230,6 +230,7 @@ export default {
   'acceptance.workspace.filters.active': 'In progress',
   'acceptance.workspace.filters.all': 'All acceptances',
   'acceptance.workspace.filters.completed': 'Completed',
+  'acceptance.workspace.filters.empty.all': 'No acceptances yet.',
   'acceptance.workspace.filters.empty.active': 'No acceptances in progress.',
   'acceptance.workspace.filters.empty.completed': 'No completed acceptances.',
   'acceptance.workspace.filters.noSearchResults': 'No acceptances match “{{query}}”.',


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Follow-up to #17484.

#### 🔀 Description of Change

`tsgo --noEmit` currently fails on `canary` (blocking every PR's Code quality check):

```
src/features/Verify/Acceptance/Workspace/AcceptanceListPanel.tsx(628,25): error TS2345:
Type '"acceptance.workspace.filters.empty.all"' is not assignable to ...
```

`AcceptanceListPanel` calls `t(`acceptance.workspace.filters.empty.${filter}`)` where `filter` is `'all' | 'active' | 'completed'`, but the default `verify` locale only defines `empty.active` and `empty.completed`. The `empty.all` branch is unreachable at runtime (the surrounding condition routes `filter === 'all'` with no query to the first-run empty state), yet the template-literal key type still requires it.

Adds the missing `acceptance.workspace.filters.empty.all` key to the default locale, `en-US`, and `zh-CN`.

#### 🧪 How to Test

- `bun run type-check` fails before, passes after.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📝 Additional Information

Type-level fix only; no runtime behavior change.