### PR TITLE
✨ feat(home): give the portrait a speech bubble

### DIFF
--- a/.agents/acceptance/common-mistakes.md
+++ b/.agents/acceptance/common-mistakes.md
@@ -129,6 +129,37 @@ observed behavior may belong to a fallback model.
 provider/model configuration and the first completed assistant message metadata.
 Attach the runtime identity to the Acceptance round before judging quality.
 
+### L-E11 — Declaring an ingest done without reconciling its evidence count
+
+**Wrong approach:** read `acceptance run ingest`'s success JSON, see an
+`acceptanceId` and a round index, and stop — treating a `[WARN] evidence upload
+failed, skipping <file>` line above it as noise because the command still exited 0.
+
+**Why it fails:** a transient storage error skips exactly one artifact and the run
+publishes anyway. When the casualty is one half of a `comparison` pair, the
+surviving half renders alone under its role band — a lone `before` screenshot reads
+as "the fix never landed", inverting the round's verdict.
+
+**Correct approach:** count the evidence items in `result.json` before publishing
+and compare against the ingest JSON's `evidence` field; treat any WARN line as a
+failure of the publish step. Do not retro-attach the missing file with
+`acceptance run evidence upload` — that path carries no `comparison` metadata, so
+the image lands unpaired and unlabeled. Publish a fresh round carrying the complete
+evidence set instead, and say in `report.md` that it re-publishes the same
+observations rather than re-running the cases.
+
+### L-E12 — Expressing multimodal disclosure through the `verifier` enum
+
+**Wrong approach:** write a value such as `"verifier": "multimodal LLM"` in a plan
+item to satisfy the requirement that screenshot checks disclose multimodal review.
+
+**Why it fails:** `verifier` is a closed set (`program` / `agent` / `llm`) that the
+ingest validator rejects outside those values, so the whole payload fails. The
+disclosure is not expressible in that field.
+
+**Correct approach:** set `"verifier": "llm"` and carry the multimodal disclosure in
+the plan item's `method` prose alongside `"requiredEvidence": ["screenshot"]`.
+
 ## Product and interaction contracts
 
 ### L-D1 — Rebuilding a canonical surface from visual impression
@@ -259,6 +290,30 @@ the user's LobeHub instance may expose no debugging port at all.
 **Correct approach:** verify the owning process path and probe a LobeHub-specific
 renderer marker before collecting evidence. If needed, start an isolated pool
 instance on a distinct port rather than guessing.
+
+### L-S6 — Reading or writing the url from a portal'd sidebar on desktop
+
+**Wrong approach:** use `useSearchParams`, `useQueryState`, `useParams`,
+`useLocation`, `useNavigate`, or a bare `<Link>` inside a component that a route
+layout registers through `NavPanelPortal`, and verify it only on web.
+
+**Why it fails:** the desktop shell renders every registered sidebar outside the
+per-tab routers, so React context binds those hooks to the root router, whose
+location never moves. A write lands on a router no page reads and a read resolves
+the boot url. Both are silent: the sidebar renders normally and web is unaffected,
+so the defect looks like unrelated page logic. Verified twice in this catalogue's
+lifetime — as a topic-switch failure that made the generation page ignore its own
+send button, and as a library tree that never expanded to the open folder.
+
+**Correct approach:** in any shell-rendered tree, read through the active-tab
+facades (`useActiveLocation`, `useActiveRouteParams`) and navigate through
+`useWorkspaceAwareNavigate` / `appNavigate`, keeping `<Link>` only for its href
+with the click handled by the facade. Note that no active-tab twin exists for
+search params: express a param write as a facade navigation rather than
+`setSearchParams`. When the state is a url ⇄ store sync owned by the page, mount
+it in the route layout instead, and cover it with a test that asserts which router
+received the write — a test that only asserts a write happened passes on the
+broken topology too.
 
 ## Historical source
 

--- a/.agents/acceptance/probe-mock-patterns.md
+++ b/.agents/acceptance/probe-mock-patterns.md
@@ -380,6 +380,51 @@ Keep that command session open for the run. Confirm the CDP endpoint, project
 process path, `app-probe.sh ready`, renderer auth, server auth, and a raw-CDP
 screenshot before collecting evidence.
 
+### `app-probe.sh goto /` cannot reach the desktop Home route — seed the tab first
+
+**Situation:** driving the Electron shell to the Home route (`/`) to check the nav
+panel there.
+
+**Doesn't work:** `app-probe.sh goto /` prints `"/"` but the renderer stays on the
+previous route. `goto` is a full reload, and the desktop shell restores the active
+tab's persisted url on boot — every non-root route survives that restore, so `goto`
+appears to work for `/tasks`, `/agents`, `/settings` and silently fails only for
+`/`. The follow-up probe then describes the old page with no error anywhere.
+
+**Works:** create and activate a Home tab first, then navigate:
+
+```js
+window.__LOBE_STORES.electron().addTab('/'); // addTab also activates it
+```
+
+```bash
+.agents/acceptance/scripts/app-probe.sh goto /
+```
+
+Assert `location.pathname` after the reload rather than trusting `goto`'s echo.
+
+### Anchor nav-panel assertions on `#nav-panel-drawer`, not a `data-insp-path` match
+
+**Situation:** asserting what the left nav panel renders on a given route.
+
+**Doesn't work:** `document.querySelector('[data-insp-path*="NavPanelDraggable"]')`.
+It resolves during a settled render but returns `null` in the seconds after a full
+reload, and the usual `|| document.body` fallback then reads
+`document.body.innerText === ''` (generic C4) — which looks exactly like an empty
+panel and turns a normal loading window into a false regression.
+
+**Works:** the panel is the `<aside>` sibling of the stable drawer anchor:
+
+```js
+const drawer = document.getElementById('nav-panel-drawer');
+const aside = drawer && [...drawer.parentElement.children].find((c) => c.tagName === 'ASIDE');
+```
+
+Then assert on `aside.innerText` line count plus a count of text-free rounded boxes
+(the skeleton rows). Distinguish the two skeleton states explicitly: the whole panel
+collapsing to \~8 text-free rows is the nav-panel fallback, while fixed items present
+with only the list area shimmering is ordinary data loading.
+
 ## Detailed references
 
 - [Probe field notes](./references/probe-field-notes.md) — all historical

--- a/e2e/src/features/home/layout.feature
+++ b/e2e/src/features/home/layout.feature
@@ -9,5 +9,6 @@ Feature: Home Dashboard 双列布局
   Scenario: 受限桌面宽度下双列滚动条不覆盖内容
     Given 用户在受限宽度下打开 Home 页面
     Then Home 主列滚动条应位于双列间距中央
-    And Home 右栏折叠控制应贴合双列边界
+    And Home 右栏折叠控制应固定在页面右上角
+    And Home 开合右栏不应改变主列纵向位置
     And Home 右栏应保持卡片、滚动条轨道与页面边缘的分层间距

--- a/e2e/src/steps/home/layout.steps.ts
+++ b/e2e/src/steps/home/layout.steps.ts
@@ -40,33 +40,55 @@ Then('Home 主列滚动条应位于双列间距中央', async function (this: Cu
   expect(scrollbarCenter).toBeCloseTo(columnGapCenter, 0);
 });
 
-Then('Home 右栏折叠控制应贴合双列边界', async function (this: CustomWorld) {
+Then('Home 右栏折叠控制应固定在页面右上角', async function (this: CustomWorld) {
   const main = this.page.locator('[data-testid="home-main"]:visible');
   const rail = this.page.locator('[data-testid="home-rail"]:visible');
-  const desktopToggle = this.page.getByTestId('home-rail-toggle-desktop');
-  const mobileToggle = this.page.getByTestId('home-rail-toggle-mobile');
+  const toggle = this.page.locator('[data-testid="home-rail-toggle"]:visible');
 
-  await expect(desktopToggle).toBeVisible({ timeout: WAIT_TIMEOUT });
-  await expect(mobileToggle).toBeHidden();
+  await expect(toggle).toBeVisible({ timeout: WAIT_TIMEOUT });
 
-  const [mainBox, railBox, toggleBox] = await Promise.all([
+  const [mainBox, expandedBox, viewportWidth] = await Promise.all([
     main.boundingBox(),
-    rail.boundingBox(),
-    desktopToggle.boundingBox(),
+    toggle.boundingBox(),
+    this.page.evaluate(() => window.innerWidth),
   ]);
 
   expect(mainBox).not.toBeNull();
-  expect(railBox).not.toBeNull();
-  expect(toggleBox).not.toBeNull();
+  expect(expandedBox).not.toBeNull();
+  expect(expandedBox!.y + expandedBox!.height).toBeLessThanOrEqual(mainBox!.y);
+  expect(viewportWidth - (expandedBox!.x + expandedBox!.width)).toBeLessThanOrEqual(24);
 
-  const mainRight = mainBox!.x + mainBox!.width;
-  const railLeft = railBox!.x;
-  const toggleCenter = toggleBox!.x + toggleBox!.width / 2;
-  const columnGapCenter = mainRight + (railLeft - mainRight) / 2;
+  await toggle.click();
+  await expect(rail).toHaveCount(0);
 
-  expect(toggleBox!.x).toBeGreaterThanOrEqual(mainRight);
-  expect(toggleBox!.x + toggleBox!.width).toBeLessThanOrEqual(railLeft);
-  expect(toggleCenter).toBeCloseTo(columnGapCenter, 0);
+  const collapsedBox = await toggle.boundingBox();
+  expect(collapsedBox).not.toBeNull();
+  expect(collapsedBox!.x).toBeCloseTo(expandedBox!.x, 0);
+  expect(collapsedBox!.y).toBeCloseTo(expandedBox!.y, 0);
+
+  await toggle.click();
+  await expect(rail).toBeVisible({ timeout: WAIT_TIMEOUT });
+});
+
+Then('Home 开合右栏不应改变主列纵向位置', async function (this: CustomWorld) {
+  const main = this.page.locator('[data-testid="home-main"]:visible');
+  const rail = this.page.locator('[data-testid="home-rail"]:visible');
+  const toggle = this.page.locator('[data-testid="home-rail-toggle"]:visible');
+
+  const expandedBox = await main.boundingBox();
+  expect(expandedBox).not.toBeNull();
+
+  await toggle.click();
+  await expect(rail).toHaveCount(0);
+
+  // The greeting measures against a fixed width, so collapsing must not re-wrap
+  // it and push the composer plus the whole task list down a line.
+  const collapsedBox = await main.boundingBox();
+  expect(collapsedBox).not.toBeNull();
+  expect(collapsedBox!.y).toBeCloseTo(expandedBox!.y, 0);
+
+  await toggle.click();
+  await expect(rail).toBeVisible({ timeout: WAIT_TIMEOUT });
 });
 
 Then('Home 右栏应保持卡片、滚动条轨道与页面边缘的分层间距', async function (this: CustomWorld) {

--- a/e2e/src/steps/home/layout.steps.ts
+++ b/e2e/src/steps/home/layout.steps.ts
@@ -4,6 +4,27 @@ import { expect } from '@playwright/test';
 import type { CustomWorld } from '../../support/world';
 import { WAIT_TIMEOUT } from '../../support/world';
 
+/**
+ * The rail slides 24px on its way in and out. `toBeVisible` resolves the moment
+ * visibility flips, well before the transform lands, so any step that toggles
+ * the rail must settle it before the next step measures anything.
+ */
+const settleRail = async (world: CustomWorld) => {
+  const rail = world.page.locator('[data-testid="home-rail"]:visible');
+
+  await expect
+    .poll(
+      async () => {
+        const before = await rail.boundingBox();
+        await world.page.waitForTimeout(80);
+        const after = await rail.boundingBox();
+        return before?.x === after?.x;
+      },
+      { timeout: WAIT_TIMEOUT },
+    )
+    .toBe(true);
+};
+
 Given('用户在受限宽度下打开 Home 页面', async function (this: CustomWorld) {
   // Keep the desktop width while constraining the height so a fresh E2E account's
   // single rail card still overflows and exposes the real ScrollArea scrollbar.
@@ -68,6 +89,7 @@ Then('Home 右栏折叠控制应固定在页面右上角', async function (this:
 
   await toggle.click();
   await expect(rail).toBeVisible({ timeout: WAIT_TIMEOUT });
+  await settleRail(this);
 });
 
 Then('Home 开合右栏不应改变主列纵向位置', async function (this: CustomWorld) {
@@ -81,14 +103,16 @@ Then('Home 开合右栏不应改变主列纵向位置', async function (this: Cu
   await toggle.click();
   await expect(rail).toHaveCount(0);
 
-  // The greeting measures against a fixed width, so collapsing must not re-wrap
-  // it and push the composer plus the whole task list down a line.
+  // Measured mid-collapse on purpose: the greeting wraps against a fixed width,
+  // so no frame of the transition may re-wrap it and push the composer plus the
+  // whole task list down a line.
   const collapsedBox = await main.boundingBox();
   expect(collapsedBox).not.toBeNull();
   expect(collapsedBox!.y).toBeCloseTo(expandedBox!.y, 0);
 
   await toggle.click();
   await expect(rail).toBeVisible({ timeout: WAIT_TIMEOUT });
+  await settleRail(this);
 });
 
 Then('Home 右栏应保持卡片、滚动条轨道与页面边缘的分层间距', async function (this: CustomWorld) {

--- a/src/business/client/features/HomePromoBanner.tsx
+++ b/src/business/client/features/HomePromoBanner.tsx
@@ -1,3 +1,0 @@
-export default function HomePromoBanner() {
-  return null;
-}

--- a/src/business/client/features/useHomePromoLine.ts
+++ b/src/business/client/features/useHomePromoLine.ts
@@ -1,0 +1,8 @@
+import type { ReactNode } from 'react';
+
+/**
+ * The promo the home portrait speaks. Returning a node (rather than rendering
+ * one) is what lets the caller know a promo is live, so it can hold back the
+ * daily brief — and hand the brief back the moment the promo is dismissed.
+ */
+export const useHomePromoLine = (): ReactNode | undefined => undefined;

--- a/src/features/Home/HomeHeader.tsx
+++ b/src/features/Home/HomeHeader.tsx
@@ -9,26 +9,22 @@ import { authSelectors, userProfileSelectors } from '@/store/user/slices/auth/se
 import AgentSelect from './AgentSelect';
 
 const styles = createStaticStyles(({ css }) => ({
-  // A fixed measure, not a fluid one: collapsing the rail changes this column's
-  // width, and a headline that re-wraps on collapse would shove the composer
-  // and the whole task list down by a line. Wide enough that a long display
-  // name still fits, narrow enough to stay clear of the portrait's bubble.
+  // The measure comes from the layout (`--home-greeting-measure`), which derives
+  // it from the container width: it has to clear the portrait's bubble, and it
+  // must not depend on the rail, or collapsing would re-wrap the headline and
+  // shove the composer and the whole task list down by a line.
   greeting: css`
     overflow: hidden;
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
 
-    max-width: 440px;
+    max-width: var(--home-greeting-measure, none);
     margin: 0;
 
     font-size: 22px;
     line-height: 1.4;
     letter-spacing: -0.01em;
-
-    @media (width <= 1100px) {
-      max-width: none;
-    }
   `,
   toolbar: css`
     width: 100%;

--- a/src/features/Home/HomeHeader.tsx
+++ b/src/features/Home/HomeHeader.tsx
@@ -3,49 +3,34 @@ import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import HomePromoBanner from '@/business/client/features/HomePromoBanner';
-import { useHomeDailyBrief } from '@/hooks/useHomeDailyBrief';
 import { useUserStore } from '@/store/user';
 import { authSelectors, userProfileSelectors } from '@/store/user/slices/auth/selectors';
 
 import AgentSelect from './AgentSelect';
-import GreetingLine from './GreetingLine';
-import RailToggle from './RailToggle';
-import { parseGreetingLine } from './welcomeText';
 
 const styles = createStaticStyles(({ css }) => ({
-  // The dynamic half is generated prose of unpredictable length, and the
-  // composer sits directly below — clamp to two lines so a wordy brief can
-  // never push the input down the page.
+  // A fixed measure, not a fluid one: collapsing the rail changes this column's
+  // width, and a headline that re-wraps on collapse would shove the composer
+  // and the whole task list down by a line. Wide enough that a long display
+  // name still fits, narrow enough to stay clear of the portrait's bubble.
   greeting: css`
     overflow: hidden;
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
 
+    max-width: 440px;
     margin: 0;
 
     font-size: 22px;
     line-height: 1.4;
     letter-spacing: -0.01em;
-  `,
-  promo: css`
-    flex: none;
-    min-width: 0;
-
-    @container (width <= 620px) {
-      display: none;
-    }
-  `,
-  railToggle: css`
-    display: none;
 
     @media (width <= 1100px) {
-      display: block;
+      max-width: none;
     }
   `,
   toolbar: css`
-    container-type: inline-size;
     width: 100%;
     min-width: 0;
     min-height: 48px;
@@ -58,57 +43,23 @@ const getGreetingKey = (hour: number): 'afternoon' | 'evening' | 'morning' => {
   return 'evening';
 };
 
-/** CJK greetings already end on a full-width stop, which carries its own trailing space. */
-const greetingSeparator = (greeting: string) => (/[。！？]$/.test(greeting) ? '' : ' ');
-
-interface HomeHeaderProps {
-  onToggleRail?: () => void;
-  railVisible: boolean;
-}
-
-const HomeHeader = memo<HomeHeaderProps>(({ onToggleRail, railVisible }) => {
+const HomeHeader = memo(() => {
   const { t } = useTranslation('home');
   const displayName = useUserStore(userProfileSelectors.displayUserName);
   const isLogin = useUserStore(authSelectors.isLogin);
-
-  const { currentPair } = useHomeDailyBrief();
 
   const greetingKey = getGreetingKey(new Date().getHours());
   const greeting = isLogin
     ? t(`dashboard.greeting.${greetingKey}`, { name: displayName })
     : t(`dashboard.greeting.${greetingKey}Guest`);
-  // Falls back to the static line until the daily brief lands — or forever, for
-  // an account the generator has not run for yet.
-  const parsed = currentPair?.welcome ? parseGreetingLine(currentPair.welcome) : undefined;
+
   return (
     <Flexbox gap={16} justify={'center'}>
-      <Flexbox
-        horizontal
-        align={'center'}
-        className={styles.toolbar}
-        gap={16}
-        justify={'space-between'}
-      >
+      <Flexbox horizontal align={'center'} className={styles.toolbar} gap={16}>
         <AgentSelect />
-        <Flexbox horizontal align={'center'} flex={'none'} gap={4}>
-          <div className={styles.promo}>
-            <HomePromoBanner />
-          </div>
-          {isLogin && onToggleRail && (
-            <div className={styles.railToggle}>
-              <RailToggle
-                railVisible={railVisible}
-                testId={'home-rail-toggle-mobile'}
-                onToggle={onToggleRail}
-              />
-            </div>
-          )}
-        </Flexbox>
       </Flexbox>
       <Text as={'h1'} className={styles.greeting} weight={600}>
         {greeting}
-        {greetingSeparator(greeting)}
-        {parsed?.plain ? <GreetingLine parsed={parsed} /> : t('dashboard.greeting.subtitle')}
       </Text>
     </Flexbox>
   );

--- a/src/features/Home/HomeNavHeader.tsx
+++ b/src/features/Home/HomeNavHeader.tsx
@@ -1,0 +1,43 @@
+import { createStaticStyles } from 'antd-style';
+import { memo } from 'react';
+
+import NavHeader from '@/features/NavHeader';
+import { useGlobalStore } from '@/store/global';
+import { systemStatusSelectors } from '@/store/global/selectors';
+import { useUserStore } from '@/store/user';
+import { authSelectors } from '@/store/user/slices/auth/selectors';
+
+import RailToggle from './RailToggle';
+
+// Floats over the dashboard instead of pushing it down: the controls live in
+// the page's top corners, where the content never reaches.
+const styles = createStaticStyles(({ css }) => ({
+  header: css`
+    position: absolute;
+    z-index: 10;
+    inset-block-start: 0;
+    inset-inline: 0;
+  `,
+}));
+
+const HomeNavHeader = memo(() => {
+  const isLogin = useUserStore(authSelectors.isLogin);
+  const [showHomeRail, toggleHomeRail, isStatusInit] = useGlobalStore((s) => [
+    systemStatusSelectors.showHomeRail(s),
+    s.toggleHomeRail,
+    systemStatusSelectors.isStatusInit(s),
+  ]);
+
+  return (
+    <NavHeader
+      className={styles.header}
+      right={
+        isLogin && isStatusInit ? (
+          <RailToggle railVisible={showHomeRail} onToggle={toggleHomeRail} />
+        ) : undefined
+      }
+    />
+  );
+});
+
+export default HomeNavHeader;

--- a/src/features/Home/PortraitBubble/bubbleLine.test.ts
+++ b/src/features/Home/PortraitBubble/bubbleLine.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveBubbleLine } from './bubbleLine';
+
+describe('resolveBubbleLine', () => {
+  it('lets a promo interrupt the brief', () => {
+    expect(resolveBubbleLine({ hasBrief: true, hasPromo: true })).toBe('promo');
+  });
+
+  it('hands the brief back once the promo is gone', () => {
+    expect(resolveBubbleLine({ hasBrief: true, hasPromo: false })).toBe('brief');
+  });
+
+  it('falls back to the static line rather than going mute', () => {
+    expect(resolveBubbleLine({ hasBrief: false, hasPromo: false })).toBe('fallback');
+    expect(resolveBubbleLine({ hasBrief: false, hasPromo: true })).toBe('promo');
+  });
+});

--- a/src/features/Home/PortraitBubble/bubbleLine.ts
+++ b/src/features/Home/PortraitBubble/bubbleLine.ts
@@ -1,0 +1,17 @@
+export type BubbleLineKind = 'brief' | 'fallback' | 'promo';
+
+interface BubbleLineInput {
+  hasBrief: boolean;
+  hasPromo: boolean;
+}
+
+/**
+ * The portrait has one mouth, so its lines queue rather than stack: a promo
+ * interrupts the brief, and dismissing the promo hands the brief back instead
+ * of leaving the agent mute.
+ */
+export const resolveBubbleLine = ({ hasPromo, hasBrief }: BubbleLineInput): BubbleLineKind => {
+  if (hasPromo) return 'promo';
+  if (hasBrief) return 'brief';
+  return 'fallback';
+};

--- a/src/features/Home/PortraitBubble/index.tsx
+++ b/src/features/Home/PortraitBubble/index.tsx
@@ -1,0 +1,95 @@
+import { createStaticStyles } from 'antd-style';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useHomePromoLine } from '@/business/client/features/useHomePromoLine';
+import { useHomeDailyBrief } from '@/hooks/useHomeDailyBrief';
+
+import GreetingLine from '../GreetingLine';
+import { parseGreetingLine } from '../welcomeText';
+import { resolveBubbleLine } from './bubbleLine';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  // Prose, not a row of chips: a flex container would make the brief's entity
+  // links their own flex items and break the sentence into side-by-side columns.
+  bubble: css`
+    position: relative;
+
+    overflow: hidden;
+    display: block;
+
+    max-width: 336px;
+    padding-block: 8px;
+    padding-inline: 12px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: 14px;
+
+    font-size: 14px;
+    line-height: 1.5;
+    color: ${cssVar.colorTextSecondary};
+
+    background: ${cssVar.colorBgContainer};
+    box-shadow: ${cssVar.boxShadowTertiary};
+
+    /* The tail is what makes this read as the agent's line rather than one more
+       toolbar chip, so it exists only where the portrait does. */
+    @media (width > 1100px) {
+      &::after {
+        content: '';
+
+        position: absolute;
+        inset-block-start: 50%;
+        inset-inline-end: -5px;
+        transform: translateY(-50%) rotate(45deg);
+
+        width: 9px;
+        height: 9px;
+        border-block-start: 1px solid ${cssVar.colorBorderSecondary};
+        border-inline-end: 1px solid ${cssVar.colorBorderSecondary};
+
+        background: ${cssVar.colorBgContainer};
+      }
+
+      &:dir(rtl)::after {
+        inset-inline: -5px auto;
+        transform: translateY(-50%) rotate(225deg);
+      }
+    }
+  `,
+  // The bubble is anchored by its bottom edge, so an unbounded line grows
+  // upward into the toolbar row.
+  line: css`
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  `,
+  promo: css`
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  `,
+}));
+
+const PortraitBubble = memo(() => {
+  const { t } = useTranslation('home');
+  const promo = useHomePromoLine();
+  const { currentPair } = useHomeDailyBrief();
+
+  const parsed = currentPair?.welcome ? parseGreetingLine(currentPair.welcome) : undefined;
+  const kind = resolveBubbleLine({ hasBrief: Boolean(parsed?.plain), hasPromo: Boolean(promo) });
+
+  return (
+    <div className={styles.bubble}>
+      {kind === 'promo' && <div className={styles.promo}>{promo}</div>}
+      {kind === 'brief' && parsed && (
+        <div className={styles.line}>
+          <GreetingLine parsed={parsed} />
+        </div>
+      )}
+      {kind === 'fallback' && <div className={styles.line}>{t('dashboard.greeting.subtitle')}</div>}
+    </div>
+  );
+});
+
+export default PortraitBubble;

--- a/src/features/Home/PortraitBubble/index.tsx
+++ b/src/features/Home/PortraitBubble/index.tsx
@@ -18,7 +18,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     overflow: hidden;
     display: block;
 
-    max-width: 336px;
+    max-width: 100%;
     padding-block: 8px;
     padding-inline: 12px;
     border: 1px solid ${cssVar.colorBorderSecondary};
@@ -32,28 +32,29 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     box-shadow: ${cssVar.boxShadowTertiary};
 
     /* The tail is what makes this read as the agent's line rather than one more
-       toolbar chip, so it exists only where the portrait does. */
-    @media (width > 1100px) {
-      &::after {
-        content: '';
+       toolbar chip, so the layout switches it off via --home-bubble-tail wherever
+       it parks the bubble below the greeting instead of beside him. */
+    &::after {
+      content: '';
 
-        position: absolute;
-        inset-block-start: 50%;
-        inset-inline-end: -5px;
-        transform: translateY(-50%) rotate(45deg);
+      position: absolute;
+      inset-block-start: 50%;
+      inset-inline-end: -5px;
+      transform: translateY(-50%) rotate(45deg);
 
-        width: 9px;
-        height: 9px;
-        border-block-start: 1px solid ${cssVar.colorBorderSecondary};
-        border-inline-end: 1px solid ${cssVar.colorBorderSecondary};
+      display: var(--home-bubble-tail, none);
 
-        background: ${cssVar.colorBgContainer};
-      }
+      width: 9px;
+      height: 9px;
+      border-block-start: 1px solid ${cssVar.colorBorderSecondary};
+      border-inline-end: 1px solid ${cssVar.colorBorderSecondary};
 
-      &:dir(rtl)::after {
-        inset-inline: -5px auto;
-        transform: translateY(-50%) rotate(225deg);
-      }
+      background: ${cssVar.colorBgContainer};
+    }
+
+    &:dir(rtl)::after {
+      inset-inline: -5px auto;
+      transform: translateY(-50%) rotate(225deg);
     }
   `,
   // The bubble is anchored by its bottom edge, so an unbounded line grows

--- a/src/features/Home/RailToggle.tsx
+++ b/src/features/Home/RailToggle.tsx
@@ -1,39 +1,10 @@
 import { ActionIcon } from '@lobehub/ui';
-import { createStaticStyles, cx } from 'antd-style';
-import {
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  PanelRightCloseIcon,
-  PanelRightOpenIcon,
-} from 'lucide-react';
+import { createStaticStyles } from 'antd-style';
+import { PanelRightCloseIcon, PanelRightOpenIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const styles = createStaticStyles(({ css, cssVar }) => ({
-  edge: css`
-    color: ${cssVar.colorTextQuaternary};
-    opacity: 0.56;
-    background: ${cssVar.colorFillQuaternary};
-    transition:
-      color ${cssVar.motionDurationFast} ${cssVar.motionEaseOut},
-      background ${cssVar.motionDurationFast} ${cssVar.motionEaseOut},
-      opacity ${cssVar.motionDurationFast} ${cssVar.motionEaseOut};
-
-    &[aria-expanded='false'] {
-      opacity: 0.8;
-    }
-
-    &:hover,
-    &:focus-visible {
-      color: ${cssVar.colorTextSecondary};
-      opacity: 1;
-      background: ${cssVar.colorFillSecondary};
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-      transition: none;
-    }
-  `,
+const styles = createStaticStyles(({ css }) => ({
   root: css`
     &:dir(rtl) svg {
       transform: scaleX(-1);
@@ -41,37 +12,24 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
-const EDGE_SIZE = { blockSize: 40, borderRadius: 999, size: 14, strokeWidth: 2 } as const;
-const EDGE_STYLE = { width: 18 } as const;
-
 interface RailToggleProps {
-  edge?: boolean;
   onToggle: () => void;
   railVisible: boolean;
-  testId: string;
 }
 
-const RailToggle = memo<RailToggleProps>(({ edge, onToggle, railVisible, testId }) => {
+const RailToggle = memo<RailToggleProps>(({ onToggle, railVisible }) => {
   const { t } = useTranslation('home');
   const label = railVisible ? t('dashboard.rail.hide') : t('dashboard.rail.show');
-  const icon = edge
-    ? railVisible
-      ? ChevronRightIcon
-      : ChevronLeftIcon
-    : railVisible
-      ? PanelRightCloseIcon
-      : PanelRightOpenIcon;
 
   return (
     <ActionIcon
       aria-controls={'home-rail'}
       aria-expanded={railVisible}
       aria-label={label}
-      className={cx(styles.root, edge && styles.edge)}
-      data-testid={testId}
-      icon={icon}
-      size={edge ? EDGE_SIZE : 'small'}
-      style={edge ? EDGE_STYLE : undefined}
+      className={styles.root}
+      data-testid={'home-rail-toggle'}
+      icon={railVisible ? PanelRightCloseIcon : PanelRightOpenIcon}
+      size={'small'}
       title={label}
       variant={'borderless'}
       onClick={onToggle}

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -16,7 +16,7 @@ import HomeHeader from './HomeHeader';
 import HomeModeContent from './HomeModeContent';
 import HomePortrait from './HomePortrait';
 import InputArea from './InputArea';
-import RailToggle from './RailToggle';
+import PortraitBubble from './PortraitBubble';
 import type { HomeMode } from './types';
 
 /** Mirrors the row hover bleed in HomeModeContent; the viewport would clip it. */
@@ -39,7 +39,12 @@ const RAIL_COLUMN_GAP = 28;
 const MAIN_SCROLLBAR_OFFSET = RAIL_COLUMN_GAP / 2;
 const RAIL_EXIT_OFFSET = 24;
 const RAIL_TRANSITION_DURATION = 220;
-const COLLAPSED_CONTENT_OFFSET = (RAIL_CARD_WIDTH + RAIL_GUTTER + RAIL_COLUMN_GAP) / 2;
+const RAIL_RECLAIMED_WIDTH = RAIL_CARD_WIDTH + RAIL_GUTTER + RAIL_COLUMN_GAP;
+/** Share of the vacated rail track the content keeps; the rest is split as margin. */
+const COLLAPSED_CONTENT_GAIN = 140;
+const COLLAPSED_CONTENT_OFFSET = (RAIL_RECLAIMED_WIDTH - COLLAPSED_CONTENT_GAIN) / 2;
+/** Portrait width plus its inline inset and the gap the bubble keeps from it. */
+const PORTRAIT_LANE = 152 + 12 + 16;
 
 const MAIN_CONTENT_STYLE = { ...scrollContent, paddingInline: ROW_BLEED };
 const RAIL_CONTENT_STYLE = { ...scrollContent, paddingInlineEnd: RAIL_GUTTER };
@@ -64,15 +69,24 @@ const styles = createStaticStyles(({ css }) => ({
     }
   `,
   content: css`
-    transition: transform ${RAIL_TRANSITION_DURATION}ms ease-out;
+    /* An explicit width is what makes the collapse animate: the stretched
+       default computes to "auto", which cannot interpolate against a length,
+       so the width would snap while the transform slid. */
+    width: 100%;
+    transition:
+      transform ${RAIL_TRANSITION_DURATION}ms ease-out,
+      width ${RAIL_TRANSITION_DURATION}ms ease-out;
 
     @media (prefers-reduced-motion: reduce) {
       transition: none;
     }
   `,
-  contentCentered: css`
+  // Collapsed, the content takes part of the vacated rail track and re-centers
+  // on what is left, so the page reads wider without going full-bleed.
+  contentCollapsed: css`
     @media (width > 1100px) {
       transform: translateX(${COLLAPSED_CONTENT_OFFSET}px);
+      width: calc(100% + ${COLLAPSED_CONTENT_GAIN}px);
 
       &:dir(rtl) {
         transform: translateX(-${COLLAPSED_CONTENT_OFFSET}px);
@@ -80,7 +94,43 @@ const styles = createStaticStyles(({ css }) => ({
     }
   `,
   header: css`
+    position: relative;
     grid-area: 1 / 1;
+  `,
+  // Parks beside the portrait on desktop; below the greeting once the portrait
+  // is gone, where it is just another line and needs no anchoring.
+  bubbleSlot: css`
+    margin-block-start: 16px;
+
+    @media (width > 1100px) {
+      position: absolute;
+      inset-block-end: 4px;
+
+      /* Anchored to the header's trailing edge, which itself widens and slides
+         on collapse — so the slot only has to make up the difference, and it
+         makes it up with a transform, in step with the portrait it belongs to. */
+      inset-inline-end: ${PORTRAIT_LANE - RAIL_RECLAIMED_WIDTH}px;
+
+      display: flex;
+      justify-content: flex-end;
+
+      margin-block-start: 0;
+
+      transition: transform ${RAIL_TRANSITION_DURATION}ms ease-out;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
+  `,
+  bubbleSlotCollapsed: css`
+    @media (width > 1100px) {
+      transform: translateX(-${RAIL_RECLAIMED_WIDTH}px);
+
+      &:dir(rtl) {
+        transform: translateX(${RAIL_RECLAIMED_WIDTH}px);
+      }
+    }
   `,
   inputArea: css`
     position: relative;
@@ -91,17 +141,6 @@ const styles = createStaticStyles(({ css }) => ({
     grid-area: 2 / 1;
     min-width: 0;
     min-height: 0;
-  `,
-  railToggle: css`
-    position: absolute;
-    z-index: 3;
-    inset-block-start: 50%;
-    inset-inline-end: -23px;
-    transform: translateY(-50%);
-
-    @media (width <= 1100px) {
-      display: none;
-    }
   `,
   mainScroll: css`
     flex: 1;
@@ -123,9 +162,26 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   portrait: css`
     grid-area: 1 / 2;
+    transition: transform ${RAIL_TRANSITION_DURATION}ms ease-out;
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
 
     @media (width <= 1100px) {
       display: none;
+    }
+  `,
+  // With the rail gone the agent has nothing to lean into, so it slides over the
+  // composer instead of disappearing with the cards — keeping the same dip, so
+  // the same half of it stays behind the surface it leans on.
+  portraitCollapsed: css`
+    @media (width > 1100px) {
+      transform: translateX(-${COLLAPSED_CONTENT_OFFSET}px);
+
+      &:dir(rtl) {
+        transform: translateX(${COLLAPSED_CONTENT_OFFSET}px);
+      }
     }
   `,
   railSurface: css`
@@ -193,11 +249,7 @@ const styles = createStaticStyles(({ css }) => ({
 
 const Home = memo(() => {
   const isLogin = useUserStore(authSelectors.isLogin);
-  const [showHomeRail, toggleHomeRail, isStatusInit] = useGlobalStore((s) => [
-    systemStatusSelectors.showHomeRail(s),
-    s.toggleHomeRail,
-    systemStatusSelectors.isStatusInit(s),
-  ]);
+  const showHomeRail = useGlobalStore(systemStatusSelectors.showHomeRail);
   const [mode, setMode] = useState<HomeMode>('chat');
   const [inputValue, setInputValue] = useState('');
   const railVisible = Boolean(isLogin && showHomeRail);
@@ -221,39 +273,28 @@ const Home = memo(() => {
 
   return (
     <Flexbox className={styles.grid}>
-      <div className={cx(styles.header, styles.content, railCollapsed && styles.contentCentered)}>
-        <HomeHeader
-          railVisible={railVisible}
-          onToggleRail={isStatusInit ? toggleHomeRail : undefined}
-        />
+      <div className={cx(styles.header, styles.content, railCollapsed && styles.contentCollapsed)}>
+        <HomeHeader />
+        {/* No portrait for signed-out visitors, so no one to speak the line. */}
+        {isLogin && (
+          <div className={cx(styles.bubbleSlot, railCollapsed && styles.bubbleSlotCollapsed)}>
+            <PortraitBubble />
+          </div>
+        )}
       </div>
 
       {isLogin && (
-        <div
-          aria-hidden={railCollapsed}
-          className={cx(styles.portrait, styles.railSurface)}
-          data-collapsed={railCollapsed}
-        >
+        <div className={cx(styles.portrait, railCollapsed && styles.portraitCollapsed)}>
           <HomePortrait />
         </div>
       )}
 
       <Flexbox
-        className={cx(styles.main, styles.content, railCollapsed && styles.contentCentered)}
+        className={cx(styles.main, styles.content, railCollapsed && styles.contentCollapsed)}
         data-testid={'home-main'}
         gap={24}
       >
         <div className={styles.inputArea}>
-          {isLogin && isStatusInit && (
-            <div className={styles.railToggle}>
-              <RailToggle
-                edge
-                railVisible={railVisible}
-                testId={'home-rail-toggle-desktop'}
-                onToggle={toggleHomeRail}
-              />
-            </div>
-          )}
           <InputArea
             inputValue={inputValue}
             mode={mode}

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -45,6 +45,19 @@ const COLLAPSED_CONTENT_GAIN = 140;
 const COLLAPSED_CONTENT_OFFSET = (RAIL_RECLAIMED_WIDTH - COLLAPSED_CONTENT_GAIN) / 2;
 /** Portrait width plus its inline inset and the gap the bubble keeps from it. */
 const PORTRAIT_LANE = 152 + 12 + 16;
+const BUBBLE_MAX_WIDTH = 336;
+const BUBBLE_GAP = 16;
+/**
+ * What the greeting must leave alone so the bubble never lands on it, measured
+ * in the tighter of the two states: the collapsed content is inset by
+ * COLLAPSED_CONTENT_OFFSET on both sides, and the bubble occupies the portrait's
+ * lane plus its own width. Subtracted from the *container* width, because the
+ * bubble tracks the container's trailing edge while the greeting starts at its
+ * leading edge — a fixed measure only happens to clear it at full width.
+ */
+const GREETING_LANE = COLLAPSED_CONTENT_OFFSET * 2 + PORTRAIT_LANE + BUBBLE_MAX_WIDTH + BUBBLE_GAP;
+/** Under this the greeting, the bubble and the portrait cannot share a line. */
+const BUBBLE_INLINE_MIN = 1080;
 
 const MAIN_CONTENT_STYLE = { ...scrollContent, paddingInline: ROW_BLEED };
 const RAIL_CONTENT_STYLE = { ...scrollContent, paddingInlineEnd: RAIL_GUTTER };
@@ -53,6 +66,9 @@ const styles = createStaticStyles(({ css }) => ({
   // Row 1 (greeting + portrait) is fixed; row 2 gives each column its own
   // scroll viewport, so the rail and the task list scroll independently.
   grid: css`
+    /* The nav panel takes 240–400px out of the viewport, so viewport breakpoints
+       say nothing about the room this dashboard actually has. */
+    container: home / inline-size;
     display: grid;
     grid-template-columns: minmax(0, 1fr) ${RAIL_CARD_WIDTH + RAIL_GUTTER}px;
     grid-template-rows: auto minmax(0, 1fr);
@@ -94,15 +110,26 @@ const styles = createStaticStyles(({ css }) => ({
     }
   `,
   header: css`
+    --home-greeting-measure: none;
+
     position: relative;
     grid-area: 1 / 1;
+
+    @container home (width >= ${BUBBLE_INLINE_MIN}px) {
+      --home-greeting-measure: calc(100cqw - ${GREETING_LANE}px);
+    }
   `,
-  // Parks beside the portrait on desktop; below the greeting once the portrait
-  // is gone, where it is just another line and needs no anchoring.
+  // Parks beside the portrait when the row is wide enough for the three of them;
+  // otherwise it drops below the greeting, where it is just another line and
+  // needs no anchoring.
   bubbleSlot: css`
+    --home-bubble-tail: none;
+
     margin-block-start: 16px;
 
-    @media (width > 1100px) {
+    @container home (width >= ${BUBBLE_INLINE_MIN}px) {
+      --home-bubble-tail: block;
+
       position: absolute;
       inset-block-end: 4px;
 
@@ -114,6 +141,7 @@ const styles = createStaticStyles(({ css }) => ({
       display: flex;
       justify-content: flex-end;
 
+      max-width: ${BUBBLE_MAX_WIDTH}px;
       margin-block-start: 0;
 
       transition: transform ${RAIL_TRANSITION_DURATION}ms ease-out;
@@ -124,7 +152,7 @@ const styles = createStaticStyles(({ css }) => ({
     }
   `,
   bubbleSlotCollapsed: css`
-    @media (width > 1100px) {
+    @container home (width >= ${BUBBLE_INLINE_MIN}px) {
       transform: translateX(-${RAIL_RECLAIMED_WIDTH}px);
 
       &:dir(rtl) {

--- a/src/features/Home/welcomeText.ts
+++ b/src/features/Home/welcomeText.ts
@@ -31,9 +31,9 @@ const normalize = (raw: string): string => raw.replaceAll('**', '').replaceAll(/
 
 /**
  * The daily-brief welcome is authored as markdown for a two-line block of its
- * own, where each line is a separate finding. The greeting appends it to a
- * sentence instead, so only the first finding is taken — concatenating both
- * with a space reads as one run-on claim and pushes the heading to three lines.
+ * own, where each line is a separate finding. The portrait speaks a single
+ * line instead, so only the first finding is taken — concatenating both reads
+ * as one run-on claim, and overruns the bubble.
  *
  * Links are kept as spans rather than flattened: the generator wraps every
  * referenced entity in `[name](url)` precisely so the reader can jump to it.

--- a/src/routes/(main)/home/index.tsx
+++ b/src/routes/(main)/home/index.tsx
@@ -3,14 +3,14 @@ import { type FC } from 'react';
 
 import HomePageTracker from '@/components/Analytics/HomePageTracker';
 import HomeContent from '@/features/Home';
-import NavHeader from '@/features/NavHeader';
+import HomeNavHeader from '@/features/Home/HomeNavHeader';
 import WideScreenContainer from '@/features/WideScreenContainer';
 
 const Home: FC = () => {
   return (
     <>
       <HomePageTracker />
-      <NavHeader />
+      <HomeNavHeader />
       <Flexbox
         height={'100%'}
         style={{ overflow: 'hidden', paddingBlockStart: 32, paddingInline: 24 }}


### PR DESCRIPTION
The home promo used to be a chip in the header toolbar, and the daily brief was glued onto the greeting. Both now come out of the portrait's mouth, so the agent has one voice instead of two and the headline is just a greeting.

| Before | After |
| ------ | ----- |
| Promo chip sits in the toolbar next to the agent name; the brief is appended to the `h1`; the rail toggle floats at the composer's right edge | The portrait speaks one line — promo if one is live, otherwise the brief, otherwise `greeting.subtitle`; the headline is greeting-only; the rail toggle sits in a fixed top-right slot |

Screenshots pending — the surface needs a signed-in cloud session, so I verified the geometry against a prototype built on the same design system and the same constants rather than shipping a misleading capture.

#### What changed

- **`useHomePromoLine()` replaces the `HomePromoBanner` stub.** Returning a node rather than rendering one is what lets the caller know a promo is live, hold the brief back while it speaks, and hand the brief back the moment it is dismissed — so the agent is never left mute. **Cloud must follow**: `HomePromoBanner/index.tsx` has to return label + CTA + dismiss as bare content, move its impression tracking into the hook (and only record when the line is actually spoken), and express the `FreePlanGate` wait as `undefined`. Any "how long does a promo hold the mouth" policy lives there too.
- **The headline takes a fixed 440px measure.** It used to wrap against the column, whose width changes on collapse (818 → 782), so a brief of the wrong length re-wrapped and pushed the composer plus the whole task list down a line. Probing real headline lengths at the shipped font found 42–43 CJK characters landing exactly on that boundary — one line open, two collapsed, a 30.8px jump. Now the line count depends only on the copy.
- **The rail toggle moves to a fixed top-right slot** in an absolutely positioned nav header (no height of its own), replacing both the edge control and its mobile twin; one control at every width.
- **Collapsed, the content reclaims 140px** of the vacated rail track and the portrait slides over to lean on the composer instead of leaving with the cards. `content` also gained an explicit `width: 100%` — the stretched default computes to `auto`, which cannot interpolate against a length, so the width used to snap while the transform slid.
- **The bubble rides the same 220ms curve** as the portrait: its offset is carried by a transform, not by `inset`, so the gap between them holds at 16px for every frame of the collapse.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`resolveBubbleLine` has unit coverage for the three-way priority (promo interrupts brief / dismissing hands the brief back / neither falls back to the static line). The e2e home layout scenario gains `Home 开合右栏不应改变主列纵向位置`, which is the regression for the headline re-wrap above, and its rail-toggle step now asserts the control keeps its top-right slot across a collapse instead of hugging the column boundary.

Lint clean; full type-check shows only the pre-existing `keygrip` errors in `src/libs/oidc-provider`.

#### 🔗 Related Issue

None — no matching issue found.

---

The second commit (`📝 docs(acceptance)`) is unrelated bookkeeping: three lessons for the acceptance catalogue that were already sitting in the working tree.