### PR TITLE
🐛 fix: hide open-in-IDE button when no working directory is set

### DIFF
--- a/src/hooks/useEffectiveWorkingDirectory.test.ts
+++ b/src/hooks/useEffectiveWorkingDirectory.test.ts
@@ -1,0 +1,150 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAgentStore } from '@/store/agent';
+import { useChatStore } from '@/store/chat';
+import { useDeviceStore } from '@/store/device';
+import { useElectronStore } from '@/store/electron';
+import { useUserStore } from '@/store/user';
+
+import { useEffectiveWorkingDirectory } from './useEffectiveWorkingDirectory';
+
+vi.mock('@lobechat/const', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  isDesktop: true,
+}));
+
+vi.mock('@/helpers/GlobalAgentContextManager', () => ({
+  globalAgentContextManager: {
+    getContext: () => ({ desktopPath: '/Users/me/Desktop', homePath: '/Users/me' }),
+  },
+}));
+
+const effectiveAgencyConfig = vi.hoisted(() => ({
+  agencyConfig: undefined as unknown,
+  workspaceScoped: false,
+}));
+
+vi.mock('@/hooks/useEffectiveAgencyConfig', () => ({
+  useEffectiveAgencyConfig: () => effectiveAgencyConfig,
+}));
+
+vi.mock('@/store/agent', () => ({ useAgentStore: vi.fn() }));
+vi.mock('@/store/chat', () => ({ useChatStore: vi.fn() }));
+vi.mock('@/store/chat/selectors', () => ({
+  topicSelectors: {
+    currentTopicMetadata: (s: { topicMetadata?: object }) => s.topicMetadata,
+    currentTopicWorkingDirectory: (s: { topicWorkingDirectory?: string }) =>
+      s.topicWorkingDirectory,
+  },
+}));
+vi.mock('@/store/device', () => ({
+  deviceSelectors: {
+    getDeviceDefaultCwd: () => (s: { deviceDefaultCwd?: string }) => s.deviceDefaultCwd,
+  },
+  useDeviceStore: vi.fn(),
+}));
+vi.mock('@/store/electron', () => ({ useElectronStore: vi.fn() }));
+vi.mock('@/store/user', () => ({ useUserStore: vi.fn() }));
+vi.mock('@/store/user/selectors', () => ({
+  authSelectors: { isLogin: () => true },
+}));
+
+const mockedUseAgentStore = vi.mocked(useAgentStore);
+const mockedUseChatStore = vi.mocked(useChatStore);
+const mockedUseDeviceStore = vi.mocked(useDeviceStore);
+const mockedUseElectronStore = vi.mocked(useElectronStore);
+const mockedUseUserStore = vi.mocked(useUserStore);
+
+const setupStores = ({
+  agencyConfig,
+  deviceDefaultCwd,
+  legacyWorkingDirectory,
+  topicWorkingDirectory,
+}: {
+  agencyConfig?: unknown;
+  deviceDefaultCwd?: string;
+  legacyWorkingDirectory?: string;
+  topicWorkingDirectory?: string;
+} = {}) => {
+  effectiveAgencyConfig.agencyConfig = agencyConfig;
+
+  const agentState = {
+    localAgentWorkingDirectoryMap: legacyWorkingDirectory
+      ? { 'agent-1': legacyWorkingDirectory }
+      : {},
+  };
+  const chatState = { topicMetadata: undefined, topicWorkingDirectory };
+  const deviceState = { deviceDefaultCwd, useFetchDevices: vi.fn() };
+  const electronState = { gatewayDeviceInfo: { deviceId: 'device-A' } };
+  const userState = {};
+
+  mockedUseAgentStore.mockImplementation((selector: any) => selector(agentState));
+  mockedUseChatStore.mockImplementation((selector: any) => selector(chatState));
+  mockedUseDeviceStore.mockImplementation((selector: any) => selector(deviceState));
+  mockedUseElectronStore.mockImplementation((selector: any) => selector(electronState));
+  mockedUseUserStore.mockImplementation((selector: any) => selector(userState));
+};
+
+describe('useEffectiveWorkingDirectory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    effectiveAgencyConfig.agencyConfig = undefined;
+    effectiveAgencyConfig.workspaceScoped = false;
+  });
+
+  it('falls back to the desktop path when nothing is configured', () => {
+    setupStores();
+
+    const { result } = renderHook(() => useEffectiveWorkingDirectory('agent-1'));
+
+    expect(result.current).toBe('/Users/me/Desktop');
+  });
+
+  it('returns undefined with homeFallback disabled and nothing configured', () => {
+    // Regression: the conversation header must not surface the open-in-IDE
+    // button off the desktop/home fallback when no directory was ever picked.
+    setupStores();
+
+    const { result } = renderHook(() =>
+      useEffectiveWorkingDirectory('agent-1', { homeFallback: false }),
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('still resolves explicitly configured directories with homeFallback disabled', () => {
+    setupStores({
+      agencyConfig: { workingDirByDevice: { 'device-A': '/repo/project' } },
+    });
+
+    const { result } = renderHook(() =>
+      useEffectiveWorkingDirectory('agent-1', { homeFallback: false }),
+    );
+
+    expect(result.current).toBe('/repo/project');
+  });
+
+  it('prefers the topic override over the agent choice', () => {
+    setupStores({
+      agencyConfig: { workingDirByDevice: { 'device-A': '/repo/project' } },
+      topicWorkingDirectory: '/repo/topic-project',
+    });
+
+    const { result } = renderHook(() =>
+      useEffectiveWorkingDirectory('agent-1', { homeFallback: false }),
+    );
+
+    expect(result.current).toBe('/repo/topic-project');
+  });
+
+  it('keeps the device default cwd with homeFallback disabled', () => {
+    setupStores({ deviceDefaultCwd: '/repo/device-default' });
+
+    const { result } = renderHook(() =>
+      useEffectiveWorkingDirectory('agent-1', { homeFallback: false }),
+    );
+
+    expect(result.current).toBe('/repo/device-default');
+  });
+});

--- a/src/hooks/useEffectiveWorkingDirectory.ts
+++ b/src/hooks/useEffectiveWorkingDirectory.ts
@@ -14,18 +14,33 @@ import { useElectronStore } from '@/store/electron';
 import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/selectors';
 
+interface UseEffectiveWorkingDirectoryOptions {
+  /**
+   * Whether to fall back to the desktop/home directory when nothing is
+   * configured. Turn OFF for UI affordances that should only appear once the
+   * user explicitly picked a directory (e.g. the "open in IDE" header button),
+   * while runtime consumers keep the fallback so tools always have a cwd.
+   *
+   * @default true
+   */
+  homeFallback?: boolean;
+}
+
 /**
  * The agent's effective working directory under the unified precedence:
  *
  *   topic override > agent's per-device choice > legacy localStorage > device
- *   default > home (desktop only).
+ *   default > home (desktop only, unless `homeFallback` is disabled).
  *
  * Combines the agent store (agencyConfig + legacy map), chat store (topic cwd),
  * device store (defaultCwd) and the current machine's deviceId. Use this instead
  * of the old `topicCwd || agentCwd` pattern so local and remote resolve the same
  * way. Returns `undefined` only on web with nothing configured.
  */
-export const useEffectiveWorkingDirectory = (agentId?: string): string | undefined => {
+export const useEffectiveWorkingDirectory = (
+  agentId?: string,
+  { homeFallback = true }: UseEffectiveWorkingDirectoryOptions = {},
+): string | undefined => {
   // Self-populate the device store (SWR dedupes by key across all callers).
   // Devices live behind an authed lambda procedure, so only fetch once signed in
   // (desktop always fetches — it relies on the local device's saved cwd).
@@ -50,7 +65,7 @@ export const useEffectiveWorkingDirectory = (agentId?: string): string | undefin
   const deviceDefaultCwd = useDeviceStore(deviceSelectors.getDeviceDefaultCwd(targetDeviceId));
 
   // Home is the last-resort default, desktop-only (matches the legacy selector).
-  const ctx = isDesktop ? globalAgentContextManager.getContext() : undefined;
+  const ctx = isDesktop && homeFallback ? globalAgentContextManager.getContext() : undefined;
   const fallback = ctx?.desktopPath ?? ctx?.homePath;
 
   return resolveAgentWorkingDirectory({

--- a/src/routes/(main)/agent/features/Conversation/Header/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/index.tsx
@@ -7,11 +7,10 @@ import { memo } from 'react';
 import NavHeader from '@/features/NavHeader';
 import OpenInAppButton from '@/features/OpenInAppButton';
 import TopicCommentButton from '@/features/TopicComment/TopicCommentButton';
+import { useEffectiveWorkingDirectory } from '@/hooks/useEffectiveWorkingDirectory';
 import { useAgentStore } from '@/store/agent';
-import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
+import { chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
-import { topicSelectors } from '@/store/chat/selectors';
-import { useElectronStore } from '@/store/electron';
 
 import HeaderActions from './HeaderActions';
 import ShareButton from './ShareButton';
@@ -92,17 +91,14 @@ const headerStyles = createStaticStyles(({ css }) => ({
 
 const Header = memo(() => {
   const agentId = useChatStore((s) => s.activeAgentId);
-  const topicWorkingDirectory = useChatStore(topicSelectors.currentTopicWorkingDirectory);
-  const currentDeviceId = useElectronStore((s) => s.gatewayDeviceInfo?.deviceId);
-  const agentWorkingDirectory = useAgentStore((s) =>
-    agentId
-      ? agentByIdSelectors.getAgentWorkingDirectoryById(agentId, currentDeviceId)(s)
-      : undefined,
-  );
+  // No home/desktop fallback: the IDE button should only show up once the user
+  // explicitly picked a working directory (topic / agent / device default).
+  const workingDirectory = useEffectiveWorkingDirectory(agentId || undefined, {
+    homeFallback: false,
+  });
   const isLocalSystemEnabled = useAgentStore((s) =>
     agentId ? chatConfigByIdSelectors.isLocalSystemEnabledById(agentId)(s) : false,
   );
-  const effectiveWorkingDirectory = topicWorkingDirectory || agentWorkingDirectory || '';
 
   return (
     <div className={headerStyles.container}>
@@ -121,8 +117,8 @@ const Header = memo(() => {
         }
         right={
           <Flexbox horizontal align={'center'} className={headerStyles.rightContent} gap={4}>
-            {isLocalSystemEnabled && (
-              <OpenInAppButton workingDirectory={effectiveWorkingDirectory} />
+            {isLocalSystemEnabled && workingDirectory && (
+              <OpenInAppButton workingDirectory={workingDirectory} />
             )}
             <TopicCommentButton />
             <ShareButton />


### PR DESCRIPTION
The conversation header showed the open-in-IDE button even when the user never picked a working directory: `getAgentWorkingDirectoryById` falls back to `desktopPath ?? homePath`, so the header always received a non-empty path — inconsistent with the composer's working-directory chip, which showed "unset".

**Changes**

- `useEffectiveWorkingDirectory` gains a `homeFallback` option (default `true`). With `homeFallback: false` it resolves only user-configured directories (topic override > agent per-device choice > legacy localStorage > device default cwd) and returns `undefined` otherwise. Runtime consumers keep the fallback so tools always have a cwd.
- The conversation header now uses this hook with `homeFallback: false` and skips rendering `OpenInAppButton` when nothing is configured. This also aligns the header with the composer picker's resolution (the header previously ignored the device default cwd).

#### Test

- [x] Tested locally
- [x] Added/updated tests

Regression tests in `src/hooks/useEffectiveWorkingDirectory.test.ts` cover the no-fallback case and the precedence chain.

#### 🔗 Related Issue

Fixes LOBE-12874