### PR TITLE
🐛 fix(agent): enable drag-to-collapse right panels

### DIFF
--- a/package.json
+++ b/package.json
@@ -299,7 +299,7 @@
     "@lobehub/icons": "^5.11.0",
     "@lobehub/market-sdk": "0.39.2",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "^5.23.0",
+    "@lobehub/ui": "^5.23.3",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@napi-rs/canvas": "^0.1.100",
     "@neondatabase/serverless": "^1.1.0",

--- a/src/features/AgentBuilder/index.tsx
+++ b/src/features/AgentBuilder/index.tsx
@@ -29,6 +29,7 @@ const AgentBuilder = memo(() => {
   return (
     <RightPanel
       stableLayout
+      collapseThreshold={320}
       defaultWidth={width}
       expand={showAgentBuilderPanel}
       onExpandChange={toggleAgentBuilderPanel}

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
@@ -660,6 +660,7 @@ const AgentWorkingSidebar = memo(() => {
   return (
     <RightPanel
       stableLayout
+      collapseThreshold={320}
       defaultWidth={displayWidth}
       maxWidth={MAX_PANEL_WIDTH}
       minWidth={300}


### PR DESCRIPTION
## Summary

- upgrade `@lobehub/ui` to `^5.23.3`, which contains the reversible `DraggablePanel` collapse fix
- enable a `320px` collapse threshold for the Agent Builder right panel
- enable the same drag-to-collapse behavior for the conversation Working Sidebar
- retain stable panel layout while previewing and committing collapse

## Impact

Users can drag either right panel below the threshold to close it. Before releasing the pointer, dragging back above the threshold cancels the collapse. Reopening restores the previous panel width.

## Verification

- `bun run check package.json src/features/AgentBuilder/index.tsx 'src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx'`: lint clean, 28 tests passed
- published `@lobehub/ui@5.23.3` verified in a downstream production-built browser harness
- verified threshold preview, drag-back cancellation, controlled-state synchronization, absence of a reappearance frame, and width restoration
- `git diff --check` passed

## Known unrelated issue

The repository-wide type check remains blocked by the existing Verify workspace i18n key error in `src/features/Verify/Acceptance/Workspace/AcceptanceListPanel.tsx:628`.