### PR TITLE
💄 style(home): fold the rail's sections into the main column when it collapses

### DIFF
--- a/src/features/Home/EmptySuggestions.tsx
+++ b/src/features/Home/EmptySuggestions.tsx
@@ -53,7 +53,10 @@ const EmptySuggestions = memo<EmptySuggestionsProps>(({ onSelect }) => {
   const { t } = useTranslation('home');
 
   return (
-    <Flexbox gap={8}>
+    // Inset from the column edge: the composer above and the list rows below
+    // are both padded surfaces, so a flush-left block here reads as hanging
+    // outside the page's own rhythm.
+    <Flexbox gap={12} paddingBlock={8} paddingInline={12}>
       <Flexbox gap={2}>
         <Text className={homeType.sectionLabel}>{t('dashboard.empty.title')}</Text>
         <Text className={homeType.supporting}>{t('dashboard.empty.subtitle')}</Text>

--- a/src/features/Home/HomeModeContent.tsx
+++ b/src/features/Home/HomeModeContent.tsx
@@ -291,7 +291,22 @@ const HomeModeContent = memo<HomeModeContentProps>(({ inlineRail, mode, onSugges
         (briefsInit || Boolean(briefsSWR.error)),
     });
 
-    if (state === 'empty') return <EmptySuggestions onSelect={onSuggestionSelect} />;
+    // The empty short-circuit predates the fold-in: with the rail open it only
+    // skips the main column's own blocks, while news and suggestions live on in
+    // the rail. Folded, it would swallow them too — news needs no activity to
+    // exist. Mirror the expanded page instead: suggestions first, then whatever
+    // folded in (both sections render null when there is nothing to carry).
+    if (state === 'empty') {
+      if (!inlineRail) return <EmptySuggestions onSelect={onSuggestionSelect} />;
+
+      return (
+        <Flexbox gap={32}>
+          <EmptySuggestions onSelect={onSuggestionSelect} />
+          <HomeInbox inlineRail variant={'main'} />
+          <Recommendations variant={'main'} />
+        </Flexbox>
+      );
+    }
 
     return (
       <Flexbox gap={32}>
@@ -319,7 +334,19 @@ const HomeModeContent = memo<HomeModeContentProps>(({ inlineRail, mode, onSugges
   if (!isLogin) return null;
 
   if (mode === 'task') {
-    return <TaskContent />;
+    if (!inlineRail) return <TaskContent />;
+
+    // The rail's sections sit beside task mode while it is open, so a folded
+    // rail must not take them away here either: in flight and what happened
+    // above the task list, suggestions after it. Unread and needs-you stay
+    // hidden — task mode never surfaces them, folded or not.
+    return (
+      <Flexbox gap={32}>
+        <HomeInbox hideNeedsYou hideUnread inlineRail variant={'main'} />
+        <TaskContent />
+        <Recommendations variant={'main'} />
+      </Flexbox>
+    );
   }
 
   return null;

--- a/src/features/Home/HomeModeContent.tsx
+++ b/src/features/Home/HomeModeContent.tsx
@@ -14,6 +14,7 @@ import HomeInbox from '@/features/HomeInbox';
 import { filterTopicsForInboxScope } from '@/features/HomeInbox/scopeTogglePlacement';
 import { splitBriefs } from '@/features/HomeInbox/splitBriefs';
 import { useHomeInboxTopics } from '@/features/HomeInbox/useHomeInboxTopics';
+import Recommendations from '@/features/Recommendations';
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
 import { useClientDataSWR } from '@/libs/swr';
 import { recentKeys } from '@/libs/swr/keys';
@@ -76,6 +77,12 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 }));
 
 interface HomeModeContentProps {
+  /**
+   * The rail is folded away, so this column carries the sections it owns: what
+   * is in flight and what happened stay above the recent topics, and the
+   * suggestions — nothing that happened, only what you could do — land after.
+   */
+  inlineRail?: boolean;
   mode: HomeMode;
   onSuggestionSelect: (prompt: string) => void;
 }
@@ -242,7 +249,7 @@ const TaskContent = memo(() => {
   );
 });
 
-const HomeModeContent = memo<HomeModeContentProps>(({ mode, onSuggestionSelect }) => {
+const HomeModeContent = memo<HomeModeContentProps>(({ inlineRail, mode, onSuggestionSelect }) => {
   const { t } = useTranslation('home');
   const isLogin = useUserStore(authSelectors.isLogin);
   const authLoaded = useUserStore(authSelectors.isLoaded);
@@ -288,7 +295,7 @@ const HomeModeContent = memo<HomeModeContentProps>(({ mode, onSuggestionSelect }
 
     return (
       <Flexbox gap={32}>
-        <HomeInbox variant={'main'} />
+        <HomeInbox inlineRail={inlineRail} variant={'main'} />
         {(state !== 'ready' || topicRecents.length > 0) && (
           <GroupBlock count={topicRecents.length || undefined} title={t('dashboard.chat.recents')}>
             {state === 'error' ? (
@@ -304,6 +311,7 @@ const HomeModeContent = memo<HomeModeContentProps>(({ mode, onSuggestionSelect }
             )}
           </GroupBlock>
         )}
+        {inlineRail && <Recommendations variant={'main'} />}
       </Flexbox>
     );
   }

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -285,7 +285,11 @@ const Home = memo(() => {
             onModeChange={setMode}
           />
         </div>
-        <HomeModeContent mode={mode} onSuggestionSelect={handleSuggestionSelect} />
+        <HomeModeContent
+          inlineRail={railCollapsed && isLogin}
+          mode={mode}
+          onSuggestionSelect={handleSuggestionSelect}
+        />
       </Flexbox>
 
       {isLogin && (

--- a/src/features/HomeInbox/index.tsx
+++ b/src/features/HomeInbox/index.tsx
@@ -20,6 +20,7 @@ import InboxBriefCard from './InboxBriefCard';
 import MarkAllReadButton from './MarkAllReadButton';
 import NeedsYouRailCard from './NeedsYouRailCard';
 import NewsList from './NewsList';
+import { ownsRailSections } from './railSectionPlacement';
 import RunningTasksCard from './RunningTasksCard';
 import { filterTopicsForInboxScope, resolveScopeToggleSection } from './scopeTogglePlacement';
 import { splitBriefs } from './splitBriefs';
@@ -80,12 +81,19 @@ interface InboxSection {
 interface HomeInboxProps {
   hideNeedsYou?: boolean;
   hideUnread?: boolean;
+  /**
+   * Main column only: the rail is collapsed, so the sections it owns (running,
+   * news) fold into this column instead of disappearing with it.
+   */
+  inlineRail?: boolean;
   variant?: 'default' | 'main' | 'rail';
 }
 
-const HomeInbox = memo<HomeInboxProps>(({ hideNeedsYou, hideUnread, variant = 'default' }) => {
+const HomeInbox = memo<HomeInboxProps>((props) => {
+  const { hideNeedsYou, hideUnread, inlineRail, variant = 'default' } = props;
   const isRail = variant === 'rail';
   const isMain = variant === 'main';
+  const showRailSections = ownsRailSections({ inlineRail, variant });
   const { t } = useTranslation('home');
   const isLogin = useUserStore(authSelectors.isLogin);
   const myId = useUserStore(userProfileSelectors.userId);
@@ -259,7 +267,7 @@ const HomeInbox = memo<HomeInboxProps>(({ hideNeedsYou, hideUnread, variant = 'd
   }
 
   // No title: the card already says "3 tasks running" on its own head.
-  if (!isMain && runningTopics.length > 0)
+  if (showRailSections && runningTopics.length > 0)
     sections.push({
       key: 'running',
       node: (
@@ -272,7 +280,7 @@ const HomeInbox = memo<HomeInboxProps>(({ hideNeedsYou, hideUnread, variant = 'd
       ),
     });
 
-  if (!isMain && news.length > 0)
+  if (showRailSections && news.length > 0)
     sections.push({
       action: <MarkAllReadButton news={news} />,
       // Team view: News is still only mine (briefs are per-user), so say so

--- a/src/features/HomeInbox/railSectionPlacement.test.ts
+++ b/src/features/HomeInbox/railSectionPlacement.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { ownsRailSections } from './railSectionPlacement';
+
+describe('ownsRailSections', () => {
+  it('leaves running and news to the rail while it is open', () => {
+    expect(ownsRailSections({ variant: 'main' })).toBe(false);
+    expect(ownsRailSections({ inlineRail: false, variant: 'main' })).toBe(false);
+  });
+
+  it('hands them to the main column once the rail folds away', () => {
+    expect(ownsRailSections({ inlineRail: true, variant: 'main' })).toBe(true);
+  });
+
+  it('keeps them in the rail itself, folded or not', () => {
+    expect(ownsRailSections({ variant: 'rail' })).toBe(true);
+    expect(ownsRailSections({ inlineRail: true, variant: 'rail' })).toBe(true);
+  });
+
+  it('keeps the single-column default carrying everything', () => {
+    expect(ownsRailSections({ variant: 'default' })).toBe(true);
+  });
+});

--- a/src/features/HomeInbox/railSectionPlacement.ts
+++ b/src/features/HomeInbox/railSectionPlacement.ts
@@ -1,0 +1,15 @@
+interface RailSectionPlacementInput {
+  /** The rail is folded away, so the main column carries the sections it owns. */
+  inlineRail?: boolean;
+  variant: 'default' | 'main' | 'rail';
+}
+
+/**
+ * Whether this column carries the sections the rail owns — running and news.
+ *
+ * They live in the rail while it is open; the main column takes them only once
+ * it folds away, which is the difference between "collapsed" and "gone": a
+ * folded rail must not take what is in flight and what happened off the page.
+ */
+export const ownsRailSections = ({ inlineRail, variant }: RailSectionPlacementInput): boolean =>
+  variant !== 'main' || Boolean(inlineRail);

--- a/src/features/Recommendations/index.tsx
+++ b/src/features/Recommendations/index.tsx
@@ -9,6 +9,7 @@ import {
   type DailyBriefRecommendationsUIState,
   useDailyBriefRecommendationsUI,
 } from '@/business/client/useDailyBriefRecommendationsUI';
+import GroupBlock from '@/features/Home/components/GroupBlock';
 import RailCard from '@/features/Home/components/RailCard';
 
 import { useEligibleActions } from './hooks/useEligibleActions';
@@ -26,7 +27,7 @@ export const useRecommendationsVisible = (): boolean => {
 };
 
 interface RecommendationsProps {
-  variant?: 'default' | 'rail';
+  variant?: 'default' | 'main' | 'rail';
 }
 
 const Recommendations = memo<RecommendationsProps>(({ variant = 'default' }) => {
@@ -110,6 +111,15 @@ const Recommendations = memo<RecommendationsProps>(({ variant = 'default' }) => 
       <RailCard action={refresh} title={t('recommendations.title')}>
         {body}
       </RailCard>
+    );
+
+  // In the main column it is one section among the page's other headed blocks,
+  // so it wears the same heading they do instead of its own subtitle line.
+  if (variant === 'main')
+    return (
+      <GroupBlock action={refresh} title={t('recommendations.title')}>
+        {body}
+      </GroupBlock>
     );
 
   return (


### PR DESCRIPTION
Collapsing the Home rail used to take what is in flight and what happened off the page entirely — the running-tasks card, today's briefs, and the suggestions all disappeared with the rail instead of moving somewhere the user could still reach them.

Now the main column carries them while the rail is folded away, in an order that keeps the page readable:

**running → today's briefs → recent topics → suggestions**

What is in flight and what already happened stay above the recent topics; the suggestions — nothing that happened, only what you *could* do — land after them.

Two supporting changes:

- `Recommendations` gains a `main` variant. In the main column it is one section among the page's other headed blocks, so it now wears the same `GroupBlock` heading as its neighbours instead of its own smaller `recommendations.subtitle` line, which otherwise read as an appendix to the recent topics. The `rail` and existing `default` variants are untouched.
- The placement rule is extracted into `ownsRailSections` (`railSectionPlacement.ts`), so it can be pinned by a unit test rather than a component test (per the repo's "no new component tests" rule).

The expanded rail is unaffected: the sections stay in the rail, and the main column shows only the recent topics.

| Before | After |
| ------ | ----- |
| Rail collapsed → running / today's briefs / suggestions vanish from the page; main column shows only recent topics | Rail collapsed → main column shows running → today's briefs → recent topics → suggestions |

#### Test

Verified on the Electron desktop shell against a real signed-in account (2 running tasks, 6 briefs, 3 suggestions, 9 recent topics), across four states — rail expanded/collapsed × 1200px/1000px viewport:

- Expanded (baseline, no regression): rail holds running → briefs → suggestions; main column holds only recent topics.
- Collapsed: main column order is running → briefs → recent topics → suggestions.
- Folding is a *move*, not a copy: a DOM probe gated on `checkVisibility({ checkOpacity, checkVisibilityCSS })` shows exactly one visible instance of each section in every state. (Gating on `getBoundingClientRect()` alone is not enough — the collapsed rail is `visibility: hidden` and keeps its layout boxes.)
- The ≤1100px single-column breakpoint does not change the collapsed order.
- `railSectionPlacement.test.ts` covers the four input combinations; reverting the implementation to the pre-change semantics (`variant !== 'main'`) makes the "folds into the main column" case fail, so the test is not vacuous.

`bun run check`: 6 files lint clean, 4 tests passed. Full type-check clean.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

**Not covered:** dark mode (the desktop theme follows the macOS system appearance, so exercising it would mean changing a device-level setting); web and mobile surfaces; the unread and needs-you sections, which were empty on the test account — they sit above these sections in `HomeInbox`'s existing push order and this diff does not touch their branches.

#### 🔗 Related Issue

None.