### PR TITLE
🐛 fix: clarify acceptance plan API key errors

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/verify.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/verify.test.ts
@@ -12,6 +12,7 @@ const modelMocks = vi.hoisted(() => ({
   findRunByOperation: vi.fn(),
   findRunById: vi.fn(),
   findResultById: vi.fn(),
+  generateCriteria: vi.fn(),
   getFullFileUrl: vi.fn(),
   getServerDB: vi.fn(async () => ({})),
   updateRun: vi.fn(),
@@ -50,7 +51,9 @@ vi.mock('@/server/services/verify', async (importOriginal) => ({
   ...(await importOriginal<typeof VerifyServiceModule>()),
   VerifyExecutorService: class VerifyExecutorService {},
   VerifyFeedbackService: class VerifyFeedbackService {},
-  VerifyPlanGeneratorService: class VerifyPlanGeneratorService {},
+  VerifyPlanGeneratorService: class VerifyPlanGeneratorService {
+    generateCriteria = modelMocks.generateCriteria;
+  },
   VerifyReporterService: class VerifyReporterService {},
 }));
 
@@ -81,6 +84,31 @@ describe('verifyRouter', () => {
           getFullFileUrl: modelMocks.getFullFileUrl,
         }) as any,
     );
+  });
+
+  describe('generateCriteria', () => {
+    it('preserves InvalidProviderAPIKey as an actionable client error', async () => {
+      modelMocks.generateCriteria.mockRejectedValueOnce({ errorType: 'InvalidProviderAPIKey' });
+
+      await expect(
+        createCaller().generateCriteria({
+          goal: 'Ship a responsive task board',
+          modelConfig: { model: 'claude-sonnet-4-6', provider: 'anthropic' },
+        }),
+      ).rejects.toMatchObject({ code: 'UNAUTHORIZED', message: 'InvalidProviderAPIKey' });
+    });
+
+    it('does not rewrite unrelated generation failures', async () => {
+      const providerError = new Error('Provider timed out');
+      modelMocks.generateCriteria.mockRejectedValueOnce(providerError);
+
+      await expect(
+        createCaller().generateCriteria({
+          goal: 'Ship a responsive task board',
+          modelConfig: { model: 'claude-sonnet-4-6', provider: 'anthropic' },
+        }),
+      ).rejects.toThrow('Provider timed out');
+    });
   });
 
   describe('ingestResult', () => {

--- a/apps/server/src/routers/lambda/verify.ts
+++ b/apps/server/src/routers/lambda/verify.ts
@@ -5,6 +5,7 @@ import {
   verifySurfaces,
   verifyVisibilities,
 } from '@lobechat/const/verify';
+import { AgentRuntimeErrorType } from '@lobechat/model-runtime';
 import type {
   VerifyCheckItem,
   VerifyCheckResultMetadata,
@@ -489,7 +490,22 @@ export const verifyRouter = router({
         modelConfig: modelConfigSchema,
       }),
     )
-    .mutation(async ({ ctx, input }) => ctx.planGenerator.generateCriteria(input)),
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await ctx.planGenerator.generateCriteria(input);
+      } catch (error) {
+        const errorType = (error as { errorType?: unknown } | null)?.errorType;
+        if (errorType === AgentRuntimeErrorType.InvalidProviderAPIKey) {
+          throw new TRPCError({
+            cause: error,
+            code: 'UNAUTHORIZED',
+            message: AgentRuntimeErrorType.InvalidProviderAPIKey,
+          });
+        }
+
+        throw error;
+      }
+    }),
 
   /** Persist (user-edited) drafts as standalone criteria; returns their ids in order. */
   createCriteria: verifyWriteProcedure

--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -1756,6 +1756,7 @@
   "verifyConfig.fromTemplate": "Pick from template",
   "verifyConfig.generate": "Generate acceptance plan",
   "verifyConfig.generateFailed": "Failed to generate acceptance plan",
+  "verifyConfig.generateInvalidProviderAPIKey": "The API key for {{provider}} is invalid or missing. Check the provider settings for {{model}} and try again.",
   "verifyConfig.generating": "Breaking down acceptance criteria…",
   "verifyConfig.manualAdd": "Add manually",
   "verifyConfig.moreActions": "More actions",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -1756,6 +1756,7 @@
   "verifyConfig.fromTemplate": "从模板选择",
   "verifyConfig.generate": "生成验收方案",
   "verifyConfig.generateFailed": "生成验收方案失败",
+  "verifyConfig.generateInvalidProviderAPIKey": "{{provider}} 的 API 密钥无效或缺失，请检查 {{model}} 的服务商设置后重试。",
   "verifyConfig.generating": "正在拆解验收项…",
   "verifyConfig.manualAdd": "手动添加",
   "verifyConfig.moreActions": "更多操作",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -2371,6 +2371,8 @@ export default {
   'verifyConfig.fromTemplate': 'Pick from template',
   'verifyConfig.generate': 'Generate acceptance plan',
   'verifyConfig.generateFailed': 'Failed to generate acceptance plan',
+  'verifyConfig.generateInvalidProviderAPIKey':
+    'The API key for {{provider}} is invalid or missing. Check the provider settings for {{model}} and try again.',
   'verifyConfig.generating': 'Breaking down acceptance criteria…',
   'verifyConfig.manualAdd': 'Add manually',
   'verifyConfig.moreActions': 'More actions',

--- a/src/features/AgentTasks/AgentTaskDetail/TaskVerifyConfig.test.ts
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskVerifyConfig.test.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it } from 'vitest';
 
-import { toTemplateCriterionDrafts } from './TaskVerifyConfig';
+import { isInvalidProviderApiKeyError, toTemplateCriterionDrafts } from './TaskVerifyConfig';
+
+describe('isInvalidProviderApiKeyError', () => {
+  it.each([
+    { errorType: 'InvalidProviderAPIKey' },
+    { message: 'InvalidProviderAPIKey' },
+    { data: { errorType: 'InvalidProviderAPIKey' } },
+    { data: { errorData: { errorType: 'InvalidProviderAPIKey' } } },
+  ])('recognizes the runtime error across tRPC serialization shapes', (error) => {
+    expect(isInvalidProviderApiKeyError(error)).toBe(true);
+  });
+
+  it('does not classify unrelated generation errors as API key failures', () => {
+    expect(isInvalidProviderApiKeyError(new Error('Provider timed out'))).toBe(false);
+  });
+});
 
 describe('toTemplateCriterionDrafts', () => {
   it('removes task-local identities when snapshotting criteria for a reusable rubric', () => {

--- a/src/features/AgentTasks/AgentTaskDetail/TaskVerifyConfig.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskVerifyConfig.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { AgentRuntimeErrorType } from '@lobechat/model-runtime';
 import { ActionIcon, Block, Flexbox, Icon, SortableList, Tag, Text, TextArea } from '@lobehub/ui';
 import {
   Button,
@@ -93,6 +94,23 @@ const toDraftItem = (draft: VerifyCriterionDraft, criterionId?: string): DraftIt
   criterionId,
   id: nextUid(),
 });
+
+export const isInvalidProviderApiKeyError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') return false;
+
+  const errorRecord = error as {
+    data?: { errorData?: { errorType?: unknown }; errorType?: unknown };
+    errorType?: unknown;
+    message?: unknown;
+  };
+
+  return [
+    errorRecord.errorType,
+    errorRecord.message,
+    errorRecord.data?.errorType,
+    errorRecord.data?.errorData?.errorType,
+  ].includes(AgentRuntimeErrorType.InvalidProviderAPIKey);
+};
 
 /** Snapshot task-owned criteria into independent rows before mounting them on a reusable rubric. */
 export const toTemplateCriterionDrafts = (drafts: DraftItem[]): VerifyCriterionDraft[] =>
@@ -357,7 +375,11 @@ const TaskVerifyConfig = memo(() => {
         commit(items, { enabled: true, requirement: goal });
       } catch (error) {
         console.error('[TaskVerifyConfig] generate failed:', error);
-        toast.error(t('verifyConfig.generateFailed'));
+        toast.error(
+          isInvalidProviderApiKeyError(error)
+            ? t('verifyConfig.generateInvalidProviderAPIKey', { model, provider })
+            : t('verifyConfig.generateFailed'),
+        );
       } finally {
         setGenerating(false);
       }


### PR DESCRIPTION
## What changed

- preserve `InvalidProviderAPIKey` when acceptance-plan generation crosses the tRPC boundary
- show an actionable error containing the selected provider and model
- add English and Chinese copy plus server/client regression coverage

## Why

Acceptance-plan generation previously collapsed provider credential failures into the generic “Failed to generate acceptance plan” toast. Production tracing showed the affected request failed with `InvalidProviderAPIKey`, but users had no indication that their provider credentials needed attention.

## Impact

Users now see which provider/model configuration needs to be checked. Other generation failures continue to use the existing generic message.

## Validation

- `bun run check <7 changed files>`
- 7 files lint clean
- 37 related tests passed
