### PR TITLE
📌 chore(deps): pin @lobehub/ui to ~5.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     ]
   },
   "overrides": {
+    "@lobehub/ui": "~5.28.1",
     "@types/react": "19.2.13",
     "antd": "6.3.5",
     "baseline-browser-mapping": "2.10.31",
@@ -303,7 +304,7 @@
     "@lobehub/icons": "^5.11.0",
     "@lobehub/market-sdk": "0.39.2",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "^5.28.0",
+    "@lobehub/ui": "~5.28.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@neondatabase/serverless": "^1.1.0",
     "@next/third-parties": "^16.3.0",
@@ -578,6 +579,7 @@
       "ffmpeg-static"
     ],
     "overrides": {
+      "@lobehub/ui": "~5.28.1",
       "@react-pdf/image": "3.0.4",
       "@types/react": "19.2.13",
       "@vitest/coverage-v8": "3.2.6",


### PR DESCRIPTION
`@lobehub/ui@5.29.0` (published 2026-08-06 23:00 UTC) flipped the `DraggablePanel` `stableLayout` default from `false` to `true` — the only behavioural change in that release:

```diff
- stableLayout = false,
+ stableLayout = true,
```

With it on, the panel `<aside>` picks up an extra inline style block, and in `mode="fixed"` that includes `height: 100%`:

```js
{ display: 'flex', flexDirection: 'column', minHeight: 0, ...(mode === 'fixed' && { height: '100%' }) }
```

Combined with the `flex-shrink: 0` already on the panel root class, any `DraggablePanel` sitting in a **column** flex parent now claims the entire column.

On the agent chat page that panel is `ChatTerminalPanel` (`placement="bottom"`), a sibling of the conversation row inside `ChatLayout`'s outer column. It takes the full height and squeezes the row (`flex: 1; min-height: 0`) down to zero, so the chat area renders blank.

#### Why it appeared between canary.35 and canary.36

No source change: `src/routes/(main)/agent/(chat)/_layout/index.tsx` is byte-identical across the two tags. The drift is purely in dependency resolution:

- `package.json` declared `^5.28.0`, while `pnpm-lock.yaml` still records the root importer at `5.19.0` — the lockfile is stale and cannot be enforced
- `.github/workflows/release-desktop-canary.yml` runs a plain `pnpm install` (no `--frozen-lockfile`), so `^5.28.0` re-resolves at build time
- canary.35 was built 2026-08-06 20:02 CST → `5.28.1`; canary.36 was built 2026-08-07 14:22 CST → `5.29.0`

Confirmed by unpacking the shipped `app.asar` of 2.2.14-canary.36: the renderer bundle contains `stableLayout: h = !0`, which only matches the 5.29.0 tarball.

#### What this PR does

Pins the root dependency and both `overrides` maps to `~5.28.1`, so the `^5` specifiers in `packages/*` resolve to the same copy instead of pulling a second 5.29.0 tree.

This is the root-cause counterpart to #18013, which pinned one layout's direction to work around the same regression.

#### Follow-ups (not in this PR)

- Regenerate `pnpm-lock.yaml` — it is far out of sync (`5.19.0` vs `^5.28.0`) and currently provides no build reproducibility
- Switch the release workflows to `pnpm install --frozen-lockfile` so a dependency can never change under a tagged build again
- Audit `DraggablePanel` call sites before intentionally moving to 5.29.x, or pass `stableLayout={false}` where a panel lives in a column parent

| Before | After |
| ------ | ----- |
| Chat area blank on canary.36 (terminal panel's aside claims 100% height) | Chat renders normally |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Verified by diffing the 5.28.1 and 5.29.0 tarballs (`stableLayout` default is the sole functional delta), and by matching the shipped canary.36 renderer bundle plus the reported DevTools computed styles against 5.29.0's `stableAsideStyle`. `~5.28.1` resolves to `5.28.1` (`npm view "@lobehub/ui@~5.28.1" version`).

#### 🔗 Related Issue

Related to #18013

🤖 Generated with [Claude Code](https://claude.com/claude-code)