### PR TITLE
🐛 fix: align assistant step count with LLM calls

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
@@ -407,6 +407,7 @@ describe('Group', () => {
     // sibling for every turn, latest or not — never swallowed into the fold.
     expect(fold.contains(answer)).toBe(false);
     expect(fold.contains(screen.getByTestId('workflow-segment'))).toBe(true);
+    expect(fold).toHaveAttribute('data-step-count', '2');
   });
 
   it('keeps the latest finished turn’s final answer visible outside the fold', () => {

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -26,7 +26,7 @@ import { CollapsedMessage } from './CollapsedMessage';
 import GroupItem from './GroupItem';
 import ProcessFold from './ProcessFold';
 import type { GroupRenderSegment } from './segments';
-import { countFoldedProcessSteps, hasRenderableFinalAnswer, shouldFoldProcess } from './segments';
+import { countAssistantLlmCalls, hasRenderableFinalAnswer, shouldFoldProcess } from './segments';
 import type { RenderableAssistantContentBlock } from './types';
 import WorkflowCollapse, { type WorkflowExpandLevelDefault } from './WorkflowCollapse';
 
@@ -346,7 +346,7 @@ const Group = memo<GroupChildrenProps>(
     // does not collapse into a lone header); still-generating turns render in
     // full.
     const { processSegments, finalSegments } = splitAssistantGroupFinalAnswer(segments);
-    const processStepCount = countFoldedProcessSteps(processSegments);
+    const llmCallCount = countAssistantLlmCalls(segments);
     const foldProcess = shouldFoldProcess({
       enabled: enableProcessFold,
       hasFinalAnswer: hasRenderableFinalAnswer(finalSegments),
@@ -364,7 +364,7 @@ const Group = memo<GroupChildrenProps>(
         <Flexbox className={styles.container} gap={8}>
           {foldProcess ? (
             <>
-              <ProcessFold durationText={durationText} stepCount={processStepCount}>
+              <ProcessFold durationText={durationText} stepCount={llmCallCount}>
                 <Flexbox gap={8}>
                   {processSegments.map((segment) =>
                     renderSegment(segment, segments.indexOf(segment)),

--- a/src/features/Conversation/Messages/AssistantGroup/components/segments.test.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/components/segments.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { LOADING_FLAT } from '@/const/message';
 
-import { countFoldedProcessSteps, hasRenderableFinalAnswer, shouldFoldProcess } from './segments';
+import { countAssistantLlmCalls, hasRenderableFinalAnswer, shouldFoldProcess } from './segments';
 
 const a = (id: string, content = 'answer') => ({
   block: { content, id } as any,
@@ -15,17 +15,17 @@ const w = (id: string, toolCount = 0) => ({
   kind: 'workflow' as const,
 });
 
-describe('countFoldedProcessSteps', () => {
-  it('counts folded assistant blocks and tool calls', () => {
+describe('countAssistantLlmCalls', () => {
+  it('counts assistant blocks without counting tool calls', () => {
     const segments = [w('b1', 2), a('b2'), w('b3', 1)];
 
-    expect(countFoldedProcessSteps(segments)).toBe(6);
+    expect(countAssistantLlmCalls(segments)).toBe(3);
   });
 
   it('does not double-count a mixed block split into answer and workflow segments', () => {
     const segments = [a('mixed-block'), w('mixed-block', 2), w('next-block', 1)];
 
-    expect(countFoldedProcessSteps(segments)).toBe(5);
+    expect(countAssistantLlmCalls(segments)).toBe(2);
   });
 });
 

--- a/src/features/Conversation/Messages/AssistantGroup/components/segments.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/components/segments.ts
@@ -6,9 +6,8 @@ import type { RenderableAssistantContentBlock } from './types';
 
 export type GroupRenderSegment = AssistantGroupSegment<RenderableAssistantContentBlock>;
 
-export const countFoldedProcessSteps = (segments: GroupRenderSegment[]): number => {
+export const countAssistantLlmCalls = (segments: GroupRenderSegment[]): number => {
   const assistantBlockIds = new Set<string>();
-  let toolCount = 0;
 
   for (const segment of segments) {
     if (segment.kind === 'answer') {
@@ -18,11 +17,10 @@ export const countFoldedProcessSteps = (segments: GroupRenderSegment[]): number 
 
     for (const block of segment.blocks) {
       assistantBlockIds.add(block.id);
-      toolCount += block.tools?.length ?? 0;
     }
   }
 
-  return assistantBlockIds.size + toolCount;
+  return assistantBlockIds.size;
 };
 
 export const hasRenderableFinalAnswer = (segments: GroupRenderSegment[]): boolean =>


### PR DESCRIPTION
## Summary

- count distinct assistant blocks as LLM calls in the folded process header
- exclude tool calls and tool-result messages from the displayed step count
- include the final-answer LLM call while deduplicating mixed projected blocks

## Test plan

- `bun run check src/features/Conversation/Messages/AssistantGroup/components/segments.ts src/features/Conversation/Messages/AssistantGroup/components/Group.tsx src/features/Conversation/Messages/AssistantGroup/components/segments.test.ts src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx`
- 29 related tests passed