### PR TITLE
🐛 fix(agent): enable message channels for Codex agents

### DIFF
--- a/src/features/AgentSidebar/Header/Nav.test.tsx
+++ b/src/features/AgentSidebar/Header/Nav.test.tsx
@@ -18,6 +18,9 @@ const permissionMock = vi.hoisted(() => ({
   create_content: true,
   edit_own_content: true,
 }));
+const agentMock = vi.hoisted(() => ({
+  heterogeneousProviderType: undefined as string | undefined,
+}));
 
 vi.mock('@/features/ResourcePermission/useResourceAccess', () => ({
   useResourceAccess: () => ({ canEditResource: true, isAccessResolved: true }),
@@ -98,12 +101,13 @@ vi.mock('@/hooks/usePermission', () => ({
 }));
 
 vi.mock('@/store/agent', () => ({
-  useAgentStore: (selector: (state: unknown) => unknown) => selector({}),
+  useAgentStore: (selector: (state: typeof agentMock) => unknown) => selector(agentMock),
 }));
 
 vi.mock('@/store/agent/selectors', () => ({
   agentSelectors: {
-    currentAgentHeterogeneousProviderType: () => undefined,
+    currentAgentHeterogeneousProviderType: (state: typeof agentMock) =>
+      state.heterogeneousProviderType,
   },
 }));
 
@@ -144,6 +148,7 @@ describe('Agent sidebar header nav', () => {
     usePathnameMock.mockReset();
     permissionMock.create_content = true;
     permissionMock.edit_own_content = true;
+    agentMock.heterogeneousProviderType = undefined;
 
     useParamsMock.mockReturnValue({ aid: 'agt_eH4zL98zBx5u', topicId: 'tpc_2FCHvjS7d4CA' });
   });
@@ -185,5 +190,14 @@ describe('Agent sidebar header nav', () => {
 
     expect(pushMock).not.toHaveBeenCalled();
     expect(mutateMock).not.toHaveBeenCalled();
+  });
+
+  it('shows message channels for Codex agents', () => {
+    agentMock.heterogeneousProviderType = 'codex';
+    usePathnameMock.mockReturnValue('/agent/agt_eH4zL98zBx5u');
+
+    render(<Nav />);
+
+    expect(screen.getByRole('button', { name: 'tab.integration' })).toBeInTheDocument();
   });
 });

--- a/src/features/AgentSidebar/Header/Nav.test.tsx
+++ b/src/features/AgentSidebar/Header/Nav.test.tsx
@@ -200,4 +200,13 @@ describe('Agent sidebar header nav', () => {
 
     expect(screen.getByRole('button', { name: 'tab.integration' })).toBeInTheDocument();
   });
+
+  it('hides message channels for device-only heterogeneous agents', () => {
+    agentMock.heterogeneousProviderType = 'opencode';
+    usePathnameMock.mockReturnValue('/agent/agt_eH4zL98zBx5u');
+
+    render(<Nav />);
+
+    expect(screen.queryByRole('button', { name: 'tab.integration' })).not.toBeInTheDocument();
+  });
 });

--- a/src/features/AgentSidebar/Header/Nav.tsx
+++ b/src/features/AgentSidebar/Header/Nav.tsx
@@ -20,6 +20,8 @@ import { usePermission } from '@/hooks/usePermission';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
 import { useActionSWR } from '@/libs/swr';
 import { topicActionKeys } from '@/libs/swr/keys';
+import { useAgentStore } from '@/store/agent';
+import { agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
 import { useGlobalStore } from '@/store/global';
@@ -42,8 +44,15 @@ const Nav = memo(() => {
   const { canEditResource, isAccessResolved } = useResourceAccess('agent', agentId);
   const { isAgentEditable } = useServerConfigStore(featureFlagsSelectors);
   const toggleCommandMenu = useGlobalStore((s) => s.toggleCommandMenu);
+  const heterogeneousProviderType = useAgentStore(
+    agentSelectors.currentAgentHeterogeneousProviderType,
+  );
   const hideProfile = !isAgentEditable || !isAccessResolved || !canEditContent || !canEditResource;
-  const hideChannel = hideProfile;
+  const supportsMessageChannels =
+    !heterogeneousProviderType ||
+    heterogeneousProviderType === 'claude-code' ||
+    heterogeneousProviderType === 'codex';
+  const hideChannel = hideProfile || !supportsMessageChannels;
   const switchTopic = useChatStore((s) => s.switchTopic);
   const [openNewTopicOrSaveTopic] = useChatStore((s) => [s.openNewTopicOrSaveTopic]);
   const isNewTopicSendInFlight = useChatStore(topicSelectors.isNewTopicSendInFlight);

--- a/src/features/AgentSidebar/Header/Nav.tsx
+++ b/src/features/AgentSidebar/Header/Nav.tsx
@@ -20,8 +20,6 @@ import { usePermission } from '@/hooks/usePermission';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
 import { useActionSWR } from '@/libs/swr';
 import { topicActionKeys } from '@/libs/swr/keys';
-import { useAgentStore } from '@/store/agent';
-import { agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
 import { useGlobalStore } from '@/store/global';
@@ -44,13 +42,8 @@ const Nav = memo(() => {
   const { canEditResource, isAccessResolved } = useResourceAccess('agent', agentId);
   const { isAgentEditable } = useServerConfigStore(featureFlagsSelectors);
   const toggleCommandMenu = useGlobalStore((s) => s.toggleCommandMenu);
-  const heterogeneousProviderType = useAgentStore(
-    agentSelectors.currentAgentHeterogeneousProviderType,
-  );
   const hideProfile = !isAgentEditable || !isAccessResolved || !canEditContent || !canEditResource;
-  // Claude Code agents can use message channels; other hetero providers (e.g. codex) still hide it.
-  const hideChannel =
-    hideProfile || (!!heterogeneousProviderType && heterogeneousProviderType !== 'claude-code');
+  const hideChannel = hideProfile;
   const switchTopic = useChatStore((s) => s.switchTopic);
   const [openNewTopicOrSaveTopic] = useChatStore((s) => [s.openNewTopicOrSaveTopic]);
   const isNewTopicSendInFlight = useChatStore(topicSelectors.isNewTopicSendInFlight);


### PR DESCRIPTION
## Summary

- allow Codex agents to configure message-channel integrations alongside Claude Code
- keep channel integrations hidden for device-only heterogeneous runtimes
- preserve the existing edit and resource permission guards
- add positive Codex and negative device-only regression coverage

## Testing

- `bun run check src/features/AgentSidebar/Header/Nav.tsx src/features/AgentSidebar/Header/Nav.test.tsx`