### PR TITLE
🐛 fix(desktop): stop tool_result image upload from crashing the main process

### DIFF
--- a/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
@@ -1,5 +1,8 @@
+import type { RemoteServerAuth } from '@/modules/heterogeneousAgent/fileStorePort';
+
 import type HeterogeneousAgentImplementation from './HeterogeneousAgentImpl';
 import { ControllerModule, IpcMethod } from './index';
+import RemoteServerConfigCtr from './RemoteServerConfigCtr';
 
 type Implementation = HeterogeneousAgentImplementation;
 
@@ -13,10 +16,27 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
 
   private implementationPromise?: Promise<Implementation>;
 
+  /**
+   * Resolved on this side of the lazy boundary and handed to the implementation.
+   * This controller lives in the eager main chunk next to `App` and
+   * `RemoteServerConfigCtr`; the implementation is a deferred chunk where the
+   * same `getController` lookup came back `undefined` at runtime and crashed the
+   * main process. Missing controller degrades to "no authed remote server",
+   * which makes the image upload a no-op instead of an unhandled rejection.
+   */
+  private remoteServerAuth: RemoteServerAuth = {
+    getAccessToken: async () => (await this.remoteServerConfigCtr?.getAccessToken()) ?? null,
+    getServerUrl: async () => (await this.remoteServerConfigCtr?.getRemoteServerUrl()) ?? null,
+  };
+
+  private get remoteServerConfigCtr(): RemoteServerConfigCtr | undefined {
+    return this.app.getController(RemoteServerConfigCtr);
+  }
+
   private getImplementation = (): Promise<Implementation> => {
     this.implementationPromise ??= import('./HeterogeneousAgentImpl')
       .then(({ default: Implementation }) => {
-        const implementation = new Implementation(this.app);
+        const implementation = new Implementation(this.app, this.remoteServerAuth);
         implementation.afterAppReady();
         return implementation;
       })

--- a/apps/desktop/src/main/controllers/HeterogeneousAgentImpl.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentImpl.ts
@@ -71,7 +71,10 @@ import {
   consumeCodexRateLimitResetCredit as consumeCodexRateLimitResetCreditRequest,
   fetchCodexQuota,
 } from '@/modules/heterogeneousAgent/codexQuota';
-import { createLambdaFileStorePort } from '@/modules/heterogeneousAgent/fileStorePort';
+import {
+  createLambdaFileStorePort,
+  type RemoteServerAuth,
+} from '@/modules/heterogeneousAgent/fileStorePort';
 import type {
   HeterogeneousAgentBuildPlan,
   HeterogeneousAgentImageAttachment,
@@ -331,7 +334,27 @@ interface InterventionSlot {
 }
 
 export default class HeterogeneousAgentCtr {
-  constructor(public app: App) {}
+  /**
+   * Remote-server credentials for the tool_result image upload.
+   *
+   * Injected by the eager `HeterogeneousAgentCtr` wrapper rather than resolved
+   * here: this file is a deferred chunk, and reaching back into the App's
+   * controller registry from it is exactly what broke — the lookup resolved to
+   * `undefined`, and the resulting TypeError escaped as an unhandled rejection
+   * that killed the main process. The fallback keeps standalone construction
+   * (tests, future call sites) working and never throws.
+   */
+  private readonly remoteServerAuth: RemoteServerAuth;
+
+  constructor(
+    public app: App,
+    remoteServerAuth?: RemoteServerAuth,
+  ) {
+    this.remoteServerAuth = remoteServerAuth ?? {
+      getAccessToken: async () => (await this.remoteServerConfigCtr?.getAccessToken()) ?? null,
+      getServerUrl: async () => (await this.remoteServerConfigCtr?.getRemoteServerUrl()) ?? null,
+    };
+  }
 
   private sessions = new Map<string, AgentSession>();
   /**
@@ -357,7 +380,11 @@ export default class HeterogeneousAgentCtr {
   });
   private readonly codexQuotaCache = new QuotaSnapshotCache<CodexQuotaSnapshot>();
 
-  private get remoteServerConfigCtr() {
+  /**
+   * Typed as optional on purpose: a deferred chunk cannot assume the registry
+   * hands back the controller it asks for.
+   */
+  private get remoteServerConfigCtr(): RemoteServerConfigCtr | undefined {
     return this.app.getController(RemoteServerConfigCtr);
   }
 
@@ -367,10 +394,7 @@ export default class HeterogeneousAgentCtr {
    * of heavy base64. Mirrors what `lh hetero exec` does for the gateway path.
    */
   private uploadResultImage = createFileStoreImageUploader(() =>
-    createLambdaFileStorePort({
-      getAccessToken: () => this.remoteServerConfigCtr.getAccessToken(),
-      getServerUrl: async () => (await this.remoteServerConfigCtr.getRemoteServerUrl()) ?? null,
-    }),
+    createLambdaFileStorePort(this.remoteServerAuth),
   );
 
   private resolveSessionCommand(session: AgentSession): string {

--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentLazyCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentLazyCtr.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { App } from '@/core/App';
+import type { RemoteServerAuth } from '@/modules/heterogeneousAgent/fileStorePort';
 
 import HeterogeneousAgentCtr from '../HeterogeneousAgentCtr';
 
@@ -12,8 +13,8 @@ const implementationMocks = vi.hoisted(() => ({
 
 vi.mock('../HeterogeneousAgentImpl', () => ({
   default: class MockHeterogeneousAgentImplementation {
-    constructor(app: App) {
-      implementationMocks.constructor(app);
+    constructor(app: App, remoteServerAuth?: RemoteServerAuth) {
+      implementationMocks.constructor(app, remoteServerAuth);
     }
 
     afterAppReady() {
@@ -27,6 +28,10 @@ vi.mock('../HeterogeneousAgentImpl', () => ({
 }));
 
 describe('HeterogeneousAgentCtr lazy implementation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('defers the heavy implementation and initializes it exactly once on first use', async () => {
     const app = {} as App;
     const controller = new HeterogeneousAgentCtr(app);
@@ -40,8 +45,32 @@ describe('HeterogeneousAgentCtr lazy implementation', () => {
     await (controller as any).startSession({ prompt: 'second' });
 
     expect(implementationMocks.constructor).toHaveBeenCalledOnce();
-    expect(implementationMocks.constructor).toHaveBeenCalledWith(app);
+    expect(implementationMocks.constructor).toHaveBeenCalledWith(app, expect.any(Object));
     expect(implementationMocks.afterAppReady).toHaveBeenCalledOnce();
     expect(implementationMocks.startSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('injects remote-server auth resolved on the eager side of the lazy boundary', async () => {
+    const remoteServerConfigCtr = {
+      getAccessToken: vi.fn(async () => 'token-1'),
+      getRemoteServerUrl: vi.fn(async () => 'https://cloud.lobehub.com'),
+    };
+    const getController = vi.fn(() => remoteServerConfigCtr as any);
+    const app = { getController } as unknown as App;
+
+    const controller = new HeterogeneousAgentCtr(app);
+    await (controller as any).startSession({ prompt: 'first' });
+
+    const auth = implementationMocks.constructor.mock.calls[0][1] as RemoteServerAuth;
+
+    await expect(auth.getServerUrl()).resolves.toBe('https://cloud.lobehub.com');
+    await expect(auth.getAccessToken()).resolves.toBe('token-1');
+
+    // A registry lookup that comes back empty must degrade to "no authed remote
+    // server" — never a throw, which would escape as a fatal unhandled rejection.
+    getController.mockReturnValue(undefined as any);
+
+    await expect(auth.getServerUrl()).resolves.toBeNull();
+    await expect(auth.getAccessToken()).resolves.toBeNull();
   });
 });

--- a/apps/desktop/src/main/modules/heterogeneousAgent/fileStorePort.test.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/fileStorePort.test.ts
@@ -38,6 +38,36 @@ describe('createLambdaFileStorePort', () => {
     ).toBeUndefined();
   });
 
+  it('keeps a sibling rejection handled when an auth callback throws synchronously', async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      // Shape of the real failure: `getServerUrl` is async (rejects) while
+      // `getAccessToken` is a plain arrow that throws. Building the `Promise.all`
+      // argument list must not leave the first rejection without a subscriber —
+      // in Electron main an unhandled rejection kills the process.
+      await expect(
+        createLambdaFileStorePort({
+          getAccessToken: () => {
+            throw new TypeError("Cannot read properties of undefined (reading 'getAccessToken')");
+          },
+          getServerUrl: async () => {
+            throw new TypeError("Cannot read properties of undefined (reading 'getServerUrl')");
+          },
+        }),
+      ).rejects.toThrow(TypeError);
+
+      // Node reports unhandled rejections once the microtask queue drains.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+  });
+
   it('POSTs a superjson-serialized input to the lambda procedure and deserializes the result', async () => {
     vi.mocked(fetch).mockResolvedValue(trpcOk({ isExist: true, url: 'files/a/b.png' }) as any);
 

--- a/apps/desktop/src/main/modules/heterogeneousAgent/fileStorePort.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/fileStorePort.ts
@@ -75,7 +75,16 @@ const lambdaMutation = async <T>(
 export const createLambdaFileStorePort = async (
   auth: RemoteServerAuth,
 ): Promise<FileStorePort | undefined> => {
-  const [serverUrl, accessToken] = await Promise.all([auth.getServerUrl(), auth.getAccessToken()]);
+  // Sequential on purpose. Both reads are local (settings store + `safeStorage`
+  // decryption), so there is nothing to win by parallelizing — while
+  // `Promise.all([auth.getServerUrl(), auth.getAccessToken()])` is a trap: the
+  // argument list is evaluated first, so a callback that throws *synchronously*
+  // abandons the array before `Promise.all` ever subscribes to its sibling,
+  // orphaning that rejection. In Electron main an unhandled rejection is fatal
+  // (`process-error-handlers` re-throws it), so an injected-callback bug would
+  // kill the app instead of degrading to "no image upload".
+  const serverUrl = await auth.getServerUrl();
+  const accessToken = await auth.getAccessToken();
 
   if (!serverUrl || !accessToken) {
     logger.debug('No authed remote server — skipping tool_result image upload');


### PR DESCRIPTION
A Claude Code `tool_result` carrying a base64 image kills the desktop **main process**. Seen twice in one day on `2.2.14-canary.2` (still reproducible in the pending `canary.5` build), each time taking down a running agent session:

```
[error] [main:process-error-handlers] Unhandled rejection in main process:
TypeError: Cannot read properties of undefined (reading 'getRemoteServerUrl')
    at Object.getServerUrl (…/HeterogeneousAgentImpl-*.js)
    at Ki                  (…createLambdaFileStorePort)
    at Xn.uploadImage      (…createFileStoreImageUploader)
    at Xn.uploadResultImages / processPayloads / push  (AgentStreamPipeline)
```

`process-error-handlers` re-throws non-transient unhandled rejections on purpose, so this surfaces as an `uncaughtException` and the app restarts mid-run.

#### Root cause

Two independent defects had to line up:

1. **The controller lookup came back empty.** `HeterogeneousAgentImpl` became a deferred chunk in #17811 (`⚡️ perf(desktop): reduce cold-start critical path`); the uploader code itself has been unchanged since #16965. From that deferred chunk, `app.getController(RemoteServerConfigCtr)` resolved to `undefined` at runtime — `canary.1` never crashed, `canary.2` (first build containing the split) crashes.
2. **The failure could not be contained.** `createLambdaFileStorePort` did `await Promise.all([auth.getServerUrl(), auth.getAccessToken()])`, but only `getServerUrl` was `async`. The argument list is evaluated *before* `Promise.all` is called, so when `getAccessToken` threw synchronously the array was abandoned and `Promise.all` never subscribed to the already-rejected first promise — orphaning it. `AgentStreamPipeline`'s `try/catch` around the uploader caught the sync throw and dropped the image as designed, while the orphaned rejection killed the process.

#### The fix

- **Resolve credentials on the eager side of the lazy boundary.** `HeterogeneousAgentCtr` (eager main chunk, next to `App` and `RemoteServerConfigCtr`) now builds the `RemoteServerAuth` and injects it into the implementation. The implementation no longer reaches back into the controller registry; its fallback path is optional-chained so a missing controller degrades to "no authed remote server".
- **Drop the `Promise.all` entirely.** Both credential reads are local (settings store + `safeStorage` decryption) — there was never anything to parallelize. Sequential awaits are structurally incapable of orphaning a rejection, since only one promise is ever in flight.

Worst case is now a dropped image with the `[Image: …]` placeholder kept — the documented degradation — instead of a dead main process.

| Before | After |
| ------ | ----- |
| CC returns an image → main process dies, app restarts | Upload failure degrades to the `[Image: …]` placeholder |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check` on the touched files: lint clean, tests passed, types clean.

Both regression tests were verified to fail before the fix:

- `fileStorePort.test.ts` — reproduces the exact shape (async `getServerUrl` rejects, sync `getAccessToken` throws) and asserts no `unhandledRejection` fires. Restoring the `Promise.all` argument list makes it report `TypeError: Cannot read properties of undefined (reading 'getServerUrl')`, i.e. the production error.
- `HeterogeneousAgentLazyCtr.test.ts` — asserts the wrapper injects the auth across the lazy boundary, and that an empty registry lookup resolves to `null` instead of throwing.

#### 🔗 Related Issue

Regression from #17811. No matching GitHub issue found.