### PR TITLE
🐛 fix(mcp): negotiate dynamic client registration metadata

### DIFF
--- a/apps/server/src/services/connector/oauth.test.ts
+++ b/apps/server/src/services/connector/oauth.test.ts
@@ -1,0 +1,150 @@
+import type {
+  AuthorizationServerMetadata,
+  OAuthClientInformationFull,
+  OAuthClientMetadata,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { registerDynamicClient } from './oauth';
+
+vi.mock('@/envs/app', () => ({
+  appEnv: { APP_URL: 'https://app.example.com' },
+}));
+
+const authorizationServerUrl = 'https://auth.example.com';
+const redirectUri = 'https://app.example.com/oauth/connector/callback';
+
+const createMetadata = (
+  overrides: Partial<AuthorizationServerMetadata> = {},
+): AuthorizationServerMetadata => ({
+  authorization_endpoint: `${authorizationServerUrl}/authorize`,
+  issuer: authorizationServerUrl,
+  registration_endpoint: `${authorizationServerUrl}/register`,
+  response_types_supported: ['code'],
+  token_endpoint: `${authorizationServerUrl}/token`,
+  ...overrides,
+});
+
+const registeredClient: OAuthClientInformationFull = {
+  client_id: 'registered-client',
+  redirect_uris: [redirectUri],
+};
+
+const getRegistrationMetadata = async (
+  metadata: AuthorizationServerMetadata,
+): Promise<OAuthClientMetadata> => {
+  await registerDynamicClient({
+    authorizationServerUrl,
+    metadata,
+    redirectUri,
+  });
+
+  const [requestUrl, request] = vi.mocked(fetch).mock.calls.at(-1) ?? [];
+  if (String(requestUrl) !== `${authorizationServerUrl}/register`) {
+    throw new Error('Expected the dynamic registration endpoint to be called');
+  }
+  if (typeof request?.body !== 'string') {
+    throw new Error('Expected dynamic client metadata in the request body');
+  }
+
+  return JSON.parse(request.body);
+};
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation(
+      async () =>
+        new Response(JSON.stringify(registeredClient), {
+          headers: { 'content-type': 'application/json' },
+          status: 201,
+        }),
+    ),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('registerDynamicClient', () => {
+  it('registers a public client when the server only supports none', async () => {
+    const metadata = await getRegistrationMetadata(
+      createMetadata({
+        token_endpoint_auth_methods_supported: ['none'],
+      }),
+    );
+
+    expect(metadata.token_endpoint_auth_method).toBe('none');
+  });
+
+  it('keeps confidential client_secret_post registration when it is the only supported method', async () => {
+    const metadata = await getRegistrationMetadata(
+      createMetadata({
+        token_endpoint_auth_methods_supported: ['client_secret_post'],
+      }),
+    );
+
+    expect(metadata.token_endpoint_auth_method).toBe('client_secret_post');
+  });
+
+  it('uses client_secret_basic when it is the only supported confidential method', async () => {
+    const metadata = await getRegistrationMetadata(
+      createMetadata({
+        token_endpoint_auth_methods_supported: ['client_secret_basic'],
+      }),
+    );
+
+    expect(metadata.token_endpoint_auth_method).toBe('client_secret_basic');
+  });
+
+  it('prefers a public client when both none and client_secret_post are supported', async () => {
+    const metadata = await getRegistrationMetadata(
+      createMetadata({
+        token_endpoint_auth_methods_supported: ['client_secret_post', 'none'],
+      }),
+    );
+
+    expect(metadata.token_endpoint_auth_method).toBe('none');
+  });
+
+  it('preserves client_secret_post when auth-method metadata is missing', async () => {
+    const metadata = await getRegistrationMetadata(createMetadata());
+
+    expect(metadata.token_endpoint_auth_method).toBe('client_secret_post');
+  });
+
+  it('rejects servers that advertise only unsupported token endpoint auth methods', async () => {
+    await expect(
+      registerDynamicClient({
+        authorizationServerUrl,
+        metadata: createMetadata({
+          token_endpoint_auth_methods_supported: ['private_key_jwt'],
+        }),
+        redirectUri,
+      }),
+    ).rejects.toThrow(
+      'Incompatible auth server: unsupported token endpoint auth methods: private_key_jwt',
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('requests refresh_token only when the server advertises it', async () => {
+    const authorizationCodeOnly = await getRegistrationMetadata(
+      createMetadata({
+        grant_types_supported: ['authorization_code'],
+      }),
+    );
+    const withRefreshToken = await getRegistrationMetadata(
+      createMetadata({
+        grant_types_supported: ['authorization_code', 'refresh_token'],
+      }),
+    );
+    const missingGrantMetadata = await getRegistrationMetadata(createMetadata());
+
+    expect(authorizationCodeOnly.grant_types).toEqual(['authorization_code']);
+    expect(withRefreshToken.grant_types).toEqual(['authorization_code', 'refresh_token']);
+    expect(missingGrantMetadata.grant_types).toEqual(['authorization_code']);
+  });
+});

--- a/apps/server/src/services/connector/oauth.ts
+++ b/apps/server/src/services/connector/oauth.ts
@@ -39,6 +39,30 @@ export interface DiscoveredOAuth {
   metadata: AuthorizationServerMetadata;
 }
 
+const selectDynamicClientAuthMethod = (metadata: AuthorizationServerMetadata): string => {
+  const supportedMethods = metadata.token_endpoint_auth_methods_supported;
+
+  // Keep the existing confidential-client behavior for servers that omit this
+  // metadata. When a server explicitly supports public clients, prefer `none`
+  // because this authorization-code flow always uses PKCE.
+  if (!supportedMethods) return 'client_secret_post';
+  if (supportedMethods.includes('none')) return 'none';
+  if (supportedMethods.includes('client_secret_post')) return 'client_secret_post';
+  if (supportedMethods.includes('client_secret_basic')) return 'client_secret_basic';
+
+  throw new Error(
+    `Incompatible auth server: unsupported token endpoint auth methods: ${supportedMethods.join(', ')}`,
+  );
+};
+
+const selectDynamicClientGrantTypes = (metadata: AuthorizationServerMetadata): string[] => {
+  const grantTypes = ['authorization_code'];
+  if (metadata.grant_types_supported?.includes('refresh_token')) {
+    grantTypes.push('refresh_token');
+  }
+  return grantTypes;
+};
+
 /**
  * Discover the OAuth authorization server backing a remote MCP resource.
  *
@@ -96,11 +120,11 @@ export const registerDynamicClient = async (params: {
   return registerClient(params.authorizationServerUrl, {
     clientMetadata: {
       client_name: params.clientName ?? 'LobeHub',
-      grant_types: ['authorization_code', 'refresh_token'],
+      grant_types: selectDynamicClientGrantTypes(params.metadata),
       redirect_uris: [params.redirectUri],
       response_types: ['code'],
       scope: params.scopes?.join(' '),
-      token_endpoint_auth_method: 'client_secret_post',
+      token_endpoint_auth_method: selectDynamicClientAuthMethod(params.metadata),
     },
     metadata: params.metadata,
     scope: params.scopes?.join(' '),


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No existing issue.

#### 🔀 Description of Change

Dynamic client registration currently ignores the authorization server metadata and always requests `client_secret_post` plus the `refresh_token` grant. That makes standards-conforming public PKCE servers fail registration and asks authorization servers for a grant they may not support.

This change:

- prefers `none` when the server advertises public-client support;
- otherwise uses an advertised `client_secret_post` or `client_secret_basic` method;
- preserves the existing `client_secret_post` fallback when metadata is omitted;
- always requests `authorization_code` and only adds `refresh_token` when advertised; and
- returns a clear incompatibility error for explicitly unsupported auth methods.

#### 🧪 How to Test

`bun run check apps/server/src/services/connector/oauth.ts apps/server/src/services/connector/oauth.test.ts --lint --test --type`

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

The focused suite covers public clients, both confidential methods, mixed-method preference, backward-compatible missing metadata, unsupported methods, and grant negotiation. Result: lint clean, 7 tests passed, types clean.

#### 📸 Screenshots / Videos

Not applicable; server-side OAuth registration only.

#### 📝 Additional Information

No migration or UI change. The compatibility fallback for authorization servers that omit auth-method metadata is unchanged.