### PR TITLE
🐛 fix(conversation): skip empty content block placeholder and fold turn process at visible output end

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.test.tsx
@@ -270,6 +270,17 @@ describe('AssistantGroup ContentBlock', () => {
     expect(screen.getByText('reasoning')).toBeInTheDocument();
   });
 
+  it('renders nothing for an empty block waiting for its first stream chunk', () => {
+    // A new step block mounts before any content/reasoning streams and before
+    // the reasoning op starts. Rendering an empty wrapper would consume a flex
+    // gap slot in the block list and visibly push the next sibling down.
+    const { container } = render(
+      <ContentBlock assistantId="assistant-1" content="" id="block-1" />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it('keeps the streaming reasoning placeholder when no reasoning object exists yet', () => {
     isInReasoningMock = true;
 

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
@@ -99,6 +99,15 @@ const ContentBlock = memo<ContentBlockProps>(
       return errorBlock;
     }
 
+    // A freshly created step block can mount before anything about it is
+    // renderable — no content/reasoning has streamed yet and the reasoning op
+    // hasn't started. Mounting the wrapper anyway would consume a flex `gap`
+    // slot in the parent block list, visibly pushing the next sibling (e.g. the
+    // message footer) down a beat before the block's content appears.
+    if (!showReasoning && !showMessageContent && !showImageItems && !errorBlock) {
+      return null;
+    }
+
     return (
       <Flexbox gap={8} id={domId ?? id}>
         {showReasoning && (

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
@@ -13,6 +13,7 @@ import Group from './Group';
 let mockIsCollapsed = false;
 let mockIsGenerating = false;
 let mockDbMessages: { createdAt?: Date | number | string | null; id: string }[] = [];
+let mockOperations: { metadata: Record<string, unknown>; status: string }[] = [];
 
 vi.mock('@lobehub/ui', () => ({
   Flexbox: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
@@ -30,7 +31,7 @@ vi.mock('@/store/chat', () => ({
 
 vi.mock('@/store/chat/slices/operation/selectors', () => ({
   operationSelectors: {
-    getOperationsByMessage: () => () => [],
+    getOperationsByMessage: () => () => mockOperations,
   },
 }));
 
@@ -179,6 +180,7 @@ describe('Group', () => {
     mockIsCollapsed = false;
     mockIsGenerating = false;
     mockDbMessages = [];
+    mockOperations = [];
   });
 
   it('keeps a long mixed single-tool block inline in its natural order', () => {
@@ -408,6 +410,61 @@ describe('Group', () => {
     expect(fold.contains(answer)).toBe(false);
     expect(fold.contains(screen.getByTestId('workflow-segment'))).toBe(true);
     expect(fold).toHaveAttribute('data-step-count', '2');
+  });
+
+  it('folds as soon as the operation’s visible output ends, before terminal completion', () => {
+    // After `visible_output_end` the op stays `running` for seconds of terminal
+    // bookkeeping (persistence, agent_runtime_end, completeRun). Folding must
+    // key off the visible end, not the terminal status flip.
+    mockOperations = [{ metadata: { visibleLoadingDone: true }, status: 'running' }];
+
+    render(
+      <Group
+        enableProcessFold
+        isLatestItem
+        id="assistant-1"
+        messageIndex={0}
+        blocks={[
+          blk({
+            content: 'Running the checks.',
+            id: 'block-1',
+            tools: [
+              { apiName: 'bash', id: 'tool-1', result: { content: 'ok' } } as any,
+              { apiName: 'bash', id: 'tool-2', result: { content: 'ok' } } as any,
+            ],
+          }),
+          blk({ content: 'Here is the final answer.', id: 'block-2' }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId('process-fold')).toBeInTheDocument();
+  });
+
+  it('does not fold while the operation is still visibly running', () => {
+    mockOperations = [{ metadata: {}, status: 'running' }];
+
+    render(
+      <Group
+        enableProcessFold
+        isLatestItem
+        id="assistant-1"
+        messageIndex={0}
+        blocks={[
+          blk({
+            content: 'Running the checks.',
+            id: 'block-1',
+            tools: [
+              { apiName: 'bash', id: 'tool-1', result: { content: 'ok' } } as any,
+              { apiName: 'bash', id: 'tool-2', result: { content: 'ok' } } as any,
+            ],
+          }),
+          blk({ content: 'Here is the final answer.', id: 'block-2' }),
+        ]}
+      />,
+    );
+
+    expect(screen.queryByTestId('process-fold')).not.toBeInTheDocument();
   });
 
   it('keeps the latest finished turn’s final answer visible outside the fold', () => {

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -206,10 +206,20 @@ const Group = memo<GroupChildrenProps>(
       messageStateSelectors.isMessageCollapsed(id)(s),
       messageStateSelectors.isAssistantGroupItemGenerating(id)(s),
     ]);
+    // A running op whose visible output already ended (`visible_output_end` →
+    // `metadata.visibleLoadingDone`) only has terminal bookkeeping left
+    // (server-side persistence, agent_runtime_end, completeRun). Treating it as
+    // still active would delay process folding by seconds after the answer
+    // finished streaming. Safe to fold early: `stream_start` resets the flag,
+    // so a follow-up step re-activates the operation.
     const hasActiveOperation = useChatStore((s) =>
       operationSelectors
         .getOperationsByMessage(id)(s)
-        .some((op) => ACTIVE_OPERATION_STATUSES.has(op.status)),
+        .some(
+          (op) =>
+            ACTIVE_OPERATION_STATUSES.has(op.status) &&
+            !(op.status === 'running' && op.metadata.visibleLoadingDone),
+        ),
     );
     const turnDurationMs = useConversationStore((s) => getTurnDurationMs(s.dbMessages, blocks));
     const contextValue = useMemo(() => ({ assistantGroupId: id }), [id]);


### PR DESCRIPTION
Two streaming-UI glitches in the assistant group message, both visible in the same screen recording:

**1. Gap briefly widens between the tool list and the message footer**

When a new step block is created (e.g. reasoning about to start), it mounts before any of its content is renderable — `ContentBlock` still returned an empty `<Flexbox>` wrapper, which consumed a `gap: 8px` slot in the parent block list and visibly pushed the next sibling down a beat before the reasoning card appeared.

Fix: `ContentBlock` returns `null` when it has nothing to show (no reasoning, no content/tools, no images, no error).

**2. Process folding ("Ran N steps") lags ~5s behind the finished answer**

`Group`'s `hasActiveOperation` gated folding on the operation leaving `running` status, which only happens after server-side terminal bookkeeping (final persistence, `agent_runtime_end`) plus the client's `completeRun` chain. The visible output had already ended seconds earlier via `visible_output_end` → `metadata.visibleLoadingDone` — the same signal that already drives `isGenerating`.

Fix: treat a running operation with `visibleLoadingDone` as ended for fold purposes, so the process folds as soon as the final answer finishes streaming. `stream_start` resets the flag, so a follow-up step re-activates the operation.

#### Test

- [x] Tested locally
- [x] Added/updated tests

Regression tests: empty block renders nothing (`ContentBlock.test.tsx`); fold triggers on `visibleLoadingDone` while still `running`, and not while visibly running (`Group.test.tsx`).