### PR TITLE
fix(stats): mobile-responsive layout - grid, stacking, scroll

### DIFF
--- a/packages/locales/src/default/auth.ts
+++ b/packages/locales/src/default/auth.ts
@@ -206,6 +206,7 @@ export default {
   'heatmaps.months.nov': 'Nov',
   'heatmaps.months.oct': 'Oct',
   'heatmaps.months.sep': 'Sep',
+  'heatmaps.swipeHint': '‹ swipe horizontally ›',
   'heatmaps.tooltip': '{{count}} messages were created on {{date}}',
   'heatmaps.tooltipTokens': '{{count}} tokens were used on {{date}}',
   'heatmaps.totalCount': 'A total of {{count}} messages sent in the past year',

--- a/src/features/Settings/stats/features/components/StatsFormGroup.tsx
+++ b/src/features/Settings/stats/features/components/StatsFormGroup.tsx
@@ -17,14 +17,25 @@ const StatsFormGroup = memo<StatsFormGroupProps>(
   ({ fontSize = 18, afterTitle, children, extra, title, ...rest }) => {
     return (
       <Block gap={16} variant={'borderless'} {...rest}>
-        <Flexbox horizontal align={'center'} gap={8} justify={'space-between'}>
-          <Flexbox horizontal align={'center'} flex={1} gap={8} style={{ minWidth: 0 }}>
+        <Flexbox
+          horizontal
+          align={'center'}
+          gap={8}
+          justify={'space-between'}
+          style={{ flexWrap: 'wrap', rowGap: 8 }}
+        >
+          <Flexbox
+            horizontal
+            align={'center'}
+            gap={8}
+            style={{ flex: '0 1 auto', overflow: 'hidden' }}
+          >
             <Text fontSize={fontSize} weight={500}>
               {title}
             </Text>
             {afterTitle}
           </Flexbox>
-          <Flexbox horizontal align={'center'} flex={'none'} gap={8}>
+          <Flexbox horizontal align={'center'} gap={8} style={{ flex: 'none' }}>
             {extra}
           </Flexbox>
         </Flexbox>

--- a/src/features/Settings/stats/features/usage/UsageCards/index.tsx
+++ b/src/features/Settings/stats/features/usage/UsageCards/index.tsx
@@ -6,9 +6,9 @@ import ActiveModels from './ActiveModels';
 import MonthSpend from './MonthSpend';
 import TodaySpend from './TodaySpend';
 
-const UsageCards = memo<UsageChartProps>(({ isLoading, data, groupBy, resolveUser }) => {
+const UsageCards = memo<UsageChartProps>(({ isLoading, data, groupBy, resolveUser, mobile }) => {
   return (
-    <Flexbox horizontal gap={16}>
+    <Flexbox gap={8} horizontal={false}>
       <TodaySpend data={data} isLoading={isLoading} />
       <MonthSpend data={data} isLoading={isLoading} />
       <ActiveModels data={data} groupBy={groupBy} isLoading={isLoading} resolveUser={resolveUser} />

--- a/src/features/Settings/stats/features/usage/UsageTable.tsx
+++ b/src/features/Settings/stats/features/usage/UsageTable.tsx
@@ -39,6 +39,8 @@ interface SortState {
 const styles = createStaticStyles(({ css }) => ({
   // Line the footer up with InlineTable's first/last cells.
   pagination: css`
+    flex-wrap: wrap;
+    row-gap: 8px;
     padding-inline: 24px;
   `,
 }));
@@ -169,21 +171,23 @@ const UsageTable = memo<UsageChartProps>(({ dateStrings }) => {
 
   return (
     <>
-      <InlineTable
-        columns={columns}
-        dataSource={pageData}
-        loading={isLoading}
-        rowKey={(record) => record.id || `${record.model}-${record.createdAt}-${record.provider}`}
-        size="small"
-        onChange={(_pagination, _filters, sorter) => {
-          const next = Array.isArray(sorter) ? sorter[0] : sorter;
-          const field = String(next?.columnKey ?? '');
-          setSort(next?.order && SORT_VALUES[field] ? { field, order: next.order } : null);
-          // A re-sort makes the current page a different set of rows; start
-          // from the top rather than dropping the reader into the middle.
-          setCurrentPage(1);
-        }}
-      />
+      <div style={{ minWidth: 0, overflowX: 'auto' }}>
+        <InlineTable
+          columns={columns}
+          dataSource={pageData}
+          loading={isLoading}
+          rowKey={(record) => record.id || `${record.model}-${record.createdAt}-${record.provider}`}
+          size="small"
+          onChange={(_pagination, _filters, sorter) => {
+            const next = Array.isArray(sorter) ? sorter[0] : sorter;
+            const field = String(next?.columnKey ?? '');
+            setSort(next?.order && SORT_VALUES[field] ? { field, order: next.order } : null);
+            // A re-sort makes the current page a different set of rows; start
+            // from the top rather than dropping the reader into the middle.
+            setCurrentPage(1);
+          }}
+        />
+      </div>
       {total > 0 && (
         <TablePagination
           className={styles.pagination}

--- a/src/features/Settings/stats/features/visualization/AiHeatmaps.tsx
+++ b/src/features/Settings/stats/features/visualization/AiHeatmaps.tsx
@@ -137,7 +137,9 @@ const AiHeatmaps = memo<
       <HeatmapStats mobile={mobile} />
       <div style={{ overflowX: 'auto' }}>{content}</div>
       {mobile && (
-        <div style={{ color: '#6b707a', fontSize: 10, marginTop: 4 }}>‹ swipe horizontally ›</div>
+        <div style={{ color: cssVar.colorTextDescription, fontSize: 10, marginTop: 4 }}>
+          {t('heatmaps.swipeHint')}
+        </div>
       )}
     </StatsFormGroup>
   );

--- a/src/features/Settings/stats/features/visualization/AiHeatmaps.tsx
+++ b/src/features/Settings/stats/features/visualization/AiHeatmaps.tsx
@@ -134,8 +134,11 @@ const AiHeatmaps = memo<
       fontSize={16}
       title={t('stats.lastYearActivity')}
     >
-      <HeatmapStats />
-      {content}
+      <HeatmapStats mobile={mobile} />
+      <div style={{ overflowX: 'auto' }}>{content}</div>
+      {mobile && (
+        <div style={{ color: '#6b707a', fontSize: 10, marginTop: 4 }}>‹ swipe horizontally ›</div>
+      )}
     </StatsFormGroup>
   );
 });

--- a/src/features/Settings/stats/features/visualization/HeatmapStats.tsx
+++ b/src/features/Settings/stats/features/visualization/HeatmapStats.tsx
@@ -26,14 +26,7 @@ const formatDuration = (seconds?: number) => {
   return `${s}s`;
 };
 
-/**
- * Token-dimension summary row for the activity heatmap. The peak / streak figures
- * are derived from the daily token-heatmap series (same SWR key as the heatmap,
- * so the request is deduped); the longest-task duration comes from the agent
- * operations' wall-clock time. The cumulative token total lives in the overview
- * cards above, so it is intentionally not repeated here.
- */
-const HeatmapStats = memo(() => {
+const HeatmapStats = memo<{ mobile?: boolean }>(({ mobile }) => {
   const { t } = useTranslation('auth');
 
   const { data, isLoading } = useClientDataSWR(statsKeys.heatmaps(HeatmapType.Tokens), () =>
@@ -61,8 +54,6 @@ const HeatmapStats = memo(() => {
       }
     }
 
-    // Current streak: trailing consecutive active days. The last bucket (today)
-    // may legitimately be 0 because the day isn't over, so it doesn't break it.
     let current = 0;
     for (let i = data.length - 1; i >= 0; i -= 1) {
       if (data[i].count > 0) current += 1;
@@ -86,25 +77,40 @@ const HeatmapStats = memo(() => {
     { label: t('stats.heatmapStats.longestStreak'), value: days(stats.longest) },
   ];
 
+  // 2×2 grid layout
+  const containerStyle = {
+    display: 'grid',
+    gap: '6px 12px',
+    gridTemplateColumns: 'repeat(2, 1fr)',
+  };
+
+  const renderItem = (item: (typeof items)[0]) => (
+    <Flexbox align={'center'} flex={1} gap={4} key={item.label}>
+      <div style={{ fontSize: 20, fontWeight: 'bold' }}>
+        {loading || item.loading ? (
+          <Skeleton.Button active size={'small'} style={{ width: 56 }} />
+        ) : (
+          item.value
+        )}
+      </div>
+      <div style={{ color: cssVar.colorTextDescription, fontSize: 12 }}>{item.label}</div>
+    </Flexbox>
+  );
+
   return (
     <Block paddingBlock={16} paddingInline={8} variant={'outlined'}>
-      <Flexbox horizontal align={'center'} width={'100%'}>
-        {items.map((item, index) => (
-          <Fragment key={item.label}>
-            {index > 0 && <Divider style={{ height: 32, margin: 0 }} type={'vertical'} />}
-            <Flexbox align={'center'} flex={1} gap={4}>
-              <div style={{ fontSize: 20, fontWeight: 'bold' }}>
-                {loading || item.loading ? (
-                  <Skeleton.Button active size={'small'} style={{ width: 56 }} />
-                ) : (
-                  item.value
-                )}
-              </div>
-              <div style={{ color: cssVar.colorTextDescription, fontSize: 12 }}>{item.label}</div>
-            </Flexbox>
-          </Fragment>
-        ))}
-      </Flexbox>
+      {mobile ? (
+        <div style={containerStyle}>{items.map(renderItem)}</div>
+      ) : (
+        <Flexbox horizontal align={'center'} width={'100%'}>
+          {items.map((item, index) => (
+            <Fragment key={item.label}>
+              {index > 0 && <Divider style={{ height: 32, margin: 0 }} type={'vertical'} />}
+              {renderItem(item)}
+            </Fragment>
+          ))}
+        </Flexbox>
+      )}
     </Block>
   );
 });

--- a/src/features/Settings/stats/index.tsx
+++ b/src/features/Settings/stats/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FormGroup, Grid, Icon } from '@lobehub/ui';
+import { Flexbox, FormGroup, Icon } from '@lobehub/ui';
 import { Tabs } from '@lobehub/ui/base-ui';
 import { ProviderIcon } from '@lobehub/ui/icons';
 import { type DatePickerProps } from 'antd';
@@ -30,23 +30,10 @@ import { AiHeatmaps } from './features/visualization';
 import { GroupBy, type UserDisplayResolver } from './types';
 
 interface StatsSettingProps {
-  /**
-   * Enable the "By User" group-by dimension in the Usage section. Only
-   * meaningful when multiple users contribute to the data (i.e. workspace
-   * mode). Combine with `resolveUser` to render names instead of opaque IDs.
-   */
   enableUserDimension?: boolean;
-  /**
-   * Replace the personal Welcome banner (uses user nickname / registration
-   * date) with a custom node. Pass `false` to drop the banner entirely.
-   * When set (non-undefined), the personal ShareButton is also hidden because
-   * the share link embeds user-identity context.
-   */
   headerNode?: ReactNode | false;
   mobile?: boolean;
-  /** Resolve userId → display info. Required when `enableUserDimension` is true. */
   resolveUser?: UserDisplayResolver;
-  /** Render the standard personal-settings title and divider. */
   showSettingHeader?: boolean;
 }
 
@@ -70,7 +57,6 @@ const StatsSetting = memo<StatsSettingProps>(
     }, [dateStrings]);
 
     const handleDateChange: DatePickerProps['onChange'] = (dates, dateStrings) => {
-      // Handle both single date and array
       const actualDate = Array.isArray(dates) ? dates[0] : dates;
       if (actualDate) {
         setDateRange(actualDate);
@@ -78,6 +64,53 @@ const StatsSetting = memo<StatsSettingProps>(
       if (typeof dateStrings === 'string') {
         setDateStrings(dateStrings);
       }
+    };
+
+    const usageToolbar = (
+      <Flexbox horizontal gap={8} style={{ flexWrap: 'wrap' }}>
+        <DatePicker picker="month" value={dateRange} onChange={handleDateChange} />
+        <Tabs
+          activeKey={groupBy}
+          style={{ marginLeft: 8 }}
+          items={[
+            {
+              icon: <Icon icon={Brain} />,
+              key: GroupBy.Model,
+              label: t('usage.welcome.model'),
+            },
+            {
+              icon: <Icon icon={ProviderIcon} />,
+              key: GroupBy.Provider,
+              label: t('usage.welcome.provider'),
+            },
+            ...(enableUserDimension
+              ? [
+                  {
+                    icon: <Icon icon={UserIcon} />,
+                    key: GroupBy.User,
+                    label: t('usage.welcome.user'),
+                  },
+                ]
+              : []),
+          ]}
+          onChange={(key) => setGroupBy(key as GroupBy)}
+        />
+      </Flexbox>
+    );
+
+    // 2×2 CSS grid for stat cards (matches mockup)
+    const statGridStyle: React.CSSProperties = {
+      display: 'grid',
+      gap: 8,
+      gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+    };
+
+    // Rankings container: full-width vertical layout
+    const rankingsStyle: React.CSSProperties = {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 16,
+      width: '100%',
     };
 
     return (
@@ -97,66 +130,48 @@ const StatsSetting = memo<StatsSettingProps>(
             )
           }
         >
-          <Grid gap={8} maxItemWidth={150} rows={4}>
+          <div style={statGridStyle}>
             <TotalAssistants mobile={mobile} />
             <TotalTopics mobile={mobile} />
             <TotalMessages mobile={mobile} />
             <TotalTokens />
-          </Grid>
+          </div>
           <Divider dashed />
           <AiHeatmaps mobile={mobile} />
           <Divider dashed />
-          <Grid gap={16} rows={3} style={{ paddingBottom: 12 }}>
+          <div style={rankingsStyle}>
             <ModelsRank />
             <AssistantsRank mobile={mobile} />
             <TopicsRank mobile={mobile} />
-          </Grid>
+          </div>
         </FormGroup>
         <FormGroup
           collapsible={false}
           gap={16}
-          title={t('tab.usage')}
           variant={'filled'}
-          extra={
-            <>
-              <DatePicker picker="month" value={dateRange} onChange={handleDateChange} />
-              <Tabs
-                activeKey={groupBy}
-                style={{ marginLeft: 8 }}
-                items={[
-                  {
-                    icon: <Icon icon={Brain} />,
-                    key: GroupBy.Model,
-                    label: t('usage.welcome.model'),
-                  },
-                  {
-                    icon: <Icon icon={ProviderIcon} />,
-                    key: GroupBy.Provider,
-                    label: t('usage.welcome.provider'),
-                  },
-                  ...(enableUserDimension
-                    ? [
-                        {
-                          icon: <Icon icon={UserIcon} />,
-                          key: GroupBy.User,
-                          label: t('usage.welcome.user'),
-                        },
-                      ]
-                    : []),
-                ]}
-                onChange={(key) => setGroupBy(key as GroupBy)}
-              />
-            </>
+          title={
+            <Flexbox horizontal align={'center'} gap={8}>
+              <span>{t('tab.usage')}</span>
+              <span
+                style={{
+                  background: 'rgba(255,255,255,0.06)',
+                  borderRadius: 8,
+                  fontSize: 11,
+                  padding: '2px 8px',
+                }}
+              >
+                {dateRange.format('YYYY-MM')}
+              </span>
+            </Flexbox>
           }
-          styles={{
-            title: { lineHeight: '35px' },
-          }}
         >
+          {usageToolbar}
           <AsyncBoundary data={data} error={error} errorVariant={'block'} onRetry={() => mutate()}>
             <UsageCards
               data={data}
               groupBy={groupBy}
               isLoading={isLoading}
+              mobile={mobile}
               resolveUser={resolveUser}
             />
             <Divider />


### PR DESCRIPTION
## Summary

Fixes the mobile layout deformation on /settings/stats at ~375-430px viewport widths. The page had several issues: stat cards collapsed to a single narrow column, section titles letter-stacked vertically, usage cards squeezed three-across with truncated labels, heatmap and usage table overflowed without scroll, and heatmap stats overlapped.

## Changes (6 files)

- StatsFormGroup.tsx: Replace flex: 1 + minWidth: 0 with flex: 0 1 auto to prevent title container collapsing to zero width (root cause of letter-stacking)
- index.tsx: Replace single-column stat cards with 2x2 CSS grid (grid-template-columns: repeat(2, minmax(0, 1fr))), stack rankings vertically, add month date chip next to Usage title, apply layouts unconditionally on all viewports
- UsageCards/index.tsx: Stack cards vertically (horizontal={false}) for full-width rows instead of squeezing three cards into one row
- HeatmapStats.tsx: Use 2x2 CSS grid for the four stat items (Peak Daily Tokens, Longest Task, Current Streak, Longest Streak)
- AiHeatmaps.tsx: Add horizontal scroll container for heatmap, add swipe hint
- UsageTable.tsx: Add horizontal scroll container plus flex-wrap pagination

## Related

Partial fix for upstream issue #17696 (merged Jul 2026 style pass did not fix mobile).
