### PR TITLE
💄 style(agent): show agent role beside the name in agent pickers

### DIFF
--- a/packages/types/src/agent/displayName.test.ts
+++ b/packages/types/src/agent/displayName.test.ts
@@ -31,18 +31,24 @@ describe('agentDisplayName', () => {
 });
 
 describe('agentSecondaryDisplayName', () => {
-  it('prefers a runtime label over a platform profile title', () => {
-    expect(agentSecondaryDisplayName({ name: '陆令言', title: 'default' }, 'Hermes')).toBe(
-      'Hermes',
-    );
-    expect(agentSecondaryDisplayName({ name: '燕来', title: 'Pi' }, 'Pi')).toBe('Pi');
-  });
-
-  it('keeps regular roles and suppresses labels that duplicate the primary name', () => {
+  it('shows the role of a named agent', () => {
     expect(agentSecondaryDisplayName({ name: 'Alice', title: 'Health Assistant' })).toBe(
       'Health Assistant',
     );
-    expect(agentSecondaryDisplayName({ title: 'Pi' }, 'Pi')).toBeUndefined();
+  });
+
+  it('treats a heterogeneous agent like any other — its role, not its runtime', () => {
+    expect(agentSecondaryDisplayName({ name: '陆令言', title: 'default' })).toBe('default');
+  });
+
+  it('shows nothing when the title is already the primary label', () => {
     expect(agentSecondaryDisplayName({ title: 'Health Assistant' })).toBeUndefined();
+    expect(agentSecondaryDisplayName({ name: '  ', title: 'Pi' })).toBeUndefined();
+  });
+
+  it('treats a blank role as absent', () => {
+    expect(agentSecondaryDisplayName({ name: 'Alice', title: '   ' })).toBeUndefined();
+    expect(agentSecondaryDisplayName({ name: 'Alice' })).toBeUndefined();
+    expect(agentSecondaryDisplayName(null)).toBeUndefined();
   });
 });

--- a/packages/types/src/agent/displayName.ts
+++ b/packages/types/src/agent/displayName.ts
@@ -45,20 +45,17 @@ export function agentDisplayName(
 }
 
 /**
- * Resolve the supporting label shown beside an agent's primary name.
+ * Resolve the supporting label shown beside an agent's primary name: its role.
  *
- * Runtime-backed agents can supply `preferredLabel` (for example "Hermes")
- * because their persisted title may instead contain an internal platform
- * profile name such as "default". Regular agents show their role only when a
- * personal name is present. A label matching the primary name is suppressed.
+ * Only an agent with a personal name has one — an agent without a name already
+ * renders its title as the primary label, so repeating it would be noise. This
+ * is deliberately uniform across every kind of agent, including runtime-backed
+ * (heterogeneous) ones: they show their own role rather than their runtime.
  */
 export const agentSecondaryDisplayName = (
   agent: AgentNameFields | null | undefined,
-  preferredLabel?: string | null,
 ): string | undefined => {
-  const primaryLabel = agentDisplayName(agent);
-  const role = firstNonBlank(agent?.name) ? agent?.title : undefined;
-  const secondaryLabel = firstNonBlank(preferredLabel, role);
+  const role = firstNonBlank(agent?.name) ? firstNonBlank(agent?.title) : undefined;
 
-  return secondaryLabel === primaryLabel ? undefined : secondaryLabel;
+  return role === agentDisplayName(agent) ? undefined : role;
 };

--- a/src/features/AgentTaskManager/AgentSelectorAction.tsx
+++ b/src/features/AgentTaskManager/AgentSelectorAction.tsx
@@ -120,6 +120,7 @@ const AgentSelectorAction = memo<AgentSelectorActionProps>(({ onAgentChange }) =
     list.map((agent) => (
       <AgentItem
         active={agent.id === agentId}
+        agent={agent}
         agentId={agent.id}
         agentTitle={agentDisplayName(agent, t('untitledAgent', { ns: 'chat' }))}
         avatar={agent.avatar}

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailAssignee.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailAssignee.tsx
@@ -43,13 +43,18 @@ const TaskDetailAssignee = memo(() => {
           gap={8}
           paddingBlock={4}
           paddingInline={11}
-          style={{ minHeight: 32 }}
+          // `flex: none` keeps the chip at its content width so a narrow column
+          // wraps the row instead of squeezing the name to one character per
+          // line; `maxWidth` + the label's ellipsis then bound a very long name.
+          style={{ flex: 'none', maxWidth: '100%', minHeight: 32 }}
           variant={isDarkMode ? 'filled' : 'outlined'}
         >
           {assigneeAgentId ? (
             <>
               <AssigneeAvatar agentId={assigneeAgentId} size={20} />
-              <Text weight={500}>{assigneeMeta?.title}</Text>
+              <Text ellipsis weight={500}>
+                {assigneeMeta?.title}
+              </Text>
               <HeterogeneousTag type={assigneeHeterogeneousType} />
             </>
           ) : (

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailSections.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailSections.tsx
@@ -24,10 +24,18 @@ const TaskDetailSections = memo(() => {
     <>
       <Flexbox gap={4} style={{ paddingBlock: '24px 36px' }}>
         <TaskDetailTitleInput />
-        <Flexbox horizontal align={'flex-start'} gap={16} justify={'space-between'}>
-          <Flexbox align={'flex-start'} flex={1} gap={16}>
+        {/* Everything here wraps rather than compresses: this block also renders
+            inside the chat-side Portal and beside the task-agent panel, where the
+            column can get far narrower than the viewport. Without wrapping, the
+            assignee chip is the item that gives — it shrinks until its label
+            breaks one character per line. */}
+        <Flexbox horizontal align={'flex-start'} gap={16} justify={'space-between'} wrap={'wrap'}>
+          {/* `minWidth` is what makes the row actually wrap: a `flex: 1` column
+              with `min-width: 0` shrinks to a sliver instead, and the properties
+              panel keeps its place while the assignee chip overflows. */}
+          <Flexbox align={'flex-start'} flex={1} gap={16} style={{ minWidth: 240 }}>
             <TaskParentBar />
-            <Flexbox horizontal align={'center'} gap={8}>
+            <Flexbox horizontal align={'center'} gap={8} style={{ maxWidth: '100%' }} wrap={'wrap'}>
               <TaskDetailAssignee />
               <TaskModelConfig />
             </Flexbox>

--- a/src/features/AgentTasks/features/AssigneeAgentSelector.tsx
+++ b/src/features/AgentTasks/features/AssigneeAgentSelector.tsx
@@ -55,11 +55,20 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
+// Both labels rendered on a row are searchable: the name and the role shown
+// beside it, so typing a role ("设计") finds the agent the user sees.
+const matchesSearch = (agent: SidebarAgentItem, q: string) =>
+  [agentDisplayName(agent), agent.title].some((label) => (label ?? '').toLowerCase().includes(q));
+
 const triggerStyle: CSSProperties = {
   alignItems: 'center',
   display: 'inline-flex',
   justifyContent: 'center',
   lineHeight: 1,
+  // Bound the trigger to its row so a chip inside it can cap at `max-width:
+  // 100%` and ellipsis its label, instead of overflowing a narrow column.
+  maxWidth: '100%',
+  minWidth: 0,
 };
 
 const AssigneeAgentSelector = memo<AssigneeAgentSelectorProps>(
@@ -129,17 +138,13 @@ const AssigneeAgentSelector = memo<AssigneeAgentSelectorProps>(
     const filteredPrivate = useMemo(() => {
       const q = search.trim().toLowerCase();
       if (!q) return privateAgents;
-      return privateAgents.filter((agent) =>
-        (agentDisplayName(agent) ?? '').toLowerCase().includes(q),
-      );
+      return privateAgents.filter((agent) => matchesSearch(agent, q));
     }, [privateAgents, search]);
 
     const filteredWorkspace = useMemo(() => {
       const q = search.trim().toLowerCase();
       if (!q) return workspaceAgents;
-      return workspaceAgents.filter((agent) =>
-        (agentDisplayName(agent) ?? '').toLowerCase().includes(q),
-      );
+      return workspaceAgents.filter((agent) => matchesSearch(agent, q));
     }, [workspaceAgents, search]);
 
     // Flat order for keyboard navigation and activeIndex: private first, then workspace.
@@ -212,10 +217,10 @@ const AssigneeAgentSelector = memo<AssigneeAgentSelectorProps>(
           >
             <AgentItem
               active={flatIndex === activeIndex}
+              agent={agent}
               agentId={agent.id}
               agentTitle={agentDisplayName(agent, t('untitledAgent', { ns: 'chat' }))}
               avatar={agent.avatar}
-              heterogeneousType={agent.heterogeneousType}
               onAgentChange={handleAgentChange}
               onClose={() => setKey((k) => k + 1)}
             />

--- a/src/features/AgentTopicManager/MoveTopicsModal/Content.tsx
+++ b/src/features/AgentTopicManager/MoveTopicsModal/Content.tsx
@@ -148,6 +148,7 @@ const MoveTopicsContent = memo<MoveTopicsContentProps>(({ onMoved, sourceAgentId
             {filteredAgents.map((agent) => (
               <AgentItem
                 active={false}
+                agent={agent}
                 agentId={agent.id}
                 agentTitle={agentDisplayName(agent, t('untitledAgent', { ns: 'chat' }))}
                 avatar={agent.avatar}

--- a/src/features/AgentViewAll/AgentCard.tsx
+++ b/src/features/AgentViewAll/AgentCard.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { AGENT_CHAT_URL, DEFAULT_AVATAR, GROUP_CHAT_URL } from '@lobechat/const';
-import { getHeterogeneousTypeLabel } from '@lobechat/heterogeneous-agents';
 import type { SidebarAgentItem } from '@lobechat/types';
 import { agentDisplayName, agentSecondaryDisplayName } from '@lobechat/types';
 import {
@@ -102,8 +101,7 @@ const AgentCard = memo<AgentCardProps>(
     const { description, id, type, updatedAt } = item;
     // Groups have no personal name, so this resolves to their title.
     const displayTitle = agentDisplayName(item, t('agentViewAll.untitled'));
-    const runtimeTag = getHeterogeneousTypeLabel(item.heterogeneousType);
-    const roleTag = agentSecondaryDisplayName(item, runtimeTag);
+    const roleTag = agentSecondaryDisplayName(item);
     const [anchor, setAnchor] = useState<HTMLElement | null>(null);
 
     // Right-click support — same bridge as AgentRow: the hook-bearing menu

--- a/src/features/AgentViewAll/AgentRow.tsx
+++ b/src/features/AgentViewAll/AgentRow.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { AGENT_CHAT_URL, DEFAULT_AVATAR, GROUP_CHAT_URL } from '@lobechat/const';
-import { getHeterogeneousTypeLabel } from '@lobechat/heterogeneous-agents';
 import type { SidebarAgentItem } from '@lobechat/types';
 import { agentDisplayName, agentSecondaryDisplayName } from '@lobechat/types';
 import {
@@ -113,8 +112,7 @@ const AgentRow = memo<AgentRowProps>(
     const { id, type, updatedAt } = item;
     // Groups have no personal name, so this resolves to their title.
     const displayTitle = agentDisplayName(item, t('agentViewAll.untitled'));
-    const runtimeTag = getHeterogeneousTypeLabel(item.heterogeneousType);
-    const roleTag = agentSecondaryDisplayName(item, runtimeTag);
+    const roleTag = agentSecondaryDisplayName(item);
     const [anchor, setAnchor] = useState<HTMLElement | null>(null);
 
     // Right-click support (Task-List-style): the hook-bearing menu mounts on

--- a/src/features/AgentViewAll/SidebarAgentsSection.tsx
+++ b/src/features/AgentViewAll/SidebarAgentsSection.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { AGENT_CHAT_URL, GROUP_CHAT_URL } from '@lobechat/const';
-import { getHeterogeneousTypeLabel } from '@lobechat/heterogeneous-agents';
 import type { SidebarAgentItem } from '@lobechat/types';
 import { agentDisplayName, agentSecondaryDisplayName } from '@lobechat/types';
 import { Block, ContextMenuTrigger, Flexbox, Icon, type MenuProps, Tag, Text } from '@lobehub/ui';
@@ -106,8 +105,7 @@ const SidebarMiniCard = memo<SidebarMiniCardProps>(({ item, onToggleSidebar }) =
   const { description, id, type } = item;
   // Groups have no personal name, so this resolves to their title.
   const displayTitle = agentDisplayName(item, t('agentViewAll.untitled'));
-  const runtimeTag = getHeterogeneousTypeLabel(item.heterogeneousType);
-  const roleTag = agentSecondaryDisplayName(item, runtimeTag);
+  const roleTag = agentSecondaryDisplayName(item);
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
 
   const [menuActivated, setMenuActivated] = useState(false);

--- a/src/features/HomeSidebar/Body/Agent/List/AgentItem/index.tsx
+++ b/src/features/HomeSidebar/Body/Agent/List/AgentItem/index.tsx
@@ -1,4 +1,3 @@
-import { getHeterogeneousTypeLabel } from '@lobechat/heterogeneous-agents';
 import type { SidebarAgentItem } from '@lobechat/types';
 import { agentDisplayName, agentSecondaryDisplayName } from '@lobechat/types';
 import { ActionIcon, Icon } from '@lobehub/ui';
@@ -99,11 +98,9 @@ const AgentItem = memo<AgentItemProps>(({ item, style, className, onNavigate }) 
 
   // Name-first label with fallback (see agentDisplayName)
   const displayTitle = agentDisplayName(item, t('untitledAgent'));
-  // A heterogeneous agent's persisted title may be a platform profile name
-  // (Hermes commonly reports "default"), not the runtime users need to identify.
-  // Prefer the runtime label; regular agents still show their role beside their name.
-  const runtimeTag = getHeterogeneousTypeLabel(item.heterogeneousType);
-  const roleTag = agentSecondaryDisplayName(item, runtimeTag);
+  // The role shown beside the name — same rule for every agent, heterogeneous
+  // ones included (see agentSecondaryDisplayName).
+  const roleTag = agentSecondaryDisplayName(item);
 
   const agentUrl = usePreservedAgentUrl(id);
 

--- a/src/features/PageEditor/Copilot/AgentSelector/AgentItem.tsx
+++ b/src/features/PageEditor/Copilot/AgentSelector/AgentItem.tsx
@@ -1,28 +1,36 @@
-import { type GroupMemberAvatar } from '@lobechat/types';
-import { Flexbox } from '@lobehub/ui';
+import {
+  type AgentNameFields,
+  agentSecondaryDisplayName,
+  type GroupMemberAvatar,
+} from '@lobechat/types';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import HeterogeneousTag from '@/features/HeterogeneousTag';
 import AgentAvatar from '@/features/HomeSidebar/Body/Agent/List/AgentItem/Avatar';
 import NavItem from '@/features/NavPanel/components/NavItem';
 
 interface AgentItemProps {
   active: boolean;
+  /**
+   * Identity fields of the agent, used to resolve the role shown beside its
+   * name. Omit for rows that have no agent record behind them.
+   */
+  agent?: AgentNameFields | null;
   agentId: string;
   agentTitle: string;
   avatar: string | GroupMemberAvatar[] | null | undefined;
-  /** Heterogeneous runtime type (e.g. `claude-code`); shows a runtime tag when set. */
-  heterogeneousType?: string | null;
   onAgentChange: (agentId: string) => void;
   onClose: () => void;
 }
 
 const AgentItem = memo<AgentItemProps>(
-  ({ active, agentId, agentTitle, avatar, heterogeneousType, onAgentChange, onClose }) => {
+  ({ active, agent, agentId, agentTitle, avatar, onAgentChange, onClose }) => {
     const { t } = useTranslation('chat');
 
     const title = agentTitle || t('untitledAgent');
+    // Same name + muted role treatment as the sidebar's agent list, so a row
+    // reads identically wherever an agent is listed.
+    const roleTag = agentSecondaryDisplayName(agent);
 
     return (
       <NavItem
@@ -30,13 +38,11 @@ const AgentItem = memo<AgentItemProps>(
         icon={<AgentAvatar avatar={typeof avatar === 'string' ? avatar : undefined} />}
         style={{ flexShrink: 0 }}
         title={
-          heterogeneousType ? (
-            <Flexbox horizontal align={'center'} gap={4}>
-              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                {title}
-              </span>
-              <HeterogeneousTag type={heterogeneousType} />
-            </Flexbox>
+          roleTag ? (
+            <>
+              {title}
+              <span style={{ fontSize: 12, marginInlineStart: 6, opacity: 0.6 }}>{roleTag}</span>
+            </>
           ) : (
             title
           )

--- a/src/features/PageEditor/Copilot/AgentSelector/AgentSelectorAction.tsx
+++ b/src/features/PageEditor/Copilot/AgentSelector/AgentSelectorAction.tsx
@@ -99,6 +99,7 @@ const AgentSelectorAction = memo<AgentSelectorActionProps>(({ onAgentChange }) =
       {agentsWithBuiltin.map((agent) => (
         <AgentItem
           active={agent.id === agentId}
+          agent={agent}
           agentId={agent.id}
           agentTitle={agentDisplayName(agent, t('untitledAgent', { ns: 'chat' }))}
           avatar={agent.avatar}


### PR DESCRIPTION
Agent pickers only rendered an agent's name, so two agents sharing a personal name were indistinguishable and the role a user had written into `title` was invisible exactly where it matters for picking one.

The shared picker `AgentItem` now renders the role after the name using the sidebar's muted-text treatment, so a row reads identically wherever an agent is listed. All four pickers built on that component pick it up — task assignee, task-manager, move-topics, and the document copilot — three of which previously showed no supporting label at all, because they never passed the runtime type down.

`agentSecondaryDisplayName` loses its `preferredLabel` parameter. Heterogeneous agents are no longer special-cased into showing their runtime ("Claude Code") in place of their own role, so every agent now follows one rule. Agents with only a name, or only a title, still get no supporting label — their single label is already the primary one.

Two supporting fixes fall out of this:

- **Assignee search matches the role too**, so typing a role the user can see on screen finds that agent instead of returning nothing.
- **The task-detail header wraps instead of compressing.** It also renders in the chat-side Portal and beside the task-agent panel, where the column gets far narrower than the viewport. With no wrapping anywhere in that cluster, the assignee chip was the item that gave — it shrank until its label broke one character per line. Note `min-width` (not `min-width: 0`) on the left column is what actually makes the row wrap; a `flex: 1` column otherwise just keeps shrinking and the properties panel never yields.

| Before | After |
| ------ | ----- |
| Narrow column: assignee chip squeezed to 60×218, name broken one character per line, properties panel clipped | Chip back to 180×32 on one line, model select and properties panel wrap onto their own rows |

Rendered before/after screenshots for every case are on the acceptance page: https://app.lobehub.com/acceptance/8fb846dd-ac72-4cfb-87b7-699869f423f7

#### Test

Verified on the desktop app across three review rounds, driving the real pickers and measuring layout rather than eyeballing it:

- role renders after the name in all four pickers, in the sidebar's muted style;
- a heterogeneous agent whose persisted `title` is `default` shows `default`, not `Claude Code` — a fixture that fails if the special case is still there;
- name-only and title-only agents render no supporting label;
- searching a role word (`家庭`, present only in the title) narrows to that agent;
- narrow/wide A/B at the same container width: `chip 60×218 → 180×32`, `modelBelowChip false → true`, and unchanged at 731px;
- sidebar and the Agents management list re-checked for regressions.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check` is clean (lint + the `agentSecondaryDisplayName` unit tests, which were rewritten for the new rule). The layout change has no unit test — it is asserted through DOM measurements plus screenshots in the acceptance run above.

#### 🔗 Related Issue

None — surfaced from review feedback on the acceptance above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)