### PR TITLE
✨ feat(home): include pinned private agents in view-all + full item actions menu

### DIFF
--- a/src/features/AgentViewAll/AgentCard.tsx
+++ b/src/features/AgentViewAll/AgentCard.tsx
@@ -2,17 +2,16 @@
 
 import { AGENT_CHAT_URL, DEFAULT_AVATAR, GROUP_CHAT_URL } from '@lobechat/const';
 import { type SidebarAgentItem } from '@lobechat/types';
-import { ActionIcon, Avatar, Block, Flexbox, Text } from '@lobehub/ui';
-import { DropdownMenu } from '@lobehub/ui/base-ui';
+import { Avatar, Block, Flexbox, Text } from '@lobehub/ui';
 import { createStaticStyles, responsive } from 'antd-style';
-import { EllipsisIcon, EyeIcon, EyeOffIcon } from 'lucide-react';
-import { memo, useCallback } from 'react';
+import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
 
 import AgentAvatar from './AgentAvatar';
 import { type AgentRowAuthor, formatUpdatedAt } from './AgentRow';
+import ItemActions from './ItemActions';
 
 // Card layout mirrors the agent channel platform cards
 // (src/routes/(main)/agent/channel/list.tsx): icon + title + trailing state on
@@ -89,15 +88,13 @@ const AgentCard = memo<AgentCardProps>(
   ({ author, item, onToggleSidebar, showAuthor, sidebarHidden }) => {
     const { t } = useTranslation('common');
     const { description, id, title, type, updatedAt } = item;
-
-    const handleToggleSidebar = useCallback(() => {
-      onToggleSidebar?.(item);
-    }, [item, onToggleSidebar]);
+    const [anchor, setAnchor] = useState<HTMLElement | null>(null);
 
     return (
       <WorkspaceLink
         aria-label={title || undefined}
         className={cardStyles.link}
+        ref={setAnchor}
         to={type === 'group' ? GROUP_CHAT_URL(id) : AGENT_CHAT_URL(id, false)}
       >
         <Block clickable className={cardStyles.card} height={'100%'} variant={'outlined'}>
@@ -106,32 +103,22 @@ const AgentCard = memo<AgentCardProps>(
             <Text ellipsis style={{ flex: 1, minWidth: 0 }} weight={600}>
               {title || t('agentViewAll.untitled')}
             </Text>
-            {onToggleSidebar && (
-              <Flexbox
-                flex={'none'}
-                onClick={(e) => {
-                  // Keep the menu from following the card link.
-                  e.preventDefault();
-                  e.stopPropagation();
-                }}
-              >
-                <DropdownMenu
-                  nativeButton={false}
-                  items={[
-                    {
-                      icon: sidebarHidden ? EyeIcon : EyeOffIcon,
-                      key: 'sidebar',
-                      label: sidebarHidden
-                        ? t('agentViewAll.addToSidebar')
-                        : t('agentViewAll.removeFromSidebar'),
-                      onClick: handleToggleSidebar,
-                    },
-                  ]}
-                >
-                  <ActionIcon icon={EllipsisIcon} size={'small'} />
-                </DropdownMenu>
-              </Flexbox>
-            )}
+            <Flexbox
+              flex={'none'}
+              onClick={(e) => {
+                // Keep the menu from following the card link.
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+            >
+              <ItemActions
+                includeSidebarToggle
+                anchor={anchor}
+                item={item}
+                sidebarHidden={sidebarHidden}
+                onToggleSidebar={onToggleSidebar}
+              />
+            </Flexbox>
           </Flexbox>
           <Text className={cardStyles.description} fontSize={12} type={'secondary'}>
             {description}

--- a/src/features/AgentViewAll/AgentRow.tsx
+++ b/src/features/AgentViewAll/AgentRow.tsx
@@ -6,17 +6,18 @@ import { ActionIcon, Avatar, Flexbox, Text } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import dayjs from 'dayjs';
 import { EyeIcon, EyeOffIcon } from 'lucide-react';
-import { memo, type MouseEvent, useCallback } from 'react';
+import { memo, type MouseEvent, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
 
 import AgentAvatar from './AgentAvatar';
+import ItemActions from './ItemActions';
 
 /** Shared column widths so the table header and rows stay aligned. */
 export const AUTHOR_COL_WIDTH = 180;
 export const TIME_COL_WIDTH = 130;
-export const ACTION_COL_WIDTH = 56;
+export const ACTION_COL_WIDTH = 88;
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   description: css`
@@ -72,6 +73,7 @@ const AgentRow = memo<AgentRowProps>(
   ({ author, item, onToggleSidebar, showAuthor, sidebarHidden }) => {
     const { t } = useTranslation('common');
     const { description, id, title, type, updatedAt } = item;
+    const [anchor, setAnchor] = useState<HTMLElement | null>(null);
 
     const handleToggleSidebar = useCallback(
       (e: MouseEvent) => {
@@ -87,6 +89,7 @@ const AgentRow = memo<AgentRowProps>(
       <WorkspaceLink
         aria-label={title || undefined}
         className={styles.row}
+        ref={setAnchor}
         to={type === 'group' ? GROUP_CHAT_URL(id) : AGENT_CHAT_URL(id, false)}
       >
         <Flexbox horizontal align={'center'} gap={12}>
@@ -126,8 +129,19 @@ const AgentRow = memo<AgentRowProps>(
           <Text className={styles.updatedAt} fontSize={12} style={{ width: TIME_COL_WIDTH }}>
             {updatedAt ? formatUpdatedAt(updatedAt) : '–'}
           </Text>
-          {onToggleSidebar ? (
-            <Flexbox align={'center'} flex={'none'} style={{ width: ACTION_COL_WIDTH }}>
+          <Flexbox
+            horizontal
+            align={'center'}
+            flex={'none'}
+            gap={4}
+            style={{ width: ACTION_COL_WIDTH }}
+            onClick={(e) => {
+              // Keep the actions from following the row link.
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+          >
+            {onToggleSidebar && (
               <ActionIcon
                 color={cssVar.colorTextSecondary}
                 icon={sidebarHidden ? EyeOffIcon : EyeIcon}
@@ -142,10 +156,9 @@ const AgentRow = memo<AgentRowProps>(
                 }
                 onClick={handleToggleSidebar}
               />
-            </Flexbox>
-          ) : (
-            <div style={{ flex: 'none', width: ACTION_COL_WIDTH }} />
-          )}
+            )}
+            <ItemActions anchor={anchor} item={item} />
+          </Flexbox>
         </Flexbox>
       </WorkspaceLink>
     );

--- a/src/features/AgentViewAll/AgentViewAllPage.tsx
+++ b/src/features/AgentViewAll/AgentViewAllPage.tsx
@@ -150,7 +150,18 @@ const AgentViewAllPage = memo(() => {
     return map;
   }, [members]);
 
-  const { groupBy, orderBy, orderDirection, showSidebarHidden } = viewOptions;
+  // A persisted author sort/grouping can outlive the tab that offers it
+  // (picked on the workspace tab, then the user opens Private where the
+  // author controls are hidden) — coerce back to visible defaults instead of
+  // sorting by an invisible key with a select value that has no option.
+  const { orderDirection, showSidebarHidden } = viewOptions;
+  const groupBy = showAuthor ? viewOptions.groupBy : 'none';
+  const orderBy =
+    !showAuthor && viewOptions.orderBy === 'author' ? 'updatedAt' : viewOptions.orderBy;
+  const effectiveViewOptions = useMemo(
+    () => ({ ...viewOptions, groupBy, orderBy }),
+    [viewOptions, groupBy, orderBy],
+  );
 
   const filteredItems = useMemo(() => {
     const query = keyword.trim().toLowerCase();
@@ -295,7 +306,7 @@ const AgentViewAllPage = memo(() => {
         }
         right={
           <ListConfig
-            options={viewOptions}
+            options={effectiveViewOptions}
             setOptions={setViewOptions}
             setViewMode={handleViewModeChange}
             showAuthor={showAuthor}

--- a/src/features/AgentViewAll/AgentViewAllPage.tsx
+++ b/src/features/AgentViewAll/AgentViewAllPage.tsx
@@ -96,6 +96,7 @@ const AgentViewAllPage = memo(() => {
   const pinnedAgents = useHomeStore(homeAgentListSelectors.pinnedAgents, isEqual);
   const agentGroups = useHomeStore(homeAgentListSelectors.agentGroups, isEqual);
   const ungroupedAgents = useHomeStore(homeAgentListSelectors.ungroupedAgents, isEqual);
+  const privatePinnedAgents = useHomeStore(homeAgentListSelectors.privatePinnedAgents, isEqual);
   const privateAgentGroups = useHomeStore(homeAgentListSelectors.privateAgentGroups, isEqual);
   const privateUngroupedAgents = useHomeStore(
     homeAgentListSelectors.privateUngroupedAgents,
@@ -119,11 +120,20 @@ const AgentViewAllPage = memo(() => {
     [pinnedAgents, agentGroups, ungroupedAgents],
   );
   const privateItems = useMemo(
-    () => dedupeById([...privateAgentGroups.flatMap((g) => g.items), ...privateUngroupedAgents]),
-    [privateAgentGroups, privateUngroupedAgents],
+    () =>
+      dedupeById([
+        ...privatePinnedAgents,
+        ...privateAgentGroups.flatMap((g) => g.items),
+        ...privateUngroupedAgents,
+      ]),
+    [privatePinnedAgents, privateAgentGroups, privateUngroupedAgents],
   );
 
   const items = activeWorkspaceId && segment === 'private' ? privateItems : workspaceItems;
+
+  // Author info (column, grouping, sorting) only means something on the
+  // workspace tab — every private item is the viewer's own.
+  const showAuthor = !!activeWorkspaceId && segment !== 'private';
 
   // Creator column: resolve each item's userId against the member roster.
   const members = useWorkspaceMembers();
@@ -175,10 +185,12 @@ const AgentViewAllPage = memo(() => {
     authorByUserId,
   ]);
 
-  // Author sections (workspace only): items are already sorted, so buckets
-  // keep the in-group order; groups themselves read alphabetically.
+  // Author sections (workspace tab only — every private item is the viewer's
+  // own, so author buckets would be a single redundant group): items are
+  // already sorted, so buckets keep the in-group order; groups themselves
+  // read alphabetically.
   const groupedItems = useMemo(() => {
-    if (!activeWorkspaceId || groupBy !== 'author') return null;
+    if (!activeWorkspaceId || groupBy !== 'author' || segment === 'private') return null;
     const buckets = new Map<string, SidebarAgentItem[]>();
     for (const item of filteredItems) {
       const key = item.userId ?? '';
@@ -193,7 +205,7 @@ const AgentViewAllPage = memo(() => {
         (userId && authorByUserId.get(userId)?.name) || t('agentViewAll.groupBy.unknownAuthor'),
     }));
     return groups.sort((a, b) => a.label.localeCompare(b.label));
-  }, [activeWorkspaceId, groupBy, filteredItems, authorByUserId, t]);
+  }, [activeWorkspaceId, groupBy, segment, filteredItems, authorByUserId, t]);
 
   const handleToggleSidebar = useCallback(
     (item: SidebarAgentItem) => {
@@ -215,12 +227,12 @@ const AgentViewAllPage = memo(() => {
         author={item.userId ? authorByUserId.get(item.userId) : undefined}
         item={item}
         key={item.id}
-        showAuthor={!!activeWorkspaceId}
+        showAuthor={showAuthor}
         sidebarHidden={sidebarHiddenAgentIds.includes(item.id)}
         onToggleSidebar={handleToggleSidebar}
       />
     ),
-    [activeWorkspaceId, authorByUserId, handleToggleSidebar, sidebarHiddenAgentIds],
+    [showAuthor, authorByUserId, handleToggleSidebar, sidebarHiddenAgentIds],
   );
 
   const renderRow = useCallback(
@@ -229,12 +241,12 @@ const AgentViewAllPage = memo(() => {
         author={item.userId ? authorByUserId.get(item.userId) : undefined}
         item={item}
         key={item.id}
-        showAuthor={!!activeWorkspaceId}
+        showAuthor={showAuthor}
         sidebarHidden={sidebarHiddenAgentIds.includes(item.id)}
         onToggleSidebar={handleToggleSidebar}
       />
     ),
-    [activeWorkspaceId, authorByUserId, handleToggleSidebar, sidebarHiddenAgentIds],
+    [showAuthor, authorByUserId, handleToggleSidebar, sidebarHiddenAgentIds],
   );
 
   const { allowed: canCreate, reason: createBlockedReason } = usePermission('create_content');
@@ -286,7 +298,7 @@ const AgentViewAllPage = memo(() => {
             options={viewOptions}
             setOptions={setViewOptions}
             setViewMode={handleViewModeChange}
-            showAuthor={!!activeWorkspaceId}
+            showAuthor={showAuthor}
             viewMode={viewMode}
           />
         }
@@ -370,7 +382,7 @@ const AgentViewAllPage = memo(() => {
           )
         ) : (
           <Flexbox gap={2}>
-            <TableHeader showAuthor={!!activeWorkspaceId} />
+            <TableHeader showAuthor={showAuthor} />
             {groupedItems
               ? groupedItems.map((group) => (
                   <Flexbox gap={2} key={group.key}>

--- a/src/features/AgentViewAll/AgentViewAllPage.tsx
+++ b/src/features/AgentViewAll/AgentViewAllPage.tsx
@@ -28,22 +28,13 @@ import { workspaceUserSettingsSelectors } from '@/store/user/selectors';
 
 import AgentCard, { cardStyles } from './AgentCard';
 import AgentRow, { type AgentRowAuthor } from './AgentRow';
+import { flattenAgentBuckets } from './flattenBuckets';
 import ListConfig from './ListConfig';
 import { type AgentListViewOptions, normalizeAgentListViewOptions } from './listViewOptions';
 import TableHeader from './TableHeader';
 
 type SegmentValue = 'private' | 'workspace';
 type ViewMode = 'card' | 'list';
-
-/** Flatten sidebar buckets into one list, first occurrence of an id wins. */
-const dedupeById = (items: SidebarAgentItem[]): SidebarAgentItem[] => {
-  const seen = new Set<string>();
-  return items.filter((item) => {
-    if (seen.has(item.id)) return false;
-    seen.add(item.id);
-    return true;
-  });
-};
 
 const AgentViewAllPage = memo(() => {
   const { t } = useTranslation('common');
@@ -116,16 +107,11 @@ const AgentViewAllPage = memo(() => {
   const updatePreference = useUserStore((s) => s.updatePreference);
 
   const workspaceItems = useMemo(
-    () => dedupeById([...pinnedAgents, ...agentGroups.flatMap((g) => g.items), ...ungroupedAgents]),
+    () => flattenAgentBuckets(pinnedAgents, agentGroups, ungroupedAgents),
     [pinnedAgents, agentGroups, ungroupedAgents],
   );
   const privateItems = useMemo(
-    () =>
-      dedupeById([
-        ...privatePinnedAgents,
-        ...privateAgentGroups.flatMap((g) => g.items),
-        ...privateUngroupedAgents,
-      ]),
+    () => flattenAgentBuckets(privatePinnedAgents, privateAgentGroups, privateUngroupedAgents),
     [privatePinnedAgents, privateAgentGroups, privateUngroupedAgents],
   );
 

--- a/src/features/AgentViewAll/ItemActions.tsx
+++ b/src/features/AgentViewAll/ItemActions.tsx
@@ -43,55 +43,14 @@ interface ItemActionsProps {
   sidebarHidden?: boolean;
 }
 
-/**
- * The "…" dropdown on view-all cards / rows. Reuses the sidebar item menus
- * (pin / rename / duplicate / open in new window / move to group / copy to /
- * visibility / delete) so both surfaces expose the same operations with the
- * same permission gating.
- */
-const ItemActions = memo<ItemActionsProps>(
-  ({ anchor, includeSidebarToggle, item, onToggleSidebar, sidebarHidden }) => {
+interface ActionsDropdownProps extends Omit<ItemActionsProps, 'anchor'> {
+  getMenuItems: () => MenuProps['items'];
+}
+
+/** Shared "…" trigger: adapts a sidebar item menu for the flat view-all list. */
+const ActionsDropdown = memo<ActionsDropdownProps>(
+  ({ getMenuItems, includeSidebarToggle, item, onToggleSidebar, sidebarHidden }) => {
     const { t } = useTranslation('common');
-    const { openCreateGroupModal } = useAgentModal();
-    const { avatar, backgroundColor, description, id, pinned, slug, title, type, userId } = item;
-    const visibility = item.visibility;
-
-    const customAvatar = typeof avatar === 'string' ? avatar : undefined;
-    const memberAvatars = Array.isArray(avatar) ? avatar : [];
-    const displayTitle = title || t('agentViewAll.untitled');
-
-    const handleOpenCreateGroupModal = useCallback(() => {
-      openCreateGroupModal(id, visibility);
-    }, [id, openCreateGroupModal, visibility]);
-
-    // Both hooks run unconditionally (rules of hooks); the item type picks
-    // which menu the dropdown actually renders.
-    const getAgentMenu = useAgentDropdownMenu({
-      anchor,
-      avatar: customAvatar,
-      backgroundColor: backgroundColor || undefined,
-      group: undefined,
-      id,
-      openCreateGroupModal: handleOpenCreateGroupModal,
-      pinned: pinned ?? false,
-      slug,
-      title: displayTitle,
-      userId,
-      visibility,
-    });
-    const getGroupMenu = useGroupDropdownMenu({
-      anchor,
-      avatar: customAvatar,
-      backgroundColor: backgroundColor || undefined,
-      description,
-      id,
-      memberAvatars,
-      pinned: pinned ?? false,
-      title: displayTitle,
-      userId,
-    });
-
-    const getMenuItems = type === 'group' ? getGroupMenu : getAgentMenu;
 
     const items = useMemo(
       () => (): MenuProps['items'] => {
@@ -128,6 +87,78 @@ const ItemActions = memo<ItemActionsProps>(
       </DropdownMenu>
     );
   },
+);
+
+ActionsDropdown.displayName = 'ActionsDropdown';
+
+/**
+ * Agent and group menus live in separate components so only the matching
+ * dropdown hook runs per row — each hook fetches resource access for its own
+ * resource type, and running both would issue a wrong-type permission lookup
+ * (NOT_FOUND) for every item in the list.
+ */
+const AgentItemActions = memo<ItemActionsProps>(({ anchor, item, ...rest }) => {
+  const { t } = useTranslation('common');
+  const { openCreateGroupModal } = useAgentModal();
+  const { avatar, backgroundColor, id, pinned, slug, title, userId, visibility } = item;
+
+  const customAvatar = typeof avatar === 'string' ? avatar : undefined;
+
+  const handleOpenCreateGroupModal = useCallback(() => {
+    openCreateGroupModal(id, visibility);
+  }, [id, openCreateGroupModal, visibility]);
+
+  const getAgentMenu = useAgentDropdownMenu({
+    anchor,
+    avatar: customAvatar,
+    backgroundColor: backgroundColor || undefined,
+    group: undefined,
+    id,
+    openCreateGroupModal: handleOpenCreateGroupModal,
+    pinned: pinned ?? false,
+    slug,
+    title: title || t('agentViewAll.untitled'),
+    userId,
+    visibility,
+  });
+
+  return <ActionsDropdown getMenuItems={getAgentMenu} item={item} {...rest} />;
+});
+
+AgentItemActions.displayName = 'AgentItemActions';
+
+const GroupItemActions = memo<ItemActionsProps>(({ anchor, item, ...rest }) => {
+  const { t } = useTranslation('common');
+  const { avatar, backgroundColor, description, id, pinned, title, userId } = item;
+
+  const customAvatar = typeof avatar === 'string' ? avatar : undefined;
+  const memberAvatars = Array.isArray(avatar) ? avatar : [];
+
+  const getGroupMenu = useGroupDropdownMenu({
+    anchor,
+    avatar: customAvatar,
+    backgroundColor: backgroundColor || undefined,
+    description,
+    id,
+    memberAvatars,
+    pinned: pinned ?? false,
+    title: title || t('agentViewAll.untitled'),
+    userId,
+  });
+
+  return <ActionsDropdown getMenuItems={getGroupMenu} item={item} {...rest} />;
+});
+
+GroupItemActions.displayName = 'GroupItemActions';
+
+/**
+ * The "…" dropdown on view-all cards / rows. Reuses the sidebar item menus
+ * (pin / rename / duplicate / open in new window / move to group / copy to /
+ * visibility / delete) so both surfaces expose the same operations with the
+ * same permission gating.
+ */
+const ItemActions = memo<ItemActionsProps>((props) =>
+  props.item.type === 'group' ? <GroupItemActions {...props} /> : <AgentItemActions {...props} />,
 );
 
 ItemActions.displayName = 'ItemActions';

--- a/src/features/AgentViewAll/ItemActions.tsx
+++ b/src/features/AgentViewAll/ItemActions.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { type SidebarAgentItem } from '@lobechat/types';
+import { ActionIcon, DropdownMenu, Icon, type MenuProps } from '@lobehub/ui';
+import { EllipsisIcon, EyeIcon, EyeOffIcon } from 'lucide-react';
+import { memo, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useGroupDropdownMenu } from '@/routes/(main)/home/_layout/Body/Agent/List/AgentGroupItem/useDropdownMenu';
+import { useAgentDropdownMenu } from '@/routes/(main)/home/_layout/Body/Agent/List/AgentItem/useDropdownMenu';
+import { useAgentModal } from '@/routes/(main)/home/_layout/Body/Agent/ModalProvider';
+
+type MenuItems = NonNullable<MenuProps['items']>;
+
+/** Drop leading / trailing / consecutive dividers left behind by filtering. */
+const collapseDividers = (menu: MenuItems): MenuItems => {
+  const result: MenuItems = [];
+  for (const menuItem of menu) {
+    const isDivider = !!menuItem && 'type' in menuItem && menuItem.type === 'divider';
+    const lastItem = result.at(-1);
+    const lastIsDivider = !!lastItem && 'type' in lastItem && lastItem.type === 'divider';
+    if (isDivider && (result.length === 0 || lastIsDivider)) continue;
+    result.push(menuItem);
+  }
+  while (result.length > 0) {
+    const lastItem = result.at(-1);
+    if (!!lastItem && 'type' in lastItem && lastItem.type === 'divider') result.pop();
+    else break;
+  }
+  return result;
+};
+
+interface ItemActionsProps {
+  /** Element the rename EditingPopover anchors to (the card / row root). */
+  anchor: HTMLElement | null;
+  /**
+   * Merge the sidebar show/hide toggle in as the first menu item (card mode).
+   * List mode keeps the standalone eye icon next to this menu instead.
+   */
+  includeSidebarToggle?: boolean;
+  item: SidebarAgentItem;
+  onToggleSidebar?: (item: SidebarAgentItem) => void;
+  sidebarHidden?: boolean;
+}
+
+/**
+ * The "…" dropdown on view-all cards / rows. Reuses the sidebar item menus
+ * (pin / rename / duplicate / open in new window / move to group / copy to /
+ * visibility / delete) so both surfaces expose the same operations with the
+ * same permission gating.
+ */
+const ItemActions = memo<ItemActionsProps>(
+  ({ anchor, includeSidebarToggle, item, onToggleSidebar, sidebarHidden }) => {
+    const { t } = useTranslation('common');
+    const { openCreateGroupModal } = useAgentModal();
+    const { avatar, backgroundColor, description, id, pinned, slug, title, type, userId } = item;
+    const visibility = item.visibility;
+
+    const customAvatar = typeof avatar === 'string' ? avatar : undefined;
+    const memberAvatars = Array.isArray(avatar) ? avatar : [];
+    const displayTitle = title || t('agentViewAll.untitled');
+
+    const handleOpenCreateGroupModal = useCallback(() => {
+      openCreateGroupModal(id, visibility);
+    }, [id, openCreateGroupModal, visibility]);
+
+    // Both hooks run unconditionally (rules of hooks); the item type picks
+    // which menu the dropdown actually renders.
+    const getAgentMenu = useAgentDropdownMenu({
+      anchor,
+      avatar: customAvatar,
+      backgroundColor: backgroundColor || undefined,
+      group: undefined,
+      id,
+      openCreateGroupModal: handleOpenCreateGroupModal,
+      pinned: pinned ?? false,
+      slug,
+      title: displayTitle,
+      userId,
+      visibility,
+    });
+    const getGroupMenu = useGroupDropdownMenu({
+      anchor,
+      avatar: customAvatar,
+      backgroundColor: backgroundColor || undefined,
+      description,
+      id,
+      memberAvatars,
+      pinned: pinned ?? false,
+      title: displayTitle,
+      userId,
+    });
+
+    const getMenuItems = type === 'group' ? getGroupMenu : getAgentMenu;
+
+    const items = useMemo(
+      () => (): MenuProps['items'] => {
+        // Pin and move-to-group organize the sidebar; they're meaningless in
+        // this flat view-all list, so drop them (and any dividers left over).
+        const menu = collapseDividers(
+          (getMenuItems() ?? []).filter(
+            (menuItem) => !menuItem || !['moveGroup', 'pin'].includes(String(menuItem.key)),
+          ),
+        );
+        if (!includeSidebarToggle || !onToggleSidebar) return menu;
+        return [
+          {
+            icon: <Icon icon={sidebarHidden ? EyeIcon : EyeOffIcon} />,
+            key: 'sidebar',
+            label: sidebarHidden
+              ? t('agentViewAll.addToSidebar')
+              : t('agentViewAll.removeFromSidebar'),
+            onClick: ({ domEvent }: any) => {
+              domEvent?.stopPropagation();
+              onToggleSidebar(item);
+            },
+          },
+          { type: 'divider' as const },
+          ...menu,
+        ];
+      },
+      [getMenuItems, includeSidebarToggle, item, onToggleSidebar, sidebarHidden, t],
+    );
+
+    return (
+      <DropdownMenu items={items}>
+        <ActionIcon icon={EllipsisIcon} size={'small'} />
+      </DropdownMenu>
+    );
+  },
+);
+
+ItemActions.displayName = 'ItemActions';
+
+export default ItemActions;

--- a/src/features/AgentViewAll/ItemActions.tsx
+++ b/src/features/AgentViewAll/ItemActions.tsx
@@ -3,7 +3,7 @@
 import { type SidebarAgentItem } from '@lobechat/types';
 import { ActionIcon, DropdownMenu, Icon, type MenuProps } from '@lobehub/ui';
 import { EllipsisIcon, EyeIcon, EyeOffIcon } from 'lucide-react';
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useGroupDropdownMenu } from '@/routes/(main)/home/_layout/Body/Agent/List/AgentGroupItem/useDropdownMenu';
@@ -156,10 +156,31 @@ GroupItemActions.displayName = 'GroupItemActions';
  * (pin / rename / duplicate / open in new window / move to group / copy to /
  * visibility / delete) so both surfaces expose the same operations with the
  * same permission gating.
+ *
+ * The hook-bearing menu component (whose `useResourceAccess` fetches this
+ * item's permission) mounts lazily on first pointer-enter/focus — the
+ * view-all page renders the entire workspace list at once, and fetching one
+ * permission per row on page load would fan out N TRPC requests before the
+ * user opens any menu. Pointer-enter precedes the click that opens the menu,
+ * so the real menu is mounted by the time it is needed.
  */
-const ItemActions = memo<ItemActionsProps>((props) =>
-  props.item.type === 'group' ? <GroupItemActions {...props} /> : <AgentItemActions {...props} />,
-);
+const ItemActions = memo<ItemActionsProps>((props) => {
+  const [activated, setActivated] = useState(false);
+  const activate = useCallback(() => setActivated(true), []);
+
+  if (!activated)
+    return (
+      <span onFocus={activate} onPointerEnter={activate}>
+        <ActionIcon icon={EllipsisIcon} size={'small'} />
+      </span>
+    );
+
+  return props.item.type === 'group' ? (
+    <GroupItemActions {...props} />
+  ) : (
+    <AgentItemActions {...props} />
+  );
+});
 
 ItemActions.displayName = 'ItemActions';
 

--- a/src/features/AgentViewAll/ItemActions.tsx
+++ b/src/features/AgentViewAll/ItemActions.tsx
@@ -3,7 +3,7 @@
 import { type SidebarAgentItem } from '@lobechat/types';
 import { ActionIcon, DropdownMenu, Icon, type MenuProps } from '@lobehub/ui';
 import { EllipsisIcon, EyeIcon, EyeOffIcon } from 'lucide-react';
-import { memo, useCallback, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useGroupDropdownMenu } from '@/routes/(main)/home/_layout/Body/Agent/List/AgentGroupItem/useDropdownMenu';
@@ -166,19 +166,36 @@ GroupItemActions.displayName = 'GroupItemActions';
  */
 const ItemActions = memo<ItemActionsProps>((props) => {
   const [activated, setActivated] = useState(false);
+  const containerRef = useRef<HTMLSpanElement>(null);
+  const refocusPending = useRef(false);
   const activate = useCallback(() => setActivated(true), []);
+  const activateFromFocus = useCallback(() => {
+    // Swapping the focused placeholder subtree drops keyboard focus — note
+    // it so the effect below can move focus onto the real trigger.
+    refocusPending.current = true;
+    setActivated(true);
+  }, []);
 
-  if (!activated)
-    return (
-      <span onFocus={activate} onPointerEnter={activate}>
-        <ActionIcon icon={EllipsisIcon} size={'small'} />
-      </span>
-    );
+  useEffect(() => {
+    if (!activated || !refocusPending.current) return;
+    refocusPending.current = false;
+    containerRef.current?.querySelector('button')?.focus();
+  }, [activated]);
 
-  return props.item.type === 'group' ? (
-    <GroupItemActions {...props} />
-  ) : (
-    <AgentItemActions {...props} />
+  return (
+    <span ref={containerRef}>
+      {activated ? (
+        props.item.type === 'group' ? (
+          <GroupItemActions {...props} />
+        ) : (
+          <AgentItemActions {...props} />
+        )
+      ) : (
+        <span onFocus={activateFromFocus} onPointerEnter={activate}>
+          <ActionIcon icon={EllipsisIcon} size={'small'} />
+        </span>
+      )}
+    </span>
   );
 });
 

--- a/src/features/AgentViewAll/flattenBuckets.test.ts
+++ b/src/features/AgentViewAll/flattenBuckets.test.ts
@@ -1,0 +1,31 @@
+import { type SidebarAgentItem } from '@lobechat/types';
+import { describe, expect, it } from 'vitest';
+
+import { flattenAgentBuckets } from './flattenBuckets';
+
+const item = (id: string): SidebarAgentItem =>
+  ({ id, title: id, type: 'agent' }) as SidebarAgentItem;
+
+describe('flattenAgentBuckets', () => {
+  it('includes pinned items ahead of grouped and ungrouped ones', () => {
+    // Regression: the private view-all list originally omitted the pinned
+    // bucket, so pinned private agents vanished from /agents?tab=private.
+    const result = flattenAgentBuckets(
+      [item('pinned-1')],
+      [{ items: [item('grouped-1')] }, { items: [item('grouped-2')] }],
+      [item('ungrouped-1')],
+    );
+
+    expect(result.map((r) => r.id)).toEqual(['pinned-1', 'grouped-1', 'grouped-2', 'ungrouped-1']);
+  });
+
+  it('dedupes by id with the first occurrence winning', () => {
+    const result = flattenAgentBuckets(
+      [item('a')],
+      [{ items: [item('a'), item('b')] }],
+      [item('b'), item('c')],
+    );
+
+    expect(result.map((r) => r.id)).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/src/features/AgentViewAll/flattenBuckets.ts
+++ b/src/features/AgentViewAll/flattenBuckets.ts
@@ -1,0 +1,22 @@
+import { type SidebarAgentItem } from '@lobechat/types';
+
+/** Flatten sidebar buckets into one list, first occurrence of an id wins. */
+export const dedupeById = (items: SidebarAgentItem[]): SidebarAgentItem[] => {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    if (seen.has(item.id)) return false;
+    seen.add(item.id);
+    return true;
+  });
+};
+
+/**
+ * One view-all list from a sidebar section's three buckets. Pinned items
+ * lead — omitting them (the original bug) makes pinned agents unfindable on
+ * the view-all page even though the sidebar still shows them.
+ */
+export const flattenAgentBuckets = (
+  pinned: SidebarAgentItem[],
+  groups: { items: SidebarAgentItem[] }[],
+  ungrouped: SidebarAgentItem[],
+): SidebarAgentItem[] => dedupeById([...pinned, ...groups.flatMap((g) => g.items), ...ungrouped]);


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Follow-up to #17512.

#### 🔀 Description of Change

- Include `privatePinnedAgents` when flattening `privateItems` on `/agents?tab=private`, so pinned private agents appear in the view-all page (raised by Codex review on #17512).
- Extract a shared `ItemActions` dropdown for card and row views, reusing the sidebar's agent/group dropdown-menu hooks so the view-all page offers the full action set (with divider collapsing for filtered menus).
- Gate the author column/grouping/sorting behind `showAuthor` — author info only means something on the workspace tab.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Open `/agents?tab=private` with a pinned private agent — it now appears; the card/row "…" menu shows the same actions as the sidebar item menu.