### PR TITLE
feat(mobile): expose notification router on the mobile tRPC endpoint

### DIFF
--- a/apps/server/src/routers/mobile/index.ts
+++ b/apps/server/src/routers/mobile/index.ts
@@ -23,6 +23,7 @@ import { homeRouter } from '../lambda/home';
 import { knowledgeBaseRouter } from '../lambda/knowledgeBase';
 import { marketRouter } from '../lambda/market';
 import { messageRouter } from '../lambda/message';
+import { notificationRouter } from '../lambda/notification';
 import { pluginRouter } from '../lambda/plugin';
 import { pushTokenRouter } from '../lambda/pushToken';
 import { sessionRouter } from '../lambda/session';
@@ -53,6 +54,7 @@ export const mobileRouter = router({
   knowledgeBase: knowledgeBaseRouter,
   market: marketRouter,
   message: messageRouter,
+  notification: notificationRouter,
   plugin: pluginRouter,
   pushToken: pushTokenRouter,
   session: sessionRouter,


### PR DESCRIPTION
## What

Mount `notificationRouter` on the **mobile** tRPC router (`/trpc/mobile`).

## Why

The mobile app's Notifications tab calls `notification.list` / `markAsRead` / `unreadCount`, but `notificationRouter` was only registered on the **lambda** router. Every mobile call therefore failed with:

```
No procedure found on path "notification.list"
```

so the mobile inbox rendered empty even for accounts that have inbox history on web/desktop.

## How

Added the import and one registration line, alphabetically between `message` and `plugin`. The router builds on the same `wsCompatProcedure` base as every other lambda router already exposed on the mobile endpoint, so workspace/personal inbox scoping carries over unchanged — no new auth surface.

## Test

- `tsc --noEmit` on `apps/server`: no errors touch `routers/mobile/index` or `lambda/notification` (the 256 remaining errors are pre-existing canary drift — missing `@/server/services/*` modules unrelated to this change).
- Server-side enabler for the mobile inbox tab (lobehub-mobile #226). Once deployed, the mobile Notifications tab resolves against the official cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)