### PR TITLE
🐛 fix(knowledge): resolve chunk status by backing file id for file-backed documents

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/file.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/file.test.ts
@@ -760,6 +760,40 @@ describe('fileRouter', () => {
         name: 'Document 1',
       });
     });
+
+    it('should resolve chunk status by backing file id for file-backed documents', async () => {
+      const knowledgeItems = [
+        {
+          ...mockFile,
+          chunkTaskId: 'chunk-1',
+          embeddingTaskId: 'emb-1',
+          fileId: 'file-1',
+          id: 'docs_1',
+          sourceType: 'file' as const,
+        },
+      ];
+
+      mockKnowledgeRepoQuery.mockResolvedValue(knowledgeItems);
+      mockChunkCountByFileIds.mockResolvedValue([{ count: 7, id: 'file-1' }]);
+      mockAsyncTaskFindByIds
+        .mockResolvedValueOnce([{ error: null, id: 'chunk-1', status: AsyncTaskStatus.Success }])
+        .mockResolvedValueOnce([{ error: null, id: 'emb-1', status: AsyncTaskStatus.Success }]);
+      mockFileServiceGetFileAccessUrl.mockResolvedValue('https://lobehub.com/f/file-1');
+
+      const result = await caller.getKnowledgeItems({});
+
+      expect(mockChunkCountByFileIds).toHaveBeenCalledWith(['file-1']);
+      expect(result.items[0]).toMatchObject({
+        chunkCount: 7,
+        chunkingStatus: AsyncTaskStatus.Success,
+        embeddingStatus: AsyncTaskStatus.Success,
+        finishEmbedding: true,
+        fileId: 'file-1',
+        id: 'docs_1',
+        sourceType: 'file',
+        url: 'https://lobehub.com/f/file-1',
+      });
+    });
   });
 
   describe('getKnowledgeItemStatusesByIds', () => {

--- a/apps/server/src/routers/lambda/file.ts
+++ b/apps/server/src/routers/lambda/file.ts
@@ -69,12 +69,13 @@ const getKnowledgeItemStatusMap = async (
   fileItems: Array<{
     chunkTaskId?: string | null;
     embeddingTaskId?: string | null;
+    fileId?: string | null;
     id: string;
   }>,
 ): Promise<Map<string, KnowledgeItemStatus>> => {
   if (fileItems.length === 0) return new Map();
 
-  const fileIds = fileItems.map((item) => item.id);
+  const fileIds = fileItems.map((item) => item.fileId ?? item.id);
   const chunkTaskIds = [
     ...new Set(fileItems.map((item) => item.chunkTaskId).filter(Boolean)),
   ] as string[];
@@ -108,11 +109,12 @@ const getKnowledgeItemStatusMap = async (
       const embeddingTask = item.embeddingTaskId
         ? embeddingTaskMap.get(item.embeddingTaskId)
         : null;
+      const chunkId = item.fileId ?? item.id;
 
       return [
         item.id,
         {
-          chunkCount: chunkCountMap.get(item.id) ?? null,
+          chunkCount: chunkCountMap.get(chunkId) ?? null,
           chunkingError: (chunkTask?.error as IAsyncTaskError | null | undefined) ?? null,
           chunkingStatus: (chunkTask?.status as AsyncTaskStatus | null | undefined) ?? null,
           embeddingError: (embeddingTask?.error as IAsyncTaskError | null | undefined) ?? null,
@@ -417,6 +419,9 @@ export const fileRouter = router({
     // Process files (add chunk info and async task status)
     const fileItems = filteredItems.filter((item) => item.sourceType === 'file');
     const statusMap = await getKnowledgeItemStatusMap(ctx, fileItems);
+    const statusByFileId = new Map(
+      fileItems.map((item) => [item.fileId ?? item.id, statusMap.get(item.id)]),
+    );
 
     // Resolve file access URLs in parallel: in local dev each call goes through
     // Redis + a possible S3 presign, so a serial loop stacks up N RTTs on
@@ -424,12 +429,26 @@ export const fileRouter = router({
     const resultItems = await Promise.all(
       filteredItems.map(async (item) => {
         if (item.sourceType === 'file') {
-          const status = statusMap.get(item.id)!;
+          const status = statusByFileId.get(item.fileId ?? item.id);
+          if (status) {
+            return {
+              ...item,
+              editorData: null,
+              url: await ctx.fileService.getFileAccessUrl(item),
+              ...status,
+            } as FileListItem;
+          }
+          item.fileId = item.id;
           return {
             ...item,
             editorData: null,
+            chunkCount: null,
+            chunkingError: null,
+            chunkingStatus: null,
+            embeddingError: null,
+            embeddingStatus: null,
+            finishEmbedding: false,
             url: await ctx.fileService.getFileAccessUrl(item),
-            ...status,
           } as FileListItem;
         }
         return {

--- a/src/services/file/index.test.ts
+++ b/src/services/file/index.test.ts
@@ -41,8 +41,12 @@ describe('FileService.getKnowledgeItem', () => {
       updatedAt: new Date('2026-07-22T00:00:00.000Z'),
     });
     mockGetFileItemById.mockResolvedValue({
+      chunkCount: 42,
+      chunkingStatus: 'success',
       createdAt: new Date('2026-07-22T00:00:00.000Z'),
+      embeddingStatus: 'success',
       fileType: 'application/pdf',
+      finishEmbedding: true,
       id: 'file_pdf',
       name: 'original.pdf',
       size: 98_765,
@@ -54,8 +58,12 @@ describe('FileService.getKnowledgeItem', () => {
     const result = await service.getKnowledgeItem('docs_pdf');
 
     expect(result).toMatchObject({
+      chunkCount: 42,
+      chunkingStatus: 'success',
+      embeddingStatus: 'success',
       fileId: 'file_pdf',
       fileType: 'application/pdf',
+      finishEmbedding: true,
       id: 'docs_pdf',
       name: 'original.pdf',
       size: 98_765,

--- a/src/services/file/index.ts
+++ b/src/services/file/index.ts
@@ -97,17 +97,17 @@ export class FileService {
 
       // Convert document to FileListItem format
       return {
-        chunkCount: null,
-        chunkingError: null,
-        chunkingStatus: null,
+        chunkCount: backingFile?.chunkCount ?? null,
+        chunkingError: backingFile?.chunkingError ?? null,
+        chunkingStatus: backingFile?.chunkingStatus ?? null,
         content: doc.content,
         createdAt: doc.createdAt ? new Date(doc.createdAt) : new Date(),
         editorData: doc.editorData,
-        embeddingError: null,
-        embeddingStatus: null,
+        embeddingError: backingFile?.embeddingError ?? null,
+        embeddingStatus: backingFile?.embeddingStatus ?? null,
         fileId: doc.fileId,
         fileType: backingFile?.fileType || doc.fileType || CUSTOM_DOCUMENT_FILE_TYPE,
-        finishEmbedding: false,
+        finishEmbedding: backingFile?.finishEmbedding ?? false,
         id: doc.id,
         metadata: doc.metadata,
         name: backingFile?.name || doc.title || doc.filename || 'Untitled',


### PR DESCRIPTION
Fixes #18051

## Summary

Since #13221, chunking auto-creates a `documents` row (`docs_*` prefix) for every uploaded file. `getKnowledgeItems` lists these file-backed documents, but the chunk/embedding status code only looked up chunks by `item.id` (the `docs_*` id), while `file_chunks` rows are keyed by the underlying `file_*` id — so the list badge and detail modal showed `chunkCount: null` / "No chunks" even though the DB had chunks and embeddings.

Changes:
- `getKnowledgeItemStatusMap` (apps/server/src/routers/lambda/file.ts): query and map chunk counts by `item.fileId ?? item.id`, and return the status keyed by item id as before.
- `getKnowledgeItems`: build a status lookup keyed by backing file id and apply it to the returned `FileListItem`.
- `getKnowledgeItem` frontend docs_ branch (src/services/file/index.ts): propagate `chunkCount` / `chunkingError` / `chunkingStatus` / `embeddingError` / `embeddingStatus` / `finishEmbedding` from the backing file instead of hardcoding `null`.

## Test

- `bunx vitest run --config vitest.config.mts apps/server/src/routers/lambda/__tests__/file.test.ts` — 39 passed (added: file-backed doc resolves chunk status by `fileId`)
- `bunx vitest run --config vitest.config.mts src/services/file/index.test.ts` — 2 passed (extended: docs_ item inherits backing-file chunk/embedding status)
- `bunx eslint` and `prettier --check` clean