### PR TITLE
✨ feat(volcengine): add env toggle to use polling instead of webhook for video generation

### DIFF
--- a/packages/model-runtime/src/providers/volcengine/index.ts
+++ b/packages/model-runtime/src/providers/volcengine/index.ts
@@ -3,7 +3,7 @@ import { ModelProvider } from 'model-bank';
 import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
 import type { ChatStreamPayload } from '../../types';
 import { createVolcengineImage } from './createImage';
-import { createVolcengineVideo } from './video/createVideo';
+import { createVolcengineVideo, pollVolcengineVideoStatus } from './video/createVideo';
 import { handleVolcengineVideoWebhook } from './video/handleCreateVideoWebhook';
 
 const isVolcengineReasoningEffortModel = (model: string) => {
@@ -76,6 +76,7 @@ export const LobeVolcengineAI = createOpenAICompatibleRuntime({
     responses: () => process.env.DEBUG_VOLCENGINE_RESPONSES === '1',
   },
   handleCreateVideoWebhook: handleVolcengineVideoWebhook,
+  handlePollVideoStatus: (inferenceId, options) => pollVolcengineVideoStatus(inferenceId, options),
   provider: ModelProvider.Volcengine,
   responses: {
     handlePayload: (payload) => {

--- a/packages/model-runtime/src/providers/volcengine/video/createVideo.test.ts
+++ b/packages/model-runtime/src/providers/volcengine/video/createVideo.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { CreateVideoOptions } from '../../../core/openaiCompatibleFactory';
 import type { CreateVideoPayload } from '../../../types/video';
-import { createVolcengineVideo } from './createVideo';
+import { createVolcengineVideo, pollVolcengineVideoStatus } from './createVideo';
 
 vi.mock('debug', () => ({
   default: vi.fn(() => vi.fn()),
@@ -17,6 +17,7 @@ describe('createVolcengineVideo', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.VOLCENGINE_VIDEO_USE_WEBHOOK;
 
     payload = {
       model: 'doubao-video-model',
@@ -53,6 +54,54 @@ describe('createVolcengineVideo', () => {
 
       expect((result as any).useWebhook).toBe(true);
     });
+  });
+
+  describe('webhook toggle via VOLCENGINE_VIDEO_USE_WEBHOOK', () => {
+    it('should default to webhook flow and attach callback_url when unset', async () => {
+      mockFetch.mockResolvedValue({
+        json: () => Promise.resolve({ id: 'task-1' }),
+        ok: true,
+      });
+      payload.callbackUrl = 'https://example.com/webhook';
+
+      const result = await createVolcengineVideo(payload, options);
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.callback_url).toBe('https://example.com/webhook');
+      expect((result as any).useWebhook).toBe(true);
+    });
+
+    it('should keep webhook flow when explicitly set to "1"', async () => {
+      process.env.VOLCENGINE_VIDEO_USE_WEBHOOK = '1';
+      mockFetch.mockResolvedValue({
+        json: () => Promise.resolve({ id: 'task-1' }),
+        ok: true,
+      });
+      payload.callbackUrl = 'https://example.com/webhook';
+
+      const result = await createVolcengineVideo(payload, options);
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.callback_url).toBe('https://example.com/webhook');
+      expect((result as any).useWebhook).toBe(true);
+    });
+
+    it('should disable webhook and omit callback_url when set to "0"', async () => {
+      process.env.VOLCENGINE_VIDEO_USE_WEBHOOK = '0';
+      mockFetch.mockResolvedValue({
+        json: () => Promise.resolve({ id: 'task-poll' }),
+        ok: true,
+      });
+      payload.callbackUrl = 'https://example.com/webhook';
+
+      const result = await createVolcengineVideo(payload, options);
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.callback_url).toBeUndefined();
+      expect(result).toEqual({ inferenceId: 'task-poll' });
+      expect((result as any).useWebhook).toBeUndefined();
+    });
+  });
 
     it('should send minimal body with only prompt', async () => {
       mockFetch.mockResolvedValue({
@@ -283,5 +332,120 @@ describe('createVolcengineVideo', () => {
         'Invalid response: missing task id',
       );
     });
+  });
+});
+
+describe('pollVolcengineVideoStatus', () => {
+  let options: CreateVideoOptions;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    options = {
+      apiKey: 'test-api-key',
+      provider: 'volcengine',
+    };
+  });
+
+  it('should GET the task status endpoint with Authorization header', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ id: 'task-1', status: 'running' }),
+      ok: true,
+    });
+
+    await pollVolcengineVideoStatus('task-1', options);
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe(
+      'https://ark.cn-beijing.volces.com/api/v3/contents/generations/tasks/task-1',
+    );
+    expect(init.method).toBe('GET');
+    expect(init.headers.Authorization).toBe('Bearer test-api-key');
+  });
+
+  it('should return success with videoUrl when succeeded', async () => {
+    mockFetch.mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          content: { video_url: 'https://cdn.example.com/v.mp4' },
+          id: 'task-1',
+          status: 'succeeded',
+        }),
+      ok: true,
+    });
+
+    const result = await pollVolcengineVideoStatus('task-1', options);
+
+    expect(result).toEqual({ status: 'success', videoUrl: 'https://cdn.example.com/v.mp4' });
+  });
+
+  it('should return failed when succeeded but missing video_url', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ id: 'task-1', status: 'succeeded' }),
+      ok: true,
+    });
+
+    const result = await pollVolcengineVideoStatus('task-1', options);
+
+    expect(result.status).toBe('failed');
+  });
+
+  it('should return failed with error message when failed', async () => {
+    mockFetch.mockResolvedValue({
+      json: () =>
+        Promise.resolve({ error: { message: 'content moderation' }, id: 'task-1', status: 'failed' }),
+      ok: true,
+    });
+
+    const result = await pollVolcengineVideoStatus('task-1', options);
+
+    expect(result).toEqual({ error: 'content moderation', status: 'failed' });
+  });
+
+  it('should return failed for expired task', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ id: 'task-1', status: 'expired' }),
+      ok: true,
+    });
+
+    const result = await pollVolcengineVideoStatus('task-1', options);
+
+    expect(result).toEqual({ error: 'Video generation task expired', status: 'failed' });
+  });
+
+  it('should return pending for queued / running status', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ id: 'task-1', status: 'queued' }),
+      ok: true,
+    });
+
+    const result = await pollVolcengineVideoStatus('task-1', options);
+
+    expect(result).toEqual({ status: 'pending' });
+  });
+
+  it('should use custom baseURL when provided', async () => {
+    options.baseURL = 'https://custom-endpoint.com/api/v3';
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ id: 'task-1', status: 'running' }),
+      ok: true,
+    });
+
+    await pollVolcengineVideoStatus('task-1', options);
+
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      'https://custom-endpoint.com/api/v3/contents/generations/tasks/task-1',
+    );
+  });
+
+  it('should throw on HTTP error', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve('Not Found'),
+    });
+
+    await expect(pollVolcengineVideoStatus('task-1', options)).rejects.toThrow(
+      'Volcengine video status API error: 404 Not Found',
+    );
   });
 });

--- a/packages/model-runtime/src/providers/volcengine/video/createVideo.ts
+++ b/packages/model-runtime/src/providers/volcengine/video/createVideo.ts
@@ -1,9 +1,28 @@
 import createDebug from 'debug';
 
 import type { CreateVideoOptions } from '../../../core/openaiCompatibleFactory';
-import type { CreateVideoPayload, CreateVideoResponse } from '../../../types/video';
+import type {
+  CreateVideoPayload,
+  CreateVideoResponse,
+  PollVideoStatusResult,
+} from '../../../types/video';
 
 const log = createDebug('lobe-video:volcengine');
+
+const DEFAULT_BASE_URL = 'https://ark.cn-beijing.volces.com/api/v3';
+
+/**
+ * Whether to use webhook (callback_url) based async flow.
+ *
+ * Volcengine video generation defaults to a webhook callback: the server passes a
+ * `callback_url` and waits for Volcengine to push the result. In self-hosted / internal
+ * network deployments the callback endpoint may be unreachable (e.g. behind NAT / P2P),
+ * so this can be switched off to fall back to server-side polling instead.
+ *
+ * Set `VOLCENGINE_VIDEO_USE_WEBHOOK=0` to disable webhook and use polling.
+ * Defaults to webhook (backward compatible).
+ */
+const useWebhookFlow = () => process.env.VOLCENGINE_VIDEO_USE_WEBHOOK !== '0';
 
 /**
  * Volcengine video generation implementation
@@ -31,7 +50,9 @@ export async function createVolcengineVideo(
 
   log('Creating video with Volcengine API - model: %s, params: %O', model, params);
 
-  const baseURL = options.baseURL || 'https://ark.cn-beijing.volces.com/api/v3';
+  const baseURL = options.baseURL || DEFAULT_BASE_URL;
+
+  const withWebhook = useWebhookFlow();
 
   // Build content array
   const content: Record<string, unknown>[] = [{ text: prompt, type: 'text' }];
@@ -68,7 +89,9 @@ export async function createVolcengineVideo(
   if (seed !== undefined && seed !== null) body.seed = seed;
   if (resolution !== undefined) body.resolution = resolution;
   if (cameraFixed !== undefined) body.camera_fixed = cameraFixed;
-  if (payload.callbackUrl) body.callback_url = payload.callbackUrl;
+  // Only attach callback_url when webhook flow is enabled; otherwise the task
+  // completes via server-side polling (see pollVolcengineVideoStatus).
+  if (withWebhook && payload.callbackUrl) body.callback_url = payload.callbackUrl;
 
   log('Volcengine video API request body: %s', JSON.stringify(body, null, 2));
 
@@ -95,5 +118,74 @@ export async function createVolcengineVideo(
     throw new Error('Invalid response: missing task id');
   }
 
-  return { inferenceId: data.id, useWebhook: true };
+  // When webhook is disabled, omit `useWebhook` so the server falls back to
+  // background polling via handlePollVideoStatus.
+  return withWebhook
+    ? { inferenceId: data.id, useWebhook: true }
+    : { inferenceId: data.id };
+}
+
+interface VolcengineVideoTaskResponse {
+  content?: {
+    video_url?: string;
+  };
+  error?: {
+    code?: string;
+    message?: string;
+  };
+  id?: string;
+  status?: string;
+}
+
+/**
+ * Poll the status of a Volcengine video generation task.
+ * Used when webhook flow is disabled (VOLCENGINE_VIDEO_USE_WEBHOOK=0).
+ * API docs: https://www.volcengine.com/docs/82379/1521675
+ */
+export async function pollVolcengineVideoStatus(
+  taskId: string,
+  options: CreateVideoOptions,
+): Promise<PollVideoStatusResult> {
+  const baseURL = options.baseURL || DEFAULT_BASE_URL;
+
+  log('Polling Volcengine video task status: %s', taskId);
+
+  const response = await fetch(`${baseURL}/contents/generations/tasks/${taskId}`, {
+    headers: {
+      Authorization: `Bearer ${options.apiKey}`,
+    },
+    method: 'GET',
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    log('Volcengine video status API error: %s %s', response.status, errorText);
+    throw new Error(`Volcengine video status API error: ${response.status} ${errorText}`);
+  }
+
+  const data = (await response.json()) as VolcengineVideoTaskResponse;
+
+  log('Volcengine video task status response: %O', data);
+
+  const status = data.status;
+
+  if (status === 'succeeded') {
+    const videoUrl = data.content?.video_url;
+    if (!videoUrl) {
+      return { error: 'Task succeeded but no video URL found', status: 'failed' };
+    }
+    return { status: 'success', videoUrl };
+  }
+
+  if (status === 'failed' || status === 'expired') {
+    return {
+      error:
+        data.error?.message ||
+        (status === 'expired' ? 'Video generation task expired' : 'Video generation failed'),
+      status: 'failed',
+    };
+  }
+
+  // queued / running / unknown -> keep polling
+  return { status: 'pending' };
 }


### PR DESCRIPTION
## 💻 变更类型 | Change Type

- [x] ✨ feat

## 🔀 变更说明 | Description of Change

Volcengine video generation currently **hardcodes** webhook (`callback_url`) based async completion — the server passes a `callback_url` and waits for Volcengine to push the result back. In self-hosted / internal-network deployments the callback endpoint is often unreachable (behind NAT / P2P hole-punching), so video tasks never complete.

This PR adds an env toggle to fall back to **server-side polling**, mirroring the existing `LLM_VISION_IMAGE_USE_BASE64` opt-out pattern.

### Env

| Variable | Values | Default | Behavior |
|---|---|---|---|
| `VOLCENGINE_VIDEO_USE_WEBHOOK` | `1` / `0` | webhook | `0` → disable webhook, omit `callback_url`, use polling |

Fully backward compatible — unset or `1` keeps the current webhook flow.

### Changes

- `createVideo.ts`: read `VOLCENGINE_VIDEO_USE_WEBHOOK`. When `0`, skip `callback_url` and return without `useWebhook`, so the server routes to background polling.
- `createVideo.ts`: add `pollVolcengineVideoStatus` (GET `/contents/generations/tasks/{id}`) returning the standard `PollVideoStatusResult`.
- `index.ts`: register `handlePollVideoStatus` so polling resolves end-to-end (mirrors the `qwen` provider), driven by the existing `videoBackgroundPolling` service.
- Tests for the toggle (default / `1` / `0`) and for the poll-status handler (success / no-url / failed / expired / pending / custom baseURL / HTTP error).

## 📝 补充信息 | Additional Information

Motivation: self-hosted deployments behind NAT / P2P cannot receive the Volcengine webhook callback, leaving video tasks stuck. Polling is already fully supported by the server (`videoBackgroundPolling`) and used by other providers such as Qwen — this PR just wires Volcengine into that path behind an env flag.