### PR TITLE
🧹 chore: remove all LOBE-XXX marker references from source code

### DIFF
--- a/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
@@ -185,7 +185,7 @@ describe('createServerToolsEngine', () => {
     expect(availablePlugins).toContain('test-plugin');
   });
 
-  it('drops manifests without an api array instead of crashing the tools build (LOBE-12528)', () => {
+  it('drops manifests without an api array instead of crashing the tools build', () => {
     // A DB plugin row whose manifest jsonb lacks `api` used to crash
     // ToolsEngine.convertManifestsToTools (`manifest.api.map`) and with it
     // every execAgent call of the affected user.

--- a/packages/context-engine/src/engine/messages/__tests__/MessagesEngine.test.ts
+++ b/packages/context-engine/src/engine/messages/__tests__/MessagesEngine.test.ts
@@ -124,7 +124,7 @@ describe('MessagesEngine', () => {
       });
     });
 
-    it('should drop placeholder residue hidden inside tasks containers (LOBE-12572)', async () => {
+    it('should drop placeholder residue hidden inside tasks containers', async () => {
       // TasksFlattenProcessor emits children as role='task' and
       // TaskMessageProcessor converts them to assistant AFTER the flatten —
       // the post-flatten placeholder pass must run after that conversion, or
@@ -155,7 +155,7 @@ describe('MessagesEngine', () => {
       expect(result.messages[0].role).toBe('user');
     });
 
-    it('should not let placeholder-only containers consume history slots (LOBE-12572)', async () => {
+    it('should not let placeholder-only containers consume history slots', async () => {
       // History truncation counts each container as one group; a placeholder-
       // only container must be dropped BEFORE truncation or it eats a slot and
       // then vanishes at the flatten phase, losing a real history turn.

--- a/packages/context-engine/src/processors/__tests__/PlaceholderMessageFilter.test.ts
+++ b/packages/context-engine/src/processors/__tests__/PlaceholderMessageFilter.test.ts
@@ -20,7 +20,7 @@ describe('PlaceholderMessageFilterProcessor', () => {
   it('should remove failed assistant placeholders that carry an error', async () => {
     // Regression: persisted "..." rows from failed generations poisoned the
     // topic — replayed at the payload tail they trigger the Claude 4.6+
-    // assistant-prefill 400 on every subsequent send (LOBE-12572).
+    // assistant-prefill 400 on every subsequent send.
     const context = createContext([
       { content: 'hi', id: 'u1', role: 'user' },
       { content: '...', error: { type: 'CapabilityNotSupported' }, id: 'a1', role: 'assistant' },

--- a/packages/database/src/repositories/search/index.test.ts
+++ b/packages/database/src/repositories/search/index.test.ts
@@ -1328,7 +1328,7 @@ describe.skipIf(!isServerDB)('SearchRepo', () => {
     });
   });
 
-  // Regression guard for LOBE-12379: the BM25 scans were split into an inner
+  // Regression guard: the BM25 scans were split into an inner
   // single-table subquery (so ParadeDB can pick its TopN custom scan) with the
   // joins and — in personal mode — the `workspace_id IS NULL` check moved above
   // it. These tests pin the two things that split could break: rows leaking
@@ -1545,7 +1545,7 @@ describe.skipIf(!isServerDB)('SearchRepo', () => {
       if (hit?.type === 'file') expect(hit.knowledgeBaseId).toBe(base.id);
     });
   });
-  // Regression guard for LOBE-12575: the agent filter on topics/messages moved
+  // Regression guard: the agent filter on topics/messages moved
   // from inside the BM25 scan to above it (over-fetching through a deep
   // candidate pool). These tests pin the result semantics that move could
   // break: rows leaking across agents, and the filter being lost entirely.
@@ -1629,7 +1629,7 @@ describe.skipIf(!isServerDB)('SearchRepo', () => {
 
   // The workspace-scoping tests above pin *results*, and this change is
   // deliberately result-neutral — they pass against the pre-fix implementation
-  // too. What actually fixes LOBE-12379 is the *shape* of the emitted SQL, so
+  // too. What actually fixes the split-query structure is the *shape* of the emitted SQL, so
   // it needs its own guard: ParadeDB only picks `TopNScanExecState` when the
   // scan node itself carries the whole `ORDER BY paradedb.score() LIMIT n`.
   //
@@ -1768,7 +1768,7 @@ describe.skipIf(!isServerDB)('SearchRepo', () => {
       }
     });
 
-    // Guard for LOBE-12575: `agent_id` is not a BM25 field either — inside the
+    // Guard: `agent_id` is not a BM25 field either — inside the
     // scan it costs TopN and, on production pg_search 0.15.26, NULLs out every
     // score (arbitrary order, flat relevance 3). The agent filter must sit
     // above the scan, backed by a deepened candidate pool.

--- a/packages/database/src/repositories/search/index.ts
+++ b/packages/database/src/repositories/search/index.ts
@@ -233,10 +233,7 @@ const RECENCY_CANDIDATE_MULTIPLIER = 4;
  * score ordering is real (see `liftsAgentFilter`): trading the exact inline
  * predicate for a score-ordered pool is unsound when the scores backing that
  * order are NULL. Indexing the column instead is tracked with the other
- * missing fast fields in LOBE-12381.
- *
- * @see https://linear.app/lobehub/issue/LOBE-12379
- * @see https://linear.app/lobehub/issue/LOBE-12575
+ * missing fast fields (adding workspace_id to BM25 indexes).
  */
 const WORKSPACE_FILTER_CANDIDATE_MULTIPLIER = 5;
 
@@ -269,7 +266,7 @@ const WORKSPACE_FILTER_MIN_CANDIDATES = 500;
 
 /**
  * Flip to `true` once every BM25 index used by this repo carries `workspace_id`
- * as a fast keyword field (LOBE-12381). pg_search then pushes `workspace_id IS
+ * as a fast keyword field. pg_search then pushes `workspace_id IS
  * NULL` down as `must_not: exists(workspace_id)` and `workspace_id = ?` as a
  * `term`, so the ownership predicate can stay inline and personal search becomes
  * exact again (no candidate over-fetch, no dropped rows) while workspace-mode
@@ -311,7 +308,7 @@ export class SearchRepo {
    * approximation. Workspace mode has no such pushdown-able owner column — its
    * rows are a tiny slice of a global TopN — so lifting the filter there would
    * silently return nothing. It keeps the exact inline predicate and stays on
-   * the slow plan until LOBE-12381 lands.
+   * the slow plan until workspace_id is added to the BM25 indexes.
    */
   private get liftsWorkspaceFilter() {
     return !WORKSPACE_ID_IN_BM25_INDEX && !this.workspaceId;
@@ -324,7 +321,7 @@ export class SearchRepo {
    * pool, which is only sound while the scan's `ORDER BY paradedb.score()` is
    * real. Personal mode qualifies: its scan keeps only pushdown-able quals, so
    * scores are valid and the pool is genuinely the top-N matches. Workspace
-   * mode does not (until LOBE-12381 makes `workspace_id` a fast field): its
+   * mode does not (its `workspace_id` is not yet a BM25 fast field): its
    * inline `workspace_id` qual NULLs the whole score column on pg_search
    * 0.15.26, so a pool cut on that ordering would be an arbitrary slice that
    * silently drops agent rows. It keeps `agent_id` inline next to
@@ -1017,7 +1014,7 @@ export class SearchRepo {
    * the plain index-scan plan: `knowledge_base_id` is not in the BM25 index
    * either, so isolating the scan would not buy TopN. The KB filter does bound
    * the match set to one knowledge base (via its btree index), which keeps it
-   * workable until LOBE-12381 adds the missing fast fields.
+   * workable until the missing fast fields are added to the BM25 indexes.
    */
   async searchKnowledgeBaseDocuments(
     query: string,

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.test.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.test.ts
@@ -24,7 +24,7 @@ describe('Anthropic generateObject', () => {
     );
   });
 
-  it('should strip trailing assistant messages for models without prefill support (LOBE-12572)', async () => {
+  it('should strip trailing assistant messages for models without prefill support', async () => {
     const { requestParams } = await buildAnthropicGenerateObjectRequest({
       messages: [
         { content: 'Generate data', role: 'user' as const },

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.test.ts
@@ -216,7 +216,7 @@ describe('createAnthropicCompatibleRuntime', () => {
   it('should strip trailing assistant prefill when a logical id maps to a Claude 5 model', async () => {
     // The prefill strip inside handlePayload sees the logical id; when the
     // mapping only later resolves to a Claude 4.6+/5 upstream id, chat() must
-    // re-strip against the model actually sent (LOBE-12572).
+    // re-strip against the model actually sent.
     const messagesCreate = vi.fn().mockResolvedValue({ content: [] });
     const Runtime = createAnthropicCompatibleRuntime({
       chatCompletion: {

--- a/packages/model-runtime/src/providers/anthropic/claudePrefill.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/claudePrefill.test.ts
@@ -14,7 +14,7 @@ describe('stripUnsupportedClaudeAssistantPrefill', () => {
   });
 
   it('should strip ALL stacked trailing assistant messages', () => {
-    // Regression LOBE-12572: failed-run placeholders can stack multiple
+    // Regression: failed-run placeholders can stack multiple
     // assistant turns at the tail; popping only one still returns 400.
     const messages = [
       user('hi'),

--- a/packages/model-runtime/src/providers/anthropic/claudePrefill.ts
+++ b/packages/model-runtime/src/providers/anthropic/claudePrefill.ts
@@ -8,8 +8,8 @@ import { shouldDropUnsupportedClaudeAssistantPrefill } from './modelId';
  * unsupported assistant prefill and returns 400 before generation starts.
  *
  * A single trailing pop is not enough: failed-run placeholder rows can stack
- * multiple assistant messages at the payload tail (see LOBE-12572), so strip
- * until the conversation ends with a non-assistant turn. Models that still
+ * multiple assistant messages at the payload tail, so strip until the
+ * conversation ends with a non-assistant turn. Models that still
  * support prefill are left untouched.
  * @see https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prefill-claudes-response
  */

--- a/packages/model-runtime/src/providers/anthropic/index.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/index.test.ts
@@ -909,7 +909,7 @@ describe('LobeAnthropicAI', () => {
         ]);
       });
 
-      it('should drop ALL stacked trailing assistant messages (LOBE-12572)', async () => {
+      it('should drop ALL stacked trailing assistant messages', async () => {
         // Failed-run placeholder rows can stack several assistant turns at the
         // payload tail; popping only one still triggers the prefill 400.
         const payload: ChatStreamPayload = {

--- a/packages/model-runtime/src/providers/bedrock/index.test.ts
+++ b/packages/model-runtime/src/providers/bedrock/index.test.ts
@@ -244,7 +244,7 @@ describe('LobeBedrockAI', () => {
         ]);
       });
 
-      it('should drop ALL stacked trailing assistant messages (LOBE-12572)', async () => {
+      it('should drop ALL stacked trailing assistant messages', async () => {
         const mockStream = new ReadableStream({
           start(controller) {
             controller.enqueue('Hello, world!');
@@ -278,7 +278,7 @@ describe('LobeBedrockAI', () => {
 
       it('should drop assistant prefill when a logical id maps to a Claude 5 Bedrock id', async () => {
         // The channel modelIdMapping resolves the actually-sent Bedrock model
-        // id; the prefill guard must follow it, not the logical id (LOBE-12572).
+        // id; the prefill guard must follow it, not the logical id.
         const mappedInstance = new LobeBedrockAI({
           accessKeyId: 'test-access-key-id',
           accessKeySecret: 'test-access-key-secret',
@@ -1358,7 +1358,7 @@ describe('LobeBedrockAI', () => {
 
     it('should drop assistant prefill in generateObject when a logical id maps to Claude 5', async () => {
       // The prefill guard must follow the resolved Bedrock model id, not the
-      // logical alias the channel mapping hides it behind (LOBE-12572).
+      // logical alias the channel mapping hides it behind.
       const mappedInstance = new LobeBedrockAI({
         accessKeyId: 'test-access-key-id',
         accessKeySecret: 'test-access-key-secret',

--- a/src/features/ChatInput/ChatInputNotice/useChatInputNotice.test.tsx
+++ b/src/features/ChatInput/ChatInputNotice/useChatInputNotice.test.tsx
@@ -154,7 +154,7 @@ describe('useChatInputNotice', () => {
     expect(result.current).toEqual({ key: 'input.viewOnlyGroup', type: 'warning' });
   });
 
-  it('stays silent for a gated member who can use but not edit the agent (LOBE-12547)', () => {
+  it('stays silent for a gated member who can use but not edit the agent', () => {
     // The use-only permission is explained on the controls it actually locks
     // (model trigger / device chip), not as a standing banner.
     testState.resourceAccess = {

--- a/src/features/ChatInput/ChatInputNotice/useChatInputNotice.ts
+++ b/src/features/ChatInput/ChatInputNotice/useChatInputNotice.ts
@@ -62,7 +62,7 @@ export const resolveChatInputNotice = ({
 
   // Use-level General access (can chat, can't edit the shared config) is
   // deliberately NOT a notice: a standing "you can only use this agent" banner
-  // states a permission without naming what it blocks (LOBE-12547). The locked
+  // states a permission without naming what it blocks. The locked
   // controls explain themselves instead — see `useModelLockTooltip` for the
   // model triggers and the fixed-target tooltip on the device chip.
 };

--- a/src/features/Conversation/store/utils/effectiveModel.test.ts
+++ b/src/features/Conversation/store/utils/effectiveModel.test.ts
@@ -22,7 +22,7 @@ afterEach(() => {
 describe('getEffectiveConversationModel', () => {
   it('prefers the topic-scoped model override over the agent default', () => {
     // A topic switched to a Claude 5 model must drive capability guards even
-    // when the agent default is still a prefill-capable model (LOBE-12572).
+    // when the agent default is still a prefill-capable model.
     useAgentStore.setState({
       agentMap: { [AGENT_ID]: { chatConfig: {}, model: 'gpt-5.2' } },
     } as any);

--- a/src/features/VisibilityConfirmContent/index.test.tsx
+++ b/src/features/VisibilityConfirmContent/index.test.tsx
@@ -36,7 +36,7 @@ describe('VisibilityConfirmContent', () => {
     expect(screen.getAllByText('visibilityConfirm.irreversible')).toHaveLength(1);
   });
 
-  // LOBE-12543: publishing no longer asks for member permissions up front —
+  // Publishing no longer asks for member permissions up front —
   // the resource lands on the workspace default and the owner tunes it later
   // from the resource's own "Member Permissions" entry.
   it('does not render a member-permission select when publishing', () => {

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
@@ -354,7 +354,7 @@ describe('Agent profile EditorCanvas', () => {
   it('does not bubble mode-switch clicks to the click-to-focus wrapper', () => {
     // The profile page wraps the canvas in a click-to-focus area; a bubbled
     // toggle click would focus the editor and scroll to the caret at the
-    // document end. See LOBE-12593.
+    // document end.
     const onWrapperClick = vi.fn();
     render(
       <div onClick={onWrapperClick}>

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
@@ -452,7 +452,6 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
               // bubbled click, and Lexical's focus() moves the caret to the
               // document end when there is no selection — scrolling the page to
               // the bottom. Toggling the view mode must not move the caret.
-              // See LOBE-12593.
               onClick={(e) => e.stopPropagation()}
             >
               <ActionIcon

--- a/src/routes/(main)/agent/profile/features/useClickToFocusEditor.test.ts
+++ b/src/routes/(main)/agent/profile/features/useClickToFocusEditor.test.ts
@@ -36,7 +36,7 @@ describe('useClickToFocusEditor', () => {
     // Lexical's focus() selects the document end when no selection exists, so
     // focusing the display:none visual editor leaves a dirty end-of-document
     // selection that scrolls the page to the bottom once the editor becomes
-    // visible again. See LOBE-12593.
+    // visible again.
     getRootElement.mockReturnValue({ offsetParent: null });
     const { result } = renderHook(() => useClickToFocusEditor(editor, true));
 

--- a/src/routes/(main)/agent/profile/features/useClickToFocusEditor.ts
+++ b/src/routes/(main)/agent/profile/features/useClickToFocusEditor.ts
@@ -10,7 +10,7 @@ import { type MouseEvent, useCallback } from 'react';
  * `display: none`). Lexical's `focus()` falls back to `selectEnd()` when the
  * editor has no selection, so focusing the hidden editor leaves a dirty
  * end-of-document selection that scrolls the page to the bottom once the editor
- * becomes visible again. See LOBE-12593.
+ * becomes visible again.
  */
 export const useClickToFocusEditor = (editor: IEditor | undefined, canEdit: boolean) =>
   useCallback(

--- a/src/routes/(main)/home/_layout/hooks/useCreateMenuItems.tsx
+++ b/src/routes/(main)/home/_layout/hooks/useCreateMenuItems.tsx
@@ -377,7 +377,7 @@ export const useCreateMenuItems = () => {
         if (!canCreate) return;
 
         if (openCreateGroupModal) {
-          // Let the user name the group at creation time (LOBE-12597)
+          // Let the user name the group at creation time
           openCreateGroupModal(undefined, options?.visibility);
           return;
         }


### PR DESCRIPTION
## Summary

Removed all `LOBE-XXX` internal Linear ticket references from 20 files across the codebase. The existing comments already describe the context — the internal ticket references are not meaningful for open-source readers.

## Removed markers

| Marker | Files |
|--------|-------|
| LOBE-12379 | `packages/database/src/repositories/search/` |
| LOBE-12381 | `packages/database/src/repositories/search/` |
| LOBE-12528 | `apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/` |
| LOBE-12543 | `src/features/VisibilityConfirmContent/` |
| LOBE-12547 | `src/features/ChatInput/ChatInputNotice/` |
| LOBE-12572 | `packages/model-runtime/`, `packages/context-engine/`, `src/features/Conversation/` |
| LOBE-12575 | `packages/database/src/repositories/search/` |
| LOBE-12593 | `src/routes/(main)/agent/profile/` |
| LOBE-12597 | `src/routes/(main)/home/_layout/` |

## Changed files (20)

- `apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts`
- `packages/context-engine/src/engine/messages/__tests__/MessagesEngine.test.ts`
- `packages/context-engine/src/processors/__tests__/PlaceholderMessageFilter.test.ts`
- `packages/database/src/repositories/search/index.test.ts`
- `packages/database/src/repositories/search/index.ts`
- `packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.test.ts`
- `packages/model-runtime/src/core/anthropicCompatibleFactory/index.test.ts`
- `packages/model-runtime/src/providers/anthropic/claudePrefill.test.ts`
- `packages/model-runtime/src/providers/anthropic/claudePrefill.ts`
- `packages/model-runtime/src/providers/anthropic/index.test.ts`
- `packages/model-runtime/src/providers/bedrock/index.test.ts`
- `src/features/ChatInput/ChatInputNotice/useChatInputNotice.test.tsx`
- `src/features/ChatInput/ChatInputNotice/useChatInputNotice.ts`
- `src/features/Conversation/store/utils/effectiveModel.test.ts`
- `src/features/VisibilityConfirmContent/index.test.tsx`
- `src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx`
- `src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx`
- `src/routes/(main)/agent/profile/features/useClickToFocusEditor.test.ts`
- `src/routes/(main)/agent/profile/features/useClickToFocusEditor.ts`
- `src/routes/(main)/home/_layout/hooks/useCreateMenuItems.tsx`

Auto-generated on 2026-08-03