### PR TITLE
🐛 fix(desktop): stop cold start from seeding a duplicate tab

### DIFF
--- a/src/features/Electron/TabHost/useSeedTabsOnBoot.test.ts
+++ b/src/features/Electron/TabHost/useSeedTabsOnBoot.test.ts
@@ -41,6 +41,26 @@ describe('useSeedTabsOnBoot', () => {
     expect(activeUrl()).toBe('/agent/a#msg_2');
   });
 
+  it('restores the persisted session on a cold start carrying the main-process locale param', () => {
+    saveTabPages(PERSONAL_TAB_SCOPE, [{ id: 'a', lastVisited: 1, url: '/agent/a' }], 'a');
+    window.history.replaceState(null, '', '/?lng=zh-CN');
+
+    renderHook(() => useSeedTabsOnBoot());
+
+    expect(useElectronStore.getState().tabs).toHaveLength(1);
+    expect(useElectronStore.getState().activeTabId).toBe('a');
+  });
+
+  it('matches a persisted tab on a deep link whose query also carries the locale param', () => {
+    saveTabPages(PERSONAL_TAB_SCOPE, [{ id: 'a', lastVisited: 1, url: '/agent/a?topic=t1' }], null);
+    window.history.replaceState(null, '', '/agent/a?topic=t1&lng=zh-CN');
+
+    renderHook(() => useSeedTabsOnBoot());
+
+    expect(useElectronStore.getState().tabs).toHaveLength(1);
+    expect(activeUrl()).toBe('/agent/a?topic=t1');
+  });
+
   it('activates a persisted tab instead of adding one when the boot url matches', () => {
     saveTabPages(PERSONAL_TAB_SCOPE, [{ id: 'a', lastVisited: 1, url: '/agent/a' }], null);
     window.history.replaceState(null, '', '/agent/a');

--- a/src/features/Electron/TabHost/useSeedTabsOnBoot.ts
+++ b/src/features/Electron/TabHost/useSeedTabsOnBoot.ts
@@ -6,6 +6,22 @@ import { useElectronStore } from '@/store/electron';
 
 import { resolveBootAction } from './resolveBootAction';
 
+// The main process appends `lng` to every renderer load (Browser.buildUrlWithLocale)
+// and index.html consumes it before React mounts. It describes the window, not the
+// route, so it must stay out of tab identity — otherwise a plain launch reads as a
+// deep link into `/?lng=…`, matches no persisted tab, and seeds a duplicate one.
+const readBootUrl = (): string => {
+  const { hash, pathname, search } = window.location;
+
+  const params = new URLSearchParams(search);
+  if (!params.has('lng')) return `${pathname}${search}${hash}`;
+
+  params.delete('lng');
+  const query = params.toString();
+
+  return `${pathname}${query ? `?${query}` : ''}${hash}`;
+};
+
 export const useSeedTabsOnBoot = () => {
   const seededRef = useRef(false);
 
@@ -13,7 +29,7 @@ export const useSeedTabsOnBoot = () => {
     if (seededRef.current) return;
     seededRef.current = true;
 
-    const bootUrl = window.location.pathname + window.location.search + window.location.hash;
+    const bootUrl = readBootUrl();
 
     const { loadTabs } = useElectronStore.getState();
     loadTabs(bootUrl);


### PR DESCRIPTION
Every desktop cold start added a tab instead of restoring the persisted session.

The main process appends `?lng=<locale>` to every renderer load (`Browser.buildUrlWithLocale`) so `index.html` can resolve the UI language before React mounts. `useSeedTabsOnBoot` read `window.location` verbatim, so that transport param became part of the tab target: `normalizeTabUrl('/?lng=zh-CN') !== '/'`, so `resolveBootAction` no longer saw a default launch, matched no persisted tab, and fell through to `add`. Deep links were hit the same way — `/agent/x?topic=1&lng=zh-CN` did not match an existing `/agent/x?topic=1` tab.

This is a regression from #17804, which changed `lng` from "injected only when the stored locale is not `auto`" to always injected — before that, the default `auto` setting produced a clean `/` boot url.

Fix: strip only `lng` when deriving the boot url, keeping the rest of the query and the fragment intact. The param is already consumed synchronously in `<head>`, and `useWindowUrlMirror` replaces the window url right after mount anyway, so nothing else observes the change.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Two regression tests in `useSeedTabsOnBoot.test.ts` (cold start with `lng`, deep link with `lng`) — both seed a second tab before the fix and restore the persisted tab after. `bun run check` on the touched files: lint clean, 5 tests passed; the full `TabHost` suite is green (43 tests).

#### 🔗 Related Issue

Fixes LOBE-12657