### PR TITLE
🐛 fix(topic): keep the sidebar spinner on through the direct-mention bridge

### DIFF
--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
@@ -2688,6 +2688,102 @@ describe('ConversationLifecycle actions', () => {
         );
       });
 
+      it('should keep the topic visibly running through the direct-mention bridge', async () => {
+        const { result } = renderHook(() => useChatStore());
+        const targetAgentId = 'agent-direct-target';
+        const toolMessageId = 'tool-call-agent-result';
+        const message = '@Agent B hello';
+
+        const userMessage = createMockMessage({
+          id: TEST_IDS.USER_MESSAGE_ID,
+          role: 'user',
+          content: message,
+        });
+        let assistantMessage = createMockMessage({
+          id: TEST_IDS.ASSISTANT_MESSAGE_ID,
+          role: 'assistant',
+          content: '',
+          tools: [],
+        });
+
+        vi.spyOn(aiChatService, 'sendMessageInServer').mockResolvedValue({
+          messages: [userMessage, assistantMessage],
+          topics: [],
+          assistantMessageId: TEST_IDS.ASSISTANT_MESSAGE_ID,
+          userMessageId: TEST_IDS.USER_MESSAGE_ID,
+        } as any);
+
+        (messageService.updateMessage as any).mockImplementation(
+          async (_id: string, value: any) => {
+            assistantMessage = { ...assistantMessage, ...value };
+            return { messages: [userMessage, assistantMessage], success: true };
+          },
+        );
+        (messageService.createMessage as any).mockImplementation(async (params: any) => {
+          const toolMessage = createMockMessage({ ...params, id: toolMessageId, role: 'tool' });
+          return { id: toolMessageId, messages: [userMessage, assistantMessage, toolMessage] };
+        });
+
+        // The moment the sub-agent executor is entered is the END of the
+        // bridge: sendMessage has already been completed, and only the bridge
+        // op spans the awaited message/config steps that led here. The spinner
+        // must not have blinked off across that window. The send created the
+        // topic (context.topicId is null in this fixture), so the id under
+        // test is the client-minted one — take it from the send's own
+        // (settled) operation context.
+        let runningAtSubAgentEntry: boolean | undefined;
+        let topicIdAtSubAgentEntry: string | undefined;
+        act(() => {
+          useChatStore.setState({
+            executeClientAgent: vi.fn().mockImplementation(async () => {
+              const s = useChatStore.getState();
+              topicIdAtSubAgentEntry =
+                Object.values(s.operations).find(
+                  (op) => op.type === 'sendMessage' && op.context.topicId,
+                )?.context.topicId ?? undefined;
+              runningAtSubAgentEntry = topicIdAtSubAgentEntry
+                ? operationSelectors.isTopicVisiblyRunning(topicIdAtSubAgentEntry)(s)
+                : undefined;
+            }),
+          });
+        });
+
+        await act(async () => {
+          await result.current.sendMessage({
+            message,
+            editorData: {
+              root: {
+                children: [
+                  {
+                    children: [
+                      {
+                        label: 'Agent B',
+                        metadata: { id: targetAgentId, type: 'agent' },
+                        type: 'mention',
+                      },
+                      { text: ' hello', type: 'text' },
+                    ],
+                    type: 'paragraph',
+                  },
+                ],
+                type: 'root',
+              },
+            } as any,
+            context: createTestContext(),
+          });
+        });
+
+        expect(useChatStore.getState().executeClientAgent).toHaveBeenCalled();
+        expect(topicIdAtSubAgentEntry).toBeTruthy();
+        expect(runningAtSubAgentEntry).toBe(true);
+        // Bridge completed with the send — no stuck spinner afterwards.
+        expect(
+          operationSelectors.isTopicVisiblyRunning(topicIdAtSubAgentEntry!)(
+            useChatStore.getState(),
+          ),
+        ).toBe(false);
+      });
+
       it('should route a single leading @agent through the gateway when gateway mode is enabled', async () => {
         const { result } = renderHook(() => useChatStore());
         const targetAgentId = 'agent-direct-target';

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -1747,6 +1747,11 @@ export class ConversationLifecycleActionImpl {
         apiName: AgentManagementApiName.callAgent,
         targetAgentId,
         tool_call_id: toolPayload.id,
+        // The parent sendMessage op is already completed when this bridge
+        // runs, and the sub-agent runtime op only starts after the awaited
+        // message/config steps below — without this flag the sidebar topic
+        // spinner (isTopicVisiblyRunning) blinks off for the whole hand-off.
+        topicRunningBridge: true,
       },
       parentOperationId,
       type: 'toolCalling',

--- a/src/store/chat/slices/operation/__tests__/selectors.test.ts
+++ b/src/store/chat/slices/operation/__tests__/selectors.test.ts
@@ -733,6 +733,41 @@ describe('Operation Selectors', () => {
 
       expect(operationSelectors.isTopicVisiblyRunning('topic1')(result.current)).toBe(false);
     });
+
+    it('should count a toolCalling op only when it opts in as a topic-running bridge', () => {
+      const { result } = renderHook(() => useChatStore());
+
+      // Ordinary toolCalling (a child of a running runtime) must NOT count on
+      // its own — that would broaden "turn in progress" to every tool call.
+      act(() => {
+        result.current.startOperation({
+          type: 'toolCalling',
+          context: { agentId: 'agent1', topicId: 'topic1' },
+        });
+      });
+      expect(operationSelectors.isTopicVisiblyRunning('topic1')(result.current)).toBe(false);
+
+      // The direct-mention bridge opts in: sendMessage is already settled and
+      // the sub-agent runtime has not started yet, so this op is the only
+      // thing keeping the turn visibly in progress.
+      let bridgeOpId = '';
+      act(() => {
+        bridgeOpId = result.current.startOperation({
+          type: 'toolCalling',
+          context: { agentId: 'agent1', topicId: 'topic2' },
+          metadata: { topicRunningBridge: true },
+        }).operationId;
+      });
+      expect(operationSelectors.isTopicVisiblyRunning('topic2')(result.current)).toBe(true);
+      expect(operationSelectors.visiblyRunningTopicIds(result.current)).toEqual(
+        new Set(['topic2']),
+      );
+
+      act(() => {
+        result.current.completeOperation(bridgeOpId);
+      });
+      expect(operationSelectors.isTopicVisiblyRunning('topic2')(result.current)).toBe(false);
+    });
   });
 
   describe('visible loading selectors', () => {

--- a/src/store/chat/slices/operation/selectors.ts
+++ b/src/store/chat/slices/operation/selectors.ts
@@ -435,8 +435,24 @@ const isAgentVisiblyRunning =
   };
 
 /**
+ * Op types that can carry a turn's "visibly in progress" state for a topic:
+ * the send → run pipeline, plus `toolCalling` for bridge ops that explicitly
+ * opt in via `metadata.topicRunningBridge` (the direct-@mention route settles
+ * its `sendMessage` before the bridge spawns the sub-agent runtime, so without
+ * the bridge the spinner blinks off during that hand-off).
+ */
+const TOPIC_RUNNING_OPERATION_TYPES: OperationType[] = [
+  ...INPUT_LOADING_OPERATION_TYPES,
+  'toolCalling',
+];
+
+const isTopicRunningOperation = (op: Operation): boolean =>
+  isVisiblyRunningOperation(op) &&
+  (op.type !== 'toolCalling' || op.metadata.topicRunningBridge === true);
+
+/**
  * Whether a turn is visibly in progress for a topic on THIS client — the whole
- * send → run pipeline (see INPUT_LOADING_OPERATION_TYPES), matched by the
+ * send → run pipeline (see TOPIC_RUNNING_OPERATION_TYPES), matched by the
  * operation context's topicId regardless of agent/group/thread.
  *
  * Drives the sidebar topic spinner. Persisted `topic.status === 'running'`
@@ -447,11 +463,11 @@ const isAgentVisiblyRunning =
 const isTopicVisiblyRunning =
   (topicId: string) =>
   (s: ChatStoreState): boolean => {
-    for (const type of INPUT_LOADING_OPERATION_TYPES) {
+    for (const type of TOPIC_RUNNING_OPERATION_TYPES) {
       const operationIds = s.operationsByType[type] || [];
       const hasRunning = operationIds.some((id) => {
         const op = s.operations[id];
-        return op && isVisiblyRunningOperation(op) && op.context.topicId === topicId;
+        return op && isTopicRunningOperation(op) && op.context.topicId === topicId;
       });
       if (hasRunning) return true;
     }
@@ -466,10 +482,10 @@ const isTopicVisiblyRunning =
  */
 const visiblyRunningTopicIds = (s: ChatStoreState): Set<string> => {
   const ids = new Set<string>();
-  for (const type of INPUT_LOADING_OPERATION_TYPES) {
+  for (const type of TOPIC_RUNNING_OPERATION_TYPES) {
     for (const id of s.operationsByType[type] || []) {
       const op = s.operations[id];
-      if (op && isVisiblyRunningOperation(op) && op.context.topicId) {
+      if (op && isTopicRunningOperation(op) && op.context.topicId) {
         ids.add(op.context.topicId);
       }
     }

--- a/src/store/chat/slices/operation/types.ts
+++ b/src/store/chat/slices/operation/types.ts
@@ -173,6 +173,15 @@ export interface OperationMetadata {
   streamRetry?: StreamRetryMetadata;
 
   /**
+   * This op is a routing bridge between a settled `sendMessage` and the child
+   * runtime op it will spawn (e.g. the direct-@mention callAgent bridge), so
+   * the topic-running selectors must count it — its type alone (`toolCalling`)
+   * is not part of the send→run pipeline. Opt-in per op: ordinary toolCalling
+   * children of a running runtime never set it.
+   */
+  topicRunningBridge?: boolean;
+
+  /**
    * The model text stream has finished and there is no visible follow-up phase
    * to wait for, but the runtime operation still needs its terminal lifecycle
    * (`agent_runtime_end`) for cache, queue, unread, and notification effects.


### PR DESCRIPTION
Fixes the P2 review finding on #17926 ("Include direct-mention bridge in topic-running selector").

A single-agent @mention settles its `sendMessage` op before `#executeDirectMentionRoute` spawns the sub-agent runtime, and the bridge between them is a `toolCalling` op — not part of `INPUT_LOADING_OPERATION_TYPES` — so the operations-driven topic spinner (and the byStatus / project-group overlays) blinked off for the whole hand-off: two awaited message writes plus a possible agent-config fetch, typically a few hundred ms and up to ~1s. The `topicLoadingIds` owner that #17926 removed used to cover exactly this window.

#### Why not the two obvious fixes

- **Counting every `toolCalling` op** would broaden "turn in progress" to all tool calls for every consumer of the selector.
- **Holding the `sendMessage` op open through the bridge** (the gateway phase-1 hand-off pattern) looks cleaner but is a trap: it makes a fast follow-up Enter *queue* during the bridge, and a `sub_agent`-scoped run completion deliberately never drains the queue (`buildRunLifecycle.ts` gates draining to top-level runs) — the queued message would be stuck until the next manual send. The current concurrent-send behaviour during the bridge is a pre-existing canary trait, out of scope here.

#### What this does

The bridge op opts in explicitly via `metadata.topicRunningBridge`, and `isTopicVisiblyRunning` / `visiblyRunningTopicIds` count `toolCalling` ops **only** when that flag is set. Spinner timeline for a mention send becomes: `sendMessage` (running) → bridge op (flagged, running) → sub-agent runtime op — continuous, with the client executor starting its op synchronously at entry and the gateway executor starting its child before completing the phase-1 parent.

#### Test

- New regression test drives a real `@Agent` send and asserts the topic is still visibly running at the moment the sub-agent executor is entered (the end of the bridge) and off after the send settles — fails without the fix (verified A/B), passes with it.
- New selector test pins the non-broadening: a plain `toolCalling` op still does not count; only the flagged bridge does, and it stops counting once completed.
- `bun run check` on the 5 changed files: 112 passed; full type-check clean.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)