### PR TITLE
⚡️ perf: batch recent-topic previews instead of per-topic subquery

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -22,6 +22,7 @@
     "@lobechat/types": "workspace:*",
     "@lobechat/utils": "workspace:*",
     "random-words": "^2.0.1",
+    "remove-markdown": "^0.6.4",
     "ts-md5": "^2.0.1",
     "type-fest": "^5.7.0",
     "ws": "^8.21.0"

--- a/packages/database/src/models/__tests__/recent.test.ts
+++ b/packages/database/src/models/__tests__/recent.test.ts
@@ -610,6 +610,32 @@ describe('RecentModel', () => {
         expect(result[1].lastAssistantMessage).toBe('Last assistant answer');
       });
 
+      it('strips markdown syntax from topic previews', async () => {
+        await serverDB.insert(agents).values({ id: 'agent-inbox', userId, slug: 'inbox' });
+        await serverDB.insert(topics).values({
+          agentId: 'agent-inbox',
+          id: 'topic-markdown-preview',
+          status: 'active',
+          updatedAt: minutesAgo(1),
+          userId,
+        });
+        await serverDB.insert(messages).values({
+          agentId: 'agent-inbox',
+          content:
+            '## Heading\n\nSome **bold** text with a [link](https://example.com) and `code`.',
+          id: 'markdown-preview-message',
+          role: 'assistant',
+          topicId: 'topic-markdown-preview',
+          userId,
+        });
+
+        const result = await recentModel.queryRecent(1, ['topic'], true);
+
+        expect(result[0].lastAssistantMessage).toBe(
+          'Heading\n\nSome bold text with a link and code.',
+        );
+      });
+
       it('returns Date objects for updatedAt', async () => {
         await serverDB.insert(agents).values({ id: 'agent-inbox', userId, slug: 'inbox' });
         await serverDB.insert(topics).values({

--- a/packages/database/src/models/recent.ts
+++ b/packages/database/src/models/recent.ts
@@ -68,31 +68,16 @@ export class RecentModel {
     const mineDocumentWhere = mineOnly ? eq(documents.userId, this.userId) : undefined;
     const mineTaskWhere = mineOnly ? eq(tasks.createdByUserId, this.userId) : undefined;
 
-    const lastAssistantMessageSubquery = this.db
-      .select({
-        value: sql<string>`left(${messages.content}, ${LAST_MESSAGE_PREVIEW_LENGTH + 1})`,
-      })
-      .from(messages)
-      .where(
-        and(
-          eq(messages.topicId, topics.id),
-          eq(messages.role, 'assistant'),
-          buildWorkspaceWhere(scope, messages),
-          ne(messages.content, ''),
-        ),
-      )
-      .orderBy(desc(messages.createdAt))
-      .limit(1);
-
     const topicArm = this.db
       .select({
         description: withTopicPreview
           ? topics.description
           : sql<string | null>`NULL`.as('description'),
         id: topics.id,
-        lastAssistantMessage: withTopicPreview
-          ? sql<string | null>`(${lastAssistantMessageSubquery})`.as('last_assistant_message')
-          : sql<string | null>`NULL`.as('last_assistant_message'),
+        // Previews are fetched in a second batched query scoped to the final
+        // page — inlining the subquery here would evaluate it for every topic
+        // the user owns before the sort/limit prunes to `limit` rows.
+        lastAssistantMessage: sql<string | null>`NULL`.as('last_assistant_message'),
         metadata: sql<any>`${topics.metadata}`.as('metadata'),
         routeGroupId: sql<string | null>`${topics.groupId}`.as('route_group_id'),
         routeId: sql<string | null>`${topics.agentId}`.as('route_id'),
@@ -177,21 +162,54 @@ export class RecentModel {
       .orderBy(desc(sql`updated_at`))
       .limit(limit);
 
-    return rows.map((row) => ({
-      description: row.description,
-      id: row.id,
-      lastAssistantMessage:
-        row.lastAssistantMessage && row.lastAssistantMessage.length > LAST_MESSAGE_PREVIEW_LENGTH
-          ? `${row.lastAssistantMessage.slice(0, LAST_MESSAGE_PREVIEW_LENGTH)}…`
-          : row.lastAssistantMessage,
-      metadata: row.metadata ?? undefined,
-      routeGroupId: row.routeGroupId,
-      routeId: row.routeId,
-      status: row.status,
-      title: row.title,
-      type: row.type,
-      updatedAt: row.updatedAt instanceof Date ? row.updatedAt : new Date(row.updatedAt as any),
-      userId: row.userId,
-    }));
+    const previewByTopicId = withTopicPreview
+      ? await this.queryLastAssistantPreviews(
+          rows.filter((row) => row.type === 'topic').map((row) => row.id),
+        )
+      : new Map<string, string>();
+
+    return rows.map((row) => {
+      const preview = previewByTopicId.get(row.id) ?? null;
+      return {
+        description: row.description,
+        id: row.id,
+        lastAssistantMessage:
+          preview && preview.length > LAST_MESSAGE_PREVIEW_LENGTH
+            ? `${preview.slice(0, LAST_MESSAGE_PREVIEW_LENGTH)}…`
+            : preview,
+        metadata: row.metadata ?? undefined,
+        routeGroupId: row.routeGroupId,
+        routeId: row.routeId,
+        status: row.status,
+        title: row.title,
+        type: row.type,
+        updatedAt: row.updatedAt instanceof Date ? row.updatedAt : new Date(row.updatedAt as any),
+        userId: row.userId,
+      };
+    });
+  };
+
+  private queryLastAssistantPreviews = async (topicIds: string[]): Promise<Map<string, string>> => {
+    if (topicIds.length === 0) return new Map();
+
+    const rows = await this.db
+      .selectDistinctOn([messages.topicId], {
+        topicId: messages.topicId,
+        value: sql<string>`left(${messages.content}, ${LAST_MESSAGE_PREVIEW_LENGTH + 1})`,
+      })
+      .from(messages)
+      .where(
+        and(
+          inArray(messages.topicId, topicIds),
+          eq(messages.role, 'assistant'),
+          buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, messages),
+          ne(messages.content, ''),
+        ),
+      )
+      .orderBy(messages.topicId, desc(messages.createdAt));
+
+    return new Map(
+      rows.filter((row) => row.topicId !== null).map((row) => [row.topicId!, row.value]),
+    );
   };
 }

--- a/packages/database/src/models/recent.ts
+++ b/packages/database/src/models/recent.ts
@@ -1,6 +1,7 @@
 import type { ChatTopicStatus, TaskStatus } from '@lobechat/types';
 import { and, desc, eq, inArray, isNotNull, isNull, ne, not, or, sql } from 'drizzle-orm';
 import { unionAll } from 'drizzle-orm/pg-core';
+import removeMarkdown from 'remove-markdown';
 
 import { agents, DOCUMENT_FOLDER_TYPE, documents, messages, tasks, topics } from '../schemas';
 import type { LobeChatDatabase } from '../type';
@@ -34,6 +35,16 @@ const TOOL_DOCUMENT_SOURCE_TYPES = ['agent', 'agent-signal', 'file', 'web'] as c
 const TASK_FINAL_STATUSES = ['completed', 'canceled'];
 const TOPIC_INBOX_STATUSES: ChatTopicStatus[] = ['running', 'unread'];
 const LAST_MESSAGE_PREVIEW_LENGTH = 2000;
+
+// Best-effort markdown → plain text; previews render in a plain-text row, so
+// syntax noise (**, #, []() …) would show up literally.
+const toPlainTextPreview = (markdown: string): string => {
+  try {
+    return removeMarkdown(markdown).trimEnd();
+  } catch {
+    return markdown;
+  }
+};
 
 export class RecentModel {
   private userId: string;
@@ -74,10 +85,6 @@ export class RecentModel {
           ? topics.description
           : sql<string | null>`NULL`.as('description'),
         id: topics.id,
-        // Previews are fetched in a second batched query scoped to the final
-        // page — inlining the subquery here would evaluate it for every topic
-        // the user owns before the sort/limit prunes to `limit` rows.
-        lastAssistantMessage: sql<string | null>`NULL`.as('last_assistant_message'),
         metadata: sql<any>`${topics.metadata}`.as('metadata'),
         routeGroupId: sql<string | null>`${topics.groupId}`.as('route_group_id'),
         routeId: sql<string | null>`${topics.agentId}`.as('route_id'),
@@ -109,7 +116,6 @@ export class RecentModel {
       .select({
         description: sql<string | null>`NULL`.as('description'),
         id: documents.id,
-        lastAssistantMessage: sql<string | null>`NULL`.as('last_assistant_message'),
         metadata: sql<any>`NULL`.as('metadata'),
         routeGroupId: sql<string | null>`NULL`.as('route_group_id'),
         routeId: sql<string | null>`NULL`.as('route_id'),
@@ -139,7 +145,6 @@ export class RecentModel {
       .select({
         description: sql<string | null>`NULL`.as('description'),
         id: tasks.id,
-        lastAssistantMessage: sql<string | null>`NULL`.as('last_assistant_message'),
         metadata: sql<any>`NULL`.as('metadata'),
         routeGroupId: sql<string | null>`NULL`.as('route_group_id'),
         routeId: sql<string | null>`${tasks.assigneeAgentId}`.as('route_id'),
@@ -162,6 +167,9 @@ export class RecentModel {
       .orderBy(desc(sql`updated_at`))
       .limit(limit);
 
+    // Previews are fetched in a second batched query scoped to the final page
+    // — inlining a correlated subquery in the topic arm would evaluate it for
+    // every topic the user owns before the sort/limit prunes to `limit` rows.
     const previewByTopicId = withTopicPreview
       ? await this.queryLastAssistantPreviews(
           rows.filter((row) => row.type === 'topic').map((row) => row.id),
@@ -209,7 +217,9 @@ export class RecentModel {
       .orderBy(messages.topicId, desc(messages.createdAt));
 
     return new Map(
-      rows.filter((row) => row.topicId !== null).map((row) => [row.topicId!, row.value]),
+      rows
+        .filter((row) => row.topicId !== null)
+        .map((row) => [row.topicId!, toPlainTextPreview(row.value)]),
     );
   };
 }


### PR DESCRIPTION
The home Recents endpoint (`RecentModel.queryRecent` with `withTopicPreview`) inlined the `lastAssistantMessage` preview as a correlated subquery in the topic arm's SELECT list. Since the union's `ORDER BY updated_at DESC LIMIT n` sits above it, Postgres evaluated the preview subquery for **every topic the user owns** before pruning to the final page — and the subquery itself (`ORDER BY messages.created_at`) has no matching index, so each evaluation scanned all of the topic's messages including wide `content` heap/TOAST pages.

Prod impact (pg_stat_statements): 30k calls, **mean 6.6s, max 215s, ~56h total DB time** — the single most expensive query in the database. Reproduced on a heavy user (8.9k topics): 83s cold / 30s warm, with the preview SubPlan at `loops=8926`.

Changes:

- Fetch previews in a second `DISTINCT ON (topic_id)` query scoped to the ≤`limit` topic ids that survived the sort — turning ~9k correlated scans into one batched lookup. Same-page measurement on the same heavy user: **83s → ~1.8s cold** (step 1: 1.3s, step 2: 0.5s); the preview-less union variant already averages 17ms in prod.
- Drop the `last_assistant_message` column from all three union arms entirely — it was a constant NULL in each arm once the preview moved out of SQL.
- Strip markdown from previews via `remove-markdown` (same lib behind `src/utils/markdownToTxt.ts`) — previews render in plain-text rows where raw syntax (`**`, `#`, `[]()` …) shows up literally.

Rebased on top of #17927: the batched preview query carries the same `buildWorkspaceWhere` predicate on `messages` that the revert restored, so scope semantics match canary.

#### Test

- [x] Tested locally
- [x] Added/updated tests

`packages/database` → `vitest run src/models/__tests__/recent.test.ts`: 27/27 pass, including a new markdown-stripping case. Verified the two-step query plan and timings directly against the prod DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)