### PR TITLE
🐛 fix: avoid topic comment provider crash

### DIFF
--- a/src/features/Conversation/hooks/useConversationResourceAccess.test.ts
+++ b/src/features/Conversation/hooks/useConversationResourceAccess.test.ts
@@ -1,0 +1,94 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useActiveConversationResourceAccess } from './useConversationResourceAccess';
+
+const mocks = vi.hoisted(() => ({
+  agentState: {
+    agentMap: {
+      'agent-1': { visibility: 'public' },
+    } as Record<string, { visibility: 'private' | 'public' }>,
+    inboxAgentId: 'inbox',
+  },
+  chatState: {
+    activeAgentId: 'agent-1',
+    activeGroupId: undefined as string | undefined,
+  },
+  conversationStore: vi.fn(() => {
+    throw new Error('Seems like you have not used zustand provider as an ancestor.');
+  }),
+  groupState: {
+    groupMap: {} as Record<string, { id: string; visibility: 'private' | 'public' }>,
+  },
+  useResourceAccess: vi.fn(() => ({ canUseResource: true, isLoading: false })),
+}));
+
+vi.mock('@/features/ResourcePermission/useResourceAccess', () => ({
+  useResourceAccess: (...args: unknown[]) => mocks.useResourceAccess(...(args as [])),
+}));
+
+vi.mock('@/hooks/usePermission', () => ({
+  usePermission: () => ({ allowed: true }),
+}));
+
+vi.mock('@/store/agent', () => ({
+  useAgentStore: (selector: (state: typeof mocks.agentState) => unknown) =>
+    selector(mocks.agentState),
+}));
+
+vi.mock('@/store/agent/selectors', () => ({
+  builtinAgentSelectors: {
+    inboxAgentId: (state: typeof mocks.agentState) => state.inboxAgentId,
+  },
+}));
+
+vi.mock('@/store/agentGroup', () => ({
+  useAgentGroupStore: (selector: (state: typeof mocks.groupState) => unknown) =>
+    selector(mocks.groupState),
+}));
+
+vi.mock('@/store/agentGroup/selectors', () => ({
+  agentGroupSelectors: {
+    getGroupById: (id: string) => (state: typeof mocks.groupState) => state.groupMap[id],
+  },
+}));
+
+vi.mock('@/store/chat', () => ({
+  useChatStore: (selector: (state: typeof mocks.chatState) => unknown) => selector(mocks.chatState),
+}));
+
+vi.mock('../store', () => ({
+  useConversationStore: mocks.conversationStore,
+}));
+
+describe('useActiveConversationResourceAccess', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.chatState.activeAgentId = 'agent-1';
+    mocks.chatState.activeGroupId = undefined;
+    mocks.groupState.groupMap = {};
+    mocks.useResourceAccess.mockReturnValue({ canUseResource: true, isLoading: false });
+  });
+
+  it('resolves active agent access without reading the ConversationStore provider', () => {
+    const { result } = renderHook(() => useActiveConversationResourceAccess());
+
+    expect(result.current.canUseResource).toBe(true);
+    expect(result.current.isGroupContext).toBe(false);
+    expect(mocks.conversationStore).not.toHaveBeenCalled();
+    expect(mocks.useResourceAccess).toHaveBeenCalledWith('agent', 'agent-1');
+  });
+
+  it('resolves an active group without reading the ConversationStore provider', () => {
+    mocks.chatState.activeGroupId = 'group-1';
+    mocks.groupState.groupMap = {
+      'group-1': { id: 'group-1', visibility: 'public' },
+    };
+
+    const { result } = renderHook(() => useActiveConversationResourceAccess());
+
+    expect(result.current.isGroupContext).toBe(true);
+    expect(mocks.conversationStore).not.toHaveBeenCalled();
+    expect(mocks.useResourceAccess).toHaveBeenCalledWith('agentGroup', 'group-1');
+  });
+});

--- a/src/features/Conversation/hooks/useConversationResourceAccess.ts
+++ b/src/features/Conversation/hooks/useConversationResourceAccess.ts
@@ -6,24 +6,19 @@ import { useAgentStore } from '@/store/agent';
 import { builtinAgentSelectors } from '@/store/agent/selectors';
 import { useAgentGroupStore } from '@/store/agentGroup';
 import { agentGroupSelectors } from '@/store/agentGroup/selectors';
+import { useChatStore } from '@/store/chat';
 
 import { useConversationStore } from '../store';
 
-/**
- * Per-resource General-access gating for the CURRENT conversation, resolved
- * from the ConversationStore context (the agent, or the group for group
- * conversations). The counterpart of `useChatInputResourceAccess` for
- * surfaces that live outside the ChatInput store tree — message actions,
- * intervention approvals, queue tray, URL/forward auto-send dispatchers.
- *
- * Workspace topics are shared across members, so a `view`-level member can
- * open a teammate's conversation — every mutating affordance must check
- * `canUseResource` before firing. Inbox and private resources are never
- * gated; loading defaults permissive (`isAccessLoading` lets auto-send
- * dispatchers wait for the settled value instead).
- */
-export const useConversationResourceAccess = () => {
-  const [agentId, groupId] = useConversationStore((s) => [s.context?.agentId, s.context?.groupId]);
+interface ConversationResourceTarget {
+  agentId?: string | null;
+  groupId?: string | null;
+}
+
+const useConversationResourceAccessForTarget = ({
+  agentId,
+  groupId,
+}: ConversationResourceTarget) => {
   const isGroupContext = !!groupId;
 
   const inboxAgentId = useAgentStore(builtinAgentSelectors.inboxAgentId);
@@ -45,7 +40,7 @@ export const useConversationResourceAccess = () => {
   const { allowed: canCreateContent } = usePermission('create_content');
   const { canUseResource, isLoading } = useResourceAccess(
     isGroupContext ? 'agentGroup' : 'agent',
-    gatedResourceId,
+    gatedResourceId ?? undefined,
   );
 
   return {
@@ -53,4 +48,34 @@ export const useConversationResourceAccess = () => {
     isAccessLoading: isLoading,
     isGroupContext,
   };
+};
+
+/**
+ * Per-resource General-access gating for the CURRENT conversation, resolved
+ * from the ConversationStore context (the agent, or the group for group
+ * conversations). The counterpart of `useChatInputResourceAccess` for
+ * surfaces that live outside the ChatInput store tree — message actions,
+ * intervention approvals, queue tray, URL/forward auto-send dispatchers.
+ *
+ * Workspace topics are shared across members, so a `view`-level member can
+ * open a teammate's conversation — every mutating affordance must check
+ * `canUseResource` before firing. Inbox and private resources are never
+ * gated; loading defaults permissive (`isAccessLoading` lets auto-send
+ * dispatchers wait for the settled value instead).
+ */
+export const useConversationResourceAccess = () => {
+  const [agentId, groupId] = useConversationStore((s) => [s.context?.agentId, s.context?.groupId]);
+  return useConversationResourceAccessForTarget({ agentId, groupId });
+};
+
+/**
+ * Resource gating for surfaces that render beside, rather than inside, the
+ * active ConversationProvider (for example the Portal pane). The global chat
+ * store owns the same active agent/group coordinates used to build the main
+ * conversation context, so these siblings can resolve access without touching
+ * the provider-scoped ConversationStore.
+ */
+export const useActiveConversationResourceAccess = () => {
+  const [agentId, groupId] = useChatStore((s) => [s.activeAgentId, s.activeGroupId]);
+  return useConversationResourceAccessForTarget({ agentId, groupId });
 };

--- a/src/features/Portal/TopicComments/Composer.tsx
+++ b/src/features/Portal/TopicComments/Composer.tsx
@@ -5,7 +5,7 @@ import { memo, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
-import { useConversationResourceAccess } from '@/features/Conversation/hooks/useConversationResourceAccess';
+import { useActiveConversationResourceAccess } from '@/features/Conversation/hooks/useConversationResourceAccess';
 import { useTopicCommentMutations } from '@/features/TopicComment/hooks';
 import { useEnterToSend } from '@/hooks/useEnterToSend';
 import {
@@ -31,7 +31,7 @@ const Composer = memo<ComposerProps>(
     const { t } = useTranslation('chat');
     const { message } = App.useApp();
     const workspaceId = useActiveWorkspaceId();
-    const { canUseResource } = useConversationResourceAccess();
+    const { canUseResource } = useActiveConversationResourceAccess();
     const key = workspaceId
       ? createTopicCommentDraftKey({ messageId, parentCommentId, topicId, workspaceId })
       : '';


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Regression from #17537.

#### 🔀 Description of Change

Fixes a crash when opening Topic Comments from the conversation working sidebar.

The Topic Comments portal is rendered outside the `ConversationProvider` subtree, but its composer used a resource-access hook that reads the provider-scoped Conversation store. Opening the comments panel therefore threw a missing Zustand provider error.

- Reuses the existing resource-access calculation for an explicit agent/group target.
- Adds an active-conversation variant backed by the global Chat store for portal surfaces.
- Keeps the existing provider-scoped hook for components inside the conversation tree.
- Updates the Topic Comment composer to use the portal-safe hook.
- Adds regressions for agent and group conversations without a Conversation provider.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

1. Open an agent or group conversation with a topic.
2. Click the Topic Comments button in the upper-right working sidebar.
3. Confirm the comments panel opens without a Zustand provider error.
4. Confirm composer permissions still reflect the active agent/group resource.

Validation:

- Focused lint and tests: 2 passed
- Type check: passed

#### 📸 Screenshots / Videos

Not applicable — behavior-only crash fix.

#### 📝 Additional Information

The regression entered `canary` in squash commit `3384fe491e` (#17537). Within the original PR history, the provider-scoped hook call was introduced by `859f9e5018`.
