### PR TITLE
🐛 fix(agent): stabilize builder panel layout

### DIFF
--- a/src/features/AgentBuilder/index.tsx
+++ b/src/features/AgentBuilder/index.tsx
@@ -28,6 +28,7 @@ const AgentBuilder = memo(() => {
 
   return (
     <RightPanel
+      stableLayout
       defaultWidth={width}
       expand={showAgentBuilderPanel}
       onExpandChange={toggleAgentBuilderPanel}


### PR DESCRIPTION
## Summary

- enable `stableLayout` on the Agent Builder right panel
- keep the right-panel layout stable while its expanded state changes

## Verification

- `bun run check src/features/AgentBuilder/index.tsx` passed linting; no related tests were discovered