### PR TITLE
docs(readme): add DaoXE to OpenAI third-party proxy list

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ If you find signing up for an OpenAI account or binding a foreign-currency credi
 |                                                                     | Provider     | Features                                                                                                | Proxy URL                 | Link                              |
 | ------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------- | ------------------------- | --------------------------------- |
 | <img src="https://resource.aihubmix.com/logo.png?v=1" width="48" /> | **AIHubMix** | Uses the OpenAI enterprise API; all models site-wide at **14% off** the official price (incl. GPT-5.6 and Claude Fable 5) | `https://aihubmix.com/v1` | [Get](https://console.aihubmix.com/token?aff=8DBz) |
+|  | **DaoXE** | OpenAI-compatible multi-model gateway (GPT/Claude/Gemini/DeepSeek etc.); also Anthropic Messages; Alipay/WeChat/USDT | `https://api.daoxe.com/v1` | [Get](https://daoxe.com) |
 
 > \[!WARNING]
 >

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -310,6 +310,7 @@ API Key 是使用 LobeHub 进行大语言模型会话的必要信息，本节以
 |                                                                                                                                                   | 服务商       | 特性说明                                                        | Proxy 代理地址            | 链接                            |
 | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | --------------------------------------------------------------- | ------------------------- | ------------------------------- |
 | <img src="https://resource.aihubmix.com/logo.png?v=1" width="48" /> | **AIHubMix** | 使用 OpenAI 企业接口，全站模型价格为官方 **86 折**（含 GPT-5.6 和 Claude Fable 5） | `https://aihubmix.com/v1` | [获取](https://console.aihubmix.com/token?aff=8DBz) |
+|  | **DaoXE** | OpenAI 兼容多模型网关（GPT/Claude/Gemini/DeepSeek 等）；支持 Anthropic Messages；支付宝/微信/USDT | `https://api.daoxe.com/v1` | [获取](https://daoxe.com) |
 
 > \[!WARNING]
 >


### PR DESCRIPTION
## Summary
Adds **DaoXE** to the existing OpenAI third-party proxy reference tables in `README.md` and `README.zh-CN.md`.

- Base URL: `https://api.daoxe.com/v1` (works with `OPENAI_PROXY_URL`)
- Multi-model OpenAI-compatible gateway (+ Anthropic Messages)
- Payment: Alipay / WeChat / USDT

No runtime code changes. Existing third-party key disclaimer still applies.

## Test plan
- [ ] README tables render (EN + ZH)
- [ ] Links resolve