### PR TITLE
🐛 fix(hetero-agent): prefer platformAgentId for OpenClaw agent selection

### DIFF
--- a/apps/cli/src/tools/__tests__/heteroTask.test.ts
+++ b/apps/cli/src/tools/__tests__/heteroTask.test.ts
@@ -66,6 +66,7 @@ describe('runHeteroTask (openclaw)', () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -90,6 +91,43 @@ describe('runHeteroTask (openclaw)', () => {
     expect(messageArg).toContain('lh notify');
     expect(messageArg).toContain('MSG_ID');
   });
+
+  it.each([
+    {
+      environmentAgentId: 'ops-default',
+      expectedAgentId: 'researcher',
+      platformAgentId: ' researcher ',
+    },
+    {
+      environmentAgentId: 'ops-default',
+      expectedAgentId: 'ops-default',
+      platformAgentId: undefined,
+    },
+    {
+      environmentAgentId: 'ops-default',
+      expectedAgentId: 'ops-default',
+      platformAgentId: '   ',
+    },
+    { environmentAgentId: '', expectedAgentId: 'main', platformAgentId: undefined },
+  ])(
+    'selects OpenClaw agent $expectedAgentId from platform config before environment fallback',
+    async ({ environmentAgentId, expectedAgentId, platformAgentId }) => {
+      vi.stubEnv('OPENCLAW_AGENT_ID', environmentAgentId);
+      spawnMock.mockReturnValue(makeMockChild());
+
+      await runHeteroTask({
+        agentType: 'openclaw',
+        operationId: 'op-agent-selection',
+        platformAgentId,
+        prompt: 'hello',
+        taskId: 'task-agent-selection',
+        topicId: 'topic-agent-selection',
+      });
+
+      const [, spawnArgs] = spawnMock.mock.calls[0] as [string, string[]];
+      expect(spawnArgs[spawnArgs.indexOf('--agent') + 1]).toBe(expectedAgentId);
+    },
+  );
 
   it('always injects protocol even on the second turn of the same session', async () => {
     const child1 = makeMockChild(1111);

--- a/apps/cli/src/tools/heteroTask.ts
+++ b/apps/cli/src/tools/heteroTask.ts
@@ -54,6 +54,7 @@ export interface RunHeteroTaskParams {
   agentType: RemoteHeterogeneousAgentType;
   cwd?: string;
   operationId: string;
+  platformAgentId?: string;
   prompt: string;
   taskId: string;
   topicId: string;
@@ -154,7 +155,17 @@ function buildNotifyProtocol(lhPath: string, topicId: string): string {
 }
 
 export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string> {
-  const { agentId, agentType, cwd, operationId, prompt, taskId, topicId, workspaceId } = params;
+  const {
+    agentId,
+    agentType,
+    cwd,
+    operationId,
+    platformAgentId,
+    prompt,
+    taskId,
+    topicId,
+    workspaceId,
+  } = params;
   const workDir = cwd || process.cwd();
   const lhPath = resolveLhPath();
   // Propagate workspace scope into the spawned child so its own `lh notify`
@@ -168,7 +179,7 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
     // openclaw agent --local is one-shot: each invocation processes one message and exits.
     // The --session-id links turns into the same conversation history on disk.
     // Requires the `openclaw` binary to be on PATH with Node >=22.19.
-    const openclawAgent = process.env.OPENCLAW_AGENT_ID ?? 'main';
+    const openclawAgent = platformAgentId?.trim() || process.env.OPENCLAW_AGENT_ID || 'main';
 
     // Always inject the notify protocol so openclaw knows how to report results
     // back to the LobeHub UI — even if the previous turn failed and the session

--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -591,6 +591,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
             agentType: string;
             cwd?: string;
             operationId: string;
+            platformAgentId?: string;
             prompt: string;
             taskId: string;
             topicId: string;
@@ -831,12 +832,23 @@ export default class GatewayConnectionCtr extends ControllerModule {
     agentType: string;
     cwd?: string;
     operationId: string;
+    platformAgentId?: string;
     prompt: string;
     taskId: string;
     topicId: string;
     workspaceId?: string;
   }): Promise<string> {
-    const { agentId, agentType, cwd, operationId, prompt, taskId, topicId, workspaceId } = args;
+    const {
+      agentId,
+      agentType,
+      cwd,
+      operationId,
+      platformAgentId,
+      prompt,
+      taskId,
+      topicId,
+      workspaceId,
+    } = args;
     const workDir = cwd || process.cwd();
 
     const [serverUrl, accessToken] = await Promise.all([
@@ -862,7 +874,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
       }
       if (commandStatus.resolvedPathEnv) childEnv.PATH = commandStatus.resolvedPathEnv;
       const lhPath = this.resolveLhPath();
-      const openclawAgent = process.env['OPENCLAW_AGENT_ID'] ?? 'main';
+      const openclawAgent = platformAgentId?.trim() || process.env['OPENCLAW_AGENT_ID'] || 'main';
 
       // Always inject the notify protocol so openclaw knows how to report results
       // back to the LobeHub UI — even if the previous turn failed and the session

--- a/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
@@ -313,6 +313,7 @@ describe('GatewayConnectionCtr', () => {
 
   afterEach(() => {
     ctr.disconnect();
+    vi.unstubAllEnvs();
     vi.useRealTimers();
   });
 
@@ -1047,6 +1048,49 @@ describe('GatewayConnectionCtr', () => {
       expect(messageArg).toContain('hello');
       expect(messageArg).toContain('lh notify');
     });
+
+    it.each([
+      {
+        environmentAgentId: 'ops-default',
+        expectedAgentId: 'researcher',
+        platformAgentId: ' researcher ',
+      },
+      {
+        environmentAgentId: 'ops-default',
+        expectedAgentId: 'ops-default',
+        platformAgentId: undefined,
+      },
+      {
+        environmentAgentId: 'ops-default',
+        expectedAgentId: 'ops-default',
+        platformAgentId: '   ',
+      },
+      { environmentAgentId: '', expectedAgentId: 'main', platformAgentId: undefined },
+    ])(
+      'selects OpenClaw agent $expectedAgentId from platform config before environment fallback',
+      async ({ environmentAgentId, expectedAgentId, platformAgentId }) => {
+        vi.stubEnv('OPENCLAW_AGENT_ID', environmentAgentId);
+        spawnMock.mockReturnValue(makeMockChild());
+
+        const client = await connectAndOpen();
+        client.simulateToolCallRequest(
+          'runHeteroTask',
+          {
+            agentType: 'openclaw',
+            operationId: 'op-agent-selection',
+            platformAgentId,
+            prompt: 'hello',
+            taskId: 'task-agent-selection',
+            topicId: 'topic-agent-selection',
+          },
+          'req-agent-selection',
+        );
+        await vi.advanceTimersByTimeAsync(0);
+
+        const [, spawnArgs] = spawnMock.mock.calls[0] as [string, string[]];
+        expect(spawnArgs[spawnArgs.indexOf('--agent') + 1]).toBe(expectedAgentId);
+      },
+    );
 
     it('kills an existing concurrent openclaw process for the same topicId before spawning', async () => {
       const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
@@ -745,7 +745,7 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
     it('keeps the conversation workspace separate from a personal platform device scope', async () => {
       heteroAgentConfig.agencyConfig = {
         executionTarget: 'local',
-        heterogeneousProvider: { type: 'openclaw' },
+        heterogeneousProvider: { platformAgentId: 'researcher', type: 'openclaw' },
       } as any;
       (heteroAgentConfig as any).userId = userId;
       (heteroAgentConfig as any).visibility = 'public';
@@ -774,6 +774,7 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
       expect(JSON.parse(toolCall.arguments)).toEqual(
         expect.objectContaining({
           agentType: 'openclaw',
+          platformAgentId: 'researcher',
           workspaceId: 'workspace-a',
         }),
       );

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -2393,6 +2393,7 @@ export class AiAgentService {
               agentType: heteroType,
               cwd: undefined,
               operationId,
+              platformAgentId: agentConfig.agencyConfig?.heterogeneousProvider?.platformAgentId,
               prompt,
               taskId: operationId,
               topicId,


### PR DESCRIPTION
<!-- Brief and heads-up -->

Wire `agencyConfig.heterogeneousProvider.platformAgentId` through server → desktop/CLI `runHeteroTask` so OpenClaw spawns with the configured platform agent instead of only `OPENCLAW_AGENT_ID` / `main`.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

**How to test**

1. Configure an OpenClaw hetero agent with `platformAgentId` (e.g. `researcher`) in agency config.
2. Run a hetero task on CLI or desktop gateway.
3. Confirm the spawned `openclaw` process uses `--agent researcher`.
4. When `platformAgentId` is missing/blank, fall back to `OPENCLAW_AGENT_ID`, then `main`.

Unit coverage:
- `apps/cli/src/tools/__tests__/heteroTask.test.ts` — agent selection priority matrix
- `apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts` — same for desktop gateway
- `apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts` — server forwards `platformAgentId` in tool call args

#### 🔗 Related Issue

N/A