### PR TITLE
✨ feat(chat): make opening questions editable

### DIFF
--- a/src/features/AgentHome/OpeningQuestions.tsx
+++ b/src/features/AgentHome/OpeningQuestions.tsx
@@ -35,7 +35,7 @@ interface OpeningQuestionsProps {
 
 const OpeningQuestions = memo<OpeningQuestionsProps>(({ questions }) => {
   const { t } = useTranslation(['welcome', 'chat']);
-  const [sendMessage] = useConversationStore((s) => [s.sendMessage]);
+  const fillInputMessage = useConversationStore((s) => s.fillInputMessage);
 
   // Same per-resource General-access gating as the chat input below (see
   // useChatInputResourceAccess): inbox and private agents are never gated.
@@ -64,7 +64,7 @@ const OpeningQuestions = memo<OpeningQuestionsProps>(({ questions }) => {
               onClick={
                 canUseResource
                   ? () => {
-                      sendMessage({ message: question });
+                      fillInputMessage(question);
                     }
                   : undefined
               }

--- a/src/features/Conversation/FollowUp/FollowUpChips.test.tsx
+++ b/src/features/Conversation/FollowUp/FollowUpChips.test.tsx
@@ -24,10 +24,7 @@ const CHILD_MSG = 'msg-1-child-answer';
 const KEY = 'main_agent-a_topic-1';
 const OTHER_KEY = 'main_agent-a_topic-2';
 
-const updateInputMessageMock = vi.fn();
-const editorSetDocumentMock = vi.fn();
-const editorFocusMock = vi.fn();
-const editorMock = { focus: editorFocusMock, setDocument: editorSetDocumentMock };
+const fillInputMessageMock = vi.fn();
 let isGeneratingMock = false;
 let displayMessagesMock: Array<{ children?: Array<{ id: string }>; id: string }> = [];
 
@@ -39,19 +36,16 @@ vi.mock('@/features/Conversation/store', () => ({
   useConversationStore: (selector: any) =>
     selector({
       displayMessages: displayMessagesMock,
-      editor: editorMock,
+      fillInputMessage: fillInputMessageMock,
       operationState: {
         getMessageOperationState: () => ({ isGenerating: isGeneratingMock }),
       },
-      updateInputMessage: updateInputMessageMock,
     }),
 }));
 
 describe('<FollowUpChips />', () => {
   beforeEach(() => {
-    updateInputMessageMock.mockReset();
-    editorSetDocumentMock.mockReset();
-    editorFocusMock.mockReset();
+    fillInputMessageMock.mockReset();
     isGeneratingMock = false;
     displayMessagesMock = [{ id: MSG }];
     useFollowUpActionStore.getState().reset();
@@ -162,9 +156,7 @@ describe('<FollowUpChips />', () => {
     });
     render(<FollowUpChips conversationKey={KEY} messageId={MSG} />);
     fireEvent.click(screen.getByRole('button', { name: 'go' }));
-    expect(updateInputMessageMock).toHaveBeenCalledWith('go ahead');
-    expect(editorSetDocumentMock).toHaveBeenCalledWith('text', 'go ahead');
-    expect(editorFocusMock).toHaveBeenCalled();
+    expect(fillInputMessageMock).toHaveBeenCalledWith('go ahead');
     expect(useFollowUpActionStore.getState().slots[KEY]?.status).toBe('ready');
   });
 });

--- a/src/features/Conversation/FollowUp/FollowUpChips.tsx
+++ b/src/features/Conversation/FollowUp/FollowUpChips.tsx
@@ -24,21 +24,16 @@ const FollowUpChips = memo<FollowUpChipsProps>(({ conversationKey, messageId }) 
     [childIdsKey, conversationKey, messageId],
   );
   const chips = useFollowUpActionStore(selector);
-  const updateInputMessage = useConversationStore((s) => s.updateInputMessage);
-  const editor = useConversationStore((s) => s.editor);
+  const fillInputMessage = useConversationStore((s) => s.fillInputMessage);
   const isGenerating = useConversationStore(
     messageStateSelectors.isAssistantGroupItemGenerating(messageId),
   );
 
   const handleClick = useCallback(
     (chip: FollowUpChip) => {
-      updateInputMessage('');
-      editor?.setDocument('text', '');
-      updateInputMessage(chip.message);
-      editor?.setDocument('text', chip.message);
-      editor?.focus();
+      fillInputMessage(chip.message);
     },
-    [updateInputMessage, editor],
+    [fillInputMessage],
   );
 
   if (chips.length === 0 || isGenerating) return null;

--- a/src/features/Conversation/store.test.ts
+++ b/src/features/Conversation/store.test.ts
@@ -197,6 +197,47 @@ describe('ConversationStore', () => {
   });
 
   describe('UI Actions', () => {
+    describe('fillInputMessage', () => {
+      it('should replace the composer content and focus the editor', () => {
+        const context: ConversationContext = {
+          agentId: 'session-1',
+          topicId: null,
+          threadId: null,
+        };
+        const editor = {
+          focus: vi.fn(),
+          setDocument: vi.fn(),
+        };
+        const store = createStore({ context });
+
+        act(() => {
+          store.getState().setEditor(editor);
+          store.getState().updateInputMessage('Existing draft');
+          store.getState().fillInputMessage('Editable opening question');
+        });
+
+        expect(store.getState().inputMessage).toBe('Editable opening question');
+        expect(editor.setDocument).toHaveBeenNthCalledWith(1, 'text', '');
+        expect(editor.setDocument).toHaveBeenNthCalledWith(2, 'text', 'Editable opening question');
+        expect(editor.focus).toHaveBeenCalledOnce();
+      });
+
+      it('should update the input state before the editor is ready', () => {
+        const context: ConversationContext = {
+          agentId: 'session-1',
+          topicId: null,
+          threadId: null,
+        };
+        const store = createStore({ context });
+
+        act(() => {
+          store.getState().fillInputMessage('Editable opening question');
+        });
+
+        expect(store.getState().inputMessage).toBe('Editable opening question');
+      });
+    });
+
     describe('updateInputMessage', () => {
       it('should update input message', () => {
         const context: ConversationContext = {

--- a/src/features/Conversation/store/slices/input/action.ts
+++ b/src/features/Conversation/store/slices/input/action.ts
@@ -28,6 +28,11 @@ export interface InputAction {
   commitScheduledSend: (message: string, files?: { id: string }[]) => Promise<boolean>;
 
   /**
+   * Fill the composer with editable text and move focus to the editor.
+   */
+  fillInputMessage: (message: string) => void;
+
+  /**
    * Report the floating overlay height (TodoProgress + QueueTray) so the
    * ChatList scroll container can reserve matching bottom padding.
    */
@@ -102,6 +107,16 @@ export const inputSlice: StateCreator<State & InputAction, [], [], InputAction> 
     );
 
     return true;
+  },
+
+  fillInputMessage: (message) => {
+    const { editor } = get();
+
+    set({ inputMessage: '' });
+    editor?.setDocument('text', '');
+    set({ inputMessage: message });
+    editor?.setDocument('text', message);
+    editor?.focus();
   },
 
   setChatInputOverlayHeight: (height) => {

--- a/src/routes/(main)/group/features/Conversation/AgentWelcome/OpeningQuestions.tsx
+++ b/src/routes/(main)/group/features/Conversation/AgentWelcome/OpeningQuestions.tsx
@@ -44,7 +44,7 @@ interface OpeningQuestionsProps {
 
 const OpeningQuestions = memo<OpeningQuestionsProps>(({ mobile, questions }) => {
   const { t } = useTranslation(['welcome', 'chat']);
-  const [sendMessage] = useConversationStore((s) => [s.sendMessage]);
+  const fillInputMessage = useConversationStore((s) => s.fillInputMessage);
 
   // Same per-resource General-access gating as the chat input (see
   // useChatInputResourceAccess): private groups are never gated.
@@ -71,7 +71,7 @@ const OpeningQuestions = memo<OpeningQuestionsProps>(({ mobile, questions }) => 
               onClick={
                 canUseResource
                   ? () => {
-                      sendMessage({ message: question });
+                      fillInputMessage(question);
                     }
                   : undefined
               }


### PR DESCRIPTION
## Summary

- fill the chat composer when an opening question is selected instead of sending it immediately
- apply the same editable-draft behavior to follow-up suggestion chips
- centralize composer replacement and focus behavior in `fillInputMessage`
- cover store behavior and follow-up chip integration with regression tests

## Testing

- `bun run check` — lint clean, 24 tests passed
- `bun run check --type` — blocked by cross-worktree module resolution while reusing the main checkout's `node_modules`; TypeScript loaded duplicate workspace packages from both absolute paths, with failures outside these changed files