### PR TITLE
✨ feat(async): make ASYNC_TASK_TIMEOUT configurable via env

### DIFF
--- a/packages/business/config/src/server/route.ts
+++ b/packages/business/config/src/server/route.ts
@@ -1,8 +1,20 @@
 // set timeout to about 5 minutes, and give 2s padding time.
 // Can be overridden via the ASYNC_TASK_TIMEOUT_SECONDS env var (in seconds);
 // defaults to the original 298s so existing deployments are unaffected.
+// Only a finite, positive value is accepted; any invalid input (non-numeric,
+// zero, negative, Infinity, NaN) falls back to the default to avoid producing
+// a non-positive timeout that would abort pending tasks immediately.
+const DEFAULT_ASYNC_TASK_TIMEOUT_SECONDS = 60 * 5 - 2;
+
+const parseAsyncTaskTimeoutSeconds = (raw: string | undefined): number => {
+  if (raw === undefined) return DEFAULT_ASYNC_TASK_TIMEOUT_SECONDS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_ASYNC_TASK_TIMEOUT_SECONDS;
+  return parsed;
+};
+
 export const ASYNC_TASK_TIMEOUT =
-  (Number(process.env.ASYNC_TASK_TIMEOUT_SECONDS) || 60 * 5 - 2) * 1000;
+  parseAsyncTaskTimeoutSeconds(process.env.ASYNC_TASK_TIMEOUT_SECONDS) * 1000;
 
 // // trpc routes max duration
 // export const TRPC_ASYNC_MAX_DURATION: number | undefined = undefined;

--- a/packages/business/config/src/server/route.ts
+++ b/packages/business/config/src/server/route.ts
@@ -1,5 +1,8 @@
-// set timeout to about 5 minutes, and give 2s padding time
-export const ASYNC_TASK_TIMEOUT = (60 * 5 - 2) * 1000;
+// set timeout to about 5 minutes, and give 2s padding time.
+// Can be overridden via the ASYNC_TASK_TIMEOUT_SECONDS env var (in seconds);
+// defaults to the original 298s so existing deployments are unaffected.
+export const ASYNC_TASK_TIMEOUT =
+  (Number(process.env.ASYNC_TASK_TIMEOUT_SECONDS) || 60 * 5 - 2) * 1000;
 
 // // trpc routes max duration
 // export const TRPC_ASYNC_MAX_DURATION: number | undefined = undefined;


### PR DESCRIPTION
### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

### 🔀 变更说明 | Description of Change

Make the async task timeout configurable via a new `ASYNC_TASK_TIMEOUT_SECONDS` environment variable.

Currently `ASYNC_TASK_TIMEOUT` is hardcoded to `(60 * 5 - 2) * 1000` = **298s** in `packages/business/config/src/server/route.ts`. This value drives `checkTimeoutTasks` in the async task model, which marks any `Pending`/`Processing` task older than the timeout as `Error` with `TaskTimeout`.

For self-hosted deployments — especially ones relying on **polling-based** video/image providers, or running behind slower/internal networks — 298s can be too aggressive, causing tasks that would otherwise succeed to be prematurely marked as timed out.

This change reads the timeout (in seconds) from `ASYNC_TASK_TIMEOUT_SECONDS` when present, and **falls back to the original `60 * 5 - 2` (298s)** otherwise. Existing deployments are completely unaffected unless they explicitly set the env var.

```ts
export const ASYNC_TASK_TIMEOUT =
  (Number(process.env.ASYNC_TASK_TIMEOUT_SECONDS) || 60 * 5 - 2) * 1000;
```

### 📝 补充信息 | Additional Information

- Default behavior unchanged (backward compatible).
- Scope is intentionally minimal — only the timeout constant is made configurable.