### PR TITLE
💄 style(desktop): spring the tab avatar's inset, and open the close button's room on hover

### DIFF
--- a/src/features/Electron/titlebar/TabBar/TabItem.tsx
+++ b/src/features/Electron/titlebar/TabBar/TabItem.tsx
@@ -11,7 +11,7 @@ import {
 } from '@lobehub/ui';
 import { cx } from 'antd-style';
 import { X } from 'lucide-react';
-import { useMotionValue, useSpring } from 'motion/react';
+import { useMotionValue, useSpring, useTransform } from 'motion/react';
 import * as m from 'motion/react-m';
 import { memo, useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -24,7 +24,7 @@ import { useTabUnread } from './hooks/useTabUnread';
 import { TAB_SPRING } from './motion';
 import { useStyles } from './styles';
 import { buildTabContextMenuItems } from './tabContextMenu';
-import { type TabTier } from './tabLayout';
+import { resolveTabInset, type TabTier } from './tabLayout';
 
 // 20px box on an 8px-round tab, inset a uniform 3px: 8 - 3 = 5 keeps the button's curve
 // concentric with the tab's own. ActionIcon writes blockSize and borderRadius straight
@@ -102,11 +102,21 @@ const TabItem = memo<TabItemProps>(
     const springWidth = useSpring(targetWidth, TAB_SPRING);
     const targetX = useMotionValue(enterX);
     const springX = useSpring(targetX, TAB_SPRING);
+    // The avatar's inset is sprung here rather than switched in the stylesheet. `tier` is
+    // resolved from the target width, so a rule keyed on it lands a whole spring before the
+    // box reaches the width that rule suits: centring from CSS threw the avatar into the
+    // middle of a tab that had not begun to shrink, a jump to the right before the travel
+    // left. Seeded at its resolved value rather than at zero, so a tab that mounts straight
+    // into the icon tier is centred on its first frame instead of sliding into place.
+    const targetInset = useMotionValue(resolveTabInset(width));
+    const springInset = useSpring(targetInset, TAB_SPRING);
+    const inset = useTransform(springInset, (value) => `${value}px`);
     const wasSorting = useRef(false);
 
     useEffect(() => {
       targetWidth.set(width);
-    }, [width, targetWidth]);
+      targetInset.set(resolveTabInset(width));
+    }, [width, targetWidth, targetInset]);
 
     // Dropping a drag must jump, not animate. dnd-kit clears its transform in the same
     // commit that the reordered store lands, and up to that frame the tab is already
@@ -209,6 +219,7 @@ const TabItem = memo<TabItemProps>(
           isDragging && styles.tabDragging,
         )}
         style={{
+          paddingInlineStart: inset,
           // dnd-kit's displacement rides the standalone `translate` property while the
           // offset spring owns `transform`. Both are pure x translations, so they
           // compose, and neither has to be folded into the other's value.

--- a/src/features/Electron/titlebar/TabBar/styles.test.ts
+++ b/src/features/Electron/titlebar/TabBar/styles.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+// Read as source rather than exercised through a rendered tab: the rules under test only
+// exist as `[data-tier]` selectors in a static stylesheet, and a happy-dom render
+// reproduces neither the attribute cascade nor the thing that makes them wrong — the tier
+// landing a whole spring ahead of the width it describes.
+import source from './styles.ts?raw';
+
+const ruleBody = (selector: string): string => {
+  const start = source.indexOf(selector);
+  if (start < 0) throw new Error(`selector not found: ${selector}`);
+
+  const open = source.indexOf('{', start);
+  let depth = 0;
+
+  for (let index = open; index < source.length; index += 1) {
+    if (source[index] === '{') depth += 1;
+    else if (source[index] === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(open + 1, index);
+    }
+  }
+
+  throw new Error(`unbalanced rule: ${selector}`);
+};
+
+describe('icon tier', () => {
+  const body = ruleBody("&[data-tier='icon']");
+
+  // Geometry belongs to the springs in TabItem, which arrive with the width. Anything here
+  // lands on the tier flip instead, a whole spring earlier.
+  it('moves nothing', () => {
+    expect(body).not.toMatch(/padding-inline|justify-content|gap\s*:|width\s*:|flex\s*:/);
+  });
+
+  it('fades the title rather than collapsing it', () => {
+    expect(body).toMatch(/opacity:\s*0/);
+  });
+});

--- a/src/features/Electron/titlebar/TabBar/styles.ts
+++ b/src/features/Electron/titlebar/TabBar/styles.ts
@@ -1,11 +1,25 @@
 import { createStaticStyles } from 'antd-style';
 
+import { TAB_ICON_SIZE, TAB_INLINE_INSET } from './tabLayout';
+
 const TAB_HEIGHT = 26;
 
 export const useStyles = createStaticStyles(({ css, cssVar }) => ({
+  // A fixed slot, because the indicator is not one size: a tab with metadata renders a
+  // 16px Avatar and one without falls back to a 14px Icon. resolveTabInset centres on
+  // TAB_ICON_SIZE for both, so the slot has to be that size or the fallback sits a pixel
+  // off centre in a pinned pill. Measured on the desktop app, not inferred.
   avatarWrapper: css`
     position: relative;
-    flex-shrink: 0;
+
+    display: flex;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+
+    width: ${TAB_ICON_SIZE}px;
+    height: ${TAB_ICON_SIZE}px;
+
     line-height: 0;
   `,
   closeIcon: css`
@@ -77,7 +91,10 @@ export const useStyles = createStaticStyles(({ css, cssVar }) => ({
     align-items: center;
 
     height: ${TAB_HEIGHT}px;
-    padding-inline: 8px 6px;
+
+    /* The start is the resting value only; TabItem overrides it with a sprung inset so the
+       avatar can travel to the middle of a tab that has shrunk to icon width. */
+    padding-inline: ${TAB_INLINE_INSET}px 6px;
     border-radius: ${cssVar.borderRadius};
 
     font-size: 12px;
@@ -112,17 +129,15 @@ export const useStyles = createStaticStyles(({ css, cssVar }) => ({
       margin-inline-end: 17px;
     }
 
-    /* The avatar is the only thing left, so centre it and collapse the title rather than
-       unmounting it — the tab is mid-shrink at this point and a title that pops out of
-       the flow would jerk the avatar sideways instead of gliding it to the middle. */
+    /* Nothing here may touch layout. The tier is resolved from the target width, so this
+       rule lands a whole spring before the box reaches it: centring the avatar from here
+       applied while the tab was still 200px wide and threw it into the middle of a box it
+       had not begun to shrink into — a jump to the right before the travel left. The
+       avatar still centres at this tier, but through the sprung inset in TabItem, which
+       arrives with the width instead of ahead of it. The title likewise only fades:
+       collapsing its width clipped the fade away in the frame it started. */
     &[data-tier='icon'] {
-      gap: 0;
-      justify-content: center;
-      padding-inline: 0;
-
       [data-tab-title] {
-        flex: none;
-        width: 0;
         opacity: 0;
       }
     }

--- a/src/features/Electron/titlebar/TabBar/styles.ts
+++ b/src/features/Electron/titlebar/TabBar/styles.ts
@@ -107,28 +107,6 @@ export const useStyles = createStaticStyles(({ css, cssVar }) => ({
       background-color: ${cssVar.colorFillQuaternary};
     }
 
-    /* Persistent on a full tab, hover-only on a compact one. Below that the tab cannot
-       spare the button's 20px: the title would be cut to a couple of glyphs to make room
-       for it, and at icon width the icon is the only identity signal left. Pinned tabs
-       are always at icon width, so they fall out of this rule too. The button stays
-       mounted at every tier and fades — unmounting it made it vanish mid-pin. */
-    &[data-tier='full'] [data-tab-close],
-    &[data-tier='compact']:hover [data-tab-close] {
-      pointer-events: auto;
-      opacity: 1;
-    }
-
-    /* Reserve the button's footprint whether or not it is currently visible, so the
-       title's fade lands before it and no glyph is ever drawn under the button. Margin
-       rather than padding: the mask applies to the padding box, so padding would put the
-       gradient inside the reservation instead of at the text's edge. Keeping the
-       reservation constant also stops the text reflowing on hover.
-       20px button + 3px inset - the tab's own 6px end padding. */
-    &[data-tier='full'] [data-tab-title],
-    &[data-tier='compact'] [data-tab-title] {
-      margin-inline-end: 17px;
-    }
-
     /* Nothing here may touch layout. The tier is resolved from the target width, so this
        rule lands a whole spring before the box reaches it: centring the avatar from here
        applied while the tab was still 200px wide and threw it into the middle of a box it
@@ -139,6 +117,38 @@ export const useStyles = createStaticStyles(({ css, cssVar }) => ({
     &[data-tier='icon'] {
       [data-tab-title] {
         opacity: 0;
+      }
+    }
+
+    /* The button and the room for it are one rule on purpose: reserving the footprint
+       full-time cost the title 17px it almost never needed, and revealing the button
+       without the reservation would run the title's fade straight under it. Sharing a
+       selector makes the second state unreachable. Both sides ease over the same 0.15s,
+       so the gap opens exactly as the glyph arrives.
+
+       Below the compact tier neither appears: the tab cannot spare the button's 20px —
+       the title would be cut to a couple of glyphs — and at icon width the avatar is the
+       only identity signal left. Pinned tabs are always at icon width, so they fall out
+       too. The button stays mounted at every tier and fades; unmounting it made it vanish
+       mid-pin.
+
+       :has() carries the keyboard path — the button is focusable at these tiers, so
+       without it a tabbing user would land on something invisible.
+
+       Reservation is 20px button + 3px inset - the tab's own 6px end padding. Margin
+       rather than padding: the mask applies to the padding box, so padding would put the
+       gradient inside the reservation instead of at the text's edge. */
+    &[data-tier='full']:hover,
+    &[data-tier='compact']:hover,
+    &[data-tier='full']:has([data-tab-close]:focus-visible),
+    &[data-tier='compact']:has([data-tab-close]:focus-visible) {
+      [data-tab-close] {
+        pointer-events: auto;
+        opacity: 1;
+      }
+
+      [data-tab-title] {
+        margin-inline-end: 17px;
       }
     }
   `,
@@ -222,7 +232,9 @@ export const useStyles = createStaticStyles(({ css, cssVar }) => ({
     color: ${cssVar.colorText};
     white-space: nowrap;
 
-    transition: opacity 0.12s ${cssVar.motionEaseInOut};
+    transition:
+      margin-inline-end 0.15s ${cssVar.motionEaseInOut},
+      opacity 0.12s ${cssVar.motionEaseInOut};
 
     /* The one physical direction left in this file — mask-image has no logical form, and
        nothing in the app sets dir="rtl". max(60%, …) caps the ramp at 40% of the box:

--- a/src/features/Electron/titlebar/TabBar/tabLayout.test.ts
+++ b/src/features/Electron/titlebar/TabBar/tabLayout.test.ts
@@ -10,8 +10,11 @@ import {
   PINNED_DIVIDER_WIDTH,
   PINNED_TAB_WIDTH,
   resolvePlacements,
+  resolveTabInset,
   resolveTabTier,
   TAB_GAP,
+  TAB_ICON_SIZE,
+  TAB_INLINE_INSET,
 } from './tabLayout';
 
 const totalWidth = (widths: number[]) =>
@@ -29,6 +32,25 @@ describe('resolveTabTier', () => {
     [MIN_TAB_WIDTH, 'icon'],
   ])('maps %ipx to %s', (width, tier) => {
     expect(resolveTabTier(width)).toBe(tier);
+  });
+});
+
+describe('resolveTabInset', () => {
+  it('leads the title from a fixed inset while a title is still shown', () => {
+    expect(resolveTabInset(MAX_TAB_WIDTH)).toBe(TAB_INLINE_INSET);
+    expect(resolveTabInset(58)).toBe(TAB_INLINE_INSET);
+  });
+
+  it('centres the avatar once it is the only content left', () => {
+    expect(resolveTabInset(57)).toBe((57 - TAB_ICON_SIZE) / 2);
+    expect(resolveTabInset(MIN_TAB_WIDTH)).toBe((MIN_TAB_WIDTH - TAB_ICON_SIZE) / 2);
+  });
+
+  // Pinning sends a tab across the whole strip while it shrinks by 168px, so it is the one
+  // width change where a sprung inset would read as the avatar drifting inside its own tab.
+  // The pinned width is chosen to land back on the inset the tab already had.
+  it('resolves a pinned pill to the inset it started from', () => {
+    expect(resolveTabInset(PINNED_TAB_WIDTH)).toBe(TAB_INLINE_INSET);
   });
 });
 

--- a/src/features/Electron/titlebar/TabBar/tabLayout.ts
+++ b/src/features/Electron/titlebar/TabBar/tabLayout.ts
@@ -1,7 +1,13 @@
 export const MAX_TAB_WIDTH = 200;
 export const MIN_TAB_WIDTH = 40;
 export const ACTIVE_TAB_MIN_WIDTH = 150;
-export const PINNED_TAB_WIDTH = 34;
+export const TAB_ICON_SIZE = 16;
+// Where the avatar sits while a title shares the tab with it.
+export const TAB_INLINE_INSET = 8;
+// Sized so that `resolveTabInset` returns TAB_INLINE_INSET for it: a pinned pill centres
+// the avatar on the inset it already had, so pinning — the longest journey any tab makes —
+// moves the avatar not at all relative to its own tab.
+export const PINNED_TAB_WIDTH = TAB_ICON_SIZE + TAB_INLINE_INSET * 2;
 export const TAB_GAP = 2;
 export const OVERFLOW_CONTROL_WIDTH = 34;
 export const PINNED_DIVIDER_MARGIN = 6;
@@ -29,6 +35,14 @@ export const resolveTabTier = (width: number): TabTier => {
   if (width >= 58) return 'narrow';
   return 'icon';
 };
+
+// Below the icon tier the avatar is the only content left, so it takes the middle; above
+// it, it leads the title from a fixed inset. The two rules disagree at the boundary — that
+// is inherent, since centring grows with width while leading does not — so the caller must
+// spring this value rather than apply it outright. Applying it outright is also what the
+// stylesheet used to do, one `tier` flip ahead of the width it was computed for.
+export const resolveTabInset = (width: number): number =>
+  resolveTabTier(width) === 'icon' ? (width - TAB_ICON_SIZE) / 2 : TAB_INLINE_INSET;
 
 const clampWidth = (width: number): number =>
   Math.max(MIN_TAB_WIDTH, Math.min(MAX_TAB_WIDTH, Math.floor(width)));


### PR DESCRIPTION
Follow-up to #17857, which landed the pinned-tab travel. Two motion defects that survived it.

#### Spring the avatar's inset instead of switching it in CSS

`tier` is resolved from the *target* width, so a stylesheet rule keyed on it lands a whole spring before the box reaches the width that rule suits. Pinning a 200px tab flipped `data-tier` to `icon` at once, and `justify-content: center` + `padding-inline: 0` centred the avatar inside a box that had not begun to shrink — measured on the desktop app, the avatar jumped 85px to the right on the first frame and only then travelled left. The nested title rule collapsed to `width: 0` in the same frame, clipping away the 0.12s fade it was supposed to have.

The inset is now its own motion value, sprung on the same `TAB_SPRING` as the width and the offset, targeting `resolveTabInset(targetWidth)`. Centring and leading disagree at the tier boundary — centring grows with width, leading does not — so the discontinuity stays on the target and the spring absorbs it. Deriving the inset from the *animated* width instead was tried and is worse: pinning crosses the 58px threshold, so the avatar would bulge out to 20.5px before coming back.

`PINNED_TAB_WIDTH` is derived as `TAB_ICON_SIZE + TAB_INLINE_INSET * 2` (32, was 34) so `resolveTabInset` returns the inset the tab already had: pinning, the longest journey any tab makes, moves the avatar not at all relative to its own tab. `avatarWrapper` becomes a fixed `TAB_ICON_SIZE` slot — a tab with metadata renders a 16px Avatar and one without falls back to a 14px Icon, while the inset centres on 16 for both.

#### Open the close button's room only on hover

The footprint was reserved at the full and compact tiers whether or not the button was showing, so every tab paid 17px of title it almost never needed. The reservation now arrives with the button.

That makes the button hover-only at the full tier too, where it used to be persistent: revealing it without the reservation would run the title's fade straight under it — at 200px the mask ramp reaches the button's left edge still 85% opaque, so glyphs would sit behind the button. Both live in one selector block now, which makes "button visible, no room for it" unreachable rather than merely avoided, and both ease over the same 0.15s so the gap opens exactly as the button arrives.

`:has([data-tab-close]:focus-visible)` carries the keyboard path. The button is focusable at these tiers, and without it a tabbing user would land on something invisible — a regression this change would otherwise introduce at the full tier.

The icon-tier rule moves above the hover block to keep specificity ascending; the two can never both match, so the order is for stylelint, not the cascade.

| Before | After |
| ------ | ----- |
| Pinning jumps the avatar +85px right on frame 1, then travels back left; title fade clipped to `width: 0` | Avatar never moves right — 0 frames of reversal, settles on the exact centre |
| Every full/compact tab reserves 17px for a close button that is not shown | Reservation arrives with the button; resting tabs get the 17px back as title |

> This is a motion change, so the evidence below is per-frame computed style sampled over CDP on the running desktop app rather than a static screenshot.

#### Test

Sampled computed style per frame over CDP against the desktop app:

**Avatar inset**

- Pin 200px → pinned: 0 frames moving right (was +85px on the first frame), settles on the exact centre.
- Squeeze 58 → 55px: inset springs 8 → 19.5 = `(55-16)/2`, largest single-frame step 1.84px.

**Close button**

- Resting: `margin-inline-end` 0px, close opacity 0, title box 164px of a 200px tab.
- Hover: margin and opacity move together (0.32px/0.019 → 11.01px/0.648 → 17px/1), title box 164 → 147.
- Unhover returns to 0px/0; focusing the button gives 17px/1 with no pointer involved.

**Unit tests** — `bun run check` on the 5 touched files: lint clean, 32 passed.

- `tabLayout.test.ts` covers `resolveTabInset`: leading from a fixed inset while a title still shows, centring once the avatar is the only content left, and a pinned pill resolving to the inset it started from.
- `styles.test.ts` asserts the icon-tier rule declares no layout property at all, and fades the title rather than collapsing it — that is the invariant the sprung-inset timing depends on.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Follow-up to #17857.