### PR TITLE
🐛 fix(openai): handle Codex model prefixes

### DIFF
--- a/packages/model-runtime/src/providers/openai/index.test.ts
+++ b/packages/model-runtime/src/providers/openai/index.test.ts
@@ -314,6 +314,26 @@ describe('LobeOpenAI', () => {
       expect(createCall.model).toBe('gpt-5.6-sol');
     });
 
+    it('should prune sampling parameters for Codex-prefixed GPT-5.6 models', async () => {
+      const payload = {
+        frequency_penalty: 0.5,
+        messages: [{ content: 'Hello', role: 'user' as const }],
+        model: 'codex/gpt-5.6-luna',
+        presence_penalty: 0.3,
+        temperature: 0.7,
+        top_p: 0.9,
+      };
+
+      await instance.chat(payload);
+
+      expect(instance['client'].responses.create).toHaveBeenCalled();
+      const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+      expect(createCall.frequency_penalty).toBeUndefined();
+      expect(createCall.presence_penalty).toBeUndefined();
+      expect(createCall.temperature).toBeUndefined();
+      expect(createCall.top_p).toBeUndefined();
+    });
+
     it('should use responses API when enabledSearch is true', async () => {
       const payload = {
         enabledSearch: true,

--- a/packages/model-runtime/src/providers/openai/modelId.test.ts
+++ b/packages/model-runtime/src/providers/openai/modelId.test.ts
@@ -45,6 +45,17 @@ describe('parseOpenAIModelId', () => {
     });
   });
 
+  it('should parse Codex-prefixed OpenAI ids', () => {
+    expect(parseOpenAIModelId('codex/gpt-5.6-luna')).toEqual({
+      family: 'gpt',
+      majorVersion: 5,
+      minorVersion: 6,
+      modifiers: ['luna'],
+      normalizedModelId: 'gpt-5.6-luna',
+      source: 'codex',
+    });
+  });
+
   it('should not treat release dates as minor versions', () => {
     expect(parseOpenAIModelId('gpt-5-pro-2025-10-06')).toEqual({
       family: 'gpt',
@@ -86,6 +97,11 @@ describe('isGPT5ResponsesModel', () => {
     expect(isGPT5ResponsesModel('gpt-5.6-sol')).toBe(true);
     expect(isGPT5ResponsesModel('gpt-5.6-terra')).toBe(true);
     expect(isGPT5ResponsesModel('gpt-5.6-luna')).toBe(true);
+  });
+
+  it('should match Codex-prefixed GPT-5.6 models', () => {
+    expect(isGPT5ResponsesModel('codex/gpt-5.6-luna')).toBe(true);
+    expect(isResponsesAPIModel('codex/gpt-5.6-luna')).toBe(true);
   });
 
   it('should not force OpenRouter GPT slugs into the built-in Responses API rules', () => {
@@ -139,6 +155,7 @@ describe('isOpenAIReasoningPayloadModel', () => {
     expect(isOpenAIReasoningPayloadModel('codex-mini-latest')).toBe(true);
     expect(isOpenAIReasoningPayloadModel('computer-use-preview')).toBe(true);
     expect(isOpenAIReasoningPayloadModel('gpt-5.6-luna')).toBe(true);
+    expect(isOpenAIReasoningPayloadModel('codex/gpt-5.6-luna')).toBe(true);
     expect(isOpenAIReasoningPayloadModel('openai/gpt-5.6-sol')).toBe(true);
   });
 

--- a/packages/model-runtime/src/providers/openai/modelId.ts
+++ b/packages/model-runtime/src/providers/openai/modelId.ts
@@ -1,4 +1,4 @@
-export type OpenAIModelIdSource = 'openRouter' | 'openai';
+export type OpenAIModelIdSource = 'codex' | 'openRouter' | 'openai';
 
 export interface ParsedOpenAIModelId {
   family: 'gpt';
@@ -54,19 +54,42 @@ export const responsesAPIModels = new Set([
 const GPT_MODEL_PATTERN =
   /^gpt-(\d+)(?:\.(\d+))?(?:\b|[-.:])(?:-([a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*))?/;
 
+/**
+ * Codex-compatible gateways namespace OpenAI models as `codex/gpt-*`. These models still use
+ * the Responses contract, so capability detection must preserve that namespace separately from
+ * OpenRouter's `openai/*` model IDs.
+ *
+ * @see https://github.com/lobehub/lobehub/issues/17831
+ */
+const CODEX_MODEL_PREFIX = 'codex/';
+const OPENROUTER_OPENAI_MODEL_PREFIX = 'openai/';
+
 const normalizeOpenAIModelId = (model: string): string | undefined => {
   const normalized = model.trim().toLowerCase();
   if (!normalized) return;
 
-  return normalized.startsWith('openai/') ? normalized.slice('openai/'.length) : normalized;
+  if (normalized.startsWith(CODEX_MODEL_PREFIX)) {
+    return normalized.slice(CODEX_MODEL_PREFIX.length);
+  }
+
+  return normalized.startsWith(OPENROUTER_OPENAI_MODEL_PREFIX)
+    ? normalized.slice(OPENROUTER_OPENAI_MODEL_PREFIX.length)
+    : normalized;
 };
 
 const extractOpenAIModelId = (model: string): ExtractedOpenAIModelId | undefined => {
   const normalized = model.trim().toLowerCase();
   if (!normalized) return;
 
-  if (normalized.startsWith('openai/')) {
-    return { normalizedModelId: normalized.slice('openai/'.length), source: 'openRouter' };
+  if (normalized.startsWith(CODEX_MODEL_PREFIX)) {
+    return { normalizedModelId: normalized.slice(CODEX_MODEL_PREFIX.length), source: 'codex' };
+  }
+
+  if (normalized.startsWith(OPENROUTER_OPENAI_MODEL_PREFIX)) {
+    return {
+      normalizedModelId: normalized.slice(OPENROUTER_OPENAI_MODEL_PREFIX.length),
+      source: 'openRouter',
+    };
   }
 
   if (normalized.startsWith('gpt-')) {
@@ -114,9 +137,9 @@ const isGPT5Model = (model: string): ParsedOpenAIModelId | undefined => {
   return parsed;
 };
 
-const isNativeGPT5Model = (model: string): ParsedOpenAIModelId | undefined => {
+const isGPT5ResponsesEndpointModel = (model: string): ParsedOpenAIModelId | undefined => {
   const parsed = isGPT5Model(model);
-  if (!parsed || parsed.source !== 'openai') return;
+  if (!parsed || parsed.source === 'openRouter') return;
 
   return parsed;
 };
@@ -127,7 +150,7 @@ const hasModifier = (parsed: ParsedOpenAIModelId, modifier: string): boolean =>
 const baseGPT5MiniResponsesModels = new Set(['gpt-5-mini', 'gpt-5-mini-2025-08-07']);
 
 export const isGPT5ResponsesModel = (model: string): boolean => {
-  const parsed = isNativeGPT5Model(model);
+  const parsed = isGPT5ResponsesEndpointModel(model);
   if (!parsed) return false;
 
   if (hasModifier(parsed, 'chat')) return false;
@@ -141,12 +164,12 @@ export const isResponsesAPIModel = (model: string): boolean =>
   responsesAPIModels.has(model) || isGPT5ResponsesModel(model);
 
 export const isGPT5ProResponsesModel = (model: string): boolean => {
-  const parsed = isNativeGPT5Model(model);
+  const parsed = isGPT5ResponsesEndpointModel(model);
   return !!parsed && hasModifier(parsed, 'pro');
 };
 
 export const supportsGPT5ResponsesReasoningEffortNone = (model: string): boolean => {
-  const parsed = isNativeGPT5Model(model);
+  const parsed = isGPT5ResponsesEndpointModel(model);
   if (!parsed || parsed.minorVersion === undefined) return false;
 
   return !hasModifier(parsed, 'pro');


### PR DESCRIPTION
Normalize `codex/gpt-*` model IDs as an explicit Codex source so GPT-5.6 models use the Responses API reasoning payload rules. This prevents unsupported sampling parameters such as `temperature` from reaching Codex-compatible gateways.

#### Key Decisions / Non-goals

- Keep `codex/` distinct from OpenRouter's `openai/` namespace so existing OpenRouter routing behavior remains unchanged.
- Reuse the existing GPT model parser and reasoning payload pruning instead of stripping sampling parameters from every Responses API request.
- This change does not alter provider configuration, model mappings, or non-Codex model IDs.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check lobehub/packages/model-runtime/src/providers/openai/modelId.ts lobehub/packages/model-runtime/src/providers/openai/modelId.test.ts lobehub/packages/model-runtime/src/providers/openai/index.test.ts --lint --test --type
```

Result: 51 tests passed; lint and types are clean.

#### 🔗 Related Issue

Fixes #17831
