### PR TITLE
🐛 fix(calculator): type nerdamer all entrypoint

### DIFF
--- a/packages/builtin-tool-calculator/src/calculate.test.ts
+++ b/packages/builtin-tool-calculator/src/calculate.test.ts
@@ -1330,7 +1330,7 @@ describe('Calculator Equation Solver', () => {
       // *any* failure — including a dereference TypeError — into the same
       // `success: false` / `SolveError` pair, so those two alone cannot tell
       // the guarded path from the unguarded one.
-      const spy = vi.spyOn(nerdamer, 'solveEquations').mockReturnValue(null as never);
+      const spy = vi.spyOn(nerdamer, 'solveEquations').mockReturnValue(null);
 
       try {
         const result = await calculatorExecutor.solve({

--- a/packages/builtin-tool-calculator/src/executor/index.ts
+++ b/packages/builtin-tool-calculator/src/executor/index.ts
@@ -1,7 +1,6 @@
 import { BaseExecutor, type BuiltinToolResult, type IBuiltinToolExecutor } from '@lobechat/types';
 import { defBase } from '@thi.ng/base-n/base';
 import { all, create } from 'mathjs';
-// @ts-ignore - nerdamer doesn't have TypeScript definitions
 import nerdamer from 'nerdamer-prime/all';
 
 import {
@@ -50,6 +49,7 @@ class CalculatorExecutor
     } catch (error) {
       throw new Error(
         `Failed to evaluate expression: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        { cause: error },
       );
     }
   }

--- a/packages/builtin-tool-calculator/src/nerdamer-prime.d.ts
+++ b/packages/builtin-tool-calculator/src/nerdamer-prime.d.ts
@@ -1,0 +1,5 @@
+declare module 'nerdamer-prime/all' {
+  import nerdamer = require('nerdamer-prime');
+
+  export = nerdamer;
+}


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

`nerdamer-prime` publishes TypeScript declarations for its package root but not for the `nerdamer-prime/all` entrypoint used by the calculator to load every addon. The production import previously suppressed this gap with `@ts-ignore`; a test import added in #17588 exposed it as TS7016 during the root type-check.

This change:

- declares `nerdamer-prime/all` as the same typed API exported by the package root;
- removes the production `@ts-ignore` and lets the official Nerdamer types cover the executor and tests;
- removes the test's `null as never` workaround because the official `SolveResult` correctly includes `null`;
- preserves the original math evaluation error as `cause`, resolving the existing lint violation surfaced by checking the touched executor.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check packages/builtin-tool-calculator/src/nerdamer-prime.d.ts \
  packages/builtin-tool-calculator/src/executor/index.ts \
  packages/builtin-tool-calculator/src/calculate.test.ts
bun run check --type
```

Result: targeted lint clean and full repository type-check clean.

The calculator package is not matched by the repository's owning Vitest config, so its suite was also run directly with an isolated Node Vitest config: **127 tests passed**.

#### 📸 Screenshots / Videos

N/A — type declaration and error metadata changes only.

#### 📝 Additional Information

No dependency version or runtime loading behavior changes.
