### PR TITLE
✨ feat: support Apple Smart App Banner via APPLE_APP_STORE_ID

### DIFF
--- a/packages/business/const/src/branding.ts
+++ b/packages/business/const/src/branding.ts
@@ -37,5 +37,7 @@ export const BRANDING_EMAIL = {
 
 export const BRANDING_PROVIDER = 'lobehub';
 
+export const APPLE_APP_STORE_ID = '';
+
 export const COPYRIGHT = `© ${new Date().getFullYear()} ${ORG_NAME}`;
 export const COPYRIGHT_FULL = `${COPYRIGHT}. All rights reserved.`;

--- a/src/app/[variants]/metadata.ts
+++ b/src/app/[variants]/metadata.ts
@@ -1,4 +1,9 @@
-import { BRANDING_LOGO_URL, BRANDING_NAME, ORG_NAME } from '@lobechat/business-const';
+import {
+  APPLE_APP_STORE_ID,
+  BRANDING_LOGO_URL,
+  BRANDING_NAME,
+  ORG_NAME,
+} from '@lobechat/business-const';
 import { OG_URL } from '@lobechat/const';
 
 import { DEFAULT_LANG } from '@/const/locale';
@@ -30,6 +35,7 @@ export const generateMetadata = async (props: DynamicLayoutProps) => {
           icon: isDev ? '/favicon-dev.ico' : '/favicon.ico?v=1',
           shortcut: isDev ? '/favicon-32x32-dev.ico' : '/favicon-32x32.ico?v=1',
         },
+    ...(APPLE_APP_STORE_ID ? { itunes: { appId: APPLE_APP_STORE_ID } } : {}),
     manifest: '/manifest.json',
     metadataBase: new URL(OFFICIAL_URL),
     openGraph: {

--- a/src/app/spa-auth/[locale]/[[...path]]/seoMeta.ts
+++ b/src/app/spa-auth/[locale]/[[...path]]/seoMeta.ts
@@ -1,4 +1,4 @@
-import { BRANDING_NAME, ORG_NAME } from '@lobechat/business-const';
+import { APPLE_APP_STORE_ID, BRANDING_NAME, ORG_NAME } from '@lobechat/business-const';
 import { OG_URL } from '@lobechat/const';
 import urlJoin from 'url-join';
 
@@ -47,7 +47,7 @@ export async function buildSeoMeta(locale: string, pathname: string): Promise<st
   const { title, description, canonicalPath } = await buildAuthSeoEntry(lng, pathname);
   const ogUrl = canonicalPath ? urlJoin(OFFICIAL_URL, canonicalPath) : OFFICIAL_URL;
 
-  return [
+  const metas = [
     `<title>${title}</title>`,
     `<meta name="description" content="${description}" />`,
     `<meta property="og:title" content="${title}" />`,
@@ -62,5 +62,11 @@ export async function buildSeoMeta(locale: string, pathname: string): Promise<st
     `<meta name="twitter:description" content="${description}" />`,
     `<meta name="twitter:image" content="${OG_URL}" />`,
     `<meta name="twitter:site" content="${isCustomORG ? `@${ORG_NAME}` : '@lobehub'}" />`,
-  ].join('\n    ');
+  ];
+
+  if (APPLE_APP_STORE_ID) {
+    metas.push(`<meta name="apple-itunes-app" content="app-id=${APPLE_APP_STORE_ID}" />`);
+  }
+
+  return metas.join('\n    ');
 }

--- a/src/app/spa/[variants]/[[...path]]/route.ts
+++ b/src/app/spa/[variants]/[[...path]]/route.ts
@@ -1,4 +1,4 @@
-import { BRANDING_NAME, ORG_NAME } from '@lobechat/business-const';
+import { APPLE_APP_STORE_ID, BRANDING_NAME, ORG_NAME } from '@lobechat/business-const';
 import { OG_URL } from '@lobechat/const';
 
 import { getServerFeatureFlagsValue } from '@/config/featureFlags';
@@ -50,12 +50,12 @@ function buildClientEnv(): SPAClientEnv {
   };
 }
 
-async function buildSeoMeta(locale: string): Promise<string> {
+async function buildSeoMeta(locale: string, isMobile: boolean): Promise<string> {
   const { t } = await translation('metadata', locale);
   const title = t('chat.title', { appName: BRANDING_NAME });
   const description = t('chat.description', { appName: BRANDING_NAME });
 
-  return [
+  const metas = [
     `<title>${title}</title>`,
     `<meta name="description" content="${description}" />`,
     `<meta property="og:title" content="${title}" />`,
@@ -70,7 +70,13 @@ async function buildSeoMeta(locale: string): Promise<string> {
     `<meta name="twitter:description" content="${description}" />`,
     `<meta name="twitter:image" content="${OG_URL}" />`,
     `<meta name="twitter:site" content="${isCustomORG ? `@${ORG_NAME}` : '@lobehub'}" />`,
-  ].join('\n    ');
+  ];
+
+  if (isMobile && APPLE_APP_STORE_ID) {
+    metas.push(`<meta name="apple-itunes-app" content="app-id=${APPLE_APP_STORE_ID}" />`);
+  }
+
+  return metas.join('\n    ');
 }
 
 export async function GET(
@@ -89,7 +95,7 @@ export async function GET(
   };
 
   const template = await getTemplate(isMobile);
-  const seoMeta = await buildSeoMeta(locale);
+  const seoMeta = await buildSeoMeta(locale, isMobile);
 
   return renderSpaHtml(template, { seoMeta, serverConfig: spaConfig });
 }


### PR DESCRIPTION
Adds opt-in support for Safari's Smart App Banner so deployments with an iOS app on the App Store can promote it on the mobile web.

- New `APPLE_APP_STORE_ID` branding const in `@lobechat/business-const`, empty by default — no behavior change for open-source deployments.
- SPA HTML service (`src/app/spa/[variants]/[[...path]]/route.ts`): when serving the **mobile** template and the id is set, injects `<meta name="apple-itunes-app" content="app-id=...">` into the SEO meta block.
- Auth SPA (`src/app/spa-auth/[locale]/[[...path]]/seoMeta.ts`): emits the same tag when the id is set, so auth entry pages (`/signin`, `/signup`, …) — which the proxy rewrites to this shell — also show the banner. The auth shell has no mobile/desktop split and the tag is only consumed by iOS Safari, so it is emitted unconditionally.
- SSR pages (`src/app/[variants]/metadata.ts`): emits the same tag via the Next.js Metadata `itunes.appId` field when the id is set.

The banner is rendered natively by iOS Safari; no UI code involved.

#### Test

- [x] Tested locally (`bun run check` — lint clean, existing `seoMeta` tests pass; default empty id keeps output identical for OSS)
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

N/A