### PR TITLE
💄 style(task): stop automation tasks from marking themselves completed

### DIFF
--- a/apps/server/src/services/taskRunner/buildTaskPrompt.ts
+++ b/apps/server/src/services/taskRunner/buildTaskPrompt.ts
@@ -240,12 +240,14 @@ export async function buildTaskPrompt(
     parentTask: parentTaskContext,
     task: {
       assigneeAgentId: task.assigneeAgentId,
+      automationMode: task.automationMode,
       dependencies: dependencies.map((d: any) => ({
         dependsOn: depIdToIdentifier.get(d.dependsOnId) ?? d.dependsOnId,
         type: d.type,
       })),
       description: task.description,
       ...(taskFiles.length > 0 ? { files: taskFiles } : {}),
+      heartbeatInterval: task.heartbeatInterval,
       id: task.id,
       identifier: task.identifier,
       instruction: task.instruction,
@@ -253,6 +255,8 @@ export async function buildTaskPrompt(
       parentIdentifier,
       priority: task.priority,
       review: taskModel.getReviewConfig(task) as any,
+      schedulePattern: task.schedulePattern,
+      scheduleTimezone: task.scheduleTimezone,
       status: task.status,
       verify: verifyEnabled
         ? {

--- a/apps/server/src/services/taskRunner/taskSkill.test.ts
+++ b/apps/server/src/services/taskRunner/taskSkill.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+
+import { builtinSkills, TaskIdentifier } from '@lobechat/builtin-skills';
+import { describe, expect, it } from 'vitest';
+
+// The vitest config stubs `.md` imports to an empty string, so read the skill
+// instructions straight from disk instead of through the package export.
+const builtinSkillsEntry = createRequire(import.meta.url).resolve('@lobechat/builtin-skills');
+const content = readFileSync(join(dirname(builtinSkillsEntry), 'task/SKILL.md'), 'utf8');
+
+/**
+ * TaskRunnerService auto-activates the task skill for every task run, so its
+ * SKILL.md lands in the system context — a higher-priority surface than the
+ * per-run task prompt. Guard that the "complete when done" guidance it ships
+ * carries the automation exception; without it, a quiet automation tick can
+ * follow the skill and `lh task complete` its own recurring task, which
+ * cancels the in-flight run and permanently disarms the heartbeat/schedule
+ * loop.
+ */
+describe('task skill instructions', () => {
+  it('is mounted under the identifier the task runner auto-activates', () => {
+    expect(builtinSkills.some((s) => s.identifier === TaskIdentifier)).toBe(true);
+  });
+
+  it('ships the complete-when-done guidance the exception guards against', () => {
+    expect(content).toContain('lh task complete');
+    expect(content).toContain('Complete when done');
+  });
+
+  it('forbids completing automation tasks via the CLI', () => {
+    expect(content).toContain('Automation tasks are the exception — NEVER complete them');
+    expect(content).toContain(
+      'NEVER run `lh task complete` (or set a terminal status via `lh task edit --status`)',
+    );
+    // The exception must follow the completion guidance it carves out of.
+    expect(content.indexOf('NEVER run `lh task complete`')).toBeGreaterThan(
+      content.indexOf('Complete when done'),
+    );
+  });
+});

--- a/packages/builtin-skills/src/task/SKILL.md
+++ b/packages/builtin-skills/src/task/SKILL.md
@@ -1,4 +1,4 @@
-\<task_skill_guides>
+\<task\_skill\_guides>
 You are executing a task within the LobeHub task system. Use the `lh task` CLI via `runCommand` to manage your task and related resources.
 
 # Task Lifecycle
@@ -50,4 +50,5 @@ You are executing a task within the LobeHub task system. Use the `lh task` CLI v
 - **Report progress**: Use `lh task comment` to log key milestones
 - **Respect dependencies**: Check `lh task tree` to understand task ordering
 - **Complete when done**: Use `lh task complete` when all deliverables are ready
-  \</task_skill_guides>
+- **Automation tasks are the exception — NEVER complete them**: a task with automation (heartbeat or schedule — shown as an `Automation:` line in the task context) is a recurring loop, and this run is one tick of it. NEVER run `lh task complete` (or set a terminal status via `lh task edit --status`) on that task: a terminal status cancels the in-flight run and permanently disarms the loop — no future tick will fire and nothing recovers it. A tick with nothing to do is still a successful run; just finish your turn and the next tick is armed automatically. Only the user retires a recurring task.
+  \</task\_skill\_guides>

--- a/packages/builtin-tool-task/src/systemRole.ts
+++ b/packages/builtin-tool-task/src/systemRole.ts
@@ -21,6 +21,8 @@ Schedule fields (setTaskSchedule):
 
 After configuring a cron-based schedule (automationMode="schedule") on a task that is neither currently running nor already scheduled, start its schedule by default with updateTaskStatus(identifier, "scheduled") so it waits for the next scheduled run. When the user explicitly asks to keep it paused or as a draft, call updateTaskStatus(identifier, "paused") instead — a schedule-mode task left in any other non-terminal status is still picked up by the cron dispatcher. Never call updateTaskStatus on a currently running task just to arm the schedule — that interrupts the in-flight run, and the task returns to "scheduled" automatically once the run completes. A task already in "scheduled" stays armed after schedule edits — re-calling updateTaskStatus would reset its execution-count window. Do NOT call runTask just to start the schedule — runTask executes the task immediately.
 
+An automation task (automationMode 'heartbeat' or 'schedule') is a recurring loop: each triggered run is one tick, and a tick with nothing to do is still a SUCCESSFUL tick — not a reason to close the task. When the task you are currently executing is an automation task, NEVER call updateTaskStatus with "completed" (or any other terminal status) on it: a terminal status cancels the in-flight run and permanently disarms the loop — no future tick will ever fire, and nothing recovers it automatically. Simply finish your turn; the scheduler parks the task back at 'scheduled' and arms the next tick on its own. Instructions like "end this run normally" or "treat as completed" refer to the current tick, not the task. Only the user retires a recurring task — either by doing it themselves or by explicitly asking you to stop the recurring task for good.
+
 Verify fields (setTaskVerify):
 - **enabled**: true to require a verify gate when the task completes, false to disable, null to clear
 - **requirement**: a one-sentence description of what "done" means for the task; the server synthesizes acceptance criteria from it. This is usually all you need
@@ -40,4 +42,4 @@ When planning work:
 1. Create tasks for each major piece of work (use parentIdentifier to organize as subtasks)
 2. Use editTask with addDependencies to control execution order
 3. For executable tasks dispatched to an agent, use setTaskVerify to attach acceptance criteria before running them
-4. Use updateTaskStatus to mark the current task as completed when you finish all work`;
+4. Use updateTaskStatus to mark the current task as completed when you finish all work — unless it is an automation (heartbeat/schedule) task, which must stay non-terminal so its loop keeps running`;

--- a/packages/prompts/src/prompts/task/index.test.ts
+++ b/packages/prompts/src/prompts/task/index.test.ts
@@ -112,6 +112,61 @@ describe('buildTaskRunPrompt', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it('should render a heartbeat automation line with the interval and a no-terminal warning', () => {
+    const result = buildTaskRunPrompt(
+      {
+        task: {
+          ...baseTask,
+          automationMode: 'heartbeat',
+          heartbeatInterval: 14_400,
+          identifier: 'TASK-1',
+          instruction: '每 4 小时监听 Discord 频道',
+          name: 'Discord 监听',
+        },
+      },
+      NOW,
+    );
+
+    expect(result).toContain('Automation: heartbeat, every 4h');
+    expect(result).toContain('NEVER set this task to completed');
+  });
+
+  it('should render a schedule automation line with the cron pattern and timezone', () => {
+    const result = buildTaskRunPrompt(
+      {
+        task: {
+          ...baseTask,
+          automationMode: 'schedule',
+          identifier: 'TASK-1',
+          instruction: '每天早上汇总',
+          name: '每日汇总',
+          schedulePattern: '0 9 * * *',
+          scheduleTimezone: 'Asia/Shanghai',
+        },
+      },
+      NOW,
+    );
+
+    expect(result).toContain('Automation: cron "0 9 * * *" (Asia/Shanghai)');
+    expect(result).toContain('NEVER set this task to completed');
+  });
+
+  it('should not render an automation line for non-automation tasks', () => {
+    const result = buildTaskRunPrompt(
+      {
+        task: {
+          ...baseTask,
+          identifier: 'TASK-1',
+          instruction: '一次性任务',
+          name: '一次性任务',
+        },
+      },
+      NOW,
+    );
+
+    expect(result).not.toContain('Automation:');
+  });
+
   it('should prioritize user feedback at the top', () => {
     const result = buildTaskRunPrompt(
       {

--- a/packages/prompts/src/prompts/task/index.ts
+++ b/packages/prompts/src/prompts/task/index.ts
@@ -417,11 +417,13 @@ export interface TaskRunPromptInput {
   /** Task data */
   task: {
     assigneeAgentId?: string | null;
+    automationMode?: 'heartbeat' | 'schedule' | null;
     dependencies?: Array<{ dependsOn: string; type: string }>;
     description?: string | null;
     /** Lightweight metadata of files attached to the task instruction. Actual
      * content is forwarded to the agent runtime via `fileIds` on execAgent. */
     files?: TaskRunPromptAttachment[];
+    heartbeatInterval?: number | null;
     id: string;
     identifier: string;
     instruction: string;
@@ -433,6 +435,8 @@ export interface TaskRunPromptInput {
       maxIterations?: number;
       rubrics?: Array<{ name: string; threshold?: number; type: string }>;
     } | null;
+    schedulePattern?: string | null;
+    scheduleTimezone?: string | null;
     status: string;
     subtasks?: Array<TaskSummary & { blockedBy?: string }>;
     /** Delivery-acceptance criteria the builder must self-evidence while working. */
@@ -464,6 +468,14 @@ const timeAgo = (dateStr: string, now?: Date): string => {
   if (diffHr < 24) return `${diffHr}h ago`;
   const diffDay = Math.floor(diffHr / 24);
   return `${diffDay}d ago`;
+};
+
+// ── Heartbeat interval helper ──
+
+const formatInterval = (seconds: number): string => {
+  if (seconds % 3600 === 0) return `${seconds / 3600}h`;
+  if (seconds % 60 === 0) return `${seconds / 60}m`;
+  return `${seconds}s`;
 };
 
 // ── Brief icon ──
@@ -528,8 +540,19 @@ export const buildTaskRunPrompt = (input: TaskRunPromptInput, now?: Date): strin
     `<hint>This tag contains the complete task context. Do NOT call viewTask to re-fetch it.</hint>`,
     `${task.identifier} ${task.name || task.identifier}`,
     `Status: ${statusIcon(task.status)} ${task.status}     Priority: ${priorityLabel(task.priority)}`,
-    `Instruction: ${task.instruction}`,
   ];
+  if (task.automationMode) {
+    const cadence =
+      task.automationMode === 'heartbeat' && task.heartbeatInterval
+        ? `heartbeat, every ${formatInterval(task.heartbeatInterval)}`
+        : task.automationMode === 'schedule' && task.schedulePattern
+          ? `cron "${task.schedulePattern}" (${task.scheduleTimezone || 'UTC'})`
+          : task.automationMode;
+    taskLines.push(
+      `Automation: ${cadence} — this task is a recurring loop and this run is one tick of it. When the run ends, the next tick is armed automatically; a tick with nothing to do is still a successful run. NEVER set this task to completed (or any terminal status) — that permanently stops the loop.`,
+    );
+  }
+  taskLines.push(`Instruction: ${task.instruction}`);
   if (task.description) taskLines.push(`Description: ${task.description}`);
   if (task.files && task.files.length > 0) {
     taskLines.push('Attachments (contents provided separately as multimodal inputs):');


### PR DESCRIPTION
A heartbeat task ran exactly one tick and then went silent forever: the executing agent finished a quiet tick ("no new messages in the window") and called `updateTaskStatus(completed)` on its own task. The terminal status interrupted the in-flight run (its `task_topics` row landed `canceled`) and `maybeRearmHeartbeat` bailed on `isTerminal`, so no next tick was ever armed — an unrecoverable stop with no error anywhere.

The agent had no way to know better: the task-tool system role explicitly says "mark the current task as completed when you finish all work" with no automation exemption, and the injected `<task>` context only shows `Status: scheduled` without revealing the task is a recurring loop.

This is a prompt-only fix (no server-side behavior change — users legitimately mark recurring tasks completed themselves), applied to every surface that tells the agent to complete its task:

- **`builtin-tool-task` systemRole**: new paragraph stating an automation task is a recurring loop, a quiet tick is still a successful tick, and the executing agent must never put its own automation task into a terminal status; the closing "mark completed when done" rule now carries the exemption.
- **`builtin-skills` task SKILL.md**: the task skill is auto-activated for every task run (`TaskRunnerService` mounts `TaskSkillIdentifier`) and its "Complete when done → `lh task complete`" guideline lives in the system context, which outranks the task prompt — so the same exception is added right below it, covering both `lh task complete` and terminal `lh task edit --status`.
- **`buildTaskRunPrompt` `<task>` block**: renders an `Automation:` line for automation tasks — heartbeat cadence (`every 4h`) or cron pattern + timezone — with an inline warning that finishing the run re-arms the loop and terminal statuses kill it permanently.
- **`buildTaskPrompt` (server)**: passes `automationMode` / `heartbeatInterval` / `schedulePattern` / `scheduleTimezone` through to the prompt builder.

#### Test

- [x] Tested locally
- [x] Added/updated tests

`packages/prompts` task prompt tests: 3 new cases (heartbeat line, schedule line, absent for non-automation tasks), all 25 pass; snapshots unchanged. New `apps/server` regression test reads the assembled task skill instructions from disk (the vitest raw-md stub makes package-export assertions vacuous) and guards that the completion guidance carries the automation exception. `tsgo --noEmit` clean.

Sample incident: task T-198 (Discord monitor, 4h heartbeat) — first heartbeat tick fired on time, agent self-completed after a quiet window, loop dead since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)