### PR TITLE
✨ feat: add Modelsell provider

### DIFF
--- a/locales/en-US/providers.json
+++ b/locales/en-US/providers.json
@@ -41,6 +41,7 @@
   "minimaxcodingplan.description": "MiniMax Token Plan provides access to MiniMax models including M2.7 for coding tasks via a fixed-fee subscription.",
   "mistral.description": "Mistral offers advanced general, specialized, and research models for complex reasoning, multilingual tasks, and code generation, with function-calling for custom integrations.",
   "modelscope.description": "ModelScope is Alibaba Cloud’s model-as-a-service platform, offering a wide range of AI models and inference services.",
+  "modelsell.description": "Modelsell provides unified access to multiple AI models through an OpenAI-compatible API.",
   "moonshot.description": "Moonshot, from Moonshot AI (Beijing Moonshot Technology), offers multiple NLP models for use cases like content creation, research, recommendations, and medical analysis, with strong long-context and complex generation support.",
   "nebius.description": "Nebius provides high-performance infrastructure for global AI innovators via large-scale GPU clusters and a vertically integrated cloud platform.",
   "newapi.description": "An open-source aggregation and routing platform for multiple AI services.",

--- a/locales/zh-CN/providers.json
+++ b/locales/zh-CN/providers.json
@@ -41,6 +41,7 @@
   "minimaxcodingplan.description": "MiniMax Token Plan 提供对 MiniMax 模型（包括 M2.7）的访问，适用于编程任务，采用固定月费订阅模式。",
   "mistral.description": "Mistral 提供先进的通用、专业与研究型模型，支持复杂推理、多语言任务与代码生成，具备函数调用能力以实现定制集成。",
   "modelscope.description": "ModelScope 是阿里云的模型即服务平台，提供丰富的 AI 模型与推理服务。",
+  "modelsell.description": "Modelsell 通过兼容 OpenAI 的 API，统一提供多种 AI 模型的访问能力。",
   "moonshot.description": "Moonshot（北京月之暗面科技）推出多款 NLP 模型，适用于内容创作、科研、推荐与医疗分析等场景，具备强大的长文本与复杂生成能力。",
   "nebius.description": "Nebius 通过大规模 GPU 集群与垂直整合的云平台，为全球 AI 创新者提供高性能基础设施。",
   "newapi.description": "一个开源的多 AI 服务聚合与路由平台。",

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -41,6 +41,7 @@ export enum ModelProvider {
   MinimaxCodingPlan = 'minimaxcodingplan',
   Mistral = 'mistral',
   ModelScope = 'modelscope',
+  Modelsell = 'modelsell',
   Moonshot = 'moonshot',
   Nebius = 'nebius',
   NewAPI = 'newapi',

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -43,6 +43,7 @@ import MinimaxProvider from './minimax';
 import MinimaxCodingPlanProvider from './minimaxCodingPlan';
 import MistralProvider from './mistral';
 import ModelScopeProvider from './modelscope';
+import ModelsellProvider from './modelsell';
 import MoonshotProvider from './moonshot';
 import NebiusProvider from './nebius';
 import NewAPIProvider from './newapi';
@@ -217,6 +218,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   ReplicateProvider,
   NebiusProvider,
   CometAPIProvider,
+  ModelsellProvider,
   VercelAIGatewayProvider,
   CerebrasProvider,
   ZenMuxProvider,
@@ -287,6 +289,7 @@ export { default as MinimaxProviderCard } from './minimax';
 export { default as MinimaxCodingPlanProviderCard } from './minimaxCodingPlan';
 export { default as MistralProviderCard } from './mistral';
 export { default as ModelScopeProviderCard } from './modelscope';
+export { default as ModelsellProviderCard } from './modelsell';
 export { default as MoonshotProviderCard } from './moonshot';
 export { default as NebiusProviderCard } from './nebius';
 export { default as NewAPIProviderCard } from './newapi';

--- a/packages/model-bank/src/modelProviders/modelsell.test.ts
+++ b/packages/model-bank/src/modelProviders/modelsell.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_MODEL_PROVIDER_LIST } from './index';
+import Modelsell from './modelsell';
+
+describe('Modelsell provider card', () => {
+  it('registers the OpenAI-compatible provider with dynamic model discovery', () => {
+    expect(DEFAULT_MODEL_PROVIDER_LIST).toContain(Modelsell);
+    expect(Modelsell).toMatchObject({
+      apiKeyUrl: 'https://modelsell.com/console/token',
+      chatModels: [],
+      id: 'modelsell',
+      modelList: { showModelFetcher: true },
+      modelsUrl: 'https://modelsell.com/v1/models',
+      settings: {
+        proxyUrl: { placeholder: 'https://modelsell.com/v1' },
+        sdkType: 'openai',
+        showModelFetcher: true,
+      },
+      url: 'https://modelsell.com',
+    });
+  });
+});

--- a/packages/model-bank/src/modelProviders/modelsell.ts
+++ b/packages/model-bank/src/modelProviders/modelsell.ts
@@ -1,0 +1,23 @@
+import type { ModelProviderCard } from '../types';
+
+const Modelsell: ModelProviderCard = {
+  apiKeyUrl: 'https://modelsell.com/console/token',
+  chatModels: [],
+  description:
+    'Modelsell provides unified access to multiple AI models through an OpenAI-compatible API.',
+  enabled: true,
+  id: 'modelsell',
+  modelList: { showModelFetcher: true },
+  modelsUrl: 'https://modelsell.com/v1/models',
+  name: 'Modelsell',
+  settings: {
+    proxyUrl: {
+      placeholder: 'https://modelsell.com/v1',
+    },
+    sdkType: 'openai',
+    showModelFetcher: true,
+  },
+  url: 'https://modelsell.com',
+};
+
+export default Modelsell;

--- a/packages/model-runtime/src/index.ts
+++ b/packages/model-runtime/src/index.ts
@@ -57,6 +57,7 @@ export { LobeLongCatAI } from './providers/longcat';
 export { LobeMinimaxAI } from './providers/minimax';
 export { LobeMinimaxCodingPlanAI } from './providers/minimaxCodingPlan';
 export { LobeMistralAI } from './providers/mistral';
+export { LobeModelsellAI } from './providers/modelsell';
 export { LobeMoonshotAI } from './providers/moonshot';
 export { isKimiAlwaysPreserveThinkingModel } from './providers/moonshot/modelId';
 export { LobeNebiusAI } from './providers/nebius';

--- a/packages/model-runtime/src/providers/modelsell/index.test.ts
+++ b/packages/model-runtime/src/providers/modelsell/index.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment node
+import { ModelProvider } from 'model-bank';
+import { describe, expect, it } from 'vitest';
+
+import { testProvider } from '../../providerTestUtils';
+import { LobeModelsellAI, params } from './index';
+
+testProvider({
+  Runtime: LobeModelsellAI,
+  chatDebugEnv: 'DEBUG_MODELSELL_CHAT_COMPLETION',
+  chatModel: 'test-model',
+  defaultBaseURL: 'https://modelsell.com/v1',
+  provider: ModelProvider.Modelsell,
+});
+
+describe('LobeModelsellAI', () => {
+  it('uses the Modelsell provider contract', () => {
+    expect(params.baseURL).toBe('https://modelsell.com/v1');
+    expect(params.provider).toBe(ModelProvider.Modelsell);
+  });
+});

--- a/packages/model-runtime/src/providers/modelsell/index.ts
+++ b/packages/model-runtime/src/providers/modelsell/index.ts
@@ -1,0 +1,14 @@
+import { ModelProvider } from 'model-bank';
+
+import type { OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
+import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+
+export const params = {
+  baseURL: 'https://modelsell.com/v1',
+  debug: {
+    chatCompletion: () => process.env.DEBUG_MODELSELL_CHAT_COMPLETION === '1',
+  },
+  provider: ModelProvider.Modelsell,
+} satisfies OpenAICompatibleFactoryOptions;
+
+export const LobeModelsellAI = createOpenAICompatibleRuntime(params);

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -40,6 +40,7 @@ import { LobeMinimaxAI } from './providers/minimax';
 import { LobeMinimaxCodingPlanAI } from './providers/minimaxCodingPlan';
 import { LobeMistralAI } from './providers/mistral';
 import { LobeModelScopeAI } from './providers/modelscope';
+import { LobeModelsellAI } from './providers/modelsell';
 import { LobeMoonshotAI } from './providers/moonshot';
 import { LobeNebiusAI } from './providers/nebius';
 import { LobeNewAPIAI } from './providers/newapi';
@@ -124,6 +125,7 @@ export const providerRuntimeMap = {
   minimax: LobeMinimaxAI,
   minimaxcodingplan: LobeMinimaxCodingPlanAI,
   mistral: LobeMistralAI,
+  modelsell: LobeModelsellAI,
   modelscope: LobeModelScopeAI,
   moonshot: LobeMoonshotAI,
   nebius: LobeNebiusAI,


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| Modelsell was not available as a built-in provider. | Modelsell is available with an OpenAI-compatible runtime and dynamic model discovery. |

This PR adds:

- a Modelsell provider card with API key and website links
- dynamic model discovery through `https://modelsell.com/v1/models`
- an OpenAI-compatible runtime using `https://modelsell.com/v1`
- provider enum, runtime map, and public exports
- English and Simplified Chinese provider descriptions
- model-bank and runtime regression tests

Models remain dynamically fetched and are not hardcoded. No live authenticated Modelsell API call was performed.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation performed:

- `bun run check` passed for all changed files.
- Model-bank provider test passed: 1 test.
- Modelsell runtime test passed: 11 tests.

#### 🔗 Related Issue

Closes #17657
