### PR TITLE
🔒 fix(server): hide LobeHub Skill connectors in private-label deployments

### DIFF
--- a/apps/server/src/globalConfig/getServerGlobalConfig.test.ts
+++ b/apps/server/src/globalConfig/getServerGlobalConfig.test.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
 interface MockGlobalConfigOptions {
   agentGatewayUrl?: string;
   enableAgentGateway?: boolean;
+  marketTrustedClient?: boolean;
 }
 
 const mockGlobalConfigDependencies = (
@@ -42,6 +43,9 @@ const mockGlobalConfigDependencies = (
       ...(options.enableAgentGateway === undefined
         ? {}
         : { ENABLE_AGENT_GATEWAY: options.enableAgentGateway }),
+      ...(options.marketTrustedClient
+        ? { MARKET_TRUSTED_CLIENT_ID: 'test-id', MARKET_TRUSTED_CLIENT_SECRET: 'test-secret' }
+        : {}),
     },
     getAppConfig: vi.fn(() => ({
       DEFAULT_AGENT_CONFIG: '',
@@ -194,6 +198,22 @@ describe('getServerGlobalConfig', () => {
 
     await expect(loadServerConfig(false, { enableAgentGateway: true })).resolves.toMatchObject({
       enableGatewayMode: false,
+    });
+  });
+
+  it('should hide the LobeHub Skill connectors in business feature mode even if market trusted-client env vars are set', async () => {
+    await expect(loadServerConfig(true, { marketTrustedClient: true })).resolves.toMatchObject({
+      enableLobehubSkill: false,
+    });
+  });
+
+  it('should keep the LobeHub Skill connectors gated by the market trusted-client env vars outside business feature mode', async () => {
+    await expect(loadServerConfig(false, { marketTrustedClient: true })).resolves.toMatchObject({
+      enableLobehubSkill: true,
+    });
+
+    await expect(loadServerConfig(false)).resolves.toMatchObject({
+      enableLobehubSkill: false,
     });
   });
 });

--- a/apps/server/src/globalConfig/index.ts
+++ b/apps/server/src/globalConfig/index.ts
@@ -107,7 +107,15 @@ export const getServerGlobalConfig = async () => {
     enableComposio: !!composioEnv.COMPOSIO_API_KEY,
     enableGatewayMode:
       ENABLE_BUSINESS_FEATURES || (!!appEnv.ENABLE_AGENT_GATEWAY && !!appEnv.AGENT_GATEWAY_URL),
-    enableLobehubSkill: !!(appEnv.MARKET_TRUSTED_CLIENT_SECRET && appEnv.MARKET_TRUSTED_CLIENT_ID),
+    // The LobeHub Skill connectors (Notion/PostHog/GitHub/etc. OAuth) are a
+    // hosted-cloud-only integration — private-label deployments can't complete
+    // their OAuth handshake, so keep them hidden even if the market trusted-
+    // client env vars happen to be set for other reasons. The Skill Store
+    // marketplace and cloud sandbox are unaffected — separate feature, no
+    // dependency on these env vars.
+    enableLobehubSkill:
+      !ENABLE_BUSINESS_FEATURES &&
+      !!(appEnv.MARKET_TRUSTED_CLIENT_SECRET && appEnv.MARKET_TRUSTED_CLIENT_ID),
     enableMagicLink: authEnv.AUTH_ENABLE_MAGIC_LINK,
     enableMarketTrustedClient: !!(
       appEnv.MARKET_TRUSTED_CLIENT_SECRET && appEnv.MARKET_TRUSTED_CLIENT_ID


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A (raised directly, not tracked in an existing Linear issue)

#### 🔀 Description of Change

The Notion / PostHog / GitHub / Linear / Microsoft / X (Twitter) / Vercel "Connect" rows (visible in Settings > Skill, the ChatInput tools dropdown, and ProfileEditor) are entirely gated by one flag: `enableLobehubSkill = !!(MARKET_TRUSTED_CLIENT_ID && MARKET_TRUSTED_CLIENT_SECRET)`. These OAuth connectors are a hosted-cloud-only LobeHub integration — a private-label deployment can't complete their OAuth handshake — so whenever those env vars happen to be set (e.g. for an unrelated reason), the UI shows "Connect" buttons that don't actually work for the customer.

This forces `enableLobehubSkill` off whenever `ENABLE_BUSINESS_FEATURES` is on, regardless of the env vars, following the same business-override pattern already used a few lines above it in the same file (`aiProviderSpecificConfig`).

**Explicitly unaffected:**
- The Skill Store marketplace (`searchSkill` / `importFromMarket`) and the cloud sandbox — neither depends on `MARKET_TRUSTED_CLIENT_ID`/`SECRET` at all, confirmed by grep across the codebase. This is the capability private deployments are meant to keep.
- `enableMarketTrustedClient` — a separate, broader flag used by Community/auth trusted-login flows (`MarketAuthProvider`, `ProfileSetupModal`). Not touched.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Added two regression cases to `getServerGlobalConfig.test.ts`:
- business-feature mode + market trusted-client env vars set → `enableLobehubSkill: false` (this is the bug fix — previously this would have been `true`)
- non-business (OSS) mode → behavior unchanged, still driven by the env vars

`bun run check --lint --test` on both touched files: lint clean, 9/9 tests passed.

#### 📝 Additional Information

Based on `feat/business-chat-extension-hooks` (not `canary`), same as the sibling branding-cleanup PR — this is CPC-specific business logic that accumulates on that integration branch before being PR'd upstream as a whole. Branched from the same parent commit as that PR (not stacked on it) since the two changes are independent.