### PR TITLE
✨ feat(portal): open topic & thread side-by-side via drag or menu

### DIFF
--- a/locales/en-US/common.json
+++ b/locales/en-US/common.json
@@ -411,6 +411,8 @@
   "oauth": "SSO Sign-in",
   "officialSite": "Official Website",
   "ok": "OK",
+  "openOnRight": "Open on the right",
+  "openOnRightHint": "Release to open side-by-side on the right",
   "operationFailed": "Operation failed, please try again",
   "or": "or",
   "pageSizeItem": "{{count}} items",

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -411,6 +411,8 @@
   "oauth": "SSO 登录",
   "officialSite": "官方网站",
   "ok": "确认",
+  "openOnRight": "在右侧打开",
+  "openOnRightHint": "松开以在右侧并排打开",
   "operationFailed": "操作失败，请重试",
   "or": "或",
   "pageSizeItem": "{{count}} 个条目",

--- a/packages/const/src/index.ts
+++ b/packages/const/src/index.ts
@@ -26,6 +26,7 @@ export * from './settings';
 export * from './skill';
 export * from './taskTemplate';
 export * from './theme';
+export * from './threadDrag';
 export * from './topicDrag';
 export * from './trace';
 export * from './url';

--- a/packages/const/src/threadDrag.ts
+++ b/packages/const/src/threadDrag.ts
@@ -1,0 +1,6 @@
+/**
+ * DataTransfer MIME type used when dragging a thread row into the conversation
+ * area to open it side-by-side in the portal. A custom type keeps Lexical (and
+ * the topic drop handler) from mistaking the payload for a dropped topic/text.
+ */
+export const THREAD_DRAG_MIME = 'application/x-lobe-thread';

--- a/packages/locales/src/default/common.ts
+++ b/packages/locales/src/default/common.ts
@@ -464,6 +464,8 @@ export default {
   'deleteSharedOwnerOnly':
     "Only a workspace owner can delete this — it carries other members' conversations",
   'manageOnlyCreator': 'Only the creator or a workspace owner can do this',
+  'openOnRight': 'Open on the right',
+  'openOnRightHint': 'Release to open side-by-side on the right',
   'operationFailed': 'Operation failed, please try again',
   'addNew': 'Add new',
   'gotIt': 'Got it',

--- a/src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.test.tsx
+++ b/src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.test.tsx
@@ -119,6 +119,8 @@ describe('useTopicItemDropdownMenu', () => {
     const items = result.current.dropdownMenu();
 
     expect(items.map((item) => (item && 'key' in item ? item.key : 'divider'))).toEqual([
+      'openOnRight',
+      'divider',
       'markCompleted',
       'favorite',
       'divider',

--- a/src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.tsx
+++ b/src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.tsx
@@ -13,6 +13,7 @@ import {
   Hash,
   Link2,
   LucideCopy,
+  PanelRight,
   PanelTop,
   PencilLine,
   Star,
@@ -62,6 +63,7 @@ export const useTopicItemDropdownMenu = ({
   const { allowed: canEditTopic } = usePermission('edit_own_content');
 
   const openTopicInNewWindow = useGlobalStore((s) => s.openTopicInNewWindow);
+  const openTopicInPortal = useChatStore((s) => s.openTopicInPortal);
   const activeAgentId = useAgentStore((s) => s.activeAgentId);
   const addTab = useElectronStore((s) => s.addTab);
   const appOrigin = useAppOrigin();
@@ -95,6 +97,17 @@ export const useTopicItemDropdownMenu = ({
     if (!id) return [];
 
     return [
+      {
+        icon: <Icon icon={PanelRight} />,
+        key: 'openOnRight',
+        label: t('openOnRight', { ns: 'common' }),
+        onClick: () => {
+          openTopicInPortal(id);
+        },
+      },
+      {
+        type: 'divider' as const,
+      },
       {
         disabled: !canEditTopic,
         icon: <Icon icon={isCompleted ? ArchiveRestore : Archive} />,
@@ -307,6 +320,7 @@ export const useTopicItemDropdownMenu = ({
     removeTopic,
     updateTopicTitle,
     openTopicInNewWindow,
+    openTopicInPortal,
     addTab,
     navigate,
     t,

--- a/src/features/AgentSidebar/Topic/TopicListContent/ThreadList/ThreadItem/index.tsx
+++ b/src/features/AgentSidebar/Topic/TopicListContent/ThreadList/ThreadItem/index.tsx
@@ -1,8 +1,10 @@
 import { Icon } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { CornerDownRight } from 'lucide-react';
+import type { DragEvent } from 'react';
 import { memo, useCallback } from 'react';
 
+import { startThreadDrag } from '@/features/ChatInput/InputEditor/ReferTopic/threadDragData';
 import NavItem from '@/features/NavPanel/components/NavItem';
 import { useChatStore } from '@/store/chat';
 
@@ -15,6 +17,7 @@ export interface ThreadItemProps {
   id: string;
   index: number;
   isSubagent?: boolean;
+  sourceMessageId?: string;
   title: string;
 }
 
@@ -23,7 +26,7 @@ export interface ThreadItemProps {
 // while the row background/highlight stays full-width.
 const SUBAGENT_PADDING_INLINE_START = 32;
 
-const ThreadItem = memo<ThreadItemProps>(({ title, id, isSubagent }) => {
+const ThreadItem = memo<ThreadItemProps>(({ title, id, isSubagent, sourceMessageId }) => {
   const [editing, activeThreadId] = useChatStore((s) => [
     s.threadRenamingId === id,
     s.activeThreadId,
@@ -43,8 +46,16 @@ const ThreadItem = memo<ThreadItemProps>(({ title, id, isSubagent }) => {
     navigateToThread(id);
   }, [editing, id, navigateToThread]);
 
+  const handleDragStart = useCallback(
+    (event: DragEvent) => {
+      startThreadDrag(event, { sourceMessageId, threadId: id, threadTitle: title });
+    },
+    [id, title, sourceMessageId],
+  );
+
   const dropdownMenu = useThreadItemDropdownMenu({
     id,
+    sourceMessageId,
     toggleEditing,
   });
 
@@ -53,6 +64,7 @@ const ThreadItem = memo<ThreadItemProps>(({ title, id, isSubagent }) => {
   return (
     <>
       <NavItem
+        draggable
         actions={<Actions dropdownMenu={dropdownMenu} />}
         active={active && !isInAgentSubRoute}
         contextMenuItems={dropdownMenu}
@@ -68,6 +80,7 @@ const ThreadItem = memo<ThreadItemProps>(({ title, id, isSubagent }) => {
           ...(isSubagent && { paddingInlineStart: SUBAGENT_PADDING_INLINE_START }),
         }}
         onClick={handleClick}
+        onDragStart={handleDragStart}
       />
       <Editing id={id} title={title} toggleEditing={toggleEditing} />
     </>

--- a/src/features/AgentSidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx
+++ b/src/features/AgentSidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx
@@ -1,7 +1,7 @@
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
-import { PencilLine, Trash } from 'lucide-react';
+import { PanelRight, PencilLine, Trash } from 'lucide-react';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -10,20 +10,36 @@ import { useChatStore } from '@/store/chat';
 
 interface ThreadItemDropdownMenuProps {
   id: string;
+  sourceMessageId?: string;
   toggleEditing: (visible?: boolean) => void;
 }
 
 export const useThreadItemDropdownMenu = ({
   id,
+  sourceMessageId,
   toggleEditing,
 }: ThreadItemDropdownMenuProps): (() => MenuProps['items']) => {
   const { t } = useTranslation(['thread', 'common']);
   const { allowed: canEditThread } = usePermission('edit_own_content');
 
-  const [removeThread] = useChatStore((s) => [s.removeThread]);
+  const [removeThread, openThreadInPortal] = useChatStore((s) => [
+    s.removeThread,
+    s.openThreadInPortal,
+  ]);
 
   return useCallback(() => {
     return [
+      {
+        icon: <Icon icon={PanelRight} />,
+        key: 'openOnRight',
+        label: t('openOnRight', { ns: 'common' }),
+        onClick: () => {
+          openThreadInPortal(id, sourceMessageId);
+        },
+      },
+      {
+        type: 'divider' as const,
+      },
       {
         disabled: !canEditThread,
         icon: <Icon icon={PencilLine} />,
@@ -58,5 +74,5 @@ export const useThreadItemDropdownMenu = ({
         sfSymbol: 'trash',
       },
     ].filter(Boolean) as MenuProps['items'];
-  }, [id, canEditThread, removeThread, toggleEditing, t]);
+  }, [id, sourceMessageId, canEditThread, removeThread, openThreadInPortal, toggleEditing, t]);
 };

--- a/src/features/AgentSidebar/Topic/TopicListContent/ThreadList/index.tsx
+++ b/src/features/AgentSidebar/Topic/TopicListContent/ThreadList/index.tsx
@@ -38,6 +38,7 @@ const ThreadList = memo(({ topicId }: { topicId: string }) => {
           index={index}
           isSubagent={item.type === ThreadType.Isolation}
           key={item.id}
+          sourceMessageId={item.sourceMessageId ?? undefined}
           title={item.title}
         />
       ))}

--- a/src/features/ChatInput/InputEditor/ReferTopic/dragLabelPreview.ts
+++ b/src/features/ChatInput/InputEditor/ReferTopic/dragLabelPreview.ts
@@ -1,0 +1,86 @@
+import { cssVar } from 'antd-style';
+import type React from 'react';
+
+const resolveCssVar = (ref: string, context: Element): string => {
+  const name = /var\((--[^\s),]+)/.exec(ref)?.[1];
+  if (!name) return ref;
+  return getComputedStyle(context).getPropertyValue(name).trim() || ref;
+};
+
+/**
+ * Replaces the browser's default drag ghost with a floating labelled pill that
+ * tracks the cursor — shared by the topic and thread sidebar drags so both read
+ * the same way. `iconSvg` is the inner markup of a 24×24 lucide icon.
+ */
+export const setDragLabelPreview = (
+  event: React.DragEvent,
+  { iconSvg, label }: { iconSvg: string; label: string },
+): void => {
+  if (typeof document === 'undefined') return;
+
+  const host = event.currentTarget as Element;
+  const ghost = document.createElement('div');
+  Object.assign(ghost.style, {
+    height: '1px',
+    left: '-9999px',
+    opacity: '0',
+    position: 'fixed',
+    top: '-9999px',
+    width: '1px',
+  });
+  document.body.append(ghost);
+  event.dataTransfer.setDragImage(ghost, 0, 0);
+
+  const preview = document.createElement('div');
+  Object.assign(preview.style, {
+    alignItems: 'center',
+    background: resolveCssVar(cssVar.colorBgElevated, host),
+    border: `1px solid ${resolveCssVar(cssVar.colorInfoBorder, host)}`,
+    borderRadius: '10px',
+    color: resolveCssVar(cssVar.colorInfo, host),
+    display: 'inline-flex',
+    fontSize: '13px',
+    gap: '8px',
+    left: '0',
+    lineHeight: '1',
+    maxWidth: '280px',
+    padding: '8px 14px',
+    pointerEvents: 'none',
+    position: 'fixed',
+    top: '0',
+    transform: `translate(${event.clientX}px, ${event.clientY}px) translate(-50%, -100%)`,
+    whiteSpace: 'nowrap',
+    zIndex: '9999',
+  });
+
+  const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  icon.setAttribute('width', '16');
+  icon.setAttribute('height', '16');
+  icon.setAttribute('viewBox', '0 0 24 24');
+  icon.setAttribute('fill', 'none');
+  icon.setAttribute('stroke', 'currentColor');
+  icon.setAttribute('stroke-width', '2');
+  icon.setAttribute('stroke-linecap', 'round');
+  icon.setAttribute('stroke-linejoin', 'round');
+  icon.innerHTML = iconSvg;
+  preview.append(icon);
+
+  const text = document.createElement('span');
+  text.textContent = label;
+  text.style.overflow = 'hidden';
+  text.style.textOverflow = 'ellipsis';
+  preview.append(text);
+  document.body.append(preview);
+
+  const move = (dragEvent: DragEvent) => {
+    preview.style.transform = `translate(${dragEvent.clientX}px, ${dragEvent.clientY}px) translate(-50%, -100%)`;
+  };
+  const cleanup = () => {
+    document.removeEventListener('dragover', move);
+    preview.remove();
+    ghost.remove();
+  };
+
+  document.addEventListener('dragover', move);
+  host.addEventListener('dragend', cleanup as EventListener, { once: true });
+};

--- a/src/features/ChatInput/InputEditor/ReferTopic/threadDragData.test.ts
+++ b/src/features/ChatInput/InputEditor/ReferTopic/threadDragData.test.ts
@@ -1,0 +1,50 @@
+import { THREAD_DRAG_MIME } from '@lobechat/const';
+import { describe, expect, it } from 'vitest';
+
+import { readThreadDragData, writeThreadDragData } from './threadDragData';
+
+describe('threadDragData', () => {
+  it('round-trips a thread payload through the custom MIME', () => {
+    const dataTransfer = new DataTransfer();
+    writeThreadDragData(dataTransfer, {
+      sourceMessageId: 'msg-9',
+      threadId: 'thread-1',
+      threadTitle: 'Side quest',
+    });
+
+    expect(dataTransfer.types).toContain(THREAD_DRAG_MIME);
+    expect(dataTransfer.effectAllowed).toBe('copy');
+    expect(readThreadDragData(dataTransfer)).toEqual({
+      sourceMessageId: 'msg-9',
+      threadId: 'thread-1',
+      threadTitle: 'Side quest',
+    });
+  });
+
+  it('does not react to unrelated drag data', () => {
+    const dataTransfer = new DataTransfer();
+    dataTransfer.setData('text/plain', 'thread-1');
+
+    expect(readThreadDragData(dataTransfer)).toBeUndefined();
+  });
+
+  it('rejects malformed data and payloads without an id', () => {
+    const dataTransfer = new DataTransfer();
+    dataTransfer.setData(THREAD_DRAG_MIME, '{invalid');
+    expect(readThreadDragData(dataTransfer)).toBeUndefined();
+
+    dataTransfer.setData(THREAD_DRAG_MIME, JSON.stringify({ threadTitle: 'Missing id' }));
+    expect(readThreadDragData(dataTransfer)).toBeUndefined();
+  });
+
+  it('leaves sourceMessageId undefined and falls back to an untitled title', () => {
+    const dataTransfer = new DataTransfer();
+    dataTransfer.setData(THREAD_DRAG_MIME, JSON.stringify({ threadId: 'thread-1' }));
+
+    expect(readThreadDragData(dataTransfer)).toEqual({
+      sourceMessageId: undefined,
+      threadId: 'thread-1',
+      threadTitle: 'Untitled',
+    });
+  });
+});

--- a/src/features/ChatInput/InputEditor/ReferTopic/threadDragData.ts
+++ b/src/features/ChatInput/InputEditor/ReferTopic/threadDragData.ts
@@ -1,0 +1,48 @@
+import { THREAD_DRAG_MIME } from '@lobechat/const';
+import type React from 'react';
+
+import { setDragLabelPreview } from './dragLabelPreview';
+
+export interface ThreadDragPayload {
+  sourceMessageId?: string;
+  threadId: string;
+  threadTitle: string;
+}
+
+export const writeThreadDragData = (
+  dataTransfer: DataTransfer,
+  payload: ThreadDragPayload,
+): void => {
+  dataTransfer.setData(THREAD_DRAG_MIME, JSON.stringify(payload));
+  dataTransfer.effectAllowed = 'copy';
+};
+
+// lucide `CornerDownRight` — the same glyph the thread rows use in the sidebar.
+const THREAD_ICON_SVG = '<path d="m15 10 5 5-5 5"/><path d="M4 4v7a4 4 0 0 0 4 4h12"/>';
+
+export const startThreadDrag = (event: React.DragEvent, payload: ThreadDragPayload): void => {
+  writeThreadDragData(event.dataTransfer, payload);
+  setDragLabelPreview(event, { iconSvg: THREAD_ICON_SVG, label: payload.threadTitle });
+};
+
+export const readThreadDragData = (dataTransfer: DataTransfer): ThreadDragPayload | undefined => {
+  const raw = dataTransfer.getData(THREAD_DRAG_MIME);
+  if (!raw) return undefined;
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<ThreadDragPayload>;
+    if (typeof parsed.threadId !== 'string' || parsed.threadId.length === 0) return undefined;
+
+    return {
+      sourceMessageId:
+        typeof parsed.sourceMessageId === 'string' ? parsed.sourceMessageId : undefined,
+      threadId: parsed.threadId,
+      threadTitle:
+        typeof parsed.threadTitle === 'string' && parsed.threadTitle.length > 0
+          ? parsed.threadTitle
+          : 'Untitled',
+    };
+  } catch {
+    return undefined;
+  }
+};

--- a/src/features/ChatInput/InputEditor/ReferTopic/topicDragData.ts
+++ b/src/features/ChatInput/InputEditor/ReferTopic/topicDragData.ts
@@ -1,6 +1,7 @@
 import { TOPIC_DRAG_MIME } from '@lobechat/const';
-import { cssVar } from 'antd-style';
 import type React from 'react';
+
+import { setDragLabelPreview } from './dragLabelPreview';
 
 export interface TopicDragPayload {
   topicId: string;
@@ -12,88 +13,12 @@ export const writeTopicDragData = (dataTransfer: DataTransfer, payload: TopicDra
   dataTransfer.effectAllowed = 'copy';
 };
 
-const resolveCssVar = (ref: string, context: Element): string => {
-  const name = /var\((--[^\s),]+)/.exec(ref)?.[1];
-  if (!name) return ref;
-  return getComputedStyle(context).getPropertyValue(name).trim() || ref;
-};
-
 const TOPIC_ICON_SVG =
   '<path d="M21 15a4 4 0 0 1-4 4H8l-5 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4Z"/><path d="M8 9h8"/><path d="M8 13h6"/>';
 
-const setTopicDragImage = (event: React.DragEvent, label: string): void => {
-  if (typeof document === 'undefined') return;
-
-  const host = event.currentTarget as Element;
-  const ghost = document.createElement('div');
-  Object.assign(ghost.style, {
-    height: '1px',
-    left: '-9999px',
-    opacity: '0',
-    position: 'fixed',
-    top: '-9999px',
-    width: '1px',
-  });
-  document.body.append(ghost);
-  event.dataTransfer.setDragImage(ghost, 0, 0);
-
-  const preview = document.createElement('div');
-  Object.assign(preview.style, {
-    alignItems: 'center',
-    background: resolveCssVar(cssVar.colorBgElevated, host),
-    border: `1px solid ${resolveCssVar(cssVar.colorInfoBorder, host)}`,
-    borderRadius: '10px',
-    color: resolveCssVar(cssVar.colorInfo, host),
-    display: 'inline-flex',
-    fontSize: '13px',
-    gap: '8px',
-    left: '0',
-    lineHeight: '1',
-    maxWidth: '280px',
-    padding: '8px 14px',
-    pointerEvents: 'none',
-    position: 'fixed',
-    top: '0',
-    transform: `translate(${event.clientX}px, ${event.clientY}px) translate(-50%, -100%)`,
-    whiteSpace: 'nowrap',
-    zIndex: '9999',
-  });
-
-  const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-  icon.setAttribute('width', '16');
-  icon.setAttribute('height', '16');
-  icon.setAttribute('viewBox', '0 0 24 24');
-  icon.setAttribute('fill', 'none');
-  icon.setAttribute('stroke', 'currentColor');
-  icon.setAttribute('stroke-width', '2');
-  icon.setAttribute('stroke-linecap', 'round');
-  icon.setAttribute('stroke-linejoin', 'round');
-  icon.innerHTML = TOPIC_ICON_SVG;
-  preview.append(icon);
-
-  const text = document.createElement('span');
-  text.textContent = label;
-  text.style.overflow = 'hidden';
-  text.style.textOverflow = 'ellipsis';
-  preview.append(text);
-  document.body.append(preview);
-
-  const move = (dragEvent: DragEvent) => {
-    preview.style.transform = `translate(${dragEvent.clientX}px, ${dragEvent.clientY}px) translate(-50%, -100%)`;
-  };
-  const cleanup = () => {
-    document.removeEventListener('dragover', move);
-    preview.remove();
-    ghost.remove();
-  };
-
-  document.addEventListener('dragover', move);
-  host.addEventListener('dragend', cleanup as EventListener, { once: true });
-};
-
 export const startTopicDrag = (event: React.DragEvent, payload: TopicDragPayload): void => {
   writeTopicDragData(event.dataTransfer, payload);
-  setTopicDragImage(event, payload.topicTitle);
+  setDragLabelPreview(event, { iconSvg: TOPIC_ICON_SVG, label: payload.topicTitle });
 };
 
 export const readTopicDragData = (dataTransfer: DataTransfer): TopicDragPayload | undefined => {

--- a/src/features/Conversation/SplitDropZone/index.tsx
+++ b/src/features/Conversation/SplitDropZone/index.tsx
@@ -36,7 +36,8 @@ const styles = createStaticStyles(({ css }) => ({
  */
 const SplitDropZone = memo<{ children: ReactNode }>(({ children }) => {
   const { t } = useTranslation('common');
-  const { dragKind, onDragEnter, onDragLeave, onDragOver, onDrop } = useConversationPanelDrop();
+  const { dragKind, onDragEnter, onDragLeave, onDragOver, onDrop, onDropCapture } =
+    useConversationPanelDrop();
 
   return (
     <Flexbox
@@ -45,6 +46,7 @@ const SplitDropZone = memo<{ children: ReactNode }>(({ children }) => {
       onDragLeave={onDragLeave}
       onDragOver={onDragOver}
       onDrop={onDrop}
+      onDropCapture={onDropCapture}
     >
       {children}
       {dragKind && (

--- a/src/features/Conversation/SplitDropZone/useConversationPanelDrop.ts
+++ b/src/features/Conversation/SplitDropZone/useConversationPanelDrop.ts
@@ -20,6 +20,7 @@ interface UseConversationPanelDropResult {
   onDragLeave: (event: React.DragEvent) => void;
   onDragOver: (event: React.DragEvent) => void;
   onDrop: (event: React.DragEvent) => void;
+  onDropCapture: (event: React.DragEvent) => void;
 }
 
 /**
@@ -58,11 +59,18 @@ export const useConversationPanelDrop = (): UseConversationPanelDropResult => {
     if (depthRef.current === 0) setDragKind(null);
   }, []);
 
+  // Capture-phase reset: a drop on the nested composer is consumed there
+  // (useTopicDrop stops propagation to insert a topic reference), so the
+  // bubble-phase handler below never runs for it. Capture always fires first,
+  // guaranteeing the overlay clears no matter which descendant owns the drop.
+  const onDropCapture = useCallback((_event: React.DragEvent) => {
+    depthRef.current = 0;
+    setDragKind(null);
+  }, []);
+
   const onDrop = useCallback(
     (event: React.DragEvent) => {
       const kind = resolveDragKind(event.dataTransfer.types);
-      depthRef.current = 0;
-      setDragKind(null);
       if (!kind) return;
 
       event.preventDefault();
@@ -80,5 +88,5 @@ export const useConversationPanelDrop = (): UseConversationPanelDropResult => {
     [openTopicInPortal, openThreadInPortal],
   );
 
-  return { dragKind, onDragEnter, onDragLeave, onDragOver, onDrop };
+  return { dragKind, onDragEnter, onDragLeave, onDragOver, onDrop, onDropCapture };
 };

--- a/src/features/Portal/Topic/Chat/index.tsx
+++ b/src/features/Portal/Topic/Chat/index.tsx
@@ -1,8 +1,14 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
+import { cssVar } from 'antd-style';
 import { memo, Suspense, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 
+import {
+  TopicMigrationPlaceholder,
+  useTopicMigrationPending,
+} from '@/features/AgentTransferMigration';
 import {
   ChatInput,
   ChatList,
@@ -14,6 +20,7 @@ import SkeletonList from '@/features/Conversation/components/SkeletonList';
 import { useChatFollowUp } from '@/features/Conversation/hooks/useChatFollowUp';
 import { useGatewayReconnect } from '@/hooks/useGatewayReconnect';
 import { useOperationState } from '@/hooks/useOperationState';
+import HeterogeneousChatInput from '@/routes/(main)/agent/features/Conversation/HeterogeneousChatInput';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
@@ -30,6 +37,7 @@ import { messageMapKey } from '@/store/chat/utils/messageMapKey';
  * load and stream independently and each can reply on its own.
  */
 const TopicChat = memo(() => {
+  const { t } = useTranslation('chat');
   const [activeAgentId, portalTopicId] = useChatStore((s) => [
     s.activeAgentId,
     chatPortalSelectors.portalTopicId(s),
@@ -69,6 +77,14 @@ const TopicChat = memo(() => {
     topicId: portalTopicId ?? undefined,
   });
 
+  // Same gate as the main conversation: a topic still awaiting its transfer
+  // backfill shows a placeholder instead of an empty history and blocks
+  // sending — the server could not assemble the missing context anyway.
+  const { job: migrationJob, topicPending } = useTopicMigrationPending(
+    activeAgentId,
+    portalTopicId,
+  );
+
   if (!portalTopicId) return null;
 
   return (
@@ -98,12 +114,30 @@ const TopicChat = memo(() => {
             position: 'relative',
           }}
         >
-          <ChatList
-            defaultWorkflowExpandLevel={isHeterogeneousAgent ? { streaming: 'full' } : undefined}
-          />
+          {topicPending ? (
+            <TopicMigrationPlaceholder agentId={activeAgentId} topicId={portalTopicId} />
+          ) : (
+            <ChatList
+              defaultWorkflowExpandLevel={isHeterogeneousAgent ? { streaming: 'full' } : undefined}
+            />
+          )}
         </Flexbox>
       </Suspense>
-      <ChatInput leftActions={['typo']} rightActions={['contextWindow']} />
+      {topicPending ? (
+        <Flexbox horizontal align={'center'} justify={'center'} paddingBlock={6} paddingInline={16}>
+          <span style={{ color: cssVar.colorTextDescription, fontSize: 12, textAlign: 'center' }}>
+            {t(
+              migrationJob?.type === 'copy'
+                ? 'transferMigration.inputDisabledHintCopy'
+                : 'transferMigration.inputDisabledHint',
+            )}
+          </span>
+        </Flexbox>
+      ) : isHeterogeneousAgent ? (
+        <HeterogeneousChatInput />
+      ) : (
+        <ChatInput leftActions={['typo']} rightActions={['contextWindow']} />
+      )}
     </ConversationProvider>
   );
 });

--- a/src/features/Portal/Topic/Chat/index.tsx
+++ b/src/features/Portal/Topic/Chat/index.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { Flexbox } from '@lobehub/ui';
+import { memo, Suspense, useMemo } from 'react';
+
+import {
+  ChatInput,
+  ChatList,
+  type ConversationContext,
+  type ConversationHooks,
+  ConversationProvider,
+} from '@/features/Conversation';
+import SkeletonList from '@/features/Conversation/components/SkeletonList';
+import { useChatFollowUp } from '@/features/Conversation/hooks/useChatFollowUp';
+import { useGatewayReconnect } from '@/hooks/useGatewayReconnect';
+import { useOperationState } from '@/hooks/useOperationState';
+import { useAgentStore } from '@/store/agent';
+import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
+import { useChatStore } from '@/store/chat';
+import { chatPortalSelectors, topicSelectors } from '@/store/chat/selectors';
+import { messageMapKey } from '@/store/chat/utils/messageMapKey';
+
+/**
+ * Topic Chat Component
+ *
+ * Renders a *second*, side-by-side conversation in the portal: the main column
+ * keeps rendering `activeTopicId`, while this pane renders a different topic
+ * (dragged in from the sidebar or opened via the row menu) under the same
+ * agent. Because everything is keyed by `messageMapKey(context)`, the two panes
+ * load and stream independently and each can reply on its own.
+ */
+const TopicChat = memo(() => {
+  const [activeAgentId, portalTopicId] = useChatStore((s) => [
+    s.activeAgentId,
+    chatPortalSelectors.portalTopicId(s),
+  ]);
+
+  const context: ConversationContext = useMemo(
+    () => ({
+      agentId: activeAgentId,
+      scope: 'main',
+      topicId: portalTopicId,
+    }),
+    [activeAgentId, portalTopicId],
+  );
+
+  const chatKey = useMemo(() => messageMapKey(context), [context]);
+  const replaceMessages = useChatStore((s) => s.replaceMessages);
+  const messages = useChatStore((s) => s.dbMessagesMap[chatKey]);
+
+  const operationState = useOperationState(context);
+
+  const isHeterogeneousAgent = useAgentStore(
+    agentByIdSelectors.isAgentHeterogeneousById(activeAgentId),
+  );
+
+  // Live-stream a topic that is already running when it's dragged in.
+  const runningOperation = useChatStore((s) =>
+    portalTopicId
+      ? topicSelectors.getTopicById(portalTopicId)(s)?.metadata?.runningOperation
+      : undefined,
+  );
+  useGatewayReconnect(portalTopicId, runningOperation);
+
+  const agentChatConfig = useAgentStore(chatConfigByIdSelectors.getChatConfigById(activeAgentId));
+  const hooks: ConversationHooks = useChatFollowUp({
+    agentChatConfig,
+    conversationKey: chatKey,
+    topicId: portalTopicId ?? undefined,
+  });
+
+  if (!portalTopicId) return null;
+
+  return (
+    <ConversationProvider
+      context={context}
+      hasInitMessages={!!messages}
+      hooks={hooks}
+      messages={messages}
+      operationState={operationState}
+      onMessagesChange={(msgs, ctx, meta) => {
+        replaceMessages(msgs, { context: ctx, source: meta?.source });
+      }}
+    >
+      <Suspense
+        fallback={
+          <Flexbox flex={1} height={'100%'}>
+            <SkeletonList />
+          </Flexbox>
+        }
+      >
+        <Flexbox
+          flex={1}
+          width={'100%'}
+          style={{
+            overflowX: 'hidden',
+            overflowY: 'auto',
+            position: 'relative',
+          }}
+        >
+          <ChatList
+            defaultWorkflowExpandLevel={isHeterogeneousAgent ? { streaming: 'full' } : undefined}
+          />
+        </Flexbox>
+      </Suspense>
+      <ChatInput leftActions={['typo']} rightActions={['contextWindow']} />
+    </ConversationProvider>
+  );
+});
+
+TopicChat.displayName = 'TopicChat';
+
+export default TopicChat;

--- a/src/features/Portal/Topic/Header/Title.tsx
+++ b/src/features/Portal/Topic/Header/Title.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { Text } from '@lobehub/ui';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useChatStore } from '@/store/chat';
+import { chatPortalSelectors, topicSelectors } from '@/store/chat/selectors';
+
+const Title = memo(() => {
+  const { t } = useTranslation('topic');
+  const title = useChatStore((s) => {
+    const topicId = chatPortalSelectors.portalTopicId(s);
+    return topicId ? topicSelectors.getTopicById(topicId)(s)?.title : undefined;
+  });
+
+  return (
+    <Text ellipsis style={{ fontSize: 14, fontWeight: 500 }}>
+      {title || t('defaultTitle')}
+    </Text>
+  );
+});
+
+Title.displayName = 'PortalTopicTitle';
+
+export default Title;

--- a/src/features/Portal/Topic/Header/index.tsx
+++ b/src/features/Portal/Topic/Header/index.tsx
@@ -1,0 +1,28 @@
+import { ActionIcon } from '@lobehub/ui';
+import { cssVar } from 'antd-style';
+import { XIcon } from 'lucide-react';
+import { memo } from 'react';
+
+import NavHeader from '@/features/NavHeader';
+import { useChatStore } from '@/store/chat';
+
+import Title from './Title';
+
+const Header = memo(() => {
+  const closeTopicPortal = useChatStore((s) => s.closeTopicPortal);
+
+  return (
+    <NavHeader
+      left={<Title />}
+      paddingBlock={6}
+      paddingInline={8}
+      right={<ActionIcon icon={XIcon} size={'small'} onClick={closeTopicPortal} />}
+      showTogglePanelButton={false}
+      style={{
+        borderBottom: `1px solid ${cssVar.colorBorderSecondary}`,
+      }}
+    />
+  );
+});
+
+export default Header;

--- a/src/features/Portal/Topic/index.ts
+++ b/src/features/Portal/Topic/index.ts
@@ -1,0 +1,9 @@
+import { type PortalImpl } from '../type';
+import Chat from './Chat';
+import Header from './Header';
+
+export const Topic: PortalImpl = {
+  Body: Chat,
+  Header,
+  Title: () => null,
+};

--- a/src/features/Portal/portalWidth.ts
+++ b/src/features/Portal/portalWidth.ts
@@ -25,6 +25,7 @@ const VIEW_MIN_WIDTH: PortalWidths = {
   [PortalViewType.TaskDetail]: CHAT_PORTAL_TOOL_UI_WIDTH,
   [PortalViewType.Thread]: CHAT_PORTAL_TOOL_UI_WIDTH,
   [PortalViewType.ToolUI]: CHAT_PORTAL_TOOL_UI_WIDTH,
+  [PortalViewType.Topic]: CHAT_PORTAL_TOOL_UI_WIDTH,
 };
 
 /**

--- a/src/features/Portal/router.tsx
+++ b/src/features/Portal/router.tsx
@@ -21,6 +21,7 @@ import { Notebook } from './Notebook';
 import { Plugins } from './Plugins';
 import { TaskDetail } from './TaskDetail';
 import { Thread } from './Thread';
+import { Topic } from './Topic';
 import { TopicComments, TopicCommentThread } from './TopicComments';
 import { type PortalImpl } from './type';
 import { VerifyReport } from './VerifyReport';
@@ -44,6 +45,7 @@ const VIEW_COMPONENTS: Record<PortalViewType, PortalImpl> = {
   [PortalViewType.ToolUI]: Plugins,
   [PortalViewType.TaskDetail]: TaskDetail,
   [PortalViewType.Thread]: Thread,
+  [PortalViewType.Topic]: Topic,
   [PortalViewType.TopicCommentThread]: TopicCommentThread,
   [PortalViewType.TopicComments]: TopicComments,
   [PortalViewType.GroupThread]: GroupThread,

--- a/src/routes/(main)/agent/(chat)/_layout/index.tsx
+++ b/src/routes/(main)/agent/(chat)/_layout/index.tsx
@@ -9,6 +9,7 @@ import { Outlet } from 'react-router';
 import ChatTerminalPanel from '@/features/ChatTerminal';
 import AgentWorkingSidebar from '@/features/Conversation/WorkingSidebar';
 import ChatHeader from '@/routes/(main)/agent/features/Conversation/Header';
+import SplitDropZone from '@/routes/(main)/agent/features/Conversation/SplitDropZone';
 import Portal from '@/routes/(main)/agent/features/Portal';
 
 import HeaderSlot from './HeaderSlot';
@@ -46,9 +47,9 @@ const ChatLayout = memo(() => {
             style={{ minHeight: 0, minWidth: 0 }}
           >
             <ChatHeader />
-            <Flexbox flex={1} style={{ minHeight: 0, position: 'relative' }}>
+            <SplitDropZone>
               <Outlet />
-            </Flexbox>
+            </SplitDropZone>
           </Flexbox>
           <Portal />
           <AgentWorkingSidebar availableWidth={rowSize?.width} />

--- a/src/routes/(main)/agent/(chat)/_layout/index.tsx
+++ b/src/routes/(main)/agent/(chat)/_layout/index.tsx
@@ -7,9 +7,9 @@ import { memo, useRef } from 'react';
 import { Outlet } from 'react-router';
 
 import ChatTerminalPanel from '@/features/ChatTerminal';
+import SplitDropZone from '@/features/Conversation/SplitDropZone';
 import AgentWorkingSidebar from '@/features/Conversation/WorkingSidebar';
 import ChatHeader from '@/routes/(main)/agent/features/Conversation/Header';
-import SplitDropZone from '@/routes/(main)/agent/features/Conversation/SplitDropZone';
 import Portal from '@/routes/(main)/agent/features/Portal';
 
 import HeaderSlot from './HeaderSlot';

--- a/src/routes/(main)/agent/features/Conversation/SplitDropZone/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/SplitDropZone/index.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { Flexbox, Icon, Text } from '@lobehub/ui';
+import { createStaticStyles, cssVar } from 'antd-style';
+import { PanelRight } from 'lucide-react';
+import { memo, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useConversationPanelDrop } from './useConversationPanelDrop';
+
+const styles = createStaticStyles(({ css }) => ({
+  overlay: css`
+    pointer-events: none;
+
+    position: absolute;
+    z-index: 20;
+    inset: 8px;
+
+    border: 2px dashed ${cssVar.colorInfoBorder};
+    border-radius: ${cssVar.borderRadiusLG};
+
+    opacity: 0.9;
+    background: ${cssVar.colorInfoBg};
+  `,
+  root: css`
+    position: relative;
+    flex: 1;
+    min-height: 0;
+  `,
+}));
+
+/**
+ * Wraps the main conversation body so a topic/thread dragged from the sidebar
+ * can be dropped to open side-by-side in the portal. Renders a highlight
+ * overlay while a droppable payload hovers.
+ */
+const SplitDropZone = memo<{ children: ReactNode }>(({ children }) => {
+  const { t } = useTranslation('common');
+  const { dragKind, onDragEnter, onDragLeave, onDragOver, onDrop } = useConversationPanelDrop();
+
+  return (
+    <Flexbox
+      className={styles.root}
+      onDragEnter={onDragEnter}
+      onDragLeave={onDragLeave}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+    >
+      {children}
+      {dragKind && (
+        <Flexbox align={'center'} className={styles.overlay} justify={'center'}>
+          <Flexbox align={'center'} gap={8} style={{ color: cssVar.colorInfo }}>
+            <Icon icon={PanelRight} size={28} />
+            <Text style={{ color: 'inherit', fontSize: 14, fontWeight: 500 }}>
+              {t('openOnRightHint')}
+            </Text>
+          </Flexbox>
+        </Flexbox>
+      )}
+    </Flexbox>
+  );
+});
+
+SplitDropZone.displayName = 'SplitDropZone';
+
+export default SplitDropZone;

--- a/src/routes/(main)/agent/features/Conversation/SplitDropZone/useConversationPanelDrop.ts
+++ b/src/routes/(main)/agent/features/Conversation/SplitDropZone/useConversationPanelDrop.ts
@@ -1,0 +1,84 @@
+import { THREAD_DRAG_MIME, TOPIC_DRAG_MIME } from '@lobechat/const';
+import type React from 'react';
+import { useCallback, useRef, useState } from 'react';
+
+import { readThreadDragData } from '@/features/ChatInput/InputEditor/ReferTopic/threadDragData';
+import { readTopicDragData } from '@/features/ChatInput/InputEditor/ReferTopic/topicDragData';
+import { useChatStore } from '@/store/chat';
+
+export type PanelDragKind = 'topic' | 'thread';
+
+const resolveDragKind = (types: readonly string[]): PanelDragKind | null => {
+  if (types.includes(TOPIC_DRAG_MIME)) return 'topic';
+  if (types.includes(THREAD_DRAG_MIME)) return 'thread';
+  return null;
+};
+
+interface UseConversationPanelDropResult {
+  dragKind: PanelDragKind | null;
+  onDragEnter: (event: React.DragEvent) => void;
+  onDragLeave: (event: React.DragEvent) => void;
+  onDragOver: (event: React.DragEvent) => void;
+  onDrop: (event: React.DragEvent) => void;
+}
+
+/**
+ * Drop target for the main conversation column: dropping a sidebar topic or
+ * thread here opens it side-by-side in the portal (a second conversation),
+ * instead of the input's "refer topic" behaviour. The input owns TOPIC drops
+ * over itself (it stops propagation), so those still insert a reference — only
+ * drops on the conversation body reach here.
+ */
+export const useConversationPanelDrop = (): UseConversationPanelDropResult => {
+  const [dragKind, setDragKind] = useState<PanelDragKind | null>(null);
+  // dragenter/dragleave fire for every descendant; a depth counter keeps the
+  // overlay stable until the pointer truly leaves the column.
+  const depthRef = useRef(0);
+  const [openTopicInPortal, openThreadInPortal] = useChatStore((s) => [
+    s.openTopicInPortal,
+    s.openThreadInPortal,
+  ]);
+
+  const onDragEnter = useCallback((event: React.DragEvent) => {
+    const kind = resolveDragKind(event.dataTransfer.types);
+    if (!kind) return;
+    depthRef.current += 1;
+    setDragKind(kind);
+  }, []);
+
+  const onDragOver = useCallback((event: React.DragEvent) => {
+    if (!resolveDragKind(event.dataTransfer.types)) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+  }, []);
+
+  const onDragLeave = useCallback((event: React.DragEvent) => {
+    if (!resolveDragKind(event.dataTransfer.types)) return;
+    depthRef.current = Math.max(0, depthRef.current - 1);
+    if (depthRef.current === 0) setDragKind(null);
+  }, []);
+
+  const onDrop = useCallback(
+    (event: React.DragEvent) => {
+      const kind = resolveDragKind(event.dataTransfer.types);
+      depthRef.current = 0;
+      setDragKind(null);
+      if (!kind) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (kind === 'topic') {
+        const payload = readTopicDragData(event.dataTransfer);
+        if (payload) openTopicInPortal(payload.topicId);
+        return;
+      }
+
+      const payload = readThreadDragData(event.dataTransfer);
+      if (payload) openThreadInPortal(payload.threadId, payload.sourceMessageId);
+    },
+    [openTopicInPortal, openThreadInPortal],
+  );
+
+  return { dragKind, onDragEnter, onDragLeave, onDragOver, onDrop };
+};

--- a/src/store/chat/slices/portal/action.test.ts
+++ b/src/store/chat/slices/portal/action.test.ts
@@ -1177,4 +1177,50 @@ describe('chatDockSlice', () => {
       expect(result.current.showPortal).toBe(true);
     });
   });
+
+  describe('openTopicInPortal', () => {
+    it('opens a topic as a side-by-side portal view and exposes its id', () => {
+      const { result } = renderHook(() => useChatStore());
+
+      act(() => {
+        result.current.openTopicInPortal('tpc-1');
+      });
+
+      expect(result.current.portalStack.at(-1)).toEqual({
+        type: PortalViewType.Topic,
+        topicId: 'tpc-1',
+      });
+      expect(result.current.showPortal).toBe(true);
+      expect(chatPortalSelectors.portalTopicId(result.current)).toBe('tpc-1');
+      expect(chatPortalSelectors.showTopicChat(result.current)).toBe(true);
+    });
+
+    it('replaces the topic view when a different topic is dragged in', () => {
+      const { result } = renderHook(() => useChatStore());
+
+      act(() => {
+        result.current.openTopicInPortal('tpc-1');
+      });
+      act(() => {
+        result.current.openTopicInPortal('tpc-2');
+      });
+
+      expect(result.current.portalStack).toHaveLength(1);
+      expect(chatPortalSelectors.portalTopicId(result.current)).toBe('tpc-2');
+    });
+
+    it('closeTopicPortal pops only when a topic view is on top', () => {
+      const { result } = renderHook(() => useChatStore());
+
+      act(() => {
+        result.current.openTopicInPortal('tpc-1');
+      });
+      act(() => {
+        result.current.closeTopicPortal();
+      });
+
+      expect(result.current.showPortal).toBe(false);
+      expect(chatPortalSelectors.portalTopicId(result.current)).toBeUndefined();
+    });
+  });
 });

--- a/src/store/chat/slices/portal/action.ts
+++ b/src/store/chat/slices/portal/action.ts
@@ -657,6 +657,17 @@ export class ChatPortalActionImpl {
     this.#get().pushPortalView({ identifier, messageId, params, type: PortalViewType.ToolUI });
   };
 
+  openTopicInPortal = (topicId: string): void => {
+    this.#get().pushPortalView({ topicId, type: PortalViewType.Topic });
+  };
+
+  closeTopicPortal = (): void => {
+    const { portalStack } = this.#get();
+    if (getCurrentViewType(portalStack) === PortalViewType.Topic) {
+      this.#get().popPortalView();
+    }
+  };
+
   openVerifyResult = (operationId: string, checkItemId: string): void => {
     this.#get().pushPortalView({ checkItemId, operationId, type: PortalViewType.VerifyResult });
   };

--- a/src/store/chat/slices/portal/initialState.ts
+++ b/src/store/chat/slices/portal/initialState.ts
@@ -24,6 +24,7 @@ export enum PortalViewType {
   TaskDetail = 'taskDetail',
   Thread = 'thread',
   ToolUI = 'toolUI',
+  Topic = 'topic',
   TopicComments = 'topicComments',
   TopicCommentThread = 'topicCommentThread',
   VerifyReport = 'verifyReport',
@@ -72,6 +73,7 @@ export type PortalViewData =
       type: PortalViewType.ToolUI;
     }
   | { startMessageId?: string; threadId?: string; type: PortalViewType.Thread }
+  | { topicId: string; type: PortalViewType.Topic }
   | { agentId: string; type: PortalViewType.GroupThread }
   | { taskId: string; type: PortalViewType.TaskDetail }
   | {

--- a/src/store/chat/slices/portal/selectors.ts
+++ b/src/store/chat/slices/portal/selectors.ts
@@ -52,6 +52,7 @@ const showMessageDetail = (s: ChatStoreState) =>
   currentViewType(s) === PortalViewType.MessageDetail;
 const showPluginUI = (s: ChatStoreState) => currentViewType(s) === PortalViewType.ToolUI;
 const showTaskDetail = (s: ChatStoreState) => currentViewType(s) === PortalViewType.TaskDetail;
+const showTopicChat = (s: ChatStoreState) => currentViewType(s) === PortalViewType.Topic;
 
 // ============== Data Extractors ==============
 
@@ -248,6 +249,12 @@ const taskDetailId = (s: ChatStoreState): string | undefined => {
   return view?.taskId;
 };
 
+// Topic chat selectors — the second, side-by-side topic opened in the portal
+const portalTopicId = (s: ChatStoreState): string | undefined => {
+  const view = getViewData(s, PortalViewType.Topic);
+  return view?.topicId;
+};
+
 const topicCommentsView = (s: ChatStoreState) => getViewData(s, PortalViewType.TopicComments);
 const topicCommentThreadView = (s: ChatStoreState) =>
   getViewData(s, PortalViewType.TopicCommentThread);
@@ -297,6 +304,7 @@ export const chatPortalSelectors = {
   showMessageDetail,
   showPluginUI,
   showTaskDetail,
+  showTopicChat,
 
   // Agent detail data
   agentDetailId,
@@ -337,6 +345,9 @@ export const chatPortalSelectors = {
 
   // Task detail data
   taskDetailId,
+
+  // Topic chat data
+  portalTopicId,
 
   // Topic comment data
   topicCommentsView,


### PR DESCRIPTION
## 💻 变更类型 | Change Type

- [x] ✨ feat

## 🔀 变更说明 | Description of Change

Open a **second conversation side-by-side** in the portal, without leaving the current one.

Two entry points, one shared destination:

- **Drag** a topic or sub-topic (thread) row from the sidebar into the conversation area — a drop zone highlights with a "Release to open side-by-side on the right" hint, and dropping opens it in the right-hand portal.
- **Row menu** → **"Open on the right"** on any topic or thread row does the same without dragging.

Each pane keeps its own message stream and composer, so you can read/reply in both independently. The active (left) conversation never changes.

### What's inside

- `PortalViewType.Topic` + a `Topic` portal view (`src/features/Portal/Topic/*`) rendering a full chat pane by `topicId`
- `openTopicInPortal` / `closeTopicPortal` store actions; `portalTopicId` / `showTopicChat` selectors
- `SplitDropZone` drop target wrapping the conversation `<Outlet />`, with `useConversationPanelDrop` handling both topic and thread payloads
- A shared HTML5 drag protocol: `threadDrag` MIME const, `threadDragData` (+ test), and `dragLabelPreview` extracted from the existing `topicDragData` so topic and thread rows share one drag-image implementation
- `openOnRight` / `openOnRightHint` i18n keys (en-US + zh-CN)

## 📝 补充信息 | Additional Information

Verified end-to-end on a real SPA via agent-testing (topic menu, side-by-side render, drag with hover-highlight + drop, per-pane composers, thread portal render). The thread **sidebar-row** affordance is covered by unit tests (`threadDragData.test.ts`) plus the code-identical topic-row path; its live end state (`openThreadInPortal`) was exercised directly.

## 🧪 How to Test

1. Open an agent with multiple topics.
2. Right-click a topic (or sub-topic) row → **Open on the right** → a second conversation opens in the right portal; the left one is unchanged.
2. Drag a topic/thread row into the conversation body → drop zone shows the hint → release → opens side-by-side.
3. Confirm each pane has its own composer and message stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)