### PR TITLE
🐛 fix: discard signature-only reasoning

### DIFF
--- a/packages/fetch-sse/src/__tests__/reasoningSignature.test.ts
+++ b/packages/fetch-sse/src/__tests__/reasoningSignature.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 });
 
 describe('fetchSSE reasoning signatures', () => {
-  it('should preserve a reasoning signature without visible reasoning text', async () => {
+  it('should discard a reasoning signature without visible reasoning text', async () => {
     const mockOnFinish = vi.fn();
 
     (fetchEventSource as any).mockImplementationOnce(
@@ -38,10 +38,7 @@ describe('fetchSSE reasoning signatures', () => {
 
     expect(mockOnFinish).toHaveBeenCalledWith('Done', {
       observationId: null,
-      reasoning: {
-        content: undefined,
-        signature: 'encrypted-reasoning-content',
-      },
+      reasoning: undefined,
       toolCalls: undefined,
       traceId: null,
       type: 'done',

--- a/packages/fetch-sse/src/fetchSSE.ts
+++ b/packages/fetch-sse/src/fetchSSE.ts
@@ -548,10 +548,11 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
         grounding,
         images: images.length > 0 ? images : undefined,
         observationId,
-        reasoning:
-          thinking || thinkingSignature
-            ? { content: thinking || undefined, signature: thinkingSignature }
-            : undefined,
+        /**
+         * A scalar signature is opaque replay state, not reasoning content. Keep the historical
+         * persistence guard so a signature-only event cannot create a reasoning record.
+         */
+        reasoning: thinking ? { content: thinking, signature: thinkingSignature } : undefined,
         speed,
         toolCalls,
         traceId,

--- a/packages/model-runtime/src/core/streams/protocol.test.ts
+++ b/packages/model-runtime/src/core/streams/protocol.test.ts
@@ -743,6 +743,18 @@ describe('createCallbacksTransformer', () => {
     );
   });
 
+  it('should discard reasoning signatures without reasoning content', async () => {
+    const onCompletion = vi.fn();
+    const transformer = createCallbacksTransformer({ onCompletion });
+
+    const chunks = ['event: reasoning_signature\n', 'data: "encrypted-signature"\n\n'];
+
+    await processChunks(transformer, chunks);
+
+    expect(onCompletion).toHaveBeenCalledOnce();
+    expect(onCompletion.mock.calls[0][0]).not.toHaveProperty('reasoning');
+  });
+
   it('should handle base64_image chunks and call onBase64Image callback', async () => {
     const receivedCalls: Array<{
       image: { id: string; data: string };

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -462,7 +462,11 @@ export function createCallbacksTransformer(
         toolsCalling,
         usage,
       };
-      if (aggregatedThinking || reasoningSignature) {
+      /**
+       * A scalar signature is opaque replay state, not reasoning content. Keep the historical
+       * persistence guard so a signature-only event cannot create a reasoning record.
+       */
+      if (aggregatedThinking) {
         data.reasoning = {
           content: aggregatedThinking,
           signature: reasoningSignature,

--- a/src/store/chat/agents/StreamingHandler.test.ts
+++ b/src/store/chat/agents/StreamingHandler.test.ts
@@ -578,7 +578,7 @@ describe('StreamingHandler', () => {
       expect(result.metadata.reasoning?.signature).toBe('fallback-sig');
     });
 
-    it('should preserve a reasoning signature without reasoning content', async () => {
+    it('should discard a reasoning signature without reasoning content', async () => {
       const callbacks = createMockCallbacks();
       const handler = new StreamingHandler(mockContext, callbacks);
 
@@ -589,8 +589,7 @@ describe('StreamingHandler', () => {
         reasoning: { signature: 'signature-only' },
       });
 
-      expect(result.metadata.reasoning?.content).toBeUndefined();
-      expect(result.metadata.reasoning?.signature).toBe('signature-only');
+      expect(result.metadata.reasoning).toBeUndefined();
     });
   });
 

--- a/src/store/chat/agents/StreamingHandler.ts
+++ b/src/store/chat/agents/StreamingHandler.ts
@@ -537,7 +537,7 @@ export class StreamingHandler {
         duration: finalDuration,
         signature: reasoningSignature,
       };
-    } else if (finishData.reasoning?.content || reasoningSignature) {
+    } else if (finishData.reasoning?.content) {
       finalReasoning = {
         ...finishData.reasoning,
         duration: finalDuration,


### PR DESCRIPTION
Restore the pre-ChatGPT-provider persistence guard for scalar reasoning signatures.

- omit `reasoning` when a stream contains `reasoning_signature` but no visible reasoning content
- apply the same rule to client SSE aggregation, server callback aggregation, and final client message assembly
- continue preserving signatures when reasoning content is present

#### 🧭 Key Decisions / Non-goals

- This PR intentionally contains only the scalar signature persistence guard.
- It does not add `responseItems`, `signatureScope`, database fields, provider routing logic, or replay filtering.
- OpenAI Responses may still emit `reasoning_signature`; this change only prevents a signature-only event from creating persisted reasoning.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check lobehub/packages/fetch-sse/src/fetchSSE.ts lobehub/packages/fetch-sse/src/__tests__/reasoningSignature.test.ts lobehub/packages/model-runtime/src/core/streams/protocol.ts lobehub/packages/model-runtime/src/core/streams/protocol.test.ts lobehub/src/store/chat/agents/StreamingHandler.ts lobehub/src/store/chat/agents/StreamingHandler.test.ts --lint --test
bun run check --type
```

Result: 6 files lint clean, 118 tests passed, and types clean.

#### 🔗 Related Issue

Related to LOBE-12535