### PR TITLE
🐛 fix: avoid implicit any in DeepSeek model test

### DIFF
--- a/packages/model-runtime/src/providers/deepseek/__tests__/index.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/__tests__/index.test.ts
@@ -159,7 +159,7 @@ describe('LobeDeepSeekAI', () => {
 
         expect(fetchSpy).toHaveBeenCalledTimes(1);
         expect(requestURL).toBe(expectedURL);
-        expect(models?.map(({ id }) => id)).toContain('deepseek-chat');
+        expect(models).toContainEqual(expect.objectContaining({ id: 'deepseek-chat' }));
       },
     );
   });


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to #17573

#### 🔀 Description of Change

Replace the DeepSeek model discovery assertion that destructures an untyped callback parameter with an equivalent object-containment assertion. This removes the TS7031 implicit-any error currently blocking `Test Database`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bunx vitest run --silent=passed-only src/providers/deepseek/__tests__/index.test.ts` — 18 passed
- ESLint for the changed test file — passed
- Root type-check no longer reports the DeepSeek TS7031 error; the temporary shared-dependency worktree reports unrelated cross-branch workspace resolution errors, so a clean CI run remains authoritative

#### 📸 Screenshots / Videos

Not applicable.

#### 📝 Additional Information

The failing test file is unchanged in #17573 relative to its base and also exists on `canary`, so this is intentionally submitted as a standalone `canary` fix.