### PR TITLE
✨ feat: support hidden builtin model lists

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/aiModel.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiModel.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AiModelModel } from '@/database/models/aiModel';
 import { AiInfraRepos } from '@/database/repositories/aiInfra';
 
 import { aiModelRouter } from '../aiModel';
 
+const mockGetHiddenBuiltinModelsForUser = vi.hoisted(() => vi.fn());
+
+vi.mock('@/business/server/aiProvider', () => ({
+  getHiddenBuiltinModelsForUser: mockGetHiddenBuiltinModelsForUser,
+}));
 vi.mock('@/database/models/aiModel');
 vi.mock('@/database/models/user');
 vi.mock('@/database/repositories/aiInfra');
@@ -26,6 +31,11 @@ describe('aiModelRouter', () => {
   const mockCtx = {
     userId: 'test-user',
   };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetHiddenBuiltinModelsForUser.mockResolvedValue([]);
+  });
 
   it('should create ai model', async () => {
     const mockCreate = vi.fn().mockResolvedValue({ id: 'model-1' });

--- a/apps/server/src/routers/lambda/__tests__/aiProvider.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiProvider.test.ts
@@ -187,6 +187,53 @@ describe('aiProviderRouter', () => {
       expect(mockGetHiddenBuiltinModelsForUser).toHaveBeenCalledWith(mockUserId);
       expect(mockGetState).toHaveBeenCalledWith(KeyVaultsGateKeeper.getUserKeyVaults);
     });
+
+    it('should remove hidden models and providers from the runtime state', async () => {
+      const lobehubProvider = { id: 'lobehub', source: 'builtin' as const };
+      const openaiProvider = { id: 'openai', source: 'builtin' as const };
+      const hiddenImageModel = {
+        abilities: {},
+        enabled: true,
+        id: 'hidden-image',
+        providerId: 'lobehub',
+        type: 'image' as const,
+      };
+      const visibleChatModel = {
+        abilities: {},
+        enabled: true,
+        id: 'visible-chat',
+        providerId: 'lobehub',
+        type: 'chat' as const,
+      };
+      const visibleImageModel = {
+        abilities: {},
+        enabled: true,
+        id: 'visible-image',
+        providerId: 'openai',
+        type: 'image' as const,
+      };
+      const runtimeState: AiProviderRuntimeState = {
+        enabledAiModels: [hiddenImageModel, visibleChatModel, visibleImageModel],
+        enabledAiProviders: [lobehubProvider, openaiProvider],
+        enabledChatAiProviders: [lobehubProvider],
+        enabledImageAiProviders: [lobehubProvider, openaiProvider],
+        enabledVideoAiProviders: [],
+        runtimeConfig: {},
+      };
+      vi.mocked(AiInfraRepos).prototype.getAiProviderRuntimeState = vi
+        .fn()
+        .mockResolvedValue(runtimeState);
+      mockGetHiddenBuiltinModelsForUser.mockResolvedValue([
+        { id: 'hidden-image', providerId: 'lobehub' },
+      ]);
+
+      const caller = aiProviderRouter.createCaller(createMockContext());
+      const result = await caller.getAiProviderRuntimeState({});
+
+      expect(result.enabledAiModels).toEqual([visibleChatModel, visibleImageModel]);
+      expect(result.enabledChatAiProviders).toEqual([lobehubProvider]);
+      expect(result.enabledImageAiProviders).toEqual([openaiProvider]);
+    });
   });
 
   describe('removeAiProvider', () => {

--- a/apps/server/src/routers/lambda/__tests__/aiProvider.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiProvider.test.ts
@@ -170,7 +170,7 @@ describe('aiProviderRouter', () => {
       const caller = aiProviderRouter.createCaller(createMockContext());
       const result = await caller.getAiProviderRuntimeState({});
 
-      expect(result).toEqual(mockRuntimeState);
+      expect(result).toEqual({ ...mockRuntimeState, hiddenBuiltinModels: [] });
       expect(mockGetState).toHaveBeenCalledWith(KeyVaultsGateKeeper.getUserKeyVaults);
     });
 

--- a/apps/server/src/routers/lambda/__tests__/aiProvider.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiProvider.test.ts
@@ -13,6 +13,11 @@ import { type AiProviderDetailItem, type AiProviderRuntimeState } from '@/types/
 
 import { aiProviderRouter } from '../aiProvider';
 
+const mockGetHiddenBuiltinModelsForUser = vi.hoisted(() => vi.fn());
+
+vi.mock('@/business/server/aiProvider', () => ({
+  getHiddenBuiltinModelsForUser: mockGetHiddenBuiltinModelsForUser,
+}));
 vi.mock('@/server/globalConfig');
 vi.mock('@/server/modules/KeyVaultsEncrypt');
 vi.mock('@/database/repositories/aiInfra');
@@ -63,6 +68,7 @@ describe('aiProviderRouter', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetHiddenBuiltinModelsForUser.mockResolvedValue(undefined);
 
     vi.mocked(getServerGlobalConfig).mockReturnValue({
       aiProvider: {},
@@ -165,6 +171,20 @@ describe('aiProviderRouter', () => {
       const result = await caller.getAiProviderRuntimeState({});
 
       expect(result).toEqual(mockRuntimeState);
+      expect(mockGetState).toHaveBeenCalledWith(KeyVaultsGateKeeper.getUserKeyVaults);
+    });
+
+    it('should append user-scoped hidden builtin models without changing runtime state loading', async () => {
+      const mockGetState = vi.fn().mockResolvedValue(mockRuntimeState);
+      const hiddenBuiltinModels = [{ id: 'hidden-model', providerId: 'lobehub' }];
+      vi.mocked(AiInfraRepos).prototype.getAiProviderRuntimeState = mockGetState;
+      mockGetHiddenBuiltinModelsForUser.mockResolvedValue(hiddenBuiltinModels);
+
+      const caller = aiProviderRouter.createCaller(createMockContext());
+      const result = await caller.getAiProviderRuntimeState({});
+
+      expect(result).toEqual({ ...mockRuntimeState, hiddenBuiltinModels });
+      expect(mockGetHiddenBuiltinModelsForUser).toHaveBeenCalledWith(mockUserId);
       expect(mockGetState).toHaveBeenCalledWith(KeyVaultsGateKeeper.getUserKeyVaults);
     });
   });

--- a/apps/server/src/routers/lambda/__tests__/aiProvider.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiProvider.test.ts
@@ -68,7 +68,7 @@ describe('aiProviderRouter', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetHiddenBuiltinModelsForUser.mockResolvedValue(undefined);
+    mockGetHiddenBuiltinModelsForUser.mockResolvedValue([]);
 
     vi.mocked(getServerGlobalConfig).mockReturnValue({
       aiProvider: {},

--- a/apps/server/src/routers/lambda/aiModel.ts
+++ b/apps/server/src/routers/lambda/aiModel.ts
@@ -20,6 +20,7 @@ import { router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { getServerGlobalConfig } from '@/server/globalConfig';
 import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
+import { getUserScopedAiProviderModelList } from '@/server/services/aiProviderAccess';
 import { type ProviderConfig } from '@/types/user/settings';
 
 const AI_MODEL_UNIQUE_CONSTRAINT = 'ai_models_id_provider_id_user_id_pk';
@@ -148,12 +149,16 @@ export const aiModelRouter = router({
       }),
     )
     .query(async ({ ctx, input }): Promise<AiProviderModelListItem[]> => {
-      return ctx.aiInfraRepos.getAiProviderModelList(input.id, {
+      const options = {
         enabled: input.enabled,
         limit: input.limit,
         offset: input.offset,
         type: input.type,
-      });
+      };
+
+      return getUserScopedAiProviderModelList(ctx.userId, input.id, options, (scopedOptions) =>
+        ctx.aiInfraRepos.getAiProviderModelList(input.id, scopedOptions),
+      );
     }),
 
   removeAiModel: aiModelProcedure

--- a/apps/server/src/routers/lambda/aiProvider.ts
+++ b/apps/server/src/routers/lambda/aiProvider.ts
@@ -3,7 +3,6 @@ import { RequestTrigger } from '@lobechat/types';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
-import { getHiddenBuiltinModelsForUser } from '@/business/server/aiProvider';
 import { withScopedPermission } from '@/business/server/trpc-middlewares/rbacPermission';
 import {
   requireWorkspaceRoleWhenScoped,
@@ -17,6 +16,7 @@ import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { getServerGlobalConfig } from '@/server/globalConfig';
 import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
+import { getUserScopedAiProviderRuntimeState } from '@/server/services/aiProviderAccess';
 import { type AiProviderDetailItem, type AiProviderRuntimeState } from '@/types/aiProvider';
 import {
   CreateAiProviderSchema,
@@ -24,7 +24,6 @@ import {
   UpdateAiProviderSchema,
 } from '@/types/aiProvider';
 import { type ProviderConfig } from '@/types/user/settings';
-import { filterEnabledProvidersByModelType, filterHiddenBuiltinModels } from '@/utils/aiProvider';
 
 const aiProviderProcedure = wsCompatProcedure.use(serverDatabase).use(async (opts) => {
   const { ctx } = opts;
@@ -139,35 +138,9 @@ export const aiProviderRouter = router({
   getAiProviderRuntimeState: aiProviderProcedure
     .input(z.object({ isLogin: z.boolean().optional() }))
     .query(async ({ ctx }): Promise<AiProviderRuntimeState> => {
-      const [runtimeState, hiddenBuiltinModels] = await Promise.all([
+      return getUserScopedAiProviderRuntimeState(ctx.userId, () =>
         ctx.aiInfraRepos.getAiProviderRuntimeState(KeyVaultsGateKeeper.getUserKeyVaults),
-        getHiddenBuiltinModelsForUser(ctx.userId),
-      ]);
-      const enabledAiModels = filterHiddenBuiltinModels(
-        runtimeState.enabledAiModels,
-        hiddenBuiltinModels,
       );
-
-      return {
-        ...runtimeState,
-        enabledAiModels,
-        enabledChatAiProviders: filterEnabledProvidersByModelType(
-          runtimeState.enabledChatAiProviders,
-          enabledAiModels,
-          'chat',
-        ),
-        enabledImageAiProviders: filterEnabledProvidersByModelType(
-          runtimeState.enabledImageAiProviders,
-          enabledAiModels,
-          'image',
-        ),
-        enabledVideoAiProviders: filterEnabledProvidersByModelType(
-          runtimeState.enabledVideoAiProviders,
-          enabledAiModels,
-          'video',
-        ),
-        ...(hiddenBuiltinModels && { hiddenBuiltinModels }),
-      };
     }),
 
   // Provider rows carry workspace-shared credentials and the model-layer where is

--- a/apps/server/src/routers/lambda/aiProvider.ts
+++ b/apps/server/src/routers/lambda/aiProvider.ts
@@ -3,6 +3,7 @@ import { RequestTrigger } from '@lobechat/types';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
+import { getHiddenBuiltinModelsForUser } from '@/business/server/aiProvider';
 import { withScopedPermission } from '@/business/server/trpc-middlewares/rbacPermission';
 import {
   requireWorkspaceRoleWhenScoped,
@@ -137,7 +138,15 @@ export const aiProviderRouter = router({
   getAiProviderRuntimeState: aiProviderProcedure
     .input(z.object({ isLogin: z.boolean().optional() }))
     .query(async ({ ctx }): Promise<AiProviderRuntimeState> => {
-      return ctx.aiInfraRepos.getAiProviderRuntimeState(KeyVaultsGateKeeper.getUserKeyVaults);
+      const [runtimeState, hiddenBuiltinModels] = await Promise.all([
+        ctx.aiInfraRepos.getAiProviderRuntimeState(KeyVaultsGateKeeper.getUserKeyVaults),
+        getHiddenBuiltinModelsForUser(ctx.userId),
+      ]);
+
+      return {
+        ...runtimeState,
+        ...(hiddenBuiltinModels && { hiddenBuiltinModels }),
+      };
     }),
 
   // Provider rows carry workspace-shared credentials and the model-layer where is

--- a/apps/server/src/routers/lambda/aiProvider.ts
+++ b/apps/server/src/routers/lambda/aiProvider.ts
@@ -24,6 +24,7 @@ import {
   UpdateAiProviderSchema,
 } from '@/types/aiProvider';
 import { type ProviderConfig } from '@/types/user/settings';
+import { filterEnabledProvidersByModelType, filterHiddenBuiltinModels } from '@/utils/aiProvider';
 
 const aiProviderProcedure = wsCompatProcedure.use(serverDatabase).use(async (opts) => {
   const { ctx } = opts;
@@ -142,9 +143,29 @@ export const aiProviderRouter = router({
         ctx.aiInfraRepos.getAiProviderRuntimeState(KeyVaultsGateKeeper.getUserKeyVaults),
         getHiddenBuiltinModelsForUser(ctx.userId),
       ]);
+      const enabledAiModels = filterHiddenBuiltinModels(
+        runtimeState.enabledAiModels,
+        hiddenBuiltinModels,
+      );
 
       return {
         ...runtimeState,
+        enabledAiModels,
+        enabledChatAiProviders: filterEnabledProvidersByModelType(
+          runtimeState.enabledChatAiProviders,
+          enabledAiModels,
+          'chat',
+        ),
+        enabledImageAiProviders: filterEnabledProvidersByModelType(
+          runtimeState.enabledImageAiProviders,
+          enabledAiModels,
+          'image',
+        ),
+        enabledVideoAiProviders: filterEnabledProvidersByModelType(
+          runtimeState.enabledVideoAiProviders,
+          enabledAiModels,
+          'video',
+        ),
         ...(hiddenBuiltinModels && { hiddenBuiltinModels }),
       };
     }),

--- a/apps/server/src/services/aiProviderAccess.test.ts
+++ b/apps/server/src/services/aiProviderAccess.test.ts
@@ -139,7 +139,8 @@ describe('getUserScopedAiProviderRuntimeState', () => {
       enabledChatAiProviders: [],
       enabledImageAiProviders: [],
       enabledVideoAiProviders: [],
-      hiddenBuiltinModels: [{ id: 'possibly-hidden-chat', providerId: 'lobehub' }],
+      hiddenBuiltinModelsResolved: false,
     });
+    expect(result).not.toHaveProperty('hiddenBuiltinModels');
   });
 });

--- a/apps/server/src/services/aiProviderAccess.test.ts
+++ b/apps/server/src/services/aiProviderAccess.test.ts
@@ -1,0 +1,53 @@
+import type { AiProviderRuntimeState } from 'model-bank';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getUserScopedAiProviderRuntimeState } from './aiProviderAccess';
+
+const mockGetHiddenBuiltinModelsForUser = vi.hoisted(() => vi.fn());
+
+vi.mock('@/business/server/aiProvider', () => ({
+  getHiddenBuiltinModelsForUser: mockGetHiddenBuiltinModelsForUser,
+}));
+
+describe('getUserScopedAiProviderRuntimeState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('filters hidden models and model-type providers for server consumers', async () => {
+    const lobehubProvider = { id: 'lobehub', source: 'builtin' as const };
+    const openaiProvider = { id: 'openai', source: 'builtin' as const };
+    const hiddenChatModel = {
+      abilities: {},
+      id: 'hidden-chat',
+      providerId: 'lobehub',
+      type: 'chat' as const,
+    };
+    const visibleImageModel = {
+      abilities: {},
+      id: 'visible-image',
+      providerId: 'openai',
+      type: 'image' as const,
+    };
+    const runtimeState: AiProviderRuntimeState = {
+      enabledAiModels: [hiddenChatModel, visibleImageModel],
+      enabledAiProviders: [lobehubProvider, openaiProvider],
+      enabledChatAiProviders: [lobehubProvider],
+      enabledImageAiProviders: [openaiProvider],
+      enabledVideoAiProviders: [],
+      runtimeConfig: {},
+    };
+    mockGetHiddenBuiltinModelsForUser.mockResolvedValue([
+      { id: 'hidden-chat', providerId: 'lobehub' },
+    ]);
+
+    const result = await getUserScopedAiProviderRuntimeState('user-1', async () => runtimeState);
+
+    expect(result).toEqual({
+      ...runtimeState,
+      enabledAiModels: [visibleImageModel],
+      enabledChatAiProviders: [],
+      hiddenBuiltinModels: [{ id: 'hidden-chat', providerId: 'lobehub' }],
+    });
+  });
+});

--- a/apps/server/src/services/aiProviderAccess.test.ts
+++ b/apps/server/src/services/aiProviderAccess.test.ts
@@ -139,6 +139,7 @@ describe('getUserScopedAiProviderRuntimeState', () => {
       enabledChatAiProviders: [],
       enabledImageAiProviders: [],
       enabledVideoAiProviders: [],
+      hiddenBuiltinModels: [{ id: 'possibly-hidden-chat', providerId: 'lobehub' }],
     });
   });
 });

--- a/apps/server/src/services/aiProviderAccess.test.ts
+++ b/apps/server/src/services/aiProviderAccess.test.ts
@@ -140,7 +140,27 @@ describe('getUserScopedAiProviderRuntimeState', () => {
       enabledImageAiProviders: [],
       enabledVideoAiProviders: [],
       hiddenBuiltinModelsResolved: false,
+      runtimeConfig: {},
     });
     expect(result).not.toHaveProperty('hiddenBuiltinModels');
+  });
+
+  it('stops server runtimes when model access cannot be resolved', async () => {
+    mockGetHiddenBuiltinModelsForUser.mockResolvedValue(undefined);
+
+    await expect(
+      getUserScopedAiProviderRuntimeState(
+        'user-1',
+        async () => ({
+          enabledAiModels: [],
+          enabledAiProviders: [],
+          enabledChatAiProviders: [],
+          enabledImageAiProviders: [],
+          enabledVideoAiProviders: [],
+          runtimeConfig: { lobehub: {} as never },
+        }),
+        { throwOnUnresolvedAccess: true },
+      ),
+    ).rejects.toThrow('Unable to resolve user-scoped model access');
   });
 });

--- a/apps/server/src/services/aiProviderAccess.test.ts
+++ b/apps/server/src/services/aiProviderAccess.test.ts
@@ -1,13 +1,75 @@
 import type { AiProviderRuntimeState } from 'model-bank';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getUserScopedAiProviderRuntimeState } from './aiProviderAccess';
+import {
+  getUserScopedAiProviderModelList,
+  getUserScopedAiProviderRuntimeState,
+} from './aiProviderAccess';
 
 const mockGetHiddenBuiltinModelsForUser = vi.hoisted(() => vi.fn());
 
 vi.mock('@/business/server/aiProvider', () => ({
   getHiddenBuiltinModelsForUser: mockGetHiddenBuiltinModelsForUser,
 }));
+
+describe('getUserScopedAiProviderModelList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('filters hidden models before applying pagination without mutating cached data', async () => {
+    const models = [{ id: 'hidden-model' }, { id: 'visible-model-1' }, { id: 'visible-model-2' }];
+    const loadModelList = vi.fn().mockResolvedValue(models);
+    mockGetHiddenBuiltinModelsForUser.mockResolvedValue([
+      { id: 'hidden-model', providerId: 'lobehub' },
+    ]);
+
+    const result = await getUserScopedAiProviderModelList(
+      'user-1',
+      'lobehub',
+      { enabled: false, limit: 1, offset: 1, type: 'chat' },
+      loadModelList,
+    );
+
+    expect(loadModelList).toHaveBeenCalledWith({
+      enabled: false,
+      limit: undefined,
+      offset: undefined,
+      type: 'chat',
+    });
+    expect(result).toEqual([{ id: 'visible-model-2' }]);
+    expect(models).toHaveLength(3);
+  });
+
+  it('preserves the repository query when the provider has no hidden models', async () => {
+    const models = [{ id: 'visible-model' }];
+    const loadModelList = vi.fn().mockResolvedValue(models);
+    const options = { enabled: true, limit: 20, offset: 10, type: 'image' };
+    mockGetHiddenBuiltinModelsForUser.mockResolvedValue([
+      { id: 'hidden-model', providerId: 'lobehub' },
+    ]);
+
+    const result = await getUserScopedAiProviderModelList(
+      'user-1',
+      'openai',
+      options,
+      loadModelList,
+    );
+
+    expect(loadModelList).toHaveBeenCalledWith(options);
+    expect(result).toBe(models);
+  });
+
+  it('fails closed without reading cached models when access cannot be resolved', async () => {
+    const loadModelList = vi.fn();
+    mockGetHiddenBuiltinModelsForUser.mockResolvedValue(undefined);
+
+    const result = await getUserScopedAiProviderModelList('user-1', 'lobehub', {}, loadModelList);
+
+    expect(result).toEqual([]);
+    expect(loadModelList).not.toHaveBeenCalled();
+  });
+});
 
 describe('getUserScopedAiProviderRuntimeState', () => {
   beforeEach(() => {
@@ -48,6 +110,35 @@ describe('getUserScopedAiProviderRuntimeState', () => {
       enabledAiModels: [visibleImageModel],
       enabledChatAiProviders: [],
       hiddenBuiltinModels: [{ id: 'hidden-chat', providerId: 'lobehub' }],
+    });
+  });
+
+  it('fails closed when model access cannot be resolved', async () => {
+    const provider = { id: 'lobehub', source: 'builtin' as const };
+    const runtimeState: AiProviderRuntimeState = {
+      enabledAiModels: [
+        {
+          abilities: {},
+          id: 'possibly-hidden-chat',
+          providerId: 'lobehub',
+          type: 'chat',
+        },
+      ],
+      enabledAiProviders: [provider],
+      enabledChatAiProviders: [provider],
+      enabledImageAiProviders: [],
+      enabledVideoAiProviders: [],
+      runtimeConfig: {},
+    };
+    mockGetHiddenBuiltinModelsForUser.mockResolvedValue(undefined);
+
+    const result = await getUserScopedAiProviderRuntimeState('user-1', async () => runtimeState);
+
+    expect(result).toMatchObject({
+      enabledAiModels: [],
+      enabledChatAiProviders: [],
+      enabledImageAiProviders: [],
+      enabledVideoAiProviders: [],
     });
   });
 });

--- a/apps/server/src/services/aiProviderAccess.ts
+++ b/apps/server/src/services/aiProviderAccess.ts
@@ -1,7 +1,51 @@
-import type { AiProviderRuntimeState } from 'model-bank';
+import type { AiProviderModelListItem, AiProviderRuntimeState } from 'model-bank';
 
 import { getHiddenBuiltinModelsForUser } from '@/business/server/aiProvider';
-import { filterEnabledProvidersByModelType, filterHiddenBuiltinModels } from '@/utils/aiProvider';
+import {
+  filterEnabledProvidersByModelType,
+  filterHiddenBuiltinModels,
+  filterHiddenProviderModels,
+} from '@/utils/aiProvider';
+
+interface AiProviderModelListOptions {
+  enabled?: boolean;
+  limit?: number;
+  offset?: number;
+  type?: string;
+}
+
+/**
+ * Resolves a user-scoped model list after the repository has loaded its complete cached data.
+ * For providers with hidden models, pagination is applied after filtering so hidden rows neither
+ * leak nor consume visible result slots.
+ */
+export const getUserScopedAiProviderModelList = async (
+  userId: string,
+  providerId: string,
+  options: AiProviderModelListOptions,
+  loadModelList: (options: AiProviderModelListOptions) => Promise<AiProviderModelListItem[]>,
+): Promise<AiProviderModelListItem[]> => {
+  const hiddenBuiltinModels = await getHiddenBuiltinModelsForUser(userId);
+  if (hiddenBuiltinModels === undefined) return [];
+
+  const hasHiddenModels = hiddenBuiltinModels.some((model) => model.providerId === providerId);
+
+  if (!hasHiddenModels) return loadModelList(options);
+
+  const models = await loadModelList({
+    ...options,
+    limit: undefined,
+    offset: undefined,
+  });
+  const visibleModels = filterHiddenProviderModels(models, providerId, hiddenBuiltinModels);
+  const offset = Math.max(0, options.offset ?? 0);
+
+  if (typeof options.limit === 'number') {
+    return visibleModels.slice(offset, offset + Math.max(0, options.limit));
+  }
+
+  return offset > 0 ? visibleModels.slice(offset) : visibleModels;
+};
 
 /**
  * Resolves a user-scoped runtime state for server consumers that select or expose builtin models.
@@ -15,10 +59,10 @@ export const getUserScopedAiProviderRuntimeState = async (
     loadRuntimeState(),
     getHiddenBuiltinModelsForUser(userId),
   ]);
-  const enabledAiModels = filterHiddenBuiltinModels(
-    runtimeState.enabledAiModels,
-    hiddenBuiltinModels,
-  );
+  const enabledAiModels =
+    hiddenBuiltinModels === undefined
+      ? []
+      : filterHiddenBuiltinModels(runtimeState.enabledAiModels, hiddenBuiltinModels);
 
   return {
     ...runtimeState,

--- a/apps/server/src/services/aiProviderAccess.ts
+++ b/apps/server/src/services/aiProviderAccess.ts
@@ -59,10 +59,17 @@ export const getUserScopedAiProviderRuntimeState = async (
     loadRuntimeState(),
     getHiddenBuiltinModelsForUser(userId),
   ]);
-  const enabledAiModels =
-    hiddenBuiltinModels === undefined
-      ? []
-      : filterHiddenBuiltinModels(runtimeState.enabledAiModels, hiddenBuiltinModels);
+  /**
+   * Return an explicit blocklist when access is unresolved. Omitting the field would let clients
+   * coalesce it to an empty default and rebuild a visible list from their complete model cache.
+   */
+  const resolvedHiddenBuiltinModels =
+    hiddenBuiltinModels ??
+    runtimeState.enabledAiModels.map(({ id, providerId }) => ({ id, providerId }));
+  const enabledAiModels = filterHiddenBuiltinModels(
+    runtimeState.enabledAiModels,
+    resolvedHiddenBuiltinModels,
+  );
 
   return {
     ...runtimeState,
@@ -82,6 +89,6 @@ export const getUserScopedAiProviderRuntimeState = async (
       enabledAiModels,
       'video',
     ),
-    ...(hiddenBuiltinModels && { hiddenBuiltinModels }),
+    hiddenBuiltinModels: resolvedHiddenBuiltinModels,
   };
 };

--- a/apps/server/src/services/aiProviderAccess.ts
+++ b/apps/server/src/services/aiProviderAccess.ts
@@ -59,17 +59,10 @@ export const getUserScopedAiProviderRuntimeState = async (
     loadRuntimeState(),
     getHiddenBuiltinModelsForUser(userId),
   ]);
-  /**
-   * Return an explicit blocklist when access is unresolved. Omitting the field would let clients
-   * coalesce it to an empty default and rebuild a visible list from their complete model cache.
-   */
-  const resolvedHiddenBuiltinModels =
-    hiddenBuiltinModels ??
-    runtimeState.enabledAiModels.map(({ id, providerId }) => ({ id, providerId }));
-  const enabledAiModels = filterHiddenBuiltinModels(
-    runtimeState.enabledAiModels,
-    resolvedHiddenBuiltinModels,
-  );
+  const isHiddenBuiltinModelsResolved = hiddenBuiltinModels !== undefined;
+  const enabledAiModels = isHiddenBuiltinModelsResolved
+    ? filterHiddenBuiltinModels(runtimeState.enabledAiModels, hiddenBuiltinModels)
+    : [];
 
   return {
     ...runtimeState,
@@ -89,6 +82,8 @@ export const getUserScopedAiProviderRuntimeState = async (
       enabledAiModels,
       'video',
     ),
-    hiddenBuiltinModels: resolvedHiddenBuiltinModels,
+    ...(isHiddenBuiltinModelsResolved
+      ? hiddenBuiltinModels.length > 0 && { hiddenBuiltinModels }
+      : { hiddenBuiltinModelsResolved: false }),
   };
 };

--- a/apps/server/src/services/aiProviderAccess.ts
+++ b/apps/server/src/services/aiProviderAccess.ts
@@ -14,6 +14,10 @@ interface AiProviderModelListOptions {
   type?: string;
 }
 
+interface UserScopedRuntimeStateOptions {
+  throwOnUnresolvedAccess?: boolean;
+}
+
 /**
  * Resolves a user-scoped model list after the repository has loaded its complete cached data.
  * For providers with hidden models, pagination is applied after filtering so hidden rows neither
@@ -54,12 +58,17 @@ export const getUserScopedAiProviderModelList = async (
 export const getUserScopedAiProviderRuntimeState = async (
   userId: string,
   loadRuntimeState: () => Promise<AiProviderRuntimeState>,
+  options: UserScopedRuntimeStateOptions = {},
 ): Promise<AiProviderRuntimeState> => {
   const [runtimeState, hiddenBuiltinModels] = await Promise.all([
     loadRuntimeState(),
     getHiddenBuiltinModelsForUser(userId),
   ]);
   const isHiddenBuiltinModelsResolved = hiddenBuiltinModels !== undefined;
+  if (!isHiddenBuiltinModelsResolved && options.throwOnUnresolvedAccess) {
+    throw new Error('Unable to resolve user-scoped model access');
+  }
+
   const enabledAiModels = isHiddenBuiltinModelsResolved
     ? filterHiddenBuiltinModels(runtimeState.enabledAiModels, hiddenBuiltinModels)
     : [];
@@ -85,5 +94,6 @@ export const getUserScopedAiProviderRuntimeState = async (
     ...(isHiddenBuiltinModelsResolved
       ? { hiddenBuiltinModels }
       : { hiddenBuiltinModelsResolved: false }),
+    runtimeConfig: isHiddenBuiltinModelsResolved ? runtimeState.runtimeConfig : {},
   };
 };

--- a/apps/server/src/services/aiProviderAccess.ts
+++ b/apps/server/src/services/aiProviderAccess.ts
@@ -83,7 +83,7 @@ export const getUserScopedAiProviderRuntimeState = async (
       'video',
     ),
     ...(isHiddenBuiltinModelsResolved
-      ? hiddenBuiltinModels.length > 0 && { hiddenBuiltinModels }
+      ? { hiddenBuiltinModels }
       : { hiddenBuiltinModelsResolved: false }),
   };
 };

--- a/apps/server/src/services/aiProviderAccess.ts
+++ b/apps/server/src/services/aiProviderAccess.ts
@@ -1,0 +1,43 @@
+import type { AiProviderRuntimeState } from 'model-bank';
+
+import { getHiddenBuiltinModelsForUser } from '@/business/server/aiProvider';
+import { filterEnabledProvidersByModelType, filterHiddenBuiltinModels } from '@/utils/aiProvider';
+
+/**
+ * Resolves a user-scoped runtime state for server consumers that select or expose builtin models.
+ * The repository state stays complete and cacheable; access filtering is applied to the returned copy.
+ */
+export const getUserScopedAiProviderRuntimeState = async (
+  userId: string,
+  loadRuntimeState: () => Promise<AiProviderRuntimeState>,
+): Promise<AiProviderRuntimeState> => {
+  const [runtimeState, hiddenBuiltinModels] = await Promise.all([
+    loadRuntimeState(),
+    getHiddenBuiltinModelsForUser(userId),
+  ]);
+  const enabledAiModels = filterHiddenBuiltinModels(
+    runtimeState.enabledAiModels,
+    hiddenBuiltinModels,
+  );
+
+  return {
+    ...runtimeState,
+    enabledAiModels,
+    enabledChatAiProviders: filterEnabledProvidersByModelType(
+      runtimeState.enabledChatAiProviders,
+      enabledAiModels,
+      'chat',
+    ),
+    enabledImageAiProviders: filterEnabledProvidersByModelType(
+      runtimeState.enabledImageAiProviders,
+      enabledAiModels,
+      'image',
+    ),
+    enabledVideoAiProviders: filterEnabledProvidersByModelType(
+      runtimeState.enabledVideoAiProviders,
+      enabledAiModels,
+      'video',
+    ),
+    ...(hiddenBuiltinModels && { hiddenBuiltinModels }),
+  };
+};

--- a/apps/server/src/services/memory/userMemory/extract.ts
+++ b/apps/server/src/services/memory/userMemory/extract.ts
@@ -2377,8 +2377,10 @@ export class MemoryExtractionExecutor {
     const db = await this.db;
     const aiInfraRepos = new AiInfraRepos(db, userId, this.aiProviderConfig, workspaceId);
 
-    return getUserScopedAiProviderRuntimeState(userId, () =>
-      aiInfraRepos.getAiProviderRuntimeState(KeyVaultsGateKeeper.getUserKeyVaults),
+    return getUserScopedAiProviderRuntimeState(
+      userId,
+      () => aiInfraRepos.getAiProviderRuntimeState(KeyVaultsGateKeeper.getUserKeyVaults),
+      { throwOnUnresolvedAccess: true },
     );
   }
 

--- a/apps/server/src/services/memory/userMemory/extract.ts
+++ b/apps/server/src/services/memory/userMemory/extract.ts
@@ -77,6 +77,7 @@ import { type MemoryAgentConfig } from '@/server/globalConfig/parseMemoryExtract
 import { parseMemoryExtractionConfig } from '@/server/globalConfig/parseMemoryExtractionConfig';
 import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
 import { S3 } from '@/server/modules/S3';
+import { getUserScopedAiProviderRuntimeState } from '@/server/services/aiProviderAccess';
 import {
   AsyncTaskError,
   type AsyncTaskErrorBody,
@@ -2376,7 +2377,9 @@ export class MemoryExtractionExecutor {
     const db = await this.db;
     const aiInfraRepos = new AiInfraRepos(db, userId, this.aiProviderConfig, workspaceId);
 
-    return aiInfraRepos.getAiProviderRuntimeState(KeyVaultsGateKeeper.getUserKeyVaults);
+    return getUserScopedAiProviderRuntimeState(userId, () =>
+      aiInfraRepos.getAiProviderRuntimeState(KeyVaultsGateKeeper.getUserKeyVaults),
+    );
   }
 
   private async resolveRuntimeKeyVaults(

--- a/apps/server/src/services/memory/userMemory/persona/__tests__/service.test.ts
+++ b/apps/server/src/services/memory/userMemory/persona/__tests__/service.test.ts
@@ -90,6 +90,7 @@ beforeEach(async () => {
     enabledAiProviders: [],
     enabledChatAiProviders: [],
     enabledImageAiProviders: [],
+    enabledVideoAiProviders: [],
     runtimeConfig: {
       openai: { keyVaults: { apiKey: 'vault-key', baseURL: 'https://vault.example.com' } },
     },
@@ -154,6 +155,7 @@ describe('UserPersonaService', () => {
       enabledAiProviders: [],
       enabledChatAiProviders: [],
       enabledImageAiProviders: [],
+      enabledVideoAiProviders: [],
       runtimeConfig: {},
     });
 

--- a/apps/server/src/services/memory/userMemory/persona/service.ts
+++ b/apps/server/src/services/memory/userMemory/persona/service.ts
@@ -21,6 +21,7 @@ import { type LobeChatDatabase } from '@/database/type';
 import { type MemoryAgentConfig } from '@/server/globalConfig/parseMemoryExtractionConfig';
 import { parseMemoryExtractionConfig } from '@/server/globalConfig/parseMemoryExtractionConfig';
 import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
+import { getUserScopedAiProviderRuntimeState } from '@/server/services/aiProviderAccess';
 import {
   type ProviderKeyVaultMap,
   type RuntimeResolveOptions,
@@ -100,8 +101,8 @@ export class UserPersonaService {
     // purely user-level feature with no workspace concept; the payload carries no
     // workspaceId, so provider config is resolved against the user's personal scope.
     const aiInfraRepos = new AiInfraRepos(this.db, payload.userId, {});
-    const runtimeState = await aiInfraRepos.getAiProviderRuntimeState(
-      KeyVaultsGateKeeper.getUserKeyVaults,
+    const runtimeState = await getUserScopedAiProviderRuntimeState(payload.userId, () =>
+      aiInfraRepos.getAiProviderRuntimeState(KeyVaultsGateKeeper.getUserKeyVaults),
     );
     const providerId = await AiInfraRepos.tryMatchingProviderFrom(runtimeState, {
       fallbackProvider: agentConfig.provider,

--- a/apps/server/src/services/memory/userMemory/persona/service.ts
+++ b/apps/server/src/services/memory/userMemory/persona/service.ts
@@ -101,8 +101,10 @@ export class UserPersonaService {
     // purely user-level feature with no workspace concept; the payload carries no
     // workspaceId, so provider config is resolved against the user's personal scope.
     const aiInfraRepos = new AiInfraRepos(this.db, payload.userId, {});
-    const runtimeState = await getUserScopedAiProviderRuntimeState(payload.userId, () =>
-      aiInfraRepos.getAiProviderRuntimeState(KeyVaultsGateKeeper.getUserKeyVaults),
+    const runtimeState = await getUserScopedAiProviderRuntimeState(
+      payload.userId,
+      () => aiInfraRepos.getAiProviderRuntimeState(KeyVaultsGateKeeper.getUserKeyVaults),
+      { throwOnUnresolvedAccess: true },
     );
     const providerId = await AiInfraRepos.tryMatchingProviderFrom(runtimeState, {
       fallbackProvider: agentConfig.provider,

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/agentBuilder.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/agentBuilder.test.ts
@@ -67,6 +67,18 @@ describe('agentBuilderRuntime', () => {
   });
 
   describe('getAvailableModels', () => {
+    it('does not query or expose models when access cannot be resolved', async () => {
+      mockGetAiProviderList.mockResolvedValue([{ enabled: true, id: 'lobehub', name: 'LobeHub' }]);
+
+      const result = await createRuntime().getAvailableModels({});
+
+      expect(result).toMatchObject({
+        state: { providers: [] },
+        success: true,
+      });
+      expect(mockGetAiProviderModelList).not.toHaveBeenCalled();
+    });
+
     it('does not expose models hidden for the current user', async () => {
       mockGetAiProviderList.mockResolvedValue([{ enabled: true, id: 'lobehub', name: 'LobeHub' }]);
       mockGetAiProviderModelList.mockResolvedValue([

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/agentBuilder.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/agentBuilder.test.ts
@@ -6,14 +6,24 @@ const {
   mockCreatePlugin,
   mockFindById,
   mockGetAgentConfigById,
+  mockGetAiProviderList,
+  mockGetAiProviderModelList,
+  mockGetHiddenBuiltinModelsForUser,
   mockUpdateAgent,
   mockUpdateConfig,
 } = vi.hoisted(() => ({
   mockCreatePlugin: vi.fn(),
   mockFindById: vi.fn(),
   mockGetAgentConfigById: vi.fn(),
+  mockGetAiProviderList: vi.fn(),
+  mockGetAiProviderModelList: vi.fn(),
+  mockGetHiddenBuiltinModelsForUser: vi.fn(),
   mockUpdateAgent: vi.fn(),
   mockUpdateConfig: vi.fn(),
+}));
+
+vi.mock('@/business/server/aiProvider', () => ({
+  getHiddenBuiltinModelsForUser: mockGetHiddenBuiltinModelsForUser,
 }));
 
 vi.mock('@/database/models/agent', () => ({
@@ -32,7 +42,10 @@ vi.mock('@/database/models/plugin', () => ({
 }));
 
 vi.mock('@/database/repositories/aiInfra', () => ({
-  AiInfraRepos: vi.fn(() => ({})),
+  AiInfraRepos: vi.fn(() => ({
+    getAiProviderList: mockGetAiProviderList,
+    getAiProviderModelList: mockGetAiProviderModelList,
+  })),
 }));
 
 vi.mock('@/server/services/discover', () => ({
@@ -50,6 +63,34 @@ const createRuntime = () =>
 describe('agentBuilderRuntime', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetHiddenBuiltinModelsForUser.mockResolvedValue(undefined);
+  });
+
+  describe('getAvailableModels', () => {
+    it('does not expose models hidden for the current user', async () => {
+      mockGetAiProviderList.mockResolvedValue([{ enabled: true, id: 'lobehub', name: 'LobeHub' }]);
+      mockGetAiProviderModelList.mockResolvedValue([
+        { displayName: 'Hidden Chat', id: 'hidden-chat' },
+        { displayName: 'Visible Chat', id: 'visible-chat' },
+      ]);
+      mockGetHiddenBuiltinModelsForUser.mockResolvedValue([
+        { id: 'hidden-chat', providerId: 'lobehub' },
+      ]);
+
+      const result = await createRuntime().getAvailableModels({});
+
+      expect(result).toMatchObject({
+        state: {
+          providers: [
+            {
+              id: 'lobehub',
+              models: [{ id: 'visible-chat', name: 'Visible Chat' }],
+            },
+          ],
+        },
+        success: true,
+      });
+    });
   });
 
   describe('updateConfig - togglePlugin', () => {

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/imageGeneration.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/imageGeneration.test.ts
@@ -150,6 +150,36 @@ describe('imageGenerationRuntime', () => {
     });
   });
 
+  it('does not list models hidden for the current user', async () => {
+    callerMocks.aiProvider.mockReturnValue({
+      getAiProviderRuntimeState: vi.fn().mockResolvedValue({
+        enabledImageAiProviders: [{ id: 'lobehub', name: 'LobeHub' }],
+        hiddenBuiltinModels: [{ id: 'hidden-image', providerId: 'lobehub' }],
+      }),
+    });
+    callerMocks.aiModel.mockReturnValue({
+      getAiProviderModelList: vi
+        .fn()
+        .mockResolvedValue([{ id: 'visible-image' }, { id: 'hidden-image' }]),
+    });
+
+    const runtime = imageGenerationRuntime.factory({
+      toolManifestMap: {},
+      userId: 'user-1',
+      workspaceId: 'workspace-1',
+    });
+
+    const result = await runtime.listImageModels({ provider: 'lobehub' });
+
+    expect(result).toMatchObject({
+      state: {
+        providers: [{ id: 'lobehub', models: [{ id: 'visible-image' }] }],
+        totalModels: 1,
+      },
+      success: true,
+    });
+  });
+
   it('does not list models from a disabled provider', async () => {
     const getAiProviderModelList = vi.fn();
     callerMocks.aiModel.mockReturnValue({ getAiProviderModelList });

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/imageGeneration.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/imageGeneration.test.ts
@@ -158,9 +158,10 @@ describe('imageGenerationRuntime', () => {
       }),
     });
     callerMocks.aiModel.mockReturnValue({
-      getAiProviderModelList: vi
-        .fn()
-        .mockResolvedValue([{ id: 'visible-image' }, { id: 'hidden-image' }]),
+      getAiProviderModelList: vi.fn(async ({ limit }: { limit?: number }) => {
+        const models = [{ id: 'hidden-image' }, { id: 'visible-image' }];
+        return typeof limit === 'number' ? models.slice(0, limit) : models;
+      }),
     });
 
     const runtime = imageGenerationRuntime.factory({
@@ -169,7 +170,7 @@ describe('imageGenerationRuntime', () => {
       workspaceId: 'workspace-1',
     });
 
-    const result = await runtime.listImageModels({ provider: 'lobehub' });
+    const result = await runtime.listImageModels({ limit: 1, provider: 'lobehub' });
 
     expect(result).toMatchObject({
       state: {

--- a/apps/server/src/services/toolExecution/serverRuntimes/agentBuilder.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/agentBuilder.ts
@@ -49,7 +49,12 @@ export const agentBuilderRuntime: ServerRuntimeRegistration = {
             aiInfraRepos.getAiProviderList(),
             getHiddenBuiltinModelsForUser(userId),
           ]);
-          const enabledProviders = allProviders.filter((p) => p.enabled);
+          /**
+           * An unresolved access policy must not be interpreted as an empty blocklist.
+           * Keep the model tool empty until the user-scoped policy can be loaded.
+           */
+          const enabledProviders =
+            hiddenBuiltinModels === undefined ? [] : allProviders.filter((p) => p.enabled);
 
           // LobeHub provider first, then by sort order
           enabledProviders.sort((a, b) => {

--- a/apps/server/src/services/toolExecution/serverRuntimes/agentBuilder.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/agentBuilder.ts
@@ -11,10 +11,12 @@ import { BRANDING_PROVIDER } from '@lobechat/business-const';
 import { modelsResultsPrompt } from '@lobechat/prompts';
 import { getPluginMode, upsertPluginMode } from '@lobechat/types';
 
+import { getHiddenBuiltinModelsForUser } from '@/business/server/aiProvider';
 import { AgentModel } from '@/database/models/agent';
 import { PluginModel } from '@/database/models/plugin';
 import { AiInfraRepos } from '@/database/repositories/aiInfra';
 import { DiscoverService } from '@/server/services/discover';
+import { filterHiddenProviderModels } from '@/utils/aiProvider';
 
 import { type ToolExecutionContext, type ToolExecutionResult } from '../types';
 import { type ServerRuntimeRegistration } from './types';
@@ -31,15 +33,11 @@ export const agentBuilderRuntime: ServerRuntimeRegistration = {
     if (!context.userId || !context.serverDB) {
       throw new Error('userId and serverDB are required for Agent Builder execution');
     }
+    const userId = context.userId;
 
-    const agentModel = new AgentModel(context.serverDB, context.userId, context.workspaceId);
-    const pluginModel = new PluginModel(context.serverDB, context.userId, context.workspaceId);
-    const aiInfraRepos = new AiInfraRepos(
-      context.serverDB,
-      context.userId,
-      {},
-      context.workspaceId,
-    );
+    const agentModel = new AgentModel(context.serverDB, userId, context.workspaceId);
+    const pluginModel = new PluginModel(context.serverDB, userId, context.workspaceId);
+    const aiInfraRepos = new AiInfraRepos(context.serverDB, userId, {}, context.workspaceId);
     const discoverService = new DiscoverService();
 
     return {
@@ -47,7 +45,10 @@ export const agentBuilderRuntime: ServerRuntimeRegistration = {
         params: GetAvailableModelsParams,
       ): Promise<ToolExecutionResult> => {
         try {
-          const allProviders = await aiInfraRepos.getAiProviderList();
+          const [allProviders, hiddenBuiltinModels] = await Promise.all([
+            aiInfraRepos.getAiProviderList(),
+            getHiddenBuiltinModelsForUser(userId),
+          ]);
           const enabledProviders = allProviders.filter((p) => p.enabled);
 
           // LobeHub provider first, then by sort order
@@ -87,9 +88,14 @@ export const agentBuilderRuntime: ServerRuntimeRegistration = {
               enabled: true,
               type: 'chat',
             });
+            const visibleChatModels = filterHiddenProviderModels(
+              enabledChatModels,
+              provider.id,
+              hiddenBuiltinModels,
+            );
 
             const remaining = MAX_MODELS - totalModels;
-            const sliced = enabledChatModels.slice(0, remaining);
+            const sliced = visibleChatModels.slice(0, remaining);
 
             if (sliced.length === 0) continue;
 

--- a/apps/server/src/services/toolExecution/serverRuntimes/imageGeneration.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/imageGeneration.ts
@@ -8,6 +8,7 @@ import { aiProviderRouter } from '@/server/routers/lambda/aiProvider';
 import { generationRouter } from '@/server/routers/lambda/generation';
 import { generationTopicRouter } from '@/server/routers/lambda/generationTopic';
 import { imageRouter } from '@/server/routers/lambda/image';
+import { filterHiddenProviderModels } from '@/utils/aiProvider';
 
 import { type ServerRuntimeRegistration } from './types';
 
@@ -68,10 +69,15 @@ export const imageGenerationRuntime: ServerRuntimeRegistration = {
               limit,
               type: 'image',
             });
+            const visibleModels = filterHiddenProviderModels(
+              models,
+              item.id,
+              runtimeState.hiddenBuiltinModels,
+            );
 
             return {
               id: item.id,
-              models: models.map(normalizeModel),
+              models: visibleModels.map(normalizeModel),
               name: item.name || item.id,
             };
           }),

--- a/apps/server/src/services/toolExecution/serverRuntimes/imageGeneration.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/imageGeneration.ts
@@ -63,10 +63,17 @@ export const imageGenerationRuntime: ServerRuntimeRegistration = {
           : runtimeState.enabledImageAiProviders;
         const providers = await Promise.all(
           enabledProviders.map(async (item) => {
+            /**
+             * Hidden models must be removed before applying the caller's limit, otherwise they
+             * consume result slots and can make a provider appear empty despite later visible models.
+             */
+            const hasHiddenModels = runtimeState.hiddenBuiltinModels?.some(
+              (model) => model.providerId === item.id,
+            );
             const models = await aiModelCaller.getAiProviderModelList({
               enabled: true,
               id: item.id,
-              limit,
+              limit: hasHiddenModels ? undefined : limit,
               type: 'image',
             });
             const visibleModels = filterHiddenProviderModels(
@@ -74,10 +81,12 @@ export const imageGenerationRuntime: ServerRuntimeRegistration = {
               item.id,
               runtimeState.hiddenBuiltinModels,
             );
+            const limitedModels =
+              typeof limit === 'number' ? visibleModels.slice(0, limit) : visibleModels;
 
             return {
               id: item.id,
-              models: visibleModels.map(normalizeModel),
+              models: limitedModels.map(normalizeModel),
               name: item.name || item.id,
             };
           }),

--- a/packages/builtin-tool-image-generation/src/client/executor/index.test.ts
+++ b/packages/builtin-tool-image-generation/src/client/executor/index.test.ts
@@ -7,13 +7,19 @@ const mocks = vi.hoisted(() => ({
   createTopic: vi.fn(),
   enabledImageModelList: vi.fn(),
   getAgentStoreState: vi.fn(),
+  getAiProviderModelList: vi.fn(),
+  getAiProviderRuntimeState: vi.fn(),
 }));
 
 vi.mock('@/services/aiModel', () => ({
-  aiModelService: {},
+  aiModelService: {
+    getAiProviderModelList: mocks.getAiProviderModelList,
+  },
 }));
 vi.mock('@/services/aiProvider', () => ({
-  aiProviderService: {},
+  aiProviderService: {
+    getAiProviderRuntimeState: mocks.getAiProviderRuntimeState,
+  },
 }));
 vi.mock('@/services/generation', () => ({
   generationService: {},
@@ -93,5 +99,38 @@ describe('ImageGenerationExecutor', () => {
       'public',
       'A shared workspace illustration',
     );
+  });
+
+  it('does not expose hidden models while the store model list is hydrating', async () => {
+    mocks.enabledImageModelList.mockReturnValue([]);
+    mocks.getAiProviderRuntimeState.mockResolvedValue({
+      enabledImageAiProviders: [{ id: 'lobehub', name: 'LobeHub' }],
+      hiddenBuiltinModels: [{ id: 'hidden-image', providerId: 'lobehub' }],
+    });
+    mocks.getAiProviderModelList.mockImplementation(
+      async (_providerId: string, options: { limit?: number }) => {
+        const models = [{ id: 'hidden-image' }, { id: 'visible-image' }];
+
+        return typeof options.limit === 'number' ? models.slice(0, options.limit) : models;
+      },
+    );
+
+    const result = await imageGenerationExecutor.listImageModels({
+      limit: 1,
+      provider: 'lobehub',
+    });
+
+    expect(result).toMatchObject({
+      state: {
+        providers: [
+          {
+            id: 'lobehub',
+            models: [{ id: 'visible-image' }],
+          },
+        ],
+        totalModels: 1,
+      },
+      success: true,
+    });
   });
 });

--- a/packages/builtin-tool-image-generation/src/client/executor/index.test.ts
+++ b/packages/builtin-tool-image-generation/src/client/executor/index.test.ts
@@ -9,8 +9,12 @@ const mocks = vi.hoisted(() => ({
   getAgentStoreState: vi.fn(),
   getAiProviderModelList: vi.fn(),
   getAiProviderRuntimeState: vi.fn(),
+  loadDefaultHiddenBuiltinModels: vi.fn(),
 }));
 
+vi.mock('@/business/client/model-bank/loadModels', () => ({
+  loadDefaultHiddenBuiltinModels: mocks.loadDefaultHiddenBuiltinModels,
+}));
 vi.mock('@/services/aiModel', () => ({
   aiModelService: {
     getAiProviderModelList: mocks.getAiProviderModelList,
@@ -69,6 +73,7 @@ describe('ImageGenerationExecutor', () => {
         name: 'Provider 1',
       },
     ]);
+    mocks.loadDefaultHiddenBuiltinModels.mockResolvedValue([]);
     mocks.createTopic.mockResolvedValue('topic-1');
     mocks.createImage.mockResolvedValue({
       data: {
@@ -132,5 +137,51 @@ describe('ImageGenerationExecutor', () => {
       },
       success: true,
     });
+  });
+
+  it('uses the client default blocklist with an older runtime-state response', async () => {
+    mocks.enabledImageModelList.mockReturnValue([]);
+    mocks.getAiProviderRuntimeState.mockResolvedValue({
+      enabledImageAiProviders: [{ id: 'lobehub', name: 'LobeHub' }],
+    });
+    mocks.loadDefaultHiddenBuiltinModels.mockResolvedValue([
+      { id: 'hidden-image', providerId: 'lobehub' },
+    ]);
+    mocks.getAiProviderModelList.mockResolvedValue([
+      { id: 'hidden-image' },
+      { id: 'visible-image' },
+    ]);
+
+    const result = await imageGenerationExecutor.listImageModels({
+      limit: 1,
+      provider: 'lobehub',
+    });
+
+    expect(result).toMatchObject({
+      state: {
+        providers: [{ id: 'lobehub', models: [{ id: 'visible-image' }] }],
+        totalModels: 1,
+      },
+      success: true,
+    });
+  });
+
+  it('fails closed when the runtime-state policy is unresolved', async () => {
+    mocks.enabledImageModelList.mockReturnValue([]);
+    mocks.getAiProviderRuntimeState.mockResolvedValue({
+      enabledImageAiProviders: [{ id: 'lobehub', name: 'LobeHub' }],
+      hiddenBuiltinModelsResolved: false,
+    });
+
+    const result = await imageGenerationExecutor.listImageModels({
+      limit: 1,
+      provider: 'lobehub',
+    });
+
+    expect(result).toMatchObject({
+      state: { providers: [], totalModels: 0 },
+      success: true,
+    });
+    expect(mocks.getAiProviderModelList).not.toHaveBeenCalled();
   });
 });

--- a/packages/builtin-tool-image-generation/src/client/executor/index.ts
+++ b/packages/builtin-tool-image-generation/src/client/executor/index.ts
@@ -90,6 +90,18 @@ const createClientImageGenerationRuntime = (topicVisibility?: 'private' | 'publi
       }
 
       const runtimeState = await aiProviderService.getAiProviderRuntimeState();
+      let hiddenBuiltinModels = runtimeState.hiddenBuiltinModels;
+
+      if (runtimeState.hiddenBuiltinModelsResolved !== false && hiddenBuiltinModels === undefined) {
+        const { loadDefaultHiddenBuiltinModels } =
+          await import('@/business/client/model-bank/loadModels');
+        hiddenBuiltinModels = await loadDefaultHiddenBuiltinModels();
+      }
+
+      if (hiddenBuiltinModels === undefined) {
+        return { providers: [], totalModels: 0 };
+      }
+
       const enabledProviders = provider
         ? runtimeState.enabledImageAiProviders.filter((item) => item.id === provider)
         : runtimeState.enabledImageAiProviders;
@@ -100,19 +112,13 @@ const createClientImageGenerationRuntime = (topicVisibility?: 'private' | 'publi
            * Hidden models must be removed before applying the caller's limit so they do not
            * consume result slots while the store-backed model list is still hydrating.
            */
-          const hasHiddenModels = runtimeState.hiddenBuiltinModels?.some(
-            (model) => model.providerId === item.id,
-          );
+          const hasHiddenModels = hiddenBuiltinModels.some((model) => model.providerId === item.id);
           const models = await aiModelService.getAiProviderModelList(item.id, {
             enabled: true,
             limit: hasHiddenModels ? undefined : limit,
             type: 'image',
           });
-          const visibleModels = filterHiddenProviderModels(
-            models,
-            item.id,
-            runtimeState.hiddenBuiltinModels,
-          );
+          const visibleModels = filterHiddenProviderModels(models, item.id, hiddenBuiltinModels);
           const limitedModels =
             typeof limit === 'number' ? visibleModels.slice(0, limit) : visibleModels;
 

--- a/packages/builtin-tool-image-generation/src/client/executor/index.ts
+++ b/packages/builtin-tool-image-generation/src/client/executor/index.ts
@@ -14,6 +14,7 @@ import { imageService } from '@/services/image';
 import { getAgentStoreState } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 import { aiProviderSelectors, getAiInfraStoreState } from '@/store/aiInfra';
+import { filterHiddenProviderModels } from '@/utils/aiProvider';
 
 import { ImageGenerationExecutionRuntime } from '../../ExecutionRuntime';
 import { ImageGenerationManifest } from '../../manifest';
@@ -95,14 +96,29 @@ const createClientImageGenerationRuntime = (topicVisibility?: 'private' | 'publi
 
       const providers = await Promise.all(
         enabledProviders.map(async (item) => {
+          /**
+           * Hidden models must be removed before applying the caller's limit so they do not
+           * consume result slots while the store-backed model list is still hydrating.
+           */
+          const hasHiddenModels = runtimeState.hiddenBuiltinModels?.some(
+            (model) => model.providerId === item.id,
+          );
           const models = await aiModelService.getAiProviderModelList(item.id, {
             enabled: true,
-            limit,
+            limit: hasHiddenModels ? undefined : limit,
             type: 'image',
           });
+          const visibleModels = filterHiddenProviderModels(
+            models,
+            item.id,
+            runtimeState.hiddenBuiltinModels,
+          );
+          const limitedModels =
+            typeof limit === 'number' ? visibleModels.slice(0, limit) : visibleModels;
+
           return {
             id: item.id,
-            models: models.map(normalizeRawModel),
+            models: limitedModels.map(normalizeRawModel),
             name: item.name || item.id,
           };
         }),

--- a/packages/business-server/src/aiProvider.ts
+++ b/packages/business-server/src/aiProvider.ts
@@ -1,0 +1,5 @@
+import type { BuiltinModelIdentifier } from 'model-bank';
+
+export const getHiddenBuiltinModelsForUser = async (
+  _userId: string,
+): Promise<BuiltinModelIdentifier[] | undefined> => undefined;

--- a/packages/business-server/src/aiProvider.ts
+++ b/packages/business-server/src/aiProvider.ts
@@ -2,4 +2,4 @@ import type { BuiltinModelIdentifier } from 'model-bank';
 
 export const getHiddenBuiltinModelsForUser = async (
   _userId: string,
-): Promise<BuiltinModelIdentifier[] | undefined> => undefined;
+): Promise<BuiltinModelIdentifier[] | undefined> => [];

--- a/packages/model-bank/src/types/aiProvider.ts
+++ b/packages/model-bank/src/types/aiProvider.ts
@@ -422,5 +422,7 @@ export interface AiProviderRuntimeState {
   enabledImageAiProviders: EnabledProvider[];
   enabledVideoAiProviders: EnabledProvider[];
   hiddenBuiltinModels?: BuiltinModelIdentifier[];
+  /** False when the server could not resolve the current user's hidden-model policy. */
+  hiddenBuiltinModelsResolved?: boolean;
   runtimeConfig: Record<string, AiProviderRuntimeConfig>;
 }

--- a/packages/model-bank/src/types/aiProvider.ts
+++ b/packages/model-bank/src/types/aiProvider.ts
@@ -410,11 +410,17 @@ export interface AiProviderRuntimeConfig {
   settings: AiProviderSettings;
 }
 
+export interface BuiltinModelIdentifier {
+  id: string;
+  providerId: string;
+}
+
 export interface AiProviderRuntimeState {
   enabledAiModels: EnabledAiModel[];
   enabledAiProviders: EnabledProvider[];
   enabledChatAiProviders: EnabledProvider[];
   enabledImageAiProviders: EnabledProvider[];
   enabledVideoAiProviders: EnabledProvider[];
+  hiddenBuiltinModels?: BuiltinModelIdentifier[];
   runtimeConfig: Record<string, AiProviderRuntimeConfig>;
 }

--- a/src/business/client/model-bank/loadModels.ts
+++ b/src/business/client/model-bank/loadModels.ts
@@ -1,1 +1,5 @@
+import type { BuiltinModelIdentifier } from 'model-bank';
+
+export const loadDefaultHiddenBuiltinModels = async (): Promise<BuiltinModelIdentifier[]> => [];
+
 export { loadModels } from '@lobechat/business-model-bank/model-config';

--- a/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
+++ b/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
@@ -3,6 +3,7 @@ import type { AIImageModelCard, EnabledAiModel, ModelParamsSchema, Pricing } fro
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  filterEnabledProvidersByModelType,
   filterHiddenBuiltinModels,
   getChatModelList,
   getEmbeddingModelList,
@@ -74,6 +75,22 @@ describe('aiProvider action helpers', () => {
 
       expect(result).toEqual([models[0], models[2]]);
       expect(models).toHaveLength(3);
+    });
+  });
+
+  describe('filterEnabledProvidersByModelType', () => {
+    const providers = [
+      { id: 'lobehub', source: 'builtin' as const },
+      { id: 'openai', source: 'builtin' as const },
+    ];
+
+    it('removes providers without a visible model of the requested type', () => {
+      const models = [
+        createChatModel({ providerId: 'lobehub' }),
+        createImageModel({ providerId: 'openai' }),
+      ];
+
+      expect(filterEnabledProvidersByModelType(providers, models, 'image')).toEqual([providers[1]]);
     });
   });
 

--- a/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
+++ b/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
@@ -3,6 +3,7 @@ import type { AIImageModelCard, EnabledAiModel, ModelParamsSchema, Pricing } fro
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  filterHiddenBuiltinModels,
   getChatModelList,
   getEmbeddingModelList,
   getImageModelList,
@@ -53,6 +54,27 @@ describe('aiProvider action helpers', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  describe('filterHiddenBuiltinModels', () => {
+    const models = [
+      createChatModel({ id: 'public-model', providerId: 'lobehub' }),
+      createChatModel({ id: 'hidden-model', providerId: 'lobehub' }),
+      createChatModel({ id: 'hidden-model', providerId: 'openai' }),
+    ];
+
+    it('returns the cached array unchanged when no models are hidden', () => {
+      expect(filterHiddenBuiltinModels(models, [])).toBe(models);
+    });
+
+    it('filters a matching provider and model id without mutating the cached array', () => {
+      const result = filterHiddenBuiltinModels(models, [
+        { id: 'hidden-model', providerId: 'lobehub' },
+      ]);
+
+      expect(result).toEqual([models[0], models[2]]);
+      expect(models).toHaveLength(3);
+    });
   });
 
   describe('normalizeChatModel', () => {

--- a/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
+++ b/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
@@ -68,6 +68,10 @@ describe('aiProvider action helpers', () => {
       expect(filterHiddenBuiltinModels(models, [])).toBe(models);
     });
 
+    it('returns the cached array unchanged while hidden models are not loaded', () => {
+      expect(filterHiddenBuiltinModels(models, undefined)).toBe(models);
+    });
+
     it('filters a matching provider and model id without mutating the cached array', () => {
       const result = filterHiddenBuiltinModels(models, [
         { id: 'hidden-model', providerId: 'lobehub' },

--- a/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
+++ b/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
@@ -11,6 +11,7 @@ import {
   normalizeChatModel,
   normalizeEmbeddingModel,
   normalizeImageModel,
+  resolveUserScopedBuiltinModelState,
 } from '../action';
 
 const createChatModel = (overrides: Partial<EnabledAiModel> = {}): EnabledAiModel => ({
@@ -79,6 +80,29 @@ describe('aiProvider action helpers', () => {
 
       expect(result).toEqual([models[0], models[2]]);
       expect(models).toHaveLength(3);
+    });
+  });
+
+  describe('resolveUserScopedBuiltinModelState', () => {
+    it('does not rebuild complete client caches when the server policy is unresolved', () => {
+      const allBuiltinAiModels = [
+        createChatModel({ enabled: false, id: 'disabled-model', providerId: 'lobehub' }),
+      ];
+      const runtimeState = {
+        enabledAiModels: [],
+        enabledAiProviders: [],
+        enabledChatAiProviders: [],
+        enabledImageAiProviders: [],
+        enabledVideoAiProviders: [],
+        hiddenBuiltinModelsResolved: false,
+        runtimeConfig: {},
+      };
+
+      expect(resolveUserScopedBuiltinModelState(allBuiltinAiModels, runtimeState, [])).toEqual({
+        builtinAiModelList: [],
+        enabledAiModels: [],
+        hiddenBuiltinModels: undefined,
+      });
     });
   });
 

--- a/src/store/aiInfra/slices/aiProvider/action.ts
+++ b/src/store/aiInfra/slices/aiProvider/action.ts
@@ -97,6 +97,17 @@ export const filterHiddenBuiltinModels = <T extends BuiltinModelIdentifier>(
   return models.filter((model) => !hiddenModelKeys.has(getBuiltinModelIdentifierKey(model)));
 };
 
+export const filterEnabledProvidersByModelType = (
+  providers: EnabledProvider[],
+  enabledAiModels: EnabledAiModel[],
+  type: EnabledAiModel['type'],
+): EnabledProvider[] =>
+  providers.filter((provider) =>
+    enabledAiModels.some(
+      (model) => model.providerId === provider.id && model.type === type && isAiModelVisible(model),
+    ),
+  );
+
 const createProviderModelCollector = (
   type: EnabledAiModel['type'],
   normalizer: ModelNormalizer,
@@ -566,11 +577,26 @@ export class AiProviderActionImpl {
             hiddenBuiltinModels,
           );
 
-          const enabledEmbeddingAiProviders = data.enabledAiProviders.filter((provider) => {
-            return enabledAiModels.some(
-              (model) => model.providerId === provider.id && model.type === 'embedding',
-            );
-          });
+          const enabledChatAiProviders = filterEnabledProvidersByModelType(
+            data.enabledChatAiProviders,
+            enabledAiModels,
+            'chat',
+          );
+          const enabledEmbeddingAiProviders = filterEnabledProvidersByModelType(
+            data.enabledAiProviders,
+            enabledAiModels,
+            'embedding',
+          );
+          const enabledImageAiProviders = filterEnabledProvidersByModelType(
+            data.enabledImageAiProviders,
+            enabledAiModels,
+            'image',
+          );
+          const enabledVideoAiProviders = filterEnabledProvidersByModelType(
+            data.enabledVideoAiProviders,
+            enabledAiModels,
+            'video',
+          );
 
           // Build model lists with proper async handling
           const [
@@ -579,19 +605,22 @@ export class AiProviderActionImpl {
             enabledImageModelList,
             enabledVideoModelList,
           ] = await Promise.all([
-            buildChatProviderModelLists(data.enabledChatAiProviders, enabledAiModels),
+            buildChatProviderModelLists(enabledChatAiProviders, enabledAiModels),
             buildEmbeddingProviderModelLists(enabledEmbeddingAiProviders, enabledAiModels),
-            buildImageProviderModelLists(data.enabledImageAiProviders, enabledAiModels),
-            buildVideoProviderModelLists(data.enabledVideoAiProviders, enabledAiModels),
+            buildImageProviderModelLists(enabledImageAiProviders, enabledAiModels),
+            buildVideoProviderModelLists(enabledVideoAiProviders, enabledAiModels),
           ]);
 
           return {
             ...data,
             builtinAiModelList,
             enabledAiModels,
+            enabledChatAiProviders,
             enabledChatModelList,
             enabledEmbeddingModelList,
+            enabledImageAiProviders,
             enabledImageModelList,
+            enabledVideoAiProviders,
             enabledVideoModelList,
             hiddenBuiltinModels,
           };

--- a/src/store/aiInfra/slices/aiProvider/action.ts
+++ b/src/store/aiInfra/slices/aiProvider/action.ts
@@ -6,6 +6,7 @@ import {
 import { uniqBy } from 'es-toolkit/compat';
 import type {
   AiFullModelCard,
+  BuiltinModelIdentifier,
   EnabledAiModel,
   LobeDefaultAiModelListItem,
   ModelAbilities,
@@ -36,6 +37,39 @@ import { AiProviderSourceEnum } from '@/types/aiProvider';
 import { filterEnabledProvidersByModelType, filterHiddenBuiltinModels } from '@/utils/aiProvider';
 
 export { filterEnabledProvidersByModelType, filterHiddenBuiltinModels } from '@/utils/aiProvider';
+
+interface UserScopedBuiltinModelState {
+  builtinAiModelList: LobeDefaultAiModelListItem[];
+  enabledAiModels: EnabledAiModel[];
+  hiddenBuiltinModels?: BuiltinModelIdentifier[];
+}
+
+/**
+ * Applies a user-scoped hidden-model policy to complete client-side model caches.
+ * A new server can explicitly mark the policy unresolved; older servers omit the marker and keep
+ * using the client default blocklist for backward compatibility.
+ */
+export const resolveUserScopedBuiltinModelState = (
+  allBuiltinAiModels: LobeDefaultAiModelListItem[],
+  runtimeState: AiProviderRuntimeState,
+  defaultHiddenBuiltinModels: BuiltinModelIdentifier[] | undefined,
+): UserScopedBuiltinModelState => {
+  if (runtimeState.hiddenBuiltinModelsResolved === false) {
+    return {
+      builtinAiModelList: [],
+      enabledAiModels: [],
+      hiddenBuiltinModels: undefined,
+    };
+  }
+
+  const hiddenBuiltinModels = runtimeState.hiddenBuiltinModels ?? defaultHiddenBuiltinModels;
+
+  return {
+    builtinAiModelList: filterHiddenBuiltinModels(allBuiltinAiModels, hiddenBuiltinModels),
+    enabledAiModels: filterHiddenBuiltinModels(runtimeState.enabledAiModels, hiddenBuiltinModels),
+    hiddenBuiltinModels,
+  };
+};
 
 export type ProviderModelListItem = {
   abilities: ModelAbilities;
@@ -545,15 +579,12 @@ export class AiProviderActionImpl {
 
         if (isLogin) {
           const data = await aiProviderService.getAiProviderRuntimeState();
-          const hiddenBuiltinModels = data.hiddenBuiltinModels ?? defaultHiddenBuiltinModels;
-          const builtinAiModelList = filterHiddenBuiltinModels(
-            allBuiltinAiModels,
-            hiddenBuiltinModels,
-          );
-          const enabledAiModels = filterHiddenBuiltinModels(
-            data.enabledAiModels,
-            hiddenBuiltinModels,
-          );
+          const { builtinAiModelList, enabledAiModels, hiddenBuiltinModels } =
+            resolveUserScopedBuiltinModelState(
+              allBuiltinAiModels,
+              data,
+              defaultHiddenBuiltinModels,
+            );
 
           const enabledChatAiProviders = filterEnabledProvidersByModelType(
             data.enabledChatAiProviders,

--- a/src/store/aiInfra/slices/aiProvider/action.ts
+++ b/src/store/aiInfra/slices/aiProvider/action.ts
@@ -89,9 +89,9 @@ const getBuiltinModelIdentifierKey = ({ id, providerId }: BuiltinModelIdentifier
 
 export const filterHiddenBuiltinModels = <T extends BuiltinModelIdentifier>(
   models: T[],
-  hiddenModels: readonly BuiltinModelIdentifier[],
+  hiddenModels: readonly BuiltinModelIdentifier[] | undefined,
 ): T[] => {
-  if (hiddenModels.length === 0) return models;
+  if (!hiddenModels || hiddenModels.length === 0) return models;
 
   const hiddenModelKeys = new Set(hiddenModels.map(getBuiltinModelIdentifierKey));
   return models.filter((model) => !hiddenModelKeys.has(getBuiltinModelIdentifierKey(model)));
@@ -707,7 +707,8 @@ export class AiProviderActionImpl {
               enabledEmbeddingModelList: data.enabledEmbeddingModelList || [],
               enabledImageModelList: data.enabledImageModelList || [],
               enabledVideoModelList: data.enabledVideoModelList || [],
-              hiddenBuiltinModels: data.hiddenBuiltinModels || [],
+              /** Preserve "not loaded" so a later business-config refresh can still fail closed. */
+              hiddenBuiltinModels: data.hiddenBuiltinModels,
               isInitAiProviderRuntimeState: true,
             },
             false,

--- a/src/store/aiInfra/slices/aiProvider/action.ts
+++ b/src/store/aiInfra/slices/aiProvider/action.ts
@@ -6,6 +6,7 @@ import {
 import { uniqBy } from 'es-toolkit/compat';
 import type {
   AiFullModelCard,
+  BuiltinModelIdentifier,
   EnabledAiModel,
   LobeDefaultAiModelListItem,
   ModelAbilities,
@@ -82,6 +83,19 @@ const resolveModelParameters = async (
 };
 
 const dedupeById = (models: ProviderModelListItem[]) => uniqBy(models, 'id');
+
+const getBuiltinModelIdentifierKey = ({ id, providerId }: BuiltinModelIdentifier) =>
+  `${providerId}\u0000${id}`;
+
+export const filterHiddenBuiltinModels = <T extends BuiltinModelIdentifier>(
+  models: T[],
+  hiddenModels: readonly BuiltinModelIdentifier[],
+): T[] => {
+  if (hiddenModels.length === 0) return models;
+
+  const hiddenModelKeys = new Set(hiddenModels.map(getBuiltinModelIdentifierKey));
+  return models.filter((model) => !hiddenModelKeys.has(getBuiltinModelIdentifierKey(model)));
+};
 
 const createProviderModelCollector = (
   type: EnabledAiModel['type'],
@@ -530,17 +544,30 @@ export class AiProviderActionImpl {
     return useClientDataSWR<AiProviderRuntimeStateWithBuiltinModels | undefined>(
       shouldFetch ? [AiProviderSwrKey.fetchAiProviderRuntimeState, isLogin] : null,
       async ([, isLogin]) => {
-        const [{ loadModels }, { DEFAULT_MODEL_PROVIDER_LIST }] = await Promise.all([
-          import('@/business/client/model-bank/loadModels'),
-          import('model-bank/modelProviders'),
+        const [{ loadDefaultHiddenBuiltinModels, loadModels }, { DEFAULT_MODEL_PROVIDER_LIST }] =
+          await Promise.all([
+            import('@/business/client/model-bank/loadModels'),
+            import('model-bank/modelProviders'),
+          ]);
+        const [allBuiltinAiModels, defaultHiddenBuiltinModels] = await Promise.all([
+          loadModels(),
+          loadDefaultHiddenBuiltinModels(),
         ]);
-        const builtinAiModelList = await loadModels();
 
         if (isLogin) {
           const data = await aiProviderService.getAiProviderRuntimeState();
+          const hiddenBuiltinModels = data.hiddenBuiltinModels ?? defaultHiddenBuiltinModels;
+          const builtinAiModelList = filterHiddenBuiltinModels(
+            allBuiltinAiModels,
+            hiddenBuiltinModels,
+          );
+          const enabledAiModels = filterHiddenBuiltinModels(
+            data.enabledAiModels,
+            hiddenBuiltinModels,
+          );
 
           const enabledEmbeddingAiProviders = data.enabledAiProviders.filter((provider) => {
-            return data.enabledAiModels.some(
+            return enabledAiModels.some(
               (model) => model.providerId === provider.id && model.type === 'embedding',
             );
           });
@@ -552,22 +579,28 @@ export class AiProviderActionImpl {
             enabledImageModelList,
             enabledVideoModelList,
           ] = await Promise.all([
-            buildChatProviderModelLists(data.enabledChatAiProviders, data.enabledAiModels),
-            buildEmbeddingProviderModelLists(enabledEmbeddingAiProviders, data.enabledAiModels),
-            buildImageProviderModelLists(data.enabledImageAiProviders, data.enabledAiModels),
-            buildVideoProviderModelLists(data.enabledVideoAiProviders, data.enabledAiModels),
+            buildChatProviderModelLists(data.enabledChatAiProviders, enabledAiModels),
+            buildEmbeddingProviderModelLists(enabledEmbeddingAiProviders, enabledAiModels),
+            buildImageProviderModelLists(data.enabledImageAiProviders, enabledAiModels),
+            buildVideoProviderModelLists(data.enabledVideoAiProviders, enabledAiModels),
           ]);
 
           return {
             ...data,
             builtinAiModelList,
+            enabledAiModels,
             enabledChatModelList,
             enabledEmbeddingModelList,
             enabledImageModelList,
             enabledVideoModelList,
+            hiddenBuiltinModels,
           };
         }
 
+        const builtinAiModelList = filterHiddenBuiltinModels(
+          allBuiltinAiModels,
+          defaultHiddenBuiltinModels,
+        );
         const enabledAiProviders: EnabledProvider[] = DEFAULT_MODEL_PROVIDER_LIST.filter(
           (provider) => provider.enabled,
         ).map((item) => ({ id: item.id, name: item.name, source: AiProviderSourceEnum.Builtin }));
@@ -627,6 +660,7 @@ export class AiProviderActionImpl {
           enabledImageModelList,
           enabledVideoAiProviders,
           enabledVideoModelList,
+          hiddenBuiltinModels: defaultHiddenBuiltinModels,
           runtimeConfig: {},
         };
       },
@@ -644,6 +678,7 @@ export class AiProviderActionImpl {
               enabledEmbeddingModelList: data.enabledEmbeddingModelList || [],
               enabledImageModelList: data.enabledImageModelList || [],
               enabledVideoModelList: data.enabledVideoModelList || [],
+              hiddenBuiltinModels: data.hiddenBuiltinModels || [],
               isInitAiProviderRuntimeState: true,
             },
             false,

--- a/src/store/aiInfra/slices/aiProvider/action.ts
+++ b/src/store/aiInfra/slices/aiProvider/action.ts
@@ -6,7 +6,6 @@ import {
 import { uniqBy } from 'es-toolkit/compat';
 import type {
   AiFullModelCard,
-  BuiltinModelIdentifier,
   EnabledAiModel,
   LobeDefaultAiModelListItem,
   ModelAbilities,
@@ -34,6 +33,9 @@ import {
   type UpdateAiProviderParams,
 } from '@/types/aiProvider';
 import { AiProviderSourceEnum } from '@/types/aiProvider';
+import { filterEnabledProvidersByModelType, filterHiddenBuiltinModels } from '@/utils/aiProvider';
+
+export { filterEnabledProvidersByModelType, filterHiddenBuiltinModels } from '@/utils/aiProvider';
 
 export type ProviderModelListItem = {
   abilities: ModelAbilities;
@@ -83,30 +85,6 @@ const resolveModelParameters = async (
 };
 
 const dedupeById = (models: ProviderModelListItem[]) => uniqBy(models, 'id');
-
-const getBuiltinModelIdentifierKey = ({ id, providerId }: BuiltinModelIdentifier) =>
-  `${providerId}\u0000${id}`;
-
-export const filterHiddenBuiltinModels = <T extends BuiltinModelIdentifier>(
-  models: T[],
-  hiddenModels: readonly BuiltinModelIdentifier[] | undefined,
-): T[] => {
-  if (!hiddenModels || hiddenModels.length === 0) return models;
-
-  const hiddenModelKeys = new Set(hiddenModels.map(getBuiltinModelIdentifierKey));
-  return models.filter((model) => !hiddenModelKeys.has(getBuiltinModelIdentifierKey(model)));
-};
-
-export const filterEnabledProvidersByModelType = (
-  providers: EnabledProvider[],
-  enabledAiModels: EnabledAiModel[],
-  type: EnabledAiModel['type'],
-): EnabledProvider[] =>
-  providers.filter((provider) =>
-    enabledAiModels.some(
-      (model) => model.providerId === provider.id && model.type === type && isAiModelVisible(model),
-    ),
-  );
 
 const createProviderModelCollector = (
   type: EnabledAiModel['type'],

--- a/src/store/aiInfra/slices/aiProvider/initialState.ts
+++ b/src/store/aiInfra/slices/aiProvider/initialState.ts
@@ -1,4 +1,4 @@
-import { type EnabledAiModel } from 'model-bank';
+import type { BuiltinModelIdentifier, EnabledAiModel } from 'model-bank';
 
 import {
   type AiProviderDetailItem,
@@ -27,6 +27,7 @@ export interface AIProviderState {
   enabledEmbeddingModelList?: EnabledProviderWithModels[];
   enabledImageModelList?: EnabledProviderWithModels[];
   enabledVideoModelList?: EnabledProviderWithModels[];
+  hiddenBuiltinModels?: BuiltinModelIdentifier[];
   initAiProviderList: boolean;
   isInitAiProviderRuntimeState: boolean;
   providerSearchKeyword: string;

--- a/src/store/aiInfra/slices/aiProvider/selectors.ts
+++ b/src/store/aiInfra/slices/aiProvider/selectors.ts
@@ -21,6 +21,8 @@ const enabledImageModelList = (s: AIProviderStoreState) => s.enabledImageModelLi
 
 const enabledVideoModelList = (s: AIProviderStoreState) => s.enabledVideoModelList || [];
 
+const hiddenBuiltinModels = (s: AIProviderStoreState) => s.hiddenBuiltinModels;
+
 const isProviderEnabled = (id: string) => (s: AIProviderStoreState) =>
   enabledAiProviderList(s).some((i) => i.id === id);
 
@@ -142,6 +144,7 @@ export const aiProviderSelectors = {
   enabledEmbeddingModelList,
   enabledImageModelList,
   enabledVideoModelList,
+  hiddenBuiltinModels,
   isActiveProviderApiKeyNotEmpty,
   isActiveProviderEndpointNotEmpty,
   isAiProviderConfigLoading,

--- a/src/utils/aiProvider.ts
+++ b/src/utils/aiProvider.ts
@@ -1,0 +1,41 @@
+import type { BuiltinModelIdentifier, EnabledAiModel } from 'model-bank';
+import { isAiModelVisible } from 'model-bank';
+
+const getBuiltinModelIdentifierKey = ({ id, providerId }: BuiltinModelIdentifier) =>
+  `${providerId}\u0000${id}`;
+
+export const filterHiddenBuiltinModels = <T extends BuiltinModelIdentifier>(
+  models: T[],
+  hiddenModels: readonly BuiltinModelIdentifier[] | undefined,
+): T[] => {
+  if (!hiddenModels || hiddenModels.length === 0) return models;
+
+  const hiddenModelKeys = new Set(hiddenModels.map(getBuiltinModelIdentifierKey));
+  return models.filter((model) => !hiddenModelKeys.has(getBuiltinModelIdentifierKey(model)));
+};
+
+export const filterHiddenProviderModels = <T extends { id: string }>(
+  models: T[],
+  providerId: string,
+  hiddenModels: readonly BuiltinModelIdentifier[] | undefined,
+): T[] => {
+  if (!hiddenModels || hiddenModels.length === 0) return models;
+
+  const hiddenModelIds = new Set(
+    hiddenModels.filter((model) => model.providerId === providerId).map((model) => model.id),
+  );
+  if (hiddenModelIds.size === 0) return models;
+
+  return models.filter((model) => !hiddenModelIds.has(model.id));
+};
+
+export const filterEnabledProvidersByModelType = <T extends { id: string }>(
+  providers: T[],
+  enabledAiModels: EnabledAiModel[],
+  type: EnabledAiModel['type'],
+): T[] =>
+  providers.filter((provider) =>
+    enabledAiModels.some(
+      (model) => model.providerId === provider.id && model.type === type && isAiModelVisible(model),
+    ),
+  );


### PR DESCRIPTION
Add generic support for user-scoped hidden builtin model identifiers.

The runtime state can now carry a list of hidden builtin models, and client model lists are derived from the complete cached model arrays without mutating the cache. Open-source defaults keep every builtin model visible.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed
- `bun run check <9 changed OSS files>` — lint clean, 70 tests passed
