### PR TITLE
🔥 refactor(labs): remove Connect Agent lab flag

### DIFF
--- a/locales/en-US/labs.json
+++ b/locales/en-US/labs.json
@@ -26,8 +26,6 @@
   "features.messageTextSelectionActions.title": "Message Text Selection Actions",
   "features.oauthApps.desc": "Show OAuth app management in personal and workspace settings. This feature is hidden by default.",
   "features.oauthApps.title": "OAuth Apps",
-  "features.platformAgent.desc": "Show the \"Connect Agent\" entry in the create menu. Connected agents (e.g. OpenClaw, Hermes) run on your own devices and communicate back via lh connect.",
-  "features.platformAgent.title": "Connect Agent",
   "features.taskVerify.desc": "Add a delivery-acceptance section to the task detail: describe acceptance in one sentence and let AI generate editable verify criteria.",
   "features.taskVerify.title": "Task Delivery Acceptance",
   "features.topicAcceptance.desc": "Author a delivery checklist for the current topic right above the composer, so the conversation is held to standards you can edit any time.",

--- a/locales/zh-CN/labs.json
+++ b/locales/zh-CN/labs.json
@@ -26,8 +26,6 @@
   "features.messageTextSelectionActions.title": "消息文本选择操作",
   "features.oauthApps.desc": "在个人和工作区设置中显示 OAuth 应用管理入口。此功能默认隐藏。",
   "features.oauthApps.title": "OAuth 应用",
-  "features.platformAgent.desc": "在创建菜单中显示「接入助理」入口。接入的助理（如 OpenClaw、Hermes）运行在你自己的设备上，通过 lh connect 与 LobeHub 通信。",
-  "features.platformAgent.title": "接入助理",
   "features.taskVerify.desc": "在任务详情里增加「交付验收」模块：一句话描述验收要求，AI 自动生成可编辑的验收项。",
   "features.taskVerify.title": "任务交付验收",
   "features.topicAcceptance.desc": "在输入框上方为当前话题编写一份交付验收清单，让对话对照你随时可编辑的标准来交付。",

--- a/packages/const/src/user.ts
+++ b/packages/const/src/user.ts
@@ -13,7 +13,6 @@ export const DEFAULT_PREFERENCE: UserPreference = {
     enableInputMarkdown: true,
     enableMessageTextSelectionActions: false,
     enableOAuthApps: false,
-    enablePlatformAgent: false,
   },
   topicGroupMode: 'byTime',
   topicIncludeCompleted: false,

--- a/packages/locales/src/default/labs.ts
+++ b/packages/locales/src/default/labs.ts
@@ -39,9 +39,6 @@ export default {
   'features.oauthApps.desc':
     'Show OAuth app management in personal and workspace settings. This feature is hidden by default.',
   'features.oauthApps.title': 'OAuth Apps',
-  'features.platformAgent.desc':
-    'Show the "Connect Agent" entry in the create menu. Connected agents (e.g. OpenClaw, Hermes) run on your own devices and communicate back via lh connect.',
-  'features.platformAgent.title': 'Connect Agent',
   'features.taskVerify.desc':
     'Add a delivery-acceptance section to the task detail: describe acceptance in one sentence and let AI generate editable verify criteria.',
   'features.taskVerify.title': 'Task Delivery Acceptance',

--- a/packages/types/src/user/preference.ts
+++ b/packages/types/src/user/preference.ts
@@ -198,10 +198,6 @@ export const UserLabSchema = z.object({
    */
   enableOAuthApps: z.boolean().optional(),
   /**
-   * show the "Add Platform Agent" entry in the create menu
-   */
-  enablePlatformAgent: z.boolean().optional(),
-  /**
    * enable the task delivery-acceptance (verify) config UI on the task detail
    */
   enableTaskVerify: z.boolean().optional(),

--- a/src/routes/(main)/settings/labs/index.tsx
+++ b/src/routes/(main)/settings/labs/index.tsx
@@ -12,7 +12,6 @@ import { useTranslation } from 'react-i18next';
 import AsyncError from '@/components/AsyncError';
 import { FORM_STYLE } from '@/const/layoutTokens';
 import SettingHeader from '@/routes/(main)/settings/features/SettingHeader';
-import { useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import { labPreferSelectors, preferenceSelectors } from '@/store/user/selectors';
 
@@ -34,7 +33,6 @@ const LabsForm = memo(() => {
     refreshUserState,
     enableAgentGraphConfig,
     enableInputMarkdown,
-    enablePlatformAgent,
     enableImessage,
     enableClaudeCodeSdk,
     enableCodexAppServer,
@@ -52,7 +50,6 @@ const LabsForm = memo(() => {
     s.refreshUserState,
     labPreferSelectors.enableAgentGraphConfig(s),
     labPreferSelectors.enableInputMarkdown(s),
-    labPreferSelectors.enablePlatformAgent(s),
     labPreferSelectors.enableImessage(s),
     labPreferSelectors.enableClaudeCodeSdk(s),
     labPreferSelectors.enableCodexAppServer(s),
@@ -64,8 +61,6 @@ const LabsForm = memo(() => {
     labPreferSelectors.enableTopicAcceptance(s),
     s.updateLab,
   ]);
-
-  const hasGatewayUrl = useServerConfigStore((s) => !!s.serverConfig.agentGatewayUrl);
 
   if (!isUserStateInit) {
     // A failed user-state init must show error + Retry, not a permanent skeleton
@@ -148,23 +143,6 @@ const LabsForm = memo(() => {
       label: tLabs('features.oauthApps.title'),
       minWidth: undefined,
     },
-    ...(hasGatewayUrl
-      ? [
-          {
-            children: (
-              <Switch
-                checked={enablePlatformAgent}
-                loading={!isPreferenceInit}
-                onChange={(checked: boolean) => updateLab({ enablePlatformAgent: checked })}
-              />
-            ),
-            className: styles.labItem,
-            desc: tLabs('features.platformAgent.desc'),
-            label: tLabs('features.platformAgent.title'),
-            minWidth: undefined,
-          } satisfies FormItemProps,
-        ]
-      : []),
     {
       children: (
         <Switch

--- a/src/store/user/slices/preference/selectors/labPrefer.ts
+++ b/src/store/user/slices/preference/selectors/labPrefer.ts
@@ -24,7 +24,6 @@ export const labPreferSelectors = {
     DEFAULT_PREFERENCE.lab?.enableMessageTextSelectionActions ??
     false,
   enableOAuthApps: (s: UserState): boolean => s.preference.lab?.enableOAuthApps ?? false,
-  enablePlatformAgent: (s: UserState): boolean => s.preference.lab?.enablePlatformAgent ?? false,
   enableTaskVerify: (s: UserState): boolean => s.preference.lab?.enableTaskVerify ?? false,
   enableTopicAcceptance: (s: UserState): boolean =>
     s.preference.lab?.enableTopicAcceptance ?? false,


### PR DESCRIPTION
#### Test

Remove the experimental Connect Agent lab preference (`enablePlatformAgent`) and its labs settings toggle. The flag is no longer needed for the product surface.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

N/A

#### Description of Change

- Remove `enablePlatformAgent` from user lab preference types, defaults, and selectors
- Remove the Connect Agent switch from Settings → Labs (including the gateway-gated item)
- Drop en-US / zh-CN / default labs i18n keys for `features.platformAgent.*`

Other locale files still contain the keys; they fall back cleanly and will be cleaned by the daily auto-i18n workflow.