### PR TITLE
🐛 fix: cache self-hosted SPA assets

### DIFF
--- a/src/libs/next/config/define-config.test.ts
+++ b/src/libs/next/config/define-config.test.ts
@@ -8,15 +8,16 @@ describe('defineConfig', () => {
     expect(defineConfig({}).agentRules).toBe(false);
   });
 
-  it('caches SPA build artifacts', async () => {
+  it('caches SPA and auth build artifacts', async () => {
     const headers = await defineConfig({}).headers?.();
-    const spaHeaders = headers?.find(({ source }) => source === '/_spa/:path*');
 
-    expect(spaHeaders?.headers).toContainEqual({
-      key: 'Cache-Control',
-      value:
-        'public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800, stale-if-error=86400, immutable',
-    });
+    for (const source of ['/_spa/:path*', '/_spa-auth/:path*']) {
+      expect(headers?.find((header) => header.source === source)?.headers).toContainEqual({
+        key: 'Cache-Control',
+        value:
+          'public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800, stale-if-error=86400, immutable',
+      });
+    }
   });
 });
 

--- a/src/libs/next/config/define-config.test.ts
+++ b/src/libs/next/config/define-config.test.ts
@@ -7,6 +7,17 @@ describe('defineConfig', () => {
   it('disables Next.js agent rule injection', () => {
     expect(defineConfig({}).agentRules).toBe(false);
   });
+
+  it('caches SPA build artifacts', async () => {
+    const headers = await defineConfig({}).headers?.();
+    const spaHeaders = headers?.find(({ source }) => source === '/_spa/:path*');
+
+    expect(spaHeaders?.headers).toContainEqual({
+      key: 'Cache-Control',
+      value:
+        'public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800, stale-if-error=86400, immutable',
+    });
+  });
 });
 
 describe('dockerCanvasTracingIncludes', () => {

--- a/src/libs/next/config/define-config.ts
+++ b/src/libs/next/config/define-config.ts
@@ -124,6 +124,21 @@ export function defineConfig(config: CustomNextConfig) {
           headers: [
             {
               key: 'Cache-Control',
+              value:
+                'public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800, stale-if-error=86400, immutable',
+            },
+            {
+              key: 'CDN-Cache-Control',
+              value:
+                'public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800, stale-if-error=86400, immutable',
+            },
+          ],
+          source: '/_spa/:path*',
+        },
+        {
+          headers: [
+            {
+              key: 'Cache-Control',
               value: 'public, max-age=31536000, immutable',
             },
             {

--- a/src/libs/next/config/define-config.ts
+++ b/src/libs/next/config/define-config.ts
@@ -139,6 +139,21 @@ export function defineConfig(config: CustomNextConfig) {
           headers: [
             {
               key: 'Cache-Control',
+              value:
+                'public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800, stale-if-error=86400, immutable',
+            },
+            {
+              key: 'CDN-Cache-Control',
+              value:
+                'public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800, stale-if-error=86400, immutable',
+            },
+          ],
+          source: '/_spa-auth/:path*',
+        },
+        {
+          headers: [
+            {
+              key: 'Cache-Control',
               value: 'public, max-age=31536000, immutable',
             },
             {

--- a/vercel.json
+++ b/vercel.json
@@ -2,19 +2,6 @@
   "buildCommand": "bun run build:vercel",
   "headers": [
     {
-      "source": "/_spa/(.*)",
-      "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800, stale-if-error=86400, immutable"
-        },
-        {
-          "key": "CDN-Cache-Control",
-          "value": "public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800, stale-if-error=86400, immutable"
-        }
-      ]
-    },
-    {
       "source": "/_dangerous_local_dev_proxy",
       "headers": [
         {


### PR DESCRIPTION
Serve `/_spa/*` assets with cache headers from Next.js so self-hosted deployments no longer default to `Cache-Control: public, max-age=0`.

This moves the existing Vercel-only SPA cache policy into the shared Next configuration and removes the duplicate Vercel rule.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check --lint --test src/libs/next/config/define-config.ts src/libs/next/config/define-config.test.ts vercel.json`
- `bunx vitest run --silent='passed-only' src/libs/next/config/define-config.test.ts`\n- Verified the deployed Node origin and Cloudflare response headers; Cloudflare cache reached `HIT`.

#### 🔗 Related Issue
N/A