### PR TITLE
💄 style: polish model param controls and localize skip message

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -1298,6 +1298,8 @@
   "tool.intervention.renderFallback.rawJson": "Raw JSON",
   "tool.intervention.renderFallback.title": "Interaction display downgraded",
   "tool.intervention.scrollToIntervention": "View",
+  "tool.intervention.skipMessage": "I'll skip this.",
+  "tool.intervention.skipMessageWithReason": "I'll skip this. {{reason}}",
   "tool.intervention.submit": "Submit",
   "tool.intervention.toolAbort": "You canceled this Skill call",
   "tool.intervention.toolRejected": "This Skill call was rejected",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -1298,6 +1298,8 @@
   "tool.intervention.renderFallback.rawJson": "原始 JSON",
   "tool.intervention.renderFallback.title": "交互展示已降级",
   "tool.intervention.scrollToIntervention": "查看",
+  "tool.intervention.skipMessage": "先跳过这个问题。",
+  "tool.intervention.skipMessageWithReason": "先跳过这个问题。{{reason}}",
   "tool.intervention.submit": "提交",
   "tool.intervention.toolAbort": "你已取消本次技能调用",
   "tool.intervention.toolRejected": "本次技能调用已被拒绝",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -1458,6 +1458,8 @@ export default {
     'This display was downgraded to raw JSON because the current model was not capable enough to generate a stable interactive payload. Switch to a stronger model and try again.',
   'tool.intervention.renderFallback.rawJson': 'Raw JSON',
   'tool.intervention.renderFallback.title': 'Interaction display downgraded',
+  'tool.intervention.skipMessage': "I'll skip this.",
+  'tool.intervention.skipMessageWithReason': "I'll skip this. {{reason}}",
   'tool.intervention.submit': 'Submit',
   'tool.intervention.mode.allowList': 'Allow List',
   'tool.intervention.mode.allowListDesc': 'Only automatically execute approved tools',

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
@@ -234,7 +234,6 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <ReasoningEffortSlider />,
-        desc: 'reasoning_effort',
         label: t('extendParams.reasoningEffort.title'),
         layout: 'vertical',
         minWidth: undefined,
@@ -290,7 +289,6 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <GPT5ReasoningEffortSlider />,
-        desc: 'reasoning_effort',
         label: t('extendParams.reasoningEffort.title'),
         layout: 'vertical',
         minWidth: undefined,
@@ -301,7 +299,6 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <GPT51ReasoningEffortSlider />,
-        desc: 'reasoning_effort',
         label: t('extendParams.reasoningEffort.title'),
         layout: 'vertical',
         minWidth: undefined,
@@ -312,7 +309,6 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <GPT52ReasoningEffortSlider defaultValue={gpt52ReasoningEffortDefaultValue} />,
-        desc: 'reasoning_effort',
         label: t('extendParams.reasoningEffort.title'),
         layout: 'vertical',
         minWidth: undefined,
@@ -323,7 +319,6 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <GPT56ReasoningEffortSlider />,
-        desc: 'reasoning_effort',
         label: t('extendParams.reasoningEffort.title'),
         layout: 'vertical',
         minWidth: undefined,
@@ -334,7 +329,6 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <GPT52ProReasoningEffortSlider />,
-        desc: 'reasoning_effort',
         label: t('extendParams.reasoningEffort.title'),
         layout: 'vertical',
         minWidth: undefined,
@@ -345,7 +339,6 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <GLM52ReasoningEffortSlider />,
-        desc: 'reasoning_effort',
         label: t('extendParams.reasoningEffort.title'),
         layout: 'vertical',
         minWidth: undefined,
@@ -356,7 +349,6 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <Grok420ReasoningEffortSlider />,
-        desc: 'reasoning_effort',
         label: t('extendParams.reasoningEffort.title'),
         layout: 'vertical',
         minWidth: undefined,
@@ -367,7 +359,6 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <Grok43ReasoningEffortSlider />,
-        desc: 'reasoning_effort',
         label: t('extendParams.reasoningEffort.title'),
         layout: 'vertical',
         minWidth: undefined,
@@ -378,7 +369,6 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <Grok45ReasoningEffortSlider />,
-        desc: 'reasoning_effort',
         label: t('extendParams.reasoningEffort.title'),
         layout: 'vertical',
         minWidth: undefined,
@@ -389,7 +379,6 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <Hy3ReasoningEffortSlider />,
-        desc: 'reasoning_effort',
         label: t('extendParams.reasoningEffort.title'),
         layout: 'vertical',
         minWidth: undefined,
@@ -400,7 +389,6 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <KimiK3ReasoningEffortSlider />,
-        desc: 'reasoning_effort',
         label: t('extendParams.reasoningEffort.title'),
         layout: 'vertical',
         minWidth: undefined,
@@ -411,7 +399,6 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <Ring26ReasoningEffortSlider />,
-        desc: 'reasoning_effort',
         label: t('extendParams.reasoningEffort.title'),
         layout: 'vertical',
         minWidth: undefined,
@@ -422,7 +409,6 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <CodexMaxReasoningEffortSlider />,
-        desc: 'reasoning_effort',
         label: t('extendParams.reasoningEffort.title'),
         layout: 'vertical',
         minWidth: undefined,
@@ -433,7 +419,6 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <Step3_5ReasoningEffortSlider />,
-        desc: 'reasoning_effort',
         label: t('extendParams.reasoningEffort.title'),
         layout: 'vertical',
         minWidth: undefined,
@@ -444,7 +429,6 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <TextVerbositySlider />,
-        desc: 'text_verbosity',
         label: t('extendParams.textVerbosity.title'),
         layout: 'vertical',
         minWidth: undefined,
@@ -462,7 +446,6 @@ const ControlsForm = memo<ControlsFormProps>(
         style: {
           paddingBottom: 0,
         },
-        tag: 'thinkingBudget',
       },
       {
         children: <Switch disabled={disabled} size={'small'} />,
@@ -476,7 +459,6 @@ const ControlsForm = memo<ControlsFormProps>(
         minWidth: undefined,
         name: 'urlContext',
         style: undefined,
-        tag: 'urlContext',
       },
       {
         children: <ThinkingSlider />,
@@ -497,7 +479,6 @@ const ControlsForm = memo<ControlsFormProps>(
         style: {
           paddingBottom: 0,
         },
-        desc: 'thinkingLevel',
       },
       {
         children: <ThinkingLevel2Slider />,
@@ -508,7 +489,6 @@ const ControlsForm = memo<ControlsFormProps>(
         style: {
           paddingBottom: 0,
         },
-        desc: 'thinkingLevel',
       },
       {
         children: <ThinkingLevel3Slider />,
@@ -519,7 +499,6 @@ const ControlsForm = memo<ControlsFormProps>(
         style: {
           paddingBottom: 0,
         },
-        desc: 'thinkingLevel',
       },
       {
         children: <ThinkingLevel4Slider />,
@@ -530,7 +509,6 @@ const ControlsForm = memo<ControlsFormProps>(
         style: {
           paddingBottom: 0,
         },
-        desc: 'thinkingLevel',
       },
       {
         children: <ImageAspectRatioSelect />,
@@ -541,7 +519,6 @@ const ControlsForm = memo<ControlsFormProps>(
         style: {
           paddingBottom: 0,
         },
-        desc: 'aspectRatio',
       },
       {
         children: <ImageAspectRatio2Select />,
@@ -552,7 +529,6 @@ const ControlsForm = memo<ControlsFormProps>(
         style: {
           paddingBottom: 0,
         },
-        desc: 'aspectRatio',
       },
       {
         children: <ImageResolutionSlider />,
@@ -563,7 +539,6 @@ const ControlsForm = memo<ControlsFormProps>(
         style: {
           paddingBottom: 0,
         },
-        desc: 'imageSize',
       },
       {
         children: <ImageResolution2Slider />,
@@ -574,7 +549,6 @@ const ControlsForm = memo<ControlsFormProps>(
         style: {
           paddingBottom: 0,
         },
-        desc: 'imageSize',
       },
     ].filter(Boolean) as FormItemProps[];
 

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
@@ -1,12 +1,14 @@
 import type { LobeAgentChatConfig } from '@lobechat/types';
 import { type FormItemProps } from '@lobehub/ui';
-import { Form } from '@lobehub/ui';
+import { Flexbox, Form } from '@lobehub/ui';
 import { Switch } from '@lobehub/ui/base-ui';
-import { Form as AntdForm, Grid } from 'antd';
+import { Form as AntdForm } from 'antd';
 import isEqual from 'fast-deep-equal';
+import type { ReactNode } from 'react';
 import { memo, useEffect, useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
+import InfoTooltip from '@/components/InfoTooltip';
 import { useAgentId } from '@/features/ChatInput/hooks/useAgentId';
 import { useUpdateAgentConfig } from '@/features/ChatInput/hooks/useUpdateAgentConfig';
 import {
@@ -119,76 +121,68 @@ const ControlsForm = memo<ControlsFormProps>(
     const enableReasoningValue =
       AntdForm.useWatch(['enableReasoning'], form) ?? initialValues.enableReasoning;
 
-    const screens = Grid.useBreakpoint();
-    const isNarrow = !screens.sm;
     const gpt52ReasoningEffortDefaultValue = model === 'gpt-5.5' ? 'medium' : 'none';
     const thinkingLevelDefaultValue = resolveDefaultThinkingLevelForModel(model);
 
-    const descWide = { display: 'inline-block', width: 300 } as const;
-    const descNarrow = {
-      display: 'block',
-      maxWidth: '100%',
-      whiteSpace: 'normal',
-    } as const;
+    // Show descriptions as a question-mark tooltip beside the label, matching
+    // the ControlRow items rendered above this form in the params panel.
+    const labelWithTooltip = (label: string, tooltip: ReactNode) => (
+      <Flexbox horizontal align={'center'} gap={6}>
+        {label}
+        <InfoTooltip title={tooltip} />
+      </Flexbox>
+    );
 
     const items = [
       {
         children: <ContextCachingSwitch disabled={disabled} />,
-        desc: (
-          <span style={isNarrow ? descNarrow : descWide}>
-            <Trans i18nKey={'extendParams.disableContextCaching.desc'} ns={'chat'}>
-              单条对话生成成本最高可降低 90%，响应速度提升 4 倍（
-              <a
-                href={'https://www.anthropic.com/news/prompt-caching?utm_source=lobechat'}
-                rel="noreferrer nofollow"
-                target="_blank"
-              >
-                了解更多
-              </a>
-              ）。开启后将自动禁用历史记录限制
-            </Trans>
-          </span>
+        label: labelWithTooltip(
+          t('extendParams.disableContextCaching.title'),
+          <Trans i18nKey={'extendParams.disableContextCaching.desc'} ns={'chat'}>
+            单条对话生成成本最高可降低 90%，响应速度提升 4 倍（
+            <a
+              href={'https://www.anthropic.com/news/prompt-caching?utm_source=lobechat'}
+              rel="noreferrer nofollow"
+              target="_blank"
+            >
+              了解更多
+            </a>
+            ）。开启后将自动禁用历史记录限制
+          </Trans>,
         ),
-        label: t('extendParams.disableContextCaching.title'),
-        layout: isNarrow ? 'vertical' : 'horizontal',
+        layout: 'horizontal',
         minWidth: undefined,
         name: 'disableContextCaching',
       },
       {
         children: <Switch disabled={disabled} size={'small'} />,
-        desc: (
-          <span style={isNarrow ? descNarrow : descWide}>
-            <Trans i18nKey={'extendParams.enableReasoning.desc'} ns={'chat'}>
-              开启后模型会先进行推理，适合复杂问题。
-            </Trans>
-          </span>
+        label: labelWithTooltip(
+          t('extendParams.enableReasoning.title'),
+          <Trans i18nKey={'extendParams.enableReasoning.desc'} ns={'chat'}>
+            开启后模型会先进行推理，适合复杂问题。
+          </Trans>,
         ),
-        label: t('extendParams.enableReasoning.title'),
-        layout: isNarrow ? 'vertical' : 'horizontal',
+        layout: 'horizontal',
         minWidth: undefined,
         name: 'enableReasoning',
       },
       {
         children: <Switch disabled={disabled} size={'small'} />,
-        desc: isNarrow ? (
-          <span style={descNarrow}>{t('extendParams.preserveThinking.desc')}</span>
-        ) : (
-          t('extendParams.preserveThinking.desc')
+        label: labelWithTooltip(
+          t('extendParams.preserveThinking.title'),
+          t('extendParams.preserveThinking.desc'),
         ),
-        label: t('extendParams.preserveThinking.title'),
-        layout: isNarrow ? 'vertical' : 'horizontal',
+        layout: 'horizontal',
         minWidth: undefined,
         name: 'preserveThinking',
       },
       {
         children: <Switch size={'small'} />,
-        desc: isNarrow ? (
-          <span style={descNarrow}>{t('extendParams.enableAdaptiveThinking.desc')}</span>
-        ) : (
-          t('extendParams.enableAdaptiveThinking.desc')
+        label: labelWithTooltip(
+          t('extendParams.enableAdaptiveThinking.title'),
+          t('extendParams.enableAdaptiveThinking.desc'),
         ),
-        label: t('extendParams.enableAdaptiveThinking.title'),
-        layout: isNarrow ? 'vertical' : 'horizontal',
+        layout: 'horizontal',
         minWidth: undefined,
         name: 'enableAdaptiveThinking',
       },
@@ -244,12 +238,10 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <ReasoningModeSegmented />,
-        desc: isNarrow ? (
-          <span style={descNarrow}>{t('extendParams.reasoningMode.desc')}</span>
-        ) : (
-          t('extendParams.reasoningMode.desc')
+        label: labelWithTooltip(
+          t('extendParams.reasoningMode.title'),
+          t('extendParams.reasoningMode.desc'),
         ),
-        label: t('extendParams.reasoningMode.title'),
         layout: 'vertical',
         minWidth: undefined,
         name: 'reasoningMode',
@@ -259,12 +251,7 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <EffortSlider />,
-        desc: isNarrow ? (
-          <span style={descNarrow}>{t('extendParams.effort.desc')}</span>
-        ) : (
-          t('extendParams.effort.desc')
-        ),
-        label: t('extendParams.effort.title'),
+        label: labelWithTooltip(t('extendParams.effort.title'), t('extendParams.effort.desc')),
         layout: 'vertical',
         minWidth: undefined,
         name: 'effort',
@@ -274,12 +261,7 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <Opus47EffortSlider />,
-        desc: isNarrow ? (
-          <span style={descNarrow}>{t('extendParams.effort.desc')}</span>
-        ) : (
-          t('extendParams.effort.desc')
-        ),
-        label: t('extendParams.effort.title'),
+        label: labelWithTooltip(t('extendParams.effort.title'), t('extendParams.effort.desc')),
         layout: 'vertical',
         minWidth: undefined,
         name: 'opus47Effort',
@@ -449,13 +431,11 @@ const ControlsForm = memo<ControlsFormProps>(
       },
       {
         children: <Switch disabled={disabled} size={'small'} />,
-        desc: isNarrow ? (
-          <span style={descNarrow}>{t('extendParams.urlContext.desc')}</span>
-        ) : (
-          t('extendParams.urlContext.desc')
+        label: labelWithTooltip(
+          t('extendParams.urlContext.title'),
+          t('extendParams.urlContext.desc'),
         ),
-        label: t('extendParams.urlContext.title'),
-        layout: isNarrow ? 'vertical' : 'horizontal',
+        layout: 'horizontal',
         minWidth: undefined,
         name: 'urlContext',
         style: undefined,

--- a/src/features/ModelSwitchPanel/components/ControlsForm/LevelSlider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/LevelSlider.tsx
@@ -174,6 +174,20 @@ function LevelSlider<T extends string = string>({
   const sliderValue = currentIndex === -1 ? Math.floor(levels.length / 2) : currentIndex;
   const { minWidth: customMinWidth, ...restStyle } = style ?? {};
 
+  // Slider dots sit at i / (n - 1) of the track while equal grid columns center
+  // labels at (i + 0.5) / n, so labels drift off their dots (e.g. 'none' / 'max'
+  // float away from the track ends). Half-width edge columns with start/end
+  // alignment pin the first/last labels to the ends and center the middle
+  // labels exactly under their dots.
+  const gridTemplateColumns =
+    levels.length > 1
+      ? [
+          'minmax(0, 0.5fr)',
+          ...Array.from({ length: levels.length - 2 }).fill('minmax(0, 1fr)'),
+          'minmax(0, 0.5fr)',
+        ].join(' ')
+      : 'minmax(0, 1fr)';
+
   const handleChange = (index: number) => {
     if (disabled) return;
 
@@ -205,12 +219,12 @@ function LevelSlider<T extends string = string>({
           onChange={handleChange}
         />
       </div>
-      <div
-        className={styles.labels}
-        style={{ gridTemplateColumns: `repeat(${levels.length}, minmax(0, 1fr))` }}
-      >
+      <div className={styles.labels} style={{ gridTemplateColumns }}>
         {options.map((option, index) => {
           const selected = index === sliderValue;
+          const isFirst = index === 0;
+          const isLast = index === levels.length - 1;
+          const textAlign = isFirst === isLast ? 'center' : isFirst ? 'start' : 'end';
 
           return (
             <button
@@ -218,7 +232,7 @@ function LevelSlider<T extends string = string>({
               className={cx(styles.label, selected && styles.selectedLabel)}
               disabled={disabled}
               key={option.value}
-              style={option.style}
+              style={{ textAlign, ...option.style }}
               type="button"
               onClick={() => {
                 if (disabled) return;

--- a/src/features/ModelSwitchPanel/components/ControlsForm/__tests__/ControlsForm.test.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/__tests__/ControlsForm.test.tsx
@@ -31,7 +31,10 @@ vi.mock('@lobehub/ui', () => {
   const MockForm = () => <div data-testid="controls-form" />;
   MockForm.useForm = () => [{ setFieldsValue: testState.setFieldsValue }];
 
-  return { Form: MockForm };
+  return {
+    Flexbox: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    Form: MockForm,
+  };
 });
 
 vi.mock('antd', () => {

--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationControl.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationControl.test.ts
@@ -1,5 +1,6 @@
 import { type ConversationContext, RequestTrigger } from '@lobechat/types';
 import { act, renderHook } from '@testing-library/react';
+import { t } from 'i18next';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { lambdaClient } from '@/libs/trpc/client';
@@ -1874,7 +1875,7 @@ describe('ConversationControl actions', () => {
 
       expect(optimisticCreateMessageSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          content: `I'll skip this. ${reason}`,
+          content: t('tool.intervention.skipMessageWithReason', { ns: 'chat', reason }),
           groupId: 'group-1',
           metadata: { trigger: RequestTrigger.Onboarding },
           // Anchored on the assistant that asked, not left null — a null parent

--- a/src/store/chat/slices/agentRun/actions/entries/conversationControl.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationControl.ts
@@ -7,6 +7,7 @@ import {
   type MessageMetadata,
   type UIChatMessage,
 } from '@lobechat/types';
+import { t } from 'i18next';
 
 import { type ChatInputEditor } from '@/features/ChatInput';
 import { lambdaClient } from '@/libs/trpc/client';
@@ -841,7 +842,9 @@ export class ConversationControlActionImpl {
     // 2. Create a user message indicating the skip
     const chatKey = messageMapKey({ agentId, topicId, threadId, scope });
     const requestMetadata = this.#getRequestMetadataFromMessageChain(toolMessageId);
-    const userMessageContent = reason ? `I'll skip this. ${reason}` : "I'll skip this.";
+    const userMessageContent = reason
+      ? t('tool.intervention.skipMessageWithReason', { ns: 'chat', reason })
+      : t('tool.intervention.skipMessage', { ns: 'chat' });
     const groupId = toolMessage.groupId;
     const userMsg = await this.#get().optimisticCreateMessage(
       {


### PR DESCRIPTION
Three small UX/i18n fixes in the model param controls and tool-interaction skip flow:

1. **Localize the skip message** — skipping a tool interaction (e.g. AskUserQuestion) created a synthetic user message with hardcoded English `"I'll skip this."` regardless of locale. It now goes through i18n (`tool.intervention.skipMessage` / `skipMessageWithReason` in the `chat` namespace), with en-US and zh-CN shipped.
2. **Clean up model config control labels** — items in `ControlsForm` rendered raw parameter names (`thinkingLevel`, `urlContext`, `reasoning_effort`, `text_verbosity`, `aspectRatio`, `imageSize`, `thinkingBudget`) as `desc` / `tag`, which read as unexplained English noise in the UI; these are removed. Real translated descriptions moved from desc text under the control into an `InfoTooltip` question-mark icon beside the label, matching the ControlRow params rendered above this form in the agent params panel.
3. **Align level slider labels with track dots** — `LevelSlider` laid out labels in an equal-column grid with centered text, so label centers sat at `(i + 0.5) / n` while slider dots sit at `i / (n - 1)`; edge labels like `none` / `max` drifted away from the track ends. Edge columns are now half-width with start/end alignment, pinning first/last labels to the ends and centering middle labels under their dots.

#### Test

- [x] Tested locally
- [x] Added/updated tests

`bun run check` — lint clean, all related tests passed; the skip-message assertion in `conversationControl.test.ts` now resolves through i18n.

#### 🔗 Related Issue

Fixes LOBE-12413, Fixes LOBE-12395, Fixes LOBE-12396