### PR TITLE
🐛 fix: prevent prompt view-mode toggle from scrolling to bottom

### DIFF
--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
@@ -351,6 +351,24 @@ describe('Agent profile EditorCanvas', () => {
     expect(setHasEdited).toHaveBeenCalledWith(true);
   });
 
+  it('does not bubble mode-switch clicks to the click-to-focus wrapper', () => {
+    // The profile page wraps the canvas in a click-to-focus area; a bubbled
+    // toggle click would focus the editor and scroll to the caret at the
+    // document end. See LOBE-12593.
+    const onWrapperClick = vi.fn();
+    render(
+      <div onClick={onWrapperClick}>
+        <EditorCanvas />
+      </div>,
+    );
+    act(() => editorProps.last?.onInit());
+
+    fireEvent.click(screen.getByRole('button', { name: 'settingAgent.prompt.mode.source' }));
+    fireEvent.click(screen.getByRole('button', { name: 'settingAgent.prompt.mode.visual' }));
+
+    expect(onWrapperClick).not.toHaveBeenCalled();
+  });
+
   it('moves the prompt description into the title tooltip', () => {
     render(<EditorCanvas />);
 

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
@@ -452,7 +452,17 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
                 onRetry={editable ? () => void retryPromptSave() : undefined}
               />
             )}
-            <Flexbox horizontal className={styles.modeSwitch} gap={2}>
+            <Flexbox
+              horizontal
+              className={styles.modeSwitch}
+              gap={2}
+              // The profile content wrapper focuses the prompt editor on any
+              // bubbled click, and Lexical's focus() moves the caret to the
+              // document end when there is no selection — scrolling the page to
+              // the bottom. Toggling the view mode must not move the caret.
+              // See LOBE-12593.
+              onClick={(e) => e.stopPropagation()}
+            >
               <ActionIcon
                 active={activeEditorMode === 'visual'}
                 aria-label={t('settingAgent.prompt.mode.visual')}

--- a/src/routes/(main)/agent/profile/features/useClickToFocusEditor.test.ts
+++ b/src/routes/(main)/agent/profile/features/useClickToFocusEditor.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { type IEditor } from '@lobehub/editor';
+import { renderHook } from '@testing-library/react';
+import { type MouseEvent } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useClickToFocusEditor } from './useClickToFocusEditor';
+
+const focus = vi.fn();
+const getRootElement = vi.fn<() => { offsetParent: unknown } | null>();
+const editor = { focus, getRootElement } as unknown as IEditor;
+
+const clickEvent = (contains = true) =>
+  ({
+    currentTarget: { contains: () => contains },
+    target: {},
+  }) as unknown as MouseEvent<HTMLDivElement>;
+
+describe('useClickToFocusEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('focuses the editor when its root element is visible', () => {
+    getRootElement.mockReturnValue({ offsetParent: {} });
+    const { result } = renderHook(() => useClickToFocusEditor(editor, true));
+
+    result.current(clickEvent());
+
+    expect(focus).toHaveBeenCalled();
+  });
+
+  it('does not focus the editor while its root element is hidden (source mode)', () => {
+    // Lexical's focus() selects the document end when no selection exists, so
+    // focusing the display:none visual editor leaves a dirty end-of-document
+    // selection that scrolls the page to the bottom once the editor becomes
+    // visible again. See LOBE-12593.
+    getRootElement.mockReturnValue({ offsetParent: null });
+    const { result } = renderHook(() => useClickToFocusEditor(editor, true));
+
+    result.current(clickEvent());
+
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it('still focuses when the root element is not resolvable yet', () => {
+    getRootElement.mockReturnValue(null);
+    const { result } = renderHook(() => useClickToFocusEditor(editor, true));
+
+    result.current(clickEvent());
+
+    expect(focus).toHaveBeenCalled();
+  });
+
+  it('ignores clicks bubbling from portal content outside the wrapper', () => {
+    getRootElement.mockReturnValue({ offsetParent: {} });
+    const { result } = renderHook(() => useClickToFocusEditor(editor, true));
+
+    result.current(clickEvent(false));
+
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it('skips focus entirely without edit permission', () => {
+    getRootElement.mockReturnValue({ offsetParent: {} });
+    const { result } = renderHook(() => useClickToFocusEditor(editor, false));
+
+    result.current(clickEvent());
+
+    expect(focus).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/(main)/agent/profile/features/useClickToFocusEditor.ts
+++ b/src/routes/(main)/agent/profile/features/useClickToFocusEditor.ts
@@ -1,0 +1,27 @@
+import { type IEditor } from '@lobehub/editor';
+import { type MouseEvent, useCallback } from 'react';
+
+/**
+ * Focus the prompt editor when the user clicks the surrounding profile content
+ * area, mirroring a document-style "click anywhere to type" surface.
+ *
+ * The handler skips focusing when the editor's root element is hidden (the
+ * prompt is in Markdown source mode, which keeps the visual editor mounted but
+ * `display: none`). Lexical's `focus()` falls back to `selectEnd()` when the
+ * editor has no selection, so focusing the hidden editor leaves a dirty
+ * end-of-document selection that scrolls the page to the bottom once the editor
+ * becomes visible again. See LOBE-12593.
+ */
+export const useClickToFocusEditor = (editor: IEditor | undefined, canEdit: boolean) =>
+  useCallback(
+    (e: MouseEvent<HTMLDivElement>) => {
+      if (!canEdit) return;
+      // Only focus editor for clicks within this DOM element,
+      // not from React portal (e.g. Modal) whose DOM is outside this tree
+      if (!e.currentTarget.contains(e.target as Node)) return;
+      const rootElement = editor?.getRootElement();
+      if (rootElement && rootElement.offsetParent === null) return;
+      editor?.focus();
+    },
+    [canEdit, editor],
+  );

--- a/src/routes/(main)/agent/profile/index.tsx
+++ b/src/routes/(main)/agent/profile/index.tsx
@@ -21,6 +21,7 @@ import ProfileEditor from './features/ProfileEditor';
 import ProfileHydration from './features/ProfileHydration';
 import ProfileProvider from './features/ProfileProvider';
 import { selectors as profileSelectors, useProfileStore } from './features/store';
+import { useClickToFocusEditor } from './features/useClickToFocusEditor';
 
 const styles = StyleSheet.create({
   contentWrapper: {
@@ -44,6 +45,7 @@ const ProfileArea = memo(() => {
   const configError = useAgentStore(agentSelectors.currentAgentConfigError);
   const retryAgentConfigFetch = useAgentStore((s) => s.retryAgentConfigFetch);
   const { allowed: canEdit } = usePermission('edit_own_content');
+  const handleContentClick = useClickToFocusEditor(editor, canEdit);
 
   return (
     <>
@@ -69,14 +71,7 @@ const ProfileArea = memo(() => {
             height={'100%'}
             style={{ ...styles.contentWrapper, cursor: canEdit ? 'text' : 'default' }}
             width={'100%'}
-            onClick={(e) => {
-              if (!canEdit) return;
-              // Only focus editor for clicks within this DOM element,
-              // not from React portal (e.g. Modal) whose DOM is outside this tree
-              if (e.currentTarget.contains(e.target as Node)) {
-                editor?.focus();
-              }
-            }}
+            onClick={handleContentClick}
           >
             <WideScreenContainer>
               <ProfileEditor />


### PR DESCRIPTION
Clicking the source/preview mode toggle in the agent profile's Core Instructions editor scrolled the page to the bottom.

**Root cause**: the profile content wrapper focuses the prompt editor on any bubbled click (`src/routes/(main)/agent/profile/index.tsx`), and the mode-toggle buttons sit inside that wrapper but outside the editor shell's `stopPropagation` boundary. The bubbled click calls `editor.focus()`, and Lexical's `focus()` falls back to `root.selectEnd()` when the editor has no selection — the commit then runs `scrollIntoViewIfNeeded`, scrolling every scrollable ancestor to the end-of-document caret.

**Fix**:

- Stop propagation on the mode-switch button cluster in `EditorCanvas` — toggling the view mode must never move the caret (the scroll reproduced in both toggle directions).
- Extract the click-to-focus handler into `useClickToFocusEditor` and skip focusing while the editor's root element is hidden (`display: none` in source mode). Focusing the hidden editor left a dirty end-of-document selection that scrolled the page once the editor became visible again.

Verified against the live app via CDP: with the guard in place the profile scroll container stays at its position across source ⇄ preview toggles (previously jumped to the bottom deterministically).

#### Test

- [x] Tested locally
- [x] Added/updated tests

Regression tests: mode-toggle clicks no longer bubble to the click-to-focus wrapper (fails before the fix), plus unit coverage for the hidden-editor guard in `useClickToFocusEditor`.

#### 🔗 Related Issue

Fixes LOBE-12593