### PR TITLE
💄 style(agent): move profile header spacing below identity block

### DIFF
--- a/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.tsx
@@ -36,7 +36,7 @@ const AgentHeader = memo(() => {
   return (
     <Flexbox
       gap={16}
-      paddingBlock={'16px 0'}
+      paddingBlock={'0 16px'}
       style={{
         cursor: 'default',
         marginInline: -16,


### PR DESCRIPTION
### 问题

#17929 引入 profile artwork 后，助理档案页头部的 16px `paddingBlock` 加在了 banner 上方，而下方的姓名/角色区块紧贴「模型与工具」配置框，间距方向反了。

### 修复

把 `AgentHeader` 根容器的 `paddingBlock` 从 `'16px 0'` 换成 `'0 16px'`：banner 顶部贴住内容区，16px 间距改到 identity 区块与配置框之间。

🤖 Generated with [Claude Code](https://claude.com/claude-code)