### PR TITLE
🐛 fix(agent): pin root layout direction

### DIFF
--- a/src/routes/(main)/agent/_layout/index.test.tsx
+++ b/src/routes/(main)/agent/_layout/index.test.tsx
@@ -8,8 +8,18 @@ import { describe, expect, it, vi } from 'vitest';
 import Layout from './index';
 
 vi.mock('@lobehub/ui', () => ({
-  Flexbox: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
-    <div {...props}>{children}</div>
+  Flexbox: ({
+    children,
+    direction,
+    ...props
+  }: {
+    children?: ReactNode;
+    direction?: 'horizontal' | 'vertical';
+    [key: string]: unknown;
+  }) => (
+    <div {...props} style={{ flexDirection: direction === 'vertical' ? 'column' : direction }}>
+      {children}
+    </div>
   ),
   ShikiLobeTheme: {},
 }));
@@ -41,6 +51,14 @@ describe('Agent layout', () => {
 
     expect(screen.getByTestId('agent-layout-sidebar')).toBeInTheDocument();
     expect(screen.getByTestId('agent-layout-outlet')).toBeInTheDocument();
+  });
+
+  it('keeps routed content in a vertical layout', () => {
+    render(<Layout />);
+
+    expect(screen.getByTestId('agent-layout-outlet').parentElement).toHaveStyle({
+      flexDirection: 'column',
+    });
   });
 
   it('mounts AgentIdSync in layout', () => {

--- a/src/routes/(main)/agent/_layout/index.tsx
+++ b/src/routes/(main)/agent/_layout/index.tsx
@@ -19,7 +19,7 @@ const Layout: FC = () => {
   return (
     <>
       <AgentSidebar />
-      <Flexbox className={styles.mainContainer} flex={1} height={'100%'}>
+      <Flexbox className={styles.mainContainer} direction="vertical" flex={1} height={'100%'}>
         {/* Keep the sidebar interactive when the routed agent is gone (deleted
             or made private) — only the content area collapses to the 404 card. */}
         <AgentNotFoundGuard>


### PR DESCRIPTION
Pins the agent route root `Flexbox` to a vertical direction instead of relying on the global Flex direction reset at this layout boundary. This prevents the chat content and terminal panel from being arranged along the wrong axis and clipped by the content shell overflow boundary.

Investigation confirmed that the `Flexbox` default did not change: the published 5.27.0, 5.28.0, and 5.29.0 packages all default `--lobe-flex-direction` to `column`, and their `FlexBasic` implementations are identical. The affected Electron environment had a mixed dependency graph (`@lobehub/ui` 5.29.0 at the workspace root and 5.14.1 in the standalone desktop install), with both versions present in the Vite optimized-dependency metadata. Making the route direction explicit removes this layout boundary from global-style injection and stale-cache ordering.

| Before | After |
| ------ | ----- |
| Agent content area could render blank after dependency re-optimization | Conversation content remains visible with a stable vertical route layout |

#### Test

- [x] Tested locally with Electron CDP on the affected agent/topic route
- [x] Added/updated tests
- [ ] No tests needed

Validation: `bun run check src/routes/(main)/agent/_layout/index.tsx src/routes/(main)/agent/_layout/index.test.tsx` (lint clean, 3 tests passed).

#### 🔗 Related Issue

N/A