### PR TITLE
✨ feat: add acceptance feedback watch

### DIFF
--- a/.agents/skills/agent-testing/SKILL.md
+++ b/.agents/skills/agent-testing/SKILL.md
@@ -512,7 +512,47 @@ later round that supplies one.
 The first ingest creates the acceptance and every ingest creates its next
 immutable round. The user closes the loop on `/acceptance/<acceptanceId>`; the
 same state is available through
-`lh acceptance view|accept|reject <id | type:id>`.
+`lh acceptance view|watch|accept|reject <id | type:id>`.
+
+#### After every ingest: start the managed feedback watcher (mandatory)
+
+Read `acceptanceId` and `roundIndex` from the ingest result, then launch this as
+a **managed background task owned by the current agent runtime**:
+
+```bash
+env -u LOBEHUB_SERVER -u LOBE_API_KEY -u LOBEHUB_CLI_API_KEY -u LOBEHUB_CLI_HOME \
+  lh acceptance watch "$ACCEPTANCE_ID" --round "$ROUND_INDEX"
+```
+
+Hard rules:
+
+- Use the runtime's background-task facility and retain its task/job id. Do not
+  use shell `&`, `nohup`, a detached daemon, or a busy polling loop.
+- Do not repeatedly call `acceptance view` or poll the background job. The
+  managed task's completion is the wake-up signal for this same agent.
+- Waiting stdout is intentionally silent. A successful exit prints exactly one
+  readable terminal report, either `FEEDBACK SUBMITTED` with accepted checks,
+  repair instructions, annotations, attachments, group feedback and the
+  overall note, or `ACCEPTANCE ACCEPTED`.
+- `--json` is optional for machine consumers; agents should use the default
+  readable text because it is more concise and directly actionable.
+- After publishing, send only an intermediate user update containing the
+  Acceptance URL and state that review is awaited. Do not send the task's final
+  answer and do not tear down the environment while the watcher is active.
+
+When the managed task completes:
+
+1. On `FEEDBACK SUBMITTED`, treat accepted checks as settled, implement every
+   repair instruction, silently re-check environment/auth, run the affected
+   cases, publish a new immutable round on the same Acceptance, and immediately
+   start a new managed watcher for that new `roundIndex`. Do this autonomously;
+   the original Phase 1 approval remains valid unless a material boundary
+   changes.
+2. On `ACCEPTANCE ACCEPTED`, no further repair is required. Proceed to Step 7,
+   then send the final completion response.
+3. On a non-zero operational failure, report the concrete connection/auth
+   error and restart the watcher when safe. Never reinterpret an operational
+   failure as user feedback.
 
 When no subject exists yet (first verification in a repo, no tracked task),
 create one with the CLI instead of asking the user for an id — a dedicated task
@@ -586,8 +626,11 @@ Close the run cleanly and leave behind only intentional, auditable artifacts.
 ### Step 7 — Teardown and handoff (default: stop what you started)
 
 A test run leaves processes and code edits behind. Clean them up by default once
-the report is published — a dev server left listening or an injection left in a
-source file silently corrupts the next run (and the next agent's mental model).
+the Acceptance is accepted (or the user explicitly cancels the loop). Publishing
+an intermediate round is not the finish boundary: keep the environment required
+for follow-up repairs while its managed acceptance watcher is active. A dev
+server left listening after the final decision or an injection left in a source
+file silently corrupts the next run (and the next agent's mental model).
 
 - **Stop what you started.** Stop the dev server and any services you started,
   using the stop commands from `PROJECT.md` §2. Stop only what THIS run started —

--- a/apps/cli/src/commands/verify.test.ts
+++ b/apps/cli/src/commands/verify.test.ts
@@ -38,8 +38,12 @@ const { mockTrpcClient } = vi.hoisted(() => ({
 const { getTrpcClient: mockGetTrpcClient } = vi.hoisted(() => ({
   getTrpcClient: vi.fn(),
 }));
+const { mockGetAuthInfo } = vi.hoisted(() => ({
+  mockGetAuthInfo: vi.fn(),
+}));
 
 vi.mock('../api/client', () => ({ getTrpcClient: mockGetTrpcClient }));
+vi.mock('../api/http', () => ({ getAuthInfo: mockGetAuthInfo }));
 vi.mock('../settings', () => ({ resolveServerUrl: () => 'https://app.lobehub.com' }));
 vi.mock('../utils/logger', () => ({
   log: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
@@ -938,10 +942,61 @@ describe('subjectFromEnv — default topic acceptance', () => {
 
 describe('lh acceptance — canonical run tree', () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  const acceptanceBundle = (
+    status: 'accepted' | 'delivered' | 'rejected',
+    userReview?: { action: 'accept' | 'reject'; stale: boolean },
+    feedbackSubmitted = false,
+  ) => ({
+    acceptance: { id: 'acceptance-1', requirement: 'Ship the feature', status },
+    checks: [
+      {
+        id: 'check-1',
+        result: { id: 'result-1' },
+        reviews:
+          userReview?.action === 'reject'
+            ? [
+                {
+                  action: 'reject',
+                  comment: 'The empty state is missing',
+                  roundIndex: 1,
+                },
+              ]
+            : [],
+        seq: 1,
+        state: 'passed',
+        title: 'Render the empty state',
+        userReview: userReview ?? null,
+      },
+    ],
+    latestReport: null,
+    rounds: [
+      {
+        report: { verdict: 'passed' },
+        run: {
+          decisionDetail: {
+            ...(feedbackSubmitted ? { feedbackSubmittedAt: '2026-07-28T08:00:00.000Z' } : {}),
+            groupFeedback: [],
+          },
+          id: 'run-1',
+          roundIndex: 1,
+          status: 'delivered',
+          userDecision: status === 'accepted' ? 'accept' : status === 'rejected' ? 'reject' : null,
+        },
+      },
+    ],
+    subject: { id: 'topic-1', title: 'Acceptance topic', type: 'topic' },
+  });
 
   beforeEach(() => {
     consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     mockGetTrpcClient.mockResolvedValue(mockTrpcClient);
+    mockGetAuthInfo.mockResolvedValue({
+      headers: { 'Oidc-Auth': 'token' },
+      serverUrl: 'https://app.lobehub.com',
+    });
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
     (mockTrpcClient.verify as Record<string, any>).submitCheckEvidence = {
       mutate: vi.fn().mockResolvedValue({
         checkResult: { id: 'result_1', verifyRunId: 'run_1' },
@@ -949,7 +1004,10 @@ describe('lh acceptance — canonical run tree', () => {
       }),
     };
   });
-  afterEach(() => consoleSpy.mockRestore());
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
 
   const run = async (args: string[]) => {
     const program = new Command();
@@ -1003,6 +1061,103 @@ describe('lh acceptance — canonical run tree', () => {
 
     const output = JSON.parse(consoleSpy.mock.calls.map((call) => String(call[0])).join(''));
     expect(output.url).toBe('https://app.lobehub.com/verify/run_1');
+  });
+
+  it('stays silent until SSE reports submitted feedback, then exits with readable text', async () => {
+    const submittedBundle = acceptanceBundle(
+      'delivered',
+      { action: 'reject', stale: false },
+      true,
+    ) as any;
+    submittedBundle.checks[0].reviews[0].annotations = [
+      { comment: 'Button overlaps the text', evidenceId: 'evidence-1' },
+    ];
+    submittedBundle.checks[0].reviews[0].fileIds = ['file-1'];
+    submittedBundle.checks.push({
+      id: 'check-2',
+      result: { id: 'result-2' },
+      reviews: [],
+      seq: 2,
+      state: 'passed',
+      title: 'Preserve keyboard navigation',
+      userReview: { action: 'accept', stale: false },
+    });
+    submittedBundle.rounds[0].run.decisionDetail.groupFeedback = [
+      { category: 'accessibility', comment: 'Keep focus visible', fileIds: ['file-2'] },
+    ];
+    submittedBundle.rounds[0].run.decisionDetail.comment = 'Repair only the rejected scope';
+
+    const getBundle = vi
+      .fn()
+      .mockResolvedValueOnce(acceptanceBundle('delivered'))
+      .mockResolvedValueOnce(submittedBundle);
+    mockTrpcClient.acceptance = { getBundle: { query: getBundle } };
+    fetchSpy.mockImplementation(async () => {
+      expect(consoleSpy).not.toHaveBeenCalled();
+      return new Response('event: acceptance.feedbackSubmitted\ndata: {}\n\n', {
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+    });
+
+    await run(['watch', 'acceptance-1', '--round', '1']);
+
+    expect(getBundle).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const output = consoleSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(output).toContain('FEEDBACK SUBMITTED');
+    expect(output).toContain('Needs repair');
+    expect(output).toContain('C1 [check-1] Render the empty state');
+    expect(output).toContain('The empty state is missing');
+    expect(output).toContain('Region on evidence evidence-1: Button overlaps the text');
+    expect(output).toContain('Attachments: file-1');
+    expect(output).toContain('Accepted — keep settled, do not rerun');
+    expect(output).toContain('C2 [check-2] Preserve keyboard navigation');
+    expect(output).toContain('Group feedback — accessibility');
+    expect(output).toContain('Keep focus visible');
+    expect(output).toContain('Overall');
+    expect(output).toContain('Repair only the rejected scope');
+  });
+
+  it('emits the terminal feedback result as JSON only when requested', async () => {
+    mockTrpcClient.acceptance = {
+      getBundle: {
+        query: vi
+          .fn()
+          .mockResolvedValue(
+            acceptanceBundle('rejected', { action: 'reject', stale: false }, true),
+          ),
+      },
+    };
+
+    await run(['watch', 'acceptance-1', '--round', '1', '--json']);
+
+    const event = JSON.parse(String(consoleSpy.mock.calls.at(-1)?.[0]));
+    expect(event).toMatchObject({
+      acceptanceId: 'acceptance-1',
+      rejectedChecks: [
+        {
+          id: 'check-1',
+          comment: 'The empty state is missing',
+        },
+      ],
+      terminal: 'feedback-submitted',
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('exits immediately when the acceptance is already accepted', async () => {
+    mockTrpcClient.acceptance = {
+      getBundle: {
+        query: vi
+          .fn()
+          .mockResolvedValue(acceptanceBundle('accepted', { action: 'accept', stale: false })),
+      },
+    };
+
+    await run(['watch', 'acceptance-1', '--round', '1']);
+
+    expect(String(consoleSpy.mock.calls.at(-1)?.[0])).toContain('ACCEPTANCE ACCEPTED');
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it('exposes `acceptance install` defaulting to the acceptance skill', async () => {

--- a/apps/cli/src/commands/verifyAcceptance.ts
+++ b/apps/cli/src/commands/verifyAcceptance.ts
@@ -2,6 +2,7 @@ import type { Command } from 'commander';
 import pc from 'picocolors';
 
 import { getTrpcClient } from '../api/client';
+import { getAuthInfo } from '../api/http';
 import { outputJson, printTable, timeAgo, truncate } from '../utils/format';
 import { log } from '../utils/logger';
 import { attachAcceptanceRunCommands } from './acceptanceRun';
@@ -49,6 +50,239 @@ const userGlyph = (userReview?: { action: string; stale: boolean } | null): stri
   if (userReview.action === 'ignore') return pc.dim('⊘ ignored');
   return userReview.stale ? pc.dim('· pending') : pc.red('✗ rejected');
 };
+
+interface AcceptanceWatchBundle {
+  acceptance: { id: string; requirement?: string | null; status: string };
+  checks: {
+    id: string;
+    result?: unknown;
+    reviews: {
+      action: string;
+      annotations?: { comment?: string; evidenceId: string }[];
+      comment?: string | null;
+      fileIds?: string[];
+      roundIndex: number;
+    }[];
+    seq?: number;
+    state: string;
+    title?: string;
+    userReview?: { action: string; stale: boolean } | null;
+  }[];
+  rounds: {
+    report?: { verdict?: string | null } | null;
+    run: {
+      decisionDetail?: {
+        comment?: string;
+        feedbackSubmittedAt?: string;
+        groupFeedback?: {
+          category: string;
+          comment: string;
+          fileIds?: string[];
+        }[];
+      } | null;
+      roundIndex?: number | null;
+      status?: string | null;
+      userDecision?: string | null;
+    };
+  }[];
+  subject: { id: string; title?: string | null; type: string };
+}
+
+type AcceptanceWatchTerminal = 'accepted' | 'feedback-submitted';
+
+class AcceptanceWatchRequestError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+  ) {
+    super(message);
+  }
+}
+
+/** Read one SSE connection until its terminal acceptance event or EOF. */
+const readAcceptanceEvent = async (
+  url: URL,
+  headers: Record<string, string>,
+): Promise<AcceptanceWatchTerminal | null> => {
+  const response = await fetch(url, { headers: { ...headers, Accept: 'text/event-stream' } });
+  if (!response.ok) {
+    throw new AcceptanceWatchRequestError(
+      `Acceptance watch request failed (${response.status})`,
+      response.status,
+    );
+  }
+  if (!response.body) throw new AcceptanceWatchRequestError('Acceptance watch returned no stream');
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    buffer += decoder.decode(value, { stream: !done }).replaceAll('\r\n', '\n');
+
+    let boundary = buffer.indexOf('\n\n');
+    while (boundary >= 0) {
+      const block = buffer.slice(0, boundary);
+      buffer = buffer.slice(boundary + 2);
+      const event = block
+        .split('\n')
+        .find((line) => line.startsWith('event:'))
+        ?.slice('event:'.length)
+        .trim();
+      if (event === 'acceptance.accepted') return 'accepted';
+      if (event === 'acceptance.feedbackSubmitted') return 'feedback-submitted';
+      boundary = buffer.indexOf('\n\n');
+    }
+
+    if (done) return null;
+  }
+};
+
+const resolveWatchTerminal = (
+  bundle: AcceptanceWatchBundle,
+  roundIndex: number,
+): AcceptanceWatchTerminal | null => {
+  if (bundle.acceptance.status === 'accepted') return 'accepted';
+  const round = bundle.rounds.find((item) => item.run.roundIndex === roundIndex);
+  return round?.run.decisionDetail?.feedbackSubmittedAt ? 'feedback-submitted' : null;
+};
+
+const watchResult = (bundle: AcceptanceWatchBundle, roundIndex: number) => {
+  const round = bundle.rounds.find((item) => item.run.roundIndex === roundIndex);
+  if (!round) throw new Error(`Acceptance round ${roundIndex} was not found`);
+
+  const acceptedChecks = bundle.checks.filter((check) => check.userReview?.action === 'accept');
+  const rejectedChecks = bundle.checks.flatMap((check) => {
+    const review = [...check.reviews]
+      .reverse()
+      .find((item) => item.action === 'reject' && item.roundIndex === roundIndex);
+    return review ? [{ check, review }] : [];
+  });
+
+  return {
+    acceptanceId: bundle.acceptance.id,
+    acceptedChecks: acceptedChecks.map((check) => ({
+      id: check.id,
+      seq: check.seq,
+      title: check.title,
+    })),
+    feedbackSubmittedAt: round.run.decisionDetail?.feedbackSubmittedAt,
+    groupFeedback: round.run.decisionDetail?.groupFeedback ?? [],
+    overallComment: round.run.decisionDetail?.comment,
+    rejectedChecks: rejectedChecks.map(({ check, review }) => ({
+      annotations: review.annotations,
+      comment: review.comment,
+      fileIds: review.fileIds,
+      id: check.id,
+      seq: check.seq,
+      title: check.title,
+    })),
+    roundIndex,
+    status: bundle.acceptance.status,
+    subject: bundle.subject,
+  };
+};
+
+const checkLabel = (check: { id: string; seq?: number; title?: string }): string =>
+  `${check.seq ? `C${check.seq} ` : ''}[${check.id}]${check.title ? ` ${check.title}` : ''}`;
+
+const printWatchResult = (
+  bundle: AcceptanceWatchBundle,
+  roundIndex: number,
+  terminal: AcceptanceWatchTerminal,
+  json = false,
+): void => {
+  const result = watchResult(bundle, roundIndex);
+  if (json) {
+    console.log(JSON.stringify({ terminal, ...result }));
+    return;
+  }
+
+  const subject = result.subject.title ?? result.subject.id;
+  if (terminal === 'accepted') {
+    console.log(
+      `ACCEPTANCE ACCEPTED — ${subject} (${result.acceptanceId}) · round ${roundIndex}\n\nNo further repair is required.`,
+    );
+    return;
+  }
+
+  const lines = [`FEEDBACK SUBMITTED — ${subject} (${result.acceptanceId}) · round ${roundIndex}`];
+  if (result.acceptedChecks.length > 0) {
+    lines.push('', 'Accepted — keep settled, do not rerun');
+    for (const check of result.acceptedChecks) lines.push(`- ${checkLabel(check)}`);
+  }
+  if (result.rejectedChecks.length > 0) {
+    lines.push('', 'Needs repair');
+    for (const check of result.rejectedChecks) {
+      lines.push(`- ${checkLabel(check)}`);
+      if (check.comment) lines.push(`  ${check.comment}`);
+      for (const annotation of check.annotations ?? []) {
+        if (annotation.comment) {
+          lines.push(`  Region on evidence ${annotation.evidenceId}: ${annotation.comment}`);
+        }
+      }
+      if (check.fileIds?.length) lines.push(`  Attachments: ${check.fileIds.join(', ')}`);
+    }
+  }
+  for (const feedback of result.groupFeedback) {
+    lines.push('', `Group feedback — ${feedback.category || 'overall'}`, `- ${feedback.comment}`);
+    if (feedback.fileIds?.length) lines.push(`  Attachments: ${feedback.fileIds.join(', ')}`);
+  }
+  if (result.overallComment) lines.push('', 'Overall', `- ${result.overallComment}`);
+  if (
+    result.rejectedChecks.length === 0 &&
+    result.groupFeedback.length === 0 &&
+    !result.overallComment
+  ) {
+    lines.push('', 'No repair instructions were recorded.');
+  }
+  console.log(lines.join('\n'));
+};
+
+async function watchAcceptance(
+  idOrSubject: string,
+  options: { json?: boolean; round?: string },
+): Promise<void> {
+  const id = await resolveAcceptanceId(idOrSubject);
+  const client = await getTrpcClient();
+  let bundle = (await client.acceptance.getBundle.query({ id })) as AcceptanceWatchBundle;
+  const roundIndex = options.round ? Number(options.round) : bundle.rounds.at(-1)?.run.roundIndex;
+  if (!roundIndex || !Number.isInteger(roundIndex) || roundIndex < 1) {
+    throw new Error('--round must identify a positive acceptance round');
+  }
+
+  let terminal = resolveWatchTerminal(bundle, roundIndex);
+  if (!terminal) {
+    const { headers, serverUrl } = await getAuthInfo();
+    const url = new URL('/webapi/acceptance/events', serverUrl);
+    url.searchParams.set('id', id);
+    url.searchParams.set('round', String(roundIndex));
+
+    while (!terminal) {
+      try {
+        terminal = await readAcceptanceEvent(url, headers);
+      } catch (error) {
+        if (
+          error instanceof AcceptanceWatchRequestError &&
+          error.status !== undefined &&
+          [400, 401, 403, 404].includes(error.status)
+        ) {
+          throw error;
+        }
+        log.warn(`Acceptance watch disconnected: ${(error as Error).message}; reconnecting`);
+      }
+      if (terminal) break;
+      log.warn('Acceptance watch stream closed before a decision; reconnecting');
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
+    bundle = (await client.acceptance.getBundle.query({ id })) as AcceptanceWatchBundle;
+    terminal = resolveWatchTerminal(bundle, roundIndex) ?? terminal;
+  }
+
+  printWatchResult(bundle, roundIndex, terminal, options.json);
+}
 
 /**
  * The acceptance command set. Registered twice: as the first-class
@@ -275,6 +509,13 @@ export function registerAcceptanceCommands(parent: Command, options?: { deprecat
         }
       },
     );
+
+  acceptance
+    .command('watch <idOrSubject>')
+    .description('Wait for submitted feedback or final acceptance, then exit once')
+    .option('--round <index>', 'Immutable acceptance round to watch')
+    .option('--json', 'Output the terminal result as JSON')
+    .action(watchAcceptance);
 
   acceptance
     .command('accept <idOrSubject>')

--- a/apps/cli/src/program.ts
+++ b/apps/cli/src/program.ts
@@ -97,7 +97,7 @@ export function createProgram() {
   registerPluginCommand(program);
   registerUserCommand(program);
   registerVerifyCommand(program);
-  // First-class review-loop entry: `lh acceptance list|view|feedback|accept|reject`.
+  // First-class review-loop entry: `lh acceptance list|view|watch|feedback|accept|reject`.
   registerAcceptanceCommands(program);
   registerConfigCommand(program);
   registerEvalCommand(program);

--- a/apps/server/src/routers/lambda/acceptance.ts
+++ b/apps/server/src/routers/lambda/acceptance.ts
@@ -549,6 +549,27 @@ export const acceptanceRouter = router({
     }),
 
   /**
+   * Finalize the current round's accumulated feedback. The durable marker is
+   * the watcher's one-shot exit condition; the returned lease state lets the
+   * UI retain its legacy conversation dispatch only when no watcher exists.
+   */
+  submitFeedback: acceptanceWriteProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const acceptance = await resolveAcceptance(ctx, input.id);
+      assertWorkspaceRowManageable(ctx, acceptance.userId, 'acceptance');
+
+      try {
+        return await ctx.acceptanceService.submitFeedback(acceptance.id);
+      } catch (error) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: error instanceof Error ? error.message : 'Failed to submit feedback',
+        });
+      }
+    }),
+
+  /**
    * The user sent the delivery back for a repair round (the in-app 打回重跑
    * dispatch). Stamps the aggregate `repairing` so every surface reflects the
    * send-back immediately; the next round's ingest recomputes the status from

--- a/apps/server/src/services/resourceEvents/__tests__/index.test.ts
+++ b/apps/server/src/services/resourceEvents/__tests__/index.test.ts
@@ -21,5 +21,16 @@ describe('resourceEvents', () => {
         { actorId: 'u1', data: { holderId: null }, type: 'lock.changed' },
       ),
     ).resolves.toBeUndefined();
+
+    await expect(
+      publishResourceEvent(
+        { id: 'acceptance-1', type: 'acceptance' },
+        {
+          actorId: 'u1',
+          data: { roundIndex: 2 },
+          type: 'acceptance.feedbackSubmitted',
+        },
+      ),
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/server/src/services/resourceEvents/types.ts
+++ b/apps/server/src/services/resourceEvents/types.ts
@@ -1,12 +1,13 @@
 /** Editable resource families that can broadcast realtime events. */
-export type ResourceType = 'agent' | 'chatGroup' | 'document' | 'task';
+export type ResourceType = 'acceptance' | 'agent' | 'chatGroup' | 'document' | 'task';
 
 export interface ResourceRef {
   id: string;
   type: ResourceType;
 }
 
-export type ResourceEventType = 'doc.updated' | 'lock.changed';
+export type ResourceEventType =
+  'acceptance.accepted' | 'acceptance.feedbackSubmitted' | 'doc.updated' | 'lock.changed';
 
 export interface ResourceEvent {
   /** User id that triggered the event; lets subscribers ignore self-originated events. */

--- a/apps/server/src/services/verify/__tests__/acceptanceDecision.test.ts
+++ b/apps/server/src/services/verify/__tests__/acceptanceDecision.test.ts
@@ -5,7 +5,10 @@ import { AcceptanceService } from '../acceptanceService';
 
 const mocks = vi.hoisted(() => ({
   findById: vi.fn(),
+  hasActiveWatcher: vi.fn(),
   listByAcceptance: vi.fn(),
+  mergeDecisionDetail: vi.fn(),
+  publishResourceEvent: vi.fn(),
   setDecision: vi.fn(),
   taskResolve: vi.fn(),
   updateStatus: vi.fn(),
@@ -20,8 +23,15 @@ vi.mock('@/database/models/acceptance', () => ({
 vi.mock('@/database/models/verifyRun', () => ({
   VerifyRunModel: vi.fn(() => ({
     listByAcceptance: mocks.listByAcceptance,
+    mergeDecisionDetail: mocks.mergeDecisionDetail,
     setDecision: mocks.setDecision,
   })),
+}));
+vi.mock('@/server/services/resourceEvents', () => ({
+  publishResourceEvent: mocks.publishResourceEvent,
+}));
+vi.mock('@/server/services/verify/acceptanceWatchers', () => ({
+  hasActiveAcceptanceWatcher: mocks.hasActiveWatcher,
 }));
 vi.mock('@/database/models/verifyCheckResult', () => ({ VerifyCheckResultModel: vi.fn() }));
 vi.mock('@/database/models/verifyEvidence', () => ({ VerifyEvidenceModel: vi.fn() }));
@@ -46,6 +56,7 @@ describe('AcceptanceService decision gating', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.listByAcceptance.mockResolvedValue([{ id: 'run-1', roundIndex: 1 }]);
+    mocks.hasActiveWatcher.mockResolvedValue(true);
   });
 
   it.each(['pending', 'planned', 'verifying', 'repairing'])(
@@ -87,6 +98,10 @@ describe('AcceptanceService decision gating', () => {
       expect.objectContaining({ comment: 'looks good', decidedBy: 'user-1' }),
     );
     expect(mocks.updateStatus).toHaveBeenCalledWith('acc-1', 'accepted');
+    expect(mocks.publishResourceEvent).toHaveBeenCalledWith(
+      { id: 'acc-1', type: 'acceptance' },
+      { actorId: 'user-1', type: 'acceptance.accepted' },
+    );
   });
 
   it('rejects a settled delivery with the re-tasking comment', async () => {
@@ -100,5 +115,46 @@ describe('AcceptanceService decision gating', () => {
       expect.objectContaining({ comment: 'dark mode needs a screenshot' }),
     );
     expect(mocks.updateStatus).toHaveBeenCalledWith('acc-1', 'rejected');
+    expect(mocks.publishResourceEvent).toHaveBeenCalledWith(
+      { id: 'acc-1', type: 'acceptance' },
+      expect.objectContaining({
+        data: { roundIndex: 1 },
+        type: 'acceptance.feedbackSubmitted',
+      }),
+    );
+  });
+
+  it('submits accumulated feedback once and reports an active watcher', async () => {
+    mocks.findById.mockResolvedValue(acceptance('delivered'));
+
+    const result = await service().submitFeedback('acc-1');
+
+    expect(mocks.mergeDecisionDetail).toHaveBeenCalledWith(
+      'run-1',
+      expect.objectContaining({ feedbackSubmittedBy: 'user-1' }),
+    );
+    expect(mocks.updateStatus).toHaveBeenCalledWith('acc-1', 'repairing');
+    expect(result).toMatchObject({ alreadySubmitted: false, roundIndex: 1, watcherActive: true });
+    expect(mocks.publishResourceEvent).toHaveBeenCalledWith(
+      { id: 'acc-1', type: 'acceptance' },
+      expect.objectContaining({ type: 'acceptance.feedbackSubmitted' }),
+    );
+  });
+
+  it('does not rewrite or redispatch fallback work when feedback was already submitted', async () => {
+    mocks.findById.mockResolvedValue(acceptance('repairing'));
+    mocks.listByAcceptance.mockResolvedValue([
+      {
+        decisionDetail: { feedbackSubmittedAt: '2026-07-28T08:00:00.000Z' },
+        id: 'run-1',
+        roundIndex: 1,
+      },
+    ]);
+    mocks.hasActiveWatcher.mockResolvedValue(false);
+
+    const result = await service().submitFeedback('acc-1');
+
+    expect(result).toMatchObject({ alreadySubmitted: true, watcherActive: false });
+    expect(mocks.mergeDecisionDetail).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/services/verify/__tests__/acceptanceWatchers.test.ts
+++ b/apps/server/src/services/verify/__tests__/acceptanceWatchers.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  hasActiveAcceptanceWatcher,
+  releaseAcceptanceWatcher,
+  renewAcceptanceWatcher,
+} from '../acceptanceWatchers';
+
+vi.mock('@/server/modules/AgentRuntime/redis', () => ({
+  getAgentRuntimeRedisClient: () => null,
+}));
+
+describe('acceptance watcher leases', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('tracks and releases a local watcher when Redis is unavailable', async () => {
+    await renewAcceptanceWatcher('acceptance-1', 2, 'watcher-1');
+    await expect(hasActiveAcceptanceWatcher('acceptance-1', 2)).resolves.toBe(true);
+
+    await releaseAcceptanceWatcher('acceptance-1', 2, 'watcher-1');
+    await expect(hasActiveAcceptanceWatcher('acceptance-1', 2)).resolves.toBe(false);
+  });
+
+  it('expires stale watcher leases', async () => {
+    vi.useFakeTimers();
+    await renewAcceptanceWatcher('acceptance-2', 1, 'watcher-2', 1000);
+    await vi.advanceTimersByTimeAsync(1001);
+
+    await expect(hasActiveAcceptanceWatcher('acceptance-2', 1)).resolves.toBe(false);
+  });
+});

--- a/apps/server/src/services/verify/acceptanceService.ts
+++ b/apps/server/src/services/verify/acceptanceService.ts
@@ -30,6 +30,8 @@ import type {
 import type { LobeChatDatabase } from '@/database/type';
 import { TaskService } from '@/server/services/task';
 
+import { publishResourceEvent } from '../resourceEvents';
+import { hasActiveAcceptanceWatcher } from './acceptanceWatchers';
 import { computeFalseFlags } from './feedbackService';
 
 const log = debug('lobe-server:verify-acceptance');
@@ -527,6 +529,10 @@ export class AcceptanceService {
 
     await this.stampDecision(acceptanceId, 'accept', comment);
     await this.acceptanceModel.updateStatus(acceptanceId, 'accepted');
+    await publishResourceEvent(
+      { id: acceptanceId, type: 'acceptance' },
+      { actorId: this.userId, type: 'acceptance.accepted' },
+    );
 
     if (acceptance.subjectType === 'task') await this.completeTaskSubject(acceptance.subjectId);
 
@@ -543,10 +549,71 @@ export class AcceptanceService {
   reject = async (acceptanceId: string, comment: string): Promise<AcceptanceItem> => {
     await this.requireDecidableAcceptance(acceptanceId);
 
-    await this.stampDecision(acceptanceId, 'reject', comment);
+    const submitted = await this.stampDecision(acceptanceId, 'reject', comment, true);
     await this.acceptanceModel.updateStatus(acceptanceId, 'rejected');
+    await publishResourceEvent(
+      { id: acceptanceId, type: 'acceptance' },
+      {
+        actorId: this.userId,
+        data: { roundIndex: submitted.roundIndex },
+        type: 'acceptance.feedbackSubmitted',
+      },
+    );
 
     return (await this.acceptanceModel.findById(acceptanceId))!;
+  };
+
+  /**
+   * Commit all check/group feedback accumulated on the current round and wake
+   * its managed CLI watcher. This is deliberately separate from editing an
+   * individual review: only the explicit final hand-off terminates `watch`.
+   */
+  submitFeedback = async (
+    acceptanceId: string,
+  ): Promise<{
+    alreadySubmitted: boolean;
+    roundIndex: number;
+    submittedAt: string;
+    watcherActive: boolean;
+  }> => {
+    const acceptance = await this.acceptanceModel.findById(acceptanceId);
+    if (!acceptance) throw new Error(`Acceptance "${acceptanceId}" not found`);
+    if (acceptance.status === 'accepted')
+      throw new Error('This delivery has already been accepted');
+    if (!['delivered', 'errored', 'repairing', 'rejected'].includes(acceptance.status)) {
+      throw new Error(
+        `Verification is still in progress (${acceptance.status}) — feedback can be submitted once the round settles`,
+      );
+    }
+
+    const runs = await this.runModel.listByAcceptance(acceptanceId);
+    const current = runs.at(-1);
+    if (!current) throw new Error('This acceptance has no verification round to review');
+
+    const alreadySubmitted = Boolean(current.decisionDetail?.feedbackSubmittedAt);
+    const submittedAt = current.decisionDetail?.feedbackSubmittedAt ?? new Date().toISOString();
+    if (!alreadySubmitted) {
+      await this.runModel.mergeDecisionDetail(current.id, {
+        feedbackSubmittedAt: submittedAt,
+        feedbackSubmittedBy: this.userId,
+      });
+    }
+
+    const roundIndex = current.roundIndex ?? 0;
+    const watcherActive = await hasActiveAcceptanceWatcher(acceptanceId, roundIndex);
+    if (acceptance.status !== 'rejected') {
+      await this.acceptanceModel.updateStatus(acceptanceId, 'repairing');
+    }
+    await publishResourceEvent(
+      { id: acceptanceId, type: 'acceptance' },
+      {
+        actorId: this.userId,
+        data: { roundIndex },
+        type: 'acceptance.feedbackSubmitted',
+      },
+    );
+
+    return { alreadySubmitted, roundIndex, submittedAt, watcherActive };
   };
 
   /**
@@ -670,7 +737,8 @@ export class AcceptanceService {
     acceptanceId: string,
     decision: 'accept' | 'reject',
     comment?: string,
-  ): Promise<void> => {
+    submitFeedback = false,
+  ): Promise<{ roundIndex: number }> => {
     const runs = await this.runModel.listByAcceptance(acceptanceId);
     const current = runs.at(-1);
     if (!current) throw new Error('This acceptance has no verification round to decide on');
@@ -679,8 +747,12 @@ export class AcceptanceService {
       decidedAt: new Date().toISOString(),
       decidedBy: this.userId,
       ...(comment ? { comment } : {}),
+      ...(submitFeedback
+        ? { feedbackSubmittedAt: new Date().toISOString(), feedbackSubmittedBy: this.userId }
+        : {}),
     };
     await this.runModel.setDecision(current.id, decision, detail);
+    return { roundIndex: current.roundIndex ?? 0 };
   };
 
   /**

--- a/apps/server/src/services/verify/acceptanceWatchers.ts
+++ b/apps/server/src/services/verify/acceptanceWatchers.ts
@@ -1,0 +1,93 @@
+import debug from 'debug';
+
+import { getAgentRuntimeRedisClient } from '@/server/modules/AgentRuntime/redis';
+
+const log = debug('lobe-server:acceptance-watchers');
+
+export const ACCEPTANCE_WATCHER_LEASE_MS = 90_000;
+
+const localWatchers = new Map<string, Map<string, number>>();
+
+const watcherKey = (acceptanceId: string, roundIndex: number): string =>
+  `acceptance:${acceptanceId}:round:${roundIndex}:watchers`;
+
+const pruneLocal = (key: string, now = Date.now()): Map<string, number> => {
+  const watchers = localWatchers.get(key) ?? new Map<string, number>();
+  for (const [watcherId, expiresAt] of watchers) {
+    if (expiresAt <= now) watchers.delete(watcherId);
+  }
+  if (watchers.size === 0) localWatchers.delete(key);
+  else localWatchers.set(key, watchers);
+  return watchers;
+};
+
+/** Register or refresh one active SSE watcher. */
+export const renewAcceptanceWatcher = async (
+  acceptanceId: string,
+  roundIndex: number,
+  watcherId: string,
+  leaseMs = ACCEPTANCE_WATCHER_LEASE_MS,
+): Promise<void> => {
+  const key = watcherKey(acceptanceId, roundIndex);
+  const expiresAt = Date.now() + leaseMs;
+  const redis = getAgentRuntimeRedisClient();
+
+  if (redis) {
+    try {
+      await redis
+        .multi()
+        .zadd(key, expiresAt, watcherId)
+        .zremrangebyscore(key, 0, Date.now())
+        .expire(key, Math.ceil((leaseMs * 2) / 1000))
+        .exec();
+      return;
+    } catch (error) {
+      log('failed to renew Redis watcher lease; using local fallback %O', error);
+    }
+  }
+
+  const watchers = pruneLocal(key);
+  watchers.set(watcherId, expiresAt);
+  localWatchers.set(key, watchers);
+};
+
+/** Remove a watcher immediately when its SSE request closes. */
+export const releaseAcceptanceWatcher = async (
+  acceptanceId: string,
+  roundIndex: number,
+  watcherId: string,
+): Promise<void> => {
+  const key = watcherKey(acceptanceId, roundIndex);
+  const redis = getAgentRuntimeRedisClient();
+  if (redis) {
+    try {
+      await redis.zrem(key, watcherId);
+    } catch (error) {
+      log('failed to release Redis watcher lease %O', error);
+    }
+  }
+
+  const watchers = pruneLocal(key);
+  watchers.delete(watcherId);
+  if (watchers.size === 0) localWatchers.delete(key);
+};
+
+/** Whether the final-submit action can rely on a managed background watcher. */
+export const hasActiveAcceptanceWatcher = async (
+  acceptanceId: string,
+  roundIndex: number,
+): Promise<boolean> => {
+  const key = watcherKey(acceptanceId, roundIndex);
+  const redis = getAgentRuntimeRedisClient();
+  if (redis) {
+    try {
+      const now = Date.now();
+      const results = await redis.multi().zremrangebyscore(key, 0, now).zcard(key).exec();
+      return Number(results?.[1]?.[1] ?? 0) > 0;
+    } catch (error) {
+      log('failed to inspect Redis watcher lease; using local fallback %O', error);
+    }
+  }
+
+  return pruneLocal(key).size > 0;
+};

--- a/apps/server/src/services/verify/index.ts
+++ b/apps/server/src/services/verify/index.ts
@@ -9,6 +9,12 @@ export {
   buildAcceptanceCheckUnion,
   buildCheckReviewOverlay,
 } from './acceptanceService';
+export {
+  ACCEPTANCE_WATCHER_LEASE_MS,
+  hasActiveAcceptanceWatcher,
+  releaseAcceptanceWatcher,
+  renewAcceptanceWatcher,
+} from './acceptanceWatchers';
 export { createVerifierAgentRunner } from './agentVerifier';
 export { coverageGaps, readRequiredEvidence } from './evidenceCoverage';
 export { createEvidenceFileResolver, type EvidenceFileMeta } from './evidenceFiles';

--- a/locales/en-US/verify.json
+++ b/locales/en-US/verify.json
@@ -22,6 +22,7 @@
   "acceptance.bar.copied": "Copied — paste it to any agent to start the repair.",
   "acceptance.bar.copyReview": "Copy review prompt",
   "acceptance.bar.feedback": "Feedback {{count}}",
+  "acceptance.bar.feedbackSubmitted": "Feedback submitted — the agent is resuming.",
   "acceptance.bar.needsFix": "All reviewed — {{count}} to fix",
   "acceptance.bar.progress": "Confirmed {{done}} / {{total}} checks — {{rest}} awaiting your review",
   "acceptance.bar.progressDone": "All {{total}} checks confirmed — ready to accept",

--- a/locales/zh-CN/verify.json
+++ b/locales/zh-CN/verify.json
@@ -22,6 +22,7 @@
   "acceptance.bar.copied": "已复制，粘贴给任意 agent 即可开始修复。",
   "acceptance.bar.copyReview": "复制 review 建议",
   "acceptance.bar.feedback": "反馈 {{count}}",
+  "acceptance.bar.feedbackSubmitted": "反馈已提交，Agent 正在继续处理。",
   "acceptance.bar.needsFix": "已全部评审 · {{count}} 项待修复",
   "acceptance.bar.progress": "已完成 {{done}} / {{total}} 项验证项，剩余 {{rest}} 项等待你的验收",
   "acceptance.bar.progressDone": "{{total}} 项验证项已全部确认，可以接受交付",

--- a/packages/database/src/models/__tests__/acceptance.test.ts
+++ b/packages/database/src/models/__tests__/acceptance.test.ts
@@ -178,6 +178,11 @@ describe('VerifyRunModel acceptance chain', () => {
     const runModel = new VerifyRunModel(serverDB, userId);
     const run = await runModel.create({ source: 'agent-testing' });
     await runModel.attachToAcceptance(run.id, acceptance.id);
+    await runModel.appendGroupFeedback(run.id, {
+      category: 'empty state',
+      comment: 'show the recovery action',
+      createdAt: new Date().toISOString(),
+    });
 
     await runModel.setDecision(run.id, 'reject', {
       comment: 'dark mode needs a screenshot',
@@ -188,6 +193,7 @@ describe('VerifyRunModel acceptance chain', () => {
     const found = await runModel.findById(run.id);
     expect(found?.userDecision).toBe('reject');
     expect(found?.decisionDetail?.comment).toBe('dark mode needs a screenshot');
+    expect(found?.decisionDetail?.groupFeedback).toHaveLength(1);
   });
 
   it('rejects attaching a run that is not owned by the caller', async () => {

--- a/packages/database/src/models/verifyRun.ts
+++ b/packages/database/src/models/verifyRun.ts
@@ -314,14 +314,42 @@ export class VerifyRunModel {
     return decisionDetail;
   };
 
+  /** Merge lifecycle metadata into the round without discarding review feedback. */
+  mergeDecisionDetail = async (
+    runId: string,
+    patch: Partial<VerifyRunDecisionDetail>,
+  ): Promise<VerifyRunDecisionDetail> => {
+    const run = await this.db.query.verifyRuns.findFirst({
+      where: and(eq(verifyRuns.id, runId), this.ownership()),
+    });
+    if (!run) throw new Error(`Verify run "${runId}" not found in the current workspace`);
+
+    const decisionDetail: VerifyRunDecisionDetail = { ...run.decisionDetail, ...patch };
+    await this.db
+      .update(verifyRuns)
+      .set({ decisionDetail })
+      .where(and(eq(verifyRuns.id, runId), this.ownership()));
+    return decisionDetail;
+  };
+
   setDecision = async (
     runId: string,
     userDecision: string,
     decisionDetail?: VerifyRunDecisionDetail,
   ): Promise<void> => {
+    const run = await this.db.query.verifyRuns.findFirst({
+      where: and(eq(verifyRuns.id, runId), this.ownership()),
+    });
+    if (!run) throw new Error(`Verify run "${runId}" not found in the current workspace`);
+
     await this.db
       .update(verifyRuns)
-      .set({ decisionDetail, userDecision })
+      .set({
+        decisionDetail: decisionDetail
+          ? { ...run.decisionDetail, ...decisionDetail }
+          : run.decisionDetail,
+        userDecision,
+      })
       .where(and(eq(verifyRuns.id, runId), this.ownership()));
   };
 

--- a/packages/locales/src/default/verify.ts
+++ b/packages/locales/src/default/verify.ts
@@ -29,6 +29,7 @@ export default {
   'acceptance.bar.copied': 'Copied — paste it to any agent to start the repair.',
   'acceptance.bar.copyReview': 'Copy review prompt',
   'acceptance.bar.feedback': 'Feedback {{count}}',
+  'acceptance.bar.feedbackSubmitted': 'Feedback submitted — the agent is resuming.',
   'acceptance.bar.needsFix': 'All reviewed — {{count}} to fix',
   'acceptance.bar.progress':
     'Confirmed {{done}} / {{total}} checks — {{rest}} awaiting your review',

--- a/packages/types/src/verify.ts
+++ b/packages/types/src/verify.ts
@@ -282,6 +282,14 @@ export interface VerifyRunDecisionDetail {
   decidedAt?: string;
   /** Who made the decision (user id) — set when it may differ from the run owner. */
   decidedBy?: string;
+  /**
+   * The explicit hand-off boundary for this round's accumulated feedback.
+   * Individual check/group edits remain drafts until this timestamp is set;
+   * acceptance watchers terminate only after this durable marker exists.
+   */
+  feedbackSubmittedAt?: string;
+  /** User who submitted the round feedback. */
+  feedbackSubmittedBy?: string;
   /** Attachments backing the decision (annotated screenshots, etc.) — FKs to files. */
   fileIds?: string[];
   /**

--- a/src/app/(backend)/webapi/acceptance/events/route.test.ts
+++ b/src/app/(backend)/webapi/acceptance/events/route.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GET } from './route';
+
+const readStringStream = async (response: Response): Promise<string> => {
+  const reader = response.body!.getReader();
+  let body = '';
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) return body;
+    body += value as unknown as string;
+  }
+};
+
+const mocks = vi.hoisted(() => ({
+  findById: vi.fn(),
+  loadRounds: vi.fn(),
+  releaseWatcher: vi.fn(),
+  renewWatcher: vi.fn(),
+  subscribe: vi.fn(),
+}));
+
+vi.mock('@/app/(backend)/middleware/auth', () => ({
+  checkAuth:
+    (handler: any) =>
+    (req: Request): Promise<Response> =>
+      handler(req, { serverDB: {}, userId: 'user-1' }),
+}));
+vi.mock('@/server/services/resourceEvents', () => ({
+  subscribeResourceEvents: mocks.subscribe,
+}));
+vi.mock('@/server/services/verify', () => ({
+  AcceptanceService: vi.fn(() => ({
+    acceptanceModel: { findById: mocks.findById },
+    loadRounds: mocks.loadRounds,
+  })),
+  releaseAcceptanceWatcher: mocks.releaseWatcher,
+  renewAcceptanceWatcher: mocks.renewWatcher,
+}));
+vi.mock('../../_utils/workspace', () => ({
+  resolveValidWorkspaceIdFromRequest: vi.fn().mockResolvedValue(undefined),
+  WORKSPACE_ID_HEADER: 'X-Workspace-Id',
+}));
+
+describe('acceptance events route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findById.mockResolvedValue({ id: 'acceptance-1', status: 'delivered' });
+    mocks.renewWatcher.mockResolvedValue(undefined);
+    mocks.releaseWatcher.mockResolvedValue(undefined);
+    mocks.subscribe.mockImplementation(
+      (_ref: unknown, _listener: unknown, signal: AbortSignal) =>
+        new Promise<void>((resolve) =>
+          signal.addEventListener('abort', () => resolve(), { once: true }),
+        ),
+    );
+  });
+
+  it('replays a durable feedback submission and closes the stream', async () => {
+    mocks.loadRounds.mockResolvedValue({
+      runs: [
+        {
+          decisionDetail: { feedbackSubmittedAt: '2026-07-28T08:00:00.000Z' },
+          roundIndex: 1,
+        },
+      ],
+    });
+
+    const response = await GET(
+      new Request('https://app.lobehub.com/webapi/acceptance/events?id=acceptance-1&round=1'),
+      {} as any,
+    );
+    const body = await readStringStream(response);
+
+    expect(body).toContain('event: acceptance.feedbackSubmitted');
+    expect(mocks.renewWatcher).toHaveBeenCalledWith('acceptance-1', 1, expect.any(String));
+    expect(mocks.releaseWatcher).toHaveBeenCalledWith('acceptance-1', 1, expect.any(String));
+  });
+
+  it('terminates an outstanding round when the aggregate is accepted', async () => {
+    mocks.findById.mockResolvedValue({ id: 'acceptance-1', status: 'accepted' });
+    mocks.loadRounds.mockResolvedValue({ runs: [{ decisionDetail: {}, roundIndex: 1 }] });
+
+    const response = await GET(
+      new Request('https://app.lobehub.com/webapi/acceptance/events?id=acceptance-1&round=1'),
+      {} as any,
+    );
+
+    await expect(readStringStream(response)).resolves.toContain('event: acceptance.accepted');
+  });
+});

--- a/src/app/(backend)/webapi/acceptance/events/route.ts
+++ b/src/app/(backend)/webapi/acceptance/events/route.ts
@@ -1,0 +1,147 @@
+import { createSSEHeaders, createSSEWriter } from '@lobechat/utils/server';
+import debug from 'debug';
+
+import { checkAuth } from '@/app/(backend)/middleware/auth';
+import { subscribeResourceEvents } from '@/server/services/resourceEvents';
+import {
+  AcceptanceService,
+  releaseAcceptanceWatcher,
+  renewAcceptanceWatcher,
+} from '@/server/services/verify';
+
+import { resolveValidWorkspaceIdFromRequest, WORKSPACE_ID_HEADER } from '../../_utils/workspace';
+
+const log = debug('api-route:acceptance:events');
+
+export const maxDuration = 300;
+export const runtime = 'nodejs';
+
+const jsonError = (message: string, status: number) =>
+  new Response(JSON.stringify({ error: message }), {
+    headers: { 'Content-Type': 'application/json' },
+    status,
+  });
+
+/**
+ * One-shot acceptance watch stream. It remains quiet except for connection /
+ * heartbeat frames, then emits exactly one terminal domain event and closes.
+ * The CLI refetches the canonical bundle after that signal.
+ */
+export const GET = checkAuth(async (req, { userId, serverDB }) => {
+  const url = new URL(req.url);
+  const acceptanceId = url.searchParams.get('id')?.trim();
+  if (!acceptanceId) return jsonError('id is required', 400);
+
+  const requestedWorkspaceId = req.headers.get(WORKSPACE_ID_HEADER)?.trim();
+  const workspaceId = await resolveValidWorkspaceIdFromRequest({ req, serverDB, userId });
+  if (requestedWorkspaceId && !workspaceId) return jsonError('workspace access required', 403);
+
+  const service = new AcceptanceService(serverDB, userId, workspaceId);
+  const acceptance = await service.acceptanceModel.findById(acceptanceId);
+  if (!acceptance) return jsonError('acceptance not found', 404);
+
+  const requestedRound = url.searchParams.get('round');
+  const parsedRound = requestedRound === null ? undefined : Number(requestedRound);
+  if (parsedRound !== undefined && (!Number.isInteger(parsedRound) || parsedRound < 1)) {
+    return jsonError('round must be a positive integer', 400);
+  }
+
+  const initialRounds = (await service.loadRounds(acceptanceId)).runs;
+  const roundIndex = parsedRound ?? initialRounds.at(-1)?.roundIndex;
+  if (!roundIndex || !initialRounds.some((run) => run.roundIndex === roundIndex)) {
+    return jsonError('acceptance round not found', 404);
+  }
+
+  const ref = { id: acceptanceId, type: 'acceptance' as const };
+  const watcherId = crypto.randomUUID();
+  let cleanup = () => {};
+
+  const stream = new ReadableStream<string>({
+    cancel() {
+      cleanup();
+    },
+    async start(controller) {
+      const writer = createSSEWriter(controller);
+      const abort = new AbortController();
+      let cleaned = false;
+      let finished = false;
+
+      const finish = (type: 'acceptance.accepted' | 'acceptance.feedbackSubmitted') => {
+        if (finished) return;
+        finished = true;
+        writer.writeEvent({ data: { roundIndex, type }, event: type });
+        cleanup();
+        controller.close();
+      };
+
+      const reconcile = async () => {
+        if (finished) return;
+        try {
+          const currentAcceptance = await service.acceptanceModel.findById(acceptanceId);
+          if (currentAcceptance?.status === 'accepted') {
+            finish('acceptance.accepted');
+            return;
+          }
+
+          const target = (await service.loadRounds(acceptanceId)).runs.find(
+            (run) => run.roundIndex === roundIndex,
+          );
+          if (target?.decisionDetail?.feedbackSubmittedAt) {
+            finish('acceptance.feedbackSubmitted');
+          }
+        } catch (error) {
+          log('reconciliation failed for %s r%d %O', acceptanceId, roundIndex, error);
+        }
+      };
+
+      await renewAcceptanceWatcher(acceptanceId, roundIndex, watcherId);
+      writer.writeConnection(acceptanceId, '$');
+
+      const heartbeat = setInterval(() => {
+        if (finished) return;
+        try {
+          writer.writeHeartbeat();
+        } catch {
+          cleanup();
+          return;
+        }
+        void renewAcceptanceWatcher(acceptanceId, roundIndex, watcherId);
+        void reconcile();
+      }, 30_000);
+
+      cleanup = () => {
+        if (cleaned) return;
+        cleaned = true;
+        finished = true;
+        if (!abort.signal.aborted) abort.abort();
+        clearInterval(heartbeat);
+        req.signal.removeEventListener('abort', cleanup);
+        void releaseAcceptanceWatcher(acceptanceId, roundIndex, watcherId);
+      };
+
+      void subscribeResourceEvents(
+        ref,
+        (event) => {
+          if (event.type === 'acceptance.accepted') {
+            finish('acceptance.accepted');
+            return;
+          }
+          if (
+            event.type === 'acceptance.feedbackSubmitted' &&
+            event.data?.roundIndex === roundIndex
+          ) {
+            finish('acceptance.feedbackSubmitted');
+          }
+        },
+        abort.signal,
+      ).catch((error) => {
+        if (!abort.signal.aborted) log('subscription error %O', error);
+      });
+
+      req.signal.addEventListener('abort', cleanup, { once: true });
+      await reconcile();
+    },
+  });
+
+  return new Response(stream, { headers: createSSEHeaders() });
+});

--- a/src/features/Verify/Acceptance/DecisionBar.tsx
+++ b/src/features/Verify/Acceptance/DecisionBar.tsx
@@ -146,7 +146,7 @@ interface DecisionBarProps {
   /** A live round that is a dispatched repair — coloured as an in-progress task
       (warning), not a neutral verify, to match the system's task-process cue. */
   repairing?: boolean;
-  /** The origin conversation is known — the rerun dispatch has a target. */
+  /** The feedback can be finalized; a watcher or fallback dispatch handles continuation. */
   rerunAvailable: boolean;
   rerunPending: boolean;
   state: BarState;

--- a/src/features/Verify/Acceptance/index.tsx
+++ b/src/features/Verify/Acceptance/index.tsx
@@ -976,42 +976,36 @@ const AcceptancePage = memo<AcceptancePageProps>(
       });
     };
 
-    // Dispatch the repair prompt straight into the origin conversation — the
-    // agent reads the feedback itself via the CLI, no hand-summarizing. The
-    // aggregate is stamped `repairing` so the page (and the list) show the
-    // send-back took effect instead of sitting unchanged.
-    //
-    // Portal embed exception: the acceptance sits beside the live conversation, so
-    // a send-back drafts the prompt into the user's own composer (left) for them
-    // to review and send — never a silent backend post behind their back.
+    // Commit the whole round's feedback once. A managed CLI watcher is the
+    // primary continuation channel; only when no watcher exists do we retain
+    // the legacy origin-conversation dispatch / embedded draft.
     const handleRerun = async () => {
-      if (isEmbedded) {
-        // The portal handler drafts into the composer AND syncs its input state so
-        // Send enables; only toast once it actually landed (composer mounted).
-        if (onDraftToComposer?.(repairPrompt)) {
-          toast.success({
-            placement: 'bottom',
-            style: { marginBlockEnd: 88 },
-            title: t('acceptance.bar.rerunDrafted'),
-          });
-        }
-        return;
-      }
-      if (!origin?.topic) return;
       setRerunPending(true);
       try {
-        await verifyService.dispatchAcceptanceRepair({
-          agentId: origin.agent?.id,
-          content: repairPrompt,
-          topicId: origin.topic.id,
-        });
-        await verifyService.markAcceptanceRepairing(acceptance.id);
+        const submission = await verifyService.submitAcceptanceFeedback(acceptance.id);
+        let successMessage = t('acceptance.bar.feedbackSubmitted');
+
+        if (!submission.alreadySubmitted && !submission.watcherActive && isEmbedded) {
+          // The portal handler drafts into the composer AND syncs its input state
+          // so Send enables; the user remains in control of the fallback message.
+          if (onDraftToComposer?.(repairPrompt)) {
+            successMessage = t('acceptance.bar.rerunDrafted');
+          }
+        } else if (!submission.alreadySubmitted && !submission.watcherActive && origin?.topic) {
+          await verifyService.dispatchAcceptanceRepair({
+            agentId: origin.agent?.id,
+            content: repairPrompt,
+            topicId: origin.topic.id,
+          });
+          successMessage = t('acceptance.bar.rerunSent');
+        }
+
         await mutate();
         void globalMutate(verifyKeys.acceptances());
         toast.success({
           placement: 'bottom',
           style: { marginBlockEnd: 88 },
-          title: t('acceptance.bar.rerunSent'),
+          title: successMessage,
         });
       } catch (cause) {
         toast.error(cause instanceof Error ? cause.message : t('acceptance.actionError'));
@@ -1799,6 +1793,7 @@ const AcceptancePage = memo<AcceptancePageProps>(
               queueing feedback are the author's calls, never a visitor's. */}
             {isOwner && !focusedCheck && acceptance.status !== 'closed' && (
               <DecisionBar
+                rerunAvailable
                 acceptedCount={acceptedCount}
                 embedded={isEmbedded}
                 feedbackCount={activeFeedbackCount}
@@ -1806,7 +1801,6 @@ const AcceptancePage = memo<AcceptancePageProps>(
                 needsFixCount={needsFixCount}
                 pending={pending}
                 repairing={acceptance.status === 'repairing'}
-                rerunAvailable={isEmbedded || Boolean(origin?.topic)}
                 rerunPending={rerunPending}
                 state={barState}
                 statusText={barTexts.statusText}

--- a/src/services/verify.ts
+++ b/src/services/verify.ts
@@ -207,6 +207,9 @@ export class VerifyService {
       topicId: input.topicId,
     });
 
+  /** Commit the current round's review and wake its managed background watcher. */
+  submitAcceptanceFeedback = (id: string) => lambdaClient.acceptance.submitFeedback.mutate({ id });
+
   /** Stamp the aggregate `repairing` after the send-back dispatch. */
   markAcceptanceRepairing = (id: string) => lambdaClient.acceptance.markRepairing.mutate({ id });
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Adds a one-shot acceptance feedback watcher for agent-managed verification loops.

- adds `lh acceptance watch <id> --round <index>` backed by an authenticated SSE route;
- persists the explicit feedback-submission boundary on the immutable verification round;
- exits only when the selected round's feedback is submitted or the acceptance is accepted;
- prints concise, readable repair context by default, with optional JSON output;
- tracks short-lived watcher leases so the UI avoids duplicate origin-conversation dispatch;
- updates the agent-testing skill to keep the watcher as a managed background task and automatically publish follow-up rounds.

#### 🧭 Key Decisions / Non-goals

- SSE is a wake-up signal only. The CLI refetches the canonical acceptance bundle before printing feedback.
- Individual check and group edits remain drafts; only the explicit final submission sets `feedbackSubmittedAt`.
- The durable marker provides reconnect recovery without a database migration because decision detail is existing JSONB.
- The legacy conversation dispatch remains a fallback only when no active watcher lease exists.
- This PR does not introduce shell-detached background processes; task ownership remains with the agent runtime.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

### Automated Tests

- Targeted repository check: lint clean and 86 related tests passed.
- `pnpm -C apps/cli build`
- SSE route tests cover durable feedback replay and accepted termination.
- CLI tests cover silent waiting, readable feedback output, JSON opt-in, and accepted termination.

### Manual Verification

- Verified that the default terminal payload includes accepted checks, rejected checks, annotations, attachments, group feedback, and the overall comment.
- Verified that the watcher remains open before the durable submission marker exists.

#### 📝 Additional Information

- No environment variables, schema migration, or data backfill is required.
- The full workspace type-check remains blocked by pre-existing errors outside this change; no errors matched the new acceptance watcher files in the filtered audit.
