### PR TITLE
🐛 fix: persist sidebar task list cache to skip repeat skeleton

### DIFF
--- a/src/features/AgentSidebar/Task/index.tsx
+++ b/src/features/AgentSidebar/Task/index.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useClientDataSWR } from '@/libs/swr';
-import { sidebarKeys } from '@/libs/swr/keys';
+import { taskKeys } from '@/libs/swr/keys';
 import { taskService } from '@/services/task';
 import { useAgentStore } from '@/store/agent';
 import type { TaskGroupItem } from '@/store/task/slices/list/initialState';
@@ -33,7 +33,7 @@ const TaskList = memo<TaskListProps>(({ itemKey }) => {
 
   const enabled = !!agentId;
   const { data, isLoading } = useClientDataSWR<{ data: TaskGroupItem[]; success: boolean }>(
-    enabled ? sidebarKeys.taskGroups(agentId) : null,
+    enabled ? taskKeys.sidebarGroups(agentId) : null,
     async ([, id]: [string, string]) =>
       taskService.groupList({ assigneeAgentId: id, groups: SIDEBAR_GROUPS }),
     {

--- a/src/libs/swr/keys.test.ts
+++ b/src/libs/swr/keys.test.ts
@@ -1,6 +1,8 @@
+import { unstable_serialize } from 'swr';
 import { describe, expect, it } from 'vitest';
 
-import { recentKeys } from './keys';
+import { recentKeys, taskKeys } from './keys';
+import { CACHE_TIERS } from './localStorageProvider';
 
 describe('recentKeys', () => {
   it('keys the Home recent list by identity cache scope', () => {
@@ -22,5 +24,19 @@ describe('recentKeys', () => {
     expect(recentKeys.allDrawer(true, 'user-1:workspace-1')).not.toEqual(
       recentKeys.allDrawer(true, 'user-1:workspace-2'),
     );
+  });
+});
+
+describe('taskKeys', () => {
+  // Regression for LOBE-12552: the sidebar task list used a `sidebar:` domain
+  // key that no CACHE_TIERS pattern matched, so it was memory-only and every
+  // fresh page load showed a skeleton. The key must route to a persisted tier
+  // (the provider matches patterns against the serialized SWR key).
+  it('routes the sidebar task-groups key to a persisted cache tier', () => {
+    const serialized = unstable_serialize(taskKeys.sidebarGroups('agent-1'));
+    const persisted = [...CACHE_TIERS.idb, ...CACHE_TIERS.local].some((pattern) =>
+      serialized.includes(pattern),
+    );
+    expect(persisted).toBe(true);
   });
 });

--- a/src/libs/swr/keys.ts
+++ b/src/libs/swr/keys.ts
@@ -253,6 +253,12 @@ export const taskKeys = {
       visibility,
     ],
   ),
+  /**
+   * AgentSidebar task panel. Lives in the `task:` domain (not a `sidebar:`
+   * one) so the tiered cache provider persists it to IndexedDB and the second
+   * open renders from cache instead of a skeleton.
+   */
+  sidebarGroups: def('task:sidebarGroups', (agentId: string) => ['task:sidebarGroups', agentId]),
 };
 
 // ---- work ---------------------------------------------------------------
@@ -1060,9 +1066,6 @@ export const builtinAgentKeys = {
 export const imessageKeys = {
   bridgeStatus: def('imessage:bridgeStatus', () => ['imessage:bridgeStatus']),
 };
-export const sidebarKeys = {
-  taskGroups: def('sidebar:taskGroups', (agentId: string) => ['sidebar:taskGroups', agentId]),
-};
 // Desktop/electron IPC fetches — roots keep their existing `electron:getXxx` value.
 export const electronKeys = {
   appTrayVisible: def('electron:getAppTrayVisible', () => ['electron:getAppTrayVisible']),
@@ -1135,7 +1138,6 @@ export const swrKeys = {
   serverConfig: serverConfigKeys,
   session: sessionKeys,
   share: shareKeys,
-  sidebar: sidebarKeys,
   stats: statsKeys,
   task: taskKeys,
   taskTemplate: taskTemplateKeys,


### PR DESCRIPTION
The AgentSidebar task list showed a skeleton on every fresh page load, even when the same data had already been fetched before. Its SWR key lived in a `sidebar:` domain that no `CACHE_TIERS` pattern matched, so the tiered cache provider kept it memory-only — unlike the tasks page's `task:groupList` key, which persists to IndexedDB and renders instantly on a second open.

This PR moves the key into the `task:` domain (`sidebar:taskGroups` → `task:sidebarGroups`, now defined under `taskKeys`), so it routes to the existing IndexedDB tier. On a second open the cache hydrates before mount, `isLoading` stays false, and the panel renders cached data while SWR revalidates in the background.

No cache migration is needed: the old key was never persisted, and the semantics are stale-while-revalidate as with the rest of the `task:` domain.

#### Test

- [x] Added/updated tests

Regression test in `src/libs/swr/keys.test.ts` asserts the serialized sidebar task-groups key matches a persisted `CACHE_TIERS` tier — it fails with the old `sidebar:` domain key and passes now.

#### 🔗 Related Issue

Fixes LOBE-12552