### PR TITLE
🐛 fix(error): collapse repeated network-error toasts into one

### DIFF
--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
     "@lobehub/icons": "^5.11.0",
     "@lobehub/market-sdk": "0.39.2",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "^5.24.0",
+    "@lobehub/ui": "^5.27.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@napi-rs/canvas": "^0.1.100",
     "@neondatabase/serverless": "^1.1.0",

--- a/src/components/Error/remoteServerErrorToast.test.ts
+++ b/src/components/Error/remoteServerErrorToast.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { remoteServerErrorToast } from './remoteServerErrorToast';
 
@@ -13,34 +13,30 @@ vi.mock('i18next', () => ({
 }));
 
 beforeEach(() => {
-  vi.useFakeTimers();
   toastError.mockClear();
 });
 
-afterEach(() => {
-  vi.useRealTimers();
-});
-
 describe('remoteServerErrorToast', () => {
-  it('shows the same errorType at most once per interval', () => {
+  it('reuses one toast id per errorType so repeats collapse instead of stacking', () => {
     remoteServerErrorToast('RemoteServerTimeout');
     remoteServerErrorToast('RemoteServerTimeout');
     remoteServerErrorToast('RemoteServerTimeout');
 
-    expect(toastError).toHaveBeenCalledTimes(1);
-    expect(toastError).toHaveBeenCalledWith({
+    expect(toastError).toHaveBeenCalledTimes(3);
+    expect(new Set(toastError.mock.calls.map(([options]) => options.id)).size).toBe(1);
+    expect(toastError).toHaveBeenLastCalledWith({
+      id: 'remote-server-network-error-RemoteServerTimeout',
       title: 'translated_response.RemoteServerTimeout',
     });
-
-    vi.advanceTimersByTime(10_000);
-    remoteServerErrorToast('RemoteServerTimeout');
-    expect(toastError).toHaveBeenCalledTimes(2);
   });
 
-  it('debounces per errorType independently', () => {
+  it('gives each errorType its own id', () => {
     remoteServerErrorToast('RemoteServerDNSFailed');
     remoteServerErrorToast('RemoteServerOffline');
 
-    expect(toastError).toHaveBeenCalledTimes(2);
+    expect(toastError.mock.calls.map(([options]) => options.id)).toEqual([
+      'remote-server-network-error-RemoteServerDNSFailed',
+      'remote-server-network-error-RemoteServerOffline',
+    ]);
   });
 });

--- a/src/components/Error/remoteServerErrorToast.ts
+++ b/src/components/Error/remoteServerErrorToast.ts
@@ -2,14 +2,9 @@ import type { RemoteServerNetworkErrorType } from '@lobechat/types';
 import { toast } from '@lobehub/ui/base-ui';
 import { t } from 'i18next';
 
-const MIN_TOAST_INTERVAL = 10_000;
-const lastShownAt = new Map<string, number>();
-
 export const remoteServerErrorToast = (errorType: RemoteServerNetworkErrorType) => {
-  const now = Date.now();
-  const last = lastShownAt.get(errorType) ?? 0;
-  if (now - last < MIN_TOAST_INTERVAL) return;
-  lastShownAt.set(errorType, now);
-
-  toast.error({ title: t(`response.${errorType}`, { ns: 'error' }) });
+  toast.error({
+    id: `remote-server-network-error-${errorType}`,
+    title: t(`response.${errorType}`, { ns: 'error' }),
+  });
 };


### PR DESCRIPTION
A flaky connection fires the same proxy failure on every request, and each one stacked its own toast until the viewport was a wall of identical "connection refused" cards.

The 10s per-errorType throttle this had was a workaround for the toast API having no notion of identity: it hid duplicates by dropping them, which also dropped the signal that the problem was still happening. `@lobehub/ui` 5.27.0 adds `ToastOptions.id` (lobehub/lobe-ui#594), so give each errorType a stable one instead — repeats now refresh the visible toast, reset its timer, and pull it back to the front of the stack if newer toasts buried it.

```diff
-const MIN_TOAST_INTERVAL = 10_000;
-const lastShownAt = new Map<string, number>();
-
 export const remoteServerErrorToast = (errorType: RemoteServerNetworkErrorType) => {
-  const now = Date.now();
-  const last = lastShownAt.get(errorType) ?? 0;
-  if (now - last < MIN_TOAST_INTERVAL) return;
-  lastShownAt.set(errorType, now);
-
-  toast.error({ title: t(`response.${errorType}`, { ns: 'error' }) });
+  toast.error({
+    id: `remote-server-network-error-${errorType}`,
+    title: t(`response.${errorType}`, { ns: 'error' }),
+  });
 };
```

**Behaviour change worth a look:** the toast now stays up while the network keeps failing (every failure resets its 5s timer) instead of reappearing every 10s. That reads as the honest state — the problem has not gone away — but it is user-visible, so flagging it explicitly.

| Before | After |
| ------ | ----- |
| One toast per failed request; 3-4 identical cards stacked in the corner | One toast that refreshes in place and returns to the front of the stack |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`remoteServerErrorToast.test.ts` now locks the identity contract rather than the timing one: repeated calls for the same errorType all carry a single `id` (so the UI layer collapses them), and distinct errorTypes get distinct ids.

- `bun run check src/components/Error/remoteServerErrorToast.ts src/components/Error/remoteServerErrorToast.test.ts` — lint clean, 2 tests passed
- `bun run check --type` — types clean after the version bump

The dedupe/promote behaviour itself is covered upstream in `src/base-ui/Toast/dedupe.test.tsx` (lobehub/lobe-ui#594), where reverting the implementation fails 3 of the 6 cases.

#### 🔗 Related Issue

Fixes LOBE-12745

Depends on `@lobehub/ui@5.27.0` (lobehub/lobe-ui#594), already published.