### PR TITLE
🐛 fix(creds): preserve workspace scope in sandbox injection

### DIFF
--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/creds.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/creds.test.ts
@@ -2,44 +2,85 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MarketService } from '@/server/services/market';
 
+import { type ToolExecutionContext } from '../../types';
 import { credsRuntime } from '../creds';
+
+const { getMember } = vi.hoisted(() => ({
+  getMember: vi.fn(),
+}));
+
+vi.mock('@/database/models/workspaceMember', () => ({
+  WorkspaceMemberModel: vi.fn().mockImplementation(() => ({ getMember })),
+}));
 
 vi.mock('@/server/services/market', () => ({
   MarketService: vi.fn(),
 }));
 
 describe('credsRuntime', () => {
+  const serverDB = {} as NonNullable<ToolExecutionContext['serverDB']>;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    getMember.mockResolvedValue({ role: 'member' });
   });
 
-  it('signs workspace context into the Market trusted-client identity', () => {
-    credsRuntime.factory({
+  it('signs verified workspace context into the Market trusted-client identity', async () => {
+    await credsRuntime.factory({
+      serverDB,
       toolManifestMap: {},
       topicId: 'topic-1',
       userId: 'user-1',
       workspaceId: 'workspace-1',
     });
 
+    expect(getMember).toHaveBeenCalledWith('workspace-1', 'user-1');
     expect(MarketService).toHaveBeenCalledWith({
       userInfo: { userId: 'user-1', workspaceId: 'workspace-1' },
     });
   });
 
-  it('keeps personal runtime identity outside a workspace', () => {
-    credsRuntime.factory({
+  it('rejects workspace context without an active membership', async () => {
+    getMember.mockResolvedValue(undefined);
+
+    await expect(
+      credsRuntime.factory({
+        serverDB,
+        toolManifestMap: {},
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+      }),
+    ).rejects.toThrow('Workspace membership is required for workspace Creds execution');
+    expect(MarketService).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when workspace membership cannot be queried', async () => {
+    await expect(
+      credsRuntime.factory({
+        toolManifestMap: {},
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+      }),
+    ).rejects.toThrow('serverDB is required for workspace Creds execution');
+    expect(getMember).not.toHaveBeenCalled();
+    expect(MarketService).not.toHaveBeenCalled();
+  });
+
+  it('keeps personal runtime identity outside a workspace', async () => {
+    await credsRuntime.factory({
       toolManifestMap: {},
       topicId: 'topic-1',
       userId: 'user-1',
     });
 
+    expect(getMember).not.toHaveBeenCalled();
     expect(MarketService).toHaveBeenCalledWith({
       userInfo: { userId: 'user-1', workspaceId: undefined },
     });
   });
 
-  it('rejects runtime creation without a user identity', () => {
-    expect(() => credsRuntime.factory({ toolManifestMap: {} })).toThrow(
+  it('rejects runtime creation without a user identity', async () => {
+    await expect(credsRuntime.factory({ toolManifestMap: {} })).rejects.toThrow(
       'userId is required for Creds execution',
     );
   });

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/creds.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/creds.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MarketService } from '@/server/services/market';
+
+import { credsRuntime } from '../creds';
+
+vi.mock('@/server/services/market', () => ({
+  MarketService: vi.fn(),
+}));
+
+describe('credsRuntime', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('signs workspace context into the Market trusted-client identity', () => {
+    credsRuntime.factory({
+      toolManifestMap: {},
+      topicId: 'topic-1',
+      userId: 'user-1',
+      workspaceId: 'workspace-1',
+    });
+
+    expect(MarketService).toHaveBeenCalledWith({
+      userInfo: { userId: 'user-1', workspaceId: 'workspace-1' },
+    });
+  });
+
+  it('keeps personal runtime identity outside a workspace', () => {
+    credsRuntime.factory({
+      toolManifestMap: {},
+      topicId: 'topic-1',
+      userId: 'user-1',
+    });
+
+    expect(MarketService).toHaveBeenCalledWith({
+      userInfo: { userId: 'user-1', workspaceId: undefined },
+    });
+  });
+
+  it('rejects runtime creation without a user identity', () => {
+    expect(() => credsRuntime.factory({ toolManifestMap: {} })).toThrow(
+      'userId is required for Creds execution',
+    );
+  });
+});

--- a/apps/server/src/services/toolExecution/serverRuntimes/creds.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/creds.ts
@@ -111,10 +111,8 @@ class ServerCredsService implements ICredsService {
   }> {
     log('injectCreds: keys=%O, topicId=%s', params.keys, params.topicId);
 
-    // NOTE: stays on the personal `market.creds.inject` even inside a workspace.
-    // The Market SDK's org-scoped creds service has no `inject`/`injectForSkill`
-    // equivalent yet (see LOBE-10978) — sandbox injection cannot be routed to the
-    // workspace's organization credentials until Market adds that endpoint.
+    // Market's generic inject endpoint resolves organization credentials from
+    // the workspaceId signed into this service's trusted-client token.
     const result = await this.marketService.market.creds.inject({
       keys: params.keys,
       sandbox: params.sandbox,
@@ -173,7 +171,9 @@ export const credsRuntime: ServerRuntimeRegistration = {
       context.workspaceId,
     );
 
-    const marketService = new MarketService({ userInfo: { userId: context.userId } });
+    const marketService = new MarketService({
+      userInfo: { userId: context.userId, workspaceId: context.workspaceId },
+    });
     const credsService = new ServerCredsService(marketService, context.workspaceId);
 
     return new CredsExecutionRuntime(credsService, {

--- a/apps/server/src/services/toolExecution/serverRuntimes/creds.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/creds.ts
@@ -5,6 +5,7 @@ import {
 } from '@lobechat/builtin-tool-creds';
 import debug from 'debug';
 
+import { WorkspaceMemberModel } from '@/database/models/workspaceMember';
 import { MarketService } from '@/server/services/market';
 
 import { type ServerRuntimeRegistration } from './types';
@@ -159,9 +160,23 @@ class ServerCredsService implements ICredsService {
  * Per-request runtime (needs userId, topicId)
  */
 export const credsRuntime: ServerRuntimeRegistration = {
-  factory: (context) => {
+  factory: async (context) => {
     if (!context.userId) {
       throw new Error('userId is required for Creds execution');
+    }
+
+    if (context.workspaceId) {
+      if (!context.serverDB) {
+        throw new Error('serverDB is required for workspace Creds execution');
+      }
+
+      const membership = await new WorkspaceMemberModel(context.serverDB, context.userId).getMember(
+        context.workspaceId,
+        context.userId,
+      );
+      if (!membership) {
+        throw new Error('Workspace membership is required for workspace Creds execution');
+      }
     }
 
     log(


### PR DESCRIPTION
## Summary

- verify workspace membership before signing workspace scope into the credential service identity
- propagate the verified operation workspace ID when constructing the credential service client
- fail closed when workspace membership cannot be verified while preserving personal credential scope outside workspaces
- add regression coverage for verified, unverified, missing-DB, personal, and missing-user contexts

## Key decisions / non-goals

- reuse the existing workspace-aware trusted-client identity and generic credential injection path
- keep the authorization check at the credential runtime boundary so every operation entry path is covered
- do not add a separate organization injection endpoint or change the SDK contract
- no migration is required

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands:

```bash
bun run check \
  lobehub/apps/server/src/services/toolExecution/serverRuntimes/creds.ts \
  lobehub/apps/server/src/services/toolExecution/serverRuntimes/__tests__/creds.test.ts
bun run check --type
```
