### PR TITLE
🐛 fix: hide unavailable workspace environment on web

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Overview/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Overview/index.tsx
@@ -98,6 +98,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 interface OverviewProps {
   active: boolean;
   deviceId?: string;
+  environmentAvailable: boolean;
   onOpenTab: (tab: string) => void;
   repoType?: string;
   workingDirectory?: string;
@@ -113,7 +114,7 @@ const OverviewRowLead = ({ children, icon }: { children: ReactNode; icon: IconPr
 );
 
 const Overview = memo<OverviewProps>(
-  ({ active, deviceId, onOpenTab, repoType, workingDirectory }) => {
+  ({ active, deviceId, environmentAvailable, onOpenTab, repoType, workingDirectory }) => {
     const { t } = useTranslation('chat');
     const isHetero = useAgentStore(agentSelectors.isCurrentAgentHeterogeneous);
     const topicId = useChatStore((s) => s.activeTopicId);
@@ -168,103 +169,105 @@ const Overview = memo<OverviewProps>(
 
     return (
       <Flexbox className={styles.body} gap={14}>
-        <Flexbox>
-          <Flexbox
-            horizontal
-            align={'center'}
-            className={styles.sectionHeader}
-            justify={'space-between'}
-          >
-            <span className={styles.sectionTitle}>{t('workingPanel.overview.environment')}</span>
-            {workingDirectory && (
-              <Tag size={'small'}>
-                {deviceId
-                  ? t('workingPanel.overview.execution.device')
-                  : t('workingPanel.overview.execution.local')}
-              </Tag>
-            )}
-          </Flexbox>
+        {environmentAvailable && (
+          <Flexbox>
+            <Flexbox
+              horizontal
+              align={'center'}
+              className={styles.sectionHeader}
+              justify={'space-between'}
+            >
+              <span className={styles.sectionTitle}>{t('workingPanel.overview.environment')}</span>
+              {workingDirectory && (
+                <Tag size={'small'}>
+                  {deviceId
+                    ? t('workingPanel.overview.execution.device')
+                    : t('workingPanel.overview.execution.local')}
+                </Tag>
+              )}
+            </Flexbox>
 
-          <Flexbox
-            horizontal
-            align={'flex-start'}
-            className={styles.row}
-            gap={10}
-            onClick={workingDirectory ? () => onOpenTab('files') : undefined}
-          >
-            <OverviewRowLead icon={workingDirectory ? FolderGit2Icon : LaptopIcon}>
-              <Flexbox flex={1} style={{ minWidth: 0 }}>
-                <Text ellipsis weight={500}>
-                  {directoryName || t('workingPanel.overview.workspace.empty')}
-                </Text>
-                <Text ellipsis color={cssVar.colorTextTertiary} fontSize={12}>
-                  {workingDirectory || t('workingPanel.overview.workspace.emptyDesc')}
-                </Text>
-              </Flexbox>
-            </OverviewRowLead>
-          </Flexbox>
-
-          {repoType && workingDirectory && isGitLoading ? (
-            <div className={styles.skeleton}>
-              <Skeleton active paragraph={{ rows: 2 }} title={false} />
-            </div>
-          ) : gitError ? (
-            <Center className={styles.error} gap={8}>
-              <Text type={'danger'}>{t('workingPanel.overview.environmentError')}</Text>
-              <Button icon={RefreshCwIcon} size={'small'} onClick={retryGit}>
-                {t('retry', { ns: 'common' })}
-              </Button>
-            </Center>
-          ) : repoType && workingDirectory ? (
-            <>
-              <Flexbox
-                horizontal
-                align={'flex-start'}
-                className={cx(styles.row, styles.rowStatus)}
-                gap={10}
-              >
-                <OverviewRowLead icon={GitBranchIcon}>
-                  <Flexbox flex={1}>
-                    <Text className={styles.rowStatusPrimary}>
-                      {t('workingPanel.overview.branch')}
-                    </Text>
-                  </Flexbox>
-                </OverviewRowLead>
-                <Flexbox horizontal align={'center'} className={styles.stats} gap={6}>
-                  <Text ellipsis fontSize={12} style={{ maxWidth: 128 }}>
-                    {branchData?.branch || t('workingPanel.overview.branch.detached')}
+            <Flexbox
+              horizontal
+              align={'flex-start'}
+              className={styles.row}
+              gap={10}
+              onClick={workingDirectory ? () => onOpenTab('files') : undefined}
+            >
+              <OverviewRowLead icon={workingDirectory ? FolderGit2Icon : LaptopIcon}>
+                <Flexbox flex={1} style={{ minWidth: 0 }}>
+                  <Text ellipsis weight={500}>
+                    {directoryName || t('workingPanel.overview.workspace.empty')}
                   </Text>
-                  {!!aheadBehind?.ahead && <Tag size={'small'}>↑{aheadBehind.ahead}</Tag>}
-                  {!!aheadBehind?.behind && <Tag size={'small'}>↓{aheadBehind.behind}</Tag>}
+                  <Text ellipsis color={cssVar.colorTextTertiary} fontSize={12}>
+                    {workingDirectory || t('workingPanel.overview.workspace.emptyDesc')}
+                  </Text>
                 </Flexbox>
-              </Flexbox>
-              <Flexbox
-                horizontal
-                align={'flex-start'}
-                className={styles.row}
-                gap={10}
-                onClick={() => onOpenTab('review')}
-              >
-                <OverviewRowLead icon={ClipboardListIcon}>
-                  <Flexbox flex={1} style={{ minWidth: 0 }}>
-                    <Text weight={500}>{t('workingPanel.overview.changes')}</Text>
-                    <Text color={cssVar.colorTextTertiary} fontSize={12}>
-                      {changeStats.files
-                        ? t('workingPanel.overview.changes.files', { count: changeStats.files })
-                        : t('workingPanel.overview.changes.clean')}
+              </OverviewRowLead>
+            </Flexbox>
+
+            {repoType && workingDirectory && isGitLoading ? (
+              <div className={styles.skeleton}>
+                <Skeleton active paragraph={{ rows: 2 }} title={false} />
+              </div>
+            ) : gitError ? (
+              <Center className={styles.error} gap={8}>
+                <Text type={'danger'}>{t('workingPanel.overview.environmentError')}</Text>
+                <Button icon={RefreshCwIcon} size={'small'} onClick={retryGit}>
+                  {t('retry', { ns: 'common' })}
+                </Button>
+              </Center>
+            ) : repoType && workingDirectory ? (
+              <>
+                <Flexbox
+                  horizontal
+                  align={'flex-start'}
+                  className={cx(styles.row, styles.rowStatus)}
+                  gap={10}
+                >
+                  <OverviewRowLead icon={GitBranchIcon}>
+                    <Flexbox flex={1}>
+                      <Text className={styles.rowStatusPrimary}>
+                        {t('workingPanel.overview.branch')}
+                      </Text>
+                    </Flexbox>
+                  </OverviewRowLead>
+                  <Flexbox horizontal align={'center'} className={styles.stats} gap={6}>
+                    <Text ellipsis fontSize={12} style={{ maxWidth: 128 }}>
+                      {branchData?.branch || t('workingPanel.overview.branch.detached')}
                     </Text>
+                    {!!aheadBehind?.ahead && <Tag size={'small'}>↑{aheadBehind.ahead}</Tag>}
+                    {!!aheadBehind?.behind && <Tag size={'small'}>↓{aheadBehind.behind}</Tag>}
                   </Flexbox>
-                </OverviewRowLead>
-                {changeStats.files > 0 && (
-                  <Flexbox horizontal className={styles.stats} gap={8}>
-                    <span className={styles.changeAdditions}>+{changeStats.additions}</span>
-                    <span className={styles.changeDeletions}>−{changeStats.deletions}</span>
-                  </Flexbox>
-                )}
-              </Flexbox>
-            </>
-          ) : null}
-        </Flexbox>
+                </Flexbox>
+                <Flexbox
+                  horizontal
+                  align={'flex-start'}
+                  className={styles.row}
+                  gap={10}
+                  onClick={() => onOpenTab('review')}
+                >
+                  <OverviewRowLead icon={ClipboardListIcon}>
+                    <Flexbox flex={1} style={{ minWidth: 0 }}>
+                      <Text weight={500}>{t('workingPanel.overview.changes')}</Text>
+                      <Text color={cssVar.colorTextTertiary} fontSize={12}>
+                        {changeStats.files
+                          ? t('workingPanel.overview.changes.files', { count: changeStats.files })
+                          : t('workingPanel.overview.changes.clean')}
+                      </Text>
+                    </Flexbox>
+                  </OverviewRowLead>
+                  {changeStats.files > 0 && (
+                    <Flexbox horizontal className={styles.stats} gap={8}>
+                      <span className={styles.changeAdditions}>+{changeStats.additions}</span>
+                      <span className={styles.changeDeletions}>−{changeStats.deletions}</span>
+                    </Flexbox>
+                  )}
+                </Flexbox>
+              </>
+            ) : null}
+          </Flexbox>
+        )}
 
         <ProgressSection />
 

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/useReviewPatches.test.ts
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/useReviewPatches.test.ts
@@ -6,6 +6,15 @@ import {
   useReviewPatches,
 } from './useReviewPatches';
 
+const platform = vi.hoisted(() => ({ isDesktop: true }));
+
+vi.mock('@lobechat/const', async (importOriginal) => ({
+  ...(await importOriginal()),
+  get isDesktop() {
+    return platform.isDesktop;
+  },
+}));
+
 vi.mock('@/libs/swr', () => ({
   mutate: vi.fn(),
   useClientDataSWR: vi.fn(() => ({ data: undefined })),
@@ -22,6 +31,7 @@ vi.mock('@/services/git', () => ({
 describe('useReviewPatches', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    platform.isDesktop = true;
   });
 
   it('polls while the review tab is active and disables polling while hidden', () => {
@@ -52,6 +62,18 @@ describe('useReviewPatches', () => {
       expect.objectContaining({
         refreshInterval: 0,
       }),
+    );
+  });
+
+  it('does not request local git patches from a web client without a target device', () => {
+    platform.isDesktop = false;
+
+    useReviewPatches('/repo', 'unstaged', undefined, undefined, true);
+
+    expect(useClientDataSWR).toHaveBeenCalledWith(
+      null,
+      expect.any(Function),
+      expect.objectContaining({ refreshInterval: 10_000 }),
     );
   });
 

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
@@ -33,6 +33,8 @@ const effectiveConfig = vi.hoisted(() => ({
   workspaceScoped: false,
 }));
 
+const platform = vi.hoisted(() => ({ isDesktop: true }));
+
 const filesProps = vi.hoisted(() => ({
   current: undefined as { deviceId?: string; workingDirectory: string } | undefined,
 }));
@@ -115,10 +117,22 @@ vi.mock('../Browser', () => ({
   },
 }));
 vi.mock('../Overview', () => ({
-  default: ({ onOpenTab }: { onOpenTab: (tab: string) => void }) => (
-    <button type="button" onClick={() => onOpenTab('review')}>
-      Open Review from Overview
-    </button>
+  default: ({
+    environmentAvailable,
+    onOpenTab,
+    workingDirectory,
+  }: {
+    environmentAvailable: boolean;
+    onOpenTab: (tab: string) => void;
+    workingDirectory?: string;
+  }) => (
+    <>
+      <button type="button" onClick={() => onOpenTab('review')}>
+        Open Review from Overview
+      </button>
+      {environmentAvailable && <span>Workspace environment</span>}
+      {workingDirectory && <span>{workingDirectory}</span>}
+    </>
   ),
 }));
 
@@ -191,11 +205,20 @@ vi.mock('@/helpers/agentWorkingDirectory', () => ({ resolveTargetDeviceId: () =>
 vi.mock('@/helpers/executionTarget', () => ({
   resolveExecutionTarget: (
     agencyConfig: { executionTarget?: 'device' | 'local' } | undefined,
-    options: { workspaceScoped?: boolean },
-  ) => (options.workspaceScoped ? 'device' : (agencyConfig?.executionTarget ?? 'local')),
+    options: { clientExecutionAvailable: boolean; workspaceScoped?: boolean },
+  ) => {
+    if (options.workspaceScoped) return 'device';
+    const target = agencyConfig?.executionTarget;
+    if (!options.clientExecutionAvailable && target === 'local') return 'sandbox';
+    return target ?? (options.clientExecutionAvailable ? 'local' : 'none');
+  },
 }));
 vi.mock('@/helpers/gatewayMode', () => ({ useIsGatewayModeEnabled: () => false }));
-vi.mock('@/const/version', () => ({ isDesktop: true }));
+vi.mock('@/const/version', () => ({
+  get isDesktop() {
+    return platform.isDesktop;
+  },
+}));
 vi.mock('@/store/user', () => ({ useUserStore: () => true }));
 vi.mock('@/store/user/selectors', () => ({
   labPreferSelectors: { enableInAppBrowser: () => true },
@@ -287,6 +310,7 @@ beforeEach(() => {
   agentStore.rawAgencyConfig = undefined;
   effectiveConfig.agencyConfig = undefined;
   effectiveConfig.workspaceScoped = false;
+  platform.isDesktop = true;
   filesProps.current = undefined;
   reviewState.repoType = undefined;
   reviewState.setRepoType = undefined;
@@ -438,6 +462,21 @@ describe('AgentWorkingSidebar — controlled panel width', () => {
       deviceId: 'workspace-device',
       workingDirectory: '/workspace/project',
     });
+  });
+
+  it('does not expose a persisted local workspace when the web client has no local runtime', () => {
+    platform.isDesktop = false;
+    agentStore.activeAgentId = 'agent';
+    effectiveConfig.agencyConfig = { executionTarget: 'local' };
+    reviewState.repoType = 'git';
+    reviewState.workingDirectory = '/Users/me/project';
+    globalStore.status.workingSidebarTab = 'overview';
+
+    render(<AgentWorkingSidebar />);
+
+    expect(screen.queryByText('Workspace environment')).not.toBeInTheDocument();
+    expect(screen.queryByText('/Users/me/project')).not.toBeInTheDocument();
+    expect(filesProps.current).toBeUndefined();
   });
 });
 

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
@@ -209,6 +209,9 @@ const AgentWorkingSidebar = memo(() => {
   // actions enabled.
   const remoteDeviceId = isDeviceMode ? agencyConfig.boundDeviceId : undefined;
   const isLocalExecution = effectiveTarget === 'local';
+  const filesystemEnvironmentAvailable = isLocalExecution || isDeviceMode;
+  const environmentWorkingDirectory = filesystemEnvironmentAvailable ? workingDirectory : undefined;
+  const environmentRepoType = filesystemEnvironmentAvailable ? repoType : undefined;
   // Files tab is an agent-mode affordance — in plain chat mode the working
   // directory is irrelevant to the user, so hide the tab even when one resolves.
   const filesAvailable = !isChatMode && (isLocalExecution || isDeviceMode) && !!workingDirectory;
@@ -740,8 +743,9 @@ const AgentWorkingSidebar = memo(() => {
             <Overview
               active={Boolean(showRightPanel) && activeTab === 'overview'}
               deviceId={remoteDeviceId}
-              repoType={repoType}
-              workingDirectory={workingDirectory}
+              environmentAvailable={filesystemEnvironmentAvailable}
+              repoType={environmentRepoType}
+              workingDirectory={environmentWorkingDirectory}
               onOpenTab={openTab}
             />
           </Flexbox>

--- a/src/store/device/gitHooks.ts
+++ b/src/store/device/gitHooks.ts
@@ -107,7 +107,7 @@ export const useReviewPatches = (
   deviceId?: string,
   active = true,
 ) => {
-  const enabled = active && Boolean(dirPath);
+  const enabled = active && isEnabled(deviceId, dirPath);
   const key = enabled ? getGitReviewPatchesKey({ baseRef, deviceId, dirPath, mode }) : null;
 
   return useClientDataSWR<ReviewPatchesData>(


### PR DESCRIPTION
## Summary

- hide the Workspace Overview environment section when the effective Web runtime has no local or device filesystem
- prevent Web clients without a target device from requesting local Git review patches
- preserve existing Electron-local and bound-device behavior

## Root cause

The Overview received a persisted working directory independently of the resolved execution target. In addition, `useReviewPatches` gated requests only on an active path, unlike the other Git hooks, so a Web client could attempt an unavailable local Git operation and render an error state.

## Validation

- `bun run check` for the five changed files: lint clean, 32 tests passed
- `bun run check --type`: passed
- `git diff --check`: passed