### PR TITLE
✨ feat(desktop): use Chromium zoom presets

### DIFF
--- a/apps/desktop/src/main/services/__tests__/zoomSrv.test.ts
+++ b/apps/desktop/src/main/services/__tests__/zoomSrv.test.ts
@@ -1,40 +1,47 @@
+import type { WebContents } from 'electron';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { App } from '@/core/App';
 
-import ZoomService, { ZOOM_LEVEL_MAX, ZOOM_LEVEL_MIN } from '../zoomSrv';
+import ZoomService, { ZOOM_FACTOR_MAX, ZOOM_FACTOR_MIN } from '../zoomSrv';
 
 vi.mock('@/utils/logger', () => ({
   createLogger: () => ({
     debug: vi.fn(),
+    error: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
-    error: vi.fn(),
   }),
 }));
 
 interface MockWebContents {
   destroyed: boolean;
-  getZoomLevel: () => number;
+  factor: number;
+  getZoomFactor: () => number;
   isDestroyed: () => boolean;
-  level: number;
   send: ReturnType<typeof vi.fn>;
-  setZoomLevel: (level: number) => void;
+  setZoomFactor: (factor: number) => void;
 }
 
-const createMockWebContents = (initialLevel = 0): MockWebContents => {
-  const wc: MockWebContents = {
+const createMockWebContents = (initialFactor = 1): MockWebContents => {
+  const webContents: MockWebContents = {
     destroyed: false,
-    level: initialLevel,
-    getZoomLevel: () => wc.level,
-    isDestroyed: () => wc.destroyed,
+    factor: initialFactor,
+    getZoomFactor: () => webContents.factor,
+    isDestroyed: () => webContents.destroyed,
     send: vi.fn(),
-    setZoomLevel: (level: number) => {
-      wc.level = level;
+    setZoomFactor: (factor: number) => {
+      webContents.factor = factor;
     },
   };
-  return wc;
+
+  return webContents;
 };
+
+const getExpectedPayload = (factor: number) => ({
+  factor,
+  level: Number((Math.log(factor) / Math.log(1.2)).toFixed(4)),
+});
 
 describe('ZoomService', () => {
   let service: ZoomService;
@@ -43,62 +50,73 @@ describe('ZoomService', () => {
     service = new ZoomService({} as App);
   });
 
-  it('increments zoom level by 1 on action=in', () => {
-    const wc = createMockWebContents(0);
-    service.apply('in', wc as any);
-    expect(wc.level).toBe(1);
-    expect(wc.send).toHaveBeenCalledWith('zoom:changed', { factor: 1.2, level: 1 });
+  it('increases zoom factor by 10 percentage points on action=in', () => {
+    const webContents = createMockWebContents(1);
+
+    service.apply('in', webContents as unknown as WebContents);
+
+    expect(webContents.factor).toBe(1.1);
+    expect(webContents.send).toHaveBeenCalledWith('zoom:changed', getExpectedPayload(1.1));
   });
 
-  it('decrements zoom level by 1 on action=out', () => {
-    const wc = createMockWebContents(0);
-    service.apply('out', wc as any);
-    expect(wc.level).toBe(-1);
-    expect(wc.send).toHaveBeenCalledWith('zoom:changed', {
-      factor: Number((1.2 ** -1).toFixed(4)),
-      level: -1,
-    });
+  it('decreases zoom factor by 10 percentage points on action=out', () => {
+    const webContents = createMockWebContents(1);
+
+    service.apply('out', webContents as unknown as WebContents);
+
+    expect(webContents.factor).toBe(0.9);
+    expect(webContents.send).toHaveBeenCalledWith('zoom:changed', getExpectedPayload(0.9));
   });
 
-  it('resets to 0 on action=reset', () => {
-    const wc = createMockWebContents(2);
-    service.apply('reset', wc as any);
-    expect(wc.level).toBe(0);
-    expect(wc.send).toHaveBeenCalledWith('zoom:changed', { factor: 1, level: 0 });
+  it('resets zoom factor to 1 on action=reset', () => {
+    const webContents = createMockWebContents(1.3);
+
+    service.apply('reset', webContents as unknown as WebContents);
+
+    expect(webContents.factor).toBe(1);
+    expect(webContents.send).toHaveBeenCalledWith('zoom:changed', getExpectedPayload(1));
   });
 
-  it('clamps at ZOOM_LEVEL_MAX and still broadcasts current level', () => {
-    const wc = createMockWebContents(ZOOM_LEVEL_MAX);
-    service.apply('in', wc as any);
-    expect(wc.level).toBe(ZOOM_LEVEL_MAX);
-    expect(wc.send).toHaveBeenCalledWith('zoom:changed', {
-      factor: Number((1.2 ** ZOOM_LEVEL_MAX).toFixed(4)),
-      level: ZOOM_LEVEL_MAX,
-    });
+  it('rounds the zoom factor to avoid floating-point drift', () => {
+    const webContents = createMockWebContents(1.1);
+
+    service.apply('in', webContents as unknown as WebContents);
+
+    expect(webContents.factor).toBe(1.2);
+    expect(webContents.send).toHaveBeenCalledWith('zoom:changed', getExpectedPayload(1.2));
   });
 
-  it('clamps at ZOOM_LEVEL_MIN and still broadcasts current level', () => {
-    const wc = createMockWebContents(ZOOM_LEVEL_MIN);
-    service.apply('out', wc as any);
-    expect(wc.level).toBe(ZOOM_LEVEL_MIN);
-    expect(wc.send).toHaveBeenCalledWith('zoom:changed', {
-      factor: Number((1.2 ** ZOOM_LEVEL_MIN).toFixed(4)),
-      level: ZOOM_LEVEL_MIN,
-    });
+  it('clamps at ZOOM_FACTOR_MAX and still broadcasts the current factor', () => {
+    const webContents = createMockWebContents(ZOOM_FACTOR_MAX);
+
+    service.apply('in', webContents as unknown as WebContents);
+
+    expect(webContents.factor).toBe(ZOOM_FACTOR_MAX);
+    expect(webContents.send).toHaveBeenCalledWith(
+      'zoom:changed',
+      getExpectedPayload(ZOOM_FACTOR_MAX),
+    );
+  });
+
+  it('clamps at ZOOM_FACTOR_MIN and still broadcasts the current factor', () => {
+    const webContents = createMockWebContents(ZOOM_FACTOR_MIN);
+
+    service.apply('out', webContents as unknown as WebContents);
+
+    expect(webContents.factor).toBe(ZOOM_FACTOR_MIN);
+    expect(webContents.send).toHaveBeenCalledWith(
+      'zoom:changed',
+      getExpectedPayload(ZOOM_FACTOR_MIN),
+    );
   });
 
   it('skips when webContents is destroyed', () => {
-    const wc = createMockWebContents(0);
-    wc.destroyed = true;
-    service.apply('in', wc as any);
-    expect(wc.level).toBe(0);
-    expect(wc.send).not.toHaveBeenCalled();
-  });
+    const webContents = createMockWebContents(1);
+    webContents.destroyed = true;
 
-  it('factor matches 1.2 ** level for reset', () => {
-    const wc = createMockWebContents(0);
-    service.apply('reset', wc as any);
-    const payload = wc.send.mock.calls[0][1];
-    expect(payload.factor).toBe(1);
+    service.apply('in', webContents as unknown as WebContents);
+
+    expect(webContents.factor).toBe(1);
+    expect(webContents.send).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/services/__tests__/zoomSrv.test.ts
+++ b/apps/desktop/src/main/services/__tests__/zoomSrv.test.ts
@@ -50,7 +50,7 @@ describe('ZoomService', () => {
     service = new ZoomService({} as App);
   });
 
-  it('increases zoom factor by 10 percentage points on action=in', () => {
+  it('moves to the next Chromium zoom preset on action=in', () => {
     const webContents = createMockWebContents(1);
 
     service.apply('in', webContents as unknown as WebContents);
@@ -59,7 +59,7 @@ describe('ZoomService', () => {
     expect(webContents.send).toHaveBeenCalledWith('zoom:changed', getExpectedPayload(1.1));
   });
 
-  it('decreases zoom factor by 10 percentage points on action=out', () => {
+  it('moves to the previous Chromium zoom preset on action=out', () => {
     const webContents = createMockWebContents(1);
 
     service.apply('out', webContents as unknown as WebContents);
@@ -77,13 +77,53 @@ describe('ZoomService', () => {
     expect(webContents.send).toHaveBeenCalledWith('zoom:changed', getExpectedPayload(1));
   });
 
-  it('rounds the zoom factor to avoid floating-point drift', () => {
+  it('uses Chromium preset spacing beyond 110%', () => {
     const webContents = createMockWebContents(1.1);
 
     service.apply('in', webContents as unknown as WebContents);
 
-    expect(webContents.factor).toBe(1.2);
-    expect(webContents.send).toHaveBeenCalledWith('zoom:changed', getExpectedPayload(1.2));
+    expect(webContents.factor).toBe(1.25);
+    expect(webContents.send).toHaveBeenCalledWith('zoom:changed', getExpectedPayload(1.25));
+  });
+
+  it('uses Chromium preset spacing below 125%', () => {
+    const webContents = createMockWebContents(1.25);
+
+    service.apply('out', webContents as unknown as WebContents);
+
+    expect(webContents.factor).toBe(1.1);
+    expect(webContents.send).toHaveBeenCalledWith('zoom:changed', getExpectedPayload(1.1));
+  });
+
+  it('uses an epsilon when selecting a preset around floating-point drift', () => {
+    const zoomedInWebContents = createMockWebContents(1.1005);
+    const zoomedOutWebContents = createMockWebContents(1.0995);
+
+    service.apply('in', zoomedInWebContents as unknown as WebContents);
+    service.apply('out', zoomedOutWebContents as unknown as WebContents);
+
+    expect(zoomedInWebContents.factor).toBe(1.25);
+    expect(zoomedOutWebContents.factor).toBe(1);
+  });
+
+  it('zooms in from the legacy maximum without reversing direction', () => {
+    const legacyMaximum = 1.2 ** 3;
+    const webContents = createMockWebContents(legacyMaximum);
+
+    service.apply('in', webContents as unknown as WebContents);
+
+    expect(webContents.factor).toBe(1.75);
+    expect(webContents.factor).toBeGreaterThan(legacyMaximum);
+  });
+
+  it('zooms out from the legacy minimum without reversing direction', () => {
+    const legacyMinimum = 1.2 ** -3;
+    const webContents = createMockWebContents(legacyMinimum);
+
+    service.apply('out', webContents as unknown as WebContents);
+
+    expect(webContents.factor).toBe(0.5);
+    expect(webContents.factor).toBeLessThan(legacyMinimum);
   });
 
   it('clamps at ZOOM_FACTOR_MAX and still broadcasts the current factor', () => {

--- a/apps/desktop/src/main/services/zoomSrv.ts
+++ b/apps/desktop/src/main/services/zoomSrv.ts
@@ -4,33 +4,45 @@ import { createLogger } from '@/utils/logger';
 
 import { ServiceModule } from './index';
 
-export const ZOOM_LEVEL_MIN = -3;
-export const ZOOM_LEVEL_MAX = 3;
+export const ZOOM_FACTOR_MIN = 0.6;
+export const ZOOM_FACTOR_MAX = 1.7;
 
 export type ZoomAction = 'in' | 'out' | 'reset';
 
+const ELECTRON_ZOOM_BASE = 1.2;
+const ZOOM_FACTOR_STEP = 0.1;
+
 const logger = createLogger('services:ZoomService');
+
+const roundZoomFactor = (factor: number) => Number(factor.toFixed(1));
 
 export default class ZoomService extends ServiceModule {
   apply(action: ZoomAction, webContents: WebContents): void {
     if (!webContents || webContents.isDestroyed()) return;
 
-    const current = webContents.getZoomLevel();
+    const current = webContents.getZoomFactor();
     const next =
       action === 'reset'
-        ? 0
-        : Math.min(ZOOM_LEVEL_MAX, Math.max(ZOOM_LEVEL_MIN, current + (action === 'in' ? 1 : -1)));
+        ? 1
+        : Math.min(
+            ZOOM_FACTOR_MAX,
+            Math.max(
+              ZOOM_FACTOR_MIN,
+              roundZoomFactor(current + (action === 'in' ? ZOOM_FACTOR_STEP : -ZOOM_FACTOR_STEP)),
+            ),
+          );
 
     if (next !== current) {
-      webContents.setZoomLevel(next);
-      logger.debug(`Zoom ${action}: level ${current} -> ${next}`);
+      webContents.setZoomFactor(next);
+      logger.debug(`Zoom ${action}: factor ${current} -> ${next}`);
     }
 
     this.broadcast(webContents, next);
   }
 
-  private broadcast(webContents: WebContents, level: number): void {
-    const factor = Number((1.2 ** level).toFixed(4));
+  private broadcast(webContents: WebContents, factor: number): void {
+    const level = Number((Math.log(factor) / Math.log(ELECTRON_ZOOM_BASE)).toFixed(4));
+
     try {
       webContents.send('zoom:changed', { factor, level });
     } catch (error) {

--- a/apps/desktop/src/main/services/zoomSrv.ts
+++ b/apps/desktop/src/main/services/zoomSrv.ts
@@ -4,33 +4,43 @@ import { createLogger } from '@/utils/logger';
 
 import { ServiceModule } from './index';
 
-export const ZOOM_FACTOR_MIN = 0.6;
-export const ZOOM_FACTOR_MAX = 1.7;
+export const ZOOM_FACTOR_MIN = 0.5;
+export const ZOOM_FACTOR_MAX = 1.75;
 
 export type ZoomAction = 'in' | 'out' | 'reset';
 
 const ELECTRON_ZOOM_BASE = 1.2;
-const ZOOM_FACTOR_STEP = 0.1;
+const ZOOM_FACTOR_EPSILON = 0.001;
+const ZOOM_FACTOR_PRESETS = [
+  ZOOM_FACTOR_MIN,
+  2 / 3,
+  0.75,
+  0.8,
+  0.9,
+  1,
+  1.1,
+  1.25,
+  1.5,
+  ZOOM_FACTOR_MAX,
+] as const;
 
 const logger = createLogger('services:ZoomService');
 
-const roundZoomFactor = (factor: number) => Number(factor.toFixed(1));
+const getAdjacentZoomFactor = (current: number, action: Exclude<ZoomAction, 'reset'>): number => {
+  const next =
+    action === 'in'
+      ? ZOOM_FACTOR_PRESETS.find((factor) => factor > current + ZOOM_FACTOR_EPSILON)
+      : ZOOM_FACTOR_PRESETS.findLast((factor) => factor < current - ZOOM_FACTOR_EPSILON);
+
+  return next ?? current;
+};
 
 export default class ZoomService extends ServiceModule {
   apply(action: ZoomAction, webContents: WebContents): void {
     if (!webContents || webContents.isDestroyed()) return;
 
     const current = webContents.getZoomFactor();
-    const next =
-      action === 'reset'
-        ? 1
-        : Math.min(
-            ZOOM_FACTOR_MAX,
-            Math.max(
-              ZOOM_FACTOR_MIN,
-              roundZoomFactor(current + (action === 'in' ? ZOOM_FACTOR_STEP : -ZOOM_FACTOR_STEP)),
-            ),
-          );
+    const next = action === 'reset' ? 1 : getAdjacentZoomFactor(current, action);
 
     if (next !== current) {
       webContents.setZoomFactor(next);


### PR DESCRIPTION
Support finer-grained zoom controls in the desktop app by changing the zoom shortcuts from Electron's `1.2^level` steps to fixed 10-percentage-point factor steps.

- `Zoom In` / `Cmd +` now moves from 100% to 110%.
- `Zoom Out` / `Cmd -` now moves from 100% to 90%.
- Zoom remains bounded to approximately the existing range (60%–170%).
- Reset, zoom change notifications, and boundary notifications are preserved.
- Regression tests cover zoom in/out, reset, floating-point rounding, boundaries, and destroyed web contents.

| Before | After |
| ------ | ----- |
| 100% → 120% or ~83.3% | 100% → 110% or 90% |

#### Test

- `bun run check apps/desktop/src/main/services/zoomSrv.ts apps/desktop/src/main/services/__tests__/zoomSrv.test.ts`
- `cd apps/desktop && pnpm type-check`
- `cd apps/desktop && pnpm build:main`

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Fixes #17678
