### PR TITLE
🔨 chore: warn on new component tests

### DIFF
--- a/.agents/scripts/check/advisories.ts
+++ b/.agents/scripts/check/advisories.ts
@@ -11,7 +11,8 @@ interface BaseFileStatus {
 type InspectBaseFile = (file: string) => Promise<BaseFileStatus | undefined>;
 
 const NEW_COMPONENT_TEST_PATTERN = /\.test\.tsx$/;
-const TESTING_SKILL_REFERENCE = '.agents/skills/testing/SKILL.md:47';
+const TESTING_SKILL_REFERENCE =
+  '.agents/skills/testing/SKILL.md (Core Principles: "No new component tests")';
 
 const createBaseFileInspector = (): InspectBaseFile => {
   const mergeBases = new Map<RepoMount, Promise<string | undefined>>();
@@ -22,6 +23,7 @@ const createBaseFileInspector = (): InspectBaseFile => {
 
     let mergeBase = mergeBases.get(mount);
     if (!mergeBase) {
+      // This advisory is best-effort: an unavailable local base skips it instead of failing checks.
       mergeBase = run('git', ['merge-base', 'HEAD', mount.baseRef], mountDir(mount)).then(
         (result) => (result.code === 0 ? result.stdout.trim() || undefined : undefined),
       );
@@ -29,6 +31,7 @@ const createBaseFileInspector = (): InspectBaseFile => {
     }
 
     const baseCommit = await mergeBase;
+    // Unlike a missing file at a valid base, an unresolved base cannot prove the file is new.
     if (!baseCommit) return;
 
     const result = await run(

--- a/.agents/scripts/check/advisories.ts
+++ b/.agents/scripts/check/advisories.ts
@@ -1,0 +1,62 @@
+import { run } from './exec';
+import { getConfig, mountDir } from './paths';
+import { resolveMount } from './routing';
+import type { RepoMount } from './types';
+
+interface BaseFileStatus {
+  baseRef: string;
+  exists: boolean;
+}
+
+type InspectBaseFile = (file: string) => Promise<BaseFileStatus | undefined>;
+
+const NEW_COMPONENT_TEST_PATTERN = /\.test\.tsx$/;
+const TESTING_SKILL_REFERENCE = '.agents/skills/testing/SKILL.md:47';
+
+const createBaseFileInspector = (): InspectBaseFile => {
+  const mergeBases = new Map<RepoMount, Promise<string | undefined>>();
+
+  return async (file) => {
+    const { mount, subPath } = resolveMount(getConfig().repos, file);
+    if (!mount.baseRef) return;
+
+    let mergeBase = mergeBases.get(mount);
+    if (!mergeBase) {
+      mergeBase = run('git', ['merge-base', 'HEAD', mount.baseRef], mountDir(mount)).then(
+        (result) => (result.code === 0 ? result.stdout.trim() || undefined : undefined),
+      );
+      mergeBases.set(mount, mergeBase);
+    }
+
+    const baseCommit = await mergeBase;
+    if (!baseCommit) return;
+
+    const result = await run(
+      'git',
+      ['cat-file', '-e', `${baseCommit}:${subPath}`],
+      mountDir(mount),
+    );
+
+    return {
+      baseRef: mount.baseRef,
+      exists: result.code === 0,
+    };
+  };
+};
+
+export const findNewComponentTestAdvisories = async (
+  files: string[],
+  inspectBaseFile: InspectBaseFile = createBaseFileInspector(),
+): Promise<string[]> => {
+  const candidates = [...new Set(files.filter((file) => NEW_COMPONENT_TEST_PATTERN.test(file)))];
+  const statuses = await Promise.all(candidates.map((file) => inspectBaseFile(file)));
+
+  return candidates.flatMap((file, index) => {
+    const status = statuses[index];
+    if (!status || status.exists) return [];
+
+    return [
+      `${file}: new .test.tsx file relative to ${status.baseRef}. New React component tests are not allowed; extract complex logic into a hook and test it in .test.ts instead (${TESTING_SKILL_REFERENCE}).`,
+    ];
+  });
+};

--- a/.agents/scripts/check/check.test.ts
+++ b/.agents/scripts/check/check.test.ts
@@ -146,7 +146,9 @@ describe('findNewComponentTestAdvisories', () => {
     expect(advisories).toEqual([
       expect.stringContaining('src/New.test.tsx: new .test.tsx file relative to origin/canary'),
     ]);
-    expect(advisories[0]).toContain('.agents/skills/testing/SKILL.md:47');
+    expect(advisories[0]).toContain(
+      '.agents/skills/testing/SKILL.md (Core Principles: "No new component tests")',
+    );
   });
 
   it('skips the warning when the configured base cannot be inspected', async () => {

--- a/.agents/scripts/check/check.test.ts
+++ b/.agents/scripts/check/check.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
+import { findNewComponentTestAdvisories } from './advisories';
 import { diffStat, renderDiffsForStdout } from './autofix';
 import { hostRootFromGitdir } from './delegate';
 import { lobehubPipelines } from './pipelines';
@@ -129,6 +130,29 @@ describe('relatedTestCandidates', () => {
   it('returns nothing for non-source files', () => {
     expect(relatedTestCandidates('AGENTS.md')).toEqual([]);
     expect(relatedTestCandidates('image.png')).toEqual([]);
+  });
+});
+
+describe('findNewComponentTestAdvisories', () => {
+  it('warns only for new .test.tsx files', async () => {
+    const advisories = await findNewComponentTestAdvisories(
+      ['src/New.test.tsx', 'src/Existing.test.tsx', 'src/useFeature.test.ts'],
+      async (file) => ({
+        baseRef: 'origin/canary',
+        exists: file.includes('Existing'),
+      }),
+    );
+
+    expect(advisories).toEqual([
+      expect.stringContaining('src/New.test.tsx: new .test.tsx file relative to origin/canary'),
+    ]);
+    expect(advisories[0]).toContain('.agents/skills/testing/SKILL.md:47');
+  });
+
+  it('skips the warning when the configured base cannot be inspected', async () => {
+    await expect(
+      findNewComponentTestAdvisories(['src/New.test.tsx'], async () => undefined),
+    ).resolves.toEqual([]);
   });
 });
 

--- a/.agents/scripts/check/cli.ts
+++ b/.agents/scripts/check/cli.ts
@@ -28,7 +28,10 @@ const main = async () => {
     return;
   }
 
-  await runCli({ repos: [{ dir: '', pipelines: lobehubPipelines }], rootDir });
+  await runCli({
+    repos: [{ baseRef: 'origin/canary', dir: '', pipelines: lobehubPipelines }],
+    rootDir,
+  });
 };
 
 main().catch((error) => {

--- a/.agents/scripts/check/index.ts
+++ b/.agents/scripts/check/index.ts
@@ -19,6 +19,7 @@
  * mounting this repo provides its own entry that adds its root pipelines and
  * mounts this repo's via `pipelines.ts`.
  */
+import { findNewComponentTestAdvisories } from './advisories';
 import { collectAutofixDiffs, snapshot, writeFullDiff } from './autofix';
 import { collectFromGit, normalizeArgs } from './collect';
 import { run } from './exec';
@@ -126,6 +127,8 @@ export const runCli = async (config: CheckConfig) => {
     tests = await runTestGroups(testFiles);
   }
 
+  const advisories = await findNewComponentTestAdvisories([...new Set([...files, ...testFiles])]);
+
   /* ---- Type check ---- */
   let typeOutput: string | null = null;
   if (runType) {
@@ -135,6 +138,7 @@ export const runCli = async (config: CheckConfig) => {
 
   const fullDiffPath = diffs.length > 0 ? await writeFullDiff(diffs) : null;
   const { failed } = printReport({
+    advisories,
     diffs,
     fatal,
     fileCount: files.length,

--- a/.agents/scripts/check/report.ts
+++ b/.agents/scripts/check/report.ts
@@ -2,6 +2,7 @@ import { renderDiffsForStdout } from './autofix';
 import type { FileDiff, LintProblem, TestOutcome } from './types';
 
 export interface ReportInput {
+  advisories: string[];
   diffs: FileDiff[];
   fatal: string[];
   fileCount: number;
@@ -21,6 +22,7 @@ export interface ReportInput {
 /** Print the compact report; the summary line mentions only checks that ran. */
 export const printReport = (input: ReportInput): { failed: boolean } => {
   const {
+    advisories,
     diffs,
     fatal,
     fileCount,
@@ -65,6 +67,7 @@ export const printReport = (input: ReportInput): { failed: boolean } => {
     );
   }
   if (typeOutput !== null) parts.push(typeOutput ? 'types failed' : 'types clean');
+  if (advisories.length > 0) parts.push(`${advisories.length} advisories`);
   if (skipped > 0) parts.push(`${skipped} skipped (no linter)`);
 
   console.log(`${failed ? '✗' : '✓'} ${parts.join(' · ')}`);
@@ -77,6 +80,11 @@ export const printReport = (input: ReportInput): { failed: boolean } => {
       );
   }
   for (const message of fatal) console.log(`\nlint fatal:\n${message}`);
+
+  if (advisories.length > 0) {
+    console.log('\nadvisories:');
+    for (const advisory of advisories) console.log(`⚠ ${advisory}`);
+  }
 
   if (tests && tests.failedOutput.length > 0)
     console.log(`\ntests:\n${tests.failedOutput.join('\n\n')}`);

--- a/.agents/scripts/check/types.ts
+++ b/.agents/scripts/check/types.ts
@@ -7,6 +7,8 @@ export interface PipelineEntry {
 
 /** A repository participating in the check: the host root or a vendored sub-repo. */
 export interface RepoMount {
+  /** Base ref used to decide whether a selected file is newly added in this PR. */
+  baseRef?: string;
   /** Root-relative directory of the repo; '' means the host repo itself. */
   dir: string;
   pipelines: PipelineEntry[];


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Add a non-failing `bun run check` advisory for newly added `.test.tsx` files.
- Compare selected test files with each repository mount's PR base using the local merge base.
- Point the advisory to the testing guideline that recommends extracting complex logic into hooks and testing it in `.test.ts`.
- Allow host repositories to configure their own base refs while standalone LobeHub uses `origin/canary`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check --test lobehub/.agents/scripts/check/check.test.ts` from the Cloud host checkout: 21 passed.
- Verified a new `.test.tsx` prints `1 advisories` and the testing-skill guidance without failing the check.
- Verified existing `.test.tsx` files and `.test.ts` files do not produce the advisory.

#### 📝 Additional Information

- The advisory is intentionally non-blocking; it surfaces policy guidance without changing lint or test exit status.
