### PR TITLE
🐛 fix(desktop): allow update downgrades

### DIFF
--- a/apps/desktop/src/main/core/infrastructure/UpdaterManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/UpdaterManager.ts
@@ -112,7 +112,6 @@ export class UpdaterManager {
 
     autoUpdater.autoDownload = false;
     autoUpdater.autoInstallOnAppQuit = false;
-    autoUpdater.allowDowngrade = false;
 
     const useDevConfig = isDev || FORCE_DEV_UPDATE_CONFIG;
     if (useDevConfig) {
@@ -128,6 +127,10 @@ export class UpdaterManager {
       );
       this.configureUpdateProvider();
     }
+
+    // Keep every release channel rollback-capable. Assign this after configuring the provider because
+    // electron-updater's channel setter mutates allowDowngrade as a side effect.
+    autoUpdater.allowDowngrade = true;
 
     this.registerEvents();
 
@@ -149,14 +152,13 @@ export class UpdaterManager {
   public switchChannel = (channel: UpdateChannel) => {
     logger.info(`Switching update channel: ${this.currentChannel} -> ${channel}`);
 
-    const isDowngrade = this.currentChannel === 'canary' && channel === 'stable';
-
     this.currentChannel = channel;
-    autoUpdater.allowDowngrade = isDowngrade;
-    logger.info(`allowDowngrade=${isDowngrade}`);
-
     autoUpdater.allowPrerelease = channel !== 'stable';
     this.configureUpdateProvider();
+
+    // Reapply after configureUpdateProvider for the same channel-setter side effect as initialize.
+    autoUpdater.allowDowngrade = true;
+    logger.info('allowDowngrade=true');
 
     this.installLaterVersion = null;
 

--- a/apps/desktop/src/main/core/infrastructure/__tests__/UpdaterManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/UpdaterManager.test.ts
@@ -23,23 +23,33 @@ vi.mock('electron-log', () => ({
 }));
 
 // Mock electron-updater
-vi.mock('electron-updater', () => ({
-  autoUpdater: {
-    allowDowngrade: false,
-    allowPrerelease: false,
-    autoDownload: false,
-    autoInstallOnAppQuit: false,
-    channel: 'stable',
-    checkForUpdates: vi.fn(),
-    currentVersion: undefined as any,
-    downloadUpdate: vi.fn(),
-    forceDevUpdateConfig: false,
-    logger: null as any,
-    on: vi.fn(),
-    quitAndInstall: vi.fn(),
-    setFeedURL: vi.fn(),
-  },
-}));
+vi.mock('electron-updater', () => {
+  let channel = 'stable';
+
+  return {
+    autoUpdater: {
+      allowDowngrade: false,
+      allowPrerelease: false,
+      autoDownload: false,
+      autoInstallOnAppQuit: false,
+      get channel() {
+        return channel;
+      },
+      set channel(value: string) {
+        channel = value;
+        this.allowDowngrade = true;
+      },
+      checkForUpdates: vi.fn(),
+      currentVersion: undefined as any,
+      downloadUpdate: vi.fn(),
+      forceDevUpdateConfig: false,
+      logger: null as any,
+      on: vi.fn(),
+      quitAndInstall: vi.fn(),
+      setFeedURL: vi.fn(),
+    },
+  };
+});
 
 // Mock electron - uses hoisted functions for require() compatibility
 vi.mock('electron', () => ({
@@ -155,7 +165,17 @@ describe('UpdaterManager', () => {
       expect(autoUpdater.autoInstallOnAppQuit).toBe(false);
       expect(autoUpdater.channel).toBe('stable');
       expect(autoUpdater.allowPrerelease).toBe(false);
-      expect(autoUpdater.allowDowngrade).toBe(false);
+      expect(autoUpdater.allowDowngrade).toBe(true);
+    });
+
+    it('should allow a persisted canary channel to roll back to an older canary build', async () => {
+      vi.mocked(mockApp.storeManager.get).mockReturnValue('canary');
+
+      await updaterManager.initialize();
+
+      expect(autoUpdater.channel).toBe('canary');
+      expect(autoUpdater.allowPrerelease).toBe(true);
+      expect(autoUpdater.allowDowngrade).toBe(true);
     });
 
     it('should register all event listeners', async () => {
@@ -167,6 +187,29 @@ describe('UpdaterManager', () => {
       expect(autoUpdater.on).toHaveBeenCalledWith('error', expect.any(Function));
       expect(autoUpdater.on).toHaveBeenCalledWith('download-progress', expect.any(Function));
       expect(autoUpdater.on).toHaveBeenCalledWith('update-downloaded', expect.any(Function));
+    });
+  });
+
+  describe('switchChannel', () => {
+    it('should allow rollback whenever canary is the target channel', () => {
+      updaterManager.switchChannel('canary');
+
+      expect(autoUpdater.allowDowngrade).toBe(true);
+    });
+
+    it('should preserve canary-to-stable downgrade support', async () => {
+      vi.mocked(mockApp.storeManager.get).mockReturnValue('canary');
+      await updaterManager.initialize();
+
+      updaterManager.switchChannel('stable');
+
+      expect(autoUpdater.allowDowngrade).toBe(true);
+    });
+
+    it('should allow rollback when stable remains the target channel', () => {
+      updaterManager.switchChannel('stable');
+
+      expect(autoUpdater.allowDowngrade).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

- allow Desktop updates to install lower versions on both Stable and Canary channels
- reapply the downgrade policy after provider configuration to account for electron-updater's channel setter side effect
- align the updater mock with the real channel behavior and cover initialization and channel-switch rollback paths

## Why

Desktop release rollback should be operationally simple: publishing an older version in a channel manifest must allow affected clients to return to that version. The previous policy was conditional and could also be overwritten while configuring the update provider.

With this change, every effective Desktop update channel explicitly keeps `allowDowngrade` enabled.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check --lint --test apps/desktop/src/main/core/infrastructure/UpdaterManager.ts apps/desktop/src/main/core/infrastructure/__tests__/UpdaterManager.test.ts
# 2 files · lint clean · tests 42 passed

git diff --check origin/canary..HEAD
```

Desktop type-check remains blocked by the pre-existing `NativeImage.createMenuSymbol` error in `src/main/core/ui/nativeContextMenu.ts:39`.

#### 🔗 Related Issue

N/A
