### PR TITLE
✨ feat: support iterative onboarding understanding

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/user.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/user.test.ts
@@ -26,6 +26,7 @@ const mockAfterTasks = vi.hoisted((): Promise<void>[] => []);
 const mockUnderstandingService = vi.hoisted(() => ({
   confirm: vi.fn(),
   get: vi.fn(),
+  revise: vi.fn(),
   retry: vi.fn(),
   start: vi.fn(),
 }));
@@ -166,6 +167,15 @@ describe('userRouter', () => {
         'confirmOnboardingUnderstanding',
         { resultId: 'result-1', sessionId: 'session-1', topicId: 'topic-1' },
       ],
+      [
+        'reviseOnboardingUnderstanding',
+        {
+          feedback: 'Focus on infrastructure.',
+          providerIds: ['gmail'],
+          sessionId: 'session-1',
+          topicId: 'topic-1',
+        },
+      ],
     ] as const)('denies workspace access to %s', async (procedure, input) => {
       const caller = userRouter.createCaller(workspaceCtx);
 
@@ -203,6 +213,29 @@ describe('userRouter', () => {
         topicId: 'topic-1',
       });
       expect(result).toEqual(pollingResult);
+    });
+
+    /**
+     * @example
+     * expect(result.status).toBe('processing');
+     */
+    it('delegates cumulative feedback and additive sources', async () => {
+      mockUnderstandingService.revise.mockResolvedValueOnce({
+        ...pollingResult,
+        status: 'processing',
+      });
+      const input = {
+        expectedFeedbackRevision: 0,
+        feedback: 'Focus on infrastructure.',
+        providerIds: ['gmail'],
+        sessionId: 'session-1',
+        topicId: 'topic-1',
+      };
+
+      const result = await userRouter.createCaller(scopedCtx).reviseOnboardingUnderstanding(input);
+
+      expect(mockUnderstandingService.revise).toHaveBeenCalledWith(input);
+      expect(result).toMatchObject({ status: 'processing' });
     });
 
     it('delegates confirmation and returns the created persona version', async () => {

--- a/apps/server/src/routers/lambda/user.ts
+++ b/apps/server/src/routers/lambda/user.ts
@@ -17,11 +17,15 @@ import type {
   OnboardingUnderstandingPollingResult,
   OnboardingUnderstandingTopicInput,
   RetryOnboardingUnderstandingProviderInput,
+  ReviseOnboardingUnderstandingInput,
+  StartOnboardingUnderstandingInput,
   UserInitializationState,
   UserPreference,
   UserSettings,
 } from '@lobechat/types';
 import {
+  MAX_COLLECTION_COUNT,
+  MAX_UNDERSTANDING_FEEDBACK_LENGTH,
   Plans,
   SaveUserQuestionInputSchema,
   UserAgentOnboardingSchema,
@@ -115,6 +119,22 @@ const understandingIdSchema = z.string().trim().min(1).max(512);
 const onboardingUnderstandingTopicInputSchema = z
   .object({ topicId: understandingIdSchema })
   .strict() satisfies z.ZodType<OnboardingUnderstandingTopicInput>;
+const startOnboardingUnderstandingInputSchema = z
+  .object({
+    providerIds: z
+      .array(
+        z
+          .string()
+          .trim()
+          .min(1)
+          .max(64)
+          .regex(/^[\w-]+$/),
+      )
+      .max(16)
+      .optional(),
+    topicId: understandingIdSchema,
+  })
+  .strict() satisfies z.ZodType<StartOnboardingUnderstandingInput>;
 const retryOnboardingUnderstandingSourceInputSchema = z
   .object({
     providerId: understandingIdSchema,
@@ -129,6 +149,24 @@ const confirmOnboardingUnderstandingInputSchema = z
     topicId: understandingIdSchema,
   })
   .strict() satisfies z.ZodType<ConfirmOnboardingUnderstandingInput>;
+const reviseOnboardingUnderstandingInputSchema = z
+  .object({
+    expectedFeedbackRevision: z.number().int().nonnegative().max(MAX_COLLECTION_COUNT),
+    feedback: z.string().trim().min(1).max(MAX_UNDERSTANDING_FEEDBACK_LENGTH).optional(),
+    providerIds: z
+      .array(
+        z
+          .string()
+          .trim()
+          .min(1)
+          .max(64)
+          .regex(/^[\w-]+$/),
+      )
+      .max(16),
+    sessionId: understandingIdSchema,
+    topicId: understandingIdSchema,
+  })
+  .strict() satisfies z.ZodType<ReviseOnboardingUnderstandingInput>;
 
 const AVATAR_WEBAPI_PREFIX = '/webapi/';
 const OWNER_SETTING_KEYS = ['defaultAgent', 'image', 'memory', 'systemAgent', 'tts'] as const;
@@ -317,6 +355,12 @@ export const userRouter = router({
     return ctx.userModel.deleteSetting();
   }),
 
+  reviseOnboardingUnderstanding: understandingServiceProcedure
+    .input(reviseOnboardingUnderstandingInputSchema)
+    .mutation(async ({ ctx, input }): Promise<OnboardingUnderstandingPollingResult> => {
+      return ctx.understandingService.revise(input);
+    }),
+
   retryOnboardingUnderstandingSource: understandingServiceProcedure
     .input(retryOnboardingUnderstandingSourceInputSchema)
     .mutation(async ({ ctx, input }): Promise<OnboardingUnderstandingPollingResult> => {
@@ -324,9 +368,11 @@ export const userRouter = router({
     }),
 
   startOnboardingUnderstanding: understandingServiceProcedure
-    .input(onboardingUnderstandingTopicInputSchema)
+    .input(startOnboardingUnderstandingInputSchema)
     .mutation(async ({ ctx, input }): Promise<OnboardingUnderstandingPollingResult> => {
-      return ctx.understandingService.start(input.topicId);
+      return input.providerIds
+        ? ctx.understandingService.start(input.topicId, input.providerIds)
+        : ctx.understandingService.start(input.topicId);
     }),
 
   updateAvatar: userProcedure.input(z.string()).mutation(async ({ ctx, input }) => {

--- a/apps/server/src/services/understanding/service.test.ts
+++ b/apps/server/src/services/understanding/service.test.ts
@@ -12,15 +12,19 @@ import { UnderstandingService, type UnderstandingServiceDependencies } from './s
 import type { StoredUnderstandingProviderContext } from './sourceStore';
 import type { UnderstandingProvider } from './types';
 
-const { mockAssertWorkflowAvailable, mockTriggerProviders } = vi.hoisted(() => ({
-  mockAssertWorkflowAvailable: vi.fn(),
-  mockTriggerProviders: vi.fn(),
-}));
+const { mockAssertWorkflowAvailable, mockTriggerProviders, mockTriggerWriting } = vi.hoisted(
+  () => ({
+    mockAssertWorkflowAvailable: vi.fn(),
+    mockTriggerProviders: vi.fn(),
+    mockTriggerWriting: vi.fn(),
+  }),
+);
 
 vi.mock('@/server/workflows/onboardingUnderstanding', () => ({
   OnboardingUnderstandingWorkflow: {
     assertAvailable: mockAssertWorkflowAvailable,
     triggerProviders: mockTriggerProviders,
+    triggerWriting: mockTriggerWriting,
   },
 }));
 
@@ -132,6 +136,37 @@ const createHarness = (initialSession?: OnboardingUnderstandingSession) => {
     ),
     confirm: vi.fn(async () => ({ personaVersion: 1 })),
     expireProviderContexts: vi.fn(async () => session!),
+    extend: vi.fn(
+      async ({ feedback, providerIds }: { feedback?: string; providerIds: string[] }) => {
+        const currentFeedback = session?.feedback ?? { revision: 0, turns: [] };
+        const nextRevision = feedback ? currentFeedback.revision + 1 : currentFeedback.revision;
+        session = {
+          ...session!,
+          feedback: {
+            revision: nextRevision,
+            turns: feedback
+              ? [
+                  ...currentFeedback.turns,
+                  {
+                    content: feedback,
+                    createdAt: '2026-07-24T00:00:00.000Z',
+                    revision: nextRevision,
+                  },
+                ]
+              : currentFeedback.turns,
+          },
+          sources: {
+            ...session!.sources,
+            ...Object.fromEntries(
+              providerIds
+                .filter((providerId) => !session!.sources[providerId])
+                .map((providerId) => [providerId, providerState('pending')]),
+            ),
+          },
+        };
+        return session;
+      },
+    ),
     failProvider: vi.fn(async () => session!),
     failWriting: vi.fn(async ({ error, sourceFingerprint }) => {
       session = {
@@ -163,16 +198,21 @@ const createHarness = (initialSession?: OnboardingUnderstandingSession) => {
       return { revision };
     }),
     prepareWriting: vi.fn(async ({ sourceFingerprint, threadId }) => {
+      const feedbackRevision = session?.feedback?.revision ?? 0;
+      const generationRevision = (session?.generationRevision ?? 0) + 1;
       session = {
         ...session!,
+        generationRevision,
         writing: {
+          feedbackRevision,
+          generationRevision,
           resultMessageId: session?.writing?.resultMessageId,
           sourceFingerprint,
           status: 'running',
           updatedAt: '2026-07-20T00:00:00.000Z',
         },
       };
-      return { ready: true, threadId };
+      return { feedbackRevision, generationRevision, ready: true, threadId };
     }),
   };
   const sourceStore = {
@@ -247,6 +287,100 @@ describe('UnderstandingService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockTriggerProviders.mockResolvedValue({ workflowRunId: 'workflow-1' });
+    mockTriggerWriting.mockResolvedValue({ workflowRunId: 'workflow-writing-1' });
+  });
+
+  /**
+   * @example
+   * expect(result.feedback?.revision).toBe(1);
+   */
+  it('submits cumulative feedback and only newly added sources', async () => {
+    const harness = createHarness(createSession({ github: providerState('completed', 1) }));
+    harness.stored.set('github:1', storedContext('github', '# GitHub'));
+
+    await expect(
+      harness.service.revise({
+        expectedFeedbackRevision: 0,
+        feedback: 'Focus on infrastructure.',
+        providerIds: ['github', 'gmail'],
+        sessionId: 'session-1',
+        topicId: 'topic-1',
+      }),
+    ).resolves.toMatchObject({
+      feedback: { revision: 1 },
+      sources: {
+        github: { status: 'completed' },
+        gmail: { status: 'pending' },
+      },
+    });
+
+    expect(harness.repository.extend).toHaveBeenCalledWith({
+      expectedFeedbackRevision: 0,
+      feedback: 'Focus on infrastructure.',
+      providerIds: ['github', 'gmail'],
+      sessionId: 'session-1',
+      topicId: 'topic-1',
+    });
+    expect(mockTriggerProviders).toHaveBeenCalledWith(
+      {
+        providers: [{ id: 'gmail', revision: 1 }],
+        sessionId: 'session-1',
+        topicId: 'topic-1',
+        userId: 'user-1',
+      },
+      expect.objectContaining({
+        workflowRunId: expect.stringContaining('onboarding-understanding-extend-session-1'),
+      }),
+    );
+    expect(mockTriggerWriting).toHaveBeenCalledWith(
+      {
+        sessionId: 'session-1',
+        sourceFingerprint: 'github@1',
+        topicId: 'topic-1',
+        userId: 'user-1',
+      },
+      expect.any(Object),
+    );
+  });
+
+  /**
+   * @example
+   * expect(provider.revision).toBe(2);
+   */
+  it('automatically recollects included sources whose Redis context expired', async () => {
+    const harness = createHarness(createSession({ github: providerState('completed', 1) }));
+    harness.repository.expireProviderContexts.mockImplementationOnce(async () => {
+      const expired = createSession({ github: providerState('failed', 1) });
+      harness.setSession(expired);
+      return expired;
+    });
+
+    await harness.service.revise({
+      expectedFeedbackRevision: 0,
+      feedback: 'Focus on infrastructure.',
+      providerIds: [],
+      sessionId: 'session-1',
+      topicId: 'topic-1',
+    });
+
+    expect(harness.repository.expireProviderContexts).toHaveBeenCalledWith({
+      providers: [{ providerId: 'github', revision: 1 }],
+      sessionId: 'session-1',
+      sourceFingerprint: 'github@1',
+      topicId: 'topic-1',
+    });
+    expect(harness.repository.markProviderRunning).toHaveBeenCalledWith(
+      'topic-1',
+      'session-1',
+      'github',
+    );
+    expect(mockTriggerProviders).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providers: [{ id: 'github', revision: 2 }],
+      }),
+      expect.any(Object),
+    );
+    expect(mockTriggerWriting).not.toHaveBeenCalled();
   });
 
   it('starts static providers with deterministic pending revisions', async () => {
@@ -267,6 +401,27 @@ describe('UnderstandingService', () => {
         userId: 'user-1',
       },
       { workflowRunId: 'onboarding-understanding-initial-session-new' },
+    );
+  });
+
+  /**
+   * @example
+   * expect(result.sources.gmail).toBeUndefined();
+   */
+  it('starts only the connected providers selected by the onboarding UI', async () => {
+    const harness = createHarness();
+
+    await expect(harness.service.start('topic-1', ['github'])).resolves.toMatchObject({
+      sources: { github: { status: 'pending' } },
+    });
+    expect(harness.repository.initialize).toHaveBeenCalledWith('topic-1', 'session-new', [
+      'github',
+    ]);
+    expect(mockTriggerProviders).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providers: [{ id: 'github', revision: 1 }],
+      }),
+      expect.any(Object),
     );
   });
 
@@ -384,6 +539,50 @@ describe('UnderstandingService', () => {
     expect(JSON.parse(createdMessage.content)).toEqual(analysis);
   });
 
+  /**
+   * @example
+   * expect(writerInput.messages[0].content).toContain('Focus on infrastructure.');
+   */
+  it('includes cumulative user feedback in writer instructions', async () => {
+    const harness = createHarness({
+      feedback: {
+        revision: 2,
+        turns: [
+          {
+            content: 'Focus on infrastructure.',
+            createdAt: '2026-07-24T00:00:00.000Z',
+            revision: 1,
+          },
+          {
+            content: 'Do not infer interests from newsletters.',
+            createdAt: '2026-07-24T00:01:00.000Z',
+            revision: 2,
+          },
+        ],
+      },
+      id: 'session-1',
+      sources: { github: providerState('completed', 1) },
+    });
+    harness.stored.set('github:1', storedContext('github', '# GitHub'));
+
+    await harness.service.processCollected({
+      expectedSourceFingerprint: 'github@1',
+      sessionId: 'session-1',
+      topicId: 'topic-1',
+    });
+
+    const writerInput = harness.generateObject.mock.calls[0][0];
+    expect(writerInput.messages[0].content).toContain('Focus on infrastructure.');
+    expect(writerInput.messages[0].content).toContain('Do not infer interests from newsletters.');
+    expect(writerInput.messages[1].content).not.toContain('Focus on infrastructure.');
+    expect(harness.repository.commitWriting).toHaveBeenCalledWith(
+      expect.objectContaining({
+        feedbackRevision: 2,
+        generationRevision: 1,
+      }),
+    );
+  });
+
   it('polls without resolving the writer agent', async () => {
     const harness = createHarness(createSession({ github: providerState('completed', 1) }));
 
@@ -394,7 +593,7 @@ describe('UnderstandingService', () => {
     expect(harness.generateObject).not.toHaveBeenCalled();
   });
 
-  it('records a current writing failure before prepareWriting runs', async () => {
+  it('ignores a writing failure before a generation is prepared', async () => {
     const harness = createHarness(createSession({ github: providerState('completed', 1) }));
 
     await expect(
@@ -403,10 +602,9 @@ describe('UnderstandingService', () => {
         sourceFingerprint: 'github@1',
         topicId: 'topic-1',
       }),
-    ).resolves.toMatchObject({
-      writing: { sourceFingerprint: 'github@1', status: 'failed' },
-    });
+    ).resolves.toBeUndefined();
     expect(harness.repository.prepareWriting).not.toHaveBeenCalled();
+    expect(harness.repository.failWriting).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/apps/server/src/services/understanding/service.ts
+++ b/apps/server/src/services/understanding/service.ts
@@ -22,6 +22,8 @@ import type {
   OnboardingUnderstandingPollingResult,
   OnboardingUnderstandingSession,
   RetryOnboardingUnderstandingProviderInput,
+  ReviseOnboardingUnderstandingInput,
+  UnderstandingFeedbackTurn,
 } from '@lobechat/types';
 import {
   MAX_COLLECTION_ERRORS,
@@ -73,6 +75,7 @@ type UnderstandingRepository = Pick<
   | 'completeProvider'
   | 'confirm'
   | 'expireProviderContexts'
+  | 'extend'
   | 'failProvider'
   | 'failWriting'
   | 'get'
@@ -140,11 +143,13 @@ const parseStoredAnalysis = (content: unknown) => {
   }
 };
 
-const writingThreadId = (sessionId: string, sourceFingerprint: string) =>
+const writingThreadId = (sessionId: string, sourceFingerprint: string, feedbackRevision: number) =>
   `thd_${createHash('sha256')
     .update(sessionId)
     .update('\0')
     .update(sourceFingerprint)
+    .update('\0')
+    .update(String(feedbackRevision))
     .digest('hex')
     .slice(0, 24)}`;
 
@@ -212,22 +217,30 @@ const storedProposal = (metadata: unknown) => {
 export class UnderstandingService {
   constructor(private readonly dependencies: UnderstandingServiceDependencies) {}
 
-  private initialize = async (topicId: string): Promise<OnboardingUnderstandingSession> => {
+  private initialize = async (
+    topicId: string,
+    selectedProviderIds?: string[],
+  ): Promise<OnboardingUnderstandingSession> => {
     await this.dependencies.topic.assertActiveOnboardingTopic(topicId);
     const current = await this.dependencies.repository.get(topicId);
     if (current) return current;
-    return this.dependencies.repository.initialize(
-      topicId,
-      this.dependencies.ids(),
-      [...this.dependencies.providers.keys()].sort(),
-    );
+    const providerIds = selectedProviderIds
+      ? [...new Set(selectedProviderIds)].sort()
+      : [...this.dependencies.providers.keys()].sort();
+    if (providerIds.some((providerId) => !this.dependencies.providers.has(providerId))) {
+      throw new UnderstandingResourceNotFoundError('session');
+    }
+    return this.dependencies.repository.initialize(topicId, this.dependencies.ids(), providerIds);
   };
 
-  start = async (topicId: string): Promise<OnboardingUnderstandingPollingResult> => {
+  start = async (
+    topicId: string,
+    selectedProviderIds?: string[],
+  ): Promise<OnboardingUnderstandingPollingResult> => {
     const { OnboardingUnderstandingWorkflow } =
       await import('@/server/workflows/onboardingUnderstanding');
     OnboardingUnderstandingWorkflow.assertAvailable();
-    const session = await this.initialize(topicId);
+    const session = await this.initialize(topicId, selectedProviderIds);
     const providers = Object.entries(session.sources)
       .filter(([, state]) => state.status === 'pending')
       .toSorted(([left], [right]) => left.localeCompare(right))
@@ -246,6 +259,109 @@ export class UnderstandingService {
     return this.get(topicId);
   };
 
+  revise = async (
+    input: ReviseOnboardingUnderstandingInput,
+  ): Promise<OnboardingUnderstandingPollingResult> => {
+    const { OnboardingUnderstandingWorkflow } =
+      await import('@/server/workflows/onboardingUnderstanding');
+    OnboardingUnderstandingWorkflow.assertAvailable();
+    const current = await this.activeSession(input.topicId, input.sessionId);
+    const providerIds = [...new Set(input.providerIds)].sort();
+    if (providerIds.some((providerId) => !this.dependencies.providers.has(providerId))) {
+      throw new UnderstandingResourceNotFoundError('session');
+    }
+
+    const next = await this.dependencies.repository.extend({
+      expectedFeedbackRevision: input.expectedFeedbackRevision,
+      feedback: input.feedback,
+      providerIds,
+      sessionId: input.sessionId,
+      topicId: input.topicId,
+    });
+    const addedProviders = providerIds
+      .filter((providerId) => !current.sources[providerId])
+      .map((id) => ({ id, revision: 1 }));
+    const completedProviders = Object.entries(next.sources).filter(
+      ([, state]) => state.status === 'completed',
+    );
+    const sourceStore = completedProviders.length > 0 ? this.dependencies.sourceStore() : undefined;
+    const storedContexts = sourceStore
+      ? await Promise.all(
+          completedProviders.map(([providerId, state]) =>
+            sourceStore.get({
+              providerId,
+              revision: state.revision,
+              sessionId: input.sessionId,
+              userId: this.dependencies.userId,
+            }),
+          ),
+        )
+      : [];
+    const expiredProviders = completedProviders.flatMap(([providerId, state], index) =>
+      storedContexts[index] ? [] : [{ providerId, revision: state.revision }],
+    );
+    const currentSourceFingerprint = getUnderstandingSourceFingerprint(next);
+    const availableSession =
+      expiredProviders.length > 0 && currentSourceFingerprint
+        ? await this.dependencies.repository.expireProviderContexts({
+            providers: expiredProviders,
+            sessionId: input.sessionId,
+            sourceFingerprint: currentSourceFingerprint,
+            topicId: input.topicId,
+          })
+        : next;
+    const recollectedProviders = await Promise.all(
+      expiredProviders.map(async ({ providerId }) => ({
+        id: providerId,
+        ...(await this.dependencies.repository.markProviderRunning(
+          input.topicId,
+          input.sessionId,
+          providerId,
+        )),
+      })),
+    );
+    const providerAttempts = [...addedProviders, ...recollectedProviders].sort((left, right) =>
+      left.id.localeCompare(right.id),
+    );
+    if (providerAttempts.length > 0) {
+      await OnboardingUnderstandingWorkflow.triggerProviders(
+        {
+          providers: providerAttempts,
+          sessionId: input.sessionId,
+          topicId: input.topicId,
+          userId: this.dependencies.userId,
+        },
+        {
+          workflowRunId: `onboarding-understanding-extend-${input.sessionId}-${next.feedback?.revision ?? 0}-${providerAttempts.map(({ id, revision }) => `${id}-${revision}`).join('-')}`,
+        },
+      );
+    }
+
+    const sourceFingerprint = getUnderstandingSourceFingerprint(availableSession);
+    if (input.feedback?.trim() && sourceFingerprint) {
+      await OnboardingUnderstandingWorkflow.triggerWriting(
+        {
+          sessionId: input.sessionId,
+          sourceFingerprint,
+          topicId: input.topicId,
+          userId: this.dependencies.userId,
+        },
+        {
+          workflowRunId: `onboarding-understanding-feedback-${createHash('sha256')
+            .update(input.sessionId)
+            .update('\0')
+            .update(sourceFingerprint)
+            .update('\0')
+            .update(String(next.feedback?.revision ?? 0))
+            .digest('hex')
+            .slice(0, 32)}`,
+        },
+      );
+    }
+
+    return this.get(input.topicId);
+  };
+
   get = async (topicId: string): Promise<OnboardingUnderstandingPollingResult> => {
     await this.dependencies.topic.assertActiveOnboardingTopic(topicId);
     const session = await this.dependencies.repository.get(topicId);
@@ -256,6 +372,9 @@ export class UnderstandingService {
       proposal = storedProposal(message?.metadata);
     }
     return {
+      confirmed: Boolean(session.confirmedAt),
+      feedback: session.feedback,
+      generationRevision: session.generationRevision,
       id: session.id,
       ...(proposal ? { proposal } : {}),
       sources: session.sources,
@@ -461,11 +580,13 @@ export class UnderstandingService {
     topicId,
   }: ProcessCollectedInput) => {
     const session = await this.activeSession(topicId, sessionId);
+    const feedback = session.feedback ?? { revision: 0, turns: [] };
     if (getUnderstandingSourceFingerprint(session) !== expectedSourceFingerprint) {
       return { published: false as const, sourceFingerprint: expectedSourceFingerprint };
     }
     if (
       session.writing?.sourceFingerprint === expectedSourceFingerprint &&
+      (session.writing.feedbackRevision ?? 0) === feedback.revision &&
       session.writing.status === 'completed'
     ) {
       return {
@@ -503,10 +624,11 @@ export class UnderstandingService {
     }
 
     const sourceContexts = contexts as StoredUnderstandingProviderContext[];
-    const threadId = writingThreadId(sessionId, expectedSourceFingerprint);
+    const threadId = writingThreadId(sessionId, expectedSourceFingerprint, feedback.revision);
     const writerAgent = await this.dependencies.writerAgent();
     const prepared = await this.dependencies.repository.prepareWriting({
       agentId: writerAgent.id,
+      expectedFeedbackRevision: feedback.revision,
       sessionId,
       sourceFingerprint: expectedSourceFingerprint,
       threadId,
@@ -521,6 +643,7 @@ export class UnderstandingService {
     const writerResult = await this.runWriter({
       contexts: sourceContexts,
       diagnostics,
+      feedback: feedback.turns,
       providers,
       threadId,
       topicId,
@@ -529,6 +652,8 @@ export class UnderstandingService {
     const metadata = OnboardingUnderstandingMessageMetadataSchema.parse({
       analysis: writerResult.analysis,
       diagnostics,
+      feedbackRevision: prepared.feedbackRevision,
+      generationRevision: prepared.generationRevision,
       kind: 'proposal',
       providers,
       resultId: writerResult.assistantMessageId,
@@ -536,6 +661,8 @@ export class UnderstandingService {
     });
     const committed = await this.dependencies.repository.commitWriting({
       assistantMessageId: writerResult.assistantMessageId,
+      feedbackRevision: prepared.feedbackRevision,
+      generationRevision: prepared.generationRevision,
       metadata,
       sessionId,
       sourceFingerprint: expectedSourceFingerprint,
@@ -565,6 +692,8 @@ export class UnderstandingService {
     topicId: string;
   }) => {
     try {
+      const current = await this.activeSession(topicId, sessionId);
+      if (!current.writing || current.writing.sourceFingerprint !== sourceFingerprint) return;
       const session = await this.dependencies.repository.failWriting({
         error: canonicalCollectionError(
           'understanding',
@@ -572,6 +701,8 @@ export class UnderstandingService {
           'UNDERSTANDING_WRITING_FAILED',
           true,
         ),
+        feedbackRevision: current.writing.feedbackRevision ?? 0,
+        generationRevision: current.writing.generationRevision ?? 0,
         sessionId,
         sourceFingerprint,
         topicId,
@@ -639,6 +770,7 @@ export class UnderstandingService {
   private runWriter = async ({
     contexts,
     diagnostics,
+    feedback,
     providers,
     threadId,
     topicId,
@@ -646,6 +778,7 @@ export class UnderstandingService {
   }: {
     contexts: StoredUnderstandingProviderContext[];
     diagnostics: CollectionDiagnostics;
+    feedback: UnderstandingFeedbackTurn[];
     providers: string[];
     threadId: string;
     topicId: string;
@@ -666,7 +799,10 @@ export class UnderstandingService {
       await this.dependencies.generator.generateObject(
         {
           messages: [
-            { content: chainUnderstandingPersona({ diagnostics, providers }), role: 'system' },
+            {
+              content: chainUnderstandingPersona({ diagnostics, feedback, providers }),
+              role: 'system',
+            },
             {
               content: [
                 'Write onboarding persona from collected provider contexts.',

--- a/apps/server/src/workflows/onboardingUnderstanding/index.test.ts
+++ b/apps/server/src/workflows/onboardingUnderstanding/index.test.ts
@@ -68,6 +68,31 @@ describe('OnboardingUnderstandingWorkflow', () => {
     );
   });
 
+  /**
+   * @example
+   * expect(trigger.url).toContain('process-collected');
+   */
+  it('triggers a direct rewrite for feedback-only revisions', async () => {
+    const { OnboardingUnderstandingWorkflow } = await import('.');
+    const payload = {
+      sessionId: 'session-1',
+      sourceFingerprint: 'github@1',
+      topicId: 'topic-1',
+      userId: 'user-1',
+    };
+
+    await OnboardingUnderstandingWorkflow.triggerWriting(payload, {
+      workflowRunId: 'feedback-session-1-revision-2',
+    });
+
+    expect(triggerMock).toHaveBeenCalledWith({
+      body: payload,
+      headers: { traceparent: 'trace-1' },
+      url: 'http://internal:3011/api/workflows/onboarding/understanding/process-collected',
+      workflowRunId: 'feedback-session-1-revision-2',
+    });
+  });
+
   it('rejects triggering when workflow configuration is unavailable', async () => {
     delete process.env.QSTASH_TOKEN;
     const { OnboardingUnderstandingWorkflow, UnderstandingWorkflowUnavailableError } =

--- a/apps/server/src/workflows/onboardingUnderstanding/index.ts
+++ b/apps/server/src/workflows/onboardingUnderstanding/index.ts
@@ -3,6 +3,8 @@ import { injectActiveTraceHeaders } from '@/libs/observability/traceparent';
 import { workflowClient } from '@/libs/qstash';
 
 import {
+  type ProcessCollectedUnderstandingPayload,
+  ProcessCollectedUnderstandingPayloadSchema,
   type ProcessUnderstandingProvidersPayload,
   ProcessUnderstandingProvidersPayloadSchema,
 } from './types';
@@ -13,6 +15,7 @@ export type {
 } from './types';
 
 const PROCESS_PROVIDERS_PATH = '/api/workflows/onboarding/understanding/process-providers';
+const PROCESS_COLLECTED_PATH = '/api/workflows/onboarding/understanding/process-collected';
 
 export class UnderstandingWorkflowUnavailableError extends Error {
   readonly code = 'ONBOARDING_UNDERSTANDING_WORKFLOW_UNAVAILABLE';
@@ -49,6 +52,23 @@ export class OnboardingUnderstandingWorkflow {
       body: payload,
       headers: Object.fromEntries(traceHeaders.entries()),
       url: new URL(PROCESS_PROVIDERS_PATH, baseUrl).toString(),
+      ...(options?.workflowRunId ? { workflowRunId: options.workflowRunId } : {}),
+    });
+  }
+
+  static async triggerWriting(
+    input: ProcessCollectedUnderstandingPayload,
+    options?: { workflowRunId?: string },
+  ) {
+    const baseUrl = this.assertAvailable();
+    const payload = ProcessCollectedUnderstandingPayloadSchema.parse(input);
+    const traceHeaders = new Headers();
+    injectActiveTraceHeaders(traceHeaders);
+
+    return workflowClient.trigger({
+      body: payload,
+      headers: Object.fromEntries(traceHeaders.entries()),
+      url: new URL(PROCESS_COLLECTED_PATH, baseUrl).toString(),
       ...(options?.workflowRunId ? { workflowRunId: options.workflowRunId } : {}),
     });
   }

--- a/packages/database/src/repositories/onboardingUnderstanding/repository.test.ts
+++ b/packages/database/src/repositories/onboardingUnderstanding/repository.test.ts
@@ -67,9 +67,11 @@ const proposal = (
   sourceFingerprint: string,
   providers: string[],
   succeededCount: number,
+  revisions?: { feedbackRevision: number; generationRevision: number },
 ): OnboardingUnderstandingMessageMetadata => ({
   analysis,
   diagnostics: { errors: [], evidenceCount: 4, failedCount: 0, succeededCount },
+  ...revisions,
   kind: 'proposal',
   providers,
   resultId,
@@ -134,19 +136,23 @@ describe('OnboardingUnderstandingRepository', () => {
     messageId: string,
     threadId: string,
   ) => {
-    await expect(
-      repository.prepareWriting({
-        agentId,
-        sessionId,
-        sourceFingerprint: fingerprint,
-        threadId,
-        topicId,
-      }),
-    ).resolves.toEqual({ ready: true, threadId });
+    const prepared = await repository.prepareWriting({
+      agentId,
+      sessionId,
+      sourceFingerprint: fingerprint,
+      threadId,
+      topicId,
+    });
+    expect(prepared).toMatchObject({ ready: true, threadId });
     await insertAssistant(messageId, threadId);
     return repository.commitWriting({
       assistantMessageId: messageId,
-      metadata: proposal(messageId, fingerprint, providers, providers.length === 1 ? 3 : 5),
+      feedbackRevision: prepared.feedbackRevision,
+      generationRevision: prepared.generationRevision,
+      metadata: proposal(messageId, fingerprint, providers, providers.length === 1 ? 3 : 5, {
+        feedbackRevision: prepared.feedbackRevision,
+        generationRevision: prepared.generationRevision,
+      }),
       sessionId,
       sourceFingerprint: fingerprint,
       threadId,
@@ -165,7 +171,121 @@ describe('OnboardingUnderstandingRepository', () => {
     repository = new OnboardingUnderstandingRepository(db, userId);
   });
 
-  it('publishes provider proposals and preserves a user edit across confirmation replay', async () => {
+  /**
+   * @example
+   * expect(session.feedback?.revision).toBe(2);
+   */
+  it('adds sources monotonically and accumulates immutable feedback turns', async () => {
+    await repository.initialize(topicId, sessionId, ['github']);
+
+    const first = await repository.extend({
+      expectedFeedbackRevision: 0,
+      feedback: 'Focus on my open-source infrastructure work.',
+      providerIds: ['github', 'gmail'],
+      sessionId,
+      topicId,
+    });
+    const second = await repository.extend({
+      expectedFeedbackRevision: 1,
+      feedback: 'Do not treat newsletters as durable interests.',
+      providerIds: ['gmail'],
+      sessionId,
+      topicId,
+    });
+
+    expect(first.sources).toEqual({
+      github: expect.objectContaining({ revision: 0, status: 'pending' }),
+      gmail: expect.objectContaining({ revision: 0, status: 'pending' }),
+    });
+    expect(second.feedback).toEqual({
+      revision: 2,
+      turns: [
+        expect.objectContaining({
+          content: 'Focus on my open-source infrastructure work.',
+          revision: 1,
+        }),
+        expect.objectContaining({
+          content: 'Do not treat newsletters as durable interests.',
+          revision: 2,
+        }),
+      ],
+    });
+    await expect(
+      repository.extend({
+        expectedFeedbackRevision: 1,
+        feedback: 'Duplicate stale submission.',
+        providerIds: [],
+        sessionId,
+        topicId,
+      }),
+    ).rejects.toThrow('feedback is no longer active');
+  });
+
+  /**
+   * @example
+   * expect(stale.published).toBe(false);
+   */
+  it('publishes only the latest feedback and source generation', async () => {
+    await repository.initialize(topicId, sessionId, ['github']);
+    await completeProvider('github', 3);
+    const first = await repository.prepareWriting({
+      agentId,
+      sessionId,
+      sourceFingerprint: 'github@1',
+      threadId: 'generation-1-thread',
+      topicId,
+    });
+    await insertAssistant('generation-1-result', 'generation-1-thread');
+
+    await repository.extend({
+      expectedFeedbackRevision: 0,
+      feedback: 'Focus on infrastructure.',
+      providerIds: [],
+      sessionId,
+      topicId,
+    });
+    const second = await repository.prepareWriting({
+      agentId,
+      sessionId,
+      sourceFingerprint: 'github@1',
+      threadId: 'generation-2-thread',
+      topicId,
+    });
+    await insertAssistant('generation-2-result', 'generation-2-thread');
+
+    await expect(
+      repository.commitWriting({
+        assistantMessageId: 'generation-1-result',
+        feedbackRevision: first.feedbackRevision,
+        generationRevision: first.generationRevision,
+        metadata: proposal('generation-1-result', 'github@1', ['github'], 3, {
+          feedbackRevision: first.feedbackRevision,
+          generationRevision: first.generationRevision,
+        }),
+        sessionId,
+        sourceFingerprint: 'github@1',
+        threadId: 'generation-1-thread',
+        topicId,
+      }),
+    ).resolves.toEqual({ published: false });
+    await expect(
+      repository.commitWriting({
+        assistantMessageId: 'generation-2-result',
+        feedbackRevision: second.feedbackRevision,
+        generationRevision: second.generationRevision,
+        metadata: proposal('generation-2-result', 'github@1', ['github'], 3, {
+          feedbackRevision: second.feedbackRevision,
+          generationRevision: second.generationRevision,
+        }),
+        sessionId,
+        sourceFingerprint: 'github@1',
+        threadId: 'generation-2-thread',
+        topicId,
+      }),
+    ).resolves.toEqual({ published: true });
+  });
+
+  it('freezes the confirmed proposal while preserving later user edits', async () => {
     await repository.initialize(topicId, sessionId, ['github', 'gmail']);
     await completeProvider('github', 3);
     await expect(
@@ -181,6 +301,8 @@ describe('OnboardingUnderstandingRepository', () => {
         provider: 'understanding',
         retryable: true,
       },
+      feedbackRevision: 0,
+      generationRevision: 1,
       sessionId,
       sourceFingerprint: 'github@1',
       topicId,
@@ -192,11 +314,21 @@ describe('OnboardingUnderstandingRepository', () => {
 
     await expect(
       repository.confirm({ resultId: 'github-result', sessionId, topicId }),
+    ).rejects.toThrow('result_not_confirmable');
+
+    await completeProvider('gmail', 2);
+    await expect(
+      publish('github@1,gmail@1', ['github', 'gmail'], 'combined-result', 'combined-thread'),
+    ).resolves.toEqual({
+      published: true,
+    });
+    await expect(
+      repository.confirm({ resultId: 'combined-result', sessionId, topicId }),
     ).resolves.toEqual({ personaVersion: 1 });
     const persona = new UserPersonaModel(db, userId);
     await persona.upsertPersona({ persona: 'User-edited persona', tagline: 'User-edited tagline' });
     await expect(
-      repository.confirm({ resultId: 'github-result', sessionId, topicId }),
+      repository.confirm({ resultId: 'combined-result', sessionId, topicId }),
     ).resolves.toEqual({ personaVersion: 2 });
     await expect(persona.getLatestPersonaDocument()).resolves.toMatchObject({
       persona: 'User-edited persona',
@@ -204,37 +336,34 @@ describe('OnboardingUnderstandingRepository', () => {
       version: 2,
     });
 
-    await completeProvider('gmail', 2);
-    const failedBeforePrepare = await repository.failWriting({
-      error: {
-        code: 'UNDERSTANDING_WRITING_FAILED',
-        message: 'understanding writing failed',
-        operation: 'writing',
-        provider: 'understanding',
-        retryable: true,
-      },
-      sessionId,
-      sourceFingerprint: 'github@1,gmail@1',
-      topicId,
-    });
-    expect(failedBeforePrepare.writing).toMatchObject({
-      resultMessageId: 'github-result',
-      sourceFingerprint: 'github@1,gmail@1',
-      status: 'failed',
-    });
     await expect(
-      publish('github@1,gmail@1', ['github', 'gmail'], 'combined-result', 'combined-thread'),
-    ).resolves.toEqual({ personaVersion: 3, published: true });
+      repository.prepareWriting({
+        agentId,
+        sessionId,
+        sourceFingerprint: 'github@1,gmail@1',
+        threadId: 'another-thread',
+        topicId,
+      }),
+    ).rejects.toThrow('session_confirmed');
+    await expect(
+      repository.extend({
+        expectedFeedbackRevision: 0,
+        feedback: 'This must not update a confirmed session.',
+        providerIds: [],
+        sessionId,
+        topicId,
+      }),
+    ).rejects.toThrow('session_confirmed');
     await expect(persona.getLatestPersonaDocument()).resolves.toMatchObject({
-      persona: analysis.personaProposal.content,
-      version: 3,
+      persona: 'User-edited persona',
+      version: 2,
     });
     expect(
       await db
         .select()
         .from(userPersonaDocumentHistories)
         .where(eq(userPersonaDocumentHistories.userId, userId)),
-    ).toHaveLength(2);
+    ).toHaveLength(1);
   });
 
   it('rejects delayed provider revisions and refuses stale writing fingerprints', async () => {
@@ -293,6 +422,8 @@ describe('OnboardingUnderstandingRepository', () => {
         provider: 'understanding',
         retryable: true,
       },
+      feedbackRevision: 0,
+      generationRevision: 0,
       sessionId,
       sourceFingerprint: 'github@1',
       topicId,
@@ -309,10 +440,12 @@ describe('OnboardingUnderstandingRepository', () => {
         threadId: 'stale-thread',
         topicId,
       }),
-    ).resolves.toEqual({ ready: false, threadId: 'stale-thread' });
+    ).resolves.toMatchObject({ ready: false, threadId: 'stale-thread' });
     await expect(
       repository.commitWriting({
         assistantMessageId: 'missing-stale-result',
+        feedbackRevision: 0,
+        generationRevision: 0,
         metadata: proposal('missing-stale-result', 'github@1', ['github'], 3),
         sessionId,
         sourceFingerprint: 'github@1',
@@ -370,12 +503,17 @@ describe('OnboardingUnderstandingRepository', () => {
         threadId: 'owned-thread',
         topicId,
       }),
-    ).resolves.toEqual({ ready: true, threadId: 'owned-thread' });
+    ).resolves.toMatchObject({ ready: true, threadId: 'owned-thread' });
     await insertAssistant('wrong-agent-message', 'owned-thread', { agent: otherAgentId });
     await expect(
       repository.commitWriting({
         assistantMessageId: 'wrong-agent-message',
-        metadata: proposal('wrong-agent-message', 'github@1', ['github'], 3),
+        feedbackRevision: 0,
+        generationRevision: 1,
+        metadata: proposal('wrong-agent-message', 'github@1', ['github'], 3, {
+          feedbackRevision: 0,
+          generationRevision: 1,
+        }),
         sessionId,
         sourceFingerprint: 'github@1',
         threadId: 'owned-thread',
@@ -440,7 +578,12 @@ describe('OnboardingUnderstandingRepository', () => {
       () =>
         repository.commitWriting({
           assistantMessageId: 'inaccessible-message',
-          metadata: proposal('inaccessible-message', 'github@1', ['github'], 1),
+          feedbackRevision: 0,
+          generationRevision: 1,
+          metadata: proposal('inaccessible-message', 'github@1', ['github'], 1, {
+            feedbackRevision: 0,
+            generationRevision: 1,
+          }),
           sessionId: 'inaccessible-session',
           sourceFingerprint: 'github@1',
           threadId: 'inaccessible-thread',
@@ -455,6 +598,8 @@ describe('OnboardingUnderstandingRepository', () => {
             provider: 'understanding',
             retryable: true,
           },
+          feedbackRevision: 0,
+          generationRevision: 1,
           sessionId: 'inaccessible-session',
           sourceFingerprint: 'github@1',
           topicId: inaccessibleTopicId,

--- a/packages/database/src/repositories/onboardingUnderstanding/repository.ts
+++ b/packages/database/src/repositories/onboardingUnderstanding/repository.ts
@@ -10,6 +10,7 @@ import {
   CollectionDiagnosticsSummarySchema,
   MAX_COLLECTION_COUNT,
   MAX_COLLECTION_ERRORS,
+  MAX_UNDERSTANDING_FEEDBACK_TURNS,
   OnboardingUnderstandingMessageMetadataSchema,
   OnboardingUnderstandingSessionSchema,
   ThreadStatus,
@@ -64,7 +65,14 @@ export class UnderstandingResourceNotFoundError extends Error {
 }
 
 export class UnderstandingPreconditionError extends Error {
-  constructor(reason: 'result_not_confirmable' | 'source_not_retryable' | 'writing_not_active') {
+  constructor(
+    reason:
+      | 'feedback_limit_reached'
+      | 'result_not_confirmable'
+      | 'session_confirmed'
+      | 'source_not_retryable'
+      | 'writing_not_active',
+  ) {
     super(`Onboarding Understanding precondition failed: ${reason}`);
     this.name = 'UnderstandingPreconditionError';
   }
@@ -89,14 +97,25 @@ interface ExpireProviderContextsInput {
 
 interface PrepareWritingInput {
   agentId: string;
+  expectedFeedbackRevision?: number;
   sessionId: string;
   sourceFingerprint: string;
   threadId: string;
   topicId: string;
 }
 
+interface ExtendSessionInput {
+  expectedFeedbackRevision: number;
+  feedback?: string;
+  providerIds: string[];
+  sessionId: string;
+  topicId: string;
+}
+
 interface CommitWritingInput {
   assistantMessageId: string;
+  feedbackRevision: number;
+  generationRevision: number;
   metadata: OnboardingUnderstandingMessageMetadata;
   sessionId: string;
   sourceFingerprint: string;
@@ -106,6 +125,8 @@ interface CommitWritingInput {
 
 interface FailWritingInput {
   error: CollectionError;
+  feedbackRevision: number;
+  generationRevision: number;
   sessionId: string;
   sourceFingerprint: string;
   topicId: string;
@@ -280,6 +301,55 @@ export class OnboardingUnderstandingRepository {
       }),
     );
 
+  extend = async ({
+    expectedFeedbackRevision,
+    feedback,
+    providerIds,
+    sessionId,
+    topicId,
+  }: ExtendSessionInput): Promise<OnboardingUnderstandingSession> => {
+    providerIds.forEach(assertProviderId);
+    return this.db.transaction((tx) =>
+      mutateTopicSession(tx, this.userId, topicId, (persisted) => {
+        const session = requireSession(topicId, sessionId, persisted);
+        if (session.confirmedAt) throw new UnderstandingPreconditionError('session_confirmed');
+
+        const trimmedFeedback = feedback?.trim();
+        const currentFeedback = session.feedback ?? { revision: 0, turns: [] };
+        if (currentFeedback.revision !== expectedFeedbackRevision) {
+          throw new StaleUnderstandingRevisionError('feedback', expectedFeedbackRevision);
+        }
+        if (trimmedFeedback && currentFeedback.turns.length >= MAX_UNDERSTANDING_FEEDBACK_TURNS) {
+          throw new UnderstandingPreconditionError('feedback_limit_reached');
+        }
+
+        const sources = { ...session.sources };
+        for (const providerId of new Set(providerIds)) {
+          sources[providerId] ??= initialProviderState();
+        }
+        const nextFeedback = trimmedFeedback
+          ? {
+              revision: currentFeedback.revision + 1,
+              turns: [
+                ...currentFeedback.turns,
+                {
+                  content: trimmedFeedback,
+                  createdAt: new Date().toISOString(),
+                  revision: currentFeedback.revision + 1,
+                },
+              ],
+            }
+          : currentFeedback;
+        const changed =
+          trimmedFeedback || Object.keys(sources).length !== Object.keys(session.sources).length;
+        if (!changed) return { nextSession: session, result: session, write: false };
+
+        const nextSession = parseSession({ ...session, feedback: nextFeedback, sources });
+        return { nextSession, result: nextSession, write: true };
+      }),
+    );
+  };
+
   markProviderRunning = async (
     topicId: string,
     sessionId: string,
@@ -289,6 +359,7 @@ export class OnboardingUnderstandingRepository {
     return this.db.transaction((tx) =>
       mutateTopicSession(tx, this.userId, topicId, (persisted) => {
         const session = requireSession(topicId, sessionId, persisted);
+        if (session.confirmedAt) throw new UnderstandingPreconditionError('session_confirmed');
         const provider = session.sources[providerId];
         if (!provider) throw new UnderstandingResourceNotFoundError('session');
         if (provider.status !== 'pending' && provider.status !== 'failed') {
@@ -334,6 +405,7 @@ export class OnboardingUnderstandingRepository {
     return this.db.transaction((tx) =>
       mutateTopicSession(tx, this.userId, topicId, (persisted) => {
         const session = requireSession(topicId, sessionId, persisted);
+        if (session.confirmedAt) throw new UnderstandingPreconditionError('session_confirmed');
         if (getUnderstandingSourceFingerprint(session) !== sourceFingerprint) {
           return { nextSession: session, result: session, write: false };
         }
@@ -376,22 +448,55 @@ export class OnboardingUnderstandingRepository {
 
   prepareWriting = async ({
     agentId,
+    expectedFeedbackRevision,
     sessionId,
     sourceFingerprint,
     threadId,
     topicId,
-  }: PrepareWritingInput): Promise<{ ready: boolean; threadId: string }> =>
+  }: PrepareWritingInput): Promise<{
+    feedbackRevision: number;
+    generationRevision: number;
+    ready: boolean;
+    threadId: string;
+  }> =>
     this.db.transaction((tx) =>
       mutateTopicSession(tx, this.userId, topicId, async (persisted) => {
         const session = requireSession(topicId, sessionId, persisted);
+        if (session.confirmedAt) throw new UnderstandingPreconditionError('session_confirmed');
+        const feedbackRevision = session.feedback?.revision ?? 0;
+        const currentGenerationRevision = session.generationRevision ?? 0;
         if (
+          (expectedFeedbackRevision !== undefined &&
+            feedbackRevision !== expectedFeedbackRevision) ||
           getUnderstandingSourceFingerprint(session) !== sourceFingerprint ||
           (session.writing?.sourceFingerprint === sourceFingerprint &&
+            (session.writing.feedbackRevision ?? 0) === feedbackRevision &&
             session.writing.status === 'completed')
         ) {
           return {
             nextSession: session,
-            result: { ready: false as boolean, threadId },
+            result: {
+              feedbackRevision,
+              generationRevision: currentGenerationRevision,
+              ready: false as boolean,
+              threadId,
+            },
+            write: false,
+          };
+        }
+        if (
+          session.writing?.sourceFingerprint === sourceFingerprint &&
+          (session.writing.feedbackRevision ?? 0) === feedbackRevision &&
+          session.writing.status === 'running'
+        ) {
+          return {
+            nextSession: session,
+            result: {
+              feedbackRevision,
+              generationRevision: session.writing.generationRevision ?? currentGenerationRevision,
+              ready: true as boolean,
+              threadId,
+            },
             write: false,
           };
         }
@@ -423,9 +528,13 @@ export class OnboardingUnderstandingRepository {
           throw new UnderstandingResourceNotFoundError('result');
         }
 
+        const generationRevision = currentGenerationRevision + 1;
         const nextSession = parseSession({
           ...session,
+          generationRevision,
           writing: {
+            feedbackRevision,
+            generationRevision,
             resultMessageId: session.writing?.resultMessageId,
             sourceFingerprint,
             status: 'running',
@@ -434,7 +543,7 @@ export class OnboardingUnderstandingRepository {
         });
         return {
           nextSession,
-          result: { ready: true as boolean, threadId },
+          result: { feedbackRevision, generationRevision, ready: true as boolean, threadId },
           write: true,
         };
       }),
@@ -442,6 +551,8 @@ export class OnboardingUnderstandingRepository {
 
   commitWriting = async ({
     assistantMessageId,
+    feedbackRevision,
+    generationRevision,
     metadata,
     sessionId,
     sourceFingerprint,
@@ -452,13 +563,22 @@ export class OnboardingUnderstandingRepository {
     if (requestedProposal.sourceFingerprint !== sourceFingerprint) {
       throw new Error('Understanding proposal fingerprint does not match the writing state');
     }
+    if (
+      requestedProposal.feedbackRevision !== feedbackRevision ||
+      requestedProposal.generationRevision !== generationRevision
+    ) {
+      throw new Error('Understanding proposal revisions do not match the writing state');
+    }
 
     return this.db.transaction((tx) =>
       mutateTopicSession(tx, this.userId, topicId, async (persisted) => {
         const session = requireSession(topicId, sessionId, persisted);
         if (
+          session.confirmedAt ||
           getUnderstandingSourceFingerprint(session) !== sourceFingerprint ||
-          session.writing?.sourceFingerprint !== sourceFingerprint
+          session.writing?.sourceFingerprint !== sourceFingerprint ||
+          session.writing.feedbackRevision !== feedbackRevision ||
+          session.writing.generationRevision !== generationRevision
         ) {
           return {
             nextSession: session,
@@ -500,12 +620,11 @@ export class OnboardingUnderstandingRepository {
           .set({ status: ThreadStatus.Completed, updatedAt: new Date() })
           .where(and(eq(threads.id, threadId), threadOwnership(this.userId)));
 
-        const personaVersion = session.confirmedAt
-          ? await this.writePersona(tx, sessionId, proposal)
-          : undefined;
         const nextSession = parseSession({
           ...session,
           writing: {
+            feedbackRevision,
+            generationRevision,
             resultMessageId: assistantMessageId,
             sourceFingerprint,
             status: 'completed',
@@ -514,10 +633,7 @@ export class OnboardingUnderstandingRepository {
         });
         return {
           nextSession,
-          result: {
-            ...(personaVersion ? { personaVersion } : {}),
-            published: true as boolean,
-          },
+          result: { published: true as boolean },
           write: true,
         };
       }),
@@ -526,6 +642,8 @@ export class OnboardingUnderstandingRepository {
 
   failWriting = async ({
     error,
+    feedbackRevision,
+    generationRevision,
     sessionId,
     sourceFingerprint,
     topicId,
@@ -535,6 +653,8 @@ export class OnboardingUnderstandingRepository {
         const session = requireSession(topicId, sessionId, persisted);
         if (
           getUnderstandingSourceFingerprint(session) !== sourceFingerprint ||
+          session.writing?.feedbackRevision !== feedbackRevision ||
+          session.writing?.generationRevision !== generationRevision ||
           (session.writing?.sourceFingerprint === sourceFingerprint &&
             session.writing.status !== 'running')
         ) {
@@ -544,6 +664,8 @@ export class OnboardingUnderstandingRepository {
           ...session,
           writing: {
             error,
+            feedbackRevision,
+            generationRevision,
             resultMessageId: session.writing?.resultMessageId,
             sourceFingerprint,
             status: 'failed',
@@ -563,6 +685,16 @@ export class OnboardingUnderstandingRepository {
         if (!session.writing?.resultMessageId || session.writing.status !== 'completed') {
           throw new UnderstandingPreconditionError('result_not_confirmable');
         }
+        if (
+          Object.values(session.sources).some(
+            (source) => source.status === 'pending' || source.status === 'running',
+          ) ||
+          getUnderstandingSourceFingerprint(session) !== session.writing.sourceFingerprint ||
+          (session.writing.feedbackRevision ?? 0) !== (session.feedback?.revision ?? 0) ||
+          (session.writing.generationRevision ?? 0) !== (session.generationRevision ?? 0)
+        ) {
+          throw new UnderstandingPreconditionError('result_not_confirmable');
+        }
         const [message] = await tx
           .select()
           .from(messages)
@@ -576,6 +708,8 @@ export class OnboardingUnderstandingRepository {
           message.role !== 'assistant' ||
           message.topicId !== input.topicId ||
           proposal?.resultId !== input.resultId ||
+          (proposal.feedbackRevision ?? 0) !== (session.writing.feedbackRevision ?? 0) ||
+          (proposal.generationRevision ?? 0) !== (session.writing.generationRevision ?? 0) ||
           !message.threadId
         ) {
           throw new UnderstandingResourceNotFoundError('result');
@@ -632,6 +766,7 @@ export class OnboardingUnderstandingRepository {
     return this.db.transaction((tx) =>
       mutateTopicSession(tx, this.userId, input.topicId, (persisted) => {
         const session = requireSession(input.topicId, input.sessionId, persisted);
+        if (session.confirmedAt) throw new UnderstandingPreconditionError('session_confirmed');
         const provider = session.sources[input.providerId];
         if (!provider) throw new UnderstandingResourceNotFoundError('session');
         if (provider.revision !== input.revision || provider.status !== 'running') {

--- a/packages/prompts/src/chains/understanding.ts
+++ b/packages/prompts/src/chains/understanding.ts
@@ -3,6 +3,7 @@ import {
   MAX_ANALYSIS_DESCRIPTION_LENGTH,
   MAX_ANALYSIS_SHORT_TEXT_LENGTH,
   MAX_PERSONA_CONTENT_LENGTH,
+  type UnderstandingFeedbackTurn,
 } from '@lobechat/types';
 
 type SafeCollectionDiagnostics = Pick<
@@ -12,6 +13,7 @@ type SafeCollectionDiagnostics = Pick<
 
 interface UnderstandingPersonaPromptInput {
   diagnostics: SafeCollectionDiagnostics;
+  feedback?: UnderstandingFeedbackTurn[];
   providers: string[];
 }
 
@@ -201,9 +203,24 @@ const outputContract = [
 
 export const chainUnderstandingPersona = ({
   diagnostics,
+  feedback = [],
   providers,
-}: UnderstandingPersonaPromptInput): string =>
-  [
+}: UnderstandingPersonaPromptInput): string => {
+  const feedbackSection =
+    feedback.length > 0
+      ? [
+          'Direct user revision guidance follows as trusted preferences for this rewrite. Apply every compatible turn; when turns conflict, the higher revision wins. Guidance may correct interpretation but does not increase evidence counts or justify claims unsupported by either the connected sources or explicit user statements.',
+          JSON.stringify(
+            feedback.map(({ content, revision }) => ({
+              content,
+              revision,
+            })),
+          ),
+          'End direct user revision guidance.',
+        ]
+      : [];
+
+  return [
     'Write one coherent onboarding persona from all available provider-delimited Markdown and XML contexts.',
     'Analyze the original provider contexts directly, not prior generated analyses.',
     'Providers represented in the input (untrusted JSON):',
@@ -212,6 +229,7 @@ export const chainUnderstandingPersona = ({
     ),
     'End provider metadata.',
     `Collection completeness: ${formatCompleteness(diagnostics)}. Treat incomplete collection as uncertainty; do not invent the missing information.`,
+    ...feedbackSection,
     'The current ephemeral user message contains the complete available provider contexts.',
     'Reconcile conflicts by preferring explicit and specific statements and signals recurring across independent providers.',
     'Deduplicate overlapping identities and interests. Combine descriptions only when they refer to the same durable signal.',
@@ -219,3 +237,4 @@ export const chainUnderstandingPersona = ({
     ...sharedAnalysisRules,
     outputContract,
   ].join('\n\n');
+};

--- a/packages/types/src/understanding.test.ts
+++ b/packages/types/src/understanding.test.ts
@@ -5,7 +5,11 @@ import type {
   OnboardingUnderstandingSessionStatus,
   UnderstandingProviderState,
 } from './understanding';
-import { projectOnboardingUnderstandingSessionStatus } from './understanding';
+import {
+  OnboardingUnderstandingMessageMetadataSchema,
+  OnboardingUnderstandingSessionSchema,
+  projectOnboardingUnderstandingSessionStatus,
+} from './understanding';
 
 const completedProvider: UnderstandingProviderState = {
   errors: [],
@@ -110,5 +114,90 @@ const cases: Array<[string, OnboardingUnderstandingSession, OnboardingUnderstand
 describe('projectOnboardingUnderstandingSessionStatus', () => {
   it.each(cases)('projects %s', (_, session, expected) => {
     expect(projectOnboardingUnderstandingSessionStatus(session)).toBe(expected);
+  });
+});
+
+describe('onboarding Understanding revision schemas', () => {
+  /**
+   * @example
+   * expect(session.success).toBe(true);
+   */
+  it('accepts cumulative feedback and the current generation revision', () => {
+    const session = OnboardingUnderstandingSessionSchema.safeParse({
+      feedback: {
+        revision: 2,
+        turns: [
+          {
+            content: 'Focus on my open-source infrastructure work.',
+            createdAt: '2026-07-24T00:00:00.000Z',
+            revision: 1,
+          },
+          {
+            content: 'Do not treat newsletters as durable interests.',
+            createdAt: '2026-07-24T00:01:00.000Z',
+            revision: 2,
+          },
+        ],
+      },
+      generationRevision: 3,
+      id: 'session',
+      sources: { github: completedProvider },
+      writing: {
+        feedbackRevision: 2,
+        generationRevision: 3,
+        resultMessageId: 'message',
+        sourceFingerprint: 'github@1',
+        status: 'completed',
+        updatedAt: '2026-07-24T00:02:00.000Z',
+      },
+    });
+
+    expect(session.success).toBe(true);
+  });
+
+  /**
+   * @example
+   * expect(proposal.success).toBe(true);
+   */
+  it('binds a proposal to the feedback and generation revisions that produced it', () => {
+    const proposal = OnboardingUnderstandingMessageMetadataSchema.safeParse({
+      analysis: {
+        composition: {
+          identities: [],
+          interests: [],
+          lifeStyle: [],
+          social: [],
+          working: [],
+        },
+        personaProposal: {
+          content: 'You build open-source infrastructure.',
+          reasoning: 'Your direct feedback clarifies the connected evidence.',
+          tagline: 'Open-source infrastructure builder',
+        },
+        profile: {
+          description: 'Builds open-source infrastructure.',
+          domains: ['open source'],
+          name: 'Neko',
+          pronoun: 'non-specific',
+          roles: ['engineer'],
+          summary: 'Open-source infrastructure engineer.',
+          tagline: 'Open-source infrastructure builder',
+        },
+      },
+      diagnostics: {
+        errors: [],
+        evidenceCount: 1,
+        failedCount: 0,
+        succeededCount: 1,
+      },
+      feedbackRevision: 2,
+      generationRevision: 3,
+      kind: 'proposal',
+      providers: ['github'],
+      resultId: 'message',
+      sourceFingerprint: 'github@1',
+    });
+
+    expect(proposal.success).toBe(true);
   });
 });

--- a/packages/types/src/understanding.ts
+++ b/packages/types/src/understanding.ts
@@ -10,6 +10,10 @@ export const MAX_DIAGNOSTIC_OPERATION_LENGTH = 64;
 export const MAX_PROVIDER_ID_LENGTH = 64;
 export const MAX_ANALYSIS_DESCRIPTION_LENGTH = 2000;
 export const MAX_ANALYSIS_SHORT_TEXT_LENGTH = 256;
+/** Maximum characters accepted in one direct Understanding feedback turn. */
+export const MAX_UNDERSTANDING_FEEDBACK_LENGTH = 2000;
+/** Maximum immutable feedback turns retained by one Understanding session. */
+export const MAX_UNDERSTANDING_FEEDBACK_TURNS = 16;
 export const MAX_PERSONA_CONTENT_LENGTH = 4000;
 
 export type UnderstandingProviderStatus = 'pending' | 'running' | 'completed' | 'failed';
@@ -92,6 +96,18 @@ export interface UnderstandingProviderState {
 }
 
 interface UnderstandingWritingStateBase {
+  /**
+   * Latest cumulative feedback revision included in this generation.
+   *
+   * @default 0
+   */
+  feedbackRevision?: number;
+  /**
+   * Monotonic generation revision used to reject delayed writer results.
+   *
+   * @default 0
+   */
+  generationRevision?: number;
   sourceFingerprint: string;
   updatedAt: string;
 }
@@ -117,6 +133,16 @@ export type UnderstandingWritingState = UnderstandingWritingStateBase &
 
 export interface OnboardingUnderstandingSession {
   confirmedAt?: string;
+  /**
+   * Cumulative direct guidance supplied by the user for proposal rewriting.
+   */
+  feedback?: UnderstandingFeedbackState;
+  /**
+   * Latest generation revision allocated for this session.
+   *
+   * @default 0
+   */
+  generationRevision?: number;
   id: string;
   sources: Record<string, UnderstandingProviderState>;
   writing?: UnderstandingWritingState;
@@ -125,13 +151,54 @@ export interface OnboardingUnderstandingSession {
 export interface OnboardingUnderstandingMessageMetadata {
   analysis: UnderstandingAnalysis;
   diagnostics: CollectionDiagnostics;
+  /**
+   * Feedback revision used to produce this proposal.
+   *
+   * @default 0
+   */
+  feedbackRevision?: number;
+  /**
+   * Generation revision used to make this proposal the latest-wins candidate.
+   *
+   * @default 0
+   */
+  generationRevision?: number;
   kind: 'proposal';
   providers: string[];
   resultId: string;
   sourceFingerprint: string;
 }
 
+/**
+ * One immutable user instruction included in subsequent Understanding rewrites.
+ */
+export interface UnderstandingFeedbackTurn {
+  /** User-authored instruction, trimmed before persistence. */
+  content: string;
+  /** ISO timestamp recording when this instruction was accepted. */
+  createdAt: string;
+  /** Monotonic revision within the current Understanding session. */
+  revision: number;
+}
+
+/**
+ * Cumulative feedback history for an onboarding Understanding session.
+ */
+export interface UnderstandingFeedbackState {
+  /**
+   * Latest accepted feedback revision.
+   *
+   * @default 0
+   */
+  revision: number;
+  /** Ordered immutable instructions; newer turns override conflicting older turns. */
+  turns: UnderstandingFeedbackTurn[];
+}
+
 export interface OnboardingUnderstandingPollingResult {
+  confirmed?: boolean;
+  feedback?: UnderstandingFeedbackState;
+  generationRevision?: number;
   id: string;
   proposal?: OnboardingUnderstandingMessageMetadata;
   sources: Record<string, UnderstandingProviderState>;
@@ -141,6 +208,28 @@ export interface OnboardingUnderstandingPollingResult {
 
 export interface OnboardingUnderstandingTopicInput {
   topicId: string;
+}
+
+/**
+ * Starts Understanding with only the sources selected and already connected by the user.
+ */
+export interface StartOnboardingUnderstandingInput extends OnboardingUnderstandingTopicInput {
+  /** Initial additive providers; omitted callers retain the legacy all-provider behavior. */
+  providerIds?: string[];
+}
+
+/**
+ * Adds direct feedback and newly selected providers to an active Understanding session.
+ */
+export interface ReviseOnboardingUnderstandingInput extends OnboardingUnderstandingTopicInput {
+  /** Feedback revision observed by the caller; prevents duplicate or stale appends. */
+  expectedFeedbackRevision: number;
+  /** Optional direct guidance appended to the cumulative writer prompt. */
+  feedback?: string;
+  /** Additive provider identifiers; existing sources are never removed. */
+  providerIds: string[];
+  /** Active Understanding session identifier used for stale-client protection. */
+  sessionId: string;
 }
 
 export interface RetryOnboardingUnderstandingProviderInput extends OnboardingUnderstandingTopicInput {
@@ -237,12 +326,31 @@ export const OnboardingUnderstandingMessageMetadataSchema = z
   .object({
     analysis: UnderstandingAnalysisSchema,
     diagnostics: CollectionDiagnosticsSchema,
+    feedbackRevision: z.number().int().nonnegative().max(MAX_COLLECTION_COUNT).default(0),
+    generationRevision: z.number().int().nonnegative().max(MAX_COLLECTION_COUNT).default(0),
     kind: z.literal('proposal'),
     providers: z.array(z.string().max(MAX_PROVIDER_ID_LENGTH)),
     resultId: z.string(),
     sourceFingerprint: z.string(),
   })
   .strict() satisfies z.ZodType<StrictOnly<OnboardingUnderstandingMessageMetadata>>;
+
+/** Validates one immutable, revisioned Understanding feedback instruction. */
+export const UnderstandingFeedbackTurnSchema = z
+  .object({
+    content: z.string().trim().min(1).max(MAX_UNDERSTANDING_FEEDBACK_LENGTH),
+    createdAt: z.string(),
+    revision: z.number().int().positive().max(MAX_COLLECTION_COUNT),
+  })
+  .strict() satisfies z.ZodType<UnderstandingFeedbackTurn>;
+
+/** Validates the cumulative feedback history attached to an Understanding session. */
+export const UnderstandingFeedbackStateSchema = z
+  .object({
+    revision: z.number().int().nonnegative().max(MAX_COLLECTION_COUNT),
+    turns: z.array(UnderstandingFeedbackTurnSchema).max(MAX_UNDERSTANDING_FEEDBACK_TURNS),
+  })
+  .strict() satisfies z.ZodType<UnderstandingFeedbackState>;
 
 export const UnderstandingProviderStateSchema = z
   .object({
@@ -256,6 +364,8 @@ export const UnderstandingProviderStateSchema = z
   .strict() satisfies z.ZodType<UnderstandingProviderState>;
 
 const understandingWritingStateBaseShape = {
+  feedbackRevision: z.number().int().nonnegative().max(MAX_COLLECTION_COUNT).default(0),
+  generationRevision: z.number().int().nonnegative().max(MAX_COLLECTION_COUNT).default(0),
   sourceFingerprint: z.string(),
   updatedAt: z.string(),
 };
@@ -288,6 +398,8 @@ export const UnderstandingWritingStateSchema = z.discriminatedUnion('status', [
 export const OnboardingUnderstandingSessionSchema = z
   .object({
     confirmedAt: z.string().optional(),
+    feedback: UnderstandingFeedbackStateSchema.default({ revision: 0, turns: [] }),
+    generationRevision: z.number().int().nonnegative().max(MAX_COLLECTION_COUNT).default(0),
     id: z.string(),
     sources: z.record(z.string().max(MAX_PROVIDER_ID_LENGTH), UnderstandingProviderStateSchema),
     writing: UnderstandingWritingStateSchema.optional(),

--- a/src/services/user/index.test.ts
+++ b/src/services/user/index.test.ts
@@ -6,10 +6,15 @@ import { UserService, userService } from './index';
 
 const mockLambdaClient = vi.hoisted(() => ({
   user: {
+    confirmOnboardingUnderstanding: { mutate: vi.fn() },
+    getOnboardingUnderstanding: { query: vi.fn() },
     getUserRegistrationDuration: { query: vi.fn() },
     getUserState: { query: vi.fn() },
     getUserSSOProviders: { query: vi.fn() },
     makeUserOnboarded: { mutate: vi.fn() },
+    retryOnboardingUnderstandingSource: { mutate: vi.fn() },
+    reviseOnboardingUnderstanding: { mutate: vi.fn() },
+    startOnboardingUnderstanding: { mutate: vi.fn() },
     updateAvatar: { mutate: vi.fn() },
     updateFullName: { mutate: vi.fn() },
     updatePreference: { mutate: vi.fn() },
@@ -36,6 +41,63 @@ describe('UserService', () => {
       expect(mockLambdaClient.user.getUserRegistrationDuration.query).toHaveBeenCalled();
       expect(result).toEqual(mockResult);
     });
+  });
+
+  /**
+   * @example
+   * expect(result.id).toBe('session-1');
+   */
+  it('exposes the onboarding Understanding lifecycle', async () => {
+    const pollingResult = { id: 'session-1', sources: {}, status: 'pending' };
+    mockLambdaClient.user.startOnboardingUnderstanding.mutate.mockResolvedValueOnce(pollingResult);
+    mockLambdaClient.user.getOnboardingUnderstanding.query.mockResolvedValueOnce(pollingResult);
+    mockLambdaClient.user.reviseOnboardingUnderstanding.mutate.mockResolvedValueOnce(pollingResult);
+    mockLambdaClient.user.retryOnboardingUnderstandingSource.mutate.mockResolvedValueOnce(
+      pollingResult,
+    );
+    mockLambdaClient.user.confirmOnboardingUnderstanding.mutate.mockResolvedValueOnce({
+      confirmed: true,
+    });
+
+    await userService.startOnboardingUnderstanding({
+      providerIds: ['github'],
+      topicId: 'topic-1',
+    });
+    await userService.getOnboardingUnderstanding('topic-1');
+    await userService.reviseOnboardingUnderstanding({
+      expectedFeedbackRevision: 0,
+      feedback: 'Focus on infrastructure.',
+      providerIds: ['gmail'],
+      sessionId: 'session-1',
+      topicId: 'topic-1',
+    });
+    await userService.retryOnboardingUnderstandingSource({
+      providerId: 'gmail',
+      sessionId: 'session-1',
+      topicId: 'topic-1',
+    });
+    await userService.confirmOnboardingUnderstanding({
+      resultId: 'result-1',
+      sessionId: 'session-1',
+      topicId: 'topic-1',
+    });
+
+    expect(mockLambdaClient.user.startOnboardingUnderstanding.mutate).toHaveBeenCalledWith({
+      providerIds: ['github'],
+      topicId: 'topic-1',
+    });
+    expect(mockLambdaClient.user.getOnboardingUnderstanding.query).toHaveBeenCalledWith({
+      topicId: 'topic-1',
+    });
+    expect(mockLambdaClient.user.reviseOnboardingUnderstanding.mutate).toHaveBeenCalledWith({
+      expectedFeedbackRevision: 0,
+      feedback: 'Focus on infrastructure.',
+      providerIds: ['gmail'],
+      sessionId: 'session-1',
+      topicId: 'topic-1',
+    });
+    expect(mockLambdaClient.user.retryOnboardingUnderstandingSource.mutate).toHaveBeenCalled();
+    expect(mockLambdaClient.user.confirmOnboardingUnderstanding.mutate).toHaveBeenCalled();
   });
 
   describe('getUserState', () => {

--- a/src/services/user/index.ts
+++ b/src/services/user/index.ts
@@ -1,5 +1,12 @@
 import type { OnboardingUserInfo } from '@lobechat/context-engine';
 import { type MarkdownPatchHunk } from '@lobechat/markdown-patch';
+import type {
+  ConfirmOnboardingUnderstandingInput,
+  OnboardingUnderstandingPollingResult,
+  RetryOnboardingUnderstandingProviderInput,
+  ReviseOnboardingUnderstandingInput,
+  StartOnboardingUnderstandingInput,
+} from '@lobechat/types';
 import { type PartialDeep } from 'type-fest';
 
 import { lambdaClient } from '@/libs/trpc/client';
@@ -16,6 +23,16 @@ import {
 import { type UserSettings } from '@/types/user/settings';
 
 export class UserService {
+  confirmOnboardingUnderstanding = async (input: ConfirmOnboardingUnderstandingInput) => {
+    return lambdaClient.user.confirmOnboardingUnderstanding.mutate(input);
+  };
+
+  getOnboardingUnderstanding = async (
+    topicId: string,
+  ): Promise<OnboardingUnderstandingPollingResult> => {
+    return lambdaClient.user.getOnboardingUnderstanding.query({ topicId });
+  };
+
   getUserActivitySummary = async (): Promise<{
     lastUserMessageAt: Date | null;
     userCreatedAt: Date | null;
@@ -97,6 +114,24 @@ export class UserService {
 
   makeUserOnboarded = async () => {
     return lambdaClient.user.makeUserOnboarded.mutate();
+  };
+
+  retryOnboardingUnderstandingSource = async (
+    input: RetryOnboardingUnderstandingProviderInput,
+  ): Promise<OnboardingUnderstandingPollingResult> => {
+    return lambdaClient.user.retryOnboardingUnderstandingSource.mutate(input);
+  };
+
+  reviseOnboardingUnderstanding = async (
+    input: ReviseOnboardingUnderstandingInput,
+  ): Promise<OnboardingUnderstandingPollingResult> => {
+    return lambdaClient.user.reviseOnboardingUnderstanding.mutate(input);
+  };
+
+  startOnboardingUnderstanding = async (
+    input: StartOnboardingUnderstandingInput,
+  ): Promise<OnboardingUnderstandingPollingResult> => {
+    return lambdaClient.user.startOnboardingUnderstanding.mutate(input);
   };
 
   resetAgentOnboarding = async () => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Built on #17520.

#### 🔀 Description of Change

- add cumulative written feedback before onboarding Understanding confirmation
- allow additive connector sources while preserving existing completed source context
- rerun only newly added or expired provider sources; valid Redis contexts retain the existing 3-day TTL
- use feedback and generation revisions to make latest generation win under concurrent workflow runs
- prevent confirmation while the latest revision is still changing, then freeze the confirmed session
- expose start/revise API inputs without changing onboarding UI

No database migration is required; the revision state is stored in the existing onboarding session metadata.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Automated coverage:

- Understanding service and workflow tests
- lambda router and client service tests
- onboarding Understanding repository tests
- shared Understanding schema tests

Local end-to-end verification of start → feedback revise/add source → confirm is in progress and will be reported in a follow-up comment.

#### 📸 Screenshots / Videos

No UI changes.

#### 📝 Additional Information

The PR intentionally targets `fix/onboarding-understanding-reliability` so it can build on the direct structured-generation and reliability changes from #17520.