### PR TITLE
🐛 fix(conversation): hide empty reasoning card for signature-only reasoning

### DIFF
--- a/src/features/Conversation/Messages/Assistant/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/Assistant/components/MessageContent.tsx
@@ -8,7 +8,7 @@ import { CollapsedMessage } from '../../AssistantGroup/components/CollapsedMessa
 import DisplayContent from '../../components/DisplayContent';
 import FileChunks from '../../components/FileChunks';
 import ImageFileListViewer from '../../components/ImageFileListViewer';
-import Reasoning from '../../components/Reasoning';
+import Reasoning, { hasRenderableReasoning } from '../../components/Reasoning';
 import SearchGrounding from '../../components/SearchGrounding';
 import { useMarkdown } from '../useMarkdown';
 
@@ -30,8 +30,7 @@ const MessageContent = memo<UIChatMessage>(
     // remove \n to avoid empty content
     // refs: https://github.com/lobehub/lobe-chat/pull/6153
     const showReasoning =
-      (!!props.reasoning && props.reasoning.content?.trim() !== '') ||
-      (!props.reasoning && isReasoning);
+      hasRenderableReasoning(props.reasoning) || (!props.reasoning && isReasoning);
 
     const showFileChunks = !!chunksList && chunksList.length > 0;
 

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.test.tsx
@@ -105,7 +105,9 @@ vi.mock('../../components/ImageFileListViewer', () => ({
   default: () => <div>images</div>,
 }));
 
-vi.mock('../../components/Reasoning', () => ({
+vi.mock('../../components/Reasoning', async (importOriginal) => ({
+  // keep the real hasRenderableReasoning predicate — these tests exercise it
+  ...(await importOriginal<Record<string, unknown>>()),
   default: () => <div>reasoning</div>,
 }));
 

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.test.tsx
@@ -250,6 +250,24 @@ describe('AssistantGroup ContentBlock', () => {
     expect(screen.queryByText('reasoning')).not.toBeInTheDocument();
   });
 
+  it('renders multimodal reasoning that streams tempDisplayContent without content', () => {
+    // StreamingHandler emits { isMultimodal, tempDisplayContent } with no content
+    // while image reasoning parts stream — must not be treated as signature-only.
+    render(
+      <ContentBlock
+        assistantId="assistant-1"
+        content=""
+        id="block-1"
+        reasoning={{
+          isMultimodal: true,
+          tempDisplayContent: [{ image: 'data:image/png;base64,b64', type: 'image' }],
+        }}
+      />,
+    );
+
+    expect(screen.getByText('reasoning')).toBeInTheDocument();
+  });
+
   it('keeps the streaming reasoning placeholder when no reasoning object exists yet', () => {
     isInReasoningMock = true;
 

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.test.tsx
@@ -12,6 +12,7 @@ const continueGenerationMock = vi.fn();
 const deleteDBMessageMock = vi.fn();
 const continueHeteroAfterErrorMock = vi.fn();
 const navigateMock = vi.fn();
+let isInReasoningMock = false;
 
 vi.mock('@lobehub/ui', () => ({
   Block: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
@@ -121,7 +122,7 @@ vi.mock('../../../store', () => ({
     getDisplayMessageById: () => () => ({ parentId: 'user-1' }),
   },
   messageStateSelectors: {
-    isMessageInReasoning: () => () => false,
+    isMessageInReasoning: () => () => isInReasoningMock,
   },
   useConversationStore: (selector: (state: unknown) => unknown) =>
     selector({
@@ -144,6 +145,7 @@ describe('AssistantGroup ContentBlock', () => {
     deleteDBMessageMock.mockClear();
     continueHeteroAfterErrorMock.mockClear();
     navigateMock.mockClear();
+    isInReasoningMock = false;
   });
 
   it('resumes the run (not the no-op continueGeneration) when retrying a heterogeneous error in a group', () => {
@@ -203,6 +205,57 @@ describe('AssistantGroup ContentBlock', () => {
     );
 
     expect(screen.getByText('guide:claude-code:rate_limit')).toBeInTheDocument();
+  });
+
+  it('does not render an empty reasoning card for signature-only reasoning', () => {
+    // Some providers (e.g. DeepSeek over the Anthropic protocol) emit a thinking
+    // block with only a signature_delta and zero thinking text. The signature is
+    // persisted for multi-turn replay but must not render a card. See LOBE-12829.
+    render(
+      <ContentBlock
+        assistantId="assistant-1"
+        content="final answer"
+        id="block-1"
+        reasoning={{ signature: '395a9e64-8cfb-4e4b-a8b8-f11f5d5e2181' }}
+      />,
+    );
+
+    expect(screen.queryByText('reasoning')).not.toBeInTheDocument();
+    expect(screen.getByText('message content')).toBeInTheDocument();
+  });
+
+  it('renders reasoning when content is present alongside a signature', () => {
+    render(
+      <ContentBlock
+        assistantId="assistant-1"
+        content="final answer"
+        id="block-1"
+        reasoning={{ content: 'let me think', signature: 'sig' }}
+      />,
+    );
+
+    expect(screen.getByText('reasoning')).toBeInTheDocument();
+  });
+
+  it('does not render a reasoning card for whitespace-only content', () => {
+    render(
+      <ContentBlock
+        assistantId="assistant-1"
+        content="final answer"
+        id="block-1"
+        reasoning={{ content: '   ' }}
+      />,
+    );
+
+    expect(screen.queryByText('reasoning')).not.toBeInTheDocument();
+  });
+
+  it('keeps the streaming reasoning placeholder when no reasoning object exists yet', () => {
+    isInReasoningMock = true;
+
+    render(<ContentBlock assistantId="assistant-1" content="" id="block-1" />);
+
+    expect(screen.getByText('reasoning')).toBeInTheDocument();
   });
 
   it('renders the error below the content when a turn errors after streaming content', () => {

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
@@ -11,7 +11,7 @@ import ErrorMessageExtra, {
 import ErrorContent from '../../../ChatItem/components/ErrorContent';
 import { dataSelectors, messageStateSelectors, useConversationStore } from '../../../store';
 import ImageFileListViewer from '../../components/ImageFileListViewer';
-import Reasoning from '../../components/Reasoning';
+import Reasoning, { hasRenderableReasoning } from '../../components/Reasoning';
 import { Tools } from '../Tools';
 import MessageContent from './MessageContent';
 import type { RenderableAssistantContentBlock } from './types';
@@ -51,15 +51,7 @@ const ContentBlock = memo<ContentBlockProps>(
     );
     const isHeteroError = isHeterogeneousAgentStatusGuideError(error?.body);
     const hasTools = !!tools?.length;
-    // A signature-only reasoning ({ signature } without content) is protocol state
-    // kept for multi-turn replay, not renderable thinking — don't show an empty
-    // "deep thought" card for it. Multimodal reasoning streams image parts via
-    // tempDisplayContent without content, so count those as renderable too.
-    // See LOBE-12829.
-    const showReasoning =
-      !!reasoning?.content?.trim() ||
-      !!reasoning?.tempDisplayContent?.length ||
-      (!reasoning && isReasoning);
+    const showReasoning = hasRenderableReasoning(reasoning) || (!reasoning && isReasoning);
     const hasContent = !!content && content !== LOADING_FLAT;
     const showMessageContent = hasContent || content === LOADING_FLAT || hasTools;
 

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
@@ -51,8 +51,10 @@ const ContentBlock = memo<ContentBlockProps>(
     );
     const isHeteroError = isHeterogeneousAgentStatusGuideError(error?.body);
     const hasTools = !!tools?.length;
-    const showReasoning =
-      (!!reasoning && reasoning.content?.trim() !== '') || (!reasoning && isReasoning);
+    // A signature-only reasoning ({ signature } without content) is protocol state
+    // kept for multi-turn replay, not renderable thinking — don't show an empty
+    // "deep thought" card for it. See LOBE-12829.
+    const showReasoning = !!reasoning?.content?.trim() || (!reasoning && isReasoning);
     const hasContent = !!content && content !== LOADING_FLAT;
     const showMessageContent = hasContent || content === LOADING_FLAT || hasTools;
 

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
@@ -53,8 +53,13 @@ const ContentBlock = memo<ContentBlockProps>(
     const hasTools = !!tools?.length;
     // A signature-only reasoning ({ signature } without content) is protocol state
     // kept for multi-turn replay, not renderable thinking — don't show an empty
-    // "deep thought" card for it. See LOBE-12829.
-    const showReasoning = !!reasoning?.content?.trim() || (!reasoning && isReasoning);
+    // "deep thought" card for it. Multimodal reasoning streams image parts via
+    // tempDisplayContent without content, so count those as renderable too.
+    // See LOBE-12829.
+    const showReasoning =
+      !!reasoning?.content?.trim() ||
+      !!reasoning?.tempDisplayContent?.length ||
+      (!reasoning && isReasoning);
     const hasContent = !!content && content !== LOADING_FLAT;
     const showMessageContent = hasContent || content === LOADING_FLAT || hasTools;
 

--- a/src/features/Conversation/Messages/components/Reasoning.test.ts
+++ b/src/features/Conversation/Messages/components/Reasoning.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasRenderableReasoning } from './Reasoning';
+
+describe('hasRenderableReasoning', () => {
+  it('is false for signature-only reasoning', () => {
+    expect(hasRenderableReasoning({ signature: '395a9e64-8cfb' })).toBe(false);
+  });
+
+  it('is false for missing or whitespace-only content', () => {
+    expect(hasRenderableReasoning(undefined)).toBe(false);
+    expect(hasRenderableReasoning({})).toBe(false);
+    expect(hasRenderableReasoning({ content: '   ' })).toBe(false);
+  });
+
+  it('is true for non-blank content', () => {
+    expect(hasRenderableReasoning({ content: 'let me think', signature: 'sig' })).toBe(true);
+  });
+
+  it('is true for multimodal tempDisplayContent without content', () => {
+    expect(
+      hasRenderableReasoning({
+        isMultimodal: true,
+        tempDisplayContent: [{ image: 'data:image/png;base64,b64', type: 'image' }],
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/features/Conversation/Messages/components/Reasoning.tsx
+++ b/src/features/Conversation/Messages/components/Reasoning.tsx
@@ -1,4 +1,4 @@
-import { type MessageContentPart } from '@lobechat/types';
+import { type MessageContentPart, type ModelReasoning } from '@lobechat/types';
 import { deserializeParts } from '@lobechat/utils';
 import { memo } from 'react';
 
@@ -8,6 +8,16 @@ import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import { messageStateSelectors, useConversationStore } from '../../store';
 import { RichContentRenderer } from './RichContentRenderer';
+
+/**
+ * Whether a persisted reasoning object holds renderable thinking. A
+ * signature-only reasoning ({ signature } without content) is protocol state
+ * kept for multi-turn replay and must not render an empty "deep thought" card
+ * (LOBE-12829). Multimodal reasoning streams image parts via tempDisplayContent
+ * without content, so those count as renderable.
+ */
+export const hasRenderableReasoning = (reasoning?: ModelReasoning): boolean =>
+  !!reasoning?.content?.trim() || !!reasoning?.tempDisplayContent?.length;
 
 interface ReasoningProps {
   content?: string;

--- a/src/features/Conversation/Messages/components/Reasoning.tsx
+++ b/src/features/Conversation/Messages/components/Reasoning.tsx
@@ -16,7 +16,7 @@ import { RichContentRenderer } from './RichContentRenderer';
  * (LOBE-12829). Multimodal reasoning streams image parts via tempDisplayContent
  * without content, so those count as renderable.
  */
-export const hasRenderableReasoning = (reasoning?: ModelReasoning): boolean =>
+export const hasRenderableReasoning = (reasoning?: ModelReasoning | null): boolean =>
   !!reasoning?.content?.trim() || !!reasoning?.tempDisplayContent?.length;
 
 interface ReasoningProps {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-12829

#### 📝 Description of Change

Some providers speaking the Anthropic protocol (e.g. DeepSeek `deepseek-v4-flash`) occasionally emit a thinking block with **zero `thinking_delta`** — only a `signature_delta` followed by `content_block_stop`. Captured raw stream:

```
chunk 1: content_block_start → {"type":"thinking","thinking":"","signature":""}
chunk 2: content_block_delta → {"type":"signature_delta","signature":"395a9e64-..."}
chunk 3: content_block_stop
chunk 4: content_block_start → text block (answer starts directly)
```

The signature is persisted as `reasoning: { signature }` (needed for multi-turn replay), but the `showReasoning` check in `ContentBlock.tsx` used `reasoning.content?.trim() !== ''`, which is `true` when `content` is `undefined` — so an empty, expandable "deep thought" card was rendered.

This PR tightens the visibility check to require non-blank `reasoning.content`, while keeping:

- the streaming placeholder (`!reasoning && isReasoning`) untouched
- signature persistence and replay untouched

#### 🧪 How to Test

- [x] Unit tests added in `ContentBlock.test.tsx`:
  - `{ signature }` only → no reasoning card
  - `{ content, signature }` → card renders
  - whitespace-only `content` → no card
  - no reasoning + `isReasoning` → streaming placeholder kept