### PR TITLE
💄 style(agent): collapse Codex reset credits and hide model-specific quotas

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/CodexQuotaMenu.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/CodexQuotaMenu.tsx
@@ -4,10 +4,9 @@ import type {
   CodexQuotaSnapshot,
   CodexQuotaWindow,
   CodexRateLimitResetCredit,
-  CodexRateLimitSnapshot,
 } from '@lobechat/electron-client-ipc';
 import { uuid } from '@lobechat/utils';
-import { Flexbox, Icon, Text } from '@lobehub/ui';
+import { Collapse, Flexbox, Icon, Text } from '@lobehub/ui';
 import { Button, confirmModal, toast } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { RotateCcwIcon } from 'lucide-react';
@@ -33,6 +32,9 @@ const styles = createStaticStyles(({ css }) => ({
     &:not(:last-child) {
       border-block-end: 1px solid ${cssVar.colorBorderSecondary};
     }
+  `,
+  creditCollapse: css`
+    width: 100%;
   `,
   creditExpiry: css`
     flex: none;
@@ -171,19 +173,13 @@ const CodexQuotaMenu = memo<CodexQuotaMenuProps>(({ command, env }) => {
     [t],
   );
 
-  const getRateLimitWindowLabel = useCallback(
-    (rateLimit: CodexRateLimitSnapshot, window: CodexQuotaWindow, fallback: string) => {
-      const windowLabel = getWindowLabel(window, fallback);
-      if (rateLimit.limitId.toLowerCase() === 'codex') return windowLabel;
-
-      return `${rateLimit.limitName || rateLimit.limitId} · ${windowLabel}`;
-    },
-    [getWindowLabel],
-  );
-
   const getWindows = useCallback(
     (quota: CodexQuotaSnapshot): QuotaWindowItem[] => {
-      if (!quota.rateLimits?.length) {
+      const rateLimit = quota.rateLimits?.find(
+        (rateLimit) => rateLimit.limitId.toLowerCase() === 'codex',
+      );
+
+      if (!rateLimit) {
         return [
           {
             key: 'primary',
@@ -198,37 +194,20 @@ const CodexQuotaMenu = memo<CodexQuotaMenuProps>(({ command, env }) => {
         ];
       }
 
-      return quota.rateLimits.flatMap((rateLimit) => {
-        const windows: QuotaWindowItem[] = [];
-
-        if (rateLimit.primary) {
-          windows.push({
-            key: `${rateLimit.limitId}:primary`,
-            label: getRateLimitWindowLabel(
-              rateLimit,
-              rateLimit.primary,
-              t('heteroAgent.quota.session'),
-            ),
-            window: rateLimit.primary,
-          });
-        }
-
-        if (rateLimit.secondary) {
-          windows.push({
-            key: `${rateLimit.limitId}:secondary`,
-            label: getRateLimitWindowLabel(
-              rateLimit,
-              rateLimit.secondary,
-              t('heteroAgent.quota.weekly'),
-            ),
-            window: rateLimit.secondary,
-          });
-        }
-
-        return windows;
-      });
+      return [
+        {
+          key: `${rateLimit.limitId}:primary`,
+          label: getWindowLabel(rateLimit.primary, t('heteroAgent.quota.session')),
+          window: rateLimit.primary,
+        },
+        {
+          key: `${rateLimit.limitId}:secondary`,
+          label: getWindowLabel(rateLimit.secondary, t('heteroAgent.quota.weekly')),
+          window: rateLimit.secondary,
+        },
+      ];
     },
-    [getRateLimitWindowLabel, getWindowLabel, t],
+    [getWindowLabel, t],
   );
 
   const hasExtraData = useCallback(
@@ -349,84 +328,109 @@ const CodexQuotaMenu = memo<CodexQuotaMenuProps>(({ command, env }) => {
       }));
 
       return (
-        <Flexbox className={styles.resetCredits} gap={8}>
-          <Flexbox gap={2}>
-            <Flexbox horizontal align={'center'} gap={4}>
-              <Icon icon={RotateCcwIcon} size={14} />
-              <Text strong style={{ fontSize: 12 }}>
-                {t('heteroAgent.codexQuota.resetCredits', { count: resetCreditCount })}
-              </Text>
-            </Flexbox>
-            {resetCredits.totalEarnedCount !== undefined && (
-              <Text color={cssVar.colorTextTertiary} style={{ fontSize: 12 }}>
-                {t('heteroAgent.codexQuota.totalEarned', {
-                  count: resetCredits.totalEarnedCount,
-                })}
-              </Text>
-            )}
-          </Flexbox>
+        <Flexbox className={styles.resetCredits}>
+          <Collapse
+            className={styles.creditCollapse}
+            collapsible={resetCreditCount > 0 || !!resetFeedback}
+            defaultActiveKey={[]}
+            expandIconPlacement={'end'}
+            padding={0}
+            variant={'borderless'}
+            items={[
+              {
+                children: (
+                  <Flexbox gap={8}>
+                    {resetCreditItems.length > 0 && (
+                      <Flexbox className={styles.creditList}>
+                        {resetCreditItems.map(({ credit, index }) => {
+                          const fallbackExpiry =
+                            index === 1 ? resetCredits.nextExpiresAt : undefined;
+                          const expiresAt = credit ? credit.expiresAt : fallbackExpiry;
+                          const expiresIn = expiresAt ? formatDuration(expiresAt - now) : undefined;
 
-          {resetCreditItems.length > 0 && (
-            <Flexbox className={styles.creditList}>
-              {resetCreditItems.map(({ credit, index }) => {
-                const fallbackExpiry = index === 1 ? resetCredits.nextExpiresAt : undefined;
-                const expiresAt = credit ? credit.expiresAt : fallbackExpiry;
-                const expiresIn = expiresAt ? formatDuration(expiresAt - now) : undefined;
+                          return (
+                            <Flexbox
+                              horizontal
+                              align={'center'}
+                              className={styles.credit}
+                              gap={8}
+                              key={credit?.id ?? `reset-credit-${index}`}
+                            >
+                              <Text className={styles.creditIndex} style={{ fontSize: 12 }}>
+                                {`#${index}`}
+                              </Text>
+                              <Text strong className={styles.creditTitle} style={{ fontSize: 12 }}>
+                                {credit?.title || t('heteroAgent.codexQuota.resetCreditTitle')}
+                              </Text>
+                              <Text
+                                className={styles.creditExpiry}
+                                style={{ fontSize: 12 }}
+                                type="secondary"
+                              >
+                                {expiresAt
+                                  ? expiresIn
+                                    ? t('heteroAgent.codexQuota.expiresIn', {
+                                        duration: expiresIn,
+                                      })
+                                    : t('heteroAgent.codexQuota.expiresSoon')
+                                  : credit
+                                    ? t('heteroAgent.codexQuota.doesNotExpire')
+                                    : t('heteroAgent.codexQuota.resetCreditDetailsUnavailable')}
+                              </Text>
+                            </Flexbox>
+                          );
+                        })}
+                      </Flexbox>
+                    )}
 
-                return (
-                  <Flexbox
-                    horizontal
-                    align={'center'}
-                    className={styles.credit}
-                    gap={8}
-                    key={credit?.id ?? `reset-credit-${index}`}
-                  >
-                    <Text className={styles.creditIndex} style={{ fontSize: 12 }}>
-                      {`#${index}`}
-                    </Text>
-                    <Text strong className={styles.creditTitle} style={{ fontSize: 12 }}>
-                      {credit?.title || t('heteroAgent.codexQuota.resetCreditTitle')}
-                    </Text>
-                    <Text className={styles.creditExpiry} style={{ fontSize: 12 }} type="secondary">
-                      {expiresAt
-                        ? expiresIn
-                          ? t('heteroAgent.codexQuota.expiresIn', { duration: expiresIn })
-                          : t('heteroAgent.codexQuota.expiresSoon')
-                        : credit
-                          ? t('heteroAgent.codexQuota.doesNotExpire')
-                          : t('heteroAgent.codexQuota.resetCreditDetailsUnavailable')}
-                    </Text>
+                    {resetFeedback && (
+                      <div
+                        aria-live="polite"
+                        className={styles.feedback}
+                        data-kind={resetFeedback.kind}
+                        role={resetFeedback.kind === 'error' ? 'alert' : 'status'}
+                      >
+                        {resetFeedback.text}
+                      </div>
+                    )}
+
+                    {resetCreditCount > 0 && (
+                      <Button
+                        block
+                        icon={RotateCcwIcon}
+                        loading={resetting}
+                        size={'small'}
+                        type={'primary'}
+                        onClick={() => confirmReset(nextCredit?.id ?? undefined, applyQuota)}
+                      >
+                        {resetting
+                          ? t('heteroAgent.codexQuota.resetting')
+                          : t('heteroAgent.codexQuota.resetNow')}
+                      </Button>
+                    )}
                   </Flexbox>
-                );
-              })}
-            </Flexbox>
-          )}
-
-          {resetFeedback && (
-            <div
-              aria-live="polite"
-              className={styles.feedback}
-              data-kind={resetFeedback.kind}
-              role={resetFeedback.kind === 'error' ? 'alert' : 'status'}
-            >
-              {resetFeedback.text}
-            </div>
-          )}
-
-          {resetCreditCount > 0 && (
-            <Button
-              block
-              icon={RotateCcwIcon}
-              loading={resetting}
-              size={'small'}
-              type={'primary'}
-              onClick={() => confirmReset(nextCredit?.id ?? undefined, applyQuota)}
-            >
-              {resetting
-                ? t('heteroAgent.codexQuota.resetting')
-                : t('heteroAgent.codexQuota.resetNow')}
-            </Button>
-          )}
+                ),
+                key: 'reset-credits',
+                label: (
+                  <Flexbox gap={2}>
+                    <Flexbox horizontal align={'center'} gap={4}>
+                      <Icon icon={RotateCcwIcon} size={14} />
+                      <Text strong style={{ fontSize: 12 }}>
+                        {t('heteroAgent.codexQuota.resetCredits', { count: resetCreditCount })}
+                      </Text>
+                    </Flexbox>
+                    {resetCredits.totalEarnedCount !== undefined && (
+                      <Text color={cssVar.colorTextTertiary} style={{ fontSize: 12 }}>
+                        {t('heteroAgent.codexQuota.totalEarned', {
+                          count: resetCredits.totalEarnedCount,
+                        })}
+                      </Text>
+                    )}
+                  </Flexbox>
+                ),
+              },
+            ]}
+          />
         </Flexbox>
       );
     },

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/QuotaMenu.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/QuotaMenu.test.tsx
@@ -131,36 +131,70 @@ vi.mock('antd-style', async (importOriginal) => {
   };
 });
 
-vi.mock('@lobehub/ui', () => ({
-  ActionIcon: ({ disabled, onClick }: { disabled?: boolean; onClick?: () => void }) => (
-    <button data-testid="refresh" disabled={disabled} type="button" onClick={onClick} />
-  ),
-  Flexbox: ({ children, className }: { children?: ReactNode; className?: string }) => (
-    <div className={className}>{children}</div>
-  ),
-  Icon: () => <svg />,
-  // Render the popover content unconditionally so window rows are assertable
-  // without driving the open/close interaction.
-  Popover: ({
-    children,
-    content,
-    onOpenChange,
-  }: {
-    children?: ReactNode;
-    content?: ReactNode;
-    onOpenChange?: (open: boolean) => void;
-  }) => (
-    <div>
-      <div data-testid="popover-content">{content}</div>
-      <div data-testid="quota-trigger" onClick={() => onOpenChange?.(true)}>
-        {children}
+vi.mock('@lobehub/ui', async () => {
+  const { useState } = await import('react');
+
+  return {
+    ActionIcon: ({ disabled, onClick }: { disabled?: boolean; onClick?: () => void }) => (
+      <button data-testid="refresh" disabled={disabled} type="button" onClick={onClick} />
+    ),
+    Collapse: ({
+      defaultActiveKey = [],
+      items,
+    }: {
+      defaultActiveKey?: string[];
+      items: { children?: ReactNode; key: string; label?: ReactNode }[];
+    }) => {
+      const [activeKeys, setActiveKeys] = useState(defaultActiveKey);
+
+      return (
+        <div>
+          {items.map((item) => {
+            const expanded = activeKeys.includes(item.key);
+
+            return (
+              <div key={item.key}>
+                <button
+                  aria-expanded={expanded}
+                  type="button"
+                  onClick={() => setActiveKeys(expanded ? [] : [item.key])}
+                >
+                  {item.label}
+                </button>
+                {expanded && item.children}
+              </div>
+            );
+          })}
+        </div>
+      );
+    },
+    Flexbox: ({ children, className }: { children?: ReactNode; className?: string }) => (
+      <div className={className}>{children}</div>
+    ),
+    Icon: () => <svg />,
+    // Render the popover content unconditionally so window rows are assertable
+    // without driving the open/close interaction.
+    Popover: ({
+      children,
+      content,
+      onOpenChange,
+    }: {
+      children?: ReactNode;
+      content?: ReactNode;
+      onOpenChange?: (open: boolean) => void;
+    }) => (
+      <div>
+        <div data-testid="popover-content">{content}</div>
+        <div data-testid="quota-trigger" onClick={() => onOpenChange?.(true)}>
+          {children}
+        </div>
       </div>
-    </div>
-  ),
-  Skeleton: { Button: () => <div data-testid="skeleton" /> },
-  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
-  Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
-}));
+    ),
+    Skeleton: { Button: () => <div data-testid="skeleton" /> },
+    Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+    Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  };
+});
 
 vi.mock('@lobehub/ui/base-ui', () => ({
   Button: ({
@@ -915,7 +949,12 @@ describe('CodexQuotaMenu', () => {
     expect(
       screen.getAllByText((content) => content.startsWith('heteroAgent.quota.duration.')),
     ).toHaveLength(2);
-    expect(screen.getByText('heteroAgent.codexQuota.resetCredits:4')).toBeTruthy();
+    const resetCreditsSummary = screen.getByText('heteroAgent.codexQuota.resetCredits:4');
+    expect(resetCreditsSummary.closest('button')?.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByText('#1')).toBeNull();
+
+    fireEvent.click(resetCreditsSummary);
+
     expect(screen.getByText('#1')).toBeTruthy();
     expect(screen.getByText('#2')).toBeTruthy();
     expect(screen.getByText('#3')).toBeTruthy();
@@ -934,7 +973,7 @@ describe('CodexQuotaMenu', () => {
     });
   });
 
-  it('renders every Codex rate-limit bucket and uses the tightest window in the trigger', async () => {
+  it('hides model-specific rate-limit buckets and excludes them from the trigger', async () => {
     mockService.getCodexQuota.mockResolvedValue(
       codexSnapshot({
         rateLimits: [
@@ -958,15 +997,15 @@ describe('CodexQuotaMenu', () => {
 
     render(<CodexQuotaMenu />);
 
-    expect(await screen.findByText('heteroAgent.quota.compactLeft:2')).toBeTruthy();
+    expect(await screen.findByText('heteroAgent.quota.compactLeft:80')).toBeTruthy();
     expect(screen.getByText('heteroAgent.codexQuota.fiveHour')).toBeTruthy();
     expect(screen.getByText('heteroAgent.quota.weekly')).toBeTruthy();
-    expect(screen.getByText('Codex Other · heteroAgent.quota.session')).toBeTruthy();
-    expect(screen.getByText('Codex Other · heteroAgent.codexQuota.monthly')).toBeTruthy();
+    expect(screen.queryByText('Codex Other · heteroAgent.quota.session')).toBeNull();
+    expect(screen.queryByText('Codex Other · heteroAgent.codexQuota.monthly')).toBeNull();
     expect(screen.getByText('90%')).toBeTruthy();
     expect(screen.getByText('80%')).toBeTruthy();
-    expect(screen.getByText('2%')).toBeTruthy();
-    expect(screen.getByText('60%')).toBeTruthy();
+    expect(screen.queryByText('2%')).toBeNull();
+    expect(screen.queryByText('60%')).toBeNull();
   });
 
   it('renders the credits-unavailable footer when the RPC omits credits', async () => {
@@ -1011,6 +1050,8 @@ describe('CodexQuotaMenu', () => {
     );
 
     render(<CodexQuotaMenu />);
+
+    fireEvent.click(await screen.findByText('heteroAgent.codexQuota.resetCredits:3'));
 
     expect(await screen.findByText('Early reset')).toBeTruthy();
     expect(screen.getByText('Weekly rescue')).toBeTruthy();
@@ -1070,6 +1111,7 @@ describe('CodexQuotaMenu', () => {
 
     render(<CodexQuotaMenu command="codex" env={{ CODEX_HOME: '/custom' }} />);
 
+    fireEvent.click(await screen.findByText('heteroAgent.codexQuota.resetCredits:2'));
     fireEvent.click(await screen.findByRole('button', { name: 'heteroAgent.codexQuota.resetNow' }));
     expect(confirmModalMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1121,6 +1163,7 @@ describe('CodexQuotaMenu', () => {
     render(<CodexQuotaMenu />);
 
     expect(await screen.findByText('4%')).toBeTruthy();
+    fireEvent.click(screen.getByText('heteroAgent.codexQuota.resetCredits:1'));
 
     fireEvent.click(screen.getByTestId('refresh'));
 


### PR DESCRIPTION
<!-- Brief and heads-up -->

Compact the Codex quota panel: only show the main Codex rate-limit windows (hide model-specific buckets), and fold reset credits into a collapsed section by default.

<!-- If this PR includes UI changes, please provide screenshots or videos. -->

| Before | After |
| ------ | ----- |
| All rate-limit buckets (including model-specific) expanded; reset credits always open | Only main Codex windows; reset credits collapsed until expanded |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check --test` on the QuotaMenu files — 35 tests passed.

#### 🔗 Related Issue

N/A