### PR TITLE
♻️ refactor(ci): simplify MCP marketplace issue bot to single CLI redirect

### DIFF
--- a/.github/scripts/auto-handle-mcp-submission.ts
+++ b/.github/scripts/auto-handle-mcp-submission.ts
@@ -1,23 +1,18 @@
 #!/usr/bin/env bun
 /**
- * Auto-handle "Add my MCP server to the marketplace" issues.
+ * Auto-handle MCP marketplace listing issues (new listing + rescan/refresh).
  *
- * MCP listing requests are now self-service via the @lobehub/market-cli, so we
- * no longer take them through GitHub issues. This script runs when an issue is
- * opened: if it is a *new-server listing request* (and NOT a marketplace bug or
- * CLI feedback), it labels the issue `mcp:submission`, posts the redirect
- * template (pointing at the CLI, with the author's own repo filled in), and
- * closes it as `not_planned`. The comment invites the author to reopen if it
- * was closed by mistake.
+ * Listing and refresh requests are self-service via @lobehub/market-cli.
+ * When an issue matches, we label it `mcp:submission`, post a CLI redirect
+ * comment, and close it as `not_planned`. Authors can reopen if it was closed
+ * by mistake, or open a new issue if the CLI cannot complete the task.
  *
- * Anything that is not a confident match is left untouched for normal triage.
+ * Product bugs and CLI feedback are left for normal triage.
  */
 
 import {
   MCP_LABEL_COLORS,
   MCP_LABEL_DESCRIPTIONS,
-  MCP_MANUAL_REVIEW_LABEL,
-  MCP_RESCAN_LABEL,
   MCP_SUBMISSION_LABEL,
 } from './shared/mcp-labels';
 import { classify } from './shared/mcp-submission-classifier';
@@ -32,6 +27,7 @@ declare global {
 
 const MARKER = '<!-- bot:mcp-submission -->';
 const REPO_PLACEHOLDER = 'https://github.com/<owner>/<repo>';
+const PUBLISH_SKILL_URL = 'https://lobehub.com/publish-mcp/skill.md';
 
 interface GitHubLabel {
   name: string;
@@ -73,7 +69,6 @@ async function githubRequest<T>(
     );
   }
 
-  // Some endpoints (e.g. label add) return 200 with a body; others may be empty.
   const text = await response.text();
   return (text ? JSON.parse(text) : undefined) as T;
 }
@@ -82,30 +77,38 @@ function buildComment(repoUrl: string | null): string {
   const submitUrl = repoUrl ?? REPO_PLACEHOLDER;
 
   return `${MARKER}
-👋 Thanks for this! Heads-up: **we no longer take MCP listing requests via issues** — there's now a self-service flow, so you can list and manage your server yourself without waiting on us.
+👋 Thanks for this! **MCP marketplace listing and refresh requests are self-service** — please use the official CLI instead of GitHub issues. You can list a new server, claim an existing one, and publish version/metadata updates yourself without waiting on us.
 
-**Easiest — let your coding agent do it.** Paste this into Claude Code / Cursor / Codex / etc.:
+### Easiest — let your coding agent do it
+
+Paste this into Claude Code / Cursor / Codex / etc.:
 
 \`\`\`text
-Read https://lobehub.com/publish-mcp/skill.md and follow the instructions to publish my MCP server to the LobeHub Marketplace
+Read ${PUBLISH_SKILL_URL} and follow the instructions to publish (or refresh) my MCP server on the LobeHub Marketplace
 \`\`\`
 
-It reads our publishing skill and drives the CLI for you (login → verify GitHub ownership → submit your repo).
-
-**Prefer to run it yourself?** Use the official CLI directly (Node.js ≥ 22):
+### Or run the CLI yourself (Node.js ≥ 22)
 
 \`\`\`bash
-npx -y @lobehub/market-cli login            # browser login
-npx -y @lobehub/market-cli github connect    # verify you own the repo
+# 1. Login + link GitHub (browser, once)
+npx -y @lobehub/market-cli login
+npx -y @lobehub/market-cli github connect
+
+# 2a. New listing — submit a GitHub repo you own (or have push access to).
+#     Private repos work too after \`github connect\`. Replace the URL if needed.
 npx -y @lobehub/market-cli plugin submit ${submitUrl}
-npx -y @lobehub/market-cli plugin list --output json   # import is async (~a few min)
+# Import is async (~a few minutes). Track with:
+npx -y @lobehub/market-cli plugin list --output json
+
+# 2b. Already listed — claim it, then publish an updated version / metadata
+#     (from a directory that has lhm.plugin.json)
+npx -y @lobehub/market-cli plugin claim <identifier>
+npx -y @lobehub/market-cli plugin publish --dir /absolute/path/to/your-mcp
 \`\`\`
 
-After that you self-manage everything — versions, metadata, delist, delete — via \`plugin publish\` / \`unpublish\` / \`delete\`. Full guide: **https://lobehub.com/publish-mcp/skill.md**
+If the CLI fails (claim/submit stuck, docs wrong, etc.), **open a new issue** with the command you ran and the full error output — that feedback is welcome.
 
-Self-publish works from a **GitHub repo you own**. Not your repo and you just want it indexed? Use the **"Request a Server"** button at **https://lobehub.com/mcp**.
-
-I'll close this as a listing request — **if you think it was closed by mistake, just reopen this issue (or leave a comment) and we'll take another look.** The CLI just launched, so if you hit _any_ problem using it, a new issue is very welcome — that feedback is exactly what we want right now. Thanks! 🙏`;
+I'll close this as a marketplace listing request. **If it was closed by mistake, reopen or comment and we'll take another look.** Thanks! 🙏`;
 }
 
 async function ensureLabel(
@@ -174,41 +177,17 @@ async function main(): Promise<void> {
     return;
   }
 
-  // Idempotency is handled per-step below (label adds are idempotent, the close is a
-  // no-op on an already-closed issue, and the redirect comment is guarded by its
-  // marker), so a re-run after a partial failure safely completes the missing steps.
-  const { delivery, isSubmission, kind, reason, repoUrl } = classify(
-    issue.title || '',
-    issue.body || '',
-  );
-  console.log(`[INFO] Classification: ${kind} — ${reason}`);
+  // Idempotency: label add is safe to re-run, close is a no-op when already closed,
+  // and the redirect comment is guarded by its marker.
+  const { isSubmission, reason, repoUrl } = classify(issue.title || '', issue.body || '');
+  console.log(`[INFO] Classification: isSubmission=${isSubmission} — ${reason}`);
   if (repoUrl) console.log(`[INFO] Extracted repo: ${repoUrl}`);
 
-  // Rescan / refresh requests against an existing listing get their own queue
-  // label and stay open: they need a maintainer (or future automation) to
-  // trigger a rescan, not the "use the CLI" redirect.
-  if (kind === 'listing-ops') {
-    await ensureLabel(
-      owner,
-      repo,
-      token,
-      MCP_RESCAN_LABEL,
-      MCP_LABEL_COLORS.rescan,
-      MCP_LABEL_DESCRIPTIONS.rescan,
-    );
-    await addLabel(owner, repo, token, issueNumber, MCP_RESCAN_LABEL);
-    console.log(
-      '[DONE] Existing-listing rescan request — labeled, left open (no comment, no close)',
-    );
-    return;
-  }
-
   if (!isSubmission) {
-    console.log('[DONE] Not a listing request — leaving for normal triage');
+    console.log('[DONE] Not a marketplace listing request — leaving for normal triage');
     return;
   }
 
-  // Every detected listing request gets the category label.
   await ensureLabel(
     owner,
     repo,
@@ -219,27 +198,6 @@ async function main(): Promise<void> {
   );
   await addLabel(owner, repo, token, issueNumber, MCP_SUBMISSION_LABEL);
 
-  // Remote-only or unknown-delivery servers cannot be self-published through the
-  // CLI, so we must NOT send the "use the CLI" redirect or close them. Flag for
-  // maintainer review and leave open.
-  if (delivery !== 'local') {
-    await ensureLabel(
-      owner,
-      repo,
-      token,
-      MCP_MANUAL_REVIEW_LABEL,
-      MCP_LABEL_COLORS.manualReview,
-      MCP_LABEL_DESCRIPTIONS.manualReview,
-    );
-    await addLabel(owner, repo, token, issueNumber, MCP_MANUAL_REVIEW_LABEL);
-    console.log(
-      `[DONE] ${delivery} delivery — left open for manual handling (no comment, no close)`,
-    );
-    return;
-  }
-
-  // Local / installable server — redirect to the self-service CLI and close.
-  // Guard the comment with its marker so a re-run never double-posts.
   const comments = await githubRequest<GitHubComment[]>(
     `/repos/${owner}/${repo}/issues/${issueNumber}/comments`,
     token,
@@ -253,16 +211,13 @@ async function main(): Promise<void> {
     console.log('[INFO] Posted CLI redirect comment');
   }
 
-  // Closing an already-closed issue is a harmless no-op, so this step is re-run safe.
   await githubRequest(`/repos/${owner}/${repo}/issues/${issueNumber}`, token, 'PATCH', {
     state: 'closed',
     state_reason: 'not_planned',
   });
-  console.log(`[SUCCESS] Closed #${issueNumber} (local submission) as not planned`);
+  console.log(`[SUCCESS] Closed #${issueNumber} (marketplace listing request) as not planned`);
 }
 
-// Run only when executed directly, so `classify`/`extractRepoUrl` can be
-// imported by unit tests without firing the GitHub side effects.
 // @ts-ignore - import.meta.main is provided by Bun
 if (import.meta.main) {
   main().catch((error) => {

--- a/.github/scripts/shared/mcp-labels.ts
+++ b/.github/scripts/shared/mcp-labels.ts
@@ -1,16 +1,18 @@
 export const MCP_FEATURE_LABEL = 'feature:mcp';
 export const MCP_SUBMISSION_LABEL = 'mcp:submission';
-export const MCP_MANUAL_REVIEW_LABEL = 'mcp:manual-review';
-export const MCP_RESCAN_LABEL = 'mcp:rescan';
 export const MCP_TRIGGER_TRIAGE_LABEL = 'trigger:mcp-triage';
 
+/** @deprecated Legacy labels kept only so old issues still skip dedupe. */
 export const MCP_LEGACY_SUBMISSION_LABEL = 'mcp-submission';
+/** @deprecated */
 export const MCP_LEGACY_REMOTE_LABEL = 'mcp:remote';
+/** @deprecated Removed in favor of mcp:submission */
+export const MCP_LEGACY_MANUAL_REVIEW_LABEL = 'mcp:manual-review';
+/** @deprecated Removed in favor of mcp:submission */
+export const MCP_LEGACY_RESCAN_LABEL = 'mcp:rescan';
 
 export const MCP_LABEL_COLORS = {
   feature: 'faf9f6',
-  manualReview: 'fbca04',
-  rescan: '1d76db',
   submission: 'c5def5',
   triggerTriage: 'ededed',
 } as const;
@@ -18,10 +20,7 @@ export const MCP_LABEL_COLORS = {
 export const MCP_LABEL_DESCRIPTIONS = {
   feature:
     'MCP-related issues across connectors, tools, marketplace, runtime, and desktop integration',
-  manualReview:
-    'MCP submission cannot be resolved by the self-service CLI; maintainer review required',
-  rescan:
-    'Existing MCP marketplace listing needs a rescan/refresh; maintainer or automation action required',
-  submission: 'MCP marketplace listing submission handled by the MCP submission workflow',
+  submission:
+    'MCP marketplace listing request (new listing, refresh, or rescan) redirected to self-service CLI',
   triggerTriage: 'Manually trigger MCP submission handling',
 } as const;

--- a/.github/scripts/shared/mcp-submission-classifier.ts
+++ b/.github/scripts/shared/mcp-submission-classifier.ts
@@ -1,12 +1,10 @@
 export interface Classification {
-  // How the server is delivered: only local installable servers can be
-  // self-published via the CLI; remote URL-only and unknown delivery go to humans.
-  delivery: 'local' | 'remote' | 'unknown';
+  /**
+   * True when the issue is a marketplace listing request we auto-handle:
+   * new-server submission, rescan/refresh of an existing listing, etc.
+   * Product bugs and CLI feedback stay false for normal triage.
+   */
   isSubmission: boolean;
-  // Sub-category the triage bot routes on: a NEW listing submission, an ops
-  // request against an EXISTING listing (rescan / refresh / re-index / stuck
-  // scoring), or neither.
-  kind: 'listing-ops' | 'none' | 'submission';
   reason: string;
   repoUrl: string | null;
 }
@@ -15,6 +13,9 @@ export interface Classification {
  * Pull the first plausible "server repo" GitHub URL out of the issue body.
  * Skips links to LobeHub's own org and the MCP registry org so we land on the
  * submitter's repository.
+ *
+ * A missing URL is fine: private repos can still be submitted via the CLI after
+ * `github connect`, so the handler redirects even when no public URL is pasted.
  */
 export function extractRepoUrl(body: string): string | null {
   // github.com first-path segments that are not repositories: attachments,
@@ -58,11 +59,13 @@ export function extractRepoUrl(body: string): string | null {
 }
 
 /**
- * Decide whether an issue is a new MCP server listing request.
+ * Decide whether an issue is an MCP marketplace listing request (new listing
+ * or refresh/rescan of an existing one).
  *
- * High precision on purpose: the MCP submission handler uses this to drive an
- * auto-close path. We require add/submit intent + the word "mcp" + a server
- * reference, and explicitly bail out on marketplace bugs and CLI feedback.
+ * High precision on the *intent* (listing/ops vs product bug / CLI failure):
+ * the handler auto-closes matches and redirects to the self-service CLI.
+ * A public repo URL is optional — private repos are submitted through the CLI
+ * after GitHub ownership verification.
  */
 export function classify(title: string, body: string): Classification {
   const text = `${title}\n${body}`.toLowerCase();
@@ -84,15 +87,9 @@ export function classify(title: string, body: string): Classification {
   const hasMarketContext =
     /marketplace|市场|上架|收录|登记/.test(text) || /^\s*\[mcp\b/i.test(title);
 
-  const isMarketplaceBug =
-    /scoring|re-?scan|re-?index|stuck|outdated|out of date|stale|not updating|won'?t update|wrong version|shows? (?:old|outdated|wrong)|disappeared|removed from|missing from|not show(?:ing)?|not syncing|sync(?:ing)? (?:from|issue)|canonical cache/.test(
-      text,
-    );
-
   // Ops request against an EXISTING listing (rescan / refresh / re-index /
-  // stuck scoring). Kept high-precision like the submission path: an explicit
-  // rescan-style verb or "listing is stale" framing — not just any marketplace
-  // complaint — so product bugs that mention refreshing never match.
+  // stuck scoring). High-precision so product bugs that mention "refresh"
+  // never match.
   const isListingOps =
     hasMcp &&
     (/\bre-?scan(?:ned|ning)?\b|\bre-?index(?:ed|ing)?\b|refresh (?:the )?(?:existing )?(?:mcp )?(?:server )?(?:listing|metadata)|listing (?:is )?stale|stale (?:listing|scan|canonical)|scoring stuck|stuck scoring|canonical cache|重新扫描|重新索引|刷新.{0,6}(?:列表|收录|索引)/.test(
@@ -101,91 +98,89 @@ export function classify(title: string, body: string): Classification {
       (/\b(?:listing|marketplace)\b|市场/.test(text) &&
         /\bstale\b|\bscoring\b|\bstuck (?:at|on) v?\d/.test(text)));
 
-  const kind: Classification['kind'] = isListingOps ? 'listing-ops' : 'none';
-
   const isPublishingFlowFeedback =
     /publish-mcp|publishing skill/.test(text) &&
     /\b(?:feedback|wrong|confusing?|docs?|instructions?|guide|command sequence|not work|fail|error|bug|issue|problem|can'?t|cannot|unable)\b/.test(
       text,
     );
 
+  // CLI / publish tooling failures must stay open for triage — including when
+  // the user also says "rescan" (otherwise isListingOps would auto-close them
+  // and re-point them at the same broken CLI path).
   const isCliFeedback =
     isPublishingFlowFeedback ||
-    /\bcli\b.+(?:fail|error|issue|problem|bug|not work|can'?t|unable)/.test(text) ||
-    /(?:fail|error|unable|can'?t|cannot).*(?:submit|publish|login|connect|verify ownership)/.test(
+    /\b(?:market-)?cli\b.+(?:fail|error|issue|problem|bug|not work|can'?t|cannot|unable|reject)/.test(
+      text,
+    ) ||
+    /(?:fail|error|unable|can'?t|cannot|reject).*(?:submit|publish|login|connect|claim|verify ownership)/.test(
+      text,
+    ) ||
+    /(?:submit|publish|login|connect|claim|verify ownership).*(?:fail|error|unable|can'?t|cannot|reject)/.test(
       text,
     );
 
-  // Strong install signals prove the CLI can publish the server.
-  const hasStrongInstall =
-    /\bnpx\b|\buvx\b|\bpipx\b|\bpip install\b|\bdocker run\b/.test(text) ||
-    /"command"\s*:/.test(text) ||
-    /npmjs\.com\/package\//.test(text);
-  const hasStdioMention = /\bstdio\b/.test(text);
-  const hasRemoteSignal =
-    /"url"\s*:/.test(text) ||
-    /\bstreamable[- ]?http\b|\bsse\b/.test(text) ||
-    /transport[^a-z]{0,8}(?:sse|http|streamable)/.test(text) ||
-    /\bremote(?:ly)? (?:hosted|mcp|server)\b|\bhosted mcp\b/.test(text) ||
-    /\b(?:endpoint|url)\b[^\n]{1,15}https?:\/\/(?!github\.com)/.test(text);
-  const isRemoteOnly =
-    /\bno install\b|\bno npm\b|\bremote[- ]only\b|no local install|installation[- ]free/.test(text);
+  // CLI limitations (claim rejects org, etc.). Checked BEFORE isListingOps so
+  // "please rescan — market-cli cannot claim" is not auto-closed back into CLI.
+  const isCliLimitation =
+    /market.?cli cannot|cannot claim|can'?t claim|rejects? org|org[- ]owned|push\/admin access cannot claim/.test(
+      text,
+    );
 
-  const delivery: Classification['delivery'] = isRemoteOnly
-    ? 'remote'
-    : hasStrongInstall
-      ? 'local'
-      : hasRemoteSignal
-        ? 'remote'
-        : hasStdioMention
-          ? 'local'
-          : 'unknown';
+  // Marketplace product bugs that are NOT a self-service list/rescan request.
+  // Applied only on the new-submission path so phrases like "listing stale …
+  // not syncing" still match isListingOps.
+  const isProductMarketplaceBug =
+    /disappeared|removed from|missing from|not show(?:ing)?|not syncing|sync(?:ing)? (?:from|issue)|install button/.test(
+      text,
+    );
 
-  if (!hasMcp) return { delivery, isSubmission: false, kind, reason: 'no "mcp" keyword', repoUrl };
-  // Listing-ops takes precedence over submission: "add X (rescan existing
-  // listing to v2)" is a rescan of an existing entry, not a new submission.
-  if (isListingOps)
+  if (isCliFeedback) {
     return {
-      delivery,
       isSubmission: false,
-      kind,
-      reason: 'rescan/refresh request for an existing marketplace listing',
-      repoUrl,
-    };
-  if (!hasAddVerb)
-    return { delivery, isSubmission: false, kind, reason: 'no add/submit intent', repoUrl };
-  if (!hasMarketContext)
-    return { delivery, isSubmission: false, kind, reason: 'no marketplace context', repoUrl };
-  if (!repoUrl && delivery !== 'remote')
-    return {
-      delivery,
-      isSubmission: false,
-      kind,
-      reason: 'no server reference (repo URL or endpoint)',
-      repoUrl,
-    };
-  if (isMarketplaceBug)
-    return {
-      delivery,
-      isSubmission: false,
-      kind,
-      reason: 'looks like a marketplace/listing bug',
-      repoUrl,
-    };
-  if (isCliFeedback)
-    return {
-      delivery,
-      isSubmission: false,
-      kind,
       reason: 'looks like CLI/publishing feedback',
       repoUrl,
     };
+  }
 
+  if (isCliLimitation) {
+    return {
+      isSubmission: false,
+      reason: 'looks like a marketplace/listing bug or CLI limitation',
+      repoUrl,
+    };
+  }
+
+  // Rescan / refresh of an existing listing → same self-service path as new listings.
+  if (isListingOps) {
+    return {
+      isSubmission: true,
+      reason: 'existing marketplace listing rescan/refresh request',
+      repoUrl,
+    };
+  }
+
+  if (!hasMcp) {
+    return { isSubmission: false, reason: 'no "mcp" keyword', repoUrl };
+  }
+  if (!hasAddVerb) {
+    return { isSubmission: false, reason: 'no add/submit intent', repoUrl };
+  }
+  if (!hasMarketContext) {
+    return { isSubmission: false, reason: 'no marketplace context', repoUrl };
+  }
+  if (isProductMarketplaceBug) {
+    return {
+      isSubmission: false,
+      reason: 'looks like a marketplace/listing bug or CLI limitation',
+      repoUrl,
+    };
+  }
+
+  // No public repo URL is OK: private repos are listed via the CLI after
+  // `github connect` verifies ownership.
   return {
-    delivery,
     isSubmission: true,
-    kind: 'submission',
-    reason: `new MCP server listing request (${delivery})`,
+    reason: 'new MCP server listing request',
     repoUrl,
   };
 }

--- a/.github/scripts/shared/mcp-submission-classifier.ts
+++ b/.github/scripts/shared/mcp-submission-classifier.ts
@@ -73,14 +73,15 @@ export function classify(title: string, body: string): Classification {
 
   const hasMcp = /\bmcp\b/.test(text);
 
-  // Explicit add / submit intent. The `[MCP Submission]` and `[MCP Plugin]`
-  // title prefixes are themselves a declaration of intent.
-  const hasAddVerb =
-    /\b(?:add|submit|submission|submitting|list(?:ing)?|publish|index|register|include)\b/.test(
-      text,
-    ) ||
+  // URL-less requests need an unambiguous action signal because "listing" is
+  // also a common noun in marketplace product bug reports.
+  const hasExplicitSubmissionIntent =
+    /\b(?:add|submit|submission|submitting|publish|index|register|include)\b/.test(text) ||
+    /\b(?:please|kindly|request(?:ing)?(?:\s+to)?)\s+list\b|\blisting\s+request\b/.test(text) ||
     /上架|收录|添加|提交|登记/.test(text) ||
-    /^\s*\[mcp\s*(?:submission|plugin)\]/i.test(title);
+    /^\s*\[mcp\s*(?:submission|plugin)\]/i.test(title) ||
+    /^\s*\[request\].*\blist\b/i.test(title);
+  const hasSubmissionIntent = hasExplicitSubmissionIntent || /\blist(?:ing)?\b/.test(text);
 
   // Marketplace framing keeps us on listing requests and off random MCP bug
   // reports that merely mention "mcp" and a verb in passing.
@@ -122,7 +123,7 @@ export function classify(title: string, body: string): Classification {
   // CLI limitations (claim rejects org, etc.). Checked BEFORE isListingOps so
   // "please rescan — market-cli cannot claim" is not auto-closed back into CLI.
   const isCliLimitation =
-    /market.?cli cannot|cannot claim|can'?t claim|rejects? org|org[- ]owned|push\/admin access cannot claim/.test(
+    /market.?cli cannot|cannot claim|can'?t claim|rejects? org|push\/admin access cannot claim/.test(
       text,
     );
 
@@ -162,7 +163,7 @@ export function classify(title: string, body: string): Classification {
   if (!hasMcp) {
     return { isSubmission: false, reason: 'no "mcp" keyword', repoUrl };
   }
-  if (!hasAddVerb) {
+  if (!hasSubmissionIntent) {
     return { isSubmission: false, reason: 'no add/submit intent', repoUrl };
   }
   if (!hasMarketContext) {
@@ -172,6 +173,13 @@ export function classify(title: string, body: string): Classification {
     return {
       isSubmission: false,
       reason: 'looks like a marketplace/listing bug or CLI limitation',
+      repoUrl,
+    };
+  }
+  if (!repoUrl && !hasExplicitSubmissionIntent) {
+    return {
+      isSubmission: false,
+      reason: 'no explicit add/submit intent for a URL-less request',
       repoUrl,
     };
   }

--- a/.github/scripts/shared/mcp-submission-classifier.ts
+++ b/.github/scripts/shared/mcp-submission-classifier.ts
@@ -97,7 +97,7 @@ export function classify(title: string, body: string): Classification {
       text,
     ) ||
       (/\b(?:listing|marketplace)\b|市场/.test(text) &&
-        /\bstale\b|\bscoring\b|\bstuck (?:at|on) v?\d/.test(text)));
+        /\bstale\b|\bstuck (?:at|on) v?\d/.test(text)));
 
   const isPublishingFlowFeedback =
     /publish-mcp|publishing skill/.test(text) &&
@@ -110,13 +110,13 @@ export function classify(title: string, body: string): Classification {
   // and re-point them at the same broken CLI path).
   const isCliFeedback =
     isPublishingFlowFeedback ||
-    /\b(?:market-)?cli\b.+(?:fail|error|issue|problem|bug|not work|can'?t|cannot|unable|reject)/.test(
+    /\b(?:market-)?cli\b.+(?:fail|error|issue|problem|bug|not work|can'?t|cannot|unable|reject)/s.test(
       text,
     ) ||
-    /(?:fail|error|unable|can'?t|cannot|reject).*(?:submit|publish|login|connect|claim|verify ownership)/.test(
+    /(?:fail|error|unable|can'?t|cannot|reject).*(?:add|list|submit|publish|login|connect|claim|verify ownership)/s.test(
       text,
     ) ||
-    /(?:submit|publish|login|connect|claim|verify ownership).*(?:fail|error|unable|can'?t|cannot|reject)/.test(
+    /(?:add|list|submit|publish|login|connect|claim|verify ownership).*(?:fail|error|unable|can'?t|cannot|reject)/s.test(
       text,
     );
 

--- a/.github/scripts/should-run-dedupe.ts
+++ b/.github/scripts/should-run-dedupe.ts
@@ -3,10 +3,10 @@
 import { appendFile } from 'node:fs/promises';
 
 import {
+  MCP_LEGACY_MANUAL_REVIEW_LABEL,
   MCP_LEGACY_REMOTE_LABEL,
+  MCP_LEGACY_RESCAN_LABEL,
   MCP_LEGACY_SUBMISSION_LABEL,
-  MCP_MANUAL_REVIEW_LABEL,
-  MCP_RESCAN_LABEL,
   MCP_SUBMISSION_LABEL,
 } from './shared/mcp-labels';
 import { classify } from './shared/mcp-submission-classifier';
@@ -29,10 +29,10 @@ interface DedupeDecision {
 
 const MCP_DEDUPE_SKIP_LABELS = [
   MCP_SUBMISSION_LABEL,
-  MCP_MANUAL_REVIEW_LABEL,
-  MCP_RESCAN_LABEL,
   MCP_LEGACY_SUBMISSION_LABEL,
   MCP_LEGACY_REMOTE_LABEL,
+  MCP_LEGACY_MANUAL_REVIEW_LABEL,
+  MCP_LEGACY_RESCAN_LABEL,
 ] as const;
 
 async function githubRequest<T>(endpoint: string, token: string): Promise<T> {
@@ -84,13 +84,7 @@ export function shouldDedupeIssue(issue: DedupeIssue): DedupeDecision {
   const classification = classify(issue.title || '', issue.body || '');
   if (classification.isSubmission) {
     return {
-      reason: `MCP marketplace listing request (${classification.delivery}) is handled by the MCP submission workflow`,
-      shouldDedupe: false,
-    };
-  }
-  if (classification.kind === 'listing-ops') {
-    return {
-      reason: 'MCP listing rescan request is handled by the MCP submission workflow',
+      reason: `MCP marketplace listing request (${classification.reason}) is handled by the MCP submission workflow`,
       shouldDedupe: false,
     };
   }

--- a/.github/workflows/mcp-submission-handler.yml
+++ b/.github/workflows/mcp-submission-handler.yml
@@ -1,5 +1,5 @@
 name: MCP Submission Handler
-# Auto-close "Add my MCP server to the marketplace" issues and redirect to the self-service CLI
+# Auto-close MCP marketplace listing / rescan issues and redirect to the self-service CLI
 
 on:
   issues:

--- a/tests/github-scripts/mcpLabels.test.ts
+++ b/tests/github-scripts/mcpLabels.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import {
   MCP_LABEL_DESCRIPTIONS,
-  MCP_MANUAL_REVIEW_LABEL,
-  MCP_RESCAN_LABEL,
+  MCP_LEGACY_MANUAL_REVIEW_LABEL,
+  MCP_LEGACY_RESCAN_LABEL,
   MCP_SUBMISSION_LABEL,
   MCP_TRIGGER_TRIAGE_LABEL,
 } from '../../.github/scripts/shared/mcp-labels';
@@ -13,21 +13,13 @@ import { shouldDedupeIssue } from '../../.github/scripts/should-run-dedupe';
 describe('MCP issue labels', () => {
   it('uses normalized names and descriptions for the MCP submission workflow', () => {
     expect(MCP_SUBMISSION_LABEL).toBe('mcp:submission');
-    expect(MCP_MANUAL_REVIEW_LABEL).toBe('mcp:manual-review');
-    expect(MCP_RESCAN_LABEL).toBe('mcp:rescan');
     expect(MCP_TRIGGER_TRIAGE_LABEL).toBe('trigger:mcp-triage');
     expect(MCP_LABEL_DESCRIPTIONS.submission).toBe(
-      'MCP marketplace listing submission handled by the MCP submission workflow',
-    );
-    expect(MCP_LABEL_DESCRIPTIONS.manualReview).toBe(
-      'MCP submission cannot be resolved by the self-service CLI; maintainer review required',
-    );
-    expect(MCP_LABEL_DESCRIPTIONS.rescan).toBe(
-      'Existing MCP marketplace listing needs a rescan/refresh; maintainer or automation action required',
+      'MCP marketplace listing request (new listing, refresh, or rescan) redirected to self-service CLI',
     );
   });
 
-  it('skips duplicate detection for MCP workflow labels', () => {
+  it('skips duplicate detection for MCP workflow labels (including legacy)', () => {
     const baseIssue = {
       body: '',
       labels: [],
@@ -35,7 +27,11 @@ describe('MCP issue labels', () => {
       title: 'Regular issue',
     };
 
-    for (const label of [MCP_SUBMISSION_LABEL, MCP_MANUAL_REVIEW_LABEL, MCP_RESCAN_LABEL]) {
+    for (const label of [
+      MCP_SUBMISSION_LABEL,
+      MCP_LEGACY_MANUAL_REVIEW_LABEL,
+      MCP_LEGACY_RESCAN_LABEL,
+    ]) {
       expect(
         shouldDedupeIssue({
           ...baseIssue,
@@ -53,11 +49,11 @@ describe('MCP issue labels', () => {
       title: '[Request] Rescan elecz MCP listing to v1.9.6',
     });
     expect(decision.shouldDedupe).toBe(false);
-    expect(decision.reason).toContain('rescan');
+    expect(decision.reason).toMatch(/rescan|listing request/i);
   });
 });
 
-describe('classify: listing-ops (rescan of an existing listing)', () => {
+describe('classify: marketplace listing requests (submit + rescan)', () => {
   // Real historical issue titles from lobehub/lobehub.
   const rescanTitles = [
     '[MCP Marketplace] Scoring stuck for @apexfdn/copilot-mcp — manual rescan needed',
@@ -73,19 +69,18 @@ describe('classify: listing-ops (rescan of an existing listing)', () => {
     'MCP Server re-index request: degen0root-panchanga_api',
   ];
 
-  it.each(rescanTitles)('flags "%s" as listing-ops', (title) => {
+  it.each(rescanTitles)('handles rescan/refresh "%s" as a listing request', (title) => {
     const result = classify(title, '');
-    expect(result.kind).toBe('listing-ops');
-    expect(result.isSubmission).toBe(false);
+    expect(result.isSubmission).toBe(true);
+    expect(result.reason).toMatch(/rescan|refresh/i);
   });
 
-  it('prefers listing-ops over submission when both intents appear', () => {
+  it('handles combined add + rescan intent as a listing request', () => {
     const result = classify(
       '[Request] Add scholar-sidekick-mcp to the MCP marketplace (rescan existing v0.3.0 listing to v0.4.1)',
       'https://github.com/mlava/scholar-sidekick-mcp — please rescan, npx install works.',
     );
-    expect(result.kind).toBe('listing-ops');
-    expect(result.isSubmission).toBe(false);
+    expect(result.isSubmission).toBe(true);
   });
 
   it('does not flag MCP product bugs that merely mention refreshing or lists', () => {
@@ -95,16 +90,54 @@ describe('classify: listing-ops (rescan of an existing listing)', () => {
       '自定义添加的mcp服务器无法自动更新工具列表',
     ];
     for (const title of productBugTitles) {
-      expect(classify(title, '').kind).toBe('none');
+      expect(classify(title, '').isSubmission).toBe(false);
     }
   });
 
-  it('still classifies a plain new-server submission as submission', () => {
+  it('classifies a plain new-server submission as a listing request', () => {
     const result = classify(
       '[MCP Submission] Add my weather server to the marketplace',
       'Please add https://github.com/someone/weather-mcp — install with `npx weather-mcp`.',
     );
-    expect(result.kind).toBe('submission');
     expect(result.isSubmission).toBe(true);
+    expect(result.repoUrl).toBe('https://github.com/someone/weather-mcp');
+  });
+
+  it('also handles remote-only listing requests (redirect to CLI / website)', () => {
+    const result = classify(
+      '[Request] Add DC Hub Intelligence to the MCP marketplace',
+      `Remote MCP server for data-center intelligence.
+
+- Endpoint: https://dchub.cloud/mcp
+- Repo: https://github.com/azmartone67/dchub-mcp-server`,
+    );
+    expect(result.isSubmission).toBe(true);
+    expect(result.repoUrl).toBe('https://github.com/azmartone67/dchub-mcp-server');
+  });
+
+  it('allows new listing requests without a public repo URL (private repos via CLI)', () => {
+    const result = classify(
+      '[Request] Add my private weather MCP server to the marketplace',
+      'Please list our internal MCP server. The repo is private; I will submit via the CLI after github connect.',
+    );
+    expect(result.isSubmission).toBe(true);
+    expect(result.repoUrl).toBeNull();
+  });
+
+  it('does not auto-handle rescan + CLI claim failure (avoids close loop)', () => {
+    const result = classify(
+      '[Request] Rescan my MCP listing',
+      'Please rescan my listing — I moved the repo to an org and market-cli cannot claim it (rejects org).',
+    );
+    expect(result.isSubmission).toBe(false);
+    expect(result.reason).toMatch(/CLI|marketplace\/listing bug|limitation/i);
+  });
+
+  it('does not auto-handle claim failure even when the title says rescan', () => {
+    const result = classify(
+      'Rescan needed after org migration',
+      'MCP marketplace listing stuck. Cannot claim via CLI: rejects org-owned repos even with push access.',
+    );
+    expect(result.isSubmission).toBe(false);
   });
 });

--- a/tests/github-scripts/mcpSubmissionClassifier.test.ts
+++ b/tests/github-scripts/mcpSubmissionClassifier.test.ts
@@ -17,4 +17,25 @@ The publishing skill points me at the wrong command sequence for this server.`,
       reason: 'looks like CLI/publishing feedback',
     });
   });
+
+  it('does not classify market-cli claim failures as listing requests', () => {
+    const classification = classify(
+      'market-cli cannot claim org-owned MCP server',
+      'Submit works for personal repos but claim rejects org even with admin access.',
+    );
+
+    expect(classification.isSubmission).toBe(false);
+  });
+
+  it('still treats a plain rescan (no CLI failure) as a listing request', () => {
+    const classification = classify(
+      '[Request] Rescan elecz MCP listing to v1.9.6',
+      'The marketplace listing is stuck on an old version, please rescan.',
+    );
+
+    expect(classification).toMatchObject({
+      isSubmission: true,
+      reason: expect.stringMatching(/rescan|refresh/i),
+    });
+  });
 });

--- a/tests/github-scripts/mcpSubmissionClassifier.test.ts
+++ b/tests/github-scripts/mcpSubmissionClassifier.test.ts
@@ -27,6 +27,24 @@ The publishing skill points me at the wrong command sequence for this server.`,
     expect(classification.isSubmission).toBe(false);
   });
 
+  it('classifies org-owned MCP submissions when no claim failure occurred', () => {
+    const classification = classify(
+      '[Request] Add our org-owned MCP server to the marketplace',
+      'Repo: https://github.com/example/acme-mcp',
+    );
+
+    expect(classification).toMatchObject({
+      isSubmission: true,
+      repoUrl: 'https://github.com/example/acme-mcp',
+    });
+  });
+
+  it('does not classify URL-less marketplace product reports as submissions', () => {
+    const classification = classify('[Request] MCP marketplace listing page filters reset', '');
+
+    expect(classification.isSubmission).toBe(false);
+  });
+
   it('still treats a plain rescan (no CLI failure) as a listing request', () => {
     const classification = classify(
       '[Request] Rescan elecz MCP listing to v1.9.6',

--- a/tests/github-scripts/mcpSubmissionClassifier.test.ts
+++ b/tests/github-scripts/mcpSubmissionClassifier.test.ts
@@ -45,6 +45,41 @@ The publishing skill points me at the wrong command sequence for this server.`,
     expect(classification.isSubmission).toBe(false);
   });
 
+  it('does not classify inability to add an MCP server as a submission', () => {
+    const classification = classify('[Bug] Cannot add MCP server to marketplace', '');
+
+    expect(classification).toMatchObject({
+      isSubmission: false,
+      reason: 'looks like CLI/publishing feedback',
+    });
+  });
+
+  it('does not classify multiline CLI failures as rescan requests', () => {
+    const classification = classify(
+      'Please rescan my MCP marketplace listing',
+      `I ran:
+
+market-cli plugin claim foo
+Error: permission denied
+
+Please rescan the listing.`,
+    );
+
+    expect(classification).toMatchObject({
+      isSubmission: false,
+      reason: 'looks like CLI/publishing feedback',
+    });
+  });
+
+  it('does not classify marketplace scoring bugs as rescan requests', () => {
+    const classification = classify(
+      '[Bug] MCP marketplace scoring is incorrect',
+      'The score shown for my server seems wrong compared to similar servers.',
+    );
+
+    expect(classification.isSubmission).toBe(false);
+  });
+
   it('still treats a plain rescan (no CLI failure) as a listing request', () => {
     const classification = classify(
       '[Request] Rescan elecz MCP listing to v1.9.6',


### PR DESCRIPTION
## Summary

Simplify the MCP marketplace GitHub issue bot so **new listings and rescan/refresh requests** share one path:

1. Label `mcp:submission`
2. Post self-service `@lobehub/market-cli` guidance
3. Close as `not_planned`

### Changes

- **Remove multi-path handling** for `mcp:manual-review` and `mcp:rescan` (kept as legacy names only for dedupe skip on old issues)
- **Unified redirect comment**: login → github connect → `plugin submit` / `plugin claim` + `plugin publish` (private repos supported after `github connect`)
- **Classifier safety**:
  - CLI feedback / claim-org failures are checked **before** `isListingOps`, so “rescan + cannot claim” is not auto-closed into a CLI loop
  - Public repo URL is optional (private repos submit via CLI)
- Update related unit tests

### Labels (target state)

| Label | Role |
| --- | --- |
| `mcp:submission` | Marketplace list/refresh requests (auto-handled) |
| `trigger:mcp-triage` | Manual re-run (ephemeral) |
| `feature:mcp` | Product domain (unchanged) |
| `mcp:manual-review` / `mcp:rescan` | Deprecated (legacy skip only) |

> Note: deleting the deprecated labels on GitHub is a separate ops step if desired.

## Test plan

- [x] `bunx vitest run tests/github-scripts/mcpLabels.test.ts tests/github-scripts/mcpSubmissionClassifier.test.ts tests/github-scripts/shouldRunDedupe.test.ts`
- [ ] After merge: open a sample “Add X to MCP marketplace” issue → expect CLI comment + close
- [ ] Open “rescan + market-cli cannot claim org” style issue → expect **left open** for triage
- [ ] Optional: `trigger:mcp-triage` on a leftover open listing issue re-runs the handler