### PR TITLE
🐛 fix(agent-runtime): enforce scoped tool allowlists

### DIFF
--- a/packages/agent-runtime/src/agents/GeneralChatAgent.ts
+++ b/packages/agent-runtime/src/agents/GeneralChatAgent.ts
@@ -1,3 +1,4 @@
+import { ToolNameResolver } from '@lobechat/context-engine';
 import {
   type ChatToolPayload,
   type ExtendedHumanInterventionConfig,
@@ -25,6 +26,10 @@ import {
   type SubAgentsBatchResultPayload,
 } from '../types';
 import { shouldCompress } from '../utils/tokenCounter';
+
+const TOOL_NOT_ALLOWED_CONTENT =
+  'Tool execution blocked because the tool is not allowed in the current execution scope.';
+const TOOL_NOT_ALLOWED_REASON = 'tool_not_allowed';
 
 /**
  * ChatAgent - The "Brain" of the chat agent
@@ -54,6 +59,24 @@ export class GeneralChatAgent implements Agent {
     return this.config.allowedToolNames === undefined
       ? {}
       : { allowedToolNames: this.config.allowedToolNames };
+  }
+
+  private partitionToolsByAllowList(toolsCalling: ChatToolPayload[]) {
+    if (this.config.allowedToolNames === undefined) {
+      return { allowedTools: toolsCalling, blockedTools: [] };
+    }
+
+    const allowedToolNames = new Set(this.config.allowedToolNames);
+    const toolNameResolver = new ToolNameResolver();
+    const allowedTools: ChatToolPayload[] = [];
+    const blockedTools: ChatToolPayload[] = [];
+
+    for (const tool of toolsCalling) {
+      const toolName = toolNameResolver.generate(tool.identifier, tool.apiName, tool.type);
+      (allowedToolNames.has(toolName) ? allowedTools : blockedTools).push(tool);
+    }
+
+    return { allowedTools, blockedTools };
   }
 
   /**
@@ -515,9 +538,10 @@ export class GeneralChatAgent implements Agent {
           context.payload as GeneralAgentCallLLMResultPayload;
 
         if (hasToolsCalling && toolsCalling && toolsCalling.length > 0) {
+          const { allowedTools, blockedTools } = this.partitionToolsByAllowList(toolsCalling);
           // Check which tools need human intervention
           const [toolsNeedingIntervention, toolsToExecute] = await this.checkInterventionNeeded(
-            toolsCalling,
+            allowedTools,
             state,
           );
 
@@ -570,6 +594,18 @@ export class GeneralChatAgent implements Agent {
                 type: 'request_human_approve',
               });
             }
+          }
+
+          if (blockedTools.length > 0) {
+            instructions.push({
+              payload: {
+                blockedContent: TOOL_NOT_ALLOWED_CONTENT,
+                blockedReason: TOOL_NOT_ALLOWED_REASON,
+                parentMessageId,
+                toolsCalling: blockedTools,
+              },
+              type: 'resolve_blocked_tools',
+            } satisfies AgentInstruction);
           }
 
           return instructions;

--- a/packages/agent-runtime/src/agents/GeneralChatAgent.ts
+++ b/packages/agent-runtime/src/agents/GeneralChatAgent.ts
@@ -62,6 +62,7 @@ export class GeneralChatAgent implements Agent {
   }
 
   private partitionToolsByAllowList(toolsCalling: ChatToolPayload[]) {
+    // An omitted allow-list preserves unrestricted behavior; an explicit empty list blocks all tools.
     if (this.config.allowedToolNames === undefined) {
       return { allowedTools: toolsCalling, blockedTools: [] };
     }
@@ -569,6 +570,19 @@ export class GeneralChatAgent implements Agent {
             }
           }
 
+          // Resolve denied tools before an approval request parks the runtime.
+          if (blockedTools.length > 0) {
+            instructions.push({
+              payload: {
+                blockedContent: TOOL_NOT_ALLOWED_CONTENT,
+                blockedReason: TOOL_NOT_ALLOWED_REASON,
+                parentMessageId,
+                toolsCalling: blockedTools,
+              },
+              type: 'resolve_blocked_tools',
+            } satisfies AgentInstruction);
+          }
+
           // Request approval for tools that need intervention
           // Non-headless mode waits for human approval; headless mode returns blocked tool results.
           if (toolsNeedingIntervention.length > 0) {
@@ -594,18 +608,6 @@ export class GeneralChatAgent implements Agent {
                 type: 'request_human_approve',
               });
             }
-          }
-
-          if (blockedTools.length > 0) {
-            instructions.push({
-              payload: {
-                blockedContent: TOOL_NOT_ALLOWED_CONTENT,
-                blockedReason: TOOL_NOT_ALLOWED_REASON,
-                parentMessageId,
-                toolsCalling: blockedTools,
-              },
-              type: 'resolve_blocked_tools',
-            } satisfies AgentInstruction);
           }
 
           return instructions;

--- a/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
+++ b/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
@@ -424,6 +424,101 @@ describe('GeneralChatAgent', () => {
       ]);
     });
 
+    it('should block every tool when allowedToolNames is empty', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        allowedToolNames: [],
+        operationId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+      const toolCall: ChatToolPayload = {
+        apiName: 'runCommand',
+        arguments: '{}',
+        id: 'call-1',
+        identifier: 'lobe-local-system',
+        type: 'builtin',
+      };
+
+      const result = await agent.runner(
+        createMockContext('llm_result', {
+          hasToolsCalling: true,
+          parentMessageId: 'msg-1',
+          toolsCalling: [toolCall],
+        }),
+        createMockState(),
+      );
+
+      expect(result).toEqual([
+        {
+          payload: {
+            blockedContent:
+              'Tool execution blocked because the tool is not allowed in the current execution scope.',
+            blockedReason: 'tool_not_allowed',
+            parentMessageId: 'msg-1',
+            toolsCalling: [toolCall],
+          },
+          type: 'resolve_blocked_tools',
+        },
+      ]);
+    });
+
+    it('should send allowed tools through intervention checks and block the rest', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        allowedToolNames: ['lobe-local-system____readFile'],
+        operationId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+      const readFile: ChatToolPayload = {
+        apiName: 'readFile',
+        arguments: '{}',
+        id: 'call-read',
+        identifier: 'lobe-local-system',
+        type: 'builtin',
+      };
+      const runCommand: ChatToolPayload = {
+        apiName: 'runCommand',
+        arguments: '{}',
+        id: 'call-command',
+        identifier: 'lobe-local-system',
+        type: 'builtin',
+      };
+
+      const result = await agent.runner(
+        createMockContext('llm_result', {
+          hasToolsCalling: true,
+          parentMessageId: 'msg-1',
+          toolsCalling: [readFile, runCommand],
+        }),
+        createMockState({
+          toolManifestMap: {
+            'lobe-local-system': {
+              api: [{ name: 'readFile' }, { name: 'runCommand' }],
+              identifier: 'lobe-local-system',
+              type: 'builtin',
+            },
+          },
+        }),
+      );
+
+      expect(result).toEqual([
+        {
+          payload: { parentMessageId: 'msg-1', toolCalling: readFile },
+          type: 'call_tool',
+        },
+        {
+          payload: {
+            blockedContent:
+              'Tool execution blocked because the tool is not allowed in the current execution scope.',
+            blockedReason: 'tool_not_allowed',
+            parentMessageId: 'msg-1',
+            toolsCalling: [runCommand],
+          },
+          type: 'resolve_blocked_tools',
+        },
+      ]);
+    });
+
     it('should handle invalid JSON in tool arguments gracefully', async () => {
       const agent = new GeneralChatAgent({
         agentConfig: { maxSteps: 100 },

--- a/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
+++ b/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
@@ -462,10 +462,10 @@ describe('GeneralChatAgent', () => {
       ]);
     });
 
-    it('should send allowed tools through intervention checks and block the rest', async () => {
+    it('should execute allowed tools, resolve denied tools, then pause for approval', async () => {
       const agent = new GeneralChatAgent({
         agentConfig: { maxSteps: 100 },
-        allowedToolNames: ['lobe-local-system____readFile'],
+        allowedToolNames: ['lobe-local-system____readFile', 'lobe-local-system____deleteFile'],
         operationId: 'test-session',
         modelRuntimeConfig: mockModelRuntimeConfig,
       });
@@ -473,6 +473,13 @@ describe('GeneralChatAgent', () => {
         apiName: 'readFile',
         arguments: '{}',
         id: 'call-read',
+        identifier: 'lobe-local-system',
+        type: 'builtin',
+      };
+      const deleteFile: ChatToolPayload = {
+        apiName: 'deleteFile',
+        arguments: '{}',
+        id: 'call-delete',
         identifier: 'lobe-local-system',
         type: 'builtin',
       };
@@ -488,12 +495,16 @@ describe('GeneralChatAgent', () => {
         createMockContext('llm_result', {
           hasToolsCalling: true,
           parentMessageId: 'msg-1',
-          toolsCalling: [readFile, runCommand],
+          toolsCalling: [readFile, deleteFile, runCommand],
         }),
         createMockState({
           toolManifestMap: {
             'lobe-local-system': {
-              api: [{ name: 'readFile' }, { name: 'runCommand' }],
+              api: [
+                { name: 'readFile' },
+                { humanIntervention: 'require', name: 'deleteFile' },
+                { name: 'runCommand' },
+              ],
               identifier: 'lobe-local-system',
               type: 'builtin',
             },
@@ -515,6 +526,12 @@ describe('GeneralChatAgent', () => {
             toolsCalling: [runCommand],
           },
           type: 'resolve_blocked_tools',
+        },
+        {
+          parentMessageId: 'msg-1',
+          pendingToolsCalling: [deleteFile],
+          reason: 'human_intervention_required',
+          type: 'request_human_approve',
         },
       ]);
     });

--- a/packages/agent-runtime/src/agents/__tests__/GraphAgent.test.ts
+++ b/packages/agent-runtime/src/agents/__tests__/GraphAgent.test.ts
@@ -766,6 +766,50 @@ describe('GraphAgent', () => {
       ).toEqual([readToolName, searchToolName]);
     });
 
+    it('should reject a resolved tool call outside the active node allow-list', async () => {
+      const agent = new GraphAgent({
+        agentConfig: { maxSteps: 100 },
+        graph: loadGoalLoopGraph(),
+        modelRuntimeConfig: { model: 'gpt-4', provider: 'openai' },
+        operationId: 'test-operation',
+      });
+      const state = createMockState({
+        messages: [{ content: '/goal inspect workspace', role: 'user' }],
+      });
+      const writeToolCall = {
+        apiName: 'write',
+        arguments: '{}',
+        id: 'call-write',
+        identifier: 'workspace',
+        type: 'builtin' as const,
+      };
+
+      expectCallLlm(await agent.runner(createContext('init'), state));
+
+      const instruction = await agent.runner(
+        createContext('llm_result', {
+          hasToolsCalling: true,
+          parentMessageId: 'assistant-msg-1',
+          result: { content: '', tool_calls: [] },
+          toolsCalling: [writeToolCall],
+        }),
+        state,
+      );
+
+      expect(instruction).toEqual([
+        {
+          payload: {
+            blockedContent:
+              'Tool execution blocked because the tool is not allowed in the current execution scope.',
+            blockedReason: 'tool_not_allowed',
+            parentMessageId: 'assistant-msg-1',
+            toolsCalling: [writeToolCall],
+          },
+          type: 'resolve_blocked_tools',
+        },
+      ]);
+    });
+
     it('should not add a tool allow-list when delegating an unrestricted agent node', async () => {
       const graph = loadGoalLoopGraph();
       const planNode = graph.nodes.plan;

--- a/packages/agent-runtime/src/executors/resolveTools.test.ts
+++ b/packages/agent-runtime/src/executors/resolveTools.test.ts
@@ -126,6 +126,43 @@ describe('resolveTools executors', () => {
     });
   });
 
+  it('persists a caller-provided blocked reason and content', async () => {
+    const instruction: Extract<AgentInstruction, { type: 'resolve_blocked_tools' }> = {
+      payload: {
+        blockedContent: 'Tool is outside the current execution scope.',
+        blockedReason: 'tool_not_allowed',
+        parentMessageId: 'assistant-msg-1',
+        toolsCalling: [createToolCall()],
+      },
+      type: 'resolve_blocked_tools',
+    };
+
+    const result = await resolveBlockedTools(host)(instruction, createState());
+
+    expect(createToolMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'Tool is outside the current execution scope.',
+        pluginError: 'tool_not_allowed',
+        pluginIntervention: {
+          rejectedReason: 'tool_not_allowed',
+          status: 'rejected',
+        },
+        pluginState: { reason: 'tool_not_allowed', type: 'blocked' },
+      }),
+    );
+    expect(result.events).toContainEqual({
+      id: 'tool-call-1',
+      result: {
+        content: 'Tool is outside the current execution scope.',
+        error: 'tool_not_allowed',
+        executionTime: 0,
+        state: { reason: 'tool_not_allowed', type: 'blocked' },
+        success: false,
+      },
+      type: 'tool_result',
+    });
+  });
+
   it('persists aborted tools and completes the operation as user_aborted', async () => {
     const instruction: Extract<AgentInstruction, { type: 'resolve_aborted_tools' }> = {
       payload: {

--- a/packages/agent-runtime/src/executors/resolveTools.ts
+++ b/packages/agent-runtime/src/executors/resolveTools.ts
@@ -86,6 +86,8 @@ export const resolveBlockedTools =
     const topicId = operation.topicId ?? state.metadata?.topicId;
     const events: AgentEvent[] = [];
     const newState = structuredClone(state);
+    const blockedContent = payload.blockedContent ?? BLOCKED_TOOL_CONTENT;
+    const blockedReason = payload.blockedReason ?? BLOCKED_TOOL_ERROR;
     const toolResults: Array<{ data: ToolRunResult; toolCallId: string }> = [];
     const toolMessageIds: string[] = [];
 
@@ -97,10 +99,13 @@ export const resolveBlockedTools =
 
     for (const toolPayload of payload.toolsCalling) {
       const result: ToolRunResult = {
-        content: BLOCKED_TOOL_CONTENT,
-        error: BLOCKED_TOOL_ERROR,
+        content: blockedContent,
+        error: blockedReason,
         executionTime: 0,
-        state: { type: 'blocked' },
+        state: {
+          ...(payload.blockedReason && { reason: blockedReason }),
+          type: 'blocked',
+        },
         success: false,
       };
 
@@ -128,7 +133,7 @@ export const resolveBlockedTools =
           plugin: toolPayload as any,
           pluginError: result.error,
           pluginIntervention: {
-            rejectedReason: BLOCKED_TOOL_ERROR,
+            rejectedReason: blockedReason,
             status: 'rejected',
           },
           pluginState: result.state,


### PR DESCRIPTION
<!-- Brief and heads-up -->

## Summary

Enforce `allowedToolNames` at the agent execution boundary.

Graph nodes pass their resolved tool allow-list to `GeneralChatAgent`. An LLM can still emit a call outside that scope when prompt context mentions an unavailable tool or an upstream schema exposes it. `GeneralChatAgent` now partitions returned calls before intervention checks and routes disallowed calls through the existing `resolve_blocked_tools` security path with the reason `tool_not_allowed`.

An omitted allow-list remains unrestricted for backward compatibility, while an explicit empty allow-list blocks every tool.

The blocked-tool executor now persists caller-provided `blockedContent` and `blockedReason` in the tool message, intervention state, and emitted tool result.

Heads-up: this PR adds execution-time enforcement. It does not remove upstream prompt or tool-schema references to unavailable tools.

## Risk

A repository-wide `rg` search found that `GraphAgent` is the only production caller that explicitly supplies `allowedToolNames`. The remaining matches define the payload types, pass the value through client/server context builders, consume it in `ToolResolver`, or test those paths. The ordinary client and server `GeneralChatAgent` constructors omit the field, so they retain unrestricted behavior.

The substantive in-repository behavior change is therefore limited to Graph runtime nodes that set `allowedToolApiNames` or intentionally resolve to an empty tool list. `GeneralAgentConfig` is a public package type, so an external consumer that already supplies `allowedToolNames` will also receive the new execution-time enforcement.

<!-- If this PR includes UI changes, please provide screenshots or videos. -->

| Before | After |
| ------ | ----- |
| A Graph node could receive an out-of-scope tool call such as `runCommand` and continue through the normal intervention/execution path. | The runtime rejects the call before intervention/execution with `tool_not_allowed` and continues allowed calls from the same response. |

#### Test

<!-- How you tested your changes -->

Automated coverage includes:

- An explicit empty allow-list blocks every returned tool call.
- Mixed allowed/disallowed calls execute only the allowed subset and reject the rest.
- A Graph agent node rejects a resolved tool call outside its active node allow-list.
- Caller-provided blocked content and reason are persisted to messages and runtime events.
- An unrestricted Graph node continues to omit `allowedToolNames` and retains all tools.

Local smoke scenarios:

- A read-only Graph inspection node successfully invoked the allowed `createPlan` and `createTodos` tools.
- An adversarial prompt forced a real `lobe-skills/runCommand` tool call. The runtime persisted a rejected tool result with `rejectedReason: tool_not_allowed`, `toolExecutionTimeMs: 0`, and zero executed tool calls.


- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

N/A
