### PR TITLE
🐛 fix(deepseek): preserve omitted thinking signatures

### DIFF
--- a/packages/model-runtime/src/providers/deepseek/chatPayload.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/chatPayload.test.ts
@@ -43,4 +43,42 @@ describe('buildDeepSeekAnthropicPayload — completion budget', () => {
     expect(payload.max_tokens).toBeGreaterThan(0);
     expect(payload.max_tokens).toBeLessThanOrEqual(393_216);
   });
+
+  it('repairs and replays an omitted thinking block without adding a placeholder', async () => {
+    const signature = 'f2667b49-5a24-49f4-bc41-4de7b6097afa';
+    const payload = await buildDeepSeekAnthropicPayload({
+      messages: [
+        { content: 'Run the command', role: 'user' },
+        {
+          content: [
+            { signature, type: 'thinking' },
+            { text: '', type: 'text' },
+          ],
+          reasoning: { signature },
+          role: 'assistant',
+          tool_calls: [
+            {
+              function: { arguments: '{}', name: 'runCommand' },
+              id: 'call-1',
+              type: 'function',
+            },
+          ],
+        },
+        { content: 'done', role: 'tool', tool_call_id: 'call-1' },
+      ],
+      model: 'deepseek-v4-flash',
+    } as any);
+
+    const assistant = payload.messages.find((message) => message.role === 'assistant');
+    const thinkingBlocks = Array.isArray(assistant?.content)
+      ? assistant.content.filter((part) => part.type === 'thinking')
+      : [];
+
+    expect(thinkingBlocks).toEqual([{ signature, thinking: '', type: 'thinking' }]);
+    expect(assistant?.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'call-1', name: 'runCommand', type: 'tool_use' }),
+      ]),
+    );
+  });
 });

--- a/packages/model-runtime/src/providers/deepseek/chatPayload.ts
+++ b/packages/model-runtime/src/providers/deepseek/chatPayload.ts
@@ -16,8 +16,18 @@ const hasReasoningContent = (reasoning: any) => typeof reasoning?.content === 's
 
 const buildThinkingBlock = (reasoning: any) =>
   hasReasoningContent(reasoning)
-    ? { thinking: reasoning.content, type: 'thinking' as const }
+    ? {
+        ...(typeof reasoning.signature === 'string' && { signature: reasoning.signature }),
+        thinking: reasoning.content,
+        type: 'thinking' as const,
+      }
     : undefined;
+
+const normalizeThinkingPart = (part: any) =>
+  // Omitted thinking still carries a signature and must round-trip with `thinking: ''`.
+  part?.type === 'thinking' && typeof part.signature === 'string'
+    ? { ...part, thinking: typeof part.thinking === 'string' ? part.thinking : '' }
+    : part;
 
 const toContentArray = (content: any) =>
   Array.isArray(content)
@@ -78,15 +88,21 @@ const normalizeMessagesForAnthropic = (
     if (message.role !== 'assistant') return message;
 
     const { reasoning, ...rest } = message;
+    const content = Array.isArray(message.content)
+      ? message.content.map(normalizeThinkingPart)
+      : message.content;
+    const hasThinkingPart =
+      Array.isArray(content) && content.some((part: any) => part?.type === 'thinking');
     const thinkingBlock = buildThinkingBlock(reasoning);
-    const effectiveThinkingBlock =
-      thinkingBlock || (forceThinking ? { thinking: ' ', type: 'thinking' as const } : undefined);
+    const effectiveThinkingBlock = hasThinkingPart
+      ? undefined
+      : thinkingBlock || (forceThinking ? { thinking: ' ', type: 'thinking' as const } : undefined);
 
-    if (!effectiveThinkingBlock) return rest;
+    if (!effectiveThinkingBlock) return { ...rest, content };
 
     return {
       ...rest,
-      content: [effectiveThinkingBlock, ...toContentArray(message.content)],
+      content: [effectiveThinkingBlock, ...toContentArray(content)],
     };
   });
 


### PR DESCRIPTION
  #### 💻 Change Type

  - [ ] ✨ feat
  - [x] 🐛 fix
  - [ ] ♻️  refactor
  - [ ] 💄 style
  - [ ] 👷 build
  - [ ] ⚡️ perf
  - [ ] ✅ test
  - [ ] 📝 docs
  - [ ] 🔨 chore

  #### 🔗 Related Issue

  N/A

  #### 🔀 Description of Change

  DeepSeek's Anthropic-compatible endpoint may return an omitted thinking block that carries a signature
  without a visible `thinking` field:

  ```json
  {
    "type": "thinking",
    "signature": "..."
  }
```

  When this assistant message is replayed after a tool call, the Anthropic payload schema still requires
  thinking to be a string. Previously, the payload builder could retain the incomplete block and prepend
  another placeholder thinking block.

  This PR:

  - normalizes signed, omitted thinking blocks with thinking: "";
  - preserves the opaque signature unchanged;
  - reuses an existing thinking block instead of inserting a duplicate placeholder;
  - preserves signatures when converting structured reasoning into an Anthropic thinking block.

  The normalization does not reconstruct or fabricate reasoning content. The empty string only restores the
  required Anthropic-compatible payload shape.

  #### 🧪 How to Test

  Run the focused model-runtime tests:
```
  pnpm --filter @lobechat/model-runtime test --run \
    src/providers/deepseek/chatPayload.test.ts \
    src/providers/deepseek/__tests__/anthropic.test.ts
```

  Expected result:
```
  Test Files  2 passed
  Tests       13 passed
```

  The regression test verifies that:

  - a signature-only thinking block becomes { type: "thinking", thinking: "", signature };
  - exactly one thinking block is emitted;
  - the associated tool_use block remains in the assistant message.
  - [x] Tested locally
  - [x] Added/updated tests
  - [ ] No tests needed

  #### 📸 Screenshots / Videos

  N/A — no UI changes.

  #### 📝 Additional Information

  - The change is scoped to DeepSeek's Anthropic-compatible payload builder.
  - No migration or configuration changes are required.
  - No behavior changes are introduced for the OpenAI-compatible DeepSeek path.