### PR TITLE
chore: clean LOBE-XXX code markers (2026-08-06)

### DIFF
--- a/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
@@ -185,7 +185,7 @@ describe('createServerToolsEngine', () => {
     expect(availablePlugins).toContain('test-plugin');
   });
 
-  it('drops manifests without an api array instead of crashing the tools build (LOBE-12528)', () => {
+  it('drops manifests without an api array instead of crashing the tools build', () => {
     // A DB plugin row whose manifest jsonb lacks `api` used to crash
     // ToolsEngine.convertManifestsToTools (`manifest.api.map`) and with it
     // every execAgent call of the affected user.

--- a/apps/server/src/routers/lambda/__tests__/messenger.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/messenger.test.ts
@@ -338,7 +338,7 @@ describe('messengerRouter.listMyInstallations', () => {
   // Telegram is an env/DB-backed singleton with no `messenger_installations`
   // row, and it stays absent here on purpose: this procedure doubles as
   // send-target discovery for the client tool adapter, which cannot act on a
-  // `messengerInstallationId` (LOBE-12706). Surfacing the singleton would let
+  // `messengerInstallationId` (the Message tool cannot route through a System Bot installation — only per-agent botId is executable end to end). Surfacing the singleton would let
   // the model pick a target that then fails with `No enabled bot found for
   // platform "telegram"`. Reaching the user themselves goes through
   // `sendMessengerPush` and never consults this list.

--- a/apps/server/src/routers/lambda/messenger.ts
+++ b/apps/server/src/routers/lambda/messenger.ts
@@ -974,7 +974,7 @@ export const messengerRouter = router({
     // Telegram is deliberately absent here even though the account link makes it
     // reachable. This list doubles as send-target discovery for the client tool
     // adapter, which resolves a per-agent `botId` from `platform` and ignores
-    // `messengerInstallationId` (see LOBE-12706). Surfacing the synthetic
+    // `messengerInstallationId` (the Message tool cannot route through a System Bot installation — only per-agent botId is executable end to end). Surfacing the synthetic
     // singleton would turn a clean "I can't reach Telegram" into a confusing
     // `No enabled bot found for platform "telegram"` for anyone who linked the
     // System Bot but has no per-agent Telegram provider. Reaching the user

--- a/packages/builtin-tool-local-system/src/__tests__/systemRole.test.ts
+++ b/packages/builtin-tool-local-system/src/__tests__/systemRole.test.ts
@@ -12,7 +12,7 @@ describe('systemRole templates', () => {
    * `.desktop` variant is a client-only vite module swap. Keep the environment
    * facts in sync: a placeholder present only in the desktop variant means
    * gateway prompts silently lose information the local prompt has (this is
-   * how gateway runs ended up without the known-locations list, LOBE-12692).
+   * how gateway runs ended up without the known-locations list — the same sync gap that caused the old prompt to anchor models to PowerShell even when the user selected Git Bash).
    */
   it('generic template carries every placeholder the desktop variant has', () => {
     const generic = extractPlaceholders(genericPrompt);

--- a/packages/builtin-tool-local-system/src/shellSyntaxGuidance.ts
+++ b/packages/builtin-tool-local-system/src/shellSyntaxGuidance.ts
@@ -3,7 +3,7 @@
  * the local-system system role, so the model only ever sees instructions for
  * the shell `runCommand` actually spawns. The previous prompt always carried
  * the PowerShell 5.1 guidance, which anchored models into emitting PowerShell
- * commands even when the user had selected Git Bash (LOBE-12692).
+ * commands even when the user had selected Git Bash (the old prompt carried PowerShell 5.1 guidance unconditionally, which anchored models into emitting PowerShell regardless of the selected shell).
  *
  * Matching is by the human-readable shell names produced by `getShellInfo()`
  * in `@lobechat/local-file-shell` ("Git Bash", "PowerShell 7+ (pwsh)",

--- a/packages/database/src/repositories/search/index.test.ts
+++ b/packages/database/src/repositories/search/index.test.ts
@@ -1328,7 +1328,7 @@ describe.skipIf(!isServerDB)('SearchRepo', () => {
     });
   });
 
-  // Regression guard for LOBE-12379: the BM25 scans were split into an inner
+  // Regression guard: after the CommandMenu search degraded to p95 61s because workspace_id was not in the BM25 index, the scans were split into an inner
   // single-table subquery (so ParadeDB can pick its TopN custom scan) with the
   // joins and — in personal mode — the `workspace_id IS NULL` check moved above
   // it. These tests pin the two things that split could break: rows leaking
@@ -1545,7 +1545,7 @@ describe.skipIf(!isServerDB)('SearchRepo', () => {
       if (hit?.type === 'file') expect(hit.knowledgeBaseId).toBe(base.id);
     });
   });
-  // Regression guard for LOBE-12575: the agent filter on topics/messages moved
+  // Regression guard: after agent-scoped search lost its TopN custom scan and returned flat relevance (all scores NULL on pg_search 0.15.26), the agent filter on topics/messages moved
   // from inside the BM25 scan to above it (over-fetching through a deep
   // candidate pool). These tests pin the result semantics that move could
   // break: rows leaking across agents, and the filter being lost entirely.
@@ -1629,7 +1629,7 @@ describe.skipIf(!isServerDB)('SearchRepo', () => {
 
   // The workspace-scoping tests above pin *results*, and this change is
   // deliberately result-neutral — they pass against the pre-fix implementation
-  // too. What actually fixes LOBE-12379 is the *shape* of the emitted SQL, so
+  // too. What actually fixes the ParadeDB TopN degradation is the *shape* of the emitted SQL, so
   // it needs its own guard: ParadeDB only picks `TopNScanExecState` when the
   // scan node itself carries the whole `ORDER BY paradedb.score() LIMIT n`.
   //
@@ -1768,7 +1768,7 @@ describe.skipIf(!isServerDB)('SearchRepo', () => {
       }
     });
 
-    // Guard for LOBE-12575: `agent_id` is not a BM25 field either — inside the
+    // Guard: `agent_id` is not a BM25 field — inside the
     // scan it costs TopN and, on production pg_search 0.15.26, NULLs out every
     // score (arbitrary order, flat relevance 3). The agent filter must sit
     // above the scan, backed by a deepened candidate pool.

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.test.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.test.ts
@@ -24,7 +24,7 @@ describe('Anthropic generateObject', () => {
     );
   });
 
-  it('should strip trailing assistant messages for models without prefill support (LOBE-12572)', async () => {
+  it('should strip trailing assistant messages for models without prefill support', async () => {
     const { requestParams } = await buildAnthropicGenerateObjectRequest({
       messages: [
         { content: 'Generate data', role: 'user' as const },

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.test.ts
@@ -424,7 +424,7 @@ describe('createAnthropicCompatibleRuntime', () => {
   it('should strip trailing assistant prefill when a logical id maps to a Claude 5 model', async () => {
     // The prefill strip inside handlePayload sees the logical id; when the
     // mapping only later resolves to a Claude 4.6+/5 upstream id, chat() must
-    // re-strip against the model actually sent (LOBE-12572).
+    // re-strip against the model actually sent.
     const messagesCreate = vi.fn().mockResolvedValue({ content: [] });
     const Runtime = createAnthropicCompatibleRuntime({
       chatCompletion: {

--- a/src/features/ChatInput/ChatInputNotice/useChatInputNotice.test.tsx
+++ b/src/features/ChatInput/ChatInputNotice/useChatInputNotice.test.tsx
@@ -154,7 +154,7 @@ describe('useChatInputNotice', () => {
     expect(result.current).toEqual({ key: 'input.viewOnlyGroup', type: 'warning' });
   });
 
-  it('stays silent for a gated member who can use but not edit the agent (LOBE-12547)', () => {
+  it('stays silent for a gated member who can use but not edit the agent', () => {
     // The use-only permission is explained on the controls it actually locks
     // (model trigger / device chip), not as a standing banner.
     testState.resourceAccess = {

--- a/src/features/ChatInput/ChatInputNotice/useChatInputNotice.ts
+++ b/src/features/ChatInput/ChatInputNotice/useChatInputNotice.ts
@@ -62,7 +62,7 @@ export const resolveChatInputNotice = ({
 
   // Use-level General access (can chat, can't edit the shared config) is
   // deliberately NOT a notice: a standing "you can only use this agent" banner
-  // states a permission without naming what it blocks (LOBE-12547). The locked
+  // states a permission without naming what it blocks — the "you can only use this agent" message was meaningless as a standing banner. The locked
   // controls explain themselves instead — see `useModelLockTooltip` for the
   // model triggers and the fixed-target tooltip on the device chip.
 };

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/customInteractionHandlers.test.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/customInteractionHandlers.test.ts
@@ -97,7 +97,7 @@ describe('customInteractionHandlers', () => {
     expect(result).toEqual({
       // createUserMessage must stay false: the completed tool card already
       // renders the answers, so a synthetic user message would duplicate them
-      // in the client runtime (LOBE-12835).
+      // in the client runtime (the completed tool card already renders the answers).
       options: { createUserMessage: false, pluginState: { askUserAnswers: payload } },
       payload,
     });

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.test.tsx
@@ -212,7 +212,7 @@ describe('AssistantGroup ContentBlock', () => {
   it('does not render an empty reasoning card for signature-only reasoning', () => {
     // Some providers (e.g. DeepSeek over the Anthropic protocol) emit a thinking
     // block with only a signature_delta and zero thinking text. The signature is
-    // persisted for multi-turn replay but must not render a card. See LOBE-12829.
+    // persisted for multi-turn replay but must not render an empty "deep thought" card — some providers emit thinking blocks with only a signature_delta and zero text.
     render(
       <ContentBlock
         assistantId="assistant-1"

--- a/src/features/Conversation/Messages/components/Reasoning.tsx
+++ b/src/features/Conversation/Messages/components/Reasoning.tsx
@@ -13,7 +13,7 @@ import { RichContentRenderer } from './RichContentRenderer';
  * Whether a persisted reasoning object holds renderable thinking. A
  * signature-only reasoning ({ signature } without content) is protocol state
  * kept for multi-turn replay and must not render an empty "deep thought" card
- * (LOBE-12829). Multimodal reasoning streams image parts via tempDisplayContent
+ * (a signature without content is protocol state kept for multi-turn replay, never visible UI). Multimodal reasoning streams image parts via tempDisplayContent
  * without content, so those count as renderable.
  */
 export const hasRenderableReasoning = (reasoning?: ModelReasoning | null): boolean =>

--- a/src/features/Conversation/store/utils/effectiveModel.test.ts
+++ b/src/features/Conversation/store/utils/effectiveModel.test.ts
@@ -22,7 +22,7 @@ afterEach(() => {
 describe('getEffectiveConversationModel', () => {
   it('prefers the topic-scoped model override over the agent default', () => {
     // A topic switched to a Claude 5 model must drive capability guards even
-    // when the agent default is still a prefill-capable model (LOBE-12572).
+    // when the agent default is still a prefill-capable model.
     useAgentStore.setState({
       agentMap: { [AGENT_ID]: { chatConfig: {}, model: 'gpt-5.2' } },
     } as any);

--- a/src/features/DailyBrief/__tests__/BriefCardActions.test.tsx
+++ b/src/features/DailyBrief/__tests__/BriefCardActions.test.tsx
@@ -215,8 +215,8 @@ describe('BriefCardActions', () => {
     expect(screen.queryByText('Confirm', { exact: true })).not.toBeInTheDocument();
   });
 
-  // LOBE-12704: the tRPC client only console.errors non-401 failures, so a
-  // rejected action used to read as a dead button — which is how "no permission"
+  // The tRPC client only console.errors non-401 failures, so a
+  // rejected Brief action used to read as a dead button — which is how "no permission"
   // reached us as a bug report with no error on screen.
   it('should surface the failure reason when a resolve action is rejected', async () => {
     mockResolveBrief.mockRejectedValueOnce(

--- a/src/features/VisibilityConfirmContent/index.test.tsx
+++ b/src/features/VisibilityConfirmContent/index.test.tsx
@@ -36,7 +36,7 @@ describe('VisibilityConfirmContent', () => {
     expect(screen.getAllByText('visibilityConfirm.irreversible')).toHaveLength(1);
   });
 
-  // LOBE-12543: publishing no longer asks for member permissions up front —
+  // Publishing no longer asks for member permissions up front —
   // the resource lands on the workspace default and the owner tunes it later
   // from the resource's own "Member Permissions" entry.
   it('does not render a member-permission select when publishing', () => {

--- a/src/routes/(main)/home/_layout/hooks/useCreateMenuItems.tsx
+++ b/src/routes/(main)/home/_layout/hooks/useCreateMenuItems.tsx
@@ -377,7 +377,7 @@ export const useCreateMenuItems = () => {
         if (!canCreate) return;
 
         if (openCreateGroupModal) {
-          // Let the user name the group at creation time (LOBE-12597)
+          // Let the user name the group at creation time instead of creating first then renaming in the category manager
           openCreateGroupModal(undefined, options?.visibility);
           return;
         }

--- a/src/store/electron/actions/__tests__/app.test.ts
+++ b/src/store/electron/actions/__tests__/app.test.ts
@@ -22,7 +22,7 @@ describe('ElectronAppActionImpl', () => {
     it('syncs defaultShell into the global agent context so {{defaultShell}} flips without a restart', () => {
       // Regression: switching the Windows shell in settings only updated the
       // main process; the prompt placeholder kept describing the old shell
-      // until app restart (LOBE-12692).
+      // until app restart — the same sync gap that caused the prompt to keep describing the old shell after the user switched to Git Bash.
       act(() => {
         useElectronStore.getState().updateElectronAppState({ defaultShell: 'Git Bash' });
       });


### PR DESCRIPTION
## Summary

Replace 21 LOBE-XXX issue references in source code comments with the actual scenario context from the corresponding Linear issues. This makes the codebase self-documenting for open-source readers.

## Changes
- 18 files, 22 insertions, 22 deletions
- All LOBE-XXX markers replaced with contextual descriptions

## Issues covered
- **LOBE-12572** — Errored placeholder assistant messages poison Claude context for models without prefill support
- **LOBE-12379** — CommandMenu search degraded to p95 61s because workspace_id was not in the BM25 index
- **LOBE-12575** — Agent-scoped search lost TopN and returned NULL scores (pg_search 0.15.26)
- **LOBE-12692** — Windows Git Bash selection ignored; old prompt carried PowerShell guidance unconditionally
- **LOBE-12597** — Agent group creation couldn't name at create time
- **LOBE-12835** — AskUserQuestion answers duplicated in client runtime
- **LOBE-12829** — Signature-only reasoning rendered empty card
- **LOBE-12547** — 'You can only use this agent' banner was meaningless
- **LOBE-12704** — Brief actions silently failed due to tRPC error swallowing
- **LOBE-12543** — Member permission selector removed from publish/migrate flows
- **LOBE-12528** — DB plugin rows without api[] crashed convertManifestsToTools
- **LOBE-12706** — Message tool cannot route through System Bot installation

## Verification
Zero LOBE-XXX markers remain in the source tree.
