### PR TITLE
🐛 fix(verify): finish acceptance Drawer migration & stop drawer focus-scroll page jump

### DIFF
--- a/.agents/acceptance/common-mistakes.md
+++ b/.agents/acceptance/common-mistakes.md
@@ -339,6 +339,23 @@ it in the route layout instead, and cover it with a test that asserts which rout
 received the write — a test that only asserts a write happened passes on the
 broken topology too.
 
+### L-S7 — Verifying a dependency-level fix through a dev server that predates the install
+
+**Wrong approach:** confirm the fixed version exists in `node_modules`, then capture
+behavioral evidence through an already-running Vite dev server.
+
+**Why it fails:** Vite pins its optimized dependency bundle at server boot. A server
+started before (or during) the `pnpm install` that brought the fix serves the old
+dependency code for its entire lifetime — the browser provably executes code that no
+longer exists on disk, and the evidence contradicts the source. An in-process restart
+via touching the Vite config can wedge the optimizer (new dep URLs 504); only a real
+process restart is trustworthy.
+
+**Correct approach:** before capturing evidence for a dependency-level change, prove
+the served bundle carries it — fetch the relevant `/node_modules/.vite/deps/*` chunk
+from the dev server and grep for a marker of the fix — or restart the dev server
+process outright and re-verify.
+
 ## Historical source
 
 Detailed incident narratives and retired pixel- or component-specific directions

--- a/src/features/Verify/Acceptance/index.tsx
+++ b/src/features/Verify/Acceptance/index.tsx
@@ -7,7 +7,6 @@ import {
   Center,
   copyToClipboard,
   DraggablePanel,
-  Drawer,
   Empty,
   Flexbox,
   Icon,
@@ -15,7 +14,7 @@ import {
   Text,
 } from '@lobehub/ui';
 import type { DropdownItem } from '@lobehub/ui/base-ui';
-import { Button, DropdownMenu, Select, toast } from '@lobehub/ui/base-ui';
+import { Button, Drawer, DropdownMenu, Select, toast } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx, useResponsive } from 'antd-style';
 import dayjs from 'dayjs';
 import {
@@ -1848,7 +1847,7 @@ const AcceptancePage = memo<AcceptancePageProps>(
               containerMaxWidth={'100%'}
               open={ledgerExpand}
               placement={'right'}
-              styles={{ body: { padding: 0 } }}
+              styles={{ bodyContent: { padding: 0 } }}
               width={'min(340px, 88vw)'}
               onClose={() => setLedgerExpand(false)}
             >
@@ -1872,6 +1871,7 @@ const AcceptancePage = memo<AcceptancePageProps>(
             </Drawer>
           ) : (
             <DraggablePanel
+              stableLayout
               defaultSize={{ width: 340 }}
               expand={ledgerExpand}
               minWidth={300}
@@ -1910,15 +1910,13 @@ const AcceptancePage = memo<AcceptancePageProps>(
           so no extra close button here (two would overlap). */}
         {showHistory && (
           <Drawer
-            destroyOnHidden
             noHeader
             containerMaxWidth={'100%'}
             open={reportRound !== null}
             placement={'right'}
             width={'min(960px, 92vw)'}
             styles={{
-              body: { height: '100%', padding: 0 },
-              bodyContent: { height: '100%', minHeight: 0, overflow: 'hidden' },
+              bodyContent: { height: '100%', minHeight: 0, overflow: 'hidden', padding: 0 },
             }}
             onClose={() => openReport(null)}
           >

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -23,9 +23,12 @@ const genGlobalStyle = ({ token }: { prefixCls: string; token: Theme }) => css`
   }
 
   body {
-    /* Increase compositing layer, force hardware acceleration, otherwise render black edges will appear */
+    /* Own stacking context, otherwise render black edges will appear. Must NOT
+       be a transform-based hack: a transform on body rebases every position:
+       fixed descendant onto body, and a drawer panel mid slide-in then overflows
+       body horizontally — focusing it scrolls the whole page sideways. */
     will-change: opacity;
-    transform: translateZ(0);
+    isolation: isolate;
   }
 
   * {


### PR DESCRIPTION
The acceptance page carried the last two antd-backed Drawers in the repo, and opening its report drawer made the whole page jump left and spring back. Both are addressed here, plus a `stableLayout` on the ledger panel.

**1. Finish the base-ui Drawer migration (missed by #17914)**

`Acceptance/index.tsx` still imported `Drawer` from the `@lobehub/ui` root (antd wrapper) — the last such call sites in the repo. Migrated with the exact prop mapping #17914 established: `styles.body` → `styles.bodyContent`, `destroyOnHidden` dropped. Verified the `noHeader` floating close still renders on the report drill-down drawer. The ledger `DraggablePanel` also gains `stableLayout` so collapse/expand keeps content layout stable.

**2. Body `translateZ(0)` hack → `isolation: isolate`**

The global `body { transform: translateZ(0) }` compositing hack made body the containing block for every `position: fixed` element in the app. A base-ui drawer panel mid slide-in therefore overflowed body horizontally, and Base UI's open-time autofocus made the browser focus-scroll `body.scrollLeft` to ~835px before snapping back — the visible "page shifts left, then returns" glitch. antd drawers wrapped their panel in an `inset: 0` box, which is why the migration exposed it.

`isolation: isolate` provides the stacking context the black-edge workaround needs without hijacking fixed positioning. Verified in-browser after the change: the drawer popup's `offsetParent` is `null` again (true viewport-fixed), and a 60fps rAF sample across a cold drawer open shows `body.scrollLeft` pinned at 0 with zero layout shift (previously jumped to 835 and animated back).

Also records an agent-testing living-log entry (L-S7): a Vite dev server started mid-`pnpm install` serves stale optimized deps for its whole session — verify the served bundle, not `node_modules`, before capturing evidence.

| Before | After |
| ------ | ----- |
| Opening the report drawer horizontally scrolls body (scrollLeft → 835), the page visibly jumps left and springs back; image viewer opened inside the drawer loses its backdrop under stale deps | Drawer opens with zero page movement (`body.scrollLeft` stays 0, max layout shift 0px over 278 sampled frames); viewer backdrop renders at z-1220 with blur |

#### Test

Reproduced and verified live on the acceptance page through the local dev proxy, sampling `body.scrollLeft` and the decision bar's bounding rect per animation frame across cold drawer opens, before and after the fix. No unit test: the failure needs real-browser focus-scroll and containing-block behavior that jsdom cannot express; the invariant is documented inline in `global.ts`.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed