### PR TITLE
🐛 fix(skill): recognize /skill slash-preloaded skills as activated for execScript

### DIFF
--- a/apps/server/src/routers/tools/market.test.ts
+++ b/apps/server/src/routers/tools/market.test.ts
@@ -17,6 +17,10 @@ const mockMarketSDK = vi.hoisted(() => ({
     listTools: vi.fn(),
   },
 }));
+const mockFindByIdentifier = vi.hoisted(() => vi.fn());
+const mockFindByName = vi.hoisted(() => vi.fn());
+const mockCheckHash = vi.hoisted(() => vi.fn());
+const mockGetFullFileUrl = vi.hoisted(() => vi.fn());
 
 vi.mock('@/libs/trpc/lambda/middleware', () => ({
   marketUserInfo: vi.fn((opts: any) => opts.next({ ctx: opts.ctx })),
@@ -36,8 +40,33 @@ vi.mock('@/libs/trpc/lambda/middleware/marketSDK', () => ({
   requireMarketAuth: vi.fn((opts: any) => opts.next({ ctx: opts.ctx })),
 }));
 
+vi.mock('@/database/models/agentSkill', () => ({
+  AgentSkillModel: vi.fn(() => ({
+    findByIdentifier: mockFindByIdentifier,
+    findByName: mockFindByName,
+  })),
+}));
+
+vi.mock('@/database/models/file', () => ({
+  FileModel: vi.fn(() => ({
+    checkHash: mockCheckHash,
+  })),
+}));
+
+vi.mock('@/database/models/user', () => ({
+  UserModel: vi.fn(() => ({})),
+}));
+
+vi.mock('@/server/services/discover', () => ({
+  DiscoverService: vi.fn(() => ({})),
+}));
+
 vi.mock('@/server/services/file', () => ({
-  FileService: vi.fn(() => ({})),
+  FileService: vi.fn(() => ({ getFullFileUrl: mockGetFullFileUrl })),
+}));
+
+vi.mock('@/server/services/market', () => ({
+  MarketService: vi.fn(() => ({})),
 }));
 
 vi.mock('@/server/services/sandbox', () => ({
@@ -141,5 +170,105 @@ describe('tools marketRouter', () => {
       tool: 'query',
       topicId: undefined,
     });
+  });
+
+  // Regression: the Web cloud-sandbox execScript path resolves activated-skill
+  // zipUrls independently from SkillServerRuntimeService. A /skill slash-
+  // preloaded skill persists the identifier (which may differ from the DB
+  // display name), so this path must resolve by identifier FIRST — otherwise
+  // the zipUrl misses and cwd silently falls back to the working directory,
+  // the exact bug this PR fixes (on the most common Web path).
+  it('resolves slash-preloaded skill zipUrls by identifier first on the cloud-sandbox path', async () => {
+    mockPreprocessLhCommand.mockResolvedValue({
+      command: 'python scripts/plan_layouts.py',
+      isLhCommand: false,
+      skipSkillLookup: false,
+    });
+    mockFindByIdentifier.mockResolvedValue({
+      id: 'marketing-skill-id',
+      identifier: 'marketing-adapter',
+      name: 'Multi-Size Marketing Adapter',
+      zipFileHash: 'zip-hash-2',
+    });
+    mockCheckHash.mockResolvedValue({ isExist: true, url: 'skills/marketing.zip' });
+    mockGetFullFileUrl.mockResolvedValue('https://files.example.com/marketing.zip');
+    mockSandboxCallTool.mockResolvedValue({ result: { exitCode: 0, stdout: 'ok' }, success: true });
+
+    const caller = marketRouter.createCaller({
+      serverDB: {},
+      userId: 'user-1',
+      workspaceId: 'workspace-1',
+    } as any);
+
+    await caller.execInSandbox({
+      params: {
+        activatedSkills: [{ identifier: 'marketing-adapter', name: 'marketing-adapter' }],
+        command: 'python scripts/plan_layouts.py',
+        description: 'Run layout planner',
+      },
+      toolName: 'execScript',
+      topicId: 'topic-1',
+    });
+
+    expect(mockFindByIdentifier).toHaveBeenCalledWith('marketing-adapter');
+    // identifier resolved — findByName must not be tried, so a collision with
+    // another skill's display name can't pick the wrong archive.
+    expect(mockFindByName).not.toHaveBeenCalledWith('marketing-adapter');
+    expect(mockSandboxCallTool).toHaveBeenCalledWith(
+      'execScript',
+      expect.objectContaining({
+        skillZipUrls: { 'marketing-adapter': 'https://files.example.com/marketing.zip' },
+      }),
+    );
+  });
+
+  it('resolves by identifier on the cloud-sandbox path even when another skill shares that identifier as its name', async () => {
+    mockPreprocessLhCommand.mockResolvedValue({
+      command: 'python scripts/plan_layouts.py',
+      isLhCommand: false,
+      skipSkillLookup: false,
+    });
+    // A DIFFERENT skill whose display name collides with the target identifier.
+    mockFindByName.mockResolvedValue({
+      id: 'colliding-skill-id',
+      identifier: 'colliding-adapter',
+      name: 'marketing-adapter',
+      zipFileHash: 'colliding-zip-hash',
+    });
+    mockFindByIdentifier.mockResolvedValue({
+      id: 'marketing-skill-id',
+      identifier: 'marketing-adapter',
+      name: 'Multi-Size Marketing Adapter',
+      zipFileHash: 'zip-hash-2',
+    });
+    mockCheckHash.mockResolvedValue({ isExist: true, url: 'skills/marketing.zip' });
+    mockGetFullFileUrl.mockResolvedValue('https://files.example.com/marketing.zip');
+    mockSandboxCallTool.mockResolvedValue({ result: { exitCode: 0, stdout: 'ok' }, success: true });
+
+    const caller = marketRouter.createCaller({
+      serverDB: {},
+      userId: 'user-1',
+      workspaceId: 'workspace-1',
+    } as any);
+
+    await caller.execInSandbox({
+      params: {
+        activatedSkills: [{ identifier: 'marketing-adapter', name: 'marketing-adapter' }],
+        command: 'python scripts/plan_layouts.py',
+        description: 'Run layout planner',
+      },
+      toolName: 'execScript',
+      topicId: 'topic-1',
+    });
+
+    // identifier-first: the colliding skill's archive is never touched.
+    expect(mockCheckHash).toHaveBeenCalledWith('zip-hash-2');
+    expect(mockCheckHash).not.toHaveBeenCalledWith('colliding-zip-hash');
+    expect(mockSandboxCallTool).toHaveBeenCalledWith(
+      'execScript',
+      expect.objectContaining({
+        skillZipUrls: { 'marketing-adapter': 'https://files.example.com/marketing.zip' },
+      }),
+    );
   });
 });

--- a/apps/server/src/routers/tools/market.ts
+++ b/apps/server/src/routers/tools/market.ts
@@ -232,7 +232,20 @@ const execInSandboxHandler = async ({
       for (const activatedSkill of enhancedParams.activatedSkills) {
         if (!activatedSkill.name) continue;
 
-        const skill = await agentSkillModel.findByName(activatedSkill.name);
+        // /skill slash-preloaded skills persist the identifier (the stable
+        // canonical key, which may differ from the DB display name). Resolve by
+        // identifier BEFORE name so a skill whose identifier collides with
+        // another skill's display name doesn't resolve to the wrong archive —
+        // mirroring SkillServerRuntimeService.resolveActivatedSkillArchives.
+        // The activateSkill path carries no identifier, so it still resolves by
+        // name exactly as before.
+        let skill = activatedSkill.identifier
+          ? await agentSkillModel.findByIdentifier(activatedSkill.identifier)
+          : undefined;
+        if (!skill) {
+          skill = await agentSkillModel.findByName(activatedSkill.name);
+        }
+
         if (!skill?.zipFileHash) continue;
 
         const fileInfo = await fileModel.checkHash(skill.zipFileHash);

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
@@ -241,13 +241,15 @@ describe('skillsRuntime', () => {
     expect(result.success).toBe(true);
     expect(mocks.findByName).toHaveBeenCalledWith('marketing-adapter');
     expect(mocks.findByIdentifier).toHaveBeenCalledWith('marketing-adapter');
-    // The fallback resolved the archive, so its zip url is attached under the
-    // skill's DB name (Multi-Size Marketing Adapter).
+    // The archive is keyed by the activated name (the identifier), which is the
+    // key both the device path (`archiveByName.get(activated.name)`) and the
+    // sandbox path (`skillZipUrls[skill.name]`) look up by — so cwd resolution
+    // does not fall back to the working directory for identifier ≠ name skills.
     expect(mocks.sandboxService.callTool).toHaveBeenCalledWith(
       'execScript',
       expect.objectContaining({
         skillZipUrls: {
-          'Multi-Size Marketing Adapter': 'https://files.example.com/user-skill.zip',
+          'marketing-adapter': 'https://files.example.com/user-skill.zip',
         },
       }),
     );

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => {
     },
     findAll: vi.fn(),
     findById: vi.fn(),
+    findByIdentifier: vi.fn(),
     findByName: vi.fn(),
     isLhCommand: vi.fn(),
     getAgentConfigById: vi.fn(),
@@ -55,6 +56,7 @@ vi.mock('@/database/models/agentSkill', () => ({
   AgentSkillModel: vi.fn(() => ({
     findAll: mocks.findAll,
     findById: mocks.findById,
+    findByIdentifier: mocks.findByIdentifier,
     findByName: mocks.findByName,
   })),
 }));
@@ -142,6 +144,21 @@ describe('skillsRuntime', () => {
 
       return undefined;
     });
+    // /skill slash-preloaded skills resolve by identifier when findByName misses
+    // (their persisted tag carries only the identifier, which may differ from the
+    // DB skill name).
+    mocks.findByIdentifier.mockImplementation(async (identifier: string) => {
+      if (identifier === 'marketing-adapter') {
+        return {
+          id: 'marketing-skill-id',
+          identifier: 'marketing-adapter',
+          name: 'Multi-Size Marketing Adapter',
+          zipFileHash: 'zip-hash-2',
+        };
+      }
+
+      return undefined;
+    });
     mocks.getAgentSkills.mockResolvedValue([]);
     mocks.getUserSettings.mockResolvedValue({ market: { accessToken: 'market-token' } });
     // Pass-through by default: the runtime now routes both runCommand and
@@ -199,6 +216,38 @@ describe('skillsRuntime', () => {
         description: 'Run skill script',
         skillZipUrls: {
           'user-skill': 'https://files.example.com/user-skill.zip',
+        },
+      }),
+    );
+  }, 20_000);
+
+  it('resolves slash-preloaded skills by identifier when findByName misses', async () => {
+    const { skillsRuntime } = await import('../skills');
+    const runtime = await skillsRuntime.factory({
+      serverDB: {} as never,
+      toolManifestMap: {},
+      topicId: 'topic-1',
+      userId: 'user-1',
+    });
+
+    // A /skill slash-preloaded skill: name carries the identifier (the only
+    // key persisted in the <skill> tag), which differs from the DB skill name.
+    const result = await runtime.execScript({
+      activatedSkills: [{ identifier: 'marketing-adapter', name: 'marketing-adapter' }],
+      command: 'python scripts/plan_layouts.py',
+      description: 'Run layout planner',
+    });
+
+    expect(result.success).toBe(true);
+    expect(mocks.findByName).toHaveBeenCalledWith('marketing-adapter');
+    expect(mocks.findByIdentifier).toHaveBeenCalledWith('marketing-adapter');
+    // The fallback resolved the archive, so its zip url is attached under the
+    // skill's DB name (Multi-Size Marketing Adapter).
+    expect(mocks.sandboxService.callTool).toHaveBeenCalledWith(
+      'execScript',
+      expect.objectContaining({
+        skillZipUrls: {
+          'Multi-Size Marketing Adapter': 'https://files.example.com/user-skill.zip',
         },
       }),
     );

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
@@ -221,7 +221,7 @@ describe('skillsRuntime', () => {
     );
   }, 20_000);
 
-  it('resolves slash-preloaded skills by identifier when findByName misses', async () => {
+  it('resolves slash-preloaded skills by identifier first, without a name lookup', async () => {
     const { skillsRuntime } = await import('../skills');
     const runtime = await skillsRuntime.factory({
       serverDB: {} as never,
@@ -239,8 +239,11 @@ describe('skillsRuntime', () => {
     });
 
     expect(result.success).toBe(true);
-    expect(mocks.findByName).toHaveBeenCalledWith('marketing-adapter');
+    // identifier is the primary lookup key — findByName must not be tried at
+    // all when the identifier resolves, so a collision with another skill's
+    // display name can't pick the wrong archive.
     expect(mocks.findByIdentifier).toHaveBeenCalledWith('marketing-adapter');
+    expect(mocks.findByName).not.toHaveBeenCalledWith('marketing-adapter');
     // The archive is keyed by the activated name (the identifier), which is the
     // key both the device path (`archiveByName.get(activated.name)`) and the
     // sandbox path (`skillZipUrls[skill.name]`) look up by — so cwd resolution
@@ -251,6 +254,62 @@ describe('skillsRuntime', () => {
         skillZipUrls: {
           'marketing-adapter': 'https://files.example.com/user-skill.zip',
         },
+      }),
+    );
+  }, 20_000);
+
+  // Regression: a slash-preloaded skill's identifier may collide with another
+  // skill's DB display name. identifier must stay the primary lookup key so
+  // the wrong archive is never prepared/executed.
+  it('resolves by identifier even when another skill shares that identifier as its name', async () => {
+    mocks.findByName.mockImplementation(async (name: string) => {
+      // A DIFFERENT skill whose display name collides with the target identifier.
+      if (name === 'marketing-adapter') {
+        return {
+          id: 'colliding-skill-id',
+          identifier: 'colliding-adapter',
+          name: 'marketing-adapter',
+          zipFileHash: 'colliding-zip-hash',
+        };
+      }
+      return undefined;
+    });
+    mocks.findByIdentifier.mockImplementation(async (identifier: string) => {
+      if (identifier === 'marketing-adapter') {
+        return {
+          id: 'marketing-skill-id',
+          identifier: 'marketing-adapter',
+          name: 'Multi-Size Marketing Adapter',
+          zipFileHash: 'zip-hash-2',
+        };
+      }
+      return undefined;
+    });
+    mocks.checkHash.mockResolvedValue({ isExist: true, url: 'skills/marketing.zip' });
+    mocks.fileService.getFullFileUrl.mockResolvedValue('https://files.example.com/marketing.zip');
+
+    const { skillsRuntime } = await import('../skills');
+    const runtime = await skillsRuntime.factory({
+      serverDB: {} as never,
+      toolManifestMap: {},
+      topicId: 'topic-1',
+      userId: 'user-1',
+    });
+
+    const result = await runtime.execScript({
+      activatedSkills: [{ identifier: 'marketing-adapter', name: 'marketing-adapter' }],
+      command: 'python scripts/plan_layouts.py',
+      description: 'Run layout planner',
+    });
+
+    expect(result.success).toBe(true);
+    // identifier-first: the colliding skill's archive is never touched.
+    expect(mocks.checkHash).toHaveBeenCalledWith('zip-hash-2');
+    expect(mocks.checkHash).not.toHaveBeenCalledWith('colliding-zip-hash');
+    expect(mocks.sandboxService.callTool).toHaveBeenCalledWith(
+      'execScript',
+      expect.objectContaining({
+        skillZipUrls: { 'marketing-adapter': 'https://files.example.com/marketing.zip' },
       }),
     );
   }, 20_000);

--- a/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
@@ -276,7 +276,13 @@ class SkillServerRuntimeService implements SkillRuntimeService {
     for (const activatedSkill of activatedSkills) {
       if (!activatedSkill.name) continue;
 
-      const skill = await this.skillModel.findByName(activatedSkill.name);
+      let skill = await this.skillModel.findByName(activatedSkill.name);
+
+      // /skill slash-preloaded skills persist only the identifier (no DB id),
+      // and identifier may differ from name — fall back to findByIdentifier.
+      if (!skill && activatedSkill.identifier) {
+        skill = await this.skillModel.findByIdentifier(activatedSkill.identifier);
+      }
 
       if (!skill) {
         log('No persisted skill bundle found for activated skill: %s', activatedSkill.name);

--- a/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
@@ -276,12 +276,18 @@ class SkillServerRuntimeService implements SkillRuntimeService {
     for (const activatedSkill of activatedSkills) {
       if (!activatedSkill.name) continue;
 
-      let skill = await this.skillModel.findByName(activatedSkill.name);
+      // /skill slash-preloaded skills persist the identifier (the stable
+      // canonical key, which may differ from the DB display name). Resolve by
+      // identifier BEFORE name so a skill whose identifier collides with
+      // another skill's display name doesn't resolve to the wrong archive.
+      // The activateSkill path carries no identifier, so it still resolves by
+      // name exactly as before.
+      let skill = activatedSkill.identifier
+        ? await this.skillModel.findByIdentifier(activatedSkill.identifier)
+        : undefined;
 
-      // /skill slash-preloaded skills persist only the identifier (no DB id),
-      // and identifier may differ from name — fall back to findByIdentifier.
-      if (!skill && activatedSkill.identifier) {
-        skill = await this.skillModel.findByIdentifier(activatedSkill.identifier);
+      if (!skill) {
+        skill = await this.skillModel.findByName(activatedSkill.name);
       }
 
       if (!skill) {

--- a/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
@@ -296,7 +296,14 @@ class SkillServerRuntimeService implements SkillRuntimeService {
 
       const fullUrl = await this.fileService.getFullFileUrl(fileInfo.url);
       if (fullUrl) {
-        archives.push({ name: skill.name, url: fullUrl, zipHash: skill.zipFileHash });
+        // Key the archive by the activated name — this is the key both the
+        // device path (`archiveByName.get(activated.name)`) and the sandbox
+        // path (`skillZipUrls[skill.name]` in resolveExecScriptSkillName) look
+        // it up by. For /skill slash-preloaded skills activated.name is the
+        // identifier, which may differ from the DB skill name; keying by
+        // activated.name keeps the lookup consistent so cwd resolution doesn't
+        // silently fall back to the working directory.
+        archives.push({ name: activatedSkill.name, url: fullUrl, zipHash: skill.zipFileHash });
         log('Resolved zipUrl for skill %s', skill.name);
       }
     }

--- a/packages/agent-runtime/src/utils/messageSelectors.test.ts
+++ b/packages/agent-runtime/src/utils/messageSelectors.test.ts
@@ -530,6 +530,88 @@ describe('extractActivatedSkillsFromMessages', () => {
 
     expect(extractActivatedSkillsFromMessages(messages)).toBeUndefined();
   });
+
+  // Regression: /skill slash-preloaded skills are scoped to the CURRENT
+  // request (SelectedSkillInjector marks them "for this request"). A skill
+  // slash-selected in an earlier request must NOT leak into a later request
+  // that didn't select it — only the latest user message's tags are parsed.
+  it('should not leak slash-preloaded skills from an earlier user message', () => {
+    const messages = [
+      createMessage({
+        content:
+          '<selected_skills>\n  <skill identifier="pdf-tools" name="PDF Tools" />\n</selected_skills>',
+        role: 'user',
+      } as any),
+      createMessage({ content: 'now do something unrelated', role: 'user' } as any),
+    ];
+
+    expect(extractActivatedSkillsFromMessages(messages)).toBeUndefined();
+  });
+
+  it('should parse only the latest user message slash selection', () => {
+    const messages = [
+      createMessage({
+        content:
+          '<selected_skills>\n  <skill identifier="pdf-tools" name="PDF Tools" />\n</selected_skills>',
+        role: 'user',
+      } as any),
+      createMessage({
+        content:
+          '<selected_skills>\n  <skill identifier="xlsx-tools" name="XLSX Tools" />\n</selected_skills>',
+        role: 'user',
+      } as any),
+    ];
+
+    expect(extractActivatedSkillsFromMessages(messages)).toEqual([
+      { identifier: 'xlsx-tools', name: 'xlsx-tools' },
+    ]);
+  });
+
+  // Explicit activateSkill activations accumulate across the whole
+  // conversation, while slash-preloaded ones are request-scoped — a slash
+  // selection in an earlier request drops out, but an activateSkill from that
+  // same earlier request persists into the current one.
+  it('should keep activateSkill activations but drop earlier slash selections', () => {
+    const messages = [
+      createToolMessage({
+        plugin: { apiName: 'activateSkill', identifier: 'lobe-skills' },
+        pluginState: { id: 'skl_1', name: 'pdf' },
+      } as any),
+      createMessage({
+        content:
+          '<selected_skills>\n  <skill identifier="xlsx-tools" name="XLSX Tools" />\n</selected_skills>',
+        role: 'user',
+      } as any),
+      createMessage({ content: 'follow-up request with no selection', role: 'user' } as any),
+    ];
+
+    expect(extractActivatedSkillsFromMessages(messages)).toEqual([
+      { description: undefined, id: 'skl_1', name: 'pdf' },
+    ]);
+  });
+
+  // "Last activation wins the cwd" must hold across BOTH sources: when the
+  // user slash-selects A and the agent then calls activateSkill(B) in the SAME
+  // turn, B is the more recent activation and must win — the slash entry must
+  // NOT be appended after the later tool result.
+  it('should let a same-turn activateSkill win the cwd over the request slash selection', () => {
+    const messages = [
+      createMessage({
+        content:
+          '<selected_skills>\n  <skill identifier="pdf-tools" name="PDF Tools" />\n</selected_skills>',
+        role: 'user',
+      } as any),
+      createToolMessage({
+        plugin: { apiName: 'activateSkill', identifier: 'lobe-skills' },
+        pluginState: { id: 'skl_1', name: 'xlsx' },
+      } as any),
+    ];
+
+    expect(extractActivatedSkillsFromMessages(messages)).toEqual([
+      { identifier: 'pdf-tools', name: 'pdf-tools' },
+      { description: undefined, id: 'skl_1', name: 'xlsx' },
+    ]);
+  });
 });
 
 describe('extractActivatedToolIdsFromMessages', () => {

--- a/packages/agent-runtime/src/utils/messageSelectors.test.ts
+++ b/packages/agent-runtime/src/utils/messageSelectors.test.ts
@@ -107,10 +107,12 @@ describe('TODO state selectors', () => {
   const item = { status: 'processing' as const, text: 'Ship the fix' };
 
   it('normalizes canonical and legacy states, including empty clear tombstones', () => {
-    expect(normalizeTodosState({ items: [item], updatedAt: 'canonical-time' }, 'fallback')).toEqual({
-      items: [item],
-      updatedAt: 'canonical-time',
-    });
+    expect(normalizeTodosState({ items: [item], updatedAt: 'canonical-time' }, 'fallback')).toEqual(
+      {
+        items: [item],
+        updatedAt: 'canonical-time',
+      },
+    );
     expect(normalizeTodosState([item], 'fallback')).toEqual({
       items: [item],
       updatedAt: 'fallback',
@@ -129,7 +131,9 @@ describe('TODO state selectors', () => {
   it('rejects alternate fields and malformed items', () => {
     expect(normalizeTodosState({ tasks: [item] }, 'fallback')).toBeUndefined();
     expect(normalizeTodosState({ todoList: [item] }, 'fallback')).toBeUndefined();
-    expect(normalizeTodosState({ items: [{ status: 'unknown', text: 'bad' }] }, 'fallback')).toBeUndefined();
+    expect(
+      normalizeTodosState({ items: [{ status: 'unknown', text: 'bad' }] }, 'fallback'),
+    ).toBeUndefined();
     expect(normalizeTodosState({ items: [{ status: 'todo' }] }, 'fallback')).toBeUndefined();
   });
 
@@ -472,6 +476,56 @@ describe('extractActivatedSkillsFromMessages', () => {
         ],
         role: 'assistantGroup',
       } as any),
+    ];
+
+    expect(extractActivatedSkillsFromMessages(messages)).toBeUndefined();
+  });
+
+  // Regression: the /skill slash preload path inlines skill content into the
+  // user message as a <selected_skill_context> block WITHOUT a synthetic
+  // activateSkill tool call. extractActivatedSkillsFromMessages must still
+  // recognize these skills so execScript can resolve their cwd.
+  it('should extract skills from /skill slash preload tags in user messages', () => {
+    const messages = [
+      createMessage({
+        content:
+          'Generate marketing images\n\n' +
+          '<system_context_start>\n' +
+          '<selected_skill_context>\n' +
+          '<selected_skills>\n' +
+          '  <skill identifier="multi-size-marketing-adapter" name="Multi-Size Marketing Adapter">\n' +
+          '  SKILL.md content here\n' +
+          '  </skill>\n' +
+          '</selected_skills>\n' +
+          '</selected_skill_context>\n' +
+          '<system_context_end>',
+        role: 'user',
+      } as any),
+    ];
+
+    expect(extractActivatedSkillsFromMessages(messages)).toEqual([
+      { identifier: 'multi-size-marketing-adapter', name: 'multi-size-marketing-adapter' },
+    ]);
+  });
+
+  it('should extract self-closing slash preload skill tags without content', () => {
+    const messages = [
+      createMessage({
+        content:
+          'do thing\n\n<selected_skills>\n  <skill identifier="pdf-tools" name="PDF Tools" />\n</selected_skills>',
+        role: 'user',
+      } as any),
+    ];
+
+    expect(extractActivatedSkillsFromMessages(messages)).toEqual([
+      { identifier: 'pdf-tools', name: 'pdf-tools' },
+    ]);
+  });
+
+  it('should not treat ordinary user messages as skill activations', () => {
+    const messages = [
+      createMessage({ content: 'hi', role: 'user' } as any),
+      createMessage({ content: 'activate the xlsx skill please', role: 'user' } as any),
     ];
 
     expect(extractActivatedSkillsFromMessages(messages)).toBeUndefined();

--- a/packages/agent-runtime/src/utils/messageSelectors.ts
+++ b/packages/agent-runtime/src/utils/messageSelectors.ts
@@ -1,3 +1,4 @@
+import { parseSelectedSkillTags } from '@lobechat/context-engine';
 import type { StepActivatedSkill, StepContextTodos, UIChatMessage } from '@lobechat/types';
 import { isNonEmptyString, isPlainRecord } from '@lobechat/utils/object';
 
@@ -173,9 +174,7 @@ export const normalizeTodosState = (
   if (!items || !items.every(isTodoItem)) return undefined;
 
   const updatedAt =
-    isPlainRecord(value) && isNonEmptyString(value.updatedAt)
-      ? value.updatedAt
-      : fallbackUpdatedAt;
+    isPlainRecord(value) && isNonEmptyString(value.updatedAt) ? value.updatedAt : fallbackUpdatedAt;
 
   return { items, updatedAt };
 };
@@ -268,6 +267,22 @@ export const extractActivatedSkillsFromMessages = (
             });
           }
         }
+      }
+    }
+
+    // Skills activated via the /skill slash preload path: their content is
+    // inlined into the user message as a <selected_skill_context> block (see
+    // formatSelectedSkillsContext in @lobechat/context-engine) WITHOUT a
+    // synthetic activateSkill tool call, so the tool-invocation scan above
+    // can't see them. Parse the persisted <skill identifier="..." name="...">
+    // tags so execScript can still resolve their cwd. The identifier doubles
+    // as `name` (DB skills commonly have name === identifier); consumers fall
+    // back to getByIdentifier when identifier differs from name.
+    if (msg.role === 'user' && typeof msg.content === 'string') {
+      for (const tag of parseSelectedSkillTags(msg.content)) {
+        const key = tag.identifier;
+        skillsMap.delete(key);
+        skillsMap.set(key, { identifier: tag.identifier, name: tag.identifier });
       }
     }
   }

--- a/packages/agent-runtime/src/utils/messageSelectors.ts
+++ b/packages/agent-runtime/src/utils/messageSelectors.ts
@@ -200,12 +200,23 @@ export const extractTodosFromMessages = (
 };
 
 /**
- * Accumulate activated skills from all activateSkill / activateTools tool
- * messages. Skills once activated remain active for the rest of the
- * conversation; the skill id (or name, for filesystem/builtin activations that
- * persist no id) deduplicates — a reactivation updates the entry AND moves it
- * to the end, since exec paths treat the last entry as the most recent
- * activation when picking the script cwd.
+ * Resolve the active skill set for `execScript` cwd resolution.
+ *
+ * Two activation sources, with different scopes:
+ * - `activateSkill` / `activateTools` tool results accumulate across the whole
+ *   conversation — a skill once activated stays available for later requests.
+ * - `/skill` slash-preloaded skills are scoped to the CURRENT request only
+ *   (SelectedSkillInjector marks them "for this request"), so only the latest
+ *   user message's `<selected_skills>` tags are parsed — older slash selections
+ *   must not leak into a request that didn't select them.
+ *
+ * The skill id (or name, for filesystem/builtin activations that persist no
+ * id) deduplicates — a reactivation updates the entry AND moves it to the end,
+ * since exec paths treat the last entry as the most recent activation when
+ * picking the script cwd. Slash tags are inserted at the latest user message's
+ * natural chronological position (not appended at the end) so an
+ * `activateSkill` call later in the SAME turn still wins the cwd — "last
+ * activation wins" must hold across both sources.
  *
  * Shared by the client transport (chat store dbMessage selector feeding
  * `computeStepContext`) and the server runtime executors (`callTool` /
@@ -219,7 +230,28 @@ export const extractActivatedSkillsFromMessages = (
 ): StepActivatedSkill[] | undefined => {
   const skillsMap = new Map<string, StepActivatedSkill>();
 
-  for (const msg of messages) {
+  // The /skill slash preload path is scoped to the CURRENT request: only the
+  // latest user message's tags are parsed, so older slash selections can't
+  // leak into a request that didn't select them. Resolve its index up front so
+  // the main loop can insert those activations at their natural chronological
+  // position — preserving "last activation wins the cwd" relative to
+  // activateSkill/activateTools tool calls later in the same turn.
+  let slashUserIndex = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === 'user') {
+      slashUserIndex = i;
+      break;
+    }
+  }
+
+  // Explicit activateSkill / activateTools tool results accumulate across the
+  // whole conversation — a skill once activated stays available for the rest
+  // of the conversation. (The skill id, or name for id-less filesystem/builtin
+  // activations, deduplicates; a reactivation moves it to the end since exec
+  // paths treat the last entry as the most recent activation for the cwd.)
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+
     for (const invocation of collectToolInvocations(msg)) {
       if (!(
         invocation.identifier === SKILLS_IDENTIFIER ||
@@ -270,15 +302,17 @@ export const extractActivatedSkillsFromMessages = (
       }
     }
 
-    // Skills activated via the /skill slash preload path: their content is
-    // inlined into the user message as a <selected_skill_context> block (see
+    // /skill slash-preloaded skills: their content is inlined into the user
+    // message as a <selected_skill_context> block (see
     // formatSelectedSkillsContext in @lobechat/context-engine) WITHOUT a
     // synthetic activateSkill tool call, so the tool-invocation scan above
-    // can't see them. Parse the persisted <skill identifier="..." name="...">
-    // tags so execScript can still resolve their cwd. The identifier doubles
-    // as `name` (DB skills commonly have name === identifier); consumers fall
-    // back to getByIdentifier when identifier differs from name.
-    if (msg.role === 'user' && typeof msg.content === 'string') {
+    // can't see them. Parse ONLY the latest user message (slashUserIndex) —
+    // older slash selections must not leak into the current request. Inserted
+    // here, at the message's natural position, so a later activateSkill in the
+    // same turn still wins the cwd. The identifier doubles as `name` (DB skills
+    // commonly have name === identifier); consumers resolve by identifier
+    // first, falling back to name when identifier differs.
+    if (i === slashUserIndex && typeof msg.content === 'string') {
       for (const tag of parseSelectedSkillTags(msg.content)) {
         const key = tag.identifier;
         skillsMap.delete(key);

--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
@@ -42,7 +42,12 @@ export interface SkillRuntimeService {
   execScript?: (
     command: string,
     options: {
-      activatedSkills?: Array<{ description?: string; id?: string; name: string }>;
+      activatedSkills?: Array<{
+        description?: string;
+        id?: string;
+        identifier?: string;
+        name: string;
+      }>;
       description: string;
     },
   ) => Promise<CommandResult>;

--- a/packages/builtin-tool-skills/src/executor/index.ts
+++ b/packages/builtin-tool-skills/src/executor/index.ts
@@ -40,6 +40,7 @@ class SkillsExecutor extends BaseExecutor<typeof SkillsApiName> {
         activatedSkills: activatedSkills?.map((s) => ({
           description: s.description,
           id: s.id,
+          identifier: s.identifier,
           name: s.name,
         })),
       });

--- a/packages/builtin-tool-skills/src/types.ts
+++ b/packages/builtin-tool-skills/src/types.ts
@@ -32,6 +32,12 @@ export interface ExecScriptActivatedSkill {
   description?: string;
   /** DB skill id; absent for filesystem/builtin activations — match by `name`. */
   id?: string;
+  /**
+   * Skill identifier (slug). Carried for /skill slash-preloaded skills, whose
+   * persisted context has only identifier + display name (no DB id). Consumers
+   * fall back to `getByIdentifier` when `id`/`name` lookups miss.
+   */
+  identifier?: string;
   name: string;
 }
 

--- a/packages/context-engine/src/providers/SelectedSkillInjector.ts
+++ b/packages/context-engine/src/providers/SelectedSkillInjector.ts
@@ -69,6 +69,45 @@ export const formatSelectedSkillsContext = (
   ].join('\n');
 };
 
+const SKILL_TAG_OPENING_RE = /<skill\b([^>]*?)(?:\/>|>)/g;
+
+const getTagAttr = (attrs: string, name: string): string | undefined => {
+  const match = new RegExp(`${name}="([^"]*)"`, 'i').exec(attrs);
+  return match?.[1];
+};
+
+/**
+ * Parse persisted `<skill identifier="..." name="...">` tags from a user
+ * message content block produced by `formatSelectedSkills`. Co-located with the
+ * writer so the tag format has a single source of truth.
+ *
+ * The `/skill` slash preload path inlines skill content into the user message
+ * WITHOUT emitting a synthetic `activateSkill` tool call — these tags are the
+ * only persisted trace that the skill was activated. Downstream consumers (e.g.
+ * `extractActivatedSkillsFromMessages`) use this to register slash-preloaded
+ * skills as activated so `execScript` can resolve their cwd.
+ *
+ * Returns `{ identifier, name? }` for each tag. Tolerates attribute order,
+ * self-closing (`<skill ... />`) and content-bearing (`<skill ...>...</skill>`)
+ * forms. Returns an empty array when the content carries no
+ * `<selected_skills>` block (fast path for ordinary user messages).
+ */
+export const parseSelectedSkillTags = (
+  content: string,
+): Array<{ identifier: string; name?: string }> => {
+  if (!content.includes('<selected_skills>')) return [];
+
+  const tags: Array<{ identifier: string; name?: string }> = [];
+  for (const match of content.matchAll(SKILL_TAG_OPENING_RE)) {
+    const attrs = match[1] ?? '';
+    const identifier = getTagAttr(attrs, 'identifier');
+    if (!identifier) continue;
+    const name = getTagAttr(attrs, 'name');
+    tags.push({ identifier, ...(name && { name }) });
+  }
+  return tags;
+};
+
 /**
  * Extract skill identifiers @mentioned in earlier messages via their persisted editorData.
  * Walks the Lexical JSON tree looking for action-tag nodes with actionCategory === 'skill'.

--- a/packages/context-engine/src/providers/__tests__/SelectedSkillInjector.test.ts
+++ b/packages/context-engine/src/providers/__tests__/SelectedSkillInjector.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { PipelineContext } from '../../types';
-import { SelectedSkillInjector } from '../SelectedSkillInjector';
+import { parseSelectedSkillTags, SelectedSkillInjector } from '../SelectedSkillInjector';
 
 const createContext = (messages: any[] = []): PipelineContext => ({
   initialState: {
@@ -97,5 +97,65 @@ describe('SelectedSkillInjector', () => {
     expect(content.match(/<!-- SYSTEM CONTEXT \(NOT PART OF USER QUERY\) -->/g)).toHaveLength(1);
     expect(content).toContain('<current_page_context>');
     expect(content).toContain('<selected_skill_context>');
+  });
+});
+
+describe('parseSelectedSkillTags', () => {
+  it('parses content-bearing skill tags', () => {
+    const content =
+      '<selected_skills>\n' +
+      '  <skill identifier="marketing-adapter" name="Multi-Size Marketing Adapter">\n' +
+      '  SKILL.md content\n' +
+      '  </skill>\n' +
+      '</selected_skills>';
+
+    expect(parseSelectedSkillTags(content)).toEqual([
+      { identifier: 'marketing-adapter', name: 'Multi-Size Marketing Adapter' },
+    ]);
+  });
+
+  it('parses self-closing skill tags', () => {
+    const content =
+      '<selected_skills>\n  <skill identifier="pdf-tools" name="PDF Tools" />\n</selected_skills>';
+
+    expect(parseSelectedSkillTags(content)).toEqual([
+      { identifier: 'pdf-tools', name: 'PDF Tools' },
+    ]);
+  });
+
+  it('parses multiple skills and tolerates attribute order', () => {
+    const content =
+      '<selected_skills>\n' +
+      '  <skill name="Grep" identifier="grep" />\n' +
+      '  <skill identifier="translate" name="Translate" />\n' +
+      '</selected_skills>';
+
+    expect(parseSelectedSkillTags(content)).toEqual([
+      { identifier: 'grep', name: 'Grep' },
+      { identifier: 'translate', name: 'Translate' },
+    ]);
+  });
+
+  it('skips tags without an identifier', () => {
+    const content =
+      '<selected_skills>\n  <skill name="No Identifier" />\n  <skill identifier="ok" />\n</selected_skills>';
+
+    expect(parseSelectedSkillTags(content)).toEqual([{ identifier: 'ok' }]);
+  });
+
+  it('returns an empty array for ordinary user messages (no selected_skills block)', () => {
+    expect(parseSelectedSkillTags('hi, please help me with images')).toEqual([]);
+    expect(parseSelectedSkillTags('')).toEqual([]);
+  });
+
+  it('round-trips with formatSelectedSkills', async () => {
+    const { formatSelectedSkills } = await import('../SelectedSkillInjector');
+    const skills = [
+      { identifier: 'a', name: 'A' },
+      { identifier: 'b', name: 'B' },
+    ];
+    const formatted = formatSelectedSkills(skills)!;
+
+    expect(parseSelectedSkillTags(formatted).map((t) => t.identifier)).toEqual(['a', 'b']);
   });
 });

--- a/packages/context-engine/src/providers/index.ts
+++ b/packages/context-engine/src/providers/index.ts
@@ -30,6 +30,7 @@ export { PlanInjector } from './PlanInjector';
 export {
   formatSelectedSkills,
   formatSelectedSkillsContext,
+  parseSelectedSkillTags,
   SelectedSkillInjector,
 } from './SelectedSkillInjector';
 export {

--- a/packages/types/src/stepContext.ts
+++ b/packages/types/src/stepContext.ts
@@ -41,6 +41,13 @@ export interface StepActivatedSkill {
    * `name` (the server exec paths resolve archives/project skills by name).
    */
   id?: string;
+  /**
+   * Skill identifier (slug). Carried for skills activated via the `/skill`
+   * slash preload path, whose persisted `<selected_skill_context>` block has
+   * only the identifier + display name — no DB id. Consumers fall back to
+   * `getByIdentifier` when `id` and `name` lookups miss.
+   */
+  identifier?: string;
   name: string;
 }
 

--- a/src/services/electron/__tests__/desktopSkillRuntime.test.ts
+++ b/src/services/electron/__tests__/desktopSkillRuntime.test.ts
@@ -4,12 +4,14 @@ import { desktopSkillRuntimeService } from '@/services/electron/desktopSkillRunt
 
 const {
   getByIdMock,
+  getByIdentifierMock,
   getByNameMock,
   getZipUrlMock,
   prepareSkillDirectoryMock,
   resolveSkillResourcePathMock,
 } = vi.hoisted(() => ({
   getByIdMock: vi.fn(),
+  getByIdentifierMock: vi.fn(),
   getByNameMock: vi.fn(),
   getZipUrlMock: vi.fn(),
   prepareSkillDirectoryMock: vi.fn(),
@@ -19,6 +21,7 @@ const {
 vi.mock('@/services/skill', () => ({
   agentSkillService: {
     getById: getByIdMock,
+    getByIdentifier: getByIdentifierMock,
     getByName: getByNameMock,
     getZipUrl: getZipUrlMock,
   },
@@ -193,5 +196,76 @@ describe('desktopSkillRuntimeService', () => {
       zipHash: 'zip-hash-1',
     });
     expect(result).toBe('/tmp/demo-skill/docs/bazi.py');
+  });
+
+  // Regression for #17977 desktop exec path: /skill slash-preloaded skills
+  // persist only the identifier (no DB id), and the identifier may differ from
+  // the DB display name. resolveSkill must resolve them by identifier so
+  // execScript gets the skill's extracted directory as cwd.
+  it('should resolve a slash-preloaded skill by identifier (no DB id)', async () => {
+    getByIdMock.mockResolvedValue(undefined);
+    getByIdentifierMock.mockResolvedValue({
+      id: 'marketing-skill-id',
+      identifier: 'marketing-adapter',
+      name: 'Multi-Size Marketing Adapter',
+      zipFileHash: 'zip-hash-2',
+    });
+    getZipUrlMock.mockResolvedValue({
+      name: 'Multi-Size Marketing Adapter',
+      url: 'https://example.com/marketing.zip',
+    });
+    prepareSkillDirectoryMock.mockResolvedValue({
+      extractedDir: '/tmp/marketing-adapter',
+      success: true,
+      zipPath: '/tmp/marketing-adapter.zip',
+    });
+
+    const result = await desktopSkillRuntimeService.resolveExecutionDirectory([
+      { identifier: 'marketing-adapter', name: 'marketing-adapter' },
+    ]);
+
+    expect(getByIdentifierMock).toHaveBeenCalledWith('marketing-adapter');
+    expect(getByNameMock).not.toHaveBeenCalled();
+    expect(getZipUrlMock).toHaveBeenCalledWith('marketing-skill-id');
+    expect(result).toBe('/tmp/marketing-adapter');
+  });
+
+  // Regression: a slash-preloaded skill's identifier may collide with another
+  // skill's DB display name. identifier must be the primary lookup key so the
+  // wrong package is never extracted/executed.
+  it('should resolve by identifier even when another skill shares that identifier as its name', async () => {
+    getByIdMock.mockResolvedValue(undefined);
+    // A DIFFERENT skill whose display name collides with the target identifier.
+    getByNameMock.mockResolvedValue({
+      id: 'colliding-skill-id',
+      identifier: 'colliding-adapter',
+      name: 'marketing-adapter',
+      zipFileHash: 'colliding-zip-hash',
+    });
+    getByIdentifierMock.mockResolvedValue({
+      id: 'marketing-skill-id',
+      identifier: 'marketing-adapter',
+      name: 'Multi-Size Marketing Adapter',
+      zipFileHash: 'zip-hash-2',
+    });
+    getZipUrlMock.mockResolvedValue({
+      name: 'Multi-Size Marketing Adapter',
+      url: 'https://example.com/marketing.zip',
+    });
+    prepareSkillDirectoryMock.mockResolvedValue({
+      extractedDir: '/tmp/marketing-adapter',
+      success: true,
+      zipPath: '/tmp/marketing-adapter.zip',
+    });
+
+    const result = await desktopSkillRuntimeService.resolveExecutionDirectory([
+      { identifier: 'marketing-adapter', name: 'marketing-adapter' },
+    ]);
+
+    // identifier-first: the colliding skill is never looked up by name.
+    expect(getByIdentifierMock).toHaveBeenCalledWith('marketing-adapter');
+    expect(getByNameMock).not.toHaveBeenCalled();
+    expect(getZipUrlMock).toHaveBeenCalledWith('marketing-skill-id');
+    expect(result).toBe('/tmp/marketing-adapter');
   });
 });

--- a/src/services/electron/desktopSkillRuntime.ts
+++ b/src/services/electron/desktopSkillRuntime.ts
@@ -30,13 +30,15 @@ class DesktopSkillRuntimeService {
   private async resolveSkill(params: { id?: string; identifier?: string; name?: string }) {
     const skillById = params.id ? await agentSkillService.getById(params.id) : undefined;
     if (skillById) return skillById;
-    const skillByName = params.name ? await agentSkillService.getByName(params.name) : undefined;
-    if (skillByName) return skillByName;
-    // Fallback for /skill slash-preloaded skills: their persisted tag carries
-    // only the identifier (no DB id), and identifier may differ from name.
-    return params.identifier
-      ? await agentSkillService.getByIdentifier(params.identifier)
-      : undefined;
+    // /skill slash-preloaded skills persist the identifier (the stable canonical
+    // key, which may differ from the DB display name). Resolve by identifier
+    // BEFORE name so a skill whose identifier collides with another skill's
+    // display name doesn't resolve to the wrong package.
+    if (params.identifier) {
+      const skillByIdentifier = await agentSkillService.getByIdentifier(params.identifier);
+      if (skillByIdentifier) return skillByIdentifier;
+    }
+    return params.name ? await agentSkillService.getByName(params.name) : undefined;
   }
 
   async resolveExecutionDirectory(

--- a/src/services/electron/desktopSkillRuntime.ts
+++ b/src/services/electron/desktopSkillRuntime.ts
@@ -27,9 +27,16 @@ class DesktopSkillRuntimeService {
     return prepared.extractedDir;
   }
 
-  private async resolveSkill(params: { id?: string; name?: string }) {
+  private async resolveSkill(params: { id?: string; identifier?: string; name?: string }) {
     const skillById = params.id ? await agentSkillService.getById(params.id) : undefined;
-    return skillById ?? (params.name ? await agentSkillService.getByName(params.name) : undefined);
+    if (skillById) return skillById;
+    const skillByName = params.name ? await agentSkillService.getByName(params.name) : undefined;
+    if (skillByName) return skillByName;
+    // Fallback for /skill slash-preloaded skills: their persisted tag carries
+    // only the identifier (no DB id), and identifier may differ from name.
+    return params.identifier
+      ? await agentSkillService.getByIdentifier(params.identifier)
+      : undefined;
   }
 
   async resolveExecutionDirectory(
@@ -43,7 +50,11 @@ class DesktopSkillRuntimeService {
     // skill activated before/after them. Mirrors the server exec paths'
     // "last resolvable skill wins the cwd" semantics.
     for (const activated of [...activatedSkills].reverse()) {
-      const skill = await this.resolveSkill({ id: activated.id, name: activated.name });
+      const skill = await this.resolveSkill({
+        id: activated.id,
+        identifier: activated.identifier,
+        name: activated.name,
+      });
       if (!skill?.zipFileHash) continue;
 
       return this.prepareSkillDirectoryForSkill(skill);


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes #17977

#### 🔀 Description of Change

Skills activated via the `/skill` slash menu fail to run their bundled scripts. The slash preload path inlines skill content into the user message (`SelectedSkillInjector`) **by design without emitting a synthetic `activateSkill` tool call**. However, `extractActivatedSkillsFromMessages` only scans `activateSkill`/`activateTools` tool invocations, so these skills never enter `stepContext.activatedSkills`. `execScript` then can't resolve the skill's zip-extracted directory as cwd, and relative script paths (e.g. `python3 scripts/foo.py`) run against the process cwd and fail with "No such file" — often masked as a false `success: true` by `|| echo` fallbacks in skill-authored commands.

This is a structural mismatch: the skill is semantically activated (content loaded) but not registered as activated for cwd resolution. See #17977 for the full root-cause analysis.

**Fix** (does not change the "no fake activateSkill" design of `SelectedSkillInjector`):
- Add `parseSelectedSkillTags` in `context-engine` (co-located with `formatSelectedSkills`, single source of truth for the tag format) and use it in the shared `extractActivatedSkillsFromMessages` to derive activation from the persisted `<skill identifier>` tags in user messages. This covers both client and server exec paths, since both rehydrate activation from messages via this shared selector.
- Thread an optional `identifier` through `StepActivatedSkill` / `ExecScriptActivatedSkill`, with `getByIdentifier` / `findByIdentifier` fallbacks in `resolveSkill` (desktop) and `resolveActivatedSkillArchives` (server) for skills whose `identifier` differs from `name`.

#### 🧪 How to Test

- [x] Added/updated tests:
  - `SelectedSkillInjector.test.ts`: `parseSelectedSkillTags` (content-bearing / self-closing / multi / attribute-order / no-block / round-trip with `formatSelectedSkills`)
  - `messageSelectors.test.ts`: slash `<skill identifier>` tag → activatedSkills; ordinary user messages not treated as activations
  - `skills.test.ts`: `findByName` miss → `findByIdentifier` fallback resolves the archive
- [x] Tested locally: `pnpm lint` (incl. `type-check` + `lint:circular`) and targeted `vitest` all pass (64 tests)

#### 📸 Screenshots / Videos

N/A — no UI change.

#### 📝 Additional Information

- Non-breaking: `identifier` is an optional additive field; message parsing is additive and gated on `content.includes('<selected_skills>')` so ordinary user messages are not scanned.
- Edge case (non-issue): a skill both slash-preloaded and later `activateSkill`-called could yield two entries when `identifier ≠ name`; in practice the system prompt discourages calling `activateSkill` for preloaded skills.