### PR TITLE
✨ feat(onboarding): decouple task recommendation generation

### DIFF
--- a/apps/server/src/services/understanding/service.ts
+++ b/apps/server/src/services/understanding/service.ts
@@ -84,6 +84,16 @@ type UnderstandingRepository = Pick<
 
 type UnderstandingContexts = Pick<UnderstandingSourceStore, 'get' | 'put'>;
 
+/** Controls optional downstream work started with an Understanding collection run. */
+export interface UnderstandingStartOptions {
+  /**
+   * Starts task recommendations as soon as the first source completes.
+   *
+   * @default true
+   */
+  triggerTaskRecommendations?: boolean;
+}
+
 export interface UnderstandingServiceDependencies {
   connectorData: ConnectorDataService;
   generator: Pick<AiGenerationService, 'generateObject'>;
@@ -257,6 +267,7 @@ export class UnderstandingService {
     topicId: string,
     responseLanguage: string,
     selectedProviderIds?: string[],
+    options: UnderstandingStartOptions = {},
   ): Promise<OnboardingUnderstandingPollingResult> => {
     const { OnboardingUnderstandingWorkflow } =
       await import('@/server/workflows/onboardingUnderstanding');
@@ -272,6 +283,7 @@ export class UnderstandingService {
           providers,
           responseLanguage,
           sessionId: session.id,
+          triggerTaskRecommendations: options.triggerTaskRecommendations,
           topicId,
           userId: this.dependencies.userId,
         },

--- a/apps/server/src/workflows/onboardingUnderstanding/processProviders.test.ts
+++ b/apps/server/src/workflows/onboardingUnderstanding/processProviders.test.ts
@@ -162,6 +162,29 @@ describe('processUnderstandingProviders', () => {
     );
   });
 
+  /**
+   * @example A diagnostic run writes Understanding without implicitly starting task generation.
+   */
+  it('can suppress automatic task recommendations while preserving Understanding writing', async () => {
+    const service = { processProvider: vi.fn(async () => completed('github', 'github@1')) };
+    const diagnostic = createContext({
+      ...payload,
+      providers: [{ id: 'github', revision: 1 }],
+      triggerTaskRecommendations: false,
+    });
+    const triggerTaskRecommendations = vi.fn<TriggerTaskRecommendations>(async () => undefined);
+
+    await processUnderstandingProviders(diagnostic.context as never, {
+      createService: async () => service as never,
+      processCollectedWorkflow: workflow as never,
+      triggerTaskRecommendations,
+    });
+
+    expect(diagnostic.invocations).toHaveLength(1);
+    expect(diagnostic.invocations[0].settings.body.sourceFingerprint).toBe('github@1');
+    expect(triggerTaskRecommendations).not.toHaveBeenCalled();
+  });
+
   it('does not invoke writing for terminal failure and lets transient errors retry', async () => {
     const terminal = createContext({
       ...payload,

--- a/apps/server/src/workflows/onboardingUnderstanding/processProviders.ts
+++ b/apps/server/src/workflows/onboardingUnderstanding/processProviders.ts
@@ -98,7 +98,7 @@ export const processUnderstandingProviders = async (
           topicId: payload.topicId,
           userId: payload.userId,
         };
-        await Promise.all([
+        const downstreamTasks: Promise<unknown>[] = [
           context.invoke(`provider:${providerId}:write:${result.revision}`, {
             body,
             // Serialize writers for this session. The repository's fingerprint CAS then prevents a
@@ -110,27 +110,32 @@ export const processUnderstandingProviders = async (
             workflow: dependencies.processCollectedWorkflow,
             workflowRunId: collectedWorkflowRunId(payload.sessionId, result.sourceFingerprint),
           }),
-          context.run(`provider:${providerId}:recommend:${result.revision}`, () =>
-            // NOTICE:
-            // Cross-route workflow fan-out must use an absolute QStash trigger.
-            // context.invoke only replaces the current URL's final path segment, which sent this
-            // child to `/api/workflows/onboarding/understanding/process` and returned 404.
-            // Source/context: `workflows-hono/memory-user-memory/workflows/processUserTopics.ts:193`.
-            // Remove when Upstash context.invoke supports absolute cross-route workflow URLs.
-            dependencies.triggerTaskRecommendations(body, {
-              // Every completed provider may race to schedule a fingerprint-specific run. The
-              // session-scoped flow-control key makes the first accepted fingerprint immutable.
-              flowControl: {
-                key: getTaskRecommendationFlowControlKey(payload.sessionId),
-                parallelism: 1,
-              },
-              workflowRunId: taskRecommendationWorkflowRunId(
-                payload.sessionId,
-                result.sourceFingerprint,
-              ),
-            }),
-          ),
-        ]);
+        ];
+        if (payload.triggerTaskRecommendations !== false) {
+          downstreamTasks.push(
+            context.run(`provider:${providerId}:recommend:${result.revision}`, () =>
+              // NOTICE:
+              // Cross-route workflow fan-out must use an absolute QStash trigger.
+              // context.invoke only replaces the current URL's final path segment, which sent this
+              // child to `/api/workflows/onboarding/understanding/process` and returned 404.
+              // Source/context: `workflows-hono/memory-user-memory/workflows/processUserTopics.ts:193`.
+              // Remove when Upstash context.invoke supports absolute cross-route workflow URLs.
+              dependencies.triggerTaskRecommendations(body, {
+                // Every completed provider may race to schedule a fingerprint-specific run. The
+                // session-scoped flow-control key makes the first accepted fingerprint immutable.
+                flowControl: {
+                  key: getTaskRecommendationFlowControlKey(payload.sessionId),
+                  parallelism: 1,
+                },
+                workflowRunId: taskRecommendationWorkflowRunId(
+                  payload.sessionId,
+                  result.sourceFingerprint,
+                ),
+              }),
+            ),
+          );
+        }
+        await Promise.all(downstreamTasks);
       }
 
       return {

--- a/apps/server/src/workflows/onboardingUnderstanding/types.ts
+++ b/apps/server/src/workflows/onboardingUnderstanding/types.ts
@@ -13,6 +13,12 @@ export interface ProcessUnderstandingProvidersPayload {
   responseLanguage: string;
   sessionId: string;
   topicId: string;
+  /**
+   * Whether completed sources should also start task recommendation generation.
+   *
+   * @default true
+   */
+  triggerTaskRecommendations?: boolean;
   userId: string;
 }
 
@@ -53,6 +59,7 @@ export const ProcessUnderstandingProvidersPayloadSchema = z
       .max(64)
       .regex(/^[A-Z]{2,3}(?:-[A-Z0-9]{2,8})*$/i),
     sessionId: identifierSchema,
+    triggerTaskRecommendations: z.boolean().optional(),
     topicId: identifierSchema,
     userId: identifierSchema,
   })


### PR DESCRIPTION
### 📝 Description

Allows onboarding Understanding callers to opt out of automatically launching task recommendations while preserving the existing default behavior. This enables independent, observable generation runs without changing the normal onboarding flow.

### ✅ Tests

- Added regression coverage for disabling task recommendation generation.
- `bunx vitest run --silent=passed-only apps/server/src/workflows/onboardingUnderstanding/processProviders.test.ts`
- `bun run check apps/server/src/services/understanding/service.ts apps/server/src/workflows/onboardingUnderstanding/processProviders.ts apps/server/src/workflows/onboardingUnderstanding/processProviders.test.ts apps/server/src/workflows/onboardingUnderstanding/types.ts`

### 🔗 Related issue

N/A