### PR TITLE
🐛 fix(onboarding): pass language to understanding workflow

### DIFF
--- a/apps/server/src/routers/lambda/user.ts
+++ b/apps/server/src/routers/lambda/user.ts
@@ -132,12 +132,24 @@ const startOnboardingUnderstandingInputSchema = z
       )
       .max(16)
       .optional(),
+    responseLanguage: z
+      .string()
+      .trim()
+      .min(2)
+      .max(64)
+      .regex(/^[A-Z]{2,3}(?:-[A-Z0-9]{2,8})*$/i),
     topicId: understandingIdSchema,
   })
   .strict() satisfies z.ZodType<StartOnboardingUnderstandingInput>;
 const retryOnboardingUnderstandingSourceInputSchema = z
   .object({
     providerId: understandingIdSchema,
+    responseLanguage: z
+      .string()
+      .trim()
+      .min(2)
+      .max(64)
+      .regex(/^[A-Z]{2,3}(?:-[A-Z0-9]{2,8})*$/i),
     sessionId: understandingIdSchema,
     topicId: understandingIdSchema,
   })
@@ -163,6 +175,12 @@ const reviseOnboardingUnderstandingInputSchema = z
           .regex(/^[\w-]+$/),
       )
       .max(16),
+    responseLanguage: z
+      .string()
+      .trim()
+      .min(2)
+      .max(64)
+      .regex(/^[A-Z]{2,3}(?:-[A-Z0-9]{2,8})*$/i),
     sessionId: understandingIdSchema,
     topicId: understandingIdSchema,
   })
@@ -371,8 +389,8 @@ export const userRouter = router({
     .input(startOnboardingUnderstandingInputSchema)
     .mutation(async ({ ctx, input }): Promise<OnboardingUnderstandingPollingResult> => {
       return input.providerIds
-        ? ctx.understandingService.start(input.topicId, input.providerIds)
-        : ctx.understandingService.start(input.topicId);
+        ? ctx.understandingService.start(input.topicId, input.responseLanguage, input.providerIds)
+        : ctx.understandingService.start(input.topicId, input.responseLanguage);
     }),
 
   updateAvatar: userProcedure.input(z.string()).mutation(async ({ ctx, input }) => {

--- a/apps/server/src/services/understanding/service.test.ts
+++ b/apps/server/src/services/understanding/service.test.ts
@@ -303,6 +303,7 @@ describe('UnderstandingService', () => {
         expectedFeedbackRevision: 0,
         feedback: 'Focus on infrastructure.',
         providerIds: ['github', 'gmail'],
+        responseLanguage: 'zh-CN',
         sessionId: 'session-1',
         topicId: 'topic-1',
       }),
@@ -324,6 +325,7 @@ describe('UnderstandingService', () => {
     expect(mockTriggerProviders).toHaveBeenCalledWith(
       {
         providers: [{ id: 'gmail', revision: 1 }],
+        responseLanguage: 'zh-CN',
         sessionId: 'session-1',
         topicId: 'topic-1',
         userId: 'user-1',
@@ -334,6 +336,7 @@ describe('UnderstandingService', () => {
     );
     expect(mockTriggerWriting).toHaveBeenCalledWith(
       {
+        responseLanguage: 'zh-CN',
         sessionId: 'session-1',
         sourceFingerprint: 'github@1',
         topicId: 'topic-1',
@@ -359,6 +362,7 @@ describe('UnderstandingService', () => {
       expectedFeedbackRevision: 0,
       feedback: 'Focus on infrastructure.',
       providerIds: [],
+      responseLanguage: 'zh-CN',
       sessionId: 'session-1',
       topicId: 'topic-1',
     });
@@ -386,7 +390,7 @@ describe('UnderstandingService', () => {
   it('starts static providers with deterministic pending revisions', async () => {
     const harness = createHarness();
 
-    await expect(harness.service.start('topic-1')).resolves.toMatchObject({
+    await expect(harness.service.start('topic-1', 'zh-CN')).resolves.toMatchObject({
       id: 'session-new',
       status: 'processing',
     });
@@ -396,6 +400,7 @@ describe('UnderstandingService', () => {
           { id: 'github', revision: 1 },
           { id: 'gmail', revision: 1 },
         ],
+        responseLanguage: 'zh-CN',
         sessionId: 'session-new',
         topicId: 'topic-1',
         userId: 'user-1',
@@ -411,7 +416,7 @@ describe('UnderstandingService', () => {
   it('starts only the connected providers selected by the onboarding UI', async () => {
     const harness = createHarness();
 
-    await expect(harness.service.start('topic-1', ['github'])).resolves.toMatchObject({
+    await expect(harness.service.start('topic-1', 'zh-CN', ['github'])).resolves.toMatchObject({
       sources: { github: { status: 'pending' } },
     });
     expect(harness.repository.initialize).toHaveBeenCalledWith('topic-1', 'session-new', [
@@ -503,6 +508,7 @@ describe('UnderstandingService', () => {
     await expect(
       harness.service.processCollected({
         expectedSourceFingerprint: fingerprint,
+        responseLanguage: 'zh-CN',
         sessionId: 'session-1',
         topicId: 'topic-1',
       }),
@@ -517,6 +523,7 @@ describe('UnderstandingService', () => {
       { metadata: { trigger: RequestTrigger.Onboarding } },
     );
     const writerInput = harness.generateObject.mock.calls[0][0];
+    expect(writerInput.messages[0].content).toContain('every user-visible string value in zh-CN');
     expect(writerInput.messages[1].content).toContain('# GitHub\n\nGITHUB_MARKDOWN');
     expect(writerInput.messages[1].content).toContain(
       '```xml\n<gmailMessages>GMAIL_XML</gmailMessages>\n```',
@@ -567,6 +574,7 @@ describe('UnderstandingService', () => {
 
     await harness.service.processCollected({
       expectedSourceFingerprint: 'github@1',
+      responseLanguage: 'zh-CN',
       sessionId: 'session-1',
       topicId: 'topic-1',
     });
@@ -637,6 +645,7 @@ describe('UnderstandingService', () => {
       await expect(
         harness.service.processCollected({
           expectedSourceFingerprint: expected,
+          responseLanguage: 'zh-CN',
           sessionId: 'session-1',
           topicId: 'topic-1',
         }),
@@ -668,6 +677,7 @@ describe('UnderstandingService', () => {
     await expect(
       harness.service.processCollected({
         expectedSourceFingerprint: fingerprint,
+        responseLanguage: 'zh-CN',
         sessionId: 'session-1',
         topicId: 'topic-1',
       }),

--- a/apps/server/src/services/understanding/service.ts
+++ b/apps/server/src/services/understanding/service.ts
@@ -65,6 +65,7 @@ interface ProviderOperationInput {
 
 interface ProcessCollectedInput {
   expectedSourceFingerprint: string;
+  responseLanguage: string;
   sessionId: string;
   topicId: string;
 }
@@ -235,6 +236,7 @@ export class UnderstandingService {
 
   start = async (
     topicId: string,
+    responseLanguage: string,
     selectedProviderIds?: string[],
   ): Promise<OnboardingUnderstandingPollingResult> => {
     const { OnboardingUnderstandingWorkflow } =
@@ -249,6 +251,7 @@ export class UnderstandingService {
       await OnboardingUnderstandingWorkflow.triggerProviders(
         {
           providers,
+          responseLanguage,
           sessionId: session.id,
           topicId,
           userId: this.dependencies.userId,
@@ -327,6 +330,7 @@ export class UnderstandingService {
       await OnboardingUnderstandingWorkflow.triggerProviders(
         {
           providers: providerAttempts,
+          responseLanguage: input.responseLanguage,
           sessionId: input.sessionId,
           topicId: input.topicId,
           userId: this.dependencies.userId,
@@ -342,6 +346,7 @@ export class UnderstandingService {
       await OnboardingUnderstandingWorkflow.triggerWriting(
         {
           sessionId: input.sessionId,
+          responseLanguage: input.responseLanguage,
           sourceFingerprint,
           topicId: input.topicId,
           userId: this.dependencies.userId,
@@ -406,6 +411,7 @@ export class UnderstandingService {
       await OnboardingUnderstandingWorkflow.triggerProviders(
         {
           providers: [{ id: input.providerId, revision }],
+          responseLanguage: input.responseLanguage,
           sessionId: input.sessionId,
           topicId: input.topicId,
           userId: this.dependencies.userId,
@@ -576,6 +582,7 @@ export class UnderstandingService {
 
   processCollected = async ({
     expectedSourceFingerprint,
+    responseLanguage,
     sessionId,
     topicId,
   }: ProcessCollectedInput) => {
@@ -645,6 +652,7 @@ export class UnderstandingService {
       diagnostics,
       feedback: feedback.turns,
       providers,
+      responseLanguage,
       threadId,
       topicId,
       writerAgent,
@@ -772,6 +780,7 @@ export class UnderstandingService {
     diagnostics,
     feedback,
     providers,
+    responseLanguage,
     threadId,
     topicId,
     writerAgent,
@@ -780,6 +789,7 @@ export class UnderstandingService {
     diagnostics: CollectionDiagnostics;
     feedback: UnderstandingFeedbackTurn[];
     providers: string[];
+    responseLanguage: string;
     threadId: string;
     topicId: string;
     writerAgent: { id: string; model: string; provider: string };
@@ -800,7 +810,12 @@ export class UnderstandingService {
         {
           messages: [
             {
-              content: chainUnderstandingPersona({ diagnostics, feedback, providers }),
+              content: chainUnderstandingPersona({
+                diagnostics,
+                feedback,
+                providers,
+                responseLanguage,
+              }),
               role: 'system',
             },
             {

--- a/apps/server/src/workflows/onboardingUnderstanding/index.test.ts
+++ b/apps/server/src/workflows/onboardingUnderstanding/index.test.ts
@@ -33,6 +33,7 @@ describe('OnboardingUnderstandingWorkflow', () => {
     const { OnboardingUnderstandingWorkflow } = await import('.');
     const payload = {
       providers: [{ id: 'github', revision: 1 }],
+      responseLanguage: 'zh-CN',
       sessionId: 'session:1',
       topicId: 'topic-1',
       userId: 'user-1',
@@ -56,6 +57,7 @@ describe('OnboardingUnderstandingWorkflow', () => {
           { id: 'gmail', revision: 1 },
           { id: 'github', revision: 1 },
         ],
+        responseLanguage: 'zh-CN',
         sessionId: 'session-1',
         topicId: 'topic-1',
         userId: 'user-1',
@@ -75,6 +77,7 @@ describe('OnboardingUnderstandingWorkflow', () => {
   it('triggers a direct rewrite for feedback-only revisions', async () => {
     const { OnboardingUnderstandingWorkflow } = await import('.');
     const payload = {
+      responseLanguage: 'zh-CN',
       sessionId: 'session-1',
       sourceFingerprint: 'github@1',
       topicId: 'topic-1',
@@ -104,6 +107,7 @@ describe('OnboardingUnderstandingWorkflow', () => {
     await expect(
       OnboardingUnderstandingWorkflow.triggerProviders({
         providers: [{ id: 'github', revision: 1 }],
+        responseLanguage: 'zh-CN',
         sessionId: 'session-1',
         topicId: 'topic-1',
         userId: 'user-1',

--- a/apps/server/src/workflows/onboardingUnderstanding/processCollected.test.ts
+++ b/apps/server/src/workflows/onboardingUnderstanding/processCollected.test.ts
@@ -20,6 +20,7 @@ vi.mock('@/server/services/understanding/service', () => ({
 }));
 
 const payload = {
+  responseLanguage: 'zh-CN',
   sessionId: 'session-1',
   sourceFingerprint: 'github@1',
   topicId: 'topic-1',
@@ -60,6 +61,7 @@ describe('processCollectedUnderstanding', () => {
     expect(steps).toEqual(['collected:process']);
     expect(service.processCollected).toHaveBeenCalledWith({
       expectedSourceFingerprint: 'github@1',
+      responseLanguage: 'zh-CN',
       sessionId: 'session-1',
       topicId: 'topic-1',
     });

--- a/apps/server/src/workflows/onboardingUnderstanding/processCollected.ts
+++ b/apps/server/src/workflows/onboardingUnderstanding/processCollected.ts
@@ -47,6 +47,7 @@ export const processCollectedUnderstanding = async (
     try {
       return await service.processCollected({
         expectedSourceFingerprint: payload.sourceFingerprint,
+        responseLanguage: payload.responseLanguage,
         sessionId: payload.sessionId,
         topicId: payload.topicId,
       });

--- a/apps/server/src/workflows/onboardingUnderstanding/processProviders.test.ts
+++ b/apps/server/src/workflows/onboardingUnderstanding/processProviders.test.ts
@@ -26,6 +26,7 @@ const payload = {
     { id: 'gmail', revision: 1 },
     { id: 'github', revision: 1 },
   ],
+  responseLanguage: 'zh-CN',
   sessionId: 'session-1',
   topicId: 'topic-1',
   userId: 'user-1',
@@ -80,6 +81,7 @@ describe('processUnderstandingProviders', () => {
 
     await vi.waitFor(() => expect(invocations).toHaveLength(1));
     expect(invocations[0].settings.body).toEqual({
+      responseLanguage: 'zh-CN',
       sessionId: 'session-1',
       sourceFingerprint: 'github@1',
       topicId: 'topic-1',

--- a/apps/server/src/workflows/onboardingUnderstanding/processProviders.ts
+++ b/apps/server/src/workflows/onboardingUnderstanding/processProviders.ts
@@ -76,6 +76,7 @@ export const processUnderstandingProviders = async (
       if (result.status === 'completed' && result.revision === revision) {
         await context.invoke(`provider:${providerId}:write:${result.revision}`, {
           body: {
+            responseLanguage: payload.responseLanguage,
             sessionId: payload.sessionId,
             sourceFingerprint: result.sourceFingerprint,
             topicId: payload.topicId,

--- a/apps/server/src/workflows/onboardingUnderstanding/types.ts
+++ b/apps/server/src/workflows/onboardingUnderstanding/types.ts
@@ -6,20 +6,26 @@ const providerIdSchema = z
   .min(1)
   .max(128)
   .regex(/^[\w-]+$/);
-
+/** Payload for collecting all selected Understanding providers. */
 export interface ProcessUnderstandingProvidersPayload {
   providers: UnderstandingProviderAttempt[];
+  /** Language required for the eventual user-visible proposal. */
+  responseLanguage: string;
   sessionId: string;
   topicId: string;
   userId: string;
 }
 
+/** One provider collection attempt in an Understanding workflow. */
 export interface UnderstandingProviderAttempt {
   id: string;
   revision: number;
 }
 
+/** Payload for generating an Understanding proposal from collected sources. */
 export interface ProcessCollectedUnderstandingPayload {
+  /** Language required for every user-visible proposal field. */
+  responseLanguage: string;
   sessionId: string;
   sourceFingerprint: string;
   topicId: string;
@@ -40,6 +46,12 @@ export const ProcessUnderstandingProvidersPayloadSchema = z
         (providers) => new Set(providers.map(({ id }) => id)).size === providers.length,
         'Provider attempts must be unique',
       ),
+    responseLanguage: z
+      .string()
+      .trim()
+      .min(2)
+      .max(64)
+      .regex(/^[A-Z]{2,3}(?:-[A-Z0-9]{2,8})*$/i),
     sessionId: identifierSchema,
     topicId: identifierSchema,
     userId: identifierSchema,
@@ -48,6 +60,12 @@ export const ProcessUnderstandingProvidersPayloadSchema = z
 
 export const ProcessCollectedUnderstandingPayloadSchema = z
   .object({
+    responseLanguage: z
+      .string()
+      .trim()
+      .min(2)
+      .max(64)
+      .regex(/^[A-Z]{2,3}(?:-[A-Z0-9]{2,8})*$/i),
     sessionId: identifierSchema,
     sourceFingerprint: z
       .string()

--- a/packages/prompts/src/chains/understanding.ts
+++ b/packages/prompts/src/chains/understanding.ts
@@ -15,6 +15,7 @@ interface UnderstandingPersonaPromptInput {
   diagnostics: SafeCollectionDiagnostics;
   feedback?: UnderstandingFeedbackTurn[];
   providers: string[];
+  responseLanguage: string;
 }
 
 interface UnderstandingAnalysisJsonSchema {
@@ -205,6 +206,7 @@ export const chainUnderstandingPersona = ({
   diagnostics,
   feedback = [],
   providers,
+  responseLanguage,
 }: UnderstandingPersonaPromptInput): string => {
   const feedbackSection =
     feedback.length > 0
@@ -222,6 +224,7 @@ export const chainUnderstandingPersona = ({
 
   return [
     'Write one coherent onboarding persona from all available provider-delimited Markdown and XML contexts.',
+    `Write every user-visible string value in ${boundUntrustedMetadata(responseLanguage, 64)}. Keep JSON property names unchanged and preserve proper names when translation would make them inaccurate.`,
     'Analyze the original provider contexts directly, not prior generated analyses.',
     'Providers represented in the input (untrusted JSON):',
     JSON.stringify(

--- a/packages/types/src/understanding.ts
+++ b/packages/types/src/understanding.ts
@@ -216,6 +216,8 @@ export interface OnboardingUnderstandingTopicInput {
 export interface StartOnboardingUnderstandingInput extends OnboardingUnderstandingTopicInput {
   /** Initial additive providers; omitted callers retain the legacy all-provider behavior. */
   providerIds?: string[];
+  /** Language selected for user-visible Understanding output. */
+  responseLanguage: string;
 }
 
 /**
@@ -228,12 +230,16 @@ export interface ReviseOnboardingUnderstandingInput extends OnboardingUnderstand
   feedback?: string;
   /** Additive provider identifiers; existing sources are never removed. */
   providerIds: string[];
+  /** Language selected for user-visible Understanding output. */
+  responseLanguage: string;
   /** Active Understanding session identifier used for stale-client protection. */
   sessionId: string;
 }
 
 export interface RetryOnboardingUnderstandingProviderInput extends OnboardingUnderstandingTopicInput {
   providerId: string;
+  /** Language selected for user-visible Understanding output. */
+  responseLanguage: string;
   sessionId: string;
 }
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

- Related cloud PR: https://github.com/lobehub-biz/lobehub-cloud/pull/1150
- GitHub issue: N/A

#### 🔀 Description of Change

Pass the user's selected response language through the onboarding Understanding API and both QStash workflow payloads. The writer prompt now requires all user-visible proposal values to use that language while preserving JSON property names and proper names.

The same language is forwarded for initial generation, provider retries, and feedback revisions.

#### 🧭 Key Decisions / Non-goals

- This branch is rebuilt directly on the latest `canary` so the PR contains only the response-language fix.
- Language identifiers are validated at API and workflow boundaries.
- No database migration or persisted-session format change is required.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Automated verification:

- `bunx vitest run --silent='passed-only' 'apps/server/src/services/understanding/service.test.ts' 'apps/server/src/workflows/onboardingUnderstanding/index.test.ts' 'apps/server/src/workflows/onboardingUnderstanding/processProviders.test.ts' 'apps/server/src/workflows/onboardingUnderstanding/processCollected.test.ts'`
- `pnpm type-check`
- Targeted lint for the changed workflow and router files

Scenario: select `zh-CN`, start Understanding, and verify the writer system prompt requires every user-visible output value to use `zh-CN`.

#### 📸 Screenshots / Videos

N/A — no visual changes.

#### 📝 Additional Information

The Cloud client reads the response language from user settings and supplies it to this API contract.
