### PR TITLE
🐛 fix(i18n): restore CI translations and English fallback

### DIFF
--- a/.agents/skills/i18n/SKILL.md
+++ b/.agents/skills/i18n/SKILL.md
@@ -9,7 +9,7 @@ user-invocable: false
 - Default language: English (en-US)
 - Framework: react-i18next
 - **Only edit files in `packages/locales/src/default/`** - Never edit JSON files in `locales/` (except hand-written en-US/zh-CN previews)
-- Run `bun run i18n` to generate translations (or manually translate zh-CN/en-US for dev preview)
+- Leave generated locales to the daily `auto-i18n.yml` workflow by default; run `bun run i18n` manually only when they are needed immediately
 
 ## Key Naming Convention
 
@@ -54,7 +54,8 @@ export default {
 1. Add keys to `packages/locales/src/default/{namespace}.ts`
 2. Export new namespace in `packages/locales/src/default/index.ts`
 3. For dev preview: manually translate `locales/zh-CN/{namespace}.json` and `locales/en-US/{namespace}.json`
-4. Remind the user to run `bun run i18n` before creating PR — do NOT run it yourself (very slow)
+4. Leave all other locales to `.github/workflows/auto-i18n.yml`, which runs daily and opens an automated translation PR
+5. Run `bun run i18n` manually only when the branch needs those translations immediately; it is slow and requires `OPENAI_API_KEY`
 
 ## Usage
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,8 +125,9 @@ bun run check [changed-files...]
 ### i18n
 
 - Add keys to a namespace file under `packages/locales/src/default/` (e.g. `agent.ts`, `auth.ts`)
-- Hand-write en-US + zh-CN for dev preview: author the English source in `packages/locales/src/default/*.ts`, mirror it to `locales/en-US/`, and hand-translate `locales/zh-CN/`.
-- Before opening the PR, run `bun run i18n` (slow) to fill the remaining locales with the script — don't hand-translate those.
+- Ship en-US and zh-CN by hand in the same PR: author the English source in `packages/locales/src/default/*.ts`, mirror it to `locales/en-US/`, and hand-translate `locales/zh-CN/`.
+- Leave all other locales to the daily CI workflow (`.github/workflows/auto-i18n.yml`), which runs `bun run i18n` and opens an automated translation PR. Missing locale keys fall back to English until that PR is merged.
+- Run `bun run i18n` manually only when the translated locales are needed immediately instead of waiting for the daily workflow. It is slow and requires `OPENAI_API_KEY`; don't hand-translate the generated locales.
 
 ### Code Style
 

--- a/src/libs/i18n/serverTranslation.test.ts
+++ b/src/libs/i18n/serverTranslation.test.ts
@@ -98,6 +98,12 @@ describe('translation', () => {
     expect(t('nested.key')).toBe('Nested value');
   });
 
+  it('should fallback to the default locale when a locale file is missing a key', async () => {
+    const { t } = await translation('common', 'fr-FR');
+
+    expect(t('key2', { param: 'fallback' })).toBe('Value 2 with fallback');
+  });
+
   it('should handle multiple parameters in translation string', async () => {
     const { t } = await translation('common', 'en-US');
     expect(t('multiParam', { name: 'John', count: '5' })).toBe('Hello John, you have 5 messages');

--- a/src/libs/i18n/serverTranslation.ts
+++ b/src/libs/i18n/serverTranslation.ts
@@ -10,26 +10,33 @@ export const getLocale = async (hl?: string): Promise<Locales> => {
 };
 
 export const translation = async (ns: NS = 'common', hl: string) => {
+  let defaultI18ns: Record<string, string> = {};
   let i18ns: Record<string, string> = {};
   const lng = await getLocale(hl);
 
-  const loadTranslations = async () => {
-    // Keep the same fallback rule as `src/locales/create.ts`:
-    // - DEFAULT_LANG loads from `src/locales/default`
-    // - other languages load from `locales/<lng>/*.json`, and fallback to default if missing
+  const loadTranslations = async (locale: string) => {
     return loadI18nNamespaceModuleWithFallback({
       defaultLang: DEFAULT_LANG,
-      lng,
+      lng: locale,
       normalizeLocale,
       ns,
       onFallback: () => {
-        console.warn(`Translation file for ${lng}/${ns} not found, falling back to default`);
+        console.warn(`Translation file for ${locale}/${ns} not found, falling back to default`);
       },
     });
   };
 
   try {
-    i18ns = unwrapESMModule(await loadTranslations());
+    const defaultTranslationsPromise = loadTranslations(DEFAULT_LANG);
+    const localeTranslationsPromise =
+      lng === DEFAULT_LANG ? defaultTranslationsPromise : loadTranslations(lng);
+    const [defaultTranslations, localeTranslations] = await Promise.all([
+      defaultTranslationsPromise,
+      localeTranslationsPromise,
+    ]);
+
+    defaultI18ns = unwrapESMModule(defaultTranslations);
+    i18ns = unwrapESMModule(localeTranslations);
   } catch (e) {
     console.error('Error while reading translation file', e);
   }
@@ -38,7 +45,7 @@ export const translation = async (ns: NS = 'common', hl: string) => {
     locale: lng,
     t: (key: string, options: { [key: string]: string } = {}) => {
       if (!i18ns) return key;
-      let content = i18ns[key];
+      let content = i18ns[key] || defaultI18ns[key];
       if (!content) return key;
       if (options) {
         Object.entries(options).forEach(([k, value]) => {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No related issue found.

#### 🔀 Description of Change

- Restore the intended i18n contribution workflow: feature PRs maintain the default source, en-US, and zh-CN, while the daily `auto-i18n.yml` workflow generates the remaining locales in a dedicated PR.
- Keep the agent i18n skill aligned with the repository guidance so automated reviews no longer require all generated locale files in every feature PR.
- Make server-side translations fall back per key to the English default catalog while an automated translation PR is pending. Localized values still take precedence, and keys missing from both catalogs keep the existing raw-key fallback.
- Load the default and requested locale catalogs concurrently to avoid adding serial I/O latency.

#### 🧪 How to Test

```bash
bun run check src/libs/i18n/serverTranslation.ts src/libs/i18n/serverTranslation.test.ts
```

Result: `2 files · lint clean · tests 14 passed`

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

Not applicable; no UI changes.

#### 📝 Additional Information

The browser i18next setup already falls back to en-US. This change brings the lightweight server translator in line with that behavior for locale files that exist but are temporarily missing newly added keys.
