### PR TITLE
🐛 fix(moonshot): support structured output with thinking

### DIFF
--- a/packages/model-runtime/src/providers/moonshot/index.test.ts
+++ b/packages/model-runtime/src/providers/moonshot/index.test.ts
@@ -692,7 +692,7 @@ describe('LobeMoonshotAnthropicAI', () => {
       expect(payload.thinking).toBeUndefined();
     });
 
-    it('should use any tool choice for Kimi tools while thinking is enabled', async () => {
+    it('should enable thinking and use any tool choice for Kimi thinking-toggle models', async () => {
       await instance.generateObject({
         messages: [{ content: 'Get the result', role: 'user' }],
         model: 'kimi-k2.6',
@@ -709,6 +709,19 @@ describe('LobeMoonshotAnthropicAI', () => {
       });
 
       const payload = getLastRequestPayload();
+      expect(payload.thinking).toEqual({ budget_tokens: 1024, type: 'enabled' });
+      expect(payload.tool_choice).toEqual({ type: 'any' });
+    });
+
+    it('should explicitly enable thinking for native K2.x models', async () => {
+      await instance.generateObject({
+        messages: [{ content: 'Extract the result', role: 'user' }],
+        model: 'kimi-k2.7-code',
+        schema,
+      });
+
+      const payload = getLastRequestPayload();
+      expect(payload.thinking).toEqual({ budget_tokens: 1024, type: 'enabled' });
       expect(payload.tool_choice).toEqual({ type: 'any' });
     });
 
@@ -718,7 +731,7 @@ describe('LobeMoonshotAnthropicAI', () => {
         model: 'kimi-k2.6',
         schema,
         thinking: { budget_tokens: 0, type: 'disabled' },
-      } as any);
+      });
 
       const payload = getLastRequestPayload();
       expect(payload.thinking).toEqual({ type: 'disabled' });

--- a/packages/model-runtime/src/providers/moonshot/index.test.ts
+++ b/packages/model-runtime/src/providers/moonshot/index.test.ts
@@ -664,6 +664,68 @@ describe('LobeMoonshotAnthropicAI', () => {
     });
   });
 
+  describe('generateObject', () => {
+    const schema = {
+      name: 'extract_result',
+      schema: {
+        properties: { result: { type: 'string' as const } },
+        required: ['result'],
+        type: 'object' as const,
+      },
+    };
+
+    beforeEach(() => {
+      ((instance as any).client.messages.create as Mock).mockResolvedValue({
+        content: [{ input: { result: 'ok' }, name: 'extract_result', type: 'tool_use' }],
+      });
+    });
+
+    it('should use any schema tool choice for always-thinking Kimi models', async () => {
+      await instance.generateObject({
+        messages: [{ content: 'Extract the result', role: 'user' }],
+        model: 'kimi-k3',
+        schema,
+      });
+
+      const payload = getLastRequestPayload();
+      expect(payload.tool_choice).toEqual({ type: 'any' });
+      expect(payload.thinking).toBeUndefined();
+    });
+
+    it('should use any tool choice for Kimi tools while thinking is enabled', async () => {
+      await instance.generateObject({
+        messages: [{ content: 'Get the result', role: 'user' }],
+        model: 'kimi-k2.6',
+        tools: [
+          {
+            function: {
+              description: 'Get a result',
+              name: 'get_result',
+              parameters: { properties: {}, type: 'object' },
+            },
+            type: 'function',
+          },
+        ],
+      });
+
+      const payload = getLastRequestPayload();
+      expect(payload.tool_choice).toEqual({ type: 'any' });
+    });
+
+    it('should preserve forced schema tool choice when Kimi thinking is disabled', async () => {
+      await instance.generateObject({
+        messages: [{ content: 'Extract the result', role: 'user' }],
+        model: 'kimi-k2.6',
+        schema,
+        thinking: { budget_tokens: 0, type: 'disabled' },
+      } as any);
+
+      const payload = getLastRequestPayload();
+      expect(payload.thinking).toEqual({ type: 'disabled' });
+      expect(payload.tool_choice).toEqual({ name: 'extract_result', type: 'tool' });
+    });
+  });
+
   describe('handlePayload', () => {
     describe('empty assistant messages', () => {
       it('should replace empty string assistant message with a space', async () => {

--- a/packages/model-runtime/src/providers/moonshot/index.test.ts
+++ b/packages/model-runtime/src/providers/moonshot/index.test.ts
@@ -725,6 +725,31 @@ describe('LobeMoonshotAnthropicAI', () => {
       expect(payload.tool_choice).toEqual({ type: 'any' });
     });
 
+    it('should normalize assistant history when thinking is enabled', async () => {
+      await instance.generateObject({
+        messages: [
+          { content: 'Initial question', role: 'user' },
+          { content: 'Previous answer', role: 'assistant' },
+          { content: 'Extract the result', role: 'user' },
+        ],
+        model: 'kimi-k2.7-code',
+        schema,
+      });
+
+      const payload = getLastRequestPayload();
+      expect(payload.messages).toEqual([
+        { content: 'Initial question', role: 'user' },
+        {
+          content: [
+            { thinking: ' ', type: 'thinking' },
+            { text: 'Previous answer', type: 'text' },
+          ],
+          role: 'assistant',
+        },
+        { content: 'Extract the result', role: 'user' },
+      ]);
+    });
+
     it('should preserve forced schema tool choice when Kimi thinking is disabled', async () => {
       await instance.generateObject({
         messages: [{ content: 'Extract the result', role: 'user' }],

--- a/packages/model-runtime/src/providers/moonshot/index.ts
+++ b/packages/model-runtime/src/providers/moonshot/index.ts
@@ -303,7 +303,10 @@ const buildMoonshotOpenAIPayload = (
  * Kimi's Anthropic-compatible endpoint maps forced tool choices to `specified`,
  * which is incompatible with thinking mode, but accepts `{ type: "any" }`.
  * With a single schema tool this still forces structured output.
+ * K2.x thinking models also require an explicit `thinking` parameter on this
+ * endpoint, while K3+ uses `reasoning_effort` and must omit it.
  * https://platform.kimi.com/docs/guide/kimi-k2-7-code-quickstart
+ * https://platform.kimi.com/docs/guide/claude-code-kimi
  */
 const createMoonshotAnthropicGenerateObject = async (
   client: Anthropic,
@@ -312,20 +315,31 @@ const createMoonshotAnthropicGenerateObject = async (
   pricing?: Pricing,
   config?: AnthropicGenerateObjectConfig,
 ) => {
-  const thinking = (payload as GenerateObjectPayload & Pick<ChatStreamPayload, 'thinking'>)
-    .thinking;
+  const { thinking } = payload;
   const isThinkingToggle = isKimiThinkingToggleModel(payload.model);
+  const isNativeThinking = isKimiNativeThinkingModel(payload.model);
   const isThinkingDisabled = isThinkingToggle && thinking?.type === 'disabled';
-  const isThinkingModel = isKimiNativeThinkingModel(payload.model) || isThinkingToggle;
+  const isThinkingModel = isNativeThinking || isThinkingToggle;
   const schemaToolChoice = isThinkingDisabled ? 'tool' : 'any';
+  const thinkingParam = isThinkingDisabled
+    ? ({ type: 'disabled' } as const)
+    : isThinkingModel && !isKimiReasoningEffortModel(payload.model)
+      ? ({
+          budget_tokens: Math.min(
+            thinking?.budget_tokens || 1024,
+            (config?.maxTokens ?? 64_000) - 1,
+          ),
+          type: 'enabled',
+        } as const)
+      : undefined;
 
   return createAnthropicGenerateObject(client, payload, options, pricing, {
     ...config,
-    ...(isThinkingDisabled
+    ...(thinkingParam
       ? {
           requestParams: {
             ...config?.requestParams,
-            thinking: { type: 'disabled' },
+            thinking: thinkingParam,
           },
         }
       : {}),

--- a/packages/model-runtime/src/providers/moonshot/index.ts
+++ b/packages/model-runtime/src/providers/moonshot/index.ts
@@ -1,5 +1,6 @@
 import type Anthropic from '@anthropic-ai/sdk';
 import type { ChatModelCard } from '@lobechat/types';
+import type { Pricing } from 'model-bank';
 import { ModelProvider } from 'model-bank';
 import type OpenAI from 'openai';
 
@@ -8,10 +9,12 @@ import {
   createAnthropicCompatibleParams,
   createAnthropicCompatibleRuntime,
 } from '../../core/anthropicCompatibleFactory';
+import type { AnthropicGenerateObjectConfig } from '../../core/anthropicCompatibleFactory/generateObject';
+import { createAnthropicGenerateObject } from '../../core/anthropicCompatibleFactory/generateObject';
 import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
 import type { CreateRouterRuntimeOptions } from '../../core/RouterRuntime';
 import { createRouterRuntime } from '../../core/RouterRuntime';
-import type { ChatStreamPayload } from '../../types';
+import type { ChatStreamPayload, GenerateObjectOptions, GenerateObjectPayload } from '../../types';
 import { getModelPropertyWithFallback } from '../../utils/getFallbackModelProperty';
 import { MODEL_LIST_CONFIGS, processModelList } from '../../utils/modelParse';
 import { sanitizeAnthropicThinkingParts } from '../../utils/sanitizeAnthropicThinkingParts';
@@ -297,6 +300,40 @@ const buildMoonshotOpenAIPayload = (
 };
 
 /**
+ * Kimi's Anthropic-compatible endpoint maps forced tool choices to `specified`,
+ * which is incompatible with thinking mode, but accepts `{ type: "any" }`.
+ * With a single schema tool this still forces structured output.
+ * https://platform.kimi.com/docs/guide/kimi-k2-7-code-quickstart
+ */
+const createMoonshotAnthropicGenerateObject = async (
+  client: Anthropic,
+  payload: GenerateObjectPayload,
+  options?: GenerateObjectOptions,
+  pricing?: Pricing,
+  config?: AnthropicGenerateObjectConfig,
+) => {
+  const thinking = (payload as GenerateObjectPayload & Pick<ChatStreamPayload, 'thinking'>)
+    .thinking;
+  const isThinkingToggle = isKimiThinkingToggleModel(payload.model);
+  const isThinkingDisabled = isThinkingToggle && thinking?.type === 'disabled';
+  const isThinkingModel = isKimiNativeThinkingModel(payload.model) || isThinkingToggle;
+  const schemaToolChoice = isThinkingDisabled ? 'tool' : 'any';
+
+  return createAnthropicGenerateObject(client, payload, options, pricing, {
+    ...config,
+    ...(isThinkingDisabled
+      ? {
+          requestParams: {
+            ...config?.requestParams,
+            thinking: { type: 'disabled' },
+          },
+        }
+      : {}),
+    ...(isThinkingModel ? { schemaToolChoice } : {}),
+  });
+};
+
+/**
  * Fetch Moonshot models from the API using OpenAI client
  */
 export const fetchMoonshotModels = async ({
@@ -328,6 +365,7 @@ export const anthropicParams = createAnthropicCompatibleParams({
   debug: {
     chatCompletion: () => process.env.DEBUG_MOONSHOT_CHAT_COMPLETION === '1',
   },
+  generateObject: createMoonshotAnthropicGenerateObject,
   provider: ModelProvider.Moonshot,
 });
 

--- a/packages/model-runtime/src/providers/moonshot/index.ts
+++ b/packages/model-runtime/src/providers/moonshot/index.ts
@@ -305,6 +305,8 @@ const buildMoonshotOpenAIPayload = (
  * With a single schema tool this still forces structured output.
  * K2.x thinking models also require an explicit `thinking` parameter on this
  * endpoint, while K3+ uses `reasoning_effort` and must omit it.
+ * Thinking-enabled assistant history must use the same placeholder-block
+ * normalization as chat requests before the generic Anthropic conversion.
  * https://platform.kimi.com/docs/guide/kimi-k2-7-code-quickstart
  * https://platform.kimi.com/docs/guide/claude-code-kimi
  */
@@ -320,10 +322,11 @@ const createMoonshotAnthropicGenerateObject = async (
   const isNativeThinking = isKimiNativeThinkingModel(payload.model);
   const isThinkingDisabled = isThinkingToggle && thinking?.type === 'disabled';
   const isThinkingModel = isNativeThinking || isThinkingToggle;
+  const isThinkingEnabled = isThinkingModel && !isThinkingDisabled;
   const schemaToolChoice = isThinkingDisabled ? 'tool' : 'any';
   const thinkingParam = isThinkingDisabled
     ? ({ type: 'disabled' } as const)
-    : isThinkingModel && !isKimiReasoningEffortModel(payload.model)
+    : isThinkingEnabled && !isKimiReasoningEffortModel(payload.model)
       ? ({
           budget_tokens: Math.min(
             thinking?.budget_tokens || 1024,
@@ -332,8 +335,17 @@ const createMoonshotAnthropicGenerateObject = async (
           type: 'enabled',
         } as const)
       : undefined;
+  const normalizedPayload = isThinkingEnabled
+    ? {
+        ...payload,
+        messages: normalizeMessagesForAnthropic(
+          payload.messages as ChatStreamPayload['messages'],
+          true,
+        ) as GenerateObjectPayload['messages'],
+      }
+    : payload;
 
-  return createAnthropicGenerateObject(client, payload, options, pricing, {
+  return createAnthropicGenerateObject(client, normalizedPayload, options, pricing, {
     ...config,
     ...(thinkingParam
       ? {


### PR DESCRIPTION
## Summary

- Use Anthropic `tool_choice: { type: "any" }` for schema-based structured output when Kimi thinking is active.
- Forward the required enabled thinking parameter for K2.x models, while K3+ continues to omit it.
- Normalize thinking-enabled assistant history before Anthropic conversion so multi-turn structured-output requests satisfy Moonshot's message contract.
- Preserve the named schema tool choice when thinking is explicitly disabled.
- Add regression coverage for always-thinking and thinking-toggle Kimi models.

#### Key Decisions / Non-goals

- `any` is intentional instead of `auto`: generateObject provides a single schema tool, so this still forces structured output while avoiding the named choice that Kimi maps to `specified`.
- The workaround is scoped to Moonshot's Anthropic-compatible generateObject path; generic Anthropic-compatible behavior is unchanged.
- Normal chat tool handling and model capability declarations are not changed.

#### Test

- [x] Tested locally
- [x] Added/updated tests

```bash
bun run check lobehub/packages/model-runtime/src/providers/moonshot/index.ts lobehub/packages/model-runtime/src/providers/moonshot/index.test.ts --lint --test
```

Result: 78 tests passed, lint clean.

A direct Kimi Anthropic-compatible request with thinking and `tool_choice: { type: "any" }` returned the expected schema tool result.

#### 🔗 Related Issue

Fixes LOBE-12477

Reference: https://platform.kimi.com/docs/guide/kimi-k2-7-code-quickstart