### PR TITLE
📝 docs(deep-review): add parser input-space and fix-round re-review rules

### DIFF
--- a/.agents/skills/deep-review/SKILL.md
+++ b/.agents/skills/deep-review/SKILL.md
@@ -87,6 +87,7 @@ A wrapping repository (e.g. a private deployment that vendors this repo as a sub
 1. Determine review scope exactly as deep mode step 0 does (see the environment manual's scope rules — three-dot diff from a base that does not lag the fork point, submodule diffs included), but skip the background-hunting extras when context already tells you what changed.
 2. Apply the pruning table; read the `Quick checklist` section of each surviving dimension file, plus extension-pack counterparts.
 3. Review inline. Findings must cite a rule source or code evidence; respect the codebase-calibration principle.
+   - On a follow-up round (verifying that earlier findings were fixed), review the newly changed code as a fresh diff under the same checklists — never just confirm the requested edits landed. Fix commits introduce new logic (guards, parsers, refactors) whose bugs a checkbox pass will miss.
 4. Label every finding on the same two axes deep mode uses, and let them drive the recommendation:
    - **Severity** — use only P0 (incident-level impact), P1 (must fix in this change), or P2
      (real but deferrable). Never invent additional levels. State whether each finding blocks

--- a/.agents/skills/deep-review/references/dimensions/logic.md
+++ b/.agents/skills/deep-review/references/dimensions/logic.md
@@ -11,6 +11,7 @@ Does the change do what the requirement asked, and does it hold up under real in
 ## Quick checklist
 
 - Edge cases: empty arrays/strings, zero, boundary indexes, first/last page, single-item collections
+- Text parsers/extractors (envelopes, markers, delimiters): enumerate the input space systematically instead of spot-checking — empty payload, marker-only payload, delimiter/marker literals occurring inside the body, truncated/partial input. When one delimiter lookup is found fragile, apply the same attack to every other `indexOf`/`lastIndexOf`/regex lookup in the function
 - Null/undefined flowing into code that assumes presence
 - Race conditions: concurrent mutations, stale closures, un-awaited promises whose order matters
 - Error handling: failure paths that leave state half-mutated or the UI stuck
@@ -29,6 +30,7 @@ Does the change do what the requirement asked, and does it hold up under real in
 2. Trace each error path to its end state: user feedback, state rollback, log.
 3. Compare behavior against the scope summary; deviations are findings even when the code is internally correct.
 4. For fixes: `ls` the sibling `__tests__/` and check the fixed scenario is actually covered, not just any test touched.
+5. For text-parsing functions: write the adversarial input list first (empty, marker-only, body-contains-delimiter, truncated), then read the code against each item — do not evaluate edge cases ad hoc as they come to mind.
 
 ## Violations
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A — review-process improvement distilled from PR #18023's fix round.

#### 📝 Description of Change

Feeds two rule gaps back into the deep-review skill, both surfaced while reviewing #18023 (three P2 defects in `parseOpenCodeReadContent` were caught by a bot pass after the agent review missed them):

1. **logic dimension** — text parsers/extractors must be reviewed against a systematically enumerated input space (empty payload, marker-only payload, delimiter/marker literals inside the body, truncated input), and a fragility found in one delimiter lookup must be applied to every other lookup in the same function. Added to both the Quick checklist and the How-to-check steps.
2. **light-mode procedure** — a follow-up round that verifies earlier findings were fixed must re-review the newly changed code as a fresh diff, not just confirm the requested edits landed; fix commits introduce new logic whose bugs a checkbox pass misses.

#### 🧪 How to Test

- [x] Doc-only change to `.agents/skills/deep-review/`; no runtime code affected.
