### PR TITLE
🐛 fix(conversation): stop the message list blanking on new-topic first send

### DIFF
--- a/.agents/acceptance/probe-mock-patterns.md
+++ b/.agents/acceptance/probe-mock-patterns.md
@@ -662,6 +662,45 @@ in-page sampler above. Either way, disarm with
 `Page.removeScriptToEvaluateOnNewDocument` and reload before capturing the settled
 state, or the comparison shot is taken against a still-crippled runtime.
 
+### Proving or disproving a conversation-surface flicker
+
+**Situation:** a user reports that messages blank out and come back (e.g. right
+after the first send in a new topic). The window is tens of milliseconds, so it
+never lands in a screenshot, and the store may be correct the whole time.
+
+**Doesn't work:** a `requestAnimationFrame` sampler over store buckets and a DOM
+node count. It under-resolves the gap — a real blank can surface as a single
+"count dipped by one" frame that reads like ordinary progressive rendering, which
+is how a genuine regression gets dismissed as not reproducible. React-render
+assertions are equally blind: the conversation list is virtualized (`virtua`), so
+a correct React commit can still paint zero rows while the virtualizer re-measures.
+An existing regression test asserting at React-commit granularity can therefore be
+green while the flicker is fully present.
+
+**Works:** attach a `MutationObserver` for sub-frame DOM truth and record the
+message **ids**, not just the count, so an in-place data swap is distinguishable
+from a teardown:
+
+```js
+const ids = () =>
+  [...document.querySelectorAll('[data-message-id]')].map((e) =>
+    e.getAttribute('data-message-id').slice(-8),
+  );
+window.__MUT = [];
+new MutationObserver(() => {
+  const sig = ids().join(',');
+  if (window.__MUT.at(-1)?.ids !== sig) {
+    window.__MUT.push({ t: Math.round(performance.now()), n: ids().length, ids: sig });
+  }
+}).observe(document.body, { childList: true, subtree: true });
+```
+
+An `n: 0` entry between two populated ones is the flicker. Pair it with a wrapper
+around `chatStore.replaceMessages` (log `action` + `context.topicId`) and a probe
+on `ConversationProvider`'s `createStore`: if the store was seeded correctly but
+the DOM still blanked, the defect is a **remount**, not a data gap — the store is
+keyed per conversation, so any context-key change tears the virtualized list down.
+
 ## Detailed references
 
 - [Probe field notes](./references/probe-field-notes.md) — all historical

--- a/src/features/Conversation/ConversationProvider.test.tsx
+++ b/src/features/Conversation/ConversationProvider.test.tsx
@@ -10,7 +10,7 @@ import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 
 import ChatList from './ChatList';
 import { ConversationProvider } from './ConversationProvider';
-import { dataSelectors, useConversationStore } from './store';
+import { dataSelectors, useConversationStore, useConversationStoreApi } from './store';
 
 const chatListMocks = vi.hoisted(() => ({
   isStreaming: false,
@@ -172,6 +172,22 @@ const Probe = ({
   return null;
 };
 
+/**
+ * Records one entry per distinct ConversationStore instance, so a test can tell
+ * a re-render (same store) from a remount (fresh store). Remounting is what
+ * tears the virtualized message list down and repaints it from an empty
+ * viewport — the DOM-level half of the first-send flicker, which a
+ * React-commit-level assertion cannot observe.
+ */
+const StoreIdentityProbe = ({ stores }: { stores: unknown[] }) => {
+  const storeApi = useConversationStoreApi();
+  const context = useConversationStore((s) => s.context);
+
+  if (stores.at(-1) !== storeApi) stores.push(storeApi);
+
+  return <div data-testid="store-context-key">{messageMapKey(context)}</div>;
+};
+
 const OverlayHeightSetter = () => {
   const setChatInputOverlayHeight = useConversationStore((s) => s.setChatInputOverlayHeight);
 
@@ -219,6 +235,70 @@ describe('ConversationProvider', () => {
     );
 
     expect(mismatchedNextContextSnapshots).toEqual([]);
+  });
+
+  it('keeps the same store when a new conversation materializes its topic', () => {
+    const stores: unknown[] = [];
+    const newChatContext = {
+      agentId: 'agt_old',
+      threadId: null,
+      topicId: null,
+    } satisfies ConversationContext;
+    const materializedContext = {
+      agentId: 'agt_old',
+      threadId: null,
+      topicId: 'tpc_created',
+    } satisfies ConversationContext;
+
+    const { rerender } = render(
+      <ConversationProvider hasInitMessages context={newChatContext} messages={[]}>
+        <StoreIdentityProbe stores={stores} />
+      </ConversationProvider>,
+    );
+
+    rerender(
+      <ConversationProvider hasInitMessages context={materializedContext} messages={oldMessages}>
+        <StoreIdentityProbe stores={stores} />
+      </ConversationProvider>,
+    );
+
+    // A remount here resets virtua and paints an empty list for ~50ms — the
+    // "all messages vanished then came back" flicker right after the first send.
+    expect(stores).toHaveLength(1);
+    // …and the surviving store still follows the freshly created topic.
+    expect(screen.getByTestId('store-context-key')).toHaveTextContent(
+      messageMapKey(materializedContext),
+    );
+  });
+
+  it('creates a fresh store when switching between two persisted topics', () => {
+    const stores: unknown[] = [];
+    const firstTopic = {
+      agentId: 'agt_old',
+      threadId: null,
+      topicId: 'tpc_a',
+    } satisfies ConversationContext;
+    const secondTopic = {
+      agentId: 'agt_old',
+      threadId: null,
+      topicId: 'tpc_b',
+    } satisfies ConversationContext;
+
+    const { rerender } = render(
+      <ConversationProvider hasInitMessages context={firstTopic} messages={oldMessages}>
+        <StoreIdentityProbe stores={stores} />
+      </ConversationProvider>,
+    );
+
+    rerender(
+      <ConversationProvider hasInitMessages context={secondTopic} messages={[]}>
+        <StoreIdentityProbe stores={stores} />
+      </ConversationProvider>,
+    );
+
+    // Genuine conversation switches must stay isolated — no stale messages,
+    // input or tool state carried across.
+    expect(stores).toHaveLength(2);
   });
 
   it('renders the message skeleton before the first request settles', () => {

--- a/src/features/Conversation/ConversationProvider.test.tsx
+++ b/src/features/Conversation/ConversationProvider.test.tsx
@@ -188,6 +188,23 @@ const StoreIdentityProbe = ({ stores }: { stores: unknown[] }) => {
   return <div data-testid="store-context-key">{messageMapKey(context)}</div>;
 };
 
+/**
+ * Arms a scheduled send, then reports whether it is still armed. Scheduled send
+ * is per-conversation state that only a remount clears — `StoreUpdater` resets
+ * context and message fields, not the composer.
+ */
+const ScheduledSendProbe = () => {
+  const scheduledSendAt = useConversationStore((s) => s.scheduledSendAt);
+  const setScheduledSendAt = useConversationStore((s) => s.setScheduledSendAt);
+
+  return (
+    <div>
+      <button onClick={() => setScheduledSendAt('2026-01-01T00:00:00.000Z')}>arm</button>
+      <div data-testid="scheduled-send-at">{scheduledSendAt ?? 'none'}</div>
+    </div>
+  );
+};
+
 const OverlayHeightSetter = () => {
   const setChatInputOverlayHeight = useConversationStore((s) => s.setChatInputOverlayHeight);
 
@@ -257,7 +274,12 @@ describe('ConversationProvider', () => {
     );
 
     rerender(
-      <ConversationProvider hasInitMessages context={materializedContext} messages={oldMessages}>
+      <ConversationProvider
+        hasInitMessages
+        context={materializedContext}
+        materializedTopicId={'tpc_created'}
+        messages={oldMessages}
+      >
         <StoreIdentityProbe stores={stores} />
       </ConversationProvider>,
     );
@@ -269,6 +291,44 @@ describe('ConversationProvider', () => {
     expect(screen.getByTestId('store-context-key')).toHaveTextContent(
       messageMapKey(materializedContext),
     );
+  });
+
+  it('creates a fresh store when navigating from a new chat to an existing topic', () => {
+    const stores: unknown[] = [];
+    const newChatContext = {
+      agentId: 'agt_old',
+      threadId: null,
+      topicId: null,
+    } satisfies ConversationContext;
+    const existingTopicContext = {
+      agentId: 'agt_old',
+      threadId: null,
+      topicId: 'tpc_existing',
+    } satisfies ConversationContext;
+
+    const { rerender } = render(
+      <ConversationProvider hasInitMessages context={newChatContext} messages={[]}>
+        <ScheduledSendProbe />
+        <StoreIdentityProbe stores={stores} />
+      </ConversationProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'arm' }));
+    expect(screen.getByTestId('scheduled-send-at')).toHaveTextContent('2026-01-01T00:00:00.000Z');
+
+    // Opening an unrelated topic from the sidebar is navigation, not this
+    // send's topic materializing — `materializedTopicId` stays undefined.
+    rerender(
+      <ConversationProvider hasInitMessages context={existingTopicContext} messages={oldMessages}>
+        <ScheduledSendProbe />
+        <StoreIdentityProbe stores={stores} />
+      </ConversationProvider>,
+    );
+
+    expect(stores).toHaveLength(2);
+    // A send armed in the new chat must not stay armed in the topic the user
+    // navigated to.
+    expect(screen.getByTestId('scheduled-send-at')).toHaveTextContent('none');
   });
 
   it('creates a fresh store when switching between two persisted topics', () => {

--- a/src/features/Conversation/ConversationProvider.tsx
+++ b/src/features/Conversation/ConversationProvider.tsx
@@ -56,6 +56,20 @@ export interface ConversationProviderProps {
    * External messages to sync into the store
    * When provided, these messages will be used as the source of truth
    */
+  /**
+   * The topic id that the in-flight send just created for THIS conversation
+   * (`chatStore.materializedTopicId`).
+   *
+   * Supplying it lets the provider keep its store — and therefore the
+   * virtualized message list — mounted while `topicId: null` turns into that
+   * id, instead of remounting and blanking the list for a frame.
+   *
+   * A `null → id` transition alone is NOT sufficient to infer this: opening any
+   * existing topic from the new-chat view looks identical. So the host must
+   * establish it, and when it cannot the provider falls back to remounting,
+   * which is always correct (just visibly less smooth).
+   */
+  materializedTopicId?: string;
   messages?: UIChatMessage[];
   /**
    * Callback when messages are fetched or changed internally
@@ -90,6 +104,7 @@ export const ConversationProvider = memo<ConversationProviderProps>(
     context,
     hooks = {},
     hasInitMessages,
+    materializedTopicId,
     messages,
     onMessagesChange,
     operationState,
@@ -115,13 +130,22 @@ export const ConversationProvider = memo<ConversationProviderProps>(
      * what resets the virtualizer. So absorb this one transition and keep the
      * subtree mounted; `StoreUpdater`'s pre-paint layout effect already handles
      * a context change within a mount.
+     *
+     * The shape of the transition is deliberately NOT the test. Opening any
+     * existing topic from the new-chat view is also `topicId: null` → an id, and
+     * absorbing that one would carry composer state — an armed `scheduledSendAt`,
+     * the draft, message-edit and tool state — into an unrelated conversation,
+     * because `StoreUpdater` resets only the context and message fields. So the
+     * host must name the id its send just created; without that, remount.
      */
     const providerKeyRef = useRef(contextKey);
     const prevContextKeyRef = useRef(contextKey);
     if (prevContextKeyRef.current !== contextKey) {
-      const materializedTopicKey = messageMapKey({ ...context, topicId: null });
+      const newChatKey = messageMapKey({ ...context, topicId: null });
       const isTopicMaterialization =
-        !!context.topicId && prevContextKeyRef.current === materializedTopicKey;
+        !!context.topicId &&
+        context.topicId === materializedTopicId &&
+        prevContextKeyRef.current === newChatKey;
 
       if (!isTopicMaterialization) providerKeyRef.current = contextKey;
       prevContextKeyRef.current = contextKey;

--- a/src/features/Conversation/ConversationProvider.tsx
+++ b/src/features/Conversation/ConversationProvider.tsx
@@ -4,7 +4,7 @@ import { type UIChatMessage } from '@lobechat/types';
 import debug from 'debug';
 import isEqual from 'fast-deep-equal';
 import { type ReactNode } from 'react';
-import { memo, useMemo } from 'react';
+import { memo, useMemo, useRef } from 'react';
 
 import { useFetchAvailableAgents } from '@/hooks/useFetchAvailableAgents';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
@@ -97,6 +97,37 @@ export const ConversationProvider = memo<ConversationProviderProps>(
   }) => {
     const contextKey = useMemo(() => messageMapKey(context), [context]);
 
+    /**
+     * Identity key for `<Provider>`.
+     *
+     * The store is keyed so a genuine conversation switch gets a fresh instance —
+     * no stale messages / input / tool state leaking across conversations.
+     *
+     * A conversation that *materializes its topic*, though, is NOT a switch:
+     * `topicId: null` → the id the server just created for this very send is the
+     * same conversation gaining an id. Remounting there tears the virtualized
+     * message list down and back up, and virtua re-measures from an empty
+     * viewport — the list paints zero rows for ~50ms, which reads as "every
+     * message vanished, then came back" right after the first send.
+     *
+     * Seeding the new store (`initialMessages`) fixes the React-data half of
+     * that flicker but cannot help the DOM half, because the remount itself is
+     * what resets the virtualizer. So absorb this one transition and keep the
+     * subtree mounted; `StoreUpdater`'s pre-paint layout effect already handles
+     * a context change within a mount.
+     */
+    const providerKeyRef = useRef(contextKey);
+    const prevContextKeyRef = useRef(contextKey);
+    if (prevContextKeyRef.current !== contextKey) {
+      const materializedTopicKey = messageMapKey({ ...context, topicId: null });
+      const isTopicMaterialization =
+        !!context.topicId && prevContextKeyRef.current === materializedTopicKey;
+
+      if (!isTopicMaterialization) providerKeyRef.current = contextKey;
+      prevContextKeyRef.current = contextKey;
+    }
+    const providerKey = providerKeyRef.current;
+
     log(
       '[Provider] render | contextKey=%s | messagesCount=%d | hasInitMessages=%s | skipFetch=%s',
       contextKey,
@@ -108,7 +139,7 @@ export const ConversationProvider = memo<ConversationProviderProps>(
     return (
       <Provider
         createStore={() => createStore({ context, hooks, initialMessages: messages, skipFetch })}
-        key={contextKey}
+        key={providerKey}
       >
         <StoreUpdater
           actionsBar={actionsBar}

--- a/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
@@ -69,6 +69,10 @@ const Conversation = memo(() => {
   );
   const replaceMessages = useChatStore((s) => s.replaceMessages);
   const messages = useChatStore((s) => s.dbMessagesMap[chatKey]);
+  // Set only when a send just created this conversation's topic, so the
+  // provider can keep the message list mounted across `_new` → that id instead
+  // of remounting and blanking it for a frame.
+  const materializedTopicId = useChatStore((s) => s.materializedTopicId);
 
   log('contextKey %s: %o', chatKey, messages);
 
@@ -122,6 +126,7 @@ const Conversation = memo(() => {
       context={context}
       hasInitMessages={!!messages}
       hooks={hooks}
+      materializedTopicId={materializedTopicId}
       messages={messages}
       operationState={operationState}
       onMessagesChange={(messages, ctx) => {

--- a/src/routes/(main)/group/features/Conversation/ConversationArea.tsx
+++ b/src/routes/(main)/group/features/Conversation/ConversationArea.tsx
@@ -42,6 +42,9 @@ const Conversation = memo<ConversationAreaProps>(({ mobile = false }) => {
   );
   const replaceMessages = useChatStore((s) => s.replaceMessages);
   const messages = useChatStore((s) => s.dbMessagesMap[chatKey]);
+  // Set only when a send just created this conversation's topic — the group
+  // first-message flow this file drives is exactly that case.
+  const materializedTopicId = useChatStore((s) => s.materializedTopicId);
 
   // Get operation state from ChatStore for reactive updates
   const operationState = useOperationState(context);
@@ -53,6 +56,7 @@ const Conversation = memo<ConversationAreaProps>(({ mobile = false }) => {
       actionsBar={actionsBarConfig}
       context={context}
       hasInitMessages={!!messages}
+      materializedTopicId={materializedTopicId}
       messages={messages}
       operationState={operationState}
       onMessagesChange={(messages, ctx) => {

--- a/src/store/chat/slices/topic/action.test.ts
+++ b/src/store/chat/slices/topic/action.test.ts
@@ -910,6 +910,39 @@ describe('topic action', () => {
       expect(revalidateMessagesSpy).not.toHaveBeenCalled();
     });
 
+    it('should mark materializedTopicId only for a send-created topic', async () => {
+      const { result } = renderHook(() => useChatStore());
+
+      // `clearNewKey` is only passed by the send / topic-creation paths.
+      await act(async () => {
+        await result.current.switchTopic('tpc_created', {
+          clearNewKey: true,
+          skipRefreshMessage: true,
+        });
+      });
+
+      expect(useChatStore.getState().materializedTopicId).toBe('tpc_created');
+
+      // Opening an existing topic is navigation — it must clear the marker, so a
+      // stale id can never make real navigation look like a materialization.
+      await act(async () => {
+        await result.current.switchTopic('tpc_existing', { skipRefreshMessage: true });
+      });
+
+      expect(useChatStore.getState().materializedTopicId).toBeUndefined();
+
+      // Going back to the new-chat view clears it too.
+      await act(async () => {
+        await result.current.switchTopic('tpc_created', {
+          clearNewKey: true,
+          skipRefreshMessage: true,
+        });
+        await result.current.switchTopic(null, { skipRefreshMessage: true });
+      });
+
+      expect(useChatStore.getState().materializedTopicId).toBeUndefined();
+    });
+
     it('should clear new key data when switching to null (main scope)', async () => {
       const { result } = renderHook(() => useChatStore());
       const activeAgentId = 'test-agent-id';

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -1201,8 +1201,16 @@ export class ChatTopicActionImpl {
       });
     }
 
+    // `clearNewKey` is passed only by the send / topic-creation paths, so it is
+    // the one signal that separates "this conversation just materialized its
+    // topic" from "the user opened a different topic". Consumers use it to keep
+    // the conversation surface mounted across the former; any other switch must
+    // clear it so a stale id can never make real navigation look like a
+    // materialization.
+    const materializedTopicId = id && opts.clearNewKey ? id : undefined;
+
     this.#set(
-      { activeTopicId: id || (null as any), activeThreadId: undefined },
+      { activeTopicId: id || (null as any), activeThreadId: undefined, materializedTopicId },
       false,
       n('toggleTopic'),
     );

--- a/src/store/chat/slices/topic/initialState.ts
+++ b/src/store/chat/slices/topic/initialState.ts
@@ -51,6 +51,17 @@ export interface ChatTopicState {
   creatingTopic: boolean;
   inSearchingMode?: boolean;
   isSearchingTopic: boolean;
+  /**
+   * The topic id that was just created by an in-flight send, i.e. the id the
+   * `_new` conversation materialized into. Only the send / topic-creation paths
+   * set it (they are the ones that pass `clearNewKey`); every other topic switch
+   * clears it.
+   *
+   * This is what lets a consumer tell "the conversation I am in just gained an
+   * id" apart from "the user navigated to a different topic" — the two are
+   * otherwise indistinguishable, since both are a `topicId: null` → id change.
+   */
+  materializedTopicId?: string;
   searchTopics: ChatTopic[];
   /**
    * Unified topic data map for each agent


### PR DESCRIPTION
Sending the first message in a new conversation made **every message vanish for ~50ms** before reappearing.

`ConversationProvider` keys `<Provider>` by `contextKey`. When the server creates the topic and `activeTopicId` flips, that key goes `main_<agent>_new` → `main_<agent>_<topicId>`, so React remounts the entire conversation subtree. The remounted `virtua` list has to re-measure its viewport before it can emit any rows — so it paints zero of them first.

Sub-frame `MutationObserver` evidence from a real browser, one new-topic first send:

| Before | After |
| ------ | ----- |
| `2 → 0 → 1 → 2` — DOM blank for **54ms** | `2 → 2` — no blank frame |
| `createStore` called **1×** (remount) | `createStore` called **0×** |

```
t=19503  n=2  ids=lUjUZ4HX,fTR4e1ZD   optimistic pair painted
t=20229  createStore(main_..._tpc_YEqq) seed=2
t=20229  ChatList render: ids=2, init=true    <- React data correct throughout
t=20298  n=0  ids=""                          <- DOM blank ❗
t=20334  n=1
t=20352  n=2  ids=Vq6dN6U6,rXQpE7yy
```

#### Why the previous fix didn't cover it

#16259 added the `initialMessages` seed, which closes the **React** half of the flicker — and the probes above confirm the data layer is correct the whole time (`seed=2`, `messagesInit: true`, `displayMessageIds.length === 2` on the new store's very first render). But the remount itself is what resets the virtualizer, and that PR's regression test asserts at **React-commit granularity**, where this is invisible. It has been green while the flicker was fully present.

`VirtualizedList.tsx` even documents the intended behaviour — *"Provider does not remount on topic switch"* — which the `key` contradicts.

#### The fix

A topic materializing is not a conversation switch: `topicId: null` turning into the id the server just created **for this very send** is the same conversation gaining an id. Absorb that one transition in the provider key so the subtree stays mounted — `StoreUpdater`'s pre-paint layout effect already handles a context change within a mount.

Genuine switches still get a fresh store, so conversation isolation is unchanged.

#### Test

Verified end-to-end in a browser against a local full-stack dev server (gateway/queue runtime, mocked LLM), with a `MutationObserver` + `replaceMessages` + `createStore` probe:

| Scenario | Result |
| -------- | ------ |
| New-topic first send | ✅ no blank frame, run completes |
| Topic A → topic B | ✅ still remounts (isolation kept) |
| Topic → new chat | ✅ still remounts |
| New chat → existing topic | ✅ absorbed, messages render correctly |
| Switch agent | ✅ still remounts |

The two new tests were confirmed to **fail without the fix** (`expected 2 to have a length of 1`), so they actually pin this regression rather than just passing.

`bun run check` on the changed files: lint clean, 8 tests passed. Full `--type`: clean. `src/features/Conversation/` suite: 96/97 files pass — the one failure (`webOnboarding.test.tsx`) reproduces identically on `canary` without this change.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Follow-up to #16259 — same symptom, remaining DOM-level cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)