### PR TITLE
🐛 fix(agent): clean orphan placeholder and abort retry backoff when stopping generation

### DIFF
--- a/src/store/chat/agents/transports/ClientLLMTransport.test.ts
+++ b/src/store/chat/agents/transports/ClientLLMTransport.test.ts
@@ -246,3 +246,63 @@ describe('ClientLLMTransport.retryPolicy.onError · terminal operation teardown'
     expect(store.updateTopicStatus).not.toHaveBeenCalled();
   });
 });
+
+// The retry loop only re-checks for cancellation AFTER `waitForRetry` resolves,
+// so the backoff wait must be abort-aware: a Stop landing mid-backoff has to
+// resolve it immediately instead of blocking for the full exponential delay,
+// during which the topic stays `running` and can be stranded there (#17723).
+describe('ClientLLMTransport.retryPolicy.waitForRetry · abort-aware backoff', () => {
+  const createRetryPolicy = () => {
+    const abortController = new AbortController();
+    const store = {
+      operations: { 'op-1': { abortController, context: {}, status: 'running' } },
+    } as unknown as ChatStore;
+    const transport = new ClientLLMTransport({
+      get: () => store,
+      operationId: 'op-1',
+      session: { assistantMessageId: 'msg-1' } as any,
+    });
+    return { abortController, retryPolicy: transport.retryPolicy };
+  };
+
+  it('resolves immediately when the operation was already aborted', async () => {
+    const { abortController, retryPolicy } = createRetryPolicy();
+    abortController.abort();
+
+    await expect(retryPolicy.waitForRetry!(10_000)).resolves.toBeUndefined();
+  });
+
+  it('resolves as soon as the signal aborts mid-wait, without waiting out the delay', async () => {
+    vi.useFakeTimers();
+    try {
+      const { abortController, retryPolicy } = createRetryPolicy();
+      const waited = retryPolicy.waitForRetry!(10_000);
+      abortController.abort();
+
+      // Resolves off the abort event — no timer advance needed.
+      await expect(waited).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('waits out the full delay when no abort arrives', async () => {
+    vi.useFakeTimers();
+    try {
+      const { retryPolicy } = createRetryPolicy();
+      let resolved = false;
+      const waited = retryPolicy.waitForRetry!(1000).then(() => {
+        resolved = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(resolved).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await waited;
+      expect(resolved).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/store/chat/agents/transports/ClientLLMTransport.test.ts
+++ b/src/store/chat/agents/transports/ClientLLMTransport.test.ts
@@ -247,10 +247,6 @@ describe('ClientLLMTransport.retryPolicy.onError · terminal operation teardown'
   });
 });
 
-// The retry loop only re-checks for cancellation AFTER `waitForRetry` resolves,
-// so the backoff wait must be abort-aware: a Stop landing mid-backoff has to
-// resolve it immediately instead of blocking for the full exponential delay,
-// during which the topic stays `running` and can be stranded there (#17723).
 describe('ClientLLMTransport.retryPolicy.waitForRetry · abort-aware backoff', () => {
   const createRetryPolicy = () => {
     const abortController = new AbortController();

--- a/src/store/chat/agents/transports/ClientLLMTransport.ts
+++ b/src/store/chat/agents/transports/ClientLLMTransport.ts
@@ -187,13 +187,8 @@ class ClientLLMRetryPolicy implements LLMRetryPolicy {
     // Already stopped before the backoff even began — don't wait at all.
     if (signal?.aborted) return;
 
-    // Race the backoff delay against the operation's abort signal. The retry
-    // loop (packages/agent-runtime `call_llm`) only re-checks for cancellation
-    // AFTER `waitForRetry` resolves, so a plain `sleep` here swallows a Stop that
-    // lands mid-backoff until the full (exponential) delay elapses — during which
-    // the topic stays `running` and, if the tab is closed in that window, is
-    // stranded there until the 2h stale watchdog fires (#17723). Resolving as
-    // soon as the signal aborts lets the cancellation be observed immediately.
+    // Race the backoff delay against the operation's abort signal so a Stop
+    // mid-backoff is observed immediately instead of after the full delay (#17723).
     await new Promise<void>((resolve) => {
       const settle = () => {
         clearTimeout(timer);

--- a/src/store/chat/agents/transports/ClientLLMTransport.ts
+++ b/src/store/chat/agents/transports/ClientLLMTransport.ts
@@ -27,7 +27,6 @@ import { t } from 'i18next';
 
 import { chatService } from '@/services/chat';
 import { getFileStoreState } from '@/store/file/store';
-import { sleep } from '@/utils/sleep';
 
 import type { ChatStore } from '../../store';
 import { StreamingHandler } from '../StreamingHandler';
@@ -184,7 +183,26 @@ class ClientLLMRetryPolicy implements LLMRetryPolicy {
   }
 
   async waitForRetry(delayMs: number): Promise<void> {
-    await sleep(delayMs);
+    const signal = this.get().operations[this.operationId]?.abortController?.signal;
+    // Already stopped before the backoff even began — don't wait at all.
+    if (signal?.aborted) return;
+
+    // Race the backoff delay against the operation's abort signal. The retry
+    // loop (packages/agent-runtime `call_llm`) only re-checks for cancellation
+    // AFTER `waitForRetry` resolves, so a plain `sleep` here swallows a Stop that
+    // lands mid-backoff until the full (exponential) delay elapses — during which
+    // the topic stays `running` and, if the tab is closed in that window, is
+    // stranded there until the 2h stale watchdog fires (#17723). Resolving as
+    // soon as the signal aborts lets the cancellation be observed immediately.
+    await new Promise<void>((resolve) => {
+      const settle = () => {
+        clearTimeout(timer);
+        signal?.removeEventListener('abort', settle);
+        resolve();
+      };
+      const timer = setTimeout(settle, delayMs);
+      signal?.addEventListener('abort', settle, { once: true });
+    });
   }
 }
 

--- a/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.test.ts
@@ -41,15 +41,10 @@ const CONTEXT: ConversationContext = {
 } as ConversationContext;
 
 const makeStore = (afterCompletionCallbacks?: Array<() => void>) => {
-  // Stands in for `messageService.removeMessage` — the one server-side delete both
-  // delete paths funnel into. Asserting on it (rather than on whichever store
-  // action was called) is what makes the topic-switch test below non-tautological:
-  // the active-scoped path can be called and still never reach the server.
+  // Shared server-side delete both paths funnel into — asserting on this rather
+  // than on the store action is what makes the topic-switch test non-tautological.
   const removeMessage = vi.fn(async (_id: string, _context: unknown) => {});
 
-  // Stands in for `internal_getConversationContext`: both delete paths resolve the
-  // conversation from the operation before hitting the service, so the only thing
-  // that differs between them is WHETHER they get that far.
   const resolveContext = (context?: { operationId?: string }) =>
     context?.operationId
       ? store.operations[context.operationId as keyof typeof store.operations]?.context
@@ -61,12 +56,8 @@ const makeStore = (afterCompletionCallbacks?: Array<() => void>) => {
     activeTopicId: 't1',
     completeOperation: vi.fn(),
     dbMessagesMap: {},
-    // Faithful to publicApi.deleteMessage: it resolves the target through the
-    // REAL `getDisplayMessageById` selector (active conversation only) and
-    // early-returns when that misses — the #17723 topic-switch hole. No test
-    // asserts on it directly; it is the contrast path, and modelling it honestly
-    // is what makes the topic-switch test below fail if the cleanup is ever
-    // pointed back at the active-scoped delete.
+    // Contrast path: resolves via the REAL getDisplayMessageById selector
+    // (active conversation only), so it misses after a topic switch (#17723).
     deleteMessage: vi.fn(async (id: string, context?: { operationId?: string }) => {
       const message = displayMessageSelectors.getDisplayMessageById(id)(store as any);
       if (!message) return;
@@ -77,9 +68,8 @@ const makeStore = (afterCompletionCallbacks?: Array<() => void>) => {
     internal_updateTopic: vi.fn(),
     markTopicUnread: vi.fn(),
     messagesMap: {},
-    // Faithful to optimisticUpdate.optimisticDeleteMessage: it resolves the
-    // conversation from the OPERATION's context, so it is independent of whichever
-    // topic happens to be active.
+    // Resolves the conversation from the operation's context, independent of
+    // whichever topic is active.
     optimisticDeleteMessage: vi.fn(async (id: string, context?: { operationId?: string }) => {
       await removeMessage(id, resolveContext(context));
     }),
@@ -298,11 +288,6 @@ describe('buildRunLifecycle.completeRun — client resets a viewed topic out of 
   });
 });
 
-// A cancelled run can leave its assistant placeholder empty (aborted before it
-// produced anything — e.g. Stop during TTFT or provider-retry backoff). Nothing
-// on the cancel path finalizes it, so it renders as a perpetually-"generating"
-// empty bubble that survives reloads in server DB mode (#17723). completeRun
-// drops such a placeholder on the cancelled disposition.
 describe('buildRunLifecycle.completeRun — removes the orphan empty placeholder on cancel', () => {
   const KEY = messageMapKey(CONTEXT);
   const emptyAssistant = { content: '', id: 'a-empty', parentId: 'u1', role: 'assistant' } as any;
@@ -389,19 +374,12 @@ describe('buildRunLifecycle.completeRun — removes the orphan empty placeholder
     expect(store.optimisticDeleteMessage).not.toHaveBeenCalled();
   });
 
-  // Regression for the review finding on #17864: the cleanup used to go through
-  // `deleteMessage`, which resolves its target with
-  // `displayMessageSelectors.getDisplayMessageById` — the ACTIVE conversation only.
-  // Stop, then switch topic before the cleanup lands, and that lookup misses, the
-  // delete silently no-ops, and the orphan row this fix exists to remove survives.
-  // The operation-scoped path resolves the run's own conversation instead.
+  // Regression for #17864: deleteMessage resolves via the active conversation
+  // only, so it must not be the one used once the user has switched topics.
   it('still deletes the placeholder when the user switched topics before the cleanup ran', async () => {
     const { get, removeMessage, store } = makeStore();
 
-    // The run's placeholder lives under the RUN's conversation key...
     store.messagesMap = { [KEY]: [emptyAssistant] } as any;
-    // ...while the user has already moved to a DIFFERENT topic, which is what the
-    // active-conversation lookup would search (and miss).
     store.activeTopicId = 't2';
     expect(displayMessageSelectors.getDisplayMessageById('a-empty')(store as any)).toBeUndefined();
 
@@ -409,10 +387,6 @@ describe('buildRunLifecycle.completeRun — removes the orphan empty placeholder
       completeEvent('client', { runtimeStatus: 'interrupted' }),
     );
 
-    // The server-side delete actually fired, resolved against the RUN's own
-    // conversation rather than the now-active one. This is the assertion that
-    // catches the bug: the active-scoped path reaches its store action too, then
-    // silently drops the delete on the missed lookup and never gets here.
     expect(removeMessage).toHaveBeenCalledWith('a-empty', CONTEXT);
     expect(store.optimisticDeleteMessage).toHaveBeenCalledWith('a-empty', { operationId: OP });
   });

--- a/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ChatStore } from '@/store/chat/store';
 
 import { messageMapKey } from '../../../../utils/messageMapKey';
+import { displayMessageSelectors } from '../../../message/selectors/displayMessage';
 import type { AgentRuntimeType } from '../dispatch/agentDispatcher';
 import { buildRunLifecycle } from './buildRunLifecycle';
 import type { RunCompleteEvent, RunTerminalStatus, UserMessagePersistedEvent } from './types';
@@ -40,17 +41,48 @@ const CONTEXT: ConversationContext = {
 } as ConversationContext;
 
 const makeStore = (afterCompletionCallbacks?: Array<() => void>) => {
+  // Stands in for `messageService.removeMessage` — the one server-side delete both
+  // delete paths funnel into. Asserting on it (rather than on whichever store
+  // action was called) is what makes the topic-switch test below non-tautological:
+  // the active-scoped path can be called and still never reach the server.
+  const removeMessage = vi.fn(async (_id: string, _context: unknown) => {});
+
+  // Stands in for `internal_getConversationContext`: both delete paths resolve the
+  // conversation from the operation before hitting the service, so the only thing
+  // that differs between them is WHETHER they get that far.
+  const resolveContext = (context?: { operationId?: string }) =>
+    context?.operationId
+      ? store.operations[context.operationId as keyof typeof store.operations]?.context
+      : undefined;
+
   const store = {
     activeAgentId: 'a1',
     activeGroupId: undefined,
     activeTopicId: 't1',
     completeOperation: vi.fn(),
     dbMessagesMap: {},
+    // Faithful to publicApi.deleteMessage: it resolves the target through the
+    // REAL `getDisplayMessageById` selector (active conversation only) and
+    // early-returns when that misses — the #17723 topic-switch hole. No test
+    // asserts on it directly; it is the contrast path, and modelling it honestly
+    // is what makes the topic-switch test below fail if the cleanup is ever
+    // pointed back at the active-scoped delete.
+    deleteMessage: vi.fn(async (id: string, context?: { operationId?: string }) => {
+      const message = displayMessageSelectors.getDisplayMessageById(id)(store as any);
+      if (!message) return;
+      await removeMessage(id, resolveContext(context));
+    }),
     drainQueuedMessages: vi.fn(() => []),
     failOperation: vi.fn(),
     internal_updateTopic: vi.fn(),
     markTopicUnread: vi.fn(),
     messagesMap: {},
+    // Faithful to optimisticUpdate.optimisticDeleteMessage: it resolves the
+    // conversation from the OPERATION's context, so it is independent of whichever
+    // topic happens to be active.
+    optimisticDeleteMessage: vi.fn(async (id: string, context?: { operationId?: string }) => {
+      await removeMessage(id, resolveContext(context));
+    }),
     operations: {
       [OP]: {
         context: CONTEXT,
@@ -64,7 +96,7 @@ const makeStore = (afterCompletionCallbacks?: Array<() => void>) => {
     topicDataMap: {},
     updateTopicStatus: vi.fn(async () => {}),
   };
-  return { get: (() => store) as unknown as () => ChatStore, store };
+  return { get: (() => store) as unknown as () => ChatStore, removeMessage, store };
 };
 
 const lifecycle = (
@@ -263,6 +295,126 @@ describe('buildRunLifecycle.completeRun — client resets a viewed topic out of 
     );
 
     expect(store.updateTopicStatus).not.toHaveBeenCalled();
+  });
+});
+
+// A cancelled run can leave its assistant placeholder empty (aborted before it
+// produced anything — e.g. Stop during TTFT or provider-retry backoff). Nothing
+// on the cancel path finalizes it, so it renders as a perpetually-"generating"
+// empty bubble that survives reloads in server DB mode (#17723). completeRun
+// drops such a placeholder on the cancelled disposition.
+describe('buildRunLifecycle.completeRun — removes the orphan empty placeholder on cancel', () => {
+  const KEY = messageMapKey(CONTEXT);
+  const emptyAssistant = { content: '', id: 'a-empty', parentId: 'u1', role: 'assistant' } as any;
+
+  it('deletes the empty assistant placeholder when a client run is cancelled', async () => {
+    const { get, store } = makeStore();
+    store.messagesMap = { [KEY]: [emptyAssistant] } as any;
+
+    await lifecycle('client', get).completeRun(
+      completeEvent('client', { runtimeStatus: 'interrupted' }),
+    );
+
+    expect(store.optimisticDeleteMessage).toHaveBeenCalledWith('a-empty', { operationId: OP });
+  });
+
+  it('deletes the placeholder when it IS the parentMessage (production main-send shape)', async () => {
+    // The real send path calls executeClientAgent with parentMessageType
+    // 'assistant' and parentMessageId = the placeholder id itself
+    // (skipCreateFirstMessage), so the id resolves via the fallback branch of
+    // findCompletionAssistantMessageId rather than descendant lookup.
+    const { get, store } = makeStore();
+    store.messagesMap = { [KEY]: [{ content: '', id: 'a-empty', role: 'assistant' }] } as any;
+
+    await buildRunLifecycle(get, {
+      context: CONTEXT,
+      parentMessageId: 'a-empty',
+      parentMessageType: 'assistant',
+      runId: OP,
+      runScope: 'top_level',
+      runtimeType: 'client',
+    }).completeRun({
+      context: CONTEXT,
+      operationId: OP,
+      runId: OP,
+      runScope: 'top_level',
+      runtimeStatus: 'interrupted',
+      runtimeType: 'client',
+    });
+
+    expect(store.optimisticDeleteMessage).toHaveBeenCalledWith('a-empty', { operationId: OP });
+  });
+
+  it('keeps a placeholder that has streamed content', async () => {
+    const { get, store } = makeStore();
+    store.messagesMap = {
+      [KEY]: [{ ...emptyAssistant, content: 'partial answer' }],
+    } as any;
+
+    await lifecycle('client', get).completeRun(
+      completeEvent('client', { runtimeStatus: 'interrupted' }),
+    );
+
+    expect(store.optimisticDeleteMessage).not.toHaveBeenCalled();
+  });
+
+  it('keeps a placeholder that recorded an error (so the failure stays visible)', async () => {
+    const { get, store } = makeStore();
+    store.messagesMap = {
+      [KEY]: [{ ...emptyAssistant, error: { type: 'ProviderBizError' } }],
+    } as any;
+
+    await lifecycle('client', get).completeRun(
+      completeEvent('client', { runtimeStatus: 'interrupted' }),
+    );
+
+    expect(store.optimisticDeleteMessage).not.toHaveBeenCalled();
+  });
+
+  it('does NOT delete on a successful client run (only the cancel disposition cleans up)', async () => {
+    const { get, store } = makeStore();
+    store.messagesMap = { [KEY]: [emptyAssistant] } as any;
+
+    await lifecycle('client', get).completeRun(completeEvent('client', { runtimeStatus: 'done' }));
+
+    expect(store.optimisticDeleteMessage).not.toHaveBeenCalled();
+  });
+
+  it('does NOT delete for gateway cancel (client transport owns this cleanup)', async () => {
+    const { get, store } = makeStore();
+    store.messagesMap = { [KEY]: [emptyAssistant] } as any;
+
+    await lifecycle('gateway', get).completeRun(completeEvent('gateway', { status: 'cancelled' }));
+
+    expect(store.optimisticDeleteMessage).not.toHaveBeenCalled();
+  });
+
+  // Regression for the review finding on #17864: the cleanup used to go through
+  // `deleteMessage`, which resolves its target with
+  // `displayMessageSelectors.getDisplayMessageById` — the ACTIVE conversation only.
+  // Stop, then switch topic before the cleanup lands, and that lookup misses, the
+  // delete silently no-ops, and the orphan row this fix exists to remove survives.
+  // The operation-scoped path resolves the run's own conversation instead.
+  it('still deletes the placeholder when the user switched topics before the cleanup ran', async () => {
+    const { get, removeMessage, store } = makeStore();
+
+    // The run's placeholder lives under the RUN's conversation key...
+    store.messagesMap = { [KEY]: [emptyAssistant] } as any;
+    // ...while the user has already moved to a DIFFERENT topic, which is what the
+    // active-conversation lookup would search (and miss).
+    store.activeTopicId = 't2';
+    expect(displayMessageSelectors.getDisplayMessageById('a-empty')(store as any)).toBeUndefined();
+
+    await lifecycle('client', get).completeRun(
+      completeEvent('client', { runtimeStatus: 'interrupted' }),
+    );
+
+    // The server-side delete actually fired, resolved against the RUN's own
+    // conversation rather than the now-active one. This is the assertion that
+    // catches the bug: the active-scoped path reaches its store action too, then
+    // silently drops the delete on the missed lookup and never gets here.
+    expect(removeMessage).toHaveBeenCalledWith('a-empty', CONTEXT);
+    expect(store.optimisticDeleteMessage).toHaveBeenCalledWith('a-empty', { operationId: OP });
   });
 });
 

--- a/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
@@ -371,6 +371,57 @@ export const buildRunLifecycle = (
         });
       };
 
+      // On a cancelled run the assistant placeholder can be left EMPTY — no
+      // content, reasoning, tools or error — because the stream was aborted
+      // before it produced anything (Stop during TTFT, or during the provider
+      // retry backoff). Nothing else on the cancel path finalizes it, so it
+      // lingers as a perpetually-"generating" empty bubble that survives reloads
+      // in server DB mode (#17723). Drop it, the same way resumeReplay trims a
+      // trailing empty placeholder. Client + top-level + real topic only,
+      // mirroring resetActiveTopicRunningStatus; a placeholder that recorded an
+      // error is kept so the failure stays visible.
+      const cleanupEmptyAssistantPlaceholderOnCancel = async () => {
+        if (adapter.runtimeType !== 'client') return;
+        if (adapter.runScope === 'sub_agent') return;
+        if (disposition !== 'cancelled') return;
+        if (!topicId) return;
+
+        const messages = get().messagesMap[messageKey] || [];
+        const assistantMessageId = findCompletionAssistantMessageId(
+          messages,
+          parentMessageId,
+          parentMessageType,
+        );
+        if (!assistantMessageId) return;
+
+        const assistantMessage = messages.find((message) => message.id === assistantMessageId);
+        if (!assistantMessage || assistantMessage.role !== 'assistant') return;
+
+        const isEmptyPlaceholder =
+          !assistantMessage.content?.trim() &&
+          !assistantMessage.error &&
+          (assistantMessage.tools?.length ?? 0) === 0 &&
+          (assistantMessage.imageList?.length ?? 0) === 0 &&
+          !assistantMessage.reasoning?.content?.trim();
+        if (!isEmptyPlaceholder) return;
+
+        try {
+          // Operation-scoped delete, NOT `deleteMessage`: that one resolves the
+          // message through `displayMessageSelectors.getDisplayMessageById`, which
+          // only searches the ACTIVE conversation, so if the user switched topics
+          // before this cleanup ran it would silently no-op and leave the orphan
+          // row behind. `optimisticDeleteMessage` resolves the conversation from
+          // `operations[operationId].context` — the run's own topic — so the
+          // server-side delete still lands after a topic switch.
+          // Skipping `deleteMessage`'s cascade to assistantGroup children and tool
+          // results is safe here: the guards above already require a plain
+          // 'assistant' role with no tools and no images.
+          await get().optimisticDeleteMessage?.(assistantMessageId, { operationId });
+        } catch (error) {
+          console.error('[completeRun] failed to remove empty aborted assistant message:', error);
+        }
+      };
+
       // 1. afterCompletion callbacks — fire on ALL terminal states (tools that
       //    registered post-run actions: speak / broadcast / delegate).
       const operation = get().operations[operationId];
@@ -458,6 +509,11 @@ export const buildRunLifecycle = (
         // Parked states never reach `completeRun` — the executor routes them to
         // `onRunParked`.
       }
+
+      // Remove the orphan empty assistant placeholder before flipping the topic
+      // status, so a cancelled run leaves neither a stuck spinner nor a blank
+      // "generating" bubble behind.
+      await cleanupEmptyAssistantPlaceholderOnCancel();
 
       // Runs past the requeue early-return, so a run that continues into a queued
       // follow-up (which writes 'running' again) is never reset mid-flight.

--- a/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
@@ -371,15 +371,9 @@ export const buildRunLifecycle = (
         });
       };
 
-      // On a cancelled run the assistant placeholder can be left EMPTY — no
-      // content, reasoning, tools or error — because the stream was aborted
-      // before it produced anything (Stop during TTFT, or during the provider
-      // retry backoff). Nothing else on the cancel path finalizes it, so it
-      // lingers as a perpetually-"generating" empty bubble that survives reloads
-      // in server DB mode (#17723). Drop it, the same way resumeReplay trims a
-      // trailing empty placeholder. Client + top-level + real topic only,
-      // mirroring resetActiveTopicRunningStatus; a placeholder that recorded an
-      // error is kept so the failure stays visible.
+      // A cancelled run can leave the assistant placeholder empty (aborted before
+      // any content/reasoning/tools/error landed); drop it so it doesn't linger as
+      // a stuck "generating" bubble (#17723). A placeholder with an error is kept.
       const cleanupEmptyAssistantPlaceholderOnCancel = async () => {
         if (adapter.runtimeType !== 'client') return;
         if (adapter.runScope === 'sub_agent') return;
@@ -406,16 +400,8 @@ export const buildRunLifecycle = (
         if (!isEmptyPlaceholder) return;
 
         try {
-          // Operation-scoped delete, NOT `deleteMessage`: that one resolves the
-          // message through `displayMessageSelectors.getDisplayMessageById`, which
-          // only searches the ACTIVE conversation, so if the user switched topics
-          // before this cleanup ran it would silently no-op and leave the orphan
-          // row behind. `optimisticDeleteMessage` resolves the conversation from
-          // `operations[operationId].context` — the run's own topic — so the
-          // server-side delete still lands after a topic switch.
-          // Skipping `deleteMessage`'s cascade to assistantGroup children and tool
-          // results is safe here: the guards above already require a plain
-          // 'assistant' role with no tools and no images.
+          // Operation-scoped: deleteMessage resolves via the ACTIVE conversation
+          // only, so it no-ops after a topic switch (#17723).
           await get().optimisticDeleteMessage?.(assistantMessageId, { operationId });
         } catch (error) {
           console.error('[completeRun] failed to remove empty aborted assistant message:', error);


### PR DESCRIPTION
Fixes two loose ends on the **Stop** (cancel) path that surface most painfully in **server DB mode**, where topic status and messages are persisted authoritatively and survive reloads (reported in #17723):

1. **Orphan empty assistant placeholder.** When a run is stopped before it produces any output (Stop during TTFT, or while the provider is in its automatic retry backoff), the assistant placeholder row is left with empty `content`, no `reasoning`, no `tools` and `error = NULL`. Nothing on the cancel path finalizes it, so it renders as a perpetually "generating" blank bubble that survives reloads. `persistInterruptedCallLlmResult` deliberately no-ops for an empty output (`callLlmFinalizer.ts`), and `completeRun` had no placeholder cleanup.

2. **Non-abort-aware retry backoff.** `ClientLLMRetryPolicy.waitForRetry` was a plain `sleep(delayMs)`. The package retry loop (`packages/agent-runtime/src/executors/callLlm.ts`) only re-checks for cancellation *after* `waitForRetry` resolves, so a Stop that lands mid-backoff isn't observed until the full (exponential) delay elapses. During that window the topic stays `running`; if the tab is closed then, it stays `running` until the 2h stale watchdog fires — the "endless spinner" in the report.

### What changed

- `ClientLLMTransport.ts` — `waitForRetry` now races the delay against the operation's `abortController.signal`, resolving immediately when a Stop lands (or if the run was already cancelled). Cancellation is observed on the next loop check instead of after the full backoff.
- `buildRunLifecycle.ts` — `completeRun` now removes the empty assistant placeholder on the **cancelled** disposition (client transport, top-level, real topic), mirroring how `resumeReplay` trims a trailing empty placeholder. A placeholder that recorded an `error` is kept so the failure stays visible.

Both changes are tightly scoped (client transport / top-level / real topic) and reuse the existing terminal-lifecycle seam; no refactor of unrelated code.

> Note: the base "reset topic status out of `running`" on cancel already lands via `resetActiveTopicRunningStatus` (#17372). This PR closes the two remaining gaps that PR did not cover — the empty-placeholder orphan and the backoff window that delays (and, on tab-close, strands) the reset.

| Before | After |
| ------ | ----- |
| Stop during TTFT / retry backoff → empty assistant bubble stuck "generating" + topic spinner keeps spinning through the whole backoff (and forever if the tab is closed mid-backoff). | Stop is observed immediately even mid-backoff; the run completes, the topic status resets to `active`, and the empty placeholder is removed. |

#### Test

Code-level reproduction + unit tests (a full server-DB runtime repro was not run; the fix is covered by targeted tests exercising the real retry policy and the real `completeRun` lifecycle).

- `ClientLLMTransport.test.ts` — `waitForRetry` resolves immediately when already aborted, resolves as soon as the signal aborts mid-wait (without advancing timers), and still waits out the full delay when no abort arrives.
- `buildRunLifecycle.test.ts` — `completeRun` deletes the empty placeholder on client cancel; keeps a placeholder that has content; keeps one that recorded an error; does not delete on success; does not delete for gateway cancel.

Verification:
- `vitest run` on the two touched files → 38 passed.
- `vitest run` across `src/store/chat/agents/transports` + `src/store/chat/slices/agentRun` → 629 passed (36 files).
- `tsgo --noEmit` (type-check) → clean.
- `eslint` on the touched files → clean.

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Closes #17723
