### PR TITLE
🐛 fix(chat): preload heterogeneous agent model catalog on mount

### DIFF
--- a/src/features/ChatInput/ControlBar/HeterogeneousAgentModelSelector.tsx
+++ b/src/features/ChatInput/ControlBar/HeterogeneousAgentModelSelector.tsx
@@ -191,7 +191,8 @@ export const HeterogeneousAgentModelSelector = memo<HeterogeneousAgentModelSelec
       handleOpenChangeComplete: completeOpenChange,
       open,
     } = useMenuContentLifecycle(onSelect);
-    const { agencyConfig, workspaceScoped } = useEffectiveAgencyConfig(agentId);
+    const { agencyConfig, isPreferenceLoading, workspaceScoped } =
+      useEffectiveAgencyConfig(agentId);
     const cwd = useEffectiveWorkingDirectory(agentId);
     const provider = agencyConfig?.heterogeneousProvider;
     useElectronStore((s) => s.useFetchGatewayDeviceInfo)();
@@ -214,8 +215,10 @@ export const HeterogeneousAgentModelSelector = memo<HeterogeneousAgentModelSelec
     const { data, error, isLoading, isValidating, mutate } = useHeterogeneousAgentModelCatalog({
       cwd,
       deviceId: rpcDeviceId,
-      enabled: targetReady,
+      isPreferenceLoading,
+      open,
       provider,
+      targetReady,
       type,
     });
 

--- a/src/features/ChatInput/ControlBar/HeterogeneousAgentModelSelector.tsx
+++ b/src/features/ChatInput/ControlBar/HeterogeneousAgentModelSelector.tsx
@@ -1,10 +1,6 @@
 'use client';
 
-import type {
-  HeterogeneousAgentModel,
-  HeterogeneousProviderConfig,
-  ListHeterogeneousAgentModelsParams,
-} from '@lobechat/types';
+import type { HeterogeneousAgentModel, ListHeterogeneousAgentModelsParams } from '@lobechat/types';
 import { HETEROGENEOUS_AGENT_DEFAULT_SELECTION } from '@lobechat/types';
 import { ActionIcon, Icon, Input, Tooltip } from '@lobehub/ui';
 import {
@@ -26,19 +22,16 @@ import {
 } from 'lucide-react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import useSWR from 'swr';
 
 import { isDesktop } from '@/const/version';
 import { resolveTargetDeviceId } from '@/helpers/agentWorkingDirectory';
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
 import { useEffectiveAgencyConfig } from '@/hooks/useEffectiveAgencyConfig';
 import { useEffectiveWorkingDirectory } from '@/hooks/useEffectiveWorkingDirectory';
-import { heterogeneousAgentCatalogService } from '@/services/heterogeneousAgent';
 import { useElectronStore } from '@/store/electron';
 
+import { useHeterogeneousAgentModelCatalog } from './useHeterogeneousAgentModelCatalog';
 import { useMenuContentLifecycle } from './useMenuContentLifecycle';
-
-const DEDUPING_INTERVAL = 5 * 60 * 1000;
 
 const styles = createStaticStyles(({ css }) => ({
   check: css`
@@ -158,19 +151,6 @@ const styles = createStaticStyles(({ css }) => ({
   `,
 }));
 
-const fingerprintConfig = (provider: HeterogeneousProviderConfig | undefined) => {
-  const serialized = JSON.stringify({
-    args: provider?.args ?? [],
-    env: Object.entries(provider?.env ?? {}).sort(([a], [b]) => a.localeCompare(b)),
-  });
-  let hash = 2166136261;
-  for (let index = 0; index < serialized.length; index += 1) {
-    hash ^= serialized.charCodeAt(index);
-    hash = Math.imul(hash, 16777619);
-  }
-  return (hash >>> 0).toString(36);
-};
-
 const getCatalogErrorKey = (name: string) => {
   switch (name) {
     case 'cli_not_found': {
@@ -206,7 +186,6 @@ export const HeterogeneousAgentModelSelector = memo<HeterogeneousAgentModelSelec
     const agentName = type === 'pi' ? 'Pi' : type === 'qoder' ? 'Qoder' : 'OpenCode';
     const [search, setSearch] = useState('');
     const {
-      contentActive,
       deferSelection: handleSelect,
       handleOpenChange,
       handleOpenChangeComplete: completeOpenChange,
@@ -232,40 +211,13 @@ export const HeterogeneousAgentModelSelector = memo<HeterogeneousAgentModelSelec
       model && model !== HETEROGENEOUS_AGENT_DEFAULT_SELECTION
         ? model
         : HETEROGENEOUS_AGENT_DEFAULT_SELECTION;
-    const configFingerprint = fingerprintConfig(provider);
-
-    const { data, error, isLoading, isValidating, mutate } = useSWR(
-      contentActive && targetReady
-        ? [
-            'heterogeneous-agent-model-catalog',
-            type,
-            useLocalIpc ? 'local' : rpcDeviceId,
-            cwd ?? '',
-            provider?.command ?? '',
-            configFingerprint,
-          ]
-        : null,
-      async () => {
-        const result = await heterogeneousAgentCatalogService.listModels({
-          command: provider?.command,
-          cwd,
-          deviceId: rpcDeviceId,
-          env: provider?.env,
-          type,
-        });
-        if (result.status === 'error') {
-          const catalogError = new Error(result.error.message);
-          catalogError.name = result.error.code;
-          throw catalogError;
-        }
-        return result;
-      },
-      {
-        dedupingInterval: DEDUPING_INTERVAL,
-        revalidateOnFocus: false,
-        shouldRetryOnError: false,
-      },
-    );
+    const { data, error, isLoading, isValidating, mutate } = useHeterogeneousAgentModelCatalog({
+      cwd,
+      deviceId: rpcDeviceId,
+      enabled: targetReady,
+      provider,
+      type,
+    });
 
     const catalogModels = useMemo(() => data?.models ?? [], [data]);
     const selectedIsStale =

--- a/src/features/ChatInput/ControlBar/HeterogeneousAgentModelSelector.tsx
+++ b/src/features/ChatInput/ControlBar/HeterogeneousAgentModelSelector.tsx
@@ -28,7 +28,10 @@ import { resolveTargetDeviceId } from '@/helpers/agentWorkingDirectory';
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
 import { useEffectiveAgencyConfig } from '@/hooks/useEffectiveAgencyConfig';
 import { useEffectiveWorkingDirectory } from '@/hooks/useEffectiveWorkingDirectory';
+import { useDeviceStore } from '@/store/device';
 import { useElectronStore } from '@/store/electron';
+import { useUserStore } from '@/store/user';
+import { authSelectors } from '@/store/user/selectors';
 
 import { useHeterogeneousAgentModelCatalog } from './useHeterogeneousAgentModelCatalog';
 import { useMenuContentLifecycle } from './useMenuContentLifecycle';
@@ -193,6 +196,10 @@ export const HeterogeneousAgentModelSelector = memo<HeterogeneousAgentModelSelec
     } = useMenuContentLifecycle(onSelect);
     const { agencyConfig, isPreferenceLoading, workspaceScoped } =
       useEffectiveAgencyConfig(agentId);
+    const isLogin = useUserStore(authSelectors.isLogin);
+    const { isLoading: isDeviceListLoading } = useDeviceStore((s) => s.useFetchDevices)(
+      isLogin || isDesktop,
+    );
     const cwd = useEffectiveWorkingDirectory(agentId);
     const provider = agencyConfig?.heterogeneousProvider;
     useElectronStore((s) => s.useFetchGatewayDeviceInfo)();
@@ -215,6 +222,7 @@ export const HeterogeneousAgentModelSelector = memo<HeterogeneousAgentModelSelec
     const { data, error, isLoading, isValidating, mutate } = useHeterogeneousAgentModelCatalog({
       cwd,
       deviceId: rpcDeviceId,
+      isDeviceListLoading,
       isPreferenceLoading,
       open,
       provider,

--- a/src/features/ChatInput/ControlBar/useHeterogeneousAgentModelCatalog.test.ts
+++ b/src/features/ChatInput/ControlBar/useHeterogeneousAgentModelCatalog.test.ts
@@ -1,0 +1,67 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { createElement } from 'react';
+import { SWRConfig } from 'swr';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { heterogeneousAgentCatalogService } from '@/services/heterogeneousAgent';
+
+import { useHeterogeneousAgentModelCatalog } from './useHeterogeneousAgentModelCatalog';
+
+const createWrapper = () => {
+  const value = { provider: () => new Map() };
+
+  return function SWRTestWrapper({ children }: PropsWithChildren) {
+    return createElement(SWRConfig, { value }, children);
+  };
+};
+
+describe('useHeterogeneousAgentModelCatalog', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each(['opencode', 'pi', 'qoder'] as const)(
+    'starts loading the %s catalog as soon as the selector mounts',
+    async (type) => {
+      const pendingCatalog = new Promise<
+        Awaited<ReturnType<typeof heterogeneousAgentCatalogService.listModels>>
+      >(() => {});
+      const listModels = vi
+        .spyOn(heterogeneousAgentCatalogService, 'listModels')
+        .mockReturnValue(pendingCatalog);
+
+      const { result } = renderHook(
+        () =>
+          useHeterogeneousAgentModelCatalog({
+            enabled: true,
+            provider: { type },
+            type,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => expect(listModels).toHaveBeenCalledTimes(1));
+      expect(result.current.isLoading).toBe(true);
+    },
+  );
+
+  it('does not load a catalog until its execution target is ready', async () => {
+    const listModels = vi.spyOn(heterogeneousAgentCatalogService, 'listModels');
+
+    const { result } = renderHook(
+      () =>
+        useHeterogeneousAgentModelCatalog({
+          enabled: false,
+          provider: { type: 'opencode' },
+          type: 'opencode',
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(listModels).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/src/features/ChatInput/ControlBar/useHeterogeneousAgentModelCatalog.test.ts
+++ b/src/features/ChatInput/ControlBar/useHeterogeneousAgentModelCatalog.test.ts
@@ -34,6 +34,7 @@ describe('useHeterogeneousAgentModelCatalog', () => {
       const { result } = renderHook(
         () =>
           useHeterogeneousAgentModelCatalog({
+            isDeviceListLoading: false,
             isPreferenceLoading: false,
             open: false,
             provider: { type },
@@ -54,6 +55,7 @@ describe('useHeterogeneousAgentModelCatalog', () => {
     const { result } = renderHook(
       () =>
         useHeterogeneousAgentModelCatalog({
+          isDeviceListLoading: false,
           isPreferenceLoading: true,
           open: false,
           provider: { type: 'opencode' },
@@ -69,12 +71,54 @@ describe('useHeterogeneousAgentModelCatalog', () => {
     expect(result.current.isLoading).toBe(false);
   });
 
+  it('waits for the device default directory before preloading the catalog', async () => {
+    const pendingCatalog = new Promise<
+      Awaited<ReturnType<typeof heterogeneousAgentCatalogService.listModels>>
+    >(() => {});
+    const listModels = vi
+      .spyOn(heterogeneousAgentCatalogService, 'listModels')
+      .mockReturnValue(pendingCatalog);
+    const initialProps: { cwd?: string; isDeviceListLoading: boolean } = {
+      cwd: undefined,
+      isDeviceListLoading: true,
+    };
+
+    const { rerender } = renderHook(
+      ({ cwd, isDeviceListLoading }: { cwd?: string; isDeviceListLoading: boolean }) =>
+        useHeterogeneousAgentModelCatalog({
+          cwd,
+          deviceId: 'device-1',
+          isDeviceListLoading,
+          isPreferenceLoading: false,
+          open: false,
+          provider: { type: 'opencode' },
+          targetReady: true,
+          type: 'opencode',
+        }),
+      {
+        initialProps,
+        wrapper: createWrapper(),
+      },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(listModels).not.toHaveBeenCalled();
+
+    rerender({ cwd: '/repo/device-default', isDeviceListLoading: false });
+
+    await waitFor(() => expect(listModels).toHaveBeenCalledTimes(1));
+    expect(listModels).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: '/repo/device-default', deviceId: 'device-1' }),
+    );
+  });
+
   it('does not load a catalog until its execution target is ready', async () => {
     const listModels = vi.spyOn(heterogeneousAgentCatalogService, 'listModels');
 
     renderHook(
       () =>
         useHeterogeneousAgentModelCatalog({
+          isDeviceListLoading: false,
           isPreferenceLoading: false,
           open: false,
           provider: { type: 'opencode' },
@@ -112,6 +156,7 @@ describe('useHeterogeneousAgentModelCatalog', () => {
     const { rerender, result } = renderHook(
       ({ open }) =>
         useHeterogeneousAgentModelCatalog({
+          isDeviceListLoading: false,
           isPreferenceLoading: false,
           open,
           provider: { type: 'qoder' },

--- a/src/features/ChatInput/ControlBar/useHeterogeneousAgentModelCatalog.test.ts
+++ b/src/features/ChatInput/ControlBar/useHeterogeneousAgentModelCatalog.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import type { PropsWithChildren } from 'react';
 import { createElement } from 'react';
 import { SWRConfig } from 'swr';
@@ -34,8 +34,10 @@ describe('useHeterogeneousAgentModelCatalog', () => {
       const { result } = renderHook(
         () =>
           useHeterogeneousAgentModelCatalog({
-            enabled: true,
+            isPreferenceLoading: false,
+            open: false,
             provider: { type },
+            targetReady: true,
             type,
           }),
         { wrapper: createWrapper() },
@@ -46,14 +48,16 @@ describe('useHeterogeneousAgentModelCatalog', () => {
     },
   );
 
-  it('does not load a catalog until its execution target is ready', async () => {
+  it('does not preload the shared fallback while a member device preference is loading', async () => {
     const listModels = vi.spyOn(heterogeneousAgentCatalogService, 'listModels');
 
     const { result } = renderHook(
       () =>
         useHeterogeneousAgentModelCatalog({
-          enabled: false,
+          isPreferenceLoading: true,
+          open: false,
           provider: { type: 'opencode' },
+          targetReady: true,
           type: 'opencode',
         }),
       { wrapper: createWrapper() },
@@ -63,5 +67,68 @@ describe('useHeterogeneousAgentModelCatalog', () => {
 
     expect(listModels).not.toHaveBeenCalled();
     expect(result.current.isLoading).toBe(false);
+  });
+
+  it('does not load a catalog until its execution target is ready', async () => {
+    const listModels = vi.spyOn(heterogeneousAgentCatalogService, 'listModels');
+
+    renderHook(
+      () =>
+        useHeterogeneousAgentModelCatalog({
+          isPreferenceLoading: false,
+          open: false,
+          provider: { type: 'opencode' },
+          targetReady: false,
+          type: 'opencode',
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(listModels).not.toHaveBeenCalled();
+  });
+
+  it('revalidates a failed preload when the selector opens', async () => {
+    const failedCatalog = {
+      error: { code: 'device_unavailable' as const, message: 'Device unavailable' },
+      status: 'error' as const,
+      updatedAt: 1,
+    };
+    const loadedCatalog = {
+      models: [{ id: 'provider/model', modelId: 'model', providerId: 'provider' }],
+      status: 'success' as const,
+      updatedAt: 2,
+    };
+    let resolveRetry: (catalog: typeof loadedCatalog) => void = () => {};
+    const retry = new Promise<typeof loadedCatalog>((resolve) => {
+      resolveRetry = resolve;
+    });
+    const listModels = vi
+      .spyOn(heterogeneousAgentCatalogService, 'listModels')
+      .mockResolvedValueOnce(failedCatalog)
+      .mockReturnValueOnce(retry);
+
+    const { rerender, result } = renderHook(
+      ({ open }) =>
+        useHeterogeneousAgentModelCatalog({
+          isPreferenceLoading: false,
+          open,
+          provider: { type: 'qoder' },
+          targetReady: true,
+          type: 'qoder',
+        }),
+      { initialProps: { open: false }, wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.error?.name).toBe('device_unavailable'));
+
+    rerender({ open: true });
+
+    await waitFor(() => expect(listModels).toHaveBeenCalledTimes(2));
+
+    act(() => resolveRetry(loadedCatalog));
+
+    await waitFor(() => expect(result.current.data).toEqual(loadedCatalog));
   });
 });

--- a/src/features/ChatInput/ControlBar/useHeterogeneousAgentModelCatalog.ts
+++ b/src/features/ChatInput/ControlBar/useHeterogeneousAgentModelCatalog.ts
@@ -2,6 +2,7 @@ import type {
   HeterogeneousProviderConfig,
   ListHeterogeneousAgentModelsParams,
 } from '@lobechat/types';
+import { useEffect, useRef } from 'react';
 import useSWR from 'swr';
 
 import { heterogeneousAgentCatalogService } from '@/services/heterogeneousAgent';
@@ -24,24 +25,29 @@ const fingerprintConfig = (provider: HeterogeneousProviderConfig | undefined) =>
 interface UseHeterogeneousAgentModelCatalogParams {
   cwd?: string;
   deviceId?: string;
-  enabled: boolean;
+  isPreferenceLoading: boolean;
+  open: boolean;
   provider?: HeterogeneousProviderConfig;
+  targetReady: boolean;
   type: ListHeterogeneousAgentModelsParams['type'];
 }
 
 /**
- * Keep the catalog request active for the selector's entire mounted lifetime so
- * the models start loading with the conversation page rather than on menu open.
+ * Preload after the member's effective target settles, then revalidate a failed
+ * preload if the user opens the selector after the target becomes available.
  */
 export const useHeterogeneousAgentModelCatalog = ({
   cwd,
   deviceId,
-  enabled,
+  isPreferenceLoading,
+  open,
   provider,
+  targetReady,
   type,
-}: UseHeterogeneousAgentModelCatalogParams) =>
-  useSWR(
-    enabled
+}: UseHeterogeneousAgentModelCatalogParams) => {
+  const wasOpenRef = useRef(open);
+  const response = useSWR(
+    targetReady && !isPreferenceLoading
       ? [
           'heterogeneous-agent-model-catalog',
           type,
@@ -72,3 +78,13 @@ export const useHeterogeneousAgentModelCatalog = ({
       shouldRetryOnError: false,
     },
   );
+
+  useEffect(() => {
+    const hasJustOpened = open && !wasOpenRef.current;
+    wasOpenRef.current = open;
+
+    if (hasJustOpened && response.error) void response.mutate();
+  }, [open, response.error, response.mutate]);
+
+  return response;
+};

--- a/src/features/ChatInput/ControlBar/useHeterogeneousAgentModelCatalog.ts
+++ b/src/features/ChatInput/ControlBar/useHeterogeneousAgentModelCatalog.ts
@@ -25,6 +25,7 @@ const fingerprintConfig = (provider: HeterogeneousProviderConfig | undefined) =>
 interface UseHeterogeneousAgentModelCatalogParams {
   cwd?: string;
   deviceId?: string;
+  isDeviceListLoading: boolean;
   isPreferenceLoading: boolean;
   open: boolean;
   provider?: HeterogeneousProviderConfig;
@@ -33,12 +34,14 @@ interface UseHeterogeneousAgentModelCatalogParams {
 }
 
 /**
- * Preload after the member's effective target settles, then revalidate a failed
- * preload if the user opens the selector after the target becomes available.
+ * Preload after the member's effective target and device directory settle, then
+ * revalidate a failed preload if the user opens the selector after the target
+ * becomes available.
  */
 export const useHeterogeneousAgentModelCatalog = ({
   cwd,
   deviceId,
+  isDeviceListLoading,
   isPreferenceLoading,
   open,
   provider,
@@ -47,7 +50,7 @@ export const useHeterogeneousAgentModelCatalog = ({
 }: UseHeterogeneousAgentModelCatalogParams) => {
   const wasOpenRef = useRef(open);
   const response = useSWR(
-    targetReady && !isPreferenceLoading
+    targetReady && !isDeviceListLoading && !isPreferenceLoading
       ? [
           'heterogeneous-agent-model-catalog',
           type,

--- a/src/features/ChatInput/ControlBar/useHeterogeneousAgentModelCatalog.ts
+++ b/src/features/ChatInput/ControlBar/useHeterogeneousAgentModelCatalog.ts
@@ -1,0 +1,74 @@
+import type {
+  HeterogeneousProviderConfig,
+  ListHeterogeneousAgentModelsParams,
+} from '@lobechat/types';
+import useSWR from 'swr';
+
+import { heterogeneousAgentCatalogService } from '@/services/heterogeneousAgent';
+
+const DEDUPING_INTERVAL = 5 * 60 * 1000;
+
+const fingerprintConfig = (provider: HeterogeneousProviderConfig | undefined) => {
+  const serialized = JSON.stringify({
+    args: provider?.args ?? [],
+    env: Object.entries(provider?.env ?? {}).sort(([a], [b]) => a.localeCompare(b)),
+  });
+  let hash = 2166136261;
+  for (let index = 0; index < serialized.length; index += 1) {
+    hash ^= serialized.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+};
+
+interface UseHeterogeneousAgentModelCatalogParams {
+  cwd?: string;
+  deviceId?: string;
+  enabled: boolean;
+  provider?: HeterogeneousProviderConfig;
+  type: ListHeterogeneousAgentModelsParams['type'];
+}
+
+/**
+ * Keep the catalog request active for the selector's entire mounted lifetime so
+ * the models start loading with the conversation page rather than on menu open.
+ */
+export const useHeterogeneousAgentModelCatalog = ({
+  cwd,
+  deviceId,
+  enabled,
+  provider,
+  type,
+}: UseHeterogeneousAgentModelCatalogParams) =>
+  useSWR(
+    enabled
+      ? [
+          'heterogeneous-agent-model-catalog',
+          type,
+          deviceId ?? 'local',
+          cwd ?? '',
+          provider?.command ?? '',
+          fingerprintConfig(provider),
+        ]
+      : null,
+    async () => {
+      const result = await heterogeneousAgentCatalogService.listModels({
+        command: provider?.command,
+        cwd,
+        deviceId,
+        env: provider?.env,
+        type,
+      });
+      if (result.status === 'error') {
+        const catalogError = new Error(result.error.message);
+        catalogError.name = result.error.code;
+        throw catalogError;
+      }
+      return result;
+    },
+    {
+      dedupingInterval: DEDUPING_INTERVAL,
+      revalidateOnFocus: false,
+      shouldRetryOnError: false,
+    },
+  );


### PR DESCRIPTION
<!-- Brief and heads-up -->

Heterogeneous agent model pickers (OpenCode / Pi / Qoder) previously deferred the catalog SWR request until the menu content became active. Opening the menu therefore often showed a cold loading state. This change starts the catalog fetch as soon as the selector mounts (when the execution target is ready), and extracts the fetch into a dedicated hook with regression tests.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check --test --lint` on the three touched files (7 tests passed)
- Hook tests cover: catalog loads on mount for `opencode` / `pi` / `qoder`, waits for member preference and device-directory resolution, waits for a ready execution target, and retries a failed preload when opened

#### 🔗 Related Issue

N/A