### PR TITLE
✨ feat: support ChatGPT subscription authentication

### DIFF
--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.test.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.test.ts
@@ -110,6 +110,7 @@ describe('ServerCallLlmAttempt', () => {
         await callback?.onToolsCalling?.({ chunk: [], toolsCalling: [rawToolCall] });
         await callback?.onCompletion?.({
           finishReason: 'tool_use',
+          reasoning: { content: 'Reasoning', signature: 'encrypted-signature' },
           speed: { tps: 20, ttft: 100 },
           text: '',
           usage: { totalInputTokens: 10, totalOutputTokens: 5, totalTokens: 15 },
@@ -124,6 +125,10 @@ describe('ServerCallLlmAttempt', () => {
     expect(snapshot.content).toBe('Visible answer');
     expect(snapshot.thinkingContent).toBe('Reasoning');
     expect(snapshot.grounding).toEqual({ searchQueries: ['docs'] });
+    expect(snapshot.reasoning).toEqual({
+      content: 'Reasoning',
+      signature: 'encrypted-signature',
+    });
     expect(snapshot.finishReason).toBe('tool_use');
     expect(snapshot.speed).toEqual({ tps: 20, ttft: 100 });
     expect(snapshot.usage).toEqual({

--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.ts
@@ -12,6 +12,7 @@ import type {
   GroundingSearch,
   MessageToolCall,
   ModelPerformance,
+  ModelReasoning,
   ModelUsage,
 } from '@lobechat/types';
 import { pickString, toRecord } from '@lobechat/utils/object';
@@ -77,6 +78,7 @@ export class ServerCallLlmAttempt {
   private readonly onFirstChunk: () => void;
   private readonly operationLogId: string;
   private readonly provider: string;
+  private reasoning?: ModelReasoning;
   private readonly resolved: ServerCallLlmTooling['resolved'];
   private speed?: ModelPerformance;
   private readonly streamSink: ServerCallLlmStreamSink;
@@ -151,6 +153,7 @@ export class ServerCallLlmAttempt {
           if (data.usage) this.usage = data.usage;
           if (data.speed) this.speed = data.speed;
           if (data.finishReason) this.finishReason = data.finishReason;
+          if (data.reasoning) this.reasoning = data.reasoning;
         },
         onContentPart: async (part) => {
           this.onFirstChunk();
@@ -264,6 +267,7 @@ export class ServerCallLlmAttempt {
       hasContentImages: this.streamSink.hasContentImages,
       hasReasoningImages: this.streamSink.hasReasoningImages,
       imageList: [...this.imageList],
+      reasoning: this.reasoning,
       reasoningParts: [...this.streamSink.reasoningParts],
       speed: this.speed,
       thinkingContent: this.streamSink.thinkingContent,

--- a/apps/server/src/modules/ModelRuntime/index.test.ts
+++ b/apps/server/src/modules/ModelRuntime/index.test.ts
@@ -576,6 +576,20 @@ describe('buildPayloadFromKeyVaults', () => {
       });
     });
 
+    it('ChatGPT: returns the OAuth access token and account id', () => {
+      const keyVaults = {
+        oauthAccessToken: 'oauth-access-token',
+        oauthAccountId: 'chatgpt-account-id',
+      };
+      const payload = buildPayloadFromKeyVaults(keyVaults, ModelProvider.ChatGPT);
+
+      expect(payload).toEqual({
+        apiKey: 'oauth-access-token',
+        chatgptAccountId: 'chatgpt-account-id',
+        runtimeProvider: ModelProvider.ChatGPT,
+      });
+    });
+
     it('Azure: returns apiKey, baseURL and runtimeProvider', () => {
       const keyVaults = {
         apiKey: 'azure-api-key',

--- a/apps/server/src/modules/ModelRuntime/index.ts
+++ b/apps/server/src/modules/ModelRuntime/index.ts
@@ -12,6 +12,7 @@ import {
   type CloudflareKeyVault,
   type ComfyUIKeyVault,
   type GithubCopilotKeyVault,
+  type OAuthDeviceFlowKeyVault,
   type OpenAICompatibleKeyVault,
   type SuperGrokKeyVault,
   type VertexAIKeyVault,
@@ -41,6 +42,7 @@ type ProviderKeyVaults = OpenAICompatibleKeyVault &
   CloudflareKeyVault &
   ComfyUIKeyVault &
   GithubCopilotKeyVault &
+  OAuthDeviceFlowKeyVault &
   SuperGrokKeyVault &
   VertexAIKeyVault;
 
@@ -161,6 +163,14 @@ export const buildPayloadFromKeyVaults = (
       };
     }
 
+    case ModelProvider.ChatGPT: {
+      return {
+        apiKey: keyVaults.oauthAccessToken,
+        chatgptAccountId: keyVaults.oauthAccountId,
+        runtimeProvider,
+      };
+    }
+
     default: {
       return {
         apiKey: keyVaults.apiKey,
@@ -276,6 +286,13 @@ const getParamsFromPayload = (provider: string, payload: ClientSecretPayload) =>
     case ModelProvider.SuperGrok: {
       // OAuth-only: never fall back to env API keys
       return { apiKey: payload.apiKey };
+    }
+
+    case ModelProvider.ChatGPT: {
+      return {
+        apiKey: payload.apiKey,
+        chatgptAccountId: payload.chatgptAccountId,
+      };
     }
 
     case ModelProvider.ComfyUI: {

--- a/apps/server/src/routers/lambda/oauthDeviceFlow.ts
+++ b/apps/server/src/routers/lambda/oauthDeviceFlow.ts
@@ -171,6 +171,7 @@ export const oauthDeviceFlowRouter = router({
           input.providerId,
           {
             keyVaults: {
+              oauthAccountId: pollResult.tokens.accountId,
               oauthAccessToken: pollResult.tokens.accessToken,
               oauthRefreshToken: pollResult.tokens.refreshToken,
               oauthTokenExpiresAt: expiresAt ? String(expiresAt) : undefined,
@@ -199,6 +200,7 @@ export const oauthDeviceFlowRouter = router({
             bearerTokenExpiresAt: undefined,
             githubAvatarUrl: undefined,
             githubUsername: undefined,
+            oauthAccountId: undefined,
             oauthAccessToken: undefined,
             oauthRefreshToken: undefined,
             oauthTokenExpiresAt: undefined,

--- a/apps/server/src/services/oauthDeviceFlow/__tests__/providers/chatGPT.test.ts
+++ b/apps/server/src/services/oauthDeviceFlow/__tests__/providers/chatGPT.test.ts
@@ -141,6 +141,30 @@ describe('ChatGPTOAuthService', () => {
     expect(tokenExchangeBody).toContain('code_verifier=pkce-verifier');
   });
 
+  it('rejects tokens that do not contain a ChatGPT account id', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          authorization_code: 'authorization-code',
+          code_verifier: 'pkce-verifier',
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          access_token: 'access-token',
+          refresh_token: 'refresh-token',
+          token_type: 'bearer',
+        }),
+      );
+
+    await expect(
+      new ChatGPTOAuthService().pollForToken(
+        config,
+        JSON.stringify({ deviceAuthId: 'device-auth-id', userCode: 'ABCD-EFGH' }),
+      ),
+    ).rejects.toThrow('ChatGPT token response is missing an account id');
+  });
+
   it('rejects malformed client-provided device state before making a request', async () => {
     await expect(new ChatGPTOAuthService().pollForToken(config, 'invalid')).rejects.toThrow(
       'Invalid ChatGPT device authorization state',

--- a/apps/server/src/services/oauthDeviceFlow/__tests__/providers/chatGPT.test.ts
+++ b/apps/server/src/services/oauthDeviceFlow/__tests__/providers/chatGPT.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ChatGPTOAuthService, extractChatGPTAccountId } from '../../providers/chatGPT';
+import { getOAuthService } from '../../providers/githubCopilot';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const config = {
+  clientId: 'codex-client',
+  defaultPollingInterval: 8,
+  deviceCodeEndpoint: 'https://auth.openai.com/api/accounts/deviceauth/usercode',
+  refreshTokenGrant: true,
+  scopes: [],
+  tokenEndpoint: 'https://auth.openai.com/oauth/token',
+  tokenExchangeEndpoint: 'https://auth.openai.com/api/accounts/deviceauth/token',
+};
+
+const jsonResponse = (body: unknown, status = 200) => ({
+  json: () => Promise.resolve(body),
+  ok: status >= 200 && status < 300,
+  status,
+  text: () => Promise.resolve(JSON.stringify(body)),
+});
+
+const buildJwt = (claims: object) =>
+  `${Buffer.from('{"alg":"none"}').toString('base64url')}.${Buffer.from(
+    JSON.stringify(claims),
+  ).toString('base64url')}.signature`;
+
+describe('ChatGPTOAuthService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is selected by the OAuth service factory', () => {
+    expect(getOAuthService('chatgpt')).toBeInstanceOf(ChatGPTOAuthService);
+  });
+
+  it('initiates the Codex device flow and returns an opaque polling state', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        device_auth_id: 'device-auth-id',
+        interval: '5',
+        user_code: 'ABCD-EFGH',
+      }),
+    );
+
+    const result = await new ChatGPTOAuthService().initiateDeviceCode(config);
+
+    expect(result).toEqual({
+      deviceCode: JSON.stringify({
+        deviceAuthId: 'device-auth-id',
+        userCode: 'ABCD-EFGH',
+      }),
+      expiresIn: 900,
+      interval: 8,
+      userCode: 'ABCD-EFGH',
+      verificationUri: 'https://auth.openai.com/codex/device',
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      config.deviceCodeEndpoint,
+      expect.objectContaining({
+        body: JSON.stringify({ client_id: config.clientId }),
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'LobeHub/1.0',
+        },
+        method: 'POST',
+      }),
+    );
+  });
+
+  it.each([403, 404])('treats HTTP %s from the polling endpoint as pending', async (status) => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}, status));
+
+    const result = await new ChatGPTOAuthService().pollForToken(
+      config,
+      JSON.stringify({ deviceAuthId: 'device-auth-id', userCode: 'ABCD-EFGH' }),
+    );
+
+    expect(result).toEqual({ status: 'pending' });
+  });
+
+  it('exchanges the authorized device code and extracts the ChatGPT account id', async () => {
+    const idToken = buildJwt({
+      'https://api.openai.com/auth': { chatgpt_account_id: 'account-id' },
+    });
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          authorization_code: 'authorization-code',
+          code_verifier: 'pkce-verifier',
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          access_token: 'access-token',
+          expires_in: 3600,
+          id_token: idToken,
+          refresh_token: 'refresh-token',
+          token_type: 'bearer',
+        }),
+      );
+
+    const result = await new ChatGPTOAuthService().pollForToken(
+      config,
+      JSON.stringify({ deviceAuthId: 'device-auth-id', userCode: 'ABCD-EFGH' }),
+    );
+
+    expect(result).toEqual({
+      status: 'success',
+      tokens: {
+        accessToken: 'access-token',
+        accountId: 'account-id',
+        expiresIn: 3600,
+        refreshToken: 'refresh-token',
+        scope: undefined,
+        tokenType: 'bearer',
+      },
+    });
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      config.tokenExchangeEndpoint,
+      expect.objectContaining({
+        body: JSON.stringify({
+          device_auth_id: 'device-auth-id',
+          user_code: 'ABCD-EFGH',
+        }),
+      }),
+    );
+
+    const tokenExchangeBody = mockFetch.mock.calls[1][1].body as string;
+    expect(tokenExchangeBody).toContain('grant_type=authorization_code');
+    expect(tokenExchangeBody).toContain('code=authorization-code');
+    expect(tokenExchangeBody).toContain(
+      'redirect_uri=https%3A%2F%2Fauth.openai.com%2Fdeviceauth%2Fcallback',
+    );
+    expect(tokenExchangeBody).toContain('code_verifier=pkce-verifier');
+  });
+
+  it('rejects malformed client-provided device state before making a request', async () => {
+    await expect(new ChatGPTOAuthService().pollForToken(config, 'invalid')).rejects.toThrow(
+      'Invalid ChatGPT device authorization state',
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('extractChatGPTAccountId', () => {
+  it('falls back to the access token and organization claim shapes', () => {
+    const accessToken = buildJwt({ organizations: [{ id: 'organization-id' }] });
+
+    expect(extractChatGPTAccountId(undefined, accessToken)).toBe('organization-id');
+  });
+});

--- a/apps/server/src/services/oauthDeviceFlow/__tests__/providers/chatGPT.test.ts
+++ b/apps/server/src/services/oauthDeviceFlow/__tests__/providers/chatGPT.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { CURRENT_VERSION } from '@lobechat/const';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ChatGPTOAuthService, extractChatGPTAccountId } from '../../providers/chatGPT';
@@ -65,7 +66,7 @@ describe('ChatGPTOAuthService', () => {
         body: JSON.stringify({ client_id: config.clientId }),
         headers: {
           'Content-Type': 'application/json',
-          'User-Agent': 'LobeHub/1.0',
+          'User-Agent': `LobeHub/${CURRENT_VERSION}`,
         },
         method: 'POST',
       }),

--- a/apps/server/src/services/oauthDeviceFlow/__tests__/refresh.test.ts
+++ b/apps/server/src/services/oauthDeviceFlow/__tests__/refresh.test.ts
@@ -182,6 +182,31 @@ describe('ensureFreshOAuthToken', () => {
     expect(result.oauthRefreshToken).toBe('old-refresh');
   });
 
+  it('preserves the provider account id when refresh does not return a new one', async () => {
+    mockFetch.mockResolvedValueOnce(
+      tokenResponse({ access_token: 'new-access', refresh_token: 'new-refresh' }),
+    );
+
+    const result = await ensureFreshOAuthToken(
+      makeParams({
+        oauthAccessToken: 'old-access',
+        oauthAccountId: 'account-id',
+        oauthRefreshToken: 'old-refresh',
+        oauthTokenExpiresAt: String(Date.now() - 1000),
+      }),
+    );
+
+    expect(result.oauthAccountId).toBe('account-id');
+    expect(mockUpdateConfig).toHaveBeenCalledWith(
+      'supergrok',
+      expect.objectContaining({
+        keyVaults: expect.objectContaining({ oauthAccountId: 'account-id' }),
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
   it('collapses concurrent refreshes onto a single HTTP call', async () => {
     mockFetch.mockResolvedValue(
       tokenResponse({ access_token: 'new-access', refresh_token: 'new-refresh' }),

--- a/apps/server/src/services/oauthDeviceFlow/index.ts
+++ b/apps/server/src/services/oauthDeviceFlow/index.ts
@@ -15,6 +15,7 @@ export interface DeviceCodeResponse {
 
 export interface TokenResponse {
   accessToken: string;
+  accountId?: string;
   expiresIn?: number;
   refreshToken?: string;
   scope?: string;

--- a/apps/server/src/services/oauthDeviceFlow/providers/chatGPT.ts
+++ b/apps/server/src/services/oauthDeviceFlow/providers/chatGPT.ts
@@ -1,10 +1,12 @@
+import { CURRENT_VERSION } from '@lobechat/const';
+
 import type { OAuthDeviceFlowConfig } from '@/types/aiProvider';
 
 import { type DeviceCodeResponse, OAuthDeviceFlowService, type PollResult } from '../index';
 
 const DEVICE_CODE_TTL_SECONDS = 15 * 60;
 const POLLING_SAFETY_MARGIN_SECONDS = 3;
-const USER_AGENT = 'LobeHub/1.0';
+const USER_AGENT = `LobeHub/${CURRENT_VERSION}`;
 
 interface ChatGPTDeviceState {
   deviceAuthId: string;

--- a/apps/server/src/services/oauthDeviceFlow/providers/chatGPT.ts
+++ b/apps/server/src/services/oauthDeviceFlow/providers/chatGPT.ts
@@ -166,11 +166,16 @@ export class ChatGPTOAuthService extends OAuthDeviceFlowService {
       );
     }
 
+    const accountId = extractChatGPTAccountId(tokens.id_token, tokens.access_token);
+    if (!accountId) {
+      throw new Error('ChatGPT token response is missing an account id');
+    }
+
     return {
       status: 'success',
       tokens: {
         accessToken: tokens.access_token,
-        accountId: extractChatGPTAccountId(tokens.id_token, tokens.access_token),
+        accountId,
         expiresIn: tokens.expires_in,
         refreshToken: tokens.refresh_token,
         scope: tokens.scope,

--- a/apps/server/src/services/oauthDeviceFlow/providers/chatGPT.ts
+++ b/apps/server/src/services/oauthDeviceFlow/providers/chatGPT.ts
@@ -1,0 +1,179 @@
+import type { OAuthDeviceFlowConfig } from '@/types/aiProvider';
+
+import { type DeviceCodeResponse, OAuthDeviceFlowService, type PollResult } from '../index';
+
+const DEVICE_CODE_TTL_SECONDS = 15 * 60;
+const POLLING_SAFETY_MARGIN_SECONDS = 3;
+const USER_AGENT = 'LobeHub/1.0';
+
+interface ChatGPTDeviceState {
+  deviceAuthId: string;
+  userCode: string;
+}
+
+interface ChatGPTTokenClaims {
+  'chatgpt_account_id'?: string;
+  'https://api.openai.com/auth'?: {
+    chatgpt_account_id?: string;
+  };
+  'organizations'?: { id?: string }[];
+}
+
+const parseTokenClaims = (token?: string): ChatGPTTokenClaims | undefined => {
+  if (!token) return undefined;
+
+  const parts = token.split('.');
+  if (parts.length !== 3) return undefined;
+
+  try {
+    return JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+  } catch {
+    return undefined;
+  }
+};
+
+export const extractChatGPTAccountId = (
+  idToken?: string,
+  accessToken?: string,
+): string | undefined => {
+  for (const token of [idToken, accessToken]) {
+    const claims = parseTokenClaims(token);
+    const accountId =
+      claims?.chatgpt_account_id ||
+      claims?.['https://api.openai.com/auth']?.chatgpt_account_id ||
+      claims?.organizations?.[0]?.id;
+
+    if (accountId) return accountId;
+  }
+
+  return undefined;
+};
+
+const parseDeviceState = (deviceCode: string): ChatGPTDeviceState => {
+  try {
+    const state = JSON.parse(deviceCode);
+    if (typeof state?.deviceAuthId === 'string' && typeof state?.userCode === 'string') {
+      return state;
+    }
+  } catch {
+    // Fall through to the stable user-facing error below.
+  }
+
+  throw new Error('Invalid ChatGPT device authorization state');
+};
+
+/**
+ * OpenAI's Codex device login is a two-stage flow:
+ * 1. poll the device endpoint for an authorization code + PKCE verifier
+ * 2. exchange that code at the standard OAuth token endpoint
+ */
+export class ChatGPTOAuthService extends OAuthDeviceFlowService {
+  override async initiateDeviceCode(config: OAuthDeviceFlowConfig): Promise<DeviceCodeResponse> {
+    const response = await fetch(config.deviceCodeEndpoint, {
+      body: JSON.stringify({ client_id: config.clientId }),
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': USER_AGENT,
+      },
+      method: 'POST',
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to initiate device code: ${response.status} ${errorText}`);
+    }
+
+    const data = await response.json();
+    if (!data?.device_auth_id || !data?.user_code) {
+      throw new Error('Invalid ChatGPT device code response');
+    }
+
+    const issuer = new URL(config.tokenEndpoint).origin;
+    const providerInterval = Number.parseInt(data.interval, 10);
+    const interval = Number.isFinite(providerInterval)
+      ? Math.max(providerInterval, 1) + POLLING_SAFETY_MARGIN_SECONDS
+      : config.defaultPollingInterval || 8;
+
+    return {
+      deviceCode: JSON.stringify({
+        deviceAuthId: data.device_auth_id,
+        userCode: data.user_code,
+      } satisfies ChatGPTDeviceState),
+      expiresIn: DEVICE_CODE_TTL_SECONDS,
+      interval,
+      userCode: data.user_code,
+      verificationUri: `${issuer}/codex/device`,
+    };
+  }
+
+  override async pollForToken(
+    config: OAuthDeviceFlowConfig,
+    deviceCode: string,
+  ): Promise<PollResult> {
+    if (!config.tokenExchangeEndpoint) {
+      throw new Error('ChatGPT device token endpoint is not configured');
+    }
+
+    const state = parseDeviceState(deviceCode);
+    const pollResponse = await fetch(config.tokenExchangeEndpoint, {
+      body: JSON.stringify({
+        device_auth_id: state.deviceAuthId,
+        user_code: state.userCode,
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': USER_AGENT,
+      },
+      method: 'POST',
+    });
+
+    if (pollResponse.status === 403 || pollResponse.status === 404) {
+      return { status: 'pending' };
+    }
+
+    if (!pollResponse.ok) {
+      const errorText = await pollResponse.text();
+      throw new Error(`Failed to poll device authorization: ${pollResponse.status} ${errorText}`);
+    }
+
+    const authorization = await pollResponse.json();
+    if (!authorization?.authorization_code || !authorization?.code_verifier) {
+      throw new Error('Invalid ChatGPT device authorization response');
+    }
+
+    const issuer = new URL(config.tokenEndpoint).origin;
+    const tokenResponse = await fetch(config.tokenEndpoint, {
+      body: new URLSearchParams({
+        client_id: config.clientId,
+        code: authorization.authorization_code,
+        code_verifier: authorization.code_verifier,
+        grant_type: 'authorization_code',
+        redirect_uri: `${issuer}/deviceauth/callback`,
+      }).toString(),
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      method: 'POST',
+    });
+
+    const tokens = await tokenResponse.json().catch(() => ({}));
+    if (!tokenResponse.ok || !tokens.access_token) {
+      throw new Error(
+        `Failed to exchange ChatGPT authorization code: ${tokenResponse.status} ${tokens.error || ''} ${tokens.error_description || ''}`.trim(),
+      );
+    }
+
+    return {
+      status: 'success',
+      tokens: {
+        accessToken: tokens.access_token,
+        accountId: extractChatGPTAccountId(tokens.id_token, tokens.access_token),
+        expiresIn: tokens.expires_in,
+        refreshToken: tokens.refresh_token,
+        scope: tokens.scope,
+        tokenType: tokens.token_type || 'bearer',
+      },
+    };
+  }
+}

--- a/apps/server/src/services/oauthDeviceFlow/providers/githubCopilot.ts
+++ b/apps/server/src/services/oauthDeviceFlow/providers/githubCopilot.ts
@@ -1,6 +1,7 @@
 import { type OAuthDeviceFlowConfig } from '@/types/aiProvider';
 
 import { OAuthDeviceFlowService } from '../index';
+import { ChatGPTOAuthService } from './chatGPT';
 
 export interface CopilotTokenResponse {
   expiresAt: number;
@@ -128,6 +129,9 @@ export class GithubCopilotOAuthService extends OAuthDeviceFlowService {
  * Factory function to get the appropriate OAuth service based on provider
  */
 export function getOAuthService(providerId: string): OAuthDeviceFlowService {
+  if (providerId === 'chatgpt') {
+    return new ChatGPTOAuthService();
+  }
   if (providerId === 'githubcopilot') {
     return new GithubCopilotOAuthService();
   }

--- a/apps/server/src/services/oauthDeviceFlow/refresh.ts
+++ b/apps/server/src/services/oauthDeviceFlow/refresh.ts
@@ -25,6 +25,7 @@ const DEFAULT_TOKEN_TTL_MS = 3600 * 1000;
 
 export interface OAuthTokenKeyVaults {
   oauthAccessToken?: string;
+  oauthAccountId?: string;
   oauthRefreshToken?: string;
   oauthTokenExpiresAt?: number | string;
 }
@@ -93,6 +94,7 @@ const persistKeyVaults = async (
     providerId,
     {
       keyVaults: {
+        oauthAccountId: keyVaults.oauthAccountId,
         oauthAccessToken: keyVaults.oauthAccessToken,
         oauthRefreshToken: keyVaults.oauthRefreshToken,
         oauthTokenExpiresAt:
@@ -157,6 +159,7 @@ const refreshAndPersist = async (
     Date.now() + DEFAULT_TOKEN_TTL_MS;
 
   const nextKeyVaults: OAuthTokenKeyVaults = {
+    oauthAccountId: tokens.accountId ?? keyVaults.oauthAccountId,
     oauthAccessToken: tokens.accessToken,
     oauthRefreshToken: tokens.refreshToken,
     oauthTokenExpiresAt: expiresAt,

--- a/packages/agent-runtime/src/executors/callLlmFinalizer.test.ts
+++ b/packages/agent-runtime/src/executors/callLlmFinalizer.test.ts
@@ -134,6 +134,8 @@ describe('callLlmFinalizer', () => {
     expect(result.newState.messages.at(-1)).toEqual({
       content: 'Answer',
       id: 'assistant-1',
+      model: 'fallback-model',
+      provider: 'fallback-provider',
       reasoning: { content: 'Reasoning' },
       role: 'assistant',
       tool_calls: [
@@ -168,6 +170,28 @@ describe('callLlmFinalizer', () => {
       vi.mocked(messages.update).mock.invocationCallOrder[0],
     );
     expect(publishedEvents.some(([event]) => event.type === 'visible_output_end')).toBe(false);
+  });
+
+  it('tags replayable reasoning with its source model and provider', async () => {
+    const result = await finalizeCallLlmTurn({
+      assistantMessageId: 'assistant-1',
+      events: [],
+      host: createHost(),
+      model: 'gpt-5',
+      output: createOutput({
+        reasoning: { signature: 'encrypted-reasoning' },
+        thinkingContent: '',
+      }),
+      provider: 'chatgpt',
+      shouldReplayAssistantReasoning: true,
+      state: AgentRuntime.createInitialState({ operationId: 'operation-1' }),
+    });
+
+    expect(result.newState.messages.at(-1)).toMatchObject({
+      model: 'gpt-5',
+      provider: 'chatgpt',
+      reasoning: { signature: 'encrypted-reasoning' },
+    });
   });
 
   it('publishes no-tool visible output end before persistence and records the marker', async () => {
@@ -308,6 +332,8 @@ describe('callLlmFinalizer', () => {
     expect(result.newState.messages.at(-1)).toEqual({
       content: 'Image answer',
       id: 'assistant-existing',
+      model: 'gemini',
+      provider: 'google',
       reasoning: undefined,
       role: 'assistant',
       tool_calls: undefined,

--- a/packages/agent-runtime/src/executors/callLlmFinalizer.ts
+++ b/packages/agent-runtime/src/executors/callLlmFinalizer.ts
@@ -222,6 +222,8 @@ const buildFinalState = ({
   newState.messages.push({
     content: output.content,
     id: assistantMessageId,
+    model,
+    provider,
     reasoning: shouldReplayAssistantReasoning ? finalReasoning : undefined,
     role: 'assistant',
     tool_calls: sanitizeStateToolCalls(output.toolCalls),

--- a/packages/context-engine/src/processors/MessageCleanup.ts
+++ b/packages/context-engine/src/processors/MessageCleanup.ts
@@ -73,6 +73,8 @@ export class MessageCleanupProcessor extends BaseProcessor {
       case 'assistant': {
         return {
           content: message.content,
+          ...(message.model && { model: message.model }),
+          ...(message.provider && { provider: message.provider }),
           role: message.role,
           ...(message.tool_calls && { tool_calls: message.tool_calls }),
           ...(message.reasoning && { reasoning: message.reasoning }),

--- a/packages/context-engine/src/processors/__tests__/MessageCleanup.test.ts
+++ b/packages/context-engine/src/processors/__tests__/MessageCleanup.test.ts
@@ -159,6 +159,27 @@ describe('MessageCleanupProcessor', () => {
       });
     });
 
+    it('should preserve source model and provider in assistant messages', async () => {
+      const processor = new MessageCleanupProcessor();
+      const context = createContext([
+        {
+          content: 'Here is the answer',
+          model: 'gpt-5.5',
+          provider: 'chatgpt',
+          role: 'assistant',
+        },
+      ]);
+
+      const result = await processor.process(context);
+
+      expect(result.messages[0]).toEqual({
+        content: 'Here is the answer',
+        model: 'gpt-5.5',
+        provider: 'chatgpt',
+        role: 'assistant',
+      });
+    });
+
     it('should clean tool messages with name', async () => {
       const processor = new MessageCleanupProcessor();
       const context = createContext([

--- a/packages/fetch-sse/src/__tests__/reasoningSignature.test.ts
+++ b/packages/fetch-sse/src/__tests__/reasoningSignature.test.ts
@@ -1,0 +1,50 @@
+import type { FetchEventSourceInit } from '@lobechat/utils/client/fetchEventSource/index';
+import { fetchEventSource } from '@lobechat/utils/client/fetchEventSource/index';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchSSE } from '../fetchSSE';
+
+vi.mock('@lobechat/model-runtime', () => ({
+  parseToolCalls: vi.fn(),
+}));
+
+vi.mock('@lobechat/utils/client/fetchEventSource/index', () => ({
+  fetchEventSource: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('fetchSSE reasoning signatures', () => {
+  it('should preserve a reasoning signature without visible reasoning text', async () => {
+    const mockOnFinish = vi.fn();
+
+    (fetchEventSource as any).mockImplementationOnce(
+      (url: string, options: FetchEventSourceInit) => {
+        options.onopen!({ clone: () => ({ ok: true, headers: new Headers() }) } as any);
+        options.onmessage!({
+          data: JSON.stringify('encrypted-reasoning-content'),
+          event: 'reasoning_signature',
+        } as any);
+        options.onmessage!({ data: JSON.stringify('Done'), event: 'text' } as any);
+      },
+    );
+
+    await fetchSSE('/', {
+      onFinish: mockOnFinish,
+      responseAnimation: 'fadeIn',
+    });
+
+    expect(mockOnFinish).toHaveBeenCalledWith('Done', {
+      observationId: null,
+      reasoning: {
+        content: undefined,
+        signature: 'encrypted-reasoning-content',
+      },
+      toolCalls: undefined,
+      traceId: null,
+      type: 'done',
+    });
+  });
+});

--- a/packages/fetch-sse/src/fetchSSE.ts
+++ b/packages/fetch-sse/src/fetchSSE.ts
@@ -548,7 +548,10 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
         grounding,
         images: images.length > 0 ? images : undefined,
         observationId,
-        reasoning: !!thinking ? { content: thinking, signature: thinkingSignature } : undefined,
+        reasoning:
+          thinking || thinkingSignature
+            ? { content: thinking || undefined, signature: thinkingSignature }
+            : undefined,
         speed,
         toolCalls,
         traceId,

--- a/packages/fetch-sse/vitest.config.mts
+++ b/packages/fetch-sse/vitest.config.mts
@@ -1,7 +1,13 @@
+import path from 'node:path';
+
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    alias: {
+      // Keep this package unit-testable when a parent workspace overrides model-runtime.
+      '@lobechat/model-runtime': path.resolve(__dirname, '../model-runtime/src/helpers/index.ts'),
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'lcov', 'text-summary'],

--- a/packages/model-bank/package.json
+++ b/packages/model-bank/package.json
@@ -20,6 +20,7 @@
     "./bedrock": "./src/aiModels/bedrock.ts",
     "./bfl": "./src/aiModels/bfl.ts",
     "./cerebras": "./src/aiModels/cerebras.ts",
+    "./chatGPT": "./src/aiModels/chatGPT.ts",
     "./cloudflare": "./src/aiModels/cloudflare.ts",
     "./cohere": "./src/aiModels/cohere.ts",
     "./cometapi": "./src/aiModels/cometapi.ts",

--- a/packages/model-bank/src/aiModels/__tests__/index.test.ts
+++ b/packages/model-bank/src/aiModels/__tests__/index.test.ts
@@ -99,3 +99,16 @@ describe('knowledgeCutoff backfill', () => {
     expect(lobehubModels.find((m) => m.id === 'gpt-5-mini')?.knowledgeCutoff).toBe('2024-05');
   });
 });
+
+describe('ChatGPT subscription models', () => {
+  it('advertises reasoning replay support', () => {
+    const models = LOBE_DEFAULT_MODEL_LIST.filter(
+      (model) => model.providerId === ModelProvider.ChatGPT,
+    );
+
+    expect(models).toHaveLength(4);
+    expect(
+      models.every((model) => model.settings?.extendParams?.includes('preserveThinking')),
+    ).toBe(true);
+  });
+});

--- a/packages/model-bank/src/aiModels/chatGPT.ts
+++ b/packages/model-bank/src/aiModels/chatGPT.ts
@@ -1,0 +1,19 @@
+import type { AIChatModelCard } from '../types/aiModel';
+import { openaiChatModels } from './openai';
+
+const CHATGPT_MODEL_IDS = new Set(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna', 'gpt-5.5']);
+
+/**
+ * Models available through ChatGPT subscription authentication use the Codex
+ * backend rather than the usage-billed OpenAI Platform API. Reuse the OpenAI
+ * model metadata, but omit per-token pricing and cap the context window to the
+ * current Codex catalog limit.
+ */
+const chatGPTChatModels: AIChatModelCard[] = openaiChatModels
+  .filter(({ id }) => CHATGPT_MODEL_IDS.has(id))
+  .map(({ pricing: _pricing, ...model }) => ({
+    ...model,
+    contextWindowTokens: 272_000,
+  }));
+
+export default chatGPTChatModels;

--- a/packages/model-bank/src/aiModels/chatGPT.ts
+++ b/packages/model-bank/src/aiModels/chatGPT.ts
@@ -14,6 +14,10 @@ const chatGPTChatModels: AIChatModelCard[] = openaiChatModels
   .map(({ pricing: _pricing, ...model }) => ({
     ...model,
     contextWindowTokens: 272_000,
+    settings: {
+      ...model.settings,
+      extendParams: [...(model.settings?.extendParams || []), 'preserveThinking'],
+    },
   }));
 
 export default chatGPTChatModels;

--- a/packages/model-bank/src/aiModels/index.ts
+++ b/packages/model-bank/src/aiModels/index.ts
@@ -15,6 +15,7 @@ import { default as bailiancodingplan } from './bailianCodingPlan';
 import { default as bedrock } from './bedrock';
 import { default as bfl } from './bfl';
 import { default as cerebras } from './cerebras';
+import { default as chatgpt } from './chatGPT';
 import { default as cloudflare } from './cloudflare';
 import { default as cohere } from './cohere';
 import { default as cometapi } from './cometapi';
@@ -124,6 +125,7 @@ const staticModelMap: ModelsMap = {
   bedrock,
   bfl,
   cerebras,
+  chatgpt,
   cloudflare,
   cohere,
   cometapi,
@@ -239,6 +241,7 @@ export { default as bailiancodingplan } from './bailianCodingPlan';
 export { default as bedrock } from './bedrock';
 export { default as bfl } from './bfl';
 export { default as cerebras } from './cerebras';
+export { default as chatgpt } from './chatGPT';
 export { default as cloudflare } from './cloudflare';
 export { default as cohere } from './cohere';
 export { default as cometapi } from './cometapi';

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -13,6 +13,7 @@ export enum ModelProvider {
   Bedrock = 'bedrock',
   Bfl = 'bfl',
   Cerebras = 'cerebras',
+  ChatGPT = 'chatgpt',
   Cloudflare = 'cloudflare',
   Cohere = 'cohere',
   CometAPI = 'cometapi',

--- a/packages/model-bank/src/modelProviders/chatGPT.ts
+++ b/packages/model-bank/src/modelProviders/chatGPT.ts
@@ -1,0 +1,37 @@
+import type { ModelProviderCard } from '../types';
+
+/**
+ * ChatGPT subscription access to OpenAI models through the Codex OAuth device
+ * flow and Responses API backend. The OAuth client id belongs to the public
+ * Codex CLI client and does not require a client secret.
+ */
+const ChatGPT: ModelProviderCard = {
+  chatModels: [],
+  checkModel: 'gpt-5.5',
+  description:
+    'Use models included with your ChatGPT subscription through Codex, without an OpenAI Platform API key.',
+  disableBrowserRequest: true,
+  id: 'chatgpt',
+  modelsUrl: 'https://learn.chatgpt.com/docs/models',
+  name: 'ChatGPT',
+  settings: {
+    authType: 'oauthDeviceFlow',
+    disableBrowserRequest: true,
+    oauthDeviceFlow: {
+      clientId: 'app_EMoamEEZ73f0CkXaXp7hrann',
+      defaultPollingInterval: 8,
+      deviceCodeEndpoint: 'https://auth.openai.com/api/accounts/deviceauth/usercode',
+      refreshTokenGrant: true,
+      scopes: [],
+      tokenEndpoint: 'https://auth.openai.com/oauth/token',
+      tokenExchangeEndpoint: 'https://auth.openai.com/api/accounts/deviceauth/token',
+    },
+    sdkType: 'openai',
+    showApiKey: false,
+    showChecker: true,
+    showModelFetcher: false,
+  },
+  url: 'https://chatgpt.com',
+};
+
+export default ChatGPT;

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -15,6 +15,7 @@ import BailianCodingPlanProvider from './bailianCodingPlan';
 import BedrockProvider from './bedrock';
 import BflProvider from './bfl';
 import CerebrasProvider from './cerebras';
+import ChatGPTProvider from './chatGPT';
 import CloudflareProvider from './cloudflare';
 import CohereProvider from './cohere';
 import CometAPIProvider from './cometapi';
@@ -148,6 +149,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   GLMCodingPlanProvider,
   KimiCodingPlanProvider,
   OpenAIProvider,
+  ChatGPTProvider,
   DeepSeekProvider,
   XinferenceProvider,
   MoonshotProvider,
@@ -257,6 +259,7 @@ export { default as BailianCodingPlanProviderCard } from './bailianCodingPlan';
 export { default as BedrockProviderCard } from './bedrock';
 export { default as BflProviderCard } from './bfl';
 export { default as CerebrasProviderCard } from './cerebras';
+export { default as ChatGPTProviderCard } from './chatGPT';
 export { default as CloudflareProviderCard } from './cloudflare';
 export { default as CohereProviderCard } from './cohere';
 export { default as CometAPIProviderCard } from './cometapi';

--- a/packages/model-bank/src/types/aiProvider.ts
+++ b/packages/model-bank/src/types/aiProvider.ts
@@ -82,6 +82,11 @@ export interface OAuthDeviceFlowKeyVault {
    */
   oauthAccessToken?: string;
   /**
+   * Provider account identifier associated with the OAuth token.
+   * Some OAuth-backed inference endpoints require it as a request header.
+   */
+  oauthAccountId?: string;
+  /**
    * OAuth refresh token. May rotate on every refresh (e.g. xAI) — always
    * persist the value returned by the latest refresh response.
    */

--- a/packages/model-runtime/src/core/contextBuilders/openai.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.test.ts
@@ -920,17 +920,18 @@ describe('convertOpenAIResponseInputs', () => {
     ]);
   });
 
-  it('should preserve encrypted reasoning content for stateless Responses requests', async () => {
+  it('should replay encrypted reasoning from a persisted message for the same provider', async () => {
     const messages: OpenAIChatMessage[] = [
       {
         content: 'hello',
+        model: 'gpt-5.6-sol',
         provider: 'chatgpt',
         reasoning: {
           content: 'reasoning content',
           signature: 'encrypted-reasoning-content',
         },
         role: 'assistant',
-      } as OpenAIChatMessage & { provider: string },
+      },
     ];
 
     const result = await convertOpenAIResponseInputs(messages, { provider: 'chatgpt' });
@@ -952,7 +953,7 @@ describe('convertOpenAIResponseInputs', () => {
         provider: 'chatgpt',
         reasoning: { signature: 'encrypted-reasoning-content' },
         role: 'assistant',
-      } as OpenAIChatMessage & { provider: string },
+      },
     ];
 
     const result = await convertOpenAIResponseInputs(messages, { provider: 'chatgpt' });
@@ -1032,7 +1033,7 @@ describe('convertOpenAIResponseInputs', () => {
           duration: 110,
           signature: 'E',
         },
-      } as OpenAIChatMessage & { provider: string },
+      },
     ];
     const result = await convertOpenAIResponseInputs(messages, { provider: 'chatgpt' });
     expect(result).toEqual([

--- a/packages/model-runtime/src/core/contextBuilders/openai.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.test.ts
@@ -920,6 +920,53 @@ describe('convertOpenAIResponseInputs', () => {
     ]);
   });
 
+  it('should preserve encrypted reasoning content for stateless Responses requests', async () => {
+    const messages: OpenAIChatMessage[] = [
+      {
+        content: 'hello',
+        provider: 'chatgpt',
+        reasoning: {
+          content: 'reasoning content',
+          signature: 'encrypted-reasoning-content',
+        },
+        role: 'assistant',
+      } as OpenAIChatMessage & { provider: string },
+    ];
+
+    const result = await convertOpenAIResponseInputs(messages, { provider: 'chatgpt' });
+
+    expect(result).toEqual([
+      {
+        encrypted_content: 'encrypted-reasoning-content',
+        summary: [{ text: 'reasoning content', type: 'summary_text' }],
+        type: 'reasoning',
+      },
+      { content: 'hello', role: 'assistant' },
+    ]);
+  });
+
+  it('should preserve encrypted reasoning content without a visible summary', async () => {
+    const messages: OpenAIChatMessage[] = [
+      {
+        content: 'hello',
+        provider: 'chatgpt',
+        reasoning: { signature: 'encrypted-reasoning-content' },
+        role: 'assistant',
+      } as OpenAIChatMessage & { provider: string },
+    ];
+
+    const result = await convertOpenAIResponseInputs(messages, { provider: 'chatgpt' });
+
+    expect(result).toEqual([
+      {
+        encrypted_content: 'encrypted-reasoning-content',
+        summary: [],
+        type: 'reasoning',
+      },
+      { content: 'hello', role: 'assistant' },
+    ]);
+  });
+
   it('should preserve message order when earlier messages have async content (images)', async () => {
     const messages: OpenAIChatMessage[] = [
       { content: 'system prompts', role: 'system' },
@@ -978,16 +1025,16 @@ describe('convertOpenAIResponseInputs', () => {
             type: 'text',
           },
         ],
+        provider: 'anthropic',
         role: 'assistant',
         reasoning: {
           content: 'The user is asking',
           duration: 110,
-          // @ts-expect-error: ignore
           signature: 'E',
         },
-      },
+      } as OpenAIChatMessage & { provider: string },
     ];
-    const result = await convertOpenAIResponseInputs(messages);
+    const result = await convertOpenAIResponseInputs(messages, { provider: 'chatgpt' });
     expect(result).toEqual([
       { content: 'system prompts', role: 'developer' },
       { content: '你是谁', role: 'user' },

--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -224,7 +224,7 @@ export const convertOpenAIResponseInputs = async (
   const inputGroups = await Promise.all(
     messages.map(async (message) => {
       const items: OpenAI.Responses.ResponseInputItem[] = [];
-      const sourceProvider = (message as OpenAIChatMessage & { provider?: string }).provider;
+      const sourceProvider = message.provider;
       const reasoning = message.reasoning;
       const encryptedContent =
         sourceProvider && sourceProvider === options?.provider ? reasoning?.signature : undefined;
@@ -384,15 +384,16 @@ export const convertOpenAIResponseInputs = async (
         return items;
       }
 
+      const {
+        model: _model,
+        provider: _provider,
+        reasoning: _reasoning,
+        ...responseMessage
+      } = message;
       const item = {
-        ...message,
+        ...responseMessage,
         content,
       } as OpenAI.Responses.ResponseInputItem;
-
-      // remove reasoning field from the message item
-      delete (item as any).reasoning;
-      delete (item as any).model;
-      delete (item as any).provider;
 
       items.push(item);
       return items;

--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -19,6 +19,7 @@ type ConvertMessageContentOptions = {
   forceImageBase64?: boolean;
   forceVideoBase64?: boolean;
   model?: string;
+  provider?: string;
   strictToolPairing?: boolean;
 };
 
@@ -223,11 +224,16 @@ export const convertOpenAIResponseInputs = async (
   const inputGroups = await Promise.all(
     messages.map(async (message) => {
       const items: OpenAI.Responses.ResponseInputItem[] = [];
+      const sourceProvider = (message as OpenAIChatMessage & { provider?: string }).provider;
+      const reasoning = message.reasoning;
+      const encryptedContent =
+        sourceProvider && sourceProvider === options?.provider ? reasoning?.signature : undefined;
 
-      // if message has reasoning, add it as a separate reasoning item
-      if (message.reasoning?.content) {
+      // Preserve encrypted reasoning state for stateless Responses API requests.
+      if (reasoning?.content || encryptedContent) {
         items.push({
-          summary: [{ text: message.reasoning.content, type: 'summary_text' }],
+          encrypted_content: encryptedContent,
+          summary: reasoning?.content ? [{ text: reasoning.content, type: 'summary_text' }] : [],
           type: 'reasoning',
         } as OpenAI.Responses.ResponseReasoningItem);
       }
@@ -385,6 +391,8 @@ export const convertOpenAIResponseInputs = async (
 
       // remove reasoning field from the message item
       delete (item as any).reasoning;
+      delete (item as any).model;
+      delete (item as any).provider;
 
       items.push(item);
       return items;

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -396,6 +396,18 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
       return { ...requestPayload, model: mappedModel };
     }
 
+    private prepareResponsesRequest(
+      requestPayload: ResponseCreateParamsWithPromptCacheKey,
+      logicalModel: string,
+    ) {
+      const mappedRequestPayload = this.withMappedRequestModel(requestPayload, logicalModel);
+      return (
+        responses?.prepareRequest?.(mappedRequestPayload, this._options) || {
+          payload: mappedRequestPayload,
+        }
+      );
+    }
+
     /**
      * Determine if should use Responses API based on various configuration options
      * @param params - Configuration parameters
@@ -1052,20 +1064,26 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
 
         if (shouldUseResponses) {
           log('calling responses.create for structured output');
-          const res = await this.client!.responses.create(
-            this.withMappedRequestModel(
-              {
-                input: messages,
-                model,
-                ...getGenerateObjectResponsesReasoningParams(payload),
-                ...this.resolvePromptCacheKeyParams(model, options?.user),
-                text: { format: { strict: true, type: 'json_schema', ...processedSchema } },
-                // Responses API replaced `user` with `safety_identifier`; some endpoints reject `user`
-                safety_identifier: options?.user,
-              } as any,
+          const preparedRequest = this.prepareResponsesRequest(
+            {
+              input: messages,
               model,
-            ),
-            { headers: options?.headers, signal: options?.signal },
+              ...getGenerateObjectResponsesReasoningParams(payload),
+              ...this.resolvePromptCacheKeyParams(model, options?.user),
+              text: { format: { strict: true, type: 'json_schema', ...processedSchema } },
+              // Responses API replaced `user` with `safety_identifier`; some endpoints reject `user`
+              safety_identifier: options?.user,
+            } as any,
+            model,
+          );
+          const res = await this.client!.responses.create(
+            preparedRequest.payload as OpenAI.Responses.ResponseCreateParamsNonStreaming,
+            {
+              headers: preparedRequest.headers
+                ? { ...options?.headers, ...preparedRequest.headers }
+                : options?.headers,
+              signal: options?.signal,
+            },
           );
 
           if (res.usage) {
@@ -1453,9 +1471,8 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           preferTemperature: true,
         }),
       } as ResponseCreateParamsWithPromptCacheKey;
-      const mappedRequestPayload = this.withMappedRequestModel(postPayload, usageModel);
-      const preparedRequest = responses?.prepareRequest?.(mappedRequestPayload, this._options);
-      const requestPayload = preparedRequest?.payload || mappedRequestPayload;
+      const preparedRequest = this.prepareResponsesRequest(postPayload, usageModel);
+      const requestPayload = preparedRequest.payload;
 
       if (debugParams?.responses?.()) {
         debugPayload(requestPayload);
@@ -1570,20 +1587,26 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           strictToolPairing: true,
         });
 
+        const preparedRequest = this.prepareResponsesRequest(
+          {
+            input,
+            model,
+            ...this.resolvePromptCacheKeyParams(model, options?.user),
+            tool_choice: 'required',
+            tools: tools!.map((tool) => this.convertChatCompletionToolToResponseTool(tool)),
+            // Responses API replaced `user` with `safety_identifier`; some endpoints reject `user`
+            safety_identifier: options?.user,
+          } as any,
+          payload.model,
+        );
         const res = await this.client.responses.create(
-          this.withMappedRequestModel(
-            {
-              input,
-              model,
-              ...this.resolvePromptCacheKeyParams(model, options?.user),
-              tool_choice: 'required',
-              tools: tools!.map((tool) => this.convertChatCompletionToolToResponseTool(tool)),
-              // Responses API replaced `user` with `safety_identifier`; some endpoints reject `user`
-              safety_identifier: options?.user,
-            } as any,
-            payload.model,
-          ),
-          { headers: options?.headers, signal: options?.signal },
+          preparedRequest.payload as OpenAI.Responses.ResponseCreateParamsNonStreaming,
+          {
+            headers: preparedRequest.headers
+              ? { ...options?.headers, ...preparedRequest.headers }
+              : options?.headers,
+            signal: options?.signal,
+          },
         );
 
         if (res.usage) {

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -305,6 +305,13 @@ export interface OpenAICompatibleFactoryOptions<T extends Record<string, any> = 
       payload: ChatStreamPayload,
       options: ConstructorOptions<T>,
     ) => ChatStreamPayload;
+    prepareRequest?: (
+      payload: ResponseCreateParamsWithPromptCacheKey,
+      options: ConstructorOptions<T>,
+    ) => {
+      headers?: Record<string, string>;
+      payload: ResponseCreateParamsWithPromptCacheKey;
+    };
   };
 }
 
@@ -1446,7 +1453,9 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           preferTemperature: true,
         }),
       } as ResponseCreateParamsWithPromptCacheKey;
-      const requestPayload = this.withMappedRequestModel(postPayload, usageModel);
+      const mappedRequestPayload = this.withMappedRequestModel(postPayload, usageModel);
+      const preparedRequest = responses?.prepareRequest?.(mappedRequestPayload, this._options);
+      const requestPayload = preparedRequest?.payload || mappedRequestPayload;
 
       if (debugParams?.responses?.()) {
         debugPayload(requestPayload);
@@ -1455,7 +1464,10 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
       log('sending responses.create request');
 
       const response = await this.client.responses.create(requestPayload, {
-        headers: options?.requestHeaders,
+        headers: {
+          ...options?.requestHeaders,
+          ...preparedRequest?.headers,
+        },
         signal: options?.signal,
       });
 

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -1406,6 +1406,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
       const input = await convertOpenAIResponseInputs(messages as any, {
         forceImageBase64: chatCompletion?.forceImageBase64,
         forceVideoBase64: chatCompletion?.forceVideoBase64,
+        provider: this.id,
         strictToolPairing: true,
       });
 
@@ -1553,6 +1554,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         const input = await convertOpenAIResponseInputs(messages as any, {
           forceImageBase64: chatCompletion?.forceImageBase64,
           forceVideoBase64: chatCompletion?.forceVideoBase64,
+          provider: this.id,
           strictToolPairing: true,
         });
 

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/nonStreamToStream.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/nonStreamToStream.test.ts
@@ -465,6 +465,47 @@ describe('nonStreamToStream', () => {
       ]);
     });
 
+    it('should preserve encrypted reasoning in a non-streaming response', async () => {
+      const reasoning = {
+        encrypted_content: 'encrypted-signature',
+        id: 'reasoning_001',
+        summary: [],
+        type: 'reasoning',
+      };
+      const mockResponse = {
+        created_at: 1677652288,
+        id: 'resp_reasoning',
+        model: 'gpt-5.6-sol',
+        object: 'response',
+        output: [reasoning],
+        status: 'completed',
+      } as unknown as OpenAI.Responses.Response;
+
+      const stream = transformResponseAPIToStream(mockResponse);
+      const events = [];
+      const reader = stream.getReader();
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        events.push(value);
+      }
+
+      expect(events).toEqual([
+        {
+          item: reasoning,
+          output_index: 0,
+          sequence_number: 0,
+          type: 'response.output_item.done',
+        },
+        {
+          response: mockResponse,
+          sequence_number: 999,
+          type: 'response.completed',
+        },
+      ]);
+    });
+
     it('should handle Response API with message but no text content', async () => {
       const mockResponse: OpenAI.Responses.Response = {
         id: 'resp_no_text',

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/nonStreamToStream.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/nonStreamToStream.ts
@@ -97,7 +97,7 @@ export const transformResponseAPIToStream = (data: OpenAI.Responses.Response) =>
     start(controller) {
       // Check if output exists and is an array
       if (data.output && Array.isArray(data.output)) {
-        data.output.forEach((output) => {
+        data.output.forEach((output, outputIndex) => {
           switch (output.type) {
             case 'message': {
               // Check if content exists and is an array
@@ -116,6 +116,17 @@ export const transformResponseAPIToStream = (data: OpenAI.Responses.Response) =>
                     }
                   }
                 });
+              }
+              break;
+            }
+            case 'reasoning': {
+              if (output.encrypted_content) {
+                controller.enqueue({
+                  item: output,
+                  output_index: outputIndex,
+                  sequence_number: outputIndex,
+                  type: 'response.output_item.done',
+                } as OpenAI.Responses.ResponseOutputItemDoneEvent);
               }
               break;
             }

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
@@ -709,6 +709,34 @@ describe('OpenAIResponsesStream', () => {
     expect(chunks).toMatchSnapshot();
   });
 
+  it('should emit encrypted reasoning content as a reasoning signature', async () => {
+    const mockOpenAIStream = createReadableStream([
+      {
+        type: 'response.created',
+        response: {
+          id: 'resp_reasoning_signature',
+          status: 'in_progress',
+        },
+      },
+      {
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          encrypted_content: 'encrypted-reasoning-content',
+          id: 'reasoning_item',
+          summary: [],
+          type: 'reasoning',
+        },
+      },
+    ]);
+
+    const protocolStream = OpenAIResponsesStream(mockOpenAIStream);
+    const chunks = await readStreamChunk(protocolStream);
+
+    expect(chunks.some((chunk) => chunk.includes('event: reasoning_signature'))).toBe(true);
+    expect(chunks.some((chunk) => chunk.includes('encrypted-reasoning-content'))).toBe(true);
+  });
+
   it('should handle response.completed with usage', async () => {
     const mockOpenAIStream = createReadableStream([
       {

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.ts
@@ -146,6 +146,14 @@ const transformOpenAIStream = (
       }
 
       case 'response.output_item.done': {
+        if (chunk.item.type === 'reasoning' && chunk.item.encrypted_content) {
+          return {
+            data: chunk.item.encrypted_content,
+            id: chunk.item.id,
+            type: 'reasoning_signature',
+          };
+        }
+
         if (streamContext.returnedCitationArray?.length) {
           return {
             data: { citations: streamContext.returnedCitationArray },

--- a/packages/model-runtime/src/core/streams/protocol.test.ts
+++ b/packages/model-runtime/src/core/streams/protocol.test.ts
@@ -720,6 +720,29 @@ describe('createCallbacksTransformer', () => {
     expect(onThinking).toHaveBeenNthCalledWith(2, ' about this');
   });
 
+  it('should preserve reasoning signatures in final callback data', async () => {
+    const onCompletion = vi.fn();
+    const transformer = createCallbacksTransformer({ onCompletion });
+
+    const chunks = [
+      'event: reasoning\n',
+      'data: "Thinking..."\n\n',
+      'event: reasoning_signature\n',
+      'data: "encrypted-signature"\n\n',
+    ];
+
+    await processChunks(transformer, chunks);
+
+    expect(onCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reasoning: {
+          content: 'Thinking...',
+          signature: 'encrypted-signature',
+        },
+      }),
+    );
+  });
+
   it('should handle base64_image chunks and call onBase64Image callback', async () => {
     const receivedCalls: Array<{
       image: { id: string; data: string };
@@ -939,6 +962,7 @@ describe('createCallbacksTransformer', () => {
       thinking: 'Thinking...',
       usage: { totalTokens: 10 },
       grounding: undefined,
+      reasoning: { content: 'Thinking...', signature: undefined },
       speed: undefined,
       toolsCalling: undefined,
     };

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -437,6 +437,7 @@ export function createCallbacksTransformer(
   const textEncoder = new TextEncoder();
   let aggregatedText = '';
   let aggregatedThinking: string | undefined = undefined;
+  let reasoningSignature: string | undefined;
   let usage: ModelUsage | undefined;
   let speed: ModelPerformance | undefined;
   let grounding: any;
@@ -461,6 +462,12 @@ export function createCallbacksTransformer(
         toolsCalling,
         usage,
       };
+      if (aggregatedThinking || reasoningSignature) {
+        data.reasoning = {
+          content: aggregatedThinking,
+          signature: reasoningSignature,
+        };
+      }
       const usageMissingDiagnostics = usage
         ? undefined
         : options?.streamStack?.usageMissingDiagnostics;
@@ -516,6 +523,11 @@ export function createCallbacksTransformer(
 
             aggregatedThinking += data;
             await callbacks.onThinking?.(data);
+            break;
+          }
+
+          case 'reasoning_signature': {
+            reasoningSignature = data;
             break;
           }
 

--- a/packages/model-runtime/src/index.ts
+++ b/packages/model-runtime/src/index.ts
@@ -43,6 +43,7 @@ export { LobeBailianCodingPlanAI } from './providers/bailianCodingPlan';
 export { LobeBedrockAI } from './providers/bedrock';
 export { LobeBflAI } from './providers/bfl';
 export { LobeCerebrasAI } from './providers/cerebras';
+export { LobeChatGPTAI } from './providers/chatGPT';
 export { LobeCometAPIAI } from './providers/cometapi';
 export { LobeComfyUI } from './providers/comfyui';
 export { LobeDeepSeekAI } from './providers/deepseek';

--- a/packages/model-runtime/src/providers/chatGPT/index.test.ts
+++ b/packages/model-runtime/src/providers/chatGPT/index.test.ts
@@ -130,6 +130,123 @@ describe('LobeChatGPTAI', () => {
     },
   );
 
+  it('uses the Responses Lite contract for structured output', async () => {
+    (instance['client'].responses.create as Mock).mockResolvedValue({
+      output_text: '{"city":"Hangzhou"}',
+    });
+
+    const result = await instance.generateObject(
+      {
+        messages: [{ content: 'Extract the city', role: 'user' }],
+        model: 'gpt-5.6-sol',
+        schema: {
+          name: 'location',
+          schema: {
+            properties: { city: { type: 'string' } },
+            required: ['city'],
+            type: 'object',
+          },
+        },
+      },
+      { headers: { 'x-request-id': 'request-id' }, user: 'user-id' },
+    );
+
+    const [request, requestOptions] = (instance['client'].responses.create as Mock).mock.calls[0];
+
+    expect(result).toEqual({ city: 'Hangzhou' });
+    expect(request).toMatchObject({
+      input: [
+        { role: 'developer', tools: [], type: 'additional_tools' },
+        { content: 'Extract the city', role: 'user' },
+      ],
+      model: 'gpt-5.6-sol',
+      reasoning: { context: 'all_turns' },
+      text: {
+        format: {
+          name: 'location',
+          schema: {
+            properties: { city: { type: 'string' } },
+            required: ['city'],
+            type: 'object',
+          },
+          strict: true,
+          type: 'json_schema',
+        },
+      },
+      tool_choice: 'auto',
+    });
+    expect(request.safety_identifier).toBeUndefined();
+    expect(requestOptions.headers).toMatchObject({
+      'x-openai-internal-codex-responses-lite': 'true',
+      'x-request-id': 'request-id',
+    });
+  });
+
+  it('uses Responses Lite tools while preserving required tool choice', async () => {
+    (instance['client'].responses.create as Mock).mockResolvedValue({
+      output: [
+        {
+          arguments: '{"city":"Hangzhou"}',
+          name: 'extract_location',
+          type: 'function_call',
+        },
+      ],
+    });
+
+    const result = await instance.generateObject(
+      {
+        messages: [{ content: 'Extract the city', role: 'user' }],
+        model: 'gpt-5.6-sol',
+        tools: [
+          {
+            function: {
+              name: 'extract_location',
+              parameters: {
+                properties: { city: { type: 'string' } },
+                required: ['city'],
+                type: 'object',
+              },
+            },
+            type: 'function',
+          },
+        ],
+      },
+      { user: 'user-id' },
+    );
+
+    const [request, requestOptions] = (instance['client'].responses.create as Mock).mock.calls[0];
+
+    expect(result).toEqual([{ arguments: { city: 'Hangzhou' }, name: 'extract_location' }]);
+    expect(request).toMatchObject({
+      input: [
+        {
+          role: 'developer',
+          tools: [
+            {
+              name: 'extract_location',
+              parameters: {
+                properties: { city: { type: 'string' } },
+                required: ['city'],
+                type: 'object',
+              },
+              type: 'function',
+            },
+          ],
+          type: 'additional_tools',
+        },
+        { content: 'Extract the city', role: 'user' },
+      ],
+      parallel_tool_calls: false,
+      reasoning: { context: 'all_turns' },
+      tool_choice: 'required',
+    });
+    expect(request.safety_identifier).toBeUndefined();
+    expect(request.tools).toBeUndefined();
+    expect(requestOptions.headers).toMatchObject({
+      'x-openai-internal-codex-responses-lite': 'true',
+    });
+  });
+
   it('reuses OpenAI Responses payload handling for reasoning and web search', async () => {
     await instance.chat({
       enabledSearch: true,

--- a/packages/model-runtime/src/providers/chatGPT/index.test.ts
+++ b/packages/model-runtime/src/providers/chatGPT/index.test.ts
@@ -30,11 +30,15 @@ describe('LobeChatGPTAI', () => {
 
     expect(instance.baseURL).toBe('https://chatgpt.com/backend-api/codex');
     expect(instance['client'].apiKey).toBe('access-token');
-    expect(headers['ChatGPT-Account-Id']).toBe('account-id');
-    expect(headers['User-Agent']).toBe(`LobeHub/${CURRENT_VERSION}`);
-    expect(headers.originator).toBe('lobehub');
-    expect(headers['session-id']).toEqual(expect.any(String));
-    expect(headers.version).toBe(CURRENT_VERSION);
+    expect(headers).toEqual(
+      expect.objectContaining({
+        'ChatGPT-Account-Id': 'account-id',
+        'User-Agent': `LobeHub/${CURRENT_VERSION}`,
+        'originator': 'lobehub',
+        'session-id': expect.any(String),
+        'version': CURRENT_VERSION,
+      }),
+    );
   });
 
   it('always uses Responses API and omits public API output limits', async () => {
@@ -74,7 +78,6 @@ describe('LobeChatGPTAI', () => {
             { content: 'Check the weather', role: 'user' },
           ],
           model,
-          parallel_tool_calls: true,
           reasoning_effort: 'high',
           tools: [
             {

--- a/packages/model-runtime/src/providers/chatGPT/index.test.ts
+++ b/packages/model-runtime/src/providers/chatGPT/index.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+import type { Mock } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LobeChatGPTAI } from './index';
+
+vi.mock('@lobechat/business-model-bank/model-config', () => ({
+  loadModels: vi.fn().mockResolvedValue([]),
+}));
+
+describe('LobeChatGPTAI', () => {
+  let instance: InstanceType<typeof LobeChatGPTAI>;
+
+  beforeEach(() => {
+    instance = new LobeChatGPTAI({
+      apiKey: 'access-token',
+      chatgptAccountId: 'account-id',
+    });
+    vi.spyOn(instance['client'].chat.completions, 'create').mockResolvedValue(
+      new ReadableStream() as never,
+    );
+    vi.spyOn(instance['client'].responses, 'create').mockResolvedValue(
+      new ReadableStream() as never,
+    );
+  });
+
+  it('configures the Codex endpoint and OAuth account headers', () => {
+    const headers = instance['client']['_options'].defaultHeaders;
+
+    expect(instance.baseURL).toBe('https://chatgpt.com/backend-api/codex');
+    expect(instance['client'].apiKey).toBe('access-token');
+    expect(headers['ChatGPT-Account-Id']).toBe('account-id');
+    expect(headers['User-Agent']).toBe('LobeHub/1.0');
+    expect(headers.originator).toBe('lobehub');
+    expect(headers['session-id']).toEqual(expect.any(String));
+  });
+
+  it('always uses Responses API and omits public API output limits', async () => {
+    await instance.chat({
+      apiMode: 'chatCompletion',
+      max_tokens: 4096,
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: 'gpt-5.5',
+      stream: true,
+    });
+
+    const request = (instance['client'].responses.create as Mock).mock.calls[0][0];
+
+    expect(request).toMatchObject({
+      include: ['reasoning.encrypted_content'],
+      input: [{ content: 'Hello', role: 'user' }],
+      model: 'gpt-5.5',
+      store: false,
+      stream: true,
+    });
+    expect(request.max_output_tokens).toBeUndefined();
+    expect(instance['client'].chat.completions.create).not.toHaveBeenCalled();
+  });
+
+  it('reuses OpenAI Responses payload handling for reasoning and web search', async () => {
+    await instance.chat({
+      enabledSearch: true,
+      messages: [{ content: 'Search for this', role: 'user' }],
+      model: 'gpt-5.5',
+      reasoning_effort: 'high',
+    });
+
+    const request = (instance['client'].responses.create as Mock).mock.calls[0][0];
+
+    expect(request.reasoning).toEqual({ effort: 'high', summary: 'auto' });
+    expect(request.tools).toContainEqual({ type: 'web_search' });
+  });
+});

--- a/packages/model-runtime/src/providers/chatGPT/index.test.ts
+++ b/packages/model-runtime/src/providers/chatGPT/index.test.ts
@@ -38,15 +38,18 @@ describe('LobeChatGPTAI', () => {
   });
 
   it('always uses Responses API and omits public API output limits', async () => {
-    await instance.chat({
-      apiMode: 'chatCompletion',
-      max_tokens: 4096,
-      messages: [{ content: 'Hello', role: 'user' }],
-      model: 'gpt-5.5',
-      stream: true,
-    });
+    await instance.chat(
+      {
+        apiMode: 'chatCompletion',
+        max_tokens: 4096,
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'gpt-5.5',
+        stream: true,
+      },
+      { user: 'user-id' },
+    );
 
-    const request = (instance['client'].responses.create as Mock).mock.calls[0][0];
+    const [request, requestOptions] = (instance['client'].responses.create as Mock).mock.calls[0];
 
     expect(request).toMatchObject({
       include: ['reasoning.encrypted_content'],
@@ -56,8 +59,76 @@ describe('LobeChatGPTAI', () => {
       stream: true,
     });
     expect(request.max_output_tokens).toBeUndefined();
+    expect(request.safety_identifier).toBeUndefined();
+    expect(requestOptions.headers).not.toHaveProperty('x-openai-internal-codex-responses-lite');
     expect(instance['client'].chat.completions.create).not.toHaveBeenCalled();
   });
+
+  it.each(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])(
+    'uses the Responses Lite request contract for %s',
+    async (model) => {
+      await instance.chat(
+        {
+          messages: [
+            { content: 'Follow the instructions', role: 'system' },
+            { content: 'Check the weather', role: 'user' },
+          ],
+          model,
+          parallel_tool_calls: true,
+          reasoning_effort: 'high',
+          tools: [
+            {
+              function: {
+                description: 'Get the weather',
+                name: 'get_weather',
+                parameters: {
+                  properties: { city: { type: 'string' } },
+                  required: ['city'],
+                  type: 'object',
+                },
+              },
+              type: 'function',
+            },
+          ],
+        },
+        { user: 'user-id' },
+      );
+
+      const [request, requestOptions] = (instance['client'].responses.create as Mock).mock.calls[0];
+
+      expect(requestOptions.headers).toMatchObject({
+        'x-openai-internal-codex-responses-lite': 'true',
+      });
+      expect(request).toMatchObject({
+        input: [
+          {
+            role: 'developer',
+            tools: [
+              {
+                description: 'Get the weather',
+                name: 'get_weather',
+                parameters: {
+                  properties: { city: { type: 'string' } },
+                  required: ['city'],
+                  type: 'object',
+                },
+                type: 'function',
+              },
+            ],
+            type: 'additional_tools',
+          },
+          { content: 'Follow the instructions', role: 'developer' },
+          { content: 'Check the weather', role: 'user' },
+        ],
+        parallel_tool_calls: false,
+        reasoning: { context: 'all_turns', effort: 'high', summary: 'auto' },
+        tool_choice: 'auto',
+      });
+      expect(request.instructions).toBeUndefined();
+      expect(request.safety_identifier).toBeUndefined();
+      expect(request.tools).toBeUndefined();
+    },
+  );
 
   it('reuses OpenAI Responses payload handling for reasoning and web search', async () => {
     await instance.chat({

--- a/packages/model-runtime/src/providers/chatGPT/index.test.ts
+++ b/packages/model-runtime/src/providers/chatGPT/index.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { CURRENT_VERSION } from '@lobechat/const';
 import type { Mock } from 'vitest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -30,9 +31,10 @@ describe('LobeChatGPTAI', () => {
     expect(instance.baseURL).toBe('https://chatgpt.com/backend-api/codex');
     expect(instance['client'].apiKey).toBe('access-token');
     expect(headers['ChatGPT-Account-Id']).toBe('account-id');
-    expect(headers['User-Agent']).toBe('LobeHub/1.0');
+    expect(headers['User-Agent']).toBe(`LobeHub/${CURRENT_VERSION}`);
     expect(headers.originator).toBe('lobehub');
     expect(headers['session-id']).toEqual(expect.any(String));
+    expect(headers.version).toBe(CURRENT_VERSION);
   });
 
   it('always uses Responses API and omits public API output limits', async () => {

--- a/packages/model-runtime/src/providers/chatGPT/index.ts
+++ b/packages/model-runtime/src/providers/chatGPT/index.ts
@@ -6,11 +6,22 @@ import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactor
 import { params as openAIParams } from '../openai';
 
 const CHATGPT_CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex';
+const CHATGPT_RESPONSES_LITE_HEADER = 'x-openai-internal-codex-responses-lite';
+const CHATGPT_RESPONSES_LITE_MODEL_IDS = new Set(['gpt-5.6-luna', 'gpt-5.6-sol', 'gpt-5.6-terra']);
 const USER_AGENT = `LobeHub/${CURRENT_VERSION}`;
 
 interface ChatGPTClientOptions {
   chatgptAccountId?: string;
 }
+
+interface ChatGPTAdditionalToolsInput {
+  role: 'developer';
+  tools: OpenAI.Responses.Tool[];
+  type: 'additional_tools';
+}
+
+const isResponsesLiteModel = (model: string | undefined) =>
+  !!model && CHATGPT_RESPONSES_LITE_MODEL_IDS.has(model);
 
 export const LobeChatGPTAI = createOpenAICompatibleRuntime<ChatGPTClientOptions>({
   baseURL: CHATGPT_CODEX_BASE_URL,
@@ -47,6 +58,54 @@ export const LobeChatGPTAI = createOpenAICompatibleRuntime<ChatGPTClientOptions>
         ...rest,
         include: ['reasoning.encrypted_content'],
         max_tokens: undefined,
+      };
+    },
+    prepareRequest: (payload) => {
+      const { safety_identifier: _safetyIdentifier, ...subscriptionPayload } = payload;
+
+      if (!isResponsesLiteModel(payload.model)) {
+        return { payload: subscriptionPayload };
+      }
+
+      // Codex GPT-5.6 models use Responses Lite: tools move into the input
+      // sequence, reasoning spans all turns, and the protocol header is required.
+      const {
+        input,
+        instructions,
+        parallel_tool_calls: _parallelToolCalls,
+        reasoning,
+        tools,
+        ...rest
+      } = subscriptionPayload;
+      const additionalTools: ChatGPTAdditionalToolsInput = {
+        role: 'developer',
+        tools: tools || [],
+        type: 'additional_tools',
+      };
+      const developerInstructions =
+        instructions && typeof instructions === 'string'
+          ? [
+              {
+                content: [{ text: instructions, type: 'input_text' as const }],
+                role: 'developer' as const,
+                type: 'message' as const,
+              },
+            ]
+          : [];
+
+      return {
+        headers: { [CHATGPT_RESPONSES_LITE_HEADER]: 'true' },
+        payload: {
+          ...rest,
+          input: [
+            additionalTools as OpenAI.Responses.ResponseInputItem,
+            ...developerInstructions,
+            ...(Array.isArray(input) ? input : []),
+          ],
+          parallel_tool_calls: false,
+          reasoning: { ...reasoning, context: 'all_turns' },
+          tool_choice: 'auto',
+        },
       };
     },
   },

--- a/packages/model-runtime/src/providers/chatGPT/index.ts
+++ b/packages/model-runtime/src/providers/chatGPT/index.ts
@@ -1,3 +1,4 @@
+import { CURRENT_VERSION } from '@lobechat/const';
 import { ModelProvider } from 'model-bank';
 import OpenAI from 'openai';
 
@@ -5,7 +6,7 @@ import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactor
 import { params as openAIParams } from '../openai';
 
 const CHATGPT_CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex';
-const USER_AGENT = 'LobeHub/1.0';
+const USER_AGENT = `LobeHub/${CURRENT_VERSION}`;
 
 interface ChatGPTClientOptions {
   chatgptAccountId?: string;
@@ -26,6 +27,7 @@ export const LobeChatGPTAI = createOpenAICompatibleRuntime<ChatGPTClientOptions>
           'User-Agent': USER_AGENT,
           'originator': 'lobehub',
           'session-id': crypto.randomUUID(),
+          'version': CURRENT_VERSION,
         },
       }),
   },

--- a/packages/model-runtime/src/providers/chatGPT/index.ts
+++ b/packages/model-runtime/src/providers/chatGPT/index.ts
@@ -74,6 +74,7 @@ export const LobeChatGPTAI = createOpenAICompatibleRuntime<ChatGPTClientOptions>
         instructions,
         parallel_tool_calls: _parallelToolCalls,
         reasoning,
+        tool_choice: toolChoice,
         tools,
         ...rest
       } = subscriptionPayload;
@@ -104,7 +105,7 @@ export const LobeChatGPTAI = createOpenAICompatibleRuntime<ChatGPTClientOptions>
           ],
           parallel_tool_calls: false,
           reasoning: { ...reasoning, context: 'all_turns' },
-          tool_choice: 'auto',
+          tool_choice: toolChoice || 'auto',
         },
       };
     },

--- a/packages/model-runtime/src/providers/chatGPT/index.ts
+++ b/packages/model-runtime/src/providers/chatGPT/index.ts
@@ -1,0 +1,51 @@
+import { ModelProvider } from 'model-bank';
+import OpenAI from 'openai';
+
+import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+import { params as openAIParams } from '../openai';
+
+const CHATGPT_CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex';
+const USER_AGENT = 'LobeHub/1.0';
+
+interface ChatGPTClientOptions {
+  chatgptAccountId?: string;
+}
+
+export const LobeChatGPTAI = createOpenAICompatibleRuntime<ChatGPTClientOptions>({
+  baseURL: CHATGPT_CODEX_BASE_URL,
+  chatCompletion: {
+    useResponse: true,
+  },
+  customClient: {
+    createClient: ({ chatgptAccountId, ...options }) =>
+      new OpenAI({
+        ...options,
+        defaultHeaders: {
+          ...options.defaultHeaders,
+          ...(chatgptAccountId && { 'ChatGPT-Account-Id': chatgptAccountId }),
+          'User-Agent': USER_AGENT,
+          'originator': 'lobehub',
+          'session-id': crypto.randomUUID(),
+        },
+      }),
+  },
+  debug: {
+    chatCompletion: () => process.env.DEBUG_CHATGPT_CHAT_COMPLETION === '1',
+    responses: () => process.env.DEBUG_CHATGPT_RESPONSES === '1',
+  },
+  provider: ModelProvider.ChatGPT,
+  responses: {
+    handlePayload: (payload) => {
+      const handledPayload = openAIParams.responses?.handlePayload?.(payload) || payload;
+      const { service_tier: _serviceTier, ...rest } = handledPayload;
+
+      // The ChatGPT Codex backend manages output limits from the subscription
+      // model catalog and rejects the public API's max_output_tokens field.
+      return {
+        ...rest,
+        include: ['reasoning.encrypted_content'],
+        max_tokens: undefined,
+      };
+    },
+  },
+});

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -12,6 +12,7 @@ import { LobeBailianCodingPlanAI } from './providers/bailianCodingPlan';
 import { LobeBedrockAI } from './providers/bedrock';
 import { LobeBflAI } from './providers/bfl';
 import { LobeCerebrasAI } from './providers/cerebras';
+import { LobeChatGPTAI } from './providers/chatGPT';
 import { LobeCloudflareAI } from './providers/cloudflare';
 import { LobeCohereAI } from './providers/cohere';
 import { LobeCometAPIAI } from './providers/cometapi';
@@ -96,6 +97,7 @@ export const providerRuntimeMap = {
   bedrock: LobeBedrockAI,
   bfl: LobeBflAI,
   cerebras: LobeCerebrasAI,
+  chatgpt: LobeChatGPTAI,
   cloudflare: LobeCloudflareAI,
   cohere: LobeCohereAI,
   cometapi: LobeCometAPIAI,

--- a/packages/model-runtime/src/types/chat.ts
+++ b/packages/model-runtime/src/types/chat.ts
@@ -56,6 +56,7 @@ export interface OpenAIChatMessage {
   reasoning?: {
     content?: string;
     duration?: number;
+    signature?: string;
   };
   reasoning_content?: string;
   role: LLMRoleType;

--- a/packages/model-runtime/src/types/chat.ts
+++ b/packages/model-runtime/src/types/chat.ts
@@ -1,4 +1,9 @@
-import type { ModelPerformance, ModelTokensUsage, ModelUsage } from '@lobechat/types';
+import type {
+  ModelPerformance,
+  ModelReasoning,
+  ModelTokensUsage,
+  ModelUsage,
+} from '@lobechat/types';
 
 import type { ModelPricingContext } from './pricing';
 import type { MessageToolCall, MessageToolCallChunk } from './toolsCalling';
@@ -245,6 +250,7 @@ export interface OnFinishData {
    */
   finishReason?: string;
   grounding?: any;
+  reasoning?: ModelReasoning;
   speed?: ModelPerformance;
   text: string;
   thinking?: string;

--- a/packages/model-runtime/src/types/chat.ts
+++ b/packages/model-runtime/src/types/chat.ts
@@ -57,7 +57,9 @@ export type UserMessageContentPart =
 
 export interface OpenAIChatMessage {
   content: string | UserMessageContentPart[];
+  model?: string;
   name?: string;
+  provider?: string;
   reasoning?: {
     content?: string;
     duration?: number;

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -24,6 +24,10 @@ export interface ClientSecretPayload {
 
   bearerTokenExpiresAt?: number;
 
+  /**
+   * ChatGPT account identifier associated with an OAuth access token.
+   */
+  chatgptAccountId?: string;
   cloudflareBaseURLOrAccountID?: string;
   customHeaders?: Record<string, string>;
   /**

--- a/packages/types/src/openai/chat.ts
+++ b/packages/types/src/openai/chat.ts
@@ -63,6 +63,7 @@ export interface OpenAIChatMessage {
   reasoning?: {
     content?: string;
     duration?: number;
+    signature?: string;
   };
   reasoning_content?: string;
   /**

--- a/packages/types/src/openai/chat.ts
+++ b/packages/types/src/openai/chat.ts
@@ -59,7 +59,9 @@ export interface OpenAIChatMessage {
    * @deprecated
    */
   function_call?: OpenAIFunctionCall;
+  model?: string;
   name?: string;
+  provider?: string;
   reasoning?: {
     content?: string;
     duration?: number;

--- a/src/store/chat/agents/StreamingHandler.test.ts
+++ b/src/store/chat/agents/StreamingHandler.test.ts
@@ -577,6 +577,21 @@ describe('StreamingHandler', () => {
       expect(result.metadata.reasoning?.content).toBe('Fallback');
       expect(result.metadata.reasoning?.signature).toBe('fallback-sig');
     });
+
+    it('should preserve a reasoning signature without reasoning content', async () => {
+      const callbacks = createMockCallbacks();
+      const handler = new StreamingHandler(mockContext, callbacks);
+
+      handler.handleChunk({ type: 'text', text: 'Content' });
+
+      const result = await handler.handleFinish({
+        type: 'stop',
+        reasoning: { signature: 'signature-only' },
+      });
+
+      expect(result.metadata.reasoning?.content).toBeUndefined();
+      expect(result.metadata.reasoning?.signature).toBe('signature-only');
+    });
   });
 
   describe('getter methods', () => {

--- a/src/store/chat/agents/StreamingHandler.ts
+++ b/src/store/chat/agents/StreamingHandler.ts
@@ -537,7 +537,7 @@ export class StreamingHandler {
         duration: finalDuration,
         signature: reasoningSignature,
       };
-    } else if (finishData.reasoning?.content) {
+    } else if (finishData.reasoning?.content || reasoningSignature) {
       finalReasoning = {
         ...finishData.reasoning,
         duration: finalDuration,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

- Related to #14400
- Prior art: #17001
- OpenCode reference: https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/plugin/openai/codex.ts
- Official Codex device auth: https://github.com/openai/codex/blob/main/codex-rs/login/src/device_code_auth.rs

#### 🔀 Description of Change

Add a built-in ChatGPT provider that uses a ChatGPT subscription through the Codex OAuth device flow and Responses backend.

- implement the two-stage Codex device authorization and token exchange flow
- persist the OAuth account identifier required by ChatGPT inference requests
- add a server-only Responses runtime with the required Codex endpoint and headers
- add the current ChatGPT/Codex model catalog without usage-based API pricing
- preserve encrypted Responses reasoning state across stateless multi-turn requests
- keep encrypted reasoning provider-scoped so signatures are never replayed across providers

#### 🧭 Key Decisions / Non-goals

- The provider uses the public Codex OAuth client identifier and does not require a client secret, environment variable, or database migration.
- Browser requests are disabled because OAuth tokens and account routing headers must stay server-side.
- The model catalog is intentionally static. Dynamic model discovery is not part of this PR.
- The Codex subscription backend is not documented as a stable general-purpose third-party API, so upstream protocol changes may require follow-up maintenance.
- Completing authorization and inference with a real ChatGPT subscription is left to manual reviewer verification; no subscription credential was accessed during development.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Automated:

```bash
bun run check
bun run type-check
```

Results:

- 30 changed files, lint clean, 311 tests passed
- full TypeScript check passed

Manual:

- verified that the public Codex device authorization endpoint returns HTTP 200 with the expected response shape
- connect a ChatGPT subscription from provider settings
- verify first-turn chat, multi-turn reasoning, tool calling, token refresh, and disconnect/reconnect

#### 📸 Screenshots / Videos

N/A — this reuses the existing OAuth device-flow UI.

#### 📝 Additional Information

- No environment variables, migrations, or deployment configuration changes are required.
- The implementation follows the existing generic OAuth key-vault encryption and refresh lifecycle.
