### PR TITLE
♻️ refactor(onboarding): centralize task recommendation prompts

### DIFF
--- a/apps/server/src/services/taskRecommendation/config.test.ts
+++ b/apps/server/src/services/taskRecommendation/config.test.ts
@@ -17,17 +17,13 @@ describe('TaskRecommendationConfigurator', () => {
     expect(new TaskRecommendationConfigurator().recommendationsPerProvider(0)).toBe(0);
   });
 
-  /** @example Default guidance favors private background deliverables over external writes. */
-  it('keeps generated work autonomous and behind explicit write boundaries', () => {
-    const configurator = new TaskRecommendationConfigurator();
-    const writingGuidance = configurator.writing.instructionPrinciples.join('\n');
-    const githubGuidance = configurator.providers.github.principles.join('\n');
-    const gmailGuidance = configurator.providers.gmail.principles.join('\n');
+  /** @example Runtime collection limits remain paired with prompt-package provider guides. */
+  it('combines operational provider settings with prompt guides', () => {
+    const { providers, writing } = new TaskRecommendationConfigurator();
 
-    expect(writingGuidance).toContain('finish asynchronously');
-    expect(writingGuidance).toContain('require a later explicit user-approved action');
-    expect(githubGuidance).toContain('authored pull requests');
-    expect(githubGuidance).toContain('Never comment, submit a review, approve');
-    expect(gmailGuidance).toContain('Never unsubscribe, send, archive, or delete');
+    expect(providers.github).toMatchObject({ maxContextLength: 24_000, maxSignals: 24 });
+    expect(providers.github.examples.length).toBeGreaterThan(0);
+    expect(providers.gmail.queries).toHaveLength(3);
+    expect(writing.maxSourcesPerRecommendation).toBe(4);
   });
 });

--- a/apps/server/src/services/taskRecommendation/config.ts
+++ b/apps/server/src/services/taskRecommendation/config.ts
@@ -1,3 +1,9 @@
+import type {
+  OnboardingTaskRecommendationProviderGuide,
+  OnboardingTaskRecommendationWritingGuide,
+} from '@lobechat/prompts/onboardingTaskRecommendation';
+import { DEFAULT_ONBOARDING_TASK_RECOMMENDATION_PROMPT_CONFIG } from '@lobechat/prompts/onboardingTaskRecommendation';
+
 /** Allocation settings for distributing generated tasks across connected providers. */
 export interface TaskRecommendationAllocationConfig {
   /** Maximum recommendations generated for one provider. */
@@ -9,23 +15,9 @@ export interface TaskRecommendationAllocationConfig {
 }
 
 /** Provider-specific prompt guidance and examples supplied to the recommendation agent. */
-export interface TaskRecommendationProviderConfig {
-  /** Few-shot examples that demonstrate supported recommendation shapes. */
-  examples: string[];
+export interface TaskRecommendationProviderConfig extends OnboardingTaskRecommendationProviderGuide {
   /** Maximum serialized connector context supplied to one provider agent call. */
   maxContextLength: number;
-  /** Product guidance that constrains which provider signals become tasks. */
-  principles: string[];
-}
-
-/** Shared writing policy applied to every connector recommendation call. */
-export interface TaskRecommendationWritingConfig {
-  /** Guidance that makes task instructions executable without reopening the source first. */
-  instructionPrinciples: string[];
-  /** Maximum evidence links retained on one recommendation. */
-  maxSourcesPerRecommendation: number;
-  /** Guidance that keeps titles distinguishable in large cross-project task lists. */
-  titlePrinciples: string[];
 }
 
 /** GitHub collection policy for task-oriented repository and contribution signals. */
@@ -64,7 +56,7 @@ export interface TaskRecommendationConfig {
     gmail: GmailTaskRecommendationProviderConfig;
   };
   /** Cross-provider recommendation writing policy. */
-  writing: TaskRecommendationWritingConfig;
+  writing: OnboardingTaskRecommendationWritingGuide;
 }
 
 /** Default recommendation policy kept in one injectable configuration object. */
@@ -76,34 +68,14 @@ export const defaultTaskRecommendationConfig: TaskRecommendationConfig = {
   },
   providers: {
     github: {
-      examples: [
-        'Title: Analyze mobile lifecycle risk in Godot Kirie. Instruction: Work in the background from the linked pull request: inspect the diff, CI state, and review discussion; compare Android and iOS attach-detach behavior with the existing lifecycle; then return a private risk summary, missing-test list, and recommended next step. Do not comment, approve, merge, or push changes.',
-        'Title: Prepare the next auv-cli architecture milestone. Instruction: Read the linked issue and related repository activity, turn the proposal into a bounded milestone plan, and return compatibility risks plus the smallest independently reviewable implementation slice. Keep the result as a private plan and do not modify repository state.',
-        'Title: Assess maintenance options for the dormant example repository. Instruction: Inspect repository activity, dependency metadata, and CI configuration in the background, then return a prioritized maintenance brief with evidence and an optional patch plan. Do not open issues, create pull requests, or push changes.',
-      ],
+      ...DEFAULT_ONBOARDING_TASK_RECOMMENDATION_PROMPT_CONFIG.providers.github,
       maxContextLength: 24_000,
-      principles: [
-        'Prefer specific repositories, pull requests, and contributions over generic GitHub cleanup.',
-        'Do not claim an issue, dependency alert, or failing check exists unless the evidence explicitly says so.',
-        'A stale repository is a maintenance opportunity, not proof that work is overdue.',
-        'Use the supplied relationship field: authored pull requests favor CI and review-feedback triage; reviewer activity favors independent diff analysis and draft review notes; never assume a role that the evidence does not establish.',
-        'Default to read-only GitHub work that returns a private report, checklist, draft, or patch plan. Never comment, submit a review, approve, request changes, merge, close, label, or push unless a later user action explicitly authorizes it.',
-      ],
       maxSignals: 24,
       staleAfterDays: 120,
     },
     gmail: {
-      examples: [
-        'Title: Draft a follow-up for the onboarding design review. Instruction: Work in the background from the supplied thread evidence, summarize the unresolved question and elapsed context, and return a concise follow-up draft for user approval. Do not send it, and do not claim the recipient has not replied unless thread evidence proves it.',
-        'Title: Prepare an unsubscribe shortlist for recurring developer newsletters. Instruction: Compare the supplied promotional messages, group repeat senders, and return a private shortlist with evidence and expected inbox impact. Do not unsubscribe, archive, or delete anything.',
-        'Title: Triage this month’s account and billing messages. Instruction: Read the supplied important threads, separate actionable items from informational notices, and return a prioritized private checklist with deadlines, uncertainty, and source subjects. Do not reply, forward, archive, or change labels.',
-      ],
+      ...DEFAULT_ONBOARDING_TASK_RECOMMENDATION_PROMPT_CONFIG.providers.gmail,
       maxContextLength: 24_000,
-      principles: [
-        'Treat sent-message results as follow-up candidates unless thread evidence proves no reply.',
-        'Never unsubscribe, send, archive, or delete mail without a later explicit user-approved action.',
-        'Prefer direct and important mail over promotions, except for an explicit subscription-cleanup task.',
-      ],
       maxSignals: 32,
       queries: [
         { kind: 'actionable', query: 'in:inbox newer_than:30d (is:important OR is:starred)' },
@@ -115,23 +87,7 @@ export const defaultTaskRecommendationConfig: TaskRecommendationConfig = {
       ],
     },
   },
-  writing: {
-    instructionPrinciples: [
-      'Write two to four sentences addressed directly to an autonomous agent. State the background work it can perform, the concrete private deliverable it must return, and the completion criteria.',
-      'Include enough project, person, or subject context for the Inbox agent to execute the task without guessing which similarly named work item is intended.',
-      'Preserve uncertainty from the evidence and state any user approval boundary explicitly.',
-      'Prefer tasks that can finish asynchronously without interrupting the user: gather evidence, analyze activity, summarize, compare, prioritize, or prepare a draft, checklist, report, or patch plan.',
-      'Minimize clarification requests by making conservative assumptions and recording them in the result. Ask the user only when a consequential choice or new authorization is required.',
-      'Do not perform external side effects by default. Email sends, deletion, unsubscribe, archive, label changes, GitHub comments, review submission, approval, merge, close, label, and push operations require a later explicit user-approved action.',
-    ],
-    maxSourcesPerRecommendation: 4,
-    titlePrinciples: [
-      'Start with a clear action such as Review, Follow up on, Plan, Prepare, Triage, or Refresh.',
-      'Name the concrete project, person, account, or business topic that distinguishes the task in a large team task list.',
-      'Avoid source-local shorthand such as a bare feature name; the title must remain understandable before the source badge is read.',
-      'Keep pull request numbers and connector mechanics in sources unless the number itself is essential to distinguish the task.',
-    ],
-  },
+  writing: DEFAULT_ONBOARDING_TASK_RECOMMENDATION_PROMPT_CONFIG.writing,
 };
 
 /** Computes provider budgets from an injectable recommendation policy. */
@@ -140,7 +96,7 @@ export class TaskRecommendationConfigurator {
   /** Provider-specific collection and prompt policy keyed by connector. */
   readonly providers: TaskRecommendationConfig['providers'];
   /** Shared title, instruction, and source policy for every provider writer. */
-  readonly writing: TaskRecommendationWritingConfig;
+  readonly writing: OnboardingTaskRecommendationWritingGuide;
 
   constructor(config: TaskRecommendationConfig = defaultTaskRecommendationConfig) {
     this.allocation = config.allocation;

--- a/apps/server/src/services/taskRecommendation/config.ts
+++ b/apps/server/src/services/taskRecommendation/config.ts
@@ -1,8 +1,8 @@
 import type {
   OnboardingTaskRecommendationProviderGuide,
   OnboardingTaskRecommendationWritingGuide,
-} from '@lobechat/prompts/onboardingTaskRecommendation';
-import { DEFAULT_ONBOARDING_TASK_RECOMMENDATION_PROMPT_CONFIG } from '@lobechat/prompts/onboardingTaskRecommendation';
+} from '@lobechat/prompts';
+import { DEFAULT_ONBOARDING_TASK_RECOMMENDATION_PROMPT_CONFIG } from '@lobechat/prompts';
 
 /** Allocation settings for distributing generated tasks across connected providers. */
 export interface TaskRecommendationAllocationConfig {

--- a/apps/server/src/services/taskRecommendation/writer.ts
+++ b/apps/server/src/services/taskRecommendation/writer.ts
@@ -1,9 +1,16 @@
+import type {
+  OnboardingTaskRecommendationProviderGuide,
+  OnboardingTaskRecommendationProviderId,
+  OnboardingTaskRecommendationWritingGuide,
+} from '@lobechat/prompts/onboardingTaskRecommendation';
+import {
+  chainOnboardingTaskRecommendation,
+  ONBOARDING_TASK_RECOMMENDATION_JSON_SCHEMA,
+} from '@lobechat/prompts/onboardingTaskRecommendation';
 import { RequestTrigger } from '@lobechat/types';
 import { z } from 'zod';
 
 import type { AiGenerationService } from '@/server/services/aiGeneration';
-
-import type { TaskRecommendationProviderConfig, TaskRecommendationWritingConfig } from './config';
 
 const recommendationOutputSchema = z.object({
   recommendations: z.array(
@@ -15,32 +22,6 @@ const recommendationOutputSchema = z.object({
     }),
   ),
 });
-
-const RECOMMENDATION_JSON_SCHEMA = {
-  name: 'onboarding_task_recommendations',
-  schema: {
-    additionalProperties: false,
-    properties: {
-      recommendations: {
-        items: {
-          additionalProperties: false,
-          properties: {
-            instruction: { type: 'string' },
-            reason: { type: 'string' },
-            sourceUrls: { items: { type: 'string' }, minItems: 1, type: 'array' },
-            title: { type: 'string' },
-          },
-          required: ['title', 'instruction', 'reason', 'sourceUrls'],
-          type: 'object',
-        },
-        type: 'array',
-      },
-    },
-    required: ['recommendations'],
-    type: 'object' as const,
-  },
-  strict: true,
-};
 
 /** One validated recommendation returned before connector-source grounding. */
 export interface GeneratedTaskRecommendation {
@@ -59,15 +40,15 @@ export interface TaskRecommendationWriterInput {
   /** Bounded untrusted connector evidence serialized by the provider collector. */
   context: string;
   /** Provider-specific recommendation examples and safety policy. */
-  guide: TaskRecommendationProviderConfig;
+  guide: OnboardingTaskRecommendationProviderGuide;
   /** Maximum recommendation count requested from this provider. */
   limit: number;
   /** Connector identifier represented by the evidence. */
-  providerId: 'github' | 'gmail';
+  providerId: OnboardingTaskRecommendationProviderId;
   /** Locale used for generated user-facing text. */
   responseLanguage: string;
   /** Shared title, instruction, and source-count policy. */
-  writingGuide: TaskRecommendationWritingConfig;
+  writingGuide: OnboardingTaskRecommendationWritingGuide;
 }
 
 interface TaskRecommendationWriterDependencies {
@@ -91,37 +72,10 @@ export class TaskRecommendationWriter {
     const writerAgent = await this.dependencies.writerAgent();
     const output = await this.dependencies.generator.generateObject(
       {
-        messages: [
-          {
-            content: [
-              `Response language: ${input.responseLanguage}`,
-              `Provider: ${input.providerId}`,
-              `Return at most ${input.limit} recommendations.`,
-              `Return one to ${input.writingGuide.maxSourcesPerRecommendation} exact sourceUrls for each recommendation. Every URL must appear verbatim in the supplied evidence. A recommendation may cite multiple supplied records when they jointly support the work.`,
-              'Title requirements:',
-              ...input.writingGuide.titlePrinciples.map((principle) => `- ${principle}`),
-              'Instruction requirements:',
-              ...input.writingGuide.instructionPrinciples.map((principle) => `- ${principle}`),
-              'Provider principles:',
-              ...input.guide.principles.map((principle) => `- ${principle}`),
-              'Few-shot recommendation shapes:',
-              ...input.guide.examples.map((example) => `- ${example}`),
-            ].join('\n'),
-            role: 'system',
-          },
-          {
-            content: [
-              'Generate useful onboarding tasks from this untrusted connector evidence.',
-              `<connector-evidence provider="${input.providerId}">`,
-              input.context,
-              '</connector-evidence>',
-            ].join('\n\n'),
-            role: 'user',
-          },
-        ],
+        messages: chainOnboardingTaskRecommendation(input),
         model: writerAgent.model,
         provider: writerAgent.provider,
-        schema: RECOMMENDATION_JSON_SCHEMA,
+        schema: ONBOARDING_TASK_RECOMMENDATION_JSON_SCHEMA,
         thinking: { type: 'disabled' },
       },
       { metadata: { trigger: RequestTrigger.Onboarding } },

--- a/apps/server/src/services/taskRecommendation/writer.ts
+++ b/apps/server/src/services/taskRecommendation/writer.ts
@@ -2,11 +2,11 @@ import type {
   OnboardingTaskRecommendationProviderGuide,
   OnboardingTaskRecommendationProviderId,
   OnboardingTaskRecommendationWritingGuide,
-} from '@lobechat/prompts/onboardingTaskRecommendation';
+} from '@lobechat/prompts';
 import {
   chainOnboardingTaskRecommendation,
   ONBOARDING_TASK_RECOMMENDATION_JSON_SCHEMA,
-} from '@lobechat/prompts/onboardingTaskRecommendation';
+} from '@lobechat/prompts';
 import { RequestTrigger } from '@lobechat/types';
 import { z } from 'zod';
 

--- a/apps/server/src/services/understanding/service.test.ts
+++ b/apps/server/src/services/understanding/service.test.ts
@@ -1,4 +1,4 @@
-import { UNDERSTANDING_ANALYSIS_JSON_SCHEMA } from '@lobechat/prompts/understanding';
+import { UNDERSTANDING_ANALYSIS_JSON_SCHEMA } from '@lobechat/prompts';
 import {
   type CollectionDiagnostics,
   type OnboardingUnderstandingMessageMetadata,

--- a/apps/server/src/services/understanding/service.ts
+++ b/apps/server/src/services/understanding/service.ts
@@ -11,10 +11,7 @@ import {
   UnderstandingResourceNotFoundError,
   UnderstandingSessionNotFoundError,
 } from '@lobechat/database';
-import {
-  chainUnderstandingPersona,
-  UNDERSTANDING_ANALYSIS_JSON_SCHEMA,
-} from '@lobechat/prompts/understanding';
+import { chainUnderstandingPersona, UNDERSTANDING_ANALYSIS_JSON_SCHEMA } from '@lobechat/prompts';
 import type {
   CollectionDiagnostics,
   ConfirmOnboardingUnderstandingInput,

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -5,6 +5,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./fileSystem": "./src/prompts/fileSystem/index.ts",
+    "./onboardingTaskRecommendation": "./src/chains/onboardingTaskRecommendation.ts",
     "./understanding": "./src/chains/understanding.ts"
   },
   "main": "./src/index.ts",

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -4,9 +4,7 @@
   "private": true,
   "exports": {
     ".": "./src/index.ts",
-    "./fileSystem": "./src/prompts/fileSystem/index.ts",
-    "./onboardingTaskRecommendation": "./src/chains/onboardingTaskRecommendation.ts",
-    "./understanding": "./src/chains/understanding.ts"
+    "./fileSystem": "./src/prompts/fileSystem/index.ts"
   },
   "main": "./src/index.ts",
   "scripts": {

--- a/packages/prompts/src/chains/index.ts
+++ b/packages/prompts/src/chains/index.ts
@@ -8,6 +8,7 @@ export * from './generateSkillMeta';
 export * from './inputCompletion';
 export * from './judgeBriefEmit';
 export * from './langDetect';
+export * from './onboardingTaskRecommendation';
 export * from './pickEmoji';
 export * from './rewriteGenerationPrompt';
 export * from './summaryAgentName';

--- a/packages/prompts/src/chains/onboardingTaskRecommendation.test.ts
+++ b/packages/prompts/src/chains/onboardingTaskRecommendation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  chainOnboardingTaskRecommendation,
+  DEFAULT_ONBOARDING_TASK_RECOMMENDATION_PROMPT_CONFIG,
+} from './onboardingTaskRecommendation';
+
+/** @example Onboarding task prompts preserve evidence boundaries and autonomous work policy. */
+describe('chainOnboardingTaskRecommendation', () => {
+  /** @example GitHub guidance and evidence produce an isolated system/user message pair. */
+  it('combines shared policy, provider few-shots, and delimited evidence', () => {
+    const messages = chainOnboardingTaskRecommendation({
+      context: '{"pullRequest":1}',
+      guide: DEFAULT_ONBOARDING_TASK_RECOMMENDATION_PROMPT_CONFIG.providers.github,
+      limit: 3,
+      providerId: 'github',
+      responseLanguage: 'en-US',
+      writingGuide: DEFAULT_ONBOARDING_TASK_RECOMMENDATION_PROMPT_CONFIG.writing,
+    });
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0].content).toContain('Return at most 3 recommendations.');
+    expect(messages[0].content).toContain('Never comment, submit a review, approve');
+    expect(messages[0].content).toContain('Title: Analyze mobile lifecycle risk');
+    expect(messages[1].content).toContain('<connector-evidence provider="github">');
+    expect(messages[1].content).toContain('{"pullRequest":1}');
+  });
+
+  /** @example Gmail guidance keeps side effects behind later user approval. */
+  it('keeps mail recommendations read-only by default', () => {
+    const { providers, writing } = DEFAULT_ONBOARDING_TASK_RECOMMENDATION_PROMPT_CONFIG;
+
+    expect(providers.gmail.principles.join('\n')).toContain(
+      'Never unsubscribe, send, archive, or delete',
+    );
+    expect(writing.instructionPrinciples.join('\n')).toContain('finish asynchronously');
+    expect(writing.instructionPrinciples.join('\n')).toContain(
+      'require a later explicit user-approved action',
+    );
+  });
+});

--- a/packages/prompts/src/chains/onboardingTaskRecommendation.ts
+++ b/packages/prompts/src/chains/onboardingTaskRecommendation.ts
@@ -1,0 +1,165 @@
+export type OnboardingTaskRecommendationProviderId = 'github' | 'gmail';
+
+/** Provider-specific examples and safety rules used to recommend onboarding tasks. */
+export interface OnboardingTaskRecommendationProviderGuide {
+  /** Few-shot examples that demonstrate useful, background-safe task shapes. */
+  examples: readonly string[];
+  /** Product rules that constrain how connector signals become tasks. */
+  principles: readonly string[];
+}
+
+/** Shared title, instruction, and source policy for onboarding task recommendations. */
+export interface OnboardingTaskRecommendationWritingGuide {
+  /** Guidance that makes delegated work executable without reopening the source first. */
+  instructionPrinciples: readonly string[];
+  /** Maximum evidence links requested for one recommendation. */
+  maxSourcesPerRecommendation: number;
+  /** Guidance that keeps task titles distinguishable in large cross-project lists. */
+  titlePrinciples: readonly string[];
+}
+
+interface OnboardingTaskRecommendationPromptInput {
+  context: string;
+  guide: OnboardingTaskRecommendationProviderGuide;
+  limit: number;
+  providerId: OnboardingTaskRecommendationProviderId;
+  responseLanguage: string;
+  writingGuide: OnboardingTaskRecommendationWritingGuide;
+}
+
+interface OnboardingTaskRecommendationJsonSchema {
+  name: string;
+  schema: {
+    additionalProperties: false;
+    properties: Record<string, unknown>;
+    required: string[];
+    type: 'object';
+  };
+  strict: true;
+}
+
+/** Structured output contract shared by the recommendation prompt and server-side generation. */
+export const ONBOARDING_TASK_RECOMMENDATION_JSON_SCHEMA = {
+  name: 'onboarding_task_recommendations',
+  schema: {
+    additionalProperties: false,
+    properties: {
+      recommendations: {
+        items: {
+          additionalProperties: false,
+          properties: {
+            instruction: { type: 'string' },
+            reason: { type: 'string' },
+            sourceUrls: { items: { type: 'string' }, minItems: 1, type: 'array' },
+            title: { type: 'string' },
+          },
+          required: ['title', 'instruction', 'reason', 'sourceUrls'],
+          type: 'object',
+        },
+        type: 'array',
+      },
+    },
+    required: ['recommendations'],
+    type: 'object',
+  },
+  strict: true,
+} satisfies OnboardingTaskRecommendationJsonSchema;
+
+/** Default model-facing policy and few-shot examples for supported recommendation providers. */
+export const DEFAULT_ONBOARDING_TASK_RECOMMENDATION_PROMPT_CONFIG = {
+  providers: {
+    github: {
+      examples: [
+        'Title: Analyze mobile lifecycle risk in Godot Kirie. Instruction: Work in the background from the linked pull request: inspect the diff, CI state, and review discussion; compare Android and iOS attach-detach behavior with the existing lifecycle; then return a private risk summary, missing-test list, and recommended next step. Do not comment, approve, merge, or push changes.',
+        'Title: Prepare the next auv-cli architecture milestone. Instruction: Read the linked issue and related repository activity, turn the proposal into a bounded milestone plan, and return compatibility risks plus the smallest independently reviewable implementation slice. Keep the result as a private plan and do not modify repository state.',
+        'Title: Assess maintenance options for the dormant example repository. Instruction: Inspect repository activity, dependency metadata, and CI configuration in the background, then return a prioritized maintenance brief with evidence and an optional patch plan. Do not open issues, create pull requests, or push changes.',
+      ],
+      principles: [
+        'Prefer specific repositories, pull requests, and contributions over generic GitHub cleanup.',
+        'Do not claim an issue, dependency alert, or failing check exists unless the evidence explicitly says so.',
+        'A stale repository is a maintenance opportunity, not proof that work is overdue.',
+        'Use the supplied relationship field: authored pull requests favor CI and review-feedback triage; reviewer activity favors independent diff analysis and draft review notes; never assume a role that the evidence does not establish.',
+        'Default to read-only GitHub work that returns a private report, checklist, draft, or patch plan. Never comment, submit a review, approve, request changes, merge, close, label, or push unless a later user action explicitly authorizes it.',
+      ],
+    },
+    gmail: {
+      examples: [
+        'Title: Draft a follow-up for the onboarding design review. Instruction: Work in the background from the supplied thread evidence, summarize the unresolved question and elapsed context, and return a concise follow-up draft for user approval. Do not send it, and do not claim the recipient has not replied unless thread evidence proves it.',
+        'Title: Prepare an unsubscribe shortlist for recurring developer newsletters. Instruction: Compare the supplied promotional messages, group repeat senders, and return a private shortlist with evidence and expected inbox impact. Do not unsubscribe, archive, or delete anything.',
+        'Title: Triage this month’s account and billing messages. Instruction: Read the supplied important threads, separate actionable items from informational notices, and return a prioritized private checklist with deadlines, uncertainty, and source subjects. Do not reply, forward, archive, or change labels.',
+      ],
+      principles: [
+        'Treat sent-message results as follow-up candidates unless thread evidence proves no reply.',
+        'Never unsubscribe, send, archive, or delete mail without a later explicit user-approved action.',
+        'Prefer direct and important mail over promotions, except for an explicit subscription-cleanup task.',
+      ],
+    },
+  },
+  writing: {
+    instructionPrinciples: [
+      'Write two to four sentences addressed directly to an autonomous agent. State the background work it can perform, the concrete private deliverable it must return, and the completion criteria.',
+      'Include enough project, person, or subject context for the Inbox agent to execute the task without guessing which similarly named work item is intended.',
+      'Preserve uncertainty from the evidence and state any user approval boundary explicitly.',
+      'Prefer tasks that can finish asynchronously without interrupting the user: gather evidence, analyze activity, summarize, compare, prioritize, or prepare a draft, checklist, report, or patch plan.',
+      'Minimize clarification requests by making conservative assumptions and recording them in the result. Ask the user only when a consequential choice or new authorization is required.',
+      'Do not perform external side effects by default. Email sends, deletion, unsubscribe, archive, label changes, GitHub comments, review submission, approval, merge, close, label, and push operations require a later explicit user-approved action.',
+    ],
+    maxSourcesPerRecommendation: 4,
+    titlePrinciples: [
+      'Start with a clear action such as Review, Follow up on, Plan, Prepare, Triage, or Refresh.',
+      'Name the concrete project, person, account, or business topic that distinguishes the task in a large team task list.',
+      'Avoid source-local shorthand such as a bare feature name; the title must remain understandable before the source badge is read.',
+      'Keep pull request numbers and connector mechanics in sources unless the number itself is essential to distinguish the task.',
+    ],
+  },
+} as const satisfies {
+  providers: Record<
+    OnboardingTaskRecommendationProviderId,
+    OnboardingTaskRecommendationProviderGuide
+  >;
+  writing: OnboardingTaskRecommendationWritingGuide;
+};
+
+/**
+ * Builds the isolated system and user messages for one connector recommendation pass.
+ *
+ * Use when:
+ * - A task recommendation writer has collected bounded connector evidence
+ * - Provider-specific examples must be combined with shared writing policy
+ *
+ * Expects:
+ * - Connector evidence remains untrusted and provider-delimited
+ *
+ * Returns:
+ * - A system/user message pair ready for structured generation
+ */
+export const chainOnboardingTaskRecommendation = (
+  input: OnboardingTaskRecommendationPromptInput,
+) => [
+  {
+    content: [
+      `Response language: ${input.responseLanguage}`,
+      `Provider: ${input.providerId}`,
+      `Return at most ${input.limit} recommendations.`,
+      `Return one to ${input.writingGuide.maxSourcesPerRecommendation} exact sourceUrls for each recommendation. Every URL must appear verbatim in the supplied evidence. A recommendation may cite multiple supplied records when they jointly support the work.`,
+      'Title requirements:',
+      ...input.writingGuide.titlePrinciples.map((principle) => `- ${principle}`),
+      'Instruction requirements:',
+      ...input.writingGuide.instructionPrinciples.map((principle) => `- ${principle}`),
+      'Provider principles:',
+      ...input.guide.principles.map((principle) => `- ${principle}`),
+      'Few-shot recommendation shapes:',
+      ...input.guide.examples.map((example) => `- ${example}`),
+    ].join('\n'),
+    role: 'system' as const,
+  },
+  {
+    content: [
+      'Generate useful onboarding tasks from this untrusted connector evidence.',
+      `<connector-evidence provider="${input.providerId}">`,
+      input.context,
+      '</connector-evidence>',
+    ].join('\n\n'),
+    role: 'user' as const,
+  },
+];


### PR DESCRIPTION
Moves onboarding task recommendation prompt ownership into `@lobechat/prompts`.

- Adds an `onboardingTaskRecommendation` prompt boundary with the structured output schema, shared writing policy, provider principles, and GitHub/Gmail few-shot examples.
- Exposes the boundary through the prompts root and a dedicated package subpath.
- Keeps server configuration focused on allocation and connector collection parameters.
- Keeps the writer focused on model resolution, structured generation, and output validation.

No UI changes.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check packages/prompts/src/chains/onboardingTaskRecommendation.ts packages/prompts/src/chains/onboardingTaskRecommendation.test.ts packages/prompts/src/chains/index.ts packages/prompts/package.json apps/server/src/services/taskRecommendation/writer.ts apps/server/src/services/taskRecommendation/config.ts apps/server/src/services/taskRecommendation/config.test.ts`

Result: 7 files lint clean, 6 tests passed.

#### 🔗 Related Issue

Follow-up to #17757.
