### PR TITLE
✨ feat: route declarative context menus through the native interceptor

### DIFF
--- a/package.json
+++ b/package.json
@@ -299,7 +299,7 @@
     "@lobehub/icons": "^5.11.0",
     "@lobehub/market-sdk": "0.39.2",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "^5.23.0",
+    "@lobehub/ui": "^5.24.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@napi-rs/canvas": "^0.1.100",
     "@neondatabase/serverless": "^1.1.0",

--- a/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
+++ b/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
@@ -334,6 +334,7 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, onOpenDocumen
           key: 'open-as-page',
           label: t('agentDocument.openAsPage'),
           onClick: () => navigate(buildAgentDocumentPath(agentId, node.data!.documentId)),
+          sfSymbol: 'arrow.up.left.and.arrow.down.right',
         });
       }
 
@@ -347,6 +348,7 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, onOpenDocumen
           key: 'convert-to-skill',
           label: t('workingPanel.resources.tree.convertToSkill'),
           onClick: () => handleConvertToSkill(node.data!),
+          sfSymbol: 'sparkles',
         });
       }
 

--- a/src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.tsx
+++ b/src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.tsx
@@ -107,6 +107,7 @@ export const useTopicItemDropdownMenu = ({
             markTopicCompleted(id);
           }
         },
+        sfSymbol: isCompleted ? 'tray.and.arrow.up' : 'archivebox',
       },
       {
         type: 'divider' as const,
@@ -119,6 +120,7 @@ export const useTopicItemDropdownMenu = ({
         onClick: () => {
           favoriteTopic(id, !fav);
         },
+        sfSymbol: fav ? 'star.slash' : 'star',
       },
       {
         type: 'divider' as const,
@@ -131,6 +133,7 @@ export const useTopicItemDropdownMenu = ({
         onClick: () => {
           autoRenameTopicTitle(id);
         },
+        sfSymbol: 'wand.and.stars',
       },
       {
         disabled: !canEditTopic,
@@ -155,6 +158,7 @@ export const useTopicItemDropdownMenu = ({
             title: t('renameModal.title', { ns: 'topic' }),
           });
         },
+        sfSymbol: 'pencil',
       },
       {
         disabled: !canEditTopic,
@@ -164,6 +168,7 @@ export const useTopicItemDropdownMenu = ({
         onClick: () => {
           openTopicDoctorModal({ agentId: activeAgentId, topicId: id });
         },
+        sfSymbol: 'stethoscope',
       },
       {
         type: 'divider' as const,
@@ -254,6 +259,7 @@ export const useTopicItemDropdownMenu = ({
         key: 'share',
         label: t('share', { ns: 'common' }),
         onClick: handleOpenShareModal,
+        sfSymbol: 'square.and.arrow.up',
       },
       {
         type: 'divider' as const,
@@ -280,6 +286,7 @@ export const useTopicItemDropdownMenu = ({
             topicIds: [id],
           });
         },
+        sfSymbol: 'trash',
       },
     ].filter(Boolean) as MenuProps['items'];
   }, [

--- a/src/features/AgentSidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx
+++ b/src/features/AgentSidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx
@@ -32,6 +32,7 @@ export const useThreadItemDropdownMenu = ({
         onClick: () => {
           toggleEditing(true);
         },
+        sfSymbol: 'pencil',
       },
       {
         type: 'divider' as const,
@@ -54,6 +55,7 @@ export const useThreadItemDropdownMenu = ({
             title: t('delete', { ns: 'common' }),
           });
         },
+        sfSymbol: 'trash',
       },
     ].filter(Boolean) as MenuProps['items'];
   }, [id, canEditThread, removeThread, toggleEditing, t]);

--- a/src/features/Electron/titlebar/TabBar/TabItem.tsx
+++ b/src/features/Electron/titlebar/TabBar/TabItem.tsx
@@ -21,6 +21,7 @@ import { type ResolvedTab } from './hooks/useResolvedTabs';
 import { useTabRunning } from './hooks/useTabRunning';
 import { useTabUnread } from './hooks/useTabUnread';
 import { useStyles } from './styles';
+import { buildTabContextMenuItems } from './tabContextMenu';
 
 interface TabItemProps {
   index: number;
@@ -73,33 +74,17 @@ const TabItem = memo<TabItemProps>(
     );
 
     const contextMenuItems = useCallback(
-      (): GenericItemType[] => [
-        {
-          disabled: totalCount === 1,
-          key: 'closeCurrentTab',
-          label: t('tab.closeCurrentTab'),
-          onClick: () => onClose(id),
-        },
-        {
-          disabled: totalCount === 1,
-          key: 'closeOtherTabs',
-          label: t('tab.closeOtherTabs'),
-          onClick: () => onCloseOthers(id),
-        },
-        { type: 'divider' },
-        {
-          disabled: index === 0,
-          key: 'closeLeftTabs',
-          label: t('tab.closeLeftTabs'),
-          onClick: () => onCloseLeft(id),
-        },
-        {
-          disabled: index === totalCount - 1,
-          key: 'closeRightTabs',
-          label: t('tab.closeRightTabs'),
-          onClick: () => onCloseRight(id),
-        },
-      ],
+      (): GenericItemType[] =>
+        buildTabContextMenuItems({
+          id,
+          index,
+          onClose,
+          onCloseLeft,
+          onCloseOthers,
+          onCloseRight,
+          t,
+          totalCount,
+        }),
       [t, id, index, totalCount, onClose, onCloseOthers, onCloseLeft, onCloseRight],
     );
 

--- a/src/features/Electron/titlebar/TabBar/__snapshots__/tabContextMenu.test.ts.snap
+++ b/src/features/Electron/titlebar/TabBar/__snapshots__/tabContextMenu.test.ts.snap
@@ -1,0 +1,29 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`tab context menu ownership > goes native on macOS desktop (plain string labels, no web-only capabilities) 1`] = `
+[
+  {
+    "id": "0",
+    "label": "tab.closeCurrentTab",
+    "type": "normal",
+  },
+  {
+    "id": "1",
+    "label": "tab.closeOtherTabs",
+    "type": "normal",
+  },
+  {
+    "type": "separator",
+  },
+  {
+    "id": "3",
+    "label": "tab.closeLeftTabs",
+    "type": "normal",
+  },
+  {
+    "id": "4",
+    "label": "tab.closeRightTabs",
+    "type": "normal",
+  },
+]
+`;

--- a/src/features/Electron/titlebar/TabBar/tabContextMenu.test.ts
+++ b/src/features/Electron/titlebar/TabBar/tabContextMenu.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { canGoNative } from '@/libs/contextMenu/canGoNative';
+import { toNativeTemplate } from '@/libs/contextMenu/toNativeTemplate';
+
+import { buildTabContextMenuItems } from './tabContextMenu';
+
+const build = (index: number, totalCount: number) =>
+  buildTabContextMenuItems({
+    id: 'tab-1',
+    index,
+    onClose: vi.fn(),
+    onCloseLeft: vi.fn(),
+    onCloseOthers: vi.fn(),
+    onCloseRight: vi.fn(),
+    t: (key) => key,
+    totalCount,
+  });
+
+describe('tab context menu ownership', () => {
+  it('goes native on macOS desktop (plain string labels, no web-only capabilities)', () => {
+    const items = build(1, 3);
+
+    expect(canGoNative(items)).toBe(true);
+    expect(toNativeTemplate(items).template).toMatchSnapshot();
+  });
+
+  it('stays native-eligible in the fully disabled single-tab state', () => {
+    expect(canGoNative(build(0, 1))).toBe(true);
+  });
+});

--- a/src/features/Electron/titlebar/TabBar/tabContextMenu.ts
+++ b/src/features/Electron/titlebar/TabBar/tabContextMenu.ts
@@ -1,0 +1,52 @@
+import type { GenericItemType } from '@lobehub/ui';
+
+type TabContextMenuLabelKey =
+  'tab.closeCurrentTab' | 'tab.closeLeftTabs' | 'tab.closeOtherTabs' | 'tab.closeRightTabs';
+
+interface TabContextMenuParams {
+  id: string;
+  index: number;
+  onClose: (id: string) => void;
+  onCloseLeft: (id: string) => void;
+  onCloseOthers: (id: string) => void;
+  onCloseRight: (id: string) => void;
+  t: (key: TabContextMenuLabelKey) => string;
+  totalCount: number;
+}
+
+export const buildTabContextMenuItems = ({
+  id,
+  index,
+  onClose,
+  onCloseLeft,
+  onCloseOthers,
+  onCloseRight,
+  t,
+  totalCount,
+}: TabContextMenuParams): GenericItemType[] => [
+  {
+    disabled: totalCount === 1,
+    key: 'closeCurrentTab',
+    label: t('tab.closeCurrentTab'),
+    onClick: () => onClose(id),
+  },
+  {
+    disabled: totalCount === 1,
+    key: 'closeOtherTabs',
+    label: t('tab.closeOtherTabs'),
+    onClick: () => onCloseOthers(id),
+  },
+  { type: 'divider' },
+  {
+    disabled: index === 0,
+    key: 'closeLeftTabs',
+    label: t('tab.closeLeftTabs'),
+    onClick: () => onCloseLeft(id),
+  },
+  {
+    disabled: index === totalCount - 1,
+    key: 'closeRightTabs',
+    label: t('tab.closeRightTabs'),
+    onClick: () => onCloseRight(id),
+  },
+];

--- a/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.tsx
+++ b/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.tsx
@@ -103,6 +103,7 @@ export const useDropdownMenu = ({
               markTopicCompleted(topicId);
             }
           },
+          sfSymbol: isCompleted ? 'tray.and.arrow.up' : 'archivebox',
         },
         {
           type: 'divider' as const,
@@ -117,6 +118,7 @@ export const useDropdownMenu = ({
           onClick: () => {
             favoriteTopic(topicId, !fav);
           },
+          sfSymbol: fav ? 'star.slash' : 'star',
         },
         {
           type: 'divider' as const,
@@ -129,6 +131,7 @@ export const useDropdownMenu = ({
           onClick: () => {
             autoRenameTopicTitle(topicId);
           },
+          sfSymbol: 'wand.and.stars',
         },
         {
           disabled: !canEditTopic,
@@ -145,6 +148,7 @@ export const useDropdownMenu = ({
               title: t('renameModal.title', { ns: 'topic' }),
             });
           },
+          sfSymbol: 'pencil',
         },
         {
           type: 'divider' as const,
@@ -222,6 +226,7 @@ export const useDropdownMenu = ({
           key: 'share',
           label: t('share'),
           onClick: handleOpenShareModal,
+          sfSymbol: 'square.and.arrow.up',
         },
         {
           type: 'divider' as const,
@@ -242,6 +247,7 @@ export const useDropdownMenu = ({
               topicIds: [topicId],
             });
           },
+          sfSymbol: 'trash',
         },
       ].filter(Boolean) as MenuProps['items'],
     [

--- a/src/features/SkillsList/SkillsList.tsx
+++ b/src/features/SkillsList/SkillsList.tsx
@@ -1,4 +1,5 @@
 import { EMPTY_ARRAY } from '@lobechat/const';
+import type { SFSymbol } from '@lobechat/electron-client-ipc';
 import {
   ContextMenuTrigger,
   Flexbox,
@@ -45,6 +46,7 @@ export interface SkillRowAction {
   key: string;
   label: string;
   onClick: (item: SkillListItem) => void;
+  sfSymbol?: SFSymbol;
   /** Hover-icon tooltip; falls back to `label`. Use for "coming soon" hints. */
   tooltip?: string;
 }
@@ -341,7 +343,7 @@ const SkillRow = memo<SkillRowProps>(
     }, []);
 
     const contextMenuItems = useCallback(
-      (): GenericItemType[] =>
+      (): (GenericItemType & { sfSymbol?: SFSymbol })[] =>
         actions.map((action) => ({
           danger: action.danger,
           disabled: action.disabled,
@@ -349,6 +351,7 @@ const SkillRow = memo<SkillRowProps>(
           key: action.key,
           label: action.label,
           onClick: () => action.onClick(item),
+          sfSymbol: action.sfSymbol,
         })),
       [actions, item],
     );

--- a/src/features/SkillsList/useProjectSkills.ts
+++ b/src/features/SkillsList/useProjectSkills.ts
@@ -120,6 +120,7 @@ export const useProjectSkills = (
         key: 'view',
         label: t('workingPanel.skills.actions.view'),
         onClick: onOpenSkill,
+        sfSymbol: 'eye',
       },
       {
         // Renaming a filesystem skill needs an IPC/RPC that doesn't exist yet.
@@ -128,6 +129,7 @@ export const useProjectSkills = (
         key: 'rename',
         label: t('workingPanel.skills.actions.rename'),
         onClick: () => {},
+        sfSymbol: 'pencil',
         tooltip: comingSoon,
       },
       {
@@ -137,6 +139,7 @@ export const useProjectSkills = (
         key: 'delete',
         label: t('workingPanel.skills.actions.delete'),
         onClick: () => {},
+        sfSymbol: 'trash',
         tooltip: comingSoon,
       },
     ];

--- a/src/layout/SPAGlobalProvider/index.test.tsx
+++ b/src/layout/SPAGlobalProvider/index.test.tsx
@@ -18,6 +18,7 @@ vi.mock('@lobehub/ui', async () => {
     ContextMenuHost: () => React.createElement('div', { 'data-testid': 'context-menu-host' }),
     ModalHost: () => React.createElement('div', { 'data-testid': 'legacy-modal-host' }),
     TooltipGroup: Passthrough,
+    setContextMenuInterceptor: vi.fn(),
   };
 });
 

--- a/src/layout/SPAGlobalProvider/index.tsx
+++ b/src/layout/SPAGlobalProvider/index.tsx
@@ -18,10 +18,13 @@ import { GroupWizardProvider } from '@/layout/GlobalProvider/GroupWizardProvider
 import QueryProvider from '@/layout/GlobalProvider/Query';
 import ServerVersionOutdatedAlert from '@/layout/GlobalProvider/ServerVersionOutdatedAlert';
 import StoreInitialization from '@/layout/GlobalProvider/StoreInitialization';
+import { registerNativeContextMenuInterceptor } from '@/libs/contextMenu';
 import { ServerConfigStoreProvider } from '@/store/serverConfig/Provider';
 import type { SPAServerConfig } from '@/types/spaServerConfig';
 
 import Locale from './Locale';
+
+registerNativeContextMenuInterceptor();
 
 const ModalHost = lazy(() => import('@lobehub/ui').then((m) => ({ default: m.ModalHost })));
 const BaseModalHost = lazy(() =>

--- a/src/libs/contextMenu/index.test.ts
+++ b/src/libs/contextMenu/index.test.ts
@@ -1,16 +1,19 @@
 import {
   closeContextMenu as closeWebContextMenu,
+  type ContextMenuInterceptor,
+  setContextMenuInterceptor,
   showContextMenu as showWebContextMenu,
 } from '@lobehub/ui';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { electronSystemService } from '@/services/electron/system';
 
-import { closeContextMenu, showContextMenu } from './index';
+import { closeContextMenu, registerNativeContextMenuInterceptor, showContextMenu } from './index';
 import type { NativeContextMenuItem } from './types';
 
 vi.mock('@lobehub/ui', () => ({
   closeContextMenu: vi.fn(),
+  setContextMenuInterceptor: vi.fn(),
   showContextMenu: vi.fn(),
 }));
 
@@ -209,5 +212,65 @@ describe('closeContextMenu routing', () => {
 
     expect(closeWebContextMenu).toHaveBeenCalledTimes(1);
     expect(electronSystemService.closePopupContextMenu).not.toHaveBeenCalled();
+  });
+});
+
+describe('registerNativeContextMenuInterceptor', () => {
+  const getInterceptor = (): ContextMenuInterceptor => {
+    registerNativeContextMenuInterceptor();
+    expect(setContextMenuInterceptor).toHaveBeenCalledTimes(1);
+    return vi.mocked(setContextMenuInterceptor).mock.calls[0][0] as ContextMenuInterceptor;
+  };
+
+  it('routes declarative shows to the native popup on darwin without touching the fallback', async () => {
+    stubDarwin();
+    vi.mocked(electronSystemService.popupContextMenu).mockResolvedValue({ clickedId: null });
+    const fallback = vi.fn();
+
+    getInterceptor().show?.([{ key: '1', label: 'Copy' }], undefined, fallback);
+    await flush();
+
+    expect(electronSystemService.popupContextMenu).toHaveBeenCalledTimes(1);
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it('invokes the fallback for native-unsafe items and off darwin', () => {
+    const fallback = vi.fn();
+    const interceptor = getInterceptor();
+
+    interceptor.show?.([{ key: '1', label: 'Copy' }], undefined, fallback);
+    expect(fallback).toHaveBeenCalledTimes(1);
+
+    stubDarwin();
+    interceptor.show?.(
+      [{ extra: 'x', key: '1', label: 'Copy' }] as unknown as NativeContextMenuItem[],
+      undefined,
+      fallback,
+    );
+    expect(fallback).toHaveBeenCalledTimes(2);
+    expect(electronSystemService.popupContextMenu).not.toHaveBeenCalled();
+  });
+
+  it('routes close to the native IPC while a native popup is open, else to the fallback', async () => {
+    stubDarwin();
+    let resolvePopup: (value: { clickedId: string | null }) => void = () => {};
+    vi.mocked(electronSystemService.popupContextMenu).mockImplementation(
+      () => new Promise((resolve) => (resolvePopup = resolve)),
+    );
+    const closeFallback = vi.fn();
+    const interceptor = getInterceptor();
+
+    interceptor.show?.([{ key: '1', label: 'Copy' }], undefined, vi.fn());
+    interceptor.close?.(closeFallback);
+
+    expect(electronSystemService.closePopupContextMenu).toHaveBeenCalledTimes(1);
+    expect(closeFallback).not.toHaveBeenCalled();
+
+    resolvePopup({ clickedId: null });
+    await flush();
+    interceptor.close?.(closeFallback);
+
+    expect(closeFallback).toHaveBeenCalledTimes(1);
+    expect(electronSystemService.closePopupContextMenu).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/libs/contextMenu/index.ts
+++ b/src/libs/contextMenu/index.ts
@@ -1,5 +1,6 @@
 import {
   closeContextMenu as closeWebContextMenu,
+  setContextMenuInterceptor,
   showContextMenu as showWebContextMenu,
 } from '@lobehub/ui';
 import debug from 'debug';
@@ -42,13 +43,14 @@ const runNativePopup = (
     });
 };
 
-export const showContextMenu = (
+const routeShow = (
   items: NativeContextMenuItem[],
-  options?: ShowContextMenuOptions,
-): void => {
+  options: ShowContextMenuOptions | undefined,
+  showWeb: () => void,
+) => {
   if (!isDarwinDesktop() || !canGoNative(items, options)) {
     activeMenu = 'web';
-    showWebContextMenu(items, options);
+    showWeb();
     return;
   }
 
@@ -56,19 +58,37 @@ export const showContextMenu = (
 
   if (template.length === 0) {
     activeMenu = 'web';
-    showWebContextMenu(items, options);
+    showWeb();
     return;
   }
 
   runNativePopup(template, handlers);
 };
 
-export const closeContextMenu = (): void => {
+const routeClose = (closeWeb: () => void) => {
   if (activeMenu === 'native') {
     activeMenu = null;
     void electronSystemService.closePopupContextMenu();
     return;
   }
 
-  closeWebContextMenu();
+  closeWeb();
+};
+
+export const showContextMenu = (
+  items: NativeContextMenuItem[],
+  options?: ShowContextMenuOptions,
+): void => {
+  routeShow(items, options, () => showWebContextMenu(items, options));
+};
+
+export const closeContextMenu = (): void => {
+  routeClose(closeWebContextMenu);
+};
+
+export const registerNativeContextMenuInterceptor = (): void => {
+  setContextMenuInterceptor({
+    close: routeClose,
+    show: routeShow,
+  });
 };

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.tsx
@@ -439,6 +439,7 @@ const AgentDocumentsGroup = memo<AgentDocumentsGroupProps>(
           key: 'view',
           label: t('workingPanel.skills.actions.view'),
           onClick: openAgentSkill,
+          sfSymbol: 'eye',
         },
         {
           disabled: !rowId,
@@ -466,6 +467,7 @@ const AgentDocumentsGroup = memo<AgentDocumentsGroupProps>(
               },
             });
           },
+          sfSymbol: 'pencil',
         },
         {
           danger: true,
@@ -494,6 +496,7 @@ const AgentDocumentsGroup = memo<AgentDocumentsGroupProps>(
               title: t('workingPanel.skills.delete.title'),
             });
           },
+          sfSymbol: 'trash',
         },
       ];
     };

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/UserLevelSkills.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/UserLevelSkills.tsx
@@ -80,6 +80,7 @@ const UserLevelSkills = memo<UserLevelSkillsProps>(({ hideHeader }) => {
         key: 'view',
         label: t('workingPanel.skills.actions.view'),
         onClick: () => setDetailSkillId(skill.id),
+        sfSymbol: 'eye',
       },
     ];
 
@@ -106,6 +107,7 @@ const UserLevelSkills = memo<UserLevelSkillsProps>(({ hideHeader }) => {
             },
           });
         },
+        sfSymbol: 'pencil',
       });
     }
 
@@ -134,6 +136,7 @@ const UserLevelSkills = memo<UserLevelSkillsProps>(({ hideHeader }) => {
           title: t('workingPanel.skills.delete.title'),
         });
       },
+      sfSymbol: 'trash',
     });
 
     return actions;

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
@@ -1,6 +1,7 @@
+import type { SFSymbol } from '@lobechat/electron-client-ipc';
 import { nanoid } from '@lobechat/utils';
 import { ActionIcon, Flexbox, Icon, type IconProps, Skeleton } from '@lobehub/ui';
-import { type ContextMenuItem, type DropdownItem, DropdownMenu } from '@lobehub/ui/base-ui';
+import { type DropdownItem, DropdownMenu } from '@lobehub/ui/base-ui';
 import { SkillsIcon } from '@lobehub/ui/icons';
 import { createStaticStyles } from 'antd-style';
 import {
@@ -48,6 +49,7 @@ import { useIsGatewayModeEnabled } from '@/helpers/gatewayMode';
 import { useEffectiveAgencyConfig } from '@/hooks/useEffectiveAgencyConfig';
 import { useEffectiveWorkingDirectory } from '@/hooks/useEffectiveWorkingDirectory';
 import { useLocalStorageState } from '@/hooks/useLocalStorageState';
+import type { NativeContextMenuItem } from '@/libs/contextMenu/types';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
@@ -495,7 +497,7 @@ const AgentWorkingSidebar = memo(() => {
     })
     .filter((tab): tab is SidebarTabDescriptor => Boolean(tab));
   const createTabContextMenuItems = useCallback(
-    (tab: string, index: number): ContextMenuItem[] => {
+    (tab: string, index: number): NativeContextMenuItem[] => {
       const pinned = pinnedTabsSet.has(tab);
       const leftTabs = openedTabs.slice(0, index);
       const rightTabs = openedTabs.slice(index + 1);
@@ -510,7 +512,8 @@ const AgentWorkingSidebar = memo(() => {
                 key: pinned ? 'unpin' : 'pin',
                 label: t(pinned ? 'workingPanel.tabs.unpin' : 'workingPanel.tabs.pin'),
                 onClick: () => (pinned ? unpinTab(tab) : pinTab(tab)),
-              } as ContextMenuItem,
+                sfSymbol: (pinned ? 'pin.slash' : 'pin') satisfies SFSymbol,
+              } as NativeContextMenuItem,
               { type: 'divider' as const },
             ]
           : []),
@@ -544,7 +547,7 @@ const AgentWorkingSidebar = memo(() => {
     },
     [closeTab, closeTabs, openedTabs, pinTab, pinnedTabsSet, t, unpinTab],
   );
-  const overviewContextMenuItems = useMemo<ContextMenuItem[]>(
+  const overviewContextMenuItems = useMemo<NativeContextMenuItem[]>(
     () => [
       {
         disabled: !openedTabs.some((tab) => !pinnedTabsSet.has(tab)),

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
@@ -85,6 +85,7 @@ export const useTopicItemDropdownMenu = ({
             markTopicCompleted(id);
           }
         },
+        sfSymbol: isCompleted ? 'tray.and.arrow.up' : 'archivebox',
       },
       {
         type: 'divider' as const,
@@ -97,6 +98,7 @@ export const useTopicItemDropdownMenu = ({
         onClick: () => {
           autoRenameTopicTitle(id);
         },
+        sfSymbol: 'wand.and.stars',
       },
       {
         disabled: !canEditTopic,
@@ -106,6 +108,7 @@ export const useTopicItemDropdownMenu = ({
         onClick: () => {
           toggleEditing(true);
         },
+        sfSymbol: 'pencil',
       },
       {
         type: 'divider' as const,
@@ -185,6 +188,7 @@ export const useTopicItemDropdownMenu = ({
             topicIds: [id],
           });
         },
+        sfSymbol: 'trash',
       },
     ].filter(Boolean) as MenuProps['items'];
   }, [

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx
@@ -32,6 +32,7 @@ export const useThreadItemDropdownMenu = ({
         onClick: () => {
           toggleEditing(true);
         },
+        sfSymbol: 'pencil',
       },
       {
         type: 'divider' as const,
@@ -54,6 +55,7 @@ export const useThreadItemDropdownMenu = ({
             title: t('delete', { ns: 'common' }),
           });
         },
+        sfSymbol: 'trash',
       },
     ].filter(Boolean) as MenuProps['items'];
   }, [id, canEditThread, removeThread, toggleEditing, t]);

--- a/src/routes/(main)/home/_layout/Body/Agent/List/AgentGroupItem/useDropdownMenu.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/AgentGroupItem/useDropdownMenu.tsx
@@ -69,6 +69,7 @@ export const useGroupDropdownMenu = ({
                 key: 'pin',
                 label: t(pinned ? 'pinOff' : 'pin'),
                 onClick: () => pinAgentGroup(id, !pinned),
+                sfSymbol: pinned ? 'pin.slash' : 'pin',
               },
               {
                 icon: <Icon icon={Pen} />,
@@ -88,6 +89,7 @@ export const useGroupDropdownMenu = ({
                     });
                   }
                 },
+                sfSymbol: 'pencil',
               },
               {
                 icon: <Icon icon={LucideCopy} />,
@@ -97,6 +99,7 @@ export const useGroupDropdownMenu = ({
                   domEvent.stopPropagation();
                   duplicateAgentGroup(id);
                 },
+                sfSymbol: 'doc.on.doc',
               },
             ]
           : []),
@@ -108,6 +111,7 @@ export const useGroupDropdownMenu = ({
             domEvent.stopPropagation();
             openAgentInNewWindow(id);
           },
+          sfSymbol: 'macwindow.badge.plus',
         },
         ...(canConfigure && transferMenuItems?.length
           ? [{ type: 'divider' as const }, ...transferMenuItems]
@@ -144,6 +148,7 @@ export const useGroupDropdownMenu = ({
                     title: t('delete', { ns: 'common' }),
                   });
                 },
+                sfSymbol: 'trash',
               },
             ]
           : []),

--- a/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/useDropdownMenu.test.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/useDropdownMenu.test.tsx
@@ -1,6 +1,8 @@
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { canGoNative } from '@/libs/contextMenu/canGoNative';
+
 import { useAgentDropdownMenu } from './useDropdownMenu';
 
 const mocks = vi.hoisted(() => ({
@@ -146,5 +148,24 @@ describe('useAgentDropdownMenu', () => {
     );
 
     expect(getMenuKeys(result.current())).toEqual(['openInNewWindow']);
+  });
+
+  it('stays native-eligible (string labels only, including the Move to Category submenu)', () => {
+    mocks.canEditResource = true;
+
+    const { result } = renderHook(() =>
+      useAgentDropdownMenu({
+        anchor: null,
+        group: undefined,
+        id: 'agent-1',
+        openCreateGroupModal: vi.fn(),
+        pinned: false,
+        title: 'Public Agent',
+        userId: 'member-1',
+        visibility: 'public',
+      }),
+    );
+
+    expect(canGoNative(result.current() ?? [])).toBe(true);
   });
 });

--- a/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/useDropdownMenu.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/useDropdownMenu.tsx
@@ -150,6 +150,7 @@ export const useAgentDropdownMenu = ({
                 key: 'pin',
                 label: t(pinned ? 'pinOff' : 'pin'),
                 onClick: () => pinAgent(id, !pinned),
+                sfSymbol: pinned ? 'pin.slash' : 'pin',
               },
             ]
           : []),
@@ -167,6 +168,7 @@ export const useAgentDropdownMenu = ({
                     openEditingPopover({ anchor, avatar, id, title, type: 'agent' });
                   }
                 },
+                sfSymbol: 'pencil',
               },
             ]
           : []),
@@ -180,6 +182,7 @@ export const useAgentDropdownMenu = ({
                   domEvent.stopPropagation();
                   duplicateAgent(id);
                 },
+                sfSymbol: 'doc.on.doc',
               },
             ]
           : []),
@@ -191,6 +194,7 @@ export const useAgentDropdownMenu = ({
             domEvent.stopPropagation();
             openAgentInNewWindow(id);
           },
+          sfSymbol: 'macwindow.badge.plus',
         },
         ...(canEdit
           ? [
@@ -202,27 +206,31 @@ export const useAgentDropdownMenu = ({
                     key: groupId,
                     label: name,
                     onClick: () => updateAgentGroup(id, groupId),
+                    sfSymbol: group === groupId ? 'checkmark' : undefined,
                   })),
                   {
                     icon: isDefault ? <Icon icon={Check} /> : <div />,
                     key: 'defaultList',
                     label: t('defaultList'),
                     onClick: () => updateAgentGroup(id, SessionDefaultGroup.Default),
+                    sfSymbol: isDefault ? 'checkmark' : undefined,
                   },
                   { type: 'divider' as const },
                   {
                     icon: <Icon icon={LucidePlus} />,
                     key: 'createGroup',
-                    label: <div>{t('sessionGroup.createGroup')}</div>,
+                    label: t('sessionGroup.createGroup'),
                     onClick: ({ domEvent }: any) => {
                       domEvent.stopPropagation();
                       openCreateGroupModal();
                     },
+                    sfSymbol: 'folder.badge.plus',
                   },
                 ],
                 icon: <Icon icon={FolderInputIcon} />,
                 key: 'moveGroup',
                 label: t('sessionGroup.moveGroup'),
+                sfSymbol: 'folder',
               },
             ]
           : []),
@@ -286,6 +294,7 @@ export const useAgentDropdownMenu = ({
                           }),
                         });
                       },
+                      sfSymbol: 'globe',
                     },
                   ]
                 : []),
@@ -317,6 +326,7 @@ export const useAgentDropdownMenu = ({
                           title: t('makePrivate.confirm.title', { ns: 'common' }),
                         });
                       },
+                      sfSymbol: 'eye.slash',
                     },
                   ]
                 : []),
@@ -352,6 +362,7 @@ export const useAgentDropdownMenu = ({
                           title: t('delete', { ns: 'common' }),
                         });
                       },
+                      sfSymbol: 'trash',
                     },
                   ]
                 : []),

--- a/src/routes/(main)/home/_layout/Body/Agent/List/Group/useDropdownMenu.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/Group/useDropdownMenu.tsx
@@ -1,3 +1,4 @@
+import type { SFSymbol } from '@lobechat/electron-client-ipc';
 import { type SidebarVisibility } from '@lobechat/types';
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
@@ -65,6 +66,7 @@ export const useGroupDropdownMenu = ({
           disabled: !canEdit,
           icon: <Icon icon={GlobeIcon} />,
           key: 'publishToWorkspace',
+          sfSymbol: 'globe' as SFSymbol,
           label: t('sessionGroup.publishToWorkspace', {
             defaultValue: 'Publish to Workspace',
             ns: 'chat',

--- a/src/routes/(main)/home/_layout/Body/index.tsx
+++ b/src/routes/(main)/home/_layout/Body/index.tsx
@@ -14,6 +14,7 @@ import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
 import { useActiveTabKey } from '@/hooks/useActiveTabKey';
 import type { NavItem as NavItemType } from '@/hooks/useNavLayout';
 import { useNavLayout } from '@/hooks/useNavLayout';
+import type { NativeContextMenuItem } from '@/libs/contextMenu/types';
 import Recents from '@/routes/(main)/home/features/Recents';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
@@ -96,21 +97,26 @@ const Body = memo(() => {
   );
 
   const getContextMenuItems = useCallback(
-    (key: string): MenuProps['items'] => [
-      {
-        icon: <Icon icon={EyeOffIcon} />,
-        key: 'hideSection',
-        label: t('navPanel.hideSection'),
-        onClick: () => hideSection(key),
-      },
-      { type: 'divider' as const },
-      {
-        icon: <Icon icon={SlidersHorizontalIcon} />,
-        key: 'customizeSidebar',
-        label: t('navPanel.customizeSidebar'),
-        onClick: () => openCustomizeSidebarModal(),
-      },
-    ],
+    (key: string): MenuProps['items'] => {
+      const items: NativeContextMenuItem[] = [
+        {
+          icon: <Icon icon={EyeOffIcon} />,
+          key: 'hideSection',
+          label: t('navPanel.hideSection'),
+          onClick: () => hideSection(key),
+          sfSymbol: 'eye.slash',
+        },
+        { type: 'divider' as const },
+        {
+          icon: <Icon icon={SlidersHorizontalIcon} />,
+          key: 'customizeSidebar',
+          label: t('navPanel.customizeSidebar'),
+          onClick: () => openCustomizeSidebarModal(),
+          sfSymbol: 'gearshape',
+        },
+      ];
+      return items as MenuProps['items'];
+    },
     [t, hideSection],
   );
 

--- a/src/routes/(main)/home/_layout/Header/components/InboxDrawer/NotificationItem.tsx
+++ b/src/routes/(main)/home/_layout/Header/components/InboxDrawer/NotificationItem.tsx
@@ -8,6 +8,7 @@ import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
+import type { NativeContextMenuItem } from '@/libs/contextMenu/types';
 
 import { formatNotificationRelativeTime } from './formatNotificationRelativeTime';
 import { createNotificationDetailModal } from './NotificationDetailModal';
@@ -102,17 +103,18 @@ const NotificationItem = memo<NotificationItemProps>(
 
     const handleArchive = useCallback(() => onArchive(id), [id, onArchive]);
 
+    const contextMenuItems: NativeContextMenuItem[] = [
+      {
+        icon: ArchiveIcon,
+        key: 'archive',
+        label: t('inbox.archive'),
+        onClick: handleArchive,
+        sfSymbol: 'archivebox',
+      },
+    ];
+
     return (
-      <ContextMenuTrigger
-        items={[
-          {
-            icon: ArchiveIcon,
-            key: 'archive',
-            label: t('inbox.archive'),
-            onClick: handleArchive,
-          },
-        ]}
-      >
+      <ContextMenuTrigger items={contextMenuItems}>
         <Block
           clickable
           aria-label={title}

--- a/src/routes/(main)/home/_layout/hooks/useCreateMenuItems.tsx
+++ b/src/routes/(main)/home/_layout/hooks/useCreateMenuItems.tsx
@@ -1,4 +1,5 @@
 import { isDesktop } from '@lobechat/const';
+import type { SFSymbol } from '@lobechat/electron-client-ipc';
 import { HETEROGENEOUS_AGENT_CLIENT_CONFIGS } from '@lobechat/heterogeneous-agents/client';
 import { Icon } from '@lobehub/ui';
 import { GroupBotSquareIcon } from '@lobehub/ui/icons';
@@ -32,6 +33,8 @@ import { useHomeStore } from '@/store/home';
 import { usePageStore } from '@/store/page';
 import { useUserStore } from '@/store/user';
 import { labPreferSelectors } from '@/store/user/selectors';
+
+type MenuItem = NonNullable<ItemType> & { sfSymbol?: SFSymbol };
 
 interface CreateAgentOptions {
   groupId?: string;
@@ -238,13 +241,14 @@ export const useCreateMenuItems = () => {
    * Create agent menu item
    */
   const createAgentMenuItem = useCallback(
-    (options?: CreateAgentOptions): ItemType => ({
+    (options?: CreateAgentOptions): MenuItem => ({
       icon: <Icon icon={BotIcon} />,
       disabled: !canCreate,
       // Key needs to vary by visibility so the public and private "New
       // Agent" entries can coexist (e.g. if a future menu lists both).
       key: options?.visibility === 'private' ? 'newPrivateAgent' : 'newAgent',
       label: t('newAgent'),
+      sfSymbol: 'plus.bubble',
       onClick: async (info) => {
         info.domEvent?.stopPropagation();
         if (!canCreate) return;
@@ -266,11 +270,12 @@ export const useCreateMenuItems = () => {
    * Add market agent menu item
    */
   const createMarketAgentMenuItem = useCallback(
-    (): ItemType => ({
+    (): MenuItem => ({
       icon: <Icon icon={Store} />,
       disabled: !canCreate,
       key: 'addAgentFromMarket',
       label: t('addAgentFromMarket'),
+      sfSymbol: 'bag',
       onClick: (info) => {
         info.domEvent?.stopPropagation();
         if (!canCreate) return;
@@ -313,12 +318,13 @@ export const useCreateMenuItems = () => {
    * Opens the 3-step creation modal
    */
   const createPlatformAgentMenuItem = useCallback(
-    (options?: CreateAgentOptions): ItemType => {
+    (options?: CreateAgentOptions): MenuItem | null => {
       if (!enablePlatformAgent) return null;
       return {
         icon: <Icon icon={MonitorSmartphone} />,
         key: 'newPlatformAgent',
         label: t('newPlatformAgent'),
+        sfSymbol: 'laptopcomputer.and.iphone',
         onClick: (info) => {
           info.domEvent?.stopPropagation();
           agentModal?.openCreatePlatformAgentModal(
@@ -337,11 +343,12 @@ export const useCreateMenuItems = () => {
    * Creates an empty group and navigates to its profile page
    */
   const createGroupChatMenuItem = useCallback(
-    (options?: CreateAgentOptions): ItemType => ({
+    (options?: CreateAgentOptions): MenuItem => ({
       icon: <Icon icon={GroupBotSquareIcon} />,
       disabled: !canCreate,
       key: options?.visibility === 'private' ? 'newPrivateGroupChat' : 'newGroupChat',
       label: t('newGroupChat'),
+      sfSymbol: 'person.2',
       onClick: async (info) => {
         info.domEvent?.stopPropagation();
         if (!canCreate) return;
@@ -363,11 +370,12 @@ export const useCreateMenuItems = () => {
    * Add session group menu item
    */
   const createSessionGroupMenuItem = useCallback(
-    (options?: { visibility?: 'private' | 'public' }): ItemType => ({
+    (options?: { visibility?: 'private' | 'public' }): MenuItem => ({
       icon: <Icon icon={FolderPlus} />,
       disabled: !canCreate,
       key: options?.visibility === 'private' ? 'addPrivateSessionGroup' : 'addSessionGroup',
       label: t('sessionGroup.createGroup'),
+      sfSymbol: 'folder.badge.plus',
       onClick: async (info) => {
         info.domEvent?.stopPropagation();
         if (!canCreate) return;
@@ -384,10 +392,11 @@ export const useCreateMenuItems = () => {
    * Config menu item
    */
   const configMenuItem = useCallback(
-    (onOpenConfig: () => void): ItemType => ({
+    (onOpenConfig: () => void): MenuItem => ({
       icon: <Icon icon={FolderCogIcon} />,
       key: 'config',
       label: t('sessionGroup.manageCategory'),
+      sfSymbol: 'folder.badge.gearshape',
       onClick: (info) => {
         info.domEvent?.stopPropagation();
         onOpenConfig();
@@ -420,11 +429,12 @@ export const useCreateMenuItems = () => {
    * Create page menu item
    */
   const createPageMenuItem = useCallback(
-    (): ItemType => ({
+    (): MenuItem => ({
       icon: <Icon icon={FileTextIcon} />,
       disabled: !canCreate,
       key: 'newPage',
       label: t('newPage'),
+      sfSymbol: 'doc.badge.plus',
       onClick: async (info) => {
         info.domEvent?.stopPropagation();
         if (!canCreate) return;

--- a/src/routes/(main)/home/_layout/hooks/useSessionGroupMenuItems.tsx
+++ b/src/routes/(main)/home/_layout/hooks/useSessionGroupMenuItems.tsx
@@ -1,3 +1,4 @@
+import type { SFSymbol } from '@lobechat/electron-client-ipc';
 import { Icon } from '@lobehub/ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
@@ -13,6 +14,8 @@ import { usePermission } from '@/hooks/usePermission';
 import { useAgentStore } from '@/store/agent';
 import { useAgentGroupStore } from '@/store/agentGroup';
 import { useHomeStore } from '@/store/home';
+
+type MenuItem = NonNullable<ItemType> & { sfSymbol?: SFSymbol };
 
 /**
  * Hook for generating menu items for session group containers
@@ -36,13 +39,14 @@ export const useSessionGroupMenuItems = () => {
    * Rename group menu item
    */
   const renameGroupMenuItem = useCallback(
-    (groupId: string, groupName: string, anchor: HTMLElement | null): ItemType => {
+    (groupId: string, groupName: string, anchor: HTMLElement | null): MenuItem => {
       const iconElement = <Icon icon={FolderPenIcon} />;
       return {
         disabled: !canEdit,
         icon: iconElement,
         key: 'rename',
         label: t('sessionGroup.rename'),
+        sfSymbol: 'pencil',
         onClick: (info: any) => {
           info.domEvent?.stopPropagation();
           if (!canEdit) return;
@@ -60,13 +64,14 @@ export const useSessionGroupMenuItems = () => {
    * Config group menu item
    */
   const configGroupMenuItem = useCallback(
-    (onOpenConfig: () => void): ItemType => {
+    (onOpenConfig: () => void): MenuItem => {
       const iconElement = <Icon icon={FolderCogIcon} />;
       return {
         disabled: !canEdit,
         icon: iconElement,
         key: 'config',
         label: t('sessionGroup.config'),
+        sfSymbol: 'folder.badge.gearshape',
         onClick: (info: any) => {
           info.domEvent?.stopPropagation();
           if (!canEdit) return;
@@ -82,7 +87,7 @@ export const useSessionGroupMenuItems = () => {
    * Delete group menu item with confirmation modal
    */
   const deleteGroupMenuItem = useCallback(
-    (groupId: string): ItemType => {
+    (groupId: string): MenuItem => {
       const trashIcon = <Icon icon={Trash} />;
       return {
         danger: true,
@@ -90,6 +95,7 @@ export const useSessionGroupMenuItems = () => {
         icon: trashIcon,
         key: 'delete',
         label: t('delete', { ns: 'common' }),
+        sfSymbol: 'trash',
         onClick: (info: any) => {
           info.domEvent?.stopPropagation();
           if (!canEdit) return;
@@ -114,13 +120,14 @@ export const useSessionGroupMenuItems = () => {
    * Create agent in group menu item
    */
   const createAgentInGroupMenuItem = useCallback(
-    (groupId: string, _isPinned?: boolean): ItemType => {
+    (groupId: string, _isPinned?: boolean): MenuItem => {
       const iconElement = <Icon icon={FolderPenIcon} />;
       return {
         disabled: !canCreate,
         icon: iconElement,
         key: 'createAgent',
         label: t('newAgent'),
+        sfSymbol: 'plus.bubble',
         onClick: async (info: any) => {
           info.domEvent?.stopPropagation();
           if (!canCreate) return;
@@ -159,13 +166,14 @@ export const useSessionGroupMenuItems = () => {
         onCancel: () => void;
         onConfirm: (selectedAgents: string[]) => Promise<void>;
       }) => void,
-    ): ItemType => {
+    ): MenuItem => {
       const iconElement = <Icon icon={FolderPenIcon} />;
       return {
         disabled: !canCreate,
         icon: iconElement,
         key: 'createGroupChat',
         label: t('newGroupChat'),
+        sfSymbol: 'person.2',
         onClick: async (info: any) => {
           info.domEvent?.stopPropagation();
           if (!canCreate) return;

--- a/src/routes/(main)/home/features/Recents/useDropdownMenu.tsx
+++ b/src/routes/(main)/home/features/Recents/useDropdownMenu.tsx
@@ -9,6 +9,7 @@ import { useDocumentTransferMenuItem } from '@/business/client/hooks/useDocument
 import { useTaskTransferMenuItem } from '@/business/client/hooks/useTaskTransferMenuItem';
 import { confirmRemoveTopic } from '@/features/DeleteTopicConfirm';
 import { usePermission } from '@/hooks/usePermission';
+import type { NativeContextMenuItem } from '@/libs/contextMenu/types';
 import { type RecentItem } from '@/server/routers/lambda/recent';
 import { documentService } from '@/services/document';
 import { taskService } from '@/services/task';
@@ -103,13 +104,14 @@ export const useRecentItemDropdownMenu = (
   }, [item, t, refreshRecents]);
 
   const dropdownMenu = useCallback((): MenuProps['items'] => {
-    return [
+    const items: NativeContextMenuItem[] = [
       {
         disabled: !canEdit,
         icon: <Icon icon={PencilLineIcon} />,
         key: 'rename',
         label: t('rename'),
         onClick: () => toggleEditing(true),
+        sfSymbol: 'pencil',
       },
       ...(transferMenuItems ?? []),
       ...(transferMenuItems?.length ? [{ type: 'divider' as const }] : []),
@@ -120,8 +122,10 @@ export const useRecentItemDropdownMenu = (
         key: 'delete',
         label: t('delete'),
         onClick: handleDelete,
+        sfSymbol: 'trash',
       },
     ];
+    return items as MenuProps['items'];
   }, [canEdit, t, toggleEditing, handleDelete, transferMenuItems]);
 
   return { dropdownMenu, handleRename };

--- a/src/routes/(main)/settings/provider/ProviderMenu/useDropdownMenu.tsx
+++ b/src/routes/(main)/settings/provider/ProviderMenu/useDropdownMenu.tsx
@@ -4,6 +4,8 @@ import { LucideCheck } from 'lucide-react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import type { NativeContextMenuItem } from '@/libs/contextMenu/types';
+
 // Sort type enumeration
 export enum SortType {
   Alphabetical = 'alphabetical',
@@ -22,13 +24,14 @@ export const useProviderDropdownMenu = ({
 }: DropdownMenuProps): MenuProps['items'] => {
   const { t } = useTranslation('modelProvider');
 
-  return useMemo(
-    () => [
+  return useMemo(() => {
+    const items: NativeContextMenuItem[] = [
       {
         icon: sortType === SortType.Default ? <Icon icon={LucideCheck} /> : <div />,
         key: 'default',
         label: t('menu.list.disabledActions.sortDefault'),
         onClick: () => onSortChange(SortType.Default),
+        sfSymbol: sortType === SortType.Default ? 'checkmark' : undefined,
       },
       {
         type: 'divider' as const,
@@ -38,14 +41,16 @@ export const useProviderDropdownMenu = ({
         key: 'alphabetical',
         label: t('menu.list.disabledActions.sortAlphabetical'),
         onClick: () => onSortChange(SortType.Alphabetical),
+        sfSymbol: sortType === SortType.Alphabetical ? 'checkmark' : undefined,
       },
       {
         icon: sortType === SortType.AlphabeticalDesc ? <Icon icon={LucideCheck} /> : <div />,
         key: 'alphabeticalDesc',
         label: t('menu.list.disabledActions.sortAlphabeticalDesc'),
         onClick: () => onSortChange(SortType.AlphabeticalDesc),
+        sfSymbol: sortType === SortType.AlphabeticalDesc ? 'checkmark' : undefined,
       },
-    ],
-    [sortType, onSortChange, t],
-  );
+    ];
+    return items as MenuProps['items'];
+  }, [sortType, onSortChange, t]);
 };


### PR DESCRIPTION
Stacked on #17648 — merge that first (GitHub will auto-retarget this PR to `canary` when the base merges).

`@lobehub/ui@5.24.0` shipped a global context-menu interceptor (lobehub/lobe-ui#586, our upstream PR). This PR registers our native routing through it, which extends native macOS menus to every **declarative** `ContextMenuTrigger` surface (tab bar, nav items, file tree, …) — the population the imperative migration in #17648 structurally could not reach — and makes the native override impossible to bypass for future call sites, whichever API they use.

- Bump `@lobehub/ui` to `^5.24.0` (interceptor API floor).
- `src/libs/contextMenu`: extract the existing routing into shared `routeShow` / `routeClose`, add `registerNativeContextMenuInterceptor()` — the interceptor and the exported imperative wrappers are now the same code path; probe/template/IPC unchanged.
- Register once at SPA bootstrap (`SPAGlobalProvider`, module scope — before any render).
- TabBar: hoist the tab context-menu builder into `tabContextMenu.ts` (no behavior change) and lock its ownership with a snapshot test — plain string labels, so tab menus go native on macOS desktop; `AgentTasks` keeps probing web (extra badges) exactly as before.

Behavior notes:
- A declarative menu that fails the probe falls back to the library's own web menu via the interceptor's `fallback` closure — recursion-free by construction.
- The lib's exported `showContextMenu` web-fallback path now re-enters the interceptor once through the library (one redundant pure-function probe, terminates via `fallback`); imperative call-site imports from `@/libs/contextMenu` are kept — they remain correct either way.

#### Test

- 19 tests green across the touched files (3 new interceptor routing tests incl. fallback + deferred close; 2 new TabBar ownership tests with template snapshot, double-run stable); full type-check clean.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed