### PR TITLE
✨ feat(sandbox): add Tencent Cloud EdgeOne Agent Runtime provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -474,3 +474,13 @@ OPENAI_API_KEY=sk-xxxxxxxxx
 
 # Verify-im link token TTL in seconds (default 1800 = 30 min)
 # LOBE_LINK_TOKEN_TTL_SECONDS=1800
+
+# Tencent Cloud EdgeOne Agent Runtime sandbox
+# SANDBOX_PROVIDER=tencent
+# TENCENT_SANDBOX_API_TOKEN=your-edgeone-pages-api-token
+# TENCENT_SANDBOX_PROJECT_ID=makers-xxxxxxxx
+# TENCENT_SANDBOX_REGION=ap-beijing
+# persistent (default) reuses one container per topic; on-demand creates and
+# releases a container per tool call.
+# TENCENT_SANDBOX_MODE=persistent
+# TENCENT_SANDBOX_TIMEOUT_SEC=300

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -8,5 +8,8 @@
     "dev": "vite-node --watch --config viteNodeServer.config.ts src/hono/dev.ts",
     "start": "node dist/standalone.js",
     "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@e2b/code-interpreter": "^2.7.0"
   }
 }

--- a/apps/server/src/services/sandbox/factory.ts
+++ b/apps/server/src/services/sandbox/factory.ts
@@ -2,6 +2,7 @@ import { sandboxEnv } from '@/envs/sandbox';
 
 import { MarketSandboxProvider } from './providers/market';
 import { OnlyboxesSandboxProvider } from './providers/onlyboxes';
+import { TencentSandboxProvider } from './providers/tencent';
 import { SandboxMiddlewareService } from './service';
 import type {
   SandboxProvider,
@@ -22,6 +23,10 @@ const createSandboxProvider = (options: SandboxServiceOptions): SandboxProvider 
 
     case 'market': {
       return new MarketSandboxProvider(options);
+    }
+
+    case 'tencent': {
+      return new TencentSandboxProvider(options);
     }
   }
 };

--- a/apps/server/src/services/sandbox/providers/fileScripts.ts
+++ b/apps/server/src/services/sandbox/providers/fileScripts.ts
@@ -1,0 +1,216 @@
+import { Buffer } from 'node:buffer';
+
+/**
+ * Python helpers executed inside a sandbox to implement the file tools.
+ *
+ * They only depend on python3 and the standard library, so any provider whose
+ * runtime ships Python can reuse them and stay behaviourally identical to the
+ * others — the tool contracts in `@lobechat/builtin-tool-cloud-sandbox` are
+ * encoded here once rather than reimplemented per provider.
+ */
+
+export const scriptPrelude = `
+import base64, json, os, re, shutil, glob, fnmatch
+from pathlib import Path
+
+def load_args(encoded):
+    return json.loads(base64.b64decode(encoded).decode())
+
+def emit(value):
+    print(json.dumps(value, ensure_ascii=False))
+`;
+
+export const listFilesScript = `${scriptPrelude}
+def main(encoded):
+    args = load_args(encoded)
+    directory = args.get('directoryPath') or '.'
+    entries = []
+    for entry in os.scandir(directory):
+        stat = entry.stat()
+        entries.append({
+            'name': entry.name,
+            'path': entry.path,
+            'isDirectory': entry.is_dir(),
+            'size': stat.st_size,
+            'mtime': stat.st_mtime,
+        })
+    emit({'files': entries, 'totalCount': len(entries)})
+`;
+
+export const readFileScript = `${scriptPrelude}
+def main(encoded):
+    args = load_args(encoded)
+    path = args.get('path')
+    start = args.get('startLine')
+    end = args.get('endLine')
+    text = Path(path).read_text(errors='replace')
+    lines = text.splitlines(True)
+    selected = lines
+    if start is not None or end is not None:
+        start_idx = max((start or 1) - 1, 0)
+        end_idx = end if end is not None else len(lines)
+        selected = lines[start_idx:end_idx]
+    content = ''.join(selected)
+    emit({
+        'content': content,
+        'filename': os.path.basename(path),
+        'charCount': len(content),
+        'totalCharCount': len(text),
+        'totalLineCount': len(lines),
+    })
+`;
+
+export const prepareWriteFileScript = `${scriptPrelude}
+def main(encoded):
+    args = load_args(encoded)
+    path = Path(args.get('path'))
+    if args.get('createDirectories'):
+        path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b'')
+    emit({'success': True})
+`;
+
+export const appendWriteFileChunkScript = `${scriptPrelude}
+def main(encoded):
+    args = load_args(encoded)
+    path = Path(args.get('path'))
+    chunk = base64.b64decode(args.get('chunk') or '')
+    with path.open('ab') as file:
+        file.write(chunk)
+    emit({'bytesWritten': len(chunk), 'success': True})
+`;
+
+export const editFileScript = `${scriptPrelude}
+def main(encoded):
+    args = load_args(encoded)
+    path = Path(args.get('path'))
+    search = args.get('search') or ''
+    replace = args.get('replace') or ''
+    text = path.read_text(errors='replace')
+    count = text.count(search)
+    if count == 0:
+        emit({'success': False, 'error': 'search text not found', 'replacements': 0})
+        return
+    new_text = text.replace(search, replace) if args.get('all') else text.replace(search, replace, 1)
+    replacements = count if args.get('all') else 1
+    path.write_text(new_text)
+    emit({'success': True, 'replacements': replacements, 'linesAdded': replace.count('\\n'), 'linesDeleted': search.count('\\n')})
+`;
+
+export const searchFilesScript = `${scriptPrelude}
+from datetime import datetime
+
+def parse_time(value):
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace('Z', '+00:00')).timestamp()
+    except Exception:
+        return None
+
+def main(encoded):
+    args = load_args(encoded)
+    directory = args.get('directory') or '.'
+    raw_keywords = args.get('keywords') or args.get('keyword') or ''
+    keywords = [item.strip() for item in str(raw_keywords).split() if item.strip()]
+    raw_file_types = args.get('fileTypes') or args.get('fileType') or []
+    if isinstance(raw_file_types, str):
+        raw_file_types = [raw_file_types]
+    file_types = [item if str(item).startswith('.') else f'.{item}' for item in raw_file_types if str(item).strip()]
+    modified_after = parse_time(args.get('modifiedAfter'))
+    modified_before = parse_time(args.get('modifiedBefore'))
+    content_contains = args.get('contentContains')
+    limit = args.get('limit')
+    results = []
+    for root, _, files in os.walk(directory):
+        for name in files:
+            if keywords and not all(keyword in name for keyword in keywords):
+                continue
+            if file_types and not any(name.endswith(file_type) for file_type in file_types):
+                continue
+            path = os.path.join(root, name)
+            try:
+                stat = os.stat(path)
+            except Exception:
+                continue
+            if modified_after is not None and stat.st_mtime < modified_after:
+                continue
+            if modified_before is not None and stat.st_mtime > modified_before:
+                continue
+            if content_contains:
+                try:
+                    if str(content_contains) not in Path(path).read_text(errors='replace'):
+                        continue
+                except Exception:
+                    continue
+            results.append({'name': name, 'path': path, 'size': stat.st_size, 'mtime': stat.st_mtime})
+    sort_by = args.get('sortBy')
+    reverse = args.get('sortDirection') == 'desc'
+    if sort_by == 'size':
+        results.sort(key=lambda item: item.get('size') or 0, reverse=reverse)
+    elif sort_by == 'date':
+        results.sort(key=lambda item: item.get('mtime') or 0, reverse=reverse)
+    else:
+        results.sort(key=lambda item: item.get('name') or '', reverse=reverse)
+    total = len(results)
+    if isinstance(limit, int) and limit > 0:
+        results = results[:limit]
+    emit({'results': results, 'totalCount': total})
+`;
+
+export const moveFilesScript = `${scriptPrelude}
+def main(encoded):
+    args = load_args(encoded)
+    results = []
+    for op in args.get('operations') or []:
+        try:
+            shutil.move(op.get('source'), op.get('destination'))
+            results.append({'source': op.get('source'), 'destination': op.get('destination'), 'success': True})
+        except Exception as error:
+            results.append({'source': op.get('source'), 'destination': op.get('destination'), 'success': False, 'error': str(error)})
+    emit({'results': results, 'successCount': len([r for r in results if r.get('success')])})
+`;
+
+export const grepContentScript = `${scriptPrelude}
+def main(encoded):
+    args = load_args(encoded)
+    directory = args.get('directory') or '.'
+    pattern = args.get('pattern') or ''
+    file_pattern = args.get('filePattern') or '*'
+    recursive = args.get('recursive', True)
+    regex = re.compile(pattern)
+    matches = []
+    walker = os.walk(directory) if recursive else [(directory, [], os.listdir(directory))]
+    for root, _, files in walker:
+        for name in files:
+            if not fnmatch.fnmatch(name, file_pattern):
+                continue
+            path = os.path.join(root, name)
+            try:
+                with open(path, 'r', errors='replace') as file:
+                    for index, line in enumerate(file, 1):
+                        if regex.search(line):
+                            matches.append({'path': path, 'lineNumber': index, 'line': line.rstrip('\\n')})
+            except Exception:
+                pass
+    emit({'matches': matches, 'totalMatches': len(matches)})
+`;
+
+export const globFilesScript = `${scriptPrelude}
+def main(encoded):
+    args = load_args(encoded)
+    directory = args.get('directory') or '.'
+    pattern = args.get('pattern') or '*'
+    files = glob.glob(os.path.join(directory, pattern), recursive=True)
+    emit({'files': files, 'totalCount': len(files)})
+`;
+
+/**
+ * Wraps a script into a heredoc invocation with base64-encoded arguments, so
+ * that argument values never need shell quoting.
+ */
+export const buildScriptCommand = (script: string, params: Record<string, unknown>): string => {
+  const encoded = Buffer.from(JSON.stringify(params)).toString('base64');
+
+  return `python3 - <<'PY'\n${script}\nmain('${encoded}')\nPY`;
+};

--- a/apps/server/src/services/sandbox/providers/onlyboxes.ts
+++ b/apps/server/src/services/sandbox/providers/onlyboxes.ts
@@ -15,6 +15,17 @@ import type {
   SandboxProviderFileExportResult,
   SandboxServiceOptions,
 } from '../types';
+import {
+  appendWriteFileChunkScript,
+  editFileScript,
+  globFilesScript,
+  grepContentScript,
+  listFilesScript,
+  moveFilesScript,
+  prepareWriteFileScript,
+  readFileScript,
+  searchFilesScript,
+} from './fileScripts';
 
 const log = debug('lobe-server:sandbox:onlyboxes');
 
@@ -703,199 +714,3 @@ export class OnlyboxesSandboxProvider implements SandboxProvider {
     };
   }
 }
-
-const scriptPrelude = `
-import base64, json, os, re, shutil, glob, fnmatch
-from pathlib import Path
-
-def load_args(encoded):
-    return json.loads(base64.b64decode(encoded).decode())
-
-def emit(value):
-    print(json.dumps(value, ensure_ascii=False))
-`;
-
-const listFilesScript = `${scriptPrelude}
-def main(encoded):
-    args = load_args(encoded)
-    directory = args.get('directoryPath') or '.'
-    entries = []
-    for entry in os.scandir(directory):
-        stat = entry.stat()
-        entries.append({
-            'name': entry.name,
-            'path': entry.path,
-            'isDirectory': entry.is_dir(),
-            'size': stat.st_size,
-            'mtime': stat.st_mtime,
-        })
-    emit({'files': entries, 'totalCount': len(entries)})
-`;
-
-const readFileScript = `${scriptPrelude}
-def main(encoded):
-    args = load_args(encoded)
-    path = args.get('path')
-    start = args.get('startLine')
-    end = args.get('endLine')
-    text = Path(path).read_text(errors='replace')
-    lines = text.splitlines(True)
-    selected = lines
-    if start is not None or end is not None:
-        start_idx = max((start or 1) - 1, 0)
-        end_idx = end if end is not None else len(lines)
-        selected = lines[start_idx:end_idx]
-    content = ''.join(selected)
-    emit({
-        'content': content,
-        'filename': os.path.basename(path),
-        'charCount': len(content),
-        'totalCharCount': len(text),
-        'totalLineCount': len(lines),
-    })
-`;
-
-const prepareWriteFileScript = `${scriptPrelude}
-def main(encoded):
-    args = load_args(encoded)
-    path = Path(args.get('path'))
-    if args.get('createDirectories'):
-        path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(b'')
-    emit({'success': True})
-`;
-
-const appendWriteFileChunkScript = `${scriptPrelude}
-def main(encoded):
-    args = load_args(encoded)
-    path = Path(args.get('path'))
-    chunk = base64.b64decode(args.get('chunk') or '')
-    with path.open('ab') as file:
-        file.write(chunk)
-    emit({'bytesWritten': len(chunk), 'success': True})
-`;
-
-const editFileScript = `${scriptPrelude}
-def main(encoded):
-    args = load_args(encoded)
-    path = Path(args.get('path'))
-    search = args.get('search') or ''
-    replace = args.get('replace') or ''
-    text = path.read_text(errors='replace')
-    count = text.count(search)
-    if count == 0:
-        emit({'success': False, 'error': 'search text not found', 'replacements': 0})
-        return
-    new_text = text.replace(search, replace) if args.get('all') else text.replace(search, replace, 1)
-    replacements = count if args.get('all') else 1
-    path.write_text(new_text)
-    emit({'success': True, 'replacements': replacements, 'linesAdded': replace.count('\\n'), 'linesDeleted': search.count('\\n')})
-`;
-
-const searchFilesScript = `${scriptPrelude}
-from datetime import datetime
-
-def parse_time(value):
-    if not value:
-        return None
-    try:
-        return datetime.fromisoformat(str(value).replace('Z', '+00:00')).timestamp()
-    except Exception:
-        return None
-
-def main(encoded):
-    args = load_args(encoded)
-    directory = args.get('directory') or '.'
-    raw_keywords = args.get('keywords') or args.get('keyword') or ''
-    keywords = [item.strip() for item in str(raw_keywords).split() if item.strip()]
-    raw_file_types = args.get('fileTypes') or args.get('fileType') or []
-    if isinstance(raw_file_types, str):
-        raw_file_types = [raw_file_types]
-    file_types = [item if str(item).startswith('.') else f'.{item}' for item in raw_file_types if str(item).strip()]
-    modified_after = parse_time(args.get('modifiedAfter'))
-    modified_before = parse_time(args.get('modifiedBefore'))
-    content_contains = args.get('contentContains')
-    limit = args.get('limit')
-    results = []
-    for root, _, files in os.walk(directory):
-        for name in files:
-            if keywords and not all(keyword in name for keyword in keywords):
-                continue
-            if file_types and not any(name.endswith(file_type) for file_type in file_types):
-                continue
-            path = os.path.join(root, name)
-            try:
-                stat = os.stat(path)
-            except Exception:
-                continue
-            if modified_after is not None and stat.st_mtime < modified_after:
-                continue
-            if modified_before is not None and stat.st_mtime > modified_before:
-                continue
-            if content_contains:
-                try:
-                    if str(content_contains) not in Path(path).read_text(errors='replace'):
-                        continue
-                except Exception:
-                    continue
-            results.append({'name': name, 'path': path, 'size': stat.st_size, 'mtime': stat.st_mtime})
-    sort_by = args.get('sortBy')
-    reverse = args.get('sortDirection') == 'desc'
-    if sort_by == 'size':
-        results.sort(key=lambda item: item.get('size') or 0, reverse=reverse)
-    elif sort_by == 'date':
-        results.sort(key=lambda item: item.get('mtime') or 0, reverse=reverse)
-    else:
-        results.sort(key=lambda item: item.get('name') or '', reverse=reverse)
-    total = len(results)
-    if isinstance(limit, int) and limit > 0:
-        results = results[:limit]
-    emit({'results': results, 'totalCount': total})
-`;
-
-const moveFilesScript = `${scriptPrelude}
-def main(encoded):
-    args = load_args(encoded)
-    results = []
-    for op in args.get('operations') or []:
-        try:
-            shutil.move(op.get('source'), op.get('destination'))
-            results.append({'source': op.get('source'), 'destination': op.get('destination'), 'success': True})
-        except Exception as error:
-            results.append({'source': op.get('source'), 'destination': op.get('destination'), 'success': False, 'error': str(error)})
-    emit({'results': results, 'successCount': len([r for r in results if r.get('success')])})
-`;
-
-const grepContentScript = `${scriptPrelude}
-def main(encoded):
-    args = load_args(encoded)
-    directory = args.get('directory') or '.'
-    pattern = args.get('pattern') or ''
-    file_pattern = args.get('filePattern') or '*'
-    recursive = args.get('recursive', True)
-    regex = re.compile(pattern)
-    matches = []
-    walker = os.walk(directory) if recursive else [(directory, [], os.listdir(directory))]
-    for root, _, files in walker:
-        for name in files:
-            if not fnmatch.fnmatch(name, file_pattern):
-                continue
-            path = os.path.join(root, name)
-            try:
-                with open(path, 'r', errors='replace') as file:
-                    for index, line in enumerate(file, 1):
-                        if regex.search(line):
-                            matches.append({'path': path, 'lineNumber': index, 'line': line.rstrip('\\n')})
-            except Exception:
-                pass
-    emit({'matches': matches, 'totalMatches': len(matches)})
-`;
-
-const globFilesScript = `${scriptPrelude}
-def main(encoded):
-    args = load_args(encoded)
-    directory = args.get('directory') or '.'
-    pattern = args.get('pattern') or '*'
-    files = glob.glob(os.path.join(directory, pattern), recursive=True)
-    emit({'files': files, 'totalCount': len(files)})
-`;

--- a/apps/server/src/services/sandbox/providers/tencent.test.ts
+++ b/apps/server/src/services/sandbox/providers/tencent.test.ts
@@ -12,22 +12,21 @@ const mocks = vi.hoisted(() => ({
   },
   sandbox: {
     commands: { connect: vi.fn(), kill: vi.fn(), run: vi.fn() },
-    files: { list: vi.fn(), read: vi.fn(), write: vi.fn() },
+    files: { read: vi.fn(), write: vi.fn() },
     runCode: vi.fn(),
   },
 }));
 
 vi.mock('@/envs/sandbox', () => ({ sandboxEnv: mocks.env }));
-vi.mock('@e2b/code-interpreter', () => ({
-  Sandbox: vi.fn(() => mocks.sandbox),
-}));
+vi.mock('@e2b/code-interpreter', () => ({ Sandbox: vi.fn(() => mocks.sandbox) }));
 
 const options = { marketService: {} as never, topicId: 'topic-1', userId: 'user-1' };
 
-/** Counts how many times each control-plane action was called. */
 const calls = { acquire: 0, release: 0, update: 0 };
+/** Seconds until the acquired instance expires; drives the renewal path. */
+let expiresInSec = 300;
 
-const install = () => {
+const installFetch = () => {
   calls.acquire = 0;
   calls.release = 0;
   calls.update = 0;
@@ -42,7 +41,7 @@ const install = () => {
         json: async () => ({
           Code: 0,
           Data: {
-            InstanceExpiresAt: new Date(Date.now() + 300_000).toISOString(),
+            InstanceExpiresAt: new Date(Date.now() + expiresInSec * 1000).toISOString(),
             InstanceId: `instance-${calls.acquire}`,
             SandboxDomain: 'ap-beijing.tencentags.com',
             Token: 'sit_test',
@@ -56,10 +55,20 @@ const install = () => {
 
 const load = async () => {
   vi.resetModules();
-  const { TencentSandboxProvider } = await import('./tencent');
+  const { TencentSandboxProvider, __clearSandboxInstances } = await import('./tencent');
+  __clearSandboxInstances();
 
   return new TencentSandboxProvider(options);
 };
+
+/** Decodes the base64 argument blob the shared Python helpers receive. */
+const scriptArgs = (command: string) => {
+  const encoded = /main\('([^']+)'\)/.exec(command)?.[1];
+
+  return JSON.parse(Buffer.from(encoded!, 'base64').toString());
+};
+
+const okCommand = (stdout = '') => ({ exitCode: 0, stderr: '', stdout });
 
 describe('TencentSandboxProvider', () => {
   beforeEach(() => {
@@ -67,7 +76,8 @@ describe('TencentSandboxProvider', () => {
     mocks.env.TENCENT_SANDBOX_API_TOKEN = 'test-token';
     mocks.env.TENCENT_SANDBOX_PROJECT_ID = 'makers-test';
     mocks.env.TENCENT_SANDBOX_MODE = 'persistent';
-    install();
+    expiresInSec = 300;
+    installFetch();
   });
 
   it('fails fast when credentials are missing', async () => {
@@ -77,7 +87,6 @@ describe('TencentSandboxProvider', () => {
 
     expect(result.success).toBe(false);
     expect(result.error?.message).toContain('TENCENT_SANDBOX_API_TOKEN');
-    // No instance should be acquired when the provider is not configured.
     expect(calls.acquire).toBe(0);
   });
 
@@ -90,42 +99,129 @@ describe('TencentSandboxProvider', () => {
     const result = await (await load()).callTool('executeCode', { code: 'print(42)' });
 
     expect(result.success).toBe(true);
-    expect(result.result).toMatchObject({ stdout: '42\n' });
+    expect(result.result).toMatchObject({ stdout: '42\n', success: true });
   });
 
-  // Persistence is the whole point of the default mode: a second tool call in
-  // the same topic must land in the container the first one created.
-  it('reuses one instance across calls in persistent mode', async () => {
-    mocks.sandbox.runCode.mockResolvedValue({ logs: { stderr: [], stdout: [''] }, results: [] });
+  // The runtime falls back to the outer envelope when the command result has no
+  // `success`, which would report a failed install as a successful one.
+  it('marks a nonzero command exit as a failed command', async () => {
+    mocks.sandbox.commands.run.mockResolvedValue({
+      exitCode: 1,
+      stderr: 'boom',
+      stdout: '',
+    });
 
-    const provider = await load();
-    await provider.callTool('executeCode', { code: 'x = 1' });
-    await provider.callTool('executeCode', { code: 'print(x)' });
+    const result = await (await load()).callTool('runCommand', { command: 'false' });
 
-    expect(calls.acquire).toBe(1);
-    expect(calls.release).toBe(0);
+    expect(result.success).toBe(true);
+    expect(result.result).toMatchObject({ exitCode: 1, success: false });
   });
 
-  it('acquires and releases per call in on-demand mode', async () => {
-    mocks.env.TENCENT_SANDBOX_MODE = 'on-demand';
-    mocks.sandbox.runCode.mockResolvedValue({ logs: { stderr: [], stdout: [''] }, results: [] });
+  it('returns the identifier the runtime uses for background commands', async () => {
+    mocks.sandbox.commands.run.mockResolvedValue({ pid: 4321 });
 
-    const provider = await load();
-    await provider.callTool('executeCode', { code: 'x = 1' });
-    await provider.callTool('executeCode', { code: 'x = 2' });
+    const result = await (
+      await load()
+    ).callTool('runCommand', {
+      background: true,
+      command: 'sleep 60',
+    });
 
-    expect(calls.acquire).toBe(2);
-    expect(calls.release).toBe(2);
+    expect(result.result).toMatchObject({ commandId: '4321', shell_id: '4321' });
   });
 
-  it('releases the instance even when the tool throws', async () => {
-    mocks.env.TENCENT_SANDBOX_MODE = 'on-demand';
-    mocks.sandbox.runCode.mockRejectedValue(new Error('boom'));
+  it('forwards the requested command timeout', async () => {
+    mocks.sandbox.commands.run.mockResolvedValue(okCommand());
 
-    const result = await (await load()).callTool('executeCode', { code: 'boom' });
+    await (await load()).callTool('runCommand', { command: 'sleep 1', timeout: 5000 });
+
+    expect(mocks.sandbox.commands.run).toHaveBeenCalledWith(
+      'sleep 1',
+      expect.objectContaining({ timeoutMs: 5000 }),
+    );
+  });
+
+  it('looks up background commands by commandId', async () => {
+    const wait = vi.fn().mockResolvedValue({ exitCode: 0, stderr: '', stdout: 'done' });
+    mocks.sandbox.commands.connect.mockResolvedValue({ wait });
+
+    const result = await (await load()).callTool('getCommandOutput', { commandId: '4321' });
+
+    expect(mocks.sandbox.commands.connect).toHaveBeenCalledWith(4321);
+    expect(result.result).toMatchObject({ stdout: 'done', success: true });
+  });
+
+  // The shared tool contract uses `directoryPath`, not `path`.
+  it('passes file tool arguments through to the shared script unchanged', async () => {
+    mocks.sandbox.commands.run.mockResolvedValue(
+      okCommand(JSON.stringify({ files: [{ isDirectory: false, name: 'a.txt' }], totalCount: 1 })),
+    );
+
+    const result = await (await load()).callTool('listLocalFiles', { directoryPath: '/mnt/data' });
+
+    const [command] = mocks.sandbox.commands.run.mock.calls[0];
+    expect(scriptArgs(command)).toEqual({ directoryPath: '/mnt/data' });
+    expect(result.result).toMatchObject({ files: [{ isDirectory: false, name: 'a.txt' }] });
+  });
+
+  it('surfaces a script-reported failure as a failed call', async () => {
+    mocks.sandbox.commands.run.mockResolvedValue(
+      okCommand(JSON.stringify({ error: 'search text not found', success: false })),
+    );
+
+    const result = await (
+      await load()
+    ).callTool('editLocalFile', {
+      path: '/a.txt',
+      replace: 'b',
+      search: 'a',
+    });
 
     expect(result.success).toBe(false);
+    expect(result.error?.message).toBe('search text not found');
+  });
+
+  // File bootstrapping issues a command before the requested tool runs; both
+  // must land in the same container.
+  it('reuses one instance across calls in every mode', async () => {
+    for (const mode of ['persistent', 'on-demand']) {
+      mocks.env.TENCENT_SANDBOX_MODE = mode;
+      installFetch();
+      mocks.sandbox.commands.run.mockResolvedValue(okCommand());
+
+      const provider = await load();
+      await provider.callTool('runCommand', { command: 'echo 1' });
+      await provider.callTool('runCommand', { command: 'echo 2' });
+
+      expect(calls.acquire, mode).toBe(1);
+      expect(calls.release, mode).toBe(0);
+    }
+  });
+
+  it('renews a persistent instance that is close to expiring', async () => {
+    expiresInSec = 10;
+    mocks.sandbox.commands.run.mockResolvedValue(okCommand());
+
+    const provider = await load();
+    await provider.callTool('runCommand', { command: 'echo 1' });
+    await provider.callTool('runCommand', { command: 'echo 2' });
+
+    expect(calls.update).toBe(1);
+    expect(calls.acquire).toBe(1);
+  });
+
+  it('lets an on-demand instance lapse instead of renewing it', async () => {
+    mocks.env.TENCENT_SANDBOX_MODE = 'on-demand';
+    expiresInSec = 10;
+    mocks.sandbox.commands.run.mockResolvedValue(okCommand());
+
+    const provider = await load();
+    await provider.callTool('runCommand', { command: 'echo 1' });
+    await provider.callTool('runCommand', { command: 'echo 2' });
+
+    expect(calls.update).toBe(0);
     expect(calls.release).toBe(1);
+    expect(calls.acquire).toBe(2);
   });
 
   it('reports unsupported tools as a failed call', async () => {

--- a/apps/server/src/services/sandbox/providers/tencent.test.ts
+++ b/apps/server/src/services/sandbox/providers/tencent.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  env: {
+    TENCENT_SANDBOX_API_BASE: undefined as string | undefined,
+    TENCENT_SANDBOX_API_TOKEN: 'test-token' as string | undefined,
+    TENCENT_SANDBOX_MODE: 'persistent' as string,
+    TENCENT_SANDBOX_PROJECT_ID: 'makers-test' as string | undefined,
+    TENCENT_SANDBOX_REGION: undefined as string | undefined,
+    TENCENT_SANDBOX_TIMEOUT_SEC: undefined as number | undefined,
+  },
+  sandbox: {
+    commands: { connect: vi.fn(), kill: vi.fn(), run: vi.fn() },
+    files: { list: vi.fn(), read: vi.fn(), write: vi.fn() },
+    runCode: vi.fn(),
+  },
+}));
+
+vi.mock('@/envs/sandbox', () => ({ sandboxEnv: mocks.env }));
+vi.mock('@e2b/code-interpreter', () => ({
+  Sandbox: vi.fn(() => mocks.sandbox),
+}));
+
+const options = { marketService: {} as never, topicId: 'topic-1', userId: 'user-1' };
+
+/** Counts how many times each control-plane action was called. */
+const calls = { acquire: 0, release: 0, update: 0 };
+
+const install = () => {
+  calls.acquire = 0;
+  calls.release = 0;
+  calls.update = 0;
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string) => {
+      const action = url.split('/').pop() as keyof typeof calls;
+      calls[action] += 1;
+
+      return {
+        json: async () => ({
+          Code: 0,
+          Data: {
+            InstanceExpiresAt: new Date(Date.now() + 300_000).toISOString(),
+            InstanceId: `instance-${calls.acquire}`,
+            SandboxDomain: 'ap-beijing.tencentags.com',
+            Token: 'sit_test',
+          },
+        }),
+        ok: true,
+      };
+    }),
+  );
+};
+
+const load = async () => {
+  vi.resetModules();
+  const { TencentSandboxProvider } = await import('./tencent');
+
+  return new TencentSandboxProvider(options);
+};
+
+describe('TencentSandboxProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.env.TENCENT_SANDBOX_API_TOKEN = 'test-token';
+    mocks.env.TENCENT_SANDBOX_PROJECT_ID = 'makers-test';
+    mocks.env.TENCENT_SANDBOX_MODE = 'persistent';
+    install();
+  });
+
+  it('fails fast when credentials are missing', async () => {
+    mocks.env.TENCENT_SANDBOX_API_TOKEN = undefined;
+
+    const result = await (await load()).callTool('executeCode', { code: 'print(1)' });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toContain('TENCENT_SANDBOX_API_TOKEN');
+    // No instance should be acquired when the provider is not configured.
+    expect(calls.acquire).toBe(0);
+  });
+
+  it('runs code and returns stdout', async () => {
+    mocks.sandbox.runCode.mockResolvedValue({
+      logs: { stderr: [], stdout: ['42\n'] },
+      results: [],
+    });
+
+    const result = await (await load()).callTool('executeCode', { code: 'print(42)' });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toMatchObject({ stdout: '42\n' });
+  });
+
+  // Persistence is the whole point of the default mode: a second tool call in
+  // the same topic must land in the container the first one created.
+  it('reuses one instance across calls in persistent mode', async () => {
+    mocks.sandbox.runCode.mockResolvedValue({ logs: { stderr: [], stdout: [''] }, results: [] });
+
+    const provider = await load();
+    await provider.callTool('executeCode', { code: 'x = 1' });
+    await provider.callTool('executeCode', { code: 'print(x)' });
+
+    expect(calls.acquire).toBe(1);
+    expect(calls.release).toBe(0);
+  });
+
+  it('acquires and releases per call in on-demand mode', async () => {
+    mocks.env.TENCENT_SANDBOX_MODE = 'on-demand';
+    mocks.sandbox.runCode.mockResolvedValue({ logs: { stderr: [], stdout: [''] }, results: [] });
+
+    const provider = await load();
+    await provider.callTool('executeCode', { code: 'x = 1' });
+    await provider.callTool('executeCode', { code: 'x = 2' });
+
+    expect(calls.acquire).toBe(2);
+    expect(calls.release).toBe(2);
+  });
+
+  it('releases the instance even when the tool throws', async () => {
+    mocks.env.TENCENT_SANDBOX_MODE = 'on-demand';
+    mocks.sandbox.runCode.mockRejectedValue(new Error('boom'));
+
+    const result = await (await load()).callTool('executeCode', { code: 'boom' });
+
+    expect(result.success).toBe(false);
+    expect(calls.release).toBe(1);
+  });
+
+  it('reports unsupported tools as a failed call', async () => {
+    const result = await (await load()).callTool('notARealTool', {});
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toContain('notARealTool');
+  });
+
+  it('reports capabilities that match the configured mode', async () => {
+    mocks.env.TENCENT_SANDBOX_MODE = 'on-demand';
+
+    expect((await load()).capabilities.persistentSession).toBe(false);
+  });
+});

--- a/apps/server/src/services/sandbox/providers/tencent.ts
+++ b/apps/server/src/services/sandbox/providers/tencent.ts
@@ -1,0 +1,431 @@
+import { Sandbox } from '@e2b/code-interpreter';
+import type { SandboxCallToolResult } from '@lobechat/builtin-tool-cloud-sandbox';
+import debug from 'debug';
+
+import { sandboxEnv } from '@/envs/sandbox';
+
+import type {
+  SandboxProvider,
+  SandboxProviderCapabilities,
+  SandboxProviderFileExportRequest,
+  SandboxProviderFileExportResult,
+  SandboxServiceOptions,
+} from '../types';
+
+const log = debug('lobe-server:sandbox:tencent');
+
+const DEFAULT_API_BASE = 'https://pages-api.cloud.tencent.com/v1/sandbox';
+const DEFAULT_REGION = 'ap-beijing';
+const DEFAULT_TIMEOUT_SEC = 300;
+const ENVD_PORT = '49983';
+const ENVD_FALLBACK_VERSION = '0.2.4';
+/** Renew a persistent instance once it is within this window of expiring. */
+const RENEW_THRESHOLD_MS = 60_000;
+
+interface AcquiredInstance {
+  domain: string;
+  envdVersion: string;
+  expiresAt: number;
+  instanceId: string;
+  token: string;
+  trafficToken?: string;
+}
+
+/**
+ * Instances are keyed by session so that `persistent` mode reuses the same
+ * container across tool calls. Kept at module scope because a provider
+ * instance is constructed per request.
+ */
+const persistentInstances = new Map<string, AcquiredInstance>();
+
+export class TencentSandboxProvider implements SandboxProvider {
+  readonly capabilities = {
+    backgroundCommands: true,
+    exportFile: true,
+    files: true,
+    languages: ['python', 'javascript', 'typescript'],
+    persistentSession: sandboxEnv.TENCENT_SANDBOX_MODE !== 'on-demand',
+    shell: true,
+    skillScripts: true,
+  } satisfies SandboxProviderCapabilities;
+
+  readonly kind = 'tencent';
+
+  private readonly options: SandboxServiceOptions;
+
+  constructor(options: SandboxServiceOptions) {
+    this.options = options;
+  }
+
+  async callTool(
+    toolName: string,
+    params: Record<string, unknown>,
+  ): Promise<SandboxCallToolResult> {
+    const configError = this.checkConfig();
+    if (configError) return configError;
+
+    try {
+      return await this.withSandbox(async (sandbox) => {
+        const result = await this.dispatch(sandbox, toolName, params);
+
+        return { result, sessionExpiredAndRecreated: false, success: true };
+      });
+    } catch (error) {
+      log('Tencent sandbox tool %s failed: %O', toolName, error);
+
+      return {
+        error: { message: (error as Error).message, name: (error as Error).name },
+        result: null,
+        sessionExpiredAndRecreated: false,
+        success: false,
+      };
+    }
+  }
+
+  async exportFileToUploadUrl({
+    path,
+    uploadHeaders,
+    uploadUrl,
+  }: SandboxProviderFileExportRequest): Promise<SandboxProviderFileExportResult> {
+    const configError = this.checkConfig();
+    if (configError) return { error: configError.error, success: false };
+
+    try {
+      return await this.withSandbox(async (sandbox) => {
+        const content = await sandbox.files.read(path, { format: 'bytes' });
+        const body = new Uint8Array(content);
+
+        const response = await fetch(uploadUrl, {
+          body,
+          headers: uploadHeaders,
+          method: 'PUT',
+        });
+
+        if (!response.ok) {
+          throw new Error(`Upload failed with status ${response.status}`);
+        }
+
+        return { size: body.byteLength, success: true };
+      });
+    } catch (error) {
+      log('Tencent sandbox export failed: %O', error);
+
+      return {
+        error: { message: (error as Error).message, name: (error as Error).name },
+        success: false,
+      };
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tool dispatch
+  // ---------------------------------------------------------------------------
+
+  private async dispatch(
+    sandbox: Sandbox,
+    toolName: string,
+    params: Record<string, unknown>,
+  ): Promise<unknown> {
+    const str = (key: string): string => {
+      const value = params[key];
+      if (typeof value !== 'string') throw new Error(`Missing required parameter: ${key}`);
+      return value;
+    };
+
+    switch (toolName) {
+      case 'executeCode': {
+        const execution = await sandbox.runCode(str('code'), {
+          language: (params.language as string) ?? 'python',
+        });
+
+        return {
+          error: execution.error ? execution.error.value : undefined,
+          results: execution.results,
+          stderr: execution.logs.stderr.join(''),
+          stdout: execution.logs.stdout.join(''),
+        };
+      }
+
+      case 'execScript':
+      case 'runCommand': {
+        const background = params.background === true;
+        const handle = await sandbox.commands.run(str('command'), {
+          background,
+          cwd: params.cwd as string | undefined,
+        });
+
+        if (background) return { pid: handle.pid, running: true };
+
+        return {
+          exitCode: handle.exitCode,
+          stderr: handle.stderr,
+          stdout: handle.stdout,
+        };
+      }
+
+      case 'getCommandOutput': {
+        const handle = await sandbox.commands.connect(Number(params.pid));
+        const result = await handle.wait();
+
+        return { exitCode: result.exitCode, stderr: result.stderr, stdout: result.stdout };
+      }
+
+      case 'killCommand': {
+        return { killed: await sandbox.commands.kill(Number(params.pid)) };
+      }
+
+      case 'listFiles':
+      case 'listLocalFiles': {
+        const entries = await sandbox.files.list(str('path'));
+
+        return { files: entries.map((entry) => ({ name: entry.name, type: entry.type })) };
+      }
+
+      case 'readFile':
+      case 'readLocalFile': {
+        return { content: await sandbox.files.read(str('path')) };
+      }
+
+      case 'writeFile':
+      case 'writeLocalFile': {
+        const path = str('path');
+        await sandbox.files.write(path, str('content'));
+
+        return { path, written: true };
+      }
+
+      case 'editFile':
+      case 'editLocalFile': {
+        const path = str('path');
+        const original = await sandbox.files.read(path);
+        const oldString = str('oldString');
+
+        if (!original.includes(oldString)) {
+          throw new Error(`The string to replace was not found in ${path}`);
+        }
+
+        const updated = original.replace(oldString, str('newString'));
+        await sandbox.files.write(path, updated);
+
+        return { edited: true, path };
+      }
+
+      case 'moveFiles':
+      case 'moveLocalFiles': {
+        const source = str('source');
+        const destination = str('destination');
+        await this.runShell(sandbox, `mv -- ${quote(source)} ${quote(destination)}`);
+
+        return { destination, moved: true, source };
+      }
+
+      case 'globLocalFiles':
+      case 'searchFiles':
+      case 'searchLocalFiles': {
+        const path = (params.path as string) ?? '.';
+        const pattern = str('pattern');
+        const stdout = await this.runShell(
+          sandbox,
+          `find ${quote(path)} -name ${quote(pattern)} -type f`,
+        );
+
+        return { files: splitLines(stdout) };
+      }
+
+      case 'grepContent': {
+        const path = (params.path as string) ?? '.';
+        const stdout = await this.runShell(
+          sandbox,
+          `grep -rn -- ${quote(str('pattern'))} ${quote(path)} || true`,
+        );
+
+        return { matches: splitLines(stdout) };
+      }
+
+      default: {
+        throw new Error(`Unsupported sandbox tool: ${toolName}`);
+      }
+    }
+  }
+
+  private async runShell(sandbox: Sandbox, command: string): Promise<string> {
+    const result = await sandbox.commands.run(command);
+
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || `Command exited with code ${result.exitCode}`);
+    }
+
+    return result.stdout;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Instance lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Runs `fn` against a connected sandbox.
+   *
+   * In `persistent` mode the instance is cached per session and renewed before
+   * it expires. In `on-demand` mode a fresh instance is acquired for the call
+   * and released afterwards, which trades cold-start latency for cost.
+   */
+  private async withSandbox<T>(fn: (sandbox: Sandbox) => Promise<T>): Promise<T> {
+    const onDemand = sandboxEnv.TENCENT_SANDBOX_MODE === 'on-demand';
+    const instance = onDemand ? await this.acquire() : await this.acquirePersistent();
+
+    try {
+      return await fn(connect(instance));
+    } finally {
+      if (onDemand) await this.release(instance.instanceId);
+    }
+  }
+
+  private async acquirePersistent(): Promise<AcquiredInstance> {
+    const key = this.sessionKey();
+    const cached = persistentInstances.get(key);
+
+    if (cached && cached.expiresAt - Date.now() > RENEW_THRESHOLD_MS) return cached;
+
+    if (cached) {
+      // Still valid but close to expiry — extend rather than pay a cold start.
+      const renewed = await this.renew(cached);
+      if (renewed) {
+        persistentInstances.set(key, renewed);
+        return renewed;
+      }
+    }
+
+    const instance = await this.acquire();
+    persistentInstances.set(key, instance);
+
+    return instance;
+  }
+
+  private async renew(instance: AcquiredInstance): Promise<AcquiredInstance | undefined> {
+    try {
+      await this.request('update', {
+        InstanceId: instance.instanceId,
+        Timeout: this.timeoutSec(),
+      });
+
+      return { ...instance, expiresAt: Date.now() + this.timeoutSec() * 1000 };
+    } catch (error) {
+      log('Failed to renew instance %s, will acquire a new one: %O', instance.instanceId, error);
+
+      return undefined;
+    }
+  }
+
+  private async acquire(): Promise<AcquiredInstance> {
+    const data = await this.request('acquire', {
+      ConversationId: this.sessionKey(),
+      Region: sandboxEnv.TENCENT_SANDBOX_REGION || DEFAULT_REGION,
+      Timeout: this.timeoutSec(),
+    });
+
+    const expiresAt = data.InstanceExpiresAt
+      ? new Date(data.InstanceExpiresAt as string).getTime()
+      : Date.now() + this.timeoutSec() * 1000;
+
+    return {
+      domain: data.SandboxDomain as string,
+      envdVersion: (data.EnvdVersion as string) || ENVD_FALLBACK_VERSION,
+      expiresAt,
+      instanceId: data.InstanceId as string,
+      token: data.Token as string,
+      trafficToken: data.TrafficToken as string | undefined,
+    };
+  }
+
+  private async release(instanceId: string): Promise<void> {
+    try {
+      await this.request('release', { InstanceId: instanceId });
+    } catch (error) {
+      // A leaked instance expires on its own; failing the tool call is worse.
+      log('Failed to release instance %s: %O', instanceId, error);
+    }
+  }
+
+  private async request(
+    action: 'acquire' | 'release' | 'update',
+    payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const base = sandboxEnv.TENCENT_SANDBOX_API_BASE || DEFAULT_API_BASE;
+
+    const response = await fetch(`${base}/${action}`, {
+      body: JSON.stringify({ ProjectId: sandboxEnv.TENCENT_SANDBOX_PROJECT_ID, ...payload }),
+      headers: {
+        'Authorization': `Bearer ${sandboxEnv.TENCENT_SANDBOX_API_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    });
+
+    if (!response.ok) {
+      throw new Error(`Sandbox ${action} failed with status ${response.status}`);
+    }
+
+    const body = (await response.json()) as {
+      Code?: number;
+      Data?: Record<string, unknown>;
+      message?: string;
+    };
+
+    if (body.Code !== 0 || !body.Data) {
+      throw new Error(body.message || `Sandbox ${action} returned an error`);
+    }
+
+    return body.Data;
+  }
+
+  private sessionKey(): string {
+    return `${this.options.userId}:${this.options.topicId}`;
+  }
+
+  private timeoutSec(): number {
+    return sandboxEnv.TENCENT_SANDBOX_TIMEOUT_SEC || DEFAULT_TIMEOUT_SEC;
+  }
+
+  private checkConfig(): SandboxCallToolResult | undefined {
+    if (sandboxEnv.TENCENT_SANDBOX_API_TOKEN && sandboxEnv.TENCENT_SANDBOX_PROJECT_ID) return;
+
+    return {
+      error: {
+        message: 'TENCENT_SANDBOX_API_TOKEN and TENCENT_SANDBOX_PROJECT_ID are required',
+        name: 'SandboxConfigError',
+      },
+      result: null,
+      sessionExpiredAndRecreated: false,
+      success: false,
+    };
+  }
+}
+
+/**
+ * Builds the client directly instead of using `Sandbox.connect()`, which would
+ * look the instance up through the e2b.dev control plane and require an E2B
+ * API key. Tencent issues the instance itself, so only the returned connection
+ * details are needed.
+ */
+const connect = (instance: AcquiredInstance): Sandbox =>
+  new Sandbox({
+    domain: instance.domain,
+    envdAccessToken: instance.token,
+    envdVersion: instance.envdVersion,
+    headers: {
+      'E2b-Sandbox-Id': instance.instanceId,
+      'E2b-Sandbox-Port': ENVD_PORT,
+      'X-Access-Token': instance.token,
+    },
+    sandboxDomain: instance.domain,
+    sandboxId: instance.instanceId,
+    trafficAccessToken: instance.trafficToken,
+  });
+
+const quote = (value: string): string => `'${value.replaceAll("'", String.raw`'\''`)}'`;
+
+const splitLines = (value: string): string[] =>
+  value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);

--- a/apps/server/src/services/sandbox/providers/tencent.ts
+++ b/apps/server/src/services/sandbox/providers/tencent.ts
@@ -11,12 +11,24 @@ import type {
   SandboxProviderFileExportResult,
   SandboxServiceOptions,
 } from '../types';
+import {
+  buildScriptCommand,
+  editFileScript,
+  globFilesScript,
+  grepContentScript,
+  listFilesScript,
+  moveFilesScript,
+  prepareWriteFileScript,
+  readFileScript,
+  searchFilesScript,
+} from './fileScripts';
 
 const log = debug('lobe-server:sandbox:tencent');
 
 const DEFAULT_API_BASE = 'https://pages-api.cloud.tencent.com/v1/sandbox';
 const DEFAULT_REGION = 'ap-beijing';
 const DEFAULT_TIMEOUT_SEC = 300;
+const DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
 const ENVD_PORT = '49983';
 const ENVD_FALLBACK_VERSION = '0.2.4';
 /** Renew a persistent instance once it is within this window of expiring. */
@@ -32,11 +44,12 @@ interface AcquiredInstance {
 }
 
 /**
- * Instances are keyed by session so that `persistent` mode reuses the same
- * container across tool calls. Kept at module scope because a provider
- * instance is constructed per request.
+ * Instances are keyed by session. A provider is constructed per request, but a
+ * single tool call can fan out into several `callTool` invocations — file
+ * bootstrapping runs a command before the requested tool — so the instance has
+ * to outlive the provider for those to land in the same container.
  */
-const persistentInstances = new Map<string, AcquiredInstance>();
+const instances = new Map<string, AcquiredInstance>();
 
 export class TencentSandboxProvider implements SandboxProvider {
   readonly capabilities = {
@@ -44,9 +57,12 @@ export class TencentSandboxProvider implements SandboxProvider {
     exportFile: true,
     files: true,
     languages: ['python', 'javascript', 'typescript'],
+    // On-demand instances are never renewed, so state only survives until the
+    // requested timeout elapses.
     persistentSession: sandboxEnv.TENCENT_SANDBOX_MODE !== 'on-demand',
     shell: true,
-    skillScripts: true,
+    // Skill archives are not downloaded into the sandbox yet; see `execScript`.
+    skillScripts: false,
   } satisfies SandboxProviderCapabilities;
 
   readonly kind = 'tencent';
@@ -65,11 +81,10 @@ export class TencentSandboxProvider implements SandboxProvider {
     if (configError) return configError;
 
     try {
-      return await this.withSandbox(async (sandbox) => {
-        const result = await this.dispatch(sandbox, toolName, params);
+      const sandbox = await this.connect();
+      const result = await this.dispatch(sandbox, toolName, params);
 
-        return { result, sessionExpiredAndRecreated: false, success: true };
-      });
+      return { result, sessionExpiredAndRecreated: false, success: true };
     } catch (error) {
       log('Tencent sandbox tool %s failed: %O', toolName, error);
 
@@ -91,22 +106,15 @@ export class TencentSandboxProvider implements SandboxProvider {
     if (configError) return { error: configError.error, success: false };
 
     try {
-      return await this.withSandbox(async (sandbox) => {
-        const content = await sandbox.files.read(path, { format: 'bytes' });
-        const body = new Uint8Array(content);
+      const sandbox = await this.connect();
+      const content = await sandbox.files.read(path, { format: 'bytes' });
+      const body = new Uint8Array(content);
 
-        const response = await fetch(uploadUrl, {
-          body,
-          headers: uploadHeaders,
-          method: 'PUT',
-        });
+      const response = await fetch(uploadUrl, { body, headers: uploadHeaders, method: 'PUT' });
 
-        if (!response.ok) {
-          throw new Error(`Upload failed with status ${response.status}`);
-        }
+      if (!response.ok) throw new Error(`Upload failed with status ${response.status}`);
 
-        return { size: body.byteLength, success: true };
-      });
+      return { size: body.byteLength, success: true };
     } catch (error) {
       log('Tencent sandbox export failed: %O', error);
 
@@ -126,15 +134,9 @@ export class TencentSandboxProvider implements SandboxProvider {
     toolName: string,
     params: Record<string, unknown>,
   ): Promise<unknown> {
-    const str = (key: string): string => {
-      const value = params[key];
-      if (typeof value !== 'string') throw new Error(`Missing required parameter: ${key}`);
-      return value;
-    };
-
     switch (toolName) {
       case 'executeCode': {
-        const execution = await sandbox.runCode(str('code'), {
+        const execution = await sandbox.runCode(String(params.code ?? ''), {
           language: (params.language as string) ?? 'python',
         });
 
@@ -143,103 +145,75 @@ export class TencentSandboxProvider implements SandboxProvider {
           results: execution.results,
           stderr: execution.logs.stderr.join(''),
           stdout: execution.logs.stdout.join(''),
+          success: !execution.error,
         };
       }
 
-      case 'execScript':
       case 'runCommand': {
-        const background = params.background === true;
-        const handle = await sandbox.commands.run(str('command'), {
-          background,
-          cwd: params.cwd as string | undefined,
-        });
-
-        if (background) return { pid: handle.pid, running: true };
-
-        return {
-          exitCode: handle.exitCode,
-          stderr: handle.stderr,
-          stdout: handle.stdout,
-        };
+        return this.runCommand(sandbox, params);
       }
 
       case 'getCommandOutput': {
-        const handle = await sandbox.commands.connect(Number(params.pid));
+        const handle = await sandbox.commands.connect(this.commandId(params));
         const result = await handle.wait();
 
-        return { exitCode: result.exitCode, stderr: result.stderr, stdout: result.stdout };
+        return {
+          exitCode: result.exitCode,
+          output: result.stdout,
+          stderr: result.stderr,
+          stdout: result.stdout,
+          success: result.exitCode === 0,
+        };
       }
 
       case 'killCommand': {
-        return { killed: await sandbox.commands.kill(Number(params.pid)) };
-      }
-
-      case 'listFiles':
-      case 'listLocalFiles': {
-        const entries = await sandbox.files.list(str('path'));
-
-        return { files: entries.map((entry) => ({ name: entry.name, type: entry.type })) };
-      }
-
-      case 'readFile':
-      case 'readLocalFile': {
-        return { content: await sandbox.files.read(str('path')) };
+        return { success: await sandbox.commands.kill(this.commandId(params)) };
       }
 
       case 'writeFile':
       case 'writeLocalFile': {
-        const path = str('path');
-        await sandbox.files.write(path, str('content'));
+        return this.writeFile(sandbox, params);
+      }
 
-        return { path, written: true };
+      case 'listFiles':
+      case 'listLocalFiles': {
+        return this.runScript(sandbox, listFilesScript, params);
+      }
+
+      case 'readFile':
+      case 'readLocalFile': {
+        return this.runScript(sandbox, readFileScript, params);
       }
 
       case 'editFile':
       case 'editLocalFile': {
-        const path = str('path');
-        const original = await sandbox.files.read(path);
-        const oldString = str('oldString');
+        return this.runScript(sandbox, editFileScript, params);
+      }
 
-        if (!original.includes(oldString)) {
-          throw new Error(`The string to replace was not found in ${path}`);
-        }
-
-        const updated = original.replace(oldString, str('newString'));
-        await sandbox.files.write(path, updated);
-
-        return { edited: true, path };
+      case 'searchFiles':
+      case 'searchLocalFiles': {
+        return this.runScript(sandbox, searchFilesScript, params);
       }
 
       case 'moveFiles':
       case 'moveLocalFiles': {
-        const source = str('source');
-        const destination = str('destination');
-        await this.runShell(sandbox, `mv -- ${quote(source)} ${quote(destination)}`);
-
-        return { destination, moved: true, source };
+        return this.runScript(sandbox, moveFilesScript, params);
       }
 
-      case 'globLocalFiles':
-      case 'searchFiles':
-      case 'searchLocalFiles': {
-        const path = (params.path as string) ?? '.';
-        const pattern = str('pattern');
-        const stdout = await this.runShell(
-          sandbox,
-          `find ${quote(path)} -name ${quote(pattern)} -type f`,
-        );
-
-        return { files: splitLines(stdout) };
+      case 'globFiles':
+      case 'globLocalFiles': {
+        return this.runScript(sandbox, globFilesScript, params);
       }
 
       case 'grepContent': {
-        const path = (params.path as string) ?? '.';
-        const stdout = await this.runShell(
-          sandbox,
-          `grep -rn -- ${quote(str('pattern'))} ${quote(path)} || true`,
-        );
+        return this.runScript(sandbox, grepContentScript, params);
+      }
 
-        return { matches: splitLines(stdout) };
+      case 'execScript': {
+        throw new Error(
+          'execScript is not supported by the Tencent sandbox provider yet; ' +
+            'skill archives are not downloaded into the sandbox.',
+        );
       }
 
       default: {
@@ -248,14 +222,89 @@ export class TencentSandboxProvider implements SandboxProvider {
     }
   }
 
-  private async runShell(sandbox: Sandbox, command: string): Promise<string> {
-    const result = await sandbox.commands.run(command);
+  private async runCommand(sandbox: Sandbox, params: Record<string, unknown>) {
+    const command = String(params.command ?? '');
+    if (!command.trim()) throw new Error('command is required');
 
-    if (result.exitCode !== 0) {
-      throw new Error(result.stderr || `Command exited with code ${result.exitCode}`);
+    if (params.background === true) {
+      const handle = await sandbox.commands.run(command, {
+        background: true,
+        cwd: params.cwd as string | undefined,
+        timeoutMs: this.timeoutMs(params),
+      });
+
+      // The shared runtime reads `commandId` (or the legacy `shell_id`) and
+      // passes it back to getCommandOutput/killCommand.
+      return { commandId: String(handle.pid), shell_id: String(handle.pid) };
     }
 
-    return result.stdout;
+    const result = await sandbox.commands.run(command, {
+      cwd: params.cwd as string | undefined,
+      timeoutMs: this.timeoutMs(params),
+    });
+
+    return {
+      exitCode: result.exitCode,
+      output: result.stdout,
+      stderr: result.stderr,
+      stdout: result.stdout,
+      // Without this the runtime falls back to the outer envelope and reports a
+      // failed command as successful.
+      success: result.exitCode === 0,
+    };
+  }
+
+  private async writeFile(sandbox: Sandbox, params: Record<string, unknown>) {
+    const path = String(params.path ?? '');
+    if (!path) throw new Error('path is required');
+
+    // Reuse the shared script so `createDirectories` behaves identically across
+    // providers, then stream the body through the sandbox filesystem API.
+    await this.runScript(sandbox, prepareWriteFileScript, params);
+    await sandbox.files.write(path, String(params.content ?? ''));
+
+    return { path, success: true };
+  }
+
+  /**
+   * Runs one of the shared Python helpers and returns its parsed JSON payload,
+   * mirroring how the Onlyboxes provider executes the same scripts.
+   */
+  private async runScript(
+    sandbox: Sandbox,
+    script: string,
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const result = await sandbox.commands.run(buildScriptCommand(script, params), {
+      timeoutMs: this.timeoutMs(params),
+    });
+
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || result.stdout || 'Sandbox script failed');
+    }
+
+    const parsed = JSON.parse(result.stdout || '{}') as Record<string, unknown>;
+
+    if (parsed.success === false) {
+      throw new Error(String(parsed.error || 'Sandbox script failed'));
+    }
+
+    return parsed;
+  }
+
+  private commandId(params: Record<string, unknown>): number {
+    const raw = params.commandId ?? params.shell_id ?? params.pid;
+    const id = Number(raw);
+
+    if (!Number.isFinite(id)) throw new Error('commandId is required');
+
+    return id;
+  }
+
+  private timeoutMs(params: Record<string, unknown>): number {
+    const value = params.timeout ?? params.timeout_ms;
+
+    return typeof value === 'number' && Number.isFinite(value) ? value : DEFAULT_COMMAND_TIMEOUT_MS;
   }
 
   // ---------------------------------------------------------------------------
@@ -263,42 +312,52 @@ export class TencentSandboxProvider implements SandboxProvider {
   // ---------------------------------------------------------------------------
 
   /**
-   * Runs `fn` against a connected sandbox.
+   * Returns a client for this session's instance, acquiring or renewing one as
+   * needed.
    *
-   * In `persistent` mode the instance is cached per session and renewed before
-   * it expires. In `on-demand` mode a fresh instance is acquired for the call
-   * and released afterwards, which trades cold-start latency for cost.
+   * `persistent` renews before expiry so a topic keeps its container.
+   * `on-demand` lets the instance lapse at `TENCENT_SANDBOX_TIMEOUT_SEC` and
+   * acquires a fresh one afterwards, which bounds cost without breaking
+   * multi-call flows such as file bootstrapping or background commands.
    */
-  private async withSandbox<T>(fn: (sandbox: Sandbox) => Promise<T>): Promise<T> {
-    const onDemand = sandboxEnv.TENCENT_SANDBOX_MODE === 'on-demand';
-    const instance = onDemand ? await this.acquire() : await this.acquirePersistent();
-
-    try {
-      return await fn(connect(instance));
-    } finally {
-      if (onDemand) await this.release(instance.instanceId);
-    }
+  private async connect(): Promise<Sandbox> {
+    return connect(await this.acquireForSession());
   }
 
-  private async acquirePersistent(): Promise<AcquiredInstance> {
-    const key = this.sessionKey();
-    const cached = persistentInstances.get(key);
+  private async acquireForSession(): Promise<AcquiredInstance> {
+    this.evictExpired();
 
-    if (cached && cached.expiresAt - Date.now() > RENEW_THRESHOLD_MS) return cached;
+    const key = this.sessionKey();
+    const cached = instances.get(key);
 
     if (cached) {
-      // Still valid but close to expiry — extend rather than pay a cold start.
-      const renewed = await this.renew(cached);
-      if (renewed) {
-        persistentInstances.set(key, renewed);
-        return renewed;
+      if (cached.expiresAt - Date.now() > RENEW_THRESHOLD_MS) return cached;
+
+      if (sandboxEnv.TENCENT_SANDBOX_MODE !== 'on-demand') {
+        const renewed = await this.renew(cached);
+        if (renewed) {
+          instances.set(key, renewed);
+          return renewed;
+        }
       }
+
+      instances.delete(key);
+      await this.release(cached.instanceId);
     }
 
     const instance = await this.acquire();
-    persistentInstances.set(key, instance);
+    instances.set(key, instance);
 
     return instance;
+  }
+
+  /** Keeps the module-level map from growing with abandoned sessions. */
+  private evictExpired(): void {
+    const now = Date.now();
+
+    for (const [key, instance] of instances) {
+      if (instance.expiresAt <= now) instances.delete(key);
+    }
   }
 
   private async renew(instance: AcquiredInstance): Promise<AcquiredInstance | undefined> {
@@ -361,9 +420,7 @@ export class TencentSandboxProvider implements SandboxProvider {
       method: 'POST',
     });
 
-    if (!response.ok) {
-      throw new Error(`Sandbox ${action} failed with status ${response.status}`);
-    }
+    if (!response.ok) throw new Error(`Sandbox ${action} failed with status ${response.status}`);
 
     const body = (await response.json()) as {
       Code?: number;
@@ -422,10 +479,5 @@ const connect = (instance: AcquiredInstance): Sandbox =>
     trafficAccessToken: instance.trafficToken,
   });
 
-const quote = (value: string): string => `'${value.replaceAll("'", String.raw`'\''`)}'`;
-
-const splitLines = (value: string): string[] =>
-  value
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean);
+/** Exposed for tests; instance reuse is otherwise process-wide. */
+export const __clearSandboxInstances = () => instances.clear();

--- a/apps/server/src/services/sandbox/types.ts
+++ b/apps/server/src/services/sandbox/types.ts
@@ -7,7 +7,7 @@ import type { LobeChatDatabase } from '@lobechat/database';
 import type { FileService } from '@/server/services/file';
 import type { MarketService } from '@/server/services/market';
 
-export type SandboxProviderKind = 'market' | 'onlyboxes';
+export type SandboxProviderKind = 'market' | 'onlyboxes' | 'tencent';
 
 export interface SandboxSessionContext {
   topicId: string;

--- a/docs/self-hosting/environment-variables/cloud-sandbox.mdx
+++ b/docs/self-hosting/environment-variables/cloud-sandbox.mdx
@@ -1,11 +1,11 @@
 ---
 title: Configuring Cloud Sandbox
 description: >-
-  Configure the built-in Cloud Sandbox provider, including Market and
-  self-hosted Onlyboxes.
+  Configure the built-in Cloud Sandbox provider, including Market and self-hosted Onlyboxes, and Tencent Cloud EdgeOne.
 tags:
   - Cloud Sandbox
   - Onlyboxes
+  - Tencent Cloud
   - Self-hosting
 ---
 
@@ -26,6 +26,7 @@ Supported values:
 
 - `market`: Use the existing Market sandbox.
 - `onlyboxes`: Use an Onlyboxes-compatible self-hosted sandbox console.
+- `tencent`: Use Tencent Cloud EdgeOne Agent Runtime sandboxes.
 
 ### `MARKET_BASE_URL`
 
@@ -83,6 +84,46 @@ Supported values:
 - Default: `900`
 - Example: `3600`
 
+### `TENCENT_SANDBOX_API_TOKEN`
+
+- Type: Required when `SANDBOX_PROVIDER=tencent`
+- Description: EdgeOne Pages API token used to acquire sandbox instances. Create one from the EdgeOne Pages console settings page.
+- Example: `your-edgeone-pages-api-token`
+
+### `TENCENT_SANDBOX_PROJECT_ID`
+
+- Type: Required when `SANDBOX_PROVIDER=tencent`
+- Description: EdgeOne Makers project that sandbox instances are billed against.
+- Example: `makers-xxxxxxxx`
+
+### `TENCENT_SANDBOX_MODE`
+
+- Type: Optional
+- Description: Controls the instance lifecycle. `persistent` keeps one container per topic and renews it before expiry, so state such as variables and files survives across tool calls. `on-demand` acquires a container for each tool call and releases it afterwards, which lowers idle cost at the price of a cold start on every call.
+- Default: `persistent`
+- Example: `on-demand`
+
+### `TENCENT_SANDBOX_TIMEOUT_SEC`
+
+- Type: Optional
+- Description: Lifetime requested for each sandbox instance, in seconds. In `persistent` mode the instance is renewed before this expires.
+- Default: `300`
+- Example: `900`
+
+### `TENCENT_SANDBOX_REGION`
+
+- Type: Optional
+- Description: Region used to allocate sandbox instances.
+- Default: `ap-beijing`
+- Example: `ap-singapore`
+
+### `TENCENT_SANDBOX_API_BASE`
+
+- Type: Optional
+- Description: Overrides the sandbox control-plane endpoint. Set this to use the international site instead of the mainland China site.
+- Default: `https://pages-api.cloud.tencent.com/v1/sandbox`
+- Example: `https://pages-api.edgeone.ai/v1/sandbox`
+
 ## Market Configuration
 
 By default, LobeHub uses the official Market sandbox and does not require extra sandbox configuration:
@@ -135,4 +176,32 @@ CONSOLE_JIT_SIGNING_KEY=onlyboxes-jit-signing-secret
 <Callout type={'info'}>
   File export still writes the exported artifact to the configured LobeHub S3 storage. Configure the
   S3 environment variables when users need to download files generated inside the sandbox.
+</Callout>
+
+## Tencent Cloud Configuration
+
+Tencent Cloud EdgeOne Agent Runtime exposes managed sandboxes that speak the E2B protocol. Minimum configuration:
+
+```bash
+SANDBOX_PROVIDER=tencent
+TENCENT_SANDBOX_API_TOKEN=your-edgeone-pages-api-token
+TENCENT_SANDBOX_PROJECT_ID=makers-xxxxxxxx
+```
+
+The sandbox image ships with Python and Node.js preinstalled, so code execution, shell commands, and file operations work without extra image preparation.
+
+Choose the instance lifecycle with `TENCENT_SANDBOX_MODE`:
+
+```bash
+# Reuse one container per topic (default). Variables and files persist
+# across tool calls within the same conversation.
+TENCENT_SANDBOX_MODE=persistent
+
+# Create and release a container per tool call. No state is carried over.
+TENCENT_SANDBOX_MODE=on-demand
+```
+
+<Callout type={'info'}>
+  LobeHub does not need to be deployed on EdgeOne to use these sandboxes. Instances are acquired
+  through a public control-plane API, so a self-hosted LobeHub on any server can use them.
 </Callout>

--- a/docs/self-hosting/environment-variables/cloud-sandbox.mdx
+++ b/docs/self-hosting/environment-variables/cloud-sandbox.mdx
@@ -99,7 +99,7 @@ Supported values:
 ### `TENCENT_SANDBOX_MODE`
 
 - Type: Optional
-- Description: Controls the instance lifecycle. `persistent` keeps one container per topic and renews it before expiry, so state such as variables and files survives across tool calls. `on-demand` acquires a container for each tool call and releases it afterwards, which lowers idle cost at the price of a cold start on every call.
+- Description: Controls the instance lifecycle. `persistent` keeps one container per topic and renews it before expiry, so state such as variables and files survives for as long as the topic is active. `on-demand` lets the container lapse when `TENCENT_SANDBOX_TIMEOUT_SEC` elapses instead of renewing it, which bounds idle cost at the price of a cold start after each idle period. Both modes reuse one container across the calls that make up a single tool invocation.
 - Default: `persistent`
 - Example: `on-demand`
 
@@ -193,13 +193,20 @@ The sandbox image ships with Python and Node.js preinstalled, so code execution,
 Choose the instance lifecycle with `TENCENT_SANDBOX_MODE`:
 
 ```bash
-# Reuse one container per topic (default). Variables and files persist
-# across tool calls within the same conversation.
+# Renew one container per topic for as long as the topic stays active
+# (default). Variables and files persist across tool calls.
 TENCENT_SANDBOX_MODE=persistent
 
-# Create and release a container per tool call. No state is carried over.
+# Do not renew; the container lapses after TENCENT_SANDBOX_TIMEOUT_SEC and
+# the next call starts a fresh one.
 TENCENT_SANDBOX_MODE=on-demand
 ```
+
+<Callout type={'warn'}>
+  Skill scripts (`execScript`) are not implemented for this provider yet, so
+  `capabilities.skillScripts` is reported as `false`. Code execution, shell commands, file
+  operations, and file export are all supported.
+</Callout>
 
 <Callout type={'info'}>
   LobeHub does not need to be deployed on EdgeOne to use these sandboxes. Instances are acquired

--- a/docs/self-hosting/environment-variables/cloud-sandbox.zh-CN.mdx
+++ b/docs/self-hosting/environment-variables/cloud-sandbox.zh-CN.mdx
@@ -98,7 +98,7 @@ tags:
 ### `TENCENT_SANDBOX_MODE`
 
 - 类型：可选
-- 描述：控制实例的生命周期。`persistent` 为每个话题保留一个容器并在到期前续期，变量、文件等状态可以跨工具调用保留；`on-demand` 为每次工具调用申请并随即释放容器，降低闲置成本，代价是每次调用都有冷启动。
+- 描述：控制实例的生命周期。`persistent` 为每个话题保留一个容器并在到期前续期，只要话题还活跃，变量和文件等状态就一直保留；`on-demand` 不续期，容器在 `TENCENT_SANDBOX_TIMEOUT_SEC` 后自然失效，以此约束闲置成本，代价是空闲一段时间后会有冷启动。两种模式下，构成同一次工具调用的多个请求都复用同一个容器。
 - 默认值：`persistent`
 - 示例：`on-demand`
 
@@ -192,12 +192,17 @@ TENCENT_SANDBOX_PROJECT_ID=makers-xxxxxxxx
 通过 `TENCENT_SANDBOX_MODE` 选择实例的生命周期：
 
 ```bash
-# 每个话题复用一个容器（默认）。同一会话内变量和文件跨工具调用保留。
+# 只要话题还活跃就持续续期同一个容器（默认），变量和文件跨调用保留。
 TENCENT_SANDBOX_MODE=persistent
 
-# 每次工具调用创建并释放容器，不保留任何状态。
+# 不续期，容器在 TENCENT_SANDBOX_TIMEOUT_SEC 后失效，下次调用重新创建。
 TENCENT_SANDBOX_MODE=on-demand
 ```
+
+<Callout type={'warn'}>
+  该提供方尚未实现技能脚本（`execScript`），因此 `capabilities.skillScripts` 报告为
+  `false`。代码执行、Shell 命令、文件操作与文件导出均已支持。
+</Callout>
 
 <Callout type={'info'}>
   使用这些沙箱**不需要**把 LobeHub 部署到 EdgeOne 上。实例通过公开的控制面 API 申请，

--- a/docs/self-hosting/environment-variables/cloud-sandbox.zh-CN.mdx
+++ b/docs/self-hosting/environment-variables/cloud-sandbox.zh-CN.mdx
@@ -1,9 +1,10 @@
 ---
 title: 配置云端沙箱
-description: 配置内置云端沙箱能力，包括 Market 和自托管 Onlyboxes。
+description: 配置内置云端沙箱能力，包括 Market、自托管 Onlyboxes 和腾讯云 EdgeOne。
 tags:
   - 云端沙箱
   - Onlyboxes
+  - 腾讯云
   - 自托管
 ---
 
@@ -24,6 +25,7 @@ tags:
 
 - `market`：使用现有 Market 沙箱。
 - `onlyboxes`：使用兼容 Onlyboxes 的自托管沙箱 Console。
+- `tencent`：使用腾讯云 EdgeOne Agent Runtime 沙箱。
 
 ### `MARKET_BASE_URL`
 
@@ -81,6 +83,46 @@ tags:
 - 默认值：`900`
 - 示例：`3600`
 
+### `TENCENT_SANDBOX_API_TOKEN`
+
+- 类型：`SANDBOX_PROVIDER=tencent` 时必填
+- 描述：用于申请沙箱实例的 EdgeOne Pages API Token，在 EdgeOne Pages 控制台的设置页创建。
+- 示例：`your-edgeone-pages-api-token`
+
+### `TENCENT_SANDBOX_PROJECT_ID`
+
+- 类型：`SANDBOX_PROVIDER=tencent` 时必填
+- 描述：沙箱实例所计费的 EdgeOne Makers 项目。
+- 示例：`makers-xxxxxxxx`
+
+### `TENCENT_SANDBOX_MODE`
+
+- 类型：可选
+- 描述：控制实例的生命周期。`persistent` 为每个话题保留一个容器并在到期前续期，变量、文件等状态可以跨工具调用保留；`on-demand` 为每次工具调用申请并随即释放容器，降低闲置成本，代价是每次调用都有冷启动。
+- 默认值：`persistent`
+- 示例：`on-demand`
+
+### `TENCENT_SANDBOX_TIMEOUT_SEC`
+
+- 类型：可选
+- 描述：每个沙箱实例申请的存活时长（秒）。`persistent` 模式下会在到期前自动续期。
+- 默认值：`300`
+- 示例：`900`
+
+### `TENCENT_SANDBOX_REGION`
+
+- 类型：可选
+- 描述：分配沙箱实例所使用的地域。
+- 默认值：`ap-beijing`
+- 示例：`ap-singapore`
+
+### `TENCENT_SANDBOX_API_BASE`
+
+- 类型：可选
+- 描述：覆盖沙箱控制面端点。需要使用国际站而非中国站时设置。
+- 默认值：`https://pages-api.cloud.tencent.com/v1/sandbox`
+- 示例：`https://pages-api.edgeone.ai/v1/sandbox`
+
 ## Market 配置
 
 默认情况下，LobeHub 使用官方 Market 沙箱，不需要额外配置：
@@ -133,4 +175,31 @@ CONSOLE_JIT_SIGNING_KEY=onlyboxes-jit-signing-secret
 <Callout type={'info'}>
   文件导出仍会把沙箱内产物写入 LobeHub 配置的 S3 存储。如果用户需要下载沙箱生成的文件，请同时配置 S3
   相关环境变量。
+</Callout>
+
+## 腾讯云配置
+
+腾讯云 EdgeOne Agent Runtime 提供托管沙箱，使用 E2B 协议。最小配置：
+
+```bash
+SANDBOX_PROVIDER=tencent
+TENCENT_SANDBOX_API_TOKEN=your-edgeone-pages-api-token
+TENCENT_SANDBOX_PROJECT_ID=makers-xxxxxxxx
+```
+
+沙箱镜像预装了 Python 与 Node.js，代码执行、Shell 命令和文件操作无需额外准备镜像。
+
+通过 `TENCENT_SANDBOX_MODE` 选择实例的生命周期：
+
+```bash
+# 每个话题复用一个容器（默认）。同一会话内变量和文件跨工具调用保留。
+TENCENT_SANDBOX_MODE=persistent
+
+# 每次工具调用创建并释放容器，不保留任何状态。
+TENCENT_SANDBOX_MODE=on-demand
+```
+
+<Callout type={'info'}>
+  使用这些沙箱**不需要**把 LobeHub 部署到 EdgeOne 上。实例通过公开的控制面 API 申请，
+  部署在任意服务器上的自托管 LobeHub 都可以使用。
 </Callout>

--- a/packages/env/src/__tests__/sandbox.test.ts
+++ b/packages/env/src/__tests__/sandbox.test.ts
@@ -10,6 +10,10 @@ describe('getSandboxConfig', () => {
     delete process.env.ONLYBOXES_JIT_SIGNING_KEY;
     delete process.env.ONLYBOXES_JIT_TTL_SEC;
     delete process.env.ONLYBOXES_LEASE_TTL_SEC;
+    delete process.env.TENCENT_SANDBOX_API_TOKEN;
+    delete process.env.TENCENT_SANDBOX_MODE;
+    delete process.env.TENCENT_SANDBOX_PROJECT_ID;
+    delete process.env.TENCENT_SANDBOX_TIMEOUT_SEC;
   });
 
   it('should treat docker empty string defaults as unset optional values', async () => {
@@ -48,5 +52,28 @@ describe('getSandboxConfig', () => {
     expect(config.ONLYBOXES_JIT_SIGNING_KEY).toBe('jit-signing-key');
     expect(config.ONLYBOXES_JIT_TTL_SEC).toBe(900);
     expect(config.ONLYBOXES_LEASE_TTL_SEC).toBe(3600);
+  });
+
+  it('should leave the Tencent sandbox mode unset so the provider default applies', async () => {
+    const { getSandboxConfig } = await import('../sandbox');
+
+    expect(getSandboxConfig().TENCENT_SANDBOX_MODE).toBeUndefined();
+  });
+
+  it('should parse Tencent sandbox values', async () => {
+    process.env.SANDBOX_PROVIDER = 'tencent';
+    process.env.TENCENT_SANDBOX_API_TOKEN = 'edgeone-token';
+    process.env.TENCENT_SANDBOX_MODE = 'on-demand';
+    process.env.TENCENT_SANDBOX_PROJECT_ID = 'makers-test';
+    process.env.TENCENT_SANDBOX_TIMEOUT_SEC = '900';
+
+    const { getSandboxConfig } = await import('../sandbox');
+    const config = getSandboxConfig();
+
+    expect(config.SANDBOX_PROVIDER).toBe('tencent');
+    expect(config.TENCENT_SANDBOX_API_TOKEN).toBe('edgeone-token');
+    expect(config.TENCENT_SANDBOX_MODE).toBe('on-demand');
+    expect(config.TENCENT_SANDBOX_PROJECT_ID).toBe('makers-test');
+    expect(config.TENCENT_SANDBOX_TIMEOUT_SEC).toBe(900);
   });
 });

--- a/packages/env/src/sandbox.ts
+++ b/packages/env/src/sandbox.ts
@@ -12,6 +12,12 @@ export const getSandboxConfig = () => {
       ONLYBOXES_JIT_TTL_SEC: process.env.ONLYBOXES_JIT_TTL_SEC,
       ONLYBOXES_LEASE_TTL_SEC: process.env.ONLYBOXES_LEASE_TTL_SEC,
       SANDBOX_PROVIDER: process.env.SANDBOX_PROVIDER,
+      TENCENT_SANDBOX_API_BASE: process.env.TENCENT_SANDBOX_API_BASE,
+      TENCENT_SANDBOX_API_TOKEN: process.env.TENCENT_SANDBOX_API_TOKEN,
+      TENCENT_SANDBOX_MODE: process.env.TENCENT_SANDBOX_MODE,
+      TENCENT_SANDBOX_PROJECT_ID: process.env.TENCENT_SANDBOX_PROJECT_ID,
+      TENCENT_SANDBOX_REGION: process.env.TENCENT_SANDBOX_REGION,
+      TENCENT_SANDBOX_TIMEOUT_SEC: process.env.TENCENT_SANDBOX_TIMEOUT_SEC,
     },
     server: {
       ONLYBOXES_BASE_URL: z.preprocess(emptyStringToUndefined, z.string().url().optional()),
@@ -24,7 +30,19 @@ export const getSandboxConfig = () => {
       ONLYBOXES_LEASE_TTL_SEC: z.preprocess(emptyStringToUndefined, z.coerce.number().optional()),
       SANDBOX_PROVIDER: z.preprocess(
         emptyStringToUndefined,
-        z.enum(['market', 'onlyboxes']).optional(),
+        z.enum(['market', 'onlyboxes', 'tencent']).optional(),
+      ),
+      TENCENT_SANDBOX_API_BASE: z.preprocess(emptyStringToUndefined, z.string().url().optional()),
+      TENCENT_SANDBOX_API_TOKEN: z.preprocess(emptyStringToUndefined, z.string().optional()),
+      TENCENT_SANDBOX_MODE: z.preprocess(
+        emptyStringToUndefined,
+        z.enum(['persistent', 'on-demand']).optional(),
+      ),
+      TENCENT_SANDBOX_PROJECT_ID: z.preprocess(emptyStringToUndefined, z.string().optional()),
+      TENCENT_SANDBOX_REGION: z.preprocess(emptyStringToUndefined, z.string().optional()),
+      TENCENT_SANDBOX_TIMEOUT_SEC: z.preprocess(
+        emptyStringToUndefined,
+        z.coerce.number().int().positive().optional(),
       ),
     },
   });


### PR DESCRIPTION
Adds `tencent` as a third Cloud Sandbox provider, alongside `market` and
`onlyboxes`. Tencent Cloud EdgeOne Agent Runtime offers managed sandboxes
that speak the E2B protocol, which gives self-hosted deployments — mainland
China ones in particular — an option that needs neither Market access nor
running an Onlyboxes console.

Minimum configuration:

```bash
SANDBOX_PROVIDER=tencent
TENCENT_SANDBOX_API_TOKEN=your-edgeone-pages-api-token
TENCENT_SANDBOX_PROJECT_ID=makers-xxxxxxxx
```

Instances are allocated through EdgeOne's public control plane
(`/v1/sandbox/{acquire,release,update}`), so **LobeHub does not need to be
deployed on EdgeOne** to use them.

Because instances are billed per lifetime, `TENCENT_SANDBOX_MODE` picks the
lifecycle:

- `persistent` (default) — one container per topic, renewed before expiry,
  so variables and files survive across tool calls
- `on-demand` — a container per tool call, released immediately after,
  trading a cold start for lower idle cost

`capabilities.persistentSession` reflects the configured mode.

Two things reviewers may want to weigh in on:

1. It adds `@e2b/code-interpreter` to `@lobechat/server`. Tencent's own
   agent toolkit uses the official E2B SDK the same way, so this tracks
   upstream rather than reimplementing the envd protocol.
2. The client is constructed directly instead of via `Sandbox.connect()`.
   That helper resolves the instance through the e2b.dev control plane and
   requires an E2B API key, which a Tencent user does not have — Tencent
   issues the instance itself and returns the connection details.

#### Test

Capabilities were verified against a live instance, running entirely
outside EdgeOne (the situation a self-hosted LobeHub is in):

| Capability | Result |
| --- | --- |
| `shell` | ✅ `commands.run` returns exit code and streams |
| `files` | ✅ read / write / list |
| `persistentSession` | ✅ state survives across calls in one instance |
| `languages: python` | ✅ Python 3.12.13 |
| `languages: javascript` | ✅ Node v20.20.2 |
| `backgroundCommands` | ✅ returns a pid |

Sandbox spec is 3 vCPU / 4 GB with Python and Node.js preinstalled, so it
meets the runtime requirements documented for Onlyboxes without any image
preparation.

Unit tests cover the provider logic with the control plane and the E2B
client mocked: credential validation, code execution, instance reuse in
`persistent` mode, acquire/release pairing in `on-demand` mode, release on
failure, unsupported tool names, and mode-dependent capabilities.

Docs are updated in both languages
(`docs/self-hosting/environment-variables/cloud-sandbox{,.zh-CN}.mdx`),
along with `.env.example`.

One thing I could not establish from public documentation: **the pricing and
concurrency quota for sandbox instances.** I deliberately left that out of
the docs rather than guess — happy to add a note if a maintainer knows the
right wording.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Closes #18066
