### PR TITLE
✨ feat: support Markdown source mode in agent profile

### DIFF
--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -666,6 +666,8 @@
   "settingAgent.name.title": "Name",
   "settingAgent.prompt.desc": "Defines who this agent is, what it is responsible for, and how it works and responds. It serves as a core instruction in every conversation.",
   "settingAgent.prompt.editorPlaceholder": "Enter core instructions, press / to open the Slash Menu",
+  "settingAgent.prompt.mode.source": "Markdown source",
+  "settingAgent.prompt.mode.visual": "Visual editor",
   "settingAgent.prompt.placeholder": "Enter agent instructions",
   "settingAgent.prompt.title": "Core Instructions",
   "settingAgent.runtimeConfig.title": "Model & Tools",

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -666,6 +666,8 @@
   "settingAgent.name.title": "名称",
   "settingAgent.prompt.desc": "定义这个助理的身份、职责、工作方式和回应风格。这里的设定会在每次对话中生效。",
   "settingAgent.prompt.editorPlaceholder": "输入核心指令，按 / 打开斜杠菜单",
+  "settingAgent.prompt.mode.source": "Markdown 源码",
+  "settingAgent.prompt.mode.visual": "所见即所得",
   "settingAgent.prompt.placeholder": "请输入助理指令",
   "settingAgent.prompt.title": "核心指令",
   "settingAgent.runtimeConfig.title": "模型与工具",

--- a/packages/locales/src/default/setting.ts
+++ b/packages/locales/src/default/setting.ts
@@ -710,6 +710,8 @@ export default {
     'Defines who this agent is, what it is responsible for, and how it works and responds. It serves as a core instruction in every conversation.',
   'settingAgent.prompt.editorPlaceholder':
     'Enter core instructions, press / to open the Slash Menu',
+  'settingAgent.prompt.mode.source': 'Markdown source',
+  'settingAgent.prompt.mode.visual': 'Visual editor',
   'settingAgent.prompt.placeholder': 'Enter agent instructions',
   'settingAgent.prompt.title': 'Core Instructions',
   'settingAgent.agentTools.add': 'Add Tool',

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
@@ -14,6 +14,9 @@ const editorProps = vi.hoisted(() => ({
 const autoSaveHintProps = vi.hoisted(() => ({
   last: undefined as any,
 }));
+const codeEditorPaneProps = vi.hoisted(() => ({
+  last: undefined as any,
+}));
 
 const editorDocuments = {
   json: undefined as unknown,
@@ -105,6 +108,20 @@ vi.mock('@/components/Editor/AutoSaveHint', () => ({
   }),
 }));
 
+vi.mock('@/components/CodeEditorPane', () => ({
+  default: vi.fn((props: any) => {
+    codeEditorPaneProps.last = props;
+    return (
+      <textarea
+        data-testid="prompt-source-editor"
+        readOnly={props.readOnly}
+        value={props.value}
+        onChange={(event) => props.onChange?.(event.target.value)}
+      />
+    );
+  }),
+}));
+
 vi.mock('@/components/InfoTooltip', () => ({
   default: ({ title }: { title: string }) => (
     <button aria-label={title} data-testid="prompt-description-tooltip" type="button" />
@@ -171,6 +188,8 @@ describe('Agent profile EditorCanvas', () => {
     vi.clearAllMocks();
     editorProps.last = undefined;
     autoSaveHintProps.last = undefined;
+    codeEditorPaneProps.last = undefined;
+    localStorage.clear();
     permissionState.allowed = false;
     agentStoreMock.listeners.clear();
     agentStoreState.activeAgentId = 'agent-a';
@@ -205,6 +224,70 @@ describe('Agent profile EditorCanvas', () => {
 
     expect(editorProps.last?.lineEmptyPlaceholder).toBe('settingAgent.prompt.editorPlaceholder');
     expect(editorProps.last?.placeholder).toBe('settingAgent.prompt.editorPlaceholder');
+  });
+
+  it('switches between the visual editor and Markdown source mode', async () => {
+    agentStoreState.agentMap = {
+      'agent-a': {
+        editorData: undefined,
+        systemRole: '# Core instructions',
+      },
+    };
+
+    render(<EditorCanvas />);
+    act(() => editorProps.last?.onInit());
+
+    fireEvent.click(screen.getByRole('button', { name: 'settingAgent.prompt.mode.source' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('prompt-source-editor')).toHaveValue('# Core instructions'),
+    );
+    expect(codeEditorPaneProps.last?.language).toBe('markdown');
+    expect(screen.getByRole('button', { name: 'settingAgent.prompt.mode.source' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'settingAgent.prompt.mode.visual' }));
+
+    expect(screen.queryByTestId('prompt-source-editor')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'settingAgent.prompt.mode.visual' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('converts Markdown source edits into the shared rich document and autosave payload', async () => {
+    permissionState.allowed = true;
+    agentStoreState.agentMap = {
+      'agent-a': {
+        editorData: undefined,
+        systemRole: '# Initial role',
+      },
+    };
+
+    render(<EditorCanvas />);
+    act(() => editorProps.last?.onInit());
+    await waitFor(() =>
+      expect(editor.setDocument).toHaveBeenCalledWith('markdown', '# Initial role'),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'settingAgent.prompt.mode.source' }));
+
+    fireEvent.change(await screen.findByTestId('prompt-source-editor'), {
+      target: { value: '# Updated role\n\nFollow the user.' },
+    });
+
+    expect(editor.setDocument).toHaveBeenCalledWith(
+      'markdown',
+      '# Updated role\n\nFollow the user.',
+    );
+    expect(handleContentChange).toHaveBeenCalledWith(
+      'agent-a',
+      expect.any(Function),
+      editor,
+      '# Updated role\n\nFollow the user.',
+    );
+    expect(setHasEdited).toHaveBeenCalledWith(true);
   });
 
   it('moves the prompt description into the title tooltip', () => {

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
@@ -277,6 +277,47 @@ describe('Agent profile EditorCanvas', () => {
     expect(await screen.findByTestId('prompt-source-editor')).toHaveValue(persistedMarkdown);
   });
 
+  it('ignores source change callbacks caused by a programmatic value sync', async () => {
+    permissionState.allowed = true;
+    const initialEditorData = { root: { children: ['initial'] } };
+    const serverEditorData = { root: { children: ['server'] } };
+    agentStoreState.agentMap = {
+      'agent-a': { editorData: initialEditorData, systemRole: 'initial prompt' },
+    };
+
+    render(<EditorCanvas />);
+    act(() => editorProps.last?.onInit());
+    fireEvent.click(screen.getByRole('button', { name: 'settingAgent.prompt.mode.source' }));
+    await waitFor(() =>
+      expect(screen.getByTestId('prompt-source-editor')).toHaveValue('initial prompt'),
+    );
+
+    act(() => {
+      agentStoreState.agentMap = {
+        'agent-a': { editorData: serverEditorData, systemRole: 'server prompt' },
+      };
+      agentStoreMock.listeners.forEach((listener) => listener());
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('prompt-source-editor')).toHaveValue('server prompt'),
+    );
+
+    act(() => codeEditorPaneProps.last?.onChange('server prompt'));
+
+    expect(handleContentChange).not.toHaveBeenCalled();
+    expect(setHasEdited).not.toHaveBeenCalled();
+
+    act(() => codeEditorPaneProps.last?.onChange('user prompt'));
+
+    expect(handleContentChange).toHaveBeenCalledWith(
+      'agent-a',
+      expect.any(Function),
+      editor,
+      'user prompt',
+    );
+    expect(setHasEdited).toHaveBeenCalledWith(true);
+  });
+
   it('converts Markdown source edits into the shared rich document and autosave payload', async () => {
     permissionState.allowed = true;
     agentStoreState.agentMap = {

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
@@ -257,6 +257,26 @@ describe('Agent profile EditorCanvas', () => {
     );
   });
 
+  it('seeds source mode from the persisted Markdown when editor data also exists', async () => {
+    const editorData = { root: { children: ['parsed source'] } };
+    const persistedMarkdown = '<details>\n\n  raw spacing\n\n</details>';
+    agentStoreState.agentMap = {
+      'agent-a': {
+        editorData,
+        systemRole: persistedMarkdown,
+      },
+    };
+    editorDocuments.markdown = 'normalized markdown';
+
+    render(<EditorCanvas />);
+    act(() => editorProps.last?.onInit());
+    await waitFor(() => expect(editor.setDocument).toHaveBeenCalledWith('json', editorData));
+
+    fireEvent.click(screen.getByRole('button', { name: 'settingAgent.prompt.mode.source' }));
+
+    expect(await screen.findByTestId('prompt-source-editor')).toHaveValue(persistedMarkdown);
+  });
+
   it('converts Markdown source edits into the shared rich document and autosave payload', async () => {
     permissionState.allowed = true;
     agentStoreState.agentMap = {

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
@@ -3,18 +3,21 @@
 import type { IEditor } from '@lobehub/editor';
 import { ReactMentionPlugin, ReactTablePlugin, ReactToolbarPlugin } from '@lobehub/editor';
 import { Editor } from '@lobehub/editor/react';
-import { Flexbox } from '@lobehub/ui';
+import { ActionIcon, Flexbox } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import isEqual from 'fast-deep-equal';
+import { CodeXmlIcon, TextCursorInputIcon } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { message } from '@/components/AntdStaticMethods';
+import CodeEditorPane from '@/components/CodeEditorPane';
 import AutoSaveHint from '@/components/Editor/AutoSaveHint';
 import InfoTooltip from '@/components/InfoTooltip';
 import { createChatInputRichPlugins } from '@/features/ChatInput/InputEditor/plugins';
 import { EditingIndicator } from '@/features/EditLock';
 import { useResourceAccess } from '@/features/ResourcePermission/useResourceAccess';
+import { useLocalStorageState } from '@/hooks/useLocalStorageState';
 import { usePermission } from '@/hooks/usePermission';
 import { EMPTY_EDITOR_STATE } from '@/libs/editor/constants';
 import { useAgentStore } from '@/store/agent';
@@ -39,8 +42,16 @@ const styles = createStaticStyles(({ css }) => ({
   header: css`
     max-width: 820px;
   `,
+  modeSwitch: css`
+    padding-inline-start: 4px;
+    border-inline-start: 1px solid ${cssVar.colorBorderSecondary};
+  `,
   root: css`
     padding-block-end: 16px;
+  `,
+  sourceEditor: css`
+    min-height: 262px;
+    background: transparent;
   `,
   title: css`
     cursor: default;
@@ -59,11 +70,41 @@ interface ProgrammaticDocument {
   value: unknown;
 }
 
+type PromptEditorMode = 'source' | 'visual';
+
+const PROMPT_EDITOR_MODE_STORAGE_KEY = 'agent-profile-prompt-editor-mode';
+
+const usePromptEditorMode = () => {
+  const [editorMode, setEditorMode] = useLocalStorageState<PromptEditorMode>(
+    PROMPT_EDITOR_MODE_STORAGE_KEY,
+    'visual',
+  );
+  const [sourceMarkdown, setSourceMarkdown] = useState('');
+
+  const syncSourceMarkdown = useCallback((sourceEditor: IEditor) => {
+    try {
+      setSourceMarkdown((sourceEditor.getDocument('markdown') as unknown as string) || '');
+    } catch {
+      // Keep the last readable source value if the editor is between document states.
+    }
+  }, []);
+
+  return {
+    activeEditorMode: editorMode === 'source' ? 'source' : 'visual',
+    setEditorMode,
+    setSourceMarkdown,
+    sourceMarkdown,
+    syncSourceMarkdown,
+  } as const;
+};
+
 const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
   const { t } = useTranslation('setting');
   const { allowed: hasEditPermission } = usePermission('edit_own_content');
   const [editorInit, setEditorInit] = useState(false);
   const [contentInit, setContentInit] = useState(false);
+  const { activeEditorMode, setEditorMode, setSourceMarkdown, sourceMarkdown, syncSourceMarkdown } =
+    usePromptEditorMode();
   const config = useAgentStore((s) => s.agentMap[agentId], isEqual);
   const editorData = config?.editorData;
   const systemRole = config?.systemRole;
@@ -139,6 +180,15 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
     [],
   );
 
+  const setProgrammaticDocument = useCallback(
+    (sourceEditor: IEditor, format: ProgrammaticDocument['format'], value: unknown) => {
+      sourceEditor.setDocument(format, value);
+      recordProgrammaticDocument(sourceEditor, format);
+      syncSourceMarkdown(sourceEditor);
+    },
+    [recordProgrammaticDocument, syncSourceMarkdown],
+  );
+
   const isProgrammaticChange = useCallback(
     (sourceEditor?: IEditor) => {
       const pendingDocument = programmaticDocumentRef.current;
@@ -168,6 +218,7 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
       // edit. Streaming systemRole writes are programmatic and skipped above.
       localEditRef.current = true;
       setHasEdited(true);
+      if (sourceEditor) syncSourceMarkdown(sourceEditor);
       handleContentChange(agentId, updatePromptConfigById, sourceEditor);
     },
     [
@@ -176,6 +227,35 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
       handleContentChange,
       isProgrammaticChange,
       setHasEdited,
+      syncSourceMarkdown,
+      streamingInProgress,
+      updatePromptConfigById,
+    ],
+  );
+
+  const handleSourceChange = useCallback(
+    (value: string) => {
+      setSourceMarkdown(value);
+      if (!editor || !editable || streamingInProgress) return;
+
+      localEditRef.current = true;
+      setHasEdited(true);
+      try {
+        editor.setDocument('markdown', value);
+        recordProgrammaticDocument(editor, 'markdown');
+        handleContentChange(agentId, updatePromptConfigById, editor, value);
+      } catch (error) {
+        console.error('[EditorCanvas] Failed to update Markdown source:', error);
+      }
+    },
+    [
+      agentId,
+      editable,
+      editor,
+      handleContentChange,
+      recordProgrammaticDocument,
+      setHasEdited,
+      setSourceMarkdown,
       streamingInProgress,
       updatePromptConfigById,
     ],
@@ -193,13 +273,12 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
     if (streamingSystemRole !== prevStreamingRef.current) {
       prevStreamingRef.current = streamingSystemRole;
       try {
-        editor.setDocument('markdown', streamingSystemRole || '');
-        recordProgrammaticDocument(editor, 'markdown');
+        setProgrammaticDocument(editor, 'markdown', streamingSystemRole || '');
       } catch {
         // Ignore errors during streaming updates
       }
     }
-  }, [editor, editorInit, recordProgrammaticDocument, streamingInProgress, streamingSystemRole]);
+  }, [editor, editorInit, setProgrammaticDocument, streamingInProgress, streamingSystemRole]);
 
   // Trigger save when streaming ends
   useEffect(() => {
@@ -237,15 +316,15 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
     if (streamingInProgress) return;
     try {
       if (editorData && editorData?.root !== undefined) {
-        editor.setDocument('json', editorData);
-        recordProgrammaticDocument(editor, 'json');
+        setProgrammaticDocument(editor, 'json', editorData);
         lastSyncedEditorDataRef.current = structuredClone(editorData);
       } else if (systemRole) {
-        editor.setDocument('markdown', systemRole);
-        recordProgrammaticDocument(editor, 'markdown');
+        setProgrammaticDocument(editor, 'markdown', systemRole);
         // Record the displayed role so the external-update re-sync below doesn't
         // redundantly re-push the same value right after init.
         lastSyncedRoleRef.current = systemRole;
+      } else {
+        setSourceMarkdown('');
       }
       // If no editorData and no systemRole, leave editor empty to show placeholder
       setContentInit(true);
@@ -257,7 +336,8 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
     editor,
     editorData,
     editorInit,
-    recordProgrammaticDocument,
+    setProgrammaticDocument,
+    setSourceMarkdown,
     streamingInProgress,
     systemRole,
   ]);
@@ -283,8 +363,7 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
       if (localEditRef.current || isEqual(lastSyncedEditorDataRef.current, editorData)) return;
 
       try {
-        editor.setDocument('json', editorData);
-        recordProgrammaticDocument(editor, 'json');
+        setProgrammaticDocument(editor, 'json', editorData);
         lastSyncedEditorDataRef.current = structuredClone(editorData);
       } catch (error) {
         console.error('[EditorCanvas] Failed to sync editor content:', error);
@@ -298,8 +377,7 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
     lastSyncedRoleRef.current = role;
 
     try {
-      editor.setDocument('markdown', role);
-      recordProgrammaticDocument(editor, 'markdown');
+      setProgrammaticDocument(editor, 'markdown', role);
     } catch {
       // ignore
     }
@@ -308,7 +386,7 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
     editor,
     editorData,
     editorInit,
-    recordProgrammaticDocument,
+    setProgrammaticDocument,
     streamingInProgress,
     systemRole,
   ]);
@@ -325,13 +403,35 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
               title={t('settingAgent.prompt.desc')}
             />
           </Flexbox>
-          {promptSaveStatus !== 'idle' && (
-            <AutoSaveHint
-              lastUpdatedTime={promptLastUpdatedTime}
-              saveStatus={promptSaveStatus}
-              onRetry={editable ? () => void retryPromptSave() : undefined}
-            />
-          )}
+          <Flexbox horizontal align={'center'} gap={4}>
+            {promptSaveStatus !== 'idle' && (
+              <AutoSaveHint
+                lastUpdatedTime={promptLastUpdatedTime}
+                saveStatus={promptSaveStatus}
+                onRetry={editable ? () => void retryPromptSave() : undefined}
+              />
+            )}
+            <Flexbox horizontal className={styles.modeSwitch} gap={2}>
+              <ActionIcon
+                active={activeEditorMode === 'visual'}
+                aria-label={t('settingAgent.prompt.mode.visual')}
+                aria-pressed={activeEditorMode === 'visual'}
+                icon={TextCursorInputIcon}
+                size={'small'}
+                title={t('settingAgent.prompt.mode.visual')}
+                onClick={() => setEditorMode('visual')}
+              />
+              <ActionIcon
+                active={activeEditorMode === 'source'}
+                aria-label={t('settingAgent.prompt.mode.source')}
+                aria-pressed={activeEditorMode === 'source'}
+                icon={CodeXmlIcon}
+                size={'small'}
+                title={t('settingAgent.prompt.mode.source')}
+                onClick={() => setEditorMode('source')}
+              />
+            </Flexbox>
+          </Flexbox>
         </Flexbox>
       </Flexbox>
       <div
@@ -347,28 +447,39 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
           holderId={lockedByOther ? lockHolderId : null}
           pending={canEdit && lockPending}
         />
-        <Editor
-          content={initialLoad}
-          editable={editable}
-          editor={editor!}
-          lineEmptyPlaceholder={t('settingAgent.prompt.editorPlaceholder')}
-          mentionOption={mentionOptions}
-          placeholder={t('settingAgent.prompt.editorPlaceholder')}
-          style={{ paddingBottom: 0 }}
-          plugins={[
-            ...createChatInputRichPlugins(),
-            ReactTablePlugin,
-            ReactMentionPlugin,
-            Editor.withProps(ReactToolbarPlugin, {
-              children: <TypoBar />,
-            }),
-          ]}
-          slashOption={{
-            items: slashItems,
-          }}
-          onInit={() => setEditorInit(true)}
-          onTextChange={handleChange}
-        />
+        <div hidden={activeEditorMode !== 'visual'}>
+          <Editor
+            content={initialLoad}
+            editable={editable}
+            editor={editor!}
+            lineEmptyPlaceholder={t('settingAgent.prompt.editorPlaceholder')}
+            mentionOption={mentionOptions}
+            placeholder={t('settingAgent.prompt.editorPlaceholder')}
+            style={{ paddingBottom: 0 }}
+            plugins={[
+              ...createChatInputRichPlugins(),
+              ReactTablePlugin,
+              ReactMentionPlugin,
+              Editor.withProps(ReactToolbarPlugin, {
+                children: <TypoBar />,
+              }),
+            ]}
+            slashOption={{
+              items: slashItems,
+            }}
+            onInit={() => setEditorInit(true)}
+            onTextChange={handleChange}
+          />
+        </div>
+        {activeEditorMode === 'source' && contentInit && (
+          <CodeEditorPane
+            className={styles.sourceEditor}
+            language={'markdown'}
+            readOnly={!editable || streamingInProgress}
+            value={sourceMarkdown}
+            onChange={handleSourceChange}
+          />
+        )}
       </div>
     </Flexbox>
   );

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
@@ -90,6 +90,9 @@ const usePromptEditorMode = () => {
   }, []);
 
   return {
+    // localStorage holds unvalidated JSON, so fall back to the visual editor for
+    // any value that isn't a known mode — otherwise both render branches miss and
+    // the editor shell renders empty.
     activeEditorMode: editorMode === 'source' ? 'source' : 'visual',
     setEditorMode,
     setSourceMarkdown,
@@ -184,6 +187,17 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
     [],
   );
 
+  /**
+   * Writes a document into the editor and keeps the source pane's Markdown in sync.
+   *
+   * @param markdownSource - The exact Markdown to show in source mode. Pass the
+   *   persisted `systemRole` whenever it exists: `getDocument('markdown')` is a
+   *   lossy re-serialization, so deriving the source here would replace the user's
+   *   raw Markdown with the editor's normalized rendering — and the next source-mode
+   *   keystroke would persist that normalized text. Nullish (no persisted source)
+   *   falls back to the editor's own, normalized Markdown.
+   *   See LOBE-12367 / lobehub/lobehub#17580.
+   */
   const setProgrammaticDocument = useCallback(
     (
       sourceEditor: IEditor,

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
@@ -181,12 +181,21 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
   );
 
   const setProgrammaticDocument = useCallback(
-    (sourceEditor: IEditor, format: ProgrammaticDocument['format'], value: unknown) => {
+    (
+      sourceEditor: IEditor,
+      format: ProgrammaticDocument['format'],
+      value: unknown,
+      markdownSource?: string | null,
+    ) => {
       sourceEditor.setDocument(format, value);
       recordProgrammaticDocument(sourceEditor, format);
-      syncSourceMarkdown(sourceEditor);
+      if (markdownSource == null) {
+        syncSourceMarkdown(sourceEditor);
+      } else {
+        setSourceMarkdown(markdownSource);
+      }
     },
-    [recordProgrammaticDocument, syncSourceMarkdown],
+    [recordProgrammaticDocument, setSourceMarkdown, syncSourceMarkdown],
   );
 
   const isProgrammaticChange = useCallback(
@@ -273,7 +282,8 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
     if (streamingSystemRole !== prevStreamingRef.current) {
       prevStreamingRef.current = streamingSystemRole;
       try {
-        setProgrammaticDocument(editor, 'markdown', streamingSystemRole || '');
+        const markdown = streamingSystemRole || '';
+        setProgrammaticDocument(editor, 'markdown', markdown, markdown);
       } catch {
         // Ignore errors during streaming updates
       }
@@ -316,10 +326,10 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
     if (streamingInProgress) return;
     try {
       if (editorData && editorData?.root !== undefined) {
-        setProgrammaticDocument(editor, 'json', editorData);
+        setProgrammaticDocument(editor, 'json', editorData, systemRole);
         lastSyncedEditorDataRef.current = structuredClone(editorData);
       } else if (systemRole) {
-        setProgrammaticDocument(editor, 'markdown', systemRole);
+        setProgrammaticDocument(editor, 'markdown', systemRole, systemRole);
         // Record the displayed role so the external-update re-sync below doesn't
         // redundantly re-push the same value right after init.
         lastSyncedRoleRef.current = systemRole;
@@ -363,7 +373,7 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
       if (localEditRef.current || isEqual(lastSyncedEditorDataRef.current, editorData)) return;
 
       try {
-        setProgrammaticDocument(editor, 'json', editorData);
+        setProgrammaticDocument(editor, 'json', editorData, systemRole);
         lastSyncedEditorDataRef.current = structuredClone(editorData);
       } catch (error) {
         console.error('[EditorCanvas] Failed to sync editor content:', error);
@@ -377,7 +387,7 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
     lastSyncedRoleRef.current = role;
 
     try {
-      setProgrammaticDocument(editor, 'markdown', role);
+      setProgrammaticDocument(editor, 'markdown', role, role);
     } catch {
       // ignore
     }

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
@@ -6,7 +6,7 @@ import { Editor } from '@lobehub/editor/react';
 import { ActionIcon, Flexbox } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import isEqual from 'fast-deep-equal';
-import { CodeXmlIcon, TextCursorInputIcon } from 'lucide-react';
+import { CodeXmlIcon, LetterTextIcon } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -457,7 +457,7 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
                 active={activeEditorMode === 'visual'}
                 aria-label={t('settingAgent.prompt.mode.visual')}
                 aria-pressed={activeEditorMode === 'visual'}
-                icon={TextCursorInputIcon}
+                icon={LetterTextIcon}
                 size={'small'}
                 title={t('settingAgent.prompt.mode.visual')}
                 onClick={() => setEditorMode('visual')}

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
@@ -132,6 +132,10 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
   );
   const prevStreamingRef = useRef<string | undefined>(undefined);
   const wasStreamingRef = useRef(false);
+  // CodeMirror emits `change` for controlled `setValue` calls as well as user
+  // edits. Remember the next value pushed from props so that callback does not
+  // acquire the edit lock or enqueue an autosave.
+  const programmaticSourceChangeRef = useRef<string | undefined>(undefined);
   // The editor debounces onTextChange internally. Keep the exact document
   // written by code so the delayed callback can be identified by payload,
   // independent of how long that internal debounce waits.
@@ -190,12 +194,19 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
       sourceEditor.setDocument(format, value);
       recordProgrammaticDocument(sourceEditor, format);
       if (markdownSource == null) {
-        syncSourceMarkdown(sourceEditor);
+        try {
+          const nextSource = (sourceEditor.getDocument('markdown') as unknown as string) || '';
+          programmaticSourceChangeRef.current = nextSource;
+          setSourceMarkdown(nextSource);
+        } catch {
+          // Keep the last readable source value if the editor is between document states.
+        }
       } else {
+        programmaticSourceChangeRef.current = markdownSource;
         setSourceMarkdown(markdownSource);
       }
     },
-    [recordProgrammaticDocument, setSourceMarkdown, syncSourceMarkdown],
+    [recordProgrammaticDocument, setSourceMarkdown],
   );
 
   const isProgrammaticChange = useCallback(
@@ -244,6 +255,12 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
 
   const handleSourceChange = useCallback(
     (value: string) => {
+      const programmaticValue = programmaticSourceChangeRef.current;
+      if (programmaticValue !== undefined) {
+        programmaticSourceChangeRef.current = undefined;
+        if (programmaticValue === value) return;
+      }
+
       setSourceMarkdown(value);
       if (!editor || !editable || streamingInProgress) return;
 

--- a/src/routes/(main)/agent/profile/features/store/action.test.ts
+++ b/src/routes/(main)/agent/profile/features/store/action.test.ts
@@ -105,6 +105,29 @@ describe('agent profile store actions', () => {
     });
   });
 
+  it('preserves the exact Markdown source while saving the parsed editor document', async () => {
+    const profileStore = createStore({ editor });
+    const sourceEditor = {
+      getDocument: vi.fn((format: 'json' | 'markdown') =>
+        format === 'json' ? { root: { children: ['parsed source'] } } : 'normalized markdown',
+      ),
+    } as unknown as IEditor;
+    const updateConfigById = vi.fn().mockResolvedValue(undefined);
+    const markdownSource = '<details>\n\n  raw spacing\n\n</details>';
+
+    profileStore
+      .getState()
+      .handleContentChange('agent-a', updateConfigById, sourceEditor, markdownSource);
+
+    await vi.advanceTimersByTimeAsync(EDITOR_DEBOUNCE_TIME);
+    await profileStore.getState().flushSave();
+
+    expect(updateConfigById).toHaveBeenCalledWith('agent-a', {
+      editorData: { root: { children: ['parsed source'] } },
+      systemRole: markdownSource,
+    });
+  });
+
   it('keeps a failed Prompt save visible and retries the same draft', async () => {
     const profileStore = createStore({ editor });
     const updateConfigById = vi

--- a/src/routes/(main)/agent/profile/features/store/action.ts
+++ b/src/routes/(main)/agent/profile/features/store/action.ts
@@ -33,6 +33,7 @@ export interface Action {
     agentId: string,
     updateConfigById: UpdateConfigById,
     sourceEditor?: State['editor'],
+    markdownSource?: string,
   ) => void;
   /** Retry the latest failed Prompt autosave. */
   retryPromptSave: () => Promise<void>;
@@ -178,12 +179,13 @@ export const store: (initState?: Partial<State>) => StateCreator<Store> =
         await saveQueue;
       },
 
-      handleContentChange: (agentId, updateConfigById, sourceEditor) => {
+      handleContentChange: (agentId, updateConfigById, sourceEditor, markdownSource) => {
         const editor = sourceEditor ?? get().editor;
         if (!agentId || !editor) return;
 
         try {
-          const markdownContent = (editor.getDocument('markdown') as unknown as string) || '';
+          const markdownContent =
+            markdownSource ?? (editor.getDocument('markdown') as unknown as string) ?? '';
           const jsonContent = editor.getDocument('json') as unknown as Record<string, unknown>;
 
           getDebouncedSave(agentId)(


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-12367

#### 🔀 Description of Change

- Add visual-editor and Markdown-source modes to Agent Profile core instructions.
- Persist the preferred editing mode locally and reuse the existing edit lock, streaming updates, and autosave feedback in both modes.
- Preserve the exact Markdown source in systemRole while keeping parsed editor JSON available for the visual editor.
- Add English and Simplified Chinese labels for the mode switch.

#### 🧭 Key Decisions / Non-goals

- Keep a single rich-editor instance mounted so switching modes does not reset editor state or bypass the existing collaboration and save lifecycle.
- Treat the Markdown source as authoritative for source-mode saves; parsed editor JSON is a synchronized visual representation and must not normalize the saved source.
- No database schema, API contract, or agent-runtime behavior changes are included.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Automated validation:

- bun run check <7 changed files> --lint --test --type
- Result: lint clean, 19 tests passed, types clean

Manual scenario:

1. Open an Agent Profile and switch Core Instructions to Markdown source mode.
2. Edit Markdown containing whitespace or HTML structures and wait for autosave.
3. Switch to the visual editor and back; confirm the source remains available and subsequent visual edits stay synchronized.

#### 📸 Screenshots / Videos

N/A — the change adds a compact two-icon mode switch to the existing Core Instructions header.

#### 📝 Additional Information

No migration or rollout step is required. Other locale files can be generated through the standard i18n pipeline.
