### PR TITLE
✨ feat: add GreenPT provider

### DIFF
--- a/packages/env/src/llm.ts
+++ b/packages/env/src/llm.ts
@@ -175,6 +175,9 @@ export const getLLMConfig = () => {
       ENABLED_SAMBANOVA: z.boolean(),
       SAMBANOVA_API_KEY: z.string().optional(),
 
+      ENABLED_GREENPT: z.boolean(),
+      GREENPT_API_KEY: z.string().optional(),
+
       ENABLED_PPIO: z.boolean(),
       PPIO_API_KEY: z.string().optional(),
 
@@ -425,6 +428,9 @@ export const getLLMConfig = () => {
 
       ENABLED_SAMBANOVA: !!process.env.SAMBANOVA_API_KEY,
       SAMBANOVA_API_KEY: process.env.SAMBANOVA_API_KEY,
+
+      ENABLED_GREENPT: !!process.env.GREENPT_API_KEY,
+      GREENPT_API_KEY: process.env.GREENPT_API_KEY,
 
       ENABLED_PPIO: !!process.env.PPIO_API_KEY,
       PPIO_API_KEY: process.env.PPIO_API_KEY,

--- a/packages/model-bank/package.json
+++ b/packages/model-bank/package.json
@@ -33,6 +33,7 @@
     "./githubCopilot": "./src/aiModels/githubCopilot.ts",
     "./google": "./src/aiModels/google.ts",
     "./glmCodingPlan": "./src/aiModels/glmCodingPlan.ts",
+    "./greenpt": "./src/aiModels/greenpt.ts",
     "./groq": "./src/aiModels/groq.ts",
     "./higress": "./src/aiModels/higress.ts",
     "./huggingface": "./src/aiModels/huggingface.ts",

--- a/packages/model-bank/src/aiModels/greenpt.ts
+++ b/packages/model-bank/src/aiModels/greenpt.ts
@@ -1,0 +1,110 @@
+import type { AIASRModelCard, AIChatModelCard, AIEmbeddingModelCard } from '../types/aiModel';
+
+// GreenPT publishes prices in EUR. USD rates use the ECB reference rate for 2026-07-24:
+// 1 EUR = 1.1377 USD.
+// https://docs.greenpt.ai/pricing
+// https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html
+const greenptChatModels: AIChatModelCard[] = [
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 1_000_000,
+    description:
+      'GreenPT Code flagship model for long-horizon reasoning, agentic tool use, and multi-file software engineering.',
+    displayName: 'GLM-5.2',
+    enabled: true,
+    family: 'glm',
+    generation: 'glm-5.2',
+    id: 'glm-5.2',
+    maxOutput: 131_072,
+    pricing: {
+      currency: 'USD',
+      units: [
+        { name: 'textInput', rate: 1.501764, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 5.256174, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    settings: {
+      extendParams: ['glm5_2ReasoningEffort'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 262_144,
+    description:
+      'Moonshot Kimi K2.7 Code, served by GreenPT and tuned for software engineering and agentic coding tasks.',
+    displayName: 'Kimi K2.7 Code',
+    enabled: true,
+    family: 'kimi',
+    generation: 'kimi-k2.7',
+    id: 'kimi-k2.7-code',
+    maxOutput: 262_144,
+    pricing: {
+      currency: 'USD',
+      units: [
+        { name: 'textInput', rate: 0.944291, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 4.380145, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    settings: {
+      extendParams: ['reasoningEffort'],
+    },
+    type: 'chat',
+  },
+];
+
+const greenptEmbeddingModels: AIEmbeddingModelCard[] = [
+  {
+    contextWindowTokens: 32_768,
+    description:
+      'GreenPT multilingual dense embedding model for semantic search, retrieval, clustering, and RAG.',
+    displayName: 'Green Embedding',
+    enabled: true,
+    family: 'qwen',
+    id: 'green-embedding',
+    maxDimension: 2560,
+    pricing: {
+      currency: 'USD',
+      units: [{ name: 'textInput', rate: 0.22754, strategy: 'fixed', unit: 'millionTokens' }],
+    },
+    releasedAt: '2025-06-01',
+    type: 'embedding',
+  },
+];
+
+const greenptASRModels: AIASRModelCard[] = [
+  {
+    description: 'GreenPT speech-to-text model for pre-recorded and live transcription.',
+    displayName: 'GreenS',
+    enabled: true,
+    id: 'green-s',
+    pricing: {
+      currency: 'USD',
+      units: [{ name: 'audioInput', rate: 0.000072686, strategy: 'fixed', unit: 'second' }],
+    },
+    releasedAt: '2025-01-01',
+    type: 'asr',
+  },
+  {
+    description: 'GreenPT advanced speech-to-text model with multilingual transcription support.',
+    displayName: 'GreenS Pro',
+    enabled: true,
+    id: 'green-s-pro',
+    pricing: {
+      currency: 'USD',
+      units: [{ name: 'audioInput', rate: 0.000072686, strategy: 'fixed', unit: 'second' }],
+    },
+    releasedAt: '2025-01-01',
+    type: 'asr',
+  },
+];
+
+export const allModels = [...greenptChatModels, ...greenptEmbeddingModels, ...greenptASRModels];
+
+export default allModels;

--- a/packages/model-bank/src/aiModels/index.ts
+++ b/packages/model-bank/src/aiModels/index.ts
@@ -28,6 +28,7 @@ import { default as github } from './github';
 import { default as githubcopilot } from './githubCopilot';
 import { default as glmcodingplan } from './glmCodingPlan';
 import { default as google } from './google';
+import { default as greenpt } from './greenpt';
 import { default as groq } from './groq';
 import { default as higress } from './higress';
 import { default as huggingface } from './huggingface';
@@ -139,6 +140,7 @@ const staticModelMap: ModelsMap = {
   google,
   glmcodingplan,
   groq,
+  greenpt,
   higress,
   huggingface,
   hunyuan,
@@ -254,6 +256,7 @@ export { default as github } from './github';
 export { default as githubcopilot } from './githubCopilot';
 export { default as glmcodingplan } from './glmCodingPlan';
 export { default as google } from './google';
+export { default as greenpt } from './greenpt';
 export { default as groq } from './groq';
 export { default as higress } from './higress';
 export { default as huggingface } from './huggingface';

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -26,6 +26,7 @@ export enum ModelProvider {
   GithubCopilot = 'githubcopilot',
   GLMCodingPlan = 'glmcodingplan',
   Google = 'google',
+  GreenPT = 'greenpt',
   Groq = 'groq',
   Higress = 'higress',
   HuggingFace = 'huggingface',

--- a/packages/model-bank/src/modelProviders/greenpt.ts
+++ b/packages/model-bank/src/modelProviders/greenpt.ts
@@ -1,0 +1,24 @@
+import type { ModelProviderCard } from '../types';
+
+const GreenPT: ModelProviderCard = {
+  apiKeyUrl: 'https://account.greenpt.ai/api/keys',
+  chatModels: [],
+  checkModel: 'glm-5.2',
+  description:
+    'GreenPT is a European AI provider with an OpenAI-compatible API, optimized infrastructure, and data centers powered by 100% renewable energy.',
+  id: 'greenpt',
+  modelList: { showModelFetcher: true },
+  modelsUrl: 'https://docs.greenpt.ai/model-cards',
+  name: 'GreenPT',
+  settings: {
+    disableBrowserRequest: true,
+    proxyUrl: {
+      placeholder: 'https://api.greenpt.ai/v1',
+    },
+    sdkType: 'openai',
+    showModelFetcher: true,
+  },
+  url: 'https://greenpt.com/api',
+};
+
+export default GreenPT;

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -28,6 +28,7 @@ import GithubProvider from './github';
 import GithubCopilotProvider from './githubCopilot';
 import GLMCodingPlanProvider from './glmCodingPlan';
 import GoogleProvider from './google';
+import GreenPTProvider from './greenpt';
 import GroqProvider from './groq';
 import HigressProvider from './higress';
 import HuggingFaceProvider from './huggingface';
@@ -178,6 +179,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   TogetherAIProvider,
   FireworksAIProvider,
   GroqProvider,
+  GreenPTProvider,
   PerplexityProvider,
   MistralProvider,
   ModelScopeProvider,
@@ -272,6 +274,7 @@ export { default as GithubProviderCard } from './github';
 export { default as GithubCopilotProviderCard } from './githubCopilot';
 export { default as GLMCodingPlanProviderCard } from './glmCodingPlan';
 export { default as GoogleProviderCard } from './google';
+export { default as GreenPTProviderCard } from './greenpt';
 export { default as GroqProviderCard } from './groq';
 export { default as HigressProviderCard } from './higress';
 export { default as HuggingFaceProviderCard } from './huggingface';

--- a/packages/model-runtime/src/providers/greenpt/index.test.ts
+++ b/packages/model-runtime/src/providers/greenpt/index.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+import { ModelProvider } from 'model-bank';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { testProvider } from '../../providerTestUtils';
+import { LobeGreenPTAI } from './index';
+
+const provider = ModelProvider.GreenPT;
+const defaultBaseURL = 'https://api.greenpt.ai/v1';
+
+testProvider({
+  Runtime: LobeGreenPTAI,
+  provider,
+  defaultBaseURL,
+  chatDebugEnv: 'DEBUG_GREENPT_CHAT_COMPLETION',
+  chatModel: 'glm-5.2',
+});
+
+describe('GreenPT provider extensions', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('discovers supported models while excluding the unsupported reranker type', async () => {
+    const instance = new LobeGreenPTAI({ apiKey: 'test' });
+    vi.spyOn(instance.client.models, 'list').mockResolvedValue({
+      data: [
+        { id: 'glm-5.2' },
+        { id: 'green-embedding' },
+        { id: 'green-s' },
+        { id: 'green-rerank' },
+      ],
+    } as any);
+
+    const models = await instance.models();
+
+    expect(models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'glm-5.2', type: 'chat' }),
+        expect.objectContaining({ id: 'green-embedding', type: 'embedding' }),
+        expect.objectContaining({ id: 'green-s', type: 'asr' }),
+      ]),
+    );
+    expect(models).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: 'green-rerank' })]),
+    );
+  });
+
+  it('transcribes audio through the GreenPT listen endpoint', async () => {
+    const instance = new LobeGreenPTAI({ apiKey: 'test-key' });
+    const file = new Blob(['audio'], { type: 'audio/wav' });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          results: {
+            channels: [
+              { alternatives: [{ transcript: ' First channel ' }] },
+              { alternatives: [{ transcript: 'Second channel' }] },
+            ],
+          },
+        }),
+        { headers: { 'Content-Type': 'application/json' }, status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(instance.transcribe({ file, language: 'en', model: 'green-s' })).resolves.toEqual({
+      text: 'First channel\nSecond channel',
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL('https://api.greenpt.ai/v1/listen?model=green-s&language=en'),
+      expect.objectContaining({
+        body: file,
+        headers: {
+          'Authorization': 'Bearer test-key',
+          'Content-Type': 'audio/wav',
+        },
+        method: 'POST',
+      }),
+    );
+  });
+});

--- a/packages/model-runtime/src/providers/greenpt/index.ts
+++ b/packages/model-runtime/src/providers/greenpt/index.ts
@@ -1,0 +1,70 @@
+import { ModelProvider } from 'model-bank';
+
+import type { OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
+import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+import type { ASROptions, ASRPayload, ASRResponse } from '../../types';
+import { processModelList } from '../../utils/modelParse';
+
+interface GreenPTTranscriptionResponse {
+  results?: {
+    channels?: Array<{
+      alternatives?: Array<{ transcript?: string }>;
+    }>;
+  };
+}
+
+export const params = {
+  baseURL: 'https://api.greenpt.ai/v1',
+  debug: {
+    chatCompletion: () => process.env.DEBUG_GREENPT_CHAT_COMPLETION === '1',
+  },
+  models: async ({ client }) => {
+    const modelsPage = (await client.models.list()) as any;
+    const modelList = (Array.isArray(modelsPage?.data) ? modelsPage.data : []).filter(
+      ({ id }: { id?: string }) => id && id !== 'green-rerank',
+    );
+
+    return processModelList(modelList, {}, ModelProvider.GreenPT);
+  },
+  provider: ModelProvider.GreenPT,
+} satisfies OpenAICompatibleFactoryOptions;
+
+const GreenPTOpenAICompatibleRuntime = createOpenAICompatibleRuntime(params);
+
+export class LobeGreenPTAI extends GreenPTOpenAICompatibleRuntime {
+  async transcribe(payload: ASRPayload, options?: ASROptions): Promise<ASRResponse> {
+    const url = new URL(`${this.baseURL.replace(/\/+$/, '')}/listen`);
+    url.searchParams.set('model', this.getMappedModelId(payload.model));
+    if (payload.language) url.searchParams.set('language', payload.language);
+
+    try {
+      const response = await fetch(url, {
+        body: payload.file,
+        headers: {
+          'Authorization': `Bearer ${this._options.apiKey}`,
+          'Content-Type': payload.file.type || 'application/octet-stream',
+          ...options?.headers,
+        },
+        method: 'POST',
+        signal: options?.signal,
+      });
+
+      if (!response.ok) {
+        const error = new Error(`GreenPT transcription request failed: ${response.status}`);
+        Object.assign(error, { status: response.status });
+        throw error;
+      }
+
+      const data = (await response.json()) as GreenPTTranscriptionResponse;
+      const text =
+        data.results?.channels
+          ?.map((channel) => channel.alternatives?.[0]?.transcript?.trim())
+          .filter(Boolean)
+          .join('\n') ?? '';
+
+      return { text };
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+}

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -25,6 +25,7 @@ import { LobeGithubAI } from './providers/github';
 import { LobeGithubCopilotAI } from './providers/githubCopilot';
 import { LobeGLMCodingPlanAI } from './providers/glmCodingPlan';
 import { LobeGoogleAI } from './providers/google';
+import { LobeGreenPTAI } from './providers/greenpt';
 import { LobeGroq } from './providers/groq';
 import { LobeHigressAI } from './providers/higress';
 import { LobeHuggingFaceAI } from './providers/huggingface';
@@ -111,6 +112,7 @@ export const providerRuntimeMap = {
   google: LobeGoogleAI,
   glmcodingplan: LobeGLMCodingPlanAI,
   groq: LobeGroq,
+  greenpt: LobeGreenPTAI,
   higress: LobeHigressAI,
   huggingface: LobeHuggingFaceAI,
   hunyuan: LobeHunyuanAI,


### PR DESCRIPTION
## Summary

Adds GreenPT as a native LobeHub model provider.

GreenPT is a European AI provider with an OpenAI-compatible API, optimized infrastructure, and data centers powered by 100% renewable energy.

## What changed

- adds the `greenpt` provider and `GREENPT_API_KEY` server configuration
- features `glm-5.2` and `kimi-k2.7-code` as the default chat and coding models
- adds `green-embedding` for embeddings
- adds `green-s` and `green-s-pro` speech-to-text models through GreenPT's `/v1/listen` endpoint
- fetches the current catalog from `GET /v1/models`
- includes context windows, capabilities, output limits, and USD pricing metadata

`green-rerank` is intentionally filtered from model discovery because LobeHub does not currently define a reranker model type or runtime contract; exposing it would incorrectly classify it as a chat model.

The GreenPT provider icon is proposed separately in [lobehub/lobe-icons#372](https://github.com/lobehub/lobe-icons/pull/372).

## User impact

Users can select GreenPT directly, enter a GreenPT API key, refresh the live model catalog, chat with its flagship coding models, create embeddings, and transcribe audio without configuring a custom OpenAI provider.

## Validation

- `bun run check <changed files>` — lint clean, 25 tests passed
- `bun run check --type` — types clean
- `bunx vitest run --silent='passed-only' 'src/providers/greenpt/index.test.ts'` — 12 tests passed
