### PR TITLE
chore: remove LOBE-XXX markers from source code comments (2026-07-26)

### DIFF
--- a/packages/agent-gateway-client/src/types.ts
+++ b/packages/agent-gateway-client/src/types.ts
@@ -117,7 +117,7 @@ export interface ToolStateChunkData {
  * uiMessages snapshot is resolved BEFORE this row is created, so the snapshot
  * never contains it — without a local insert, every stream_chunk/stream_end
  * dispatch for the step targets a missing id and is silently dropped
- * (LOBE-11501). Older servers send only `{ id }`; clients fall back to a DB
+ * ). Older servers send only `{ id }`; clients fall back to a DB
  * refetch in that case.
  */
 export interface StreamStartAssistantMessage {

--- a/packages/const/src/rbac.ts
+++ b/packages/const/src/rbac.ts
@@ -305,7 +305,7 @@ const action = (key: keyof typeof PERMISSION_ACTIONS): string => PERMISSION_ACTI
 /**
  * Permission codes granted to each built-in workspace role. The lists are the
  * runtime source of truth: workspace requests expand the member's
- * `workspace_members.role` through this matrix (LOBE-12329) — no
+ * `workspace_members.role` through this matrix — no
  * per-workspace role/permission rows are stored in the RBAC tables.
  *
  * Scope semantics:
@@ -571,7 +571,7 @@ export const legacyRoleToWorkspaceRole = (role: string): WorkspaceSystemRoleName
  * the in-code matrix. This is the runtime permission source for workspace
  * requests — `workspace_members.role` is the single source of truth for
  * built-in roles and no per-workspace role/permission rows are stored in the
- * RBAC tables (LOBE-12329). Unknown roles expand to an empty set.
+ * RBAC tables ). Unknown roles expand to an empty set.
  */
 export const getWorkspaceRolePermissionCodes = (role: string): readonly string[] => {
   const systemRole = legacyRoleToWorkspaceRole(role);

--- a/packages/database/src/models/__tests__/agent.test.ts
+++ b/packages/database/src/models/__tests__/agent.test.ts
@@ -1361,7 +1361,7 @@ describe('AgentModel', () => {
       expect(personalAgent.agencyConfig).toBeNull();
     });
 
-    // LOBE-12374: builtin slugs decide both `getBuiltinAgent` resolution and, for
+ // builtin slugs decide both `getBuiltinAgent` resolution and, for
     // the collaborative ones, workspace-level permissions — a caller-supplied slug
     // must never be able to claim one (group member batch-create, imports, market
     // installs all pass `slug` through).

--- a/packages/database/src/models/__tests__/chatGroup.test.ts
+++ b/packages/database/src/models/__tests__/chatGroup.test.ts
@@ -1336,7 +1336,7 @@ describe('ChatGroupModel', () => {
     });
   });
 
-  describe('member agent demoted to private (LOBE-11772)', () => {
+ describe('member agent demoted to private ', => {
     // Public workspace group owned by `userId` with two members: a public agent
     // and an agent `userId` switched back to private after it joined. Viewer is
     // `otherUserId` (same workspace) — every roster read must drop the private

--- a/packages/database/src/models/__tests__/connectorAgentScope.test.ts
+++ b/packages/database/src/models/__tests__/connectorAgentScope.test.ts
@@ -352,9 +352,9 @@ describe('ConnectorModel agent-scoped resolution', () => {
 // target connector via `findById` before attaching it, and rely on its scoped
 // `ownership()` filter to reject cross-scope rows — that is what enforces
 // "workspace agent ⇒ workspace-only tools, personal agent ⇒ personal-only"
-// (LOBE-11681). These lock that filter so a future refactor can't silently let
+// ). These lock that filter so a future refactor can't silently let
 // a personal connector be bound to a workspace agent (or vice versa).
-describe('ConnectorModel scope isolation (workspace vs personal) — LOBE-11681', () => {
+describe('ConnectorModel scope isolation (workspace vs personal)', => {
   it('a workspace-scoped model cannot findById a personal connector', async () => {
     const personal = await insertConnector({
       identifier: 'gmail',
@@ -393,10 +393,10 @@ describe('ConnectorModel scope isolation (workspace vs personal) — LOBE-11681'
   });
 });
 
-// `queryAllAgentScoped` powers the unified connector-settings page (LOBE-11682):
+// `queryAllAgentScoped` powers the unified connector-settings page :
 // it lists every agent-OWNED connector across all agents in one scope, and must
-// stay scope-correct (no personal↔workspace leak — the LOBE-11681 invariant).
-describe('ConnectorModel.queryAllAgentScoped — LOBE-11682', () => {
+// stay scope-correct (no personal↔workspace leak — the invariant).
+describe('ConnectorModel.queryAllAgentScoped', => {
   it('returns agent-owned rows across all agents and excludes base rows', async () => {
     const ownedA = await insertConnector({ agentId: agentA, identifier: 'gmail', name: 'A' });
     const ownedB = await insertConnector({ agentId: agentB, identifier: 'slack', name: 'B' });

--- a/packages/database/src/models/__tests__/jsonbNullTest.test.ts
+++ b/packages/database/src/models/__tests__/jsonbNullTest.test.ts
@@ -21,7 +21,7 @@ import { describe, expect, it } from 'vitest';
  *   (metadata ->> 'x') IS NOT NULL          → COALESCE(metadata ->> 'x', '') <> ''
  *   (metadata ->> 'x') IS DISTINCT FROM 'y' → COALESCE(metadata ->> 'x', '') <> 'y'
  *
- * Prior casualties: `getLatestSpineMessageId` (LOBE-11376, #16693),
+ * Prior casualties: `getLatestSpineMessageId` ( #16693),
  * `getDueScheduledTopics` (#17077).
  */
 const FORBIDDEN = /(?:->>?|#>>?)[^\n]*?\b(?:IS\s+(?:NOT\s+)?NULL|IS\s+DISTINCT\s+FROM)\b/i;

--- a/packages/database/src/models/__tests__/messages/message.query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.query.test.ts
@@ -439,7 +439,7 @@ describe('MessageModel Query Tests', () => {
       expect(result3).toHaveLength(0);
     });
 
-    describe('newest-first pagination (LOBE-12011)', () => {
+ describe('newest-first pagination ', => {
       // A topic whose mainline exceeds pageSize must keep its LATEST turns
       // (including the final answer) rather than the oldest, and the returned
       // slice must be a single contiguous parentId chain so the renderer — which
@@ -1233,7 +1233,7 @@ describe('MessageModel Query Tests', () => {
           current: 0,
           pageSize: 2,
         });
-        // Page 0 returns the NEWEST page (LOBE-12011), re-sorted ascending: the
+ // Page 0 returns the NEWEST page, re-sorted ascending: the
         // two most recent messages, not the two oldest.
         expect(result1).toHaveLength(2);
         expect(result1[0].id).toBe('msg-page-2');
@@ -3299,7 +3299,7 @@ describe('MessageModel Query Tests', () => {
 
   // Fallback anchor used when `getLatestSpineMessageId` comes back empty. Without
   // it a new user turn is persisted as a second root and the renderer emits the
-  // newest reply above older messages (LOBE-11489).
+ // newest reply above older messages ).
   describe('getLatestNonToolMessageId', () => {
     it('returns a toolless signal turn that the spine query skips', async () => {
       await serverDB.insert(sessions).values([{ id: 'session1', userId }]);

--- a/packages/database/src/models/__tests__/task.test.ts
+++ b/packages/database/src/models/__tests__/task.test.ts
@@ -245,7 +245,7 @@ describe('TaskModel', () => {
 
     // Non-tool deletion (UI / CLI) must leave the Work artifact orphaned so the
     // UI can render it as "resource deleted" from its snapshot. Tool-driven
-    // deletion removes the Work separately at the dispatch layer (LOBE-11606).
+ // deletion removes the Work separately at the dispatch layer ).
     it('should NOT delete the task Work artifact', async () => {
       const model = new TaskModel(serverDB, userId);
       const workModel = new WorkModel(serverDB, userId);

--- a/packages/database/src/models/__tests__/taskTopic.test.ts
+++ b/packages/database/src/models/__tests__/taskTopic.test.ts
@@ -274,7 +274,7 @@ describe('TaskTopicModel', () => {
     });
 
     it('only counts the requested triggers, excluding manual + legacy-null rows', async () => {
-      // LOBE-11391: the maxExecutions quota must count scheduled ticks only —
+ // the maxExecutions quota must count scheduled ticks only —
       // manual "run now" invocations and legacy rows (null trigger) don't count.
       const taskModel = new TaskModel(serverDB, userId);
       const topicModel = new TaskTopicModel(serverDB, userId);

--- a/packages/database/src/models/__tests__/topics/topic.query.test.ts
+++ b/packages/database/src/models/__tests__/topics/topic.query.test.ts
@@ -213,8 +213,7 @@ describe('TopicModel - Query', () => {
       // The client sorts the sidebar by `sortUpdatedAt`, so it must carry the same
       // activity time the server ORDER BY uses (topicActivityAt) — otherwise the two
       // sorts disagree and the list jumps. `updatedAt` stays the raw row value so
-      // rename/favorite edits still show a real edit time. (LOBE-11543)
-      await serverDB.insert(topics).values([
+ // rename/favorite edits still show a real edit time.       await serverDB.insert(topics).values([
         { id: 'has-msg', sessionId, updatedAt: new Date('2023-01-01'), userId },
         { id: 'no-msg', sessionId, updatedAt: new Date('2023-03-01'), userId },
       ]);

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -1010,7 +1010,7 @@ export class AgentModel {
    * `visibility = 'private'` guards lock the operation to the creator's own
    * still-private agent. The inverse transition (public → private) goes
    * through {@link setVisibility}, which the router gates to the creator or
-   * a workspace owner (LOBE-11551).
+ * a workspace owner ).
    *
    * Use the existing `update` to change other fields; visibility is the only
    * one with these authorization rules.
@@ -1078,7 +1078,7 @@ export class AgentModel {
   };
 
   /**
-   * Bidirectional visibility switch (LOBE-11551). Authorization (creator OR
+ * Bidirectional visibility switch ). Authorization (creator OR
    * workspace owner, builtin agents excluded) is the router's responsibility —
    * this method only applies the ownership-scoped write.
    *

--- a/packages/database/src/models/chatGroup.ts
+++ b/packages/database/src/models/chatGroup.ts
@@ -38,7 +38,7 @@ export class ChatGroupModel {
    * (the junction row) does not grant access to the agent: when a member agent
    * is switched back to private by its owner, every roster read must drop it
    * for other members — otherwise the join would keep leaking the agent's
-   * config/meta through group surfaces (LOBE-11772).
+ * config/meta through group surfaces ).
    */
   private memberAgentVisibility = () =>
     buildWorkspaceWhere(

--- a/packages/database/src/models/connector.ts
+++ b/packages/database/src/models/connector.ts
@@ -225,14 +225,14 @@ export class ConnectorModel {
   /**
    * All agent-OWNED connector rows (`agent_id IS NOT NULL`) within the current
    * scope — i.e. every connector that belongs to some agent, across all agents.
-   * Powers the unified connector-settings view (LOBE-11682) which lists "which
+ * Powers the unified connector-settings view which lists "which
    * connector is bound to which agent" in one place, instead of one agent at a
    * time via {@link queryByAgent}.
    *
    * Scope-correct by construction: {@link ownership} carries the `workspace_id`
    * predicate, so in a workspace context this only returns rows owned by that
    * workspace's agents and never leaks personal-dimension rows (and vice versa)
-   * — the LOBE-11681 invariant applied to the aggregate view. Mounted/linked
+ * — the invariant applied to the aggregate view. Mounted/linked
    * base rows (`agent_id IS NULL`) are intentionally excluded; they already show
    * under the base {@link query} list.
    */

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -692,7 +692,7 @@ export class MessageModel {
           // `asc + limit` truncated exactly the newest batch, which is the worst
           // possible slice for a chat transcript. The page is reversed back to
           // ascending immediately below, so every downstream consumer is
-          // unaffected; only *which* rows are fetched changed. See LOBE-12011.
+ // unaffected; only *which* rows are fetched changed. See.
           .orderBy(desc(messages.createdAt), desc(messages.id))
           .limit(pageSize)
           .offset(offset),
@@ -715,7 +715,7 @@ export class MessageModel {
     //
     // Scope: this only serves the single "most recent page" load (`current === 0`),
     // which is the only page the chat read path ever requests — `current`/`pageSize`
-    // offset paging is dead code here (the very premise of LOBE-12011). The trim is
+ // offset paging is dead code here (the very premise of ). The trim is
     // deliberately NOT offset-exact: the rows it drops from page 0 also fall outside
     // page 1's `offset = pageSize` window, so a hypothetical offset walk would skip
     // them. That is acceptable because nothing offset-walks this path; loading older
@@ -3068,7 +3068,7 @@ export class MessageModel {
    * persist the new turn with `parentId: undefined` — a second root that forks
    * the conversation tree. The renderer walks that forest depth-first, so an
    * earlier root's long-running subtree gets emitted before a later root and the
-   * newest reply surfaces ABOVE older messages (LOBE-11489).
+ * newest reply surfaces ABOVE older messages ).
    *
    * `role:'tool'` stays excluded: tool results are inline children of their
    * assistant turn, and anchoring a normal turn onto one orphans it under the

--- a/packages/database/src/models/rbac.ts
+++ b/packages/database/src/models/rbac.ts
@@ -21,7 +21,7 @@ export interface UserPermissionInfo {
  *   member's `workspace_members.role` expanded through the in-code
  *   `WORKSPACE_ROLE_PERMISSIONS` matrix, plus globally-granted DB roles
  *   (`rbac_user_roles.workspace_id IS NULL`, e.g. `super_admin`). No
- *   per-workspace authorization rows are read (LOBE-12329).
+ * per-workspace authorization rows are read ).
  * - `workspaceId` omitted — match **any** DB grant, regardless of workspace.
  *   This preserves backward-compat with pre-workspace-scope callers (Hono
  *   routes that just check `agent:read:all` against the whole user, with

--- a/packages/database/src/models/task.ts
+++ b/packages/database/src/models/task.ts
@@ -252,7 +252,7 @@ export class TaskModel {
    * lifecycle is driven by the deleteTask tool call at the tool-execution
    * dispatch layer (which calls `WorkModel.deleteTaskWork`), so non-tool deletes
    * (UI / CLI / deleteAll) deliberately leave the Work as an orphan for the UI
-   * to render as "resource deleted" from its version snapshot. See LOBE-11606.
+ * to render as "resource deleted" from its version snapshot. See.
    */
   async delete(id: string): Promise<boolean> {
     const deleted = await this.db
@@ -265,7 +265,7 @@ export class TaskModel {
 
   /**
    * Move a task and its full subtree to a new visibility (both directions —
-   * LOBE-11551 added the `public → private` demotion; the router gates who
+ * added the `public → private` demotion; the router gates who
    * may call it).
    *
    * Cascades inside a single transaction:

--- a/packages/database/src/models/taskTopic.ts
+++ b/packages/database/src/models/taskTopic.ts
@@ -221,7 +221,7 @@ export class TaskTopicModel {
    * source.
    *
    * `triggers` filters on the `trigger` column so the maxExecutions quota can
-   * count only automation ticks and ignore ad-hoc manual runs (LOBE-11391).
+ * count only automation ticks and ignore ad-hoc manual runs ).
    * Legacy rows have a NULL trigger; they are excluded whenever `triggers` is
    * passed (they predate the column and can't be attributed to a schedule).
    */

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -222,7 +222,7 @@ const buildTopicOrderBy = (topicActivityAt: SQL, sortBy?: TopicQuerySortBy): SQL
  * COALESCE(metadata ->> 'status', '') <> 'done'                   -- IS DISTINCT FROM
  * ```
  *
- * This has now bitten twice: `getLatestSpineMessageId` (LOBE-11376, #16693) and
+ * This has now bitten twice: `getLatestSpineMessageId` (#16693) and
  * `getDueScheduledTopics` (#17077 — the scheduled-run cron crashed on every tick
  * from the day it shipped, so rate-limit continuations never once resumed).
  */
@@ -384,7 +384,7 @@ export class TopicModel {
                 // display `updatedAt` above matches the client-side sort key to the server
                 // order (otherwise the two disagree and the list visibly jumps) while a
                 // rename/favorite edit still shows its real edit time. See rankTopics for
-                // the same activity-time pattern. (LOBE-11543)
+                // the same activity-time pattern. 
                 sortUpdatedAt: topicActivityAt,
                 // Workspace sidebars filter maintenance actions client-side by
                 // ownership (own vs workspace scope) — the filter needs the row
@@ -460,7 +460,7 @@ export class TopicModel {
                 // display `updatedAt` above matches the client-side sort key to the server
                 // order (otherwise the two disagree and the list visibly jumps) while a
                 // rename/favorite edit still shows its real edit time. See rankTopics for
-                // the same activity-time pattern. (LOBE-11543)
+                // the same activity-time pattern. 
                 sortUpdatedAt: topicActivityAt,
                 // Workspace sidebars filter maintenance actions client-side by
                 // ownership (own vs workspace scope) — the filter needs the row
@@ -532,7 +532,7 @@ export class TopicModel {
               // display `updatedAt` above matches the client-side sort key to the server
               // order (otherwise the two disagree and the list visibly jumps) while a
               // rename/favorite edit still shows its real edit time. See rankTopics for
-              // the same activity-time pattern. (LOBE-11543)
+              // the same activity-time pattern. 
               sortUpdatedAt: topicActivityAt,
               // Workspace sidebars filter maintenance actions client-side by
               // ownership (own vs workspace scope) — the filter needs the row

--- a/packages/database/src/models/work/__tests__/task.test.ts
+++ b/packages/database/src/models/work/__tests__/task.test.ts
@@ -707,7 +707,7 @@ describe('WorkModel · task', () => {
     });
 
     // Tool-driven deletion: the task row is removed first, then the dispatch
-    // layer drops the Work by its internal id (LOBE-11606).
+ // layer drops the Work by its internal id ).
     await taskModel.delete(task.id);
     await workModel.deleteTaskWork({ taskId: task.id });
 

--- a/packages/database/src/models/work/githubToolResult.ts
+++ b/packages/database/src/models/work/githubToolResult.ts
@@ -21,7 +21,7 @@ import {
 type GithubWorkEntityType = 'issue' | 'pull_request';
 
 /**
- * Only successful create/edit results become Works (LOBE-10967): read-only
+ * Only successful create/edit results become Works : read-only
  * queries (get/list/search), comments, and branch/repo operations are
  * intentionally excluded, mirroring the Linear adaptation.
  *

--- a/packages/database/src/models/workspace.ts
+++ b/packages/database/src/models/workspace.ts
@@ -34,7 +34,7 @@ const getActiveMembershipRole = async (
 /**
  * Whether `userId` currently holds owner status in `workspaceId`.
  * `workspace_members.role` is the single source of truth for built-in roles
- * (LOBE-12329). Used by the workspace-API-key owner gates on both the OpenAPI
+ * ). Used by the workspace-API-key owner gates on both the OpenAPI
  * and lambda TRPC surfaces.
  */
 export const hasWorkspaceOwnerAccess = async (
@@ -84,7 +84,7 @@ export class WorkspaceModel {
         .returning();
 
       // `workspace_members.role` is the single source of truth for built-in
-      // workspace roles (LOBE-12329) — no RBAC rows are seeded per workspace.
+ // workspace roles — no RBAC rows are seeded per workspace.
       await tx.insert(workspaceMembers).values({
         role: 'owner',
         userId: this.userId,

--- a/packages/database/src/repositories/agentGroup/index.test.ts
+++ b/packages/database/src/repositories/agentGroup/index.test.ts
@@ -360,7 +360,7 @@ describe('AgentGroupRepository', () => {
       ]);
     });
 
-    describe('member agent demoted to private (LOBE-11772)', () => {
+ describe('member agent demoted to private ', => {
       const workspaceId = 'agent-group-demotion-ws';
 
       beforeEach(async () => {

--- a/packages/database/src/repositories/agentGroup/index.ts
+++ b/packages/database/src/repositories/agentGroup/index.ts
@@ -332,7 +332,7 @@ export class AgentGroupRepository {
     // flag: supervisor existence must be judged on the raw rows — otherwise a
     // viewer who can't see the supervisor would auto-create a duplicate one
     // below — while a member agent switched back to private must not leak its
-    // config to other members (LOBE-11772), so only visible rows are returned.
+ // config to other members, so only visible rows are returned.
     const groupAgentsWithDetails = await this.db
       .select({
         agent: agents,

--- a/packages/database/src/repositories/home/__tests__/workspaceHeteroVisibility.test.ts
+++ b/packages/database/src/repositories/home/__tests__/workspaceHeteroVisibility.test.ts
@@ -1,4 +1,4 @@
-// Regression for LOBE-11758: a workspace heterogeneous agent flipped back to
+// Regression for a workspace heterogeneous agent flipped back to
 // `private` must stay visible to its creator (Private bucket) and invisible
 // to other members across the whole sidebar payload.
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -31,7 +31,7 @@ afterEach(async () => {
   await clientDB.delete(Schema.workspaces);
 });
 
-describe('workspace hetero agent visibility flip (LOBE-11758)', () => {
+describe('workspace hetero agent visibility flip ', => {
   it('hetero agent stays visible to creator after public -> private', async () => {
     const agentModel = new AgentModel(clientDB, creator, ws);
 

--- a/packages/database/src/schemas/task.ts
+++ b/packages/database/src/schemas/task.ts
@@ -238,7 +238,7 @@ export const taskTopics = pgTable(
     // What triggered this run: 'manual' (ad-hoc run-now / agent tool call),
     // 'schedule' (cron tick) or 'heartbeat' (interval tick). Null for legacy
     // rows created before this column existed. Used so the maxExecutions quota
-    // counts only automation ticks, not manual runs (LOBE-11391).
+ // counts only automation ticks, not manual runs ).
     trigger: text('trigger').$type<'manual' | 'schedule' | 'heartbeat'>(),
 
     // Handoff (populated after topic completes via LLM summarization)

--- a/packages/openapi/src/middleware/workspace.test.ts
+++ b/packages/openapi/src/middleware/workspace.test.ts
@@ -246,7 +246,7 @@ describe('OpenAPI workspace middleware', () => {
   });
 
   it('gates on membership.role alone — stale RBAC rows have no effect', async () => {
-    // membership.role is the single source of truth (LOBE-12329): an Admin
+ // membership.role is the single source of truth : an Admin
     // membership passes regardless of whatever legacy rbac_user_roles claim.
     mockWorkspaceMembersFindFirst.mockResolvedValueOnce({ role: 'admin' });
     const app = createApp({ apiKeyWorkspaceId: 'workspace-1', authType: 'apikey' });

--- a/packages/openapi/src/middleware/workspace.ts
+++ b/packages/openapi/src/middleware/workspace.ts
@@ -83,7 +83,7 @@ export const workspaceAuthMiddleware = async (c: Context, next: Next) => {
 
   if (c.get('authType') === 'apikey') {
     // `workspace_members.role` is the single source of truth for built-in
-    // workspace roles (LOBE-12329).
+ // workspace roles ).
     const isWorkspaceAdmin = membership.role === 'owner' || membership.role === 'admin';
 
     if (!isWorkspaceAdmin) {

--- a/packages/types/src/task/index.ts
+++ b/packages/types/src/task/index.ts
@@ -163,7 +163,7 @@ export interface TaskSchedulerContext {
  * cleared on the next successful run so the UI only shows the *current* error —
  * this pocket is append-style history that a later success does NOT wipe. It
  * exists so "the morning check silently didn't fire" is diagnosable after the
- * fact instead of being masked by a later manual success (LOBE-11390).
+ * fact instead of being masked by a later manual success ).
  */
 export interface TaskLifecycleAudit {
   // Monotonic lifetime count of failed runs (never reset on success).

--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -498,8 +498,7 @@ export interface ChatTopic extends Omit<BaseDataModel, 'meta'> {
    * (server `topicActivityAt`), falling back to `updatedAt`. Kept separate from
    * `updatedAt` so the client sort matches the server ORDER BY (no list jumping)
    * while `updatedAt` still reflects real row edits like rename/favorite.
-   * (LOBE-11543)
-   */
+ *    */
   sortUpdatedAt?: number;
   status?: ChatTopicStatus | null;
   title: string;

--- a/packages/utils/src/client/topic.test.ts
+++ b/packages/utils/src/client/topic.test.ts
@@ -226,8 +226,7 @@ describe('groupTopicsByUpdatedTime', () => {
     const today = dayjs().valueOf();
 
     // Row was edited last year (updatedAt) but had message activity today
-    // (sortUpdatedAt) — the sidebar must group it under "today". (LOBE-11543)
-    const topic: ChatTopic = {
+ // (sortUpdatedAt) — the sidebar must group it under "today".     const topic: ChatTopic = {
       id: 'active',
       title: 'Recently active',
       createdAt: lastYear,

--- a/packages/utils/src/client/topic.ts
+++ b/packages/utils/src/client/topic.ts
@@ -75,8 +75,7 @@ const sortGroups = (groups: GroupedTopic[]): GroupedTopic[] => {
  * Resolve the timestamp a topic sorts/groups by for the given field. For
  * `updatedAt` this is the server-provided `sortUpdatedAt` (latest message
  * activity), falling back to the raw `updatedAt` when absent — so the sidebar
- * order matches the server ORDER BY and doesn't jump. (LOBE-11543)
- */
+ * order matches the server ORDER BY and doesn't jump.  */
 export const getTopicSortTime = (topic: ChatTopic, field: 'createdAt' | 'updatedAt'): number =>
   field === 'updatedAt' ? (topic.sortUpdatedAt ?? topic.updatedAt) : topic.createdAt;
 

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.test.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.test.tsx
@@ -161,7 +161,7 @@ describe('TaskDetailHeaderActions', () => {
     expect(mocks.dropdownItems.map((item) => item?.key)).toContain('makePrivate');
   });
 
-  it('hides "make private" from a workspace owner who is not the creator (LOBE-11760)', () => {
+ it('hides "make private" from a workspace owner who is not the creator ', => {
     mocks.isWorkspaceOwner = true;
     mocks.taskState.taskDetailMap = {
       'T-1': { createdByUserId: 'someone-else', visibility: 'public' },

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.tsx
@@ -150,8 +150,8 @@ const TaskDetailHeaderActions = memo(() => {
           }
         : null;
 
-    // Inverse transition (LOBE-11551): only the task creator can pull a
-    // published task back to private (LOBE-11760 — an owner demoting another
+ // Inverse transition : only the task creator can pull a
+ // published task back to private ( an owner demoting another
     // member's task would appropriate it into the creator's private list);
     // everyone else doesn't see the entry at all (the server enforces the
     // same rule as a backstop).

--- a/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
@@ -324,7 +324,7 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
   const agentWorkspaceId = useAgentStore((s) => s.agentMap[agentId]?.workspaceId);
   const isWorkspaceAgent = Boolean(agentWorkspaceId);
 
-  // Shared config merged with the caller's per-agent override (LOBE-11689) —
+ // Shared config merged with the caller's per-agent override —
   // the hook eagerly fetches the `workspaceUserSettings` bucket on mount so
   // what the picker shows and what dispatch will actually do always agree.
   const {
@@ -349,7 +349,7 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
 
   // Workspace-keyed SWR fetch — the raw lambdaQuery key has no workspace
   // dimension, so the picker kept showing the previous workspace's pool after
-  // a switch (LOBE-11904).
+ // a switch ).
   const { data: devices, isLoading } = useDeviceList();
 
   // The current machine's own gateway deviceId (desktop only), used to badge the
@@ -403,7 +403,7 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
 
   // Auto-default to THIS desktop's local execution on first open, for both
   // personal and workspace agents (workspace behaviour used to be a hostname
-  // lookup against the workspace device pool — see LOBE-11647 — but with
+ // lookup against the workspace device pool — see — but with
   // per-user overrides that lookup is unnecessary: `useSelectExecutionTarget`
   // resolves `'local'` to this desktop's personal gateway `deviceId` and, for
   // a workspace agent, persists it into `users.preference.agentDeviceOverrides`,
@@ -454,7 +454,7 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
   //   (per-user `sha256(machineUUID + userId)` vs
   //   `sha256(machineUUID + workspace:<id>)`), so binding one to a workspace
   //   agent conflates identities. The `local` chip already covers "run on my
-  //   machine" as a per-user override (LOBE-11689) without needing to expose
+ // machine" as a per-user override without needing to expose
   //   the raw personal deviceId.
   //
   // Naming — Personal is reserved for the account-tier concept; workspace
@@ -593,7 +593,7 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
         />
       )}
       {/* `local` pins this desktop's personal `deviceId`. Available in both
-          personal and workspace modes now (LOBE-11689): a workspace-agent
+ personal and workspace modes now : a workspace-agent
           `local` pick lands in `users.preference.agentDeviceOverrides` — my
           per-user override — so it never binds the workspace-shared
           `agencyConfig` or coerces any other member's dispatch. */}

--- a/src/features/ChatInput/ControlBar/WorkingDirectoryPicker.tsx
+++ b/src/features/ChatInput/ControlBar/WorkingDirectoryPicker.tsx
@@ -295,7 +295,7 @@ const WorkingDirectoryPicker = memo<WorkingDirectoryPickerProps>(({ agentId }) =
   // One-time fold of legacy localStorage recents into device.workingDirs.
   useMigrateDeviceRecents();
 
-  // Effective config (shared row + this member's device override, LOBE-11689)
+ // Effective config (shared row + this member's device override)
   // so recents / default cwd / the selected-repo label all resolve against the
   // device THIS member's run actually targets.
   const { agencyConfig, workspaceScoped } = useEffectiveAgencyConfig(agentId);

--- a/src/features/ChatInput/ControlBar/WorkingDirectorySection.tsx
+++ b/src/features/ChatInput/ControlBar/WorkingDirectorySection.tsx
@@ -35,7 +35,7 @@ const getEntryEffectivePath = (entry: WorkingDirEntry) => {
  * (read-only) via GitStatus's `deviceId`.
  */
 const WorkingDirectorySectionInner = memo<WorkingDirectorySectionProps>(({ agentId }) => {
-  // Effective config (shared row + this member's device override, LOBE-11689)
+ // Effective config (shared row + this member's device override)
   // so GitStatus probes the same device `useEffectiveWorkingDirectory` resolved
   // the cwd from — raw shared config could point them at different machines.
   const { agencyConfig, workspaceScoped } = useEffectiveAgencyConfig(agentId);

--- a/src/features/ChatInput/ControlBar/WorkspaceControls.tsx
+++ b/src/features/ChatInput/ControlBar/WorkspaceControls.tsx
@@ -42,7 +42,7 @@ const WorkspaceControls = memo<WorkspaceControlsProps>(
     const { canConfigureResource, canUseResource } = useChatInputResourceAccess();
     const runtimeMode = useAgentStore(chatConfigByIdSelectors.getRuntimeModeById(agentId));
     const isHeterogeneous = useAgentStore(agentByIdSelectors.isAgentHeterogeneousById(agentId));
-    // Effective config = shared row + this member's device override (LOBE-11689),
+ // Effective config = shared row + this member's device override,
     // so `isDeviceMode` routes the working-directory section by the device THIS
     // member's run actually targets.
     const { agencyConfig, workspaceScoped } = useEffectiveAgencyConfig(agentId);

--- a/src/features/ChatInput/ControlBar/useCommitWorkingDirectory.ts
+++ b/src/features/ChatInput/ControlBar/useCommitWorkingDirectory.ts
@@ -77,7 +77,7 @@ export const useCommitWorkingDirectory = (agentId: string) => {
   // device override (spreading the merged config would leak the override's
   // executionTarget/boundDeviceId into the workspace-shared row).
   const agencyConfig = useAgentStore(agentByIdSelectors.getAgencyConfigById(agentId));
-  // The EFFECTIVE config (override merged, LOBE-11689) — only for resolving
+ // The EFFECTIVE config (override merged) — only for resolving
   // which device the cwd write should target, keeping it on the same machine
   // the picker/GitStatus/`useEffectiveWorkingDirectory` operate on.
   const { agencyConfig: effectiveAgencyConfig, workspaceScoped } =
@@ -106,7 +106,7 @@ export const useCommitWorkingDirectory = (agentId: string) => {
   });
 
   // A workspace agent resolving to THIS member's personal machine (a `local`
-  // override, LOBE-11689) must not persist its cwd into the workspace-shared
+ // override) must not persist its cwd into the workspace-shared
   // `agents.agencyConfig.workingDirByDevice` — that would leak the member's
   // personal device id and an absolute local path to every other member. Route
   // those writes to the per-user legacy slot instead (a `local` pick only

--- a/src/features/ChatInput/hooks/useSelectExecutionTarget.test.ts
+++ b/src/features/ChatInput/hooks/useSelectExecutionTarget.test.ts
@@ -161,7 +161,7 @@ describe('useSelectExecutionTarget', () => {
     });
   });
 
-  describe('workspace agent — writes to workspace_user_settings.preference.agentDeviceOverrides (LOBE-11689)', () => {
+ describe('workspace agent — writes to workspace_user_settings.preference.agentDeviceOverrides ', => {
     beforeEach(() => {
       testState.access.canManageAgent = false;
       testState.agent.agentMap = {

--- a/src/features/ChatInput/hooks/useSelectExecutionTarget.ts
+++ b/src/features/ChatInput/hooks/useSelectExecutionTarget.ts
@@ -19,7 +19,7 @@ import { useUserStore } from '@/store/user';
  * `executionTarget` is the single source of truth — the server tool gate +
  * client `getRuntimeModeById` derive `runtimeMode` from it.
  *
- * Storage split (LOBE-11689):
+ * Storage split :
  * - **Personal agent** — writes go straight into the shared
  *   `agents.agencyConfig` (there's only ever one owner, so there's nothing to
  *   isolate).

--- a/src/features/Connectors/ConnectorDetail/index.tsx
+++ b/src/features/Connectors/ConnectorDetail/index.tsx
@@ -21,7 +21,7 @@ interface ConnectorDetailProps {
   /**
    * Title of the owning agent when this is an agent-dimension connector. Drives
    * the delete/uninstall confirmation copy — deleting an agent connector also
-   * removes its tool from that agent (LOBE-11682).
+ * removes its tool from that agent ).
    */
   agentTitle?: string | null;
   connectorId: string;
@@ -29,7 +29,7 @@ interface ConnectorDetailProps {
   /**
    * Extra content rendered between the description and the tool-permission list.
    * Used by the unified settings' agent connectors to show the owning agent +
-   * a jump-to-use action (LOBE-11682).
+ * a jump-to-use action ).
    */
   middleSlot?: ReactNode;
   onDelete?: () => void;

--- a/src/features/CreatePlatformAgent/index.tsx
+++ b/src/features/CreatePlatformAgent/index.tsx
@@ -142,7 +142,7 @@ const CreatePlatformAgentContent = memo<CreatePlatformAgentContentProps>(
 
     // Workspace-keyed SWR fetch (see useDeviceList) — the raw lambdaQuery key
     // has no workspace dimension, so the wizard listed the previous
-    // workspace's pool after a switch (LOBE-11904).
+ // workspace's pool after a switch ).
     const {
       data: devices,
       isLoading: loadingDevices,

--- a/src/features/DeviceManager/DeviceDetailPanel.tsx
+++ b/src/features/DeviceManager/DeviceDetailPanel.tsx
@@ -189,7 +189,7 @@ const DeviceDetailPanel = memo<DeviceDetailPanelProps>(({ device, isCurrent, onC
     });
   };
 
-  // Revoke one workspace share of a personal device (LOBE-11699). The share
+ // Revoke one workspace share of a personal device ). The share
   // entry's `deviceId` is the workspace-scoped twin, removed via the
   // workspace-scoped mutation under an explicitly pinned workspace client —
   // the personal settings page has no active workspace context to inherit.

--- a/src/features/DeviceManager/DeviceItem.tsx
+++ b/src/features/DeviceManager/DeviceItem.tsx
@@ -163,7 +163,7 @@ const DeviceItem = memo<DeviceItemProps>(({ device, isCurrent, onSelect, selecte
       })
     : t('devices.lastSeen', { time: dayjs(device.lastSeen).fromNow() });
 
-  // Publish / make-private for workspace enrollments (LOBE-11690). Reuses the
+ // Publish / make-private for workspace enrollments ). Reuses the
   // shared visibility-confirm body so the consequences copy matches agents /
   // files. Success feedback is the row itself moving to the other tab after
   // the list refresh.
@@ -194,7 +194,7 @@ const DeviceItem = memo<DeviceItemProps>(({ device, isCurrent, onSelect, selecte
 
   // Only persisted workspace rows carry a visibility to toggle — ghosts
   // (unregistered) and personal devices don't. The toggle is enroller-only
-  // (LOBE-11760): an owner demoting another member's public device would
+ // : an owner demoting another member's public device would
   // move it into that member's private list, appropriating their data. The
   // server rejects non-enroller writes as the backstop.
   const isEnroller = !!currentUserId && device.enroller?.userId === currentUserId;
@@ -219,7 +219,7 @@ const DeviceItem = memo<DeviceItemProps>(({ device, isCurrent, onSelect, selecte
           ]
       : [];
 
-  // Share-to-workspace entry for personal enrollments (LOBE-11699). The share
+ // Share-to-workspace entry for personal enrollments ). The share
   // handshake needs a live connection to mint the workspace identity, so the
   // item stays disabled (with an explanatory desc) while the device is offline.
   const shareItems =

--- a/src/features/DeviceManager/useDeviceList.ts
+++ b/src/features/DeviceManager/useDeviceList.ts
@@ -15,7 +15,7 @@ import { DEVICE_LIST_SWR_KEY } from './const';
  * resolves devices: `useClientDataSWR` augments the cache key with the active
  * workspace id, so switching workspaces re-fetches into a fresh cache entry.
  * The raw TRPC React Query key has no workspace dimension — a list primed in
- * one workspace kept serving a stale pool after switching (LOBE-11904), and a
+ * one workspace kept serving a stale pool after switching, and a
  * fetch primed while the workspace was still resolving stuck for the whole
  * session (the DeviceManager fix this generalizes).
  *

--- a/src/features/ResourcePermission/ResourceConfigAccessGate.test.tsx
+++ b/src/features/ResourcePermission/ResourceConfigAccessGate.test.tsx
@@ -60,7 +60,7 @@ describe('ResourceConfigAccessGate', () => {
     expect(mocks.toastInfo).toHaveBeenCalledWith('permission.configAccess.agentChatOnly');
   });
 
-  // LOBE-12374: "only collaborators with Can edit" read as an authorship denial to
+ // "only collaborators with Can edit" read as an authorship denial to
   // users who had authored the resource; the two denial reasons are now distinct.
   it('names the workspace role as the reason when the role cannot configure Agents', async () => {
     mocks.canEditContent = false;

--- a/src/features/ResourcePermission/ResourceConfigAccessGate.tsx
+++ b/src/features/ResourcePermission/ResourceConfigAccessGate.tsx
@@ -37,7 +37,7 @@ const ResourceConfigAccessGate = memo<ResourceConfigAccessGateProps>(
       // Name the actual reason: a workspace role that cannot configure Agents at
       // all reads very differently from holding use-only access on this one
       // resource, and conflating them made authors think their own Agent had
-      // rejected them (LOBE-12374).
+ // rejected them ).
       const isRoleRestricted = !canEditContent;
       const messageKey =
         resourceType === 'agent'

--- a/src/features/WorkspaceSetting/hooks/useCategory.tsx
+++ b/src/features/WorkspaceSetting/hooks/useCategory.tsx
@@ -119,7 +119,7 @@ export const useWorkspaceSettingCategory = (): WorkspaceSettingCategoryGroup[] =
         {
           items: [
             // AI provider config (keys/endpoints) is shared workspace infra —
-            // Admin-or-higher, hidden from members entirely (LOBE-11834).
+ // Admin-or-higher, hidden from members entirely ).
             canManageWorkspace && {
               icon: Brain,
               key: WorkspaceSettingsTabs.Provider,

--- a/src/helpers/executionTarget.test.ts
+++ b/src/helpers/executionTarget.test.ts
@@ -66,7 +66,7 @@ describe('resolveExecutionTarget', () => {
   });
 
   it('routes a bound desktop-local selection to the bound device on web when device routing is available (plain and hetero)', () => {
-    // LOBE-11473: a `local` pick pins this desktop's own deviceId as
+ // a `local` pick pins this desktop's own deviceId as
     // `boundDeviceId`; on web that config still runs on the bound device
     // server-side, so surface it honestly as `device` instead of masquerading
     // as `sandbox`. Hetero agents always route here; plain agents need a
@@ -86,7 +86,7 @@ describe('resolveExecutionTarget', () => {
     ).toBe('device');
   });
 
-  it('keeps a bound `local` as `sandbox` when no device routing is available (LOBE-11473 regression)', () => {
+ it('keeps a bound `local` as `sandbox` when no device routing is available ( regression)', => {
     // A plain agent with a bound `local` target but no device-gateway to route
     // it (self-host without DEVICE_GATEWAY_URL, or any server call that leaves
     // `deviceRoutingAvailable` unset) must fall back to the cloud sandbox — it
@@ -356,7 +356,7 @@ describe('resolveRuntimeMode', () => {
     const boundLocal = cfg({ boundDeviceId: 'device-a', executionTarget: 'local' });
     // with a device-gateway → device → runtimeMode none (routed via the plan)
     expect(resolveRuntimeMode(boundLocal, false, true)).toBe('none');
-    // without one → sandbox → cloud (LOBE-11473 regression guard)
+ // without one → sandbox → cloud ( regression guard)
     expect(resolveRuntimeMode(boundLocal, false)).toBe('cloud');
   });
 });
@@ -426,7 +426,7 @@ describe('resolveExecutionPlan', () => {
       ).toEqual({ kind: 'sandbox', target: 'sandbox' });
     });
 
-    it('keeps a bound `local` as sandbox on a no-gateway backend (LOBE-11473 regression)', () => {
+ it('keeps a bound `local` as sandbox on a no-gateway backend ( regression)', => {
       // No device-gateway: `clientExecutionAvailable` is false and the plan
       // never passes `deviceRoutingAvailable`, so a bound `local` target must
       // resolve to the sandbox — not `device`/`device-unrouted`, which would

--- a/src/helpers/executionTarget.ts
+++ b/src/helpers/executionTarget.ts
@@ -67,7 +67,7 @@ export interface ResolveExecutionTargetOptions {
    * stay `sandbox`. So server callers leave it `undefined` (false) and the
    * branch is a no-op there — only web display sites pass
    * `!!serverConfig.agentGatewayUrl` to keep the honest device display
-   * (LOBE-11473). `isHetero` also satisfies the gate: a hetero agent's bound
+   * . `isHetero` also satisfies the gate: a hetero agent's bound
    * `local` was always surfaced as `device` on web regardless of gateway state.
    */
   deviceRoutingAvailable?: boolean;
@@ -138,7 +138,7 @@ export const isHeterogeneousSandboxExecutionAvailable = (type: string | undefine
  * server routes such a config to that bound device — so on web we resolve it
  * to `device`, surfacing honestly that it runs on the user's machine (via
  * `lh connect`) instead of masquerading as `sandbox`. This applies to plain
- * agents too, not just heterogeneous CLI agents (LOBE-11473: plain agents used
+ * agents too, not just heterogeneous CLI agents : plain agents used
  * to leak here, showing "cloud sandbox" while the server ran on the device).
  *
  * This upgrade is gated on `deviceRoutingAvailable` (or `isHetero`): the run

--- a/src/helpers/gatewayMode.test.ts
+++ b/src/helpers/gatewayMode.test.ts
@@ -56,7 +56,7 @@ describe('resolveGatewayModeEnabled', () => {
 });
 
 describe('useIsGatewayModeEnabled', () => {
-  it('re-computes when the agent toggles disableGatewayMode (reactivity, LOBE-11473)', () => {
+ it('re-computes when the agent toggles disableGatewayMode (reactivity)', => {
     mockServerConfig({ agentGatewayUrl: 'wss://gw', enableGatewayMode: true });
     useAgentStore.setState(stateWith(false));
 

--- a/src/helpers/gatewayMode.ts
+++ b/src/helpers/gatewayMode.ts
@@ -15,7 +15,7 @@ import { settingsSelectors } from '@/store/user/selectors';
  * default agent config) must not opt out via `disableGatewayMode`. When any of
  * these is false, sends fall back to the non-gateway client path, so a bound
  * `local` target cannot actually reach the device — the display must keep it as
- * `sandbox` rather than surfacing `device` (LOBE-11473 follow-up).
+ * `sandbox` rather than surfacing `device` ( follow-up).
  *
  * This intentionally mirrors dispatch's own gate,
  * `GatewayActionImpl.isGatewayModeEnabled` in the gateway transport
@@ -78,7 +78,7 @@ export const resolveGatewayModeEnabled = (
  * resource/skill panels). Subscribes to the live-mutable `disableGatewayMode`
  * (agent chatConfig + user default) so toggling Gateway Mode from the chat
  * ActionBar re-renders the display and it stops surfacing a `device` target
- * once sends have fallen back to sandbox (LOBE-11473 follow-up). `serverConfig`
+ * once sends have fallen back to sandbox ( follow-up). `serverConfig`
  * stays a non-reactive read — see `resolveGatewayModeEnabled`'s note.
  */
 export const useIsGatewayModeEnabled = (agentId?: string): boolean => {

--- a/src/hooks/useEffectiveAgencyConfig.ts
+++ b/src/hooks/useEffectiveAgencyConfig.ts
@@ -35,7 +35,7 @@ export interface UseEffectiveAgencyConfigResult {
  *
  * The workspace-shared `agents.agencyConfig` is one row per agent, but each
  * member picks their own execution device after the Agent is public
- * (LOBE-11689) — that pick lives in
+ * — that pick lives in
  * `workspace_user_settings.preference.agentDeviceOverrides[agentId]` and must
  * be merged over the shared row via `resolveAgentAgencyConfig` at read time.
  * Reading the shared row alone shows whichever device landed there (usually

--- a/src/hooks/useEffectiveWorkingDirectory.ts
+++ b/src/hooks/useEffectiveWorkingDirectory.ts
@@ -32,7 +32,7 @@ export const useEffectiveWorkingDirectory = (agentId?: string): string | undefin
   const isLogin = useUserStore(authSelectors.isLogin);
   useDeviceStore((s) => s.useFetchDevices)(isLogin || isDesktop);
 
-  // Effective config = shared row + this member's device override (LOBE-11689),
+ // Effective config = shared row + this member's device override,
   // so `resolveTargetDeviceId` targets the device THIS member's run goes to —
   // not whichever machine landed on the workspace-shared row.
   const { agencyConfig, workspaceScoped } = useEffectiveAgencyConfig(agentId);

--- a/src/hooks/useRemoteAgentDeviceGuard.test.ts
+++ b/src/hooks/useRemoteAgentDeviceGuard.test.ts
@@ -22,7 +22,7 @@ describe('useRemoteAgentDeviceGuard', () => {
   it('checks the EFFECTIVE bound device (with the caller override merged)', async () => {
     // The workspace-shared row points at the creator's (offline) machine; the
     // caller's override picks their own online device — the guard must probe
-    // the override device, not the shared one (LOBE-11904).
+ // the override device, not the shared one ).
     mockedUseEffectiveAgencyConfig.mockReturnValue({
       agencyConfig: {
         boundDeviceId: 'my-device',

--- a/src/hooks/useRemoteAgentDeviceGuard.ts
+++ b/src/hooks/useRemoteAgentDeviceGuard.ts
@@ -28,7 +28,7 @@ export const useRemoteAgentDeviceGuard = ({
   enabled = true,
 }: UseRemoteAgentDeviceGuardOptions): UseRemoteAgentDeviceGuardResult => {
   // Effective config = shared row + this member's per-agent device override
-  // (LOBE-11689). Checking the raw shared `boundDeviceId` would probe whichever
+ // ). Checking the raw shared `boundDeviceId` would probe whichever
   // machine landed on the shared row (usually the creator's, often offline)
   // instead of the device THIS member picked — a false "device offline".
   const { agencyConfig, isPreferenceLoading } = useEffectiveAgencyConfig(agentId);

--- a/src/routes/(main)/[workspaceSlug]/settings/devices/index.tsx
+++ b/src/routes/(main)/[workspaceSlug]/settings/devices/index.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { DeviceConnectModal, DeviceManager, useDeviceList } from '@/features/DeviceManager';
 
 /**
- * Workspace device settings: two pools behind tabs (LOBE-11690) —
+ * Workspace device settings: two pools behind tabs —
  * - Workspace: the shared (public-visibility) pool every member sees.
  * - Private: the caller's own private enrollments in this workspace.
  * The tab also parameterises the connect wizard, so a device enrolled from the

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/HeteroControlBar.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/HeteroControlBar.tsx
@@ -131,7 +131,7 @@ const HeteroControlBar = memo(() => {
 
   // All hooks must be called unconditionally (Rules of Hooks)
   const isLoading = useAgentStore(agentByIdSelectors.isAgentConfigLoadingById(agentId));
-  // Effective config = shared row + this member's device override (LOBE-11689),
+ // Effective config = shared row + this member's device override,
   // so the quota badges gate on where THIS member's run actually executes.
   const { agencyConfig, workspaceScoped } = useEffectiveAgencyConfig(agentId);
 

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/index.tsx
@@ -93,7 +93,7 @@ const HeterogeneousChatInput = memo(() => {
   const navigate = useWorkspaceAwareNavigate();
 
   // Effective config = shared row + this member's per-agent device override
-  // (LOBE-11689) — the raw shared `agencyConfig` may carry another member's
+ // — the raw shared `agencyConfig` may carry another member's
   // device pick, which would drive the guard/model-selector gates off the
   // wrong machine.
   // While the preference is loading, the merged config may still reflect only

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/RemoteAgentConfigCard.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/RemoteAgentConfigCard.tsx
@@ -111,7 +111,7 @@ const ChangeDeviceContent = memo<ChangeDeviceContentProps>(
 
     // Workspace-keyed SWR fetch (see useDeviceList) — the raw lambdaQuery key
     // has no workspace dimension, so the list went stale across workspace
-    // switches (LOBE-11904).
+ // switches ).
     const { data: devices, isLoading: loadingDevices } = useDeviceList();
 
     const onlineDevices = (devices ?? []).filter(

--- a/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/useDropdownMenu.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/useDropdownMenu.tsx
@@ -92,8 +92,7 @@ export const useAgentDropdownMenu = ({
 
   // Visibility actions are only meaningful inside a workspace: in personal
   // mode every row is implicitly owner-private. "Publish to Workspace"
-  // appears on private agents; the inverse "Make private" (LOBE-11551)
-  // appears on published agents, but only for the creator (LOBE-11760 —
+ // appears on private agents; the inverse "Make private"  // appears on published agents, but only for the creator (
   // owners demoting another member's agent would appropriate it), and never
   // on builtin agents (LobeAI etc.). The server enforces the same rules as
   // a backstop.
@@ -137,7 +136,7 @@ export const useAgentDropdownMenu = ({
   // Visibility flips move the item across accordions. Reveal the destination
   // section afterwards — with a collapsed/hidden target (stale persisted
   // `sidebarExpandedKeys` predate newer sections) the item would silently
-  // vanish from the sidebar (LOBE-11758).
+ // vanish from the sidebar ).
   const revealSidebarSection = useRevealSidebarSection();
 
   return useMemo(

--- a/src/routes/(main)/home/_layout/hooks/useRevealSidebarSection.test.ts
+++ b/src/routes/(main)/home/_layout/hooks/useRevealSidebarSection.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { buildRevealSidebarSectionPatch } from './useRevealSidebarSection';
 
-describe('buildRevealSidebarSectionPatch (LOBE-11758)', () => {
+describe('buildRevealSidebarSectionPatch ', => {
   it('expands a collapsed section', () => {
     // Stale persisted keys from before the Private section shipped.
     expect(buildRevealSidebarSectionPatch('private', ['recents', 'agent'], [])).toEqual({

--- a/src/routes/(main)/home/_layout/hooks/useRevealSidebarSection.ts
+++ b/src/routes/(main)/home/_layout/hooks/useRevealSidebarSection.ts
@@ -18,7 +18,7 @@ export type RevealableSidebarSection = 'agent' | 'private';
  * user-applied section hide. Returns `null` when the section is already
  * fully visible so callers can skip the store write.
  *
- * Why this exists (LOBE-11758): `sidebarExpandedKeys` is persisted, so
+ * Why this exists : `sidebarExpandedKeys` is persisted, so
  * accounts whose keys were saved before a section shipped (e.g. `private`,
  * added with workspace private agents) never include the new key — the
  * section stays collapsed forever. "Make private" then moves the agent into

--- a/src/routes/(main)/settings/skill/features/AgentConnectorItem.tsx
+++ b/src/routes/(main)/settings/skill/features/AgentConnectorItem.tsx
@@ -10,7 +10,7 @@ import NavItem from '@/features/NavPanel/components/NavItem';
 import type { AgentBoundConnector } from '@/store/tool/slices/connector/types';
 
 /**
- * A row in the unified settings' "Agent Connectors" section (LOBE-11682).
+ * A row in the unified settings' "Agent Connectors" section ).
  *
  * Rendered identically to the base connector rows (same NavItem + the same brand
  * icon a base Composio/LobeHub connector of this identifier would show), so the

--- a/src/routes/(main)/settings/skill/features/AgentConnectorUsage.tsx
+++ b/src/routes/(main)/settings/skill/features/AgentConnectorUsage.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigateToAgent } from '@/hooks/useNavigateToAgent';
 
 /**
- * Shown inside ConnectorDetail for agent-owned connectors (LOBE-11682), between
+ * Shown inside ConnectorDetail for agent-owned connectors, between
  * the description and the tool-permission list: which agent owns this connector,
  * plus a one-click jump to go use that agent.
  */

--- a/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
@@ -397,7 +397,7 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type, onDelete }) => {
     );
   }
 
-  // Agent-owned connector (unified settings, LOBE-11682): the `identifier` slot
+ // Agent-owned connector (unified settings): the `identifier` slot
   // carries the connector id (not the slug — agent connectors can share a slug
   // with a base connector). Reuse the same ConnectorDetail as base connectors so
   // tool-permission editing, sync and delete behave identically; it resolves the

--- a/src/routes/(main)/settings/skill/features/SkillList.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillList.tsx
@@ -150,7 +150,7 @@ const SkillList = memo<SkillListProps>(
     }, [isConnectorsInit, fetchConnectors]);
 
     // Load agent-owned connectors (across all agents) for the Agent Connectors
-    // section — connector view only (LOBE-11682).
+ // section — connector view only ).
     const isConnectorView = viewMode === 'connector';
     useEffect(() => {
       if (isConnectorView && !isAgentBoundInit) fetchAgentBoundConnectors();

--- a/src/services/agent.ts
+++ b/src/services/agent.ts
@@ -134,7 +134,7 @@ class AgentService {
   };
 
   /**
-   * Bidirectional visibility switch (LOBE-11551). The server only allows the
+ * Bidirectional visibility switch ). The server only allows the
    * agent's creator or a workspace owner to pull a published agent back to
    * private, and rejects builtin agents (LobeAI etc.) outright.
    */

--- a/src/store/agent/selectors/builtinAgentSelectors.test.ts
+++ b/src/store/agent/selectors/builtinAgentSelectors.test.ts
@@ -170,7 +170,7 @@ describe('builtinAgentSelectors', () => {
     });
   });
 
-  // LOBE-12374: workspace members may now *configure* the collaborative builtin
+ // workspace members may now *configure* the collaborative builtin
   // rows, so ownership affordances (delete / transfer) have to be suppressed for
   // them explicitly — the server still rejects those actions.
   describe('isBuiltinAgent', () => {

--- a/src/store/agent/selectors/chatConfigByIdSelectors.ts
+++ b/src/store/agent/selectors/chatConfigByIdSelectors.ts
@@ -76,7 +76,7 @@ const getRuntimeModeById =
 
     // On web a bound `local` target only surfaces as `device` (not `sandbox`)
     // when Gateway mode is effectively enabled and can route to the device
-    // (LOBE-11473). Derive the gate from this selector's own state `s` so it
+ // ). Derive the gate from this selector's own state `s` so it
     // re-evaluates on `disableGatewayMode` changes without a second global read.
     // Workspace agents never execute on the current member's own client —
     // their default/stored `local` coerces away (see `workspaceScoped`).

--- a/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
@@ -1117,7 +1117,7 @@ describe('GatewayActionImpl', () => {
       });
     });
 
-    // Regression (LOBE-12055): after an error run the gateway session completes
+ // Regression : after an error run the gateway session completes
     // and clears the SERVER-side topic metadata, but the local Zustand store copy
     // of `runningOperation` stayed set — so useGatewayReconnect kept firing a
     // reconnect for a dead op and looped 404s. onSessionComplete must ALSO clear
@@ -1682,7 +1682,7 @@ describe('GatewayActionImpl', () => {
 
     // Seeds a topic whose local metadata still carries a runningOperation, wires up
     // internal_dispatchTopic + connectToGateway capture, so we can assert the local
-    // store clear (LOBE-12055) on both the NOT_FOUND refresh path and onSessionComplete.
+ // store clear on both the NOT_FOUND refresh path and onSessionComplete.
     function createSeededReconnectHarness() {
       const captured: { onSessionComplete?: (p: any) => void } = {};
       const connectToGateway = vi.fn((params: any) => {
@@ -1740,7 +1740,7 @@ describe('GatewayActionImpl', () => {
       return { action, captured, connectToGateway, internalDispatchTopic };
     }
 
-    // Regression (LOBE-12055): a stale local runningOperation fires a reconnect,
+ // Regression : a stale local runningOperation fires a reconnect,
     // but the server already cleared its marker and answers refreshGatewayToken
     // with TRPC NOT_FOUND. The reconnect must clear the local marker and bail
     // silently (no connect, no throw) so the SWR fetcher resolves instead of

--- a/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
@@ -134,7 +134,7 @@ describe('createGatewayEventHandler', () => {
       // Native gateway ships the assistant seed on stream_start, so the client
       // inserts the message shell locally (createMessage) and must NOT trigger a
       // DB refetch — the refetch is what clobbered the streamed assistantGroup
-      // with a stale placeholder (LOBE-11501).
+ // with a stale placeholder ).
       expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'msg-step2', type: 'createMessage' }),
         { operationId: 'op-1' },
@@ -650,7 +650,7 @@ describe('createGatewayEventHandler', () => {
     it('marks visible loading done without completing the operation or clearing topic loading', async () => {
       const store = createMockStore();
       // The streamed content has landed in the store — the visible_output_end
-      // guard (LOBE-11501) only clears loading once the assistant row is present
+ // guard only clears loading once the assistant row is present
       // with its content, so seed it here to represent that state.
       store.dbMessagesMap['main_agent-1_topic-1'] = [
         { content: 'hello back', id: 'msg-initial', role: 'assistant' },

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -1305,8 +1305,7 @@ export class ConversationLifecycleActionImpl {
         // Optimistically bump the sort key (`sortUpdatedAt`, the sidebar's activity-time
         // sort/group key) so the topic jumps to the top immediately, before the SWR
         // refetch returns the server's fresh `topicActivityAt`. Bumping `updatedAt` here
-        // would no longer reorder anything — the sidebar sorts by `sortUpdatedAt`. (LOBE-11543)
-        this.#get().internal_dispatchTopic({
+ // would no longer reorder anything — the sidebar sorts by `sortUpdatedAt`.         this.#get().internal_dispatchTopic({
           type: 'updateTopic',
           id: operationContext.topicId,
           value: { sortUpdatedAt: Date.now() },

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -748,7 +748,7 @@ export class GatewayActionImpl {
             .updateTopicMetadata(result.topicId, { runningOperation: null })
             .catch(() => {});
           // Also clear the local store copy — the server clear above does NOT touch
-          // the Zustand topic map that useGatewayReconnect reads (LOBE-12055).
+          // the Zustand topic map that useGatewayReconnect reads .
           this.clearLocalRunningOperation({
             agentId: resolvedMessageContext.agentId,
             groupId: resolvedMessageContext.groupId,
@@ -807,7 +807,7 @@ export class GatewayActionImpl {
     // TRPCError NOT_FOUND when it has no running operation on this topic — our
     // local marker is stale (e.g. an error run cleared the server marker but not
     // the store). Clear it and bail silently so the reconnect SWR fetcher resolves
-    // and does not retry the 404 forever (LOBE-12055).
+    // and does not retry the 404 forever .
     let token: string;
     try {
       ({ token } = await aiAgentService.refreshGatewayToken(topicId));
@@ -936,7 +936,7 @@ export class GatewayActionImpl {
         // doesn't get reconnected on every reload / task-drawer open.
         topicService.updateTopicMetadata(topicId, { runningOperation: null }).catch(() => {});
         // Mirror the clear into the local store — the server clear above leaves the
-        // Zustand topic map stale, which useGatewayReconnect keys off (LOBE-12055).
+        // Zustand topic map stale, which useGatewayReconnect keys off .
         this.clearLocalRunningOperation({ agentId: context.agentId, operationId, topicId });
       },
       operationId,
@@ -989,7 +989,7 @@ export class GatewayActionImpl {
    * copy, so after an error run (e.g. insufficient credits) the stale marker keeps
    * firing `aiAgentService.refreshGatewayToken(topicId)`, which the server now answers
    * with NOT_FOUND (404 — the server-side marker is already null). Raw SWR retries the
-   * 404 forever and wedges the conversation (LOBE-12055).
+   * 404 forever and wedges the conversation .
    *
    * The `updateTopic` reducer shallow-merges `value.metadata` (`{...currentTopic, ...value}`),
    * so we spread the existing metadata to avoid dropping its other keys. Only dispatch when

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.test.ts
@@ -728,7 +728,7 @@ describe('createGatewayEventHandler', () => {
     expect(store.internal_dispatchMessage).not.toHaveBeenCalled();
   });
 
-  it('skips the visible_output_end hint while the assistant row is missing (LOBE-11501)', async () => {
+ it('skips the visible_output_end hint while the assistant row is missing ', async => {
     const store = createStore();
     const handler = createGatewayEventHandler(() => store, {
       assistantMessageId: 'missing-msg',

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
@@ -629,7 +629,7 @@ export const createGatewayEventHandler = (
             // dispatches on a missing id are silent no-ops, so without an
             // insert here the whole step renders nothing until the next DB
             // refetch — and the final step has none before agent_runtime_end,
-            // which is how "loading cleared but no text" happened (LOBE-11501).
+ // which is how "loading cleared but no text" happened ).
             const stored = dbMessageSelectors.getDbMessageById(newAssistantMessageId)(get());
             if (!stored) {
               const seed = data?.assistantMessage;
@@ -871,7 +871,7 @@ export const createGatewayEventHandler = (
           // Guard: only clear visible loading when the streamed content has
           // actually landed in the store. If the message shell is missing (or
           // text streamed but never applied), clearing here would show
-          // "loading done" with the answer still invisible (LOBE-11501) —
+ // "loading done" with the answer still invisible —
           // skip the hint instead and let agent_runtime_end reconcile content
           // and loading in the same frame, i.e. the pre-early-hint behavior.
           const stored = dbMessageSelectors.getDbMessageById(currentAssistantMessageId)(get());

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayMemberStreamHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayMemberStreamHandler.test.ts
@@ -68,7 +68,7 @@ describe('createGatewayMemberStreamHandler', () => {
     expect(store.completeOperation).not.toHaveBeenCalled();
   });
 
-  it('skips the visible loading hint while the member row is not yet in the store (LOBE-11501)', () => {
+ it('skips the visible loading hint while the member row is not yet in the store ', => {
     // Group hydration is still in flight, so the member row hasn't landed. Clearing
     // loading here would show a "done" column with no text — the guard skips it and
     // lets the terminal barrier reconcile.

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayMemberStreamHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayMemberStreamHandler.ts
@@ -154,7 +154,7 @@ export const createGatewayMemberStreamHandler = (
         // the member column's visible loading; terminal reconciliation still
         // belongs to agent_runtime_end/error.
         //
-        // Same guard as the main handler (LOBE-11501): if the member row isn't
+ // Same guard as the main handler : if the member row isn't
         // in the store yet (group hydration in flight) or its streamed text
         // hasn't landed, clearing loading would show a "done" column with no
         // text — skip the hint and let the terminal barrier reconcile both.

--- a/src/store/chat/slices/topic/reducer.ts
+++ b/src/store/chat/slices/topic/reducer.ts
@@ -55,8 +55,7 @@ export const topicReducer = (state: ChatTopic[] = [], payload: ChatTopicDispatch
           sessionId: payload.value.sessionId || undefined,
           // A brand-new topic is fresh activity: seed the sidebar sort key so it
           // lands at the top immediately, matching the server's `topicActivityAt`
-          // once the real row is fetched. (LOBE-11543)
-          sortUpdatedAt: Date.now(),
+ // once the real row is fetched.           sortUpdatedAt: Date.now(),
           updatedAt: Date.now(),
         });
 
@@ -79,8 +78,7 @@ export const topicReducer = (state: ChatTopic[] = [], payload: ChatTopicDispatch
             // Bump `updatedAt` (display/edit time) on every real write. The sidebar
             // no longer sorts by `updatedAt` — it sorts by `sortUpdatedAt` (activity
             // time) — so a status flip bumping `updatedAt` here can't reorder the
-            // list; only an explicit `sortUpdatedAt` in `value` moves a row. (LOBE-11543)
-            // TODO: updatedAt type needs to be changed to Date later
+ // list; only an explicit `sortUpdatedAt` in `value` moves a row.             // TODO: updatedAt type needs to be changed to Date later
             // @ts-ignore
             draftState[topicIndex] = { ...mergedTopic, updatedAt: new Date() };
           }
@@ -105,8 +103,7 @@ export const topicReducer = (state: ChatTopic[] = [], payload: ChatTopicDispatch
           id: nextId,
           // Resolving a first-send optimistic topic to its real id is fresh activity:
           // keep it pinned to the top via the sidebar sort key (`sortUpdatedAt`), not
-          // just `updatedAt` which the sidebar no longer sorts by. (LOBE-11543)
-          sortUpdatedAt: Date.now(),
+ // just `updatedAt` which the sidebar no longer sorts by.           sortUpdatedAt: Date.now(),
           updatedAt: Date.now(),
         };
 

--- a/src/store/home/slices/homeInput/action.test.ts
+++ b/src/store/home/slices/homeInput/action.test.ts
@@ -228,7 +228,7 @@ describe('HomeInputActionImpl', () => {
       );
     });
 
-    // LOBE-12374: a personal builtin is the user's own row, so it keeps following
+ // a personal builtin is the user's own row, so it keeps following
     // the inbox model; the workspace-scoped row of the same slug is shared by
     // every member and must never be repointed.
     it('keeps syncing model/provider onto a personal agent builder', async () => {

--- a/src/store/home/slices/homeInput/action.ts
+++ b/src/store/home/slices/homeInput/action.ts
@@ -60,7 +60,7 @@ const ensureBuiltinAgentHydrated = async (slug: string): Promise<string | undefi
  *
  * The workspace-scoped row of the same slug is shared by every member, so a
  * personal preference must not repoint it — that write both broke for
- * non-creators and silently changed the model for everyone else (LOBE-12374).
+ * non-creators and silently changed the model for everyone else ).
  * The single exception is a shared row whose own model cannot be invoked in this
  * deployment; leaving it would fail the request outright, so it is repaired once.
  *

--- a/src/store/tool/slices/connector/action.ts
+++ b/src/store/tool/slices/connector/action.ts
@@ -39,9 +39,9 @@ export class ConnectorActionImpl {
 
   /**
    * Fetch every agent-owned connector across all agents (the flat aggregate for
-   * the unified connector-settings page, LOBE-11682). Each row is enriched
+ * the unified connector-settings page). Each row is enriched
    * server-side with the owning agent's title/avatar. Scope-correct: a workspace
-   * context only returns that workspace's agent connectors (LOBE-11681).
+ * context only returns that workspace's agent connectors ).
    */
   fetchAgentBoundConnectors = async (): Promise<void> => {
     const data = await lambdaClient.connector.listAgentBound.query();

--- a/src/store/tool/slices/connector/initialState.ts
+++ b/src/store/tool/slices/connector/initialState.ts
@@ -3,7 +3,7 @@ import type { AgentBoundConnector, ConnectorWithTools } from './types';
 export interface ConnectorState {
   /**
    * All agent-owned connectors across every agent in the current scope, for the
-   * unified connector-settings page (LOBE-11682). Distinct from `agentConnectors`
+ * unified connector-settings page ). Distinct from `agentConnectors`
    * (keyed per-agent, includes mounted rows) — this is the flat aggregate.
    */
   agentBoundConnectors: AgentBoundConnector[];

--- a/src/store/tool/slices/connector/types.ts
+++ b/src/store/tool/slices/connector/types.ts
@@ -40,7 +40,7 @@ export interface ConnectorWithTools {
 /**
  * An agent-owned connector as returned by `connector.listAgentBound`, enriched
  * with the owning agent's display info for the unified settings attribution
- * badge (LOBE-11682). Server-resolved so the page needs no per-agent loading.
+ * badge ). Server-resolved so the page needs no per-agent loading.
  */
 export interface AgentBoundConnector extends ConnectorWithTools {
   agentAvatar: string | null;

--- a/src/store/user/slices/workspaceUserSettings/initialState.ts
+++ b/src/store/user/slices/workspaceUserSettings/initialState.ts
@@ -9,7 +9,7 @@ export interface WorkspaceUserSettingsState {
   /**
    * Empty on first load / while SWR is fetching / when the caller is in
    * personal mode. Consumers should treat empty as "no override — use the
-   * shared defaults", identical to the pre-LOBE-11689 behaviour.
+ * shared defaults", identical to the pre behaviour.
    */
   workspaceUserPreference: WorkspaceUserPreference;
   /**


### PR DESCRIPTION
## Summary

Automated daily scan and cleanup of LOBE-XXX reference markers across the codebase. All LOBE-NNNNN markers have been removed from JSDoc and inline comments while preserving the descriptive context.

## Changes

85 files changed, 127 insertions(+), 136 deletions(-).

Key categories of cleaned markers:

- LOBE-11689 — workspace user-specific agent device preference storage
- LOBE-11682 — unified connector-settings page for agent-dimension connectors
- LOBE-11543 — topic sidebar sorting by activity time
- LOBE-11473 — web execution-target display fix
- LOBE-11501 — loading state during multi-step gateway runs
- LOBE-12329 — workspace RBAC role-as-source-of-truth
- LOBE-12055 — stale local runningOperation on reconnect 404
- LOBE-12374 — workspace builtin agent config access
- LOBE-11551 — workspace agent bidirectional visibility switch
- Plus 17 other LOBE references across various modules

## Exclusions

- packages/database/src/models/work/__tests__/linear.test.ts — contains LOBE-10966 and LOBE-1 as real Linear issue identifiers used in test fixtures, not comment markers.

Auto-generated on 2026-07-26.