### PR TITLE
💄 style(desktop): let pinned tabs travel, and tidy the tab chrome

### DIFF
--- a/src/features/Electron/titlebar/TabBar/TabItem.tsx
+++ b/src/features/Electron/titlebar/TabBar/TabItem.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useSortable } from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
 import {
   ActionIcon,
   Avatar,
@@ -14,7 +13,7 @@ import { cx } from 'antd-style';
 import { X } from 'lucide-react';
 import { useMotionValue, useSpring } from 'motion/react';
 import * as m from 'motion/react-m';
-import { memo, useCallback, useEffect } from 'react';
+import { memo, useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { electronStylish } from '@/styles/electron';
@@ -22,31 +21,28 @@ import { electronStylish } from '@/styles/electron';
 import { type ResolvedTab } from './hooks/useResolvedTabs';
 import { useTabRunning } from './hooks/useTabRunning';
 import { useTabUnread } from './hooks/useTabUnread';
+import { TAB_SPRING } from './motion';
 import { useStyles } from './styles';
 import { buildTabContextMenuItems } from './tabContextMenu';
 import { type TabTier } from './tabLayout';
 
-// Width is driven by a spring rather than a CSS transition: tab widths are a layout
-// response — several tabs resize at once whenever one is activated, added or closed —
-// and a spring both settles more naturally and is interruptible, so rapid switching
-// redirects the motion instead of restarting a fixed 180ms ramp.
-//
-// Only `width` is animated here. dnd-kit owns `transform`/`transition` on the same
-// element (and inline style beats any class-level declaration), so background-color
-// keeps its own CSS transition composed alongside dnd-kit's below.
-// restDelta of half a pixel: without it the spring keeps ticking rAF long after the
-// motion is visually over (measured still 0.1px short at 425ms), which costs a frame
-// callback per tab for nothing.
-const WIDTH_SPRING = {
-  damping: 26,
-  mass: 0.4,
-  restDelta: 0.5,
-  restSpeed: 2,
-  stiffness: 380,
-} as const;
-const BACKGROUND_MOTION = 'background-color 0.15s var(--ant-motion-ease-in-out)';
+// 20px box on an 8px-round tab, inset a uniform 3px: 8 - 3 = 5 keeps the button's curve
+// concentric with the tab's own. ActionIcon writes blockSize and borderRadius straight
+// into its inline style, so a class cannot reach them — but it spreads `style` last.
+// `size` stays "small" for the glyph: passing the {blockSize, borderRadius} object form
+// sends the same object to Icon's own calcSize, which reads `size` off it, misses, and
+// falls back to a 24px glyph inside the 20px box.
+const CLOSE_BUTTON_STYLE = { borderRadius: 5, height: 20, width: 20 } as const;
 
 interface TabItemProps {
+  /**
+   * Where the tab's offset spring starts on the very first render — the strip's previous
+   * total width, i.e. the point a newly opened tab is appended at. Seeding it at the
+   * target instead would drop the tab straight onto its final offset while its
+   * neighbours are still shrinking into place, so the two would overlap by a full tab
+   * width and take the whole settle to pull apart.
+   */
+  enterX: number;
   index: number;
   isActive: boolean;
   item: ResolvedTab;
@@ -60,6 +56,7 @@ interface TabItemProps {
   tier: TabTier;
   totalCount: number;
   width: number;
+  x: number;
 }
 
 const TabItem = memo<TabItemProps>(
@@ -71,6 +68,8 @@ const TabItem = memo<TabItemProps>(
     tier,
     totalCount,
     width,
+    x,
+    enterX,
     onActivate,
     onClose,
     onCloseOthers,
@@ -86,26 +85,45 @@ const TabItem = memo<TabItemProps>(
     const isUnread = useTabUnread(tab);
     const showUnreadDot = !isRunning && isUnread;
     const pinned = !!tab.pinned;
-    const iconOnly = tier === 'icon';
-    // The close button needs 22px of its own, and below the compact tier the tab cannot
-    // spare them: the title would be cut to a couple of glyphs to make room for a button
-    // that is usually not even shown. Narrower tabs close by middle-click or the context
-    // menu instead. At icon width there is the further problem that the icon is the only
-    // identity signal left, so overlaying it would also change what a click does.
-    const closable = !pinned && totalCount > 1 && (tier === 'full' || tier === 'compact');
+    // Which tiers actually show the button is settled in CSS so that it can fade rather
+    // than unmount; a lone tab is the one case with no button to fade at all. Staying
+    // mounted below the compact tier would otherwise leave an invisible button in the
+    // focus order, so those tiers are made inert rather than merely transparent.
+    const closable = totalCount > 1;
+    const closeInert = tier !== 'full' && tier !== 'compact';
 
-    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    const { attributes, listeners, setNodeRef, transform, isDragging, isSorting } = useSortable({
       id,
     });
 
     // A newly opened tab springs out from zero rather than popping in at full width; the
     // motion value starts collapsed and is set to the real width on mount.
     const targetWidth = useMotionValue(0);
-    const springWidth = useSpring(targetWidth, WIDTH_SPRING);
+    const springWidth = useSpring(targetWidth, TAB_SPRING);
+    const targetX = useMotionValue(enterX);
+    const springX = useSpring(targetX, TAB_SPRING);
+    const wasSorting = useRef(false);
 
     useEffect(() => {
       targetWidth.set(width);
     }, [width, targetWidth]);
+
+    // Dropping a drag must jump, not animate. dnd-kit clears its transform in the same
+    // commit that the reordered store lands, and up to that frame the tab is already
+    // sitting at its new offset (springX at the old slot plus dnd-kit's displacement).
+    // Animating from there would send it back to where it was picked up and re-slide it.
+    useEffect(() => {
+      const settledFromDrag = wasSorting.current && !isSorting;
+      wasSorting.current = isSorting;
+
+      if (!settledFromDrag) {
+        targetX.set(x);
+        return;
+      }
+
+      targetX.jump(x);
+      springX.jump(x);
+    }, [x, isSorting, targetX, springX]);
 
     const handleClick = useCallback(() => {
       if (!isActive) {
@@ -186,16 +204,18 @@ const TabItem = memo<TabItemProps>(
         className={cx(
           electronStylish.nodrag,
           styles.tab,
+          pinned && styles.tabPinned,
           isActive && styles.tabActive,
           isDragging && styles.tabDragging,
         )}
         style={{
-          gap: iconOnly ? 0 : 6,
-          justifyContent: iconOnly ? 'center' : undefined,
-          transform: CSS.Translate.toString(transform),
-          transition: transition ? `${transition}, ${BACKGROUND_MOTION}` : BACKGROUND_MOTION,
+          // dnd-kit's displacement rides the standalone `translate` property while the
+          // offset spring owns `transform`. Both are pure x translations, so they
+          // compose, and neither has to be folded into the other's value.
+          translate: transform ? `${transform.x}px` : undefined,
           width: springWidth,
-          zIndex: isDragging ? 1 : undefined,
+          x: springX,
+          zIndex: isDragging ? 2 : pinned ? 1 : undefined,
         }}
         onAuxClick={handleAuxClick}
         onClick={handleClick}
@@ -203,30 +223,34 @@ const TabItem = memo<TabItemProps>(
         {...listeners}
       >
         {indicator}
-        {!iconOnly && (
-          <span data-tab-title className={styles.tabTitle}>
-            {meta.title}
-          </span>
-        )}
+        <span data-tab-title className={styles.tabTitle}>
+          {meta.title}
+        </span>
         {closable && (
           <ActionIcon
             data-tab-close
             className={styles.closeIcon}
             icon={X}
+            inert={closeInert}
             size="small"
+            style={CLOSE_BUTTON_STYLE}
             onClick={handleClose}
           />
         )}
       </m.div>
     );
 
-    // The Tooltip wraps unconditionally and opts out via an empty title. Swapping between
+    // The Tooltip wraps unconditionally and opts out through `disabled`. Swapping between
     // a wrapped and a bare node would remount the tab on every tier change — which is
-    // exactly when the width animates, so the new node would mount at its final width and
-    // the transition would never run.
+    // exactly when the width and offset animate, so the new node would mount at its final
+    // geometry and neither spring would ever run. An empty title is not an opt-out: the
+    // component only bails on a nullish one (`title == null`), so a full-width tab used to
+    // pop a blank bubble on hover.
     return (
       <ContextMenuTrigger items={contextMenuItems}>
-        <Tooltip title={tier === 'full' ? '' : meta.title}>{face}</Tooltip>
+        <Tooltip disabled={tier === 'full'} title={meta.title}>
+          {face}
+        </Tooltip>
       </ContextMenuTrigger>
     );
   },

--- a/src/features/Electron/titlebar/TabBar/index.tsx
+++ b/src/features/Electron/titlebar/TabBar/index.tsx
@@ -16,7 +16,9 @@ import { ActionIcon, Flexbox } from '@lobehub/ui';
 import { type DropdownItem, DropdownMenu } from '@lobehub/ui/base-ui';
 import { cx } from 'antd-style';
 import { ChevronDown, Plus } from 'lucide-react';
-import { useCallback, useMemo } from 'react';
+import { useMotionValue, useSpring } from 'motion/react';
+import * as m from 'motion/react-m';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
@@ -29,20 +31,22 @@ import { electronStylish } from '@/styles/electron';
 
 import { useResolvedTabs } from './hooks/useResolvedTabs';
 import { useStripWidth } from './hooks/useStripWidth';
+import { TAB_SPRING } from './motion';
 import { resolveTabScope } from './scope';
 import { useStyles } from './styles';
 import TabItem from './TabItem';
 import {
   allocateTabWidths,
   OVERFLOW_CONTROL_WIDTH,
+  PINNED_DIVIDER_WIDTH,
   PINNED_TAB_WIDTH,
+  resolvePlacements,
   resolveTabTier,
   TAB_GAP,
 } from './tabLayout';
 
 const NEW_TAB_URL = '/';
 const NEW_TAB_BUTTON_WIDTH = 26 + TAB_GAP;
-const PINNED_DIVIDER_WIDTH = 13;
 
 // Tabs only reorder along the horizontal axis, so lock the drag transform to X.
 const restrictToHorizontalAxis: Modifier = ({ transform }) => ({ ...transform, y: 0 });
@@ -86,6 +90,34 @@ const TabBar = () => {
       usableWidth: Math.max(0, stripWidth - pinnedWidth - NEW_TAB_BUTTON_WIDTH),
     });
   }, [flowTabs, pinnedTabs.length, activeTabId, stripWidth]);
+
+  const { dividerX, placements, total } = useMemo(
+    () =>
+      resolvePlacements({
+        flowIds: flowTabs.map((tab) => tab.tab.id),
+        pinnedIds: pinnedTabs.map((tab) => tab.tab.id),
+        visibleIndices: layout.visibleIndices,
+        widths: layout.widths,
+      }),
+    [flowTabs, pinnedTabs, layout],
+  );
+
+  const tabsById = useMemo(() => new Map(tabs.map((tab) => [tab.tab.id, tab])), [tabs]);
+
+  const targetTotal = useMotionValue(0);
+  const springTotal = useSpring(targetTotal, TAB_SPRING);
+  const targetDividerX = useMotionValue(dividerX);
+  const springDividerX = useSpring(targetDividerX, TAB_SPRING);
+
+  // Read during render, so it still holds the width the strip had on the previous commit
+  // — which is exactly where a tab appended this commit should enter from.
+  const previousTotal = useRef(0);
+
+  useEffect(() => {
+    targetTotal.set(total);
+    targetDividerX.set(dividerX);
+    previousTotal.current = total;
+  }, [total, dividerX, targetTotal, targetDividerX]);
 
   const newTabUrl = useMemo(() => {
     const scope = resolveTabScope(location.pathname + location.search);
@@ -188,25 +220,6 @@ const TabBar = () => {
 
   if (tabs.length === 0) return null;
 
-  const renderTab = (tab: (typeof tabs)[number], width: number) => (
-    <TabItem
-      index={tabIds.indexOf(tab.tab.id)}
-      isActive={tab.tab.id === activeTabId}
-      item={tab}
-      key={tab.tab.id}
-      pinnedCount={pinnedTabs.length}
-      tier={resolveTabTier(width)}
-      totalCount={tabs.length}
-      width={width}
-      onActivate={handleActivate}
-      onClose={handleClose}
-      onCloseLeft={handleCloseLeft}
-      onCloseOthers={handleCloseOthers}
-      onCloseRight={handleCloseRight}
-      onTogglePin={handleTogglePin}
-    />
-  );
-
   return (
     <Flexbox horizontal align={'center'} className={styles.container} gap={TAB_GAP} ref={stripRef}>
       <DndContext
@@ -216,11 +229,41 @@ const TabBar = () => {
         onDragEnd={handleDragEnd}
       >
         <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
-          {pinnedTabs.map((tab) => renderTab(tab, PINNED_TAB_WIDTH))}
-          {pinnedTabs.length > 0 && <span className={styles.pinnedDivider} />}
-          {layout.visibleIndices.map((tabIndex, position) =>
-            renderTab(flowTabs[tabIndex], layout.widths[position]),
-          )}
+          {/* One keyed list for pinned and flowing tabs alike. Rendering them as two
+              sibling arrays scoped their keys separately, so pinning unmounted the tab
+              from one and mounted a fresh one in the other — losing its springs, which
+              is why the tab used to pop rather than travel. */}
+          <m.div className={styles.strip} style={{ width: springTotal }}>
+            {placements.map((placement) => {
+              const tab = tabsById.get(placement.id);
+              if (!tab) return null;
+
+              return (
+                <TabItem
+                  enterX={previousTotal.current}
+                  index={tabIds.indexOf(placement.id)}
+                  isActive={placement.id === activeTabId}
+                  item={tab}
+                  key={placement.id}
+                  pinnedCount={pinnedTabs.length}
+                  tier={resolveTabTier(placement.width)}
+                  totalCount={tabs.length}
+                  width={placement.width}
+                  x={placement.x}
+                  onActivate={handleActivate}
+                  onClose={handleClose}
+                  onCloseLeft={handleCloseLeft}
+                  onCloseOthers={handleCloseOthers}
+                  onCloseRight={handleCloseRight}
+                  onTogglePin={handleTogglePin}
+                />
+              );
+            })}
+            <m.span
+              className={styles.pinnedDivider}
+              style={{ opacity: pinnedTabs.length > 0 ? 1 : 0, x: springDividerX }}
+            />
+          </m.div>
         </SortableContext>
       </DndContext>
       <ActionIcon

--- a/src/features/Electron/titlebar/TabBar/motion.ts
+++ b/src/features/Electron/titlebar/TabBar/motion.ts
@@ -1,0 +1,21 @@
+/**
+ * Width and offset are driven by springs rather than CSS transitions: both are layout
+ * responses — several tabs resize and shift at once whenever one is activated, added,
+ * closed or pinned — and a spring both settles more naturally and is interruptible, so
+ * rapid switching redirects the motion instead of restarting a fixed ramp.
+ *
+ * Every animated quantity in the strip shares this one config on purpose. Same-parameter
+ * springs superpose, which is what makes a tab's independently sprung x trace the same
+ * path as the running sum of its neighbours' sprung widths — see `resolvePlacements`.
+ *
+ * restDelta of half a pixel: without it the spring keeps ticking rAF long after the
+ * motion is visually over (measured still 0.1px short at 425ms), which costs a frame
+ * callback per tab for nothing.
+ */
+export const TAB_SPRING = {
+  damping: 26,
+  mass: 0.4,
+  restDelta: 0.5,
+  restSpeed: 2,
+  stiffness: 380,
+} as const;

--- a/src/features/Electron/titlebar/TabBar/styles.ts
+++ b/src/features/Electron/titlebar/TabBar/styles.ts
@@ -9,8 +9,10 @@ export const useStyles = createStaticStyles(({ css, cssVar }) => ({
     line-height: 0;
   `,
   closeIcon: css`
+    pointer-events: none;
+
     position: absolute;
-    inset-inline-end: 4px;
+    inset-inline-end: 3px;
 
     flex-shrink: 0;
 
@@ -53,14 +55,25 @@ export const useStyles = createStaticStyles(({ css, cssVar }) => ({
     flex: 1;
     min-width: 0;
   `,
+  // Tabs are absolutely positioned inside this box so that pinning can spring a tab
+  // across to its new slot; a flex reorder could only teleport it. The box tracks the
+  // strip's own width so the trailing "+" follows the tabs instead of jumping.
+  strip: css`
+    position: relative;
+    flex: none;
+    height: ${TAB_HEIGHT}px;
+  `,
   tab: css`
     cursor: default;
     user-select: none;
 
-    position: relative;
+    position: absolute;
+    inset-block-start: 0;
+    inset-inline-start: 0;
 
     display: flex;
     flex-shrink: 0;
+    gap: 6px;
     align-items: center;
 
     height: ${TAB_HEIGHT}px;
@@ -71,37 +84,71 @@ export const useStyles = createStaticStyles(({ css, cssVar }) => ({
 
     background-color: transparent;
 
-    /* No transition here: dnd-kit writes its own into the inline style, which would win
-       over anything declared in this class. TabItem composes both. */
+    transition: background-color 0.15s ${cssVar.motionEaseInOut};
 
     &:hover {
       background-color: ${cssVar.colorFillQuaternary};
     }
 
-    /* Persistent on a full tab, hover-only on a compact one. Narrower tiers carry no
-       close button at all — see TabItem. */
+    /* Persistent on a full tab, hover-only on a compact one. Below that the tab cannot
+       spare the button's 20px: the title would be cut to a couple of glyphs to make room
+       for it, and at icon width the icon is the only identity signal left. Pinned tabs
+       are always at icon width, so they fall out of this rule too. The button stays
+       mounted at every tier and fades — unmounting it made it vanish mid-pin. */
     &[data-tier='full'] [data-tab-close],
-    &:hover [data-tab-close] {
+    &[data-tier='compact']:hover [data-tab-close] {
+      pointer-events: auto;
       opacity: 1;
     }
 
     /* Reserve the button's footprint whether or not it is currently visible, so the
-       title's ellipsis lands before it. Fading the title out under the button instead
-       leaves half-opaque glyphs inside the gradient, which reads as an overlap. Keeping
-       the reservation constant also stops the text reflowing on hover. */
+       title's fade lands before it and no glyph is ever drawn under the button. Margin
+       rather than padding: the mask applies to the padding box, so padding would put the
+       gradient inside the reservation instead of at the text's edge. Keeping the
+       reservation constant also stops the text reflowing on hover.
+       20px button + 3px inset - the tab's own 6px end padding. */
     &[data-tier='full'] [data-tab-title],
     &[data-tier='compact'] [data-tab-title] {
-      padding-inline-end: 22px;
+      margin-inline-end: 17px;
+    }
+
+    /* The avatar is the only thing left, so centre it and collapse the title rather than
+       unmounting it — the tab is mid-shrink at this point and a title that pops out of
+       the flow would jerk the avatar sideways instead of gliding it to the middle. */
+    &[data-tier='icon'] {
+      gap: 0;
+      justify-content: center;
+      padding-inline: 0;
+
+      [data-tab-title] {
+        flex: none;
+        width: 0;
+        opacity: 0;
+      }
     }
   `,
   pinnedDivider: css`
-    align-self: center;
+    position: absolute;
+    inset-block-start: 4px;
+    inset-inline-start: 0;
 
     width: 1px;
     height: 18px;
-    margin-inline: 6px;
 
     background-color: ${cssVar.colorBorder};
+
+    transition: opacity 0.18s ${cssVar.motionEaseInOut};
+  `,
+  // A pinned tab renders at icon width, which is pixel-identical to an unpinned tab
+  // squeezed by a crowded strip — the surface is what tells the two apart. Declared
+  // ahead of `tabActive` so that an active pinned tab still reads as active:
+  // createStaticStyles settles equal specificity by definition order.
+  tabPinned: css`
+    background-color: ${cssVar.colorFillQuaternary};
+
+    &:hover {
+      background-color: ${cssVar.colorFillTertiary};
+    }
   `,
   overflowButton: css`
     cursor: default;
@@ -158,8 +205,15 @@ export const useStyles = createStaticStyles(({ css, cssVar }) => ({
 
     font-size: 12px;
     color: ${cssVar.colorText};
-    text-overflow: ellipsis;
     white-space: nowrap;
+
+    transition: opacity 0.12s ${cssVar.motionEaseInOut};
+
+    /* The one physical direction left in this file — mask-image has no logical form, and
+       nothing in the app sets dir="rtl". max(60%, …) caps the ramp at 40% of the box:
+       a narrow tab leaves the title barely 22px to live in, and a flat 20px ramp would
+       swallow the whole word rather than trailing it off. */
+    mask-image: linear-gradient(to right, #000 max(60%, calc(100% - 20px)), transparent);
   `,
   newTabButton: css`
     display: inline-flex;

--- a/src/features/Electron/titlebar/TabBar/tabLayout.test.ts
+++ b/src/features/Electron/titlebar/TabBar/tabLayout.test.ts
@@ -6,6 +6,10 @@ import {
   MAX_TAB_WIDTH,
   MIN_TAB_WIDTH,
   OVERFLOW_CONTROL_WIDTH,
+  PINNED_DIVIDER_MARGIN,
+  PINNED_DIVIDER_WIDTH,
+  PINNED_TAB_WIDTH,
+  resolvePlacements,
   resolveTabTier,
   TAB_GAP,
 } from './tabLayout';
@@ -181,5 +185,87 @@ describe('allocateTabWidths', () => {
 
     expect(widths).toEqual([MAX_TAB_WIDTH, MAX_TAB_WIDTH]);
     expect(totalWidth(widths)).toBeLessThan(900);
+  });
+});
+
+describe('resolvePlacements', () => {
+  it('returns nothing for an empty strip', () => {
+    expect(
+      resolvePlacements({ flowIds: [], pinnedIds: [], visibleIndices: [], widths: [] }),
+    ).toEqual({ dividerX: PINNED_DIVIDER_MARGIN, placements: [], total: 0 });
+  });
+
+  it('lays flowing tabs out end to end with one gap between them', () => {
+    const { placements, total } = resolvePlacements({
+      flowIds: ['a', 'b', 'c'],
+      pinnedIds: [],
+      visibleIndices: [0, 1, 2],
+      widths: [120, 80, 60],
+    });
+
+    expect(placements).toEqual([
+      { id: 'a', pinned: false, width: 120, x: 0 },
+      { id: 'b', pinned: false, width: 80, x: 122 },
+      { id: 'c', pinned: false, width: 60, x: 204 },
+    ]);
+    // Trailing gap excluded: the strip ends at the last tab's right edge, and the
+    // container's own flex gap supplies the space before the "+".
+    expect(total).toBe(264);
+  });
+
+  it('leads with the pinned run and clears the divider before the flowing tabs', () => {
+    const { dividerX, placements, total } = resolvePlacements({
+      flowIds: ['c'],
+      pinnedIds: ['a', 'b'],
+      visibleIndices: [0],
+      widths: [100],
+    });
+
+    const runEnd = 2 * (PINNED_TAB_WIDTH + TAB_GAP);
+
+    expect(placements).toEqual([
+      { id: 'a', pinned: true, width: PINNED_TAB_WIDTH, x: 0 },
+      { id: 'b', pinned: true, width: PINNED_TAB_WIDTH, x: PINNED_TAB_WIDTH + TAB_GAP },
+      { id: 'c', pinned: false, width: 100, x: runEnd + PINNED_DIVIDER_WIDTH },
+    ]);
+    expect(dividerX).toBe(runEnd + PINNED_DIVIDER_MARGIN);
+    expect(total).toBe(runEnd + PINNED_DIVIDER_WIDTH + 100);
+  });
+
+  it('reserves no divider room when nothing is pinned', () => {
+    const { placements } = resolvePlacements({
+      flowIds: ['a'],
+      pinnedIds: [],
+      visibleIndices: [0],
+      widths: [100],
+    });
+
+    expect(placements[0].x).toBe(0);
+  });
+
+  // The width split can promote a tab past the visible cut, so `visibleIndices` is not
+  // always 0..n — placements must follow it rather than the flow order.
+  it('follows the visible indices when the active tab is held past the cut', () => {
+    const { placements } = resolvePlacements({
+      flowIds: ['a', 'b', 'c', 'd'],
+      pinnedIds: [],
+      visibleIndices: [0, 3],
+      widths: [40, 150],
+    });
+
+    expect(placements.map((placement) => placement.id)).toEqual(['a', 'd']);
+    expect(placements[1].x).toBe(42);
+  });
+
+  it('skips an index that no longer resolves to a tab', () => {
+    const { placements, total } = resolvePlacements({
+      flowIds: ['a'],
+      pinnedIds: [],
+      visibleIndices: [0, 1],
+      widths: [100, 100],
+    });
+
+    expect(placements).toEqual([{ id: 'a', pinned: false, width: 100, x: 0 }]);
+    expect(total).toBe(100);
   });
 });

--- a/src/features/Electron/titlebar/TabBar/tabLayout.ts
+++ b/src/features/Electron/titlebar/TabBar/tabLayout.ts
@@ -4,6 +4,8 @@ export const ACTIVE_TAB_MIN_WIDTH = 150;
 export const PINNED_TAB_WIDTH = 34;
 export const TAB_GAP = 2;
 export const OVERFLOW_CONTROL_WIDTH = 34;
+export const PINNED_DIVIDER_MARGIN = 6;
+export const PINNED_DIVIDER_WIDTH = PINNED_DIVIDER_MARGIN * 2 + 1;
 
 export type TabTier = 'compact' | 'full' | 'icon' | 'narrow';
 
@@ -124,4 +126,64 @@ export const allocateTabWidths = ({
 
   const last = attemptLayout(1, budget, count, activeIndex);
   return { hiddenCount: count - 1, visibleIndices: last.indices, widths: last.widths };
+};
+
+export interface TabPlacement {
+  id: string;
+  pinned: boolean;
+  width: number;
+  x: number;
+}
+
+export interface TabPlacementInput {
+  /** Ids of the unpinned tabs, in store order. */
+  flowIds: string[];
+  /** Ids of the pinned tabs, in store order — they always lead the strip. */
+  pinnedIds: string[];
+  visibleIndices: number[];
+  widths: number[];
+}
+
+export interface TabPlacementResult {
+  dividerX: number;
+  placements: TabPlacement[];
+  total: number;
+}
+
+/**
+ * Turns the width allocation into absolute offsets. Tabs are positioned rather than laid
+ * out by flex because pinning reorders the strip, and a flex reorder can only teleport:
+ * an explicit x is what lets the moved tab spring across to its new slot.
+ *
+ * Offsets are derived from the target widths, not the animated ones. Same-parameter
+ * springs superpose, so a tab springing its own x traces the identical path as summing
+ * the neighbours' springing widths would — no per-frame layout pass needed.
+ */
+export const resolvePlacements = ({
+  flowIds,
+  pinnedIds,
+  visibleIndices,
+  widths,
+}: TabPlacementInput): TabPlacementResult => {
+  const placements: TabPlacement[] = [];
+  let x = 0;
+
+  for (const id of pinnedIds) {
+    placements.push({ id, pinned: true, width: PINNED_TAB_WIDTH, x });
+    x += PINNED_TAB_WIDTH + TAB_GAP;
+  }
+
+  const dividerX = x + PINNED_DIVIDER_MARGIN;
+  if (pinnedIds.length > 0) x += PINNED_DIVIDER_WIDTH;
+
+  visibleIndices.forEach((index, position) => {
+    const id = flowIds[index];
+    if (id === undefined) return;
+
+    const width = widths[position];
+    placements.push({ id, pinned: false, width, x });
+    x += width + TAB_GAP;
+  });
+
+  return { dividerX, placements, total: Math.max(0, x - TAB_GAP) };
 };


### PR DESCRIPTION
Pinning a desktop tab used to teleport it. The pinned run and the flowing run were rendered as **two sibling arrays**, so React keys did not carry across them — pinning unmounted the tab from one list and mounted a fresh one in the other, losing its springs. Both runs now render from a single keyed list inside a positioned strip, and every tab carries an offset spring alongside its width spring, so a pinned tab slides to its slot while it shrinks.

Offsets come from a new pure `resolvePlacements`, computed off the *target* widths rather than the animated ones. Same-parameter springs superpose, so a tab's own sprung offset traces the same path as summing its neighbours' sprung widths would — no per-frame layout pass or DOM measurement needed. Every animated quantity in the strip shares one spring config for exactly that reason.

Two implementation notes for reviewers:

- **dnd-kit composition.** Its displacement rides the standalone CSS `translate` property while the offset spring owns `transform`. Both are pure x translations, so they compose and neither has to be folded into the other. Verified against `framer-motion@12.43.0` that bare `translate` is not in its transform-prop list.
- **Drops must jump, not animate.** dnd-kit clears its transform in the same commit the reordered store lands, and by then the tab already sits at its new offset. Animating from there would fling it back to the pickup point and re-slide it.

Also in the strip chrome:

- Close button is 20×20 at radius 5, inset a uniform 3px, so its curve is concentric with the tab's own 8px corner.
- Titles fade out under a mask gradient instead of `text-overflow: ellipsis`. The ramp is capped at 40% of the box so a `narrow` tab, whose title has barely 22px to live in, keeps a readable head.
- Pinned tabs carry a persistent surface — at icon width they were otherwise pixel-identical to a tab merely squeezed by a crowded strip.
- Title and close button now fade rather than unmount when a tab reaches icon width, so pinning does not make them blink out mid-travel. Below the compact tier the close button is `inert`, so keeping it mounted does not leave an invisible button in the focus order.
- **Bug fix:** a blank tooltip on full-width tabs. The opt-out passed an empty title, but the component only bails on a nullish one (`title == null`), so it built a real bubble with nothing in it. Now uses `disabled`, which keeps the element tree stable across tier changes — conditionally rendering the wrapper would reintroduce the remount this component is built to avoid.

Closing a middle tab now slides its neighbours over instead of snapping them.

| Before | After |
| ------ | ----- |
| Pinning pops: the tab vanishes from its slot and reappears collapsed at the head; blank tooltip on hover | Pinning travels: the tab slides left while shrinking, title and close button cross-fade, divider expands |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`resolvePlacements` has 7 new unit tests covering the pinned run, divider reservation, and the non-obvious case that `visibleIndices` is not always `0..n` because the active tab gets held past the visible cut. All 95 TabBar tests pass; lint clean; the full type-check sits at 35 errors both with and without this change (all pre-existing, from the duplicate `@types/react` between root and `apps/desktop`).

Motion was designed against an interactive prototype running the real spring integrator before any of it was written into the component.

**Worth a reviewer's eye on real hardware:** the dark-mode pinned surface is `colorFillQuaternary` (`rgba(255,255,255,.04)` on a black titlebar) — it may want an inset border instead. Separately, `animationMode: 'disabled'` is still not respected by the strip; that gap predates this PR but matters more now that there is roughly three times as much motion.

#### 🔗 Related Issue

None found.