### PR TITLE
💄 style: refine conversation portal headers

### DIFF
--- a/src/features/Portal/TaskDetail/Header.tsx
+++ b/src/features/Portal/TaskDetail/Header.tsx
@@ -1,0 +1,56 @@
+import { DESKTOP_HEADER_ICON_SMALL_SIZE, isDesktop } from '@lobechat/const';
+import { ActionIcon } from '@lobehub/ui';
+import { ExternalLink } from 'lucide-react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
+import { useAppOrigin } from '@/hooks/useAppOrigin';
+import { electronSystemService } from '@/services/electron/system';
+import { useChatStore } from '@/store/chat';
+import { chatPortalSelectors } from '@/store/chat/selectors';
+import { useTaskStore } from '@/store/task';
+
+import PortalHeader from '../components/Header';
+import Title from './Title';
+import { getTaskDetailPageUrl } from './url';
+
+const TaskDetailHeader = memo(() => {
+  const { t } = useTranslation('verify');
+  const appOrigin = useAppOrigin();
+  const activeWorkspaceSlug = useActiveWorkspaceSlug();
+  const taskId = useChatStore(chatPortalSelectors.taskDetailId);
+  const agentId = useTaskStore((state) =>
+    taskId ? (state.taskDetailMap[taskId]?.agentId ?? undefined) : undefined,
+  );
+  const pageUrl = getTaskDetailPageUrl({
+    agentId,
+    appOrigin,
+    taskId,
+    workspaceSlug: activeWorkspaceSlug,
+  });
+
+  return (
+    <PortalHeader
+      title={<Title />}
+      rightExtra={
+        <ActionIcon
+          disabled={!pageUrl}
+          icon={ExternalLink}
+          size={DESKTOP_HEADER_ICON_SMALL_SIZE}
+          title={t('report.actions.openInBrowser')}
+          onClick={() => {
+            if (!pageUrl) return;
+            if (isDesktop) {
+              void electronSystemService.openExternalLink(pageUrl);
+              return;
+            }
+            window.open(pageUrl, '_blank', 'noopener,noreferrer');
+          }}
+        />
+      }
+    />
+  );
+});
+
+export default TaskDetailHeader;

--- a/src/features/Portal/TaskDetail/Title.tsx
+++ b/src/features/Portal/TaskDetail/Title.tsx
@@ -30,10 +30,13 @@ const Title = memo(() => {
   const name = detail?.name;
 
   return (
-    <Flexbox horizontal align={'center'} gap={8} style={{ minWidth: 0 }}>
+    <Flexbox horizontal align={'center'} flex={1} gap={8} style={{ minWidth: 0 }}>
       {identifier && <span className={styles.identifier}>{identifier}</span>}
       {name && (
-        <Text className={oneLineEllipsis} style={{ color: cssVar.colorText, fontSize: 14 }}>
+        <Text
+          className={oneLineEllipsis}
+          style={{ color: cssVar.colorText, flex: 1, fontSize: 14, minWidth: 0 }}
+        >
           {name}
         </Text>
       )}

--- a/src/features/Portal/TaskDetail/index.ts
+++ b/src/features/Portal/TaskDetail/index.ts
@@ -1,8 +1,6 @@
 import { type PortalImpl } from '../type';
 import Body from './Body';
+import Header from './Header';
 import Title from './Title';
 
-export const TaskDetail: PortalImpl = {
-  Body,
-  Title,
-};
+export const TaskDetail: PortalImpl = { Body, Header, Title };

--- a/src/features/Portal/TaskDetail/url.test.ts
+++ b/src/features/Portal/TaskDetail/url.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { getTaskDetailPageUrl } from './url';
+
+describe('getTaskDetailPageUrl', () => {
+  it('builds a workspace-aware agent task URL', () => {
+    expect(
+      getTaskDetailPageUrl({
+        agentId: 'agt-owner',
+        appOrigin: 'https://app.example.com',
+        taskId: 'T-245',
+        workspaceSlug: 'lobehub',
+      }),
+    ).toBe('https://app.example.com/lobehub/agent/agt-owner/task/T-245');
+  });
+
+  it('falls back to the unscoped task route without an agent', () => {
+    expect(getTaskDetailPageUrl({ appOrigin: 'https://app.example.com', taskId: 'T-245' })).toBe(
+      'https://app.example.com/task/T-245',
+    );
+  });
+
+  it('returns undefined without a resolvable absolute URL', () => {
+    expect(getTaskDetailPageUrl({ appOrigin: 'https://app.example.com' })).toBeUndefined();
+    expect(getTaskDetailPageUrl({ taskId: 'T-245' })).toBeUndefined();
+  });
+});

--- a/src/features/Portal/TaskDetail/url.ts
+++ b/src/features/Portal/TaskDetail/url.ts
@@ -1,0 +1,21 @@
+import { taskDetailPath } from '@/features/AgentTasks/shared/taskDetailPath';
+import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
+
+interface TaskDetailPageUrlOptions {
+  agentId?: string;
+  appOrigin?: string;
+  taskId?: string;
+  workspaceSlug?: string | null;
+}
+
+export const getTaskDetailPageUrl = ({
+  agentId,
+  appOrigin,
+  taskId,
+  workspaceSlug,
+}: TaskDetailPageUrlOptions): string | undefined => {
+  if (!appOrigin || !taskId) return;
+
+  const path = buildWorkspaceAwarePath(taskDetailPath(taskId, agentId), workspaceSlug);
+  return `${appOrigin}${path}`;
+};

--- a/src/routes/(main)/agent/features/Conversation/Header/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/index.tsx
@@ -57,7 +57,6 @@ const headerStyles = createStaticStyles(({ css }) => ({
     ${FLOATING_HEADER_QUERY} {
       flex-grow: 0;
       border-radius: ${cssVar.borderRadius};
-      box-shadow: ${cssVar.boxShadowTertiary};
     }
   `,
   rightContent: css`
@@ -65,7 +64,6 @@ const headerStyles = createStaticStyles(({ css }) => ({
 
     ${FLOATING_HEADER_QUERY} {
       border-radius: ${cssVar.borderRadius};
-      box-shadow: ${cssVar.boxShadowTertiary};
     }
   `,
   slotLeft: css`
@@ -79,6 +77,7 @@ const headerStyles = createStaticStyles(({ css }) => ({
 
       /* Hug the title pill so the transparent middle stays click-through */
       flex-grow: 0;
+      max-width: 300px;
     }
   `,
   slotRight: css`


### PR DESCRIPTION
## Summary

- remove shadows from the floating conversation header sections
- cap the floating conversation title area at 300px so long titles truncate without crowding actions
- add a Task Detail portal header matching the Acceptance portal interaction contract
- ellipsize long Task titles before the header actions
- support opening the Task detail page in a new browser tab or the system browser on Electron

## Testing

- `bun run check src/routes/\(main\)/agent/features/Conversation/Header/index.tsx`
- `bun run check src/features/Portal/TaskDetail/Header.tsx src/features/Portal/TaskDetail/Title.tsx src/features/Portal/TaskDetail/index.ts src/features/Portal/TaskDetail/url.ts src/features/Portal/TaskDetail/url.test.ts`
- 3 Task detail URL tests passed