### PR TITLE
🔧 chore(lint): disable unicorn/number-literal-case and apply eslint autofix

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -284,6 +284,8 @@ export default eslint(
       'react/no-unknown-property': 0,
       'regexp/match-any': 0,
       'unicorn/better-regex': 0,
+      // conflicts with prettier, which lowercases hex literals
+      'unicorn/number-literal-case': 0,
     },
   },
   // TypeScript files - enforce consistent type imports

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.test.tsx
@@ -69,12 +69,12 @@ describe('ContentBlocksScroll', () => {
     const { container } = render(
       <ContentBlocksScroll
         assistantId="assistant-1"
+        scroll={false}
+        variant="workflow"
         blocks={[
           { content: 'first workflow block', id: 'block-1' },
           { content: 'second workflow block', id: 'block-2' },
         ]}
-        scroll={false}
-        variant="workflow"
       />,
     );
 

--- a/src/features/Electron/HeterogeneousAgent/StatusGuide/states/AuthRequiredState.tsx
+++ b/src/features/Electron/HeterogeneousAgent/StatusGuide/states/AuthRequiredState.tsx
@@ -17,9 +17,6 @@ const AuthRequiredState = ({
 
   return (
     <GuideShell
-      headerDescription={
-        <Text type="secondary">{t('cliAuthGuide.desc', { name: config.title })}</Text>
-      }
       icon={<config.icon size={24} />}
       title={t('cliAuthGuide.title', { name: config.title })}
       variant={variant}
@@ -31,6 +28,9 @@ const AuthRequiredState = ({
           openSystemToolsLabel={t('cliAuthGuide.actions.openSystemTools')}
           onOpenSystemTools={onOpenSystemTools}
         />
+      }
+      headerDescription={
+        <Text type="secondary">{t('cliAuthGuide.desc', { name: config.title })}</Text>
       }
     >
       <Flexbox gap={6}>


### PR DESCRIPTION
`unicorn/number-literal-case` rewrites hex literals to uppercase (`0x81_1c_9d_c5` → `0x81_1C_9D_C5`), while Prettier lowercases them again. Every `eslint --fix` run produced churn that the next `bun run check` reverted, leaving 10 permanent warnings across 3 files that nobody could ever clear.

Disabled the rule in the global overrides of `eslint.config.mjs`, and committed the remaining (stable) autofixes — `react/jsx-sort-props` prop reordering in two files.

`eslint-suppressions.json` was pruned in the same pass and came out unchanged: both entries are still live and the tree has 0 errors, so there was nothing to add or drop.

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

`npx eslint src/ tests/ --fix` → 0 errors, 161 warnings, no leftover working-tree churn.
`bun run check` → 3 files, lint clean, 25 tests passed.

#### 🔗 Related Issue

N/A