### PR TITLE
🐛 fix(server): drop api-less manifests before the tools build

### DIFF
--- a/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
@@ -184,6 +184,37 @@ describe('createServerToolsEngine', () => {
     // Non-device plugins survive.
     expect(availablePlugins).toContain('test-plugin');
   });
+
+  it('drops manifests without an api array instead of crashing the tools build (LOBE-12528)', () => {
+    // A DB plugin row whose manifest jsonb lacks `api` used to crash
+    // ToolsEngine.convertManifestsToTools (`manifest.api.map`) and with it
+    // every execAgent call of the affected user.
+    const brokenPlugin: InstalledPlugin = {
+      identifier: 'broken-plugin',
+      type: 'plugin',
+      runtimeType: 'mcp',
+      manifest: { identifier: 'broken-plugin', meta: { title: 'Broken' } } as any,
+    };
+    const brokenAdditional = { identifier: 'broken-additional', meta: { title: 'Broken' } } as any;
+
+    const context = createMockContext({
+      installedPlugins: [...mockInstalledPlugins, brokenPlugin],
+    });
+    const engine = createServerToolsEngine(context, {
+      additionalManifests: [brokenAdditional],
+    });
+
+    const result = engine.generateTools({
+      toolIds: ['broken-plugin', 'broken-additional', 'test-plugin'],
+      model: 'gpt-4',
+      provider: 'openai',
+    });
+
+    // Valid plugin still produces its tool; broken sources are dropped.
+    expect(result).toHaveLength(1);
+    expect(engine.getAvailablePlugins()).not.toContain('broken-plugin');
+    expect(engine.getAvailablePlugins()).not.toContain('broken-additional');
+  });
 });
 
 describe('createServerAgentToolsEngine', () => {

--- a/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
@@ -62,6 +62,46 @@ export type {
 const log = debug('lobe-server:agent-tools-engine');
 
 /**
+ * A manifest is usable by ToolsEngine only if it has an `api` array.
+ * ToolsEngine.convertManifestsToTools calls `manifest.api.map(...)`
+ * unconditionally, so any entry with `api` missing / non-array crashes the
+ * whole tools build — and with it every execAgent call of the affected user.
+ * Installed-plugin manifests come straight from a DB jsonb column with no
+ * schema validation, so guard defensively at the merge point. Mirrors the
+ * frontend `dropInvalidManifests` in `src/helpers/toolEngineering`.
+ */
+const isValidToolManifest = (m: LobeToolManifest | undefined): m is LobeToolManifest =>
+  !!m && typeof m === 'object' && Array.isArray((m as LobeToolManifest).api);
+
+const dropInvalidManifests = (
+  manifests: (LobeToolManifest | undefined)[],
+  source: string,
+): LobeToolManifest[] => {
+  const valid: LobeToolManifest[] = [];
+  const dropped: Array<{ identifier?: string; reason: string }> = [];
+
+  for (const m of manifests) {
+    if (isValidToolManifest(m)) {
+      valid.push(m);
+    } else if (m) {
+      dropped.push({
+        identifier: (m as { identifier?: string }).identifier,
+        reason: 'missing `api` field (expected array)',
+      });
+    }
+  }
+
+  if (dropped.length > 0) {
+    console.warn(
+      `[AgentToolsEngine] Dropped ${dropped.length} invalid manifest(s) from ${source}:`,
+      dropped,
+    );
+  }
+
+  return valid;
+};
+
+/**
  * Initialize ToolsEngine with server-side context
  *
  * This is the server-side equivalent of frontend's `createToolsEngine`
@@ -84,9 +124,10 @@ export const createServerToolsEngine = (
   } = config;
 
   // Get plugin manifests from installed plugins (from database)
-  const pluginManifests = context.installedPlugins
-    .map((plugin) => plugin.manifest as LobeToolManifest)
-    .filter(Boolean);
+  const pluginManifests = dropInvalidManifests(
+    context.installedPlugins.map((plugin) => plugin.manifest as LobeToolManifest | undefined),
+    'installedPlugins',
+  );
 
   // Get builtin tool manifests from the (possibly pre-filtered) list. The
   // filter is one half of the hard wall keeping device tools out of an
@@ -116,7 +157,11 @@ export const createServerToolsEngine = (
   // Skill/Composio manifest claiming `lobe-remote-device` would otherwise
   // slip through `buildAllowedBuiltinTools` (which only touches the
   // builtin source).
-  const combinedManifests = [...pluginManifests, ...builtinManifests, ...additionalManifests];
+  const combinedManifests = [
+    ...pluginManifests,
+    ...builtinManifests,
+    ...dropInvalidManifests(additionalManifests, 'additionalManifests'),
+  ];
   const allManifests = excludeIdentifiers
     ? combinedManifests.filter((m) => !excludeIdentifiers.has(m.identifier))
     : combinedManifests;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-12528

#### 📝 Description of Change

Production `aiAgent.execAgent` calls were failing with `TypeError: Cannot read properties of undefined (reading 'map')` thrown from `ToolsEngine.convertManifestsToTools` (`manifest.api.map`). The trigger is a `plugins`-table row whose `manifest` jsonb lacks an `api` array: the server-side merge point in `createServerToolsEngine` only did `.filter(Boolean)` on installed-plugin manifests, so a single malformed row crashed **every** agent run of the affected user (~19×/hour observed on `dpl_37obTCGhezmghB94my9cbPjGKY9k`, mobile + lambda paths).

The frontend already guards this exact crash with `dropInvalidManifests` (`src/helpers/toolEngineering/index.ts`, added in #15546); the server-side equivalent never got the same guard. This PR mirrors it in `apps/server/src/modules/Mecha/AgentToolsEngine`:

- Validate `Array.isArray(manifest.api)` for installed-plugin manifests and `additionalManifests` at the merge point, dropping invalid entries instead of crashing.
- `console.warn` the dropped identifiers so the dirty rows are identifiable in production logs.

Note: this is **not** a deploy regression — the delta between the erroring deployment and the previous good one contains no manifest-path changes. The crash is data-triggered; the guard makes the tools build resilient regardless of how the malformed manifest got persisted.

#### 🧪 How to Test

- [x] Unit test: `apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts` — regression test reproduces the exact production TypeError before the fix and passes after (broken plugin + broken additional manifest are dropped, valid plugins still produce tools).
- [x] `bun run check` — lint clean, 57 tests passed; full type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)