### PR TITLE
🐛 fix(layout): render DevDockLayout inside CacheHydrationGate

### DIFF
--- a/src/layout/SPAGlobalProvider/index.test.tsx
+++ b/src/layout/SPAGlobalProvider/index.test.tsx
@@ -13,7 +13,8 @@ import { type DevDockLayout as DevDockLayoutComponent } from './index';
 
 let SPAGlobalProvider: typeof SPAGlobalProviderComponent;
 let DevDockLayout: typeof DevDockLayoutComponent;
-const { canAccessDevDock, devDockRenderError } = vi.hoisted(() => ({
+const { cacheGateReleased, canAccessDevDock, devDockRenderError } = vi.hoisted(() => ({
+  cacheGateReleased: { current: true },
   canAccessDevDock: vi.fn(() => false),
   devDockRenderError: { current: null as Error | null },
 }));
@@ -124,7 +125,7 @@ vi.mock('@/layout/GlobalProvider/CacheHydrationGate', async () => {
 
   return {
     default: ({ children }: { children?: ReactNode }) =>
-      React.createElement(React.Fragment, null, children),
+      cacheGateReleased.current ? React.createElement(React.Fragment, null, children) : null,
   };
 });
 
@@ -198,6 +199,7 @@ describe('SPAGlobalProvider', () => {
   });
 
   beforeEach(() => {
+    cacheGateReleased.current = true;
     canAccessDevDock.mockReturnValue(false);
     devDockRenderError.current = null;
     setDevDockUnlocked(false);

--- a/src/layout/SPAGlobalProvider/index.tsx
+++ b/src/layout/SPAGlobalProvider/index.tsx
@@ -97,7 +97,9 @@ const SPAGlobalProvider = memo<PropsWithChildren>(({ children }) => {
                 <TooltipGroup layoutAnimation={false}>
                   <StyleProvider speedy={import.meta.env.PROD}>
                     <LobeAnalyticsProviderWrapper>
-                      <CacheHydrationGate>{children}</CacheHydrationGate>
+                      <CacheHydrationGate>
+                        <DevDockLayout>{children}</DevDockLayout>
+                      </CacheHydrationGate>
                     </LobeAnalyticsProviderWrapper>
                   </StyleProvider>
                 </TooltipGroup>
@@ -124,9 +126,7 @@ const SPAGlobalProvider = memo<PropsWithChildren>(({ children }) => {
           isMobile={isMobile}
           serverConfig={serverConfig?.config}
         >
-          <QueryProvider>
-            <DevDockLayout>{content}</DevDockLayout>
-          </QueryProvider>
+          <QueryProvider>{content}</QueryProvider>
         </ServerConfigStoreProvider>
       </AppTheme>
     </Locale>


### PR DESCRIPTION
<!-- Brief and heads-up -->

`DevDockLayout` previously wrapped the whole app content **outside** `CacheHydrationGate`, so the dev dock layout mounted around content before the cache gate released. This moves it inside the gate so the dock and page content only render after cache hydration completes.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Updated `src/layout/SPAGlobalProvider/index.test.tsx` with a controllable `CacheHydrationGate` mock to cover the new ordering; all 9 tests pass.

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->