### PR TITLE
💄 style(task): refine topic conversation drawer

### DIFF
--- a/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.test.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.test.tsx
@@ -119,7 +119,7 @@ vi.mock('@lobehub/ui/base-ui', () => ({
     open?: boolean;
     placement?: string;
     resizable?: boolean;
-    styles?: { body?: CSSProperties; title?: CSSProperties };
+    styles?: { body?: CSSProperties; panel?: CSSProperties; title?: CSSProperties };
     title?: ReactNode;
     width?: unknown;
   }) =>
@@ -128,10 +128,12 @@ vi.mock('@lobehub/ui/base-ui', () => ({
         data-height={serializeSize(height)}
         data-min-height={serializeSize(minHeight)}
         data-min-width={serializeSize(minWidth)}
+        data-panel-background={serializeSize(styles?.panel?.background)}
         data-placement={placement}
         data-resizable={String(resizable)}
         data-testid="topic-panel"
         data-width={serializeSize(width)}
+        style={styles?.panel}
       >
         <div data-testid="panel-title-slot" style={styles?.title}>
           {title}
@@ -218,8 +220,10 @@ vi.mock('@/store/chat/utils/messageMapKey', () => ({
   messageMapKey: () => 'topic-chat-key',
 }));
 
-vi.mock('../TopicStatusIcon', () => ({
-  default: () => <span data-testid="topic-status-icon" />,
+vi.mock('../../features/AssigneeAvatar', () => ({
+  default: ({ agentId, size }: { agentId?: string; size?: number }) => (
+    <span data-agent-id={agentId} data-size={size} data-testid="assignee-avatar" />
+  ),
 }));
 
 vi.mock('./FeedbackInput', () => ({
@@ -282,6 +286,22 @@ describe('TopicChatDrawer', () => {
       maxWidth: '100%',
       overflow: 'hidden',
     });
+  });
+
+  it('shows the assignee avatar in the topic header', () => {
+    const { getByTestId } = render(<TopicChatDrawer />);
+
+    expect(getByTestId('assignee-avatar')).toHaveAttribute('data-agent-id', 'agt_assignee');
+    expect(getByTestId('assignee-avatar')).toHaveAttribute('data-size', '20');
+  });
+
+  it('uses the container background for the conversation panel', () => {
+    const { getByTestId } = render(<TopicChatDrawer />);
+
+    expect(getByTestId('topic-panel')).toHaveAttribute(
+      'data-panel-background',
+      'var(--ant-color-bg-container)',
+    );
   });
 
   it('renders the share button in the floating panel actions slot', () => {

--- a/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx
@@ -4,6 +4,7 @@ import type { ConversationContext } from '@lobechat/types';
 import type { DropdownItem } from '@lobehub/ui';
 import { ActionIcon, copyToClipboard, DropdownMenu, Flexbox, Freeze, Tag, Text } from '@lobehub/ui';
 import { FloatingPanel } from '@lobehub/ui/base-ui';
+import { cssVar } from 'antd-style';
 import { Copy, MoreHorizontal, Share2 } from 'lucide-react';
 import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -27,7 +28,7 @@ import { taskActivitySelectors, taskDetailSelectors } from '@/store/task/selecto
 import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/selectors';
 
-import TopicStatusIcon from '../TopicStatusIcon';
+import AssigneeAvatar from '../../features/AssigneeAvatar';
 import FeedbackInput from './FeedbackInput';
 
 const SHARE_ICON_SIZE = { blockSize: 32, size: 16 } as const;
@@ -126,7 +127,6 @@ const TopicChatDrawer = memo(() => {
   useFetchTaskDetail(topicId ? activeTaskId : undefined);
 
   const open = !!topicId && !!agentId;
-  const status = activity?.status;
 
   const shareContext = useMemo<Partial<ConversationContext>>(
     () => ({ agentId: agentId ?? undefined, topicId: topicId ?? undefined }),
@@ -170,7 +170,7 @@ const TopicChatDrawer = memo(() => {
       gap={8}
       style={{ maxWidth: '100%', minWidth: 0, overflow: 'hidden' }}
     >
-      <TopicStatusIcon size={16} status={status} />
+      <AssigneeAvatar agentId={agentId} size={20} />
       {activity?.sourceTaskIdentifier && (
         <Tag
           size={'small'}
@@ -231,7 +231,10 @@ const TopicChatDrawer = memo(() => {
       width={640}
       styles={{
         body: { padding: 0 },
-        panel: { maxHeight: 'calc(100dvh - 16px)' },
+        panel: {
+          background: cssVar.colorBgContainer,
+          maxHeight: 'calc(100dvh - 16px)',
+        },
         title: {
           boxSizing: 'border-box',
           maxWidth: '100%',


### PR DESCRIPTION
## Summary

- replace the topic status icon in the floating conversation header with the assigned agent avatar
- use the container background token for the topic conversation panel
- add regression coverage for the header identity and panel background

## Why

The floating topic conversation should communicate which agent owns the conversation, while its surface should visually match other container-level panels instead of inheriting the layout background.

## Validation

- `bun run check src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.test.tsx`
- 8 targeted tests passed
