### PR TITLE
🐛 fix: restore image paste in browser runtime

### DIFF
--- a/packages/utils/src/mimeType.test.ts
+++ b/packages/utils/src/mimeType.test.ts
@@ -1,6 +1,22 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { getMimeType, resolveMimeType, tryGetMimeType } from './mimeType';
+
+afterEach(() => {
+  vi.doUnmock('node:path');
+  vi.resetModules();
+});
+
+describe('browser compatibility', () => {
+  it('detects a pasted image without relying on Node path.extname', async () => {
+    vi.doMock('node:path', () => ({ default: {} }));
+    vi.resetModules();
+
+    const browserMimeType = await import('./mimeType');
+
+    expect(browserMimeType.getMimeType('pasted-image.png')).toBe('image/png');
+  });
+});
 
 describe('getMimeType', () => {
   describe('custom code file MIME types', () => {

--- a/packages/utils/src/mimeType.ts
+++ b/packages/utils/src/mimeType.ts
@@ -1,5 +1,3 @@
-import path from 'node:path';
-
 import { fileTypeFromBuffer } from 'file-type';
 import mime from 'mime';
 
@@ -38,8 +36,15 @@ const withCharset = (mimeType: string): string =>
     ? `${mimeType}; charset=utf-8`
     : mimeType;
 
+const getExtension = (filePath: string): string => {
+  const fileName = filePath.replace(/^.*[/\\]/s, '');
+  const dotIndex = fileName.lastIndexOf('.');
+
+  return dotIndex > 0 ? fileName.slice(dotIndex).toLowerCase() : '';
+};
+
 const lookupExtensionMime = (filePath: string): string | null => {
-  const ext = path.extname(filePath).toLowerCase();
+  const ext = getExtension(filePath);
   return CUSTOM_MIME_TYPES[ext] ?? mime.getType(filePath);
 };
 


### PR DESCRIPTION
## Summary

- remove the Node `path` runtime dependency from the shared MIME helper
- extract file extensions with a browser-safe string helper
- add a regression test for pasted image MIME detection when `node:path` has no `extname` implementation

## Root cause

Commit `0b5af01ceff4d233811ac7f6ad257cd6bd62ff58` changed the shared MIME helper to call `path.extname`. The helper is also bundled into the renderer and runs when an image is pasted, where the Node path shim does not provide that function, causing `TypeError: ...default.extname is not a function`.

## Test plan

- `cd packages/utils && bunx vitest run --silent=passed-only src/mimeType.test.ts`
- `bun run check packages/utils/src/mimeType.ts packages/utils/src/mimeType.test.ts`