### PR TITLE
🐛 fix: recognize image-only model completions

### DIFF
--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.test.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.test.ts
@@ -287,4 +287,36 @@ describe('ServerCallLlmAttempt', () => {
       }),
     );
   });
+
+  it('accepts an image-only multimodal completion as non-empty', async () => {
+    const blobStore: BlobStore = {
+      persistBase64: vi.fn().mockResolvedValue({
+        fileId: 'file-1',
+        key: 'files/generations/image.png',
+        url: 'https://files.example/image.png',
+      }),
+      resolveUrl: vi.fn(),
+    };
+    const { attempt } = createAttempt(async ({ callback }) => {
+      await callback?.onContentPart?.({
+        content: 'BASE64_IMAGE',
+        mimeType: 'image/png',
+        partType: 'image',
+      });
+      await callback?.onCompletion?.({
+        finishReason: 'stop',
+        text: '',
+        usage: { outputImageTokens: 1120, totalOutputTokens: 1120 },
+      });
+    }, blobStore);
+
+    await expect(attempt.execute()).resolves.toBeUndefined();
+    expect(attempt.snapshot()).toEqual(
+      expect.objectContaining({
+        content: '',
+        contentParts: [{ image: 'https://files.example/image.png', type: 'image' }],
+        hasContentImages: true,
+      }),
+    );
+  });
 });

--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.ts
@@ -278,11 +278,13 @@ export class ServerCallLlmAttempt {
   }
 
   private async assertNonEmptyCompletion() {
+    const imageCount = this.getOutputImageCount();
+
     if (
       isEmptyModelCompletion({
         content: this.streamSink.content,
         hasGrounding: !!this.grounding,
-        imageCount: this.imageList.length,
+        imageCount,
         outputTokens: this.usage?.totalOutputTokens,
         reasoning: this.streamSink.thinkingContent,
         toolCallCount: this.toolsCalling.length + this.toolCalls.length,
@@ -300,7 +302,7 @@ export class ServerCallLlmAttempt {
         contentLength: this.streamSink.content.length,
         cost: this.usage?.cost,
         finishReason: this.finishReason,
-        imageCount: this.imageList.length,
+        imageCount,
         maxAttempts: this.maxAttempts,
         model: this.model,
         outputTokens: this.usage?.totalOutputTokens,
@@ -309,6 +311,19 @@ export class ServerCallLlmAttempt {
         toolCallCount: this.toolsCalling.length + this.toolCalls.length,
       });
     }
+  }
+
+  /**
+   * Native multimodal responses store generated images in contentParts rather
+   * than the legacy imageList. Count both paths so image-only completions are
+   * not mistaken for empty provider responses.
+   */
+  private getOutputImageCount() {
+    const contentPartImageCount = this.streamSink.contentParts.filter(
+      (part) => part.type === 'image',
+    ).length;
+
+    return this.imageList.length + contentPartImageCount;
   }
 
   private logResult() {


### PR DESCRIPTION
## 📝 Additional Information

Image-only native multimodal responses are persisted in `contentParts`, while the empty-completion guard only counted the legacy `imageList`. As a result, a valid generated image with no accompanying text could be rejected as an empty model completion.

This change counts images from both representations when validating and reporting completion output.

### Key Decisions / Non-goals

- Treat persisted image content parts as valid completion output without adding provider-specific behavior.
- Preserve the existing empty-completion error for responses with no text, reasoning, tools, grounding, or images.
- Keep the legacy image callback path unchanged.

#### Test

- [x] Added/updated tests
- [x] `bun run check lobehub/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.ts lobehub/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.test.ts` — lint clean, 7 tests passed
- [ ] `bun run check --type` — blocked by pre-existing `RightPanelProps.collapseThreshold` and `setContextMenuInterceptor` errors outside this change

#### 🔗 Related Issue

Related to #17365