### PR TITLE
🐛 fix: guard OIDC account session consistency

### DIFF
--- a/apps/server/src/services/oidc/accountGuard.test.ts
+++ b/apps/server/src/services/oidc/accountGuard.test.ts
@@ -75,7 +75,7 @@ describe('guardOIDCAuthorizationAccount', () => {
     expect(getServerDB).toHaveBeenCalledOnce();
   });
 
-  it.each(['dangling_session', 'invalid_cookie'] as const)(
+  it.each(['dangling_session', 'expired_session', 'invalid_cookie'] as const)(
     'recovers a stale %s without requiring an application session',
     async (reason) => {
       vi.mocked(getUserAuth).mockResolvedValueOnce({ betterAuth: null, userId: undefined });

--- a/apps/server/src/services/oidc/accountGuard.test.ts
+++ b/apps/server/src/services/oidc/accountGuard.test.ts
@@ -27,7 +27,7 @@ const serverDB = { id: 'server-db' } as unknown as LobeChatDatabase;
 describe('guardOIDCAuthorizationAccount', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(getUserAuth).mockResolvedValue({ betterAuth: undefined, userId: 'user-b' });
+    vi.mocked(getUserAuth).mockResolvedValue({ betterAuth: null, userId: 'user-b' });
     vi.mocked(getServerDB).mockResolvedValue(serverDB);
   });
 
@@ -48,7 +48,7 @@ describe('guardOIDCAuthorizationAccount', () => {
   });
 
   it('reports a missing application session before reading OIDC state', async () => {
-    vi.mocked(getUserAuth).mockResolvedValueOnce({ betterAuth: undefined, userId: undefined });
+    vi.mocked(getUserAuth).mockResolvedValueOnce({ betterAuth: null, userId: undefined });
 
     const result = await guardOIDCAuthorizationAccount({
       getCookie: vi.fn(),

--- a/apps/server/src/services/oidc/accountGuard.test.ts
+++ b/apps/server/src/services/oidc/accountGuard.test.ts
@@ -48,6 +48,8 @@ describe('guardOIDCAuthorizationAccount', () => {
   });
 
   it('allows first-time authorization without an OIDC session', async () => {
+    vi.mocked(reconcileCurrentOIDCSession).mockResolvedValueOnce({ status: 'missing' });
+
     const result = await guardOIDCAuthorizationAccount({
       getCookie: vi.fn(() => null),
       pathname: '/oidc/auth',
@@ -55,12 +57,13 @@ describe('guardOIDCAuthorizationAccount', () => {
     });
 
     expect(result).toEqual({ path: 'authorization', status: 'missing' });
-    expect(getUserAuth).not.toHaveBeenCalled();
-    expect(getServerDB).not.toHaveBeenCalled();
+    expect(getUserAuth).toHaveBeenCalledOnce();
+    expect(getServerDB).toHaveBeenCalledOnce();
   });
 
-  it('reports a missing application session before reading OIDC state', async () => {
+  it('blocks an existing OIDC session when the application session is missing', async () => {
     vi.mocked(getUserAuth).mockResolvedValueOnce({ betterAuth: null, userId: undefined });
+    vi.mocked(reconcileCurrentOIDCSession).mockResolvedValueOnce({ status: 'unverified' });
 
     const result = await guardOIDCAuthorizationAccount({
       getCookie: vi.fn((name) => (name === '_session' ? 'oidc-session-a' : null)),
@@ -69,8 +72,27 @@ describe('guardOIDCAuthorizationAccount', () => {
     });
 
     expect(result).toEqual({ path: 'authorization', status: 'missing_app_session' });
-    expect(getServerDB).not.toHaveBeenCalled();
+    expect(getServerDB).toHaveBeenCalledOnce();
   });
+
+  it.each(['dangling_session', 'invalid_cookie'] as const)(
+    'recovers a stale %s without requiring an application session',
+    async (reason) => {
+      vi.mocked(getUserAuth).mockResolvedValueOnce({ betterAuth: null, userId: undefined });
+      vi.mocked(reconcileCurrentOIDCSession).mockResolvedValueOnce({
+        reason,
+        status: 'recovered',
+      });
+
+      const result = await guardOIDCAuthorizationAccount({
+        getCookie: vi.fn(),
+        pathname: '/oidc/auth',
+        provider,
+      });
+
+      expect(result).toEqual({ path: 'authorization', reason, status: 'recovered' });
+    },
+  );
 
   it('reconciles the persisted session at authorization entry', async () => {
     vi.mocked(reconcileCurrentOIDCSession).mockResolvedValueOnce({

--- a/apps/server/src/services/oidc/accountGuard.test.ts
+++ b/apps/server/src/services/oidc/accountGuard.test.ts
@@ -137,4 +137,33 @@ describe('guardOIDCAuthorizationAccount', () => {
     );
     expect(getServerDB).not.toHaveBeenCalled();
   });
+
+  it('lets oidc-provider handle an expired authorization interaction', async () => {
+    const error = new Error('invalid_request');
+    error.name = 'SessionNotFound';
+    vi.spyOn(OIDCService.prototype, 'reconcileInteractionAccount').mockRejectedValueOnce(error);
+
+    const result = await guardOIDCAuthorizationAccount({
+      getCookie: vi.fn(),
+      pathname: '/oidc/auth/interaction-1',
+      provider,
+    });
+
+    expect(result).toEqual({ path: 'resume', status: 'missing_interaction' });
+    expect(getServerDB).not.toHaveBeenCalled();
+  });
+
+  it('propagates unexpected interaction reconciliation errors', async () => {
+    vi.spyOn(OIDCService.prototype, 'reconcileInteractionAccount').mockRejectedValueOnce(
+      new Error('database unavailable'),
+    );
+
+    await expect(
+      guardOIDCAuthorizationAccount({
+        getCookie: vi.fn(),
+        pathname: '/oidc/auth/interaction-1',
+        provider,
+      }),
+    ).rejects.toThrow('database unavailable');
+  });
 });

--- a/apps/server/src/services/oidc/accountGuard.test.ts
+++ b/apps/server/src/services/oidc/accountGuard.test.ts
@@ -47,11 +47,23 @@ describe('guardOIDCAuthorizationAccount', () => {
     expect(getServerDB).not.toHaveBeenCalled();
   });
 
+  it('allows first-time authorization without an OIDC session', async () => {
+    const result = await guardOIDCAuthorizationAccount({
+      getCookie: vi.fn(() => null),
+      pathname: '/oidc/auth',
+      provider,
+    });
+
+    expect(result).toEqual({ path: 'authorization', status: 'missing' });
+    expect(getUserAuth).not.toHaveBeenCalled();
+    expect(getServerDB).not.toHaveBeenCalled();
+  });
+
   it('reports a missing application session before reading OIDC state', async () => {
     vi.mocked(getUserAuth).mockResolvedValueOnce({ betterAuth: null, userId: undefined });
 
     const result = await guardOIDCAuthorizationAccount({
-      getCookie: vi.fn(),
+      getCookie: vi.fn((name) => (name === '_session' ? 'oidc-session-a' : null)),
       pathname: '/oidc/auth',
       provider,
     });
@@ -65,7 +77,7 @@ describe('guardOIDCAuthorizationAccount', () => {
       reason: 'account_mismatch',
       status: 'recovered',
     });
-    const getCookie = vi.fn();
+    const getCookie = vi.fn((name) => (name === '_session' ? 'oidc-session-a' : null));
 
     const result = await guardOIDCAuthorizationAccount({
       getCookie,

--- a/apps/server/src/services/oidc/accountGuard.test.ts
+++ b/apps/server/src/services/oidc/accountGuard.test.ts
@@ -1,0 +1,106 @@
+import type { LobeChatDatabase } from '@lobechat/database';
+import { getServerDB } from '@lobechat/database';
+import { getUserAuth } from '@lobechat/utils/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { OIDCProvider } from '@/libs/oidc-provider/provider';
+import { reconcileCurrentOIDCSession } from '@/libs/oidc-provider/session-cleanup';
+
+import { OIDCService } from '.';
+import { guardOIDCAuthorizationAccount } from './accountGuard';
+
+vi.mock('@lobechat/database', () => ({
+  getServerDB: vi.fn(),
+}));
+
+vi.mock('@lobechat/utils/server', () => ({
+  getUserAuth: vi.fn(),
+}));
+
+vi.mock('@/libs/oidc-provider/session-cleanup', () => ({
+  reconcileCurrentOIDCSession: vi.fn(),
+}));
+
+const provider = { id: 'provider' } as unknown as OIDCProvider;
+const serverDB = { id: 'server-db' } as unknown as LobeChatDatabase;
+
+describe('guardOIDCAuthorizationAccount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getUserAuth).mockResolvedValue({ betterAuth: undefined, userId: 'user-b' });
+    vi.mocked(getServerDB).mockResolvedValue(serverDB);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('ignores requests outside the authorization flow', async () => {
+    const result = await guardOIDCAuthorizationAccount({
+      getCookie: vi.fn(),
+      pathname: '/oidc/token',
+      provider,
+    });
+
+    expect(result).toBeNull();
+    expect(getUserAuth).not.toHaveBeenCalled();
+    expect(getServerDB).not.toHaveBeenCalled();
+  });
+
+  it('reports a missing application session before reading OIDC state', async () => {
+    vi.mocked(getUserAuth).mockResolvedValueOnce({ betterAuth: undefined, userId: undefined });
+
+    const result = await guardOIDCAuthorizationAccount({
+      getCookie: vi.fn(),
+      pathname: '/oidc/auth',
+      provider,
+    });
+
+    expect(result).toEqual({ path: 'authorization', status: 'missing_app_session' });
+    expect(getServerDB).not.toHaveBeenCalled();
+  });
+
+  it('reconciles the persisted session at authorization entry', async () => {
+    vi.mocked(reconcileCurrentOIDCSession).mockResolvedValueOnce({
+      reason: 'account_mismatch',
+      status: 'recovered',
+    });
+    const getCookie = vi.fn();
+
+    const result = await guardOIDCAuthorizationAccount({
+      getCookie,
+      pathname: '/oidc/auth',
+      provider,
+    });
+
+    expect(result).toEqual({
+      path: 'authorization',
+      reason: 'account_mismatch',
+      status: 'recovered',
+    });
+    expect(reconcileCurrentOIDCSession).toHaveBeenCalledWith(serverDB, 'user-b', { getCookie });
+  });
+
+  it('replaces a mismatched account when authorization resumes', async () => {
+    vi.spyOn(OIDCService.prototype, 'reconcileInteractionAccount').mockResolvedValueOnce(
+      'recovered',
+    );
+
+    const result = await guardOIDCAuthorizationAccount({
+      getCookie: vi.fn(),
+      pathname: '/oidc/auth/interaction-1',
+      provider,
+    });
+
+    expect(result).toEqual({
+      path: 'resume',
+      reason: 'account_mismatch',
+      status: 'recovered',
+    });
+    expect(OIDCService.prototype.reconcileInteractionAccount).toHaveBeenCalledWith(
+      'interaction-1',
+      'user-b',
+    );
+    expect(getServerDB).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/services/oidc/accountGuard.ts
+++ b/apps/server/src/services/oidc/accountGuard.ts
@@ -1,7 +1,6 @@
 import { getServerDB } from '@lobechat/database';
 import { getUserAuth } from '@lobechat/utils/server';
 
-import { OIDC_SESSION_COOKIE_NAME } from '@/libs/oidc-provider/cookies';
 import type { OIDCProvider } from '@/libs/oidc-provider/provider';
 import type { OIDCSessionReconciliationResult } from '@/libs/oidc-provider/session-cleanup';
 import { reconcileCurrentOIDCSession } from '@/libs/oidc-provider/session-cleanup';
@@ -54,14 +53,11 @@ export const guardOIDCAuthorizationAccount = async ({
   const stage = getAuthorizationStage(pathname);
   if (!stage) return null;
 
-  if (stage.name === 'authorization' && !getCookie(OIDC_SESSION_COOKIE_NAME)) {
-    return { path: stage.name, status: 'missing' };
-  }
-
   const { userId } = await getUserAuth();
-  if (!userId) return { path: stage.name, status: 'missing_app_session' };
 
   if (stage.name === 'resume') {
+    if (!userId) return { path: stage.name, status: 'missing_app_session' };
+
     const status = await new OIDCService(provider).reconcileInteractionAccount(stage.uid, userId);
 
     return status === 'recovered'
@@ -71,6 +67,10 @@ export const guardOIDCAuthorizationAccount = async ({
 
   const db = await getServerDB();
   const result = await reconcileCurrentOIDCSession(db, userId, { getCookie });
+
+  if (result.status === 'unverified') {
+    return { path: stage.name, status: 'missing_app_session' };
+  }
 
   return { path: stage.name, ...result };
 };

--- a/apps/server/src/services/oidc/accountGuard.ts
+++ b/apps/server/src/services/oidc/accountGuard.ts
@@ -19,7 +19,7 @@ type OIDCRecoveryReason = Extract<
 type OIDCAccountGuardResult =
   | {
       path: OIDCAccountGuardPath;
-      status: 'matched' | 'missing' | 'missing_app_session';
+      status: 'matched' | 'missing' | 'missing_app_session' | 'missing_interaction';
     }
   | {
       path: OIDCAccountGuardPath;
@@ -58,11 +58,22 @@ export const guardOIDCAuthorizationAccount = async ({
   if (stage.name === 'resume') {
     if (!userId) return { path: stage.name, status: 'missing_app_session' };
 
-    const status = await new OIDCService(provider).reconcileInteractionAccount(stage.uid, userId);
+    try {
+      const status = await new OIDCService(provider).reconcileInteractionAccount(stage.uid, userId);
 
-    return status === 'recovered'
-      ? { path: stage.name, reason: 'account_mismatch', status }
-      : { path: stage.name, status };
+      return status === 'recovered'
+        ? { path: stage.name, reason: 'account_mismatch', status }
+        : { path: stage.name, status };
+    } catch (error) {
+      /**
+       * An expired interaction is a normal browser timeout. The provider callback owns its
+       * standard invalid-request response, so it must not become an account-guard outage.
+       */
+      if (error instanceof Error && error.name === 'SessionNotFound') {
+        return { path: stage.name, status: 'missing_interaction' };
+      }
+      throw error;
+    }
   }
 
   const db = await getServerDB();

--- a/apps/server/src/services/oidc/accountGuard.ts
+++ b/apps/server/src/services/oidc/accountGuard.ts
@@ -1,0 +1,71 @@
+import { getServerDB } from '@lobechat/database';
+import { getUserAuth } from '@lobechat/utils/server';
+
+import type { OIDCProvider } from '@/libs/oidc-provider/provider';
+import type { OIDCSessionReconciliationResult } from '@/libs/oidc-provider/session-cleanup';
+import { reconcileCurrentOIDCSession } from '@/libs/oidc-provider/session-cleanup';
+
+import { OIDCService } from '.';
+
+const AUTHORIZATION_PATH = /^\/oidc\/auth\/?$/;
+const AUTHORIZATION_RESUME_PATH = /^\/oidc\/auth\/([^/]+)\/?$/;
+
+type OIDCAccountGuardPath = 'authorization' | 'resume';
+type OIDCRecoveryReason = Extract<
+  OIDCSessionReconciliationResult,
+  { status: 'recovered' }
+>['reason'];
+
+type OIDCAccountGuardResult =
+  | {
+      path: OIDCAccountGuardPath;
+      status: 'matched' | 'missing' | 'missing_app_session';
+    }
+  | {
+      path: OIDCAccountGuardPath;
+      reason: OIDCRecoveryReason;
+      status: 'recovered';
+    };
+
+interface GuardOIDCAuthorizationAccountParams {
+  getCookie: (name: string) => string | null;
+  pathname: string;
+  provider: OIDCProvider;
+}
+
+type AuthorizationStage = { name: 'authorization' } | { name: 'resume'; uid: string };
+
+const getAuthorizationStage = (pathname: string): AuthorizationStage | null => {
+  if (AUTHORIZATION_PATH.test(pathname)) return { name: 'authorization' };
+
+  const resumeMatch = AUTHORIZATION_RESUME_PATH.exec(pathname);
+  return resumeMatch ? { name: 'resume', uid: resumeMatch[1] } : null;
+};
+
+/**
+ * Verifies that the active application account owns the OIDC authorization session.
+ */
+export const guardOIDCAuthorizationAccount = async ({
+  getCookie,
+  pathname,
+  provider,
+}: GuardOIDCAuthorizationAccountParams): Promise<OIDCAccountGuardResult | null> => {
+  const stage = getAuthorizationStage(pathname);
+  if (!stage) return null;
+
+  const { userId } = await getUserAuth();
+  if (!userId) return { path: stage.name, status: 'missing_app_session' };
+
+  if (stage.name === 'resume') {
+    const status = await new OIDCService(provider).reconcileInteractionAccount(stage.uid, userId);
+
+    return status === 'recovered'
+      ? { path: stage.name, reason: 'account_mismatch', status }
+      : { path: stage.name, status };
+  }
+
+  const db = await getServerDB();
+  const result = await reconcileCurrentOIDCSession(db, userId, { getCookie });
+
+  return { path: stage.name, ...result };
+};

--- a/apps/server/src/services/oidc/accountGuard.ts
+++ b/apps/server/src/services/oidc/accountGuard.ts
@@ -1,6 +1,7 @@
 import { getServerDB } from '@lobechat/database';
 import { getUserAuth } from '@lobechat/utils/server';
 
+import { OIDC_SESSION_COOKIE_NAME } from '@/libs/oidc-provider/cookies';
 import type { OIDCProvider } from '@/libs/oidc-provider/provider';
 import type { OIDCSessionReconciliationResult } from '@/libs/oidc-provider/session-cleanup';
 import { reconcileCurrentOIDCSession } from '@/libs/oidc-provider/session-cleanup';
@@ -52,6 +53,10 @@ export const guardOIDCAuthorizationAccount = async ({
 }: GuardOIDCAuthorizationAccountParams): Promise<OIDCAccountGuardResult | null> => {
   const stage = getAuthorizationStage(pathname);
   if (!stage) return null;
+
+  if (stage.name === 'authorization' && !getCookie(OIDC_SESSION_COOKIE_NAME)) {
+    return { path: stage.name, status: 'missing' };
+  }
 
   const { userId } = await getUserAuth();
   if (!userId) return { path: stage.name, status: 'missing_app_session' };

--- a/apps/server/src/services/oidc/index.test.ts
+++ b/apps/server/src/services/oidc/index.test.ts
@@ -134,6 +134,45 @@ describe('OIDCService', () => {
     );
   });
 
+  it('reconcileInteractionAccount should replace a mismatched result with a login result', async () => {
+    const provider = createMockProvider();
+    provider.interactionDetails.mockResolvedValue({
+      session: { accountId: 'account-a' },
+    });
+    provider.interactionResult.mockResolvedValue('/oidc/auth/uid-4');
+    vi.mocked(createContextForInteractionDetails).mockResolvedValue({
+      req: { id: 'req' },
+      res: { id: 'res' },
+    } as any);
+
+    const service = new OIDCService(provider as any);
+    const result = await service.reconcileInteractionAccount('uid-4', 'account-b');
+
+    expect(result).toBe('recovered');
+    expect(provider.interactionResult).toHaveBeenCalledWith(
+      { id: 'req' },
+      { id: 'res' },
+      { login: { accountId: 'account-b', remember: true } },
+    );
+  });
+
+  it('reconcileInteractionAccount should preserve a matching interaction', async () => {
+    const provider = createMockProvider();
+    provider.interactionDetails.mockResolvedValue({
+      session: { accountId: 'account-a' },
+    });
+    vi.mocked(createContextForInteractionDetails).mockResolvedValue({
+      req: { id: 'req' },
+      res: { id: 'res' },
+    } as any);
+
+    const service = new OIDCService(provider as any);
+    const result = await service.reconcileInteractionAccount('uid-5', 'account-a');
+
+    expect(result).toBe('matched');
+    expect(provider.interactionResult).not.toHaveBeenCalled();
+  });
+
   it('findOrCreateGrants should reuse existing matching grant', async () => {
     const provider = createMockProvider();
     const existingGrant = { accountId: 'account-1', clientId: 'client-1' };
@@ -147,7 +186,7 @@ describe('OIDCService', () => {
     expect(grant).toBe(existingGrant);
   });
 
-  it('findOrCreateGrants should destroy mismatched grant and create a new one', async () => {
+  it('findOrCreateGrants should reject an account mismatch without destroying the grant', async () => {
     const provider = createMockProvider();
     const staleGrant = {
       accountId: 'other-account',
@@ -156,15 +195,13 @@ describe('OIDCService', () => {
     };
     provider.Grant.find.mockResolvedValue(staleGrant as any);
 
-    const createdGrant = { accountId: 'account-2', clientId: 'client-1' };
-    provider.Grant.mockImplementation(() => createdGrant as any);
-
     const service = new OIDCService(provider as any);
-    const grant = await service.findOrCreateGrants('account-2', 'client-1', 'grant-2');
+    await expect(service.findOrCreateGrants('account-2', 'client-1', 'grant-2')).rejects.toThrow(
+      'OIDC grant account does not match the authorization session',
+    );
 
-    expect(staleGrant.destroy).toHaveBeenCalledTimes(1);
-    expect(provider.Grant).toHaveBeenCalledWith({ accountId: 'account-2', clientId: 'client-1' });
-    expect(grant).toBe(createdGrant);
+    expect(staleGrant.destroy).not.toHaveBeenCalled();
+    expect(provider.Grant).not.toHaveBeenCalled();
   });
 
   it('findOrCreateGrants should create new grant when no existing id is provided', async () => {
@@ -194,7 +231,7 @@ describe('OIDCService', () => {
     expect(grant).toBe(createdGrant);
   });
 
-  it('findOrCreateGrants should recreate grant if client mismatch occurs', async () => {
+  it('findOrCreateGrants should reject a client mismatch without destroying the grant', async () => {
     const provider = createMockProvider();
     const staleGrant = {
       accountId: 'account-5',
@@ -203,39 +240,13 @@ describe('OIDCService', () => {
     };
     provider.Grant.find.mockResolvedValue(staleGrant as any);
 
-    const createdGrant = { accountId: 'account-5', clientId: 'client-5' };
-    provider.Grant.mockImplementation(() => createdGrant as any);
-
     const service = new OIDCService(provider as any);
-    const grant = await service.findOrCreateGrants(
-      'account-5',
-      'client-5',
-      'grant-client-mismatch',
-    );
+    await expect(
+      service.findOrCreateGrants('account-5', 'client-5', 'grant-client-mismatch'),
+    ).rejects.toThrow('OIDC grant client does not match the authorization request');
 
-    expect(staleGrant.destroy).toHaveBeenCalledTimes(1);
-    expect(provider.Grant).toHaveBeenCalledWith({ accountId: 'account-5', clientId: 'client-5' });
-    expect(grant).toBe(createdGrant);
-  });
-
-  it('findOrCreateGrants should continue when destroy throws during mismatch cleanup', async () => {
-    const provider = createMockProvider();
-    const staleGrant = {
-      accountId: 'wrong-account',
-      clientId: 'client-6',
-      destroy: vi.fn().mockRejectedValue(new Error('destroy failed')),
-    };
-    provider.Grant.find.mockResolvedValue(staleGrant as any);
-
-    const createdGrant = { accountId: 'account-6', clientId: 'client-6' };
-    provider.Grant.mockImplementation(() => createdGrant as any);
-
-    const service = new OIDCService(provider as any);
-    const grant = await service.findOrCreateGrants('account-6', 'client-6', 'grant-error');
-
-    expect(staleGrant.destroy).toHaveBeenCalledTimes(1);
-    expect(provider.Grant).toHaveBeenCalledWith({ accountId: 'account-6', clientId: 'client-6' });
-    expect(grant).toBe(createdGrant);
+    expect(staleGrant.destroy).not.toHaveBeenCalled();
+    expect(provider.Grant).not.toHaveBeenCalled();
   });
 
   it('getClientMetadata should return metadata from client lookup', async () => {

--- a/apps/server/src/services/oidc/index.ts
+++ b/apps/server/src/services/oidc/index.ts
@@ -48,6 +48,23 @@ export class OIDCService {
     return this.provider.interactionFinished(req, res, result, { mergeWithLastSubmission: true });
   }
 
+  async reconcileInteractionAccount(uid: string, accountId: string) {
+    const details = await this.getInteractionDetails(uid);
+    const interactionAccountId = details.session?.accountId;
+
+    if (!interactionAccountId) return 'missing';
+    if (interactionAccountId === accountId) return 'matched';
+
+    /**
+     * Replacing a stale consent result with a login result delegates account switching to
+     * oidc-provider's resume and end-session flow before it loads an account-bound grant.
+     */
+    await this.getInteractionResult(uid, {
+      login: { accountId, remember: true },
+    });
+    return 'recovered';
+  }
+
   async findOrCreateGrants(accountId: string, clientId: string, existingGrantId?: string) {
     // 2. Find or create Grant object
     let grant;
@@ -56,25 +73,16 @@ export class OIDCService {
       grant = await this.provider.Grant.find(existingGrantId);
       log('Found existing grantId: %s', existingGrantId);
       if (grant) {
-        const accountMismatch = grant.accountId && grant.accountId !== accountId;
-        const clientMismatch = grant.clientId && grant.clientId !== clientId;
-
-        if (accountMismatch || clientMismatch) {
-          log(
-            'Discarding stale grant %s due to mismatch (stored account=%s, client=%s; expected account=%s, client=%s)',
-            existingGrantId,
-            grant.accountId,
-            grant.clientId,
-            accountId,
-            clientId,
-          );
-          try {
-            await grant.destroy();
-            log('Destroyed mismatched grant: %s', existingGrantId);
-          } catch (error) {
-            log('Failed to destroy mismatched grant %s: %O', existingGrantId, error);
-          }
-          grant = undefined;
+        /**
+         * An interaction grant is already bound to its account and client. Replacing a mismatched
+         * grant would hide a stale session binding and could destroy another account's grant.
+         * Account recovery must rotate the OIDC session before consent reaches this method.
+         */
+        if (grant.accountId !== accountId) {
+          throw new Error('OIDC grant account does not match the authorization session');
+        }
+        if (grant.clientId !== clientId) {
+          throw new Error('OIDC grant client does not match the authorization request');
         }
       } else {
         log('Existing grantId %s not found in storage, will create a new grant', existingGrantId);

--- a/src/app/(backend)/oidc/[...oidc]/route.test.ts
+++ b/src/app/(backend)/oidc/[...oidc]/route.test.ts
@@ -116,6 +116,29 @@ describe('OIDC route', () => {
     expect(mocks.getOIDCProvider).not.toHaveBeenCalled();
   });
 
+  it('blocks authorization when the application session is missing', async () => {
+    mocks.guardOIDCAuthorizationAccount.mockResolvedValueOnce({
+      path: 'authorization',
+      status: 'missing_app_session',
+    });
+
+    const { GET } = await import('./route');
+    const request = {
+      cookies: { get: vi.fn() },
+      method: 'GET',
+      url: 'https://example.com/oidc/auth?client_id=client-1',
+    } as unknown as NextRequest;
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: 'unauthorized',
+      error_description: 'Authentication is required to continue authorization',
+    });
+    expect(mocks.providerCallback).not.toHaveBeenCalled();
+  });
+
   it('fails closed when the authorization account check fails', async () => {
     mocks.guardOIDCAuthorizationAccount.mockRejectedValueOnce(new Error('auth unavailable'));
     vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/src/app/(backend)/oidc/[...oidc]/route.test.ts
+++ b/src/app/(backend)/oidc/[...oidc]/route.test.ts
@@ -5,13 +5,16 @@ import type { NextRequest } from 'next/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  accountGuardModuleLoaded: vi.fn(),
+  authEnv: {
+    ENABLE_OIDC: true,
+  },
   createNodeRequest: vi.fn(),
   createNodeResponse: vi.fn(),
-  getUserAuth: vi.fn(),
+  getOIDCProvider: vi.fn(),
+  guardOIDCAuthorizationAccount: vi.fn(),
   middleware: vi.fn(),
   providerCallback: vi.fn(),
-  reconcileInteractionAccount: vi.fn(),
-  reconcileCurrentOIDCSession: vi.fn(),
 }));
 
 vi.mock('debug', () => ({
@@ -19,17 +22,7 @@ vi.mock('debug', () => ({
 }));
 
 vi.mock('@/envs/auth', () => ({
-  authEnv: {
-    ENABLE_OIDC: true,
-  },
-}));
-
-vi.mock('@lobechat/database', () => ({
-  serverDB: { id: 'server-db' },
-}));
-
-vi.mock('@lobechat/utils/server', () => ({
-  getUserAuth: mocks.getUserAuth,
+  authEnv: mocks.authEnv,
 }));
 
 vi.mock('@/libs/oidc-provider/http-adapter', () => ({
@@ -37,26 +30,27 @@ vi.mock('@/libs/oidc-provider/http-adapter', () => ({
   createNodeResponse: mocks.createNodeResponse,
 }));
 
-vi.mock('@/libs/oidc-provider/session-cleanup', () => ({
-  reconcileCurrentOIDCSession: mocks.reconcileCurrentOIDCSession,
-}));
-
-vi.mock('@/server/services/oidc', () => ({
-  OIDCService: class {
-    reconcileInteractionAccount = mocks.reconcileInteractionAccount;
-  },
-}));
+vi.mock('@/server/services/oidc/accountGuard', () => {
+  mocks.accountGuardModuleLoaded();
+  return {
+    guardOIDCAuthorizationAccount: mocks.guardOIDCAuthorizationAccount,
+  };
+});
 
 vi.mock('@/server/services/oidc/oidcProvider', () => ({
-  getOIDCProvider: vi.fn(async () => ({
-    callback: mocks.providerCallback,
-  })),
+  getOIDCProvider: mocks.getOIDCProvider,
 }));
 
 describe('OIDC route', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
 
+    mocks.authEnv.ENABLE_OIDC = true;
+    mocks.getOIDCProvider.mockResolvedValue({
+      callback: mocks.providerCallback,
+    });
+    mocks.guardOIDCAuthorizationAccount.mockResolvedValue(null);
     mocks.providerCallback.mockReturnValue(mocks.middleware);
     mocks.middleware.mockImplementation(
       (_request: unknown, _response: unknown, next: (error?: Error) => void) => next(),
@@ -68,18 +62,15 @@ describe('OIDC route', () => {
       responseHeaders: {},
       responseStatus: 200,
     });
-    mocks.getUserAuth.mockResolvedValue({ userId: undefined });
-    mocks.reconcileInteractionAccount.mockResolvedValue('matched');
-    mocks.reconcileCurrentOIDCSession.mockResolvedValue({ status: 'missing' });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('reconciles the current browser session before an authorization request', async () => {
-    mocks.getUserAuth.mockResolvedValueOnce({ userId: 'user-b' });
-    mocks.reconcileCurrentOIDCSession.mockResolvedValueOnce({
+  it('loads the account guard after OIDC is enabled', async () => {
+    mocks.guardOIDCAuthorizationAccount.mockResolvedValueOnce({
+      path: 'authorization',
       reason: 'account_mismatch',
       status: 'recovered',
     });
@@ -98,38 +89,35 @@ describe('OIDC route', () => {
     const response = await GET(request);
 
     expect(response.status).toBe(200);
-    expect(mocks.reconcileCurrentOIDCSession).toHaveBeenCalledWith(
-      { id: 'server-db' },
-      'user-b',
-      expect.objectContaining({ getCookie: expect.any(Function) }),
-    );
-    const cookieReader = mocks.reconcileCurrentOIDCSession.mock.calls[0][2];
-    expect(cookieReader.getCookie('_session')).toBe('oidc-session-a');
+    expect(mocks.accountGuardModuleLoaded).toHaveBeenCalledTimes(1);
+    expect(mocks.guardOIDCAuthorizationAccount).toHaveBeenCalledWith({
+      getCookie: expect.any(Function),
+      pathname: '/oidc/auth',
+      provider: expect.objectContaining({ callback: mocks.providerCallback }),
+    });
+    const { getCookie: readCookie } = mocks.guardOIDCAuthorizationAccount.mock.calls[0][0];
+    expect(readCookie('_session')).toBe('oidc-session-a');
     expect(mocks.middleware).toHaveBeenCalledTimes(1);
   });
 
-  it('replaces a stale interaction result before resuming authorization', async () => {
-    mocks.getUserAuth.mockResolvedValueOnce({ userId: 'user-b' });
-    mocks.reconcileInteractionAccount.mockResolvedValueOnce('recovered');
-    vi.spyOn(console, 'warn').mockImplementation(() => {});
-
+  it('does not load server account dependencies when OIDC is disabled', async () => {
+    mocks.authEnv.ENABLE_OIDC = false;
     const { GET } = await import('./route');
     const request = {
       cookies: { get: vi.fn() },
       method: 'GET',
-      url: 'https://example.com/oidc/auth/interaction-1',
+      url: 'https://example.com/oidc/auth',
     } as unknown as NextRequest;
 
     const response = await GET(request);
 
-    expect(response.status).toBe(200);
-    expect(mocks.reconcileInteractionAccount).toHaveBeenCalledWith('interaction-1', 'user-b');
-    expect(mocks.reconcileCurrentOIDCSession).not.toHaveBeenCalled();
-    expect(mocks.middleware).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(404);
+    expect(mocks.accountGuardModuleLoaded).not.toHaveBeenCalled();
+    expect(mocks.getOIDCProvider).not.toHaveBeenCalled();
   });
 
   it('fails closed when the authorization account check fails', async () => {
-    mocks.getUserAuth.mockRejectedValueOnce(new Error('auth unavailable'));
+    mocks.guardOIDCAuthorizationAccount.mockRejectedValueOnce(new Error('auth unavailable'));
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const { GET } = await import('./route');

--- a/src/app/(backend)/oidc/[...oidc]/route.test.ts
+++ b/src/app/(backend)/oidc/[...oidc]/route.test.ts
@@ -100,6 +100,26 @@ describe('OIDC route', () => {
     expect(mocks.middleware).toHaveBeenCalledTimes(1);
   });
 
+  it('continues first-time authorization without an OIDC session', async () => {
+    mocks.guardOIDCAuthorizationAccount.mockResolvedValueOnce({
+      path: 'authorization',
+      status: 'missing',
+    });
+
+    const { GET } = await import('./route');
+    const request = {
+      cookies: { get: vi.fn() },
+      method: 'GET',
+      url: 'https://example.com/oidc/auth?client_id=client-1',
+    } as unknown as NextRequest;
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(mocks.providerCallback).toHaveBeenCalledTimes(1);
+    expect(mocks.middleware).toHaveBeenCalledTimes(1);
+  });
+
   it('does not load server account dependencies when OIDC is disabled', async () => {
     mocks.authEnv.ENABLE_OIDC = false;
     const { GET } = await import('./route');

--- a/src/app/(backend)/oidc/[...oidc]/route.test.ts
+++ b/src/app/(backend)/oidc/[...oidc]/route.test.ts
@@ -136,7 +136,7 @@ describe('OIDC route', () => {
     expect(mocks.getOIDCProvider).not.toHaveBeenCalled();
   });
 
-  it('blocks authorization when the application session is missing', async () => {
+  it('redirects to sign-in when the application session is missing', async () => {
     mocks.guardOIDCAuthorizationAccount.mockResolvedValueOnce({
       path: 'authorization',
       status: 'missing_app_session',
@@ -151,12 +151,33 @@ describe('OIDC route', () => {
 
     const response = await GET(request);
 
-    expect(response.status).toBe(401);
-    await expect(response.json()).resolves.toEqual({
-      error: 'unauthorized',
-      error_description: 'Authentication is required to continue authorization',
-    });
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe(
+      'https://example.com/signin?callbackUrl=%2Foidc%2Fauth%3Fclient_id%3Dclient-1',
+    );
     expect(mocks.providerCallback).not.toHaveBeenCalled();
+  });
+
+  it('lets oidc-provider render the standard error for an expired interaction', async () => {
+    mocks.guardOIDCAuthorizationAccount.mockResolvedValueOnce({
+      path: 'resume',
+      status: 'missing_interaction',
+    });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { GET } = await import('./route');
+    const request = {
+      cookies: { get: vi.fn() },
+      method: 'GET',
+      url: 'https://example.com/oidc/auth/interaction-1',
+    } as unknown as NextRequest;
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(mocks.providerCallback).toHaveBeenCalledTimes(1);
+    expect(mocks.middleware).toHaveBeenCalledTimes(1);
+    expect(consoleError).not.toHaveBeenCalled();
   });
 
   it('fails closed when the authorization account check fails', async () => {

--- a/src/app/(backend)/oidc/[...oidc]/route.test.ts
+++ b/src/app/(backend)/oidc/[...oidc]/route.test.ts
@@ -2,13 +2,16 @@
  * @vitest-environment node
  */
 import type { NextRequest } from 'next/server';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   createNodeRequest: vi.fn(),
   createNodeResponse: vi.fn(),
+  getUserAuth: vi.fn(),
   middleware: vi.fn(),
   providerCallback: vi.fn(),
+  reconcileInteractionAccount: vi.fn(),
+  reconcileCurrentOIDCSession: vi.fn(),
 }));
 
 vi.mock('debug', () => ({
@@ -21,9 +24,27 @@ vi.mock('@/envs/auth', () => ({
   },
 }));
 
+vi.mock('@lobechat/database', () => ({
+  serverDB: { id: 'server-db' },
+}));
+
+vi.mock('@lobechat/utils/server', () => ({
+  getUserAuth: mocks.getUserAuth,
+}));
+
 vi.mock('@/libs/oidc-provider/http-adapter', () => ({
   createNodeRequest: mocks.createNodeRequest,
   createNodeResponse: mocks.createNodeResponse,
+}));
+
+vi.mock('@/libs/oidc-provider/session-cleanup', () => ({
+  reconcileCurrentOIDCSession: mocks.reconcileCurrentOIDCSession,
+}));
+
+vi.mock('@/server/services/oidc', () => ({
+  OIDCService: class {
+    reconcileInteractionAccount = mocks.reconcileInteractionAccount;
+  },
 }));
 
 vi.mock('@/server/services/oidc/oidcProvider', () => ({
@@ -37,12 +58,95 @@ describe('OIDC route', () => {
     vi.clearAllMocks();
 
     mocks.providerCallback.mockReturnValue(mocks.middleware);
+    mocks.middleware.mockImplementation(
+      (_request: unknown, _response: unknown, next: (error?: Error) => void) => next(),
+    );
+    mocks.createNodeRequest.mockResolvedValue({});
     mocks.createNodeResponse.mockReturnValue({
       nodeResponse: {},
       responseBody: '',
       responseHeaders: {},
       responseStatus: 200,
     });
+    mocks.getUserAuth.mockResolvedValue({ userId: undefined });
+    mocks.reconcileInteractionAccount.mockResolvedValue('matched');
+    mocks.reconcileCurrentOIDCSession.mockResolvedValue({ status: 'missing' });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reconciles the current browser session before an authorization request', async () => {
+    mocks.getUserAuth.mockResolvedValueOnce({ userId: 'user-b' });
+    mocks.reconcileCurrentOIDCSession.mockResolvedValueOnce({
+      reason: 'account_mismatch',
+      status: 'recovered',
+    });
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { GET } = await import('./route');
+    const getCookie = vi.fn((name: string) =>
+      name === '_session' ? { value: 'oidc-session-a' } : undefined,
+    );
+    const request = {
+      cookies: { get: getCookie },
+      method: 'GET',
+      url: 'https://example.com/oidc/auth?client_id=client-1',
+    } as unknown as NextRequest;
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(mocks.reconcileCurrentOIDCSession).toHaveBeenCalledWith(
+      { id: 'server-db' },
+      'user-b',
+      expect.objectContaining({ getCookie: expect.any(Function) }),
+    );
+    const cookieReader = mocks.reconcileCurrentOIDCSession.mock.calls[0][2];
+    expect(cookieReader.getCookie('_session')).toBe('oidc-session-a');
+    expect(mocks.middleware).toHaveBeenCalledTimes(1);
+  });
+
+  it('replaces a stale interaction result before resuming authorization', async () => {
+    mocks.getUserAuth.mockResolvedValueOnce({ userId: 'user-b' });
+    mocks.reconcileInteractionAccount.mockResolvedValueOnce('recovered');
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { GET } = await import('./route');
+    const request = {
+      cookies: { get: vi.fn() },
+      method: 'GET',
+      url: 'https://example.com/oidc/auth/interaction-1',
+    } as unknown as NextRequest;
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(mocks.reconcileInteractionAccount).toHaveBeenCalledWith('interaction-1', 'user-b');
+    expect(mocks.reconcileCurrentOIDCSession).not.toHaveBeenCalled();
+    expect(mocks.middleware).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed when the authorization account check fails', async () => {
+    mocks.getUserAuth.mockRejectedValueOnce(new Error('auth unavailable'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { GET } = await import('./route');
+    const request = {
+      cookies: { get: vi.fn() },
+      method: 'GET',
+      url: 'https://example.com/oidc/auth?client_id=client-1',
+    } as unknown as NextRequest;
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: 'temporarily_unavailable',
+      error_description: 'OIDC authorization is temporarily unavailable',
+    });
+    expect(mocks.providerCallback).not.toHaveBeenCalled();
   });
 
   it('returns a 500 response when creating the Node request fails', async () => {

--- a/src/app/(backend)/oidc/[...oidc]/route.ts
+++ b/src/app/(backend)/oidc/[...oidc]/route.ts
@@ -39,6 +39,16 @@ const handler = async (req: NextRequest) => {
         provider,
       });
 
+      if (reconciliation?.status === 'missing_app_session') {
+        return NextResponse.json(
+          {
+            error: 'unauthorized',
+            error_description: 'Authentication is required to continue authorization',
+          },
+          { status: 401 },
+        );
+      }
+
       if (reconciliation?.status === 'recovered') {
         console.warn(
           `[OIDC Account Guard] recovered path=${reconciliation.path} reason=${reconciliation.reason}`,

--- a/src/app/(backend)/oidc/[...oidc]/route.ts
+++ b/src/app/(backend)/oidc/[...oidc]/route.ts
@@ -1,14 +1,30 @@
 import { URL } from 'node:url';
 
+import { serverDB } from '@lobechat/database';
+import { getUserAuth } from '@lobechat/utils/server';
 import debug from 'debug';
 import { type NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
 import { authEnv } from '@/envs/auth';
 import { createNodeRequest, createNodeResponse } from '@/libs/oidc-provider/http-adapter';
+import { reconcileCurrentOIDCSession } from '@/libs/oidc-provider/session-cleanup';
+import { OIDCService } from '@/server/services/oidc';
 import { getOIDCProvider } from '@/server/services/oidc/oidcProvider';
 
 const log = debug('lobe-oidc:route'); // Create a debug instance with a namespace
+
+const AUTHORIZATION_PATH = /^\/oidc\/auth\/?$/;
+const AUTHORIZATION_RESUME_PATH = /^\/oidc\/auth\/([^/]+)\/?$/;
+
+type AuthorizationStage = { name: 'authorization' } | { name: 'resume'; uid: string };
+
+const getAuthorizationStage = (pathname: string): AuthorizationStage | null => {
+  if (AUTHORIZATION_PATH.test(pathname)) return { name: 'authorization' };
+
+  const resumeMatch = AUTHORIZATION_RESUME_PATH.exec(pathname);
+  return resumeMatch ? { name: 'resume', uid: resumeMatch[1] } : null;
+};
 
 const handler = async (req: NextRequest) => {
   const requestUrl = new URL(req.url);
@@ -26,6 +42,56 @@ const handler = async (req: NextRequest) => {
 
     // Get the OIDC Provider instance
     const provider = await getOIDCProvider();
+
+    const authorizationStage = getAuthorizationStage(requestUrl.pathname);
+    if (authorizationStage) {
+      try {
+        const { userId } = await getUserAuth();
+        if (userId) {
+          const reconciliation =
+            authorizationStage.name === 'authorization'
+              ? await reconcileCurrentOIDCSession(serverDB, userId, {
+                  getCookie: (name) => req.cookies.get(name)?.value ?? null,
+                })
+              : await new OIDCService(provider).reconcileInteractionAccount(
+                  authorizationStage.uid,
+                  userId,
+                );
+
+          if (reconciliation === 'recovered') {
+            console.warn(
+              `[OIDC Account Guard] recovered path=${authorizationStage.name} reason=account_mismatch`,
+            );
+          } else if (typeof reconciliation !== 'string' && reconciliation.status === 'recovered') {
+            console.warn(
+              `[OIDC Account Guard] recovered path=${authorizationStage.name} reason=${reconciliation.reason}`,
+            );
+          } else {
+            const status =
+              typeof reconciliation === 'string' ? reconciliation : reconciliation.status;
+            log('[OIDC Account Guard] %s path=%s', status, authorizationStage.name);
+          }
+        } else {
+          log('[OIDC Account Guard] missing_app_session path=%s', authorizationStage.name);
+        }
+      } catch (error) {
+        /**
+         * An unverified account binding must not reach oidc-provider because a stale session can
+         * otherwise issue a code or token for the previous browser account without an interaction.
+         */
+        console.error(
+          `[OIDC Account Guard] recovery_failed path=${authorizationStage.name}`,
+          error,
+        );
+        return NextResponse.json(
+          {
+            error: 'temporarily_unavailable',
+            error_description: 'OIDC authorization is temporarily unavailable',
+          },
+          { status: 503 },
+        );
+      }
+    }
 
     log(`Calling provider.callback() for ${req.method}`); // Log the method
     await new Promise<void>((resolve, reject) => {

--- a/src/app/(backend)/oidc/[...oidc]/route.ts
+++ b/src/app/(backend)/oidc/[...oidc]/route.ts
@@ -1,30 +1,14 @@
 import { URL } from 'node:url';
 
-import { serverDB } from '@lobechat/database';
-import { getUserAuth } from '@lobechat/utils/server';
 import debug from 'debug';
 import { type NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
 import { authEnv } from '@/envs/auth';
 import { createNodeRequest, createNodeResponse } from '@/libs/oidc-provider/http-adapter';
-import { reconcileCurrentOIDCSession } from '@/libs/oidc-provider/session-cleanup';
-import { OIDCService } from '@/server/services/oidc';
 import { getOIDCProvider } from '@/server/services/oidc/oidcProvider';
 
 const log = debug('lobe-oidc:route'); // Create a debug instance with a namespace
-
-const AUTHORIZATION_PATH = /^\/oidc\/auth\/?$/;
-const AUTHORIZATION_RESUME_PATH = /^\/oidc\/auth\/([^/]+)\/?$/;
-
-type AuthorizationStage = { name: 'authorization' } | { name: 'resume'; uid: string };
-
-const getAuthorizationStage = (pathname: string): AuthorizationStage | null => {
-  if (AUTHORIZATION_PATH.test(pathname)) return { name: 'authorization' };
-
-  const resumeMatch = AUTHORIZATION_RESUME_PATH.exec(pathname);
-  return resumeMatch ? { name: 'resume', uid: resumeMatch[1] } : null;
-};
 
 const handler = async (req: NextRequest) => {
   const requestUrl = new URL(req.url);
@@ -43,54 +27,38 @@ const handler = async (req: NextRequest) => {
     // Get the OIDC Provider instance
     const provider = await getOIDCProvider();
 
-    const authorizationStage = getAuthorizationStage(requestUrl.pathname);
-    if (authorizationStage) {
-      try {
-        const { userId } = await getUserAuth();
-        if (userId) {
-          const reconciliation =
-            authorizationStage.name === 'authorization'
-              ? await reconcileCurrentOIDCSession(serverDB, userId, {
-                  getCookie: (name) => req.cookies.get(name)?.value ?? null,
-                })
-              : await new OIDCService(provider).reconcileInteractionAccount(
-                  authorizationStage.uid,
-                  userId,
-                );
+    try {
+      /**
+       * Load the account guard only after the feature gate. Its server dependencies initialize
+       * the database, which disabled OIDC deployments must not require.
+       */
+      const { guardOIDCAuthorizationAccount } = await import('@/server/services/oidc/accountGuard');
+      const reconciliation = await guardOIDCAuthorizationAccount({
+        getCookie: (name) => req.cookies.get(name)?.value ?? null,
+        pathname: requestUrl.pathname,
+        provider,
+      });
 
-          if (reconciliation === 'recovered') {
-            console.warn(
-              `[OIDC Account Guard] recovered path=${authorizationStage.name} reason=account_mismatch`,
-            );
-          } else if (typeof reconciliation !== 'string' && reconciliation.status === 'recovered') {
-            console.warn(
-              `[OIDC Account Guard] recovered path=${authorizationStage.name} reason=${reconciliation.reason}`,
-            );
-          } else {
-            const status =
-              typeof reconciliation === 'string' ? reconciliation : reconciliation.status;
-            log('[OIDC Account Guard] %s path=%s', status, authorizationStage.name);
-          }
-        } else {
-          log('[OIDC Account Guard] missing_app_session path=%s', authorizationStage.name);
-        }
-      } catch (error) {
-        /**
-         * An unverified account binding must not reach oidc-provider because a stale session can
-         * otherwise issue a code or token for the previous browser account without an interaction.
-         */
-        console.error(
-          `[OIDC Account Guard] recovery_failed path=${authorizationStage.name}`,
-          error,
+      if (reconciliation?.status === 'recovered') {
+        console.warn(
+          `[OIDC Account Guard] recovered path=${reconciliation.path} reason=${reconciliation.reason}`,
         );
-        return NextResponse.json(
-          {
-            error: 'temporarily_unavailable',
-            error_description: 'OIDC authorization is temporarily unavailable',
-          },
-          { status: 503 },
-        );
+      } else if (reconciliation) {
+        log('[OIDC Account Guard] %s path=%s', reconciliation.status, reconciliation.path);
       }
+    } catch (error) {
+      /**
+       * An unverified account binding must not reach oidc-provider because a stale session can
+       * otherwise issue a code or token for the previous browser account without an interaction.
+       */
+      console.error('[OIDC Account Guard] recovery_failed', error);
+      return NextResponse.json(
+        {
+          error: 'temporarily_unavailable',
+          error_description: 'OIDC authorization is temporarily unavailable',
+        },
+        { status: 503 },
+      );
     }
 
     log(`Calling provider.callback() for ${req.method}`); // Log the method

--- a/src/app/(backend)/oidc/[...oidc]/route.ts
+++ b/src/app/(backend)/oidc/[...oidc]/route.ts
@@ -40,13 +40,9 @@ const handler = async (req: NextRequest) => {
       });
 
       if (reconciliation?.status === 'missing_app_session') {
-        return NextResponse.json(
-          {
-            error: 'unauthorized',
-            error_description: 'Authentication is required to continue authorization',
-          },
-          { status: 401 },
-        );
+        const signInUrl = new URL('/signin', requestUrl);
+        signInUrl.searchParams.set('callbackUrl', `${requestUrl.pathname}${requestUrl.search}`);
+        return NextResponse.redirect(signInUrl, { status: 302 });
       }
 
       if (reconciliation?.status === 'recovered') {

--- a/src/app/(backend)/oidc/consent/route.test.ts
+++ b/src/app/(backend)/oidc/consent/route.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @vitest-environment node
+ */
+import type { NextRequest } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findOrCreateGrants: vi.fn(),
+  getInteractionDetails: vi.fn(),
+  getInteractionResult: vi.fn(),
+  getUserAuth: vi.fn(),
+  initialize: vi.fn(),
+}));
+
+vi.mock('debug', () => ({
+  default: () => vi.fn(),
+}));
+
+vi.mock('@lobechat/utils/server', () => ({
+  getUserAuth: mocks.getUserAuth,
+}));
+
+vi.mock('@/envs/app', () => ({
+  appEnv: { APP_URL: 'https://example.com' },
+}));
+
+vi.mock('@/server/services/oidc', () => ({
+  OIDCService: {
+    initialize: mocks.initialize,
+  },
+}));
+
+const createConsentRequest = () =>
+  new Request('https://example.com/oidc/consent', {
+    body: new URLSearchParams({ consent: 'accept', uid: 'interaction-1' }),
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    method: 'POST',
+  }) as unknown as NextRequest;
+
+describe('OIDC consent route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.initialize.mockResolvedValue({
+      findOrCreateGrants: mocks.findOrCreateGrants,
+      getInteractionDetails: mocks.getInteractionDetails,
+      getInteractionResult: mocks.getInteractionResult,
+    });
+    mocks.getUserAuth.mockResolvedValue({ userId: 'user-b' });
+    mocks.getInteractionResult.mockResolvedValue(
+      'https://oidc.example.com/oidc/auth/interaction-1',
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rotates the provider session instead of creating a grant for another account', async () => {
+    mocks.getInteractionDetails.mockResolvedValue({
+      grantId: 'grant-a',
+      params: { client_id: 'client-1' },
+      prompt: { details: {}, name: 'consent' },
+      session: { accountId: 'user-a' },
+    });
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { POST } = await import('./route');
+    const response = await POST(createConsentRequest());
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toBe('https://example.com/oidc/auth/interaction-1');
+    expect(mocks.findOrCreateGrants).not.toHaveBeenCalled();
+    expect(mocks.getInteractionResult).toHaveBeenCalledWith('interaction-1', {
+      login: { accountId: 'user-b', remember: true },
+    });
+  });
+
+  it('creates the consent grant only when the provider session matches the active user', async () => {
+    const grant = {
+      addOIDCClaims: vi.fn(),
+      addOIDCScope: vi.fn(),
+      addResourceScope: vi.fn(),
+      save: vi.fn().mockResolvedValue('grant-b'),
+    };
+    mocks.findOrCreateGrants.mockResolvedValue(grant);
+    mocks.getInteractionDetails.mockResolvedValue({
+      grantId: 'grant-b',
+      params: { client_id: 'client-1' },
+      prompt: {
+        details: {
+          missingOIDCClaims: ['email'],
+          missingOIDCScope: ['openid'],
+          missingResourceScopes: {},
+        },
+        name: 'consent',
+      },
+      session: { accountId: 'user-b' },
+    });
+
+    const { POST } = await import('./route');
+    const response = await POST(createConsentRequest());
+
+    expect(response.status).toBe(303);
+    expect(mocks.findOrCreateGrants).toHaveBeenCalledWith('user-b', 'client-1', 'grant-b');
+    expect(mocks.getInteractionResult).toHaveBeenCalledWith('interaction-1', {
+      consent: { grantId: 'grant-b' },
+    });
+  });
+
+  it('fails closed when the application session is missing', async () => {
+    mocks.getInteractionDetails.mockResolvedValue({
+      params: { client_id: 'client-1' },
+      prompt: { details: {}, name: 'consent' },
+      session: { accountId: 'user-a' },
+    });
+    mocks.getUserAuth.mockResolvedValue({ userId: undefined });
+
+    const { POST } = await import('./route');
+    const response = await POST(createConsentRequest());
+
+    expect(response.status).toBe(401);
+    expect(mocks.findOrCreateGrants).not.toHaveBeenCalled();
+    expect(mocks.getInteractionResult).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(backend)/oidc/consent/route.ts
+++ b/src/app/(backend)/oidc/consent/route.ts
@@ -52,6 +52,16 @@ export async function POST(request: NextRequest) {
       const { userId } = await getUserAuth();
       log('Obtained userId: %s', userId);
 
+      if (!userId) {
+        return NextResponse.json(
+          {
+            error: 'unauthorized',
+            error_description: 'Authentication is required to continue authorization',
+          },
+          { status: 401 },
+        );
+      }
+
       if (details.prompt.name === 'login') {
         result = {
           login: { accountId: userId, remember: true },
@@ -59,46 +69,58 @@ export async function POST(request: NextRequest) {
       } else {
         log(`Handling 'consent' prompt`);
 
-        // 1. Get necessary IDs
-        const clientId = details.params.client_id as string;
+        if (details.session?.accountId !== userId) {
+          /**
+           * Submitting a login result lets oidc-provider rotate the old account session through its
+           * built-in resume and end-session flow. Creating a grant here would bind the new account
+           * to the old session and fail later with `accountId mismatch`.
+           */
+          result = {
+            login: { accountId: userId, remember: true },
+          };
+          console.warn('[OIDC Account Guard] recovered path=consent reason=account_mismatch');
+        } else {
+          // 1. Get necessary IDs
+          const clientId = details.params.client_id as string;
 
-        // 2. Find or create Grant object
-        const grant = await oidcService.findOrCreateGrants(userId!, clientId, details.grantId);
+          // 2. Find or create Grant object
+          const grant = await oidcService.findOrCreateGrants(userId, clientId, details.grantId);
 
-        // 3. Add user-consented scopes and claims to Grant object
-        //    This information is typically in details.prompt.details
-        const missingOIDCScope = (prompt.details.missingOIDCScope as string[]) || [];
-        if (missingOIDCScope) {
-          grant.addOIDCScope(missingOIDCScope.join(' '));
-          log('Added OIDC scopes to grant: %s', missingOIDCScope.join(' '));
-        }
-        const missingOIDCClaims = (prompt.details.missingOIDCClaims as string[]) || [];
-        if (missingOIDCClaims) {
-          grant.addOIDCClaims(missingOIDCClaims);
-          log('Added OIDC claims to grant: %s', missingOIDCClaims.join(' '));
-        }
-
-        const missingResourceScopes =
-          (prompt.details.missingResourceScopes as Record<string, string[]>) || {};
-        if (missingResourceScopes) {
-          for (const [indicator, scopes] of Object.entries(missingResourceScopes)) {
-            grant.addResourceScope(indicator, scopes.join(' '));
-            log('Added resource scopes for %s to grant: %s', indicator, scopes.join(' '));
+          // 3. Add user-consented scopes and claims to Grant object
+          //    This information is typically in details.prompt.details
+          const missingOIDCScope = (prompt.details.missingOIDCScope as string[]) || [];
+          if (missingOIDCScope) {
+            grant.addOIDCScope(missingOIDCScope.join(' '));
+            log('Added OIDC scopes to grant: %s', missingOIDCScope.join(' '));
           }
+          const missingOIDCClaims = (prompt.details.missingOIDCClaims as string[]) || [];
+          if (missingOIDCClaims) {
+            grant.addOIDCClaims(missingOIDCClaims);
+            log('Added OIDC claims to grant: %s', missingOIDCClaims.join(' '));
+          }
+
+          const missingResourceScopes =
+            (prompt.details.missingResourceScopes as Record<string, string[]>) || {};
+          if (missingResourceScopes) {
+            for (const [indicator, scopes] of Object.entries(missingResourceScopes)) {
+              grant.addResourceScope(indicator, scopes.join(' '));
+              log('Added resource scopes for %s to grant: %s', indicator, scopes.join(' '));
+            }
+          }
+          // If RAR (Rich Authorization Requests) is used, it also needs to be added to grant
+          // if (prompt.details.rar) {
+          //   prompt.details.rar.forEach(detail => grant.addRar(detail));
+          // }
+
+          // 4. Save Grant object to get its jti (grantId)
+          const newGrantId = await grant.save();
+          log('Saved grant with ID: %s', newGrantId);
+
+          // 5. Prepare result containing grantId
+          result = { consent: { grantId: newGrantId } };
+
+          log('Consent result prepared with grantId');
         }
-        // If RAR (Rich Authorization Requests) is used, it also needs to be added to grant
-        // if (prompt.details.rar) {
-        //   prompt.details.rar.forEach(detail => grant.addRar(detail));
-        // }
-
-        // 4. Save Grant object to get its jti (grantId)
-        const newGrantId = await grant.save();
-        log('Saved grant with ID: %s', newGrantId);
-
-        // 5. Prepare result containing grantId
-        result = { consent: { grantId: newGrantId } };
-
-        log('Consent result prepared with grantId');
       }
       log('User %s the authorization', consent);
     } else {

--- a/src/libs/oidc-provider/session-cleanup.test.ts
+++ b/src/libs/oidc-provider/session-cleanup.test.ts
@@ -82,18 +82,46 @@ describe('reconcileCurrentOIDCSession', () => {
     expect(delete_).not.toHaveBeenCalled();
   });
 
-  it('does not query storage for an invalid signed cookie', async () => {
+  it('recovers an invalid signed cookie without an active user', async () => {
     const { db, delete_ } = createDb([{ userId: 'user-a' }]);
     const context = createCookieContext('oidc-session-a', 'invalid-signature');
 
     const result = await reconcileCurrentOIDCSession(
       db as unknown as Parameters<typeof reconcileCurrentOIDCSession>[0],
-      'user-b',
+      undefined,
       context,
     );
 
     expect(result).toEqual({ reason: 'invalid_cookie', status: 'recovered' });
     expect(db.select).not.toHaveBeenCalled();
+    expect(delete_).not.toHaveBeenCalled();
+  });
+
+  it('recovers a dangling session without an active user', async () => {
+    const { db, delete_ } = createDb([]);
+    const context = createCookieContext('missing-session');
+
+    const result = await reconcileCurrentOIDCSession(
+      db as unknown as Parameters<typeof reconcileCurrentOIDCSession>[0],
+      undefined,
+      context,
+    );
+
+    expect(result).toEqual({ reason: 'dangling_session', status: 'recovered' });
+    expect(delete_).not.toHaveBeenCalled();
+  });
+
+  it('leaves an existing session unverified when there is no active user', async () => {
+    const { db, delete_ } = createDb([{ userId: 'user-a' }]);
+    const context = createCookieContext('oidc-session-a');
+
+    const result = await reconcileCurrentOIDCSession(
+      db as unknown as Parameters<typeof reconcileCurrentOIDCSession>[0],
+      undefined,
+      context,
+    );
+
+    expect(result).toEqual({ status: 'unverified' });
     expect(delete_).not.toHaveBeenCalled();
   });
 });

--- a/src/libs/oidc-provider/session-cleanup.test.ts
+++ b/src/libs/oidc-provider/session-cleanup.test.ts
@@ -3,7 +3,11 @@ import Keygrip from 'keygrip';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { OIDC_SESSION_COOKIE_NAMES } from './cookies';
-import { clearCurrentOIDCSession, clearMismatchedOIDCSession } from './session-cleanup';
+import {
+  clearCurrentOIDCSession,
+  clearMismatchedOIDCSession,
+  reconcileCurrentOIDCSession,
+} from './session-cleanup';
 
 const TEST_COOKIE_KEY = 'test-cookie-key';
 
@@ -41,6 +45,57 @@ const createCookieContext = (
     return null;
   }),
   setCookie: vi.fn(),
+});
+
+describe('reconcileCurrentOIDCSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('deletes the current browser session when it belongs to another user', async () => {
+    const { db, delete_, deleteWhere } = createDb([{ userId: 'user-a' }]);
+    const context = createCookieContext('oidc-session-a');
+
+    const result = await reconcileCurrentOIDCSession(
+      db as unknown as Parameters<typeof reconcileCurrentOIDCSession>[0],
+      'user-b',
+      context,
+    );
+
+    expect(result).toEqual({ reason: 'account_mismatch', status: 'recovered' });
+    expect(delete_).toHaveBeenCalledWith(oidcSessions);
+    expect(deleteWhere).toHaveBeenCalledOnce();
+    expect(context.setCookie).not.toHaveBeenCalled();
+  });
+
+  it('preserves a session that already belongs to the active user', async () => {
+    const { db, delete_ } = createDb([{ userId: 'user-a' }]);
+    const context = createCookieContext('oidc-session-a');
+
+    const result = await reconcileCurrentOIDCSession(
+      db as unknown as Parameters<typeof reconcileCurrentOIDCSession>[0],
+      'user-a',
+      context,
+    );
+
+    expect(result).toEqual({ status: 'matched' });
+    expect(delete_).not.toHaveBeenCalled();
+  });
+
+  it('does not query storage for an invalid signed cookie', async () => {
+    const { db, delete_ } = createDb([{ userId: 'user-a' }]);
+    const context = createCookieContext('oidc-session-a', 'invalid-signature');
+
+    const result = await reconcileCurrentOIDCSession(
+      db as unknown as Parameters<typeof reconcileCurrentOIDCSession>[0],
+      'user-b',
+      context,
+    );
+
+    expect(result).toEqual({ reason: 'invalid_cookie', status: 'recovered' });
+    expect(db.select).not.toHaveBeenCalled();
+    expect(delete_).not.toHaveBeenCalled();
+  });
 });
 
 describe('clearMismatchedOIDCSession', () => {

--- a/src/libs/oidc-provider/session-cleanup.test.ts
+++ b/src/libs/oidc-provider/session-cleanup.test.ts
@@ -18,7 +18,7 @@ vi.mock('@/config/db', () => ({
 const signSessionCookie = (sessionId: string) =>
   new Keygrip([TEST_COOKIE_KEY]).sign(`_session=${sessionId}`);
 
-const createDb = (sessions: Array<{ userId: string }>) => {
+const createDb = (sessions: Array<{ expiresAt?: Date; userId: string }>) => {
   const limit = vi.fn().mockResolvedValue(sessions);
   const selectWhere = vi.fn(() => ({ limit }));
   const from = vi.fn(() => ({ where: selectWhere }));
@@ -108,6 +108,22 @@ describe('reconcileCurrentOIDCSession', () => {
     );
 
     expect(result).toEqual({ reason: 'dangling_session', status: 'recovered' });
+    expect(delete_).not.toHaveBeenCalled();
+  });
+
+  it('recovers an expired session without an active user', async () => {
+    const { db, delete_ } = createDb([
+      { expiresAt: new Date(Date.now() - 1000), userId: 'user-a' },
+    ]);
+    const context = createCookieContext('expired-session');
+
+    const result = await reconcileCurrentOIDCSession(
+      db as unknown as Parameters<typeof reconcileCurrentOIDCSession>[0],
+      undefined,
+      context,
+    );
+
+    expect(result).toEqual({ reason: 'expired_session', status: 'recovered' });
     expect(delete_).not.toHaveBeenCalled();
   });
 

--- a/src/libs/oidc-provider/session-cleanup.ts
+++ b/src/libs/oidc-provider/session-cleanup.ts
@@ -8,8 +8,11 @@ import {
   verifyOIDCCookieSignature,
 } from './cookies';
 
-export interface OIDCSessionCookieContext {
+export interface OIDCSessionCookieReader {
   getCookie: (name: string) => string | null;
+}
+
+export interface OIDCSessionCookieContext extends OIDCSessionCookieReader {
   setCookie: (
     name: string,
     value: string,
@@ -19,6 +22,14 @@ export interface OIDCSessionCookieContext {
 
 type OIDCSessionCookieResult =
   { status: 'invalid' } | { status: 'missing' } | { sessionId: string; status: 'valid' };
+
+export type OIDCSessionReconciliationResult =
+  | { status: 'matched' }
+  | { status: 'missing' }
+  | {
+      reason: 'account_mismatch' | 'dangling_session' | 'invalid_cookie';
+      status: 'recovered';
+    };
 
 const expireOIDCSessionCookies = (context: OIDCSessionCookieContext) => {
   for (const name of OIDC_SESSION_COOKIE_NAMES) {
@@ -30,17 +41,56 @@ const expireOIDCSessionCookies = (context: OIDCSessionCookieContext) => {
   }
 };
 
-const getOIDCSessionCookie = (context: OIDCSessionCookieContext): OIDCSessionCookieResult => {
+const getOIDCSessionCookie = (context: OIDCSessionCookieReader): OIDCSessionCookieResult => {
   const sessionId = context.getCookie(OIDC_SESSION_COOKIE_NAME);
   if (!sessionId) return { status: 'missing' };
 
   const signature = context.getCookie(`${OIDC_SESSION_COOKIE_NAME}.sig`);
   if (!signature || !verifyOIDCCookieSignature(OIDC_SESSION_COOKIE_NAME, sessionId, signature)) {
-    expireOIDCSessionCookies(context);
     return { status: 'invalid' };
   }
 
   return { sessionId, status: 'valid' };
+};
+
+/**
+ * Reconciles the OIDC session referenced by the current browser with the active application user.
+ *
+ * Deleting only the persisted session is intentional for authorization requests: oidc-provider
+ * treats the still-signed cookie as a missing session, rotates it through its own middleware, and
+ * restarts login without carrying the previous account binding into code or token issuance.
+ */
+export const reconcileCurrentOIDCSession = async (
+  db: LobeChatDatabase,
+  userId: string,
+  context: OIDCSessionCookieReader,
+  onRecovery?: () => void,
+): Promise<OIDCSessionReconciliationResult> => {
+  const cookie = getOIDCSessionCookie(context);
+  if (cookie.status === 'missing') return { status: 'missing' };
+
+  if (cookie.status === 'invalid') {
+    onRecovery?.();
+    return { reason: 'invalid_cookie', status: 'recovered' };
+  }
+
+  const [session] = await db
+    .select({ userId: oidcSessions.userId })
+    .from(oidcSessions)
+    .where(eq(oidcSessions.id, cookie.sessionId))
+    .limit(1);
+
+  if (session?.userId === userId) return { status: 'matched' };
+
+  if (session) {
+    await db.delete(oidcSessions).where(eq(oidcSessions.id, cookie.sessionId));
+  }
+
+  onRecovery?.();
+  return {
+    reason: session ? 'account_mismatch' : 'dangling_session',
+    status: 'recovered',
+  };
 };
 
 /**
@@ -51,7 +101,11 @@ export const clearCurrentOIDCSession = async (
   context: OIDCSessionCookieContext,
 ) => {
   const cookie = getOIDCSessionCookie(context);
-  if (cookie.status !== 'valid') return false;
+  if (cookie.status === 'invalid') {
+    expireOIDCSessionCookies(context);
+    return false;
+  }
+  if (cookie.status === 'missing') return false;
 
   await db.delete(oidcSessions).where(eq(oidcSessions.id, cookie.sessionId));
   expireOIDCSessionCookies(context);
@@ -72,22 +126,8 @@ export const clearMismatchedOIDCSession = async (
 ) => {
   if (!context) return false;
 
-  const cookie = getOIDCSessionCookie(context);
-  if (cookie.status === 'missing') return false;
-  if (cookie.status === 'invalid') return true;
-
-  const [session] = await db
-    .select({ userId: oidcSessions.userId })
-    .from(oidcSessions)
-    .where(eq(oidcSessions.id, cookie.sessionId))
-    .limit(1);
-
-  if (session?.userId === userId) return false;
-
-  if (session) {
-    await db.delete(oidcSessions).where(eq(oidcSessions.id, cookie.sessionId));
-  }
-
-  expireOIDCSessionCookies(context);
-  return true;
+  const result = await reconcileCurrentOIDCSession(db, userId, context, () =>
+    expireOIDCSessionCookies(context),
+  );
+  return result.status === 'recovered';
 };

--- a/src/libs/oidc-provider/session-cleanup.ts
+++ b/src/libs/oidc-provider/session-cleanup.ts
@@ -28,7 +28,7 @@ export type OIDCSessionReconciliationResult =
   | { status: 'missing' }
   | { status: 'unverified' }
   | {
-      reason: 'account_mismatch' | 'dangling_session' | 'invalid_cookie';
+      reason: 'account_mismatch' | 'dangling_session' | 'expired_session' | 'invalid_cookie';
       status: 'recovered';
     };
 
@@ -60,8 +60,8 @@ const getOIDCSessionCookie = (context: OIDCSessionCookieReader): OIDCSessionCook
  * Deleting only the persisted session is intentional for authorization requests: oidc-provider
  * treats the still-signed cookie as a missing session, rotates it through its own middleware, and
  * restarts login without carrying the previous account binding into code or token issuance.
- * Without an active user, invalid or dangling sessions can still recover safely, while an existing
- * account-bound session remains untouched and is reported as unverified.
+ * Without an active user, invalid, dangling, or expired sessions can still recover safely, while
+ * an existing account-bound session remains untouched and is reported as unverified.
  */
 export const reconcileCurrentOIDCSession = async (
   db: LobeChatDatabase,
@@ -78,7 +78,7 @@ export const reconcileCurrentOIDCSession = async (
   }
 
   const [session] = await db
-    .select({ userId: oidcSessions.userId })
+    .select({ expiresAt: oidcSessions.expiresAt, userId: oidcSessions.userId })
     .from(oidcSessions)
     .where(eq(oidcSessions.id, cookie.sessionId))
     .limit(1);
@@ -86,6 +86,11 @@ export const reconcileCurrentOIDCSession = async (
   if (!session) {
     onRecovery?.();
     return { reason: 'dangling_session', status: 'recovered' };
+  }
+
+  if (session.expiresAt < new Date()) {
+    onRecovery?.();
+    return { reason: 'expired_session', status: 'recovered' };
   }
 
   if (!userId) return { status: 'unverified' };

--- a/src/libs/oidc-provider/session-cleanup.ts
+++ b/src/libs/oidc-provider/session-cleanup.ts
@@ -26,6 +26,7 @@ type OIDCSessionCookieResult =
 export type OIDCSessionReconciliationResult =
   | { status: 'matched' }
   | { status: 'missing' }
+  | { status: 'unverified' }
   | {
       reason: 'account_mismatch' | 'dangling_session' | 'invalid_cookie';
       status: 'recovered';
@@ -59,10 +60,12 @@ const getOIDCSessionCookie = (context: OIDCSessionCookieReader): OIDCSessionCook
  * Deleting only the persisted session is intentional for authorization requests: oidc-provider
  * treats the still-signed cookie as a missing session, rotates it through its own middleware, and
  * restarts login without carrying the previous account binding into code or token issuance.
+ * Without an active user, invalid or dangling sessions can still recover safely, while an existing
+ * account-bound session remains untouched and is reported as unverified.
  */
 export const reconcileCurrentOIDCSession = async (
   db: LobeChatDatabase,
-  userId: string,
+  userId: string | undefined,
   context: OIDCSessionCookieReader,
   onRecovery?: () => void,
 ): Promise<OIDCSessionReconciliationResult> => {
@@ -80,17 +83,17 @@ export const reconcileCurrentOIDCSession = async (
     .where(eq(oidcSessions.id, cookie.sessionId))
     .limit(1);
 
-  if (session?.userId === userId) return { status: 'matched' };
-
-  if (session) {
-    await db.delete(oidcSessions).where(eq(oidcSessions.id, cookie.sessionId));
+  if (!session) {
+    onRecovery?.();
+    return { reason: 'dangling_session', status: 'recovered' };
   }
 
+  if (!userId) return { status: 'unverified' };
+  if (session.userId === userId) return { status: 'matched' };
+
+  await db.delete(oidcSessions).where(eq(oidcSessions.id, cookie.sessionId));
   onRecovery?.();
-  return {
-    reason: session ? 'account_mismatch' : 'dangling_session',
-    status: 'recovered',
-  };
+  return { reason: 'account_mismatch', status: 'recovered' };
 };
 
 /**


### PR DESCRIPTION
Prevent an OIDC browser session from continuing authorization under a different active application account.

The authorization entrypoint now reconciles the signed OIDC session before code or token issuance. In-flight interactions are recovered through oidc-provider's built-in login and end-session flow, and consent no longer replaces or destroys an account-bound grant when the session principal differs.

#### Key Decisions / Non-goals

- Fail closed only for the current OIDC authorization when account consistency cannot be verified; primary application sign-in remains unaffected.
- Limit cleanup to the OIDC session referenced by the current browser.
- Preserve sessions on other devices and persistent grants or refresh tokens.
- Do not add migrations, backfills, global cleanup, or authorization-parameter reconstruction.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Automated verification:

- `bun run check --lint --test --type <8 changed OIDC files>`
- 32 related tests passed
- Full type check passed

Manual verification:

- Verified with `oidc-provider@9.11.1` that removing a stale persisted session restarts login instead of silently issuing a code.
- Verified that a consent account mismatch enters the provider's built-in session rotation without raising `accountId mismatch`.

#### 🔗 Related Issue

N/A
