### PR TITLE
🐛 fix(generation): disable TooltipGroup layout animation in topic grid

### DIFF
--- a/src/routes/(main)/(create)/features/GenerationLayout/Body/List/TopicList.tsx
+++ b/src/routes/(main)/(create)/features/GenerationLayout/Body/List/TopicList.tsx
@@ -54,7 +54,7 @@ const TopicsList = memo<TopicListProps>(({ viewMode = 'auto', visibility }) => {
       {isList ? (
         content
       ) : (
-        <TooltipGroup layoutAnimation>
+        <TooltipGroup>
           <Grid gap={4} maxItemWidth={64} padding={6} rows={6} width={'100%'}>
             {content}
           </Grid>


### PR DESCRIPTION
<!-- Brief and heads-up -->

Remove `layoutAnimation` from `TooltipGroup` wrapping the generation topic grid so tooltips no longer trigger layout animation jank when topics reflow.

| Before | After |
| ------ | ----- |
| Grid topics wrapped in `TooltipGroup layoutAnimation` | Same group without `layoutAnimation` |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Open Create / generation sidebar, switch to grid topic view, hover topics and create/switch topics — tooltips should still work without layout thrashing.

#### 🔗 Related Issue

N/A