### PR TITLE
🐛 fix: gate the agent config entries on both halves of configure access

### DIFF
--- a/src/routes/(main)/agent/profile/features/Header/index.test.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/index.test.tsx
@@ -36,6 +36,10 @@ const mocks = vi.hoisted(() => ({
     removeAgent: vi.fn(),
   },
   navigate: vi.fn(),
+  // The two independent halves of "may configure this agent": the workspace
+  // role permission and this agent's General Access level.
+  permission: { allowed: true },
+  resourceAccess: { canEditResource: true, canManageResource: true },
   profileState: {
     editor: undefined as { getDocument: (format: string) => string | undefined } | undefined,
     lockState: { holderId: null as string | null, lockedByOther: false, pending: false },
@@ -49,18 +53,22 @@ vi.mock('@lobechat/const', async (importOriginal) => ({
 
 interface MockDropdownItem {
   children?: MockDropdownItem[];
+  disabled?: boolean;
   key?: string;
   label?: ReactNode;
   onClick?: () => void;
   type?: string;
 }
 
+// `disabled` is forwarded rather than dropped: the permission entries below are
+// deliberately rendered-but-disabled, so a harness that ignores the flag would
+// report them as available and pass no matter what the component decides.
 const renderMenuItems = (items: MockDropdownItem[]) =>
   items
     .filter((item) => item.type !== 'divider')
     .map((item) => (
       <div key={item.key}>
-        <button type="button" onClick={item.onClick}>
+        <button disabled={item.disabled} type="button" onClick={item.onClick}>
           {item.label}
         </button>
         {item.children && <div>{renderMenuItems(item.children)}</div>}
@@ -160,8 +168,12 @@ vi.mock('@/features/ResourcePermission/AccessLevelTag', () => ({
   ),
 }));
 
+vi.mock('@/hooks/usePermission', () => ({
+  usePermission: () => mocks.permission,
+}));
+
 vi.mock('@/features/ResourcePermission/useResourceAccess', () => ({
-  useResourceAccess: () => ({ canEditResource: true, canManageResource: true }),
+  useResourceAccess: () => mocks.resourceAccess,
 }));
 
 vi.mock('@/features/NavHeader', () => ({
@@ -259,6 +271,37 @@ describe('Agent profile Header', () => {
     mocks.agentState.visibility = 'public';
     mocks.globalState.showAgentBuilderPanel = false;
     mocks.profileState.editor = undefined;
+    mocks.permission.allowed = true;
+    mocks.resourceAccess.canEditResource = true;
+    mocks.resourceAccess.canManageResource = true;
+  });
+
+  // `ResourceConfigAccessGate` requires the role permission AND resource-level
+  // edit access. A member whose role cannot edit content but who holds `edit`
+  // General Access on this agent satisfies only the second half — offering them
+  // an enabled entry sends them to a page that immediately bounces them back.
+  it.each([
+    ['the role cannot edit content', { canEditResource: true, permission: false }],
+    ['General Access is view-only', { canEditResource: false, permission: true }],
+  ])('disables the config entries when %s', (_label, { canEditResource, permission }) => {
+    mocks.permission.allowed = permission;
+    mocks.resourceAccess.canEditResource = canEditResource;
+    // No global mock reset in this file, so the shared spy carries calls in
+    // from earlier cases; a "never navigated" assertion has to start clean.
+    mocks.navigate.mockClear();
+
+    render(<Header />);
+
+    const settings = screen.getByRole('button', { name: 'advancedSettings' });
+    const permissionEntry = screen.getByRole('button', { name: 'permission.page.entry' });
+
+    expect(settings).toBeDisabled();
+    expect(permissionEntry).toBeDisabled();
+
+    // The handler guards independently of the `disabled` prop, since the real
+    // menu renders through a component that may still deliver the click.
+    fireEvent.click(permissionEntry);
+    expect(mocks.navigate).not.toHaveBeenCalledWith('/agent/agent-1/permission');
   });
 
   it.each([false, true])(

--- a/src/routes/(main)/agent/profile/features/Header/index.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/index.tsx
@@ -145,6 +145,11 @@ const Header = memo(() => {
   // affordance must not be offered at all.
   const isBuiltinAgent = useAgentStore(builtinAgentSelectors.isBuiltinAgent(activeAgentId));
   const canManage = hasEditPermission && canManageResource && !isBuiltinAgent;
+  // Both halves, in the same order `ResourceConfigAccessGate` applies them: a
+  // role that cannot edit content is refused even where this agent's General
+  // Access says `edit`. Checking only the resource half would re-open the
+  // dead-end click for exactly that member.
+  const canConfigure = hasEditPermission && canEditResource;
 
   const handleDelete = useCallback(() => {
     if (!canManage || !activeAgentId) return;
@@ -227,12 +232,12 @@ const Header = memo(() => {
       {
         // View/use-level members can't edit the agent config — keep the entry
         // visible but disabled (project convention: disabled, not hidden).
-        disabled: !canEditResource,
+        disabled: !canConfigure,
         icon: <Icon icon={Settings2Icon} />,
         key: 'advanced-settings',
         label: t('advancedSettings', { ns: 'setting' }),
         onClick: () => {
-          if (!canEditResource) return;
+          if (!canConfigure) return;
           settingsModalRef.current?.close();
           settingsModalRef.current = openAgentSettingsModal();
         },
@@ -251,12 +256,12 @@ const Header = memo(() => {
             // without edit-level access it redirects straight back with a
             // toast, so an enabled entry here is a click into a dead end.
             // Disabled, not hidden — the member can still see the action exists.
-            disabled: !canEditResource,
+            disabled: !canConfigure,
             icon: <Icon icon={UsersIcon} />,
             key: 'permission',
             label: t('permission.page.entry', { ns: 'setting' }),
             onClick: () => {
-              if (!canEditResource) return;
+              if (!canConfigure) return;
               if (activeAgentId) navigate(`/agent/${activeAgentId}/permission`);
             },
           }
@@ -318,7 +323,7 @@ const Header = memo(() => {
   }, [
     activeAgentId,
     authorName,
-    canEditResource,
+    canConfigure,
     canManage,
     createdAt,
     dateLocale,


### PR DESCRIPTION
Follow-up to #17848 — a P2 Codex raised there after it had already gone green, so it lands as its own PR rather than holding that one up.

## The gap

`ResourceConfigAccessGate` admits a member only when **both** halves hold:

```ts
const canConfigure = accessReady && canEditContent && canEditResource;
```

The two menu entries on the agent profile header checked only the second half. A workspace role that cannot `edit_own_content`, but which holds `edit` General Access on this particular agent, satisfies `canEditResource` alone — so the entries stayed enabled, the click navigated, and the gate bounced them right back with a toast.

That is precisely the dead-end click the disabled state was added to remove, reintroduced through the narrower predicate.

## The fix

Both entries now use `hasEditPermission && canEditResource`, in the same order the gate applies them.

I swept every other `canEditResource` consumer before writing this: the rest already combine both halves (`usePageEditable`, `useChatInputResourceAccess`, the group sidebar and profile, `EditorCanvas`). The `ResourceManager` files that gate on a lone `canEditResources` are *not* the same shape — despite the plural name that binding **is** `usePermission('edit_own_content')`, the role half, and files carry no per-resource General Access. So this was the only instance.

## Test

The regression test fails on `main` for the role-restricted case and passes for the view-only case, which is what pins it to the right gap:

```
× disables the config entries when the role cannot edit content
✓ disables the config entries when General Access is view-only
```

Getting there needed one harness fix: `renderMenuItems` dropped `disabled`, so entries that are deliberately rendered-but-disabled looked available to every assertion in the file. Any test of a disabled entry would have passed regardless of what the component decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)