### PR TITLE
💄 style(subscription): add sidebar upgrade card copy

### DIFF
--- a/locales/ar/subscription.json
+++ b/locales/ar/subscription.json
@@ -303,6 +303,8 @@
   "models.link": "عرض",
   "models.output": "إخراج",
   "models.title": "النماذج",
+  "navPanelUpgrade.desc": "قم بالترقية لفتح قدرات موسّعة",
+  "navPanelUpgrade.dismiss": "إخفاء مؤقتًا",
   "payDiffPrice": "دفع الفرق",
   "payDiffPriceApprox": "تقريبًا",
   "payDiffPriceTip": "المبلغ الفعلي يعتمد على صفحة الدفع",

--- a/locales/bg-BG/subscription.json
+++ b/locales/bg-BG/subscription.json
@@ -303,6 +303,8 @@
   "models.link": "Преглед",
   "models.output": "Изход",
   "models.title": "Модели",
+  "navPanelUpgrade.desc": "Надстройте, за да отключите разширени възможности",
+  "navPanelUpgrade.dismiss": "Скрий засега",
   "payDiffPrice": "Плати разликата",
   "payDiffPriceApprox": "Приблизително",
   "payDiffPriceTip": "Действителната сума се определя на страницата за плащане",

--- a/locales/de-DE/subscription.json
+++ b/locales/de-DE/subscription.json
@@ -303,6 +303,8 @@
   "models.link": "Anzeigen",
   "models.output": "Ausgabe",
   "models.title": "Modelle",
+  "navPanelUpgrade.desc": "Upgraden Sie, um erweiterte Funktionen freizuschalten",
+  "navPanelUpgrade.dismiss": "Vorerst ausblenden",
   "payDiffPrice": "Differenz bezahlen",
   "payDiffPriceApprox": "Ca.",
   "payDiffPriceTip": "Der tatsächliche Betrag richtet sich nach der Zahlungsseite",

--- a/locales/en-US/subscription.json
+++ b/locales/en-US/subscription.json
@@ -303,6 +303,8 @@
   "models.link": "View",
   "models.output": "Output",
   "models.title": "Models",
+  "navPanelUpgrade.desc": "Upgrade to unlock extended capabilities",
+  "navPanelUpgrade.dismiss": "Hide for now",
   "payDiffPrice": "Pay Difference",
   "payDiffPriceApprox": "Approx.",
   "payDiffPriceTip": "Actual amount subject to payment page",

--- a/locales/es-ES/subscription.json
+++ b/locales/es-ES/subscription.json
@@ -303,6 +303,8 @@
   "models.link": "Ver",
   "models.output": "Salida",
   "models.title": "Modelos",
+  "navPanelUpgrade.desc": "Actualiza para desbloquear capacidades ampliadas",
+  "navPanelUpgrade.dismiss": "Ocultar por ahora",
   "payDiffPrice": "Pagar Diferencia",
   "payDiffPriceApprox": "Aprox.",
   "payDiffPriceTip": "El importe real se mostrará en la página de pago",

--- a/locales/fa-IR/subscription.json
+++ b/locales/fa-IR/subscription.json
@@ -303,6 +303,8 @@
   "models.link": "مشاهده",
   "models.output": "خروجی",
   "models.title": "مدل‌ها",
+  "navPanelUpgrade.desc": "برای باز کردن قابلیت‌های گسترده ارتقا دهید",
+  "navPanelUpgrade.dismiss": "فعلاً پنهان شود",
   "payDiffPrice": "پرداخت مابه‌التفاوت",
   "payDiffPriceApprox": "تقریباً",
   "payDiffPriceTip": "مبلغ نهایی در صفحه پرداخت مشخص می‌شود",

--- a/locales/fr-FR/subscription.json
+++ b/locales/fr-FR/subscription.json
@@ -303,6 +303,8 @@
   "models.link": "Voir",
   "models.output": "Sortie",
   "models.title": "Modèles",
+  "navPanelUpgrade.desc": "Mettez à niveau pour débloquer des fonctionnalités étendues",
+  "navPanelUpgrade.dismiss": "Masquer pour l'instant",
   "payDiffPrice": "Payer la différence",
   "payDiffPriceApprox": "Env.",
   "payDiffPriceTip": "Montant réel selon la page de paiement",

--- a/locales/it-IT/subscription.json
+++ b/locales/it-IT/subscription.json
@@ -303,6 +303,8 @@
   "models.link": "Visualizza",
   "models.output": "Output",
   "models.title": "Modelli",
+  "navPanelUpgrade.desc": "Effettua l'upgrade per sbloccare funzionalità estese",
+  "navPanelUpgrade.dismiss": "Nascondi per ora",
   "payDiffPrice": "Paga la differenza",
   "payDiffPriceApprox": "Circa",
   "payDiffPriceTip": "Importo effettivo soggetto alla pagina di pagamento",

--- a/locales/ja-JP/subscription.json
+++ b/locales/ja-JP/subscription.json
@@ -303,6 +303,8 @@
   "models.link": "表示",
   "models.output": "出力",
   "models.title": "モデル",
+  "navPanelUpgrade.desc": "アップグレードして拡張機能をアンロック",
+  "navPanelUpgrade.dismiss": "今は非表示にする",
   "payDiffPrice": "差額を支払う",
   "payDiffPriceApprox": "約",
   "payDiffPriceTip": "実際の金額は支払いページでご確認ください",

--- a/locales/ko-KR/subscription.json
+++ b/locales/ko-KR/subscription.json
@@ -303,6 +303,8 @@
   "models.link": "보기",
   "models.output": "출력",
   "models.title": "모델",
+  "navPanelUpgrade.desc": "업그레이드하고 확장된 기능을 잠금 해제하세요",
+  "navPanelUpgrade.dismiss": "지금은 숨기기",
   "payDiffPrice": "차액 결제",
   "payDiffPriceApprox": "약",
   "payDiffPriceTip": "실제 결제 금액은 결제 페이지에서 확인하세요",

--- a/locales/nl-NL/subscription.json
+++ b/locales/nl-NL/subscription.json
@@ -303,6 +303,8 @@
   "models.link": "Bekijk",
   "models.output": "Uitvoer",
   "models.title": "Modellen",
+  "navPanelUpgrade.desc": "Upgrade om uitgebreide functies te ontgrendelen",
+  "navPanelUpgrade.dismiss": "Voorlopig verbergen",
   "payDiffPrice": "Betaal Verschil",
   "payDiffPriceApprox": "Ca.",
   "payDiffPriceTip": "Het werkelijke bedrag wordt getoond op de betaalpagina",

--- a/locales/pl-PL/subscription.json
+++ b/locales/pl-PL/subscription.json
@@ -303,6 +303,8 @@
   "models.link": "Zobacz",
   "models.output": "Wyjście",
   "models.title": "Modele",
+  "navPanelUpgrade.desc": "Ulepsz, aby odblokować rozszerzone możliwości",
+  "navPanelUpgrade.dismiss": "Ukryj na razie",
   "payDiffPrice": "Dopłać różnicę",
   "payDiffPriceApprox": "Około",
   "payDiffPriceTip": "Rzeczywista kwota zgodna ze stroną płatności",

--- a/locales/pt-BR/subscription.json
+++ b/locales/pt-BR/subscription.json
@@ -303,6 +303,8 @@
   "models.link": "Ver",
   "models.output": "Saída",
   "models.title": "Modelos",
+  "navPanelUpgrade.desc": "Atualize para desbloquear capacidades estendidas",
+  "navPanelUpgrade.dismiss": "Ocultar por enquanto",
   "payDiffPrice": "Pagar Diferença",
   "payDiffPriceApprox": "Aprox.",
   "payDiffPriceTip": "Valor real sujeito à página de pagamento",

--- a/locales/ru-RU/subscription.json
+++ b/locales/ru-RU/subscription.json
@@ -303,6 +303,8 @@
   "models.link": "Посмотреть",
   "models.output": "Вывод",
   "models.title": "Модели",
+  "navPanelUpgrade.desc": "Обновите план, чтобы открыть расширенные возможности",
+  "navPanelUpgrade.dismiss": "Скрыть на время",
   "payDiffPrice": "Оплатить разницу",
   "payDiffPriceApprox": "Приблизительно",
   "payDiffPriceTip": "Фактическая сумма указывается на странице оплаты",

--- a/locales/tr-TR/subscription.json
+++ b/locales/tr-TR/subscription.json
@@ -303,6 +303,8 @@
   "models.link": "Görüntüle",
   "models.output": "Çıktı",
   "models.title": "Modeller",
+  "navPanelUpgrade.desc": "Genişletilmiş özelliklerin kilidini açmak için yükseltin",
+  "navPanelUpgrade.dismiss": "Şimdilik gizle",
   "payDiffPrice": "Farkı Öde",
   "payDiffPriceApprox": "Yaklaşık",
   "payDiffPriceTip": "Gerçek tutar ödeme sayfasında geçerlidir",

--- a/locales/vi-VN/subscription.json
+++ b/locales/vi-VN/subscription.json
@@ -303,6 +303,8 @@
   "models.link": "Xem",
   "models.output": "Đầu ra",
   "models.title": "Mô hình",
+  "navPanelUpgrade.desc": "Nâng cấp để mở khóa các tính năng mở rộng",
+  "navPanelUpgrade.dismiss": "Tạm ẩn",
   "payDiffPrice": "Thanh toán phần chênh lệch",
   "payDiffPriceApprox": "Xấp xỉ",
   "payDiffPriceTip": "Số tiền thực tế sẽ hiển thị trên trang thanh toán",

--- a/locales/zh-CN/subscription.json
+++ b/locales/zh-CN/subscription.json
@@ -303,6 +303,8 @@
   "models.link": "查看",
   "models.output": "输出",
   "models.title": "模型",
+  "navPanelUpgrade.desc": "升级以解锁更多能力",
+  "navPanelUpgrade.dismiss": "暂时隐藏",
   "payDiffPrice": "支付差价",
   "payDiffPriceApprox": "约",
   "payDiffPriceTip": "实际金额以支付页面为准",

--- a/locales/zh-TW/subscription.json
+++ b/locales/zh-TW/subscription.json
@@ -303,6 +303,8 @@
   "models.link": "查看",
   "models.output": "輸出",
   "models.title": "模型",
+  "navPanelUpgrade.desc": "升級以解鎖更多能力",
+  "navPanelUpgrade.dismiss": "暫時隱藏",
   "payDiffPrice": "支付差額",
   "payDiffPriceApprox": "約",
   "payDiffPriceTip": "實際金額以付款頁面為準",

--- a/packages/locales/src/default/subscription.ts
+++ b/packages/locales/src/default/subscription.ts
@@ -360,6 +360,8 @@ export default {
   'models.link': 'View',
   'models.output': 'Output',
   'models.title': 'Models',
+  'navPanelUpgrade.desc': 'Upgrade to unlock extended capabilities',
+  'navPanelUpgrade.dismiss': 'Hide for now',
   'payDiffPrice': 'Pay Difference',
   'payDiffPriceApprox': 'Approx.',
   'payDiffPriceTip': 'Actual amount subject to payment page',


### PR DESCRIPTION
Adds the two `navPanelUpgrade.*` strings consumed by the sidebar upgrade card — its description line and the tooltip on its dismiss control — with hand-written en-US and zh-CN translations. Remaining locales are left to the daily auto-i18n workflow.

Locale-only change; the card itself lives on the cloud side.

#### Test

- [x] No tests needed

#### 🔗 Related Issue

N/A