### PR TITLE
🐛 fix(conversation): fix layout jitter on tool-call turn completion

### DIFF
--- a/src/features/Conversation/ChatList/hooks/useConversationScroll.test.ts
+++ b/src/features/Conversation/ChatList/hooks/useConversationScroll.test.ts
@@ -341,6 +341,32 @@ describe('useConversationScroll — pin behavior', () => {
     expect(scrollToIndex).not.toHaveBeenCalled();
   });
 
+  // Regression: settle re-pins fire while the content height is still changing
+  // (e.g. a workflow collapse at turn completion). A smooth scroll there is
+  // itself a visible slide, so only the initial send scroll may animate.
+  it('re-pins without smooth scrolling once the spacer layout settles', () => {
+    const { result, rerender } = renderScrollHook({
+      dataSource: [assistantId, 'prev'],
+      isSecondLastMessageFromUser: false,
+    });
+
+    rerender({
+      dataSource: ['m0', 'm1', userId, assistantId],
+      isSecondLastMessageFromUser: true,
+    });
+    expect(scrollToIndex).toHaveBeenCalledWith(2, { align: 'start', smooth: true });
+    scrollToIndex.mockClear();
+
+    // Registering the spacer node bumps spacerLayoutVersion, which is the
+    // "layout settled" beat the pin controller retries on.
+    const spacerNode = document.createElement('div');
+    act(() => {
+      result.current.registerSpacerNode(spacerNode);
+    });
+
+    expect(scrollToIndex).toHaveBeenCalledWith(2, { align: 'start', smooth: false });
+  });
+
   it('does not scroll on initial render', () => {
     renderScrollHook({
       dataSource: ['a', 'b', userId, assistantId],

--- a/src/features/Conversation/ChatList/hooks/useConversationScroll.ts
+++ b/src/features/Conversation/ChatList/hooks/useConversationScroll.ts
@@ -12,6 +12,9 @@ export const CONVERSATION_SPACER_TRANSITION_MS = 200;
 
 const SCROLL_SHRINK_END_DELAY_MS = 150;
 
+/** The one `scrollToPinned` reason that is allowed to animate — see `scrollToPinned`. */
+const SEND_SCROLL_REASON = 'send';
+
 // -------- pure helpers --------
 
 export const calculateConversationSpacerHeight = (
@@ -304,9 +307,15 @@ const usePinController = ({
         return;
       }
 
-      log('scrollToPinned (%s) index=%d', reason, pin.index);
+      // Only the initial send scroll animates. Settle re-pins fire while the
+      // content height is still changing (e.g. the workflow collapse at turn
+      // completion); a smooth scroll there is itself a visible slide, so the
+      // correction must land in the same frame to stay imperceptible.
+      const smooth = reason === SEND_SCROLL_REASON;
+
+      log('scrollToPinned (%s) index=%d smooth=%s', reason, pin.index, smooth);
       // pin.index is a message index; the header slot row shifts virtua rows.
-      scrollToIndex(pin.index + headerOffset, { align: 'start', smooth: true });
+      scrollToIndex(pin.index + headerOffset, { align: 'start', smooth });
     },
     [headerOffset, virtuaRef],
   );
@@ -524,7 +533,7 @@ export const useConversationScroll = ({
 
     // Scroll immediately. If virtuaRef isn't ready yet, the spacerLayoutVersion
     // bumps that follow mount+measurement will retry.
-    scrollToPinned('send');
+    scrollToPinned(SEND_SCROLL_REASON);
 
     requestAnimationFrame(() => {
       updateSpacerHeight();

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -300,6 +300,15 @@ const Group = memo<GroupChildrenProps>(
             defaultWorkflowExpandLevel={defaultWorkflowExpandLevel}
             disableEditing={disableEditing}
             key={segment.blocks[0]?.renderKey ?? `${id}.workflow.${index}`}
+            // While the turn's operation is still running, process folding may
+            // take over the moment it ends: the segment tree re-parents into
+            // ProcessFold, which remounts WorkflowCollapse already collapsed —
+            // one non-animated reflow. Letting the collapse also self-animate
+            // from semi → collapsed first would shrink the layout twice and make
+            // the conversation jitter. Once the op ends without a fold happening
+            // (tool-only turn, no final answer), suppression releases and
+            // WorkflowCollapse applies its completion level then.
+            suppressAutoCollapse={!!enableProcessFold && hasActiveOperation}
             workflowChromeComplete={
               workflowChromeComplete ||
               (hasRenderedContentAfter(segments, index) && !hasPendingIntervention(segment.blocks))

--- a/src/features/Conversation/Messages/AssistantGroup/components/ProcessFold.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ProcessFold.tsx
@@ -1,4 +1,4 @@
-import { Accordion, AccordionItem, Text } from '@lobehub/ui';
+import { Accordion, AccordionItem, Flexbox, Text } from '@lobehub/ui';
 import { type Key, memo, type ReactNode, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -30,11 +30,15 @@ const ProcessFold = memo<ProcessFoldProps>(
     const expandedKeys = useMemo(() => (expanded ? [PROCESS_KEY] : []), [expanded]);
 
     const title = (
-      <Text style={{ minWidth: 0 }} type={'secondary'}>
-        {durationText
-          ? t('turnProcess.ranFor', { count: stepCount, duration: durationText })
-          : t('turnProcess.done', { count: stepCount })}
-      </Text>
+      // minHeight matches WorkflowCollapse's 24px status-icon row so the header
+      // keeps the same height when the workflow is swapped for this fold.
+      <Flexbox horizontal align={'center'} style={{ minHeight: 24, minWidth: 0 }}>
+        <Text style={{ minWidth: 0 }} type={'secondary'}>
+          {durationText
+            ? t('turnProcess.ranFor', { count: stepCount, duration: durationText })
+            : t('turnProcess.done', { count: stepCount })}
+        </Text>
+      </Flexbox>
     );
 
     return (

--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
@@ -221,6 +221,74 @@ describe('WorkflowCollapse', () => {
     expect(screen.getByRole('button', { name: 'Collapse' })).toBeInTheDocument();
   });
 
+  it('auto-collapses on completion by default', () => {
+    const { rerender } = render(
+      <WorkflowCollapse assistantMessageId="msg-1" blocks={makeBlocks()} />,
+    );
+
+    expect(getExpandedKeys()).toBe('["workflow"]');
+
+    mockIsGenerating = false;
+    rerender(
+      <WorkflowCollapse
+        assistantMessageId="msg-1"
+        blocks={makeBlocks({ result: { content: 'ok' } })}
+      />,
+    );
+
+    expect(getExpandedKeys()).toBe('[]');
+  });
+
+  it('skips the completion auto-collapse while suppressAutoCollapse is set', () => {
+    // Regression: the animated semi → collapsed transition used to run right
+    // before the parent folded the whole workflow into ProcessFold, shrinking
+    // the layout twice and making the conversation visibly jitter.
+    const { rerender } = render(
+      <WorkflowCollapse suppressAutoCollapse assistantMessageId="msg-1" blocks={makeBlocks()} />,
+    );
+
+    expect(getExpandedKeys()).toBe('["workflow"]');
+
+    mockIsGenerating = false;
+    rerender(
+      <WorkflowCollapse
+        suppressAutoCollapse
+        assistantMessageId="msg-1"
+        blocks={makeBlocks({ result: { content: 'ok' } })}
+      />,
+    );
+
+    expect(getExpandedKeys()).toBe('["workflow"]');
+  });
+
+  it('collapses late when suppressAutoCollapse is released after completion', () => {
+    // The turn ended but never folded (e.g. tool-only turn with no final
+    // answer), so nothing else collapses the workflow — the late release must.
+    const { rerender } = render(
+      <WorkflowCollapse suppressAutoCollapse assistantMessageId="msg-1" blocks={makeBlocks()} />,
+    );
+
+    mockIsGenerating = false;
+    rerender(
+      <WorkflowCollapse
+        suppressAutoCollapse
+        assistantMessageId="msg-1"
+        blocks={makeBlocks({ result: { content: 'ok' } })}
+      />,
+    );
+    expect(getExpandedKeys()).toBe('["workflow"]');
+
+    rerender(
+      <WorkflowCollapse
+        assistantMessageId="msg-1"
+        blocks={makeBlocks({ result: { content: 'ok' } })}
+        suppressAutoCollapse={false}
+      />,
+    );
+
+    expect(getExpandedKeys()).toBe('[]');
+  });
+
   it('auto expands and switches the header when confirmation is pending', async () => {
     render(
       <WorkflowCollapse

--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
@@ -45,8 +45,7 @@ export type WorkflowExpandLevel = 'collapsed' | 'semi' | 'full';
  *  should differ — e.g. heterogeneous agents want full while streaming but
  *  still collapse once a turn finishes. A plain string applies to both. */
 export type WorkflowExpandLevelDefault =
-  | WorkflowExpandLevel
-  | { completion?: WorkflowExpandLevel; streaming?: WorkflowExpandLevel };
+  WorkflowExpandLevel | { completion?: WorkflowExpandLevel; streaming?: WorkflowExpandLevel };
 
 interface WorkflowCollapseProps {
   /** Assistant group message id (for generation state) */
@@ -61,6 +60,14 @@ interface WorkflowCollapseProps {
    */
   defaultWorkflowExpandLevel?: WorkflowExpandLevelDefault;
   disableEditing?: boolean;
+  /**
+   * Skip the completion auto-collapse (semi → collapsed, an animated Accordion
+   * height transition) because the parent is about to fold the whole workflow
+   * into `ProcessFold` in a single commit. Collapsing twice — once as a
+   * multi-frame animation, once as the fold swap — is what makes the
+   * conversation visibly jitter when a turn with tool calls finishes.
+   */
+  suppressAutoCollapse?: boolean;
   workflowChromeComplete?: boolean;
 }
 
@@ -140,6 +147,7 @@ const WorkflowCollapse = memo<WorkflowCollapseProps>(
     blocks,
     defaultWorkflowExpandLevel,
     disableEditing,
+    suppressAutoCollapse = false,
     workflowChromeComplete = false,
   }) => {
     const { t } = useTranslation('chat');
@@ -186,10 +194,13 @@ const WorkflowCollapse = memo<WorkflowCollapseProps>(
     );
     const userOpenedRef = useRef(false);
     const prevCompleteRef = useRef(allComplete);
+    const prevSuppressRef = useRef(suppressAutoCollapse);
 
     useEffect(() => {
       const wasComplete = prevCompleteRef.current;
       prevCompleteRef.current = allComplete;
+      const wasSuppressed = prevSuppressRef.current;
+      prevSuppressRef.current = suppressAutoCollapse;
 
       if (!allComplete && wasComplete) {
         userOpenedRef.current = false;
@@ -197,10 +208,28 @@ const WorkflowCollapse = memo<WorkflowCollapseProps>(
         return;
       }
 
-      if (allComplete && !wasComplete && !userOpenedRef.current && allTools.length > 0) {
+      const autoCollapsable = !userOpenedRef.current && allTools.length > 0;
+
+      if (allComplete && !wasComplete) {
+        if (!suppressAutoCollapse && autoCollapsable) setExpandLevel(completionInitialLevel);
+        return;
+      }
+
+      // Late release: suppression is held while the turn's operation is still
+      // active, so it can lift *after* completion already happened. That is the
+      // path where the parent ends up NOT folding into ProcessFold (e.g. a
+      // tool-only turn with no final answer), so nothing else will collapse this
+      // workflow — apply the completion level now instead.
+      if (allComplete && wasSuppressed && !suppressAutoCollapse && autoCollapsable) {
         setExpandLevel(completionInitialLevel);
       }
-    }, [allComplete, allTools.length, streamingInitialLevel, completionInitialLevel]);
+    }, [
+      allComplete,
+      allTools.length,
+      streamingInitialLevel,
+      completionInitialLevel,
+      suppressAutoCollapse,
+    ]);
 
     const streaming = !allComplete;
     const forceExpanded = streaming && pendingInterventionPresent;


### PR DESCRIPTION
When an assistant turn with tool calls finished, the conversation visibly jittered: content dropped ~60px then slid back up. Three stacked causes:

1. `WorkflowCollapse` auto-collapsed (`semi` → `collapsed`) with an animated Accordion height transition as soon as tools completed, and moments later the whole segment tree re-parented into `ProcessFold` — the layout shrank twice, the first time as a multi-frame animation.
2. The conversation spacer compensates content-height changes asynchronously (ResizeObserver + rAF), so it lagged the collapse animation by 1–2 frames every frame; virtua clamped the scroll offset and content visually dropped. The pin controller then re-pinned with `smooth: true`, producing the visible slide back.
3. `ProcessFold`'s text-only header is ~2px shorter than the `WorkflowCollapse` header (24px status-icon row) it replaces.

#### Fix

Principle: animation is reserved for user-initiated toggles; programmatic layout changes must land in a single frame so the spacer can compensate in one step.

- `WorkflowCollapse` gains `suppressAutoCollapse`: while the turn's operation is still active and process folding will take over, the completion auto-collapse is skipped — the fold swap then collapses everything in one non-animated commit. A late-release path still collapses turns that end without folding (e.g. tool-only turns).
- `scrollToPinned` only animates for the initial send; settle re-pins triggered by content-height changes are now instant, so any residual clamp is corrected in the same frame.
- `ProcessFold` title row gets `minHeight: 24` to match the header it replaces.

#### Test

Verified on the desktop app with real streaming tool-call runs, using a rAF probe recording the assistant message's viewport position every frame: max down-then-up excursion at completion went from ~60px (with a 15-frame smooth slide back) to ~5.5px with no multi-frame slide. Streaming keeps the workflow expanded; completion swaps directly to the folded "ran N steps" header; send-time smooth pinning is unaffected.

- [x] Tested locally
- [x] Added/updated tests