### PR TITLE
🐛 fix(document): serialize the file parse cache write and order its lookup

### DIFF
--- a/apps/server/src/services/document/__tests__/index.test.ts
+++ b/apps/server/src/services/document/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import { type LobeChatDatabase } from '@lobechat/database';
 import { TRPCError } from '@trpc/server';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DocumentModel } from '@/database/models/document';
@@ -89,6 +90,7 @@ describe('DocumentService', () => {
 
   beforeEach(() => {
     mockDb = {
+      execute: vi.fn().mockResolvedValue(undefined),
       query: {
         documents: {
           findMany: vi.fn().mockResolvedValue([]),
@@ -1776,6 +1778,104 @@ describe('DocumentService', () => {
         });
       }
 
+      expect(mockCleanup).toHaveBeenCalled();
+    });
+
+    it('should return the cached document without parsing it again', async () => {
+      const cached = { content: 'Cached', id: 'doc-1' };
+      mockDocumentModel.findByFileId.mockResolvedValueOnce(cached);
+
+      const result = await service.parseFile('file-1');
+
+      expect(result).toEqual(cached);
+      expect(mockFileService.downloadFileToLocal).not.toHaveBeenCalled();
+      expect(loadFile).not.toHaveBeenCalled();
+      expect(mockDocumentModel.create).not.toHaveBeenCalled();
+    });
+
+    // The model bound to the locked transaction has to be a different object
+    // from the one the service already holds, otherwise no assertion can tell
+    // which connection the re-check and the insert actually ran on.
+    const mountLockedTransaction = (transactionModel: any) => {
+      const executeSpy = vi.fn().mockResolvedValue(undefined);
+      const trx = { execute: executeSpy };
+      mockDb.transaction = vi.fn(async (callback: any) => callback(trx));
+      vi.mocked(DocumentModel).mockImplementation(
+        (db: any) => (db === trx ? transactionModel : mockDocumentModel) as any,
+      );
+
+      return { executeSpy, trx };
+    };
+
+    it('should take a per-file advisory lock before writing the parse cache', async () => {
+      vi.mocked(loadFile).mockResolvedValue({
+        content: 'Content',
+        fileType: 'markdown',
+        metadata: {},
+        pages: undefined,
+        totalCharCount: 7,
+        totalLineCount: 1,
+      } as any);
+      const transactionModel = {
+        create: vi.fn().mockResolvedValue({ id: 'doc-1' }),
+        findByFileId: vi.fn().mockResolvedValue(null),
+      };
+      const { executeSpy, trx } = mountLockedTransaction(transactionModel);
+      const scopedService = new DocumentService(mockDb, userId, 'workspace-1', 'public');
+
+      const result = await scopedService.parseFile('file-1');
+
+      expect(executeSpy).toHaveBeenCalledTimes(1);
+      // Render the statement the way the driver receives it, so the assertion
+      // covers the real SQL and its bound parameter.
+      const lockStatement = new PgDialect().sqlToQuery(executeSpy.mock.calls[0][0]);
+      expect(lockStatement.sql).toContain('pg_advisory_xact_lock');
+      // The key is derived from the file, so different files take different keys.
+      expect(lockStatement.params).toEqual(['parseFile:file-1']);
+      // The re-check and the insert run on the locked transaction and keep the
+      // service's own scope — not on the connection the service already holds.
+      expect(vi.mocked(DocumentModel)).toHaveBeenLastCalledWith(
+        trx,
+        userId,
+        'workspace-1',
+        'public',
+      );
+      expect(transactionModel.findByFileId).toHaveBeenCalledWith('file-1');
+      expect(transactionModel.create).toHaveBeenCalledTimes(1);
+      expect(mockDocumentModel.create).not.toHaveBeenCalled();
+      // Both have to happen after the lock is held — re-checking before it would
+      // leave the same window open.
+      expect(executeSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        transactionModel.findByFileId.mock.invocationCallOrder[0],
+      );
+      expect(executeSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        transactionModel.create.mock.invocationCallOrder[0],
+      );
+      expect(result).toEqual({ id: 'doc-1' });
+    });
+
+    it('should return the document another request published while this parse ran', async () => {
+      vi.mocked(loadFile).mockResolvedValue({
+        content: 'Content',
+        fileType: 'markdown',
+        metadata: {},
+        pages: undefined,
+        totalCharCount: 7,
+        totalLineCount: 1,
+      } as any);
+      const published = { content: 'Published by the other request', id: 'doc-raced' };
+      const transactionModel = {
+        create: vi.fn(),
+        // The check before the parse missed it; the re-check under the lock hits.
+        findByFileId: vi.fn().mockResolvedValue(published),
+      };
+      mountLockedTransaction(transactionModel);
+
+      const result = await service.parseFile('file-1');
+
+      expect(result).toEqual(published);
+      expect(transactionModel.create).not.toHaveBeenCalled();
+      expect(mockDocumentModel.create).not.toHaveBeenCalled();
       expect(mockCleanup).toHaveBeenCalled();
     });
 

--- a/apps/server/src/services/document/index.ts
+++ b/apps/server/src/services/document/index.ts
@@ -7,7 +7,7 @@ import { documents, files } from '@lobechat/database/schemas';
 import { loadFile, UnsupportedFileTypeError } from '@lobechat/file-loaders';
 import { TRPCError } from '@trpc/server';
 import debug from 'debug';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import isEqual from 'fast-deep-equal';
 
 import { DocumentModel } from '@/database/models/document';
@@ -809,8 +809,14 @@ export class DocumentService {
   }
 
   /**
-   * Parse file content
+   * Parse file content.
    *
+   * Idempotent: returns the document already stored for the file, and serializes
+   * the cache write per file so two concurrent calls cannot both insert one.
+   *
+   * The database handle must not be an open transaction — the advisory lock is
+   * transaction scoped, so a nested call would hold it until the outer
+   * transaction commits instead of releasing it after the insert.
    */
   async parseFile(fileId: string): Promise<LobeDocument> {
     // Idempotent: return existing document if already parsed
@@ -837,19 +843,48 @@ export class DocumentService {
         file.name.replace(/\.(pdf|docx?|md|markdown)$/i, '') ||
         'Untitled';
 
-      const document = await this.documentModel.create({
-        content: fileDocument.content,
-        fileId,
-        fileType: CUSTOM_DOCUMENT_FILE_TYPE, // Use custom/document for all parsed files
-        filename: title,
-        metadata: fileDocument.metadata,
-        pages: fileDocument.pages,
-        parentId: file.parentId,
-        source: file.url,
-        sourceType: 'file',
-        title,
-        totalCharCount: fileDocument.totalCharCount,
-        totalLineCount: fileDocument.totalLineCount,
+      const document = await this.db.transaction(async (tx) => {
+        // The existence check above ran before the download and the parse, so
+        // another request can have published its own row for this file in the
+        // meantime. Serialize the write per file so two concurrent `parseFile`
+        // calls cannot both insert one. `hashtext` returns int4 while
+        // `pg_advisory_xact_lock` takes bigint, so cast. Under the default READ
+        // COMMITTED isolation the re-check below takes a fresh snapshot once the
+        // lock is granted, so it sees whatever the holder committed. The parse
+        // itself stays outside the transaction: it downloads and reads the whole
+        // file, and holding a connection that long would turn every large upload
+        // into pool pressure.
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtext(${`parseFile:${fileId}`})::bigint)`,
+        );
+
+        const transactionDb = tx as unknown as LobeChatDatabase;
+        const transactionDocumentModel = new DocumentModel(
+          transactionDb,
+          this.userId,
+          this.workspaceId,
+          this.callerAgentVisibility,
+        );
+
+        // Whoever inserted first wins; discard this parse rather than adding a
+        // second document for the same file.
+        const raced = await transactionDocumentModel.findByFileId(fileId);
+        if (raced) return raced;
+
+        return transactionDocumentModel.create({
+          content: fileDocument.content,
+          fileId,
+          fileType: CUSTOM_DOCUMENT_FILE_TYPE, // Use custom/document for all parsed files
+          filename: title,
+          metadata: fileDocument.metadata,
+          pages: fileDocument.pages,
+          parentId: file.parentId,
+          source: file.url,
+          sourceType: 'file',
+          title,
+          totalCharCount: fileDocument.totalCharCount,
+          totalLineCount: fileDocument.totalLineCount,
+        });
       });
 
       return document as LobeDocument;

--- a/packages/database/src/models/__tests__/document.test.ts
+++ b/packages/database/src/models/__tests__/document.test.ts
@@ -590,6 +590,89 @@ describe('DocumentModel', () => {
       expect(found?.id).toBe(firstId);
     });
 
+    it('should return the oldest document when rows are inserted out of order', async () => {
+      const { id: fileId } = await fileModel.create({
+        fileType: 'text/plain',
+        name: 'test.txt',
+        size: 100,
+        url: 'https://example.com/test.txt',
+      });
+
+      const file = await fileModel.findById(fileId);
+      if (!file) throw new Error('File not found after creation');
+
+      // Insert the newer row first, so physical row order disagrees with
+      // creation order and an unordered lookup would return the wrong one.
+      await documentModel.create({
+        content: 'Newer document',
+        createdAt: new Date('2026-02-02T00:00:00.000Z'),
+        fileId: file.id,
+        fileType: 'text/plain',
+        source: file.url,
+        sourceType: 'file',
+        totalCharCount: 14,
+        totalLineCount: 1,
+      });
+
+      const { id: olderId } = await documentModel.create({
+        content: 'Older document',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        fileId: file.id,
+        fileType: 'text/plain',
+        source: file.url,
+        sourceType: 'file',
+        totalCharCount: 14,
+        totalLineCount: 1,
+      });
+
+      const found = await documentModel.findByFileId(file.id);
+      expect(found?.id).toBe(olderId);
+      expect(found?.content).toBe('Older document');
+    });
+
+    it('should break created-at ties on id so the lookup stays stable', async () => {
+      const { id: fileId } = await fileModel.create({
+        fileType: 'text/plain',
+        name: 'test.txt',
+        size: 100,
+        url: 'https://example.com/test.txt',
+      });
+
+      const file = await fileModel.findById(fileId);
+      if (!file) throw new Error('File not found after creation');
+
+      const sameInstant = new Date('2026-03-03T00:00:00.000Z');
+
+      // Identical timestamps, inserted highest id first: without a tiebreaker
+      // the row that comes back is whichever one the scan reaches first.
+      await documentModel.create({
+        content: 'Tie b',
+        createdAt: sameInstant,
+        fileId: file.id,
+        fileType: 'text/plain',
+        id: 'document-tie-b',
+        source: file.url,
+        sourceType: 'file',
+        totalCharCount: 5,
+        totalLineCount: 1,
+      });
+
+      await documentModel.create({
+        content: 'Tie a',
+        createdAt: sameInstant,
+        fileId: file.id,
+        fileType: 'text/plain',
+        id: 'document-tie-a',
+        source: file.url,
+        sourceType: 'file',
+        totalCharCount: 5,
+        totalLineCount: 1,
+      });
+
+      const found = await documentModel.findByFileId(file.id);
+      expect(found?.id).toBe('document-tie-a');
+    });
+
     it('should handle different file types', async () => {
       const { id: pdfFileId } = await fileModel.create({
         fileType: 'application/pdf',

--- a/packages/database/src/models/document.ts
+++ b/packages/database/src/models/document.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, inArray, isNull, ne, notInArray, sum } from 'drizzle-orm';
+import { and, asc, count, desc, eq, inArray, isNull, ne, notInArray, sum } from 'drizzle-orm';
 
 import type { DocumentItem, NewDocument } from '../schemas';
 import { DOCUMENT_FOLDER_TYPE, documents, files, works } from '../schemas';
@@ -206,6 +206,12 @@ export class DocumentModel {
 
   findByFileId = async (fileId: string) => {
     return this.db.query.documents.findFirst({
+      // A file can legitimately own more than one document: `parseDocument`
+      // writes a page-editor copy next to the parse cache `parseFile` writes.
+      // Pick the oldest one explicitly instead of leaving the choice to the
+      // query plan, so repeated lookups keep returning the same content.
+      // `created_at` carries no uniqueness guarantee, so `id` breaks ties.
+      orderBy: [asc(documents.createdAt), asc(documents.id)],
       where: and(this.ownership(), eq(documents.fileId, fileId)),
     });
   };


### PR DESCRIPTION
### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

### 🔀 变更说明 | Description of Change

`DocumentService.parseFile` documents itself as idempotent — `// Idempotent: return existing document if already parsed`. Sequentially it is. Concurrently it is not, and the lookup it relies on does not always return the same row.

**1. The check and the insert are not atomic.** `parseFile` reads `documentModel.findByFileId(fileId)`, then downloads the file and parses it, then inserts. The gap spans the whole download plus parse, and nothing serializes it: `documents.file_id` carries a plain index (`documents_file_id_idx`), not a unique one. Two calls for the same file both miss the check and both insert.

Reproduced on Postgres 16, two sessions, the second starting 0.5 s after the first (script at the end of this description):

```
two concurrent parses, check-then-insert, no lock
  rows for f1: 2
  doc-a | parsed by A
  doc-b | parsed by B
```

Reachable paths, all for one already-existing `fileId`:

- `POST /files/queries` — `BatchGetFilesRequestSchema` has `.min(1)` and no upper bound, and `handleQueries` maps the array through `Promise.all` with no dedupe (`packages/openapi/src/services/file.service.ts:1183-1203`), so a single request naming the same unparsed file more than once races itself.
- `POST /files/:id/parses` and the CLI (`apps/cli/src/commands/doc.ts:289`) both re-enter `parseFile` for an id the caller already has.
- The async chunking task (`apps/server/src/routers/async/file.ts:290`) overlapping any other parse of the same file.
- Two agent runs that reference the same attachment (`apps/server/src/services/file/resolveAttachments.ts:91`) or the same knowledge file.

**2. Which stored parse gets served is left to the query plan.** `findByFileId` is a `findFirst` with no `orderBy`, so SQL does not define which row comes back once a file has more than one — and more than one is a normal state, not only a raced one: `parseDocument` writes a page-editor copy for the same `fileId` — same `sourceType: 'file'`, same `fileType: custom/document` — with no existence check (`PageExplorer` reaches it via `document.parseDocument`; so does the CLI). In practice the answer follows the heap, so ordinary maintenance changes it:

```
fresh table              unordered=doc-newer  ordered=doc-older
after editing the newer  unordered=doc-newer  ordered=doc-older
after VACUUM FULL        unordered=doc-older  ordered=doc-older   <-- same query, different row
after editing the older  unordered=doc-newer  ordered=doc-older
```

The repo already asserts that the first-created row is the one returned — `models/__tests__/document.test.ts` has *"should return the first document when multiple documents exist for same file"* with the comment `// Should return the first created document`. That test inserts its two rows in creation order, so it passes without any `ORDER BY`; it says nothing about the case where insert order and creation order disagree, which is exactly the case that breaks.

#### The fix

- **`parseFile`** takes a per-file transaction-scoped advisory lock, re-checks under it, and inserts only if nothing was published meanwhile — the shape `OnboardingService.sendOnboardingFirstMessage` already uses for its own "create if absent, idempotent under concurrent invocation" step (#15090). Same experiment as above, with the fix: `rows for f3: 1`.

- **`findByFileId`** orders by `created_at` then `id`, so the oldest stored document for the file is returned deterministically and the assertion the repo already makes holds by construction rather than by accident.

The parse deliberately stays outside the transaction, so the locked section is one `SELECT` plus at most one `INSERT`. Measured on Postgres 16 with a 2 s parse and a 1 MB body:

| | with the lock | today |
|---|---|---|
| 2 concurrent parses, same file | 2078 ms, **1 row** | 2 rows |
| 2 concurrent parses, different files | 2103 ms, 2 rows | 2 rows |
| 30 concurrent parses, same file | 2472 ms, **1 row** | 30 rows, 29 MB written |
| 30 concurrent parses, 30 different files | 2166 ms, 30 rows | 30 rows |

A waiter blocks 0.16–0.70 ms: the first caller inserts, everyone behind it finds the row and returns it, so the serialized work is one insert and a series of indexed lookups.

#### Why not a unique index on `(file_id, user_id)`

It looks like the obvious fix and it does not work here: `parseDocument` unconditionally creates a second document row for a file that may already have a parse-cache row, so the constraint would make the page-editor import fail (and `parseDocument` twice on one file would fail too). `documents.file_id` is non-unique in practice. Serializing the writer that claims to be idempotent also keeps this change free of a migration and of any cleanup of rows existing installs already have. A partial unique index does not rescue the approach either — nothing on the row separates a parse-cache row from a page-editor one: `parseFile` leaves `pages` null for any file the loader does not paginate, and neither path writes `editorData` at insert time.

#### Scope and trade-offs

- Concurrent callers still each parse the file. Only one row is written and all of them get the same document back. Serializing the parse itself would hold a database connection across a download and a full file read, which trades a duplicated row for pool pressure on every large upload.
- Only concurrent `parseFile` calls are serialized. `parseDocument` does not take the lock and still writes its own row, by design.
- The lock key is `hashtext('parseFile:' || fileId)`, and `hashtext` is 32-bit, so two unrelated files can share a key. The consequence is a few milliseconds of unnecessary serialization, never a wrong row.
- On deployments that set `DATABASE_STATEMENT_TIMEOUT`, the lock wait counts toward it. With the parse outside the transaction the wait is sub-millisecond per waiter, but a pathological convoy on one file could abort with `57014`; `document.parseFileContent` is the one caller that surfaces such an error rather than swallowing it.
- The lookup does not distinguish a parse-cache row from a page-editor row, because nothing on the row does. It returns the older one consistently — which on an install that already has both may be the page-editor copy, including one the user has since edited. A real discriminator needs a schema-level marker and belongs in its own change; so does honouring `skipExist`, which the `parseFileContent` input accepts today but never reads, leaving no way to refresh a stale row through the API.
- `parseFile` must not be called with a transaction as its database handle — noted in its docstring, since a nested transaction would hold the advisory lock until the outer one commits. All six current call sites are outside transactions.
- The added `ORDER BY` sorts the rows matching one `file_id` — normally one or two, and only unbounded if the page-editor path is run repeatedly on the same file.
- A file whose parse fails permanently is unaffected: it has no row before or after this change.

### 📝 补充信息 | Additional Information

Found while working on knowledge-file parsing (#17856): the parse cache that path depends on can hold two rows for one file, and which one is read back is not stable.

**Tests.** Five added. `apps/server/src/services/document/__tests__/index.test.ts`: the advisory lock is taken on the transaction, keyed on the file, before both the re-check and the insert, and both of those run on the transaction-bound model with the service's scope; a row published by another request is returned instead of inserting a second one; plus a cache-hit case that covers the pre-existing fast path rather than the new code. `packages/database/src/models/__tests__/document.test.ts`: the oldest row wins when inserts and `created_at` disagree, and `created_at` ties break on `id`. Suites: 95/95 and 44/44, the latter on both the PGlite harness and a real Postgres 16 (`TEST_SERVER_DB=1`).

Fifteen mutations were planted one at a time — a revert of each change here, plus re-checking before the lock instead of after it, running the re-check or the insert on the pooled connection instead of the transaction, dropping the lock-key namespace, dropping the workspace scope, ordering by `updated_at`, and newest-wins — and every one is caught. A comment-only control mutation is not, which is how the runs were checked for failing for the right reason. The suites mock the database, so the lock statement itself is exercised by the script below rather than by CI.

<details><summary>Reproduction script (psql)</summary>

```sql
CREATE TABLE documents (
  id varchar(255) PRIMARY KEY, file_id text, content text,
  created_at timestamptz NOT NULL DEFAULT now()
);
CREATE INDEX documents_file_id_idx ON documents USING btree (file_id);

-- 1. today: run both blocks concurrently, the second ~0.5s behind → 2 rows
BEGIN;
  SELECT count(*) FROM documents WHERE file_id = 'f1';  -- 0 for both
  SELECT pg_sleep(2);                                   -- download + parse
  INSERT INTO documents (id, file_id, content) VALUES ('doc-a', 'f1', 'parsed by A');
COMMIT;

-- 2. with this change: parse outside, lock + re-check inside → 1 row
SELECT pg_sleep(2);
BEGIN;
  SELECT pg_advisory_xact_lock(hashtext('parseFile:f3')::bigint);
  INSERT INTO documents (id, file_id, content)
    SELECT 'doc-a', 'f3', 'parsed by A'
    WHERE NOT EXISTS (SELECT 1 FROM documents WHERE file_id = 'f3');
COMMIT;

-- 3. unordered lookup follows the heap; ORDER BY does not
INSERT INTO documents (id, file_id, content, created_at)
  VALUES ('doc-newer', 'f2', 'newer', '2026-02-02'), ('doc-older', 'f2', 'older', '2026-01-01');
SELECT id FROM documents WHERE file_id = 'f2' LIMIT 1;                       -- doc-newer
VACUUM FULL documents;
SELECT id FROM documents WHERE file_id = 'f2' LIMIT 1;                       -- doc-older
SELECT id FROM documents WHERE file_id = 'f2' ORDER BY created_at, id LIMIT 1;  -- doc-older, always
```

</details>
