### PR TITLE
♻️ refactor(ui): migrate every Drawer call site to base-ui Drawer

### DIFF
--- a/.agents/acceptance/common-mistakes.md
+++ b/.agents/acceptance/common-mistakes.md
@@ -232,24 +232,29 @@ DOM measurements as well as visual evidence.
 
 ## Environment safety
 
-### L-S0 — Installing with `--filter .` after changing a dependency range
+### L-S0 — Concluding a dependency moved from the root manifest alone
 
 **Wrong approach:** refresh a shared dependency by running `pnpm install --filter .`
-at the repo root, then treat a type-check failure in untouched files as pre-existing.
+at the repo root — or by bumping only the root range and running a full install —
+then read the new version out of `package.json` and treat a type-check failure in
+untouched files as pre-existing.
 
-**Why it fails:** the filter installs only the root workspace, so `packages/*` keep
-their previously resolved copies of every shared peer. Two identities of the same
-package then coexist in the graph, and the errors surface far from the change — a
-duplicated `next` shows up as `NextRequest is not assignable to NextRequest` in
-backend route shells, and a duplicated UI package kills routes at the ErrorBoundary
-with a missing React context. Neither names the real cause.
+**Why it fails:** the filter installs only the root workspace, and even an unfiltered
+install leaves `packages/*` on their old resolution when they declare a loose range
+(`"@lobehub/ui": "^5"` is satisfied by both the old and the new version, so nothing
+forces them to move). Two identities of the same package then coexist in the graph,
+and the errors surface far from the change — a duplicated `next` shows up as
+`NextRequest is not assignable to NextRequest` in backend route shells, and a
+duplicated UI package kills routes at the ErrorBoundary with a missing React context,
+or gives a component library two copies of a shared z-index/portal manager. Neither
+names the real cause.
 
 **Correct approach:** run a full `pnpm install` (no filter) after any dependency
 range change, then `pnpm dedupe` when the root and the workspace packages resolve
-different versions of a shared peer. Verify convergence by comparing
-`readlink node_modules/<pkg>` with `readlink packages/*/node_modules/<pkg>` before
-concluding anything about the branch. Remember `apps/desktop` and `apps/cli` are
-standalone installs that a root install never covers.
+different versions of a shared peer. State the version only from resolved copies —
+count the versions under `node_modules/<pkg>` and every `packages/*/node_modules/<pkg>`
+and require one distinct value — never from the root manifest. Remember `apps/desktop`
+and `apps/cli` are standalone installs that a root install never covers.
 
 ### L-S1 — Publishing to an assumed server target
 

--- a/.agents/acceptance/common-mistakes.md
+++ b/.agents/acceptance/common-mistakes.md
@@ -232,6 +232,25 @@ DOM measurements as well as visual evidence.
 
 ## Environment safety
 
+### L-S0 — Installing with `--filter .` after changing a dependency range
+
+**Wrong approach:** refresh a shared dependency by running `pnpm install --filter .`
+at the repo root, then treat a type-check failure in untouched files as pre-existing.
+
+**Why it fails:** the filter installs only the root workspace, so `packages/*` keep
+their previously resolved copies of every shared peer. Two identities of the same
+package then coexist in the graph, and the errors surface far from the change — a
+duplicated `next` shows up as `NextRequest is not assignable to NextRequest` in
+backend route shells, and a duplicated UI package kills routes at the ErrorBoundary
+with a missing React context. Neither names the real cause.
+
+**Correct approach:** run a full `pnpm install` (no filter) after any dependency
+range change, then `pnpm dedupe` when the root and the workspace packages resolve
+different versions of a shared peer. Verify convergence by comparing
+`readlink node_modules/<pkg>` with `readlink packages/*/node_modules/<pkg>` before
+concluding anything about the branch. Remember `apps/desktop` and `apps/cli` are
+standalone installs that a root install never covers.
+
 ### L-S1 — Publishing to an assumed server target
 
 **Wrong approach:** strip a server environment variable and treat `lh whoami` as

--- a/.agents/skills/react/SKILL.md
+++ b/.agents/skills/react/SKILL.md
@@ -37,6 +37,7 @@ If unsure about available components, search existing code or check `node_module
 | `Switch`                                   | `import { Switch } from '@lobehub/ui/base-ui';`                                                         |
 | `Toast`                                    | `import { Toast } from '@lobehub/ui/base-ui';`                                                          |
 | `FloatingSheet`                            | `import { FloatingSheet } from '@lobehub/ui/base-ui';`                                                  |
+| `Drawer`                                   | `import { Drawer } from '@lobehub/ui/base-ui';`                                                         |
 
 For Modal specifically, see the dedicated **modal** skill — use the imperative `createModal({ content: … })` pattern over the legacy `<Modal open … />` declarative pattern. base-ui has its own `ModalHost` already mounted in `SPAGlobalProvider`.
 
@@ -49,7 +50,7 @@ For Modal specifically, see the dedicated **modal** skill — use the imperative
 | General      | ActionIcon, ActionIconGroup, Block, Button, Icon                                      |
 | Data Display | Avatar, Collapse, Empty, Highlighter, Markdown, Tag, Tooltip                          |
 | Data Entry   | CodeEditor, CopyButton, EditableText, Form, Input, InputPassword, SearchBar, TextArea |
-| Feedback     | Alert, Drawer                                                                         |
+| Feedback     | Alert                                                                                 |
 | Layout       | Center, DraggablePanel, Flexbox, Grid, Header, MaskShadow                             |
 | Navigation   | Burger, Menu, SideNav, Tabs                                                           |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Guidelines for using AI coding agents in this opensource LobeHub repository.
 - Next.js 16 + React 19 + TypeScript
 - SPA inside Next.js with `react-router-dom`
 - `@lobehub/ui`, antd for components; antd-style for CSS-in-JS — **prefer `createStaticStyles` with `cssVar.*`** (zero-runtime); only fall back to `createStyles` + `token` when styles genuinely need runtime computation. See `.cursor/docs/createStaticStyles_migration_guide.md`.
-- **Component priority**: `@lobehub/ui/base-ui` (headless primitives) **first**, then `@lobehub/ui` root, then antd as last resort. When the component exists in base-ui, use it — never reach for the root or antd counterpart. Base-ui covers `Select`, `Modal` / `createModal` / `confirmModal`, `DropdownMenu`, `ContextMenu`, `Popover`, `ScrollArea`, `Switch`, `Toast`, `FloatingSheet`. Prefer `@lobehub/ui/base-ui` for new code and migrate root-package call sites opportunistically.
+- **Component priority**: `@lobehub/ui/base-ui` (headless primitives) **first**, then `@lobehub/ui` root, then antd as last resort. When the component exists in base-ui, use it — never reach for the root or antd counterpart. Base-ui covers `Select`, `Modal` / `createModal` / `confirmModal`, `DropdownMenu`, `ContextMenu`, `Popover`, `ScrollArea`, `Switch`, `Toast`, `FloatingSheet`, `Drawer`. Prefer `@lobehub/ui/base-ui` for new code and migrate root-package call sites opportunistically.
 - react-i18next for i18n; zustand for state management
 - SWR for data fetching; TRPC for type-safe backend
 - Drizzle ORM with PostgreSQL; Vitest for testing

--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
     "@lobehub/icons": "^5.11.0",
     "@lobehub/market-sdk": "0.39.2",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "^5.27.0",
+    "@lobehub/ui": "^5.28.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@napi-rs/canvas": "^0.1.100",
     "@neondatabase/serverless": "^1.1.0",

--- a/src/components/HtmlPreview/PreviewDrawer.tsx
+++ b/src/components/HtmlPreview/PreviewDrawer.tsx
@@ -1,8 +1,7 @@
 import { TITLE_BAR_HEIGHT } from '@lobechat/desktop-bridge';
 import { exportFile } from '@lobechat/utils/client';
 import { Block, Flexbox, Highlighter, HtmlPreview } from '@lobehub/ui';
-import { Button, Tabs } from '@lobehub/ui/base-ui';
-import { Drawer } from 'antd';
+import { Button, Drawer, Tabs } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import { Code2, Download, Eye } from 'lucide-react';
 import { memo, useCallback, useState } from 'react';
@@ -49,9 +48,8 @@ const HtmlPreviewDrawer = memo<HtmlPreviewDrawerProps>(({ content, open, onClose
     exportFile(content, `${base}.html`);
   }, [content, extractTitle, sanitizeFileName]);
 
-  const Title = (
-    <Flexbox horizontal align={'center'} justify={'space-between'} style={{ width: '100%' }}>
-      {t('HtmlPreview.title')}
+  const extra = (
+    <Flexbox horizontal align={'center'} gap={8}>
       <Tabs
         activeKey={mode}
         items={[
@@ -84,13 +82,14 @@ const HtmlPreviewDrawer = memo<HtmlPreviewDrawerProps>(({ content, open, onClose
 
   return (
     <Drawer
-      destroyOnHidden
+      containerMaxWidth={'100%'}
+      extra={extra}
       height={isDesktop ? `calc(100vh - ${TITLE_BAR_HEIGHT}px)` : '100vh'}
       open={open}
       placement="bottom"
-      title={Title}
+      title={t('HtmlPreview.title')}
       styles={{
-        body: { height: '100%', padding: 0 },
+        bodyContent: { height: '100%', padding: 0 },
         header: { paddingBlock: 8, paddingInline: 12 },
       }}
       onClose={onClose}

--- a/src/features/AgentSkillEdit/index.tsx
+++ b/src/features/AgentSkillEdit/index.tsx
@@ -3,8 +3,8 @@
 import { isDesktop } from '@lobechat/const';
 import { TITLE_BAR_HEIGHT } from '@lobechat/desktop-bridge';
 import { type SkillResourceTreeNode } from '@lobechat/types';
-import { Drawer, Flexbox } from '@lobehub/ui';
-import { Button, toast } from '@lobehub/ui/base-ui';
+import { Flexbox } from '@lobehub/ui';
+import { Button, Drawer, toast } from '@lobehub/ui/base-ui';
 import { Alert, Form as AForm, Popconfirm, Skeleton } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { memo, useMemo, useState } from 'react';
@@ -146,7 +146,6 @@ const AgentSkillEdit = memo<AgentSkillEditProps>(({ skillId, open, onClose }) =>
 
   return (
     <Drawer
-      destroyOnHidden
       containerMaxWidth={'auto'}
       footer={footer}
       height={isDesktop ? `calc(100vh - ${TITLE_BAR_HEIGHT}px)` : '100vh'}
@@ -155,13 +154,9 @@ const AgentSkillEdit = memo<AgentSkillEditProps>(({ skillId, open, onClose }) =>
       push={false}
       title={t('agentSkillEdit.title')}
       styles={{
-        body: { padding: 0 },
-        bodyContent: { height: '100%' },
+        bodyContent: { height: '100%', padding: 0 },
       }}
-      onClose={(e) => {
-        e.stopPropagation();
-        onClose();
-      }}
+      onClose={onClose}
     >
       {isLoading ? (
         <Skeleton active paragraph={{ rows: 8 }} style={{ padding: 16 }} />

--- a/src/features/AgentTasks/AgentTaskDetail/TaskVerifyConfig.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskVerifyConfig.tsx
@@ -3,7 +3,6 @@
 import {
   ActionIcon,
   Block,
-  Drawer,
   type DropdownItem,
   DropdownMenu,
   Flexbox,
@@ -13,7 +12,7 @@ import {
   Text,
   TextArea,
 } from '@lobehub/ui';
-import { Button, Checkbox, Select, toast } from '@lobehub/ui/base-ui';
+import { Button, Checkbox, Drawer, Select, toast } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import {
   ChevronRight,
@@ -751,10 +750,9 @@ const TaskVerifyConfig = memo(() => {
         ) : null}
       </Flexbox>
       <Drawer
-        destroyOnHidden
         open={Boolean(selectedCriterionId)}
         placement={'right'}
-        styles={{ body: { padding: 0 } }}
+        styles={{ bodyContent: { padding: 0 } }}
         title={t('verifyConfig.detail.title')}
         width={'min(92vw, 440px)'}
         onClose={() => setSelectedCriterionId(null)}

--- a/src/features/Electron/connection/Connection.tsx
+++ b/src/features/Electron/connection/Connection.tsx
@@ -1,6 +1,6 @@
 import { Center, Flexbox } from '@lobehub/ui';
-import { Drawer } from 'antd';
-import { createStaticStyles, cssVar } from 'antd-style';
+import { Drawer } from '@lobehub/ui/base-ui';
+import { cssVar } from 'antd-style';
 import { Suspense, useCallback } from 'react';
 
 import { BrandTextLoading } from '@/components/Loading';
@@ -11,18 +11,6 @@ import { isMacOS } from '@/utils/platform';
 import RemoteStatus from './RemoteStatus';
 
 const isMac = isMacOS();
-
-const styles = createStaticStyles(({ css }) => {
-  return {
-    modal: css`
-      .ant-drawer-close {
-        position: absolute;
-        inset-block-start: ${isMac ? '12px' : '46px'};
-        inset-inline-end: 6px;
-      }
-    `,
-  };
-});
 
 const Connection = () => {
   const [isOpen, setConnectionDrawerOpen] = useElectronStore((s) => [
@@ -42,13 +30,17 @@ const Connection = () => {
         }}
       />
       <Drawer
-        classNames={{ header: styles.modal }}
+        noHeader
+        height={'100vh'}
         open={isOpen}
         placement={'top'}
-        size={'100vh'}
-        styles={{ body: { padding: 0 }, header: { padding: 0 } }}
         style={{
           background: cssVar.colorBgLayout,
+        }}
+        styles={{
+          bodyContent: { padding: 0 },
+          // Clears the Electron title bar, which only overlaps the drawer off macOS.
+          extra: { insetBlockStart: isMac ? 12 : 46, insetInlineEnd: 6 },
         }}
         onClose={handleClose}
       >

--- a/src/features/NavPanel/SideBarDrawer.tsx
+++ b/src/features/NavPanel/SideBarDrawer.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { ActionIcon, Flexbox, Text } from '@lobehub/ui';
-import { Drawer } from 'antd';
-import { cssVar } from 'antd-style';
+import { DrawerPopup, DrawerPortal, DrawerRoot } from '@lobehub/ui/base-ui';
+import { createStaticStyles } from 'antd-style';
 import { XIcon } from 'lucide-react';
-import type { ReactNode, Ref } from 'react';
-import { cloneElement, isValidElement, memo, Suspense, useCallback, useState } from 'react';
+import type { ReactNode } from 'react';
+import { memo, Suspense, useEffect, useState } from 'react';
 
 import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 
@@ -13,6 +13,30 @@ import SkeletonList from './components/SkeletonList';
 import { NAV_PANEL_RIGHT_DRAWER_ID } from './constants';
 import { OverlayContainerContext } from './OverlayContainer';
 import SideBarHeaderLayout from './SideBarHeaderLayout';
+
+const DRAWER_WIDTH = 280;
+
+// Stays under the base-ui floating tier (1100) so dropdowns and popovers raised
+// from inside the panel still paint above it.
+const DRAWER_Z_INDEX = 1000;
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  body: css`
+    overflow: hidden auto;
+    flex: 1;
+    min-height: 0;
+    background: ${cssVar.colorBgLayout};
+  `,
+  panel: css`
+    border-inline: 1px solid ${cssVar.colorBorderSecondary};
+    background: ${cssVar.colorBgLayout};
+    box-shadow: 4px 0 8px -2px rgb(0 0 0 / 4%);
+  `,
+  popup: css`
+    position: absolute;
+    overflow: hidden;
+  `,
+}));
 
 interface SideBarDrawerProps {
   action?: ReactNode;
@@ -23,79 +47,35 @@ interface SideBarDrawerProps {
   title?: ReactNode;
 }
 
-interface DrawerRenderNodeProps {
-  containerRef?: Ref<HTMLDivElement>;
-}
-
-const setRef = <T,>(ref: Ref<T> | undefined, value: T | null) => {
-  if (!ref) return;
-
-  if (typeof ref === 'function') {
-    ref(value);
-    return;
-  }
-
-  (ref as { current: T | null }).current = value;
-};
-
 const SideBarDrawer = memo<SideBarDrawerProps>(
   ({ subHeader, open, onClose, children, title, action }) => {
-    const size = 280;
-
     const [overlayContainer, setOverlayContainer] = useState<HTMLDivElement | null>(null);
+    const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(null);
 
-    const renderDrawerContent = useCallback((node: ReactNode) => {
-      if (!isValidElement<DrawerRenderNodeProps>(node)) return node;
-
-      const originalContainerRef = node.props.containerRef;
-
-      // Intentionally hook rc-drawer's section ref so dropdown portals stay inside the real drawer content.
-      // eslint-disable-next-line @eslint-react/no-clone-element
-      return cloneElement(node, {
-        containerRef: (instance: HTMLDivElement | null) => {
-          setOverlayContainer((current) => (current === instance ? current : instance));
-          setRef(originalContainerRef, instance);
-        },
-      });
+    useEffect(() => {
+      setPortalContainer(document.querySelector<HTMLElement>(`#${NAV_PANEL_RIGHT_DRAWER_ID}`));
     }, []);
 
     return (
       <OverlayContainerContext value={overlayContainer}>
-        <Drawer
-          destroyOnHidden
-          closable={false}
-          drawerRender={renderDrawerContent}
-          getContainer={() => document.querySelector(`#${NAV_PANEL_RIGHT_DRAWER_ID}`)!}
-          mask={false}
+        <DrawerRoot
+          modal={false}
           open={open}
-          placement="left"
-          size={size}
-          rootStyle={{
-            bottom: 0,
-            overflow: 'hidden',
-            position: 'absolute',
-            top: 0,
-            width: `${size}px`,
+          zIndex={DRAWER_Z_INDEX}
+          onOpenChange={(nextOpen, eventDetails) => {
+            if (nextOpen || eventDetails.reason === 'outside-press') return;
+            onClose();
           }}
-          styles={{
-            body: {
-              background: cssVar.colorBgLayout,
-              padding: 0,
-            },
-            header: {
-              background: cssVar.colorBgLayout,
-              borderBottom: 'none',
-              padding: 0,
-            },
-            wrapper: {
-              borderLeft: `1px solid ${cssVar.colorBorderSecondary}`,
-              borderRight: `1px solid ${cssVar.colorBorderSecondary}`,
-              boxShadow: `4px 0 8px -2px rgba(0,0,0,.04)`,
-              zIndex: 0,
-            },
-          }}
-          title={
-            <>
+        >
+          <DrawerPortal container={portalContainer}>
+            <DrawerPopup
+              flush
+              className={styles.popup}
+              panelClassName={styles.panel}
+              placement={'left'}
+              ref={setOverlayContainer}
+              width={DRAWER_WIDTH}
+            >
               <SideBarHeaderLayout
                 showBack={false}
                 showTogglePanelButton={false}
@@ -126,20 +106,20 @@ const SideBarDrawer = memo<SideBarDrawerProps>(
                 }
               />
               {subHeader}
-            </>
-          }
-          onClose={onClose}
-        >
-          <Suspense
-            fallback={
-              <Flexbox gap={1} paddingBlock={1} paddingInline={4}>
-                <SkeletonList rows={3} />
-              </Flexbox>
-            }
-          >
-            {children}
-          </Suspense>
-        </Drawer>
+              <div className={styles.body}>
+                <Suspense
+                  fallback={
+                    <Flexbox gap={1} paddingBlock={1} paddingInline={4}>
+                      <SkeletonList rows={3} />
+                    </Flexbox>
+                  }
+                >
+                  {children}
+                </Suspense>
+              </div>
+            </DrawerPopup>
+          </DrawerPortal>
+        </DrawerRoot>
       </OverlayContainerContext>
     );
   },

--- a/src/features/PluginDevModal/index.tsx
+++ b/src/features/PluginDevModal/index.tsx
@@ -1,8 +1,8 @@
 import { isDesktop } from '@lobechat/const';
 import { TITLE_BAR_HEIGHT } from '@lobechat/desktop-bridge';
 import { type LobeToolCustomPlugin } from '@lobechat/types';
-import { Drawer, Flexbox } from '@lobehub/ui';
-import { Button, toast } from '@lobehub/ui/base-ui';
+import { Flexbox } from '@lobehub/ui';
+import { Button, Drawer, toast } from '@lobehub/ui/base-ui';
 import { Form, Popconfirm } from 'antd';
 import { useResponsive } from 'antd-style';
 import { memo, useEffect, useRef, useState } from 'react';
@@ -168,7 +168,6 @@ const DevModal = memo<DevModalProps>(
         }}
       >
         <Drawer
-          destroyOnHidden
           containerMaxWidth={'auto'}
           footer={footer}
           height={isDesktop ? `calc(100vh - ${TITLE_BAR_HEIGHT}px)` : '100vh'}
@@ -177,21 +176,13 @@ const DevModal = memo<DevModalProps>(
           push={false}
           title={t(isEditMode ? 'dev.title.skillSettings' : 'dev.title.create')}
           width={mobile ? '100%' : 800}
-          // Sit above @lobehub/ui's base-ui floating layer (Popover/Dropdown/Tooltip = 1100).
-          // antd Drawer defaults to ~1000, so a config panel opened from the Tools skill
-          // popover would otherwise mount *behind* the still-open popover and look like it
-          // "didn't open". 1200 = the base-ui modal tier.
-          zIndex={1200}
           styles={{
-            body: {
-              padding: 0,
-            },
             bodyContent: {
               height: '100%',
+              padding: 0,
             },
           }}
-          onClose={(e) => {
-            e.stopPropagation();
+          onClose={() => {
             onOpenChange(false);
           }}
         >

--- a/src/features/ResourceManager/components/ChunkDrawer/index.tsx
+++ b/src/features/ResourceManager/components/ChunkDrawer/index.tsx
@@ -1,5 +1,5 @@
 import { Flexbox } from '@lobehub/ui';
-import { Drawer } from 'antd';
+import { Drawer } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { memo } from 'react';
 
@@ -24,10 +24,10 @@ const ChunkDrawer = memo(() => {
   return (
     <Drawer
       open={open}
-      size="large"
       title={file?.name}
+      width={736}
       styles={{
-        body: { padding: 0 },
+        bodyContent: { height: '100%', padding: 0 },
       }}
       onClose={() => {
         closeChunkDrawer();

--- a/src/features/Verify/Acceptance/FeedbackDrawer.tsx
+++ b/src/features/Verify/Acceptance/FeedbackDrawer.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import type { AcceptanceAttachment } from '@lobechat/types';
-import { Drawer, Flexbox, Text } from '@lobehub/ui';
+import { Flexbox, Text } from '@lobehub/ui';
+import { Drawer } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import dayjs from 'dayjs';
 import { memo } from 'react';

--- a/src/features/Verify/Acceptance/attachments.test.tsx
+++ b/src/features/Verify/Acceptance/attachments.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AttachmentThumbs } from './attachments';
+
+// The unit env has neither the MotionProvider nor the image-preview portal the real
+// components need; stub them down to the DOM the assertions actually read.
+vi.mock('@lobehub/ui', () => ({
+  Flexbox: ({ children, onClick }: any) => <div onClick={onClick}>{children}</div>,
+  Icon: () => null,
+  Image: ({ alt, src }: any) => <img alt={alt} src={src} />,
+}));
+
+vi.mock('@lobehub/ui/base-ui', () => ({
+  Button: ({ children, onClick }: any) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('antd', () => ({ Upload: ({ children }: any) => <div>{children}</div> }));
+
+vi.mock('@/store/file', () => ({ useFileStore: () => vi.fn() }));
+
+const attachments = [{ id: 'att-1', name: 'screenshot.png', url: 'https://example.com/a.png' }];
+
+afterEach(cleanup);
+
+describe('AttachmentThumbs', () => {
+  it('does not trigger the host row while zooming a thumbnail', async () => {
+    // The feedback/check row wrapping this list is itself clickable and its handler
+    // closes the surrounding drawer, which unmounts the zoom viewer in the tick it
+    // opens. Zooming has to stay its own action.
+    const onRowClick = vi.fn();
+
+    render(
+      <div onClick={onRowClick}>
+        <AttachmentThumbs attachments={attachments} />
+      </div>,
+    );
+
+    await userEvent.click(screen.getByRole('img'));
+
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it('still lets the host row handle clicks outside the thumbnails', async () => {
+    const onRowClick = vi.fn();
+
+    render(
+      <div onClick={onRowClick}>
+        <span>row body</span>
+        <AttachmentThumbs attachments={attachments} />
+      </div>,
+    );
+
+    await userEvent.click(screen.getByText('row body'));
+
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/Verify/Acceptance/attachments.tsx
+++ b/src/features/Verify/Acceptance/attachments.tsx
@@ -239,7 +239,17 @@ export const AttachmentThumbs = memo<AttachmentThumbsProps>(({ attachments }) =>
   const usable = (attachments ?? []).filter((attachment) => attachment.url);
   if (usable.length === 0) return null;
   return (
-    <Flexbox horizontal gap={6} wrap={'wrap'}>
+    // Every host row is itself clickable (jump to the check), and that jump closes the
+    // drawer this list often lives in — which would unmount the zoom viewer in the same
+    // tick it opened. Zooming a thumbnail is its own action, so it stops here.
+    <Flexbox
+      horizontal
+      gap={6}
+      wrap={'wrap'}
+      onClick={(event) => {
+        event.stopPropagation();
+      }}
+    >
       {usable.map((attachment) => (
         <div className={styles.thumb} key={attachment.id}>
           <Image alt={attachment.name ?? ''} src={attachment.url!} />

--- a/src/features/Verify/ReportViewer.tsx
+++ b/src/features/Verify/ReportViewer.tsx
@@ -13,8 +13,8 @@ import type {
   VerifyVerdict,
 } from '@lobechat/types';
 import { toRecord } from '@lobechat/utils/object';
-import { Block, Center, Drawer, Empty, Flexbox, Icon, Image, Markdown, Text } from '@lobehub/ui';
-import { Button } from '@lobehub/ui/base-ui';
+import { Block, Center, Empty, Flexbox, Icon, Image, Markdown, Text } from '@lobehub/ui';
+import { Button, Drawer } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import type { TFunction } from 'i18next';
 import {
@@ -1307,21 +1307,17 @@ const EvidenceDrawer = memo<{
   title: string;
 }>(({ evidence, onClose, open, title }) => (
   <Drawer
-    destroyOnHidden
     containerMaxWidth={'100%'}
     open={open}
     placement={'right'}
     title={title}
     width={'min(1120px, calc(100vw - 48px))'}
     styles={{
-      body: {
-        height: '100%',
-        padding: 0,
-      },
       bodyContent: {
         height: '100%',
         minHeight: 0,
         overflow: 'hidden',
+        padding: 0,
       },
     }}
     onClose={onClose}

--- a/src/features/Verify/components/MarkdownEvidence.tsx
+++ b/src/features/Verify/components/MarkdownEvidence.tsx
@@ -1,16 +1,7 @@
 'use client';
 
-import {
-  Center,
-  Drawer,
-  Flexbox,
-  Highlighter,
-  Icon,
-  Markdown,
-  MaskShadow,
-  Text,
-} from '@lobehub/ui';
-import { Button } from '@lobehub/ui/base-ui';
+import { Center, Flexbox, Highlighter, Icon, Markdown, MaskShadow, Text } from '@lobehub/ui';
+import { Button, Drawer } from '@lobehub/ui/base-ui';
 import { useSize } from 'ahooks';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { ChevronsDownUpIcon, ChevronsUpDownIcon, FileText } from 'lucide-react';
@@ -235,15 +226,13 @@ export const EvidenceFileCard = memo<{
       </button>
       {open && (
         <Drawer
-          destroyOnHidden
           containerMaxWidth={'100%'}
           open={open}
           placement={'right'}
           title={name}
           width={'min(1120px, calc(100vw - 48px))'}
           styles={{
-            body: { height: '100%', padding: 0 },
-            bodyContent: { height: '100%', minHeight: 0, overflow: 'hidden' },
+            bodyContent: { height: '100%', minHeight: 0, overflow: 'hidden', padding: 0 },
           }}
           onClose={() => setOpen(false)}
         >

--- a/src/routes/(mobile)/community/(list)/_layout/Nav.tsx
+++ b/src/routes/(mobile)/community/(list)/_layout/Nav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ActionIcon, Flexbox } from '@lobehub/ui';
-import { Drawer } from 'antd';
+import { Drawer } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { MenuIcon } from 'lucide-react';
 import { memo, useState } from 'react';
@@ -60,25 +60,20 @@ const Nav = memo(() => {
       </Flexbox>
 
       <Drawer
-        headerStyle={{ display: 'none' }}
+        noHeader
+        closable={false}
         open={open}
         placement={'left'}
-        rootStyle={{ position: 'absolute' }}
         width={260}
         zIndex={10}
-        bodyStyle={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 20,
-          justifyContent: 'space-between',
-          padding: 16,
-        }}
         style={{
           background: cssVar.colorBgLayout,
           borderRight: `1px solid ${cssVar.colorSplit}`,
           paddingTop: 44,
         }}
-        onClick={() => setOpen(false)}
+        styles={{
+          bodyContent: { gap: 20, justifyContent: 'space-between', padding: 16 },
+        }}
         onClose={() => setOpen(false)}
       >
         <Menu
@@ -93,6 +88,7 @@ const Nav = memo(() => {
             } else {
               navigate(`/community/${key}`);
             }
+            setOpen(false);
           }}
         />
       </Drawer>


### PR DESCRIPTION
`@lobehub/ui` ships a `Drawer` under its `base-ui` subpath, so nothing needs the antd-backed one any more. All eleven call sites move over — six imported `Drawer` from the `@lobehub/ui` root (itself an antd wrapper), five straight from `antd`.

A repo-wide grep for `Drawer` imported from `antd` or `@lobehub/ui` now returns nothing.

#### Prop mapping

| antd / root Drawer | base-ui Drawer |
| --- | --- |
| `styles.body` | `styles.bodyContent` (padding lives one level lower) |
| `destroyOnHidden` | implicit — the portal unmounts on close |
| `onClose(event)` | `onClose()` |
| `size="large"` | `width={736}` |
| `size="100vh"` | `height={'100vh'}` |
| `headerStyle: { display: none }` | `noHeader` + `closable={false}` |
| `drawerRender` | a ref on `DrawerPopup` (atoms only) |
| `rootStyle` | dropped — base-ui derives panel geometry itself |

Two call sites deserve a note:

- **`NavPanel/SideBarDrawer`** is the one site that cannot use the high-level component. It needs a ref to the drawer's own DOM node so dropdowns opened inside it portal into the drawer rather than the page — antd gave that through `drawerRender`, base-ui gives it as a ref on `DrawerPopup`. So it composes `DrawerRoot` / `DrawerPortal` / `DrawerPopup` directly.
- **`PluginDevModal`** drops its hard-coded `zIndex={1200}`. base-ui assigns the modal tier itself and lands at 1211, above the floating tier (1100) the original comment was guarding against.

#### Two fixes found while driving the migrated surfaces

- The **mobile community nav drawer** collapsed to its padding (260×44, menu items clipped out of view). antd's `rootStyle` had been translated literally into a `styles.popup` position override, which breaks the `position: fixed` + `inset-block: 0` pair that gives the base-ui panel its height.
- **Acceptance attachment thumbnails** now stop click propagation. Their host row navigates to the check and closes the surrounding drawer, which unmounted the image zoom viewer in the same tick it opened. The propagation was always wrong; it only became user-visible once closing a drawer started unmounting its children.

#### One upstream fix, pulled in as 5.28.0

Chasing that last one surfaced a real defect in the library. Base UI renders a dialog's backdrop under `enabled: forceRender || !nested`, so a dialog opened while another is already open silently loses its own scrim. That is right for an overlay stacked on its host and wrong for the image viewer, which replaces the screen — opened from a drawer it inherited the drawer's flat `rgba(0,0,0,0.44)` mask, and from a maskless drawer it got nothing at all, leaving the page visible through the letterbox around the picture.

Fixed upstream in lobehub/lobe-ui#598 by opting the viewer's own `Dialog.Backdrop` out with `forceRender`; this branch bumps `@lobehub/ui` to **5.28.0**, the first release carrying it. Measured on the acceptance feedback drawer, same fixture on both versions:

| | layers with the viewer open |
| --- | --- |
| 5.27.0 | 1210 drawer scrim `0.44` → 1211 drawer panel → 1221 viewer panel — **no backdrop between them** |
| 5.28.0 | 1210 → 1211 → **1220 at `0.9` alpha + `blur(8px)`** → 1221 |

Two guards on the fix rather than the symptom: dismissing the viewer removes only 1220/1221 and leaves the drawer open, and a viewer opened straight from the page still renders exactly one backdrop, not two stacked ones.

Note for reviewers: the workspace packages declare `@lobehub/ui: "^5"`, which both versions satisfy, so bumping the root range does not move them — a `pnpm dedupe` is needed for the graph to converge on a single copy.

`Drawer` also moves from the root tier to the base-ui tier in `AGENTS.md` and the React skill's component tables.

#### Test

Ten of the eleven drawers were opened, measured and visually inspected in the running app — web, mobile SPA entry and the Electron shell — with product data seeded for the surfaces that needed it (a file with chunks, a task with an acceptance criterion, an acceptance with file-backed evidence and a real rejection comment, a custom skill).

| Drawer | Placement | Measured |
| --- | --- | --- |
| NavPanel SideBarDrawer (Home / Pages) | left | 280px inside `#nav-panel-drawer`, maskless, unmounts on close |
| PluginDevModal | bottom | 1280×633 flush, footer slot, popup z-index 1211 |
| ChunkDrawer | right | 736px, masked, file preview + chunk list |
| TaskVerifyConfig | right | 440px |
| MarkdownEvidence / evidence gallery | right | 1120px |
| Acceptance FeedbackDrawer | right | 440px; image zoom opens above it at 1221, with its own backdrop at 1220 |
| HtmlPreview PreviewDrawer | bottom | 1280×633 flush, title + tabs + download in header |
| mobile community Nav | left | 260×844, closes on menu selection |
| Electron connection | top | full viewport (1560×953), flush |

`AgentSkillEdit` could not be exercised: its trigger (the `store.actions.configure` button) sits behind a `!onSelect` branch that the settings page never takes, so the drawer has had no entry point since the master–detail rework in e751b884f5. Unrelated to this change; it is covered by the type-check only.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

The backdrop fix carries its own regression tests upstream (`ImageViewer.nested.test.tsx` in lobehub/lobe-ui#598) — one case that opens the viewer on its own and one that opens it from inside a drawer, the latter failing before the fix.

#### 🔗 Related Issue

None.
