### PR TITLE
🐛 fix: improve acceptance check details

### DIFF
--- a/src/features/Portal/AcceptanceCheck/Body.tsx
+++ b/src/features/Portal/AcceptanceCheck/Body.tsx
@@ -22,6 +22,10 @@ import { chatPortalSelectors } from '@/store/chat/selectors';
 const styles = createStaticStyles(({ css }) => ({
   body: css`
     overflow-y: auto;
+    flex: 1;
+
+    height: 100%;
+    min-height: 0;
     padding-block: 0 24px;
     padding-inline: 24px;
   `,

--- a/src/features/Verify/Acceptance/CheckList.test.ts
+++ b/src/features/Verify/Acceptance/CheckList.test.ts
@@ -5,11 +5,13 @@ import {
   checkFilterState,
   focusedCheckStates,
   groupChecks,
+  hasAnnotatableEvidence,
   hasVisualEvidence,
   isCheckWorkActionable,
   shouldGroupChecks,
   userReviewState,
 } from './CheckList';
+import { mergeRejectComments } from './CheckRejectModal';
 
 const check = (id: string, category: string | null, surface: AcceptanceCheck['surface']) =>
   ({ category, id, surface }) as AcceptanceCheck;
@@ -76,6 +78,40 @@ describe('hasVisualEvidence', () => {
         evidence: [{ content: 'details', type: 'markdown' }],
       } as AcceptanceCheck),
     ).toBe(false);
+  });
+});
+
+describe('hasAnnotatableEvidence', () => {
+  it('offers region comments for image evidence', () => {
+    expect(
+      hasAnnotatableEvidence({
+        evidence: [{ fileUrl: 'https://example.com/evidence.png', type: 'screenshot' }],
+      } as AcceptanceCheck),
+    ).toBe(true);
+  });
+
+  it('does not offer region comments for video-only evidence', () => {
+    expect(
+      hasAnnotatableEvidence({
+        evidence: [{ fileUrl: 'https://example.com/evidence.mp4', type: 'video' }],
+      } as AcceptanceCheck),
+    ).toBe(false);
+  });
+});
+
+describe('mergeRejectComments', () => {
+  it('carries the focused-detail draft into the annotation modal', () => {
+    expect(mergeRejectComments('Inline feedback', '')).toBe('Inline feedback');
+  });
+
+  it('preserves both the inline and persisted annotation drafts', () => {
+    expect(mergeRejectComments('Inline feedback', 'Saved annotation feedback')).toBe(
+      'Inline feedback\n\nSaved annotation feedback',
+    );
+  });
+
+  it('does not duplicate the same draft', () => {
+    expect(mergeRejectComments('Same feedback', 'Same feedback')).toBe('Same feedback');
   });
 });
 

--- a/src/features/Verify/Acceptance/CheckList.test.ts
+++ b/src/features/Verify/Acceptance/CheckList.test.ts
@@ -5,6 +5,7 @@ import {
   checkFilterState,
   focusedCheckStates,
   groupChecks,
+  hasVisualEvidence,
   isCheckWorkActionable,
   shouldGroupChecks,
   userReviewState,
@@ -57,6 +58,24 @@ describe('shouldGroupChecks', () => {
 
   it('groups checklists only after they exceed 10 items', () => {
     expect(shouldGroupChecks(11)).toBe(true);
+  });
+});
+
+describe('hasVisualEvidence', () => {
+  it('offers region comments for file-backed screenshots in focused check details', () => {
+    expect(
+      hasVisualEvidence({
+        evidence: [{ fileUrl: 'https://example.com/evidence.png', type: 'screenshot' }],
+      } as AcceptanceCheck),
+    ).toBe(true);
+  });
+
+  it('does not offer region comments when the check has no annotatable evidence', () => {
+    expect(
+      hasVisualEvidence({
+        evidence: [{ content: 'details', type: 'markdown' }],
+      } as AcceptanceCheck),
+    ).toBe(false);
   });
 });
 

--- a/src/features/Verify/Acceptance/CheckList.tsx
+++ b/src/features/Verify/Acceptance/CheckList.tsx
@@ -142,11 +142,18 @@ export const isException = (check: AcceptanceCheck) =>
   check.state === 'failed' || check.state === 'uncertain';
 
 const VISUAL_EVIDENCE = new Set(['gif', 'screenshot', 'video']);
+const ANNOTATABLE_EVIDENCE = new Set(['gif', 'screenshot']);
 
 const isVisual = (item: AcceptanceEvidence) =>
   Boolean(item.fileUrl) && VISUAL_EVIDENCE.has(item.type);
 
 export const hasVisualEvidence = (check: AcceptanceCheck) => check.evidence.some(isVisual);
+
+const isAnnotatable = (item: AcceptanceEvidence) =>
+  Boolean(item.fileUrl) && ANNOTATABLE_EVIDENCE.has(item.type);
+
+export const hasAnnotatableEvidence = (check: AcceptanceCheck) =>
+  check.evidence.some(isAnnotatable);
 
 const styles = createStaticStyles(({ css }) => ({
   caption: css`
@@ -816,16 +823,20 @@ const CheckRow = memo<{
       checkTitle: `C${check.seq} · ${check.title}`,
       draftKey: check.id,
       evidence: check.evidence
-        .filter((item) => isVisual(item))
+        .filter((item) => isAnnotatable(item))
         .map((item) => ({ fileUrl: item.fileUrl!, id: item.id })),
-      onConfirm: ({ annotations, comment, fileIds }) =>
-        onReview({
+      initialComment: reviewComment,
+      onConfirm: async ({ annotations, comment, fileIds }) => {
+        const ok = await onReview({
           action: 'reject',
           annotations: annotations.length > 0 ? annotations : undefined,
           checkItemIds: [check.id],
           comment: comment || undefined,
           fileIds: fileIds.length > 0 ? fileIds : undefined,
-        }),
+        });
+        if (ok) setReviewComment('');
+        return ok;
+      },
     });
 
   // Accepting settles the check — the row folds itself away once the write
@@ -1212,7 +1223,7 @@ const CheckRow = memo<{
             !activeReview &&
             (detailMode ? (
               <Flexbox gap={10} style={{ marginBlockStart: 6 }}>
-                {hasVisualEvidence(check) && (
+                {hasAnnotatableEvidence(check) && (
                   <Button
                     icon={<Icon icon={Images} />}
                     style={{ alignSelf: 'flex-start' }}

--- a/src/features/Verify/Acceptance/CheckList.tsx
+++ b/src/features/Verify/Acceptance/CheckList.tsx
@@ -1212,6 +1212,19 @@ const CheckRow = memo<{
             !activeReview &&
             (detailMode ? (
               <Flexbox gap={10} style={{ marginBlockStart: 6 }}>
+                {hasVisualEvidence(check) && (
+                  <Button
+                    icon={<Icon icon={Images} />}
+                    style={{ alignSelf: 'flex-start' }}
+                    type={'text'}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      openReject();
+                    }}
+                  >
+                    {t('acceptance.review.annotate')}
+                  </Button>
+                )}
                 <TextArea
                   autoSize={{ maxRows: 8, minRows: 3 }}
                   placeholder={t('acceptance.review.detailPlaceholder')}

--- a/src/features/Verify/Acceptance/CheckRejectModal.tsx
+++ b/src/features/Verify/Acceptance/CheckRejectModal.tsx
@@ -186,6 +186,8 @@ interface CheckRejectModalProps {
   /** Stable key (the check id) for the refresh-surviving draft cache. */
   draftKey?: string;
   evidence: RejectableEvidence[];
+  /** Feedback already typed in the focused detail before opening annotation. */
+  initialComment?: string;
   /** Perform the reject; resolve true to close, false to stay open. */
   onConfirm: (value: {
     annotations: AcceptanceReviewAnnotation[];
@@ -194,12 +196,22 @@ interface CheckRejectModalProps {
   }) => Promise<boolean>;
 }
 
+export const mergeRejectComments = (initialComment = '', storedComment = '') => {
+  const initial = initialComment.trim();
+  const stored = storedComment.trim();
+  if (!initial) return stored;
+  if (!stored || stored === initial) return initial;
+  return `${initial}\n\n${stored}`;
+};
+
 const CheckRejectContent = memo<CheckRejectModalProps>(
-  ({ checkTitle, draftKey, evidence, onConfirm }) => {
+  ({ checkTitle, draftKey, evidence, initialComment, onConfirm }) => {
     const { t: translate } = useTranslation('verify');
     const { close } = useModalContext();
     const [draft] = useState(() => readDraft(draftKey));
-    const [comment, setComment] = useState(draft?.comment ?? '');
+    const [comment, setComment] = useState(() =>
+      mergeRejectComments(initialComment, draft?.comment),
+    );
     const [loading, setLoading] = useState(false);
     const [activeEvidenceId, setActiveEvidenceId] = useState(evidence[0]?.id);
     const [annotations, setAnnotations] = useState<DraftAnnotationEntry[]>(


### PR DESCRIPTION
## Summary

- restore scrolling in the Task CheckItem detail portal for overflowing evidence
- add screenshot region-comment entry to focused Acceptance check details
- cover visual-evidence detection with regression tests

## Verification

- `bun run check src/features/Portal/AcceptanceCheck/Body.tsx src/features/Verify/Acceptance/CheckList.tsx src/features/Verify/Acceptance/CheckList.test.ts`
- lint clean, 28 tests passed
- Web agent testing passed for both region annotation and long-detail scrolling
- Acceptance report: https://app.lobehub.com/acceptance/0ca23c4e-cf18-4f81-842d-2976e8aeaaa7

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed