### PR TITLE
🐛 fix(chat): prevent collapsed terminal from hiding conversation

### DIFF
--- a/src/features/ChatTerminal/index.test.tsx
+++ b/src/features/ChatTerminal/index.test.tsx
@@ -13,8 +13,20 @@ vi.mock('@lobechat/const', async (importOriginal) => ({
 }));
 
 vi.mock('@lobehub/ui', () => ({
-  DraggablePanel: ({ children, expand }: { children?: ReactNode; expand?: boolean }) => (
-    <div data-expand={String(expand)} data-testid="terminal-panel">
+  DraggablePanel: ({
+    children,
+    expand,
+    stableLayout = true,
+  }: {
+    children?: ReactNode;
+    expand?: boolean;
+    stableLayout?: boolean;
+  }) => (
+    <div
+      data-expand={String(expand)}
+      data-testid="terminal-panel"
+      style={{ height: expand ? 320 : stableLayout ? '100%' : 0 }}
+    >
       {children}
     </div>
   ),
@@ -45,8 +57,11 @@ describe('ChatTerminalPanel', () => {
     render(<ChatTerminalPanel />);
 
     // Closed: the panel is mounted (so it can animate) with expand=false,
-    // rather than returning null as the old implementation did.
+    // rather than returning null as the old implementation did. It must use
+    // the legacy DraggablePanel layout so the collapsed bottom panel does not
+    // retain the stable layout's full-height fixed aside.
     expect(screen.getByTestId('terminal-panel').dataset.expand).toBe('false');
+    expect(screen.getByTestId('terminal-panel')).toHaveStyle({ height: '0px' });
 
     setShow(true);
     await waitFor(() => expect(screen.getByTestId('terminal-panel').dataset.expand).toBe('true'));

--- a/src/features/ChatTerminal/index.tsx
+++ b/src/features/ChatTerminal/index.tsx
@@ -65,6 +65,9 @@ const ChatTerminalPanel = memo(() => {
       minHeight={160}
       placement={'bottom'}
       size={{ height, width: '100%' }}
+      // Stable layout makes the fixed aside full-height, which consumes this
+      // column even while a bottom panel is collapsed.
+      stableLayout={false}
       onSizeChange={(_, size) => {
         if (!size?.height) return;
         const next =

--- a/src/routes/(main)/agent/_layout/index.test.tsx
+++ b/src/routes/(main)/agent/_layout/index.test.tsx
@@ -8,18 +8,8 @@ import { describe, expect, it, vi } from 'vitest';
 import Layout from './index';
 
 vi.mock('@lobehub/ui', () => ({
-  Flexbox: ({
-    children,
-    direction,
-    ...props
-  }: {
-    children?: ReactNode;
-    direction?: 'horizontal' | 'vertical';
-    [key: string]: unknown;
-  }) => (
-    <div {...props} style={{ flexDirection: direction === 'vertical' ? 'column' : direction }}>
-      {children}
-    </div>
+  Flexbox: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
+    <div {...props}>{children}</div>
   ),
   ShikiLobeTheme: {},
 }));
@@ -51,14 +41,6 @@ describe('Agent layout', () => {
 
     expect(screen.getByTestId('agent-layout-sidebar')).toBeInTheDocument();
     expect(screen.getByTestId('agent-layout-outlet')).toBeInTheDocument();
-  });
-
-  it('keeps routed content in a vertical layout', () => {
-    render(<Layout />);
-
-    expect(screen.getByTestId('agent-layout-outlet').parentElement).toHaveStyle({
-      flexDirection: 'column',
-    });
   });
 
   it('mounts AgentIdSync in layout', () => {

--- a/src/routes/(main)/agent/_layout/index.tsx
+++ b/src/routes/(main)/agent/_layout/index.tsx
@@ -19,7 +19,7 @@ const Layout: FC = () => {
   return (
     <>
       <AgentSidebar />
-      <Flexbox className={styles.mainContainer} direction="vertical" flex={1} height={'100%'}>
+      <Flexbox className={styles.mainContainer} flex={1} height={'100%'}>
         {/* Keep the sidebar interactive when the routed agent is gone (deleted
             or made private) — only the content area collapses to the 404 card. */}
         <AgentNotFoundGuard>


### PR DESCRIPTION
## Summary

- replace the route-direction workaround from #18013 with the actual consumer-level fix
- opt the bottom chat terminal out of DraggablePanel stable layout
- keep the collapsed terminal from reserving the full chat height

## Root cause

@lobehub/ui v5.29.0 changed DraggablePanel stableLayout from false to true by default. In fixed bottom placement, stable layout writes height: 100% to the outer aside. Because ChatTerminalPanel is a child of the vertical chat layout, that collapsed aside consumes the entire column and shrinks the conversation row to 0px.

The Flexbox default remains column; it did not change in this release.

## Verification

- bun run check on the four changed source/test files: lint clean, 4 tests passed
- regression test fails without the fix: expected collapsed height 0px, received 100%
- Electron CDP on the reported agent/topic route:
  - before: conversation row 0px, collapsed terminal aside 885px
  - after: conversation row 885px, collapsed terminal aside 0px
  - terminal open: conversation row 564px, terminal 321px
  - terminal closed again: conversation row 885px, terminal 0px

Supersedes #18013.