### PR TITLE
✨ feat(agent): move channels & statistics into a profile Segmented switcher

### DIFF
--- a/.agents/acceptance/common-mistakes.md
+++ b/.agents/acceptance/common-mistakes.md
@@ -230,6 +230,26 @@ and intermediate flex sizing can hide the intended inner scrollbars.
 independent scroll regions to navigation and detail, and verify scroll ownership with
 DOM measurements as well as visual evidence.
 
+### L-D7 — Treating a route-driven Segmented's selected segment as a clickable affordance
+
+**Wrong approach:** put a `Segmented` in a page header, have `onChange` write the URL, and
+then rely on clicking the already-selected segment to reach that section's own index route —
+typically to get back to a list from a `:param` detail route nested under it. Removing the
+breadcrumb's section link on the strength of that assumption is the usual companion move.
+
+**Why it fails:** `Segmented` fires only on a _change_, so the active segment dispatches
+nothing. On the detail route the segment is still highlighted, so it reads as the obvious way
+back while being completely inert — the click is silent, the URL does not move, and nothing
+errors. A grouped route family makes this easy to miss, because the switcher works perfectly
+on every sibling index route and fails only one level deeper.
+
+**Correct approach:** treat a route-driven Segmented as a switcher between sibling sections,
+never as navigation _within_ the selected section. Whenever a section owns deeper routes,
+keep a separate ancestor affordance for them — the breadcrumb's section link is the natural
+one. Where that link would otherwise duplicate the segment's own label, render it only on the
+deeper routes and let the segment name the section on the index route. Verify the deepest
+route of every section, not just the index: an index-only pass cannot see this failure.
+
 ## Environment safety
 
 ### L-S0 — Concluding a dependency moved from the root manifest alone

--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -1081,6 +1081,7 @@
   "tab.groupProfile": "Group Profile",
   "tab.integration": "Channels",
   "tab.profile": "Agent Profile",
+  "tab.profileBasic": "Profile",
   "tab.search": "Search",
   "tab.tasks": "Tasks",
   "task.activity.calling": "Calling Skill...",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -1081,6 +1081,7 @@
   "tab.groupProfile": "群组档案",
   "tab.integration": "消息频道",
   "tab.profile": "助理档案",
+  "tab.profileBasic": "基础档案",
   "tab.search": "搜索",
   "tab.tasks": "任务",
   "task.activity.calling": "正在调用技能…",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -1172,6 +1172,7 @@ export default {
   'tab.groupProfile': 'Group Profile',
   'tab.integration': 'Channels',
   'tab.profile': 'Agent Profile',
+  'tab.profileBasic': 'Profile',
   'tab.search': 'Search',
   'tab.tasks': 'Tasks',
   'task.activity.calling': 'Calling Skill...',

--- a/src/features/AgentBreadcrumb/index.tsx
+++ b/src/features/AgentBreadcrumb/index.tsx
@@ -40,8 +40,11 @@ interface AgentBreadcrumbProps {
   extraItems?: ReactNode[];
   /**
    * The current section under the agent, e.g. 话题 / 助理档案 / 用量与成本.
+   * Omit it where the page already names its own section — the profile group
+   * carries a Segmented switcher, so repeating the active tab here would render
+   * the same word twice in one 44px bar.
    */
-  title: ReactNode;
+  title?: ReactNode;
 }
 
 /**
@@ -80,13 +83,17 @@ const AgentBreadcrumb = memo<AgentBreadcrumbProps>(({ agentId, extraItems, title
             </Link>
           ),
         },
-        {
-          title: (
-            <Text as={'span'} color={'inherit'} weight={500}>
-              {title}
-            </Text>
-          ),
-        },
+        ...(title === undefined || title === null
+          ? []
+          : [
+              {
+                title: (
+                  <Text as={'span'} color={'inherit'} weight={500}>
+                    {title}
+                  </Text>
+                ),
+              },
+            ]),
         ...(extraItems ?? []).map((item, index) => ({
           key: `extra-${index}`,
           title: (

--- a/src/features/AgentProfileTabs/index.tsx
+++ b/src/features/AgentProfileTabs/index.tsx
@@ -29,9 +29,14 @@ export type { AgentProfileTab } from './tabOptions';
  * three headers can't drift.
  */
 export const AGENT_PROFILE_TABS_CENTER_STYLE: CSSProperties = {
-  insetBlockStart: '50%',
-  insetInlineStart: '50%',
+  // Physical `left`/`top`, not `inset-inline-start`: the paired transform below
+  // is physical (always shifts left/up), so a logical anchor would resolve to
+  // `right: 50%` under an RTL locale while the transform still pulls left —
+  // landing the switcher far left of center. Physical anchor + physical
+  // transform compose correctly in both LTR and RTL.
+  left: '50%',
   position: 'absolute',
+  top: '50%',
   // Both axes: an absolutely-positioned flex child no longer inherits the row's
   // vertical centering, so center it explicitly rather than trusting top:auto.
   transform: 'translate(-50%, -50%)',

--- a/src/features/AgentProfileTabs/index.tsx
+++ b/src/features/AgentProfileTabs/index.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { Segmented } from '@lobehub/ui/base-ui';
+import { type CSSProperties, memo, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useResourceAccess } from '@/features/ResourcePermission/useResourceAccess';
+import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
+import { usePermission } from '@/hooks/usePermission';
+import { useAgentStore } from '@/store/agent';
+import { agentSelectors } from '@/store/agent/selectors';
+import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
+
+import {
+  type AgentProfileTab,
+  buildAgentProfileTabOptions,
+  buildAgentProfileTabPath,
+  supportsMessageChannels,
+} from './tabOptions';
+
+export type { AgentProfileTab } from './tabOptions';
+
+/**
+ * Style for the host `NavHeader`'s `center` slot so the switcher sits on the
+ * *header* midpoint with equal gaps on both sides — not merely centered within
+ * the leftover flex track between the left/right slots (whose widths differ, so
+ * that reads as space-between, not centered). Requires the NavHeader itself to
+ * be `position: relative`. Shared by every page that hosts the switcher so the
+ * three headers can't drift.
+ */
+export const AGENT_PROFILE_TABS_CENTER_STYLE: CSSProperties = {
+  insetBlockStart: '50%',
+  insetInlineStart: '50%',
+  position: 'absolute',
+  // Both axes: an absolutely-positioned flex child no longer inherits the row's
+  // vertical centering, so center it explicitly rather than trusting top:auto.
+  transform: 'translate(-50%, -50%)',
+};
+
+interface AgentProfileTabsProps {
+  /** The tab owned by the page rendering this switcher. */
+  active: AgentProfileTab;
+  agentId: string;
+}
+
+/**
+ * Segmented switcher shared by the agent profile group — Profile / Channels /
+ * Statistics. The three surfaces are separate routes, so a segment writes the
+ * URL rather than holding local state: deep links and back/forward keep working.
+ */
+const AgentProfileTabs = memo<AgentProfileTabsProps>(({ active, agentId }) => {
+  const { t } = useTranslation(['chat', 'spend']);
+  const navigate = useWorkspaceAwareNavigate();
+
+  const heterogeneousProviderType = useAgentStore(
+    agentSelectors.currentAgentHeterogeneousProviderType,
+  );
+  const { allowed: canEditContent } = usePermission('edit_own_content');
+  const { canEditResource, isAccessResolved } = useResourceAccess('agent', agentId);
+  const { isAgentEditable } = useServerConfigStore(featureFlagsSelectors);
+
+  const canConfigure = !!isAgentEditable && isAccessResolved && canEditContent && canEditResource;
+  const channelsSupported = supportsMessageChannels(heterogeneousProviderType);
+
+  const options = useMemo(
+    () =>
+      buildAgentProfileTabOptions({
+        active,
+        canConfigure,
+        channelsSupported,
+        labels: {
+          channel: t('tab.integration'),
+          // Inside the profile group the whole surface *is* the agent profile,
+          // so the first segment is the "basic" tab, not "Agent Profile" again —
+          // that broader name stays on the sidebar entry that opens the group.
+          profile: t('tab.profileBasic'),
+          statistics: t('usageStats.title', { ns: 'spend' }),
+        },
+      }),
+    [active, canConfigure, channelsSupported, t],
+  );
+
+  // A lone segment is a label, not a switcher.
+  if (options.length < 2) return null;
+
+  return (
+    <Segmented
+      options={options}
+      size={'small'}
+      value={active}
+      // `Segmented` only fires on a *change*, so the active segment is inert —
+      // notably on `/channel/:platform`, where Channels stays selected. Going
+      // back to the platform list is the breadcrumb's job, not this switcher's.
+      onChange={(value) => navigate(buildAgentProfileTabPath(agentId, value as AgentProfileTab))}
+    />
+  );
+});
+
+AgentProfileTabs.displayName = 'AgentProfileTabs';
+
+export default AgentProfileTabs;

--- a/src/features/AgentProfileTabs/tabOptions.test.ts
+++ b/src/features/AgentProfileTabs/tabOptions.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildAgentProfileTabOptions,
+  buildAgentProfileTabPath,
+  supportsMessageChannels,
+} from './tabOptions';
+
+const labels = {
+  channel: 'tab.integration',
+  profile: 'tab.profile',
+  statistics: 'usageStats.title',
+};
+
+describe('supportsMessageChannels', () => {
+  it('allows cloud agents and the CLI providers that host channels', () => {
+    expect(supportsMessageChannels()).toBe(true);
+    expect(supportsMessageChannels('claude-code')).toBe(true);
+    expect(supportsMessageChannels('codex')).toBe(true);
+  });
+
+  it('rejects device-only heterogeneous agents', () => {
+    expect(supportsMessageChannels('opencode')).toBe(false);
+  });
+});
+
+describe('buildAgentProfileTabPath', () => {
+  it('builds the sub-route of the agent', () => {
+    expect(buildAgentProfileTabPath('agt_1', 'statistics')).toBe('/agent/agt_1/statistics');
+  });
+});
+
+describe('buildAgentProfileTabOptions', () => {
+  it('lists the full group for a member who can configure the agent', () => {
+    const options = buildAgentProfileTabOptions({
+      active: 'profile',
+      canConfigure: true,
+      channelsSupported: true,
+      labels,
+    });
+
+    expect(options.map((option) => option.value)).toEqual(['profile', 'channel', 'statistics']);
+  });
+
+  it('drops channels when the agent cannot host them', () => {
+    const options = buildAgentProfileTabOptions({
+      active: 'profile',
+      canConfigure: true,
+      channelsSupported: false,
+      labels,
+    });
+
+    expect(options.map((option) => option.value)).toEqual(['profile', 'statistics']);
+  });
+
+  it('drops the config tabs for a member without edit access', () => {
+    const options = buildAgentProfileTabOptions({
+      active: 'statistics',
+      canConfigure: false,
+      channelsSupported: true,
+      labels,
+    });
+
+    expect(options.map((option) => option.value)).toEqual(['statistics']);
+  });
+
+  it('keeps the tab owned by the current page even when it is gated off', () => {
+    const options = buildAgentProfileTabOptions({
+      active: 'channel',
+      canConfigure: false,
+      channelsSupported: false,
+      labels,
+    });
+
+    expect(options.map((option) => option.value)).toEqual(['channel', 'statistics']);
+  });
+});

--- a/src/features/AgentProfileTabs/tabOptions.ts
+++ b/src/features/AgentProfileTabs/tabOptions.ts
@@ -1,0 +1,54 @@
+import urlJoin from 'url-join';
+
+export type AgentProfileTab = 'channel' | 'profile' | 'statistics';
+
+export interface AgentProfileTabOption {
+  label: string;
+  value: AgentProfileTab;
+}
+
+/**
+ * Message channels exist for cloud agents and for the two CLI providers whose
+ * runtime can host them — a device-only heterogeneous agent has nothing to
+ * connect, so the segment must not be offered.
+ */
+export const supportsMessageChannels = (heterogeneousProviderType?: string) =>
+  !heterogeneousProviderType ||
+  heterogeneousProviderType === 'claude-code' ||
+  heterogeneousProviderType === 'codex';
+
+export const buildAgentProfileTabPath = (agentId: string, tab: AgentProfileTab) =>
+  urlJoin('/agent', agentId, tab);
+
+/**
+ * Which segments the profile-group switcher shows.
+ *
+ * `canConfigure` is the same gate `ResourceConfigAccessGate` applies to the
+ * Profile / Channels routes: without edit-level access those pages bounce the
+ * member straight back out with a toast, so the segment must not offer the
+ * click. Statistics carries no such gate and is always listed.
+ *
+ * The tab owned by the current page is always kept, even when the gates would
+ * drop it — otherwise `value` would point at no option and the switcher would
+ * render with nothing selected on the very page that owns it.
+ */
+export const buildAgentProfileTabOptions = ({
+  active,
+  canConfigure,
+  channelsSupported,
+  labels,
+}: {
+  active: AgentProfileTab;
+  canConfigure: boolean;
+  channelsSupported: boolean;
+  labels: Record<AgentProfileTab, string>;
+}): AgentProfileTabOption[] => {
+  const showProfile = canConfigure || active === 'profile';
+  const showChannel = (canConfigure && channelsSupported) || active === 'channel';
+
+  return [
+    showProfile ? { label: labels.profile, value: 'profile' as const } : null,
+    showChannel ? { label: labels.channel, value: 'channel' as const } : null,
+    { label: labels.statistics, value: 'statistics' as const },
+  ].filter((option) => !!option);
+};

--- a/src/features/AgentSidebar/Header/Nav.test.tsx
+++ b/src/features/AgentSidebar/Header/Nav.test.tsx
@@ -18,10 +18,6 @@ const permissionMock = vi.hoisted(() => ({
   create_content: true,
   edit_own_content: true,
 }));
-const agentMock = vi.hoisted(() => ({
-  heterogeneousProviderType: undefined as string | undefined,
-}));
-
 vi.mock('@/features/ResourcePermission/useResourceAccess', () => ({
   useResourceAccess: () => ({ canEditResource: true, isAccessResolved: true }),
 }));
@@ -39,7 +35,6 @@ vi.mock('@lobehub/ui/icons', () => ({
 vi.mock('lucide-react', () => ({
   MessageSquarePlusIcon: () => null,
   MessagesSquareIcon: () => null,
-  RadioTowerIcon: () => null,
   SearchIcon: () => null,
   TargetIcon: () => null,
 }));
@@ -101,15 +96,11 @@ vi.mock('@/hooks/usePermission', () => ({
   }),
 }));
 
+// Nav no longer reads the agent store, but its transitive imports pull it in —
+// and the real module drags `lucide-react` icon internals through this file's
+// icon mock. Keep the stub so the module graph stays inert here.
 vi.mock('@/store/agent', () => ({
-  useAgentStore: (selector: (state: typeof agentMock) => unknown) => selector(agentMock),
-}));
-
-vi.mock('@/store/agent/selectors', () => ({
-  agentSelectors: {
-    currentAgentHeterogeneousProviderType: (state: typeof agentMock) =>
-      state.heterogeneousProviderType,
-  },
+  useAgentStore: (selector: (state: Record<string, unknown>) => unknown) => selector({}),
 }));
 
 vi.mock('@/store/chat', () => ({
@@ -161,7 +152,6 @@ describe('Agent sidebar header nav', () => {
     usePathnameMock.mockReset();
     permissionMock.create_content = true;
     permissionMock.edit_own_content = true;
-    agentMock.heterogeneousProviderType = undefined;
 
     useParamsMock.mockReturnValue({ aid: 'agt_eH4zL98zBx5u', topicId: 'tpc_2FCHvjS7d4CA' });
   });
@@ -205,23 +195,28 @@ describe('Agent sidebar header nav', () => {
     expect(mutateMock).not.toHaveBeenCalled();
   });
 
-  it('shows message channels for Codex agents', () => {
-    agentMock.heterogeneousProviderType = 'codex';
-
-    usePathnameMock.mockReturnValue('/agent/agt_eH4zL98zBx5u');
-
-    render(<Nav />);
-
-    expect(screen.getByRole('button', { name: 'tab.integration' })).toBeInTheDocument();
-  });
-
-  it('hides message channels for device-only heterogeneous agents', () => {
-    agentMock.heterogeneousProviderType = 'opencode';
+  it('no longer offers a standalone message channels entry', () => {
     usePathnameMock.mockReturnValue('/agent/agt_eH4zL98zBx5u');
 
     render(<Nav />);
 
     expect(screen.queryByRole('button', { name: 'tab.integration' })).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['/agent/agt_eH4zL98zBx5u/profile'],
+    ['/agent/agt_eH4zL98zBx5u/channel'],
+    ['/agent/agt_eH4zL98zBx5u/channel/slack'],
+    ['/agent/agt_eH4zL98zBx5u/statistics'],
+  ])('keeps the profile entry active on %s', (pathname) => {
+    usePathnameMock.mockReturnValue(pathname);
+
+    render(<Nav />);
+
+    expect(screen.getByRole('button', { name: 'tab.profile' })).toHaveAttribute(
+      'data-active',
+      'true',
+    );
   });
 
   it('navigates to the agent goals page', () => {

--- a/src/features/AgentSidebar/Header/Nav.tsx
+++ b/src/features/AgentSidebar/Header/Nav.tsx
@@ -2,13 +2,7 @@
 
 import { Flexbox } from '@lobehub/ui';
 import { BotPromptIcon } from '@lobehub/ui/icons';
-import {
-  MessageSquarePlusIcon,
-  MessagesSquareIcon,
-  RadioTowerIcon,
-  SearchIcon,
-  TargetIcon,
-} from 'lucide-react';
+import { MessageSquarePlusIcon, MessagesSquareIcon, SearchIcon, TargetIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
@@ -21,8 +15,6 @@ import { usePermission } from '@/hooks/usePermission';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
 import { useActionSWR } from '@/libs/swr';
 import { topicActionKeys } from '@/libs/swr/keys';
-import { useAgentStore } from '@/store/agent';
-import { agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
 import { useGlobalStore } from '@/store/global';
@@ -36,9 +28,14 @@ const Nav = memo(() => {
   const params = useActiveRouteParams();
   const agentId = params.aid;
   const { pathname } = useActiveLocation();
-  const isProfileActive = pathname.includes('/profile');
+  // The profile entry now owns a group of sub-views — profile / channels /
+  // statistics — switched by a Segmented in the page header, so all three keep
+  // this entry lit instead of leaving the sidebar with nothing selected.
+  const isProfileActive =
+    pathname.includes('/profile') ||
+    pathname.includes('/channel') ||
+    pathname.endsWith('/statistics');
   const isGoalsActive = pathname.endsWith('/goals');
-  const isChannelActive = pathname.includes('/channel');
   // Topic IDs are prefixed `topics_`, so /agent/:aid/topics_abc would also match
   // pathname.includes('/topics') — anchor to end to avoid that false positive.
   const isTopicsActive = pathname.endsWith('/topics');
@@ -48,15 +45,7 @@ const Nav = memo(() => {
   const { canEditResource, isAccessResolved } = useResourceAccess('agent', agentId);
   const { isAgentEditable } = useServerConfigStore(featureFlagsSelectors);
   const toggleCommandMenu = useGlobalStore((s) => s.toggleCommandMenu);
-  const heterogeneousProviderType = useAgentStore(
-    agentSelectors.currentAgentHeterogeneousProviderType,
-  );
   const hideProfile = !isAgentEditable || !isAccessResolved || !canEditContent || !canEditResource;
-  const supportsMessageChannels =
-    !heterogeneousProviderType ||
-    heterogeneousProviderType === 'claude-code' ||
-    heterogeneousProviderType === 'codex';
-  const hideChannel = hideProfile || !supportsMessageChannels;
   const switchTopic = useChatStore((s) => s.switchTopic);
   const [openNewTopicOrSaveTopic] = useChatStore((s) => [s.openNewTopicOrSaveTopic]);
   const isNewTopicSendInFlight = useChatStore(topicSelectors.isNewTopicSendInFlight);
@@ -117,17 +106,6 @@ const Nav = memo(() => {
           onClick={() => {
             switchTopic(null, { skipRefreshMessage: true });
             router.push(urlJoin('/agent', agentId!, 'goals'));
-          }}
-        />
-      )}
-      {!hideChannel && (
-        <NavItem
-          active={isChannelActive}
-          icon={RadioTowerIcon}
-          title={t('tab.integration')}
-          onClick={() => {
-            switchTopic(null, { skipRefreshMessage: true });
-            router.push(urlJoin('/agent', agentId!, 'channel'));
           }}
         />
       )}

--- a/src/features/AgentUsage/index.tsx
+++ b/src/features/AgentUsage/index.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 
 import AsyncError from '@/components/AsyncError';
 import AgentBreadcrumb from '@/features/AgentBreadcrumb';
+import AgentProfileTabs, { AGENT_PROFILE_TABS_CENTER_STYLE } from '@/features/AgentProfileTabs';
 import NavHeader from '@/features/NavHeader';
 import WideScreenContainer from '@/features/WideScreenContainer';
 import { useAgentStore } from '@/store/agent';
@@ -69,12 +70,18 @@ const AgentUsage = memo(() => {
   return (
     <Flexbox height={'100%'} width={'100%'}>
       <NavHeader
-        left={
-          activeAgentId ? (
-            <AgentBreadcrumb agentId={activeAgentId} title={t('usageStats.title')} />
-          ) : null
-        }
-      />
+        // No section title — the Segmented beside it names the current tab.
+        left={activeAgentId ? <AgentBreadcrumb agentId={activeAgentId} /> : null}
+        // `relative` anchors the absolutely-centered switcher below.
+        style={{ position: 'relative' }}
+        styles={{
+          // Center on the header midpoint (equal gaps), not the leftover track.
+          center: AGENT_PROFILE_TABS_CENTER_STYLE,
+          left: { minWidth: 0, paddingInlineStart: 8 },
+        }}
+      >
+        {activeAgentId && <AgentProfileTabs active={'statistics'} agentId={activeAgentId} />}
+      </NavHeader>
       <Flexbox flex={1} style={styles.body} width={'100%'}>
         <WideScreenContainer>
           <Flexbox gap={16} paddingBlock={16}>

--- a/src/routes/(main)/agent/channel/Header.tsx
+++ b/src/routes/(main)/agent/channel/Header.tsx
@@ -18,6 +18,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 
 import AgentBreadcrumb from '@/features/AgentBreadcrumb';
+import AgentProfileTabs, { AGENT_PROFILE_TABS_CENTER_STYLE } from '@/features/AgentProfileTabs';
 import NavHeader from '@/features/NavHeader';
 import type { SerializedPlatformDefinition } from '@/server/services/bot/platforms/types';
 import { useAgentStore } from '@/store/agent';
@@ -271,21 +272,7 @@ const Header = memo<HeaderProps>(
           onChange={handleFileChange}
         />
         <NavHeader
-          left={
-            <AgentBreadcrumb
-              agentId={agentId}
-              extraItems={platformDef ? [platformDef.name] : undefined}
-              title={
-                platformDef ? (
-                  <Link relative="path" to="..">
-                    {t('tab.integration', { ns: 'chat' })}
-                  </Link>
-                ) : (
-                  t('tab.integration', { ns: 'chat' })
-                )
-              }
-            />
-          }
+          style={{ position: 'relative' }}
           right={
             <Flexbox horizontal align="center" gap={8}>
               {platformDef?.comingSoon && <Tag size={'small'}>{t('channel.comingSoon')}</Tag>}
@@ -327,10 +314,36 @@ const Header = memo<HeaderProps>(
               </DropdownMenu>
             </Flexbox>
           }
+          // `relative` anchors the absolutely-centered switcher below.
+          left={
+            // On the platform list the Segmented already names the section, so
+            // repeating it here would print the same word twice. A platform
+            // detail still needs it: the active segment is inert, so this link
+            // is the only way back to the list.
+            <AgentBreadcrumb
+              agentId={agentId}
+              extraItems={platformDef ? [platformDef.name] : undefined}
+              title={
+                platformDef ? (
+                  <Link relative="path" to="..">
+                    {t('tab.integration', { ns: 'chat' })}
+                  </Link>
+                ) : undefined
+              }
+            />
+          }
           styles={{
+            // Center on the header midpoint (equal gaps), not the leftover track.
+            center: AGENT_PROFILE_TABS_CENTER_STYLE,
             left: { minWidth: 0, paddingInlineStart: 8 },
           }}
-        />
+        >
+          {/* The switcher belongs to the section's index (the platform list).
+              On a platform detail (`/channel/:platform`) it is one level too
+              deep, so drop it there and let the breadcrumb's Channels link be
+              the way back. */}
+          {!platformDef && <AgentProfileTabs active={'channel'} agentId={agentId} />}
+        </NavHeader>
       </>
     );
   },

--- a/src/routes/(main)/agent/profile/features/Header/index.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/index.tsx
@@ -7,7 +7,6 @@ import { cssVar } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import type { TFunction } from 'i18next';
 import {
-  BarChart3,
   BotMessageSquareIcon,
   Download,
   MoreHorizontal,
@@ -25,6 +24,7 @@ import { useBusinessAgentImportMenuItem } from '@/business/client/hooks/useBusin
 import { useHasActiveWorkspace } from '@/business/client/hooks/useHasActiveWorkspace';
 import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import AgentBreadcrumb from '@/features/AgentBreadcrumb';
+import AgentProfileTabs, { AGENT_PROFILE_TABS_CENTER_STYLE } from '@/features/AgentProfileTabs';
 import NavHeader from '@/features/NavHeader';
 import { formatPageEditorInfoTime } from '@/features/PageEditor/formatPageEditorInfoTime';
 import AccessLevelTag from '@/features/ResourcePermission/AccessLevelTag';
@@ -45,10 +45,7 @@ import AgentForkTag from './AgentForkTag';
 import AgentStatusTag from './AgentStatusTag';
 import AgentVersionReviewTag from './AgentVersionReviewTag';
 
-type HeaderTranslation = TFunction<
-  readonly ['setting', 'chat', 'file', 'common', 'spend'],
-  undefined
->;
+type HeaderTranslation = TFunction<readonly ['setting', 'chat', 'file', 'common'], undefined>;
 
 const buildAgentProfileMarkdown = (params: {
   description?: string;
@@ -100,7 +97,7 @@ const buildAgentProfileMarkdown = (params: {
 };
 
 const Header = memo(() => {
-  const { i18n, t } = useTranslation(['setting', 'chat', 'file', 'common', 'spend']);
+  const { i18n, t } = useTranslation(['setting', 'chat', 'file', 'common']);
   const dateLocale = i18n?.resolvedLanguage || i18n?.language;
   const navigate = useWorkspaceAwareNavigate();
 
@@ -257,14 +254,6 @@ const Header = memo(() => {
           settingsModalRef.current = openAgentSettingsModal();
         },
       },
-      {
-        icon: <Icon icon={BarChart3} />,
-        key: 'usage-stats',
-        label: t('usageStats.entry', { ns: 'spend' }),
-        onClick: () => {
-          if (activeAgentId) navigate(`/agent/${activeAgentId}/statistics`);
-        },
-      },
       showPermissionPageEntry
         ? {
             // Same gate the page itself applies (ResourceConfigAccessGate):
@@ -354,20 +343,7 @@ const Header = memo(() => {
 
   return (
     <NavHeader
-      left={
-        <Flexbox horizontal align={'center'} gap={8}>
-          {activeAgentId && (
-            <AgentBreadcrumb agentId={activeAgentId} title={t('tab.profile', { ns: 'chat' })} />
-          )}
-          <AgentStatusTag />
-          <AgentVersionReviewTag />
-          <AgentForkTag />
-          <AccessLevelTag
-            resourceId={showPermissionsEntry ? (activeAgentId ?? undefined) : undefined}
-            resourceType={'agent'}
-          />
-        </Flexbox>
-      }
+      style={{ position: 'relative' }}
       right={
         <Flexbox horizontal align={'center'} gap={4}>
           <DropdownMenu items={menuItems}>
@@ -383,12 +359,33 @@ const Header = memo(() => {
           )}
         </Flexbox>
       }
+      // `relative` anchors the absolutely-centered switcher below.
+      left={
+        <Flexbox horizontal align={'center'} gap={8}>
+          {/* No section title — the Segmented beside it names the current tab. */}
+          {activeAgentId && <AgentBreadcrumb agentId={activeAgentId} />}
+          <AgentStatusTag />
+          <AgentVersionReviewTag />
+          <AgentForkTag />
+          <AccessLevelTag
+            resourceId={showPermissionsEntry ? (activeAgentId ?? undefined) : undefined}
+            resourceType={'agent'}
+          />
+        </Flexbox>
+      }
       styles={{
+        // Center the switcher on the *header* midpoint, not within the leftover
+        // flex track between the left/right slots — those slots differ in width,
+        // so flex centering leaves unequal gaps (it reads as space-between, not
+        // centered). Absolute + translateX(-50%) makes the two gaps equal.
+        center: AGENT_PROFILE_TABS_CENTER_STYLE,
         left: {
           paddingInlineStart: 8,
         },
       }}
-    />
+    >
+      {activeAgentId && <AgentProfileTabs active={'profile'} agentId={activeAgentId} />}
+    </NavHeader>
   );
 });
 


### PR DESCRIPTION
Group the agent **Profile / Channels / Statistics** pages under one centered `Segmented` switcher in the page header, instead of a separate sidebar entry (Channels) and a dropdown-menu item (Statistics).

- The Channels sidebar entry and the Statistics "⋯" menu item are removed; the sidebar **Agent Profile** entry now stays active across all three routes so the sidebar never shows "nothing selected".
- New `AgentProfileTabs` feature. Tab-visibility rules live in a pure `tabOptions` helper: device-only heterogeneous agents hide Channels; a member without edit access sees only Statistics; the current page's own tab is never dropped (otherwise the Segmented would render with no selection on its own page).
- The switcher is centered on the header midpoint (absolute + `translate(-50%,-50%)`) so the two side gaps stay equal regardless of the left/right slot widths — plain flex centering only centers it within the leftover track, which reads as space-between.
- On a platform **detail** sub-page (`/channel/:platform`) the switcher is hidden; the breadcrumb "Channels" link is the way back to the platform list (the active Segmented segment is inert — `Segmented` only fires on a value change).
- New `tab.profileBasic` ("Profile" / "基础档案") for the first segment; `tab.profile` ("Agent Profile" / "助理档案") stays as the group name on the sidebar and breadcrumb.

| Before | After |
| ------ | ----- |
| Channels in the left sidebar; Statistics buried in the profile "⋯" menu | Profile / Channels / Statistics as a centered Segmented atop the profile group |

#### Test

Verified end-to-end on the local Web surface across 3 review rounds (segment render + navigation, sidebar entry removal + active-highlight, menu item removal, collapsed panel, platform-detail no-segment + breadcrumb back, true centering with equal left/right gaps measured on all three pages). Unit matrix for tab-visibility + sidebar behavior added.

Acceptance report: https://app.lobehub.com/acceptance/eea27722-9f99-4c20-aea5-c4a5d33830cb

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

N/A