### PR TITLE
💄 style(portal): let each portal view remember its own width

### DIFF
--- a/packages/const/src/layoutTokens.ts
+++ b/packages/const/src/layoutTokens.ts
@@ -14,6 +14,11 @@ export const CHAT_PORTAL_MAX_WIDTH = 1280;
 export const CHAT_PORTAL_TOOL_UI_WIDTH = 600;
 /** For portal views that read as a document (acceptance report, evidence, screenshots) */
 export const CHAT_PORTAL_WIDE_WIDTH = 840;
+/**
+ * Width the conversation column needs to stay usable next to an open portal.
+ * Below this the working sidebar yields, leaving conversation + portal.
+ */
+export const CONVERSATION_KEEP_WIDTH = 420;
 
 export const MARKET_SIDEBAR_WIDTH = 400;
 export const FOLDER_WIDTH = 270;

--- a/packages/const/src/layoutTokens.ts
+++ b/packages/const/src/layoutTokens.ts
@@ -12,6 +12,8 @@ export const CONVERSATION_MIN_WIDTH = 960;
 export const CHAT_PORTAL_WIDTH = 400;
 export const CHAT_PORTAL_MAX_WIDTH = 1280;
 export const CHAT_PORTAL_TOOL_UI_WIDTH = 600;
+/** For portal views that read as a document (acceptance report, evidence, screenshots) */
+export const CHAT_PORTAL_WIDE_WIDTH = 840;
 
 export const MARKET_SIDEBAR_WIDTH = 400;
 export const FOLDER_WIDTH = 270;

--- a/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
+++ b/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
@@ -86,6 +86,8 @@ const globalStore = vi.hoisted(() => ({
   toggleTerminalPanel: vi.fn(),
   setWorkingSidebarTab: vi.fn(),
   status: {
+    portalWidth: 400 as number | undefined,
+    portalWidths: undefined as Record<string, number> | undefined,
     showRightPanel: true,
     workingSidebarTab: 'params' as string | undefined,
     workingSidebarTabRequest: undefined as { nonce: number; tab: string } | undefined,
@@ -168,6 +170,8 @@ vi.mock('@/store/global', () => ({
 }));
 vi.mock('@/store/global/selectors', () => ({
   systemStatusSelectors: {
+    portalWidth: (s: typeof globalStore) => s.status.portalWidth || 400,
+    portalWidths: (s: typeof globalStore) => s.status.portalWidths,
     workingSidebarWidth: (s: typeof globalStore) => s.status.workingSidebarWidth || 360,
   },
 }));

--- a/src/features/Conversation/WorkingSidebar/fitsBesidePortal.test.ts
+++ b/src/features/Conversation/WorkingSidebar/fitsBesidePortal.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { CHAT_PORTAL_WIDE_WIDTH, CHAT_PORTAL_WIDTH } from '@/const/layoutTokens';
+
+import { fitsBesidePortal } from './fitsBesidePortal';
+
+const SIDEBAR = 360;
+
+describe('fitsBesidePortal', () => {
+  it('keeps the sidebar until the row has been measured', () => {
+    expect(fitsBesidePortal({ portalWidth: CHAT_PORTAL_WIDE_WIDTH, sidebarWidth: SIDEBAR })).toBe(
+      true,
+    );
+    expect(
+      fitsBesidePortal({
+        availableWidth: 0,
+        portalWidth: CHAT_PORTAL_WIDE_WIDTH,
+        sidebarWidth: SIDEBAR,
+      }),
+    ).toBe(true);
+  });
+
+  it('yields the sidebar when a wide portal would squeeze the conversation out', () => {
+    // the reported regression: 1200px window, acceptance portal at 840
+    expect(
+      fitsBesidePortal({
+        availableWidth: 1182,
+        portalWidth: CHAT_PORTAL_WIDE_WIDTH,
+        sidebarWidth: SIDEBAR,
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps all three when the row is wide enough', () => {
+    expect(
+      fitsBesidePortal({
+        availableWidth: 1710,
+        portalWidth: CHAT_PORTAL_WIDE_WIDTH,
+        sidebarWidth: SIDEBAR,
+      }),
+    ).toBe(true);
+  });
+
+  it('leaves the sidebar alone while the portal is closed', () => {
+    expect(fitsBesidePortal({ availableWidth: 1182, portalWidth: 0, sidebarWidth: SIDEBAR })).toBe(
+      true,
+    );
+  });
+
+  it('still fits a narrow portal at the same row width that a wide one does not', () => {
+    expect(
+      fitsBesidePortal({
+        availableWidth: 1182,
+        portalWidth: CHAT_PORTAL_WIDTH,
+        sidebarWidth: SIDEBAR,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/features/Conversation/WorkingSidebar/fitsBesidePortal.ts
+++ b/src/features/Conversation/WorkingSidebar/fitsBesidePortal.ts
@@ -1,0 +1,29 @@
+import { CONVERSATION_KEEP_WIDTH } from '@/const/layoutTokens';
+
+interface FitsBesidePortalParams {
+  /** measured width of the row holding conversation + portal + sidebar */
+  availableWidth?: number;
+  /** 0 when the portal is closed */
+  portalWidth: number;
+  sidebarWidth: number;
+}
+
+/**
+ * The conversation, the portal and the working sidebar share one row. A wide
+ * portal (an acceptance report opens at 840) plus the sidebar can consume the
+ * whole row and leave the conversation at zero width, so the sidebar yields
+ * first: keeping conversation + portal beats keeping all three.
+ *
+ * Returns true while all three fit — before the row has been measured too, so
+ * the first paint matches the user's own `showRightPanel` preference instead of
+ * flashing the sidebar away.
+ */
+export const fitsBesidePortal = ({
+  availableWidth,
+  portalWidth,
+  sidebarWidth,
+}: FitsBesidePortalParams): boolean => {
+  if (!availableWidth) return true;
+
+  return availableWidth - portalWidth - sidebarWidth >= CONVERSATION_KEEP_WIDTH;
+};

--- a/src/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/index.tsx
@@ -41,6 +41,7 @@ import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspace
 import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import { isDesktop } from '@/const/version';
 import { useRepoType } from '@/features/ChatInput/ControlBar/useRepoType';
+import { getPortalViewWidth } from '@/features/Portal/portalWidth';
 import TopicCommentsSidebar from '@/features/Portal/TopicComments/Sidebar';
 import RightPanel from '@/features/RightPanel';
 import { resolveTargetDeviceId } from '@/helpers/agentWorkingDirectory';
@@ -62,6 +63,7 @@ import { useUserStore } from '@/store/user';
 import { labPreferSelectors } from '@/store/user/selectors';
 
 import Files from './Files';
+import { fitsBesidePortal } from './fitsBesidePortal';
 import Overview from './Overview';
 import ResourcesSection from './ResourcesSection';
 import Review from './Review';
@@ -155,10 +157,20 @@ const BROWSER_TAB_KEY = 'browser';
 const BROWSER_TAB_PREFIX = 'browser:';
 const isBrowserTab = (tab: string) => tab === BROWSER_TAB_KEY || tab.startsWith(BROWSER_TAB_PREFIX);
 
-const AgentWorkingSidebar = memo(() => {
+interface AgentWorkingSidebarProps {
+  /**
+   * Measured width of the row this sidebar shares with the conversation and the
+   * portal. Undefined until the layout has measured it.
+   */
+  availableWidth?: number;
+}
+
+const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) => {
   const { t } = useTranslation(['chat', 'setting']);
   const [
     storedWidth,
+    legacyPortalWidth,
+    portalWidths,
     updateSystemStatus,
     toggleRightPanel,
     toggleTerminalPanel,
@@ -168,6 +180,8 @@ const AgentWorkingSidebar = memo(() => {
     tabRequest,
   ] = useGlobalStore((s) => [
     systemStatusSelectors.workingSidebarWidth(s),
+    systemStatusSelectors.portalWidth(s),
+    systemStatusSelectors.portalWidths(s),
     s.updateSystemStatus,
     s.toggleRightPanel,
     s.toggleTerminalPanel,
@@ -181,11 +195,17 @@ const AgentWorkingSidebar = memo(() => {
   ]);
   const activeAgentId = useAgentStore((s) => s.activeAgentId);
   const workspaceId = useActiveWorkspaceId();
-  const [topicId, currentPortalView, openTopicComments] = useChatStore((s) => [
+  const [topicId, currentPortalView, portalOpen, openTopicComments] = useChatStore((s) => [
     s.activeTopicId,
     chatPortalSelectors.currentView(s),
+    chatPortalSelectors.showStandalonePortal(s),
     s.openTopicComments,
   ]);
+  const portalWidth = getPortalViewWidth({
+    legacyWidth: legacyPortalWidth,
+    viewType: currentPortalView?.type,
+    widths: portalWidths,
+  });
   const isChatMode = useAgentStore((s) =>
     activeAgentId ? chatConfigByIdSelectors.isChatModeById(activeAgentId)(s) : false,
   );
@@ -640,6 +660,14 @@ const AgentWorkingSidebar = memo(() => {
   );
   const reviewTwoPane = activeTab === 'review' && reviewAvailable && showReviewTree;
   const displayWidth = reviewTwoPane ? Math.max(storedWidth, TWO_PANE_MIN_WIDTH) : storedWidth;
+  // Yield the row to conversation + portal when the three no longer fit. This
+  // only overrides the rendered state — `showRightPanel` keeps the user's own
+  // choice, so the sidebar comes back by itself once there is room again.
+  const fits = fitsBesidePortal({
+    availableWidth,
+    portalWidth: portalOpen ? portalWidth : 0,
+    sidebarWidth: displayWidth,
+  });
   const openMenuItems = useCallback((): DropdownItem[] => {
     const itemOf = (key: string): DropdownItem | undefined => {
       const tab = availableTabs.get(key);
@@ -728,6 +756,7 @@ const AgentWorkingSidebar = memo(() => {
       stableLayout
       collapseThreshold={320}
       defaultWidth={displayWidth}
+      expand={Boolean(showRightPanel) && fits}
       maxWidth={MAX_PANEL_WIDTH}
       minWidth={300}
       width={displayWidth}

--- a/src/features/Portal/portalWidth.test.ts
+++ b/src/features/Portal/portalWidth.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CHAT_PORTAL_MAX_WIDTH,
+  CHAT_PORTAL_TOOL_UI_WIDTH,
+  CHAT_PORTAL_WIDE_WIDTH,
+  CHAT_PORTAL_WIDTH,
+} from '@/const/layoutTokens';
+import { PortalViewType } from '@/store/chat/slices/portal/initialState';
+
+import { getPortalViewMinWidth, getPortalViewWidth } from './portalWidth';
+
+describe('getPortalViewMinWidth', () => {
+  it('keeps the reading column for plain views', () => {
+    expect(getPortalViewMinWidth(PortalViewType.Home)).toBe(CHAT_PORTAL_WIDTH);
+    expect(getPortalViewMinWidth(null)).toBe(CHAT_PORTAL_WIDTH);
+    expect(getPortalViewMinWidth(PortalViewType.Document)).toBe(CHAT_PORTAL_WIDTH);
+  });
+
+  it('widens the views that render tool UI, code or nested conversations', () => {
+    for (const viewType of [
+      PortalViewType.Acceptance,
+      PortalViewType.AcceptanceCheck,
+      PortalViewType.AgentDetail,
+      PortalViewType.Artifact,
+      PortalViewType.TaskDetail,
+      PortalViewType.Thread,
+      PortalViewType.ToolUI,
+    ]) {
+      expect(getPortalViewMinWidth(viewType)).toBe(CHAT_PORTAL_TOOL_UI_WIDTH);
+    }
+  });
+});
+
+describe('getPortalViewWidth', () => {
+  it('opens acceptance wide even when the legacy shared width is narrow', () => {
+    expect(
+      getPortalViewWidth({ legacyWidth: CHAT_PORTAL_WIDTH, viewType: PortalViewType.Acceptance }),
+    ).toBe(CHAT_PORTAL_WIDE_WIDTH);
+  });
+
+  it('remembers the width per view instead of sharing one value', () => {
+    const widths = { [PortalViewType.Acceptance]: 1000, [PortalViewType.TaskDetail]: 620 };
+
+    expect(getPortalViewWidth({ viewType: PortalViewType.Acceptance, widths })).toBe(1000);
+    expect(getPortalViewWidth({ viewType: PortalViewType.TaskDetail, widths })).toBe(620);
+    // untouched views are unaffected by the two above
+    expect(
+      getPortalViewWidth({ legacyWidth: 480, viewType: PortalViewType.Document, widths }),
+    ).toBe(480);
+  });
+
+  it('falls back to the legacy width for views without an explicit default', () => {
+    expect(getPortalViewWidth({ legacyWidth: 520, viewType: PortalViewType.Home })).toBe(520);
+    expect(getPortalViewWidth({ viewType: PortalViewType.Home })).toBe(CHAT_PORTAL_WIDTH);
+    expect(getPortalViewWidth({})).toBe(CHAT_PORTAL_WIDTH);
+  });
+
+  it('clamps to the view min width and the panel max width', () => {
+    expect(
+      getPortalViewWidth({ legacyWidth: CHAT_PORTAL_WIDTH, viewType: PortalViewType.ToolUI }),
+    ).toBe(CHAT_PORTAL_TOOL_UI_WIDTH);
+    expect(
+      getPortalViewWidth({
+        viewType: PortalViewType.Acceptance,
+        widths: { [PortalViewType.Acceptance]: 300 },
+      }),
+    ).toBe(CHAT_PORTAL_TOOL_UI_WIDTH);
+    expect(
+      getPortalViewWidth({
+        viewType: PortalViewType.Acceptance,
+        widths: { [PortalViewType.Acceptance]: 9999 },
+      }),
+    ).toBe(CHAT_PORTAL_MAX_WIDTH);
+  });
+});

--- a/src/features/Portal/portalWidth.ts
+++ b/src/features/Portal/portalWidth.ts
@@ -1,0 +1,66 @@
+import {
+  CHAT_PORTAL_MAX_WIDTH,
+  CHAT_PORTAL_TOOL_UI_WIDTH,
+  CHAT_PORTAL_WIDE_WIDTH,
+  CHAT_PORTAL_WIDTH,
+} from '@/const/layoutTokens';
+import { PortalViewType } from '@/store/chat/slices/portal/initialState';
+
+/**
+ * Persisted portal widths, keyed by `PortalViewType`. Each view remembers the
+ * width the user dragged it to, so resizing the task detail pane no longer
+ * shrinks the acceptance report the next time it opens.
+ */
+export type PortalWidths = Partial<Record<PortalViewType, number>>;
+
+/**
+ * Views that can't be read in the default 400px reading column: they render
+ * code, tool UI, tables or nested conversations.
+ */
+const VIEW_MIN_WIDTH: PortalWidths = {
+  [PortalViewType.Acceptance]: CHAT_PORTAL_TOOL_UI_WIDTH,
+  [PortalViewType.AcceptanceCheck]: CHAT_PORTAL_TOOL_UI_WIDTH,
+  [PortalViewType.AgentDetail]: CHAT_PORTAL_TOOL_UI_WIDTH,
+  [PortalViewType.Artifact]: CHAT_PORTAL_TOOL_UI_WIDTH,
+  [PortalViewType.TaskDetail]: CHAT_PORTAL_TOOL_UI_WIDTH,
+  [PortalViewType.Thread]: CHAT_PORTAL_TOOL_UI_WIDTH,
+  [PortalViewType.ToolUI]: CHAT_PORTAL_TOOL_UI_WIDTH,
+};
+
+/**
+ * Opening width for views that want more than the remembered generic width.
+ * A view listed here ignores the legacy shared width, so users who had dragged
+ * the portal narrow still get a readable pane the first time they open it.
+ */
+const VIEW_DEFAULT_WIDTH: PortalWidths = {
+  [PortalViewType.Acceptance]: CHAT_PORTAL_WIDE_WIDTH,
+  [PortalViewType.AcceptanceCheck]: CHAT_PORTAL_WIDE_WIDTH,
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const normalizeViewType = (viewType?: PortalViewType | null) => viewType ?? PortalViewType.Home;
+
+export const getPortalViewMinWidth = (viewType?: PortalViewType | null): number =>
+  VIEW_MIN_WIDTH[normalizeViewType(viewType)] ?? CHAT_PORTAL_WIDTH;
+
+interface GetPortalViewWidthParams {
+  /**
+   * The legacy shared `portalWidth`, used as the fallback for views that have
+   * neither a remembered width nor an explicit default.
+   */
+  legacyWidth?: number;
+  viewType?: PortalViewType | null;
+  widths?: PortalWidths;
+}
+
+export const getPortalViewWidth = ({
+  legacyWidth,
+  viewType,
+  widths,
+}: GetPortalViewWidthParams): number => {
+  const key = normalizeViewType(viewType);
+  const fallback = VIEW_DEFAULT_WIDTH[key] ?? legacyWidth ?? CHAT_PORTAL_WIDTH;
+
+  return clamp(widths?.[key] || fallback, getPortalViewMinWidth(key), CHAT_PORTAL_MAX_WIDTH);
+};

--- a/src/routes/(main)/agent/(chat)/_layout/index.tsx
+++ b/src/routes/(main)/agent/(chat)/_layout/index.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
+import { useSize } from 'ahooks';
 import { createStaticStyles } from 'antd-style';
-import { memo } from 'react';
+import { memo, useRef } from 'react';
 import { Outlet } from 'react-router';
 
 import ChatTerminalPanel from '@/features/ChatTerminal';
@@ -24,12 +25,18 @@ const styles = createStaticStyles(({ css }) => ({
 }));
 
 const ChatLayout = memo(() => {
+  // The working sidebar needs the row width to know whether it still fits next
+  // to an open portal — a wide portal otherwise squeezes the conversation out.
+  const rowRef = useRef<HTMLDivElement>(null);
+  const rowSize = useSize(rowRef);
+
   return (
     <HeaderSlot.Provider>
       <Flexbox flex={1} height={'100%'} style={{ minHeight: 0, overflow: 'hidden' }} width={'100%'}>
         <Flexbox
           horizontal
           flex={1}
+          ref={rowRef}
           style={{ minHeight: 0, overflow: 'hidden', position: 'relative' }}
           width={'100%'}
         >
@@ -44,7 +51,7 @@ const ChatLayout = memo(() => {
             </Flexbox>
           </Flexbox>
           <Portal />
-          <AgentWorkingSidebar />
+          <AgentWorkingSidebar availableWidth={rowSize?.width} />
         </Flexbox>
         <ChatTerminalPanel />
       </Flexbox>

--- a/src/routes/(main)/agent/features/Portal/features/Portal.tsx
+++ b/src/routes/(main)/agent/features/Portal/features/Portal.tsx
@@ -7,13 +7,11 @@ import isEqual from 'fast-deep-equal';
 import { type PropsWithChildren } from 'react';
 import { Activity, memo, useState } from 'react';
 
-import {
-  CHAT_PORTAL_MAX_WIDTH,
-  CHAT_PORTAL_TOOL_UI_WIDTH,
-  CHAT_PORTAL_WIDTH,
-} from '@/const/layoutTokens';
+import { CHAT_PORTAL_MAX_WIDTH } from '@/const/layoutTokens';
+import { getPortalViewMinWidth, getPortalViewWidth } from '@/features/Portal/portalWidth';
 import { useChatStore } from '@/store/chat';
 import { chatPortalSelectors, portalThreadSelectors } from '@/store/chat/selectors';
+import { PortalViewType } from '@/store/chat/slices/portal/initialState';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 
@@ -39,20 +37,22 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 }));
 
 const PortalPanel = memo(({ children }: PropsWithChildren) => {
-  const [showPortal, showToolUI, showArtifactUI, showThread, showTaskDetail, showAgentDetail] =
-    useChatStore((s) => [
-      chatPortalSelectors.showStandalonePortal(s),
-      chatPortalSelectors.showPluginUI(s),
-      chatPortalSelectors.showArtifactUI(s),
-      portalThreadSelectors.showThread(s),
-      chatPortalSelectors.showTaskDetail(s),
-      chatPortalSelectors.showAgentDetail(s),
-    ]);
+  const [showPortal, currentViewType, showThread] = useChatStore((s) => [
+    chatPortalSelectors.showStandalonePortal(s),
+    chatPortalSelectors.currentViewType(s),
+    portalThreadSelectors.showThread(s),
+  ]);
 
-  const [portalWidth, updateSystemStatus] = useGlobalStore((s) => [
+  // legacy threads live outside the view stack, so they surface as an empty stack
+  const viewType = currentViewType ?? (showThread ? PortalViewType.Thread : null);
+
+  const [legacyWidth, portalWidths, updateSystemStatus] = useGlobalStore((s) => [
     systemStatusSelectors.portalWidth(s),
+    systemStatusSelectors.portalWidths(s),
     s.updateSystemStatus,
   ]);
+
+  const portalWidth = getPortalViewWidth({ legacyWidth, viewType, widths: portalWidths });
 
   const [tmpWidth, setWidth] = useState(portalWidth);
   if (tmpWidth !== portalWidth) setWidth(portalWidth);
@@ -66,7 +66,8 @@ const PortalPanel = memo(({ children }: PropsWithChildren) => {
 
     if (isEqual(nextWidth, portalWidth)) return;
     setWidth(nextWidth);
-    updateSystemStatus({ portalWidth: nextWidth });
+    // updateSystemStatus deep-merges, so the other views keep their widths
+    updateSystemStatus({ portalWidths: { [viewType ?? PortalViewType.Home]: nextWidth } });
   };
 
   return (
@@ -76,6 +77,7 @@ const PortalPanel = memo(({ children }: PropsWithChildren) => {
       expand={showPortal}
       expandable={false}
       maxWidth={CHAT_PORTAL_MAX_WIDTH}
+      minWidth={getPortalViewMinWidth(viewType)}
       mode={lg ? 'fixed' : 'float'}
       placement={'right'}
       showHandleWhenCollapsed={false}
@@ -84,11 +86,6 @@ const PortalPanel = memo(({ children }: PropsWithChildren) => {
       classNames={{
         content: styles.content,
       }}
-      minWidth={
-        showArtifactUI || showToolUI || showThread || showTaskDetail || showAgentDetail
-          ? CHAT_PORTAL_TOOL_UI_WIDTH
-          : CHAT_PORTAL_WIDTH
-      }
       onSizeChange={handleSizeChange}
     >
       <Activity mode={showPortal ? 'visible' : 'hidden'} name="AgentPortal">

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -252,7 +252,15 @@ export interface SystemStatus {
    * number of pages (documents) to display per page
    */
   pagePageSize?: number;
+  /**
+   * @deprecated legacy shared portal width, kept as the fallback for views that
+   * have no entry in `portalWidths` yet
+   */
   portalWidth: number;
+  /**
+   * portal width remembered per view type, see `PortalWidths`
+   */
+  portalWidths?: Record<string, number>;
   /**
    * number of private agents (ungrouped) to display in the Private sidebar bucket
    */
@@ -507,6 +515,7 @@ export const INITIAL_STATUS = {
   pageAgentPanelWidth: 360,
   pagePageSize: 20,
   portalWidth: 400,
+  portalWidths: {},
   readNotificationSlugs: [],
   resourceManagerColumnWidths: DEFAULT_RESOURCE_MANAGER_COLUMN_WIDTHS,
   showCommandMenu: false,

--- a/src/store/global/selectors/systemStatus.ts
+++ b/src/store/global/selectors/systemStatus.ts
@@ -396,6 +396,7 @@ const leftPanelWidth = (s: GlobalState): number => {
   return normalizeNavPanelWidth(s.status.leftPanelWidth);
 };
 const portalWidth = (s: GlobalState) => s.status.portalWidth || 400;
+const portalWidths = (s: GlobalState) => s.status.portalWidths;
 const filePanelWidth = (s: GlobalState) => s.status.filePanelWidth;
 const groupAgentBuilderPanelWidth = (s: GlobalState) => s.status.groupAgentBuilderPanelWidth || 360;
 const imagePanelWidth = (s: GlobalState) => s.status.imagePanelWidth;
@@ -475,6 +476,7 @@ export const systemStatusSelectors = {
   pageAgentPanelWidth,
   pagePageSize,
   portalWidth,
+  portalWidths,
   privateAgentPageSize,
   recentPageSize,
   taskCreateInlineCollapsed,


### PR DESCRIPTION
The portal pane persisted a single `status.portalWidth` shared by every view. Two consequences: dragging the task-detail pane narrow also shrank the acceptance report the next time it opened, and the acceptance view had no way to open wider than the 400px default — it is a document-shaped surface (evidence, screenshots, annotations) squeezed into a chat-sidebar column.

Widths are now keyed by `PortalViewType`, so each view remembers what the user dragged it to, and acceptance opens at a readable 840. When the row can no longer hold all three columns, the working sidebar yields so conversation + portal keep it.

#### What changed

- **`src/features/Portal/portalWidth.ts`** (new) — resolves the width for a view. Priority: the width remembered for that view → that view's explicit default → the legacy shared `portalWidth` → 400, then clamped to `[view min, CHAT_PORTAL_MAX_WIDTH]`.
  - `VIEW_MIN_WIDTH` replaces the hardcoded `showArtifactUI || showToolUI || …` ternary in the panel with a table, and adds Acceptance / AcceptanceCheck to the 600px tier.
  - `VIEW_DEFAULT_WIDTH` gives Acceptance / AcceptanceCheck an opening width of `CHAT_PORTAL_WIDE_WIDTH` (840). A view with an explicit default deliberately ignores the legacy shared value — otherwise a user who had previously dragged the portal to 400 would still get 400.
- **`src/store/global/initialState.ts` / `selectors/systemStatus.ts`** — new persisted `status.portalWidths?: Record<string, number>`. The old `portalWidth` is marked `@deprecated` and kept as the migration fallback; nothing writes to it anymore, so views without their own default keep the width these users already had.
- **`src/routes/(main)/agent/features/Portal/features/Portal.tsx`** — reads `currentViewType` and writes only `portalWidths[viewType]` on drag. `updateSystemStatus` deep-merges, so committing the single key leaves the other views untouched. Legacy threads (`threadStartMessageId` set but the view stack empty) still resolve to `PortalViewType.Thread`.
- **`src/features/Conversation/WorkingSidebar/fitsBesidePortal.ts`** (new) + `WorkingSidebar/index.tsx` — the conversation, the portal and the working sidebar share one row, and 840 + 360 can consume all of it. When the conversation would be left under `CONVERSATION_KEEP_WIDTH` (420), the sidebar yields. This overrides only the rendered state: `showRightPanel` keeps the user's own choice, so the sidebar returns by itself once the window is wide enough again.
- **`src/routes/(main)/agent/(chat)/_layout/index.tsx`** — measures the row with `useSize` and passes the width down. Measuring the row rather than `window.innerWidth` matters because the left nav panel changes how much of it is available.
- **`packages/const/src/layoutTokens.ts`** — new `CHAT_PORTAL_WIDE_WIDTH = 840` and `CONVERSATION_KEEP_WIDTH = 420`.

#### Test

Unit: `portalWidth.test.ts` (6 cases) covers the resolution priority and clamping; `fitsBesidePortal.test.ts` (5 cases) covers the unmeasured row, the reported 1200px regression, the wide case, a closed portal, and a narrow portal. `bun run check` — lint clean, related tests pass, and the full type-check reports nothing in the files this PR touches.

Desktop (Electron, real account data, isolated dev instance) — https://app.lobehub.com/acceptance/a343f222-fb1e-4864-a237-1b611a16468f

Round 1, each verified by clicking through the real UI and measuring the rendered panel:

- Acceptance opens at 840 instead of the shared 400 (A/B against `canary`'s `Portal.tsx` in the same instance, same window, same link).
- Dragging Acceptance to 1000 writes only `portalWidths.acceptance`; the legacy `portalWidth` stays 400.
- Opening Notebook after that gives it its own 400, and dragging it to 500 leaves Acceptance at 1000 — reopening Acceptance restores 1000 exactly. On `canary` the shared value would have made it 500.
- Dragging Acceptance past the lower bound clamps at 600 and persists the clamped value.

Round 1 also found a regression at narrow windows: at 1200×832 with the overview sidebar open, 840 + 360 exceeded the row and the conversation column collapsed to 0px. Round 2 fixes it and re-verifies:

- At 1200×832 the row is now conversation 341 + portal 841 + sidebar 0 — the sidebar yields, the conversation and its composer stay usable.
- `showRightPanel` is still `true` throughout, and widening the viewport to 1728 brings the sidebar back (508 + 841 + 361) with no user action.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

N/A