### PR TITLE
🐛 fix(cli): warn when an evidence comparison is dropped for being the wrong shape

### DIFF
--- a/.agents/skills/agent-testing/SKILL.md
+++ b/.agents/skills/agent-testing/SKILL.md
@@ -399,6 +399,14 @@ run metadata so the report can render a separate interaction-cost section.
 
 ### Step 5 — Structured report (mandatory deliverable)
 
+**Read [references/report.md](./references/report.md) in full before writing the
+first line of `result.json`** — it is the schema, and this section is only a
+summary of it. Do not infer field shapes from the snippets here: the fields that
+actually get written wrong are the nested ones (evidence `comparison` pairs,
+structured `visualizations`, `plan[]` verifier metadata), and none of them are
+spelled out below. A field written in the wrong shape is dropped on ingest, so
+the run publishes green with the evidence silently degraded.
+
 Every automated test session ends with a structured, evidence-backed report — not
 a chat-only summary. Scaffold it up front and fill it as you test:
 
@@ -446,6 +454,10 @@ Hard rules worth front-loading:
 - **Visual evidence lives in `result.json`, NOT in `report.md`.** Attach each
   screenshot/GIF to its case via `cases[].evidence`; the page renders it next to
   the check. Do NOT embed images/GIFs in `report.md`.
+- **A before/after pair is one nested `comparison` object per half**, never a
+  flat `comparison` + `role` pair of keys — copy the example in
+  [references/report.md](./references/report.md#workflow) rather than writing it
+  from memory. Both halves need the same `id`, opposite `role`s, and a `label`.
 - **Non-visual behavioral claims use dual text evidence.** Attach two separate
   text artifacts to the same case: a reviewer-facing **reasoning** document and
   an audit-facing **execution** document. The reasoning artifact explains the

--- a/.agents/skills/agent-testing/SKILL.md
+++ b/.agents/skills/agent-testing/SKILL.md
@@ -401,11 +401,10 @@ run metadata so the report can render a separate interaction-cost section.
 
 **Read [references/report.md](./references/report.md) in full before writing the
 first line of `result.json`** — it is the schema, and this section is only a
-summary of it. Do not infer field shapes from the snippets here: the fields that
-actually get written wrong are the nested ones (evidence `comparison` pairs,
-structured `visualizations`, `plan[]` verifier metadata), and none of them are
-spelled out below. A field written in the wrong shape is dropped on ingest, so
-the run publishes green with the evidence silently degraded.
+summary of it. Do not infer a field's shape from the snippets here; the nested
+ones are spelled out there and nowhere else. A field written in the wrong shape
+is dropped on ingest, so the run publishes green with its evidence silently
+degraded.
 
 Every automated test session ends with a structured, evidence-backed report — not
 a chat-only summary. Scaffold it up front and fill it as you test:
@@ -454,10 +453,6 @@ Hard rules worth front-loading:
 - **Visual evidence lives in `result.json`, NOT in `report.md`.** Attach each
   screenshot/GIF to its case via `cases[].evidence`; the page renders it next to
   the check. Do NOT embed images/GIFs in `report.md`.
-- **A before/after pair is one nested `comparison` object per half**, never a
-  flat `comparison` + `role` pair of keys — copy the example in
-  [references/report.md](./references/report.md#workflow) rather than writing it
-  from memory. Both halves need the same `id`, opposite `role`s, and a `label`.
 - **Non-visual behavioral claims use dual text evidence.** Attach two separate
   text artifacts to the same case: a reviewer-facing **reasoning** document and
   an audit-facing **execution** document. The reasoning artifact explains the

--- a/.agents/skills/agent-testing/references/common-mistakes.md
+++ b/.agents/skills/agent-testing/references/common-mistakes.md
@@ -569,3 +569,31 @@ attempt, pass criteria, interpretation, and limitations. The second is an
 execution document: exact command/request, relevant raw output and observed state,
 plus a short mapping from those values to the criteria. Republish both halves in
 every follow-up round so the round remains self-contained.
+
+---
+
+## M28 — Writing a report field from the router's summary instead of opening the linked schema
+
+**Wrong approach**: reading SKILL.md's Step 5, seeing that it describes `result.json`
+and links the format reference, and then writing the file from that summary plus
+inference — without opening the reference. The summary describes what the fields
+_mean_; it does not spell out the nested shapes.
+
+**Why it's wrong**: the fields that get written wrong are exactly the ones a summary
+cannot convey — a before/after `comparison`, a structured visualization, plan-item
+verifier metadata. The plausible-looking guess (a flat `comparison` + `role` pair of
+keys instead of one nested object per half) parses as valid JSON, so nothing on the
+authoring side objects. Ingest then drops the unrecognized shape, exits zero, and the
+published round looks complete.
+
+**What it breaks**: a passing round whose evidence is silently degraded — two
+screenshots that were meant to read as Before / After render as unlabeled siblings,
+so the contrast the case depends on is invisible to the reviewer. It surfaces only
+when a human asks why the page looks wrong, costing a whole extra round.
+
+**Correct approach**: when a step links a schema or format reference, open it before
+writing the artifact, and **copy the example rather than reconstructing it**. After
+ingest, read the command's warnings as failures, not noise: a dropped-field warning
+means the round published incomplete and needs a corrected re-ingest, the same as a
+skipped evidence upload. And when a reviewer reports that something rendered wrong,
+suspect your own metadata shape before the renderer.

--- a/.agents/skills/agent-testing/references/report.md
+++ b/.agents/skills/agent-testing/references/report.md
@@ -95,10 +95,18 @@ table — those double up on the page. It carries only the non-duplicate narrati
      ]
      ```
 
+     `comparison` is a nested **object** on each half. Writing it flat —
+     `{ "path": "…", "comparison": "topic-row", "role": "before" }` — is the
+     usual slip, and it does not pair: `role` is read from inside `comparison`,
+     never from the evidence item itself.
+
      The verify page renders a complete pair with each screenshot under its own
      tinted band — red for `before`, green for `after`. A group contains exactly one
      `before` and one `after`, and **both halves need the same string `id`**; a half
      without an `id` can never pair. Incomplete groups render as ordinary evidence.
+     `acceptance run ingest` warns on every malformed `comparison` it drops —
+     treat that warning as a failed publish and re-ingest a corrected round,
+     exactly as with a skipped evidence upload.
 
      Two fields are worth setting on every pair:
 

--- a/apps/cli/src/commands/verify.test.ts
+++ b/apps/cli/src/commands/verify.test.ts
@@ -9,6 +9,7 @@ import { log } from '../utils/logger';
 import {
   deriveReportVerdict,
   evidenceTypeForFile,
+  formatAnnotationRegion,
   genericContextFromResult,
   inlineTextEvidenceForFile,
   originFromEnv,
@@ -1148,5 +1149,41 @@ describe('lh acceptance — canonical run tree', () => {
     const acceptance = program.commands.find((c) => c.name() === 'acceptance');
     const hasRun = acceptance?.commands.some((c) => c.name() === 'run');
     expect(hasRun).toBe(false);
+  });
+});
+
+describe('formatAnnotationRegion', () => {
+  const rect = { height: 0.03, width: 0.12, x: 0.31, y: 0.24 };
+
+  it('names the evidence the region was drawn on and where on it', () => {
+    expect(
+      formatAnnotationRegion(
+        { comment: 'too light', evidenceId: 'ev-1', rect },
+        new Map([['ev-1', 'c11-profile-editing.png']]),
+      ),
+    ).toBe('c11-profile-editing.png @ 31%,24% · 12%×3%');
+  });
+
+  // Without the filename a reader still cannot tell WHICH screenshot was circled,
+  // so the raw id is better than dropping the reference entirely.
+  it('falls back to the raw evidence id when the label is unknown', () => {
+    expect(formatAnnotationRegion({ evidenceId: 'ev-9', rect })).toBe('ev-9 @ 31%,24% · 12%×3%');
+  });
+
+  it('renders the position alone when the annotation names no evidence', () => {
+    expect(formatAnnotationRegion({ rect })).toBe('31%,24% · 12%×3%');
+  });
+
+  it('renders the evidence alone when the rect is absent', () => {
+    expect(formatAnnotationRegion({ evidenceId: 'ev-1' }, new Map([['ev-1', 'shot.png']]))).toBe(
+      'shot.png',
+    );
+  });
+
+  // Reviews made before regions existed carry only a comment — printing an empty
+  // "└" line under every one of them would be pure noise.
+  it('returns undefined when there is no location at all', () => {
+    expect(formatAnnotationRegion({ comment: 'just a note' })).toBeUndefined();
+    expect(formatAnnotationRegion({ rect: { x: 0.1 } })).toBeUndefined();
   });
 });

--- a/apps/cli/src/commands/verify.test.ts
+++ b/apps/cli/src/commands/verify.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { log } from '../utils/logger';
 import {
   deriveReportVerdict,
   evidenceTypeForFile,
@@ -304,6 +305,37 @@ describe('reportEvidence — comparison normalization', () => {
     expect(
       reportEvidence([{ comparison: { id: 'x' }, path: 'a.png' }])[0].comparison,
     ).toBeUndefined();
+  });
+
+  // The flat shape (`comparison: "row", role: "before"`) is the easiest one to
+  // write from memory, and it used to be the ONLY malformed shape that produced
+  // no warning: the guard parsed the field into an object first, so a string
+  // read as "no comparison at all" and the ingest exited clean while the page
+  // rendered two unpaired images.
+  it('warns and drops a comparison that is not an object', () => {
+    vi.mocked(log.warn).mockClear();
+
+    const [item] = reportEvidence([
+      { comparison: 'row', path: 'before.png', role: 'before' } as unknown,
+    ]);
+
+    expect(item).toEqual({ comparison: undefined, description: undefined, path: 'before.png' });
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('before.png'));
+  });
+
+  it('warns for every malformed comparison shape, and stays quiet for a valid or absent one', () => {
+    const warnsFor = (comparison: unknown) => {
+      vi.mocked(log.warn).mockClear();
+      reportEvidence([{ comparison, path: 'a.png' } as unknown]);
+      return vi.mocked(log.warn).mock.calls.length > 0;
+    };
+
+    expect(warnsFor('row')).toBe(true);
+    expect(warnsFor(['row'])).toBe(true);
+    expect(warnsFor({ id: 'row' })).toBe(true);
+    expect(warnsFor({ id: 'row', role: 'middle' })).toBe(true);
+    expect(warnsFor({ id: 'row', role: 'before' })).toBe(false);
+    expect(warnsFor(undefined)).toBe(false);
   });
 
   it('supports the `file` / `desc` aliases and skips entries with no path', () => {

--- a/apps/cli/src/commands/verify.test.ts
+++ b/apps/cli/src/commands/verify.test.ts
@@ -334,8 +334,18 @@ describe('reportEvidence — comparison normalization', () => {
     expect(warnsFor(['row'])).toBe(true);
     expect(warnsFor({ id: 'row' })).toBe(true);
     expect(warnsFor({ id: 'row', role: 'middle' })).toBe(true);
+
+    // Falsy but present: someone wrote the field, so it is malformed rather
+    // than absent. A truthiness guard would drop these without a word.
+    expect(warnsFor('')).toBe(true);
+    expect(warnsFor(0)).toBe(true);
+    expect(warnsFor(false)).toBe(true);
+    expect(warnsFor(Number.NaN)).toBe(true);
+
+    // Absent is null/undefined only — an evidence item without a pair.
     expect(warnsFor({ id: 'row', role: 'before' })).toBe(false);
     expect(warnsFor(undefined)).toBe(false);
+    expect(warnsFor(null)).toBe(false);
   });
 
   it('supports the `file` / `desc` aliases and skips entries with no path', () => {

--- a/apps/cli/src/commands/verifyAcceptance.ts
+++ b/apps/cli/src/commands/verifyAcceptance.ts
@@ -5,7 +5,8 @@ import { getTrpcClient } from '../api/client';
 import { outputJson, printTable, timeAgo, truncate } from '../utils/format';
 import { log } from '../utils/logger';
 import { attachAcceptanceRunCommands } from './acceptanceRun';
-import { parseSubjectRef } from './verifyHelpers';
+import type { ReviewAnnotationRegion } from './verifyHelpers';
+import { formatAnnotationRegion, parseSubjectRef } from './verifyHelpers';
 
 /**
  * Resolve an acceptance from either its uuid or a `type:id` subject reference —
@@ -191,7 +192,12 @@ export function registerAcceptanceCommands(parent: Command, options?: { deprecat
 
         interface FeedbackEntry {
           actionable: boolean;
-          annotations?: { comment?: string }[];
+          /**
+           * Kept whole. Dropping `evidenceId`/`rect` here used to leave the
+           * reader with a bare note and several plausible targets on the
+           * screenshot — the location is the actionable half of a region.
+           */
+          annotations?: (ReviewAnnotationRegion & { region?: string })[];
           category?: string;
           checkId?: string;
           checkSeq?: number;
@@ -201,6 +207,26 @@ export function registerAcceptanceCommands(parent: Command, options?: { deprecat
           kind: 'check' | 'group';
           roundIndex: number;
           title?: string;
+        }
+
+        // `evidenceId` is opaque on its own — resolve it to the artifact name the
+        // report used. An annotation can point at an older round's evidence, so
+        // the timeline is folded in alongside the check's current evidence.
+        interface EvidenceRow {
+          description?: string | null;
+          id?: string;
+        }
+        const evidenceLabels = new Map<string, string>();
+        for (const check of bundle.checks) {
+          const rows: EvidenceRow[] = [
+            ...(check.evidence ?? []),
+            ...(check.timeline ?? []).flatMap(
+              (entry: { evidence?: EvidenceRow[] }) => entry.evidence ?? [],
+            ),
+          ];
+          for (const row of rows) {
+            if (row?.id && row.description) evidenceLabels.set(row.id, row.description);
+          }
         }
 
         const entries: FeedbackEntry[] = [];
@@ -217,7 +243,10 @@ export function registerAcceptanceCommands(parent: Command, options?: { deprecat
             );
             entries.push({
               actionable: standing,
-              annotations: review.annotations?.map((a) => ({ comment: a.comment })),
+              annotations: review.annotations?.map((a: ReviewAnnotationRegion) => ({
+                ...a,
+                region: formatAnnotationRegion(a, evidenceLabels),
+              })),
               checkId: check.id,
               checkSeq: check.seq,
               comment: review.comment ?? '',
@@ -269,6 +298,7 @@ export function registerAcceptanceCommands(parent: Command, options?: { deprecat
           if (entry.comment) console.log(`    ${entry.comment}`);
           for (const annotation of entry.annotations ?? []) {
             if (annotation.comment) console.log(`    ${pc.dim('region:')} ${annotation.comment}`);
+            if (annotation.region) console.log(`      ${pc.dim(`└ ${annotation.region}`)}`);
           }
           if (entry.fileIds?.length)
             console.log(`    ${pc.dim(`attachments: ${entry.fileIds.join(', ')}`)}`);

--- a/apps/cli/src/commands/verifyHelpers.ts
+++ b/apps/cli/src/commands/verifyHelpers.ts
@@ -387,9 +387,14 @@ export function reportEvidence(evidence: unknown): ReportEvidenceInput[] {
       // The report viewer pairs on `id` and drops any comparison lacking one, so
       // an id-less half could never render side by side. Warn rather than upload
       // a comparison that is silently downgraded to an ordinary image.
-      if (comparison && !(id && (role === 'before' || role === 'after'))) {
+      //
+      // Test the raw field, not the parsed object: a comparison written flat
+      // (`comparison: "row", role: "before"`) is not an object at all, so keying
+      // the warning off `objectValue()` skipped the one shape that most needs
+      // it — the author saw a clean ingest and unpaired images on the page.
+      if (value.comparison && !(comparison && id && (role === 'before' || role === 'after'))) {
         log.warn(
-          `evidence ${evidencePath}: comparison needs both a string "id" and role "before"/"after" — ignoring it`,
+          `evidence ${evidencePath}: comparison must be an object with a string "id" and role "before"/"after" — ignoring it`,
         );
       }
       const layout = comparison?.layout === 'vertical' ? 'vertical' : undefined;

--- a/apps/cli/src/commands/verifyHelpers.ts
+++ b/apps/cli/src/commands/verifyHelpers.ts
@@ -392,7 +392,10 @@ export function reportEvidence(evidence: unknown): ReportEvidenceInput[] {
       // (`comparison: "row", role: "before"`) is not an object at all, so keying
       // the warning off `objectValue()` skipped the one shape that most needs
       // it — the author saw a clean ingest and unpaired images on the page.
-      if (value.comparison && !(comparison && id && (role === 'before' || role === 'after'))) {
+      // Absent means null/undefined only; `""` / `0` / `false` are malformed
+      // values that were written on purpose, so they warn like any other.
+      const hasComparison = value.comparison !== undefined && value.comparison !== null;
+      if (hasComparison && !(comparison && id && (role === 'before' || role === 'after'))) {
         log.warn(
           `evidence ${evidencePath}: comparison must be an object with a string "id" and role "before"/"after" — ignoring it`,
         );

--- a/apps/cli/src/commands/verifyHelpers.ts
+++ b/apps/cli/src/commands/verifyHelpers.ts
@@ -798,3 +798,46 @@ export function statusColor(status: string): string {
   if (status === 'running') return pc.yellow(status);
   return pc.dim(status);
 }
+
+/** A region a reviewer circled on one evidence image. */
+export interface ReviewAnnotationRegion {
+  comment?: string;
+  evidenceId?: string;
+  rect?: { height?: number; width?: number; x?: number; y?: number };
+}
+
+const asPercent = (value?: number) =>
+  typeof value === 'number' && Number.isFinite(value) ? `${Math.round(value * 100)}%` : undefined;
+
+/**
+ * Where a review annotation points, rendered for a terminal.
+ *
+ * The comment alone is not enough to act on: a screenshot usually has several
+ * plausible targets, and without the image and the rect the reader has to guess
+ * which one was circled. `rect` is normalized to the image box (0–1), so it is
+ * printed as percentages.
+ *
+ * Returns `undefined` when the annotation carries no location at all — an older
+ * review, or one made before regions existed.
+ */
+export function formatAnnotationRegion(
+  annotation: ReviewAnnotationRegion,
+  evidenceLabels?: Map<string, string>,
+): string | undefined {
+  const label = annotation.evidenceId
+    ? (evidenceLabels?.get(annotation.evidenceId) ?? annotation.evidenceId)
+    : undefined;
+
+  const { rect } = annotation;
+  const x = asPercent(rect?.x);
+  const y = asPercent(rect?.y);
+  const width = asPercent(rect?.width);
+  const height = asPercent(rect?.height);
+  const at = x && y ? `${x},${y}` : undefined;
+  const size = width && height ? `${width}×${height}` : undefined;
+  const position = [at, size].filter(Boolean).join(' · ');
+
+  if (!label && !position) return undefined;
+  if (!position) return label;
+  return label ? `${label} @ ${position}` : position;
+}


### PR DESCRIPTION
`reportEvidence` already had a guard whose comment states the intent plainly — *"Warn rather than upload a comparison that is silently downgraded to an ordinary image."* It missed the one shape that most needs it.

```ts
const comparison = objectValue(value.comparison);   // string → undefined
...
if (comparison && !(id && (role === 'before' || role === 'after'))) { log.warn(…) }
```

The field is parsed into an object *before* the guard runs. A comparison written flat —

```json
{ "path": "assets/before.png", "comparison": "topic-row", "role": "before" }
```

— is a string, so `objectValue()` returns `undefined`, `comparison` is falsy, and the branch never executes. `acceptance run ingest` exits 0 with no warning while the verify page renders the two screenshots as unpaired siblings. Malformed comparison *objects* warned correctly; only the wrong-type case was silent, which is the shape you get when the field is written from memory rather than copied from the schema.

This happened on a real run: a before/after pair published unlabeled, and it surfaced only when a human asked why the page looked wrong.

#### What changed

- **`apps/cli/src/commands/verifyHelpers.ts`** — decide "is there a comparison here?" from the raw field rather than the parsed object, so a string, an array, a number, or a malformed object all warn. Absence is `null` / `undefined` only: a truthiness test would let `""`, `0`, `false` and `NaN` through as "no comparison at all", dropping a field the author did write and leaving open the same silent-degradation path this fixes.
- **`.agents/skills/agent-testing/SKILL.md`** — Step 5 now requires reading `references/report.md` before writing the first line of `result.json`, and says why: Step 5 is a summary, and the nested field shapes are spelled out in the reference and nowhere else. No field-level detail is restated here — that would duplicate the schema and invite the two copies to drift.
- **`.agents/skills/agent-testing/references/report.md`** — calls out the flat form as the usual slip next to the correct example, and says an ingest warning about a dropped `comparison` should be treated as a failed publish (same rule the doc already has for a skipped evidence upload).
- **`.agents/skills/agent-testing/references/common-mistakes.md`** — M28: writing a report field from the router's summary instead of opening the linked schema.

#### Test

`apps/cli/src/commands/verify.test.ts` gains two cases: a non-object `comparison` must warn *and* drop, and a table asserting every malformed shape warns (`"row"`, `["row"]`, `{id}` alone, a bad role, plus `""` / `0` / `false` / `NaN`) while a valid one, `undefined` and `null` stay quiet.

Both regressions are proven, not assumed — against `canary` the suite is 2 failed / 72 passed, and against the first commit's truthiness guard the falsy rows alone fail (1 failed / 73 passed). With both commits the file is 74 passing. Lint clean; the full type-check reports nothing in the touched files.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Found while iterating on #17861, whose round-1 acceptance shipped an unpaired before/after because of this.