### PR TITLE
💄 style: rename zh-CN model rating intelligence label to 智能

### DIFF
--- a/locales/zh-CN/components.json
+++ b/locales/zh-CN/components.json
@@ -171,7 +171,7 @@
   "ModelSwitchPanel.detail.rating.clickHint": "点击查看详情与对比",
   "ModelSwitchPanel.detail.rating.dimension.agentic": "Agentic",
   "ModelSwitchPanel.detail.rating.dimension.design": "设计",
-  "ModelSwitchPanel.detail.rating.dimension.intelligence": "智力",
+  "ModelSwitchPanel.detail.rating.dimension.intelligence": "智能",
   "ModelSwitchPanel.detail.rating.dimension.price": "价格",
   "ModelSwitchPanel.detail.rating.dimension.speed": "速度",
   "ModelSwitchPanel.detail.rating.dimension.writing": "写作",


### PR DESCRIPTION
Renames the zh-CN label for the model rating radar's intelligence dimension from 智力 to 智能, which reads more naturally as the translation of "Intelligence" in this context.

| Before | After |
| ------ | ----- |
| 智力   | 智能  |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

One-line zh-CN copy change; other locales are unchanged.