### PR TITLE
🐛 fix(model-runtime): keep pre-flight context errors structured in Anthropic factory

### DIFF
--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.test.ts
@@ -2,6 +2,8 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { isNonRetryableRequestError } from '../../utils/isNonRetryableRequestError';
+import { ContextExceededPreFlightError } from '../../utils/resolveSafeMaxTokens';
 import {
   createAnthropicCompatibleRuntime,
   createDefaultAnthropicClient,
@@ -255,5 +257,94 @@ describe('createAnthropicCompatibleRuntime', () => {
       expect.objectContaining({ requestModel: 'upstream-model' }),
     );
     expect(result).toEqual({ ok: true });
+  });
+});
+
+describe('anthropicCompatibleFactory pre-flight context errors', () => {
+  const preFlightError = () =>
+    new ContextExceededPreFlightError({
+      ctx: 1_048_576,
+      minOutputTokens: 1024,
+      model: 'deepseek-v4-pro',
+      promptTokens: 1_054_972,
+    });
+
+  const createRuntimeThrowing = (
+    error: Error,
+    handleError?: (error: any) => { errorType: string } | undefined,
+  ) => {
+    const Runtime = createAnthropicCompatibleRuntime({
+      chatCompletion: {
+        handleError,
+        handlePayload: () => {
+          throw error;
+        },
+      },
+      customClient: {
+        createClient: () =>
+          ({
+            baseURL: 'https://api.deepseek.com/anthropic',
+            messages: { create: vi.fn() },
+          }) as unknown as Anthropic,
+      },
+      provider: 'deepseek',
+    });
+
+    return new Runtime({ apiKey: 'test-key' });
+  };
+
+  it('should surface ContextExceededPreFlightError as ExceededContextWindow with diagnostics', async () => {
+    const runtime = createRuntimeThrowing(preFlightError());
+
+    const error = await runtime
+      .chat({ messages: [{ content: 'hi', role: 'user' }], model: 'deepseek-v4-pro' } as any)
+      .catch((e) => e);
+
+    expect(error).toMatchObject({
+      errorType: 'ExceededContextWindow',
+      provider: 'deepseek',
+    });
+    expect(error.errorType).not.toBe('ProviderBizError');
+    expect(error.error).toEqual({
+      ctx: 1_048_576,
+      minOutputTokens: 1024,
+      model: 'deepseek-v4-pro',
+      promptTokens: 1_054_972,
+      shortBy: 6396,
+      suggestions: ['fork_topic', 'switch_to_larger_ctx_model'],
+      type: 'context_exceeded_pre_flight',
+    });
+  });
+
+  it('should take precedence over a provider-specific handleError', async () => {
+    const handleError = vi.fn(() => ({ errorType: 'ProviderBizError' }));
+    const runtime = createRuntimeThrowing(preFlightError(), handleError);
+
+    const error = await runtime
+      .chat({ messages: [{ content: 'hi', role: 'user' }], model: 'deepseek-v4-pro' } as any)
+      .catch((e) => e);
+
+    expect(error.errorType).toBe('ExceededContextWindow');
+    expect(handleError).not.toHaveBeenCalled();
+  });
+
+  it('should stop the router from retrying the request on other channels', async () => {
+    const runtime = createRuntimeThrowing(preFlightError());
+
+    const error = await runtime
+      .chat({ messages: [{ content: 'hi', role: 'user' }], model: 'deepseek-v4-pro' } as any)
+      .catch((e) => e);
+
+    expect(isNonRetryableRequestError(error)).toBe(true);
+  });
+
+  it('should keep classifying unrelated provider errors as biz errors', async () => {
+    const runtime = createRuntimeThrowing(new Error('something else went wrong'));
+
+    const error = await runtime
+      .chat({ messages: [{ content: 'hi', role: 'user' }], model: 'deepseek-v4-pro' } as any)
+      .catch((e) => e);
+
+    expect(error.errorType).toBe('ProviderBizError');
   });
 });

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
@@ -27,6 +27,7 @@ import { getModelPricing } from '../../utils/getModelPricing';
 import type { ModelIdMappingOptions } from '../../utils/modelIdMapping';
 import { resolveMappedModelId } from '../../utils/modelIdMapping';
 import { MODEL_LIST_CONFIGS, processModelList } from '../../utils/modelParse';
+import { ContextExceededPreFlightError } from '../../utils/resolveSafeMaxTokens';
 import { StreamingResponse } from '../../utils/response';
 import type { LobeRuntimeAI } from '../BaseAI';
 import {
@@ -726,6 +727,23 @@ export const createAnthropicCompatibleRuntime = <T extends Record<string, any> =
       let desensitizedEndpoint = this.baseURL;
       if (this.baseURL !== DEFAULT_BASE_URL) {
         desensitizedEndpoint = desensitizeUrl(this.baseURL);
+      }
+
+      // Keep pre-flight context-window failures structured, mirroring
+      // `openaiCompatibleFactory`. Without this branch the error falls through to
+      // the generic string classifier, which cannot match the pre-flight message
+      // and downgrades it to a `ProviderBizError` — that hides the dedicated
+      // "exceeded context window" UI and stops the router from treating the
+      // request as non-retryable, so it keeps burning fallback channels.
+      if (error instanceof ContextExceededPreFlightError) {
+        log('pre-flight context exceeded: %s', error.message);
+        return AgentRuntimeError.chat({
+          endpoint: desensitizedEndpoint,
+          error: error.toPayload(),
+          errorType: AgentRuntimeErrorType.ExceededContextWindow,
+          message: error.message,
+          provider: this.id,
+        });
       }
 
       if (chatCompletion?.handleError) {

--- a/packages/model-runtime/src/providers/deepseek/__tests__/anthropic.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/__tests__/anthropic.test.ts
@@ -217,3 +217,35 @@ describe('LobeDeepSeekAnthropicAI handlePayload', () => {
     expect(serialized).toContain(validEmoji);
   });
 });
+
+// Regression for the production incident where a ~5 MB attachment pushed the
+// prompt past deepseek-v4-pro's 1M window: the pre-flight error was downgraded
+// to ProviderBizError, so the client showed a generic "request hiccup" instead
+// of the context-window UI and the router kept retrying other channels.
+describe('LobeDeepSeekAnthropicAI context pre-flight', () => {
+  it('should reject an over-window prompt as ExceededContextWindow', async () => {
+    const instance = new LobeDeepSeekAnthropicAI({ apiKey: 'test' });
+    const messagesCreate = vi
+      .spyOn((instance as any).client.messages, 'create')
+      .mockResolvedValue(new ReadableStream() as any);
+
+    // ~10M chars — unambiguously over the 1,048,576-token window.
+    const huge = 'lorem ipsum dolor '.repeat(560_000);
+
+    const error = await instance
+      .chat({ messages: [{ content: huge, role: 'user' }], model: 'deepseek-v4-pro' })
+      .catch((e) => e);
+
+    expect(error).toMatchObject({
+      error: expect.objectContaining({
+        ctx: 1_048_576,
+        model: 'deepseek-v4-pro',
+        type: 'context_exceeded_pre_flight',
+      }),
+      errorType: 'ExceededContextWindow',
+      provider: 'deepseek',
+    });
+    // Nothing should reach upstream — the whole point of the pre-flight check.
+    expect(messagesCreate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-12376

#### 🔀 Description of Change

`openaiCompatibleFactory` already maps `ContextExceededPreFlightError` to `AgentRuntimeErrorType.ExceededContextWindow`, but `anthropicCompatibleFactory` had no equivalent branch. The error fell through to the generic `handleAnthropicError()` string classifier, which cannot match the pre-flight message:

```
Prompt tokens (1054972) leave less than 1024 tokens for completion within the model context window (1048576) for model "deepseek-v4-pro".
```

so it was downgraded to `ProviderBizError`. Three things broke as a result:

1. The client fell back to the generic error card instead of the dedicated "exceeded context window" UI with its compress / fork-topic affordances.
2. `isNonRetryableRequestError()` no longer recognised the request as doomed, so the router kept retrying the same over-window prompt across every fallback channel.
3. The structured diagnostics (`type` / `model` / `promptTokens` / `ctx` / `shortBy` / `minOutputTokens` / `suggestions`) were dropped from the error body.

This affects every Anthropic-compatible provider that fails pre-flight — DeepSeek's Anthropic route is the one that surfaces it today, since `buildDeepSeekAnthropicPayload()` runs `resolveSafeMaxTokens()`.

The fix adds the same `instanceof ContextExceededPreFlightError` branch to `anthropicCompatibleFactory.handleError()`, placed before the provider-specific `chatCompletion.handleError` hook so a provider handler can't swallow it. No UI change is needed — the existing `ExceededContextWindowError` view takes over once the error type is correct.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Four new regression tests, all failing before this commit and passing after:

- `anthropicCompatibleFactory/index.test.ts` — pre-flight error becomes `ExceededContextWindow` with the diagnostic payload intact; takes precedence over a provider `handleError`; `isNonRetryableRequestError()` returns `true`; unrelated errors still classify as `ProviderBizError`.
- `providers/deepseek/__tests__/anthropic.test.ts` — an over-window prompt through the real `LobeDeepSeekAnthropicAI` wiring yields `ExceededContextWindow` and never reaches upstream.

```bash
cd packages/model-runtime
bunx vitest run src/core/anthropicCompatibleFactory/index.test.ts src/providers/deepseek/__tests__/anthropic.test.ts
```

#### 📝 Additional Information

Out of scope, tracked separately: blocking over-window attachments client-side before send, and moving very large documents to retrieval instead of inlining the full body into the prompt.