### PR TITLE
🐛 fix(topic): stop the sidebar spinner sticking after a client-minted topic resolves

### DIFF
--- a/src/store/chat/slices/topic/action.test.ts
+++ b/src/store/chat/slices/topic/action.test.ts
@@ -2390,6 +2390,63 @@ describe('topic action', () => {
       expect(result.current.topicLoadingIds).toEqual(['topic-1']);
       expect(result.current.topicLoadingIdCounts).toEqual({ 'topic-1': 2 });
     });
+
+    it('should not double the loading count when resolving a client-minted id to itself', () => {
+      const { result } = renderHook(() => useChatStore());
+      const agentId = 'agent-1';
+      const key = topicMapKey({ agentId });
+      const mintedId = 'tpc_minted0000000001';
+      const optimisticTopic: ChatTopic = {
+        createdAt: Date.now(),
+        favorite: false,
+        id: mintedId,
+        sessionId: agentId,
+        title: '666',
+        updatedAt: Date.now(),
+      };
+
+      act(() => {
+        useChatStore.setState({
+          activeAgentId: agentId,
+          topicDataMap: {
+            [key]: {
+              currentPage: 0,
+              hasMore: false,
+              isExpandingPageSize: false,
+              isLoadingMore: false,
+              items: [optimisticTopic],
+              pageSize: 20,
+              total: 1,
+            },
+          },
+          topicLoadingIdCounts: {},
+          topicLoadingIds: [],
+        });
+      });
+
+      // Send flow: one loading owner opened at optimistic creation…
+      act(() => {
+        result.current.internal_updateTopicLoading(mintedId, true);
+      });
+
+      // …then the server confirms the SAME id (#17889 client-minted ids).
+      act(() => {
+        result.current.internal_replaceTopicId({
+          agentId,
+          nextId: mintedId,
+          previousId: mintedId,
+          value: { sessionId: agentId },
+        });
+      });
+
+      // …and the single run-end release must fully clear the spinner.
+      act(() => {
+        result.current.internal_updateTopicLoading(mintedId, false);
+      });
+
+      expect(result.current.topicLoadingIds).toEqual([]);
+      expect(result.current.topicLoadingIdCounts).toEqual({});
+    });
   });
   describe('summaryTopicTitle', () => {
     it('should show a loading placeholder when auto-summarizing a topic without a title', async () => {

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -1468,6 +1468,12 @@ export class ChatTopicActionImpl {
       n('replaceTopicId'),
     );
 
+    // Client-minted ids (#17889) resolve with previousId === nextId — there is
+    // no loading owner to migrate, and running the merge below would read the
+    // same counter twice and double it, leaving the sidebar spinner stuck after
+    // the single run-end release.
+    if (previousId === nextId) return;
+
     this.#set(
       (state) => {
         const previousCount = state.topicLoadingIdCounts[previousId] ?? 0;


### PR DESCRIPTION
Since #17889 the send flow mints the final topic id up front, so `internal_replaceTopicId` now resolves with `previousId === nextId`. The loading-count migration read the **same counter twice and summed it** (1 → 2), so the single run-end release could never clear it — every topic created by sending a message kept spinning in the sidebar forever, across all three transports (client / gateway / hetero).

The fix short-circuits the migration when the two ids are equal: there is no owner to move, and the counter must stay as-is.

#### Test

- Regression test pins the exact flow: open one loading owner at optimistic creation → server confirms the **same** id → one run-end release fully clears `topicLoadingIds`. Fails before the fix (count doubles to 2), passes after.
- `bun run check` on the changed files: 76 passed.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Regression from #17889.

🤖 Generated with [Claude Code](https://claude.com/claude-code)