### PR TITLE
🐛 fix(skill): initialize custom skill agent modes

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/connector.syncPluginTools.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/connector.syncPluginTools.test.ts
@@ -259,13 +259,8 @@ describe('connectorRouter.create — sourceType handling on existing rows', () =
   });
 });
 
-describe('connectorRouter.delete — agent connector unpins from the owning agent (LOBE-11682)', () => {
-  // Deleting an agent-owned connector must also remove its tool from that
-  // agent's `plugins`, so the unified settings delete matches the agent-profile
-  // delete (row + pin) and never leaves a dangling pin. Done server-side so the
-  // unified page needs no access to an arbitrary agent's config.
+describe('connectorRouter.delete — delegates atomic policy cleanup to ConnectorModel', () => {
   let connectorModelMock: any;
-  let agentModelMock: any;
 
   const DELETE_ID = '11111111-1111-4111-8111-111111111111';
 
@@ -275,14 +270,9 @@ describe('connectorRouter.delete — agent connector unpins from the owning agen
       delete: vi.fn().mockResolvedValue(undefined),
       findById: vi.fn(),
     };
-    agentModelMock = {
-      getAgentConfigById: vi.fn(),
-      update: vi.fn().mockResolvedValue(undefined),
-    };
     vi.mocked(ConnectorModel).mockImplementation(() => connectorModelMock);
     vi.mocked(ConnectorToolModel).mockImplementation(() => ({}) as any);
     vi.mocked(PluginModel).mockImplementation(() => ({}) as any);
-    vi.mocked(AgentModel).mockImplementation(() => agentModelMock);
   });
 
   const caller = () =>
@@ -292,24 +282,20 @@ describe('connectorRouter.delete — agent connector unpins from the owning agen
       workspaceId: null,
     } as any);
 
-  it('deletes the row and strips the identifier from the owning agent plugins', async () => {
+  it('deletes an agent-owned connector through the model', async () => {
     connectorModelMock.findById.mockResolvedValueOnce({
       agentId: 'agent-1',
       id: 'c1',
       identifier: 'gmail',
       userId: 'user_test',
     });
-    agentModelMock.getAgentConfigById.mockResolvedValueOnce({ plugins: ['gmail', 'notion'] });
 
     await caller().delete({ id: DELETE_ID });
 
     expect(connectorModelMock.delete).toHaveBeenCalledWith(DELETE_ID);
-    expect(agentModelMock.getAgentConfigById).toHaveBeenCalledWith('agent-1');
-    // 'gmail' removed, 'notion' preserved.
-    expect(agentModelMock.update).toHaveBeenCalledWith('agent-1', { plugins: ['notion'] });
   });
 
-  it('leaves the agent config untouched for a base (non-agent) connector', async () => {
+  it('deletes a base connector through the model', async () => {
     connectorModelMock.findById.mockResolvedValueOnce({
       agentId: null,
       id: 'c2',
@@ -320,17 +306,14 @@ describe('connectorRouter.delete — agent connector unpins from the owning agen
     await caller().delete({ id: DELETE_ID });
 
     expect(connectorModelMock.delete).toHaveBeenCalledWith(DELETE_ID);
-    expect(agentModelMock.getAgentConfigById).not.toHaveBeenCalled();
-    expect(agentModelMock.update).not.toHaveBeenCalled();
   });
 
-  it('is a no-op on the agent when the connector row is already gone', async () => {
+  it('is a no-op when the connector row is already gone', async () => {
     connectorModelMock.findById.mockResolvedValueOnce(null);
 
     await caller().delete({ id: DELETE_ID });
 
     expect(connectorModelMock.delete).not.toHaveBeenCalled();
-    expect(agentModelMock.update).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/server/src/routers/lambda/connector.ts
+++ b/apps/server/src/routers/lambda/connector.ts
@@ -1,4 +1,4 @@
-import { upsertPluginMode } from '@lobechat/types';
+import { parsePluginEntry } from '@lobechat/types';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
@@ -660,21 +660,16 @@ export const connectorRouter = router({
       assertWorkspaceRowManageable(ctx, target.userId, 'connector');
       await ctx.connectorModel.delete(input.id);
 
-      // Agent-owned connector: also unpin its tool from the owning agent's
-      // `plugins`, so deleting it here matches the agent-profile delete (row +
-      // pin) and never leaves a dangling pin. Done server-side because the
-      // unified settings page has no safe access to an arbitrary agent's config
-      // (mirrors the profile page's client-side unpin, `upsertPluginMode(...,
-      // 'auto')`). Idempotent: re-running on an already-unpinned agent is a no-op.
+      // Agent-owned connector: also remove its policy entry from the owning
+      // agent. This is resource deletion rather than a user selecting `auto`,
+      // so retaining an explicit auto entry would leave a dangling identifier.
       if (target.agentId) {
         const agentModel = new AgentModel(ctx.serverDB, ctx.userId, ctx.workspaceId ?? undefined);
         const config = await agentModel.getAgentConfigById(target.agentId);
         if (config) {
           await agentModel.update(target.agentId, {
-            plugins: upsertPluginMode(
-              config.plugins ?? undefined,
-              target.identifier,
-              'auto',
+            plugins: (config.plugins ?? []).filter(
+              (entry) => parsePluginEntry(entry).identifier !== target.identifier,
             ) as any,
           });
         }

--- a/apps/server/src/routers/lambda/connector.ts
+++ b/apps/server/src/routers/lambda/connector.ts
@@ -1,4 +1,3 @@
-import { parsePluginEntry } from '@lobechat/types';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
@@ -659,21 +658,6 @@ export const connectorRouter = router({
       if (!target) return;
       assertWorkspaceRowManageable(ctx, target.userId, 'connector');
       await ctx.connectorModel.delete(input.id);
-
-      // Agent-owned connector: also remove its policy entry from the owning
-      // agent. This is resource deletion rather than a user selecting `auto`,
-      // so retaining an explicit auto entry would leave a dangling identifier.
-      if (target.agentId) {
-        const agentModel = new AgentModel(ctx.serverDB, ctx.userId, ctx.workspaceId ?? undefined);
-        const config = await agentModel.getAgentConfigById(target.agentId);
-        if (config) {
-          await agentModel.update(target.agentId, {
-            plugins: (config.plugins ?? []).filter(
-              (entry) => parsePluginEntry(entry).identifier !== target.identifier,
-            ) as any,
-          });
-        }
-      }
     }),
 
   /**

--- a/apps/server/src/services/skill/importer.test.ts
+++ b/apps/server/src/services/skill/importer.test.ts
@@ -1,6 +1,14 @@
 // @vitest-environment node
 import type { LobeChatDatabase } from '@lobechat/database';
-import { agentSkills, files, globalFiles, users, workspaces } from '@lobechat/database/schemas';
+import {
+  agentSkills,
+  files,
+  globalFiles,
+  userConnectors,
+  userInstalledPlugins,
+  users,
+  workspaces,
+} from '@lobechat/database/schemas';
 import { getTestDB } from '@lobechat/database/test-utils';
 import { and, eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -185,6 +193,53 @@ describe('SkillImporter', () => {
       } catch (e) {
         expect((e as SkillImportError).code).toBe('CONFLICT');
       }
+    });
+
+    it('should reject an identifier used by a builtin tool', async () => {
+      await expect(
+        importer.createUserSkill({
+          content: '# Collision',
+          description: 'Conflicts with a builtin tool',
+          identifier: 'lobe-web-browsing',
+          name: 'Builtin Collision',
+        }),
+      ).rejects.toMatchObject({ code: 'CONFLICT' });
+    });
+
+    it('should reject an identifier used by an installed plugin', async () => {
+      await db.insert(userInstalledPlugins).values({
+        identifier: 'installed-plugin',
+        type: 'plugin',
+        userId,
+      });
+
+      await expect(
+        importer.createUserSkill({
+          content: '# Collision',
+          description: 'Conflicts with an installed plugin',
+          identifier: 'installed-plugin',
+          name: 'Plugin Collision',
+        }),
+      ).rejects.toMatchObject({ code: 'CONFLICT' });
+    });
+
+    it('should reject an identifier used by an installed connector', async () => {
+      await db.insert(userConnectors).values({
+        identifier: 'installed-connector',
+        name: 'Installed connector',
+        sourceType: 'custom',
+        status: 'connected',
+        userId,
+      });
+
+      await expect(
+        importer.createUserSkill({
+          content: '# Collision',
+          description: 'Conflicts with an installed connector',
+          identifier: 'installed-connector',
+          name: 'Connector Collision',
+        }),
+      ).rejects.toMatchObject({ code: 'CONFLICT' });
     });
 
     it('should store manifest with description', async () => {

--- a/apps/server/src/services/skill/importer.ts
+++ b/apps/server/src/services/skill/importer.ts
@@ -1,5 +1,7 @@
 import { readFile } from 'node:fs/promises';
 
+import { builtinSkills } from '@lobechat/builtin-skills';
+import { builtinTools } from '@lobechat/builtin-tools';
 import { type LobeChatDatabase } from '@lobechat/database';
 import { ssrfSafeFetch } from '@lobechat/ssrf-safe-fetch';
 import {
@@ -14,6 +16,8 @@ import { nanoid } from '@lobechat/utils';
 import debug from 'debug';
 
 import { AgentSkillModel } from '@/database/models/agentSkill';
+import { ConnectorModel } from '@/database/models/connector';
+import { PluginModel } from '@/database/models/plugin';
 import { GitHub, GitHubNotFoundError, GitHubParseError } from '@/server/modules/GitHub';
 import { FileService } from '@/server/services/file';
 
@@ -25,6 +29,8 @@ const log = debug('lobe-chat:service:skill-importer');
 
 export class SkillImporter {
   private skillModel: AgentSkillModel;
+  private connectorModel: ConnectorModel;
+  private pluginModel: PluginModel;
   private parser: SkillParser;
   private resourceService: SkillResourceService;
   private fileService: FileService;
@@ -40,6 +46,8 @@ export class SkillImporter {
     options?: { workspaceRole?: string },
   ) {
     this.skillModel = new AgentSkillModel(db, userId, workspaceId);
+    this.connectorModel = new ConnectorModel(db, userId, workspaceId);
+    this.pluginModel = new PluginModel(db, userId, workspaceId);
     this.parser = new SkillParser();
     this.resourceService = new SkillResourceService(db, userId, workspaceId);
     this.fileService = new FileService(db, userId, workspaceId);
@@ -47,6 +55,23 @@ export class SkillImporter {
     this.userId = userId;
     this.workspaceId = workspaceId;
     this.workspaceRole = options?.workspaceRole;
+  }
+
+  private async assertIdentifierAvailable(identifier: string) {
+    const isBuiltin =
+      builtinTools.some((tool) => tool.identifier === identifier) ||
+      builtinSkills.some((skill) => skill.identifier === identifier);
+    const [installedPlugin, installedConnector] = await Promise.all([
+      this.pluginModel.findById(identifier),
+      this.connectorModel.hasIdentifier(identifier),
+    ]);
+
+    if (isBuiltin || installedPlugin || installedConnector) {
+      throw new SkillImportError(
+        `Identifier "${identifier}" is already used by another tool`,
+        'CONFLICT',
+      );
+    }
   }
 
   /**
@@ -84,6 +109,7 @@ export class SkillImporter {
         'CONFLICT',
       );
     }
+    await this.assertIdentifierAvailable(identifier);
 
     const manifest: SkillManifest = {
       description: input.description || '',
@@ -131,15 +157,16 @@ export class SkillImporter {
         throw new SkillImportError(`Skill with name "${manifest.name}" already exists`, 'CONFLICT');
       }
 
-      // 4. Store resource files
+      // 4. Generate and validate identifier before storing resources.
+      const identifier = `user.${nanoid(12)}`;
+      await this.assertIdentifierAvailable(identifier);
+      log('importFromZip: generated identifier=%s', identifier);
+
+      // 5. Store resource files
       const resourceIds = zipHash
         ? await this.resourceService.storeResources(zipHash, resources)
         : {};
       log('importFromZip: stored resources=%o', resourceIds);
-
-      // 5. Generate identifier
-      const identifier = `user.${nanoid(12)}`;
-      log('importFromZip: generated identifier=%s', identifier);
 
       // 6. Create skill record
       const skill = await this.skillModel.create({
@@ -228,6 +255,7 @@ export class SkillImporter {
       );
       return { skill: existing, status: 'unchanged' };
     }
+    if (!existing) await this.assertIdentifierAvailable(identifier);
 
     // 6. Store resource files (only if skill is new or changed)
     log('importFromGitHub: storing %d resources...', resources.size);
@@ -420,6 +448,7 @@ export class SkillImporter {
 
     // 5. Check for existing skill
     const existing = await this.skillModel.findByIdentifier(identifier);
+    if (!existing) await this.assertIdentifierAvailable(identifier);
 
     // 6. Build manifest with source URL
     const fullManifest: SkillManifest = {

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/agentBuilder.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/agentBuilder.test.ts
@@ -88,7 +88,7 @@ describe('agentBuilderRuntime', () => {
       });
     });
 
-    it('disabling (enabled: false) reverts the entry to auto, removing it from the array', async () => {
+    it('disabling (enabled: false) persists an explicit auto entry', async () => {
       mockGetAgentConfigById.mockResolvedValue({
         id: 'agent-1',
         plugins: ['plugin-a', 'plugin-b'],
@@ -102,7 +102,9 @@ describe('agentBuilderRuntime', () => {
 
       expect(result.success).toBe(true);
       expect(result.state).toMatchObject({ agentId: 'agent-1' });
-      expect(mockUpdateConfig).toHaveBeenCalledWith('agent-1', { plugins: ['plugin-a'] });
+      expect(mockUpdateConfig).toHaveBeenCalledWith('agent-1', {
+        plugins: ['plugin-a', { identifier: 'plugin-b', mode: 'auto' }],
+      });
     });
 
     it('returns the invocation target for a successful no-op', async () => {

--- a/packages/database/src/models/__tests__/agent.test.ts
+++ b/packages/database/src/models/__tests__/agent.test.ts
@@ -1,5 +1,7 @@
 // @vitest-environment node
 import { DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE, INBOX_SESSION_ID } from '@lobechat/const';
+import type { AgentPluginEntry } from '@lobechat/types';
+import { getPluginMode } from '@lobechat/types';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -8,6 +10,7 @@ import type { NewAgent } from '../../schemas';
 import {
   agents,
   agentsFiles,
+  agentSkills,
   agentsKnowledgeBases,
   agentsToSessions,
   devices,
@@ -1344,6 +1347,59 @@ describe('AgentModel', () => {
   });
 
   describe('create', () => {
+    it('defaults existing custom skills to disabled without overriding explicit plugin modes', async () => {
+      await serverDB.insert(agentSkills).values([
+        {
+          description: 'Existing custom skill',
+          identifier: 'existing-custom-skill',
+          manifest: { description: 'Existing custom skill', name: 'Existing Custom Skill' },
+          name: 'Existing Custom Skill',
+          source: 'user',
+          userId,
+        },
+        {
+          description: 'Explicit custom skill',
+          identifier: 'explicit-custom-skill',
+          manifest: { description: 'Explicit custom skill', name: 'Explicit Custom Skill' },
+          name: 'Explicit Custom Skill',
+          source: 'user',
+          userId,
+        },
+      ]);
+
+      const result = await agentModel.create({
+        plugins: ['explicit-custom-skill'],
+        title: 'Agent Created After Skills',
+      });
+      const plugins = result.plugins as AgentPluginEntry[] | undefined;
+
+      expect(getPluginMode(plugins, 'existing-custom-skill')).toBe('disabled');
+      expect(getPluginMode(plugins, 'explicit-custom-skill')).toBe('pinned');
+    });
+
+    it('defaults workspace skills to disabled for agents created by another workspace member', async () => {
+      const [workspace] = await serverDB
+        .insert(workspaces)
+        .values({ name: 'skill-defaults', primaryOwnerId: userId, slug: 'skill-defaults' })
+        .returning();
+      await serverDB.insert(agentSkills).values({
+        description: 'Workspace custom skill',
+        identifier: 'workspace-custom-skill',
+        manifest: { description: 'Workspace custom skill', name: 'Workspace Custom Skill' },
+        name: 'Workspace Custom Skill',
+        source: 'user',
+        userId,
+        workspaceId: workspace.id,
+      });
+
+      const workspaceMemberAgentModel = new AgentModel(serverDB, userId2, workspace.id);
+      const result = await workspaceMemberAgentModel.create({ title: 'Workspace Member Agent' });
+
+      expect(
+        getPluginMode(result.plugins as AgentPluginEntry[] | undefined, 'workspace-custom-skill'),
+      ).toBe('disabled');
+    });
+
     it('should persist explicit selection policy defaults only for workspace agents', async () => {
       const [workspace] = await serverDB
         .insert(workspaces)
@@ -1511,6 +1567,33 @@ describe('AgentModel', () => {
   });
 
   describe('batchCreate', () => {
+    it('defaults existing custom skills to disabled for every created agent', async () => {
+      await serverDB.insert(agentSkills).values({
+        description: 'Existing batch custom skill',
+        identifier: 'existing-batch-custom-skill',
+        manifest: { description: 'Existing batch custom skill', name: 'Batch Custom Skill' },
+        name: 'Batch Custom Skill',
+        source: 'user',
+        userId,
+      });
+
+      const created = await agentModel.batchCreate([
+        { title: 'Batch Agent A' },
+        { plugins: ['already-pinned-plugin'], title: 'Batch Agent B' },
+      ]);
+
+      expect(created).toHaveLength(2);
+      for (const agent of created) {
+        expect(
+          getPluginMode(
+            agent.plugins as AgentPluginEntry[] | undefined,
+            'existing-batch-custom-skill',
+          ),
+        ).toBe('disabled');
+      }
+      expect(created[1].plugins).toContain('already-pinned-plugin');
+    });
+
     it('should drop reserved builtin slugs in a batch', async () => {
       const created = await agentModel.batchCreate([
         { slug: 'inbox', title: 'Squatter A' },

--- a/packages/database/src/models/__tests__/agent.test.ts
+++ b/packages/database/src/models/__tests__/agent.test.ts
@@ -25,8 +25,10 @@ import {
 } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
 import { AgentModel } from '../agent';
+import { AgentSkillModel } from '../agentSkill';
 
 const serverDB: LobeChatDatabase = await getTestDB();
+const isServerDB = process.env.TEST_SERVER_DB === '1';
 
 const userId = 'agent-model-test-user-id';
 const userId2 = 'agent-model-test-user-id-2';
@@ -796,6 +798,25 @@ describe('AgentModel', () => {
   });
 
   describe('update', () => {
+    it('keeps scoped custom skills disabled when a full plugins array omits them', async () => {
+      await serverDB.insert(agentSkills).values({
+        description: 'Update path skill',
+        identifier: 'update-path-skill',
+        manifest: { description: 'Update path skill', name: 'Update Path Skill' },
+        name: 'Update Path Skill',
+        source: 'user',
+        userId,
+      });
+      const agent = await agentModel.create({ title: 'Update Path Agent' });
+
+      await agentModel.update(agent.id, { plugins: ['caller-plugin'] as unknown as string[] });
+
+      const updated = await serverDB.query.agents.findFirst({ where: eq(agents.id, agent.id) });
+      const plugins = updated?.plugins as AgentPluginEntry[] | undefined;
+      expect(getPluginMode(plugins, 'caller-plugin')).toBe('pinned');
+      expect(getPluginMode(plugins, 'update-path-skill')).toBe('disabled');
+    });
+
     it('should update agent fields and set updatedAt', async () => {
       const agent = await serverDB
         .insert(agents)
@@ -1146,6 +1167,135 @@ describe('AgentModel', () => {
   });
 
   describe('updateConfig', () => {
+    it('preserves a committed skill default when a stale full plugins array is written later', async () => {
+      const [agent] = await serverDB
+        .insert(agents)
+        .values({ plugins: ['original-plugin'], userId })
+        .returning();
+      await new AgentSkillModel(serverDB, userId).create({
+        description: 'Committed config skill',
+        identifier: 'committed-config-skill',
+        manifest: { description: 'Committed config skill', name: 'Committed Config Skill' },
+        name: 'Committed Config Skill',
+        source: 'user',
+      });
+
+      await agentModel.updateConfig(agent.id, { plugins: ['stale-caller-plugin'] });
+
+      const updated = await serverDB.query.agents.findFirst({ where: eq(agents.id, agent.id) });
+      const plugins = updated?.plugins as AgentPluginEntry[] | undefined;
+      expect(getPluginMode(plugins, 'stale-caller-plugin')).toBe('pinned');
+      expect(getPluginMode(plugins, 'committed-config-skill')).toBe('disabled');
+    });
+
+    it('preserves an explicit auto selection for a custom skill', async () => {
+      await serverDB.insert(agentSkills).values({
+        description: 'Explicit auto skill',
+        identifier: 'explicit-auto-skill',
+        manifest: { description: 'Explicit auto skill', name: 'Explicit Auto Skill' },
+        name: 'Explicit Auto Skill',
+        source: 'user',
+        userId,
+      });
+      const agent = await agentModel.create({ title: 'Explicit Auto Agent' });
+
+      await agentModel.updateConfig(agent.id, {
+        plugins: [{ identifier: 'explicit-auto-skill', mode: 'auto' }] as unknown as string[],
+      });
+
+      const updated = await serverDB.query.agents.findFirst({ where: eq(agents.id, agent.id) });
+      expect(
+        getPluginMode(updated?.plugins as AgentPluginEntry[] | undefined, 'explicit-auto-skill'),
+      ).toBe('auto');
+    });
+
+    it('does not default scoped custom skills to disabled for inbox records', async () => {
+      await serverDB.insert(agentSkills).values({
+        description: 'Inbox config skill',
+        identifier: 'inbox-config-skill',
+        manifest: { description: 'Inbox config skill', name: 'Inbox Config Skill' },
+        name: 'Inbox Config Skill',
+        source: 'user',
+        userId,
+      });
+      const [inbox, historicalInbox] = await serverDB
+        .insert(agents)
+        .values([
+          { slug: INBOX_SESSION_ID, userId },
+          { slug: 'historical-inbox-agent', userId },
+        ])
+        .returning();
+      const [inboxSession] = await serverDB
+        .insert(sessions)
+        .values({ slug: INBOX_SESSION_ID, userId })
+        .returning();
+      await serverDB
+        .insert(agentsToSessions)
+        .values({ agentId: historicalInbox.id, sessionId: inboxSession.id, userId });
+
+      await agentModel.updateConfig(inbox.id, { plugins: ['inbox-plugin'] });
+      await agentModel.updateConfig(historicalInbox.id, { plugins: ['historical-inbox-plugin'] });
+
+      const updated = await serverDB.query.agents.findMany({
+        where: (agent, { inArray }) => inArray(agent.id, [inbox.id, historicalInbox.id]),
+      });
+      for (const agent of updated) {
+        expect(
+          getPluginMode(agent.plugins as AgentPluginEntry[] | undefined, 'inbox-config-skill'),
+        ).toBe('auto');
+      }
+    });
+
+    it.skipIf(!isServerDB)(
+      'preserves a disabled entry when a skill commits before a queued full-array plugin write',
+      async () => {
+        const [agent] = await serverDB
+          .insert(agents)
+          .values({ plugins: ['original-plugin'], userId })
+          .returning();
+        const skillModel = new AgentSkillModel(serverDB, userId);
+
+        let signalScopeLocked!: () => void;
+        let releaseScopeLock!: () => void;
+        const scopeLocked = new Promise<void>((resolve) => {
+          signalScopeLocked = resolve;
+        });
+        const holdScopeLock = new Promise<void>((resolve) => {
+          releaseScopeLock = resolve;
+        });
+        const blocker = serverDB.transaction(async (trx) => {
+          await trx.select({ id: users.id }).from(users).where(eq(users.id, userId)).for('update');
+          signalScopeLocked();
+          await holdScopeLock;
+        });
+
+        await scopeLocked;
+        const skillCreation = skillModel.create({
+          description: 'Concurrent config skill',
+          identifier: 'concurrent-config-skill',
+          manifest: { description: 'Concurrent config skill', name: 'Concurrent Config Skill' },
+          name: 'Concurrent Config Skill',
+          source: 'user',
+        });
+        // Queue skill creation first; updateConfig then waits on the same scope
+        // lock and must merge the newly committed identifier before writing.
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        const configUpdate = agentModel.updateConfig(agent.id, { plugins: ['updated-plugin'] });
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        releaseScopeLock();
+        await Promise.all([blocker, skillCreation, configUpdate]);
+
+        const updated = await serverDB.query.agents.findFirst({
+          where: eq(agents.id, agent.id),
+        });
+        const plugins = updated?.plugins as AgentPluginEntry[] | undefined;
+
+        expect(getPluginMode(plugins, 'updated-plugin')).toBe('pinned');
+        expect(getPluginMode(plugins, 'concurrent-config-skill')).toBe('disabled');
+      },
+    );
+
     it('should update agent config and set updatedAt', async () => {
       const agent = await serverDB
         .insert(agents)

--- a/packages/database/src/models/__tests__/agent.test.ts
+++ b/packages/database/src/models/__tests__/agent.test.ts
@@ -2075,6 +2075,47 @@ describe('AgentModel', () => {
         expect(result?.slug).toBe('task-agent');
         expect(result?.virtual).toBe(true);
       });
+
+      it('reconciles custom skill defaults for an existing non-inbox builtin agent', async () => {
+        const originalUpdatedAt = new Date('2024-01-02T03:04:05.000Z');
+        await serverDB.insert(agentSkills).values({
+          description: 'Skill created before the builtin is read',
+          identifier: 'legacy-builtin-custom-skill',
+          manifest: { description: 'Legacy builtin skill', name: 'Legacy Builtin Skill' },
+          name: 'Legacy Builtin Skill',
+          source: 'user',
+          userId,
+        });
+        const [existing] = await serverDB
+          .insert(agents)
+          .values({
+            plugins: ['existing-plugin'],
+            slug: 'page-agent',
+            updatedAt: originalUpdatedAt,
+            userId,
+            virtual: true,
+          })
+          .returning();
+
+        const result = await agentModel.getBuiltinAgent('page-agent');
+        const persisted = await serverDB.query.agents.findFirst({
+          where: eq(agents.id, existing.id),
+        });
+
+        expect(
+          getPluginMode(
+            result?.plugins as AgentPluginEntry[] | undefined,
+            'legacy-builtin-custom-skill',
+          ),
+        ).toBe('disabled');
+        expect(
+          getPluginMode(
+            persisted?.plugins as AgentPluginEntry[] | undefined,
+            'legacy-builtin-custom-skill',
+          ),
+        ).toBe('disabled');
+        expect(persisted?.updatedAt).toEqual(originalUpdatedAt);
+      });
     });
 
     describe('workspace mode', () => {

--- a/packages/database/src/models/__tests__/agent.test.ts
+++ b/packages/database/src/models/__tests__/agent.test.ts
@@ -303,6 +303,7 @@ describe('AgentModel', () => {
 
     it('lazily backfills disabled policies for agents that predate custom-skill defaults', async () => {
       const agentId = 'legacy-agent-before-skill-defaults';
+      const originalUpdatedAt = new Date('2024-01-02T03:04:05.000Z');
       await serverDB.insert(agentSkills).values([
         {
           description: 'Legacy missing policy skill',
@@ -326,6 +327,7 @@ describe('AgentModel', () => {
         plugins: [
           { identifier: 'legacy-explicit-policy-skill', mode: 'auto' },
         ] as unknown as string[],
+        updatedAt: originalUpdatedAt,
         userId,
       });
 
@@ -350,6 +352,7 @@ describe('AgentModel', () => {
           'legacy-missing-policy-skill',
         ),
       ).toBe('disabled');
+      expect(persisted?.updatedAt).toEqual(originalUpdatedAt);
     });
 
     it('keeps a historical session-linked inbox implicit auto during lazy reconciliation', async () => {

--- a/packages/database/src/models/__tests__/agent.test.ts
+++ b/packages/database/src/models/__tests__/agent.test.ts
@@ -301,6 +301,86 @@ describe('AgentModel', () => {
       expect(result?.id).toBe(agentId);
     });
 
+    it('lazily backfills disabled policies for agents that predate custom-skill defaults', async () => {
+      const agentId = 'legacy-agent-before-skill-defaults';
+      await serverDB.insert(agentSkills).values([
+        {
+          description: 'Legacy missing policy skill',
+          identifier: 'legacy-missing-policy-skill',
+          manifest: { description: 'Legacy missing policy skill', name: 'Legacy Missing Policy' },
+          name: 'Legacy Missing Policy',
+          source: 'user',
+          userId,
+        },
+        {
+          description: 'Legacy explicit policy skill',
+          identifier: 'legacy-explicit-policy-skill',
+          manifest: { description: 'Legacy explicit policy skill', name: 'Legacy Explicit Policy' },
+          name: 'Legacy Explicit Policy',
+          source: 'user',
+          userId,
+        },
+      ]);
+      await serverDB.insert(agents).values({
+        id: agentId,
+        plugins: [
+          { identifier: 'legacy-explicit-policy-skill', mode: 'auto' },
+        ] as unknown as string[],
+        userId,
+      });
+
+      const result = await agentModel.getAgentConfig(agentId);
+      const persisted = await serverDB.query.agents.findFirst({ where: eq(agents.id, agentId) });
+
+      expect(
+        getPluginMode(
+          result?.plugins as AgentPluginEntry[] | undefined,
+          'legacy-missing-policy-skill',
+        ),
+      ).toBe('disabled');
+      expect(
+        getPluginMode(
+          result?.plugins as AgentPluginEntry[] | undefined,
+          'legacy-explicit-policy-skill',
+        ),
+      ).toBe('auto');
+      expect(
+        getPluginMode(
+          persisted?.plugins as AgentPluginEntry[] | undefined,
+          'legacy-missing-policy-skill',
+        ),
+      ).toBe('disabled');
+    });
+
+    it('keeps a historical session-linked inbox implicit auto during lazy reconciliation', async () => {
+      const agentId = 'legacy-session-linked-inbox-reconciliation';
+      await serverDB.insert(agentSkills).values({
+        description: 'Inbox reconciliation skill',
+        identifier: 'inbox-reconciliation-skill',
+        manifest: { description: 'Inbox reconciliation skill', name: 'Inbox Reconciliation' },
+        name: 'Inbox Reconciliation',
+        source: 'user',
+        userId,
+      });
+      await serverDB.insert(agents).values({ id: agentId, userId });
+      await serverDB
+        .insert(sessions)
+        .values({ id: 'legacy-reconciliation-session', slug: 'inbox', userId });
+      await serverDB.insert(agentsToSessions).values({
+        agentId,
+        sessionId: 'legacy-reconciliation-session',
+        userId,
+      });
+
+      const result = await agentModel.getAgentConfigById(agentId);
+      const persisted = await serverDB.query.agents.findFirst({ where: eq(agents.id, agentId) });
+
+      expect(getPluginMode(result?.plugins ?? undefined, 'inbox-reconciliation-skill')).toBe(
+        'auto',
+      );
+      expect(persisted?.plugins).toBeNull();
+    });
+
     it('should find agent by slug when ID does not match', async () => {
       const agentId = 'test-agent-slug';
       const slug = 'my-agent-slug';

--- a/packages/database/src/models/__tests__/agentSkill.test.ts
+++ b/packages/database/src/models/__tests__/agentSkill.test.ts
@@ -279,26 +279,55 @@ describe('AgentSkillModel', () => {
   });
 
   describe('delete', () => {
-    it('should delete an agent skill by id', async () => {
+    it('removes agent policies before the identifier is reused by another skill', async () => {
+      const identifier = 'reused-deleted-skill';
+      const originalUpdatedAt = new Date('2024-01-02T03:04:05.000Z');
+      await serverDB.insert(agents).values({
+        id: 'deleted-skill-policy-agent',
+        plugins: [{ identifier, mode: 'auto' }, 'kept-plugin'] as unknown as string[],
+        updatedAt: originalUpdatedAt,
+        userId,
+      });
       const { id } = await serverDB
         .insert(agentSkills)
         .values({
-          name: 'To Delete',
-          description: 'To delete skill',
-          identifier: 'to.delete',
-          source: 'user',
+          description: 'Skill whose identifier will be reused',
+          identifier,
           manifest: createManifest(),
+          name: 'To Delete',
+          source: 'user',
           userId,
         })
         .returning()
         .then((res) => res[0]);
 
-      await agentSkillModel.delete(id);
+      const result = await agentSkillModel.delete(id);
 
       const skill = await serverDB.query.agentSkills.findFirst({
         where: eq(agentSkills.id, id),
       });
+      const agentAfterDelete = await serverDB.query.agents.findFirst({
+        where: eq(agents.id, 'deleted-skill-policy-agent'),
+      });
+      expect(result).toEqual({ success: true });
       expect(skill).toBeUndefined();
+      expect(agentAfterDelete?.plugins).toEqual(['kept-plugin']);
+      expect(agentAfterDelete?.updatedAt).toEqual(originalUpdatedAt);
+
+      await agentSkillModel.create({
+        description: 'Replacement skill with the reused identifier',
+        identifier,
+        manifest: createManifest(),
+        name: 'Replacement Skill',
+        source: 'user',
+      });
+
+      const agentAfterReuse = await serverDB.query.agents.findFirst({
+        where: eq(agents.id, 'deleted-skill-policy-agent'),
+      });
+      expect(
+        getPluginMode(agentAfterReuse?.plugins as AgentPluginEntry[] | undefined, identifier),
+      ).toBe('disabled');
     });
   });
 

--- a/packages/database/src/models/__tests__/agentSkill.test.ts
+++ b/packages/database/src/models/__tests__/agentSkill.test.ts
@@ -5,8 +5,9 @@ import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../core/getTestDB';
-import { agents, agentSkills, users } from '../../schemas';
+import { agents, agentSkills, agentsToSessions, sessions, users, workspaces } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
+import { AgentModel } from '../agent';
 import { AgentSkillModel } from '../agentSkill';
 
 const serverDB: LobeChatDatabase = await getTestDB();
@@ -69,6 +70,12 @@ describe('AgentSkillModel', () => {
           userId,
           virtual: true,
         },
+        {
+          id: 'skill-default-explicit-agent',
+          plugins: [{ identifier: 'new-custom-skill', mode: 'pinned' }] as unknown as string[],
+          slug: 'explicit-agent',
+          userId,
+        },
       ]);
 
       await agentSkillModel.create({
@@ -99,8 +106,175 @@ describe('AgentSkillModel', () => {
           'new-custom-skill',
         ),
       ).toBe('disabled');
-      expect(pluginsByAgentId.get('skill-default-inbox')).toContain('existing-inbox-plugin');
+      expect(
+        getPluginMode(
+          pluginsByAgentId.get('skill-default-explicit-agent') ?? undefined,
+          'new-custom-skill',
+        ),
+      ).toBe('pinned');
+      expect(pluginsByAgentId.get('skill-default-inbox')).toEqual(['existing-inbox-plugin']);
       expect(pluginsByAgentId.get('skill-default-agent')).toContain('existing-agent-plugin');
+    });
+
+    it('keeps a legacy session-linked inbox on the implicit auto default', async () => {
+      await serverDB.insert(agents).values({
+        id: 'legacy-inbox-agent',
+        plugins: ['existing-inbox-plugin'],
+        slug: null,
+        userId,
+      });
+      await serverDB.insert(sessions).values({ id: 'legacy-inbox-session', slug: 'inbox', userId });
+      await serverDB.insert(agentsToSessions).values({
+        agentId: 'legacy-inbox-agent',
+        sessionId: 'legacy-inbox-session',
+        userId,
+      });
+
+      await agentSkillModel.create({
+        description: 'A newly added custom skill',
+        identifier: 'legacy-inbox-custom-skill',
+        manifest: createManifest(),
+        name: 'Legacy Inbox Custom Skill',
+        source: 'user',
+      });
+
+      const inbox = await serverDB.query.agents.findFirst({
+        where: eq(agents.id, 'legacy-inbox-agent'),
+      });
+      expect(inbox?.plugins).toEqual(['existing-inbox-plugin']);
+      expect(
+        getPluginMode(
+          inbox?.plugins as AgentPluginEntry[] | undefined,
+          'legacy-inbox-custom-skill',
+        ),
+      ).toBe('auto');
+    });
+
+    it('initializes a large agent set without dropping any agent', async () => {
+      const agentCount = 100;
+      await serverDB.insert(agents).values(
+        Array.from({ length: agentCount }, (_, index) => ({
+          id: `large-agent-set-${index}`,
+          slug: `large-agent-${index}`,
+          userId,
+        })),
+      );
+
+      await agentSkillModel.create({
+        description: 'A skill shared with many agents',
+        identifier: 'large-agent-set-skill',
+        manifest: createManifest(),
+        name: 'Large Agent Set Skill',
+        source: 'user',
+      });
+
+      const configuredAgents = await serverDB.query.agents.findMany({
+        where: eq(agents.userId, userId),
+      });
+      expect(configuredAgents).toHaveLength(agentCount);
+      expect(
+        configuredAgents.every(
+          ({ plugins }) =>
+            getPluginMode(plugins as AgentPluginEntry[] | undefined, 'large-agent-set-skill') ===
+            'disabled',
+        ),
+      ).toBe(true);
+    });
+
+    it('initializes every non-inbox agent in a shared workspace', async () => {
+      const workspaceMemberId = 'agent-skill-workspace-member';
+      await serverDB.insert(users).values({ id: workspaceMemberId });
+      const [workspace] = await serverDB
+        .insert(workspaces)
+        .values({
+          name: 'Agent Skill Workspace',
+          primaryOwnerId: userId,
+          slug: 'agent-skill-workspace',
+        })
+        .returning();
+      await serverDB.insert(agents).values([
+        {
+          id: 'workspace-owner-agent',
+          userId,
+          visibility: 'private',
+          workspaceId: workspace.id,
+        },
+        {
+          id: 'workspace-member-agent',
+          userId: workspaceMemberId,
+          visibility: 'private',
+          workspaceId: workspace.id,
+        },
+      ]);
+
+      const workspaceSkillModel = new AgentSkillModel(serverDB, userId, workspace.id);
+      await workspaceSkillModel.create({
+        description: 'A workspace custom skill',
+        identifier: 'workspace-shared-skill',
+        manifest: createManifest(),
+        name: 'Workspace Shared Skill',
+        source: 'user',
+      });
+
+      const workspaceAgents = await serverDB.query.agents.findMany({
+        where: eq(agents.workspaceId, workspace.id),
+      });
+      expect(workspaceAgents).toHaveLength(2);
+      expect(
+        workspaceAgents.every(
+          ({ plugins }) =>
+            getPluginMode(plugins as AgentPluginEntry[] | undefined, 'workspace-shared-skill') ===
+            'disabled',
+        ),
+      ).toBe(true);
+    });
+
+    it('preserves both entries when two skills are created concurrently', async () => {
+      await serverDB.insert(agents).values({ id: 'concurrent-skill-agent', userId });
+
+      await Promise.all([
+        agentSkillModel.create({
+          description: 'Concurrent skill A',
+          identifier: 'concurrent-skill-a',
+          manifest: createManifest(),
+          name: 'Concurrent Skill A',
+          source: 'user',
+        }),
+        agentSkillModel.create({
+          description: 'Concurrent skill B',
+          identifier: 'concurrent-skill-b',
+          manifest: createManifest(),
+          name: 'Concurrent Skill B',
+          source: 'user',
+        }),
+      ]);
+
+      const agent = await serverDB.query.agents.findFirst({
+        where: eq(agents.id, 'concurrent-skill-agent'),
+      });
+      const plugins = agent?.plugins as AgentPluginEntry[] | undefined;
+
+      expect(getPluginMode(plugins, 'concurrent-skill-a')).toBe('disabled');
+      expect(getPluginMode(plugins, 'concurrent-skill-b')).toBe('disabled');
+    });
+
+    it('defaults to disabled when a skill and regular agent are created concurrently', async () => {
+      const concurrentAgentModel = new AgentModel(serverDB, userId);
+
+      const [, agent] = await Promise.all([
+        agentSkillModel.create({
+          description: 'Skill created alongside an agent',
+          identifier: 'skill-created-with-agent',
+          manifest: createManifest(),
+          name: 'Skill Created With Agent',
+          source: 'user',
+        }),
+        concurrentAgentModel.create({ title: 'Agent Created With Skill' }),
+      ]);
+
+      expect(
+        getPluginMode(agent.plugins as AgentPluginEntry[] | undefined, 'skill-created-with-agent'),
+      ).toBe('disabled');
     });
   });
 

--- a/packages/database/src/models/__tests__/agentSkill.test.ts
+++ b/packages/database/src/models/__tests__/agentSkill.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment node
-import type { SkillManifest } from '@lobechat/types';
+import type { AgentPluginEntry, SkillManifest } from '@lobechat/types';
+import { getPluginMode } from '@lobechat/types';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../core/getTestDB';
-import { agentSkills, users } from '../../schemas';
+import { agents, agentSkills, users } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
 import { AgentSkillModel } from '../agentSkill';
 
@@ -45,6 +46,61 @@ describe('AgentSkillModel', () => {
 
       expect(skill).toMatchObject(params);
       expect(skill.id).toBeDefined();
+    });
+
+    it('defaults a new skill to auto for inbox and disabled for every other agent', async () => {
+      await serverDB.insert(agents).values([
+        {
+          id: 'skill-default-inbox',
+          plugins: ['existing-inbox-plugin'],
+          slug: 'inbox',
+          userId,
+          virtual: true,
+        },
+        {
+          id: 'skill-default-agent',
+          plugins: ['existing-agent-plugin'],
+          slug: 'custom-agent',
+          userId,
+        },
+        {
+          id: 'skill-default-virtual-agent',
+          slug: 'virtual-agent',
+          userId,
+          virtual: true,
+        },
+      ]);
+
+      await agentSkillModel.create({
+        content: '# New custom skill',
+        description: 'A newly added custom skill',
+        identifier: 'new-custom-skill',
+        manifest: createManifest(),
+        name: 'New Custom Skill',
+        source: 'user',
+      });
+
+      const configuredAgents = await serverDB.query.agents.findMany({
+        where: eq(agents.userId, userId),
+      });
+      const pluginsByAgentId = new Map(
+        configuredAgents.map((agent) => [agent.id, agent.plugins as AgentPluginEntry[] | null]),
+      );
+
+      expect(
+        getPluginMode(pluginsByAgentId.get('skill-default-inbox') ?? undefined, 'new-custom-skill'),
+      ).toBe('auto');
+      expect(
+        getPluginMode(pluginsByAgentId.get('skill-default-agent') ?? undefined, 'new-custom-skill'),
+      ).toBe('disabled');
+      expect(
+        getPluginMode(
+          pluginsByAgentId.get('skill-default-virtual-agent') ?? undefined,
+          'new-custom-skill',
+        ),
+      ).toBe('disabled');
+      expect(pluginsByAgentId.get('skill-default-inbox')).toContain('existing-inbox-plugin');
+      expect(pluginsByAgentId.get('skill-default-agent')).toContain('existing-agent-plugin');
     });
   });
 

--- a/packages/database/src/models/__tests__/agentTransfer.test.ts
+++ b/packages/database/src/models/__tests__/agentTransfer.test.ts
@@ -1,4 +1,6 @@
 // @vitest-environment node
+import type { AgentPluginEntry } from '@lobechat/types';
+import { getPluginMode } from '@lobechat/types';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -8,6 +10,7 @@ import {
   agentCronJobs,
   agents,
   agentsFiles,
+  agentSkills,
   agentsKnowledgeBases,
   agentsToSessions,
   briefs,
@@ -818,6 +821,27 @@ describe('AgentModel.transferAgent', () => {
 });
 
 describe('AgentModel.transferAgents (batch)', () => {
+  it('defaults target workspace skills to disabled while preserving existing modes', async () => {
+    await serverDB.insert(agentSkills).values({
+      description: 'Target transfer skill',
+      identifier: 'target-transfer-skill',
+      manifest: { description: 'Target transfer skill', name: 'Target Transfer Skill' },
+      name: 'Target Transfer Skill',
+      source: 'user',
+      userId: targetUserId,
+      workspaceId: wsId2,
+    });
+    const model = new AgentModel(serverDB, userId, wsId1);
+    const agent = await model.create({ plugins: ['existing-plugin'], title: 'Transferred Agent' });
+
+    await model.transferAgents([agent.id], wsId2, targetUserId);
+
+    const updated = await serverDB.query.agents.findFirst({ where: eq(agents.id, agent.id) });
+    const plugins = updated?.plugins as AgentPluginEntry[] | undefined;
+    expect(getPluginMode(plugins, 'existing-plugin')).toBe('pinned');
+    expect(getPluginMode(plugins, 'target-transfer-skill')).toBe('disabled');
+  });
+
   it('should transfer multiple agents with their topics and messages in one call', async () => {
     const model = new AgentModel(serverDB, userId);
     const agent1 = await model.create({ title: 'Agent 1' });

--- a/packages/database/src/models/__tests__/connector.test.ts
+++ b/packages/database/src/models/__tests__/connector.test.ts
@@ -599,6 +599,44 @@ describe('ConnectorModel', () => {
       ]);
     });
 
+    it('preserves the policy of an agent-owned copy when its base connector is deleted', async () => {
+      const identifier = 'copied-base-connector';
+      await serverDB.insert(agents).values([
+        {
+          id: 'connector-copy-agent',
+          plugins: [{ identifier, mode: 'pinned' }] as unknown as string[],
+          userId,
+        },
+        {
+          id: 'connector-base-only-agent',
+          plugins: [{ identifier, mode: 'pinned' }] as unknown as string[],
+          userId,
+        },
+      ]);
+      const model = new ConnectorModel(serverDB, userId);
+      const base = await model.create({
+        identifier,
+        name: 'Base Connector',
+        sourceType: 'custom',
+        status: 'connected',
+      });
+      await model.copyToAgent(base.id, 'connector-copy-agent');
+
+      await model.delete(base.id);
+
+      const policiesAfterDelete = await serverDB.query.agents.findMany({
+        where: (table, { inArray }) =>
+          inArray(table.id, ['connector-copy-agent', 'connector-base-only-agent']),
+      });
+      const pluginsByAgentId = new Map(
+        policiesAfterDelete.map((agent) => [agent.id, agent.plugins]),
+      );
+      expect(pluginsByAgentId.get('connector-copy-agent')).toEqual([
+        { identifier, mode: 'pinned' },
+      ]);
+      expect(pluginsByAgentId.get('connector-base-only-agent')).toEqual([]);
+    });
+
     it('does not delete connectors owned by another user', async () => {
       const otherModel = new ConnectorModel(serverDB, otherUserId);
       const created = await otherModel.create({

--- a/packages/database/src/models/__tests__/connector.test.ts
+++ b/packages/database/src/models/__tests__/connector.test.ts
@@ -7,7 +7,7 @@ import { getTestDB } from '../../core/getTestDB';
 import type { ConnectorCredentials } from '../../schemas';
 import { agents, userConnectors, users, workspaces } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
-import { AgentSkillModel } from '../agentSkill';
+import { AgentSkillModel, lockAgentSkillScope } from '../agentSkill';
 import { ConnectorModel } from '../connector';
 
 const serverDB: LobeChatDatabase = await getTestDB();
@@ -635,6 +635,40 @@ describe('ConnectorModel', () => {
         { identifier, mode: 'pinned' },
       ]);
       expect(pluginsByAgentId.get('connector-base-only-agent')).toEqual([]);
+    });
+
+    it('serializes policy cleanup with a concurrent agent writer', async () => {
+      const identifier = 'concurrently-deleted-connector';
+      const model = new ConnectorModel(serverDB, userId);
+      const connector = await model.create({
+        identifier,
+        name: 'Concurrent Connector',
+        sourceType: 'custom',
+        status: 'connected',
+      });
+
+      let notifyLockAcquired!: () => void;
+      const lockAcquired = new Promise<void>((resolve) => {
+        notifyLockAcquired = resolve;
+      });
+      const agentWriter = serverDB.transaction(async (trx) => {
+        await lockAgentSkillScope(trx, { userId });
+        notifyLockAcquired();
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        await trx.insert(agents).values({
+          id: 'concurrent-connector-policy-agent',
+          plugins: [{ identifier, mode: 'auto' }] as unknown as string[],
+          userId,
+        });
+      });
+
+      await lockAcquired;
+      await Promise.all([agentWriter, model.delete(connector.id)]);
+
+      const agent = await serverDB.query.agents.findFirst({
+        where: (table, { eq }) => eq(table.id, 'concurrent-connector-policy-agent'),
+      });
+      expect(agent?.plugins).toEqual([]);
     });
 
     it('does not delete connectors owned by another user', async () => {

--- a/packages/database/src/models/__tests__/connector.test.ts
+++ b/packages/database/src/models/__tests__/connector.test.ts
@@ -1,3 +1,5 @@
+import type { AgentPluginEntry } from '@lobechat/types';
+import { getPluginMode } from '@lobechat/types';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -5,6 +7,7 @@ import { getTestDB } from '../../core/getTestDB';
 import type { ConnectorCredentials } from '../../schemas';
 import { agents, userConnectors, users, workspaces } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
+import { AgentSkillModel } from '../agentSkill';
 import { ConnectorModel } from '../connector';
 
 const serverDB: LobeChatDatabase = await getTestDB();
@@ -498,6 +501,102 @@ describe('ConnectorModel', () => {
       await model.delete(created.id);
 
       expect(await model.findById(created.id)).toBeNull();
+    });
+
+    it('removes base connector policies before its identifier is reused by a custom skill', async () => {
+      const identifier = 'reused-base-connector';
+      const originalUpdatedAt = new Date('2024-01-02T03:04:05.000Z');
+      const model = new ConnectorModel(serverDB, userId);
+      const created = await model.create({
+        identifier,
+        name: 'Base Connector',
+        sourceType: 'custom',
+        status: 'connected',
+      });
+      await serverDB.insert(agents).values([
+        {
+          id: 'base-connector-object-policy-agent',
+          plugins: [{ identifier, mode: 'pinned' }, 'kept-plugin'] as unknown as string[],
+          updatedAt: originalUpdatedAt,
+          userId,
+        },
+        {
+          id: 'base-connector-string-policy-agent',
+          plugins: [identifier],
+          userId,
+        },
+      ]);
+
+      await model.delete(created.id);
+
+      const policiesAfterDelete = await serverDB.query.agents.findMany({
+        where: (table, { eq }) => eq(table.userId, userId),
+      });
+      const policiesByAgentId = new Map(policiesAfterDelete.map((agent) => [agent.id, agent]));
+      expect(policiesByAgentId.get('base-connector-object-policy-agent')?.plugins).toEqual([
+        'kept-plugin',
+      ]);
+      expect(policiesByAgentId.get('base-connector-object-policy-agent')?.updatedAt).toEqual(
+        originalUpdatedAt,
+      );
+      expect(policiesByAgentId.get('base-connector-string-policy-agent')?.plugins).toEqual([]);
+
+      const agentSkillModel = new AgentSkillModel(serverDB, userId);
+      await agentSkillModel.create({
+        description: 'Skill reusing a deleted connector identifier',
+        identifier,
+        manifest: { description: 'Replacement skill', name: 'Replacement Skill' },
+        name: 'Replacement Skill',
+        source: 'user',
+      });
+
+      const policiesAfterReuse = await serverDB.query.agents.findMany({
+        where: (table, { eq }) => eq(table.userId, userId),
+      });
+      expect(
+        policiesAfterReuse.every(
+          ({ plugins }) =>
+            getPluginMode(plugins as AgentPluginEntry[] | undefined, identifier) === 'disabled',
+        ),
+      ).toBe(true);
+    });
+
+    it('removes an agent-owned connector policy only from its owning agent', async () => {
+      const identifier = 'agent-owned-connector';
+      await serverDB.insert(agents).values([
+        {
+          id: 'connector-owner-agent',
+          plugins: [{ identifier, mode: 'auto' }] as unknown as string[],
+          userId,
+        },
+        {
+          id: 'connector-other-agent',
+          plugins: [{ identifier, mode: 'pinned' }] as unknown as string[],
+          userId,
+        },
+      ]);
+      const model = new ConnectorModel(serverDB, userId);
+      const created = await model.create({
+        agentId: 'connector-owner-agent',
+        identifier,
+        name: 'Agent Connector',
+        sourceType: 'custom',
+        status: 'connected',
+      });
+
+      await model.delete(created.id);
+
+      const policiesAfterDelete = await serverDB.query.agents.findMany({
+        where: (table, { inArray }) =>
+          inArray(table.id, ['connector-owner-agent', 'connector-other-agent']),
+      });
+      const pluginsByAgentId = new Map(
+        policiesAfterDelete.map((agent) => [agent.id, agent.plugins]),
+      );
+      expect(pluginsByAgentId.get('connector-owner-agent')).toEqual([]);
+      expect(pluginsByAgentId.get('connector-other-agent')).toEqual([
+        { identifier, mode: 'pinned' },
+      ]);
     });
 
     it('does not delete connectors owned by another user', async () => {

--- a/packages/database/src/models/__tests__/plugin.test.ts
+++ b/packages/database/src/models/__tests__/plugin.test.ts
@@ -1,10 +1,13 @@
 // @vitest-environment node
+import type { AgentPluginEntry } from '@lobechat/types';
+import { getPluginMode } from '@lobechat/types';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../core/getTestDB';
 import type { NewInstalledPlugin } from '../../schemas';
-import { userInstalledPlugins, users } from '../../schemas';
+import { agents, userInstalledPlugins, users } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
+import { AgentSkillModel } from '../agentSkill';
 import { PluginModel } from '../plugin';
 
 const serverDB: LobeChatDatabase = await getTestDB();
@@ -56,6 +59,72 @@ describe('PluginModel', () => {
 
       const result = await serverDB.select().from(userInstalledPlugins);
       expect(result).toHaveLength(0);
+    });
+
+    it('removes stale agent policies before the identifier is reused by a custom skill', async () => {
+      const identifier = 'reused-plugin-identifier';
+      const originalUpdatedAt = new Date('2024-01-02T03:04:05.000Z');
+      await serverDB.insert(userInstalledPlugins).values({
+        identifier,
+        manifest: { name: 'Plugin to remove' },
+        type: 'plugin',
+        userId,
+      } as unknown as NewInstalledPlugin);
+      await serverDB.insert(agents).values([
+        {
+          id: 'plugin-policy-object-agent',
+          plugins: [{ identifier, mode: 'auto' }, 'kept-plugin'] as unknown as string[],
+          updatedAt: originalUpdatedAt,
+          userId,
+        },
+        {
+          id: 'plugin-policy-string-agent',
+          plugins: [
+            identifier,
+            { identifier: 'kept-disabled', mode: 'disabled' },
+          ] as unknown as string[],
+          userId,
+        },
+        {
+          id: 'other-user-plugin-policy-agent',
+          plugins: [{ identifier, mode: 'auto' }] as unknown as string[],
+          userId: '456',
+        },
+      ]);
+
+      await pluginModel.delete(identifier);
+
+      const policiesAfterDelete = await serverDB.query.agents.findMany();
+      const policiesByAgentId = new Map(policiesAfterDelete.map((agent) => [agent.id, agent]));
+      expect(policiesByAgentId.get('plugin-policy-object-agent')?.plugins).toEqual(['kept-plugin']);
+      expect(policiesByAgentId.get('plugin-policy-object-agent')?.updatedAt).toEqual(
+        originalUpdatedAt,
+      );
+      expect(policiesByAgentId.get('plugin-policy-string-agent')?.plugins).toEqual([
+        { identifier: 'kept-disabled', mode: 'disabled' },
+      ]);
+      expect(policiesByAgentId.get('other-user-plugin-policy-agent')?.plugins).toEqual([
+        { identifier, mode: 'auto' },
+      ]);
+
+      const agentSkillModel = new AgentSkillModel(serverDB, userId);
+      await agentSkillModel.create({
+        description: 'Skill reusing a removed plugin identifier',
+        identifier,
+        manifest: { description: 'Reused identifier skill', name: 'Reused Identifier Skill' },
+        name: 'Reused Identifier Skill',
+        source: 'user',
+      });
+
+      const policiesAfterReuse = await serverDB.query.agents.findMany({
+        where: (table, { eq }) => eq(table.userId, userId),
+      });
+      expect(
+        policiesAfterReuse.every(
+          ({ plugins }) =>
+            getPluginMode(plugins as AgentPluginEntry[] | undefined, identifier) === 'disabled',
+        ),
+      ).toBe(true);
     });
   });
 

--- a/packages/database/src/models/__tests__/plugin.test.ts
+++ b/packages/database/src/models/__tests__/plugin.test.ts
@@ -8,6 +8,7 @@ import type { NewInstalledPlugin } from '../../schemas';
 import { agents, userInstalledPlugins, users } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
 import { AgentSkillModel } from '../agentSkill';
+import { ConnectorModel } from '../connector';
 import { PluginModel } from '../plugin';
 
 const serverDB: LobeChatDatabase = await getTestDB();
@@ -125,6 +126,37 @@ describe('PluginModel', () => {
             getPluginMode(plugins as AgentPluginEntry[] | undefined, identifier) === 'disabled',
         ),
       ).toBe(true);
+    });
+
+    it('preserves policies when a legacy plugin is replaced by a connector', async () => {
+      const identifier = 'migrated-legacy-plugin';
+      await serverDB.insert(userInstalledPlugins).values({
+        identifier,
+        manifest: { name: 'Legacy plugin' },
+        type: 'customPlugin',
+        userId,
+      } as unknown as NewInstalledPlugin);
+      await serverDB.insert(agents).values({
+        id: 'legacy-plugin-agent',
+        plugins: [{ identifier, mode: 'pinned' }] as unknown as string[],
+        userId,
+      });
+
+      // The migration creates and syncs the replacement connector before
+      // uninstalling the legacy plugin under the same identifier.
+      const connectorModel = new ConnectorModel(serverDB, userId);
+      await connectorModel.create({
+        identifier,
+        name: 'Migrated Connector',
+        sourceType: 'custom',
+        status: 'connected',
+      });
+      await pluginModel.delete(identifier);
+
+      const agent = await serverDB.query.agents.findFirst({
+        where: (table, { eq }) => eq(table.id, 'legacy-plugin-agent'),
+      });
+      expect(agent?.plugins).toEqual([{ identifier, mode: 'pinned' }]);
     });
   });
 

--- a/packages/database/src/models/__tests__/plugin.test.ts
+++ b/packages/database/src/models/__tests__/plugin.test.ts
@@ -7,7 +7,7 @@ import { getTestDB } from '../../core/getTestDB';
 import type { NewInstalledPlugin } from '../../schemas';
 import { agents, userInstalledPlugins, users } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
-import { AgentSkillModel } from '../agentSkill';
+import { AgentSkillModel, lockAgentSkillScope } from '../agentSkill';
 import { ConnectorModel } from '../connector';
 import { PluginModel } from '../plugin';
 
@@ -157,6 +157,39 @@ describe('PluginModel', () => {
         where: (table, { eq }) => eq(table.id, 'legacy-plugin-agent'),
       });
       expect(agent?.plugins).toEqual([{ identifier, mode: 'pinned' }]);
+    });
+
+    it('serializes policy cleanup with a concurrent agent writer', async () => {
+      const identifier = 'concurrently-deleted-plugin';
+      await serverDB.insert(userInstalledPlugins).values({
+        identifier,
+        manifest: { name: 'Concurrent plugin' },
+        type: 'plugin',
+        userId,
+      } as unknown as NewInstalledPlugin);
+
+      let notifyLockAcquired!: () => void;
+      const lockAcquired = new Promise<void>((resolve) => {
+        notifyLockAcquired = resolve;
+      });
+      const agentWriter = serverDB.transaction(async (trx) => {
+        await lockAgentSkillScope(trx, { userId });
+        notifyLockAcquired();
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        await trx.insert(agents).values({
+          id: 'concurrent-plugin-policy-agent',
+          plugins: [{ identifier, mode: 'auto' }] as unknown as string[],
+          userId,
+        });
+      });
+
+      await lockAcquired;
+      await Promise.all([agentWriter, pluginModel.delete(identifier)]);
+
+      const agent = await serverDB.query.agents.findFirst({
+        where: (table, { eq }) => eq(table.id, 'concurrent-plugin-policy-agent'),
+      });
+      expect(agent?.plugins).toEqual([]);
     });
   });
 

--- a/packages/database/src/models/__tests__/session.test.ts
+++ b/packages/database/src/models/__tests__/session.test.ts
@@ -1,4 +1,6 @@
 import { DEFAULT_AGENT_CONFIG } from '@lobechat/const';
+import type { AgentPluginEntry } from '@lobechat/types';
+import { getPluginMode } from '@lobechat/types';
 import { and, eq, inArray } from 'drizzle-orm';
 import type { LLMParams } from 'model-bank';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -7,6 +9,7 @@ import { getTestDB } from '../../core/getTestDB';
 import type { NewSession, SessionItem } from '../../schemas';
 import {
   agents,
+  agentSkills,
   agentsToSessions,
   messages,
   sessionGroups,
@@ -367,6 +370,45 @@ describe('SessionModel', () => {
   });
 
   describe('create', () => {
+    it('defaults existing skills to disabled for a regular agent but auto for inbox', async () => {
+      await serverDB.insert(agentSkills).values({
+        description: 'Existing session custom skill',
+        identifier: 'existing-session-custom-skill',
+        manifest: { description: 'Existing session custom skill', name: 'Session Custom Skill' },
+        name: 'Session Custom Skill',
+        source: 'user',
+        userId,
+      });
+
+      const regularSession = await sessionModel.create({
+        config: {},
+        session: { title: 'Regular Session' },
+        type: 'agent',
+      });
+      const inboxSession = await sessionModel.create({
+        config: {},
+        session: { title: 'Inbox' },
+        slug: 'inbox',
+        type: 'agent',
+      });
+
+      const regular = await sessionModel.findByIdOrSlug(regularSession.id);
+      const inbox = await sessionModel.findByIdOrSlug(inboxSession.id);
+
+      expect(
+        getPluginMode(
+          regular?.agent.plugins as AgentPluginEntry[] | undefined,
+          'existing-session-custom-skill',
+        ),
+      ).toBe('disabled');
+      expect(
+        getPluginMode(
+          inbox?.agent.plugins as AgentPluginEntry[] | undefined,
+          'existing-session-custom-skill',
+        ),
+      ).toBe('auto');
+    });
+
     it('should create a new session', async () => {
       // Call the create method
       const result = await sessionModel.create({

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -1478,7 +1478,11 @@ export class AgentModel {
       where: and(eq(agents.slug, slug), this.ownership()),
     });
 
-    if (existing) return normalizeInboxAgentMeta(existing, { slug: existing.slug });
+    if (existing) {
+      return this.reconcileAgentSkillDefaults(
+        normalizeInboxAgentMeta(existing, { slug: existing.slug }),
+      );
+    }
 
     // For inbox agent, it has special compatibility handling:
     // Historical inbox was stored as session with slug='inbox' and linked agent via agentsToSessions

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -217,6 +217,49 @@ export class AgentModel {
     buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, agentsToSessions);
 
   /**
+   * Lazily reconcile agents created before custom-skill defaults were persisted.
+   * The fast path is read-only once every scoped skill already has a policy
+   * entry. Missing entries are rechecked under the shared scope lock before
+   * writing, so a concurrent skill creation cannot be lost.
+   */
+  private reconcileAgentSkillDefaults = async (agent: AgentItem): Promise<AgentItem | null> => {
+    if (agent.slug === INBOX_SESSION_ID) return agent;
+
+    const scope = { userId: this.userId, workspaceId: this.workspaceId };
+    const skillIdentifiers = await getScopedAgentSkillIdentifiers(this.db, scope);
+    const plugins = appendDisabledAgentSkillDefaults(
+      agent.plugins as AgentPluginEntry[] | null,
+      skillIdentifiers,
+    );
+    if ((plugins?.length ?? 0) === (agent.plugins?.length ?? 0)) return agent;
+
+    return this.db.transaction(async (trx) => {
+      await lockAgentSkillScope(trx, scope);
+      const currentAgent = await trx.query.agents.findFirst({
+        where: and(eq(agents.id, agent.id), this.ownership()),
+      });
+      if (!currentAgent) return null;
+      if (await isInboxAgentRecord(trx, currentAgent.id)) return currentAgent;
+
+      const currentSkillIdentifiers = await getScopedAgentSkillIdentifiers(trx, scope);
+      const currentPlugins = appendDisabledAgentSkillDefaults(
+        currentAgent.plugins as AgentPluginEntry[] | null,
+        currentSkillIdentifiers,
+      );
+      if ((currentPlugins?.length ?? 0) === (currentAgent.plugins?.length ?? 0)) {
+        return currentAgent;
+      }
+
+      const [updatedAgent] = await trx
+        .update(agents)
+        .set({ plugins: currentPlugins as string[] })
+        .where(and(eq(agents.id, currentAgent.id), this.ownership()))
+        .returning();
+      return updatedAgent ?? currentAgent;
+    });
+  };
+
+  /**
    * Collect device ids that an incoming `agencyConfig` patch is *setting*
    * (not clearing). `workingDirByDevice` entries with `undefined` value are
    * deletes (per `pruneWorkingDirByDeviceDeletes`) and are skipped.
@@ -340,7 +383,10 @@ export class AgentModel {
 
     if (!agent) return null;
 
-    return this.enrichAgentWithKnowledge(agent);
+    const reconciledAgent = await this.reconcileAgentSkillDefaults(agent);
+    if (!reconciledAgent) return null;
+
+    return this.enrichAgentWithKnowledge(reconciledAgent);
   };
 
   /**
@@ -640,7 +686,10 @@ export class AgentModel {
 
     if (!agent) return null;
 
-    return this.enrichAgentWithKnowledge(agent);
+    const reconciledAgent = await this.reconcileAgentSkillDefaults(agent);
+    if (!reconciledAgent) return null;
+
+    return this.enrichAgentWithKnowledge(reconciledAgent);
   };
 
   /**

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -58,6 +58,7 @@ import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
 import {
   appendDisabledAgentSkillDefaults,
   getScopedAgentSkillIdentifiers,
+  isInboxAgentRecord,
   lockAgentSkillScope,
 } from './agentSkill';
 import {
@@ -994,6 +995,29 @@ export class AgentModel {
       this.stripImmutableFields(data),
     );
 
+    if (sanitizedData.plugins !== undefined) {
+      return this.db.transaction(async (trx) => {
+        const scope = { userId: this.userId, workspaceId: this.workspaceId };
+        await lockAgentSkillScope(trx, scope);
+        const skillIdentifiers = await getScopedAgentSkillIdentifiers(trx, scope);
+        const plugins = (await isInboxAgentRecord(trx, agentId))
+          ? sanitizedData.plugins
+          : appendDisabledAgentSkillDefaults(
+              sanitizedData.plugins as AgentPluginEntry[] | null,
+              skillIdentifiers,
+            );
+
+        return trx
+          .update(agents)
+          .set({
+            ...sanitizedData,
+            plugins: plugins as string[] | undefined,
+            updatedAt: new Date(),
+          })
+          .where(and(eq(agents.id, agentId), this.ownership()));
+      });
+    }
+
     return this.db
       .update(agents)
       .set({ ...sanitizedData, updatedAt: new Date() })
@@ -1194,9 +1218,37 @@ export class AgentModel {
   updateConfig = async (agentId: string, input: PartialDeep<AgentItem> | undefined | null) => {
     if (!input || Object.keys(input).length === 0) return;
 
+    if (input.plugins === undefined) {
+      return this.updateConfigWithExecutor(this.db, agentId, input);
+    }
+
+    const scope = { userId: this.userId, workspaceId: this.workspaceId };
+
+    return this.db.transaction(async (trx) => {
+      await lockAgentSkillScope(trx, scope);
+      const skillIdentifiers = await getScopedAgentSkillIdentifiers(trx, scope);
+      const plugins = (await isInboxAgentRecord(trx, agentId))
+        ? input.plugins
+        : appendDisabledAgentSkillDefaults(
+            input.plugins as AgentPluginEntry[] | null,
+            skillIdentifiers,
+          );
+      const synchronizedInput = { ...input, plugins: plugins as string[] | undefined };
+
+      return this.updateConfigWithExecutor(trx, agentId, synchronizedInput);
+    });
+  };
+
+  private updateConfigWithExecutor = async (
+    executor: LobeChatDatabase,
+    agentId: string,
+    input: PartialDeep<AgentItem> | undefined | null,
+  ) => {
+    if (!input || Object.keys(input).length === 0) return;
+
     const data = this.stripImmutableFields(input);
 
-    const agent = await this.db.query.agents.findFirst({
+    const agent = await executor.query.agents.findFirst({
       where: and(eq(agents.id, agentId), this.ownership()),
     });
 
@@ -1291,7 +1343,7 @@ export class AgentModel {
 
     const { updatedAt: _, accessedAt: __, createdAt: ___, ...updateData } = mergedValue;
 
-    return this.db
+    return executor
       .update(agents)
       .set(updateData)
       .where(and(eq(agents.id, agentId), this.ownership()));
@@ -1577,6 +1629,24 @@ export class AgentModel {
       if (foundAgents.length !== new Set(agentIds).size) throw new Error('Agent not found');
       const agentById = new Map(foundAgents.map((agent) => [agent.id, agent]));
 
+      const targetScope = {
+        userId: targetUserId,
+        workspaceId: targetWorkspaceId ?? undefined,
+      };
+      await lockAgentSkillScope(trx, targetScope);
+      const targetSkillIdentifiers = await getScopedAgentSkillIdentifiers(trx, targetScope);
+      const historicalInboxLinks = await trx
+        .select({ agentId: agentsToSessions.agentId })
+        .from(agentsToSessions)
+        .innerJoin(sessions, eq(sessions.id, agentsToSessions.sessionId))
+        .where(
+          and(inArray(agentsToSessions.agentId, agentIds), eq(sessions.slug, INBOX_SESSION_ID)),
+        );
+      const inboxAgentIds = new Set([
+        ...foundAgents.filter((agent) => agent.slug === INBOX_SESSION_ID).map((agent) => agent.id),
+        ...historicalInboxLinks.map(({ agentId }) => agentId),
+      ]);
+
       // 2. Resolve slug conflicts in the target scope with a single query:
       //    fetch every existing slug that could collide (exact match or
       //    `<slug>-<n>` suffix), then pick free suffixes in memory. Agents
@@ -1726,6 +1796,12 @@ export class AgentModel {
             agencyConfig: targetWorkspaceId
               ? (resolvedAgencyConfigs.get(agent.id) ?? null)
               : (agent.agencyConfig ?? null),
+            plugins: inboxAgentIds.has(agent.id)
+              ? agent.plugins
+              : (appendDisabledAgentSkillDefaults(
+                  agent.plugins as AgentPluginEntry[] | null,
+                  targetSkillIdentifiers,
+                ) as string[] | undefined),
             sessionGroupId: null,
             slug: resolvedSlugs.get(agent.id) ?? agent.slug,
             // A scope transfer does not make the agent's content newer. Keep the

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -252,7 +252,7 @@ export class AgentModel {
 
       const [updatedAgent] = await trx
         .update(agents)
-        .set({ plugins: currentPlugins as string[] })
+        .set({ plugins: currentPlugins as string[], updatedAt: agents.updatedAt })
         .where(and(eq(agents.id, currentAgent.id), this.ownership()))
         .returning();
       return updatedAgent ?? currentAgent;

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -1,6 +1,6 @@
 import { BUILTIN_AGENT_SLUGS, getAgentPersistConfig } from '@lobechat/builtin-agents';
 import { INBOX_SESSION_ID, isHeterogeneousAgentModelId } from '@lobechat/const';
-import type { AgentRankItem, LobeAgentAgencyConfig } from '@lobechat/types';
+import type { AgentPluginEntry, AgentRankItem, LobeAgentAgencyConfig } from '@lobechat/types';
 import {
   DEFAULT_WORKSPACE_AGENT_SELECTION_POLICIES,
   pruneWorkingDirByDeviceDeletes,
@@ -55,6 +55,11 @@ import type { LobeChatDatabase } from '../type';
 import { genEndDateWhere, genRangeWhere, genStartDateWhere, genWhere } from '../utils/genWhere';
 import { normalizeInboxAgentMeta } from '../utils/inboxAgent';
 import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
+import {
+  appendDisabledAgentSkillDefaults,
+  getScopedAgentSkillIdentifiers,
+  lockAgentSkillScope,
+} from './agentSkill';
 import {
   hasForeignTopicComments,
   syncTopicCommentsOnTopicTransfer,
@@ -917,19 +922,26 @@ export class AgentModel {
     await this.assertWorkspaceDeviceBinding(this.workspaceId ?? null, agencyConfig);
     await this.assertFixedExecutionTarget(this.workspaceId ?? null, agencyConfig);
 
-    const [result] = await this.db
-      .insert(agents)
-      .values([
-        buildWorkspacePayload(
-          { userId: this.userId, workspaceId: this.workspaceId },
-          {
+    const [result] = await this.db.transaction(async (trx) => {
+      const scope = { userId: this.userId, workspaceId: this.workspaceId };
+      await lockAgentSkillScope(trx, scope);
+      const skillIdentifiers = await getScopedAgentSkillIdentifiers(trx, scope);
+
+      return trx
+        .insert(agents)
+        .values([
+          buildWorkspacePayload(scope, {
             ...config,
             agencyConfig,
             model: typeof config.model === 'string' ? config.model : null,
-          },
-        ),
-      ])
-      .returning();
+            plugins: appendDisabledAgentSkillDefaults(
+              config.plugins as AgentPluginEntry[] | null | undefined,
+              skillIdentifiers,
+            ) as string[] | undefined,
+          }),
+        ])
+        .returning();
+    });
 
     return result;
   };
@@ -953,20 +965,27 @@ export class AgentModel {
       ]),
     );
 
-    return this.db
-      .insert(agents)
-      .values(
-        normalizedConfigs.map((config) =>
-          buildWorkspacePayload(
-            { userId: this.userId, workspaceId: this.workspaceId },
-            {
+    return this.db.transaction(async (trx) => {
+      const scope = { userId: this.userId, workspaceId: this.workspaceId };
+      await lockAgentSkillScope(trx, scope);
+      const skillIdentifiers = await getScopedAgentSkillIdentifiers(trx, scope);
+
+      return trx
+        .insert(agents)
+        .values(
+          normalizedConfigs.map((config) =>
+            buildWorkspacePayload(scope, {
               ...config,
               model: typeof config.model === 'string' ? config.model : null,
-            },
+              plugins: appendDisabledAgentSkillDefaults(
+                config.plugins as AgentPluginEntry[] | null | undefined,
+                skillIdentifiers,
+              ) as string[] | undefined,
+            }),
           ),
-        ),
-      )
-      .returning();
+        )
+        .returning();
+    });
   };
 
   update = async (agentId: string, data: Partial<AgentItem>) => {
@@ -1296,20 +1315,24 @@ export class AgentModel {
    * Returns the new agent ID.
    */
   duplicate = async (agentId: string, newTitle?: string): Promise<{ agentId: string } | null> => {
-    // Get the source agent
-    const sourceAgent = await this.db.query.agents.findFirst({
-      where: and(eq(agents.id, agentId), this.ownership()),
-    });
+    return this.db.transaction(async (trx) => {
+      const scope = { userId: this.userId, workspaceId: this.workspaceId };
+      await lockAgentSkillScope(trx, scope);
 
-    if (!sourceAgent) return null;
+      // Get the source agent
+      const sourceAgent = await trx.query.agents.findFirst({
+        where: and(eq(agents.id, agentId), this.ownership()),
+      });
 
-    // Create new agent with explicit include fields
-    const [newAgent] = await this.db
-      .insert(agents)
-      .values(
-        buildWorkspacePayload(
-          { userId: this.userId, workspaceId: this.workspaceId },
-          {
+      if (!sourceAgent) return null;
+
+      const skillIdentifiers = await getScopedAgentSkillIdentifiers(trx, scope);
+
+      // Create new agent with explicit include fields
+      const [newAgent] = await trx
+        .insert(agents)
+        .values(
+          buildWorkspacePayload(scope, {
             avatar: sourceAgent.avatar,
             backgroundColor: sourceAgent.backgroundColor,
             chatConfig: sourceAgent.chatConfig,
@@ -1321,7 +1344,10 @@ export class AgentModel {
             params: sourceAgent.params,
             pinned: sourceAgent.pinned,
             // Config
-            plugins: sourceAgent.plugins,
+            plugins: appendDisabledAgentSkillDefaults(
+              sourceAgent.plugins as AgentPluginEntry[] | null,
+              skillIdentifiers,
+            ) as string[] | undefined,
             provider: sourceAgent.provider,
 
             // Session group
@@ -1332,12 +1358,12 @@ export class AgentModel {
             // Metadata
             title: newTitle || (sourceAgent.title ? `${sourceAgent.title} (Copy)` : 'Copy'),
             tts: sourceAgent.tts,
-          },
-        ),
-      )
-      .returning();
+          }),
+        )
+        .returning();
 
-    return { agentId: newAgent.id };
+      return { agentId: newAgent.id };
+    });
   };
 
   /**
@@ -1396,22 +1422,28 @@ export class AgentModel {
     // partitioned { target, where } once 0109 has flipped the index in every
     // environment. Payload still carries workspaceId so workspace-scoped
     // builtin agents land in the right workspace.
-    const result = await this.db
-      .insert(agents)
-      .values(
-        buildWorkspacePayload(
-          { userId: this.userId, workspaceId: this.workspaceId },
-          {
+    const result = await this.db.transaction(async (trx) => {
+      const scope = { userId: this.userId, workspaceId: this.workspaceId };
+      await lockAgentSkillScope(trx, scope);
+      const skillIdentifiers =
+        slug === INBOX_SESSION_ID ? [] : await getScopedAgentSkillIdentifiers(trx, scope);
+
+      return trx
+        .insert(agents)
+        .values(
+          buildWorkspacePayload(scope, {
             agencyConfig: this.withWorkspaceSelectionPolicyDefaults(undefined),
             model: persistConfig.model,
+            plugins: appendDisabledAgentSkillDefaults(undefined, skillIdentifiers) as
+              string[] | undefined,
             provider: persistConfig.provider,
             slug: persistConfig.slug,
             virtual: true,
-          },
-        ),
-      )
-      .onConflictDoNothing()
-      .returning();
+          }),
+        )
+        .onConflictDoNothing()
+        .returning();
+    });
 
     if (result[0]) return normalizeInboxAgentMeta(result[0], { slug: result[0].slug });
 

--- a/packages/database/src/models/agentSkill.ts
+++ b/packages/database/src/models/agentSkill.ts
@@ -14,6 +14,36 @@ interface AgentSkillScope {
   workspaceId?: string;
 }
 
+export const removeAgentPluginPolicyEntries = async (
+  executor: LobeChatDatabase,
+  scope: AgentSkillScope,
+  identifier: string,
+  agentId?: string,
+) => {
+  const agentScope = buildWorkspaceWhere(scope, {
+    userId: agents.userId,
+    workspaceId: agents.workspaceId,
+  });
+
+  await executor.execute(sql`
+    update ${agents}
+    set ${sql.identifier('plugins')} = (
+      select coalesce(jsonb_agg(plugin.entry order by plugin.ordinality), '[]'::jsonb)
+      from jsonb_array_elements(coalesce(${agents.plugins}, '[]'::jsonb))
+        with ordinality as plugin(entry, ordinality)
+      where plugin.entry #>> '{}' is distinct from ${identifier}
+        and plugin.entry ->> 'identifier' is distinct from ${identifier}
+    )
+    where ${and(agentScope, agentId ? eq(agents.id, agentId) : undefined)}
+      and exists (
+        select 1
+        from jsonb_array_elements(coalesce(${agents.plugins}, '[]'::jsonb)) as plugin(entry)
+        where plugin.entry #>> '{}' = ${identifier}
+           or plugin.entry ->> 'identifier' = ${identifier}
+      )
+  `);
+};
+
 // Agent and skill creation take the same parent-row lock so overlapping
 // transactions cannot each miss the other's still-uncommitted row.
 export const lockAgentSkillScope = async (trx: Transaction, scope: AgentSkillScope) => {
@@ -272,10 +302,19 @@ export class AgentSkillModel {
   // ========== Delete ==========
 
   delete = async (id: string): Promise<{ success: boolean }> => {
-    const result = await this.db
-      .delete(agentSkills)
-      .where(and(eq(agentSkills.id, id), this.scopeWhere()));
+    return this.db.transaction(async (trx) => {
+      const scope = { userId: this.userId, workspaceId: this.workspaceId };
+      await lockAgentSkillScope(trx, scope);
+      const [deleted] = await trx
+        .delete(agentSkills)
+        .where(and(eq(agentSkills.id, id), this.scopeWhere()))
+        .returning({ identifier: agentSkills.identifier });
 
-    return { success: (result.rowCount ?? 0) > 0 };
+      if (!deleted) return { success: false };
+
+      await removeAgentPluginPolicyEntries(trx, scope, deleted.identifier);
+
+      return { success: true };
+    });
   };
 }

--- a/packages/database/src/models/agentSkill.ts
+++ b/packages/database/src/models/agentSkill.ts
@@ -1,9 +1,11 @@
-import type { SkillItem, SkillListItem } from '@lobechat/types';
+import { INBOX_SESSION_ID } from '@lobechat/const';
+import type { AgentPluginEntry, SkillItem, SkillListItem } from '@lobechat/types';
+import { getPluginMode, upsertPluginMode } from '@lobechat/types';
 import { merge } from '@lobechat/utils';
 import { and, desc, eq, ilike, inArray, or, sql } from 'drizzle-orm';
 
 import type { NewAgentSkill } from '../schemas';
-import { agentSkills } from '../schemas';
+import { agents, agentSkills } from '../schemas';
 import type { LobeChatDatabase } from '../type';
 import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
 
@@ -52,14 +54,47 @@ export class AgentSkillModel {
   private scopeWhere = () =>
     buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, agentSkills);
 
+  // Workspace skills are shared, so initialize every agent in the workspace,
+  // including private agents owned by other members.
+  private agentScopeWhere = () =>
+    buildWorkspaceWhere(
+      { userId: this.userId, workspaceId: this.workspaceId },
+      { userId: agents.userId, workspaceId: agents.workspaceId },
+    );
+
   // ========== Create ==========
 
   create = async (data: Omit<NewAgentSkill, 'userId' | 'workspaceId'>): Promise<SkillItem> => {
-    const [result] = await this.db
-      .insert(agentSkills)
-      .values(buildWorkspacePayload({ userId: this.userId, workspaceId: this.workspaceId }, data))
-      .returning(skillItemColumns);
-    return result;
+    return this.db.transaction(async (trx) => {
+      const [result] = await trx
+        .insert(agentSkills)
+        .values(buildWorkspacePayload({ userId: this.userId, workspaceId: this.workspaceId }, data))
+        .returning(skillItemColumns);
+
+      const scopedAgents = await trx
+        .select({ id: agents.id, plugins: agents.plugins, slug: agents.slug })
+        .from(agents)
+        .where(this.agentScopeWhere());
+
+      for (const agent of scopedAgents) {
+        const plugins = agent.plugins as AgentPluginEntry[] | null;
+        const defaultMode = agent.slug === INBOX_SESSION_ID ? 'auto' : 'disabled';
+        if (getPluginMode(plugins ?? undefined, data.identifier) === defaultMode) continue;
+
+        await trx
+          .update(agents)
+          .set({
+            plugins: upsertPluginMode(
+              plugins ?? undefined,
+              data.identifier,
+              defaultMode,
+            ) as string[],
+          })
+          .where(and(eq(agents.id, agent.id), this.agentScopeWhere()));
+      }
+
+      return result;
+    });
   };
 
   // ========== Read ==========

--- a/packages/database/src/models/agentSkill.ts
+++ b/packages/database/src/models/agentSkill.ts
@@ -1,13 +1,63 @@
 import { INBOX_SESSION_ID } from '@lobechat/const';
 import type { AgentPluginEntry, SkillItem, SkillListItem } from '@lobechat/types';
-import { getPluginMode, upsertPluginMode } from '@lobechat/types';
+import { parsePluginEntry } from '@lobechat/types';
 import { merge } from '@lobechat/utils';
-import { and, desc, eq, ilike, inArray, or, sql } from 'drizzle-orm';
+import { and, desc, eq, ilike, inArray, isNull, ne, notExists, or, sql } from 'drizzle-orm';
 
 import type { NewAgentSkill } from '../schemas';
-import { agents, agentSkills } from '../schemas';
-import type { LobeChatDatabase } from '../type';
+import { agents, agentSkills, agentsToSessions, sessions, users, workspaces } from '../schemas';
+import type { LobeChatDatabase, Transaction } from '../type';
 import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
+
+interface AgentSkillScope {
+  userId: string;
+  workspaceId?: string;
+}
+
+// Agent and skill creation take the same parent-row lock so overlapping
+// transactions cannot each miss the other's still-uncommitted row.
+export const lockAgentSkillScope = async (trx: Transaction, scope: AgentSkillScope) => {
+  if (scope.workspaceId) {
+    await trx
+      .select({ id: workspaces.id })
+      .from(workspaces)
+      .where(eq(workspaces.id, scope.workspaceId))
+      .for('update');
+    return;
+  }
+
+  await trx.select({ id: users.id }).from(users).where(eq(users.id, scope.userId)).for('update');
+};
+
+export const getScopedAgentSkillIdentifiers = async (
+  trx: Transaction,
+  scope: AgentSkillScope,
+): Promise<string[]> => {
+  const rows = await trx
+    .select({ identifier: agentSkills.identifier })
+    .from(agentSkills)
+    .where(buildWorkspaceWhere(scope, agentSkills));
+
+  return rows.map(({ identifier }) => identifier);
+};
+
+export const appendDisabledAgentSkillDefaults = (
+  plugins: AgentPluginEntry[] | null | undefined,
+  skillIdentifiers: string[],
+): AgentPluginEntry[] | undefined => {
+  if (skillIdentifiers.length === 0) return plugins ?? undefined;
+
+  const next = plugins ? [...plugins] : [];
+  const configuredIdentifiers = new Set(next.map((entry) => parsePluginEntry(entry).identifier));
+
+  for (const identifier of skillIdentifiers) {
+    if (configuredIdentifiers.has(identifier)) continue;
+    next.push({ identifier, mode: 'disabled' });
+    configuredIdentifiers.add(identifier);
+  }
+
+  return next;
+};
 
 const skillItemColumns = {
   content: agentSkills.content,
@@ -66,32 +116,46 @@ export class AgentSkillModel {
 
   create = async (data: Omit<NewAgentSkill, 'userId' | 'workspaceId'>): Promise<SkillItem> => {
     return this.db.transaction(async (trx) => {
+      await lockAgentSkillScope(trx, { userId: this.userId, workspaceId: this.workspaceId });
+
       const [result] = await trx
         .insert(agentSkills)
         .values(buildWorkspacePayload({ userId: this.userId, workspaceId: this.workspaceId }, data))
         .returning(skillItemColumns);
 
-      const scopedAgents = await trx
-        .select({ id: agents.id, plugins: agents.plugins, slug: agents.slug })
-        .from(agents)
-        .where(this.agentScopeWhere());
-
-      for (const agent of scopedAgents) {
-        const plugins = agent.plugins as AgentPluginEntry[] | null;
-        const defaultMode = agent.slug === INBOX_SESSION_ID ? 'auto' : 'disabled';
-        if (getPluginMode(plugins ?? undefined, data.identifier) === defaultMode) continue;
-
-        await trx
-          .update(agents)
-          .set({
-            plugins: upsertPluginMode(
-              plugins ?? undefined,
-              data.identifier,
-              defaultMode,
-            ) as string[],
-          })
-          .where(and(eq(agents.id, agent.id), this.agentScopeWhere()));
-      }
+      // Keep inbox on the implicit `auto` default. For every other existing agent,
+      // atomically append a disabled entry only when the identifier is absent.
+      // This is one set-based UPDATE, so concurrent skill imports retain each
+      // other's entries and existing user-selected modes are left untouched.
+      await trx.execute(sql`
+        update ${agents}
+        set ${sql.identifier('plugins')} =
+          coalesce(${agents.plugins}, '[]'::jsonb)
+          || jsonb_build_array(
+            jsonb_build_object('identifier', (${data.identifier})::text, 'mode', 'disabled')
+          )
+        where ${and(
+          this.agentScopeWhere(),
+          or(isNull(agents.slug), ne(agents.slug, INBOX_SESSION_ID)),
+          // Historical inbox agents may only be identifiable through their
+          // linked session, before getBuiltinAgent backfills agents.slug.
+          notExists(
+            trx
+              .select({ agentId: agentsToSessions.agentId })
+              .from(agentsToSessions)
+              .innerJoin(sessions, eq(sessions.id, agentsToSessions.sessionId))
+              .where(
+                and(eq(agentsToSessions.agentId, agents.id), eq(sessions.slug, INBOX_SESSION_ID)),
+              ),
+          ),
+          sql`not exists (
+              select 1
+              from jsonb_array_elements(coalesce(${agents.plugins}, '[]'::jsonb)) as plugin(entry)
+              where plugin.entry #>> '{}' = ${data.identifier}
+                 or plugin.entry ->> 'identifier' = ${data.identifier}
+            )`,
+        )}
+      `);
 
       return result;
     });

--- a/packages/database/src/models/agentSkill.ts
+++ b/packages/database/src/models/agentSkill.ts
@@ -30,10 +30,10 @@ export const lockAgentSkillScope = async (trx: Transaction, scope: AgentSkillSco
 };
 
 export const getScopedAgentSkillIdentifiers = async (
-  trx: Transaction,
+  executor: LobeChatDatabase,
   scope: AgentSkillScope,
 ): Promise<string[]> => {
-  const rows = await trx
+  const rows = await executor
     .select({ identifier: agentSkills.identifier })
     .from(agentSkills)
     .where(buildWorkspaceWhere(scope, agentSkills));
@@ -57,6 +57,25 @@ export const appendDisabledAgentSkillDefaults = (
   }
 
   return next;
+};
+
+export const isInboxAgentRecord = async (executor: LobeChatDatabase, agentId: string) => {
+  const [agent] = await executor
+    .select({ slug: agents.slug })
+    .from(agents)
+    .where(eq(agents.id, agentId))
+    .limit(1);
+
+  if (agent?.slug === INBOX_SESSION_ID) return true;
+
+  const [inboxSession] = await executor
+    .select({ agentId: agentsToSessions.agentId })
+    .from(agentsToSessions)
+    .innerJoin(sessions, eq(sessions.id, agentsToSessions.sessionId))
+    .where(and(eq(agentsToSessions.agentId, agentId), eq(sessions.slug, INBOX_SESSION_ID)))
+    .limit(1);
+
+  return !!inboxSession;
 };
 
 const skillItemColumns = {

--- a/packages/database/src/models/agentSkill.ts
+++ b/packages/database/src/models/agentSkill.ts
@@ -5,7 +5,16 @@ import { merge } from '@lobechat/utils';
 import { and, desc, eq, ilike, inArray, isNull, ne, notExists, or, sql } from 'drizzle-orm';
 
 import type { NewAgentSkill } from '../schemas';
-import { agents, agentSkills, agentsToSessions, sessions, users, workspaces } from '../schemas';
+import {
+  agents,
+  agentSkills,
+  agentsToSessions,
+  sessions,
+  userConnectors,
+  userInstalledPlugins,
+  users,
+  workspaces,
+} from '../schemas';
 import type { LobeChatDatabase, Transaction } from '../type';
 import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
 
@@ -24,6 +33,9 @@ export const removeAgentPluginPolicyEntries = async (
     userId: agents.userId,
     workspaceId: agents.workspaceId,
   });
+  const skillScope = buildWorkspaceWhere(scope, agentSkills);
+  const pluginScope = buildWorkspaceWhere(scope, userInstalledPlugins);
+  const connectorScope = buildWorkspaceWhere(scope, userConnectors);
 
   await executor.execute(sql`
     update ${agents}
@@ -35,6 +47,25 @@ export const removeAgentPluginPolicyEntries = async (
         and plugin.entry ->> 'identifier' is distinct from ${identifier}
     )
     where ${and(agentScope, agentId ? eq(agents.id, agentId) : undefined)}
+      and not exists (
+        select 1
+        from ${agentSkills}
+        where ${and(skillScope, eq(agentSkills.identifier, identifier))}
+      )
+      and not exists (
+        select 1
+        from ${userInstalledPlugins}
+        where ${and(pluginScope, eq(userInstalledPlugins.identifier, identifier))}
+      )
+      and not exists (
+        select 1
+        from ${userConnectors}
+        where ${and(
+          connectorScope,
+          eq(userConnectors.identifier, identifier),
+          or(isNull(userConnectors.agentId), eq(userConnectors.agentId, agents.id)),
+        )}
+      )
       and exists (
         select 1
         from jsonb_array_elements(coalesce(${agents.plugins}, '[]'::jsonb)) as plugin(entry)

--- a/packages/database/src/models/connector.ts
+++ b/packages/database/src/models/connector.ts
@@ -9,6 +9,7 @@ import type {
 import { userConnectors, userConnectorTools } from '../schemas';
 import type { LobeChatDatabase } from '../type';
 import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
+import { removeAgentPluginPolicyEntries } from './agentSkill';
 
 interface GateKeeper {
   decrypt: (ciphertext: string) => Promise<{ plaintext: string }>;
@@ -184,7 +185,21 @@ export class ConnectorModel {
   };
 
   delete = async (id: string): Promise<void> => {
-    await this.db.delete(userConnectors).where(and(eq(userConnectors.id, id), this.ownership()));
+    await this.db.transaction(async (trx) => {
+      const [deleted] = await trx
+        .delete(userConnectors)
+        .where(and(eq(userConnectors.id, id), this.ownership()))
+        .returning({ agentId: userConnectors.agentId, identifier: userConnectors.identifier });
+
+      if (!deleted) return;
+
+      await removeAgentPluginPolicyEntries(
+        trx,
+        { userId: this.userId, workspaceId: this.workspaceId },
+        deleted.identifier,
+        deleted.agentId ?? undefined,
+      );
+    });
   };
 
   query = async (

--- a/packages/database/src/models/connector.ts
+++ b/packages/database/src/models/connector.ts
@@ -9,7 +9,7 @@ import type {
 import { userConnectors, userConnectorTools } from '../schemas';
 import type { LobeChatDatabase } from '../type';
 import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
-import { removeAgentPluginPolicyEntries } from './agentSkill';
+import { lockAgentSkillScope, removeAgentPluginPolicyEntries } from './agentSkill';
 
 interface GateKeeper {
   decrypt: (ciphertext: string) => Promise<{ plaintext: string }>;
@@ -186,6 +186,8 @@ export class ConnectorModel {
 
   delete = async (id: string): Promise<void> => {
     await this.db.transaction(async (trx) => {
+      const scope = { userId: this.userId, workspaceId: this.workspaceId };
+      await lockAgentSkillScope(trx, scope);
       const [deleted] = await trx
         .delete(userConnectors)
         .where(and(eq(userConnectors.id, id), this.ownership()))
@@ -195,7 +197,7 @@ export class ConnectorModel {
 
       await removeAgentPluginPolicyEntries(
         trx,
-        { userId: this.userId, workspaceId: this.workspaceId },
+        scope,
         deleted.identifier,
         deleted.agentId ?? undefined,
       );

--- a/packages/database/src/models/connector.ts
+++ b/packages/database/src/models/connector.ts
@@ -247,6 +247,16 @@ export class ConnectorModel {
     return Promise.all(rows.map((r) => decryptRow(r, gateKeeper)));
   };
 
+  hasIdentifier = async (identifier: string): Promise<boolean> => {
+    const [row] = await this.db
+      .select({ id: userConnectors.id })
+      .from(userConnectors)
+      .where(and(this.ownership(), eq(userConnectors.identifier, identifier)))
+      .limit(1);
+
+    return !!row;
+  };
+
   /**
    * Base (non-agent) rows for the given identifiers. Excludes agent-scoped rows;
    * use {@link resolveByIdentifiers} for agent-aware runtime resolution.

--- a/packages/database/src/models/plugin.ts
+++ b/packages/database/src/models/plugin.ts
@@ -1,10 +1,11 @@
 import type { LobeTool } from '@lobechat/types';
-import { and, desc, eq, sql } from 'drizzle-orm';
+import { and, desc, eq } from 'drizzle-orm';
 
 import type { InstalledPluginItem, NewInstalledPlugin } from '../schemas';
-import { agents, userInstalledPlugins } from '../schemas';
+import { userInstalledPlugins } from '../schemas';
 import type { LobeChatDatabase } from '../type';
 import { buildWorkspaceWhere } from '../utils/workspace';
+import { removeAgentPluginPolicyEntries } from './agentSkill';
 
 export class PluginModel {
   private userId: string;
@@ -21,12 +22,6 @@ export class PluginModel {
     buildWorkspaceWhere(
       { userId: this.userId, workspaceId: this.workspaceId },
       userInstalledPlugins,
-    );
-
-  private agentScope = () =>
-    buildWorkspaceWhere(
-      { userId: this.userId, workspaceId: this.workspaceId },
-      { userId: agents.userId, workspaceId: agents.workspaceId },
     );
 
   create = async (
@@ -59,23 +54,11 @@ export class PluginModel {
       // Resource deletion must physically remove the policy entry. Otherwise a
       // later custom skill with the same identifier would inherit stale
       // pinned/auto state instead of receiving its default mode.
-      await trx.execute(sql`
-        update ${agents}
-        set ${sql.identifier('plugins')} = (
-          select coalesce(jsonb_agg(plugin.entry order by plugin.ordinality), '[]'::jsonb)
-          from jsonb_array_elements(coalesce(${agents.plugins}, '[]'::jsonb))
-            with ordinality as plugin(entry, ordinality)
-          where plugin.entry #>> '{}' is distinct from ${id}
-            and plugin.entry ->> 'identifier' is distinct from ${id}
-        )
-        where ${this.agentScope()}
-          and exists (
-            select 1
-            from jsonb_array_elements(coalesce(${agents.plugins}, '[]'::jsonb)) as plugin(entry)
-            where plugin.entry #>> '{}' = ${id}
-               or plugin.entry ->> 'identifier' = ${id}
-          )
-      `);
+      await removeAgentPluginPolicyEntries(
+        trx,
+        { userId: this.userId, workspaceId: this.workspaceId },
+        id,
+      );
 
       return deleted;
     });

--- a/packages/database/src/models/plugin.ts
+++ b/packages/database/src/models/plugin.ts
@@ -1,8 +1,8 @@
 import type { LobeTool } from '@lobechat/types';
-import { and, desc, eq } from 'drizzle-orm';
+import { and, desc, eq, sql } from 'drizzle-orm';
 
 import type { InstalledPluginItem, NewInstalledPlugin } from '../schemas';
-import { userInstalledPlugins } from '../schemas';
+import { agents, userInstalledPlugins } from '../schemas';
 import type { LobeChatDatabase } from '../type';
 import { buildWorkspaceWhere } from '../utils/workspace';
 
@@ -21,6 +21,12 @@ export class PluginModel {
     buildWorkspaceWhere(
       { userId: this.userId, workspaceId: this.workspaceId },
       userInstalledPlugins,
+    );
+
+  private agentScope = () =>
+    buildWorkspaceWhere(
+      { userId: this.userId, workspaceId: this.workspaceId },
+      { userId: agents.userId, workspaceId: agents.workspaceId },
     );
 
   create = async (
@@ -42,9 +48,37 @@ export class PluginModel {
   };
 
   delete = async (id: string) => {
-    return this.db
-      .delete(userInstalledPlugins)
-      .where(and(eq(userInstalledPlugins.identifier, id), this.ownership()));
+    return this.db.transaction(async (trx) => {
+      const deleted = await trx
+        .delete(userInstalledPlugins)
+        .where(and(eq(userInstalledPlugins.identifier, id), this.ownership()))
+        .returning({ identifier: userInstalledPlugins.identifier });
+
+      if (deleted.length === 0) return deleted;
+
+      // Resource deletion must physically remove the policy entry. Otherwise a
+      // later custom skill with the same identifier would inherit stale
+      // pinned/auto state instead of receiving its default mode.
+      await trx.execute(sql`
+        update ${agents}
+        set ${sql.identifier('plugins')} = (
+          select coalesce(jsonb_agg(plugin.entry order by plugin.ordinality), '[]'::jsonb)
+          from jsonb_array_elements(coalesce(${agents.plugins}, '[]'::jsonb))
+            with ordinality as plugin(entry, ordinality)
+          where plugin.entry #>> '{}' is distinct from ${id}
+            and plugin.entry ->> 'identifier' is distinct from ${id}
+        )
+        where ${this.agentScope()}
+          and exists (
+            select 1
+            from jsonb_array_elements(coalesce(${agents.plugins}, '[]'::jsonb)) as plugin(entry)
+            where plugin.entry #>> '{}' = ${id}
+               or plugin.entry ->> 'identifier' = ${id}
+          )
+      `);
+
+      return deleted;
+    });
   };
 
   deleteAll = async () => {

--- a/packages/database/src/models/plugin.ts
+++ b/packages/database/src/models/plugin.ts
@@ -5,7 +5,7 @@ import type { InstalledPluginItem, NewInstalledPlugin } from '../schemas';
 import { userInstalledPlugins } from '../schemas';
 import type { LobeChatDatabase } from '../type';
 import { buildWorkspaceWhere } from '../utils/workspace';
-import { removeAgentPluginPolicyEntries } from './agentSkill';
+import { lockAgentSkillScope, removeAgentPluginPolicyEntries } from './agentSkill';
 
 export class PluginModel {
   private userId: string;
@@ -44,6 +44,8 @@ export class PluginModel {
 
   delete = async (id: string) => {
     return this.db.transaction(async (trx) => {
+      const scope = { userId: this.userId, workspaceId: this.workspaceId };
+      await lockAgentSkillScope(trx, scope);
       const deleted = await trx
         .delete(userInstalledPlugins)
         .where(and(eq(userInstalledPlugins.identifier, id), this.ownership()))
@@ -54,11 +56,7 @@ export class PluginModel {
       // Resource deletion must physically remove the policy entry. Otherwise a
       // later custom skill with the same identifier would inherit stale
       // pinned/auto state instead of receiving its default mode.
-      await removeAgentPluginPolicyEntries(
-        trx,
-        { userId: this.userId, workspaceId: this.workspaceId },
-        id,
-      );
+      await removeAgentPluginPolicyEntries(trx, scope, id);
 
       return deleted;
     });

--- a/packages/database/src/models/session.ts
+++ b/packages/database/src/models/session.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_AGENT_CONFIG, INBOX_SESSION_ID } from '@lobechat/const';
 import type {
+  AgentPluginEntry,
   ChatSessionList,
   LobeAgentConfig,
   LobeAgentSession,
@@ -17,6 +18,11 @@ import { sanitizeBm25Query } from '../utils/bm25';
 import { genEndDateWhere, genRangeWhere, genStartDateWhere, genWhere } from '../utils/genWhere';
 import { idGenerator } from '../utils/idGenerator';
 import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
+import {
+  appendDisabledAgentSkillDefaults,
+  getScopedAgentSkillIdentifiers,
+  lockAgentSkillScope,
+} from './agentSkill';
 
 export class SessionModel {
   private userId: string;
@@ -245,34 +251,39 @@ export class SessionModel {
         return result[0];
       }
 
+      const scope = { userId: this.userId, workspaceId: this.workspaceId };
+      await lockAgentSkillScope(trx, scope);
+      const skillIdentifiers =
+        slug === INBOX_SESSION_ID ? [] : await getScopedAgentSkillIdentifiers(trx, scope);
+
       const newAgents = await trx
         .insert(agents)
         .values(
-          buildWorkspacePayload(
-            { userId: this.userId, workspaceId: this.workspaceId },
-            {
-              avatar,
-              backgroundColor,
-              chatConfig: chatConfig || {},
-              createdAt: new Date(),
-              description,
-              editorData: editorData || null,
-              fewShots: examples || null, // Map examples to fewShots field
-              id: idGenerator('agents'),
-              marketIdentifier: identifier || marketIdentifier,
-              model: typeof model === 'string' ? model : null,
-              openingMessage,
-              openingQuestions,
-              params: params || {},
-              plugins,
-              provider,
-              systemRole,
-              tags,
-              title,
-              tts: tts || {},
-              updatedAt: new Date(),
-            },
-          ),
+          buildWorkspacePayload(scope, {
+            avatar,
+            backgroundColor,
+            chatConfig: chatConfig || {},
+            createdAt: new Date(),
+            description,
+            editorData: editorData || null,
+            fewShots: examples || null, // Map examples to fewShots field
+            id: idGenerator('agents'),
+            marketIdentifier: identifier || marketIdentifier,
+            model: typeof model === 'string' ? model : null,
+            openingMessage,
+            openingQuestions,
+            params: params || {},
+            plugins: appendDisabledAgentSkillDefaults(
+              plugins as AgentPluginEntry[] | null | undefined,
+              skillIdentifiers,
+            ) as string[] | undefined,
+            provider,
+            systemRole,
+            tags,
+            title,
+            tts: tts || {},
+            updatedAt: new Date(),
+          }),
         )
         .returning();
 

--- a/packages/database/src/repositories/agentGroup/index.test.ts
+++ b/packages/database/src/repositories/agentGroup/index.test.ts
@@ -1,5 +1,7 @@
 // @vitest-environment node
 import { BUILTIN_AGENT_SLUGS } from '@lobechat/builtin-agents';
+import type { AgentPluginEntry } from '@lobechat/types';
+import { getPluginMode } from '@lobechat/types';
 import { eq } from 'drizzle-orm';
 import { beforeEach, describe, expect, it } from 'vitest';
 
@@ -11,6 +13,7 @@ import {
   TopicCommentModel,
 } from '../../models/topicComment';
 import { agents } from '../../schemas/agent';
+import { agentSkills } from '../../schemas/agentSkill';
 import { chatGroups, chatGroupsAgents } from '../../schemas/chatGroup';
 import { messagePlugins, messages } from '../../schemas/message';
 import { threads, topics } from '../../schemas/topic';
@@ -545,6 +548,31 @@ describe('AgentGroupRepository', () => {
   });
 
   describe('createGroupWithSupervisor', () => {
+    it('defaults existing custom skills to disabled for the created supervisor', async () => {
+      await serverDB.insert(agentSkills).values({
+        description: 'Group supervisor skill',
+        identifier: 'group-supervisor-skill',
+        manifest: { description: 'Group supervisor skill', name: 'Group Supervisor Skill' },
+        name: 'Group Supervisor Skill',
+        source: 'user',
+        userId,
+      });
+
+      const result = await agentGroupRepo.createGroupWithSupervisor({
+        title: 'Group With Existing Skill',
+      });
+      const supervisor = await serverDB.query.agents.findFirst({
+        where: (agent, { eq }) => eq(agent.id, result.supervisorAgentId),
+      });
+
+      expect(
+        getPluginMode(
+          supervisor?.plugins as AgentPluginEntry[] | undefined,
+          'group-supervisor-skill',
+        ),
+      ).toBe('disabled');
+    });
+
     it('should create group with supervisor agent', async () => {
       const result = await agentGroupRepo.createGroupWithSupervisor({
         config: {
@@ -1015,6 +1043,15 @@ describe('AgentGroupRepository', () => {
     });
 
     it('should copy virtual member agents (create new agents)', async () => {
+      await serverDB.insert(agentSkills).values({
+        description: 'Group duplicate skill',
+        identifier: 'group-duplicate-skill',
+        manifest: { description: 'Group duplicate skill', name: 'Group Duplicate Skill' },
+        name: 'Group Duplicate Skill',
+        source: 'user',
+        userId,
+      });
+
       // Create source group
       await serverDB.insert(chatGroups).values({
         id: 'virtual-member-group',
@@ -1101,6 +1138,22 @@ describe('AgentGroupRepository', () => {
           virtual: true,
         }),
       );
+      expect(
+        getPluginMode(
+          copiedAgent?.plugins as AgentPluginEntry[] | undefined,
+          'group-duplicate-skill',
+        ),
+      ).toBe('disabled');
+
+      const copiedSupervisor = await serverDB.query.agents.findFirst({
+        where: (agent, { eq }) => eq(agent.id, result!.supervisorAgentId),
+      });
+      expect(
+        getPluginMode(
+          copiedSupervisor?.plugins as AgentPluginEntry[] | undefined,
+          'group-duplicate-skill',
+        ),
+      ).toBe('disabled');
 
       // Verify original virtual member still exists
       const originalAgent = await serverDB.query.agents.findFirst({
@@ -1494,6 +1547,15 @@ describe('AgentGroupRepository', () => {
         primaryOwnerId: userId,
         slug: 'agent-group-target-ws',
       });
+      await serverDB.insert(agentSkills).values({
+        description: 'Target transfer skill',
+        identifier: 'group-target-transfer-skill',
+        manifest: { description: 'Target transfer skill', name: 'Target Transfer Skill' },
+        name: 'Target Transfer Skill',
+        source: 'user',
+        userId,
+        workspaceId: targetWorkspaceId,
+      });
 
       await serverDB.insert(chatGroups).values({
         id: 'transfer-group',
@@ -1589,6 +1651,15 @@ describe('AgentGroupRepository', () => {
         where: (a, { inArray }) => inArray(a.id, ['transfer-supervisor', 'transfer-member']),
       });
       expect(memberAgents.every((agent) => agent.workspaceId === targetWorkspaceId)).toBe(true);
+      expect(
+        memberAgents.every(
+          (agent) =>
+            getPluginMode(
+              agent.plugins as AgentPluginEntry[] | undefined,
+              'group-target-transfer-skill',
+            ) === 'disabled',
+        ),
+      ).toBe(true);
 
       const junctions = await serverDB.query.chatGroupsAgents.findMany({
         where: (cga, { eq }) => eq(cga.chatGroupId, 'transfer-group'),
@@ -1723,6 +1794,15 @@ describe('AgentGroupRepository', () => {
         primaryOwnerId: userId,
         slug: 'agent-group-copy-target-ws',
       });
+      await serverDB.insert(agentSkills).values({
+        description: 'Target workspace skill',
+        identifier: 'target-workspace-skill',
+        manifest: { description: 'Target workspace skill', name: 'Target Workspace Skill' },
+        name: 'Target Workspace Skill',
+        source: 'user',
+        userId,
+        workspaceId: targetWorkspaceId,
+      });
 
       await serverDB.insert(chatGroups).values({
         avatar: 'group-avatar',
@@ -1804,6 +1884,15 @@ describe('AgentGroupRepository', () => {
       });
       expect(copiedAgents.every((agent) => agent.workspaceId === targetWorkspaceId)).toBe(true);
       expect(copiedAgents.map((agent) => agent.title).sort()).toEqual(['Member', 'Supervisor']);
+      expect(
+        copiedAgents.every(
+          (agent) =>
+            getPluginMode(
+              agent.plugins as AgentPluginEntry[] | undefined,
+              'target-workspace-skill',
+            ) === 'disabled',
+        ),
+      ).toBe(true);
     });
 
     it('copies group topics and messages when conversation history is selected', async () => {

--- a/packages/database/src/repositories/agentGroup/index.test.ts
+++ b/packages/database/src/repositories/agentGroup/index.test.ts
@@ -1566,6 +1566,7 @@ describe('AgentGroupRepository', () => {
       await serverDB.insert(agents).values([
         {
           id: 'transfer-supervisor',
+          plugins: ['group-target-transfer-skill'],
           title: 'Supervisor',
           userId,
           virtual: true,
@@ -1573,6 +1574,7 @@ describe('AgentGroupRepository', () => {
         },
         {
           id: 'transfer-member',
+          plugins: ['member-existing-tool'],
           title: 'Member',
           userId,
           virtual: false,
@@ -1651,15 +1653,25 @@ describe('AgentGroupRepository', () => {
         where: (a, { inArray }) => inArray(a.id, ['transfer-supervisor', 'transfer-member']),
       });
       expect(memberAgents.every((agent) => agent.workspaceId === targetWorkspaceId)).toBe(true);
+      const membersById = new Map(memberAgents.map((agent) => [agent.id, agent]));
       expect(
-        memberAgents.every(
-          (agent) =>
-            getPluginMode(
-              agent.plugins as AgentPluginEntry[] | undefined,
-              'group-target-transfer-skill',
-            ) === 'disabled',
+        getPluginMode(
+          membersById.get('transfer-supervisor')?.plugins as AgentPluginEntry[] | undefined,
+          'group-target-transfer-skill',
         ),
-      ).toBe(true);
+      ).toBe('pinned');
+      expect(
+        getPluginMode(
+          membersById.get('transfer-member')?.plugins as AgentPluginEntry[] | undefined,
+          'group-target-transfer-skill',
+        ),
+      ).toBe('disabled');
+      expect(
+        getPluginMode(
+          membersById.get('transfer-member')?.plugins as AgentPluginEntry[] | undefined,
+          'member-existing-tool',
+        ),
+      ).toBe('pinned');
 
       const junctions = await serverDB.query.chatGroupsAgents.findMany({
         where: (cga, { eq }) => eq(cga.chatGroupId, 'transfer-group'),

--- a/packages/database/src/repositories/agentGroup/index.ts
+++ b/packages/database/src/repositories/agentGroup/index.ts
@@ -1,8 +1,15 @@
 import { BUILTIN_AGENT_SLUGS } from '@lobechat/builtin-agents';
+import { INBOX_SESSION_ID } from '@lobechat/const';
 import type { AgentGroupDetail, AgentGroupMember, AgentPluginEntry } from '@lobechat/types';
 import { cleanObject } from '@lobechat/utils';
 import { and, asc, eq, inArray, ne, not, sql } from 'drizzle-orm';
 
+import { AgentModel } from '../../models/agent';
+import {
+  appendDisabledAgentSkillDefaults,
+  getScopedAgentSkillIdentifiers,
+  lockAgentSkillScope,
+} from '../../models/agentSkill';
 import {
   hasForeignTopicComments,
   syncTopicCommentsOnTopicTransfer,
@@ -17,10 +24,12 @@ import type {
 } from '../../schemas';
 import {
   agents,
+  agentsToSessions,
   chatGroups,
   chatGroupsAgents,
   messagePlugins,
   messages,
+  sessions,
   threads,
   topics,
 } from '../../schemas';
@@ -119,6 +128,7 @@ export class AgentGroupRepository {
     targetUserId: string,
     fallbackTitle: string,
     targetVisibility?: 'private' | 'public',
+    skillIdentifiers: string[] = [],
   ): NewAgent => ({
     agencyConfig: source?.agencyConfig,
     avatar: source?.avatar,
@@ -132,7 +142,10 @@ export class AgentGroupRepository {
     openingQuestions: source?.openingQuestions,
     params: source?.params,
     pinned: source?.pinned,
-    plugins: source?.plugins,
+    plugins: appendDisabledAgentSkillDefaults(
+      source?.plugins as AgentPluginEntry[] | null | undefined,
+      skillIdentifiers,
+    ) as string[] | undefined,
     provider: source?.provider,
     systemRole: source?.systemRole,
     tags: source?.tags,
@@ -377,17 +390,12 @@ export class AgentGroupRepository {
     // 4. If no supervisor exists, create a virtual supervisor agent
     if (!supervisorAgentId) {
       // Create supervisor agent (virtual agent)
-      const [supervisorAgent] = await this.db
-        .insert(agents)
-        .values({
-          model: undefined,
-          provider: undefined,
-          title: 'Supervisor',
-          userId: this.userId,
-          virtual: true,
-          workspaceId: this.workspaceId ?? null,
-        })
-        .returning();
+      const supervisorAgent = await new AgentModel(this.db, this.userId, this.workspaceId).create({
+        model: undefined,
+        provider: undefined,
+        title: 'Supervisor',
+        virtual: true,
+      });
 
       // Add supervisor agent to group with role 'supervisor'
       await this.db.insert(chatGroupsAgents).values({
@@ -439,30 +447,21 @@ export class AgentGroupRepository {
     const groupVisibility = groupParams.visibility ?? 'public';
 
     // 1. Create supervisor agent (virtual agent)
-    const [supervisorAgent] = await this.db
-      .insert(agents)
-      .values({
-        avatar: supervisorConfig?.avatar,
-        backgroundColor: supervisorConfig?.backgroundColor,
-        chatConfig: supervisorConfig?.chatConfig,
-        description: supervisorConfig?.description,
-        model: supervisorConfig?.model,
-        params: supervisorConfig?.params,
-        // The `plugins` column is still typed `string[]` at the schema layer
-        // (widening deferred to the tri-state rollout's final phase) but
-        // legitimately holds mixed AgentPluginEntry[] at runtime — JSONB has
-        // no schema enforcement.
-        plugins: supervisorConfig?.plugins as unknown as string[] | undefined,
-        provider: supervisorConfig?.provider,
-        systemRole: supervisorConfig?.systemRole,
-        tags: supervisorConfig?.tags,
-        title: supervisorConfig?.title ?? 'Supervisor',
-        userId: this.userId,
-        virtual: true,
-        visibility: groupVisibility,
-        workspaceId: this.workspaceId ?? null,
-      })
-      .returning();
+    const supervisorAgent = await new AgentModel(this.db, this.userId, this.workspaceId).create({
+      avatar: supervisorConfig?.avatar,
+      backgroundColor: supervisorConfig?.backgroundColor,
+      chatConfig: supervisorConfig?.chatConfig,
+      description: supervisorConfig?.description,
+      model: supervisorConfig?.model,
+      params: supervisorConfig?.params,
+      plugins: supervisorConfig?.plugins as unknown as string[] | undefined,
+      provider: supervisorConfig?.provider,
+      systemRole: supervisorConfig?.systemRole,
+      tags: supervisorConfig?.tags,
+      title: supervisorConfig?.title ?? 'Supervisor',
+      virtual: true,
+      visibility: groupVisibility,
+    });
 
     // 2. Create the group
     const [group] = await this.db
@@ -659,6 +658,10 @@ export class AgentGroupRepository {
 
     // Use transaction to ensure atomicity
     return this.db.transaction(async (trx) => {
+      const scope = { userId: this.userId, workspaceId: this.workspaceId };
+      await lockAgentSkillScope(trx, scope);
+      const skillIdentifiers = await getScopedAgentSkillIdentifiers(trx, scope);
+
       // 4. Create the new group
       const [newGroup] = await trx
         .insert(chatGroups)
@@ -686,6 +689,10 @@ export class AgentGroupRepository {
           description: supervisorAgent?.description,
           model: supervisorAgent?.model,
           params: supervisorAgent?.params,
+          plugins: appendDisabledAgentSkillDefaults(
+            supervisorAgent?.plugins as AgentPluginEntry[] | null | undefined,
+            skillIdentifiers,
+          ) as string[] | undefined,
           provider: supervisorAgent?.provider,
           systemRole: supervisorAgent?.systemRole,
           tags: supervisorAgent?.tags,
@@ -712,7 +719,10 @@ export class AgentGroupRepository {
           openingMessage: member.agent.openingMessage,
           openingQuestions: member.agent.openingQuestions,
           params: member.agent.params,
-          plugins: member.agent.plugins,
+          plugins: appendDisabledAgentSkillDefaults(
+            member.agent.plugins as AgentPluginEntry[] | null,
+            skillIdentifiers,
+          ) as string[] | undefined,
           provider: member.agent.provider,
           systemRole: member.agent.systemRole,
           tags: member.agent.tags,
@@ -838,12 +848,41 @@ export class AgentGroupRepository {
     if (!sourceGroup) return null;
 
     return this.db.transaction(async (trx) => {
+      const targetScope = {
+        userId: targetUserId,
+        workspaceId: targetWorkspaceId ?? undefined,
+      };
+      await lockAgentSkillScope(trx, targetScope);
+      const targetSkillIdentifiers = await getScopedAgentSkillIdentifiers(trx, targetScope);
+
       const memberRows = await trx
-        .select({ agentId: chatGroupsAgents.agentId })
+        .select({
+          agentId: chatGroupsAgents.agentId,
+          plugins: agents.plugins,
+          slug: agents.slug,
+        })
         .from(chatGroupsAgents)
+        .innerJoin(agents, eq(agents.id, chatGroupsAgents.agentId))
         .where(eq(chatGroupsAgents.chatGroupId, groupId));
 
       const agentIds = memberRows.map((row) => row.agentId);
+      const historicalInboxLinks =
+        agentIds.length > 0
+          ? await trx
+              .select({ agentId: agentsToSessions.agentId })
+              .from(agentsToSessions)
+              .innerJoin(sessions, eq(sessions.id, agentsToSessions.sessionId))
+              .where(
+                and(
+                  inArray(agentsToSessions.agentId, agentIds),
+                  eq(sessions.slug, INBOX_SESSION_ID),
+                ),
+              )
+          : [];
+      const inboxAgentIds = new Set([
+        ...memberRows.filter(({ slug }) => slug === INBOX_SESSION_ID).map(({ agentId }) => agentId),
+        ...historicalInboxLinks.map(({ agentId }) => agentId),
+      ]);
       const ownershipUpdate = {
         userId: targetUserId,
         workspaceId: targetWorkspaceId,
@@ -874,10 +913,22 @@ export class AgentGroupRepository {
             ),
           );
 
-        await trx
-          .update(agents)
-          .set({ ...ownershipUpdate, ...visibilityUpdate, updatedAt: new Date() })
-          .where(inArray(agents.id, agentIds));
+        for (const member of memberRows) {
+          await trx
+            .update(agents)
+            .set({
+              ...ownershipUpdate,
+              ...visibilityUpdate,
+              plugins: inboxAgentIds.has(member.agentId)
+                ? member.plugins
+                : (appendDisabledAgentSkillDefaults(
+                    member.plugins as AgentPluginEntry[] | null,
+                    targetSkillIdentifiers,
+                  ) as string[] | undefined),
+              updatedAt: new Date(),
+            })
+            .where(eq(agents.id, member.agentId));
+        }
       }
 
       await trx
@@ -960,6 +1011,13 @@ export class AgentGroupRepository {
       targetWorkspaceId && options.targetVisibility ? options.targetVisibility : undefined;
 
     return this.db.transaction(async (trx) => {
+      const targetScope = {
+        userId: targetUserId,
+        workspaceId: targetWorkspaceId ?? undefined,
+      };
+      await lockAgentSkillScope(trx, targetScope);
+      const skillIdentifiers = await getScopedAgentSkillIdentifiers(trx, targetScope);
+
       const [newGroup] = await trx
         .insert(chatGroups)
         .values({
@@ -986,6 +1044,7 @@ export class AgentGroupRepository {
             targetUserId,
             'Supervisor',
             targetVisibility,
+            skillIdentifiers,
           ),
         )
         .returning();
@@ -1002,6 +1061,7 @@ export class AgentGroupRepository {
                 targetUserId,
                 'Agent',
                 targetVisibility,
+                skillIdentifiers,
               ),
             ),
           )

--- a/packages/database/src/repositories/agentGroup/index.ts
+++ b/packages/database/src/repositories/agentGroup/index.ts
@@ -913,22 +913,26 @@ export class AgentGroupRepository {
             ),
           );
 
-        for (const member of memberRows) {
-          await trx
-            .update(agents)
-            .set({
-              ...ownershipUpdate,
-              ...visibilityUpdate,
-              plugins: inboxAgentIds.has(member.agentId)
-                ? member.plugins
-                : (appendDisabledAgentSkillDefaults(
-                    member.plugins as AgentPluginEntry[] | null,
-                    targetSkillIdentifiers,
-                  ) as string[] | undefined),
-              updatedAt: new Date(),
-            })
-            .where(eq(agents.id, member.agentId));
-        }
+        const pluginsByAgentId = Object.fromEntries(
+          memberRows.map((member) => [
+            member.agentId,
+            inboxAgentIds.has(member.agentId)
+              ? member.plugins
+              : (appendDisabledAgentSkillDefaults(
+                  member.plugins as AgentPluginEntry[] | null,
+                  targetSkillIdentifiers,
+                ) ?? null),
+          ]),
+        );
+        await trx
+          .update(agents)
+          .set({
+            ...ownershipUpdate,
+            ...visibilityUpdate,
+            plugins: sql`${JSON.stringify(pluginsByAgentId)}::jsonb -> ${agents.id}`,
+            updatedAt: new Date(),
+          })
+          .where(inArray(agents.id, agentIds));
       }
 
       await trx

--- a/packages/database/src/repositories/dataImporter/deprecated/__tests__/index.test.ts
+++ b/packages/database/src/repositories/dataImporter/deprecated/__tests__/index.test.ts
@@ -1,10 +1,13 @@
 // @vitest-environment node
-import type { ImporterEntryData } from '@lobechat/types';
+import { INBOX_SESSION_ID } from '@lobechat/const';
+import type { AgentPluginEntry, ImporterEntryData } from '@lobechat/types';
+import { getPluginMode } from '@lobechat/types';
 import { eq, inArray } from 'drizzle-orm';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
   agents,
+  agentSkills,
   agentsToSessions,
   messages,
   sessionGroups,
@@ -140,6 +143,53 @@ describe('DataImporter', () => {
 
       const agentSessionCount = await serverDB.query.agentsToSessions.findMany();
       expect(agentSessionCount.length).toBe(2);
+    });
+
+    it('keeps custom skills implicit auto for an imported legacy inbox session', async () => {
+      const skillIdentifier = 'imported-inbox-custom-skill';
+      await serverDB.insert(agentSkills).values({
+        description: 'Skill that predates the inbox import',
+        identifier: skillIdentifier,
+        manifest: { description: 'Imported inbox skill', name: 'Imported Inbox Skill' },
+        name: 'Imported Inbox Skill',
+        source: 'user',
+        userId,
+      });
+
+      await importer.importData({
+        sessions: [
+          {
+            config: {
+              chatConfig: {} as any,
+              model: 'abc',
+              openingQuestions: [],
+              params: {},
+              plugins: ['existing-inbox-plugin'],
+              systemRole: 'Inbox',
+              tts: {} as any,
+            },
+            createdAt: '2022-05-14T18:18:10.494Z',
+            id: INBOX_SESSION_ID,
+            meta: { title: 'Inbox' },
+            type: 'agent',
+            updatedAt: '2023-01-01',
+          },
+        ],
+        version: CURRENT_CONFIG_VERSION,
+      });
+
+      const importedInbox = await serverDB.query.sessions.findFirst({
+        where: eq(sessions.clientId, INBOX_SESSION_ID),
+      });
+      const inboxLink = await serverDB.query.agentsToSessions.findFirst({
+        where: eq(agentsToSessions.sessionId, importedInbox!.id),
+        with: { agent: true },
+      });
+      const inboxAgent = inboxLink?.agent as unknown as
+        { plugins?: AgentPluginEntry[] } | undefined;
+      const plugins = inboxAgent?.plugins;
+      expect(plugins).toEqual(['existing-inbox-plugin']);
+      expect(getPluginMode(plugins, skillIdentifier)).toBe('auto');
     });
 
     it('should skip existing sessions and return correct result', async () => {

--- a/packages/database/src/repositories/dataImporter/deprecated/index.ts
+++ b/packages/database/src/repositories/dataImporter/deprecated/index.ts
@@ -1,3 +1,4 @@
+import { INBOX_SESSION_ID } from '@lobechat/const';
 import type { AgentPluginEntry, ImporterEntryData } from '@lobechat/types';
 import { and, inArray, sql } from 'drizzle-orm';
 
@@ -151,7 +152,7 @@ export class DeprecatedDataImporterRepos {
           const agentMapArray = await trx
             .insert(agents)
             .values(
-              shouldInsertSessionAgents.map(({ config, meta }) => ({
+              shouldInsertSessionAgents.map(({ id, config, meta }) => ({
                 ...config,
                 // `config` is the `@lobechat/types` LobeAgentConfig shape
                 // (plugins: AgentPluginEntry[]); the `agents` table's
@@ -160,10 +161,12 @@ export class DeprecatedDataImporterRepos {
                 // rollout, not the JSONB column's compile-time annotation).
                 // Legacy import payloads only ever contain bare strings
                 // anyway.
-                plugins: appendDisabledAgentSkillDefaults(
-                  config.plugins as AgentPluginEntry[] | undefined,
-                  skillIdentifiers,
-                ) as string[] | undefined,
+                plugins: (id === INBOX_SESSION_ID
+                  ? config.plugins
+                  : appendDisabledAgentSkillDefaults(
+                      config.plugins as AgentPluginEntry[] | undefined,
+                      skillIdentifiers,
+                    )) as string[] | undefined,
                 ...meta,
                 userId: this.userId,
                 workspaceId: this.workspaceId ?? null,

--- a/packages/database/src/repositories/dataImporter/deprecated/index.ts
+++ b/packages/database/src/repositories/dataImporter/deprecated/index.ts
@@ -1,8 +1,13 @@
-import type { ImporterEntryData } from '@lobechat/types';
+import type { AgentPluginEntry, ImporterEntryData } from '@lobechat/types';
 import { and, inArray, sql } from 'drizzle-orm';
 
 import { sanitizeUTF8 } from '@/utils/sanitizeUTF8';
 
+import {
+  appendDisabledAgentSkillDefaults,
+  getScopedAgentSkillIdentifiers,
+  lockAgentSkillScope,
+} from '../../../models/agentSkill';
 import {
   agents,
   agentsToSessions,
@@ -139,6 +144,10 @@ export class DeprecatedDataImporterRepos {
 
         // Only insert agent when new sessions are needed
         if (shouldInsertSessionAgents.length > 0) {
+          const scope = { userId: this.userId, workspaceId: this.workspaceId };
+          await lockAgentSkillScope(trx, scope);
+          const skillIdentifiers = await getScopedAgentSkillIdentifiers(trx, scope);
+
           const agentMapArray = await trx
             .insert(agents)
             .values(
@@ -151,7 +160,10 @@ export class DeprecatedDataImporterRepos {
                 // rollout, not the JSONB column's compile-time annotation).
                 // Legacy import payloads only ever contain bare strings
                 // anyway.
-                plugins: config.plugins as unknown as string[] | undefined,
+                plugins: appendDisabledAgentSkillDefaults(
+                  config.plugins as AgentPluginEntry[] | undefined,
+                  skillIdentifiers,
+                ) as string[] | undefined,
                 ...meta,
                 userId: this.userId,
                 workspaceId: this.workspaceId ?? null,

--- a/packages/openapi/src/services/agent.service.test.ts
+++ b/packages/openapi/src/services/agent.service.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentService } from './agent.service';
+
+const { agentCreate } = vi.hoisted(() => ({ agentCreate: vi.fn() }));
+
+vi.mock('@/database/models/agent', () => ({
+  AgentModel: vi.fn().mockImplementation(() => ({ create: agentCreate })),
+}));
+vi.mock('@/database/schemas', () => ({ agents: {}, agentsToSessions: {} }));
+vi.mock('@/database/utils/idGenerator', () => ({
+  idGenerator: vi.fn().mockReturnValue('agent-openapi'),
+  randomSlug: vi.fn().mockReturnValue('openapi-slug'),
+}));
+vi.mock('../common/base.service', () => ({
+  BaseService: class {
+    protected db: unknown;
+    protected userId: string;
+    protected workspaceId?: string;
+
+    constructor(db: unknown, userId: string | null, workspaceId?: string) {
+      this.db = db;
+      this.userId = userId || '';
+      this.workspaceId = workspaceId;
+    }
+
+    protected handleServiceError(error: unknown): never {
+      throw error;
+    }
+
+    protected log() {}
+  },
+}));
+
+describe('AgentService.createAgent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    agentCreate.mockResolvedValue({
+      id: 'agent-openapi',
+      plugins: [{ identifier: 'existing-custom-skill', mode: 'disabled' }],
+      slug: 'openapi-slug',
+      title: 'OpenAPI Agent',
+    });
+  });
+
+  it('uses AgentModel.create so scoped skill defaults are applied', async () => {
+    const result = await new AgentService({} as never, 'user-1').createAgent({
+      title: 'OpenAPI Agent',
+    });
+
+    expect(agentCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'agent-openapi',
+        slug: 'openapi-slug',
+        title: 'OpenAPI Agent',
+      }),
+    );
+    expect(result.plugins).toEqual([{ identifier: 'existing-custom-skill', mode: 'disabled' }]);
+  });
+});

--- a/packages/openapi/src/services/agent.service.ts
+++ b/packages/openapi/src/services/agent.service.ts
@@ -1,7 +1,6 @@
 import { and, count, desc, eq, ilike, inArray, isNull, or } from 'drizzle-orm';
 
 import { AgentModel } from '@/database/models/agent';
-import type { NewAgent } from '@/database/schemas';
 import { agents, agentsToSessions } from '@/database/schemas';
 import type { LobeChatDatabase } from '@/database/type';
 import { idGenerator, randomSlug } from '@/database/utils/idGenerator';
@@ -78,34 +77,29 @@ export class AgentService extends BaseService {
     this.log('info', 'create agent', { title: request.title });
 
     try {
-      return await this.db.transaction(async (tx) => {
-        // Prepare creation data
-        const newAgentData: NewAgent = {
-          accessedAt: new Date(),
-          avatar: request.avatar || null,
-          chatConfig: request.chatConfig || null,
-          createdAt: new Date(),
-          description: request.description || null,
-          id: idGenerator('agents'),
-          model: request.model || null,
-          params: request.params ?? {},
-          provider: request.provider || null,
-          slug: randomSlug(4), // Auto-generated slug
-          systemRole: request.systemRole || null,
-          title: request.title,
-          updatedAt: new Date(),
-          ...this.buildWorkspacePayload({}),
-        };
-
-        // Insert into database
-        const [createdAgent] = await tx.insert(agents).values(newAgentData).returning();
-        this.log('info', 'agent created successfully', {
-          id: createdAgent.id,
-          slug: createdAgent.slug,
-        });
-
-        return createdAgent;
+      const now = new Date();
+      const agentModel = new AgentModel(this.db, this.userId, this.workspaceId);
+      const createdAgent = await agentModel.create({
+        accessedAt: now,
+        avatar: request.avatar || null,
+        chatConfig: request.chatConfig || null,
+        createdAt: now,
+        description: request.description || null,
+        id: idGenerator('agents'),
+        model: request.model || null,
+        params: request.params ?? {},
+        provider: request.provider || null,
+        slug: randomSlug(4),
+        systemRole: request.systemRole || null,
+        title: request.title,
+        updatedAt: now,
       });
+      this.log('info', 'agent created successfully', {
+        id: createdAgent.id,
+        slug: createdAgent.slug,
+      });
+
+      return createdAgent;
     } catch (error) {
       this.handleServiceError(error, 'create agent');
     }

--- a/packages/types/src/agent/pluginConfig.test.ts
+++ b/packages/types/src/agent/pluginConfig.test.ts
@@ -137,14 +137,20 @@ describe('upsertPluginMode', () => {
     ]);
   });
 
-  it('removes the entry (legacy string or object) when set to auto, instead of persisting it', () => {
-    expect(upsertPluginMode(['a', 'b'], 'a', 'auto')).toEqual(['b']);
+  it('persists auto explicitly so full-array writes retain user intent', () => {
+    expect(upsertPluginMode(['a', 'b'], 'a', 'auto')).toEqual([
+      { identifier: 'a', mode: 'auto' },
+      'b',
+    ]);
     expect(
       upsertPluginMode([{ identifier: 'a', mode: 'disabled' as const }, 'b'], 'a', 'auto'),
-    ).toEqual(['b']);
+    ).toEqual([{ identifier: 'a', mode: 'auto' }, 'b']);
   });
 
-  it('is a no-op when setting auto on an identifier that is already absent', () => {
-    expect(upsertPluginMode(['a'], 'not-there', 'auto')).toEqual(['a']);
+  it('appends an explicit auto entry when the identifier is absent', () => {
+    expect(upsertPluginMode(['a'], 'not-there', 'auto')).toEqual([
+      'a',
+      { identifier: 'not-there', mode: 'auto' },
+    ]);
   });
 });

--- a/packages/types/src/agent/pluginConfig.test.ts
+++ b/packages/types/src/agent/pluginConfig.test.ts
@@ -153,4 +153,19 @@ describe('upsertPluginMode', () => {
       { identifier: 'not-there', mode: 'auto' },
     ]);
   });
+
+  it('collapses duplicate string and object entries for the updated identifier', () => {
+    expect(
+      upsertPluginMode(
+        [
+          { identifier: 'a', mode: 'auto' as const },
+          'b',
+          'a',
+          { identifier: 'a', mode: 'pinned' as const },
+        ],
+        'a',
+        'disabled',
+      ),
+    ).toEqual([{ identifier: 'a', mode: 'disabled' }, 'b']);
+  });
 });

--- a/packages/types/src/agent/pluginConfig.ts
+++ b/packages/types/src/agent/pluginConfig.ts
@@ -90,10 +90,9 @@ export const getActivePluginIds = (plugins: AgentPluginEntry[] | undefined): str
  * Sets `identifier`'s mode, upgrading only that one entry. Every other entry
  * — including untouched legacy strings — is returned unchanged.
  *
- * `'auto'` is the implicit default for an identifier absent from `plugins`
- * altogether, so setting it explicitly removes any existing entry instead of
- * persisting a redundant `{ identifier, mode: 'auto' }` record — this mirrors
- * the pre-tri-state behavior where unpinning spliced the id out of the array.
+ * `auto` is persisted explicitly when selected. Absence still resolves to
+ * `auto` for legacy rows, but preserving the explicit entry lets full-array
+ * writes distinguish user intent from an identifier the caller has not seen.
  */
 export const upsertPluginMode = (
   plugins: AgentPluginEntry[] | undefined,
@@ -102,11 +101,6 @@ export const upsertPluginMode = (
 ): AgentPluginEntry[] => {
   const list = plugins ? [...plugins] : [];
   const index = list.findIndex((item) => parsePluginEntry(item).identifier === identifier);
-
-  if (mode === 'auto') {
-    if (index !== -1) list.splice(index, 1);
-    return list;
-  }
 
   if (index === -1) {
     list.push({ identifier, mode });

--- a/packages/types/src/agent/pluginConfig.ts
+++ b/packages/types/src/agent/pluginConfig.ts
@@ -87,8 +87,9 @@ export const getActivePluginIds = (plugins: AgentPluginEntry[] | undefined): str
   getPinnedPluginIds(plugins);
 
 /**
- * Sets `identifier`'s mode, upgrading only that one entry. Every other entry
- * — including untouched legacy strings — is returned unchanged.
+ * Sets `identifier`'s mode, upgrading its first entry and removing duplicate
+ * string/object entries for the same identifier. Entries for every other
+ * identifier — including untouched legacy strings — are returned unchanged.
  *
  * `auto` is persisted explicitly when selected. Absence still resolves to
  * `auto` for legacy rows, but preserving the explicit entry lets full-array
@@ -99,17 +100,23 @@ export const upsertPluginMode = (
   identifier: string,
   mode: AgentPluginMode,
 ): AgentPluginEntry[] => {
-  const list = plugins ? [...plugins] : [];
-  const index = list.findIndex((item) => parsePluginEntry(item).identifier === identifier);
+  const next: AgentPluginEntry[] = [];
+  let updated = false;
 
-  if (index === -1) {
-    list.push({ identifier, mode });
-    return list;
+  for (const entry of plugins ?? []) {
+    if (parsePluginEntry(entry).identifier !== identifier) {
+      next.push(entry);
+      continue;
+    }
+
+    // Keep the first matching entry in place and remove any duplicate legacy
+    // string/object entries left by direct array writers.
+    if (!updated) {
+      next.push(typeof entry === 'string' ? { identifier: entry, mode } : { ...entry, mode });
+      updated = true;
+    }
   }
 
-  const existing = list[index];
-  list[index] =
-    typeof existing === 'string' ? { identifier: existing, mode } : { ...existing, mode };
-
-  return list;
+  if (!updated) next.push({ identifier, mode });
+  return next;
 };

--- a/src/features/AgentSetting/store/reducers/config.test.ts
+++ b/src/features/AgentSetting/store/reducers/config.test.ts
@@ -49,7 +49,7 @@ describe('configReducer', () => {
       expect(nextState.plugins).toEqual(['plugin-a', { identifier: 'plugin-b', mode: 'pinned' }]);
     });
 
-    it('unpins (removes) an already-pinned legacy string entry', () => {
+    it('unpins an already-pinned legacy string entry with an explicit auto mode', () => {
       const state = { ...DEFAULT_AGENT_CONFIG, plugins: ['plugin-a', 'plugin-b'] };
 
       const nextState = configReducer(state, {
@@ -57,7 +57,7 @@ describe('configReducer', () => {
         type: 'togglePlugin',
       });
 
-      expect(nextState.plugins).toEqual(['plugin-a']);
+      expect(nextState.plugins).toEqual(['plugin-a', { identifier: 'plugin-b', mode: 'auto' }]);
     });
 
     it('flips an existing disabled object entry back to pinned, without duplicating it', () => {
@@ -75,7 +75,7 @@ describe('configReducer', () => {
       expect(nextState.plugins).toEqual(['plugin-a', { identifier: 'plugin-b', mode: 'pinned' }]);
     });
 
-    it('explicit state=false reverts the entry to auto, removing it from the array', () => {
+    it('explicit state=false persists the auto mode', () => {
       const state = {
         ...DEFAULT_AGENT_CONFIG,
         plugins: ['plugin-a', { identifier: 'plugin-b', mode: 'disabled' }] as any,
@@ -87,7 +87,7 @@ describe('configReducer', () => {
         type: 'togglePlugin',
       });
 
-      expect(nextState.plugins).toEqual(['plugin-a']);
+      expect(nextState.plugins).toEqual(['plugin-a', { identifier: 'plugin-b', mode: 'auto' }]);
     });
   });
 });

--- a/src/features/ChatInput/ActionBar/Tools/ComposioServerItem.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/ComposioServerItem.tsx
@@ -1,3 +1,4 @@
+import { getPluginMode, upsertPluginMode } from '@lobechat/types';
 import { Checkbox, Flexbox, Icon, stopPropagation } from '@lobehub/ui';
 import { Loader2, SquareArrowOutUpRight } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
@@ -184,21 +185,29 @@ const ComposioServerItem = memo<ComposioServerItemProps>(
     const pluginId = server ? server.identifier : '';
     const plugins =
       useAgentStore(agentSelectors.getAgentConfigById(effectiveAgentId))?.plugins || [];
-    const checked = plugins.includes(pluginId);
+    const checked = getPluginMode(plugins, pluginId) === 'pinned';
     const updateAgentConfigById = useAgentStore((s) => s.updateAgentConfigById);
 
     // Toggle plugin for the effective agent
     const togglePlugin = useCallback(
-      async (pluginIdToToggle: string) => {
+      async (pluginIdToToggle: string, state?: boolean) => {
         if (!effectiveAgentId) return;
-        const currentPlugins = plugins;
-        const hasPlugin = currentPlugins.includes(pluginIdToToggle);
-        const newPlugins = hasPlugin
-          ? currentPlugins.filter((id) => id !== pluginIdToToggle)
-          : [...currentPlugins, pluginIdToToggle];
-        await updateAgentConfigById(effectiveAgentId, { plugins: newPlugins });
+        const currentPlugins =
+          agentSelectors.getAgentConfigById(effectiveAgentId)(useAgentStore.getState())?.plugins ||
+          [];
+        const isPinned = getPluginMode(currentPlugins, pluginIdToToggle) === 'pinned';
+        const shouldPin = state ?? !isPinned;
+        if (shouldPin === isPinned) return;
+
+        await updateAgentConfigById(effectiveAgentId, {
+          plugins: upsertPluginMode(
+            currentPlugins,
+            pluginIdToToggle,
+            shouldPin ? 'pinned' : 'auto',
+          ),
+        });
       },
-      [effectiveAgentId, plugins, updateAgentConfigById],
+      [effectiveAgentId, updateAgentConfigById],
     );
 
     const handleConnect = async () => {
@@ -224,7 +233,7 @@ const ComposioServerItem = memo<ComposioServerItemProps>(
         if (newServer) {
           // Auto-enable plugin after installation (using identifier)
           const newPluginId = newServer.identifier;
-          await togglePlugin(newPluginId);
+          await togglePlugin(newPluginId, true);
 
           // If already authenticated, refresh tool list directly, skip OAuth
           if (newServer.status === ComposioServerStatus.ACTIVE) {

--- a/src/features/ChatInput/ActionBar/Tools/LobehubSkillServerItem.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/LobehubSkillServerItem.tsx
@@ -1,3 +1,4 @@
+import { getPluginMode, upsertPluginMode } from '@lobechat/types';
 import { Checkbox, Flexbox, Icon, stopPropagation } from '@lobehub/ui';
 import { Loader2, SquareArrowOutUpRight } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
@@ -142,21 +143,25 @@ const LobehubSkillServerItem = memo<LobehubSkillServerItemProps>(({ provider, la
 
   const pluginId = server ? server.identifier : '';
   const plugins = useAgentStore(agentSelectors.getAgentConfigById(effectiveAgentId))?.plugins || [];
-  const checked = plugins.includes(pluginId);
+  const checked = getPluginMode(plugins, pluginId) === 'pinned';
   const updateAgentConfigById = useAgentStore((s) => s.updateAgentConfigById);
 
   // Toggle plugin for the effective agent
   const togglePlugin = useCallback(
-    async (pluginIdToToggle: string) => {
+    async (pluginIdToToggle: string, state?: boolean) => {
       if (!effectiveAgentId) return;
-      const currentPlugins = plugins;
-      const hasPlugin = currentPlugins.includes(pluginIdToToggle);
-      const newPlugins = hasPlugin
-        ? currentPlugins.filter((id) => id !== pluginIdToToggle)
-        : [...currentPlugins, pluginIdToToggle];
-      await updateAgentConfigById(effectiveAgentId, { plugins: newPlugins });
+      const currentPlugins =
+        agentSelectors.getAgentConfigById(effectiveAgentId)(useAgentStore.getState())?.plugins ||
+        [];
+      const isPinned = getPluginMode(currentPlugins, pluginIdToToggle) === 'pinned';
+      const shouldPin = state ?? !isPinned;
+      if (shouldPin === isPinned) return;
+
+      await updateAgentConfigById(effectiveAgentId, {
+        plugins: upsertPluginMode(currentPlugins, pluginIdToToggle, shouldPin ? 'pinned' : 'auto'),
+      });
     },
-    [effectiveAgentId, plugins, updateAgentConfigById],
+    [effectiveAgentId, updateAgentConfigById],
   );
 
   // Listen for OAuth success message from popup window
@@ -184,10 +189,10 @@ const LobehubSkillServerItem = memo<LobehubSkillServerItemProps>(({ provider, la
           const currentAgentPlugins =
             agentSelectors.getAgentConfigById(effectiveAgentId)(useAgentStore.getState())
               ?.plugins || [];
-          const isAlreadyEnabled = currentAgentPlugins.includes(newPluginId);
+          const isAlreadyEnabled = getPluginMode(currentAgentPlugins, newPluginId) === 'pinned';
           if (canEdit && !isAlreadyEnabled) {
             console.info('[LobehubSkill] Auto-enabling plugin:', newPluginId);
-            togglePlugin(newPluginId);
+            togglePlugin(newPluginId, true);
           }
         }
       }

--- a/src/store/agent/slices/agent/action.test.ts
+++ b/src/store/agent/slices/agent/action.test.ts
@@ -693,6 +693,33 @@ describe('AgentSlice Actions', () => {
     });
   });
 
+  describe('toggleAgentPlugin', () => {
+    it('pins a tri-state entry without appending a duplicate identifier', async () => {
+      const { result } = renderHook(() => useAgentStore());
+      const updateConfigSpy = vi
+        .spyOn(result.current, 'updateAgentConfig')
+        .mockResolvedValue(undefined);
+      act(() => {
+        useAgentStore.setState({
+          activeAgentId: 'agent-1',
+          agentMap: {
+            'agent-1': {
+              plugins: [{ identifier: 'duplicate-plugin', mode: 'auto' }, 'duplicate-plugin'],
+            },
+          },
+        });
+      });
+
+      await act(async () => {
+        await result.current.toggleAgentPlugin('duplicate-plugin', true);
+      });
+
+      expect(updateConfigSpy).toHaveBeenCalledWith({
+        plugins: [{ identifier: 'duplicate-plugin', mode: 'pinned' }],
+      });
+    });
+  });
+
   describe('optimisticUpdateAgentConfig', () => {
     it('should perform optimistic update and then use API result', async () => {
       const { result } = renderHook(() => useAgentStore());

--- a/src/store/agent/slices/agent/action.ts
+++ b/src/store/agent/slices/agent/action.ts
@@ -1,9 +1,11 @@
 import { isDesktop } from '@lobechat/const';
 import { type AgentContextDocument } from '@lobechat/context-engine';
 import {
+  getPluginMode,
   isChatGroupSessionId,
   type LobeAgentAgencyConfig,
   pruneWorkingDirByDeviceDeletes,
+  upsertPluginMode,
 } from '@lobechat/types';
 import { getSingletonAnalyticsOptional } from '@lobehub/analytics';
 import isEqual from 'fast-deep-equal';
@@ -231,23 +233,16 @@ export class AgentSliceActionImpl {
     const { activeAgentId, agentMap, updateAgentConfig } = this.#get();
     if (!activeAgentId) return;
 
-    const currentPlugins = (agentMap[activeAgentId]?.plugins as string[]) || [];
-    const hasPlugin = currentPlugins.includes(pluginId);
+    const currentPlugins = agentMap[activeAgentId]?.plugins;
+    const isPinned = getPluginMode(currentPlugins, pluginId) === 'pinned';
 
     // Determine new state
-    const shouldEnable = state !== undefined ? state : !hasPlugin;
+    const shouldEnable = state ?? !isPinned;
+    if (shouldEnable === isPinned) return;
 
-    let newPlugins: string[];
-    if (shouldEnable && !hasPlugin) {
-      newPlugins = [...currentPlugins, pluginId];
-    } else if (!shouldEnable && hasPlugin) {
-      newPlugins = currentPlugins.filter((id) => id !== pluginId);
-    } else {
-      // No change needed
-      return;
-    }
-
-    await updateAgentConfig({ plugins: newPlugins });
+    await updateAgentConfig({
+      plugins: upsertPluginMode(currentPlugins, pluginId, shouldEnable ? 'pinned' : 'auto'),
+    });
   };
 
   updateAgentChatConfig = async (config: Partial<LobeAgentChatConfig>): Promise<void> => {

--- a/src/store/agent/slices/plugin/action.test.ts
+++ b/src/store/agent/slices/plugin/action.test.ts
@@ -70,7 +70,7 @@ describe('PluginSlice Actions', () => {
       );
     });
 
-    it('should remove plugin when in list', async () => {
+    it('should set a listed plugin to explicit auto', async () => {
       const { result } = renderHook(() => useAgentStore());
 
       vi.mocked(agentService.updateAgentConfig).mockResolvedValue({
@@ -92,7 +92,7 @@ describe('PluginSlice Actions', () => {
       expect(agentService.updateAgentConfig).toHaveBeenCalledWith(
         'agent-1',
         expect.objectContaining({
-          plugins: [],
+          plugins: [{ identifier: 'plugin-1', mode: 'auto' }],
         }),
         expect.any(AbortSignal),
       );
@@ -126,7 +126,7 @@ describe('PluginSlice Actions', () => {
       );
     });
 
-    it('should remove plugin when open=false explicitly', async () => {
+    it('should set plugin to explicit auto when open=false', async () => {
       const { result } = renderHook(() => useAgentStore());
 
       vi.mocked(agentService.updateAgentConfig).mockResolvedValue({
@@ -148,7 +148,7 @@ describe('PluginSlice Actions', () => {
       expect(agentService.updateAgentConfig).toHaveBeenCalledWith(
         'agent-1',
         expect.objectContaining({
-          plugins: [],
+          plugins: [{ identifier: 'plugin-1', mode: 'auto' }],
         }),
         expect.any(AbortSignal),
       );
@@ -235,7 +235,7 @@ describe('PluginSlice Actions', () => {
       expect(agentService.updateAgentConfig).toHaveBeenCalledWith(
         'agent-1',
         expect.objectContaining({
-          plugins: [],
+          plugins: [{ identifier: 'plugin-1', mode: 'auto' }],
         }),
         expect.any(AbortSignal),
       );
@@ -260,11 +260,11 @@ describe('PluginSlice Actions', () => {
         await result.current.removePlugin('non-existent');
       });
 
-      // Should not modify the array
+      // Preserve the explicit auto intent even when no entry existed before.
       expect(agentService.updateAgentConfig).toHaveBeenCalledWith(
         'agent-1',
         expect.objectContaining({
-          plugins: ['existing-plugin'],
+          plugins: ['existing-plugin', { identifier: 'non-existent', mode: 'auto' }],
         }),
         expect.any(AbortSignal),
       );
@@ -331,7 +331,7 @@ describe('PluginSlice Actions', () => {
       );
     });
 
-    it('setting mode to auto removes the entry entirely', async () => {
+    it('setting mode to auto persists the explicit mode', async () => {
       const { result } = renderHook(() => useAgentStore());
 
       vi.mocked(agentService.updateAgentConfig).mockResolvedValue({
@@ -357,7 +357,7 @@ describe('PluginSlice Actions', () => {
       expect(agentService.updateAgentConfig).toHaveBeenCalledWith(
         'agent-1',
         expect.objectContaining({
-          plugins: ['plugin-2'],
+          plugins: [{ identifier: 'plugin-1', mode: 'auto' }, 'plugin-2'],
         }),
         expect.any(AbortSignal),
       );

--- a/src/store/user/slices/onboarding/action.test.ts
+++ b/src/store/user/slices/onboarding/action.test.ts
@@ -155,14 +155,16 @@ describe('onboarding actions', () => {
       });
     });
 
-    it('setting open=false reverts the entry to auto, removing it from the array', async () => {
+    it('setting open=false persists an explicit auto entry', async () => {
       const { result } = renderHook(() => useUserStore());
 
       await act(async () => {
         await result.current.toggleInboxAgentDefaultPlugin('plugin-1', false);
       });
 
-      expect(updateAgentConfigById).toHaveBeenCalledWith('inbox-agent-id', { plugins: [] });
+      expect(updateAgentConfigById).toHaveBeenCalledWith('inbox-agent-id', {
+        plugins: [{ identifier: 'plugin-1', mode: 'auto' }],
+      });
     });
   });
 });


### PR DESCRIPTION
Custom skills use implicit `auto` when no per-agent plugin entry exists. This PR makes the intended default deterministic across creation, update, copy, import, reconciliation, and scope-transfer paths:

- inbox remains on implicit `auto` (including historical session-linked inbox records)
- every other agent in the same personal/workspace scope receives an explicit `disabled` entry
- creating or copying an agent after skills already exist seeds those skills as `disabled`
- legacy agents created before this behavior lazily reconcile missing policies before their config is returned
- OpenAPI agent creation now delegates to the same locked `AgentModel.create` path
- full-array plugin writes cannot erase a newly seeded disabled entry
- caller-selected `pinned` / `auto` / `disabled` modes are preserved; `auto` is now persisted explicitly so it is distinguishable from a stale payload that has never seen the skill
- group supervisor/member creation, duplication, workspace copy, legacy import, and scope transfer use the same target-scope defaults
- group transfer updates all member policies in one set-based statement while retaining each member's distinct modes
- skill creation uses one atomic, set-based JSONB update instead of N sequential read-modify-write updates
- skill and agent plugin-policy writes serialize per personal/workspace scope so overlapping transactions cannot miss each other
- custom skill imports reject identifiers already owned by builtin tools/skills, installed plugins, or connectors
- resource deletion physically removes dangling connector policy entries, while user-selected `auto` remains explicit
- updates and unchanged re-imports do not reset user choices

| Scenario | Result |
| --- | --- |
| Create skill after agents | Inbox: `auto`; other agents: `disabled` |
| Read a legacy agent with existing skills | Missing policies are persisted as `disabled` before use |
| Create agent after skills | New non-inbox agent: existing skills `disabled` |
| Create agent through OpenAPI | Existing custom skills: `disabled` |
| Duplicate/copy a group | New supervisor/members: destination skills `disabled` |
| Transfer an agent/group | Destination skills: `disabled`; existing explicit modes preserved |
| Write a stale full plugins array | Missing scoped skills are restored as `disabled` |
| Explicitly select `auto` | Explicit `auto` entry is preserved |
| Import a colliding skill identifier | Rejected with `CONFLICT` |
| Create skills concurrently | Every disabled entry is retained |
| Create skill and agent concurrently | New non-inbox agent still receives `disabled` |

#### Test

- latest database/model/repository checks: 210 tests passed
- prior affected checks: 66 and 349 tests passed
- database package full suite: 3656 passed, 112 skipped
- full typecheck passed

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

N/A
