### PR TITLE
🐛 fix(hetero-agent): harden Windows CLI spawning

### DIFF
--- a/apps/desktop/src/main/controllers/HeterogeneousAgentImpl.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentImpl.ts
@@ -1084,6 +1084,7 @@ export default class HeterogeneousAgentCtr {
     let traceSession;
     let cwd: string;
     let initialCumulativeUsage: UsageData | undefined;
+    let resolvedCliSpawnPlan;
     let spawnEnv: NodeJS.ProcessEnv;
     try {
       const driver = getHeterogeneousAgentDriver(session.agentType);
@@ -1111,6 +1112,11 @@ export default class HeterogeneousAgentCtr {
         promptInput,
         resumeSessionId: session.agentSessionId,
       });
+
+      resolvedCliSpawnPlan = await resolveCliSpawnPlan(
+        session.resolvedCommandPath ?? session.command,
+        spawnPlan.args,
+      );
 
       // Fall back to the user's Desktop so the process never inherits
       // the Electron parent's cwd (which is `/` when launched from Finder).
@@ -1153,11 +1159,6 @@ export default class HeterogeneousAgentCtr {
       throw err;
     }
     const useStdin = spawnPlan.stdinPayload !== undefined;
-    const cliArgs = spawnPlan.args;
-    const resolvedCliSpawnPlan = await resolveCliSpawnPlan(
-      session.resolvedCommandPath ?? session.command,
-      cliArgs,
-    );
 
     logger.info(
       'Spawning agent:',

--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
@@ -19,6 +19,8 @@ vi.mock('node:os', async () => {
   return { ...actual, platform: vi.fn(() => 'linux') };
 });
 
+const platformMock = vi.mocked(os.platform);
+
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return { ...actual, existsSync: vi.fn(() => true) };
@@ -263,6 +265,7 @@ describe('HeterogeneousAgentCtr', () => {
     codexAppServerConstructMock.mockReset();
     codexAppServerInterruptMock.mockReset();
     mockGetAllWindows.mockReset();
+    platformMock.mockReturnValue('linux');
     delete process.env.LOBE_CLAUDE_CODE_SDK;
     delete process.env.LOBE_CODEX_APP_SERVER;
   });
@@ -642,6 +645,45 @@ describe('HeterogeneousAgentCtr', () => {
         { text: 'selected code context', type: 'text' },
         { text: 'user task', type: 'text' },
       ]);
+    });
+
+    it('cleans up the intervention when Windows command-line validation rejects before spawn', async () => {
+      platformMock.mockReturnValue('win32');
+      const operationId = 'op-oversized-windows-argv';
+      const tmpConfigPath = path.join(os.tmpdir(), `lobe-cc-mcp-${operationId}.json`);
+      await rm(tmpConfigPath, { force: true });
+
+      const ctr = new HeterogeneousAgentCtr({
+        appStoragePath,
+        binaryManager: {
+          detect: vi.fn().mockResolvedValue({
+            available: true,
+            path: 'C:\\claude.exe',
+          }),
+        },
+        storeManager: { get: vi.fn() },
+      } as any);
+      const { sessionId } = await ctr.startSession({
+        agentType: 'claude-code',
+        args: ['a'.repeat(32_767)],
+        command: 'claude',
+      });
+
+      await expect(
+        ctr.sendPrompt({
+          agentId: 'agent-1',
+          operationId,
+          prompt: 'hello',
+          sessionId,
+          topicId: 'topic-1',
+        }),
+      ).rejects.toThrow(/resolved Windows command line requires/);
+
+      expect(spawnCalls).toHaveLength(0);
+      expect((ctr as any).opIdToIntervention.has(operationId)).toBe(false);
+      expect((ctr as any).opIdToBrowserBinding.has(operationId)).toBe(false);
+      expect((ctr as any).builtinMcpServer.hasOperation(operationId)).toBe(false);
+      await expect(access(tmpConfigPath)).rejects.toThrow();
     });
 
     it('uses Claude SDK streaming lab instead of spawning claude -p', async () => {

--- a/apps/desktop/src/main/modules/binaries/__tests__/cliAgentBinaries.test.ts
+++ b/apps/desktop/src/main/modules/binaries/__tests__/cliAgentBinaries.test.ts
@@ -36,13 +36,6 @@ const callExecFileError = (err: Error) => {
     return {} as any;
   }) as any);
 };
-const callExec = (stdout: string, stderr = '') => {
-  execMock.mockImplementationOnce(((cmd: string, opts: any, cb: any) => {
-    const callback = typeof opts === 'function' ? opts : cb;
-    callback(noErr, { stdout, stderr });
-    return {} as any;
-  }) as any);
-};
 
 describe('cliAgentBinaries', () => {
   beforeEach(() => {
@@ -59,11 +52,11 @@ describe('cliAgentBinaries', () => {
       platformMock.mockReturnValue('win32');
     });
 
-    it('resolves `claude` to the .cmd path via `where`, then runs it through the shell', async () => {
+    it('resolves `claude` to the .cmd path via `where` without constructing a shell command', async () => {
       // 1) `where claude` → resolves to the .cmd shim under %APPDATA%\npm
       callExecFile('C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude.cmd\r\n');
-      // 2) `cmd /c "...\\claude.cmd" --version` → keyword match
-      callExec('1.2.3 (Claude Code)');
+      // 2) validate the resolved command without interpolating it into a shell string
+      callExecFile('1.2.3 (Claude Code)');
 
       const { claudeCodeBinary } = await import('../cliAgentBinaries');
       const status = await claudeCodeBinary.detect();
@@ -72,11 +65,12 @@ describe('cliAgentBinaries', () => {
       expect(status.path).toBe('C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude.cmd');
       expect(status.version).toBe('1.2.3 (Claude Code)');
 
-      // The validation call must go via `exec` (shell), NOT `execFile`, so
-      // cmd.exe can actually interpret the .cmd shim.
-      expect(execMock).toHaveBeenCalledTimes(1);
-      const execCall = execMock.mock.calls[0]!;
-      expect(execCall[0]).toBe('"C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude.cmd" --version');
+      expect(execMock).not.toHaveBeenCalled();
+      expect(execFileMock).toHaveBeenCalledTimes(2);
+      expect(execFileMock.mock.calls[1]![0]).toBe(
+        'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude.cmd',
+      );
+      expect(execFileMock.mock.calls[1]![1]).toEqual(['--version']);
     });
 
     it('returns unavailable when `where` finds nothing', async () => {
@@ -101,7 +95,7 @@ describe('cliAgentBinaries', () => {
 
     it('fails detection when version output does not match the expected keyword', async () => {
       callExecFile('C:\\some\\other\\claude.cmd\r\n');
-      callExec('this is some other binary v1.0');
+      callExecFile('this is some other binary v1.0');
 
       const { claudeCodeBinary } = await import('../cliAgentBinaries');
       const status = await claudeCodeBinary.detect();
@@ -120,16 +114,18 @@ describe('cliAgentBinaries', () => {
           'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\codex.ps1',
         ].join('\r\n'),
       );
-      callExec('codex 0.130.0');
+      callExecFile('codex 0.130.0');
 
       const { codexBinary } = await import('../cliAgentBinaries');
       const status = await codexBinary.detect();
 
       expect(status.available).toBe(true);
       expect(status.path).toBe('C:\\Users\\Hanam\\AppData\\Roaming\\npm\\codex.cmd');
-      expect(execMock.mock.calls[0]![0]).toBe(
-        '"C:\\Users\\Hanam\\AppData\\Roaming\\npm\\codex.cmd" --version',
+      expect(execMock).not.toHaveBeenCalled();
+      expect(execFileMock.mock.calls[1]![0]).toBe(
+        'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\codex.cmd',
       );
+      expect(execFileMock.mock.calls[1]![1]).toEqual(['--version']);
     });
 
     it('prefers .exe over .cmd when both are present', async () => {
@@ -154,17 +150,18 @@ describe('cliAgentBinaries', () => {
           'C:\\Users\\hp\\.vite-plus\\bin\\claude.exe',
         ].join('\r\n'),
       );
-      callExec('1.2.3 (Claude Code)');
+      callExecFile('1.2.3 (Claude Code)');
 
       const { claudeCodeBinary } = await import('../cliAgentBinaries');
       const status = await claudeCodeBinary.detect();
 
       expect(status.available).toBe(true);
       expect(status.path).toBe('C:\\Users\\hp\\AppData\\Roaming\\npm\\claude.cmd');
-      expect(execMock).toHaveBeenCalledTimes(1);
-      expect(execMock.mock.calls[0]![0]).toBe(
-        '"C:\\Users\\hp\\AppData\\Roaming\\npm\\claude.cmd" --version',
+      expect(execMock).not.toHaveBeenCalled();
+      expect(execFileMock.mock.calls[1]![0]).toBe(
+        'C:\\Users\\hp\\AppData\\Roaming\\npm\\claude.cmd',
       );
+      expect(execFileMock.mock.calls[1]![1]).toEqual(['--version']);
     });
 
     it('reports unavailable when `where` only returns unrunnable matches (.ps1 / extensionless)', async () => {

--- a/packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts
@@ -34,8 +34,7 @@ const readFileMock = vi.mocked(fsPromises.readFile);
 const callExecFile = (stdout: string) => {
   execFileMock.mockImplementationOnce(((...args: unknown[]) => {
     const callback = [...args].reverse().find((arg) => typeof arg === 'function') as
-      | ((error: Error | null, stdout: string) => void)
-      | undefined;
+      ((error: Error | null, stdout: string) => void) | undefined;
     callback?.(null, stdout);
     return {} as childProcess.ChildProcess;
   }) as typeof childProcess.execFile);
@@ -225,5 +224,31 @@ describe('cliSpawn', () => {
       args: ['--version'],
       command: shimPath,
     });
+  });
+
+  it('accepts the exact Windows command-line limit and rejects one UTF-16 unit more', async () => {
+    platformMock.mockReturnValue('win32');
+    const command = 'C:\\codex.exe';
+    const { resolveCliSpawnPlan } = await import('./cliSpawn');
+    const exactPrompt = 'a'.repeat(32_767 - command.length - 2);
+
+    await expect(resolveCliSpawnPlan(command, [exactPrompt])).resolves.toEqual({
+      args: [exactPrompt],
+      command,
+    });
+    await expect(resolveCliSpawnPlan(command, [`${exactPrompt}a`])).rejects.toThrow(
+      /Windows command line requires 32768 UTF-16 code units/,
+    );
+  });
+
+  it('counts astral characters as two Windows UTF-16 code units', async () => {
+    platformMock.mockReturnValue('win32');
+    const command = 'C:\\codex.exe';
+    const { resolveCliSpawnPlan } = await import('./cliSpawn');
+    const promptPrefix = 'a'.repeat(32_767 - command.length - 3);
+
+    await expect(resolveCliSpawnPlan(command, [`${promptPrefix}😀`])).rejects.toThrow(
+      /Windows command line requires 32768 UTF-16 code units/,
+    );
   });
 });

--- a/packages/heterogeneous-agents/src/spawn/cliSpawn.ts
+++ b/packages/heterogeneous-agents/src/spawn/cliSpawn.ts
@@ -4,6 +4,7 @@ import { platform } from 'node:os';
 import path from 'node:path';
 
 const WINDOWS_EXE_EXT_PATTERN = /\.exe$/i;
+const WINDOWS_MAX_COMMAND_LINE_LENGTH = 32_767;
 const WINDOWS_NODE_EXE_PATTERN = /(?:^|[\\/])node(?:\.exe)?$/i;
 
 export interface CliSpawnPlan {
@@ -17,6 +18,41 @@ interface WindowsShimTarget {
 }
 
 const isWindows = () => platform() === 'win32';
+
+const quoteWindowsCommandLineArgument = (argument: string): string => {
+  if (argument && !/[\t "]/u.test(argument)) return argument;
+
+  let quoted = '"';
+  let backslashCount = 0;
+
+  for (const character of argument) {
+    if (character === '\\') {
+      backslashCount += 1;
+      continue;
+    }
+
+    if (character === '"') {
+      quoted += `${'\\'.repeat(backslashCount * 2 + 1)}"`;
+    } else {
+      quoted += `${'\\'.repeat(backslashCount)}${character}`;
+    }
+    backslashCount = 0;
+  }
+
+  return `${quoted}${'\\'.repeat(backslashCount * 2)}"`;
+};
+
+const assertWindowsCommandLineFits = ({ args, command }: CliSpawnPlan): void => {
+  const commandLineLength = [command, ...args]
+    .map(quoteWindowsCommandLineArgument)
+    .join(' ').length;
+  const requiredLength = commandLineLength + 1;
+  if (requiredLength <= WINDOWS_MAX_COMMAND_LINE_LENGTH) return;
+
+  throw new Error(
+    `Cannot start CLI because the resolved Windows command line requires ${requiredLength} UTF-16 code units; Windows permits at most ${WINDOWS_MAX_COMMAND_LINE_LENGTH} including the terminator. Shorten the prompt or conversation context and retry.`,
+  );
+};
 
 const isPathLikeCommand = (command: string) =>
   path.win32.isAbsolute(command) || path.posix.isAbsolute(command) || /[\\/]/.test(command);
@@ -229,7 +265,10 @@ export const resolveCliSpawnPlan = async (
     ? await inferWindowsNpmShimTarget(trimmedCommand)
     : await resolveWindowsBareCommand(trimmedCommand);
 
-  if (!target) return { args, command };
+  const spawnPlan = target
+    ? { args: [...(target.argsPrefix ?? []), ...args], command: target.command }
+    : { args, command };
 
-  return { args: [...(target.argsPrefix ?? []), ...args], command: target.command };
+  assertWindowsCommandLineFits(spawnPlan);
+  return spawnPlan;
 };

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
@@ -36,14 +36,6 @@ const callExecFileError = (err: Error) => {
     return {} as any;
   }) as any);
 };
-const callExec = (stdout: string, stderr = '') => {
-  execMock.mockImplementationOnce(((cmd: string, opts: any, cb: any) => {
-    const callback = typeof opts === 'function' ? opts : cb;
-    callback(noErr, { stdout, stderr });
-    return {} as any;
-  }) as any);
-};
-
 const importModule = () => import('./resolveCliCommand');
 
 describe('resolveCliCommand', () => {
@@ -255,18 +247,18 @@ describe('resolveCliCommand', () => {
       platformMock.mockReturnValue('win32');
     });
 
-    it('resolves `codex` to the .cmd shim via `where`, then runs it through the shell', async () => {
+    it('resolves `codex` to the .cmd shim without constructing a shell command', async () => {
       callExecFile('C:\\Users\\x\\AppData\\Roaming\\npm\\codex.cmd\r\n');
-      callExec('codex 0.142.5');
+      callExecFile('codex 0.142.5');
 
       const { detectValidatedCommand } = await importModule();
       const status = await detectValidatedCommand('codex', { validateKeywords: ['codex'] });
 
       expect(status.available).toBe(true);
       expect(status.path).toBe('C:\\Users\\x\\AppData\\Roaming\\npm\\codex.cmd');
-      expect(execMock.mock.calls[0]![0]).toBe(
-        '"C:\\Users\\x\\AppData\\Roaming\\npm\\codex.cmd" --version',
-      );
+      expect(execFileMock.mock.calls[1]![0]).toBe('C:\\Users\\x\\AppData\\Roaming\\npm\\codex.cmd');
+      expect(execFileMock.mock.calls[1]![1]).toEqual(['--version']);
+      expect(execMock).not.toHaveBeenCalled();
     });
 
     it('prefers the .cmd shim when `where` returns multiple PATHEXT matches', async () => {
@@ -277,7 +269,7 @@ describe('resolveCliCommand', () => {
           'C:\\Users\\x\\AppData\\Roaming\\npm\\codex.ps1',
         ].join('\r\n'),
       );
-      callExec('codex 0.142.5');
+      callExecFile('codex 0.142.5');
 
       const { detectValidatedCommand } = await importModule();
       const status = await detectValidatedCommand('codex', { validateKeywords: ['codex'] });
@@ -296,7 +288,7 @@ describe('resolveCliCommand', () => {
           'C:\\Users\\hp\\.vite-plus\\bin\\claude.exe',
         ].join('\r\n'),
       );
-      callExec('1.2.3 (Claude Code)');
+      callExecFile('1.2.3 (Claude Code)');
 
       const { detectValidatedCommand } = await importModule();
       const status = await detectValidatedCommand('claude', {

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
@@ -1,10 +1,11 @@
-import { exec, execFile } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { homedir, platform } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
 import type { LocalHeterogeneousAgentType } from '../config';
 import { HETEROGENEOUS_AGENT_CONFIGS } from '../config';
+import { resolveCliSpawnPlan } from './cliSpawn';
 
 /**
  * Shared resolver for external CLI-agent binaries (Amp / Claude Code / Codex / OpenCode / Pi / Qoder).
@@ -21,7 +22,6 @@ import { HETEROGENEOUS_AGENT_CONFIGS } from '../config';
  */
 
 const execFilePromise = promisify(execFile);
-const execPromise = promisify(exec);
 
 export type HeterogeneousCliAgentType = LocalHeterogeneousAgentType;
 
@@ -58,13 +58,12 @@ interface ResolvedCommand {
 const isWindows = () => platform() === 'win32';
 let shellPathPromise: Promise<string | undefined> | undefined;
 
-// Reject anything that could break out of the `cmd /c "<path>" --version`
-// shell line we build for Windows .cmd shims (see `detectValidatedCommand`).
-// User-supplied custom commands flow through here via `detectHeterogeneousCliCommand`.
+// Reject shell syntax in user-supplied custom commands instead of treating it
+// as part of a command name.
 const WINDOWS_SHELL_METAS = /[&|;<>^`!"]/;
 
-// Extensions we can actually execute on Windows.
-// `.exe` runs directly via `execFile`, `.cmd` / `.bat` runs via `cmd.exe`.
+// Extensions eligible for execution on Windows. `.exe` runs directly, while
+// supported `.cmd` / `.bat` shims are unwrapped by `resolveCliSpawnPlan`.
 // `.ps1` and extensionless wrappers (npm sometimes drops a Unix shell script
 // next to the `.cmd` shim) are deliberately excluded — we can't run them.
 //
@@ -185,6 +184,15 @@ const resolveCommandPath = async (command: string): Promise<ResolvedCommand | un
   return { env: lookupEnv, path: lines[0] };
 };
 
+const execResolvedCommand = async (command: string, args: string[], env?: NodeJS.ProcessEnv) => {
+  const spawnPlan = await resolveCliSpawnPlan(command, args);
+  return execFilePromise(spawnPlan.command, spawnPlan.args, {
+    env,
+    timeout: 5000,
+    windowsHide: true,
+  });
+};
+
 /**
  * Resolve a command via which/where, then confirm it's the binary we expect by
  * matching `--version` output against a keyword or output pattern (avoids
@@ -209,18 +217,7 @@ export const detectValidatedCommand = async (
   const { env, path: resolvedPath } = resolvedCommand;
 
   try {
-    const needsShell = isWindows() && /\.(?:cmd|bat)$/i.test(resolvedPath);
-    const { stderr, stdout } = needsShell
-      ? await execPromise(`"${resolvedPath}" ${validateFlag}`, {
-          env,
-          timeout: 5000,
-          windowsHide: true,
-        })
-      : await execFilePromise(resolvedPath, [validateFlag], {
-          env,
-          timeout: 5000,
-          windowsHide: true,
-        });
+    const { stderr, stdout } = await execResolvedCommand(resolvedPath, [validateFlag], env);
     const output = `${stdout}\n${stderr}`.trim();
     const loweredOutput = output.toLowerCase();
     const matchesKeyword = validateKeywords?.some((keyword) =>


### PR DESCRIPTION
## Summary

Harden the shared Windows CLI resolution and spawn path used by heterogeneous agents.

| Before | After |
| ------ | ----- |
| `.cmd` / `.bat` validation interpolated a shell command string | npm shims are unwrapped through the shared argv-based spawn plan and executed with `execFile` |
| Oversized Windows command lines failed at process creation with an opaque platform error | The resolved command line is measured against the 32,767 UTF-16-unit Windows limit before spawning |

### What changed

- Reuse `resolveCliSpawnPlan` when validating resolved Windows commands
- Remove shell-string construction from `.cmd` / `.bat` capability checks
- Preserve PATH-order selection for npm shims versus later executables
- Validate the final quoted Windows command-line length
- Add regression coverage for Claude Code and Codex npm shims, quoting, and UTF-16 length accounting

This is PR 1 of 3 split from #18061. The device-cancellation lifecycle PR is stacked on this branch; the Kimi Code integration remains in #18061.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation: `bun run check <5 changed files>` — 53 tests passed, lint clean.

#### 🔗 Related Issue

Related to #18061
