### PR TITLE
🐛 fix(heterogeneous-agent): preserve OpenCode step boundaries

### DIFF
--- a/packages/heterogeneous-agents/src/adapters/opencode.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/opencode.test.ts
@@ -87,6 +87,58 @@ describe('OpenCodeAdapter', () => {
     expect(adapter.adapt(raw)).toEqual([]);
   });
 
+  it('opens a new step for the final answer after a completed tool turn', () => {
+    const adapter = new OpenCodeAdapter();
+    const firstStart = adapter.adapt({
+      part: { id: 'step-1', type: 'step-start' },
+      sessionID: 'ses-post-tool',
+      type: 'step_start',
+    });
+
+    adapter.adapt({
+      part: {
+        callID: 'call-1',
+        id: 'tool-1',
+        state: { input: { command: 'pwd' }, output: '/workspace', status: 'completed' },
+        tool: 'bash',
+        type: 'tool',
+      },
+      sessionID: 'ses-post-tool',
+      type: 'tool_use',
+    });
+
+    const secondStart = adapter.adapt({
+      part: { id: 'step-2', type: 'step-start' },
+      sessionID: 'ses-post-tool',
+      type: 'step_start',
+    });
+    const finalText = adapter.adapt({
+      part: { id: 'text-1', text: 'Final answer.', type: 'text' },
+      sessionID: 'ses-post-tool',
+      type: 'text',
+    });
+
+    expect(firstStart[0]).toMatchObject({
+      data: { provider: 'opencode', sessionId: 'ses-post-tool' },
+      stepIndex: 0,
+      type: 'stream_start',
+    });
+    expect(firstStart[0].data.newStep).toBeUndefined();
+    expect(secondStart).toEqual([
+      expect.objectContaining({ data: {}, stepIndex: 0, type: 'stream_end' }),
+      expect.objectContaining({
+        data: { newStep: true, provider: 'opencode', sessionId: 'ses-post-tool' },
+        stepIndex: 1,
+        type: 'stream_start',
+      }),
+    ]);
+    expect(finalText[0]).toMatchObject({
+      data: { chunkType: 'text', content: 'Final answer.' },
+      stepIndex: 1,
+      type: 'stream_chunk',
+    });
+  });
+
   it('suppresses duplicate completed part ids', () => {
     const adapter = new OpenCodeAdapter();
     const raw = {

--- a/packages/heterogeneous-agents/src/adapters/opencode.ts
+++ b/packages/heterogeneous-agents/src/adapters/opencode.ts
@@ -111,7 +111,11 @@ export class OpenCodeAdapter implements AgentEventAdapter {
       this.started = true;
     }
     this.streamOpen = true;
-    const data: StreamStartData = { provider: OPENCODE_IDENTIFIER, sessionId: this.sessionId };
+    const data: StreamStartData & { newStep?: boolean } = {
+      provider: OPENCODE_IDENTIFIER,
+      sessionId: this.sessionId,
+      ...(this.stepIndex > 0 ? { newStep: true } : {}),
+    };
     events.push(this.makeEvent('stream_start', data));
     return events;
   }


### PR DESCRIPTION
## Brief

Mark every OpenCode step after the first as a new heterogeneous-agent step.

OpenCode already incremented its internal `stepIndex`, but its follow-up `stream_start` events did not include `newStep: true`. The shared main-agent reducer therefore kept post-tool final text on the tool-issuing assistant message, causing the final answer to render before the completed tool card.

| Before | After |
| ------ | ----- |
| Post-tool final text and tool calls can be persisted on one assistant block, rendering the answer before the tool card. | Follow-up OpenCode steps open a distinct assistant block, preserving tool → final-answer order. |

#### Test

- `bun run check packages/heterogeneous-agents/src/adapters/opencode.ts packages/heterogeneous-agents/src/adapters/opencode.test.ts`
- Added a regression scenario covering completed Bash tool → next OpenCode step → final answer.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

No matching issue found.
