### PR TITLE
🐛 fix(desktop): make split view collapse cleanly on tab switch and close

### DIFF
--- a/src/features/Electron/TabHost/TabHost.tsx
+++ b/src/features/Electron/TabHost/TabHost.tsx
@@ -33,7 +33,18 @@ interface TabHostProps {
 }
 
 const rootStyle: CSSProperties = { blockSize: '100%', inlineSize: '100%', position: 'relative' };
-const slotStyle: CSSProperties = { inset: 0, position: 'absolute' };
+// Longhands only — no `inset` shorthand. The split styles override `left`/`right`
+// per pane, and React's style diff never re-applies an unchanged shorthand, so a
+// pane leaving the split would keep `right` removed (not restored to 0) and
+// collapse to zero width.
+const slotStyle: CSSProperties = {
+  bottom: 0,
+  left: 0,
+  position: 'absolute',
+  right: 0,
+  top: 0,
+  width: 'auto',
+};
 const hiddenSlotStyle: CSSProperties = { ...slotStyle, display: 'none' };
 
 const styles = createStaticStyles(({ css, cssVar }) => ({

--- a/src/features/Electron/titlebar/TabBar/TabItem.tsx
+++ b/src/features/Electron/titlebar/TabBar/TabItem.tsx
@@ -144,10 +144,10 @@ const TabItem = memo<TabItemProps>(
     }, [x, isSorting, targetX, springX]);
 
     const handleClick = useCallback(() => {
-      if (!isActive) {
+      if (!isActive || isSplitVisible) {
         onActivate(id, tab.url);
       }
-    }, [isActive, onActivate, id, tab.url]);
+    }, [isActive, isSplitVisible, onActivate, id, tab.url]);
 
     const handleClose = useCallback(
       (e: React.MouseEvent) => {

--- a/src/features/Electron/titlebar/TabBar/index.tsx
+++ b/src/features/Electron/titlebar/TabBar/index.tsx
@@ -63,7 +63,7 @@ const TabBar = () => {
   const { tabs, activeTabId } = useResolvedTabs();
   const splitView = useElectronStore((s) => s.splitView);
   const splitViewEnabled = useUserStore(labPreferSelectors.enableDesktopSplitView);
-  const activateTab = useElectronStore((s) => s.activateTab);
+  const switchTab = useElectronStore((s) => s.switchTab);
   const addNewTab = useElectronStore((s) => s.addNewTab);
   const removeTab = useElectronStore((s) => s.removeTab);
   const closeOtherTabs = useElectronStore((s) => s.closeOtherTabs);
@@ -148,9 +148,9 @@ const TabBar = () => {
 
   const handleActivate = useCallback(
     (id: string) => {
-      activateTab(id);
+      switchTab(id);
     },
-    [activateTab],
+    [switchTab],
   );
 
   const handleClose = useCallback(

--- a/src/hooks/useHotkeys/desktopTabScope.ts
+++ b/src/hooks/useHotkeys/desktopTabScope.ts
@@ -15,11 +15,11 @@ import { useElectronStore } from '@/store/electron';
  */
 export const useRegisterDesktopTabHotkeys = () => {
   const switchToTabByIndex = useCallback((index: number) => {
-    const { tabs, activateTab } = useElectronStore.getState();
+    const { tabs, switchTab } = useElectronStore.getState();
     if (index < 0 || index >= tabs.length) return;
 
     const target = tabs[index];
-    activateTab(target.id);
+    switchTab(target.id);
   }, []);
 
   // Mod+1 through Mod+9
@@ -43,14 +43,14 @@ export const useRegisterDesktopTabHotkeys = () => {
     'ctrl+tab',
     (e) => {
       e.preventDefault();
-      const { tabs, activeTabId, activateTab } = useElectronStore.getState();
+      const { tabs, activeTabId, switchTab } = useElectronStore.getState();
       if (tabs.length === 0) return;
 
       const currentIndex = tabs.findIndex((t) => t.id === activeTabId);
       const nextIndex = (currentIndex + 1) % tabs.length;
       const target = tabs[nextIndex];
 
-      activateTab(target.id);
+      switchTab(target.id);
     },
     {
       enableOnFormTags: true,
@@ -63,14 +63,14 @@ export const useRegisterDesktopTabHotkeys = () => {
     'ctrl+shift+tab',
     (e) => {
       e.preventDefault();
-      const { tabs, activeTabId, activateTab } = useElectronStore.getState();
+      const { tabs, activeTabId, switchTab } = useElectronStore.getState();
       if (tabs.length === 0) return;
 
       const currentIndex = tabs.findIndex((t) => t.id === activeTabId);
       const prevIndex = (currentIndex - 1 + tabs.length) % tabs.length;
       const target = tabs[prevIndex];
 
-      activateTab(target.id);
+      switchTab(target.id);
     },
     {
       enableOnFormTags: true,

--- a/src/store/electron/actions/__tests__/tabPages.test.ts
+++ b/src/store/electron/actions/__tests__/tabPages.test.ts
@@ -248,6 +248,64 @@ describe('tabPages actions', () => {
       expect(result.current.activeTabId).toBe('/left');
     });
 
+    it('removes the duplicated pane and refocuses the source when the split closes', () => {
+      const result = seed();
+      let duplicateId: string | null = null;
+      act(() => {
+        duplicateId = result.current.openTabInSplitView('/left');
+      });
+
+      act(() => result.current.closeSplitView());
+
+      expect(result.current.splitView).toBeNull();
+      expect(result.current.activeTabId).toBe('/left');
+      expect(result.current.tabs.some((t) => t.id === duplicateId)).toBe(false);
+    });
+
+    it('redirects a titlebar switch on the duplicate back to its source tab', () => {
+      const result = seed();
+      let duplicateId: string | null = null;
+      act(() => {
+        duplicateId = result.current.openTabInSplitView('/left');
+      });
+
+      act(() => result.current.switchTab(duplicateId!));
+
+      expect(result.current.splitView).toBeNull();
+      expect(result.current.activeTabId).toBe('/left');
+      expect(result.current.tabs).toHaveLength(3);
+    });
+
+    it('keeps the duplicate as the only remaining tab when its source closes', () => {
+      const result = seed();
+      let duplicateId: string | null = null;
+      act(() => {
+        duplicateId = result.current.openTabInSplitView('/left');
+      });
+
+      act(() => result.current.removeTab('/left'));
+
+      expect(result.current.splitView).toBeNull();
+      expect(result.current.activeTabId).toBe(duplicateId);
+      expect(result.current.tabs.some((t) => t.id === duplicateId)).toBe(true);
+    });
+
+    it('drops the duplicate when another tab takes its pane', () => {
+      const result = seed();
+      let duplicateId: string | null = null;
+      act(() => {
+        duplicateId = result.current.openTabInSplitView('/left');
+      });
+      // the duplicate pane holds focus, so activating a third tab replaces that pane
+      act(() => result.current.activateTab('/third'));
+
+      expect(result.current.splitView).toMatchObject({
+        primaryTabId: '/left',
+        secondaryTabId: '/third',
+      });
+      expect(result.current.tabs.some((t) => t.id === duplicateId)).toBe(false);
+    });
+
     it('clamps the divider ratio to usable pane widths', () => {
       const result = seed();
       act(() => result.current.openTabInSplitView('/right'));

--- a/src/store/electron/actions/__tests__/tabPages.test.ts
+++ b/src/store/electron/actions/__tests__/tabPages.test.ts
@@ -306,6 +306,75 @@ describe('tabPages actions', () => {
       expect(result.current.tabs.some((t) => t.id === duplicateId)).toBe(false);
     });
 
+    it('drops the duplicate when a newly created tab takes its pane', () => {
+      const result = seed();
+      let duplicateId: string | null = null;
+      act(() => {
+        duplicateId = result.current.openTabInSplitView('/left');
+      });
+      // the duplicate pane holds focus, so the new tab replaces that pane
+      let newTabId = '';
+      act(() => {
+        newTabId = result.current.addNewTab('/');
+      });
+
+      expect(result.current.splitView).toMatchObject({
+        primaryTabId: '/left',
+        secondaryTabId: newTabId,
+      });
+      expect(result.current.splitView?.duplicatedTabId).toBeUndefined();
+      expect(result.current.tabs.some((t) => t.id === duplicateId)).toBe(false);
+      expect(result.current.activeTabId).toBe(newTabId);
+    });
+
+    it('keeps the copy when its real source closed after being displaced from the split', () => {
+      const result = seed();
+      let duplicateId: string | null = null;
+      act(() => {
+        duplicateId = result.current.openTabInSplitView('/left');
+      });
+      // replace the source pane with a third tab, then close the real source tab
+      act(() => result.current.focusTabPane('/left'));
+      act(() => result.current.activateTab('/third'));
+      act(() => result.current.removeTab('/left'));
+
+      act(() => result.current.closeSplitView());
+
+      // the copy is the page's only remaining tab — it must survive the close
+      expect(result.current.splitView).toBeNull();
+      expect(result.current.tabs.some((t) => t.id === duplicateId)).toBe(true);
+    });
+
+    it('removes the copy and refocuses its real source when the replaced pane closes', () => {
+      const result = seed();
+      let duplicateId: string | null = null;
+      act(() => {
+        duplicateId = result.current.openTabInSplitView('/left');
+      });
+      act(() => result.current.focusTabPane('/left'));
+      act(() => result.current.activateTab('/third'));
+
+      act(() => result.current.removeTab('/third'));
+
+      expect(result.current.splitView).toBeNull();
+      expect(result.current.tabs.some((t) => t.id === duplicateId)).toBe(false);
+      expect(result.current.activeTabId).toBe('/left');
+    });
+
+    it('refreshes the promoted source tab recency when the split closes', () => {
+      const result = seed();
+      act(() => {
+        result.current.openTabInSplitView('/left');
+      });
+
+      act(() => result.current.closeSplitView());
+
+      // seed tabs start at lastVisited=1; the promoted source must be re-touched
+      // or the limited live-router set can evict the tab that just became active
+      const source = result.current.tabs.find((t) => t.id === '/left');
+      expect(source!.lastVisited).toBeGreaterThan(1);
+    });
+
     it('clamps the divider ratio to usable pane widths', () => {
       const result = seed();
       act(() => result.current.openTabInSplitView('/right'));

--- a/src/store/electron/actions/__tests__/tabPages.test.ts
+++ b/src/store/electron/actions/__tests__/tabPages.test.ts
@@ -229,6 +229,16 @@ describe('tabPages actions', () => {
       expect(result.current.activeTabId).toBe('/third');
     });
 
+    it('collapses split view when switching from the titlebar tab strip', () => {
+      const result = seed();
+      act(() => result.current.openTabInSplitView('/right'));
+
+      act(() => result.current.switchTab('/left'));
+
+      expect(result.current.activeTabId).toBe('/left');
+      expect(result.current.splitView).toBeNull();
+    });
+
     it('collapses to the remaining pane when one visible tab closes', () => {
       const result = seed();
       act(() => result.current.openTabInSplitView('/right'));

--- a/src/store/electron/actions/tabPages.ts
+++ b/src/store/electron/actions/tabPages.ts
@@ -75,6 +75,22 @@ export class TabPagesActionImpl {
     this.#persist();
   };
 
+  switchTab = (id: string): void => {
+    const { tabs } = this.#get();
+    if (!tabs.some((t) => t.id === id)) return;
+
+    this.#set(
+      {
+        activeTabId: id,
+        splitView: null,
+        tabs: this.#touch(tabs, id),
+      },
+      false,
+      'switchTab',
+    );
+    this.#persist();
+  };
+
   addTab = (url: string, cached?: DynamicRouteMeta, activate = true): string => {
     this.#ensureScopeForUrl(url);
     const { tabs } = this.#get();

--- a/src/store/electron/actions/tabPages.ts
+++ b/src/store/electron/actions/tabPages.ts
@@ -30,6 +30,12 @@ export interface TabPagesState {
 
 export interface SplitViewState {
   /**
+   * The tab `duplicatedTabId` was copied from. Recorded at split time because
+   * panes can be replaced afterwards — deriving the source from "the other
+   * pane" later would point at whatever tab happens to sit there.
+   */
+  duplicatedFromTabId?: string;
+  /**
    * Tab created by copying the active tab when it was split against itself.
    * It only exists to mirror its source side-by-side and is removed as soon as
    * it leaves the split, so no stray duplicate tab survives the session.
@@ -139,7 +145,12 @@ export class TabPagesActionImpl {
     const cleaned = this.#dropDisplacedDuplicate(splitView, null, tabs, activeTabId);
 
     this.#set(
-      { activeTabId: cleaned.activeTabId, splitView: null, tabs: cleaned.tabs },
+      {
+        activeTabId: cleaned.activeTabId,
+        splitView: null,
+        // #touch keeps the promoted source tab's keep-alive recency fresh — see #touch.
+        tabs: this.#touch(cleaned.tabs, cleaned.activeTabId),
+      },
       false,
       'closeSplitView',
     );
@@ -182,6 +193,7 @@ export class TabPagesActionImpl {
       : this.#touch(tabs, id);
 
     const nextSplitView: SplitViewState = {
+      duplicatedFromTabId: shouldDuplicate ? id : undefined,
       duplicatedTabId: shouldDuplicate ? secondaryTabId : undefined,
       primaryTabId,
       ratio: splitView?.ratio ?? 0.5,
@@ -470,16 +482,15 @@ export class TabPagesActionImpl {
         nextSplitView.secondaryTabId === duplicatedTabId);
     if (stillInPane) return keep;
 
-    const sourceTabId =
-      prevSplitView.primaryTabId === duplicatedTabId
-        ? prevSplitView.secondaryTabId
-        : prevSplitView.primaryTabId;
+    const sourceTabId = prevSplitView.duplicatedFromTabId;
     // The source tab already closed, so the copy is the page's only remaining tab.
-    if (!tabs.some((tab) => tab.id === sourceTabId)) return keep;
+    if (!sourceTabId || !tabs.some((tab) => tab.id === sourceTabId)) return keep;
 
     return {
       activeTabId: activeTabId === duplicatedTabId ? sourceTabId : activeTabId,
-      splitView: nextSplitView,
+      splitView: nextSplitView
+        ? { ...nextSplitView, duplicatedFromTabId: undefined, duplicatedTabId: undefined }
+        : null,
       tabs: tabs.filter((tab) => tab.id !== duplicatedTabId),
     };
   };
@@ -519,11 +530,21 @@ export class TabPagesActionImpl {
       url,
     };
 
+    const withNew = [...tabs, newTab];
+    const cleaned = activate
+      ? this.#dropDisplacedDuplicate(
+          splitView,
+          this.#replaceFocusedPane(splitView, activeTabId, id),
+          withNew,
+          id,
+        )
+      : { activeTabId, splitView, tabs: withNew };
+
     this.#set(
       {
         activeTabId: activate ? id : activeTabId,
-        splitView: activate ? this.#replaceFocusedPane(splitView, activeTabId, id) : splitView,
-        tabs: [...tabs, newTab],
+        splitView: cleaned.splitView,
+        tabs: cleaned.tabs,
       },
       false,
       'addTab',

--- a/src/store/electron/actions/tabPages.ts
+++ b/src/store/electron/actions/tabPages.ts
@@ -29,6 +29,12 @@ export interface TabPagesState {
 }
 
 export interface SplitViewState {
+  /**
+   * Tab created by copying the active tab when it was split against itself.
+   * It only exists to mirror its source side-by-side and is removed as soon as
+   * it leaves the split, so no stray duplicate tab survives the session.
+   */
+  duplicatedTabId?: string;
   primaryTabId: string;
   ratio: number;
   secondaryTabId: string;
@@ -63,11 +69,18 @@ export class TabPagesActionImpl {
     const { activeTabId, splitView, tabs } = this.#get();
     if (!tabs.some((t) => t.id === id)) return;
 
+    const cleaned = this.#dropDisplacedDuplicate(
+      splitView,
+      this.#replaceFocusedPane(splitView, activeTabId, id),
+      tabs,
+      id,
+    );
+
     this.#set(
       {
-        activeTabId: id,
-        splitView: this.#replaceFocusedPane(splitView, activeTabId, id),
-        tabs: this.#touch(tabs, id),
+        activeTabId: cleaned.activeTabId,
+        splitView: cleaned.splitView,
+        tabs: this.#touch(cleaned.tabs, cleaned.activeTabId),
       },
       false,
       'activateTab',
@@ -76,14 +89,16 @@ export class TabPagesActionImpl {
   };
 
   switchTab = (id: string): void => {
-    const { tabs } = this.#get();
+    const { splitView, tabs } = this.#get();
     if (!tabs.some((t) => t.id === id)) return;
+
+    const cleaned = this.#dropDisplacedDuplicate(splitView, null, tabs, id);
 
     this.#set(
       {
-        activeTabId: id,
+        activeTabId: cleaned.activeTabId,
         splitView: null,
-        tabs: this.#touch(tabs, id),
+        tabs: this.#touch(cleaned.tabs, cleaned.activeTabId),
       },
       false,
       'switchTab',
@@ -118,8 +133,17 @@ export class TabPagesActionImpl {
   };
 
   closeSplitView = (): void => {
-    if (!this.#get().splitView) return;
-    this.#set({ splitView: null }, false, 'closeSplitView');
+    const { activeTabId, splitView, tabs } = this.#get();
+    if (!splitView) return;
+
+    const cleaned = this.#dropDisplacedDuplicate(splitView, null, tabs, activeTabId);
+
+    this.#set(
+      { activeTabId: cleaned.activeTabId, splitView: null, tabs: cleaned.tabs },
+      false,
+      'closeSplitView',
+    );
+    this.#persist();
   };
 
   focusTabPane = (id: string): void => {
@@ -157,15 +181,24 @@ export class TabPagesActionImpl {
         ]
       : this.#touch(tabs, id);
 
+    const nextSplitView: SplitViewState = {
+      duplicatedTabId: shouldDuplicate ? secondaryTabId : undefined,
+      primaryTabId,
+      ratio: splitView?.ratio ?? 0.5,
+      secondaryTabId,
+    };
+    const cleaned = this.#dropDisplacedDuplicate(
+      splitView,
+      nextSplitView,
+      nextTabs,
+      secondaryTabId,
+    );
+
     this.#set(
       {
-        activeTabId: secondaryTabId,
-        splitView: {
-          primaryTabId,
-          ratio: splitView?.ratio ?? 0.5,
-          secondaryTabId,
-        },
-        tabs: nextTabs,
+        activeTabId: cleaned.activeTabId,
+        splitView: cleaned.splitView,
+        tabs: cleaned.tabs,
       },
       false,
       'openTabInSplitView',
@@ -212,7 +245,7 @@ export class TabPagesActionImpl {
       {
         activeTabId: newActiveId,
         splitView: reconciled.splitView,
-        tabs: this.#touch(newTabs, newActiveId),
+        tabs: this.#touch(reconciled.tabs, newActiveId),
       },
       false,
       'removeTab',
@@ -353,13 +386,14 @@ export class TabPagesActionImpl {
     if (newTabs.length === tabs.length) return;
 
     const preferredActiveId = newTabs.some((t) => t.id === activeTabId) ? activeTabId : targetId;
-    const { activeTabId: newActiveId, splitView } = this.#reconcileSplitView(
-      newTabs,
-      preferredActiveId,
-    );
+    const reconciled = this.#reconcileSplitView(newTabs, preferredActiveId);
 
     this.#set(
-      { activeTabId: newActiveId, splitView, tabs: this.#touch(newTabs, newActiveId) },
+      {
+        activeTabId: reconciled.activeTabId,
+        splitView: reconciled.splitView,
+        tabs: this.#touch(reconciled.tabs, reconciled.activeTabId),
+      },
       false,
       action,
     );
@@ -416,24 +450,63 @@ export class TabPagesActionImpl {
       : { ...splitView, primaryTabId: nextTabId };
   };
 
+  // A duplicated pane that leaves the split (the split collapses or another tab takes
+  // its pane) must not survive as a stray second tab for the same page: closing or
+  // revisiting the leftover forces a hidden→visible remount of a pane the user never
+  // saw leave. Drop the copy and hand focus back to its source tab instead.
+  #dropDisplacedDuplicate = (
+    prevSplitView: SplitViewState | null,
+    nextSplitView: SplitViewState | null,
+    tabs: TabItem[],
+    activeTabId: string | null,
+  ): Pick<TabPagesState, 'activeTabId' | 'splitView' | 'tabs'> => {
+    const duplicatedTabId = prevSplitView?.duplicatedTabId;
+    const keep = { activeTabId, splitView: nextSplitView, tabs };
+    if (!prevSplitView || !duplicatedTabId) return keep;
+
+    const stillInPane =
+      nextSplitView &&
+      (nextSplitView.primaryTabId === duplicatedTabId ||
+        nextSplitView.secondaryTabId === duplicatedTabId);
+    if (stillInPane) return keep;
+
+    const sourceTabId =
+      prevSplitView.primaryTabId === duplicatedTabId
+        ? prevSplitView.secondaryTabId
+        : prevSplitView.primaryTabId;
+    // The source tab already closed, so the copy is the page's only remaining tab.
+    if (!tabs.some((tab) => tab.id === sourceTabId)) return keep;
+
+    return {
+      activeTabId: activeTabId === duplicatedTabId ? sourceTabId : activeTabId,
+      splitView: nextSplitView,
+      tabs: tabs.filter((tab) => tab.id !== duplicatedTabId),
+    };
+  };
+
   #reconcileSplitView = (
     tabs: TabItem[],
     preferredActiveId: string | null,
-  ): Pick<TabPagesState, 'activeTabId' | 'splitView'> => {
+  ): Pick<TabPagesState, 'activeTabId' | 'splitView' | 'tabs'> => {
     const { splitView } = this.#get();
-    if (!splitView) return { activeTabId: preferredActiveId, splitView: null };
+    if (!splitView) return { activeTabId: preferredActiveId, splitView: null, tabs };
 
     const tabIds = new Set(tabs.map((tab) => tab.id));
     const hasPrimary = tabIds.has(splitView.primaryTabId);
     const hasSecondary = tabIds.has(splitView.secondaryTabId);
-    if (hasPrimary && hasSecondary) return { activeTabId: preferredActiveId, splitView };
+    if (hasPrimary && hasSecondary) return { activeTabId: preferredActiveId, splitView, tabs };
 
     const remainingPaneId = hasPrimary
       ? splitView.primaryTabId
       : hasSecondary
         ? splitView.secondaryTabId
         : null;
-    return { activeTabId: remainingPaneId ?? preferredActiveId, splitView: null };
+    return this.#dropDisplacedDuplicate(
+      splitView,
+      null,
+      tabs,
+      remainingPaneId ?? preferredActiveId,
+    );
   };
 
   #createTab = (url: string, cached: DynamicRouteMeta | undefined, activate: boolean): string => {


### PR DESCRIPTION
## Summary

Three fixes for the desktop tab split view (#18004, Labs alpha):

- **Tab switching while split is open** — clicking a tab in the titlebar strip (or using Mod+1–9 / Ctrl+Tab) used to replace the focused pane instead of switching views, so the strip and the visible content disagreed and switching tabs looked broken. A new `switchTab` action collapses the split alongside the activation; the titlebar strip and the tab hotkeys now route through it. `activateTab` keeps its split-preserving behavior for internal callers.
- **Closing the split left a stray duplicate tab** — splitting the active tab against itself copies it into a second tab so each pane owns a router. That copy outlived the split: closing left a duplicate tab in the strip, and closing or revisiting it forced a full hidden→visible remount of a pane the user never saw leave, which read as a whole-page reload. The copy is now tracked as `splitView.duplicatedTabId` and removed on every path where it leaves the split (context-menu close, titlebar switch collapse, pane replacement, reconcile after a tab closes), with focus handed back to its source tab. The copy is kept only when its source tab itself was closed.
- **Closing the split collapsed the surviving pane to zero width** (found during verification) — the pane slot styles mixed the `inset` shorthand with per-pane `left`/`right` longhand overrides. React's style diff never re-applies an unchanged shorthand, so a pane leaving the split kept `right` removed instead of restored to 0 and collapsed to zero width — a black content area until the next unrelated re-render. Slot styles now use longhands only.

## UI verification

Verified end-to-end in the Electron dev app over CDP (worktree bundle proven live via `switchTab` presence; real titlebar DOM clicks; DOM-identity markers proving the surviving pane is not remounted and the window never reloads):

https://app.lobehub.com/acceptance/e0327a1c-e3fc-41f6-a4a9-7e53bee3a586?r=1

#### Test

- [x] Tested locally
- [x] Added/updated tests

- `bun run check` passed for the changed files (45 + 10 tests)
- Electron verification passed: 4/4 checks (split open baseline, titlebar switch collapse, duplicate-tab cleanup on close, no-remount/no-reload assertion)

#### 🔗 Related Issue

Follow-up to #18004

🤖 Generated with [Claude Code](https://claude.com/claude-code)