### PR TITLE
chore: remove LOBE-XXX annotation markers from source code

### DIFF
--- a/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
@@ -932,7 +932,7 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
       this.builtinMcpStartPromise = (async () => {
         const server = new LobeBuiltinMcpServer({
           // In-app browser control tools ride the same per-op MCP server so
-          // CC can drive the browser sidebar (LOBE-11712 M3, hetero path).
+          // CC can drive the browser sidebar ( M3, hetero path).
           extraTools: buildBrowserMcpTools((operationId, apiName, args) =>
             this.runBrowserMcpTool(operationId, apiName, args),
           ),

--- a/apps/server/src/agent-hono/handlers/botCallback.ts
+++ b/apps/server/src/agent-hono/handlers/botCallback.ts
@@ -40,7 +40,7 @@ export async function botCallback(c: Context): Promise<Response> {
   }
 
   // console (not debug) for completions only: arrival of the final-reply
-  // callback must be provable from production logs (LOBE-11632) — the debug
+  // callback must be provable from production logs — the debug
   // namespace above is not enabled in production, and steps are too chatty.
   if (type === 'completion') {
     console.info(

--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextBuilder.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextBuilder.ts
@@ -284,7 +284,7 @@ export const buildServerCallLlmContext = async ({
     try {
       const marketService = new MarketService({ userInfo: { userId: ctx.userId } });
       // Inside a workspace, the agent must only see the workspace's shared
-      // organization credentials — personal creds are not visible here (LOBE-10978).
+      // organization credentials — personal creds are not visible here.
       const credsResult = ctx.workspaceId
         ? await marketService.market.organizations.creds({ workspaceId: ctx.workspaceId }).list()
         : await marketService.market.creds.list();

--- a/apps/server/src/modules/Mecha/ContextEngineering/__tests__/serverMessagesEngine.test.ts
+++ b/apps/server/src/modules/Mecha/ContextEngineering/__tests__/serverMessagesEngine.test.ts
@@ -70,7 +70,7 @@ describe('serverMessagesEngine', () => {
       expect(result[0].content).toBe(systemRole + '\n\n' + getCurrentDateContent());
     });
 
-    it('renders {{workingDirectory}} to a fallback instead of leaking the literal (LOBE-11473)', async () => {
+    it('renders {{workingDirectory}} to a fallback instead of leaking the literal ', async () => {
       const messages = createBasicMessages();
       const systemRole = '<working-directory>{{workingDirectory}}</working-directory>';
 

--- a/apps/server/src/modules/Mecha/ContextEngineering/index.ts
+++ b/apps/server/src/modules/Mecha/ContextEngineering/index.ts
@@ -30,7 +30,7 @@ const createServerVariableGenerators = (params: {
     // resolves) and overrides this through the spread order below. Without this
     // fallback, a device-run whose cwd can't be resolved (e.g. a web-originated
     // session with no bound directory) leaves `{{workingDirectory}}` unmatched and
-    // leaks the literal into the local-system system prompt (LOBE-11473).
+    // leaks the literal into the local-system system prompt.
     workingDirectory: () => '(not specified, use user Home directory as default)',
   };
 };

--- a/apps/server/src/routers/lambda/__tests__/agent.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/agent.test.ts
@@ -582,7 +582,7 @@ describe('agentRouter', () => {
       expect(agentModelMock.setVisibility).toHaveBeenCalledWith('agent-1', 'private');
     });
 
-    it('rejects demotion while the agent supervises group chats visible to others (LOBE-11772)', async () => {
+    it('rejects demotion while the agent supervises group chats visible to others ', async () => {
       chatGroupModelMock.countGroupsBlockingAgentDemotion.mockResolvedValue(1);
 
       const caller = agentRouter.createCaller(wsCtx());
@@ -598,7 +598,7 @@ describe('agentRouter', () => {
       expect(agentModelMock.setVisibility).not.toHaveBeenCalled();
     });
 
-    it('rejects demotion of another member agent even for a workspace owner (LOBE-11760)', async () => {
+    it('rejects demotion of another member agent even for a workspace owner ', async () => {
       agentModelMock.getAgentVisibilityMeta.mockResolvedValue({
         slug: null,
         userId: 'other-member',

--- a/apps/server/src/routers/lambda/__tests__/connector.syncPluginTools.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/connector.syncPluginTools.test.ts
@@ -259,7 +259,7 @@ describe('connectorRouter.create — sourceType handling on existing rows', () =
   });
 });
 
-describe('connectorRouter.delete — agent connector unpins from the owning agent (LOBE-11682)', () => {
+describe('connectorRouter.delete — agent connector unpins from the owning agent ', () => {
   // Deleting an agent-owned connector must also remove its tool from that
   // agent's `plugins`, so the unified settings delete matches the agent-profile
   // delete (row + pin) and never leaves a dangling pin. Done server-side so the
@@ -334,7 +334,7 @@ describe('connectorRouter.delete — agent connector unpins from the owning agen
   });
 });
 
-describe('connectorRouter.listAgentBound — hides connectors of unseen agents (LOBE-11681)', () => {
+describe('connectorRouter.listAgentBound — hides connectors of unseen agents ', () => {
   // `queryAllAgentScoped` filters only by `workspace_id`, so a member could
   // otherwise see connectors owned by another member's PRIVATE agent. Gate the
   // result on the visibility-aware agent set (`getAgentAvatarsByIds`).

--- a/apps/server/src/routers/lambda/_helpers/resourceConfigGuard.test.ts
+++ b/apps/server/src/routers/lambda/_helpers/resourceConfigGuard.test.ts
@@ -43,7 +43,7 @@ beforeEach(() => {
 });
 
 describe('getResourceConfigAccess', () => {
-  // LOBE-12374: builtins are `virtual: true`, so linking one into a group made the
+  // builtins are `virtual: true`, so linking one into a group made the
   // parent cap reduce `full` to `profile` — the config was redacted and the route
   // redirected exactly as before the fix. The evaluator alone cannot show this.
   it('does not cap a collaborative builtin at its parent group access', async () => {

--- a/apps/server/src/routers/lambda/_helpers/resourceConfigGuard.ts
+++ b/apps/server/src/routers/lambda/_helpers/resourceConfigGuard.ts
@@ -93,7 +93,7 @@ export const getResourceConfigAccess = async (
   // Collaborative builtins (Lobe AI, the builders, the page agent) are workspace
   // infrastructure that happens to be `virtual: true`, so linking one into a group
   // would otherwise cap its config access at that group's level — reinstating the
-  // lockout this whole change removes (LOBE-12374). They are not group-owned
+  // lockout this whole change removes. They are not group-owned
   // content, so the parent cap does not apply to them.
   if (isCollaborativeBuiltinAgent(resourceType, meta)) return ownAccess;
 

--- a/apps/server/src/routers/lambda/agent.ts
+++ b/apps/server/src/routers/lambda/agent.ts
@@ -169,7 +169,7 @@ export const agentRouter = router({
    * Publish a private agent into the workspace. Only the creator of a
    * still-private agent can run this; the underlying SQL enforces both rules.
    * The inverse transition (public → private) goes through
-   * `setAgentVisibility`, which is gated to the creator only (LOBE-11760).
+   * `setAgentVisibility`, which is gated to the creator only.
    */
   publishAgentToWorkspace: agentProcedure
     .use(withScopedPermission('agent:update'))
@@ -193,11 +193,11 @@ export const agentRouter = router({
     }),
 
   /**
-   * Bidirectional visibility switch (LOBE-11551). Rules:
+   * Bidirectional visibility switch. Rules:
    * - builtin agents (LobeAI etc., identified by slug) can never change
    *   visibility — the workspace copy must stay shared;
    * - only the agent's creator may pull a published agent back to private
-   *   (LOBE-11760): a workspace owner demoting another member's agent would
+   *: a workspace owner demoting another member's agent would
    *   effectively appropriate it, so everyone else gets FORBIDDEN. The UI
    *   hides the entry for them, this is the server-side backstop.
    */
@@ -287,7 +287,7 @@ export const agentRouter = router({
       // Same source-level guard for group chats, but only for the supervisor
       // role: a private supervisor is unresolvable for every other viewer and
       // bricks the whole group. Regular members are not blocked — roster
-      // reads drop a non-visible member per viewer instead (LOBE-11772).
+      // reads drop a non-visible member per viewer instead.
       if (input.visibility === 'private') {
         const chatGroupModel = new ChatGroupModel(ctx.serverDB, ctx.userId, ctx.workspaceId);
         const blockingGroups = await chatGroupModel.countGroupsBlockingAgentDemotion(

--- a/apps/server/src/routers/lambda/connector.ts
+++ b/apps/server/src/routers/lambda/connector.ts
@@ -201,7 +201,7 @@ export const connectorRouter = router({
    * `agentId` and is enriched with the owning agent's `agentTitle`/`agentAvatar`
    * for attribution badges. Scope-correct via `ConnectorModel.ownership()` (and
    * `AgentModel.ownership()` for the titles) — a workspace context only returns
-   * that workspace's agent connectors (LOBE-11681 / LOBE-11682).
+   * that workspace's agent connectors ( /).
    */
   listAgentBound: connectorProcedure.query(async ({ ctx }) => {
     const connectors = await ctx.connectorModel.queryAllAgentScoped();
@@ -218,7 +218,7 @@ export const connectorRouter = router({
     // plus their own private agents. A `user_connectors` row is scoped only by
     // `workspace_id`, so on its own it would surface connectors owned by another
     // member's PRIVATE agent. Gate on the visible-agent set so private-agent
-    // connector inventory never leaks across members (LOBE-11681).
+    // connector inventory never leaks across members.
     const agentMetas = agentIds.length > 0 ? await agentModel.getAgentAvatarsByIds(agentIds) : [];
     const agentMetaById = new Map(agentMetas.map((m) => [m.id, m]));
 

--- a/apps/server/src/routers/lambda/device.ts
+++ b/apps/server/src/routers/lambda/device.ts
@@ -1144,7 +1144,7 @@ export const deviceRouter = router({
    * Publish a private workspace device to the shared pool, or pull a public one
    * back to private. Mirrors the agent/file `setVisibility` contract:
    *   - the enrolling member may toggle their own device both ways;
-   *   - nobody else may touch visibility (LOBE-11760): owners demoting another
+   * - nobody else may touch visibility: owners demoting another
    *     member's public device would appropriate it into that member's private
    *     list, and other members' private devices are invisible to everyone
    *     else by design (the lookup below already fails closed with NOT_FOUND),

--- a/apps/server/src/routers/lambda/task.ts
+++ b/apps/server/src/routers/lambda/task.ts
@@ -1105,7 +1105,7 @@ export const taskRouter = router({
         // The creator can always change visibility on their own tasks. In
         // workspace mode, workspace owners may still promote other members'
         // tasks (mirrors the transferTask policy at line ~1166), but demoting
-        // to private stays creator-only (LOBE-11760): the task would land in
+        // to private stays creator-only: the task would land in
         // the creator's private list, so an owner-initiated demotion just
         // appropriates another member's data.
         if (ctx.workspaceId && resolved.createdByUserId !== ctx.userId) {

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.spineAnchor.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.spineAnchor.test.ts
@@ -153,7 +153,7 @@ const assistantMessageCall = () =>
   mockMessageCreate.mock.calls.find((call) => call[0].role === 'assistant');
 
 /**
- * Regression coverage for LOBE-11489: a user turn persisted with
+ * Regression coverage for a user turn persisted with
  * `parentId: undefined` into a non-empty topic becomes a second ROOT. The
  * renderer walks the parentId forest depth-first, so an earlier root's
  * still-growing subtree is emitted before a later root and the newest reply

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1792,7 +1792,7 @@ export class AiAgentService {
     // undefined for a topic that already has messages: `parentId: undefined`
     // persists a second ROOT, and the renderer walks the parentId forest
     // depth-first — an earlier root's still-growing subtree is emitted before a
-    // later root, so the newest reply lands ABOVE older messages (LOBE-11489).
+    // later root, so the newest reply lands ABOVE older messages.
     //
     // `getLatestSpineMessageId` skips tool rows and toolless signal turns, so it
     // can come back empty on a topic built entirely from signal callbacks; fall
@@ -1981,7 +1981,7 @@ export class AiAgentService {
         agentConfig.agencyConfig?.heterogeneousProvider?.env?.GITHUB_CRED_KEY ?? 'github';
       try {
         // Inside a workspace, the GitHub cred must come from the workspace's shared
-        // organization credentials, not the operator's personal creds (LOBE-10978).
+        // organization credentials, not the operator's personal creds.
         const credsAccessor = this.workspaceId
           ? this.marketService.market.organizations.creds({ workspaceId: this.workspaceId })
           : this.marketService.market.creds;
@@ -2902,7 +2902,7 @@ export class AiAgentService {
             await getScopedOnlineDevices(this.db, this.userId, this.workspaceId)
           ).filter((d) => d.online);
           // A workspace agent whose caller pinned this desktop's personal
-          // deviceId via `users.preference.agentDeviceOverrides` (LOBE-11689,
+          // deviceId via `users.preference.agentDeviceOverrides` (
           // the `local` code path in `useSelectExecutionTarget`) needs its
           // personal device to be visible in this run's device pool — otherwise
           // `resolveExecutionPlan` treats the bound device as offline and the
@@ -3047,7 +3047,7 @@ export class AiAgentService {
       const deviceLocked = isDeviceLockedPlan(executionPlan);
       activeDeviceId = executionPlan.kind === 'device' ? executionPlan.deviceId : undefined;
       // Which principal pool the routed device lives in. A workspace run with a
-      // per-user `local` override (LOBE-11689) routes to the caller's PERSONAL
+      // per-user `local` override routes to the caller's PERSONAL
       // device — the union above added it from the personal pool — and the
       // device runtimes must address it via `(userId, deviceId)`, not the
       // `workspace:<id>` pool where it has no connection. Carried through

--- a/apps/server/src/services/bot/AgentBridgeService.ts
+++ b/apps/server/src/services/bot/AgentBridgeService.ts
@@ -738,7 +738,7 @@ export class AgentBridgeService {
     const timezone = await this.loadTimezone();
 
     // Make sure the person who triggered the run is a member of the reply
-    // thread, so the platform notifies them when the reply lands (LOBE-11632:
+    // thread, so the platform notifies them when the reply lands (
     // Discord's auto-created mention threads never add the mentioning user,
     // and pill rendering on the origin message proved unreliable — replies
     // were delivered but nobody was told). Fire-and-forget; never blocks.

--- a/apps/server/src/services/bot/BotCallbackService.ts
+++ b/apps/server/src/services/bot/BotCallbackService.ts
@@ -460,7 +460,7 @@ export class BotCallbackService {
     const hasAttachments = !!attachments?.length;
     if (!hasText && !hasAttachments) {
       // console (not debug) — every one of these is a user-facing "bot went
-      // silent" (LOBE-11632): the run completed but the completion event
+      // silent": the run completed but the completion event
       // carried nothing to deliver. Must stay visible in production logs.
       console.error(
         `[BotCallbackService] completion had no lastAssistantContent and no attachments, skipping reply (operationId=${operationId}, topicId=${body.topicId}, thread=${body.platformThreadId})`,
@@ -542,7 +542,7 @@ export class BotCallbackService {
         await messenger.editMessage(progressMessageId, payload);
         // Positive delivery record (console, not debug): "we sent it and the
         // platform accepted it" must be provable from production logs alone —
-        // LOBE-11632 burned days on inferring delivery from the absence of
+        // burned days on inferring delivery from the absence of
         // error logs while the target thread had been deleted out from under
         // the bot.
         console.info(
@@ -558,7 +558,7 @@ export class BotCallbackService {
       console.info('[BotCallbackService] completion reply delivered via createMessage');
     } catch (error) {
       // Last resort failed — the reply is lost. console (not debug) so the
-      // "agent ran but no reply appeared" class of failures (LOBE-11632)
+      // "agent ran but no reply appeared" class of failures 
       // is visible in production logs instead of an HTTP 200 with nothing.
       console.error(
         `[BotCallbackService] createMessage fallback failed, reply lost: ${describePlatformError(error)}`,

--- a/apps/server/src/services/bot/__tests__/BotMessageRouter.test.ts
+++ b/apps/server/src/services/bot/__tests__/BotMessageRouter.test.ts
@@ -1967,7 +1967,7 @@ describe('BotMessageRouter', () => {
 
   describe('rejection notice visibility (ensureThreadMember)', () => {
     /**
-     * LOBE-12191: on Discord a channel @mention auto-creates a reply
+     * on Discord a channel @mention auto-creates a reply
      * thread and rejection notices are posted there — but the rejected
      * sender was never added to the thread, so they got no notification
      * and perceived the bot as silently ignoring them. Every group-scope

--- a/apps/server/src/services/bot/platforms/discord/api.ts
+++ b/apps/server/src/services/bot/platforms/discord/api.ts
@@ -227,7 +227,7 @@ export class DiscordApi {
   /**
    * Add a user to a thread. Members receive a notification and see the
    * thread in their client regardless of whether the origin message's
-   * thread pill rendered (see LOBE-11632).
+   * thread pill rendered (see).
    */
   async addThreadMember(threadId: string, userId: string): Promise<void> {
     log('addThreadMember: thread=%s, user=%s', threadId, userId);

--- a/apps/server/src/services/bot/platforms/types.ts
+++ b/apps/server/src/services/bot/platforms/types.ts
@@ -212,7 +212,7 @@ export interface PlatformClient {
    * Discord: the auto-created per-mention reply thread never adds the
    * mentioning user as a member — the reply lands in a thread the user is
    * not notified about, and thread-pill rendering on the origin message has
-   * proven unreliable (LOBE-11632: two separate clients showed no pill for
+   * proven unreliable (two separate clients showed no pill for
    * hours while the API said `HAS_THREAD`). Explicit membership bypasses
    * both gaps. Best-effort — implementations must swallow failures.
    *

--- a/apps/server/src/services/composio/index.ts
+++ b/apps/server/src/services/composio/index.ts
@@ -32,7 +32,7 @@ export interface ComposioServiceOptions {
   /**
    * Workspace scope. When set, connector/plugin rows resolve within the team
    * workspace instead of the caller's personal scope (fixes workspace-installed
-   * Composio connectors being invisible at runtime — LOBE-10891).
+   * Composio connectors being invisible at runtime).
    */
   workspaceId?: string;
 }

--- a/apps/server/src/services/resourcePermission/index.test.ts
+++ b/apps/server/src/services/resourcePermission/index.test.ts
@@ -266,7 +266,7 @@ describe('canPerformResourceAction', () => {
     ]);
   });
 
-  // LOBE-12374: workspace-level builtin agents (Lobe AI inbox, the builders) are
+  // workspace-level builtin agents (Lobe AI inbox, the builders) are
   // created lazily by whoever opens the workspace first, so their `user_id` is an
   // accident of timing and they never get a `resource_permissions` row. Members
   // must still be able to configure them.
@@ -507,7 +507,7 @@ describe('canPerformResourceAction', () => {
     });
 
     // Linking the real inbox into an agent group is supported, so a linked builtin
-    // must keep the bypass — excluding group members would reproduce LOBE-12374 for
+    // must keep the bypass — excluding group members would reproduce for
     // that workspace.
     it('keeps the bypass for a builtin that is linked into an agent group', async () => {
       permissionMatchesMock.mockResolvedValue({ hasAllScope: false, hasOwnerScope: true });

--- a/apps/server/src/services/resourcePermission/index.ts
+++ b/apps/server/src/services/resourcePermission/index.ts
@@ -164,7 +164,7 @@ const COLLABORATIVE_BUILTIN_AGENT_SLUGS: ReadonlySet<string> = new Set<string>([
  * `resource_permissions` row is ever written for them (their effective General
  * access falls back to the `use` default). Treating them as creator-owned locks
  * every other member out of the Agent Builder, of Lobe AI's config page, and of
- * the Page Copilot's own settings (LOBE-12374), so they are governed by workspace
+ * the Page Copilot's own settings, so they are governed by workspace
  * capability instead: anyone holding `agent:update:{owner,all}` may
  * read/use/configure them, while destructive and ownership actions (delete /
  * transfer / visibility) stay with the creator and the workspace primary owner.
@@ -181,7 +181,7 @@ const COLLABORATIVE_BUILTIN_AGENT_SLUGS: ReadonlySet<string> = new Set<string>([
  * change and is tracked separately. Group membership is NOT usable as the
  * discriminator: linking the real inbox into an agent group is supported, so
  * excluding linked rows would deny configuration on a legitimately provisioned
- * builtin and reproduce LOBE-12374.
+ * builtin and reproduce.
  */
 export const isCollaborativeBuiltinAgent = (
   resourceType: PermissionResourceType,

--- a/apps/server/src/services/taskLifecycle/index.ts
+++ b/apps/server/src/services/taskLifecycle/index.ts
@@ -91,7 +91,7 @@ export interface TopicCompleteParams {
   operationId: string;
   reason: string; // 'done' | 'error' | 'interrupted' | ...
   // What triggered the run. Manual "run now" failures are ad-hoc and must not
-  // change an automation task's scheduling state (LOBE-11388). Undefined is
+  // change an automation task's scheduling state. Undefined is
   // treated as 'manual' for backward compatibility with older callers.
   runTrigger?: TaskRunTrigger;
   taskId: string;
@@ -247,7 +247,7 @@ export class TaskLifecycleService {
           // 'scheduled' state and clears the live error column. Before clearing
           // it, stamp a durable recovery marker + reset the failure fuse so the
           // recovery is auditable and a later query can still tell the task once
-          // failed — the live `error` alone would silently self-heal (LOBE-11390).
+          // failed — the live `error` alone would silently self-heal.
           await this.recordAutomationRecovery(currentTask);
           await this.taskModel.updateStatus(taskId, 'scheduled', { error: null });
         } else if (!verifyBound && this.taskModel.shouldPauseOnTopicComplete(currentTask)) {
@@ -332,7 +332,7 @@ export class TaskLifecycleService {
         await this.recordAutomationError(currentTask, errorText, runTrigger);
         await this.taskModel.updateStatus(taskId, 'paused', { error: errorText });
       } else if (!isAutomationTick) {
-        // LOBE-11388: a manual "run now" of an automation task failed. This is
+        // a manual "run now" of an automation task failed. This is
         // an ad-hoc debug/backfill run — its failure is NOT a health signal for
         // the automation. Restore the resting 'scheduled' state (the run had
         // flipped it to 'running') so the next scheduled tick still fires, and
@@ -341,7 +341,7 @@ export class TaskLifecycleService {
         await this.recordAutomationError(currentTask, errorText, runTrigger);
         await this.taskModel.updateStatus(taskId, 'scheduled', { error: errorText });
       } else if (currentTask.automationMode === 'schedule') {
-        // LOBE-11389: a scheduled tick failed. A single transient error must not
+        // a scheduled tick failed. A single transient error must not
         // permanently pause a recurring task. Count consecutive failures and
         // only pause once the fuse blows; otherwise keep the task 'scheduled' so
         // the next tick retries. (Heartbeat tasks are handled by
@@ -454,7 +454,7 @@ export class TaskLifecycleService {
     const runCount = await this.taskTopicModel.countByTask(task.id, {
       since: new Date(startedAtIso),
       // Only scheduled ticks consume the quota — manual "run now" invocations
-      // are ad-hoc and must not push the task toward its cap (LOBE-11391).
+      // are ad-hoc and must not push the task toward its cap.
       triggers: ['schedule'],
     });
     return runCount >= maxExecutions;
@@ -464,7 +464,7 @@ export class TaskLifecycleService {
    * Append a failure to the durable lifecycle audit trail
    * (`context.lifecycle`). Unlike the live `tasks.error` column — cleared by
    * the next successful run — this history survives a later success so a missed
-   * fire / prior pause stays diagnosable after the fact (LOBE-11390).
+   * fire / prior pause stays diagnosable after the fact.
    *
    * When `extra.pauseReason` is set, also stamps `lastPausedAt`/`lastPauseReason`
    * (the failure fuse just auto-paused the task). When `extra.consecutiveFailures`

--- a/apps/server/src/services/taskLifecycle/onTopicComplete.test.ts
+++ b/apps/server/src/services/taskLifecycle/onTopicComplete.test.ts
@@ -363,7 +363,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
       expect(updateStatus).toHaveBeenCalledWith('task-1', 'paused', { error: 'boom' });
     });
 
-    it('LOBE-11388: manual run of a schedule task fails → restored to scheduled, NOT paused', async () => {
+    it('manual run of a schedule task fails → restored to scheduled, NOT paused', async () => {
       const task = baseTask({ automationMode: 'schedule', status: 'running' });
       findById.mockResolvedValue(task);
 
@@ -388,7 +388,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
       );
     });
 
-    it('LOBE-11388: undefined runTrigger defaults to manual (backward compat)', async () => {
+    it('undefined runTrigger defaults to manual (backward compat)', async () => {
       const task = baseTask({ automationMode: 'schedule' });
       findById.mockResolvedValue(task);
 
@@ -405,7 +405,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
       expect(updateStatus).toHaveBeenCalledWith('task-1', 'scheduled', { error: 'boom' });
     });
 
-    it('LOBE-11389: scheduled run fails below fuse → stays scheduled + increments failures', async () => {
+    it('scheduled run fails below fuse → stays scheduled + increments failures', async () => {
       const task = baseTask({
         automationMode: 'schedule',
         context: { scheduler: { consecutiveFailures: 1 } } as any,
@@ -431,7 +431,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
       );
     });
 
-    it('LOBE-11389: scheduled run fails AT fuse → pauses for human attention', async () => {
+    it('scheduled run fails AT fuse → pauses for human attention', async () => {
       const task = baseTask({
         automationMode: 'schedule',
         context: { scheduler: { consecutiveFailures: 2 } } as any,
@@ -450,7 +450,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
 
       // 2 prior + this one = 3 = fuse → pause.
       expect(updateStatus).toHaveBeenCalledWith('task-1', 'paused', { error: 'boom' });
-      // Audit trail records the pause reason durably (LOBE-11390).
+      // Audit trail records the pause reason durably.
       expect(updateContext).toHaveBeenCalledWith(
         'task-1',
         expect.objectContaining({
@@ -460,7 +460,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
       );
     });
 
-    it('LOBE-11390: every error appends to the durable lifecycle audit trail', async () => {
+    it('every error appends to the durable lifecycle audit trail', async () => {
       const task = baseTask({
         automationMode: 'schedule',
         context: { lifecycle: { errorCount: 4 } } as any,
@@ -583,7 +583,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
     });
   });
 
-  describe('reason=done recovery audit (LOBE-11390)', () => {
+  describe('reason=done recovery audit ', () => {
     it('successful automation tick after an error stamps lastRecoveredAt + resets fuse', async () => {
       const task = baseTask({
         automationMode: 'schedule',

--- a/apps/server/src/services/taskRunner/index.ts
+++ b/apps/server/src/services/taskRunner/index.ts
@@ -26,7 +26,7 @@ export interface RunTaskParams {
    * What triggered this run. Defaults to `'manual'` — the ad-hoc "run now"
    * path (TRPC `task.run`, agent `runTask` tool). The scheduler ticks pass
    * `'schedule'` / `'heartbeat'` so the lifecycle can tell an ad-hoc run apart
-   * from an automation tick (LOBE-11388/11391).
+   * from an automation tick ().
    */
   trigger?: TaskRunTrigger;
 }
@@ -262,7 +262,7 @@ export class TaskRunnerService {
             // scheduling state is not a per-run health signal. Restore the
             // resting 'scheduled' state so the next tick still fires (this is
             // the sync mirror of the async onTopicComplete error handling —
-            // LOBE-11388/11389). Non-automation (ad-hoc / dependency) tasks keep
+            //). Non-automation (ad-hoc / dependency) tasks keep
             // the legacy pause-for-attention behavior.
             if (failedTask.automationMode) {
               await this.taskModel.updateStatus(failedTask.id, 'scheduled', { error: errorText });

--- a/apps/server/src/services/taskRunner/scheduleTick.test.ts
+++ b/apps/server/src/services/taskRunner/scheduleTick.test.ts
@@ -126,7 +126,7 @@ describe('runScheduleTick', () => {
     const outcome = await runScheduleTick(taskId, userId);
 
     expect(outcome).toEqual({ ran: true, taskIdentifier: 'T-1' });
-    // Quota counts only scheduled ticks, not ad-hoc manual runs (LOBE-11391).
+    // Quota counts only scheduled ticks, not ad-hoc manual runs.
     expect(mockTaskTopicModel.countByTask).toHaveBeenCalledWith(taskId, {
       since: new Date('2026-05-01T00:00:00Z'),
       triggers: ['schedule'],

--- a/apps/server/src/services/taskRunner/scheduleTick.ts
+++ b/apps/server/src/services/taskRunner/scheduleTick.ts
@@ -101,7 +101,7 @@ export async function runScheduleTick(
       const startedAt = new Date(startedAtIso);
       const topicModel = new TaskTopicModel(db, userId, wsId);
       // Only automation ticks count against the quota — ad-hoc manual runs must
-      // not consume scheduled executions (LOBE-11391).
+      // not consume scheduled executions.
       const runCount = await topicModel.countByTask(taskId, {
         since: startedAt,
         triggers: ['schedule'],

--- a/apps/server/src/services/toolExecution/builtin.ts
+++ b/apps/server/src/services/toolExecution/builtin.ts
@@ -140,7 +140,7 @@ export class BuiltinToolsExecutor implements IToolExecutor {
 
     // Route Composio tools to ComposioService. Build it request-scoped: agentId
     // and workspaceId live on the per-call context (not known at construction),
-    // so a workspace run resolves workspace connectors (LOBE-10891) and a
+    // so a workspace run resolves workspace connectors and a
     // service-account agent runs off its own Composio account
     // (Agent > Workspace/Personal).
     if (source === 'composio') {

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/localSystem.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/localSystem.test.ts
@@ -144,7 +144,7 @@ describe('localSystemRuntime', () => {
     });
 
     it('addresses a personal-scope active device via the personal pool even in a workspace run', async () => {
-      // Workspace agent + per-user `local` override (LOBE-11689): the routed
+      // Workspace agent + per-user `local` override: the routed
       // device only has a connection under the personal principal, so the
       // workspace id must NOT be forwarded to the gateway call.
       const context: ToolExecutionContext = {

--- a/apps/server/src/services/toolExecution/serverRuntimes/creds.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/creds.ts
@@ -27,7 +27,7 @@ class ServerCredsService implements ICredsService {
 
   /**
    * Inside a workspace, reads/writes must hit the workspace's shared organization
-   * credentials, never the operator's personal creds (LOBE-10978). Falls back to
+   * credentials, never the operator's personal creds. Falls back to
    * the personal `market.creds` namespace outside a workspace.
    */
   private credsAccessor() {

--- a/apps/server/src/services/toolExecution/serverRuntimes/resolveWorkspaceScope.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/resolveWorkspaceScope.ts
@@ -27,7 +27,7 @@ type DeviceScopeContext = Pick<
  *
  * EXCEPTION: a run whose active device is PERSONAL-scope (a workspace agent
  * routed to the caller's own machine via the per-user `local` override,
- * LOBE-11689) must be addressed through the personal `(userId, deviceId)`
+ *) must be addressed through the personal `(userId, deviceId)`
  * pool — that device has no connection under the `workspace:<id>` principal,
  * so a workspace-addressed call would simply miss it.
  */

--- a/apps/server/src/workflows-hono/task/handlers/__tests__/scheduledTopicDispatch.test.ts
+++ b/apps/server/src/workflows-hono/task/handlers/__tests__/scheduledTopicDispatch.test.ts
@@ -118,7 +118,7 @@ describe('scheduledTopicDispatch', () => {
     expect(mocks.execAgent.mock.calls[0][0]).not.toHaveProperty('resume', true);
     // `suppressUserMessage` writes no user row, so the assistant turn anchors on
     // `parentMessageId` alone — without it the reply persists as a second root and
-    // renders above the prompt it answers (LOBE-11489).
+    // renders above the prompt it answers.
     expect(mocks.execAgent.mock.calls[0][0]).toMatchObject({ parentMessageId: 'user-scheduled' });
     // Success hands the run to execAgent, so the topic leaves `scheduled`.
     expect(mocks.clearScheduledRun).toHaveBeenCalledWith(

--- a/apps/server/src/workflows-hono/task/handlers/scheduledRunKinds.ts
+++ b/apps/server/src/workflows-hono/task/handlers/scheduledRunKinds.ts
@@ -114,7 +114,7 @@ const runDelayedStart: ScheduledRunHandlers['delayed_start'] = async (
     // `suppressUserMessage` creates no user row, so the assistant turn anchors on
     // `parentMessageId` alone. Leave it out and the reply persists as a SECOND
     // root: the renderer walks the parentId forest depth-first, so it would land
-    // above the very prompt it answers (LOBE-11489).
+    // above the very prompt it answers.
     parentMessageId: userMessage.id,
     prompt: userMessage.content ?? '',
     provider: run.provider,

--- a/packages/agent-gateway-client/src/types.ts
+++ b/packages/agent-gateway-client/src/types.ts
@@ -117,7 +117,7 @@ export interface ToolStateChunkData {
  * uiMessages snapshot is resolved BEFORE this row is created, so the snapshot
  * never contains it — without a local insert, every stream_chunk/stream_end
  * dispatch for the step targets a missing id and is silently dropped
- * (LOBE-11501). Older servers send only `{ id }`; clients fall back to a DB
+ *. Older servers send only `{ id}`; clients fall back to a DB
  * refetch in that case.
  */
 export interface StreamStartAssistantMessage {

--- a/packages/const/src/rbac.ts
+++ b/packages/const/src/rbac.ts
@@ -305,7 +305,7 @@ const action = (key: keyof typeof PERMISSION_ACTIONS): string => PERMISSION_ACTI
 /**
  * Permission codes granted to each built-in workspace role. The lists are the
  * runtime source of truth: workspace requests expand the member's
- * `workspace_members.role` through this matrix (LOBE-12329) — no
+ * `workspace_members.role` through this matrix — no
  * per-workspace role/permission rows are stored in the RBAC tables.
  *
  * Scope semantics:
@@ -571,7 +571,7 @@ export const legacyRoleToWorkspaceRole = (role: string): WorkspaceSystemRoleName
  * the in-code matrix. This is the runtime permission source for workspace
  * requests — `workspace_members.role` is the single source of truth for
  * built-in roles and no per-workspace role/permission rows are stored in the
- * RBAC tables (LOBE-12329). Unknown roles expand to an empty set.
+ * RBAC tables. Unknown roles expand to an empty set.
  */
 export const getWorkspaceRolePermissionCodes = (role: string): readonly string[] => {
   const systemRole = legacyRoleToWorkspaceRole(role);

--- a/packages/database/src/models/__tests__/agent.test.ts
+++ b/packages/database/src/models/__tests__/agent.test.ts
@@ -1361,7 +1361,7 @@ describe('AgentModel', () => {
       expect(personalAgent.agencyConfig).toBeNull();
     });
 
-    // LOBE-12374: builtin slugs decide both `getBuiltinAgent` resolution and, for
+    // builtin slugs decide both `getBuiltinAgent` resolution and, for
     // the collaborative ones, workspace-level permissions — a caller-supplied slug
     // must never be able to claim one (group member batch-create, imports, market
     // installs all pass `slug` through).

--- a/packages/database/src/models/__tests__/chatGroup.test.ts
+++ b/packages/database/src/models/__tests__/chatGroup.test.ts
@@ -1336,7 +1336,7 @@ describe('ChatGroupModel', () => {
     });
   });
 
-  describe('member agent demoted to private (LOBE-11772)', () => {
+  describe('member agent demoted to private ', () => {
     // Public workspace group owned by `userId` with two members: a public agent
     // and an agent `userId` switched back to private after it joined. Viewer is
     // `otherUserId` (same workspace) — every roster read must drop the private

--- a/packages/database/src/models/__tests__/connectorAgentScope.test.ts
+++ b/packages/database/src/models/__tests__/connectorAgentScope.test.ts
@@ -352,9 +352,9 @@ describe('ConnectorModel agent-scoped resolution', () => {
 // target connector via `findById` before attaching it, and rely on its scoped
 // `ownership()` filter to reject cross-scope rows — that is what enforces
 // "workspace agent ⇒ workspace-only tools, personal agent ⇒ personal-only"
-// (LOBE-11681). These lock that filter so a future refactor can't silently let
+//. These lock that filter so a future refactor can't silently let
 // a personal connector be bound to a workspace agent (or vice versa).
-describe('ConnectorModel scope isolation (workspace vs personal) — LOBE-11681', () => {
+describe('ConnectorModel scope isolation (workspace vs personal)', () => {
   it('a workspace-scoped model cannot findById a personal connector', async () => {
     const personal = await insertConnector({
       identifier: 'gmail',
@@ -393,10 +393,10 @@ describe('ConnectorModel scope isolation (workspace vs personal) — LOBE-11681'
   });
 });
 
-// `queryAllAgentScoped` powers the unified connector-settings page (LOBE-11682):
+// `queryAllAgentScoped` powers the unified connector-settings page:
 // it lists every agent-OWNED connector across all agents in one scope, and must
-// stay scope-correct (no personal↔workspace leak — the LOBE-11681 invariant).
-describe('ConnectorModel.queryAllAgentScoped — LOBE-11682', () => {
+// stay scope-correct (no personal↔workspace leak — the invariant).
+describe('ConnectorModel.queryAllAgentScoped', () => {
   it('returns agent-owned rows across all agents and excludes base rows', async () => {
     const ownedA = await insertConnector({ agentId: agentA, identifier: 'gmail', name: 'A' });
     const ownedB = await insertConnector({ agentId: agentB, identifier: 'slack', name: 'B' });

--- a/packages/database/src/models/__tests__/jsonbNullTest.test.ts
+++ b/packages/database/src/models/__tests__/jsonbNullTest.test.ts
@@ -21,7 +21,7 @@ import { describe, expect, it } from 'vitest';
  *   (metadata ->> 'x') IS NOT NULL          → COALESCE(metadata ->> 'x', '') <> ''
  *   (metadata ->> 'x') IS DISTINCT FROM 'y' → COALESCE(metadata ->> 'x', '') <> 'y'
  *
- * Prior casualties: `getLatestSpineMessageId` (LOBE-11376, #16693),
+ * Prior casualties: `getLatestSpineMessageId` (#16693),
  * `getDueScheduledTopics` (#17077).
  */
 const FORBIDDEN = /(?:->>?|#>>?)[^\n]*?\b(?:IS\s+(?:NOT\s+)?NULL|IS\s+DISTINCT\s+FROM)\b/i;

--- a/packages/database/src/models/__tests__/messages/message.query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.query.test.ts
@@ -439,7 +439,7 @@ describe('MessageModel Query Tests', () => {
       expect(result3).toHaveLength(0);
     });
 
-    describe('newest-first pagination (LOBE-12011)', () => {
+    describe('newest-first pagination ', () => {
       // A topic whose mainline exceeds pageSize must keep its LATEST turns
       // (including the final answer) rather than the oldest, and the returned
       // slice must be a single contiguous parentId chain so the renderer — which
@@ -1233,7 +1233,7 @@ describe('MessageModel Query Tests', () => {
           current: 0,
           pageSize: 2,
         });
-        // Page 0 returns the NEWEST page (LOBE-12011), re-sorted ascending: the
+        // Page 0 returns the NEWEST page, re-sorted ascending: the
         // two most recent messages, not the two oldest.
         expect(result1).toHaveLength(2);
         expect(result1[0].id).toBe('msg-page-2');
@@ -3299,7 +3299,7 @@ describe('MessageModel Query Tests', () => {
 
   // Fallback anchor used when `getLatestSpineMessageId` comes back empty. Without
   // it a new user turn is persisted as a second root and the renderer emits the
-  // newest reply above older messages (LOBE-11489).
+  // newest reply above older messages.
   describe('getLatestNonToolMessageId', () => {
     it('returns a toolless signal turn that the spine query skips', async () => {
       await serverDB.insert(sessions).values([{ id: 'session1', userId }]);

--- a/packages/database/src/models/__tests__/task.test.ts
+++ b/packages/database/src/models/__tests__/task.test.ts
@@ -245,7 +245,7 @@ describe('TaskModel', () => {
 
     // Non-tool deletion (UI / CLI) must leave the Work artifact orphaned so the
     // UI can render it as "resource deleted" from its snapshot. Tool-driven
-    // deletion removes the Work separately at the dispatch layer (LOBE-11606).
+    // deletion removes the Work separately at the dispatch layer.
     it('should NOT delete the task Work artifact', async () => {
       const model = new TaskModel(serverDB, userId);
       const workModel = new WorkModel(serverDB, userId);

--- a/packages/database/src/models/__tests__/taskTopic.test.ts
+++ b/packages/database/src/models/__tests__/taskTopic.test.ts
@@ -274,7 +274,7 @@ describe('TaskTopicModel', () => {
     });
 
     it('only counts the requested triggers, excluding manual + legacy-null rows', async () => {
-      // LOBE-11391: the maxExecutions quota must count scheduled ticks only —
+      // the maxExecutions quota must count scheduled ticks only —
       // manual "run now" invocations and legacy rows (null trigger) don't count.
       const taskModel = new TaskModel(serverDB, userId);
       const topicModel = new TaskTopicModel(serverDB, userId);

--- a/packages/database/src/models/__tests__/topics/topic.query.test.ts
+++ b/packages/database/src/models/__tests__/topics/topic.query.test.ts
@@ -213,7 +213,7 @@ describe('TopicModel - Query', () => {
       // The client sorts the sidebar by `sortUpdatedAt`, so it must carry the same
       // activity time the server ORDER BY uses (topicActivityAt) — otherwise the two
       // sorts disagree and the list jumps. `updatedAt` stays the raw row value so
-      // rename/favorite edits still show a real edit time. (LOBE-11543)
+      // rename/favorite edits still show a real edit time. 
       await serverDB.insert(topics).values([
         { id: 'has-msg', sessionId, updatedAt: new Date('2023-01-01'), userId },
         { id: 'no-msg', sessionId, updatedAt: new Date('2023-03-01'), userId },

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -1010,7 +1010,7 @@ export class AgentModel {
    * `visibility = 'private'` guards lock the operation to the creator's own
    * still-private agent. The inverse transition (public → private) goes
    * through {@link setVisibility}, which the router gates to the creator or
-   * a workspace owner (LOBE-11551).
+   * a workspace owner.
    *
    * Use the existing `update` to change other fields; visibility is the only
    * one with these authorization rules.
@@ -1078,7 +1078,7 @@ export class AgentModel {
   };
 
   /**
-   * Bidirectional visibility switch (LOBE-11551). Authorization (creator OR
+   * Bidirectional visibility switch. Authorization (creator OR
    * workspace owner, builtin agents excluded) is the router's responsibility —
    * this method only applies the ownership-scoped write.
    *

--- a/packages/database/src/models/chatGroup.ts
+++ b/packages/database/src/models/chatGroup.ts
@@ -38,7 +38,7 @@ export class ChatGroupModel {
    * (the junction row) does not grant access to the agent: when a member agent
    * is switched back to private by its owner, every roster read must drop it
    * for other members — otherwise the join would keep leaking the agent's
-   * config/meta through group surfaces (LOBE-11772).
+   * config/meta through group surfaces.
    */
   private memberAgentVisibility = () =>
     buildWorkspaceWhere(

--- a/packages/database/src/models/connector.ts
+++ b/packages/database/src/models/connector.ts
@@ -225,14 +225,14 @@ export class ConnectorModel {
   /**
    * All agent-OWNED connector rows (`agent_id IS NOT NULL`) within the current
    * scope — i.e. every connector that belongs to some agent, across all agents.
-   * Powers the unified connector-settings view (LOBE-11682) which lists "which
+   * Powers the unified connector-settings view which lists "which
    * connector is bound to which agent" in one place, instead of one agent at a
    * time via {@link queryByAgent}.
    *
    * Scope-correct by construction: {@link ownership} carries the `workspace_id`
    * predicate, so in a workspace context this only returns rows owned by that
    * workspace's agents and never leaks personal-dimension rows (and vice versa)
-   * — the LOBE-11681 invariant applied to the aggregate view. Mounted/linked
+   * — the invariant applied to the aggregate view. Mounted/linked
    * base rows (`agent_id IS NULL`) are intentionally excluded; they already show
    * under the base {@link query} list.
    */

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -692,7 +692,7 @@ export class MessageModel {
           // `asc + limit` truncated exactly the newest batch, which is the worst
           // possible slice for a chat transcript. The page is reversed back to
           // ascending immediately below, so every downstream consumer is
-          // unaffected; only *which* rows are fetched changed. See LOBE-12011.
+          // unaffected; only *which* rows are fetched changed. See.
           .orderBy(desc(messages.createdAt), desc(messages.id))
           .limit(pageSize)
           .offset(offset),
@@ -715,7 +715,7 @@ export class MessageModel {
     //
     // Scope: this only serves the single "most recent page" load (`current === 0`),
     // which is the only page the chat read path ever requests — `current`/`pageSize`
-    // offset paging is dead code here (the very premise of LOBE-12011). The trim is
+    // offset paging is dead code here (the very premise of). The trim is
     // deliberately NOT offset-exact: the rows it drops from page 0 also fall outside
     // page 1's `offset = pageSize` window, so a hypothetical offset walk would skip
     // them. That is acceptable because nothing offset-walks this path; loading older
@@ -3074,7 +3074,7 @@ export class MessageModel {
    * persist the new turn with `parentId: undefined` — a second root that forks
    * the conversation tree. The renderer walks that forest depth-first, so an
    * earlier root's long-running subtree gets emitted before a later root and the
-   * newest reply surfaces ABOVE older messages (LOBE-11489).
+   * newest reply surfaces ABOVE older messages.
    *
    * `role:'tool'` stays excluded: tool results are inline children of their
    * assistant turn, and anchoring a normal turn onto one orphans it under the

--- a/packages/database/src/models/rbac.ts
+++ b/packages/database/src/models/rbac.ts
@@ -21,7 +21,7 @@ export interface UserPermissionInfo {
  *   member's `workspace_members.role` expanded through the in-code
  *   `WORKSPACE_ROLE_PERMISSIONS` matrix, plus globally-granted DB roles
  *   (`rbac_user_roles.workspace_id IS NULL`, e.g. `super_admin`). No
- *   per-workspace authorization rows are read (LOBE-12329).
+ * per-workspace authorization rows are read.
  * - `workspaceId` omitted — match **any** DB grant, regardless of workspace.
  *   This preserves backward-compat with pre-workspace-scope callers (Hono
  *   routes that just check `agent:read:all` against the whole user, with

--- a/packages/database/src/models/task.ts
+++ b/packages/database/src/models/task.ts
@@ -252,7 +252,7 @@ export class TaskModel {
    * lifecycle is driven by the deleteTask tool call at the tool-execution
    * dispatch layer (which calls `WorkModel.deleteTaskWork`), so non-tool deletes
    * (UI / CLI / deleteAll) deliberately leave the Work as an orphan for the UI
-   * to render as "resource deleted" from its version snapshot. See LOBE-11606.
+   * to render as "resource deleted" from its version snapshot. See.
    */
   async delete(id: string): Promise<boolean> {
     const deleted = await this.db
@@ -265,7 +265,7 @@ export class TaskModel {
 
   /**
    * Move a task and its full subtree to a new visibility (both directions —
-   * LOBE-11551 added the `public → private` demotion; the router gates who
+   * added the `public → private` demotion; the router gates who
    * may call it).
    *
    * Cascades inside a single transaction:

--- a/packages/database/src/models/taskTopic.ts
+++ b/packages/database/src/models/taskTopic.ts
@@ -221,7 +221,7 @@ export class TaskTopicModel {
    * source.
    *
    * `triggers` filters on the `trigger` column so the maxExecutions quota can
-   * count only automation ticks and ignore ad-hoc manual runs (LOBE-11391).
+   * count only automation ticks and ignore ad-hoc manual runs.
    * Legacy rows have a NULL trigger; they are excluded whenever `triggers` is
    * passed (they predate the column and can't be attributed to a schedule).
    */

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -222,7 +222,7 @@ const buildTopicOrderBy = (topicActivityAt: SQL, sortBy?: TopicQuerySortBy): SQL
  * COALESCE(metadata ->> 'status', '') <> 'done'                   -- IS DISTINCT FROM
  * ```
  *
- * This has now bitten twice: `getLatestSpineMessageId` (LOBE-11376, #16693) and
+ * This has now bitten twice: `getLatestSpineMessageId` (#16693) and
  * `getDueScheduledTopics` (#17077 — the scheduled-run cron crashed on every tick
  * from the day it shipped, so rate-limit continuations never once resumed).
  */
@@ -384,7 +384,7 @@ export class TopicModel {
                 // display `updatedAt` above matches the client-side sort key to the server
                 // order (otherwise the two disagree and the list visibly jumps) while a
                 // rename/favorite edit still shows its real edit time. See rankTopics for
-                // the same activity-time pattern. (LOBE-11543)
+                // the same activity-time pattern. 
                 sortUpdatedAt: topicActivityAt,
                 // Workspace sidebars filter maintenance actions client-side by
                 // ownership (own vs workspace scope) — the filter needs the row
@@ -460,7 +460,7 @@ export class TopicModel {
                 // display `updatedAt` above matches the client-side sort key to the server
                 // order (otherwise the two disagree and the list visibly jumps) while a
                 // rename/favorite edit still shows its real edit time. See rankTopics for
-                // the same activity-time pattern. (LOBE-11543)
+                // the same activity-time pattern. 
                 sortUpdatedAt: topicActivityAt,
                 // Workspace sidebars filter maintenance actions client-side by
                 // ownership (own vs workspace scope) — the filter needs the row
@@ -532,7 +532,7 @@ export class TopicModel {
               // display `updatedAt` above matches the client-side sort key to the server
               // order (otherwise the two disagree and the list visibly jumps) while a
               // rename/favorite edit still shows its real edit time. See rankTopics for
-              // the same activity-time pattern. (LOBE-11543)
+              // the same activity-time pattern. 
               sortUpdatedAt: topicActivityAt,
               // Workspace sidebars filter maintenance actions client-side by
               // ownership (own vs workspace scope) — the filter needs the row

--- a/packages/database/src/models/work/__tests__/task.test.ts
+++ b/packages/database/src/models/work/__tests__/task.test.ts
@@ -707,7 +707,7 @@ describe('WorkModel · task', () => {
     });
 
     // Tool-driven deletion: the task row is removed first, then the dispatch
-    // layer drops the Work by its internal id (LOBE-11606).
+    // layer drops the Work by its internal id.
     await taskModel.delete(task.id);
     await workModel.deleteTaskWork({ taskId: task.id });
 

--- a/packages/database/src/models/work/githubToolResult.ts
+++ b/packages/database/src/models/work/githubToolResult.ts
@@ -22,7 +22,7 @@ import {
 type GithubWorkEntityType = 'issue' | 'pull_request';
 
 /**
- * Only successful create/edit results become Works (LOBE-10967): read-only
+ * Only successful create/edit results become Works: read-only
  * queries (get/list/search), comments, and branch/repo operations are
  * intentionally excluded, mirroring the Linear adaptation.
  *

--- a/packages/database/src/models/workspace.ts
+++ b/packages/database/src/models/workspace.ts
@@ -34,7 +34,7 @@ const getActiveMembershipRole = async (
 /**
  * Whether `userId` currently holds owner status in `workspaceId`.
  * `workspace_members.role` is the single source of truth for built-in roles
- * (LOBE-12329). Used by the workspace-API-key owner gates on both the OpenAPI
+ *. Used by the workspace-API-key owner gates on both the OpenAPI
  * and lambda TRPC surfaces.
  */
 export const hasWorkspaceOwnerAccess = async (
@@ -84,7 +84,7 @@ export class WorkspaceModel {
         .returning();
 
       // `workspace_members.role` is the single source of truth for built-in
-      // workspace roles (LOBE-12329) — no RBAC rows are seeded per workspace.
+      // workspace roles — no RBAC rows are seeded per workspace.
       await tx.insert(workspaceMembers).values({
         role: 'owner',
         userId: this.userId,

--- a/packages/database/src/repositories/agentGroup/index.test.ts
+++ b/packages/database/src/repositories/agentGroup/index.test.ts
@@ -360,7 +360,7 @@ describe('AgentGroupRepository', () => {
       ]);
     });
 
-    describe('member agent demoted to private (LOBE-11772)', () => {
+    describe('member agent demoted to private ', () => {
       const workspaceId = 'agent-group-demotion-ws';
 
       beforeEach(async () => {

--- a/packages/database/src/repositories/agentGroup/index.ts
+++ b/packages/database/src/repositories/agentGroup/index.ts
@@ -332,7 +332,7 @@ export class AgentGroupRepository {
     // flag: supervisor existence must be judged on the raw rows — otherwise a
     // viewer who can't see the supervisor would auto-create a duplicate one
     // below — while a member agent switched back to private must not leak its
-    // config to other members (LOBE-11772), so only visible rows are returned.
+    // config to other members, so only visible rows are returned.
     const groupAgentsWithDetails = await this.db
       .select({
         agent: agents,

--- a/packages/database/src/repositories/home/__tests__/workspaceHeteroVisibility.test.ts
+++ b/packages/database/src/repositories/home/__tests__/workspaceHeteroVisibility.test.ts
@@ -1,4 +1,4 @@
-// Regression for LOBE-11758: a workspace heterogeneous agent flipped back to
+// Regression for a workspace heterogeneous agent flipped back to
 // `private` must stay visible to its creator (Private bucket) and invisible
 // to other members across the whole sidebar payload.
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -31,7 +31,7 @@ afterEach(async () => {
   await clientDB.delete(Schema.workspaces);
 });
 
-describe('workspace hetero agent visibility flip (LOBE-11758)', () => {
+describe('workspace hetero agent visibility flip ', () => {
   it('hetero agent stays visible to creator after public -> private', async () => {
     const agentModel = new AgentModel(clientDB, creator, ws);
 

--- a/packages/database/src/schemas/task.ts
+++ b/packages/database/src/schemas/task.ts
@@ -238,7 +238,7 @@ export const taskTopics = pgTable(
     // What triggered this run: 'manual' (ad-hoc run-now / agent tool call),
     // 'schedule' (cron tick) or 'heartbeat' (interval tick). Null for legacy
     // rows created before this column existed. Used so the maxExecutions quota
-    // counts only automation ticks, not manual runs (LOBE-11391).
+    // counts only automation ticks, not manual runs.
     trigger: text('trigger').$type<'manual' | 'schedule' | 'heartbeat'>(),
 
     // Handoff (populated after topic completes via LLM summarization)

--- a/packages/openapi/src/middleware/workspace.test.ts
+++ b/packages/openapi/src/middleware/workspace.test.ts
@@ -246,7 +246,7 @@ describe('OpenAPI workspace middleware', () => {
   });
 
   it('gates on membership.role alone — stale RBAC rows have no effect', async () => {
-    // membership.role is the single source of truth (LOBE-12329): an Admin
+    // membership.role is the single source of truth: an Admin
     // membership passes regardless of whatever legacy rbac_user_roles claim.
     mockWorkspaceMembersFindFirst.mockResolvedValueOnce({ role: 'admin' });
     const app = createApp({ apiKeyWorkspaceId: 'workspace-1', authType: 'apikey' });

--- a/packages/openapi/src/middleware/workspace.ts
+++ b/packages/openapi/src/middleware/workspace.ts
@@ -83,7 +83,7 @@ export const workspaceAuthMiddleware = async (c: Context, next: Next) => {
 
   if (c.get('authType') === 'apikey') {
     // `workspace_members.role` is the single source of truth for built-in
-    // workspace roles (LOBE-12329).
+    // workspace roles.
     const isWorkspaceAdmin = membership.role === 'owner' || membership.role === 'admin';
 
     if (!isWorkspaceAdmin) {

--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -498,7 +498,7 @@ export interface ChatTopic extends Omit<BaseDataModel, 'meta'> {
    * (server `topicActivityAt`), falling back to `updatedAt`. Kept separate from
    * `updatedAt` so the client sort matches the server ORDER BY (no list jumping)
    * while `updatedAt` still reflects real row edits like rename/favorite.
-   * (LOBE-11543)
+   * 
    */
   sortUpdatedAt?: number;
   status?: ChatTopicStatus | null;

--- a/packages/utils/src/client/topic.test.ts
+++ b/packages/utils/src/client/topic.test.ts
@@ -226,7 +226,7 @@ describe('groupTopicsByUpdatedTime', () => {
     const today = dayjs().valueOf();
 
     // Row was edited last year (updatedAt) but had message activity today
-    // (sortUpdatedAt) — the sidebar must group it under "today". (LOBE-11543)
+    // (sortUpdatedAt) — the sidebar must group it under "today". 
     const topic: ChatTopic = {
       id: 'active',
       title: 'Recently active',

--- a/packages/utils/src/client/topic.ts
+++ b/packages/utils/src/client/topic.ts
@@ -75,7 +75,7 @@ const sortGroups = (groups: GroupedTopic[]): GroupedTopic[] => {
  * Resolve the timestamp a topic sorts/groups by for the given field. For
  * `updatedAt` this is the server-provided `sortUpdatedAt` (latest message
  * activity), falling back to the raw `updatedAt` when absent — so the sidebar
- * order matches the server ORDER BY and doesn't jump. (LOBE-11543)
+ * order matches the server ORDER BY and doesn't jump. 
  */
 export const getTopicSortTime = (topic: ChatTopic, field: 'createdAt' | 'updatedAt'): number =>
   field === 'updatedAt' ? (topic.sortUpdatedAt ?? topic.updatedAt) : topic.createdAt;

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.test.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.test.tsx
@@ -161,7 +161,7 @@ describe('TaskDetailHeaderActions', () => {
     expect(mocks.dropdownItems.map((item) => item?.key)).toContain('makePrivate');
   });
 
-  it('hides "make private" from a workspace owner who is not the creator (LOBE-11760)', () => {
+  it('hides "make private" from a workspace owner who is not the creator ', () => {
     mocks.isWorkspaceOwner = true;
     mocks.taskState.taskDetailMap = {
       'T-1': { createdByUserId: 'someone-else', visibility: 'public' },

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.tsx
@@ -150,8 +150,8 @@ const TaskDetailHeaderActions = memo(() => {
           }
         : null;
 
-    // Inverse transition (LOBE-11551): only the task creator can pull a
-    // published task back to private (LOBE-11760 — an owner demoting another
+    // Inverse transition: only the task creator can pull a
+    // published task back to private ( — an owner demoting another
     // member's task would appropriate it into the creator's private list);
     // everyone else doesn't see the entry at all (the server enforces the
     // same rule as a backstop).

--- a/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
@@ -324,7 +324,7 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
   const agentWorkspaceId = useAgentStore((s) => s.agentMap[agentId]?.workspaceId);
   const isWorkspaceAgent = Boolean(agentWorkspaceId);
 
-  // Shared config merged with the caller's per-agent override (LOBE-11689) —
+  // Shared config merged with the caller's per-agent override —
   // the hook eagerly fetches the `workspaceUserSettings` bucket on mount so
   // what the picker shows and what dispatch will actually do always agree.
   const {
@@ -349,7 +349,7 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
 
   // Workspace-keyed SWR fetch — the raw lambdaQuery key has no workspace
   // dimension, so the picker kept showing the previous workspace's pool after
-  // a switch (LOBE-11904).
+  // a switch.
   const { data: devices, isLoading } = useDeviceList();
 
   // The current machine's own gateway deviceId (desktop only), used to badge the
@@ -403,7 +403,7 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
 
   // Auto-default to THIS desktop's local execution on first open, for both
   // personal and workspace agents (workspace behaviour used to be a hostname
-  // lookup against the workspace device pool — see LOBE-11647 — but with
+  // lookup against the workspace device pool — see — but with
   // per-user overrides that lookup is unnecessary: `useSelectExecutionTarget`
   // resolves `'local'` to this desktop's personal gateway `deviceId` and, for
   // a workspace agent, persists it into `users.preference.agentDeviceOverrides`,
@@ -454,7 +454,7 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
   //   (per-user `sha256(machineUUID + userId)` vs
   //   `sha256(machineUUID + workspace:<id>)`), so binding one to a workspace
   //   agent conflates identities. The `local` chip already covers "run on my
-  //   machine" as a per-user override (LOBE-11689) without needing to expose
+  // machine" as a per-user override without needing to expose
   //   the raw personal deviceId.
   //
   // Naming — Personal is reserved for the account-tier concept; workspace
@@ -593,7 +593,7 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
         />
       )}
       {/* `local` pins this desktop's personal `deviceId`. Available in both
-          personal and workspace modes now (LOBE-11689): a workspace-agent
+          personal and workspace modes now : a workspace-agent
           `local` pick lands in `users.preference.agentDeviceOverrides` — my
           per-user override — so it never binds the workspace-shared
           `agencyConfig` or coerces any other member's dispatch. */}

--- a/src/features/ChatInput/ControlBar/WorkingDirectoryPicker.tsx
+++ b/src/features/ChatInput/ControlBar/WorkingDirectoryPicker.tsx
@@ -295,7 +295,7 @@ const WorkingDirectoryPicker = memo<WorkingDirectoryPickerProps>(({ agentId }) =
   // One-time fold of legacy localStorage recents into device.workingDirs.
   useMigrateDeviceRecents();
 
-  // Effective config (shared row + this member's device override, LOBE-11689)
+  // Effective config (shared row + this member's device override)
   // so recents / default cwd / the selected-repo label all resolve against the
   // device THIS member's run actually targets.
   const { agencyConfig, workspaceScoped } = useEffectiveAgencyConfig(agentId);

--- a/src/features/ChatInput/ControlBar/WorkingDirectorySection.tsx
+++ b/src/features/ChatInput/ControlBar/WorkingDirectorySection.tsx
@@ -35,7 +35,7 @@ const getEntryEffectivePath = (entry: WorkingDirEntry) => {
  * (read-only) via GitStatus's `deviceId`.
  */
 const WorkingDirectorySectionInner = memo<WorkingDirectorySectionProps>(({ agentId }) => {
-  // Effective config (shared row + this member's device override, LOBE-11689)
+  // Effective config (shared row + this member's device override)
   // so GitStatus probes the same device `useEffectiveWorkingDirectory` resolved
   // the cwd from — raw shared config could point them at different machines.
   const { agencyConfig, workspaceScoped } = useEffectiveAgencyConfig(agentId);

--- a/src/features/ChatInput/ControlBar/WorkspaceControls.tsx
+++ b/src/features/ChatInput/ControlBar/WorkspaceControls.tsx
@@ -42,7 +42,7 @@ const WorkspaceControls = memo<WorkspaceControlsProps>(
     const { canConfigureResource, canUseResource } = useChatInputResourceAccess();
     const runtimeMode = useAgentStore(chatConfigByIdSelectors.getRuntimeModeById(agentId));
     const isHeterogeneous = useAgentStore(agentByIdSelectors.isAgentHeterogeneousById(agentId));
-    // Effective config = shared row + this member's device override (LOBE-11689),
+    // Effective config = shared row + this member's device override,
     // so `isDeviceMode` routes the working-directory section by the device THIS
     // member's run actually targets.
     const { agencyConfig, workspaceScoped } = useEffectiveAgencyConfig(agentId);

--- a/src/features/ChatInput/ControlBar/useCommitWorkingDirectory.ts
+++ b/src/features/ChatInput/ControlBar/useCommitWorkingDirectory.ts
@@ -77,7 +77,7 @@ export const useCommitWorkingDirectory = (agentId: string) => {
   // device override (spreading the merged config would leak the override's
   // executionTarget/boundDeviceId into the workspace-shared row).
   const agencyConfig = useAgentStore(agentByIdSelectors.getAgencyConfigById(agentId));
-  // The EFFECTIVE config (override merged, LOBE-11689) — only for resolving
+  // The EFFECTIVE config (override merged) — only for resolving
   // which device the cwd write should target, keeping it on the same machine
   // the picker/GitStatus/`useEffectiveWorkingDirectory` operate on.
   const { agencyConfig: effectiveAgencyConfig, workspaceScoped } =
@@ -106,7 +106,7 @@ export const useCommitWorkingDirectory = (agentId: string) => {
   });
 
   // A workspace agent resolving to THIS member's personal machine (a `local`
-  // override, LOBE-11689) must not persist its cwd into the workspace-shared
+  // override) must not persist its cwd into the workspace-shared
   // `agents.agencyConfig.workingDirByDevice` — that would leak the member's
   // personal device id and an absolute local path to every other member. Route
   // those writes to the per-user legacy slot instead (a `local` pick only

--- a/src/features/ChatInput/hooks/useSelectExecutionTarget.test.ts
+++ b/src/features/ChatInput/hooks/useSelectExecutionTarget.test.ts
@@ -161,7 +161,7 @@ describe('useSelectExecutionTarget', () => {
     });
   });
 
-  describe('workspace agent — writes to workspace_user_settings.preference.agentDeviceOverrides (LOBE-11689)', () => {
+  describe('workspace agent — writes to workspace_user_settings.preference.agentDeviceOverrides ', () => {
     beforeEach(() => {
       testState.access.canManageAgent = false;
       testState.agent.agentMap = {

--- a/src/features/ChatInput/hooks/useSelectExecutionTarget.ts
+++ b/src/features/ChatInput/hooks/useSelectExecutionTarget.ts
@@ -19,7 +19,7 @@ import { useUserStore } from '@/store/user';
  * `executionTarget` is the single source of truth — the server tool gate +
  * client `getRuntimeModeById` derive `runtimeMode` from it.
  *
- * Storage split (LOBE-11689):
+ * Storage split:
  * - **Personal agent** — writes go straight into the shared
  *   `agents.agencyConfig` (there's only ever one owner, so there's nothing to
  *   isolate).

--- a/src/features/Connectors/ConnectorDetail/index.tsx
+++ b/src/features/Connectors/ConnectorDetail/index.tsx
@@ -21,7 +21,7 @@ interface ConnectorDetailProps {
   /**
    * Title of the owning agent when this is an agent-dimension connector. Drives
    * the delete/uninstall confirmation copy — deleting an agent connector also
-   * removes its tool from that agent (LOBE-11682).
+   * removes its tool from that agent.
    */
   agentTitle?: string | null;
   connectorId: string;
@@ -29,7 +29,7 @@ interface ConnectorDetailProps {
   /**
    * Extra content rendered between the description and the tool-permission list.
    * Used by the unified settings' agent connectors to show the owning agent +
-   * a jump-to-use action (LOBE-11682).
+   * a jump-to-use action.
    */
   middleSlot?: ReactNode;
   onDelete?: () => void;

--- a/src/features/CreatePlatformAgent/index.tsx
+++ b/src/features/CreatePlatformAgent/index.tsx
@@ -142,7 +142,7 @@ const CreatePlatformAgentContent = memo<CreatePlatformAgentContentProps>(
 
     // Workspace-keyed SWR fetch (see useDeviceList) — the raw lambdaQuery key
     // has no workspace dimension, so the wizard listed the previous
-    // workspace's pool after a switch (LOBE-11904).
+    // workspace's pool after a switch.
     const {
       data: devices,
       isLoading: loadingDevices,

--- a/src/features/DeviceManager/DeviceDetailPanel.tsx
+++ b/src/features/DeviceManager/DeviceDetailPanel.tsx
@@ -189,7 +189,7 @@ const DeviceDetailPanel = memo<DeviceDetailPanelProps>(({ device, isCurrent, onC
     });
   };
 
-  // Revoke one workspace share of a personal device (LOBE-11699). The share
+  // Revoke one workspace share of a personal device. The share
   // entry's `deviceId` is the workspace-scoped twin, removed via the
   // workspace-scoped mutation under an explicitly pinned workspace client —
   // the personal settings page has no active workspace context to inherit.

--- a/src/features/DeviceManager/DeviceItem.tsx
+++ b/src/features/DeviceManager/DeviceItem.tsx
@@ -163,7 +163,7 @@ const DeviceItem = memo<DeviceItemProps>(({ device, isCurrent, onSelect, selecte
       })
     : t('devices.lastSeen', { time: dayjs(device.lastSeen).fromNow() });
 
-  // Publish / make-private for workspace enrollments (LOBE-11690). Reuses the
+  // Publish / make-private for workspace enrollments. Reuses the
   // shared visibility-confirm body so the consequences copy matches agents /
   // files. Success feedback is the row itself moving to the other tab after
   // the list refresh.
@@ -194,7 +194,7 @@ const DeviceItem = memo<DeviceItemProps>(({ device, isCurrent, onSelect, selecte
 
   // Only persisted workspace rows carry a visibility to toggle — ghosts
   // (unregistered) and personal devices don't. The toggle is enroller-only
-  // (LOBE-11760): an owner demoting another member's public device would
+  //: an owner demoting another member's public device would
   // move it into that member's private list, appropriating their data. The
   // server rejects non-enroller writes as the backstop.
   const isEnroller = !!currentUserId && device.enroller?.userId === currentUserId;
@@ -219,7 +219,7 @@ const DeviceItem = memo<DeviceItemProps>(({ device, isCurrent, onSelect, selecte
           ]
       : [];
 
-  // Share-to-workspace entry for personal enrollments (LOBE-11699). The share
+  // Share-to-workspace entry for personal enrollments. The share
   // handshake needs a live connection to mint the workspace identity, so the
   // item stays disabled (with an explanatory desc) while the device is offline.
   const shareItems =

--- a/src/features/DeviceManager/useDeviceList.ts
+++ b/src/features/DeviceManager/useDeviceList.ts
@@ -15,7 +15,7 @@ import { DEVICE_LIST_SWR_KEY } from './const';
  * resolves devices: `useClientDataSWR` augments the cache key with the active
  * workspace id, so switching workspaces re-fetches into a fresh cache entry.
  * The raw TRPC React Query key has no workspace dimension — a list primed in
- * one workspace kept serving a stale pool after switching (LOBE-11904), and a
+ * one workspace kept serving a stale pool after switching, and a
  * fetch primed while the workspace was still resolving stuck for the whole
  * session (the DeviceManager fix this generalizes).
  *

--- a/src/features/ResourcePermission/ResourceConfigAccessGate.test.tsx
+++ b/src/features/ResourcePermission/ResourceConfigAccessGate.test.tsx
@@ -60,7 +60,7 @@ describe('ResourceConfigAccessGate', () => {
     expect(mocks.toastInfo).toHaveBeenCalledWith('permission.configAccess.agentChatOnly');
   });
 
-  // LOBE-12374: "only collaborators with Can edit" read as an authorship denial to
+  // "only collaborators with Can edit" read as an authorship denial to
   // users who had authored the resource; the two denial reasons are now distinct.
   it('names the workspace role as the reason when the role cannot configure Agents', async () => {
     mocks.canEditContent = false;

--- a/src/features/ResourcePermission/ResourceConfigAccessGate.tsx
+++ b/src/features/ResourcePermission/ResourceConfigAccessGate.tsx
@@ -37,7 +37,7 @@ const ResourceConfigAccessGate = memo<ResourceConfigAccessGateProps>(
       // Name the actual reason: a workspace role that cannot configure Agents at
       // all reads very differently from holding use-only access on this one
       // resource, and conflating them made authors think their own Agent had
-      // rejected them (LOBE-12374).
+      // rejected them.
       const isRoleRestricted = !canEditContent;
       const messageKey =
         resourceType === 'agent'

--- a/src/features/WorkspaceSetting/hooks/useCategory.tsx
+++ b/src/features/WorkspaceSetting/hooks/useCategory.tsx
@@ -119,7 +119,7 @@ export const useWorkspaceSettingCategory = (): WorkspaceSettingCategoryGroup[] =
         {
           items: [
             // AI provider config (keys/endpoints) is shared workspace infra —
-            // Admin-or-higher, hidden from members entirely (LOBE-11834).
+            // Admin-or-higher, hidden from members entirely.
             canManageWorkspace && {
               icon: Brain,
               key: WorkspaceSettingsTabs.Provider,

--- a/src/helpers/executionTarget.test.ts
+++ b/src/helpers/executionTarget.test.ts
@@ -66,7 +66,7 @@ describe('resolveExecutionTarget', () => {
   });
 
   it('routes a bound desktop-local selection to the bound device on web when device routing is available (plain and hetero)', () => {
-    // LOBE-11473: a `local` pick pins this desktop's own deviceId as
+    // a `local` pick pins this desktop's own deviceId as
     // `boundDeviceId`; on web that config still runs on the bound device
     // server-side, so surface it honestly as `device` instead of masquerading
     // as `sandbox`. Hetero agents always route here; plain agents need a
@@ -86,7 +86,7 @@ describe('resolveExecutionTarget', () => {
     ).toBe('device');
   });
 
-  it('keeps a bound `local` as `sandbox` when no device routing is available (LOBE-11473 regression)', () => {
+  it('keeps a bound `local` as `sandbox` when no device routing is available ( regression)', () => {
     // A plain agent with a bound `local` target but no device-gateway to route
     // it (self-host without DEVICE_GATEWAY_URL, or any server call that leaves
     // `deviceRoutingAvailable` unset) must fall back to the cloud sandbox — it
@@ -356,7 +356,7 @@ describe('resolveRuntimeMode', () => {
     const boundLocal = cfg({ boundDeviceId: 'device-a', executionTarget: 'local' });
     // with a device-gateway → device → runtimeMode none (routed via the plan)
     expect(resolveRuntimeMode(boundLocal, false, true)).toBe('none');
-    // without one → sandbox → cloud (LOBE-11473 regression guard)
+    // without one → sandbox → cloud ( regression guard)
     expect(resolveRuntimeMode(boundLocal, false)).toBe('cloud');
   });
 });
@@ -426,7 +426,7 @@ describe('resolveExecutionPlan', () => {
       ).toEqual({ kind: 'sandbox', target: 'sandbox' });
     });
 
-    it('keeps a bound `local` as sandbox on a no-gateway backend (LOBE-11473 regression)', () => {
+    it('keeps a bound `local` as sandbox on a no-gateway backend ( regression)', () => {
       // No device-gateway: `clientExecutionAvailable` is false and the plan
       // never passes `deviceRoutingAvailable`, so a bound `local` target must
       // resolve to the sandbox — not `device`/`device-unrouted`, which would

--- a/src/helpers/executionTarget.ts
+++ b/src/helpers/executionTarget.ts
@@ -67,7 +67,7 @@ export interface ResolveExecutionTargetOptions {
    * stay `sandbox`. So server callers leave it `undefined` (false) and the
    * branch is a no-op there — only web display sites pass
    * `!!serverConfig.agentGatewayUrl` to keep the honest device display
-   * (LOBE-11473). `isHetero` also satisfies the gate: a hetero agent's bound
+   *. `isHetero` also satisfies the gate: a hetero agent's bound
    * `local` was always surfaced as `device` on web regardless of gateway state.
    */
   deviceRoutingAvailable?: boolean;
@@ -138,7 +138,7 @@ export const isHeterogeneousSandboxExecutionAvailable = (type: string | undefine
  * server routes such a config to that bound device — so on web we resolve it
  * to `device`, surfacing honestly that it runs on the user's machine (via
  * `lh connect`) instead of masquerading as `sandbox`. This applies to plain
- * agents too, not just heterogeneous CLI agents (LOBE-11473: plain agents used
+ * agents too, not just heterogeneous CLI agents (plain agents used
  * to leak here, showing "cloud sandbox" while the server ran on the device).
  *
  * This upgrade is gated on `deviceRoutingAvailable` (or `isHetero`): the run

--- a/src/helpers/gatewayMode.test.ts
+++ b/src/helpers/gatewayMode.test.ts
@@ -56,7 +56,7 @@ describe('resolveGatewayModeEnabled', () => {
 });
 
 describe('useIsGatewayModeEnabled', () => {
-  it('re-computes when the agent toggles disableGatewayMode (reactivity, LOBE-11473)', () => {
+  it('re-computes when the agent toggles disableGatewayMode (reactivity)', () => {
     mockServerConfig({ agentGatewayUrl: 'wss://gw', enableGatewayMode: true });
     useAgentStore.setState(stateWith(false));
 

--- a/src/helpers/gatewayMode.ts
+++ b/src/helpers/gatewayMode.ts
@@ -15,7 +15,7 @@ import { settingsSelectors } from '@/store/user/selectors';
  * default agent config) must not opt out via `disableGatewayMode`. When any of
  * these is false, sends fall back to the non-gateway client path, so a bound
  * `local` target cannot actually reach the device — the display must keep it as
- * `sandbox` rather than surfacing `device` (LOBE-11473 follow-up).
+ * `sandbox` rather than surfacing `device` ( follow-up).
  *
  * This intentionally mirrors dispatch's own gate,
  * `GatewayActionImpl.isGatewayModeEnabled` in the gateway transport
@@ -78,7 +78,7 @@ export const resolveGatewayModeEnabled = (
  * resource/skill panels). Subscribes to the live-mutable `disableGatewayMode`
  * (agent chatConfig + user default) so toggling Gateway Mode from the chat
  * ActionBar re-renders the display and it stops surfacing a `device` target
- * once sends have fallen back to sandbox (LOBE-11473 follow-up). `serverConfig`
+ * once sends have fallen back to sandbox ( follow-up). `serverConfig`
  * stays a non-reactive read — see `resolveGatewayModeEnabled`'s note.
  */
 export const useIsGatewayModeEnabled = (agentId?: string): boolean => {

--- a/src/hooks/useEffectiveAgencyConfig.ts
+++ b/src/hooks/useEffectiveAgencyConfig.ts
@@ -35,7 +35,7 @@ export interface UseEffectiveAgencyConfigResult {
  *
  * The workspace-shared `agents.agencyConfig` is one row per agent, but each
  * member picks their own execution device after the Agent is public
- * (LOBE-11689) — that pick lives in
+ * — that pick lives in
  * `workspace_user_settings.preference.agentDeviceOverrides[agentId]` and must
  * be merged over the shared row via `resolveAgentAgencyConfig` at read time.
  * Reading the shared row alone shows whichever device landed there (usually

--- a/src/hooks/useEffectiveWorkingDirectory.ts
+++ b/src/hooks/useEffectiveWorkingDirectory.ts
@@ -32,7 +32,7 @@ export const useEffectiveWorkingDirectory = (agentId?: string): string | undefin
   const isLogin = useUserStore(authSelectors.isLogin);
   useDeviceStore((s) => s.useFetchDevices)(isLogin || isDesktop);
 
-  // Effective config = shared row + this member's device override (LOBE-11689),
+  // Effective config = shared row + this member's device override,
   // so `resolveTargetDeviceId` targets the device THIS member's run goes to —
   // not whichever machine landed on the workspace-shared row.
   const { agencyConfig, workspaceScoped } = useEffectiveAgencyConfig(agentId);

--- a/src/hooks/useRemoteAgentDeviceGuard.test.ts
+++ b/src/hooks/useRemoteAgentDeviceGuard.test.ts
@@ -22,7 +22,7 @@ describe('useRemoteAgentDeviceGuard', () => {
   it('checks the EFFECTIVE bound device (with the caller override merged)', async () => {
     // The workspace-shared row points at the creator's (offline) machine; the
     // caller's override picks their own online device — the guard must probe
-    // the override device, not the shared one (LOBE-11904).
+    // the override device, not the shared one.
     mockedUseEffectiveAgencyConfig.mockReturnValue({
       agencyConfig: {
         boundDeviceId: 'my-device',

--- a/src/hooks/useRemoteAgentDeviceGuard.ts
+++ b/src/hooks/useRemoteAgentDeviceGuard.ts
@@ -28,7 +28,7 @@ export const useRemoteAgentDeviceGuard = ({
   enabled = true,
 }: UseRemoteAgentDeviceGuardOptions): UseRemoteAgentDeviceGuardResult => {
   // Effective config = shared row + this member's per-agent device override
-  // (LOBE-11689). Checking the raw shared `boundDeviceId` would probe whichever
+  //. Checking the raw shared `boundDeviceId` would probe whichever
   // machine landed on the shared row (usually the creator's, often offline)
   // instead of the device THIS member picked — a false "device offline".
   const { agencyConfig, isPreferenceLoading } = useEffectiveAgencyConfig(agentId);

--- a/src/routes/(main)/[workspaceSlug]/settings/devices/index.tsx
+++ b/src/routes/(main)/[workspaceSlug]/settings/devices/index.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { DeviceConnectModal, DeviceManager, useDeviceList } from '@/features/DeviceManager';
 
 /**
- * Workspace device settings: two pools behind tabs (LOBE-11690) —
+ * Workspace device settings: two pools behind tabs —
  * - Workspace: the shared (public-visibility) pool every member sees.
  * - Private: the caller's own private enrollments in this workspace.
  * The tab also parameterises the connect wizard, so a device enrolled from the

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/HeteroControlBar.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/HeteroControlBar.tsx
@@ -131,7 +131,7 @@ const HeteroControlBar = memo(() => {
 
   // All hooks must be called unconditionally (Rules of Hooks)
   const isLoading = useAgentStore(agentByIdSelectors.isAgentConfigLoadingById(agentId));
-  // Effective config = shared row + this member's device override (LOBE-11689),
+  // Effective config = shared row + this member's device override,
   // so the quota badges gate on where THIS member's run actually executes.
   const { agencyConfig, workspaceScoped } = useEffectiveAgencyConfig(agentId);
 

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/index.tsx
@@ -93,7 +93,7 @@ const HeterogeneousChatInput = memo(() => {
   const navigate = useWorkspaceAwareNavigate();
 
   // Effective config = shared row + this member's per-agent device override
-  // (LOBE-11689) — the raw shared `agencyConfig` may carry another member's
+  // — the raw shared `agencyConfig` may carry another member's
   // device pick, which would drive the guard/model-selector gates off the
   // wrong machine.
   // While the preference is loading, the merged config may still reflect only

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/RemoteAgentConfigCard.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/RemoteAgentConfigCard.tsx
@@ -111,7 +111,7 @@ const ChangeDeviceContent = memo<ChangeDeviceContentProps>(
 
     // Workspace-keyed SWR fetch (see useDeviceList) — the raw lambdaQuery key
     // has no workspace dimension, so the list went stale across workspace
-    // switches (LOBE-11904).
+    // switches.
     const { data: devices, isLoading: loadingDevices } = useDeviceList();
 
     const onlineDevices = (devices ?? []).filter(

--- a/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/useDropdownMenu.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/useDropdownMenu.tsx
@@ -92,8 +92,8 @@ export const useAgentDropdownMenu = ({
 
   // Visibility actions are only meaningful inside a workspace: in personal
   // mode every row is implicitly owner-private. "Publish to Workspace"
-  // appears on private agents; the inverse "Make private" (LOBE-11551)
-  // appears on published agents, but only for the creator (LOBE-11760 —
+  // appears on private agents; the inverse "Make private" 
+  // appears on published agents, but only for the creator ( —
   // owners demoting another member's agent would appropriate it), and never
   // on builtin agents (LobeAI etc.). The server enforces the same rules as
   // a backstop.
@@ -137,7 +137,7 @@ export const useAgentDropdownMenu = ({
   // Visibility flips move the item across accordions. Reveal the destination
   // section afterwards — with a collapsed/hidden target (stale persisted
   // `sidebarExpandedKeys` predate newer sections) the item would silently
-  // vanish from the sidebar (LOBE-11758).
+  // vanish from the sidebar.
   const revealSidebarSection = useRevealSidebarSection();
 
   return useMemo(

--- a/src/routes/(main)/home/_layout/hooks/useRevealSidebarSection.test.ts
+++ b/src/routes/(main)/home/_layout/hooks/useRevealSidebarSection.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { buildRevealSidebarSectionPatch } from './useRevealSidebarSection';
 
-describe('buildRevealSidebarSectionPatch (LOBE-11758)', () => {
+describe('buildRevealSidebarSectionPatch ', () => {
   it('expands a collapsed section', () => {
     // Stale persisted keys from before the Private section shipped.
     expect(buildRevealSidebarSectionPatch('private', ['recents', 'agent'], [])).toEqual({

--- a/src/routes/(main)/home/_layout/hooks/useRevealSidebarSection.ts
+++ b/src/routes/(main)/home/_layout/hooks/useRevealSidebarSection.ts
@@ -18,7 +18,7 @@ export type RevealableSidebarSection = 'agent' | 'private';
  * user-applied section hide. Returns `null` when the section is already
  * fully visible so callers can skip the store write.
  *
- * Why this exists (LOBE-11758): `sidebarExpandedKeys` is persisted, so
+ * Why this exists: `sidebarExpandedKeys` is persisted, so
  * accounts whose keys were saved before a section shipped (e.g. `private`,
  * added with workspace private agents) never include the new key — the
  * section stays collapsed forever. "Make private" then moves the agent into

--- a/src/routes/(main)/settings/skill/features/AgentConnectorItem.tsx
+++ b/src/routes/(main)/settings/skill/features/AgentConnectorItem.tsx
@@ -10,7 +10,7 @@ import NavItem from '@/features/NavPanel/components/NavItem';
 import type { AgentBoundConnector } from '@/store/tool/slices/connector/types';
 
 /**
- * A row in the unified settings' "Agent Connectors" section (LOBE-11682).
+ * A row in the unified settings' "Agent Connectors" section.
  *
  * Rendered identically to the base connector rows (same NavItem + the same brand
  * icon a base Composio/LobeHub connector of this identifier would show), so the

--- a/src/routes/(main)/settings/skill/features/AgentConnectorUsage.tsx
+++ b/src/routes/(main)/settings/skill/features/AgentConnectorUsage.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigateToAgent } from '@/hooks/useNavigateToAgent';
 
 /**
- * Shown inside ConnectorDetail for agent-owned connectors (LOBE-11682), between
+ * Shown inside ConnectorDetail for agent-owned connectors, between
  * the description and the tool-permission list: which agent owns this connector,
  * plus a one-click jump to go use that agent.
  */

--- a/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
@@ -397,7 +397,7 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type, onDelete }) => {
     );
   }
 
-  // Agent-owned connector (unified settings, LOBE-11682): the `identifier` slot
+  // Agent-owned connector (unified settings): the `identifier` slot
   // carries the connector id (not the slug — agent connectors can share a slug
   // with a base connector). Reuse the same ConnectorDetail as base connectors so
   // tool-permission editing, sync and delete behave identically; it resolves the

--- a/src/routes/(main)/settings/skill/features/SkillList.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillList.tsx
@@ -150,7 +150,7 @@ const SkillList = memo<SkillListProps>(
     }, [isConnectorsInit, fetchConnectors]);
 
     // Load agent-owned connectors (across all agents) for the Agent Connectors
-    // section — connector view only (LOBE-11682).
+    // section — connector view only.
     const isConnectorView = viewMode === 'connector';
     useEffect(() => {
       if (isConnectorView && !isAgentBoundInit) fetchAgentBoundConnectors();

--- a/src/services/agent.ts
+++ b/src/services/agent.ts
@@ -134,7 +134,7 @@ class AgentService {
   };
 
   /**
-   * Bidirectional visibility switch (LOBE-11551). The server only allows the
+   * Bidirectional visibility switch. The server only allows the
    * agent's creator or a workspace owner to pull a published agent back to
    * private, and rejects builtin agents (LobeAI etc.) outright.
    */

--- a/src/store/agent/selectors/builtinAgentSelectors.test.ts
+++ b/src/store/agent/selectors/builtinAgentSelectors.test.ts
@@ -170,7 +170,7 @@ describe('builtinAgentSelectors', () => {
     });
   });
 
-  // LOBE-12374: workspace members may now *configure* the collaborative builtin
+  // workspace members may now *configure* the collaborative builtin
   // rows, so ownership affordances (delete / transfer) have to be suppressed for
   // them explicitly — the server still rejects those actions.
   describe('isBuiltinAgent', () => {

--- a/src/store/agent/selectors/chatConfigByIdSelectors.ts
+++ b/src/store/agent/selectors/chatConfigByIdSelectors.ts
@@ -76,7 +76,7 @@ const getRuntimeModeById =
 
     // On web a bound `local` target only surfaces as `device` (not `sandbox`)
     // when Gateway mode is effectively enabled and can route to the device
-    // (LOBE-11473). Derive the gate from this selector's own state `s` so it
+    //. Derive the gate from this selector's own state `s` so it
     // re-evaluates on `disableGatewayMode` changes without a second global read.
     // Workspace agents never execute on the current member's own client —
     // their default/stored `local` coerces away (see `workspaceScoped`).

--- a/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
@@ -1117,7 +1117,7 @@ describe('GatewayActionImpl', () => {
       });
     });
 
-    // Regression (LOBE-12055): after an error run the gateway session completes
+    // Regression: after an error run the gateway session completes
     // and clears the SERVER-side topic metadata, but the local Zustand store copy
     // of `runningOperation` stayed set — so useGatewayReconnect kept firing a
     // reconnect for a dead op and looped 404s. onSessionComplete must ALSO clear
@@ -1682,7 +1682,7 @@ describe('GatewayActionImpl', () => {
 
     // Seeds a topic whose local metadata still carries a runningOperation, wires up
     // internal_dispatchTopic + connectToGateway capture, so we can assert the local
-    // store clear (LOBE-12055) on both the NOT_FOUND refresh path and onSessionComplete.
+    // store clear on both the NOT_FOUND refresh path and onSessionComplete.
     function createSeededReconnectHarness() {
       const captured: { onSessionComplete?: (p: any) => void } = {};
       const connectToGateway = vi.fn((params: any) => {
@@ -1740,7 +1740,7 @@ describe('GatewayActionImpl', () => {
       return { action, captured, connectToGateway, internalDispatchTopic };
     }
 
-    // Regression (LOBE-12055): a stale local runningOperation fires a reconnect,
+    // Regression: a stale local runningOperation fires a reconnect,
     // but the server already cleared its marker and answers refreshGatewayToken
     // with TRPC NOT_FOUND. The reconnect must clear the local marker and bail
     // silently (no connect, no throw) so the SWR fetcher resolves instead of

--- a/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
@@ -134,7 +134,7 @@ describe('createGatewayEventHandler', () => {
       // Native gateway ships the assistant seed on stream_start, so the client
       // inserts the message shell locally (createMessage) and must NOT trigger a
       // DB refetch — the refetch is what clobbered the streamed assistantGroup
-      // with a stale placeholder (LOBE-11501).
+      // with a stale placeholder.
       expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'msg-step2', type: 'createMessage' }),
         { operationId: 'op-1' },
@@ -650,7 +650,7 @@ describe('createGatewayEventHandler', () => {
     it('marks visible loading done without completing the operation or clearing topic loading', async () => {
       const store = createMockStore();
       // The streamed content has landed in the store — the visible_output_end
-      // guard (LOBE-11501) only clears loading once the assistant row is present
+      // guard only clears loading once the assistant row is present
       // with its content, so seed it here to represent that state.
       store.dbMessagesMap['main_agent-1_topic-1'] = [
         { content: 'hello back', id: 'msg-initial', role: 'assistant' },

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -1305,7 +1305,7 @@ export class ConversationLifecycleActionImpl {
         // Optimistically bump the sort key (`sortUpdatedAt`, the sidebar's activity-time
         // sort/group key) so the topic jumps to the top immediately, before the SWR
         // refetch returns the server's fresh `topicActivityAt`. Bumping `updatedAt` here
-        // would no longer reorder anything — the sidebar sorts by `sortUpdatedAt`. (LOBE-11543)
+        // would no longer reorder anything — the sidebar sorts by `sortUpdatedAt`. 
         this.#get().internal_dispatchTopic({
           type: 'updateTopic',
           id: operationContext.topicId,

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -748,7 +748,7 @@ export class GatewayActionImpl {
             .updateTopicMetadata(result.topicId, { runningOperation: null })
             .catch(() => {});
           // Also clear the local store copy — the server clear above does NOT touch
-          // the Zustand topic map that useGatewayReconnect reads (LOBE-12055).
+          // the Zustand topic map that useGatewayReconnect reads.
           this.clearLocalRunningOperation({
             agentId: resolvedMessageContext.agentId,
             groupId: resolvedMessageContext.groupId,
@@ -807,7 +807,7 @@ export class GatewayActionImpl {
     // TRPCError NOT_FOUND when it has no running operation on this topic — our
     // local marker is stale (e.g. an error run cleared the server marker but not
     // the store). Clear it and bail silently so the reconnect SWR fetcher resolves
-    // and does not retry the 404 forever (LOBE-12055).
+    // and does not retry the 404 forever.
     let token: string;
     try {
       ({ token } = await aiAgentService.refreshGatewayToken(topicId));
@@ -936,7 +936,7 @@ export class GatewayActionImpl {
         // doesn't get reconnected on every reload / task-drawer open.
         topicService.updateTopicMetadata(topicId, { runningOperation: null }).catch(() => {});
         // Mirror the clear into the local store — the server clear above leaves the
-        // Zustand topic map stale, which useGatewayReconnect keys off (LOBE-12055).
+        // Zustand topic map stale, which useGatewayReconnect keys off.
         this.clearLocalRunningOperation({ agentId: context.agentId, operationId, topicId });
       },
       operationId,
@@ -989,7 +989,7 @@ export class GatewayActionImpl {
    * copy, so after an error run (e.g. insufficient credits) the stale marker keeps
    * firing `aiAgentService.refreshGatewayToken(topicId)`, which the server now answers
    * with NOT_FOUND (404 — the server-side marker is already null). Raw SWR retries the
-   * 404 forever and wedges the conversation (LOBE-12055).
+   * 404 forever and wedges the conversation.
    *
    * The `updateTopic` reducer shallow-merges `value.metadata` (`{...currentTopic, ...value}`),
    * so we spread the existing metadata to avoid dropping its other keys. Only dispatch when

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.test.ts
@@ -728,7 +728,7 @@ describe('createGatewayEventHandler', () => {
     expect(store.internal_dispatchMessage).not.toHaveBeenCalled();
   });
 
-  it('skips the visible_output_end hint while the assistant row is missing (LOBE-11501)', async () => {
+  it('skips the visible_output_end hint while the assistant row is missing ', async () => {
     const store = createStore();
     const handler = createGatewayEventHandler(() => store, {
       assistantMessageId: 'missing-msg',

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
@@ -629,7 +629,7 @@ export const createGatewayEventHandler = (
             // dispatches on a missing id are silent no-ops, so without an
             // insert here the whole step renders nothing until the next DB
             // refetch — and the final step has none before agent_runtime_end,
-            // which is how "loading cleared but no text" happened (LOBE-11501).
+            // which is how "loading cleared but no text" happened.
             const stored = dbMessageSelectors.getDbMessageById(newAssistantMessageId)(get());
             if (!stored) {
               const seed = data?.assistantMessage;
@@ -871,7 +871,7 @@ export const createGatewayEventHandler = (
           // Guard: only clear visible loading when the streamed content has
           // actually landed in the store. If the message shell is missing (or
           // text streamed but never applied), clearing here would show
-          // "loading done" with the answer still invisible (LOBE-11501) —
+          // "loading done" with the answer still invisible —
           // skip the hint instead and let agent_runtime_end reconcile content
           // and loading in the same frame, i.e. the pre-early-hint behavior.
           const stored = dbMessageSelectors.getDbMessageById(currentAssistantMessageId)(get());

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayMemberStreamHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayMemberStreamHandler.test.ts
@@ -68,7 +68,7 @@ describe('createGatewayMemberStreamHandler', () => {
     expect(store.completeOperation).not.toHaveBeenCalled();
   });
 
-  it('skips the visible loading hint while the member row is not yet in the store (LOBE-11501)', () => {
+  it('skips the visible loading hint while the member row is not yet in the store ', () => {
     // Group hydration is still in flight, so the member row hasn't landed. Clearing
     // loading here would show a "done" column with no text — the guard skips it and
     // lets the terminal barrier reconcile.

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayMemberStreamHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayMemberStreamHandler.ts
@@ -154,7 +154,7 @@ export const createGatewayMemberStreamHandler = (
         // the member column's visible loading; terminal reconciliation still
         // belongs to agent_runtime_end/error.
         //
-        // Same guard as the main handler (LOBE-11501): if the member row isn't
+        // Same guard as the main handler: if the member row isn't
         // in the store yet (group hydration in flight) or its streamed text
         // hasn't landed, clearing loading would show a "done" column with no
         // text — skip the hint and let the terminal barrier reconcile both.

--- a/src/store/chat/slices/topic/reducer.ts
+++ b/src/store/chat/slices/topic/reducer.ts
@@ -55,7 +55,7 @@ export const topicReducer = (state: ChatTopic[] = [], payload: ChatTopicDispatch
           sessionId: payload.value.sessionId || undefined,
           // A brand-new topic is fresh activity: seed the sidebar sort key so it
           // lands at the top immediately, matching the server's `topicActivityAt`
-          // once the real row is fetched. (LOBE-11543)
+          // once the real row is fetched. 
           sortUpdatedAt: Date.now(),
           updatedAt: Date.now(),
         });
@@ -79,7 +79,7 @@ export const topicReducer = (state: ChatTopic[] = [], payload: ChatTopicDispatch
             // Bump `updatedAt` (display/edit time) on every real write. The sidebar
             // no longer sorts by `updatedAt` — it sorts by `sortUpdatedAt` (activity
             // time) — so a status flip bumping `updatedAt` here can't reorder the
-            // list; only an explicit `sortUpdatedAt` in `value` moves a row. (LOBE-11543)
+            // list; only an explicit `sortUpdatedAt` in `value` moves a row. 
             // TODO: updatedAt type needs to be changed to Date later
             // @ts-ignore
             draftState[topicIndex] = { ...mergedTopic, updatedAt: new Date() };
@@ -105,7 +105,7 @@ export const topicReducer = (state: ChatTopic[] = [], payload: ChatTopicDispatch
           id: nextId,
           // Resolving a first-send optimistic topic to its real id is fresh activity:
           // keep it pinned to the top via the sidebar sort key (`sortUpdatedAt`), not
-          // just `updatedAt` which the sidebar no longer sorts by. (LOBE-11543)
+          // just `updatedAt` which the sidebar no longer sorts by. 
           sortUpdatedAt: Date.now(),
           updatedAt: Date.now(),
         };

--- a/src/store/home/slices/homeInput/action.test.ts
+++ b/src/store/home/slices/homeInput/action.test.ts
@@ -228,7 +228,7 @@ describe('HomeInputActionImpl', () => {
       );
     });
 
-    // LOBE-12374: a personal builtin is the user's own row, so it keeps following
+    // a personal builtin is the user's own row, so it keeps following
     // the inbox model; the workspace-scoped row of the same slug is shared by
     // every member and must never be repointed.
     it('keeps syncing model/provider onto a personal agent builder', async () => {

--- a/src/store/home/slices/homeInput/action.ts
+++ b/src/store/home/slices/homeInput/action.ts
@@ -60,7 +60,7 @@ const ensureBuiltinAgentHydrated = async (slug: string): Promise<string | undefi
  *
  * The workspace-scoped row of the same slug is shared by every member, so a
  * personal preference must not repoint it — that write both broke for
- * non-creators and silently changed the model for everyone else (LOBE-12374).
+ * non-creators and silently changed the model for everyone else.
  * The single exception is a shared row whose own model cannot be invoked in this
  * deployment; leaving it would fail the request outright, so it is repaired once.
  *

--- a/src/store/tool/slices/connector/action.ts
+++ b/src/store/tool/slices/connector/action.ts
@@ -39,9 +39,9 @@ export class ConnectorActionImpl {
 
   /**
    * Fetch every agent-owned connector across all agents (the flat aggregate for
-   * the unified connector-settings page, LOBE-11682). Each row is enriched
+   * the unified connector-settings page). Each row is enriched
    * server-side with the owning agent's title/avatar. Scope-correct: a workspace
-   * context only returns that workspace's agent connectors (LOBE-11681).
+   * context only returns that workspace's agent connectors.
    */
   fetchAgentBoundConnectors = async (): Promise<void> => {
     const data = await lambdaClient.connector.listAgentBound.query();

--- a/src/store/tool/slices/connector/initialState.ts
+++ b/src/store/tool/slices/connector/initialState.ts
@@ -3,7 +3,7 @@ import type { AgentBoundConnector, ConnectorWithTools } from './types';
 export interface ConnectorState {
   /**
    * All agent-owned connectors across every agent in the current scope, for the
-   * unified connector-settings page (LOBE-11682). Distinct from `agentConnectors`
+   * unified connector-settings page. Distinct from `agentConnectors`
    * (keyed per-agent, includes mounted rows) — this is the flat aggregate.
    */
   agentBoundConnectors: AgentBoundConnector[];

--- a/src/store/tool/slices/connector/types.ts
+++ b/src/store/tool/slices/connector/types.ts
@@ -40,7 +40,7 @@ export interface ConnectorWithTools {
 /**
  * An agent-owned connector as returned by `connector.listAgentBound`, enriched
  * with the owning agent's display info for the unified settings attribution
- * badge (LOBE-11682). Server-resolved so the page needs no per-agent loading.
+ * badge. Server-resolved so the page needs no per-agent loading.
  */
 export interface AgentBoundConnector extends ConnectorWithTools {
   agentAvatar: string | null;

--- a/src/store/user/slices/workspaceUserSettings/initialState.ts
+++ b/src/store/user/slices/workspaceUserSettings/initialState.ts
@@ -9,7 +9,7 @@ export interface WorkspaceUserSettingsState {
   /**
    * Empty on first load / while SWR is fetching / when the caller is in
    * personal mode. Consumers should treat empty as "no override — use the
-   * shared defaults", identical to the pre-LOBE-11689 behaviour.
+   * shared defaults", identical to the pre behaviour.
    */
   workspaceUserPreference: WorkspaceUserPreference;
   /**


### PR DESCRIPTION
## Summary

Automated daily cleanup of `LOBE-XXXXX` comment annotations across the codebase.

## Changes

- **118 files modified**, 186 insertions / 186 deletions
- Removed all `LOBE-XXXXX` markers from JSDoc comments, inline comments, and test descriptions
- Preserved all useful context and explanations — only the LOBE reference tags were removed
- Test fixture data (Linear issue ID strings in test data values) intentionally left unchanged

## Verification

- No remaining `LOBE-XXXXX` annotations in source comments
- No functional code changes — comment-only cleanup
- All test fixture references remain intact

---
Auto-generated on 2026-07-29 02:32:16