### PR TITLE
🐛 fix(mdx): restore the blur-up placeholder on the rewritten Image

### DIFF
--- a/src/components/mdx/Image.tsx
+++ b/src/components/mdx/Image.tsx
@@ -4,8 +4,6 @@ import { Image } from '@lobehub/ui/mdx';
 import { getPlaiceholder } from 'plaiceholder';
 import { type FC } from 'react';
 
-import Img from '@/libs/next/Image';
-
 const DEFAULT_WIDTH = 800;
 
 const fetchImage = async (url: string) => {
@@ -31,15 +29,13 @@ const ImageWrapper: FC<{ alt: string; src: string }> = async ({ alt, src, ...res
         height={height}
         src={src}
         width={DEFAULT_WIDTH}
-        placeholder={
-          <Img
-            alt={alt}
-            height={height}
-            src={base64}
-            style={{ filter: 'blur(24px)', height: 'auto', scale: 1.2, width: '100%' }}
-            width={DEFAULT_WIDTH}
-          />
-        }
+        styles={{
+          wrapper: {
+            backgroundImage: `url(${base64})`,
+            backgroundPosition: 'center',
+            backgroundSize: 'cover',
+          },
+        }}
       />
     );
   } catch {


### PR DESCRIPTION
## Why

`@lobehub/ui` rewrote `Image` on top of a Base UI dialog and dropped the antd/rc-image passthrough, so `placeholder` is no longer a prop.

This is not a latent issue — **`canary` fails type-check right now.** The dependency range is `^5.24.0` and `pnpm-lock.yaml` is gitignored, so every fresh install already resolves to 5.27.0:

```
$ git checkout origin/canary && pnpm install && tsgo --noEmit
src/components/mdx/Image.tsx(34,9): error TS2322: Property 'placeholder' does not exist on type ...
(1 error)
```

## What

Paint the plaiceholder base64 as the wrapper background instead of passing a placeholder node. The real `<img>` covers it once it decodes, so the LQIP effect survives without any client state — which matters here because this is a `'use server'` component.

## Verification

- `tsgo --noEmit`: 1 error before, **0 after**
- `eslint`: clean
- Layering confirmed in Chromium: the decoded image fully covers the background, `imgCoversWrapper: true`

## Known difference

The old placeholder carried `filter: blur(24px)` and `scale: 1.2`. Those cannot be kept on a wrapper background — a `filter` on the wrapper would blur the real image too. The plaiceholder base64 is a tiny image, so `background-size: cover` scales it up and reads as blurred, but it is not pixel-identical to the previous treatment.

## Note

Deliberately does **not** bump `package.json`. `^5.24.0` already floats to 5.27.0, so the bump is cosmetic, and #17873 already carries one — leaving it out avoids a conflict.