### PR TITLE
💄 polish task scheduling and home running card

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -1183,6 +1183,7 @@
   "taskDetail.modelConfig": "Model Override",
   "taskDetail.navigation": "Navigation",
   "taskDetail.nextRunCountdown": "Next run in {{countdown}}",
+  "taskDetail.nextRunCountdownDays": "Next run in {{days}}d {{hours}}h",
   "taskDetail.notFound.backToTasks": "Back to all tasks",
   "taskDetail.notFound.desc": "This task may have been deleted, or you don't have permission to view it.",
   "taskDetail.notFound.title": "Task not found",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -1183,6 +1183,7 @@
   "taskDetail.modelConfig": "模型覆盖",
   "taskDetail.navigation": "导航",
   "taskDetail.nextRunCountdown": "{{countdown}} 后执行",
+  "taskDetail.nextRunCountdownDays": "{{days}} 天 {{hours}} 小时后执行",
   "taskDetail.notFound.backToTasks": "返回任务列表",
   "taskDetail.notFound.desc": "该任务可能已被删除，或你没有查看权限。",
   "taskDetail.notFound.title": "找不到该任务",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -1341,6 +1341,7 @@ export default {
   'taskDetail.latestActivity.untitledTopic': 'Untitled topic',
   'taskDetail.cancelSchedule': 'Cancel schedule',
   'taskDetail.nextRunCountdown': 'Next run in {{countdown}}',
+  'taskDetail.nextRunCountdownDays': 'Next run in {{days}}d {{hours}}h',
   'taskDetail.pauseTask': 'Pause task',
   'taskDetail.rerunTask': 'Re-run task',
   'taskDetail.runNow': 'Run now',

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailRunPauseAction.test.ts
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailRunPauseAction.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatCountdown } from './TaskDetailRunPauseAction';
+
+describe('formatCountdown', () => {
+  it('keeps the precise countdown for durations shorter than one day', () => {
+    expect(formatCountdown((23 * 3600 + 59 * 60 + 59) * 1000)).toEqual({
+      countdown: '23:59:59',
+      type: 'time',
+    });
+  });
+
+  it('formats durations of at least one day as days and hours', () => {
+    expect(formatCountdown((2 * 86_400 + 16 * 3600 + 55 * 60 + 28) * 1000)).toEqual({
+      days: 2,
+      hours: 16,
+      type: 'days',
+    });
+  });
+
+  it('clamps expired countdowns to zero', () => {
+    expect(formatCountdown(-1000)).toEqual({ countdown: '00:00', type: 'time' });
+  });
+});

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailRunPauseAction.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailRunPauseAction.tsx
@@ -15,13 +15,25 @@ import { nextHeartbeatFiring, nextScheduleFiring } from './scheduler/helpers';
 
 const padTime = (n: number) => String(n).padStart(2, '0');
 
-const formatCountdown = (msRemaining: number): string => {
+export type CountdownDisplay =
+  { countdown: string; type: 'time' } | { days: number; hours: number; type: 'days' };
+
+export const formatCountdown = (msRemaining: number): CountdownDisplay => {
   const totalSeconds = Math.max(0, Math.floor(msRemaining / 1000));
+  const days = Math.floor(totalSeconds / 86_400);
+  if (days > 0) {
+    return { days, hours: Math.floor((totalSeconds % 86_400) / 3600), type: 'days' };
+  }
+
   const hours = Math.floor(totalSeconds / 3600);
   const minutes = Math.floor((totalSeconds % 3600) / 60);
   const seconds = totalSeconds % 60;
-  if (hours > 0) return `${padTime(hours)}:${padTime(minutes)}:${padTime(seconds)}`;
-  return `${padTime(minutes)}:${padTime(seconds)}`;
+  const countdown =
+    hours > 0
+      ? `${padTime(hours)}:${padTime(minutes)}:${padTime(seconds)}`
+      : `${padTime(minutes)}:${padTime(seconds)}`;
+
+  return { countdown, type: 'time' };
 };
 
 const TaskDetailRunPauseAction = memo(() => {
@@ -165,7 +177,9 @@ const TaskDetailRunPauseAction = memo(() => {
         </SplitButton>
         {countdownText && (
           <Text fontSize={12} type={'secondary'}>
-            {t('taskDetail.nextRunCountdown', { countdown: countdownText })}
+            {countdownText.type === 'days'
+              ? t('taskDetail.nextRunCountdownDays', countdownText)
+              : t('taskDetail.nextRunCountdown', countdownText)}
           </Text>
         )}
       </Flexbox>

--- a/src/features/HomeInbox/RunningTasksCard.tsx
+++ b/src/features/HomeInbox/RunningTasksCard.tsx
@@ -25,19 +25,17 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
       margin-inline-start: -6px;
     }
   `,
-  // Inside a rail card the shell is already drawn; only the hover bleed remains.
-  bareHead: css`
-    padding-block: 7px;
-    padding-inline: 8px;
-    border-radius: ${cssVar.borderRadius};
-  `,
   bareRoot: css`
+    margin-block: -6px;
     margin-inline: -8px;
   `,
   body: css`
     padding-block: 4px 8px;
     padding-inline: 8px;
     border-block-start: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+  bareBody: css`
+    padding-inline: 0;
   `,
   card: css`
     overflow: hidden;
@@ -63,6 +61,12 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     &:hover {
       background: ${cssVar.colorFillQuaternary};
     }
+  `,
+  // Inside a rail card the shell is already drawn; only the hover bleed remains.
+  bareHead: css`
+    padding-block: 7px;
+    padding-inline: 8px;
+    border-radius: ${cssVar.borderRadius};
   `,
   overflowCount: css`
     flex: none;
@@ -163,7 +167,7 @@ const RunningTasksCard = memo<RunningTasksCardProps>(({ action, bare, running, s
       </Flexbox>
 
       {open && (
-        <Flexbox className={styles.body}>
+        <Flexbox className={cx(styles.body, bare && styles.bareBody)}>
           {running.map((topic) => (
             <TopicRow
               key={topic.id}


### PR DESCRIPTION
## Summary

- tighten the Home rail running-task card spacing in collapsed and expanded states
- keep an even 8px inset between the rail shell and its hoverable row
- format scheduled-task countdowns longer than one day as days and hours
- add English and Chinese countdown copy plus boundary regression tests

## Why

The running-task card combined the rail shell padding with its own row padding, making the collapsed state feel taller than neighboring Home cards. Expanded items also inherited an extra horizontal inset.

Long scheduled-task countdowns were rendered as unbounded clock hours such as `64:55:28`, which is harder to scan than a calendar-oriented duration.

## Impact

- Home running-task cards stay compact and align expanded rows more clearly.
- Countdown values below 24 hours keep the precise `HH:mm:ss` / `MM:ss` form.
- Countdown values of at least 24 hours render as `N days X hours` (`N 天 X 小时后执行` in zh-CN).

## Verification

- `bun run check src/features/HomeInbox/RunningTasksCard.tsx`
- `bun run check --test src/features/AgentTasks/AgentTaskDetail/TaskDetailRunPauseAction.tsx src/features/AgentTasks/AgentTaskDetail/TaskDetailRunPauseAction.test.ts` — 3 tests passed
- Agent Testing Acceptance: https://app.lobehub.com/acceptance/7632fe88-4469-4949-8ea7-fa8ad508e44f?r=3
