### PR TITLE
🐛 fix: wake registered-only gateway connections during sync

### DIFF
--- a/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
+++ b/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
@@ -1052,6 +1052,47 @@ describe('GatewayService', () => {
       expect(mockGatewayClient.disconnect).not.toHaveBeenCalled();
     });
 
+    it('samples registered-only wakes instead of always burning the cap on the same prefix', async () => {
+      // A stable iteration order + head-first cap would starve ids after
+      // position 50 forever when the early ones stay registered-only (parked
+      // 409s). Force the sampler's rng to pick from the tail and assert the
+      // selection is not the head prefix.
+      const providers = Array.from({ length: 2000 }, (_, index) => ({
+        ...provider,
+        applicationId: `app-${index}`,
+        id: `prov-${index}`,
+      }));
+
+      mockFindEnabledByPlatform.mockImplementation(async (_db: unknown, platform: string) =>
+        platform === 'discord' ? providers : [],
+      );
+      mockGatewayClient.getStats.mockResolvedValue({ byPlatform: {}, connections: [], total: 0 });
+      mockGatewayClient.getRegisteredIds.mockResolvedValue({
+        ids: providers.map(({ id }) => id),
+      });
+      mockGatewayClient.connect.mockResolvedValue({ status: 'connecting' });
+
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.999_999);
+      try {
+        await service.ensureRunning();
+      } finally {
+        randomSpy.mockRestore();
+      }
+
+      expect(mockGatewayClient.connect).toHaveBeenCalledTimes(50);
+      const wokenIds = new Set(
+        mockGatewayClient.connect.mock.calls.map(
+          ([config]: [{ connectionId: string }]) => config.connectionId,
+        ),
+      );
+      // rng pinned to ~1 → the sampler reaches the tail; the old head-first
+      // cap could only ever pick prov-0..prov-49 and would return exactly
+      // that prefix.
+      expect(wokenIds.has('prov-1999')).toBe(true);
+      const isHeadPrefix = [...wokenIds].every((id) => Number(id.split('-')[1]) < 50);
+      expect(isHeadPrefix).toBe(false);
+    });
+
     it('uses registered ids as a complete existence snapshot when stats is unavailable', async () => {
       mockFindEnabledByPlatform.mockImplementation(async (_db: unknown, platform: string) =>
         platform === 'discord' ? [provider] : [],

--- a/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
+++ b/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
@@ -1082,7 +1082,7 @@ describe('GatewayService', () => {
       expect(mockGatewayClient.connect).toHaveBeenCalledTimes(50);
       const wokenIds = new Set(
         mockGatewayClient.connect.mock.calls.map(
-          ([config]: [{ connectionId: string }]) => config.connectionId,
+          (call) => (call[0] as { connectionId: string }).connectionId,
         ),
       );
       // rng pinned to ~1 → the sampler reaches the tail; the old head-first

--- a/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
+++ b/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
@@ -338,7 +338,11 @@ describe('GatewayService', () => {
       expect(mockGatewayClient.connect).not.toHaveBeenCalled();
     });
 
-    it('skips providers already present in the registered-id snapshot without probing status', async () => {
+    it('ensure-wakes a registered-only desired provider without probing status', async () => {
+      // Registered-only (pruned from stats) used to be skipped outright, but a
+      // stranded DO (alarm chain lost) looks exactly like this and sleeps
+      // forever unless woken. The wake is an `ensure` connect, never a status
+      // probe: parked connections answer 409 and keep their park.
       mockFindEnabledByPlatform.mockResolvedValue([
         {
           applicationId: 'app-1',
@@ -350,11 +354,15 @@ describe('GatewayService', () => {
       ]);
       mockResolveConnectionMode.mockReturnValue('websocket');
       mockGatewayClient.getRegisteredIds.mockResolvedValue({ ids: ['prov-1'] });
+      mockGatewayClient.connect.mockResolvedValue({ status: 'connecting' });
 
       await service.ensureRunning();
 
       expect(mockGatewayClient.getStatus).not.toHaveBeenCalled();
-      expect(mockGatewayClient.connect).not.toHaveBeenCalled();
+      expect(mockGatewayClient.connect).toHaveBeenCalledWith(
+        expect.objectContaining({ connectionId: 'prov-1' }),
+        { ensure: true },
+      );
     });
 
     it('connects disconnected providers', async () => {
@@ -571,9 +579,13 @@ describe('GatewayService', () => {
 
       await service.ensureRunning();
 
-      // Fail-open: no disconnect, provider stays in the desired set.
+      // Fail-open: no disconnect, provider stays in the desired set. As a
+      // desired registered-only id it may receive the idempotent ensure wake,
+      // which preserves whatever state the gateway holds.
       expect(mockGatewayClient.disconnect).not.toHaveBeenCalled();
-      expect(mockGatewayClient.connect).not.toHaveBeenCalled();
+      expect(mockGatewayClient.connect).not.toHaveBeenCalledWith(expect.anything(), {
+        ensure: false,
+      });
     });
 
     it('does not repeatedly disconnect a gated provider absent from the gateway snapshot', async () => {
@@ -947,17 +959,38 @@ describe('GatewayService', () => {
       );
     });
 
-    it('keeps registered-only ids without waking their connection DOs', async () => {
+    it('ensure-wakes registered-only desired ids instead of leaving them stranded', async () => {
       mockFindEnabledByPlatform.mockImplementation(async (_db: unknown, platform: string) =>
         platform === 'discord' ? [provider] : [],
       );
       mockGatewayClient.getStats.mockResolvedValue({ byPlatform: {}, connections: [], total: 0 });
       mockGatewayClient.getRegisteredIds.mockResolvedValue({ ids: ['prov-1'] });
+      mockGatewayClient.connect.mockResolvedValue({ status: 'connecting' });
 
       await service.ensureRunning();
 
       expect(mockGatewayClient.getStatus).not.toHaveBeenCalled();
-      expect(mockGatewayClient.connect).not.toHaveBeenCalled();
+      expect(mockGatewayClient.connect).toHaveBeenCalledWith(
+        expect.objectContaining({ connectionId: 'prov-1' }),
+        { ensure: true },
+      );
+      expect(mockGatewayClient.disconnect).not.toHaveBeenCalled();
+    });
+
+    it('keeps a parked registered-only connection parked (ensure 409 is not a status reset)', async () => {
+      mockFindEnabledByPlatform.mockImplementation(async (_db: unknown, platform: string) =>
+        platform === 'discord' ? [provider] : [],
+      );
+      mockGatewayClient.getStats.mockResolvedValue({ byPlatform: {}, connections: [], total: 0 });
+      mockGatewayClient.getRegisteredIds.mockResolvedValue({ ids: ['prov-1'] });
+      mockGatewayClient.connect.mockRejectedValue(new Error('409 connection parked'));
+
+      await service.ensureRunning();
+
+      // The 409 must not overwrite the bot's runtime status with a fresh state.
+      expect(mockUpdateBotRuntimeStatus).not.toHaveBeenCalledWith(
+        expect.objectContaining({ applicationId: 'app-1', status: 'starting' }),
+      );
       expect(mockGatewayClient.disconnect).not.toHaveBeenCalled();
     });
 
@@ -1005,12 +1038,17 @@ describe('GatewayService', () => {
         ids: providers.map(({ id }) => id),
       });
 
+      mockGatewayClient.connect.mockResolvedValue({ status: 'connecting' });
+
       await service.ensureRunning();
 
       expect(mockGatewayClient.getStats).toHaveBeenCalledTimes(1);
       expect(mockGatewayClient.getRegisteredIds).toHaveBeenCalledTimes(1);
       expect(mockGatewayClient.getStatus).not.toHaveBeenCalled();
-      expect(mockGatewayClient.connect).not.toHaveBeenCalled();
+      // Registered-only wakes are capped per round so a large fleet cannot
+      // turn the reconcile into a wake storm; the remainder waits for the
+      // next cron round.
+      expect(mockGatewayClient.connect).toHaveBeenCalledTimes(50);
       expect(mockGatewayClient.disconnect).not.toHaveBeenCalled();
     });
 
@@ -1020,11 +1058,17 @@ describe('GatewayService', () => {
       );
       mockGatewayClient.getStats.mockRejectedValue(new Error('stats unavailable'));
       mockGatewayClient.getRegisteredIds.mockResolvedValue({ ids: ['prov-1'] });
+      mockGatewayClient.connect.mockResolvedValue({ status: 'connecting' });
 
       await service.ensureRunning();
 
       expect(mockGatewayClient.getStatus).not.toHaveBeenCalled();
-      expect(mockGatewayClient.connect).not.toHaveBeenCalled();
+      // With no stats, every desired id is registered-only (status unknown) —
+      // still handled via the capped ensure wake, never a per-DO status probe.
+      expect(mockGatewayClient.connect).toHaveBeenCalledWith(
+        expect.objectContaining({ connectionId: 'prov-1' }),
+        { ensure: true },
+      );
       expect(mockGatewayClient.disconnect).not.toHaveBeenCalled();
     });
 

--- a/apps/server/src/services/gateway/index.ts
+++ b/apps/server/src/services/gateway/index.ts
@@ -68,6 +68,18 @@ const GATEWAY_SYNC_CONCURRENCY = 8;
  */
 const GATEWAY_SYNC_STALE_DISCONNECT_LIMIT = 50;
 
+/**
+ * Cap on registered-only wake-up connects per sync round. A registered-only id
+ * (in the registry but pruned from live stats) is usually a parked or
+ * self-waking dormant DO, but a stranded DO — alarm chain lost after a deploy
+ * cancelled its in-flight alarm invocation — looks identical and sleeps
+ * forever unless something wakes it. The `ensure` connect is that wake: parked
+ * connections answer 409 and keep their park, healthy ones no-op. The cap
+ * keeps a large parked backlog from turning every cron round into a fleet-wide
+ * wake storm; the remainder is retried on later rounds.
+ */
+const GATEWAY_SYNC_REGISTERED_ONLY_WAKE_LIMIT = 50;
+
 interface DesiredGatewayConnection {
   connectionMode: ConnectionMode;
   platform: string;
@@ -218,6 +230,8 @@ export class GatewayService {
     let deferred = 0;
     let skipped = 0;
     let failed = 0;
+    let registeredOnlyWakes = 0;
+    let registeredOnlyDeferred = 0;
 
     await pMap(
       desired.values(),
@@ -234,14 +248,25 @@ export class GatewayService {
 
           // Registered ids are the gateway's authoritative existence set. Use
           // the status already present in live stats to recover an explicitly
-          // disconnected connection, but never wake registered-only DOs merely
-          // to inspect their runtime status.
+          // disconnected connection. Registered-only ids (status null — pruned
+          // from stats) get a capped ensure-connect wake instead of a skip:
+          // see GATEWAY_SYNC_REGISTERED_ONLY_WAKE_LIMIT. Never probe per-DO
+          // status here.
           const exists = actual?.connections.has(provider.id) ?? false;
           const snapshotStatus = actual?.connections.get(provider.id);
           if (exists && snapshotStatus !== 'disconnected') {
-            skipped++;
-            log('Gateway sync: %s already registered, skipping', provider.id);
-            return;
+            if (snapshotStatus !== null) {
+              skipped++;
+              log('Gateway sync: %s already registered, skipping', provider.id);
+              return;
+            }
+            if (registeredOnlyWakes >= GATEWAY_SYNC_REGISTERED_ONLY_WAKE_LIMIT) {
+              registeredOnlyDeferred++;
+              log('Gateway sync: %s registered-only, wake cap reached, deferring', provider.id);
+              return;
+            }
+            registeredOnlyWakes++;
+            log('Gateway sync: %s registered-only, ensure-waking', provider.id);
           }
 
           // Without a complete registry snapshot, absence from live stats does
@@ -300,7 +325,7 @@ export class GatewayService {
     );
 
     log(
-      'Gateway sync complete in %dms: desired=%d actual=%s snapshotComplete=%s connected=%d skipped=%d deferred=%d gated=%d gatedDisconnected=%d stale=%d failed=%d',
+      'Gateway sync complete in %dms: desired=%d actual=%s snapshotComplete=%s connected=%d skipped=%d deferred=%d gated=%d gatedDisconnected=%d stale=%d failed=%d registeredOnlyWakes=%d registeredOnlyDeferred=%d',
       Date.now() - startedAt,
       desired.size,
       actual ? actual.connections.size : 'unavailable',
@@ -312,6 +337,8 @@ export class GatewayService {
       gatedDisconnected,
       stale,
       failed,
+      registeredOnlyWakes,
+      registeredOnlyDeferred,
     );
   }
 

--- a/apps/server/src/services/gateway/index.ts
+++ b/apps/server/src/services/gateway/index.ts
@@ -80,6 +80,25 @@ const GATEWAY_SYNC_STALE_DISCONNECT_LIMIT = 50;
  */
 const GATEWAY_SYNC_REGISTERED_ONLY_WAKE_LIMIT = 50;
 
+/**
+ * Uniformly sample up to `limit` ids via a partial Fisher-Yates shuffle.
+ * Stateless by design — the gateway cron runs in fresh serverless invocations,
+ * so a persisted round-robin cursor would need external storage; uniform
+ * sampling gives every candidate an expected candidates/limit-round latency
+ * without any state.
+ */
+const sampleIds = (ids: string[], limit: number): Set<string> => {
+  if (ids.length <= limit) return new Set(ids);
+  const pool = [...ids];
+  const picked = new Set<string>();
+  for (let i = 0; i < limit; i++) {
+    const j = i + Math.floor(Math.random() * (pool.length - i));
+    [pool[i], pool[j]] = [pool[j], pool[i]];
+    picked.add(pool[i]);
+  }
+  return picked;
+};
+
 interface DesiredGatewayConnection {
   connectionMode: ConnectionMode;
   platform: string;
@@ -230,8 +249,24 @@ export class GatewayService {
     let deferred = 0;
     let skipped = 0;
     let failed = 0;
+
+    // Registered-only wake candidates are SAMPLED, not taken head-first: the
+    // desired map iterates in a stable order, and parked connections (409,
+    // stay registered-only until their 7d expiry) would otherwise burn the
+    // whole cap on the same prefix every round, starving stranded DOs that
+    // sort after position N. Uniform sampling reaches every candidate within
+    // an expected candidates/limit rounds with no persisted cursor.
+    const registeredOnlyCandidates = [...desired.values()]
+      .map(({ provider }) => provider.id)
+      .filter(
+        (id) => (actual?.connections.has(id) ?? false) && actual?.connections.get(id) === null,
+      );
+    const registeredOnlyWakeIds = sampleIds(
+      registeredOnlyCandidates,
+      GATEWAY_SYNC_REGISTERED_ONLY_WAKE_LIMIT,
+    );
+    const registeredOnlyDeferred = registeredOnlyCandidates.length - registeredOnlyWakeIds.size;
     let registeredOnlyWakes = 0;
-    let registeredOnlyDeferred = 0;
 
     await pMap(
       desired.values(),
@@ -260,9 +295,11 @@ export class GatewayService {
               log('Gateway sync: %s already registered, skipping', provider.id);
               return;
             }
-            if (registeredOnlyWakes >= GATEWAY_SYNC_REGISTERED_ONLY_WAKE_LIMIT) {
-              registeredOnlyDeferred++;
-              log('Gateway sync: %s registered-only, wake cap reached, deferring', provider.id);
+            if (!registeredOnlyWakeIds.has(provider.id)) {
+              log(
+                'Gateway sync: %s registered-only, not sampled this round, deferring',
+                provider.id,
+              );
               return;
             }
             registeredOnlyWakes++;


### PR DESCRIPTION
## 背景

`syncGatewayConnections` 对「注册表里有、但 live stats 里没有」(registered-only,status=null)的 desired 连接一律跳过("never wake registered-only DOs")。这个 LOBE-11586 时期的防探活风暴假设认为 registered-only 要么是 parked、要么是会自己醒的 dormant DO——但 alarm 链丢失的搁浅 DO(deploy 取消进行中 alarm 调用所致)看起来完全一样,会永远沉睡且同步永远不会去修它。07-24 生产清点有 78 个此类连接(59 个 telegram messenger、15 个 discord 用户 bot)。

## 变更

registered-only 且属于 desired 的连接改为**每轮最多 50 个**(`GATEWAY_SYNC_REGISTERED_ONLY_WAKE_LIMIT`)的 `ensure` connect 唤醒:

- parked 连接返回 409,park 状态保留,不会被重置(维持 LOBE-11586 的防护);
- 搁浅 DO 被唤醒后自动回到重连生命周期;
- 超出上限计入 `registeredOnlyDeferred`,与 `registeredOnlyWakes` 一起打进 sync 汇总日志,下一轮 cron 继续;
- 仍然不做任何 per-DO status 探测,快照请求数不变(stats + registered-ids 各 1 次)。

配合 message-gateway 侧的搁浅自愈(lobehub-biz/message-gateway#35)构成双保险;建议在其之后部署,效果在下一个 6h gateway cron tick 生效,可通过日志中 `registeredOnlyWakes=N` 观察。

## 测试

更新 5 例锁旧行为的测试,新增 parked-409 不覆盖运行时状态用例;gateway 目录 106 例全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)