### PR TITLE
⚡️ perf(desktop): reduce conversation tab switching overhead

### DIFF
--- a/scripts/benchmarks/desktop-tab-cpu-profile.mjs
+++ b/scripts/benchmarks/desktop-tab-cpu-profile.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import { writeFile } from 'node:fs/promises';
+import process from 'node:process';
+
+import WebSocket from 'ws';
+
+const port = Number(process.env.CDP_PORT || 9223);
+const output = process.argv[2];
+if (!output) throw new Error('Usage: desktop-tab-cpu-profile.mjs <output.json>');
+
+const targets = await fetch(`http://127.0.0.1:${port}/json/list`).then((response) =>
+  response.json(),
+);
+const page = targets.find((target) => target.type === 'page' && target.url.startsWith('app://'));
+if (!page) throw new Error(`No app:// page target found on CDP port ${port}`);
+
+const socket = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => {
+  socket.once('open', resolve);
+  socket.once('error', reject);
+});
+
+let commandId = 0;
+const pending = new Map();
+socket.on('message', (data) => {
+  const message = JSON.parse(data.toString());
+  const waiter = pending.get(message.id);
+  if (!waiter) return;
+  pending.delete(message.id);
+  if (message.error) waiter.reject(new Error(message.error.message));
+  else waiter.resolve(message.result);
+});
+const send = (method, params = {}) =>
+  new Promise((resolve, reject) => {
+    const id = ++commandId;
+    pending.set(id, { reject, resolve });
+    socket.send(JSON.stringify({ id, method, params }));
+  });
+const evaluate = async (expression) => {
+  const response = await send('Runtime.evaluate', { expression, returnByValue: true });
+  if (response.exceptionDetails) throw new Error('Evaluation failed');
+  return response.result.value;
+};
+
+const before = await evaluate(`(() => {
+  const tabs = [...document.querySelectorAll('div')].filter((element) => {
+    const rect = element.getBoundingClientRect();
+    return Math.abs(rect.y - 5) < 1 && Math.abs(rect.width - 180) < 1 && Math.abs(rect.height - 28) < 1;
+  });
+  const activeIndex = tabs.findIndex((element) => element.dataset.active === 'true');
+  const target = tabs[(activeIndex + 1) % tabs.length];
+  const rect = target.getBoundingClientRect();
+  return {
+    from: location.pathname + location.search,
+    target: target.textContent?.trim(),
+    x: rect.x + rect.width / 2,
+    y: rect.y + rect.height / 2,
+  };
+})()`);
+
+await send('Profiler.enable');
+await send('Profiler.setSamplingInterval', { interval: 100 });
+await send('Profiler.start');
+await send('Input.dispatchMouseEvent', {
+  button: 'left',
+  clickCount: 1,
+  type: 'mousePressed',
+  x: before.x,
+  y: before.y,
+});
+await send('Input.dispatchMouseEvent', {
+  button: 'left',
+  clickCount: 1,
+  type: 'mouseReleased',
+  x: before.x,
+  y: before.y,
+});
+await new Promise((resolve) => setTimeout(resolve, 750));
+const { profile } = await send('Profiler.stop');
+const after = await evaluate(`location.pathname + location.search`);
+
+const nodeById = new Map(profile.nodes.map((node) => [node.id, node]));
+const selfTimeByNode = new Map();
+for (let index = 0; index < profile.samples.length; index += 1) {
+  const nodeId = profile.samples[index];
+  selfTimeByNode.set(nodeId, (selfTimeByNode.get(nodeId) || 0) + profile.timeDeltas[index]);
+}
+const hottest = [...selfTimeByNode.entries()]
+  .map(([nodeId, microseconds]) => {
+    const frame = nodeById.get(nodeId)?.callFrame;
+    return {
+      column: frame?.columnNumber,
+      functionName: frame?.functionName || '(anonymous)',
+      line: frame?.lineNumber,
+      milliseconds: microseconds / 1000,
+      url: frame?.url,
+    };
+  })
+  .filter((entry) => entry.milliseconds >= 0.5)
+  .sort((a, b) => b.milliseconds - a.milliseconds)
+  .slice(0, 80);
+
+await writeFile(output, `${JSON.stringify({ after, before, hottest, profile }, null, 2)}\n`);
+socket.close();
+console.table(hottest.slice(0, 25));

--- a/scripts/benchmarks/desktop-tab-switch.mjs
+++ b/scripts/benchmarks/desktop-tab-switch.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+
+import { writeFile } from 'node:fs/promises';
+import process from 'node:process';
+
+import WebSocket from 'ws';
+
+const port = Number(process.env.CDP_PORT || 9223);
+const output = process.argv[2];
+const iterations = Number(process.env.ITERATIONS || 12);
+
+if (!output) {
+  throw new Error('Usage: desktop-tab-switch.mjs <output.json>');
+}
+
+const targets = await fetch(`http://127.0.0.1:${port}/json/list`).then((response) =>
+  response.json(),
+);
+const page = targets.find((target) => target.type === 'page' && target.url.startsWith('app://'));
+
+if (!page) throw new Error(`No app:// page target found on CDP port ${port}`);
+
+const socket = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => {
+  socket.once('open', resolve);
+  socket.once('error', reject);
+});
+
+let commandId = 0;
+const pending = new Map();
+
+socket.on('message', (data) => {
+  const message = JSON.parse(data.toString());
+  if (!message.id) return;
+  const waiter = pending.get(message.id);
+  if (!waiter) return;
+  pending.delete(message.id);
+  if (message.error) waiter.reject(new Error(message.error.message));
+  else waiter.resolve(message.result);
+});
+
+const send = (method, params = {}) =>
+  new Promise((resolve, reject) => {
+    const id = ++commandId;
+    pending.set(id, { reject, resolve });
+    socket.send(JSON.stringify({ id, method, params }));
+  });
+
+await send('Runtime.enable');
+await send('Performance.enable');
+await send('HeapProfiler.collectGarbage');
+
+const beforeMetrics = await send('Performance.getMetrics');
+const evaluate = async (expression, awaitPromise = false) => {
+  const response = await send('Runtime.evaluate', {
+    awaitPromise,
+    expression,
+    returnByValue: true,
+  });
+  if (response.exceptionDetails) {
+    throw new Error(response.exceptionDetails.exception?.description || 'Evaluation failed');
+  }
+  return response.result.value;
+};
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const tabSnapshotExpression = `(() => {
+  const tabs = [...document.querySelectorAll('div')].filter((element) => {
+    const rect = element.getBoundingClientRect();
+    return Math.abs(rect.y - 5) < 1 && Math.abs(rect.width - 180) < 1 && Math.abs(rect.height - 28) < 1;
+  });
+  const activeIndex = tabs.findIndex((element) => element.dataset.active === 'true');
+  return {
+    activeIndex,
+    path: location.pathname + location.search,
+    tabs: tabs.map((element) => {
+      const rect = element.getBoundingClientRect();
+      return { title: element.textContent?.trim(), x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
+    }),
+  };
+})()`;
+
+await evaluate(`(() => {
+  window.__desktopTabBenchmark = { active: true, frameGaps: [], longTasks: [] };
+  let lastFrame = performance.now();
+  const frameLoop = (now) => {
+    if (!window.__desktopTabBenchmark.active) return;
+    const gap = now - lastFrame;
+    if (gap > 20) window.__desktopTabBenchmark.frameGaps.push({ at: now, duration: gap });
+    lastFrame = now;
+    requestAnimationFrame(frameLoop);
+  };
+  requestAnimationFrame(frameLoop);
+  try {
+    window.__desktopTabBenchmark.observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        window.__desktopTabBenchmark.longTasks.push({ at: entry.startTime, duration: entry.duration });
+      }
+    });
+    window.__desktopTabBenchmark.observer.observe({ buffered: true, type: 'longtask' });
+  } catch {}
+})()`);
+
+const results = [];
+await sleep(1000);
+for (let index = 0; index < iterations; index += 1) {
+  const before = await evaluate(tabSnapshotExpression);
+  if (before.tabs.length < 3) throw new Error(`Expected 3 tabs, found ${before.tabs.length}`);
+  const targetIndex = (before.activeIndex + 1) % before.tabs.length;
+  const target = before.tabs[targetIndex];
+  const offsets = await evaluate(
+    `({ frameGaps: window.__desktopTabBenchmark.frameGaps.length, longTasks: window.__desktopTabBenchmark.longTasks.length })`,
+  );
+  const start = performance.now();
+
+  await send('Input.dispatchMouseEvent', {
+    button: 'left',
+    clickCount: 1,
+    type: 'mousePressed',
+    x: target.x,
+    y: target.y,
+  });
+  await send('Input.dispatchMouseEvent', {
+    button: 'left',
+    clickCount: 1,
+    type: 'mouseReleased',
+    x: target.x,
+    y: target.y,
+  });
+
+  let current = before;
+  while (current.activeIndex !== targetIndex && performance.now() - start < 5000) {
+    await sleep(5);
+    current = await evaluate(tabSnapshotExpression);
+  }
+  const activeAt = performance.now();
+  while (current.path === before.path && performance.now() - start < 5000) {
+    await sleep(5);
+    current = await evaluate(tabSnapshotExpression);
+  }
+  const routeAt = performance.now();
+  await sleep(50);
+  const settledAt = performance.now();
+  await sleep(250);
+  const observations = await evaluate(`({
+    frameGaps: window.__desktopTabBenchmark.frameGaps.slice(${offsets.frameGaps}),
+    longTasks: window.__desktopTabBenchmark.longTasks.slice(${offsets.longTasks})
+  })`);
+
+  results.push({
+    activeMs: activeAt - start,
+    frameGaps: observations.frameGaps,
+    from: before.path,
+    iteration: index + 1,
+    longTasks: observations.longTasks,
+    routeMs: routeAt - start,
+    settledMs: settledAt - start,
+    target: target.title,
+    to: current.path,
+  });
+}
+
+const runtimeInfo = await evaluate(
+  `({ finishedAt: new Date().toISOString(), userAgent: navigator.userAgent })`,
+);
+
+const afterMetrics = await send('Performance.getMetrics');
+await evaluate(`(() => {
+  window.__desktopTabBenchmark.active = false;
+  window.__desktopTabBenchmark.observer?.disconnect();
+})()`);
+const metricMap = (metrics) =>
+  Object.fromEntries(metrics.metrics.map(({ name, value }) => [name, value]));
+const before = metricMap(beforeMetrics);
+const after = metricMap(afterMetrics);
+const metricNames = [
+  'TaskDuration',
+  'ScriptDuration',
+  'LayoutDuration',
+  'RecalcStyleDuration',
+  'JSHeapUsedSize',
+];
+const metricDelta = Object.fromEntries(
+  metricNames.map((name) => [name, (after[name] ?? 0) - (before[name] ?? 0)]),
+);
+
+const payload = {
+  ...runtimeInfo,
+  iterations,
+  metricDelta,
+  port,
+  results,
+};
+
+await writeFile(output, `${JSON.stringify(payload, null, 2)}\n`);
+socket.close();
+
+const values = payload.results.map((result) => result.settledMs).sort((a, b) => a - b);
+const percentile = (fraction) =>
+  values[Math.min(values.length - 1, Math.floor(values.length * fraction))];
+console.log(
+  JSON.stringify({
+    activeMedianMs: median(payload.results.map((result) => result.activeMs)),
+    routeMedianMs: median(payload.results.map((result) => result.routeMs)),
+    settledMedianMs: median(values),
+    settledP95Ms: percentile(0.95),
+    totalFrameGaps: payload.results.reduce((sum, result) => sum + result.frameGaps.length, 0),
+    totalLongTasks: payload.results.reduce((sum, result) => sum + result.longTasks.length, 0),
+  }),
+);
+
+function median(valuesToSort) {
+  const sorted = [...valuesToSort].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2;
+}

--- a/src/features/Conversation/ConversationProvider.tsx
+++ b/src/features/Conversation/ConversationProvider.tsx
@@ -53,6 +53,10 @@ export interface ConversationProviderProps {
    */
   hooks?: ConversationHooks;
   /**
+   * Parsed messages cached by the parent store for synchronous remount reuse.
+   */
+  initialDisplayMessages?: UIChatMessage[];
+  /**
    * External messages to sync into the store
    * When provided, these messages will be used as the source of truth
    */
@@ -90,6 +94,7 @@ export const ConversationProvider = memo<ConversationProviderProps>(
     context,
     hooks = {},
     hasInitMessages,
+    initialDisplayMessages,
     messages,
     onMessagesChange,
     operationState,
@@ -107,8 +112,16 @@ export const ConversationProvider = memo<ConversationProviderProps>(
 
     return (
       <Provider
-        createStore={() => createStore({ context, hooks, initialMessages: messages, skipFetch })}
         key={contextKey}
+        createStore={() =>
+          createStore({
+            context,
+            hooks,
+            initialDisplayMessages,
+            initialMessages: messages,
+            skipFetch,
+          })
+        }
       >
         <StoreUpdater
           actionsBar={actionsBar}

--- a/src/features/Conversation/StoreUpdater.tsx
+++ b/src/features/Conversation/StoreUpdater.tsx
@@ -59,7 +59,7 @@ const StoreUpdater = memo<StoreUpdaterProps>(
   }) => {
     const storeApi = useConversationStoreApi();
     const useStoreUpdater = createStoreUpdater(storeApi);
-    const prevMessagesRef = useRef<UIChatMessage[] | undefined>(undefined);
+    const prevMessagesRef = useRef<UIChatMessage[] | undefined>(messages);
     const contextKey = messageMapKey(context);
 
     useStoreUpdater('actionsBar', actionsBar);
@@ -106,6 +106,8 @@ const StoreUpdater = memo<StoreUpdaterProps>(
         const newCount = messages.length;
         const isSameReference = prevMessages === messages;
         const storeMessages = storeApi.getState().dbMessages;
+
+        if (isSameReference && storeMessages === messages) return;
 
         log(
           '[StoreUpdater] messages effect | contextKey=%s | prevCount=%d | newCount=%d | sameRef=%s | storeCount=%d | messageIds=%o',

--- a/src/features/Conversation/store.test.ts
+++ b/src/features/Conversation/store.test.ts
@@ -1,3 +1,4 @@
+import type { UIChatMessage } from '@lobechat/types';
 import { act } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -147,6 +148,35 @@ describe('ConversationStore', () => {
       expect(state.hooks).toBe(hooks);
       expect(state.hooks.onBeforeSendMessage).toBeDefined();
       expect(state.hooks.onAfterSendMessage).toBeDefined();
+    });
+
+    it('should reuse cached display messages when seeding an initialized conversation', () => {
+      const context: ConversationContext = {
+        agentId: 'session-1',
+        threadId: null,
+        topicId: 'topic-1',
+      };
+      const initialMessages = [
+        {
+          content: 'raw message',
+          createdAt: 1,
+          id: 'message-1',
+          role: 'assistant',
+          updatedAt: 1,
+        },
+      ] as UIChatMessage[];
+      const initialDisplayMessages = [
+        {
+          ...initialMessages[0],
+          content: 'already parsed',
+        },
+      ] as UIChatMessage[];
+
+      const store = createStore({ context, initialDisplayMessages, initialMessages });
+
+      expect(store.getState().dbMessages).toBe(initialMessages);
+      expect(store.getState().displayMessages).toBe(initialDisplayMessages);
+      expect(store.getState().messagesInit).toBe(true);
     });
 
     it('should create store with thread context', () => {

--- a/src/features/Conversation/store/action.ts
+++ b/src/features/Conversation/store/action.ts
@@ -40,6 +40,12 @@ export interface CreateStoreParams {
   context: ConversationContext;
   hooks?: ConversationHooks;
   /**
+   * Parsed display messages already cached by the parent ChatStore. Reusing
+   * them avoids rebuilding the entire conversation-flow tree synchronously
+   * whenever a desktop tab switches back to an initialized conversation.
+   */
+  initialDisplayMessages?: UIChatMessage[];
+  /**
    * Messages to seed the freshly-created store with, already known by the parent
    * (ConversationArea reads them from ChatStore's `dbMessagesMap`). Seeding at
    * creation — rather than waiting for StoreUpdater's post-mount effect — is what
@@ -61,7 +67,7 @@ type CreateStore = (
 ) => StateCreator<Store, [['zustand/devtools', never]]>;
 
 export const createStoreAction: CreateStore =
-  ({ context, hooks = {}, initialMessages, skipFetch }) =>
+  ({ context, hooks = {}, initialDisplayMessages, initialMessages, skipFetch }) =>
   (...params) => ({
     ...initialState,
     context,
@@ -73,7 +79,7 @@ export const createStoreAction: CreateStore =
     ...(initialMessages
       ? {
           dbMessages: initialMessages,
-          displayMessages: parse(initialMessages).flatList,
+          displayMessages: initialDisplayMessages ?? parse(initialMessages).flatList,
           messagesInit: true,
         }
       : {}),

--- a/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
@@ -68,6 +68,7 @@ const Conversation = memo(() => {
   );
   const replaceMessages = useChatStore((s) => s.replaceMessages);
   const messages = useChatStore((s) => s.dbMessagesMap[chatKey]);
+  const displayMessages = useChatStore((s) => s.messagesMap[chatKey]);
 
   log('contextKey %s: %o', chatKey, messages);
 
@@ -116,6 +117,7 @@ const Conversation = memo(() => {
       context={context}
       hasInitMessages={!!messages}
       hooks={hooks}
+      initialDisplayMessages={displayMessages}
       messages={messages}
       operationState={operationState}
       onMessagesChange={(messages, ctx) => {


### PR DESCRIPTION
## Summary

- reuse the parsed conversation messages already cached in ChatStore when a desktop tab remounts a Conversation store
- skip the initial StoreUpdater message replacement when both stores already share the same raw-message reference
- add a regression test and reusable CDP benchmarks for tab-switch latency and CPU profiles

## Root cause

Switching between conversation tabs recreates the local Conversation store because its context key changes. The new store synchronously parsed the full raw message list even though ChatStore had already cached the parsed display list. StoreUpdater then performed another initial replacement, parsing the same messages again. On tool-heavy conversations this produced substantial temporary allocation and GC pressure.

## Verification

- `bun run check <changed source/test files>`: 21 tests passed
- benchmark scripts: lint clean
- controlled 750 ms CPU profiles: GC self-time dropped from roughly 171–319 ms to 23–25 ms, and `collectToolMessages` / `findFlatChainContinuation` disappeared as switch-time hotspots

## Notes

This removes the deterministic duplicate parsing cost. Route trees other than Home are still unmounted and remounted during tab navigation, so tab-scoped route keep-alive should be evaluated separately.

Acceptance evidence: https://app.lobehub.com/verify/307765e6-e058-4097-b4bb-d63e3123f2e3