### PR TITLE
🐛 fix(home): scroll the dashboard as one page, and persist the recents cache

### DIFF
--- a/.agents/acceptance/probe-mock-patterns.md
+++ b/.agents/acceptance/probe-mock-patterns.md
@@ -58,7 +58,7 @@ HttpOnly, so an empty `document.cookie` does not establish signed-out state.
 | Render message-attached error UI   | In-memory chat dispatch                    | Safe when the temporary message has a unique id and is deleted |
 | Force a tool result                | `beforeToolCall` hook + `event.mock()`     | Local/in-memory hook mode only                                 |
 | Force a fetch failure              | Request boundary or narrow HMR injection   | Preserve dirty files byte-for-byte                             |
-| Verify first-load error            | Clear the relevant cache tier, then reload | A failed revalidation may intentionally keep settled data      |
+| Verify first-load error            | Clear the cache tier in the _new_ document | Clearing then reloading does not work — see "Cold SWR cache"   |
 | Diagnose Electron target confusion | CDP target list / raw CDP                  | Use a distinct agent-browser session per CDP port              |
 | Seed backend fixtures              | Public API first, raw SQL last             | Raw SQL must preserve product id and relation invariants       |
 
@@ -455,6 +455,40 @@ LOBE_DESKTOP_VITE_PORT=5175 \
 Keep that command session open for the run. Confirm the CDP endpoint, project
 process path, `app-probe.sh ready`, renderer auth, server auth, and a raw-CDP
 screenshot before collecting evidence.
+
+### Cold SWR cache: clearing then reloading is undone by the outgoing page
+
+**Situation:** forcing a first-load / skeleton state for anything backed by the
+tiered SWR cache (`recent:*`, `topic:*`, `message:*`, …).
+
+**Doesn't work:** clearing `localStorage['lobechat-swr-cache:<scope>']` (and the
+`lobehub-local-data` IndexedDB) in the current document, then reloading. The cache
+provider registers `flushAll()` on `visibilitychange` and `pagehide`, so the reload
+itself makes the outgoing page write its in-memory cache straight back. The next
+document hydrates from a repopulated tier and renders settled data — which reads as
+"the loading state never happens" and can be mistaken for a product bug.
+
+```
+1. before clear      : true
+2. right after clear : false
+3. after reload      : true   <- the outgoing page re-flushed on pagehide
+```
+
+**Works:** clear at document start in the NEW document, before the provider
+hydrates:
+
+```js
+Page.addScriptToEvaluateOnNewDocument({
+  source: `Object.keys(localStorage).filter(k=>k.startsWith('lobechat-swr-cache'))
+             .forEach(k=>localStorage.removeItem(k));
+           indexedDB.deleteDatabase('lobehub-local-data');`,
+});
+```
+
+Assert the clear actually ran in the new document (set a flag in that script and
+read it back) rather than trusting the removal. Pair it with a warm control run: if
+the warm run renders data while the request is held paused and the cold run shows
+the skeleton, the cache tier is proven to be what the render reads.
 
 ### `app-probe.sh goto /` cannot reach the desktop Home route — seed the tab first
 

--- a/e2e/src/features/home/layout.feature
+++ b/e2e/src/features/home/layout.feature
@@ -1,14 +1,15 @@
 @journey @home @layout @regression
 Feature: Home Dashboard 双列布局
-  作为桌面端用户，我希望主列与右栏的滚动条始终位于各自的独立间距内
+  作为桌面端用户，我希望 Home 内容作为一个整体滚动，且滚动条始终位于内容之外的间距内
 
   Background:
     Given 用户已登录系统
 
   @HOME-LAYOUT-RAIL-001 @P1
-  Scenario: 受限桌面宽度下双列滚动条不覆盖内容
+  Scenario: 受限桌面宽度下 Home 内容整体滚动
     Given 用户在受限宽度下打开 Home 页面
-    Then Home 主列滚动条应位于双列间距中央
+    Then Home 主列与右栏都不应有各自的滚动条
+    And Home 滚动应同时带动主列与右栏
+    And Home 页面滚动条应位于右栏卡片与页面边缘之间
     And Home 右栏折叠控制应固定在页面右上角
     And Home 开合右栏不应改变主列纵向位置
-    And Home 右栏应保持卡片、滚动条轨道与页面边缘的分层间距

--- a/e2e/src/features/home/layout.feature
+++ b/e2e/src/features/home/layout.feature
@@ -1,6 +1,6 @@
 @journey @home @layout @regression
 Feature: Home Dashboard 双列布局
-  作为桌面端用户，我希望 Home 内容作为一个整体滚动，且滚动条始终位于内容之外的间距内
+  作为桌面端用户，我希望 Home 内容作为一个整体滚动，且滚动条贴合内容区边缘
 
   Background:
     Given 用户已登录系统
@@ -9,7 +9,8 @@ Feature: Home Dashboard 双列布局
   Scenario: 受限桌面宽度下 Home 内容整体滚动
     Given 用户在受限宽度下打开 Home 页面
     Then Home 主列与右栏都不应有各自的滚动条
+    And Home 滚动容器应贴合内容区右缘
     And Home 滚动应同时带动主列与右栏
-    And Home 页面滚动条应位于右栏卡片与页面边缘之间
+    And Home 右栏应保持卡片与页面边缘的分层间距
     And Home 右栏折叠控制应固定在页面右上角
     And Home 开合右栏不应改变主列纵向位置

--- a/e2e/src/steps/home/layout.steps.ts
+++ b/e2e/src/steps/home/layout.steps.ts
@@ -43,14 +43,54 @@ Then('Home 主列与右栏都不应有各自的滚动条', async function (this:
 
   // A column-local viewport is exactly what "scroll as one page" rules out: it
   // would let the topic list travel under a pinned greeting while the rail sits
-  // still. The page scroller is the only vertical scrollbar on the dashboard.
+  // still.
+  const columnsScroll = await this.page.evaluate(() =>
+    ['home-main', 'home-rail']
+      .map((id) => document.querySelector<HTMLElement>(`[data-testid="${id}"]`))
+      .filter((node): node is HTMLElement => !!node)
+      .some((node) => {
+        const overflowY = getComputedStyle(node).overflowY;
+        return overflowY === 'auto' || overflowY === 'scroll';
+      }),
+  );
+
+  expect(columnsScroll).toBe(false);
+  // Nor via a scroll-viewport widget nested inside either column.
   await expect(main.locator('[data-orientation="vertical"]')).toHaveCount(0);
   await expect(rail.locator('[data-orientation="vertical"]')).toHaveCount(0);
-  await expect(
-    this.page
-      .locator('[data-testid="home-scroll"]:visible')
-      .locator('[data-orientation="vertical"]'),
-  ).toHaveCount(1);
+});
+
+Then('Home 滚动容器应贴合内容区右缘', async function (this: CustomWorld) {
+  const measured = await this.page.evaluate(() => {
+    const main = document.querySelector<HTMLElement>('[data-testid="home-main"]')!;
+    const scrolls = (node: HTMLElement) =>
+      ['auto', 'scroll'].includes(getComputedStyle(node).overflowY);
+
+    let scroller: HTMLElement | null = null;
+    for (let node = main.parentElement; node && !scroller; node = node.parentElement)
+      if (scrolls(node)) scroller = node;
+    if (!scroller) return null;
+
+    // The centred column the dashboard is laid out in — the thing the scroller
+    // must NOT be, or the bar floats in the margin beside the content.
+    const column = main.closest<HTMLElement>('[data-testid="home-main"]')!.parentElement!;
+
+    return {
+      columnRight: column.getBoundingClientRect().right,
+      overflow: scroller.scrollHeight - scroller.clientHeight,
+      paneRight: scroller.parentElement!.getBoundingClientRect().right,
+      scrollerRight: scroller.getBoundingClientRect().right,
+    };
+  });
+
+  expect(measured).not.toBeNull();
+  const { columnRight, overflow, paneRight, scrollerRight } = measured!;
+
+  // A scrollbar rides its own scroller's edge, so the scroller has to be the
+  // full-width pane, not the centred column inside it.
+  expect(overflow).toBeGreaterThan(0);
+  expect(scrollerRight).toBeCloseTo(paneRight, 0);
+  expect(scrollerRight).toBeGreaterThan(columnRight);
 });
 
 Then('Home 滚动应同时带动主列与右栏', async function (this: CustomWorld) {
@@ -79,34 +119,27 @@ Then('Home 滚动应同时带动主列与右栏', async function (this: CustomWo
   await settleBox(this, main);
 });
 
-Then('Home 页面滚动条应位于右栏卡片与页面边缘之间', async function (this: CustomWorld) {
+Then('Home 右栏应保持卡片与页面边缘的分层间距', async function (this: CustomWorld) {
   const rail = this.page.locator('[data-testid="home-rail"]:visible');
   const card = rail.getByTestId('home-rail-card').first();
-  const scrollbar = this.page
-    .locator('[data-testid="home-scroll"]:visible')
-    .locator('[data-orientation="vertical"]')
-    .first();
 
   await expect(card).toBeVisible({ timeout: WAIT_TIMEOUT });
 
-  const [railBox, cardBox, scrollbarBox, viewportWidth] = await Promise.all([
+  const [railBox, cardBox, viewportWidth] = await Promise.all([
     rail.boundingBox(),
     card.boundingBox(),
-    scrollbar.boundingBox(),
     this.page.evaluate(() => window.innerWidth),
   ]);
 
   expect(railBox).not.toBeNull();
   expect(cardBox).not.toBeNull();
-  expect(scrollbarBox).not.toBeNull();
 
   const railRight = railBox!.x + railBox!.width;
   const cardRight = cardBox!.x + cardBox!.width;
 
-  // Card → gutter → scrollbar track → page edge, each layer clear of the last.
+  // Card → gutter → column edge → page margin, each layer clear of the last.
   expect(cardBox!.width).toBeCloseTo(380, 0);
   expect(railRight - cardRight).toBeCloseTo(14, 0);
-  expect(scrollbarBox!.x).toBeGreaterThanOrEqual(cardRight);
   expect(viewportWidth - railRight).toBeGreaterThanOrEqual(24);
 });
 

--- a/e2e/src/steps/home/layout.steps.ts
+++ b/e2e/src/steps/home/layout.steps.ts
@@ -61,19 +61,23 @@ Then('Home 主列与右栏都不应有各自的滚动条', async function (this:
 });
 
 Then('Home 滚动容器应贴合内容区右缘', async function (this: CustomWorld) {
+  // NOTE: never declare a named function inside a `page.evaluate` callback here.
+  // The steps are transpiled by `tsx/cjs` (esbuild with keepNames), which rewrites
+  // `const fn = () => …` into `__name(() => …, 'fn')`. `__name` is a module-scope
+  // helper that exists in Node but not in the page, so the callback dies in the
+  // browser with `ReferenceError: __name is not defined`. Inline arrows passed
+  // straight to `.map` / `.some` are left alone and are safe.
   const measured = await this.page.evaluate(() => {
     const main = document.querySelector<HTMLElement>('[data-testid="home-main"]')!;
-    const scrolls = (node: HTMLElement) =>
-      ['auto', 'scroll'].includes(getComputedStyle(node).overflowY);
 
     let scroller: HTMLElement | null = null;
     for (let node = main.parentElement; node && !scroller; node = node.parentElement)
-      if (scrolls(node)) scroller = node;
+      if (['auto', 'scroll'].includes(getComputedStyle(node).overflowY)) scroller = node;
     if (!scroller) return null;
 
     // The centred column the dashboard is laid out in — the thing the scroller
     // must NOT be, or the bar floats in the margin beside the content.
-    const column = main.closest<HTMLElement>('[data-testid="home-main"]')!.parentElement!;
+    const column = main.parentElement!;
 
     return {
       columnRight: column.getBoundingClientRect().right,

--- a/e2e/src/steps/home/layout.steps.ts
+++ b/e2e/src/steps/home/layout.steps.ts
@@ -1,29 +1,30 @@
 import { Given, Then } from '@cucumber/cucumber';
-import { expect } from '@playwright/test';
+import { expect, type Locator } from '@playwright/test';
 
 import type { CustomWorld } from '../../support/world';
 import { WAIT_TIMEOUT } from '../../support/world';
 
 /**
- * The rail slides 24px on its way in and out. `toBeVisible` resolves the moment
- * visibility flips, well before the transform lands, so any step that toggles
- * the rail must settle it before the next step measures anything.
+ * Wait until a node stops moving. Both the rail transition (24px slide) and a
+ * wheel-driven scroll resolve their promise well before the motion lands, so
+ * any step that measures after one must settle it first.
  */
-const settleRail = async (world: CustomWorld) => {
-  const rail = world.page.locator('[data-testid="home-rail"]:visible');
-
+const settleBox = async (world: CustomWorld, target: Locator) => {
   await expect
     .poll(
       async () => {
-        const before = await rail.boundingBox();
+        const before = await target.boundingBox();
         await world.page.waitForTimeout(80);
-        const after = await rail.boundingBox();
-        return before?.x === after?.x;
+        const after = await target.boundingBox();
+        return before?.x === after?.x && before?.y === after?.y;
       },
       { timeout: WAIT_TIMEOUT },
     )
     .toBe(true);
 };
+
+const settleRail = (world: CustomWorld) =>
+  settleBox(world, world.page.locator('[data-testid="home-rail"]:visible'));
 
 Given('用户在受限宽度下打开 Home 页面', async function (this: CustomWorld) {
   // Keep the desktop width while constraining the height so a fresh E2E account's
@@ -36,29 +37,77 @@ Given('用户在受限宽度下打开 Home 页面', async function (this: Custom
   });
 });
 
-Then('Home 主列滚动条应位于双列间距中央', async function (this: CustomWorld) {
+Then('Home 主列与右栏都不应有各自的滚动条', async function (this: CustomWorld) {
   const main = this.page.locator('[data-testid="home-main"]:visible');
   const rail = this.page.locator('[data-testid="home-rail"]:visible');
-  const scrollbar = main.locator('[data-orientation="vertical"]').first();
 
-  const [mainBox, railBox, scrollbarBox] = await Promise.all([
-    main.boundingBox(),
+  // A column-local viewport is exactly what "scroll as one page" rules out: it
+  // would let the topic list travel under a pinned greeting while the rail sits
+  // still. The page scroller is the only vertical scrollbar on the dashboard.
+  await expect(main.locator('[data-orientation="vertical"]')).toHaveCount(0);
+  await expect(rail.locator('[data-orientation="vertical"]')).toHaveCount(0);
+  await expect(
+    this.page
+      .locator('[data-testid="home-scroll"]:visible')
+      .locator('[data-orientation="vertical"]'),
+  ).toHaveCount(1);
+});
+
+Then('Home 滚动应同时带动主列与右栏', async function (this: CustomWorld) {
+  const main = this.page.locator('[data-testid="home-main"]:visible');
+  const rail = this.page.locator('[data-testid="home-rail"]:visible');
+
+  const [mainBefore, railBefore] = await Promise.all([main.boundingBox(), rail.boundingBox()]);
+  expect(mainBefore).not.toBeNull();
+  expect(railBefore).not.toBeNull();
+
+  // Wheel over the main column, not the rail: the point is that a gesture
+  // anywhere in the dashboard moves the whole dashboard.
+  await main.hover({ position: { x: 40, y: 40 } });
+  await this.page.mouse.wheel(0, 200);
+  await settleBox(this, main);
+
+  const [mainAfter, railAfter] = await Promise.all([main.boundingBox(), rail.boundingBox()]);
+  const mainShift = mainBefore!.y - mainAfter!.y;
+
+  // The Given constrains the viewport height so the dashboard genuinely
+  // overflows; without this the equality below would hold vacuously at 0.
+  expect(mainShift).toBeGreaterThan(0);
+  expect(railBefore!.y - railAfter!.y).toBeCloseTo(mainShift, 0);
+
+  await this.page.mouse.wheel(0, -200);
+  await settleBox(this, main);
+});
+
+Then('Home 页面滚动条应位于右栏卡片与页面边缘之间', async function (this: CustomWorld) {
+  const rail = this.page.locator('[data-testid="home-rail"]:visible');
+  const card = rail.getByTestId('home-rail-card').first();
+  const scrollbar = this.page
+    .locator('[data-testid="home-scroll"]:visible')
+    .locator('[data-orientation="vertical"]')
+    .first();
+
+  await expect(card).toBeVisible({ timeout: WAIT_TIMEOUT });
+
+  const [railBox, cardBox, scrollbarBox, viewportWidth] = await Promise.all([
     rail.boundingBox(),
+    card.boundingBox(),
     scrollbar.boundingBox(),
+    this.page.evaluate(() => window.innerWidth),
   ]);
 
-  expect(mainBox).not.toBeNull();
   expect(railBox).not.toBeNull();
+  expect(cardBox).not.toBeNull();
   expect(scrollbarBox).not.toBeNull();
 
-  const mainRight = mainBox!.x + mainBox!.width;
-  const railLeft = railBox!.x;
-  const scrollbarCenter = scrollbarBox!.x + scrollbarBox!.width / 2;
-  const columnGapCenter = mainRight + (railLeft - mainRight) / 2;
+  const railRight = railBox!.x + railBox!.width;
+  const cardRight = cardBox!.x + cardBox!.width;
 
-  expect(scrollbarBox!.x).toBeGreaterThanOrEqual(mainRight);
-  expect(scrollbarBox!.x + scrollbarBox!.width).toBeLessThanOrEqual(railLeft);
-  expect(scrollbarCenter).toBeCloseTo(columnGapCenter, 0);
+  // Card → gutter → scrollbar track → page edge, each layer clear of the last.
+  expect(cardBox!.width).toBeCloseTo(380, 0);
+  expect(railRight - cardRight).toBeCloseTo(14, 0);
+  expect(scrollbarBox!.x).toBeGreaterThanOrEqual(cardRight);
+  expect(viewportWidth - railRight).toBeGreaterThanOrEqual(24);
 });
 
 Then('Home 右栏折叠控制应固定在页面右上角', async function (this: CustomWorld) {
@@ -113,33 +162,4 @@ Then('Home 开合右栏不应改变主列纵向位置', async function (this: Cu
   await toggle.click();
   await expect(rail).toBeVisible({ timeout: WAIT_TIMEOUT });
   await settleRail(this);
-});
-
-Then('Home 右栏应保持卡片、滚动条轨道与页面边缘的分层间距', async function (this: CustomWorld) {
-  const rail = this.page.locator('[data-testid="home-rail"]:visible');
-  const card = rail.getByTestId('home-rail-card').first();
-  const scrollbar = rail.locator('[data-orientation="vertical"]').first();
-
-  await expect(card).toBeVisible({ timeout: WAIT_TIMEOUT });
-
-  const [railBox, cardBox, scrollbarBox, viewportWidth] = await Promise.all([
-    rail.boundingBox(),
-    card.boundingBox(),
-    scrollbar.boundingBox(),
-    this.page.evaluate(() => window.innerWidth),
-  ]);
-
-  expect(railBox).not.toBeNull();
-  expect(cardBox).not.toBeNull();
-  expect(scrollbarBox).not.toBeNull();
-
-  const railRight = railBox!.x + railBox!.width;
-  const cardRight = cardBox!.x + cardBox!.width;
-  const scrollbarRight = scrollbarBox!.x + scrollbarBox!.width;
-
-  expect(cardBox!.width).toBeCloseTo(380, 0);
-  expect(railRight - cardRight).toBeCloseTo(14, 0);
-  expect(scrollbarBox!.x).toBeGreaterThanOrEqual(cardRight);
-  expect(scrollbarRight).toBeLessThanOrEqual(railRight);
-  expect(viewportWidth - railRight).toBeGreaterThanOrEqual(24);
 });

--- a/locales/zh-CN/home.json
+++ b/locales/zh-CN/home.json
@@ -43,7 +43,7 @@
   "cardBindingPromoBanner.dismiss": "关闭",
   "cardBindingPromoBanner.label": "首次添加支付方式，即送 1M 积分",
   "dashboard.chat.empty": "暂无最近对话",
-  "dashboard.chat.recents": "最近主题",
+  "dashboard.chat.recents": "最近话题",
   "dashboard.chat.running": "正在运行",
   "dashboard.empty.plan.description": "把目标拆解为清晰、可执行的下一步",
   "dashboard.empty.plan.prompt": "帮我为以下目标制定一份切实可行的计划：",

--- a/src/features/Home/HomeModeContent.tsx
+++ b/src/features/Home/HomeModeContent.tsx
@@ -1,7 +1,8 @@
 import type { TaskStatus } from '@lobechat/types';
+import type { FlexboxProps } from '@lobehub/ui';
 import { Avatar, Flexbox, Icon, Skeleton, Text } from '@lobehub/ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
-import { HashIcon, ListTodoIcon } from 'lucide-react';
+import { HashIcon } from 'lucide-react';
 import { memo, type ReactNode, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -44,20 +45,25 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     color: ${cssVar.colorTextTertiary};
   `,
   row: css`
-    min-width: 0;
-    margin-inline: -10px;
-    padding-block: 9px;
-    padding-inline: 10px;
     border-radius: ${cssVar.borderRadiusLG};
-
     color: inherit;
     text-decoration: none;
-
     transition: background ${cssVar.motionDurationFast};
 
     &:hover {
       background: ${cssVar.colorFillQuaternary};
     }
+  `,
+  /**
+   * Box metrics shared by a real row and its skeleton, so the placeholder
+   * occupies exactly the space its content will. Kept apart from `row` because
+   * the skeleton must not pick up the hover affordance — nothing to click yet.
+   */
+  rowBox: css`
+    min-width: 0;
+    margin-inline: -10px;
+    padding-block: 9px;
+    padding-inline: 10px;
   `,
   rowText: css`
     flex: 1;
@@ -97,7 +103,7 @@ const normalizeTaskStatus = (status: string): TaskStatus =>
   TASK_STATUSES.has(status as TaskStatus) ? (status as TaskStatus) : 'backlog';
 
 const Row = memo<RowProps>(({ description, href, icon, title, trailing }) => (
-  <WorkspaceLink className={styles.row} to={href}>
+  <WorkspaceLink className={cx(styles.rowBox, styles.row)} to={href}>
     <Flexbox horizontal align={'flex-start'} gap={12}>
       <Flexbox flex={'none'} paddingBlock={3}>
         {icon}
@@ -143,24 +149,63 @@ const RecentTopicRow = memo<{ topic: RecentItem }>(({ topic }) => {
   );
 });
 
-const LoadingRows = ({ icon = HashIcon }: { icon?: typeof HashIcon }) => (
-  <Flexbox gap={1}>
-    {[
-      ['62%', '24%'],
-      ['48%', '20%'],
-      ['70%', '27%'],
-    ].map(([titleWidth, descriptionWidth], index) => (
-      <Flexbox aria-hidden horizontal className={styles.row} gap={12} key={index}>
-        <Flexbox flex={'none'} paddingBlock={3}>
-          <Icon color={cssVar.colorTextDescription} icon={icon} size={16} />
-        </Flexbox>
-        <Flexbox flex={1} gap={5}>
-          <Skeleton.Button active size={'small'} style={{ height: 14, width: titleWidth }} />
-          <Skeleton.Button active size={'small'} style={{ height: 11, width: descriptionWidth }} />
-        </Flexbox>
-      </Flexbox>
-    ))}
+interface SkeletonLineProps {
+  /** Height of the painted band inside the line box. */
+  bar: number;
+  flex?: FlexboxProps['flex'];
+  /** Line-height of the text role this stands in for, from {@link homeType}. */
+  line: number;
+  width: number | string;
+}
+
+/**
+ * A skeleton bar centred in the exact line box of the text it stands in for, so
+ * the row already has its final height and nothing reflows when data lands.
+ */
+const SkeletonLine = memo<SkeletonLineProps>(({ bar, flex, line, width }) => (
+  <Flexbox align={'flex-start'} flex={flex} height={line} justify={'center'}>
+    <Skeleton.Block active height={bar} width={width} />
   </Flexbox>
+));
+
+/**
+ * Widths per row, shaped like the content they precede: a short name over a
+ * longer sentence. Uneven rows read as "a list is coming", not as a filled block.
+ */
+const SKELETON_ROWS = [
+  { description: '86%', title: '38%' },
+  { description: '64%', title: '27%' },
+  { description: '92%', title: '48%' },
+];
+
+/**
+ * Loading placeholder for {@link Row}. It mirrors the real row exactly — same
+ * padding, same 12px lead gap, same line boxes — and keeps every element a
+ * skeleton: a concrete leading icon would read as already-loaded content and
+ * then be swapped for an avatar, which is precisely the wrong promise to make.
+ */
+const LoadingRows = memo<{ avatarSize?: number; withTime?: boolean }>(
+  ({ avatarSize = 22, withTime }) => (
+    <Flexbox aria-hidden gap={4}>
+      {SKELETON_ROWS.map(({ description, title }, index) => (
+        <Flexbox horizontal align={'flex-start'} className={styles.rowBox} gap={12} key={index}>
+          <Flexbox flex={'none'} paddingBlock={3}>
+            <Skeleton.Avatar
+              active
+              className={styles.topicAvatar}
+              shape={'circle'}
+              size={avatarSize}
+            />
+          </Flexbox>
+          <Flexbox className={styles.rowText} gap={3}>
+            <SkeletonLine bar={14} line={22} width={title} />
+            <SkeletonLine bar={12} line={20} width={description} />
+          </Flexbox>
+          {withTime && <SkeletonLine bar={10} flex={'none'} line={18} width={52} />}
+        </Flexbox>
+      ))}
+    </Flexbox>
+  ),
 );
 
 const TaskContent = memo(() => {
@@ -177,7 +222,7 @@ const TaskContent = memo(() => {
       {tasksSWR.error && !tasksInit ? (
         <AsyncError error={tasksSWR.error} variant={'inline'} onRetry={tasksSWR.mutate} />
       ) : !tasksInit ? (
-        <LoadingRows icon={ListTodoIcon} />
+        <LoadingRows avatarSize={16} />
       ) : tasks.length === 0 ? (
         <Text className={styles.empty}>{t('dashboard.task.empty')}</Text>
       ) : (
@@ -249,7 +294,7 @@ const HomeModeContent = memo<HomeModeContentProps>(({ mode, onSuggestionSelect }
             {state === 'error' ? (
               <AsyncError error={recentsSWR.error} variant={'inline'} onRetry={recentsSWR.mutate} />
             ) : state === 'loading' ? (
-              <LoadingRows />
+              <LoadingRows withTime />
             ) : (
               <Flexbox gap={4}>
                 {topicRecents.slice(0, 8).map((item) => (

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { ScrollArea } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';
 import { memo, useCallback, useState } from 'react';
 
@@ -19,10 +18,7 @@ import InputArea from './InputArea';
 import PortraitBubble from './PortraitBubble';
 import type { HomeMode } from './types';
 
-/** Mirrors the row hover bleed in HomeModeContent; the viewport would clip it. */
-const ROW_BLEED = 10;
-
-/** Gutter the page scrollbar lives in, so it never sits over a rail card. */
+/** Trailing gutter that keeps the rail's cards off the page's scroll lane. */
 const RAIL_GUTTER = 14;
 const RAIL_CARD_WIDTH = 380;
 const RAIL_COLUMN_GAP = 28;
@@ -48,30 +44,11 @@ const GREETING_LANE = COLLAPSED_CONTENT_OFFSET * 2 + PORTRAIT_LANE + BUBBLE_MAX_
 /** Under this the greeting, the bubble and the portrait cannot share a line. */
 const BUBBLE_INLINE_MIN = 1080;
 
-/**
- * ScrollArea's content node ships its own gap / font-size — neutralize both.
- * The inline padding is the lane the row hover bleed paints into: without it the
- * viewport's own overflow clip would shear the bleed off at the column edge.
- */
-const PAGE_CONTENT_STYLE = {
-  display: 'block',
-  fontSize: 'inherit',
-  gap: 0,
-  lineHeight: 'inherit',
-  paddingBlockEnd: 24,
-  paddingInline: ROW_BLEED,
-} as const;
-
 const styles = createStaticStyles(({ css }) => ({
-  // One scroll viewport wraps the whole dashboard, so the greeting, the
-  // composer, the topic list and the rail travel together. Giving the columns
-  // their own viewports made the page scroll in pieces: the list moved under a
-  // pinned greeting while the rail sat still, and the reading position of the
-  // page as a whole was never anyone's to control.
-  pageScroll: css`
-    flex: 1;
-    min-height: 0;
-  `,
+  // Both rows size to their content and the page scrolls around the whole grid
+  // (see the route). Giving each column its own scroll viewport made the page
+  // scroll in pieces: the topic list moved under a pinned greeting while the
+  // rail sat still, and no gesture moved the dashboard as a whole.
   grid: css`
     /* The nav panel takes 240–400px out of the viewport, so viewport breakpoints
        say nothing about the room this dashboard actually has. */
@@ -232,8 +209,8 @@ const styles = createStaticStyles(({ css }) => ({
     }
   `,
   // Above the portrait so the agent stands behind the glass, not on top of it.
-  // The trailing gutter is what the page scrollbar rides in, so the track never
-  // lands on a card.
+  // The trailing gutter keeps the cards short of the column edge, so they stop
+  // where the main column's rows stop instead of running to the page margin.
   rail: css`
     position: relative;
     z-index: 1;
@@ -278,63 +255,52 @@ const Home = memo(() => {
   );
 
   return (
-    // No scrollFade: the mask would make this viewport a backdrop root, and the
-    // rail cards' glass has to keep sampling the portrait standing behind them.
-    <ScrollArea
-      disableContentFit
-      className={styles.pageScroll}
-      contentProps={{ style: PAGE_CONTENT_STYLE }}
-      data-testid={'home-scroll'}
-    >
-      <Flexbox className={styles.grid}>
-        <div
-          className={cx(styles.header, styles.content, railCollapsed && styles.contentCollapsed)}
-        >
-          <HomeHeader />
-          {/* No portrait for signed-out visitors, so no one to speak the line. */}
-          {isLogin && (
-            <div className={cx(styles.bubbleSlot, railCollapsed && styles.bubbleSlotCollapsed)}>
-              <PortraitBubble />
-            </div>
-          )}
+    <Flexbox className={styles.grid}>
+      <div className={cx(styles.header, styles.content, railCollapsed && styles.contentCollapsed)}>
+        <HomeHeader />
+        {/* No portrait for signed-out visitors, so no one to speak the line. */}
+        {isLogin && (
+          <div className={cx(styles.bubbleSlot, railCollapsed && styles.bubbleSlotCollapsed)}>
+            <PortraitBubble />
+          </div>
+        )}
+      </div>
+
+      {isLogin && (
+        <div className={cx(styles.portrait, railCollapsed && styles.portraitCollapsed)}>
+          <HomePortrait />
         </div>
+      )}
 
-        {isLogin && (
-          <div className={cx(styles.portrait, railCollapsed && styles.portraitCollapsed)}>
-            <HomePortrait />
-          </div>
-        )}
-
-        <Flexbox
-          className={cx(styles.main, styles.content, railCollapsed && styles.contentCollapsed)}
-          data-testid={'home-main'}
-          gap={24}
-        >
-          <div className={styles.inputArea}>
-            <InputArea
-              inputValue={inputValue}
-              mode={mode}
-              onInputValueChange={handleInputValueChange}
-              onModeChange={setMode}
-            />
-          </div>
-          <HomeModeContent mode={mode} onSuggestionSelect={handleSuggestionSelect} />
-        </Flexbox>
-
-        {isLogin && (
-          <aside
-            aria-hidden={railCollapsed}
-            className={cx(styles.rail, styles.railSurface)}
-            data-collapsed={railCollapsed}
-            data-testid={'home-rail'}
-            id={'home-rail'}
-            inert={railCollapsed}
-          >
-            <HomeInbox hideNeedsYou hideUnread variant={'rail'} />
-          </aside>
-        )}
+      <Flexbox
+        className={cx(styles.main, styles.content, railCollapsed && styles.contentCollapsed)}
+        data-testid={'home-main'}
+        gap={24}
+      >
+        <div className={styles.inputArea}>
+          <InputArea
+            inputValue={inputValue}
+            mode={mode}
+            onInputValueChange={handleInputValueChange}
+            onModeChange={setMode}
+          />
+        </div>
+        <HomeModeContent mode={mode} onSuggestionSelect={handleSuggestionSelect} />
       </Flexbox>
-    </ScrollArea>
+
+      {isLogin && (
+        <aside
+          aria-hidden={railCollapsed}
+          className={cx(styles.rail, styles.railSurface)}
+          data-collapsed={railCollapsed}
+          data-testid={'home-rail'}
+          id={'home-rail'}
+          inert={railCollapsed}
+        >
+          <HomeInbox hideNeedsYou hideUnread variant={'rail'} />
+        </aside>
+      )}
+    </Flexbox>
   );
 });
 

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -22,21 +22,10 @@ import type { HomeMode } from './types';
 /** Mirrors the row hover bleed in HomeModeContent; the viewport would clip it. */
 const ROW_BLEED = 10;
 
-/** ScrollArea's content node ships its own gap / font-size — neutralize both. */
-const scrollContent = {
-  display: 'block',
-  fontSize: 'inherit',
-  gap: 0,
-  lineHeight: 'inherit',
-  paddingBlockEnd: 24,
-} as const;
-
-/** Gutter the rail's scrollbar lives in, so it never sits over a card. */
+/** Gutter the page scrollbar lives in, so it never sits over a rail card. */
 const RAIL_GUTTER = 14;
 const RAIL_CARD_WIDTH = 380;
 const RAIL_COLUMN_GAP = 28;
-/** Keep the main scrollbar off the content edge and centered in the column gap. */
-const MAIN_SCROLLBAR_OFFSET = RAIL_COLUMN_GAP / 2;
 const RAIL_EXIT_OFFSET = 24;
 const RAIL_TRANSITION_DURATION = 220;
 const RAIL_RECLAIMED_WIDTH = RAIL_CARD_WIDTH + RAIL_GUTTER + RAIL_COLUMN_GAP;
@@ -59,27 +48,42 @@ const GREETING_LANE = COLLAPSED_CONTENT_OFFSET * 2 + PORTRAIT_LANE + BUBBLE_MAX_
 /** Under this the greeting, the bubble and the portrait cannot share a line. */
 const BUBBLE_INLINE_MIN = 1080;
 
-const MAIN_CONTENT_STYLE = { ...scrollContent, paddingInline: ROW_BLEED };
-const RAIL_CONTENT_STYLE = { ...scrollContent, paddingInlineEnd: RAIL_GUTTER };
+/**
+ * ScrollArea's content node ships its own gap / font-size — neutralize both.
+ * The inline padding is the lane the row hover bleed paints into: without it the
+ * viewport's own overflow clip would shear the bleed off at the column edge.
+ */
+const PAGE_CONTENT_STYLE = {
+  display: 'block',
+  fontSize: 'inherit',
+  gap: 0,
+  lineHeight: 'inherit',
+  paddingBlockEnd: 24,
+  paddingInline: ROW_BLEED,
+} as const;
 
 const styles = createStaticStyles(({ css }) => ({
-  // Row 1 (greeting + portrait) is fixed; row 2 gives each column its own
-  // scroll viewport, so the rail and the task list scroll independently.
+  // One scroll viewport wraps the whole dashboard, so the greeting, the
+  // composer, the topic list and the rail travel together. Giving the columns
+  // their own viewports made the page scroll in pieces: the list moved under a
+  // pinned greeting while the rail sat still, and the reading position of the
+  // page as a whole was never anyone's to control.
+  pageScroll: css`
+    flex: 1;
+    min-height: 0;
+  `,
   grid: css`
     /* The nav panel takes 240–400px out of the viewport, so viewport breakpoints
        say nothing about the room this dashboard actually has. */
     container: home / inline-size;
     display: grid;
     grid-template-columns: minmax(0, 1fr) ${RAIL_CARD_WIDTH + RAIL_GUTTER}px;
-    grid-template-rows: auto minmax(0, 1fr);
-    flex: 1;
+    grid-template-rows: auto auto;
     gap: 24px ${RAIL_COLUMN_GAP}px;
 
     width: 100%;
-    min-height: 0;
 
     @media (width <= 1100px) {
-      overflow-y: auto;
       grid-template-columns: 1fr;
       grid-template-rows: auto auto auto;
     }
@@ -168,25 +172,6 @@ const styles = createStaticStyles(({ css }) => ({
     position: relative;
     grid-area: 2 / 1;
     min-width: 0;
-    min-height: 0;
-  `,
-  mainScroll: css`
-    flex: 1;
-    min-height: 0;
-    margin-inline: -${ROW_BLEED}px;
-
-    @media (width <= 1100px) {
-      flex: none;
-    }
-  `,
-  mainScrollbar: css`
-    @media (width > 1100px) {
-      transform: translateX(${MAIN_SCROLLBAR_OFFSET}px);
-
-      &:dir(rtl) {
-        transform: translateX(-${MAIN_SCROLLBAR_OFFSET}px);
-      }
-    }
   `,
   portrait: css`
     grid-area: 1 / 2;
@@ -247,30 +232,23 @@ const styles = createStaticStyles(({ css }) => ({
     }
   `,
   // Above the portrait so the agent stands behind the glass, not on top of it.
+  // The trailing gutter is what the page scrollbar rides in, so the track never
+  // lands on a card.
   rail: css`
     position: relative;
     z-index: 1;
 
     display: flex;
     grid-area: 2 / 2;
+    flex-direction: column;
 
     min-width: 0;
-    min-height: 0;
+    padding-inline-end: ${RAIL_GUTTER}px;
 
     @media (width <= 1100px) {
       grid-area: 3 / 1;
       justify-self: end;
       width: min(100%, ${RAIL_CARD_WIDTH + RAIL_GUTTER}px);
-    }
-  `,
-  railScroll: css`
-    flex: 1;
-    min-width: 0;
-    min-height: 0;
-
-    @media (width <= 1100px) {
-      flex: none;
-      width: 100%;
     }
   `,
 }));
@@ -300,68 +278,63 @@ const Home = memo(() => {
   );
 
   return (
-    <Flexbox className={styles.grid}>
-      <div className={cx(styles.header, styles.content, railCollapsed && styles.contentCollapsed)}>
-        <HomeHeader />
-        {/* No portrait for signed-out visitors, so no one to speak the line. */}
+    // No scrollFade: the mask would make this viewport a backdrop root, and the
+    // rail cards' glass has to keep sampling the portrait standing behind them.
+    <ScrollArea
+      disableContentFit
+      className={styles.pageScroll}
+      contentProps={{ style: PAGE_CONTENT_STYLE }}
+      data-testid={'home-scroll'}
+    >
+      <Flexbox className={styles.grid}>
+        <div
+          className={cx(styles.header, styles.content, railCollapsed && styles.contentCollapsed)}
+        >
+          <HomeHeader />
+          {/* No portrait for signed-out visitors, so no one to speak the line. */}
+          {isLogin && (
+            <div className={cx(styles.bubbleSlot, railCollapsed && styles.bubbleSlotCollapsed)}>
+              <PortraitBubble />
+            </div>
+          )}
+        </div>
+
         {isLogin && (
-          <div className={cx(styles.bubbleSlot, railCollapsed && styles.bubbleSlotCollapsed)}>
-            <PortraitBubble />
+          <div className={cx(styles.portrait, railCollapsed && styles.portraitCollapsed)}>
+            <HomePortrait />
           </div>
         )}
-      </div>
 
-      {isLogin && (
-        <div className={cx(styles.portrait, railCollapsed && styles.portraitCollapsed)}>
-          <HomePortrait />
-        </div>
-      )}
-
-      <Flexbox
-        className={cx(styles.main, styles.content, railCollapsed && styles.contentCollapsed)}
-        data-testid={'home-main'}
-        gap={24}
-      >
-        <div className={styles.inputArea}>
-          <InputArea
-            inputValue={inputValue}
-            mode={mode}
-            onInputValueChange={handleInputValueChange}
-            onModeChange={setMode}
-          />
-        </div>
-        <ScrollArea
-          disableContentFit
-          scrollFade
-          className={styles.mainScroll}
-          contentProps={{ style: MAIN_CONTENT_STYLE }}
-          scrollbarProps={{ className: styles.mainScrollbar }}
+        <Flexbox
+          className={cx(styles.main, styles.content, railCollapsed && styles.contentCollapsed)}
+          data-testid={'home-main'}
+          gap={24}
         >
+          <div className={styles.inputArea}>
+            <InputArea
+              inputValue={inputValue}
+              mode={mode}
+              onInputValueChange={handleInputValueChange}
+              onModeChange={setMode}
+            />
+          </div>
           <HomeModeContent mode={mode} onSuggestionSelect={handleSuggestionSelect} />
-        </ScrollArea>
-      </Flexbox>
+        </Flexbox>
 
-      {isLogin && (
-        <aside
-          aria-hidden={railCollapsed}
-          className={cx(styles.rail, styles.railSurface)}
-          data-collapsed={railCollapsed}
-          data-testid={'home-rail'}
-          id={'home-rail'}
-          inert={railCollapsed}
-        >
-          {/* No scrollFade: its mask would make the viewport a backdrop root
-              and the cards' glass would stop sampling the portrait behind it. */}
-          <ScrollArea
-            disableContentFit
-            className={styles.railScroll}
-            contentProps={{ style: RAIL_CONTENT_STYLE }}
+        {isLogin && (
+          <aside
+            aria-hidden={railCollapsed}
+            className={cx(styles.rail, styles.railSurface)}
+            data-collapsed={railCollapsed}
+            data-testid={'home-rail'}
+            id={'home-rail'}
+            inert={railCollapsed}
           >
             <HomeInbox hideNeedsYou hideUnread variant={'rail'} />
-          </ScrollArea>
-        </aside>
-      )}
-    </Flexbox>
+          </aside>
+        )}
+      </Flexbox>
+    </ScrollArea>
   );
 });
 

--- a/src/libs/swr/keys.test.ts
+++ b/src/libs/swr/keys.test.ts
@@ -33,6 +33,18 @@ describe('recentKeys', () => {
       'user-1:workspace-1',
     ]);
   });
+
+  // Regression: `recent:topicList` had no CACHE_TIERS entry of its own, and the
+  // provider matches patterns as substrings — so `recent:list` never covered it.
+  // The Home recents list was memory-only and flashed a skeleton on every boot.
+  it('routes the Home topic-only recents key to a persisted cache tier', () => {
+    const serialized = unstable_serialize(recentKeys.topicList(9, 'user-1:workspace-1'));
+    const persisted = [...CACHE_TIERS.idb, ...CACHE_TIERS.local].some((pattern) =>
+      serialized.includes(pattern),
+    );
+
+    expect(persisted).toBe(true);
+  });
 });
 
 describe('taskKeys', () => {

--- a/src/libs/swr/localStorageProvider.ts
+++ b/src/libs/swr/localStorageProvider.ts
@@ -493,6 +493,10 @@ export const CACHE_TIERS = {
   /** Small, frequently-changing list shells → localStorage (sync first paint). */
   local: [
     'recent:list',
+    // Home's chat-mode recents. Matching is substring-based, so `recent:list`
+    // does not cover this sibling key — without its own entry the list is
+    // memory-only and every cold boot pays a skeleton for data we already had.
+    'recent:topicList',
     'fetchRecentTopics',
     'fetchRecentResources',
     'fetchRecentPages',

--- a/src/routes/(main)/home/index.tsx
+++ b/src/routes/(main)/home/index.tsx
@@ -11,15 +11,20 @@ const Home: FC = () => {
     <>
       <HomePageTracker />
       <HomeNavHeader />
+      {/* The page scrolls here, at full pane width, rather than inside the
+          centered column: it puts the scrollbar against the app frame instead
+          of floating it in the margin beside the content, and a native
+          overflow container takes no tab stop — a scroll viewport would, and
+          its focus ring would trace a box around the entire dashboard. */}
       <Flexbox
         height={'100%'}
-        style={{ overflow: 'hidden', paddingBlockStart: 32, paddingInline: 24 }}
+        style={{ overflowY: 'auto', paddingBlock: '32px 24px', paddingInline: 24 }}
         width={'100%'}
       >
         <WideScreenContainer
           fullWidth
-          style={{ marginInline: 'auto', maxWidth: 1240, minHeight: 0 }}
-          wrapperStyle={{ flex: 1, minHeight: 0 }}
+          style={{ marginInline: 'auto', maxWidth: 1240 }}
+          wrapperStyle={{ flex: 'none' }}
         >
           <HomeContent />
         </WideScreenContainer>


### PR DESCRIPTION
Four fixes to the Home dashboard.

### The dashboard scrolled in pieces

Each column owned its own scroll viewport, so the topic list travelled under a pinned greeting while the rail sat still — no gesture moved the dashboard as a whole. The grid is now wrapped in a single scroll region and row 2 sizes to its content, so the greeting, the composer, the topic list and the rail travel together.

The scroll container is the route's **full-width wrapper** with a plain `overflow-y: auto` — the idiom `AgentTasksPage` and `AgentViewAllPage` already use — not a `ScrollArea` around the dashboard. That placement matters twice over: a scrollbar rides its own scroller's edge, so scrolling at the pane puts the bar against the app frame instead of floating it in the margin beside the centred 1240px column; and a native overflow container takes no tab stop, whereas a scroll viewport is a focusable region whose focus ring would trace a box around the entire dashboard. The row hover bleed paints into the route's existing 24px inline padding rather than needing a lane of its own.

### The recents list was never cached

`CACHE_TIERS.local` listed `recent:list`, and the cache provider matches patterns as substrings — so the sibling key `recent:topicList` was never covered by it. The list stayed memory-only, and every cold boot refetched it and flashed a skeleton for data we already had. It now gets its own tier entry.

### The skeleton it flashed was wrong on two counts

It painted a real leading icon (`HashIcon` / `ListTodoIcon`), so the loading state showed concrete content that was then swapped out for an avatar — the wrong promise to make. And its bars (14px / 11px, spaced by a flex `gap`) didn't match the row's actual line boxes. The placeholder now mirrors the row: shared box metrics (`rowBox`), a skeleton avatar in the lead slot, bars centred inside the real line boxes, and the trailing timestamp that recents rows actually have. Hover styling stays off the skeleton — there's nothing to click yet.

**Corrected from an earlier revision of this description:** I previously wrote that nothing reflows when data lands. Measured, that holds only for rows *with* a description preview — skeleton row and loaded two-line row are both exactly 63px. A loaded row *without* a description is 47px, so those settle 16px shorter. A skeleton can only reserve one height and this reserves the majority case; the "no reflow" claim was too strong.

### zh-CN copy

`dashboard.chat.recents` said 最近主题; topic is 话题 everywhere else in the product. en-US unchanged.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check` — lint clean, 28 tests passed, full type-check clean.

**Full agent-testing round published:** https://app.lobehub.com/acceptance/253b8cdb-ae5b-4e1f-a375-0dc9255032fc — 8 checks, all passing, against a local full-stack dev server with a seeded signed-in account carrying 100 topics. Highlights:

- scroll container right edge == content pane right edge (1491), 24px outside the centred column (1467) — the bar sits on the app frame;
- greeting / main column / rail all shift by exactly the scroll delta (240 / 240 / 240), with the rail visibly travelling in the screenshot;
- **every** focusable element in the document enumerated (109 of them): zero are ancestors of the dashboard, and the scroller has no `tabindex` attribute at all — a proof rather than a Tab-sampling;
- skeleton and cache proven by a warm/cold pair with the recents tRPC request **held paused over CDP**: warm renders 8 real rows from the localStorage tier while the network is still blocked; cold shows the 3-row skeleton;
- rail card 380px + 14px gutter, verified against real rail cards (this was marked unverified in an earlier revision of this description);
- Electron parity: same invariants hold in the desktop shell at a different width (763 vs 1210), so it is a genuine re-verification, not a repeated measurement.

Not covered: the rewritten `layout.feature` E2E scenario was not itself executed, and the skeleton/cache checks were not repeated on desktop (that Electron instance's backend was unreachable, so its data sections were in an error state).

#### 🔗 Related Issue

None found.