### PR TITLE
🧹 chore: clean LOBE-XXX code markers (2026-08-04)

### DIFF
--- a/packages/context-engine/src/engine/messages/__tests__/MessagesEngine.test.ts
+++ b/packages/context-engine/src/engine/messages/__tests__/MessagesEngine.test.ts
@@ -124,7 +124,7 @@ describe('MessagesEngine', () => {
       });
     });
 
-    it('should drop placeholder residue hidden inside tasks containers (LOBE-12572)', async () => {
+    it('should drop placeholder residue hidden inside tasks containers', async () => {
       // TasksFlattenProcessor emits children as role='task' and
       // TaskMessageProcessor converts them to assistant AFTER the flatten —
       // the post-flatten placeholder pass must run after that conversion, or
@@ -155,7 +155,7 @@ describe('MessagesEngine', () => {
       expect(result.messages[0].role).toBe('user');
     });
 
-    it('should not let placeholder-only containers consume history slots (LOBE-12572)', async () => {
+    it('should not let placeholder-only containers consume history slots', async () => {
       // History truncation counts each container as one group; a placeholder-
       // only container must be dropped BEFORE truncation or it eats a slot and
       // then vanishes at the flatten phase, losing a real history turn.

--- a/packages/context-engine/src/processors/__tests__/PlaceholderMessageFilter.test.ts
+++ b/packages/context-engine/src/processors/__tests__/PlaceholderMessageFilter.test.ts
@@ -20,7 +20,7 @@ describe('PlaceholderMessageFilterProcessor', () => {
   it('should remove failed assistant placeholders that carry an error', async () => {
     // Regression: persisted "..." rows from failed generations poisoned the
     // topic — replayed at the payload tail they trigger the Claude 4.6+
-    // assistant-prefill 400 on every subsequent send (LOBE-12572).
+    // assistant-prefill 400 on every subsequent send.
     const context = createContext([
       { content: 'hi', id: 'u1', role: 'user' },
       { content: '...', error: { type: 'CapabilityNotSupported' }, id: 'a1', role: 'assistant' },

--- a/packages/database/src/repositories/search/index.ts
+++ b/packages/database/src/repositories/search/index.ts
@@ -233,10 +233,9 @@ const RECENCY_CANDIDATE_MULTIPLIER = 4;
  * score ordering is real (see `liftsAgentFilter`): trading the exact inline
  * predicate for a score-ordered pool is unsound when the scores backing that
  * order are NULL. Indexing the column instead is tracked with the other
- * missing fast fields in LOBE-12381.
+ * missing fast fields.
  *
- * @see https://linear.app/lobehub/issue/LOBE-12379
- * @see https://linear.app/lobehub/issue/LOBE-12575
+ * Indexing the column is tracked with the other missing fast fields.
  */
 const WORKSPACE_FILTER_CANDIDATE_MULTIPLIER = 5;
 
@@ -269,7 +268,7 @@ const WORKSPACE_FILTER_MIN_CANDIDATES = 500;
 
 /**
  * Flip to `true` once every BM25 index used by this repo carries `workspace_id`
- * as a fast keyword field (LOBE-12381). pg_search then pushes `workspace_id IS
+ * as a fast keyword field. pg_search then pushes `workspace_id IS
  * NULL` down as `must_not: exists(workspace_id)` and `workspace_id = ?` as a
  * `term`, so the ownership predicate can stay inline and personal search becomes
  * exact again (no candidate over-fetch, no dropped rows) while workspace-mode
@@ -311,7 +310,7 @@ export class SearchRepo {
    * approximation. Workspace mode has no such pushdown-able owner column — its
    * rows are a tiny slice of a global TopN — so lifting the filter there would
    * silently return nothing. It keeps the exact inline predicate and stays on
-   * the slow plan until LOBE-12381 lands.
+   * the slow plan until `workspace_id` becomes a fast keyword field in the BM25 index.
    */
   private get liftsWorkspaceFilter() {
     return !WORKSPACE_ID_IN_BM25_INDEX && !this.workspaceId;
@@ -324,7 +323,7 @@ export class SearchRepo {
    * pool, which is only sound while the scan's `ORDER BY paradedb.score()` is
    * real. Personal mode qualifies: its scan keeps only pushdown-able quals, so
    * scores are valid and the pool is genuinely the top-N matches. Workspace
-   * mode does not (until LOBE-12381 makes `workspace_id` a fast field): its
+   * mode does not (until `workspace_id` becomes a fast field in the BM25 index): its
    * inline `workspace_id` qual NULLs the whole score column on pg_search
    * 0.15.26, so a pool cut on that ordering would be an arbitrary slice that
    * silently drops agent rows. It keeps `agent_id` inline next to
@@ -1017,7 +1016,7 @@ export class SearchRepo {
    * the plain index-scan plan: `knowledge_base_id` is not in the BM25 index
    * either, so isolating the scan would not buy TopN. The KB filter does bound
    * the match set to one knowledge base (via its btree index), which keeps it
-   * workable until LOBE-12381 adds the missing fast fields.
+   * workable until `workspace_id` and `visibility` become fast fields in the BM25 index.
    */
   async searchKnowledgeBaseDocuments(
     query: string,

--- a/packages/model-runtime/src/providers/anthropic/claudePrefill.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/claudePrefill.test.ts
@@ -14,7 +14,7 @@ describe('stripUnsupportedClaudeAssistantPrefill', () => {
   });
 
   it('should strip ALL stacked trailing assistant messages', () => {
-    // Regression LOBE-12572: failed-run placeholders can stack multiple
+    // Regression: failed-run placeholders can stack multiple
     // assistant turns at the tail; popping only one still returns 400.
     const messages = [
       user('hi'),

--- a/packages/model-runtime/src/providers/anthropic/claudePrefill.ts
+++ b/packages/model-runtime/src/providers/anthropic/claudePrefill.ts
@@ -8,7 +8,7 @@ import { shouldDropUnsupportedClaudeAssistantPrefill } from './modelId';
  * unsupported assistant prefill and returns 400 before generation starts.
  *
  * A single trailing pop is not enough: failed-run placeholder rows can stack
- * multiple assistant messages at the payload tail (see LOBE-12572), so strip
+ * multiple assistant messages at the payload tail, so strip
  * until the conversation ends with a non-assistant turn. Models that still
  * support prefill are left untouched.
  * @see https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prefill-claudes-response

--- a/packages/model-runtime/src/providers/anthropic/index.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/index.test.ts
@@ -909,7 +909,7 @@ describe('LobeAnthropicAI', () => {
         ]);
       });
 
-      it('should drop ALL stacked trailing assistant messages (LOBE-12572)', async () => {
+      it('should drop ALL stacked trailing assistant messages', async () => {
         // Failed-run placeholder rows can stack several assistant turns at the
         // payload tail; popping only one still triggers the prefill 400.
         const payload: ChatStreamPayload = {

--- a/packages/model-runtime/src/providers/bedrock/index.test.ts
+++ b/packages/model-runtime/src/providers/bedrock/index.test.ts
@@ -244,7 +244,7 @@ describe('LobeBedrockAI', () => {
         ]);
       });
 
-      it('should drop ALL stacked trailing assistant messages (LOBE-12572)', async () => {
+      it('should drop ALL stacked trailing assistant messages', async () => {
         const mockStream = new ReadableStream({
           start(controller) {
             controller.enqueue('Hello, world!');
@@ -278,7 +278,7 @@ describe('LobeBedrockAI', () => {
 
       it('should drop assistant prefill when a logical id maps to a Claude 5 Bedrock id', async () => {
         // The channel modelIdMapping resolves the actually-sent Bedrock model
-        // id; the prefill guard must follow it, not the logical id (LOBE-12572).
+        // id; the prefill guard must follow it, not the logical id.
         const mappedInstance = new LobeBedrockAI({
           accessKeyId: 'test-access-key-id',
           accessKeySecret: 'test-access-key-secret',
@@ -1358,7 +1358,7 @@ describe('LobeBedrockAI', () => {
 
     it('should drop assistant prefill in generateObject when a logical id maps to Claude 5', async () => {
       // The prefill guard must follow the resolved Bedrock model id, not the
-      // logical alias the channel mapping hides it behind (LOBE-12572).
+      // logical alias the channel mapping hides it behind.
       const mappedInstance = new LobeBedrockAI({
         accessKeyId: 'test-access-key-id',
         accessKeySecret: 'test-access-key-secret',

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
@@ -354,7 +354,7 @@ describe('Agent profile EditorCanvas', () => {
   it('does not bubble mode-switch clicks to the click-to-focus wrapper', () => {
     // The profile page wraps the canvas in a click-to-focus area; a bubbled
     // toggle click would focus the editor and scroll to the caret at the
-    // document end. See LOBE-12593.
+    // document end.
     const onWrapperClick = vi.fn();
     render(
       <div onClick={onWrapperClick}>

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
@@ -452,7 +452,6 @@ const AgentEditorCanvas = memo<AgentEditorCanvasProps>(({ agentId }) => {
               // bubbled click, and Lexical's focus() moves the caret to the
               // document end when there is no selection — scrolling the page to
               // the bottom. Toggling the view mode must not move the caret.
-              // See LOBE-12593.
               onClick={(e) => e.stopPropagation()}
             >
               <ActionIcon

--- a/src/routes/(main)/agent/profile/features/useClickToFocusEditor.test.ts
+++ b/src/routes/(main)/agent/profile/features/useClickToFocusEditor.test.ts
@@ -36,7 +36,7 @@ describe('useClickToFocusEditor', () => {
     // Lexical's focus() selects the document end when no selection exists, so
     // focusing the display:none visual editor leaves a dirty end-of-document
     // selection that scrolls the page to the bottom once the editor becomes
-    // visible again. See LOBE-12593.
+    // visible again.
     getRootElement.mockReturnValue({ offsetParent: null });
     const { result } = renderHook(() => useClickToFocusEditor(editor, true));
 

--- a/src/routes/(main)/agent/profile/features/useClickToFocusEditor.ts
+++ b/src/routes/(main)/agent/profile/features/useClickToFocusEditor.ts
@@ -10,7 +10,7 @@ import { type MouseEvent, useCallback } from 'react';
  * `display: none`). Lexical's `focus()` falls back to `selectEnd()` when the
  * editor has no selection, so focusing the hidden editor leaves a dirty
  * end-of-document selection that scrolls the page to the bottom once the editor
- * becomes visible again. See LOBE-12593.
+ * becomes visible again.
  */
 export const useClickToFocusEditor = (editor: IEditor | undefined, canEdit: boolean) =>
   useCallback(


### PR DESCRIPTION
## Summary

Automated daily scan and cleanup of `LOBE-XXX` format markers from source code.

## Changes

Replaced LOBE issue references with descriptive context from the resolved Linear issues:

| Marker | Description | Files |
|--------|-------------|-------|
| LOBE-12572 | Failed-run assistant placeholders poisoning topics with stacked prefill | 7 files |
| LOBE-12593 | View-mode toggle scrolling to bottom due to dirty editor focus | 4 files |
| LOBE-12381 | BM25 index missing workspace_id/visibility fast fields (pending) | 1 file |
| LOBE-12379 | Search latency degradation root cause (resolved) | removed @see |
| LOBE-12575 | Agent-scoped search score/ordering fix (resolved) | removed @see |

## Files changed

```
packages/context-engine/src/engine/messages/__tests__/MessagesEngine.test.ts
packages/context-engine/src/processors/__tests__/PlaceholderMessageFilter.test.ts
packages/database/src/repositories/search/index.ts
packages/model-runtime/src/providers/anthropic/claudePrefill.test.ts
packages/model-runtime/src/providers/anthropic/claudePrefill.ts
packages/model-runtime/src/providers/anthropic/index.test.ts
packages/model-runtime/src/providers/bedrock/index.test.ts
src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
src/routes/(main)/agent/profile/features/useClickToFocusEditor.test.ts
src/routes/(main)/agent/profile/features/useClickToFocusEditor.ts
```

## Verification

- ✅ Lint clean (11 files)
- ✅ Tests pass (185/185)
- ✅ Zero remaining LOBE-XXX markers in modified files