### PR TITLE
✅ test(topic): assert default model constants in createTopic expectation

### DIFF
--- a/src/store/chat/slices/topic/action.test.ts
+++ b/src/store/chat/slices/topic/action.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from '@lobechat/business-const';
 import type { LobeUser, UIChatMessage } from '@lobechat/types';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { type Mock } from 'vitest';
@@ -2439,8 +2440,10 @@ describe('topic action', () => {
       });
 
       expect(createTopicSpy).toHaveBeenCalledWith({
-        model: 'deepseek-v4-pro',
-        provider: 'deepseek',
+        // The test never seeds agentMap, so snapshotAgentModel falls back to the
+        // defaults — assert the constants so default-model bumps can't break this.
+        model: DEFAULT_MODEL,
+        provider: DEFAULT_PROVIDER,
         sessionId: activeAgentId,
         messages: messages.map((m) => m.id),
         title: 'defaultTitle',


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✅ test

#### 📝 Description of Change

[#17933](https://github.com/lobehub/lobehub/pull/17933) bumped `DEFAULT_MODEL` from `deepseek-v4-pro` to `deepseek-v4-flash`, but `createTopic > should create a new topic and update the store` hardcodes the old value, so `Test App (shard 1/2)` fails on current `canary` (and on every PR based on it, e.g. #17938).

The test never seeds `agentMap`, so `snapshotAgentModel` falls back to the defaults — assert `DEFAULT_MODEL` / `DEFAULT_PROVIDER` from `@lobechat/business-const` instead of literals so future default-model bumps can't break it again.

#### 🧪 How to Test

- [x] `bunx vitest run src/store/chat/slices/topic/action.test.ts` — the previously failing case passes