### PR TITLE
🐛 fix(agent-runtime): enable provider builtin search

### DIFF
--- a/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -46,6 +46,11 @@ const mockBuiltinModels = vi.hoisted(() => [
     providerId: 'google',
     settings: { extendParams: ['preserveThinking'] },
   },
+  {
+    abilities: { functionCall: true, search: true, video: false, vision: true },
+    id: 'grok-4.5',
+    providerId: 'supergrok',
+  },
 ]);
 
 // Mock dependencies
@@ -364,6 +369,40 @@ describe('RuntimeExecutors', { timeout: 60_000 }, () => {
         'user-123',
         'openai',
         'ws-1',
+      );
+    });
+
+    it('enables provider builtin search for supported models in the server runtime', async () => {
+      const mockChat = vi.fn().mockImplementation(async (_payload: any, options: any) => {
+        await options?.callback?.onText?.('done');
+        return new Response('done');
+      });
+      vi.mocked(initModelRuntimeFromDB).mockResolvedValueOnce({ chat: mockChat } as any);
+      const executors = createRuntimeExecutors({
+        ...ctx,
+        agentConfig: {
+          chatConfig: { searchMode: 'auto', useModelBuiltinSearch: true },
+          plugins: [],
+          systemRole: 'test',
+        },
+      });
+
+      await executors.call_llm!(
+        {
+          payload: {
+            messages: [{ content: 'Search X', role: 'user' }],
+            model: 'grok-4.5',
+            provider: 'supergrok',
+            tools: [],
+          },
+          type: 'call_llm',
+        },
+        createMockState(),
+      );
+
+      expect(mockChat).toHaveBeenCalledWith(
+        expect.objectContaining({ enabledSearch: true }),
+        expect.anything(),
       );
     });
 

--- a/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -406,6 +406,40 @@ describe('RuntimeExecutors', { timeout: 60_000 }, () => {
       );
     });
 
+    it('enables provider builtin search for unbundled OpenRouter models', async () => {
+      const mockChat = vi.fn().mockImplementation(async (_payload: any, options: any) => {
+        await options?.callback?.onText?.('done');
+        return new Response('done');
+      });
+      vi.mocked(initModelRuntimeFromDB).mockResolvedValueOnce({ chat: mockChat } as any);
+      const executors = createRuntimeExecutors({
+        ...ctx,
+        agentConfig: {
+          chatConfig: { searchMode: 'auto', useModelBuiltinSearch: true },
+          plugins: [],
+          systemRole: 'test',
+        },
+      });
+
+      await executors.call_llm!(
+        {
+          payload: {
+            messages: [{ content: 'Search the web', role: 'user' }],
+            model: 'vendor/unbundled-model',
+            provider: 'openrouter',
+            tools: [],
+          },
+          type: 'call_llm',
+        },
+        createMockState(),
+      );
+
+      expect(mockChat).toHaveBeenCalledWith(
+        expect.objectContaining({ enabledSearch: true }),
+        expect.anything(),
+      );
+    });
+
     it('should restrict context tools to allowedToolNames', async () => {
       const toolNameResolver = new ToolNameResolver();
       const readToolName = toolNameResolver.generate('workspace', 'read', 'builtin');

--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextHints.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextHints.ts
@@ -9,6 +9,7 @@ import {
 } from '@lobechat/model-runtime';
 import type { UIChatMessage } from '@lobechat/types';
 import { type ExtendParamsType, ModelProvider } from 'model-bank';
+import { isProviderHasBuiltinSearch } from 'model-bank/modelProviders';
 
 import { AiModelModel } from '@/database/models/aiModel';
 
@@ -106,6 +107,7 @@ export const resolveServerCallLlmContextHints = async ({
     modelCard?.abilities?.search ??
     (provider === ModelProvider.LobeHub ? canonicalModelCard?.abilities?.search : false) ??
     false;
+  const supportsBuiltinSearch = isProviderHasBuiltinSearch(provider) || modelSupportsBuiltinSearch;
 
   const modelSupportsPreserveThinkingFromCard =
     Array.isArray(modelExtendParams) && modelExtendParams.includes('preserveThinking');
@@ -157,7 +159,7 @@ export const resolveServerCallLlmContextHints = async ({
         }),
         ...(agentConfig.chatConfig.searchMode !== 'off' &&
           agentConfig.chatConfig.useModelBuiltinSearch === true &&
-          modelSupportsBuiltinSearch && { enabledSearch: true }),
+          supportsBuiltinSearch && { enabledSearch: true }),
       }
     : undefined;
 

--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextHints.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextHints.ts
@@ -33,7 +33,7 @@ export interface ServerCallLlmContextHints {
   modelDisplayName?: string;
   modelKnowledgeCutoff?: string;
   preserveThinkingForPayload?: boolean;
-  resolvedExtendParams?: ModelExtendParams;
+  resolvedExtendParams?: ModelExtendParams & { enabledSearch?: boolean };
   shouldReplayAssistantReasoning: boolean;
 }
 
@@ -102,6 +102,11 @@ export const resolveServerCallLlmContextHints = async ({
     modelExtendParams = readExtendParams(canonicalModelCard);
   }
 
+  const modelSupportsBuiltinSearch =
+    modelCard?.abilities?.search ??
+    (provider === ModelProvider.LobeHub ? canonicalModelCard?.abilities?.search : false) ??
+    false;
+
   const modelSupportsPreserveThinkingFromCard =
     Array.isArray(modelExtendParams) && modelExtendParams.includes('preserveThinking');
   // Kimi K2.7+ Code has preserved thinking always active and cannot opt out.
@@ -144,11 +149,16 @@ export const resolveServerCallLlmContextHints = async ({
       : undefined;
 
   const resolvedExtendParams = agentConfig?.chatConfig
-    ? applyModelExtendParams({
-        chatConfig: agentConfig.chatConfig,
-        extendParams: modelExtendParams as ExtendParamsType[] | undefined,
-        model,
-      })
+    ? {
+        ...applyModelExtendParams({
+          chatConfig: agentConfig.chatConfig,
+          extendParams: modelExtendParams as ExtendParamsType[] | undefined,
+          model,
+        }),
+        ...(agentConfig.chatConfig.searchMode !== 'off' &&
+          agentConfig.chatConfig.useModelBuiltinSearch === true &&
+          modelSupportsBuiltinSearch && { enabledSearch: true }),
+      }
     : undefined;
 
   const messagesForContext = shouldReplayAssistantReasoning

--- a/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
@@ -256,6 +256,48 @@ describe('createServerAgentToolsEngine', () => {
     expect(result.enabledToolIds).not.toContain(WebBrowsingManifest.identifier);
   });
 
+  it('should disable WebBrowsing when provider builtin search is selected', () => {
+    const context = createMockContext();
+    const engine = createServerAgentToolsEngine(context, {
+      agentConfig: {
+        plugins: [WebBrowsingManifest.identifier],
+        chatConfig: { searchMode: 'auto', useModelBuiltinSearch: true },
+      },
+      model: 'grok-4.5',
+      modelAbilities: { functionCall: true, search: true },
+      provider: 'supergrok',
+    });
+
+    const result = engine.generateToolsDetailed({
+      toolIds: [WebBrowsingManifest.identifier],
+      model: 'grok-4.5',
+      provider: 'supergrok',
+    });
+
+    expect(result.enabledToolIds).not.toContain(WebBrowsingManifest.identifier);
+  });
+
+  it('should fall back to WebBrowsing when the model lacks builtin search', () => {
+    const context = createMockContext();
+    const engine = createServerAgentToolsEngine(context, {
+      agentConfig: {
+        plugins: [WebBrowsingManifest.identifier],
+        chatConfig: { searchMode: 'auto', useModelBuiltinSearch: true },
+      },
+      model: 'gpt-4',
+      modelAbilities: { functionCall: true, search: false },
+      provider: 'openai',
+    });
+
+    const result = engine.generateToolsDetailed({
+      toolIds: [WebBrowsingManifest.identifier],
+      model: 'gpt-4',
+      provider: 'openai',
+    });
+
+    expect(result.enabledToolIds).toContain(WebBrowsingManifest.identifier);
+  });
+
   it('should enable ImageGeneration in chat mode when model lacks native image output', () => {
     const context = createMockContext();
     const engine = createServerAgentToolsEngine(context, {

--- a/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
@@ -277,6 +277,26 @@ describe('createServerAgentToolsEngine', () => {
     expect(result.enabledToolIds).not.toContain(WebBrowsingManifest.identifier);
   });
 
+  it('should disable WebBrowsing for unbundled models when the provider supports builtin search', () => {
+    const context = createMockContext();
+    const engine = createServerAgentToolsEngine(context, {
+      agentConfig: {
+        plugins: [WebBrowsingManifest.identifier],
+        chatConfig: { searchMode: 'auto', useModelBuiltinSearch: true },
+      },
+      model: 'vendor/unbundled-model',
+      provider: 'openrouter',
+    });
+
+    const result = engine.generateToolsDetailed({
+      toolIds: [WebBrowsingManifest.identifier],
+      model: 'vendor/unbundled-model',
+      provider: 'openrouter',
+    });
+
+    expect(result.enabledToolIds).not.toContain(WebBrowsingManifest.identifier);
+  });
+
   it('should fall back to WebBrowsing when the model lacks builtin search', () => {
     const context = createMockContext();
     const engine = createServerAgentToolsEngine(context, {

--- a/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
@@ -208,6 +208,11 @@ export const createServerAgentToolsEngine = (
 
   const searchMode = agentConfig.chatConfig?.searchMode ?? 'auto';
   const isSearchEnabled = searchMode !== 'off';
+  const useModelBuiltinSearch =
+    isSearchEnabled &&
+    agentConfig.chatConfig?.useModelBuiltinSearch === true &&
+    modelAbilities?.search === true;
+  const useApplicationBuiltinSearch = isSearchEnabled && !useModelBuiltinSearch;
   const imageGenerationEnabled =
     context.isModelSupportToolUse(model, provider) && !modelAbilities?.imageOutput;
   // Tool mode: explicit `toolMode` wins; otherwise derive from `enableAgentMode`
@@ -240,7 +245,7 @@ export const createServerAgentToolsEngine = (
     [ImageGenerationManifest.identifier]: imageGenerationEnabled,
     [KnowledgeBaseManifest.identifier]: hasEnabledKnowledgeBases,
     [MemoryManifest.identifier]: globalMemoryEnabled,
-    [WebBrowsingManifest.identifier]: isSearchEnabled,
+    [WebBrowsingManifest.identifier]: useApplicationBuiltinSearch,
   };
 
   // Custom mode: the tool set is EXACTLY the agent's declared plugins — no
@@ -295,7 +300,7 @@ export const createServerAgentToolsEngine = (
     // degrades denied targets to `none` (→ not deviceCapable) and the
     // physical walls drop it for `canUseDevice=false` turns.
     [RemoteDeviceManifest.identifier]: deviceCapable && hasDeviceProxy && !deviceLocked,
-    [WebBrowsingManifest.identifier]: isSearchEnabled,
+    [WebBrowsingManifest.identifier]: useApplicationBuiltinSearch,
   };
 
   const excludedIdentifiers = new Set(disabledPluginIds);

--- a/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
@@ -33,6 +33,7 @@ import {
   type RuntimePlatform,
 } from '@lobechat/types';
 import debug from 'debug';
+import { isProviderHasBuiltinSearch } from 'model-bank/modelProviders';
 
 import {
   executionTargetToRuntimeMode,
@@ -211,7 +212,7 @@ export const createServerAgentToolsEngine = (
   const useModelBuiltinSearch =
     isSearchEnabled &&
     agentConfig.chatConfig?.useModelBuiltinSearch === true &&
-    modelAbilities?.search === true;
+    (isProviderHasBuiltinSearch(provider) || modelAbilities?.search === true);
   const useApplicationBuiltinSearch = isSearchEnabled && !useModelBuiltinSearch;
   const imageGenerationEnabled =
     context.isModelSupportToolUse(model, provider) && !modelAbilities?.imageOutput;

--- a/apps/server/src/modules/Mecha/AgentToolsEngine/types.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/types.ts
@@ -79,6 +79,7 @@ export interface ServerCreateAgentToolsEngineParams {
        */
       enableAgentMode?: boolean;
       searchMode?: 'off' | 'on' | 'auto';
+      useModelBuiltinSearch?: boolean;
       /**
        * Overrides the `enableAgentMode` derivation. `custom` = the toolset is
        * exactly the agent's declared plugins (focused builtin sub-agents).

--- a/packages/model-bank/src/modelProviders/index.test.ts
+++ b/packages/model-bank/src/modelProviders/index.test.ts
@@ -4,6 +4,7 @@ import { type ModelProviderCard } from '../types';
 import {
   DEFAULT_MODEL_PROVIDER_LIST,
   isProviderDisableBrowserRequest,
+  isProviderHasBuiltinSearch,
   isProviderOAuthDeviceFlow,
 } from './index';
 
@@ -25,6 +26,7 @@ describe('model provider predicates', () => {
       createProvider({ id: 'root-disabled', disableBrowserRequest: true }),
       createProvider({ id: 'settings-disabled', settings: { disableBrowserRequest: true } }),
       createProvider({ id: 'oauth-provider', settings: { authType: 'oauthDeviceFlow' } }),
+      createProvider({ id: 'search-provider', settings: { searchMode: 'params' } }),
       createProvider({ id: 'enabled-provider' }),
     );
   });
@@ -48,6 +50,12 @@ describe('model provider predicates', () => {
 
   it('returns false for unknown provider id', () => {
     expect(isProviderDisableBrowserRequest('not-exists')).toBe(false);
+  });
+
+  it('detects providers with builtin search', () => {
+    expect(isProviderHasBuiltinSearch('search-provider')).toBe(true);
+    expect(isProviderHasBuiltinSearch('enabled-provider')).toBe(false);
+    expect(isProviderHasBuiltinSearch('not-exists')).toBe(false);
   });
 
   it('detects OAuth device flow providers', () => {

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -240,6 +240,11 @@ export const isProviderDisableBrowserRequest = (id: string) => {
   return !!provider;
 };
 
+export const isProviderHasBuiltinSearch = (id: string) =>
+  DEFAULT_MODEL_PROVIDER_LIST.some(
+    (provider) => provider.id === id && !!provider.settings?.searchMode,
+  );
+
 export const isProviderOAuthDeviceFlow = (id?: string) =>
   DEFAULT_MODEL_PROVIDER_LIST.some(
     (provider) => provider.id === id && provider.settings?.authType === 'oauthDeviceFlow',


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Server-side agent runs ignored `useModelBuiltinSearch`: supported providers such as SuperGrok did not receive `enabledSearch`, while the Lobe Web Browsing tool was still injected instead.

This change:

- propagates `enabledSearch: true` when provider search is selected and either the model card or provider configuration supports native search;
- honors provider-wide search for unbundled models, including OpenRouter's `settings.searchMode` capability;
- avoids injecting the application Web Browsing tool when provider-native search is active;
- preserves the application search fallback when neither the provider nor model supports native search;
- keeps `searchMode: off` authoritative for both search paths.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Targeted check:

```bash
bun run check \
  packages/model-bank/src/modelProviders/index.ts \
  packages/model-bank/src/modelProviders/index.test.ts \
  apps/server/src/modules/Mecha/AgentToolsEngine/types.ts \
  apps/server/src/modules/Mecha/AgentToolsEngine/index.ts \
  apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextHints.ts \
  apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts \
  apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
```

Result: lint clean, 203 tests passed. `model-bank` package type-check also passes.

The root type-check remains blocked on `nerdamer-prime/all` declarations in the calculator package; that pre-existing issue is fixed separately in #17611.

#### 📸 Screenshots / Videos

N/A — server runtime behavior only.

#### 📝 Additional Information

No migration or configuration changes are required.
