### PR TITLE
🐛 fix(agent): inject runtime todos into server context

### DIFF
--- a/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -160,6 +160,13 @@ vi.mock('@/database/models/work', () => ({
   })),
 }));
 
+const { mockFindPlanDocuments } = vi.hoisted(() => ({ mockFindPlanDocuments: vi.fn() }));
+vi.mock('@/database/models/topicDocument', () => ({
+  TopicDocumentModel: vi.fn().mockImplementation(() => ({
+    findByTopicId: mockFindPlanDocuments,
+  })),
+}));
+
 describe('RuntimeExecutors', { timeout: 60_000 }, () => {
   let mockMessageModel: any;
   let mockStreamManager: any;
@@ -178,6 +185,8 @@ describe('RuntimeExecutors', { timeout: 60_000 }, () => {
     mockRegisterDocument.mockResolvedValue({ id: 'doc-work-1' });
     mockRegisterTask.mockReset();
     mockRegisterTask.mockResolvedValue({ id: 'work-1' });
+    mockFindPlanDocuments.mockReset();
+    mockFindPlanDocuments.mockResolvedValue([]);
     vi.mocked(initModelRuntimeFromDB).mockReset();
     mockCreateCompressionGroup.mockReset();
     mockCancelCompression.mockReset();
@@ -2138,6 +2147,177 @@ describe('RuntimeExecutors', { timeout: 60_000 }, () => {
 
       afterEach(() => {
         engineSpy.mockRestore();
+      });
+
+      const stateWithLobeAgent = (overrides?: Partial<AgentState>) =>
+        createMockState({
+          operationToolSet: {
+            enabledToolIds: ['lobe-agent'],
+            executorMap: {},
+            manifestMap: {},
+            sourceMap: {},
+            tools: [],
+          },
+          ...overrides,
+        });
+
+      const callWithMessages = async (
+        messages: any[],
+        state: AgentState,
+        contextOverrides?: Partial<RuntimeExecutorContext>,
+      ) => {
+        const ctxWithConfig: RuntimeExecutorContext = {
+          ...ctx,
+          agentConfig: { plugins: [], systemRole: 'test' },
+          ...contextOverrides,
+        };
+        await createRuntimeExecutors(ctxWithConfig).call_llm!(
+          {
+            payload: { messages, model: 'gpt-4', provider: 'openai' },
+            type: 'call_llm',
+          },
+          state,
+        );
+
+        return mockChat.mock.calls[0][0].messages.find(
+          (message: { role?: string }) => message.role === 'user',
+        )?.content as string;
+      };
+
+      it('injects the newest valid message TODO state and skips Notebook', async () => {
+        mockFindPlanDocuments.mockResolvedValue([
+          {
+            metadata: { todos: [{ status: 'todo', text: 'Stale metadata task' }] },
+            updatedAt: new Date(),
+          },
+        ]);
+        const content = await callWithMessages(
+          [
+            {
+              content: 'old result',
+              pluginState: {
+                todos: { items: [{ status: 'todo', text: 'Old task' }], updatedAt: 'old' },
+              },
+              role: 'tool',
+            },
+            {
+              content: 'new result',
+              pluginState: {
+                todos: { items: [{ status: 'processing', text: 'New task' }], updatedAt: 'new' },
+              },
+              role: 'tool',
+            },
+            { content: 'Continue', role: 'user' },
+          ],
+          stateWithLobeAgent(),
+        );
+
+        expect(content).toContain('New task');
+        expect(content).not.toContain('Old task');
+        expect(content).not.toContain('Stale metadata task');
+        expect(mockFindPlanDocuments).not.toHaveBeenCalled();
+      });
+
+      it.each([
+        { items: [], updatedAt: 'canonical-clear' },
+        [],
+      ])('treats canonical and legacy empty message states as clear tombstones', async (todos) => {
+        mockFindPlanDocuments.mockResolvedValue([
+          {
+            metadata: {
+              todos: { items: [{ status: 'todo', text: 'Stale metadata task' }] },
+            },
+            updatedAt: new Date(),
+          },
+        ]);
+
+        const content = await callWithMessages(
+          [
+            { content: 'cleared', pluginState: { todos }, role: 'tool' },
+            { content: 'Continue', role: 'user' },
+          ],
+          stateWithLobeAgent(),
+        );
+
+        expect(content).not.toContain('<todo_context>');
+        expect(content).not.toContain('Stale metadata task');
+        expect(mockFindPlanDocuments).not.toHaveBeenCalled();
+      });
+
+      it.each([
+        {
+          items: [{ status: 'todo', text: 'Canonical metadata task' }],
+          updatedAt: 'metadata-time',
+        },
+        [{ status: 'todo', text: 'Legacy metadata task' }],
+      ])('falls back to canonical and legacy Notebook metadata', async (todos) => {
+        mockFindPlanDocuments.mockResolvedValue([
+          { metadata: { todos }, updatedAt: new Date('2026-01-01T00:00:00.000Z') },
+        ]);
+
+        const content = await callWithMessages(
+          [{ content: 'Continue', role: 'user' }],
+          stateWithLobeAgent(),
+        );
+
+        expect(content).toContain('metadata task');
+        expect(mockFindPlanDocuments).toHaveBeenCalledWith('topic-123', {
+          type: 'agent/plan',
+        });
+      });
+
+      it('treats empty legacy Notebook metadata as a clear tombstone', async () => {
+        mockFindPlanDocuments.mockResolvedValue([
+          { metadata: { todos: [] }, updatedAt: new Date('2026-01-01T00:00:00.000Z') },
+        ]);
+
+        const content = await callWithMessages(
+          [{ content: 'Continue', role: 'user' }],
+          stateWithLobeAgent(),
+        );
+
+        expect(content).not.toContain('<todo_context>');
+        expect(mockFindPlanDocuments).toHaveBeenCalledOnce();
+      });
+
+      it('uses the runtime context topic for Notebook fallback', async () => {
+        mockFindPlanDocuments.mockResolvedValue([
+          {
+            metadata: {
+              todos: [{ status: 'todo', text: 'Runtime context metadata task' }],
+            },
+            updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+          },
+        ]);
+
+        const content = await callWithMessages(
+          [{ content: 'Continue', role: 'user' }],
+          stateWithLobeAgent({ metadata: { agentId: 'agent-123' } }),
+          { topicId: 'context-topic' },
+        );
+
+        expect(content).toContain('Runtime context metadata task');
+        expect(mockFindPlanDocuments).toHaveBeenCalledWith('context-topic', {
+          type: 'agent/plan',
+        });
+      });
+
+      it('does not query Notebook when lobe-agent is disabled', async () => {
+        await callWithMessages([{ content: 'Continue', role: 'user' }], createMockState());
+
+        expect(mockFindPlanDocuments).not.toHaveBeenCalled();
+      });
+
+      it('continues the rollout when the Notebook query fails', async () => {
+        mockFindPlanDocuments.mockRejectedValue(new Error('database unavailable'));
+
+        const content = await callWithMessages(
+          [{ content: 'Continue', role: 'user' }],
+          stateWithLobeAgent(),
+        );
+
+        expect(content).toContain('Continue');
+        expect(content).not.toContain('<todo_context>');
       });
 
       it('should process messages through serverMessagesEngine when agentConfig is set', async () => {

--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextBuilder.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextBuilder.ts
@@ -1,4 +1,5 @@
 import type { AgentState, CallLLMPayload } from '@lobechat/agent-runtime';
+import { extractTodosFromMessages, normalizeTodosState } from '@lobechat/agent-runtime';
 import {
   type ComposioServiceSummary,
   type CredSummary,
@@ -8,13 +9,14 @@ import {
   resolveAvailableComposioServices,
 } from '@lobechat/builtin-tool-creds';
 import { builtinTools } from '@lobechat/builtin-tools';
-import { COMPOSIO_APP_TYPES } from '@lobechat/const';
+import { AGENT_PLAN_FILE_TYPE, COMPOSIO_APP_TYPES } from '@lobechat/const';
 import type {
   AgentBuilderContext,
   AgentContextDocument,
   AgentGroupConfig,
   OfficialToolItem,
   OnboardingContext,
+  PlanTodoConfig,
 } from '@lobechat/context-engine';
 import { resolveTopicReferences } from '@lobechat/context-engine';
 import type { ChatStreamPayload } from '@lobechat/model-runtime';
@@ -31,6 +33,7 @@ import { AgentModel } from '@/database/models/agent';
 import { FileModel } from '@/database/models/file';
 import { MessageModel as MessageModelClass } from '@/database/models/message';
 import { TopicModel } from '@/database/models/topic';
+import { TopicDocumentModel } from '@/database/models/topicDocument';
 import { UserModel } from '@/database/models/user';
 import { UserPersonaModel } from '@/database/models/userMemory/persona';
 import { serverMessagesEngine } from '@/server/modules/Mecha/ContextEngineering';
@@ -216,7 +219,7 @@ export const buildServerCallLlmContext = async ({
   // `{{agent_id}}` / `{{agent_title}}` / `{{topic_id}}` etc. into the
   // model's prompt without needing a separate context injector.
   const lobehubSkillAgentId = state.metadata?.agentId;
-  const lobehubSkillTopicId = state.metadata?.topicId;
+  const lobehubSkillTopicId = ctx.topicId ?? state.metadata?.topicId;
   const lobehubSkillAgentMeta = state.metadata?.agentConfig as
     { description?: string | null; title?: string | null } | undefined;
 
@@ -278,6 +281,38 @@ export const buildServerCallLlmContext = async ({
   const memoryEffort = String(
     (state.metadata?.agentConfig as any)?.chatConfig?.memory?.effort ?? '',
   );
+
+  const messageTodos = extractTodosFromMessages(messagesForContext);
+  let planTodo: PlanTodoConfig | undefined =
+    messageTodos !== undefined ? { enabled: true, todos: messageTodos } : undefined;
+
+  if (
+    messageTodos === undefined &&
+    resolved.enabledToolIds.includes('lobe-agent') &&
+    lobehubSkillTopicId &&
+    ctx.serverDB &&
+    ctx.userId
+  ) {
+    try {
+      const topicDocumentModel = new TopicDocumentModel(
+        ctx.serverDB,
+        ctx.userId,
+        state.metadata?.workspaceId ?? ctx.workspaceId,
+      );
+      const [planDocument] = await topicDocumentModel.findByTopicId(lobehubSkillTopicId, {
+        type: AGENT_PLAN_FILE_TYPE,
+      });
+      if (planDocument) {
+        const todos = normalizeTodosState(
+          planDocument.metadata?.todos,
+          planDocument.updatedAt.toISOString(),
+        );
+        if (todos !== undefined) planTodo = { enabled: true, todos };
+      }
+    } catch (error) {
+      log('Failed to resolve plan TODO context for topic %s: %O', lobehubSkillTopicId, error);
+    }
+  }
 
   let credsListStr = '';
   if (ctx.userId) {
@@ -478,6 +513,7 @@ export const buildServerCallLlmContext = async ({
     modelDisplayName,
     modelKnowledgeCutoff,
     provider,
+    ...(planTodo && { planTodo }),
     systemRole: agentConfig.systemRole ?? undefined,
     toolDiscoveryConfig,
     toolsConfig: {

--- a/apps/server/src/modules/Mecha/ContextEngineering/__tests__/serverMessagesEngine.test.ts
+++ b/apps/server/src/modules/Mecha/ContextEngineering/__tests__/serverMessagesEngine.test.ts
@@ -48,21 +48,18 @@ describe('serverMessagesEngine', () => {
       expect(userContent).toContain('Keep server context in sync');
     });
 
-    it.each([{ items: [], updatedAt: 'canonical-clear' }, []])(
-      'does not inject a canonical or legacy empty TODO state',
-      async (todos) => {
-        const result = await serverMessagesEngine({
-          messages: createBasicMessages(),
-          model: 'gpt-4',
-          planTodo: { enabled: true, todos: todos as any },
-          provider: 'openai',
-        });
+    it('does not inject an empty TODO state', async () => {
+      const result = await serverMessagesEngine({
+        messages: createBasicMessages(),
+        model: 'gpt-4',
+        planTodo: { enabled: true, todos: { items: [], updatedAt: 'canonical-clear' } },
+        provider: 'openai',
+      });
 
-        expect(result.find((message) => message.role === 'user')?.content).not.toContain(
-          '<todo_context>',
-        );
-      },
-    );
+      expect(result.find((message) => message.role === 'user')?.content).not.toContain(
+        '<todo_context>',
+      );
+    });
 
     it('matches client-style stepContext and server planTodo output', async () => {
       const todos = { items, updatedAt: 'same' };

--- a/apps/server/src/modules/Mecha/ContextEngineering/__tests__/serverMessagesEngine.test.ts
+++ b/apps/server/src/modules/Mecha/ContextEngineering/__tests__/serverMessagesEngine.test.ts
@@ -32,6 +32,60 @@ describe('serverMessagesEngine', () => {
     } as UIChatMessage,
   ];
 
+  describe('TODO context', () => {
+    const items = [{ status: 'processing' as const, text: 'Keep server context in sync' }];
+
+    it('forwards non-empty planTodo state to MessagesEngine', async () => {
+      const result = await serverMessagesEngine({
+        messages: createBasicMessages(),
+        model: 'gpt-4',
+        planTodo: { enabled: true, todos: { items, updatedAt: 'now' } },
+        provider: 'openai',
+      });
+      const userContent = result.find((message) => message.role === 'user')?.content;
+
+      expect(userContent).toContain('<todo_context>');
+      expect(userContent).toContain('Keep server context in sync');
+    });
+
+    it.each([{ items: [], updatedAt: 'canonical-clear' }, []])(
+      'does not inject a canonical or legacy empty TODO state',
+      async (todos) => {
+        const result = await serverMessagesEngine({
+          messages: createBasicMessages(),
+          model: 'gpt-4',
+          planTodo: { enabled: true, todos: todos as any },
+          provider: 'openai',
+        });
+
+        expect(result.find((message) => message.role === 'user')?.content).not.toContain(
+          '<todo_context>',
+        );
+      },
+    );
+
+    it('matches client-style stepContext and server planTodo output', async () => {
+      const todos = { items, updatedAt: 'same' };
+      const clientResult = await new MessagesEngine({
+        enableSystemDate: false,
+        messages: createBasicMessages(),
+        model: 'gpt-4',
+        provider: 'openai',
+        stepContext: { todos },
+      }).process();
+      const serverResult = await serverMessagesEngine({
+        messages: createBasicMessages(),
+        model: 'gpt-4',
+        planTodo: { enabled: true, todos },
+        provider: 'openai',
+      });
+
+      expect(serverResult.find((message) => message.role === 'user')?.content).toBe(
+        clientResult.messages.find((message) => message.role === 'user')?.content,
+      );
+    });
+  });
+
   describe('basic functionality', () => {
     it('should process messages with required parameters', async () => {
       const messages = createBasicMessages();

--- a/apps/server/src/modules/Mecha/ContextEngineering/index.ts
+++ b/apps/server/src/modules/Mecha/ContextEngineering/index.ts
@@ -86,6 +86,7 @@ export const serverMessagesEngine = async ({
   agentManagementContext,
   onboardingContext,
   pageContentContext,
+  planTodo,
   topicReferences,
   additionalVariables,
   userTimezone,
@@ -135,6 +136,7 @@ export const serverMessagesEngine = async ({
     modelKnowledgeCutoff,
 
     provider,
+    planTodo,
     systemRole,
 
     // Timezone for system date provider

--- a/apps/server/src/modules/Mecha/ContextEngineering/types.ts
+++ b/apps/server/src/modules/Mecha/ContextEngineering/types.ts
@@ -11,6 +11,7 @@ import type {
   KnowledgeBaseInfo,
   LobeToolManifest,
   OnboardingContext,
+  PlanTodoConfig,
   SkillMeta,
   ToolDiscoveryConfig,
   TopicReferenceItem,
@@ -139,6 +140,9 @@ export interface ServerMessagesEngineParams {
 
   /** Page content context (optional, for document editing) */
   pageContentContext?: PageContentContext;
+
+  /** Plan document TODO state used when conversation messages contain no TODO state */
+  planTodo?: PlanTodoConfig;
 
   /** Provider ID */
   provider: string;

--- a/packages/agent-runtime/src/utils/messageSelectors.test.ts
+++ b/packages/agent-runtime/src/utils/messageSelectors.test.ts
@@ -5,7 +5,9 @@ import {
   collectFromMessages,
   extractActivatedSkillsFromMessages,
   extractActivatedToolIdsFromMessages,
+  extractTodosFromMessages,
   findInMessages,
+  normalizeTodosState,
 } from './messageSelectors';
 
 const createMessage = (overrides: Partial<UIChatMessage> = {}): UIChatMessage =>
@@ -98,6 +100,96 @@ describe('collectFromMessages', () => {
     });
 
     expect(result).toEqual(['tool']);
+  });
+});
+
+describe('TODO state selectors', () => {
+  const item = { status: 'processing' as const, text: 'Ship the fix' };
+
+  it('normalizes canonical and legacy states, including empty clear tombstones', () => {
+    expect(normalizeTodosState({ items: [item], updatedAt: 'canonical-time' }, 'fallback')).toEqual({
+      items: [item],
+      updatedAt: 'canonical-time',
+    });
+    expect(normalizeTodosState([item], 'fallback')).toEqual({
+      items: [item],
+      updatedAt: 'fallback',
+    });
+    expect(normalizeTodosState({ items: [] }, 'fallback')).toEqual({
+      items: [],
+      updatedAt: 'fallback',
+    });
+    expect(normalizeTodosState({ items: [item], updatedAt: 42 }, 'fallback')).toEqual({
+      items: [item],
+      updatedAt: 'fallback',
+    });
+    expect(normalizeTodosState([], 'fallback')).toEqual({ items: [], updatedAt: 'fallback' });
+  });
+
+  it('rejects alternate fields and malformed items', () => {
+    expect(normalizeTodosState({ tasks: [item] }, 'fallback')).toBeUndefined();
+    expect(normalizeTodosState({ todoList: [item] }, 'fallback')).toBeUndefined();
+    expect(normalizeTodosState({ items: [{ status: 'unknown', text: 'bad' }] }, 'fallback')).toBeUndefined();
+    expect(normalizeTodosState({ items: [{ status: 'todo' }] }, 'fallback')).toBeUndefined();
+  });
+
+  it('selects the newest valid exact pluginState.todos from any producer', () => {
+    const messages = [
+      createToolMessage({
+        plugin: { identifier: 'producer-a' },
+        pluginState: { todos: { items: [{ status: 'todo', text: 'old' }], updatedAt: 'old' } },
+      } as any),
+      createToolMessage({
+        content: JSON.stringify({ todos: { items: [item] } }),
+        plugin: { identifier: 'producer-b' },
+        pluginState: { tasks: [item] },
+      } as any),
+      createToolMessage({
+        plugin: { identifier: 'producer-c' },
+        pluginState: { todos: { items: [{ status: 'completed', text: 'new' }], updatedAt: 'new' } },
+      } as any),
+      createToolMessage({
+        plugin: { identifier: 'producer-d' },
+        pluginState: { todos: { items: [{ status: 'invalid', text: 'skip' }] } },
+      } as any),
+    ];
+
+    expect(extractTodosFromMessages(messages)).toEqual({
+      items: [{ status: 'completed', text: 'new' }],
+      updatedAt: 'new',
+    });
+  });
+
+  it('extracts equivalent TODO state from flat, grouped, and compressed messages', () => {
+    const todos = { items: [item], updatedAt: 'same' };
+    const flat = createToolMessage({ pluginState: { todos } });
+    const grouped = createMessage({
+      children: [
+        {
+          id: 'assistant',
+          tools: [{ id: 'call', result: { id: 'result', state: { todos } } }],
+        },
+      ],
+      role: 'supervisor',
+    } as any);
+    const compressed = createMessage({
+      compressedMessages: [grouped],
+      role: 'compressedGroup',
+    } as any);
+
+    expect(extractTodosFromMessages([flat])).toEqual(todos);
+    expect(extractTodosFromMessages([grouped])).toEqual(todos);
+    expect(extractTodosFromMessages([compressed])).toEqual(todos);
+  });
+
+  it('does not read TODO-like values from arguments or content', () => {
+    const message = createToolMessage({
+      content: JSON.stringify({ todos: [item] }),
+      plugin: { arguments: JSON.stringify({ todos: [item] }) },
+      pluginState: { todoList: [item] },
+    } as any);
+
+    expect(extractTodosFromMessages([message])).toBeUndefined();
   });
 });
 

--- a/packages/agent-runtime/src/utils/messageSelectors.ts
+++ b/packages/agent-runtime/src/utils/messageSelectors.ts
@@ -1,4 +1,5 @@
-import type { StepActivatedSkill, UIChatMessage } from '@lobechat/types';
+import type { StepActivatedSkill, StepContextTodos, UIChatMessage } from '@lobechat/types';
+import { isNonEmptyString, isPlainRecord } from '@lobechat/utils/object';
 
 /**
  * Wire-format tool identifiers that carry skill activations in their
@@ -151,6 +152,52 @@ const collectToolInvocations = (msg: UIChatMessage): ToolInvocation[] => {
   }
 
   return invocations;
+};
+
+const isTodoItem = (value: unknown): value is StepContextTodos['items'][number] =>
+  isPlainRecord(value) &&
+  typeof value.text === 'string' &&
+  (value.status === 'todo' || value.status === 'processing' || value.status === 'completed');
+
+/** Normalize persisted canonical and legacy TODO states without guessing alternate fields. */
+export const normalizeTodosState = (
+  value: unknown,
+  fallbackUpdatedAt: string,
+): StepContextTodos | undefined => {
+  const items = Array.isArray(value)
+    ? value
+    : isPlainRecord(value) && Array.isArray(value.items)
+      ? value.items
+      : undefined;
+
+  if (!items || !items.every(isTodoItem)) return undefined;
+
+  const updatedAt =
+    isPlainRecord(value) && isNonEmptyString(value.updatedAt)
+      ? value.updatedAt
+      : fallbackUpdatedAt;
+
+  return { items, updatedAt };
+};
+
+/** Select the newest valid exact `pluginState.todos` state across flat and grouped messages. */
+export const extractTodosFromMessages = (
+  messages: UIChatMessage[],
+): StepContextTodos | undefined => {
+  const fallbackUpdatedAt = new Date().toISOString();
+
+  for (let messageIndex = messages.length - 1; messageIndex >= 0; messageIndex--) {
+    const invocations = collectToolInvocations(messages[messageIndex]);
+    for (let invocationIndex = invocations.length - 1; invocationIndex >= 0; invocationIndex--) {
+      const state = invocations[invocationIndex].state;
+      if (!isPlainRecord(state) || !Object.hasOwn(state, 'todos')) continue;
+
+      const todos = normalizeTodosState(state.todos, fallbackUpdatedAt);
+      if (todos !== undefined) return todos;
+    }
+  }
+
+  return undefined;
 };
 
 /**

--- a/packages/context-engine/src/engine/messages/MessagesEngine.ts
+++ b/packages/context-engine/src/engine/messages/MessagesEngine.ts
@@ -200,9 +200,15 @@ export class MessagesEngine {
     // Page editor is enabled if either direct pageContentContext or initialContext.pageEditor is provided
     const isPageEditorEnabled = !!pageContentContext || !!initialContext?.pageEditor;
     const hasActiveTopicDocument = !!initialContext?.activeTopicDocument;
-    // Plan/Todo is enabled if planTodo.enabled is true and either plan or todos is provided
+    // Runtime message state is authoritative, including an empty clear tombstone.
     const isPlanEnabled = planTodo?.enabled && planTodo?.plan;
-    const isTodoEnabled = planTodo?.enabled && planTodo?.todos;
+    const effectiveTodos =
+      stepContext?.todos !== undefined
+        ? stepContext.todos
+        : planTodo?.enabled
+          ? planTodo.todos
+          : undefined;
+    const isTodoEnabled = effectiveTodos !== undefined;
 
     // System date is redundant when web-browsing or memory tools are enabled,
     // as they already include current date in their system prompts
@@ -382,7 +388,7 @@ export class MessagesEngine {
         enabled: !!initialContext?.taskManager?.contextPrompt,
       }),
       // Todo list (at end of last user message)
-      new TodoInjector({ enabled: !!isTodoEnabled, todos: planTodo?.todos }),
+      new TodoInjector({ enabled: isTodoEnabled, todos: effectiveTodos }),
       // Topic Reference context (referenced topic summaries to last user message)
       new TopicReferenceContextInjector({
         enabled: !!(topicReferences && topicReferences.length > 0),

--- a/packages/context-engine/src/engine/messages/__tests__/MessagesEngine.test.ts
+++ b/packages/context-engine/src/engine/messages/__tests__/MessagesEngine.test.ts
@@ -72,6 +72,58 @@ describe('MessagesEngine', () => {
   });
 
   describe('process', () => {
+    describe('TODO context priority', () => {
+      const messageTodos = {
+        items: [{ status: 'processing' as const, text: 'Message task' }],
+        updatedAt: 'message-time',
+      };
+      const metadataTodos = {
+        items: [{ status: 'todo' as const, text: 'Metadata task' }],
+        updatedAt: 'metadata-time',
+      };
+
+      it('injects stepContext.todos without a plan configuration', async () => {
+        const result = await new MessagesEngine(
+          createBasicParams({ stepContext: { todos: messageTodos } }),
+        ).process();
+
+        expect(result.messages[0].content).toContain('<todo_context>');
+        expect(result.messages[0].content).toContain('Message task');
+      });
+
+      it('prefers message state over plan metadata', async () => {
+        const result = await new MessagesEngine(
+          createBasicParams({
+            planTodo: { enabled: true, todos: metadataTodos },
+            stepContext: { todos: messageTodos },
+          }),
+        ).process();
+
+        expect(result.messages[0].content).toContain('Message task');
+        expect(result.messages[0].content).not.toContain('Metadata task');
+      });
+
+      it('uses an empty message tombstone to suppress non-empty metadata', async () => {
+        const result = await new MessagesEngine(
+          createBasicParams({
+            planTodo: { enabled: true, todos: metadataTodos },
+            stepContext: { todos: { items: [], updatedAt: 'cleared' } },
+          }),
+        ).process();
+
+        expect(result.messages[0].content).not.toContain('<todo_context>');
+        expect(result.messages[0].content).not.toContain('Metadata task');
+      });
+
+      it('falls back to enabled plan metadata when message state is undefined', async () => {
+        const result = await new MessagesEngine(
+          createBasicParams({ planTodo: { enabled: true, todos: metadataTodos } }),
+        ).process();
+
+        expect(result.messages[0].content).toContain('Metadata task');
+      });
+    });
+
     it('should process messages and return result with stats', async () => {
       const params = createBasicParams();
       const engine = new MessagesEngine(params);

--- a/src/store/chat/slices/message/selectors/dbMessage.ts
+++ b/src/store/chat/slices/message/selectors/dbMessage.ts
@@ -1,4 +1,7 @@
-import { extractActivatedSkillsFromMessages } from '@lobechat/agent-runtime';
+import {
+  extractActivatedSkillsFromMessages,
+  extractTodosFromMessages,
+} from '@lobechat/agent-runtime';
 import { LobeActivatorIdentifier } from '@lobechat/builtin-tool-activator';
 import {
   type StepActivatedSkill,
@@ -235,34 +238,7 @@ export const selectActivatedSkillsFromMessages = (
  */
 export const selectTodosFromMessages = (
   messages: UIChatMessage[],
-): StepContextTodos | undefined => {
-  // Search from newest to oldest
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
-
-    if (msg.role === 'tool' && msg.pluginState?.todos) {
-      const todos = msg.pluginState.todos as { items?: unknown[]; updatedAt?: string };
-
-      // Handle the todos structure: { items: TodoItem[], updatedAt: string }
-      if (typeof todos === 'object' && 'items' in todos && Array.isArray(todos.items)) {
-        return {
-          items: todos.items as StepContextTodos['items'],
-          updatedAt: todos.updatedAt || new Date().toISOString(),
-        };
-      }
-
-      // Legacy format: direct array of TodoItem[]
-      if (Array.isArray(todos)) {
-        return {
-          items: todos as StepContextTodos['items'],
-          updatedAt: new Date().toISOString(),
-        };
-      }
-    }
-  }
-
-  return undefined;
-};
+): StepContextTodos | undefined => extractTodosFromMessages(messages);
 
 /**
  * Select todos from the current agent turn only — messages after the last


### PR DESCRIPTION
# 🐛 fix(agent): inject runtime TODOs into server context

Fix server-side AgentRuntime rollouts losing TODO context after message rehydration.

The server now extracts the latest valid `pluginState.todos` from flat, grouped, and compressed messages. Messagestate takes priority over Notebook metadata, including empty TODO lists used as clear tombstones.

When messages contain no TODO state and `lobe-agent` is enabled, the runtime falls back to the topic's plan document. Canonical `{ items, updatedAt }` and legacy `TodoItem[]` states share the same strict normalization logic.

The client selector now delegates to the shared extractor, keeping client and server TODO selection consistent.

| Before | After |
| ------ | ----- |
| Server rollouts could omit current TODOs or use stale plan metadata. | Server rollouts inject the latest message TODO state and use plan metadata only as a fallback. |
| Empty message TODO state could fall through to stale metadata. | Empty TODO state suppresses fallback and produces no `<todo_context>`. |
| Client and server used separate TODO selection logic. | Both paths use the shared selector and normalization rules. |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Covered scenarios:

- Canonical and legacy TODO normalization
- Empty TODO clear tombstones
- Strict rejection of malformed and TODO-like fields
- Latest valid state selection across flat, grouped, and compressed messages
- Message state precedence over Notebook metadata
- Canonical and legacy Notebook fallback
- Notebook query failure without interrupting the rollout
- Client and server TODO context output consistency

All targeted tests passed: 4 test files, 248 tests.

#### 🔗 Related Issue