### PR TITLE
⚡️ perf(quota): paint persisted quota instantly and revalidate on focus

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/ClaudeCodeQuotaMenu.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/ClaudeCodeQuotaMenu.tsx
@@ -14,12 +14,12 @@ import QuotaMenu, { createQuotaSourceKey } from './QuotaMenu';
 import { buildClaudeSnapshotFromWindows, isQuotaStale } from './quotaViewModel';
 
 /**
- * Only hit the live Anthropic usage API when the persisted data is this stale.
- * Kept low-frequency (1h) — the panel reads from our DB, so it stays instant and
- * fresh-enough without hammering the rate-limited usage endpoint. A manual
- * refresh always forces a live fetch.
+ * Hit the live Anthropic usage API when the newest persisted reading is this
+ * stale. Focus / popover revalidation and manual refresh bypass this gate; the
+ * main-process snapshot cache (5 min fresh window) is what actually protects
+ * the rate-limited usage endpoint.
  */
-const QUOTA_REFRESH_MS = 60 * 60 * 1000;
+const QUOTA_REFRESH_MS = 30 * 60 * 1000;
 
 const createErrorSnapshot = (error: unknown): ClaudeCodeQuotaSnapshot => ({
   error: error instanceof Error ? error.message : String(error),
@@ -56,29 +56,37 @@ const ClaudeCodeQuotaMenu = memo<ClaudeCodeQuotaMenuProps>(({ env }) => {
   const sourceKey = createQuotaSourceKey('claude-code', env);
 
   /**
-   * DB-first: render the persisted windows from our own database, and only fall
-   * back to the live Anthropic usage API to refresh + ingest when the newest
-   * persisted reading is older than QUOTA_REFRESH_MS (or the user forces it). So
-   * the panel shows data instantly and survives a failing live fetch.
+   * DB-first: render the persisted windows from our own database, and go to the
+   * live Anthropic usage API to refresh + ingest when the newest persisted
+   * reading is older than QUOTA_REFRESH_MS, the caller revalidates (focus /
+   * popover open), or the user forces it. The persisted snapshot paints first
+   * through onInterim, so the panel shows data instantly and survives a failing
+   * live fetch.
    */
   const fetchQuota = useCallback(
-    async (options?: FetchQuotaOptions): Promise<ClaudeCodeQuotaSnapshot> => {
+    async (
+      options?: FetchQuotaOptions<ClaudeCodeQuotaSnapshot>,
+    ): Promise<ClaudeCodeQuotaSnapshot> => {
       const force = !!options?.force;
 
       // 1) Resolve the account to display — pinned for this agent, else the first.
-      let accounts = await agentQuotaService.listAccounts().catch(() => []);
+      const [initialAccounts, bindings] = await Promise.all([
+        agentQuotaService.listAccounts().catch(() => []),
+        agentId ? agentQuotaService.listBindings(agentId).catch(() => []) : [],
+      ]);
+      let accounts = initialAccounts;
       let claude = accounts.filter((a) => a.provider === 'claude-code');
-      let pinnedId: string | undefined;
-      if (agentId) {
-        const bindings = await agentQuotaService.listBindings(agentId).catch(() => []);
-        pinnedId = bindings.find((b) => b.role === 'pinned')?.accountId;
-      }
+      const pinnedId = bindings.find((b) => b.role === 'pinned')?.accountId;
       let account = claude.find((a) => a.id === pinnedId) ?? claude[0];
       let windows = account ? await agentQuotaService.getWindows(account.id).catch(() => []) : [];
 
-      // 2) Throttled live refresh + ingest.
+      // 2) Throttled live refresh + ingest. Paint the persisted windows before
+      // awaiting the live fetch so the panel never blocks on it.
       let live: ClaudeCodeQuotaSnapshot | null = null;
-      if (force || isQuotaStale(windows, Date.now(), QUOTA_REFRESH_MS)) {
+      if (force || options?.revalidate || isQuotaStale(windows, Date.now(), QUOTA_REFRESH_MS)) {
+        if (account && windows.length > 0) {
+          options?.onInterim?.(buildClaudeSnapshotFromWindows(account, windows));
+        }
         live = await heterogeneousAgentService
           .getClaudeCodeQuota({ env, ...(force ? { force: true } : {}) })
           .catch(() => null);

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/ClaudeCodeQuotaMenu.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/ClaudeCodeQuotaMenu.tsx
@@ -11,7 +11,7 @@ import { heterogeneousAgentService } from '@/services/electron/heterogeneousAgen
 import QuotaAccountSwitcher from './QuotaAccountSwitcher';
 import type { FetchQuotaOptions, QuotaWindowItem } from './QuotaMenu';
 import QuotaMenu, { createQuotaSourceKey } from './QuotaMenu';
-import { buildClaudeSnapshotFromWindows, isQuotaStale } from './quotaViewModel';
+import { buildClaudeSnapshotFromWindows, isQuotaStale, newestSeenAt } from './quotaViewModel';
 
 /**
  * Hit the live Anthropic usage API when the newest persisted reading is this
@@ -93,18 +93,29 @@ const ClaudeCodeQuotaMenu = memo<ClaudeCodeQuotaMenuProps>(({ env }) => {
 
         const externalAccountId = live?.identity?.externalAccountId;
         if (live?.status === 'ok' && externalAccountId && live.readings?.length) {
-          await agentQuotaService
-            .ingestClaudeSnapshot({ identity: live.identity!, readings: live.readings })
-            .catch(() => {});
-          accounts = await agentQuotaService.listAccounts().catch(() => accounts);
-          claude = accounts.filter((a) => a.provider === 'claude-code');
-          account =
-            claude.find((a) => a.externalAccountId === externalAccountId) ??
-            claude.find((a) => a.id === pinnedId) ??
-            claude[0];
-          windows = account
-            ? await agentQuotaService.getWindows(account.id).catch(() => windows)
-            : windows;
+          // A revalidation inside the main-process cache's fresh window gets the
+          // readings we already persisted echoed back (same capturedAt).
+          // Snapshots are append-only, so re-ingesting an echo would duplicate
+          // history rows and rerun calibration without new evidence — skip it.
+          const newestCapturedAt = live.readings.reduce((max, r) => Math.max(max, r.capturedAt), 0);
+          const isCachedEcho =
+            account?.externalAccountId === externalAccountId &&
+            newestCapturedAt <= newestSeenAt(windows);
+
+          if (!isCachedEcho) {
+            await agentQuotaService
+              .ingestClaudeSnapshot({ identity: live.identity!, readings: live.readings })
+              .catch(() => {});
+            accounts = await agentQuotaService.listAccounts().catch(() => accounts);
+            claude = accounts.filter((a) => a.provider === 'claude-code');
+            account =
+              claude.find((a) => a.externalAccountId === externalAccountId) ??
+              claude.find((a) => a.id === pinnedId) ??
+              claude[0];
+            windows = account
+              ? await agentQuotaService.getWindows(account.id).catch(() => windows)
+              : windows;
+          }
         }
       }
 

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/CodexQuotaMenu.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/CodexQuotaMenu.tsx
@@ -142,7 +142,7 @@ const CodexQuotaMenu = memo<CodexQuotaMenuProps>(({ command, env }) => {
   }, [sourceKey]);
 
   const fetchQuota = useCallback(
-    (options?: FetchQuotaOptions) =>
+    (options?: FetchQuotaOptions<CodexQuotaSnapshot>) =>
       heterogeneousAgentService.getCodexQuota({
         command,
         env,

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/QuotaMenu.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/QuotaMenu.test.tsx
@@ -203,6 +203,16 @@ const persistedSessionWindow = (lastSeenAt: number) => ({
   windowSeconds: 300 * 60,
 });
 
+/** A live session reading as fossilized by the desktop sampler at `capturedAt`. */
+const liveSessionReading = (capturedAt: number) => ({
+  capturedAt,
+  isActive: true,
+  limitType: 'session',
+  resetsAt: null,
+  scopeKey: '',
+  utilization: 8,
+});
+
 const codexSnapshot = (
   overrides: Partial<ElectronClientIpcModule.CodexQuotaSnapshot> = {},
 ): ElectronClientIpcModule.CodexQuotaSnapshot => ({
@@ -230,6 +240,7 @@ beforeEach(() => {
   toastErrorMock.mockReset();
   toastSuccessMock.mockReset();
   mockQuotaService.getWindows.mockResolvedValue([]);
+  mockQuotaService.ingestClaudeSnapshot.mockClear();
   mockQuotaService.listAccounts.mockResolvedValue([]);
   mockQuotaService.listBindings.mockResolvedValue([]);
 });
@@ -640,6 +651,57 @@ describe('ClaudeCodeQuotaMenu', () => {
 
     await waitFor(() => expect(mockService.getClaudeCodeQuota).toHaveBeenCalledTimes(1));
     expect(mockService.getClaudeCodeQuota).toHaveBeenCalledWith({ env: undefined });
+  });
+
+  it('does not re-ingest a cached live snapshot echoed back during revalidation', async () => {
+    // The main-process cache stays fresh for 5min, so a focus revalidation can
+    // get the already-persisted readings back (same capturedAt). Snapshots are
+    // append-only — re-ingesting the echo would duplicate history rows.
+    const persistedAt = Date.now() - 5 * 60_000;
+    mockQuotaService.listAccounts.mockResolvedValue([persistedAccount]);
+    mockQuotaService.getWindows.mockResolvedValue([persistedSessionWindow(persistedAt)]);
+    mockService.getClaudeCodeQuota.mockResolvedValue(
+      claudeSnapshot({
+        identity: { externalAccountId: 'ext-1' },
+        readings: [liveSessionReading(persistedAt)],
+      }),
+    );
+
+    render(<ClaudeCodeQuotaMenu />);
+
+    expect(await screen.findByText('92%')).toBeTruthy();
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    await waitFor(() => expect(mockService.getClaudeCodeQuota).toHaveBeenCalledTimes(1));
+    expect(mockQuotaService.ingestClaudeSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('ingests genuinely fresh readings surfaced by a revalidation', async () => {
+    const persistedAt = Date.now() - 5 * 60_000;
+    mockQuotaService.listAccounts.mockResolvedValue([persistedAccount]);
+    mockQuotaService.getWindows.mockResolvedValue([persistedSessionWindow(persistedAt)]);
+    const readings = [liveSessionReading(Date.now())];
+    mockService.getClaudeCodeQuota.mockResolvedValue(
+      claudeSnapshot({ identity: { externalAccountId: 'ext-1' }, readings }),
+    );
+
+    render(<ClaudeCodeQuotaMenu />);
+
+    expect(await screen.findByText('92%')).toBeTruthy();
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    await waitFor(() =>
+      expect(mockQuotaService.ingestClaudeSnapshot).toHaveBeenCalledWith({
+        identity: { externalAccountId: 'ext-1' },
+        readings,
+      }),
+    );
   });
 
   it('skips the focus revalidation while the snapshot is under a minute old', async () => {

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/QuotaMenu.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/QuotaMenu.test.tsx
@@ -190,6 +190,19 @@ const claudeSnapshot = (
   ...overrides,
 });
 
+const persistedAccount = { externalAccountId: 'ext-1', id: 'acc-1', provider: 'claude-code' };
+
+/** A persisted `agent_quota_windows` row whose newest reading is `lastSeenAt`. */
+const persistedSessionWindow = (lastSeenAt: number) => ({
+  lastSeenAt: new Date(lastSeenAt),
+  lastUtilization: 8,
+  limitType: 'session',
+  peakUtilization: 8,
+  resetsAt: null,
+  scopeKey: '',
+  windowSeconds: 300 * 60,
+});
+
 const codexSnapshot = (
   overrides: Partial<ElectronClientIpcModule.CodexQuotaSnapshot> = {},
 ): ElectronClientIpcModule.CodexQuotaSnapshot => ({
@@ -549,6 +562,100 @@ describe('ClaudeCodeQuotaMenu', () => {
     render(<ClaudeCodeQuotaMenu />);
 
     expect(await screen.findByText('heteroAgent.quota.noData')).toBeTruthy();
+  });
+
+  it('renders persisted windows without a live call while the newest reading is fresh', async () => {
+    mockQuotaService.listAccounts.mockResolvedValue([persistedAccount]);
+    mockQuotaService.getWindows.mockResolvedValue([
+      persistedSessionWindow(Date.now() - 5 * 60_000),
+    ]);
+
+    render(<ClaudeCodeQuotaMenu />);
+
+    expect(await screen.findByText('92%')).toBeTruthy();
+    expect(mockService.getClaudeCodeQuota).not.toHaveBeenCalled();
+  });
+
+  it('refreshes from the live API when the newest persisted reading is older than 30 minutes', async () => {
+    // Under the previous 1h policy a 31-minute-old reading skipped the live fetch.
+    mockQuotaService.listAccounts.mockResolvedValue([persistedAccount]);
+    mockQuotaService.getWindows.mockResolvedValue([
+      persistedSessionWindow(Date.now() - 31 * 60_000),
+    ]);
+    mockService.getClaudeCodeQuota.mockResolvedValue(claudeSnapshot());
+
+    render(<ClaudeCodeQuotaMenu />);
+
+    expect(await screen.findByText('92%')).toBeTruthy();
+    await waitFor(() =>
+      expect(mockService.getClaudeCodeQuota).toHaveBeenCalledWith({ env: undefined }),
+    );
+  });
+
+  it('paints persisted windows while a stale live refresh is still in flight', async () => {
+    mockQuotaService.listAccounts.mockResolvedValue([persistedAccount]);
+    mockQuotaService.getWindows.mockResolvedValue([
+      persistedSessionWindow(Date.now() - 31 * 60_000),
+    ]);
+    const requests: Array<(snapshot: ElectronClientIpcModule.ClaudeCodeQuotaSnapshot) => void> = [];
+    mockService.getClaudeCodeQuota.mockImplementation(
+      () =>
+        new Promise<ElectronClientIpcModule.ClaudeCodeQuotaSnapshot>((resolve) => {
+          requests.push(resolve);
+        }),
+    );
+
+    render(<ClaudeCodeQuotaMenu />);
+
+    // The persisted snapshot lands before the live promise resolves — no skeleton.
+    expect(await screen.findByText('92%')).toBeTruthy();
+    expect(screen.queryByTestId('skeleton')).toBeNull();
+    expect((screen.getByTestId('refresh') as HTMLButtonElement).disabled).toBe(true);
+
+    await act(async () => {
+      requests[0](claudeSnapshot());
+    });
+
+    expect(screen.getByText('92%')).toBeTruthy();
+    expect((screen.getByTestId('refresh') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('revalidates against the live API when the window regains focus', async () => {
+    mockQuotaService.listAccounts.mockResolvedValue([persistedAccount]);
+    mockQuotaService.getWindows.mockResolvedValue([
+      persistedSessionWindow(Date.now() - 5 * 60_000),
+    ]);
+    mockService.getClaudeCodeQuota.mockResolvedValue(claudeSnapshot());
+
+    render(<ClaudeCodeQuotaMenu />);
+
+    // Fresh persisted data: nothing hits the live API on mount…
+    expect(await screen.findByText('92%')).toBeTruthy();
+    expect(mockService.getClaudeCodeQuota).not.toHaveBeenCalled();
+
+    // …but regaining focus revalidates (the main-process cache rate-limits it).
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    await waitFor(() => expect(mockService.getClaudeCodeQuota).toHaveBeenCalledTimes(1));
+    expect(mockService.getClaudeCodeQuota).toHaveBeenCalledWith({ env: undefined });
+  });
+
+  it('skips the focus revalidation while the snapshot is under a minute old', async () => {
+    mockService.getClaudeCodeQuota.mockResolvedValue(
+      claudeSnapshot({ session: { resetsAt: null, usedPercent: 8, windowMinutes: 300 } }),
+    );
+
+    render(<ClaudeCodeQuotaMenu />);
+
+    expect(await screen.findByText('92%')).toBeTruthy();
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    expect(mockService.getClaudeCodeQuota).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/QuotaMenu.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/QuotaMenu.tsx
@@ -187,14 +187,25 @@ export interface QuotaMenuHelpers<S> {
   now: number;
 }
 
-export interface FetchQuotaOptions {
+export interface FetchQuotaOptions<S = unknown> {
   force?: boolean;
+  /**
+   * Paint an intermediate snapshot (e.g. persisted DB data) immediately while
+   * a slower live refresh keeps running; the promise result stays authoritative.
+   */
+  onInterim?: (quota: S) => void;
+  /**
+   * Check the live source even when the local staleness gate would skip it
+   * (focus / popover revalidation). Unlike `force`, upstream snapshot caches
+   * may still answer from their fresh window.
+   */
+  revalidate?: boolean;
 }
 
 interface QuotaMenuProps<S extends QuotaSnapshotBase> {
   contentWidth?: number;
   createErrorSnapshot: (error: unknown) => S;
-  fetchQuota: (options?: FetchQuotaOptions) => Promise<S>;
+  fetchQuota: (options?: FetchQuotaOptions<S>) => Promise<S>;
   /** Localized explanation for `status: 'error'`; falls back to `error`. */
   getErrorText?: (quota: S) => string | undefined;
   /** Localized explanation for a manual refresh error when stale data is preserved. */
@@ -214,6 +225,7 @@ interface QuotaMenuProps<S extends QuotaSnapshotBase> {
 
 interface LoadQuotaOptions {
   manual?: boolean;
+  revalidate?: boolean;
 }
 
 /**
@@ -317,7 +329,16 @@ const QuotaMenu = <S extends QuotaSnapshotBase>({
       setLoading(true);
 
       try {
-        const nextQuota = await fetchQuota(options.manual ? { force: true } : undefined);
+        const nextQuota = await fetchQuota({
+          ...(options.manual ? { force: true } : {}),
+          ...(options.revalidate ? { revalidate: true } : {}),
+          onInterim: (interimQuota) => {
+            // Progressive paint: show the fast (persisted) snapshot while the
+            // live refresh continues; requestId still guards stale sources.
+            if (!isCurrentRequest(requestId, requestSourceKey)) return;
+            setQuotaSnapshot(interimQuota);
+          },
+        });
         applyQuotaResult(nextQuota, options, requestId, requestSourceKey);
       } catch (error) {
         console.error('Failed to fetch agent quota:', error);
@@ -328,7 +349,7 @@ const QuotaMenu = <S extends QuotaSnapshotBase>({
         }
       }
     },
-    [applyQuotaResult, createErrorSnapshot, fetchQuota, isCurrentRequest],
+    [applyQuotaResult, createErrorSnapshot, fetchQuota, isCurrentRequest, setQuotaSnapshot],
   );
 
   useEffect(() => {
@@ -350,6 +371,34 @@ const QuotaMenu = <S extends QuotaSnapshotBase>({
       window.clearInterval(interval);
     };
   }, []);
+
+  // Revalidate when the window regains focus: the user may have burned quota
+  // elsewhere (another device, a terminal CLI session) meanwhile. Upstream
+  // snapshot caches (5 min fresh window + error cooldown in the main process)
+  // keep this from hammering the rate-limited live endpoints.
+  useEffect(() => {
+    const revalidateOnFocus = () => {
+      if (document.visibilityState === 'hidden' || loading) return;
+
+      const currentTime = Date.now();
+      const recentlyFailed =
+        lastTransientErrorAtRef.current > 0 &&
+        currentTime - lastTransientErrorAtRef.current < QUOTA_RETRY_COOLDOWN_MS;
+
+      if (recentlyFailed) return;
+      if (quota && currentTime - quota.updatedAt <= QUOTA_STALE_MS) return;
+
+      void loadQuota({ revalidate: true });
+    };
+
+    window.addEventListener('focus', revalidateOnFocus);
+    document.addEventListener('visibilitychange', revalidateOnFocus);
+
+    return () => {
+      window.removeEventListener('focus', revalidateOnFocus);
+      document.removeEventListener('visibilitychange', revalidateOnFocus);
+    };
+  }, [loadQuota, loading, quota]);
 
   const formatDuration = useCallback(
     (ms: number) => {
@@ -421,7 +470,7 @@ const QuotaMenu = <S extends QuotaSnapshotBase>({
         currentTime - lastTransientErrorAtRef.current < QUOTA_RETRY_COOLDOWN_MS;
 
       if ((!quota || currentTime - quota.updatedAt > QUOTA_STALE_MS) && !recentlyFailed) {
-        void loadQuota();
+        void loadQuota({ revalidate: true });
       }
     },
     [loadQuota, loading, quota],

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/quotaViewModel.ts
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/quotaViewModel.ts
@@ -84,9 +84,17 @@ export const buildClaudeSnapshotFromWindows = (
   };
 };
 
+/**
+ * Newest persisted reading time across the windows (0 when none). `lastSeenAt`
+ * is written from the readings' `capturedAt`, so this compares 1:1 against a
+ * live snapshot's `capturedAt` values — both stamped by the desktop main
+ * process.
+ */
+export const newestSeenAt = (windows: QuotaWindowRow[]): number =>
+  windows.reduce((max, w) => Math.max(max, toMs(w.lastSeenAt) ?? 0), 0);
+
 /** Whether the newest persisted reading is older than `maxAgeMs`. */
 export const isQuotaStale = (windows: QuotaWindowRow[], now: number, maxAgeMs: number): boolean => {
-  if (windows.length === 0) return true;
-  const newest = windows.reduce((max, w) => Math.max(max, toMs(w.lastSeenAt) ?? 0), 0);
+  const newest = newestSeenAt(windows);
   return newest === 0 || now - newest > maxAgeMs;
 };


### PR DESCRIPTION
The local CLI agent quota popover (Claude Code / Codex) previously showed a skeleton on every open and only refreshed its live data once an hour, so the numbers were often stale and the panel felt slow. This PR makes the persisted data paint instantly and the live data refresh much more eagerly, without extra pressure on the rate-limited Anthropic usage endpoint.

- **Progressive paint**: `fetchQuota` gains an `onInterim` callback — the persisted DB windows render as soon as they are read, while the slower live usage fetch continues in the background and repaints on completion. The popover no longer blocks on the live API when the persisted reading has crossed the staleness gate.
- **30min staleness gate (was 1h)**: the automatic live refresh now kicks in when the newest persisted reading is older than 30 minutes.
- **Focus / open revalidation**: regaining window focus (or opening the popover with a >60s-old snapshot) now revalidates against the live source via a new `revalidate` option. Unlike a manual `force` refresh, this path does not bypass the main-process `QuotaSnapshotCache`, so its 5-minute fresh window + 60s error cooldown naturally rate-limit these checks.
- **Fewer round-trips**: `listAccounts` / `listBindings` are now fetched in parallel.

#### Test

- [x] Tested locally
- [x] Added/updated tests

New regression tests cover: no live call while the persisted reading is <30min fresh, live refresh for a 31-minute-old reading (fails under the old 1h policy), persisted windows painting with no skeleton while a live refresh is in flight, focus-triggered revalidation, and the <1min focus skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)