### PR TITLE
💄 style(i18n): guide users to free up storage by deleting files

### DIFF
--- a/locales/en-US/error.json
+++ b/locales/en-US/error.json
@@ -156,6 +156,7 @@
   "upload.networkError": "Please check your network connection and ensure that the file storage service's cross-origin configuration is correct.",
   "upload.permissionDenied": "You don't have permission to upload files in this workspace.",
   "upload.storageBlock.billingUnavailable": "Your subscription billing status cannot be verified. Please try again later or update your billing details.",
+  "upload.storageBlock.cleanupFiles": "Free up space",
   "upload.storageBlock.monthlyCapReached": "Your monthly storage spending cap has been reached.",
   "upload.storageBlock.noPaymentMethod": "Please add a payment method to continue uploading.",
   "upload.storageBlock.overageNotEnabled": "Your storage is full. Enable pay-as-you-go billing to continue uploading.",

--- a/locales/en-US/subscription.json
+++ b/locales/en-US/subscription.json
@@ -445,7 +445,7 @@
   "plansModal.creditLimit.title": "You’re out of credits",
   "plansModal.default.desc": "Unlock more capacity and advanced features.",
   "plansModal.default.title": "Upgrade your plan",
-  "plansModal.fileStorageLimit.desc": "Your file storage is full. Upgrade to keep uploading and managing files.",
+  "plansModal.fileStorageLimit.desc": "Your file storage is full. Upgrade to keep uploading, or delete unused files on the <1>Resources page</1> to free up space.",
   "plansModal.fileStorageLimit.title": "Storage limit reached",
   "plansModal.modelAccess.desc": "This model is available on paid plans. Upgrade to use the full model lineup.",
   "plansModal.modelAccess.title": "Unlock all models",

--- a/locales/zh-CN/error.json
+++ b/locales/zh-CN/error.json
@@ -156,6 +156,7 @@
   "upload.networkError": "网络异常或跨域配置不正确。请检查文件存储服务的 CORS 设置后重试",
   "upload.permissionDenied": "您没有权限在此工作区上传文件。",
   "upload.storageBlock.billingUnavailable": "无法验证您的订阅账单状态。请稍后重试或更新您的账单信息。",
+  "upload.storageBlock.cleanupFiles": "清理文件",
   "upload.storageBlock.monthlyCapReached": "已达到月度存储消费上限。",
   "upload.storageBlock.noPaymentMethod": "请添加支付方式后继续上传。",
   "upload.storageBlock.overageNotEnabled": "存储空间已满。启用按量付费后可继续上传。",

--- a/locales/zh-CN/subscription.json
+++ b/locales/zh-CN/subscription.json
@@ -445,7 +445,7 @@
   "plansModal.creditLimit.title": "积分已用尽",
   "plansModal.default.desc": "解锁更多容量与高级功能。",
   "plansModal.default.title": "升级方案",
-  "plansModal.fileStorageLimit.desc": "文件存储已达上限，升级以继续上传和管理文件。",
+  "plansModal.fileStorageLimit.desc": "文件存储已达上限，升级以继续上传，或前往<1>「资源」页面</1>删除不需要的文件以释放空间。",
   "plansModal.fileStorageLimit.title": "存储空间不足",
   "plansModal.modelAccess.desc": "该模型为付费方案专享，升级即可使用全部模型。",
   "plansModal.modelAccess.title": "解锁全部模型",

--- a/packages/locales/src/default/error.ts
+++ b/packages/locales/src/default/error.ts
@@ -271,6 +271,7 @@ export default {
     "Please check your network connection and ensure that the file storage service's cross-origin configuration is correct.",
   'upload.storageBlock.billingUnavailable':
     'Your subscription billing status cannot be verified. Please try again later or update your billing details.',
+  'upload.storageBlock.cleanupFiles': 'Free up space',
   'upload.storageBlock.monthlyCapReached': 'Your monthly storage spending cap has been reached.',
   'upload.storageBlock.noPaymentMethod': 'Please add a payment method to continue uploading.',
   'upload.storageBlock.viewUsage': 'View storage usage',

--- a/packages/locales/src/default/subscription.ts
+++ b/packages/locales/src/default/subscription.ts
@@ -517,7 +517,7 @@ export default {
   'plansModal.default.desc': 'Unlock more capacity and advanced features.',
   'plansModal.default.title': 'Upgrade your plan',
   'plansModal.fileStorageLimit.desc':
-    'Your file storage is full. Upgrade to keep uploading and managing files.',
+    'Your file storage is full. Upgrade to keep uploading, or delete unused files on the <1>Resources page</1> to free up space.',
   'plansModal.fileStorageLimit.title': 'Storage limit reached',
   'plansModal.modelAccess.desc':
     'This model is available on paid plans. Upgrade to use the full model lineup.',


### PR DESCRIPTION
When file storage is full, users repeatedly reported not knowing where files can be deleted. This PR adds/updates the copy that guides them to the Resources page:

- New key `upload.storageBlock.cleanupFiles` ("Free up space") — used as a secondary action on storage-block upload error notifications.
- `plansModal.fileStorageLimit.desc` now mentions deleting unused files on the Resources page as an alternative to upgrading, with `<1>…</1>` markup so consumers can render the phrase as an in-app link.

en-US and zh-CN are hand-translated; other locales are left to the daily auto-i18n workflow.

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Copy-only change; consumer behavior is covered by tests in the consuming app.

#### 🔗 Related Issue

Related to LOBE-11878