### PR TITLE
🐛 fix(acceptance): refine check review navigation

### DIFF
--- a/.agents/acceptance/common-mistakes.md
+++ b/.agents/acceptance/common-mistakes.md
@@ -233,3 +233,13 @@ full incident narratives and old Case numbers for earlier cross-references.
 **What it breaks**: the panel feels inflated, the evidence and decision area drift apart, and the status header starts too far below the Portal title.
 
 **Correct approach**: keep the two-column decision bar and primary contrast, but use medium 40px actions, a 12px gap, a 16px separator offset, and a compact handoff from the Portal header into the status-first detail header.
+
+## A terminally accepted Acceptance is not a container for a new delivery
+
+**Wrong approach**: publish later, separately scoped implementation work as new rounds on an Acceptance whose delivery has already been accepted.
+
+**Why it's wrong**: an accepted Acceptance is the closed audit record for one delivery. A new branch or materially new delivery needs its own subject and decision boundary, even when it evolves the same product area.
+
+**What it breaks**: the closed record acquires post-decision evidence, the round history no longer matches the delivery that was accepted, and reviewers cannot independently accept or reject the new work.
+
+**Correct approach**: before every ingest, inspect `acceptance.status` and the latest run decision. If the Acceptance is terminally accepted and the current work is a new delivery, create a new production Task (or use the new work's existing subject) and ingest there. Reuse an accepted Acceptance only when the user explicitly requests reopening that exact delivery and the product supports that lifecycle.

--- a/locales/en-US/verify.json
+++ b/locales/en-US/verify.json
@@ -94,6 +94,7 @@
   "acceptance.filter.pending": "To review {{count}}",
   "acceptance.filter.roundAll": "All rounds",
   "acceptance.focus.back": "Back to overview",
+  "acceptance.focus.enter": "Review checks",
   "acceptance.focus.evidenceCount": "{{count}} evidence items",
   "acceptance.focus.evidenceHint": "Review the acceptance criterion, evidence, and feedback for this check.",
   "acceptance.focus.state.accepted": "Accepted",

--- a/locales/zh-CN/verify.json
+++ b/locales/zh-CN/verify.json
@@ -94,6 +94,7 @@
   "acceptance.filter.pending": "未验收 {{count}}",
   "acceptance.filter.roundAll": "全部轮次",
   "acceptance.focus.back": "返回验收概览",
+  "acceptance.focus.enter": "逐项验收",
   "acceptance.focus.evidenceCount": "{{count}} 份证据",
   "acceptance.focus.evidenceHint": "集中检查该项的验收标准、证据和反馈。",
   "acceptance.focus.state.accepted": "已验收",

--- a/packages/locales/src/default/verify.ts
+++ b/packages/locales/src/default/verify.ts
@@ -109,6 +109,7 @@ export default {
   'acceptance.checkWork.sent': 'This check was sent to the source conversation',
   'acceptance.checkWork.title': 'Work on this check',
   'acceptance.focus.back': 'Back to overview',
+  'acceptance.focus.enter': 'Review checks',
   'acceptance.focus.evidenceCount': '{{count}} evidence items',
   'acceptance.focus.evidenceHint':
     'Review the acceptance criterion, evidence, and feedback for this check.',

--- a/src/features/Verify/Acceptance/CheckList.tsx
+++ b/src/features/Verify/Acceptance/CheckList.tsx
@@ -263,6 +263,7 @@ const styles = createStaticStyles(({ css }) => ({
 
     font-family: ${cssVar.fontFamilyCode};
     font-size: 11px;
+    line-height: 22px;
     color: ${cssVar.colorTextSecondary};
     letter-spacing: 0.02em;
   `,
@@ -277,13 +278,27 @@ const styles = createStaticStyles(({ css }) => ({
     opacity: 0;
     transition: opacity 0.2s;
   `,
+  rowMeta: css`
+    transition: opacity 0.2s;
+
+    @media (hover: hover) and (pointer: fine) {
+      pointer-events: none;
+      opacity: 0;
+    }
+  `,
   rowHeader: css`
     cursor: pointer;
     padding-block: 12px;
     padding-inline: 16px;
 
-    &:hover {
+    &:hover,
+    &:focus-within {
       .acceptance-row-actions {
+        opacity: 1;
+      }
+
+      .acceptance-row-meta {
+        pointer-events: auto;
         opacity: 1;
       }
     }
@@ -739,344 +754,362 @@ const CheckRow = memo<{
   check: AcceptanceCheck;
   detailMode?: boolean;
   expanded: boolean;
-  onOpen?: () => void;
   onReview: (input: CheckReviewInput) => Promise<boolean>;
   onRound: (round: number) => void;
   onToggle: () => void;
   reviewPending: boolean;
-}>(
-  ({
-    canReview,
-    check,
-    detailMode,
-    expanded,
-    onOpen,
-    onReview,
-    onRound,
-    onToggle,
-    reviewPending,
-  }) => {
-    const { t } = useTranslation('verify');
-    // The judging narrative stays collapsed: level one is title + evidence.
-    const [historyOpen, setHistoryOpen] = useState(false);
-    const [seqCopied, setSeqCopied] = useState(false);
-    const [accepting, setAccepting] = useState(false);
-    const [ignoring, setIgnoring] = useState(false);
-    const meta = STATE_META[check.state];
-    const counts = evidenceCounts(check.evidence);
+}>(({ canReview, check, detailMode, expanded, onReview, onRound, onToggle, reviewPending }) => {
+  const { t } = useTranslation('verify');
+  // The judging narrative stays collapsed: level one is title + evidence.
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [seqCopied, setSeqCopied] = useState(false);
+  const [accepting, setAccepting] = useState(false);
+  const [ignoring, setIgnoring] = useState(false);
+  const meta = STATE_META[check.state];
+  const counts = evidenceCounts(check.evidence);
 
-    const reviewState = userReviewState(check);
-    // The decision is stamped on the check's result row — a never-executed
-    // check has no evidence to judge, so it exposes no review actions.
-    const reviewable = canReview && Boolean(check.result);
-    const activeReview =
-      check.userReview && !check.userReview.stale
-        ? check.reviews.at(-1) // the standing verdict is always the newest entry
-        : undefined;
-    const historyReviews = check.reviews.filter((entry) => entry !== activeReview);
-    const evidenceById = collectEvidenceById(check);
-    const hasHistory = check.revisions > 1 || historyReviews.length > 0;
+  const reviewState = userReviewState(check);
+  // The decision is stamped on the check's result row — a never-executed
+  // check has no evidence to judge, so it exposes no review actions.
+  const reviewable = canReview && Boolean(check.result);
+  const activeReview =
+    check.userReview && !check.userReview.stale
+      ? check.reviews.at(-1) // the standing verdict is always the newest entry
+      : undefined;
+  const historyReviews = check.reviews.filter((entry) => entry !== activeReview);
+  const evidenceById = collectEvidenceById(check);
+  const hasHistory = check.revisions > 1 || historyReviews.length > 0;
 
-    const openReject = () =>
-      openCheckRejectModal({
-        checkTitle: `C${check.seq} · ${check.title}`,
-        draftKey: check.id,
-        evidence: check.evidence
-          .filter((item) => isVisual(item))
-          .map((item) => ({ fileUrl: item.fileUrl!, id: item.id })),
-        onConfirm: ({ annotations, comment, fileIds }) =>
-          onReview({
-            action: 'reject',
-            annotations: annotations.length > 0 ? annotations : undefined,
-            checkItemIds: [check.id],
-            comment: comment || undefined,
-            fileIds: fileIds.length > 0 ? fileIds : undefined,
-          }),
-      });
+  const openReject = () =>
+    openCheckRejectModal({
+      checkTitle: `C${check.seq} · ${check.title}`,
+      draftKey: check.id,
+      evidence: check.evidence
+        .filter((item) => isVisual(item))
+        .map((item) => ({ fileUrl: item.fileUrl!, id: item.id })),
+      onConfirm: ({ annotations, comment, fileIds }) =>
+        onReview({
+          action: 'reject',
+          annotations: annotations.length > 0 ? annotations : undefined,
+          checkItemIds: [check.id],
+          comment: comment || undefined,
+          fileIds: fileIds.length > 0 ? fileIds : undefined,
+        }),
+    });
 
-    // Accepting settles the check — the row folds itself away once the write
-    // lands, so the reviewer's eye moves on to what still needs judgment.
-    const handleAccept = async (event: { stopPropagation: () => void }) => {
-      event.stopPropagation();
-      setAccepting(true);
-      const ok = await onReview({ action: 'accept', checkItemIds: [check.id] });
-      setAccepting(false);
-      if (ok && expanded) onToggle();
-    };
+  // Accepting settles the check — the row folds itself away once the write
+  // lands, so the reviewer's eye moves on to what still needs judgment.
+  const handleAccept = async (event: { stopPropagation: () => void }) => {
+    event.stopPropagation();
+    setAccepting(true);
+    const ok = await onReview({ action: 'accept', checkItemIds: [check.id] });
+    setAccepting(false);
+    if (ok && expanded) onToggle();
+  };
 
-    const handleIgnore = async (event: { stopPropagation: () => void }) => {
-      event.stopPropagation();
-      setIgnoring(true);
-      const ok = await onReview({ action: 'ignore', checkItemIds: [check.id] });
-      setIgnoring(false);
-      if (ok && expanded) onToggle();
-    };
+  const handleIgnore = async (event: { stopPropagation: () => void }) => {
+    event.stopPropagation();
+    setIgnoring(true);
+    const ok = await onReview({ action: 'ignore', checkItemIds: [check.id] });
+    setIgnoring(false);
+    if (ok && expanded) onToggle();
+  };
 
-    // The user's standing verdict owns the head slot: a reject replaces the
-    // verifier's mark outright (that check IS sent back, whatever the verifier
-    // said); passed + user-accepted merges into the double-check receipt.
-    const headIcon =
-      reviewState === 'rejected'
-        ? MessageSquareX
-        : reviewState === 'ignored'
-          ? Ban
-          : check.state === 'passed' && reviewState === 'accepted'
-            ? CheckCheck
-            : meta.icon;
-    const headColor =
-      reviewState === 'rejected'
-        ? cssVar.colorError
-        : reviewState === 'ignored'
-          ? cssVar.colorTextQuaternary
-          : meta.color;
+  // The user's standing verdict owns the head slot: a reject replaces the
+  // verifier's mark outright (that check IS sent back, whatever the verifier
+  // said); passed + user-accepted merges into the double-check receipt.
+  const headIcon =
+    reviewState === 'rejected'
+      ? MessageSquareX
+      : reviewState === 'ignored'
+        ? Ban
+        : check.state === 'passed' && reviewState === 'accepted'
+          ? CheckCheck
+          : meta.icon;
+  const headColor =
+    reviewState === 'rejected'
+      ? cssVar.colorError
+      : reviewState === 'ignored'
+        ? cssVar.colorTextQuaternary
+        : meta.color;
 
-    const headIconNode = (
-      <Icon color={headColor} icon={headIcon} size={16} style={{ flex: 'none' }} />
-    );
+  const headIconNode = (
+    <Icon
+      color={headColor}
+      icon={headIcon}
+      size={16}
+      style={{ alignSelf: 'flex-start', flex: 'none', marginBlockStart: 3 }}
+    />
+  );
 
-    return (
-      <Flexbox className={detailMode ? undefined : styles.row} data-check-row={check.id}>
-        {!detailMode && (
+  return (
+    <Flexbox className={detailMode ? undefined : styles.row} data-check-row={check.id}>
+      {!detailMode && (
+        <Flexbox
+          horizontal
+          align={'flex-start'}
+          className={styles.rowHeader}
+          data-expanded={expanded ? '' : undefined}
+          gap={10}
+          onClick={onToggle}
+        >
+          {reviewState === 'rejected' ? (
+            <Tooltip title={t('acceptance.review.rejectedHint')}>{headIconNode}</Tooltip>
+          ) : (
+            headIconNode
+          )}
+          <Tooltip
+            title={seqCopied ? t('acceptance.checks.copied') : t('acceptance.checks.copySeq')}
+          >
+            <span
+              className={cx(styles.seqChip, styles.seqChipClickable)}
+              onClick={(event) => {
+                event.stopPropagation();
+                void copyToClipboard(`C${check.seq}`);
+                setSeqCopied(true);
+                setTimeout(() => setSeqCopied(false), 1500);
+              }}
+            >
+              C{check.seq}
+            </span>
+          </Tooltip>
           <Flexbox
             horizontal
             align={'center'}
-            className={styles.rowHeader}
-            data-expanded={expanded ? '' : undefined}
-            gap={10}
-            onClick={onOpen ?? onToggle}
+            flex={1}
+            gap={8}
+            style={{ minWidth: 0 }}
+            wrap={expanded ? 'wrap' : 'nowrap'}
           >
-            {reviewState === 'rejected' ? (
-              <Tooltip title={t('acceptance.review.rejectedHint')}>{headIconNode}</Tooltip>
-            ) : (
-              headIconNode
+            <Text
+              className={expanded ? undefined : styles.titleEllipsis}
+              style={{ fontSize: 13, minWidth: 0 }}
+            >
+              {check.title}
+            </Text>
+            {!check.required && (
+              <Tooltip title={t('acceptance.checks.notRequiredHint')}>
+                <Tag size={'small'}>{t('acceptance.checks.notRequired')}</Tag>
+              </Tooltip>
             )}
-            <Tooltip
-              title={seqCopied ? t('acceptance.checks.copied') : t('acceptance.checks.copySeq')}
-            >
-              <span
-                className={cx(styles.seqChip, styles.seqChipClickable)}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  void copyToClipboard(`C${check.seq}`);
-                  setSeqCopied(true);
-                  setTimeout(() => setSeqCopied(false), 1500);
-                }}
-              >
-                C{check.seq}
-              </span>
-            </Tooltip>
-            <Flexbox
-              horizontal
-              align={'center'}
-              flex={1}
-              gap={8}
-              style={{ minWidth: 0 }}
-              wrap={expanded ? 'wrap' : 'nowrap'}
-            >
-              <Text
-                className={expanded ? undefined : styles.titleEllipsis}
-                style={{ fontSize: 13, minWidth: 0 }}
-              >
-                {check.title}
-              </Text>
-              {!check.required && (
-                <Tooltip title={t('acceptance.checks.notRequiredHint')}>
-                  <Tag size={'small'}>{t('acceptance.checks.notRequired')}</Tag>
-                </Tooltip>
-              )}
-              {/* The verdict pair travels WITH the title, not adrift at the row's
+            {/* The verdict pair travels WITH the title, not adrift at the row's
               far right: the claim you judge and the judgement you give land in
               one glance, so a long checklist needs no eye round-trip across the
               row (and no mis-click onto a neighbour's buttons). */}
-              {reviewable && reviewState === 'pending' && (
-                <Flexbox
-                  horizontal
-                  align={'center'}
-                  className={cx(styles.rowActions, 'acceptance-row-actions')}
-                  gap={2}
-                  style={{
-                    // The accept spinner must stay visible after the pointer leaves.
-                    ...(accepting ? { opacity: 1 } : undefined),
-                    flex: 'none',
+            {reviewable && reviewState === 'pending' && (
+              <Flexbox
+                horizontal
+                align={'center'}
+                className={cx(styles.rowActions, 'acceptance-row-actions')}
+                gap={2}
+                style={{
+                  // The accept spinner must stay visible after the pointer leaves.
+                  ...(accepting ? { opacity: 1 } : undefined),
+                  flex: 'none',
+                }}
+              >
+                <ActionIcon
+                  disabled={reviewPending && !accepting}
+                  icon={Check}
+                  loading={accepting}
+                  size={'small'}
+                  title={t('acceptance.review.accept')}
+                  onClick={handleAccept}
+                />
+                <ActionIcon
+                  disabled={reviewPending && !ignoring}
+                  icon={Ban}
+                  loading={ignoring}
+                  size={'small'}
+                  title={t('acceptance.review.ignore')}
+                  onClick={handleIgnore}
+                />
+                <ActionIcon
+                  disabled={reviewPending}
+                  icon={MessageSquareX}
+                  size={'small'}
+                  title={t('acceptance.review.reject')}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    openReject();
+                  }}
+                />
+              </Flexbox>
+            )}
+          </Flexbox>
+          <Flexbox
+            horizontal
+            align={'center'}
+            className={cx(styles.rowMeta, 'acceptance-row-meta')}
+            gap={6}
+          >
+            {/* An accept on a NON-passed verdict can't merge into the head icon
+              (the failed/uncertain mark must stay visible) — mark it here. */}
+            {reviewState === 'accepted' && check.state !== 'passed' && (
+              <Tooltip
+                title={t('acceptance.review.acceptedNote', {
+                  time: dayjs(check.userReview!.createdAt).format('MM-DD HH:mm'),
+                })}
+              >
+                <Icon color={cssVar.colorTextQuaternary} icon={BadgeCheck} size={14} />
+              </Tooltip>
+            )}
+            {EVIDENCE_BADGES.map(({ icon, key, labelKey }) =>
+              counts[key] ? (
+                <Tooltip key={key} title={t(labelKey, { count: counts[key] })}>
+                  <Flexbox
+                    horizontal
+                    align={'center'}
+                    gap={3}
+                    style={{ color: cssVar.colorTextTertiary, fontSize: 11 }}
+                  >
+                    <Icon icon={icon} size={13} />
+                    {counts[key] > 1 ? counts[key] : null}
+                  </Flexbox>
+                </Tooltip>
+              ) : null,
+            )}
+            {/* The iteration mark stays compact — [↻ N]; the words (verified N
+              rounds · introduced in round X) live in its tooltip. Clicking
+              jumps to the round the concern first appeared in. */}
+            {check.revisions > 1 && (
+              <Tooltip
+                title={[
+                  check.titleChanged
+                    ? t('acceptance.checks.iterated', { count: check.revisions })
+                    : t('acceptance.checks.rerun', { count: check.revisions }),
+                  check.resultRound !== undefined &&
+                  check.resultRound !== null &&
+                  check.introducedAtRound !== check.resultRound
+                    ? t('acceptance.checks.introduced', { round: check.introducedAtRound })
+                    : null,
+                ]
+                  .filter(Boolean)
+                  .join(' · ')}
+              >
+                <span
+                  className={cx(styles.chip, styles.chipClickable)}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onRound(check.introducedAtRound);
                   }}
                 >
-                  <ActionIcon
-                    disabled={reviewPending && !accepting}
-                    icon={Check}
-                    loading={accepting}
-                    size={'small'}
-                    title={t('acceptance.review.accept')}
-                    onClick={handleAccept}
-                  />
-                  <ActionIcon
-                    disabled={reviewPending && !ignoring}
-                    icon={Ban}
-                    loading={ignoring}
-                    size={'small'}
-                    title={t('acceptance.review.ignore')}
-                    onClick={handleIgnore}
-                  />
-                  <ActionIcon
+                  <Icon icon={Repeat} size={10} /> {check.revisions}
+                </span>
+              </Tooltip>
+            )}
+            {check.resultRound !== undefined && check.resultRound !== null && (
+              <Tooltip title={t('acceptance.checks.finalRoundHint')}>
+                <span
+                  className={cx(styles.chip, styles.chipClickable)}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onRound(check.resultRound!);
+                  }}
+                >
+                  {t('acceptance.round', { round: check.resultRound })}
+                </span>
+              </Tooltip>
+            )}
+          </Flexbox>
+          <Flexbox align={'center'} height={22}>
+            <Icon
+              color={cssVar.colorTextQuaternary}
+              icon={ChevronRight}
+              size={14}
+              style={{
+                transform: expanded ? 'rotate(90deg)' : 'none',
+                transition: 'transform 0.2s',
+              }}
+            />
+          </Flexbox>
+        </Flexbox>
+      )}
+
+      {expanded && (
+        <Flexbox
+          gap={10}
+          paddingBlock={detailMode ? 0 : '0 14px'}
+          paddingInline={detailMode ? 0 : 16}
+        >
+          {check.result?.toulmin?.evidence && (
+            <Text className={styles.descClamp} fontSize={12} type={'secondary'}>
+              {check.result.toulmin.evidence}
+            </Text>
+          )}
+          <EvidenceList evidence={check.evidence} />
+
+          {check.state === 'not_executed' && (
+            <Flexbox
+              horizontal
+              align={'center'}
+              gap={8}
+              paddingBlock={8}
+              paddingInline={10}
+              style={{
+                background: cssVar.colorFillQuaternary,
+                borderRadius: cssVar.borderRadius,
+                width: '100%',
+              }}
+            >
+              <Icon
+                color={cssVar.colorTextQuaternary}
+                icon={CircleDashed}
+                size={15}
+                style={{ flex: 'none' }}
+              />
+              <Text fontSize={12} type={'secondary'}>
+                {t('acceptance.focus.verifierDescription.notExecuted')}
+              </Text>
+            </Flexbox>
+          )}
+
+          {/* An executed check with zero artifacts must SAY so — a silent blank
+              under the verdict reads as a rendering bug, not as a fact. Filled
+              so it reads as a status, never as more description text. */}
+          {check.state !== 'not_executed' && check.result && check.evidence.length === 0 && (
+            <Flexbox
+              paddingBlock={6}
+              paddingInline={10}
+              style={{
+                background: cssVar.colorFillQuaternary,
+                borderRadius: cssVar.borderRadius,
+                width: '100%',
+              }}
+            >
+              <Text fontSize={12} type={'secondary'}>
+                {t('acceptance.evidence.empty')}
+              </Text>
+            </Flexbox>
+          )}
+
+          {/* The user's standing feedback hangs right under the evidence it
+              judges. BOTH verdicts keep an undo path — a mis-click is the most
+              likely way either happens, and a send-back the user didn't mean
+              otherwise costs a whole repair round to walk back. */}
+          {activeReview &&
+            (activeReview.action === 'accept' ? (
+              <Flexbox horizontal align={'center'} gap={8}>
+                <AcceptedNote review={activeReview} />
+                {reviewable && (
+                  <Button
                     disabled={reviewPending}
-                    icon={MessageSquareX}
                     size={'small'}
-                    title={t('acceptance.review.reject')}
+                    type={'text'}
                     onClick={(event) => {
                       event.stopPropagation();
                       openReject();
                     }}
-                  />
-                </Flexbox>
-              )}
-            </Flexbox>
-            <Flexbox horizontal align={'center'} gap={6}>
-              {/* An accept on a NON-passed verdict can't merge into the head icon
-              (the failed/uncertain mark must stay visible) — mark it here. */}
-              {reviewState === 'accepted' && check.state !== 'passed' && (
-                <Tooltip
-                  title={t('acceptance.review.acceptedNote', {
-                    time: dayjs(check.userReview!.createdAt).format('MM-DD HH:mm'),
-                  })}
-                >
-                  <Icon color={cssVar.colorTextQuaternary} icon={BadgeCheck} size={14} />
-                </Tooltip>
-              )}
-              {EVIDENCE_BADGES.map(({ icon, key, labelKey }) =>
-                counts[key] ? (
-                  <Tooltip key={key} title={t(labelKey, { count: counts[key] })}>
-                    <Flexbox
-                      horizontal
-                      align={'center'}
-                      gap={3}
-                      style={{ color: cssVar.colorTextTertiary, fontSize: 11 }}
-                    >
-                      <Icon icon={icon} size={13} />
-                      {counts[key] > 1 ? counts[key] : null}
-                    </Flexbox>
-                  </Tooltip>
-                ) : null,
-              )}
-              {/* The iteration mark stays compact — [↻ N]; the words (verified N
-              rounds · introduced in round X) live in its tooltip. Clicking
-              jumps to the round the concern first appeared in. */}
-              {check.revisions > 1 && (
-                <Tooltip
-                  title={[
-                    check.titleChanged
-                      ? t('acceptance.checks.iterated', { count: check.revisions })
-                      : t('acceptance.checks.rerun', { count: check.revisions }),
-                    check.resultRound !== undefined &&
-                    check.resultRound !== null &&
-                    check.introducedAtRound !== check.resultRound
-                      ? t('acceptance.checks.introduced', { round: check.introducedAtRound })
-                      : null,
-                  ]
-                    .filter(Boolean)
-                    .join(' · ')}
-                >
-                  <span
-                    className={cx(styles.chip, styles.chipClickable)}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onRound(check.introducedAtRound);
-                    }}
                   >
-                    <Icon icon={Repeat} size={10} /> {check.revisions}
-                  </span>
-                </Tooltip>
-              )}
-              {check.resultRound !== undefined && check.resultRound !== null && (
-                <Tooltip title={t('acceptance.checks.finalRoundHint')}>
-                  <span
-                    className={cx(styles.chip, styles.chipClickable)}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onRound(check.resultRound!);
-                    }}
-                  >
-                    {t('acceptance.round', { round: check.resultRound })}
-                  </span>
-                </Tooltip>
-              )}
-              <Icon
-                color={cssVar.colorTextQuaternary}
-                icon={ChevronRight}
-                size={14}
-                style={{
-                  transform: expanded ? 'rotate(90deg)' : 'none',
-                  transition: 'transform 0.2s',
-                }}
-              />
-            </Flexbox>
-          </Flexbox>
-        )}
-
-        {expanded && (
-          <Flexbox
-            gap={10}
-            paddingBlock={detailMode ? 0 : '0 14px'}
-            paddingInline={detailMode ? 0 : 16}
-          >
-            {check.result?.toulmin?.evidence && (
-              <Text className={styles.descClamp} fontSize={12} type={'secondary'}>
-                {check.result.toulmin.evidence}
-              </Text>
-            )}
-            <EvidenceList evidence={check.evidence} />
-
-            {check.state === 'not_executed' && (
-              <Flexbox
-                horizontal
-                align={'center'}
-                gap={8}
-                paddingBlock={8}
-                paddingInline={10}
-                style={{
-                  background: cssVar.colorFillQuaternary,
-                  borderRadius: cssVar.borderRadius,
-                  width: '100%',
-                }}
-              >
-                <Icon
-                  color={cssVar.colorTextQuaternary}
-                  icon={CircleDashed}
-                  size={15}
-                  style={{ flex: 'none' }}
-                />
-                <Text fontSize={12} type={'secondary'}>
-                  {t('acceptance.focus.verifierDescription.notExecuted')}
-                </Text>
+                    {t('acceptance.review.revertToReject')}
+                  </Button>
+                )}
               </Flexbox>
-            )}
-
-            {/* An executed check with zero artifacts must SAY so — a silent blank
-              under the verdict reads as a rendering bug, not as a fact. Filled
-              so it reads as a status, never as more description text. */}
-            {check.state !== 'not_executed' && check.result && check.evidence.length === 0 && (
-              <Flexbox
-                paddingBlock={6}
-                paddingInline={10}
-                style={{
-                  background: cssVar.colorFillQuaternary,
-                  borderRadius: cssVar.borderRadius,
-                  width: '100%',
-                }}
-              >
-                <Text fontSize={12} type={'secondary'}>
-                  {t('acceptance.evidence.empty')}
-                </Text>
-              </Flexbox>
-            )}
-
-            {/* The user's standing feedback hangs right under the evidence it
-              judges. BOTH verdicts keep an undo path — a mis-click is the most
-              likely way either happens, and a send-back the user didn't mean
-              otherwise costs a whole repair round to walk back. */}
-            {activeReview &&
-              (activeReview.action === 'accept' ? (
-                <Flexbox horizontal align={'center'} gap={8}>
-                  <AcceptedNote review={activeReview} />
-                  {reviewable && (
+            ) : activeReview.action === 'ignore' ? (
+              <Flexbox horizontal align={'center'} gap={8}>
+                <IgnoredNote review={activeReview} />
+                {reviewable && (
+                  <>
                     <Button
                       disabled={reviewPending}
                       size={'small'}
@@ -1088,125 +1121,103 @@ const CheckRow = memo<{
                     >
                       {t('acceptance.review.revertToReject')}
                     </Button>
-                  )}
-                </Flexbox>
-              ) : activeReview.action === 'ignore' ? (
-                <Flexbox horizontal align={'center'} gap={8}>
-                  <IgnoredNote review={activeReview} />
-                  {reviewable && (
-                    <>
-                      <Button
-                        disabled={reviewPending}
-                        size={'small'}
-                        type={'text'}
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          openReject();
-                        }}
-                      >
-                        {t('acceptance.review.revertToReject')}
-                      </Button>
-                      <Button
-                        disabled={reviewPending && !accepting}
-                        loading={accepting}
-                        size={'small'}
-                        type={'text'}
-                        onClick={handleAccept}
-                      >
-                        {t('acceptance.review.revertToAccept')}
-                      </Button>
-                    </>
-                  )}
-                </Flexbox>
-              ) : (
-                <Flexbox gap={6}>
-                  <FeedbackCard evidenceById={evidenceById} review={activeReview} />
-                  {/* The mirror of the accept escape: take the send-back back.
+                    <Button
+                      disabled={reviewPending && !accepting}
+                      loading={accepting}
+                      size={'small'}
+                      type={'text'}
+                      onClick={handleAccept}
+                    >
+                      {t('acceptance.review.revertToAccept')}
+                    </Button>
+                  </>
+                )}
+              </Flexbox>
+            ) : (
+              <Flexbox gap={6}>
+                <FeedbackCard evidenceById={evidenceById} review={activeReview} />
+                {/* The mirror of the accept escape: take the send-back back.
                     A fresh accept supersedes the reject, so the check leaves
                     待修复 and the feedback drops out of the next round's input. */}
-                  {reviewable && (
-                    <Flexbox horizontal>
-                      <Button
-                        disabled={reviewPending && !accepting}
-                        loading={accepting}
-                        size={'small'}
-                        type={'text'}
-                        onClick={handleAccept}
-                      >
-                        {t('acceptance.review.revertToAccept')}
-                      </Button>
-                    </Flexbox>
-                  )}
-                </Flexbox>
-              ))}
-
-            {/* Confirm (plain filled) anchors the right edge; reject is the
-              quiet text escape next to it. */}
-            {reviewable && !activeReview && (
-              <Flexbox horizontal gap={4} justify={'flex-end'}>
-                <Button
-                  disabled={reviewPending && !ignoring}
-                  loading={ignoring}
-                  size={'small'}
-                  type={'text'}
-                  onClick={handleIgnore}
-                >
-                  {t('acceptance.review.ignore')}
-                </Button>
-                <Button
-                  disabled={reviewPending}
-                  size={'small'}
-                  type={'text'}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    openReject();
-                  }}
-                >
-                  {t('acceptance.review.reject')}
-                </Button>
-                <Button
-                  disabled={reviewPending && !accepting}
-                  icon={<Icon icon={Check} />}
-                  loading={accepting}
-                  size={'small'}
-                  type={'fill'}
-                  onClick={handleAccept}
-                >
-                  {t('acceptance.review.accept')}
-                </Button>
+                {reviewable && (
+                  <Flexbox horizontal>
+                    <Button
+                      disabled={reviewPending && !accepting}
+                      loading={accepting}
+                      size={'small'}
+                      type={'text'}
+                      onClick={handleAccept}
+                    >
+                      {t('acceptance.review.revertToAccept')}
+                    </Button>
+                  </Flexbox>
+                )}
               </Flexbox>
-            )}
+            ))}
 
-            {hasHistory && (
-              <span
-                className={styles.historyToggle}
-                onClick={() => setHistoryOpen((open) => !open)}
+          {/* Confirm (plain filled) anchors the right edge; reject is the
+              quiet text escape next to it. */}
+          {reviewable && !activeReview && (
+            <Flexbox horizontal gap={4} justify={'flex-end'}>
+              <Button
+                disabled={reviewPending && !ignoring}
+                loading={ignoring}
+                size={'small'}
+                type={'text'}
+                onClick={handleIgnore}
               >
-                <Icon
-                  icon={ChevronRight}
-                  size={12}
-                  style={{
-                    transform: historyOpen ? 'rotate(90deg)' : 'none',
-                    transition: 'transform 0.2s',
-                  }}
-                />
-                {t('acceptance.checks.iterationHistory', { count: check.revisions })}
-              </span>
-            )}
-            {historyOpen && hasHistory && (
-              <IterationTimeline
-                check={check}
-                evidenceById={evidenceById}
-                historyReviews={historyReviews}
-                onRound={onRound}
+                {t('acceptance.review.ignore')}
+              </Button>
+              <Button
+                disabled={reviewPending}
+                size={'small'}
+                type={'text'}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  openReject();
+                }}
+              >
+                {t('acceptance.review.reject')}
+              </Button>
+              <Button
+                disabled={reviewPending && !accepting}
+                icon={<Icon icon={Check} />}
+                loading={accepting}
+                size={'small'}
+                type={'fill'}
+                onClick={handleAccept}
+              >
+                {t('acceptance.review.accept')}
+              </Button>
+            </Flexbox>
+          )}
+
+          {hasHistory && (
+            <span className={styles.historyToggle} onClick={() => setHistoryOpen((open) => !open)}>
+              <Icon
+                icon={ChevronRight}
+                size={12}
+                style={{
+                  transform: historyOpen ? 'rotate(90deg)' : 'none',
+                  transition: 'transform 0.2s',
+                }}
               />
-            )}
-          </Flexbox>
-        )}
-      </Flexbox>
-    );
-  },
-);
+              {t('acceptance.checks.iterationHistory', { count: check.revisions })}
+            </span>
+          )}
+          {historyOpen && hasHistory && (
+            <IterationTimeline
+              check={check}
+              evidenceById={evidenceById}
+              historyReviews={historyReviews}
+              onRound={onRound}
+            />
+          )}
+        </Flexbox>
+      )}
+    </Flexbox>
+  );
+});
 
 interface FocusedCheckDetailsProps {
   canReview: boolean;
@@ -1304,8 +1315,6 @@ interface CheckListProps {
   groupFeedback: AcceptanceGroupFeedback[];
   /** Record group-scoped feedback; resolves true when the write landed. */
   onGroupFeedback: (category: string, comment: string, fileIds: string[]) => Promise<boolean>;
-  /** Open one check in the focused acceptance workspace. */
-  onOpenItem?: (id: string) => void;
   /** Record the user's verdict; resolves true when the write landed. */
   onReview: (input: CheckReviewInput) => Promise<boolean>;
   onRound: (round: number) => void;
@@ -1328,7 +1337,6 @@ const CheckList = memo<CheckListProps>(
     filter,
     groupFeedback,
     onGroupFeedback,
-    onOpenItem,
     onReview,
     onRound,
     onToggleGroup,
@@ -1627,7 +1635,6 @@ const CheckList = memo<CheckListProps>(
                     expanded={expanded.has(check.id)}
                     key={check.id}
                     reviewPending={reviewPending}
-                    onOpen={onOpenItem ? () => onOpenItem(check.id) : undefined}
                     onReview={onReview}
                     onRound={onRound}
                     onToggle={() => onToggleItem(check.id)}

--- a/src/features/Verify/Acceptance/Workspace/index.tsx
+++ b/src/features/Verify/Acceptance/Workspace/index.tsx
@@ -5,7 +5,7 @@ import { createStaticStyles, cssVar } from 'antd-style';
 import { PanelLeftOpen } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Outlet } from 'react-router';
+import { Outlet, useParams, useSearchParams } from 'react-router';
 
 import { RouteMetaBridge } from '@/features/RouteMeta';
 import { useUserStore } from '@/store/user';
@@ -63,6 +63,9 @@ const styles = createStaticStyles(({ css }) => ({
 const AcceptanceWorkspace = memo(() => {
   const { t } = useTranslation('verify');
   const panel = useReportPanelExpand();
+  const { checkId } = useParams<{ checkId: string }>();
+  const [searchParams] = useSearchParams();
+  const hasFocusedCheck = Boolean(checkId || searchParams.get('check'));
   const isAuthLoaded = useUserStore(authSelectors.isLoaded);
   const isLogin = useUserStore(authSelectors.isLogin);
   const canShowList = Boolean(isAuthLoaded && isLogin);
@@ -71,9 +74,9 @@ const AcceptanceWorkspace = memo(() => {
     <Flexbox horizontal height={'100dvh'} style={{ overflow: 'hidden' }} width={'100%'}>
       {/* Standalone route (outside the app main layout): drive the tab title here. */}
       <RouteMetaBridge />
-      {canShowList && <AcceptanceListPanel {...panel} />}
+      {canShowList && !hasFocusedCheck && <AcceptanceListPanel {...panel} />}
       <div className={styles.main}>
-        {canShowList && !panel.expand && (
+        {canShowList && !hasFocusedCheck && !panel.expand && (
           <button
             aria-label={t('workspace.expand')}
             className={styles.expandBtn}

--- a/src/features/Verify/Acceptance/index.tsx
+++ b/src/features/Verify/Acceptance/index.tsx
@@ -14,7 +14,7 @@ import {
   Tag,
   Text,
 } from '@lobehub/ui';
-import { Button, Segmented, Select, toast } from '@lobehub/ui/base-ui';
+import { Button, Select, toast } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx, useResponsive } from 'antd-style';
 import dayjs from 'dayjs';
 import {
@@ -41,7 +41,7 @@ import {
 } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams, useSearchParams } from 'react-router';
+import { useNavigate, useParams, useSearchParams } from 'react-router';
 
 import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
 import AgentProfilePopup from '@/features/AgentProfileCard/AgentProfilePopup';
@@ -77,6 +77,7 @@ import { EMPTY_ID_SET, setAggregateEntry } from './expandState';
 import FeedbackDrawer, { type FeedbackListEntry } from './FeedbackDrawer';
 import LedgerPanel, { type AcceptanceRound } from './LedgerPanel';
 import { openAcceptModal, openRejectModal } from './modals';
+import { acceptanceCheckPath, acceptanceOverviewPath } from './routes';
 import TopicPanel from './TopicPanel';
 
 /**
@@ -218,7 +219,7 @@ const styles = createStaticStyles(({ css }) => ({
   focusLayout: css`
     display: grid;
     grid-template-columns: 320px minmax(0, 1fr);
-    min-height: calc(100vh - 40px);
+    min-height: 100vh;
 
     @media (width <= 900px) {
       grid-template-columns: 1fr;
@@ -230,7 +231,7 @@ const styles = createStaticStyles(({ css }) => ({
 
     overflow: auto;
 
-    height: calc(100vh - 40px);
+    height: 100vh;
     padding: 8px;
     border-inline-end: 1px solid ${cssVar.colorBorderSecondary};
 
@@ -293,11 +294,12 @@ interface AcceptancePageProps {
 
 const AcceptancePage = memo<AcceptancePageProps>(
   ({ acceptanceId: explicitAcceptanceId, onDraftToComposer }) => {
-    const params = useParams<{ acceptanceId: string }>();
+    const params = useParams<{ acceptanceId: string; checkId: string }>();
     // Route params come from shared links whose autolinker may have glued
     // trailing punctuation onto the id — salvage the leading UUID.
     const acceptanceId = explicitAcceptanceId ?? extractUuid(params.acceptanceId);
     const isEmbedded = Boolean(explicitAcceptanceId);
+    const navigate = useNavigate();
     const { t } = useTranslation('verify');
     const { data, error, isLoading, mutate } = useAcceptanceBundle(acceptanceId ?? null);
     const openTopicDrawer = useTaskStore((s) => s.openTopicDrawer);
@@ -325,7 +327,8 @@ const AcceptancePage = memo<AcceptancePageProps>(
     // only on the standalone acceptance page. The portal embed rides the chat
     // URL, so it keeps the filter in local state instead of hijacking that query.
     const [searchParams, setSearchParams] = useSearchParams();
-    const focusedCheckId = isEmbedded ? null : searchParams.get('check');
+    const legacyFocusedCheckId = isEmbedded ? null : searchParams.get('check');
+    const focusedCheckId = isEmbedded ? null : (params.checkId ?? legacyFocusedCheckId);
     const [localFilter, setLocalFilter] = useState<CheckFilter>('all');
     const urlFilterRaw = searchParams.get('filter');
     const urlFilter: CheckFilter = (
@@ -381,6 +384,21 @@ const AcceptancePage = memo<AcceptancePageProps>(
     const [highlightRound, setHighlightRound] = useState<number | null>(null);
     const [ledgerExpand, setLedgerExpand] = useState(!isEmbedded);
     const [topicPanelOpen, setTopicPanelOpen] = useState(false);
+    // Keep previously shared `?check=` links working, but make the nested path
+    // the single source of truth for the selected check going forward.
+    useEffect(() => {
+      if (isEmbedded || params.checkId || !legacyFocusedCheckId || !acceptanceId) return;
+
+      const nextSearchParams = new URLSearchParams(searchParams);
+      nextSearchParams.delete('check');
+      navigate(
+        {
+          pathname: acceptanceCheckPath(acceptanceId, legacyFocusedCheckId),
+          search: nextSearchParams.toString(),
+        },
+        { replace: true },
+      );
+    }, [acceptanceId, isEmbedded, legacyFocusedCheckId, navigate, params.checkId, searchParams]);
     // Entering the narrow regime closes the ledger (it would cover the report);
     // reopening is an explicit act via the corner toggle, as a float overlay.
     useEffect(() => {
@@ -529,6 +547,11 @@ const AcceptancePage = memo<AcceptancePageProps>(
     const focusedCheck = focusedCheckId
       ? checks.find((check) => check.id === focusedCheckId)
       : undefined;
+    const orderedChecks = [...checks].sort(
+      (a, b) =>
+        CHECK_REVIEW_ORDER[checkFilterState(a)] - CHECK_REVIEW_ORDER[checkFilterState(b)] ||
+        a.seq - b.seq,
+    );
     const standingChecklist = acceptance.config?.checklist ?? [];
     const unverifiedStandingChecks = standingChecklist.filter(
       (item) => !checks.some((check) => check.id === item.id),
@@ -541,13 +564,16 @@ const AcceptancePage = memo<AcceptancePageProps>(
           verifierLabel: 'notExecuted' as const,
         };
     const setFocusedCheck = (id?: string) => {
-      if (isEmbedded) return;
-      setSearchParams(
-        (prev) => {
-          const params = new URLSearchParams(prev);
-          if (id) params.set('check', id);
-          else params.delete('check');
-          return params;
+      if (isEmbedded || !acceptanceId) return;
+
+      const nextSearchParams = new URLSearchParams(searchParams);
+      nextSearchParams.delete('check');
+      navigate(
+        {
+          pathname: id
+            ? acceptanceCheckPath(acceptanceId, id)
+            : acceptanceOverviewPath(acceptanceId),
+          search: nextSearchParams.toString(),
         },
         { replace: true },
       );
@@ -1002,12 +1028,11 @@ const AcceptancePage = memo<AcceptancePageProps>(
         <Flexbox flex={1} style={{ minWidth: 0, overflow: 'auto' }}>
           <Flexbox
             gap={16}
-            paddingBlock={20}
-            paddingInline={focusedCheck ? undefined : 24}
+            paddingBlock={focusedCheck ? 0 : 20}
+            paddingInline={focusedCheck ? 0 : 24}
             style={{
               margin: focusedCheck ? 0 : '0 auto',
               maxWidth: focusedCheck ? 'none' : 920,
-              paddingInlineStart: focusedCheck ? 24 : undefined,
               width: '100%',
             }}
           >
@@ -1027,7 +1052,6 @@ const AcceptancePage = memo<AcceptancePageProps>(
                     <Text fontSize={12} type={'secondary'}>
                       {[
                         countsText,
-                        t('acceptance.roundCount', { count: rounds.length }),
                         currentRound
                           ? t('acceptance.verdict.latestAt', {
                               time: dayjs(currentRound.run.createdAt).format('MM-DD HH:mm'),
@@ -1050,48 +1074,83 @@ const AcceptancePage = memo<AcceptancePageProps>(
                 topic). Owner-only: the server redacts it for shared links.
                 Hidden in the portal embed: that surface already lives inside
                 the origin conversation. */}
-                  {!isEmbedded && (origin?.agent || origin?.topic) && (
-                    <Flexbox horizontal align={'center'} gap={16} wrap={'wrap'}>
-                      {origin.agent && (
-                        <AgentProfilePopup
-                          agentId={origin.agent.id}
-                          trigger={'hover'}
-                          agent={{
-                            avatar: origin.agent.avatar ?? undefined,
-                            backgroundColor: origin.agent.backgroundColor ?? undefined,
-                            title: origin.agent.title ?? undefined,
-                          }}
-                        >
-                          <Flexbox
-                            horizontal
-                            align={'center'}
-                            className={styles.scopeChip}
-                            gap={6}
-                            style={{ cursor: 'default', fontSize: 14 }}
+                  {!isEmbedded &&
+                    (origin?.agent || origin?.topic || scope?.pullRequest?.number) && (
+                      <Flexbox horizontal align={'center'} gap={16} wrap={'wrap'}>
+                        {origin.agent && (
+                          <AgentProfilePopup
+                            agentId={origin.agent.id}
+                            trigger={'hover'}
+                            agent={{
+                              avatar: origin.agent.avatar ?? undefined,
+                              backgroundColor: origin.agent.backgroundColor ?? undefined,
+                              title: origin.agent.title ?? undefined,
+                            }}
                           >
-                            <Avatar
-                              avatar={origin.agent.avatar ?? undefined}
-                              background={origin.agent.backgroundColor ?? undefined}
-                              size={18}
-                            />
-                            {origin.agent.title ?? t('acceptance.origin.agentFallback')}
-                          </Flexbox>
-                        </AgentProfilePopup>
-                      )}
-                      {origin.topic && (
-                        <Button
-                          className={cx(styles.scopeChip, styles.scopeLink)}
-                          icon={MessagesSquare}
-                          size={'small'}
-                          style={{ fontSize: 14 }}
-                          title={t('acceptance.origin.openTopic')}
-                          type={'text'}
-                          onClick={openTopicPanel}
-                        >
-                          {origin.topic.title ?? subject.title ?? origin.topic.id}
-                        </Button>
-                      )}
-                    </Flexbox>
+                            <Flexbox
+                              horizontal
+                              align={'center'}
+                              className={styles.scopeChip}
+                              gap={6}
+                              style={{ cursor: 'default', fontSize: 14 }}
+                            >
+                              <Avatar
+                                avatar={origin.agent.avatar ?? undefined}
+                                background={origin.agent.backgroundColor ?? undefined}
+                                size={18}
+                              />
+                              {origin.agent.title ?? t('acceptance.origin.agentFallback')}
+                            </Flexbox>
+                          </AgentProfilePopup>
+                        )}
+                        {origin.topic && (
+                          <Button
+                            className={cx(styles.scopeChip, styles.scopeLink)}
+                            icon={MessagesSquare}
+                            size={'small'}
+                            style={{ fontSize: 14 }}
+                            title={t('acceptance.origin.openTopic')}
+                            type={'text'}
+                            onClick={openTopicPanel}
+                          >
+                            {origin.topic.title ?? subject.title ?? origin.topic.id}
+                          </Button>
+                        )}
+                        {scope?.pullRequest?.number &&
+                          (scope.pullRequest.url ? (
+                            <a
+                              className={cx(styles.scopeChip, styles.scopeLink)}
+                              href={scope.pullRequest.url}
+                              rel={'noreferrer'}
+                              target={'_blank'}
+                              title={scope.pullRequest.title ?? scope.pullRequest.url}
+                            >
+                              <Flexbox horizontal align={'center'} gap={4}>
+                                <Icon icon={GitPullRequest} size={13} /> #{scope.pullRequest.number}
+                              </Flexbox>
+                            </a>
+                          ) : (
+                            <Flexbox
+                              horizontal
+                              align={'center'}
+                              className={styles.scopeChip}
+                              gap={4}
+                            >
+                              <Icon icon={GitPullRequest} size={13} /> #{scope.pullRequest.number}
+                            </Flexbox>
+                          ))}
+                      </Flexbox>
+                    )}
+                  {!isEmbedded && orderedChecks.length > 0 && (
+                    <Button
+                      icon={<Icon icon={ChevronRight} />}
+                      size={'small'}
+                      style={{ alignSelf: 'flex-start' }}
+                      type={'text'}
+                      onClick={() => setFocusedCheck(orderedChecks[0].id)}
+                    >
+                      {t('acceptance.focus.enter')}
+                    </Button>
                   )}
                 </Flexbox>
 
@@ -1226,30 +1285,6 @@ const AcceptancePage = memo<AcceptancePageProps>(
                               {scope.commit.slice(0, 10)}
                             </Flexbox>
                           )}
-                          {scope.pullRequest?.number &&
-                            (scope.pullRequest.url ? (
-                              <a
-                                className={cx(styles.scopeChip, styles.scopeLink)}
-                                href={scope.pullRequest.url}
-                                rel={'noreferrer'}
-                                target={'_blank'}
-                                title={scope.pullRequest.title ?? scope.pullRequest.url}
-                              >
-                                <Flexbox horizontal align={'center'} gap={4}>
-                                  <Icon icon={GitPullRequest} size={13} /> #
-                                  {scope.pullRequest.number}
-                                </Flexbox>
-                              </a>
-                            ) : (
-                              <Flexbox
-                                horizontal
-                                align={'center'}
-                                className={styles.scopeChip}
-                                gap={4}
-                              >
-                                <Icon icon={GitPullRequest} size={13} /> #{scope.pullRequest.number}
-                              </Flexbox>
-                            ))}
                         </Flexbox>
                       )}
                     </Flexbox>
@@ -1308,79 +1343,69 @@ const AcceptancePage = memo<AcceptancePageProps>(
                       )}
                     </Flexbox>
                   </Flexbox>
-                  {[...checks]
-                    .sort(
-                      (a, b) =>
-                        CHECK_REVIEW_ORDER[checkFilterState(a)] -
-                          CHECK_REVIEW_ORDER[checkFilterState(b)] || a.seq - b.seq,
-                    )
-                    .map((check) => {
-                      const state = checkFilterState(check);
-                      const icon =
-                        state === 'accepted'
-                          ? BadgeCheck
-                          : state === 'needsFix'
-                            ? RotateCcw
-                            : state === 'ignored'
-                              ? Ban
-                              : CircleDashed;
-                      const color =
-                        state === 'accepted'
-                          ? 'success'
-                          : state === 'needsFix'
-                            ? 'error'
-                            : state === 'ignored'
-                              ? 'default'
-                              : 'default';
+                  {orderedChecks.map((check) => {
+                    const state = checkFilterState(check);
+                    const icon =
+                      state === 'accepted'
+                        ? BadgeCheck
+                        : state === 'needsFix'
+                          ? RotateCcw
+                          : state === 'ignored'
+                            ? Ban
+                            : CircleDashed;
+                    const color =
+                      state === 'accepted'
+                        ? 'success'
+                        : state === 'needsFix'
+                          ? 'error'
+                          : state === 'ignored'
+                            ? 'default'
+                            : 'default';
 
-                      return (
-                        <NavItem
-                          active={check.id === focusedCheck.id}
-                          key={check.id}
-                          title={check.title}
-                          titleColor={cssVar.colorText}
-                          description={
-                            <Flexbox horizontal align={'center'} gap={8}>
-                              <Tag color={color} icon={<Icon icon={icon} />} size={'small'}>
-                                {t(`acceptance.focus.state.${state}`)}
-                              </Tag>
-                              <Text fontSize={12} type={'secondary'}>
-                                {t('acceptance.focus.evidenceCount', {
-                                  count: check.evidence.length,
-                                })}
+                    return (
+                      <NavItem
+                        active={check.id === focusedCheck.id}
+                        key={check.id}
+                        title={check.title}
+                        titleColor={cssVar.colorText}
+                        description={
+                          <Flexbox horizontal align={'center'} gap={8}>
+                            <Tag color={color} icon={<Icon icon={icon} />} size={'small'}>
+                              {t(`acceptance.focus.state.${state}`)}
+                            </Tag>
+                            <Text fontSize={12} type={'secondary'}>
+                              {t('acceptance.focus.evidenceCount', {
+                                count: check.evidence.length,
+                              })}
+                            </Text>
+                          </Flexbox>
+                        }
+                        extra={
+                          <Icon color={cssVar.colorTextQuaternary} icon={ChevronRight} size={14} />
+                        }
+                        slots={{
+                          titlePrefix: (
+                            <Flexbox
+                              align={'center'}
+                              height={22}
+                              style={{ alignSelf: 'flex-start' }}
+                            >
+                              <Text
+                                style={{
+                                  color: cssVar.colorTextQuaternary,
+                                  fontFamily: cssVar.fontFamilyCode,
+                                  fontSize: 11,
+                                }}
+                              >
+                                C{check.seq}
                               </Text>
                             </Flexbox>
-                          }
-                          extra={
-                            <Icon
-                              color={cssVar.colorTextQuaternary}
-                              icon={ChevronRight}
-                              size={14}
-                            />
-                          }
-                          slots={{
-                            titlePrefix: (
-                              <Flexbox
-                                align={'center'}
-                                height={22}
-                                style={{ alignSelf: 'flex-start' }}
-                              >
-                                <Text
-                                  style={{
-                                    color: cssVar.colorTextQuaternary,
-                                    fontFamily: cssVar.fontFamilyCode,
-                                    fontSize: 11,
-                                  }}
-                                >
-                                  C{check.seq}
-                                </Text>
-                              </Flexbox>
-                            ),
-                          }}
-                          onClick={() => setFocusedCheck(check.id)}
-                        />
-                      );
-                    })}
+                          ),
+                        }}
+                        onClick={() => setFocusedCheck(check.id)}
+                      />
+                    );
+                  })}
                   {unverifiedStandingChecks.length > 0 && (
                     <Flexbox gap={4} paddingBlock={8} paddingInline={8}>
                       <Text fontSize={11} type={'secondary'}>
@@ -1519,9 +1544,8 @@ const AcceptancePage = memo<AcceptancePageProps>(
             ) : (
               <>
                 {/* Check union — the complete inventory, familiar sections (P-14).
-              Narrow surfaces (the chat portal embed, sub-lg viewports) trade
-              the Segmented for a compact Select so the toolbar stays one
-              line; wide viewports keep the glanceable Segmented. */}
+              State and round are both audit filters, so they share one compact
+              Select treatment instead of competing control dialects. */}
                 <Flexbox
                   horizontal
                   align={'center'}
@@ -1536,81 +1560,48 @@ const AcceptancePage = memo<AcceptancePageProps>(
                   </span>
                   <Flexbox flex={1} />
                   {isOwner && (
-                    <Button
-                      icon={<Icon icon={Plus} />}
+                    <ActionIcon
+                      icon={Plus}
                       size={'small'}
-                      type={'text'}
+                      title={t('acceptance.checkCreate.title')}
                       onClick={handleAddChecks}
-                    >
-                      {t('acceptance.checkCreate.title')}
-                    </Button>
-                  )}
-                  {compactToolbar ? (
-                    <Select
-                      size={'small'}
-                      style={{ height: 34, width: 118 }}
-                      value={filter}
-                      variant={'filled'}
-                      options={[
-                        {
-                          label: t('acceptance.filter.all', { count: counts.total }),
-                          value: 'all',
-                        },
-                        {
-                          label: t('acceptance.filter.pending', { count: counts.pending }),
-                          value: 'pending',
-                        },
-                        {
-                          label: t('acceptance.filter.needsFix', { count: counts.needsFix }),
-                          value: 'needsFix',
-                        },
-                        {
-                          label: t('acceptance.filter.accepted', { count: counts.accepted }),
-                          value: 'accepted',
-                        },
-                        {
-                          label: t('acceptance.filter.ignored', { count: counts.ignored }),
-                          value: 'ignored',
-                        },
-                      ]}
-                      onChange={(value) => setFilter(value as CheckFilter)}
-                    />
-                  ) : (
-                    <Segmented
-                      size={'small'}
-                      value={filter}
-                      options={[
-                        {
-                          label: t('acceptance.filter.all', { count: counts.total }),
-                          value: 'all',
-                        },
-                        {
-                          label: t('acceptance.filter.pending', { count: counts.pending }),
-                          value: 'pending',
-                        },
-                        {
-                          label: t('acceptance.filter.needsFix', { count: counts.needsFix }),
-                          value: 'needsFix',
-                        },
-                        {
-                          label: t('acceptance.filter.accepted', { count: counts.accepted }),
-                          value: 'accepted',
-                        },
-                        {
-                          label: t('acceptance.filter.ignored', { count: counts.ignored }),
-                          value: 'ignored',
-                        },
-                      ]}
-                      onChange={(value) => setFilter(value as CheckFilter)}
                     />
                   )}
+                  <Select
+                    size={'small'}
+                    style={{ height: 34, width: 118 }}
+                    value={filter}
+                    variant={'filled'}
+                    options={[
+                      {
+                        label: t('acceptance.filter.all', { count: counts.total }),
+                        value: 'all',
+                      },
+                      {
+                        label: t('acceptance.filter.pending', { count: counts.pending }),
+                        value: 'pending',
+                      },
+                      {
+                        label: t('acceptance.filter.needsFix', { count: counts.needsFix }),
+                        value: 'needsFix',
+                      },
+                      {
+                        label: t('acceptance.filter.accepted', { count: counts.accepted }),
+                        value: 'accepted',
+                      },
+                      {
+                        label: t('acceptance.filter.ignored', { count: counts.ignored }),
+                        value: 'ignored',
+                      },
+                    ]}
+                    onChange={(value) => setFilter(value as CheckFilter)}
+                  />
                   {/* Which round touched a check — audit slicing, orthogonal to the
                 review-state segments. */}
                   {rounds.length > 1 && (
                     <Select
                       size={'small'}
-                      // Filled + the Segmented's exact height so the two read as
-                      // one control family, not a stray bordered input.
+                      // Match the state filter so both read as one control family.
                       style={{ height: 34, width: 110 }}
                       value={roundFilter === null ? 'all' : String(roundFilter)}
                       variant={'filled'}
@@ -1685,7 +1676,6 @@ const AcceptancePage = memo<AcceptancePageProps>(
                   reviewPending={pending}
                   round={roundFilter}
                   onGroupFeedback={handleGroupFeedback}
-                  onOpenItem={isEmbedded ? undefined : setFocusedCheck}
                   onReview={handleReview}
                   onRound={gotoRound}
                   onToggleGroup={(key) =>

--- a/src/features/Verify/Acceptance/index.tsx
+++ b/src/features/Verify/Acceptance/index.tsx
@@ -544,6 +544,8 @@ const AcceptancePage = memo<AcceptancePageProps>(
       );
 
     const { acceptance, checks, isOwner, latestReport, origin, rounds, subject } = data;
+    const originAgent = origin?.agent;
+    const originTopic = origin?.topic;
     const focusedCheck = focusedCheckId
       ? checks.find((check) => check.id === focusedCheckId)
       : undefined;
@@ -1074,73 +1076,67 @@ const AcceptancePage = memo<AcceptancePageProps>(
                 topic). Owner-only: the server redacts it for shared links.
                 Hidden in the portal embed: that surface already lives inside
                 the origin conversation. */}
-                  {!isEmbedded &&
-                    (origin?.agent || origin?.topic || scope?.pullRequest?.number) && (
-                      <Flexbox horizontal align={'center'} gap={16} wrap={'wrap'}>
-                        {origin.agent && (
-                          <AgentProfilePopup
-                            agentId={origin.agent.id}
-                            trigger={'hover'}
-                            agent={{
-                              avatar: origin.agent.avatar ?? undefined,
-                              backgroundColor: origin.agent.backgroundColor ?? undefined,
-                              title: origin.agent.title ?? undefined,
-                            }}
+                  {!isEmbedded && (originAgent || originTopic || scope?.pullRequest?.number) && (
+                    <Flexbox horizontal align={'center'} gap={16} wrap={'wrap'}>
+                      {originAgent && (
+                        <AgentProfilePopup
+                          agentId={originAgent.id}
+                          trigger={'hover'}
+                          agent={{
+                            avatar: originAgent.avatar ?? undefined,
+                            backgroundColor: originAgent.backgroundColor ?? undefined,
+                            title: originAgent.title ?? undefined,
+                          }}
+                        >
+                          <Flexbox
+                            horizontal
+                            align={'center'}
+                            className={styles.scopeChip}
+                            gap={6}
+                            style={{ cursor: 'default', fontSize: 14 }}
                           >
-                            <Flexbox
-                              horizontal
-                              align={'center'}
-                              className={styles.scopeChip}
-                              gap={6}
-                              style={{ cursor: 'default', fontSize: 14 }}
-                            >
-                              <Avatar
-                                avatar={origin.agent.avatar ?? undefined}
-                                background={origin.agent.backgroundColor ?? undefined}
-                                size={18}
-                              />
-                              {origin.agent.title ?? t('acceptance.origin.agentFallback')}
-                            </Flexbox>
-                          </AgentProfilePopup>
-                        )}
-                        {origin.topic && (
-                          <Button
+                            <Avatar
+                              avatar={originAgent.avatar ?? undefined}
+                              background={originAgent.backgroundColor ?? undefined}
+                              size={18}
+                            />
+                            {originAgent.title ?? t('acceptance.origin.agentFallback')}
+                          </Flexbox>
+                        </AgentProfilePopup>
+                      )}
+                      {originTopic && (
+                        <Button
+                          className={cx(styles.scopeChip, styles.scopeLink)}
+                          icon={MessagesSquare}
+                          size={'small'}
+                          style={{ fontSize: 14 }}
+                          title={t('acceptance.origin.openTopic')}
+                          type={'text'}
+                          onClick={openTopicPanel}
+                        >
+                          {originTopic.title ?? subject.title ?? originTopic.id}
+                        </Button>
+                      )}
+                      {scope?.pullRequest?.number &&
+                        (scope.pullRequest.url ? (
+                          <a
                             className={cx(styles.scopeChip, styles.scopeLink)}
-                            icon={MessagesSquare}
-                            size={'small'}
-                            style={{ fontSize: 14 }}
-                            title={t('acceptance.origin.openTopic')}
-                            type={'text'}
-                            onClick={openTopicPanel}
+                            href={scope.pullRequest.url}
+                            rel={'noreferrer'}
+                            target={'_blank'}
+                            title={scope.pullRequest.title ?? scope.pullRequest.url}
                           >
-                            {origin.topic.title ?? subject.title ?? origin.topic.id}
-                          </Button>
-                        )}
-                        {scope?.pullRequest?.number &&
-                          (scope.pullRequest.url ? (
-                            <a
-                              className={cx(styles.scopeChip, styles.scopeLink)}
-                              href={scope.pullRequest.url}
-                              rel={'noreferrer'}
-                              target={'_blank'}
-                              title={scope.pullRequest.title ?? scope.pullRequest.url}
-                            >
-                              <Flexbox horizontal align={'center'} gap={4}>
-                                <Icon icon={GitPullRequest} size={13} /> #{scope.pullRequest.number}
-                              </Flexbox>
-                            </a>
-                          ) : (
-                            <Flexbox
-                              horizontal
-                              align={'center'}
-                              className={styles.scopeChip}
-                              gap={4}
-                            >
+                            <Flexbox horizontal align={'center'} gap={4}>
                               <Icon icon={GitPullRequest} size={13} /> #{scope.pullRequest.number}
                             </Flexbox>
-                          ))}
-                      </Flexbox>
-                    )}
+                          </a>
+                        ) : (
+                          <Flexbox horizontal align={'center'} className={styles.scopeChip} gap={4}>
+                            <Icon icon={GitPullRequest} size={13} /> #{scope.pullRequest.number}
+                          </Flexbox>
+                        ))}
+                    </Flexbox>
+                  )}
                   {!isEmbedded && orderedChecks.length > 0 && (
                     <Button
                       icon={<Icon icon={ChevronRight} />}

--- a/src/features/Verify/Acceptance/routes.test.ts
+++ b/src/features/Verify/Acceptance/routes.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { acceptanceCheckPath, acceptanceOverviewPath } from './routes';
+
+describe('acceptance routes', () => {
+  it('builds the overview route', () => {
+    expect(acceptanceOverviewPath('acceptance-1')).toBe('/acceptance/acceptance-1');
+  });
+
+  it('builds the nested check route and escapes route params', () => {
+    expect(acceptanceCheckPath('acceptance/1', 'check/1')).toBe(
+      '/acceptance/acceptance%2F1/check/check%2F1',
+    );
+  });
+});

--- a/src/features/Verify/Acceptance/routes.ts
+++ b/src/features/Verify/Acceptance/routes.ts
@@ -1,0 +1,5 @@
+export const acceptanceOverviewPath = (acceptanceId: string) =>
+  `/acceptance/${encodeURIComponent(acceptanceId)}`;
+
+export const acceptanceCheckPath = (acceptanceId: string, checkId: string) =>
+  `${acceptanceOverviewPath(acceptanceId)}/check/${encodeURIComponent(checkId)}`;

--- a/src/spa/router/desktopRouter.config.desktop.tsx
+++ b/src/spa/router/desktopRouter.config.desktop.tsx
@@ -840,6 +840,11 @@ export const desktopRoutes: RouteObject[] = [
         handle: { meta: acceptanceRouteMeta },
         path: ':acceptanceId',
       },
+      {
+        element: <AcceptanceReportPage />,
+        handle: { meta: acceptanceRouteMeta },
+        path: ':acceptanceId/check/:checkId',
+      },
     ],
     element: <AcceptanceWorkspace />,
     errorElement: <ErrorBoundary />,

--- a/src/spa/router/desktopRouter.config.tsx
+++ b/src/spa/router/desktopRouter.config.tsx
@@ -1111,6 +1111,14 @@ export const desktopRoutes: RouteObject[] = [
         handle: { meta: acceptanceRouteMeta },
         path: ':acceptanceId',
       },
+      {
+        element: dynamicElement(
+          () => import('@/routes/acceptance/[acceptanceId]'),
+          'Desktop > AcceptanceCheck',
+        ),
+        handle: { meta: acceptanceRouteMeta },
+        path: ':acceptanceId/check/:checkId',
+      },
     ],
     element: dynamicElement(() => import('@/routes/(main)/acceptance'), 'Desktop > Acceptance'),
     errorElement: <ErrorBoundary />,

--- a/src/spa/router/desktopRouter.sync.test.tsx
+++ b/src/spa/router/desktopRouter.sync.test.tsx
@@ -83,6 +83,16 @@ async function readDesktopRouterSources() {
 }
 
 describe('desktopRouter config sync', () => {
+  it('matches the nested acceptance check route', () => {
+    const matches = matchRoutes(desktopRoutes, '/acceptance/acceptance-1/check/check-1');
+
+    expect(matches?.at(-1)?.route.path).toBe(':acceptanceId/check/:checkId');
+    expect(matches?.at(-1)?.params).toMatchObject({
+      acceptanceId: 'acceptance-1',
+      checkId: 'check-1',
+    });
+  });
+
   it('personal memory settings route is not shadowed by workspace memory route', () => {
     const matches = matchRoutes(desktopRoutes, '/settings/memory');
     const paths = matches?.map((match) => match.route.path);

--- a/src/spa/router/mobileRouter.config.tsx
+++ b/src/spa/router/mobileRouter.config.tsx
@@ -627,4 +627,13 @@ export const mobileRoutes: RouteObject[] = [
     handle: { meta: acceptanceRouteMeta },
     path: '/acceptance/:acceptanceId',
   },
+  {
+    element: dynamicElement(
+      () => import('@/routes/acceptance/[acceptanceId]'),
+      'Mobile > AcceptanceCheck',
+    ),
+    errorElement: <ErrorBoundary />,
+    handle: { meta: acceptanceRouteMeta },
+    path: '/acceptance/:acceptanceId/check/:checkId',
+  },
 ];


### PR DESCRIPTION
## What changed

- add canonical `/acceptance/:acceptanceId/check/:checkId` routes across desktop and mobile, with legacy `?check=` migration
- preserve inline check expansion and move focused review behind an explicit entry
- replace the global Acceptance sidebar with the current check list in focused mode
- refine Acceptance hierarchy, filters, row metadata, and focused workspace spacing
- add route and desktop-router regression coverage

## Why

Check rows had two competing interaction meanings, and the focused review surface could produce a crowded three-column layout. The overview also carried dense always-visible metadata and inconsistent filter controls.

## Impact

Reviewers can expand evidence in place or intentionally enter a stable, deep-linkable check workspace. The focused page is calmer, keeps its check context, and remains compatible with existing shared links.

## Validation

- `bun run check`
- 13 files lint clean
- 29 tests passed
- Electron E2E verification against a real Acceptance, including hover/focus metadata, route switching, back navigation, and layout geometry
- Acceptance report: https://app.lobehub.com/acceptance/4577e13c-35b4-40b7-af9e-b7922361f877?r=5
