### PR TITLE
✨ feat(agent): polish work summary and acceptance handoff

### DIFF
--- a/.agents/skills/agent-testing/SKILL.md
+++ b/.agents/skills/agent-testing/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Agentic end-to-end testing for any project: backend verification via the
   project CLI, frontend verification via agent-browser (web), and desktop
   verification via CDP (Electron). Drives the real surface, captures visually
-  confirmed evidence, and publishes a structured report to the LobeHub verify
-  platform. Triggers on 'cli test', 'test with cli', 'verify with cli',
+  confirmed evidence, and publishes a structured report to LobeHub Acceptance.
+  Triggers on 'cli test', 'test with cli', 'verify with cli',
   'backend test with cli', 'local test', 'test in electron', 'test desktop',
   'manual test', 'test report', or any local end-to-end verification task.
 ---
@@ -445,7 +445,7 @@ Hard rules worth front-loading:
   every human-facing string in `result.json` (case `name`/`observation`,
   `summary.conclusion`, scope `focus`/`entry`) in the language the user is
   conversing in. `result.json` keys/status values stay English.
-- **`result.json` is the report; the verify page renders it.** Each tested
+- **`result.json` is the report; the acceptance page renders it.** Each tested
   behavior is one entry in `cases[]` (`{ name, result, observation, evidence }`);
   the page builds the scope header from `scenario`+`context`, the check list from
   `plan[]`+`cases[]`, and the verdict from `summary.conclusion`. Do NOT hand-build
@@ -463,23 +463,24 @@ Hard rules worth front-loading:
   artifacts in the current round; never require a reviewer to join explanation
   from one immutable round with logs from another. See
   [references/report.md](./references/report.md#dual-text-evidence-for-non-visual-behavior).
-- **Final replies link ONLY the published `/acceptance/<id>` page — never a
-  `/verify/<id>` URL. Put no images or local file links in the chat reply.**
+- **Final replies expose ONLY the published `/acceptance/<id>` page. Put no
+  images, local paths, local file links, or internal run-page paths in the chat
+  reply.**
   The acceptance page is the stable cross-round decision surface and renders
   each round's evidence inline. For a fixed this-round snapshot, append
   `?r=<roundIndex>` to the same acceptance URL (the ingest CLI prints it as
-  `round snapshot`) — that deep-links this round's full report. You may mention
-  the local report directory as plain text. Always leave whitespace between a
-  URL and any following text — CJK punctuation glued right after it (`…4c74（本轮`)
+  `round snapshot`) — that deep-links this round's full report. Do not mention
+  any working-artifact location. Always leave whitespace between a URL and any
+  following text — CJK punctuation glued right after it (`…4c74（本轮`)
   gets swallowed into the href by chat autolinkers and breaks the link.
 - **Time-based behavior needs a GIF, not a screenshot.** Streaming output, a
   ticking timer, loading states, animations — record with `scripts/record-gif.sh`
   and attach the GIF as that case's evidence; a static screenshot cannot prove it.
 
-### Step 6 — Publish to the LobeHub verify platform (mandatory)
+### Step 6 — Publish to LobeHub Acceptance (mandatory)
 
-The local report under `.records/reports/` is the working artifact; the
-**deliverable is the report opened on the verify platform**. Do not stop at local
+The report under `.records/reports/` is a private working artifact; the
+**deliverable is the report opened on the acceptance page**. Do not stop at local
 files — push the session up with the CLI so the user (and later reviewers) can open
 it at a stable URL with the evidence rendered inline.
 
@@ -554,8 +555,8 @@ It prints the `verifyRunId`, `acceptanceId`, `roundIndex`, and the acceptance
 paths. The final reply leads with
 `https://app.lobehub.com/acceptance/<acceptanceId>` as the latest cross-round
 state; for a fixed per-round snapshot use the same URL with `?r=<roundIndex>`
-(printed as `round snapshot`). Never link `/verify/<id>` in the reply — the
-verify run stays the internal immutable record behind the acceptance page.
+(printed as `round snapshot`). Do not expose any other run path in the reply; the
+underlying immutable run is an internal record behind the acceptance page.
 
 #### Every run belongs to a subject acceptance (mandatory)
 
@@ -650,7 +651,7 @@ env -u LOBEHUB_SERVER -u LOBE_API_KEY -u LOBEHUB_CLI_API_KEY -u LOBEHUB_CLI_HOME
 
 #### Every verification run is an immutable snapshot
 
-One call to `acceptance run ingest` creates one immutable `/verify/<id>` snapshot. Never
+One call to `acceptance run ingest` creates one immutable internal run snapshot. Never
 overwrite, replace, prune, or re-ingest into an earlier run. A fix followed by
 re-verification MUST create another run on the same acceptance, preserving the
 earlier plan, results, evidence, and verdict exactly as observed. Use a fresh

--- a/.agents/skills/agent-testing/references/common-mistakes.md
+++ b/.agents/skills/agent-testing/references/common-mistakes.md
@@ -102,7 +102,7 @@ one-line probe could have checked.
 ## M5 — Attaching a stale "before" screenshot as a passed case's evidence (unlabeled)
 
 **Wrong approach**: putting BOTH the "after" and a stale "before" screenshot into the
-same `cases[].evidence` array, unlabeled. The verify page renders every evidence
+same `cases[].evidence` array, unlabeled. The acceptance page renders every evidence
 image with its filename as a heading, so the user opens the stale shots and concludes
 the fix didn't land.
 
@@ -146,7 +146,7 @@ logic bug.
 
 ---
 
-## M7 — Embedding a local-path screenshot in the chat reply
+## M7 — Exposing working-artifact paths in the chat reply
 
 **Wrong approach**: ending the final reply with an inline image embed or link
 pointing at the local report dir, believing it will render as a picture in chat.
@@ -159,12 +159,12 @@ never inside the message.
 **What it breaks**: the reply looks like it has evidence but shows nothing — the user
 gets a broken box and has to go find the acceptance link anyway.
 
-**Correct approach**: put NO images and NO local-file links in the chat reply. The
+**Correct approach**: put NO images and NO local paths or local-file links in the
+chat reply. The
 published `/acceptance/<id>` page already renders every screenshot inline (append
 `?r=<roundIndex>` for this round's fixed snapshot) — that URL is the only visual
-deliverable; never link the raw `/verify/<id>` page. Describe key visual outcomes in
-prose; mention the local report dir as a plain string (not a markdown link) if a
-reference is useful.
+deliverable. Describe key visual outcomes in prose without exposing the working
+artifact location or any internal run-page path.
 
 ---
 

--- a/.agents/skills/agent-testing/references/project-adapter.md
+++ b/.agents/skills/agent-testing/references/project-adapter.md
@@ -18,7 +18,7 @@ project's commands.
 
 `.agents/acceptance/` is **committed** (the adapter and the project living logs are
 shared, versioned team assets). The report output directory `.records/` is
-**gitignored** — reports are per-run artifacts, published to the verify platform,
+**gitignored** — reports are per-run artifacts, published to LobeHub Acceptance,
 not committed.
 
 ## Fixed section skeleton

--- a/.agents/skills/agent-testing/references/record-app-screen.md
+++ b/.agents/skills/agent-testing/references/record-app-screen.md
@@ -95,7 +95,7 @@ sleep 10
 
 For a short, time-based assertion (streaming output, a ticking timer, a loading
 state) attach a GIF from `scripts/record-gif.sh` to the case's evidence — it is
-lighter than a full recording and embeds inline on the verify page. Reach for a full
+lighter than a full recording and embeds inline on the acceptance page. Reach for a full
 MP4 recording only when a longer flow needs to be watched end to end.
 
 ## Prerequisites

--- a/.agents/skills/agent-testing/references/report.md
+++ b/.agents/skills/agent-testing/references/report.md
@@ -31,7 +31,7 @@ Execution outputs remain in the round directory's `assets/`. See
 `scripts/fixture.mjs` and the skill's fixture workflow.
 
 **`result.json` is the report — `report.md` is just its tail.** The published
-verify page (`/verify/<id>`) renders itself from `result.json`: one line of
+acceptance page renders itself from `result.json`: one line of
 provenance (PR / branch / commit / date / surfaces), the overall conclusion from
 `summary.conclusion` directly under the title, and the check list from `plan[]`
 paired with `cases[]`. So `report.md` must NOT repeat the scope block or a case
@@ -100,7 +100,7 @@ table — those double up on the page. It carries only the non-duplicate narrati
      usual slip, and it does not pair: `role` is read from inside `comparison`,
      never from the evidence item itself.
 
-     The verify page renders a complete pair with each screenshot under its own
+     The acceptance page renders a complete pair with each screenshot under its own
      tinted band — red for `before`, green for `after`. A group contains exactly one
      `before` and one `after`, and **both halves need the same string `id`**; a half
      without an `id` can never pair. Incomplete groups render as ordinary evidence.
@@ -204,7 +204,7 @@ from the current one.
    the final chat reply.
 
 6. **Publish** (SKILL.md Step 6) — upload the finished session so it's viewable on
-   the verify platform, not just on disk. **Publish to PRODUCTION defaults with the
+   LobeHub Acceptance, not just on disk. **Publish to PRODUCTION defaults with the
    user's real login, NOT a local-dev CLI override** — strip the local dev overrides
    so `lh` uses its production defaults. Clearing an override profile looks like:
 
@@ -216,8 +216,9 @@ from the current one.
    This creates a new immutable verification run, attaches it to the required
    subject acceptance, uploads the cases, evidence, and report body, then prints
    `/acceptance/<acceptanceId>` plus its `?r=<roundIndex>` round-snapshot form.
-   Include the full production acceptance link (never a `/verify/<id>` one) in the
-   final reply alongside the local report dir — with whitespace after the URL, so
+   Include only the full production acceptance link in the final reply. Never
+   expose local paths, local file links, or internal run-page paths. Leave
+   whitespace after the URL, so
    an autolinker can't swallow adjacent CJK punctuation into the href. See SKILL.md →
    Step 6 for why production defaults (a localhost URL isn't shareable and a local
    stub storage fails file-evidence uploads), the production login check, and the

--- a/.agents/skills/agent-testing/scripts/cdp-capture.cjs
+++ b/.agents/skills/agent-testing/scripts/cdp-capture.cjs
@@ -12,7 +12,7 @@
 // Requires the `ws` package to be resolvable from this file's own location —
 // Node's require() walks up ancestor node_modules automatically, so this works
 // whether the skill ships inside @lobehub/cli's own node_modules or a hoisted
-// monorepo root; no manual NODE_PATH wiring needed. A `lh verify install`-copied
+// monorepo root; no manual NODE_PATH wiring needed. An installed
 // skill dir lives inside a consumer repo's harness skills dir, though, so the
 // ancestor walk from there never reaches @lobehub/cli's node_modules — fall
 // back to the `cliRoot` recorded in the sibling `.skill-meta.json`.

--- a/.agents/skills/agent-testing/scripts/report-init.sh
+++ b/.agents/skills/agent-testing/scripts/report-init.sh
@@ -86,7 +86,7 @@ EOF
   fi
 fi
 
-# report.md is rendered as the verify page's "Details" tail — free-form COMMENT.
+# report.md is rendered as the acceptance page's "Details" tail — free-form COMMENT.
 # The scope (范围), per-case table (用例), overall conclusion, and the score are
 # all STRUCTURED on the page now (result.json scenario/context + cases +
 # summary.conclusion + summary.score), so DON'T repeat any of them here or they

--- a/.agents/skills/agent-testing/surfaces/web.md
+++ b/.agents/skills/agent-testing/surfaces/web.md
@@ -21,7 +21,7 @@ the methodology.
 
 ## Option A — agent-browser with seeded auth (recommended)
 
-Seed/verify the web session per `PROJECT.md` §3, then drive it. Use one named
+Seed and validate the web session per `PROJECT.md` §3, then drive it. Use one named
 session as the single evidence source:
 
 ```bash

--- a/packages/builtin-skills/src/acceptance/SKILL.md
+++ b/packages/builtin-skills/src/acceptance/SKILL.md
@@ -68,6 +68,10 @@ means "skip the acceptance"** — it only means you author the plan instead of
 discovering it. On a later repair round, pass the previously printed
 `--acceptance <acceptanceId>` so the new snapshot joins the same history.
 
+On the first ingest, always supply `--requirement "<one-sentence business goal>"`.
+The requirement describes what the whole acceptance judges, not the narrower
+scope of one round. It is immutable once recorded.
+
 ## Rounds are immutable — repair means a NEW round
 
 A published round is a permanent record of what was true at that moment. **Never
@@ -76,11 +80,18 @@ re-verification as the next round, and let the acceptance page show the
 progression. Correcting a typo in the same session's report is fine; passing off
 post-fix evidence as the original round is not.
 
+Before a repair round, read the current acceptance with
+`lh acceptance view <acceptanceId | type:id> --json`. Omit checks whose latest
+`userReview.action` is `accept`; address non-stale rejects and reuse their exact
+stable check ids. When one check semantically replaces another, declare
+`supersedes: ['old-id']` and repeat the complete lineage in every later round
+that reuses the successor id.
+
 The **acceptance** (`/acceptance/<acceptanceId>`) is the stable cross-round
-decision surface that aggregates every round for a subject; each **round**
-(`/verify/<verifyRunId>`) is one immutable snapshot with its evidence. Lead your
-final reply with the acceptance link when one exists; the round link follows as
-the record of this attempt.
+decision surface that aggregates every immutable round for a subject. In the
+final reply, expose only the acceptance page. A fixed snapshot of the current
+round uses that same path with `?r=<roundIndex>`; implementation-level run pages
+stay internal.
 
 ## Prerequisites
 
@@ -179,7 +190,8 @@ lh acceptance run result submit --operation "$LOBE_OPERATION_ID" --item "$CHECK_
 call; call again for each additional one (same `--item` reuses the row). Leave the
 pass/fail **verdict** to the review step — only add `--verdict` if your task
 explicitly asks you to self-assert the outcome. Every successful submit prints the
-full `/verify/<verifyRunId>` report URL. Preserve that URL for the final handoff.
+an internal run URL. Keep the returned run id only for coverage checks; never
+expose that URL in the final handoff.
 
 ## Step 4 — Self-check coverage (do not skip)
 
@@ -201,17 +213,17 @@ how good the work is.
 
 ### Final handoff (mandatory)
 
-The final response MUST include the published URLs, together with the explicit
-coverage result. Do not finish with only a check-result id, local artifact path,
-or prose claim.
+The final response MUST include the published acceptance URL when the round is
+attached to an acceptance, together with the explicit coverage result. Do not
+finish with only a check-result id or prose claim.
 
-Lead with the **acceptance** link when the command printed one — it is the stable
-cross-round decision surface; the **round** link follows as this attempt's
-immutable record. Put no images or local file links in the chat reply.
+Expose only the **acceptance** link — it is the stable cross-round decision
+surface. For this round's fixed snapshot, append `?r=<roundIndex>` to that same
+URL. Put no images, local paths, local file links, or internal run-page paths in
+the chat reply.
 
 ```text
 Acceptance:   https://app.lobehub.com/acceptance/<acceptanceId>
-This round:   https://app.lobehub.com/verify/<verifyRunId>
 Coverage: 2/2 criteria, all required evidence uploaded
 ```
 

--- a/packages/builtin-skills/src/acceptance/index.test.ts
+++ b/packages/builtin-skills/src/acceptance/index.test.ts
@@ -1,0 +1,37 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const skillDir = path.dirname(fileURLToPath(import.meta.url));
+const readMarkdownBundle = (directory: string): string =>
+  readdirSync(directory, { withFileTypes: true })
+    .flatMap((entry) => {
+      const filePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) return readMarkdownBundle(filePath);
+      return entry.name.endsWith('.md') ? readFileSync(filePath, 'utf8') : [];
+    })
+    .join('\n');
+
+const skillContent = readFileSync(path.join(skillDir, 'SKILL.md'), 'utf8');
+const skillBundle = readMarkdownBundle(skillDir);
+
+describe('AcceptanceSkill', () => {
+  it('exposes only the acceptance path in user-facing handoff guidance', () => {
+    const internalRunPath = ['', 'verify'].join('/');
+
+    expect(skillBundle).not.toContain(internalRunPath);
+    expect(skillContent).toContain('/acceptance/<acceptanceId>');
+    expect(skillContent).toContain(
+      'Put no images, local paths, local file links, or internal run-page paths',
+    );
+  });
+
+  it('keeps the latest evidence and multi-round acceptance contracts', () => {
+    expect(skillBundle).toContain('Dual text evidence for non-visual behavior');
+    expect(skillContent).toContain('lh acceptance view <acceptanceId | type:id> --json');
+    expect(skillContent).toContain("supersedes: ['old-id']");
+    expect(skillContent).toContain('--requirement "<one-sentence business goal>"');
+  });
+});

--- a/packages/builtin-skills/src/acceptance/index.ts
+++ b/packages/builtin-skills/src/acceptance/index.ts
@@ -21,7 +21,7 @@ export const AcceptanceIdentifier = 'acceptance';
 
 /**
  * Portable builder-side acceptance skill. Unlike the repo-local `agent-testing`
- * skill (macOS scripts + local report dirs + LobeHub-specific probes), this one
+ * skill (macOS scripts + project-specific working artifacts and probes), this one
  * keeps its acceptance contract independent of repository-local scripts, so any
  * external builder (Claude Code / Codex) can run it from a task's working
  * directory, with or without a LobeHub operation/topic: discover or author the

--- a/packages/builtin-skills/src/acceptance/references/evidence.md
+++ b/packages/builtin-skills/src/acceptance/references/evidence.md
@@ -18,6 +18,19 @@ instructions merely to learn how to submit an artifact.
 The declared `requiredEvidence` type is binding. Do not replace a required video
 with a final screenshot or a required DOM snapshot with prose.
 
+## Dual text evidence for non-visual behavior
+
+CLI, API, backend, policy, security, and migration claims normally need two
+separate `text` artifacts on the same check:
+
+1. A reasoning artifact: claim, setup or threat model, method, pass criteria,
+   interpretation, and limitations.
+2. An execution artifact: exact command or request, relevant raw observations,
+   exit/status values, and a short mapping back to the pass criteria.
+
+Keep both artifacts in the current immutable round. Do not ask a reviewer to
+join an explanation from an older round with fresh execution output.
+
 ## File versus inline content
 
 - Use `--file` for binary artifacts and larger text/DOM/transcript files.

--- a/packages/builtin-skills/src/acceptance/references/report.md
+++ b/packages/builtin-skills/src/acceptance/references/report.md
@@ -5,7 +5,7 @@ exists. When it doesn't — a standalone delivery, a task run without
 `$LOBE_OPERATION_ID`, or any run where **you** author the checks — publish a
 **structured report round** instead: a self-contained directory that
 `lh acceptance run ingest` uploads as one immutable verification round. The
-verify page renders itself from `result.json`: provenance, the overall
+acceptance page renders itself from `result.json`: provenance, the overall
 conclusion, and the check list from `plan[]` paired with `cases[]`, each with
 its evidence inline — **images render as figures, before/after pairs render
 under tinted comparison bands**. A chat-only summary or a bare markdown report
@@ -32,7 +32,8 @@ the checks and use one of these first-class paths:
 REPORT_DIR=./acceptance-report
 
 # A. first external-project round — creates a standalone acceptance automatically
-lh acceptance run ingest "$REPORT_DIR" --json
+lh acceptance run ingest "$REPORT_DIR" \
+  --requirement "<one-sentence business goal>" --json
 
 # Re-verification — append a new immutable round to the same acceptance
 lh acceptance run ingest "$REPORT_DIR" --acceptance "$ACCEPTANCE_ID" --json
@@ -58,6 +59,18 @@ history is the point, not something to hide. Reuse the same `--subject` across
 rounds for a LobeHub object, or pass `--acceptance <acceptanceId>` after an
 external project's first standalone round.
 
+Before composing a repair round, read the aggregate:
+
+```bash
+lh acceptance view "$ACCEPTANCE_ID" --json
+```
+
+- Omit checks whose latest `userReview.action` is `accept` unless the repair can
+  regress them.
+- Address non-stale rejects and reuse their exact stable check ids.
+- A semantic replacement declares `supersedes: ["old-id"]`; every later round
+  reusing the successor id repeats its full `supersedes` chain.
+
 ## Directory layout
 
 Any directory works — no repo convention required:
@@ -72,7 +85,8 @@ Any directory works — no repo convention required:
 ## Workflow
 
 1. **Write `plan[]` BEFORE you run anything.** Each item is
-   `{ id, title, category, verifier, method, expected, requiredEvidence }`.
+   `{ id, title, category, verifier, method, expected, requiredEvidence,
+supersedes? }`.
    A planned item that never produces a case renders as **未执行** rather than
    vanishing — cut coverage in the open.
 2. **Collect evidence into `assets/` as you test.** Screenshots/charts must be
@@ -96,13 +110,18 @@ Any directory works — no repo convention required:
    lh acceptance run ingest "$REPORT_DIR" --source agent-testing --json
    ```
 
+   On the first ingest, add `--requirement "<one-sentence business goal>"`.
+   Describe the durable goal of the whole acceptance, not this round's narrower
+   implementation scope.
+
    Inside a LobeHub topic, the command groups the round under the current topic.
    Outside one, it creates a standalone acceptance automatically; no Task ID is
    required. To publish a repair into that same history, add
    `--acceptance <acceptanceId>` using the ID printed by the first ingest. The
    command uploads cases + evidence + report body and prints
-   `/verify/<verifyRunId>` and `/acceptance/<acceptanceId>` — include the full
-   URLs in your final reply. Never update a prior round after a fix; publish the
+   `/acceptance/<acceptanceId>` plus its `?r=<roundIndex>` snapshot form. Include
+   only the full acceptance URL in your final reply; never expose local paths or
+   internal run-page paths. Never update a prior round after a fix; publish the
    re-verification as the next round.
 
 ## result.json schema
@@ -196,6 +215,13 @@ flow are ordinary ordered evidence with captions, not a pair.
 
 - **No evidence, no claim** — every `pass`/`fail` in `cases[]` links at least
   one asset.
+- **Non-visual behavioral claims need dual text evidence** — attach a concise
+  reviewer-facing reasoning document and a separate audit-facing execution
+  artifact containing the exact command/request and observed values. Neither
+  unsupported prose nor an unexplained log dump is sufficient.
+- **Final handoff exposes only Acceptance** — use `/acceptance/<acceptanceId>` or
+  its `?r=<roundIndex>` snapshot. Never include images, local paths, local file
+  links, or internal run-page paths in chat.
 - **Report failures faithfully** — a failing case with clear evidence is a good
   report; a vague green one is not.
 - If coverage was cut, say so in `report.md` — silent truncation reads as

--- a/packages/builtin-skills/vitest.config.mts
+++ b/packages/builtin-skills/vitest.config.mts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'lcov', 'text-summary'],
+    },
+    environment: 'node',
+  },
+});

--- a/src/features/Conversation/Messages/EditedFilesCard/index.test.ts
+++ b/src/features/Conversation/Messages/EditedFilesCard/index.test.ts
@@ -4,6 +4,7 @@ import { createElement } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import EditedFilesCard, {
+  AGGREGATE_EDITED_FILE_ICON_SIZE,
   getEditedFileIconName,
   getEditedFilesCardMode,
   SINGLE_EDITED_FILE_ICON_SIZE,
@@ -56,6 +57,12 @@ describe('getFilePathDisplayInfo', () => {
 describe('SINGLE_EDITED_FILE_ICON_SIZE', () => {
   it('keeps the single-file icon container compact', () => {
     expect(SINGLE_EDITED_FILE_ICON_SIZE).toBe(40);
+  });
+});
+
+describe('AGGREGATE_EDITED_FILE_ICON_SIZE', () => {
+  it('gives the multi-file summary a prominent Codex-style icon container', () => {
+    expect(AGGREGATE_EDITED_FILE_ICON_SIZE).toBe(56);
   });
 });
 

--- a/src/features/Conversation/Messages/EditedFilesCard/index.tsx
+++ b/src/features/Conversation/Messages/EditedFilesCard/index.tsx
@@ -22,6 +22,7 @@ import { type OperationEditedFile, summarizeEditedFilesTotals } from './deriveEd
 import { useOpenEditedFile } from './useOpenEditedFile';
 
 export const SINGLE_EDITED_FILE_ICON_SIZE = 40;
+export const AGGREGATE_EDITED_FILE_ICON_SIZE = 56;
 
 /** Fire a toggle on Enter/Space so the div-based expander is keyboard operable. */
 const toggleOnKey = (toggle: () => void) => (event: KeyboardEvent<HTMLDivElement>) => {
@@ -43,8 +44,9 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   header: css`
     cursor: pointer;
-    padding-block: 10px;
-    padding-inline: 12px;
+    min-height: 84px;
+    padding-block: 14px;
+    padding-inline: 16px;
 
     &:hover {
       background: ${cssVar.colorFillQuaternary};
@@ -52,7 +54,14 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   headerIcon: css`
     flex-shrink: 0;
+
+    width: ${AGGREGATE_EDITED_FILE_ICON_SIZE}px;
+    height: ${AGGREGATE_EDITED_FILE_ICON_SIZE}px;
+    border-radius: 12px;
+
     color: ${cssVar.colorTextSecondary};
+
+    background: ${cssVar.colorFillTertiary};
   `,
   singleHeader: css`
     padding-block: 10px;
@@ -121,8 +130,9 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   title: css`
     min-width: 0;
-    font-size: 14px;
-    font-weight: 500;
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 1.4;
   `,
   stats: css`
     font-weight: 500;
@@ -209,13 +219,13 @@ const EditedFileRow = memo<{ entry: EditedFileEntry; onOpen?: () => void }>(({ e
             className={cx(styles.viewChanges, expanded && styles.viewChangesVisible)}
             size={'small'}
             type={'text'}
+            // Enter/Space on the button must not bubble into the row's own
+            // key handler, which would also open the file preview.
+            onKeyDown={(event) => event.stopPropagation()}
             onClick={(event) => {
               event.stopPropagation();
               setExpanded((prev) => !prev);
             }}
-            // Enter/Space on the button must not bubble into the row's own
-            // key handler, which would also open the file preview.
-            onKeyDown={(event) => event.stopPropagation()}
           >
             {t(expanded ? 'editedFiles.hideChanges' : 'editedFiles.viewChanges')}
           </Button>
@@ -361,23 +371,26 @@ const EditedFilesCard = memo<EditedFilesCardProps>(({ entries }) => {
         align={'center'}
         aria-expanded={expanded}
         className={styles.header}
-        gap={8}
+        gap={14}
         role={'button'}
         tabIndex={0}
         onClick={() => setExpanded((prev) => !prev)}
         onKeyDown={toggleOnKey(() => setExpanded((prev) => !prev))}
       >
-        <FilePenLineIcon className={styles.headerIcon} size={16} />
-        <Text ellipsis className={styles.title}>
-          {t('editedFiles.title', { count: entries.length })}
-        </Text>
-        <Flexbox flex={1} />
-        <LineStats
-          hideZeroDeltas
-          className={styles.stats}
-          linesAdded={totals.linesAdded}
-          linesDeleted={totals.linesDeleted}
-        />
+        <Center className={styles.headerIcon}>
+          <FilePenLineIcon size={26} />
+        </Center>
+        <Flexbox flex={1} gap={3} style={{ minWidth: 0 }}>
+          <Text ellipsis className={styles.title}>
+            {t('editedFiles.title', { count: entries.length })}
+          </Text>
+          <LineStats
+            hideZeroDeltas
+            className={styles.stats}
+            linesAdded={totals.linesAdded}
+            linesDeleted={totals.linesDeleted}
+          />
+        </Flexbox>
         {expanded ? (
           <ChevronDownIcon className={styles.chevron} size={16} />
         ) : (

--- a/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/index.test.tsx
@@ -1,11 +1,33 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import HeaderActions from './index';
 
+const { toggleTerminalPanel } = vi.hoisted(() => ({
+  toggleTerminalPanel: vi.fn(),
+}));
+
+vi.mock('@/const/version', () => ({ isDesktop: true }));
+
+vi.mock('@/store/global', () => ({
+  useGlobalStore: (
+    selector: (state: { toggleTerminalPanel: typeof toggleTerminalPanel }) => unknown,
+  ) => selector({ toggleTerminalPanel }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
 vi.mock('@lobehub/ui', () => ({
-  ActionIcon: () => <button data-testid={'overflow-menu-button'} />,
+  ActionIcon: ({ title, onClick }: { title?: string; onClick?: () => void }) => (
+    <button
+      aria-label={title}
+      data-testid={title ? undefined : 'overflow-menu-button'}
+      onClick={onClick}
+    />
+  ),
   DropdownMenu: ({ children, header }: { children?: ReactNode; header?: ReactNode }) => (
     <div>
       {header}
@@ -32,5 +54,13 @@ describe('Conversation header actions', () => {
     render(<HeaderActions />);
 
     expect(screen.getByTestId('topic-info-header')).toBeInTheDocument();
+  });
+
+  it('opens the terminal directly from the desktop header', () => {
+    render(<HeaderActions />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'terminalPanel.title' }));
+
+    expect(toggleTerminalPanel).toHaveBeenCalledWith(true);
   });
 });

--- a/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/index.tsx
@@ -1,19 +1,33 @@
 'use client';
 
 import { ActionIcon, DropdownMenu } from '@lobehub/ui';
-import { MoreHorizontal } from 'lucide-react';
+import { MoreHorizontal, SquareTerminalIcon } from 'lucide-react';
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
 
+import { isDesktop } from '@/const/version';
 import HeaderSlot from '@/routes/(main)/agent/(chat)/_layout/HeaderSlot';
+import { useGlobalStore } from '@/store/global';
 
 import { useMenu } from './useMenu';
 
 const HeaderActions = memo(() => {
+  const { t } = useTranslation('chat');
   const { menuHeader, menuItems } = useMenu();
+  const toggleTerminalPanel = useGlobalStore((s) => s.toggleTerminalPanel);
 
   return (
     <>
       <HeaderSlot.Outlet />
+      {isDesktop && (
+        <ActionIcon
+          icon={SquareTerminalIcon}
+          size={'small'}
+          title={t('terminalPanel.title')}
+          tooltipProps={{ placement: 'bottom' }}
+          onClick={() => toggleTerminalPanel(true)}
+        />
+      )}
       <DropdownMenu header={menuHeader} items={menuItems}>
         <ActionIcon icon={MoreHorizontal} size={'small'} />
       </DropdownMenu>


### PR DESCRIPTION
## Summary

- enlarge the multi-file edit summary into a more prominent Codex-style card
- restore a direct desktop-only terminal action in the conversation header
- align agent-testing and the builtin Acceptance skill around acceptance-only handoff links
- add dual-text evidence, immutable repair-round feedback, requirement, and supersedes guidance
- add a builtin Acceptance skill contract test

## Testing

- `bunx vitest run --silent=passed-only --config packages/builtin-skills/vitest.config.mts packages/builtin-skills/src/acceptance/index.test.ts`
- `bunx vitest run --silent=passed-only src/routes/(main)/agent/features/Conversation/Header/HeaderActions/index.test.tsx`
- pre-commit ESLint, Stylelint, Remark, and Prettier checks
- `git diff --check`