### PR TITLE
🐛 fix: prevent stale SWR cache replay after mutations

### DIFF
--- a/src/services/document/swrKeys.ts
+++ b/src/services/document/swrKeys.ts
@@ -23,6 +23,7 @@ export const agentDocumentSWRKeys = {
 
 export const documentSWRKeys = {
   editor: (documentId: string) => ['document:editor', documentId] as const,
+  fileDetail: (documentId: string) => ['documentDetail', documentId] as const,
   pageDetail: (documentId: string) => ['page:detail', documentId] as const,
   pageDocuments: () => ['page:list'] as const,
   pageMeta: (documentId: string) => ['page:meta', documentId] as const,

--- a/src/store/agent/slices/agent/action.test.ts
+++ b/src/store/agent/slices/agent/action.test.ts
@@ -1,6 +1,6 @@
 import { CHAT_GROUP_SESSION_ID_PREFIX } from '@lobechat/types';
 import { act, renderHook, waitFor } from '@testing-library/react';
-import type { ScopedMutator } from 'swr/_internal';
+import type { MutatorCallback, ScopedMutator } from 'swr/_internal';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { message } from '@/components/AntdStaticMethods';
@@ -896,7 +896,10 @@ describe('AgentSlice Actions', () => {
         const keyString = JSON.stringify(swrKey);
         if (data === undefined) return cache.get(keyString);
 
-        const nextData = typeof data === 'function' ? await data(cache.get(keyString)) : data;
+        const nextData =
+          typeof data === 'function'
+            ? await (data as MutatorCallback<unknown>)(cache.get(keyString))
+            : await data;
         cache.set(keyString, nextData);
         return nextData;
       }) as ScopedMutator);

--- a/src/store/agent/slices/agent/action.test.ts
+++ b/src/store/agent/slices/agent/action.test.ts
@@ -1,5 +1,6 @@
 import { CHAT_GROUP_SESSION_ID_PREFIX } from '@lobechat/types';
 import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ScopedMutator } from 'swr/_internal';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { message } from '@/components/AntdStaticMethods';
@@ -880,6 +881,55 @@ describe('AgentSlice Actions', () => {
         title: 'New Title',
       });
       expect(result.current.availableAgents).toBeUndefined();
+    });
+
+    it('keeps server-confirmed metadata in the config SWR snapshot used on remount', async () => {
+      const { result } = renderHook(() => useAgentStore());
+      const cache = new Map<string, unknown>();
+      const key = JSON.stringify(agentConfigKeys.config('agent-1'));
+      cache.set(key, {
+        id: 'agent-1',
+        model: 'gpt-4',
+        title: 'Old Title',
+      });
+      setScopedMutate((async (swrKey, data) => {
+        const keyString = JSON.stringify(swrKey);
+        if (data === undefined) return cache.get(keyString);
+
+        const nextData = typeof data === 'function' ? await data(cache.get(keyString)) : data;
+        cache.set(keyString, nextData);
+        return nextData;
+      }) as ScopedMutator);
+      vi.mocked(agentService.updateAgentMeta).mockResolvedValue({
+        agent: {
+          id: 'agent-1',
+          model: 'gpt-4',
+          title: 'New Title',
+        } as LobeAgentConfig,
+        success: true,
+      });
+
+      act(() => {
+        useAgentStore.setState({
+          agentMap: {
+            'agent-1': { id: 'agent-1', model: 'gpt-4', title: 'Old Title' } as LobeAgentConfig,
+          },
+        });
+      });
+
+      await act(async () => {
+        await result.current.optimisticUpdateAgentMeta('agent-1', { title: 'New Title' });
+      });
+
+      expect(cache.get(key)).toMatchObject({ id: 'agent-1', title: 'New Title' });
+
+      act(() => {
+        useAgentStore.setState({ agentMap: {} });
+        result.current.internal_dispatchAgentMap('agent-1', cache.get(key) as LobeAgentConfig);
+      });
+      expect(useAgentStore.getState().agentMap['agent-1']).toMatchObject({
+        title: 'New Title',
+      });
     });
 
     // Note: refreshSessions is no longer called after optimistic update

--- a/src/store/agent/slices/agent/action.ts
+++ b/src/store/agent/slices/agent/action.ts
@@ -680,6 +680,17 @@ export class AgentSliceActionImpl {
       // 3. Use returned data directly (no refetch needed!)
       if (result?.success && result.agent) {
         internal_dispatchAgentMap(id, result.agent);
+        const confirmedAgent = this.#get().agentMap[id];
+        /**
+         * Agent config is persisted and hydrates agentMap on remount. Keep the
+         * cache on the same server-confirmed snapshot as the Zustand mirror.
+         */
+        void mutate(
+          agentConfigKeys.config(id),
+          (cachedAgent: LobeAgentConfig | undefined) =>
+            merge(cachedAgent ?? {}, confirmedAgent ?? {}) as LobeAgentConfig,
+          { revalidate: false },
+        );
         this.#get().invalidateAvailableAgents();
       }
       updateSaveStatus('saved');

--- a/src/store/document/slices/editor/action.test.ts
+++ b/src/store/document/slices/editor/action.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
-import type { ScopedMutator } from 'swr/_internal';
+import type { MutatorCallback, ScopedMutator } from 'swr/_internal';
 import { describe, expect, it, vi } from 'vitest';
 
 import { EMPTY_EDITOR_STATE } from '@/libs/editor/constants';
@@ -52,7 +52,10 @@ describe('DocumentStore - Editor Actions', () => {
       const keyString = JSON.stringify(key);
       if (data === undefined) return cache.get(keyString);
 
-      const nextData = typeof data === 'function' ? await data(cache.get(keyString)) : data;
+      const nextData =
+        typeof data === 'function'
+          ? await (data as MutatorCallback<unknown>)(cache.get(keyString))
+          : await data;
       cache.set(keyString, nextData);
       return nextData;
     }) as ScopedMutator);

--- a/src/store/document/slices/editor/action.test.ts
+++ b/src/store/document/slices/editor/action.test.ts
@@ -1,8 +1,11 @@
 import { act, renderHook } from '@testing-library/react';
+import type { ScopedMutator } from 'swr/_internal';
 import { describe, expect, it, vi } from 'vitest';
 
 import { EMPTY_EDITOR_STATE } from '@/libs/editor/constants';
+import { setScopedMutate } from '@/libs/swr';
 import { documentService } from '@/services/document';
+import { documentSWRKeys } from '@/services/document/swrKeys';
 
 import { useDocumentStore } from '../../store';
 
@@ -41,7 +44,18 @@ const createValidMockEditor = () => ({
 });
 
 describe('DocumentStore - Editor Actions', () => {
+  const cache = new Map<string, unknown>();
+
   beforeEach(() => {
+    cache.clear();
+    setScopedMutate((async (key, data) => {
+      const keyString = JSON.stringify(key);
+      if (data === undefined) return cache.get(keyString);
+
+      const nextData = typeof data === 'function' ? await data(cache.get(keyString)) : data;
+      cache.set(keyString, nextData);
+      return nextData;
+    }) as ScopedMutator);
     vi.mocked(documentService.updateDocument).mockResolvedValue({
       historyAppended: false,
       id: 'doc-1',
@@ -1047,6 +1061,56 @@ name: skill-name
         }),
       );
       expect(result.current.documents['doc-1'].isDirty).toBe(false);
+    });
+
+    it('keeps saved content in the editor SWR snapshot used on remount', async () => {
+      const { result } = renderHook(() => useDocumentStore());
+      const mockEditor = createValidMockEditor() as any;
+      const key = JSON.stringify(documentSWRKeys.editor('doc-1'));
+      cache.set(key, {
+        content: '# Old content',
+        editorData: { root: { children: [], type: 'root' } },
+        id: 'doc-1',
+        metadata: {},
+        title: 'Old title',
+      });
+
+      act(() => {
+        result.current.initDocumentWithEditor({
+          content: '# Old content',
+          documentId: 'doc-1',
+          editor: mockEditor,
+          sourceType: 'page',
+        });
+        result.current.markDirty('doc-1');
+      });
+
+      await act(async () => {
+        await result.current.performSave('doc-1');
+      });
+
+      const savedSnapshot = cache.get(key) as {
+        content: string;
+        editorData: unknown;
+      };
+      expect(savedSnapshot).toMatchObject({
+        content: '# Test',
+        editorData: {
+          root: { children: [{ children: [], type: 'paragraph' }], type: 'root' },
+        },
+      });
+
+      act(() => {
+        result.current.closeDocument('doc-1');
+        result.current.initDocumentWithEditor({
+          content: savedSnapshot.content,
+          documentId: 'doc-1',
+          editor: mockEditor,
+          editorData: savedSnapshot.editorData,
+          sourceType: 'page',
+        });
+      });
+      expect(result.current.documents['doc-1'].content).toBe('# Test');
     });
 
     it('should save and persist raw editorData with diff nodes (pending human review)', async () => {

--- a/src/store/document/slices/editor/action.ts
+++ b/src/store/document/slices/editor/action.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import type { DocumentItem } from '@lobechat/database/schemas';
 import type { IEditor } from '@lobehub/editor';
 import type { EditorState as LobehubEditorState } from '@lobehub/editor/react';
 import isEqual from 'fast-deep-equal';
@@ -8,7 +9,9 @@ import { t } from 'i18next';
 import { message } from '@/components/AntdStaticMethods';
 import { EMPTY_EDITOR_STATE } from '@/libs/editor/constants';
 import { isValidEditorData } from '@/libs/editor/isValidEditorData';
+import { mutate } from '@/libs/swr';
 import { documentService } from '@/services/document';
+import { documentSWRKeys } from '@/services/document/swrKeys';
 import type { StoreSetter } from '@/store/types';
 import { composeSkillMarkdown, parseSkillMarkdownFrontmatter } from '@/utils/skillMarkdown';
 import { setNamespace } from '@/utils/storeDebug';
@@ -352,6 +355,30 @@ export class EditorActionImpl {
           saveStatus: 'saved',
         },
       });
+
+      /**
+       * The editor cache is persisted and hydrates DocumentStore on remount.
+       * Patch it with the saved snapshot so navigation cannot replay pre-save content.
+       */
+      void mutate(
+        documentSWRKeys.editor(id),
+        (document: DocumentItem | null | undefined) => {
+          if (!document) return document;
+
+          return {
+            ...document,
+            content: currentContent,
+            editorData: structuredClone(currentEditorData),
+            metadata:
+              metadata?.emoji === undefined
+                ? document.metadata
+                : { ...document.metadata, emoji: metadata.emoji },
+            title: metadata?.title ?? document.title,
+            updatedAt: result.savedAt ? new Date(result.savedAt) : new Date(),
+          };
+        },
+        { revalidate: false },
+      );
     } catch (error) {
       // The server rejects writes to a workspace document another collaborator is
       // actively editing (CONFLICT). Surface it as a lock block so the editor can

--- a/src/store/file/slices/document/action.test.ts
+++ b/src/store/file/slices/document/action.test.ts
@@ -4,7 +4,7 @@ import {
   DERIVED_DOCUMENT_SOURCE_TYPE,
 } from '@lobechat/const';
 import { act, renderHook } from '@testing-library/react';
-import type { ScopedMutator } from 'swr/_internal';
+import type { MutatorCallback, ScopedMutator } from 'swr/_internal';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { setScopedMutate } from '@/libs/swr';
@@ -72,7 +72,10 @@ beforeEach(() => {
     const keyString = JSON.stringify(key);
     if (data === undefined) return cache.get(keyString);
 
-    const nextData = typeof data === 'function' ? await data(cache.get(keyString)) : data;
+    const nextData =
+      typeof data === 'function'
+        ? await (data as MutatorCallback<unknown>)(cache.get(keyString))
+        : await data;
     cache.set(keyString, nextData);
     return nextData;
   }) as ScopedMutator);

--- a/src/store/file/slices/document/action.test.ts
+++ b/src/store/file/slices/document/action.test.ts
@@ -4,9 +4,12 @@ import {
   DERIVED_DOCUMENT_SOURCE_TYPE,
 } from '@lobechat/const';
 import { act, renderHook } from '@testing-library/react';
+import type { ScopedMutator } from 'swr/_internal';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { setScopedMutate } from '@/libs/swr';
 import { documentService } from '@/services/document';
+import { documentSWRKeys } from '@/services/document/swrKeys';
 import { DocumentSourceType, type LobeDocument } from '@/types/document';
 import { type ResourceItem } from '@/types/resource';
 
@@ -60,8 +63,19 @@ const createResourceFixture = (overrides: Partial<ResourceItem> = {}): ResourceI
   ...overrides,
 });
 
+const cache = new Map<string, unknown>();
+
 beforeEach(() => {
   vi.clearAllMocks();
+  cache.clear();
+  setScopedMutate((async (key, data) => {
+    const keyString = JSON.stringify(key);
+    if (data === undefined) return cache.get(keyString);
+
+    const nextData = typeof data === 'function' ? await data(cache.get(keyString)) : data;
+    cache.set(keyString, nextData);
+    return nextData;
+  }) as ScopedMutator);
 
   useStore.setState(
     {
@@ -178,14 +192,75 @@ describe('DocumentAction', () => {
     });
   });
 
+  it('keeps updated document detail in the SWR snapshot used on remount', async () => {
+    const { result } = renderHook(() => useStore());
+    const existingDocument = createDocumentFixture();
+    const key = JSON.stringify(documentSWRKeys.fileDetail(existingDocument.id));
+    cache.set(key, existingDocument);
+    vi.mocked(documentService.updateDocument).mockResolvedValue({
+      historyAppended: false,
+      id: existingDocument.id,
+    });
+
+    act(() => {
+      useStore.setState({ documents: [existingDocument] }, false);
+    });
+
+    await act(async () => {
+      await result.current.updateDocument(existingDocument.id, { title: 'Renamed title' });
+    });
+
+    expect(cache.get(key)).toMatchObject({ id: existingDocument.id, title: 'Renamed title' });
+
+    act(() => {
+      useStore.setState({
+        localDocumentMap: new Map([[existingDocument.id, cache.get(key) as LobeDocument]]),
+      });
+    });
+    expect(useStore.getState().localDocumentMap.get(existingDocument.id)).toMatchObject({
+      title: 'Renamed title',
+    });
+  });
+
+  it('keeps deleted document detail out of the SWR snapshot used on remount', async () => {
+    const { result } = renderHook(() => useStore());
+    const existingDocument = createDocumentFixture();
+    const key = JSON.stringify(documentSWRKeys.fileDetail(existingDocument.id));
+    cache.set(key, existingDocument);
+    vi.mocked(documentService.deleteDocument).mockResolvedValue(undefined);
+
+    act(() => {
+      useStore.setState({
+        documents: [existingDocument],
+        localDocumentMap: new Map([[existingDocument.id, existingDocument]]),
+      });
+    });
+
+    await act(async () => {
+      await result.current.removeDocument(existingDocument.id);
+    });
+
+    expect(cache.get(key)).toBeNull();
+
+    act(() => {
+      useStore.setState({ localDocumentMap: new Map() });
+      const hydratedDocument = cache.get(key) as LobeDocument | null;
+      if (hydratedDocument) {
+        useStore.setState({
+          localDocumentMap: new Map([[existingDocument.id, hydratedDocument]]),
+        });
+      }
+    });
+    expect(useStore.getState().localDocumentMap.has(existingDocument.id)).toBe(false);
+  });
+
   it('updates the resource optimistically and clears the marker after sync', async () => {
     const { result } = renderHook(() => useStore());
     const existingDocument = createDocumentFixture();
     const existingResource = createResourceFixture();
 
     let resolveUpdate:
-      | ((value: { historyAppended: boolean; id: string; savedAt?: string }) => void)
-      | undefined;
+      ((value: { historyAppended: boolean; id: string; savedAt?: string }) => void) | undefined;
     vi.mocked(documentService.updateDocument).mockImplementation(
       () =>
         new Promise((resolve) => {

--- a/src/store/file/slices/document/action.ts
+++ b/src/store/file/slices/document/action.ts
@@ -6,8 +6,9 @@ import {
 import { createNanoId } from '@lobechat/utils';
 import { type SWRResponse } from 'swr';
 
-import { useClientDataSWRWithSync } from '@/libs/swr';
+import { mutate, useClientDataSWRWithSync } from '@/libs/swr';
 import { documentService } from '@/services/document';
+import { documentSWRKeys } from '@/services/document/swrKeys';
 import { useGlobalStore } from '@/store/global';
 import { type StoreSetter } from '@/store/types';
 import { type LobeDocument } from '@/types/document';
@@ -570,6 +571,7 @@ export class DocumentActionImpl {
       false,
       n('removeDocument/optimistic'),
     );
+    void mutate(documentSWRKeys.fileDetail(documentId), null, { revalidate: false });
 
     try {
       // Delete from documents table
@@ -587,6 +589,14 @@ export class DocumentActionImpl {
         false,
         n('removeDocument/restore'),
       );
+      const originalDocument =
+        localDocumentMap.get(documentId) ??
+        documents.find((document) => document.id === documentId);
+      if (originalDocument) {
+        void mutate(documentSWRKeys.fileDetail(documentId), originalDocument, {
+          revalidate: false,
+        });
+      }
       throw error;
     }
   };
@@ -630,6 +640,7 @@ export class DocumentActionImpl {
     if (existingDocument) {
       const updatedDocument = this.#createUpdatedDocument(existingDocument, updates);
       this.#setLocalDocument(id, updatedDocument, n('updateDocument'));
+      void mutate(documentSWRKeys.fileDetail(id), updatedDocument, { revalidate: false });
       this.#syncResourceItem(
         this.#createResourceItem(updatedDocument, this.#get().resourceMap.get(id)),
       );
@@ -678,6 +689,7 @@ export class DocumentActionImpl {
 
     // Update local map immediately for optimistic UI
     this.#setLocalDocument(documentId, updatedPage, n('updateDocumentOptimistically'));
+    void mutate(documentSWRKeys.fileDetail(documentId), updatedPage, { revalidate: false });
 
     if (existingResource) {
       this.#syncResourceItem(
@@ -715,6 +727,7 @@ export class DocumentActionImpl {
         revertMap.delete(documentId);
       }
       this.#set({ localDocumentMap: revertMap }, false, n('revertOptimisticUpdate'));
+      void mutate(documentSWRKeys.fileDetail(documentId), existingPage, { revalidate: false });
 
       if (existingResource) {
         this.#syncResourceItem(existingResource);
@@ -723,7 +736,7 @@ export class DocumentActionImpl {
   };
 
   useFetchDocumentDetail = (documentId: string | undefined): SWRResponse<LobeDocument | null> => {
-    const swrKey = documentId ? ['documentDetail', documentId] : null;
+    const swrKey = documentId ? documentSWRKeys.fileDetail(documentId) : null;
 
     return useClientDataSWRWithSync<LobeDocument | null>(
       swrKey,

--- a/src/store/page/slices/crud/action.test.ts
+++ b/src/store/page/slices/crud/action.test.ts
@@ -1,6 +1,6 @@
 import { CUSTOM_DOCUMENT_FILE_TYPE } from '@lobechat/const';
 import { act, renderHook } from '@testing-library/react';
-import type { ScopedMutator } from 'swr/_internal';
+import type { MutatorCallback, ScopedMutator } from 'swr/_internal';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { setScopedMutate } from '@/libs/swr';
@@ -61,7 +61,10 @@ describe('Page mutations', () => {
       const keyString = JSON.stringify(key);
       if (data === undefined) return cache.get(keyString);
 
-      const nextData = typeof data === 'function' ? await data(cache.get(keyString)) : data;
+      const nextData =
+        typeof data === 'function'
+          ? await (data as MutatorCallback<unknown>)(cache.get(keyString))
+          : await data;
       cache.set(keyString, nextData);
       return nextData;
     }) as ScopedMutator);

--- a/src/store/page/slices/crud/action.test.ts
+++ b/src/store/page/slices/crud/action.test.ts
@@ -1,0 +1,236 @@
+import { CUSTOM_DOCUMENT_FILE_TYPE } from '@lobechat/const';
+import { act, renderHook } from '@testing-library/react';
+import type { ScopedMutator } from 'swr/_internal';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { setScopedMutate } from '@/libs/swr';
+import { documentService } from '@/services/document';
+import { documentSWRKeys } from '@/services/document/swrKeys';
+import { initialState } from '@/store/page/initialState';
+import { usePageStore } from '@/store/page/store';
+import { DocumentSourceType, type LobeDocument } from '@/types/document';
+
+vi.mock('zustand/traditional');
+
+vi.mock('@/business/client/hooks/useActiveWorkspaceId', () => ({
+  getActiveWorkspaceId: () => null,
+  useActiveWorkspaceId: () => null,
+}));
+
+vi.mock('@/services/document', () => ({
+  documentService: {
+    createDocument: vi.fn(),
+    deleteDocument: vi.fn(),
+    getDocumentById: vi.fn(),
+    getPageDocuments: vi.fn(),
+    publishDocumentToWorkspace: vi.fn(),
+    setDocumentVisibility: vi.fn(),
+    updateDocument: vi.fn(),
+  },
+}));
+
+const createPage = (
+  id: string,
+  title: string,
+  overrides: Partial<LobeDocument> = {},
+): LobeDocument => ({
+  content: `${title} content`,
+  createdAt: new Date('2026-07-31T00:00:00.000Z'),
+  editorData: {},
+  fileType: CUSTOM_DOCUMENT_FILE_TYPE,
+  filename: title,
+  id,
+  metadata: {},
+  source: 'document',
+  sourceType: DocumentSourceType.EDITOR,
+  title,
+  totalCharCount: title.length,
+  totalLineCount: 1,
+  updatedAt: new Date('2026-07-31T00:00:00.000Z'),
+  ...overrides,
+});
+
+describe('Page mutations', () => {
+  const cache = new Map<string, unknown>();
+  const cacheKey = (key: readonly unknown[]) => JSON.stringify(key);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cache.clear();
+    setScopedMutate((async (key, data) => {
+      const keyString = JSON.stringify(key);
+      if (data === undefined) return cache.get(keyString);
+
+      const nextData = typeof data === 'function' ? await data(cache.get(keyString)) : data;
+      cache.set(keyString, nextData);
+      return nextData;
+    }) as ScopedMutator);
+    usePageStore.setState({ ...initialState, navigate: vi.fn() }, false);
+  });
+
+  it('keeps a deleted page out of list and detail snapshots on remount', async () => {
+    const deletedPage = createPage('page-deleted', 'Deleted');
+    const remainingPage = createPage('page-remaining', 'Remaining');
+    cache.set(cacheKey(documentSWRKeys.pageDocuments()), [deletedPage, remainingPage]);
+    cache.set(cacheKey(documentSWRKeys.pageDetail(deletedPage.id)), deletedPage);
+    vi.mocked(documentService.deleteDocument).mockResolvedValue(undefined);
+
+    usePageStore.setState({ documents: [deletedPage, remainingPage] });
+    const { result } = renderHook(() => usePageStore());
+
+    await act(async () => {
+      await result.current.removePage(deletedPage.id);
+    });
+
+    expect(cache.get(cacheKey(documentSWRKeys.pageDocuments()))).toEqual([remainingPage]);
+    expect(cache.get(cacheKey(documentSWRKeys.pageDetail(deletedPage.id)))).toBeNull();
+
+    usePageStore.setState({
+      documents: cache.get(cacheKey(documentSWRKeys.pageDocuments())) as LobeDocument[],
+    });
+    expect(usePageStore.getState().documents).not.toContainEqual(
+      expect.objectContaining({ id: deletedPage.id }),
+    );
+  });
+
+  it('keeps renamed page metadata in list and detail snapshots on remount', async () => {
+    const oldPage = createPage('page-1', 'Old title', {
+      content: 'Full cached content',
+      metadata: { emoji: 'old' },
+    });
+    const renamedPage = createPage('page-1', 'New title', {
+      content: 'Full cached content',
+      metadata: { emoji: 'new' },
+    });
+    cache.set(cacheKey(documentSWRKeys.pageDocuments()), [oldPage]);
+    cache.set(cacheKey(documentSWRKeys.pageDetail(oldPage.id)), oldPage);
+    vi.mocked(documentService.updateDocument).mockResolvedValue({
+      historyAppended: false,
+      id: oldPage.id,
+    });
+    vi.mocked(documentService.getPageDocuments).mockResolvedValue([renamedPage] as never);
+
+    usePageStore.setState({ documents: [oldPage] });
+    const { result } = renderHook(() => usePageStore());
+
+    await act(async () => {
+      await result.current.updatePageOptimistically(oldPage.id, {
+        emoji: 'new',
+        title: 'New title',
+      });
+    });
+
+    expect(cache.get(cacheKey(documentSWRKeys.pageDocuments()))).toEqual([renamedPage]);
+    expect(cache.get(cacheKey(documentSWRKeys.pageDetail(oldPage.id)))).toMatchObject({
+      content: 'Full cached content',
+      metadata: { emoji: 'new' },
+      title: 'New title',
+    });
+  });
+
+  it('does not replay old metadata when list refresh fails after a successful rename', async () => {
+    const oldPage = createPage('page-1', 'Old title', { metadata: { emoji: 'old' } });
+    cache.set(cacheKey(documentSWRKeys.pageDocuments()), [oldPage]);
+    cache.set(cacheKey(documentSWRKeys.pageDetail(oldPage.id)), oldPage);
+    vi.mocked(documentService.updateDocument).mockResolvedValue({
+      historyAppended: false,
+      id: oldPage.id,
+    });
+    vi.mocked(documentService.getPageDocuments).mockRejectedValue(new Error('refresh failed'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    usePageStore.setState({ documents: [oldPage] });
+    const { result } = renderHook(() => usePageStore());
+
+    await act(async () => {
+      await result.current.updatePageOptimistically(oldPage.id, {
+        emoji: 'new',
+        title: 'New title',
+      });
+    });
+
+    expect(usePageStore.getState().documents?.[0]).toMatchObject({
+      metadata: { emoji: 'new' },
+      title: 'New title',
+    });
+    expect(cache.get(cacheKey(documentSWRKeys.pageDocuments()))).toEqual([
+      expect.objectContaining({ metadata: { emoji: 'new' }, title: 'New title' }),
+    ]);
+    expect(cache.get(cacheKey(documentSWRKeys.pageDetail(oldPage.id)))).toMatchObject({
+      metadata: { emoji: 'new' },
+      title: 'New title',
+    });
+  });
+
+  it('keeps a newly created page in the list snapshot on remount', async () => {
+    const existingPage = createPage('page-existing', 'Existing');
+    const createdPage = createPage('page-created', 'Created');
+    cache.set(cacheKey(documentSWRKeys.pageDocuments()), [existingPage]);
+    vi.mocked(documentService.createDocument).mockResolvedValue(createdPage as never);
+
+    usePageStore.setState({ documents: [existingPage] });
+    const { result } = renderHook(() => usePageStore());
+
+    await act(async () => {
+      await result.current.createNewPage('Created');
+    });
+
+    const cachedDocuments = cache.get(cacheKey(documentSWRKeys.pageDocuments())) as LobeDocument[];
+    expect(cachedDocuments.map((document) => document.id)).toEqual([
+      createdPage.id,
+      existingPage.id,
+    ]);
+
+    usePageStore.setState({ documents: cachedDocuments });
+    expect(usePageStore.getState().documents).toContainEqual(
+      expect.objectContaining({ id: createdPage.id, title: 'Created' }),
+    );
+  });
+
+  it('keeps page moves in list and detail snapshots on remount', async () => {
+    const oldPage = createPage('page-1', 'Page', { parentId: null });
+    const movedPage = createPage('page-1', 'Page', { parentId: 'folder-1' });
+    cache.set(cacheKey(documentSWRKeys.pageDocuments()), [oldPage]);
+    cache.set(cacheKey(documentSWRKeys.pageDetail(oldPage.id)), oldPage);
+    vi.mocked(documentService.updateDocument).mockResolvedValue({
+      historyAppended: false,
+      id: oldPage.id,
+    });
+    vi.mocked(documentService.getPageDocuments).mockResolvedValue([movedPage] as never);
+
+    usePageStore.setState({ documents: [oldPage] });
+    const { result } = renderHook(() => usePageStore());
+
+    await act(async () => {
+      await result.current.updatePage(oldPage.id, { parentId: 'folder-1' });
+    });
+
+    expect(cache.get(cacheKey(documentSWRKeys.pageDocuments()))).toEqual([movedPage]);
+    expect(cache.get(cacheKey(documentSWRKeys.pageDetail(oldPage.id)))).toMatchObject({
+      parentId: 'folder-1',
+    });
+  });
+
+  it('keeps visibility changes in list and detail snapshots on remount', async () => {
+    const publicPage = createPage('page-1', 'Page', { visibility: 'public' });
+    const privatePage = createPage('page-1', 'Page', { visibility: 'private' });
+    cache.set(cacheKey(documentSWRKeys.pageDocuments()), [publicPage]);
+    cache.set(cacheKey(documentSWRKeys.pageDetail(publicPage.id)), publicPage);
+    vi.mocked(documentService.setDocumentVisibility).mockResolvedValue({
+      documentIds: [publicPage.id],
+    });
+    vi.mocked(documentService.getPageDocuments).mockResolvedValue([privatePage] as never);
+
+    usePageStore.setState({ documents: [publicPage] });
+    const { result } = renderHook(() => usePageStore());
+
+    await act(async () => {
+      await result.current.setPageVisibility(publicPage.id, 'private');
+    });
+
+    expect(cache.get(cacheKey(documentSWRKeys.pageDocuments()))).toEqual([privatePage]);
+    expect(cache.get(cacheKey(documentSWRKeys.pageDetail(publicPage.id)))).toMatchObject({
+      visibility: 'private',
+    });
+  });
+});

--- a/src/store/page/slices/crud/action.ts
+++ b/src/store/page/slices/crud/action.ts
@@ -1,7 +1,7 @@
 import { CUSTOM_DOCUMENT_FILE_TYPE } from '@lobechat/const';
 import { type SWRResponse } from 'swr';
 
-import { useClientDataSWRWithSync } from '@/libs/swr';
+import { mutate, useClientDataSWRWithSync } from '@/libs/swr';
 import { documentService } from '@/services/document';
 import { documentSWRKeys } from '@/services/document/swrKeys';
 import { type StoreSetter } from '@/store/types';
@@ -221,6 +221,7 @@ export class CrudActionImpl {
     };
 
     this.#get().internal_dispatchDocuments({ document: editorPage, type: 'addDocument' });
+    this.#get().internal_writeThroughDocumentsCache();
 
     return newPage;
   };
@@ -241,6 +242,8 @@ export class CrudActionImpl {
 
     // Remove from documents array via internal dispatch (optimistic update)
     this.#get().internal_dispatchDocuments({ id: pageId, type: 'removeDocument' });
+    this.#get().internal_writeThroughDocumentsCache();
+    void mutate(documentSWRKeys.pageDetail(pageId), null, { revalidate: false });
 
     // Clear selected page ID if the deleted page is currently selected
     if (selectedPageId === pageId) {
@@ -259,6 +262,11 @@ export class CrudActionImpl {
           documents: originalDocuments,
           type: 'setDocuments',
         });
+        this.#get().internal_writeThroughDocumentsCache();
+        const originalPage = originalDocuments.find((document) => document.id === pageId);
+        if (originalPage) {
+          void mutate(documentSWRKeys.pageDetail(pageId), originalPage, { revalidate: false });
+        }
       }
       if (selectedPageId === pageId) {
         this.#set({ selectedPageId: pageId }, false, n('removePage/restoreSelection'));
@@ -290,6 +298,7 @@ export class CrudActionImpl {
       oldId: tempId,
       type: 'replaceDocument',
     });
+    this.#get().internal_writeThroughDocumentsCache();
   };
 
   updatePage = async (id: string, updates: Partial<LobeDocument>): Promise<void> => {
@@ -305,6 +314,43 @@ export class CrudActionImpl {
       parentId: updates.parentId !== undefined ? updates.parentId : undefined,
       title: updates.title,
     });
+
+    const existingPage = this.#get().documents?.find((document) => document.id === id);
+    if (existingPage) {
+      const updatedPage = {
+        ...existingPage,
+        ...updates,
+        metadata:
+          updates.metadata === undefined
+            ? existingPage.metadata
+            : { ...existingPage.metadata, ...updates.metadata },
+        updatedAt: new Date(),
+      };
+      this.#get().internal_dispatchDocuments({
+        document: updatedPage,
+        id,
+        type: 'updateDocument',
+      });
+      this.#get().internal_writeThroughDocumentsCache();
+    }
+
+    void mutate(
+      documentSWRKeys.pageDetail(id),
+      (document: LobeDocument | null | undefined) => {
+        if (!document) return document;
+
+        return {
+          ...document,
+          ...updates,
+          metadata:
+            updates.metadata === undefined
+              ? document.metadata
+              : { ...document.metadata, ...updates.metadata },
+          updatedAt: new Date(),
+        };
+      },
+      { revalidate: false },
+    );
     await this.#get().refreshDocuments();
   };
 
@@ -343,8 +389,21 @@ export class CrudActionImpl {
       id: pageId,
       type: 'updateDocument',
     });
+    this.#get().internal_writeThroughDocumentsCache();
+    void mutate(
+      documentSWRKeys.pageDetail(pageId),
+      (document: LobeDocument | null | undefined) =>
+        document
+          ? {
+              ...document,
+              metadata: updatedPage.metadata,
+              title: updatedPage.title,
+              updatedAt: updatedPage.updatedAt,
+            }
+          : document,
+      { revalidate: false },
+    );
 
-    // Queue background sync to DB
     try {
       await documentService.updateDocument({
         id: pageId,
@@ -352,17 +411,38 @@ export class CrudActionImpl {
         parentId: updatedPage.parentId || undefined,
         title: updatedPage.title || updatedPage.filename,
       });
-
-      // After successful sync, refresh document list to get server state
-      await this.#get().refreshDocuments();
     } catch (error) {
       console.error('[updatePageOptimistically] Failed to sync to DB:', error);
-      // On error, revert by restoring original page
       this.#get().internal_dispatchDocuments({
         document: existingPage,
         id: pageId,
         type: 'updateDocument',
       });
+      this.#get().internal_writeThroughDocumentsCache();
+      void mutate(
+        documentSWRKeys.pageDetail(pageId),
+        (document: LobeDocument | null | undefined) =>
+          document
+            ? {
+                ...document,
+                metadata: existingPage.metadata,
+                title: existingPage.title,
+                updatedAt: existingPage.updatedAt,
+              }
+            : document,
+        { revalidate: false },
+      );
+      return;
+    }
+
+    /**
+     * A refresh failure must not roll back a server-confirmed mutation. Keep the
+     * submitted snapshot in Zustand and SWR until a later revalidation succeeds.
+     */
+    try {
+      await this.#get().refreshDocuments();
+    } catch (error) {
+      console.error('[updatePageOptimistically] Failed to refresh documents:', error);
     }
   };
 

--- a/src/store/page/slices/list/action.ts
+++ b/src/store/page/slices/list/action.ts
@@ -2,7 +2,7 @@ import { CUSTOM_DOCUMENT_FILE_TYPE } from '@lobechat/const';
 import { type DocumentItem } from '@lobechat/database/schemas';
 import { type SWRResponse } from 'swr';
 
-import { useClientDataSWRWithSync } from '@/libs/swr';
+import { mutate, useClientDataSWRWithSync } from '@/libs/swr';
 import { documentService } from '@/services/document';
 import { documentSWRKeys } from '@/services/document/swrKeys';
 import { useGlobalStore } from '@/store/global';
@@ -62,6 +62,33 @@ export class ListActionImpl {
     this.#get = get;
   }
 
+  #writeThroughVisibilityCaches = (
+    documentIds: string[],
+    visibility: 'private' | 'public',
+  ): void => {
+    const documentIdSet = new Set(documentIds);
+    const { documents } = this.#get();
+    if (documents) {
+      const nextDocuments = documents.map((document) =>
+        documentIdSet.has(document.id) ? { ...document, visibility } : document,
+      );
+      this.#get().internal_dispatchDocuments({
+        documents: nextDocuments,
+        type: 'setDocuments',
+      });
+      this.internal_writeThroughDocumentsCache();
+    }
+
+    for (const documentId of documentIds) {
+      void mutate(
+        documentSWRKeys.pageDetail(documentId),
+        (document: LobeDocument | null | undefined) =>
+          document ? { ...document, visibility } : document,
+        { revalidate: false },
+      );
+    }
+  };
+
   fetchDocuments = async (): Promise<void> => {
     try {
       const pageSize = useGlobalStore.getState().status.pagePageSize || 20;
@@ -85,6 +112,7 @@ export class ListActionImpl {
         false,
         n('fetchDocuments/success'),
       );
+      this.internal_writeThroughDocumentsCache(documents);
     } catch (error) {
       console.error('Failed to fetch documents:', error);
       throw error;
@@ -140,6 +168,19 @@ export class ListActionImpl {
   };
 
   /**
+   * Keep the persisted first-page SWR snapshot aligned with the Zustand mirror.
+   * Otherwise a route remount can hydrate an older list before revalidation.
+   */
+  internal_writeThroughDocumentsCache = (documents = this.#get().documents): void => {
+    if (!documents) return;
+
+    const pageSize = useGlobalStore.getState().status.pagePageSize || 20;
+    void mutate(documentSWRKeys.pageDocuments(), documents.slice(0, pageSize), {
+      revalidate: false,
+    });
+  };
+
+  /**
    * Publish a private page (and its whole subtree) to the workspace, then
    * refetch the sidebar so the item hops from the "Private" accordion into
    * "Workspace" immediately. Errors bubble up so the caller can surface a
@@ -147,6 +188,7 @@ export class ListActionImpl {
    */
   publishPageToWorkspace = async (pageId: string): Promise<{ documentIds: string[] }> => {
     const result = await documentService.publishDocumentToWorkspace(pageId);
+    this.#writeThroughVisibilityCaches(result.documentIds, 'public');
     await this.#get().refreshDocuments();
     return result;
   };
@@ -161,6 +203,7 @@ export class ListActionImpl {
     visibility: 'private' | 'public',
   ): Promise<{ documentIds: string[] }> => {
     const result = await documentService.setDocumentVisibility(pageId, visibility);
+    this.#writeThroughVisibilityCaches(result.documentIds, visibility);
     await this.#get().refreshDocuments();
     return result;
   };


### PR DESCRIPTION
Keep persisted SWR snapshots aligned with their Zustand mirrors after successful mutations so route remounts cannot replay stale data.

This covers page list/detail mutations, document editor saves, agent metadata updates, and file document detail updates/deletions.

#### Key Decisions / Non-goals

- Reuse the existing scoped `mutate` wrapper so mutation keys receive the same workspace augmentation as SWR subscribers.
- Write through the exact list/detail/editor/config keys that hydrate each store instead of adding a new cache abstraction.
- Keep optimistic rollback symmetric across Zustand and SWR, while preserving server-confirmed values if a later list refresh fails.
- No persistence schema, migration, or generic SWR provider behavior changes are included.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check lobehub/src/libs/swr/mutate.test.ts lobehub/src/services/document/swrKeys.ts lobehub/src/store/page/slices/list/action.ts lobehub/src/store/page/slices/crud/action.ts lobehub/src/store/page/slices/crud/action.test.ts lobehub/src/store/document/slices/editor/action.ts lobehub/src/store/document/slices/editor/action.test.ts lobehub/src/store/agent/slices/agent/action.ts lobehub/src/store/agent/slices/agent/action.test.ts lobehub/src/store/file/slices/document/action.ts lobehub/src/store/file/slices/document/action.test.ts --lint --test --type
```

Result: 11 files lint clean, 100 tests passed, types clean.

Isolated cross-route browser verification remains pending because the local dev server repeatedly hit `Watchpack Error (watcher): Error: EMFILE: too many open files, watch`. Production was not used as a substitute.

#### 🔗 Related Issue

Related to [LOBE-12604](https://linear.app/lobehub/issue/LOBE-12604/统一修复-zustand-swr-镜像状态-mutation-后的旧缓存回放)
