### PR TITLE
🐛 fix: use OpenAI model discovery for dual runtimes

### DIFF
--- a/packages/model-runtime/src/providers/deepseek/__tests__/index.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/__tests__/index.test.ts
@@ -134,22 +134,34 @@ describe('LobeDeepSeekAI', () => {
     });
 
     it.each([
-      ['the default Anthropic runtime', undefined, undefined],
-      ['an Anthropic baseURL', anthropicBaseURL, undefined],
-      ['an explicit Anthropic sdkType', 'https://aihubmix.com/v1/messages', 'anthropic'],
-    ])('should use static model discovery for %s', async (_, baseURL, sdkType) => {
-      const fetchSpy = vi
-        .spyOn(globalThis, 'fetch')
-        .mockRejectedValue(new Error('Anthropic model discovery should not call the network'));
-      const runtime = createRuntime({ baseURL, sdkType });
+      ['the default Anthropic runtime', undefined, undefined, 'https://api.deepseek.com/v1/models'],
+      ['an Anthropic baseURL', anthropicBaseURL, undefined, 'https://api.deepseek.com/v1/models'],
+      [
+        'an explicit Anthropic sdkType',
+        'https://aihubmix.com/v1/messages',
+        'anthropic',
+        'https://aihubmix.com/v1/models',
+      ],
+    ])(
+      'should use OpenAI-compatible model discovery for %s',
+      async (_, baseURL, sdkType, expectedURL) => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+          new Response(JSON.stringify({ data: [{ id: 'deepseek-chat' }], object: 'list' }), {
+            headers: { 'Content-Type': 'application/json' },
+            status: 200,
+          }),
+        );
+        const runtime = createRuntime({ baseURL, sdkType });
 
-      const models = await runtime.models();
+        const models = await runtime.models();
+        const [request] = fetchSpy.mock.calls[0]!;
+        const requestURL = request instanceof Request ? request.url : String(request);
 
-      expect(models?.map(({ id }) => id)).toEqual(
-        expect.arrayContaining(['deepseek-v4-flash', 'deepseek-v4-pro']),
-      );
-      expect(fetchSpy).not.toHaveBeenCalled();
-    });
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(requestURL).toBe(expectedURL);
+        expect(models?.map(({ id }) => id)).toContain('deepseek-chat');
+      },
+    );
   });
 });
 

--- a/packages/model-runtime/src/providers/deepseek/__tests__/index.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   LobeDeepSeekAI,
@@ -8,6 +8,10 @@ import {
   openAIParams,
 } from '../index';
 import { anthropicBaseURL, defaultOpenAIBaseURL } from './testUtils';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('LobeDeepSeekAI', () => {
   const createRuntime = ({
@@ -127,6 +131,24 @@ describe('LobeDeepSeekAI', () => {
       await expect(resolveRouter(defaultOpenAIBaseURL, 'invalid')).rejects.toThrow(
         'Unsupported DeepSeek sdkType: invalid',
       );
+    });
+
+    it.each([
+      ['the default Anthropic runtime', undefined, undefined],
+      ['an Anthropic baseURL', anthropicBaseURL, undefined],
+      ['an explicit Anthropic sdkType', 'https://aihubmix.com/v1/messages', 'anthropic'],
+    ])('should use static model discovery for %s', async (_, baseURL, sdkType) => {
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockRejectedValue(new Error('Anthropic model discovery should not call the network'));
+      const runtime = createRuntime({ baseURL, sdkType });
+
+      const models = await runtime.models();
+
+      expect(models?.map(({ id }) => id)).toEqual(
+        expect.arrayContaining(['deepseek-v4-flash', 'deepseek-v4-pro']),
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/model-runtime/src/providers/deepseek/__tests__/modelFetch.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/__tests__/modelFetch.test.ts
@@ -7,12 +7,20 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { params } from '../index';
 
 describe('DeepSeek models', () => {
-  const fetchModels = params.models as (params: { client: unknown }) => Promise<ChatModelCard[]>;
+  const fetchModels = params.models as (params: {
+    client: unknown;
+    options?: { baseURL?: string; sdkType?: string };
+  }) => Promise<ChatModelCard[]>;
   const mockClient = {
     models: {
       list: vi.fn(),
     },
   };
+  const fetchOpenAIModels = () =>
+    fetchModels({
+      client: mockClient,
+      options: { baseURL: 'https://api.deepseek.com/v1' },
+    });
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -23,7 +31,7 @@ describe('DeepSeek models', () => {
       data: [{ id: 'deepseek-chat' }, { id: 'deepseek-coder' }, { id: 'deepseek-r1' }],
     });
 
-    const models = await fetchModels({ client: mockClient });
+    const models = await fetchOpenAIModels();
 
     expect(mockClient.models.list).toHaveBeenCalledTimes(1);
     expect(models).toHaveLength(3);
@@ -37,7 +45,7 @@ describe('DeepSeek models', () => {
       data: [{ id: 'deepseek-chat' }],
     });
 
-    const models = await fetchModels({ client: mockClient });
+    const models = await fetchOpenAIModels();
 
     expect(models).toHaveLength(1);
     expect(models[0].id).toBe('deepseek-chat');
@@ -48,7 +56,7 @@ describe('DeepSeek models', () => {
       data: [],
     });
 
-    const models = await fetchModels({ client: mockClient });
+    const models = await fetchOpenAIModels();
 
     expect(models).toEqual([]);
   });
@@ -58,7 +66,7 @@ describe('DeepSeek models', () => {
       data: [{ id: 'deepseek-chat' }],
     });
 
-    const models = await fetchModels({ client: mockClient });
+    const models = await fetchOpenAIModels();
 
     // The processModelList function should merge with known model list
     expect(models[0]).toHaveProperty('id');
@@ -73,7 +81,7 @@ describe('DeepSeek models', () => {
       ],
     });
 
-    const models = await fetchModels({ client: mockClient });
+    const models = await fetchOpenAIModels();
 
     expect(models).toHaveLength(2);
     expect(models[0].id).toBe('deepseek-chat');
@@ -90,7 +98,7 @@ describe('DeepSeek models', () => {
       ],
     });
 
-    const models = await fetchModels({ client: mockClient });
+    const models = await fetchOpenAIModels();
 
     expect(models).toHaveLength(4);
     expect(models.every((m) => typeof m.id === 'string')).toBe(true);

--- a/packages/model-runtime/src/providers/deepseek/__tests__/modelFetch.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/__tests__/modelFetch.test.ts
@@ -4,23 +4,17 @@ import './testUtils';
 import type { ChatModelCard } from '@lobechat/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { params } from '../index';
+import { fetchDeepSeekModels } from '../modelFetch';
 
 describe('DeepSeek models', () => {
-  const fetchModels = params.models as (params: {
+  const fetchModels = fetchDeepSeekModels as (params: {
     client: unknown;
-    options?: { baseURL?: string; sdkType?: string };
   }) => Promise<ChatModelCard[]>;
   const mockClient = {
     models: {
       list: vi.fn(),
     },
   };
-  const fetchOpenAIModels = () =>
-    fetchModels({
-      client: mockClient,
-      options: { baseURL: 'https://api.deepseek.com/v1' },
-    });
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -31,7 +25,7 @@ describe('DeepSeek models', () => {
       data: [{ id: 'deepseek-chat' }, { id: 'deepseek-coder' }, { id: 'deepseek-r1' }],
     });
 
-    const models = await fetchOpenAIModels();
+    const models = await fetchModels({ client: mockClient });
 
     expect(mockClient.models.list).toHaveBeenCalledTimes(1);
     expect(models).toHaveLength(3);
@@ -45,7 +39,7 @@ describe('DeepSeek models', () => {
       data: [{ id: 'deepseek-chat' }],
     });
 
-    const models = await fetchOpenAIModels();
+    const models = await fetchModels({ client: mockClient });
 
     expect(models).toHaveLength(1);
     expect(models[0].id).toBe('deepseek-chat');
@@ -56,7 +50,7 @@ describe('DeepSeek models', () => {
       data: [],
     });
 
-    const models = await fetchOpenAIModels();
+    const models = await fetchModels({ client: mockClient });
 
     expect(models).toEqual([]);
   });
@@ -66,7 +60,7 @@ describe('DeepSeek models', () => {
       data: [{ id: 'deepseek-chat' }],
     });
 
-    const models = await fetchOpenAIModels();
+    const models = await fetchModels({ client: mockClient });
 
     // The processModelList function should merge with known model list
     expect(models[0]).toHaveProperty('id');
@@ -81,7 +75,7 @@ describe('DeepSeek models', () => {
       ],
     });
 
-    const models = await fetchOpenAIModels();
+    const models = await fetchModels({ client: mockClient });
 
     expect(models).toHaveLength(2);
     expect(models[0].id).toBe('deepseek-chat');
@@ -98,7 +92,7 @@ describe('DeepSeek models', () => {
       ],
     });
 
-    const models = await fetchOpenAIModels();
+    const models = await fetchModels({ client: mockClient });
 
     expect(models).toHaveLength(4);
     expect(models.every((m) => typeof m.id === 'string')).toBe(true);

--- a/packages/model-runtime/src/providers/deepseek/index.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.ts
@@ -18,12 +18,21 @@ import { fetchDeepSeekModels } from './modelFetch';
 const DEFAULT_DEEPSEEK_BASE_URL = 'https://api.deepseek.com/v1';
 const DEFAULT_DEEPSEEK_ANTHROPIC_BASE_URL = 'https://api.deepseek.com/anthropic';
 const DEEPSEEK_ANTHROPIC_BASE_URL_PATTERN = /\/anthropic\/?$/;
+const DEEPSEEK_ANTHROPIC_MODEL_BASE_URL_PATTERN = /\/anthropic(?:\/v1\/messages)?\/?$/;
 const DEEPSEEK_ANTHROPIC_MESSAGES_PATH_PATTERN = /\/v1\/messages\/?$/;
 
 type DeepSeekSDKType = 'anthropic' | 'openai';
 
 const normalizeDeepSeekAnthropicBaseURL = (baseURL?: string | null) =>
   baseURL?.replace(DEEPSEEK_ANTHROPIC_MESSAGES_PATH_PATTERN, '');
+
+const normalizeDeepSeekOpenAIModelBaseURL = (baseURL?: string | null) => {
+  if (!baseURL) return DEFAULT_DEEPSEEK_BASE_URL;
+
+  return baseURL
+    .replace(DEEPSEEK_ANTHROPIC_MODEL_BASE_URL_PATTERN, '/v1')
+    .replace(DEEPSEEK_ANTHROPIC_MESSAGES_PATH_PATTERN, '/v1');
+};
 
 /**
  * `sdkType` explicitly selects the DeepSeek SDK wrapper for router-runtime channels.
@@ -75,6 +84,17 @@ export const openAIParams = {
 
 export const LobeDeepSeekOpenAI = createOpenAICompatibleRuntime(openAIParams);
 
+type DeepSeekOpenAIRuntimeOptions = ConstructorParameters<typeof LobeDeepSeekOpenAI>[0];
+
+const fetchDeepSeekModelsWithOpenAI = ({ options }: { options?: DeepSeekOpenAIRuntimeOptions }) => {
+  const runtime = new LobeDeepSeekOpenAI({
+    ...options,
+    baseURL: normalizeDeepSeekOpenAIModelBaseURL(options?.baseURL),
+  });
+
+  return runtime.models();
+};
+
 const createOpenAIRouter = (baseURLPattern?: RegExp) => ({
   apiType: 'deepseek' as const,
   ...(baseURLPattern ? { baseURLPattern } : {}),
@@ -102,7 +122,7 @@ const createAnthropicRouter = ({
 
 export const params: CreateRouterRuntimeOptions = {
   id: ModelProvider.DeepSeek,
-  models: fetchDeepSeekModels,
+  models: fetchDeepSeekModelsWithOpenAI,
   routers: (options) => {
     const sdkType = resolveDeepSeekSDKType(options.sdkType);
 

--- a/packages/model-runtime/src/providers/deepseek/modelFetch.ts
+++ b/packages/model-runtime/src/providers/deepseek/modelFetch.ts
@@ -7,11 +7,36 @@ interface DeepSeekModelCard {
   id: string;
 }
 
+interface DeepSeekModelFetchOptions {
+  baseURL?: string;
+  sdkType?: string;
+}
+
+const DEEPSEEK_ANTHROPIC_BASE_URL_PATTERN = /\/anthropic(?:\/v1\/messages)?\/?$/;
+
+const shouldLoadStaticDeepSeekModels = ({ baseURL, sdkType }: DeepSeekModelFetchOptions = {}) => {
+  if (sdkType) return sdkType === 'anthropic';
+
+  return !baseURL || DEEPSEEK_ANTHROPIC_BASE_URL_PATTERN.test(baseURL);
+};
+
+const loadStaticDeepSeekModels = async () => {
+  const { deepseek } = await import('model-bank');
+
+  return processModelList(deepseek, MODEL_LIST_CONFIGS.deepseek, 'deepseek');
+};
+
 export const fetchDeepSeekModels = async ({
   client,
+  options,
 }: {
   client: OpenAI | unknown;
+  options?: DeepSeekModelFetchOptions;
 }): Promise<ChatModelCard[]> => {
+  if (shouldLoadStaticDeepSeekModels(options)) {
+    return loadStaticDeepSeekModels();
+  }
+
   const modelClient = client as {
     models?: { list?: () => Promise<{ data?: DeepSeekModelCard[] }> };
   };
@@ -23,7 +48,5 @@ export const fetchDeepSeekModels = async ({
     return processModelList(modelList, MODEL_LIST_CONFIGS.deepseek, 'deepseek');
   }
 
-  const { deepseek } = await import('model-bank');
-
-  return processModelList(deepseek, MODEL_LIST_CONFIGS.deepseek, 'deepseek');
+  return loadStaticDeepSeekModels();
 };

--- a/packages/model-runtime/src/providers/deepseek/modelFetch.ts
+++ b/packages/model-runtime/src/providers/deepseek/modelFetch.ts
@@ -7,19 +7,6 @@ interface DeepSeekModelCard {
   id: string;
 }
 
-interface DeepSeekModelFetchOptions {
-  baseURL?: string;
-  sdkType?: string;
-}
-
-const DEEPSEEK_ANTHROPIC_BASE_URL_PATTERN = /\/anthropic(?:\/v1\/messages)?\/?$/;
-
-const shouldLoadStaticDeepSeekModels = ({ baseURL, sdkType }: DeepSeekModelFetchOptions = {}) => {
-  if (sdkType) return sdkType === 'anthropic';
-
-  return !baseURL || DEEPSEEK_ANTHROPIC_BASE_URL_PATTERN.test(baseURL);
-};
-
 const loadStaticDeepSeekModels = async () => {
   const { deepseek } = await import('model-bank');
 
@@ -28,15 +15,9 @@ const loadStaticDeepSeekModels = async () => {
 
 export const fetchDeepSeekModels = async ({
   client,
-  options,
 }: {
   client: OpenAI | unknown;
-  options?: DeepSeekModelFetchOptions;
 }): Promise<ChatModelCard[]> => {
-  if (shouldLoadStaticDeepSeekModels(options)) {
-    return loadStaticDeepSeekModels();
-  }
-
   const modelClient = client as {
     models?: { list?: () => Promise<{ data?: DeepSeekModelCard[] }> };
   };

--- a/packages/model-runtime/src/providers/minimax/index.test.ts
+++ b/packages/model-runtime/src/providers/minimax/index.test.ts
@@ -141,6 +141,38 @@ describe('LobeMinimaxAI', () => {
       );
     });
 
+    it.each([
+      ['the default runtime', undefined, undefined, 'https://api.minimaxi.com/v1/models'],
+      ['an Anthropic baseURL', anthropicBaseURL, undefined, 'https://api.minimaxi.com/v1/models'],
+      [
+        'an explicit Anthropic sdkType',
+        'https://minimax-proxy.example.com/v1/messages',
+        'anthropic',
+        'https://minimax-proxy.example.com/v1/models',
+      ],
+    ])(
+      'should use OpenAI-compatible model discovery for %s',
+      async (_, baseURL, sdkType, expectedURL) => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+          new Response(JSON.stringify({ data: [{ id: 'MiniMax-M3' }], object: 'list' }), {
+            headers: { 'Content-Type': 'application/json' },
+            status: 200,
+          }),
+        );
+
+        try {
+          await createRuntime({ baseURL, sdkType }).models();
+          const [request] = fetchSpy.mock.calls[0]!;
+          const requestURL = request instanceof Request ? request.url : String(request);
+
+          expect(fetchSpy).toHaveBeenCalledTimes(1);
+          expect(requestURL).toBe(expectedURL);
+        } finally {
+          fetchSpy.mockRestore();
+        }
+      },
+    );
+
     it('should pass modelIdMapping to the OpenAI-compatible runtime', async () => {
       const modelIdMapping = { 'minimax-public': 'MiniMax-M3' };
       const chatSpy = vi

--- a/packages/model-runtime/src/providers/minimax/index.ts
+++ b/packages/model-runtime/src/providers/minimax/index.ts
@@ -20,6 +20,7 @@ import { createMiniMaxVideo } from './createVideo';
 const DEFAULT_MINIMAX_BASE_URL = 'https://api.minimaxi.com/v1';
 const DEFAULT_MINIMAX_ANTHROPIC_BASE_URL = 'https://api.minimax.io/anthropic';
 const MINIMAX_ANTHROPIC_BASE_URL_PATTERN = /\/anthropic\/?$/;
+const MINIMAX_ANTHROPIC_MODEL_BASE_URL_PATTERN = /\/anthropic(?:\/v1\/messages)?\/?$/;
 const MINIMAX_ANTHROPIC_MESSAGES_PATH_PATTERN = /\/v1\/messages\/?$/;
 
 const isMiniMaxM3Model = (model: string) => model.toLowerCase() === 'minimax-m3';
@@ -56,6 +57,20 @@ const normalizeMiniMaxImageDetail = (content: OpenAIChatMessage['content']) => {
 
 const normalizeMiniMaxAnthropicBaseURL = (baseURL?: string | null) =>
   baseURL?.replace(MINIMAX_ANTHROPIC_MESSAGES_PATH_PATTERN, '');
+
+const normalizeMiniMaxOpenAIModelBaseURL = (baseURL?: string | null) => {
+  if (
+    !baseURL ||
+    normalizeMiniMaxAnthropicBaseURL(baseURL)?.replace(/\/$/, '') ===
+      DEFAULT_MINIMAX_ANTHROPIC_BASE_URL
+  ) {
+    return DEFAULT_MINIMAX_BASE_URL;
+  }
+
+  return baseURL
+    .replace(MINIMAX_ANTHROPIC_MODEL_BASE_URL_PATTERN, '/v1')
+    .replace(MINIMAX_ANTHROPIC_MESSAGES_PATH_PATTERN, '/v1');
+};
 
 const resolveMiniMaxSDKType = (sdkType: unknown): MiniMaxSDKType | undefined => {
   if (sdkType === undefined || sdkType === null || sdkType === '') return undefined;
@@ -339,6 +354,17 @@ export const openAIParams = {
 
 export const LobeMinimaxOpenAI = createOpenAICompatibleRuntime(openAIParams);
 
+type MiniMaxOpenAIRuntimeOptions = ConstructorParameters<typeof LobeMinimaxOpenAI>[0];
+
+const fetchMiniMaxModelsWithOpenAI = ({ options }: { options?: MiniMaxOpenAIRuntimeOptions }) => {
+  const runtime = new LobeMinimaxOpenAI({
+    ...options,
+    baseURL: normalizeMiniMaxOpenAIModelBaseURL(options?.baseURL),
+  });
+
+  return runtime.models();
+};
+
 export const anthropicParams = createAnthropicCompatibleParams({
   baseURL: DEFAULT_MINIMAX_ANTHROPIC_BASE_URL,
   chatCompletion: {
@@ -379,6 +405,7 @@ const createOpenAIRouter = () => ({
 
 export const params: CreateRouterRuntimeOptions = {
   id: ModelProvider.Minimax,
+  models: fetchMiniMaxModelsWithOpenAI,
   routers: (options) => {
     const sdkType = resolveMiniMaxSDKType(options.sdkType);
 

--- a/packages/model-runtime/src/providers/moonshot/index.test.ts
+++ b/packages/model-runtime/src/providers/moonshot/index.test.ts
@@ -5,10 +5,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   anthropicParams,
+  fetchMoonshotModels,
   LobeMoonshotAI,
   LobeMoonshotAnthropicAI,
   LobeMoonshotOpenAI,
-  params,
 } from './index';
 
 const { loadModelsMock } = vi.hoisted(() => ({
@@ -133,6 +133,38 @@ describe('LobeMoonshotAI', () => {
         'Unsupported Moonshot sdkType: invalid',
       );
     });
+
+    it.each([
+      ['the default runtime', undefined, undefined, 'https://api.moonshot.cn/v1/models'],
+      ['an Anthropic baseURL', anthropicBaseURL, undefined, 'https://api.moonshot.cn/v1/models'],
+      [
+        'an explicit Anthropic sdkType',
+        'https://aihubmix.com/v1/messages',
+        'anthropic',
+        'https://aihubmix.com/v1/models',
+      ],
+    ])(
+      'should use OpenAI-compatible model discovery for %s',
+      async (_, baseURL, sdkType, expectedURL) => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+          new Response(JSON.stringify({ data: [{ id: 'kimi-k2.5' }], object: 'list' }), {
+            headers: { 'Content-Type': 'application/json' },
+            status: 200,
+          }),
+        );
+
+        try {
+          await createRuntime({ baseURL, sdkType }).models();
+          const [request] = fetchSpy.mock.calls[0]!;
+          const requestURL = request instanceof Request ? request.url : String(request);
+
+          expect(fetchSpy).toHaveBeenCalledTimes(1);
+          expect(requestURL).toBe(expectedURL);
+        } finally {
+          fetchSpy.mockRestore();
+        }
+      },
+    );
   });
 
   describe('Debug Configuration', () => {
@@ -1078,7 +1110,7 @@ describe('LobeMoonshotAnthropicAI', () => {
 });
 
 describe('models', () => {
-  const fetchModels = params.models as (params: { client: OpenAI }) => Promise<any[]>;
+  const fetchModels = fetchMoonshotModels;
 
   it('should use OpenAI client to fetch models', async () => {
     const mockClient = {

--- a/packages/model-runtime/src/providers/moonshot/index.ts
+++ b/packages/model-runtime/src/providers/moonshot/index.ts
@@ -30,6 +30,7 @@ export interface MoonshotModelCard {
 const DEFAULT_MOONSHOT_BASE_URL = 'https://api.moonshot.cn/v1';
 const DEFAULT_MOONSHOT_ANTHROPIC_BASE_URL = 'https://api.moonshot.cn/anthropic';
 const MOONSHOT_ANTHROPIC_BASE_URL_PATTERN = /\/anthropic\/?$/;
+const MOONSHOT_ANTHROPIC_MODEL_BASE_URL_PATTERN = /\/anthropic(?:\/v1\/messages)?\/?$/;
 const MOONSHOT_ANTHROPIC_MESSAGES_PATH_PATTERN = /\/v1\/messages\/?$/;
 
 type MoonshotSDKType = 'anthropic' | 'openai';
@@ -43,6 +44,14 @@ const hasValidReasoning = (reasoning: any) => reasoning?.content && !reasoning?.
 
 const normalizeMoonshotAnthropicBaseURL = (baseURL?: string | null) =>
   baseURL?.replace(MOONSHOT_ANTHROPIC_MESSAGES_PATH_PATTERN, '');
+
+const normalizeMoonshotOpenAIModelBaseURL = (baseURL?: string | null) => {
+  if (!baseURL) return DEFAULT_MOONSHOT_BASE_URL;
+
+  return baseURL
+    .replace(MOONSHOT_ANTHROPIC_MODEL_BASE_URL_PATTERN, '/v1')
+    .replace(MOONSHOT_ANTHROPIC_MESSAGES_PATH_PATTERN, '/v1');
+};
 
 /**
  * `sdkType` explicitly selects the Moonshot SDK wrapper for router-runtime channels.
@@ -271,7 +280,11 @@ const buildMoonshotOpenAIPayload = (
 /**
  * Fetch Moonshot models from the API using OpenAI client
  */
-const fetchMoonshotModels = async ({ client }: { client: OpenAI }): Promise<ChatModelCard[]> => {
+export const fetchMoonshotModels = async ({
+  client,
+}: {
+  client: OpenAI;
+}): Promise<ChatModelCard[]> => {
   const modelsPage = (await client.models.list()) as any;
   const modelList: MoonshotModelCard[] = modelsPage.data || [];
 
@@ -315,9 +328,21 @@ export const LobeMoonshotOpenAI = createOpenAICompatibleRuntime({
   },
   // Kimi models support prompt_cache_key for multi-turn session cache optimization.
   // Docs: https://platform.kimi.com/docs/api/chat#body-one-of-0-prompt-cache-key
+  models: fetchMoonshotModels,
   promptCacheKeyModels: [/^kimi-/],
   provider: ModelProvider.Moonshot,
 });
+
+type MoonshotOpenAIRuntimeOptions = ConstructorParameters<typeof LobeMoonshotOpenAI>[0];
+
+const fetchMoonshotModelsWithOpenAI = ({ options }: { options?: MoonshotOpenAIRuntimeOptions }) => {
+  const runtime = new LobeMoonshotOpenAI({
+    ...options,
+    baseURL: normalizeMoonshotOpenAIModelBaseURL(options?.baseURL),
+  });
+
+  return runtime.models();
+};
 
 /**
  * RouterRuntime configuration for Moonshot
@@ -348,7 +373,7 @@ const createOpenAIRouter = () => ({
 
 export const params: CreateRouterRuntimeOptions = {
   id: ModelProvider.Moonshot,
-  models: fetchMoonshotModels,
+  models: fetchMoonshotModelsWithOpenAI,
   routers: (options) => {
     const sdkType = resolveMoonshotSDKType(options.sdkType);
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Decouples model discovery from the protocol selected for chat requests in the DeepSeek, Moonshot/Kimi, and MiniMax RouterRuntime providers.
- Always fetches each provider's model list through its OpenAI-compatible runtime.
- Normalizes Anthropic-style base URLs such as `/anthropic` and `/v1/messages` to the corresponding OpenAI `/v1/models` endpoint.
- Handles MiniMax's different official domains by mapping `api.minimax.io/anthropic` to `api.minimaxi.com/v1`.
- Leaves Anthropic/OpenAI chat routing and payload behavior unchanged.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check   packages/model-runtime/src/providers/deepseek/modelFetch.ts   packages/model-runtime/src/providers/deepseek/__tests__/index.test.ts   packages/model-runtime/src/providers/deepseek/__tests__/modelFetch.test.ts   packages/model-runtime/src/providers/moonshot/index.ts   packages/model-runtime/src/providers/moonshot/index.test.ts   packages/model-runtime/src/providers/minimax/index.ts   packages/model-runtime/src/providers/minimax/index.test.ts   --lint --test --type
```

Results:
- DeepSeek: 24 related tests passed.
- Moonshot/Kimi and MiniMax: 110 related tests passed.
- Lint and types clean.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Regression coverage verifies default, Anthropic-baseURL, and explicit Anthropic-sdkType configurations discover models through OpenAI-compatible `/v1/models` requests. Kimi Coding Plan is unaffected because it intentionally uses its bundled model list.
