### PR TITLE
🐛 fix(topic): support deep-linked topic details

### DIFF
--- a/src/features/Conversation/hooks/useClearActiveTopicUnread.ts
+++ b/src/features/Conversation/hooks/useClearActiveTopicUnread.ts
@@ -9,7 +9,7 @@ import { operationSelectors } from '@/store/chat/slices/operation/selectors';
  * `switchTopic` already clears unread for in-app navigation. This covers the
  * other entry points — reload, deep link, notification — where `ChatHydration`
  * sets `activeTopicId` directly (bypassing `switchTopic`) and the topic list may
- * not be loaded yet. We wait for the active topic to appear in a loaded bucket
+ * not be loaded yet. We wait for the active topic to appear in loaded topic data
  * as `unread`, then mark it read so the sidebar / home badge doesn't linger
  * while the user is already viewing it.
  *

--- a/src/features/RouteMeta/AgentDynamicMeta.tsx
+++ b/src/features/RouteMeta/AgentDynamicMeta.tsx
@@ -6,7 +6,7 @@ import type { DynamicRouteMetaProps } from '@/spa/router/routeMeta';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
-import { topicMapKey } from '@/store/chat/utils/topicMapKey';
+import { topicSelectors } from '@/store/chat/selectors';
 
 import { usePublishDynamicRouteMeta } from './usePublishDynamicRouteMeta';
 import { matchesRouteWorkspace, useRouteWorkspaceId } from './workspaceScope';
@@ -19,9 +19,7 @@ const useTopicTitle = (
   useChatStore((state) => {
     if (!agentId || !topicId || routeWorkspaceId === undefined) return undefined;
 
-    const topic = state.topicDataMap[topicMapKey({ agentId })]?.items?.find(
-      (item) => item.id === topicId,
-    );
+    const topic = topicSelectors.getTopicById(topicId)(state);
     return topic?.title || undefined;
   });
 

--- a/src/features/RouteMeta/AgentDynamicMeta.tsx
+++ b/src/features/RouteMeta/AgentDynamicMeta.tsx
@@ -19,7 +19,7 @@ const useTopicTitle = (
   useChatStore((state) => {
     if (!agentId || !topicId || routeWorkspaceId === undefined) return undefined;
 
-    const topic = topicSelectors.getTopicById(topicId)(state);
+    const topic = topicSelectors.getTopicByIdForContext(topicId, { agentId })(state);
     return topic?.title || undefined;
   });
 

--- a/src/features/RouteMeta/GroupDynamicMeta.tsx
+++ b/src/features/RouteMeta/GroupDynamicMeta.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import type { DynamicRouteMetaProps } from '@/spa/router/routeMeta';
 import { useChatStore } from '@/store/chat';
-import { topicMapKey } from '@/store/chat/utils/topicMapKey';
+import { topicSelectors } from '@/store/chat/selectors';
 import { useSessionStore } from '@/store/session';
 import { sessionGroupSelectors } from '@/store/session/slices/sessionGroup/selectors';
 
@@ -22,9 +22,7 @@ const useTopicTitle = (
   useChatStore((state) => {
     if (!groupId || !topicId || routeWorkspaceId === undefined) return undefined;
 
-    const topic = state.topicDataMap[topicMapKey({ groupId })]?.items?.find(
-      (item) => item.id === topicId,
-    );
+    const topic = topicSelectors.getTopicById(topicId)(state);
     return topic?.title || undefined;
   });
 

--- a/src/features/RouteMeta/GroupDynamicMeta.tsx
+++ b/src/features/RouteMeta/GroupDynamicMeta.tsx
@@ -22,7 +22,7 @@ const useTopicTitle = (
   useChatStore((state) => {
     if (!groupId || !topicId || routeWorkspaceId === undefined) return undefined;
 
-    const topic = topicSelectors.getTopicById(topicId)(state);
+    const topic = topicSelectors.getTopicByIdForContext(topicId, { groupId })(state);
     return topic?.title || undefined;
   });
 

--- a/src/libs/swr/keys.ts
+++ b/src/libs/swr/keys.ts
@@ -122,6 +122,7 @@ export const topicKeys = {
     containerKey,
     opts,
   ]),
+  detail: def('topic:detail', (topicId: string) => ['topic:detail', topicId]),
   list: def('topic:list', (containerKey: string, opts: Record<string, unknown>) => [
     'topic:list',
     containerKey,

--- a/src/routes/(main)/agent/features/Conversation/ChatHydration/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ChatHydration/index.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { initialState as initialChatState } from '@/store/chat/initialState';
 import { useChatStore } from '@/store/chat/store';
+import { topicMapKey } from '@/store/chat/utils/topicMapKey';
 
 import ChatHydration from './index';
 
@@ -15,6 +16,7 @@ const useLocationMock = vi.hoisted(() => vi.fn());
 const useParamsMock = vi.hoisted(() => vi.fn());
 const useSearchParamsMock = vi.hoisted(() => vi.fn());
 const workspaceMock = vi.hoisted(() => ({ activeSlug: null as string | null }));
+const getTopicDetailMock = vi.hoisted(() => vi.fn());
 
 vi.hoisted(() => {
   const storage = {
@@ -48,6 +50,12 @@ vi.mock('@/business/client/hooks/useActiveWorkspaceSlug', () => ({
   useActiveWorkspaceSlug: () => workspaceMock.activeSlug,
 }));
 
+vi.mock('@/services/topic', () => ({
+  topicService: {
+    getTopicDetail: getTopicDetailMock,
+  },
+}));
+
 describe('ChatHydration', () => {
   beforeEach(() => {
     navigateMock.mockReset();
@@ -55,6 +63,8 @@ describe('ChatHydration', () => {
     useLocationMock.mockReset();
     useParamsMock.mockReset();
     useSearchParamsMock.mockReset();
+    getTopicDetailMock.mockReset();
+    getTopicDetailMock.mockResolvedValue(null);
     workspaceMock.activeSlug = null;
 
     useChatStore.setState(
@@ -107,6 +117,53 @@ describe('ChatHydration', () => {
       expect(useChatStore.getState().activeTopicId).toBe('tpc_123');
       expect(useChatStore.getState().activeThreadId).toBe('thd_456');
       expect(navigateMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('loads a routed topic detail when it is outside the paginated topic list', async () => {
+    const topicId = 'tpc_deep_linked';
+    const topicListKey = topicMapKey({ agentId: 'agt_test' });
+    const recentTopic = {
+      createdAt: 2,
+      id: 'tpc_recent',
+      title: 'Recent topic',
+      updatedAt: 2,
+    };
+    const topicDetail = {
+      createdAt: 1,
+      id: topicId,
+      model: 'claude-sonnet-4-6',
+      provider: 'anthropic',
+      title: 'Older topic',
+      updatedAt: 1,
+    };
+
+    useParamsMock.mockReturnValue({ aid: 'agt_test', topicId });
+    useLocationMock.mockReturnValue({
+      hash: '',
+      pathname: `/agent/agt_test/${topicId}`,
+      search: '',
+    });
+    useSearchParamsMock.mockReturnValue([new URLSearchParams(''), setSearchParamsMock]);
+    useChatStore.setState({
+      topicDataMap: {
+        [topicListKey]: {
+          currentPage: 0,
+          hasMore: true,
+          items: [recentTopic],
+          pageSize: 20,
+          total: 100,
+        },
+      },
+    });
+    getTopicDetailMock.mockResolvedValueOnce(topicDetail);
+
+    render(<ChatHydration />);
+
+    await waitFor(() => {
+      expect(getTopicDetailMock).toHaveBeenCalledWith(topicId);
+      expect(useChatStore.getState().topicDetailMap[topicId]).toEqual(topicDetail);
+      expect(useChatStore.getState().topicDataMap[topicListKey].items).toEqual([recentTopic]);
     });
   });
 

--- a/src/routes/(main)/agent/features/Conversation/ChatHydration/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ChatHydration/index.tsx
@@ -15,13 +15,15 @@ const ChatHydration = memo(() => {
   const params = useParams<{ aid?: string; topicId?: string }>();
   const routeTopicId = params.topicId;
   const activeAgentId = useChatStore((s) => s.activeAgentId);
-  const topicMetadata = useChatStore((s) =>
-    routeTopicId ? topicSelectors.getTopicById(routeTopicId)(s)?.metadata : undefined,
+  const routeTopic = useChatStore((s) =>
+    routeTopicId ? topicSelectors.getTopicById(routeTopicId)(s) : undefined,
   );
+  const useFetchTopicDetail = useChatStore((s) => s.useFetchTopicDetail);
   const useFetchTopicLinkedPullRequest = useChatStore((s) => s.useFetchTopicLinkedPullRequest);
 
   useClearActiveTopicUnread();
-  useFetchTopicLinkedPullRequest(activeAgentId ? routeTopicId : undefined, topicMetadata);
+  useFetchTopicDetail(activeAgentId && !routeTopic ? routeTopicId : undefined);
+  useFetchTopicLinkedPullRequest(activeAgentId ? routeTopicId : undefined, routeTopic?.metadata);
   useTopicCommentDeepLink(routeTopicId);
   useChatRouteSync();
 

--- a/src/routes/(main)/group/features/Conversation/ChatHydration/index.tsx
+++ b/src/routes/(main)/group/features/Conversation/ChatHydration/index.tsx
@@ -9,6 +9,7 @@ import { useTopicCommentDeepLink } from '@/features/TopicComment/useTopicComment
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useQueryState } from '@/hooks/useQueryParam';
 import { useChatStore } from '@/store/chat';
+import { topicSelectors } from '@/store/chat/selectors';
 
 const getSearchSuffix = (searchParams: URLSearchParams) => {
   const search = searchParams.toString();
@@ -25,10 +26,15 @@ const ChatHydration = memo(() => {
 
   const [thread, setThread] = useQueryState('thread', { history: 'replace', throttleMs: 500 });
   const routeTopicId = params.topicId;
+  const routeTopic = useChatStore((s) =>
+    routeTopicId ? topicSelectors.getTopicById(routeTopicId)(s) : undefined,
+  );
+  const useFetchTopicDetail = useChatStore((s) => s.useFetchTopicDetail);
 
   // Route hydration sets activeTopicId directly (below) instead of going through
   // switchTopic, so clear any lingering persisted unread once the topic loads.
   useClearActiveTopicUnread();
+  useFetchTopicDetail(routeTopic ? undefined : routeTopicId);
   useTopicCommentDeepLink(routeTopicId);
 
   useLayoutEffect(() => {

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -1014,7 +1014,9 @@ export class GatewayActionImpl {
       agentId: agentId ?? state.activeAgentId,
       groupId: groupId ?? state.activeGroupId,
     });
-    const existingTopic = state.topicDataMap[key]?.items?.find((t) => t.id === topicId);
+    const existingTopic =
+      state.topicDataMap[key]?.items?.find((t) => t.id === topicId) ??
+      state.topicDetailMap[topicId];
     if (existingTopic?.metadata?.runningOperation?.operationId !== operationId) return;
 
     state.internal_dispatchTopic({

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -1016,7 +1016,7 @@ export class GatewayActionImpl {
     });
     const existingTopic =
       state.topicDataMap[key]?.items?.find((t) => t.id === topicId) ??
-      state.topicDetailMap[topicId];
+      state.topicDetailMap?.[topicId];
     if (existingTopic?.metadata?.runningOperation?.operationId !== operationId) return;
 
     state.internal_dispatchTopic({

--- a/src/store/chat/slices/operation/__tests__/actions.test.ts
+++ b/src/store/chat/slices/operation/__tests__/actions.test.ts
@@ -258,8 +258,6 @@ describe('Operation Actions', () => {
         }).operationId;
       });
 
-      const startTime = result.current.operations[operationId!].metadata.startTime;
-
       act(() => {
         result.current.completeOperation(operationId!);
       });
@@ -1053,7 +1051,7 @@ describe('Operation Actions', () => {
       const { result } = renderHook(() => useChatStore());
 
       let operationId: string;
-      const asyncHandler = vi.fn(async ({ type }) => {
+      const asyncHandler = vi.fn(async () => {
         // Simulate async cleanup
         await new Promise((resolve) => setTimeout(resolve, 10));
         // Don't return anything (void)
@@ -1517,6 +1515,49 @@ describe('Operation Actions', () => {
       expect(
         result.current.operations[childOpId!].metadata.runtimeHooks?.afterCompletionCallbacks,
       ).toBeUndefined();
+    });
+  });
+});
+
+describe('Operation topic detail fallbacks', () => {
+  beforeEach(() => {
+    useChatStore.setState(useChatStore.getInitialState());
+  });
+
+  it('marks a deep-linked unread topic as read outside the loaded list page', () => {
+    const topicId = 'deep-linked-topic';
+    const { result } = renderHook(() => useChatStore());
+
+    act(() => {
+      useChatStore.setState({
+        activeAgentId: 'agent-1',
+        activeTopicId: topicId,
+        topicDataMap: {},
+        topicDetailMap: {
+          [topicId]: {
+            createdAt: 1,
+            id: topicId,
+            status: 'unread',
+            title: 'Older topic',
+            updatedAt: 1,
+          },
+        },
+      });
+    });
+
+    const updateTopicStatus = vi
+      .spyOn(result.current, 'updateTopicStatus')
+      .mockResolvedValue(undefined);
+
+    act(() => {
+      result.current.markTopicRead({ agentId: 'agent-1', topicId });
+    });
+
+    expect(updateTopicStatus).toHaveBeenCalledWith({
+      agentId: 'agent-1',
+      groupId: undefined,
+      status: 'active',
+      topicId,
     });
   });
 });

--- a/src/store/chat/slices/operation/__tests__/selectors.test.ts
+++ b/src/store/chat/slices/operation/__tests__/selectors.test.ts
@@ -1292,3 +1292,24 @@ describe('Operation Selectors', () => {
     });
   });
 });
+
+describe('Operation topic detail selectors', () => {
+  it('finds unread state in a deep-linked topic outside the loaded list page', () => {
+    useChatStore.setState({
+      topicDataMap: {},
+      topicDetailMap: {
+        'deep-linked-topic': {
+          createdAt: 1,
+          id: 'deep-linked-topic',
+          status: 'unread',
+          title: 'Older topic',
+          updatedAt: 1,
+        },
+      },
+    });
+
+    expect(
+      operationSelectors.isTopicUnreadCompleted('deep-linked-topic')(useChatStore.getState()),
+    ).toBe(true);
+  });
+});

--- a/src/store/chat/slices/operation/__tests__/selectors.test.ts
+++ b/src/store/chat/slices/operation/__tests__/selectors.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import { useChatStore } from '@/store/chat/store';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
+import { topicMapKey } from '@/store/chat/utils/topicMapKey';
 
 import { operationSelectors } from '../selectors';
 import {
@@ -1311,5 +1312,40 @@ describe('Operation topic detail selectors', () => {
     expect(
       operationSelectors.isTopicUnreadCompleted('deep-linked-topic')(useChatStore.getState()),
     ).toBe(true);
+  });
+
+  it('prefers the loaded list row over a stale cached detail', () => {
+    const topicId = 'loaded-topic';
+    useChatStore.setState({
+      activeAgentId: 'agent-1',
+      topicDataMap: {
+        [topicMapKey({ agentId: 'agent-1' })]: {
+          currentPage: 0,
+          hasMore: false,
+          items: [
+            {
+              createdAt: 1,
+              id: topicId,
+              status: 'active',
+              title: 'Loaded topic',
+              updatedAt: 2,
+            },
+          ],
+          pageSize: 20,
+          total: 1,
+        },
+      },
+      topicDetailMap: {
+        [topicId]: {
+          createdAt: 1,
+          id: topicId,
+          status: 'unread',
+          title: 'Stale detail',
+          updatedAt: 1,
+        },
+      },
+    });
+
+    expect(operationSelectors.isTopicUnreadCompleted(topicId)(useChatStore.getState())).toBe(false);
   });
 });

--- a/src/store/chat/slices/operation/actions.ts
+++ b/src/store/chat/slices/operation/actions.ts
@@ -720,7 +720,10 @@ export class OperationActionsImpl {
       agentId: agentId ?? this.#get().activeAgentId,
       groupId: groupId ?? this.#get().activeGroupId,
     });
-    const topic = this.#get().topicDataMap[key]?.items?.find((t) => t.id === topicId);
+    const state = this.#get();
+    const topic =
+      state.topicDataMap[key]?.items?.find((t) => t.id === topicId) ??
+      state.topicDetailMap[topicId];
     if (topic?.status !== 'unread') return;
 
     void this.#get()

--- a/src/store/chat/slices/operation/actions.ts
+++ b/src/store/chat/slices/operation/actions.ts
@@ -723,7 +723,7 @@ export class OperationActionsImpl {
     const state = this.#get();
     const topic =
       state.topicDataMap[key]?.items?.find((t) => t.id === topicId) ??
-      state.topicDetailMap[topicId];
+      state.topicDetailMap?.[topicId];
     if (topic?.status !== 'unread') return;
 
     void this.#get()

--- a/src/store/chat/slices/operation/selectors.ts
+++ b/src/store/chat/slices/operation/selectors.ts
@@ -777,13 +777,11 @@ const isAgentUnreadCompleted =
 const isTopicUnreadCompleted =
   (topicId: string) =>
   (s: ChatStoreState): boolean => {
-    if (s.topicDetailMap[topicId]?.status === 'unread') return true;
-
     for (const data of Object.values(s.topicDataMap)) {
       const topic = data.items?.find((t) => t.id === topicId);
       if (topic) return topic.status === 'unread';
     }
-    return false;
+    return s.topicDetailMap?.[topicId]?.status === 'unread';
   };
 
 /**

--- a/src/store/chat/slices/operation/selectors.ts
+++ b/src/store/chat/slices/operation/selectors.ts
@@ -777,6 +777,8 @@ const isAgentUnreadCompleted =
 const isTopicUnreadCompleted =
   (topicId: string) =>
   (s: ChatStoreState): boolean => {
+    if (s.topicDetailMap[topicId]?.status === 'unread') return true;
+
     for (const data of Object.values(s.topicDataMap)) {
       const topic = data.items?.find((t) => t.id === topicId);
       if (topic) return topic.status === 'unread';

--- a/src/store/chat/slices/topic/action.test.ts
+++ b/src/store/chat/slices/topic/action.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { LOADING_FLAT } from '@/const/message';
 import { mutate } from '@/libs/swr';
+import { topicKeys } from '@/libs/swr/keys';
 import { chatService } from '@/services/chat';
 import { messageService } from '@/services/message';
 import { topicService } from '@/services/topic';
@@ -74,6 +75,8 @@ vi.mock('i18next', () => ({
 beforeEach(() => {
   // Setup initial state and mocks before each test
   vi.clearAllMocks();
+  (mutate as Mock).mockReset();
+  (mutate as Mock).mockResolvedValue(undefined);
   useChatStore.setState(
     {
       activeAgentId: undefined,
@@ -1262,6 +1265,21 @@ describe('topic action', () => {
       });
 
       expect(useChatStore.getState().topicDetailMap).toEqual({});
+    });
+
+    it('clears only matching topic detail SWR entries for a targeted reset', () => {
+      const { result } = renderHook(() => useChatStore());
+
+      act(() => {
+        result.current.internal_clearTopicDetails(['topic-1']);
+      });
+
+      expect(mutate).toHaveBeenCalledWith(expect.any(Function), undefined, { revalidate: false });
+      const matcher = (mutate as Mock).mock.calls[0][0] as (key: unknown) => boolean;
+      expect(matcher(topicKeys.detail('topic-1'))).toBe(true);
+      expect(matcher([...topicKeys.detail('topic-1'), 'workspace-1'])).toBe(true);
+      expect(matcher(topicKeys.detail('topic-2'))).toBe(false);
+      expect(matcher(topicKeys.list('agent-1', {}))).toBe(false);
     });
   });
   describe('removeTopic', () => {

--- a/src/store/chat/slices/topic/action.test.ts
+++ b/src/store/chat/slices/topic/action.test.ts
@@ -1818,6 +1818,43 @@ describe('topic action', () => {
       expect(useChatStore.getState().topicDetailMap).toEqual({});
     });
 
+    it('does not restore a cleared topic from an in-flight update response', async () => {
+      const { result } = renderHook(() => useChatStore());
+      const topicId = 'cached-topic';
+      const topic: ChatTopic = {
+        createdAt: 1,
+        id: topicId,
+        title: 'Cached topic',
+        updatedAt: 1,
+      };
+      const persistedTopic: ChatTopic = {
+        ...topic,
+        title: 'Updated topic',
+        updatedAt: 2,
+      };
+      let resolveUpdate!: (topics: ChatTopic[]) => void;
+      const updateRequest = new Promise<ChatTopic[]>((resolve) => {
+        resolveUpdate = resolve;
+      });
+      useChatStore.setState({ topicDetailMap: { [topicId]: topic } });
+      vi.spyOn(topicService, 'updateTopic').mockReturnValueOnce(updateRequest as any);
+      const refreshTopicSpy = vi.spyOn(result.current, 'refreshTopic');
+
+      const updatePromise = result.current.internal_updateTopic(topicId, {
+        title: persistedTopic.title,
+      });
+      act(() => {
+        result.current.internal_clearTopicDetails([topicId]);
+      });
+      await act(async () => {
+        resolveUpdate([persistedTopic]);
+        await updatePromise;
+      });
+
+      expect(useChatStore.getState().topicDetailMap).toEqual({});
+      expect(refreshTopicSpy).not.toHaveBeenCalled();
+    });
+
     it('should release the loading owner when updating a topic fails', async () => {
       const { result } = renderHook(() => useChatStore());
       const agentId = 'agent-1';

--- a/src/store/chat/slices/topic/action.test.ts
+++ b/src/store/chat/slices/topic/action.test.ts
@@ -566,6 +566,40 @@ describe('topic action', () => {
       // Agent-run status writes must stay a pure status update — no completedAt.
       expect(updateSpy).toHaveBeenCalledWith(topicId, { status: 'running' });
     });
+
+    it('reconciles a pending status write into an in-flight topic detail response', async () => {
+      const { result } = renderHook(() => useChatStore());
+      const topicId = 'pending-status-deep-link';
+      const staleTopic: ChatTopic = {
+        createdAt: 1,
+        id: topicId,
+        status: 'active',
+        title: 'Deep-linked topic',
+        updatedAt: 1,
+      };
+      let resolveDetail!: (topic: ChatTopic) => void;
+      const detailRequest = new Promise<ChatTopic>((resolve) => {
+        resolveDetail = resolve;
+      });
+      (topicService.getTopicDetail as Mock).mockReturnValueOnce(detailRequest);
+      vi.spyOn(topicService, 'updateTopic').mockResolvedValueOnce([]);
+
+      await act(async () => {
+        await result.current.switchTopic(topicId, { skipRefreshMessage: true });
+      });
+      await act(async () => {
+        await result.current.updateTopicStatus({ status: 'running', topicId });
+      });
+      await act(async () => {
+        resolveDetail(staleTopic);
+        await detailRequest;
+        await Promise.resolve();
+      });
+
+      expect(useChatStore.getState().topicDetailMap[topicId]).toMatchObject({
+        status: 'running',
+      });
+    });
   });
   describe('useFetchTopics', () => {
     it('should fetch topics for a given session id', async () => {
@@ -1257,6 +1291,36 @@ describe('topic action', () => {
 
       act(() => {
         result.current.internal_clearTopicDetails();
+      });
+      await act(async () => {
+        resolveDetail(topicDetail);
+        await detailRequest;
+        await Promise.resolve();
+      });
+
+      expect(useChatStore.getState().topicDetailMap).toEqual({});
+    });
+
+    it('invalidates an in-flight topic detail response when the chat store resets', async () => {
+      const { result } = renderHook(() => useChatStore());
+      const topicId = 'pre-reset-topic';
+      const topicDetail: ChatTopic = {
+        createdAt: 1,
+        id: topicId,
+        title: 'Pre-reset topic',
+        updatedAt: 1,
+      };
+      let resolveDetail!: (topic: ChatTopic) => void;
+      const detailRequest = new Promise<ChatTopic>((resolve) => {
+        resolveDetail = resolve;
+      });
+      (topicService.getTopicDetail as Mock).mockReturnValueOnce(detailRequest);
+
+      await act(async () => {
+        await result.current.switchTopic(topicId, { skipRefreshMessage: true });
+      });
+      act(() => {
+        result.current.reset();
       });
       await act(async () => {
         resolveDetail(topicDetail);

--- a/src/store/chat/slices/topic/action.test.ts
+++ b/src/store/chat/slices/topic/action.test.ts
@@ -82,13 +82,14 @@ beforeEach(() => {
       agentTopicsViewMap: {},
       searchTopics: [],
       topicDataMap: {},
+      topicDetailMap: {},
       topicLoadingIdCounts: {},
       topicLoadingIds: [],
       // ... initial state
     },
     false,
   );
-  useAgentStore.setState({ agentDocumentsMap: {} });
+  useAgentStore.setState({ agentDocumentsMap: {}, agentMap: {} });
   useUserStore.setState({ user: { id: 'user-1' } as LobeUser });
   useSessionStore.setState(
     {
@@ -1189,6 +1190,16 @@ describe('topic action', () => {
       const { result } = renderHook(() => useChatStore());
 
       const refreshTopicSpy = vi.spyOn(result.current, 'refreshTopic');
+      useChatStore.setState({
+        topicDetailMap: {
+          'topic-1': {
+            createdAt: 1,
+            id: 'topic-1',
+            title: 'Topic',
+            updatedAt: 1,
+          },
+        },
+      });
 
       await act(async () => {
         await result.current.removeAllTopics();
@@ -1196,6 +1207,7 @@ describe('topic action', () => {
 
       expect(topicService.removeAllTopic).toHaveBeenCalled();
       expect(refreshTopicSpy).toHaveBeenCalled();
+      expect(useChatStore.getState().topicDetailMap).toEqual({});
     });
   });
   describe('removeTopic', () => {
@@ -1519,6 +1531,96 @@ describe('topic action', () => {
     });
   });
   describe('internal_updateTopic', () => {
+    it('updates a deep-linked topic that is outside the loaded list page', async () => {
+      const { result } = renderHook(() => useChatStore());
+      const agentId = 'agent-1';
+      const topicId = 'deep-linked-topic';
+      const key = topicMapKey({ agentId });
+      const listedTopic: ChatTopic = {
+        createdAt: 2,
+        id: 'recent-topic',
+        title: 'Recent topic',
+        updatedAt: 2,
+      };
+      const deepLinkedTopic: ChatTopic = {
+        createdAt: 1,
+        id: topicId,
+        model: 'claude-sonnet-4-6',
+        provider: 'anthropic',
+        sessionId: agentId,
+        title: 'Older topic',
+        updatedAt: 1,
+      };
+
+      act(() => {
+        useChatStore.setState({
+          activeAgentId: agentId,
+          activeTopicId: topicId,
+          topicDataMap: {
+            [key]: {
+              currentPage: 0,
+              hasMore: true,
+              items: [listedTopic],
+              pageSize: 20,
+              total: 100,
+            },
+          },
+        });
+      });
+
+      (topicService.getTopicDetail as Mock).mockResolvedValueOnce(deepLinkedTopic);
+      vi.spyOn(topicService, 'updateTopic').mockResolvedValueOnce(undefined);
+
+      await act(async () => {
+        await result.current.updateTopicModel(topicId, {
+          model: 'deepseek-v4',
+          provider: 'deepseek',
+        });
+      });
+
+      expect(topicService.getTopicDetail).toHaveBeenCalledWith(topicId);
+      expect(topicService.updateTopic).toHaveBeenCalledWith(topicId, {
+        model: 'deepseek-v4',
+        provider: 'deepseek',
+      });
+      expect(useChatStore.getState().topicDetailMap[topicId]).toMatchObject({
+        model: 'deepseek-v4',
+        provider: 'deepseek',
+      });
+      expect(useChatStore.getState().topicDataMap[key].items).toEqual([listedTopic]);
+    });
+
+    it('still persists an update when detail hydration fails', async () => {
+      const { result } = renderHook(() => useChatStore());
+      const topicId = 'deep-linked-topic';
+      const persistedTopic: ChatTopic = {
+        createdAt: 1,
+        id: topicId,
+        model: 'deepseek-v4',
+        provider: 'deepseek',
+        title: 'Older topic',
+        updatedAt: 2,
+      };
+
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      (topicService.getTopicDetail as Mock).mockRejectedValueOnce(new Error('proxy failed'));
+      vi.spyOn(topicService, 'updateTopic').mockResolvedValueOnce([persistedTopic] as any);
+
+      await act(async () => {
+        await result.current.updateTopicModel(topicId, {
+          model: 'deepseek-v4',
+          provider: 'deepseek',
+        });
+      });
+
+      expect(topicService.updateTopic).toHaveBeenCalledWith(topicId, {
+        model: 'deepseek-v4',
+        provider: 'deepseek',
+      });
+      expect(useChatStore.getState().topicDetailMap[topicId]).toEqual(persistedTopic);
+      expect(useChatStore.getState().topicDataMap).toEqual({});
+    });
+
     it('should release the loading owner when updating a topic fails', async () => {
       const { result } = renderHook(() => useChatStore());
       const agentId = 'agent-1';
@@ -2270,6 +2372,14 @@ describe('topic action', () => {
           activeAgentId,
           messagesMap: {
             [messageMapKey({ agentId: activeAgentId })]: messages,
+          },
+        });
+        useAgentStore.setState({
+          agentMap: {
+            [activeAgentId]: {
+              model: 'deepseek-v4-pro',
+              provider: 'deepseek',
+            },
           },
         });
       });

--- a/src/store/chat/slices/topic/action.test.ts
+++ b/src/store/chat/slices/topic/action.test.ts
@@ -1267,6 +1267,36 @@ describe('topic action', () => {
       expect(useChatStore.getState().topicDetailMap).toEqual({});
     });
 
+    it('preserves an unrelated in-flight topic detail response during a targeted clear', async () => {
+      const { result } = renderHook(() => useChatStore());
+      const topicId = 'active-topic';
+      const topicDetail: ChatTopic = {
+        createdAt: 1,
+        id: topicId,
+        title: 'Active topic',
+        updatedAt: 1,
+      };
+      let resolveDetail!: (topic: ChatTopic) => void;
+      const detailRequest = new Promise<ChatTopic>((resolve) => {
+        resolveDetail = resolve;
+      });
+      (topicService.getTopicDetail as Mock).mockReturnValueOnce(detailRequest);
+
+      await act(async () => {
+        await result.current.switchTopic(topicId, { skipRefreshMessage: true });
+      });
+      act(() => {
+        result.current.internal_clearTopicDetails(['deleted-topic']);
+      });
+      await act(async () => {
+        resolveDetail(topicDetail);
+        await detailRequest;
+        await Promise.resolve();
+      });
+
+      expect(useChatStore.getState().topicDetailMap[topicId]).toEqual(topicDetail);
+    });
+
     it('clears only matching topic detail SWR entries for a targeted reset', () => {
       const { result } = renderHook(() => useChatStore());
 
@@ -1693,6 +1723,35 @@ describe('topic action', () => {
       });
       expect(useChatStore.getState().topicDetailMap[topicId]).toEqual(persistedTopic);
       expect(useChatStore.getState().topicDataMap).toEqual({});
+    });
+
+    it('aborts a pending update when its topic detail request is invalidated', async () => {
+      const { result } = renderHook(() => useChatStore());
+      const topicId = 'deep-linked-topic';
+      const topicDetail: ChatTopic = {
+        createdAt: 1,
+        id: topicId,
+        title: 'Older topic',
+        updatedAt: 1,
+      };
+      let resolveDetail!: (topic: ChatTopic) => void;
+      const detailRequest = new Promise<ChatTopic>((resolve) => {
+        resolveDetail = resolve;
+      });
+      (topicService.getTopicDetail as Mock).mockReturnValueOnce(detailRequest);
+      const updateTopicSpy = vi.spyOn(topicService, 'updateTopic').mockResolvedValueOnce([]);
+
+      const updatePromise = result.current.internal_updateTopic(topicId, { title: 'New' });
+      act(() => {
+        result.current.internal_clearTopicDetails();
+      });
+      await act(async () => {
+        resolveDetail(topicDetail);
+        await updatePromise;
+      });
+
+      expect(updateTopicSpy).not.toHaveBeenCalled();
+      expect(useChatStore.getState().topicDetailMap).toEqual({});
     });
 
     it('should release the loading owner when updating a topic fails', async () => {

--- a/src/store/chat/slices/topic/action.test.ts
+++ b/src/store/chat/slices/topic/action.test.ts
@@ -1135,7 +1135,17 @@ describe('topic action', () => {
       const { result } = renderHook(() => useChatStore());
       const activeAgentId = 'test-session-id';
       await act(async () => {
-        useChatStore.setState({ activeAgentId });
+        useChatStore.setState({
+          activeAgentId,
+          topicDetailMap: {
+            'cached-topic': {
+              createdAt: 1,
+              id: 'cached-topic',
+              title: 'Cached topic',
+              updatedAt: 1,
+            },
+          },
+        });
       });
       const refreshTopicSpy = vi.spyOn(result.current, 'refreshTopic');
       const switchTopicSpy = vi.spyOn(result.current, 'switchTopic');
@@ -1147,6 +1157,7 @@ describe('topic action', () => {
       expect(topicService.removeTopicsByAgentId).toHaveBeenCalledWith(activeAgentId, 'own');
       expect(refreshTopicSpy).toHaveBeenCalled();
       expect(switchTopicSpy).toHaveBeenCalled();
+      expect(useChatStore.getState().topicDetailMap).toEqual({});
     });
 
     it('forwards explicit workspace scope for an owner full delete', async () => {
@@ -1165,6 +1176,16 @@ describe('topic action', () => {
       const groupId = 'group-delete';
       const refreshTopicSpy = vi.spyOn(result.current, 'refreshTopic').mockResolvedValue(undefined);
       const switchTopicSpy = vi.spyOn(result.current, 'switchTopic').mockResolvedValue(undefined);
+      useChatStore.setState({
+        topicDetailMap: {
+          'cached-topic': {
+            createdAt: 1,
+            id: 'cached-topic',
+            title: 'Cached topic',
+            updatedAt: 1,
+          },
+        },
+      });
 
       await act(async () => {
         await result.current.removeGroupTopics(groupId);
@@ -1173,6 +1194,7 @@ describe('topic action', () => {
       expect(topicService.removeTopicsByGroupId).toHaveBeenCalledWith(groupId, 'own');
       expect(refreshTopicSpy).toHaveBeenCalled();
       expect(switchTopicSpy).toHaveBeenCalled();
+      expect(useChatStore.getState().topicDetailMap).toEqual({});
     });
 
     it('forwards explicit workspace scope through the group endpoint', async () => {
@@ -1207,6 +1229,38 @@ describe('topic action', () => {
 
       expect(topicService.removeAllTopic).toHaveBeenCalled();
       expect(refreshTopicSpy).toHaveBeenCalled();
+      expect(useChatStore.getState().topicDetailMap).toEqual({});
+    });
+
+    it('ignores an in-flight topic detail response after the cache is cleared', async () => {
+      const { result } = renderHook(() => useChatStore());
+      const topicId = 'stale-topic';
+      const topicDetail: ChatTopic = {
+        createdAt: 1,
+        id: topicId,
+        title: 'Stale topic',
+        updatedAt: 1,
+      };
+      let resolveDetail!: (topic: ChatTopic) => void;
+      const detailRequest = new Promise<ChatTopic>((resolve) => {
+        resolveDetail = resolve;
+      });
+      (topicService.getTopicDetail as Mock).mockReturnValueOnce(detailRequest);
+
+      await act(async () => {
+        await result.current.switchTopic(topicId, { skipRefreshMessage: true });
+      });
+      expect(topicService.getTopicDetail).toHaveBeenCalledWith(topicId);
+
+      act(() => {
+        result.current.internal_clearTopicDetails();
+      });
+      await act(async () => {
+        resolveDetail(topicDetail);
+        await detailRequest;
+        await Promise.resolve();
+      });
+
       expect(useChatStore.getState().topicDetailMap).toEqual({});
     });
   });
@@ -1487,6 +1541,7 @@ describe('topic action', () => {
               pageSize: 20,
             },
           },
+          topicDetailMap: Object.fromEntries(topics.map((topic) => [topic.id, topic])),
         });
       });
       const refreshTopicSpy = vi.spyOn(result.current, 'refreshTopic');
@@ -1499,6 +1554,7 @@ describe('topic action', () => {
       expect(topicService.batchRemoveTopics).toHaveBeenCalledWith(['topic-1', 'topic-3']);
       expect(refreshTopicSpy).toHaveBeenCalled();
       expect(switchTopicSpy).toHaveBeenCalled();
+      expect(Object.keys(useChatStore.getState().topicDetailMap)).toEqual(['topic-2']);
     });
 
     it('removes only the signed-in user’s unstarred topics when onlyOwn is enabled', async () => {

--- a/src/store/chat/slices/topic/action.test.ts
+++ b/src/store/chat/slices/topic/action.test.ts
@@ -1569,7 +1569,7 @@ describe('topic action', () => {
       });
 
       (topicService.getTopicDetail as Mock).mockResolvedValueOnce(deepLinkedTopic);
-      vi.spyOn(topicService, 'updateTopic').mockResolvedValueOnce(undefined);
+      vi.spyOn(topicService, 'updateTopic').mockResolvedValueOnce([]);
 
       await act(async () => {
         await result.current.updateTopicModel(topicId, {

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -49,8 +49,8 @@ import { setNamespace } from '@/utils/storeDebug';
 
 import { displayMessageSelectors } from '../message/selectors';
 import { type TopicData } from './initialState';
-import { type ChatTopicDispatch } from './reducer';
-import { topicReducer } from './reducer';
+import { type ChatTopicDetailDispatch, type ChatTopicDispatch } from './reducer';
+import { topicDetailReducer, topicReducer } from './reducer';
 import { topicSelectors } from './selectors';
 
 const n = setNamespace('t');
@@ -128,11 +128,34 @@ export class ChatTopicActionImpl {
 
   #staleRunningTopicCleanupInFlight = false;
 
+  #topicDetailRequests = new Map<string, Promise<ChatTopic | null>>();
+
   constructor(set: Setter, get: () => ChatStore, _api?: unknown) {
     void _api;
     this.#set = set;
     this.#get = get;
   }
+
+  #fetchTopicDetail = async (id: string): Promise<ChatTopic | null> => {
+    const stored = topicSelectors.getTopicById(id)(this.#get());
+    if (stored) return stored;
+
+    const pendingRequest = this.#topicDetailRequests.get(id);
+    if (pendingRequest) return pendingRequest;
+
+    const request = topicService.getTopicDetail(id);
+    this.#topicDetailRequests.set(id, request);
+
+    try {
+      const topic = await request;
+      if (topic) this.#get().internal_setTopicDetail(topic);
+      return topic;
+    } finally {
+      if (this.#topicDetailRequests.get(id) === request) {
+        this.#topicDetailRequests.delete(id);
+      }
+    }
+  };
 
   #resolveTopicLinkedPullRequestRefreshParams = (
     topicId: string,
@@ -387,7 +410,8 @@ export class ChatTopicActionImpl {
   };
 
   updateTopicMetadata = async (id: string, metadata: Partial<ChatTopicMetadata>): Promise<void> => {
-    const topic = topicSelectors.getTopicById(id)(this.#get());
+    const topic =
+      topicSelectors.getTopicById(id)(this.#get()) ?? (await this.#fetchTopicDetail(id));
     if (!topic) return;
 
     // Optimistic update with merged metadata
@@ -497,7 +521,9 @@ export class ChatTopicActionImpl {
       groupId: scopedGroupId,
       scope,
     });
-    const topic = state.topicDataMap[key]?.items?.find((t) => t.id === topicId);
+    const topic =
+      state.topicDataMap[key]?.items?.find((t) => t.id === topicId) ??
+      state.topicDetailMap[topicId];
 
     // Already at the target status — both the in-memory and DB writes are no-ops.
     if (topic?.status === status) return;
@@ -567,7 +593,10 @@ export class ChatTopicActionImpl {
     if (!topic.metadata?.runningOperation) return;
 
     const key = topicMapKey(patchScope);
-    const currentTopic = this.#get().topicDataMap[key]?.items.find((item) => item.id === topic.id);
+    const state = this.#get();
+    const currentTopic =
+      state.topicDataMap[key]?.items.find((item) => item.id === topic.id) ??
+      state.topicDetailMap[topic.id];
     const metadata = currentTopic?.metadata ?? topic.metadata;
 
     await topicService.updateTopicMetadata(topic.id, { runningOperation: null });
@@ -728,6 +757,20 @@ export class ChatTopicActionImpl {
       },
     );
   };
+
+  useFetchTopicDetail = (id?: string): SWRResponse<ChatTopic | null> =>
+    useClientDataSWRWithSync<ChatTopic | null>(
+      id ? topicKeys.detail(id) : null,
+      id ? () => this.#fetchTopicDetail(id) : null,
+      {
+        onData: (topic) => {
+          if (topic) this.#get().internal_setTopicDetail(topic);
+        },
+        onError: (error) => {
+          console.error('[useFetchTopicDetail] failed:', error);
+        },
+      },
+    );
 
   autoRenameTopicTitle = async (id: string): Promise<void> => {
     const { activeAgentId: agentId, summaryTopicTitle, internal_updateTopicLoading } = this.#get();
@@ -1215,6 +1258,12 @@ export class ChatTopicActionImpl {
       n('toggleTopic'),
     );
 
+    if (id && !topicSelectors.getTopicById(id)(this.#get())) {
+      void this.#fetchTopicDetail(id).catch((error) => {
+        console.error('[switchTopic] failed to fetch topic detail:', error);
+      });
+    }
+
     if (activeAgentId) {
       this.#get().markTopicRead({ agentId: activeAgentId, topicId: id ?? null });
     }
@@ -1266,6 +1315,7 @@ export class ChatTopicActionImpl {
     const { refreshTopic } = this.#get();
 
     await topicService.removeAllTopic();
+    this.#set({ topicDetailMap: {} }, false, n('removeAllTopics/clearDetails'));
     await refreshTopic();
     // every topic is gone — wipe all cached message lists
     void evictMessageCache(() => true);
@@ -1439,11 +1489,29 @@ export class ChatTopicActionImpl {
   };
 
   internal_updateTopic = async (id: string, data: Partial<ChatTopic>): Promise<void> => {
+    if (!topicSelectors.getTopicById(id)(this.#get())) {
+      try {
+        await this.#fetchTopicDetail(id);
+      } catch (error) {
+        /**
+         * Detail hydration is an optimization for the local optimistic write,
+         * not a prerequisite for persisting the user's edit. In particular,
+         * an Electron proxy blip must not turn a model switch into a client-side
+         * no-op before the update request is even attempted.
+         */
+        console.error('[internal_updateTopic] failed to hydrate topic detail:', error);
+      }
+    }
+
     this.#get().internal_dispatchTopic({ type: 'updateTopic', id, value: data });
 
     this.#get().internal_updateTopicLoading(id, true);
     try {
-      await topicService.updateTopic(id, data);
+      const persistedTopics = await topicService.updateTopic(id, data);
+      const persistedTopic = persistedTopics?.[0];
+      if (persistedTopic) {
+        this.#get().internal_setTopicDetail(persistedTopic as unknown as ChatTopic);
+      }
       await this.#get().refreshTopic();
     } finally {
       // Rename "Topic" -> "New" can fail after opening a loading owner; always release it.
@@ -1534,6 +1602,22 @@ export class ChatTopicActionImpl {
   };
 
   /**
+   * Cache a full topic row fetched outside the paginated list. The detail map
+   * is intentionally separate so opening an old topic does not change sidebar
+   * pagination, ordering, or totals.
+   */
+  internal_setTopicDetail = (topic: ChatTopic): void => {
+    const currentMap = this.#get().topicDetailMap;
+    const nextMap = topicDetailReducer(currentMap, {
+      type: 'setTopicDetail',
+      value: topic,
+    });
+
+    if (isEqual(nextMap, currentMap)) return;
+    this.#set({ topicDetailMap: nextMap }, false, n('setTopicDetail'));
+  };
+
+  /**
    * Apply a topic reducer to a bucket in `topicDataMap`. Scope on the payload
    * (`agentId`/`groupId`) wins; otherwise falls back to the currently active
    * agent/group bucket. Pass scope on the payload when the write originates
@@ -1561,9 +1645,19 @@ export class ChatTopicActionImpl {
     const nextViewItems = viewData ? topicReducer(viewData.items, payload) : undefined;
     const viewChanged = viewData ? !isEqual(nextViewItems, viewData.items) : false;
 
-    // no need to update if both maps are unchanged
-    const mainChanged = !isEqual(nextItems, currentData?.items);
-    if (!mainChanged && !viewChanged) return;
+    const detailMap = this.#get().topicDetailMap;
+    const nextDetailMap =
+      payload.type === 'addTopic'
+        ? detailMap
+        : topicDetailReducer(detailMap, payload as ChatTopicDetailDispatch);
+    const detailChanged = !isEqual(nextDetailMap, detailMap);
+
+    // Updating or deleting a missing row must not create an empty list bucket.
+    // Only addTopic is allowed to initialize a previously unloaded container.
+    const mainChanged = currentData
+      ? !isEqual(nextItems, currentData.items)
+      : payload.type === 'addTopic' && nextItems.length > 0;
+    if (!mainChanged && !viewChanged && !detailChanged) return;
 
     const currentTotal = currentData?.total ?? currentData?.items?.length ?? 0;
     const total =
@@ -1606,6 +1700,10 @@ export class ChatTopicActionImpl {
           total: viewNextTotal,
         },
       };
+    }
+
+    if (detailChanged) {
+      nextState.topicDetailMap = nextDetailMap;
     }
 
     this.#set(nextState, false, action ?? n(`dispatchTopic/${payload.type}`));

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -128,6 +128,13 @@ export class ChatTopicActionImpl {
 
   #staleRunningTopicCleanupInFlight = false;
 
+  /**
+   * Requests capture this generation before fetching. Cache-boundary resets
+   * advance it so late responses cannot repopulate a new workspace or restore
+   * topics that were deleted while their detail request was in flight.
+   */
+  #topicDetailCacheGeneration = 0;
+
   #topicDetailRequests = new Map<string, Promise<ChatTopic | null>>();
 
   constructor(set: Setter, get: () => ChatStore, _api?: unknown) {
@@ -143,11 +150,13 @@ export class ChatTopicActionImpl {
     const pendingRequest = this.#topicDetailRequests.get(id);
     if (pendingRequest) return pendingRequest;
 
+    const cacheGeneration = this.#topicDetailCacheGeneration;
     const request = topicService.getTopicDetail(id);
     this.#topicDetailRequests.set(id, request);
 
     try {
       const topic = await request;
+      if (cacheGeneration !== this.#topicDetailCacheGeneration) return null;
       if (topic) this.#get().internal_setTopicDetail(topic);
       return topic;
     } finally {
@@ -1288,6 +1297,7 @@ export class ChatTopicActionImpl {
     if (!activeAgentId) return;
 
     await topicService.removeTopicsByAgentId(activeAgentId, scope);
+    this.#get().internal_clearTopicDetails();
     await refreshTopic();
     // drop every deleted topic's message cache (all belong to this agent)
     void evictMessageCache((ctx) => ctx.agentId === activeAgentId);
@@ -1303,6 +1313,7 @@ export class ChatTopicActionImpl {
     const { switchTopic, refreshTopic } = this.#get();
 
     await topicService.removeTopicsByGroupId(groupId, scope);
+    this.#get().internal_clearTopicDetails();
     await refreshTopic();
     // drop every deleted topic's message cache (all belong to this group)
     void evictMessageCache((ctx) => ctx.groupId === groupId);
@@ -1315,7 +1326,7 @@ export class ChatTopicActionImpl {
     const { refreshTopic } = this.#get();
 
     await topicService.removeAllTopic();
-    this.#set({ topicDetailMap: {} }, false, n('removeAllTopics/clearDetails'));
+    this.#get().internal_clearTopicDetails();
     await refreshTopic();
     // every topic is gone — wipe all cached message lists
     void evictMessageCache(() => true);
@@ -1328,6 +1339,7 @@ export class ChatTopicActionImpl {
 
     // remove topic (and optionally its uploaded attachments)
     await topicService.removeTopic(id, removeFiles);
+    this.#get().internal_clearTopicDetails([id]);
     this.#get().internal_dispatchTopic({ type: 'deleteTopic', id }, 'removeTopic');
     await refreshTopic();
     // drop the deleted topic's message cache so it doesn't orphan in IndexedDB
@@ -1346,6 +1358,7 @@ export class ChatTopicActionImpl {
       .map((topic) => topic.id);
 
     await topicService.batchRemoveTopics(topicIds);
+    this.#get().internal_clearTopicDetails(topicIds);
     await refreshTopic();
     // drop the deleted topics' message caches
     const removed = new Set(topicIds);
@@ -1361,6 +1374,7 @@ export class ChatTopicActionImpl {
     const { activeTopicId, switchTopic, refreshTopic } = this.#get();
 
     await topicService.batchMoveTopics(topicIds, targetAgentId);
+    this.#get().internal_clearTopicDetails(topicIds);
 
     // Moved topics leave the current agent's list — drop them locally so the UI
     // updates immediately, then refetch to reconcile with the server.
@@ -1599,6 +1613,24 @@ export class ChatTopicActionImpl {
     this.#get().internal_updateTopicLoading(topicId, false);
 
     return topicId;
+  };
+
+  /**
+   * Clear independently fetched topic rows and invalidate requests that started
+   * before this cache boundary. Without the generation bump, a late response
+   * could restore a deleted topic or leak the previous workspace into the next.
+   */
+  internal_clearTopicDetails = (ids?: string[]): void => {
+    this.#topicDetailCacheGeneration += 1;
+    this.#topicDetailRequests.clear();
+
+    const currentMap = this.#get().topicDetailMap ?? {};
+    const nextMap = ids
+      ? ids.reduce((map, id) => topicDetailReducer(map, { type: 'deleteTopic', id }), currentMap)
+      : {};
+
+    if (isEqual(nextMap, currentMap)) return;
+    this.#set({ topicDetailMap: nextMap }, false, n('clearTopicDetails'));
   };
 
   /**

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -523,7 +523,7 @@ export class ChatTopicActionImpl {
     });
     const topic =
       state.topicDataMap[key]?.items?.find((t) => t.id === topicId) ??
-      state.topicDetailMap[topicId];
+      state.topicDetailMap?.[topicId];
 
     // Already at the target status — both the in-memory and DB writes are no-ops.
     if (topic?.status === status) return;
@@ -596,7 +596,7 @@ export class ChatTopicActionImpl {
     const state = this.#get();
     const currentTopic =
       state.topicDataMap[key]?.items.find((item) => item.id === topic.id) ??
-      state.topicDetailMap[topic.id];
+      state.topicDetailMap?.[topic.id];
     const metadata = currentTopic?.metadata ?? topic.metadata;
 
     await topicService.updateTopicMetadata(topic.id, { runningOperation: null });

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -174,8 +174,9 @@ export class ChatTopicActionImpl {
       if (request.invalidated || cacheGeneration !== this.#topicDetailCacheGeneration) {
         return null;
       }
-      if (topic) this.#get().internal_setTopicDetail(topic);
-      return topic;
+      const reconciledTopic = topic ? this.#reconcileFetchedTopics([topic])[0] : null;
+      if (reconciledTopic) this.#get().internal_setTopicDetail(reconciledTopic);
+      return reconciledTopic;
     } finally {
       if (this.#topicDetailRequests.get(id) === request) {
         this.#topicDetailRequests.delete(id);
@@ -1662,6 +1663,7 @@ export class ChatTopicActionImpl {
         const updates = this.#topicDetailUpdates.get(id);
         for (const update of updates ?? []) update.invalidated = true;
         this.#topicDetailUpdates.delete(id);
+        this.#pendingTopicStatusWrites.delete(id);
       }
     } else {
       this.#topicDetailCacheGeneration += 1;
@@ -1671,6 +1673,7 @@ export class ChatTopicActionImpl {
         for (const update of updates) update.invalidated = true;
       }
       this.#topicDetailUpdates.clear();
+      this.#pendingTopicStatusWrites.clear();
     }
 
     const idSet = ids ? new Set(ids) : undefined;

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -1521,47 +1521,51 @@ export class ChatTopicActionImpl {
   };
 
   internal_updateTopic = async (id: string, data: Partial<ChatTopic>): Promise<void> => {
-    if (!topicSelectors.getTopicById(id)(this.#get())) {
-      const update: TopicDetailUpdate = { invalidated: false };
-      const updates = this.#topicDetailUpdates.get(id) ?? new Set<TopicDetailUpdate>();
-      updates.add(update);
-      this.#topicDetailUpdates.set(id, updates);
+    const update: TopicDetailUpdate = { invalidated: false };
+    const updates = this.#topicDetailUpdates.get(id) ?? new Set<TopicDetailUpdate>();
+    updates.add(update);
+    this.#topicDetailUpdates.set(id, updates);
 
-      try {
-        await this.#fetchTopicDetail(id);
-      } catch (error) {
-        if (!update.invalidated) {
-          /**
-           * Detail hydration is an optimization for the local optimistic write,
-           * not a prerequisite for persisting the user's edit. In particular,
-           * an Electron proxy blip must not turn a model switch into a client-side
-           * no-op before the update request is even attempted.
-           */
-          console.error('[internal_updateTopic] failed to hydrate topic detail:', error);
-        }
-      } finally {
-        updates.delete(update);
-        if (updates.size === 0 && this.#topicDetailUpdates.get(id) === updates) {
-          this.#topicDetailUpdates.delete(id);
-        }
-      }
-
-      if (update.invalidated) return;
-    }
-
-    this.#get().internal_dispatchTopic({ type: 'updateTopic', id, value: data });
-
-    this.#get().internal_updateTopicLoading(id, true);
     try {
-      const persistedTopics = await topicService.updateTopic(id, data);
-      const persistedTopic = persistedTopics?.[0];
-      if (persistedTopic) {
-        this.#get().internal_setTopicDetail(persistedTopic as unknown as ChatTopic);
+      if (!topicSelectors.getTopicById(id)(this.#get())) {
+        try {
+          await this.#fetchTopicDetail(id);
+        } catch (error) {
+          if (!update.invalidated) {
+            /**
+             * Detail hydration is an optimization for the local optimistic write,
+             * not a prerequisite for persisting the user's edit. In particular,
+             * an Electron proxy blip must not turn a model switch into a client-side
+             * no-op before the update request is even attempted.
+             */
+            console.error('[internal_updateTopic] failed to hydrate topic detail:', error);
+          }
+        }
+
+        if (update.invalidated) return;
       }
-      await this.#get().refreshTopic();
+
+      this.#get().internal_dispatchTopic({ type: 'updateTopic', id, value: data });
+
+      this.#get().internal_updateTopicLoading(id, true);
+      try {
+        const persistedTopics = await topicService.updateTopic(id, data);
+        if (update.invalidated) return;
+
+        const persistedTopic = persistedTopics?.[0];
+        if (persistedTopic) {
+          this.#get().internal_setTopicDetail(persistedTopic as unknown as ChatTopic);
+        }
+        await this.#get().refreshTopic();
+      } finally {
+        // Rename "Topic" -> "New" can fail after opening a loading owner; always release it.
+        this.#get().internal_updateTopicLoading(id, false);
+      }
     } finally {
-      // Rename "Topic" -> "New" can fail after opening a loading owner; always release it.
-      this.#get().internal_updateTopicLoading(id, false);
+      updates.delete(update);
+      if (updates.size === 0 && this.#topicDetailUpdates.get(id) === updates) {
+        this.#topicDetailUpdates.delete(id);
+      }
     }
   };
 

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -76,6 +76,15 @@ type TopicPatchScope = {
   scope?: TopicMapScope;
 };
 
+interface TopicDetailRequest {
+  invalidated: boolean;
+  promise: Promise<ChatTopic | null>;
+}
+
+interface TopicDetailUpdate {
+  invalidated: boolean;
+}
+
 /**
  * Options for switchTopic action
  */
@@ -135,7 +144,9 @@ export class ChatTopicActionImpl {
    */
   #topicDetailCacheGeneration = 0;
 
-  #topicDetailRequests = new Map<string, Promise<ChatTopic | null>>();
+  #topicDetailRequests = new Map<string, TopicDetailRequest>();
+
+  #topicDetailUpdates = new Map<string, Set<TopicDetailUpdate>>();
 
   constructor(set: Setter, get: () => ChatStore, _api?: unknown) {
     void _api;
@@ -147,16 +158,22 @@ export class ChatTopicActionImpl {
     const stored = topicSelectors.getTopicById(id)(this.#get());
     if (stored) return stored;
 
-    const pendingRequest = this.#topicDetailRequests.get(id);
-    if (pendingRequest) return pendingRequest;
+    let request = this.#topicDetailRequests.get(id);
 
     const cacheGeneration = this.#topicDetailCacheGeneration;
-    const request = topicService.getTopicDetail(id);
-    this.#topicDetailRequests.set(id, request);
+    if (!request) {
+      request = {
+        invalidated: false,
+        promise: topicService.getTopicDetail(id),
+      };
+      this.#topicDetailRequests.set(id, request);
+    }
 
     try {
-      const topic = await request;
-      if (cacheGeneration !== this.#topicDetailCacheGeneration) return null;
+      const topic = await request.promise;
+      if (request.invalidated || cacheGeneration !== this.#topicDetailCacheGeneration) {
+        return null;
+      }
       if (topic) this.#get().internal_setTopicDetail(topic);
       return topic;
     } finally {
@@ -1504,17 +1521,31 @@ export class ChatTopicActionImpl {
 
   internal_updateTopic = async (id: string, data: Partial<ChatTopic>): Promise<void> => {
     if (!topicSelectors.getTopicById(id)(this.#get())) {
+      const update: TopicDetailUpdate = { invalidated: false };
+      const updates = this.#topicDetailUpdates.get(id) ?? new Set<TopicDetailUpdate>();
+      updates.add(update);
+      this.#topicDetailUpdates.set(id, updates);
+
       try {
         await this.#fetchTopicDetail(id);
       } catch (error) {
-        /**
-         * Detail hydration is an optimization for the local optimistic write,
-         * not a prerequisite for persisting the user's edit. In particular,
-         * an Electron proxy blip must not turn a model switch into a client-side
-         * no-op before the update request is even attempted.
-         */
-        console.error('[internal_updateTopic] failed to hydrate topic detail:', error);
+        if (!update.invalidated) {
+          /**
+           * Detail hydration is an optimization for the local optimistic write,
+           * not a prerequisite for persisting the user's edit. In particular,
+           * an Electron proxy blip must not turn a model switch into a client-side
+           * no-op before the update request is even attempted.
+           */
+          console.error('[internal_updateTopic] failed to hydrate topic detail:', error);
+        }
+      } finally {
+        updates.delete(update);
+        if (updates.size === 0 && this.#topicDetailUpdates.get(id) === updates) {
+          this.#topicDetailUpdates.delete(id);
+        }
       }
+
+      if (update.invalidated) return;
     }
 
     this.#get().internal_dispatchTopic({ type: 'updateTopic', id, value: data });
@@ -1618,11 +1649,29 @@ export class ChatTopicActionImpl {
   /**
    * Clear independently fetched topic rows, their SWR entries, and requests
    * that started before this cache boundary. Without clearing both cache
-   * layers, a late response or SWR sync could restore a deleted topic.
+   * layers, a late response or SWR sync could restore a deleted topic. Targeted
+   * clears invalidate only matching requests so unrelated deep links keep loading.
    */
   internal_clearTopicDetails = (ids?: string[]): void => {
-    this.#topicDetailCacheGeneration += 1;
-    this.#topicDetailRequests.clear();
+    if (ids) {
+      for (const id of ids) {
+        const request = this.#topicDetailRequests.get(id);
+        if (request) request.invalidated = true;
+        this.#topicDetailRequests.delete(id);
+
+        const updates = this.#topicDetailUpdates.get(id);
+        for (const update of updates ?? []) update.invalidated = true;
+        this.#topicDetailUpdates.delete(id);
+      }
+    } else {
+      this.#topicDetailCacheGeneration += 1;
+      for (const request of this.#topicDetailRequests.values()) request.invalidated = true;
+      this.#topicDetailRequests.clear();
+      for (const updates of this.#topicDetailUpdates.values()) {
+        for (const update of updates) update.invalidated = true;
+      }
+      this.#topicDetailUpdates.clear();
+    }
 
     const idSet = ids ? new Set(ids) : undefined;
     void Promise.resolve(

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -1616,13 +1616,27 @@ export class ChatTopicActionImpl {
   };
 
   /**
-   * Clear independently fetched topic rows and invalidate requests that started
-   * before this cache boundary. Without the generation bump, a late response
-   * could restore a deleted topic or leak the previous workspace into the next.
+   * Clear independently fetched topic rows, their SWR entries, and requests
+   * that started before this cache boundary. Without clearing both cache
+   * layers, a late response or SWR sync could restore a deleted topic.
    */
   internal_clearTopicDetails = (ids?: string[]): void => {
     this.#topicDetailCacheGeneration += 1;
     this.#topicDetailRequests.clear();
+
+    const idSet = ids ? new Set(ids) : undefined;
+    void Promise.resolve(
+      mutate(
+        (key) =>
+          Array.isArray(key) &&
+          key[0] === topicKeys.detail.root &&
+          (!idSet || (typeof key[1] === 'string' && idSet.has(key[1]))),
+        undefined,
+        { revalidate: false },
+      ),
+    ).catch((error) => {
+      console.error('[internal_clearTopicDetails] failed to clear SWR cache:', error);
+    });
 
     const currentMap = this.#get().topicDetailMap ?? {};
     const nextMap = ids

--- a/src/store/chat/slices/topic/initialState.ts
+++ b/src/store/chat/slices/topic/initialState.ts
@@ -58,6 +58,12 @@ export interface ChatTopicState {
    */
   topicDataMap: Record<string, TopicData>;
   /**
+   * Full topic rows loaded independently from the paginated sidebar list.
+   * A deep-linked or searched topic can be active without appearing in the
+   * current list page, so its model and metadata need an id-keyed detail cache.
+   */
+  topicDetailMap: Record<string, ChatTopic>;
+  /**
    * Internal ref-count for topic loading owners. A topic can be loading because
    * the agent is running and because title-summary is streaming at the same time.
    */
@@ -75,6 +81,7 @@ export const initialTopicState: ChatTopicState = {
   isSearchingTopic: false,
   searchTopics: [],
   topicDataMap: {},
+  topicDetailMap: {},
   topicLoadingIdCounts: {},
   topicLoadingIds: [],
   topicSearchKeywords: '',

--- a/src/store/chat/slices/topic/reducer.test.ts
+++ b/src/store/chat/slices/topic/reducer.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'vitest';
 import { type ChatTopic } from '@/types/topic';
 
 import { type ChatTopicDispatch } from './reducer';
-import { topicReducer } from './reducer';
+import { topicDetailReducer, topicReducer } from './reducer';
 
 describe('topicReducer', () => {
   let state: ChatTopic[];
@@ -204,5 +204,48 @@ describe('topicReducer', () => {
 
       expect(state).toEqual([]);
     });
+  });
+});
+
+describe('topicDetailReducer', () => {
+  const topic: ChatTopic = {
+    createdAt: 1,
+    id: 'topic-1',
+    model: 'claude-sonnet-4-6',
+    provider: 'anthropic',
+    title: 'Deep-linked topic',
+    updatedAt: 1,
+  };
+
+  it('sets and updates a topic without adding it to a paginated list', () => {
+    const detailMap = topicDetailReducer(
+      {},
+      {
+        type: 'setTopicDetail',
+        value: topic,
+      },
+    );
+
+    const nextMap = topicDetailReducer(detailMap, {
+      id: topic.id,
+      type: 'updateTopic',
+      value: { model: 'deepseek-v4', provider: 'deepseek' },
+    });
+
+    expect(nextMap[topic.id]).toMatchObject({
+      id: topic.id,
+      model: 'deepseek-v4',
+      provider: 'deepseek',
+      title: topic.title,
+    });
+  });
+
+  it('removes a cached detail when the topic is deleted', () => {
+    const nextMap = topicDetailReducer(
+      { [topic.id]: topic },
+      { id: topic.id, type: 'deleteTopic' },
+    );
+
+    expect(nextMap).toEqual({});
   });
 });

--- a/src/store/chat/slices/topic/reducer.ts
+++ b/src/store/chat/slices/topic/reducer.ts
@@ -43,6 +43,17 @@ type ReplaceChatTopicIdAction = ChatTopicScope & {
 export type ChatTopicDispatch =
   AddChatTopicAction | UpdateChatTopicAction | DeleteChatTopicAction | ReplaceChatTopicIdAction;
 
+type SetChatTopicDetailAction = {
+  type: 'setTopicDetail';
+  value: ChatTopic;
+};
+
+export type ChatTopicDetailDispatch =
+  | SetChatTopicDetailAction
+  | UpdateChatTopicAction
+  | DeleteChatTopicAction
+  | ReplaceChatTopicIdAction;
+
 export const topicReducer = (state: ChatTopic[] = [], payload: ChatTopicDispatch): ChatTopic[] => {
   switch (payload.type) {
     case 'addTopic': {
@@ -55,7 +66,7 @@ export const topicReducer = (state: ChatTopic[] = [], payload: ChatTopicDispatch
           sessionId: payload.value.sessionId || undefined,
           // A brand-new topic is fresh activity: seed the sidebar sort key so it
           // lands at the top immediately, matching the server's `topicActivityAt`
-          // once the real row is fetched. 
+          // once the real row is fetched.
           sortUpdatedAt: Date.now(),
           updatedAt: Date.now(),
         });
@@ -79,7 +90,7 @@ export const topicReducer = (state: ChatTopic[] = [], payload: ChatTopicDispatch
             // Bump `updatedAt` (display/edit time) on every real write. The sidebar
             // no longer sorts by `updatedAt` — it sorts by `sortUpdatedAt` (activity
             // time) — so a status flip bumping `updatedAt` here can't reorder the
-            // list; only an explicit `sortUpdatedAt` in `value` moves a row. 
+            // list; only an explicit `sortUpdatedAt` in `value` moves a row.
             // TODO: updatedAt type needs to be changed to Date later
             // @ts-ignore
             draftState[topicIndex] = { ...mergedTopic, updatedAt: new Date() };
@@ -105,7 +116,7 @@ export const topicReducer = (state: ChatTopic[] = [], payload: ChatTopicDispatch
           id: nextId,
           // Resolving a first-send optimistic topic to its real id is fresh activity:
           // keep it pinned to the top via the sidebar sort key (`sortUpdatedAt`), not
-          // just `updatedAt` which the sidebar no longer sorts by. 
+          // just `updatedAt` which the sidebar no longer sorts by.
           sortUpdatedAt: Date.now(),
           updatedAt: Date.now(),
         };
@@ -122,6 +133,63 @@ export const topicReducer = (state: ChatTopic[] = [], payload: ChatTopicDispatch
         if (topicIndex !== -1) {
           draftState.splice(topicIndex, 1);
         }
+      });
+    }
+
+    default: {
+      return state;
+    }
+  }
+};
+
+/**
+ * Keep independently fetched topic details reactive without mixing them into
+ * the paginated sidebar list. List mutations are mirrored here only when the
+ * detail row is already cached.
+ */
+export const topicDetailReducer = (
+  state: Record<string, ChatTopic> = {},
+  payload: ChatTopicDetailDispatch,
+): Record<string, ChatTopic> => {
+  switch (payload.type) {
+    case 'setTopicDetail': {
+      return produce(state, (draftState) => {
+        draftState[payload.value.id] = payload.value;
+      });
+    }
+
+    case 'updateTopic': {
+      return produce(state, (draftState) => {
+        const currentTopic = draftState[payload.id];
+        if (!currentTopic) return;
+
+        const mergedTopic = { ...currentTopic, ...payload.value };
+        if (isEqual(current(currentTopic), mergedTopic)) return;
+
+        draftState[payload.id] = { ...mergedTopic, updatedAt: Date.now() };
+      });
+    }
+
+    case 'replaceTopicId': {
+      return produce(state, (draftState) => {
+        const currentTopic = draftState[payload.id];
+        if (!currentTopic) return;
+
+        const nextTopic = draftState[payload.nextId];
+        draftState[payload.nextId] = {
+          ...currentTopic,
+          ...nextTopic,
+          ...payload.value,
+          id: payload.nextId,
+          updatedAt: Date.now(),
+        };
+        delete draftState[payload.id];
+      });
+    }
+
+    case 'deleteTopic': {
+      return produce(state, (draftState) => {
+        delete draftState[payload.id];
       });
     }
 

--- a/src/store/chat/slices/topic/selectors.test.ts
+++ b/src/store/chat/slices/topic/selectors.test.ts
@@ -88,6 +88,29 @@ describe('topicSelectors', () => {
         provider: 'openai',
       });
     });
+
+    it('reads the active model from a deep-linked topic outside the loaded list page', () => {
+      const state = merge(initialStore, {
+        activeAgentId: 'test',
+        activeTopicId: 'deep-linked',
+        topicDataMap: modelTopicDataMap,
+        topicDetailMap: {
+          'deep-linked': {
+            createdAt: 1,
+            id: 'deep-linked',
+            model: 'deepseek-v4',
+            provider: 'deepseek',
+            title: 'Older topic',
+            updatedAt: 1,
+          },
+        },
+      });
+
+      expect(topicSelectors.activeTopicModel(state)).toEqual({
+        model: 'deepseek-v4',
+        provider: 'deepseek',
+      });
+    });
   });
 
   describe('currentTopicLength', () => {
@@ -212,6 +235,22 @@ describe('topicSelectors', () => {
       const state = merge(initialStore, { topicDataMap, activeAgentId: 'test' });
       const topic = topicSelectors.getTopicById('topic1')(state);
       expect(topic).toEqual(topicItems[0]);
+    });
+
+    it('should fall back to the independently loaded detail', () => {
+      const detail = {
+        createdAt: 1,
+        id: 'older-topic',
+        title: 'Older topic',
+        updatedAt: 1,
+      };
+      const state = merge(initialStore, {
+        activeAgentId: 'test',
+        topicDataMap,
+        topicDetailMap: { [detail.id]: detail },
+      });
+
+      expect(topicSelectors.getTopicById(detail.id)(state)).toEqual(detail);
     });
   });
 

--- a/src/store/chat/slices/topic/selectors.test.ts
+++ b/src/store/chat/slices/topic/selectors.test.ts
@@ -252,6 +252,63 @@ describe('topicSelectors', () => {
 
       expect(topicSelectors.getTopicById(detail.id)(state)).toEqual(detail);
     });
+
+    it('supports partial list-only store states without a detail cache', () => {
+      const state = {
+        activeAgentId: 'test',
+        topicDataMap,
+      } as ChatStore;
+
+      expect(topicSelectors.getTopicById('topic1')(state)).toEqual(topicItems[0]);
+      expect(topicSelectors.getTopicById('notfound')(state)).toBeUndefined();
+    });
+  });
+
+  describe('getTopicByIdForContext', () => {
+    it('uses the requested route context instead of the globally active context', () => {
+      const routeTopic = { id: 'route-topic', title: 'Route topic' };
+      const state = merge(initialStore, {
+        activeAgentId: 'active-agent',
+        topicDataMap: {
+          [topicMapKey({ agentId: 'active-agent' })]: {
+            currentPage: 0,
+            hasMore: false,
+            items: [],
+            pageSize: 20,
+            total: 0,
+          },
+          [topicMapKey({ agentId: 'route-agent' })]: {
+            currentPage: 0,
+            hasMore: false,
+            items: [routeTopic],
+            pageSize: 20,
+            total: 1,
+          },
+        },
+      });
+
+      expect(
+        topicSelectors.getTopicByIdForContext('route-topic', { agentId: 'route-agent' })(state),
+      ).toEqual(routeTopic);
+      expect(topicSelectors.getTopicById('route-topic')(state)).toBeUndefined();
+    });
+
+    it('falls back to the detail cache when the route-scoped list does not contain the topic', () => {
+      const detail = {
+        createdAt: 1,
+        id: 'older-topic',
+        title: 'Older topic',
+        updatedAt: 1,
+      };
+      const state = merge(initialStore, {
+        topicDataMap: {},
+        topicDetailMap: { [detail.id]: detail },
+      });
+
+      expect(
+        topicSelectors.getTopicByIdForContext(detail.id, { groupId: 'route-group' })(state),
+      ).toEqual(detail);
+    });
   });
 
   describe('getTopicWorkingDirectory', () => {

--- a/src/store/chat/slices/topic/selectors.test.ts
+++ b/src/store/chat/slices/topic/selectors.test.ts
@@ -257,7 +257,7 @@ describe('topicSelectors', () => {
       const state = {
         activeAgentId: 'test',
         topicDataMap,
-      } as ChatStore;
+      } as unknown as ChatStore;
 
       expect(topicSelectors.getTopicById('topic1')(state)).toEqual(topicItems[0]);
       expect(topicSelectors.getTopicById('notfound')(state)).toBeUndefined();

--- a/src/store/chat/slices/topic/selectors.ts
+++ b/src/store/chat/slices/topic/selectors.ts
@@ -40,8 +40,13 @@ const currentTopicsWithoutCron = (s: ChatStoreState): ChatTopic[] | undefined =>
   return topics.filter((topic) => topic.trigger !== 'cron');
 };
 
+const getTopicById =
+  (id: string) =>
+  (s: ChatStoreState): ChatTopic | undefined =>
+    currentTopics(s)?.find((topic) => topic.id === id) ?? s.topicDetailMap[id];
+
 const currentActiveTopic = (s: ChatStoreState): ChatTopic | undefined => {
-  return currentTopics(s)?.find((topic) => topic.id === s.activeTopicId);
+  return s.activeTopicId ? getTopicById(s.activeTopicId)(s) : undefined;
 };
 const searchTopics = (s: ChatStoreState): ChatTopic[] => s.searchTopics;
 
@@ -53,11 +58,6 @@ const currentUnFavTopics = (s: ChatStoreState): ChatTopic[] =>
 const currentTopicLength = (s: ChatStoreState): number => currentTopicsWithoutCron(s)?.length || 0;
 
 const currentTopicCount = (s: ChatStoreState): number => currentTopicData(s)?.total || 0;
-
-const getTopicById =
-  (id: string) =>
-  (s: ChatStoreState): ChatTopic | undefined =>
-    currentTopics(s)?.find((topic) => topic.id === id); // Don't filter here, need to access all topics by ID
 
 /**
  * Get topics by specific agentId (for AgentBuilder scenarios where agentId differs from activeAgentId)

--- a/src/store/chat/slices/topic/selectors.ts
+++ b/src/store/chat/slices/topic/selectors.ts
@@ -18,6 +18,7 @@ import {
 } from '@/utils/client/topic';
 
 import { type ChatStoreState } from '../../initialState';
+import type { TopicMapKeyInput } from '../../utils/topicMapKey';
 import { topicMapKey } from '../../utils/topicMapKey';
 import { operationSelectors } from '../operation/selectors';
 import { type TopicData } from './initialState';
@@ -40,10 +41,26 @@ const currentTopicsWithoutCron = (s: ChatStoreState): ChatTopic[] | undefined =>
   return topics.filter((topic) => topic.trigger !== 'cron');
 };
 
+/**
+ * Keep the detail fallback compatible with partial store states that only
+ * provide the paginated topic map, such as isolated consumers and tests.
+ */
+const getTopicDetailById = (id: string, s: ChatStoreState): ChatTopic | undefined =>
+  s.topicDetailMap?.[id];
+
+const getTopicByIdForContext =
+  (id: string, context: TopicMapKeyInput) =>
+  (s: ChatStoreState): ChatTopic | undefined =>
+    s.topicDataMap[topicMapKey(context)]?.items?.find((topic) => topic.id === id) ??
+    getTopicDetailById(id, s);
+
 const getTopicById =
   (id: string) =>
   (s: ChatStoreState): ChatTopic | undefined =>
-    currentTopics(s)?.find((topic) => topic.id === id) ?? s.topicDetailMap[id];
+    getTopicByIdForContext(id, {
+      agentId: s.activeAgentId,
+      groupId: s.activeGroupId,
+    })(s);
 
 const currentActiveTopic = (s: ChatStoreState): ChatTopic | undefined => {
   return s.activeTopicId ? getTopicById(s.activeTopicId)(s) : undefined;
@@ -329,6 +346,7 @@ export const topicSelectors = {
   displayTopics,
   displayTopicsForSidebar,
   getTopicById,
+  getTopicByIdForContext,
   getTopicModelById,
   getTopicWorkingDirectory,
   getTopicsByAgentId,

--- a/src/store/chat/store.ts
+++ b/src/store/chat/store.ts
@@ -53,6 +53,15 @@ export type ChatStore = ChatStoreAction & ChatStoreState;
 //  ===============  Aggregate createStoreFn ============ //
 
 class ChatStoreResetAction extends ResetableStoreAction<ChatStore> {
+  /**
+   * Chat topic actions own request and reconciliation state outside Zustand.
+   * Invalidate it before replacing store state so a pre-reset response cannot
+   * repopulate data for a new user or remote server.
+   */
+  protected beforeReset = (state: ChatStore) => {
+    state.internal_clearTopicDetails();
+  };
+
   protected readonly resetActionName = 'resetChatStore';
 }
 

--- a/src/store/utils/resetableStore.ts
+++ b/src/store/utils/resetableStore.ts
@@ -12,6 +12,8 @@ export abstract class ResetableStoreAction<TStore extends object> implements Res
   readonly #api: StoreApi<TStore>;
   readonly #set: Setter<TStore>;
 
+  protected beforeReset?: (state: TStore) => void;
+
   protected abstract readonly resetActionName: string;
 
   constructor(set: Setter<TStore>, _get: () => TStore, api: StoreApi<TStore>) {
@@ -21,6 +23,7 @@ export abstract class ResetableStoreAction<TStore extends object> implements Res
   }
 
   reset = () => {
+    this.beforeReset?.(this.#api.getState());
     this.#set(this.#api.getInitialState(), false, this.resetActionName);
   };
 }


### PR DESCRIPTION
## 💻 Change Type

- [x] 🐛 fix

## 🔗 Related Links

- Linear / GitHub issue: N/A — no matching public issue found
- Related PRs: N/A
- Reference docs / code / articles: `src/services/topic/index.ts` single-topic detail query

## 🔀 Description of Change

Topics opened through a direct route or search can be active even when they are outside the first paginated sidebar page. The conversation messages still load, but topic-scoped state such as model and metadata previously resolved only from the list page, so optimistic updates could silently miss the active topic.

This change:

- adds an ID-keyed topic detail cache separate from paginated list data;
- hydrates missing topic details for agent and group conversation routes;
- resolves active topic selectors from the list first and the detail cache second;
- keeps desktop route metadata scoped to the route agent or group;
- mirrors topic updates, deletes, unread state, route metadata, and gateway metadata into cached details;
- invalidates Zustand details, matching SWR detail entries, and only the affected in-flight responses after topic deletion or movement;
- aborts pending edits and ignores persisted update responses invalidated by deletion, movement, or a workspace reset;
- invalidates private topic request state during a full chat-store reset;
- reconciles pending running/unread status writes before caching a detail response;
- keeps detail fallbacks safe for partial store states;
- still attempts persistence when detail hydration fails and folds the persisted row back into the detail cache.

## 🧭 Key Decisions / Non-goals

- Topic details remain separate from sidebar arrays so opening an old topic does not alter list pagination, totals, or ordering.
- Loaded list rows remain the primary source; the detail cache is only an ID-based fallback.
- Full cache-boundary resets advance a request generation; targeted clears invalidate only matching requests so unrelated deep links keep loading.
- SWR invalidation matches both plain and workspace-augmented topic detail keys.
- This PR does not change the topic page size or general transport/proxy error handling.

## 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

### Automated Tests

- `bun run check <21 changed OSS files> --lint --test --type`
- Result after rebase and the latest review fix: 21 files, lint clean, 243 tests passed, types clean.
- Unified Cloud and OSS changed-file check: 23 files, lint clean, 245 tests passed, types clean.
- Direct replay of the previously failing app test files: 170 tests passed.

### Manual Verification

- Open a topic through a direct URL when it is not present in the first sidebar page.
- Switch its model and confirm the trigger updates immediately and the selection persists after reload.
- Keep another desktop conversation tab inactive and confirm its topic title still resolves from its own route scope.
- Delete topics in bulk and confirm deleted topic details are not returned from Zustand or SWR cache.
- Confirm the sidebar page contents, total, and ordering do not change merely because the topic detail was loaded.

### Post-Deploy Verification

- Repeat the direct-link model switch on web and desktop.
- Watch for topic-detail and topic-update request errors; no migration or cache flush is required.

## 🚀 Rollout / Deployment Checklist

- [x] Environment variables: N/A
- [x] Redis / Edge Config / feature flags: N/A
- [x] Database migration or data backfill: N/A
- [x] Third-party console changes: N/A
- [x] Rollback plan: revert this change; topic list storage remains unchanged.