### PR TITLE
🐛 fix(acceptance): align task checklist grouping

### DIFF
--- a/.agents/acceptance/common-mistakes.md
+++ b/.agents/acceptance/common-mistakes.md
@@ -263,3 +263,10 @@ full incident narratives and old Case numbers for earlier cross-references.
 **What it breaks**: evidence appears to show an unexplained 6→7 mutation and two different goals, and a legitimate seventh cross-round check can be incorrectly hidden.
 
 **Correct approach**: capture definition and result states from the same Task, keep the full Acceptance check union visible, and keep the Task verify requirement synchronized with the aggregate goal.
+
+# Floating composer overlays must reserve space in every content path
+
+- Wrong approach: reserve the measured composer overlay height only in the virtualized message list.
+- Why it fails: an empty conversation renders the welcome surface instead, so alerts and trays can overlap its content.
+- What it breaks: combined Alert + tray states visually collide with welcome copy even though the overlay items do not overlap each other.
+- Correct approach: apply the same measured overlay reservation to both message and welcome paths, and capture acceptance evidence with the real combined state visible.

--- a/.agents/skills/agent-testing/SKILL.md
+++ b/.agents/skills/agent-testing/SKILL.md
@@ -466,6 +466,35 @@ older and fails only at this final step (`unknown option '--subject'`). Run
 `lh --version` first; when it is older than the marker version, publish through
 `npx @lobehub/cli@latest` instead of the PATH binary.
 
+#### Operation ID is optional for agent-testing (mandatory)
+
+An external project normally has no LobeHub Agent Operation, and that is valid.
+Do not ask the user for an Operation ID, invent one, or pass `--operation` merely
+because the report is being published to LobeHub.
+
+- Prefer `lh acceptance run ingest "$DIR" ...`. It creates a standalone
+  verification run and does not require an Operation ID.
+- `--operation <id>` means “this verification session evaluates this existing
+  LobeHub Agent Run.” Use it only when the user explicitly targets a real
+  operation that exists in the current LobeHub workspace.
+- `LOBEHUB_OPERATION_ID`, when present, identifies the in-app run that authored
+  the report. The CLI records it as optional origin metadata; its absence in a
+  plain terminal or external repository is not an error.
+- If atomic commands are genuinely needed, first run
+  `lh acceptance run create --json`, retain its returned `verifyRunId`, and pass
+  that value as `--run <verifyRunId>` to result/report/submit commands. Never
+  substitute an Operation ID for a missing Verify Run ID.
+
+Interpret common errors before retrying:
+
+- `Provide --run or --operation` means an atomic command lacks its verification
+  run handle; supply the returned `verifyRunId` through `--run`.
+- `Agent operation ... not found` means an invalid, stale, foreign, or fabricated
+  `--operation` was supplied; remove it for standalone agent-testing.
+- `Agent verifier failed to start (no operation id returned)` is a server-side
+  verifier-agent startup failure, not a requirement for the external harness to
+  provide an Operation ID.
+
 `acceptance run ingest` reads `$DIR` and, in one call, creates a new immutable
 verification run, attaches it to the subject acceptance, and uploads everything:
 
@@ -487,10 +516,32 @@ verify run stays the internal immutable record behind the acceptance page.
 #### Every run belongs to a subject acceptance (mandatory)
 
 Every run MUST be chained onto a task, topic, or document **acceptance aggregate**,
-so every round lands on one auditable decision page. When the harness runs inside a
-LobeHub topic, `acceptance run ingest` automatically uses `LOBEHUB_TOPIC_ID` as
-`topic:<id>` — do not ask the user for it and do not omit the acceptance. Outside a
-LobeHub topic, an explicit subject is required and publishing without one fails:
+so every round lands on one auditable decision page.
+
+**Choose the subject by business continuity, not by which object is easiest to
+create:**
+
+1. Honor an explicit subject or an instruction to reuse a specific Acceptance.
+2. Otherwise, when the verification continues work discussed and implemented in
+   the current LobeHub conversation, use its `topic:<id>`. This is the default for
+   iterative fixes, review feedback, and follow-up UI polish in the same thread.
+3. Use an existing `task:<id>` when that Task already owns the deliverable, or
+   when the work is intentionally independent, durable, spans multiple topics, or
+   the user explicitly wants task-level tracking.
+4. Use `document:<id>` only when the document itself is the acceptance subject.
+5. Create a new Task only when no relevant current Topic, Task, or Document exists.
+
+**Acceptance lifecycle and subject selection are separate decisions.** If an
+Acceptance on the relevant Topic is terminal and new work needs a new Acceptance,
+keep the same Topic subject and create the new Acceptance there when the product
+lifecycle supports it. Never create a Task merely to avoid appending to a closed
+Acceptance.
+
+When the harness runs inside a relevant LobeHub topic, `acceptance run ingest`
+automatically uses `LOBEHUB_TOPIC_ID` as `topic:<id>` — do not ask the user for it.
+Pass `--subject` explicitly when an existing Task or Document owns the work.
+Outside a LobeHub topic, an explicit subject is required and publishing without
+one fails:
 
 ```bash
 # SUBJECT is task:$TASK_ID, topic:$TOPIC_ID, or document:$DOC_ID
@@ -514,9 +565,9 @@ immutable round. The user closes the loop on `/acceptance/<acceptanceId>`; the
 same state is available through
 `lh acceptance view|accept|reject <id | type:id>`.
 
-When no subject exists yet (first verification in a repo, no tracked task),
-create one with the CLI instead of asking the user for an id — a dedicated task
-is the natural acceptance subject for the run:
+When no relevant subject exists (no current Topic carrying the work and no
+existing Task or Document owns it), create a Task with the CLI instead of asking
+the user for an id:
 
 ```bash
 env -u LOBEHUB_SERVER -u LOBE_API_KEY -u LOBEHUB_CLI_API_KEY -u LOBEHUB_CLI_HOME \
@@ -571,8 +622,10 @@ Notes:
   `result`/`verdict` map onto
   `passed | failed | uncertain`.
 - Finer control is available through the atomic commands — `acceptance run create`,
-  `acceptance run result ingest`, `acceptance run evidence upload` (`--file` or `--content`),
-  `acceptance run report upsert`.
+  `acceptance run result ingest`, `acceptance run evidence upload` (`--file` or
+  `--content`), `acceptance run report upsert`. Carry the `verifyRunId` returned by
+  `create` into later commands as `--run`; external projects must not fall back to
+  `--operation`.
 - File evidence uploads through the platform's storage. Against a stub or
   unreachable bucket (common in local dev) the PUT fails; `acceptance run ingest` warns,
   **skips that one artifact**, and still finishes — so the published session is

--- a/.agents/skills/agent-testing/references/report.md
+++ b/.agents/skills/agent-testing/references/report.md
@@ -434,10 +434,27 @@ reads first: `pass`, `fail`, or `partial`.
 `subject` identifies the business subject whose **acceptance aggregate** owns this
 immutable run: either `"subject": "task:<id>"` (`task` | `topic` | `document`) or
 `{ "type": "task", "id": "task_…", "requirement": "one-sentence acceptance bar" }`.
-The `--subject` flag overrides this field. Inside a LobeHub conversation, both may
-be omitted because `acceptance run ingest` defaults to `topic:$LOBEHUB_TOPIC_ID`; outside a
-topic, an explicit subject is mandatory. Every ingest creates a new immutable run;
-never update a prior run after a fix, publish the re-verification as the next round.
+The `--subject` flag overrides this field.
+
+An Operation ID is not part of report identity and is not required for external
+agent-testing. `acceptance run ingest` creates a standalone Verify Run. Use
+`--operation` only to link the report to a real, existing LobeHub Agent Run under
+test. For atomic publication, carry the `verifyRunId` returned by
+`acceptance run create` and pass it through `--run`; never ask an external-project
+user to supply an Operation ID or fabricate one.
+
+Choose by continuity: use the current Topic for work discussed and iterated in
+that conversation; use a Task only when it already owns the deliverable or the
+work intentionally needs independent, durable, cross-topic tracking; use a
+Document only when the document itself is under acceptance. Create a Task only
+when no relevant subject exists. A terminal Acceptance may require a new
+Acceptance, but it does not by itself justify changing the subject from Topic to
+Task.
+
+Inside a relevant LobeHub conversation, both subject fields may be omitted because
+`acceptance run ingest` defaults to `topic:$LOBEHUB_TOPIC_ID`; outside a topic, an
+explicit subject is mandatory. Every ingest creates a new immutable run; never
+update a prior run after a fix, publish the re-verification as the next round.
 
 `interactionCost` is optional and run-level. For UI runs driven through
 `agent-browser`, create `interaction-trace.jsonl` with `scripts/agent-browser-klm.mjs`,

--- a/apps/cli/src/commands/acceptanceRun.ts
+++ b/apps/cli/src/commands/acceptanceRun.ts
@@ -598,6 +598,18 @@ async function ingestReportAction(reportDir: string, options: IngestReportOption
   const origin = originFromEnv();
   const newRunMetadata = metadataForReport(result, undefined, origin);
 
+  const acceptance = await client.acceptance.ensure.mutate({
+    requirement,
+    subjectId: subject.ref.subjectId,
+    subjectType: subject.ref.subjectType,
+  });
+  if (acceptance.status === 'accepted' || acceptance.status === 'closed') {
+    log.error(
+      `Acceptance is already ${acceptance.status}. Reopen it before publishing another round.`,
+    );
+    process.exit(1);
+  }
+
   // Every ingest is a new immutable verification snapshot. A repair or
   // re-verification is represented by another run on the same acceptance.
   const run = await client.verify.createRun.mutate({
@@ -615,11 +627,6 @@ async function ingestReportAction(reportDir: string, options: IngestReportOption
   // 1c. Chain the session onto its subject's acceptance as the next round
   //     BEFORE the report lands, so the report-time status rollup already
   //     sees the aggregate.
-  const acceptance = await client.acceptance.ensure.mutate({
-    requirement,
-    subjectId: subject.ref.subjectId,
-    subjectType: subject.ref.subjectType,
-  });
   const acceptanceId = acceptance.id;
   const attached = await client.acceptance.attachRun.mutate({ acceptanceId, verifyRunId: runId });
   // The chained round's index — `?r=<roundIndex>` on the acceptance URL

--- a/apps/server/src/services/verify/__tests__/acceptanceDecision.test.ts
+++ b/apps/server/src/services/verify/__tests__/acceptanceDecision.test.ts
@@ -4,7 +4,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AcceptanceService } from '../acceptanceService';
 
 const mocks = vi.hoisted(() => ({
+  attachToAcceptance: vi.fn(),
   findById: vi.fn(),
+  findRunById: vi.fn(),
   listByAcceptance: vi.fn(),
   setDecision: vi.fn(),
   taskResolve: vi.fn(),
@@ -19,6 +21,8 @@ vi.mock('@/database/models/acceptance', () => ({
 }));
 vi.mock('@/database/models/verifyRun', () => ({
   VerifyRunModel: vi.fn(() => ({
+    attachToAcceptance: mocks.attachToAcceptance,
+    findById: mocks.findRunById,
     listByAcceptance: mocks.listByAcceptance,
     setDecision: mocks.setDecision,
   })),
@@ -74,6 +78,26 @@ describe('AcceptanceService decision gating', () => {
     await expect(service().recomputeStatus('acc-1')).resolves.toBe('closed');
     expect(mocks.listByAcceptance).not.toHaveBeenCalled();
     expect(mocks.updateStatus).not.toHaveBeenCalled();
+  });
+
+  it.each(['accepted', 'closed'])(
+    'refuses to attach a new round after the acceptance is %s',
+    async (status) => {
+      mocks.findById.mockResolvedValue(acceptance(status));
+      mocks.findRunById.mockResolvedValue({ acceptanceId: null, id: 'run-2' });
+
+      await expect(service().attachRun('run-2', 'acc-1')).rejects.toThrow(`already been ${status}`);
+      expect(mocks.attachToAcceptance).not.toHaveBeenCalled();
+    },
+  );
+
+  it('keeps an already-attached run idempotent after acceptance', async () => {
+    mocks.findById.mockResolvedValue(acceptance('accepted'));
+    const existing = { acceptanceId: 'acc-1', id: 'run-1', roundIndex: 1 };
+    mocks.findRunById.mockResolvedValue(existing);
+
+    await expect(service().attachRun('run-1', 'acc-1')).resolves.toBe(existing);
+    expect(mocks.attachToAcceptance).not.toHaveBeenCalled();
   });
 
   it.each(['delivered', 'errored'])('accepts a settled (%s) delivery', async (status) => {

--- a/apps/server/src/services/verify/acceptanceService.ts
+++ b/apps/server/src/services/verify/acceptanceService.ts
@@ -480,6 +480,11 @@ export class AcceptanceService {
     if (existing.acceptanceId) {
       throw new Error('This verify run already belongs to another acceptance');
     }
+    if (acceptance.status === 'accepted' || acceptance.status === 'closed') {
+      throw new Error(
+        `This acceptance has already been ${acceptance.status} — reopen it before attaching another round`,
+      );
+    }
 
     // Rounds inherit the aggregate's visibility so a private acceptance's new
     // round never leaks through its own report URL.

--- a/src/features/AgentTasks/AgentTaskDetail/TaskAcceptance.test.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskAcceptance.test.tsx
@@ -95,6 +95,7 @@ vi.mock('@/features/Verify', () => ({
       key: `category:${category}`,
       label: category,
     })),
+  shouldGroupChecks: (checkCount: number) => checkCount > 10,
   useAcceptanceBundle: () => ({
     data: mocks.bundle,
     error: undefined,
@@ -185,7 +186,7 @@ describe('TaskAcceptance', () => {
     expect(onOpen).toHaveBeenCalledWith({ id: 'criterion-1', title: 'Word count' });
   });
 
-  it('renders grouped checks and opens the selected check in the Acceptance portal', () => {
+  it('keeps a small checklist flat and opens the selected check in the Acceptance portal', () => {
     mocks.acceptanceSubject = { id: 'acceptance-1' };
     mocks.bundle = {
       acceptance: { id: 'acceptance-1', requirement: 'Everything is verifiable.' },
@@ -199,11 +200,33 @@ describe('TaskAcceptance', () => {
     render(<TaskAcceptance />);
 
     expect(screen.queryByTestId('task-acceptance-criteria')).not.toBeInTheDocument();
-    expect(screen.getByText('Setup')).toBeInTheDocument();
-    expect(screen.getByText('Result')).toBeInTheDocument();
+    expect(screen.queryByText('Setup')).not.toBeInTheDocument();
+    expect(screen.queryByText('Result')).not.toBeInTheDocument();
+    expect(screen.queryByText('taskDetail.acceptance.collapseAll')).not.toBeInTheDocument();
     fireEvent.click(screen.getByText('Create task'));
     expect(mocks.toggleTaskAgentPanel).toHaveBeenCalledWith(true);
     expect(mocks.openAcceptanceCheck).toHaveBeenCalledWith('acceptance-1', 'c1');
+  });
+
+  it('groups a checklist with more than 10 checks', () => {
+    mocks.acceptanceSubject = { id: 'acceptance-1' };
+    mocks.bundle = {
+      acceptance: { id: 'acceptance-1', requirement: 'Everything is verifiable.' },
+      checks: Array.from({ length: 11 }, (_, index) => ({
+        category: index < 6 ? 'Setup' : 'Result',
+        id: `c${index + 1}`,
+        seq: index + 1,
+        title: `Check ${index + 1}`,
+      })),
+      isOwner: true,
+    };
+
+    render(<TaskAcceptance />);
+
+    expect(screen.getByText('Setup')).toBeInTheDocument();
+    expect(screen.getByText('Result')).toBeInTheDocument();
+    expect(screen.getByText('taskDetail.acceptance.collapseAll')).toBeInTheDocument();
+    expect(screen.getByText('Check 11')).toBeInTheDocument();
   });
 
   it('keeps the Acceptance cross-round union visible in Task detail', () => {

--- a/src/features/AgentTasks/AgentTaskDetail/TaskAcceptance.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskAcceptance.tsx
@@ -12,6 +12,7 @@ import {
   type AcceptanceCheck,
   checkHeadMeta,
   groupChecks,
+  shouldGroupChecks,
   useAcceptanceBundle,
   useAcceptanceBySubject,
 } from '@/features/Verify';
@@ -151,13 +152,15 @@ const TaskAcceptance = memo(() => {
   // count may grow when later rounds introduce checks; that history is part of
   // the delivery record rather than a mismatch with the original configuration.
   const checks = useMemo(() => bundle?.checks ?? [], [bundle?.checks]);
+  const grouped = shouldGroupChecks(checks.length);
   const requirement = resolveTaskAcceptanceRequirement(
     verify?.requirement,
     bundle?.acceptance.requirement,
   );
   const groups = useMemo(
-    () => groupChecks(checks, t('acceptance.group.uncategorized', { ns: 'verify' })),
-    [checks, t],
+    () =>
+      grouped ? groupChecks(checks, t('acceptance.group.uncategorized', { ns: 'verify' })) : [],
+    [checks, grouped, t],
   );
   const groupKeys = groups.map((group) => group.key);
   const allGroupsCollapsed =
@@ -210,7 +213,7 @@ const TaskAcceptance = memo(() => {
                     {t('taskDetail.acceptance.checklist')}
                   </Text>
                   <Flexbox flex={1} />
-                  {groupKeys.length > 0 && (
+                  {grouped && groupKeys.length > 0 && (
                     <ActionIcon
                       icon={allGroupsCollapsed ? ChevronsUpDown : ChevronsDownUp}
                       size={'small'}
@@ -226,56 +229,69 @@ const TaskAcceptance = memo(() => {
                   )}
                 </Flexbox>
                 <Block className={styles.list} variant={'outlined'}>
-                  {groups.map((group) => {
-                    const collapsed = collapsedGroups.has(group.key);
+                  {grouped
+                    ? groups.map((group) => {
+                        const collapsed = collapsedGroups.has(group.key);
 
-                    return (
-                      <Flexbox className={styles.group} key={group.key}>
-                        <Flexbox
-                          horizontal
-                          align={'center'}
-                          className={styles.groupHeader}
-                          gap={8}
-                          onClick={() =>
-                            setCollapsedGroups((previous) => {
-                              const next = new Set(previous);
-                              if (next.has(group.key)) next.delete(group.key);
-                              else next.add(group.key);
-                              return next;
-                            })
-                          }
-                        >
-                          <Text fontSize={12}>{group.label}</Text>
-                          <Text fontSize={11} type={'secondary'}>
-                            {group.checks.length}
-                          </Text>
-                          <Flexbox flex={1} />
-                          <Icon
-                            color={cssVar.colorTextDescription}
-                            icon={ChevronRight}
-                            size={13}
-                            style={{
-                              transform: collapsed ? 'none' : 'rotate(90deg)',
-                              transition: 'transform 0.2s',
-                            }}
-                          />
-                        </Flexbox>
-                        {!collapsed &&
-                          group.checks.map((check) => (
-                            <CompactCheckRow
-                              check={check}
-                              key={check.id}
-                              onOpen={() => {
-                                if (currentPortalView !== PortalViewType.TaskDetail) {
-                                  showTaskAgentPanel(true);
-                                }
-                                openAcceptanceCheck(bundle.acceptance.id, check.id);
-                              }}
-                            />
-                          ))}
-                      </Flexbox>
-                    );
-                  })}
+                        return (
+                          <Flexbox className={styles.group} key={group.key}>
+                            <Flexbox
+                              horizontal
+                              align={'center'}
+                              className={styles.groupHeader}
+                              gap={8}
+                              onClick={() =>
+                                setCollapsedGroups((previous) => {
+                                  const next = new Set(previous);
+                                  if (next.has(group.key)) next.delete(group.key);
+                                  else next.add(group.key);
+                                  return next;
+                                })
+                              }
+                            >
+                              <Text fontSize={12}>{group.label}</Text>
+                              <Text fontSize={11} type={'secondary'}>
+                                {group.checks.length}
+                              </Text>
+                              <Flexbox flex={1} />
+                              <Icon
+                                color={cssVar.colorTextDescription}
+                                icon={ChevronRight}
+                                size={13}
+                                style={{
+                                  transform: collapsed ? 'none' : 'rotate(90deg)',
+                                  transition: 'transform 0.2s',
+                                }}
+                              />
+                            </Flexbox>
+                            {!collapsed &&
+                              group.checks.map((check) => (
+                                <CompactCheckRow
+                                  check={check}
+                                  key={check.id}
+                                  onOpen={() => {
+                                    if (currentPortalView !== PortalViewType.TaskDetail) {
+                                      showTaskAgentPanel(true);
+                                    }
+                                    openAcceptanceCheck(bundle.acceptance.id, check.id);
+                                  }}
+                                />
+                              ))}
+                          </Flexbox>
+                        );
+                      })
+                    : checks.map((check) => (
+                        <CompactCheckRow
+                          check={check}
+                          key={check.id}
+                          onOpen={() => {
+                            if (currentPortalView !== PortalViewType.TaskDetail) {
+                              showTaskAgentPanel(true);
+                            }
+                            openAcceptanceCheck(bundle.acceptance.id, check.id);
+                          }}
+                        />
+                      ))}
                 </Block>
               </Flexbox>
             </>

--- a/src/features/Conversation/ChatInput/InputCompletionErrorAlert.tsx
+++ b/src/features/Conversation/ChatInput/InputCompletionErrorAlert.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { Alert, Flexbox } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+import { useBusinessInputCompletionErrorAlert } from '@/business/client/hooks/useBusinessInputCompletionErrorAlert';
+import { selectors, useChatInputStore } from '@/features/ChatInput/store';
+import type { InputCompletionError } from '@/features/ChatInput/store/initialState';
+
+export const InputCompletionErrorAlertContent = memo<{
+  inputCompletionError: InputCompletionError;
+}>(({ inputCompletionError }) => {
+  const { t } = useTranslation('chat');
+  const clearInputCompletionError = useChatInputStore((state) => state.clearInputCompletionError);
+  const dismissInputCompletionError = useChatInputStore(
+    (state) => state.dismissInputCompletionError,
+  );
+  const businessAlert = useBusinessInputCompletionErrorAlert({
+    error: inputCompletionError,
+    onRetry: clearInputCompletionError,
+  });
+
+  const action = businessAlert.action ?? (
+    <Flexbox horizontal align={'center'} gap={8}>
+      <Button size={'small'} type={'primary'} onClick={clearInputCompletionError}>
+        {t('input.inputCompletionError.retry')}
+      </Button>
+      <Link to={'/settings/agent'}>
+        <Button size={'small'}>{t('input.inputCompletionError.settings')}</Button>
+      </Link>
+    </Flexbox>
+  );
+
+  return (
+    <>
+      <Flexbox paddingBlock={'0 6px'}>
+        <Alert
+          closable
+          showIcon
+          action={action}
+          title={businessAlert.description ?? t('input.inputCompletionError.desc')}
+          type={'warning'}
+          onClose={dismissInputCompletionError}
+        />
+      </Flexbox>
+      {businessAlert.extra}
+    </>
+  );
+});
+
+InputCompletionErrorAlertContent.displayName = 'InputCompletionErrorAlertContent';
+
+const InputCompletionErrorAlert = memo(() => {
+  const inputCompletionError = useChatInputStore(selectors.inputCompletionErrorVisible);
+
+  if (!inputCompletionError) return null;
+
+  return <InputCompletionErrorAlertContent inputCompletionError={inputCompletionError} />;
+});
+
+InputCompletionErrorAlert.displayName = 'InputCompletionErrorAlert';
+
+export default InputCompletionErrorAlert;

--- a/src/features/Conversation/ChatInput/InputCompletionErrorAlert.tsx
+++ b/src/features/Conversation/ChatInput/InputCompletionErrorAlert.tsx
@@ -41,7 +41,7 @@ export const InputCompletionErrorAlertContent = memo<{
           closable
           showIcon
           action={action}
-          title={businessAlert.description ?? t('input.inputCompletionError.desc')}
+          title={businessAlert.description ?? t('input.inputCompletionError.title')}
           type={'warning'}
           onClose={dismissInputCompletionError}
         />

--- a/src/features/Conversation/ChatInput/index.tsx
+++ b/src/features/Conversation/ChatInput/index.tsx
@@ -3,22 +3,17 @@
 import { type SlashOptions } from '@lobehub/editor';
 import { type ChatInputActionsProps } from '@lobehub/editor/react';
 import { Alert, Flexbox, type MenuProps } from '@lobehub/ui';
-import { Button } from '@lobehub/ui/base-ui';
 import { type ReactNode } from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router';
 
 import {
   getBusinessChatInputSendAreaPrefix,
   useBusinessChatInputAlerts,
 } from '@/business/client/hooks/useBusinessChatInputSendAreaPrefix';
-import { useBusinessInputCompletionErrorAlert } from '@/business/client/hooks/useBusinessInputCompletionErrorAlert';
 import type { ActionKeys, ChatInputFeature } from '@/features/ChatInput';
 import { ChatInputProvider, DesktopChatInput } from '@/features/ChatInput';
-import { selectors as chatInputSelectors, useChatInputStore } from '@/features/ChatInput/store';
 import {
-  type InputCompletionError,
   type SendButtonHandler,
   type SendButtonProps,
 } from '@/features/ChatInput/store/initialState';
@@ -40,6 +35,7 @@ import {
   useConversationStoreApi,
 } from '../store';
 import TodoProgress from '../TodoProgress';
+import InputCompletionErrorAlert from './InputCompletionErrorAlert';
 import OpStatusTray from './OpStatusTray';
 import QueueTray from './QueueTray';
 import {
@@ -53,55 +49,6 @@ import GoalTray from './VerifyTray/GoalTray';
 
 /** Max recent messages to feed into auto-complete context (≈10 conversation turns) */
 const MAX_CONTEXT_MESSAGES = 25;
-
-const InputCompletionErrorAlertContent = memo<{
-  inputCompletionError: InputCompletionError;
-}>(({ inputCompletionError }) => {
-  const { t } = useTranslation('chat');
-  const clearInputCompletionError = useChatInputStore((s) => s.clearInputCompletionError);
-  const businessAlert = useBusinessInputCompletionErrorAlert({
-    error: inputCompletionError,
-    onRetry: clearInputCompletionError,
-  });
-
-  const action = businessAlert.action ?? (
-    <Flexbox horizontal align={'center'} gap={8} wrap={'wrap'}>
-      <Button size={'small'} type={'primary'} onClick={clearInputCompletionError}>
-        {t('input.inputCompletionError.retry')}
-      </Button>
-      <Link to={'/settings/agent'}>
-        <Button size={'small'}>{t('input.inputCompletionError.settings')}</Button>
-      </Link>
-    </Flexbox>
-  );
-
-  return (
-    <>
-      <Flexbox paddingBlock={'0 6px'} paddingInline={12}>
-        <Alert
-          showIcon
-          action={action}
-          description={businessAlert.description ?? t('input.inputCompletionError.desc')}
-          title={t('input.inputCompletionError.title')}
-          type={'warning'}
-        />
-      </Flexbox>
-      {businessAlert.extra}
-    </>
-  );
-});
-
-InputCompletionErrorAlertContent.displayName = 'InputCompletionErrorAlertContent';
-
-const InputCompletionErrorAlert = memo(() => {
-  const inputCompletionError = useChatInputStore(chatInputSelectors.inputCompletionErrorVisible);
-
-  if (!inputCompletionError) return null;
-
-  return <InputCompletionErrorAlertContent inputCompletionError={inputCompletionError} />;
-});
-
-InputCompletionErrorAlert.displayName = 'InputCompletionErrorAlert';
 
 export interface ChatInputProps {
   /**
@@ -443,7 +390,6 @@ const ChatInput = memo<ChatInputProps>(
               />
             </Flexbox>
           )}
-          <InputCompletionErrorAlert />
           {businessAlerts}
           <Flexbox
             paddingInline={12}
@@ -456,6 +402,7 @@ const ChatInput = memo<ChatInputProps>(
               zIndex: 10,
             }}
           >
+            <InputCompletionErrorAlert />
             {!disableQueue && hasQueuedMessages && <QueueTray />}
             <TodoProgress topAttached={!disableQueue && hasQueuedMessages} />
             <OpStatusTray topAttached={(!disableQueue && hasQueuedMessages) || hasTodos} />
@@ -463,19 +410,17 @@ const ChatInput = memo<ChatInputProps>(
               topAttached={(!disableQueue && hasQueuedMessages) || hasTodos || hasOpStatus}
             />
           </Flexbox>
+          {/* Append the armed-goal chip to every composer's action bar. While armed,
+              the next message becomes the goal and the placeholder explains that state. */}
           <DesktopChatInput
             actionBarStyle={actionBarStyle}
             borderRadius={12}
             compact={compact}
             controlBarSlot={controlBarSlot}
-            // Append the armed-goal chip to every composer's action bar; it
-            // self-hides unless the goal is armed pre-topic (see GoalArmedChip).
             hidden={hasPendingInterventions}
             isConfigLoading={isConfigLoading}
-            placeholderVariant={placeholderVariant}
             leftContent={leftContent}
-            // While armed, prompt the user to describe the goal (the next message
-            // becomes it) instead of the default composer placeholder.
+            placeholderVariant={placeholderVariant}
             sendAreaPrefix={businessSendAreaPrefix}
             showControlBar={showControlBar}
             extraActionItems={[

--- a/src/features/Conversation/ChatList/components/RefreshError.tsx
+++ b/src/features/Conversation/ChatList/components/RefreshError.tsx
@@ -13,7 +13,7 @@ const styles = createStaticStyles(({ css }) => ({
 
     width: 100%;
     min-height: 40px;
-    padding-block: 4px;
+    padding-block: 4px 10px;
     padding-inline: 12px;
     border-block-start: 1px solid ${cssVar.colorBorderSecondary};
 

--- a/src/features/Conversation/ChatList/index.tsx
+++ b/src/features/Conversation/ChatList/index.tsx
@@ -20,7 +20,7 @@ import SkeletonList from '../components/SkeletonList';
 import MessageItem from '../Messages';
 import type { WorkflowExpandLevelDefault } from '../Messages/AssistantGroup/components/WorkflowCollapse';
 import { MessageActionProvider } from '../Messages/Contexts/MessageActionProvider';
-import { dataSelectors, useConversationStore } from '../store';
+import { dataSelectors, inputSelectors, useConversationStore } from '../store';
 import AgentSignalReceiptList from './components/AgentSignalReceiptList';
 import { RefreshError } from './components/RefreshError';
 import VirtualizedList from './components/VirtualizedList';
@@ -107,6 +107,7 @@ const ChatList = memo<ChatListProps>(
     });
     const displayMessages = useConversationStore(dataSelectors.displayMessages);
     const displayMessageIds = useConversationStore(dataSelectors.displayMessageIds);
+    const overlayHeight = useConversationStore(inputSelectors.chatInputOverlayHeight);
     const latestMessageId = displayMessageIds.at(-1);
 
     // Skip fetching notebook and memories for share pages (they require authentication)
@@ -198,7 +199,9 @@ const ChatList = memo<ChatListProps>(
       (showWelcome || displayMessageIds.length === 0) && welcome ? (
         <WideScreenContainer
           style={{
+            boxSizing: 'border-box',
             height: '100%',
+            paddingBottom: overlayHeight > 0 ? overlayHeight + 12 : undefined,
           }}
           wrapperStyle={{
             minHeight: '100%',

--- a/src/features/Conversation/ConversationProvider.test.tsx
+++ b/src/features/Conversation/ConversationProvider.test.tsx
@@ -74,8 +74,10 @@ vi.mock('@/features/Conversation/Messages/Contexts/MessageActionProvider', () =>
 }));
 
 vi.mock('@/features/WideScreenContainer', () => ({
-  default: ({ children }: { children?: ReactNode }) => (
-    <div data-testid={'welcome'}>{children}</div>
+  default: ({ children, style }: { children?: ReactNode; style?: React.CSSProperties }) => (
+    <div data-testid={'welcome'} style={style}>
+      {children}
+    </div>
   ),
 }));
 
@@ -170,6 +172,12 @@ const Probe = ({
   return null;
 };
 
+const OverlayHeightSetter = () => {
+  const setChatInputOverlayHeight = useConversationStore((s) => s.setChatInputOverlayHeight);
+
+  return <button onClick={() => setChatInputOverlayHeight(48)}>set overlay height</button>;
+};
+
 const renderChatList = (messages?: UIChatMessage[]) =>
   render(
     <ConversationProvider
@@ -238,6 +246,22 @@ describe('ConversationProvider', () => {
     expect(screen.getByText('WELCOME')).toBeInTheDocument();
     expect(screen.getByRole('status')).toBeInTheDocument();
     expect(chatListMocks.refreshError.retry).toHaveBeenCalledTimes(1);
+  });
+
+  it('reserves composer overlay space in the settled empty welcome', () => {
+    const { container } = render(
+      <ConversationProvider hasInitMessages context={oldContext} messages={[]}>
+        <ChatList welcome={<div>WELCOME</div>} />
+        <OverlayHeightSetter />
+      </ConversationProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'set overlay height' }));
+
+    expect(container.querySelector('[data-testid="welcome"]')).toHaveStyle({
+      boxSizing: 'border-box',
+      paddingBottom: '60px',
+    });
   });
 
   it('renders a settled message list through the virtualized list', () => {

--- a/src/features/Verify/Acceptance/index.tsx
+++ b/src/features/Verify/Acceptance/index.tsx
@@ -211,6 +211,8 @@ const styles = createStaticStyles(({ css }) => ({
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 3;
+
+    line-height: 1.6;
   `,
   verdictPill: css`
     display: inline-flex;

--- a/src/features/Verify/ReportViewer.tsx
+++ b/src/features/Verify/ReportViewer.tsx
@@ -113,6 +113,7 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   summary: css`
     max-width: 100%;
+    line-height: 1.6;
     color: ${cssVar.colorText};
   `,
   meta: css`

--- a/src/features/Verify/index.ts
+++ b/src/features/Verify/index.ts
@@ -1,6 +1,11 @@
 export { default as AcceptanceViewer } from './Acceptance';
 export type { AcceptanceCheck, CheckReviewInput } from './Acceptance/CheckList';
-export { checkHeadMeta, FocusedCheckDetails, groupChecks } from './Acceptance/CheckList';
+export {
+  checkHeadMeta,
+  FocusedCheckDetails,
+  groupChecks,
+  shouldGroupChecks,
+} from './Acceptance/CheckList';
 export { default as AcceptanceWorkspace } from './Acceptance/Workspace';
 export { default as AcceptanceEmptyDetail } from './Acceptance/Workspace/EmptyDetail';
 export { default as CheckerDock } from './CheckerDock';


### PR DESCRIPTION
## Summary

- keep task-detail Acceptance checklists flat when they contain 10 items or fewer
- group checklists only when they contain more than 10 items
- hide group collapse controls in flat-list mode
- reuse the shared Acceptance grouping threshold

## Verification

- `bun run check src/features/AgentTasks/AgentTaskDetail/TaskAcceptance.tsx src/features/AgentTasks/AgentTaskDetail/TaskAcceptance.test.tsx src/features/Verify/index.ts`
- 5 related tests passed