### PR TITLE
🐛 fix: narrow acceptance empty filter translation key

### DIFF
--- a/src/features/Verify/Acceptance/Workspace/AcceptanceListPanel.tsx
+++ b/src/features/Verify/Acceptance/Workspace/AcceptanceListPanel.tsx
@@ -63,6 +63,10 @@ import {
 const PANEL_MIN = 260;
 const PANEL_MAX = 420;
 const ACCEPTANCE_LIST_FILTER_STORAGE_KEY = 'lobehub-acceptance-list-filter';
+const EMPTY_FILTER_KEYS = {
+  active: 'acceptance.workspace.filters.empty.active',
+  completed: 'acceptance.workspace.filters.empty.completed',
+} as const satisfies Record<Exclude<AcceptanceListFilter, 'all'>, string>;
 
 const styles = createStaticStyles(({ css }) => ({
   panel: css`
@@ -625,7 +629,9 @@ const AcceptanceListPanel = memo<ReportPanelExpand>(({ expand, isNarrow, setExpa
                 <span className={styles.searchEmptyMsg}>
                   {trimmedQuery
                     ? t('acceptance.workspace.filters.noSearchResults', { query: trimmedQuery })
-                    : t(`acceptance.workspace.filters.empty.${filter}`)}
+                    : filter === 'all'
+                      ? null
+                      : t(EMPTY_FILTER_KEYS[filter])}
                 </span>
                 <button
                   className={styles.retryBtn}


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Use an explicit, exhaustive translation-key map for acceptance list empty filter states and narrow out the `all` filter before calling `t`. This prevents i18next typed-key validation from inferring the nonexistent `acceptance.workspace.filters.empty.all` key.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Validation:
- `bun run check src/features/Verify/Acceptance/Workspace/AcceptanceListPanel.tsx`
- Pre-commit stylelint, ESLint, and Prettier hooks
- The original acceptance translation-key type error no longer appears in `bun run type-check`; the full command remains blocked by unrelated missing local modules `@anthropic-ai/sandbox-runtime` and `@lobechat/device-sandbox`.

#### 📸 Screenshots / Videos

N/A — type-safety-only change with no visual behavior change.

#### 📝 Additional Information

No runtime behavior or translation resources changed.