### PR TITLE
🐛 fix(conversation): stop duplicating AskUserQuestion answers in client runtime

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/customInteractionHandlers.test.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/customInteractionHandlers.test.ts
@@ -95,7 +95,10 @@ describe('customInteractionHandlers', () => {
     const result = await prepareCustomInteractionSubmit(identifier, payload, { apiName });
 
     expect(result).toEqual({
-      options: { pluginState: { askUserAnswers: payload } },
+      // createUserMessage must stay false: the completed tool card already
+      // renders the answers, so a synthetic user message would duplicate them
+      // in the client runtime (LOBE-12835).
+      options: { createUserMessage: false, pluginState: { askUserAnswers: payload } },
       payload,
     });
   });

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/customInteractionHandlers.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/customInteractionHandlers.ts
@@ -134,8 +134,13 @@ const customInteractionSubmitHandlers: Array<{
   match: (identifier: string, apiName?: string) => boolean;
 }> = [
   {
+    // `createUserMessage: false` — the completed tool card already renders the
+    // answers from `pluginState.askUserAnswers`, so the client runtime must
+    // resume from the tool result instead of synthesizing a `role: 'user'`
+    // message (which duplicated the answer as a user bubble). This also aligns
+    // with the Gateway resume path, which never creates a user turn here.
     handler: async (payload) => ({
-      options: { pluginState: { askUserAnswers: payload } },
+      options: { createUserMessage: false, pluginState: { askUserAnswers: payload } },
       payload,
     }),
     match: isAskUserQuestionCall,


### PR DESCRIPTION
When an agent runs on the client runtime (gateway mode disabled), submitting an AskUserQuestion answer both rendered the answers on the completed tool card (via `pluginState.askUserAnswers`, introduced in #17539) and synthesized a `role: 'user'` message from the same answers — so the answer showed up twice, and the synthetic bubble could even appear after the next assistant reply in the live list.

Fix: the AskUserQuestion custom-interaction handler now submits with `createUserMessage: false`, so the client runtime resumes directly from the tool result (`phase: 'tool_result'`) instead of creating a synthetic user turn. This matches the Gateway resume path, which already continues from the answered tool call without a user message. The LLM still reads the answers from the tool result content (`User submitted: {...}`), which is unchanged on both paths.

#### Test

- [x] Added/updated tests

Updated `customInteractionHandlers.test.ts` to pin `createUserMessage: false` for both AskUserQuestion identifiers (lobe-agent and user-interaction). The `createUserMessage: false` client resume path and the Gateway resume path are already covered by `conversationControl.test.ts`.

#### 🔗 Related Issue

Fixes LOBE-12835