### PR TITLE
🐛 fix(home): collapse the rail column when it has nothing to show

### DIFF
--- a/src/features/Home/HomeNavHeader.tsx
+++ b/src/features/Home/HomeNavHeader.tsx
@@ -1,12 +1,14 @@
 import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 
+import { useHomeRailHasContent } from '@/features/HomeInbox/useHomeInboxSections';
 import NavHeader from '@/features/NavHeader';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/slices/auth/selectors';
 
+import { resolveRailToggleVisible } from './homeRailVisibility';
 import RailToggle from './RailToggle';
 
 // Floats over the dashboard instead of pushing it down: the controls live in
@@ -22,6 +24,7 @@ const styles = createStaticStyles(({ css }) => ({
 
 const HomeNavHeader = memo(() => {
   const isLogin = useUserStore(authSelectors.isLogin);
+  const railHasContent = useHomeRailHasContent();
   const [showHomeRail, toggleHomeRail, isStatusInit] = useGlobalStore((s) => [
     systemStatusSelectors.showHomeRail(s),
     s.toggleHomeRail,
@@ -32,7 +35,7 @@ const HomeNavHeader = memo(() => {
     <NavHeader
       className={styles.header}
       right={
-        isLogin && isStatusInit ? (
+        resolveRailToggleVisible({ isLogin, isStatusInit, railHasContent }) ? (
           <RailToggle railVisible={showHomeRail} onToggle={toggleHomeRail} />
         ) : undefined
       }

--- a/src/features/Home/homeRailVisibility.test.ts
+++ b/src/features/Home/homeRailVisibility.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveHomeRailVisible, resolveRailToggleVisible } from './homeRailVisibility';
+
+describe('resolveHomeRailVisible', () => {
+  it('collapses the rail column when it has no content', () => {
+    expect(
+      resolveHomeRailVisible({ isLogin: true, railHasContent: false, showHomeRail: true }),
+    ).toBe(false);
+  });
+
+  it('shows the rail once content arrives', () => {
+    expect(
+      resolveHomeRailVisible({ isLogin: true, railHasContent: true, showHomeRail: true }),
+    ).toBe(true);
+  });
+
+  it('keeps the rail collapsed when the user manually hid it, even with content', () => {
+    expect(
+      resolveHomeRailVisible({ isLogin: true, railHasContent: true, showHomeRail: false }),
+    ).toBe(false);
+  });
+
+  it('never shows the rail to a signed-out visitor', () => {
+    expect(
+      resolveHomeRailVisible({ isLogin: false, railHasContent: true, showHomeRail: true }),
+    ).toBe(false);
+  });
+});
+
+describe('resolveRailToggleVisible', () => {
+  it('hides the toggle when the rail has no content', () => {
+    expect(
+      resolveRailToggleVisible({ isLogin: true, isStatusInit: true, railHasContent: false }),
+    ).toBe(false);
+  });
+
+  it('shows the toggle once content arrives', () => {
+    expect(
+      resolveRailToggleVisible({ isLogin: true, isStatusInit: true, railHasContent: true }),
+    ).toBe(true);
+  });
+
+  it('hides the toggle before system status has loaded', () => {
+    expect(
+      resolveRailToggleVisible({ isLogin: true, isStatusInit: false, railHasContent: true }),
+    ).toBe(false);
+  });
+});

--- a/src/features/Home/homeRailVisibility.ts
+++ b/src/features/Home/homeRailVisibility.ts
@@ -1,0 +1,23 @@
+interface ResolveHomeRailVisibleParams {
+  isLogin: boolean | undefined;
+  railHasContent: boolean;
+  showHomeRail: boolean;
+}
+
+export const resolveHomeRailVisible = ({
+  isLogin,
+  railHasContent,
+  showHomeRail,
+}: ResolveHomeRailVisibleParams): boolean => Boolean(isLogin && showHomeRail && railHasContent);
+
+interface ResolveRailToggleVisibleParams {
+  isLogin: boolean | undefined;
+  isStatusInit: boolean;
+  railHasContent: boolean;
+}
+
+export const resolveRailToggleVisible = ({
+  isLogin,
+  isStatusInit,
+  railHasContent,
+}: ResolveRailToggleVisibleParams): boolean => Boolean(isLogin && isStatusInit && railHasContent);

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -5,6 +5,10 @@ import { createStaticStyles, cx } from 'antd-style';
 import { memo, useCallback, useState } from 'react';
 
 import HomeInbox from '@/features/HomeInbox';
+import {
+  HOME_RAIL_INBOX_OPTIONS,
+  useHomeRailHasContent,
+} from '@/features/HomeInbox/useHomeInboxSections';
 import { useChatStore } from '@/store/chat';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
@@ -14,6 +18,7 @@ import { authSelectors } from '@/store/user/slices/auth/selectors';
 import HomeHeader from './HomeHeader';
 import HomeModeContent from './HomeModeContent';
 import HomePortrait from './HomePortrait';
+import { resolveHomeRailVisible } from './homeRailVisibility';
 import InputArea from './InputArea';
 import PortraitBubble from './PortraitBubble';
 import type { HomeMode } from './types';
@@ -233,9 +238,10 @@ const styles = createStaticStyles(({ css }) => ({
 const Home = memo(() => {
   const isLogin = useUserStore(authSelectors.isLogin);
   const showHomeRail = useGlobalStore(systemStatusSelectors.showHomeRail);
+  const railHasContent = useHomeRailHasContent();
   const [mode, setMode] = useState<HomeMode>('chat');
   const [inputValue, setInputValue] = useState('');
-  const railVisible = Boolean(isLogin && showHomeRail);
+  const railVisible = resolveHomeRailVisible({ isLogin, railHasContent, showHomeRail });
   const railCollapsed = !railVisible;
 
   const handleInputValueChange = useCallback((value: string) => {
@@ -301,7 +307,7 @@ const Home = memo(() => {
           id={'home-rail'}
           inert={railCollapsed}
         >
-          <HomeInbox hideNeedsYou hideUnread variant={'rail'} />
+          <HomeInbox {...HOME_RAIL_INBOX_OPTIONS} />
         </aside>
       )}
     </Flexbox>

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -248,7 +248,7 @@ const styles = createStaticStyles(({ css }) => ({
 const Home = memo(() => {
   const isLogin = useUserStore(authSelectors.isLogin);
   const showHomeRail = useGlobalStore(systemStatusSelectors.showHomeRail);
-  const { hasContent: railHasContent, status: railStatus } =
+  const { hasContent: railHasContent, hasResolved: railHasResolved } =
     useHomeInboxSections(HOME_RAIL_INBOX_OPTIONS);
   const [mode, setMode] = useState<HomeMode>('chat');
   const [inputValue, setInputValue] = useState('');
@@ -257,13 +257,13 @@ const Home = memo(() => {
 
   const hasSettledRailRef = useRef(false);
   const suppressRailTransition = resolveSuppressRailTransition({
+    hasResolved: railHasResolved,
     hasSettledBefore: hasSettledRailRef.current,
-    status: railStatus,
   });
 
   useEffect(() => {
-    if (railStatus !== 'loading') hasSettledRailRef.current = true;
-  }, [railStatus]);
+    if (railHasResolved) hasSettledRailRef.current = true;
+  }, [railHasResolved]);
 
   const handleInputValueChange = useCallback((value: string) => {
     setInputValue(value);

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -161,6 +161,10 @@ const styles = createStaticStyles(({ css }) => ({
   // reflow, not a state the user held and then changed their mind on. Only the
   // render where loading first resolves gets this; every later collapse or
   // expand (manual toggle, content arriving or leaving) keeps the transition.
+  // `!important` on both: `.railSurface[data-collapsed='true']` outweighs this
+  // single class on specificity (0,2,0 vs 0,1,0), so without it the rail's own
+  // 220ms `transition-delay` on `visibility` would still win — an instant move
+  // followed by staying "visible" for 220ms before it actually hides.
   noTransition: css`
     transition-delay: 0s !important;
     transition-duration: 0s !important;
@@ -255,6 +259,10 @@ const Home = memo(() => {
   const railVisible = resolveHomeRailVisible({ isLogin, railHasContent, showHomeRail });
   const railCollapsed = !railVisible;
 
+  // Read here as a ref, not useState: the render that first settles must see
+  // the stale `false` written by the *previous* commit, not one triggered by
+  // this render's own update — a `useState` here would fire the extra render
+  // before this transition gets suppressed, closing the window a beat early.
   const hasSettledRailRef = useRef(false);
   const suppressRailTransition = resolveSuppressRailTransition({
     hasResolved: railHasResolved,

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -2,12 +2,12 @@
 
 import { Flexbox } from '@lobehub/ui';
 import { createStaticStyles, cx } from 'antd-style';
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 
 import HomeInbox from '@/features/HomeInbox';
 import {
   HOME_RAIL_INBOX_OPTIONS,
-  useHomeRailHasContent,
+  useHomeInboxSections,
 } from '@/features/HomeInbox/useHomeInboxSections';
 import { useChatStore } from '@/store/chat';
 import { useGlobalStore } from '@/store/global';
@@ -21,6 +21,7 @@ import HomePortrait from './HomePortrait';
 import { resolveHomeRailVisible } from './homeRailVisibility';
 import InputArea from './InputArea';
 import PortraitBubble from './PortraitBubble';
+import { resolveSuppressRailTransition } from './suppressFirstRailTransition';
 import type { HomeMode } from './types';
 
 /** Trailing gutter that keeps the rail's cards off the page's scroll lane. */
@@ -155,6 +156,15 @@ const styles = createStaticStyles(({ css }) => ({
     grid-area: 2 / 1;
     min-width: 0;
   `,
+  // A first-time visitor's initial layout is the loading skeleton's, not the
+  // eventual empty one — collapsing straight into it from there is a settling
+  // reflow, not a state the user held and then changed their mind on. Only the
+  // render where loading first resolves gets this; every later collapse or
+  // expand (manual toggle, content arriving or leaving) keeps the transition.
+  noTransition: css`
+    transition-delay: 0s !important;
+    transition-duration: 0s !important;
+  `,
   portrait: css`
     grid-area: 1 / 2;
     transition: transform ${RAIL_TRANSITION_DURATION}ms ease-out;
@@ -238,11 +248,22 @@ const styles = createStaticStyles(({ css }) => ({
 const Home = memo(() => {
   const isLogin = useUserStore(authSelectors.isLogin);
   const showHomeRail = useGlobalStore(systemStatusSelectors.showHomeRail);
-  const railHasContent = useHomeRailHasContent();
+  const { hasContent: railHasContent, status: railStatus } =
+    useHomeInboxSections(HOME_RAIL_INBOX_OPTIONS);
   const [mode, setMode] = useState<HomeMode>('chat');
   const [inputValue, setInputValue] = useState('');
   const railVisible = resolveHomeRailVisible({ isLogin, railHasContent, showHomeRail });
   const railCollapsed = !railVisible;
+
+  const hasSettledRailRef = useRef(false);
+  const suppressRailTransition = resolveSuppressRailTransition({
+    hasSettledBefore: hasSettledRailRef.current,
+    status: railStatus,
+  });
+
+  useEffect(() => {
+    if (railStatus !== 'loading') hasSettledRailRef.current = true;
+  }, [railStatus]);
 
   const handleInputValueChange = useCallback((value: string) => {
     setInputValue(value);
@@ -262,26 +283,50 @@ const Home = memo(() => {
 
   return (
     <Flexbox className={styles.grid}>
-      <div className={cx(styles.header, styles.content, railCollapsed && styles.contentCollapsed)}>
+      <div
+        className={cx(
+          styles.header,
+          styles.content,
+          railCollapsed && styles.contentCollapsed,
+          suppressRailTransition && styles.noTransition,
+        )}
+      >
         <HomeHeader />
         {/* No portrait for signed-out visitors, so no one to speak the line. */}
         {isLogin && (
-          <div className={cx(styles.bubbleSlot, railCollapsed && styles.bubbleSlotCollapsed)}>
+          <div
+            className={cx(
+              styles.bubbleSlot,
+              railCollapsed && styles.bubbleSlotCollapsed,
+              suppressRailTransition && styles.noTransition,
+            )}
+          >
             <PortraitBubble />
           </div>
         )}
       </div>
 
       {isLogin && (
-        <div className={cx(styles.portrait, railCollapsed && styles.portraitCollapsed)}>
+        <div
+          className={cx(
+            styles.portrait,
+            railCollapsed && styles.portraitCollapsed,
+            suppressRailTransition && styles.noTransition,
+          )}
+        >
           <HomePortrait />
         </div>
       )}
 
       <Flexbox
-        className={cx(styles.main, styles.content, railCollapsed && styles.contentCollapsed)}
         data-testid={'home-main'}
         gap={24}
+        className={cx(
+          styles.main,
+          styles.content,
+          railCollapsed && styles.contentCollapsed,
+          suppressRailTransition && styles.noTransition,
+        )}
       >
         <div className={styles.inputArea}>
           <InputArea
@@ -301,11 +346,15 @@ const Home = memo(() => {
       {isLogin && (
         <aside
           aria-hidden={railCollapsed}
-          className={cx(styles.rail, styles.railSurface)}
           data-collapsed={railCollapsed}
           data-testid={'home-rail'}
           id={'home-rail'}
           inert={railCollapsed}
+          className={cx(
+            styles.rail,
+            styles.railSurface,
+            suppressRailTransition && styles.noTransition,
+          )}
         >
           <HomeInbox {...HOME_RAIL_INBOX_OPTIONS} />
         </aside>

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -21,7 +21,10 @@ import HomePortrait from './HomePortrait';
 import { resolveHomeRailVisible } from './homeRailVisibility';
 import InputArea from './InputArea';
 import PortraitBubble from './PortraitBubble';
-import { resolveSuppressRailTransition } from './suppressFirstRailTransition';
+import {
+  resolveRailHasSettled,
+  resolveSuppressRailTransition,
+} from './suppressFirstRailTransition';
 import type { HomeMode } from './types';
 
 /** Trailing gutter that keeps the rail's cards off the page's scroll lane. */
@@ -256,14 +259,19 @@ const Home = memo(() => {
   const railCollapsed = !railVisible;
 
   const hasSettledRailRef = useRef(false);
+  const previousShowHomeRailRef = useRef(showHomeRail);
   const suppressRailTransition = resolveSuppressRailTransition({
     hasResolved: railHasResolved,
     hasSettledBefore: hasSettledRailRef.current,
   });
 
   useEffect(() => {
-    if (railHasResolved) hasSettledRailRef.current = true;
-  }, [railHasResolved]);
+    const showHomeRailChanged = previousShowHomeRailRef.current !== showHomeRail;
+    if (resolveRailHasSettled({ hasResolved: railHasResolved, showHomeRailChanged })) {
+      hasSettledRailRef.current = true;
+    }
+    previousShowHomeRailRef.current = showHomeRail;
+  }, [railHasResolved, showHomeRail]);
 
   const handleInputValueChange = useCallback((value: string) => {
     setInputValue(value);

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -21,10 +21,7 @@ import HomePortrait from './HomePortrait';
 import { resolveHomeRailVisible } from './homeRailVisibility';
 import InputArea from './InputArea';
 import PortraitBubble from './PortraitBubble';
-import {
-  resolveRailHasSettled,
-  resolveSuppressRailTransition,
-} from './suppressFirstRailTransition';
+import { resolveSuppressRailTransition } from './suppressFirstRailTransition';
 import type { HomeMode } from './types';
 
 /** Trailing gutter that keeps the rail's cards off the page's scroll lane. */
@@ -259,19 +256,14 @@ const Home = memo(() => {
   const railCollapsed = !railVisible;
 
   const hasSettledRailRef = useRef(false);
-  const previousShowHomeRailRef = useRef(showHomeRail);
   const suppressRailTransition = resolveSuppressRailTransition({
     hasResolved: railHasResolved,
     hasSettledBefore: hasSettledRailRef.current,
   });
 
   useEffect(() => {
-    const showHomeRailChanged = previousShowHomeRailRef.current !== showHomeRail;
-    if (resolveRailHasSettled({ hasResolved: railHasResolved, showHomeRailChanged })) {
-      hasSettledRailRef.current = true;
-    }
-    previousShowHomeRailRef.current = showHomeRail;
-  }, [railHasResolved, showHomeRail]);
+    if (railHasResolved) hasSettledRailRef.current = true;
+  }, [railHasResolved]);
 
   const handleInputValueChange = useCallback((value: string) => {
     setInputValue(value);

--- a/src/features/Home/suppressFirstRailTransition.test.ts
+++ b/src/features/Home/suppressFirstRailTransition.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  resolveRailHasSettled,
-  resolveSuppressRailTransition,
-} from './suppressFirstRailTransition';
+import { resolveSuppressRailTransition } from './suppressFirstRailTransition';
 
 describe('resolveSuppressRailTransition', () => {
   it('suppresses the transition the first time the inbox resolves', () => {
@@ -25,20 +22,5 @@ describe('resolveSuppressRailTransition', () => {
     expect(resolveSuppressRailTransition({ hasResolved: false, hasSettledBefore: true })).toBe(
       false,
     );
-  });
-});
-
-describe('resolveRailHasSettled', () => {
-  it('settles once the inbox resolves, toggle or not', () => {
-    expect(resolveRailHasSettled({ hasResolved: true, showHomeRailChanged: false })).toBe(true);
-    expect(resolveRailHasSettled({ hasResolved: true, showHomeRailChanged: true })).toBe(true);
-  });
-
-  it('settles on a manual toggle even if the inbox never resolves — caps the window', () => {
-    expect(resolveRailHasSettled({ hasResolved: false, showHomeRailChanged: true })).toBe(true);
-  });
-
-  it('does not settle while neither has happened', () => {
-    expect(resolveRailHasSettled({ hasResolved: false, showHomeRailChanged: false })).toBe(false);
   });
 });

--- a/src/features/Home/suppressFirstRailTransition.test.ts
+++ b/src/features/Home/suppressFirstRailTransition.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveSuppressRailTransition } from './suppressFirstRailTransition';
+import {
+  resolveRailHasSettled,
+  resolveSuppressRailTransition,
+} from './suppressFirstRailTransition';
 
 describe('resolveSuppressRailTransition', () => {
   it('suppresses the transition the first time the inbox resolves', () => {
@@ -22,5 +25,20 @@ describe('resolveSuppressRailTransition', () => {
     expect(resolveSuppressRailTransition({ hasResolved: false, hasSettledBefore: true })).toBe(
       false,
     );
+  });
+});
+
+describe('resolveRailHasSettled', () => {
+  it('settles once the inbox resolves, toggle or not', () => {
+    expect(resolveRailHasSettled({ hasResolved: true, showHomeRailChanged: false })).toBe(true);
+    expect(resolveRailHasSettled({ hasResolved: true, showHomeRailChanged: true })).toBe(true);
+  });
+
+  it('settles on a manual toggle even if the inbox never resolves — caps the window', () => {
+    expect(resolveRailHasSettled({ hasResolved: false, showHomeRailChanged: true })).toBe(true);
+  });
+
+  it('does not settle while neither has happened', () => {
+    expect(resolveRailHasSettled({ hasResolved: false, showHomeRailChanged: false })).toBe(false);
   });
 });

--- a/src/features/Home/suppressFirstRailTransition.test.ts
+++ b/src/features/Home/suppressFirstRailTransition.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveSuppressRailTransition } from './suppressFirstRailTransition';
+
+describe('resolveSuppressRailTransition', () => {
+  it('suppresses the transition the first time loading settles to ready', () => {
+    expect(resolveSuppressRailTransition({ hasSettledBefore: false, status: 'ready' })).toBe(true);
+  });
+
+  it('suppresses the transition the first time loading settles to error', () => {
+    expect(resolveSuppressRailTransition({ hasSettledBefore: false, status: 'error' })).toBe(true);
+  });
+
+  it('does not suppress once it has already settled once', () => {
+    expect(resolveSuppressRailTransition({ hasSettledBefore: true, status: 'ready' })).toBe(false);
+    expect(resolveSuppressRailTransition({ hasSettledBefore: true, status: 'error' })).toBe(false);
+  });
+
+  it('does not suppress while still loading — it has not settled yet', () => {
+    expect(resolveSuppressRailTransition({ hasSettledBefore: false, status: 'loading' })).toBe(
+      false,
+    );
+    expect(resolveSuppressRailTransition({ hasSettledBefore: true, status: 'loading' })).toBe(
+      false,
+    );
+  });
+});

--- a/src/features/Home/suppressFirstRailTransition.test.ts
+++ b/src/features/Home/suppressFirstRailTransition.test.ts
@@ -3,24 +3,23 @@ import { describe, expect, it } from 'vitest';
 import { resolveSuppressRailTransition } from './suppressFirstRailTransition';
 
 describe('resolveSuppressRailTransition', () => {
-  it('suppresses the transition the first time loading settles to ready', () => {
-    expect(resolveSuppressRailTransition({ hasSettledBefore: false, status: 'ready' })).toBe(true);
-  });
-
-  it('suppresses the transition the first time loading settles to error', () => {
-    expect(resolveSuppressRailTransition({ hasSettledBefore: false, status: 'error' })).toBe(true);
+  it('suppresses the transition the first time the inbox resolves', () => {
+    expect(resolveSuppressRailTransition({ hasResolved: true, hasSettledBefore: false })).toBe(
+      true,
+    );
   });
 
   it('does not suppress once it has already settled once', () => {
-    expect(resolveSuppressRailTransition({ hasSettledBefore: true, status: 'ready' })).toBe(false);
-    expect(resolveSuppressRailTransition({ hasSettledBefore: true, status: 'error' })).toBe(false);
-  });
-
-  it('does not suppress while still loading — it has not settled yet', () => {
-    expect(resolveSuppressRailTransition({ hasSettledBefore: false, status: 'loading' })).toBe(
+    expect(resolveSuppressRailTransition({ hasResolved: true, hasSettledBefore: true })).toBe(
       false,
     );
-    expect(resolveSuppressRailTransition({ hasSettledBefore: true, status: 'loading' })).toBe(
+  });
+
+  it('does not suppress while still unresolved — it has not settled yet', () => {
+    expect(resolveSuppressRailTransition({ hasResolved: false, hasSettledBefore: false })).toBe(
+      false,
+    );
+    expect(resolveSuppressRailTransition({ hasResolved: false, hasSettledBefore: true })).toBe(
       false,
     );
   });

--- a/src/features/Home/suppressFirstRailTransition.ts
+++ b/src/features/Home/suppressFirstRailTransition.ts
@@ -7,3 +7,19 @@ export const resolveSuppressRailTransition = ({
   hasResolved,
   hasSettledBefore,
 }: ResolveSuppressRailTransitionParams): boolean => !hasSettledBefore && hasResolved;
+
+interface ResolveRailHasSettledParams {
+  hasResolved: boolean;
+  showHomeRailChanged: boolean;
+}
+
+// If any of the three async sources hangs, `hasResolved` never fires and the
+// suppression window would stay open indefinitely — a manual toggle in that
+// state would get a silent, unanimated jump instead of the 220ms transition
+// the user is deliberately triggering. A manual toggle is definitionally not
+// "the first settle" regardless of whether the data ever resolves, so it
+// closes the window on its own.
+export const resolveRailHasSettled = ({
+  hasResolved,
+  showHomeRailChanged,
+}: ResolveRailHasSettledParams): boolean => hasResolved || showHomeRailChanged;

--- a/src/features/Home/suppressFirstRailTransition.ts
+++ b/src/features/Home/suppressFirstRailTransition.ts
@@ -1,9 +1,9 @@
 interface ResolveSuppressRailTransitionParams {
+  hasResolved: boolean;
   hasSettledBefore: boolean;
-  status: 'error' | 'loading' | 'ready';
 }
 
 export const resolveSuppressRailTransition = ({
+  hasResolved,
   hasSettledBefore,
-  status,
-}: ResolveSuppressRailTransitionParams): boolean => !hasSettledBefore && status !== 'loading';
+}: ResolveSuppressRailTransitionParams): boolean => !hasSettledBefore && hasResolved;

--- a/src/features/Home/suppressFirstRailTransition.ts
+++ b/src/features/Home/suppressFirstRailTransition.ts
@@ -7,19 +7,3 @@ export const resolveSuppressRailTransition = ({
   hasResolved,
   hasSettledBefore,
 }: ResolveSuppressRailTransitionParams): boolean => !hasSettledBefore && hasResolved;
-
-interface ResolveRailHasSettledParams {
-  hasResolved: boolean;
-  showHomeRailChanged: boolean;
-}
-
-// If any of the three async sources hangs, `hasResolved` never fires and the
-// suppression window would stay open indefinitely — a manual toggle in that
-// state would get a silent, unanimated jump instead of the 220ms transition
-// the user is deliberately triggering. A manual toggle is definitionally not
-// "the first settle" regardless of whether the data ever resolves, so it
-// closes the window on its own.
-export const resolveRailHasSettled = ({
-  hasResolved,
-  showHomeRailChanged,
-}: ResolveRailHasSettledParams): boolean => hasResolved || showHomeRailChanged;

--- a/src/features/Home/suppressFirstRailTransition.ts
+++ b/src/features/Home/suppressFirstRailTransition.ts
@@ -1,0 +1,9 @@
+interface ResolveSuppressRailTransitionParams {
+  hasSettledBefore: boolean;
+  status: 'error' | 'loading' | 'ready';
+}
+
+export const resolveSuppressRailTransition = ({
+  hasSettledBefore,
+  status,
+}: ResolveSuppressRailTransitionParams): boolean => !hasSettledBefore && status !== 'loading';

--- a/src/features/HomeInbox/homeInboxHasContent.test.ts
+++ b/src/features/HomeInbox/homeInboxHasContent.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveHomeInboxHasContent } from './homeInboxHasContent';
+
+describe('resolveHomeInboxHasContent', () => {
+  it('shows the rail skeleton while briefs are loading', () => {
+    expect(
+      resolveHomeInboxHasContent({
+        isMain: false,
+        recommendationsVisible: false,
+        sectionsCount: 0,
+        status: 'loading',
+      }),
+    ).toBe(true);
+  });
+
+  it('shows the rail AsyncError on a first-load failure', () => {
+    expect(
+      resolveHomeInboxHasContent({
+        isMain: false,
+        recommendationsVisible: false,
+        sectionsCount: 0,
+        status: 'error',
+      }),
+    ).toBe(true);
+  });
+
+  it('has content whenever any section was assembled', () => {
+    expect(
+      resolveHomeInboxHasContent({
+        isMain: false,
+        recommendationsVisible: false,
+        sectionsCount: 1,
+        status: 'ready',
+      }),
+    ).toBe(true);
+  });
+
+  it('falls back to recommendations visibility once sections are empty', () => {
+    expect(
+      resolveHomeInboxHasContent({
+        isMain: false,
+        recommendationsVisible: true,
+        sectionsCount: 0,
+        status: 'ready',
+      }),
+    ).toBe(true);
+    expect(
+      resolveHomeInboxHasContent({
+        isMain: false,
+        recommendationsVisible: false,
+        sectionsCount: 0,
+        status: 'ready',
+      }),
+    ).toBe(false);
+  });
+
+  it('is false for an empty main inbox regardless of recommendations visibility', () => {
+    expect(
+      resolveHomeInboxHasContent({
+        isMain: true,
+        recommendationsVisible: true,
+        sectionsCount: 0,
+        status: 'ready',
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/features/HomeInbox/homeInboxHasContent.test.ts
+++ b/src/features/HomeInbox/homeInboxHasContent.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveHomeInboxHasContent } from './homeInboxHasContent';
+import { resolveHomeInboxHasContent, resolveHomeInboxHasResolved } from './homeInboxHasContent';
 
 describe('resolveHomeInboxHasContent', () => {
   it('shows the rail skeleton while briefs are loading', () => {
@@ -64,5 +64,57 @@ describe('resolveHomeInboxHasContent', () => {
         status: 'ready',
       }),
     ).toBe(false);
+  });
+});
+
+describe('resolveHomeInboxHasResolved', () => {
+  it('is unresolved while briefs are still loading', () => {
+    expect(
+      resolveHomeInboxHasResolved({
+        isRecommendationsSettled: true,
+        isTopicsInit: true,
+        status: 'loading',
+      }),
+    ).toBe(false);
+  });
+
+  it('is unresolved while topics have not finished their first fetch, even once briefs have', () => {
+    expect(
+      resolveHomeInboxHasResolved({
+        isRecommendationsSettled: true,
+        isTopicsInit: false,
+        status: 'ready',
+      }),
+    ).toBe(false);
+  });
+
+  it('is unresolved while the recommendation flow is still showing its own skeleton', () => {
+    expect(
+      resolveHomeInboxHasResolved({
+        isRecommendationsSettled: false,
+        isTopicsInit: true,
+        status: 'ready',
+      }),
+    ).toBe(false);
+  });
+
+  it('is resolved once briefs, topics, and recommendations have all settled', () => {
+    expect(
+      resolveHomeInboxHasResolved({
+        isRecommendationsSettled: true,
+        isTopicsInit: true,
+        status: 'ready',
+      }),
+    ).toBe(true);
+  });
+
+  it('is resolved on a first-load brief failure — an error is itself a final answer', () => {
+    expect(
+      resolveHomeInboxHasResolved({
+        isRecommendationsSettled: true,
+        isTopicsInit: true,
+        status: 'error',
+      }),
+    ).toBe(true);
   });
 });

--- a/src/features/HomeInbox/homeInboxHasContent.ts
+++ b/src/features/HomeInbox/homeInboxHasContent.ts
@@ -1,0 +1,18 @@
+interface ResolveHomeInboxHasContentParams {
+  isMain: boolean;
+  recommendationsVisible: boolean;
+  sectionsCount: number;
+  status: 'error' | 'loading' | 'ready';
+}
+
+export const resolveHomeInboxHasContent = ({
+  isMain,
+  recommendationsVisible,
+  sectionsCount,
+  status,
+}: ResolveHomeInboxHasContentParams): boolean => {
+  if (status === 'loading' || status === 'error') return true;
+  if (sectionsCount > 0) return true;
+  if (isMain) return false;
+  return recommendationsVisible;
+};

--- a/src/features/HomeInbox/homeInboxHasContent.ts
+++ b/src/features/HomeInbox/homeInboxHasContent.ts
@@ -16,3 +16,25 @@ export const resolveHomeInboxHasContent = ({
   if (isMain) return false;
   return recommendationsVisible;
 };
+
+interface ResolveHomeInboxHasResolvedParams {
+  isRecommendationsSettled: boolean;
+  isTopicsInit: boolean;
+  status: 'error' | 'loading' | 'ready';
+}
+
+// `hasContent` can still be transient after `status` leaves `'loading'`: the
+// `sectionsCount === 0` fallback reads `recommendationsVisible`, which is
+// `true` while the recommendation flow is only showing its own skeleton
+// (not yet a final `'hidden'` or `'cards'` answer), and `sectionsCount`
+// itself depends on topics that can still be mid-fetch independently of the
+// briefs-driven `status`. `hasResolved` is the point past which none of
+// `hasContent`'s inputs can still be a loading placeholder — the signal a
+// caller needs to tell "this collapse is the real one" from "the loading
+// state is still settling."
+export const resolveHomeInboxHasResolved = ({
+  isRecommendationsSettled,
+  isTopicsInit,
+  status,
+}: ResolveHomeInboxHasResolvedParams): boolean =>
+  status !== 'loading' && isTopicsInit && isRecommendationsSettled;

--- a/src/features/HomeInbox/index.tsx
+++ b/src/features/HomeInbox/index.tsx
@@ -54,7 +54,7 @@ const HomeInbox = memo<HomeInboxProps>(
         <Flexbox gap={12}>
           <BriefCardSkeleton />
           <BriefCardSkeleton />
-          <Recommendations variant={isRail ? 'rail' : 'default'} />
+          <Recommendations variant={variant} />
         </Flexbox>
       );
     }

--- a/src/features/HomeInbox/index.tsx
+++ b/src/features/HomeInbox/index.tsx
@@ -1,84 +1,24 @@
 import { Flexbox } from '@lobehub/ui';
-import { Segmented } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';
-import { Fragment, memo, type ReactNode, useMemo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Fragment, memo } from 'react';
 
-import { useWorkspaceMemberProfiles } from '@/business/client/hooks/useWorkspaceMemberProfiles';
 import AsyncError from '@/components/AsyncError';
 import { BriefCardSkeleton } from '@/features/DailyBrief/BriefCardSkeleton';
 import GroupBlock from '@/features/Home/components/GroupBlock';
 import { homeType } from '@/features/Home/components/homeType';
 import RailCard from '@/features/Home/components/RailCard';
-import Recommendations, { useRecommendationsVisible } from '@/features/Recommendations';
-import { useCacheScope } from '@/libs/swr/useCacheScope';
-import { useBriefStore } from '@/store/brief';
-import { briefListSelectors } from '@/store/brief/selectors';
+import Recommendations from '@/features/Recommendations';
 import { useUserStore } from '@/store/user';
-import { authSelectors, userProfileSelectors } from '@/store/user/slices/auth/selectors';
+import { authSelectors } from '@/store/user/slices/auth/selectors';
 
-import InboxBriefCard from './InboxBriefCard';
-import MarkAllReadButton from './MarkAllReadButton';
-import NeedsYouRailCard from './NeedsYouRailCard';
-import NewsList from './NewsList';
-import { ownsRailSections } from './railSectionPlacement';
-import RunningTasksCard from './RunningTasksCard';
-import { filterTopicsForInboxScope, resolveScopeToggleSection } from './scopeTogglePlacement';
-import { splitBriefs } from './splitBriefs';
-import UnreadTopicList from './UnreadTopicList';
-import { useHomeInboxTopics } from './useHomeInboxTopics';
+import { useHomeInboxSections } from './useHomeInboxSections';
 
-const styles = createStaticStyles(({ css, cssVar }) => ({
-  onlyMe: css`
-    margin-inline-start: 8px;
-    padding-inline: 5px;
-    border-radius: 3px;
-    background: ${cssVar.colorFillQuaternary};
-  `,
+const styles = createStaticStyles(({ css }) => ({
   subtitle: css`
     margin-inline-start: 8px;
   `,
 }));
 
-interface InboxSection {
-  /** Header action revealed on hover (GroupBlock's action slot). */
-  action?: ReactNode;
-  /** Trailing marker on the heading, e.g. the team-view "only mine" chip. */
-  badge?: ReactNode;
-  count?: number;
-  key: string;
-  /** Omitted when the section labels itself (the running card names its own count). */
-  label?: string;
-  node: ReactNode;
-  /** Section carries its own card shell — the rail renders it verbatim. */
-  selfShelled?: boolean;
-  subtitle?: string;
-}
-
-/**
- * The home inbox: everything the agents did while you were away, sorted by
- * whether it needs you.
- *
- * - **Needs you** — briefs blocking an agent (decide / fix). Errors sink to the
- *   bottom: a stuck decision blocks work right now, a failed run has already
- *   stopped.
- * - **Unread** — runs that finished while you were away, each showing the agent's
- *   last reply so the answer is right there.
- * - **Running** — collapsed to one line, showing who is working; a healthy run
- *   needs nothing from you.
- * - **News** — `insight` + `result` briefs (reports of finished work); read them
- *   or don't.
- *
- * **Workspace mode** adds a mine/team split, but only over the sections it can
- * honestly widen. Topics are workspace-shared, so the unread + running feeds
- * already carry every member's runs — the toggle filters them by triggerer, and
- * team view tags each row with whose it is. Briefs are per-user by a deliberate
- * ownership rule (a member never sees another's brief), so Needs-you and News
- * stay mine in both views; team view marks News as such rather than pretending.
- *
- * Sections are siblings, never nested: each names itself and carries its own
- * count, and one absent section never hides another's heading.
- */
 interface HomeInboxProps {
   hideNeedsYou?: boolean;
   hideUnread?: boolean;
@@ -90,290 +30,122 @@ interface HomeInboxProps {
   variant?: 'default' | 'main' | 'rail';
 }
 
-const HomeInbox = memo<HomeInboxProps>((props) => {
-  const { hideNeedsYou, hideUnread, inlineRail, variant = 'default' } = props;
-  const isRail = variant === 'rail';
-  const isMain = variant === 'main';
-  const showRailSections = ownsRailSections({ inlineRail, variant });
-  const { t } = useTranslation('home');
-  const isLogin = useUserStore(authSelectors.isLogin);
-  const myId = useUserStore(userProfileSelectors.userId);
+const HomeInbox = memo<HomeInboxProps>(
+  ({ hideNeedsYou, hideUnread, inlineRail, variant = 'default' }) => {
+    const isRail = variant === 'rail';
+    const isMain = variant === 'main';
+    const isLogin = useUserStore(authSelectors.isLogin);
 
-  // Briefs are per-user AND per-workspace rows, so the feed is read through the
-  // active cache scope — a list left over from the previous workspace holds ids
-  // this one cannot resolve, and every action on it would fail silently.
-  const cacheScope = useCacheScope();
-  const useFetchBriefs = useBriefStore((s) => s.useFetchBriefs);
-  const briefsSWR = useFetchBriefs(isLogin, cacheScope);
-  const briefs = useBriefStore(briefListSelectors.briefs(cacheScope));
-  const isBriefsInit = useBriefStore(briefListSelectors.isBriefsInit(cacheScope));
+    const { briefsError, recommendationsVisible, retryBriefs, sections, status } =
+      useHomeInboxSections({ hideNeedsYou, hideUnread, inlineRail, variant });
 
-  const topics = useHomeInboxTopics(isLogin);
-  const recommendationsVisible = useRecommendationsVisible();
+    if (!isLogin) return null;
 
-  // A team context is a workspace with more than the viewer in it. In personal
-  // mode this map is empty, so `isTeam` is false and the whole mine/team layer
-  // stays dark — the inbox is byte-for-byte the personal one.
-  const memberProfiles = useWorkspaceMemberProfiles();
-  const isTeam = memberProfiles.size > 1;
-
-  const [scope, setScope] = useState<'mine' | 'team'>('mine');
-  const teamView = isTeam && scope === 'team';
-
-  const { needsYou, news } = useMemo(() => splitBriefs(briefs), [briefs]);
-
-  // Topics are already workspace-wide from the server; "mine" is the viewer's
-  // own runs, "team" is everyone's. Personal mode has only the viewer's, so the
-  // filter is a no-op there.
-  const unreadTopics = useMemo(
-    () => filterTopicsForInboxScope(topics.unread, myId, teamView),
-    [teamView, topics.unread, myId],
-  );
-  const runningTopics = useMemo(
-    () => filterTopicsForInboxScope(topics.running, myId, teamView),
-    [teamView, topics.running, myId],
-  );
-
-  if (!isLogin) return null;
-
-  // The brief feed is the primary content; a first-load failure blocks the whole
-  // surface. No fabricated section heading — we don't know what's under it yet.
-  if (!isMain && briefsSWR.error && !isBriefsInit && !briefsSWR.isLoading) {
-    return (
-      <AsyncError
-        error={briefsSWR.error}
-        variant={'block'}
-        onRetry={() => {
-          void briefsSWR.mutate();
-        }}
-      />
-    );
-  }
-
-  // First load: bare skeletons, no group heading (loading must not assert a
-  // "Needs you" section that may turn out empty). Recommendations keep their own.
-  if (!isMain && !isBriefsInit) {
-    return (
-      <Flexbox gap={12}>
-        <BriefCardSkeleton />
-        <BriefCardSkeleton />
-        <Recommendations variant={variant} />
-      </Flexbox>
-    );
-  }
-
-  // Mine/team lives at page level (governs the topic sections), so it rides on
-  // the first titled section's header — the primary "Needs you", or Unread when
-  // there's nothing to handle. Only shown in a team workspace.
-  const scopeToggle = isTeam ? (
-    <Segmented
-      size={'small'}
-      value={scope}
-      options={[
-        { label: t('inbox.scope.mine'), value: 'mine' },
-        { label: t('inbox.scope.team'), value: 'team' },
-      ]}
-      onChange={(value) => setScope(value as 'mine' | 'team')}
-    />
-  ) : undefined;
-  const toggleSectionKey = scopeToggle
-    ? resolveScopeToggleSection({
-        hasNeedsYou: !hideNeedsYou && needsYou.length > 0,
-        hasRunning: runningTopics.length > 0,
-        hasUnread: !hideUnread && unreadTopics.length > 0,
-        preferUnread: isMain,
-      })
-    : null;
-  const placeToggle = (key: typeof toggleSectionKey): ReactNode =>
-    key === toggleSectionKey ? scopeToggle : undefined;
-
-  const sections: InboxSection[] = [];
-
-  if (!isMain && !hideNeedsYou && needsYou.length > 0)
-    sections.push(
-      // The rail paginates instead of stacking and owns its header. Keep the
-      // page-level scope control in that header alongside the pager.
-      isRail
-        ? {
-            key: 'needsYou',
-            node: <NeedsYouRailCard briefs={needsYou} scopeControl={placeToggle('needsYou')} />,
-            selfShelled: true,
-          }
-        : {
-            action: placeToggle('needsYou'),
-            count: needsYou.length,
-            key: 'needsYou',
-            label: t('inbox.needsYou.title'),
-            node: (
-              <Flexbox gap={12}>
-                {needsYou.map((brief) => (
-                  <InboxBriefCard brief={brief} key={brief.id} />
-                ))}
-              </Flexbox>
-            ),
-          },
-    );
-
-  // A topic-feed failure must not be silent: without this the unread / running
-  // sections would just vanish and the inbox would look empty-but-fine.
-  if (topics.error)
-    sections.push({
-      key: 'topics-error',
-      label: t('inbox.unread.title'),
-      node: <AsyncError error={topics.error} variant={'inline'} onRetry={topics.reload} />,
-    });
-
-  if (!hideUnread && unreadTopics.length > 0)
-    sections.push({
-      action: placeToggle('unread'),
-      count: unreadTopics.length,
-      key: 'unread',
-      label: t('inbox.unread.title'),
-      node: (
-        <UnreadTopicList
-          bare={isRail}
-          showAuthor={teamView}
-          topics={unreadTopics}
-          onFollowUpSent={topics.promoteToRunning}
-        />
-      ),
-    });
-
-  if (isMain) {
-    if (briefsSWR.error && !isBriefsInit && !briefsSWR.isLoading) {
-      sections.push({
-        key: 'needsYou-error',
-        label: t('inbox.needsYou.title'),
-        node: (
-          <AsyncError
-            error={briefsSWR.error}
-            variant={'inline'}
-            onRetry={() => void briefsSWR.mutate()}
-          />
-        ),
-      });
-    } else if (!isBriefsInit) {
-      sections.push({ key: 'needsYou-loading', node: <BriefCardSkeleton /> });
-    } else if (!hideNeedsYou && needsYou.length > 0) {
-      sections.push({
-        action: placeToggle('needsYou'),
-        count: needsYou.length,
-        key: 'needsYou',
-        label: t('inbox.needsYou.title'),
-        node: (
-          <Flexbox gap={12}>
-            {needsYou.map((brief) => (
-              <InboxBriefCard brief={brief} key={brief.id} />
-            ))}
-          </Flexbox>
-        ),
-      });
+    // The brief feed is the primary content; a first-load failure blocks the whole
+    // surface. No fabricated section heading — we don't know what's under it yet.
+    if (status === 'error') {
+      return <AsyncError error={briefsError} variant={'block'} onRetry={retryBriefs} />;
     }
-  }
 
-  // No title: the card already says "3 tasks running" on its own head.
-  if (showRailSections && runningTopics.length > 0)
-    sections.push({
-      key: 'running',
-      node: (
-        <RunningTasksCard
-          action={placeToggle('running')}
-          bare={isRail}
-          running={runningTopics}
-          showAuthor={teamView}
-        />
-      ),
-    });
-
-  if (showRailSections && news.length > 0)
-    sections.push({
-      action: <MarkAllReadButton news={news} />,
-      // Team view: News is still only mine (briefs are per-user), so say so
-      // rather than let a team-scoped page imply it spans the team.
-      badge: teamView && (
-        <span className={cx(homeType.meta, styles.onlyMe)}>{t('inbox.scope.onlyMe')}</span>
-      ),
-      count: news.length,
-      key: 'news',
-      label: t('inbox.news.title'),
-      node: <NewsList bare={isRail} news={news} />,
-      subtitle: t('inbox.news.subtitle'),
-    });
-
-  if (sections.length === 0) {
-    if (isMain) return null;
-
-    if (isRail)
+    // First load: bare skeletons, no group heading (loading must not assert a
+    // "Needs you" section that may turn out empty). Recommendations keep their own.
+    if (status === 'loading') {
       return (
         <Flexbox gap={12}>
-          <Recommendations variant={'rail'} />
+          <BriefCardSkeleton />
+          <BriefCardSkeleton />
+          <Recommendations variant={isRail ? 'rail' : 'default'} />
         </Flexbox>
       );
+    }
 
-    // With no titled block above it, the bare recommendations list doesn't need
-    // the full section gap below the input area — offset the parent's gap so it
-    // sits closer to the input.
-    return (
-      <>
-        {recommendationsVisible && (
-          <Flexbox style={{ marginBlockStart: -24 }}>
-            <Recommendations />
+    if (sections.length === 0) {
+      if (isMain) return null;
+
+      if (isRail)
+        return (
+          <Flexbox gap={12}>
+            <Recommendations variant={'rail'} />
           </Flexbox>
-        )}
-      </>
-    );
-  }
+        );
 
-  return (
-    <Flexbox gap={isRail ? 12 : 32}>
-      {sections.map(({ action, badge, count, key, label, node, selfShelled, subtitle }) => {
-        if (selfShelled) return <Fragment key={key}>{node}</Fragment>;
+      // With no titled block above it, the bare recommendations list doesn't need
+      // the full section gap below the input area — offset the parent's gap so it
+      // sits closer to the input.
+      return (
+        <>
+          {recommendationsVisible && (
+            <Flexbox style={{ marginBlockStart: -24 }}>
+              <Recommendations />
+            </Flexbox>
+          )}
+        </>
+      );
+    }
 
-        if (isRail)
-          return (
-            <RailCard
-              action={action}
-              count={count}
-              key={key}
-              title={
-                label && (
+    return (
+      <Flexbox gap={isRail ? 12 : 32}>
+        {sections.map(
+          ({
+            action,
+            actionAlwaysVisible,
+            badge,
+            count,
+            key,
+            label,
+            node,
+            selfShelled,
+            subtitle,
+          }) => {
+            if (selfShelled) return <Fragment key={key}>{node}</Fragment>;
+
+            if (isRail)
+              return (
+                <RailCard
+                  action={action}
+                  count={count}
+                  key={key}
+                  title={
+                    label && (
+                      <>
+                        {label}
+                        {badge}
+                      </>
+                    )
+                  }
+                >
+                  {node}
+                </RailCard>
+              );
+
+            if (!label) return <Flexbox key={key}>{node}</Flexbox>;
+
+            return (
+              <GroupBlock
+                action={action}
+                actionAlwaysVisible={actionAlwaysVisible}
+                count={count}
+                key={key}
+                title={
                   <>
                     {label}
+                    {subtitle && (
+                      <span className={cx(homeType.meta, styles.subtitle)}>· {subtitle}</span>
+                    )}
                     {badge}
                   </>
-                )
-              }
-            >
-              {node}
-            </RailCard>
-          );
+                }
+              >
+                {node}
+              </GroupBlock>
+            );
+          },
+        )}
 
-        if (!label) return <Flexbox key={key}>{node}</Flexbox>;
-
-        return (
-          <GroupBlock
-            action={action}
-            actionAlwaysVisible={key === toggleSectionKey}
-            count={count}
-            key={key}
-            title={
-              <>
-                {label}
-                {subtitle && (
-                  <span className={cx(homeType.meta, styles.subtitle)}>· {subtitle}</span>
-                )}
-                {badge}
-              </>
-            }
-          >
-            {node}
-          </GroupBlock>
-        );
-      })}
-
-      {!isMain && <Recommendations variant={variant} />}
-    </Flexbox>
-  );
-});
+        {!isMain && <Recommendations variant={variant} />}
+      </Flexbox>
+    );
+  },
+);
 
 export default HomeInbox;

--- a/src/features/HomeInbox/useHomeInboxSections.tsx
+++ b/src/features/HomeInbox/useHomeInboxSections.tsx
@@ -1,7 +1,7 @@
 import { Flexbox } from '@lobehub/ui';
 import { Segmented } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';
-import { type ReactNode, useMemo, useState } from 'react';
+import { type ReactNode, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useWorkspaceMemberProfiles } from '@/business/client/hooks/useWorkspaceMemberProfiles';
@@ -12,6 +12,8 @@ import { useRecommendationsVisible } from '@/features/Recommendations';
 import { useCacheScope } from '@/libs/swr/useCacheScope';
 import { useBriefStore } from '@/store/brief';
 import { briefListSelectors } from '@/store/brief/selectors';
+import { useHomeStore } from '@/store/home';
+import { homeInboxScopeSelectors } from '@/store/home/selectors';
 import { useUserStore } from '@/store/user';
 import { authSelectors, userProfileSelectors } from '@/store/user/slices/auth/selectors';
 
@@ -127,7 +129,8 @@ export const useHomeInboxSections = ({
   const memberProfiles = useWorkspaceMemberProfiles();
   const isTeam = memberProfiles.size > 1;
 
-  const [scope, setScope] = useState<'mine' | 'team'>('mine');
+  const scope = useHomeStore(homeInboxScopeSelectors.homeInboxScope);
+  const setScope = useHomeStore((s) => s.setHomeInboxScope);
   const teamView = isTeam && scope === 'team';
 
   const { needsYou, news } = useMemo(() => splitBriefs(briefs), [briefs]);

--- a/src/features/HomeInbox/useHomeInboxSections.tsx
+++ b/src/features/HomeInbox/useHomeInboxSections.tsx
@@ -1,0 +1,311 @@
+import { Flexbox } from '@lobehub/ui';
+import { Segmented } from '@lobehub/ui/base-ui';
+import { createStaticStyles, cx } from 'antd-style';
+import { type ReactNode, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useWorkspaceMemberProfiles } from '@/business/client/hooks/useWorkspaceMemberProfiles';
+import AsyncError from '@/components/AsyncError';
+import { BriefCardSkeleton } from '@/features/DailyBrief/BriefCardSkeleton';
+import { homeType } from '@/features/Home/components/homeType';
+import { useRecommendationsVisible } from '@/features/Recommendations';
+import { useCacheScope } from '@/libs/swr/useCacheScope';
+import { useBriefStore } from '@/store/brief';
+import { briefListSelectors } from '@/store/brief/selectors';
+import { useUserStore } from '@/store/user';
+import { authSelectors, userProfileSelectors } from '@/store/user/slices/auth/selectors';
+
+import InboxBriefCard from './InboxBriefCard';
+import MarkAllReadButton from './MarkAllReadButton';
+import NeedsYouRailCard from './NeedsYouRailCard';
+import NewsList from './NewsList';
+import { ownsRailSections } from './railSectionPlacement';
+import RunningTasksCard from './RunningTasksCard';
+import { filterTopicsForInboxScope, resolveScopeToggleSection } from './scopeTogglePlacement';
+import { splitBriefs } from './splitBriefs';
+import UnreadTopicList from './UnreadTopicList';
+import { useHomeInboxTopics } from './useHomeInboxTopics';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  onlyMe: css`
+    margin-inline-start: 8px;
+    padding-inline: 5px;
+    border-radius: 3px;
+    background: ${cssVar.colorFillQuaternary};
+  `,
+}));
+
+export interface InboxSection {
+  /** Header action revealed on hover (GroupBlock's action slot). */
+  action?: ReactNode;
+  actionAlwaysVisible?: boolean;
+  /** Trailing marker on the heading, e.g. the team-view "only mine" chip. */
+  badge?: ReactNode;
+  count?: number;
+  key: string;
+  /** Omitted when the section labels itself (the running card names its own count). */
+  label?: string;
+  node: ReactNode;
+  /** Section carries its own card shell — the rail renders it verbatim. */
+  selfShelled?: boolean;
+  subtitle?: string;
+}
+
+export interface UseHomeInboxSectionsOptions {
+  hideNeedsYou?: boolean;
+  hideUnread?: boolean;
+  /**
+   * Main column only: the rail is collapsed, so the sections it owns (running,
+   * news) fold into this column instead of disappearing with it.
+   */
+  inlineRail?: boolean;
+  variant?: 'default' | 'main' | 'rail';
+}
+
+export interface HomeInboxSectionsResult {
+  briefsError: unknown;
+  recommendationsVisible: boolean;
+  retryBriefs: () => void;
+  sections: InboxSection[];
+  status: 'loading' | 'error' | 'ready';
+}
+
+/**
+ * The home inbox: everything the agents did while you were away, sorted by
+ * whether it needs you.
+ *
+ * - **Needs you** — briefs blocking an agent (decide / fix). Errors sink to the
+ *   bottom: a stuck decision blocks work right now, a failed run has already
+ *   stopped.
+ * - **Unread** — runs that finished while you were away, each showing the agent's
+ *   last reply so the answer is right there.
+ * - **Running** — collapsed to one line, showing who is working; a healthy run
+ *   needs nothing from you.
+ * - **News** — `insight` + `result` briefs (reports of finished work); read them
+ *   or don't.
+ *
+ * **Workspace mode** adds a mine/team split, but only over the sections it can
+ * honestly widen. Topics are workspace-shared, so the unread + running feeds
+ * already carry every member's runs — the toggle filters them by triggerer, and
+ * team view tags each row with whose it is. Briefs are per-user by a deliberate
+ * ownership rule (a member never sees another's brief), so Needs-you and News
+ * stay mine in both views; team view marks News as such rather than pretending.
+ *
+ * Sections are siblings, never nested: each names itself and carries its own
+ * count, and one absent section never hides another's heading.
+ */
+export const useHomeInboxSections = ({
+  hideNeedsYou,
+  hideUnread,
+  inlineRail,
+  variant = 'default',
+}: UseHomeInboxSectionsOptions): HomeInboxSectionsResult => {
+  const isRail = variant === 'rail';
+  const isMain = variant === 'main';
+  const showRailSections = ownsRailSections({ inlineRail, variant });
+  const { t } = useTranslation('home');
+  const isLogin = useUserStore(authSelectors.isLogin);
+  const myId = useUserStore(userProfileSelectors.userId);
+
+  // Briefs are per-user AND per-workspace rows, so the feed is read through the
+  // active cache scope — a list left over from the previous workspace holds ids
+  // this one cannot resolve, and every action on it would fail silently.
+  const cacheScope = useCacheScope();
+  const useFetchBriefs = useBriefStore((s) => s.useFetchBriefs);
+  const briefsSWR = useFetchBriefs(isLogin, cacheScope);
+  const briefs = useBriefStore(briefListSelectors.briefs(cacheScope));
+  const isBriefsInit = useBriefStore(briefListSelectors.isBriefsInit(cacheScope));
+
+  const topics = useHomeInboxTopics(isLogin);
+  const recommendationsVisible = useRecommendationsVisible();
+
+  // A team context is a workspace with more than the viewer in it. In personal
+  // mode this map is empty, so `isTeam` is false and the whole mine/team layer
+  // stays dark — the inbox is byte-for-byte the personal one.
+  const memberProfiles = useWorkspaceMemberProfiles();
+  const isTeam = memberProfiles.size > 1;
+
+  const [scope, setScope] = useState<'mine' | 'team'>('mine');
+  const teamView = isTeam && scope === 'team';
+
+  const { needsYou, news } = useMemo(() => splitBriefs(briefs), [briefs]);
+
+  // Topics are already workspace-wide from the server; "mine" is the viewer's
+  // own runs, "team" is everyone's. Personal mode has only the viewer's, so the
+  // filter is a no-op there.
+  const unreadTopics = useMemo(
+    () => filterTopicsForInboxScope(topics.unread, myId, teamView),
+    [teamView, topics.unread, myId],
+  );
+  const runningTopics = useMemo(
+    () => filterTopicsForInboxScope(topics.running, myId, teamView),
+    [teamView, topics.running, myId],
+  );
+
+  const retryBriefs = () => {
+    void briefsSWR.mutate();
+  };
+
+  const status: HomeInboxSectionsResult['status'] = (() => {
+    if (!isMain && briefsSWR.error && !isBriefsInit && !briefsSWR.isLoading) return 'error';
+    if (!isMain && !isBriefsInit) return 'loading';
+    return 'ready';
+  })();
+
+  const buildSections = (): { sections: InboxSection[] } => {
+    const sections: InboxSection[] = [];
+
+    // Mine/team lives at page level (governs the topic sections), so it rides on
+    // the first titled section's header — the primary "Needs you", or Unread when
+    // there's nothing to handle. Only shown in a team workspace.
+    const scopeToggle = isTeam ? (
+      <Segmented
+        size={'small'}
+        value={scope}
+        options={[
+          { label: t('inbox.scope.mine'), value: 'mine' },
+          { label: t('inbox.scope.team'), value: 'team' },
+        ]}
+        onChange={(value) => setScope(value as 'mine' | 'team')}
+      />
+    ) : undefined;
+    const toggleSectionKey = scopeToggle
+      ? resolveScopeToggleSection({
+          hasNeedsYou: !hideNeedsYou && needsYou.length > 0,
+          hasRunning: runningTopics.length > 0,
+          hasUnread: !hideUnread && unreadTopics.length > 0,
+          preferUnread: isMain,
+        })
+      : null;
+    const placeToggle = (key: typeof toggleSectionKey): ReactNode =>
+      key === toggleSectionKey ? scopeToggle : undefined;
+
+    if (!isMain && !hideNeedsYou && needsYou.length > 0)
+      sections.push(
+        // The rail paginates instead of stacking and owns its header. Keep the
+        // page-level scope control in that header alongside the pager.
+        isRail
+          ? {
+              actionAlwaysVisible: 'needsYou' === toggleSectionKey,
+              key: 'needsYou',
+              node: <NeedsYouRailCard briefs={needsYou} scopeControl={placeToggle('needsYou')} />,
+              selfShelled: true,
+            }
+          : {
+              action: placeToggle('needsYou'),
+              actionAlwaysVisible: 'needsYou' === toggleSectionKey,
+              count: needsYou.length,
+              key: 'needsYou',
+              label: t('inbox.needsYou.title'),
+              node: (
+                <Flexbox gap={12}>
+                  {needsYou.map((brief) => (
+                    <InboxBriefCard brief={brief} key={brief.id} />
+                  ))}
+                </Flexbox>
+              ),
+            },
+      );
+
+    // A topic-feed failure must not be silent: without this the unread / running
+    // sections would just vanish and the inbox would look empty-but-fine.
+    if (topics.error)
+      sections.push({
+        key: 'topics-error',
+        label: t('inbox.unread.title'),
+        node: <AsyncError error={topics.error} variant={'inline'} onRetry={topics.reload} />,
+      });
+
+    if (!hideUnread && unreadTopics.length > 0)
+      sections.push({
+        action: placeToggle('unread'),
+        actionAlwaysVisible: 'unread' === toggleSectionKey,
+        count: unreadTopics.length,
+        key: 'unread',
+        label: t('inbox.unread.title'),
+        node: (
+          <UnreadTopicList
+            bare={isRail}
+            showAuthor={teamView}
+            topics={unreadTopics}
+            onFollowUpSent={topics.promoteToRunning}
+          />
+        ),
+      });
+
+    if (isMain) {
+      if (briefsSWR.error && !isBriefsInit && !briefsSWR.isLoading) {
+        sections.push({
+          key: 'needsYou-error',
+          label: t('inbox.needsYou.title'),
+          node: (
+            <AsyncError
+              error={briefsSWR.error}
+              variant={'inline'}
+              onRetry={() => void briefsSWR.mutate()}
+            />
+          ),
+        });
+      } else if (!isBriefsInit) {
+        sections.push({ key: 'needsYou-loading', node: <BriefCardSkeleton /> });
+      } else if (!hideNeedsYou && needsYou.length > 0) {
+        sections.push({
+          action: placeToggle('needsYou'),
+          actionAlwaysVisible: 'needsYou' === toggleSectionKey,
+          count: needsYou.length,
+          key: 'needsYou',
+          label: t('inbox.needsYou.title'),
+          node: (
+            <Flexbox gap={12}>
+              {needsYou.map((brief) => (
+                <InboxBriefCard brief={brief} key={brief.id} />
+              ))}
+            </Flexbox>
+          ),
+        });
+      }
+    }
+
+    // No title: the card already says "3 tasks running" on its own head.
+    if (showRailSections && runningTopics.length > 0)
+      sections.push({
+        actionAlwaysVisible: 'running' === toggleSectionKey,
+        key: 'running',
+        node: (
+          <RunningTasksCard
+            action={placeToggle('running')}
+            bare={isRail}
+            running={runningTopics}
+            showAuthor={teamView}
+          />
+        ),
+      });
+
+    if (showRailSections && news.length > 0)
+      sections.push({
+        action: <MarkAllReadButton news={news} />,
+        // Team view: News is still only mine (briefs are per-user), so say so
+        // rather than let a team-scoped page imply it spans the team.
+        badge: teamView && (
+          <span className={cx(homeType.meta, styles.onlyMe)}>{t('inbox.scope.onlyMe')}</span>
+        ),
+        count: news.length,
+        key: 'news',
+        label: t('inbox.news.title'),
+        node: <NewsList bare={isRail} news={news} />,
+        subtitle: t('inbox.news.subtitle'),
+      });
+
+    return { sections };
+  };
+
+  const { sections } = status === 'ready' ? buildSections() : { sections: [] };
+
+  return {
+    briefsError: status === 'error' ? briefsSWR.error : undefined,
+    recommendationsVisible,
+    retryBriefs,
+    sections,
+    status,
+  };
+};

--- a/src/features/HomeInbox/useHomeInboxSections.tsx
+++ b/src/features/HomeInbox/useHomeInboxSections.tsx
@@ -15,6 +15,7 @@ import { briefListSelectors } from '@/store/brief/selectors';
 import { useUserStore } from '@/store/user';
 import { authSelectors, userProfileSelectors } from '@/store/user/slices/auth/selectors';
 
+import { resolveHomeInboxHasContent } from './homeInboxHasContent';
 import InboxBriefCard from './InboxBriefCard';
 import MarkAllReadButton from './MarkAllReadButton';
 import NeedsYouRailCard from './NeedsYouRailCard';
@@ -64,6 +65,7 @@ export interface UseHomeInboxSectionsOptions {
 
 export interface HomeInboxSectionsResult {
   briefsError: unknown;
+  hasContent: boolean;
   recommendationsVisible: boolean;
   retryBriefs: () => void;
   sections: InboxSection[];
@@ -301,11 +303,28 @@ export const useHomeInboxSections = ({
 
   const { sections } = status === 'ready' ? buildSections() : { sections: [] };
 
+  const hasContent = resolveHomeInboxHasContent({
+    isMain,
+    recommendationsVisible,
+    sectionsCount: sections.length,
+    status,
+  });
+
   return {
     briefsError: status === 'error' ? briefsSWR.error : undefined,
+    hasContent,
     recommendationsVisible,
     retryBriefs,
     sections,
     status,
   };
 };
+
+export const HOME_RAIL_INBOX_OPTIONS = {
+  hideNeedsYou: true,
+  hideUnread: true,
+  variant: 'rail',
+} as const;
+
+export const useHomeRailHasContent = (): boolean =>
+  useHomeInboxSections(HOME_RAIL_INBOX_OPTIONS).hasContent;

--- a/src/features/HomeInbox/useHomeInboxSections.tsx
+++ b/src/features/HomeInbox/useHomeInboxSections.tsx
@@ -323,6 +323,18 @@ export const useHomeInboxSections = ({
   };
 };
 
+// Deliberately no `inlineRail` here: `ownsRailSections({ variant: 'rail' })`
+// short-circuits to `true` on the `variant !== 'main'` branch regardless of
+// `inlineRail`, so this predicate's `hasContent` can never be a function of
+// the collapsed state it's about to decide — the cycle that would create is
+// exactly what would make the rail flicker between collapsing and expanding
+// itself. When `hasContent` is `false`, the running/news sections that fold
+// into the main column instance are therefore necessarily empty too: that
+// instance reads the same briefs (`cacheScope`), the same topics, and the
+// same shared `scope` (`useHomeStore`) as this one, so whatever emptied out
+// the rail's own copy is already reflected there. That equivalence holds only
+// because `hideNeedsYou`/`hideUnread` stay `true` here — widen either and the
+// rail's section set would stop matching what actually gates `hasContent`.
 export const HOME_RAIL_INBOX_OPTIONS = {
   hideNeedsYou: true,
   hideUnread: true,

--- a/src/features/HomeInbox/useHomeInboxSections.tsx
+++ b/src/features/HomeInbox/useHomeInboxSections.tsx
@@ -8,7 +8,7 @@ import { useWorkspaceMemberProfiles } from '@/business/client/hooks/useWorkspace
 import AsyncError from '@/components/AsyncError';
 import { BriefCardSkeleton } from '@/features/DailyBrief/BriefCardSkeleton';
 import { homeType } from '@/features/Home/components/homeType';
-import { useRecommendationsVisible } from '@/features/Recommendations';
+import { useRecommendationsSettled, useRecommendationsVisible } from '@/features/Recommendations';
 import { useCacheScope } from '@/libs/swr/useCacheScope';
 import { useBriefStore } from '@/store/brief';
 import { briefListSelectors } from '@/store/brief/selectors';
@@ -17,7 +17,7 @@ import { homeInboxScopeSelectors } from '@/store/home/selectors';
 import { useUserStore } from '@/store/user';
 import { authSelectors, userProfileSelectors } from '@/store/user/slices/auth/selectors';
 
-import { resolveHomeInboxHasContent } from './homeInboxHasContent';
+import { resolveHomeInboxHasContent, resolveHomeInboxHasResolved } from './homeInboxHasContent';
 import InboxBriefCard from './InboxBriefCard';
 import MarkAllReadButton from './MarkAllReadButton';
 import NeedsYouRailCard from './NeedsYouRailCard';
@@ -68,6 +68,7 @@ export interface UseHomeInboxSectionsOptions {
 export interface HomeInboxSectionsResult {
   briefsError: unknown;
   hasContent: boolean;
+  hasResolved: boolean;
   recommendationsVisible: boolean;
   retryBriefs: () => void;
   sections: InboxSection[];
@@ -122,6 +123,7 @@ export const useHomeInboxSections = ({
 
   const topics = useHomeInboxTopics(isLogin);
   const recommendationsVisible = useRecommendationsVisible();
+  const isRecommendationsSettled = useRecommendationsSettled();
 
   // A team context is a workspace with more than the viewer in it. In personal
   // mode this map is empty, so `isTeam` is false and the whole mine/team layer
@@ -313,9 +315,16 @@ export const useHomeInboxSections = ({
     status,
   });
 
+  const hasResolved = resolveHomeInboxHasResolved({
+    isRecommendationsSettled,
+    isTopicsInit: topics.isInit,
+    status,
+  });
+
   return {
     briefsError: status === 'error' ? briefsSWR.error : undefined,
     hasContent,
+    hasResolved,
     recommendationsVisible,
     retryBriefs,
     sections,

--- a/src/features/HomeInbox/useHomeInboxSections.tsx
+++ b/src/features/HomeInbox/useHomeInboxSections.tsx
@@ -341,9 +341,11 @@ export const useHomeInboxSections = ({
 // into the main column instance are therefore necessarily empty too: that
 // instance reads the same briefs (`cacheScope`), the same topics, and the
 // same shared `scope` (`useHomeStore`) as this one, so whatever emptied out
-// the rail's own copy is already reflected there. That equivalence holds only
-// because `hideNeedsYou`/`hideUnread` stay `true` here — widen either and the
-// rail's section set would stop matching what actually gates `hasContent`.
+// the rail's own copy is already reflected there. This constant exists so
+// the predicate instance (`Home/index.tsx`) and the rendered rail (the
+// `<HomeInbox {...}>` in the aside) can never receive different options —
+// `hasContent` measures exactly what renders only as long as both spread
+// this one object.
 export const HOME_RAIL_INBOX_OPTIONS = {
   hideNeedsYou: true,
   hideUnread: true,

--- a/src/features/Recommendations/index.tsx
+++ b/src/features/Recommendations/index.tsx
@@ -26,6 +26,17 @@ export const useRecommendationsVisible = (): boolean => {
   return actions.length > 0 || isTaskTemplatesVisible(taskTemplatesState);
 };
 
+// `mode: 'skeleton'` already counts as "visible" for useRecommendationsVisible
+// (it renders something), but it isn't a final answer — the eventual mode
+// could still resolve to 'hidden'. Callers that need to know once visibility
+// can no longer flip out from under them (e.g. deciding whether a collapse
+// animation is the real one or just the loading state settling) read this
+// instead.
+export const useRecommendationsSettled = (): boolean => {
+  const taskTemplatesState = useDailyBriefRecommendationsUI();
+  return taskTemplatesState.mode !== 'skeleton';
+};
+
 interface RecommendationsProps {
   variant?: 'default' | 'main' | 'rail';
 }

--- a/src/store/home/initialState.ts
+++ b/src/store/home/initialState.ts
@@ -2,6 +2,8 @@ import { type AgentListState } from './slices/agentList/initialState';
 import { initialAgentListState } from './slices/agentList/initialState';
 import { type HomeInputState } from './slices/homeInput/initialState';
 import { initialHomeInputState } from './slices/homeInput/initialState';
+import { type InboxScopeState } from './slices/inboxScope/initialState';
+import { initialInboxScopeState } from './slices/inboxScope/initialState';
 import { type LabelState } from './slices/label/initialState';
 import { initialLabelState } from './slices/label/initialState';
 import { type RecentState } from './slices/recent/initialState';
@@ -10,7 +12,13 @@ import { type SidebarUIState } from './slices/sidebarUI/initialState';
 import { initialSidebarUIState } from './slices/sidebarUI/initialState';
 
 export interface HomeStoreState
-  extends AgentListState, RecentState, HomeInputState, LabelState, SidebarUIState {}
+  extends
+    AgentListState,
+    RecentState,
+    HomeInputState,
+    LabelState,
+    SidebarUIState,
+    InboxScopeState {}
 
 export const initialState: HomeStoreState = {
   ...initialAgentListState,
@@ -18,4 +26,5 @@ export const initialState: HomeStoreState = {
   ...initialHomeInputState,
   ...initialLabelState,
   ...initialSidebarUIState,
+  ...initialInboxScopeState,
 };

--- a/src/store/home/selectors.ts
+++ b/src/store/home/selectors.ts
@@ -1,3 +1,4 @@
 export * from './slices/agentList/selectors';
+export * from './slices/inboxScope/selectors';
 export * from './slices/label/selectors';
 export * from './slices/recent/selectors';

--- a/src/store/home/slices/inboxScope/action.test.ts
+++ b/src/store/home/slices/inboxScope/action.test.ts
@@ -25,6 +25,7 @@ vi.mock('@/business/client/hooks/useWorkspaceMemberProfiles', () => ({
 }));
 
 vi.mock('@/features/Recommendations', () => ({
+  useRecommendationsSettled: () => true,
   useRecommendationsVisible: () => false,
 }));
 

--- a/src/store/home/slices/inboxScope/action.test.ts
+++ b/src/store/home/slices/inboxScope/action.test.ts
@@ -1,15 +1,43 @@
-import { act, renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { resolveHomeInboxHasContent } from '@/features/HomeInbox/homeInboxHasContent';
-import { filterTopicsForInboxScope } from '@/features/HomeInbox/scopeTogglePlacement';
+import {
+  HOME_RAIL_INBOX_OPTIONS,
+  useHomeInboxSections,
+} from '@/features/HomeInbox/useHomeInboxSections';
+import { briefService } from '@/services/brief';
+import { topicService } from '@/services/topic';
+import { useBriefStore } from '@/store/brief';
+import { initialBriefListState } from '@/store/brief/slices/list/initialState';
 import { useHomeStore } from '@/store/home';
+import { useUserStore } from '@/store/user';
+import { withSWR } from '~test-utils';
 
 import { initialInboxScopeState } from './initialState';
 import { homeInboxScopeSelectors } from './selectors';
 
+vi.mock('@/business/client/hooks/useWorkspaceMemberProfiles', () => ({
+  useWorkspaceMemberProfiles: () =>
+    new Map([
+      ['user-1', {}],
+      ['user-2', {}],
+    ]),
+}));
+
+vi.mock('@/features/Recommendations', () => ({
+  useRecommendationsVisible: () => false,
+}));
+
 beforeEach(() => {
   useHomeStore.setState({ ...initialInboxScopeState });
+  useBriefStore.setState({ ...initialBriefListState });
+  useUserStore.setState({ isSignedIn: true, user: { id: 'user-1' } } as never);
+
+  vi.spyOn(briefService, 'listUnresolved').mockResolvedValue({ data: [] } as never);
+  vi.spyOn(topicService, 'queryTopics').mockResolvedValue([
+    { id: 'task-1', status: 'running', userId: 'user-2' },
+    { id: 'task-2', status: 'running', userId: 'user-3' },
+  ] as never);
 });
 
 describe('InboxScopeActionImpl', () => {
@@ -32,29 +60,30 @@ describe('InboxScopeActionImpl', () => {
     expect(subscriberB.current).toBe('team');
   });
 
-  it('keeps the rail visible once the viewer switches to team view and their own running tasks empty out', () => {
-    const myId = 'user-1';
-    const teamRunning = [
-      { id: 'task-1', userId: 'user-2' },
-      { id: 'task-2', userId: 'user-3' },
-    ];
+  it('keeps two independent useHomeInboxSections instances in agreement once the shared scope switches to team', async () => {
+    const { result } = renderHook(
+      () => ({
+        railPredicate: useHomeInboxSections(HOME_RAIL_INBOX_OPTIONS),
+        railRender: useHomeInboxSections(HOME_RAIL_INBOX_OPTIONS),
+      }),
+      { wrapper: withSWR },
+    );
+
+    await waitFor(() => expect(result.current.railPredicate.status).toBe('ready'));
+
+    // A team member's own running task is what would normally have kept the
+    // rail visible; with none of the mocked running tasks owned by them, the
+    // 'mine' scope both instances start on already has nothing to show.
+    expect(result.current.railPredicate.hasContent).toBe(false);
+    expect(result.current.railRender.hasContent).toBe(false);
 
     act(() => {
       useHomeStore.getState().setHomeInboxScope('team');
     });
 
-    const scope = useHomeStore.getState().homeInboxScope;
-    const teamView = scope === 'team';
-    const runningTopics = filterTopicsForInboxScope(teamRunning, myId, teamView);
-
-    expect(runningTopics).toHaveLength(2);
-    expect(
-      resolveHomeInboxHasContent({
-        isMain: false,
-        recommendationsVisible: false,
-        sectionsCount: runningTopics.length > 0 ? 1 : 0,
-        status: 'ready',
-      }),
-    ).toBe(true);
+    await waitFor(() => {
+      expect(result.current.railPredicate.hasContent).toBe(true);
+      expect(result.current.railRender.hasContent).toBe(true);
+    });
   });
 });

--- a/src/store/home/slices/inboxScope/action.test.ts
+++ b/src/store/home/slices/inboxScope/action.test.ts
@@ -1,0 +1,60 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { resolveHomeInboxHasContent } from '@/features/HomeInbox/homeInboxHasContent';
+import { filterTopicsForInboxScope } from '@/features/HomeInbox/scopeTogglePlacement';
+import { useHomeStore } from '@/store/home';
+
+import { initialInboxScopeState } from './initialState';
+import { homeInboxScopeSelectors } from './selectors';
+
+beforeEach(() => {
+  useHomeStore.setState({ ...initialInboxScopeState });
+});
+
+describe('InboxScopeActionImpl', () => {
+  it('shares one scope value across independent subscribers', () => {
+    const { result: subscriberA } = renderHook(() =>
+      useHomeStore(homeInboxScopeSelectors.homeInboxScope),
+    );
+    const { result: subscriberB } = renderHook(() =>
+      useHomeStore(homeInboxScopeSelectors.homeInboxScope),
+    );
+
+    expect(subscriberA.current).toBe('mine');
+    expect(subscriberB.current).toBe('mine');
+
+    act(() => {
+      useHomeStore.getState().setHomeInboxScope('team');
+    });
+
+    expect(subscriberA.current).toBe('team');
+    expect(subscriberB.current).toBe('team');
+  });
+
+  it('keeps the rail visible once the viewer switches to team view and their own running tasks empty out', () => {
+    const myId = 'user-1';
+    const teamRunning = [
+      { id: 'task-1', userId: 'user-2' },
+      { id: 'task-2', userId: 'user-3' },
+    ];
+
+    act(() => {
+      useHomeStore.getState().setHomeInboxScope('team');
+    });
+
+    const scope = useHomeStore.getState().homeInboxScope;
+    const teamView = scope === 'team';
+    const runningTopics = filterTopicsForInboxScope(teamRunning, myId, teamView);
+
+    expect(runningTopics).toHaveLength(2);
+    expect(
+      resolveHomeInboxHasContent({
+        isMain: false,
+        recommendationsVisible: false,
+        sectionsCount: runningTopics.length > 0 ? 1 : 0,
+        status: 'ready',
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/store/home/slices/inboxScope/action.ts
+++ b/src/store/home/slices/inboxScope/action.ts
@@ -1,0 +1,27 @@
+import { type HomeStore } from '@/store/home/store';
+import { type StoreSetter } from '@/store/types';
+import { setNamespace } from '@/utils/storeDebug';
+
+import { type HomeInboxScope } from './initialState';
+
+const n = setNamespace('inboxScope');
+
+type Setter = StoreSetter<HomeStore>;
+export const createInboxScopeSlice = (set: Setter, get: () => HomeStore, _api?: unknown) =>
+  new InboxScopeActionImpl(set, get, _api);
+
+export class InboxScopeActionImpl {
+  readonly #set: Setter;
+
+  constructor(set: Setter, _get: () => HomeStore, _api?: unknown) {
+    void _get;
+    void _api;
+    this.#set = set;
+  }
+
+  setHomeInboxScope = (scope: HomeInboxScope): void => {
+    this.#set({ homeInboxScope: scope }, false, n('setHomeInboxScope'));
+  };
+}
+
+export type InboxScopeAction = Pick<InboxScopeActionImpl, keyof InboxScopeActionImpl>;

--- a/src/store/home/slices/inboxScope/initialState.ts
+++ b/src/store/home/slices/inboxScope/initialState.ts
@@ -1,0 +1,9 @@
+export type HomeInboxScope = 'mine' | 'team';
+
+export interface InboxScopeState {
+  homeInboxScope: HomeInboxScope;
+}
+
+export const initialInboxScopeState: InboxScopeState = {
+  homeInboxScope: 'mine',
+};

--- a/src/store/home/slices/inboxScope/selectors.ts
+++ b/src/store/home/slices/inboxScope/selectors.ts
@@ -1,0 +1,7 @@
+import { type HomeStore } from '@/store/home/store';
+
+const homeInboxScope = (s: HomeStore) => s.homeInboxScope;
+
+export const homeInboxScopeSelectors = {
+  homeInboxScope,
+};

--- a/src/store/home/store.ts
+++ b/src/store/home/store.ts
@@ -17,6 +17,8 @@ import { type GroupAction } from './slices/group/action';
 import { createGroupSlice } from './slices/group/action';
 import { type HomeInputAction } from './slices/homeInput/action';
 import { createHomeInputSlice } from './slices/homeInput/action';
+import { type InboxScopeAction } from './slices/inboxScope/action';
+import { createInboxScopeSlice } from './slices/inboxScope/action';
 import { type LabelAction } from './slices/label/action';
 import { createLabelSlice } from './slices/label/action';
 import { type RecentAction } from './slices/recent/action';
@@ -34,6 +36,7 @@ export interface HomeStore
     HomeInputAction,
     LabelAction,
     SidebarUIAction,
+    InboxScopeAction,
     ResetableStore,
     HomeStoreState {}
 
@@ -43,6 +46,7 @@ type HomeStoreAction = AgentListAction &
   HomeInputAction &
   LabelAction &
   SidebarUIAction &
+  InboxScopeAction &
   ResetableStore;
 
 class HomeStoreResetAction extends ResetableStoreAction<HomeStore> {
@@ -60,6 +64,7 @@ const createStore: StateCreator<HomeStore, [['zustand/devtools', never]]> = (
     createHomeInputSlice(...parameters),
     createLabelSlice(...parameters),
     createSidebarUISlice(...parameters),
+    createInboxScopeSlice(...parameters),
     new HomeStoreResetAction(...parameters),
   ]),
 });


### PR DESCRIPTION
The home rail renders a 394px empty box when it has nothing to show, which leaves the chief-agent
portrait floating in dead space — the portrait is drawn to lean on the first rail card
(`HomePortrait.tsx` dips it below its grid row on purpose), so with no card it has nothing to rest
against.

This collapses the whole column when the rail would render nothing, reusing the existing
`railCollapsed` path rather than adding a layout branch.

#### What changed

- `useHomeInboxSections` — extracted from `HomeInbox/index.tsx` so section assembly has one owner.
  `Home` and `HomeNavHeader` are siblings under the route and cannot share props, so without this
  the "does the rail have content" predicate would be a second, drift-prone copy of the same
  conditions.
- `hasContent` per variant. `main`'s empty branch returns `null` without consulting recommendations,
  so its cell is `false`, not `recommendationsVisible`. A single unified formula would be wrong for
  it.
- `railVisible = isLogin && showHomeRail && railHasContent`. `showHomeRail` is never written — it is
  a persisted user preference; a manual collapse still wins, and content arriving restores the rail
  because the value is derived.
- The rail toggle hides when there is nothing to toggle.
- The mine/team `scope` moved from per-hook `useState` into a shared (non-persisted) `useHomeStore`
  slice. Without this the predicate instance and the rendered rail could disagree: in a team
  workspace the rail could auto-collapse *while displaying running tasks*.
- The first settle's collapse animation is suppressed, keyed to a `hasResolved` signal covering all
  three async sources (briefs, topics, recommendations). Users with content see no movement;
  an empty rail disappears in one reflow instead of sliding away for ~1s.

#### Relationship to #17885

That PR folds the rail's sections into the main column when it collapses. The two compose: an empty
rail sets `inlineRail`, but the sections folded in are necessarily empty (that is why it collapsed),
so nothing is relocated and nothing is lost.

No cycle: `HOME_RAIL_INBOX_OPTIONS` deliberately omits `inlineRail`, and
`ownsRailSections` short-circuits on `variant !== 'main'`, so the predicate can never be a function
of the collapsed state it decides.

#### Test

- [x] Tested locally
- [x] Added/updated tests

Unit coverage is at the predicate layer, not the DOM: `lobehub:testing` forbids new component
renders and recommends extracting logic into hooks. `homeInboxHasContent` / `homeRailVisibility` /
`suppressFirstRailTransition` are truth-table tested; `inboxScope/action.test.ts` renders two real
`useHomeInboxSections` instances and asserts both `hasContent` flip together after a store dispatch
(verified red on the pre-fix `useState` version).

Two behaviours were measured in a real browser with a MutationObserver latching `getComputedStyle`
at each `data-collapsed` change:

| | observed |
| --- | --- |
| cold start, empty rail | `false→true` with `transition-duration: 0s` |
| manual toggle afterwards | `false→true` with `0.22s, 0.22s, 0s` |

**Both assertions come from one session and one timing.** Slower backends reorder the three async
sources; the trigger condition itself (first visit, no cache ⇒ briefs uninitialised ⇒ `hasContent`
true) is product logic and environment-independent, but the durations are not.

#### Not covered by observation

Static reasoning only, roughly by how much they'd be worth a look:

- The cold start's **first half is still animated**: as `isLogin` hydrates, the main column slides
  open over 220ms, shows skeletons, then snaps shut. Pre-existing on the open half; this PR only
  changed the close. How the pair reads together has not been seen.
- `RailToggle` appears and then disappears within the same cold start, with no transition.
- In chat mode the main column and the rail each render a mine/team `Segmented`; sharing the store
  makes them move together now. Judged correct — that code's own comment says "Mine/team lives at
  page level" — but it is outside the spec.
- Auto-collapse now also folds running/news into the main column (#17885 interaction).
- Switching workspace replays the full 220ms collapse: `isScopeCurrent` sends `isBriefsInit` back to
  false while the settled-ref is already true. Consistent with "suppress only the first settle".
- `prefers-reduced-motion`, RTL, and the ≤1100px breakpoint (where collapse is `display:none` and
  the suppression is a no-op).

#### Deliberate non-goals

- No empty-state placeholder card.
- No error state for the recommendation feed. `useDailyBriefRecommendationsUI` deliberately folds
  errors into `mode: 'hidden'`, so "recommendations failed" and "recommendations empty" are one
  state to the rail and both collapse it. The primary rail content (briefs) keeps its own
  `AsyncError` and never reaches the collapse path.
- The `@media (width <= 1100px)` vs `@container home (width >= 1080px)` breakpoint mismatch in
  `Home/index.tsx` is untouched. With a 280px nav at 1280px viewport the container is ~1000px, so
  the bubble correctly drops below the greeting while the grid stays two-column and squeezes the
  content to 577px. Real, independent, separate issue.

#### Also worth knowing

- `scope` does not reset across workspace switches (`resetHomeStore` has no call sites) — consistent
  with the rest of the home store.
- The branch contains one commit and its revert (`0db44834` / `d496cb3e`): a suppression-window cap
  that turned out to fix a hazard the corrected formula had already made impossible. Net tree equals
  the commit before it. Harmless under squash merge; needs a fixup if merged by rebase.
