### PR TITLE
🐛 fix(acceptance): restore single-page scrolling

### DIFF
--- a/src/features/Verify/Acceptance/index.tsx
+++ b/src/features/Verify/Acceptance/index.tsx
@@ -81,7 +81,7 @@ import CheckList, {
 import DecisionBar from './DecisionBar';
 import { EMPTY_ID_SET, setAggregateEntry } from './expandState';
 import FeedbackDrawer, { type FeedbackListEntry } from './FeedbackDrawer';
-import { acceptanceFocusedLayout } from './layout';
+import { acceptanceFocusedLayout, acceptanceScrollLayout } from './layout';
 import LedgerPanel, { type AcceptanceRound } from './LedgerPanel';
 import { openAcceptModal, openRejectModal } from './modals';
 import { acceptanceCheckPath, acceptanceOverviewPath } from './routes';
@@ -166,6 +166,9 @@ const styles = createStaticStyles(({ css }) => ({
       opacity: 1;
     }
   `,
+  contentFrame: css`
+    overflow: ${acceptanceScrollLayout.frameOverflow};
+  `,
   page: css`
     position: relative;
 
@@ -236,51 +239,38 @@ const styles = createStaticStyles(({ css }) => ({
     }
   `,
   focusLayout: css`
-    overflow: ${acceptanceFocusedLayout.frameOverflow};
     display: grid;
     grid-template-columns: 320px minmax(0, 1fr);
 
-    width: 100%;
-    height: ${acceptanceFocusedLayout.viewportHeight};
-    min-height: 0;
-
     @media (width <= 900px) {
       grid-template-columns: 1fr;
-      grid-template-rows: ${acceptanceFocusedLayout.compactOutlineHeight} minmax(0, 1fr);
     }
   `,
   focusOutline: css`
-    overflow: ${acceptanceFocusedLayout.frameOverflow};
+    position: sticky;
+    inset-block-start: 0;
 
-    height: ${acceptanceFocusedLayout.viewportHeight};
-    min-height: 0;
     padding: 8px;
     border-inline-end: 1px solid ${cssVar.colorBorderSecondary};
 
     background: ${cssVar.colorFillQuaternary};
 
     @media (width <= 900px) {
-      height: 100%;
+      position: static;
       border-block-end: 1px solid ${cssVar.colorBorderSecondary};
       border-inline-end: 0;
     }
   `,
   focusOutlineList: css`
-    overflow-y: ${acceptanceFocusedLayout.paneOverflow};
-    overscroll-behavior: contain;
-    min-height: 0;
+    overflow: ${acceptanceScrollLayout.paneOverflow};
 
     > * {
       flex-shrink: 0;
     }
   `,
   focusMain: css`
-    overflow-y: ${acceptanceFocusedLayout.paneOverflow};
-    overscroll-behavior: contain;
-
+    overflow: ${acceptanceScrollLayout.paneOverflow};
     min-width: 0;
-    height: ${acceptanceFocusedLayout.viewportHeight};
-    min-height: 0;
     padding-block: ${acceptanceFocusedLayout.contentPaddingBlock};
     padding-inline: 32px;
   `,
@@ -981,7 +971,6 @@ const AcceptancePage = memo<AcceptancePageProps>(
       });
 
     const repairPrompt = buildRepairPrompt(acceptance.id);
-
     // Hand the repair prompt to the reviewer's clipboard — for pasting to any
     // agent, not just the origin conversation.
     const handleCopyReview = async () => {
@@ -1114,24 +1103,14 @@ const AcceptancePage = memo<AcceptancePageProps>(
             onClick={() => setLedgerExpand(true)}
           />
         )}
-        <Flexbox
-          flex={1}
-          style={{
-            minHeight: 0,
-            minWidth: 0,
-            overflow: focusedCheck ? acceptanceFocusedLayout.frameOverflow : 'auto',
-          }}
-        >
+        <Flexbox className={styles.contentFrame} flex={1} style={{ minWidth: 0 }}>
           <Flexbox
-            flex={focusedCheck ? 1 : undefined}
             gap={16}
             paddingBlock={focusedCheck ? 0 : 20}
             paddingInline={focusedCheck ? 0 : 24}
             style={{
-              height: focusedCheck ? '100%' : undefined,
               margin: focusedCheck ? 0 : '0 auto',
               maxWidth: focusedCheck ? 'none' : 920,
-              minHeight: 0,
               width: '100%',
             }}
           >

--- a/src/features/Verify/Acceptance/layout.test.ts
+++ b/src/features/Verify/Acceptance/layout.test.ts
@@ -1,18 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { acceptanceFocusedLayout } from './layout';
+import { acceptanceFocusedLayout, acceptanceScrollLayout } from './layout';
 
 describe('acceptanceFocusedLayout', () => {
-  it('fits the focused workspace to its scroll container instead of the browser viewport', () => {
-    expect(acceptanceFocusedLayout.viewportHeight).toBe('100%');
-  });
-
-  it('keeps the frame fixed while each master-detail pane owns its scrolling', () => {
-    expect(acceptanceFocusedLayout.frameOverflow).toBe('hidden');
-    expect(acceptanceFocusedLayout.paneOverflow).toBe('auto');
-    expect(acceptanceFocusedLayout.compactOutlineHeight).toBe('min(36%, 320px)');
-  });
-
   it('keeps deliberate reading space above and below focused check content', () => {
     expect(acceptanceFocusedLayout.contentPaddingBlock).toBe('32px 24px');
   });
@@ -21,5 +11,12 @@ describe('acceptanceFocusedLayout', () => {
     expect(acceptanceFocusedLayout.headerGap).toBe(8);
     expect(acceptanceFocusedLayout.outlineItemPaddingBlock).toBe(10);
     expect(acceptanceFocusedLayout.outlineItemPaddingInline).toBe(8);
+  });
+});
+
+describe('acceptanceScrollLayout', () => {
+  it('keeps one scroll owner for both overview and focused views', () => {
+    expect(acceptanceScrollLayout.frameOverflow).toBe('auto');
+    expect(acceptanceScrollLayout.paneOverflow).toBe('visible');
   });
 });

--- a/src/features/Verify/Acceptance/layout.ts
+++ b/src/features/Verify/Acceptance/layout.ts
@@ -1,10 +1,11 @@
 export const acceptanceFocusedLayout = {
-  compactOutlineHeight: 'min(36%, 320px)',
   contentPaddingBlock: '32px 24px',
-  frameOverflow: 'hidden',
   headerGap: 8,
   outlineItemPaddingBlock: 10,
   outlineItemPaddingInline: 8,
-  paneOverflow: 'auto',
-  viewportHeight: '100%',
+} as const;
+
+export const acceptanceScrollLayout = {
+  frameOverflow: 'auto',
+  paneOverflow: 'visible',
 } as const;


### PR DESCRIPTION
## Summary

- restore the acceptance workspace to a single outer scroll container
- remove the fixed-height and `min-height: 0` constraints introduced by #17658
- let focused-check outline and evidence panes participate in the natural document flow
- add a regression contract for frame-owned scrolling

## Why

#17658 made the focused workspace panes own scrolling through fixed heights, hidden frame overflow, and nested auto-overflow regions. Those constraints also compressed the regular acceptance overview, making the goal and checklist appear vertically flattened.

The acceptance workspace now has one scroll owner: the outer content frame. Both overview and focused-check content use natural height.

## Verification

- `bun run check src/features/Verify/Acceptance/index.tsx src/features/Verify/Acceptance/layout.ts src/features/Verify/Acceptance/layout.test.ts`
- lint clean
- 3 tests passed