### PR TITLE
💄 style(topic): refine context menu grouping

### DIFF
--- a/src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.test.tsx
+++ b/src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.test.tsx
@@ -10,6 +10,7 @@ const permissionMock = vi.hoisted(() => ({
   create_content: true,
   edit_own_content: true,
 }));
+const versionMock = vi.hoisted(() => ({ isDesktop: false }));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -39,7 +40,9 @@ vi.mock('@/components/RenameModal', () => ({
 }));
 
 vi.mock('@/const/version', () => ({
-  isDesktop: false,
+  get isDesktop() {
+    return versionMock.isDesktop;
+  },
 }));
 
 vi.mock('@/features/Electron/titlebar/RecentlyViewed/plugins', () => ({
@@ -104,6 +107,40 @@ describe('useTopicItemDropdownMenu', () => {
   beforeEach(() => {
     permissionMock.create_content = true;
     permissionMock.edit_own_content = true;
+    versionMock.isDesktop = false;
+  });
+
+  it('groups desktop topic actions by intent', () => {
+    versionMock.isDesktop = true;
+
+    const { result } = renderHook(() =>
+      useTopicItemDropdownMenu({ id: 'topic-1', title: 'Topic 1' }),
+    );
+    const items = result.current.dropdownMenu();
+
+    expect(items.map((item) => (item && 'key' in item ? item.key : 'divider'))).toEqual([
+      'markCompleted',
+      'favorite',
+      'divider',
+      'autoRename',
+      'rename',
+      'diagnose',
+      'divider',
+      'openInNewTab',
+      'openInNewWindow',
+      'divider',
+      'copySessionId',
+      'copyLink',
+      'divider',
+      'duplicate',
+      'forwardToAgent',
+      'moveToAgent',
+      'divider',
+      'share',
+      'divider',
+      'delete',
+    ]);
+    expect(getMenuItem(items, 'share')).toMatchObject({ label: 'shareModal.title' });
   });
 
   it('disables topic management actions for workspace viewers', () => {

--- a/src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.tsx
+++ b/src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.tsx
@@ -6,6 +6,7 @@ import { App } from 'antd';
 import {
   Archive,
   ArchiveRestore,
+  Download,
   ExternalLink,
   FolderInput,
   Forward,
@@ -14,7 +15,6 @@ import {
   LucideCopy,
   PanelTop,
   PencilLine,
-  Share2,
   Star,
   Stethoscope,
   Trash,
@@ -54,7 +54,7 @@ export const useTopicItemDropdownMenu = ({
   status,
   title,
 }: TopicItemDropdownMenuProps) => {
-  const { t } = useTranslation(['topic', 'common']);
+  const { t } = useTranslation(['topic', 'common', 'chat']);
   const { message } = App.useApp();
   const navigate = useWorkspaceAwareNavigate();
   const activeWorkspaceSlug = useActiveWorkspaceSlug();
@@ -107,9 +107,6 @@ export const useTopicItemDropdownMenu = ({
             markTopicCompleted(id);
           }
         },
-      },
-      {
-        type: 'divider' as const,
       },
       {
         disabled: !canEditTopic,
@@ -218,6 +215,9 @@ export const useTopicItemDropdownMenu = ({
         },
       },
       {
+        type: 'divider' as const,
+      },
+      {
         disabled: !canCreateTopic,
         icon: <Icon icon={LucideCopy} />,
         key: 'duplicate',
@@ -250,9 +250,9 @@ export const useTopicItemDropdownMenu = ({
       },
       {
         disabled: !canEditTopic,
-        icon: <Icon icon={Share2} />,
+        icon: <Icon icon={Download} />,
         key: 'share',
-        label: t('share', { ns: 'common' }),
+        label: t('shareModal.title', { ns: 'chat' }),
         onClick: handleOpenShareModal,
       },
       {


### PR DESCRIPTION
## Description of Change

Refine the topic list context menu without removing or changing the behavior of any action:

- Group Archive and Favorite as topic status actions.
- Separate topic metadata copying from Duplicate, Forward, and Move actions.
- Rename the direct ShareModal entry to Export and use a download icon, matching the modal's existing export behavior and title.
- Add regression coverage for the desktop menu grouping and Export label.

| Before | After |
| ------ | ----- |
| Archive and Favorite were separated, while copy and transfer actions shared one group. The export modal entry was labeled Share. | Status actions are grouped, copy and transfer actions are separated, and the export entry is labeled Export. |

#### Test

- `bun run check src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.tsx src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.test.tsx`

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

N/A
