### PR TITLE
🐛 fix: enforce private conversation visibility

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/aiAgent.getTaskStatus.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.getTaskStatus.test.ts
@@ -7,6 +7,8 @@ import {
   sessions,
   threads,
   topics,
+  workspaceMembers,
+  workspaces,
 } from '@lobechat/database/schemas';
 import { getTestDB } from '@lobechat/database/test-utils';
 import { ThreadStatus, ThreadType } from '@lobechat/types';
@@ -42,6 +44,7 @@ vi.mock('@/server/services/aiChat', () => ({
 
 describe('aiAgentRouter.getSubAgentTaskStatus', () => {
   let serverDB: LobeChatDatabase;
+  let otherUserId: string | undefined;
   let userId: string;
   let testAgentId: string;
   let testGroupId: string;
@@ -52,6 +55,7 @@ describe('aiAgentRouter.getSubAgentTaskStatus', () => {
     serverDB = await getTestDB();
     testDB = serverDB;
     userId = await createTestUser(serverDB);
+    otherUserId = undefined;
 
     // Create test agent
     const [agent] = await serverDB
@@ -114,6 +118,7 @@ describe('aiAgentRouter.getSubAgentTaskStatus', () => {
 
   afterEach(async () => {
     await cleanupTestUser(serverDB, userId);
+    if (otherUserId) await cleanupTestUser(serverDB, otherUserId);
     vi.clearAllMocks();
   });
 
@@ -144,6 +149,48 @@ describe('aiAgentRouter.getSubAgentTaskStatus', () => {
           threadId: 'non-existent-thread-id',
         }),
       ).rejects.toThrow('Thread not found');
+    });
+
+    it('rejects another workspace member reading a private agent thread status', async () => {
+      otherUserId = await createTestUser(serverDB);
+      const [workspace] = await serverDB
+        .insert(workspaces)
+        .values({ name: 'Private task workspace', primaryOwnerId: userId, slug: userId })
+        .returning();
+      await serverDB.insert(workspaceMembers).values([
+        { role: 'owner', userId, workspaceId: workspace.id },
+        { role: 'member', userId: otherUserId, workspaceId: workspace.id },
+      ]);
+      await serverDB.insert(agents).values({
+        id: 'private-task-status-agent',
+        userId,
+        visibility: 'private',
+        workspaceId: workspace.id,
+      });
+      await serverDB.insert(topics).values({
+        agentId: 'private-task-status-agent',
+        id: 'private-task-status-topic',
+        userId,
+        workspaceId: workspace.id,
+      });
+      await serverDB.insert(threads).values({
+        id: 'private-task-status-thread',
+        status: ThreadStatus.Processing,
+        topicId: 'private-task-status-topic',
+        type: ThreadType.Isolation,
+        userId,
+        workspaceId: workspace.id,
+      });
+
+      const caller = aiAgentRouter.createCaller({
+        jwtPayload: { userId: otherUserId },
+        userId: otherUserId,
+        workspaceId: workspace.id,
+      });
+
+      await expect(
+        caller.getSubAgentTaskStatus({ threadId: 'private-task-status-thread' }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
     });
 
     it('should return completed status from Thread', async () => {

--- a/apps/server/src/routers/lambda/__tests__/integration/message.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/message.integration.test.ts
@@ -34,6 +34,7 @@ vi.mock('@/database/core/db-adaptor', () => ({
 describe('Message Router Integration Tests', () => {
   let serverDB: LobeChatDatabase;
   let userId: string;
+  let otherUserId: string | undefined;
   let testSessionId: string;
   let testTopicId: string;
   let testAgentId: string;
@@ -42,6 +43,7 @@ describe('Message Router Integration Tests', () => {
     serverDB = await getTestDB();
     testDB = serverDB; // Set the test DB for the mock
     userId = await createTestUser(serverDB);
+    otherUserId = undefined;
 
     // Create test agent
     const { agents } = await import('@/database/schemas');
@@ -86,6 +88,7 @@ describe('Message Router Integration Tests', () => {
 
   afterEach(async () => {
     await cleanupTestUser(serverDB, userId);
+    if (otherUserId) await cleanupTestUser(serverDB, otherUserId);
   });
 
   describe('createMessage', () => {
@@ -627,6 +630,82 @@ describe('Message Router Integration Tests', () => {
         const page2Ids = page2.map((m) => m.id);
         expect(page1Ids).not.toEqual(page2Ids);
       }
+    });
+
+    it('does not expose private agent topic messages to another workspace member', async () => {
+      const { agents, workspaceMembers, workspaces } = await import('@/database/schemas');
+      otherUserId = await createTestUser(serverDB);
+      const [workspace] = await serverDB
+        .insert(workspaces)
+        .values({ name: 'Private message workspace', primaryOwnerId: userId, slug: userId })
+        .returning();
+      await serverDB.insert(workspaceMembers).values([
+        { role: 'owner', userId, workspaceId: workspace.id },
+        { role: 'member', userId: otherUserId, workspaceId: workspace.id },
+      ]);
+      await serverDB.insert(agents).values({
+        id: 'private-workspace-message-agent',
+        userId,
+        visibility: 'private',
+        workspaceId: workspace.id,
+      });
+      await serverDB.insert(topics).values({
+        agentId: 'private-workspace-message-agent',
+        id: 'private-workspace-message-topic',
+        userId,
+        workspaceId: workspace.id,
+      });
+      const { threads } = await import('@/database/schemas');
+      await serverDB.insert(threads).values({
+        id: 'private-workspace-message-thread',
+        topicId: 'private-workspace-message-topic',
+        type: 'continuation',
+        userId,
+        workspaceId: workspace.id,
+      });
+      await serverDB.insert(messages).values({
+        agentId: 'private-workspace-message-agent',
+        content: 'private workspace content',
+        id: 'private-workspace-message',
+        role: 'assistant',
+        topicId: 'private-workspace-message-topic',
+        userId,
+        workspaceId: workspace.id,
+      });
+      await serverDB.insert(messages).values({
+        agentId: 'private-workspace-message-agent',
+        content: 'private workspace thread content',
+        id: 'private-workspace-thread-message',
+        role: 'assistant',
+        threadId: 'private-workspace-message-thread',
+        topicId: 'private-workspace-message-topic',
+        userId,
+        workspaceId: workspace.id,
+      });
+
+      const ownerCaller = messageRouter.createCaller({
+        ...createTestContext(userId),
+        workspaceId: workspace.id,
+      });
+      const otherCaller = messageRouter.createCaller({
+        ...createTestContext(otherUserId),
+        workspaceId: workspace.id,
+      });
+
+      await expect(
+        ownerCaller.getMessages({ topicId: 'private-workspace-message-topic' }),
+      ).resolves.toEqual([expect.objectContaining({ content: 'private workspace content' })]);
+      await expect(
+        otherCaller.getMessages({ topicId: 'private-workspace-message-topic' }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      await expect(
+        ownerCaller.getMessages({ threadId: 'private-workspace-message-thread' }),
+      ).resolves.toEqual([
+        expect.objectContaining({ content: 'private workspace thread content' }),
+      ]);
+      await expect(
+        otherCaller.getMessages({ threadId: 'private-workspace-message-thread' }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
     });
 
     it('should return workspace topic messages via topicShareId for a link share', async () => {

--- a/apps/server/src/routers/lambda/__tests__/integration/topic.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/topic.integration.test.ts
@@ -5,14 +5,17 @@ import {
   chatGroups,
   messages,
   sessions,
+  threads,
   topics,
   workspaceMembers,
   workspaces,
 } from '@lobechat/database/schemas';
 import { getTestDB } from '@lobechat/database/test-utils';
+import { ThreadType } from '@lobechat/types';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { threadRouter } from '../../thread';
 import { topicRouter } from '../../topic';
 import { cleanupTestUser, createTestAgent, createTestContext, createTestUser } from './setup';
 
@@ -343,6 +346,101 @@ describe('Topic Router Integration Tests', () => {
       await expect(
         otherCaller.getTopicTranscript({ topicId: 'legacy-owner-only-transcript-topic' }),
       ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    });
+  });
+
+  describe('thread creation visibility', () => {
+    it('does not let another workspace member create threads in a private topic', async () => {
+      otherUserId = await createTestUser(serverDB);
+      const [workspace] = await serverDB
+        .insert(workspaces)
+        .values({ name: 'Private thread workspace', primaryOwnerId: userId, slug: userId })
+        .returning();
+      await serverDB.insert(workspaceMembers).values([
+        { role: 'owner', userId, workspaceId: workspace.id },
+        { role: 'member', userId: otherUserId, workspaceId: workspace.id },
+      ]);
+      await serverDB.insert(agents).values({
+        id: 'private-workspace-thread-agent',
+        userId,
+        visibility: 'private',
+        workspaceId: workspace.id,
+      });
+      await serverDB.insert(topics).values({
+        agentId: 'private-workspace-thread-agent',
+        id: 'private-workspace-thread-topic',
+        userId,
+        workspaceId: workspace.id,
+      });
+
+      const ownerCaller = threadRouter.createCaller({
+        ...createTestContext(userId),
+        workspaceId: workspace.id,
+      });
+      const otherCaller = threadRouter.createCaller({
+        ...createTestContext(otherUserId),
+        workspaceId: workspace.id,
+      });
+
+      await expect(
+        otherCaller.createThread({
+          id: 'forbidden-private-thread',
+          topicId: 'private-workspace-thread-topic',
+          type: ThreadType.Continuation,
+        }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      await expect(
+        otherCaller.createThreadWithMessage({
+          id: 'forbidden-private-thread-with-message',
+          message: {
+            agentId: 'private-workspace-thread-agent',
+            content: 'forbidden private thread content',
+            id: 'forbidden-private-thread-message',
+            role: 'user',
+            topicId: 'private-workspace-thread-topic',
+          },
+          topicId: 'private-workspace-thread-topic',
+          type: ThreadType.Continuation,
+        }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+      await expect(
+        serverDB
+          .select({ id: threads.id })
+          .from(threads)
+          .where(eq(threads.topicId, 'private-workspace-thread-topic')),
+      ).resolves.toEqual([]);
+      await expect(
+        serverDB
+          .select({ id: messages.id })
+          .from(messages)
+          .where(eq(messages.threadId, 'forbidden-private-thread-with-message')),
+      ).resolves.toEqual([]);
+
+      await expect(
+        ownerCaller.createThread({
+          id: 'allowed-private-thread',
+          topicId: 'private-workspace-thread-topic',
+          type: ThreadType.Continuation,
+        }),
+      ).resolves.toBe('allowed-private-thread');
+      await expect(
+        ownerCaller.createThreadWithMessage({
+          id: 'allowed-private-thread-with-message',
+          message: {
+            agentId: 'private-workspace-thread-agent',
+            content: 'allowed private thread content',
+            id: 'allowed-private-thread-message',
+            role: 'user',
+            topicId: 'private-workspace-thread-topic',
+          },
+          topicId: 'private-workspace-thread-topic',
+          type: ThreadType.Continuation,
+        }),
+      ).resolves.toEqual({
+        messageId: expect.any(String),
+        threadId: 'allowed-private-thread-with-message',
+      });
     });
   });
 

--- a/apps/server/src/routers/lambda/__tests__/integration/topic.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/topic.integration.test.ts
@@ -1,6 +1,13 @@
 // @vitest-environment node
 import { type LobeChatDatabase } from '@lobechat/database';
-import { messages, sessions, topics } from '@lobechat/database/schemas';
+import {
+  agents,
+  messages,
+  sessions,
+  topics,
+  workspaceMembers,
+  workspaces,
+} from '@lobechat/database/schemas';
 import { getTestDB } from '@lobechat/database/test-utils';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -244,6 +251,56 @@ describe('Topic Router Integration Tests', () => {
         message: 'Topic not found: private-transcript-topic',
       });
     });
+
+    it('does not expose a private agent topic to another workspace member who knows its id', async () => {
+      otherUserId = await createTestUser(serverDB);
+      const [workspace] = await serverDB
+        .insert(workspaces)
+        .values({ name: 'Private transcript workspace', primaryOwnerId: userId, slug: userId })
+        .returning();
+      await serverDB.insert(workspaceMembers).values([
+        { role: 'owner', userId, workspaceId: workspace.id },
+        { role: 'member', userId: otherUserId, workspaceId: workspace.id },
+      ]);
+      await serverDB.insert(agents).values({
+        id: 'private-workspace-transcript-agent',
+        userId,
+        visibility: 'private',
+        workspaceId: workspace.id,
+      });
+      await serverDB.insert(topics).values({
+        agentId: 'private-workspace-transcript-agent',
+        id: 'private-workspace-transcript-topic',
+        title: 'Private Workspace Transcript',
+        userId,
+        workspaceId: workspace.id,
+      });
+      await serverDB.insert(messages).values({
+        agentId: 'private-workspace-transcript-agent',
+        content: 'private workspace message',
+        id: 'private-workspace-transcript-message',
+        role: 'user',
+        topicId: 'private-workspace-transcript-topic',
+        userId,
+        workspaceId: workspace.id,
+      });
+
+      const ownerCaller = topicRouter.createCaller({
+        ...createTestContext(userId),
+        workspaceId: workspace.id,
+      });
+      const otherCaller = topicRouter.createCaller({
+        ...createTestContext(otherUserId),
+        workspaceId: workspace.id,
+      });
+
+      await expect(
+        ownerCaller.getTopicTranscript({ topicId: 'private-workspace-transcript-topic' }),
+      ).resolves.toMatchObject({ total: 1 });
+      await expect(
+        otherCaller.getTopicTranscript({ topicId: 'private-workspace-transcript-topic' }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    });
   });
 
   describe('batchCreateTopics', () => {
@@ -369,6 +426,82 @@ describe('Topic Router Integration Tests', () => {
       expect(result.items).toHaveLength(1);
       expect(result.items[0].title).toBe('Cron Topic');
       expect(result.total).toBe(1);
+    });
+
+    it('does not include another member private agent topics without a container filter', async () => {
+      otherUserId = await createTestUser(serverDB);
+      const [workspace] = await serverDB
+        .insert(workspaces)
+        .values({ name: 'Private topics workspace', primaryOwnerId: userId, slug: userId })
+        .returning();
+      await serverDB.insert(workspaceMembers).values([
+        { role: 'owner', userId, workspaceId: workspace.id },
+        { role: 'member', userId: otherUserId, workspaceId: workspace.id },
+      ]);
+      await serverDB.insert(agents).values([
+        {
+          id: 'private-agent-for-unscoped-topics',
+          userId,
+          visibility: 'private',
+          workspaceId: workspace.id,
+        },
+        {
+          id: 'public-agent-for-unscoped-topics',
+          userId,
+          visibility: 'public',
+          workspaceId: workspace.id,
+        },
+      ]);
+      await serverDB.insert(topics).values([
+        {
+          agentId: 'private-agent-for-unscoped-topics',
+          id: 'private-unscoped-topic',
+          userId,
+          workspaceId: workspace.id,
+        },
+        {
+          agentId: 'public-agent-for-unscoped-topics',
+          id: 'public-unscoped-topic',
+          userId,
+          workspaceId: workspace.id,
+        },
+      ]);
+
+      const caller = topicRouter.createCaller({
+        ...createTestContext(otherUserId),
+        workspaceId: workspace.id,
+      });
+      const result = await caller.getTopics({});
+
+      expect(result.items.map((topic) => topic.id)).toEqual(['public-unscoped-topic']);
+      expect(result.total).toBe(1);
+    });
+
+    it('rejects searching another member private agent before executing the search query', async () => {
+      otherUserId = await createTestUser(serverDB);
+      const [workspace] = await serverDB
+        .insert(workspaces)
+        .values({ name: 'Private search workspace', primaryOwnerId: userId, slug: userId })
+        .returning();
+      await serverDB.insert(workspaceMembers).values([
+        { role: 'owner', userId, workspaceId: workspace.id },
+        { role: 'member', userId: otherUserId, workspaceId: workspace.id },
+      ]);
+      await serverDB.insert(agents).values({
+        id: 'private-agent-for-search',
+        userId,
+        visibility: 'private',
+        workspaceId: workspace.id,
+      });
+
+      const caller = topicRouter.createCaller({
+        ...createTestContext(otherUserId),
+        workspaceId: workspace.id,
+      });
+
+      await expect(
+        caller.searchTopics({ agentId: 'private-agent-for-search', keywords: 'private' }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
     });
   });
 

--- a/apps/server/src/routers/lambda/__tests__/integration/topic.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/topic.integration.test.ts
@@ -2,6 +2,7 @@
 import { type LobeChatDatabase } from '@lobechat/database';
 import {
   agents,
+  chatGroups,
   messages,
   sessions,
   topics,
@@ -301,6 +302,48 @@ describe('Topic Router Integration Tests', () => {
         otherCaller.getTopicTranscript({ topicId: 'private-workspace-transcript-topic' }),
       ).rejects.toMatchObject({ code: 'FORBIDDEN' });
     });
+
+    it('does not expose an owner-only legacy workspace topic to another member', async () => {
+      otherUserId = await createTestUser(serverDB);
+      const [workspace] = await serverDB
+        .insert(workspaces)
+        .values({ name: 'Legacy transcript workspace', primaryOwnerId: userId, slug: userId })
+        .returning();
+      await serverDB.insert(workspaceMembers).values([
+        { role: 'owner', userId, workspaceId: workspace.id },
+        { role: 'member', userId: otherUserId, workspaceId: workspace.id },
+      ]);
+      await serverDB.insert(topics).values({
+        id: 'legacy-owner-only-transcript-topic',
+        title: 'Legacy Owner-only Transcript',
+        userId,
+        workspaceId: workspace.id,
+      });
+      await serverDB.insert(messages).values({
+        content: 'legacy owner-only content',
+        id: 'legacy-owner-only-transcript-message',
+        role: 'user',
+        topicId: 'legacy-owner-only-transcript-topic',
+        userId,
+        workspaceId: workspace.id,
+      });
+
+      const ownerCaller = topicRouter.createCaller({
+        ...createTestContext(userId),
+        workspaceId: workspace.id,
+      });
+      const otherCaller = topicRouter.createCaller({
+        ...createTestContext(otherUserId),
+        workspaceId: workspace.id,
+      });
+
+      await expect(
+        ownerCaller.getTopicTranscript({ topicId: 'legacy-owner-only-transcript-topic' }),
+      ).resolves.toMatchObject({ total: 1 });
+      await expect(
+        otherCaller.getTopicTranscript({ topicId: 'legacy-owner-only-transcript-topic' }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    });
   });
 
   describe('batchCreateTopics', () => {
@@ -502,6 +545,43 @@ describe('Topic Router Integration Tests', () => {
       await expect(
         caller.searchTopics({ agentId: 'private-agent-for-search', keywords: 'private' }),
       ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    });
+
+    it('ignores an unused private agent when searching a visible group', async () => {
+      otherUserId = await createTestUser(serverDB);
+      const [workspace] = await serverDB
+        .insert(workspaces)
+        .values({ name: 'Group search workspace', primaryOwnerId: userId, slug: userId })
+        .returning();
+      await serverDB.insert(workspaceMembers).values([
+        { role: 'owner', userId, workspaceId: workspace.id },
+        { role: 'member', userId: otherUserId, workspaceId: workspace.id },
+      ]);
+      await serverDB.insert(chatGroups).values({
+        id: 'public-group-for-search',
+        userId,
+        visibility: 'public',
+        workspaceId: workspace.id,
+      });
+      await serverDB.insert(agents).values({
+        id: 'unused-private-agent-for-group-search',
+        userId,
+        visibility: 'private',
+        workspaceId: workspace.id,
+      });
+
+      const caller = topicRouter.createCaller({
+        ...createTestContext(otherUserId),
+        workspaceId: workspace.id,
+      });
+
+      await expect(
+        caller.searchTopics({
+          agentId: 'unused-private-agent-for-group-search',
+          groupId: 'public-group-for-search',
+          keywords: '',
+        }),
+      ).resolves.toEqual([]);
     });
   });
 

--- a/apps/server/src/routers/lambda/_helpers/conversationResourceGuard.test.ts
+++ b/apps/server/src/routers/lambda/_helpers/conversationResourceGuard.test.ts
@@ -15,6 +15,9 @@ import {
   assertCanUseMessageTargets,
   assertCanUseSessionTargets,
   assertCanUseTopicTargets,
+  assertCanViewConversationTargets,
+  assertCanViewSessionTargets,
+  assertCanViewThreadTargets,
   assertCanViewTopicTargets,
   filterUserIdsByTopicViewAccess,
 } from './conversationResourceGuard';
@@ -83,6 +86,14 @@ describe('assertCanUseConversationTargets', () => {
         userId: 'user-1',
         workspaceId: 'ws-1',
       }),
+    );
+  });
+
+  it('can require read-only view access', async () => {
+    await assertCanViewConversationTargets(baseCtx(createDb([])), [{ agentId: 'agent-1' }]);
+
+    expect(assertActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'view', resourceId: 'agent-1', resourceType: 'agent' }),
     );
   });
 
@@ -174,6 +185,32 @@ describe('assertCanUseMessageTargets', () => {
   });
 });
 
+describe('assertCanViewThreadTargets', () => {
+  it('resolves the authoritative thread and topic targets', async () => {
+    const db = createDb([
+      [{ agentId: 'thread-agent', groupId: null, topicId: 'topic-1' }],
+      [{ agentId: 'topic-agent', groupId: null, sessionId: null }],
+    ]);
+
+    await assertCanViewThreadTargets(baseCtx(db), ['thread-1']);
+
+    expect(assertActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'view',
+        resourceId: 'thread-agent',
+        resourceType: 'agent',
+      }),
+    );
+    expect(assertActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'view',
+        resourceId: 'topic-agent',
+        resourceType: 'agent',
+      }),
+    );
+  });
+});
+
 describe('assertCanUseTopicTargets', () => {
   it('resolves the owning group from the topic rows', async () => {
     const db = createDb([[{ agentId: null, groupId: 'group-1' }]]);
@@ -252,6 +289,16 @@ describe('assertCanUseSessionTargets', () => {
     await assertCanUseSessionTargets(baseCtx(createDb([])), []);
 
     expect(assertActionMock).not.toHaveBeenCalled();
+  });
+
+  it('can require read-only view access to a session linked agent', async () => {
+    const db = createDb([[{ agentId: 'agent-1' }]]);
+
+    await assertCanViewSessionTargets(baseCtx(db), ['session-1']);
+
+    expect(assertActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'view', resourceId: 'agent-1', resourceType: 'agent' }),
+    );
   });
 });
 

--- a/apps/server/src/routers/lambda/_helpers/conversationResourceGuard.test.ts
+++ b/apps/server/src/routers/lambda/_helpers/conversationResourceGuard.test.ts
@@ -226,6 +226,20 @@ describe('assertCanUseTopicTargets', () => {
     );
   });
 
+  it('uses the group as the effective owner when a topic also has a stale agent', async () => {
+    const db = createDb([[{ agentId: 'private-agent', groupId: 'group-1' }]]);
+
+    await assertCanUseTopicTargets(baseCtx(db), ['t-1']);
+
+    expect(assertActionMock).toHaveBeenCalledTimes(1);
+    expect(assertActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ resourceId: 'group-1', resourceType: 'agentGroup' }),
+    );
+    expect(assertActionMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ resourceId: 'private-agent', resourceType: 'agent' }),
+    );
+  });
+
   it('can require read-only view access to the owning resource', async () => {
     const db = createDb([[{ agentId: 'agent-1', groupId: null }]]);
 
@@ -234,6 +248,22 @@ describe('assertCanUseTopicTargets', () => {
     expect(assertActionMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'view', resourceId: 'agent-1', resourceType: 'agent' }),
     );
+  });
+
+  it('allows only the creator to view a topic without a resolvable resource', async () => {
+    const ownerDb = createDb([
+      [{ agentId: null, groupId: null, sessionId: null, userId: 'user-1' }],
+    ]);
+    await expect(assertCanViewTopicTargets(baseCtx(ownerDb), ['t-1'])).resolves.toBeUndefined();
+
+    const memberDb = createDb([
+      [{ agentId: null, groupId: null, sessionId: null, userId: 'user-2' }],
+    ]);
+    await expect(assertCanViewTopicTargets(baseCtx(memberDb), ['t-1'])).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+
+    expect(assertActionMock).not.toHaveBeenCalled();
   });
 });
 
@@ -270,6 +300,26 @@ describe('filterUserIdsByTopicViewAccess', () => {
     expect(canPerformActionMock).toHaveBeenCalledWith(
       expect.objectContaining({ effectiveAccessLevel: 'view', userId: 'user-1' }),
     );
+  });
+
+  it('keeps only the creator for a topic without a resolvable resource', async () => {
+    const db = createDb([[{ agentId: null, groupId: null, sessionId: null, userId: 'user-1' }]]);
+    vi.spyOn(RbacModel, 'getWorkspaceUsersPermissions').mockResolvedValueOnce(
+      new Map([
+        ['user-1', ['topic:read:all']],
+        ['user-2', ['topic:read:all']],
+      ]),
+    );
+
+    await expect(
+      filterUserIdsByTopicViewAccess(
+        { db, workspaceId: 'ws-1' },
+        ['topic-1'],
+        ['user-1', 'user-2'],
+      ),
+    ).resolves.toEqual(['user-1']);
+
+    expect(canPerformActionMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/server/src/routers/lambda/_helpers/conversationResourceGuard.test.ts
+++ b/apps/server/src/routers/lambda/_helpers/conversationResourceGuard.test.ts
@@ -108,16 +108,16 @@ describe('assertCanUseConversationTargets', () => {
     );
   });
 
-  it('checks both the group and agent when both contexts are supplied', async () => {
+  it('uses group ownership when both group and agent contexts are supplied', async () => {
     await assertCanUseConversationTargets(baseCtx(createDb([])), [
       { agentId: 'supervisor-1', groupId: 'group-1' },
     ]);
 
-    expect(assertActionMock).toHaveBeenCalledTimes(2);
+    expect(assertActionMock).toHaveBeenCalledTimes(1);
     expect(assertActionMock).toHaveBeenCalledWith(
       expect.objectContaining({ resourceId: 'group-1', resourceType: 'agentGroup' }),
     );
-    expect(assertActionMock).toHaveBeenCalledWith(
+    expect(assertActionMock).not.toHaveBeenCalledWith(
       expect.objectContaining({ resourceId: 'supervisor-1', resourceType: 'agent' }),
     );
   });

--- a/apps/server/src/routers/lambda/_helpers/conversationResourceGuard.ts
+++ b/apps/server/src/routers/lambda/_helpers/conversationResourceGuard.ts
@@ -68,8 +68,7 @@ const resolveConversationTargets = async (
         resourceId: target.groupId,
         resourceType: 'agentGroup',
       });
-    }
-    if (target.agentId) {
+    } else if (target.agentId) {
       refs.set(`agent:${target.agentId}`, { resourceId: target.agentId, resourceType: 'agent' });
     }
   }

--- a/apps/server/src/routers/lambda/_helpers/conversationResourceGuard.ts
+++ b/apps/server/src/routers/lambda/_helpers/conversationResourceGuard.ts
@@ -1,7 +1,7 @@
 import { inArray } from 'drizzle-orm';
 
 import { RbacModel } from '@/database/models/rbac';
-import { agentsToSessions, messages, topics } from '@/database/schemas';
+import { agentsToSessions, messages, threads, topics } from '@/database/schemas';
 import type { LobeChatDatabase } from '@/database/type';
 import {
   assertCanPerformResourceAction,
@@ -122,6 +122,11 @@ export const assertCanUseConversationTargets = async (
   targets: ConversationTarget[],
 ): Promise<void> => assertCanAccessConversationTargets(ctx, targets, 'use');
 
+export const assertCanViewConversationTargets = async (
+  ctx: ConversationGuardCtx,
+  targets: ConversationTarget[],
+): Promise<void> => assertCanAccessConversationTargets(ctx, targets, 'view');
+
 /**
  * Resolve message ids to their owning agent/group from the DB rows (client
  * context is untrusted) and assert `use` access. Rows without a direct
@@ -219,6 +224,35 @@ export const assertCanViewTopicTargets = async (
 ): Promise<void> => assertCanAccessTopicTargets(ctx, topicIds, 'view');
 
 /**
+ * Resolve thread ids from their authoritative database rows. A thread may
+ * carry its own agent/group linkage in addition to the parent topic, so both
+ * sources must allow view access; client-supplied conversation fields are not
+ * trusted as substitutes for either one.
+ */
+export const assertCanViewThreadTargets = async (
+  ctx: ConversationGuardCtx,
+  threadIds: string[],
+): Promise<void> => {
+  if (!ctx.workspaceId || threadIds.length === 0) return;
+
+  const rows = await ctx.db
+    .select({
+      agentId: threads.agentId,
+      groupId: threads.groupId,
+      topicId: threads.topicId,
+    })
+    .from(threads)
+    .where(inArray(threads.id, threadIds));
+
+  await Promise.all([
+    assertCanViewConversationTargets(ctx, rows),
+    assertCanViewTopicTargets(ctx, [
+      ...new Set(rows.map((row) => row.topicId).filter(Boolean) as string[]),
+    ]),
+  ]);
+};
+
+/**
  * Resolve one set of topic resources, then evaluate every active recipient
  * against that shared metadata. `view` is the minimum resource access level,
  * so supplying it avoids re-reading the same General-access row per user.
@@ -267,13 +301,10 @@ export const filterUserIdsByTopicViewAccess = async (
   return activeUserIds.filter((_, index) => access[index]);
 };
 
-/**
- * Resolve session ids to their linked agents via `agentsToSessions` and assert
- * `use` access — for session-scoped bulk writes that never see a topic id.
- */
-export const assertCanUseSessionTargets = async (
+const assertCanAccessSessionTargets = async (
   ctx: ConversationGuardCtx,
   sessionIds: string[],
+  action: 'use' | 'view',
 ): Promise<void> => {
   if (!ctx.workspaceId || sessionIds.length === 0) return;
 
@@ -282,8 +313,22 @@ export const assertCanUseSessionTargets = async (
     .from(agentsToSessions)
     .where(inArray(agentsToSessions.sessionId, sessionIds));
 
-  await assertCanUseConversationTargets(ctx, targets);
+  await assertCanAccessConversationTargets(ctx, targets, action);
 };
+
+/**
+ * Resolve session ids to their linked agents via `agentsToSessions` and assert
+ * `use` access — for session-scoped bulk writes that never see a topic id.
+ */
+export const assertCanUseSessionTargets = async (
+  ctx: ConversationGuardCtx,
+  sessionIds: string[],
+): Promise<void> => assertCanAccessSessionTargets(ctx, sessionIds, 'use');
+
+export const assertCanViewSessionTargets = async (
+  ctx: ConversationGuardCtx,
+  sessionIds: string[],
+): Promise<void> => assertCanAccessSessionTargets(ctx, sessionIds, 'view');
 
 /**
  * Guard every authority-bearing field accepted by message creation. Explicit

--- a/apps/server/src/routers/lambda/_helpers/conversationResourceGuard.ts
+++ b/apps/server/src/routers/lambda/_helpers/conversationResourceGuard.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from '@trpc/server';
 import { inArray } from 'drizzle-orm';
 
 import { RbacModel } from '@/database/models/rbac';
@@ -32,6 +33,11 @@ interface ResolvedConversationTarget {
   meta: NonNullable<Awaited<ReturnType<typeof getResourceMeta>>>;
   resourceId: string;
   resourceType: 'agent' | 'agentGroup';
+}
+
+interface ResolvedTopicAccess {
+  creatorOnlyUserIds: Set<string>;
+  resources: ResolvedConversationTarget[];
 }
 
 /**
@@ -159,11 +165,18 @@ export const assertCanUseMessageTargets = async (
 const resolveTopicTargets = async (
   ctx: Pick<ConversationGuardCtx, 'db' | 'workspaceId'>,
   topicIds: string[],
-): Promise<ResolvedConversationTarget[]> => {
-  if (!ctx.workspaceId || topicIds.length === 0) return [];
+): Promise<ResolvedTopicAccess> => {
+  if (!ctx.workspaceId || topicIds.length === 0) {
+    return { creatorOnlyUserIds: new Set(), resources: [] };
+  }
 
   const rows = await ctx.db
-    .select({ agentId: topics.agentId, groupId: topics.groupId, sessionId: topics.sessionId })
+    .select({
+      agentId: topics.agentId,
+      groupId: topics.groupId,
+      sessionId: topics.sessionId,
+      userId: topics.userId,
+    })
     .from(topics)
     .where(inArray(topics.id, topicIds));
 
@@ -177,15 +190,43 @@ const resolveTopicTargets = async (
         .map((row) => row.sessionId!),
     ),
   ];
-  const sessionTargets: ConversationTarget[] =
+  const sessionTargets: { agentId: string; sessionId: string }[] =
     unresolvedSessionIds.length > 0
       ? await ctx.db
-          .select({ agentId: agentsToSessions.agentId })
+          .select({ agentId: agentsToSessions.agentId, sessionId: agentsToSessions.sessionId })
           .from(agentsToSessions)
           .where(inArray(agentsToSessions.sessionId, unresolvedSessionIds))
       : [];
 
-  return resolveConversationTargets(ctx, [...rows, ...sessionTargets]);
+  const sessionTargetsById = new Map<string, ConversationTarget[]>();
+  for (const target of sessionTargets) {
+    const targets = sessionTargetsById.get(target.sessionId) ?? [];
+    targets.push(target);
+    sessionTargetsById.set(target.sessionId, targets);
+  }
+  const targetsByTopic = rows.map((row): ConversationTarget[] => {
+    if (row.groupId) return [{ groupId: row.groupId }];
+    if (row.agentId) return [{ agentId: row.agentId }];
+    if (row.sessionId) return sessionTargetsById.get(row.sessionId) ?? [];
+    return [];
+  });
+  const resources = await resolveConversationTargets(ctx, targetsByTopic.flat());
+  const resolvedResourceKeys = new Set(
+    resources.map(({ resourceId, resourceType }) => `${resourceType}:${resourceId}`),
+  );
+  const creatorOnlyUserIds = new Set(
+    rows
+      .filter((_, index) => {
+        const targets = targetsByTopic[index];
+        return targets.every((target) => {
+          const key = target.groupId ? `agentGroup:${target.groupId}` : `agent:${target.agentId}`;
+          return !resolvedResourceKeys.has(key);
+        });
+      })
+      .map((row) => row.userId),
+  );
+
+  return { creatorOnlyUserIds, resources };
 };
 
 const assertCanAccessTopicTargets = async (
@@ -196,8 +237,12 @@ const assertCanAccessTopicTargets = async (
   const workspaceId = ctx.workspaceId ?? undefined;
   if (!workspaceId) return;
 
-  const resolved = await resolveTopicTargets(ctx, topicIds);
-  for (const { meta, resourceId, resourceType } of resolved) {
+  const { creatorOnlyUserIds, resources } = await resolveTopicTargets(ctx, topicIds);
+  if ([...creatorOnlyUserIds].some((creatorId) => creatorId !== ctx.userId)) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Topic not found' });
+  }
+
+  for (const { meta, resourceId, resourceType } of resources) {
     await assertCanPerformResourceAction({
       action,
       db: ctx.db,
@@ -266,7 +311,7 @@ export const filterUserIdsByTopicViewAccess = async (
   const uniqueUserIds = [...new Set(userIds)];
   if (!workspaceId || uniqueUserIds.length === 0) return [];
 
-  const [resolvedTargets, permissionsByUserId] = await Promise.all([
+  const [resolvedTopicAccess, permissionsByUserId] = await Promise.all([
     resolveTopicTargets(ctx, topicIds),
     RbacModel.getWorkspaceUsersPermissions({
       db: ctx.db,
@@ -278,9 +323,13 @@ export const filterUserIdsByTopicViewAccess = async (
   const activeUserIds = uniqueUserIds.filter((userId) => permissionsByUserId.has(userId));
   const access = await Promise.all(
     activeUserIds.map(async (userId) => {
+      if ([...resolvedTopicAccess.creatorOnlyUserIds].some((creatorId) => creatorId !== userId)) {
+        return false;
+      }
+
       const grantedPermissions = permissionsByUserId.get(userId)!;
       const checks = await Promise.all(
-        resolvedTargets.map(({ meta, resourceId, resourceType }) =>
+        resolvedTopicAccess.resources.map(({ meta, resourceId, resourceType }) =>
           canPerformResourceAction({
             action: 'view',
             db: ctx.db,

--- a/apps/server/src/routers/lambda/aiAgent.ts
+++ b/apps/server/src/routers/lambda/aiAgent.ts
@@ -30,6 +30,7 @@ import { unwrapPgError } from '@/server/modules/AgentRuntime/pgError';
 import {
   assertCanUseMessageTargets,
   assertCanUseTopicTargets,
+  assertCanViewThreadTargets,
 } from '@/server/routers/lambda/_helpers/conversationResourceGuard';
 import { assertCanUseWorkspaceAgent } from '@/server/routers/lambda/_helpers/workspaceAgentGuard';
 import { AgentRuntimeService } from '@/server/services/agentRuntime';
@@ -1314,6 +1315,11 @@ export const aiAgentRouter = router({
       const { threadId } = input;
 
       log('getSubAgentTaskStatus: threadId=%s', threadId);
+
+      await assertCanViewThreadTargets(
+        { db: ctx.serverDB, userId: ctx.userId, workspaceId: ctx.workspaceId },
+        [threadId],
+      );
 
       // 1. Find thread by threadId
       const thread = await ctx.threadModel.findById(threadId);

--- a/apps/server/src/routers/lambda/message.ts
+++ b/apps/server/src/routers/lambda/message.ts
@@ -27,6 +27,10 @@ import {
   assertCanUseCreateMessageTargets,
   assertCanUseMessageTargets,
   assertCanUseTopicTargets,
+  assertCanViewConversationTargets,
+  assertCanViewSessionTargets,
+  assertCanViewThreadTargets,
+  assertCanViewTopicTargets,
 } from './_helpers/conversationResourceGuard';
 import { resolveAgentIdFromSession, resolveContext } from './_helpers/resolveContext';
 import { basicContextSchema } from './_schema/context';
@@ -321,6 +325,7 @@ export const messageRouter = router({
   diagnoseTopic: messageProcedure
     .input(z.object({ agentId: z.string().nullish(), topicId: z.string() }))
     .query(async ({ ctx, input }) => {
+      await assertCanViewTopicTargets(guardCtx(ctx), [input.topicId]);
       return ctx.topicDoctorRepo.diagnose(input);
     }),
 
@@ -333,6 +338,7 @@ export const messageRouter = router({
     .use(withScopedPermission('message:update'))
     .input(z.object({ agentId: z.string().nullish(), topicId: z.string() }))
     .mutation(async ({ ctx, input }) => {
+      await assertCanUseTopicTargets(guardCtx(ctx), [input.topicId]);
       return ctx.topicDoctorRepo.repair(input);
     }),
 
@@ -397,13 +403,26 @@ export const messageRouter = router({
       }
 
       // Authenticated access - require userId
-      if (!ctx.userId) {
+      const userId = ctx.userId;
+      if (!userId) {
         throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Authentication required' });
       }
 
       const wsId = ctx.workspaceId ?? undefined;
-      const messageModel = new MessageModel(ctx.serverDB, ctx.userId, wsId);
-      const fileService = new FileService(ctx.serverDB, ctx.userId, wsId);
+      const messageModel = new MessageModel(ctx.serverDB, userId, wsId);
+      const fileService = new FileService(ctx.serverDB, userId, wsId);
+      const accessCtx = guardCtx({ ...ctx, userId });
+
+      if (queryParams.threadId) {
+        await assertCanViewThreadTargets(accessCtx, [queryParams.threadId]);
+      }
+      if (queryParams.topicId) {
+        await assertCanViewTopicTargets(accessCtx, [queryParams.topicId]);
+      } else if (queryParams.sessionId) {
+        await assertCanViewSessionTargets(accessCtx, [queryParams.sessionId]);
+      } else {
+        await assertCanViewConversationTargets(accessCtx, [queryParams]);
+      }
 
       return messageModel.query(queryParams, {
         postProcessUrl: (path, file) => fileService.getFileAccessUrl({ id: file.id, url: path }),

--- a/apps/server/src/routers/lambda/recent.ts
+++ b/apps/server/src/routers/lambda/recent.ts
@@ -40,21 +40,28 @@ export const recentRouter = router({
       z
         .object({
           limit: z.number().optional(),
-          /** Restrict a workspace feed to the viewer's own items (mine/team toggle). */
+          /** @deprecated Use `view`; retained for clients deployed before the scope fix. */
           mineOnly: z.boolean().optional(),
           types: z.array(z.enum(['topic', 'document', 'task'])).optional(),
+          view: z.enum(['mine', 'team']).optional(),
           withTopicPreview: z.boolean().optional(),
         })
         .optional(),
     )
     .query(async ({ ctx, input }): Promise<RecentItem[]> => {
       const limit = input?.limit ?? 10;
+      const legacyView =
+        input?.mineOnly === undefined
+          ? undefined
+          : input.mineOnly
+            ? ('mine' as const)
+            : ('team' as const);
 
       const items = await ctx.recentModel.queryRecent(
         limit,
         input?.types,
         input?.withTopicPreview,
-        input?.mineOnly,
+        input?.view ?? legacyView,
       );
 
       return items.map((item) => {

--- a/apps/server/src/routers/lambda/thread.ts
+++ b/apps/server/src/routers/lambda/thread.ts
@@ -6,6 +6,7 @@ import { wsCompatProcedure } from '@/business/server/trpc-middlewares/workspaceA
 import { MessageModel } from '@/database/models/message';
 import { ThreadModel } from '@/database/models/thread';
 import { updateThreadSchema } from '@/database/schemas';
+import type { LobeChatDatabase } from '@/database/type';
 import { router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { type ThreadItem } from '@/types/topic/thread';
@@ -13,6 +14,13 @@ import { createThreadSchema } from '@/types/topic/thread';
 import { markdownToTxt } from '@/utils/markdownToTxt';
 
 import { assertWorkspaceRowManageable } from './_helpers/assertWorkspaceRowManageable';
+import { assertCanViewTopicTargets } from './_helpers/conversationResourceGuard';
+
+const guardCtx = (ctx: {
+  serverDB: LobeChatDatabase;
+  userId: string;
+  workspaceId?: string | null;
+}) => ({ db: ctx.serverDB, userId: ctx.userId, workspaceId: ctx.workspaceId });
 
 /**
  * `ThreadModel.create` uses `onConflictDoNothing()` and returns undefined when
@@ -101,6 +109,7 @@ export const threadRouter = router({
   getThreads: threadProcedure
     .input(z.object({ topicId: z.string() }))
     .query(async ({ input, ctx }) => {
+      await assertCanViewTopicTargets(guardCtx(ctx), [input.topicId]);
       return ctx.threadModel.queryByTopicId(input.topicId);
     }),
 

--- a/apps/server/src/routers/lambda/thread.ts
+++ b/apps/server/src/routers/lambda/thread.ts
@@ -14,7 +14,10 @@ import { createThreadSchema } from '@/types/topic/thread';
 import { markdownToTxt } from '@/utils/markdownToTxt';
 
 import { assertWorkspaceRowManageable } from './_helpers/assertWorkspaceRowManageable';
-import { assertCanViewTopicTargets } from './_helpers/conversationResourceGuard';
+import {
+  assertCanUseTopicTargets,
+  assertCanViewTopicTargets,
+} from './_helpers/conversationResourceGuard';
 
 const guardCtx = (ctx: {
   serverDB: LobeChatDatabase;
@@ -62,6 +65,8 @@ export const threadRouter = router({
     .use(withScopedPermission('topic:create'))
     .input(createThreadSchema)
     .mutation(async ({ input, ctx }) => {
+      await assertCanUseTopicTargets(guardCtx(ctx), [input.topicId]);
+
       const thread = ensureThreadCreated(
         await ctx.threadModel.create({
           id: input.id,
@@ -85,6 +90,8 @@ export const threadRouter = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
+      await assertCanUseTopicTargets(guardCtx(ctx), [input.topicId]);
+
       const thread = ensureThreadCreated(
         await ctx.threadModel.create({
           id: input.id,

--- a/apps/server/src/routers/lambda/topic.ts
+++ b/apps/server/src/routers/lambda/topic.ts
@@ -44,6 +44,9 @@ import {
   assertCanUseConversationTargets,
   assertCanUseSessionTargets,
   assertCanUseTopicTargets,
+  assertCanViewConversationTargets,
+  assertCanViewSessionTargets,
+  assertCanViewTopicTargets,
 } from './_helpers/conversationResourceGuard';
 import {
   batchResolveAgentIdFromSessions,
@@ -145,6 +148,7 @@ export const topicRouter = router({
   getTopicDetail: topicProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ input, ctx }) => {
+      await assertCanViewTopicTargets(guardCtx(ctx), [input.id]);
       const topic = await ctx.topicModel.findById(input.id);
       if (!topic) return null;
       return topic;
@@ -160,6 +164,7 @@ export const topicRouter = router({
       }),
     )
     .query(async ({ input, ctx }) => {
+      await assertCanViewTopicTargets(guardCtx(ctx), [input.topicId]);
       const topic = await ctx.topicModel.findById(input.topicId);
 
       if (!topic) {
@@ -185,6 +190,7 @@ export const topicRouter = router({
   getTopicContext: topicProcedure
     .input(z.object({ topicId: z.string() }))
     .query(async ({ input, ctx }) => {
+      await assertCanViewTopicTargets(guardCtx(ctx), [input.topicId]);
       const topic = await ctx.topicModel.findById(input.topicId);
 
       if (!topic) {
@@ -478,6 +484,7 @@ export const topicRouter = router({
   getShareInfo: topicProcedure
     .input(z.object({ topicId: z.string() }))
     .query(async ({ input, ctx }) => {
+      await assertCanViewTopicTargets(guardCtx(ctx), [input.topicId]);
       return ctx.topicShareModel.getByTopicId(input.topicId);
     }),
 
@@ -521,6 +528,7 @@ export const topicRouter = router({
 
       // If groupId is provided, query by groupId directly
       if (groupId) {
+        await assertCanViewConversationTargets(guardCtx(ctx), [{ groupId }]);
         const result = await ctx.topicModel.query({
           excludeStatuses,
           excludeTriggers,
@@ -541,6 +549,12 @@ export const topicRouter = router({
           ctx.userId,
           ctx.workspaceId ?? undefined,
         );
+      }
+
+      if (effectiveAgentId) {
+        await assertCanViewConversationTargets(guardCtx(ctx), [{ agentId: effectiveAgentId }]);
+      } else if (sessionId) {
+        await assertCanViewSessionTargets(guardCtx(ctx), [sessionId]);
       }
 
       const result = await ctx.topicModel.query({
@@ -838,6 +852,15 @@ export const topicRouter = router({
       }),
     )
     .query(async ({ input, ctx }) => {
+      if (input.groupId) {
+        await assertCanViewConversationTargets(guardCtx(ctx), [{ groupId: input.groupId }]);
+      }
+      if (input.agentId) {
+        await assertCanViewConversationTargets(guardCtx(ctx), [{ agentId: input.agentId }]);
+      } else if (input.sessionId) {
+        await assertCanViewSessionTargets(guardCtx(ctx), [input.sessionId]);
+      }
+
       const resolved = await resolveContext(
         { agentId: input.agentId, sessionId: input.sessionId },
         ctx.serverDB,

--- a/apps/server/src/routers/lambda/topic.ts
+++ b/apps/server/src/routers/lambda/topic.ts
@@ -854,8 +854,7 @@ export const topicRouter = router({
     .query(async ({ input, ctx }) => {
       if (input.groupId) {
         await assertCanViewConversationTargets(guardCtx(ctx), [{ groupId: input.groupId }]);
-      }
-      if (input.agentId) {
+      } else if (input.agentId) {
         await assertCanViewConversationTargets(guardCtx(ctx), [{ agentId: input.agentId }]);
       } else if (input.sessionId) {
         await assertCanViewSessionTargets(guardCtx(ctx), [input.sessionId]);

--- a/packages/database/src/models/__tests__/messages/message.query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.query.test.ts
@@ -1415,7 +1415,7 @@ describe('MessageModel Query Tests', () => {
       expect(result[1].id).toBe('1');
     });
 
-    it('does not return another workspace member private agent messages', async () => {
+    it('does not let direct message targets override private topic visibility', async () => {
       await serverDB.insert(workspaces).values({
         id: 'message-list-workspace',
         name: 'Message List Workspace',
@@ -1436,6 +1436,13 @@ describe('MessageModel Query Tests', () => {
           workspaceId: 'message-list-workspace',
         },
       ]);
+      await serverDB.insert(chatGroups).values({
+        id: 'message-list-public-group',
+        title: 'Message List Public Group',
+        userId,
+        visibility: 'public',
+        workspaceId: 'message-list-workspace',
+      });
       await serverDB.insert(topics).values([
         {
           agentId: 'message-list-public-agent',
@@ -1467,15 +1474,36 @@ describe('MessageModel Query Tests', () => {
           userId,
           workspaceId: 'message-list-workspace',
         },
+        {
+          agentId: 'message-list-public-agent',
+          content: 'private workspace child-agent message',
+          id: 'message-list-private-child-message',
+          role: 'assistant',
+          topicId: 'message-list-private-topic',
+          userId,
+          workspaceId: 'message-list-workspace',
+        },
+        {
+          content: 'private workspace child-group message',
+          groupId: 'message-list-public-group',
+          id: 'message-list-private-child-group-message',
+          role: 'assistant',
+          topicId: 'message-list-private-topic',
+          userId,
+          workspaceId: 'message-list-workspace',
+        },
       ]);
 
-      const result = await new MessageModel(
-        serverDB,
-        otherUserId,
-        'message-list-workspace',
-      ).queryAll();
+      const memberModel = new MessageModel(serverDB, otherUserId, 'message-list-workspace');
 
-      expect(result.map((message) => message.id)).toEqual(['message-list-public-message']);
+      await expect(memberModel.queryAll()).resolves.toEqual([
+        expect.objectContaining({ id: 'message-list-public-message' }),
+      ]);
+      if (process.env.TEST_SERVER_DB === '1') {
+        await expect(memberModel.queryByKeyword('workspace')).resolves.toEqual([
+          expect.objectContaining({ id: 'message-list-public-message' }),
+        ]);
+      }
     });
 
     it('inherits legacy session visibility from the linked agent', async () => {

--- a/packages/database/src/models/__tests__/messages/message.query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.query.test.ts
@@ -24,6 +24,7 @@ import {
   threads,
   topics,
   users,
+  workspaces,
 } from '../../../schemas';
 import type { LobeChatDatabase } from '../../../type';
 import { MessageModel } from '../../message';
@@ -1412,6 +1413,69 @@ describe('MessageModel Query Tests', () => {
       expect(result).toHaveLength(2);
       expect(result[0].id).toBe('2');
       expect(result[1].id).toBe('1');
+    });
+
+    it('does not return another workspace member private agent messages', async () => {
+      await serverDB.insert(workspaces).values({
+        id: 'message-list-workspace',
+        name: 'Message List Workspace',
+        primaryOwnerId: userId,
+        slug: 'message-list-workspace',
+      });
+      await serverDB.insert(agents).values([
+        {
+          id: 'message-list-public-agent',
+          userId,
+          visibility: 'public',
+          workspaceId: 'message-list-workspace',
+        },
+        {
+          id: 'message-list-private-agent',
+          userId,
+          visibility: 'private',
+          workspaceId: 'message-list-workspace',
+        },
+      ]);
+      await serverDB.insert(topics).values([
+        {
+          agentId: 'message-list-public-agent',
+          id: 'message-list-public-topic',
+          userId,
+          workspaceId: 'message-list-workspace',
+        },
+        {
+          agentId: 'message-list-private-agent',
+          id: 'message-list-private-topic',
+          userId,
+          workspaceId: 'message-list-workspace',
+        },
+      ]);
+      await serverDB.insert(messages).values([
+        {
+          content: 'public workspace message',
+          id: 'message-list-public-message',
+          role: 'assistant',
+          topicId: 'message-list-public-topic',
+          userId,
+          workspaceId: 'message-list-workspace',
+        },
+        {
+          content: 'private workspace message',
+          id: 'message-list-private-message',
+          role: 'assistant',
+          topicId: 'message-list-private-topic',
+          userId,
+          workspaceId: 'message-list-workspace',
+        },
+      ]);
+
+      const result = await new MessageModel(
+        serverDB,
+        otherUserId,
+        'message-list-workspace',
+      ).queryAll();
+
+      expect(result.map((message) => message.id)).toEqual(['message-list-public-message']);
     });
   });
 

--- a/packages/database/src/models/__tests__/messages/message.query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.query.test.ts
@@ -1477,6 +1477,93 @@ describe('MessageModel Query Tests', () => {
 
       expect(result.map((message) => message.id)).toEqual(['message-list-public-message']);
     });
+
+    it('inherits legacy session visibility from the linked agent', async () => {
+      const workspaceId = 'message-legacy-workspace';
+      await serverDB.insert(workspaces).values({
+        id: workspaceId,
+        name: 'Message Legacy Workspace',
+        primaryOwnerId: userId,
+        slug: workspaceId,
+      });
+      await serverDB.insert(sessions).values([
+        { id: 'message-legacy-public-session', userId, workspaceId },
+        { id: 'message-legacy-private-session', userId, workspaceId },
+      ]);
+      await serverDB.insert(agents).values([
+        {
+          id: 'message-legacy-public-agent',
+          userId,
+          visibility: 'public',
+          workspaceId,
+        },
+        {
+          id: 'message-legacy-private-agent',
+          userId,
+          visibility: 'private',
+          workspaceId,
+        },
+      ]);
+      await serverDB.insert(agentsToSessions).values([
+        {
+          agentId: 'message-legacy-public-agent',
+          sessionId: 'message-legacy-public-session',
+          userId,
+          workspaceId,
+        },
+        {
+          agentId: 'message-legacy-private-agent',
+          sessionId: 'message-legacy-private-session',
+          userId,
+          workspaceId,
+        },
+      ]);
+      await serverDB.insert(topics).values([
+        {
+          id: 'message-legacy-public-topic',
+          sessionId: 'message-legacy-public-session',
+          userId,
+          workspaceId,
+        },
+        {
+          id: 'message-legacy-private-topic',
+          sessionId: 'message-legacy-private-session',
+          userId,
+          workspaceId,
+        },
+      ]);
+      await serverDB.insert(messages).values([
+        {
+          content: 'legacy public message',
+          createdAt: new Date('2024-01-01'),
+          id: 'message-legacy-public',
+          role: 'assistant',
+          topicId: 'message-legacy-public-topic',
+          userId,
+          workspaceId,
+        },
+        {
+          content: 'legacy private message',
+          createdAt: new Date('2024-01-02'),
+          id: 'message-legacy-private',
+          role: 'assistant',
+          topicId: 'message-legacy-private-topic',
+          userId,
+          workspaceId,
+        },
+      ]);
+
+      const memberModel = new MessageModel(serverDB, otherUserId, workspaceId);
+      const ownerModel = new MessageModel(serverDB, userId, workspaceId);
+
+      await expect(memberModel.queryAll()).resolves.toEqual([
+        expect.objectContaining({ id: 'message-legacy-public' }),
+      ]);
+      await expect(ownerModel.queryAll()).resolves.toEqual([
+        expect.objectContaining({ id: 'message-legacy-private' }),
+        expect.objectContaining({ id: 'message-legacy-public' }),
+      ]);
+    });
   });
 
   describe('findById', () => {

--- a/packages/database/src/models/__tests__/messages/message.workspace.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.workspace.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { INBOX_SESSION_ID } from '@lobechat/const';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../../core/getTestDB';
@@ -81,6 +82,48 @@ describe('MessageModel workspace scope', () => {
         topicId: 'workspace-topic',
       }),
     ).resolves.toEqual([expect.objectContaining({ id: 'workspace-message' })]);
+  });
+
+  it('scopes root and inbox messages to their creator', async () => {
+    const memberId = 'message-workspace-root-member';
+    await serverDB.insert(users).values({ id: memberId });
+    await serverDB.insert(messages).values([
+      {
+        content: 'owner root message',
+        id: 'owner-root-message',
+        role: 'user',
+        userId,
+        workspaceId,
+      },
+      {
+        content: 'member root message',
+        id: 'member-root-message',
+        role: 'user',
+        userId: memberId,
+        workspaceId,
+      },
+      {
+        content: 'shared topic message',
+        id: 'shared-topic-message',
+        role: 'user',
+        sessionId: 'workspace-session',
+        topicId: 'workspace-topic',
+        userId,
+        workspaceId,
+      },
+    ]);
+
+    const memberModel = new MessageModel(serverDB, memberId, workspaceId);
+
+    await expect(memberModel.query({})).resolves.toEqual([
+      expect.objectContaining({ id: 'member-root-message' }),
+    ]);
+    await expect(memberModel.query({ sessionId: INBOX_SESSION_ID })).resolves.toEqual([
+      expect.objectContaining({ id: 'member-root-message' }),
+    ]);
+    await expect(memberModel.query({ topicId: 'workspace-topic' })).resolves.toEqual([
+      expect.objectContaining({ id: 'shared-topic-message' }),
+    ]);
   });
 
   describe('message file references after a visibility flip', () => {

--- a/packages/database/src/models/__tests__/recent.test.ts
+++ b/packages/database/src/models/__tests__/recent.test.ts
@@ -632,7 +632,13 @@ describe('RecentModel', () => {
         await serverDB
           .insert(workspaces)
           .values({ id: workspaceId, name: 'ws', primaryOwnerId: userId, slug: workspaceId });
-        await serverDB.insert(agents).values({ id: 'agent-ws', userId, slug: 'inbox' });
+        await serverDB.insert(agents).values({
+          id: 'agent-ws',
+          slug: 'inbox',
+          userId,
+          visibility: 'public',
+          workspaceId,
+        });
         await serverDB.insert(topics).values([
           {
             agentId: 'agent-ws',
@@ -660,11 +666,84 @@ describe('RecentModel', () => {
         expect(result.map((r) => r.userId)).toEqual([userId, otherUserId]);
       });
 
-      it('narrows to the viewer own topics when mineOnly is set', async () => {
-        const result = await workspaceModel.queryRecent(10, ['topic'], false, true);
+      it('narrows to the viewer own topics in Mine', async () => {
+        const result = await workspaceModel.queryRecent(10, ['topic'], false, 'mine');
 
         expect(result.map((r) => r.id)).toEqual(['topic-ws-mine']);
         expect(result[0].userId).toBe(userId);
+      });
+
+      it('keeps the viewer own private topic in the accessible feed', async () => {
+        await serverDB.insert(agents).values([
+          {
+            id: 'agent-ws-private-mine',
+            userId,
+            visibility: 'private',
+            workspaceId,
+          },
+          {
+            id: 'agent-ws-private-other',
+            userId: otherUserId,
+            visibility: 'private',
+            workspaceId,
+          },
+        ]);
+        await serverDB.insert(topics).values([
+          {
+            agentId: 'agent-ws-private-mine',
+            id: 'topic-ws-private-mine',
+            updatedAt: now(),
+            userId,
+            workspaceId,
+          },
+          {
+            agentId: 'agent-ws-private-other',
+            id: 'topic-ws-private-other',
+            updatedAt: now(),
+            userId: otherUserId,
+            workspaceId,
+          },
+        ]);
+
+        const result = await workspaceModel.queryRecent(10, ['topic']);
+
+        expect(result.map((r) => r.id)).toContain('topic-ws-private-mine');
+        expect(result.map((r) => r.id)).not.toContain('topic-ws-private-other');
+      });
+
+      it('excludes private agent and group topics from Team before applying the limit', async () => {
+        await serverDB.insert(agents).values({
+          id: 'agent-ws-private-team',
+          userId,
+          visibility: 'private',
+          workspaceId,
+        });
+        await serverDB.insert(chatGroups).values({
+          id: 'group-ws-private-team',
+          userId,
+          visibility: 'private',
+          workspaceId,
+        });
+        await serverDB.insert(topics).values([
+          {
+            agentId: 'agent-ws-private-team',
+            id: 'topic-ws-private-agent',
+            updatedAt: now(),
+            userId,
+            workspaceId,
+          },
+          {
+            groupId: 'group-ws-private-team',
+            id: 'topic-ws-private-group',
+            updatedAt: now(),
+            userId,
+            workspaceId,
+          },
+        ]);
+
+        const result = await workspaceModel.queryRecent(2, ['topic'], false, 'team');
+
+        expect(result.map((r) => r.id)).toEqual(['topic-ws-mine', 'topic-ws-other']);
       });
     });
   });

--- a/packages/database/src/models/__tests__/recent.test.ts
+++ b/packages/database/src/models/__tests__/recent.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { sql } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../core/getTestDB';
@@ -822,6 +823,34 @@ describe('RecentModel', () => {
           expect.arrayContaining([expect.objectContaining({ id: 'recent-legacy-public-topic' })]),
         );
         expect(team.map((item) => item.id)).not.toContain('recent-legacy-private-topic');
+      });
+
+      it('treats legacy NULL visibility as public in Team', async () => {
+        await serverDB.execute(sql`ALTER TABLE agents ALTER COLUMN visibility DROP NOT NULL`);
+
+        try {
+          await serverDB.execute(
+            sql`INSERT INTO agents (id, user_id, workspace_id, visibility) VALUES (${'recent-legacy-null-agent'}, ${otherUserId}, ${workspaceId}, NULL)`,
+          );
+          await serverDB.insert(topics).values({
+            agentId: 'recent-legacy-null-agent',
+            id: 'recent-legacy-null-topic',
+            updatedAt: now(),
+            userId: otherUserId,
+            workspaceId,
+          });
+
+          const team = await workspaceModel.queryRecent(10, ['topic'], false, 'team');
+
+          expect(team).toEqual(
+            expect.arrayContaining([expect.objectContaining({ id: 'recent-legacy-null-topic' })]),
+          );
+        } finally {
+          await serverDB.execute(
+            sql`UPDATE agents SET visibility = 'public' WHERE visibility IS NULL`,
+          );
+          await serverDB.execute(sql`ALTER TABLE agents ALTER COLUMN visibility SET NOT NULL`);
+        }
       });
     });
   });

--- a/packages/database/src/models/__tests__/recent.test.ts
+++ b/packages/database/src/models/__tests__/recent.test.ts
@@ -4,10 +4,12 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { getTestDB } from '../../core/getTestDB';
 import {
   agents,
+  agentsToSessions,
   chatGroups,
   documents,
   knowledgeBases,
   messages,
+  sessions,
   tasks,
   topics,
   users,
@@ -744,6 +746,82 @@ describe('RecentModel', () => {
         const result = await workspaceModel.queryRecent(2, ['topic'], false, 'team');
 
         expect(result.map((r) => r.id)).toEqual(['topic-ws-mine', 'topic-ws-other']);
+      });
+
+      it('preserves legacy session topic visibility and routing across Mine and Team', async () => {
+        await serverDB.insert(sessions).values([
+          { id: 'recent-legacy-public-session', userId: otherUserId, workspaceId },
+          { id: 'recent-legacy-private-session', userId, workspaceId },
+        ]);
+        await serverDB.insert(agents).values([
+          {
+            id: 'recent-legacy-public-agent',
+            userId: otherUserId,
+            visibility: 'public',
+            workspaceId,
+          },
+          {
+            id: 'recent-legacy-private-agent',
+            userId,
+            visibility: 'private',
+            workspaceId,
+          },
+        ]);
+        await serverDB.insert(agentsToSessions).values([
+          {
+            agentId: 'recent-legacy-public-agent',
+            sessionId: 'recent-legacy-public-session',
+            userId: otherUserId,
+            workspaceId,
+          },
+          {
+            agentId: 'recent-legacy-private-agent',
+            sessionId: 'recent-legacy-private-session',
+            userId,
+            workspaceId,
+          },
+        ]);
+        await serverDB.insert(topics).values([
+          {
+            id: 'recent-legacy-public-topic',
+            sessionId: 'recent-legacy-public-session',
+            updatedAt: now(),
+            userId: otherUserId,
+            workspaceId,
+          },
+          {
+            id: 'recent-legacy-private-topic',
+            sessionId: 'recent-legacy-private-session',
+            updatedAt: now(),
+            userId,
+            workspaceId,
+          },
+        ]);
+
+        const accessible = await workspaceModel.queryRecent(10, ['topic']);
+        const mine = await workspaceModel.queryRecent(10, ['topic'], false, 'mine');
+        const team = await workspaceModel.queryRecent(10, ['topic'], false, 'team');
+
+        expect(accessible).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: 'recent-legacy-public-topic',
+              routeId: 'recent-legacy-public-agent',
+            }),
+            expect.objectContaining({
+              id: 'recent-legacy-private-topic',
+              routeId: 'recent-legacy-private-agent',
+            }),
+          ]),
+        );
+        expect(mine).toEqual(
+          expect.arrayContaining([expect.objectContaining({ id: 'recent-legacy-private-topic' })]),
+        );
+        expect(mine.map((item) => item.id)).not.toContain('recent-legacy-public-topic');
+        expect(team).toEqual(
+          expect.arrayContaining([expect.objectContaining({ id: 'recent-legacy-public-topic' })]),
+        );
+        expect(team.map((item) => item.id)).not.toContain('recent-legacy-private-topic');
       });
     });
   });

--- a/packages/database/src/models/__tests__/thread.test.ts
+++ b/packages/database/src/models/__tests__/thread.test.ts
@@ -7,6 +7,7 @@ import {
   agentOperations,
   agents,
   agentsToSessions,
+  chatGroups,
   messages,
   sessions,
   threads,
@@ -100,7 +101,7 @@ describe('ThreadModel', () => {
   });
 
   describe('query visibility', () => {
-    it('does not return another workspace member private agent threads', async () => {
+    it('requires parent-topic access before exposing direct thread targets', async () => {
       await serverDB.insert(workspaces).values({
         id: 'thread-visibility-workspace',
         name: 'Thread Visibility Workspace',
@@ -121,6 +122,13 @@ describe('ThreadModel', () => {
           workspaceId: 'thread-visibility-workspace',
         },
       ]);
+      await serverDB.insert(chatGroups).values({
+        id: 'thread-public-group',
+        title: 'Thread Public Group',
+        userId,
+        visibility: 'public',
+        workspaceId: 'thread-visibility-workspace',
+      });
       await serverDB.insert(topics).values([
         {
           agentId: 'thread-public-agent',
@@ -145,6 +153,22 @@ describe('ThreadModel', () => {
         },
         {
           id: 'thread-private',
+          topicId: 'thread-private-topic',
+          type: ThreadType.Standalone,
+          userId,
+          workspaceId: 'thread-visibility-workspace',
+        },
+        {
+          agentId: 'thread-public-agent',
+          id: 'thread-private-public-child-agent',
+          topicId: 'thread-private-topic',
+          type: ThreadType.Standalone,
+          userId,
+          workspaceId: 'thread-visibility-workspace',
+        },
+        {
+          groupId: 'thread-public-group',
+          id: 'thread-private-public-child-group',
           topicId: 'thread-private-topic',
           type: ThreadType.Standalone,
           userId,

--- a/packages/database/src/models/__tests__/thread.test.ts
+++ b/packages/database/src/models/__tests__/thread.test.ts
@@ -6,6 +6,7 @@ import { getTestDB } from '../../core/getTestDB';
 import {
   agentOperations,
   agents,
+  agentsToSessions,
   messages,
   sessions,
   threads,
@@ -157,6 +158,92 @@ describe('ThreadModel', () => {
         expect.objectContaining({ id: 'thread-public' }),
       ]);
       await expect(model.queryByTopicId('thread-private-topic')).resolves.toEqual([]);
+    });
+
+    it('inherits legacy session visibility from the linked agent', async () => {
+      const workspaceId = 'thread-legacy-workspace';
+      await serverDB.insert(workspaces).values({
+        id: workspaceId,
+        name: 'Thread Legacy Workspace',
+        primaryOwnerId: userId,
+        slug: workspaceId,
+      });
+      await serverDB.insert(sessions).values([
+        { id: 'thread-legacy-public-session', userId, workspaceId },
+        { id: 'thread-legacy-private-session', userId, workspaceId },
+      ]);
+      await serverDB.insert(agents).values([
+        {
+          id: 'thread-legacy-public-agent',
+          userId,
+          visibility: 'public',
+          workspaceId,
+        },
+        {
+          id: 'thread-legacy-private-agent',
+          userId,
+          visibility: 'private',
+          workspaceId,
+        },
+      ]);
+      await serverDB.insert(agentsToSessions).values([
+        {
+          agentId: 'thread-legacy-public-agent',
+          sessionId: 'thread-legacy-public-session',
+          userId,
+          workspaceId,
+        },
+        {
+          agentId: 'thread-legacy-private-agent',
+          sessionId: 'thread-legacy-private-session',
+          userId,
+          workspaceId,
+        },
+      ]);
+      await serverDB.insert(topics).values([
+        {
+          id: 'thread-legacy-public-topic',
+          sessionId: 'thread-legacy-public-session',
+          userId,
+          workspaceId,
+        },
+        {
+          id: 'thread-legacy-private-topic',
+          sessionId: 'thread-legacy-private-session',
+          userId,
+          workspaceId,
+        },
+      ]);
+      await serverDB.insert(threads).values([
+        {
+          id: 'thread-legacy-public',
+          topicId: 'thread-legacy-public-topic',
+          type: ThreadType.Standalone,
+          userId,
+          workspaceId,
+        },
+        {
+          id: 'thread-legacy-private',
+          topicId: 'thread-legacy-private-topic',
+          type: ThreadType.Standalone,
+          userId,
+          workspaceId,
+        },
+      ]);
+
+      const memberModel = new ThreadModel(serverDB, otherUserId, workspaceId);
+      const ownerModel = new ThreadModel(serverDB, userId, workspaceId);
+
+      await expect(memberModel.query()).resolves.toEqual([
+        expect.objectContaining({ id: 'thread-legacy-public' }),
+      ]);
+      await expect(memberModel.queryByTopicId('thread-legacy-public-topic')).resolves.toEqual([
+        expect.objectContaining({ id: 'thread-legacy-public' }),
+      ]);
+      await expect(memberModel.queryByTopicId('thread-legacy-private-topic')).resolves.toEqual([]);
+      await expect(ownerModel.queryByTopicId('thread-legacy-private-topic')).resolves.toEqual([
+        expect.objectContaining({ id: 'thread-legacy-private' }),
+      ]);
     });
   });
 

--- a/packages/database/src/models/__tests__/thread.test.ts
+++ b/packages/database/src/models/__tests__/thread.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { getTestDB } from '../../core/getTestDB';
 import {
   agentOperations,
+  agents,
   messages,
   sessions,
   threads,
@@ -94,6 +95,68 @@ describe('ThreadModel', () => {
         type: ThreadType.Standalone,
       });
       expect(second).toBeUndefined();
+    });
+  });
+
+  describe('query visibility', () => {
+    it('does not return another workspace member private agent threads', async () => {
+      await serverDB.insert(workspaces).values({
+        id: 'thread-visibility-workspace',
+        name: 'Thread Visibility Workspace',
+        primaryOwnerId: userId,
+        slug: 'thread-visibility-workspace',
+      });
+      await serverDB.insert(agents).values([
+        {
+          id: 'thread-public-agent',
+          userId,
+          visibility: 'public',
+          workspaceId: 'thread-visibility-workspace',
+        },
+        {
+          id: 'thread-private-agent',
+          userId,
+          visibility: 'private',
+          workspaceId: 'thread-visibility-workspace',
+        },
+      ]);
+      await serverDB.insert(topics).values([
+        {
+          agentId: 'thread-public-agent',
+          id: 'thread-public-topic',
+          userId,
+          workspaceId: 'thread-visibility-workspace',
+        },
+        {
+          agentId: 'thread-private-agent',
+          id: 'thread-private-topic',
+          userId,
+          workspaceId: 'thread-visibility-workspace',
+        },
+      ]);
+      await serverDB.insert(threads).values([
+        {
+          id: 'thread-public',
+          topicId: 'thread-public-topic',
+          type: ThreadType.Standalone,
+          userId,
+          workspaceId: 'thread-visibility-workspace',
+        },
+        {
+          id: 'thread-private',
+          topicId: 'thread-private-topic',
+          type: ThreadType.Standalone,
+          userId,
+          workspaceId: 'thread-visibility-workspace',
+        },
+      ]);
+
+      const model = new ThreadModel(serverDB, otherUserId, 'thread-visibility-workspace');
+
+      await expect(model.query()).resolves.toEqual([
+        expect.objectContaining({ id: 'thread-public' }),
+      ]);
+      await expect(model.queryByTopicId('thread-private-topic')).resolves.toEqual([]);
     });
   });
 

--- a/packages/database/src/models/__tests__/topics/topic.query.test.ts
+++ b/packages/database/src/models/__tests__/topics/topic.query.test.ts
@@ -110,6 +110,204 @@ describe('TopicModel - Query', () => {
       });
     });
 
+    it('should inherit visibility from the linked agent for legacy session-only topics', async () => {
+      await serverDB.insert(workspaces).values({
+        id: 'legacy-topic-workspace',
+        name: 'Legacy Topic Workspace',
+        primaryOwnerId: userId,
+        slug: 'legacy-topic-workspace',
+      });
+      await serverDB.insert(sessions).values([
+        { id: 'legacy-public-session', userId, workspaceId: 'legacy-topic-workspace' },
+        { id: 'legacy-private-session', userId, workspaceId: 'legacy-topic-workspace' },
+        { id: 'legacy-unmapped-session', userId, workspaceId: 'legacy-topic-workspace' },
+      ]);
+      await serverDB.insert(agents).values([
+        {
+          id: 'legacy-public-agent',
+          userId,
+          visibility: 'public',
+          workspaceId: 'legacy-topic-workspace',
+        },
+        {
+          id: 'legacy-private-agent',
+          userId,
+          visibility: 'private',
+          workspaceId: 'legacy-topic-workspace',
+        },
+      ]);
+      await serverDB.insert(agentsToSessions).values([
+        {
+          agentId: 'legacy-public-agent',
+          sessionId: 'legacy-public-session',
+          userId,
+          workspaceId: 'legacy-topic-workspace',
+        },
+        {
+          agentId: 'legacy-private-agent',
+          sessionId: 'legacy-private-session',
+          userId,
+          workspaceId: 'legacy-topic-workspace',
+        },
+      ]);
+      await serverDB.insert(topics).values([
+        {
+          id: 'legacy-public-topic',
+          sessionId: 'legacy-public-session',
+          userId,
+          workspaceId: 'legacy-topic-workspace',
+        },
+        {
+          id: 'legacy-private-topic',
+          sessionId: 'legacy-private-session',
+          userId,
+          workspaceId: 'legacy-topic-workspace',
+        },
+        {
+          id: 'legacy-unmapped-topic',
+          sessionId: 'legacy-unmapped-session',
+          userId,
+          workspaceId: 'legacy-topic-workspace',
+        },
+      ]);
+
+      const memberModel = new TopicModel(serverDB, userId2, 'legacy-topic-workspace');
+      const ownerModel = new TopicModel(serverDB, userId, 'legacy-topic-workspace');
+
+      await expect(
+        memberModel.query({ containerId: 'legacy-public-session' }),
+      ).resolves.toMatchObject({
+        items: [expect.objectContaining({ id: 'legacy-public-topic' })],
+        total: 1,
+      });
+      await expect(
+        memberModel.query({ containerId: 'legacy-private-session' }),
+      ).resolves.toMatchObject({ items: [], total: 0 });
+      await expect(
+        memberModel.query({ containerId: 'legacy-unmapped-session' }),
+      ).resolves.toMatchObject({ items: [], total: 0 });
+      await expect(
+        ownerModel.query({ containerId: 'legacy-private-session' }),
+      ).resolves.toMatchObject({
+        items: [expect.objectContaining({ id: 'legacy-private-topic' })],
+        total: 1,
+      });
+      await expect(
+        ownerModel.query({ containerId: 'legacy-unmapped-session' }),
+      ).resolves.toMatchObject({
+        items: [expect.objectContaining({ id: 'legacy-unmapped-topic' })],
+        total: 1,
+      });
+    });
+
+    it('should fail closed for foreign and mixed legacy session mappings', async () => {
+      const workspaceId = 'legacy-mapping-workspace';
+      await serverDB.insert(workspaces).values({
+        id: workspaceId,
+        name: 'Legacy Mapping Workspace',
+        primaryOwnerId: userId,
+        slug: workspaceId,
+      });
+      await serverDB.insert(sessions).values([
+        { id: 'legacy-foreign-session', userId, workspaceId },
+        { id: 'legacy-mixed-session', userId, workspaceId },
+        { id: 'legacy-other-creator-session', userId: userId2, workspaceId },
+      ]);
+      await serverDB.insert(agents).values([
+        { id: 'legacy-foreign-agent', userId, visibility: 'public' },
+        {
+          id: 'legacy-mixed-public-agent',
+          userId,
+          visibility: 'public',
+          workspaceId,
+        },
+        {
+          id: 'legacy-mixed-private-agent',
+          userId,
+          visibility: 'private',
+          workspaceId,
+        },
+      ]);
+      await serverDB.insert(agentsToSessions).values([
+        {
+          agentId: 'legacy-foreign-agent',
+          sessionId: 'legacy-foreign-session',
+          userId,
+          workspaceId,
+        },
+        {
+          agentId: 'legacy-mixed-public-agent',
+          sessionId: 'legacy-mixed-session',
+          userId,
+          workspaceId,
+        },
+        {
+          agentId: 'legacy-mixed-private-agent',
+          sessionId: 'legacy-mixed-session',
+          userId,
+          workspaceId,
+        },
+        {
+          agentId: 'legacy-mixed-private-agent',
+          sessionId: 'legacy-other-creator-session',
+          userId,
+          workspaceId,
+        },
+      ]);
+      await serverDB.insert(topics).values([
+        {
+          id: 'legacy-foreign-topic',
+          sessionId: 'legacy-foreign-session',
+          userId,
+          workspaceId,
+        },
+        {
+          id: 'legacy-mixed-topic',
+          sessionId: 'legacy-mixed-session',
+          userId,
+          workspaceId,
+        },
+        {
+          id: 'legacy-other-creator-topic',
+          sessionId: 'legacy-other-creator-session',
+          userId: userId2,
+          workspaceId,
+        },
+      ]);
+
+      const memberModel = new TopicModel(serverDB, userId2, workspaceId);
+      const ownerModel = new TopicModel(serverDB, userId, workspaceId);
+
+      for (const containerId of [
+        'legacy-foreign-session',
+        'legacy-mixed-session',
+        'legacy-other-creator-session',
+      ]) {
+        await expect(memberModel.query({ containerId })).resolves.toMatchObject({
+          items: [],
+          total: 0,
+        });
+      }
+      await expect(
+        ownerModel.query({ containerId: 'legacy-foreign-session' }),
+      ).resolves.toMatchObject({
+        items: [expect.objectContaining({ id: 'legacy-foreign-topic' })],
+        total: 1,
+      });
+      await expect(
+        ownerModel.query({ containerId: 'legacy-mixed-session' }),
+      ).resolves.toMatchObject({
+        items: [expect.objectContaining({ id: 'legacy-mixed-topic' })],
+        total: 1,
+      });
+      await expect(
+        ownerModel.query({ containerId: 'legacy-other-creator-session' }),
+      ).resolves.toMatchObject({
+        items: [expect.objectContaining({ id: 'legacy-other-creator-topic' })],
+        total: 1,
+      });
+    });
+
     it('should order by status priority when sortBy is "status"', async () => {
       await serverDB.insert(topics).values([
         // favorite floats to the top regardless of its (lower-priority) status

--- a/packages/database/src/models/__tests__/topics/topic.query.test.ts
+++ b/packages/database/src/models/__tests__/topics/topic.query.test.ts
@@ -213,7 +213,7 @@ describe('TopicModel - Query', () => {
       // The client sorts the sidebar by `sortUpdatedAt`, so it must carry the same
       // activity time the server ORDER BY uses (topicActivityAt) — otherwise the two
       // sorts disagree and the list jumps. `updatedAt` stays the raw row value so
-      // rename/favorite edits still show a real edit time. 
+      // rename/favorite edits still show a real edit time.
       await serverDB.insert(topics).values([
         { id: 'has-msg', sessionId, updatedAt: new Date('2023-01-01'), userId },
         { id: 'no-msg', sessionId, updatedAt: new Date('2023-03-01'), userId },
@@ -735,34 +735,22 @@ describe('TopicModel - Query', () => {
       expect(result.items[0].id).toBe('user-topic');
     });
 
-    it('should only lookup agentsToSessions for current user', async () => {
+    it('should not return a topic linked to another user agent', async () => {
       const otherUserId = 'other-user-for-topic-test-2';
 
       await serverDB.transaction(async (trx) => {
         await trx.insert(users).values([{ id: otherUserId }]);
-        await trx.insert(sessions).values([
-          { id: 'user-session', userId },
-          { id: 'other-user-session', userId: otherUserId },
-        ]);
-        await trx.insert(agents).values([
-          { id: 'user-agent', userId, title: 'User Agent' },
-          { id: 'other-user-agent', userId: otherUserId, title: 'Other User Agent' },
-        ]);
         await trx
-          .insert(agentsToSessions)
-          .values([
-            { agentId: 'other-user-agent', sessionId: 'other-user-session', userId: otherUserId },
-          ]);
-        await trx.insert(topics).values([
-          { id: 'topic-user', userId, agentId: 'other-user-agent' },
-          { id: 'topic-other-user', userId: otherUserId, sessionId: 'other-user-session' },
-        ]);
+          .insert(agents)
+          .values([{ id: 'other-user-agent', userId: otherUserId, title: 'Other User Agent' }]);
+        await trx
+          .insert(topics)
+          .values([{ id: 'topic-user', userId, agentId: 'other-user-agent' }]);
       });
 
       const result = await topicModel.query({ agentId: 'other-user-agent' });
 
-      expect(result.items).toHaveLength(1);
-      expect(result.items[0].id).toBe('topic-user');
+      expect(result.items).toHaveLength(0);
     });
 
     it('should work with agentId and pagination', async () => {

--- a/packages/database/src/models/__tests__/topics/topic.stats.test.ts
+++ b/packages/database/src/models/__tests__/topics/topic.stats.test.ts
@@ -1,7 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../../core/getTestDB';
-import { agents, agentsToSessions, messages, sessions, topics, users } from '../../../schemas';
+import {
+  agents,
+  agentsToSessions,
+  messages,
+  sessions,
+  topics,
+  users,
+  workspaces,
+} from '../../../schemas';
 import type { LobeChatDatabase } from '../../../type';
 import { TopicModel } from '../../topic';
 
@@ -99,6 +107,64 @@ describe('TopicModel - Stats', () => {
         const result = await topicModel.count({ agentId: 'empty-agent' });
         expect(result).toBe(0);
       });
+    });
+
+    it('counts only topics whose resources are visible in a workspace', async () => {
+      const workspaceId = 'topic-count-workspace';
+      await serverDB.insert(workspaces).values({
+        id: workspaceId,
+        name: 'Topic Count Workspace',
+        primaryOwnerId: userId,
+        slug: workspaceId,
+      });
+      await serverDB.insert(agents).values([
+        {
+          id: 'count-workspace-public-agent',
+          userId,
+          visibility: 'public',
+          workspaceId,
+        },
+        {
+          id: 'count-workspace-private-agent',
+          userId,
+          visibility: 'private',
+          workspaceId,
+        },
+        {
+          id: 'count-workspace-own-private-agent',
+          userId: userId2,
+          visibility: 'private',
+          workspaceId,
+        },
+      ]);
+      await serverDB.insert(topics).values([
+        {
+          agentId: 'count-workspace-public-agent',
+          id: 'count-workspace-public-topic',
+          userId,
+          workspaceId,
+        },
+        {
+          agentId: 'count-workspace-private-agent',
+          id: 'count-workspace-private-topic',
+          userId,
+          workspaceId,
+        },
+        {
+          agentId: 'count-workspace-own-private-agent',
+          id: 'count-workspace-own-private-topic',
+          userId: userId2,
+          workspaceId,
+        },
+      ]);
+
+      const memberModel = new TopicModel(serverDB, userId2, workspaceId);
+
+      await expect(memberModel.count()).resolves.toBe(2);
+      await expect(memberModel.count({ agentId: 'count-workspace-private-agent' })).resolves.toBe(
+        0,
+      );
+      await expect(memberModel.count({ agentId: 'count-workspace-public-agent' })).resolves.toBe(1);
     });
   });
 

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -42,6 +42,7 @@ import {
   count,
   desc,
   eq,
+  getTableColumns,
   gt,
   gte,
   inArray,
@@ -58,7 +59,9 @@ import { sanitizeNullBytes } from '@/utils/sanitizeNullBytes';
 import { today } from '@/utils/time';
 
 import {
+  agents,
   agentsToSessions,
+  chatGroups,
   chunks,
   documents,
   embeddings,
@@ -73,6 +76,7 @@ import {
   messageTranslates,
   messageTTS,
   threads,
+  topics,
   users,
 } from '../schemas';
 import type { LobeChatDatabase, Transaction } from '../type';
@@ -373,6 +377,23 @@ export class MessageModel {
 
   private ownership = () =>
     buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, messages);
+
+  /**
+   * Unscoped message lists/searches inherit visibility from the direct message
+   * target, falling back to the owning topic for legacy rows. Callers must join
+   * `topics`, `agents`, and `chatGroups` before applying this filter.
+   */
+  private resourceAccess = () => {
+    const scope = { userId: this.userId, workspaceId: this.workspaceId };
+    const groupId = sql<string | null>`COALESCE(${messages.groupId}, ${topics.groupId})`;
+    const agentId = sql<string | null>`COALESCE(${messages.agentId}, ${topics.agentId})`;
+
+    return or(
+      and(isNotNull(groupId), buildWorkspaceWhere(scope, chatGroups)),
+      and(isNull(groupId), isNotNull(agentId), buildWorkspaceWhere(scope, agents)),
+      and(isNull(groupId), isNull(agentId), eq(messages.userId, this.userId)),
+    );
+  };
 
   private pluginsOwnership = () =>
     buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, messagePlugins);
@@ -1878,9 +1899,18 @@ export class MessageModel {
     const offset = current * pageSize;
 
     const result = await this.db
-      .select()
+      .select(getTableColumns(messages))
       .from(messages)
-      .where(and(this.ownership()))
+      .leftJoin(topics, eq(messages.topicId, topics.id))
+      .leftJoin(
+        agents,
+        eq(agents.id, sql<string | null>`COALESCE(${messages.agentId}, ${topics.agentId})`),
+      )
+      .leftJoin(
+        chatGroups,
+        eq(chatGroups.id, sql<string | null>`COALESCE(${messages.groupId}, ${topics.groupId})`),
+      )
+      .where(and(this.ownership(), this.resourceAccess()))
       .orderBy(desc(messages.createdAt))
       .limit(pageSize)
       .offset(offset);
@@ -1902,9 +1932,20 @@ export class MessageModel {
 
     const bm25Query = sanitizeBm25Query(keyword);
     const result = await this.db
-      .select()
+      .select(getTableColumns(messages))
       .from(messages)
-      .where(and(this.ownership(), sql`${messages.content} @@@ ${bm25Query}`))
+      .leftJoin(topics, eq(messages.topicId, topics.id))
+      .leftJoin(
+        agents,
+        eq(agents.id, sql<string | null>`COALESCE(${messages.agentId}, ${topics.agentId})`),
+      )
+      .leftJoin(
+        chatGroups,
+        eq(chatGroups.id, sql<string | null>`COALESCE(${messages.groupId}, ${topics.groupId})`),
+      )
+      .where(
+        and(this.ownership(), this.resourceAccess(), sql`${messages.content} @@@ ${bm25Query}`),
+      )
       .orderBy(desc(messages.createdAt));
 
     return result as DBMessageItem[];

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -500,6 +500,17 @@ export class MessageModel {
       agentCondition = this.matchSession(sessionId);
     }
 
+    // Root/inbox messages have no conversation resource whose visibility can
+    // authorize workspace-wide reads, so they remain private to their creator.
+    const rootCreatorCondition =
+      !agentId &&
+      !groupId &&
+      !topicId &&
+      !threadId &&
+      (!sessionId || sessionId === INBOX_SESSION_ID)
+        ? eq(messages.userId, this.userId)
+        : undefined;
+
     // For thread queries, we need to fetch complete thread data (parent + thread messages)
     if (threadId) {
       const threadCondition = await runTimedStage(
@@ -564,6 +575,7 @@ export class MessageModel {
       conversationCondition,
       this.matchGroup(groupId),
       this.matchThread(threadId),
+      rootCreatorCondition,
     );
 
     const messageItems = await this.queryWithWhere({

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -380,18 +380,31 @@ export class MessageModel {
   private ownership = () =>
     buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, messages);
 
+  private effectiveAgentId = () =>
+    sql<
+      string | null
+    >`CASE WHEN ${messages.topicId} IS NOT NULL THEN ${topics.agentId} ELSE ${messages.agentId} END`;
+
+  private effectiveGroupId = () =>
+    sql<
+      string | null
+    >`CASE WHEN ${messages.topicId} IS NOT NULL THEN ${topics.groupId} ELSE ${messages.groupId} END`;
+
   /**
-   * Unscoped message lists/searches inherit visibility from the direct message
-   * target, falling back to the owning topic or its legacy session mapping.
+   * Unscoped message lists/searches inherit visibility from the owning topic,
+   * including its legacy session mapping. Messages without a topic use their
+   * direct target instead.
    * Callers must join `topics`, `agents`, and `chatGroups` before applying this
    * filter.
    */
   private resourceAccess = () => {
     const workspaceId = this.workspaceId;
     const scope = { userId: this.userId, workspaceId };
-    const groupId = sql<string | null>`COALESCE(${messages.groupId}, ${topics.groupId})`;
-    const agentId = sql<string | null>`COALESCE(${messages.agentId}, ${topics.agentId})`;
-    const creatorId = sql<string>`COALESCE(${topics.userId}, ${messages.userId})`;
+    const groupId = this.effectiveGroupId();
+    const agentId = this.effectiveAgentId();
+    const creatorId = sql<
+      string | null
+    >`CASE WHEN ${messages.topicId} IS NOT NULL THEN ${topics.userId} ELSE ${messages.userId} END`;
     const groupAccess = and(isNotNull(groupId), buildWorkspaceWhere(scope, chatGroups));
     const agentAccess = and(
       isNull(groupId),
@@ -1954,14 +1967,8 @@ export class MessageModel {
       .select(getTableColumns(messages))
       .from(messages)
       .leftJoin(topics, eq(messages.topicId, topics.id))
-      .leftJoin(
-        agents,
-        eq(agents.id, sql<string | null>`COALESCE(${messages.agentId}, ${topics.agentId})`),
-      )
-      .leftJoin(
-        chatGroups,
-        eq(chatGroups.id, sql<string | null>`COALESCE(${messages.groupId}, ${topics.groupId})`),
-      )
+      .leftJoin(agents, eq(agents.id, this.effectiveAgentId()))
+      .leftJoin(chatGroups, eq(chatGroups.id, this.effectiveGroupId()))
       .where(and(this.ownership(), this.resourceAccess()))
       .orderBy(desc(messages.createdAt))
       .limit(pageSize)
@@ -1987,14 +1994,8 @@ export class MessageModel {
       .select(getTableColumns(messages))
       .from(messages)
       .leftJoin(topics, eq(messages.topicId, topics.id))
-      .leftJoin(
-        agents,
-        eq(agents.id, sql<string | null>`COALESCE(${messages.agentId}, ${topics.agentId})`),
-      )
-      .leftJoin(
-        chatGroups,
-        eq(chatGroups.id, sql<string | null>`COALESCE(${messages.groupId}, ${topics.groupId})`),
-      )
+      .leftJoin(agents, eq(agents.id, this.effectiveAgentId()))
+      .leftJoin(chatGroups, eq(chatGroups.id, this.effectiveGroupId()))
       .where(
         and(this.ownership(), this.resourceAccess(), sql`${messages.content} @@@ ${bm25Query}`),
       )

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -42,6 +42,7 @@ import {
   count,
   desc,
   eq,
+  exists,
   getTableColumns,
   gt,
   gte,
@@ -50,6 +51,7 @@ import {
   isNull,
   lte,
   not,
+  notExists,
   or,
   sql,
 } from 'drizzle-orm';
@@ -380,18 +382,56 @@ export class MessageModel {
 
   /**
    * Unscoped message lists/searches inherit visibility from the direct message
-   * target, falling back to the owning topic for legacy rows. Callers must join
-   * `topics`, `agents`, and `chatGroups` before applying this filter.
+   * target, falling back to the owning topic or its legacy session mapping.
+   * Callers must join `topics`, `agents`, and `chatGroups` before applying this
+   * filter.
    */
   private resourceAccess = () => {
-    const scope = { userId: this.userId, workspaceId: this.workspaceId };
+    const workspaceId = this.workspaceId;
+    const scope = { userId: this.userId, workspaceId };
     const groupId = sql<string | null>`COALESCE(${messages.groupId}, ${topics.groupId})`;
     const agentId = sql<string | null>`COALESCE(${messages.agentId}, ${topics.agentId})`;
+    const creatorId = sql<string>`COALESCE(${topics.userId}, ${messages.userId})`;
+    const groupAccess = and(isNotNull(groupId), buildWorkspaceWhere(scope, chatGroups));
+    const agentAccess = and(
+      isNull(groupId),
+      isNotNull(agentId),
+      buildWorkspaceWhere(scope, agents),
+    );
+    const noDirectResource = and(isNull(groupId), isNull(agentId));
+
+    if (!workspaceId) {
+      return or(groupAccess, agentAccess, and(noDirectResource, eq(messages.userId, this.userId)));
+    }
+
+    const linkedWorkspaceAgents = (extraCondition?: SQL) =>
+      this.db
+        .select({ agentId: agentsToSessions.agentId })
+        .from(agentsToSessions)
+        .innerJoin(agents, eq(agents.id, agentsToSessions.agentId))
+        .where(
+          and(
+            eq(agentsToSessions.sessionId, topics.sessionId),
+            eq(agents.workspaceId, workspaceId),
+            extraCondition,
+          ),
+        );
+    const hasLinkedWorkspaceAgent = exists(linkedWorkspaceAgents());
 
     return or(
-      and(isNotNull(groupId), buildWorkspaceWhere(scope, chatGroups)),
-      and(isNull(groupId), isNotNull(agentId), buildWorkspaceWhere(scope, agents)),
-      and(isNull(groupId), isNull(agentId), eq(messages.userId, this.userId)),
+      groupAccess,
+      agentAccess,
+      and(
+        noDirectResource,
+        isNotNull(topics.sessionId),
+        hasLinkedWorkspaceAgent,
+        notExists(linkedWorkspaceAgents(not(buildWorkspaceWhere(scope, agents)))),
+      ),
+      and(
+        noDirectResource,
+        eq(creatorId, this.userId),
+        or(isNull(topics.sessionId), not(hasLinkedWorkspaceAgent)),
+      ),
     );
   };
 

--- a/packages/database/src/models/recent.ts
+++ b/packages/database/src/models/recent.ts
@@ -2,9 +2,19 @@ import type { ChatTopicStatus, TaskStatus } from '@lobechat/types';
 import { and, desc, eq, inArray, isNotNull, isNull, ne, not, or, sql } from 'drizzle-orm';
 import { unionAll } from 'drizzle-orm/pg-core';
 
-import { agents, DOCUMENT_FOLDER_TYPE, documents, messages, tasks, topics } from '../schemas';
+import {
+  agents,
+  chatGroups,
+  DOCUMENT_FOLDER_TYPE,
+  documents,
+  messages,
+  tasks,
+  topics,
+} from '../schemas';
 import type { LobeChatDatabase } from '../type';
 import { buildWorkspaceWhere } from '../utils/workspace';
+
+export type RecentView = 'mine' | 'team';
 
 export interface RecentDbItem {
   description?: string | null;
@@ -50,23 +60,38 @@ export class RecentModel {
     limit: number = 10,
     types?: RecentDbItem['type'][],
     withTopicPreview?: boolean,
-    mineOnly?: boolean,
+    view?: RecentView,
   ): Promise<RecentDbItem[]> => {
     const scope = { userId: this.userId, workspaceId: this.workspaceId };
     const requestedTypes = types ? new Set(types) : undefined;
 
-    // `tasks` uses `createdByUserId` instead of `userId`, so apply the
-    // workspace-aware predicate inline.
-    const taskScopeWhere = this.workspaceId
-      ? eq(tasks.workspaceId, this.workspaceId)
-      : and(eq(tasks.createdByUserId, this.userId), isNull(tasks.workspaceId));
+    // The team feed is shared activity, not merely "mineOnly off": own private
+    // resources belong in Mine but must not surface beside workspace content.
+    // In personal mode the view is inert because every ownership predicate is
+    // already pinned to the caller.
+    const teamAgentWhere =
+      this.workspaceId && view === 'team' ? eq(agents.visibility, 'public') : undefined;
+    const teamGroupWhere =
+      this.workspaceId && view === 'team' ? eq(chatGroups.visibility, 'public') : undefined;
+    const teamDocumentWhere =
+      this.workspaceId && view === 'team' ? eq(documents.visibility, 'public') : undefined;
+    const teamTaskWhere =
+      this.workspaceId && view === 'team' ? eq(tasks.visibility, 'public') : undefined;
+    const mineTopicWhere = view === 'mine' ? eq(topics.userId, this.userId) : undefined;
+    const mineDocumentWhere = view === 'mine' ? eq(documents.userId, this.userId) : undefined;
+    const mineTaskWhere = view === 'mine' ? eq(tasks.createdByUserId, this.userId) : undefined;
 
-    // Workspace rows are shared across members; `mineOnly` narrows a workspace
-    // feed back to the viewer's own items. A no-op in personal mode, where the
-    // scope predicate already pins the user.
-    const mineTopicWhere = mineOnly ? eq(topics.userId, this.userId) : undefined;
-    const mineDocumentWhere = mineOnly ? eq(documents.userId, this.userId) : undefined;
-    const mineTaskWhere = mineOnly ? eq(tasks.createdByUserId, this.userId) : undefined;
+    const agentAccessWhere = and(buildWorkspaceWhere(scope, agents), teamAgentWhere);
+    const groupAccessWhere = and(buildWorkspaceWhere(scope, chatGroups), teamGroupWhere);
+    const topicResourceWhere = or(
+      and(isNotNull(topics.groupId), groupAccessWhere),
+      and(isNull(topics.groupId), agentAccessWhere),
+    );
+    const taskScopeWhere = buildWorkspaceWhere(scope, {
+      userId: tasks.createdByUserId,
+      visibility: tasks.visibility,
+      workspaceId: tasks.workspaceId,
+    });
 
     const lastAssistantMessageSubquery = this.db
       .select({
@@ -104,12 +129,14 @@ export class RecentModel {
       })
       .from(topics)
       .leftJoin(agents, eq(topics.agentId, agents.id))
+      .leftJoin(chatGroups, eq(topics.groupId, chatGroups.id))
       .where(
         requestedTypes && !requestedTypes.has('topic')
           ? sql`false`
           : and(
               buildWorkspaceWhere(scope, topics),
               mineTopicWhere,
+              topicResourceWhere,
               or(
                 isNotNull(topics.groupId),
                 eq(agents.slug, 'inbox'),
@@ -144,6 +171,7 @@ export class RecentModel {
           : and(
               buildWorkspaceWhere(scope, documents),
               mineDocumentWhere,
+              teamDocumentWhere,
               not(inArray(documents.sourceType, TOOL_DOCUMENT_SOURCE_TYPES)),
               isNull(documents.knowledgeBaseId),
               ne(documents.fileType, DOCUMENT_FOLDER_TYPE),
@@ -170,7 +198,12 @@ export class RecentModel {
       .where(
         requestedTypes && !requestedTypes.has('task')
           ? sql`false`
-          : and(taskScopeWhere, mineTaskWhere, not(inArray(tasks.status, TASK_FINAL_STATUSES))),
+          : and(
+              taskScopeWhere,
+              mineTaskWhere,
+              teamTaskWhere,
+              not(inArray(tasks.status, TASK_FINAL_STATUSES)),
+            ),
       );
 
     const rows = await unionAll(topicArm, documentArm, taskArm)

--- a/packages/database/src/models/recent.ts
+++ b/packages/database/src/models/recent.ts
@@ -1,9 +1,25 @@
 import type { ChatTopicStatus, TaskStatus } from '@lobechat/types';
-import { and, desc, eq, inArray, isNotNull, isNull, ne, not, or, sql } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  exists,
+  inArray,
+  isNotNull,
+  isNull,
+  ne,
+  not,
+  notExists,
+  or,
+  sql,
+} from 'drizzle-orm';
 import { unionAll } from 'drizzle-orm/pg-core';
 
 import {
   agents,
+  agentsToSessions,
   chatGroups,
   DOCUMENT_FOLDER_TYPE,
   documents,
@@ -62,7 +78,8 @@ export class RecentModel {
     withTopicPreview?: boolean,
     view?: RecentView,
   ): Promise<RecentDbItem[]> => {
-    const scope = { userId: this.userId, workspaceId: this.workspaceId };
+    const workspaceId = this.workspaceId;
+    const scope = { userId: this.userId, workspaceId };
     const requestedTypes = types ? new Set(types) : undefined;
 
     // The team feed is shared activity, not merely "mineOnly off": own private
@@ -81,12 +98,59 @@ export class RecentModel {
     const mineDocumentWhere = view === 'mine' ? eq(documents.userId, this.userId) : undefined;
     const mineTaskWhere = view === 'mine' ? eq(tasks.createdByUserId, this.userId) : undefined;
 
-    const agentAccessWhere = and(buildWorkspaceWhere(scope, agents), teamAgentWhere);
-    const groupAccessWhere = and(buildWorkspaceWhere(scope, chatGroups), teamGroupWhere);
+    const agentAccessWhere = and(buildWorkspaceWhere(scope, agents), teamAgentWhere) as SQL;
+    const groupAccessWhere = and(buildWorkspaceWhere(scope, chatGroups), teamGroupWhere) as SQL;
+    const noDirectTopicResource = and(isNull(topics.groupId), isNull(topics.agentId));
+    const linkedWorkspaceAgents = (currentWorkspaceId: string, extraCondition?: SQL) =>
+      this.db
+        .select({ agentId: agentsToSessions.agentId })
+        .from(agentsToSessions)
+        .innerJoin(agents, eq(agents.id, agentsToSessions.agentId))
+        .where(
+          and(
+            eq(agentsToSessions.sessionId, topics.sessionId),
+            eq(agents.workspaceId, currentWorkspaceId),
+            extraCondition,
+          ),
+        );
+    const linkedSessionAccessWhere = workspaceId
+      ? and(
+          noDirectTopicResource,
+          isNotNull(topics.sessionId),
+          exists(linkedWorkspaceAgents(workspaceId)),
+          notExists(linkedWorkspaceAgents(workspaceId, not(agentAccessWhere))),
+        )
+      : undefined;
     const topicResourceWhere = or(
       and(isNotNull(topics.groupId), groupAccessWhere),
-      and(isNull(topics.groupId), agentAccessWhere),
+      and(isNull(topics.groupId), isNotNull(topics.agentId), agentAccessWhere),
+      linkedSessionAccessWhere,
     );
+    const linkedSessionRouteWhere = workspaceId
+      ? and(
+          noDirectTopicResource,
+          exists(
+            linkedWorkspaceAgents(
+              workspaceId,
+              or(eq(agents.slug, 'inbox'), ne(agents.virtual, true)),
+            ),
+          ),
+        )
+      : undefined;
+    const topicRouteWhere = or(
+      isNotNull(topics.groupId),
+      eq(agents.slug, 'inbox'),
+      and(isNull(topics.groupId), isNotNull(topics.agentId), ne(agents.virtual, true)),
+      linkedSessionRouteWhere,
+    );
+    const routeAgentId = workspaceId
+      ? sql<string | null>`COALESCE(${topics.agentId}, (${linkedWorkspaceAgents(
+          workspaceId,
+          or(eq(agents.slug, 'inbox'), ne(agents.virtual, true)),
+        )
+          .orderBy(asc(agentsToSessions.agentId))
+          .limit(1)}))`
+      : topics.agentId;
     const taskScopeWhere = buildWorkspaceWhere(scope, {
       userId: tasks.createdByUserId,
       visibility: tasks.visibility,
@@ -120,7 +184,7 @@ export class RecentModel {
           : sql<string | null>`NULL`.as('last_assistant_message'),
         metadata: sql<any>`${topics.metadata}`.as('metadata'),
         routeGroupId: sql<string | null>`${topics.groupId}`.as('route_group_id'),
-        routeId: sql<string | null>`${topics.agentId}`.as('route_id'),
+        routeId: sql<string | null>`${routeAgentId}`.as('route_id'),
         status: sql<TaskStatus | null>`NULL`.as('status'),
         title: sql<string>`COALESCE(${topics.title}, 'Untitled Topic')`.as('title'),
         type: sql<RecentDbItem['type']>`'topic'`.as('type'),
@@ -137,11 +201,7 @@ export class RecentModel {
               buildWorkspaceWhere(scope, topics),
               mineTopicWhere,
               topicResourceWhere,
-              or(
-                isNotNull(topics.groupId),
-                eq(agents.slug, 'inbox'),
-                and(isNull(topics.groupId), ne(agents.virtual, true)),
-              ),
+              topicRouteWhere,
               or(isNull(topics.trigger), not(inArray(topics.trigger, SYSTEM_TOPIC_TRIGGERS))),
               or(isNull(topics.status), not(inArray(topics.status, TOPIC_INBOX_STATUSES))),
             ),

--- a/packages/database/src/models/recent.ts
+++ b/packages/database/src/models/recent.ts
@@ -87,13 +87,21 @@ export class RecentModel {
     // In personal mode the view is inert because every ownership predicate is
     // already pinned to the caller.
     const teamAgentWhere =
-      this.workspaceId && view === 'team' ? eq(agents.visibility, 'public') : undefined;
+      workspaceId && view === 'team'
+        ? or(isNull(agents.visibility), eq(agents.visibility, 'public'))
+        : undefined;
     const teamGroupWhere =
-      this.workspaceId && view === 'team' ? eq(chatGroups.visibility, 'public') : undefined;
+      workspaceId && view === 'team'
+        ? or(isNull(chatGroups.visibility), eq(chatGroups.visibility, 'public'))
+        : undefined;
     const teamDocumentWhere =
-      this.workspaceId && view === 'team' ? eq(documents.visibility, 'public') : undefined;
+      workspaceId && view === 'team'
+        ? or(isNull(documents.visibility), eq(documents.visibility, 'public'))
+        : undefined;
     const teamTaskWhere =
-      this.workspaceId && view === 'team' ? eq(tasks.visibility, 'public') : undefined;
+      workspaceId && view === 'team'
+        ? or(isNull(tasks.visibility), eq(tasks.visibility, 'public'))
+        : undefined;
     const mineTopicWhere = view === 'mine' ? eq(topics.userId, this.userId) : undefined;
     const mineDocumentWhere = view === 'mine' ? eq(documents.userId, this.userId) : undefined;
     const mineTaskWhere = view === 'mine' ? eq(tasks.createdByUserId, this.userId) : undefined;

--- a/packages/database/src/models/thread.ts
+++ b/packages/database/src/models/thread.ts
@@ -2,6 +2,7 @@ import type { CreateThreadParams } from '@lobechat/types';
 import { RequestTrigger, ThreadStatus } from '@lobechat/types';
 import type { SQL } from 'drizzle-orm';
 import { and, desc, eq, exists, isNotNull, isNull, not, notExists, or, sql } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
 
 import type { ThreadItem } from '../schemas';
 import {
@@ -15,6 +16,11 @@ import {
 } from '../schemas';
 import type { LobeChatDatabase } from '../type';
 import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
+
+const threadTargetAgents = alias(agents, 'thread_target_agents');
+const threadTargetGroups = alias(chatGroups, 'thread_target_groups');
+const topicTargetAgents = alias(agents, 'thread_topic_target_agents');
+const topicTargetGroups = alias(chatGroups, 'thread_topic_target_groups');
 
 /**
  * Per-thread subagent metrics, derived from the child messages at read time
@@ -89,25 +95,44 @@ export class ThreadModel {
     buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, threads);
 
   /**
-   * Threads inherit conversation visibility from their own target first, then
-   * from the parent topic or its legacy session mapping. Callers must join the
-   * topic, agent, and group tables before applying this filter.
+   * Threads require access to both their direct target (when present) and the
+   * parent topic target or its legacy session mapping. Callers must join the
+   * topic and both sets of agent/group aliases before applying this filter.
    */
   private resourceAccess = () => {
     const workspaceId = this.workspaceId;
     const scope = { userId: this.userId, workspaceId };
-    const groupId = sql<string | null>`COALESCE(${threads.groupId}, ${topics.groupId})`;
-    const agentId = sql<string | null>`COALESCE(${threads.agentId}, ${topics.agentId})`;
-    const groupAccess = and(isNotNull(groupId), buildWorkspaceWhere(scope, chatGroups));
-    const agentAccess = and(
-      isNull(groupId),
-      isNotNull(agentId),
-      buildWorkspaceWhere(scope, agents),
+    const threadGroupAccess = and(
+      isNotNull(threads.groupId),
+      buildWorkspaceWhere(scope, threadTargetGroups),
     );
-    const noDirectResource = and(isNull(groupId), isNull(agentId));
+    const threadAgentAccess = and(
+      isNull(threads.groupId),
+      isNotNull(threads.agentId),
+      buildWorkspaceWhere(scope, threadTargetAgents),
+    );
+    const noThreadResource = and(isNull(threads.groupId), isNull(threads.agentId));
+    const threadAccess = or(threadGroupAccess, threadAgentAccess, noThreadResource);
+    const topicGroupAccess = and(
+      isNotNull(topics.groupId),
+      buildWorkspaceWhere(scope, topicTargetGroups),
+    );
+    const topicAgentAccess = and(
+      isNull(topics.groupId),
+      isNotNull(topics.agentId),
+      buildWorkspaceWhere(scope, topicTargetAgents),
+    );
+    const noTopicResource = and(isNull(topics.groupId), isNull(topics.agentId));
 
     if (!workspaceId) {
-      return or(groupAccess, agentAccess, and(noDirectResource, eq(threads.userId, this.userId)));
+      return and(
+        threadAccess,
+        or(
+          topicGroupAccess,
+          topicAgentAccess,
+          and(noTopicResource, eq(topics.userId, this.userId)),
+        ),
+      );
     }
 
     const linkedWorkspaceAgents = (extraCondition?: SQL) =>
@@ -124,19 +149,22 @@ export class ThreadModel {
         );
     const hasLinkedWorkspaceAgent = exists(linkedWorkspaceAgents());
 
-    return or(
-      groupAccess,
-      agentAccess,
-      and(
-        noDirectResource,
-        isNotNull(topics.sessionId),
-        hasLinkedWorkspaceAgent,
-        notExists(linkedWorkspaceAgents(not(buildWorkspaceWhere(scope, agents)))),
-      ),
-      and(
-        noDirectResource,
-        eq(topics.userId, this.userId),
-        or(isNull(topics.sessionId), not(hasLinkedWorkspaceAgent)),
+    return and(
+      threadAccess,
+      or(
+        topicGroupAccess,
+        topicAgentAccess,
+        and(
+          noTopicResource,
+          isNotNull(topics.sessionId),
+          hasLinkedWorkspaceAgent,
+          notExists(linkedWorkspaceAgents(not(buildWorkspaceWhere(scope, agents)))),
+        ),
+        and(
+          noTopicResource,
+          eq(topics.userId, this.userId),
+          or(isNull(topics.sessionId), not(hasLinkedWorkspaceAgent)),
+        ),
       ),
     );
   };
@@ -178,14 +206,10 @@ export class ThreadModel {
       .select(queryColumns)
       .from(threads)
       .innerJoin(topics, eq(threads.topicId, topics.id))
-      .leftJoin(
-        agents,
-        eq(agents.id, sql<string | null>`COALESCE(${threads.agentId}, ${topics.agentId})`),
-      )
-      .leftJoin(
-        chatGroups,
-        eq(chatGroups.id, sql<string | null>`COALESCE(${threads.groupId}, ${topics.groupId})`),
-      )
+      .leftJoin(threadTargetAgents, eq(threadTargetAgents.id, threads.agentId))
+      .leftJoin(threadTargetGroups, eq(threadTargetGroups.id, threads.groupId))
+      .leftJoin(topicTargetAgents, eq(topicTargetAgents.id, topics.agentId))
+      .leftJoin(topicTargetGroups, eq(topicTargetGroups.id, topics.groupId))
       .where(and(this.ownership(), this.resourceAccess()))
       .orderBy(desc(threads.updatedAt));
 
@@ -200,14 +224,10 @@ export class ThreadModel {
       .select({ ...queryColumns, ...subagentMetricColumns })
       .from(threads)
       .innerJoin(topics, eq(threads.topicId, topics.id))
-      .leftJoin(
-        agents,
-        eq(agents.id, sql<string | null>`COALESCE(${threads.agentId}, ${topics.agentId})`),
-      )
-      .leftJoin(
-        chatGroups,
-        eq(chatGroups.id, sql<string | null>`COALESCE(${threads.groupId}, ${topics.groupId})`),
-      )
+      .leftJoin(threadTargetAgents, eq(threadTargetAgents.id, threads.agentId))
+      .leftJoin(threadTargetGroups, eq(threadTargetGroups.id, threads.groupId))
+      .leftJoin(topicTargetAgents, eq(topicTargetAgents.id, topics.agentId))
+      .leftJoin(topicTargetGroups, eq(topicTargetGroups.id, topics.groupId))
       .leftJoin(messages, eq(messages.threadId, threads.id))
       .where(
         and(

--- a/packages/database/src/models/thread.ts
+++ b/packages/database/src/models/thread.ts
@@ -1,9 +1,9 @@
 import type { CreateThreadParams } from '@lobechat/types';
 import { RequestTrigger, ThreadStatus } from '@lobechat/types';
-import { and, desc, eq, notExists, sql } from 'drizzle-orm';
+import { and, desc, eq, isNotNull, isNull, notExists, or, sql } from 'drizzle-orm';
 
 import type { ThreadItem } from '../schemas';
-import { agentOperations, messages, threads } from '../schemas';
+import { agentOperations, agents, chatGroups, messages, threads, topics } from '../schemas';
 import type { LobeChatDatabase } from '../type';
 import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
 
@@ -80,6 +80,23 @@ export class ThreadModel {
     buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, threads);
 
   /**
+   * Threads inherit conversation visibility from their own target first, then
+   * from the parent topic for legacy rows. Callers must join the topic, agent,
+   * and group tables before applying this filter.
+   */
+  private resourceAccess = () => {
+    const scope = { userId: this.userId, workspaceId: this.workspaceId };
+    const groupId = sql<string | null>`COALESCE(${threads.groupId}, ${topics.groupId})`;
+    const agentId = sql<string | null>`COALESCE(${threads.agentId}, ${topics.agentId})`;
+
+    return or(
+      and(isNotNull(groupId), buildWorkspaceWhere(scope, chatGroups)),
+      and(isNull(groupId), isNotNull(agentId), buildWorkspaceWhere(scope, agents)),
+      and(isNull(groupId), isNull(agentId), eq(threads.userId, this.userId)),
+    );
+  };
+
+  /**
    * In workspace mode `ownership()` matches every member's threads, so a bulk
    * "clear all" would wipe teammates' rows. Destructive sweeps must
    * additionally pin `user_id` to the caller (personal mode is unchanged —
@@ -115,7 +132,16 @@ export class ThreadModel {
     const data = await this.db
       .select(queryColumns)
       .from(threads)
-      .where(this.ownership())
+      .innerJoin(topics, eq(threads.topicId, topics.id))
+      .leftJoin(
+        agents,
+        eq(agents.id, sql<string | null>`COALESCE(${threads.agentId}, ${topics.agentId})`),
+      )
+      .leftJoin(
+        chatGroups,
+        eq(chatGroups.id, sql<string | null>`COALESCE(${threads.groupId}, ${topics.groupId})`),
+      )
+      .where(and(this.ownership(), this.resourceAccess()))
       .orderBy(desc(threads.updatedAt));
 
     return data as ThreadItem[];
@@ -128,11 +154,21 @@ export class ThreadModel {
     const data = await this.db
       .select({ ...queryColumns, ...subagentMetricColumns })
       .from(threads)
+      .innerJoin(topics, eq(threads.topicId, topics.id))
+      .leftJoin(
+        agents,
+        eq(agents.id, sql<string | null>`COALESCE(${threads.agentId}, ${topics.agentId})`),
+      )
+      .leftJoin(
+        chatGroups,
+        eq(chatGroups.id, sql<string | null>`COALESCE(${threads.groupId}, ${topics.groupId})`),
+      )
       .leftJoin(messages, eq(messages.threadId, threads.id))
       .where(
         and(
           eq(threads.topicId, topicId),
           this.ownership(),
+          this.resourceAccess(),
           sql`COALESCE(${threads.metadata} ->> 'onboardingUnderstanding', '') = ''`,
           // NOTICE:
           // Internal Agent Signal and onboarding Understanding runs create

--- a/packages/database/src/models/thread.ts
+++ b/packages/database/src/models/thread.ts
@@ -1,9 +1,18 @@
 import type { CreateThreadParams } from '@lobechat/types';
 import { RequestTrigger, ThreadStatus } from '@lobechat/types';
-import { and, desc, eq, isNotNull, isNull, notExists, or, sql } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
+import { and, desc, eq, exists, isNotNull, isNull, not, notExists, or, sql } from 'drizzle-orm';
 
 import type { ThreadItem } from '../schemas';
-import { agentOperations, agents, chatGroups, messages, threads, topics } from '../schemas';
+import {
+  agentOperations,
+  agents,
+  agentsToSessions,
+  chatGroups,
+  messages,
+  threads,
+  topics,
+} from '../schemas';
 import type { LobeChatDatabase } from '../type';
 import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
 
@@ -81,18 +90,54 @@ export class ThreadModel {
 
   /**
    * Threads inherit conversation visibility from their own target first, then
-   * from the parent topic for legacy rows. Callers must join the topic, agent,
-   * and group tables before applying this filter.
+   * from the parent topic or its legacy session mapping. Callers must join the
+   * topic, agent, and group tables before applying this filter.
    */
   private resourceAccess = () => {
-    const scope = { userId: this.userId, workspaceId: this.workspaceId };
+    const workspaceId = this.workspaceId;
+    const scope = { userId: this.userId, workspaceId };
     const groupId = sql<string | null>`COALESCE(${threads.groupId}, ${topics.groupId})`;
     const agentId = sql<string | null>`COALESCE(${threads.agentId}, ${topics.agentId})`;
+    const groupAccess = and(isNotNull(groupId), buildWorkspaceWhere(scope, chatGroups));
+    const agentAccess = and(
+      isNull(groupId),
+      isNotNull(agentId),
+      buildWorkspaceWhere(scope, agents),
+    );
+    const noDirectResource = and(isNull(groupId), isNull(agentId));
+
+    if (!workspaceId) {
+      return or(groupAccess, agentAccess, and(noDirectResource, eq(threads.userId, this.userId)));
+    }
+
+    const linkedWorkspaceAgents = (extraCondition?: SQL) =>
+      this.db
+        .select({ agentId: agentsToSessions.agentId })
+        .from(agentsToSessions)
+        .innerJoin(agents, eq(agents.id, agentsToSessions.agentId))
+        .where(
+          and(
+            eq(agentsToSessions.sessionId, topics.sessionId),
+            eq(agents.workspaceId, workspaceId),
+            extraCondition,
+          ),
+        );
+    const hasLinkedWorkspaceAgent = exists(linkedWorkspaceAgents());
 
     return or(
-      and(isNotNull(groupId), buildWorkspaceWhere(scope, chatGroups)),
-      and(isNull(groupId), isNotNull(agentId), buildWorkspaceWhere(scope, agents)),
-      and(isNull(groupId), isNull(agentId), eq(threads.userId, this.userId)),
+      groupAccess,
+      agentAccess,
+      and(
+        noDirectResource,
+        isNotNull(topics.sessionId),
+        hasLinkedWorkspaceAgent,
+        notExists(linkedWorkspaceAgents(not(buildWorkspaceWhere(scope, agents)))),
+      ),
+      and(
+        noDirectResource,
+        eq(topics.userId, this.userId),
+        or(isNull(topics.sessionId), not(hasLinkedWorkspaceAgent)),
+      ),
     );
   };
 

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -906,9 +906,12 @@ export class TopicModel {
         count: count(topics.id),
       })
       .from(topics)
+      .leftJoin(agents, eq(topics.agentId, agents.id))
+      .leftJoin(chatGroups, eq(topics.groupId, chatGroups.id))
       .where(
         genWhere([
           this.ownership(),
+          this.resourceAccess(),
           agentCondition,
           params?.containerId ? this.matchContainer(params.containerId) : undefined,
           params?.range

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -19,6 +19,7 @@ import {
   count,
   desc,
   eq,
+  exists,
   getTableColumns,
   gt,
   gte,
@@ -28,6 +29,7 @@ import {
   lte,
   ne,
   not,
+  notExists,
   or,
   sql,
 } from 'drizzle-orm';
@@ -36,6 +38,7 @@ import type { TopicItem } from '../schemas';
 import {
   agentOperations,
   agents,
+  agentsToSessions,
   chatGroups,
   messagePlugins,
   messages,
@@ -254,15 +257,53 @@ export class TopicModel {
 
   /**
    * Topic rows inherit visibility from their owning group or agent. Legacy
-   * rows without either resource remain creator-only in workspace mode.
-   * Callers must join both `agents` and `chatGroups` before using this filter.
+   * session-only rows resolve through `agentsToSessions`; rows without any
+   * resolvable workspace resource remain creator-only. Callers must join both
+   * `agents` and `chatGroups` before using this filter.
    */
   private resourceAccess = () => {
-    const scope = { userId: this.userId, workspaceId: this.workspaceId };
+    const workspaceId = this.workspaceId;
+    const scope = { userId: this.userId, workspaceId };
+    const groupAccess = and(isNotNull(topics.groupId), buildWorkspaceWhere(scope, chatGroups));
+    const agentAccess = and(
+      isNull(topics.groupId),
+      isNotNull(topics.agentId),
+      buildWorkspaceWhere(scope, agents),
+    );
+    const noDirectResource = and(isNull(topics.groupId), isNull(topics.agentId));
+
+    if (!workspaceId) {
+      return or(groupAccess, agentAccess, and(noDirectResource, eq(topics.userId, this.userId)));
+    }
+
+    const linkedWorkspaceAgents = (extraCondition?: SQL) =>
+      this.db
+        .select({ agentId: agentsToSessions.agentId })
+        .from(agentsToSessions)
+        .innerJoin(agents, eq(agents.id, agentsToSessions.agentId))
+        .where(
+          and(
+            eq(agentsToSessions.sessionId, topics.sessionId),
+            eq(agents.workspaceId, workspaceId),
+            extraCondition,
+          ),
+        );
+    const hasLinkedWorkspaceAgent = exists(linkedWorkspaceAgents());
+
     return or(
-      and(isNotNull(topics.groupId), buildWorkspaceWhere(scope, chatGroups)),
-      and(isNull(topics.groupId), isNotNull(topics.agentId), buildWorkspaceWhere(scope, agents)),
-      and(isNull(topics.groupId), isNull(topics.agentId), eq(topics.userId, this.userId)),
+      groupAccess,
+      agentAccess,
+      and(
+        noDirectResource,
+        isNotNull(topics.sessionId),
+        hasLinkedWorkspaceAgent,
+        notExists(linkedWorkspaceAgents(not(buildWorkspaceWhere(scope, agents)))),
+      ),
+      and(
+        noDirectResource,
+        eq(topics.userId, this.userId),
+        or(isNull(topics.sessionId), not(hasLinkedWorkspaceAgent)),
+      ),
     );
   };
   // **************** Query *************** //

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -36,6 +36,7 @@ import type { TopicItem } from '../schemas';
 import {
   agentOperations,
   agents,
+  chatGroups,
   messagePlugins,
   messages,
   threads,
@@ -250,6 +251,20 @@ export class TopicModel {
 
   private messageOwnership = () =>
     buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, messages);
+
+  /**
+   * Topic rows inherit visibility from their owning group or agent. Legacy
+   * rows without either resource remain creator-only in workspace mode.
+   * Callers must join both `agents` and `chatGroups` before using this filter.
+   */
+  private resourceAccess = () => {
+    const scope = { userId: this.userId, workspaceId: this.workspaceId };
+    return or(
+      and(isNotNull(topics.groupId), buildWorkspaceWhere(scope, chatGroups)),
+      and(isNull(topics.groupId), isNotNull(topics.agentId), buildWorkspaceWhere(scope, agents)),
+      and(isNull(topics.groupId), isNull(topics.agentId), eq(topics.userId, this.userId)),
+    );
+  };
   // **************** Query *************** //
 
   query = async ({
@@ -349,6 +364,7 @@ export class TopicModel {
     if (groupId) {
       const whereCondition = and(
         this.ownership(),
+        this.resourceAccess(),
         eq(topics.groupId, groupId),
         includeTriggerCondition,
         excludeTriggerCondition,
@@ -393,6 +409,8 @@ export class TopicModel {
                 ...detailColumns,
               } as any)
               .from(topics)
+              .leftJoin(agents, eq(topics.agentId, agents.id))
+              .leftJoin(chatGroups, eq(topics.groupId, chatGroups.id))
               .where(whereCondition)
               .orderBy(...orderBy)
               .limit(pageSize)
@@ -403,6 +421,8 @@ export class TopicModel {
           this.db
             .select({ count: count(topics.id) })
             .from(topics)
+            .leftJoin(agents, eq(topics.agentId, agents.id))
+            .leftJoin(chatGroups, eq(topics.groupId, chatGroups.id))
             .where(whereCondition),
         ),
       ]);
@@ -428,6 +448,7 @@ export class TopicModel {
 
       const agentWhere = and(
         this.ownership(),
+        this.resourceAccess(),
         agentCondition,
         includeTriggerCondition,
         excludeTriggerCondition,
@@ -469,6 +490,8 @@ export class TopicModel {
                 ...detailColumns,
               } as any)
               .from(topics)
+              .leftJoin(agents, eq(topics.agentId, agents.id))
+              .leftJoin(chatGroups, eq(topics.groupId, chatGroups.id))
               .where(agentWhere)
               .orderBy(...orderBy)
               .limit(pageSize)
@@ -482,6 +505,8 @@ export class TopicModel {
             this.db
               .select({ count: count(topics.id) })
               .from(topics)
+              .leftJoin(agents, eq(topics.agentId, agents.id))
+              .leftJoin(chatGroups, eq(topics.groupId, chatGroups.id))
               .where(agentWhere),
           { isInbox: !!isInbox },
         ),
@@ -498,6 +523,7 @@ export class TopicModel {
     // Fallback to containerId-based query (backward compatibility)
     const whereCondition = and(
       this.ownership(),
+      this.resourceAccess(),
       this.matchContainer(containerId),
       includeTriggerCondition,
       excludeTriggerCondition,
@@ -541,6 +567,8 @@ export class TopicModel {
               ...detailColumns,
             } as any)
             .from(topics)
+            .leftJoin(agents, eq(topics.agentId, agents.id))
+            .leftJoin(chatGroups, eq(topics.groupId, chatGroups.id))
             .where(whereCondition)
             .orderBy(...orderBy)
             .limit(pageSize)
@@ -551,13 +579,20 @@ export class TopicModel {
         this.db
           .select({ count: count(topics.id) })
           .from(topics)
+          .leftJoin(agents, eq(topics.agentId, agents.id))
+          .leftJoin(chatGroups, eq(topics.groupId, chatGroups.id))
           .where(whereCondition),
       ),
     ]);
 
     // Remove internal fields before returning
 
-    const cleanItems = items.map(({ agentId: _agentId, sessionId: _sessionId, ...rest }) => rest);
+    // The conditional detail projection is intentionally cast above; joins
+    // cause Drizzle to widen that `any` selection to a nested table shape even
+    // though the runtime rows remain the explicitly selected flat columns.
+    const cleanItems = (items as any[]).map(
+      ({ agentId: _agentId, sessionId: _sessionId, ...rest }) => rest,
+    );
 
     logTiming(timing, 'db.topic.query:done', {
       itemCount: cleanItems.length,
@@ -635,6 +670,7 @@ export class TopicModel {
   } = {}): Promise<TopicListItem[]> => {
     const where = and(
       this.ownership(),
+      this.resourceAccess(),
       statuses && statuses.length > 0
         ? inArray(topics.status, statuses as ChatTopicStatus[])
         : undefined,
@@ -675,6 +711,8 @@ export class TopicModel {
           runStartedAt: runStartedAtColumn,
         })
         .from(topics)
+        .leftJoin(agents, eq(topics.agentId, agents.id))
+        .leftJoin(chatGroups, eq(topics.groupId, chatGroups.id))
         .where(where)
         .orderBy(desc(topics.updatedAt))
         .limit(pageSize);
@@ -713,6 +751,8 @@ export class TopicModel {
         runStartedAt: runStartedAtColumn,
       })
       .from(topics)
+      .leftJoin(agents, eq(topics.agentId, agents.id))
+      .leftJoin(chatGroups, eq(topics.groupId, chatGroups.id))
       .where(where)
       .orderBy(desc(topics.updatedAt))
       .limit(pageSize);
@@ -744,20 +784,32 @@ export class TopicModel {
     const [topicsByTitle, topicIdsByMessages] = await Promise.all([
       // Query topics matching by title (BM25)
       this.db
-        .select()
+        .select(getTableColumns(topics))
         .from(topics)
-        .where(and(this.ownership(), scopeCondition, sql`${topics.title} @@@ ${bm25Query}`))
+        .leftJoin(agents, eq(topics.agentId, agents.id))
+        .leftJoin(chatGroups, eq(topics.groupId, chatGroups.id))
+        .where(
+          and(
+            this.ownership(),
+            this.resourceAccess(),
+            scopeCondition,
+            sql`${topics.title} @@@ ${bm25Query}`,
+          ),
+        )
         .orderBy(desc(topics.updatedAt)),
       // Query topic IDs matching by message content (BM25)
       this.db
         .select({ topicId: messages.topicId })
         .from(messages)
         .innerJoin(topics, eq(messages.topicId, topics.id))
+        .leftJoin(agents, eq(topics.agentId, agents.id))
+        .leftJoin(chatGroups, eq(topics.groupId, chatGroups.id))
         .where(
           and(
             this.messageOwnership(),
             sql`${messages.content} @@@ ${bm25Query}`,
             this.ownership(),
+            this.resourceAccess(),
             scopeCondition,
           ),
         )
@@ -773,10 +825,13 @@ export class TopicModel {
       .map((t) => t.topicId)
       .filter((id): id is string => id !== null);
 
-    const topicsByMessages = await this.db.query.topics.findMany({
-      orderBy: [desc(topics.updatedAt)],
-      where: and(this.ownership(), inArray(topics.id, topicIds)),
-    });
+    const topicsByMessages = await this.db
+      .select(getTableColumns(topics))
+      .from(topics)
+      .leftJoin(agents, eq(topics.agentId, agents.id))
+      .leftJoin(chatGroups, eq(topics.groupId, chatGroups.id))
+      .where(and(this.ownership(), this.resourceAccess(), inArray(topics.id, topicIds)))
+      .orderBy(desc(topics.updatedAt));
 
     // Merge results and deduplicate
     const allTopics = [...topicsByTitle];
@@ -839,8 +894,10 @@ export class TopicModel {
         title: topics.title,
       })
       .from(topics)
-      .where(and(this.ownership()))
       .leftJoin(messages, eq(topics.id, messages.topicId))
+      .leftJoin(agents, eq(topics.agentId, agents.id))
+      .leftJoin(chatGroups, eq(topics.groupId, chatGroups.id))
+      .where(and(this.ownership(), this.resourceAccess()))
       .groupBy(topics.id)
       .orderBy(desc(sql`count`))
       .having(({ count }) => gt(count, 0))
@@ -877,9 +934,11 @@ export class TopicModel {
       })
       .from(topics)
       .leftJoin(agents, eq(topics.agentId, agents.id))
+      .leftJoin(chatGroups, eq(topics.groupId, chatGroups.id))
       .where(
         and(
           this.ownership(),
+          this.resourceAccess(),
           or(
             // Group topics: has groupId
             not(isNull(topics.groupId)),

--- a/src/features/Home/HomeModeContent.tsx
+++ b/src/features/Home/HomeModeContent.tsx
@@ -289,7 +289,8 @@ const HomeModeContent = memo<HomeModeContentProps>(({ inlineRail, mode, onSugges
     isLogin
       ? recentKeys.topicList(HOME_TOPIC_RECENT_LIMIT, cacheScope, teamView ? 'team' : 'mine')
       : null,
-    () => recentService.getAll(HOME_TOPIC_RECENT_LIMIT, ['topic'], true, !teamView),
+    () =>
+      recentService.getAll(HOME_TOPIC_RECENT_LIMIT, ['topic'], true, teamView ? 'team' : 'mine'),
     { revalidateOnFocus: false },
   );
 

--- a/src/services/recent/index.ts
+++ b/src/services/recent/index.ts
@@ -6,9 +6,9 @@ class RecentService {
     limit?: number,
     types?: RecentItem['type'][],
     withTopicPreview?: boolean,
-    mineOnly?: boolean,
+    view?: 'mine' | 'team',
   ): Promise<RecentItem[]> => {
-    return lambdaClient.recent.getAll.query({ limit, mineOnly, types, withTopicPreview });
+    return lambdaClient.recent.getAll.query({ limit, types, view, withTopicPreview });
   };
 }
 


### PR DESCRIPTION
## Summary

- make the workspace home Mine/Team scope explicit and keep private agent/group topics out of Team recents
- resolve topic, session, and thread ownership server-side before returning conversation data
- apply inherited agent/group visibility to unscoped topic, message, search, ranking, and thread queries
- retain compatibility for clients still sending the legacy `mineOnly` parameter

## Key Decisions / Non-goals

- Topics, messages, and threads inherit visibility from their owning group first, then their agent.
- Legacy workspace conversation rows without either resource are creator-only, which is the safe fallback.
- Visibility filters run before pagination limits so private rows cannot displace visible results.
- No schema migration or data backfill is required.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check $(git -C lobehub diff --name-only | sed 's#^#lobehub/#')` (362 tests passed before commit)
- `bun run check --type`
- `git diff --check`

#### 🔗 Related Issue

N/A
