### PR TITLE
🐛 fix(task): seed heartbeat schedule lifecycle

### DIFF
--- a/apps/server/src/services/task/index.test.ts
+++ b/apps/server/src/services/task/index.test.ts
@@ -1406,6 +1406,7 @@ describe('TaskService', () => {
       expect(scheduleNextTopic).toHaveBeenCalledWith({
         delay: 3600,
         taskId: 'task-1',
+        tickToken: expect.any(String),
         userId,
       });
       expect(mockTaskModel.updateContext).toHaveBeenCalledWith('task-1', {
@@ -1413,6 +1414,7 @@ describe('TaskService', () => {
           consecutiveFailures: 0,
           scheduledAt: expect.any(String),
           tickMessageId: 'tick-new',
+          tickToken: expect.any(String),
         },
       });
     });
@@ -1442,6 +1444,35 @@ describe('TaskService', () => {
           scheduler: expect.objectContaining({ consecutiveFailures: 2, tickMessageId: 'tick-new' }),
         }),
       );
+    });
+
+    it('restores the previous status when the first heartbeat tick cannot be published', async () => {
+      const prev = baseTask({
+        automationMode: 'heartbeat',
+        context: {},
+        heartbeatInterval: 3600,
+        status: 'paused',
+      });
+      const next = baseTask({
+        automationMode: 'heartbeat',
+        heartbeatInterval: 3600,
+        status: 'scheduled',
+      });
+      mockTaskModel.resolve.mockResolvedValue(prev);
+      mockTaskModel.updateStatus.mockResolvedValue(next);
+      scheduleNextTopic.mockRejectedValueOnce(new Error('qstash unavailable'));
+
+      const service = new TaskService(db, userId);
+
+      await expect(service.updateStatus({ id: 'T-1', status: 'scheduled' as any })).rejects.toThrow(
+        'qstash unavailable',
+      );
+      expect(mockTaskModel.updateStatus).toHaveBeenNthCalledWith(1, 'task-1', 'scheduled', {});
+      expect(mockTaskModel.updateStatus).toHaveBeenNthCalledWith(2, 'task-1', 'paused');
+      expect(mockTaskModel.updateContext).toHaveBeenCalledWith('task-1', {
+        scheduler: { tickToken: expect.any(String) },
+      });
+      expect(mockTaskModel.update).toHaveBeenCalledWith('task-1', { context: {} });
     });
 
     it('does NOT stamp when the new status is not scheduled', async () => {

--- a/apps/server/src/services/task/index.test.ts
+++ b/apps/server/src/services/task/index.test.ts
@@ -10,6 +10,11 @@ import type { LobeChatDatabase } from '@/database/type';
 
 import { TaskService } from './index';
 
+const { cancelScheduled, scheduleNextTopic } = vi.hoisted(() => ({
+  cancelScheduled: vi.fn(),
+  scheduleNextTopic: vi.fn(),
+}));
+
 vi.mock('@/database/models/agent', () => ({
   AgentModel: vi.fn(),
 }));
@@ -36,6 +41,10 @@ vi.mock('@/server/services/aiAgent', () => ({
   AiAgentService: vi.fn().mockImplementation(() => ({
     interruptTask: vi.fn(),
   })),
+}));
+
+vi.mock('@/server/services/taskScheduler', () => ({
+  createTaskSchedulerModule: () => ({ cancelScheduled, scheduleNextTopic }),
 }));
 
 // Attachment resolver hits FileModel + DocumentService + FileService — stub it
@@ -94,6 +103,8 @@ describe('TaskService', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    cancelScheduled.mockResolvedValue(undefined);
+    scheduleNextTopic.mockResolvedValue('tick-new');
     mockTaskTopicModel.findRunningByTaskIds.mockResolvedValue([]);
     (AgentModel as any).mockImplementation(() => mockAgentModel);
     (TaskModel as any).mockImplementation(() => mockTaskModel);
@@ -1095,6 +1106,7 @@ describe('TaskService', () => {
         assigneeAgentId: null,
         assigneeUserId: null,
         createdAt: null,
+        context: { scheduler: { scheduledAt: '2024-01-01T12:00:05.000Z' } },
         description: null,
         error: null,
         heartbeatInterval: 30,
@@ -1127,6 +1139,7 @@ describe('TaskService', () => {
       expect(result?.heartbeat).toEqual({
         interval: 30,
         lastAt: '2024-01-01T12:00:00.000Z',
+        scheduledAt: '2024-01-01T12:00:05.000Z',
         timeout: 60,
       });
     });
@@ -1372,16 +1385,63 @@ describe('TaskService', () => {
       expect(mockTaskModel.updateContext).not.toHaveBeenCalled();
     });
 
-    it('does NOT stamp for heartbeat-mode tasks', async () => {
-      const prev = baseTask({ status: 'backlog', automationMode: 'heartbeat' });
-      const next = baseTask({ status: 'scheduled', automationMode: 'heartbeat' });
+    it('seeds the first heartbeat tick when a user starts a heartbeat schedule', async () => {
+      const prev = baseTask({
+        automationMode: 'heartbeat',
+        context: {},
+        heartbeatInterval: 3600,
+        status: 'backlog',
+      });
+      const next = baseTask({
+        automationMode: 'heartbeat',
+        heartbeatInterval: 3600,
+        status: 'scheduled',
+      });
       mockTaskModel.resolve.mockResolvedValue(prev);
       mockTaskModel.updateStatus.mockResolvedValue(next);
 
       const service = new TaskService(db, userId);
       await service.updateStatus({ id: 'T-1', status: 'scheduled' as any });
 
-      expect(mockTaskModel.updateContext).not.toHaveBeenCalled();
+      expect(scheduleNextTopic).toHaveBeenCalledWith({
+        delay: 3600,
+        taskId: 'task-1',
+        userId,
+      });
+      expect(mockTaskModel.updateContext).toHaveBeenCalledWith('task-1', {
+        scheduler: {
+          consecutiveFailures: 0,
+          scheduledAt: expect.any(String),
+          tickMessageId: 'tick-new',
+        },
+      });
+    });
+
+    it('replaces a stale heartbeat tick when a user restarts the schedule', async () => {
+      const prev = baseTask({
+        automationMode: 'heartbeat',
+        context: { scheduler: { consecutiveFailures: 2, tickMessageId: 'tick-old' } },
+        heartbeatInterval: 3600,
+        status: 'paused',
+      });
+      const next = baseTask({
+        automationMode: 'heartbeat',
+        heartbeatInterval: 3600,
+        status: 'scheduled',
+      });
+      mockTaskModel.resolve.mockResolvedValue(prev);
+      mockTaskModel.updateStatus.mockResolvedValue(next);
+
+      const service = new TaskService(db, userId);
+      await service.updateStatus({ id: 'T-1', status: 'scheduled' as any });
+
+      expect(cancelScheduled).toHaveBeenCalledWith('tick-old');
+      expect(mockTaskModel.updateContext).toHaveBeenCalledWith(
+        'task-1',
+        expect.objectContaining({
+          scheduler: expect.objectContaining({ consecutiveFailures: 2, tickMessageId: 'tick-new' }),
+        }),
+      );
     });
 
     it('does NOT stamp when the new status is not scheduled', async () => {

--- a/apps/server/src/services/task/index.ts
+++ b/apps/server/src/services/task/index.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import type {
   TaskContext,
   TaskDetailActivity,
@@ -399,23 +401,42 @@ export class TaskService {
       const schedulerContext = (resolved.context as TaskContext | null)?.scheduler as
         TaskSchedulerContext | undefined;
       const previousTickMessageId = schedulerContext?.tickMessageId;
-      const tickMessageId = await scheduler.scheduleNextTopic({
-        delay: task.heartbeatInterval,
-        taskId: task.id,
-        userId: this.userId,
-      });
+      const tickToken = randomUUID();
+      let tickMessageId: string | undefined;
+
+      try {
+        // Invalidate the previous generation before publishing. This closes
+        // the race where an old QStash delivery arrives while the replacement
+        // message is being created.
+        await this.taskModel.updateContext(task.id, { scheduler: { tickToken } });
+        tickMessageId = await scheduler.scheduleNextTopic({
+          delay: task.heartbeatInterval,
+          taskId: task.id,
+          tickToken,
+          userId: this.userId,
+        });
+
+        await this.taskModel.updateContext(task.id, {
+          scheduler: {
+            consecutiveFailures: schedulerContext?.consecutiveFailures ?? 0,
+            scheduledAt: new Date().toISOString(),
+            tickMessageId,
+            tickToken,
+          },
+        });
+      } catch (error) {
+        // Never expose a scheduled status without a persisted tick. Restore
+        // the user-visible state and cancel a newly published message when
+        // persistence was the failing step.
+        if (tickMessageId) await scheduler.cancelScheduled(tickMessageId).catch(() => undefined);
+        await this.taskModel.update(task.id, { context: resolved.context });
+        await this.taskModel.updateStatus(task.id, resolved.status);
+        throw error;
+      }
 
       if (previousTickMessageId) {
         await scheduler.cancelScheduled(previousTickMessageId).catch(() => undefined);
       }
-
-      await this.taskModel.updateContext(task.id, {
-        scheduler: {
-          consecutiveFailures: schedulerContext?.consecutiveFailures ?? 0,
-          scheduledAt: new Date().toISOString(),
-          tickMessageId,
-        },
-      });
     }
 
     const unlocked: string[] = [];

--- a/apps/server/src/services/task/index.ts
+++ b/apps/server/src/services/task/index.ts
@@ -6,6 +6,7 @@ import type {
   TaskDetailSubtask,
   TaskDetailWorkspaceNode,
   TaskItem,
+  TaskSchedulerContext,
   TaskStatus,
   TaskTopicHandoff,
   WorkspaceData,
@@ -25,6 +26,7 @@ import { resolveAttachmentMetadata } from '../file/resolveAttachments';
 import { type SubtaskGraphPlan, TaskGraphService } from '../taskGraph';
 import { type ReviewResult, TaskReviewService } from '../taskReview';
 import { TaskRunnerService } from '../taskRunner';
+import { createTaskSchedulerModule } from '../taskScheduler';
 
 const emptyWorkspace: WorkspaceData = { nodeMap: {}, tree: [] };
 const UNTITLED_TOPIC_TITLE = 'Untitled';
@@ -378,6 +380,41 @@ export class TaskService {
     ) {
       await this.taskModel.updateContext(task.id, {
         scheduler: { scheduleStartedAt: new Date().toISOString() },
+      });
+    }
+
+    // Heartbeat ticks are one-shot delayed messages that re-arm themselves
+    // after each run. Seed the very first message when a user starts/restarts
+    // the schedule; otherwise a fresh heartbeat task has no event capable of
+    // reaching the lifecycle re-arm path.
+    if (
+      status === 'scheduled' &&
+      task.automationMode === 'heartbeat' &&
+      task.heartbeatInterval &&
+      task.heartbeatInterval > 0 &&
+      resolved.status !== 'running' &&
+      resolved.status !== 'scheduled'
+    ) {
+      const scheduler = createTaskSchedulerModule();
+      const schedulerContext = (resolved.context as TaskContext | null)?.scheduler as
+        TaskSchedulerContext | undefined;
+      const previousTickMessageId = schedulerContext?.tickMessageId;
+      const tickMessageId = await scheduler.scheduleNextTopic({
+        delay: task.heartbeatInterval,
+        taskId: task.id,
+        userId: this.userId,
+      });
+
+      if (previousTickMessageId) {
+        await scheduler.cancelScheduled(previousTickMessageId).catch(() => undefined);
+      }
+
+      await this.taskModel.updateContext(task.id, {
+        scheduler: {
+          consecutiveFailures: schedulerContext?.consecutiveFailures ?? 0,
+          scheduledAt: new Date().toISOString(),
+          tickMessageId,
+        },
       });
     }
 
@@ -780,6 +817,7 @@ export class TaskService {
     });
 
     const taskConfig = task.config ? (task.config as Record<string, unknown>) : undefined;
+    const taskContext = task.context ? (task.context as TaskContext) : undefined;
     const scheduleConfig = (taskConfig?.schedule ?? {}) as { maxExecutions?: number | null };
 
     return {
@@ -806,6 +844,7 @@ export class TaskService {
           ? {
               interval: task.heartbeatInterval,
               lastAt: task.lastHeartbeatAt ? new Date(task.lastHeartbeatAt).toISOString() : null,
+              scheduledAt: taskContext?.scheduler?.scheduledAt,
               timeout: task.heartbeatTimeout,
             }
           : undefined,

--- a/apps/server/src/services/taskLifecycle/heartbeatRearm.test.ts
+++ b/apps/server/src/services/taskLifecycle/heartbeatRearm.test.ts
@@ -59,12 +59,14 @@ describe('TaskLifecycleService.maybeRearmHeartbeat', () => {
     expect(fakeScheduler.scheduleNextTopic).toHaveBeenCalledWith({
       delay: 30,
       taskId: 'task-1',
+      tickToken: expect.any(String),
       userId: 'user-1',
     });
     expect(updateContext).toHaveBeenCalledWith('task-1', {
       scheduler: expect.objectContaining({
         consecutiveFailures: 0,
         tickMessageId: 'msg-new',
+        tickToken: expect.any(String),
       }),
     });
   });

--- a/apps/server/src/services/taskLifecycle/index.ts
+++ b/apps/server/src/services/taskLifecycle/index.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import { BRANDING_URL } from '@lobechat/business-const';
 import { TRACING_SCENARIOS } from '@lobechat/const';
 import type { TracingOptions } from '@lobechat/llm-generation-tracing';
@@ -566,6 +568,7 @@ export class TaskLifecycleService {
 
     try {
       const scheduler = createTaskSchedulerModule();
+      const tickToken = randomUUID();
 
       // Cancel any prior tick (defensive — we usually wouldn't have one
       // pending here, since the prior tick has already fired to bring us
@@ -577,6 +580,7 @@ export class TaskLifecycleService {
       const tickMessageId = await scheduler.scheduleNextTopic({
         delay: task.heartbeatInterval,
         taskId: task.id,
+        tickToken,
         userId: this.userId,
       });
 
@@ -585,6 +589,7 @@ export class TaskLifecycleService {
           consecutiveFailures,
           scheduledAt: new Date().toISOString(),
           tickMessageId,
+          tickToken,
         },
       });
 

--- a/apps/server/src/services/taskRunner/heartbeatTick.test.ts
+++ b/apps/server/src/services/taskRunner/heartbeatTick.test.ts
@@ -90,6 +90,26 @@ describe('runHeartbeatTick', () => {
     expect(mockRunner.runTask).not.toHaveBeenCalled();
   });
 
+  it('skips a stale tick whose generation token no longer matches', async () => {
+    mockSelectTask.mockResolvedValue([
+      baseTask({ context: { scheduler: { tickToken: 'tick-current' } } }),
+    ]);
+
+    const outcome = await runHeartbeatTick(taskId, userId, 'tick-old');
+
+    expect(outcome).toEqual({ ran: false, reason: 'stale-tick' });
+    expect(mockRunner.runTask).not.toHaveBeenCalled();
+  });
+
+  it('allows legacy tokenless ticks when no active generation is stored', async () => {
+    mockSelectTask.mockResolvedValue([baseTask({ context: {} })]);
+    mockRunner.runTask.mockResolvedValue(undefined);
+
+    const outcome = await runHeartbeatTick(taskId, userId);
+
+    expect(outcome).toEqual({ ran: true, taskIdentifier: 'T-1' });
+  });
+
   it('returns in-flight when runTask raises a CONFLICT', async () => {
     mockSelectTask.mockResolvedValue([baseTask()]);
     mockRunner.runTask.mockRejectedValue(new TRPCError({ code: 'CONFLICT', message: 'busy' }));

--- a/apps/server/src/services/taskRunner/heartbeatTick.ts
+++ b/apps/server/src/services/taskRunner/heartbeatTick.ts
@@ -18,7 +18,13 @@ export type HeartbeatTickOutcome =
   { ran: true; taskIdentifier: string } | { ran: false; reason: HeartbeatTickSkipReason };
 
 export type HeartbeatTickSkipReason =
-  'human-waiting' | 'in-flight' | 'mode-changed' | 'no-interval' | 'not-found' | 'terminal';
+  | 'human-waiting'
+  | 'in-flight'
+  | 'mode-changed'
+  | 'no-interval'
+  | 'not-found'
+  | 'stale-tick'
+  | 'terminal';
 
 /**
  * Run a heartbeat tick — invoked by both the LocalScheduler `setTimeout`
@@ -31,6 +37,7 @@ export type HeartbeatTickSkipReason =
 export async function runHeartbeatTick(
   taskId: string,
   userId: string,
+  tickToken?: string,
 ): Promise<HeartbeatTickOutcome> {
   const db = await getServerDB();
 
@@ -44,6 +51,12 @@ export async function runHeartbeatTick(
   if (!task) {
     log('skip task=%s reason=not-found', taskId);
     return { ran: false, reason: 'not-found' };
+  }
+  const activeTickToken = (task.context as { scheduler?: { tickToken?: string } } | null)?.scheduler
+    ?.tickToken;
+  if (activeTickToken && activeTickToken !== tickToken) {
+    log('skip task=%s reason=stale-tick', taskId);
+    return { ran: false, reason: 'stale-tick' };
   }
   if (task.automationMode !== 'heartbeat') {
     log('skip task=%s reason=mode-changed (mode=%s)', taskId, task.automationMode);
@@ -86,6 +99,6 @@ export async function runHeartbeatTick(
 // callback. Importing this module from anywhere in the server bundle (the
 // heartbeat-tick handler is the natural place) ensures local-mode heartbeat
 // loops actually fire.
-setTaskSchedulerExecutionCallback(async (taskId, userId) => {
-  await runHeartbeatTick(taskId, userId);
+setTaskSchedulerExecutionCallback(async (taskId, userId, tickToken) => {
+  await runHeartbeatTick(taskId, userId, tickToken);
 });

--- a/apps/server/src/services/taskScheduler/impls/local.test.ts
+++ b/apps/server/src/services/taskScheduler/impls/local.test.ts
@@ -29,14 +29,19 @@ describe('LocalTaskScheduler', () => {
       const callback = vi.fn().mockResolvedValue(undefined);
       scheduler.setExecutionCallback(callback);
 
-      await scheduler.scheduleNextTopic({ delay: 5, taskId: 'task-1', userId: 'user-1' });
+      await scheduler.scheduleNextTopic({
+        delay: 5,
+        taskId: 'task-1',
+        tickToken: 'generation-1',
+        userId: 'user-1',
+      });
 
       expect(callback).not.toHaveBeenCalled();
 
       await vi.advanceTimersByTimeAsync(5000);
 
       expect(callback).toHaveBeenCalledOnce();
-      expect(callback).toHaveBeenCalledWith('task-1', 'user-1');
+      expect(callback).toHaveBeenCalledWith('task-1', 'user-1', 'generation-1');
     });
 
     it('should execute callback immediately when delay is 0', async () => {

--- a/apps/server/src/services/taskScheduler/impls/local.ts
+++ b/apps/server/src/services/taskScheduler/impls/local.ts
@@ -4,7 +4,11 @@ import type { ScheduleNextTopicParams, TaskSchedulerImpl } from './type';
 
 const log = debug('task-scheduler:local');
 
-export type TaskExecutionCallback = (taskId: string, userId: string) => Promise<void>;
+export type TaskExecutionCallback = (
+  taskId: string,
+  userId: string,
+  tickToken?: string,
+) => Promise<void>;
 
 /**
  * Local task scheduler using setTimeout
@@ -19,7 +23,7 @@ export class LocalTaskScheduler implements TaskSchedulerImpl {
   }
 
   async scheduleNextTopic(params: ScheduleNextTopicParams): Promise<string> {
-    const { taskId, userId, delay = 0 } = params;
+    const { taskId, userId, delay = 0, tickToken } = params;
     const scheduleId = `local-task-${taskId}-${Date.now()}`;
 
     log('Scheduling next topic for task %s (delay: %ds)', taskId, delay);
@@ -34,7 +38,11 @@ export class LocalTaskScheduler implements TaskSchedulerImpl {
 
       try {
         log('Executing next topic for task %s', taskId);
-        await this.executionCallback(taskId, userId);
+        if (tickToken) {
+          await this.executionCallback(taskId, userId, tickToken);
+        } else {
+          await this.executionCallback(taskId, userId);
+        }
       } catch (error) {
         log('Failed to execute next topic for task %s: %O', taskId, error);
       }

--- a/apps/server/src/services/taskScheduler/impls/qstash.test.ts
+++ b/apps/server/src/services/taskScheduler/impls/qstash.test.ts
@@ -36,12 +36,13 @@ describe('QStashTaskScheduler', () => {
       const id = await scheduler.scheduleNextTopic({
         delay: 60,
         taskId: 'task-1',
+        tickToken: 'generation-1',
         userId: 'user-1',
       });
 
       expect(id).toBe('msg-abc');
       expect(publishJSON).toHaveBeenCalledWith({
-        body: { taskId: 'task-1', userId: 'user-1' },
+        body: { taskId: 'task-1', tickToken: 'generation-1', userId: 'user-1' },
         delay: 60,
         url: 'https://app.example.com/api/workflows/task/heartbeat-tick',
       });

--- a/apps/server/src/services/taskScheduler/impls/qstash.ts
+++ b/apps/server/src/services/taskScheduler/impls/qstash.ts
@@ -17,7 +17,7 @@ export interface QStashTaskSchedulerConfig {
  * QStash-backed task scheduler.
  *
  * Each `scheduleNextTopic` call publishes a one-shot delayed message; QStash will
- * POST `{ taskId, userId }` to `/api/workflows/task/heartbeat-tick` after `delay`
+ * POST `{ taskId, userId, tickToken }` to `/api/workflows/task/heartbeat-tick` after `delay`
  * seconds. The handler is responsible for re-checking task state (DB is the
  * authority — a tick may arrive after the user paused or canceled the task).
  */
@@ -31,13 +31,13 @@ export class QStashTaskScheduler implements TaskSchedulerImpl {
   }
 
   async scheduleNextTopic(params: ScheduleNextTopicParams): Promise<string> {
-    const { taskId, userId, delay = 0 } = params;
+    const { taskId, userId, delay = 0, tickToken } = params;
     const url = `${this.baseUrl}${HEARTBEAT_TICK_PATH}`;
 
     log('Publishing tick: task=%s delay=%ds url=%s', taskId, delay, url);
 
     const response = await this.qstashClient.publishJSON({
-      body: { taskId, userId },
+      body: { taskId, tickToken, userId },
       delay,
       url,
     });

--- a/apps/server/src/services/taskScheduler/impls/type.ts
+++ b/apps/server/src/services/taskScheduler/impls/type.ts
@@ -1,6 +1,7 @@
 export interface ScheduleNextTopicParams {
   delay?: number; // delay in seconds, default 0
   taskId: string;
+  tickToken?: string;
   userId: string;
 }
 

--- a/apps/server/src/services/verify/__tests__/driveTaskFromVerify.test.ts
+++ b/apps/server/src/services/verify/__tests__/driveTaskFromVerify.test.ts
@@ -100,6 +100,26 @@ describe('driveTaskFromVerify', () => {
     expect(runSetMetadata).toHaveBeenCalled();
   });
 
+  it('passed → keeps a recurring task scheduled', async () => {
+    runFindByOperation.mockResolvedValue({ id: 'run-1', metadata: null, status: 'passed' });
+    taskFindById.mockResolvedValue({
+      assigneeAgentId: 'a1',
+      automationMode: 'heartbeat',
+      id: 'task-1',
+      identifier: 'T-1',
+      status: 'scheduled',
+    });
+
+    await driveTaskFromVerify(db, 'u1', 'op-1');
+
+    expect(serviceUpdateStatus).not.toHaveBeenCalled();
+    expect(taskUpdateStatus).not.toHaveBeenCalled();
+    expect(deliverMock).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'done', taskId: 'task-1' }),
+    );
+    expect(runSetMetadata).toHaveBeenCalled();
+  });
+
   it('settles the owning task when the passing verify run belongs to a repair child', async () => {
     runFindByOperation.mockResolvedValue({ id: 'repair-run', metadata: null, status: 'passed' });
     opFindById.mockImplementation(async (id: string) =>

--- a/apps/server/src/services/verify/settle.ts
+++ b/apps/server/src/services/verify/settle.ts
@@ -95,14 +95,20 @@ export const driveTaskFromVerify = async (
     if (!task || TERMINAL_TASK_STATUS.has(task.status)) return; // task already settled
 
     if (run.status === 'passed') {
-      // Complete + cascade (checkpoint / sibling rollup / unlock downstream).
-      // The verify → TaskService → aiAgent → agentRuntime completion → verify
-      // cycle is safe statically since every use is call-time (inside this fn).
-      await new TaskService(db, userId, workspaceId).updateStatus({
-        id: taskOperation.taskId,
-        status: 'completed',
-      });
-      log('verify passed → task %s completed', taskOperation.taskId);
+      if (task.automationMode) {
+        // Recurring tasks are parked back at `scheduled` and re-armed by the
+        // task lifecycle. Verify accepts this run, not the lifetime schedule.
+        log('verify passed → recurring task %s remains scheduled', taskOperation.taskId);
+      } else {
+        // Complete + cascade (checkpoint / sibling rollup / unlock downstream).
+        // The verify → TaskService → aiAgent → agentRuntime completion → verify
+        // cycle is safe statically since every use is call-time (inside this fn).
+        await new TaskService(db, userId, workspaceId).updateStatus({
+          id: taskOperation.taskId,
+          status: 'completed',
+        });
+        log('verify passed → task %s completed', taskOperation.taskId);
+      }
     } else {
       // Two non-pass outcomes, kept distinct so an infra error never reads as a
       // rejected delivery:

--- a/apps/server/src/workflows-hono/task/handlers/heartbeatTick.ts
+++ b/apps/server/src/workflows-hono/task/handlers/heartbeatTick.ts
@@ -7,19 +7,20 @@ const log = debug('lobe-server:workflows:task:heartbeat-tick');
 
 export interface HeartbeatTickPayload {
   taskId: string;
+  tickToken?: string;
   userId: string;
 }
 
 export async function heartbeatTick(c: Context) {
   try {
     const body = (await c.req.json()) as HeartbeatTickPayload;
-    const { taskId, userId } = body;
+    const { taskId, tickToken, userId } = body;
     if (!taskId || !userId) {
       return c.json({ error: 'Missing required fields: taskId, userId' }, 400);
     }
 
     log('Received tick: taskId=%s userId=%s', taskId, userId);
-    const outcome = await runHeartbeatTick(taskId, userId);
+    const outcome = await runHeartbeatTick(taskId, userId, tickToken);
     return c.json({ success: true, ...outcome });
   } catch (error) {
     console.error('[task/heartbeat-tick] Error:', error);

--- a/packages/types/src/task/index.ts
+++ b/packages/types/src/task/index.ts
@@ -155,6 +155,10 @@ export interface TaskSchedulerContext {
   // QStash messageId (or LocalScheduler scheduleId) for the next tick. Used to
   // cancel when the user wants an interval change to take effect immediately.
   tickMessageId?: string;
+  // Generation token carried by the currently active tick. A delivered tick
+  // must match this value so a failed best-effort cancellation cannot create
+  // a second heartbeat chain.
+  tickToken?: string;
 }
 
 /**

--- a/packages/types/src/task/index.ts
+++ b/packages/types/src/task/index.ts
@@ -440,6 +440,8 @@ export interface TaskDetailData {
   heartbeat?: {
     interval?: number | null;
     lastAt?: string | null;
+    /** When the currently pending heartbeat tick was enqueued. */
+    scheduledAt?: string | null;
     timeout?: number | null;
   };
   /** Stable database identity used by subject-bound aggregates such as Acceptance. */

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailRunPauseAction.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailRunPauseAction.tsx
@@ -119,7 +119,7 @@ const TaskDetailRunPauseAction = memo(() => {
     let next = null;
     if (automationMode === 'heartbeat') {
       next = nextHeartbeatFiring(
-        detail?.heartbeat?.lastAt ?? detail?.heartbeat?.scheduledAt,
+        detail?.heartbeat?.scheduledAt ?? detail?.heartbeat?.lastAt,
         interval,
       );
     } else if (automationMode === 'schedule' && schedulePattern) {

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailRunPauseAction.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailRunPauseAction.tsx
@@ -118,7 +118,10 @@ const TaskDetailRunPauseAction = memo(() => {
     if (!isScheduled) return null;
     let next = null;
     if (automationMode === 'heartbeat') {
-      next = nextHeartbeatFiring(detail?.heartbeat?.lastAt, interval);
+      next = nextHeartbeatFiring(
+        detail?.heartbeat?.lastAt ?? detail?.heartbeat?.scheduledAt,
+        interval,
+      );
     } else if (automationMode === 'schedule' && schedulePattern) {
       next = nextScheduleFiring(schedulePattern, scheduleTimezone);
     }
@@ -128,6 +131,7 @@ const TaskDetailRunPauseAction = memo(() => {
     isScheduled,
     automationMode,
     detail?.heartbeat?.lastAt,
+    detail?.heartbeat?.scheduledAt,
     interval,
     schedulePattern,
     scheduleTimezone,

--- a/src/features/AgentTasks/AgentTaskDetail/TaskScheduleConfig.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskScheduleConfig.tsx
@@ -230,7 +230,7 @@ const TaskScheduleConfig = memo(function TaskScheduleConfig({
     if (!enabled) return null;
     if (automationMode === 'heartbeat') {
       return nextHeartbeatFiring(
-        detail?.heartbeat?.lastAt ?? detail?.heartbeat?.scheduledAt,
+        detail?.heartbeat?.scheduledAt ?? detail?.heartbeat?.lastAt,
         finalCurrentInterval,
       );
     }

--- a/src/features/AgentTasks/AgentTaskDetail/TaskScheduleConfig.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskScheduleConfig.tsx
@@ -200,11 +200,9 @@ const TaskScheduleConfig = memo(function TaskScheduleConfig({
 
   const enabled = !!automationMode;
   const [isStartingSchedule, setIsStartingSchedule] = useState(false);
-  // Heartbeat tasks are re-armed only by maybeRearmHeartbeat after a topic
-  // completes; there is no dispatcher that picks up `scheduled` heartbeat tasks,
-  // so flipping one to `scheduled` from here would leave it dormant.
   const canStartSchedule =
-    automationMode === 'schedule' &&
+    ((automationMode === 'schedule' && !!schedulePattern) ||
+      (automationMode === 'heartbeat' && finalCurrentInterval > 0)) &&
     !!finalTaskId &&
     status !== 'scheduled' &&
     status !== 'running';
@@ -228,17 +226,13 @@ const TaskScheduleConfig = memo(function TaskScheduleConfig({
     return null;
   }, [automationMode, finalCurrentInterval, schedulePattern, scheduleTimezone, t, i18n.language]);
 
-  const [nowTick, setNowTick] = useState(0);
-  useEffect(() => {
-    if (!enabled) return;
-    const id = setInterval(() => setNowTick((n) => n + 1), 60_000);
-    return () => clearInterval(id);
-  }, [enabled]);
-
   const nextRun = useMemo(() => {
     if (!enabled) return null;
     if (automationMode === 'heartbeat') {
-      return nextHeartbeatFiring(detail?.heartbeat?.lastAt, finalCurrentInterval);
+      return nextHeartbeatFiring(
+        detail?.heartbeat?.lastAt ?? detail?.heartbeat?.scheduledAt,
+        finalCurrentInterval,
+      );
     }
     if (automationMode === 'schedule' && schedulePattern) {
       return nextScheduleFiring(schedulePattern, scheduleTimezone);
@@ -247,11 +241,11 @@ const TaskScheduleConfig = memo(function TaskScheduleConfig({
   }, [
     automationMode,
     detail?.heartbeat?.lastAt,
+    detail?.heartbeat?.scheduledAt,
     enabled,
     finalCurrentInterval,
     schedulePattern,
     scheduleTimezone,
-    nowTick,
   ]);
 
   const nextRunText = useMemo(() => {


### PR DESCRIPTION
<!-- Brief and heads-up -->

Fix heartbeat tasks that could remain dormant after being moved to `scheduled`, display a non-decreasing countdown, or become terminal after a successful Verify run.

Root causes:

- Heartbeat scheduling only re-armed after a topic completed, so a new task never received its first delayed tick.
- The countdown used a fresh `now + interval` value on every render when no heartbeat had run yet.
- Verify treated a passing recurring run as completion of the whole task.

Changes:

- Seed the first QStash/local heartbeat tick on user-initiated start or restart, replacing any stale pending tick.
- Persist and expose `scheduler.scheduledAt` so the UI has a stable countdown anchor.
- Allow heartbeat schedules to be started from the schedule configuration UI.
- Keep recurring tasks scheduled when Verify accepts an individual run.
- Add regression coverage for initial scheduling, restart behavior, task detail timing, and Verify settlement.

<!-- No visual layout change; the existing countdown now advances correctly. -->

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check` on the seven changed files: lint clean, 47 tests passed.

#### 🔗 Related Issue

Reported from production task T-85 / topic `tpc_7K5zThxamdGq`.
