### PR TITLE
🐛 fix(agent-runtime): stamp the work display anchor at completion for file works

### DIFF
--- a/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
+++ b/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
@@ -540,9 +540,13 @@ export class CompletionLifecycle {
     if (state?.metadata?._fileWorksRegistered) return;
     try {
       const outcome = await registerWorksForOperation({
-        // The round's final assistant message — the shell github scan stamps the
-        // Work display anchor onto it for hetero runs (see registerWorksForOperation).
-        assistantMessageId: state?.metadata?.assistantMessageId ?? null,
+        // The round's final assistant message — the scan stamps the Work display
+        // anchor onto it (see registerWorksForOperation). Operation metadata only
+        // carries `assistantMessageId` on the hetero/client paths; the server
+        // in-process path resolves it from the terminal state's final assistant
+        // turn instead.
+        assistantMessageId:
+          state?.metadata?.assistantMessageId ?? resolveFinalAssistantMessageId(state),
         // Live terminal totals: on the pre-snapshot path the op row's cost/usage
         // columns are not persisted yet (recordCompletion runs later), so the
         // registration must not rely on reading them back from the DB.
@@ -971,6 +975,24 @@ const extractTextFromMessageContent = (content: unknown): string | undefined => 
  * the persisted leaf turns rather than that virtual wrapper, otherwise they
  * lose both the final text and the message id used by DB recovery.
  */
+/**
+ * Resolve the persisted id of the round's FINAL assistant turn from terminal
+ * state, unfolding display-only groups first (the per-step DB rehydrate stores
+ * `state.messages` in the conversation-flow folded shape). Used to anchor the
+ * Work display stamp when operation metadata carries no `assistantMessageId`
+ * (the server in-process path).
+ */
+const resolveFinalAssistantMessageId = (state: any): string | null => {
+  const messages = normalizeCompletionMessages(
+    Array.isArray(state?.messages) ? state.messages : [],
+  );
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i];
+    if (message.role === 'assistant' && typeof message.id === 'string') return message.id;
+  }
+  return null;
+};
+
 const normalizeCompletionMessages = (messages: unknown[]): Record<PropertyKey, unknown>[] => {
   const normalized: Record<PropertyKey, unknown>[] = [];
 

--- a/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
@@ -1085,6 +1085,49 @@ describe('CompletionLifecycle.registerFileWorks', () => {
     expect(mockRegister).toHaveBeenCalledTimes(1);
   });
 
+  it('resolves the anchor from the terminal final assistant turn on the server path', async () => {
+    // Server in-process runs carry no metadata.assistantMessageId — the anchor
+    // must come from the final assistant turn in state, unfolding the
+    // conversation-flow grouped shape the per-step DB rehydrate stores.
+    mockRegister.mockClear();
+    mockRegister.mockResolvedValue({ attempted: 1, failed: 0 });
+    const lifecycle = buildLifecycle();
+    const state = {
+      messages: [
+        { content: 'q', id: 'msg-user', role: 'user' },
+        {
+          children: [{ content: '', id: 'msg-mid', role: 'assistant', tools: [] }],
+          id: 'msg-group',
+          role: 'assistantGroup',
+        },
+        { content: 'done', id: 'msg-final', role: 'assistant' },
+      ],
+      metadata: {},
+    } as any;
+
+    await lifecycle.registerFileWorks('op-1', state);
+
+    expect(mockRegister).toHaveBeenCalledWith(
+      expect.objectContaining({ assistantMessageId: 'msg-final' }),
+    );
+  });
+
+  it('prefers metadata.assistantMessageId over the state-resolved anchor', async () => {
+    mockRegister.mockClear();
+    mockRegister.mockResolvedValue({ attempted: 1, failed: 0 });
+    const lifecycle = buildLifecycle();
+    const state = {
+      messages: [{ content: 'done', id: 'msg-final', role: 'assistant' }],
+      metadata: { assistantMessageId: 'msg-from-metadata' },
+    } as any;
+
+    await lifecycle.registerFileWorks('op-1', state);
+
+    expect(mockRegister).toHaveBeenCalledWith(
+      expect.objectContaining({ assistantMessageId: 'msg-from-metadata' }),
+    );
+  });
+
   it('never throws and leaves the marker unset on failure so a later call retries', async () => {
     mockRegister.mockClear();
     mockRegister.mockRejectedValueOnce(new Error('sandbox export failed'));

--- a/apps/server/src/services/agentRuntime/workRegistration.test.ts
+++ b/apps/server/src/services/agentRuntime/workRegistration.test.ts
@@ -145,7 +145,10 @@ beforeEach(() => {
   mockFindFileVersionByToolCall.mockResolvedValue(null);
   mockRegisterShellGithubResult.mockResolvedValue({ id: 'work-github' });
   mockUpdateMessage.mockResolvedValue({ success: true });
-  mockFindMessageById.mockResolvedValue(undefined);
+  // Default: the anchor fallback (tool message → owning assistant) resolves, so
+  // registrations without an explicit assistantMessageId still stamp cleanly.
+  // Tests exercising the missing-anchor path override this to undefined.
+  mockFindMessageById.mockResolvedValue({ id: 'tool-msg', parentId: 'msg-owner-assistant' });
   mockCreateSandboxService.mockReturnValue({ exportAndUploadFile: mockExportAndUploadFile });
   mockRegisterFile.mockImplementation(async (params: any) => ({
     currentVersionId: `ver-${params.filePath}`,
@@ -306,6 +309,67 @@ describe('registerWorksForOperation', () => {
 
     expect(mockExportAndUploadFile).not.toHaveBeenCalled();
     expect(mockRegisterFile).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ attempted: 1, failed: 0 });
+  });
+
+  it('stamps the work anchor on the final assistant message when file Works register', async () => {
+    // The gateway runtime's per-step rehydrate folds tool rows out of
+    // state.messages, so callLlmFinalizer's buildWorkAnchor never stamps — the
+    // completion scan is the reliable stamping site for file Works too.
+    mockListPlugins.mockResolvedValue([writeRow('a', '/mnt/data/deck.pptx')]);
+
+    const outcome = await registerWorksForOperation({
+      ...baseParams,
+      assistantMessageId: 'msg-final-assistant',
+    });
+
+    expect(mockUpdateMessage).toHaveBeenCalledWith('msg-final-assistant', {
+      metadata: { work: { rootOperationId: 'op-1' } },
+    });
+    expect(outcome).toEqual({ attempted: 1, failed: 0 });
+  });
+
+  it('anchors file Works on the owning assistant when no assistantMessageId is available', async () => {
+    mockFindMessageById.mockResolvedValue({ id: 'a', parentId: 'msg-owner-assistant' });
+    mockListPlugins.mockResolvedValue([writeRow('a', '/mnt/data/deck.pptx')]);
+
+    const outcome = await registerWorksForOperation(baseParams);
+
+    // Fallback walks provenance: the last edit's tool message → its parent.
+    expect(mockFindMessageById).toHaveBeenCalledWith('a');
+    expect(mockUpdateMessage).toHaveBeenCalledWith('msg-owner-assistant', {
+      metadata: { work: { rootOperationId: 'op-1' } },
+    });
+    expect(outcome).toEqual({ attempted: 1, failed: 0 });
+  });
+
+  it('counts a failed file-work anchor stamp so the completion backstop retries', async () => {
+    mockUpdateMessage.mockResolvedValue({ success: false });
+    mockListPlugins.mockResolvedValue([writeRow('a', '/mnt/data/deck.pptx')]);
+
+    const outcome = await registerWorksForOperation({
+      ...baseParams,
+      assistantMessageId: 'msg-final-assistant',
+    });
+
+    // The version registered, but nothing would render it — withhold the marker.
+    expect(outcome).toEqual({ attempted: 1, failed: 1 });
+  });
+
+  it('re-stamps the anchor on a retry round whose versions all short-circuit', async () => {
+    // A retry typically re-runs BECAUSE the previous stamp failed: versions are
+    // already registered (probe skip), yet the anchor must still be written.
+    mockListPlugins.mockResolvedValue([writeRow('a', '/mnt/data/deck.pptx')]);
+    mockFindFileVersionByToolCall.mockResolvedValue({ id: 'ver-existing' });
+
+    const outcome = await registerWorksForOperation({
+      ...baseParams,
+      assistantMessageId: 'msg-final-assistant',
+    });
+
+    expect(mockUpdateMessage).toHaveBeenCalledWith('msg-final-assistant', {
+      metadata: { work: { rootOperationId: 'op-1' } },
+    });
     expect(outcome).toEqual({ attempted: 1, failed: 0 });
   });
 

--- a/apps/server/src/services/agentRuntime/workRegistration.ts
+++ b/apps/server/src/services/agentRuntime/workRegistration.ts
@@ -38,10 +38,11 @@ interface FileProvenance {
 
 export interface RegisterWorksForOperationParams {
   /**
-   * The round's final assistant message. When the shell Work scan registers a
-   * Work, the anchor stamp (`metadata.work.rootOperationId`) is merged onto this
-   * message so the Works chip renders — heterogeneous runs never pass
-   * `callLlmFinalizer`, which stamps the anchor for in-process runs.
+   * The round's final assistant message. When this completion registers any
+   * Work (shell scan or file scan), the anchor stamp
+   * (`metadata.work.rootOperationId`) is merged onto this message so the Works
+   * card renders — see {@link stampWorkAnchor} for why the completion scan, not
+   * `callLlmFinalizer`, is the reliable place to stamp it.
    */
   assistantMessageId?: string | null;
   /**
@@ -438,6 +439,75 @@ const collectOperationRecords = async (
  * whole-function rejection so Work registration can never affect operation
  * completion.
  */
+/**
+ * Stamp the Work display anchor (`metadata.work.rootOperationId`) onto the
+ * round's final assistant message so the Works registered by this completion
+ * render under it.
+ *
+ * The completion scan — not `callLlmFinalizer` — is the reliable stamping site
+ * for BOTH scan families:
+ * - Heterogeneous shell runs (codex / claude-code / device) never pass
+ *   `callLlmFinalizer` at all.
+ * - In-process gateway runs DO pass it, but its `buildWorkAnchor` reads
+ *   `state.messages`, which the per-step DB rehydrate rebuilds in the
+ *   conversation-flow FOLDED shape (tool rows collapsed into `assistantGroup`
+ *   nodes, no `tool_calls`) since #16112 — so its prior-tool-interaction scan
+ *   finds nothing and the finalizer never stamps.
+ *
+ * `messageModel.update` deep-merges metadata, so re-stamping an anchor that
+ * was already written (same rootOperationId) is a no-op.
+ *
+ * Returns `true` when the anchor was stamped. The caller counts a `false`
+ * into `failed` so the completion backstop withholds its idempotency marker
+ * and retries the (idempotent) scan + stamp next round.
+ */
+const stampWorkAnchor = async ({
+  assistantMessageId,
+  fallbackToolMessageId,
+  messageModel,
+  operationId,
+}: {
+  assistantMessageId?: string | null;
+  fallbackToolMessageId?: string | null;
+  messageModel: MessageModel;
+  operationId: string;
+}): Promise<boolean> => {
+  let anchorMessageId = assistantMessageId ?? null;
+  if (!anchorMessageId && fallbackToolMessageId) {
+    // Runs can finish without a final-assistant pointer (hetero SINGLE-STEP
+    // runs: `heteroFinish` finds neither `heteroCurrentMsgId` nor
+    // `runningOperation.assistantMessageId`). Fall back to the assistant that
+    // OWNS the last registered tool call — every tool message keeps
+    // `parentId` = its owning assistant — so the Work still renders in the
+    // round instead of being persisted invisibly.
+    try {
+      const toolMessage = await messageModel.findById(fallbackToolMessageId);
+      anchorMessageId = toolMessage?.parentId ?? null;
+    } catch (error) {
+      log('[%s] Failed to resolve fallback work anchor (non-fatal): %O', operationId, error);
+    }
+  }
+
+  if (!anchorMessageId) {
+    // No resolvable anchor at all: the Work row exists but nothing would ever
+    // render it.
+    log('[%s] No anchor message available for registered Works', operationId);
+    return false;
+  }
+
+  // `messageModel.update` reports DB errors / no-matched-row as
+  // `{ success: false }` instead of throwing — a failed stamp must count as a
+  // failure so the scan is retried.
+  const stamp = await messageModel.update(anchorMessageId, {
+    metadata: { work: { rootOperationId: operationId } },
+  });
+  if (!stamp.success) {
+    log('[%s] Failed to stamp work anchor on %s', operationId, anchorMessageId);
+    return false;
+  }
+  return true;
+};
+
 export const registerWorksForOperation = async (
   params: RegisterWorksForOperationParams,
 ): Promise<WorksRegistrationOutcome> => {
@@ -571,47 +641,19 @@ export const registerWorksForOperation = async (
     workModel,
   });
 
-  // Heterogeneous runs never pass `callLlmFinalizer`, the executor that stamps
-  // the Work display anchor (`metadata.work.rootOperationId`) for in-process
-  // runs — without the stamp a registered Work never renders below the message.
-  // `messageModel.update` deep-merges metadata, so re-stamping an anchor the
-  // finalizer already wrote (same rootOperationId) is a no-op.
+  // Stamp the display anchor as soon as the shell scan registered anything;
+  // the file scan below stamps too (at most once per completion). See
+  // `stampWorkAnchor` for why the completion scan — not `callLlmFinalizer` —
+  // is the reliable stamping site for BOTH scan families.
+  let anchorStamped = false;
   if (shellOutcome.registered > 0) {
-    let anchorMessageId = params.assistantMessageId ?? null;
-    if (!anchorMessageId && shellOutcome.anchorCandidateMessageId) {
-      // Hetero SINGLE-STEP runs can finish without a final-assistant pointer
-      // (`heteroFinish` finds neither `heteroCurrentMsgId` nor
-      // `runningOperation.assistantMessageId`). Fall back to the assistant
-      // that OWNS the last registered shell tool call — every tool message
-      // keeps `parentId` = its owning assistant — so the Work still renders
-      // in the round instead of being persisted invisibly.
-      try {
-        const toolMessage = await messageModel.findById(shellOutcome.anchorCandidateMessageId);
-        anchorMessageId = toolMessage?.parentId ?? null;
-      } catch (error) {
-        log('[%s] Failed to resolve fallback work anchor (non-fatal): %O', operationId, error);
-      }
-    }
-
-    if (anchorMessageId) {
-      // `messageModel.update` reports DB errors / no-matched-row as
-      // `{ success: false }` instead of throwing — a failed stamp must count as
-      // a failure so the completion backstop withholds its idempotency marker
-      // and retries the (idempotent) scan + stamp next round.
-      const stamp = await messageModel.update(anchorMessageId, {
-        metadata: { work: { rootOperationId: operationId } },
-      });
-      if (!stamp.success) {
-        shellOutcome.failed += 1;
-        log('[%s] Failed to stamp work anchor on %s', operationId, anchorMessageId);
-      }
-    } else {
-      // No resolvable anchor at all: the Work row exists but nothing would
-      // ever render it. Withhold the completion marker so a later completion
-      // retries the (idempotent) scan + stamp.
-      shellOutcome.failed += 1;
-      log('[%s] No anchor message available for registered shell Works', operationId);
-    }
+    anchorStamped = await stampWorkAnchor({
+      assistantMessageId: params.assistantMessageId,
+      fallbackToolMessageId: shellOutcome.anchorCandidateMessageId,
+      messageModel,
+      operationId,
+    });
+    if (!anchorStamped) shellOutcome.failed += 1;
   }
 
   const scannedEntities = scanOperationFileEdits(records).filter(
@@ -814,8 +856,35 @@ export const registerWorksForOperation = async (
   const failed = settled.filter(
     (result) => result.status === 'rejected' || result.value === 'failed',
   ).length;
+
+  // File Works need the anchor stamp exactly like shell Works (the finalizer
+  // never stamps on the gateway runtime — see `stampWorkAnchor`). Stamp when
+  // any file version is in place this round, including idempotent probe skips:
+  // a retry round typically re-runs BECAUSE a previous stamp failed, so the
+  // already-registered version still needs its anchor. Skipped when the shell
+  // branch above already stamped this completion (same value, deep-merge no-op
+  // anyway — just avoids a redundant write).
+  let anchorFailed = 0;
+  const registeredFiles = settled.filter(
+    (result) => result.status === 'fulfilled' && result.value === 'ok',
+  ).length;
+  if (registeredFiles > 0 && !anchorStamped) {
+    // Fallback: the tool message that last touched the last candidate file —
+    // its `parentId` is the owning assistant, mirroring the shell fallback.
+    const fallbackToolMessageId = resolveProvenance(
+      entities.at(-1)?.sourceToolCallIds ?? [],
+    )?.messageId;
+    const stamped = await stampWorkAnchor({
+      assistantMessageId: params.assistantMessageId,
+      fallbackToolMessageId,
+      messageModel,
+      operationId,
+    });
+    if (!stamped) anchorFailed = 1;
+  }
+
   return {
     attempted: entities.length + shellOutcome.attempted,
-    failed: failed + shellOutcome.failed,
+    failed: failed + shellOutcome.failed + anchorFailed,
   };
 };


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

Registered file Works (exported pptx/xlsx/docx/pdf entities) never rendered their card: the Works card only renders under an assistant message stamped with `metadata.work.rootOperationId`, and that anchor was never written on the gateway server runtime.

Root cause: since #16112 the per-step state persistence drops `messages` and rehydrates them from the DB via `parse().flatList` — the conversation-flow **folded** shape, where tool rows are collapsed into `assistantGroup` nodes (no standalone `role:'tool'` entries, no `tool_calls`). `callLlmFinalizer`'s `buildWorkAnchor` scans that folded list for a prior tool interaction, finds none, and skips the stamp — for every in-process run. Intervention-resume runs fail doubly: their `sourceMessageId` is a tool message that no longer exists at the top level of the folded list. (Same failure family as #17725.)

Fix (completion-side backstop, mirroring the existing hetero shell-work stamp):

- Extract the anchor stamp into a shared `stampWorkAnchor` helper and run it whenever the completion scan registers **file** works too (including idempotent probe-skip rounds, so a retry after a failed stamp still anchors). A failed/unresolvable stamp counts into `failed` so the completion marker is withheld and the scan retries.
- On the server in-process path the operation metadata carries no `assistantMessageId`; resolve the anchor from the terminal state's final assistant turn (unfolding display-only groups via `normalizeCompletionMessages`).

`messageModel.update` deep-merges metadata, so re-stamping an anchor the finalizer already wrote is a no-op.

#### 📝 How to Test

- [x] Added/updated tests (file-work anchor stamp, fallback anchor via owning assistant, failed-stamp accounting, idempotent-retry re-stamp, server-path anchor resolution from terminal state)
- [x] Tested locally: reproduced on a sandbox run whose `exportFile` registered works but rendered no card (all messages lacked `metadata.work`)

#### 🔗 Related

- Part of LOBE-12455 (doc-type Work preview) verification fallout; broken since #16112 × #17079 interaction.