### PR TITLE
🐛 fix(context-engine): use absolute dates in agent documents index

### DIFF
--- a/packages/context-engine/src/providers/AgentDocumentInjector/shared.ts
+++ b/packages/context-engine/src/providers/AgentDocumentInjector/shared.ts
@@ -141,25 +141,19 @@ function formatSize(doc: Pick<AgentContextDocument, 'content' | 'contentCharCoun
 }
 
 /**
- * Render a Date / ISO string as a short relative-time token like "2d ago".
+ * Render a Date / ISO string as an absolute UTC date like "2026-04-27".
+ *
+ * Deliberately NOT a relative time ("15m ago"): the index sits at the very
+ * front of the prompt, so any string that drifts as wall-clock time passes
+ * invalidates the provider-side prompt cache on every request even when no
+ * document changed. An absolute date only changes when the document itself
+ * is updated. See https://github.com/lobehub/lobehub/issues/15624
  */
-function formatRelative(at: Date | string | undefined, now: Date): string {
+function formatUpdatedDate(at: Date | string | undefined): string {
   if (!at) return '—';
   const date = typeof at === 'string' ? new Date(at) : at;
   if (Number.isNaN(date.getTime())) return '—';
-
-  const sec = Math.max(0, Math.floor((now.getTime() - date.getTime()) / 1000));
-  if (sec < 60) return 'now';
-  const min = Math.floor(sec / 60);
-  if (min < 60) return `${min}m ago`;
-  const hr = Math.floor(min / 60);
-  if (hr < 24) return `${hr}h ago`;
-  const day = Math.floor(hr / 24);
-  if (day < 30) return `${day}d ago`;
-  const month = Math.floor(day / 30);
-  if (month < 12) return `${month}mo ago`;
-  const year = Math.floor(day / 365);
-  return `${year}y ago`;
+  return date.toISOString().slice(0, 10);
 }
 
 const TITLE_MAX_WIDTH = 60;
@@ -176,18 +170,14 @@ function truncate(s: string, max: number): string {
  * Render a list of progressive docs as a fixed-width table:
  *
  *   TITLE                ID                                    SIZE    UPDATED
- *   daily-brief.txt      2af6eb88-8bdb-468f-887f-620baa394efa  1.4k    2d ago
+ *   daily-brief.txt      2af6eb88-8bdb-468f-887f-620baa394efa  1.4k    2026-04-27
  */
-function buildIndexTable(
-  docs: AgentContextDocument[],
-  context: AgentDocumentFilterContext,
-): string {
-  const now = context.currentTime ?? new Date();
+function buildIndexTable(docs: AgentContextDocument[]): string {
   const rows = docs.map((d) => ({
     id: d.id ?? '',
     size: formatSize(d),
     title: truncate(pickRowTitle(d), TITLE_MAX_WIDTH),
-    updated: formatRelative(d.updatedAt, now),
+    updated: formatUpdatedDate(d.updatedAt),
   }));
 
   const titleWidth = Math.max('TITLE'.length, ...rows.map((r) => r.title.length));
@@ -279,13 +269,13 @@ function formatFolderSummary(docs: AgentContextDocument[]): string {
 /**
  * Render collapsed folders as a fixed-width table, newest folder first:
  *
- *   📁 dailyBrief  2af6…394efa  18 docs, 4.3k–20k  1mo ago
- *   📁 周报         6b1c…07d21  9 docs             1mo ago
+ *   📁 dailyBrief  2af6…394efa  18 docs, 4.3k–20k  2026-03-29
+ *   📁 周报         6b1c…07d21  9 docs             2026-03-27
  *
  * The ID column is the folder's `documentId` — the value the model passes to
  * `listDocuments(parentId=…)` to expand the folder on demand.
  */
-function buildFolderTable(folders: FolderGroup[], now: Date): string {
+function buildFolderTable(folders: FolderGroup[]): string {
   const rows = folders
     .map((f) => ({
       id: f.parentId,
@@ -306,7 +296,7 @@ function buildFolderTable(folders: FolderGroup[], now: Date): string {
         row.title.padEnd(titleWidth),
         row.id.padEnd(idWidth),
         row.summary.padEnd(summaryWidth),
-        row.time ? formatRelative(new Date(row.time), now) : '—',
+        row.time ? formatUpdatedDate(new Date(row.time)) : '—',
       ].join(sep),
     )
     .join('\n');
@@ -361,7 +351,6 @@ export function combineDocuments(
     // Loose docs render as flat rows; docs sharing a folder (≥2) collapse into
     // one summary row so archive-heavy agents don't spend tokens on every entry.
     const { flat, folders } = partitionFolders(userDocs);
-    const now = context.currentTime ?? new Date();
 
     const headerLines: string[] = [
       `${userDocs.length} user-created doc${userDocs.length === 1 ? '' : 's'}. Use readDocument(id) for full content.`,
@@ -378,8 +367,8 @@ export function combineDocuments(
     }
 
     const bodyBlocks: string[] = [];
-    if (flat.length > 0) bodyBlocks.push(buildIndexTable(sortByRecency(flat), context));
-    if (folders.length > 0) bodyBlocks.push(buildFolderTable(folders, now));
+    if (flat.length > 0) bodyBlocks.push(buildIndexTable(sortByRecency(flat)));
+    if (folders.length > 0) bodyBlocks.push(buildFolderTable(folders));
     const tableBlock = bodyBlocks.length > 0 ? `\n\n${bodyBlocks.join('\n\n')}` : '';
 
     parts.push(

--- a/packages/context-engine/src/providers/__tests__/AgentDocumentInjector.test.ts
+++ b/packages/context-engine/src/providers/__tests__/AgentDocumentInjector.test.ts
@@ -218,11 +218,42 @@ describe('AgentDocumentInjector', () => {
         2 user-created docs. Use readDocument(id) for full content.
 
         TITLE                     ID                                    SIZE  UPDATED
-        Daily Brief 提取框架          2af6eb88-8bdb-468f-887f-620baa394efa  35    2d ago
-        cfg-constrained-decoding  32e12975-7db2-4818-8415-9b5c3d383f05  6.0k  19d ago
+        Daily Brief 提取框架          2af6eb88-8bdb-468f-887f-620baa394efa  35    2026-04-27
+        cfg-constrained-decoding  32e12975-7db2-4818-8415-9b5c3d383f05  6.0k  2026-04-10
         </agent_documents_index>"
       `);
       expect(result.messages[0].content).not.toContain('Full content that should NOT appear');
+    });
+
+    // https://github.com/lobehub/lobehub/issues/15624 — relative times ("15m ago")
+    // in the index changed the prompt prefix every minute and broke provider-side
+    // prompt caching. The index must stay byte-identical as wall-clock time passes.
+    it('should render a time-stable index so the prompt cache prefix survives', async () => {
+      const documents = [
+        {
+          content: 'note',
+          filename: 'note.md',
+          id: 'doc-1',
+          loadPosition: 'before-first-user' as const,
+          loadRules: { rule: 'always' as const },
+          policyLoad: 'progressive' as const,
+          sourceType: 'file' as const,
+          title: 'Note',
+          updatedAt: new Date('2026-04-28T23:59:00.000Z'),
+        },
+      ];
+      const renderAt = async (currentTime: Date) => {
+        const provider = new AgentDocumentContextInjector({ currentTime, documents });
+        const context = createContext([{ content: 'Hello', id: 'user-1', role: 'user' }]);
+        const result = await provider.process(context);
+        return result.messages[0].content;
+      };
+
+      const first = await renderAt(new Date('2026-04-29T00:00:00.000Z'));
+      const later = await renderAt(new Date('2026-04-29T00:15:00.000Z'));
+
+      expect(first).toBe(later);
+      expect(first).not.toContain('ago');
     });
 
     it('should render progressive index sizes from contentCharCount when content is omitted', async () => {
@@ -299,7 +330,7 @@ describe('AgentDocumentInjector', () => {
         2 web-crawled docs hidden — call listDocuments(sourceType='web') to see them.
 
         TITLE        ID                                    SIZE  UPDATED
-        Daily Brief  2af6eb88-8bdb-468f-887f-620baa394efa  9     2d ago
+        Daily Brief  2af6eb88-8bdb-468f-887f-620baa394efa  9     2026-04-27
         </agent_documents_index>"
       `);
       expect(result.messages[0].content).not.toContain('Gold price');
@@ -372,9 +403,9 @@ describe('AgentDocumentInjector', () => {
         1 folder collapsed (📁) — call listDocuments(parentId=<id>) to list a folder's docs.
 
         TITLE      ID      SIZE  UPDATED
-        Root note  root-1  9     1d ago
+        Root note  root-1  9     2026-04-28
 
-        📁 dailyBrief  folder-daily  3 docs, 4.3k–20k  2d ago
+        📁 dailyBrief  folder-daily  3 docs, 4.3k–20k  2026-04-27
         </agent_documents_index>"
       `);
       // Individual folded doc ids are hidden — the model expands via listDocuments.
@@ -438,7 +469,7 @@ describe('AgentDocumentInjector', () => {
         1 user-created doc. Use readDocument(id) for full content.
 
         TITLE      ID                                    SIZE   UPDATED
-        周报与平台对话分析  d14dca54-7b38-44d5-9bdb-f3fed8c5f947  empty  13d ago
+        周报与平台对话分析  d14dca54-7b38-44d5-9bdb-f3fed8c5f947  empty  2026-04-16
         </agent_documents_index>"
       `);
     });


### PR DESCRIPTION
The `<agent_documents_index>` block injected at the front of the prompt rendered each document's `updatedAt` as a relative time (`15m ago`). For recently-updated documents that string changes every minute, so the prompt prefix changes on every request and provider-side prompt caching (DeepSeek / OpenAI / Anthropic) is invalidated even when nothing actually changed — users observed cache hit rates dropping to ~10%.

This PR renders the UPDATED column (flat rows and collapsed folder rows) as an absolute UTC date (`2026-04-27`) instead. The string now only changes when the document itself is updated, keeping the index byte-stable as wall-clock time passes while preserving recency information for the model.

Key decisions:

- Absolute date over dropping the column: recency still helps the model pick which doc to read, and a day-precision date is stable within a session.
- Header counts (doc/web-crawl totals) still change when documents are created/crawled mid-session; that only breaks cache on real state changes and is left out of scope here.

#### Test

- [x] Tested locally
- [x] Added/updated tests

Added a regression test asserting the injected index is byte-identical when rendered at two different wall-clock times.

#### 🔗 Related Issue

Fixes #15624