### PR TITLE
🐛 fix: hide single-round goal progress

### DIFF
--- a/src/features/AgentTasks/AgentTaskDetail/GoalRoundTimeline.test.ts
+++ b/src/features/AgentTasks/AgentTaskDetail/GoalRoundTimeline.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatGoalDuration } from './GoalRoundTimeline';
+import { formatGoalDuration, shouldShowGoalRoundTimeline } from './GoalRoundTimeline';
 
 describe('formatGoalDuration', () => {
   it('uses minutes before a full hour', () => {
@@ -15,5 +15,13 @@ describe('formatGoalDuration', () => {
 
   it('switches to days after 24 hours', () => {
     expect(formatGoalDuration(34 * 3_600_000)).toBe('1.4d');
+  });
+});
+
+describe('shouldShowGoalRoundTimeline', () => {
+  it('hides progress until there is more than one round', () => {
+    expect(shouldShowGoalRoundTimeline(0)).toBe(false);
+    expect(shouldShowGoalRoundTimeline(1)).toBe(false);
+    expect(shouldShowGoalRoundTimeline(2)).toBe(true);
   });
 });

--- a/src/features/AgentTasks/AgentTaskDetail/GoalRoundTimeline.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/GoalRoundTimeline.tsx
@@ -49,9 +49,11 @@ export const formatGoalDuration = (milliseconds: number) => {
   return `${Number((hours / 24).toFixed(1))}d`;
 };
 
+export const shouldShowGoalRoundTimeline = (roundCount: number) => roundCount > 1;
+
 const GoalRoundTimeline = memo<{ rounds?: GoalRound[] }>(({ rounds = [] }) => {
   const { t } = useTranslation('chat');
-  if (rounds.length === 0) return null;
+  if (!shouldShowGoalRoundTimeline(rounds.length)) return null;
 
   const start = new Date(rounds[0].run.createdAt).getTime();
   const elapsed = Math.max(1, Date.now() - start);


### PR DESCRIPTION
## Summary

- hide the Task goal round timeline when zero or one round exists
- show round progress only when it communicates progression across multiple rounds
- add regression coverage for the visibility threshold

## Verification

- `bun run check src/features/AgentTasks/AgentTaskDetail/GoalRoundTimeline.tsx src/features/AgentTasks/AgentTaskDetail/GoalRoundTimeline.test.ts`
- lint clean, 4 tests passed

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed