### PR TITLE
✨ feat(desktop): boot the main window straight into the last active workspace

### DIFF
--- a/apps/desktop/src/main/const/store.ts
+++ b/apps/desktop/src/main/const/store.ts
@@ -38,6 +38,7 @@ export const STORE_DEFAULTS: ElectronMainStore = {
   heteroSessionDirPrefs: {},
   heteroTracingEnabled: false,
   imessageBridgeConfigs: [],
+  lastWorkspaceSlugByAccount: {},
   locale: 'auto',
   localFileWorkspaceRoots: [],
   networkProxy: defaultProxySettings,

--- a/apps/desktop/src/main/controllers/SystemCtr.ts
+++ b/apps/desktop/src/main/controllers/SystemCtr.ts
@@ -19,6 +19,7 @@ import * as electronIs from '@/utils/platform';
 import { getSystemLanguage, resolveUILocale } from '@/utils/system-language';
 
 import { ControllerModule, IpcMethod } from './index';
+import RemoteServerConfigCtr from './RemoteServerConfigCtr';
 
 const logger = createLogger('controllers:SystemCtr');
 
@@ -77,6 +78,18 @@ export default class SystemController extends ControllerModule {
   @IpcMethod()
   setDesktopOnboardingCompleted(completed: boolean): void {
     this.app.storeManager.set('desktopOnboardingCompleted', completed);
+  }
+
+  @IpcMethod()
+  setLastWorkspaceSlug(slug: string | null): void {
+    const { userId } = this.app.getController(RemoteServerConfigCtr).getDesktopBootstrapIdentity();
+    if (!userId) return;
+
+    const slugByAccount = { ...this.app.storeManager.get('lastWorkspaceSlugByAccount', {}) };
+    if (slug) slugByAccount[userId] = slug;
+    else delete slugByAccount[userId];
+
+    this.app.storeManager.set('lastWorkspaceSlugByAccount', slugByAccount);
   }
 
   @IpcMethod()

--- a/apps/desktop/src/main/controllers/__tests__/SystemCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/SystemCtr.test.ts
@@ -97,6 +97,12 @@ vi.mock('@/utils/platform', () => ({
   macOS: vi.fn(() => true),
 }));
 
+// Sever RemoteServerConfigCtr's heavy import chain — the class only serves as
+// the getController token here, and mockApp.getController ignores it anyway.
+vi.mock('../RemoteServerConfigCtr', () => ({
+  default: class MockRemoteServerConfigCtr {},
+}));
+
 vi.mock('font-list', () => ({
   getFonts2: fontListGetFonts2Mock,
 }));
@@ -130,9 +136,17 @@ const mockI18n = {
   ns: vi.fn((namespace: string) => (key: string) => `${namespace}.${key}`),
 };
 
+const mockGetDesktopBootstrapIdentity = vi.fn(() => ({
+  isIdentityResolved: true,
+  userId: 'user_1',
+}));
+
 const mockApp = {
   appStoragePath: '/mock/storage',
   browserManager: mockBrowserManager,
+  getController: vi.fn(() => ({
+    getDesktopBootstrapIdentity: mockGetDesktopBootstrapIdentity,
+  })),
   i18n: mockI18n,
   storeManager: mockStoreManager,
 } as unknown as App;
@@ -178,6 +192,37 @@ describe('SystemController', () => {
       await invokeIpc('system.setDesktopOnboardingCompleted', true);
 
       expect(mockStoreManager.set).toHaveBeenCalledWith('desktopOnboardingCompleted', true);
+    });
+  });
+
+  describe('setLastWorkspaceSlug', () => {
+    it("records the slug under the current account's entry", async () => {
+      mockStoreManager.get.mockReturnValueOnce({ user_2: 'other' });
+
+      await invokeIpc('system.setLastWorkspaceSlug', 'acme');
+
+      expect(mockStoreManager.set).toHaveBeenCalledWith('lastWorkspaceSlugByAccount', {
+        user_1: 'acme',
+        user_2: 'other',
+      });
+    });
+
+    it("clears only the current account's entry on personal scope", async () => {
+      mockStoreManager.get.mockReturnValueOnce({ user_1: 'acme', user_2: 'other' });
+
+      await invokeIpc('system.setLastWorkspaceSlug', null);
+
+      expect(mockStoreManager.set).toHaveBeenCalledWith('lastWorkspaceSlugByAccount', {
+        user_2: 'other',
+      });
+    });
+
+    it('does nothing when no account identity is available', async () => {
+      mockGetDesktopBootstrapIdentity.mockReturnValueOnce({ isIdentityResolved: true } as any);
+
+      await invokeIpc('system.setLastWorkspaceSlug', 'acme');
+
+      expect(mockStoreManager.set).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/desktop/src/main/core/browser/BrowserManager.ts
+++ b/apps/desktop/src/main/core/browser/BrowserManager.ts
@@ -274,10 +274,27 @@ export class BrowserManager {
   private resolveMainWindowInitialPath(
     isOnboardingCompleted: boolean,
     pendingRestoreRoute: string,
+    lastWorkspaceSlug: string,
   ): string {
     if (!isOnboardingCompleted) return '/desktop-onboarding';
     if (pendingRestoreRoute) return pendingRestoreRoute;
+    // Shape guard: a corrupted store value must not produce an unloadable path.
+    if (lastWorkspaceSlug && /^[a-z0-9-]+$/.test(lastWorkspaceSlug)) {
+      return `/${lastWorkspaceSlug}`;
+    }
     return '/';
+  }
+
+  /**
+   * The account's remembered workspace slug, so the main window boots straight
+   * at `/{slug}` with no post-load redirect. The account comes from the stored
+   * OIDC token — no token (signed out) means no memory to apply.
+   */
+  private getLastWorkspaceSlug(remoteServerConfigCtr: RemoteServerConfigCtr): string {
+    const { userId } = remoteServerConfigCtr.getDesktopBootstrapIdentity();
+    if (!userId) return '';
+
+    return this.app.storeManager.get('lastWorkspaceSlugByAccount', {})[userId] ?? '';
   }
 
   /**
@@ -302,6 +319,7 @@ export class BrowserManager {
         const initialPath = this.resolveMainWindowInitialPath(
           isOnboardingCompleted,
           pendingRestoreRoute,
+          this.getLastWorkspaceSlug(remoteServerConfigCtr),
         );
         browser = {
           ...browser,

--- a/apps/desktop/src/main/core/browser/__tests__/BrowserManager.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/BrowserManager.test.ts
@@ -109,6 +109,9 @@ describe('BrowserManager', () => {
     // Create mock App
     mockApp = {
       getController: vi.fn().mockReturnValue({
+        getDesktopBootstrapIdentity: vi
+          .fn()
+          .mockReturnValue({ isIdentityResolved: true, userId: 'user_1' }),
         isRemoteServerConfigured: vi.fn().mockResolvedValue(true),
       }),
       storeManager: {
@@ -284,10 +287,10 @@ describe('BrowserManager', () => {
     });
 
     it('keeps legacy remote-configured users on the main route when no completion marker exists', async () => {
-      (mockApp.storeManager.get as any).mockImplementation((key: string) => {
+      (mockApp.storeManager.get as any).mockImplementation((key: string, defaultValue?: any) => {
         if (key === 'desktopOnboardingCompleted') return undefined;
         if (key === 'pendingRestoreRoute') return '';
-        return undefined;
+        return defaultValue;
       });
 
       await manager.initializeBrowsers();
@@ -323,6 +326,9 @@ describe('BrowserManager', () => {
         return '';
       });
       (mockApp.getController as any).mockReturnValue({
+        getDesktopBootstrapIdentity: vi
+          .fn()
+          .mockReturnValue({ isIdentityResolved: true, userId: 'user_1' }),
         isRemoteServerConfigured: vi.fn().mockResolvedValue(false),
       });
 
@@ -332,11 +338,71 @@ describe('BrowserManager', () => {
       expect(mockApp.storeManager.set).toHaveBeenCalledWith('pendingRestoreRoute', '');
     });
 
-    it('resumes onboarding when Login completed but later first-run steps did not', async () => {
+    it("boots the main window at the account's remembered workspace slug", async () => {
       (mockApp.storeManager.get as any).mockImplementation((key: string) => {
+        if (key === 'lastWorkspaceSlugByAccount') return { user_1: 'acme' };
+        return '';
+      });
+
+      await manager.initializeBrowsers();
+
+      expect(manager.browsers.get('app')?.options.path).toBe('/acme');
+    });
+
+    it("never applies another account's remembered slug", async () => {
+      (mockApp.storeManager.get as any).mockImplementation((key: string) => {
+        if (key === 'lastWorkspaceSlugByAccount') return { user_2: 'acme' };
+        return '';
+      });
+
+      await manager.initializeBrowsers();
+
+      expect(manager.browsers.get('app')?.options.path).toBe('/');
+    });
+
+    it('boots at the main route when signed out', async () => {
+      (mockApp.getController as any).mockReturnValue({
+        getDesktopBootstrapIdentity: vi.fn().mockReturnValue({ isIdentityResolved: true }),
+        isRemoteServerConfigured: vi.fn().mockResolvedValue(true),
+      });
+      (mockApp.storeManager.get as any).mockImplementation((key: string) => {
+        if (key === 'lastWorkspaceSlugByAccount') return { user_1: 'acme' };
+        return '';
+      });
+
+      await manager.initializeBrowsers();
+
+      expect(manager.browsers.get('app')?.options.path).toBe('/');
+    });
+
+    it('prefers a captured update-restart route over the remembered workspace slug', async () => {
+      (mockApp.storeManager.get as any).mockImplementation((key: string) => {
+        if (key === 'pendingRestoreRoute') return '/agent/abc';
+        if (key === 'lastWorkspaceSlugByAccount') return { user_1: 'acme' };
+        return '';
+      });
+
+      await manager.initializeBrowsers();
+
+      expect(manager.browsers.get('app')?.options.path).toBe('/agent/abc');
+    });
+
+    it('ignores a malformed remembered workspace slug', async () => {
+      (mockApp.storeManager.get as any).mockImplementation((key: string) => {
+        if (key === 'lastWorkspaceSlugByAccount') return { user_1: '../evil?x=1' };
+        return '';
+      });
+
+      await manager.initializeBrowsers();
+
+      expect(manager.browsers.get('app')?.options.path).toBe('/');
+    });
+
+    it('resumes onboarding when Login completed but later first-run steps did not', async () => {
+      (mockApp.storeManager.get as any).mockImplementation((key: string, defaultValue?: any) => {
         if (key === 'desktopOnboardingCompleted') return false;
         if (key === 'pendingRestoreRoute') return '';
-        return undefined;
+        return defaultValue;
       });
 
       await manager.initializeBrowsers();

--- a/apps/desktop/src/main/types/store.ts
+++ b/apps/desktop/src/main/types/store.ts
@@ -46,6 +46,14 @@ export interface ElectronMainStore {
   heteroSessionDirPrefs: Record<string, HeteroSessionDirPref>;
   heteroTracingEnabled: boolean;
   imessageBridgeConfigs: ImessageBridgeConfig[];
+  /**
+   * Per-account memory of the workspace slug the main window was last in
+   * (account = OIDC subject; no entry = personal). The next launch of that
+   * account boots the window straight at `/{slug}` — no post-load redirect.
+   * Written blind: a slug gone stale (membership revoked elsewhere) still
+   * boots, and the renderer settles the real scope from there.
+   */
+  lastWorkspaceSlugByAccount: Record<string, string>;
   locale: string;
   localFileWorkspaceRoots: string[];
   networkProxy: NetworkProxySettings;

--- a/src/features/Electron/TabHost/resolveBootAction.test.ts
+++ b/src/features/Electron/TabHost/resolveBootAction.test.ts
@@ -65,4 +65,20 @@ describe('resolveBootAction', () => {
 
     expect(resolveBootAction(tabs, null, '/')).toEqual({ id: 'a', type: 'activate' });
   });
+
+  it('keeps the persisted active tab on a workspace scope-root launch', () => {
+    const tabs = [tab('a', '/acme/agent/x'), tab('b', '/acme')];
+
+    expect(resolveBootAction(tabs, 'a', '/acme')).toEqual({ type: 'keep' });
+  });
+
+  it('adds a workspace home tab on a scope-root launch with an empty scope store', () => {
+    expect(resolveBootAction([], null, '/acme')).toEqual({ type: 'add', url: '/acme' });
+  });
+
+  it('still treats a workspace deep link as a deep link, not a default launch', () => {
+    const tabs = [tab('a', '/acme'), tab('b', '/acme/image')];
+
+    expect(resolveBootAction(tabs, 'a', '/acme/image')).toEqual({ id: 'b', type: 'activate' });
+  });
 });

--- a/src/features/Electron/TabHost/resolveBootAction.ts
+++ b/src/features/Electron/TabHost/resolveBootAction.ts
@@ -1,16 +1,24 @@
-import { isSameTabTarget } from '@/features/Electron/titlebar/TabBar/scope';
+import { isSameTabTarget, resolveTabScope } from '@/features/Electron/titlebar/TabBar/scope';
 import { type TabItem } from '@/features/Electron/titlebar/TabBar/types';
 import { normalizeTabUrl } from '@/features/Electron/titlebar/TabBar/url';
 
 export type BootAction =
   { type: 'keep' } | { id: string; type: 'activate'; url?: string } | { type: 'add'; url: string };
 
+const scopeRootUrl = (bootUrl: string): string => {
+  const scope = resolveTabScope(bootUrl);
+  return scope.type === 'workspace' ? `/${scope.slug}` : '/';
+};
+
 export const resolveBootAction = (
   tabs: TabItem[],
   activeTabId: string | null,
   bootUrl: string,
 ): BootAction => {
-  const isDefaultLaunch = normalizeTabUrl(bootUrl) === '/';
+  // A scope-root boot url (`/`, or `/{slug}` when the main process restores the
+  // last workspace) is a plain launch, not a deep link: keep the scope's last
+  // active tab instead of forcing its home tab to the front.
+  const isDefaultLaunch = normalizeTabUrl(bootUrl) === scopeRootUrl(bootUrl);
   const activeTabExists = !!activeTabId && tabs.some((tab) => tab.id === activeTabId);
 
   if (isDefaultLaunch && activeTabExists) return { type: 'keep' };

--- a/src/features/Electron/shell/index.ts
+++ b/src/features/Electron/shell/index.ts
@@ -1,3 +1,4 @@
 export { selectActiveTabUrl } from './activeTabUrl';
 export { useDesktopDocumentTitle } from './useDesktopDocumentTitle';
+export { useLastWorkspaceSlugSync } from './useLastWorkspaceSlugSync';
 export { useWindowUrlMirror } from './useWindowUrlMirror';

--- a/src/features/Electron/shell/useLastWorkspaceSlugSync.test.ts
+++ b/src/features/Electron/shell/useLastWorkspaceSlugSync.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
 import { PERSONAL_TAB_SCOPE } from '@/features/Electron/titlebar/TabBar/scope';
 import { electronSystemService } from '@/services/electron/system';
@@ -7,7 +7,7 @@ import { useElectronStore } from '@/store/electron';
 
 import { useLastWorkspaceSlugSync } from './useLastWorkspaceSlugSync';
 
-let setLastWorkspaceSlug: ReturnType<typeof vi.spyOn>;
+let setLastWorkspaceSlug: MockInstance<(slug: string | null) => Promise<void>>;
 
 beforeEach(() => {
   setLastWorkspaceSlug = vi

--- a/src/features/Electron/shell/useLastWorkspaceSlugSync.test.ts
+++ b/src/features/Electron/shell/useLastWorkspaceSlugSync.test.ts
@@ -1,0 +1,44 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PERSONAL_TAB_SCOPE } from '@/features/Electron/titlebar/TabBar/scope';
+import { electronSystemService } from '@/services/electron/system';
+import { useElectronStore } from '@/store/electron';
+
+import { useLastWorkspaceSlugSync } from './useLastWorkspaceSlugSync';
+
+let setLastWorkspaceSlug: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  setLastWorkspaceSlug = vi
+    .spyOn(electronSystemService, 'setLastWorkspaceSlug')
+    .mockResolvedValue();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  useElectronStore.setState({ activeTabScope: PERSONAL_TAB_SCOPE });
+});
+
+describe('useLastWorkspaceSlugSync', () => {
+  it('persists the workspace slug when the scope changes, and null back on personal', () => {
+    renderHook(() => useLastWorkspaceSlugSync());
+    expect(setLastWorkspaceSlug).toHaveBeenLastCalledWith(null);
+
+    act(() => useElectronStore.setState({ activeTabScope: { slug: 'acme', type: 'workspace' } }));
+    expect(setLastWorkspaceSlug).toHaveBeenLastCalledWith('acme');
+
+    act(() => useElectronStore.setState({ activeTabScope: PERSONAL_TAB_SCOPE }));
+    expect(setLastWorkspaceSlug).toHaveBeenLastCalledWith(null);
+  });
+
+  it('does not rewrite when a scope reload keeps the same slug', () => {
+    useElectronStore.setState({ activeTabScope: { slug: 'acme', type: 'workspace' } });
+
+    renderHook(() => useLastWorkspaceSlugSync());
+    expect(setLastWorkspaceSlug).toHaveBeenCalledTimes(1);
+
+    act(() => useElectronStore.setState({ activeTabScope: { slug: 'acme', type: 'workspace' } }));
+    expect(setLastWorkspaceSlug).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/Electron/shell/useLastWorkspaceSlugSync.ts
+++ b/src/features/Electron/shell/useLastWorkspaceSlugSync.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { electronSystemService } from '@/services/electron/system';
+import { type ElectronStore, useElectronStore } from '@/store/electron';
+
+const selectActiveScopeSlug = (s: ElectronStore): string | null =>
+  s.activeTabScope.type === 'workspace' ? s.activeTabScope.slug : null;
+
+// Mirror the active tab scope into the main-process store so the next launch
+// can boot the window directly at `/{slug}` (BrowserManager reads it when
+// resolving the main window's initial path). Personal scope clears the memory.
+export const useLastWorkspaceSlugSync = (): void => {
+  const slug = useElectronStore(selectActiveScopeSlug);
+
+  useEffect(() => {
+    electronSystemService.setLastWorkspaceSlug(slug).catch((err) => {
+      console.error('[desktop] persist last workspace slug failed', err);
+    });
+  }, [slug]);
+};

--- a/src/routes/(main)/_layout/index.desktop.tsx
+++ b/src/routes/(main)/_layout/index.desktop.tsx
@@ -18,7 +18,11 @@ import AuthRequiredModal from '@/features/Electron/AuthRequiredModal';
 import OverlayCaptureUploader from '@/features/Electron/ScreenCapture/OverlayCaptureUploader';
 import OverlayMessageDispatcher from '@/features/Electron/ScreenCapture/OverlayMessageDispatcher';
 import OverlaySnapshotPublisher from '@/features/Electron/ScreenCapture/OverlaySnapshotPublisher';
-import { useDesktopDocumentTitle, useWindowUrlMirror } from '@/features/Electron/shell';
+import {
+  useDesktopDocumentTitle,
+  useLastWorkspaceSlugSync,
+  useWindowUrlMirror,
+} from '@/features/Electron/shell';
 import ZoomHUD from '@/features/Electron/system/ZoomHUD';
 import { TabHost, useSeedTabsOnBoot } from '@/features/Electron/TabHost';
 import TabCacheBridges from '@/features/Electron/titlebar/TabBar/TabCacheBridges';
@@ -46,6 +50,7 @@ const Layout: FC = () => {
 
   useSeedTabsOnBoot();
   useWindowUrlMirror();
+  useLastWorkspaceSlugSync();
   useDesktopDocumentTitle();
 
   return (

--- a/src/services/electron/system.ts
+++ b/src/services/electron/system.ts
@@ -35,6 +35,10 @@ class ElectronSystemService {
     return this.ipc.system.setDesktopOnboardingCompleted(completed);
   }
 
+  async setLastWorkspaceSlug(slug: string | null): Promise<void> {
+    return this.ipc.system.setLastWorkspaceSlug(slug);
+  }
+
   async getSystemMonospaceFonts(): Promise<SystemMonospaceFont[]> {
     return this.ipc.system.getSystemMonospaceFonts();
   }


### PR DESCRIPTION
Desktop cold starts always loaded `/` (personal scope), so a user whose last session lived in a workspace had to be moved into it after the app was already up. This PR persists the last active workspace slug per account in the main-process store and uses it to resolve the main window's initial path, so the first `loadURL` already carries the `/{slug}` prefix — no post-load redirect.

- **Main store**: new `lastWorkspaceSlugByAccount: Record<userId, slug>` (account = OIDC `sub`), written blind at scope-change time. `SystemCtr.setLastWorkspaceSlug(slug | null)` resolves the account itself via `RemoteServerConfigCtr.getDesktopBootstrapIdentity()`; personal scope deletes the entry.
- **Boot path**: `BrowserManager.resolveMainWindowInitialPath` now falls through onboarding → `pendingRestoreRoute` → `/{lastWorkspaceSlug}` (shape-guarded) → `/`. Signed-out or another account's entry never applies.
- **Renderer**: `useLastWorkspaceSlugSync` (desktop shell) mirrors `activeTabScope` into the main store over IPC — the only renderer addition.
- **Tab boot semantics**: `resolveBootAction` treats a workspace scope-root boot URL (`/{slug}`) as a plain launch, keeping the scope's last active tab — symmetric with the existing `/` behavior.

A stale slug (membership revoked / renamed elsewhere) still boots into `/{slug}` and settles through the renderer's existing resolution; the next scope change rewrites the memory.

| Before | After |
| ------ | ----- |
| Cold start lands on `/` (personal), workspace users get moved after load | First `loadURL` is `/{slug}`; main-process log `Main window initial path: /innei-dev` and the initial CDP page target both carry the prefix |

#### Test

- Unit: `BrowserManager` (remembered-slug boot, other-account isolation, signed-out fallback, `pendingRestoreRoute` precedence, malformed slug guard), `SystemCtr` (per-account write/clear, no identity no-op), `resolveBootAction` (scope-root launch keeps active tab), `useLastWorkspaceSlugSync`.
- E2E (cloud desktop dev instance against production backend): switch to workspace → store records `{userId: slug}`; cold boot → initial page target is `app://renderer/{slug}` with no intermediate `/`; switch back to personal → entry cleared, boot returns to `/`.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

None.