### PR TITLE
💄 style(notification): strip markdown in inbox list preview

### DIFF
--- a/src/features/HomeSidebar/Header/components/InboxDrawer/NotificationDetailModal.tsx
+++ b/src/features/HomeSidebar/Header/components/InboxDrawer/NotificationDetailModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Flexbox, Text } from '@lobehub/ui';
+import { Flexbox, Markdown, Text } from '@lobehub/ui';
 import { Button, createModal, useModalContext } from '@lobehub/ui/base-ui';
 import dayjs from 'dayjs';
 import { memo } from 'react';
@@ -31,7 +31,9 @@ const NotificationDetailContent = memo<Omit<NotificationDetailParams, 'title'>>(
             {context}
           </Text>
         )}
-        <Text style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{content}</Text>
+        <Markdown fontSize={14} variant={'chat'}>
+          {content}
+        </Markdown>
         {onAction && (
           <Flexbox horizontal justify="flex-end">
             <Button

--- a/src/features/HomeSidebar/Header/components/InboxDrawer/NotificationItem.tsx
+++ b/src/features/HomeSidebar/Header/components/InboxDrawer/NotificationItem.tsx
@@ -4,7 +4,7 @@ import { Block, Flexbox, Icon, Text } from '@lobehub/ui';
 import { ContextMenuTrigger } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { ArchiveIcon, BellIcon, ImageIcon, MegaphoneIcon, VideoIcon } from 'lucide-react';
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
@@ -12,6 +12,7 @@ import type { NativeContextMenuItem } from '@/libs/contextMenu/types';
 
 import { formatNotificationRelativeTime } from './formatNotificationRelativeTime';
 import { createNotificationDetailModal } from './NotificationDetailModal';
+import { toNotificationPreview } from './toNotificationPreview';
 
 const styles = createStaticStyles(({ css }) => ({
   container: css`
@@ -68,6 +69,7 @@ const NotificationItem = memo<NotificationItemProps>(
     const navigate = useWorkspaceAwareNavigate();
     const TypeIcon = TYPE_ICON_MAP[type] || BellIcon;
     const dateLocale = i18n.resolvedLanguage || i18n.language;
+    const preview = useMemo(() => toNotificationPreview(content), [content]);
 
     const handleClick = useCallback(() => {
       if (!isRead) onMarkAsRead(id);
@@ -135,7 +137,9 @@ const NotificationItem = memo<NotificationItemProps>(
             <Flexbox horizontal align="flex-start" flex={1} gap={6} style={{ overflow: 'hidden' }}>
               {!isRead && <span className={styles.unreadDot} />}
               <Flexbox flex={1} gap={4} style={{ overflow: 'hidden' }}>
-                <Text style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{content}</Text>
+                <Text ellipsis={{ rows: 3 }} title={preview} wordBreak="break-word">
+                  {preview}
+                </Text>
                 {context && (
                   <Text ellipsis fontSize={12} title={context} type="secondary">
                     {context}

--- a/src/features/HomeSidebar/Header/components/InboxDrawer/toNotificationPreview.test.ts
+++ b/src/features/HomeSidebar/Header/components/InboxDrawer/toNotificationPreview.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { toNotificationPreview } from './toNotificationPreview';
+
+describe('toNotificationPreview', () => {
+  it('returns empty string for empty input', () => {
+    expect(toNotificationPreview('')).toBe('');
+    expect(toNotificationPreview(null)).toBe('');
+    expect(toNotificationPreview(undefined)).toBe('');
+  });
+
+  it('strips headings, bold and link syntax', () => {
+    expect(
+      toNotificationPreview(
+        '## ✅ 每日 LOBE 注释清理完成\n\n**PR**: [#17689](https://github.com/lobehub/lobehub/pull/17689)',
+      ),
+    ).toBe('✅ 每日 LOBE 注释清理完成 PR: #17689');
+  });
+
+  it('flattens markdown tables and drops divider rows', () => {
+    const content = [
+      '### 清理概要',
+      '',
+      '| 指标 | 数值 |',
+      '|------|------|',
+      '| 修改文件数 | **118** |',
+    ].join('\n');
+
+    const preview = toNotificationPreview(content);
+
+    expect(preview).toBe('清理概要 指标 数值 修改文件数 118');
+    expect(preview).not.toContain('|');
+    expect(preview).not.toContain('--');
+  });
+
+  it('collapses multi-line content into a single line', () => {
+    expect(toNotificationPreview('Line 1\n\n\nLine 2\n> quoted\n\n---\n\n- item')).toBe(
+      'Line 1 Line 2 quoted item',
+    );
+  });
+
+  it('truncates over-long previews with an ellipsis', () => {
+    const preview = toNotificationPreview('a'.repeat(500));
+
+    expect(preview).toHaveLength(301);
+    expect(preview.endsWith('…')).toBe(true);
+  });
+
+  it('keeps short plain text untouched', () => {
+    expect(toNotificationPreview('图片生成完成')).toBe('图片生成完成');
+  });
+});

--- a/src/features/HomeSidebar/Header/components/InboxDrawer/toNotificationPreview.ts
+++ b/src/features/HomeSidebar/Header/components/InboxDrawer/toNotificationPreview.ts
@@ -1,0 +1,29 @@
+import { markdownToTxt } from '@/utils/markdownToTxt';
+
+/** Table divider rows such as `|------|------|` or `| :--- | ---: |` */
+const TABLE_DIVIDER_LINE = /^[\s:|]*-[-\s:|]*$/;
+
+const MAX_LENGTH = 300;
+
+/**
+ * Notification bodies are authored as markdown (headings, tables, links, bold).
+ * The inbox list is a narrow one-glance surface, so render a flattened plain-text
+ * preview instead: strip markdown syntax, drop table dividers, and collapse the
+ * whole body into a single line that the list clamps with CSS.
+ */
+export const toNotificationPreview = (content?: string | null): string => {
+  if (!content) return '';
+
+  const text = markdownToTxt(content);
+  if (!text) return '';
+
+  const preview = text
+    .split('\n')
+    .filter((line) => !TABLE_DIVIDER_LINE.test(line))
+    // `remove-markdown` keeps table pipes — flatten cells into spaced text
+    .map((line) => line.replaceAll('|', ' ').replaceAll(/\s+/g, ' ').trim())
+    .filter(Boolean)
+    .join(' ');
+
+  return preview.length > MAX_LENGTH ? `${preview.slice(0, MAX_LENGTH)}…` : preview;
+};


### PR DESCRIPTION
Notification bodies are authored as markdown, so the inbox drawer list rendered raw syntax — `##` headings, `**bold**`, full `[link](url)` targets, and table pipes/dividers — and a single notification could span 7+ lines.

This PR splits the two surfaces:

- **Inbox list**: new `toNotificationPreview()` flattens the body to plain text via the existing `markdownToTxt` util, additionally dropping table divider rows (`|---|---|`) and collapsing residual pipes/newlines into a single line, then clamps to 3 lines with CSS ellipsis (full preview on hover via `title`).
- **Detail modal**: now renders the body with `<Markdown variant="chat">`, so tables and links stay useful where there is room (640px modal).

| Before | After |
| ------ | ----- |
| Raw markdown (`## ✅ …`, `**PR**: [#17689](…)`, table pipes) wrapped over many lines | 3-line plain-text preview; full markdown rendered in the detail modal |

#### Test

- `toNotificationPreview.test.ts`: 6 cases covering heading/bold/link stripping, table flattening, multi-line collapsing, long-content truncation, and CJK plain text.
- `bun run check` on changed files: lint clean, 6 tests passed; no new type errors.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)