### PR TITLE
🐛 fix: keep inbox route valid during initialization

### DIFF
--- a/src/features/AgentRoute/useResolvedAgentRouteId.test.ts
+++ b/src/features/AgentRoute/useResolvedAgentRouteId.test.ts
@@ -1,0 +1,14 @@
+import { BUILTIN_AGENT_SLUGS } from '@lobechat/builtin-agents';
+import { describe, expect, it } from 'vitest';
+
+import { resolveInboxAgentRouteId } from './useResolvedAgentRouteId';
+
+describe('resolveInboxAgentRouteId', () => {
+  it('should use the stable inbox slug while the persisted agent ID is loading', () => {
+    expect(resolveInboxAgentRouteId()).toBe(BUILTIN_AGENT_SLUGS.inbox);
+  });
+
+  it('should use the persisted agent ID after initialization', () => {
+    expect(resolveInboxAgentRouteId('inbox-agent-id')).toBe('inbox-agent-id');
+  });
+});

--- a/src/features/AgentRoute/useResolvedAgentRouteId.ts
+++ b/src/features/AgentRoute/useResolvedAgentRouteId.ts
@@ -5,6 +5,13 @@ import { builtinAgentSelectors } from '@/store/agent/selectors';
 
 const builtinAgentSlugs = new Set<string>(Object.values(BUILTIN_AGENT_SLUGS));
 
+/**
+ * Keep the inbox route valid while its persisted agent ID is still loading.
+ * `useResolvedAgentRouteId` resolves the stable slug once initialization finishes.
+ */
+export const resolveInboxAgentRouteId = (inboxAgentId?: string) =>
+  inboxAgentId ?? BUILTIN_AGENT_SLUGS.inbox;
+
 export const useResolvedAgentRouteId = (routeAgentId?: string) => {
   const isBuiltinSlug = !!routeAgentId && builtinAgentSlugs.has(routeAgentId);
   const resolvedAgentId = useAgentStore(

--- a/src/routes/(main)/home/_layout/Body/Agent/List/InboxItem.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/InboxItem.tsx
@@ -7,6 +7,7 @@ import { Loader2 } from 'lucide-react';
 import { type CSSProperties } from 'react';
 import { memo } from 'react';
 
+import { resolveInboxAgentRouteId } from '@/features/AgentRoute/useResolvedAgentRouteId';
 import NavItem from '@/features/NavPanel/components/NavItem';
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
 import { usePrefetchAgent } from '@/hooks/usePrefetchAgent';
@@ -51,7 +52,8 @@ interface InboxItemProps {
 
 const InboxItem = memo<InboxItemProps>(({ className, style }) => {
   const inboxAgentId = useAgentStore(builtinAgentSelectors.inboxAgentId);
-  const inboxMeta = useAgentStore(agentSelectors.getAgentMetaById(inboxAgentId!));
+  const inboxRouteAgentId = resolveInboxAgentRouteId(inboxAgentId);
+  const inboxMeta = useAgentStore(agentSelectors.getAgentMetaById(inboxRouteAgentId));
 
   const isLoading = useChatStore(
     inboxAgentId ? operationSelectors.isAgentVisiblyRunning(inboxAgentId) : () => false,
@@ -59,10 +61,10 @@ const InboxItem = memo<InboxItemProps>(({ className, style }) => {
   const prefetchAgent = usePrefetchAgent();
   const inboxAgentTitle = inboxMeta.title || 'Lobe AI';
   const inboxAgentAvatar = inboxMeta.avatar || DEFAULT_INBOX_AVATAR;
-  const inboxUrl = usePreservedAgentUrl(inboxAgentId!);
+  const inboxUrl = usePreservedAgentUrl(inboxRouteAgentId);
 
   // Prefetch agent layout chunk and data eagerly since Lobe AI is almost always clicked
-  prefetchAgent(inboxAgentId!);
+  if (inboxAgentId) prefetchAgent(inboxAgentId);
 
   const avatarNode = (
     <Avatar emojiScaleWithBackground avatar={inboxAgentAvatar} shape={'square'} size={24} />

--- a/src/routes/(mobile)/(home)/features/SessionListContent/Inbox/index.tsx
+++ b/src/routes/(mobile)/(home)/features/SessionListContent/Inbox/index.tsx
@@ -3,6 +3,7 @@ import { memo } from 'react';
 import { Link } from 'react-router';
 
 import { DEFAULT_INBOX_AVATAR } from '@/const/meta';
+import { resolveInboxAgentRouteId } from '@/features/AgentRoute/useResolvedAgentRouteId';
 import { useNavigateToAgent } from '@/hooks/useNavigateToAgent';
 import { useAgentStore } from '@/store/agent';
 import { builtinAgentSelectors } from '@/store/agent/selectors';
@@ -17,14 +18,15 @@ const Inbox = memo(() => {
   const isInboxActive = useSessionStore(sessionSelectors.isInboxSession);
   const navigateToAgent = useNavigateToAgent();
   const inboxAgentId = useAgentStore(builtinAgentSelectors.inboxAgentId);
+  const inboxRouteAgentId = resolveInboxAgentRouteId(inboxAgentId);
 
   return (
     <Link
       aria-label={'Lobe AI'}
-      to={AGENT_CHAT_URL(inboxAgentId, mobile)}
+      to={AGENT_CHAT_URL(inboxRouteAgentId, mobile)}
       onClick={(e) => {
         e.preventDefault();
-        navigateToAgent(inboxAgentId);
+        navigateToAgent(inboxRouteAgentId);
       }}
     >
       <ListItem


### PR DESCRIPTION
Prevent the Lobe AI navigation target from becoming `/agent/undefined` while the persisted inbox agent ID is still loading.

- Fall back to the stable builtin `/agent/inbox` route until the real ID resolves
- Apply the same behavior to desktop and mobile inbox entry points
- Avoid prefetching agent data until the real ID is available

#### Key Decisions / Non-goals

- Route correctness must not depend on a warm local cache. This PR does not change the existing SWR persistence tiers.
- The fallback reuses the existing builtin slug resolver instead of adding a second loading or navigation flow.

#### Test

- [x] Tested locally
- [x] Added/updated tests

`bun run check lobehub/src/features/AgentRoute/useResolvedAgentRouteId.ts lobehub/src/features/AgentRoute/useResolvedAgentRouteId.test.ts "lobehub/src/routes/(main)/home/_layout/Body/Agent/List/InboxItem.tsx" "lobehub/src/routes/(mobile)/(home)/features/SessionListContent/Inbox/index.tsx" --lint --test --type`

#### 🔗 Related Issue

Fixes LOBE-12586