### PR TITLE
🐛 fix(model-runtime): opt into summarized thinking display on Claude 5

### DIFF
--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
@@ -41,6 +41,7 @@ import {
 import { handleAnthropicError } from './handleAnthropicError';
 import { resolveCacheTTL } from './resolveCacheTTL';
 import { resolveMaxTokens } from './resolveMaxTokens';
+import { resolveClaudeThinkingConfig } from './resolveThinkingConfig';
 
 type ConstructorOptions<T extends Record<string, any> = any> = ClientOptions &
   ModelIdMappingOptions &
@@ -199,22 +200,20 @@ export const buildDefaultAnthropicPayload = async (
     postTools = postTools?.length ? [...postTools, webSearchTool] : [webSearchTool];
   }
 
-  if (!!thinking && (thinking.type === 'enabled' || thinking.type === 'adaptive')) {
-    const resolvedThinking: Anthropic.MessageCreateParams['thinking'] =
-      thinking.type === 'enabled'
-        ? {
-            budget_tokens: Math.min(thinking?.budget_tokens || 1024, resolvedMaxTokens - 1),
-            type: 'enabled',
-          }
-        : { type: 'adaptive' };
+  const resolvedThinking = resolveClaudeThinkingConfig({
+    maxTokens: resolvedMaxTokens,
+    model,
+    thinking,
+  });
 
+  if (resolvedThinking && resolvedThinking.type !== 'disabled') {
     return {
       max_tokens: resolvedMaxTokens,
       messages: postMessages,
       model,
       ...(effort ? { output_config: { effort } } : {}),
       system: systemPrompts,
-      thinking: resolvedThinking,
+      thinking: resolvedThinking as Anthropic.MessageCreateParams['thinking'],
       tools: postTools as Anthropic.MessageCreateParams['tools'],
     } as Anthropic.MessageCreateParams;
   }
@@ -235,11 +234,15 @@ export const buildDefaultAnthropicPayload = async (
     system: systemPrompts,
     temperature: resolvedSamplingParams.temperature,
     tools: postTools as Anthropic.MessageCreateParams['tools'],
+    ...(resolvedThinking
+      ? { thinking: resolvedThinking as Anthropic.MessageCreateParams['thinking'] }
+      : {}),
     top_p: resolvedSamplingParams.top_p,
   };
 
-  // If effort is specified without thinking mode, add output_config
-  if (effort) {
+  // If effort is specified without thinking mode, add output_config. Claude Opus 5 rejects
+  // `disabled` thinking at effort `xhigh` / `max`, so effort is dropped once thinking is off.
+  if (effort && !resolvedThinking) {
     return {
       ...basePayload,
       output_config: { effort },

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
@@ -6,7 +6,10 @@ import debug from 'debug';
 import type { Pricing } from 'model-bank';
 
 import { ErrorClassifier } from '../../errors';
-import { shouldDropUnsupportedClaudeAssistantPrefill } from '../../providers/anthropic/modelId';
+import {
+  rejectsDisabledThinkingAtEffort,
+  shouldDropUnsupportedClaudeAssistantPrefill,
+} from '../../providers/anthropic/modelId';
 import type {
   ChatCompletionErrorPayload,
   ChatMethodOptions,
@@ -226,6 +229,12 @@ export const buildDefaultAnthropicPayload = async (
     { normalizeTemperature: true, preferTemperature: true },
   );
 
+  // Claude Opus 5 and later reject disabled thinking at effort `xhigh` / `max`; every lower
+  // effort level stays valid, so only that pairing is dropped.
+  const forwardsEffort =
+    !!effort &&
+    !(resolvedThinking?.type === 'disabled' && rejectsDisabledThinkingAtEffort(model, effort));
+
   // Support effort parameter even without thinking (per Claude 4.6 guidance)
   const basePayload: Anthropic.MessageCreateParams = {
     max_tokens: resolvedMaxTokens,
@@ -240,9 +249,8 @@ export const buildDefaultAnthropicPayload = async (
     top_p: resolvedSamplingParams.top_p,
   };
 
-  // If effort is specified without thinking mode, add output_config. Claude Opus 5 rejects
-  // `disabled` thinking at effort `xhigh` / `max`, so effort is dropped once thinking is off.
-  if (effort && !resolvedThinking) {
+  // If effort is specified without an incompatible thinking mode, add output_config
+  if (forwardsEffort) {
     return {
       ...basePayload,
       output_config: { effort },

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/resolveThinkingConfig.test.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/resolveThinkingConfig.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveClaudeThinkingConfig } from './resolveThinkingConfig';
+
+const resolve = (
+  model: string,
+  thinking?: Parameters<typeof resolveClaudeThinkingConfig>[0]['thinking'],
+) => resolveClaudeThinkingConfig({ maxTokens: 64_000, model, thinking });
+
+describe('resolveClaudeThinkingConfig', () => {
+  describe('models that ship thinking on', () => {
+    it.each(['claude-fable-5', 'claude-opus-5', 'claude-sonnet-5'])(
+      'should request summarized thinking for %s even without a thinking config',
+      (model) => {
+        // Regression: these models think (and bill) on every request, and default `display` to
+        // `omitted`, so sending no thinking config returned empty reasoning blocks.
+        expect(resolve(model)).toEqual({ display: 'summarized', type: 'adaptive' });
+      },
+    );
+
+    it('should keep forwarding an explicit disabled thinking config', () => {
+      expect(resolve('claude-sonnet-5', { type: 'disabled' })).toEqual({ type: 'disabled' });
+    });
+
+    it('should omit the thinking config on models that reject disabled thinking', () => {
+      // Claude Fable 5 returns a 400 for `thinking.type: 'disabled'`; omitting the config keeps
+      // its default `omitted` display, which is what turning the switch off asks for.
+      expect(resolve('claude-fable-5', { type: 'disabled' })).toBeUndefined();
+    });
+  });
+
+  describe('models that default thinking off but omit the display', () => {
+    it.each(['claude-opus-4-8', 'claude-opus-4-7'])(
+      'should not turn thinking on for %s when no config is given',
+      (model) => {
+        expect(resolve(model)).toBeUndefined();
+      },
+    );
+
+    it.each(['claude-opus-4-8', 'claude-opus-4-7'])(
+      'should request summarized thinking for %s once adaptive is enabled',
+      (model) => {
+        expect(resolve(model, { type: 'adaptive' })).toEqual({
+          display: 'summarized',
+          type: 'adaptive',
+        });
+      },
+    );
+
+    it('should not forward a disabled config to a model that already defaults off', () => {
+      expect(resolve('claude-opus-4-8', { type: 'disabled' })).toBeUndefined();
+    });
+  });
+
+  describe('models that still default the display to summarized', () => {
+    it.each(['claude-opus-4-6', 'claude-sonnet-4-6'])('should leave %s untouched', (model) => {
+      expect(resolve(model)).toBeUndefined();
+      expect(resolve(model, { type: 'adaptive' })).toEqual({ type: 'adaptive' });
+    });
+
+    it('should cap the manual budget below max_tokens without adding a display', () => {
+      expect(
+        resolveClaudeThinkingConfig({
+          maxTokens: 8000,
+          model: 'claude-sonnet-4-6',
+          thinking: { budget_tokens: 32_000, type: 'enabled' },
+        }),
+      ).toEqual({ budget_tokens: 7999, type: 'enabled' });
+    });
+  });
+
+  it('should ignore non-Claude models', () => {
+    expect(resolve('gpt-5')).toBeUndefined();
+    expect(resolve('gpt-5', { type: 'disabled' })).toBeUndefined();
+  });
+});

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/resolveThinkingConfig.test.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/resolveThinkingConfig.test.ts
@@ -69,6 +69,28 @@ describe('resolveClaudeThinkingConfig', () => {
     });
   });
 
+  describe('an explicit display from the caller', () => {
+    it('should win over the model default', () => {
+      expect(resolve('claude-opus-4-7', { display: 'omitted', type: 'adaptive' })).toEqual({
+        display: 'omitted',
+        type: 'adaptive',
+      });
+    });
+
+    it('should be honored on models that default to summarized', () => {
+      expect(resolve('claude-opus-4-6', { display: 'omitted', type: 'adaptive' })).toEqual({
+        display: 'omitted',
+        type: 'adaptive',
+      });
+    });
+
+    it('should be dropped alongside disabled thinking, where display is invalid', () => {
+      expect(resolve('claude-sonnet-5', { display: 'omitted', type: 'disabled' })).toEqual({
+        type: 'disabled',
+      });
+    });
+  });
+
   it('should ignore non-Claude models', () => {
     expect(resolve('gpt-5')).toBeUndefined();
     expect(resolve('gpt-5', { type: 'disabled' })).toBeUndefined();

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/resolveThinkingConfig.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/resolveThinkingConfig.ts
@@ -38,9 +38,12 @@ export const resolveClaudeThinkingConfig = ({
   model: string;
   thinking?: ChatStreamPayload['thinking'];
 }): ResolvedClaudeThinkingConfig | undefined => {
-  const displayConfig = isThinkingDisplayOmittedByDefaultModel(model)
-    ? { display: 'summarized' as const }
-    : {};
+  // An explicit `display` from the caller always wins; the model default only fills the gap.
+  const displayConfig = thinking?.display
+    ? { display: thinking.display }
+    : isThinkingDisplayOmittedByDefaultModel(model)
+      ? { display: 'summarized' as const }
+      : {};
 
   switch (thinking?.type) {
     case 'enabled': {
@@ -61,6 +64,8 @@ export const resolveClaudeThinkingConfig = ({
       // reasoning text out of the response, which is what turning the switch off asks for.
       if (isAlwaysThinkingClaudeModel(model)) return undefined;
 
+      // `display` is invalid alongside `disabled` — there is nothing to display — so any caller
+      // value is dropped here rather than forwarded.
       // Models that default thinking off need no explicit opt-out.
       return isAdaptiveThinkingDefaultOnModel(model) ? { type: 'disabled' } : undefined;
     }

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/resolveThinkingConfig.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/resolveThinkingConfig.ts
@@ -1,0 +1,74 @@
+import {
+  isAdaptiveThinkingDefaultOnModel,
+  isAlwaysThinkingClaudeModel,
+  isThinkingDisplayOmittedByDefaultModel,
+} from '../../providers/anthropic/modelId';
+import type { ChatStreamPayload } from '../../types';
+
+export interface ResolvedClaudeThinkingConfig {
+  budget_tokens?: number;
+  display?: 'omitted' | 'summarized';
+  type: 'adaptive' | 'disabled' | 'enabled';
+}
+
+/**
+ * Resolve the `thinking` field of a Claude request payload, shared by the Anthropic-compatible
+ * factory and Bedrock so both honor the same per-model rules.
+ *
+ * Two model-specific behaviors drive this:
+ *
+ * 1. `display` defaults to `omitted` on Claude Fable 5 / Opus 5 / Sonnet 5 / Opus 4.8 / Opus 4.7,
+ *    which returns thinking blocks with an empty `thinking` field. We surface reasoning in the UI,
+ *    so those models need an explicit `display: 'summarized'`.
+ * 2. Models that ship thinking on (Claude 5 and later) keep thinking — and keep billing for it —
+ *    even when the request carries no `thinking` config, so leaving it out is not "no thinking",
+ *    it is "thinking the user never gets to see".
+ *
+ * Returns `undefined` when the request should carry no `thinking` field at all.
+ *
+ * @see https://platform.claude.com/docs/en/build-with-claude/thinking#controlling-thinking-display
+ * @see https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting#supported-models
+ */
+export const resolveClaudeThinkingConfig = ({
+  maxTokens,
+  model,
+  thinking,
+}: {
+  maxTokens: number;
+  model: string;
+  thinking?: ChatStreamPayload['thinking'];
+}): ResolvedClaudeThinkingConfig | undefined => {
+  const displayConfig = isThinkingDisplayOmittedByDefaultModel(model)
+    ? { display: 'summarized' as const }
+    : {};
+
+  switch (thinking?.type) {
+    case 'enabled': {
+      return {
+        budget_tokens: Math.min(thinking.budget_tokens || 1024, maxTokens - 1),
+        type: 'enabled',
+        ...displayConfig,
+      };
+    }
+
+    case 'adaptive': {
+      return { type: 'adaptive', ...displayConfig };
+    }
+
+    case 'disabled': {
+      // Fable 5 / Mythos 5 reject `disabled` with a 400. Omitting the config is the documented
+      // fallback: they think regardless, and their `omitted` display default already keeps the
+      // reasoning text out of the response, which is what turning the switch off asks for.
+      if (isAlwaysThinkingClaudeModel(model)) return undefined;
+
+      // Models that default thinking off need no explicit opt-out.
+      return isAdaptiveThinkingDefaultOnModel(model) ? { type: 'disabled' } : undefined;
+    }
+
+    default: {
+      return isAdaptiveThinkingDefaultOnModel(model)
+        ? { type: 'adaptive', ...displayConfig }
+        : undefined;
+    }
+  }
+};

--- a/packages/model-runtime/src/providers/anthropic/index.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/index.test.ts
@@ -884,7 +884,8 @@ describe('LobeAnthropicAI', () => {
           model: 'claude-opus-4-7',
           output_config: { effort: 'xhigh' },
           system: undefined,
-          thinking: { type: 'adaptive' },
+          // Opus 4.7 defaults `display` to `omitted`, so reasoning has to be opted into
+          thinking: { display: 'summarized', type: 'adaptive' },
           tools: undefined,
         });
       });

--- a/packages/model-runtime/src/providers/anthropic/modelId.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/modelId.test.ts
@@ -8,6 +8,7 @@ import {
   isThinkingDisplayOmittedByDefaultModel,
   isThinkingWithToolClaudeModel,
   parseClaudeModelId,
+  rejectsDisabledThinkingAtEffort,
   shouldDropUnsupportedClaudeAssistantPrefill,
   shouldOmitSamplingParams,
 } from './modelId';
@@ -174,6 +175,27 @@ describe('isThinkingDisplayOmittedByDefaultModel', () => {
     expect(isThinkingDisplayOmittedByDefaultModel('claude-opus-4-5-20251101')).toBe(false);
     expect(isThinkingDisplayOmittedByDefaultModel('claude-haiku-4-5-20251001')).toBe(false);
     expect(isThinkingDisplayOmittedByDefaultModel('gpt-5')).toBe(false);
+  });
+});
+
+describe('rejectsDisabledThinkingAtEffort', () => {
+  it('should only reject the xhigh / max pairing on Claude 5 and later', () => {
+    expect(rejectsDisabledThinkingAtEffort('claude-opus-5', 'xhigh')).toBe(true);
+    expect(rejectsDisabledThinkingAtEffort('claude-opus-5', 'max')).toBe(true);
+    expect(rejectsDisabledThinkingAtEffort('global.anthropic.claude-sonnet-5', 'max')).toBe(true);
+  });
+
+  it('should keep every lower effort level valid alongside disabled thinking', () => {
+    expect(rejectsDisabledThinkingAtEffort('claude-opus-5', 'high')).toBe(false);
+    expect(rejectsDisabledThinkingAtEffort('claude-sonnet-5', 'high')).toBe(false);
+    expect(rejectsDisabledThinkingAtEffort('claude-opus-5', 'medium')).toBe(false);
+    expect(rejectsDisabledThinkingAtEffort('claude-opus-5', 'low')).toBe(false);
+  });
+
+  it('should not apply to earlier models or non-Claude ids', () => {
+    expect(rejectsDisabledThinkingAtEffort('claude-opus-4-8', 'xhigh')).toBe(false);
+    expect(rejectsDisabledThinkingAtEffort('claude-opus-4-6', 'max')).toBe(false);
+    expect(rejectsDisabledThinkingAtEffort('gpt-5', 'xhigh')).toBe(false);
   });
 });
 

--- a/packages/model-runtime/src/providers/anthropic/modelId.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/modelId.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest';
 import {
   hasTemperatureTopPConflict,
   isAdaptiveThinkingDefaultOnModel,
+  isAlwaysThinkingClaudeModel,
   isContextCachingModel,
+  isThinkingDisplayOmittedByDefaultModel,
   isThinkingWithToolClaudeModel,
   parseClaudeModelId,
   shouldDropUnsupportedClaudeAssistantPrefill,
@@ -134,6 +136,44 @@ describe('isAdaptiveThinkingDefaultOnModel', () => {
     expect(isAdaptiveThinkingDefaultOnModel('claude-sonnet-4.6')).toBe(false);
     expect(isAdaptiveThinkingDefaultOnModel('claude-haiku-4-5-20251001')).toBe(false);
     expect(isAdaptiveThinkingDefaultOnModel('gpt-5')).toBe(false);
+  });
+});
+
+describe('isAlwaysThinkingClaudeModel', () => {
+  it('should return true for the families that reject disabled thinking', () => {
+    expect(isAlwaysThinkingClaudeModel('claude-fable-5')).toBe(true);
+    expect(isAlwaysThinkingClaudeModel('claude-mythos-5')).toBe(true);
+    expect(isAlwaysThinkingClaudeModel('anthropic/claude-fable-5')).toBe(true);
+    expect(isAlwaysThinkingClaudeModel('global.anthropic.claude-fable-5')).toBe(true);
+  });
+
+  it('should return false for models that accept disabled thinking', () => {
+    expect(isAlwaysThinkingClaudeModel('claude-opus-5')).toBe(false);
+    expect(isAlwaysThinkingClaudeModel('claude-sonnet-5')).toBe(false);
+    expect(isAlwaysThinkingClaudeModel('claude-opus-4-8')).toBe(false);
+    expect(isAlwaysThinkingClaudeModel('claude-sonnet-4-6')).toBe(false);
+    expect(isAlwaysThinkingClaudeModel('gpt-5')).toBe(false);
+  });
+});
+
+describe('isThinkingDisplayOmittedByDefaultModel', () => {
+  it('should return true for Claude 5 and Opus 4.7 / 4.8', () => {
+    expect(isThinkingDisplayOmittedByDefaultModel('claude-fable-5')).toBe(true);
+    expect(isThinkingDisplayOmittedByDefaultModel('claude-opus-5')).toBe(true);
+    expect(isThinkingDisplayOmittedByDefaultModel('claude-sonnet-5')).toBe(true);
+    expect(isThinkingDisplayOmittedByDefaultModel('claude-opus-4-8')).toBe(true);
+    expect(isThinkingDisplayOmittedByDefaultModel('claude-opus-4-7')).toBe(true);
+    expect(isThinkingDisplayOmittedByDefaultModel('claude-opus-4.7')).toBe(true);
+    expect(isThinkingDisplayOmittedByDefaultModel('global.anthropic.claude-sonnet-5')).toBe(true);
+  });
+
+  it('should return false for models that still default to summarized', () => {
+    expect(isThinkingDisplayOmittedByDefaultModel('claude-opus-4-6')).toBe(false);
+    expect(isThinkingDisplayOmittedByDefaultModel('claude-sonnet-4-6')).toBe(false);
+    expect(isThinkingDisplayOmittedByDefaultModel('claude-sonnet-4-5-20250929')).toBe(false);
+    expect(isThinkingDisplayOmittedByDefaultModel('claude-opus-4-5-20251101')).toBe(false);
+    expect(isThinkingDisplayOmittedByDefaultModel('claude-haiku-4-5-20251001')).toBe(false);
+    expect(isThinkingDisplayOmittedByDefaultModel('gpt-5')).toBe(false);
   });
 });
 

--- a/packages/model-runtime/src/providers/anthropic/modelId.ts
+++ b/packages/model-runtime/src/providers/anthropic/modelId.ts
@@ -140,6 +140,35 @@ export const isAdaptiveThinkingDefaultOnModel = (model: string): boolean => {
   return !!parsed && parsed.majorVersion >= 5;
 };
 
+/**
+ * Thinking cannot be turned off on these models — `thinking: {type: 'disabled'}` returns a 400.
+ * Callers should omit the thinking config instead; `display` is the way to hide reasoning text.
+ * @see https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting#supported-models
+ */
+export const isAlwaysThinkingClaudeModel = (model: string): boolean => {
+  const parsed = parseClaudeModelId(model);
+  if (!parsed) return false;
+
+  // Claude Fable 5 and Claude Mythos 5 (and Claude Mythos Preview) always think.
+  return isClaudeFamily(parsed, ['fable', 'mythos']) && parsed.majorVersion >= 5;
+};
+
+/**
+ * `thinking.display` defaults to `omitted` on these models, so reasoning comes back as thinking
+ * blocks with an empty `thinking` field (streaming emits no `thinking_delta`). Anything that
+ * surfaces reasoning to users has to opt into `display: 'summarized'` explicitly.
+ * @see https://platform.claude.com/docs/en/build-with-claude/thinking#controlling-thinking-display
+ */
+export const isThinkingDisplayOmittedByDefaultModel = (model: string): boolean => {
+  const parsed = parseClaudeModelId(model);
+  if (!parsed) return false;
+
+  if (parsed.majorVersion >= 5) return true;
+
+  // Claude Opus 4.8 / 4.7; Opus 4.6 and earlier still default to `summarized`.
+  return parsed.family === 'opus' && parsed.majorVersion === 4 && hasMinorVersionAtLeast(parsed, 7);
+};
+
 export const hasTemperatureTopPConflict = (model: string): boolean => {
   const parsed = parseClaudeModelId(model);
   return !!parsed && parsed.majorVersion >= 4;

--- a/packages/model-runtime/src/providers/anthropic/modelId.ts
+++ b/packages/model-runtime/src/providers/anthropic/modelId.ts
@@ -169,6 +169,22 @@ export const isThinkingDisplayOmittedByDefaultModel = (model: string): boolean =
   return parsed.family === 'opus' && parsed.majorVersion === 4 && hasMinorVersionAtLeast(parsed, 7);
 };
 
+const EFFORTS_INCOMPATIBLE_WITH_DISABLED_THINKING = new Set(['xhigh', 'max']);
+
+/**
+ * Claude Opus 5 and later reject `thinking: {type: 'disabled'}` combined with effort `xhigh` or
+ * `max`. Every lower effort level stays valid alongside disabled thinking, so callers should drop
+ * `effort` only for this specific pairing.
+ * @see https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting#supported-models
+ */
+export const rejectsDisabledThinkingAtEffort = (model: string, effort: string): boolean => {
+  const parsed = parseClaudeModelId(model);
+
+  return (
+    !!parsed && parsed.majorVersion >= 5 && EFFORTS_INCOMPATIBLE_WITH_DISABLED_THINKING.has(effort)
+  );
+};
+
 export const hasTemperatureTopPConflict = (model: string): boolean => {
   const parsed = parseClaudeModelId(model);
   return !!parsed && parsed.majorVersion >= 4;

--- a/packages/model-runtime/src/providers/bedrock/index.test.ts
+++ b/packages/model-runtime/src/providers/bedrock/index.test.ts
@@ -584,7 +584,7 @@ describe('LobeBedrockAI', () => {
       });
 
       describe('Parameter conflict handling for Claude 4+ models', () => {
-        it('should forward effort when Claude Opus 5 uses default adaptive thinking', async () => {
+        it('should forward effort and visible thinking when Claude Opus 5 uses default adaptive thinking', async () => {
           const mockStream = new ReadableStream({
             start(controller) {
               controller.enqueue('Hello, world!');
@@ -621,6 +621,9 @@ describe('LobeBedrockAI', () => {
               },
             ],
             output_config: { effort: 'xhigh' },
+            // Opus 5 thinks even without a `thinking` config, and defaults `display` to
+            // `omitted` — without this the reasoning comes back empty.
+            thinking: { display: 'summarized', type: 'adaptive' },
           });
         });
 

--- a/packages/model-runtime/src/providers/bedrock/index.ts
+++ b/packages/model-runtime/src/providers/bedrock/index.ts
@@ -14,6 +14,7 @@ import {
 } from '../../core/anthropicCompatibleFactory/generateObject';
 import { resolveCacheTTL } from '../../core/anthropicCompatibleFactory/resolveCacheTTL';
 import { resolveMaxTokens } from '../../core/anthropicCompatibleFactory/resolveMaxTokens';
+import { resolveClaudeThinkingConfig } from '../../core/anthropicCompatibleFactory/resolveThinkingConfig';
 import type { LobeRuntimeAI } from '../../core/BaseAI';
 import { buildAnthropicMessages, buildAnthropicTools } from '../../core/contextBuilders/anthropic';
 import { resolveModelSamplingParameters } from '../../core/parameterResolver';
@@ -38,10 +39,7 @@ import { debugStream } from '../../utils/debugStream';
 import { getModelPricing } from '../../utils/getModelPricing';
 import { StreamingResponse } from '../../utils/response';
 import { normalizeClaudeThinkingHistoryMessages } from '../anthropic/claudeThinkingHistory';
-import {
-  parseClaudeModelId,
-  shouldDropUnsupportedClaudeAssistantPrefill,
-} from '../anthropic/modelId';
+import { shouldDropUnsupportedClaudeAssistantPrefill } from '../anthropic/modelId';
 
 /**
  * A prompt constructor for HuggingFace LLama 2 chat models.
@@ -327,18 +325,16 @@ export class LobeBedrockAI implements LobeRuntimeAI {
 
     let anthropicPayload;
 
-    if (!!thinking && (thinking.type === 'enabled' || thinking.type === 'adaptive')) {
-      const resolvedThinking =
-        thinking.type === 'enabled'
-          ? {
-              budget_tokens: Math.min(thinking?.budget_tokens || 1024, resolvedMaxTokens - 1),
-              type: 'enabled' as const,
-            }
-          : { type: 'adaptive' as const };
+    const resolvedThinking = resolveClaudeThinkingConfig({
+      maxTokens: resolvedMaxTokens,
+      model,
+      thinking,
+    });
 
+    if (resolvedThinking && resolvedThinking.type !== 'disabled') {
       anthropicPayload = {
         ...anthropicBase,
-        ...(thinking.type === 'adaptive' && effort ? { output_config: { effort } } : {}),
+        ...(resolvedThinking.type === 'adaptive' && effort ? { output_config: { effort } } : {}),
         thinking: resolvedThinking,
       };
     } else {
@@ -349,14 +345,13 @@ export class LobeBedrockAI implements LobeRuntimeAI {
         { temperature, top_p },
         { normalizeTemperature: true, preferTemperature: true },
       );
-      const claudeModel = parseClaudeModelId(model);
-      const shouldForwardDisabledThinking =
-        thinking?.type === 'disabled' && !!claudeModel && claudeModel.majorVersion >= 5;
 
       anthropicPayload = {
         ...anthropicBase,
-        ...(effort && thinking?.type !== 'disabled' ? { output_config: { effort } } : {}),
-        ...(shouldForwardDisabledThinking ? { thinking: { type: 'disabled' as const } } : {}),
+        // Claude Opus 5 rejects `disabled` thinking at effort `xhigh` / `max`, so effort is only
+        // forwarded when thinking stays on.
+        ...(effort && !resolvedThinking ? { output_config: { effort } } : {}),
+        ...(resolvedThinking ? { thinking: resolvedThinking } : {}),
         temperature: resolvedSamplingParams.temperature,
         top_p: resolvedSamplingParams.top_p,
       };

--- a/packages/model-runtime/src/providers/bedrock/index.ts
+++ b/packages/model-runtime/src/providers/bedrock/index.ts
@@ -39,7 +39,10 @@ import { debugStream } from '../../utils/debugStream';
 import { getModelPricing } from '../../utils/getModelPricing';
 import { StreamingResponse } from '../../utils/response';
 import { normalizeClaudeThinkingHistoryMessages } from '../anthropic/claudeThinkingHistory';
-import { shouldDropUnsupportedClaudeAssistantPrefill } from '../anthropic/modelId';
+import {
+  rejectsDisabledThinkingAtEffort,
+  shouldDropUnsupportedClaudeAssistantPrefill,
+} from '../anthropic/modelId';
 
 /**
  * A prompt constructor for HuggingFace LLama 2 chat models.
@@ -346,11 +349,15 @@ export class LobeBedrockAI implements LobeRuntimeAI {
         { normalizeTemperature: true, preferTemperature: true },
       );
 
+      // Claude Opus 5 and later reject disabled thinking at effort `xhigh` / `max`; every lower
+      // effort level stays valid, so only that pairing is dropped.
+      const forwardsEffort =
+        !!effort &&
+        !(resolvedThinking?.type === 'disabled' && rejectsDisabledThinkingAtEffort(model, effort));
+
       anthropicPayload = {
         ...anthropicBase,
-        // Claude Opus 5 rejects `disabled` thinking at effort `xhigh` / `max`, so effort is only
-        // forwarded when thinking stays on.
-        ...(effort && !resolvedThinking ? { output_config: { effort } } : {}),
+        ...(forwardsEffort ? { output_config: { effort } } : {}),
         ...(resolvedThinking ? { thinking: resolvedThinking } : {}),
         temperature: resolvedSamplingParams.temperature,
         top_p: resolvedSamplingParams.top_p,

--- a/packages/model-runtime/src/types/chat.ts
+++ b/packages/model-runtime/src/types/chat.ts
@@ -166,6 +166,14 @@ export interface ChatStreamPayload {
    */
   thinking?: {
     budget_tokens?: number;
+    /**
+     * Controls whether the summarized reasoning text is returned. Defaults to `omitted` on
+     * Claude Fable 5 / Opus 5 / Sonnet 5 / Opus 4.8 / Opus 4.7, where thinking blocks then
+     * arrive with an empty `thinking` field and no `thinking_delta` events while streaming.
+     * Invalid together with `type: 'disabled'`.
+     * @see https://platform.claude.com/docs/en/build-with-claude/thinking#controlling-thinking-display
+     */
+    display?: 'omitted' | 'summarized';
     type?: 'enabled' | 'disabled' | 'adaptive';
   };
   thinkingBudget?: number;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-12398

#### 🔀 Description of Change

Reasoning rendered blank on Claude Fable 5 / Opus 5 / Sonnet 5 / Opus 4.8 / Opus 4.7.

Anthropic's `thinking.display` parameter defaults to `"omitted"` on those models, which returns thinking blocks with an empty `thinking` field and emits no `thinking_delta` events while streaming. We never sent `display` at all, so every one of those models came back with reasoning we could not render. Opus 4.6 / Sonnet 4.6 and earlier still default to `"summarized"`, which is why they were unaffected.

The subtle part: models that ship thinking **on** (Claude 5 and later) keep thinking — and keep billing for it — even when the request carries no `thinking` config. So sending nothing is not "no thinking", it is "thinking the user pays for but never sees". The fix therefore has to apply on the default path, not only when the user flips the adaptive-thinking switch.

Thinking construction was duplicated (and already drifting) between `providers/bedrock` and `core/anthropicCompatibleFactory`, so it is extracted into a shared `resolveClaudeThinkingConfig`:

| Model | No thinking config | Adaptive on | Thinking off |
| --- | --- | --- | --- |
| Fable 5 | `{adaptive, summarized}` | `{adaptive, summarized}` | *omitted* |
| Opus 5 / Sonnet 5 | `{adaptive, summarized}` | `{adaptive, summarized}` | `{disabled}` |
| Opus 4.8 / 4.7 | *omitted* | `{adaptive, summarized}` | *omitted* |
| Opus 4.6 / Sonnet 4.6 | *omitted* | `{adaptive}` | *omitted* |
| Claude 4.5 and earlier | unchanged | — | unchanged |

Two smaller correctness fixes ride along, both from the same per-model support table:

- **Claude Fable 5 rejects `thinking: {type: "disabled"}` with a 400.** The old `majorVersion >= 5` gate forwarded it anyway. Turning thinking off there now omits the config, which is the documented fallback — Fable 5 thinks regardless, and its `omitted` display default already keeps the reasoning text out of the response, which is what the switch is asking for.
- **Claude Opus 5 rejects `disabled` thinking at effort `xhigh` / `max`.** Bedrock already dropped `effort` once thinking was off; `anthropicCompatibleFactory` did not. Both paths now agree.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Verified against a live Bedrock endpoint with the payloads the patched code actually produces:

| Case | Sent | Result |
| --- | --- | --- |
| Sonnet 5, no thinking config — **before** | *no thinking field* | ⚠️ empty reasoning |
| Sonnet 5, no thinking config — **after** | `{adaptive, summarized}` | ✅ 393 chars |
| Fable 5, thinking off — **before** | `{disabled}` | ❌ HTTP 400 |
| Fable 5, thinking off — **after** | *no thinking field* | ✅ 200 |
| Opus 4.7, adaptive on | `{adaptive, summarized}` | ✅ 118 chars |
| Sonnet 4.6, adaptive on (must not change) | `{adaptive}` | ✅ 75 chars |

Unit tests: new `resolveThinkingConfig.test.ts` (14 cases) covering every row of the table above, plus `isAlwaysThinkingClaudeModel` / `isThinkingDisplayOmittedByDefaultModel` in `modelId.test.ts`. Two existing payload assertions (`claude-opus-4-7` with xhigh effort, Bedrock `claude-opus-5` default adaptive) were updated — both are the intended behavior change.

#### 📝 Additional Information

**Key decisions**

- **Opus 4.8 / 4.7 deliberately keep "no config = no thinking."** They default thinking *off*, so injecting a config on the default path would silently start thinking — and billing — for users who never enabled it. Only Claude 5, where the model thinks regardless, gets the default-path injection.
- **`display` is not added for `type: "enabled"` in practice.** Every model that still accepts manual extended thinking (4.6 and earlier) already defaults to `summarized`, so the branch is a no-op there. It is written generically rather than special-cased.
- **Non-goal:** unifying the remaining `output_config` / sampling-parameter differences between the Bedrock and Anthropic-compatible payload builders. Only the thinking construction is deduplicated here, to keep this fix's blast radius small.

Docs:

- https://platform.claude.com/docs/en/build-with-claude/thinking#controlling-thinking-display
- https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting#supported-models