### PR TITLE
🐛 fix: ship devtools chunks in production and stop DevDock load failure crashing the app

### DIFF
--- a/scripts/copySpaBuild.test.ts
+++ b/scripts/copySpaBuild.test.ts
@@ -18,7 +18,7 @@ describe('copySpaBuild', () => {
     const root = mkdtempSync(path.join(tmpdir(), 'copy-spa-build-'));
     testRoots.push(root);
 
-    for (const dir of ['assets', 'i18n', 'model-bank', 'shiki', 'vendor']) {
+    for (const dir of ['assets', 'devtools', 'i18n', 'model-bank', 'shiki', 'vendor']) {
       const sourceDir = path.join(root, 'dist/desktop', dir);
       mkdirSync(sourceDir, { recursive: true });
       writeFileSync(path.join(sourceDir, `${dir}.js`), `export default '${dir}';`);
@@ -26,7 +26,7 @@ describe('copySpaBuild', () => {
 
     copySpaBuild(root);
 
-    for (const dir of ['assets', 'i18n', 'model-bank', 'shiki', 'vendor']) {
+    for (const dir of ['assets', 'devtools', 'i18n', 'model-bank', 'shiki', 'vendor']) {
       expect(existsSync(path.join(root, 'public/_spa', dir, `${dir}.js`))).toBe(true);
     }
   });

--- a/scripts/copySpaBuildCore.ts
+++ b/scripts/copySpaBuildCore.ts
@@ -1,7 +1,7 @@
 import { cpSync, existsSync, mkdirSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
 
-const copyDirs = ['assets', 'i18n', 'model-bank', 'shiki', 'vendor'] as const;
+const copyDirs = ['assets', 'devtools', 'i18n', 'model-bank', 'shiki', 'vendor'] as const;
 const copyRootFilePatterns = [/^favicon.*\.ico$/, /^apple-touch-icon\.png$/] as const;
 const targets = [
   { distDir: 'desktop', publicDir: 'public/_spa' },

--- a/src/initialize.test.ts
+++ b/src/initialize.test.ts
@@ -4,23 +4,43 @@ const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
 
 vi.mock('@lobehub/ui/base-ui', () => ({ toast: { error: toastError } }));
 
+const reload = vi.fn();
+
+const dispatchPreloadError = (error: unknown) => {
+  const event = new Event('vite:preloadError', { cancelable: true });
+  (event as any).payload = error;
+  window.dispatchEvent(event);
+  return event;
+};
+
+const dispatchRejection = (reason: unknown) => {
+  const event = new Event('unhandledrejection', { cancelable: true });
+  (event as any).reason = reason;
+  window.dispatchEvent(event);
+  return event;
+};
+
 describe('chunk-load error listeners', () => {
   beforeAll(async () => {
     (globalThis as any).__REACT_SCAN__ = false;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload },
+      writable: true,
+    });
     await import('./initialize');
   });
 
   afterEach(() => {
     sessionStorage.clear();
     toastError.mockClear();
+    reload.mockClear();
   });
 
   it('keeps vite:preloadError default so the preload helper rethrows to React.lazy', () => {
     sessionStorage.setItem('lobe-chunk-reload', '1');
 
-    const event = new Event('vite:preloadError', { cancelable: true });
-    (event as any).payload = new Error('Failed to fetch dynamically imported module');
-    window.dispatchEvent(event);
+    const event = dispatchPreloadError(new Error('Failed to fetch dynamically imported module'));
 
     expect(toastError).toHaveBeenCalledOnce();
     expect(event.defaultPrevented).toBe(false);
@@ -29,10 +49,40 @@ describe('chunk-load error listeners', () => {
   it('ignores vite:preloadError events without a chunk-load payload', () => {
     sessionStorage.setItem('lobe-chunk-reload', '1');
 
-    const event = new Event('vite:preloadError', { cancelable: true });
-    (event as any).payload = new Error('some unrelated failure');
-    window.dispatchEvent(event);
+    dispatchPreloadError(new Error('some unrelated failure'));
 
     expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it('reloads once when the rethrown rejection repeats the preload error', () => {
+    const error = new Error('Failed to fetch dynamically imported module');
+
+    dispatchPreloadError(error);
+    dispatchRejection(error);
+
+    expect(reload).toHaveBeenCalledOnce();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it('toasts once and never re-arms the reload when the chunk is still missing after reloading', () => {
+    sessionStorage.setItem('lobe-chunk-reload', '1');
+    const error = new Error('Failed to fetch dynamically imported module');
+
+    dispatchPreloadError(error);
+    dispatchRejection(error);
+
+    expect(toastError).toHaveBeenCalledOnce();
+    expect(reload).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem('lobe-chunk-reload')).toBe('1');
+  });
+
+  it('does not reload again for distinct chunk errors after the guard is armed', () => {
+    sessionStorage.setItem('lobe-chunk-reload', '1');
+
+    dispatchRejection(new Error('Failed to fetch dynamically imported module'));
+    dispatchRejection(new Error('Failed to fetch dynamically imported module'));
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/initialize.test.ts
+++ b/src/initialize.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
+
+vi.mock('@lobehub/ui/base-ui', () => ({ toast: { error: toastError } }));
+
+describe('chunk-load error listeners', () => {
+  beforeAll(async () => {
+    (globalThis as any).__REACT_SCAN__ = false;
+    await import('./initialize');
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+    toastError.mockClear();
+  });
+
+  it('keeps vite:preloadError default so the preload helper rethrows to React.lazy', () => {
+    sessionStorage.setItem('lobe-chunk-reload', '1');
+
+    const event = new Event('vite:preloadError', { cancelable: true });
+    (event as any).payload = new Error('Failed to fetch dynamically imported module');
+    window.dispatchEvent(event);
+
+    expect(toastError).toHaveBeenCalledOnce();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('ignores vite:preloadError events without a chunk-load payload', () => {
+    sessionStorage.setItem('lobe-chunk-reload', '1');
+
+    const event = new Event('vite:preloadError', { cancelable: true });
+    (event as any).payload = new Error('some unrelated failure');
+    window.dispatchEvent(event);
+
+    expect(toastError).not.toHaveBeenCalled();
+  });
+});

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -18,9 +18,12 @@ dayjs.extend(isYesterday);
 
 // Global fallback: catch async chunk-load failures that escape Error Boundaries
 if (typeof window !== 'undefined') {
+  // Never preventDefault here: Vite's preload helper only rethrows when the
+  // event default is kept, otherwise the failed import() resolves `undefined`
+  // and every React.lazy consumer crashes with `undefined.default` instead of
+  // surfacing a recognizable chunk-load error.
   window.addEventListener('vite:preloadError', (event) => {
     if (isChunkLoadError((event as any).payload)) {
-      event.preventDefault();
       notifyChunkError();
     }
   });

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -23,15 +23,16 @@ if (typeof window !== 'undefined') {
   // and every React.lazy consumer crashes with `undefined.default` instead of
   // surfacing a recognizable chunk-load error.
   window.addEventListener('vite:preloadError', (event) => {
-    if (isChunkLoadError((event as any).payload)) {
-      notifyChunkError();
+    const payload = (event as any).payload;
+    if (isChunkLoadError(payload)) {
+      notifyChunkError(payload);
     }
   });
 
   window.addEventListener('unhandledrejection', (event) => {
     if (isChunkLoadError(event.reason)) {
       event.preventDefault();
-      notifyChunkError();
+      notifyChunkError(event.reason);
     }
   });
 }

--- a/src/layout/SPAGlobalProvider/index.test.tsx
+++ b/src/layout/SPAGlobalProvider/index.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment happy-dom
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { type ReactNode, useEffect } from 'react';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -13,8 +13,9 @@ import { type DevDockLayout as DevDockLayoutComponent } from './index';
 
 let SPAGlobalProvider: typeof SPAGlobalProviderComponent;
 let DevDockLayout: typeof DevDockLayoutComponent;
-const { canAccessDevDock } = vi.hoisted(() => ({
+const { canAccessDevDock, devDockRenderError } = vi.hoisted(() => ({
   canAccessDevDock: vi.fn(() => false),
+  devDockRenderError: { current: null as Error | null },
 }));
 
 vi.mock('@lobehub/ui', async () => {
@@ -84,7 +85,10 @@ vi.mock('@/features/DevDock', async () => {
   const React = await import('react');
 
   return {
-    default: () => React.createElement('div', { 'data-testid': 'dev-dock' }),
+    default: () => {
+      if (devDockRenderError.current) throw devDockRenderError.current;
+      return React.createElement('div', { 'data-testid': 'dev-dock' });
+    },
   };
 });
 
@@ -195,6 +199,7 @@ describe('SPAGlobalProvider', () => {
 
   beforeEach(() => {
     canAccessDevDock.mockReturnValue(false);
+    devDockRenderError.current = null;
     setDevDockUnlocked(false);
     Reflect.deleteProperty(window, '__SERVER_CONFIG__');
     setPostRenderReady(false);
@@ -263,6 +268,27 @@ describe('SPAGlobalProvider', () => {
     );
 
     expect(await screen.findByTestId('dev-dock')).toBeInTheDocument();
+  });
+
+  it('keeps the app alive when DevDock fails to load', async () => {
+    vi.stubEnv('PROD', true);
+    canAccessDevDock.mockReturnValue(true);
+    setDevDockUnlocked(true);
+    devDockRenderError.current = new TypeError(
+      "Cannot read properties of undefined (reading 'default')",
+    );
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <DevDockLayout>
+        <div data-testid="spa-route-content" />
+      </DevDockLayout>,
+    );
+
+    await waitFor(() => expect(consoleError).toHaveBeenCalled());
+    expect(screen.getByTestId('spa-route-content')).toBeInTheDocument();
+    expect(screen.queryByTestId('dev-dock')).toBeNull();
+    consoleError.mockRestore();
   });
 
   it('does not remount application providers when DevDock becomes available', async () => {

--- a/src/layout/SPAGlobalProvider/index.tsx
+++ b/src/layout/SPAGlobalProvider/index.tsx
@@ -4,7 +4,7 @@ import { ContextMenuHost, ModalHost, TooltipGroup } from '@lobehub/ui';
 import { ModalHost as BaseModalHost, ToastHost } from '@lobehub/ui/base-ui';
 import { StyleProvider } from 'antd-style';
 import { domMax, LazyMotion } from 'motion/react';
-import { type CSSProperties, lazy, memo, type PropsWithChildren, Suspense } from 'react';
+import { Component, type CSSProperties, lazy, memo, type PropsWithChildren, Suspense } from 'react';
 
 import { LobeAnalyticsProviderWrapper } from '@/components/Analytics/LobeAnalyticsProviderWrapper';
 import { DragUploadProvider } from '@/components/DragUploadZone/DragUploadProvider';
@@ -40,6 +40,18 @@ const devDockLayoutStyle: CSSProperties = {
   width: '100%',
 };
 
+class DevDockBoundary extends Component<PropsWithChildren, { failed: boolean }> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  render() {
+    return this.state.failed ? null : this.props.children;
+  }
+}
+
 export const DevDockLayout = memo<PropsWithChildren>(({ children }) => {
   const mounted = useDevDockMounted();
 
@@ -47,9 +59,11 @@ export const DevDockLayout = memo<PropsWithChildren>(({ children }) => {
     <>
       <div style={devDockLayoutStyle}>{children}</div>
       {mounted && (
-        <Suspense>
-          <DevDock />
-        </Suspense>
+        <DevDockBoundary>
+          <Suspense>
+            <DevDock />
+          </Suspense>
+        </DevDockBoundary>
       )}
     </>
   );

--- a/src/spa/router/authRouter.config.tsx
+++ b/src/spa/router/authRouter.config.tsx
@@ -31,7 +31,7 @@ const AuthErrorBoundary = () => {
   const { resolvedTheme } = useTheme();
 
   if (typeof window !== 'undefined' && isChunkLoadError(error)) {
-    notifyChunkError();
+    notifyChunkError(error);
   }
 
   // index.auth.html paints the body black in dark mode before React mounts

--- a/src/utils/chunkError.ts
+++ b/src/utils/chunkError.ts
@@ -25,16 +25,33 @@ export function isChunkLoadError(error: unknown): boolean {
 
 const RELOAD_KEY = 'lobe-chunk-reload';
 
+const notifiedErrors = new WeakSet<object>();
+
+// One failed import() surfaces several times — `vite:preloadError`, then the
+// rethrown `unhandledrejection`, then the router ErrorBoundary render — all
+// carrying the same Error instance. Only the first one may act on it.
+function isAlreadyNotified(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  if (notifiedErrors.has(error)) return true;
+
+  notifiedErrors.add(error);
+  return false;
+}
+
 /**
  * Auto-reload on chunk load error. Uses sessionStorage to prevent infinite reload loops.
  */
-export function notifyChunkError(): void {
-  const reloaded = sessionStorage.getItem(RELOAD_KEY);
-  if (reloaded) {
-    sessionStorage.removeItem(RELOAD_KEY);
+export function notifyChunkError(error?: unknown): void {
+  if (isAlreadyNotified(error)) return;
+
+  // The flag is deliberately never cleared: it must stay monotonic so a chunk
+  // that is still missing after the reload lands on the toast instead of
+  // re-arming another reload.
+  if (sessionStorage.getItem(RELOAD_KEY)) {
     toast.error('There is a new version for the web app. Refresh the page to update');
     return;
   }
+
   sessionStorage.setItem(RELOAD_KEY, '1');
   window.location.reload();
 }

--- a/src/utils/router.tsx
+++ b/src/utils/router.tsx
@@ -147,7 +147,7 @@ export const ErrorBoundary = ({ resetPath }: ErrorBoundaryProps) => {
   const appearance = isDark ? 'dark' : 'light';
 
   if (typeof window !== 'undefined' && isChunkLoadError(error)) {
-    notifyChunkError();
+    notifyChunkError(error);
   }
 
   return (


### PR DESCRIPTION
On production (app.lobehub.com), unlocking DevDock (5× About clicks) crashed the whole page with:

```
TypeError: Cannot read properties of undefined (reading 'default')
    at Lazy (<anonymous>)
```

#### Root cause

Two independent bugs stacked:

1. **`devtools/` chunks are never deployed.** #17652 routed all DevDock-related chunks to a `devtools/[name]-[hash].js` output directory (`sharedChunkFileNames`), but `scripts/copySpaBuildCore.ts` `copyDirs` was never updated, so `dist/*/devtools/` is not copied into `public/_spa/`. `GET /_spa/devtools/DevDock-*.js` returns 404 in production (verified against the live deployment).
2. **The `vite:preloadError` listener converted the 404 into an un-diagnosable render crash.** Vite's preload helper only rethrows the import error when the event default is kept (`if (!event.defaultPrevented) throw err`). Our listener in `src/initialize.ts` called `event.preventDefault()`, so the failed `import()` **resolved with `undefined`**, and React's `lazy` initializer threw `undefined.default` — a TypeError that no longer matches `isChunkLoadError`, bypassing every chunk-error recovery path. Since `DevDockLayout` wraps the entire app with no boundary in between, the root ErrorBoundary unmounted everything. The unlock flag persists in localStorage, so every subsequent load crashed again.

#### Fix

- `scripts/copySpaBuildCore.ts`: add `devtools` to `copyDirs` so the chunks actually ship.
- `src/initialize.ts`: keep the `vite:preloadError` notification but stop calling `preventDefault()`, so failed imports reject with the real chunk-load error again.
- `src/layout/SPAGlobalProvider/index.tsx`: wrap the DevDock mount in a local error boundary — a devtool must never take the app down.

Each fix has a regression test that fails before it and passes after (the boundary test reproduces the exact production `undefined.default` TypeError).

#### Test

- [x] Tested locally
- [x] Added/updated tests

#### 🔗 Related Issue

Regression from #17652.