### PR TITLE
🐛 fix(agent): show heterogeneous runtime labels

### DIFF
--- a/packages/types/src/agent/displayName.test.ts
+++ b/packages/types/src/agent/displayName.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { agentDisplayName } from './displayName';
+import { agentDisplayName, agentSecondaryDisplayName } from './displayName';
 
 describe('agentDisplayName', () => {
   it('prefers the personal name over the role', () => {
@@ -27,5 +27,22 @@ describe('agentDisplayName', () => {
   it('returns undefined without a fallback when nothing is set', () => {
     expect(agentDisplayName({})).toBeUndefined();
     expect(agentDisplayName(undefined)).toBeUndefined();
+  });
+});
+
+describe('agentSecondaryDisplayName', () => {
+  it('prefers a runtime label over a platform profile title', () => {
+    expect(agentSecondaryDisplayName({ name: '陆令言', title: 'default' }, 'Hermes')).toBe(
+      'Hermes',
+    );
+    expect(agentSecondaryDisplayName({ name: '燕来', title: 'Pi' }, 'Pi')).toBe('Pi');
+  });
+
+  it('keeps regular roles and suppresses labels that duplicate the primary name', () => {
+    expect(agentSecondaryDisplayName({ name: 'Alice', title: 'Health Assistant' })).toBe(
+      'Health Assistant',
+    );
+    expect(agentSecondaryDisplayName({ title: 'Pi' }, 'Pi')).toBeUndefined();
+    expect(agentSecondaryDisplayName({ title: 'Health Assistant' })).toBeUndefined();
   });
 });

--- a/packages/types/src/agent/displayName.ts
+++ b/packages/types/src/agent/displayName.ts
@@ -43,3 +43,22 @@ export function agentDisplayName(
 ): string | undefined {
   return firstNonBlank(agent?.name, agent?.title, fallback);
 }
+
+/**
+ * Resolve the supporting label shown beside an agent's primary name.
+ *
+ * Runtime-backed agents can supply `preferredLabel` (for example "Hermes")
+ * because their persisted title may instead contain an internal platform
+ * profile name such as "default". Regular agents show their role only when a
+ * personal name is present. A label matching the primary name is suppressed.
+ */
+export const agentSecondaryDisplayName = (
+  agent: AgentNameFields | null | undefined,
+  preferredLabel?: string | null,
+): string | undefined => {
+  const primaryLabel = agentDisplayName(agent);
+  const role = firstNonBlank(agent?.name) ? agent?.title : undefined;
+  const secondaryLabel = firstNonBlank(preferredLabel, role);
+
+  return secondaryLabel === primaryLabel ? undefined : secondaryLabel;
+};

--- a/src/features/AgentViewAll/AgentCard.tsx
+++ b/src/features/AgentViewAll/AgentCard.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import { AGENT_CHAT_URL, DEFAULT_AVATAR, GROUP_CHAT_URL } from '@lobechat/const';
-import { agentDisplayName, type SidebarAgentItem } from '@lobechat/types';
+import { HETEROGENEOUS_TYPE_LABELS } from '@lobechat/heterogeneous-agents';
+import {
+  agentDisplayName,
+  agentSecondaryDisplayName,
+  type SidebarAgentItem,
+} from '@lobechat/types';
 import {
   Avatar,
   Block,
@@ -100,9 +105,10 @@ const AgentCard = memo<AgentCardProps>(
     const { description, id, type, updatedAt } = item;
     // Groups have no personal name, so this resolves to their title.
     const displayTitle = agentDisplayName(item, t('agentViewAll.untitled'));
-    // Keep the role visible beside a personal name (same as the sidebar row) —
-    // otherwise a named agent's role disappears from this list entirely.
-    const roleTag = item.name?.trim() && item.title?.trim() ? item.title : undefined;
+    const runtimeTag = item.heterogeneousType
+      ? (HETEROGENEOUS_TYPE_LABELS[item.heterogeneousType] ?? item.heterogeneousType)
+      : undefined;
+    const roleTag = agentSecondaryDisplayName(item, runtimeTag);
     const [anchor, setAnchor] = useState<HTMLElement | null>(null);
 
     // Right-click support — same bridge as AgentRow: the hook-bearing menu

--- a/src/features/AgentViewAll/AgentRow.tsx
+++ b/src/features/AgentViewAll/AgentRow.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import { AGENT_CHAT_URL, DEFAULT_AVATAR, GROUP_CHAT_URL } from '@lobechat/const';
-import { agentDisplayName, type SidebarAgentItem } from '@lobechat/types';
+import { HETEROGENEOUS_TYPE_LABELS } from '@lobechat/heterogeneous-agents';
+import {
+  agentDisplayName,
+  agentSecondaryDisplayName,
+  type SidebarAgentItem,
+} from '@lobechat/types';
 import {
   ActionIcon,
   Avatar,
@@ -111,10 +116,10 @@ const AgentRow = memo<AgentRowProps>(
     const { id, type, updatedAt } = item;
     // Groups have no personal name, so this resolves to their title.
     const displayTitle = agentDisplayName(item, t('agentViewAll.untitled'));
-    // When the personal name won the label the role would otherwise vanish from
-    // this list entirely — keep it beside the name as a muted tag, the same way
-    // the sidebar row does. No tag when the label already IS the role.
-    const roleTag = item.name?.trim() && item.title?.trim() ? item.title : undefined;
+    const runtimeTag = item.heterogeneousType
+      ? (HETEROGENEOUS_TYPE_LABELS[item.heterogeneousType] ?? item.heterogeneousType)
+      : undefined;
+    const roleTag = agentSecondaryDisplayName(item, runtimeTag);
     const [anchor, setAnchor] = useState<HTMLElement | null>(null);
 
     // Right-click support (Task-List-style): the hook-bearing menu mounts on

--- a/src/features/AgentViewAll/SidebarAgentsSection.tsx
+++ b/src/features/AgentViewAll/SidebarAgentsSection.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import { AGENT_CHAT_URL, GROUP_CHAT_URL } from '@lobechat/const';
-import { agentDisplayName, type SidebarAgentItem } from '@lobechat/types';
+import { HETEROGENEOUS_TYPE_LABELS } from '@lobechat/heterogeneous-agents';
+import {
+  agentDisplayName,
+  agentSecondaryDisplayName,
+  type SidebarAgentItem,
+} from '@lobechat/types';
 import { Block, ContextMenuTrigger, Flexbox, Icon, type MenuProps, Tag, Text } from '@lobehub/ui';
 import { createStaticStyles, cssVar, responsive } from 'antd-style';
 import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
@@ -104,8 +109,10 @@ const SidebarMiniCard = memo<SidebarMiniCardProps>(({ item, onToggleSidebar }) =
   const { description, id, type } = item;
   // Groups have no personal name, so this resolves to their title.
   const displayTitle = agentDisplayName(item, t('agentViewAll.untitled'));
-  // Keep the role visible beside a personal name (same as the sidebar row).
-  const roleTag = item.name?.trim() && item.title?.trim() ? item.title : undefined;
+  const runtimeTag = item.heterogeneousType
+    ? (HETEROGENEOUS_TYPE_LABELS[item.heterogeneousType] ?? item.heterogeneousType)
+    : undefined;
+  const roleTag = agentSecondaryDisplayName(item, runtimeTag);
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
 
   const [menuActivated, setMenuActivated] = useState(false);

--- a/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/index.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/index.tsx
@@ -1,4 +1,9 @@
-import { agentDisplayName, type SidebarAgentItem } from '@lobechat/types';
+import { HETEROGENEOUS_TYPE_LABELS } from '@lobechat/heterogeneous-agents';
+import {
+  agentDisplayName,
+  agentSecondaryDisplayName,
+  type SidebarAgentItem,
+} from '@lobechat/types';
 import { ActionIcon, Icon } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { Loader2, PinIcon } from 'lucide-react';
@@ -97,9 +102,13 @@ const AgentItem = memo<AgentItemProps>(({ item, style, className, onNavigate }) 
 
   // Name-first label with fallback (see agentDisplayName)
   const displayTitle = agentDisplayName(item, t('untitledAgent'));
-  // When the personal name won the label, the role would otherwise be invisible —
-  // keep it beside the name as a muted tag. No tag when the label already IS the role.
-  const roleTag = item.name?.trim() && item.title?.trim() ? item.title : undefined;
+  // A heterogeneous agent's persisted title may be a platform profile name
+  // (Hermes commonly reports "default"), not the runtime users need to identify.
+  // Prefer the runtime label; regular agents still show their role beside their name.
+  const runtimeTag = item.heterogeneousType
+    ? (HETEROGENEOUS_TYPE_LABELS[item.heterogeneousType] ?? item.heterogeneousType)
+    : undefined;
+  const roleTag = agentSecondaryDisplayName(item, runtimeTag);
 
   const agentUrl = usePreservedAgentUrl(id);
 


### PR DESCRIPTION
Use the heterogeneous runtime brand for agent-list secondary labels instead of the persisted platform profile title. This makes Hermes agents with the `default` profile display `Hermes`, preserves `Pi`, keeps ordinary agent role labels, and suppresses labels that duplicate the primary name.

The shared resolver is used by the home sidebar and the AgentViewAll row, card, and sidebar sections, with regression coverage for runtime preference and duplicate suppression.

| Before | After |
| ------ | ----- |
| Hermes agents could show the profile title `default` as their secondary label. | Hermes agents show the runtime brand `Hermes`; Pi and ordinary role labels remain unchanged. |

#### Test

- `bun run check packages/types/src/agent/displayName.test.ts packages/types/src/agent/displayName.ts src/features/AgentViewAll/AgentCard.tsx src/features/AgentViewAll/AgentRow.tsx src/features/AgentViewAll/SidebarAgentsSection.tsx 'src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/index.tsx'` — 6 files lint clean, 8 tests passed
- `bun run check --type` — types clean

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

No directly matching issue found.
