### PR TITLE
🐛 fix(image): follow the @lobehub/ui Image rewrite

### DIFF
--- a/src/components/ImageItem/index.tsx
+++ b/src/components/ImageItem/index.tsx
@@ -24,14 +24,6 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   image: css`
     margin-block: 0 !important;
-
-    .ant-image {
-      height: 100% !important;
-
-      img {
-        height: 100% !important;
-      }
-    }
   `,
 }));
 
@@ -61,7 +53,7 @@ const ImageItem = memo<ImageItemProps>(
         height={isSafari ? 'auto' : '100%'}
         isLoading={loading}
         preview={preview}
-        size={IMAGE_SIZE as any}
+        size={IMAGE_SIZE}
         src={url}
         style={{ height: isSafari ? 'auto' : '100%', width: '100%', ...style }}
         actions={

--- a/src/components/mdx/Image.tsx
+++ b/src/components/mdx/Image.tsx
@@ -4,8 +4,6 @@ import { Image } from '@lobehub/ui/mdx';
 import { getPlaiceholder } from 'plaiceholder';
 import { type FC } from 'react';
 
-import Img from '@/libs/next/Image';
-
 const DEFAULT_WIDTH = 800;
 
 const fetchImage = async (url: string) => {
@@ -31,15 +29,13 @@ const ImageWrapper: FC<{ alt: string; src: string }> = async ({ alt, src, ...res
         height={height}
         src={src}
         width={DEFAULT_WIDTH}
-        placeholder={
-          <Img
-            alt={alt}
-            height={height}
-            src={base64}
-            style={{ filter: 'blur(24px)', height: 'auto', scale: 1.2, width: '100%' }}
-            width={DEFAULT_WIDTH}
-          />
-        }
+        styles={{
+          wrapper: {
+            backgroundImage: `url(${base64})`,
+            backgroundPosition: 'center',
+            backgroundSize: 'cover',
+          },
+        }}
       />
     );
   } catch {

--- a/src/features/ChatInput/Mobile/FilePreview/FileItem/Image.tsx
+++ b/src/features/ChatInput/Mobile/FilePreview/FileItem/Image.tsx
@@ -43,7 +43,7 @@ const FileItem = memo<FileItemProps>(({ alt, onRemove, src, loading }) => {
       height={64}
       isLoading={loading}
       objectFit={'cover'}
-      size={IMAGE_SIZE as any}
+      size={IMAGE_SIZE}
       src={src}
       width={64}
       actions={


### PR DESCRIPTION
Follow-up to the `@lobehub/ui` `Image` rewrite (lobehub/lobe-ui#593, shipped in 5.26.0). Three files, ~30 lines.

**`canary` fails type-check today.** The range is `^5.24.0` and `pnpm-lock.yaml` is gitignored, so every fresh install already resolves to 5.27.0:

```
$ git checkout origin/canary && pnpm install && tsgo --noEmit
src/components/mdx/Image.tsx(34,9): error TS2322: Property 'placeholder' does not exist ...
(1 error)
```

## 1. `mdx/Image` — the actual break

The rewrite dropped the antd/rc-image passthrough, so `placeholder` is gone. The LQIP effect is preserved by painting the plaiceholder base64 as the wrapper background; the real `<img>` covers it once it decodes, so no client state is needed — which matters because this is a `'use server'` component.

**Known visual difference:** the old placeholder carried `filter: blur(24px)` and `scale: 1.2`. Neither survives on a wrapper background — a `filter` there would blur the real image too. The base64 is a tiny image so `background-size: cover` still reads as blurred, but it is not pixel-identical.

## 2. `ImageItem` — the `.ant-image` block was already dead

`classNames.wrapper` landed on the same element that carried `.ant-image`, and emotion compiles the nested block to a **descendant** selector — so it looked for an `.ant-image` inside an `.ant-image`:

```
.acss-zsxaxp .ant-image      =>  0 node(s)
.acss-zsxaxp .ant-image img  =>  0 node(s)
```

Measured by rendering the real component on 5.24.0 and querying the emitted stylesheet. Dead-code removal, not a behaviour change.

Deliberately **not** ported to `img { height: 100% }` — that would newly apply a rule that has never been in effect.

## 3. Two inert `size` casts

`size` used to fall into `...rest` and reach the DOM as an invalid attribute. The rewrite resolves it to width/height, but neither call site changes: `ImageItem`'s `editable` has no callers anywhere so `IMAGE_SIZE` is always `'100%'`, and the mobile item pins `width={64} height={64}` explicitly. So the `as any` casts are just noise.

## Verification

- `tsgo --noEmit`: **1 error before, 0 after**
- `eslint`: clean
- Old vs new `ImageItem` geometry compared in Chromium using the real emitted DOM and CSS: root/wrapper/img all 200×200 in both
- LQIP layering confirmed in Chromium: `imgCoversWrapper: true`

**Not covered:** no screenshots from the real product containers. `ImageItem` renders in four places (two conversation image lists, AssistantGroup, the `/image` generation feed) and none were captured — local Web auth could not be seeded without touching the developer's own database.

## Note

Deliberately does **not** bump `package.json`. `^5.24.0` already floats to 5.27.0, so the bump is cosmetic, and #17873 already carried one.