### PR TITLE
fix(security): don't expose internal error messages in OIDC callback

### DIFF
--- a/src/app/(backend)/oidc/callback/desktop/route.ts
+++ b/src/app/(backend)/oidc/callback/desktop/route.ts
@@ -82,9 +82,9 @@ export const GET = async (req: NextRequest) => {
     const errorUrl = buildRedirectUrl(req, errorPathname);
     errorUrl.searchParams.set('reason', 'internal_error');
 
-    if (error instanceof Error) {
-      errorUrl.searchParams.set('errorMessage', error.message);
-    }
+    // Don't expose internal error messages to users in production
+    // Only log the detailed error server-side for debugging
+    log('Detailed error (not exposed to user): %O', error);
 
     log('Redirecting to error URL: %s', errorUrl.toString());
     return NextResponse.redirect(errorUrl);


### PR DESCRIPTION
## Security Fix

### Problem
In the OIDC desktop callback route, internal error messages are exposed to users via the  URL parameter. This could potentially leak sensitive information like:
- Internal file paths
- Database connection details
- Stack traces
- Other debugging information

### Location
`src/app/(backend)/oidc/callback/desktop/route.ts` (lines 82-87)

### Before
```typescript
if (error instanceof Error) {
  errorUrl.searchParams.set('errorMessage', error.message);
}
```

### After
```typescript
// Don't expose internal error messages to users in production
// Only log the detailed error server-side for debugging
log('Detailed error (not exposed to user): %O', error);
```

### Impact
- **Security**: Prevents potential information leakage
- **Debugging**: Detailed errors are still logged server-side
- **UX**: Users see generic 'internal_error' reason without sensitive details

### Testing
- Error details are logged but not exposed in redirect URL
- OIDC flow continues to work correctly