### PR TITLE
💄 style(chat): remove the role tag next to the agent name in chat messages

### DIFF
--- a/src/features/Conversation/ChatItem/components/Title.tsx
+++ b/src/features/Conversation/ChatItem/components/Title.tsx
@@ -1,5 +1,5 @@
 import { agentDisplayName } from '@lobechat/types';
-import { Tag, Text } from '@lobehub/ui';
+import { Text } from '@lobehub/ui';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -17,8 +17,6 @@ export interface TitleProps {
 const Title = memo<TitleProps>(({ showTitle, time, avatar, titleAddon }) => {
   const { t } = useTranslation('chat');
   const title = agentDisplayName(avatar, t('untitledAgent'));
-  // The role is only worth repeating when the personal name took the label slot.
-  const roleTag = avatar.name?.trim() && avatar.title?.trim() ? avatar.title.trim() : undefined;
   const { text: timeText, title: timeTitle } = useActivityTime(time);
 
   return (
@@ -28,7 +26,6 @@ const Title = memo<TitleProps>(({ showTitle, time, avatar, titleAddon }) => {
           {title}
         </Text>
       )}
-      {showTitle && roleTag && <Tag size={'small'}>{roleTag}</Tag>}
       {showTitle ? titleAddon : undefined}
       {!timeText ? null : (
         <Text


### PR DESCRIPTION
### 💄 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

### 📝 Description of Change

Since #17853 gave agents a personal name, the agent's role title (e.g. "融资 Pitch Deck 助理") was rendered as a small tag next to the personal name on every chat message. Repeating the role on each message adds visual noise and degrades the conversation experience.

This PR removes the role tag from the chat message title. The message header now shows only the agent name (plus any existing `titleAddon`, such as the "subtask" tag on task messages, which is unaffected).

### 🧪 How to Test

- [x] Manual testing
- [ ] Unit tests added/updated

Chat with an agent that has both a personal name and a role title — the message header shows only the name, without the role tag.