### PR TITLE
💄 style: polish ask user question results

### DIFF
--- a/packages/builtin-tool-lobe-agent/src/client/Inspector/index.ts
+++ b/packages/builtin-tool-lobe-agent/src/client/Inspector/index.ts
@@ -1,3 +1,4 @@
+import { AskUserQuestionInspector } from '@lobechat/builtin-tool-user-interaction/client';
 import type { BuiltinInspector } from '@lobechat/types';
 
 import { LobeAgentApiName } from '../../types';
@@ -17,6 +18,7 @@ import { UpdateTodosInspector } from './UpdateTodos';
  */
 export const LobeAgentInspectors: Record<string, BuiltinInspector> = {
   [LobeAgentApiName.analyzeVisualMedia]: AnalyzeVisualMediaInspector as BuiltinInspector,
+  [LobeAgentApiName.askUserQuestion]: AskUserQuestionInspector as BuiltinInspector,
   [LobeAgentApiName.callSubAgent]: CallSubAgentInspector as BuiltinInspector,
   [LobeAgentApiName.clearTodos]: ClearTodosInspector as BuiltinInspector,
   [LobeAgentApiName.createPlan]: CreatePlanInspector as BuiltinInspector,

--- a/packages/builtin-tool-lobe-agent/src/client/Render/index.ts
+++ b/packages/builtin-tool-lobe-agent/src/client/Render/index.ts
@@ -1,3 +1,5 @@
+import { AskUserQuestionRender } from '@lobechat/builtin-tool-user-interaction/client';
+
 import { LobeAgentApiName } from '../../types';
 import CallSubAgentRender from './CallSubAgent';
 import CreatePlan from './CreatePlan';
@@ -11,6 +13,7 @@ import TodoListRender from './TodoList';
  * share a single TodoList render.
  */
 export const LobeAgentRenders = {
+  [LobeAgentApiName.askUserQuestion]: AskUserQuestionRender,
   [LobeAgentApiName.callSubAgent]: CallSubAgentRender,
 
   // Plan operations render the PlanCard UI

--- a/packages/builtin-tool-user-interaction/src/client/Render/AskUserQuestion/index.tsx
+++ b/packages/builtin-tool-user-interaction/src/client/Render/AskUserQuestion/index.tsx
@@ -12,14 +12,7 @@ import { useTranslation } from 'react-i18next';
 
 import type { AskUserQuestionArgs } from '../../../types';
 
-/**
- * Claude Code host for the shared completed AskUserQuestion result.
- *
- * The interactive form remains an Intervention. Once resolved, every producer
- * (Claude Code, lobe-agent, and user-interaction) now uses the same read-only
- * question/answer hierarchy instead of diverging into bespoke or raw JSON UI.
- */
-const AskUserQuestion = memo<
+export const AskUserQuestionRender = memo<
   BuiltinRenderProps<AskUserQuestionArgs, AskUserQuestionResultState, string>
 >(({ args, content, pluginError, pluginState }) => {
   const { t } = useTranslation('plugin');
@@ -37,6 +30,6 @@ const AskUserQuestion = memo<
   );
 });
 
-AskUserQuestion.displayName = 'CCAskUserQuestion';
+AskUserQuestionRender.displayName = 'AskUserQuestionRender';
 
-export default AskUserQuestion;
+export default AskUserQuestionRender;

--- a/packages/builtin-tool-user-interaction/src/client/Render/index.ts
+++ b/packages/builtin-tool-user-interaction/src/client/Render/index.ts
@@ -1,0 +1,10 @@
+import type { BuiltinRender } from '@lobechat/types';
+
+import { UserInteractionApiName } from '../../types';
+import AskUserQuestionRender from './AskUserQuestion';
+
+export const UserInteractionRenders: Record<string, BuiltinRender> = {
+  [UserInteractionApiName.askUserQuestion]: AskUserQuestionRender as BuiltinRender,
+};
+
+export { default as AskUserQuestionRender } from './AskUserQuestion';

--- a/packages/builtin-tool-user-interaction/src/client/index.ts
+++ b/packages/builtin-tool-user-interaction/src/client/index.ts
@@ -4,3 +4,4 @@ export { UserInteractionInspectors } from './Inspector';
 export { default as AskUserQuestionInspector } from './Inspector/AskUserQuestion';
 export { UserInteractionInterventions } from './Intervention';
 export { default as AskUserQuestionIntervention } from './Intervention/AskUserQuestion';
+export { AskUserQuestionRender, UserInteractionRenders } from './Render';

--- a/packages/builtin-tools/src/register.ts
+++ b/packages/builtin-tools/src/register.ts
@@ -130,6 +130,7 @@ import {
   UserInteractionIdentifier,
   UserInteractionInspectors,
   UserInteractionInterventions,
+  UserInteractionRenders,
 } from '@lobechat/builtin-tool-user-interaction/client';
 import {
   WebBrowsingInspectors,
@@ -201,6 +202,7 @@ export const registerBuiltinToolSurfaces = (): void => {
     [SkillStoreManifest.identifier]: SkillStoreRenders as Record<string, BuiltinRender>,
     [SkillsManifest.identifier]: SkillsRenders as Record<string, BuiltinRender>,
     [TaskManifest.identifier]: TaskRenders as Record<string, BuiltinRender>,
+    [UserInteractionIdentifier]: UserInteractionRenders as Record<string, BuiltinRender>,
     [LobeActivatorManifest.identifier]: LobeActivatorRenders as Record<string, BuiltinRender>,
     [WebBrowsingManifest.identifier]: WebBrowsingRenders as Record<string, BuiltinRender>,
     [WebOnboardingManifest.identifier]: WebOnboardingRenders as Record<string, BuiltinRender>,

--- a/packages/shared-tool-ui/src/AskUserQuestion/AskUserQuestionResult.tsx
+++ b/packages/shared-tool-ui/src/AskUserQuestion/AskUserQuestionResult.tsx
@@ -1,0 +1,258 @@
+'use client';
+
+import { Flexbox, Icon, Text } from '@lobehub/ui';
+import { createStaticStyles, cx } from 'antd-style';
+import { Check, PenLine } from 'lucide-react';
+import { memo } from 'react';
+
+import type { AskUserQuestionItem } from './types';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  answer: css`
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1.5;
+    color: ${cssVar.colorText};
+    overflow-wrap: anywhere;
+  `,
+  answerContent: css`
+    min-width: 0;
+  `,
+  answerIcon: css`
+    flex-shrink: 0;
+    margin-block-start: 3px;
+    color: ${cssVar.colorTextSecondary};
+  `,
+  answerIconSelected: css`
+    color: ${cssVar.colorSuccess};
+  `,
+  answerRow: css`
+    box-sizing: border-box;
+    width: fit-content;
+    max-width: 100%;
+    padding-block: 8px;
+    padding-inline: 12px;
+    border-radius: 8px;
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+  container: css`
+    padding-block: 8px 4px;
+  `,
+  description: css`
+    font-size: 12px;
+    line-height: 1.5;
+    color: ${cssVar.colorTextTertiary};
+    overflow-wrap: anywhere;
+  `,
+  divider: css`
+    align-self: stretch;
+    height: 1px;
+    margin-block: 4px;
+    background: ${cssVar.colorFillSecondary};
+  `,
+  header: css`
+    flex-shrink: 0;
+
+    padding-inline: 8px;
+    border-radius: 4px;
+
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 20px;
+    color: ${cssVar.colorTextTertiary};
+    white-space: nowrap;
+
+    background: ${cssVar.colorFillQuaternary};
+  `,
+  ordinal: css`
+    flex-shrink: 0;
+
+    box-sizing: border-box;
+    width: 28px;
+    height: 20px;
+    border-radius: 4px;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    line-height: 20px;
+    color: ${cssVar.colorTextTertiary};
+    text-align: center;
+
+    background: ${cssVar.colorFillQuaternary};
+  `,
+  question: css`
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 1.5;
+    color: ${cssVar.colorTextSecondary};
+    overflow-wrap: anywhere;
+  `,
+  questionContent: css`
+    min-width: 0;
+  `,
+  titleRow: css`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: baseline;
+  `,
+  unanswered: css`
+    width: fit-content;
+    max-width: 100%;
+    padding-block: 8px;
+    padding-inline: 12px;
+    border: 1px dashed ${cssVar.colorBorderSecondary};
+    border-radius: 8px;
+
+    font-size: 12px;
+    line-height: 1.5;
+    color: ${cssVar.colorTextQuaternary};
+  `,
+}));
+
+export interface AskUserQuestionResultLabels {
+  noAnswer: string;
+  notAnswered: string;
+}
+
+interface AnswerLineProps {
+  description?: string;
+  icon: typeof Check;
+  selected?: boolean;
+  text: string;
+}
+
+const AnswerLine = memo<AnswerLineProps>(({ icon, text, description, selected }) => (
+  <Flexbox horizontal align="flex-start" className={styles.answerRow} gap={12}>
+    <Icon
+      className={cx(styles.answerIcon, selected && styles.answerIconSelected)}
+      icon={icon}
+      size={14}
+    />
+    <Flexbox className={styles.answerContent} flex={1} gap={4}>
+      <span className={styles.answer}>{text}</span>
+      {description && <span className={styles.description}>{description}</span>}
+    </Flexbox>
+  </Flexbox>
+));
+
+AnswerLine.displayName = 'AskUserQuestionResultAnswerLine';
+
+interface QuestionAnswerProps {
+  answer?: string | string[];
+  index?: number;
+  notAnswered: string;
+  question: AskUserQuestionItem;
+}
+
+const QuestionAnswer = memo<QuestionAnswerProps>(({ question, answer, index, notAnswered }) => {
+  const labels: string[] = Array.isArray(answer) ? answer : answer ? [answer] : [];
+  const optionByLabel = new Map(question.options.map((option) => [option.label, option]));
+
+  return (
+    <Flexbox align="flex-start" gap={8} horizontal={!!index}>
+      {!!index && <span className={styles.ordinal}>{`Q${index}`}</span>}
+      <Flexbox className={styles.questionContent} flex={1} gap={8}>
+        <div className={index ? styles.titleRow : undefined}>
+          <span className={styles.question}>{question.question}</span>
+          {!!index && question.header && <span className={styles.header}>{question.header}</span>}
+        </div>
+        {labels.length > 0 ? (
+          <Flexbox gap={8}>
+            {labels.map((label) => {
+              const option = optionByLabel.get(label);
+
+              return (
+                <AnswerLine
+                  selected
+                  icon={Check}
+                  key={label}
+                  text={label}
+                  description={
+                    option?.description && option.description !== label
+                      ? option.description
+                      : undefined
+                  }
+                />
+              );
+            })}
+          </Flexbox>
+        ) : (
+          <span className={styles.unanswered}>{notAnswered}</span>
+        )}
+      </Flexbox>
+    </Flexbox>
+  );
+});
+
+QuestionAnswer.displayName = 'AskUserQuestionResultQuestionAnswer';
+
+export interface AskUserQuestionResultProps {
+  answers?: Record<string, string | string[]>;
+  isError?: boolean;
+  labels: AskUserQuestionResultLabels;
+  questions: AskUserQuestionItem[];
+}
+
+/**
+ * Read-only result for a completed AskUserQuestion call.
+ *
+ * The enclosing tool already supplies the card chrome, so this view stays flat
+ * and uses question/answer typography instead of nesting another panel.
+ */
+export const AskUserQuestionResult = memo<AskUserQuestionResultProps>(
+  ({ answers, isError, labels, questions }) => {
+    const freeform = answers?.__freeform__;
+    const freeformText = typeof freeform === 'string' ? freeform.trim() : '';
+    const multiple = questions.length > 1;
+
+    if (freeformText) {
+      return (
+        <Flexbox className={styles.container} gap={16}>
+          {questions.map((question, index) => (
+            <Flexbox
+              align="flex-start"
+              gap={8}
+              horizontal={multiple}
+              key={`${question.question}-${index}`}
+            >
+              {multiple && <span className={styles.ordinal}>{`Q${index + 1}`}</span>}
+              <div
+                className={`${styles.questionContent} ${multiple ? styles.titleRow : ''}`.trim()}
+              >
+                <span className={styles.question}>{question.question}</span>
+                {multiple && question.header && (
+                  <span className={styles.header}>{question.header}</span>
+                )}
+              </div>
+            </Flexbox>
+          ))}
+          {multiple && <div className={styles.divider} />}
+          <AnswerLine icon={PenLine} text={freeformText} />
+          {isError && <Text type="warning">{labels.noAnswer}</Text>}
+        </Flexbox>
+      );
+    }
+
+    return (
+      <Flexbox className={styles.container} gap={16}>
+        {questions.map((question, index) => (
+          <QuestionAnswer
+            answer={answers?.[question.question]}
+            index={multiple ? index + 1 : undefined}
+            key={`${question.question}-${index}`}
+            notAnswered={labels.notAnswered}
+            question={question}
+          />
+        ))}
+        {isError && <Text type="warning">{labels.noAnswer}</Text>}
+      </Flexbox>
+    );
+  },
+);
+
+AskUserQuestionResult.displayName = 'AskUserQuestionResult';
+
+export default AskUserQuestionResult;

--- a/packages/shared-tool-ui/src/AskUserQuestion/index.ts
+++ b/packages/shared-tool-ui/src/AskUserQuestion/index.ts
@@ -1,4 +1,9 @@
 export {
+  AskUserQuestionResult,
+  type AskUserQuestionResultLabels,
+  type AskUserQuestionResultProps,
+} from './AskUserQuestionResult';
+export {
   type AskUserQuestionLabels,
   AskUserQuestionView,
   type AskUserQuestionViewProps,
@@ -14,6 +19,7 @@ export {
 } from './draft';
 export { normalizeAskUserQuestions } from './normalize';
 export { default as QuestionPanel } from './QuestionPanel';
+export { type AskUserQuestionResultState, resolveAskUserAnswers } from './result';
 export type {
   AskUserDraft,
   AskUserQuestionArgs,

--- a/packages/shared-tool-ui/src/AskUserQuestion/result.test.ts
+++ b/packages/shared-tool-ui/src/AskUserQuestion/result.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveAskUserAnswers } from './result';
+
+describe('resolveAskUserAnswers', () => {
+  it('prefers the structured answers persisted in plugin state', () => {
+    expect(
+      resolveAskUserAnswers(
+        { askUserAnswers: { Scope: ['Chat', 'Settings'] } },
+        'User submitted: {"Scope":"Legacy"}',
+      ),
+    ).toEqual({ Scope: ['Chat', 'Settings'] });
+  });
+
+  it('recovers answers from legacy builtin tool result content', () => {
+    expect(
+      resolveAskUserAnswers(
+        undefined,
+        'User submitted: {"Which direction?":"Visual polish","Surfaces":["Chat","Settings"]}',
+      ),
+    ).toEqual({
+      'Which direction?': 'Visual polish',
+      'Surfaces': ['Chat', 'Settings'],
+    });
+  });
+
+  it('ignores malformed or unsupported answer payloads', () => {
+    expect(resolveAskUserAnswers(undefined, 'User submitted: not-json')).toBeUndefined();
+    expect(resolveAskUserAnswers(undefined, 'Question(s) presented to the user.')).toBeUndefined();
+    expect(resolveAskUserAnswers({ askUserAnswers: { Scope: 42 } as any }, '')).toBeUndefined();
+  });
+});

--- a/packages/shared-tool-ui/src/AskUserQuestion/result.ts
+++ b/packages/shared-tool-ui/src/AskUserQuestion/result.ts
@@ -1,0 +1,43 @@
+export interface AskUserQuestionResultState {
+  askUserAnswers?: Record<string, string | string[]>;
+}
+
+const USER_SUBMITTED_PREFIX = 'User submitted:';
+
+const normalizeAnswers = (value: unknown): Record<string, string | string[]> | undefined => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return;
+
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, string | string[]] =>
+      typeof entry[1] === 'string' ||
+      (Array.isArray(entry[1]) && entry[1].every((item) => typeof item === 'string')),
+  );
+
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+};
+
+/**
+ * Resolve the structured answers for a completed AskUserQuestion call.
+ *
+ * New messages persist `pluginState.askUserAnswers`. Older builtin calls only
+ * stored `User submitted: {...}` in the tool result, so keep that lightweight
+ * compatibility path instead of exposing the generic JSON result renderer.
+ */
+export const resolveAskUserAnswers = (
+  pluginState: AskUserQuestionResultState | undefined,
+  content: unknown,
+): Record<string, string | string[]> | undefined => {
+  const persisted = normalizeAnswers(pluginState?.askUserAnswers);
+  if (persisted) return persisted;
+
+  if (typeof content !== 'string') return;
+
+  const prefixIndex = content.indexOf(USER_SUBMITTED_PREFIX);
+  if (prefixIndex < 0) return;
+
+  try {
+    return normalizeAnswers(JSON.parse(content.slice(prefixIndex + USER_SUBMITTED_PREFIX.length)));
+  } catch {
+    return;
+  }
+};

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/customInteractionHandlers.test.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/customInteractionHandlers.test.ts
@@ -1,3 +1,8 @@
+import { LobeAgentApiName, LobeAgentIdentifier } from '@lobechat/builtin-tool-lobe-agent';
+import {
+  UserInteractionApiName,
+  UserInteractionIdentifier,
+} from '@lobechat/builtin-tool-user-interaction';
 import {
   WebOnboardingApiName,
   WebOnboardingIdentifier,
@@ -76,6 +81,23 @@ describe('customInteractionHandlers', () => {
       skippedAgentIds: ['template-existing'],
     });
     expect(result.options?.createUserMessage).toBe(false);
+  });
+
+  it.each([
+    [LobeAgentIdentifier, LobeAgentApiName.askUserQuestion],
+    [UserInteractionIdentifier, UserInteractionApiName.askUserQuestion],
+  ])('persists structured ask-user answers for %s', async (identifier, apiName) => {
+    const payload = {
+      'How broad should this pass be?': 'Focused',
+      'Which surfaces?': ['Chat', 'Settings'],
+    };
+
+    const result = await prepareCustomInteractionSubmit(identifier, payload, { apiName });
+
+    expect(result).toEqual({
+      options: { pluginState: { askUserAnswers: payload } },
+      payload,
+    });
   });
 
   it('persists skipped marketplace picks from the original tool arguments', async () => {

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/customInteractionHandlers.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/customInteractionHandlers.ts
@@ -1,6 +1,9 @@
 import { ClaudeCodeIdentifier } from '@lobechat/builtin-tool-claude-code';
 import { LobeAgentApiName, LobeAgentIdentifier } from '@lobechat/builtin-tool-lobe-agent';
-import { UserInteractionIdentifier } from '@lobechat/builtin-tool-user-interaction';
+import {
+  UserInteractionApiName,
+  UserInteractionIdentifier,
+} from '@lobechat/builtin-tool-user-interaction';
 import {
   WebOnboardingApiName,
   WebOnboardingIdentifier,
@@ -37,6 +40,14 @@ type CustomInteractionSubmitHandler = (
 
 const isAgentMarketplaceCall = (identifier: string, apiName?: string) =>
   identifier === WebOnboardingIdentifier && apiName === WebOnboardingApiName.showAgentMarketplace;
+
+const isLobeAgentAskUserQuestion = (identifier: string, apiName?: string) =>
+  identifier === LobeAgentIdentifier && apiName === LobeAgentApiName.askUserQuestion;
+
+const isAskUserQuestionCall = (identifier: string, apiName?: string) =>
+  (identifier === UserInteractionIdentifier &&
+    apiName === UserInteractionApiName.askUserQuestion) ||
+  isLobeAgentAskUserQuestion(identifier, apiName);
 
 const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((item) => typeof item === 'string');
@@ -123,6 +134,13 @@ const customInteractionSubmitHandlers: Array<{
   match: (identifier: string, apiName?: string) => boolean;
 }> = [
   {
+    handler: async (payload) => ({
+      options: { pluginState: { askUserAnswers: payload } },
+      payload,
+    }),
+    match: isAskUserQuestionCall,
+  },
+  {
     handler: handleAgentMarketplaceSubmit,
     match: isAgentMarketplaceCall,
   },
@@ -149,9 +167,6 @@ export const isHeteroInteractionIdentifier = (identifier: string) =>
  * has other APIs (createPlan / clearTodos …) that must keep the default
  * approve/reject UI — so only its `askUserQuestion` API is a custom interaction.
  */
-const isLobeAgentAskUserQuestion = (identifier: string, apiName?: string) =>
-  identifier === LobeAgentIdentifier && apiName === LobeAgentApiName.askUserQuestion;
-
 export const isCustomInteractionIdentifier = (identifier: string, apiName?: string) =>
   identifier === UserInteractionIdentifier ||
   isLobeAgentAskUserQuestion(identifier, apiName) ||

--- a/src/features/DevPanel/RenderGallery/fixtures/lobe-agent.ts
+++ b/src/features/DevPanel/RenderGallery/fixtures/lobe-agent.ts
@@ -23,6 +23,41 @@ export default defineFixtures({
         provider: 'openai',
       },
     }),
+    askUserQuestion: single({
+      args: {
+        questions: [
+          {
+            header: 'Audit level',
+            options: [
+              {
+                description: 'Read the code and inspect the rendered surface.',
+                label: 'Code + visual',
+              },
+              {
+                description: 'Limit this pass to implementation details.',
+                label: 'Code only',
+              },
+            ],
+            question: 'How deep should this audit go?',
+          },
+          {
+            header: 'Scope',
+            multiSelect: true,
+            options: [
+              { description: 'Conversation messages and tool cards.', label: 'Chat' },
+              { description: 'Agent configuration and settings.', label: 'Settings' },
+            ],
+            question: 'Which surfaces should it cover?',
+          },
+        ],
+      },
+      pluginState: {
+        askUserAnswers: {
+          'How deep should this audit go?': 'Code + visual',
+          'Which surfaces should it cover?': ['Chat', 'Settings'],
+        },
+      },
+    }),
     callSubAgent: single({
       pluginState: {
         task: {

--- a/src/features/DevPanel/RenderGallery/fixtures/lobe-user-interaction.ts
+++ b/src/features/DevPanel/RenderGallery/fixtures/lobe-user-interaction.ts
@@ -31,6 +31,11 @@ export default defineFixtures({
           ],
         },
         label: 'Single question',
+        pluginState: {
+          askUserAnswers: {
+            'Which area should we explore first?': ['Evidence pages', 'Visual direction'],
+          },
+        },
       },
       {
         args: {
@@ -48,6 +53,12 @@ export default defineFixtures({
           ],
         },
         label: 'Multiple questions',
+        pluginState: {
+          askUserAnswers: {
+            'How broad should this pass be?': 'Focused',
+            'Which visual tone should we use?': 'Neutral',
+          },
+        },
       },
     ]),
   },

--- a/src/store/tool/builtinToolRegistry.test.ts
+++ b/src/store/tool/builtinToolRegistry.test.ts
@@ -5,6 +5,7 @@ import {
   GroupAgentBuilderIdentifier,
 } from '@lobechat/builtin-tool-group-agent-builder';
 import { GroupAgentBuilderInspectors } from '@lobechat/builtin-tool-group-agent-builder/client';
+import { LobeAgentApiName, LobeAgentIdentifier } from '@lobechat/builtin-tool-lobe-agent';
 import { RemoteDeviceApiName, RemoteDeviceIdentifier } from '@lobechat/builtin-tool-remote-device';
 import { SkillStoreApiName, SkillStoreIdentifier } from '@lobechat/builtin-tool-skill-store';
 import { SkillStoreInspectors, SkillStoreRenders } from '@lobechat/builtin-tool-skill-store/client';
@@ -79,9 +80,19 @@ describe('builtin tool registry', () => {
     expect(runtime.agencyConfig?.executionTarget).toBe('none');
   });
 
-  it('registers the ask user question inspector', () => {
+  it('registers the ask user question surfaces across builtin producers', () => {
     expect(
       getBuiltinInspector(UserInteractionIdentifier, UserInteractionApiName.askUserQuestion),
+    ).toBeDefined();
+    expect(
+      getBuiltinRender(UserInteractionIdentifier, UserInteractionApiName.askUserQuestion),
+    ).toBeDefined();
+    expect(
+      getBuiltinInspector(LobeAgentIdentifier, LobeAgentApiName.askUserQuestion),
+    ).toBeDefined();
+    expect(getBuiltinRender(LobeAgentIdentifier, LobeAgentApiName.askUserQuestion)).toBeDefined();
+    expect(
+      getBuiltinRender(ClaudeCodeToolIdentifier, UserInteractionApiName.askUserQuestion),
     ).toBeDefined();
   });
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A — no matching public issue was found.

#### 🔀 Description of Change

- Replace generic/raw completed `askUserQuestion` output with a shared structured question-and-answer result.
- Register the shared result across Claude Code, Lobe Agent, and User Interaction producers.
- Persist structured answers in `pluginState` and retain a compatibility parser for legacy `User submitted: {...}` results.
- Add Render Gallery fixtures plus registry, persistence, and compatibility tests.

#### 🧭 Key Decisions / Non-goals

- Keep the existing tool schema, arguments, intervention protocol, and executor unchanged.
- Keep the completed result visually flat at the tool-card level; only selected answers receive a compact filled surface.
- Reuse one renderer across producers instead of maintaining producer-specific result UIs.
- Support existing persisted messages without a migration by reading their legacy result content.
- This PR contains no cloud-specific business or operational behavior.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check` — 17 tests passed, lint clean.
- Open the Render Gallery fixtures for Lobe Agent and User Interaction `askUserQuestion` results.
- Verify single-choice, multi-choice, freeform, legacy-content, and unanswered states.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Generic parameter/result presentation or markdown-like rows | Structured question context with compact selected-answer surfaces |

#### 📝 Additional Information

No schema changes, migrations, environment variables, or rollout steps are required.
