### PR TITLE
✨ feat: lower default cost estimate warning threshold

### DIFF
--- a/packages/const/src/settings/common.ts
+++ b/packages/const/src/settings/common.ts
@@ -1,6 +1,6 @@
 import type { UserGeneralConfig } from '@lobechat/types';
 
-export const DEFAULT_COST_ESTIMATE_WARNING_THRESHOLD = 2;
+export const DEFAULT_COST_ESTIMATE_WARNING_THRESHOLD = 0.5;
 
 export const DEFAULT_COMMON_SETTINGS: UserGeneralConfig = {
   animationMode: 'agile',

--- a/src/store/user/slices/settings/selectors/general.test.ts
+++ b/src/store/user/slices/settings/selectors/general.test.ts
@@ -18,7 +18,7 @@ describe('settingsSelectors', () => {
 
       expect(result).toEqual({
         animationMode: 'agile',
-        costEstimateWarningThreshold: 2,
+        costEstimateWarningThreshold: 0.5,
         fontSize: 12,
         highlighterTheme: 'lobe-theme',
         isDevMode: false,

--- a/src/store/user/slices/settings/selectors/usage.test.ts
+++ b/src/store/user/slices/settings/selectors/usage.test.ts
@@ -12,7 +12,7 @@ describe('userUsageSettingsSelectors', () => {
         initialState as UserStore,
       );
 
-      expect(result).toBe(2);
+      expect(result).toBe(0.5);
     });
 
     it('should read the persisted threshold from general settings', () => {

--- a/src/store/user/slices/settings/selectors/usage.test.ts
+++ b/src/store/user/slices/settings/selectors/usage.test.ts
@@ -18,13 +18,13 @@ describe('userUsageSettingsSelectors', () => {
     it('should read the persisted threshold from general settings', () => {
       const s: UserState = merge(initialState, {
         settings: {
-          general: { costEstimateWarningThreshold: 0.5 },
+          general: { costEstimateWarningThreshold: 1.25 },
         },
       });
 
       const result = userUsageSettingsSelectors.costEstimateWarningThreshold(s as UserStore);
 
-      expect(result).toBe(0.5);
+      expect(result).toBe(1.25);
     });
   });
 });


### PR DESCRIPTION
## Brief

Lower the default cost estimate warning threshold from $2.00 to $0.50 while preserving explicitly persisted user settings.

#### Test

- [x] Added/updated tests
- bun run check lobehub/packages/const/src/settings/common.ts lobehub/src/store/user/slices/settings/selectors/usage.test.ts