### PR TITLE
✨ feat(home): add mine/team scope & author chips to recent topics

### DIFF
--- a/apps/server/src/routers/lambda/recent.ts
+++ b/apps/server/src/routers/lambda/recent.ts
@@ -21,6 +21,8 @@ export interface RecentItem {
   title: string;
   type: 'topic' | 'document' | 'task';
   updatedAt: Date;
+  /** The member who owns this item — for author attribution in workspace team views. */
+  userId?: string;
 }
 
 const recentProcedure = wsCompatProcedure.use(serverDatabase).use(async (opts) => {
@@ -38,6 +40,8 @@ export const recentRouter = router({
       z
         .object({
           limit: z.number().optional(),
+          /** Restrict a workspace feed to the viewer's own items (mine/team toggle). */
+          mineOnly: z.boolean().optional(),
           types: z.array(z.enum(['topic', 'document', 'task'])).optional(),
           withTopicPreview: z.boolean().optional(),
         })
@@ -46,7 +50,12 @@ export const recentRouter = router({
     .query(async ({ ctx, input }): Promise<RecentItem[]> => {
       const limit = input?.limit ?? 10;
 
-      const items = await ctx.recentModel.queryRecent(limit, input?.types, input?.withTopicPreview);
+      const items = await ctx.recentModel.queryRecent(
+        limit,
+        input?.types,
+        input?.withTopicPreview,
+        input?.mineOnly,
+      );
 
       return items.map((item) => {
         let routePath: string;
@@ -86,6 +95,7 @@ export const recentRouter = router({
           title: item.title,
           type: item.type,
           updatedAt: item.updatedAt,
+          userId: item.userId,
         };
       });
     }),

--- a/packages/database/src/models/__tests__/recent.test.ts
+++ b/packages/database/src/models/__tests__/recent.test.ts
@@ -11,6 +11,7 @@ import {
   tasks,
   topics,
   users,
+  workspaces,
 } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
 import { RecentModel } from '../recent';
@@ -620,6 +621,50 @@ describe('RecentModel', () => {
 
         const [row] = await recentModel.queryRecent();
         expect(row.updatedAt).toBeInstanceOf(Date);
+      });
+    });
+
+    describe('workspace mode', () => {
+      const workspaceId = 'recent-model-test-workspace';
+      const workspaceModel = new RecentModel(serverDB, userId, workspaceId);
+
+      beforeEach(async () => {
+        await serverDB
+          .insert(workspaces)
+          .values({ id: workspaceId, name: 'ws', primaryOwnerId: userId, slug: workspaceId });
+        await serverDB.insert(agents).values({ id: 'agent-ws', userId, slug: 'inbox' });
+        await serverDB.insert(topics).values([
+          {
+            agentId: 'agent-ws',
+            id: 'topic-ws-mine',
+            title: 'mine',
+            updatedAt: minutesAgo(1),
+            userId,
+            workspaceId,
+          },
+          {
+            agentId: 'agent-ws',
+            id: 'topic-ws-other',
+            title: 'other',
+            updatedAt: minutesAgo(2),
+            userId: otherUserId,
+            workspaceId,
+          },
+        ]);
+      });
+
+      it('returns every member topic with its author userId', async () => {
+        const result = await workspaceModel.queryRecent();
+
+        expect(result.map((r) => r.id)).toEqual(['topic-ws-mine', 'topic-ws-other']);
+        expect(result.map((r) => r.userId)).toEqual([userId, otherUserId]);
+      });
+
+      it('narrows to the viewer own topics when mineOnly is set', async () => {
+        const result = await workspaceModel.queryRecent(10, ['topic'], false, true);
+
+        expect(result.map((r) => r.id)).toEqual(['topic-ws-mine']);
+        expect(result[0].userId).toBe(userId);
       });
     });
   });

--- a/packages/database/src/models/recent.ts
+++ b/packages/database/src/models/recent.ts
@@ -18,6 +18,8 @@ export interface RecentDbItem {
   title: string;
   type: 'topic' | 'document' | 'task';
   updatedAt: Date;
+  /** The member who owns (created) this item — for author attribution in team views. */
+  userId: string;
 }
 
 // Mirrors `MAIN_SIDEBAR_EXCLUDE_TRIGGERS` in `src/const/topic.ts` plus the
@@ -48,6 +50,7 @@ export class RecentModel {
     limit: number = 10,
     types?: RecentDbItem['type'][],
     withTopicPreview?: boolean,
+    mineOnly?: boolean,
   ): Promise<RecentDbItem[]> => {
     const scope = { userId: this.userId, workspaceId: this.workspaceId };
     const requestedTypes = types ? new Set(types) : undefined;
@@ -57,6 +60,13 @@ export class RecentModel {
     const taskScopeWhere = this.workspaceId
       ? eq(tasks.workspaceId, this.workspaceId)
       : and(eq(tasks.createdByUserId, this.userId), isNull(tasks.workspaceId));
+
+    // Workspace rows are shared across members; `mineOnly` narrows a workspace
+    // feed back to the viewer's own items. A no-op in personal mode, where the
+    // scope predicate already pins the user.
+    const mineTopicWhere = mineOnly ? eq(topics.userId, this.userId) : undefined;
+    const mineDocumentWhere = mineOnly ? eq(documents.userId, this.userId) : undefined;
+    const mineTaskWhere = mineOnly ? eq(tasks.createdByUserId, this.userId) : undefined;
 
     const lastAssistantMessageSubquery = this.db
       .select({
@@ -90,6 +100,7 @@ export class RecentModel {
         title: sql<string>`COALESCE(${topics.title}, 'Untitled Topic')`.as('title'),
         type: sql<RecentDbItem['type']>`'topic'`.as('type'),
         updatedAt: topics.updatedAt,
+        userId: topics.userId,
       })
       .from(topics)
       .leftJoin(agents, eq(topics.agentId, agents.id))
@@ -98,6 +109,7 @@ export class RecentModel {
           ? sql`false`
           : and(
               buildWorkspaceWhere(scope, topics),
+              mineTopicWhere,
               or(
                 isNotNull(topics.groupId),
                 eq(agents.slug, 'inbox'),
@@ -123,6 +135,7 @@ export class RecentModel {
           ),
         type: sql<RecentDbItem['type']>`'document'`.as('type'),
         updatedAt: documents.updatedAt,
+        userId: documents.userId,
       })
       .from(documents)
       .where(
@@ -130,6 +143,7 @@ export class RecentModel {
           ? sql`false`
           : and(
               buildWorkspaceWhere(scope, documents),
+              mineDocumentWhere,
               not(inArray(documents.sourceType, TOOL_DOCUMENT_SOURCE_TYPES)),
               isNull(documents.knowledgeBaseId),
               ne(documents.fileType, DOCUMENT_FOLDER_TYPE),
@@ -150,12 +164,13 @@ export class RecentModel {
         ),
         type: sql<RecentDbItem['type']>`'task'`.as('type'),
         updatedAt: tasks.updatedAt,
+        userId: sql<string>`${tasks.createdByUserId}`.as('user_id'),
       })
       .from(tasks)
       .where(
         requestedTypes && !requestedTypes.has('task')
           ? sql`false`
-          : and(taskScopeWhere, not(inArray(tasks.status, TASK_FINAL_STATUSES))),
+          : and(taskScopeWhere, mineTaskWhere, not(inArray(tasks.status, TASK_FINAL_STATUSES))),
       );
 
     const rows = await unionAll(topicArm, documentArm, taskArm)
@@ -176,6 +191,7 @@ export class RecentModel {
       title: row.title,
       type: row.type,
       updatedAt: row.updatedAt instanceof Date ? row.updatedAt : new Date(row.updatedAt as any),
+      userId: row.userId,
     }));
   };
 }

--- a/src/features/Home/HomeModeContent.tsx
+++ b/src/features/Home/HomeModeContent.tsx
@@ -2,16 +2,19 @@ import type { TaskStatus } from '@lobechat/types';
 import { agentDisplayName } from '@lobechat/types';
 import type { FlexboxProps } from '@lobehub/ui';
 import { Avatar, Flexbox, Icon, Skeleton, Text } from '@lobehub/ui';
+import { Segmented } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { HashIcon } from 'lucide-react';
-import { memo, type ReactNode, useMemo } from 'react';
+import { memo, type ReactNode, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useWorkspaceMemberProfiles } from '@/business/client/hooks/useWorkspaceMemberProfiles';
 import AsyncError from '@/components/AsyncError';
 import TaskStatusIcon from '@/features/AgentTasks/features/TaskStatusIcon';
 import { taskDetailPath } from '@/features/AgentTasks/shared/taskDetailPath';
 import { useAgentDisplayMeta } from '@/features/AgentTasks/shared/useAgentDisplayMeta';
 import HomeInbox from '@/features/HomeInbox';
+import AuthorChip from '@/features/HomeInbox/AuthorChip';
 import { filterTopicsForInboxScope } from '@/features/HomeInbox/scopeTogglePlacement';
 import { splitBriefs } from '@/features/HomeInbox/splitBriefs';
 import { useHomeInboxTopics } from '@/features/HomeInbox/useHomeInboxTopics';
@@ -28,6 +31,7 @@ import { useTaskStore } from '@/store/task';
 import { taskListSelectors } from '@/store/task/selectors';
 import { useUserStore } from '@/store/user';
 import { authSelectors, userProfileSelectors } from '@/store/user/slices/auth/selectors';
+import { markdownToTxt } from '@/utils/markdownToTxt';
 
 import GroupBlock from './components/GroupBlock';
 import { homeType } from './components/homeType';
@@ -129,33 +133,46 @@ const Row = memo<RowProps>(({ description, href, icon, title, trailing }) => (
   </WorkspaceLink>
 ));
 
-const RecentTopicRow = memo<{ topic: RecentItem }>(({ topic }) => {
-  const agent = useAgentDisplayMeta(topic.agentId);
-  const description = topic.description?.trim() || topic.lastAssistantMessage?.trim();
+const RecentTopicRow = memo<{ showAuthor?: boolean; topic: RecentItem }>(
+  ({ showAuthor, topic }) => {
+    const agent = useAgentDisplayMeta(topic.agentId);
+    const raw = topic.description?.trim() || topic.lastAssistantMessage?.trim();
+    // The snippet is raw markdown (a user note or the last assistant reply);
+    // rendered as one plain line, its syntax markers are just noise.
+    const description = useMemo(
+      () => (raw ? markdownToTxt(raw).replaceAll(/\s+/g, ' ').trim() : undefined),
+      [raw],
+    );
 
-  return (
-    <Row
-      description={description}
-      href={topic.routePath}
-      title={topic.title}
-      trailing={<Time date={topic.updatedAt} />}
-      icon={
-        agent ? (
-          <Avatar
-            avatar={agent.avatar}
-            background={agent.backgroundColor}
-            className={styles.topicAvatar}
-            shape={'circle'}
-            size={22}
-            title={agentDisplayName(agent)}
-          />
-        ) : (
-          <Icon color={cssVar.colorTextDescription} icon={HashIcon} size={16} />
-        )
-      }
-    />
-  );
-});
+    return (
+      <Row
+        description={description}
+        href={topic.routePath}
+        title={topic.title}
+        icon={
+          agent ? (
+            <Avatar
+              avatar={agent.avatar}
+              background={agent.backgroundColor}
+              className={styles.topicAvatar}
+              shape={'circle'}
+              size={22}
+              title={agentDisplayName(agent)}
+            />
+          ) : (
+            <Icon color={cssVar.colorTextDescription} icon={HashIcon} size={16} />
+          )
+        }
+        trailing={
+          <Flexbox horizontal align={'center'} flex={'none'} gap={8}>
+            {showAuthor && <AuthorChip userId={topic.userId} />}
+            <Time date={topic.updatedAt} />
+          </Flexbox>
+        }
+      />
+    );
+  },
+);
 
 interface SkeletonLineProps {
   /** Height of the painted band inside the line box. */
@@ -256,9 +273,23 @@ const HomeModeContent = memo<HomeModeContentProps>(({ inlineRail, mode, onSugges
   const authLoaded = useUserStore(authSelectors.isLoaded);
   const myId = useUserStore(userProfileSelectors.userId);
   const cacheScope = useCacheScope();
+
+  // One page-level mine/team scope, shared by the inbox sections and Recent
+  // topics. In personal mode the member map is empty, `isTeam` stays false and
+  // the whole layer is inert.
+  const memberProfiles = useWorkspaceMemberProfiles();
+  const isTeam = memberProfiles.size > 1;
+  const [scope, setScope] = useState<'mine' | 'team'>('mine');
+  const teamView = isTeam && scope === 'team';
+
+  // Workspace topics are shared, so "mine" must be narrowed server-side —
+  // client-filtering the top N of a team-wide feed could starve out the
+  // viewer's own topics entirely.
   const recentsSWR = useClientDataSWR(
-    isLogin ? recentKeys.topicList(HOME_TOPIC_RECENT_LIMIT, cacheScope) : null,
-    () => recentService.getAll(HOME_TOPIC_RECENT_LIMIT, ['topic'], true),
+    isLogin
+      ? recentKeys.topicList(HOME_TOPIC_RECENT_LIMIT, cacheScope, teamView ? 'team' : 'mine')
+      : null,
+    () => recentService.getAll(HOME_TOPIC_RECENT_LIMIT, ['topic'], true, !teamView),
     { revalidateOnFocus: false },
   );
 
@@ -311,9 +342,31 @@ const HomeModeContent = memo<HomeModeContentProps>(({ inlineRail, mode, onSugges
 
     return (
       <Flexbox gap={32}>
-        <HomeInbox inlineRail={inlineRail} variant={'main'} />
+        <HomeInbox
+          inlineRail={inlineRail}
+          scope={scope}
+          variant={'main'}
+          onScopeChange={setScope}
+        />
         {(state !== 'ready' || topicRecents.length > 0) && (
-          <GroupBlock count={topicRecents.length || undefined} title={t('dashboard.chat.recents')}>
+          <GroupBlock
+            actionAlwaysVisible
+            count={topicRecents.length || undefined}
+            title={t('dashboard.chat.recents')}
+            action={
+              isTeam ? (
+                <Segmented
+                  size={'small'}
+                  value={scope}
+                  options={[
+                    { label: t('inbox.scope.mine'), value: 'mine' },
+                    { label: t('inbox.scope.team'), value: 'team' },
+                  ]}
+                  onChange={(value) => setScope(value as 'mine' | 'team')}
+                />
+              ) : undefined
+            }
+          >
             {state === 'error' ? (
               <AsyncError error={recentsSWR.error} variant={'inline'} onRetry={recentsSWR.mutate} />
             ) : state === 'loading' ? (
@@ -321,7 +374,7 @@ const HomeModeContent = memo<HomeModeContentProps>(({ inlineRail, mode, onSugges
             ) : (
               <Flexbox gap={4}>
                 {topicRecents.slice(0, 8).map((item) => (
-                  <RecentTopicRow key={item.id} topic={item} />
+                  <RecentTopicRow key={item.id} showAuthor={teamView} topic={item} />
                 ))}
               </Flexbox>
             )}

--- a/src/features/HomeInbox/index.tsx
+++ b/src/features/HomeInbox/index.tsx
@@ -87,11 +87,21 @@ interface HomeInboxProps {
    * news) fold into this column instead of disappearing with it.
    */
   inlineRail?: boolean;
+  /** Controlled mine/team scope — lets the page share one scope across sibling sections. */
+  onScopeChange?: (scope: 'mine' | 'team') => void;
+  scope?: 'mine' | 'team';
   variant?: 'default' | 'main' | 'rail';
 }
 
 const HomeInbox = memo<HomeInboxProps>((props) => {
-  const { hideNeedsYou, hideUnread, inlineRail, variant = 'default' } = props;
+  const {
+    hideNeedsYou,
+    hideUnread,
+    inlineRail,
+    onScopeChange,
+    scope: controlledScope,
+    variant = 'default',
+  } = props;
   const isRail = variant === 'rail';
   const isMain = variant === 'main';
   const showRailSections = ownsRailSections({ inlineRail, variant });
@@ -117,7 +127,9 @@ const HomeInbox = memo<HomeInboxProps>((props) => {
   const memberProfiles = useWorkspaceMemberProfiles();
   const isTeam = memberProfiles.size > 1;
 
-  const [scope, setScope] = useState<'mine' | 'team'>('mine');
+  const [internalScope, setInternalScope] = useState<'mine' | 'team'>('mine');
+  const scope = controlledScope ?? internalScope;
+  const setScope = onScopeChange ?? setInternalScope;
   const teamView = isTeam && scope === 'team';
 
   const { needsYou, news } = useMemo(() => splitBriefs(briefs), [briefs]);

--- a/src/libs/swr/keys.test.ts
+++ b/src/libs/swr/keys.test.ts
@@ -27,18 +27,25 @@ describe('recentKeys', () => {
   });
 
   it('keys the Home topic-only list independently from mixed recents', () => {
-    expect(recentKeys.topicList(9, 'user-1:workspace-1')).toEqual([
+    expect(recentKeys.topicList(9, 'user-1:workspace-1', 'mine')).toEqual([
       'recent:topicList',
       9,
       'user-1:workspace-1',
+      'mine',
     ]);
+  });
+
+  it('keeps the mine and team views of the Home topic list isolated', () => {
+    expect(recentKeys.topicList(9, 'user-1:workspace-1', 'mine')).not.toEqual(
+      recentKeys.topicList(9, 'user-1:workspace-1', 'team'),
+    );
   });
 
   // Regression: `recent:topicList` had no CACHE_TIERS entry of its own, and the
   // provider matches patterns as substrings — so `recent:list` never covered it.
   // The Home recents list was memory-only and flashed a skeleton on every boot.
   it('routes the Home topic-only recents key to a persisted cache tier', () => {
-    const serialized = unstable_serialize(recentKeys.topicList(9, 'user-1:workspace-1'));
+    const serialized = unstable_serialize(recentKeys.topicList(9, 'user-1:workspace-1', 'mine'));
     const persisted = [...CACHE_TIERS.idb, ...CACHE_TIERS.local].some((pattern) =>
       serialized.includes(pattern),
     );

--- a/src/libs/swr/keys.ts
+++ b/src/libs/swr/keys.ts
@@ -249,10 +249,11 @@ export const recentKeys = {
     scope,
   ]),
   /** Home chat-only list; filtering happens before the server-side limit. */
-  topicList: def('recent:topicList', (limit: number, scope: string) => [
+  topicList: def('recent:topicList', (limit: number, scope: string, view: 'mine' | 'team') => [
     'recent:topicList',
     limit,
     scope,
+    view,
   ]),
 };
 

--- a/src/services/recent/index.ts
+++ b/src/services/recent/index.ts
@@ -6,8 +6,9 @@ class RecentService {
     limit?: number,
     types?: RecentItem['type'][],
     withTopicPreview?: boolean,
+    mineOnly?: boolean,
   ): Promise<RecentItem[]> => {
-    return lambdaClient.recent.getAll.query({ limit, types, withTopicPreview });
+    return lambdaClient.recent.getAll.query({ limit, mineOnly, types, withTopicPreview });
   };
 }
 


### PR DESCRIPTION
### Brief

Three improvements to the home **Recent topics** section in team workspaces:

1. **Mine/Team scope tabs** — the section header gets the same `Segmented` control as the inbox, defaulting to **Mine**. The scope is lifted to page level (`HomeModeContent`) and `HomeInbox` now supports a controlled `scope`/`onScopeChange`, so the inbox sections and Recent topics always switch together as one page-level view.
2. **Author attribution in team view** — `RecentModel`/`RecentItem` now carry `userId`, and each row's trailing area renders the shared `AuthorChip` (avatar + name) next to the timestamp, matching the unread list.
3. **Markdown-stripped previews** — the row description (topic `description` or `lastAssistantMessage`) is passed through the existing `markdownToTxt` util and whitespace-collapsed, so `##` / `**` / links / fences no longer leak into the one-line preview.

In personal mode (or a single-member workspace) the member map is empty, so the whole scope layer stays inert — no tabs, no chips, byte-for-byte the previous rendering.

#### Key Decisions

- **Server-side `mineOnly` filter instead of client filtering**: workspace topics are shared, so filtering the top-9 team-wide feed on the client could starve out the viewer's own topics entirely. `recent.getAll` takes a `mineOnly` flag, all three `RecentModel` arms (topic/document/task) support it, and the SWR key carries the view (`mine`/`team`) so each tab caches independently and fills its full quota.
- **One page-level scope, not two independent toggles**: `HomeInbox` keeps its internal state for other variants (`rail`/`default`), but the home `main` variant passes controlled props so both Segmented controls read/write the same state.
- **No new i18n keys** — reuses `inbox.scope.mine` / `inbox.scope.team`.

#### Test

- Added workspace-mode regression tests to `packages/database` `recent.test.ts`: team feed returns every member's topics with `userId`; `mineOnly` narrows to the viewer's own.
- Updated `swr/keys` tests for the new view dimension.
- Verified end-to-end locally against an isolated full-stack env with a 2-member workspace: default Mine (`mineOnly:true` request), Team view with author chips (`mineOnly:false`), md-stripped previews from both description and last-assistant-message sources, bidirectional scope sync with the inbox, and the personal-mode no-tabs regression.

- [x] Tested locally
- [x] Added/updated tests