### PR TITLE
🐛 fix: refine acceptance review interactions

### DIFF
--- a/locales/en-US/verify.json
+++ b/locales/en-US/verify.json
@@ -49,7 +49,7 @@
   "acceptance.checkWork.action": "Ask AI to handle this check",
   "acceptance.checkWork.copied": "Check-specific instruction copied",
   "acceptance.checkWork.copy": "Copy check instruction",
-  "acceptance.checkWork.description": "Send this check, its evidence, and its feedback to the source conversation as one bounded work item.",
+  "acceptance.checkWork.description": "Copy a focused prompt with this check, its evidence, and its feedback, then paste it to an AI agent.",
   "acceptance.checkWork.drafted": "Check-specific instruction drafted",
   "acceptance.checkWork.sent": "This check was sent to the source conversation",
   "acceptance.checkWork.title": "Work on this check",

--- a/locales/zh-CN/verify.json
+++ b/locales/zh-CN/verify.json
@@ -49,7 +49,7 @@
   "acceptance.checkWork.action": "让 AI 处理此项",
   "acceptance.checkWork.copied": "已复制单项处理指令",
   "acceptance.checkWork.copy": "复制单项处理指令",
-  "acceptance.checkWork.description": "把这一项的标准、证据和反馈作为一个边界明确的工作项发送到来源会话。",
+  "acceptance.checkWork.description": "复制包含这一项标准、证据和反馈的专属提示词，再粘贴给 AI 处理。",
   "acceptance.checkWork.drafted": "单项处理指令已写入输入框",
   "acceptance.checkWork.sent": "已将这一项发送到来源会话",
   "acceptance.checkWork.title": "处理此项",

--- a/packages/locales/src/default/verify.ts
+++ b/packages/locales/src/default/verify.ts
@@ -104,7 +104,7 @@ export default {
   'acceptance.checkWork.copied': 'Check-specific instruction copied',
   'acceptance.checkWork.copy': 'Copy check instruction',
   'acceptance.checkWork.description':
-    'Send this check, its evidence, and its feedback to the source conversation as one bounded work item.',
+    'Copy a focused prompt with this check, its evidence, and its feedback, then paste it to an AI agent.',
   'acceptance.checkWork.drafted': 'Check-specific instruction drafted',
   'acceptance.checkWork.sent': 'This check was sent to the source conversation',
   'acceptance.checkWork.title': 'Work on this check',

--- a/src/features/Verify/Acceptance/AddCheckModal.tsx
+++ b/src/features/Verify/Acceptance/AddCheckModal.tsx
@@ -6,7 +6,6 @@ import {
   Button,
   createModal,
   type ModalInstance,
-  Segmented,
   Select,
   useModalContext,
 } from '@lobehub/ui/base-ui';
@@ -66,15 +65,6 @@ const AddCheckContent = memo<AddCheckContentProps>(({ existingIds, onSubmit }) =
 
   return (
     <Flexbox gap={16}>
-      <Segmented
-        block
-        value={mode}
-        options={[
-          { label: tv('acceptance.checkCreate.manual'), value: 'manual' },
-          { label: tv('acceptance.checkCreate.rubric'), value: 'rubric' },
-        ]}
-        onChange={(value) => setMode(value as 'manual' | 'rubric')}
-      />
       {mode === 'manual' ? (
         <>
           <Flexbox gap={6}>
@@ -98,9 +88,25 @@ const AddCheckContent = memo<AddCheckContentProps>(({ existingIds, onSubmit }) =
               onChange={(event) => setMethod(event.target.value)}
             />
           </Flexbox>
+          <Flexbox horizontal align={'center'} gap={2}>
+            <Text fontSize={12} type={'secondary'}>
+              {tv('or', { ns: 'common' })}
+            </Text>
+            <Button size={'small'} type={'text'} onClick={() => setMode('rubric')}>
+              {tv('acceptance.checkCreate.rubric')}
+            </Button>
+          </Flexbox>
         </>
       ) : (
         <Flexbox gap={12}>
+          <Button
+            size={'small'}
+            style={{ alignSelf: 'flex-start' }}
+            type={'text'}
+            onClick={() => setMode('manual')}
+          >
+            {tv('acceptance.checkCreate.manual')}
+          </Button>
           <Select
             loading={rubricsLoading}
             options={(rubrics ?? []).map((rubric) => ({ label: rubric.title, value: rubric.id }))}

--- a/src/features/Verify/Acceptance/Workspace/AcceptanceListPanel.tsx
+++ b/src/features/Verify/Acceptance/Workspace/AcceptanceListPanel.tsx
@@ -55,6 +55,7 @@ import { systemStatusSelectors } from '@/store/global/selectors';
 
 import { useAcceptanceList } from '../../hooks';
 import type { ReportPanelExpand } from '../../Workspace/useReportPanelExpand';
+import { acceptanceHomePath } from '../routes';
 import { getAcceptanceStatusActions } from '../statusActions';
 import {
   type AcceptanceListFilter,
@@ -593,7 +594,7 @@ const AcceptanceListPanel = memo<ReportPanelExpand>(({ expand, isNarrow, setExpa
                 icon={ArrowLeft}
                 size={'small'}
                 title={t('back', { ns: 'common' })}
-                onClick={() => navigate(-1)}
+                onClick={() => navigate(acceptanceHomePath())}
               />
               <Text strong style={{ fontSize: 15 }}>
                 {t('acceptance.workspace.title')}

--- a/src/features/Verify/Acceptance/checkWork.test.ts
+++ b/src/features/Verify/Acceptance/checkWork.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { copyCheckRepairPrompt } from './checkWork';
+
+describe('copyCheckRepairPrompt', () => {
+  it('copies a check-scoped repair prompt without dispatching work elsewhere', async () => {
+    const copy = vi.fn().mockResolvedValue(undefined);
+
+    await copyCheckRepairPrompt(
+      'acceptance-1',
+      { id: 'check-2', seq: 2, title: 'Header verdict' },
+      copy,
+    );
+
+    expect(copy).toHaveBeenCalledOnce();
+    expect(copy).toHaveBeenCalledWith(expect.stringContaining('focus on check C2'));
+    expect(copy).toHaveBeenCalledWith(expect.stringContaining('check id: check-2'));
+  });
+});

--- a/src/features/Verify/Acceptance/checkWork.ts
+++ b/src/features/Verify/Acceptance/checkWork.ts
@@ -1,0 +1,24 @@
+type CheckRepairTarget = { id: string; seq: number; title: string };
+
+/**
+ * The repair prompt points the agent at the CLI as the source of truth, so the
+ * reviewer does not have to hand-summarize evidence and feedback.
+ */
+export const buildRepairPrompt = (acceptanceId: string) =>
+  `Use the LobeHub CLI to read the latest review feedback for acceptance ${acceptanceId}:
+
+lh acceptance feedback ${acceptanceId} --actionable
+
+Every entry it prints (per-check comments, circled-region annotations on the evidence screenshots, and attachments) is the full set of feedback to handle this round. Fix the code item by item; then re-run verification and ingest the new result back into the SAME acceptance (reuse the existing check ids, and use supersedes for any check whose meaning changed). Keep the final report in the same language the previous rounds used.`;
+
+export const buildCheckRepairPrompt = (acceptanceId: string, check: CheckRepairTarget) =>
+  `${buildRepairPrompt(acceptanceId)}
+
+For this pass, focus on check C${check.seq} "${check.title}" (check id: ${check.id}). Treat it as the bounded work item: read its evidence and feedback, make the necessary change, and re-verify it without disturbing unrelated accepted or ignored checks.`;
+
+/** A per-check work action is intentionally clipboard-only; it never posts to a conversation. */
+export const copyCheckRepairPrompt = async (
+  acceptanceId: string,
+  check: CheckRepairTarget,
+  copy: (text: string) => Promise<void>,
+) => copy(buildCheckRepairPrompt(acceptanceId, check));

--- a/src/features/Verify/Acceptance/index.tsx
+++ b/src/features/Verify/Acceptance/index.tsx
@@ -78,6 +78,7 @@ import CheckList, {
   shouldGroupChecks,
   userReviewState,
 } from './CheckList';
+import { buildRepairPrompt, copyCheckRepairPrompt } from './checkWork';
 import DecisionBar from './DecisionBar';
 import { EMPTY_ID_SET, setAggregateEntry } from './expandState';
 import FeedbackDrawer, { type FeedbackListEntry } from './FeedbackDrawer';
@@ -88,25 +89,6 @@ import { acceptanceCheckPath, acceptanceOverviewPath } from './routes';
 import { getAcceptanceStatusActions } from './statusActions';
 import TopicPanel from './TopicPanel';
 import { canViewAcceptanceHistory, resolveAcceptanceHistoryNavigation } from './visibility';
-
-/**
- * The hardcoded repair prompt (复制 review 建议 / 打回重跑 share it): points the
- * agent at the CLI as the source of truth for this acceptance's feedback, so
- * nobody has to hand-summarize review notes into an instruction.
- */
-const buildRepairPrompt = (acceptanceId: string) =>
-  `Use the LobeHub CLI to read the latest review feedback for acceptance ${acceptanceId}:
-
-lh acceptance feedback ${acceptanceId} --actionable
-
-Every entry it prints (per-check comments, circled-region annotations on the evidence screenshots, and attachments) is the full set of feedback to handle this round. Fix the code item by item; then re-run verification and ingest the new result back into the SAME acceptance (reuse the existing check ids, and use supersedes for any check whose meaning changed). Keep the final report in the same language the previous rounds used.`;
-
-const buildCheckRepairPrompt = (
-  acceptanceId: string,
-  check: { id: string; seq: number; title: string },
-) => `${buildRepairPrompt(acceptanceId)}
-
-For this pass, focus on check C${check.seq} "${check.title}" (check id: ${check.id}). Treat it as the bounded work item: read its evidence and feedback, make the necessary change, and re-verify it without disturbing unrelated accepted or ignored checks.`;
 
 const styles = createStaticStyles(({ css }) => ({
   banner: css`
@@ -466,7 +448,6 @@ const AcceptancePage = memo<AcceptancePageProps>(
     }, [isEmbedded, data, urlRoundRaw]);
     const [pending, setPending] = useState(false);
     const [rerunPending, setRerunPending] = useState(false);
-    const [checkWorkPending, setCheckWorkPending] = useState(false);
     const [actionError, setActionError] = useState<string>();
     const [feedbackOpen, setFeedbackOpen] = useState(false);
 
@@ -1030,34 +1011,8 @@ const AcceptancePage = memo<AcceptancePageProps>(
 
     const handleCheckWork = async () => {
       if (!focusedCheck) return;
-      const prompt = buildCheckRepairPrompt(acceptance.id, focusedCheck);
-      if (isEmbedded) {
-        if (onDraftToComposer?.(prompt)) {
-          toast.success({ title: t('acceptance.checkWork.drafted') });
-        }
-        return;
-      }
-      if (!origin?.topic) {
-        await copyToClipboard(prompt);
-        toast.success({ title: t('acceptance.checkWork.copied') });
-        return;
-      }
-      setCheckWorkPending(true);
-      try {
-        await verifyService.dispatchAcceptanceRepair({
-          agentId: origin.agent?.id,
-          content: prompt,
-          topicId: origin.topic.id,
-        });
-        await verifyService.markAcceptanceRepairing(acceptance.id);
-        await mutate();
-        void globalMutate(verifyKeys.acceptances());
-        toast.success({ title: t('acceptance.checkWork.sent') });
-      } catch (cause) {
-        toast.error(cause instanceof Error ? cause.message : t('acceptance.actionError'));
-      } finally {
-        setCheckWorkPending(false);
-      }
+      await copyCheckRepairPrompt(acceptance.id, focusedCheck, copyToClipboard);
+      toast.success({ title: t('acceptance.checkWork.copied') });
     };
 
     const saveStandingChecklist = async (checklist: AcceptanceChecklistItem[]) => {
@@ -1622,14 +1577,8 @@ const AcceptancePage = memo<AcceptancePageProps>(
                               {t('acceptance.checkWork.description')}
                             </Text>
                           </Flexbox>
-                          <Button
-                            loading={checkWorkPending}
-                            type={'primary'}
-                            onClick={handleCheckWork}
-                          >
-                            {origin?.topic || isEmbedded
-                              ? t('acceptance.checkWork.action')
-                              : t('acceptance.checkWork.copy')}
+                          <Button type={'primary'} onClick={handleCheckWork}>
+                            {t('acceptance.checkWork.copy')}
                           </Button>
                         </Flexbox>
                       )}

--- a/src/features/Verify/Acceptance/routes.test.ts
+++ b/src/features/Verify/Acceptance/routes.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { acceptanceCheckPath, acceptanceOverviewPath } from './routes';
+import { acceptanceCheckPath, acceptanceHomePath, acceptanceOverviewPath } from './routes';
 
 describe('acceptance routes', () => {
+  it('returns from the acceptance workspace to home', () => {
+    expect(acceptanceHomePath()).toBe('/');
+  });
+
   it('builds the overview route', () => {
     expect(acceptanceOverviewPath('acceptance-1')).toBe('/acceptance/acceptance-1');
   });

--- a/src/features/Verify/Acceptance/routes.ts
+++ b/src/features/Verify/Acceptance/routes.ts
@@ -1,3 +1,5 @@
+export const acceptanceHomePath = () => '/';
+
 export const acceptanceOverviewPath = (acceptanceId: string) =>
   `/acceptance/${encodeURIComponent(acceptanceId)}`;
 


### PR DESCRIPTION
## Summary

- make the acceptance workspace back button return directly to Home
- make per-check AI handling copy a focused repair prompt instead of dispatching it
- demote Rubric creation to a secondary entry beneath the manual check form
- update EN/ZH copy and add regression coverage for navigation and prompt copying

## Testing

- `bun run check` on the 10 changed files
- 4 related tests passed