### PR TITLE
✨ feat(hetero-agent): render OpenCode and Pi file/shell tool surfaces

### DIFF
--- a/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/buildReadFileState.test.ts
+++ b/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/buildReadFileState.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildReadFileState } from './buildReadFileState';
+
+describe('buildReadFileState', () => {
+  it('keeps the card for a successful builtin read of an empty file', () => {
+    const state = buildReadFileState({
+      args: { path: '/repo/empty.txt' },
+      identifier: 'lobe-local-system',
+      parsedContent: { content: '' },
+      pluginState: { charCount: 0, content: '', fileType: 'txt', path: '/repo/empty.txt' },
+    });
+
+    expect(state).toMatchObject({ charCount: 0, content: '', path: '/repo/empty.txt' });
+  });
+
+  it('keeps the card for an OpenCode empty-file read confirmed by the envelope', () => {
+    const state = buildReadFileState({
+      args: { filePath: '/repo/empty.txt' },
+      identifier: 'opencode',
+      parsedContent: { content: '', hasEnvelope: true },
+    });
+
+    expect(state).toMatchObject({ charCount: 0, content: '', path: '/repo/empty.txt' });
+  });
+
+  it('returns nothing for unconfirmed empty content', () => {
+    const state = buildReadFileState({
+      args: { filePath: '/repo/file.txt' },
+      identifier: 'opencode',
+      parsedContent: { content: '' },
+    });
+
+    expect(state).toBeUndefined();
+  });
+
+  it('returns nothing when the tool errored', () => {
+    const state = buildReadFileState({
+      args: { path: '/repo/file.txt' },
+      identifier: 'opencode',
+      parsedContent: { content: 'boom', hasEnvelope: true },
+      pluginError: new Error('boom'),
+    });
+
+    expect(state).toBeUndefined();
+  });
+
+  it('falls back to raw content only for heterogeneous CLI identifiers', () => {
+    const fromPi = buildReadFileState({
+      args: { file_path: '/repo/file.ts' },
+      identifier: 'pi',
+      parsedContent: { content: 'const a = 1;' },
+    });
+    const fromBuiltin = buildReadFileState({
+      args: { path: '/repo/file.ts' },
+      identifier: 'lobe-local-system',
+      parsedContent: { content: 'const a = 1;' },
+    });
+
+    expect(fromPi).toMatchObject({ content: 'const a = 1;', fileType: 'ts' });
+    expect(fromBuiltin).toBeUndefined();
+  });
+
+  it('derives loc from offset and limit args', () => {
+    const state = buildReadFileState({
+      args: { limit: 10, offset: 5, path: '/repo/file.ts' },
+      identifier: 'opencode',
+      parsedContent: { content: 'line', hasEnvelope: true },
+    });
+
+    expect(state?.loc).toEqual([5, 14]);
+  });
+});

--- a/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/buildReadFileState.ts
+++ b/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/buildReadFileState.ts
@@ -1,0 +1,64 @@
+import type { ReadFileState } from '@lobechat/tool-runtime';
+import path from 'path-browserify-esm';
+
+export interface ReadFileArgs {
+  file_path?: string;
+  filePath?: string;
+  limit?: number;
+  offset?: number;
+  path?: string;
+}
+
+interface BuildReadFileStateInput {
+  args?: ReadFileArgs;
+  identifier?: string;
+  parsedContent: { content: string; hasEnvelope?: boolean; path?: string };
+  pluginError?: unknown;
+  pluginState?: Partial<ReadFileState>;
+}
+
+export const buildReadFileState = ({
+  args,
+  identifier,
+  parsedContent,
+  pluginError,
+  pluginState,
+}: BuildReadFileStateInput): ReadFileState | undefined => {
+  if (pluginError) return;
+
+  const filePath =
+    args?.path ||
+    args?.filePath ||
+    args?.file_path ||
+    pluginState?.path ||
+    parsedContent.path ||
+    '';
+  if (!filePath) return;
+
+  const canUseContentFallback = identifier === 'opencode' || identifier === 'pi';
+  const text = pluginState?.content ?? (canUseContentFallback ? parsedContent.content : '');
+  const images = pluginState?.images;
+  // An empty file is still a successful read: keep the card when the builtin
+  // tool reported a state, or when the OpenCode envelope confirms completion.
+  const isConfirmedRead = !!pluginState || parsedContent.hasEnvelope === true;
+  if (!isConfirmedRead && !text && !images?.length) return;
+
+  const startLine = args?.offset ?? pluginState?.startLine ?? pluginState?.loc?.[0];
+  const endLine =
+    pluginState?.endLine ??
+    pluginState?.loc?.[1] ??
+    (startLine !== undefined && args?.limit !== undefined
+      ? startLine + Math.max(args.limit - 1, 0)
+      : undefined);
+
+  return {
+    ...pluginState,
+    charCount: pluginState?.charCount ?? text.length,
+    content: text,
+    fileType: pluginState?.fileType ?? path.extname(filePath).slice(1).toLowerCase(),
+    loc:
+      pluginState?.loc ??
+      (startLine !== undefined && endLine !== undefined ? [startLine, endLine] : undefined),
+    path: filePath,
+  };
+};

--- a/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/index.tsx
+++ b/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/index.tsx
@@ -1,23 +1,82 @@
 import { useToolRenderCapabilities } from '@lobechat/shared-tool-ui';
 import type { ReadFileState } from '@lobechat/tool-runtime';
 import type { BuiltinRenderProps } from '@lobechat/types';
-import { memo } from 'react';
+import path from 'path-browserify-esm';
+import { memo, useMemo } from 'react';
 
+import { parseOpenCodeReadContent } from './parseReadContent';
 import ReadFileSkeleton from './ReadFileSkeleton';
 import ReadFileView from './ReadFileView';
 
-const ReadFileQuery = memo<BuiltinRenderProps<{ path: string }, ReadFileState>>(
-  ({ args, pluginState, messageId }) => {
+interface ReadFileArgs {
+  file_path?: string;
+  filePath?: string;
+  limit?: number;
+  offset?: number;
+  path?: string;
+}
+
+const ReadFileQuery = memo<BuiltinRenderProps<ReadFileArgs, Partial<ReadFileState>, string>>(
+  ({ args, content, identifier, messageId, pluginError, pluginState }) => {
     const { isLoading } = useToolRenderCapabilities();
     const loading = isLoading?.(messageId);
+    const parsedContent = useMemo(
+      () =>
+        identifier === 'opencode'
+          ? parseOpenCodeReadContent(content || '')
+          : { content: content || '' },
+      [content, identifier],
+    );
+    const filePath =
+      args?.path ||
+      args?.filePath ||
+      args?.file_path ||
+      pluginState?.path ||
+      parsedContent.path ||
+      '';
+    const readState = useMemo<ReadFileState | undefined>(() => {
+      if (pluginError) return;
+
+      const canUseContentFallback = identifier === 'opencode' || identifier === 'pi';
+      const text = pluginState?.content ?? (canUseContentFallback ? parsedContent.content : '');
+      const images = pluginState?.images;
+      if (!filePath || (!text && !images?.length)) return;
+
+      const startLine = args?.offset ?? pluginState?.startLine ?? pluginState?.loc?.[0];
+      const endLine =
+        pluginState?.endLine ??
+        pluginState?.loc?.[1] ??
+        (startLine !== undefined && args?.limit !== undefined
+          ? startLine + Math.max(args.limit - 1, 0)
+          : undefined);
+
+      return {
+        ...pluginState,
+        charCount: pluginState?.charCount ?? text.length,
+        content: text,
+        fileType: pluginState?.fileType ?? path.extname(filePath).slice(1).toLowerCase(),
+        loc:
+          pluginState?.loc ??
+          (startLine !== undefined && endLine !== undefined ? [startLine, endLine] : undefined),
+        path: filePath,
+      };
+    }, [
+      args?.limit,
+      args?.offset,
+      filePath,
+      identifier,
+      parsedContent.content,
+      pluginError,
+      pluginState,
+    ]);
 
     if (loading) {
       return <ReadFileSkeleton />;
     }
 
-    if (!args?.path || !pluginState) return null;
+    if (!readState) return null;
 
-    return <ReadFileView {...pluginState} path={args.path} />;
+    return <ReadFileView {...readState} />;
   },
 );
 

--- a/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/index.tsx
+++ b/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/index.tsx
@@ -1,20 +1,13 @@
 import { useToolRenderCapabilities } from '@lobechat/shared-tool-ui';
 import type { ReadFileState } from '@lobechat/tool-runtime';
 import type { BuiltinRenderProps } from '@lobechat/types';
-import path from 'path-browserify-esm';
 import { memo, useMemo } from 'react';
 
+import type { ReadFileArgs } from './buildReadFileState';
+import { buildReadFileState } from './buildReadFileState';
 import { parseOpenCodeReadContent } from './parseReadContent';
 import ReadFileSkeleton from './ReadFileSkeleton';
 import ReadFileView from './ReadFileView';
-
-interface ReadFileArgs {
-  file_path?: string;
-  filePath?: string;
-  limit?: number;
-  offset?: number;
-  path?: string;
-}
 
 const ReadFileQuery = memo<BuiltinRenderProps<ReadFileArgs, Partial<ReadFileState>, string>>(
   ({ args, content, identifier, messageId, pluginError, pluginState }) => {
@@ -27,48 +20,10 @@ const ReadFileQuery = memo<BuiltinRenderProps<ReadFileArgs, Partial<ReadFileStat
           : { content: content || '' },
       [content, identifier],
     );
-    const filePath =
-      args?.path ||
-      args?.filePath ||
-      args?.file_path ||
-      pluginState?.path ||
-      parsedContent.path ||
-      '';
-    const readState = useMemo<ReadFileState | undefined>(() => {
-      if (pluginError) return;
-
-      const canUseContentFallback = identifier === 'opencode' || identifier === 'pi';
-      const text = pluginState?.content ?? (canUseContentFallback ? parsedContent.content : '');
-      const images = pluginState?.images;
-      if (!filePath || (!text && !images?.length)) return;
-
-      const startLine = args?.offset ?? pluginState?.startLine ?? pluginState?.loc?.[0];
-      const endLine =
-        pluginState?.endLine ??
-        pluginState?.loc?.[1] ??
-        (startLine !== undefined && args?.limit !== undefined
-          ? startLine + Math.max(args.limit - 1, 0)
-          : undefined);
-
-      return {
-        ...pluginState,
-        charCount: pluginState?.charCount ?? text.length,
-        content: text,
-        fileType: pluginState?.fileType ?? path.extname(filePath).slice(1).toLowerCase(),
-        loc:
-          pluginState?.loc ??
-          (startLine !== undefined && endLine !== undefined ? [startLine, endLine] : undefined),
-        path: filePath,
-      };
-    }, [
-      args?.limit,
-      args?.offset,
-      filePath,
-      identifier,
-      parsedContent.content,
-      pluginError,
-      pluginState,
-    ]);
+    const readState = useMemo<ReadFileState | undefined>(
+      () => buildReadFileState({ args, identifier, parsedContent, pluginError, pluginState }),
+      [args, identifier, parsedContent, pluginError, pluginState],
+    );
 
     if (loading) {
       return <ReadFileSkeleton />;

--- a/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/parseReadContent.test.ts
+++ b/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/parseReadContent.test.ts
@@ -16,6 +16,7 @@ describe('parseOpenCodeReadContent', () => {
 
     expect(result).toEqual({
       content: 'const value = 1;\n\nexport default value;',
+      hasEnvelope: true,
       path: '/repo/src/index.ts',
     });
   });
@@ -32,13 +33,50 @@ describe('parseOpenCodeReadContent', () => {
     expect(result.content).toBe('first\nsecond');
   });
 
+  it('returns empty content for a marker-only payload from an empty file', () => {
+    const result = parseOpenCodeReadContent(`<path>/repo/empty.txt</path>
+<content>
+(End of file - total 0 lines)
+</content>`);
+
+    expect(result).toEqual({ content: '', hasEnvelope: true, path: '/repo/empty.txt' });
+  });
+
+  it('returns empty content for a marker-only continuation payload', () => {
+    const result = parseOpenCodeReadContent(`<content>
+(Showing lines 50-50 of 10. Use offset=1 to continue.)
+</content>`);
+
+    expect(result.content).toBe('');
+  });
+
+  it('keeps a literal </content> inside the file body', () => {
+    const result = parseOpenCodeReadContent(`<path>/repo/envelope.xml</path>
+<content>
+1: <content>inner</content>
+2: tail line
+
+(End of file - total 2 lines)
+</content>`);
+
+    expect(result).toEqual({
+      content: '<content>inner</content>\ntail line',
+      hasEnvelope: true,
+      path: '/repo/envelope.xml',
+    });
+  });
+
   it('preserves unnumbered content that contains a numeric-colon line', () => {
     const result = parseOpenCodeReadContent(`<content>
 42: this is file content
 plain line
 </content>`);
 
-    expect(result).toEqual({ content: '42: this is file content\nplain line', path: undefined });
+    expect(result).toEqual({
+      content: '42: this is file content\nplain line',
+      hasEnvelope: true,
+      path: undefined,
+    });
   });
 
   it('does not treat a path tag inside the file body as header metadata', () => {
@@ -49,6 +87,7 @@ plain line
 
     expect(result).toEqual({
       content: 'plain line\n<path>/not/metadata</path>',
+      hasEnvelope: true,
       path: undefined,
     });
   });

--- a/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/parseReadContent.test.ts
+++ b/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/parseReadContent.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseOpenCodeReadContent } from './parseReadContent';
+
+describe('parseOpenCodeReadContent', () => {
+  it('extracts the header path and strips OpenCode line numbers and the end marker', () => {
+    const result = parseOpenCodeReadContent(`<path>/repo/src/index.ts</path>
+<type>file</type>
+<content>
+1: const value = 1;
+2:
+3: export default value;
+
+(End of file - total 3 lines)
+</content>`);
+
+    expect(result).toEqual({
+      content: 'const value = 1;\n\nexport default value;',
+      path: '/repo/src/index.ts',
+    });
+  });
+
+  it('removes a continuation marker from a partial read', () => {
+    const result = parseOpenCodeReadContent(`<path>/repo/large.txt</path>
+<content>
+20: first
+21: second
+
+(Showing lines 20-21 of 100. Use offset=22 to continue.)
+</content>`);
+
+    expect(result.content).toBe('first\nsecond');
+  });
+
+  it('preserves unnumbered content that contains a numeric-colon line', () => {
+    const result = parseOpenCodeReadContent(`<content>
+42: this is file content
+plain line
+</content>`);
+
+    expect(result).toEqual({ content: '42: this is file content\nplain line', path: undefined });
+  });
+
+  it('does not treat a path tag inside the file body as header metadata', () => {
+    const result = parseOpenCodeReadContent(`<content>
+plain line
+<path>/not/metadata</path>
+</content>`);
+
+    expect(result).toEqual({
+      content: 'plain line\n<path>/not/metadata</path>',
+      path: undefined,
+    });
+  });
+
+  it('leaves content without a complete OpenCode envelope unchanged', () => {
+    expect(parseOpenCodeReadContent('raw file content')).toEqual({ content: 'raw file content' });
+    expect(parseOpenCodeReadContent('<content>unterminated')).toEqual({
+      content: '<content>unterminated',
+    });
+  });
+});

--- a/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/parseReadContent.ts
+++ b/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/parseReadContent.ts
@@ -1,14 +1,19 @@
 interface ParsedReadContent {
   content: string;
+  /** Whether a complete OpenCode `<content>` envelope was found and unwrapped. */
+  hasEnvelope?: boolean;
   path?: string;
 }
 
 const LINE_NUMBER_PREFIX = /^\s*\d+:\s?/;
+const READ_MARKER_AT_START = /^\((?:End of file|Showing lines)/;
 
 export const parseOpenCodeReadContent = (content: string): ParsedReadContent => {
   const contentStart = content.indexOf('<content>');
-  const contentEnd = content.indexOf('</content>', contentStart);
-  if (contentStart < 0 || contentEnd < 0) return { content };
+  // Resolve the closing tag from the end: the file body itself may contain a
+  // literal `</content>` (XML/HTML sources, code handling this envelope).
+  const contentEnd = content.lastIndexOf('</content>');
+  if (contentStart < 0 || contentEnd < contentStart + '<content>'.length) return { content };
 
   const header = content.slice(0, contentStart);
   const pathStart = header.indexOf('<path>');
@@ -20,7 +25,11 @@ export const parseOpenCodeReadContent = (content: string): ParsedReadContent => 
   const wrappedContent = content.slice(contentStart + '<content>'.length, contentEnd).trim();
   const endMarker = wrappedContent.lastIndexOf('\n(End of file');
   const continuationMarker = wrappedContent.lastIndexOf('\n(Showing lines');
-  const markerStart = Math.max(endMarker, continuationMarker);
+  // An empty file (or an offset past EOF) produces a marker-only payload with
+  // no leading newline, so also match a marker at the very start.
+  const markerStart = READ_MARKER_AT_START.test(wrappedContent)
+    ? 0
+    : Math.max(endMarker, continuationMarker);
   const contentWithoutMarker = (
     markerStart >= 0 ? wrappedContent.slice(0, markerStart) : wrappedContent
   ).trimEnd();
@@ -34,6 +43,7 @@ export const parseOpenCodeReadContent = (content: string): ParsedReadContent => 
 
   return {
     content: normalized,
+    hasEnvelope: true,
     path: filePath,
   };
 };

--- a/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/parseReadContent.ts
+++ b/packages/builtin-tool-local-system/src/client/Render/ReadLocalFile/parseReadContent.ts
@@ -1,0 +1,39 @@
+interface ParsedReadContent {
+  content: string;
+  path?: string;
+}
+
+const LINE_NUMBER_PREFIX = /^\s*\d+:\s?/;
+
+export const parseOpenCodeReadContent = (content: string): ParsedReadContent => {
+  const contentStart = content.indexOf('<content>');
+  const contentEnd = content.indexOf('</content>', contentStart);
+  if (contentStart < 0 || contentEnd < 0) return { content };
+
+  const header = content.slice(0, contentStart);
+  const pathStart = header.indexOf('<path>');
+  const pathEnd = header.indexOf('</path>', pathStart);
+  const filePath =
+    pathStart >= 0 && pathEnd >= 0
+      ? header.slice(pathStart + '<path>'.length, pathEnd).trim()
+      : undefined;
+  const wrappedContent = content.slice(contentStart + '<content>'.length, contentEnd).trim();
+  const endMarker = wrappedContent.lastIndexOf('\n(End of file');
+  const continuationMarker = wrappedContent.lastIndexOf('\n(Showing lines');
+  const markerStart = Math.max(endMarker, continuationMarker);
+  const contentWithoutMarker = (
+    markerStart >= 0 ? wrappedContent.slice(0, markerStart) : wrappedContent
+  ).trimEnd();
+  const lines = contentWithoutMarker.split('\n');
+  const nonEmptyLines = lines.filter((line) => line.trim().length > 0);
+  const hasLineNumbers =
+    nonEmptyLines.length > 0 && nonEmptyLines.every((line) => LINE_NUMBER_PREFIX.test(line));
+  const normalized = hasLineNumbers
+    ? lines.map((line) => line.replace(LINE_NUMBER_PREFIX, '')).join('\n')
+    : contentWithoutMarker;
+
+  return {
+    content: normalized,
+    path: filePath,
+  };
+};

--- a/packages/builtin-tool-local-system/src/client/Render/WriteFile/index.tsx
+++ b/packages/builtin-tool-local-system/src/client/Render/WriteFile/index.tsx
@@ -32,12 +32,18 @@ const buildNewFilePatch = (filePath: string, content: string) => {
     : `${header}${body}\n\\ No newline at end of file\n`;
 };
 
-const WriteFile = memo<BuiltinRenderProps<WriteLocalFileParams>>(({ args }) => {
+type WriteFileArgs = WriteLocalFileParams & {
+  file_path?: string;
+  filePath?: string;
+};
+
+const WriteFile = memo<BuiltinRenderProps<WriteFileArgs>>(({ args }) => {
   if (!args) return <Skeleton active />;
 
-  const { base, dir } = path.parse(args.path);
-  const ext = path.extname(args.path).slice(1).toLowerCase();
-  const isHtml = isHtmlFile({ path: args.path });
+  const filePath = args.path || args.filePath || args.file_path || '';
+  const { base, dir } = path.parse(filePath);
+  const ext = path.extname(filePath).slice(1).toLowerCase();
+  const isHtml = isHtmlFile({ path: filePath });
   const isMarkdown = ext === 'md' || ext === 'mdx';
 
   // Code-type files render as a "new file" unified diff so the visual is
@@ -48,7 +54,7 @@ const WriteFile = memo<BuiltinRenderProps<WriteLocalFileParams>>(({ args }) => {
       <PatchDiff
         fileName={base}
         language={ext || undefined}
-        patch={buildNewFilePatch(args.path, args.content)}
+        patch={buildNewFilePatch(filePath, args.content)}
         showHeader={false}
         variant={'borderless'}
         viewMode={'unified'}
@@ -61,7 +67,7 @@ const WriteFile = memo<BuiltinRenderProps<WriteLocalFileParams>>(({ args }) => {
       <Flexbox horizontal align={'center'}>
         <LocalFolder path={dir} />
         <Icon icon={ChevronRight} />
-        <LocalFile name={base} path={args.path} />
+        <LocalFile name={base} path={filePath} />
       </Flexbox>
 
       {args.content && (

--- a/packages/builtin-tool-local-system/src/client/Streaming/WriteFile/index.tsx
+++ b/packages/builtin-tool-local-system/src/client/Streaming/WriteFile/index.tsx
@@ -6,8 +6,14 @@ import { Highlighter, Markdown } from '@lobehub/ui';
 import path from 'path-browserify-esm';
 import { memo } from 'react';
 
-export const WriteFileStreaming = memo<BuiltinStreamingProps<WriteLocalFileParams>>(({ args }) => {
-  const { content, path: filePath } = args || {};
+type WriteFileArgs = WriteLocalFileParams & {
+  file_path?: string;
+  filePath?: string;
+};
+
+export const WriteFileStreaming = memo<BuiltinStreamingProps<WriteFileArgs>>(({ args }) => {
+  const content = args?.content;
+  const filePath = args?.path || args?.filePath || args?.file_path;
 
   // Don't render if no content yet
   if (!content) return null;

--- a/packages/builtin-tools/src/register.ts
+++ b/packages/builtin-tools/src/register.ts
@@ -151,6 +151,11 @@ import {
   WebOnboardingManifest,
   WebOnboardingRenders,
 } from '@lobechat/builtin-tool-web-onboarding/client';
+import {
+  createReadLocalFileInspector,
+  createRunCommandInspector,
+  createWriteLocalFileInspector,
+} from '@lobechat/shared-tool-ui/inspectors';
 import { RunCommandRender } from '@lobechat/shared-tool-ui/renders';
 import type {
   BuiltinInspector,
@@ -175,6 +180,31 @@ import { registerBuiltinStreamings } from './streamings';
 import { TwitterIdentifier, TwitterInspectors } from './twitter';
 
 const QODER_IDENTIFIER = 'qoder';
+const OPENCODE_IDENTIFIER = 'opencode';
+const PI_IDENTIFIER = 'pi';
+
+const heterogeneousCliInspectors: Record<string, BuiltinInspector> = {
+  bash: createRunCommandInspector(
+    'builtins.lobe-local-system.apiName.runCommand',
+  ) as BuiltinInspector,
+  read: createReadLocalFileInspector(
+    'builtins.lobe-local-system.apiName.readFile',
+  ) as BuiltinInspector,
+  write: createWriteLocalFileInspector(
+    'builtins.lobe-local-system.apiName.writeFile',
+  ) as BuiltinInspector,
+};
+
+const heterogeneousCliRenders: Record<string, BuiltinRender> = {
+  bash: RunCommandRender as BuiltinRender,
+  read: LocalSystemRenders[LocalSystemApiName.readFile] as BuiltinRender,
+  write: LocalSystemRenders[LocalSystemApiName.writeFile] as BuiltinRender,
+};
+
+const heterogeneousCliStreamings: Record<string, BuiltinStreaming> = {
+  bash: LocalSystemStreamings[LocalSystemApiName.runCommand] as BuiltinStreaming,
+  write: LocalSystemStreamings[LocalSystemApiName.writeFile] as BuiltinStreaming,
+};
 
 let builtinToolSurfacesRegistered = false;
 
@@ -214,6 +244,8 @@ export const registerBuiltinToolSurfaces = (): void => {
     [LobeActivatorManifest.identifier]: LobeActivatorRenders as Record<string, BuiltinRender>,
     [WebBrowsingManifest.identifier]: WebBrowsingRenders as Record<string, BuiltinRender>,
     [WebOnboardingManifest.identifier]: WebOnboardingRenders as Record<string, BuiltinRender>,
+    [OPENCODE_IDENTIFIER]: heterogeneousCliRenders,
+    [PI_IDENTIFIER]: heterogeneousCliRenders,
     codex: {
       ...CodexRenders,
       command_execution: RunCommandRender as BuiltinRender,
@@ -269,6 +301,8 @@ export const registerBuiltinToolSurfaces = (): void => {
     [UserInteractionIdentifier]: UserInteractionInspectors as Record<string, BuiltinInspector>,
     [WebBrowsingManifest.identifier]: WebBrowsingInspectors as Record<string, BuiltinInspector>,
     [WebOnboardingManifest.identifier]: WebOnboardingInspectors as Record<string, BuiltinInspector>,
+    [OPENCODE_IDENTIFIER]: heterogeneousCliInspectors,
+    [PI_IDENTIFIER]: heterogeneousCliInspectors,
     codex: CodexInspectors,
     [GithubIdentifier]: GithubInspectors,
     [LinearIdentifier]: LinearInspectors,
@@ -300,7 +334,9 @@ export const registerBuiltinToolSurfaces = (): void => {
     [LocalSystemManifest.identifier]: LocalSystemStreamings as Record<string, BuiltinStreaming>,
     [MemoryManifest.identifier]: MemoryStreamings as Record<string, BuiltinStreaming>,
     [MessageManifest.identifier]: MessageStreamings as Record<string, BuiltinStreaming>,
+    [OPENCODE_IDENTIFIER]: heterogeneousCliStreamings,
     [PageAgentManifest.identifier]: PageAgentStreamings as Record<string, BuiltinStreaming>,
+    [PI_IDENTIFIER]: heterogeneousCliStreamings,
   });
 
   registerBuiltinInterventions({

--- a/packages/shared-tool-ui/src/Inspector/ReadLocalFile/index.tsx
+++ b/packages/shared-tool-ui/src/Inspector/ReadLocalFile/index.tsx
@@ -11,7 +11,11 @@ import { inspectorTextStyles, shinyTextStyles } from '../../styles';
 
 interface ReadFileArgs {
   endLine?: number;
+  file_path?: string;
+  filePath?: string;
+  limit?: number;
   loc?: [number, number];
+  offset?: number;
   path?: string;
   startLine?: number;
 }
@@ -21,15 +25,28 @@ export const createReadLocalFileInspector = (translationKey: string) => {
     ({ args, partialArgs, isArgumentsStreaming, isLoading }) => {
       const { t } = useTranslation('plugin');
 
-      const filePath = args?.path || partialArgs?.path || '';
+      const filePath =
+        args?.path ||
+        args?.filePath ||
+        args?.file_path ||
+        partialArgs?.path ||
+        partialArgs?.filePath ||
+        partialArgs?.file_path ||
+        '';
 
       const lineRange = useMemo(() => {
-        const start = args?.startLine ?? args?.loc?.[0];
-        const end = args?.endLine ?? args?.loc?.[1];
+        const source = args || partialArgs;
+        const start = source?.startLine ?? source?.loc?.[0] ?? source?.offset;
+        const end =
+          source?.endLine ??
+          source?.loc?.[1] ??
+          (start !== undefined && source?.limit !== undefined
+            ? start + Math.max(source.limit - 1, 0)
+            : undefined);
         if (start !== undefined && end !== undefined) return `L${start}-L${end}`;
         if (start !== undefined) return `L${start}`;
         return undefined;
-      }, [args]);
+      }, [args, partialArgs]);
 
       if (isArgumentsStreaming) {
         if (!filePath)

--- a/packages/shared-tool-ui/src/Inspector/WriteLocalFile/index.tsx
+++ b/packages/shared-tool-ui/src/Inspector/WriteLocalFile/index.tsx
@@ -12,6 +12,8 @@ import { inspectorTextStyles, shinyTextStyles } from '../../styles';
 
 interface WriteFileArgs {
   content?: string;
+  file_path?: string;
+  filePath?: string;
   path?: string;
 }
 
@@ -20,7 +22,14 @@ export const createWriteLocalFileInspector = (translationKey: string) => {
     ({ args, partialArgs, isArgumentsStreaming, isLoading }) => {
       const { t } = useTranslation('plugin');
 
-      const filePath = args?.path || partialArgs?.path || '';
+      const filePath =
+        args?.path ||
+        args?.filePath ||
+        args?.file_path ||
+        partialArgs?.path ||
+        partialArgs?.filePath ||
+        partialArgs?.file_path ||
+        '';
       const lineCount = args?.content?.split('\n').length;
 
       if (isArgumentsStreaming) {

--- a/src/store/tool/builtinToolRegistry.test.ts
+++ b/src/store/tool/builtinToolRegistry.test.ts
@@ -12,6 +12,11 @@ import {
 } from '@lobechat/builtin-tool-group-agent-builder';
 import { GroupAgentBuilderInspectors } from '@lobechat/builtin-tool-group-agent-builder/client';
 import { LobeAgentApiName, LobeAgentIdentifier } from '@lobechat/builtin-tool-lobe-agent';
+import {
+  LocalSystemApiName,
+  LocalSystemRenders,
+  LocalSystemStreamings,
+} from '@lobechat/builtin-tool-local-system/client';
 import { RemoteDeviceApiName, RemoteDeviceIdentifier } from '@lobechat/builtin-tool-remote-device';
 import { SkillStoreApiName, SkillStoreIdentifier } from '@lobechat/builtin-tool-skill-store';
 import { SkillStoreInspectors, SkillStoreRenders } from '@lobechat/builtin-tool-skill-store/client';
@@ -83,6 +88,29 @@ describe('builtin tool registry', () => {
 
   it('registers the Codex error inspector', () => {
     expect(getBuiltinInspector('codex', 'error')).toBeDefined();
+  });
+
+  it.each(['opencode', 'pi'])('registers shared file and shell surfaces for %s', (identifier) => {
+    for (const apiName of ['bash', 'read', 'write']) {
+      expect(getBuiltinInspector(identifier, apiName)).toBeDefined();
+      expect(getBuiltinRender(identifier, apiName)).toBeDefined();
+    }
+
+    expect(getBuiltinRender(identifier, 'bash')).toBe(
+      LocalSystemRenders[LocalSystemApiName.runCommand],
+    );
+    expect(getBuiltinRender(identifier, 'read')).toBe(
+      LocalSystemRenders[LocalSystemApiName.readFile],
+    );
+    expect(getBuiltinRender(identifier, 'write')).toBe(
+      LocalSystemRenders[LocalSystemApiName.writeFile],
+    );
+    expect(getBuiltinStreaming(identifier, 'bash')).toBe(
+      LocalSystemStreamings[LocalSystemApiName.runCommand],
+    );
+    expect(getBuiltinStreaming(identifier, 'write')).toBe(
+      LocalSystemStreamings[LocalSystemApiName.writeFile],
+    );
   });
 
   it('registers remote device inspectors and renders', () => {


### PR DESCRIPTION
#### 💥 Change Type

- [x] ✨ feat
- [ ] 🐛 bug
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] ✅ test

#### 📝 Description of Change

Register the shared local-system inspectors, renders, and streamings for OpenCode and Pi `bash` / `read` / `write` tools so those heterogeneous CLI agents get the same file and shell tool cards as built-in local system tools.

Also normalize alternate argument shapes (`path` / `filePath` / `file_path`, `offset` / `limit`) and parse OpenCode's XML-wrapped read payload (path header, line-number prefixes, end/continuation markers) so read/write tool UI can render from real agent payloads.

#### 🧪 Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- Added unit coverage for `parseOpenCodeReadContent` (path extraction, line-number stripping, markers, non-envelope content).
- Extended `builtinToolRegistry` tests so `opencode` and `pi` resolve the shared bash/read/write inspectors, renders, and streamings.

#### 🔗 Related Issue

N/A