### PR TITLE
✨ feat: support Claude Opus 5

### DIFF
--- a/packages/locales/src/default/models.ts
+++ b/packages/locales/src/default/models.ts
@@ -10,8 +10,6 @@ LOBE_DEFAULT_MODEL_LIST.forEach((model) => {
 
 // #region LobeHub online model descriptions
 const lobeHubOnlineModelLocales = {
-  'claude-opus-5.description':
-    "Claude Opus 5 is Anthropic's strongest Opus model, built for deep reasoning, agentic coding, and long-horizon professional work.",
   'dreamina-seedance-2-0-260128.description':
     'Seedance 2.0 by ByteDance is the most powerful video generation model, supporting multimodal reference video generation, video editing, video extension, text-to-video, and image-to-video with synchronized audio.',
   'dreamina-seedance-2-0-fast-260128.description':

--- a/packages/model-bank/src/aiModels/anthropic.ts
+++ b/packages/model-bank/src/aiModels/anthropic.ts
@@ -45,6 +45,40 @@ const anthropicChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_000_000,
     description:
+      "Claude Opus 5 is Anthropic's strongest Opus model, built for deep reasoning, agentic coding, and long-horizon professional work.",
+    displayName: 'Claude Opus 5',
+    enabled: true,
+    family: 'claude-opus',
+    generation: 'claude-5',
+    id: 'claude-opus-5',
+    knowledgeCutoff: '2026-05',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheWrite', rate: 6.25, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-07-24',
+    settings: {
+      disabledParams: ['temperature', 'top_p'],
+      extendParams: ['disableContextCaching', 'enableAdaptiveThinking', 'opus47Effort'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_000_000,
+    description:
       "Claude Sonnet 5 is Anthropic's most agentic Sonnet model, built for sustained coding, tool use, and long-context workflows with Sonnet-tier speed and efficiency.",
     displayName: 'Claude Sonnet 5',
     enabled: true,

--- a/packages/model-bank/src/const/knowledgeCutoff.ts
+++ b/packages/model-bank/src/const/knowledgeCutoff.ts
@@ -25,6 +25,7 @@ export const MODEL_KNOWLEDGE_CUTOFFS: Record<string, string> = {
   'claude-opus-4-6': '2025-05',
   'claude-opus-4-7': '2026-01',
   'claude-opus-4-8': '2026-01',
+  'claude-opus-5': '2026-05',
   'claude-sonnet-4': '2025-01',
   'claude-sonnet-4-5': '2025-01',
   'claude-sonnet-4-6': '2025-05',

--- a/packages/model-runtime/src/providers/anthropic/modelId.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/modelId.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   hasTemperatureTopPConflict,
+  isAdaptiveThinkingDefaultOnModel,
   isContextCachingModel,
   isThinkingWithToolClaudeModel,
   parseClaudeModelId,
@@ -114,6 +115,25 @@ describe('isThinkingWithToolClaudeModel', () => {
   it('should preserve existing false cases', () => {
     expect(isThinkingWithToolClaudeModel('claude-3-5-sonnet-20240620')).toBe(false);
     expect(isThinkingWithToolClaudeModel('gpt-4o')).toBe(false);
+  });
+});
+
+describe('isAdaptiveThinkingDefaultOnModel', () => {
+  it('should return true for Claude 5 ids across provider spellings', () => {
+    expect(isAdaptiveThinkingDefaultOnModel('claude-opus-5')).toBe(true);
+    expect(isAdaptiveThinkingDefaultOnModel('claude-sonnet-5')).toBe(true);
+    expect(isAdaptiveThinkingDefaultOnModel('claude-fable-5')).toBe(true);
+    expect(isAdaptiveThinkingDefaultOnModel('claude-opus-5-fast')).toBe(true);
+    expect(isAdaptiveThinkingDefaultOnModel('anthropic/claude-opus-5')).toBe(true);
+    expect(isAdaptiveThinkingDefaultOnModel('global.anthropic.claude-opus-5')).toBe(true);
+  });
+
+  it('should return false for Claude 4.x and non-Claude ids', () => {
+    expect(isAdaptiveThinkingDefaultOnModel('claude-opus-4-8')).toBe(false);
+    expect(isAdaptiveThinkingDefaultOnModel('claude-opus-4-7')).toBe(false);
+    expect(isAdaptiveThinkingDefaultOnModel('claude-sonnet-4.6')).toBe(false);
+    expect(isAdaptiveThinkingDefaultOnModel('claude-haiku-4-5-20251001')).toBe(false);
+    expect(isAdaptiveThinkingDefaultOnModel('gpt-5')).toBe(false);
   });
 });
 

--- a/packages/model-runtime/src/providers/anthropic/modelId.ts
+++ b/packages/model-runtime/src/providers/anthropic/modelId.ts
@@ -129,6 +129,17 @@ export const isThinkingWithToolClaudeModel = (model: string): boolean => {
   );
 };
 
+/**
+ * Claude 5 and later think by default — omitting `thinking` runs adaptive, whereas on
+ * Opus 4.8 / 4.7 omitting it meant no thinking. Callers mirror this in the UI so a fresh
+ * config doesn't silently disable thinking on models that ship it on.
+ * @see https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
+ */
+export const isAdaptiveThinkingDefaultOnModel = (model: string): boolean => {
+  const parsed = parseClaudeModelId(model);
+  return !!parsed && parsed.majorVersion >= 5;
+};
+
 export const hasTemperatureTopPConflict = (model: string): boolean => {
   const parsed = parseClaudeModelId(model);
   return !!parsed && parsed.majorVersion >= 4;

--- a/packages/model-runtime/src/utils/modelExtendParams.test.ts
+++ b/packages/model-runtime/src/utils/modelExtendParams.test.ts
@@ -218,7 +218,23 @@ describe('applyModelExtendParams', () => {
 describe('resolveDefaultEnableAdaptiveThinkingForModel', () => {
   it('uses per-model defaults', () => {
     expect(resolveDefaultEnableAdaptiveThinkingForModel('claude-sonnet-5')).toBe(true);
+    expect(resolveDefaultEnableAdaptiveThinkingForModel('claude-opus-5')).toBe(true);
+    expect(resolveDefaultEnableAdaptiveThinkingForModel('claude-fable-5')).toBe(true);
     expect(resolveDefaultEnableAdaptiveThinkingForModel('claude-opus-4-8')).toBeUndefined();
+    expect(resolveDefaultEnableAdaptiveThinkingForModel('claude-haiku-4-5')).toBeUndefined();
+    expect(resolveDefaultEnableAdaptiveThinkingForModel('gpt-5')).toBeUndefined();
+    expect(resolveDefaultEnableAdaptiveThinkingForModel()).toBeUndefined();
+  });
+
+  // The previous hard-coded id map only matched bare ids, so the same model served under a
+  // provider-prefixed or dotted id silently lost its default and started with thinking off.
+  it('resolves the default across provider id spellings', () => {
+    expect(resolveDefaultEnableAdaptiveThinkingForModel('anthropic/claude-opus-5')).toBe(true);
+    expect(resolveDefaultEnableAdaptiveThinkingForModel('global.anthropic.claude-opus-5')).toBe(
+      true,
+    );
+    expect(resolveDefaultEnableAdaptiveThinkingForModel('claude-opus-5-fast')).toBe(true);
+    expect(resolveDefaultEnableAdaptiveThinkingForModel('claude-sonnet-4.6')).toBeUndefined();
   });
 });
 

--- a/packages/model-runtime/src/utils/modelExtendParams.ts
+++ b/packages/model-runtime/src/utils/modelExtendParams.ts
@@ -1,6 +1,8 @@
 import type { LobeAgentChatConfig } from '@lobechat/types';
 import type { ExtendParamsType } from 'model-bank';
 
+import { isAdaptiveThinkingDefaultOnModel } from '../providers/anthropic/modelId';
+
 /**
  * Extended parameters for model runtime
  */
@@ -63,10 +65,6 @@ const MODEL_THINKING_LEVEL_DEFAULTS: Partial<
   },
 } as const;
 
-const MODEL_ENABLE_ADAPTIVE_THINKING_DEFAULTS: Partial<Record<string, boolean>> = {
-  'claude-sonnet-5': true,
-} as const;
-
 /**
  * Preserves legacy `thinking` preferences for users created before `enableReasoning`.
  * Without this fallback, an old `thinking: 'enabled'` or `thinking: 'disabled'`
@@ -101,12 +99,17 @@ export const resolveDefaultThinkingLevelForModel = (model?: string): ThinkingLev
   return resolveThinkingLevelDefault(model, 'thinkingLevel');
 };
 
+/**
+ * Returns `true` for models that ship adaptive thinking on, `undefined` when the model has
+ * no opinion — `false` is intentionally never returned, since it would read as an explicit
+ * opt-out rather than "no default".
+ */
 export const resolveDefaultEnableAdaptiveThinkingForModel = (
   model?: string,
 ): boolean | undefined => {
   if (!model) return;
 
-  return MODEL_ENABLE_ADAPTIVE_THINKING_DEFAULTS[model];
+  return isAdaptiveThinkingDefaultOnModel(model) || undefined;
 };
 
 export interface ApplyModelExtendParamsContext {
@@ -192,7 +195,7 @@ export const applyModelExtendParams = (ctx: ApplyModelExtendParamsContext): Mode
       chatConfig.enableAdaptiveThinking === false &&
       !modelExtendParams.includes('enableReasoning')
     ) {
-      // Claude Sonnet 5 defaults adaptive thinking on; fresh configs used to
+      // Claude 5 and later default adaptive thinking on; fresh configs used to
       // serialize as `{ thinking: { type: 'disabled' } }` and override that.
       extendParams.thinking = {
         type: 'disabled',


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Follow-up to #17582, which added Claude Opus 5 runtime support but explicitly left static provider model cards out of scope.

#### 🔀 Description of Change

Two things:

**1. Add the `claude-opus-5` model card to the Anthropic provider.**

Placed above Sonnet 5, matching the ordering in Anthropic's "latest models" table. All values come from the official docs:

| Field | Value |
| --- | --- |
| Context / max output | 1M / 128K |
| Pricing (per MTok) | $5 in / $25 out, cacheRead 0.5, cacheWrite 6.25 — identical to Opus 4.8 |
| `knowledgeCutoff` | `2026-05` (reliable knowledge cutoff) |
| `releasedAt` | `2026-07-24` |
| `settings` | same as Opus 4.7+ — `opus47Effort` already covers the full `low`→`max` ladder |

The description was already shipped in #17582 as a manual `lobeHubOnlineModelLocales` override; it now lives on the model card instead. That override block is `Object.assign`-ed *after* the model-list loop, so leaving it in place would shadow the card. The text is unchanged, so `locales/en-US/models.json` and `locales/zh-CN/models.json` need no regeneration.

**2. Fix the adaptive-thinking default lookup (drive-by bug fix).**

Claude 5 and later think by default — omitting `thinking` runs adaptive, whereas on Opus 4.8 / 4.7 omitting it meant no thinking. `MODEL_ENABLE_ADAPTIVE_THINKING_DEFAULTS` mirrored that in the UI, but as a hard-coded literal id map it only matched bare ids. The same model served under any other spelling silently lost the default and started with thinking **off**:

- `anthropic/claude-opus-5` — OpenRouter (`openrouter.ts` already uses `anthropic/claude-opus-4.5`)
- `global.anthropic.claude-opus-5` — Bedrock
- `claude-opus-5-fast` — GitHub Copilot (`githubCopilot.ts` already ships `claude-opus-4.6-fast`, and those cards carry `enableAdaptiveThinking`)

Replaced with `isAdaptiveThinkingDefaultOnModel` in `providers/anthropic/modelId.ts`, which reuses `parseClaudeModelId` and follows the same `majorVersion >= 5` shape as the neighbouring `isContextCachingModel` / `shouldOmitSamplingParams` / `shouldDropUnsupportedClaudeAssistantPrefill` predicates. The public `resolveDefaultEnableAdaptiveThinkingForModel` signature and its call sites are unchanged.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

`bun run check` on the touched files: lint clean, 82 tests passed. Plus `parameterResolver` / `bedrock` / `modelExtendParams` / `modelId` (150 passed) and `ControlsForm.test.tsx` (3 passed) as regression.

New assertions cover the generation rule end to end: Opus 5 / Sonnet 5 / Fable 5 → on; Opus 4.8 / 4.7 / Haiku 4.5 / non-Claude → unchanged; and the three id spellings above that the old map missed.

Manual check: select Claude Opus 5 in the model switcher — the model card shows 1M context and $5/$25 pricing, and adaptive thinking defaults to on for a fresh config.

#### 📝 Additional Information

**Key decisions / non-goals**

- **`majorVersion >= 5` is deliberately forward-extrapolating.** Every other predicate in `modelId.ts` already returns `true` for unseen Claude 5+ ids, so a future `claude-haiku-5` inherits the default rather than silently regressing. Verified against the docs for every currently released model.
- **`resolveDefaultEnableAdaptiveThinkingForModel` still returns `true | undefined`, never `false`.** `false` would read as an explicit user opt-out rather than "this model has no default", so the predicate result is narrowed with `|| undefined`. Added a comment since this is easy to "simplify" incorrectly.
- **`aiModels/bedrock.ts` intentionally untouched.** Its Claude list still stops at Opus 4.7 — Opus 4.8, Sonnet 5 and Fable 5 are all missing. Adding only Opus 5 there would leave it more inconsistent, not less; catching that file up is its own PR.
- **The home starter-model slots are not changed.** Which models get promoted there is a product call, not a consequence of onboarding a model card.