### PR TITLE
💄 style: add Kimi K3 Fast model description

### DIFF
--- a/packages/locales/src/modelDescriptionOverrides.ts
+++ b/packages/locales/src/modelDescriptionOverrides.ts
@@ -10,6 +10,8 @@ export const modelDescriptionOverrides = {
     'Intelligent, blazing-fast model that reasons before responding',
   'lobehub-glm-5.2-fast.description':
     'Fast variant of GLM-5.2 with substantially lower latency. Same capabilities as GLM-5.2 — costs more, but responds much faster.',
+  'lobehub-kimi-k3-fast.description':
+    'Fast variant of Kimi K3 with substantially lower latency. Same capabilities as Kimi K3 — costs more, but responds much faster.',
   'qwen3.8-max-preview.description':
     "Qwen3.8-Max-Preview is a preview of Alibaba's next-generation 2.4T-parameter flagship model, with major gains over Qwen3.7-Max in coding and professional productivity, and leading performance on complex long-horizon tasks such as full-stack development and data analysis.",
   'seedance-1-5-pro-251215.description':


### PR DESCRIPTION
Add the default English description for the online-only `lobehub-kimi-k3-fast` model, mirroring the existing GLM-5.2 Fast entry. Since #17577 online-only model descriptions live in the shared `modelDescriptionOverrides` map (consumed by both `default/models.ts` and the browser-only `default/models.vite.ts`).

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Generated and verified with the cloud repo's `sync-lobehub-model-locales.ts` sweep (`--check` passes; output is byte-identical to this edit).

#### 🔗 Related Issue

Related to #17577