### PR TITLE
🐛 fix + ✨ feat: brief RBAC permission fix & editor canvas prompt tooltip

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/brief.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/brief.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/database/core/db-adaptor', () => ({
+  getServerDB: vi.fn(() => ({})),
+}));
+
+// Surface the permission requested by the procedure so this test catches
+// invalid or task-router-inconsistent RBAC actions before they reach cloud.
+vi.mock('@/business/server/trpc-middlewares/rbacPermission', () => ({
+  withScopedPermission: vi.fn((code: string) => () => {
+    throw new Error(`GATE:${code}`);
+  }),
+}));
+
+const { briefRouter } = await import('../brief');
+
+const createCaller = () =>
+  briefRouter.createCaller({ serverDB: {}, userId: 'user-1', workspaceId: 'ws-1' } as any);
+
+describe('briefRouter — write permission gate', () => {
+  it('resolveManyAsRead uses the task-domain agent:update permission', async () => {
+    await expect(createCaller().resolveManyAsRead({ ids: ['brief-1'] })).rejects.toThrow(
+      'GATE:agent:update',
+    );
+  });
+});

--- a/apps/server/src/routers/lambda/brief.ts
+++ b/apps/server/src/routers/lambda/brief.ts
@@ -12,7 +12,9 @@ import { NIGHTLY_REVIEW_BRIEF_TRIGGER } from '@/server/services/agentSignal/serv
 import { BriefService } from '@/server/services/brief';
 
 const briefProcedure = wsCompatProcedure.use(serverDatabase);
-const briefWriteProcedure = briefProcedure.use(withScopedPermission('task:update'));
+// Briefs are task-domain records. Keep their write gate aligned with task
+// mutations; `task:update` is not an RBAC action and is rejected in workspace mode.
+const briefWriteProcedure = briefProcedure.use(withScopedPermission('agent:update'));
 
 const idInput = z.object({ id: z.string() });
 

--- a/locales/en-US/verify.json
+++ b/locales/en-US/verify.json
@@ -207,6 +207,7 @@
   "acceptance.workspace.filters.all": "All acceptances",
   "acceptance.workspace.filters.completed": "Completed",
   "acceptance.workspace.filters.empty.active": "No acceptances in progress.",
+  "acceptance.workspace.filters.empty.all": "No acceptances yet.",
   "acceptance.workspace.filters.empty.completed": "No completed acceptances.",
   "acceptance.workspace.filters.noSearchResults": "No acceptances match “{{query}}”.",
   "acceptance.workspace.filters.showAll": "Show all acceptances",

--- a/locales/zh-CN/verify.json
+++ b/locales/zh-CN/verify.json
@@ -207,6 +207,7 @@
   "acceptance.workspace.filters.all": "全部验收",
   "acceptance.workspace.filters.completed": "已完成",
   "acceptance.workspace.filters.empty.active": "暂无进行中的验收。",
+  "acceptance.workspace.filters.empty.all": "暂无验收。",
   "acceptance.workspace.filters.empty.completed": "暂无已完成的验收。",
   "acceptance.workspace.filters.noSearchResults": "没有与「{{query}}」匹配的验收。",
   "acceptance.workspace.filters.showAll": "显示全部验收",

--- a/packages/locales/src/default/verify.ts
+++ b/packages/locales/src/default/verify.ts
@@ -231,6 +231,7 @@ export default {
   'acceptance.workspace.filters.all': 'All acceptances',
   'acceptance.workspace.filters.completed': 'Completed',
   'acceptance.workspace.filters.empty.active': 'No acceptances in progress.',
+  'acceptance.workspace.filters.empty.all': 'No acceptances yet.',
   'acceptance.workspace.filters.empty.completed': 'No completed acceptances.',
   'acceptance.workspace.filters.noSearchResults': 'No acceptances match “{{query}}”.',
   'acceptance.workspace.filters.showAll': 'Show all acceptances',

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
@@ -105,6 +105,12 @@ vi.mock('@/components/Editor/AutoSaveHint', () => ({
   }),
 }));
 
+vi.mock('@/components/InfoTooltip', () => ({
+  default: ({ title }: { title: string }) => (
+    <button aria-label={title} data-testid="prompt-description-tooltip" type="button" />
+  ),
+}));
+
 vi.mock('@/components/AntdStaticMethods', () => ({
   message: {
     error: (...args: unknown[]) => messageError(...args),
@@ -199,6 +205,15 @@ describe('Agent profile EditorCanvas', () => {
 
     expect(editorProps.last?.lineEmptyPlaceholder).toBe('settingAgent.prompt.editorPlaceholder');
     expect(editorProps.last?.placeholder).toBe('settingAgent.prompt.editorPlaceholder');
+  });
+
+  it('moves the prompt description into the title tooltip', () => {
+    render(<EditorCanvas />);
+
+    expect(screen.queryByText('settingAgent.prompt.desc')).not.toBeInTheDocument();
+    expect(screen.getByTestId('prompt-description-tooltip')).toHaveAccessibleName(
+      'settingAgent.prompt.desc',
+    );
   });
 
   it('binds a draft save to its original agent and loads the next agent content', async () => {

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 
 import { message } from '@/components/AntdStaticMethods';
 import AutoSaveHint from '@/components/Editor/AutoSaveHint';
+import InfoTooltip from '@/components/InfoTooltip';
 import { createChatInputRichPlugins } from '@/features/ChatInput/InputEditor/plugins';
 import { EditingIndicator } from '@/features/EditLock';
 import { useResourceAccess } from '@/features/ResourcePermission/useResourceAccess';
@@ -26,11 +27,6 @@ import TypoBar from './TypoBar';
 import { useSlashItems } from './useSlashItems';
 
 const styles = createStaticStyles(({ css }) => ({
-  desc: css`
-    font-size: 13px;
-    line-height: 1.6;
-    color: ${cssVar.colorTextSecondary};
-  `,
   editorShell: css`
     min-height: 300px;
     padding-block: 18px;
@@ -47,6 +43,7 @@ const styles = createStaticStyles(({ css }) => ({
     padding-block-end: 16px;
   `,
   title: css`
+    cursor: default;
     font-size: 16px;
     font-weight: 600;
     color: ${cssVar.colorText};
@@ -320,7 +317,14 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
     <Flexbox className={styles.root} gap={16}>
       <Flexbox className={styles.header} gap={4}>
         <Flexbox horizontal align={'center'} distribution={'space-between'} gap={8}>
-          <div className={styles.title}>{t('settingAgent.prompt.title')}</div>
+          <Flexbox horizontal align={'center'} gap={6}>
+            <div className={styles.title}>{t('settingAgent.prompt.title')}</div>
+            <InfoTooltip
+              iconStyle={{ cursor: 'help' }}
+              size={'small'}
+              title={t('settingAgent.prompt.desc')}
+            />
+          </Flexbox>
           {promptSaveStatus !== 'idle' && (
             <AutoSaveHint
               lastUpdatedTime={promptLastUpdatedTime}
@@ -329,7 +333,6 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
             />
           )}
         </Flexbox>
-        <div className={styles.desc}>{t('settingAgent.prompt.desc')}</div>
       </Flexbox>
       <div
         className={styles.editorShell}


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] ✨ feat

#### 🔀 Description of Change

This PR includes two independent changes:

1. **fix(server): use `agent:update` RBAC permission for brief write procedures** — The brief write procedure was gated with `task:update`, which is not a valid RBAC action and gets rejected in workspace mode. Switched to `agent:update` to align with other agent-domain write procedures.

2. **feat: move prompt description into tooltip in agent editor canvas** — Replaced the always-visible description text below the prompt title with an `InfoTooltip` icon next to the title, reducing visual clutter while keeping the description accessible on hover.

#### 🧪 How to Test

- [x] Added/updated tests

```
bunx vitest run 'apps/server/src/routers/lambda/__tests__/brief.test.ts'
bunx vitest run 'src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx'
```

Both test suites pass.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Description text visible below title | InfoTooltip icon next to title, description on hover |
