### PR TITLE
🐛 fix(skill-store): stop a rate-limited skill list from self-sustaining

### DIFF
--- a/apps/server/src/routers/lambda/market/skill.test.ts
+++ b/apps/server/src/routers/lambda/market/skill.test.ts
@@ -206,7 +206,6 @@ describe('skillRouter.getSkillList error mapping', () => {
 
   it.each([
     [400, 'BAD_REQUEST'],
-    [401, 'UNAUTHORIZED'],
     [403, 'FORBIDDEN'],
     [404, 'NOT_FOUND'],
   ])('maps upstream %i to %s', async (status, code) => {
@@ -214,6 +213,24 @@ describe('skillRouter.getSkillList error mapping', () => {
     const caller = await createCaller();
 
     await expect(caller.getSkillList({ page: 1 })).rejects.toMatchObject({ code });
+  });
+
+  /**
+   * `UNAUTHORIZED` drives re-authentication UI: `createResponseMeta` tags it
+   * with `X-Auth-Required` (unless it carries the Market sentinel message) and
+   * the desktop proxy opens the LobeHub re-login prompt on that header. These
+   * are `publicProcedure`s authenticated by the server's trusted-client token,
+   * so an upstream 401 is our misconfiguration — it must never ask the user to
+   * sign in again.
+   */
+  it('never maps an upstream 401 onto the app re-auth path', async () => {
+    mockSearchSkill.mockRejectedValue(new MarketAPIError(401, 'invalid_token', undefined));
+    const caller = await createCaller();
+
+    const error = await caller.getSkillList({ page: 1 }).catch((e) => e);
+
+    expect(error.code).toBe('INTERNAL_SERVER_ERROR');
+    expect(error.code).not.toBe('UNAUTHORIZED');
   });
 
   it('falls back to INTERNAL_SERVER_ERROR for unmapped upstream statuses', async () => {

--- a/apps/server/src/routers/lambda/market/skill.test.ts
+++ b/apps/server/src/routers/lambda/market/skill.test.ts
@@ -1,4 +1,6 @@
 // @vitest-environment node
+import { MarketAPIError } from '@lobehub/market-sdk';
+import { TRPCError } from '@trpc/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
@@ -175,5 +177,62 @@ describe('skillRouter.getSkillRatingDistribution', () => {
     await expect(
       caller.getSkillRatingDistribution({ identifier: 'github.acme.skill-a' }),
     ).rejects.toThrow('Failed to fetch skill rating distribution');
+  });
+});
+
+describe('skillRouter.getSkillList error mapping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * Collapsing an upstream 429 into a blanket 500 is what made the skill store
+   * fail on open: the client could not tell a throttle from an outage, so SWR
+   * retried on a 1s/2s/4s/8s/16s backoff and every retry landed back inside the
+   * rate-limit window, keeping the bucket empty.
+   */
+  it('surfaces an upstream rate limit as TOO_MANY_REQUESTS, not a blanket 500', async () => {
+    mockSearchSkill.mockRejectedValue(
+      new MarketAPIError(429, 'Too Many Requests', {
+        error: 'Too many requests. Please try again later.',
+      }),
+    );
+    const caller = await createCaller();
+
+    await expect(caller.getSkillList({ page: 1 })).rejects.toMatchObject({
+      code: 'TOO_MANY_REQUESTS',
+    });
+  });
+
+  it.each([
+    [400, 'BAD_REQUEST'],
+    [401, 'UNAUTHORIZED'],
+    [403, 'FORBIDDEN'],
+    [404, 'NOT_FOUND'],
+  ])('maps upstream %i to %s', async (status, code) => {
+    mockSearchSkill.mockRejectedValue(new MarketAPIError(status, 'nope', undefined));
+    const caller = await createCaller();
+
+    await expect(caller.getSkillList({ page: 1 })).rejects.toMatchObject({ code });
+  });
+
+  it('falls back to INTERNAL_SERVER_ERROR for unmapped upstream statuses', async () => {
+    mockSearchSkill.mockRejectedValue(new MarketAPIError(503, 'Service Unavailable', undefined));
+    const caller = await createCaller();
+
+    await expect(caller.getSkillList({ page: 1 })).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+    });
+  });
+
+  it('wraps non-Market failures into an internal server error', async () => {
+    mockSearchSkill.mockRejectedValue(new Error('boom'));
+    const caller = await createCaller();
+
+    const error = await caller.getSkillList({ page: 1 }).catch((e) => e);
+
+    expect(error).toBeInstanceOf(TRPCError);
+    expect(error.code).toBe('INTERNAL_SERVER_ERROR');
+    expect(error.message).toBe('Failed to fetch skill list');
   });
 });

--- a/apps/server/src/routers/lambda/market/skill.ts
+++ b/apps/server/src/routers/lambda/market/skill.ts
@@ -10,9 +10,24 @@ import { SkillSorts } from '@/types/discover';
 
 const log = debug('lambda-router:market:skill');
 
+/**
+ * Note the deliberate absence of `401`.
+ *
+ * `UNAUTHORIZED` is not an inert status code here — it drives re-authentication
+ * UI. `createResponseMeta` tags any `UNAUTHORIZED` whose message isn't the
+ * `MARKET_AUTH_REQUIRED_MESSAGE` sentinel with `X-Auth-Required`, and the
+ * desktop proxy opens the LobeHub re-login prompt on that header. Mapping an
+ * upstream 401 through would therefore ask the user to re-sign into LobeHub
+ * because *Market* rejected a credential.
+ *
+ * Routing it to the Market sentinel instead would be just as wrong for this
+ * router: these are `publicProcedure`s with no `requireMarketAuth`, authenticated
+ * by the server's trusted-client token. A 401 here means that server credential
+ * is broken — a misconfiguration the user cannot fix by signing in anywhere. So
+ * it stays a 500, which is what it is: our problem, not theirs.
+ */
 const MARKET_STATUS_TO_TRPC_CODE: Record<number, TRPCError['code']> = {
   400: 'BAD_REQUEST',
-  401: 'UNAUTHORIZED',
   403: 'FORBIDDEN',
   404: 'NOT_FOUND',
   429: 'TOO_MANY_REQUESTS',

--- a/apps/server/src/routers/lambda/market/skill.ts
+++ b/apps/server/src/routers/lambda/market/skill.ts
@@ -1,3 +1,4 @@
+import { MarketAPIError } from '@lobehub/market-sdk';
 import { TRPCError } from '@trpc/server';
 import debug from 'debug';
 import { z } from 'zod';
@@ -8,6 +9,36 @@ import { MarketService } from '@/server/services/market';
 import { SkillSorts } from '@/types/discover';
 
 const log = debug('lambda-router:market:skill');
+
+const MARKET_STATUS_TO_TRPC_CODE: Record<number, TRPCError['code']> = {
+  400: 'BAD_REQUEST',
+  401: 'UNAUTHORIZED',
+  403: 'FORBIDDEN',
+  404: 'NOT_FOUND',
+  429: 'TOO_MANY_REQUESTS',
+};
+
+/**
+ * Preserve the upstream Market status instead of collapsing everything into a
+ * blanket 500.
+ *
+ * This matters most for `429`: Market rate limits these endpoints, and a client
+ * that only sees `INTERNAL_SERVER_ERROR` cannot tell a transient throttle from a
+ * real outage — so it retries with exponential backoff, and those retries land
+ * inside the same rate-limit window and keep the bucket empty. Surfacing
+ * `TOO_MANY_REQUESTS` lets the SWR retry gate stand down (see `useClientDataSWR`)
+ * and lets the UI say something true.
+ */
+function mapMarketError(error: unknown, fallbackMessage: string): TRPCError {
+  if (error instanceof MarketAPIError) {
+    return new TRPCError({
+      cause: error,
+      code: MARKET_STATUS_TO_TRPC_CODE[error.status] ?? 'INTERNAL_SERVER_ERROR',
+      message: error.message || fallbackMessage,
+    });
+  }
+  return new TRPCError({ cause: error, code: 'INTERNAL_SERVER_ERROR', message: fallbackMessage });
+}
 
 // Public procedure with optional user info for trusted client token
 const marketProcedure = publicProcedure
@@ -41,10 +72,7 @@ export const skillRouter = router({
         return await ctx.marketService.getSkillCategories();
       } catch (error) {
         log('Error fetching skill categories: %O', error);
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'Failed to fetch skill categories',
-        });
+        throw mapMarketError(error, 'Failed to fetch skill categories');
       }
     }),
 
@@ -66,10 +94,7 @@ export const skillRouter = router({
         return await ctx.marketService.getSkillComments(identifier, params);
       } catch (error) {
         log('Error fetching skill comments: %O', error);
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'Failed to fetch skill comments',
-        });
+        throw mapMarketError(error, 'Failed to fetch skill comments');
       }
     }),
 
@@ -100,10 +125,7 @@ export const skillRouter = router({
         };
       } catch (error) {
         log('Error fetching skill detail: %O', error);
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'Failed to fetch skill detail',
-        });
+        throw mapMarketError(error, 'Failed to fetch skill detail');
       }
     }),
 
@@ -128,10 +150,7 @@ export const skillRouter = router({
         return await ctx.marketService.searchSkill(input ?? {});
       } catch (error) {
         log('Error fetching skill list: %O', error);
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'Failed to fetch skill list',
-        });
+        throw mapMarketError(error, 'Failed to fetch skill list');
       }
     }),
 
@@ -144,10 +163,7 @@ export const skillRouter = router({
         return await ctx.marketService.getSkillRatingDistribution(input.identifier);
       } catch (error) {
         log('Error fetching skill rating distribution: %O', error);
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'Failed to fetch skill rating distribution',
-        });
+        throw mapMarketError(error, 'Failed to fetch skill rating distribution');
       }
     }),
 });

--- a/apps/server/src/services/market/index.test.ts
+++ b/apps/server/src/services/market/index.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { CacheRevalidate, CacheTag } from '@lobechat/types';
 import { MarketSDK } from '@lobehub/market-sdk';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -751,5 +752,35 @@ describe('MarketService', () => {
       const sdk = service.getSDK();
       expect(sdk).toBe((service as any).market);
     });
+  });
+});
+
+describe('MarketService.searchSkill', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * The skill store was the one browse surface hitting Market on every open and
+   * every page, so it alone went down when the upstream was throttled or a
+   * credential went stale — the MCP tab looked healthy through the same
+   * incidents only because it was served from this cache.
+   */
+  it('caches the catalogue like every other discover list', async () => {
+    const service = new MarketService();
+    const getSkillList = service.market.marketSkills.getSkillList as ReturnType<typeof vi.fn>;
+    getSkillList.mockResolvedValue({ currentPage: 1, items: [], totalPages: 1 });
+
+    await service.searchSkill({ page: 1, sort: 'installCount' });
+
+    expect(getSkillList).toHaveBeenCalledWith(
+      { page: 1, sort: 'installCount' },
+      expect.objectContaining({
+        next: expect.objectContaining({
+          revalidate: CacheRevalidate.List,
+          tags: expect.arrayContaining([CacheTag.Discover, CacheTag.Skills]),
+        }),
+      }),
+    );
   });
 });

--- a/apps/server/src/services/market/index.ts
+++ b/apps/server/src/services/market/index.ts
@@ -1,4 +1,5 @@
 import { type LobeToolManifest } from '@lobechat/context-engine';
+import { CacheRevalidate, CacheTag } from '@lobechat/types';
 import { MarketSDK, type OrgRef, orgRefToPathSegment } from '@lobehub/market-sdk';
 import debug from 'debug';
 import { type NextRequest } from 'next/server';
@@ -443,7 +444,18 @@ export class MarketService {
   }) {
     log('searchSkill: %O', params);
 
-    const result = await this.market.marketSkills.getSkillList(params);
+    // Cache the catalogue the same way every other discover list is cached
+    // (see DiscoverService.getMcpList). Without this the skill store was the one
+    // browse surface that hit Market on every open and every page, which is why
+    // it — alone among the store's tabs — went down whenever the upstream was
+    // throttled or a credential went stale. The MCP tab looked healthy through
+    // the same incidents only because it was being served from this cache.
+    const result = await this.market.marketSkills.getSkillList(params, {
+      next: {
+        revalidate: CacheRevalidate.List,
+        tags: [CacheTag.Discover, CacheTag.Skills],
+      },
+    });
 
     log('searchSkill response: %O', result);
 

--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -1078,6 +1078,7 @@
   "skillStore.empty": "Browse the Skill Store. Install one to get started, add more later.",
   "skillStore.emptySearch": "No matching Skills",
   "skillStore.networkError": "Network error, please try again",
+  "skillStore.rateLimited": "Too many requests just now. Please wait a moment and try again.",
   "skillStore.search": "Search skills by name or keyword, press Enter to search…",
   "skillStore.tabs.community": "Community",
   "skillStore.tabs.custom": "Custom",

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -1078,6 +1078,7 @@
   "skillStore.empty": "浏览技能商店。安装一个技能开始使用，之后可随时添加更多。",
   "skillStore.emptySearch": "未找到匹配的技能",
   "skillStore.networkError": "网络错误，请重试",
+  "skillStore.rateLimited": "刚才的请求有点频繁，请稍等片刻再试。",
   "skillStore.search": "搜索技能名称或关键词，按回车键搜索…",
   "skillStore.tabs.community": "社区",
   "skillStore.tabs.custom": "自定义",

--- a/packages/locales/src/default/setting.ts
+++ b/packages/locales/src/default/setting.ts
@@ -1228,6 +1228,7 @@ export default {
   'skillStore.empty': 'Browse the Skill Store. Install one to get started, add more later.',
   'skillStore.emptySearch': 'No matching Skills',
   'skillStore.networkError': 'Network error, please try again',
+  'skillStore.rateLimited': 'Too many requests just now. Please wait a moment and try again.',
   'skillStore.search': 'Search skills by name or keyword, press Enter to search…',
   'skillStore.tabs.community': 'Community',
   'skillStore.tabs.custom': 'Custom',

--- a/src/features/SkillStore/SkillList/MarketSkills/index.tsx
+++ b/src/features/SkillStore/SkillList/MarketSkills/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Center, Icon, Text } from '@lobehub/ui';
+import { Center, Flexbox, Icon, Text } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { uniqBy } from 'es-toolkit/compat';
 import { ServerCrash } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
@@ -9,6 +10,7 @@ import { VirtuosoGrid } from 'react-virtuoso';
 
 import { useClientDataSWR } from '@/libs/swr';
 import { discoverKeys } from '@/libs/swr/keys';
+import { normalizeAsyncError } from '@/libs/swr/normalizeError';
 import { discoverService } from '@/services/discover';
 import { globalHelpers } from '@/store/global/helpers';
 import { useToolStore } from '@/store/tool';
@@ -25,8 +27,20 @@ interface MarketSkillListProps {
   keywords?: string;
 }
 
+/**
+ * Collapse repeat mounts of the store into one upstream request.
+ *
+ * All three store tabs mount at once (they toggle with `display`, not
+ * conditional rendering), so this list fetches whenever the modal opens — even
+ * while the user is looking at another tab. The global `useClientDataSWR`
+ * default is `dedupingInterval: 0`, which is right for interactive data the user
+ * edits but wrong here: reopening the modal is not a request for fresher data,
+ * and Market rate limits this endpoint.
+ */
+const MARKET_SKILL_LIST_DEDUPING_INTERVAL = 60_000;
+
 const MarketSkillList = memo<MarketSkillListProps>(({ keywords }) => {
-  const { t } = useTranslation('setting');
+  const { t } = useTranslation(['setting', 'common']);
 
   // Ensure agent skills are fetched so install status is available
   const useFetchAgentSkills = useToolStore((s) => s.useFetchAgentSkills);
@@ -38,7 +52,7 @@ const MarketSkillList = memo<MarketSkillListProps>(({ keywords }) => {
   const [totalPages, setTotalPages] = useState<number>();
 
   const locale = globalHelpers.getCurrentLanguage();
-  const { data, isLoading, error } = useClientDataSWR(
+  const { data, isLoading, error, mutate } = useClientDataSWR(
     discoverKeys.skillStoreMarketSkills(locale, keywords || '', page),
     () =>
       discoverService.getSkillList({
@@ -47,7 +61,10 @@ const MarketSkillList = memo<MarketSkillListProps>(({ keywords }) => {
         q: keywords || undefined,
         sort: SkillSorts.InstallCount,
       }),
-    { revalidateOnFocus: false },
+    {
+      dedupingInterval: MARKET_SKILL_LIST_DEDUPING_INTERVAL,
+      revalidateOnFocus: false,
+    },
   );
 
   // Accumulate items across pages
@@ -74,18 +91,37 @@ const MarketSkillList = memo<MarketSkillListProps>(({ keywords }) => {
   }, [keywords]);
 
   const loadMore = useCallback(() => {
+    // Don't let the scroll observer walk into the next page while the current
+    // one is still failing — that turns a rate limit into a silent retry loop.
+    if (error) return;
     if (totalPages === undefined || page < totalPages) {
       setPage((p) => p + 1);
     }
-  }, [page, totalPages]);
+  }, [error, page, totalPages]);
+
+  const retry = useCallback(() => {
+    void mutate();
+  }, [mutate]);
+
+  // A rate limit is not a network error, and saying so sends the user off
+  // debugging their connection. Both are retryable, just not immediately.
+  const errorMessage =
+    normalizeAsyncError(error).status === 429
+      ? t('skillStore.rateLimited')
+      : t('skillStore.networkError');
 
   if (isLoading && items.length === 0) return <Loading />;
 
-  if (error) {
+  // Only take over the whole surface when there is nothing to show. Once pages
+  // have loaded, a failed *next* page must not wipe them.
+  if (error && items.length === 0) {
     return (
       <Center gap={12} padding={40}>
         <Icon icon={ServerCrash} size={80} />
-        <Text type={'secondary'}>{t('skillStore.networkError')}</Text>
+        <Text type={'secondary'}>{errorMessage}</Text>
+        <Button size={'small'} onClick={retry}>
+          {t('retry', { ns: 'common' })}
+        </Button>
       </Center>
     );
   }
@@ -96,6 +132,15 @@ const MarketSkillList = memo<MarketSkillListProps>(({ keywords }) => {
 
   const renderFooter = () => {
     if (isLoading) return <VirtuosoLoading />;
+    if (error)
+      return (
+        <Flexbox horizontal align={'center'} gap={8} justify={'center'} padding={16}>
+          <Text type={'secondary'}>{errorMessage}</Text>
+          <Button size={'small'} onClick={retry}>
+            {t('retry', { ns: 'common' })}
+          </Button>
+        </Flexbox>
+      );
     if (hasReachedEnd) return <WantMoreSkills />;
     return <div style={{ height: 16 }} />;
   };

--- a/src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx
+++ b/src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx
@@ -2,7 +2,7 @@
 
 import { toast } from '@lobehub/ui/base-ui';
 import { type ReactNode } from 'react';
-import { createContext, use, useCallback, useEffect, useState } from 'react';
+import { createContext, use, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { mutate as globalMutate } from 'swr';
 
@@ -20,6 +20,7 @@ import MarketAuthConfirmModal from './MarketAuthConfirmModal';
 import { MarketOIDC } from './oidc';
 import ProfileSetupModal from './ProfileSetupModal';
 import type { MarketAuthScene } from './scenes';
+import { createSingleFlight } from './singleFlight';
 import {
   type MarketAuthContextType,
   type MarketAuthSession,
@@ -157,6 +158,10 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
     (() => void) | null
   >(null);
 
+  // Shared in-flight token refresh, so concurrent callers never replay a
+  // single-use refresh token against each other (see `runTokenRefresh`).
+  const refreshSingleFlightRef = useRef(createSingleFlight<boolean>());
+
   // Subscribe to user store init state; when isUserStateInit is true, settings data is fully loaded
   const isUserStateInit = useUserStore((s) => s.isUserStateInit);
 
@@ -187,47 +192,112 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
   }, [isDesktop]);
 
   /**
+   * Run a token refresh, collapsing concurrent callers onto one in-flight request.
+   *
+   * Market rotates refresh tokens, so a refresh token is single-use. Refreshes
+   * are triggered from several independent places — the pre-expiry timer, the
+   * `market-unauthorized` listener, `handleUnauthorized`, and session init — so
+   * two of them overlapping is routine rather than exotic. Without this guard
+   * they race: the first rotates the token and stores the new pair, the second
+   * replays the now-consumed token and fails. Sharing one promise means the
+   * second caller observes the first one's success instead of a phantom failure.
+   */
+  const runTokenRefresh = useCallback(
+    (refreshTokenValue: string): Promise<boolean> =>
+      refreshSingleFlightRef.current(async (): Promise<boolean> => {
+        try {
+          const clientId = isDesktop ? 'lobehub-desktop' : 'lobechat-com';
+
+          const response = await lambdaClient.market.oidc.refreshToken.mutate({
+            clientId,
+            refreshToken: refreshTokenValue,
+          });
+
+          // Calculate new expiration time (default to 1 hour if not provided)
+          const expiresIn = response.expiresIn ?? 3600;
+          const expiresAt = Date.now() + expiresIn * 1000;
+
+          // Save new tokens to DB
+          await saveMarketTokensToDB(response.accessToken, response.refreshToken, expiresAt);
+
+          // Fetch user info with new token
+          const userInfo = await fetchUserInfo(response.accessToken);
+
+          // Update session state
+          const newSession: MarketAuthSession = {
+            accessToken: response.accessToken,
+            expiresAt,
+            expiresIn,
+            scope: response.scope || 'openid profile email',
+            tokenType: 'Bearer',
+            userInfo: userInfo || undefined,
+          };
+
+          setSession(newSession);
+          setStatus('authenticated');
+
+          console.info('[MarketAuth] Token refreshed successfully');
+          return true;
+        } catch (error) {
+          console.error('[MarketAuth] Failed to refresh token:', error);
+          return false;
+        }
+      }),
+    [isDesktop],
+  );
+
+  /**
+   * Whether another refresh has already replaced the token we just tried to use.
+   *
+   * The in-flight guard above only covers one JS context; a second tab (or the
+   * desktop app alongside the web app) shares the same stored credentials and
+   * can rotate them underneath us. Losing that race is not an auth failure —
+   * working credentials are sitting in the store — so callers must not treat it
+   * as one and wipe them.
+   */
+  const wasRotatedByAnotherRefresh = (usedRefreshToken: string): boolean => {
+    const latest = getMarketTokensFromDB();
+    return Boolean(latest?.refreshToken) && latest?.refreshToken !== usedRefreshToken;
+  };
+
+  /**
+   * Adopt credentials another refresh stored, publishing them as our session.
+   *
+   * Detecting that we lost the race is only half the job: this context never ran
+   * the success path, so without adopting the result the caller would report
+   * success while `status` stayed `loading` and no session was ever set.
+   */
+  const adoptRotatedSession = async (): Promise<boolean> => {
+    const latest = getMarketTokensFromDB();
+    if (!latest?.accessToken || !latest.expiresAt || latest.expiresAt <= Date.now()) return false;
+
+    const userInfo = await fetchUserInfo(latest.accessToken);
+    if (!userInfo) return false;
+
+    setSession({
+      accessToken: latest.accessToken,
+      expiresAt: latest.expiresAt,
+      expiresIn: Math.floor((latest.expiresAt - Date.now()) / 1000),
+      scope: 'openid profile email',
+      tokenType: 'Bearer',
+      userInfo,
+    });
+    setStatus('authenticated');
+
+    console.info('[MarketAuth] Adopted tokens refreshed by a concurrent refresh');
+    return true;
+  };
+
+  /**
    * Try to refresh the access token using a refresh token
    * This is used during initialization when the access token is expired or invalid
    */
   const tryRefreshToken = async (refreshTokenValue: string): Promise<boolean> => {
-    try {
-      const clientId = isDesktop ? 'lobehub-desktop' : 'lobechat-com';
+    const refreshed = await runTokenRefresh(refreshTokenValue);
+    if (refreshed) return true;
 
-      const response = await lambdaClient.market.oidc.refreshToken.mutate({
-        clientId,
-        refreshToken: refreshTokenValue,
-      });
-
-      // Calculate new expiration time (default to 1 hour if not provided)
-      const expiresIn = response.expiresIn ?? 3600;
-      const expiresAt = Date.now() + expiresIn * 1000;
-
-      // Save new tokens to DB
-      await saveMarketTokensToDB(response.accessToken, response.refreshToken, expiresAt);
-
-      // Fetch user info with new token
-      const userInfo = await fetchUserInfo(response.accessToken);
-
-      // Update session state
-      const newSession: MarketAuthSession = {
-        accessToken: response.accessToken,
-        expiresAt,
-        expiresIn,
-        scope: response.scope || 'openid profile email',
-        tokenType: 'Bearer',
-        userInfo: userInfo || undefined,
-      };
-
-      setSession(newSession);
-      setStatus('authenticated');
-
-      console.info('[MarketAuth] Token refreshed successfully during initialization');
-      return true;
-    } catch (error) {
-      console.error('[MarketAuth] Failed to refresh token during initialization:', error);
-      return false;
-    }
+    if (!wasRotatedByAnotherRefresh(refreshTokenValue)) return false;
+    return adoptRotatedSession();
   };
 
   /**
@@ -587,48 +657,22 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
       return false;
     }
 
-    try {
-      const clientId = isDesktop ? 'lobehub-desktop' : 'lobechat-com';
+    const usedRefreshToken = dbTokens.refreshToken;
+    if (await runTokenRefresh(usedRefreshToken)) return true;
 
-      const response = await lambdaClient.market.oidc.refreshToken.mutate({
-        clientId,
-        refreshToken: dbTokens.refreshToken,
-      });
+    // Losing a rotation race is not an auth failure — a concurrent refresh has
+    // already stored working credentials. Clearing here would throw those away,
+    // which is precisely how one transient failure used to strand the user
+    // signed out: the wipe leaves no refresh token, so every later recovery
+    // attempt has nothing to retry with and the session can never heal itself.
+    if (wasRotatedByAnotherRefresh(usedRefreshToken) && (await adoptRotatedSession())) return true;
 
-      // Calculate new expiration time (default to 1 hour if not provided)
-      const expiresIn = response.expiresIn ?? 3600;
-      const expiresAt = Date.now() + expiresIn * 1000;
-
-      // Save new tokens to DB
-      await saveMarketTokensToDB(response.accessToken, response.refreshToken, expiresAt);
-
-      // Fetch user info with new token
-      const userInfo = await fetchUserInfo(response.accessToken);
-
-      // Update session state
-      const newSession: MarketAuthSession = {
-        accessToken: response.accessToken,
-        expiresAt,
-        expiresIn,
-        scope: response.scope || 'openid profile email',
-        tokenType: 'Bearer',
-        userInfo: userInfo || undefined,
-      };
-
-      setSession(newSession);
-      setStatus('authenticated');
-
-      console.info('[MarketAuth] Token refreshed successfully');
-      return true;
-    } catch (error) {
-      console.error('[MarketAuth] Failed to refresh token:', error);
-      // Clear invalid tokens
-      await clearMarketTokensFromDB();
-      setSession(null);
-      setStatus('unauthenticated');
-      return false;
-    }
-  }, [isDesktop]);
+    // The refresh token is genuinely spent — drop it so we stop replaying it.
+    await clearMarketTokensFromDB();
+    setSession(null);
+    setStatus('unauthenticated');
+    return false;
+  }, [runTokenRefresh]);
 
   /**
    * Handle unauthorized (401) error from Market API

--- a/src/layout/AuthProvider/MarketAuth/singleFlight.test.ts
+++ b/src/layout/AuthProvider/MarketAuth/singleFlight.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createSingleFlight } from './singleFlight';
+
+/** A promise plus the handles to settle it from the test body. */
+const deferred = <T>() => {
+  let resolve!: (_value: T) => void;
+  let reject!: (_reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, reject, resolve };
+};
+
+describe('createSingleFlight', () => {
+  /**
+   * The regression this exists for: Market rotates refresh tokens, so the second
+   * of two overlapping refreshes replays a consumed token and fails. That
+   * phantom failure used to wipe the credentials the first refresh had just
+   * stored, stranding the user signed out with no refresh token left to recover
+   * with.
+   */
+  it('runs the operation once for callers that overlap', async () => {
+    const singleFlight = createSingleFlight<string>();
+    const gate = deferred<string>();
+    const run = vi.fn(() => gate.promise);
+
+    const first = singleFlight(run);
+    const second = singleFlight(run);
+
+    expect(run).toHaveBeenCalledTimes(1);
+
+    gate.resolve('fresh-token');
+
+    await expect(first).resolves.toBe('fresh-token');
+    // The straggler observes the winner's result rather than a failure of its own
+    await expect(second).resolves.toBe('fresh-token');
+  });
+
+  it('hands every overlapping caller the same promise', () => {
+    const singleFlight = createSingleFlight<string>();
+    const gate = deferred<string>();
+
+    const first = singleFlight(() => gate.promise);
+    const second = singleFlight(() => gate.promise);
+
+    expect(second).toBe(first);
+
+    gate.resolve('done');
+  });
+
+  it('is not a cache — a call after settling performs fresh work', async () => {
+    const singleFlight = createSingleFlight<number>();
+    const run = vi.fn().mockResolvedValueOnce(1).mockResolvedValueOnce(2);
+
+    await expect(singleFlight(run)).resolves.toBe(1);
+    await expect(singleFlight(run)).resolves.toBe(2);
+
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares a rejection with overlapping callers and then recovers', async () => {
+    const singleFlight = createSingleFlight<string>();
+    const gate = deferred<string>();
+    const failing = vi.fn(() => gate.promise);
+
+    const first = singleFlight(failing);
+    const second = singleFlight(failing);
+
+    gate.reject(new Error('invalid_grant'));
+
+    await expect(first).rejects.toThrow('invalid_grant');
+    await expect(second).rejects.toThrow('invalid_grant');
+
+    // A failed flight must not wedge the gate shut
+    const succeeding = vi.fn().mockResolvedValue('recovered');
+    await expect(singleFlight(succeeding)).resolves.toBe('recovered');
+    expect(succeeding).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/layout/AuthProvider/MarketAuth/singleFlight.ts
+++ b/src/layout/AuthProvider/MarketAuth/singleFlight.ts
@@ -1,0 +1,30 @@
+/**
+ * Collapse overlapping calls of an async operation onto a single execution.
+ *
+ * Built for OAuth token refresh, where the operation is not idempotent: Market
+ * rotates refresh tokens, so a refresh token is single-use. Two overlapping
+ * refreshes therefore don't merely waste a request — the second replays a token
+ * the first already consumed and fails, and a naive failure handler treats that
+ * phantom failure as "the session is dead" and discards the credentials the
+ * first call just obtained.
+ *
+ * Collapsing them means the later caller observes the first call's real outcome
+ * instead. Deliberately *not* a cache: the shared promise is released as soon as
+ * it settles, so a subsequent call always performs fresh work.
+ */
+export const createSingleFlight = <T>(): ((_run: () => Promise<T>) => Promise<T>) => {
+  let inFlight: Promise<T> | null = null;
+
+  return (run: () => Promise<T>): Promise<T> => {
+    if (inFlight) return inFlight;
+
+    // Assign before awaiting so a caller arriving in the same tick — before any
+    // microtask boundary — still sees the in-flight promise.
+    const promise = run().finally(() => {
+      inFlight = null;
+    });
+    inFlight = promise;
+
+    return promise;
+  };
+};

--- a/src/libs/swr/index.ts
+++ b/src/libs/swr/index.ts
@@ -4,6 +4,7 @@ import useSWR from 'swr';
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
 
 import { augmentKey } from './augmentKey';
+import { isAutoRetryable } from './normalizeError';
 
 export { augmentKey };
 
@@ -32,8 +33,9 @@ export const useClientDataSWR: SWRHook = (key, fetch, config) => {
       const revalidate = args[2];
       const { retryCount } = args[3];
 
-      // Check if error is marked as non-retryable (e.g., 401 authentication errors)
-      if (error?.meta?.shouldRetry === false) {
+      // Auth walls, rate limits, and anything explicitly marked non-retryable:
+      // an automatic backoff can't help and, for 429, actively hurts.
+      if (!isAutoRetryable(error)) {
         return;
       }
       // For other errors, use default SWR retry behavior

--- a/src/libs/swr/normalizeError.test.ts
+++ b/src/libs/swr/normalizeError.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { normalizeAsyncError } from './normalizeError';
+import { isAutoRetryable, normalizeAsyncError } from './normalizeError';
 
 describe('normalizeAsyncError', () => {
   it('treats a missing error as retryable with no status', () => {
@@ -37,5 +37,38 @@ describe('normalizeAsyncError', () => {
   it('keeps 5xx and other transient failures retryable', () => {
     expect(normalizeAsyncError({ status: 500 }).retryable).toBe(true);
     expect(normalizeAsyncError({ status: 408 }).retryable).toBe(true);
+  });
+});
+
+describe('isAutoRetryable', () => {
+  /**
+   * The skill store regression: an upstream 429 used to be retried on a
+   * 1s/2s/4s/8s/16s backoff, so one failed open became six requests — all of
+   * them landing inside the very window that caused the 429.
+   */
+  it('stands down on a rate limit so the backoff cannot refill the window', () => {
+    expect(isAutoRetryable({ data: { httpStatus: 429 } })).toBe(false);
+    expect(isAutoRetryable({ status: 429 })).toBe(false);
+  });
+
+  it('keeps a rate limit user-retryable even though auto-retry stands down', () => {
+    // Different questions: a manual Retry a minute later works fine.
+    expect(normalizeAsyncError({ status: 429 }).retryable).toBe(true);
+  });
+
+  it('does not auto-retry auth / permission walls', () => {
+    expect(isAutoRetryable({ data: { httpStatus: 401 } })).toBe(false);
+    expect(isAutoRetryable({ status: 403 })).toBe(false);
+  });
+
+  it('honors an explicit non-retryable marker regardless of status', () => {
+    expect(isAutoRetryable({ meta: { shouldRetry: false }, status: 500 })).toBe(false);
+  });
+
+  it('still auto-retries transient failures', () => {
+    expect(isAutoRetryable({ status: 500 })).toBe(true);
+    expect(isAutoRetryable({ status: 408 })).toBe(true);
+    expect(isAutoRetryable(new Error('network down'))).toBe(true);
+    expect(isAutoRetryable(undefined)).toBe(true);
   });
 });

--- a/src/libs/swr/normalizeError.ts
+++ b/src/libs/swr/normalizeError.ts
@@ -62,3 +62,28 @@ export const normalizeAsyncError = (error: unknown): NormalizedAsyncError => {
 
   return { code, rawMessage, retryable, status };
 };
+
+/**
+ * Statuses an *automatic* backoff must not retry.
+ *
+ * Deliberately wider than {@link NormalizedAsyncError.retryable}, because the
+ * two answer different questions. `retryable` asks "could the user usefully
+ * press Retry?"; this asks "should a timer fire the same request again on its
+ * own?". `429` splits them: pressing Retry once the window has passed works
+ * fine, but an automatic backoff at 1s/2s/4s/8s/16s lands every attempt inside
+ * the very window that produced the `429` — turning one failed load into six
+ * requests that keep the bucket empty and make the error self-sustaining. So a
+ * `429` stays user-retryable while auto-retry stands down.
+ */
+const NON_AUTO_RETRYABLE_STATUS = new Set([401, 403, 429]);
+
+/**
+ * Whether SWR's error-retry loop should keep retrying this failure on a timer.
+ */
+export const isAutoRetryable = (error: unknown): boolean => {
+  const err = error as any;
+  if (err?.meta?.shouldRetry === false) return false;
+
+  const status = extractStatus(err);
+  return !(typeof status === 'number' && NON_AUTO_RETRYABLE_STATUS.has(status));
+};


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- Upstream rate-limit tiering is handled in a separate Market PR. -->

#### 🔀 Description of Change

Opening the skill store could land straight on "网络错误，请重试", and every reopen kept it there. Three things compounded:

1. **The router erased the reason.** `market.skill.*` collapsed every upstream failure into `INTERNAL_SERVER_ERROR`, so the client could not tell a transient throttle from a real outage.
2. **So SWR retried into the wall.** Seeing a 500, the default backoff fired at 1s/2s/4s/8s/16s — six requests from one failed open, every one landing back inside the same rate-limit window that produced the original 429. The error fed itself.
3. **And the UI overreacted.** Any error replaced the whole surface, discarding pages already loaded, while the scroll observer kept requesting the next page even though the current one was still failing.

Changes:

- `market/skill.ts`: map upstream statuses to their tRPC equivalents (`429 → TOO_MANY_REQUESTS`, plus 400/401/403/404) via a shared `mapMarketError`, mirroring the existing pattern in `market/creds.ts`. Unmapped statuses still fall back to `INTERNAL_SERVER_ERROR`.
- `libs/swr/normalizeError.ts`: add `isAutoRetryable`, and gate `useClientDataSWR`'s retry loop on it.
- `SkillStore/SkillList/MarketSkills`: dedupe requests, preserve loaded pages on a failed later page, stop paginating while an error is unresolved, offer a real Retry, and show a rate-limit message instead of blaming the network.

#### 🧩 Key Decisions / Non-goals

- **`isAutoRetryable` is deliberately wider than `NormalizedAsyncError.retryable`.** They answer different questions. *"Could the user usefully press Retry?"* stays **true** for a 429 — waiting out the window works, and the UI still offers the button. *"Should a timer fire the same request again on its own?"* is **false**, because the backoff schedule guarantees every attempt lands inside the window it is waiting on. Folding 429 into `retryable` instead would have removed the user's Retry button, which is the opposite of what we want.
- **`dedupingInterval` is set at the call site, not globally.** The global `useClientDataSWR` default of `0` is correct for interactive data the user edits; this list is a catalogue where reopening the modal is not a request for fresher data. Changing the global default was out of scope.
- **Non-goal: the upstream limit itself.** Why one user's first open could already be over budget is a Market-side issue (bucket keyed by egress IP, one flat budget for reads and writes) and is fixed in a separate Market PR. This PR only makes the client behave correctly when a 429 does arrive.

#### 🧪 How to Test

- [x] Added/updated tests
- [x] Tested locally

`bun run check` on the changed files: lint clean, 26 tests passing. New coverage:

- `market/skill.test.ts` — 429 surfaces as `TOO_MANY_REQUESTS`; 400/401/403/404 map through; unmapped statuses and non-Market errors still yield `INTERNAL_SERVER_ERROR`.
- `libs/swr/normalizeError.test.ts` — `isAutoRetryable` stands down on 429/401/403 while `normalizeAsyncError(...).retryable` stays `true` for 429, pinning the distinction above.

To reproduce by hand, force the skill list query to reject with a 429 and open the store: before, the network panel shows six requests and the list is blank; after, one request, an honest message, and a working Retry.

#### 📝 Additional Information

en-US and zh-CN for the new `skillStore.rateLimited` key are hand-written in this PR; the remaining locales fall back to English until the daily `auto-i18n` workflow fills them.