### PR TITLE
✨ feat(home): add Connect Local Agent to category group dropdown

### DIFF
--- a/src/routes/(main)/home/_layout/Body/Agent/List/Group/useDropdownMenu.test.ts
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/Group/useDropdownMenu.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useGroupDropdownMenu } from './useDropdownMenu';
+
+const createConnectAgentMenuItemMock = vi.hoisted(() => vi.fn(() => ({ key: 'newPlatformAgent' })));
+
+vi.mock('@lobehub/ui', () => ({
+  Icon: () => null,
+}));
+
+vi.mock('@lobehub/ui/base-ui', () => ({
+  confirmModal: vi.fn(),
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/business/client/hooks/useActiveWorkspaceId', () => ({
+  useActiveWorkspaceId: () => null,
+}));
+
+vi.mock('@/hooks/usePermission', () => ({
+  usePermission: () => ({ allowed: true }),
+}));
+
+vi.mock('@/libs/trpc/client', () => ({
+  lambdaClient: {},
+}));
+
+vi.mock('@/store/home', () => ({
+  useHomeStore: (selector: (state: { refreshAgentList: () => void }) => unknown) =>
+    selector({ refreshAgentList: vi.fn() }),
+}));
+
+vi.mock('../../../../hooks', () => ({
+  useCreateMenuItems: () => ({
+    createAgentMenuItem: () => ({ key: 'newAgent' }),
+    createConnectAgentMenuItem: createConnectAgentMenuItemMock,
+    createGroupChatMenuItem: () => ({ key: 'newGroupChat' }),
+  }),
+  useSessionGroupMenuItems: () => ({
+    configGroupMenuItem: () => ({ key: 'config' }),
+    deleteGroupMenuItem: () => ({ key: 'delete' }),
+    renameGroupMenuItem: () => ({ key: 'rename' }),
+  }),
+}));
+
+vi.mock('../../useSidebarGroupVisibility', () => ({
+  useSidebarGroupVisibility: () => ({ setSidebarGroupVisible: vi.fn() }),
+}));
+
+const getMenuLayout = (items: ReturnType<typeof useGroupDropdownMenu>) =>
+  (items ?? []).flatMap((item) => {
+    if (!item || typeof item !== 'object') return [];
+    if ('type' in item && item.type === 'divider') return ['divider'];
+    if ('key' in item && item.key) return [item.key];
+    return [];
+  });
+
+describe('Category useGroupDropdownMenu', () => {
+  it('includes Connect Local Agent with the current category context', () => {
+    const { result } = renderHook(() =>
+      useGroupDropdownMenu({
+        anchor: null,
+        id: 'group-1',
+        isCustomGroup: true,
+        name: 'Coding',
+        openConfigGroupModal: vi.fn(),
+        visibility: 'private',
+      }),
+    );
+
+    expect(getMenuLayout(result.current)).toEqual([
+      'newAgent',
+      'newGroupChat',
+      'divider',
+      'newPlatformAgent',
+      'divider',
+      'rename',
+      'config',
+      'hideFromSidebar',
+      'divider',
+      'delete',
+    ]);
+    expect(createConnectAgentMenuItemMock).toHaveBeenCalledWith({
+      groupId: 'group-1',
+      visibility: 'private',
+    });
+  });
+});

--- a/src/routes/(main)/home/_layout/Body/Agent/List/Group/useDropdownMenu.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/Group/useDropdownMenu.tsx
@@ -44,7 +44,8 @@ export const useGroupDropdownMenu = ({
     useSessionGroupMenuItems();
 
   // Create menu items
-  const { createAgentMenuItem, createGroupChatMenuItem } = useCreateMenuItems();
+  const { createAgentMenuItem, createConnectAgentMenuItem, createGroupChatMenuItem } =
+    useCreateMenuItems();
 
   // "Publish to Workspace" is one-way and only meaningful in workspace mode
   // for the creator's own still-private folder. Once a folder is `public`,
@@ -63,6 +64,7 @@ export const useGroupDropdownMenu = ({
   return useMemo(() => {
     const createAgentItem = createAgentMenuItem({ groupId: id, isPinned, visibility });
     const createGroupChatItem = createGroupChatMenuItem({ groupId: id, visibility });
+    const connectAgentItem = createConnectAgentMenuItem({ groupId: id, visibility });
     const configItem = configGroupMenuItem(openConfigGroupModal);
     const renameItem = id && name ? renameGroupMenuItem(id, name, anchor) : null;
     const deleteItem = id ? deleteGroupMenuItem(id) : null;
@@ -138,6 +140,7 @@ export const useGroupDropdownMenu = ({
     return [
       createAgentItem,
       createGroupChatItem,
+      ...(connectAgentItem ? [{ type: 'divider' as const }, connectAgentItem] : []),
       { type: 'divider' as const },
       ...(isCustomGroup
         ? [
@@ -158,6 +161,7 @@ export const useGroupDropdownMenu = ({
     name,
     visibility,
     createAgentMenuItem,
+    createConnectAgentMenuItem,
     createGroupChatMenuItem,
     configGroupMenuItem,
     renameGroupMenuItem,


### PR DESCRIPTION
<!-- Brief and heads-up -->

Category (folder) overflow menus could create a normal agent / group chat, but not **Connect Local Agent**. Private sidebar and View All already expose that entry with the correct `groupId` + `visibility`; this PR wires the same item into the category menu so users can spawn a local/platform agent directly into the folder they are looking at.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

**How to test**

1. Open Home → agent sidebar → open a custom category’s `⋯` menu.
2. Confirm **Connect Local Agent** appears under New Agent / New Group Chat (with a divider).
3. Choose it and verify the new agent is created in that category with the folder’s visibility.
4. Regression: unit test `useDropdownMenu.test.ts` asserts menu layout + `createConnectAgentMenuItem({ groupId, visibility })`.

#### 🔗 Related Issue

N/A