### PR TITLE
🐛 fix(server): apply builtin avatar fallback to agent config snapshots

### DIFF
--- a/apps/server/src/services/agent/index.test.ts
+++ b/apps/server/src/services/agent/index.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { BUILTIN_AGENTS } from '@lobechat/builtin-agents';
 import { DEFAULT_AGENT_CONFIG, DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE } from '@lobechat/const';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -511,6 +512,73 @@ describe('AgentService', () => {
       // Agent config should override server default
       expect(result?.model).toBe('claude-3');
       expect(result?.provider).toBe('anthropic');
+    });
+
+    // Builtin agent rows are provisioned without avatar; the client replaces its
+    // cached entry with this snapshot, so the snapshot must carry the builtin
+    // avatar or the UI degrades to the default robot avatar (LOBE-12876)
+    it('should fall back to the builtin avatar when a builtin agent row has none', async () => {
+      const mockAgent = {
+        avatar: null,
+        id: 'agent-task',
+        slug: 'task-agent',
+        title: '任务助手',
+      };
+
+      const mockAgentModel = {
+        getAgentConfigById: vi.fn().mockResolvedValue(mockAgent),
+      };
+
+      (AgentModel as any).mockImplementation(() => mockAgentModel);
+      (parseAgentConfig as any).mockReturnValue({});
+
+      const newService = new AgentService(mockDb, mockUserId);
+      const result = await newService.getAgentConfigById('agent-task');
+
+      expect(result?.avatar).toBe(BUILTIN_AGENTS['task-agent']?.avatar);
+      expect(result?.title).toBe('任务助手');
+    });
+
+    it('should fall back inbox avatar and title when the inbox row has none', async () => {
+      const mockAgent = {
+        avatar: null,
+        id: 'agent-inbox',
+        slug: 'inbox',
+        title: null,
+      };
+
+      const mockAgentModel = {
+        getAgentConfigById: vi.fn().mockResolvedValue(mockAgent),
+      };
+
+      (AgentModel as any).mockImplementation(() => mockAgentModel);
+      (parseAgentConfig as any).mockReturnValue({});
+
+      const newService = new AgentService(mockDb, mockUserId);
+      const result = await newService.getAgentConfigById('agent-inbox');
+
+      expect(result?.avatar).toBe(DEFAULT_INBOX_AVATAR);
+      expect(result?.title).toBe(DEFAULT_INBOX_TITLE);
+    });
+
+    it('should keep a custom avatar over the builtin fallback', async () => {
+      const mockAgent = {
+        avatar: 'https://example.com/custom.png',
+        id: 'agent-task',
+        slug: 'task-agent',
+      };
+
+      const mockAgentModel = {
+        getAgentConfigById: vi.fn().mockResolvedValue(mockAgent),
+      };
+
+      (AgentModel as any).mockImplementation(() => mockAgentModel);
+      (parseAgentConfig as any).mockReturnValue({});
+
+      const newService = new AgentService(mockDb, mockUserId);
+      const result = await newService.getAgentConfigById('agent-task');
+
+      expect(result?.avatar).toBe('https://example.com/custom.png');
     });
 
     describe('Redis welcome data integration', () => {

--- a/apps/server/src/services/agent/index.ts
+++ b/apps/server/src/services/agent/index.ts
@@ -86,15 +86,30 @@ export class AgentService {
 
     const mergedConfig = this.mergeDefaultConfig(agent, defaultAgentConfig);
     if (!mergedConfig) return null;
-    const identity = { slug: (mergedConfig as { slug?: string | null }).slug ?? slug };
+
+    return this.applyBuiltinIdentity(mergedConfig, slug);
+  }
+
+  /**
+   * Builtin agent rows are provisioned without avatar/title (see
+   * `AgentModel.getBuiltinAgent`) — their identity lives in the builtin-agents
+   * package definition, and in branding constants for the inbox. Every read
+   * path that returns an agent snapshot must re-apply that identity: the
+   * client treats `fetchAgentConfig` responses as authoritative full snapshots
+   * and replaces its cached entry, so a snapshot missing the avatar clobbers a
+   * previously correct one and the UI falls back to the default robot avatar.
+   */
+  private applyBuiltinIdentity<T extends LobeAgentConfig>(config: T, fallbackSlug?: string): T {
+    const slug = (config as { slug?: string | null }).slug ?? fallbackSlug;
+    const identity = { slug };
     const normalizedConfig = {
-      ...mergedConfig,
-      avatar: normalizeInboxAgentAvatar(mergedConfig.avatar, identity),
-      title: normalizeInboxAgentTitle(mergedConfig.title, identity),
+      ...config,
+      avatar: normalizeInboxAgentAvatar(config.avatar, identity),
+      title: normalizeInboxAgentTitle(config.title, identity),
     };
 
     // Use builtin avatar as fallback only when DB has no custom avatar
-    const builtinAgent = BUILTIN_AGENTS[slug as BuiltinAgentSlug];
+    const builtinAgent = slug ? BUILTIN_AGENTS[slug as BuiltinAgentSlug] : undefined;
     if (builtinAgent?.avatar && !normalizedConfig.avatar) {
       return { ...normalizedConfig, avatar: builtinAgent.avatar };
     }
@@ -118,7 +133,10 @@ export class AgentService {
       this.userModel.getUserSettingsDefaultAgentConfig(),
     ]);
 
-    return this.mergeDefaultConfig(agent, defaultAgentConfig) as AgentConfigWithId | null;
+    const config = this.mergeDefaultConfig(agent, defaultAgentConfig) as AgentConfigWithId | null;
+    if (!config) return null;
+
+    return this.applyBuiltinIdentity(config);
   }
 
   /**
@@ -141,16 +159,18 @@ export class AgentService {
     const config = this.mergeDefaultConfig(agent, defaultAgentConfig);
     if (!config) return null;
 
+    const normalizedConfig = this.applyBuiltinIdentity(config);
+
     // Merge AI-generated welcome data if available
     if (welcomeData) {
       return {
-        ...config,
+        ...normalizedConfig,
         openingMessage: welcomeData.welcomeMessage,
         openingQuestions: welcomeData.openQuestions,
       };
     }
 
-    return config;
+    return normalizedConfig;
   }
 
   /**


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔗 相关 Issue | Related Issue

Fixes LOBE-12876

#### 📝 补充信息 | Additional Information

**Problem**: Builtin agents (task agent, inbox, agent-builder…) rendered the default robot avatar in the agent profile conversation list and in the task page's agent picker.

**Root cause**: Builtin agent rows are provisioned without an avatar — `AgentService.getBuiltinAgent` re-applies the avatar from the builtin-agents package definition (and branding constants for the inbox) at read time, but `getAgentConfig` / `getAgentConfigById` did not. Since #17872, the client treats `fetchAgentConfig` responses as authoritative full snapshots and replaces the cached `agentMap` entry instead of patch-merging, so the avatar-less snapshot clobbered the previously correct avatar and the UI fell back to `DEFAULT_AVATAR`.

**Fix**: Extract the identity normalization from `getBuiltinAgent` into a shared `applyBuiltinIdentity` helper and apply it in all three read paths (`getBuiltinAgent`, `getAgentConfig`, `getAgentConfigById`), so every agent config snapshot carries the builtin avatar/title fallback. Custom avatars stored in the DB still take precedence.

**Tests**: Added regression tests covering builtin avatar fallback, inbox avatar/title fallback, and custom-avatar precedence in `getAgentConfigById` — all fail before the fix and pass after.