### PR TITLE
✨ feat: add realtime topic comment refresh

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/integration/topicComment.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/topicComment.integration.test.ts
@@ -122,6 +122,7 @@ describe('topicCommentRouter integration', () => {
     const member = topicCommentRouter.createCaller(context(memberId, workspaceId));
     const input = { clientId: 'realtime-1', content: 'created', topicId };
     const created = await member.create(input);
+    await flushAfterResponse();
     expect(publishResourceEvent).toHaveBeenCalledOnce();
     expect(publishResourceEvent).toHaveBeenLastCalledWith(
       { id: topicId, type: 'topic' },
@@ -129,11 +130,14 @@ describe('topicCommentRouter integration', () => {
     );
 
     await member.create(input);
+    await flushAfterResponse();
     expect(publishResourceEvent).toHaveBeenCalledOnce();
 
     await member.update({ content: 'updated', id: created.comment.id });
+    await flushAfterResponse();
     expect(publishResourceEvent).toHaveBeenCalledTimes(2);
     await member.delete({ id: created.comment.id });
+    await flushAfterResponse();
     expect(publishResourceEvent).toHaveBeenCalledTimes(3);
   });
 
@@ -549,9 +553,11 @@ describe('topicCommentRouter integration', () => {
       editorData: { root: { version: 1 } },
       topicId,
     });
+    await flushAfterResponse();
     expect(publishResourceEvent).toHaveBeenCalledTimes(1);
 
     const removed = await owner.delete({ id: created.comment.id });
+    await flushAfterResponse();
     expect(publishResourceEvent).toHaveBeenCalledTimes(2);
     expect(publishResourceEvent).toHaveBeenLastCalledWith(
       { id: topicId, type: 'topic' },
@@ -582,6 +588,7 @@ describe('topicCommentRouter integration', () => {
     });
 
     const restored = await owner.restore({ id: created.comment.id });
+    await flushAfterResponse();
     expect(publishResourceEvent).toHaveBeenCalledTimes(3);
     expect(publishResourceEvent).toHaveBeenLastCalledWith(
       { id: topicId, type: 'topic' },

--- a/apps/server/src/routers/lambda/__tests__/integration/topicComment.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/topicComment.integration.test.ts
@@ -553,6 +553,10 @@ describe('topicCommentRouter integration', () => {
 
     const removed = await owner.delete({ id: created.comment.id });
     expect(publishResourceEvent).toHaveBeenCalledTimes(2);
+    expect(publishResourceEvent).toHaveBeenLastCalledWith(
+      { id: topicId, type: 'topic' },
+      { actorId: '', type: 'topic.commentsChanged' },
+    );
 
     expect(removed).toMatchObject({
       comment: {
@@ -579,6 +583,10 @@ describe('topicCommentRouter integration', () => {
 
     const restored = await owner.restore({ id: created.comment.id });
     expect(publishResourceEvent).toHaveBeenCalledTimes(3);
+    expect(publishResourceEvent).toHaveBeenLastCalledWith(
+      { id: topicId, type: 'topic' },
+      { actorId: '', type: 'topic.commentsChanged' },
+    );
 
     expect(restored).toMatchObject({
       canRestore: false,

--- a/apps/server/src/routers/lambda/__tests__/integration/topicComment.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/topicComment.integration.test.ts
@@ -15,12 +15,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ResourcePermissionModel } from '@/database/models/resourcePermission';
 
+import { assertTopicCommentReadAccess } from '../../_helpers/topicCommentAccess';
 import { topicCommentRouter } from '../../topicComment';
 import { cleanupTestUser, createTestUser } from './setup';
 
 let testDB: LobeChatDatabase;
 const notifyTopicCommentActivity = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const notifyTopicCommentModeration = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const publishResourceEvent = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 vi.mock('@/database/core/db-adaptor', () => ({ getServerDB: vi.fn(() => testDB) }));
 vi.mock('@/business/server/topic-comment/notifyActivity', () => ({
   notifyTopicCommentActivity,
@@ -28,6 +30,7 @@ vi.mock('@/business/server/topic-comment/notifyActivity', () => ({
 vi.mock('@/business/server/topic-comment/notifyModeration', () => ({
   notifyTopicCommentModeration,
 }));
+vi.mock('@/server/services/resourceEvents', () => ({ publishResourceEvent }));
 // Post-response work is async (recipient re-authorization runs its own
 // queries), so tests must drain it before asserting on the delivery slots.
 const afterResponseTasks = vi.hoisted(() => [] as Promise<unknown>[]);
@@ -59,6 +62,8 @@ describe('topicCommentRouter integration', () => {
     notifyTopicCommentActivity.mockResolvedValue(undefined);
     notifyTopicCommentModeration.mockReset();
     notifyTopicCommentModeration.mockResolvedValue(undefined);
+    publishResourceEvent.mockReset();
+    publishResourceEvent.mockResolvedValue(undefined);
     db = await getTestDB();
     testDB = db;
     [ownerId, adminId, memberId, viewerId] = await Promise.all([
@@ -111,6 +116,68 @@ describe('topicCommentRouter integration', () => {
       code: 'FORBIDDEN',
     });
     expect((await owner.delete({ id: created.comment.id })).mode).toBe('moderated');
+  });
+
+  it('publishes invalidation only for committed create, update and delete changes', async () => {
+    const member = topicCommentRouter.createCaller(context(memberId, workspaceId));
+    const input = { clientId: 'realtime-1', content: 'created', topicId };
+    const created = await member.create(input);
+    expect(publishResourceEvent).toHaveBeenCalledOnce();
+    expect(publishResourceEvent).toHaveBeenLastCalledWith(
+      { id: topicId, type: 'topic' },
+      { actorId: memberId, type: 'topic.commentsChanged' },
+    );
+
+    await member.create(input);
+    expect(publishResourceEvent).toHaveBeenCalledOnce();
+
+    await member.update({ content: 'updated', id: created.comment.id });
+    expect(publishResourceEvent).toHaveBeenCalledTimes(2);
+    await member.delete({ id: created.comment.id });
+    expect(publishResourceEvent).toHaveBeenCalledTimes(3);
+  });
+
+  it('rejects realtime access to missing and cross-workspace topics', async () => {
+    await expect(
+      assertTopicCommentReadAccess({
+        db,
+        hideExistence: true,
+        topicId,
+        userId: memberId,
+        workspaceId,
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      assertTopicCommentReadAccess({
+        db,
+        hideExistence: true,
+        topicId: 'missing-topic',
+        userId: memberId,
+        workspaceId,
+      }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    const [foreignWorkspace] = await db
+      .insert(workspaces)
+      .values({ name: 'Foreign comments', primaryOwnerId: ownerId, slug: `foreign-${ownerId}` })
+      .returning();
+    try {
+      const [foreignTopic] = await db
+        .insert(topics)
+        .values({ title: 'Foreign topic', userId: ownerId, workspaceId: foreignWorkspace.id })
+        .returning();
+      await expect(
+        assertTopicCommentReadAccess({
+          db,
+          hideExistence: true,
+          topicId: foreignTopic.id,
+          userId: memberId,
+          workspaceId,
+        }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    } finally {
+      await db.delete(workspaces).where(eq(workspaces.id, foreignWorkspace.id));
+    }
   });
 
   it('enforces target access after conversation access changes', async () => {
@@ -482,8 +549,10 @@ describe('topicCommentRouter integration', () => {
       editorData: { root: { version: 1 } },
       topicId,
     });
+    expect(publishResourceEvent).toHaveBeenCalledTimes(1);
 
     const removed = await owner.delete({ id: created.comment.id });
+    expect(publishResourceEvent).toHaveBeenCalledTimes(2);
 
     expect(removed).toMatchObject({
       comment: {
@@ -509,6 +578,7 @@ describe('topicCommentRouter integration', () => {
     });
 
     const restored = await owner.restore({ id: created.comment.id });
+    expect(publishResourceEvent).toHaveBeenCalledTimes(3);
 
     expect(restored).toMatchObject({
       canRestore: false,

--- a/apps/server/src/routers/lambda/_helpers/topicCommentAccess.ts
+++ b/apps/server/src/routers/lambda/_helpers/topicCommentAccess.ts
@@ -1,0 +1,57 @@
+import { TRPCError } from '@trpc/server';
+import { and, eq } from 'drizzle-orm';
+
+import { topics } from '@/database/schemas';
+import type { LobeChatDatabase } from '@/database/type';
+import { getWorkspaceScopedPermissionMatches } from '@/server/services/workspacePermission';
+
+import { assertCanViewTopicTargets } from './conversationResourceGuard';
+
+export const assertTopicCommentReadAccess = async (params: {
+  db: LobeChatDatabase;
+  grantedPermissions?: readonly string[];
+  hideExistence?: boolean;
+  topicId: string;
+  userId: string;
+  workspaceId: string;
+}) => {
+  const permissions = await getWorkspaceScopedPermissionMatches({
+    action: 'TOPIC_COMMENT_READ',
+    db: params.db,
+    grantedPermissions: params.grantedPermissions,
+    userId: params.userId,
+    workspaceId: params.workspaceId,
+  });
+  if (!permissions.hasAllScope && !permissions.hasOwnerScope) {
+    throw new TRPCError({
+      code: params.hideExistence ? 'NOT_FOUND' : 'FORBIDDEN',
+      message: 'Topic comment resource not found',
+    });
+  }
+
+  const [topic] = await params.db
+    .select({ id: topics.id })
+    .from(topics)
+    .where(and(eq(topics.id, params.topicId), eq(topics.workspaceId, params.workspaceId)))
+    .limit(1);
+  if (!topic) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Topic comment resource not found' });
+  }
+
+  try {
+    await assertCanViewTopicTargets(
+      {
+        db: params.db,
+        grantedPermissions: params.grantedPermissions,
+        userId: params.userId,
+        workspaceId: params.workspaceId,
+      },
+      [params.topicId],
+    );
+  } catch (error) {
+    if (params.hideExistence && error instanceof TRPCError && error.code === 'FORBIDDEN') {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Topic comment resource not found' });
+    }
+    throw error;
+  }
+};

--- a/apps/server/src/routers/lambda/topicComment.ts
+++ b/apps/server/src/routers/lambda/topicComment.ts
@@ -340,10 +340,14 @@ const notifyActivityBestEffort = (
   });
 };
 
-const publishCommentsChanged = (ctx: { userId: string }, topicId: string) => {
+const publishCommentsChanged = (
+  ctx: { userId: string },
+  topicId: string,
+  options: { includeActor?: boolean } = {},
+) => {
   void publishResourceEvent(
     { id: topicId, type: 'topic' },
-    { actorId: ctx.userId, type: 'topic.commentsChanged' },
+    { actorId: options.includeActor === false ? '' : ctx.userId, type: 'topic.commentsChanged' },
   );
 };
 
@@ -515,7 +519,7 @@ export const topicCommentRouter = router({
             workspaceId: ctx.workspaceId,
           });
         }
-        publishCommentsChanged(ctx, result.comment.topicId);
+        publishCommentsChanged(ctx, result.comment.topicId, { includeActor: false });
         return {
           comment: (await enrich(ctx, [result.comment], permissions))[0],
           mode: 'moderated' as const,
@@ -648,7 +652,7 @@ export const topicCommentRouter = router({
         });
       }
 
-      publishCommentsChanged(ctx, restored.topicId);
+      publishCommentsChanged(ctx, restored.topicId, { includeActor: false });
 
       return (await enrich(ctx, [restored], permissions))[0];
     }),

--- a/apps/server/src/routers/lambda/topicComment.ts
+++ b/apps/server/src/routers/lambda/topicComment.ts
@@ -23,6 +23,7 @@ import type { TopicCommentItem } from '@/database/schemas/topicComment';
 import type { Transaction } from '@/database/type';
 import { router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
+import { publishResourceEvent } from '@/server/services/resourceEvents';
 import { getWorkspaceScopedPermissionMatches } from '@/server/services/workspacePermission';
 import { after } from '@/server/utils/scheduleAfterResponse';
 
@@ -339,6 +340,13 @@ const notifyActivityBestEffort = (
   });
 };
 
+const publishCommentsChanged = (ctx: { userId: string }, topicId: string) => {
+  void publishResourceEvent(
+    { id: topicId, type: 'topic' },
+    { actorId: ctx.userId, type: 'topic.commentsChanged' },
+  );
+};
+
 const extractMentionedUserIds = (editorData: unknown): string[] => {
   const root = toRecord(editorData)?.root;
   const pending: unknown[] = root === undefined ? [] : [root];
@@ -427,6 +435,7 @@ export const topicCommentRouter = router({
         });
 
         if (!result.isDuplicate) {
+          publishCommentsChanged(ctx, result.comment.topicId);
           const recipientsByUserId = new Map<string, TopicCommentActivityRecipient>();
           const conversationRecipients: TopicCommentActivityRecipient[] = input.parentCommentId
             ? result.parentAuthorUserId
@@ -506,6 +515,7 @@ export const topicCommentRouter = router({
             workspaceId: ctx.workspaceId,
           });
         }
+        publishCommentsChanged(ctx, result.comment.topicId);
         return {
           comment: (await enrich(ctx, [result.comment], permissions))[0],
           mode: 'moderated' as const,
@@ -516,6 +526,7 @@ export const topicCommentRouter = router({
         overrideAuthorScope: false,
       });
       if (!mode) throw new TRPCError({ code: 'NOT_FOUND', message: 'Topic comment not found' });
+      publishCommentsChanged(ctx, current.topicId);
       return { mode };
     }),
   get: topicCommentProcedure.input(z.object({ id: idSchema })).query(async ({ ctx, input }) => {
@@ -637,6 +648,8 @@ export const topicCommentRouter = router({
         });
       }
 
+      publishCommentsChanged(ctx, restored.topicId);
+
       return (await enrich(ctx, [restored], permissions))[0];
     }),
   summary: topicCommentProcedure
@@ -707,6 +720,8 @@ export const topicCommentRouter = router({
           workspaceId: ctx.workspaceId,
         });
       }
+
+      publishCommentsChanged(ctx, result.comment.topicId);
 
       return (await enrich(ctx, [result.comment], permissions))[0];
     }),

--- a/apps/server/src/routers/lambda/topicComment.ts
+++ b/apps/server/src/routers/lambda/topicComment.ts
@@ -345,9 +345,11 @@ const publishCommentsChanged = (
   topicId: string,
   options: { includeActor?: boolean } = {},
 ) => {
-  void publishResourceEvent(
-    { id: topicId, type: 'topic' },
-    { actorId: options.includeActor === false ? '' : ctx.userId, type: 'topic.commentsChanged' },
+  after(() =>
+    publishResourceEvent(
+      { id: topicId, type: 'topic' },
+      { actorId: options.includeActor === false ? '' : ctx.userId, type: 'topic.commentsChanged' },
+    ),
   );
 };
 

--- a/apps/server/src/services/resourceEvents/__tests__/index.test.ts
+++ b/apps/server/src/services/resourceEvents/__tests__/index.test.ts
@@ -5,6 +5,7 @@ import { publishResourceEvent, resourceChannelId } from '../index';
 describe('resourceEvents', () => {
   it('formats a stable channel id per resource', () => {
     expect(resourceChannelId({ id: 'doc-1', type: 'document' })).toBe('resource:document:doc-1');
+    expect(resourceChannelId({ id: 'topic-1', type: 'topic' })).toBe('resource:topic:topic-1');
   });
 
   it('publish is best-effort and never throws (no Redis → in-memory)', async () => {
@@ -12,6 +13,13 @@ describe('resourceEvents', () => {
       publishResourceEvent(
         { id: 'doc-1', type: 'document' },
         { actorId: 'u1', type: 'doc.updated' },
+      ),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      publishResourceEvent(
+        { id: 'topic-1', type: 'topic' },
+        { actorId: 'u1', type: 'topic.commentsChanged' },
       ),
     ).resolves.toBeUndefined();
 

--- a/apps/server/src/services/resourceEvents/types.ts
+++ b/apps/server/src/services/resourceEvents/types.ts
@@ -1,15 +1,15 @@
-/** Editable resource families that can broadcast realtime events. */
-export type ResourceType = 'agent' | 'chatGroup' | 'document' | 'task';
+/** Resource families that can broadcast realtime invalidation or collaboration events. */
+export type ResourceType = 'agent' | 'chatGroup' | 'document' | 'task' | 'topic';
 
 export interface ResourceRef {
   id: string;
   type: ResourceType;
 }
 
-export type ResourceEventType = 'doc.updated' | 'lock.changed';
+export type ResourceEventType = 'doc.updated' | 'lock.changed' | 'topic.commentsChanged';
 
 export interface ResourceEvent {
-  /** User id that triggered the event; lets subscribers ignore self-originated events. */
+  /** User id that triggered the event; allows subscriber-side attribution or filtering. */
   actorId: string;
   /** Event-specific payload (e.g. `{ holderId }` for `lock.changed`). */
   data?: Record<string, unknown>;

--- a/packages/database/src/models/__tests__/topicComment.test.ts
+++ b/packages/database/src/models/__tests__/topicComment.test.ts
@@ -1398,7 +1398,10 @@ describe('TopicCommentModel', () => {
       });
       expect(page2.items.map((reply) => reply.id)).toEqual(expectedOrder.slice(2));
       expect(page2.nextCursor).toBeNull();
-      expect(page2.total).toBe(2);
+      expect(page2).not.toHaveProperty('total');
+      expect(
+        (await authorModel.listReplies({ limit: 2, rootCommentId: root.comment.id })).total,
+      ).toBe(2);
 
       expect(await outsiderModel.listReplies({ rootCommentId: root.comment.id })).toEqual({
         items: [],

--- a/packages/database/src/models/__tests__/topicComment.test.ts
+++ b/packages/database/src/models/__tests__/topicComment.test.ts
@@ -1387,6 +1387,7 @@ describe('TopicCommentModel', () => {
       const page1 = await authorModel.listReplies({ limit: 2, rootCommentId: root.comment.id });
       expect(page1.items.map((reply) => reply.id)).toEqual(expectedOrder.slice(0, 2));
       expect(page1.nextCursor).not.toBeNull();
+      expect(page1.total).toBe(3);
 
       await authorModel.delete(expectedOrder[1], { overrideAuthorScope: true });
 
@@ -1397,11 +1398,42 @@ describe('TopicCommentModel', () => {
       });
       expect(page2.items.map((reply) => reply.id)).toEqual(expectedOrder.slice(2));
       expect(page2.nextCursor).toBeNull();
+      expect(page2.total).toBe(2);
 
       expect(await outsiderModel.listReplies({ rootCommentId: root.comment.id })).toEqual({
         items: [],
         nextCursor: null,
+        total: 0,
       });
+    });
+
+    it('should exclude moderated replies from the live total for privileged viewers', async () => {
+      const root = await authorModel.createWithMentions({
+        clientId: 'client-lr-moderated-root',
+        content: 'reply total root',
+        topicId: workspaceTopicId,
+      });
+      await authorModel.createWithMentions({
+        clientId: 'client-lr-live',
+        content: 'live reply',
+        parentCommentId: root.comment.id,
+        topicId: workspaceTopicId,
+      });
+      const moderated = await memberModel.createWithMentions({
+        clientId: 'client-lr-moderated',
+        content: 'moderated reply',
+        parentCommentId: root.comment.id,
+        topicId: workspaceTopicId,
+      });
+      await authorModel.moderateRemove(moderated.comment.id);
+
+      const page = await authorModel.listReplies(
+        { rootCommentId: root.comment.id },
+        { includeAllModerated: true },
+      );
+
+      expect(page.items).toHaveLength(2);
+      expect(page.total).toBe(1);
     });
   });
 

--- a/packages/database/src/models/topicComment.ts
+++ b/packages/database/src/models/topicComment.ts
@@ -188,7 +188,8 @@ export interface ListTopicCommentThreadsParams {
 export interface TopicCommentReplyPage {
   items: TopicCommentItem[];
   nextCursor: string | null;
-  total: number;
+  /** Canonical live-reply count; returned only on the first cursor page. */
+  total?: number;
 }
 
 export interface TopicCommentSummary {
@@ -887,24 +888,27 @@ export class TopicCommentModel {
       );
     }
 
-    const [rows, [{ total }]] = await Promise.all([
+    const [rows, total] = await Promise.all([
       this.db
         .select(topicCommentCursorSelection)
         .from(topicComments)
         .where(and(...conditions))
         .orderBy(asc(topicComments.createdAt), asc(topicComments.id))
         .limit(limit + 1),
-      this.db
-        .select({ total: count() })
-        .from(topicComments)
-        .where(
-          and(
-            eq(topicComments.parentCommentId, rootCommentId),
-            eq(topicComments.workspaceId, workspaceId),
-            isNull(topicComments.deletedAt),
-            isNull(topicComments.moderatedAt),
-          ),
-        ),
+      decodedCursor
+        ? Promise.resolve(undefined)
+        : this.db
+            .select({ total: count() })
+            .from(topicComments)
+            .where(
+              and(
+                eq(topicComments.parentCommentId, rootCommentId),
+                eq(topicComments.workspaceId, workspaceId),
+                isNull(topicComments.deletedAt),
+                isNull(topicComments.moderatedAt),
+              ),
+            )
+            .then(([row]) => row.total),
     ]);
     const hasMore = rows.length > limit;
     const pageRows = hasMore ? rows.slice(0, limit) : rows;
@@ -915,7 +919,7 @@ export class TopicCommentModel {
       nextCursor: hasMore
         ? encodeTopicCommentCursor(pageRows.at(-1)!.cursorCreatedAt, pageRows.at(-1)!.id)
         : null,
-      total,
+      ...(total === undefined ? {} : { total }),
     };
   }
 

--- a/packages/database/src/models/topicComment.ts
+++ b/packages/database/src/models/topicComment.ts
@@ -188,6 +188,7 @@ export interface ListTopicCommentThreadsParams {
 export interface TopicCommentReplyPage {
   items: TopicCommentItem[];
   nextCursor: string | null;
+  total: number;
 }
 
 export interface TopicCommentSummary {
@@ -886,12 +887,25 @@ export class TopicCommentModel {
       );
     }
 
-    const rows = await this.db
-      .select(topicCommentCursorSelection)
-      .from(topicComments)
-      .where(and(...conditions))
-      .orderBy(asc(topicComments.createdAt), asc(topicComments.id))
-      .limit(limit + 1);
+    const [rows, [{ total }]] = await Promise.all([
+      this.db
+        .select(topicCommentCursorSelection)
+        .from(topicComments)
+        .where(and(...conditions))
+        .orderBy(asc(topicComments.createdAt), asc(topicComments.id))
+        .limit(limit + 1),
+      this.db
+        .select({ total: count() })
+        .from(topicComments)
+        .where(
+          and(
+            eq(topicComments.parentCommentId, rootCommentId),
+            eq(topicComments.workspaceId, workspaceId),
+            isNull(topicComments.deletedAt),
+            isNull(topicComments.moderatedAt),
+          ),
+        ),
+    ]);
     const hasMore = rows.length > limit;
     const pageRows = hasMore ? rows.slice(0, limit) : rows;
     const items = pageRows.map(({ cursorCreatedAt: _cursorCreatedAt, ...item }) => item);
@@ -901,6 +915,7 @@ export class TopicCommentModel {
       nextCursor: hasMore
         ? encodeTopicCommentCursor(pageRows.at(-1)!.cursorCreatedAt, pageRows.at(-1)!.id)
         : null,
+      total,
     };
   }
 

--- a/packages/types/src/topicComment.ts
+++ b/packages/types/src/topicComment.ts
@@ -56,7 +56,8 @@ export interface TopicCommentThreadPage {
 export interface TopicCommentReplyPage {
   items: TopicCommentItem[];
   nextCursor: string | null;
-  total: number;
+  /** Canonical live-reply count; returned only on the first cursor page. */
+  total?: number;
 }
 export interface TopicCommentSummary {
   countByMessage: Record<string, number>;

--- a/packages/types/src/topicComment.ts
+++ b/packages/types/src/topicComment.ts
@@ -56,6 +56,7 @@ export interface TopicCommentThreadPage {
 export interface TopicCommentReplyPage {
   items: TopicCommentItem[];
   nextCursor: string | null;
+  total: number;
 }
 export interface TopicCommentSummary {
   countByMessage: Record<string, number>;

--- a/src/app/(backend)/webapi/topic-comment/events/route.test.ts
+++ b/src/app/(backend)/webapi/topic-comment/events/route.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GET } from './route';
+
+const mocks = vi.hoisted(() => ({
+  assertTopicCommentReadAccess: vi.fn(),
+  signal: undefined as AbortSignal | undefined,
+  subscribeResourceEvents: vi.fn(),
+  writeConnection: vi.fn(),
+  writeHeartbeat: vi.fn(),
+  writeStreamEvent: vi.fn(),
+}));
+
+vi.mock('@lobechat/utils/server', () => ({
+  createSSEHeaders: () => ({ 'Content-Type': 'text/event-stream' }),
+  createSSEWriter: () => ({
+    writeConnection: mocks.writeConnection,
+    writeHeartbeat: mocks.writeHeartbeat,
+    writeStreamEvent: mocks.writeStreamEvent,
+  }),
+}));
+
+vi.mock('@/app/(backend)/middleware/auth', () => ({
+  checkAuth:
+    (handler: (req: Request, context: { serverDB: object; userId: string }) => Promise<Response>) =>
+    (req: Request) =>
+      handler(req, { serverDB: {}, userId: 'user-1' }),
+}));
+
+vi.mock('@/server/routers/lambda/_helpers/topicCommentAccess', () => ({
+  assertTopicCommentReadAccess: mocks.assertTopicCommentReadAccess,
+}));
+
+vi.mock('@/server/services/resourceEvents', () => ({
+  subscribeResourceEvents: mocks.subscribeResourceEvents,
+}));
+
+vi.mock('../../_utils/workspace', () => ({
+  resolveValidWorkspaceIdFromRequest: vi.fn().mockResolvedValue('workspace-1'),
+}));
+
+describe('topic comment event stream', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mocks.signal = undefined;
+    mocks.assertTopicCommentReadAccess.mockResolvedValue(undefined);
+    mocks.subscribeResourceEvents.mockImplementation(
+      (_ref: unknown, _onEvent: unknown, signal: AbortSignal) => {
+        mocks.signal = signal;
+        return new Promise(() => {});
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('terminates the subscription when heartbeat access revalidation fails', async () => {
+    mocks.assertTopicCommentReadAccess
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('access revoked'));
+
+    const response = await GET(
+      new Request('https://example.com/webapi/topic-comment/events?topicId=topic-1'),
+    );
+    expect(response.status).toBe(200);
+    expect(mocks.signal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(mocks.assertTopicCommentReadAccess).toHaveBeenCalledTimes(2);
+    expect(mocks.signal?.aborted).toBe(true);
+    expect(mocks.writeHeartbeat).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(backend)/webapi/topic-comment/events/route.test.ts
+++ b/src/app/(backend)/webapi/topic-comment/events/route.test.ts
@@ -65,6 +65,7 @@ describe('topic comment event stream', () => {
 
     const response = await GET(
       new Request('https://example.com/webapi/topic-comment/events?topicId=topic-1'),
+      { params: Promise.resolve({}) },
     );
     expect(response.status).toBe(200);
     expect(mocks.signal?.aborted).toBe(false);

--- a/src/app/(backend)/webapi/topic-comment/events/route.ts
+++ b/src/app/(backend)/webapi/topic-comment/events/route.ts
@@ -1,0 +1,86 @@
+import { createSSEHeaders, createSSEWriter } from '@lobechat/utils/server';
+import { TRPCError } from '@trpc/server';
+import debug from 'debug';
+
+import { checkAuth } from '@/app/(backend)/middleware/auth';
+import { assertTopicCommentReadAccess } from '@/server/routers/lambda/_helpers/topicCommentAccess';
+import { subscribeResourceEvents } from '@/server/services/resourceEvents';
+
+import { resolveValidWorkspaceIdFromRequest } from '../../_utils/workspace';
+
+const log = debug('api-route:topic-comment:events');
+
+export const maxDuration = 300;
+export const runtime = 'nodejs';
+
+const jsonError = (message: string, status: number) =>
+  new Response(JSON.stringify({ error: message }), {
+    headers: { 'Content-Type': 'application/json' },
+    status,
+  });
+
+export const GET = checkAuth(async (req, { userId, serverDB }) => {
+  const topicId = new URL(req.url).searchParams.get('topicId');
+  if (!topicId) return jsonError('topicId is required', 400);
+
+  const workspaceId = await resolveValidWorkspaceIdFromRequest({ req, serverDB, userId });
+  if (!workspaceId) return jsonError('resource not found', 404);
+
+  try {
+    await assertTopicCommentReadAccess({
+      db: serverDB,
+      hideExistence: true,
+      topicId,
+      userId,
+      workspaceId,
+    });
+  } catch (error) {
+    if (error instanceof TRPCError && ['FORBIDDEN', 'NOT_FOUND'].includes(error.code)) {
+      return jsonError('resource not found', 404);
+    }
+    throw error;
+  }
+
+  let cleanup: (() => void) | undefined;
+  const stream = new ReadableStream<string>({
+    cancel() {
+      cleanup?.();
+    },
+    start(controller) {
+      const writer = createSSEWriter(controller);
+      writer.writeConnection(topicId, '$');
+      const ac = new AbortController();
+      const heartbeat = setInterval(() => {
+        try {
+          writer.writeHeartbeat();
+        } catch {
+          cleanup?.();
+        }
+      }, 30_000);
+      const stop = () => {
+        ac.abort();
+        clearInterval(heartbeat);
+        req.signal?.removeEventListener('abort', stop);
+      };
+      cleanup = stop;
+
+      void subscribeResourceEvents(
+        { id: topicId, type: 'topic' },
+        (event) => {
+          try {
+            writer.writeStreamEvent(event);
+          } catch (error) {
+            log('failed to write event %O', error);
+          }
+        },
+        ac.signal,
+      ).catch((error) => {
+        if (!ac.signal.aborted) log('subscription error %O', error);
+      });
+
+      req.signal?.addEventListener('abort', stop, { once: true });
+    },
+  });
+
+  return new Response(stream, { headers: createSSEHeaders() });
+});

--- a/src/app/(backend)/webapi/topic-comment/events/route.ts
+++ b/src/app/(backend)/webapi/topic-comment/events/route.ts
@@ -50,23 +50,45 @@ export const GET = checkAuth(async (req, { userId, serverDB }) => {
       const writer = createSSEWriter(controller);
       writer.writeConnection(topicId, '$');
       const ac = new AbortController();
-      const heartbeat = setInterval(() => {
-        try {
-          writer.writeHeartbeat();
-        } catch {
-          cleanup?.();
-        }
-      }, 30_000);
+      let checkingAccess = false;
       const stop = () => {
+        if (ac.signal.aborted) return;
         ac.abort();
         clearInterval(heartbeat);
         req.signal?.removeEventListener('abort', stop);
+        try {
+          controller.close();
+        } catch {
+          // The client may already have cancelled or closed the stream.
+        }
       };
       cleanup = stop;
+      const heartbeat = setInterval(() => {
+        if (checkingAccess || ac.signal.aborted) return;
+        checkingAccess = true;
+        void assertTopicCommentReadAccess({
+          db: serverDB,
+          hideExistence: true,
+          topicId,
+          userId,
+          workspaceId,
+        })
+          .then(() => {
+            if (!ac.signal.aborted) writer.writeHeartbeat();
+          })
+          .catch((error) => {
+            log('closing stream after access revalidation failed %O', error);
+            stop();
+          })
+          .finally(() => {
+            checkingAccess = false;
+          });
+      }, 30_000);
 
       void subscribeResourceEvents(
         { id: topicId, type: 'topic' },
         (event) => {
+          if (ac.signal.aborted) return;
           try {
             writer.writeStreamEvent(event);
           } catch (error) {

--- a/src/features/Portal/TopicComments/Body.tsx
+++ b/src/features/Portal/TopicComments/Body.tsx
@@ -41,7 +41,7 @@ const Body = memo(() => {
         : Promise.resolve(),
     [reload, topicId],
   );
-  useTopicCommentEvents(topicId, Boolean(topicId), refresh);
+  useTopicCommentEvents(topicId, refresh);
 
   if (!view) return null;
   if (isInitialError) {

--- a/src/features/Portal/TopicComments/Body.tsx
+++ b/src/features/Portal/TopicComments/Body.tsx
@@ -1,18 +1,21 @@
 import { Center, Empty, Flexbox } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { MessageCircle } from 'lucide-react';
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import AsyncError from '@/components/AsyncError';
 import Loading from '@/components/Loading/BrandTextLoading';
 import { useTopicCommentThreads } from '@/features/TopicComment/hooks';
+import { mutate } from '@/libs/swr';
+import { topicCommentKeys } from '@/libs/swr/keys';
 import { useChatStore } from '@/store/chat';
 import { chatPortalSelectors } from '@/store/chat/selectors';
 
 import CommentCard from './CommentCard';
 import Composer from './Composer';
 import { styles } from './styles';
+import { useTopicCommentEvents } from './useTopicCommentEvents';
 
 const Body = memo(() => {
   const { t } = useTranslation('chat');
@@ -30,6 +33,15 @@ const Body = memo(() => {
     pendingCommentIds,
     reload,
   } = useTopicCommentThreads(view?.topicId, view?.messageId);
+  const topicId = view?.topicId;
+  const refresh = useCallback(
+    () =>
+      topicId
+        ? Promise.all([reload(), mutate(topicCommentKeys.summary(topicId))]).then(() => undefined)
+        : Promise.resolve(),
+    [reload, topicId],
+  );
+  useTopicCommentEvents(topicId, Boolean(topicId), refresh);
 
   if (!view) return null;
   if (isInitialError) {

--- a/src/features/Portal/TopicComments/ThreadBody.tsx
+++ b/src/features/Portal/TopicComments/ThreadBody.tsx
@@ -53,7 +53,7 @@ const ThreadBody = memo(() => {
       mutate(topicCommentKeys.summary(topicId)),
     ]);
   }, [focusedReplyMutate, hasFocusedReply, repliesReload, rootMutate, topicId]);
-  useTopicCommentEvents(topicId, Boolean(topicId), refresh);
+  useTopicCommentEvents(topicId, refresh);
   const listRef = useRef<HTMLDivElement>(null);
   const visibleReplies = useMemo(() => {
     const focused = focusedReply.data;

--- a/src/features/Portal/TopicComments/ThreadBody.tsx
+++ b/src/features/Portal/TopicComments/ThreadBody.tsx
@@ -1,7 +1,7 @@
 import { Center, Empty, Flexbox, Text } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { MessageCircle } from 'lucide-react';
-import { memo, useEffect, useMemo, useRef } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import AsyncError from '@/components/AsyncError';
@@ -11,6 +11,8 @@ import {
   useTopicCommentReplies,
   useTopicCommentReplyCount,
 } from '@/features/TopicComment/hooks';
+import { mutate } from '@/libs/swr';
+import { topicCommentKeys } from '@/libs/swr/keys';
 import { useChatStore } from '@/store/chat';
 import { chatPortalSelectors } from '@/store/chat/selectors';
 
@@ -18,6 +20,7 @@ import CommentCard from './CommentCard';
 import Composer from './Composer';
 import { styles } from './styles';
 import { resolveTopicCommentThreadState } from './threadState';
+import { useTopicCommentEvents } from './useTopicCommentEvents';
 
 const ThreadBody = memo(() => {
   const { t } = useTranslation('chat');
@@ -30,10 +33,27 @@ const ThreadBody = memo(() => {
       : undefined,
   );
   const replies = useTopicCommentReplies(view?.rootCommentId, view?.initialReplyCount);
+  const rootMutate = root.mutate;
+  const hasFocusedReply = Boolean(
+    view?.focusCommentId && view.focusCommentId !== view.rootCommentId,
+  );
+  const focusedReplyMutate = focusedReply.mutate;
+  const repliesReload = replies.reload;
+  const topicId = view?.topicId;
   const replyCount = useTopicCommentReplyCount(
     view?.rootCommentId,
-    view?.initialReplyCount ?? replies.items.length,
+    replies.total ?? view?.initialReplyCount ?? replies.items.length,
   );
+  const refresh = useCallback(async () => {
+    if (!topicId) return;
+    await Promise.all([
+      rootMutate(),
+      hasFocusedReply ? focusedReplyMutate() : Promise.resolve(),
+      repliesReload(),
+      mutate(topicCommentKeys.summary(topicId)),
+    ]);
+  }, [focusedReplyMutate, hasFocusedReply, repliesReload, rootMutate, topicId]);
+  useTopicCommentEvents(topicId, Boolean(topicId), refresh);
   const listRef = useRef<HTMLDivElement>(null);
   const visibleReplies = useMemo(() => {
     const focused = focusedReply.data;

--- a/src/features/Portal/TopicComments/useTopicCommentEvents.test.ts
+++ b/src/features/Portal/TopicComments/useTopicCommentEvents.test.ts
@@ -5,8 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useTopicCommentEvents } from './useTopicCommentEvents';
 
 const fetchEventSource = vi.hoisted(() => vi.fn());
+const createHeaderWithAuth = vi.hoisted(() => vi.fn());
 vi.mock('@lobechat/utils/client', () => ({ fetchEventSource }));
-vi.mock('@/services/_auth', () => ({ createHeaderWithAuth: vi.fn().mockResolvedValue({}) }));
+vi.mock('@/services/_auth', () => ({ createHeaderWithAuth }));
 vi.mock('@/business/client/trpc-headers', () => ({
   getBusinessTrpcHeaders: vi.fn().mockResolvedValue({ 'X-Workspace-Id': 'workspace-1' }),
 }));
@@ -26,7 +27,10 @@ describe('useTopicCommentEvents', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
     fetchEventSource.mockReset();
+    createHeaderWithAuth.mockReset().mockResolvedValue({});
     attempts = [];
     fetchEventSource.mockImplementation(
       (_url: string, options: StreamAttempt['options']) =>
@@ -35,6 +39,7 @@ describe('useTopicCommentEvents', () => {
   });
 
   afterEach(() => {
+    vi.mocked(Math.random).mockRestore();
     vi.useRealTimers();
   });
 
@@ -58,7 +63,20 @@ describe('useTopicCommentEvents', () => {
     expect(refresh).toHaveBeenCalledTimes(2);
   });
 
-  it('reconnects after a normal close and polls until the next stream opens', async () => {
+  it('keeps a canonical reconciliation poll while the stream is open', async () => {
+    const { refresh } = await mount();
+    await act(() =>
+      attempts[0].options.onopen(
+        new Response('', { headers: { 'content-type': 'text/event-stream' } }),
+      ),
+    );
+
+    await act(async () => vi.advanceTimersByTimeAsync(30_000));
+    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(attempts).toHaveLength(1);
+  });
+
+  it('reconnects after a normal close without interrupting reconciliation polling', async () => {
     const { refresh } = await mount();
     const first = attempts[0];
     await act(() =>
@@ -79,7 +97,53 @@ describe('useTopicCommentEvents', () => {
     );
     expect(refresh).toHaveBeenCalledTimes(3);
     await act(async () => vi.advanceTimersByTimeAsync(30_000));
-    expect(refresh).toHaveBeenCalledTimes(3);
+    expect(refresh).toHaveBeenCalledTimes(4);
+  });
+
+  it('uses jittered exponential backoff across consecutive connection failures', async () => {
+    vi.mocked(Math.random).mockReturnValue(0);
+    await mount();
+    const first = attempts[0];
+    first.options.onerror({});
+    await act(async () => first.resolve());
+
+    await act(async () => vi.advanceTimersByTimeAsync(3999));
+    expect(attempts).toHaveLength(1);
+    await act(async () => vi.advanceTimersByTimeAsync(1));
+    expect(attempts).toHaveLength(2);
+
+    const second = attempts[1];
+    second.options.onerror({});
+    await act(async () => second.resolve());
+    await act(async () => vi.advanceTimersByTimeAsync(7999));
+    expect(attempts).toHaveLength(2);
+    await act(async () => vi.advanceTimersByTimeAsync(1));
+    expect(attempts).toHaveLength(3);
+  });
+
+  it('pauses polling and reconnects while hidden, then reconciles on visibility', async () => {
+    const { refresh } = await mount();
+    const first = attempts[0];
+    await act(() =>
+      first.options.onopen(new Response('', { headers: { 'content-type': 'text/event-stream' } })),
+    );
+    expect(refresh).toHaveBeenCalledOnce();
+
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await act(async () => first.resolve());
+    await act(async () => vi.advanceTimersByTimeAsync(60_000));
+    expect(refresh).toHaveBeenCalledOnce();
+    expect(attempts).toHaveLength(1);
+
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await act(async () => {});
+    expect(refresh).toHaveBeenCalledTimes(2);
+    await act(async () => vi.advanceTimersByTimeAsync(4999));
+    expect(attempts).toHaveLength(1);
+    await act(async () => vi.advanceTimersByTimeAsync(1));
+    expect(attempts).toHaveLength(2);
   });
 
   it('does not retry or poll fatal 4xx responses', async () => {
@@ -97,12 +161,30 @@ describe('useTopicCommentEvents', () => {
 
   it('aborts and clears pending work on unmount', async () => {
     const { refresh, unmount } = await mount();
-    const { options } = attempts[0];
+    const { options, resolve } = attempts[0];
     options.onerror({});
     options.onmessage({ data: JSON.stringify({ type: 'topic.commentsChanged' }) });
+    await act(async () => resolve());
     unmount();
     expect(options.signal.aborted).toBe(true);
     await act(async () => vi.advanceTimersByTimeAsync(60_000));
     expect(refresh).not.toHaveBeenCalled();
+    expect(attempts).toHaveLength(1);
+  });
+
+  it('does not schedule work when header loading fails after unmount', async () => {
+    let rejectHeaders: ((reason: Error) => void) | undefined;
+    createHeaderWithAuth.mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          rejectHeaders = reject;
+        }),
+    );
+    const { unmount } = await mount();
+    unmount();
+
+    await act(async () => rejectHeaders?.(new Error('header failure')));
+    expect(fetchEventSource).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/src/features/Portal/TopicComments/useTopicCommentEvents.test.ts
+++ b/src/features/Portal/TopicComments/useTopicCommentEvents.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useTopicCommentEvents } from './useTopicCommentEvents';
+
+const fetchEventSource = vi.hoisted(() => vi.fn());
+vi.mock('@lobechat/utils/client', () => ({ fetchEventSource }));
+vi.mock('@/services/_auth', () => ({ createHeaderWithAuth: vi.fn().mockResolvedValue({}) }));
+vi.mock('@/business/client/trpc-headers', () => ({
+  getBusinessTrpcHeaders: vi.fn().mockResolvedValue({ 'X-Workspace-Id': 'workspace-1' }),
+}));
+
+interface StreamAttempt {
+  options: {
+    onerror: (error: { fatal?: boolean }) => void;
+    onmessage: (event: { data: string }) => void;
+    onopen: (response: Response) => Promise<void>;
+    signal: AbortSignal;
+  };
+  resolve: () => void;
+}
+
+describe('useTopicCommentEvents', () => {
+  let attempts: StreamAttempt[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchEventSource.mockReset();
+    attempts = [];
+    fetchEventSource.mockImplementation(
+      (_url: string, options: StreamAttempt['options']) =>
+        new Promise<void>((resolve) => attempts.push({ options, resolve })),
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const mount = async (refresh = vi.fn().mockResolvedValue(undefined)) => {
+    const result = renderHook(() => useTopicCommentEvents('topic-1', true, refresh));
+    await act(async () => {});
+    return { ...result, refresh };
+  };
+
+  it('refreshes on open and debounces matching events without filtering the actor', async () => {
+    const { refresh } = await mount();
+    const { options } = attempts[0];
+    await act(() =>
+      options.onopen(new Response('', { headers: { 'content-type': 'text/event-stream' } })),
+    );
+    expect(refresh).toHaveBeenCalledOnce();
+
+    options.onmessage({ data: JSON.stringify({ actorId: 'self', type: 'topic.commentsChanged' }) });
+    options.onmessage({ data: JSON.stringify({ type: 'topic.commentsChanged' }) });
+    await act(async () => vi.advanceTimersByTimeAsync(250));
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
+  it('reconnects after a normal close and polls until the next stream opens', async () => {
+    const { refresh } = await mount();
+    const first = attempts[0];
+    await act(() =>
+      first.options.onopen(new Response('', { headers: { 'content-type': 'text/event-stream' } })),
+    );
+    expect(refresh).toHaveBeenCalledOnce();
+
+    await act(async () => first.resolve());
+    await act(async () => vi.advanceTimersByTimeAsync(5000));
+    expect(attempts).toHaveLength(2);
+
+    await act(async () => vi.advanceTimersByTimeAsync(25_000));
+    expect(refresh).toHaveBeenCalledTimes(2);
+
+    const second = attempts[1];
+    await act(() =>
+      second.options.onopen(new Response('', { headers: { 'content-type': 'text/event-stream' } })),
+    );
+    expect(refresh).toHaveBeenCalledTimes(3);
+    await act(async () => vi.advanceTimersByTimeAsync(30_000));
+    expect(refresh).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry or poll fatal 4xx responses', async () => {
+    const { refresh } = await mount();
+    const first = attempts[0];
+    const error = await first.options
+      .onopen(new Response('', { status: 403 }))
+      .catch((cause) => cause);
+    first.options.onerror(error);
+    await act(async () => first.resolve());
+    await act(async () => vi.advanceTimersByTimeAsync(60_000));
+    expect(refresh).not.toHaveBeenCalled();
+    expect(attempts).toHaveLength(1);
+  });
+
+  it('aborts and clears pending work on unmount', async () => {
+    const { refresh, unmount } = await mount();
+    const { options } = attempts[0];
+    options.onerror({});
+    options.onmessage({ data: JSON.stringify({ type: 'topic.commentsChanged' }) });
+    unmount();
+    expect(options.signal.aborted).toBe(true);
+    await act(async () => vi.advanceTimersByTimeAsync(60_000));
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/Portal/TopicComments/useTopicCommentEvents.test.ts
+++ b/src/features/Portal/TopicComments/useTopicCommentEvents.test.ts
@@ -170,7 +170,22 @@ describe('useTopicCommentEvents', () => {
     expect(attempts).toHaveLength(2);
   });
 
-  it('does not retry or poll fatal 4xx responses', async () => {
+  it('retries transient 4xx responses while retaining canonical polling', async () => {
+    const { refresh } = await mount();
+    const first = attempts[0];
+    const error = await first.options
+      .onopen(new Response('', { status: 429 }))
+      .catch((cause) => cause);
+    first.options.onerror(error);
+    await act(async () => first.resolve());
+
+    await act(async () => vi.advanceTimersByTimeAsync(5000));
+    expect(attempts).toHaveLength(2);
+    await act(async () => vi.advanceTimersByTimeAsync(25_000));
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+
+  it('does not retry or poll permanent 4xx responses', async () => {
     const { refresh } = await mount();
     const first = attempts[0];
     const error = await first.options

--- a/src/features/Portal/TopicComments/useTopicCommentEvents.test.ts
+++ b/src/features/Portal/TopicComments/useTopicCommentEvents.test.ts
@@ -76,6 +76,30 @@ describe('useTopicCommentEvents', () => {
     expect(attempts).toHaveLength(1);
   });
 
+  it('backs off reconciliation polling after failures and resets after success', async () => {
+    const refresh = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('refresh failed'))
+      .mockResolvedValue(undefined);
+    await mount(refresh);
+    await act(() =>
+      attempts[0].options.onopen(
+        new Response('', { headers: { 'content-type': 'text/event-stream' } }),
+      ),
+    );
+    expect(refresh).toHaveBeenCalledOnce();
+
+    await act(async () => vi.advanceTimersByTimeAsync(59_999));
+    expect(refresh).toHaveBeenCalledOnce();
+    await act(async () => vi.advanceTimersByTimeAsync(1));
+    expect(refresh).toHaveBeenCalledTimes(2);
+
+    await act(async () => vi.advanceTimersByTimeAsync(29_999));
+    expect(refresh).toHaveBeenCalledTimes(2);
+    await act(async () => vi.advanceTimersByTimeAsync(1));
+    expect(refresh).toHaveBeenCalledTimes(3);
+  });
+
   it('reconnects after a normal close without interrupting reconciliation polling', async () => {
     const { refresh } = await mount();
     const first = attempts[0];

--- a/src/features/Portal/TopicComments/useTopicCommentEvents.test.ts
+++ b/src/features/Portal/TopicComments/useTopicCommentEvents.test.ts
@@ -44,7 +44,7 @@ describe('useTopicCommentEvents', () => {
   });
 
   const mount = async (refresh = vi.fn().mockResolvedValue(undefined)) => {
-    const result = renderHook(() => useTopicCommentEvents('topic-1', true, refresh));
+    const result = renderHook(() => useTopicCommentEvents('topic-1', refresh));
     await act(async () => {});
     return { ...result, refresh };
   };

--- a/src/features/Portal/TopicComments/useTopicCommentEvents.ts
+++ b/src/features/Portal/TopicComments/useTopicCommentEvents.ts
@@ -20,11 +20,10 @@ const buildHeaders = async (): Promise<Record<string, string>> => {
 
 export const useTopicCommentEvents = (
   topicId: string | undefined,
-  enabled: boolean,
   refresh: () => void | Promise<void>,
 ) => {
   useEffect(() => {
-    if (!enabled || !topicId) return;
+    if (!topicId) return;
 
     const ac = new AbortController();
     let cancelled = false;
@@ -222,5 +221,5 @@ export const useTopicCommentEvents = (
       clearTimeout(debounceTimer);
       stopPolling();
     };
-  }, [enabled, refresh, topicId]);
+  }, [refresh, topicId]);
 };

--- a/src/features/Portal/TopicComments/useTopicCommentEvents.ts
+++ b/src/features/Portal/TopicComments/useTopicCommentEvents.ts
@@ -196,7 +196,7 @@ export const useTopicCommentEvents = (
               const error: Error & { fatal?: boolean } = new Error(
                 `SSE failed: ${response.status}`,
               );
-              error.fatal = response.status >= 400 && response.status < 500;
+              error.fatal = [400, 401, 403, 404].includes(response.status);
               throw error;
             },
             signal: ac.signal,

--- a/src/features/Portal/TopicComments/useTopicCommentEvents.ts
+++ b/src/features/Portal/TopicComments/useTopicCommentEvents.ts
@@ -1,0 +1,156 @@
+'use client';
+
+import { fetchEventSource } from '@lobechat/utils/client';
+import { useEffect } from 'react';
+
+const EVENT_DEBOUNCE_INTERVAL = 250;
+const POLLING_INTERVAL = 30_000;
+const RECONNECT_INTERVAL = 5000;
+
+const buildHeaders = async (): Promise<Record<string, string>> => {
+  const { createHeaderWithAuth } = await import('@/services/_auth');
+  const headers = (await createHeaderWithAuth()) as Record<string, string>;
+  const { getBusinessTrpcHeaders } = await import('@/business/client/trpc-headers');
+  Object.assign(headers, await getBusinessTrpcHeaders());
+  return headers;
+};
+
+export const useTopicCommentEvents = (
+  topicId: string | undefined,
+  enabled: boolean,
+  refresh: () => void | Promise<void>,
+) => {
+  useEffect(() => {
+    if (!enabled || !topicId) return;
+
+    const ac = new AbortController();
+    let cancelled = false;
+    let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+    let pollTimer: ReturnType<typeof setInterval> | undefined;
+    let reconnectResolver: (() => void) | undefined;
+    let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    let refreshing = false;
+    let refreshQueued = false;
+
+    const runRefresh = async () => {
+      if (cancelled) return;
+      if (refreshing) {
+        refreshQueued = true;
+        return;
+      }
+      refreshing = true;
+      try {
+        await refresh();
+      } catch {
+        // Realtime invalidation is best-effort; the next event or polling tick retries.
+      } finally {
+        refreshing = false;
+        if (refreshQueued && !cancelled) {
+          refreshQueued = false;
+          void runRefresh();
+        }
+      }
+    };
+    const scheduleRefresh = () => {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => void runRefresh(), EVENT_DEBOUNCE_INTERVAL);
+    };
+    const stopPolling = () => {
+      clearInterval(pollTimer);
+      pollTimer = undefined;
+    };
+    const startPolling = () => {
+      if (!pollTimer) pollTimer = setInterval(() => void runRefresh(), POLLING_INTERVAL);
+    };
+    const stopReconnectWait = () => {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = undefined;
+      const resolve = reconnectResolver;
+      reconnectResolver = undefined;
+      resolve?.();
+    };
+    const waitBeforeReconnect = () =>
+      new Promise<void>((resolve) => {
+        reconnectResolver = resolve;
+        reconnectTimer = setTimeout(() => {
+          reconnectResolver = undefined;
+          reconnectTimer = undefined;
+          resolve();
+        }, RECONNECT_INTERVAL);
+      });
+
+    const start = async () => {
+      while (!cancelled) {
+        let headers: Record<string, string>;
+        try {
+          headers = await buildHeaders();
+        } catch {
+          startPolling();
+          await waitBeforeReconnect();
+          continue;
+        }
+        if (cancelled) return;
+
+        let fatal = false;
+        await fetchEventSource(
+          `/webapi/topic-comment/events?topicId=${encodeURIComponent(topicId)}`,
+          {
+            credentials: 'include',
+            headers,
+            onerror: (error: { fatal?: boolean }) => {
+              if (cancelled) return;
+              if (error?.fatal) {
+                fatal = true;
+                stopPolling();
+                return;
+              }
+              startPolling();
+            },
+            onmessage: (event) => {
+              if (!event.data) return;
+              try {
+                const parsed = JSON.parse(event.data) as { type?: string };
+                if (parsed.type === 'topic.commentsChanged') scheduleRefresh();
+              } catch {
+                // Ignore malformed transport frames; canonical polling remains available.
+              }
+            },
+            onopen: async (response) => {
+              if (
+                response.ok &&
+                response.headers.get('content-type')?.includes('text/event-stream')
+              ) {
+                stopPolling();
+                await runRefresh();
+                return;
+              }
+              const error: Error & { fatal?: boolean } = new Error(
+                `SSE failed: ${response.status}`,
+              );
+              error.fatal = response.status >= 400 && response.status < 500;
+              throw error;
+            },
+            signal: ac.signal,
+          },
+        );
+        if (cancelled || fatal) return;
+
+        // The shared fetchEventSource is intentionally one-shot. A normal server
+        // close resolves without onerror, so reconnect explicitly and poll across the gap.
+        startPolling();
+        await waitBeforeReconnect();
+      }
+    };
+
+    void start().catch(() => {
+      if (!cancelled) startPolling();
+    });
+    return () => {
+      cancelled = true;
+      stopReconnectWait();
+      ac.abort();
+      clearTimeout(debounceTimer);
+      stopPolling();
+    };
+  }, [enabled, refresh, topicId]);
+};

--- a/src/features/Portal/TopicComments/useTopicCommentEvents.ts
+++ b/src/features/Portal/TopicComments/useTopicCommentEvents.ts
@@ -5,7 +5,8 @@ import { useEffect } from 'react';
 
 const EVENT_DEBOUNCE_INTERVAL = 250;
 const POLLING_INTERVAL = 30_000;
-const RECONNECT_INTERVAL = 5000;
+const RECONNECT_BASE_INTERVAL = 5000;
+const RECONNECT_MAX_INTERVAL = 60_000;
 
 const buildHeaders = async (): Promise<Record<string, string>> => {
   const { createHeaderWithAuth } = await import('@/services/_auth');
@@ -25,15 +26,17 @@ export const useTopicCommentEvents = (
 
     const ac = new AbortController();
     let cancelled = false;
+    let terminal = false;
     let debounceTimer: ReturnType<typeof setTimeout> | undefined;
     let pollTimer: ReturnType<typeof setInterval> | undefined;
-    let reconnectResolver: (() => void) | undefined;
-    let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    let pendingWaitCleanup: (() => void) | undefined;
+    let reconnectAttempt = 0;
     let refreshing = false;
     let refreshQueued = false;
 
+    const isVisible = () => document.visibilityState !== 'hidden';
     const runRefresh = async () => {
-      if (cancelled) return;
+      if (cancelled || terminal || !isVisible()) return;
       if (refreshing) {
         refreshQueued = true;
         return;
@@ -60,38 +63,89 @@ export const useTopicCommentEvents = (
       pollTimer = undefined;
     };
     const startPolling = () => {
-      if (!pollTimer) pollTimer = setInterval(() => void runRefresh(), POLLING_INTERVAL);
+      if (!pollTimer && isVisible()) {
+        pollTimer = setInterval(() => void runRefresh(), POLLING_INTERVAL);
+      }
     };
-    const stopReconnectWait = () => {
-      clearTimeout(reconnectTimer);
-      reconnectTimer = undefined;
-      const resolve = reconnectResolver;
-      reconnectResolver = undefined;
-      resolve?.();
+    const stopPendingWait = () => {
+      const cleanup = pendingWaitCleanup;
+      pendingWaitCleanup = undefined;
+      cleanup?.();
     };
-    const waitBeforeReconnect = () =>
-      new Promise<void>((resolve) => {
-        reconnectResolver = resolve;
-        reconnectTimer = setTimeout(() => {
-          reconnectResolver = undefined;
-          reconnectTimer = undefined;
+    const waitUntilVisible = () => {
+      if (isVisible()) return Promise.resolve();
+
+      return new Promise<void>((resolve) => {
+        const finish = () => {
+          document.removeEventListener('visibilitychange', handleVisibilityChange);
+          if (pendingWaitCleanup === finish) pendingWaitCleanup = undefined;
           resolve();
-        }, RECONNECT_INTERVAL);
+        };
+        const handleVisibilityChange = () => {
+          if (isVisible()) finish();
+        };
+        pendingWaitCleanup = finish;
+        document.addEventListener('visibilitychange', handleVisibilityChange);
       });
+    };
+    const waitBeforeReconnect = (attempt: number) =>
+      new Promise<void>((resolve) => {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const delay = Math.min(
+          RECONNECT_MAX_INTERVAL,
+          Math.round(RECONNECT_BASE_INTERVAL * 2 ** attempt * (0.8 + Math.random() * 0.4)),
+        );
+        const finish = () => {
+          clearTimeout(timer);
+          document.removeEventListener('visibilitychange', handleVisibilityChange);
+          if (pendingWaitCleanup === finish) pendingWaitCleanup = undefined;
+          resolve();
+        };
+        const schedule = () => {
+          if (!timer && isVisible()) timer = setTimeout(finish, delay);
+        };
+        const handleVisibilityChange = () => {
+          if (isVisible()) {
+            schedule();
+          } else {
+            clearTimeout(timer);
+            timer = undefined;
+          }
+        };
+        pendingWaitCleanup = finish;
+        document.addEventListener('visibilitychange', handleVisibilityChange);
+        schedule();
+      });
+
+    const handleVisibilityChange = () => {
+      if (!isVisible()) {
+        stopPolling();
+        clearTimeout(debounceTimer);
+        return;
+      }
+      if (terminal) return;
+      startPolling();
+      void runRefresh();
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    startPolling();
 
     const start = async () => {
       while (!cancelled) {
+        await waitUntilVisible();
+        if (cancelled) return;
+
         let headers: Record<string, string>;
         try {
           headers = await buildHeaders();
         } catch {
+          if (cancelled) return;
           startPolling();
-          await waitBeforeReconnect();
+          await waitBeforeReconnect(reconnectAttempt++);
           continue;
         }
         if (cancelled) return;
 
-        let fatal = false;
         await fetchEventSource(
           `/webapi/topic-comment/events?topicId=${encodeURIComponent(topicId)}`,
           {
@@ -100,7 +154,7 @@ export const useTopicCommentEvents = (
             onerror: (error: { fatal?: boolean }) => {
               if (cancelled) return;
               if (error?.fatal) {
-                fatal = true;
+                terminal = true;
                 stopPolling();
                 return;
               }
@@ -120,7 +174,7 @@ export const useTopicCommentEvents = (
                 response.ok &&
                 response.headers.get('content-type')?.includes('text/event-stream')
               ) {
-                stopPolling();
+                reconnectAttempt = 0;
                 await runRefresh();
                 return;
               }
@@ -133,12 +187,12 @@ export const useTopicCommentEvents = (
             signal: ac.signal,
           },
         );
-        if (cancelled || fatal) return;
+        if (cancelled || terminal) return;
 
         // The shared fetchEventSource is intentionally one-shot. A normal server
         // close resolves without onerror, so reconnect explicitly and poll across the gap.
         startPolling();
-        await waitBeforeReconnect();
+        await waitBeforeReconnect(reconnectAttempt++);
       }
     };
 
@@ -147,7 +201,8 @@ export const useTopicCommentEvents = (
     });
     return () => {
       cancelled = true;
-      stopReconnectWait();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      stopPendingWait();
       ac.abort();
       clearTimeout(debounceTimer);
       stopPolling();

--- a/src/features/Portal/TopicComments/useTopicCommentEvents.ts
+++ b/src/features/Portal/TopicComments/useTopicCommentEvents.ts
@@ -5,6 +5,8 @@ import { useEffect } from 'react';
 
 const EVENT_DEBOUNCE_INTERVAL = 250;
 const POLLING_INTERVAL = 30_000;
+const POLLING_MAX_BACKOFF_EXPONENT = 4;
+const POLLING_MAX_INTERVAL = 5 * 60_000;
 const RECONNECT_BASE_INTERVAL = 5000;
 const RECONNECT_MAX_INTERVAL = 60_000;
 
@@ -30,12 +32,33 @@ export const useTopicCommentEvents = (
     let debounceTimer: ReturnType<typeof setTimeout> | undefined;
     let pollTimer: ReturnType<typeof setInterval> | undefined;
     let pendingWaitCleanup: (() => void) | undefined;
+    let pollingFailureCount = 0;
     let reconnectAttempt = 0;
     let refreshing = false;
     let refreshQueued = false;
 
     const isVisible = () => document.visibilityState !== 'hidden';
-    const runRefresh = async () => {
+    const stopPolling = () => {
+      clearInterval(pollTimer);
+      pollTimer = undefined;
+    };
+    const startPolling = () => {
+      if (!pollTimer && !cancelled && !terminal && isVisible()) {
+        const interval = Math.min(
+          POLLING_MAX_INTERVAL,
+          POLLING_INTERVAL * 2 ** pollingFailureCount,
+        );
+        pollTimer = setInterval(() => void runRefresh(), interval);
+      }
+    };
+    const updatePollingBackoff = (failureCount: number) => {
+      if (pollingFailureCount === failureCount) return;
+      pollingFailureCount = failureCount;
+      if (!pollTimer) return;
+      stopPolling();
+      startPolling();
+    };
+    async function runRefresh() {
       if (cancelled || terminal || !isVisible()) return;
       if (refreshing) {
         refreshQueued = true;
@@ -44,8 +67,9 @@ export const useTopicCommentEvents = (
       refreshing = true;
       try {
         await refresh();
+        updatePollingBackoff(0);
       } catch {
-        // Realtime invalidation is best-effort; the next event or polling tick retries.
+        updatePollingBackoff(Math.min(pollingFailureCount + 1, POLLING_MAX_BACKOFF_EXPONENT));
       } finally {
         refreshing = false;
         if (refreshQueued && !cancelled) {
@@ -53,19 +77,10 @@ export const useTopicCommentEvents = (
           void runRefresh();
         }
       }
-    };
+    }
     const scheduleRefresh = () => {
       clearTimeout(debounceTimer);
       debounceTimer = setTimeout(() => void runRefresh(), EVENT_DEBOUNCE_INTERVAL);
-    };
-    const stopPolling = () => {
-      clearInterval(pollTimer);
-      pollTimer = undefined;
-    };
-    const startPolling = () => {
-      if (!pollTimer && isVisible()) {
-        pollTimer = setInterval(() => void runRefresh(), POLLING_INTERVAL);
-      }
     };
     const stopPendingWait = () => {
       const cleanup = pendingWaitCleanup;

--- a/src/features/TopicComment/hooks.test.ts
+++ b/src/features/TopicComment/hooks.test.ts
@@ -797,6 +797,19 @@ describe('useTopicCommentMutations', () => {
     expect(detail.result.current.isDeleting).toBe(true);
   });
 
+  it('clears retained detail data when revalidation reports not found', () => {
+    const comment = createComment({ id: 'deleted-reply', parentCommentId: 'comment-1' });
+    mocks.useClientDataSWR.mockReturnValue({
+      data: comment,
+      error: { data: { code: 'NOT_FOUND' } },
+    });
+
+    const detail = renderHook(() => useTopicCommentDetail(comment.id));
+
+    expect(detail.result.current.data).toBeUndefined();
+    expect(detail.result.current.error).toEqual({ data: { code: 'NOT_FOUND' } });
+  });
+
   it('rolls a failed second edit back to the last confirmed optimistic value', async () => {
     const staleComment = createComment();
     const confirmedComment = createComment({

--- a/src/features/TopicComment/hooks.test.ts
+++ b/src/features/TopicComment/hooks.test.ts
@@ -1069,7 +1069,7 @@ describe('useTopicCommentMutations', () => {
       }),
     );
     mocks.infiniteResponse = {
-      data: [{ items: [reply], nextCursor: null }],
+      data: [{ items: [reply], nextCursor: null, total: 1 }],
       error: undefined,
       isLoading: false,
       isValidating: false,
@@ -1203,7 +1203,7 @@ describe('topic comment read hooks', () => {
       ],
       nextCursor: null,
     };
-    const replyPage = { items: [{ id: 'reply-1' }], nextCursor: null };
+    const replyPage = { items: [{ id: 'reply-1' }], nextCursor: null, total: 1 };
     mocks.listThreads.mockResolvedValue(threadPage);
     mocks.listReplies.mockResolvedValue(replyPage);
     mocks.useClientDataSWR.mockImplementation((key, fetcher) => {
@@ -1310,14 +1310,14 @@ describe('topic comment read hooks', () => {
       expect.any(Function),
       expect.any(Function),
       expect.objectContaining({
-        fallbackData: [{ items: [], nextCursor: null }],
+        fallbackData: [{ items: [], nextCursor: null, total: 0 }],
         revalidateOnMount: true,
       }),
     );
   });
 
   it('uses prefetched first-page replies as an immediate fallback while revalidating', () => {
-    const page = { items: [{ id: 'reply-1' }], nextCursor: null };
+    const page = { items: [{ id: 'reply-1' }], nextCursor: null, total: 1 };
     mocks.cacheGet.mockImplementation((key) =>
       key === JSON.stringify(['topicComment:replies', 'workspace-1', 'root-comment-1', ''])
         ? { data: page }

--- a/src/features/TopicComment/hooks.ts
+++ b/src/features/TopicComment/hooks.ts
@@ -423,7 +423,7 @@ export const useTopicCommentThreads = (topicId?: string | null, messageId?: stri
     items,
     loadMore: () => response.setSize((size) => size + 1),
     pendingCommentIds,
-    reload: () => response.mutate(),
+    reload: response.mutate,
   };
 };
 
@@ -462,7 +462,7 @@ export const useTopicCommentReplies = (
   const response = useSWRInfinite<TopicCommentReplyPage>(getKey, fetchTopicCommentReplies, {
     fallbackData:
       initialReplyCount === 0
-        ? [{ items: [], nextCursor: null }]
+        ? [{ items: [], nextCursor: null, total: 0 }]
         : cachedFirstPage
           ? [cachedFirstPage]
           : undefined,
@@ -532,7 +532,8 @@ export const useTopicCommentReplies = (
     items,
     loadMore: () => response.setSize((size) => size + 1),
     pendingCommentIds,
-    reload: () => response.mutate(),
+    reload: response.mutate,
+    total: data?.[0]?.total,
   };
 };
 

--- a/src/features/TopicComment/hooks.ts
+++ b/src/features/TopicComment/hooks.ts
@@ -27,6 +27,7 @@ import type {
 } from '@/store/topicComment/initialState';
 import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/slices/auth/selectors';
+import { isTrpcErrorCode } from '@/utils/trpcError';
 
 const PAGE_SIZE = 30;
 const PREFETCH_CONCURRENCY = 4;
@@ -203,11 +204,12 @@ export const useTopicCommentDetail = (
   );
   const isDeleting =
     optimisticMutation?.kind === 'delete' && optimisticMutation.deleteMode === 'hard';
+  const isNotFound = isTrpcErrorCode(response.error, 'NOT_FOUND');
 
   return {
     ...response,
     data:
-      isDeleting && !optimisticMutation?.pending
+      isNotFound || (isDeleting && !optimisticMutation?.pending)
         ? undefined
         : (optimisticMutation?.comment ?? response.data),
     isDeleting,


### PR DESCRIPTION
## Summary

- publish best-effort resource invalidation events after topic comment mutations
- add an authorized, topic-scoped SSE endpoint for comment updates
- refresh comment lists and threads with reconnect and polling fallback behavior
- return canonical live reply totals after moderation or deletion

No visual UI changes.

#### Test

- `bun run check <15 changed files>` — lint clean, 129 tests passed

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

None.