### PR TITLE
📝 docs: fix Messenger overview MDX rendering

### DIFF
--- a/docs/usage/messenger/overview.mdx
+++ b/docs/usage/messenger/overview.mdx
@@ -79,6 +79,6 @@ These messages can appear during linking regardless of platform:
 
 - **"This link is already used"** — The one-time confirm link can only be used once. Return to the bot and send `/start` again to issue a new link.
 - **"This account is already linked"** — The platform account is bound to a different LobeHub account. Sign in to that account to manage it, or unlink it there before retrying.
-- **"Another <platform> account is already linked"** — Your LobeHub account already has a link on this platform. Disconnect the existing link in **Settings → Messenger** before linking a new one.
+- **"Another \<platform> account is already linked"** — Your LobeHub account already has a link on this platform. Disconnect the existing link in **Settings → Messenger** before linking a new one.
 
 For platform-specific issues, see the troubleshooting section on each platform's guide.

--- a/docs/usage/messenger/overview.zh-CN.mdx
+++ b/docs/usage/messenger/overview.zh-CN.mdx
@@ -78,6 +78,6 @@ Messenger 让你通过 **官方 LobeHub 机器人** 在 Telegram、Slack、Disco
 
 - **"This link is already used"（链接已被使用）** —— 一次性确认链接只能使用一次。请回到机器人重新发送 `/start` 获取新链接。
 - **"This account is already linked"（该账号已被关联）** —— 该平台账号已绑定到另一个 LobeHub 账号。请用那个 LobeHub 账号登录管理；或先在那边解绑后再尝试。
-- **"Another <platform> account is already linked"（另一个平台账号已关联）** —— 你的 LobeHub 账号在该平台上已有关联。先在 **设置 → Messenger** 里断开旧关联，再绑定新账号。
+- **"Another \<platform> account is already linked"（另一个平台账号已关联）** —— 你的 LobeHub 账号在该平台上已有关联。先在 **设置 → Messenger** 里断开旧关联，再绑定新账号。
 
 平台特有的报错和细节请见各平台文档的「故障排查」一节。


### PR DESCRIPTION
## Summary

- Escape the `<platform>` placeholder in the English and Chinese Messenger overview docs.
- Prevent `next-mdx-remote` from parsing the placeholder as an unclosed JSX element and returning HTTP 500.

| Before | After |
| ------ | ----- |
| Messenger overview fails MDX compilation with digest `339219957` | English and Chinese overview pages render successfully with the literal `<platform>` placeholder |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Validation performed:

- `bun run check lobehub/docs/usage/messenger/overview.mdx lobehub/docs/usage/messenger/overview.zh-CN.mdx`
- Started the Landing dev server with `DOCS_BRANCH=fix/messenger-overview-mdx`.
- Used `agent-browser` to verify both `/docs/usage/messenger/overview` and `/zh/docs/usage/messenger/overview` return HTTP 200, render the literal `<platform>` text, and report no browser errors.
