### PR TITLE
🐛 fix(agent-signal): preserve skill receipt rollback refs

### DIFF
--- a/apps/server/src/services/agentSignal/services/selfIteration/review/__test__/server.test.ts
+++ b/apps/server/src/services/agentSignal/services/selfIteration/review/__test__/server.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { LobeChatDatabase } from '@/database/type';
+import type { SkillManagementDocumentService } from '@/server/services/skillManagement';
 
 import { createReviewRuntimePrimitives, createServerSelfReviewPolicyOptions } from '../server';
 
@@ -86,5 +87,75 @@ describe('createReviewRuntimePrimitives', () => {
     expect(service.writeMemory).toEqual(expect.any(Function));
     expect(service.listManagedSkills).toEqual(expect.any(Function));
     expect(service.listSelfReviewProposals).toEqual(expect.any(Function));
+  });
+
+  /**
+   * @example
+   * A nightly review refines a managed skill and exposes every receipt rollback reference.
+   */
+  it('returns skill rollback refs from the nightly review runtime', async () => {
+    const currentSnapshot = {
+      agentDocumentId: 'adoc-1',
+      contentHash: 'sha256:before',
+      documentId: 'doc-bundle-1',
+      managed: true,
+      targetType: 'skill' as const,
+      writable: true,
+    };
+    const service = createReviewRuntimePrimitives({
+      agentId: 'agent-1',
+      briefModel: {} as never,
+      db: {} as unknown as LobeChatDatabase,
+      localDate: '2026-05-04',
+      proposalBriefWriter: {} as never,
+      reviewWindowEnd: '2026-05-04T14:00:00.000Z',
+      reviewWindowStart: '2026-05-03T14:00:00.000Z',
+      skillDocumentService: {
+        listSkills: vi.fn().mockResolvedValue([]),
+        readSkillTargetSnapshot: vi.fn().mockResolvedValue(currentSnapshot),
+        replaceSkillIndex: vi.fn().mockResolvedValue({
+          bundle: {
+            agentDocumentId: 'adoc-1',
+            documentId: 'doc-bundle-1',
+          },
+          expectedCurrentDocumentUpdatedAt: '2026-06-29T00:00:00.000Z',
+          index: {
+            agentDocumentId: 'adoc-index-1',
+            documentId: 'doc-index-1',
+          },
+          name: 'support-skill',
+          preMutationHistoryId: 'history-1',
+          title: 'Support Skill',
+        }),
+      } as unknown as SkillManagementDocumentService,
+      sourceId: 'nightly-review:user-1:agent-1:2026-05-04',
+      userId: 'user-1',
+    });
+
+    const result = await service.replaceSkillContentCAS?.(
+      {
+        baseSnapshot: currentSnapshot,
+        bodyMarkdown: 'Updated skill body.',
+        idempotencyKey: 'skill-replace-1',
+        skillDocumentId: 'adoc-1',
+        userId: 'user-1',
+      },
+      {},
+    );
+
+    expect(result).toMatchObject({
+      agentDocumentId: 'adoc-1',
+      documentId: 'doc-index-1',
+      expectedCurrentDocumentUpdatedAt: '2026-06-29T00:00:00.000Z',
+      historyId: 'history-1',
+      resourceId: 'adoc-1',
+      target: {
+        agentDocumentId: 'adoc-1',
+        documentId: 'doc-bundle-1',
+        id: 'adoc-1',
+        title: 'Support Skill',
+        type: 'skill',
+      },
+    });
   });
 });

--- a/apps/server/src/services/agentSignal/services/selfIteration/review/server.ts
+++ b/apps/server/src/services/agentSignal/services/selfIteration/review/server.ts
@@ -653,8 +653,21 @@ export const createReviewRuntimePrimitives = (
       if (!result) throw new Error('Skill target not found');
 
       return {
+        agentDocumentId: result.bundle.agentDocumentId,
+        documentId: result.index.documentId,
+        ...(result.expectedCurrentDocumentUpdatedAt
+          ? { expectedCurrentDocumentUpdatedAt: result.expectedCurrentDocumentUpdatedAt }
+          : {}),
+        ...(result.preMutationHistoryId ? { historyId: result.preMutationHistoryId } : {}),
         resourceId: result.bundle.agentDocumentId,
         summary: `Refined managed skill ${result.name}.`,
+        target: {
+          agentDocumentId: result.bundle.agentDocumentId,
+          documentId: result.bundle.documentId,
+          id: result.bundle.agentDocumentId,
+          title: result.title,
+          type: 'skill' as const,
+        },
       };
     },
     supersedeSelfReviewProposal: async (rawInput) => {

--- a/apps/server/src/services/agentSignal/services/selfIteration/tools/__test__/runtimePrimitives.test.ts
+++ b/apps/server/src/services/agentSignal/services/selfIteration/tools/__test__/runtimePrimitives.test.ts
@@ -27,6 +27,7 @@ interface TestResourceRuntime {
   replaceSkillContentCAS: (input: ReplaceSkillContentCASInput) => Promise<{
     agentDocumentId?: string;
     documentId?: string;
+    expectedCurrentDocumentUpdatedAt?: string;
     historyId?: string;
     resourceId?: string;
     summary?: string;
@@ -65,6 +66,7 @@ const createSkillDocumentService = (
         agentDocumentId: 'adoc_index_1',
         documentId: 'doc_index_1',
       },
+      expectedCurrentDocumentUpdatedAt: '2026-06-29T00:00:00.000Z',
       name: 'support-skill',
       preMutationHistoryId: 'history_1',
       title: 'Support Skill',
@@ -177,6 +179,7 @@ describe('createResourceRuntimePrimitives', () => {
     expect(result).toMatchObject({
       agentDocumentId: 'adoc_1',
       documentId: 'doc_index_1',
+      expectedCurrentDocumentUpdatedAt: '2026-06-29T00:00:00.000Z',
       historyId: 'history_1',
       resourceId: 'adoc_1',
       summary: 'Refined managed skill support-skill.',

--- a/apps/server/src/services/agentSignal/services/selfIteration/tools/runtimePrimitives.ts
+++ b/apps/server/src/services/agentSignal/services/selfIteration/tools/runtimePrimitives.ts
@@ -213,6 +213,9 @@ export const createResourceRuntimePrimitives = ({
         target: result.target,
         ...(result.agentDocumentId ? { agentDocumentId: result.agentDocumentId } : {}),
         ...(result.documentId ? { documentId: result.documentId } : {}),
+        ...(result.expectedCurrentDocumentUpdatedAt
+          ? { expectedCurrentDocumentUpdatedAt: result.expectedCurrentDocumentUpdatedAt }
+          : {}),
         ...(result.historyId ? { historyId: result.historyId } : {}),
       };
     },


### PR DESCRIPTION
# Pull Request

## 💻 Change Type

- [x] 🐛 fix

## 🔗 Related Links

- Linear / GitHub issue: N/A
- Related PRs: N/A
- Reference docs / code / articles: N/A

## 🔀 Description of Change

Preserve the complete rollback reference set returned after an Agent Signal managed-skill refinement.

Both the immediate resource runtime and nightly review runtime now return the pre-mutation history id, post-mutation document timestamp, backing document ids, and skill target metadata needed by completion receipt projection. This allows eligible replaceSkillContentCAS receipts to receive rollbackStatus: available and use the existing document-history restore flow.

Regression coverage verifies both runtime paths retain the rollback references.

## 🧭 Key Decisions / Non-goals

- Reuse the existing document-history restore and updatedAt conflict check instead of introducing a new compensation mechanism.
- Skill creation remains non-revertible because it has no pre-mutation history.
- Memory receipt undo is intentionally outside this PR.

## 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

### Automated Tests

- bunx vitest run --silent='passed-only' 'apps/server/src/services/agentSignal/services/selfIteration/tools/__test__/runtimePrimitives.test.ts' 'apps/server/src/services/agentSignal/services/selfIteration/review/__test__/server.test.ts' 'apps/server/src/services/agentSignal/services/selfIteration/completion/__test__/buildSelfIterationReceipts.test.ts'
- bun run check 'apps/server/src/services/agentSignal/services/selfIteration/tools/runtimePrimitives.ts' 'apps/server/src/services/agentSignal/services/selfIteration/tools/__test__/runtimePrimitives.test.ts' 'apps/server/src/services/agentSignal/services/selfIteration/review/server.ts' 'apps/server/src/services/agentSignal/services/selfIteration/review/__test__/server.test.ts'
- pnpm type-check
- pnpm lint

### Manual Verification

- Confirmed a pre-fix regression assertion dropped expectedCurrentDocumentUpdatedAt from the resource runtime output; the same assertion passes after this change.

### Post-Deploy Verification

- Refine a managed skill through Agent Signal and verify its receipt exposes Undo.

## 🚀 Rollout / Deployment Checklist

- [x] Environment variables: N/A
- [x] Redis / Edge Config / feature flags: N/A
- [x] Database migration or data backfill: N/A
- [x] Third-party console changes: N/A
- [x] Rollback plan: revert this commit if receipt projection regresses.
