### PR TITLE
🐛 fix(chat): persist topic-pinned model on assistant message instead of agent default

### DIFF
--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
@@ -1396,6 +1396,77 @@ describe('ConversationLifecycle actions', () => {
         );
       });
 
+      it('should persist the topic-pinned model on the assistant message, not the agent default', async () => {
+        const { result } = renderHook(() => useChatStore());
+        const agentId = TEST_IDS.SESSION_ID;
+        const topicId = TEST_IDS.TOPIC_ID;
+        const topicKey = topicMapKey({ agentId });
+        const topicModel = 'claude-opus-5';
+        const topicProvider = 'anthropic';
+
+        act(() => {
+          useChatStore.setState({
+            activeAgentId: agentId,
+            activeTopicId: topicId,
+            executeClientAgent: vi.fn().mockResolvedValue(undefined),
+            topicDataMap: {
+              [topicKey]: {
+                currentPage: 0,
+                hasMore: false,
+                isExpandingPageSize: false,
+                isLoadingMore: false,
+                items: [
+                  {
+                    createdAt: 0,
+                    id: topicId,
+                    model: topicModel,
+                    provider: topicProvider,
+                    title: 'pinned topic',
+                    updatedAt: 0,
+                  },
+                ],
+                pageSize: 20,
+                total: 1,
+              },
+            },
+          });
+        });
+
+        const sendMessageInServerSpy = vi
+          .spyOn(aiChatService, 'sendMessageInServer')
+          .mockResolvedValue({
+            assistantMessageId: TEST_IDS.ASSISTANT_MESSAGE_ID,
+            messages: [
+              createMockMessage({ id: TEST_IDS.USER_MESSAGE_ID, role: 'user', topicId }),
+              createMockMessage({
+                id: TEST_IDS.ASSISTANT_MESSAGE_ID,
+                model: topicModel,
+                provider: topicProvider,
+                role: 'assistant',
+                topicId,
+              }),
+            ],
+            userMessageId: TEST_IDS.USER_MESSAGE_ID,
+          } as any);
+
+        await act(async () => {
+          await result.current.sendMessage({
+            context: { agentId, threadId: null, topicId },
+            message: TEST_CONTENT.USER_MESSAGE,
+          });
+        });
+
+        expect(sendMessageInServerSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            newAssistantMessage: expect.objectContaining({
+              model: topicModel,
+              provider: topicProvider,
+            }),
+          }),
+          expect.any(AbortController),
+        );
+      });
+
       it('should stop the sidebar spinner after a gateway send creates the topic', async () => {
         const { result } = renderHook(() => useChatStore());
         const agentId = TEST_IDS.SESSION_ID;

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -1604,9 +1604,16 @@ export class ConversationLifecycleActionImpl {
 
     try {
       throwIfSendAborted(signal);
-      const { model, provider } = agentSelectors.getAgentConfigById(agentId)(getAgentStoreState());
-
       const topicId = operationContext.topicId;
+      // Mirror generation (`internal_createAgentState`): the topic pins its own
+      // model, otherwise the agent default. Writing the agent default here left
+      // the Usage card showing a stale model after a per-topic switch, while the
+      // request already ran on the topic's model.
+      const topicModel = topicId
+        ? topicSelectors.getTopicModelById(topicId)(this.#get())
+        : undefined;
+      const { model, provider } =
+        topicModel ?? agentSelectors.getAgentConfigById(agentId)(getAgentStoreState());
 
       // Persist selected skill/tool context into user message content so it survives across turns.
       // Deduplicate: skip skills/tools already @mentioned in earlier messages (via editorData).


### PR DESCRIPTION

目前聊天页返回消息底部可能仍然显示助手级模型名，而非选取的话题级模型名。本 pr 尝试修复该问题。

<img width="763" height="37" alt="image" src="https://github.com/user-attachments/assets/e9201c7d-3092-4d1c-992f-7a37b43723fc" />


-----

<!-- Brief and heads-up -->

<!-- If this PR includes UI changes, please provide screenshots or videos. -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### Test

<!-- How you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->
