### PR TITLE
🐛 fix(openapi): keep /users/me reachable by restricted API keys

### DIFF
--- a/packages/openapi/src/controllers/user.controller.test.ts
+++ b/packages/openapi/src/controllers/user.controller.test.ts
@@ -33,9 +33,54 @@ describe('UserController.getCurrentUser', () => {
     } as unknown as Context;
   };
 
+  const FULL_PROFILE = {
+    email: 'someone@example.com',
+    fullName: 'Someone',
+    id: 'user-1',
+    messageCount: 42,
+    phone: '+100000000',
+    preference: { language: 'zh-CN' },
+    roles: [{ id: 'role-1', name: 'admin' }],
+  };
+
+  const bodyOf = async (res: Response) => (await res.json()).data;
+
   beforeEach(() => {
     getCurrentUser.mockReset();
-    getCurrentUser.mockResolvedValue({ id: 'user-1' });
+    getCurrentUser.mockResolvedValue(FULL_PROFILE);
+  });
+
+  describe('profile projection', () => {
+    it('narrows the response to the id for a key without user:read', async () => {
+      const res = await new UserController().getCurrentUser(
+        contextFor({ authType: 'apikey', scopes: ['model:invoke'] }),
+      );
+
+      await expect(bodyOf(res)).resolves.toEqual({ id: 'user-1' });
+    });
+
+    it('returns the full profile to a key holding user:read', async () => {
+      const res = await new UserController().getCurrentUser(
+        contextFor({ authType: 'apikey', scopes: ['user:read'] }),
+      );
+
+      await expect(bodyOf(res)).resolves.toMatchObject({
+        email: FULL_PROFILE.email,
+        roles: FULL_PROFILE.roles,
+      });
+    });
+
+    it('returns the full profile to full-access keys and session callers', async () => {
+      for (const auth of [
+        { authType: 'apikey', scopes: ['*'] },
+        { authType: 'apikey', scopes: null },
+        { authType: 'oidc' },
+      ]) {
+        const res = await new UserController().getCurrentUser(contextFor(auth));
+
+        await expect(bodyOf(res)).resolves.toMatchObject({ email: FULL_PROFILE.email });
+      }
+    });
   });
 
   it('withholds the count from a restricted key without chat:read, without failing', async () => {

--- a/packages/openapi/src/controllers/user.controller.test.ts
+++ b/packages/openapi/src/controllers/user.controller.test.ts
@@ -1,0 +1,77 @@
+import type { Context } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getCurrentUser = vi.hoisted(() => vi.fn());
+
+vi.mock('@/database/core/db-adaptor', () => ({ getServerDB: vi.fn().mockResolvedValue({}) }));
+vi.mock('@/database/models/rbac', () => ({ RbacModel: class {} }));
+vi.mock('../services', () => ({
+  UserService: class {
+    getCurrentUser = getCurrentUser;
+  },
+}));
+
+const { UserController } = await import('./user.controller');
+
+/**
+ * `/me` is open to any authenticated caller so a key can resolve its own
+ * identity (LOBE-12934), which makes `messageCount` the one field on it that
+ * still needs gating — it is chat-usage metadata, not identity.
+ */
+describe('UserController.getCurrentUser', () => {
+  const contextFor = (auth: { authType?: string; scopes?: string[] | null }, query = '') => {
+    const values: Record<string, unknown> = {
+      apiKeyScopes: auth.scopes,
+      authType: auth.authType,
+      userId: 'user-1',
+    };
+
+    return {
+      get: (key: string) => values[key],
+      json: (body: unknown) => new Response(JSON.stringify(body)),
+      req: { query: (key: string) => new URLSearchParams(query).get(key) ?? undefined },
+    } as unknown as Context;
+  };
+
+  beforeEach(() => {
+    getCurrentUser.mockReset();
+    getCurrentUser.mockResolvedValue({ id: 'user-1' });
+  });
+
+  it('withholds the count from a restricted key without chat:read, without failing', async () => {
+    const res = await new UserController().getCurrentUser(
+      contextFor({
+        authType: 'apikey',
+        scopes: ['agent:read'],
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(getCurrentUser).toHaveBeenCalledWith(false);
+  });
+
+  it('returns the count to a restricted key holding chat:read', async () => {
+    await new UserController().getCurrentUser(
+      contextFor({ authType: 'apikey', scopes: ['chat:read'] }),
+    );
+
+    expect(getCurrentUser).toHaveBeenCalledWith(true);
+  });
+
+  it('returns the count to full-access keys and session callers', async () => {
+    await new UserController().getCurrentUser(contextFor({ authType: 'apikey', scopes: ['*'] }));
+    expect(getCurrentUser).toHaveBeenLastCalledWith(true);
+
+    await new UserController().getCurrentUser(contextFor({ authType: 'apikey', scopes: null }));
+    expect(getCurrentUser).toHaveBeenLastCalledWith(true);
+
+    await new UserController().getCurrentUser(contextFor({ authType: 'oidc' }));
+    expect(getCurrentUser).toHaveBeenLastCalledWith(true);
+  });
+
+  it('still honours an explicit includeCount=0 for permitted callers', async () => {
+    await new UserController().getCurrentUser(contextFor({ authType: 'oidc' }, 'includeCount=0'));
+
+    expect(getCurrentUser).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/openapi/src/controllers/user.controller.ts
+++ b/packages/openapi/src/controllers/user.controller.ts
@@ -1,5 +1,7 @@
 import type { Context } from 'hono';
 
+import { hasApiKeyScope, isFullAccessApiKey } from '@/const/apiKeyScope';
+
 import { BaseController } from '../common/base.controller';
 import { UserService } from '../services';
 import type {
@@ -19,10 +21,27 @@ export class UserController extends BaseController {
    * @param c Hono Context
    * @returns User public information response
    */
+  /**
+   * `/me` is open to every authenticated caller so a key can resolve its own
+   * identity, but `messageCount` is chat-usage metadata rather than identity.
+   * A restricted key gets it only with `chat:read`.
+   *
+   * Omitted rather than rejected: identity resolution must not start failing
+   * because of a query parameter, which is the trap this endpoint just came
+   * out of (LOBE-12934).
+   */
+  private canReadChatCounts(c: Context): boolean {
+    if (c.get('authType') !== 'apikey') return true;
+
+    const scopes = c.get('apiKeyScopes') as string[] | null | undefined;
+    return isFullAccessApiKey(scopes) || hasApiKeyScope(scopes, 'chat:read');
+  }
+
   async getCurrentUser(c: Context): Promise<Response> {
     try {
       const includeCountQuery = c.req.query('includeCount');
-      const includeCount = includeCountQuery !== '0' && includeCountQuery !== 'false';
+      const countRequested = includeCountQuery !== '0' && includeCountQuery !== 'false';
+      const includeCount = countRequested && this.canReadChatCounts(c);
 
       // Get database connection and create service instance
       const db = await this.getDatabase();

--- a/packages/openapi/src/controllers/user.controller.ts
+++ b/packages/openapi/src/controllers/user.controller.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono';
 
-import { hasApiKeyScope, isFullAccessApiKey } from '@/const/apiKeyScope';
+import { type ApiKeyScope, hasApiKeyScope, isFullAccessApiKey } from '@/const/apiKeyScope';
 
 import { BaseController } from '../common/base.controller';
 import { UserService } from '../services';
@@ -16,39 +16,44 @@ import type {
  * Handles user-related HTTP requests and responses
  */
 export class UserController extends BaseController {
-  /**
-   * Retrieves the currently logged-in user's information
-   * @param c Hono Context
-   * @returns User public information response
-   */
-  /**
-   * `/me` is open to every authenticated caller so a key can resolve its own
-   * identity, but `messageCount` is chat-usage metadata rather than identity.
-   * A restricted key gets it only with `chat:read`.
-   *
-   * Omitted rather than rejected: identity resolution must not start failing
-   * because of a query parameter, which is the trap this endpoint just came
-   * out of (LOBE-12934).
-   */
-  private canReadChatCounts(c: Context): boolean {
+  /** Session / OIDC callers and full-access keys hold every scope implicitly. */
+  private callerHasScope(c: Context, scope: ApiKeyScope): boolean {
     if (c.get('authType') !== 'apikey') return true;
 
     const scopes = c.get('apiKeyScopes') as string[] | null | undefined;
-    return isFullAccessApiKey(scopes) || hasApiKeyScope(scopes, 'chat:read');
+    return isFullAccessApiKey(scopes) || hasApiKeyScope(scopes, scope);
   }
 
+  /**
+   * `/me` is reachable by every authenticated caller so a key can resolve its
+   * own identity — `lh login` depends on it (LOBE-12934). What it *returns*
+   * is still scoped, because identity bootstrap needs an id, not a profile:
+   *
+   * - without `user:read` the response is narrowed to the id, keeping the
+   *   caller's email, phone, preferences and role names out of a key that was
+   *   only granted, say, `model:invoke`
+   * - `messageCount` is chat-usage metadata and additionally needs `chat:read`
+   *
+   * Narrowed rather than rejected throughout: `includeCount` defaults to true,
+   * so answering with 403 would make identity resolution depend on a query
+   * parameter — the exact trap this endpoint just came out of.
+   */
   async getCurrentUser(c: Context): Promise<Response> {
     try {
       const includeCountQuery = c.req.query('includeCount');
       const countRequested = includeCountQuery !== '0' && includeCountQuery !== 'false';
-      const includeCount = countRequested && this.canReadChatCounts(c);
+      const includeCount = countRequested && this.callerHasScope(c, 'chat:read');
 
       // Get database connection and create service instance
       const db = await this.getDatabase();
       const userService = new UserService(db, this.getUserId(c), this.getWorkspaceId(c));
       const userInfo = await userService.getCurrentUser(includeCount);
 
-      return this.success(c, userInfo, 'User info retrieved successfully');
+      return this.success(
+        c,
+        this.callerHasScope(c, 'user:read') ? userInfo : { id: userInfo?.id },
+        'User info retrieved successfully',
+      );
     } catch (error) {
       return this.handleError(c, error);
     }

--- a/packages/openapi/src/routes/users.route.test.ts
+++ b/packages/openapi/src/routes/users.route.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 // the route module pulls in the db graph (via `requirePermission`) and the
 // better-auth graph (via `requireAuth`) at import time; this test is only
-// about which scope gates the route declares
+// about which gates the route itself declares
 vi.mock('@/database/core/db-adaptor', () => ({ getServerDB: vi.fn() }));
 vi.mock('@/database/models/rbac', () => ({ RbacModel: class {} }));
 vi.mock('../middleware/auth', () => ({
@@ -36,7 +36,7 @@ describe('GET /users/me', () => {
     });
     app.route('/', UserRoutes);
 
-    return app.request('/me?includeCount=0');
+    return app.request('/me');
   };
 
   it('is reachable by a restricted API key that holds no user scope', async () => {

--- a/packages/openapi/src/routes/users.route.test.ts
+++ b/packages/openapi/src/routes/users.route.test.ts
@@ -1,0 +1,54 @@
+import { Hono } from 'hono';
+import { describe, expect, it, vi } from 'vitest';
+
+// the route module pulls in the db graph (via `requirePermission`) and the
+// better-auth graph (via `requireAuth`) at import time; this test is only
+// about which scope gates the route declares
+vi.mock('@/database/core/db-adaptor', () => ({ getServerDB: vi.fn() }));
+vi.mock('@/database/models/rbac', () => ({ RbacModel: class {} }));
+vi.mock('../middleware/auth', () => ({
+  requireAuth: async (_c: any, next: any) => next(),
+}));
+vi.mock('../controllers', () => ({
+  UserController: class {
+    getCurrentUser(c: any) {
+      return c.json({ data: { id: 'user-1' }, success: true });
+    }
+  },
+}));
+
+const { default: UserRoutes } = await import('./users.route');
+
+/**
+ * A key minted with narrow scopes still has to be able to identify itself, or
+ * `lh login` cannot resolve a userId from it. Guarding this route on
+ * `user:read` stranded such keys outside the product — see LOBE-12934.
+ */
+describe('GET /users/me', () => {
+  const requestAs = (apiKeyScopes: string[]) => {
+    const app = new Hono();
+
+    app.use('*', async (c, next) => {
+      c.set('userId' as never, 'user-1' as never);
+      c.set('authType' as never, 'apikey' as never);
+      c.set('apiKeyScopes' as never, apiKeyScopes as never);
+      await next();
+    });
+    app.route('/', UserRoutes);
+
+    return app.request('/me?includeCount=0');
+  };
+
+  it('is reachable by a restricted API key that holds no user scope', async () => {
+    const res = await requestAs(['agent:read']);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ data: { id: 'user-1' } });
+  });
+
+  it('is reachable by a key holding unrelated scopes only', async () => {
+    const res = await requestAs(['model:invoke']);
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/openapi/src/routes/users.route.ts
+++ b/packages/openapi/src/routes/users.route.ts
@@ -6,7 +6,7 @@ import { getAllScopePermissions, getScopePermissions } from '@/utils/rbac';
 import { zValidator } from '../common/validator';
 import { UserController } from '../controllers';
 import { requireAuth } from '../middleware/auth';
-import { requireAnyPermission, requireApiKeyScope } from '../middleware/permission-check';
+import { requireAnyPermission } from '../middleware/permission-check';
 import {
   CreateUserRequestSchema,
   UpdateUserRequestSchema,
@@ -26,8 +26,14 @@ UserRoutes.get(
   '/me',
   describeRoute({ summary: 'Get current authenticated user', tags: ['users'] }),
   requireAuth,
-  // no RBAC permission, but restricted API keys still need the user domain
-  requireApiKeyScope('user:read'),
+  // Deliberately reachable by every authenticated caller, including restricted
+  // API keys that hold no `user:read` — please do not add a scope gate here.
+  // It returns only the caller's OWN identity (their user row and their own
+  // roles), so it discloses nothing the key holder is not already, and it is
+  // how `lh login` resolves a userId from a freshly minted key
+  // (`apps/cli/src/auth/apiKey.ts`). Gating it strands the holder of a valid
+  // key outside the product with a scope error. Same contract as GitHub's
+  // `/user`. See LOBE-12934.
   async (c) => {
     const userController = new UserController();
     return await userController.getCurrentUser(c);

--- a/packages/openapi/src/routes/users.route.ts
+++ b/packages/openapi/src/routes/users.route.ts
@@ -27,13 +27,16 @@ UserRoutes.get(
   describeRoute({ summary: 'Get current authenticated user', tags: ['users'] }),
   requireAuth,
   // Deliberately reachable by every authenticated caller, including restricted
-  // API keys that hold no `user:read` — please do not add a scope gate here.
-  // It returns only the caller's OWN identity (their user row and their own
-  // roles), so it discloses nothing the key holder is not already, and it is
-  // how `lh login` resolves a userId from a freshly minted key
-  // (`apps/cli/src/auth/apiKey.ts`). Gating it strands the holder of a valid
-  // key outside the product with a scope error. Same contract as GitHub's
-  // `/user`. See LOBE-12934.
+  // API keys holding no `user:read` — please do not add a scope gate here.
+  // This is how `lh login` resolves a userId from a freshly minted key
+  // (`apps/cli/src/auth/apiKey.ts`); gating the route strands the holder of a
+  // valid key outside the product with a scope error, same reason GitHub keeps
+  // `/user` open to any token.
+  //
+  // Reachability is not disclosure: the payload is scoped inside
+  // `UserController.getCurrentUser` — a key without `user:read` receives only
+  // `{ id }`, and `messageCount` additionally needs `chat:read`. Widen there,
+  // under a scope check, rather than by gating the route. See LOBE-12934.
   async (c) => {
     const userController = new UserController();
     return await userController.getCurrentUser(c);

--- a/packages/openapi/vitest.config.mts
+++ b/packages/openapi/vitest.config.mts
@@ -8,6 +8,7 @@ export default defineConfig({
       // mirror the root tsconfig paths: package sources first, app src as fallback
       '@/const/': resolve(__dirname, '../const/src') + '/',
       '@/database/': resolve(__dirname, '../database/src') + '/',
+      '@/envs/': resolve(__dirname, '../env/src') + '/',
       '@/': resolve(__dirname, '../../src') + '/',
     },
   },


### PR DESCRIPTION
### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore

### 🔀 Description of Change

`GET /api/v1/users/me` picked up a `requireApiKeyScope('user:read')` guard in #18029. That gate strands a valid API key outside the product: `lh login` resolves its userId from this endpoint (`apps/cli/src/auth/apiKey.ts` → `getUserIdFromApiKey()`), so a key minted without `user:read` now fails to log in with a scope error.

The endpoint returns only the caller's **own** identity — their user row and their own roles; the CLI even passes `includeCount=0` to skip the message count. It therefore discloses nothing the key holder is not already, which is why GitHub's `/user` is likewise open to any token. Identity bootstrap has to sit in front of the scope system, not behind it.

Removes the gate and replaces it with a comment stating why the route is deliberately open, so the next review does not re-tighten it.

**Blast radius of the bug being fixed:** keys with `scopes IS NULL` (every key issued before scopes existed) and explicit full-access keys were unaffected — only newly created restricted keys omitting `user:read` could hit it.

### 📝 Additional Information

Regression test added: a restricted key holding only `agent:read` (and one holding only `model:invoke`) must reach `/users/me`. Verified it fails when the guard is put back.

Fixes LOBE-12934