### PR TITLE
🐛 fix(agent): clamp working sidebar width to the row instead of hiding the panel

### DIFF
--- a/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
+++ b/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
@@ -11,6 +11,7 @@ import AgentWorkingSidebar from '../index';
 interface CapturedRightPanelProps {
   children?: ReactNode;
   defaultWidth?: number | string;
+  expand?: boolean;
   maxWidth?: number | string;
   onSizeChange?: (size?: { height?: number | string; width?: number | string }) => void;
   width?: number | string;
@@ -433,6 +434,39 @@ describe('AgentWorkingSidebar — controlled panel width', () => {
     unmount();
     render(<AgentWorkingSidebar />);
     expect(rightPanel.current?.width).toBe(500);
+  });
+
+  // Regression: dragging the panel wide persisted a width that immediately
+  // failed the fits check, so releasing the drag unmounted the whole sidebar —
+  // and, with the too-wide value stored, it never came back at that window
+  // size. A stored width beyond the row's budget must render clamped (and cap
+  // further dragging) instead of hiding the panel.
+  it('clamps a stored width that outgrew the row instead of hiding the panel', () => {
+    globalStore.status.workingSidebarWidth = 1250;
+
+    render(<AgentWorkingSidebar availableWidth={1540} />);
+
+    expect(rightPanel.current?.expand).toBe(true);
+    // 1540 - CONVERSATION_KEEP_WIDTH (420)
+    expect(rightPanel.current?.width).toBe(1120);
+    expect(rightPanel.current?.maxWidth).toBe(1120);
+    // the clamp is render-only: the user's preference survives for wider rows
+    expect(globalStore.updateSystemStatus).not.toHaveBeenCalled();
+  });
+
+  it('still yields the whole panel when even the minimum width leaves no room', () => {
+    render(<AgentWorkingSidebar availableWidth={600} />);
+
+    // 600 - 420 = 180 < the 300 minimum — nothing to clamp to, so it hides
+    expect(rightPanel.current?.expand).toBe(false);
+  });
+
+  it('keeps a fitting stored width untouched on a measured row', () => {
+    render(<AgentWorkingSidebar availableWidth={1540} />);
+
+    expect(rightPanel.current?.expand).toBe(true);
+    expect(rightPanel.current?.width).toBe(360);
+    expect(rightPanel.current?.maxWidth).toBe(1120);
   });
 
   it('ignores a size update with no width', () => {

--- a/src/features/Conversation/WorkingSidebar/fitsBesidePortal.test.ts
+++ b/src/features/Conversation/WorkingSidebar/fitsBesidePortal.test.ts
@@ -2,9 +2,25 @@ import { describe, expect, it } from 'vitest';
 
 import { CHAT_PORTAL_WIDE_WIDTH, CHAT_PORTAL_WIDTH } from '@/const/layoutTokens';
 
-import { fitsBesidePortal } from './fitsBesidePortal';
+import { fitsBesidePortal, sidebarWidthBudget } from './fitsBesidePortal';
 
 const SIDEBAR = 360;
+
+describe('sidebarWidthBudget', () => {
+  it('is unlimited until the row has been measured', () => {
+    expect(sidebarWidthBudget({ portalWidth: 0 })).toBe(Number.POSITIVE_INFINITY);
+    expect(sidebarWidthBudget({ availableWidth: 0, portalWidth: 0 })).toBe(
+      Number.POSITIVE_INFINITY,
+    );
+  });
+
+  it('reserves the conversation share beside an open portal', () => {
+    // 1710 - 840 - 420
+    expect(sidebarWidthBudget({ availableWidth: 1710, portalWidth: CHAT_PORTAL_WIDE_WIDTH })).toBe(
+      450,
+    );
+  });
+});
 
 describe('fitsBesidePortal', () => {
   it('keeps the sidebar until the row has been measured', () => {

--- a/src/features/Conversation/WorkingSidebar/fitsBesidePortal.ts
+++ b/src/features/Conversation/WorkingSidebar/fitsBesidePortal.ts
@@ -1,29 +1,35 @@
 import { CONVERSATION_KEEP_WIDTH } from '@/const/layoutTokens';
 
-interface FitsBesidePortalParams {
+interface SidebarWidthBudgetParams {
   /** measured width of the row holding conversation + portal + sidebar */
   availableWidth?: number;
   /** 0 when the portal is closed */
   portalWidth: number;
-  sidebarWidth: number;
 }
 
 /**
  * The conversation, the portal and the working sidebar share one row. A wide
  * portal (an acceptance report opens at 840) plus the sidebar can consume the
  * whole row and leave the conversation at zero width, so the sidebar yields
- * first: keeping conversation + portal beats keeping all three.
+ * first: this is the widest the sidebar may render while the conversation
+ * keeps its share of the row.
  *
- * Returns true while all three fit — before the row has been measured too, so
- * the first paint matches the user's own `showRightPanel` preference instead of
- * flashing the sidebar away.
+ * Infinity before the row has been measured, so the first paint matches the
+ * user's own `showRightPanel` preference instead of flashing the sidebar away.
  */
-export const fitsBesidePortal = ({
+export const sidebarWidthBudget = ({
   availableWidth,
   portalWidth,
-  sidebarWidth,
-}: FitsBesidePortalParams): boolean => {
-  if (!availableWidth) return true;
+}: SidebarWidthBudgetParams): number => {
+  if (!availableWidth) return Number.POSITIVE_INFINITY;
 
-  return availableWidth - portalWidth - sidebarWidth >= CONVERSATION_KEEP_WIDTH;
+  return availableWidth - portalWidth - CONVERSATION_KEEP_WIDTH;
 };
+
+interface FitsBesidePortalParams extends SidebarWidthBudgetParams {
+  sidebarWidth: number;
+}
+
+/** True while conversation + portal + a `sidebarWidth`-wide sidebar all fit. */
+export const fitsBesidePortal = ({ sidebarWidth, ...budget }: FitsBesidePortalParams): boolean =>
+  sidebarWidth <= sidebarWidthBudget(budget);

--- a/src/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/index.tsx
@@ -63,7 +63,7 @@ import { useUserStore } from '@/store/user';
 import { labPreferSelectors } from '@/store/user/selectors';
 
 import Files from './Files';
-import { fitsBesidePortal } from './fitsBesidePortal';
+import { sidebarWidthBudget } from './fitsBesidePortal';
 import Overview from './Overview';
 import ResourcesSection from './ResourcesSection';
 import Review from './Review';
@@ -136,6 +136,7 @@ const styles = createStaticStyles(({ css }) => ({
 const REVIEW_TREE_STORAGE_KEY = 'lobechat-review-tree';
 const OPEN_TABS_STORAGE_KEY = 'lobechat-working-sidebar-open-tabs-v1';
 const PINNED_TABS_STORAGE_KEY = 'lobechat-working-sidebar-pinned-tabs-v1';
+const MIN_PANEL_WIDTH = 300;
 const MAX_PANEL_WIDTH = 1200;
 // Two-pane Review (diff list + file-tree rail) is cramped below this.
 const TWO_PANE_MIN_WIDTH = 560;
@@ -660,14 +661,23 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
   );
   const reviewTwoPane = activeTab === 'review' && reviewAvailable && showReviewTree;
   const displayWidth = reviewTwoPane ? Math.max(storedWidth, TWO_PANE_MIN_WIDTH) : storedWidth;
-  // Yield the row to conversation + portal when the three no longer fit. This
-  // only overrides the rendered state — `showRightPanel` keeps the user's own
+  // Yield the row to conversation + portal when the three no longer fit. A
+  // stored width that merely outgrew the current row (the user dragged the
+  // panel out, or resized the window down) renders clamped instead of
+  // unmounting the whole panel — the sidebar disappears only when even its
+  // minimum width leaves no room for the conversation. Either way this only
+  // overrides the rendered state — `showRightPanel` keeps the user's own
   // choice, so the sidebar comes back by itself once there is room again.
-  const fits = fitsBesidePortal({
+  const minDisplayWidth = reviewTwoPane ? TWO_PANE_MIN_WIDTH : MIN_PANEL_WIDTH;
+  const widthBudget = sidebarWidthBudget({
     availableWidth,
     portalWidth: portalOpen ? portalWidth : 0,
-    sidebarWidth: displayWidth,
   });
+  const fits = widthBudget >= minDisplayWidth;
+  const renderWidth = Math.min(displayWidth, Math.max(widthBudget, minDisplayWidth));
+  // Also cap the drag range so releasing a drag can never persist a width that
+  // immediately fails the fit check and hides the panel.
+  const maxPanelWidth = Math.min(MAX_PANEL_WIDTH, Math.max(widthBudget, minDisplayWidth));
   const openMenuItems = useCallback((): DropdownItem[] => {
     const itemOf = (key: string): DropdownItem | undefined => {
       const tab = availableTabs.get(key);
@@ -755,11 +765,11 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
     <RightPanel
       stableLayout
       collapseThreshold={320}
-      defaultWidth={displayWidth}
+      defaultWidth={renderWidth}
       expand={Boolean(showRightPanel) && fits}
-      maxWidth={MAX_PANEL_WIDTH}
-      minWidth={300}
-      width={displayWidth}
+      maxWidth={maxPanelWidth}
+      minWidth={MIN_PANEL_WIDTH}
+      width={renderWidth}
       onSizeChange={(size) => {
         if (!size?.width) return;
         // DraggablePanel emits width as a `"420px"` string on drag-stop; parse it so


### PR DESCRIPTION
Dragging the working sidebar (e.g. the in-app Browser tab) wider than the row's budget made the whole panel vanish on drag release: `fitsBesidePortal` compared the row against the just-persisted sidebar width, so `expand` flipped to false the moment the drag ended — and with the too-wide value stored in `workingSidebarWidth`, the panel never came back at that window size.

The yield-first behavior came from #17861 (per-view portal widths, acceptance opens at 840). It was meant for "a wide portal squeezed the row", but it also fired on the user's own drag.

#### Fix

- `sidebarWidthBudget` computes the widest the sidebar may render (`availableWidth - portalWidth - CONVERSATION_KEEP_WIDTH`, `Infinity` before the row is measured).
- The panel hides only when even its **minimum** width (300, or 560 in two-pane Review) doesn't fit — a stored width that merely outgrew the row now renders clamped to the budget instead of unmounting. The clamp is render-only: the persisted preference survives for wider rows, and an already-persisted too-wide value self-heals into a visible clamped panel.
- The drag range (`maxWidth`) is capped to the same budget, so releasing a drag can never persist a width that immediately hides the panel.

The genuine yield case is unchanged: an 840px acceptance portal on a narrow row still hides the sidebar when the minimum width has no room.

#### Test

- [x] Added/updated tests — the two new regression cases fail on the pre-fix code (`expand` was `false` at stored 1250 / row 1540; `maxWidth` was uncapped at 1200) and pass after.
- [x] `bun run check` on the four touched files: lint clean, 41 tests passed.

#### 🔗 Related Issue

Regression from #17861.