### PR TITLE
⏪️ revert(agent): remove root layout direction workaround

### DIFF
--- a/src/routes/(main)/agent/_layout/index.test.tsx
+++ b/src/routes/(main)/agent/_layout/index.test.tsx
@@ -8,18 +8,8 @@ import { describe, expect, it, vi } from 'vitest';
 import Layout from './index';
 
 vi.mock('@lobehub/ui', () => ({
-  Flexbox: ({
-    children,
-    direction,
-    ...props
-  }: {
-    children?: ReactNode;
-    direction?: 'horizontal' | 'vertical';
-    [key: string]: unknown;
-  }) => (
-    <div {...props} style={{ flexDirection: direction === 'vertical' ? 'column' : direction }}>
-      {children}
-    </div>
+  Flexbox: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
+    <div {...props}>{children}</div>
   ),
   ShikiLobeTheme: {},
 }));
@@ -51,14 +41,6 @@ describe('Agent layout', () => {
 
     expect(screen.getByTestId('agent-layout-sidebar')).toBeInTheDocument();
     expect(screen.getByTestId('agent-layout-outlet')).toBeInTheDocument();
-  });
-
-  it('keeps routed content in a vertical layout', () => {
-    render(<Layout />);
-
-    expect(screen.getByTestId('agent-layout-outlet').parentElement).toHaveStyle({
-      flexDirection: 'column',
-    });
   });
 
   it('mounts AgentIdSync in layout', () => {

--- a/src/routes/(main)/agent/_layout/index.tsx
+++ b/src/routes/(main)/agent/_layout/index.tsx
@@ -19,7 +19,7 @@ const Layout: FC = () => {
   return (
     <>
       <AgentSidebar />
-      <Flexbox className={styles.mainContainer} direction="vertical" flex={1} height={'100%'}>
+      <Flexbox className={styles.mainContainer} flex={1} height={'100%'}>
         {/* Keep the sidebar interactive when the routed agent is gone (deleted
             or made private) — only the content area collapses to the 404 card. */}
         <AgentNotFoundGuard>


### PR DESCRIPTION
Reverts the app-level Flexbox direction workaround introduced by #18013.

The underlying issue is fixed at the component boundary in lobehub/lobe-ui#600: stable DraggablePanel layout now sizes the fixed aside on the axis appropriate to its placement. The route-level direction override is therefore no longer required.

@lobehub/ui@5.29.1 is published and contains the upstream fix.

| Before | After |
| ------ | ----- |
| Agent route forces a vertical Flexbox direction to compensate for DraggablePanel | Agent route uses the Flexbox default; DraggablePanel owns placement-aware stable sizing |

#### Test

- [x] Tested locally with the built lobe-ui package in Electron: collapsed 885/0, expanded 564/321, collapsed again 885/0
- [x] Verified the published @lobehub/ui@5.29.1 tarball contains the placement-aware fixed-axis logic
- [x] bun run check --lint --test for the two changed agent layout files (2 tests passed)
- [x] Revert diff passes git diff --check

#### 🔗 Related Issue

- Reverts #18013
- Superseded by lobehub/lobe-ui#600