### PR TITLE
🐛 fix(home): restore layout and refine tab and topic semantics

### DIFF
--- a/e2e/src/features/home/layout.feature
+++ b/e2e/src/features/home/layout.feature
@@ -1,0 +1,11 @@
+@journey @home @layout @regression
+Feature: Home Dashboard 右栏布局
+  作为桌面端用户，我希望窗口变窄时右栏卡片、滚动条与页面边缘仍保持清晰分隔
+
+  Background:
+    Given 用户已登录系统
+
+  @HOME-LAYOUT-RAIL-001 @P1
+  Scenario: 受限桌面宽度下滚动条位于卡片外侧且保留页面右边距
+    Given 用户在受限宽度下打开 Home 页面
+    Then Home 右栏应保持卡片、滚动条轨道与页面边缘的分层间距

--- a/e2e/src/steps/home/layout.steps.ts
+++ b/e2e/src/steps/home/layout.steps.ts
@@ -1,0 +1,43 @@
+import { Given, Then } from '@cucumber/cucumber';
+import { expect } from '@playwright/test';
+
+import type { CustomWorld } from '../../support/world';
+import { WAIT_TIMEOUT } from '../../support/world';
+
+Given('用户在受限宽度下打开 Home 页面', async function (this: CustomWorld) {
+  await this.page.setViewportSize({ height: 900, width: 1500 });
+  await this.page.goto('/');
+
+  await expect(this.page.locator('[data-testid="home-rail"]:visible')).toBeVisible({
+    timeout: WAIT_TIMEOUT,
+  });
+});
+
+Then('Home 右栏应保持卡片、滚动条轨道与页面边缘的分层间距', async function (this: CustomWorld) {
+  const rail = this.page.locator('[data-testid="home-rail"]:visible');
+  const card = rail.getByTestId('home-rail-card').first();
+  const scrollbar = rail.locator('[data-orientation="vertical"]').first();
+
+  await expect(card).toBeVisible({ timeout: WAIT_TIMEOUT });
+
+  const [railBox, cardBox, scrollbarBox, viewportWidth] = await Promise.all([
+    rail.boundingBox(),
+    card.boundingBox(),
+    scrollbar.boundingBox(),
+    this.page.evaluate(() => window.innerWidth),
+  ]);
+
+  expect(railBox).not.toBeNull();
+  expect(cardBox).not.toBeNull();
+  expect(scrollbarBox).not.toBeNull();
+
+  const railRight = railBox!.x + railBox!.width;
+  const cardRight = cardBox!.x + cardBox!.width;
+  const scrollbarRight = scrollbarBox!.x + scrollbarBox!.width;
+
+  expect(cardBox!.width).toBeCloseTo(380, 0);
+  expect(railRight - cardRight).toBeCloseTo(14, 0);
+  expect(scrollbarBox!.x).toBeGreaterThanOrEqual(cardRight);
+  expect(scrollbarRight).toBeLessThanOrEqual(railRight);
+  expect(viewportWidth - railRight).toBeGreaterThanOrEqual(24);
+});

--- a/e2e/src/steps/home/layout.steps.ts
+++ b/e2e/src/steps/home/layout.steps.ts
@@ -5,7 +5,9 @@ import type { CustomWorld } from '../../support/world';
 import { WAIT_TIMEOUT } from '../../support/world';
 
 Given('用户在受限宽度下打开 Home 页面', async function (this: CustomWorld) {
-  await this.page.setViewportSize({ height: 900, width: 1500 });
+  // Keep the desktop width while constraining the height so a fresh E2E account's
+  // single rail card still overflows and exposes the real ScrollArea scrollbar.
+  await this.page.setViewportSize({ height: 360, width: 1500 });
   await this.page.goto('/');
 
   await expect(this.page.locator('[data-testid="home-rail"]:visible')).toBeVisible({

--- a/locales/en-US/electron.json
+++ b/locales/en-US/electron.json
@@ -30,6 +30,7 @@
   "navigation.memoryExperiences": "Memory - Experiences",
   "navigation.memoryIdentities": "Memory - Identities",
   "navigation.memoryPreferences": "Memory - Preferences",
+  "navigation.newChat": "New Chat",
   "navigation.noPages": "No pages yet",
   "navigation.onboarding": "Onboarding",
   "navigation.page": "Page",

--- a/locales/en-US/home.json
+++ b/locales/en-US/home.json
@@ -44,6 +44,7 @@
   "cardBindingPromoBanner.label": "Add your first payment method and get 1M credits free",
   "dashboard.chat.empty": "No recent conversations",
   "dashboard.chat.recents": "Recent topics",
+  "dashboard.chat.running": "Running topics",
   "dashboard.empty.plan.description": "Break an outcome into clear next steps",
   "dashboard.empty.plan.prompt": "Help me create a practical plan for:",
   "dashboard.empty.plan.title": "Make a plan",

--- a/locales/zh-CN/electron.json
+++ b/locales/zh-CN/electron.json
@@ -30,6 +30,7 @@
   "navigation.memoryExperiences": "记忆 - 经历",
   "navigation.memoryIdentities": "记忆 - 身份",
   "navigation.memoryPreferences": "记忆 - 偏好",
+  "navigation.newChat": "新建对话",
   "navigation.noPages": "暂无页面",
   "navigation.onboarding": "引导",
   "navigation.page": "文稿",

--- a/locales/zh-CN/home.json
+++ b/locales/zh-CN/home.json
@@ -44,6 +44,7 @@
   "cardBindingPromoBanner.label": "首次添加支付方式，即送 1M 积分",
   "dashboard.chat.empty": "暂无最近对话",
   "dashboard.chat.recents": "最近主题",
+  "dashboard.chat.running": "正在运行",
   "dashboard.empty.plan.description": "把目标拆解为清晰、可执行的下一步",
   "dashboard.empty.plan.prompt": "帮我为以下目标制定一份切实可行的计划：",
   "dashboard.empty.plan.title": "制定计划",

--- a/packages/locales/src/default/electron.ts
+++ b/packages/locales/src/default/electron.ts
@@ -21,6 +21,7 @@ export default {
   'navigation.memoryIdentities': 'Memory - Identities',
   'navigation.document': 'Document',
   'navigation.memoryPreferences': 'Memory - Preferences',
+  'navigation.newChat': 'New Chat',
   'navigation.noPages': 'No pages yet',
   'navigation.onboarding': 'Onboarding',
   'navigation.page': 'Page',

--- a/packages/locales/src/default/home.ts
+++ b/packages/locales/src/default/home.ts
@@ -49,6 +49,7 @@ export default {
   'homePromoBanner.label': '{{model}} is now available',
   'dashboard.chat.empty': 'No recent conversations',
   'dashboard.chat.recents': 'Recent topics',
+  'dashboard.chat.running': 'Running topics',
   'dashboard.empty.plan.description': 'Break an outcome into clear next steps',
   'dashboard.empty.plan.prompt': 'Help me create a practical plan for:',
   'dashboard.empty.plan.title': 'Make a plan',

--- a/src/features/Electron/titlebar/TabBar/hooks/useResolvedTabs.ts
+++ b/src/features/Electron/titlebar/TabBar/hooks/useResolvedTabs.ts
@@ -34,6 +34,7 @@ export const resolveTab = (
   liveDynamicUrl?: string | null,
 ): ResolvedTab => {
   const staticMeta = matchRouteMeta(routes, tab.url).static;
+  const titleKey = staticMeta.tabTitleKey ?? staticMeta.titleKey;
 
   const live =
     isActive && liveDynamicUrl && normalizeTabUrl(tab.url) === normalizeTabUrl(liveDynamicUrl)
@@ -43,7 +44,7 @@ export const resolveTab = (
   const title =
     pickMeaningful(live?.title) ??
     pickMeaningful(tab.cached?.title) ??
-    (staticMeta.titleKey ? t(staticMeta.titleKey, { ns: 'electron' }) : undefined) ??
+    (titleKey ? t(titleKey, { ns: 'electron' }) : undefined) ??
     t('navigation.lobehub', { ns: 'electron' });
 
   const avatar = pickMeaningful(live?.avatar) ?? pickMeaningful(tab.cached?.avatar);

--- a/src/features/Electron/titlebar/TabBar/resolveRouteMeta.test.ts
+++ b/src/features/Electron/titlebar/TabBar/resolveRouteMeta.test.ts
@@ -12,7 +12,11 @@ import {
   pickMeaningful,
 } from './resolveRouteMeta';
 
-const agentMeta: RouteMeta = { icon: MessageSquare, titleKey: 'navigation.chat' };
+const agentMeta: RouteMeta = {
+  icon: MessageSquare,
+  tabTitleKey: 'navigation.newChat',
+  titleKey: 'navigation.chat',
+};
 
 const fixtureRoutes: RouteObject[] = [
   {
@@ -25,6 +29,7 @@ describe('matchRouteMeta', () => {
   it('returns the deepest static meta for a matched route', () => {
     const result = matchRouteMeta(fixtureRoutes, '/agent/abc');
     expect(result.static.icon).toBe(MessageSquare);
+    expect(result.static.tabTitleKey).toBe('navigation.newChat');
     expect(result.static.titleKey).toBe('navigation.chat');
     expect(result.params.aid).toBe('abc');
     expect(result.meta).toBe(agentMeta);

--- a/src/features/Electron/titlebar/TabBar/resolveRouteMeta.ts
+++ b/src/features/Electron/titlebar/TabBar/resolveRouteMeta.ts
@@ -23,7 +23,11 @@ export const matchRouteMeta = (routes: RouteObject[], url: string): MatchedRoute
   for (let i = matches.length - 1; i >= 0; i -= 1) {
     const meta = getRouteMetaFromHandle(matches[i].route.handle);
     if (meta) {
-      return { meta, params, static: { icon: meta.icon, titleKey: meta.titleKey } };
+      return {
+        meta,
+        params,
+        static: { icon: meta.icon, tabTitleKey: meta.tabTitleKey, titleKey: meta.titleKey },
+      };
     }
   }
 

--- a/src/features/Electron/titlebar/TabBar/resolveTab.test.ts
+++ b/src/features/Electron/titlebar/TabBar/resolveTab.test.ts
@@ -11,7 +11,16 @@ const agentMeta: RouteMeta = { icon: MessageSquare, titleKey: 'navigation.chat' 
 
 const fixtureRoutes: RouteObject[] = [
   {
-    children: [{ handle: { meta: agentMeta }, path: 'agent/:aid' }, { path: 'group/:gid' }],
+    children: [
+      {
+        handle: {
+          meta: { tabTitleKey: 'navigation.newChat', titleKey: 'navigation.home' },
+        },
+        index: true,
+      },
+      { handle: { meta: agentMeta }, path: 'agent/:aid' },
+      { path: 'group/:gid' },
+    ],
     path: '/',
   },
 ];
@@ -89,6 +98,11 @@ describe('resolveTab', () => {
   it('falls back to the static titleKey when no snapshot exists', () => {
     const resolved = resolveTab(fixtureRoutes, tab('/agent/abc'), false, t);
     expect(resolved.meta.title).toBe('navigation.chat');
+  });
+
+  it('prefers the Electron tab title over the document title', () => {
+    const resolved = resolveTab(fixtureRoutes, tab('/'), false, t);
+    expect(resolved.meta.title).toBe('navigation.newChat');
   });
 
   it('uses the generic fallback when neither snapshot nor static meta exists', () => {

--- a/src/features/Home/HomeModeContent.tsx
+++ b/src/features/Home/HomeModeContent.tsx
@@ -1,3 +1,4 @@
+import { AGENT_CHAT_TOPIC_URL } from '@lobechat/const';
 import type { TaskStatus } from '@lobechat/types';
 import { Flexbox, Icon, Skeleton, Text } from '@lobehub/ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
@@ -8,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import AsyncError from '@/components/AsyncError';
 import TaskStatusIcon from '@/features/AgentTasks/features/TaskStatusIcon';
 import { taskDetailPath } from '@/features/AgentTasks/shared/taskDetailPath';
-import { useHomeInboxTopics } from '@/features/HomeInbox/useHomeInboxTopics';
+import { type InboxTopic, useHomeInboxTopics } from '@/features/HomeInbox/useHomeInboxTopics';
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
 import { useClientDataSWR } from '@/libs/swr';
 import { recentKeys } from '@/libs/swr/keys';
@@ -24,6 +25,7 @@ import { homeType } from './components/homeType';
 import RunningGlyph from './components/RunningGlyph';
 import EmptySuggestions from './EmptySuggestions';
 import { resolveHomeChatContentState } from './homeChatContentState';
+import { resolveHomeTopicSections } from './homeTopicSections';
 import type { HomeMode } from './types';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
@@ -82,6 +84,9 @@ const HOME_TOPIC_RECENT_LIMIT = 9;
 
 const normalizeTaskStatus = (status: string): TaskStatus =>
   TASK_STATUSES.has(status as TaskStatus) ? (status as TaskStatus) : 'backlog';
+
+const isRoutableTopic = (topic: InboxTopic): topic is InboxTopic & { agentId: string } =>
+  Boolean(topic.agentId);
 
 const Row = memo<RowProps>(({ description, href, icon, title }) => (
   <WorkspaceLink className={styles.row} to={href}>
@@ -170,11 +175,15 @@ const HomeModeContent = memo<HomeModeContentProps>(({ mode, onSuggestionSelect }
   // payload cannot say which conversation is mid-run. The rail already loads
   // that (same SWR key, so this costs no extra request).
   const inboxTopics = useHomeInboxTopics(isLogin);
-  const runningTopicIds = useMemo(
-    () => new Set(inboxTopics.running.map((topic) => topic.id)),
+  const topicRecents = useMemo(() => recentsSWR.data ?? [], [recentsSWR.data]);
+  const routableRunningTopics = useMemo(
+    () => inboxTopics.running.filter(isRoutableTopic),
     [inboxTopics.running],
   );
-  const topicRecents = recentsSWR.data ?? [];
+  const topicSections = useMemo(
+    () => resolveHomeTopicSections(topicRecents, routableRunningTopics),
+    [topicRecents, routableRunningTopics],
+  );
 
   if (mode === 'chat') {
     const state = resolveHomeChatContentState({
@@ -183,36 +192,59 @@ const HomeModeContent = memo<HomeModeContentProps>(({ mode, onSuggestionSelect }
       isLogin: !!isLogin,
       recentsCount: topicRecents.length,
       recentsInit: recentsSWR.data !== undefined,
+      runningCount: topicSections.running.length,
+      runningResolved: inboxTopics.isInit || Boolean(inboxTopics.error),
     });
 
     if (state === 'empty') return <EmptySuggestions onSelect={onSuggestionSelect} />;
 
     return (
-      <GroupBlock count={topicRecents.length || undefined} title={t('dashboard.chat.recents')}>
-        {state === 'error' ? (
-          <AsyncError error={recentsSWR.error} variant={'inline'} onRetry={recentsSWR.mutate} />
-        ) : state === 'loading' ? (
-          <LoadingRows />
-        ) : (
-          <Flexbox gap={4}>
-            {topicRecents.slice(0, 8).map((item) => (
-              <Row
-                description={item.updatedAt ? new Date(item.updatedAt).toLocaleDateString() : null}
-                href={item.routePath}
-                key={item.id}
-                title={item.title}
-                icon={
-                  runningTopicIds.has(item.id) ? (
-                    <RunningGlyph />
-                  ) : (
-                    <Icon color={cssVar.colorTextDescription} icon={HashIcon} size={16} />
-                  )
-                }
-              />
-            ))}
-          </Flexbox>
+      <Flexbox gap={32}>
+        {topicSections.running.length > 0 && (
+          <GroupBlock count={topicSections.running.length} title={t('dashboard.chat.running')}>
+            <Flexbox gap={4}>
+              {topicSections.running.map((topic) => (
+                <Row
+                  href={AGENT_CHAT_TOPIC_URL(topic.agentId, topic.id)}
+                  icon={<RunningGlyph />}
+                  key={topic.id}
+                  title={topic.title}
+                  description={
+                    topic.updatedAt ? new Date(topic.updatedAt).toLocaleDateString() : null
+                  }
+                />
+              ))}
+            </Flexbox>
+          </GroupBlock>
         )}
-      </GroupBlock>
+
+        {(state !== 'ready' || topicSections.recent.length > 0) && (
+          <GroupBlock
+            count={topicSections.recent.length || undefined}
+            title={t('dashboard.chat.recents')}
+          >
+            {state === 'error' ? (
+              <AsyncError error={recentsSWR.error} variant={'inline'} onRetry={recentsSWR.mutate} />
+            ) : state === 'loading' ? (
+              <LoadingRows />
+            ) : (
+              <Flexbox gap={4}>
+                {topicSections.recent.slice(0, 8).map((item) => (
+                  <Row
+                    href={item.routePath}
+                    icon={<Icon color={cssVar.colorTextDescription} icon={HashIcon} size={16} />}
+                    key={item.id}
+                    title={item.title}
+                    description={
+                      item.updatedAt ? new Date(item.updatedAt).toLocaleDateString() : null
+                    }
+                  />
+                ))}
+              </Flexbox>
+            )}
+          </GroupBlock>
+        )}
+      </Flexbox>
     );
   }
 

--- a/src/features/Home/components/RailCard/index.tsx
+++ b/src/features/Home/components/RailCard/index.tsx
@@ -27,7 +27,7 @@ interface RailCardProps {
 }
 
 const RailCard = memo<RailCardProps>(({ action, children, count, title }) => (
-  <Flexbox className={styles.card} gap={12}>
+  <Flexbox className={styles.card} data-testid={'home-rail-card'} gap={12}>
     {title && (
       <Flexbox horizontal align={'center'} gap={8} justify={'space-between'}>
         <Flexbox horizontal align={'center'} gap={6} style={{ minWidth: 0 }}>

--- a/src/features/Home/homeChatContentState.test.ts
+++ b/src/features/Home/homeChatContentState.test.ts
@@ -8,6 +8,8 @@ const baseState = {
   isLogin: true,
   recentsCount: 1,
   recentsInit: true,
+  runningCount: 0,
+  runningResolved: true,
 };
 
 describe('resolveHomeChatContentState', () => {
@@ -26,5 +28,26 @@ describe('resolveHomeChatContentState', () => {
     );
     expect(resolveHomeChatContentState({ ...baseState, recentsCount: 0 })).toBe('empty');
     expect(resolveHomeChatContentState(baseState)).toBe('ready');
+  });
+
+  it('keeps running topics visible when there are no recent topics', () => {
+    expect(
+      resolveHomeChatContentState({
+        ...baseState,
+        recentsCount: 0,
+        runningCount: 1,
+        runningResolved: false,
+      }),
+    ).toBe('ready');
+  });
+
+  it('waits for the running feed before declaring the chat surface empty', () => {
+    expect(
+      resolveHomeChatContentState({
+        ...baseState,
+        recentsCount: 0,
+        runningResolved: false,
+      }),
+    ).toBe('loading');
   });
 });

--- a/src/features/Home/homeChatContentState.ts
+++ b/src/features/Home/homeChatContentState.ts
@@ -6,6 +6,8 @@ interface ResolveHomeChatContentStateParams {
   isLogin: boolean;
   recentsCount: number;
   recentsInit: boolean;
+  runningCount: number;
+  runningResolved: boolean;
 }
 
 export const resolveHomeChatContentState = ({
@@ -14,11 +16,14 @@ export const resolveHomeChatContentState = ({
   isLogin,
   recentsCount,
   recentsInit,
+  runningCount,
+  runningResolved,
 }: ResolveHomeChatContentStateParams): HomeChatContentState => {
   if (!authLoaded) return 'loading';
   if (!isLogin) return 'empty';
   if (hasError && !recentsInit) return 'error';
   if (!recentsInit) return 'loading';
-  if (recentsCount === 0) return 'empty';
+  if (recentsCount === 0 && runningCount === 0 && !runningResolved) return 'loading';
+  if (recentsCount === 0 && runningCount === 0) return 'empty';
   return 'ready';
 };

--- a/src/features/Home/homeTopicSections.test.ts
+++ b/src/features/Home/homeTopicSections.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveHomeTopicSections } from './homeTopicSections';
+
+describe('resolveHomeTopicSections', () => {
+  it('shows every running topic once and removes it from recent topics', () => {
+    const runningRecent = { id: 'running-recent', title: 'Running recent topic' };
+    const recentOnly = { id: 'recent-only', title: 'Recent topic' };
+    const runningOutsideRecentLimit = {
+      id: 'running-outside-limit',
+      title: 'Running topic outside the recent limit',
+    };
+
+    expect(
+      resolveHomeTopicSections(
+        [runningRecent, recentOnly],
+        [runningRecent, runningOutsideRecentLimit],
+      ),
+    ).toEqual({
+      recent: [recentOnly],
+      running: [runningRecent, runningOutsideRecentLimit],
+    });
+  });
+});

--- a/src/features/Home/homeTopicSections.ts
+++ b/src/features/Home/homeTopicSections.ts
@@ -1,0 +1,27 @@
+interface TopicIdentity {
+  id: string;
+}
+
+interface HomeTopicSections<TRecent extends TopicIdentity, TRunning extends TopicIdentity> {
+  recent: TRecent[];
+  running: TRunning[];
+}
+
+/**
+ * Running topics are a live status group, not a subtype of recency. Keep the
+ * sections mutually exclusive while preserving the source order of both feeds.
+ */
+export const resolveHomeTopicSections = <
+  TRecent extends TopicIdentity,
+  TRunning extends TopicIdentity,
+>(
+  recentTopics: readonly TRecent[],
+  runningTopics: readonly TRunning[],
+): HomeTopicSections<TRecent, TRunning> => {
+  const runningTopicIds = new Set(runningTopics.map((topic) => topic.id));
+
+  return {
+    recent: recentTopics.filter((topic) => !runningTopicIds.has(topic.id)),
+    running: [...runningTopics],
+  };
+};

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -33,7 +33,7 @@ const RAIL_GUTTER = 14;
 const RAIL_CARD_WIDTH = 380;
 
 const MAIN_CONTENT_STYLE = { ...scrollContent, paddingInline: ROW_BLEED };
-const RAIL_CONTENT_STYLE = { ...scrollContent };
+const RAIL_CONTENT_STYLE = { ...scrollContent, paddingInlineEnd: RAIL_GUTTER };
 const SINGLE_COLUMN_STYLE = { gridTemplateColumns: 'minmax(0, 1fr)' } as const;
 
 const styles = createStaticStyles(({ css }) => ({
@@ -89,7 +89,6 @@ const styles = createStaticStyles(({ css }) => ({
 
     min-width: 0;
     min-height: 0;
-    padding-inline-end: ${RAIL_GUTTER}px;
 
     @media (width <= 1100px) {
       grid-area: 3 / 1;
@@ -99,6 +98,7 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   railScroll: css`
     flex: 1;
+    min-width: 0;
     min-height: 0;
 
     @media (width <= 1100px) {
@@ -159,7 +159,7 @@ const Home = memo(() => {
       </Flexbox>
 
       {isLogin && (
-        <aside className={styles.rail}>
+        <aside className={styles.rail} data-testid={'home-rail'}>
           {/* No scrollFade: its mask would make the viewport a backdrop root
               and the cards' glass would stop sampling the portrait behind it. */}
           <ScrollArea

--- a/src/spa/router/desktopRouter.config.desktop.tsx
+++ b/src/spa/router/desktopRouter.config.desktop.tsx
@@ -4,9 +4,9 @@ import {
   BrainCircuit,
   Download,
   FilePenIcon,
-  Home,
   Image,
   LibraryBigIcon,
+  MessageSquarePlus,
   Settings,
   ShapesIcon,
 } from 'lucide-react';
@@ -798,7 +798,11 @@ export const createMainAreaChildren = (): RouteObject[] => [
       </DesktopHomeLayout>
     ),
     handle: {
-      meta: routeMeta({ icon: Home, titleKey: 'navigation.home' }),
+      meta: routeMeta({
+        icon: MessageSquarePlus,
+        tabTitleKey: 'navigation.newChat',
+        titleKey: 'navigation.home',
+      }),
     },
     index: true,
   },

--- a/src/spa/router/desktopRouter.config.tsx
+++ b/src/spa/router/desktopRouter.config.tsx
@@ -4,9 +4,9 @@ import {
   BrainCircuit,
   Download,
   FilePenIcon,
-  Home,
   Image,
   LibraryBigIcon,
+  MessageSquarePlus,
   Settings,
   ShapesIcon,
 } from 'lucide-react';
@@ -1070,7 +1070,11 @@ export const createMainAreaChildren = (): RouteObject[] => [
   // Default route - home page (handled by persistent layout)
   {
     handle: {
-      meta: routeMeta({ icon: Home, titleKey: 'navigation.home' }),
+      meta: routeMeta({
+        icon: MessageSquarePlus,
+        tabTitleKey: 'navigation.newChat',
+        titleKey: 'navigation.home',
+      }),
     },
     index: true,
   },

--- a/src/spa/router/desktopRouter.meta.desktop.test.ts
+++ b/src/spa/router/desktopRouter.meta.desktop.test.ts
@@ -1,3 +1,4 @@
+import { MessageSquarePlus } from 'lucide-react';
 import { describe, expect, it } from 'vitest';
 
 import { matchRouteMeta } from '@/features/Electron/titlebar/TabBar/resolveRouteMeta';
@@ -10,6 +11,14 @@ import { mainAreaMetaRoutes } from './desktopRouter.config.desktop';
 // meta tree that aliased those stubs would silently degrade every tab title to
 // brand and every icon to the Circle fallback on the packaged app.
 describe('mainAreaMetaRoutes (electron twin)', () => {
+  it('uses New Chat for the personal Home tab without changing its document title', () => {
+    const { static: staticMeta } = matchRouteMeta(mainAreaMetaRoutes, '/');
+
+    expect(staticMeta.icon).toBe(MessageSquarePlus);
+    expect(staticMeta.tabTitleKey).toBe('navigation.newChat');
+    expect(staticMeta.titleKey).toBe('navigation.home');
+  });
+
   it('resolves a static settings meta from the electron build meta tree', () => {
     const { static: staticMeta } = matchRouteMeta(mainAreaMetaRoutes, '/settings/profile');
 

--- a/src/spa/router/routeMeta.ts
+++ b/src/spa/router/routeMeta.ts
@@ -3,6 +3,8 @@ import type { ComponentType } from 'react';
 
 export interface StaticRouteMeta {
   icon?: LucideIcon;
+  /** Optional Electron tab label when it should differ from the document title. */
+  tabTitleKey?: string;
   titleKey?: string;
 }
 


### PR DESCRIPTION
## Summary

- restore the Home right-rail content gutter so cards retain page-edge spacing at constrained desktop widths
- keep the vertical ScrollArea scrollbar in the dedicated gutter outside the rail cards
- label Electron root tabs as `New Chat` and use the `MessageSquarePlus` icon while preserving the Home page/sidebar semantics
- aggregate all actively running topics into a dedicated `Running topics` section above `Recent topics`
- remove running topics from the recent section so each topic appears exactly once
- add route-meta, Home rail, chat-state, and topic-section regression coverage

## Root cause

A follow-up layout change moved the 14px gutter from the ScrollArea content to the outer rail. The ScrollArea flex item also retained its automatic minimum width, allowing its card content to expand beyond the 394px grid track and consume the page's right margin.

The Home chat overview already loaded the account-wide running-topic feed, but used it only to swap individual recent-row icons. Running state therefore remained mixed into a recency group and topics outside the recent-item limit could not be surfaced there.

## Impact

The Home dashboard now preserves a 380px card width, a 14px scrollbar gutter, and the outer page margin at constrained desktop widths. Electron tabs use a creation-oriented label and icon without renaming the Home navigation entry.

Running work is now presented as a first-class status group before recent conversations. The two sections are mutually exclusive, and an active topic remains visible even when it falls outside the recent-topic limit.

## Validation

- initial scoped check — 15 files lint clean, 27 tests passed
- running-topic follow-up check — 8 files lint clean, 6 tests passed
- `bun run check --type` — types clean
- Cucumber dry-run for `@HOME-LAYOUT-RAIL-001` — scenario and steps loaded successfully
- isolated Electron layout verification at 1500×900 — 394px rail, 380px card, 14px gutter, 33px page-edge margin
- isolated Electron anonymous-state smoke check — starter content remains visible and no empty Running/Recent section is rendered
