### PR TITLE
🐛 fix(agent-documents): contain resource tree render errors

### DIFF
--- a/src/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.test.tsx
+++ b/src/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.test.tsx
@@ -4,6 +4,7 @@ import {
   AGENT_DOCUMENT_SKILL_CATEGORY,
   AGENT_SIGNAL_SOURCE_TYPE,
 } from '@lobechat/const';
+import type { ErrorBoundary as LobeErrorBoundary } from '@lobehub/ui';
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import type * as ReactRouterDom from 'react-router';
@@ -20,42 +21,60 @@ const navigateMock = vi.hoisted(() => vi.fn());
 const openDocumentMock = vi.hoisted(() => vi.fn());
 const removeDocumentMock = vi.hoisted(() => vi.fn());
 const useParamsMock = vi.hoisted(() => vi.fn());
+const documentExplorerShouldThrow = vi.hoisted(() => ({ current: false }));
 
 vi.mock('@lobehub/ui/base-ui', () => ({
   confirmModal: modalConfirm,
   toast: { error: messageError, success: messageSuccess },
 }));
 
-vi.mock('@lobehub/ui', () => ({
-  Accordion: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
-  AccordionItem: ({ children, title }: { children?: ReactNode; title?: ReactNode }) => (
-    <div>
-      {title}
-      {children}
-    </div>
-  ),
-  ActionIcon: ({ onClick, title }: { onClick?: (e: React.MouseEvent) => void; title?: string }) => (
-    <button aria-label={title} onClick={onClick}>
-      {title}
-    </button>
-  ),
-  Center: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
-  Empty: ({ description }: { description?: ReactNode }) => <div>{description}</div>,
-  Flexbox: ({
-    children,
-    onClick,
-    ...props
-  }: {
-    children?: ReactNode;
-    onClick?: () => void;
-    [key: string]: unknown;
-  }) => (
-    <div onClick={onClick} {...props}>
-      {children}
-    </div>
-  ),
-  Text: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
-}));
+vi.mock('@lobehub/ui', async (importOriginal) => {
+  const actual = await importOriginal<{ ErrorBoundary: typeof LobeErrorBoundary }>();
+  return {
+    Accordion: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    AccordionItem: ({ children, title }: { children?: ReactNode; title?: ReactNode }) => (
+      <div>
+        {title}
+        {children}
+      </div>
+    ),
+    ActionIcon: ({
+      onClick,
+      title,
+    }: {
+      onClick?: (e: React.MouseEvent) => void;
+      title?: string;
+    }) => (
+      <button aria-label={title} onClick={onClick}>
+        {title}
+      </button>
+    ),
+    Alert: ({ message, title }: { message?: ReactNode; title?: ReactNode }) => (
+      <div role="alert">
+        <div>{title}</div>
+        <div>{message}</div>
+      </div>
+    ),
+    Center: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    Empty: ({ description }: { description?: ReactNode }) => <div>{description}</div>,
+    ErrorBoundary: actual.ErrorBoundary,
+    Flexbox: ({
+      children,
+      onClick,
+      ...props
+    }: {
+      children?: ReactNode;
+      onClick?: () => void;
+      [key: string]: unknown;
+    }) => (
+      <div onClick={onClick} {...props}>
+        {children}
+      </div>
+    ),
+    Highlighter: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    Text: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  };
+});
 
 vi.mock('@/components/NeuralNetworkLoading', () => ({
   default: () => <div data-testid="neural-network-loading" />,
@@ -102,17 +121,23 @@ vi.mock('@/features/AgentDocumentsExplorer', () => ({
     data: { documentId: string; id: string; title?: string }[];
     onOpenDocument?: (documentId: string, agentDocumentId?: string) => void;
   }) => (
-    <div data-doc-count={data.length} data-testid="document-explorer-tree">
-      {data.map((doc) => (
-        <button
-          data-testid={`tree-open-${doc.id}`}
-          key={doc.id}
-          onClick={() => onOpenDocument?.(doc.documentId, doc.id)}
-        >
-          {doc.title}
-        </button>
-      ))}
-    </div>
+    documentExplorerShouldThrow.current ? (
+      (() => {
+        throw new Error('document tree render failed');
+      })()
+    ) : (
+      <div data-doc-count={data.length} data-testid="document-explorer-tree">
+        {data.map((doc) => (
+          <button
+            data-testid={`tree-open-${doc.id}`}
+            key={doc.id}
+            onClick={() => onOpenDocument?.(doc.documentId, doc.id)}
+          >
+            {doc.title}
+          </button>
+        ))}
+      </div>
+    )
   ),
 }));
 
@@ -313,6 +338,7 @@ describe('AgentDocumentsGroup', () => {
     removeDocumentMock.mockReset();
     removeDocumentMock.mockResolvedValue({ deleted: true, id: 'doc-1' });
     useParamsMock.mockReturnValue({});
+    documentExplorerShouldThrow.current = false;
   });
 
   it('defaults to the Skills tab and renders skill bundles via SkillsList', () => {
@@ -453,6 +479,21 @@ describe('AgentDocumentsGroup', () => {
     // Skill bundle, skill index, and web items are filtered out before reaching
     // the tree — only the file-backed document survives.
     expect(tree).toHaveAttribute('data-doc-count', '1');
+  });
+
+  it('contains document tree render failures in an alert boundary', () => {
+    documentExplorerShouldThrow.current = true;
+    useClientDataSWR.mockReturnValue({
+      data: [fileDocRow],
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    });
+
+    render(<AgentDocumentsGroup activeFilter="documents" />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Render Error');
+    expect(screen.getByRole('alert')).toHaveTextContent('document tree render failed');
   });
 
   it('opens document tree files in the portal by default', () => {

--- a/src/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.tsx
+++ b/src/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
 import AsyncError from '@/components/AsyncError';
+import { withErrorBoundary } from '@/components/ErrorBoundary';
 import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
 import { buildAgentDocumentPath } from '@/features/AgentDocumentPage/navigation';
 import { DocumentExplorerTree } from '@/features/AgentDocumentsExplorer';
@@ -672,4 +673,4 @@ const AgentDocumentsGroup = memo<AgentDocumentsGroupProps>(
 
 AgentDocumentsGroup.displayName = 'AgentDocumentsGroup';
 
-export default AgentDocumentsGroup;
+export default withErrorBoundary(AgentDocumentsGroup, { variant: 'alert' });


### PR DESCRIPTION
Wrap `AgentDocumentsGroup` at its export boundary with the shared alert ErrorBoundary. This keeps unexpected explorer-tree rendering failures local to the resources panel instead of escalating to the route-level error page.

The existing tree normalization and regression tests already cover duplicate sibling names, folder/file name collisions, and blank names; this boundary provides a final fallback for malformed or unsupported tree states.

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

`bun run check` completed with lint clean and 22 related tests passing before the change was moved into the isolated worktree. The existing normalization regression tests exercise the reported failure mode.

#### Key Decisions / Non-goals

- Reuse the shared alert ErrorBoundary at the component export so both resources-panel entry points are covered.
- Do not change persisted document names; normalization remains a presentation-layer concern.