### PR TITLE
chore: remove LOBE-XXX markers from recently modified source files

### DIFF
--- a/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
+++ b/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
@@ -612,7 +612,7 @@ export class CompletionLifecycle {
       // `lastAssistantContent` comes off the Redis-backed `state.messages`,
       // while the assistant message row is persisted through a separate
       // `messageModel.update` path. When the two diverge (state entry empty
-      // but the DB row holds the full reply — LOBE-11632: bot completions
+      // but the DB row holds the full reply — Discord bot completions
       // arrived with no content while the app showed the reply), consumers
       // like the IM bot callback silently drop the reply. Recover from the DB
       // row — the same source of truth the app UI renders — before dispatch.
@@ -756,7 +756,7 @@ export class CompletionLifecycle {
   /**
    * Load the final assistant message row from the DB and return its text
    * content, for completions whose Redis-side state carried no assistant
-   * text (see the LOBE-11632 note in {@link dispatchHooks}). Non-fatal: any
+   * text (see the DB recovery note in {@link dispatchHooks}). Non-fatal: any
    * failure just leaves the event as-built.
    */
   private async recoverLastAssistantContent(
@@ -795,7 +795,7 @@ export class CompletionLifecycle {
 
       // console (not debug) so state/DB divergence stays visible in
       // production logs — the silent variant of this is what made
-      // LOBE-11632 hard to diagnose.
+      // the Discord bot empty-reply issue hard to diagnose.
       console.warn(
         `[CompletionLifecycle][${operationId}] completion event had no assistant text; recovered ${content.length} chars from message ${assistantMessageId}`,
       );

--- a/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
@@ -787,7 +787,7 @@ describe('CompletionLifecycle.dispatchHooks — parks do not register file works
   });
 });
 
-describe('CompletionLifecycle.dispatchHooks — lastAssistantContent DB recovery (LOBE-11632)', () => {
+describe('CompletionLifecycle.dispatchHooks — lastAssistantContent DB recovery (Discord bot empty-reply)', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });

--- a/packages/types/src/task/index.ts
+++ b/packages/types/src/task/index.ts
@@ -163,7 +163,8 @@ export interface TaskSchedulerContext {
  * cleared on the next successful run so the UI only shows the *current* error —
  * this pocket is append-style history that a later success does NOT wipe. It
  * exists so "the morning check silently didn't fire" is diagnosable after the
- * fact instead of being masked by a later manual success (LOBE-11390).
+ * fact instead of being masked by a later manual success (paused tasks were
+ * silently overwritten to "scheduled" with error cleared on next success).
  */
 export interface TaskLifecycleAudit {
   // Monotonic lifetime count of failed runs (never reset on success).


### PR DESCRIPTION
## Summary

Incremental cleanup of LOBE-XXX comment markers from source files modified on 2026-07-28. Each marker is replaced with descriptive context from the corresponding Linear issue.

## Files changed

| File | Markers removed |
|------|----------------|
| `apps/server/src/services/agentRuntime/CompletionLifecycle.ts` | 3 (LOBE-11632) |
| `apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts` | 1 (LOBE-11632) |
| `packages/types/src/task/index.ts` | 1 (LOBE-11390) |

## Context from Linear

- **LOBE-11632** (Discord Bot 掉线不回复): Bot completions arrived with empty assistant content in Redis state while the DB had the full reply — the recovery path reads from the DB row.
- **LOBE-11390** (paused 静默且自我掩盖): Task lifecycle audit trail to prevent errors being silently masked when a later successful run overwrites the paused status and error.

Auto-generated on 2026-07-28.