### PR TITLE
fix(mobile): list agents on mobile home instead of legacy sessions

### DIFF
--- a/src/features/MobileHome/Layout/SessionHeader.tsx
+++ b/src/features/MobileHome/Layout/SessionHeader.tsx
@@ -7,15 +7,18 @@ import { memo } from 'react';
 import { useNavigate } from 'react-router';
 
 import { ProductLogo } from '@/components/Branding';
+import { AGENT_CHAT_URL } from '@/const/index';
 import { MOBILE_HEADER_ICON_SIZE } from '@/const/layoutTokens';
 import UserAvatar from '@/features/User/UserAvatar';
-import { useSessionStore } from '@/store/session';
+import { useAgentStore } from '@/store/agent';
+import { useHomeStore } from '@/store/home';
 import { mobileHeaderSticky } from '@/styles/mobileHeader';
 
 import { styles } from './SessionHeader/style';
 
 const Header = memo(() => {
-  const [createSession] = useSessionStore((s) => [s.createSession]);
+  const createAgent = useAgentStore((s) => s.createAgent);
+  const refreshAgentList = useHomeStore((s) => s.refreshAgentList);
   const navigate = useNavigate();
 
   return (
@@ -31,7 +34,13 @@ const Header = memo(() => {
         <ActionIcon
           icon={MessageSquarePlus}
           size={MOBILE_HEADER_ICON_SIZE}
-          onClick={() => createSession()}
+          onClick={async () => {
+            const result = await createAgent({});
+            await refreshAgentList();
+            if (result?.agentId) {
+              navigate(AGENT_CHAT_URL(result.agentId, true));
+            }
+          }}
         />
       }
     />

--- a/src/features/MobileHome/Layout/SessionSearchBar.tsx
+++ b/src/features/MobileHome/Layout/SessionSearchBar.tsx
@@ -6,7 +6,7 @@ import { type ChangeEvent } from 'react';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useSessionStore } from '@/store/session';
+import { useHomeStore } from '@/store/home';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/selectors';
 
@@ -15,19 +15,19 @@ const SessionSearchBar = memo<{ mobile?: boolean }>(({ mobile }) => {
   const isLoaded = useUserStore((s) => s.isLoaded);
   const hotkey = useUserStore(settingsSelectors.getHotkeyById(HotkeyEnum.Search));
 
-  const [keywords, useSearchSessions, updateSearchKeywords] = useSessionStore((s) => [
-    s.sessionSearchKeywords,
-    s.useSearchSessions,
-    s.updateSearchKeywords,
+  const [keywords, useSearchAgents, updateAgentSearchKeywords] = useHomeStore((s) => [
+    s.agentSearchKeywords,
+    s.useSearchAgents,
+    s.updateAgentSearchKeywords,
   ]);
 
-  const { isValidating } = useSearchSessions(keywords);
+  const { isValidating } = useSearchAgents(keywords);
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      updateSearchKeywords(e.target.value);
+      updateAgentSearchKeywords(e.target.value);
     },
-    [updateSearchKeywords],
+    [updateAgentSearchKeywords],
   );
 
   return (
@@ -38,7 +38,7 @@ const SessionSearchBar = memo<{ mobile?: boolean }>(({ mobile }) => {
       placeholder={t('searchAgentPlaceholder')}
       shortKey={hotkey}
       spotlight={!mobile}
-      value={keywords}
+      value={keywords || ''}
       variant={'filled'}
       onChange={handleChange}
     />

--- a/src/features/MobileHome/SessionListContent/CollapseGroup/Actions.tsx
+++ b/src/features/MobileHome/SessionListContent/CollapseGroup/Actions.tsx
@@ -8,8 +8,9 @@ import { useTranslation } from 'react-i18next';
 
 import { MemberSelectionModal } from '@/components/MemberSelectionModal';
 import { useIsMobile } from '@/hooks/useIsMobile';
+import { useAgentStore } from '@/store/agent';
 import { useAgentGroupStore } from '@/store/agentGroup';
-import { useSessionStore } from '@/store/session';
+import { useHomeStore } from '@/store/home';
 
 const styles = createStaticStyles(({ css }) => ({
   modalRoot: css`
@@ -35,10 +36,10 @@ const Actions = memo<ActionsProps>(
     const [isGroupModalOpen, setIsGroupModalOpen] = useState(false);
     const [isCreatingGroup, setIsCreatingGroup] = useState(false);
 
-    const [createSession, removeSessionGroup] = useSessionStore((s) => [
-      s.createSession,
-      s.removeSessionGroup,
-    ]);
+    const createAgent = useAgentStore((s) => s.createAgent);
+    const removeGroup = useHomeStore((s) => s.removeGroup);
+    const refreshAgentList = useHomeStore((s) => s.refreshAgentList);
+    const pinAgent = useHomeStore((s) => s.pinAgent);
 
     const [createGroup] = useAgentGroupStore((s) => [s.createGroup]);
 
@@ -60,7 +61,11 @@ const Actions = memo<ActionsProps>(
         domEvent.stopPropagation();
         const creatingToast = toast.loading(t('sessionGroup.creatingAgent'));
 
-        await createSession({ group: id, pinned: isPinned });
+        const result = await createAgent({ groupId: id });
+        if (isPinned && result?.agentId) {
+          await pinAgent(result.agentId, true);
+        }
+        await refreshAgentList();
 
         creatingToast.close();
         toast.success(t('sessionGroup.createAgentSuccess'));
@@ -145,7 +150,7 @@ const Actions = memo<ActionsProps>(
               okText: t('delete', { ns: 'common' }),
               onOk: async () => {
                 if (!id) return;
-                await removeSessionGroup(id);
+                await removeGroup(id);
               },
               title: t('delete', { ns: 'common' }),
             });

--- a/src/features/MobileHome/SessionListContent/DefaultMode.tsx
+++ b/src/features/MobileHome/SessionListContent/DefaultMode.tsx
@@ -3,6 +3,8 @@ import isEqual from 'fast-deep-equal';
 import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { type SidebarAgentItem } from '@lobechat/types';
+
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
 import { useFetchAgentList } from '@/hooks/useFetchAgentList';
 import { useGlobalStore } from '@/store/global';
@@ -33,6 +35,16 @@ const DefaultMode = memo(() => {
   const agentGroups = useHomeStore(homeAgentListSelectors.agentGroups, isEqual);
   const ungroupedAgents = useHomeStore(homeAgentListSelectors.ungroupedAgents, isEqual);
 
+  // Skip chat-group rows on mobile (no /group/:id route). The sidebar API can
+  // return `type: 'group'` items in any bucket; they must not render as agents
+  // or expose agent-only actions (e.g. removeAgent).
+  const onlyAgents = (items: SidebarAgentItem[] | undefined) =>
+    (items ?? []).filter((item) => item.type === 'agent');
+
+  const visiblePinnedAgents = onlyAgents(pinnedAgents);
+  const visibleAgentGroups = agentGroups.map((group) => ({ ...group, items: onlyAgents(group.items) }));
+  const visibleUngroupedAgents = onlyAgents(ungroupedAgents);
+
   const activeWorkspaceId = useActiveWorkspaceId();
   const sessionGroupKeys = useGlobalStore(
     systemStatusSelectors.sessionGroupKeys(activeWorkspaceId),
@@ -42,14 +54,14 @@ const DefaultMode = memo(() => {
   const items = useMemo(
     () =>
       [
-        pinnedAgents &&
-          pinnedAgents.length > 0 && {
-            children: <AgentList dataSource={pinnedAgents} />,
+        visiblePinnedAgents &&
+          visiblePinnedAgents.length > 0 && {
+            children: <AgentList dataSource={visiblePinnedAgents} />,
             extra: <Actions isPinned openConfigModal={() => setConfigGroupModalOpen(true)} />,
             key: 'pinned',
             label: t('pin'),
           },
-        ...agentGroups.map(({ id, name, items: children }) => ({
+        ...visibleAgentGroups.map(({ id, name, items: children }) => ({
           children: <AgentList dataSource={children} groupId={id} />,
           extra: (
             <Actions
@@ -63,13 +75,13 @@ const DefaultMode = memo(() => {
           label: name,
         })),
         {
-          children: <AgentList dataSource={ungroupedAgents || []} />,
+          children: <AgentList dataSource={visibleUngroupedAgents} />,
           extra: <Actions openConfigModal={() => setConfigGroupModalOpen(true)} />,
           key: 'default',
           label: t('defaultList'),
         },
       ].filter(Boolean) as CollapseProps['items'],
-    [t, agentGroups, pinnedAgents, ungroupedAgents],
+    [t, visibleAgentGroups, visiblePinnedAgents, visibleUngroupedAgents],
   );
 
   // CRITICAL: defer rendering behind serverConfigInit to prevent antd-style

--- a/src/features/MobileHome/SessionListContent/DefaultMode.tsx
+++ b/src/features/MobileHome/SessionListContent/DefaultMode.tsx
@@ -4,20 +4,17 @@ import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
-import { useFetchSessions } from '@/hooks/useFetchSessions';
+import { useFetchAgentList } from '@/hooks/useFetchAgentList';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
+import { useHomeStore } from '@/store/home';
+import { homeAgentListSelectors } from '@/store/home/selectors';
 import { useServerConfigStore } from '@/store/serverConfig';
-import { serverConfigSelectors } from '@/store/serverConfig/selectors';
-import { useSessionStore } from '@/store/session';
-import { sessionSelectors } from '@/store/session/selectors';
-import { type LobeAgentSession, type LobeSessions } from '@/types/session';
-import { LobeSessionType, SessionDefaultGroup } from '@/types/session';
 
 import CollapseGroup from './CollapseGroup';
 import Actions from './CollapseGroup/Actions';
 import Inbox from './Inbox';
-import SessionList from './List';
+import AgentList from './List';
 import ConfigGroupModal from './Modals/ConfigGroupModal';
 import { openRenameGroupModal } from './Modals/RenameGroupModal';
 
@@ -26,35 +23,15 @@ const DefaultMode = memo(() => {
 
   const [configGroupModalOpen, setConfigGroupModalOpen] = useState(false);
 
-  useFetchSessions();
+  // ALL hooks called unconditionally (Rules of Hooks)
+  useFetchAgentList();
 
-  const isMobile = useServerConfigStore(serverConfigSelectors.isMobile);
+  const serverConfigInit = useServerConfigStore((s) => s.serverConfigInit);
+  const isAgentListInit = useHomeStore(homeAgentListSelectors.isAgentListInit);
 
-  const defaultSessions = useSessionStore(sessionSelectors.defaultSessions, isEqual);
-  const customSessionGroups = useSessionStore(sessionSelectors.customSessionGroups, isEqual);
-  const pinnedSessions = useSessionStore(sessionSelectors.pinnedSessions, isEqual);
-
-  const shouldHideSession = (session: LobeSessions[0]) =>
-    !isMobile &&
-    session.type === LobeSessionType.Agent &&
-    Boolean((session as LobeAgentSession).config?.virtual);
-
-  const filterSessionsForView = (sessions: LobeSessions): LobeSessions => {
-    const filteredForDevice = isMobile
-      ? sessions.filter((session) => session.type !== LobeSessionType.Group)
-      : sessions;
-
-    if (isMobile) return filteredForDevice;
-
-    return filteredForDevice.filter((session) => !shouldHideSession(session));
-  };
-
-  const filteredDefaultSessions = filterSessionsForView(defaultSessions);
-  const filteredPinnedSessions = filterSessionsForView(pinnedSessions);
-  const filteredCustomSessionGroups = customSessionGroups?.map((group) => ({
-    ...group,
-    children: filterSessionsForView(group.children),
-  }));
+  const pinnedAgents = useHomeStore(homeAgentListSelectors.pinnedAgents, isEqual);
+  const agentGroups = useHomeStore(homeAgentListSelectors.agentGroups, isEqual);
+  const ungroupedAgents = useHomeStore(homeAgentListSelectors.ungroupedAgents, isEqual);
 
   const activeWorkspaceId = useActiveWorkspaceId();
   const sessionGroupKeys = useGlobalStore(
@@ -65,15 +42,15 @@ const DefaultMode = memo(() => {
   const items = useMemo(
     () =>
       [
-        filteredPinnedSessions &&
-          filteredPinnedSessions.length > 0 && {
-            children: <SessionList dataSource={filteredPinnedSessions} />,
+        pinnedAgents &&
+          pinnedAgents.length > 0 && {
+            children: <AgentList dataSource={pinnedAgents} />,
             extra: <Actions isPinned openConfigModal={() => setConfigGroupModalOpen(true)} />,
-            key: SessionDefaultGroup.Pinned,
+            key: 'pinned',
             label: t('pin'),
           },
-        ...(filteredCustomSessionGroups || []).map(({ id, name, children }) => ({
-          children: <SessionList dataSource={children} groupId={id} />,
+        ...agentGroups.map(({ id, name, items: children }) => ({
+          children: <AgentList dataSource={children} groupId={id} />,
           extra: (
             <Actions
               isCustomGroup
@@ -86,14 +63,20 @@ const DefaultMode = memo(() => {
           label: name,
         })),
         {
-          children: <SessionList dataSource={filteredDefaultSessions || []} />,
+          children: <AgentList dataSource={ungroupedAgents || []} />,
           extra: <Actions openConfigModal={() => setConfigGroupModalOpen(true)} />,
-          key: SessionDefaultGroup.Default,
+          key: 'default',
           label: t('defaultList'),
         },
       ].filter(Boolean) as CollapseProps['items'],
-    [t, filteredCustomSessionGroups, filteredPinnedSessions, filteredDefaultSessions],
+    [t, agentGroups, pinnedAgents, ungroupedAgents],
   );
+
+  // CRITICAL: defer rendering behind serverConfigInit to prevent antd-style
+  // theme engine crash ('.status' TypeError when components mount before init)
+  if (!serverConfigInit || !isAgentListInit) {
+    return <Inbox />;
+  }
 
   return (
     <>
@@ -114,6 +97,6 @@ const DefaultMode = memo(() => {
   );
 });
 
-DefaultMode.displayName = 'SessionDefaultMode';
+DefaultMode.displayName = 'AgentDefaultMode';
 
 export default DefaultMode;

--- a/src/features/MobileHome/SessionListContent/List/AddButton.tsx
+++ b/src/features/MobileHome/SessionListContent/List/AddButton.tsx
@@ -1,33 +1,39 @@
 import { Flexbox } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { Plus } from 'lucide-react';
-import { memo } from 'react';
+import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useActionSWR } from '@/libs/swr';
-import { sessionKeys } from '@/libs/swr/keys';
+import { useAgentStore } from '@/store/agent';
+import { useHomeStore } from '@/store/home';
 import { useServerConfigStore } from '@/store/serverConfig';
-import { useSessionStore } from '@/store/session';
 
 const AddButton = memo<{ groupId?: string }>(({ groupId }) => {
   const { t } = useTranslation('chat');
-  const createSession = useSessionStore((s) => s.createSession);
+  const createAgent = useAgentStore((s) => s.createAgent);
+  const refreshAgentList = useHomeStore((s) => s.refreshAgentList);
   const mobile = useServerConfigStore((s) => s.isMobile);
-  const { mutate, isValidating } = useActionSWR(sessionKeys.createSession(groupId), () => {
-    return createSession({ group: groupId });
-  });
+  const [loading, setLoading] = useState(false);
 
   return (
     <Flexbox flex={1} padding={mobile ? 16 : 0}>
       <Button
         block
         icon={Plus}
-        loading={isValidating}
+        loading={loading}
         type={'fill'}
         style={{
           marginTop: 8,
         }}
-        onClick={() => mutate()}
+        onClick={async () => {
+          setLoading(true);
+          try {
+            await createAgent({ groupId });
+            await refreshAgentList();
+          } finally {
+            setLoading(false);
+          }
+        }}
       >
         {t('newAgent')}
       </Button>

--- a/src/features/MobileHome/SessionListContent/List/Item/Actions.tsx
+++ b/src/features/MobileHome/SessionListContent/List/Item/Actions.tsx
@@ -20,47 +20,36 @@ import { isDesktop } from '@/const/index';
 import { usePermission } from '@/hooks/usePermission';
 import { useGlobalStore } from '@/store/global';
 import { useHomeStore } from '@/store/home';
-import { useSessionStore } from '@/store/session';
-import { sessionHelpers } from '@/store/session/helpers';
-import { sessionGroupSelectors, sessionSelectors } from '@/store/session/selectors';
-import { SessionDefaultGroup } from '@/types/index';
+import { homeAgentListSelectors } from '@/store/home/selectors';
 import { isForbiddenError, isOwnerOnlyForbiddenError } from '@/utils/forbiddenError';
 
 interface ActionProps {
   group: string | undefined;
   id: string;
   openCreateGroupModal: () => void;
-  parentType: 'agent' | 'group';
   setOpen: (open: boolean) => void;
 }
 
-const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType, setOpen }) => {
+const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, setOpen }) => {
   const { t } = useTranslation('chat');
   const { allowed: canCreate, reason: createReason } = usePermission('create_content');
   const { allowed: canEdit, reason: editReason } = usePermission('edit_own_content');
 
   const openAgentInNewWindow = useGlobalStore((s) => s.openAgentInNewWindow);
 
-  const sessionCustomGroups = useSessionStore(sessionGroupSelectors.sessionGroupItems, isEqual);
-  const [pin, removeSession, pinSession, sessionType, duplicateSession, updateSessionGroup] =
-    useSessionStore((s) => {
-      const session = sessionSelectors.getSessionById(id)(s);
-      return [
-        sessionHelpers.getSessionPinned(session),
-        s.removeSession,
-        s.pinSession,
-        session.type,
-        s.duplicateSession,
-        s.updateSessionGroupId,
-      ];
-    });
+  // Reuse agentGroups for the move-to-group dropdown
+  const customAgentGroups = useHomeStore(homeAgentListSelectors.agentGroups, isEqual);
 
-  const [pinAgentGroup, removeAgentGroup] = useHomeStore((s) => [
-    s.pinAgentGroup,
-    s.removeAgentGroup,
+  const [pinAgent, duplicateAgent, removeAgent, updateAgentGroup] = useHomeStore((s) => [
+    s.pinAgent,
+    s.duplicateAgent,
+    s.removeAgent,
+    s.updateAgentGroup,
   ]);
 
-  const isDefault = group === SessionDefaultGroup.Default;
+  const item = useHomeStore((s) => homeAgentListSelectors.getAgentById(id)(s));
+  const pinned = item?.pinned ?? false;
+  const isDefault = group === undefined || group === 'default';
 
   const items = useMemo(
     () =>
@@ -68,17 +57,13 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType
         [
           {
             disabled: !canEdit,
-            icon: <Icon icon={pin ? PinOff : Pin} />,
+            icon: <Icon icon={pinned ? PinOff : Pin} />,
             key: 'pin',
-            label: t(pin ? 'pinOff' : 'pin'),
+            label: t(pinned ? 'pinOff' : 'pin'),
             title: editReason,
             onClick: () => {
               if (!canEdit) return;
-              if (parentType === 'group') {
-                pinAgentGroup(id, !pin);
-              } else {
-                pinSession(id, !pin);
-              }
+              pinAgent(id, !pinned);
             },
           },
           {
@@ -90,8 +75,7 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType
             onClick: ({ domEvent }) => {
               domEvent.stopPropagation();
               if (!canCreate) return;
-
-              duplicateSession(id);
+              duplicateAgent(id);
             },
           },
           ...(isDesktop
@@ -112,7 +96,7 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType
           },
           {
             children: [
-              ...sessionCustomGroups.map(({ id: groupId, name }) => ({
+              ...customAgentGroups.map(({ id: groupId, name }) => ({
                 disabled: !canEdit,
                 icon: group === groupId ? <Icon icon={Check} /> : <div />,
                 key: groupId,
@@ -120,7 +104,7 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType
                 title: editReason,
                 onClick: () => {
                   if (!canEdit) return;
-                  updateSessionGroup(id, groupId);
+                  updateAgentGroup(id, groupId);
                 },
               })),
               {
@@ -131,7 +115,7 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType
                 title: editReason,
                 onClick: () => {
                   if (!canEdit) return;
-                  updateSessionGroup(id, SessionDefaultGroup.Default);
+                  updateAgentGroup(id, null);
                 },
               },
               {
@@ -173,13 +157,8 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType
                 okButtonProps: { danger: true },
                 onOk: async () => {
                   try {
-                    if (parentType === 'group') {
-                      await removeAgentGroup(id);
-                      toast.success(t('confirmRemoveGroupSuccess'));
-                    } else {
-                      await removeSession(id);
-                      toast.success(t('confirmRemoveSessionSuccess'));
-                    }
+                    await removeAgent(id);
+                    toast.success(t('confirmRemoveSessionSuccess'));
                   } catch (error) {
                     toast.error(
                       isOwnerOnlyForbiddenError(error)
@@ -190,10 +169,7 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType
                     );
                   }
                 },
-                title:
-                  sessionType === 'group'
-                    ? t('confirmRemoveChatGroupItemAlert')
-                    : t('confirmRemoveSessionItemAlert'),
+                title: t('confirmRemoveSessionItemAlert'),
               });
             },
           },
@@ -203,23 +179,19 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType
       canCreate,
       canEdit,
       createReason,
-      duplicateSession,
+      customAgentGroups,
+      duplicateAgent,
       editReason,
       group,
       id,
       isDefault,
       openAgentInNewWindow,
       openCreateGroupModal,
-      parentType,
-      pin,
-      pinAgentGroup,
-      pinSession,
-      removeAgentGroup,
-      removeSession,
-      sessionCustomGroups,
-      sessionType,
+      pinAgent,
+      pinned,
+      removeAgent,
       t,
-      updateSessionGroup,
+      updateAgentGroup,
     ],
   );
 

--- a/src/features/MobileHome/SessionListContent/List/Item/index.tsx
+++ b/src/features/MobileHome/SessionListContent/List/Item/index.tsx
@@ -1,59 +1,48 @@
-import { ModelTag } from '@lobehub/icons';
-import { Flexbox } from '@lobehub/ui';
 import React, { memo, useMemo, useState } from 'react';
 import { shallow } from 'zustand/shallow';
 
-import { DEFAULT_AVATAR } from '@/const/meta';
-import { INBOX_SESSION_ID } from '@/const/session';
 import { isDesktop } from '@/const/version';
 import { useChatStore } from '@/store/chat';
 import { operationSelectors } from '@/store/chat/selectors';
 import { useGlobalStore } from '@/store/global';
-import { useSessionStore } from '@/store/session';
-import { sessionHelpers } from '@/store/session/helpers';
-import { sessionMetaSelectors, sessionSelectors } from '@/store/session/selectors';
+import { useHomeStore } from '@/store/home';
+import { homeAgentListSelectors } from '@/store/home/selectors';
 import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
-import { type LobeGroupSession } from '@/types/session';
 
 import ListItem from '../../ListItem';
 import { openCreateGroupModal } from '../../Modals/CreateGroupModal';
 import Actions from './Actions';
 
-interface SessionItemProps {
+interface AgentItemProps {
+  groupId?: string;
   id: string;
 }
 
-const SessionItem = memo<SessionItemProps>(({ id }) => {
+const AgentItem = memo<AgentItemProps>(({ groupId, id }) => {
   const [open, setOpen] = useState(false);
 
   const openAgentInNewWindow = useGlobalStore((s) => s.openAgentInNewWindow);
 
-  const [active] = useSessionStore((s) => [s.activeId === id]);
-  const [loading] = useChatStore((s) => [
-    operationSelectors.isAgentRuntimeVisiblyRunning(s) && id === s.activeAgentId,
-  ]);
+  const active = useChatStore((s) => s.activeAgentId === id);
+  const loading = useChatStore(
+    (s) => operationSelectors.isAgentRuntimeVisiblyRunning(s) && id === s.activeAgentId,
+  );
 
-  const [pin, title, avatar, avatarBackground, updateAt, members, model, group, sessionType] =
-    useSessionStore((s) => {
-      const session = sessionSelectors.getSessionById(id)(s);
-      const meta = session.meta;
+  const item = useHomeStore((s) => homeAgentListSelectors.getAgentById(id)(s));
 
-      return [
-        sessionHelpers.getSessionPinned(session),
-        sessionMetaSelectors.getTitle(meta),
-        sessionMetaSelectors.getAvatar(meta),
-        meta.backgroundColor,
-        session?.updatedAt,
-        (session as LobeGroupSession).members,
-        session.type === 'agent' ? (session as any).model : undefined,
-        session?.group,
-        session.type,
-      ];
-    });
+  const pin = item?.pinned ?? false;
+  const title = item?.title ?? 'Untitled';
+  const avatar = item?.avatar ?? undefined;
+  const avatarBackground = item?.backgroundColor ?? undefined;
+  const updateAt = item?.updatedAt;
 
-  // Only hide the model tag for the inbox session itself (Lobe AI)
-  const showModel = sessionType === 'agent' && model && id !== INBOX_SESSION_ID;
+  const currentUser = useUserStore((s) => ({
+    avatar: userProfileSelectors.userAvatar(s),
+    name: userProfileSelectors.displayUserName(s) || userProfileSelectors.nickName(s) || 'You',
+  }));
+
+  const sessionAvatar = avatar;
 
   const handleDoubleClick = () => {
     if (isDesktop) {
@@ -62,12 +51,10 @@ const SessionItem = memo<SessionItemProps>(({ id }) => {
   };
 
   const handleDragStart = (e: React.DragEvent) => {
-    // Set drag data to identify the session being dragged
     e.dataTransfer.setData('text/plain', id);
   };
 
   const handleDragEnd = (e: React.DragEvent) => {
-    // If drag ends without being dropped in a valid target, open in new window
     if (isDesktop && e.dataTransfer.dropEffect === 'none') {
       openAgentInNewWindow(id);
     }
@@ -76,51 +63,20 @@ const SessionItem = memo<SessionItemProps>(({ id }) => {
   const actions = useMemo(
     () => (
       <Actions
-        group={group}
+        group={groupId}
         id={id}
         openCreateGroupModal={() => openCreateGroupModal(id)}
-        parentType={sessionType}
         setOpen={setOpen}
       />
     ),
-    [group, id],
+    [groupId, id],
   );
-
-  const addon = useMemo(
-    () =>
-      !showModel ? undefined : (
-        <Flexbox horizontal gap={4} style={{ flexWrap: 'wrap' }}>
-          <ModelTag model={model} />
-        </Flexbox>
-      ),
-    [showModel, model],
-  );
-
-  const currentUser = useUserStore((s) => ({
-    avatar: userProfileSelectors.userAvatar(s),
-    name: userProfileSelectors.displayUserName(s) || userProfileSelectors.nickName(s) || 'You',
-  }));
-
-  const sessionAvatar: string | { avatar: string; background?: string }[] =
-    sessionType === 'group'
-      ? [
-          {
-            avatar: currentUser.avatar || DEFAULT_AVATAR,
-            background: undefined,
-          },
-          ...(members?.map((member) => ({
-            avatar: member.avatar || DEFAULT_AVATAR,
-            background: member.backgroundColor || undefined,
-          })) || []),
-        ]
-      : avatar;
 
   return (
     <ListItem
       actions={actions}
       active={active}
-      addon={addon}
-      avatar={sessionAvatar as any} // Fix: Bypass complex intersection type ReactNode & avatar type
+      avatar={sessionAvatar as any}
       avatarBackground={avatarBackground}
       date={updateAt?.valueOf()}
       draggable={isDesktop}
@@ -129,7 +85,7 @@ const SessionItem = memo<SessionItemProps>(({ id }) => {
       pin={pin}
       showAction={open}
       title={title}
-      type={sessionType}
+      type={'agent'}
       styles={{
         container: {
           gap: 12,
@@ -146,4 +102,4 @@ const SessionItem = memo<SessionItemProps>(({ id }) => {
   );
 }, shallow);
 
-export default SessionItem;
+export default AgentItem;

--- a/src/features/MobileHome/SessionListContent/List/Item/index.tsx
+++ b/src/features/MobileHome/SessionListContent/List/Item/index.tsx
@@ -1,5 +1,8 @@
 import React, { memo, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { shallow } from 'zustand/shallow';
+
+import { agentDisplayName } from '@lobechat/types';
 
 import { isDesktop } from '@/const/version';
 import { useChatStore } from '@/store/chat';
@@ -21,6 +24,7 @@ interface AgentItemProps {
 
 const AgentItem = memo<AgentItemProps>(({ groupId, id }) => {
   const [open, setOpen] = useState(false);
+  const { t } = useTranslation('chat');
 
   const openAgentInNewWindow = useGlobalStore((s) => s.openAgentInNewWindow);
 
@@ -32,7 +36,8 @@ const AgentItem = memo<AgentItemProps>(({ groupId, id }) => {
   const item = useHomeStore((s) => homeAgentListSelectors.getAgentById(id)(s));
 
   const pin = item?.pinned ?? false;
-  const title = item?.title ?? 'Untitled';
+  // name wins over title (matches desktop sidebar); i18n fallback for unnamed
+  const title = agentDisplayName(item, t('untitledAgent'));
   const avatar = item?.avatar ?? undefined;
   const avatarBackground = item?.backgroundColor ?? undefined;
   const updateAt = item?.updatedAt;

--- a/src/features/MobileHome/SessionListContent/List/index.tsx
+++ b/src/features/MobileHome/SessionListContent/List/index.tsx
@@ -1,90 +1,49 @@
-import { useAnalytics } from '@lobehub/analytics/react';
 import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 import LazyLoad from 'react-lazy-load';
 import { Link } from 'react-router';
 
 import { AGENT_CHAT_URL } from '@/const/index';
+import { type SidebarAgentItem } from '@/database/repositories/home';
 import { useNavigateToAgent } from '@/hooks/useNavigateToAgent';
 import { useServerConfigStore } from '@/store/serverConfig';
-import { getSessionStoreState, useSessionStore } from '@/store/session';
-import { sessionGroupSelectors, sessionSelectors } from '@/store/session/selectors';
-import { getUserStoreState } from '@/store/user';
-import { userProfileSelectors } from '@/store/user/selectors';
-import { type LobeSessions } from '@/types/session';
 
-import SkeletonList from '../../SkeletonList';
 import AddButton from './AddButton';
-import SessionItem from './Item';
+import AgentItem from './Item';
 
 const styles = createStaticStyles(
   ({ css }) => css`
     min-height: 70px;
   `,
 );
-interface SessionListProps {
-  dataSource?: LobeSessions;
+
+interface AgentListProps {
+  dataSource?: SidebarAgentItem[];
   groupId?: string;
   showAddButton?: boolean;
 }
-const SessionList = memo<SessionListProps>(({ dataSource, groupId, showAddButton = true }) => {
-  const { analytics } = useAnalytics();
 
-  const isInit = useSessionStore(sessionSelectors.isSessionListInit);
+const AgentList = memo<AgentListProps>(({ dataSource, groupId, showAddButton = true }) => {
   const mobile = useServerConfigStore((s) => s.isMobile);
-
   const navigateToAgent = useNavigateToAgent();
 
   const isEmpty = !dataSource || dataSource.length === 0;
-  return !isInit ? (
-    <SkeletonList />
-  ) : !isEmpty ? (
-    dataSource.map(({ id, ...res }) => (
-      <LazyLoad className={styles} key={id}>
-        <Link
-          aria-label={id}
-          to={AGENT_CHAT_URL((res as any).config?.id, mobile)}
-          onClick={(e) => {
-            e.preventDefault();
-            navigateToAgent((res as any).config?.id);
-
-            // Enhanced analytics tracking
-            if (analytics) {
-              const userStore = getUserStoreState();
-              const sessionStore = getSessionStoreState();
-
-              const userId = userProfileSelectors.userId(userStore);
-              const session = sessionSelectors.getSessionById(id)(sessionStore);
-
-              if (session) {
-                const sessionGroupId = session.group || 'default';
-                const group = sessionGroupSelectors.getGroupById(sessionGroupId)(sessionStore);
-                const groupName =
-                  group?.name || (sessionGroupId === 'default' ? 'Default' : 'Unknown');
-
-                analytics?.track({
-                  name: 'switch_session',
-                  properties: {
-                    assistant_name: session.meta?.title || 'Untitled Agent',
-                    assistant_tags: session.meta?.tags || [],
-                    group_id: sessionGroupId,
-                    group_name: groupName,
-                    session_id: id,
-                    spm: 'homepage.chat.session_list_item.click',
-                    user_id: userId || 'anonymous',
-                  },
-                });
-              }
-            }
-          }}
-        >
-          <SessionItem id={id} />
-        </Link>
-      </LazyLoad>
-    ))
-  ) : (
-    showAddButton && <AddButton groupId={groupId} />
-  );
+  return !isEmpty
+    ? dataSource.map(({ id }) => (
+        <LazyLoad className={styles} key={id}>
+          <Link
+            aria-label={id}
+            to={AGENT_CHAT_URL(id, mobile)}
+            onClick={(e) => {
+              e.preventDefault();
+              navigateToAgent(id);
+            }}
+          >
+            <AgentItem groupId={groupId} id={id} />
+          </Link>
+        </LazyLoad>
+      ))
+    : showAddButton && <AddButton groupId={groupId} />;
 });
 
-export default SessionList;
+export default AgentList;

--- a/src/features/MobileHome/SessionListContent/Modals/ConfigGroupModal/GroupItem.tsx
+++ b/src/features/MobileHome/SessionListContent/Modals/ConfigGroupModal/GroupItem.tsx
@@ -5,8 +5,7 @@ import { PencilLine, Trash } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useSessionStore } from '@/store/session';
-import { type SessionGroupItem } from '@/types/session';
+import { useHomeStore } from '@/store/home';
 
 const styles = createStaticStyles(({ css }) => ({
   content: css`
@@ -22,18 +21,17 @@ const styles = createStaticStyles(({ css }) => ({
   `,
 }));
 
-interface GroupItemProps extends SessionGroupItem {
+interface GroupItemProps {
   disabled?: boolean;
+  id: string;
+  name: string;
 }
 
 const GroupItem = memo<GroupItemProps>(({ id, name, disabled = false }) => {
   const { t } = useTranslation(['chat', 'common']);
 
   const [editing, setEditing] = useState(false);
-  const [updateSessionGroupName, removeSessionGroup] = useSessionStore((s) => [
-    s.updateSessionGroupName,
-    s.removeSessionGroup,
-  ]);
+  const [updateGroupName, removeGroup] = useHomeStore((s) => [s.updateGroupName, s.removeGroup]);
 
   return (
     <>
@@ -64,7 +62,7 @@ const GroupItem = memo<GroupItemProps>(({ id, name, disabled = false }) => {
                 },
                 okText: t('delete', { ns: 'common' }),
                 onOk: async () => {
-                  await removeSessionGroup(id);
+                  await removeGroup(id);
                 },
                 title: t('delete', { ns: 'common' }),
               });
@@ -85,7 +83,7 @@ const GroupItem = memo<GroupItemProps>(({ id, name, disabled = false }) => {
               if (input.length === 0 || input.length > 20 || input.trim() === '')
                 return toast.warning(t('sessionGroup.tooLong'));
 
-              await updateSessionGroupName(id, input);
+              await updateGroupName(id, input);
               toast.success(t('sessionGroup.renameSuccess'));
             }
             setEditing(false);

--- a/src/features/MobileHome/SessionListContent/Modals/ConfigGroupModal/index.tsx
+++ b/src/features/MobileHome/SessionListContent/Modals/ConfigGroupModal/index.tsx
@@ -9,9 +9,9 @@ import { useTranslation } from 'react-i18next';
 
 import ImperativeModal from '@/components/ImperativeModal';
 import { usePermission } from '@/hooks/usePermission';
-import { useSessionStore } from '@/store/session';
-import { sessionGroupSelectors } from '@/store/session/selectors';
-import { type SessionGroupItem } from '@/types/session';
+import { useHomeStore } from '@/store/home';
+import { homeAgentListSelectors } from '@/store/home/selectors';
+import { type SessionGroupItemBase } from '@/types/session';
 
 import GroupItem from './GroupItem';
 
@@ -32,12 +32,15 @@ const ConfigGroupModal = memo<ModalProps>(({ open, onCancel }) => {
   const { t } = useTranslation('chat');
   const { allowed: canCreate, reason: createReason } = usePermission('create_content');
   const { allowed: canEdit } = usePermission('edit_own_content');
-  const sessionGroupItems = useSessionStore(sessionGroupSelectors.sessionGroupItems, isEqual);
-  const [addSessionGroup, updateSessionGroupSort] = useSessionStore((s) => [
-    s.addSessionGroup,
-    s.updateSessionGroupSort,
-  ]);
+  const agentGroups = useHomeStore(homeAgentListSelectors.agentGroups, isEqual);
+  const [addGroup, updateGroupSort] = useHomeStore((s) => [s.addGroup, s.updateGroupSort]);
   const [loading, setLoading] = useState(false);
+
+  const items: SessionGroupItemBase[] = agentGroups.map((g) => ({
+    children: g.items,
+    id: g.id,
+    name: g.name,
+  }));
 
   return (
     <ImperativeModal
@@ -50,8 +53,8 @@ const ConfigGroupModal = memo<ModalProps>(({ open, onCancel }) => {
     >
       <Flexbox>
         <SortableList
-          items={sessionGroupItems}
-          renderItem={(item: SessionGroupItem) => (
+          items={items}
+          renderItem={(item: SessionGroupItemBase) => (
             <SortableList.Item
               horizontal
               align={'center'}
@@ -63,9 +66,9 @@ const ConfigGroupModal = memo<ModalProps>(({ open, onCancel }) => {
               <GroupItem {...item} disabled={!canEdit} />
             </SortableList.Item>
           )}
-          onChange={(items: SessionGroupItem[]) => {
+          onChange={(newItems: SessionGroupItemBase[]) => {
             if (!canEdit) return;
-            updateSessionGroupSort(items);
+            updateGroupSort(newItems);
           }}
         />
         <Button
@@ -77,7 +80,7 @@ const ConfigGroupModal = memo<ModalProps>(({ open, onCancel }) => {
           onClick={async () => {
             if (!canCreate) return;
             setLoading(true);
-            await addSessionGroup(t('sessionGroup.newGroup'));
+            await addGroup(t('sessionGroup.newGroup'));
             setLoading(false);
           }}
         >

--- a/src/features/MobileHome/SessionListContent/Modals/CreateGroupModal.tsx
+++ b/src/features/MobileHome/SessionListContent/Modals/CreateGroupModal.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 
 import { usePermission } from '@/hooks/usePermission';
 import { useGlobalStore } from '@/store/global';
-import { useSessionStore } from '@/store/session';
+import { useHomeStore } from '@/store/home';
 
 interface CreateGroupContentProps {
   id: string;
@@ -18,26 +18,20 @@ const CreateGroupContent = memo<CreateGroupContentProps>(({ id }) => {
   const { allowed: canCreate } = usePermission('create_content');
 
   const toggleExpandSessionGroup = useGlobalStore((s) => s.toggleExpandSessionGroup);
-  const [updateSessionGroup, addCustomGroup] = useSessionStore((s) => [
-    s.updateSessionGroupId,
-    s.addSessionGroup,
-  ]);
+  const [addGroup, updateAgentGroup] = useHomeStore((s) => [s.addGroup, s.updateAgentGroup]);
 
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
 
   const handleCreate = async () => {
-    // Enter fires as fast as the user repeats it — a second pass while
-    // `addCustomGroup` is in flight would create a second group and move the
-    // session into whichever request settles last.
     if (!canCreate || loading) return;
     if (input.length === 0 || input.length > 20 || input.trim() === '')
       return toast.warning(t('sessionGroup.tooLong'));
 
     setLoading(true);
     try {
-      const groupId = await addCustomGroup(input);
-      await updateSessionGroup(id, groupId);
+      const groupId = await addGroup(input);
+      await updateAgentGroup(id, groupId);
       toggleExpandSessionGroup(groupId, true);
       toast.success(t('sessionGroup.createSuccess'));
       close();

--- a/src/features/MobileHome/SessionListContent/Modals/RenameGroupModal.tsx
+++ b/src/features/MobileHome/SessionListContent/Modals/RenameGroupModal.tsx
@@ -5,8 +5,8 @@ import { t as translate } from 'i18next';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useSessionStore } from '@/store/session';
-import { sessionGroupSelectors } from '@/store/session/selectors';
+import { useHomeStore } from '@/store/home';
+import { homeAgentListSelectors } from '@/store/home/selectors';
 
 interface RenameGroupContentProps {
   id: string;
@@ -16,8 +16,9 @@ const RenameGroupContent = memo<RenameGroupContentProps>(({ id }) => {
   const { t } = useTranslation(['chat', 'common']);
   const { close } = useModalContext();
 
-  const updateSessionGroupName = useSessionStore((s) => s.updateSessionGroupName);
-  const group = useSessionStore((s) => sessionGroupSelectors.getGroupById(id)(s), isEqual);
+  const updateGroupName = useHomeStore((s) => s.updateGroupName);
+  const groups = useHomeStore(homeAgentListSelectors.agentGroups, isEqual);
+  const group = groups.find((g) => g.id === id);
 
   const [input, setInput] = useState<string>(group?.name ?? '');
   const [loading, setLoading] = useState(false);
@@ -28,7 +29,7 @@ const RenameGroupContent = memo<RenameGroupContentProps>(({ id }) => {
 
     setLoading(true);
     try {
-      await updateSessionGroupName(id, input);
+      await updateGroupName(id, input);
       toast.success(t('sessionGroup.renameSuccess'));
       close();
     } finally {

--- a/src/features/MobileHome/SessionListContent/SearchMode.tsx
+++ b/src/features/MobileHome/SessionListContent/SearchMode.tsx
@@ -1,44 +1,31 @@
 import { memo, useMemo } from 'react';
 
-import { useServerConfigStore } from '@/store/serverConfig';
-import { serverConfigSelectors } from '@/store/serverConfig/selectors';
-import { useSessionStore } from '@/store/session';
-import { type LobeAgentSession, type LobeSessions } from '@/types/session';
-import { LobeSessionType } from '@/types/session';
+import { useHomeStore } from '@/store/home';
 
 import SkeletonList from '../SkeletonList';
-import SessionList from './List';
+import AgentList from './List';
 
 const SearchMode = memo(() => {
-  const [sessionSearchKeywords, useSearchSessions] = useSessionStore((s) => [
-    s.sessionSearchKeywords,
-    s.useSearchSessions,
+  const [agentSearchKeywords, useSearchAgents] = useHomeStore((s) => [
+    s.agentSearchKeywords,
+    s.useSearchAgents,
   ]);
 
-  const isMobile = useServerConfigStore(serverConfigSelectors.isMobile);
+  const { data, isLoading } = useSearchAgents(agentSearchKeywords);
 
-  const { data, isLoading } = useSearchSessions(sessionSearchKeywords);
-
+  // Filter out group-type items on mobile (no /group/:id route)
   const filteredData = useMemo(() => {
     if (!data) return data;
-
-    if (isMobile) {
-      return data.filter((session: LobeSessions[0]) => session.type !== LobeSessionType.Group);
-    }
-
-    return data.filter(
-      (session: LobeSessions[0]) =>
-        session.type !== LobeSessionType.Agent || !(session as LobeAgentSession).config?.virtual,
-    );
-  }, [data, isMobile]);
+    return data.filter((item) => item.type === 'agent');
+  }, [data]);
 
   return isLoading ? (
     <SkeletonList />
   ) : (
-    <SessionList dataSource={filteredData} showAddButton={false} />
+    <AgentList dataSource={filteredData} showAddButton={false} />
   );
 });
 
-SearchMode.displayName = 'SessionSearchMode';
+SearchMode.displayName = 'AgentSearchMode';
 
 export default SearchMode;

--- a/src/features/MobileHome/SessionListContent/index.tsx
+++ b/src/features/MobileHome/SessionListContent/index.tsx
@@ -2,13 +2,13 @@
 
 import { memo } from 'react';
 
-import { useSessionStore } from '@/store/session';
+import { useHomeStore } from '@/store/home';
 
 import DefaultMode from './DefaultMode';
 import SearchMode from './SearchMode';
 
 const SessionListContent = memo(() => {
-  const isSearching = useSessionStore((s) => s.isSearching);
+  const isSearching = useHomeStore((s) => s.isAgentSearching);
 
   return isSearching ? <SearchMode /> : <DefaultMode />;
 });

--- a/src/store/home/slices/agentList/action.ts
+++ b/src/store/home/slices/agentList/action.ts
@@ -32,6 +32,14 @@ export class AgentListActionImpl {
     this.#set({ allAgentsDrawerOpen: false }, false, n('closeAllAgentsDrawer'));
   };
 
+  updateAgentSearchKeywords = (keyword: string): void => {
+    this.#set(
+      { agentSearchKeywords: keyword, isAgentSearching: !!keyword },
+      false,
+      n('updateAgentSearchKeywords'),
+    );
+  };
+
   openAllAgentsDrawer = (): void => {
     this.#set({ allAgentsDrawerOpen: true }, false, n('openAllAgentsDrawer'));
   };
@@ -78,9 +86,11 @@ export class AgentListActionImpl {
 
   useSearchAgents = (keyword?: string): SWRResponse<SidebarAgentItem[]> => {
     return useClientDataSWR<SidebarAgentItem[]>(agentConfigKeys.search(keyword), async () => {
+      const trimmed = keyword?.trim();
+      if (!trimmed) return [];
       if (!keyword) return [];
 
-      return homeService.searchAgents(keyword);
+      return homeService.searchAgents(trimmed);
     });
   };
 }

--- a/src/store/home/slices/agentList/initialState.ts
+++ b/src/store/home/slices/agentList/initialState.ts
@@ -12,11 +12,13 @@ export interface AgentListState {
   /**
    * Whether all agents drawer is open
    */
+  agentSearchKeywords?: string;
   allAgentsDrawerOpen: boolean;
   /**
    * Whether the agent list has been initialized
    */
   isAgentListInit: boolean;
+  isAgentSearching: boolean;
   /**
    * Pinned agents and chat groups
    */
@@ -45,7 +47,9 @@ export interface AgentListState {
 
 export const initialAgentListState: AgentListState = {
   agentGroups: [],
+  agentSearchKeywords: undefined,
   allAgentsDrawerOpen: false,
+  isAgentSearching: false,
   isAgentListInit: false,
   pinnedAgents: [],
   privateAgentGroups: [],


### PR DESCRIPTION
## Summary

Replace the mobile home session-list data source with the agent-list store. Previously the mobile home read from the legacy sessions data source which is empty in server-DB mode, so only the default inbox agent appeared - desktop-created custom agents were invisible on mobile.

## Changes (16 files)

- Rewire MobileHome/SessionListContent components to use useFetchAgentList / useHomeStore selectors instead of useSessionStore / useFetchSessions
- Update CollapseGroup, List, Modals to work with agent-list store API
- Add serverConfigInit guard in DefaultMode to prevent antd-style theme crash when components mount before theme engine initializes
- Add isAgentListInit guard alongside existing hooks (Rules of Hooks compliance)

## Related

Fixes upstream issues #12658, #13941, #14153, #15136 (priority:high).
