### PR TITLE
chore: clean LOBE-XXX markers from recently modified source files (2026-07-27)

### DIFF
--- a/apps/server/src/routers/lambda/_helpers/resourceConfigGuard.test.ts
+++ b/apps/server/src/routers/lambda/_helpers/resourceConfigGuard.test.ts
@@ -43,7 +43,7 @@ beforeEach(() => {
 });
 
 describe('getResourceConfigAccess', () => {
-  // LOBE-12374: builtins are `virtual: true`, so linking one into a group made the
+  // Builtins are `virtual: true`, so linking one into a group made the
   // parent cap reduce `full` to `profile` — the config was redacted and the route
   // redirected exactly as before the fix. The evaluator alone cannot show this.
   it('does not cap a collaborative builtin at its parent group access', async () => {

--- a/apps/server/src/routers/lambda/_helpers/resourceConfigGuard.ts
+++ b/apps/server/src/routers/lambda/_helpers/resourceConfigGuard.ts
@@ -93,7 +93,7 @@ export const getResourceConfigAccess = async (
   // Collaborative builtins (Lobe AI, the builders, the page agent) are workspace
   // infrastructure that happens to be `virtual: true`, so linking one into a group
   // would otherwise cap its config access at that group's level — reinstating the
-  // lockout this whole change removes (LOBE-12374). They are not group-owned
+  // lockout this whole change removes. They are not group-owned
   // content, so the parent cap does not apply to them.
   if (isCollaborativeBuiltinAgent(resourceType, meta)) return ownAccess;
 

--- a/apps/server/src/services/bot/__tests__/BotMessageRouter.test.ts
+++ b/apps/server/src/services/bot/__tests__/BotMessageRouter.test.ts
@@ -1967,7 +1967,7 @@ describe('BotMessageRouter', () => {
 
   describe('rejection notice visibility (ensureThreadMember)', () => {
     /**
-     * LOBE-12191: on Discord a channel @mention auto-creates a reply
+     * On Discord a channel @mention auto-creates a reply
      * thread and rejection notices are posted there — but the rejected
      * sender was never added to the thread, so they got no notification
      * and perceived the bot as silently ignoring them. Every group-scope

--- a/apps/server/src/services/resourcePermission/index.test.ts
+++ b/apps/server/src/services/resourcePermission/index.test.ts
@@ -266,7 +266,7 @@ describe('canPerformResourceAction', () => {
     ]);
   });
 
-  // LOBE-12374: workspace-level builtin agents (Lobe AI inbox, the builders) are
+  // Workspace-level builtin agents (Lobe AI inbox, the builders) are
   // created lazily by whoever opens the workspace first, so their `user_id` is an
   // accident of timing and they never get a `resource_permissions` row. Members
   // must still be able to configure them.
@@ -507,7 +507,7 @@ describe('canPerformResourceAction', () => {
     });
 
     // Linking the real inbox into an agent group is supported, so a linked builtin
-    // must keep the bypass — excluding group members would reproduce LOBE-12374 for
+    // must keep the bypass — excluding group members would reproduce the original issue for
     // that workspace.
     it('keeps the bypass for a builtin that is linked into an agent group', async () => {
       permissionMatchesMock.mockResolvedValue({ hasAllScope: false, hasOwnerScope: true });

--- a/apps/server/src/services/resourcePermission/index.ts
+++ b/apps/server/src/services/resourcePermission/index.ts
@@ -164,7 +164,7 @@ const COLLABORATIVE_BUILTIN_AGENT_SLUGS: ReadonlySet<string> = new Set<string>([
  * `resource_permissions` row is ever written for them (their effective General
  * access falls back to the `use` default). Treating them as creator-owned locks
  * every other member out of the Agent Builder, of Lobe AI's config page, and of
- * the Page Copilot's own settings (LOBE-12374), so they are governed by workspace
+ * the Page Copilot's own settings, so they are governed by workspace
  * capability instead: anyone holding `agent:update:{owner,all}` may
  * read/use/configure them, while destructive and ownership actions (delete /
  * transfer / visibility) stay with the creator and the workspace primary owner.
@@ -181,7 +181,7 @@ const COLLABORATIVE_BUILTIN_AGENT_SLUGS: ReadonlySet<string> = new Set<string>([
  * change and is tracked separately. Group membership is NOT usable as the
  * discriminator: linking the real inbox into an agent group is supported, so
  * excluding linked rows would deny configuration on a legitimately provisioned
- * builtin and reproduce LOBE-12374.
+ * builtin and reproduce the same lockout.
  */
 export const isCollaborativeBuiltinAgent = (
   resourceType: PermissionResourceType,


### PR DESCRIPTION
## Summary

Incremental cleanup following PRs #17482 and #17617. This PR removes the remaining 6 LOBE-XXX reference markers that were introduced in commits after those PRs were created.

## Changes

5 files changed, 7 insertions(+), 7 deletions(-).

### Affected files

| File | Markers Removed |
|---|---|
| `apps/server/src/routers/lambda/_helpers/resourceConfigGuard.ts` | LOBE-12374 |
| `apps/server/src/routers/lambda/_helpers/resourceConfigGuard.test.ts` | LOBE-12374 |
| `apps/server/src/services/resourcePermission/index.ts` | LOBE-12374 (x2) |
| `apps/server/src/services/resourcePermission/index.test.ts` | LOBE-12374 (x2) |
| `apps/server/src/services/bot/__tests__/BotMessageRouter.test.ts` | LOBE-12191 |

### Context

- **LOBE-12374**: Fix for workspace builtin agents being incorrectly locked behind creator-only permissions. Builtins (Lobe AI, Agent Builder, Page Copilot) must be governed by workspace capability, not authorship.
- **LOBE-12191**: Bot permission denial improvement — on Discord, rejection notices need thread member visibility.

## Verification

- Removed only the `(LOBE-NNNNN)` identifiers; preserved all explanatory context
- No functional changes
- All files were modified after the previous cleanup PRs

Auto-generated by daily LOBE marker cleanup workflow, 2026-07-27.