### PR TITLE
✨ feat: move prompt description into tooltip in agent editor canvas

### DIFF
--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
@@ -105,6 +105,12 @@ vi.mock('@/components/Editor/AutoSaveHint', () => ({
   }),
 }));
 
+vi.mock('@/components/InfoTooltip', () => ({
+  default: ({ title }: { title: string }) => (
+    <button aria-label={title} data-testid="prompt-description-tooltip" type="button" />
+  ),
+}));
+
 vi.mock('@/components/AntdStaticMethods', () => ({
   message: {
     error: (...args: unknown[]) => messageError(...args),
@@ -199,6 +205,15 @@ describe('Agent profile EditorCanvas', () => {
 
     expect(editorProps.last?.lineEmptyPlaceholder).toBe('settingAgent.prompt.editorPlaceholder');
     expect(editorProps.last?.placeholder).toBe('settingAgent.prompt.editorPlaceholder');
+  });
+
+  it('moves the prompt description into the title tooltip', () => {
+    render(<EditorCanvas />);
+
+    expect(screen.queryByText('settingAgent.prompt.desc')).not.toBeInTheDocument();
+    expect(screen.getByTestId('prompt-description-tooltip')).toHaveAccessibleName(
+      'settingAgent.prompt.desc',
+    );
   });
 
   it('binds a draft save to its original agent and loads the next agent content', async () => {

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 
 import { message } from '@/components/AntdStaticMethods';
 import AutoSaveHint from '@/components/Editor/AutoSaveHint';
+import InfoTooltip from '@/components/InfoTooltip';
 import { createChatInputRichPlugins } from '@/features/ChatInput/InputEditor/plugins';
 import { EditingIndicator } from '@/features/EditLock';
 import { useResourceAccess } from '@/features/ResourcePermission/useResourceAccess';
@@ -26,11 +27,6 @@ import TypoBar from './TypoBar';
 import { useSlashItems } from './useSlashItems';
 
 const styles = createStaticStyles(({ css }) => ({
-  desc: css`
-    font-size: 13px;
-    line-height: 1.6;
-    color: ${cssVar.colorTextSecondary};
-  `,
   editorShell: css`
     min-height: 300px;
     padding-block: 18px;
@@ -47,6 +43,7 @@ const styles = createStaticStyles(({ css }) => ({
     padding-block-end: 16px;
   `,
   title: css`
+    cursor: default;
     font-size: 16px;
     font-weight: 600;
     color: ${cssVar.colorText};
@@ -320,7 +317,14 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
     <Flexbox className={styles.root} gap={16}>
       <Flexbox className={styles.header} gap={4}>
         <Flexbox horizontal align={'center'} distribution={'space-between'} gap={8}>
-          <div className={styles.title}>{t('settingAgent.prompt.title')}</div>
+          <Flexbox horizontal align={'center'} gap={6}>
+            <div className={styles.title}>{t('settingAgent.prompt.title')}</div>
+            <InfoTooltip
+              iconStyle={{ cursor: 'help' }}
+              size={'small'}
+              title={t('settingAgent.prompt.desc')}
+            />
+          </Flexbox>
           {promptSaveStatus !== 'idle' && (
             <AutoSaveHint
               lastUpdatedTime={promptLastUpdatedTime}
@@ -329,7 +333,6 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
             />
           )}
         </Flexbox>
-        <div className={styles.desc}>{t('settingAgent.prompt.desc')}</div>
       </Flexbox>
       <div
         className={styles.editorShell}


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] 💄 style

#### 🔗 Related Issue

<!-- No related issue found -->

#### 🔀 Description of Change

Replace the always-visible description text below the prompt title with an `InfoTooltip` icon placed next to the title. This reduces visual clutter in the agent editor canvas while keeping the description accessible on hover. Also sets `cursor: default` on the title style since it is no longer accompanied by a description block.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

A test is added verifying the description text is no longer rendered inline and is instead accessible via the tooltip accessible name.

```
bunx vitest run 'src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx'
```

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Description text visible below title | InfoTooltip icon next to title, description on hover |
