### PR TITLE
🐛 fix(home): exclude topics from sidebar recents

### DIFF
--- a/src/features/Home/Recents/AllRecentsDrawer.tsx
+++ b/src/features/Home/Recents/AllRecentsDrawer.tsx
@@ -12,7 +12,7 @@ import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
 import { useClientDataSWR } from '@/libs/swr';
 import { recentKeys } from '@/libs/swr/keys';
 import { useCacheScope } from '@/libs/swr/useCacheScope';
-import { recentService } from '@/services/recent';
+import { RECENT_SIDEBAR_TYPES, recentService } from '@/services/recent';
 
 import RecentListItem from './Item';
 
@@ -28,7 +28,7 @@ const AllRecentsDrawer = memo<AllRecentsDrawerProps>(({ open, onClose }) => {
 
   const { data: recents, isLoading } = useClientDataSWR(
     open ? recentKeys.allDrawer(open, scope) : null,
-    () => recentService.getAll(50),
+    () => recentService.getAll(50, RECENT_SIDEBAR_TYPES),
   );
 
   const filteredRecents = useMemo(() => {

--- a/src/services/recent/index.ts
+++ b/src/services/recent/index.ts
@@ -1,14 +1,24 @@
 import { lambdaClient } from '@/libs/trpc/client';
 import { type RecentItem } from '@/server/routers/lambda/recent';
 
+export const RECENT_SIDEBAR_TYPES = [
+  'document',
+  'task',
+] as const satisfies readonly RecentItem['type'][];
+
 class RecentService {
   getAll = (
     limit?: number,
-    types?: RecentItem['type'][],
+    types?: readonly RecentItem['type'][],
     withTopicPreview?: boolean,
     mineOnly?: boolean,
   ): Promise<RecentItem[]> => {
-    return lambdaClient.recent.getAll.query({ limit, mineOnly, types, withTopicPreview });
+    return lambdaClient.recent.getAll.query({
+      limit,
+      mineOnly,
+      types: types ? [...types] : undefined,
+      withTopicPreview,
+    });
   };
 }
 

--- a/src/store/home/slices/recent/action.test.ts
+++ b/src/store/home/slices/recent/action.test.ts
@@ -5,6 +5,7 @@ import * as swr from '@/libs/swr';
 import { recentKeys } from '@/libs/swr/keys';
 import * as cacheScope from '@/libs/swr/useCacheScope';
 import { type RecentItem } from '@/server/routers/lambda/recent';
+import { recentService } from '@/services/recent';
 import { useHomeStore } from '@/store/home';
 import { initialRecentState } from '@/store/home/slices/recent/initialState';
 
@@ -39,18 +40,24 @@ afterEach(() => {
 
 describe('RecentActionImpl', () => {
   describe('useFetchRecents onData scope guard', () => {
-    it('does not poll recents periodically', () => {
+    it('fetches only document and task recents without polling', async () => {
       const swrSpy = vi.spyOn(swr, 'useClientDataSWRWithSync').mockReturnValue({
         data: undefined,
         isValidating: false,
         mutate: vi.fn(),
       } as any);
+      const getAllSpy = vi.spyOn(recentService, 'getAll').mockResolvedValue([]);
 
       renderHook(() => useHomeStore.getState().useFetchRecents(true, 10, 'user-1:ws-A'));
 
       expect(swrSpy).toHaveBeenCalledWith(expect.any(Array), expect.any(Function), {
         onData: expect.any(Function),
       });
+
+      const fetcher = swrSpy.mock.calls[0][1] as () => Promise<RecentItem[]>;
+      await fetcher();
+
+      expect(getAllSpy).toHaveBeenCalledWith(11, ['document', 'task']);
     });
 
     it('applies data for the matching scope and tags recentsScope', () => {

--- a/src/store/home/slices/recent/action.ts
+++ b/src/store/home/slices/recent/action.ts
@@ -5,7 +5,7 @@ import { mutate, useClientDataSWRWithSync } from '@/libs/swr';
 import { recentKeys } from '@/libs/swr/keys';
 import { getCacheScope } from '@/libs/swr/useCacheScope';
 import { type RecentItem } from '@/server/routers/lambda/recent';
-import { recentService } from '@/services/recent';
+import { RECENT_SIDEBAR_TYPES, recentService } from '@/services/recent';
 import { type HomeStore } from '@/store/home/store';
 import { type StoreSetter } from '@/store/types';
 import { setNamespace } from '@/utils/storeDebug';
@@ -68,7 +68,7 @@ export class RecentActionImpl {
   ): SWRResponse<RecentItem[]> => {
     return useClientDataSWRWithSync<RecentItem[]>(
       isLogin === true ? recentKeys.list(isLogin, limit, scope) : null,
-      async () => recentService.getAll(limit + 1),
+      async () => recentService.getAll(limit + 1, RECENT_SIDEBAR_TYPES),
       {
         onData: (data) => {
           if (getCacheScope() !== scope) return;


### PR DESCRIPTION
## Summary

- exclude topics from the Home sidebar Recent list request
- apply the same document/task filter to the all-recents drawer
- keep the Home main-column topic recents request unchanged
- add regression coverage for the sidebar request types

## Test plan

- `bun run check src/services/recent/index.ts src/store/home/slices/recent/action.ts src/store/home/slices/recent/action.test.ts src/features/Home/Recents/AllRecentsDrawer.tsx`
- 9 related tests passed; lint clean