### PR TITLE
💄 style(portal): use cssVar.borderRadiusLG on localfile floating controls

### DIFF
--- a/src/features/Portal/LocalFile/Body.tsx
+++ b/src/features/Portal/LocalFile/Body.tsx
@@ -130,7 +130,7 @@ const floatingControlsStyles = createStaticStyles(({ css }) => ({
 
     padding: 4px;
     border: 1px solid ${cssVar.colorBorderSecondary};
-    border-radius: 8px;
+    border-radius: ${cssVar.borderRadiusLG};
 
     opacity: 0.55;
     background: ${cssVar.colorBgElevated};
@@ -287,6 +287,7 @@ const TextPreviewPane = memo<TextPreviewPaneProps>(
                 onClick={handleReloadPreview}
               />
             )}
+
             <Tabs
               activeKey={mode}
               size={'small'}


### PR DESCRIPTION
## Summary

- Swap the hard-coded \`border-radius: 8px\` on the LocalFile preview floating controls for \`cssVar.borderRadiusLG\`, per the antd-style token convention documented in \`AGENTS.md\`.
- Minor whitespace: add a blank line before the \`<Tabs>\` element in \`TextPreviewPane\` for readability.

## Test plan

- [x] \`bun run check src/features/Portal/LocalFile/Body.tsx\` — lint clean, 3 tests pass.
- [ ] Visual check: LocalFile preview floating controls still render with the expected corner radius in both light and dark themes.