### PR TITLE
🐛 fix(model-runtime): scope persisted reasoning signatures

### DIFF
--- a/packages/agent-runtime/src/executors/callLlmFinalizer.test.ts
+++ b/packages/agent-runtime/src/executors/callLlmFinalizer.test.ts
@@ -194,6 +194,47 @@ describe('callLlmFinalizer', () => {
     });
   });
 
+  it('persists scoped response items without visible reasoning in replay state', async () => {
+    const responseItem = {
+      item: {
+        encrypted_content: 'encrypted-reasoning',
+        id: 'reasoning-1',
+        summary: [],
+        type: 'reasoning' as const,
+      },
+      signatureScope: {
+        model: 'gpt-5',
+        provider: 'chatgpt',
+      },
+    };
+    const result = await finalizeCallLlmTurn({
+      assistantMessageId: 'assistant-1',
+      events: [],
+      host: createHost(),
+      model: 'gpt-5',
+      output: createOutput({
+        reasoning: {
+          responseItems: [responseItem],
+          signature: 'legacy-signature',
+        },
+        thinkingContent: '',
+      }),
+      provider: 'chatgpt',
+      shouldReplayAssistantReasoning: true,
+      state: AgentRuntime.createInitialState({ operationId: 'operation-1' }),
+    });
+
+    expect(result.newState.messages.at(-1)).toMatchObject({
+      model: 'gpt-5',
+      provider: 'chatgpt',
+      reasoning: {
+        content: undefined,
+        responseItems: [responseItem],
+        signature: undefined,
+      },
+    });
+  });
+
   it('publishes no-tool visible output end before persistence and records the marker', async () => {
     const messages = createMessageTransport();
     const stream = createStreamSink();

--- a/packages/agent-runtime/src/executors/callLlmFinalizer.test.ts
+++ b/packages/agent-runtime/src/executors/callLlmFinalizer.test.ts
@@ -172,7 +172,7 @@ describe('callLlmFinalizer', () => {
     expect(publishedEvents.some(([event]) => event.type === 'visible_output_end')).toBe(false);
   });
 
-  it('tags replayable reasoning with its source model and provider', async () => {
+  it('does not persist signature-only reasoning in replay state', async () => {
     const result = await finalizeCallLlmTurn({
       assistantMessageId: 'assistant-1',
       events: [],
@@ -190,7 +190,7 @@ describe('callLlmFinalizer', () => {
     expect(result.newState.messages.at(-1)).toMatchObject({
       model: 'gpt-5',
       provider: 'chatgpt',
-      reasoning: { signature: 'encrypted-reasoning' },
+      reasoning: undefined,
     });
   });
 

--- a/packages/agent-runtime/src/executors/callLlmFinalizer.ts
+++ b/packages/agent-runtime/src/executors/callLlmFinalizer.ts
@@ -92,9 +92,12 @@ const buildFinalReasoning = (output: CallLlmCollectedOutput): ModelReasoning | u
   }
 
   if (output.reasoning) {
+    const content = output.thinkingContent || output.reasoning.content;
+    if (!content) return undefined;
+
     return {
       ...output.reasoning,
-      content: output.thinkingContent || output.reasoning.content,
+      content,
     };
   }
 

--- a/packages/agent-runtime/src/executors/callLlmFinalizer.ts
+++ b/packages/agent-runtime/src/executors/callLlmFinalizer.ts
@@ -93,11 +93,17 @@ const buildFinalReasoning = (output: CallLlmCollectedOutput): ModelReasoning | u
 
   if (output.reasoning) {
     const content = output.thinkingContent || output.reasoning.content;
-    if (!content) return undefined;
+    /**
+     * Hidden Responses items remain replayable without visible content. Keep them while continuing
+     * to discard legacy scalar signatures that have no reasoning content.
+     */
+    const hasResponseItems = !!output.reasoning.responseItems?.length;
+    if (!content && !hasResponseItems) return undefined;
 
     return {
       ...output.reasoning,
-      content,
+      content: content || undefined,
+      signature: content ? output.reasoning.signature : undefined,
     };
   }
 

--- a/packages/fetch-sse/src/__tests__/reasoningSignature.test.ts
+++ b/packages/fetch-sse/src/__tests__/reasoningSignature.test.ts
@@ -65,7 +65,7 @@ describe('fetchSSE reasoning signatures', () => {
         options.onopen!({ clone: () => ({ ok: true, headers: new Headers() }) } as any);
         options.onmessage!({
           data: JSON.stringify(responseItem),
-          event: 'reasoning_signature',
+          event: 'reasoning_response_item',
         } as any);
         options.onmessage!({ data: JSON.stringify('Done'), event: 'text' } as any);
       },
@@ -109,7 +109,7 @@ describe('fetchSSE reasoning signatures', () => {
         options.onopen!({ clone: () => ({ ok: true, headers: new Headers() }) } as any);
         options.onmessage!({
           data: JSON.stringify(responseItem),
-          event: 'reasoning_signature',
+          event: 'reasoning_response_item',
         } as any);
         options.onmessage!({ data: JSON.stringify('Done'), event: 'text' } as any);
       },

--- a/packages/fetch-sse/src/__tests__/reasoningSignature.test.ts
+++ b/packages/fetch-sse/src/__tests__/reasoningSignature.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 });
 
 describe('fetchSSE reasoning signatures', () => {
-  it('should preserve a reasoning signature without visible reasoning text', async () => {
+  it('should discard a reasoning signature without visible reasoning text', async () => {
     const mockOnFinish = vi.fn();
 
     (fetchEventSource as any).mockImplementationOnce(
@@ -38,10 +38,7 @@ describe('fetchSSE reasoning signatures', () => {
 
     expect(mockOnFinish).toHaveBeenCalledWith('Done', {
       observationId: null,
-      reasoning: {
-        content: undefined,
-        signature: 'encrypted-reasoning-content',
-      },
+      reasoning: undefined,
       toolCalls: undefined,
       traceId: null,
       type: 'done',

--- a/packages/fetch-sse/src/__tests__/reasoningSignature.test.ts
+++ b/packages/fetch-sse/src/__tests__/reasoningSignature.test.ts
@@ -44,4 +44,48 @@ describe('fetchSSE reasoning signatures', () => {
       type: 'done',
     });
   });
+
+  it('should preserve non-streaming response items with visible summary text', async () => {
+    const mockOnFinish = vi.fn();
+    const responseItem = {
+      item: {
+        encrypted_content: 'encrypted-reasoning-content',
+        id: 'reasoning-1',
+        summary: [{ text: 'Visible summary', type: 'summary_text' }],
+        type: 'reasoning',
+      },
+      signatureScope: {
+        model: 'gpt-5.6-sol',
+        provider: 'chatgpt',
+      },
+    };
+
+    (fetchEventSource as any).mockImplementationOnce(
+      (url: string, options: FetchEventSourceInit) => {
+        options.onopen!({ clone: () => ({ ok: true, headers: new Headers() }) } as any);
+        options.onmessage!({
+          data: JSON.stringify(responseItem),
+          event: 'reasoning_signature',
+        } as any);
+        options.onmessage!({ data: JSON.stringify('Done'), event: 'text' } as any);
+      },
+    );
+
+    await fetchSSE('/', {
+      onFinish: mockOnFinish,
+      responseAnimation: 'fadeIn',
+    });
+
+    expect(mockOnFinish).toHaveBeenCalledWith('Done', {
+      observationId: null,
+      reasoning: {
+        content: 'Visible summary',
+        responseItems: [responseItem],
+        signature: undefined,
+      },
+      toolCalls: undefined,
+      traceId: null,
+      type: 'done',
+    });
+  });
 });

--- a/packages/fetch-sse/src/__tests__/reasoningSignature.test.ts
+++ b/packages/fetch-sse/src/__tests__/reasoningSignature.test.ts
@@ -88,4 +88,48 @@ describe('fetchSSE reasoning signatures', () => {
       type: 'done',
     });
   });
+
+  it('should preserve non-streaming response items without visible summary text', async () => {
+    const mockOnFinish = vi.fn();
+    const responseItem = {
+      item: {
+        encrypted_content: 'encrypted-reasoning-content',
+        id: 'reasoning-1',
+        summary: [],
+        type: 'reasoning',
+      },
+      signatureScope: {
+        model: 'gpt-5.6-sol',
+        provider: 'chatgpt',
+      },
+    };
+
+    (fetchEventSource as any).mockImplementationOnce(
+      (url: string, options: FetchEventSourceInit) => {
+        options.onopen!({ clone: () => ({ ok: true, headers: new Headers() }) } as any);
+        options.onmessage!({
+          data: JSON.stringify(responseItem),
+          event: 'reasoning_signature',
+        } as any);
+        options.onmessage!({ data: JSON.stringify('Done'), event: 'text' } as any);
+      },
+    );
+
+    await fetchSSE('/', {
+      onFinish: mockOnFinish,
+      responseAnimation: 'fadeIn',
+    });
+
+    expect(mockOnFinish).toHaveBeenCalledWith('Done', {
+      observationId: null,
+      reasoning: {
+        content: undefined,
+        responseItems: [responseItem],
+        signature: undefined,
+      },
+      toolCalls: undefined,
+      traceId: null,
+      type: 'done',
+    });
+  });
 });

--- a/packages/fetch-sse/src/fetchSSE.ts
+++ b/packages/fetch-sse/src/fetchSSE.ts
@@ -7,6 +7,7 @@ import type {
   MessageToolCall,
   ModelPerformance,
   ModelReasoning,
+  ModelReasoningResponseItem,
   ModelUsage,
   ResponseAnimation,
   ResponseAnimationStyle,
@@ -282,6 +283,7 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
 
   let thinking = '';
   let thinkingSignature: string | undefined;
+  const reasoningResponseItems: ModelReasoningResponseItem[] = [];
 
   const thinkingController = createSmoothMessage({
     onTextUpdate: (delta, text) => {
@@ -432,7 +434,11 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
         }
 
         case 'reasoning_signature': {
-          thinkingSignature = data;
+          if (typeof data === 'string') {
+            thinkingSignature = data;
+          } else {
+            reasoningResponseItems.push(data as ModelReasoningResponseItem);
+          }
           break;
         }
 
@@ -548,10 +554,13 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
         grounding,
         images: images.length > 0 ? images : undefined,
         observationId,
-        reasoning:
-          thinking || thinkingSignature
-            ? { content: thinking || undefined, signature: thinkingSignature }
-            : undefined,
+        reasoning: thinking
+          ? {
+              content: thinking,
+              responseItems: reasoningResponseItems.length > 0 ? reasoningResponseItems : undefined,
+              signature: thinkingSignature,
+            }
+          : undefined,
         speed,
         toolCalls,
         traceId,

--- a/packages/fetch-sse/src/fetchSSE.ts
+++ b/packages/fetch-sse/src/fetchSSE.ts
@@ -555,18 +555,24 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
         .filter(Boolean)
         .join('\n');
       const reasoningContent = thinking || responseItemsThinking;
+      const hasResponseItems = reasoningResponseItems.length > 0;
 
       await options?.onFinish?.(output, {
         grounding,
         images: images.length > 0 ? images : undefined,
         observationId,
-        reasoning: reasoningContent
-          ? {
-              content: reasoningContent,
-              responseItems: reasoningResponseItems.length > 0 ? reasoningResponseItems : undefined,
-              signature: thinkingSignature,
-            }
-          : undefined,
+        /**
+         * Responses reasoning items remain replayable without a visible summary, while a legacy
+         * signature alone must still be discarded because it has no safe replay context.
+         */
+        reasoning:
+          reasoningContent || hasResponseItems
+            ? {
+                content: reasoningContent || undefined,
+                responseItems: hasResponseItems ? reasoningResponseItems : undefined,
+                signature: reasoningContent ? thinkingSignature : undefined,
+              }
+            : undefined,
         speed,
         toolCalls,
         traceId,

--- a/packages/fetch-sse/src/fetchSSE.ts
+++ b/packages/fetch-sse/src/fetchSSE.ts
@@ -549,14 +549,20 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
 
       textController.flushQueue();
       thinkingController.flushQueue();
+      const responseItemsThinking = reasoningResponseItems
+        .flatMap(({ item }) => item.summary)
+        .map(({ text }) => text)
+        .filter(Boolean)
+        .join('\n');
+      const reasoningContent = thinking || responseItemsThinking;
 
       await options?.onFinish?.(output, {
         grounding,
         images: images.length > 0 ? images : undefined,
         observationId,
-        reasoning: thinking
+        reasoning: reasoningContent
           ? {
-              content: thinking,
+              content: reasoningContent,
               responseItems: reasoningResponseItems.length > 0 ? reasoningResponseItems : undefined,
               signature: thinkingSignature,
             }

--- a/packages/fetch-sse/src/fetchSSE.ts
+++ b/packages/fetch-sse/src/fetchSSE.ts
@@ -434,11 +434,12 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
         }
 
         case 'reasoning_signature': {
-          if (typeof data === 'string') {
-            thinkingSignature = data;
-          } else {
-            reasoningResponseItems.push(data as ModelReasoningResponseItem);
-          }
+          if (typeof data === 'string') thinkingSignature = data;
+          break;
+        }
+
+        case 'reasoning_response_item': {
+          reasoningResponseItems.push(data as ModelReasoningResponseItem);
           break;
         }
 

--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.test.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.test.ts
@@ -105,6 +105,40 @@ describe('createRouterRuntime', () => {
         routerId: 'router-a',
       });
     });
+
+    it('should mark router signature scopes when router and channel ids are missing', async () => {
+      let signatureScope;
+
+      class MockRuntime implements LobeRuntimeAI {
+        chat = vi.fn().mockImplementation(() => {
+          signatureScope = getRuntimeSignatureScope(this);
+        });
+        embeddings = vi.fn();
+        models = vi.fn();
+        textToSpeech = vi.fn();
+      }
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            models: ['test-model'],
+            options: {},
+            runtime: MockRuntime as any,
+          },
+        ],
+      });
+
+      await new Runtime().chat({ messages: [], model: 'test-model', temperature: 0.7 });
+
+      expect(signatureScope).toEqual({
+        apiType: 'openai',
+        channelId: undefined,
+        provider: 'test-runtime',
+        routerId: 'test-runtime',
+      });
+    });
   });
 
   describe('chat method', () => {

--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.test.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.test.ts
@@ -1,6 +1,7 @@
 import { AgentRuntimeErrorType, RequestTrigger } from '@lobechat/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { getRuntimeSignatureScope } from '../../utils/signatureScope';
 import type { LobeRuntimeAI } from '../BaseAI';
 import { createRouterRuntime } from './createRuntime';
 
@@ -58,12 +59,15 @@ describe('createRouterRuntime', () => {
 
     it('should merge router options with constructor options', async () => {
       const mockConstructor = vi.fn();
+      let signatureScope;
 
       class MockRuntime implements LobeRuntimeAI {
         constructor(options: any) {
           mockConstructor(options);
         }
-        chat = vi.fn();
+        chat = vi.fn().mockImplementation(() => {
+          signatureScope = getRuntimeSignatureScope(this);
+        });
         models = vi.fn();
         embeddings = vi.fn();
         textToSpeech = vi.fn();
@@ -74,7 +78,8 @@ describe('createRouterRuntime', () => {
         routers: [
           {
             apiType: 'openai',
-            options: { baseURL: 'https://api.example.com' },
+            id: 'router-a',
+            options: { baseURL: 'https://api.example.com', id: 'channel-a' },
             runtime: MockRuntime as any,
             models: ['test-model'],
           },
@@ -93,6 +98,12 @@ describe('createRouterRuntime', () => {
           id: 'test-runtime',
         }),
       );
+      expect(signatureScope).toEqual({
+        apiType: 'openai',
+        channelId: 'channel-a',
+        provider: 'test-runtime',
+        routerId: 'router-a',
+      });
     });
   });
 

--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
@@ -503,7 +503,11 @@ export const createRouterRuntime = ({
         apiType: resolvedApiType,
         channelId,
         provider: this._id,
-        routerId: router.id,
+        /**
+         * Keep an explicit RouterRuntime marker even when a router has no configured id. The
+         * signature matcher can then fail closed when the route also lacks a stable channel id.
+         */
+        routerId: router.id ?? this._id,
       };
 
       /**

--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
@@ -39,6 +39,7 @@ import { isNonRetryableRequestError } from '../../utils/isNonRetryableRequestErr
 import type { ModelIdMappingOptions } from '../../utils/modelIdMapping';
 import { postProcessModelList } from '../../utils/postProcessModelList';
 import { safeParseJSON } from '../../utils/safeParseJSON';
+import { setRuntimeSignatureScope } from '../../utils/signatureScope';
 import type { LobeRuntimeAI } from '../BaseAI';
 import type {
   CreateImageOptions,
@@ -498,6 +499,12 @@ export const createRouterRuntime = ({
         ...this._options,
         ...optionOverrides,
       };
+      const signatureScope = {
+        apiType: resolvedApiType,
+        channelId,
+        provider: this._id,
+        routerId: router.id,
+      };
 
       /**
        * Vertex AI uses GoogleGenAI credentials flow rather than API keys.
@@ -530,11 +537,14 @@ export const createRouterRuntime = ({
           );
         }
 
+        const runtime = LobeVertexAI.initFromVertexAI(vertexOptions);
+        setRuntimeSignatureScope(runtime, signatureScope);
+
         return {
           channelId,
           id: resolvedApiType,
           remark,
-          runtime: LobeVertexAI.initFromVertexAI(vertexOptions),
+          runtime,
         };
       }
 
@@ -544,6 +554,7 @@ export const createRouterRuntime = ({
           ? (router.runtime ?? baseRuntimeMap[resolvedApiType] ?? LobeOpenAI)
           : (baseRuntimeMap[resolvedApiType] ?? LobeOpenAI);
       const runtime: LobeRuntimeAI = new providerAI({ ...finalOptions, id: this._id });
+      setRuntimeSignatureScope(runtime, signatureScope);
 
       if (this._id === 'lobehub') {
         timing(

--- a/packages/model-runtime/src/core/contextBuilders/google.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.test.ts
@@ -3,6 +3,7 @@ import * as imageToBase64Module from '@lobechat/utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ChatCompletionTool, OpenAIChatMessage, UserMessageContentPart } from '../../types';
+import { serializeScopedSignature } from '../../utils/signatureScope';
 import { isPublicExternalUrl, parseDataUri, validateExternalUrl } from '../../utils/uriParser';
 import {
   buildGoogleMessage,
@@ -802,8 +803,15 @@ describe('google contextBuilders', () => {
         ]);
       });
 
-      it('should NOT add magic signature when thoughtSignature already exists', async () => {
+      it('should unwrap a thoughtSignature from the same channel', async () => {
         const existingSignature = 'existing_signature_from_model';
+        const signatureScope = {
+          apiType: 'google',
+          channelId: 'google-a',
+          model: 'gemini-3.0-pro',
+          provider: 'lobehub',
+          routerId: 'gemini',
+        };
         const messages: OpenAIChatMessage[] = [
           {
             content: '杭州天气如何',
@@ -819,7 +827,7 @@ describe('google contextBuilders', () => {
                   name: 'lobe-web-browsing____search',
                 },
                 id: 'call_001',
-                thoughtSignature: existingSignature,
+                thoughtSignature: serializeScopedSignature(existingSignature, signatureScope),
                 type: 'function',
               },
             ],
@@ -832,7 +840,10 @@ describe('google contextBuilders', () => {
           },
         ];
 
-        const contents = await buildGoogleMessages(messages);
+        const contents = await buildGoogleMessages(messages, {
+          model: 'gemini-3.0-pro',
+          signatureScope,
+        });
 
         expect(contents).toEqual([
           {
@@ -846,7 +857,6 @@ describe('google contextBuilders', () => {
                   args: { query: '杭州天气', searchEngines: ['google'] },
                   name: 'lobe-web-browsing____search',
                 },
-                // Should keep existing thoughtSignature, not add magic signature
                 thoughtSignature: existingSignature,
               },
             ],
@@ -864,6 +874,41 @@ describe('google contextBuilders', () => {
             role: 'user',
           },
         ]);
+      });
+
+      it('should replace a foreign-channel thoughtSignature with the magic signature', async () => {
+        const sourceScope = {
+          apiType: 'vertexai',
+          channelId: 'vertex-a',
+          model: 'gemini-3.0-pro',
+          provider: 'lobehub',
+          routerId: 'gemini',
+        };
+        const messages: OpenAIChatMessage[] = [
+          {
+            content: '',
+            role: 'assistant',
+            tool_calls: [
+              {
+                function: { arguments: '{}', name: 'search' },
+                id: 'call_001',
+                thoughtSignature: serializeScopedSignature('vertex-signature', sourceScope),
+                type: 'function',
+              },
+            ],
+          },
+        ];
+
+        const contents = await buildGoogleMessages(messages, {
+          model: 'gemini-3.0-pro',
+          signatureScope: {
+            ...sourceScope,
+            apiType: 'google',
+            channelId: 'google-a',
+          },
+        });
+
+        expect(contents[0].parts?.[0].thoughtSignature).toBe(GEMINI_MAGIC_THOUGHT_SIGNATURE);
       });
 
       it('should add magic signature to all function calls in multi-turn scenario', async () => {

--- a/packages/model-runtime/src/core/contextBuilders/google.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.ts
@@ -4,10 +4,12 @@ import type {
   Part,
   Tool as GoogleFunctionCallTool,
 } from '@google/genai';
+import type { ModelSignatureScope } from '@lobechat/types';
 import { imageUrlToBase64, resolveImageMimeTypeFromBase64 } from '@lobechat/utils';
 
 import type { ChatCompletionTool, OpenAIChatMessage, UserMessageContentPart } from '../../types';
 import { safeParseJSON } from '../../utils/safeParseJSON';
+import { resolveScopedSignature } from '../../utils/signatureScope';
 import { isPublicExternalUrl, parseDataUri, validateExternalUrl } from '../../utils/uriParser';
 
 const GOOGLE_SUPPORTED_IMAGE_TYPES = new Set([
@@ -30,6 +32,11 @@ const isImageTypeSupported = (mimeType: string | null | undefined): mimeType is 
  * @see https://github.com/pydantic/pydantic-ai/issues/3881
  */
 export const GEMINI_MAGIC_THOUGHT_SIGNATURE = 'skip_thought_signature_validator';
+
+interface GoogleMessageBuildOptions {
+  model?: string;
+  signatureScope?: ModelSignatureScope;
+}
 
 const getGeminiVersion = (model?: string) => {
   if (!model) return null;
@@ -71,7 +78,7 @@ const supportsFunctionCallId = (model?: string) => {
 
 const buildExternalUrlFileDataPart = async (
   url: string,
-  options?: { model?: string },
+  options?: GoogleMessageBuildOptions,
 ): Promise<Part | undefined> => {
   if (!supportsExternalUrlFileData(options?.model) || !isPublicExternalUrl(url)) return undefined;
 
@@ -103,7 +110,7 @@ const buildExternalUrlFileDataPart = async (
  */
 export const buildGooglePart = async (
   content: UserMessageContentPart,
-  options?: { model?: string },
+  options?: GoogleMessageBuildOptions,
 ): Promise<Part | undefined> => {
   switch (content.type) {
     default: {
@@ -232,7 +239,7 @@ export const buildGooglePart = async (
 export const buildGoogleMessage = async (
   message: OpenAIChatMessage,
   toolCallNameMap?: Map<string, string>,
-  options?: { model?: string },
+  options?: GoogleMessageBuildOptions,
 ): Promise<Content> => {
   const content = message.content as string | UserMessageContentPart[];
 
@@ -283,7 +290,7 @@ export const buildGoogleMessage = async (
             id: supportsFunctionCallId(options?.model) ? tool.id : undefined,
             name: tool.function.name,
           },
-          thoughtSignature: tool.thoughtSignature,
+          thoughtSignature: resolveScopedSignature(tool.thoughtSignature, options?.signatureScope),
         };
       }),
       role: 'model',
@@ -328,7 +335,7 @@ export const buildGoogleMessage = async (
  */
 export const buildGoogleMessages = async (
   messages: OpenAIChatMessage[],
-  options?: { model?: string },
+  options?: GoogleMessageBuildOptions,
 ): Promise<Content[]> => {
   const toolCallNameMap = new Map<string, string>();
 

--- a/packages/model-runtime/src/core/contextBuilders/openai.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.test.ts
@@ -3,6 +3,7 @@ import type OpenAI from 'openai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { OpenAIChatMessage } from '../../types';
+import { serializeScopedSignature } from '../../utils/signatureScope';
 import { parseDataUri } from '../../utils/uriParser';
 import {
   convertImageUrlToFile,
@@ -196,6 +197,38 @@ describe('convertOpenAIMessages', () => {
     const result = await convertOpenAIMessages(messages);
 
     expect(result).toEqual(messages);
+  });
+
+  it('should only unwrap tool thought signatures for the matching scope', async () => {
+    const sourceScope = {
+      apiType: 'openai',
+      channelId: 'openrouter-a',
+      model: 'google/gemini-3.5-pro',
+      provider: 'lobehub',
+      routerId: 'openrouter',
+    };
+    const messages = [
+      {
+        content: '',
+        role: 'assistant',
+        tool_calls: [
+          {
+            function: { arguments: '{}', name: 'search' },
+            id: 'call-1',
+            thoughtSignature: serializeScopedSignature('gemini-signature', sourceScope),
+            type: 'function',
+          },
+        ],
+      },
+    ] as unknown as OpenAI.ChatCompletionMessageParam[];
+
+    const matching = await convertOpenAIMessages(messages, { signatureScope: sourceScope });
+    const mismatched = await convertOpenAIMessages(messages, {
+      signatureScope: { ...sourceScope, channelId: 'openrouter-b' },
+    });
+
+    expect((matching[0] as any).tool_calls[0].thoughtSignature).toBe('gemini-signature');
+    expect((mismatched[0] as any).tool_calls[0].thoughtSignature).toBeUndefined();
   });
 
   it('should convert array content messages', async () => {
@@ -920,48 +953,100 @@ describe('convertOpenAIResponseInputs', () => {
     ]);
   });
 
-  it('should replay encrypted reasoning from a persisted message for the same provider', async () => {
+  it('should replay multiple Responses reasoning items for the same signature scope', async () => {
+    const signatureScope = {
+      channelId: 'account-1',
+      model: 'gpt-5.6-sol',
+      provider: 'chatgpt',
+    };
     const messages: OpenAIChatMessage[] = [
       {
         content: 'hello',
         model: 'gpt-5.6-sol',
         provider: 'chatgpt',
         reasoning: {
-          content: 'reasoning content',
-          signature: 'encrypted-reasoning-content',
+          content: 'first\nsecond',
+          responseItems: [
+            {
+              item: {
+                encrypted_content: 'encrypted-1',
+                id: 'reasoning-1',
+                summary: [{ text: 'first', type: 'summary_text' }],
+                type: 'reasoning',
+              },
+              signatureScope,
+            },
+            {
+              item: {
+                encrypted_content: 'encrypted-2',
+                id: 'reasoning-2',
+                summary: [{ text: 'second', type: 'summary_text' }],
+                type: 'reasoning',
+              },
+              signatureScope,
+            },
+          ],
         },
         role: 'assistant',
       },
     ];
 
-    const result = await convertOpenAIResponseInputs(messages, { provider: 'chatgpt' });
+    const result = await convertOpenAIResponseInputs(messages, { signatureScope });
 
     expect(result).toEqual([
       {
-        encrypted_content: 'encrypted-reasoning-content',
-        summary: [{ text: 'reasoning content', type: 'summary_text' }],
+        encrypted_content: 'encrypted-1',
+        id: 'reasoning-1',
+        summary: [{ text: 'first', type: 'summary_text' }],
+        type: 'reasoning',
+      },
+      {
+        encrypted_content: 'encrypted-2',
+        id: 'reasoning-2',
+        summary: [{ text: 'second', type: 'summary_text' }],
         type: 'reasoning',
       },
       { content: 'hello', role: 'assistant' },
     ]);
   });
 
-  it('should preserve encrypted reasoning content without a visible summary', async () => {
+  it('should not replay scoped or legacy encrypted reasoning to another channel', async () => {
+    const sourceScope = {
+      apiType: 'openai',
+      channelId: 'channel-a',
+      model: 'gpt-5.6-sol',
+      provider: 'lobehub',
+      routerId: 'openai',
+    };
     const messages: OpenAIChatMessage[] = [
       {
         content: 'hello',
-        provider: 'chatgpt',
-        reasoning: { signature: 'encrypted-reasoning-content' },
+        reasoning: {
+          content: 'reasoning content',
+          responseItems: [
+            {
+              item: {
+                encrypted_content: 'encrypted-reasoning-content',
+                id: 'reasoning-1',
+                summary: [{ text: 'reasoning content', type: 'summary_text' }],
+                type: 'reasoning',
+              },
+              signatureScope: sourceScope,
+            },
+          ],
+          signature: 'legacy-unscoped-signature',
+        },
         role: 'assistant',
       },
     ];
 
-    const result = await convertOpenAIResponseInputs(messages, { provider: 'chatgpt' });
+    const result = await convertOpenAIResponseInputs(messages, {
+      signatureScope: { ...sourceScope, channelId: 'channel-b' },
+    });
 
     expect(result).toEqual([
       {
-        encrypted_content: 'encrypted-reasoning-content',
-        summary: [],
+        summary: [{ text: 'reasoning content', type: 'summary_text' }],
         type: 'reasoning',
       },
       { content: 'hello', role: 'assistant' },

--- a/packages/model-runtime/src/core/contextBuilders/openai.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.test.ts
@@ -226,9 +226,20 @@ describe('convertOpenAIMessages', () => {
     const mismatched = await convertOpenAIMessages(messages, {
       signatureScope: { ...sourceScope, channelId: 'openrouter-b' },
     });
+    const missingTarget = await convertOpenAIMessages(messages);
+    const legacy = await convertOpenAIMessages([
+      {
+        ...messages[0],
+        tool_calls: [
+          { ...(messages[0] as any).tool_calls[0], thoughtSignature: 'legacy-signature' },
+        ],
+      } as OpenAI.ChatCompletionMessageParam,
+    ]);
 
     expect((matching[0] as any).tool_calls[0].thoughtSignature).toBe('gemini-signature');
     expect((mismatched[0] as any).tool_calls[0].thoughtSignature).toBeUndefined();
+    expect((missingTarget[0] as any).tool_calls[0].thoughtSignature).toBeUndefined();
+    expect((legacy[0] as any).tool_calls[0].thoughtSignature).toBe('legacy-signature');
   });
 
   it('should convert array content messages', async () => {

--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -1,11 +1,18 @@
+import type { ModelSignatureScope } from '@lobechat/types';
 import { imageUrlToBase64, videoUrlToBase64 } from '@lobechat/utils';
 import { Buffer } from 'buffer.js';
 import type OpenAI from 'openai';
 import { toFile } from 'openai';
 
 import { disableStreamModels, systemToUserModels } from '../../providers/openai/modelId';
-import type { ChatStreamPayload, OpenAIChatMessage, UserMessageContentPart } from '../../types';
+import type {
+  ChatStreamPayload,
+  MessageToolCall,
+  OpenAIChatMessage,
+  UserMessageContentPart,
+} from '../../types';
 import { isDeepSeekThinkingEligibleModel } from '../../utils/modelParse';
+import { isSameModelSignatureScope, resolveScopedSignature } from '../../utils/signatureScope';
 import { parseDataUri } from '../../utils/uriParser';
 
 export type ExtendedChatCompletionContentPart = {
@@ -20,6 +27,7 @@ type ConvertMessageContentOptions = {
   forceVideoBase64?: boolean;
   model?: string;
   provider?: string;
+  signatureScope?: ModelSignatureScope;
   strictToolPairing?: boolean;
 };
 
@@ -159,7 +167,19 @@ export const convertOpenAIMessages = async (
 
       // Add optional fields if they exist
       if (msg.name !== undefined) result.name = msg.name;
-      if (msg.tool_calls !== undefined) result.tool_calls = msg.tool_calls;
+      if (msg.tool_calls !== undefined) {
+        result.tool_calls = msg.tool_calls.map((toolCall: MessageToolCall) => {
+          if (!toolCall.thoughtSignature) return toolCall;
+
+          const { thoughtSignature, ...rest } = toolCall;
+          const resolvedSignature = resolveScopedSignature(
+            thoughtSignature,
+            options?.signatureScope,
+          );
+
+          return resolvedSignature ? { ...rest, thoughtSignature: resolvedSignature } : rest;
+        });
+      }
       if (msg.tool_call_id !== undefined) result.tool_call_id = msg.tool_call_id;
       if (msg.function_call !== undefined) result.function_call = msg.function_call;
 
@@ -224,16 +244,30 @@ export const convertOpenAIResponseInputs = async (
   const inputGroups = await Promise.all(
     messages.map(async (message) => {
       const items: OpenAI.Responses.ResponseInputItem[] = [];
-      const sourceProvider = message.provider;
       const reasoning = message.reasoning;
-      const encryptedContent =
-        sourceProvider && sourceProvider === options?.provider ? reasoning?.signature : undefined;
+      const responseItems = reasoning?.responseItems;
+      const targetSignatureScope = options?.signatureScope;
+      const replayableResponseItems =
+        responseItems?.length &&
+        targetSignatureScope &&
+        responseItems.every(({ signatureScope }) =>
+          isSameModelSignatureScope(signatureScope, targetSignatureScope),
+        )
+          ? responseItems
+          : undefined;
 
-      // Preserve encrypted reasoning state for stateless Responses API requests.
-      if (reasoning?.content || encryptedContent) {
+      // Responses reasoning items are opaque provider state and must be replayed unchanged.
+      if (replayableResponseItems) {
+        items.push(
+          ...replayableResponseItems.map(
+            ({ item }) => item as OpenAI.Responses.ResponseReasoningItem,
+          ),
+        );
+      } else if (reasoning?.content) {
+        // Legacy scalar signatures have no route/channel provenance, so retain only
+        // their visible summary instead of risking replay to a foreign endpoint.
         items.push({
-          encrypted_content: encryptedContent,
-          summary: reasoning?.content ? [{ text: reasoning.content, type: 'summary_text' }] : [],
+          summary: [{ text: reasoning.content, type: 'summary_text' }],
           type: 'reasoning',
         } as OpenAI.Responses.ResponseReasoningItem);
       }

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -9,7 +9,7 @@ import type { LobeOpenAICompatibleRuntime } from '../../core/BaseAI';
 import type { ChatStreamCallbacks, ChatStreamPayload } from '../../types/chat';
 import { AgentRuntimeErrorType } from '../../types/error';
 import * as debugStreamModule from '../../utils/debugStream';
-import { serializeScopedSignature } from '../../utils/signatureScope';
+import { createSignatureChannelId, serializeScopedSignature } from '../../utils/signatureScope';
 import * as openaiHelpers from '../contextBuilders/openai';
 import { createOpenAICompatibleRuntime } from './index';
 
@@ -230,6 +230,7 @@ describe('LobeOpenAICompatibleFactory', () => {
                 function: { arguments: '{}', name: 'search' },
                 id: 'call-1',
                 thoughtSignature: serializeScopedSignature('upstream-signature', {
+                  channelId: await createSignatureChannelId(defaultBaseURL, 'test'),
                   model: 'upstream-model',
                   provider: 'mapped-provider',
                 }),
@@ -249,6 +250,59 @@ describe('LobeOpenAICompatibleFactory', () => {
       expect((request.messages[0] as any).tool_calls[0].thoughtSignature).toBe(
         'upstream-signature',
       );
+    });
+
+    it.each([
+      {
+        sourceApiKey: 'another-key',
+        sourceBaseURL: defaultBaseURL,
+        sourceLabel: 'API key',
+      },
+      {
+        sourceApiKey: 'test',
+        sourceBaseURL: 'https://another.example.com/v1',
+        sourceLabel: 'endpoint',
+      },
+    ])('should not replay a direct signature from another $sourceLabel', async (source) => {
+      const Runtime = createOpenAICompatibleRuntime({
+        baseURL: defaultBaseURL,
+        provider: 'mapped-provider',
+      });
+      const runtime = new Runtime({ apiKey: 'test' });
+      const create = vi
+        .spyOn(runtime['client'].chat.completions, 'create')
+        .mockResolvedValue(new ReadableStream() as any);
+
+      await runtime.chat({
+        messages: [
+          {
+            content: '',
+            role: 'assistant',
+            tool_calls: [
+              {
+                function: { arguments: '{}', name: 'search' },
+                id: 'call-1',
+                thoughtSignature: serializeScopedSignature('foreign-signature', {
+                  channelId: await createSignatureChannelId(
+                    source.sourceBaseURL,
+                    source.sourceApiKey,
+                  ),
+                  model: 'upstream-model',
+                  provider: 'mapped-provider',
+                }),
+                type: 'function',
+              },
+            ],
+          },
+          { content: '{}', role: 'tool', tool_call_id: 'call-1' },
+          { content: 'Continue', role: 'user' },
+        ],
+        model: 'upstream-model',
+        temperature: 0,
+      });
+
+      const request = create.mock.calls[0][0];
+      expect((request.messages[0] as any).tool_calls[0].thoughtSignature).toBeUndefined();
     });
 
     describe('streaming response', () => {
@@ -1604,6 +1658,7 @@ describe('LobeOpenAICompatibleFactory', () => {
                       type: 'reasoning',
                     },
                     signatureScope: {
+                      channelId: await createSignatureChannelId('https://api.test.com/v1', 'test'),
                       model: 'upstream-model',
                       provider: 'mapped-provider',
                     },
@@ -3030,6 +3085,7 @@ describe('LobeOpenAICompatibleFactory', () => {
           mockResponse as any,
         );
         const signatureScope = {
+          channelId: await createSignatureChannelId(defaultBaseURL, 'test'),
           model: 'gpt-4o',
           provider: ModelProvider.Groq,
         };

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -9,6 +9,7 @@ import type { LobeOpenAICompatibleRuntime } from '../../core/BaseAI';
 import type { ChatStreamCallbacks, ChatStreamPayload } from '../../types/chat';
 import { AgentRuntimeErrorType } from '../../types/error';
 import * as debugStreamModule from '../../utils/debugStream';
+import { serializeScopedSignature } from '../../utils/signatureScope';
 import * as openaiHelpers from '../contextBuilders/openai';
 import { createOpenAICompatibleRuntime } from './index';
 
@@ -203,6 +204,50 @@ describe('LobeOpenAICompatibleFactory', () => {
       expect(runtime['client'].chat.completions.create).toHaveBeenCalledWith(
         expect.objectContaining({ model: 'upstream-model' }),
         expect.anything(),
+      );
+    });
+
+    it('should scope tool signatures to the mapped upstream model id', async () => {
+      const Runtime = createOpenAICompatibleRuntime({
+        baseURL: defaultBaseURL,
+        provider: 'mapped-provider',
+      });
+      const runtime = new Runtime({
+        apiKey: 'test',
+        modelIdMapping: { 'logical-model': 'upstream-model' },
+      });
+      const create = vi
+        .spyOn(runtime['client'].chat.completions, 'create')
+        .mockResolvedValue(new ReadableStream() as any);
+
+      await runtime.chat({
+        messages: [
+          {
+            content: '',
+            role: 'assistant',
+            tool_calls: [
+              {
+                function: { arguments: '{}', name: 'search' },
+                id: 'call-1',
+                thoughtSignature: serializeScopedSignature('upstream-signature', {
+                  model: 'upstream-model',
+                  provider: 'mapped-provider',
+                }),
+                type: 'function',
+              },
+            ],
+          },
+          { content: '{}', role: 'tool', tool_call_id: 'call-1' },
+          { content: 'Continue', role: 'user' },
+        ],
+        model: 'logical-model',
+        temperature: 0,
+      });
+
+      const request = create.mock.calls[0][0];
+      expect(request.model).toBe('upstream-model');
+      expect((request.messages[0] as any).tool_calls[0].thoughtSignature).toBe(
+        'upstream-signature',
       );
     });
 
@@ -1527,6 +1572,59 @@ describe('LobeOpenAICompatibleFactory', () => {
             strictToolPairing: true,
           }),
         );
+        convertSpy.mockRestore();
+      });
+
+      it('should replay Responses reasoning for the mapped upstream model id', async () => {
+        const Runtime = createOpenAICompatibleRuntime({
+          baseURL: 'https://api.test.com/v1',
+          chatCompletion: { useResponse: true },
+          provider: 'mapped-provider',
+        });
+        const runtime = new Runtime({
+          apiKey: 'test',
+          modelIdMapping: { 'logical-model': 'upstream-model' },
+        });
+        const create = vi
+          .spyOn(runtime['client'].responses, 'create')
+          .mockResolvedValue(new ReadableStream() as any);
+
+        await runtime.chat({
+          messages: [
+            {
+              content: 'Answer',
+              reasoning: {
+                content: 'Summary',
+                responseItems: [
+                  {
+                    item: {
+                      encrypted_content: 'upstream-encrypted-content',
+                      id: 'reasoning-1',
+                      summary: [{ text: 'Summary', type: 'summary_text' }],
+                      type: 'reasoning',
+                    },
+                    signatureScope: {
+                      model: 'upstream-model',
+                      provider: 'mapped-provider',
+                    },
+                  },
+                ],
+              },
+              role: 'assistant',
+            },
+            { content: 'Continue', role: 'user' },
+          ],
+          model: 'logical-model',
+          temperature: 0,
+        });
+
+        const request = create.mock.calls[0][0];
+        expect(request.model).toBe('upstream-model');
+        expect(request.input[0]).toMatchObject({
+          encrypted_content: 'upstream-encrypted-content',
+          id: 'reasoning-1',
+          type: 'reasoning',
+        });
       });
 
       it('should keep OpenRouter OpenAI slugs on chat completions for provider payload normalization', async () => {

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -3008,6 +3008,68 @@ describe('LobeOpenAICompatibleFactory', () => {
         ]);
       });
 
+      it('should unwrap scoped tool signatures for chat completion requests', async () => {
+        const mockResponse = {
+          choices: [
+            {
+              message: {
+                tool_calls: [
+                  {
+                    function: {
+                      arguments: '{"city":"Tokyo"}',
+                      name: 'get_weather',
+                    },
+                    type: 'function' as const,
+                  },
+                ],
+              },
+            },
+          ],
+        };
+        vi.spyOn(instance['client'].chat.completions, 'create').mockResolvedValue(
+          mockResponse as any,
+        );
+        const signatureScope = {
+          model: 'gpt-4o',
+          provider: ModelProvider.Groq,
+        };
+
+        await instance.generateObject({
+          messages: [
+            {
+              content: '',
+              role: 'assistant' as const,
+              tool_calls: [
+                {
+                  function: { arguments: '{}', name: 'search' },
+                  id: 'call-1',
+                  thoughtSignature: serializeScopedSignature('upstream-signature', signatureScope),
+                  type: 'function' as const,
+                },
+              ],
+            },
+          ],
+          model: 'gpt-4o',
+          tools: [
+            {
+              function: {
+                name: 'get_weather',
+                parameters: {
+                  properties: { city: { type: 'string' } },
+                  type: 'object' as const,
+                },
+              },
+              type: 'function' as const,
+            },
+          ],
+        });
+
+        const requestPayload = instance['client'].chat.completions.create.mock.calls[0]![0];
+        expect(requestPayload.messages[0].tool_calls[0].thoughtSignature).toBe(
+          'upstream-signature',
+        );
+      });
+
       it('should handle tools parameter with systemRole', async () => {
         const mockResponse = {
           choices: [

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -6,7 +6,7 @@ import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { LobeOpenAICompatibleRuntime } from '../../core/BaseAI';
-import type { ChatStreamCallbacks, ChatStreamPayload } from '../../types/chat';
+import type { ChatStreamCallbacks, ChatStreamPayload, OpenAIChatMessage } from '../../types/chat';
 import { AgentRuntimeErrorType } from '../../types/error';
 import * as debugStreamModule from '../../utils/debugStream';
 import { createSignatureChannelId, serializeScopedSignature } from '../../utils/signatureScope';
@@ -1675,7 +1675,7 @@ describe('LobeOpenAICompatibleFactory', () => {
 
         const request = create.mock.calls[0][0];
         expect(request.model).toBe('upstream-model');
-        expect(request.input[0]).toMatchObject({
+        expect(request.input?.[0]).toMatchObject({
           encrypted_content: 'upstream-encrypted-content',
           id: 'reasoning-1',
           type: 'reasoning',
@@ -3081,30 +3081,31 @@ describe('LobeOpenAICompatibleFactory', () => {
             },
           ],
         };
-        vi.spyOn(instance['client'].chat.completions, 'create').mockResolvedValue(
-          mockResponse as any,
-        );
+        const create = vi
+          .spyOn(instance['client'].chat.completions, 'create')
+          .mockResolvedValue(mockResponse as any);
         const signatureScope = {
           channelId: await createSignatureChannelId(defaultBaseURL, 'test'),
           model: 'gpt-4o',
           provider: ModelProvider.Groq,
         };
+        const messages = [
+          {
+            content: '',
+            role: 'assistant',
+            tool_calls: [
+              {
+                function: { arguments: '{}', name: 'search' },
+                id: 'call-1',
+                thoughtSignature: serializeScopedSignature('upstream-signature', signatureScope),
+                type: 'function',
+              },
+            ],
+          },
+        ] satisfies OpenAIChatMessage[];
 
         await instance.generateObject({
-          messages: [
-            {
-              content: '',
-              role: 'assistant' as const,
-              tool_calls: [
-                {
-                  function: { arguments: '{}', name: 'search' },
-                  id: 'call-1',
-                  thoughtSignature: serializeScopedSignature('upstream-signature', signatureScope),
-                  type: 'function' as const,
-                },
-              ],
-            },
-          ],
+          messages,
           model: 'gpt-4o',
           tools: [
             {
@@ -3120,10 +3121,9 @@ describe('LobeOpenAICompatibleFactory', () => {
           ],
         });
 
-        const requestPayload = instance['client'].chat.completions.create.mock.calls[0]![0];
-        expect(requestPayload.messages[0].tool_calls[0].thoughtSignature).toBe(
-          'upstream-signature',
-        );
+        const requestPayload = create.mock.calls[0]![0];
+        const requestMessage = requestPayload.messages[0] as OpenAIChatMessage;
+        expect(requestMessage.tool_calls?.[0]?.thoughtSignature).toBe('upstream-signature');
       });
 
       it('should handle tools parameter with systemRole', async () => {

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -61,6 +61,11 @@ import {
   ContextExceededPreFlightError,
 } from '../../utils/resolveSafeMaxTokens';
 import { StreamingResponse } from '../../utils/response';
+import {
+  createModelSignatureScope,
+  getRuntimeSignatureScope,
+  type ModelSignatureScopeBase,
+} from '../../utils/signatureScope';
 import type { LobeRuntimeAI } from '../BaseAI';
 import { normalizeToolsParameters } from '../contextBuilders/normalizeToolSchema';
 import { convertOpenAIMessages, convertOpenAIResponseInputs } from '../contextBuilders/openai';
@@ -344,6 +349,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
     private id: string;
     private logPrefix: string;
     private modelIdMappingOptions: ModelIdMappingOptions = {};
+    private directSignatureScope?: ModelSignatureScopeBase;
 
     baseURL!: string;
     protected _options: ConstructorOptions<T>;
@@ -375,7 +381,23 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
       this.baseURL = baseURL || this.client.baseURL;
 
       this.id = options.id || provider;
+      /**
+       * ChatGPT encrypted reasoning is also account-bound. Treat the subscription
+       * account as a direct-provider channel when RouterRuntime did not supply one.
+       */
+      this.directSignatureScope =
+        typeof inputOptions.chatgptAccountId === 'string'
+          ? { channelId: inputOptions.chatgptAccountId, provider: this.id }
+          : undefined;
       this.logPrefix = `lobe-model-runtime:${this.id}`;
+    }
+
+    private getSignatureScope(model: string) {
+      return createModelSignatureScope(
+        this.id,
+        model,
+        getRuntimeSignatureScope(this) ?? this.directSignatureScope,
+      );
     }
 
     protected getMappedModelId(model: string) {
@@ -657,10 +679,12 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           this.baseURL = targetBaseURL;
         }
 
+        const signatureScope = this.getSignatureScope(payload.model);
         const messages = await convertOpenAIMessages(postPayload.messages, {
           forceImageBase64: chatCompletion?.forceImageBase64,
           forceVideoBase64: chatCompletion?.forceVideoBase64,
           model: postPayload.model,
+          signatureScope,
         });
         const includeUsageRequested = Boolean(postPayload.stream && !chatCompletion?.excludeUsage);
 
@@ -675,6 +699,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
             model: payload.model,
             pricing: await getModelPricing(payload.model, this.id, options?.pricingContext),
             provider: this.id,
+            signatureScope,
           },
         };
 
@@ -1416,6 +1441,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
       log('handleResponseAPIMode called with model: %s', payload.model);
 
       const inputStartAt = Date.now();
+      const signatureScope = this.getSignatureScope(usageModel);
 
       const { messages, reasoning_effort, tools, reasoning, responseMode, max_tokens, ...res } =
         responses?.handlePayload
@@ -1432,6 +1458,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         forceImageBase64: chatCompletion?.forceImageBase64,
         forceVideoBase64: chatCompletion?.forceVideoBase64,
         provider: this.id,
+        signatureScope,
         strictToolPairing: true,
       });
 
@@ -1496,6 +1523,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           model: usageModel,
           pricing: await getModelPricing(usageModel, this.id, options?.pricingContext),
           provider: this.id,
+          signatureScope,
         },
       };
 
@@ -1584,6 +1612,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           forceImageBase64: chatCompletion?.forceImageBase64,
           forceVideoBase64: chatCompletion?.forceVideoBase64,
           provider: this.id,
+          signatureScope: this.getSignatureScope(payload.model),
           strictToolPairing: true,
         });
 

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -1610,10 +1610,10 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         model,
         responseApi,
       });
+      const signatureScope = this.getSignatureScope(this.getMappedModelId(payload.model));
 
       if (shouldUseResponses) {
         log('calling responses.create for tool calling');
-        const signatureScope = this.getSignatureScope(this.getMappedModelId(payload.model));
         const input = await convertOpenAIResponseInputs(messages as any, {
           forceImageBase64: chatCompletion?.forceImageBase64,
           forceVideoBase64: chatCompletion?.forceVideoBase64,
@@ -1671,7 +1671,12 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
       }
 
       log('calling chat.completions.create for tool calling');
-      const msgs = messages;
+      const msgs = await convertOpenAIMessages(messages as any, {
+        forceImageBase64: chatCompletion?.forceImageBase64,
+        forceVideoBase64: chatCompletion?.forceVideoBase64,
+        model,
+        signatureScope,
+      });
 
       const res = await this.client.chat.completions.create(
         this.withMappedRequestModel(

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -679,7 +679,10 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           this.baseURL = targetBaseURL;
         }
 
-        const signatureScope = this.getSignatureScope(payload.model);
+        const requestModel =
+          this.withMappedRequestModel({ model: postPayload.model }, payload.model).model ??
+          payload.model;
+        const signatureScope = this.getSignatureScope(requestModel);
         const messages = await convertOpenAIMessages(postPayload.messages, {
           forceImageBase64: chatCompletion?.forceImageBase64,
           forceVideoBase64: chatCompletion?.forceVideoBase64,
@@ -1441,12 +1444,14 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
       log('handleResponseAPIMode called with model: %s', payload.model);
 
       const inputStartAt = Date.now();
-      const signatureScope = this.getSignatureScope(usageModel);
 
       const { messages, reasoning_effort, tools, reasoning, responseMode, max_tokens, ...res } =
         responses?.handlePayload
           ? (responses?.handlePayload(payload, this._options) as ChatStreamPayload)
           : payload;
+      const requestModel =
+        this.withMappedRequestModel({ model: res.model }, usageModel).model ?? usageModel;
+      const signatureScope = this.getSignatureScope(requestModel);
 
       // remove penalty params and chat completion specific params
       delete res.apiMode;
@@ -1608,11 +1613,12 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
 
       if (shouldUseResponses) {
         log('calling responses.create for tool calling');
+        const signatureScope = this.getSignatureScope(this.getMappedModelId(payload.model));
         const input = await convertOpenAIResponseInputs(messages as any, {
           forceImageBase64: chatCompletion?.forceImageBase64,
           forceVideoBase64: chatCompletion?.forceVideoBase64,
           provider: this.id,
-          signatureScope: this.getSignatureScope(payload.model),
+          signatureScope,
           strictToolPairing: true,
         });
 

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -63,6 +63,7 @@ import {
 import { StreamingResponse } from '../../utils/response';
 import {
   createModelSignatureScope,
+  createSignatureChannelId,
   getRuntimeSignatureScope,
   type ModelSignatureScopeBase,
 } from '../../utils/signatureScope';
@@ -392,11 +393,22 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
       this.logPrefix = `lobe-model-runtime:${this.id}`;
     }
 
-    private getSignatureScope(model: string) {
+    /**
+     * Direct OpenAI-compatible endpoints do not expose a stable account id, so bind
+     * opaque reasoning state to a non-secret fingerprint of the endpoint and API key.
+     */
+    private async getSignatureScope(model: string) {
+      const runtimeScope = getRuntimeSignatureScope(this) ?? this.directSignatureScope;
+      const directChannelId =
+        runtimeScope || !this._options.apiKey
+          ? undefined
+          : await createSignatureChannelId(this.baseURL, this._options.apiKey);
+
       return createModelSignatureScope(
         this.id,
         model,
-        getRuntimeSignatureScope(this) ?? this.directSignatureScope,
+        runtimeScope ??
+          (directChannelId ? { channelId: directChannelId, provider: this.id } : undefined),
       );
     }
 
@@ -682,7 +694,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         const requestModel =
           this.withMappedRequestModel({ model: postPayload.model }, payload.model).model ??
           payload.model;
-        const signatureScope = this.getSignatureScope(requestModel);
+        const signatureScope = await this.getSignatureScope(requestModel);
         const messages = await convertOpenAIMessages(postPayload.messages, {
           forceImageBase64: chatCompletion?.forceImageBase64,
           forceVideoBase64: chatCompletion?.forceVideoBase64,
@@ -1451,7 +1463,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           : payload;
       const requestModel =
         this.withMappedRequestModel({ model: res.model }, usageModel).model ?? usageModel;
-      const signatureScope = this.getSignatureScope(requestModel);
+      const signatureScope = await this.getSignatureScope(requestModel);
 
       // remove penalty params and chat completion specific params
       delete res.apiMode;
@@ -1610,7 +1622,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         model,
         responseApi,
       });
-      const signatureScope = this.getSignatureScope(this.getMappedModelId(payload.model));
+      const signatureScope = await this.getSignatureScope(this.getMappedModelId(payload.model));
 
       if (shouldUseResponses) {
         log('calling responses.create for tool calling');

--- a/packages/model-runtime/src/core/streams/google/index.ts
+++ b/packages/model-runtime/src/core/streams/google/index.ts
@@ -2,6 +2,7 @@ import type { GenerateContentResponse, Part } from '@google/genai';
 import type { GroundingSearch } from '@lobechat/types';
 
 import type { ChatStreamCallbacks } from '../../../types';
+import { serializeScopedSignature } from '../../../utils/signatureScope';
 import { nanoid } from '../../../utils/uuid';
 import { convertGoogleAIUsage } from '../../usageConverters/google-ai';
 import type {
@@ -149,7 +150,11 @@ const transformGoogleGenerativeAIStream = (
           },
           id: value.id || generateToolCallId(index, value.name),
           index,
-          thoughtSignature: value.thoughtSignature,
+          thoughtSignature: value.thoughtSignature
+            ? payload?.signatureScope
+              ? serializeScopedSignature(value.thoughtSignature, payload.signatureScope)
+              : value.thoughtSignature
+            : undefined,
           type: 'function',
         })),
         id: context.id,

--- a/packages/model-runtime/src/core/streams/openai/openai.ts
+++ b/packages/model-runtime/src/core/streams/openai/openai.ts
@@ -6,6 +6,7 @@ import type { ChatStreamCallbacks } from '../../../types';
 import type { ILobeAgentRuntimeErrorType } from '../../../types/error';
 import { AgentRuntimeErrorType } from '../../../types/error';
 import { isErrorCausedByContentFilter } from '../../../utils/isErrorCausedByContentFilter';
+import { serializeScopedSignature } from '../../../utils/signatureScope';
 import { convertOpenAIUsage } from '../../usageConverters';
 import type {
   ChatPayloadForTransformStream,
@@ -249,7 +250,12 @@ const transformOpenAIStream = (
             // OpenRouter returns thoughtSignature in tool_calls for Gemini models (e.g. gemini-3-flash-preview)
             // [{"id":"call_123","type":"function","function":{"name":"get_weather","arguments":"{}"},"thoughtSignature":"abc123"}]
             if (hasThoughtSignature(value)) {
-              baseData.thoughtSignature = value.thoughtSignature;
+              const thoughtSignature = value.thoughtSignature;
+              if (!thoughtSignature) return baseData;
+
+              baseData.thoughtSignature = payload?.signatureScope
+                ? serializeScopedSignature(thoughtSignature, payload.signatureScope)
+                : thoughtSignature;
             }
 
             return baseData;

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
@@ -746,6 +746,36 @@ describe('OpenAIResponsesStream', () => {
     expect(chunks.some((chunk) => chunk.includes('"id":"reasoning_item"'))).toBe(true);
   });
 
+  it('should discard reasoning items without summary or encrypted content', async () => {
+    const mockOpenAIStream = createReadableStream([
+      {
+        item: {
+          encrypted_content: null,
+          id: 'empty_reasoning_item',
+          summary: [],
+          type: 'reasoning',
+        },
+        output_index: 0,
+        type: 'response.output_item.done',
+      },
+    ]);
+
+    const protocolStream = OpenAIResponsesStream(mockOpenAIStream, {
+      payload: {
+        model: 'gpt-5.6-sol',
+        provider: 'chatgpt',
+        signatureScope: {
+          channelId: 'account-1',
+          model: 'gpt-5.6-sol',
+          provider: 'chatgpt',
+        },
+      },
+    });
+    const chunks = await readStreamChunk(protocolStream);
+
+    expect(chunks.some((chunk) => chunk.includes('event: reasoning_signature'))).toBe(false);
+  });
+
   it('should handle response.completed with usage', async () => {
     const mockOpenAIStream = createReadableStream([
       {

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
@@ -776,6 +776,37 @@ describe('OpenAIResponsesStream', () => {
     expect(chunks.some((chunk) => chunk.includes('event: reasoning_signature'))).toBe(false);
   });
 
+  it('should discard encrypted reasoning without a stable channel id', async () => {
+    const mockOpenAIStream = createReadableStream([
+      {
+        item: {
+          encrypted_content: 'unverifiable-encrypted-content',
+          id: 'unverifiable_reasoning_item',
+          summary: [],
+          type: 'reasoning',
+        },
+        output_index: 0,
+        type: 'response.output_item.done',
+      },
+    ]);
+
+    const protocolStream = OpenAIResponsesStream(mockOpenAIStream, {
+      payload: {
+        model: 'gpt-5.6-sol',
+        provider: 'lobehub',
+        signatureScope: {
+          model: 'gpt-5.6-sol',
+          provider: 'lobehub',
+          routerId: 'openai',
+        },
+      },
+    });
+    const chunks = await readStreamChunk(protocolStream);
+
+    expect(chunks.some((chunk) => chunk.includes('event: reasoning_signature'))).toBe(false);
+    expect(chunks.some((chunk) => chunk.includes('unverifiable-encrypted-content'))).toBe(false);
+  });
+
   it('should handle response.completed with usage', async () => {
     const mockOpenAIStream = createReadableStream([
       {

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
@@ -709,7 +709,12 @@ describe('OpenAIResponsesStream', () => {
     expect(chunks).toMatchSnapshot();
   });
 
-  it('should emit encrypted reasoning content as a reasoning signature', async () => {
+  it('should emit the complete scoped reasoning item', async () => {
+    const signatureScope = {
+      channelId: 'account-1',
+      model: 'gpt-5.6-sol',
+      provider: 'chatgpt',
+    };
     const mockOpenAIStream = createReadableStream([
       {
         type: 'response.created',
@@ -730,11 +735,15 @@ describe('OpenAIResponsesStream', () => {
       },
     ]);
 
-    const protocolStream = OpenAIResponsesStream(mockOpenAIStream);
+    const protocolStream = OpenAIResponsesStream(mockOpenAIStream, {
+      payload: { model: 'gpt-5.6-sol', provider: 'chatgpt', signatureScope },
+    });
     const chunks = await readStreamChunk(protocolStream);
 
     expect(chunks.some((chunk) => chunk.includes('event: reasoning_signature'))).toBe(true);
     expect(chunks.some((chunk) => chunk.includes('encrypted-reasoning-content'))).toBe(true);
+    expect(chunks.some((chunk) => chunk.includes('"signatureScope"'))).toBe(true);
+    expect(chunks.some((chunk) => chunk.includes('"id":"reasoning_item"'))).toBe(true);
   });
 
   it('should handle response.completed with usage', async () => {

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
@@ -709,7 +709,7 @@ describe('OpenAIResponsesStream', () => {
     expect(chunks).toMatchSnapshot();
   });
 
-  it('should emit the complete scoped reasoning item', async () => {
+  it('should emit the complete scoped reasoning item without changing the legacy signature event', async () => {
     const signatureScope = {
       channelId: 'account-1',
       model: 'gpt-5.6-sol',
@@ -740,7 +740,8 @@ describe('OpenAIResponsesStream', () => {
     });
     const chunks = await readStreamChunk(protocolStream);
 
-    expect(chunks.some((chunk) => chunk.includes('event: reasoning_signature'))).toBe(true);
+    expect(chunks.some((chunk) => chunk.includes('event: reasoning_response_item'))).toBe(true);
+    expect(chunks.some((chunk) => chunk.includes('event: reasoning_signature'))).toBe(false);
     expect(chunks.some((chunk) => chunk.includes('encrypted-reasoning-content'))).toBe(true);
     expect(chunks.some((chunk) => chunk.includes('"signatureScope"'))).toBe(true);
     expect(chunks.some((chunk) => chunk.includes('"id":"reasoning_item"'))).toBe(true);
@@ -773,7 +774,7 @@ describe('OpenAIResponsesStream', () => {
     });
     const chunks = await readStreamChunk(protocolStream);
 
-    expect(chunks.some((chunk) => chunk.includes('event: reasoning_signature'))).toBe(false);
+    expect(chunks.some((chunk) => chunk.includes('event: reasoning_response_item'))).toBe(false);
   });
 
   it('should discard encrypted reasoning without a stable channel id', async () => {
@@ -803,7 +804,7 @@ describe('OpenAIResponsesStream', () => {
     });
     const chunks = await readStreamChunk(protocolStream);
 
-    expect(chunks.some((chunk) => chunk.includes('event: reasoning_signature'))).toBe(false);
+    expect(chunks.some((chunk) => chunk.includes('event: reasoning_response_item'))).toBe(false);
     expect(chunks.some((chunk) => chunk.includes('unverifiable-encrypted-content'))).toBe(false);
   });
 

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.ts
@@ -149,7 +149,11 @@ const transformOpenAIStream = (
         const hasReplayableReasoning =
           chunk.item.type === 'reasoning' &&
           (!!chunk.item.encrypted_content || chunk.item.summary?.some(({ text }) => !!text));
-        if (hasReplayableReasoning && payload?.signatureScope) {
+        /**
+         * Encrypted Responses reasoning is channel-bound provider state. Do not expose
+         * or persist it when the runtime cannot prove which channel produced it.
+         */
+        if (hasReplayableReasoning && payload?.signatureScope?.channelId) {
           return {
             data: {
               item: chunk.item,

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.ts
@@ -146,7 +146,10 @@ const transformOpenAIStream = (
       }
 
       case 'response.output_item.done': {
-        if (chunk.item.type === 'reasoning' && payload?.signatureScope) {
+        const hasReplayableReasoning =
+          chunk.item.type === 'reasoning' &&
+          (!!chunk.item.encrypted_content || chunk.item.summary?.some(({ text }) => !!text));
+        if (hasReplayableReasoning && payload?.signatureScope) {
           return {
             data: {
               item: chunk.item,

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.ts
@@ -154,13 +154,17 @@ const transformOpenAIStream = (
          * or persist it when the runtime cannot prove which channel produced it.
          */
         if (hasReplayableReasoning && payload?.signatureScope?.channelId) {
+          /**
+           * Keep structured Responses items on a distinct event. Released clients treat
+           * `reasoning_signature` as string-only and would assign this object to `signature`.
+           */
           return {
             data: {
               item: chunk.item,
               signatureScope: payload.signatureScope,
             },
             id: chunk.item.id,
-            type: 'reasoning_signature',
+            type: 'reasoning_response_item',
           };
         }
 

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.ts
@@ -146,9 +146,12 @@ const transformOpenAIStream = (
       }
 
       case 'response.output_item.done': {
-        if (chunk.item.type === 'reasoning' && chunk.item.encrypted_content) {
+        if (chunk.item.type === 'reasoning' && payload?.signatureScope) {
           return {
-            data: chunk.item.encrypted_content,
+            data: {
+              item: chunk.item,
+              signatureScope: payload.signatureScope,
+            },
             id: chunk.item.id,
             type: 'reasoning_signature',
           };

--- a/packages/model-runtime/src/core/streams/protocol.test.ts
+++ b/packages/model-runtime/src/core/streams/protocol.test.ts
@@ -772,7 +772,7 @@ describe('createCallbacksTransformer', () => {
     };
 
     await processChunks(transformer, [
-      'event: reasoning_signature\n',
+      'event: reasoning_response_item\n',
       `data: ${JSON.stringify(responseItem)}\n\n`,
     ]);
 
@@ -805,7 +805,7 @@ describe('createCallbacksTransformer', () => {
     };
 
     await processChunks(transformer, [
-      'event: reasoning_signature\n',
+      'event: reasoning_response_item\n',
       `data: ${JSON.stringify(responseItem)}\n\n`,
     ]);
 
@@ -854,7 +854,7 @@ describe('createCallbacksTransformer', () => {
       'event: reasoning\n',
       'data: "First\\nSecond"\n\n',
       ...responseItems.flatMap((item) => [
-        'event: reasoning_signature\n',
+        'event: reasoning_response_item\n',
         `data: ${JSON.stringify(item)}\n\n`,
       ]),
     ]);

--- a/packages/model-runtime/src/core/streams/protocol.test.ts
+++ b/packages/model-runtime/src/core/streams/protocol.test.ts
@@ -755,6 +755,39 @@ describe('createCallbacksTransformer', () => {
     expect(onCompletion.mock.calls[0][0].reasoning).toBeUndefined();
   });
 
+  it('should preserve response items when only their summaries contain reasoning text', async () => {
+    const onCompletion = vi.fn();
+    const transformer = createCallbacksTransformer({ onCompletion });
+    const responseItem = {
+      item: {
+        encrypted_content: 'encrypted-1',
+        id: 'reasoning-1',
+        summary: [{ text: 'Visible summary', type: 'summary_text' }],
+        type: 'reasoning',
+      },
+      signatureScope: {
+        model: 'gpt-5.6-sol',
+        provider: 'chatgpt',
+      },
+    };
+
+    await processChunks(transformer, [
+      'event: reasoning_signature\n',
+      `data: ${JSON.stringify(responseItem)}\n\n`,
+    ]);
+
+    expect(onCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reasoning: {
+          content: 'Visible summary',
+          responseItems: [responseItem],
+          signature: undefined,
+        },
+        thinking: 'Visible summary',
+      }),
+    );
+  });
+
   it('should preserve multiple scoped Responses reasoning items', async () => {
     const onCompletion = vi.fn();
     const transformer = createCallbacksTransformer({ onCompletion });

--- a/packages/model-runtime/src/core/streams/protocol.test.ts
+++ b/packages/model-runtime/src/core/streams/protocol.test.ts
@@ -788,6 +788,39 @@ describe('createCallbacksTransformer', () => {
     );
   });
 
+  it('should preserve response items without visible reasoning text', async () => {
+    const onCompletion = vi.fn();
+    const transformer = createCallbacksTransformer({ onCompletion });
+    const responseItem = {
+      item: {
+        encrypted_content: 'encrypted-1',
+        id: 'reasoning-1',
+        summary: [],
+        type: 'reasoning',
+      },
+      signatureScope: {
+        model: 'gpt-5.6-sol',
+        provider: 'chatgpt',
+      },
+    };
+
+    await processChunks(transformer, [
+      'event: reasoning_signature\n',
+      `data: ${JSON.stringify(responseItem)}\n\n`,
+    ]);
+
+    expect(onCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reasoning: {
+          content: undefined,
+          responseItems: [responseItem],
+          signature: undefined,
+        },
+        thinking: undefined,
+      }),
+    );
+  });
+
   it('should preserve multiple scoped Responses reasoning items', async () => {
     const onCompletion = vi.fn();
     const transformer = createCallbacksTransformer({ onCompletion });

--- a/packages/model-runtime/src/core/streams/protocol.test.ts
+++ b/packages/model-runtime/src/core/streams/protocol.test.ts
@@ -743,6 +743,67 @@ describe('createCallbacksTransformer', () => {
     );
   });
 
+  it('should discard reasoning state when the stream only contains a signature', async () => {
+    const onCompletion = vi.fn();
+    const transformer = createCallbacksTransformer({ onCompletion });
+
+    await processChunks(transformer, [
+      'event: reasoning_signature\n',
+      'data: "encrypted-signature"\n\n',
+    ]);
+
+    expect(onCompletion.mock.calls[0][0].reasoning).toBeUndefined();
+  });
+
+  it('should preserve multiple scoped Responses reasoning items', async () => {
+    const onCompletion = vi.fn();
+    const transformer = createCallbacksTransformer({ onCompletion });
+    const signatureScope = {
+      channelId: 'chatgpt-account-1',
+      model: 'gpt-5.6-sol',
+      provider: 'chatgpt',
+    };
+    const responseItems = [
+      {
+        item: {
+          encrypted_content: 'encrypted-1',
+          id: 'reasoning-1',
+          summary: [{ text: 'First', type: 'summary_text' }],
+          type: 'reasoning',
+        },
+        signatureScope,
+      },
+      {
+        item: {
+          encrypted_content: 'encrypted-2',
+          id: 'reasoning-2',
+          summary: [{ text: 'Second', type: 'summary_text' }],
+          type: 'reasoning',
+        },
+        signatureScope,
+      },
+    ];
+
+    await processChunks(transformer, [
+      'event: reasoning\n',
+      'data: "First\\nSecond"\n\n',
+      ...responseItems.flatMap((item) => [
+        'event: reasoning_signature\n',
+        `data: ${JSON.stringify(item)}\n\n`,
+      ]),
+    ]);
+
+    expect(onCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reasoning: {
+          content: 'First\nSecond',
+          responseItems,
+          signature: undefined,
+        },
+      }),
+    );
+  });
+
   it('should handle base64_image chunks and call onBase64Image callback', async () => {
     const receivedCalls: Array<{
       image: { id: string; data: string };

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -466,6 +466,7 @@ export function createCallbacksTransformer(
         .filter(Boolean)
         .join('\n');
       const reasoningContent = aggregatedThinking || responseItemsThinking;
+      const hasResponseItems = reasoningResponseItems.length > 0;
       const data: OnFinishData = {
         error: streamError,
         finishReason,
@@ -476,11 +477,15 @@ export function createCallbacksTransformer(
         toolsCalling,
         usage,
       };
-      if (reasoningContent) {
+      /**
+       * Responses reasoning items remain replayable without a visible summary, while a legacy
+       * signature alone must still be discarded because it has no safe replay context.
+       */
+      if (reasoningContent || hasResponseItems) {
         data.reasoning = {
-          content: reasoningContent,
-          responseItems: reasoningResponseItems.length > 0 ? reasoningResponseItems : undefined,
-          signature: reasoningSignature,
+          content: reasoningContent || undefined,
+          responseItems: hasResponseItems ? reasoningResponseItems : undefined,
+          signature: reasoningContent ? reasoningSignature : undefined,
         };
       }
       const usageMissingDiagnostics = usage

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -460,19 +460,25 @@ export function createCallbacksTransformer(
 
   return new TransformStream<string, Uint8Array>({
     async flush(): Promise<void> {
+      const responseItemsThinking = reasoningResponseItems
+        .flatMap(({ item }) => item.summary)
+        .map(({ text }) => text)
+        .filter(Boolean)
+        .join('\n');
+      const reasoningContent = aggregatedThinking || responseItemsThinking;
       const data: OnFinishData = {
         error: streamError,
         finishReason,
         grounding,
         speed,
         text: aggregatedText,
-        thinking: aggregatedThinking,
+        thinking: reasoningContent || undefined,
         toolsCalling,
         usage,
       };
-      if (aggregatedThinking) {
+      if (reasoningContent) {
         data.reasoning = {
-          content: aggregatedThinking,
+          content: reasoningContent,
           responseItems: reasoningResponseItems.length > 0 ? reasoningResponseItems : undefined,
           signature: reasoningSignature,
         };

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -117,6 +117,8 @@ export interface StreamProtocolChunk {
     | 'reasoning'
     // use for reasoning signature, maybe only anthropic
     | 'reasoning_signature'
+    // complete OpenAI Responses reasoning item with replay scope
+    | 'reasoning_response_item'
     // flagged reasoning signature
     | 'flagged_reasoning_signature'
     // multimodal content part in reasoning
@@ -547,11 +549,12 @@ export function createCallbacksTransformer(
           }
 
           case 'reasoning_signature': {
-            if (typeof data === 'string') {
-              reasoningSignature = data;
-            } else {
-              reasoningResponseItems.push(data as ModelReasoningResponseItem);
-            }
+            if (typeof data === 'string') reasoningSignature = data;
+            break;
+          }
+
+          case 'reasoning_response_item': {
+            reasoningResponseItems.push(data as ModelReasoningResponseItem);
             break;
           }
 

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -1,4 +1,10 @@
-import type { ChatCitationItem, ModelPerformance, ModelUsage } from '@lobechat/types';
+import type {
+  ChatCitationItem,
+  ModelPerformance,
+  ModelReasoningResponseItem,
+  ModelSignatureScope,
+  ModelUsage,
+} from '@lobechat/types';
 import type { Pricing } from 'model-bank';
 
 import { parseToolCalls } from '../../helpers';
@@ -15,6 +21,7 @@ export type ChatPayloadForTransformStream = {
   pricing?: Pricing;
   pricingOptions?: ComputeChatCostOptions;
   provider?: string;
+  signatureScope?: ModelSignatureScope;
 };
 
 /**
@@ -438,6 +445,7 @@ export function createCallbacksTransformer(
   let aggregatedText = '';
   let aggregatedThinking: string | undefined = undefined;
   let reasoningSignature: string | undefined;
+  const reasoningResponseItems: ModelReasoningResponseItem[] = [];
   let usage: ModelUsage | undefined;
   let speed: ModelPerformance | undefined;
   let grounding: any;
@@ -462,9 +470,10 @@ export function createCallbacksTransformer(
         toolsCalling,
         usage,
       };
-      if (aggregatedThinking || reasoningSignature) {
+      if (aggregatedThinking) {
         data.reasoning = {
           content: aggregatedThinking,
+          responseItems: reasoningResponseItems.length > 0 ? reasoningResponseItems : undefined,
           signature: reasoningSignature,
         };
       }
@@ -527,7 +536,11 @@ export function createCallbacksTransformer(
           }
 
           case 'reasoning_signature': {
-            reasoningSignature = data;
+            if (typeof data === 'string') {
+              reasoningSignature = data;
+            } else {
+              reasoningResponseItems.push(data as ModelReasoningResponseItem);
+            }
             break;
           }
 

--- a/packages/model-runtime/src/providers/githubCopilot/index.test.ts
+++ b/packages/model-runtime/src/providers/githubCopilot/index.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { ModelProvider } from 'model-bank';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import * as openAIContextBuilders from '../../core/contextBuilders/openai';
@@ -41,6 +42,11 @@ describe('LobeGithubCopilotAI', () => {
 
       expect(convertResponseInputsSpy).toHaveBeenCalledWith(expect.any(Array), {
         forceImageBase64: true,
+        provider: ModelProvider.GithubCopilot,
+        signatureScope: {
+          model: 'gpt-5.1-codex-mini',
+          provider: ModelProvider.GithubCopilot,
+        },
         strictToolPairing: true,
       });
     });
@@ -66,6 +72,10 @@ describe('LobeGithubCopilotAI', () => {
 
       expect(convertMessagesSpy).toHaveBeenCalledWith(expect.any(Array), {
         forceImageBase64: true,
+        signatureScope: {
+          model: 'gpt-4o',
+          provider: ModelProvider.GithubCopilot,
+        },
       });
     });
   });

--- a/packages/model-runtime/src/providers/githubCopilot/index.test.ts
+++ b/packages/model-runtime/src/providers/githubCopilot/index.test.ts
@@ -44,6 +44,7 @@ describe('LobeGithubCopilotAI', () => {
         forceImageBase64: true,
         provider: ModelProvider.GithubCopilot,
         signatureScope: {
+          channelId: expect.stringMatching(/^[\da-f]{32}$/),
           model: 'gpt-5.1-codex-mini',
           provider: ModelProvider.GithubCopilot,
         },
@@ -73,10 +74,43 @@ describe('LobeGithubCopilotAI', () => {
       expect(convertMessagesSpy).toHaveBeenCalledWith(expect.any(Array), {
         forceImageBase64: true,
         signatureScope: {
+          channelId: expect.stringMatching(/^[\da-f]{32}$/),
           model: 'gpt-4o',
           provider: ModelProvider.GithubCopilot,
         },
       });
+    });
+
+    it('should bind signature scopes to a non-secret account fingerprint', async () => {
+      const convertMessagesSpy = vi
+        .spyOn(openAIContextBuilders, 'convertOpenAIMessages')
+        .mockRejectedValue({ status: 400 });
+      const futureTime = Date.now() + 600_000;
+      const tokens = ['ghu_account_a', 'ghu_account_b'];
+
+      for (const oauthAccessToken of tokens) {
+        const instance = new LobeGithubCopilotAI({
+          bearerToken: 'cached-bearer-token',
+          bearerTokenExpiresAt: futureTime,
+          oauthAccessToken,
+        });
+
+        await expect(
+          instance.chat({
+            messages: [{ content: 'hello', role: 'user' }],
+            model: 'gpt-4o',
+          } as any),
+        ).rejects.toBeDefined();
+      }
+
+      const channelIds = convertMessagesSpy.mock.calls.map(
+        ([, options]) => options?.signatureScope?.channelId,
+      );
+      expect(channelIds[0]).toMatch(/^[\da-f]{32}$/);
+      expect(channelIds[1]).toMatch(/^[\da-f]{32}$/);
+      expect(channelIds[0]).not.toBe(channelIds[1]);
+      expect(tokens).not.toContain(channelIds[0]);
+      expect(tokens).not.toContain(channelIds[1]);
     });
   });
 

--- a/packages/model-runtime/src/providers/githubCopilot/index.ts
+++ b/packages/model-runtime/src/providers/githubCopilot/index.ts
@@ -18,6 +18,7 @@ import { AgentRuntimeError } from '../../utils/createError';
 import { debugPayload, debugResponse, debugStream } from '../../utils/debugStream';
 import { getModelPricing } from '../../utils/getModelPricing';
 import { StreamingResponse } from '../../utils/response';
+import { createModelSignatureScope } from '../../utils/signatureScope';
 import { assertToolLimits } from '../../utils/validateToolLimits';
 import { isResponsesAPIModel } from '../openai/modelId';
 
@@ -184,6 +185,7 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
 
       const { model, ...rest } = this.handlePayload(payload);
       const shouldStream = rest.stream !== false;
+      const signatureScope = createModelSignatureScope(ModelProvider.GithubCopilot, model);
 
       if (model.toLowerCase().includes('claude')) {
         const anthropicClient = new Anthropic({
@@ -283,6 +285,8 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
 
         const input = await convertOpenAIResponseInputs(messages as any, {
           forceImageBase64: true,
+          provider: ModelProvider.GithubCopilot,
+          signatureScope,
           strictToolPairing: true,
         });
 
@@ -328,7 +332,7 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
           return StreamingResponse(
             OpenAIResponsesStream(prod, {
               callbacks: options?.callback,
-              payload: { model, provider: ModelProvider.GithubCopilot },
+              payload: { model, provider: ModelProvider.GithubCopilot, signatureScope },
             }),
             { headers: options?.headers },
           );
@@ -344,7 +348,7 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
           OpenAIResponsesStream(responseStream, {
             callbacks: options?.callback,
             enableStreaming: false,
-            payload: { model, provider: ModelProvider.GithubCopilot },
+            payload: { model, provider: ModelProvider.GithubCopilot, signatureScope },
           }),
           { headers: options?.headers },
         );
@@ -353,6 +357,7 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
       const { apiMode: _, preserveThinking: _pt, ...cleanedRest } = rest as any;
       const messages = await convertOpenAIMessages(cleanedRest.messages as any, {
         forceImageBase64: true,
+        signatureScope,
       });
 
       const chatCompletionPayload = {
@@ -386,7 +391,7 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
       return StreamingResponse(
         OpenAIStream(response, {
           callbacks: options?.callback,
-          payload: { model, provider: ModelProvider.GithubCopilot },
+          payload: { model, provider: ModelProvider.GithubCopilot, signatureScope },
         }),
         { headers: options?.headers },
       );

--- a/packages/model-runtime/src/providers/githubCopilot/index.ts
+++ b/packages/model-runtime/src/providers/githubCopilot/index.ts
@@ -18,7 +18,7 @@ import { AgentRuntimeError } from '../../utils/createError';
 import { debugPayload, debugResponse, debugStream } from '../../utils/debugStream';
 import { getModelPricing } from '../../utils/getModelPricing';
 import { StreamingResponse } from '../../utils/response';
-import { createModelSignatureScope } from '../../utils/signatureScope';
+import { createModelSignatureScope, createSignatureChannelId } from '../../utils/signatureScope';
 import { assertToolLimits } from '../../utils/validateToolLimits';
 import { isResponsesAPIModel } from '../openai/modelId';
 
@@ -28,14 +28,6 @@ const TOKEN_EXCHANGE_URL = 'https://api.github.com/copilot_internal/v2/token';
 const MAX_TOTAL_ATTEMPTS = 5;
 const MAX_RATE_LIMIT_RETRIES = 3;
 const QUOTA_EXHAUSTION_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
-
-const createAccountFingerprint = async (token: string) => {
-  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(token));
-
-  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0'))
-    .join('')
-    .slice(0, 32);
-};
 
 const debugParams = {
   chatCompletion: () => process.env.DEBUG_GITHUBCOPILOT_CHAT_COMPLETION === '1',
@@ -185,7 +177,7 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
     const accountToken = this.githubToken || this.cachedBearerToken;
     if (!accountToken) return undefined;
 
-    this.accountFingerprint ??= createAccountFingerprint(accountToken);
+    this.accountFingerprint ??= createSignatureChannelId(accountToken);
     return this.accountFingerprint;
   }
 

--- a/packages/model-runtime/src/providers/githubCopilot/index.ts
+++ b/packages/model-runtime/src/providers/githubCopilot/index.ts
@@ -29,6 +29,14 @@ const MAX_TOTAL_ATTEMPTS = 5;
 const MAX_RATE_LIMIT_RETRIES = 3;
 const QUOTA_EXHAUSTION_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 
+const createAccountFingerprint = async (token: string) => {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(token));
+
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, 32);
+};
+
 const debugParams = {
   chatCompletion: () => process.env.DEBUG_GITHUBCOPILOT_CHAT_COMPLETION === '1',
   responses: () => process.env.DEBUG_GITHUBCOPILOT_RESPONSES === '1',
@@ -139,6 +147,7 @@ export interface LobeGithubCopilotAIParams {
 
 export class LobeGithubCopilotAI implements LobeRuntimeAI {
   baseURL = COPILOT_BASE_URL;
+  private accountFingerprint?: Promise<string>;
   private cachedBearerToken?: string;
   private githubToken: string;
 
@@ -167,6 +176,19 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
     }
   }
 
+  /**
+   * Bind persisted opaque reasoning state to the Copilot account without storing credentials.
+   * OAuth/PAT fingerprints survive bearer refreshes; bearer-only instances remain scoped to that
+   * bearer token's lifetime.
+   */
+  private getAccountFingerprint() {
+    const accountToken = this.githubToken || this.cachedBearerToken;
+    if (!accountToken) return undefined;
+
+    this.accountFingerprint ??= createAccountFingerprint(accountToken);
+    return this.accountFingerprint;
+  }
+
   async chat(payload: ChatStreamPayload, options?: ChatMethodOptions) {
     // Pre-flight: abort before dispatching if tools exceed the Copilot 128-tool limit
     if (payload.tools && payload.tools.length > 0) {
@@ -185,7 +207,13 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
 
       const { model, ...rest } = this.handlePayload(payload);
       const shouldStream = rest.stream !== false;
-      const signatureScope = createModelSignatureScope(ModelProvider.GithubCopilot, model);
+      const accountFingerprint = await this.getAccountFingerprint();
+      const signatureScope = accountFingerprint
+        ? createModelSignatureScope(ModelProvider.GithubCopilot, model, {
+            channelId: accountFingerprint,
+            provider: ModelProvider.GithubCopilot,
+          })
+        : undefined;
 
       if (model.toLowerCase().includes('claude')) {
         const anthropicClient = new Anthropic({

--- a/packages/model-runtime/src/providers/google/index.test.ts
+++ b/packages/model-runtime/src/providers/google/index.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import type { GenerateContentResponse } from '@google/genai';
+import type { Content, GenerateContentResponse } from '@google/genai';
 import OpenAI from 'openai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -151,9 +151,8 @@ describe('LobeGoogleAI', () => {
         temperature: 0,
       });
 
-      expect(generateContentStream.mock.calls[0][0].contents[0].parts[0].thoughtSignature).not.toBe(
-        'foreign-signature',
-      );
+      const contents = generateContentStream.mock.calls[0][0].contents as Content[];
+      expect(contents[0]?.parts?.[0]?.thoughtSignature).not.toBe('foreign-signature');
     });
 
     it('should apply upstream model compatibility after model mapping', async () => {

--- a/packages/model-runtime/src/providers/google/index.test.ts
+++ b/packages/model-runtime/src/providers/google/index.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LOBE_ERROR_KEY } from '../../core/streams';
 import { AgentRuntimeErrorType } from '../../types/error';
 import * as debugStreamModule from '../../utils/debugStream';
+import { serializeScopedSignature } from '../../utils/signatureScope';
 import { LobeGoogleAI } from './index';
 
 const provider = 'google';
@@ -73,13 +74,32 @@ describe('LobeGoogleAI', () => {
       );
 
       await mappedInstance.chat({
-        messages: [{ content: 'Hello', role: 'user' }],
+        messages: [
+          {
+            content: '',
+            role: 'assistant',
+            tool_calls: [
+              {
+                function: { arguments: '{}', name: 'search' },
+                id: 'call-1',
+                thoughtSignature: serializeScopedSignature('upstream-signature', {
+                  model: 'gemini-upstream',
+                  provider: 'google',
+                }),
+                type: 'function',
+              },
+            ],
+          },
+          { content: '{}', role: 'tool', tool_call_id: 'call-1' },
+          { content: 'Hello', role: 'user' },
+        ],
         model: 'gemini-logical',
         temperature: 0,
       });
 
       const callArgs = (mappedInstance['client'].models.generateContentStream as any).mock.calls[0];
       expect(callArgs[0].model).toBe('gemini-upstream');
+      expect(callArgs[0].contents[0].parts[0].thoughtSignature).toBe('upstream-signature');
       expect(getModelPricingMock).toHaveBeenCalledWith('gemini-logical', provider, undefined);
     });
 

--- a/packages/model-runtime/src/providers/google/index.test.ts
+++ b/packages/model-runtime/src/providers/google/index.test.ts
@@ -6,10 +6,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LOBE_ERROR_KEY } from '../../core/streams';
 import { AgentRuntimeErrorType } from '../../types/error';
 import * as debugStreamModule from '../../utils/debugStream';
-import { serializeScopedSignature } from '../../utils/signatureScope';
+import { createSignatureChannelId, serializeScopedSignature } from '../../utils/signatureScope';
 import { LobeGoogleAI } from './index';
 
 const provider = 'google';
+const defaultBaseURL = 'https://generativelanguage.googleapis.com';
 const bizErrorType = 'ProviderBizError';
 const invalidErrorType = 'InvalidProviderAPIKey';
 const getModelPricingMock = vi.hoisted(() => vi.fn());
@@ -83,6 +84,7 @@ describe('LobeGoogleAI', () => {
                 function: { arguments: '{}', name: 'search' },
                 id: 'call-1',
                 thoughtSignature: serializeScopedSignature('upstream-signature', {
+                  channelId: await createSignatureChannelId(defaultBaseURL, 'test'),
                   model: 'gemini-upstream',
                   provider: 'google',
                 }),
@@ -101,6 +103,57 @@ describe('LobeGoogleAI', () => {
       expect(callArgs[0].model).toBe('gemini-upstream');
       expect(callArgs[0].contents[0].parts[0].thoughtSignature).toBe('upstream-signature');
       expect(getModelPricingMock).toHaveBeenCalledWith('gemini-logical', provider, undefined);
+    });
+
+    it.each([
+      {
+        sourceApiKey: 'another-key',
+        sourceBaseURL: defaultBaseURL,
+        sourceLabel: 'API key',
+      },
+      {
+        sourceApiKey: 'test',
+        sourceBaseURL: 'https://another.example.com',
+        sourceLabel: 'endpoint',
+      },
+    ])('should not replay a direct signature from another $sourceLabel', async (source) => {
+      const directInstance = new LobeGoogleAI({ apiKey: 'test' });
+      const mockStreamData = createEmptyAsyncGenerator<GenerateContentResponse>();
+      const generateContentStream = vi
+        .spyOn(directInstance['client'].models, 'generateContentStream')
+        .mockResolvedValue(mockStreamData);
+
+      await directInstance.chat({
+        messages: [
+          {
+            content: '',
+            role: 'assistant',
+            tool_calls: [
+              {
+                function: { arguments: '{}', name: 'search' },
+                id: 'call-1',
+                thoughtSignature: serializeScopedSignature('foreign-signature', {
+                  channelId: await createSignatureChannelId(
+                    source.sourceBaseURL,
+                    source.sourceApiKey,
+                  ),
+                  model: 'gemini-upstream',
+                  provider: 'google',
+                }),
+                type: 'function',
+              },
+            ],
+          },
+          { content: '{}', role: 'tool', tool_call_id: 'call-1' },
+          { content: 'Continue', role: 'user' },
+        ],
+        model: 'gemini-upstream',
+        temperature: 0,
+      });
+
+      expect(generateContentStream.mock.calls[0][0].contents[0].parts[0].thoughtSignature).not.toBe(
+        'foreign-signature',
+      );
     });
 
     it('should apply upstream model compatibility after model mapping', async () => {

--- a/packages/model-runtime/src/providers/google/index.ts
+++ b/packages/model-runtime/src/providers/google/index.ts
@@ -32,7 +32,11 @@ import { parseGoogleErrorMessage } from '../../utils/googleErrorParser';
 import type { ModelIdMappingOptions } from '../../utils/modelIdMapping';
 import { withMappedModelId } from '../../utils/modelIdMapping';
 import { StreamingResponse } from '../../utils/response';
-import { createModelSignatureScope, getRuntimeSignatureScope } from '../../utils/signatureScope';
+import {
+  createModelSignatureScope,
+  createSignatureChannelId,
+  getRuntimeSignatureScope,
+} from '../../utils/signatureScope';
 import { createGoogleImage } from './createImage';
 import { createGoogleVideo, pollGoogleVideoOperation } from './createVideo';
 import { createGoogleGenerateObject, createGoogleGenerateObjectWithTools } from './generateObject';
@@ -149,11 +153,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
       const { model, thinkingBudget, thinkingLevel, imageAspectRatio, imageResolution } = payload;
       const requestPayload = withMappedModelId(payload, this.modelIdMappingOptions);
       const requestModel = requestPayload.model;
-      const signatureScope = createModelSignatureScope(
-        this.provider,
-        requestModel,
-        getRuntimeSignatureScope(this),
-      );
+      const signatureScope = await this.getSignatureScope(requestModel);
       const shouldOmitDeprecatedGenerationParams =
         shouldOmitDeprecatedGoogleGenerationParams(requestModel);
 
@@ -369,11 +369,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
     // Convert OpenAI messages to Google format
     const contents = await buildGoogleMessages(payload.messages, {
       model: requestPayload.model,
-      signatureScope: createModelSignatureScope(
-        this.provider,
-        requestPayload.model,
-        getRuntimeSignatureScope(this),
-      ),
+      signatureScope: await this.getSignatureScope(requestPayload.model),
     });
     const pricing = await getModelPricing(payload.model, this.provider, options?.pricingContext);
 
@@ -398,6 +394,26 @@ export class LobeGoogleAI implements LobeRuntimeAI {
     }
 
     return undefined;
+  }
+
+  /**
+   * Direct Gemini endpoints do not expose a stable account id, so bind thought
+   * signatures to a non-secret fingerprint when both endpoint and API key are known.
+   * Injected clients such as direct Vertex AI fail closed unless RouterRuntime supplies a channel.
+   */
+  private async getSignatureScope(model: string) {
+    const runtimeScope = getRuntimeSignatureScope(this);
+    const directChannelId =
+      runtimeScope || !this.baseURL || !this.apiKey
+        ? undefined
+        : await createSignatureChannelId(this.baseURL, this.apiKey);
+
+    return createModelSignatureScope(
+      this.provider,
+      model,
+      runtimeScope ??
+        (directChannelId ? { channelId: directChannelId, provider: this.provider } : undefined),
+    );
   }
 
   private createEnhancedStream(originalStream: any, signal: AbortSignal): ReadableStream {

--- a/packages/model-runtime/src/providers/google/index.ts
+++ b/packages/model-runtime/src/providers/google/index.ts
@@ -151,7 +151,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
       const requestModel = requestPayload.model;
       const signatureScope = createModelSignatureScope(
         this.provider,
-        model,
+        requestModel,
         getRuntimeSignatureScope(this),
       );
       const shouldOmitDeprecatedGenerationParams =
@@ -364,17 +364,18 @@ export class LobeGoogleAI implements LobeRuntimeAI {
    * @see https://ai.google.dev/gemini-api/docs/function-calling
    */
   async generateObject(payload: GenerateObjectPayload, options?: GenerateObjectOptions) {
+    const requestPayload = withMappedModelId(payload, this.modelIdMappingOptions);
+
     // Convert OpenAI messages to Google format
     const contents = await buildGoogleMessages(payload.messages, {
-      model: payload.model,
+      model: requestPayload.model,
       signatureScope: createModelSignatureScope(
         this.provider,
-        payload.model,
+        requestPayload.model,
         getRuntimeSignatureScope(this),
       ),
     });
     const pricing = await getModelPricing(payload.model, this.provider, options?.pricingContext);
-    const requestPayload = withMappedModelId(payload, this.modelIdMappingOptions);
 
     // Handle tools-based structured output
     if (payload.tools && payload.tools.length > 0) {

--- a/packages/model-runtime/src/providers/google/index.ts
+++ b/packages/model-runtime/src/providers/google/index.ts
@@ -32,6 +32,7 @@ import { parseGoogleErrorMessage } from '../../utils/googleErrorParser';
 import type { ModelIdMappingOptions } from '../../utils/modelIdMapping';
 import { withMappedModelId } from '../../utils/modelIdMapping';
 import { StreamingResponse } from '../../utils/response';
+import { createModelSignatureScope, getRuntimeSignatureScope } from '../../utils/signatureScope';
 import { createGoogleImage } from './createImage';
 import { createGoogleVideo, pollGoogleVideoOperation } from './createVideo';
 import { createGoogleGenerateObject, createGoogleGenerateObjectWithTools } from './generateObject';
@@ -148,6 +149,11 @@ export class LobeGoogleAI implements LobeRuntimeAI {
       const { model, thinkingBudget, thinkingLevel, imageAspectRatio, imageResolution } = payload;
       const requestPayload = withMappedModelId(payload, this.modelIdMappingOptions);
       const requestModel = requestPayload.model;
+      const signatureScope = createModelSignatureScope(
+        this.provider,
+        model,
+        getRuntimeSignatureScope(this),
+      );
       const shouldOmitDeprecatedGenerationParams =
         shouldOmitDeprecatedGoogleGenerationParams(requestModel);
 
@@ -159,7 +165,10 @@ export class LobeGoogleAI implements LobeRuntimeAI {
         thinkingLevel,
       }) as unknown as ThinkingConfig;
 
-      const contents = await buildGoogleMessages(payload.messages, { model: requestModel });
+      const contents = await buildGoogleMessages(payload.messages, {
+        model: requestModel,
+        signatureScope,
+      });
       if (shouldOmitDeprecatedGenerationParams) {
         // Gemini 3.6 Flash, 3.5 Flash-Lite, and later models reject assistant prefills.
         while (contents.at(-1)?.role === 'model') contents.pop();
@@ -265,7 +274,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
       const stream = GoogleGenerativeAIStream(prod, {
         callbacks: options?.callback,
         inputStartAt,
-        payload: { model, pricing, provider: this.provider },
+        payload: { model, pricing, provider: this.provider, signatureScope },
       });
 
       // Respond with the stream
@@ -356,7 +365,14 @@ export class LobeGoogleAI implements LobeRuntimeAI {
    */
   async generateObject(payload: GenerateObjectPayload, options?: GenerateObjectOptions) {
     // Convert OpenAI messages to Google format
-    const contents = await buildGoogleMessages(payload.messages, { model: payload.model });
+    const contents = await buildGoogleMessages(payload.messages, {
+      model: payload.model,
+      signatureScope: createModelSignatureScope(
+        this.provider,
+        payload.model,
+        getRuntimeSignatureScope(this),
+      ),
+    });
     const pricing = await getModelPricing(payload.model, this.provider, options?.pricingContext);
     const requestPayload = withMappedModelId(payload, this.modelIdMappingOptions);
 

--- a/packages/model-runtime/src/types/chat.ts
+++ b/packages/model-runtime/src/types/chat.ts
@@ -60,11 +60,7 @@ export interface OpenAIChatMessage {
   model?: string;
   name?: string;
   provider?: string;
-  reasoning?: {
-    content?: string;
-    duration?: number;
-    signature?: string;
-  };
+  reasoning?: ModelReasoning;
   reasoning_content?: string;
   role: LLMRoleType;
   tool_call_id?: string;

--- a/packages/model-runtime/src/utils/signatureScope.ts
+++ b/packages/model-runtime/src/utils/signatureScope.ts
@@ -61,7 +61,7 @@ export const resolveScopedSignature = (
   target: ModelSignatureScope | undefined,
 ) => {
   if (!value) return undefined;
-  if (!target) return value;
+  if (!target) return value.startsWith(SCOPED_SIGNATURE_PREFIX) ? undefined : value;
   if (!value.startsWith(SCOPED_SIGNATURE_PREFIX)) return undefined;
 
   const parsed = safeParseJSON<{ scope?: ModelSignatureScope; signature?: string }>(

--- a/packages/model-runtime/src/utils/signatureScope.ts
+++ b/packages/model-runtime/src/utils/signatureScope.ts
@@ -18,6 +18,21 @@ export const setRuntimeSignatureScope = (runtime: object, scope: ModelSignatureS
 
 export const getRuntimeSignatureScope = (runtime: object) => runtimeSignatureScopes.get(runtime);
 
+/**
+ * Derive a stable channel identifier without persisting credentials or endpoint secrets.
+ * JSON encoding keeps multi-part channel identities unambiguous before hashing.
+ */
+export const createSignatureChannelId = async (...identityParts: string[]) => {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(JSON.stringify(identityParts)),
+  );
+
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, 32);
+};
+
 export const createModelSignatureScope = (
   provider: string,
   model: string,
@@ -33,11 +48,10 @@ export const isSameModelSignatureScope = (
   target: ModelSignatureScope,
 ) => {
   /**
-   * Router options without a stable channel id cannot safely prove provenance.
-   * Refuse replay instead of treating all anonymous fallback channels as equal.
+   * Provider and model alone cannot distinguish direct API credentials or endpoints.
+   * Refuse replay whenever either side lacks a stable channel identity.
    */
-  if ((source.routerId || target.routerId) && (!source.channelId || !target.channelId))
-    return false;
+  if (!source.channelId || !target.channelId) return false;
 
   return (
     source.provider === target.provider &&

--- a/packages/model-runtime/src/utils/signatureScope.ts
+++ b/packages/model-runtime/src/utils/signatureScope.ts
@@ -1,0 +1,79 @@
+import type { ModelSignatureScope } from '@lobechat/types';
+
+import { safeParseJSON } from './safeParseJSON';
+
+export type ModelSignatureScopeBase = Omit<ModelSignatureScope, 'model'>;
+
+const SCOPED_SIGNATURE_PREFIX = 'lobe-scoped-signature-v1:';
+
+/**
+ * Keep RouterRuntime provenance off constructor options so unrelated provider SDKs
+ * never receive internal routing metadata through an options spread.
+ */
+const runtimeSignatureScopes = new WeakMap<object, ModelSignatureScopeBase>();
+
+export const setRuntimeSignatureScope = (runtime: object, scope: ModelSignatureScopeBase) => {
+  runtimeSignatureScopes.set(runtime, scope);
+};
+
+export const getRuntimeSignatureScope = (runtime: object) => runtimeSignatureScopes.get(runtime);
+
+export const createModelSignatureScope = (
+  provider: string,
+  model: string,
+  base?: ModelSignatureScopeBase,
+): ModelSignatureScope => ({
+  provider,
+  ...base,
+  model,
+});
+
+export const isSameModelSignatureScope = (
+  source: ModelSignatureScope,
+  target: ModelSignatureScope,
+) => {
+  /**
+   * Router options without a stable channel id cannot safely prove provenance.
+   * Refuse replay instead of treating all anonymous fallback channels as equal.
+   */
+  if ((source.routerId || target.routerId) && (!source.channelId || !target.channelId))
+    return false;
+
+  return (
+    source.provider === target.provider &&
+    source.model === target.model &&
+    source.apiType === target.apiType &&
+    source.routerId === target.routerId &&
+    source.channelId === target.channelId
+  );
+};
+
+/**
+ * Keep Gemini thought signatures on the existing string-only persistence path while
+ * carrying enough provenance to prevent replay to another model, API type, or channel.
+ * The raw provider signature is restored only after an exact scope match.
+ */
+export const serializeScopedSignature = (signature: string, scope: ModelSignatureScope) =>
+  `${SCOPED_SIGNATURE_PREFIX}${JSON.stringify({ scope, signature })}`;
+
+export const resolveScopedSignature = (
+  value: string | undefined,
+  target: ModelSignatureScope | undefined,
+) => {
+  if (!value) return undefined;
+  if (!target) return value;
+  if (!value.startsWith(SCOPED_SIGNATURE_PREFIX)) return undefined;
+
+  const parsed = safeParseJSON<{ scope?: ModelSignatureScope; signature?: string }>(
+    value.slice(SCOPED_SIGNATURE_PREFIX.length),
+  );
+  if (
+    !parsed?.scope ||
+    typeof parsed.signature !== 'string' ||
+    !isSameModelSignatureScope(parsed.scope, target)
+  ) {
+    return undefined;
+  }
+
+  return parsed.signature;
+};

--- a/packages/types/src/message/common/base.ts
+++ b/packages/types/src/message/common/base.ts
@@ -84,6 +84,29 @@ export interface MessageContentPartImage {
 
 export type MessageContentPart = MessageContentPartText | MessageContentPartImage;
 
+/** Provenance required before opaque provider state may be replayed. */
+export interface ModelSignatureScope {
+  apiType?: string;
+  channelId?: string;
+  model: string;
+  provider: string;
+  routerId?: string;
+}
+
+/** Original OpenAI Responses reasoning item paired with its generation scope. */
+export interface ModelReasoningResponseItem {
+  item: {
+    content?: Array<Record<string, unknown>>;
+    encrypted_content?: string | null;
+    id: string;
+    status?: 'in_progress' | 'completed' | 'incomplete';
+    summary: Array<{ text: string; type: 'summary_text' }>;
+    type: 'reasoning';
+    [key: string]: unknown;
+  };
+  signatureScope: ModelSignatureScope;
+}
+
 export interface ModelReasoning {
   /**
    * Reasoning content, can be plain string or serialized JSON array of MessageContentPart[]
@@ -94,13 +117,37 @@ export interface ModelReasoning {
    * Flag indicating if content is multimodal (serialized MessageContentPart[])
    */
   isMultimodal?: boolean;
+  responseItems?: ModelReasoningResponseItem[];
   signature?: string;
   tempDisplayContent?: MessageContentPart[];
 }
+
+export const ModelSignatureScopeSchema = z.object({
+  apiType: z.string().optional(),
+  channelId: z.string().optional(),
+  model: z.string(),
+  provider: z.string(),
+  routerId: z.string().optional(),
+});
+
+export const ModelReasoningResponseItemSchema = z.object({
+  item: z
+    .object({
+      content: z.array(z.record(z.string(), z.unknown())).optional(),
+      encrypted_content: z.string().nullish(),
+      id: z.string(),
+      status: z.enum(['in_progress', 'completed', 'incomplete']).optional(),
+      summary: z.array(z.object({ text: z.string(), type: z.literal('summary_text') })),
+      type: z.literal('reasoning'),
+    })
+    .passthrough(),
+  signatureScope: ModelSignatureScopeSchema,
+});
 
 export const ModelReasoningSchema = z.object({
   content: z.string().optional(),
   duration: z.number().optional(),
   isMultimodal: z.boolean().optional(),
+  responseItems: z.array(ModelReasoningResponseItemSchema).optional(),
   signature: z.string().optional(),
 });

--- a/packages/types/src/openai/chat.ts
+++ b/packages/types/src/openai/chat.ts
@@ -1,5 +1,5 @@
 import type { LLMRoleType } from '../llm';
-import type { MessageToolCall } from '../message';
+import type { MessageToolCall, ModelReasoning } from '../message';
 import type { OpenAIFunctionCall } from './functionCall';
 
 export type ChatResponseFormat =
@@ -62,11 +62,7 @@ export interface OpenAIChatMessage {
   model?: string;
   name?: string;
   provider?: string;
-  reasoning?: {
-    content?: string;
-    duration?: number;
-    signature?: string;
-  };
+  reasoning?: ModelReasoning;
   reasoning_content?: string;
   /**
    * Role

--- a/src/store/chat/agents/StreamingHandler.test.ts
+++ b/src/store/chat/agents/StreamingHandler.test.ts
@@ -591,6 +591,40 @@ describe('StreamingHandler', () => {
 
       expect(result.metadata.reasoning).toBeUndefined();
     });
+
+    it('should preserve response items without reasoning content', async () => {
+      const callbacks = createMockCallbacks();
+      const handler = new StreamingHandler(mockContext, callbacks);
+      const responseItem = {
+        item: {
+          encrypted_content: 'encrypted-reasoning',
+          id: 'reasoning-1',
+          summary: [],
+          type: 'reasoning' as const,
+        },
+        signatureScope: {
+          model: 'gpt-5',
+          provider: 'chatgpt',
+        },
+      };
+
+      handler.handleChunk({ type: 'text', text: 'Content' });
+
+      const result = await handler.handleFinish({
+        type: 'stop',
+        reasoning: {
+          responseItems: [responseItem],
+          signature: 'legacy-signature',
+        },
+      });
+
+      expect(result.metadata.reasoning).toEqual({
+        content: undefined,
+        duration: undefined,
+        responseItems: [responseItem],
+        signature: undefined,
+      });
+    });
   });
 
   describe('getter methods', () => {

--- a/src/store/chat/agents/StreamingHandler.test.ts
+++ b/src/store/chat/agents/StreamingHandler.test.ts
@@ -578,7 +578,7 @@ describe('StreamingHandler', () => {
       expect(result.metadata.reasoning?.signature).toBe('fallback-sig');
     });
 
-    it('should preserve a reasoning signature without reasoning content', async () => {
+    it('should discard a reasoning signature without reasoning content', async () => {
       const callbacks = createMockCallbacks();
       const handler = new StreamingHandler(mockContext, callbacks);
 
@@ -589,8 +589,7 @@ describe('StreamingHandler', () => {
         reasoning: { signature: 'signature-only' },
       });
 
-      expect(result.metadata.reasoning?.content).toBeUndefined();
-      expect(result.metadata.reasoning?.signature).toBe('signature-only');
+      expect(result.metadata.reasoning).toBeUndefined();
     });
   });
 

--- a/src/store/chat/agents/StreamingHandler.ts
+++ b/src/store/chat/agents/StreamingHandler.ts
@@ -533,11 +533,11 @@ export class StreamingHandler {
       };
     } else if (this.thinkingContent) {
       finalReasoning = {
+        ...finishData.reasoning,
         content: this.thinkingContent,
         duration: finalDuration,
-        signature: reasoningSignature,
       };
-    } else if (finishData.reasoning?.content || reasoningSignature) {
+    } else if (finishData.reasoning?.content) {
       finalReasoning = {
         ...finishData.reasoning,
         duration: finalDuration,

--- a/src/store/chat/agents/StreamingHandler.ts
+++ b/src/store/chat/agents/StreamingHandler.ts
@@ -522,6 +522,11 @@ export class StreamingHandler {
 
     // Get signature from finishData.reasoning (provided by backend in onFinish)
     const reasoningSignature = finishData.reasoning?.signature;
+    /**
+     * Hidden Responses items remain replayable without visible content. This does not retain a
+     * legacy scalar signature on its own.
+     */
+    const hasResponseItems = !!finishData.reasoning?.responseItems?.length;
 
     let finalReasoning: ReasoningState | undefined;
     if (hasReasoningImages) {
@@ -537,10 +542,11 @@ export class StreamingHandler {
         content: this.thinkingContent,
         duration: finalDuration,
       };
-    } else if (finishData.reasoning?.content) {
+    } else if (finishData.reasoning?.content || hasResponseItems) {
       finalReasoning = {
         ...finishData.reasoning,
         duration: finalDuration,
+        signature: finishData.reasoning?.content ? finishData.reasoning.signature : undefined,
       };
     }
 

--- a/src/store/chat/agents/types/streaming.ts
+++ b/src/store/chat/agents/types/streaming.ts
@@ -2,9 +2,9 @@ import {
   type ChatImageItem,
   type ChatToolPayload,
   type GroundingSearch,
-  type MessageContentPart,
   type MessageToolCall,
   type ModelPerformance,
+  type ModelReasoning,
   type ModelUsage,
 } from '@lobechat/types';
 
@@ -22,13 +22,7 @@ export interface StreamingContext {
 /**
  * Reasoning state
  */
-export interface ReasoningState {
-  content?: string;
-  duration?: number;
-  isMultimodal?: boolean;
-  signature?: string;
-  tempDisplayContent?: MessageContentPart[];
-}
+export type ReasoningState = ModelReasoning;
 
 /**
  * Grounding/search data - extends GroundingSearch for compatibility
@@ -71,7 +65,7 @@ export interface StreamingCallbacks {
 export interface FinishData {
   grounding?: GroundingData;
   observationId?: string | null;
-  reasoning?: { content?: string; signature?: string };
+  reasoning?: ModelReasoning;
   speed?: ModelPerformance;
   toolCalls?: MessageToolCall[];
   traceId?: string | null;


### PR DESCRIPTION
This change prevents opaque reasoning signatures from being replayed outside the exact model route that produced them, while restoring the previous persistence rule that reasoning without visible content is discarded.

- persist reasoning only when visible thinking content exists
- preserve all OpenAI Responses reasoning output items instead of collapsing them into one scalar signature
- scope replayable state by provider, upstream model, API type, router, and channel/account
- scope Gemini tool-call thought signatures across Google, Vertex AI, and OpenAI-compatible channels

#### 🧭 Key Decisions / Non-goals

- The persisted message schema is extended additively; no database migration or backfill is required.
- Legacy unscoped signatures are not replayed to a provider endpoint. Visible reasoning summaries remain available as ordinary context.
- Router channels without a stable channel identifier are treated as unverifiable and do not receive opaque replay state.
- Signature-only reasoning is intentionally discarded. ChatGPT subscription reasoning remains replayable when the response includes visible reasoning content.
- Structured Responses reasoning items use a dedicated SSE event so released clients ignore the new state instead of treating object payloads as scalar signatures.
- The Anthropic-compatible sanitizer from #17629 is preserved unchanged. This PR does not broaden into existing provider-specific reasoning cleanup.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check <29 changed files>
bun run check --type
```

Result: 29 files lint clean, 568 tests passed, and types clean.

Covered scenarios include signature-only persistence, multiple Responses reasoning items, ChatGPT account scope, direct credential and endpoint scope, router channel scope, mapped upstream model scope, Google versus Vertex AI scope, and OpenRouter Gemini tool signatures.

#### 🔗 Related Issue

- Related to #11897
- Follow-up to #17527
- Preserves #17629









