### PR TITLE
🐛 fix(shared-tool-ui): keep select-to-submit keyboard-only in AskUserQuestion

### DIFF
--- a/packages/shared-tool-ui/src/AskUserQuestion/AskUserQuestionView.tsx
+++ b/packages/shared-tool-ui/src/AskUserQuestion/AskUserQuestionView.tsx
@@ -171,7 +171,7 @@ export const AskUserQuestionView = memo<AskUserQuestionViewProps>((props) => {
         if (idx < q.options.length) {
           event.preventDefault();
           setHighlight(q, idx);
-          handleToggle(q, q.options[idx].label);
+          handleToggle(q, q.options[idx].label, { submitOnComplete: true });
         } else if (idx === q.options.length) {
           event.preventDefault();
           setHighlight(q, q.options.length);
@@ -216,7 +216,7 @@ export const AskUserQuestionView = memo<AskUserQuestionViewProps>((props) => {
           picks[q.question] !== q.options[highlightedIndex].label
         ) {
           event.preventDefault();
-          handleToggle(q, q.options[highlightedIndex].label);
+          handleToggle(q, q.options[highlightedIndex].label, { submitOnComplete: true });
           return;
         }
         if (isSubmitDisabled) return;

--- a/packages/shared-tool-ui/src/AskUserQuestion/useAskUserForm.test.ts
+++ b/packages/shared-tool-ui/src/AskUserQuestion/useAskUserForm.test.ts
@@ -46,11 +46,35 @@ const setup = (args: AskUserQuestionArgs, persistedDraft?: unknown) => {
 };
 
 describe('useAskUserForm select-to-submit', () => {
-  it('submits immediately when a single-select pick completes the form', () => {
+  it('submits immediately when a keyboard single-select pick completes the form', () => {
+    const { hook, onInteractionAction } = setup(singleQuestionArgs);
+
+    act(() => {
+      hook.result.current.handleToggle(singleQuestionArgs.questions[0], 'Full', {
+        submitOnComplete: true,
+      });
+    });
+
+    expect(onInteractionAction).toHaveBeenCalledExactlyOnceWith({
+      payload: { 'How broad?': 'Full' },
+      type: 'submit',
+    });
+  });
+
+  it('never submits on a plain (mouse-click) toggle, even when it completes the form', () => {
+    // Regression: clicking an option must only select it — accidental clicks
+    // were submitting the whole form when select-to-submit applied to clicks.
     const { hook, onInteractionAction } = setup(singleQuestionArgs);
 
     act(() => {
       hook.result.current.handleToggle(singleQuestionArgs.questions[0], 'Full');
+    });
+
+    expect(onInteractionAction).not.toHaveBeenCalled();
+    expect(hook.result.current.picks['How broad?']).toBe('Full');
+
+    act(() => {
+      hook.result.current.handleSubmit();
     });
 
     expect(onInteractionAction).toHaveBeenCalledExactlyOnceWith({
@@ -63,14 +87,18 @@ describe('useAskUserForm select-to-submit', () => {
     const { hook, onInteractionAction } = setup(twoQuestionArgs);
 
     act(() => {
-      hook.result.current.handleToggle(twoQuestionArgs.questions[0], 'Narrow');
+      hook.result.current.handleToggle(twoQuestionArgs.questions[0], 'Narrow', {
+        submitOnComplete: true,
+      });
     });
 
     expect(onInteractionAction).not.toHaveBeenCalled();
     expect(hook.result.current.activeTab).toBe('1');
 
     act(() => {
-      hook.result.current.handleToggle(twoQuestionArgs.questions[1], 'Auto');
+      hook.result.current.handleToggle(twoQuestionArgs.questions[1], 'Auto', {
+        submitOnComplete: true,
+      });
     });
 
     expect(onInteractionAction).toHaveBeenCalledExactlyOnceWith({
@@ -87,7 +115,9 @@ describe('useAskUserForm select-to-submit', () => {
     });
 
     act(() => {
-      hook.result.current.handleToggle(twoQuestionArgs.questions[0], 'Full');
+      hook.result.current.handleToggle(twoQuestionArgs.questions[0], 'Full', {
+        submitOnComplete: true,
+      });
     });
 
     expect(onInteractionAction).not.toHaveBeenCalled();
@@ -108,7 +138,7 @@ describe('useAskUserForm select-to-submit', () => {
     const { hook, onInteractionAction } = setup(args);
 
     act(() => {
-      hook.result.current.handleToggle(args.questions[0], 'Narrow');
+      hook.result.current.handleToggle(args.questions[0], 'Narrow', { submitOnComplete: true });
     });
 
     expect(onInteractionAction).not.toHaveBeenCalled();

--- a/packages/shared-tool-ui/src/AskUserQuestion/useAskUserForm.ts
+++ b/packages/shared-tool-ui/src/AskUserQuestion/useAskUserForm.ts
@@ -32,7 +32,19 @@ export interface AskUserFormApi {
   handleEscapeTextChange: (value: string) => void;
   handleSkip: () => void;
   handleSubmit: () => void;
-  handleToggle: (q: AskUserQuestionItem, label: string) => void;
+  handleToggle: (
+    q: AskUserQuestionItem,
+    label: string,
+    options?: {
+      /**
+       * Allow the single-select "select-to-submit" fast path for this toggle.
+       * Only keyboard-driven picks (digits / Enter) opt in — a mouse click is
+       * too easy to land by accident to fire a submit on its own, so clicks
+       * just select and leave submission to the explicit Submit button/Enter.
+       */
+      submitOnComplete?: boolean;
+    },
+  ) => void;
   isMulti: boolean;
   isSubmitDisabled: boolean;
   picks: Record<string, string | string[]>;
@@ -109,7 +121,7 @@ export const useAskUserForm = ({
   );
 
   const handleToggle = useCallback(
-    (q: AskUserQuestionItem, label: string) => {
+    (q: AskUserQuestionItem, label: string, options?: { submitOnComplete?: boolean }) => {
       let nextPicks: Record<string, string | string[]>;
       if (q.multiSelect) {
         const current = (picks[q.question] as string[] | undefined) ?? [];
@@ -137,13 +149,15 @@ export const useAskUserForm = ({
 
       if (!q.multiSelect) {
         // Codex-style select-to-submit: the pick that completes the form sends
-        // it right away — no extra Submit press for single-select flows. Gated
-        // on the question having been unanswered so revisiting an already
-        // answered question only updates the pick and never fires a surprise
-        // submit while the user is reviewing.
+        // it right away — no extra Submit press for single-select flows. Two
+        // gates: the caller must opt in via `submitOnComplete` (keyboard picks
+        // only — a stray mouse click must never submit on its own), and the
+        // question must have been unanswered so revisiting an already answered
+        // question only updates the pick and never fires a surprise submit
+        // while the user is reviewing.
         const wasUnanswered = !isQuestionAnswered(q, picks, custom);
         const allAnswered = questions.every((qq) => isQuestionAnswered(qq, nextPicks, nextCustom));
-        if (wasUnanswered && allAnswered) {
+        if (options?.submitOnComplete && wasUnanswered && allAnswered) {
           void submitWith(buildSubmitPayload(questions, nextPicks, nextCustom));
           return;
         }


### PR DESCRIPTION
Follow-up to #17903. Feedback: clicking an option on the AskUserQuestion card could submit the whole form immediately, which is too easy to trigger by accident.

This PR makes the single-select "select-to-submit" fast path opt-in per toggle:

- **Mouse click**: only selects the option — submitting requires the explicit Submit button or <kbd>Enter</kbd> (the button already advertises the Enter hotkey).
- **Keyboard** (digit keys / <kbd>Enter</kbd> on a highlighted row): keeps the Codex-style select-to-submit, since a deliberate keypress is not an accidental-click vector.

Implementation: `handleToggle` gains an optional `submitOnComplete` flag; only the view's keyboard paths pass it. The click path (`QuestionPanel` → `OptionCard`) stays flag-less.

#### Test

- [x] Added/updated tests — new regression case asserts a plain (click) toggle never auto-submits even when it completes the form; existing select-to-submit cases now exercise the keyboard flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)