### PR TITLE
🐛 fix(agent-builder): persist suggestion chips via tiered SWR cache

### DIFF
--- a/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.test.tsx
+++ b/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.test.tsx
@@ -1,9 +1,10 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { PropsWithChildren } from 'react';
 import { createElement } from 'react';
-import { SWRConfig } from 'swr';
+import { type State, SWRConfig, unstable_serialize } from 'swr';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { swrKeys } from '@/libs/swr/keys';
 import { aiChatService } from '@/services/aiChat';
 
 import { useBuilderSuggestions } from './useBuilderSuggestions';
@@ -35,8 +36,8 @@ const baseParams = {
   targetId: 'target-agent',
 } satisfies Parameters<typeof useBuilderSuggestions>[0];
 
-const createSWRWrapper = () => {
-  const value = { provider: () => new Map() };
+const createSWRWrapper = (cache: Map<string, State> = new Map()) => {
+  const value = { provider: () => cache };
 
   return function SWRTestWrapper({ children }: PropsWithChildren) {
     return createElement(SWRConfig, { value }, children);
@@ -109,6 +110,38 @@ describe('useBuilderSuggestions', () => {
 
     expect(getGeneratedUserContent(1)).toContain('manual refresh context');
     expect(result.current.suggestions[0]?.title).toBe('second title');
+  });
+
+  // Regression for LOBE-12895: suggestions are persisted via the tiered SWR
+  // cache provider. A cache hit (e.g. hydrated from localStorage on a revisit)
+  // must render directly without paying another LLM generation.
+  it('serves a persisted cache hit without regenerating', async () => {
+    const cache = new Map<string, State>();
+    const key = unstable_serialize(
+      swrKeys.agentBuilder.suggestions(
+        baseParams.mode,
+        baseParams.builderAgentId,
+        baseParams.targetId,
+      ),
+    );
+    cache.set(key, {
+      data: {
+        suggestions: [{ prompt: 'cached prompt', title: 'cached title' }],
+        tracingId: 'trace-cached',
+      },
+    });
+
+    const { result } = renderHook((props) => useBuilderSuggestions(props), {
+      initialProps: baseParams,
+      wrapper: createSWRWrapper(cache),
+    });
+
+    await waitFor(() => {
+      expect(result.current.suggestions[0]?.title).toBe('cached title');
+    });
+    await waitForNextTick();
+
+    expect(aiChatService.generateJSON).not.toHaveBeenCalled();
   });
 
   it('regenerates when the edited target changes', async () => {

--- a/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.test.tsx
+++ b/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.test.tsx
@@ -122,6 +122,7 @@ describe('useBuilderSuggestions', () => {
         baseParams.mode,
         baseParams.builderAgentId,
         baseParams.targetId,
+        baseParams.locale,
       ),
     );
     cache.set(key, {
@@ -142,6 +143,30 @@ describe('useBuilderSuggestions', () => {
     await waitForNextTick();
 
     expect(aiChatService.generateJSON).not.toHaveBeenCalled();
+  });
+
+  // Persisted entries are generated in the UI language, so a language switch
+  // must miss the cache and regenerate instead of serving old-locale chips.
+  it('regenerates when the UI locale changes', async () => {
+    vi.mocked(aiChatService.generateJSON)
+      .mockResolvedValueOnce(makeEnvelope('first'))
+      .mockResolvedValueOnce(makeEnvelope('second'));
+
+    const { rerender, result } = renderHook((props) => useBuilderSuggestions(props), {
+      initialProps: baseParams,
+      wrapper: createSWRWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.suggestions[0]?.title).toBe('first title');
+    });
+
+    rerender({ ...baseParams, locale: 'en-US' });
+
+    await waitFor(() => {
+      expect(aiChatService.generateJSON).toHaveBeenCalledTimes(2);
+    });
+    expect(result.current.suggestions[0]?.title).toBe('second title');
   });
 
   it('regenerates when the edited target changes', async () => {

--- a/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.ts
+++ b/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.ts
@@ -6,7 +6,7 @@ import {
   type BuilderSuggestionMode,
   chainBuilderSuggestion,
 } from '@lobechat/prompts';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import useSWR from 'swr';
 
 import { swrKeys } from '@/libs/swr/keys';
@@ -51,21 +51,19 @@ export const useBuilderSuggestions = ({
   enabled,
   targetId,
 }: UseBuilderSuggestionsParams): BuilderSuggestionsResult => {
-  // Bumping the nonce forces a fresh generation (SWR key change) on manual refresh.
-  const [nonce, setNonce] = useState(0);
   const markRegenerated = useBuilderSuggestionFeedbackStore((s) => s.markRegenerated);
 
   // Key on target identity only — the context summary is deliberately kept out of
   // the key so config autosaves (which stream in new summaries for the same target)
-  // don't refetch. Only a target switch or a nonce bump regenerates; the fetcher
-  // closure reads the current summary, which is always the latest value on the
-  // render that changes the key.
+  // don't refetch. Only a target switch or a manual refresh regenerates; the
+  // fetcher closure reads the current summary, which is always the latest value
+  // on the render that changes the key.
   const key =
     enabled && contextSummary && model && provider
-      ? swrKeys.agentBuilder.suggestions(mode, builderAgentId, targetId, nonce)
+      ? swrKeys.agentBuilder.suggestions(mode, builderAgentId, targetId)
       : null;
 
-  const { data, isLoading, error } = useSWR(
+  const { data, isLoading, error, mutate } = useSWR(
     key,
     async () => {
       // Read mode/context/agent from the closure: SWR runs the fetcher from the
@@ -96,6 +94,11 @@ export const useBuilderSuggestions = ({
     },
     {
       dedupingInterval: 600_000,
+      // The key is persisted to the localStorage SWR tier (see `CACHE_TIERS.local`),
+      // so a revisit hydrates the last batch synchronously. Without this flag SWR
+      // would still revalidate the stale entry on mount, regenerating (and paying
+      // an LLM call) on every page load — the exact thing the persistence avoids.
+      revalidateIfStale: false,
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
       shouldRetryOnError: false,
@@ -104,8 +107,10 @@ export const useBuilderSuggestions = ({
 
   const refresh = useCallback(() => {
     markRegenerated(data?.tracingId);
-    setNonce((n) => n + 1);
-  }, [data?.tracingId, markRegenerated]);
+    // Clear the current batch (skeleton shows) and re-run the fetcher on the
+    // same key, so the fresh batch lands in the persisted cache entry.
+    void mutate(undefined, { revalidate: true });
+  }, [data?.tracingId, markRegenerated, mutate]);
 
   return {
     error,

--- a/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.ts
+++ b/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.ts
@@ -53,14 +53,15 @@ export const useBuilderSuggestions = ({
 }: UseBuilderSuggestionsParams): BuilderSuggestionsResult => {
   const markRegenerated = useBuilderSuggestionFeedbackStore((s) => s.markRegenerated);
 
-  // Key on target identity only — the context summary is deliberately kept out of
-  // the key so config autosaves (which stream in new summaries for the same target)
-  // don't refetch. Only a target switch or a manual refresh regenerates; the
+  // Key on target identity (+ locale, since chips are generated in the UI
+  // language) — the context summary is deliberately kept out of the key so
+  // config autosaves (which stream in new summaries for the same target) don't
+  // refetch. Only a target/locale switch or a manual refresh regenerates; the
   // fetcher closure reads the current summary, which is always the latest value
   // on the render that changes the key.
   const key =
     enabled && contextSummary && model && provider
-      ? swrKeys.agentBuilder.suggestions(mode, builderAgentId, targetId)
+      ? swrKeys.agentBuilder.suggestions(mode, builderAgentId, targetId, locale)
       : null;
 
   const { data, isLoading, error, mutate } = useSWR(

--- a/src/libs/swr/keys.test.ts
+++ b/src/libs/swr/keys.test.ts
@@ -1,7 +1,7 @@
 import { unstable_serialize } from 'swr';
 import { describe, expect, it } from 'vitest';
 
-import { recentKeys, taskKeys } from './keys';
+import { agentBuilderKeys, recentKeys, taskKeys } from './keys';
 import { CACHE_TIERS } from './localStorageProvider';
 
 describe('recentKeys', () => {
@@ -50,6 +50,21 @@ describe('recentKeys', () => {
       serialized.includes(pattern),
     );
 
+    expect(persisted).toBe(true);
+  });
+});
+
+describe('agentBuilderKeys', () => {
+  // Regression: builder suggestion chips were memory-only (no CACHE_TIERS entry),
+  // so every page load showed a skeleton and paid a fresh LLM generation. The key
+  // must route to a persisted tier so revisits hydrate the last batch instead.
+  it('routes the builder suggestions key to a persisted cache tier', () => {
+    const serialized = unstable_serialize(
+      agentBuilderKeys.suggestions('agentBuilder', 'builder-1', 'target-1'),
+    );
+    const persisted = [...CACHE_TIERS.idb, ...CACHE_TIERS.local].some((pattern) =>
+      serialized.includes(pattern),
+    );
     expect(persisted).toBe(true);
   });
 });

--- a/src/libs/swr/keys.test.ts
+++ b/src/libs/swr/keys.test.ts
@@ -60,7 +60,7 @@ describe('agentBuilderKeys', () => {
   // must route to a persisted tier so revisits hydrate the last batch instead.
   it('routes the builder suggestions key to a persisted cache tier', () => {
     const serialized = unstable_serialize(
-      agentBuilderKeys.suggestions('agentBuilder', 'builder-1', 'target-1'),
+      agentBuilderKeys.suggestions('agentBuilder', 'builder-1', 'target-1', 'zh-CN'),
     );
     const persisted = [...CACHE_TIERS.idb, ...CACHE_TIERS.local].some((pattern) =>
       serialized.includes(pattern),

--- a/src/libs/swr/keys.ts
+++ b/src/libs/swr/keys.ts
@@ -196,15 +196,18 @@ export const agentLabelKeys = {
 // the LLM generation instead of paying a skeleton + a generateJSON call every
 // page load. `contextSummary` is intentionally NOT part of the key so config
 // autosaves for the same target don't refetch; manual refresh revalidates the
-// same key in place (see `useBuilderSuggestions`).
+// same key in place (see `useBuilderSuggestions`). `locale` IS part of the key:
+// chips are generated in the UI language, so a persisted entry must not be
+// served after a language switch.
 export const agentBuilderKeys = {
   suggestions: def(
     'agentBuilder:suggestions',
-    (mode: string, builderAgentId: string, targetId: string | undefined) => [
+    (mode: string, builderAgentId: string, targetId: string | undefined, locale?: string) => [
       'agentBuilder:suggestions',
       mode,
       builderAgentId,
       targetId,
+      locale ?? null,
     ],
   ),
 };

--- a/src/libs/swr/keys.ts
+++ b/src/libs/swr/keys.ts
@@ -192,18 +192,19 @@ export const agentLabelKeys = {
 };
 
 // ---- agent builder (opening-suggestion chips) ---------------------------
-// Kept off `CACHE_TIERS` on purpose — these are ephemeral LLM-generated chips.
-// `contextSummary` is intentionally NOT part of the key so config autosaves for
-// the same target don't refetch; `nonce` bumps on manual refresh.
+// Persisted to the localStorage tier (see `CACHE_TIERS.local`) so revisits skip
+// the LLM generation instead of paying a skeleton + a generateJSON call every
+// page load. `contextSummary` is intentionally NOT part of the key so config
+// autosaves for the same target don't refetch; manual refresh revalidates the
+// same key in place (see `useBuilderSuggestions`).
 export const agentBuilderKeys = {
   suggestions: def(
     'agentBuilder:suggestions',
-    (mode: string, builderAgentId: string, targetId: string | undefined, nonce: number) => [
+    (mode: string, builderAgentId: string, targetId: string | undefined) => [
       'agentBuilder:suggestions',
       mode,
       builderAgentId,
       targetId,
-      nonce,
     ],
   ),
 };

--- a/src/libs/swr/localStorageProvider.ts
+++ b/src/libs/swr/localStorageProvider.ts
@@ -501,6 +501,7 @@ export const CACHE_TIERS = {
     'fetchRecentResources',
     'fetchRecentPages',
     'group:list',
+    'agentBuilder:suggestions', // builder opening-suggestion chips (skip LLM regen on revisit)
     'taskTemplate:', // home task-template recommendations
     'modelConfig:', // small remote model config shells used by home starter chips
   ],


### PR DESCRIPTION
The Agent/Group Builder opening-suggestion chips were memory-only: every page load showed a skeleton and paid a fresh LLM `generateJSON` call, even when nothing about the target had changed.

This persists the chips through the existing tiered SWR cache provider so revisits hydrate the last batch synchronously (no skeleton, no LLM call):

- Route `agentBuilder:suggestions` to the localStorage tier in `CACHE_TIERS.local` (7-day TTL, identity-scope partitioned).
- Drop `nonce` from the SWR key — with persistence, a per-mount nonce breaks cache hits (it resets to 0 on every mount while refreshed batches land under other keys). Manual refresh now revalidates the same key in place via `mutate(undefined, { revalidate: true })`, keeping the skeleton feedback and writing the fresh batch into the persisted entry.
- Add `revalidateIfStale: false` so a cache hit renders directly instead of regenerating on mount.

#### Key Decisions / Non-goals

- `contextSummary` stays out of the SWR key (unchanged semantics): config autosaves for the same target must not refetch. A persisted batch can therefore be stale relative to config edits made in a previous session — the manual refresh button covers that, which is the accepted trade-off for skipping an LLM call per visit.
- localStorage tier (not IndexedDB): 3 small chips fit the "small shells" tier and benefit from its synchronous first paint.

#### Test

- [x] Added/updated tests
  - New regression test: a persisted cache hit renders directly without calling `generateJSON`.
  - New key-routing test: `agentBuilder:suggestions` resolves to a persisted cache tier.
  - Existing behaviors covered by the untouched tests: autosave doesn't refetch, manual refresh uses the latest context, target switch regenerates.
- [x] Tested locally — `bun run check` (lint + 46 tests) and full type-check pass.

#### 🔗 Related Issue

Fixes LOBE-12895

🤖 Generated with [Claude Code](https://claude.com/claude-code)