### PR TITLE
🐛 fix(chat-appearance): increase mermaid preview height to prevent overflow

### DIFF
--- a/src/routes/(main)/settings/chat-appearance/features/ChatAppearance/MermaidPreview.test.ts
+++ b/src/routes/(main)/settings/chat-appearance/features/ChatAppearance/MermaidPreview.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { MERMAID_PREVIEW_HEIGHT } from './MermaidPreview';
+
+describe('MermaidPreview height', () => {
+  it('is large enough to prevent the mermaid diagram from overflowing its container', () => {
+    expect(MERMAID_PREVIEW_HEIGHT).toBe(400);
+  });
+
+  it('is not the old value that caused the overflow regression', () => {
+    expect(MERMAID_PREVIEW_HEIGHT).not.toBe(280);
+  });
+});

--- a/src/routes/(main)/settings/chat-appearance/features/ChatAppearance/MermaidPreview.tsx
+++ b/src/routes/(main)/settings/chat-appearance/features/ChatAppearance/MermaidPreview.tsx
@@ -7,9 +7,11 @@ const code = `sequenceDiagram
     Alice-)John: See you later!
 `;
 
+export const MERMAID_PREVIEW_HEIGHT = 400;
+
 const MermaidPreview = ({ theme }: { theme?: MermaidProps['theme'] }) => {
   return (
-    <Center height={280}>
+    <Center height={MERMAID_PREVIEW_HEIGHT}>
       <Flexbox width={480}>
         <Mermaid theme={theme}>{code}</Mermaid>
       </Flexbox>


### PR DESCRIPTION
The mermaid diagram SVG content was taller than the 280px container, causing overflow that visually covered the FormGroup title area above it. Increasing the container height to 400px fully contains the preview diagram.

| Before | After |
| ------ | ----- |
| <img width="300" alt="before" src="https://github.com/user-attachments/assets/391e519e-716c-42da-b25a-a6a71d9082fd" /> | <img width="300" alt="after" src="https://github.com/user-attachments/assets/e780de04-08f1-4a50-b862-5373b1cf3c90" /> |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

N/A