### PR TITLE
✅ test(database): stabilize topic comment pagination

### DIFF
--- a/packages/database/src/models/__tests__/topicComment.test.ts
+++ b/packages/database/src/models/__tests__/topicComment.test.ts
@@ -880,18 +880,24 @@ describe('TopicCommentModel', () => {
 
       const base = new Date('2026-01-01T10:00:00Z');
       const later = new Date('2026-01-02T10:00:00Z');
+      // Fixed lowercase IDs keep JavaScript and PostgreSQL collations aligned
+      // while the shared timestamp still exercises the id tie-breaker.
+      const firstReplyId = 'tcm_list_reply_a';
+      const secondReplyId = 'tcm_list_reply_b';
+      const thirdReplyId = 'tcm_list_reply_c';
       await serverDB
         .update(topicComments)
-        .set({ createdAt: base })
+        .set({ createdAt: base, id: firstReplyId })
         .where(eq(topicComments.id, replies[0].comment.id));
       await serverDB
         .update(topicComments)
-        .set({ createdAt: later })
-        .where(inArray(topicComments.id, [replies[1].comment.id, replies[2].comment.id]));
-      const expectedOrder = [
-        replies[0].comment.id,
-        ...[replies[1].comment.id, replies[2].comment.id].sort(),
-      ];
+        .set({ createdAt: later, id: secondReplyId })
+        .where(eq(topicComments.id, replies[1].comment.id));
+      await serverDB
+        .update(topicComments)
+        .set({ createdAt: later, id: thirdReplyId })
+        .where(eq(topicComments.id, replies[2].comment.id));
+      const expectedOrder = [firstReplyId, secondReplyId, thirdReplyId];
 
       const page1 = await authorModel.listReplies({ limit: 2, rootCommentId: root.comment.id });
       expect(page1.items.map((reply) => reply.id)).toEqual(expectedOrder.slice(0, 2));


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Follow-up to #17605.

#### 🔀 Description of Change

- Replace random mixed-case IDs in the topic-comment reply pagination test with deterministic lowercase IDs.
- Avoid comparing JavaScript UTF-16 ordering with PostgreSQL `en_US.utf8` collation ordering.
- Preserve coverage for the `(createdAt, id)` tie-breaker and pagination after the cursor row is deleted.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check packages/database/src/models/__tests__/topicComment.test.ts
```

Result: lint clean, 62 tests passed.

#### 📸 Screenshots / Videos

Not applicable (test-only change).

#### 📝 Additional Information

No production behavior changes.