### PR TITLE
💄 fix(business-const): de-hardcode LobeHub brand strings from LLM system prompts

### DIFF
--- a/packages/builtin-agents/src/agents/agent-builder/systemRole.ts
+++ b/packages/builtin-agents/src/agents/agent-builder/systemRole.ts
@@ -1,9 +1,11 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
+
 /**
  * Agent Builder System Role Template
  *
  * This agent helps users configure and optimize their AI agents through natural conversation.
  */
-export const systemRoleTemplate = `You are Lobe, an Agent Builder integrated into LobeHub. Your role is to help users configure and optimize their AI agents through natural conversation.
+export const systemRoleTemplate = `You are Lobe, an Agent Builder integrated into ${BRANDING_NAME}. Your role is to help users configure and optimize their AI agents through natural conversation.
 
 <capabilities>
 You have access to tools that can read and modify agent configurations:

--- a/packages/builtin-agents/src/agents/group-supervisor/systemRole.ts
+++ b/packages/builtin-agents/src/agents/group-supervisor/systemRole.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
+
 /**
  * System role template for Group Supervisor agent
  *
@@ -9,7 +11,7 @@
  * - {{model}} - Current model ID (requires )
  * - {{provider}} - Current provider (requires )
  */
-export const supervisorSystemRole = `You are LobeAI, an intelligent team coordinator developed by LobeHub, powered by {{model}}. You are orchestrating the multi-agent group "{{GROUP_TITLE}}". Your primary responsibility is to facilitate productive, natural conversations by strategically coordinating when and how AI agents participate.
+export const supervisorSystemRole = `You are LobeAI, an intelligent team coordinator developed by ${BRANDING_NAME}, powered by {{model}}. You are orchestrating the multi-agent group "{{GROUP_TITLE}}". Your primary responsibility is to facilitate productive, natural conversations by strategically coordinating when and how AI agents participate.
 
 <system_context>
 - Current date: {{date}}

--- a/packages/builtin-tool-activator/package.json
+++ b/packages/builtin-tool-activator/package.json
@@ -9,6 +9,9 @@
     "./executionRuntime": "./src/ExecutionRuntime/index.ts"
   },
   "main": "./src/index.ts",
+  "dependencies": {
+    "@lobechat/business-const": "workspace:*"
+  },
   "devDependencies": {
     "@lobechat/prompts": "workspace:*",
     "@lobechat/types": "workspace:*"

--- a/packages/builtin-tool-activator/src/systemRole.ts
+++ b/packages/builtin-tool-activator/src/systemRole.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
+
 export const systemPrompt = `You have access to a Tools Activator that allows you to dynamically activate tools on demand. Not all tools are loaded by default — you must activate them before use.
 
 <how_it_works>
@@ -73,7 +75,7 @@ export const systemPrompt = `You have access to a Tools Activator that allows yo
 2. Check if the required credential already exists using the credentials list in context
 3. If credential exists → use \`getPlaintextCred\` or \`injectCredsToSandbox\` (for sandbox execution)
 4. If credential doesn't exist:
-   - For LobeHub OAuth services (GitHub, Linear, Microsoft, Notion, Twitter) → use \`initiateOAuthConnect\`
+   - For ${BRANDING_NAME} OAuth services (GitHub, Linear, Microsoft, Notion, Twitter) → use \`initiateOAuthConnect\`
    - For Composio-managed services (Slack, Google Drive, Airtable, Jira, etc.)
      → use \`connectComposioService\` after activating \`lobe-creds\`. The full list of
      available Composio services is shown in \`<composio_integrations>\` inside the

--- a/packages/builtin-tool-agent-management/package.json
+++ b/packages/builtin-tool-agent-management/package.json
@@ -10,6 +10,7 @@
   "main": "./src/index.ts",
   "dependencies": {
     "@lobechat/agent-manager-runtime": "workspace:*",
+    "@lobechat/business-const": "workspace:*",
     "@lobechat/const": "workspace:*",
     "@lobechat/heterogeneous-agents": "workspace:*",
     "lucide-react": "^1.22.0",

--- a/packages/builtin-tool-agent-management/src/systemRole.ts
+++ b/packages/builtin-tool-agent-management/src/systemRole.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
+
 /**
  * System role for Agent Management tool
  *
@@ -98,9 +100,9 @@ You are a [role] specialized in [domain].
 
 When selecting a model, follow this priority order:
 
-1. **First Priority - LobeHub Provider Models**:
+1. **First Priority - ${BRANDING_NAME} Provider Models**:
    - If available, prioritize models from the "lobehub" provider
-   - These are optimized for the LobeHub ecosystem
+   - These are optimized for the ${BRANDING_NAME} ecosystem
 
 2. **Second Priority - Premium Frontier Models**:
    - **Anthropic**: Claude Sonnet 4.5, Claude Opus 4.5, or newer Opus/Sonnet series

--- a/packages/builtin-tool-creds/package.json
+++ b/packages/builtin-tool-creds/package.json
@@ -9,7 +9,9 @@
     "./executor": "./src/executor/index.ts"
   },
   "main": "./src/index.ts",
-  "dependencies": {},
+  "dependencies": {
+    "@lobechat/business-const": "workspace:*"
+  },
   "devDependencies": {
     "@lobechat/types": "workspace:*"
   }

--- a/packages/builtin-tool-creds/src/manifest.ts
+++ b/packages/builtin-tool-creds/src/manifest.ts
@@ -1,3 +1,4 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
 import type { BuiltinToolManifest } from '@lobechat/types';
 import type { JSONSchema7 } from 'json-schema';
 
@@ -26,8 +27,7 @@ export const CredsManifest: BuiltinToolManifest = {
       } satisfies JSONSchema7,
     },
     {
-      description:
-        'Initiate OAuth connection flow for a LobeHub Skill provider (e.g., GitHub, Linear, Microsoft Outlook, Notion, Twitter/X). Returns an authorization URL that the user must click to authorize. After authorization, the credential will be automatically saved.',
+      description: `Initiate OAuth connection flow for a ${BRANDING_NAME} Skill provider (e.g., GitHub, Linear, Microsoft Outlook, Notion, Twitter/X). Returns an authorization URL that the user must click to authorize. After authorization, the credential will be automatically saved.`,
       name: CredsApiName.initiateOAuthConnect,
       parameters: {
         additionalProperties: false,

--- a/packages/builtin-tool-creds/src/systemRole.ts
+++ b/packages/builtin-tool-creds/src/systemRole.ts
@@ -1,4 +1,6 @@
-export const systemPrompt = `You have access to a LobeHub Credentials Tool. This tool helps you securely manage and use credentials (API keys, tokens, secrets) for various services.
+import { BRANDING_NAME } from '@lobechat/business-const';
+
+export const systemPrompt = `You have access to a ${BRANDING_NAME} Credentials Tool. This tool helps you securely manage and use credentials (API keys, tokens, secrets) for various services.
 
 <session_context>
 Current user: {{username}}
@@ -19,7 +21,7 @@ Sandbox mode: {{sandbox_enabled}}
 
 <core_responsibilities>
 1. **Awareness**: Know what credentials the user has configured and suggest relevant ones when needed.
-2. **Guidance**: When you detect sensitive information (API keys, tokens, passwords) in the conversation, guide the user to save them securely in LobeHub.
+2. **Guidance**: When you detect sensitive information (API keys, tokens, passwords) in the conversation, guide the user to save them securely in ${BRANDING_NAME}.
 3. **Runtime Integration**: When sandbox mode is enabled, use \`injectCredsToSandbox\` to inject credentials into the sandbox environment.
 4. **Ownership disclosure**: In a workspace, some listed credentials are tagged \`[shared by <name>]\` (a teammate's own credential they chose to share) or \`[workspace credential]\` (owned by the workspace itself). Never present a shared credential as if it belongs to the workspace or to you — when it's relevant, tell the user whose credential is actually being used.
 </core_responsibilities>
@@ -35,7 +37,7 @@ Sandbox mode: {{sandbox_enabled}}
 </tooling>
 
 <oauth_providers>
-LobeHub provides built-in OAuth integrations for the following services:
+${BRANDING_NAME} provides built-in OAuth integrations for the following services:
 - **github**: GitHub repository and code management. Connect to access repositories, create issues, manage pull requests.
 - **linear**: Linear issue tracking and project management. Connect to create/manage issues, track projects.
 - **microsoft**: Microsoft Outlook Calendar. Connect to view/create calendar events, manage meetings.
@@ -48,7 +50,7 @@ When a user mentions they want to use one of these services, use \`initiateOAuth
 <security_guidelines>
 - **Never display credential values** in your responses. Refer to credentials by their key or name only.
 - **Prompt for saving**: When you see users share sensitive information like API keys or tokens, suggest:
-  "I noticed you shared a sensitive credential. Would you like me to save it securely in LobeHub? This way you can reuse it without sharing it again."
+  "I noticed you shared a sensitive credential. Would you like me to save it securely in ${BRANDING_NAME}? This way you can reuse it without sharing it again."
 - **Explain the benefit**: Let users know that saved credentials are encrypted and can be easily reused across conversations.
 </security_guidelines>
 

--- a/packages/builtin-tool-group-agent-builder/package.json
+++ b/packages/builtin-tool-group-agent-builder/package.json
@@ -11,7 +11,8 @@
   "main": "./src/index.ts",
   "dependencies": {
     "@lobechat/agent-manager-runtime": "workspace:*",
-    "@lobechat/builtin-tool-agent-builder": "workspace:*"
+    "@lobechat/builtin-tool-agent-builder": "workspace:*",
+    "@lobechat/business-const": "workspace:*"
   },
   "devDependencies": {
     "@lobechat/types": "workspace:*"

--- a/packages/builtin-tool-group-agent-builder/src/systemRole.ts
+++ b/packages/builtin-tool-group-agent-builder/src/systemRole.ts
@@ -1,10 +1,12 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
+
 /**
  * System role for Group Agent Builder tool
  *
  * This provides guidance on how to effectively use the group agent builder tools
  * for configuring group chats and managing group members.
  */
-export const systemPrompt = `You are a Group Configuration Assistant integrated into LobeHub. Your role is to help users configure and optimize their multi-agent group chats through natural conversation.
+export const systemPrompt = `You are a Group Configuration Assistant integrated into ${BRANDING_NAME}. Your role is to help users configure and optimize their multi-agent group chats through natural conversation.
 
 <context_awareness>
 **Important**: The current group's configuration, metadata, member agents, and available tools are automatically injected into the conversation context as \`<current_group_context>\`. You can reference this information directly without calling any read APIs.

--- a/packages/builtin-tool-memory/package.json
+++ b/packages/builtin-tool-memory/package.json
@@ -12,6 +12,7 @@
   "main": "./src/index.ts",
   "scripts": {},
   "dependencies": {
+    "@lobechat/business-const": "workspace:*",
     "@lobechat/memory-user-memory": "workspace:*",
     "@lobechat/prompts": "workspace:*"
   },

--- a/packages/builtin-tool-memory/src/systemRole.ts
+++ b/packages/builtin-tool-memory/src/systemRole.ts
@@ -1,4 +1,6 @@
-export const systemPrompt = `You have a LobeHub Memory Tool. This tool is to recognise, retrieve, and coordinate high-quality user memories so downstream extractors can persist them accurately.
+import { BRANDING_NAME } from '@lobechat/business-const';
+
+export const systemPrompt = `You have a ${BRANDING_NAME} Memory Tool. This tool is to recognise, retrieve, and coordinate high-quality user memories so downstream extractors can persist them accurately.
 
 <session_context>
 Current user: {{username}}

--- a/packages/builtin-tool-message/package.json
+++ b/packages/builtin-tool-message/package.json
@@ -10,6 +10,9 @@
     "./executionRuntime": "./src/ExecutionRuntime/index.ts"
   },
   "main": "./src/index.ts",
+  "dependencies": {
+    "@lobechat/business-const": "workspace:*"
+  },
   "devDependencies": {
     "@lobechat/types": "workspace:*"
   },

--- a/packages/builtin-tool-message/src/manifest.ts
+++ b/packages/builtin-tool-message/src/manifest.ts
@@ -1,3 +1,4 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
 import type { BuiltinToolManifest } from '@lobechat/types';
 
 import { systemPrompt } from './systemRole';
@@ -854,8 +855,7 @@ export const MessageManifest: BuiltinToolManifest = {
 
     // ==================== System Bot Messenger Management ====================
     {
-      description:
-        "List the current user's LobeHub System Bot connections (Slack workspaces, Discord guilds, Telegram, and user-owned WeChat accounts). Each entry returns an `id` to pass back as `installationId` on `getMessengerDetail` / `uninstallMessenger`, or as `messengerInstallationId` on send APIs. Use this when the user asks about connected messengers, or as the fallback when `listBots` has no entry for the target platform.",
+      description: `List the current user's ${BRANDING_NAME} System Bot connections (Slack workspaces, Discord guilds, Telegram, and user-owned WeChat accounts). Each entry returns an \`id\` to pass back as \`installationId\` on \`getMessengerDetail\` / \`uninstallMessenger\`, or as \`messengerInstallationId\` on send APIs. Use this when the user asks about connected messengers, or as the fallback when \`listBots\` has no entry for the target platform.`,
       name: MessageApiName.listMessengers,
       parameters: {
         additionalProperties: false,
@@ -896,8 +896,7 @@ export const MessageManifest: BuiltinToolManifest = {
       },
     },
     {
-      description:
-        'List the platforms where the user can connect the LobeHub System Bot. Returns `appId` / `botUsername` when relevant. Use when guiding the user through `Settings → Messenger`; browser OAuth and QR setup flows cannot be initiated from this tool.',
+      description: `List the platforms where the user can connect the ${BRANDING_NAME} System Bot. Returns \`appId\` / \`botUsername\` when relevant. Use when guiding the user through \`Settings → Messenger\`; browser OAuth and QR setup flows cannot be initiated from this tool.`,
       name: MessageApiName.listMessengerPlatforms,
       parameters: {
         additionalProperties: false,

--- a/packages/builtin-tool-message/src/systemRole.ts
+++ b/packages/builtin-tool-message/src/systemRole.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
+
 export const systemPrompt = `You have access to a Message tool that provides unified messaging and bot management capabilities across multiple platforms.
 
 <supported_platforms>
@@ -25,13 +27,13 @@ export const systemPrompt = `You have access to a Message tool that provides uni
 The send APIs (\`sendMessage\`, \`sendDirectMessage\`, \`replyToThread\`) can deliver through **two sources** — both use the same underlying platform clients (so attachments / formatting / rate behavior are identical), but they come from different lists:
 
 - **Per-agent bot** (pass \`botId\`) — the agent's own credentials, configured via \`createBot\`. Listed by \`listBots\`. Messages appear with the per-agent bot's identity.
-- **System Bot installation** (pass \`messengerInstallationId\`) — the LobeHub shared bot, connected by the user via Settings → Messenger. Listed by \`listMessengers\`. Messages appear with the LobeHub System Bot identity.
+- **System Bot installation** (pass \`messengerInstallationId\`) — the ${BRANDING_NAME} shared bot, connected by the user via Settings → Messenger. Listed by \`listMessengers\`. Messages appear with the ${BRANDING_NAME} System Bot identity.
 
 **Two-step routing rule — apply in order:**
 
 1. **Call \`listBots\`.** If any entry has \`platform: "<target>"\` → use its \`botId\` on the send API. Done.
 2. **Otherwise call \`listMessengers\`.** If any entry has \`platform: "<target>"\` → use its \`id\` as \`messengerInstallationId\` on the send API. Done.
-3. **Neither has the platform → do NOT pick a different platform.** Tell the user: "I can't reach <platform> for you yet. You can either provision a dedicated bot for this agent with \`createBot\`, or install the LobeHub System Bot via Settings → Messenger." Stop.
+3. **Neither has the platform → do NOT pick a different platform.** Tell the user: "I can't reach <platform> for you yet. You can either provision a dedicated bot for this agent with \`createBot\`, or install the ${BRANDING_NAME} System Bot via Settings → Messenger." Stop.
 
 Per-agent bots always win because they're purpose-built for the current agent and use identity the user explicitly configured. Only fall back to System Bot when the agent has nothing for the platform. If the user **explicitly** asks to route through their System Bot install even when a per-agent bot exists, honor that and call \`listMessengers\` directly.
 
@@ -39,7 +41,7 @@ The send APIs accept **exactly one** of \`botId\` / \`messengerInstallationId\` 
 </outbound_routing>
 
 <system_bot_management>
-The **System Bot** is the LobeHub-owned shared bot the user connects via \`Settings → Messenger\`. It's separate from per-agent bots (\`createBot\` / \`listBots\`). This API surface mirrors the per-agent CRUD but operates on \`messenger_installations\` (workspace installs) and \`messenger_account_links\` (per-user routing plus user-owned WeChat credentials).
+The **System Bot** is the ${BRANDING_NAME}-owned shared bot the user connects via \`Settings → Messenger\`. It's separate from per-agent bots (\`createBot\` / \`listBots\`). This API surface mirrors the per-agent CRUD but operates on \`messenger_installations\` (workspace installs) and \`messenger_account_links\` (per-user routing plus user-owned WeChat credentials).
 
 **Platform coverage** — System Bot supports **Slack, Discord, Telegram, and WeChat**. Slack / Discord use workspace install flows, Telegram uses a global bot, and WeChat uses a user-owned QR connection. For Feishu / Lark / QQ the user must use a per-agent bot via \`createBot\`. \`listMessengerPlatforms\` returns the currently-enabled subset on this deployment.
 
@@ -55,8 +57,8 @@ The **System Bot** is the LobeHub-owned shared bot the user connects via \`Setti
 7. **setMessengerActiveAgent** — Change which agent receives inbound IM on a link. Pass \`agentId: null\` to clear the active agent. Scope to one workspace via \`tenantId\`; omit for single-link platforms (Telegram / WeChat). The agent must belong to the current user — server rejects cross-user ids.
 
 **Critical disambiguation — \`uninstallMessenger\` vs \`unlinkMessenger\`:**
-- "remove my account from Slack" / "stop receiving DMs from this workspace on my LobeHub" → \`unlinkMessenger\`
-- "uninstall the LobeHub bot from my workspace" / "remove the integration for everyone" → \`uninstallMessenger\` (workspace-admin level decision)
+- "remove my account from Slack" / "stop receiving DMs from this workspace on my ${BRANDING_NAME}" → \`unlinkMessenger\`
+- "uninstall the ${BRANDING_NAME} bot from my workspace" / "remove the integration for everyone" → \`uninstallMessenger\` (workspace-admin level decision)
 
 When in doubt, ask. Defaulting to the destructive option (\`uninstallMessenger\`) when the user only wanted \`unlinkMessenger\` will affect colleagues.
 

--- a/packages/builtin-tool-self-iteration/package.json
+++ b/packages/builtin-tool-self-iteration/package.json
@@ -9,6 +9,9 @@
     "./executionRuntime": "./src/ExecutionRuntime/index.ts"
   },
   "main": "./src/index.ts",
+  "dependencies": {
+    "@lobechat/business-const": "workspace:*"
+  },
   "devDependencies": {
     "@lobechat/context-engine": "workspace:*",
     "@lobechat/types": "workspace:*"

--- a/packages/builtin-tool-self-iteration/src/systemRole.ts
+++ b/packages/builtin-tool-self-iteration/src/systemRole.ts
@@ -1,4 +1,6 @@
-export const systemPrompt = `You have access to the Self Feedback Intent tool. It is a high-recall side channel for telling LobeHub that the running agent has found a concrete opportunity to improve its future memory, skills, workflow, or system behavior.
+import { BRANDING_NAME } from '@lobechat/business-const';
+
+export const systemPrompt = `You have access to the Self Feedback Intent tool. It is a high-recall side channel for telling ${BRANDING_NAME} that the running agent has found a concrete opportunity to improve its future memory, skills, workflow, or system behavior.
 
 <core_contract>
 - **declareSelfFeedbackIntent** records advisory intent only. It does not directly mutate user memory, skills, prompts, documents, or product configuration.

--- a/packages/builtin-tool-skills/package.json
+++ b/packages/builtin-tool-skills/package.json
@@ -10,6 +10,7 @@
   },
   "main": "./src/index.ts",
   "dependencies": {
+    "@lobechat/business-const": "workspace:*",
     "@lobechat/const": "workspace:*",
     "@lobechat/prompts": "workspace:*",
     "@lobechat/shared-tool-ui": "workspace:*"

--- a/packages/builtin-tool-skills/src/systemRole.ts
+++ b/packages/builtin-tool-skills/src/systemRole.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
+
 export const systemPrompt = `You have access to a Skills tool that can activate skills and execute their instructions. Skills are reusable instruction packages that extend your capabilities.
 
 <core_capabilities>
@@ -31,7 +33,7 @@ export const systemPrompt = `You have access to a Skills tool that can activate 
 
 - **runCommand**: Call this to execute shell commands in the cloud sandbox
   - Use for general CLI commands, platform tools (e.g., \`lh\` CLI), and ad-hoc operations
-  - If \`lobe-local-system\` runCommand is also available, default shell execution to it — use this sandbox runCommand only when the task needs LobeHub-managed credentials, isolation, or a tool missing on the local device
+  - If \`lobe-local-system\` runCommand is also available, default shell execution to it — use this sandbox runCommand only when the task needs ${BRANDING_NAME}-managed credentials, isolation, or a tool missing on the local device
   - Provide the command to execute and a clear description of what it does
   - Returns the command output (stdout/stderr) and exit code
   - Requires user confirmation before execution

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -14,6 +14,7 @@
     "test:update": "vitest -u"
   },
   "dependencies": {
+    "@lobechat/business-const": "workspace:*",
     "@lobechat/const": "workspace:*"
   },
   "devDependencies": {

--- a/packages/prompts/src/prompts/agentSkillManager/consolidate.ts
+++ b/packages/prompts/src/prompts/agentSkillManager/consolidate.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
+
 /**
  * Input used by the focused skill consolidation prompt.
  */
@@ -64,7 +66,7 @@ Writing quality:
 Examples:
 Input: two skills both describe PR review, one covers locale placement and one covers cloud override checks.
 Output:
-{"bodyMarkdown":"# LobeHub Cloud PR Review\\n\\n## Workflow\\n- Check cloud override paths before reviewing the submodule implementation.\\n- Verify locale keys are added in the canonical submodule locale files.\\n- Cite concrete files and lines for every finding.\\n\\n## Pitfalls\\n- Do not treat submodule-only code as authoritative when a cloud override exists.","description":"Use when reviewing LobeHub Cloud PRs that may involve cloud overrides, locale keys, or submodule behavior.","rename":{"newName":"cloud-pr-review","newTitle":"Cloud PR Review"},"reason":"The source skills overlap and should activate as one review procedure.","confidence":0.88}
+{"bodyMarkdown":"# ${BRANDING_NAME} Cloud PR Review\\n\\n## Workflow\\n- Check cloud override paths before reviewing the submodule implementation.\\n- Verify locale keys are added in the canonical submodule locale files.\\n- Cite concrete files and lines for every finding.\\n\\n## Pitfalls\\n- Do not treat submodule-only code as authoritative when a cloud override exists.","description":"Use when reviewing ${BRANDING_NAME} Cloud PRs that may involve cloud overrides, locale keys, or submodule behavior.","rename":{"newName":"cloud-pr-review","newTitle":"Cloud PR Review"},"reason":"The source skills overlap and should activate as one review procedure.","confidence":0.88}
 
 Input: sources discuss unrelated workflows.
 Output:

--- a/packages/prompts/src/prompts/agentSkillManager/create.ts
+++ b/packages/prompts/src/prompts/agentSkillManager/create.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
+
 /**
  * Input used by the skill creation authoring prompt.
  */
@@ -72,7 +74,7 @@ Writing quality:
 Examples:
 Input: feedback says future PR reviews should always inspect locale key placement and existing cloud overrides; evidence includes the exact files to check.
 Output:
-{"name":"cloud-pr-review-checks","title":"Cloud PR Review Checks","description":"Use when reviewing LobeHub Cloud PRs that may touch locale keys, cloud overrides, or submodule behavior.","bodyMarkdown":"# Cloud PR Review Checks\\n\\n## Workflow\\n- Check cloud override paths before judging submodule code.\\n- Verify new locale keys live in the submodule locale defaults and zh-CN preview files.\\n- Confirm PR feedback cites exact files and lines.\\n\\n## Verification\\n- Run the focused tests or explain why they were not run.","reason":"The feedback describes a reusable review procedure with concrete checks.","confidence":0.86}
+{"name":"cloud-pr-review-checks","title":"Cloud PR Review Checks","description":"Use when reviewing ${BRANDING_NAME} Cloud PRs that may touch locale keys, cloud overrides, or submodule behavior.","bodyMarkdown":"# Cloud PR Review Checks\\n\\n## Workflow\\n- Check cloud override paths before judging submodule code.\\n- Verify new locale keys live in the submodule locale defaults and zh-CN preview files.\\n- Confirm PR feedback cites exact files and lines.\\n\\n## Verification\\n- Run the focused tests or explain why they were not run.","reason":"The feedback describes a reusable review procedure with concrete checks.","confidence":0.86}
 
 Input: feedback says thanks, that answer was helpful.
 Output:

--- a/packages/prompts/src/prompts/task/taskManagerDefaults.ts
+++ b/packages/prompts/src/prompts/task/taskManagerDefaults.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_INBOX_TITLE } from '@lobechat/const';
+
 export interface TaskManagerPromptDefaults {
   defaultAssigneeAgentId?: string;
 }
@@ -9,9 +11,9 @@ export const buildTaskManagerDefaultsBlock = ({
 
   return [
     '<task_manager_defaults>',
-    `Default Lobe AI agent id: ${defaultAssigneeAgentId}`,
-    'Use this id as assigneeAgentId when you decide a task should be assigned to the default Lobe AI assistant.',
-    "Do not use it as a listTasks filter unless the user asks for Lobe AI's tasks.",
+    `Default ${DEFAULT_INBOX_TITLE} agent id: ${defaultAssigneeAgentId}`,
+    `Use this id as assigneeAgentId when you decide a task should be assigned to the default ${DEFAULT_INBOX_TITLE} assistant.`,
+    `Do not use it as a listTasks filter unless the user asks for ${DEFAULT_INBOX_TITLE}'s tasks.`,
     '</task_manager_defaults>',
     '',
   ];

--- a/src/components/ModelSelect/index.tsx
+++ b/src/components/ModelSelect/index.tsx
@@ -1,3 +1,4 @@
+import { BRANDING_PROVIDER } from '@lobechat/business-const';
 import { type ChatModelCard } from '@lobechat/types';
 import { type IconAvatarProps } from '@lobehub/icons';
 import { LobeHub, ModelIcon, ProviderIcon } from '@lobehub/icons';
@@ -19,6 +20,8 @@ import { type CSSProperties, type FC } from 'react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ProductLogo } from '@/components/Branding/ProductLogo';
+import { isCustomBranding } from '@/const/version';
 import { type AiProviderSourceType } from '@/types/aiProvider';
 import { formatTokenNumber } from '@/utils/format';
 
@@ -360,6 +363,8 @@ export const ProviderItemRender = memo<ProviderItemRenderProps>(
             style={isMono ? { filter: 'grayscale(1)' } : {}}
             title={name}
           />
+        ) : isCustomBranding && provider === BRANDING_PROVIDER ? (
+          <ProductLogo size={size} type={isMono ? 'mono' : 'flat'} />
         ) : provider === 'lobehub' ? (
           <LobeHub.Morden size={size} />
         ) : (


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Part of LOBE-12279

#### 🔀 Description of Change

`builtin-tool-*` / `builtin-agents` `systemRole.ts` and `manifest.ts` files had `"LobeHub"` baked directly into the text fed to the model, so private-label deployments (`BRANDING_NAME` override) still had the model refer to itself as LobeHub in agent-builder, agent-management, self-iteration, skills, creds, group-agent-builder, memory, and message tools.

Interpolates `BRANDING_NAME` from `@lobechat/business-const` wherever the text is a self-reference to the running app. Left untouched:

- Mentions of the real hosted Skill Marketplace/Market (`lobehub.com`) and the LobeHub CLI — these name real external products, not this app's own branding.
- Technical identifiers (provider id `"lobehub"`, skill CLI slug) — unaffected by branding.

`packages/prompts`:
- `taskManagerDefaults.ts` now interpolates `DEFAULT_INBOX_TITLE` (the default-assistant name) instead of hardcoding `"Lobe AI"`.
- The two `agentSkillManager` few-shot examples interpolate `BRANDING_NAME` so OSS output stays byte-identical while CPC gets its own name in the example text.

Also fixes the model-picker provider icon (`ProviderItemRender` in `src/components/ModelSelect`) always rendering the stock LobeHub mascot for the branded provider regardless of custom-branding config, following the same `isCustomBranding` + `BRANDING_PROVIDER` pattern already used in `ProviderMenu/Item.tsx`.

Note: LOBE-12279's item #1 (default assistant identity hardcodes) was already fixed by `d3dcebf7d5` prior to this PR — not part of this change.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed (prompt-string edits; verified via `bun run check --lint` clean and confirmed no related tests exist for the touched files)

Manually verified via targeted `bun run check --type` that the only type-check failures are pre-existing, in files untouched by this PR.

#### 📝 Additional Information

Based on `feat/business-chat-extension-hooks` (not `canary`) since this is CPC-specific business/white-label work that accumulates on that integration branch before being PR'd upstream as a whole, per LOBE-12279.