### PR TITLE
🐛 fix(topic): prevent actions menu from overflowing the window

### DIFF
--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/Actions.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/Actions.tsx
@@ -1,5 +1,6 @@
-import type { DropdownItem } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import { ActionIcon } from '@lobehub/ui';
+import type { DropdownItem } from '@lobehub/ui/base-ui';
+import { DropdownMenu } from '@lobehub/ui/base-ui';
 import { MoreHorizontalIcon } from 'lucide-react';
 import { memo } from 'react';
 
@@ -13,7 +14,16 @@ const Actions = memo<ActionProps>(({ dropdownMenu }) => {
   const dropdownPortalProps = useOverlayDropdownPortalProps();
 
   return (
-    <DropdownMenu items={dropdownMenu} portalProps={dropdownPortalProps}>
+    <DropdownMenu
+      items={dropdownMenu}
+      portalProps={dropdownPortalProps}
+      popupProps={{
+        style: {
+          maxHeight: 'var(--available-height)',
+          overflowY: 'auto',
+        },
+      }}
+    >
       <ActionIcon icon={MoreHorizontalIcon} size={'small'} />
     </DropdownMenu>
   );

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx
@@ -17,6 +17,7 @@ const topicMetaCardMock = vi.hoisted(() => ({
 }));
 
 vi.mock('@lobehub/ui', () => ({
+  ActionIcon: () => <button type="button" />,
   Flexbox: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
     <div {...props}>{children}</div>
   ),
@@ -32,6 +33,24 @@ vi.mock('@lobehub/ui', () => ({
     <span style={style}>{children}</span>
   ),
   Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@lobehub/ui/base-ui', () => ({
+  DropdownMenu: ({
+    children,
+    popupProps,
+  }: {
+    children?: ReactNode;
+    popupProps?: { style?: CSSProperties };
+  }) => (
+    <div
+      data-max-height={popupProps?.style?.maxHeight}
+      data-overflow-y={popupProps?.style?.overflowY}
+      data-testid="topic-actions-dropdown"
+    >
+      {children}
+    </div>
+  ),
 }));
 
 vi.mock('antd-style', () => ({
@@ -67,8 +86,12 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('@/const/version', () => ({ isDesktop: false }));
+vi.mock('@/features/NavPanel/OverlayContainer', () => ({
+  useOverlayDropdownPortalProps: () => undefined,
+}));
 vi.mock('@/features/NavPanel/components/NavItem', () => ({
   default: ({
+    actions,
     active,
     description,
     extra,
@@ -76,6 +99,7 @@ vi.mock('@/features/NavPanel/components/NavItem', () => ({
     icon,
     title,
   }: {
+    actions?: ReactNode;
     active?: boolean;
     description?: ReactNode;
     extra?: ReactNode;
@@ -88,6 +112,7 @@ vi.mock('@/features/NavPanel/components/NavItem', () => ({
       {title}
       {description}
       {extra}
+      {actions}
     </div>
   ),
 }));
@@ -144,9 +169,6 @@ vi.mock('./metaCardData', () => ({
   getPullRequestState: () => 'open',
   // Defaults to undefined so TopicItem skips the hover Popover wrapper in tests.
   getTopicMetaCard: () => topicMetaCardMock.value,
-}));
-vi.mock('./Actions', () => ({
-  default: () => null,
 }));
 vi.mock('./Editing', () => ({
   default: () => null,
@@ -213,6 +235,23 @@ describe('TopicItem active state', () => {
       'data-href',
       '/team/agent/agt_test/tpc_test',
     );
+  });
+
+  it('constrains the topic actions menu to the available viewport height', () => {
+    useTopicNavigationMock.mockReturnValue({
+      isInAgentSubRoute: false,
+      isInTopicContextRoute: false,
+      navigateToTopic: vi.fn(),
+      routeTopicId: undefined,
+    });
+
+    render(<TopicItem id="tpc_test" title="Topic" />);
+
+    expect(screen.getByTestId('topic-actions-dropdown')).toHaveAttribute(
+      'data-max-height',
+      'var(--available-height)',
+    );
+    expect(screen.getByTestId('topic-actions-dropdown')).toHaveAttribute('data-overflow-y', 'auto');
   });
 
   it('shows running elapsed time in the nav item extra slot', () => {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Closes #17516

#### 🔀 Description of Change

- Migrate the topic actions dropdown to the preferred `@lobehub/ui/base-ui` implementation.
- Constrain the dropdown popup to Base UI's computed available viewport height.
- Enable vertical scrolling when the topic actions exceed the available window height, preventing the menu from being clipped by the Electron title bar.
- Add a regression test for the popup height and overflow behavior.

#### 🧪 How to Test

1. Run:

   ```bash
   bunx vitest run --silent='passed-only' 'src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx'
   ```

2. Run:

   ```bash
   bun run check 'src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/Actions.tsx' 'src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx'
   ```

3. On Windows desktop, open the `...` actions menu for a topic near the top of the sidebar.
4. Confirm that the menu stays inside the usable window area and becomes vertically scrollable when necessary.

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| See the reproduction in #17516 | Pending Windows desktop verification |

#### 📝 Additional Information

- The focused regression suite passes: 14 tests.
- The scoped project check passes: 2 files lint clean and 14 tests passed.
- The full type-check is currently blocked by unrelated existing workspace dependency and generated-type errors, including missing internal packages and stale `.next` route declarations.
- No API, data model, or localization changes are required.
