### PR TITLE
💄 style: drop the desktop title bar tint and lower the home nav header layer

### DIFF
--- a/src/features/Electron/titlebar/TitleBar.tsx
+++ b/src/features/Electron/titlebar/TitleBar.tsx
@@ -1,7 +1,6 @@
 import { TITLE_BAR_HEIGHT } from '@lobechat/desktop-bridge';
 import { Flexbox } from '@lobehub/ui';
 import { Divider } from 'antd';
-import { createStaticStyles, cx } from 'antd-style';
 import { memo } from 'react';
 
 import { electronStylish } from '@/styles/electron';
@@ -18,20 +17,6 @@ import WinControl from './WinControl';
 
 const platform = getPlatform();
 
-// A translucent tint rather than a solid color: the desktop body is deliberately
-// semi-transparent for vibrancy, and an opaque titlebar would kill it. The tint only
-// needs to push the bar a step away from the opaque content card so the attached
-// active tab reads as part of the card.
-const styles = createStaticStyles(({ css }) => ({
-  bar: css`
-    background-color: rgb(0 0 0 / 4%);
-
-    html[data-theme='dark'] & {
-      background-color: rgb(0 0 0 / 20%);
-    }
-  `,
-}));
-
 const TitleBar = memo(() => {
   useWatchThemeUpdate();
 
@@ -41,7 +26,7 @@ const TitleBar = memo(() => {
     <Flexbox
       horizontal
       align={'center'}
-      className={cx(electronStylish.draggable, styles.bar)}
+      className={electronStylish.draggable}
       height={TITLE_BAR_HEIGHT}
       justify={'space-between'}
       style={{ minHeight: TITLE_BAR_HEIGHT, padding }}

--- a/src/features/Home/HomeNavHeader.tsx
+++ b/src/features/Home/HomeNavHeader.tsx
@@ -14,7 +14,7 @@ import RailToggle from './RailToggle';
 const styles = createStaticStyles(({ css }) => ({
   header: css`
     position: absolute;
-    z-index: 10;
+    z-index: 1;
     inset-block-start: 0;
     inset-inline: 0;
   `,


### PR DESCRIPTION
Two small chrome-layering tweaks that follow up on #17809 and #17781.

- **Desktop title bar** — remove the translucent tint added in #17809. The desktop body is deliberately semi-transparent for vibrancy, and the tint made the bar read as a separate opaque strip instead of blending with the window material. The bar is now transparent again; only `electronStylish.draggable` remains on it.
- **Home nav header** — lower `z-index` from `10` to `1`, matching the home rail. The header no longer wins the stacking contest against the dashboard content, so the rail and the portrait bubble from #17781 can layer over it instead of being covered.

| Before | After |
| ------ | ----- |
| Tinted title bar strip; nav header always painted on top of home content | Title bar blends with the window vibrancy; home content layers over the nav header |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Pure CSS change — no logic touched. `bun run check` on both files: lint clean, no related tests.

#### 🔗 Related Issue

Related to #17809, #17781