### PR TITLE
🐛 fix: harden imports, model configs, and upload ignores

### DIFF
--- a/packages/database/src/repositories/dataImporter/__tests__/index.test.ts
+++ b/packages/database/src/repositories/dataImporter/__tests__/index.test.ts
@@ -387,6 +387,66 @@ describe('DataImporter', () => {
   });
 
   describe('import message and topic', () => {
+    it('should map topic agentId to the imported agent id', async () => {
+      const exportData: ImportPgDataStructure = {
+        data: {
+          agents: [
+            {
+              id: 'agt_topic_agent',
+              slug: 'topic-agent',
+              model: 'gpt-4',
+              provider: 'openai',
+              systemRole: '',
+              createdAt: '2025-01-01T00:00:00Z',
+              updatedAt: '2025-01-01T00:00:00Z',
+            },
+          ],
+          messages: [
+            {
+              id: 'msg_topic_agent',
+              role: 'user',
+              content: 'hello',
+              topicId: 'tpc_topic_agent',
+              agentId: 'agt_topic_agent',
+              createdAt: '2025-01-01T00:00:00Z',
+              updatedAt: '2025-01-01T00:00:00Z',
+            },
+          ],
+          topics: [
+            {
+              id: 'tpc_topic_agent',
+              title: 'topic with agent',
+              agentId: 'agt_topic_agent',
+              createdAt: '2025-01-01T00:00:00Z',
+              updatedAt: '2025-01-01T00:00:00Z',
+            },
+          ],
+        },
+        mode: 'pglite',
+        schemaHash: 'test',
+      } as any;
+
+      const result = await importer.importPgData(exportData);
+
+      expect(result.success).toBe(true);
+      expect(result.results.topics).toMatchObject({ added: 1, errors: 0, skips: 0 });
+      expect(result.results.messages).toMatchObject({ added: 1, errors: 0, skips: 0 });
+
+      const [agent] = await clientDB.query.agents.findMany({
+        where: eq(Schema.agents.userId, userId),
+      });
+      const [topic] = await clientDB.query.topics.findMany({
+        where: eq(Schema.topics.userId, userId),
+      });
+      const [message] = await clientDB.query.messages.findMany({
+        where: eq(Schema.messages.userId, userId),
+      });
+
+      expect(topic.agentId).toBe(agent.id);
+      expect(message.agentId).toBe(agent.id);
+      expect(topic.agentId).not.toBe('agt_topic_agent');
+    });
+
     it('should import return correct result', async () => {
       const exportData = topicsData as ImportPgDataStructure;
       const result = await importer.importPgData(exportData);

--- a/packages/database/src/repositories/dataImporter/index.ts
+++ b/packages/database/src/repositories/dataImporter/index.ts
@@ -106,6 +106,10 @@ const IMPORT_TABLE_CONFIG: TableImportConfig[] = [
   {
     relations: [
       {
+        field: 'agentId',
+        sourceTable: 'agents',
+      },
+      {
         field: 'sessionId',
         sourceTable: 'sessions',
       },

--- a/packages/model-runtime/src/utils/getFallbackModelProperty.test.ts
+++ b/packages/model-runtime/src/utils/getFallbackModelProperty.test.ts
@@ -181,6 +181,16 @@ describe('getModelPropertyWithFallback', () => {
       expect(result).toBe('chat');
     });
 
+    it('should infer embedding type for unknown embedding-like model IDs', async () => {
+      const result = await getModelPropertyWithFallback('bge-m3', 'type', 'newapi');
+      expect(result).toBe('embedding');
+    });
+
+    it('should infer embedding type case-insensitively for custom model IDs', async () => {
+      const result = await getModelPropertyWithFallback('TEXT-EMBEDDING-3-SMALL', 'type');
+      expect(result).toBe('embedding');
+    });
+
     it('should return undefined for non-type properties when model not found', async () => {
       const result = await getModelPropertyWithFallback('non-existent-model', 'displayName');
       expect(result).toBeUndefined();

--- a/packages/model-runtime/src/utils/getFallbackModelProperty.ts
+++ b/packages/model-runtime/src/utils/getFallbackModelProperty.ts
@@ -1,8 +1,20 @@
-import type { AiFullModelCard, LobeDefaultAiModelListItem } from 'model-bank';
+import type { AiFullModelCard, AiModelType, LobeDefaultAiModelListItem } from 'model-bank';
+
+import { EMBEDDING_MODEL_KEYWORDS } from './modelTypeKeywords';
 
 interface BusinessModelConfigModule {
   loadModels: () => Promise<LobeDefaultAiModelListItem[]>;
 }
+
+const getDefaultModelType = (modelId: string): AiModelType => {
+  const lowerModelId = modelId.toLowerCase();
+
+  if (EMBEDDING_MODEL_KEYWORDS.some((keyword) => lowerModelId.includes(keyword))) {
+    return 'embedding';
+  }
+
+  return 'chat';
+};
 
 /**
  * Get the model property value, first from the specified provider, and then from other providers as a fallback.
@@ -37,5 +49,5 @@ export const getModelPropertyWithFallback = async <T>(
   }
 
   // Step 3: Return a default value
-  return (propertyName === 'type' ? 'chat' : undefined) as T;
+  return (propertyName === 'type' ? getDefaultModelType(modelId) : undefined) as T;
 };

--- a/packages/model-runtime/src/utils/modelParse.ts
+++ b/packages/model-runtime/src/utils/modelParse.ts
@@ -10,6 +10,9 @@ import type {
 import { AiModelTypeSchema, ModelProvider } from 'model-bank';
 
 import type { ModelProviderKey } from '../types';
+import { EMBEDDING_MODEL_KEYWORDS } from './modelTypeKeywords';
+
+export { EMBEDDING_MODEL_KEYWORDS } from './modelTypeKeywords';
 
 export interface ModelProcessorConfig {
   excludeKeywords?: readonly string[]; // Do not add tags to models that match
@@ -217,9 +220,6 @@ export const IMAGE_MODEL_KEYWORDS = [
   '^V_2',
   '^V_1',
 ] as const;
-
-// Embedding model keyword configuration
-export const EMBEDDING_MODEL_KEYWORDS = ['embedding', 'embed', 'bge', 'm3e'] as const;
 
 const AI_MODEL_TYPE_SET = new Set<AiModelType>(AiModelTypeSchema.options);
 

--- a/packages/model-runtime/src/utils/modelTypeKeywords.ts
+++ b/packages/model-runtime/src/utils/modelTypeKeywords.ts
@@ -1,0 +1,1 @@
+export const EMBEDDING_MODEL_KEYWORDS = ['embedding', 'embed', 'bge', 'm3e'] as const;

--- a/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
+++ b/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
@@ -173,6 +173,36 @@ describe('aiProvider action helpers', () => {
       expect(fallbackSpy).toHaveBeenCalledWith('stable-diffusion', 'pricing', 'stability');
       expect(fallbackSpy).toHaveBeenCalledWith('stable-diffusion', 'description', 'stability');
     });
+
+    it('falls back to model config when parameters is an empty object', async () => {
+      // Regression for #15493: the `parameters` DB column defaults to `{}`, which
+      // must be treated as missing so required fields (e.g. `prompt`) are restored
+      // from the bundled model config instead of failing schema validation.
+      const fallbackSpy = vi
+        .mocked(runtimeModule.getModelPropertyWithFallback)
+        .mockImplementation(async (_id, key) => {
+          if (key === 'parameters')
+            return {
+              prompt: { default: '' },
+              size: { default: '1024x1024', enum: ['512x512', '1024x1024'] },
+            } satisfies ModelParamsSchema;
+          return undefined;
+        });
+
+      const model = createImageModel({
+        id: 'cogview-4',
+        parameters: {} as ModelParamsSchema,
+        providerId: 'zhipu',
+      });
+
+      const result = await normalizeImageModel(model);
+
+      expect(result.parameters).toEqual({
+        prompt: { default: '' },
+        size: { default: '1024x1024', enum: ['512x512', '1024x1024'] },
+      });
+      expect(fallbackSpy).toHaveBeenCalledWith('cogview-4', 'parameters', 'zhipu');
+    });
   });
 
   describe('normalizeEmbeddingModel', () => {

--- a/src/store/aiInfra/slices/aiProvider/action.ts
+++ b/src/store/aiInfra/slices/aiProvider/action.ts
@@ -62,6 +62,25 @@ const getModelProperty = async <T>(
   return getModelPropertyWithFallback<T | undefined>(model.id, propertyName, model.providerId);
 };
 
+const hasParameters = (parameters?: ModelParamsSchema): parameters is ModelParamsSchema =>
+  !!parameters && Object.keys(parameters).length > 0;
+
+const resolveModelParameters = async (
+  model: EnabledAiModel,
+): Promise<ModelParamsSchema | undefined> => {
+  // The `parameters` DB column defaults to `{}`, and enabling a model never
+  // populates it. An empty object is truthy, so a naive truthy check would skip
+  // the fallback and leave required fields (e.g. `prompt`) missing, which later
+  // fails schema validation. Treat an empty object as "no inline parameters".
+  if (hasParameters(model.parameters)) return model.parameters;
+
+  return getModelPropertyWithFallback<ModelParamsSchema | undefined>(
+    model.id,
+    'parameters',
+    model.providerId,
+  );
+};
+
 const dedupeById = (models: ProviderModelListItem[]) => uniqBy(models, 'id');
 
 const createProviderModelCollector = (
@@ -135,26 +154,12 @@ export const normalizeEmbeddingModel = async (
 export const normalizeImageModel = async (
   model: EnabledAiModel,
 ): Promise<ProviderModelListItem> => {
-  const fallbackParametersPromise = model.parameters
-    ? Promise.resolve<ModelParamsSchema | undefined>(model.parameters)
-    : getModelPropertyWithFallback<ModelParamsSchema | undefined>(
-        model.id,
-        'parameters',
-        model.providerId,
-      );
-
-  const fallbackPricingPromise = getModelProperty<Pricing>(model, 'pricing');
-  const fallbackDescriptionPromise = getModelProperty<string>(model, 'description');
-
-  const [fallbackParameters, fallbackPricing, fallbackDescription] = await Promise.all([
-    fallbackParametersPromise,
-    fallbackPricingPromise,
-    fallbackDescriptionPromise,
+  const [parameters, pricing, description] = await Promise.all([
+    resolveModelParameters(model),
+    getModelProperty<Pricing>(model, 'pricing'),
+    getModelProperty<string>(model, 'description'),
   ]);
 
-  const parameters = model.parameters ?? fallbackParameters;
-  const pricing = fallbackPricing;
-  const description = fallbackDescription;
   const { price, approximatePrice } = resolveImageSinglePrice(pricing);
 
   return {
@@ -174,26 +179,12 @@ export const normalizeImageModel = async (
 export const normalizeVideoModel = async (
   model: EnabledAiModel,
 ): Promise<ProviderModelListItem> => {
-  const fallbackParametersPromise = model.parameters
-    ? Promise.resolve<ModelParamsSchema | undefined>(model.parameters)
-    : getModelPropertyWithFallback<ModelParamsSchema | undefined>(
-        model.id,
-        'parameters',
-        model.providerId,
-      );
-
-  const fallbackPricingPromise = getModelProperty<Pricing>(model, 'pricing');
-  const fallbackDescriptionPromise = getModelProperty<string>(model, 'description');
-
-  const [fallbackParameters, fallbackPricing, fallbackDescription] = await Promise.all([
-    fallbackParametersPromise,
-    fallbackPricingPromise,
-    fallbackDescriptionPromise,
+  const [parameters, pricing, description] = await Promise.all([
+    resolveModelParameters(model),
+    getModelProperty<Pricing>(model, 'pricing'),
+    getModelProperty<string>(model, 'description'),
   ]);
 
-  const parameters = model.parameters ?? fallbackParameters;
-  const pricing = fallbackPricing;
-  const description = fallbackDescription;
   const { approximatePrice } = resolveVideoSinglePrice(pricing);
 
   return {

--- a/src/utils/gitignore.test.ts
+++ b/src/utils/gitignore.test.ts
@@ -62,6 +62,18 @@ node_modules/
       expect(shouldIgnoreFile('folder/.DS_Store', ['.DS_Store'])).toBe(true);
     });
 
+    it('should match leading "**/" patterns at any depth, including the root', () => {
+      // Per gitignore spec a leading `**/` matches in all directories, so
+      // `**/foo` is equivalent to `foo` and must also match at the root.
+      expect(shouldIgnoreFile('node_modules/index.js', ['**/node_modules'])).toBe(true);
+      expect(shouldIgnoreFile('src/node_modules/index.js', ['**/node_modules'])).toBe(true);
+      expect(shouldIgnoreFile('build.log', ['**/*.log'])).toBe(true);
+      expect(shouldIgnoreFile('src/build.log', ['**/*.log'])).toBe(true);
+      expect(shouldIgnoreFile('src/main.ts', ['**/*.log'])).toBe(false);
+      expect(shouldIgnoreFile('node_modules/index.js', ['**/**/node_modules'])).toBe(true);
+      expect(shouldIgnoreFile('build.log', ['**/**/*.log'])).toBe(true);
+    });
+
     it('should handle negation patterns', () => {
       const patterns = ['*.log', '!important.log'];
       expect(shouldIgnoreFile('test.log', patterns)).toBe(true);

--- a/src/utils/gitignore.ts
+++ b/src/utils/gitignore.ts
@@ -39,6 +39,14 @@ const gitignorePatternToRegex = (pattern: string): RegExp => {
     regexPattern = regexPattern.slice(1);
   }
 
+  // A leading `**/` matches in all directories per the gitignore spec:
+  // `**/foo` is equivalent to `foo` and must also match at the root. Strip it
+  // so the remainder anchors with `(^|/)` instead of requiring (via `.*/`) at
+  // least one parent directory, which would miss root-level matches.
+  while (regexPattern.startsWith('**/') && regexPattern.length > 3) {
+    regexPattern = regexPattern.slice(3);
+  }
+
   // Escape special regex characters except *, ?, and /
   regexPattern = regexPattern.replaceAll(/[$()+.[\\\]^{|}]/g, '\\$&');
 

--- a/src/utils/server/parseModels.test.ts
+++ b/src/utils/server/parseModels.test.ts
@@ -35,6 +35,24 @@ describe('parseModelString', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it('infers embedding type for custom embedding model ids', async () => {
+    const result = await parseModelString('newapi', '+bge-m3=bge-m3,+text-embedding-custom');
+
+    expect(result.add).toEqual([
+      {
+        abilities: {},
+        displayName: 'bge-m3',
+        id: 'bge-m3',
+        type: 'embedding',
+      },
+      {
+        abilities: {},
+        id: 'text-embedding-custom',
+        type: 'embedding',
+      },
+    ]);
+  });
+
   it('empty string model', async () => {
     const result = await parseModelString(
       'test-provider',


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

- Fixes #16082
- Fixes #15720
- Fixes #15493
- Consolidates #16081, #15820, #15534, and #15911

#### 🔀 Description of Change

This PR consolidates four reviewed community bug fixes while preserving the original authorship of each commit:

- remap `topics.agentId` to the imported agent ID during PostgreSQL data imports;
- infer the embedding type for unknown custom model IDs such as `bge-m3`;
- fall back to bundled image/video model parameters when stored parameters are an empty object;
- make leading `**/` gitignore patterns match root-level paths during folder uploads.

Each fix includes focused regression coverage.

#### 🧭 Key Decisions / Non-goals

- Keep the fixes as independent commits so their authorship and review history remain clear.
- Reuse the existing embedding keyword list instead of introducing a second inference rule.
- Treat only an empty parameter object as missing; preserve non-empty inline model parameters.
- Normalize only leading `**/` segments and retain the existing matcher for all other patterns.
- No database migration, exported-data migration, or broad gitignore parser rewrite is included.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Automated verification:

- Unified lint, related-test, and type-check run for all 11 changed files.
- Result: lint clean, 199 tests passed, types clean.
- `git diff --check` passes.

#### 📸 Screenshots / Videos

No UI changes.

#### 📝 Additional Information

The four source PR authors are retained as the commit authors. This PR provides one maintained integration branch for the fixes without changing their intended scope.
