### PR TITLE
🔨 chore(renovate): enforce scheduled branch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -65,5 +65,6 @@
   "schedule": "on sunday before 6:00am",
   "separateMajorMinor": true,
   "separateMinorPatch": false,
-  "timezone": "UTC"
+  "timezone": "UTC",
+  "updateNotScheduled": false
 }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔨 chore

#### 🔗 Related Issue

Related to #194

#### 🔀 Description of Change

Set `updateNotScheduled` to `false` so existing Renovate branches follow their configured schedules instead of receiving ordinary out-of-window updates that retrigger CI and preview deployments.

Security vulnerability updates and explicitly requested rebases keep Renovate's existing bypass behavior.

#### 🧪 How to Test

- [x] No runtime tests needed
- [x] `jq empty renovate.json`
- [x] `npx --yes --package=renovate@43.280.2 renovate-config-validator renovate.json`

#### 📝 Additional Information

Key decision: keep this change scoped to strict schedule enforcement. This PR does not change the existing weekly/monthly schedules, concurrency limits, or CI workflow triggers.
