### PR TITLE
⚡ perf(desktop): eager-load home route for first-screen paint

### DIFF
--- a/.agents/acceptance/probe-mock-patterns.md
+++ b/.agents/acceptance/probe-mock-patterns.md
@@ -204,6 +204,42 @@ a source-order regression test, and say in the report that the runtime path need
 packaged build (`DESKTOP_RENDERER_STATIC` / `resolveRendererFilePath` maps
 `apps/desktop/index.html`, `popup.html`, `overlay.html`).
 
+### Measuring production-bundle startup behavior without packaging the app
+
+**Situation:** a claim depends on the built renderer (chunk splitting, lazy-route
+boundaries, startup paint timing), which dev-mode Vite cannot reproduce.
+
+**Doesn't work:** measuring in the dev instance (unbundled modules make lazy vs
+eager indistinguishable), or trusting `performance.getEntriesByType('resource')`
+to identify what loaded — the `app://` protocol emits no resource-timing entries
+at all (0 JS resources on a fully loaded page).
+
+**Works:** build the renderer (`cd apps/desktop && vite build --config
+vite.renderer.config.ts`), then launch a pool instance with the static override:
+
+```bash
+DESKTOP_RENDERER_STATIC=1 .agents/acceptance/scripts/electron-dev.sh start 1
+```
+
+The dev main process serves `apps/desktop/dist/renderer` over `app://renderer/`
+with the seeded login. Prove which build is loaded via the modulepreload hashes
+in the live DOM, not resource timing:
+
+```js
+[...document.querySelectorAll('link[rel=modulepreload]')]
+  .map((l) => l.href)
+  .find((h) => h.includes('<chunk-under-test>'));
+```
+
+Paint metrics survive post-hoc collection: a buffered
+`PerformanceObserver({ type: 'largest-contentful-paint', buffered: true })` plus
+`performance.getEntriesByType('paint')` read after load give FCP/DCL and the full
+LCP-candidate timeline. `restart 1` re-seeds userData, so each restart is a
+comparable cold start; `location.reload()` gives low-variance warm samples. For
+A/B builds, swap `dist/renderer` directories between restarts — remote-image LCP
+entries are network-noisy, so compare text-paint candidates and DCL across ≥5
+cold samples per variant before attributing a delta.
+
 ### Driving and probing a real Electron popup window
 
 **Situation:** verifying `entry.popup.tsx` behavior (its own HTML shell, no `BootShell`).

--- a/src/spa/router/desktopRouter.config.desktop.tsx
+++ b/src/spa/router/desktopRouter.config.desktop.tsx
@@ -4,6 +4,7 @@ import type { RouteObject } from 'react-router';
 
 import { dynamicElement, ErrorBoundary } from '@/utils/router';
 
+import DesktopHomeRoute from './DesktopHomeRoute';
 import {
   createMainAreaRouteFactory,
   createSharedDesktopRoutes,
@@ -13,7 +14,8 @@ import {
 export { sharedMainAreaChildren } from './desktopRouter.shared';
 
 const mainAreaRouteOptions: MainAreaRouteOptions = {
-  createHomeElement: () => dynamicElement(() => import('./DesktopHomeRoute'), 'Desktop > Home'),
+  // The first screen every tab paints — eager so it never suspends behind a chunk fetch.
+  createHomeElement: () => <DesktopHomeRoute />,
   createWorkspaceSettingsIndexElement: () =>
     dynamicElement(
       () => import('@/routes/(main)/[workspaceSlug]/settings'),


### PR DESCRIPTION
<!-- Brief and heads-up -->

Eager-load `DesktopHomeRoute` on Electron so every new tab's first screen never suspends behind a lazy chunk fetch. Also documents how to measure production-renderer startup without packaging the app.

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

How to verify:
1. Build the desktop renderer: `cd apps/desktop && vite build --config vite.renderer.config.ts`
2. Launch a pool instance with the static override: `DESKTOP_RENDERER_STATIC=1 .agents/acceptance/scripts/electron-dev.sh start 1`
3. Open a new tab / home route and confirm `DesktopHomeRoute` is in the main bundle (no separate lazy chunk fetch for home on first paint)
4. Optionally prove via modulepreload hashes in the live DOM as described in `.agents/acceptance/probe-mock-patterns.md`

#### 🔗 Related Issue

N/A — internal desktop startup paint optimization.