### PR TITLE
🐛 fix(chat): private workspace agents use shared config; move prompt desc to tooltip

### DIFF
--- a/apps/server/src/services/aiAgent/__tests__/execAgent.modelOverride.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.modelOverride.test.ts
@@ -233,13 +233,20 @@ describe('AiAgentService.execAgent - model/provider override', () => {
     expect(callArgs.agentConfig.provider).toBe('anthropic');
   });
 
-  it('ignores the caller model preference when the workspace Agent is private', async () => {
+  it('ignores retained member preferences when the workspace Agent is private', async () => {
     mockGetAgentConfig.mockResolvedValue({
       ...defaultAgentConfig,
-      agencyConfig: { modelSelectionPolicy: 'member' },
+      agencyConfig: {
+        boundDeviceId: 'private-agent-device',
+        executionTarget: 'device',
+        modelSelectionPolicy: 'member',
+      },
       visibility: 'private',
     });
     mockGetPreference.mockResolvedValue({
+      agentDeviceOverrides: {
+        'agent-1': { boundDeviceId: 'stale-member-device', executionTarget: 'local' },
+      },
       agentModelOverrides: {
         'agent-1': { model: 'claude-sonnet-4-6', provider: 'anthropic' },
       },
@@ -251,6 +258,11 @@ describe('AiAgentService.execAgent - model/provider override', () => {
     const callArgs = mockCreateOperation.mock.calls[0][0];
     expect(callArgs.agentConfig.model).toBe('gpt-4');
     expect(callArgs.agentConfig.provider).toBe('openai');
+    expect(callArgs.agentConfig.agencyConfig).toMatchObject({
+      boundDeviceId: 'private-agent-device',
+      executionTarget: 'device',
+    });
+    expect(mockGetPreference).not.toHaveBeenCalled();
   });
 
   it('ignores a retained caller preference when the workspace model policy is missing/fixed', async () => {

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1235,12 +1235,12 @@ export class AiAgentService {
     const resolvedAgentId = agentConfig.id;
     let memberModelOverride: AgentModelOverride | undefined;
 
-    // Layer this caller's workspace-scoped execution and model preferences over
+    // Layer this caller's public-workspace execution and model preferences over
     // the shared Agent row. Device selection keeps its existing fallback rules;
     // model selection is applied only when the author explicitly allows member
     // choice (an omitted policy is fixed). Both overrides live in the dedicated
     // per-(workspace, user) settings row and never mutate shared Agent config.
-    if (this.workspaceId) {
+    if (this.workspaceId && agentConfig.visibility !== 'private') {
       try {
         const workspaceUserSettings = new WorkspaceUserSettingsModel(
           this.db,

--- a/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
@@ -36,6 +36,7 @@ import {
 import { useIsGatewayModeEnabled } from '@/helpers/gatewayMode';
 import { useEffectiveAgencyConfig } from '@/hooks/useEffectiveAgencyConfig';
 import { useAgentStore } from '@/store/agent';
+import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useElectronStore } from '@/store/electron';
 
 import { formatFixedExecutionTargetTooltip } from './executionTargetTooltip';
@@ -327,6 +328,9 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
 
   const agentWorkspaceId = useAgentStore((s) => s.agentMap[agentId]?.workspaceId);
   const isWorkspaceAgent = Boolean(agentWorkspaceId);
+  const usesWorkspaceMemberSelection = useAgentStore(
+    agentByIdSelectors.usesWorkspaceMemberSelectionById(agentId),
+  );
 
   // Shared config merged with the caller's per-agent override (LOBE-11689) —
   // the hook eagerly fetches the `workspaceUserSettings` bucket on mount so
@@ -338,7 +342,7 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
   } = useEffectiveAgencyConfig(agentId);
 
   const isFixedExecutionTarget =
-    isWorkspaceAgent && agencyConfig?.executionTargetSelectionPolicy === 'fixed';
+    usesWorkspaceMemberSelection && agencyConfig?.executionTargetSelectionPolicy === 'fixed';
 
   const heteroType = agencyConfig?.heterogeneousProvider?.type;
   const boundDeviceId = agencyConfig?.boundDeviceId;
@@ -392,13 +396,9 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
     [selectExecutionTarget],
   );
 
-  // Auto-default to THIS desktop's local execution on first open, for both
-  // personal and workspace agents (workspace behaviour used to be a hostname
-  // lookup against the workspace device pool — see LOBE-11647 — but with
-  // per-user overrides that lookup is unnecessary: `useSelectExecutionTarget`
-  // resolves `'local'` to this desktop's personal gateway `deviceId` and, for
-  // a workspace agent, persists it into `users.preference.agentDeviceOverrides`,
-  // so it never touches other members' choices).
+  // Auto-default to THIS desktop's local execution on first open. Public
+  // workspace agents persist the selection as a per-user override; personal
+  // and private workspace agents persist it directly on the agent.
   //
   // Fires only when the effective (merged) target and bound device are both
   // unset — an explicit prior selection, mine or (for personal) shared,

--- a/src/features/ChatInput/hooks/useAgentModelSelection.test.ts
+++ b/src/features/ChatInput/hooks/useAgentModelSelection.test.ts
@@ -46,6 +46,10 @@ vi.mock('@/store/agent/selectors', () => ({
     getAgentById: () => (s: typeof testState.agent) => s.agentMap['agent-1'],
     getAgentModelById: () => (s: typeof testState.agent) => s.model,
     getAgentModelProviderById: () => (s: typeof testState.agent) => s.provider,
+    usesWorkspaceMemberSelectionById: (id: string) => (s: typeof testState.agent) => {
+      const agent = s.agentMap[id as 'agent-1'];
+      return Boolean(agent?.workspaceId && agent.visibility !== 'private');
+    },
   },
 }));
 

--- a/src/features/ChatInput/hooks/useAgentModelSelection.ts
+++ b/src/features/ChatInput/hooks/useAgentModelSelection.ts
@@ -36,7 +36,9 @@ export const useAgentModelSelection = (agentId: string): UseAgentModelSelectionR
   const sharedModel = useAgentStore(agentByIdSelectors.getAgentModelById(agentId));
   const sharedProvider = useAgentStore(agentByIdSelectors.getAgentModelProviderById(agentId));
   const updateAgentConfigById = useAgentStore((s) => s.updateAgentConfigById);
-  const usesWorkspaceMemberSelection = !!agent?.workspaceId && agent.visibility !== 'private';
+  const usesWorkspaceMemberSelection = useAgentStore(
+    agentByIdSelectors.usesWorkspaceMemberSelectionById(agentId),
+  );
 
   const updateWorkspaceUserPreference = useUserStore((s) => s.updateWorkspaceUserPreference);
   const storePreference = useUserStore((s) => s.workspaceUserPreference);

--- a/src/features/ChatInput/hooks/useSelectExecutionTarget.test.ts
+++ b/src/features/ChatInput/hooks/useSelectExecutionTarget.test.ts
@@ -13,7 +13,10 @@ const testState = vi.hoisted(() => ({
           heterogeneousProvider?: { type: string };
         }
       | undefined,
-    agentMap: {} as Record<string, { workspaceId?: string | null }>,
+    agentMap: {} as Record<
+      string,
+      { visibility?: 'private' | 'public'; workspaceId?: string | null }
+    >,
     isHetero: false,
     updateAgentConfigById: vi.fn(),
   },
@@ -50,6 +53,10 @@ vi.mock('@/store/agent/selectors', () => ({
   agentByIdSelectors: {
     getAgencyConfigById: () => (s: typeof testState.agent) => s.agencyConfig,
     isAgentHeterogeneousById: () => (s: typeof testState.agent) => s.isHetero,
+    usesWorkspaceMemberSelectionById: (id: string) => (s: typeof testState.agent) => {
+      const agent = s.agentMap[id];
+      return Boolean(agent?.workspaceId && agent.visibility !== 'private');
+    },
   },
 }));
 
@@ -148,9 +155,39 @@ describe('useSelectExecutionTarget', () => {
     });
   });
 
+  describe('private workspace agent — writes to the agent config', () => {
+    beforeEach(() => {
+      testState.agent.agentMap = {
+        'agent-id': { visibility: 'private', workspaceId: 'ws-1' },
+      };
+    });
+
+    it('allows its owner to switch a fixed execution target without creating a member override', async () => {
+      testState.agent.agencyConfig = {
+        boundDeviceId: 'fixed-device',
+        executionTargetSelectionPolicy: 'fixed',
+        executionTarget: 'device',
+      };
+      const { result } = renderHook(() => useSelectExecutionTarget('agent-id'));
+
+      await result.current('device', 'another-device');
+
+      expect(testState.agent.updateAgentConfigById).toHaveBeenCalledWith('agent-id', {
+        agencyConfig: {
+          boundDeviceId: 'another-device',
+          executionTargetSelectionPolicy: 'fixed',
+          executionTarget: 'device',
+        },
+      });
+      expect(testState.user.updateWorkspaceUserPreference).not.toHaveBeenCalled();
+    });
+  });
+
   describe('workspace agent — writes to workspace_user_settings.preference.agentDeviceOverrides (LOBE-11689)', () => {
     beforeEach(() => {
-      testState.agent.agentMap = { 'agent-id': { workspaceId: 'ws-1' } };
+      testState.agent.agentMap = {
+        'agent-id': { visibility: 'public', workspaceId: 'ws-1' },
+      };
     });
 
     it('routes a workspace device pick into the workspace-scoped caller preference, never the shared config', async () => {

--- a/src/features/ChatInput/hooks/useSelectExecutionTarget.ts
+++ b/src/features/ChatInput/hooks/useSelectExecutionTarget.ts
@@ -22,7 +22,7 @@ import { useUserStore } from '@/store/user';
  * - **Personal agent** — writes go straight into the shared
  *   `agents.agencyConfig` (there's only ever one owner, so there's nothing to
  *   isolate).
- * - **Workspace agent** — writes go into
+ * - **Public workspace agent** — writes go into
  *   `workspace_user_settings.preference.agentDeviceOverrides[agentId]`
  *   (per-user per-workspace) so each member's Cloud Sandbox / workspace-device
  *   / this-machine choice stays independent. The shared `agents.agencyConfig`
@@ -30,6 +30,9 @@ import { useUserStore } from '@/store/user';
  *   chosen anything yet. Reads / writes are cached through the
  *   `workspaceUserSettings` slice of the user store, keyed on the active
  *   workspaceId.
+ * - **Private workspace agent** — like a personal agent, writes go straight
+ *   into `agents.agencyConfig`; only its owner can use it, so there is no
+ *   member-specific choice to isolate yet.
  *
  * `local` is stored verbatim (`{ executionTarget: 'local', boundDeviceId: <me> }`)
  * so both desktop dispatch (in-process IPC — the fast path) and web dispatch
@@ -41,7 +44,9 @@ import { useUserStore } from '@/store/user';
 export const useSelectExecutionTarget = (agentId: string) => {
   const agencyConfig = useAgentStore(agentByIdSelectors.getAgencyConfigById(agentId));
   const isHetero = useAgentStore(agentByIdSelectors.isAgentHeterogeneousById(agentId));
-  const isWorkspaceAgent = useAgentStore((s) => Boolean(s.agentMap[agentId]?.workspaceId));
+  const usesWorkspaceMemberSelection = useAgentStore(
+    agentByIdSelectors.usesWorkspaceMemberSelectionById(agentId),
+  );
   const updateAgentConfigById = useAgentStore((s) => s.updateAgentConfigById);
 
   const updateWorkspaceUserPreference = useUserStore((s) => s.updateWorkspaceUserPreference);
@@ -60,7 +65,8 @@ export const useSelectExecutionTarget = (agentId: string) => {
       // Fixed workspace agents are author-controlled. Keep any existing member
       // override dormant (so switching back to member choice restores it), but
       // never let this picker create or update an override while fixed.
-      if (isWorkspaceAgent && agencyConfig?.executionTargetSelectionPolicy === 'fixed') return;
+      if (usesWorkspaceMemberSelection && agencyConfig?.executionTargetSelectionPolicy === 'fixed')
+        return;
 
       const boundDeviceId = agencyConfig?.boundDeviceId;
       let nextBoundDeviceId = target === 'device' ? deviceId : boundDeviceId;
@@ -92,7 +98,7 @@ export const useSelectExecutionTarget = (agentId: string) => {
       //    `resolveExecutionTarget` already coerces a stored `local` +
       //    `boundDeviceId` to `device` when a gateway is available, so the
       //    server-side dispatch path Just Works — no need to pre-coerce here.
-      if (isWorkspaceAgent) {
+      if (usesWorkspaceMemberSelection) {
         const nextOverrides = {
           ...workspaceUserPreference.agentDeviceOverrides,
           [agentId]: {
@@ -117,9 +123,9 @@ export const useSelectExecutionTarget = (agentId: string) => {
       agencyConfig,
       currentDeviceId,
       isHetero,
-      isWorkspaceAgent,
       updateAgentConfigById,
       updateWorkspaceUserPreference,
+      usesWorkspaceMemberSelection,
       workspaceUserPreference,
     ],
   );

--- a/src/features/Conversation/store/slices/generation/action.ts
+++ b/src/features/Conversation/store/slices/generation/action.ts
@@ -96,14 +96,15 @@ const settleGenerationEntry = (
 const getEffectiveAgencyConfig = (agentId: string) => {
   const agentState = getAgentStoreState();
   const sharedAgencyConfig = agentSelectors.getAgentConfigById(agentId)(agentState)?.agencyConfig;
-  const isWorkspaceAgent = agentByIdSelectors.isWorkspaceAgentById(agentId)(agentState);
-  const deviceOverride = isWorkspaceAgent
+  const usesWorkspaceMemberSelection =
+    agentByIdSelectors.usesWorkspaceMemberSelectionById(agentId)(agentState);
+  const deviceOverride = usesWorkspaceMemberSelection
     ? getUserStoreState().workspaceUserPreference.agentDeviceOverrides?.[agentId]
     : undefined;
 
   return {
     agencyConfig: resolveAgencyConfig(sharedAgencyConfig, deviceOverride),
-    workspaceScoped: resolveWorkspaceScoped(isWorkspaceAgent, deviceOverride),
+    workspaceScoped: resolveWorkspaceScoped(usesWorkspaceMemberSelection, deviceOverride),
   };
 };
 

--- a/src/features/Conversation/store/slices/generation/continueHeteroAfterError.test.ts
+++ b/src/features/Conversation/store/slices/generation/continueHeteroAfterError.test.ts
@@ -29,7 +29,7 @@ vi.mock('@/store/chat/slices/agentRun/actions/dispatch/agentDispatcher', () => (
 }));
 
 let mockResumeSessionId: string | undefined = 'sess-1';
-let mockIsWorkspaceAgent = false;
+let mockUsesWorkspaceMemberSelection = false;
 let mockSharedExecutionTarget: 'device' | 'local' = 'local';
 let mockWorkspaceOverride: { boundDeviceId: string; executionTarget: 'local' } | undefined;
 vi.mock('@/store/chat/slices/agentRun/actions/transports/hetero/heteroResume', () => ({
@@ -65,7 +65,7 @@ vi.mock('@/store/agent', () => ({
 
 vi.mock('@/store/agent/selectors', () => ({
   agentByIdSelectors: {
-    isWorkspaceAgentById: () => () => mockIsWorkspaceAgent,
+    usesWorkspaceMemberSelectionById: () => () => mockUsesWorkspaceMemberSelection,
   },
   agentSelectors: {
     getAgentConfigById: () => () => ({
@@ -160,7 +160,7 @@ describe('continueHeteroAfterError', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockResumeSessionId = 'sess-1';
-    mockIsWorkspaceAgent = false;
+    mockUsesWorkspaceMemberSelection = false;
     mockSharedExecutionTarget = 'local';
     mockWorkspaceOverride = undefined;
   });
@@ -245,7 +245,7 @@ describe('continueHeteroAfterError', () => {
   });
 
   it('resumes locally when a workspace member overrides the shared device with this desktop', async () => {
-    mockIsWorkspaceAgent = true;
+    mockUsesWorkspaceMemberSelection = true;
     mockSharedExecutionTarget = 'device';
     mockWorkspaceOverride = {
       boundDeviceId: 'personal-device',
@@ -275,8 +275,34 @@ describe('continueHeteroAfterError', () => {
     expect(executorParams().workingDirectory).toBe('/Users/me/project');
   });
 
+  it('ignores a stale member override when continuing a private workspace agent', async () => {
+    mockSharedExecutionTarget = 'device';
+    mockWorkspaceOverride = {
+      boundDeviceId: 'personal-device',
+      executionTarget: 'local',
+    };
+    const store = buildGroupStore([
+      { content: 'looking', id: 'step-1', tools: [{ id: 'call-1' }] },
+      { content: '', error: HETERO_RATE_LIMIT, id: 'step-2' },
+    ]);
+
+    await act(async () => {
+      await store.getState().continueHeteroAfterError('step-1');
+    });
+
+    expect(mockSelectRuntimeType).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boundDeviceId: 'workspace-device',
+        executionTarget: 'device',
+        isWorkspaceAgent: false,
+      }),
+    );
+    expect(mockExecuteGatewayAgent).toHaveBeenCalledTimes(1);
+    expect(mockExecuteHeterogeneousAgent).not.toHaveBeenCalled();
+  });
+
   it('falls back through the gateway for a workspace shared-local target without an override', async () => {
-    mockIsWorkspaceAgent = true;
+    mockUsesWorkspaceMemberSelection = true;
     mockSharedExecutionTarget = 'local';
     const store = buildGroupStore([
       { content: 'looking', id: 'step-1', tools: [{ id: 'call-1' }] },

--- a/src/features/Conversation/store/slices/generation/regenerateHeteroImages.test.ts
+++ b/src/features/Conversation/store/slices/generation/regenerateHeteroImages.test.ts
@@ -48,7 +48,7 @@ vi.mock('@/store/agent', () => ({
 
 vi.mock('@/store/agent/selectors', () => ({
   agentByIdSelectors: {
-    isWorkspaceAgentById: () => () => false,
+    usesWorkspaceMemberSelectionById: () => () => false,
   },
   agentSelectors: {
     getAgentConfigById: () => () => ({

--- a/src/hooks/useEffectiveAgencyConfig.test.ts
+++ b/src/hooks/useEffectiveAgencyConfig.test.ts
@@ -12,9 +12,14 @@ vi.mock('@/store/agent/selectors', () => ({
     getAgencyConfigById:
       (id: string) => (s: { agentMap: Record<string, { agencyConfig?: unknown }> }) =>
         s.agentMap[id]?.agencyConfig,
-    isWorkspaceAgentById:
-      (id: string) => (s: { agentMap: Record<string, { workspaceId?: string }> }) =>
-        Boolean(s.agentMap[id]?.workspaceId),
+    usesWorkspaceMemberSelectionById:
+      (id: string) =>
+      (s: {
+        agentMap: Record<string, { visibility?: 'private' | 'public'; workspaceId?: string }>;
+      }) => {
+        const agent = s.agentMap[id];
+        return Boolean(agent?.workspaceId && agent.visibility !== 'private');
+      },
   },
 }));
 vi.mock('@/store/user', () => ({ useUserStore: vi.fn() }));
@@ -37,6 +42,7 @@ const setupStores = ({
   fetchedPreference,
   isLoading = false,
   override,
+  visibility,
   workspaceId,
 }: {
   agencyConfig?: unknown;
@@ -44,9 +50,10 @@ const setupStores = ({
   fetchedPreference?: unknown;
   isLoading?: boolean;
   override?: unknown;
+  visibility?: 'private' | 'public';
   workspaceId?: string;
 } = {}) => {
-  const agentState = { agentMap: { 'agent-1': { agencyConfig, workspaceId } } };
+  const agentState = { agentMap: { 'agent-1': { agencyConfig, visibility, workspaceId } } };
   const userState = {
     useFetchWorkspaceUserPreference: () => ({ data: fetchedPreference, isLoading }),
     workspaceUserPreference: { agentDeviceOverrides: override ? { 'agent-1': override } : {} },
@@ -66,6 +73,21 @@ describe('useEffectiveAgencyConfig', () => {
     const { result } = renderHook(() => useEffectiveAgencyConfig('agent-1'));
 
     expect(result.current.agencyConfig).toEqual(sharedConfig);
+    expect(result.current.workspaceScoped).toBe(false);
+  });
+
+  it('ignores member overrides and loading state for a private workspace agent', () => {
+    setupStores({
+      isLoading: true,
+      override: { boundDeviceId: 'stale-member-device', executionTarget: 'local' },
+      visibility: 'private',
+      workspaceId: 'ws-1',
+    });
+
+    const { result } = renderHook(() => useEffectiveAgencyConfig('agent-1'));
+
+    expect(result.current.agencyConfig).toEqual(sharedConfig);
+    expect(result.current.isPreferenceLoading).toBe(false);
     expect(result.current.workspaceScoped).toBe(false);
   });
 

--- a/src/hooks/useEffectiveAgencyConfig.ts
+++ b/src/hooks/useEffectiveAgencyConfig.ts
@@ -11,9 +11,9 @@ export interface UseEffectiveAgencyConfigResult {
   agencyConfig: LobeAgentAgencyConfig | undefined;
   /**
    * The workspace preference fetch is still in flight. Until it settles, a
-   * workspace agent's `agencyConfig` may reflect only the shared row — callers
-   * that act on `boundDeviceId` / `executionTarget` (device guards, defaults)
-   * should wait instead of acting on a value that may flip.
+   * public workspace agent's `agencyConfig` may reflect only the shared row —
+   * callers that act on `boundDeviceId` / `executionTarget` (device guards,
+   * defaults) should wait instead of acting on a value that may flip.
    */
   isPreferenceLoading: boolean;
   /**
@@ -35,9 +35,9 @@ export interface UseEffectiveAgencyConfigResult {
  * Reading the shared row alone shows whichever device landed there (usually
  * the creator's machine) instead of this member's choice.
  *
- * Personal agents have a single owner whose choice IS the shared config, so
- * the override is only applied for workspace agents — mirroring the write
- * side (`useSelectExecutionTarget`).
+ * Personal and private workspace agents have a single user whose choice IS the
+ * agent config, so the override is only applied for public workspace agents —
+ * mirroring the write side (`useSelectExecutionTarget`).
  *
  * Self-populates the workspace preference cache (SWR dedupes across callers;
  * personal mode short-circuits without a network call).
@@ -46,8 +46,8 @@ export const useEffectiveAgencyConfig = (agentId?: string): UseEffectiveAgencyCo
   const sharedAgencyConfig = useAgentStore((s) =>
     agentId ? agentByIdSelectors.getAgencyConfigById(agentId)(s) : undefined,
   );
-  const isWorkspaceAgent = useAgentStore((s) =>
-    agentId ? agentByIdSelectors.isWorkspaceAgentById(agentId)(s) : false,
+  const usesWorkspaceMemberSelection = useAgentStore((s) =>
+    agentId ? agentByIdSelectors.usesWorkspaceMemberSelectionById(agentId)(s) : false,
   );
 
   // Prefer the SWR response over the store bucket: the SWR cache is keyed by
@@ -66,8 +66,11 @@ export const useEffectiveAgencyConfig = (agentId?: string): UseEffectiveAgencyCo
   const override = agentId ? preference.agentDeviceOverrides?.[agentId] : undefined;
 
   return {
-    agencyConfig: resolveAgencyConfig(sharedAgencyConfig, isWorkspaceAgent ? override : undefined),
-    isPreferenceLoading: isWorkspaceAgent && isLoading,
-    workspaceScoped: resolveWorkspaceScoped(isWorkspaceAgent, override),
+    agencyConfig: resolveAgencyConfig(
+      sharedAgencyConfig,
+      usesWorkspaceMemberSelection ? override : undefined,
+    ),
+    isPreferenceLoading: usesWorkspaceMemberSelection && isLoading,
+    workspaceScoped: resolveWorkspaceScoped(usesWorkspaceMemberSelection, override),
   };
 };

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
@@ -105,6 +105,12 @@ vi.mock('@/components/Editor/AutoSaveHint', () => ({
   }),
 }));
 
+vi.mock('@/components/InfoTooltip', () => ({
+  default: ({ title }: { title: string }) => (
+    <span data-testid="prompt-description-tooltip" data-title={title} />
+  ),
+}));
+
 vi.mock('@/components/AntdStaticMethods', () => ({
   message: {
     error: (...args: unknown[]) => messageError(...args),
@@ -199,6 +205,16 @@ describe('Agent profile EditorCanvas', () => {
 
     expect(editorProps.last?.lineEmptyPlaceholder).toBe('settingAgent.prompt.editorPlaceholder');
     expect(editorProps.last?.placeholder).toBe('settingAgent.prompt.editorPlaceholder');
+  });
+
+  it('moves the prompt description from persistent text into the title tooltip', () => {
+    render(<EditorCanvas />);
+
+    expect(screen.queryByText('settingAgent.prompt.desc')).not.toBeInTheDocument();
+    expect(screen.getByTestId('prompt-description-tooltip')).toHaveAttribute(
+      'data-title',
+      'settingAgent.prompt.desc',
+    );
   });
 
   it('binds a draft save to its original agent and loads the next agent content', async () => {

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 
 import { message } from '@/components/AntdStaticMethods';
 import AutoSaveHint from '@/components/Editor/AutoSaveHint';
+import InfoTooltip from '@/components/InfoTooltip';
 import { createChatInputRichPlugins } from '@/features/ChatInput/InputEditor/plugins';
 import { EditingIndicator } from '@/features/EditLock';
 import { useResourceAccess } from '@/features/ResourcePermission/useResourceAccess';
@@ -26,11 +27,6 @@ import TypoBar from './TypoBar';
 import { useSlashItems } from './useSlashItems';
 
 const styles = createStaticStyles(({ css }) => ({
-  desc: css`
-    font-size: 13px;
-    line-height: 1.6;
-    color: ${cssVar.colorTextSecondary};
-  `,
   editorShell: css`
     min-height: 300px;
     padding-block: 18px;
@@ -318,9 +314,12 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
 
   return (
     <Flexbox className={styles.root} gap={16}>
-      <Flexbox className={styles.header} gap={4}>
+      <Flexbox className={styles.header}>
         <Flexbox horizontal align={'center'} distribution={'space-between'} gap={8}>
-          <div className={styles.title}>{t('settingAgent.prompt.title')}</div>
+          <Flexbox horizontal align={'center'} gap={6}>
+            <div className={styles.title}>{t('settingAgent.prompt.title')}</div>
+            <InfoTooltip size={'small'} title={t('settingAgent.prompt.desc')} />
+          </Flexbox>
           {promptSaveStatus !== 'idle' && (
             <AutoSaveHint
               lastUpdatedTime={promptLastUpdatedTime}
@@ -329,7 +328,6 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
             />
           )}
         </Flexbox>
-        <div className={styles.desc}>{t('settingAgent.prompt.desc')}</div>
       </Flexbox>
       <div
         className={styles.editorShell}

--- a/src/store/agent/selectors/agentByIdSelectors.test.ts
+++ b/src/store/agent/selectors/agentByIdSelectors.test.ts
@@ -20,6 +20,22 @@ const createState = (overrides: Partial<AgentStoreState> = {}): AgentStoreState 
 });
 
 describe('agentByIdSelectors', () => {
+  describe('usesWorkspaceMemberSelectionById', () => {
+    it('uses member preferences only after a workspace agent is public', () => {
+      const state = createState({
+        agentMap: {
+          personal: {},
+          private: { visibility: 'private', workspaceId: 'workspace-1' },
+          public: { visibility: 'public', workspaceId: 'workspace-1' },
+        },
+      });
+
+      expect(agentByIdSelectors.usesWorkspaceMemberSelectionById('personal')(state)).toBe(false);
+      expect(agentByIdSelectors.usesWorkspaceMemberSelectionById('private')(state)).toBe(false);
+      expect(agentByIdSelectors.usesWorkspaceMemberSelectionById('public')(state)).toBe(true);
+    });
+  });
+
   describe('getAgentBuilderContextById', () => {
     it('should return builder context from existing agent config', () => {
       const state = createState({

--- a/src/store/agent/selectors/agentByIdSelectors.ts
+++ b/src/store/agent/selectors/agentByIdSelectors.ts
@@ -199,15 +199,23 @@ const isAgentHeterogeneousById =
  */
 const getAgentById = (agentId: string) => (s: AgentStoreState) => s.agentMap[agentId];
 
-/**
- * Workspace-scoped agent: shared across workspace members, so it executes on
- * the workspace device pool / sandbox — never on the current member's own
- * client. Feed this into `resolveExecutionTarget`'s `workspaceScoped` option.
- */
+/** Whether the agent belongs to a workspace, regardless of its visibility. */
 const isWorkspaceAgentById =
   (agentId: string) =>
   (s: AgentStoreState): boolean =>
     !!s.agentMap[agentId]?.workspaceId;
+
+/**
+ * Whether this agent uses per-member workspace preferences. Private workspace
+ * agents still have a single owner, so they read and write their agent config
+ * directly until published.
+ */
+const usesWorkspaceMemberSelectionById =
+  (agentId: string) =>
+  (s: AgentStoreState): boolean => {
+    const agent = s.agentMap[agentId];
+    return Boolean(agent?.workspaceId && agent.visibility !== 'private');
+  };
 
 export const agentByIdSelectors = {
   getAgencyConfigById,
@@ -231,4 +239,5 @@ export const agentByIdSelectors = {
   isAgentHeterogeneousById,
   isAgentNotFoundById,
   isWorkspaceAgentById,
+  usesWorkspaceMemberSelectionById,
 };

--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
@@ -1774,7 +1774,9 @@ describe('ConversationLifecycle actions', () => {
         });
 
         const { agentByIdSelectors } = await import('@/store/agent/selectors');
-        vi.spyOn(agentByIdSelectors, 'isWorkspaceAgentById').mockReturnValue(() => true);
+        vi.spyOn(agentByIdSelectors, 'usesWorkspaceMemberSelectionById').mockReturnValue(
+          () => true,
+        );
         useUserStore.setState({
           workspaceUserPreference: {
             agentDeviceOverrides: {
@@ -1815,6 +1817,61 @@ describe('ConversationLifecycle actions', () => {
         expect(executeGatewayAgent).not.toHaveBeenCalled();
       });
 
+      it('ignores a stale member device override when sending with a private workspace agent', async () => {
+        mockConstEnv.isDesktop = true;
+        setupMockSelectors({
+          agentConfig: {
+            agencyConfig: {
+              boundDeviceId: 'private-agent-device',
+              executionTarget: 'device',
+              heterogeneousProvider: { command: 'codex', type: 'codex' },
+            },
+          },
+        });
+
+        const { agentByIdSelectors } = await import('@/store/agent/selectors');
+        vi.spyOn(agentByIdSelectors, 'usesWorkspaceMemberSelectionById').mockReturnValue(
+          () => false,
+        );
+        useUserStore.setState({
+          workspaceUserPreference: {
+            agentDeviceOverrides: {
+              [TEST_IDS.SESSION_ID]: {
+                boundDeviceId: 'stale-personal-device',
+                executionTarget: 'local',
+              },
+            },
+          },
+        });
+
+        const executeGatewayAgent = vi.fn().mockResolvedValue(undefined);
+        act(() => {
+          useChatStore.setState({ executeGatewayAgent });
+        });
+
+        vi.spyOn(aiChatService, 'sendMessageInServer').mockResolvedValue({
+          assistantMessageId: TEST_IDS.ASSISTANT_MESSAGE_ID,
+          messages: [
+            createMockMessage({ id: TEST_IDS.USER_MESSAGE_ID, role: 'user' }),
+            createMockMessage({ id: TEST_IDS.ASSISTANT_MESSAGE_ID, role: 'assistant' }),
+          ],
+          topicId: TEST_IDS.TOPIC_ID,
+          topics: [],
+          userMessageId: TEST_IDS.USER_MESSAGE_ID,
+        } as any);
+
+        const { result } = renderHook(() => useChatStore());
+        await act(async () => {
+          await result.current.sendMessage({
+            message: TEST_CONTENT.USER_MESSAGE,
+            context: createTestContext(),
+          });
+        });
+
+        expect(executeGatewayAgent).toHaveBeenCalledTimes(1);
+        expect(executeHeterogeneousAgentMock).not.toHaveBeenCalled();
+      });
+
       it('keeps a workspace shared-local fallback on the gateway without a member override', async () => {
         mockConstEnv.isDesktop = true;
         setupMockSelectors({
@@ -1828,7 +1885,9 @@ describe('ConversationLifecycle actions', () => {
         });
 
         const { agentByIdSelectors } = await import('@/store/agent/selectors');
-        vi.spyOn(agentByIdSelectors, 'isWorkspaceAgentById').mockReturnValue(() => true);
+        vi.spyOn(agentByIdSelectors, 'usesWorkspaceMemberSelectionById').mockReturnValue(
+          () => true,
+        );
 
         const executeGatewayAgent = vi.fn().mockResolvedValue(undefined);
         act(() => {

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -286,14 +286,15 @@ export class ConversationLifecycleActionImpl {
 
     const agentState = getAgentStoreState();
     const agentConfig = agentSelectors.getAgentConfigById(agentId)(agentState);
-    const isWorkspaceAgent = agentByIdSelectors.isWorkspaceAgentById(agentId)(agentState);
-    const deviceOverride = isWorkspaceAgent
+    const usesWorkspaceMemberSelection =
+      agentByIdSelectors.usesWorkspaceMemberSelectionById(agentId)(agentState);
+    const deviceOverride = usesWorkspaceMemberSelection
       ? getUserStoreState().workspaceUserPreference.agentDeviceOverrides?.[agentId]
       : undefined;
-    const workspaceScoped = resolveWorkspaceScoped(isWorkspaceAgent, deviceOverride);
+    const workspaceScoped = resolveWorkspaceScoped(usesWorkspaceMemberSelection, deviceOverride);
     // Runtime selection must use the same per-user device override as the
-    // switcher. A workspace-local pick is intentionally private to this member
-    // and is therefore safe to execute in-process on their desktop.
+    // switcher. A public-workspace local pick is private to this member and is
+    // therefore safe to execute in-process on their desktop.
     const agencyConfig = resolveAgencyConfig(agentConfig?.agencyConfig, deviceOverride);
     const heterogeneousProvider = agencyConfig?.heterogeneousProvider;
     const runtimeType = selectRuntimeType({
@@ -1699,7 +1700,9 @@ export class ConversationLifecycleActionImpl {
           inPortalThread,
           isGatewayMode: this.#get().isGatewayModeEnabled(context.agentId),
           isWorkspaceAgent: context.agentId
-            ? agentByIdSelectors.isWorkspaceAgentById(context.agentId)(getAgentStoreState())
+            ? agentByIdSelectors.usesWorkspaceMemberSelectionById(context.agentId)(
+                getAgentStoreState(),
+              )
             : false,
           messages: messagesWithInstruction,
           parentOperationId: operationId,


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] 💄 style

#### 🔗 Related Issue

Related to LOBE-11689

#### 🔀 Description of Change

This PR contains two changes:

**1. Private workspace agents use shared agent config instead of per-member overrides**

Previously, all workspace agents (any agent with a `workspaceId`) routed execution-target reads and writes through per-member `workspace_user_settings.preference.agentDeviceOverrides`. This meant a **private** workspace agent — which only its owner can access — was treated as if multiple members needed isolated choices, even though there is only one user.

This introduces a new selector `usesWorkspaceMemberSelectionById` that returns `true` only when an agent has a `workspaceId` **and** `visibility !== "private"`. The following hooks/components are updated to use it:

- `useSelectExecutionTarget` — private workspace agents now write directly to `agents.agencyConfig` (like personal agents), not member overrides.
- `useEffectiveAgencyConfig` — private workspace agents skip the member-override merge and the preference-loading state.
- `useAgentModelSelection` — uses the new selector instead of inline `workspaceId + visibility` logic.
- `HeteroDeviceSwitcher` — the fixed-execution-target guard now keys off `usesWorkspaceMemberSelection` instead of `isWorkspaceAgent`.

The existing `isWorkspaceAgentById` selector is preserved for callers that genuinely need "belongs to a workspace" regardless of visibility.

**2. Move prompt description into title tooltip (EditorCanvas)**

The prompt section description text (`settingAgent.prompt.desc`) was shown as a persistent line below the title. It is now rendered inside an `InfoTooltip` next to the title, reducing visual clutter while keeping the description accessible.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

**Private workspace agent:**
- A private workspace agent owner can switch a fixed execution target; the change persists to `agents.agencyConfig` and does **not** create a `workspace_user_settings` member override.
- `useEffectiveAgencyConfig` returns `isPreferenceLoading: false` and `workspaceScoped: false` for a private workspace agent, even when a stale member override and loading state exist.

**Public workspace agent (unchanged behaviour):**
- A public workspace agent still routes device picks into per-member overrides.

**EditorCanvas:**
- The prompt description no longer appears as persistent text; an `InfoTooltip` with the description is rendered next to the title.

#### 📸 Screenshots / Videos

N/A — no visible layout change beyond the description moving into a tooltip.

#### 📝 Additional Information

The `isWorkspaceAgentById` selector remains exported for any caller that needs the broad "has a workspace" check. The new `usesWorkspaceMemberSelectionById` is the correct selector for all read/write paths that distinguish per-member vs. shared agent config.
