### PR TITLE
🐛 fix(hetero-agent): unify device cancellation lifecycle

### DIFF
--- a/apps/cli/src/commands/hetero.test.ts
+++ b/apps/cli/src/commands/hetero.test.ts
@@ -519,10 +519,10 @@ describe('hetero exec command', () => {
     expect(exitSpy).toHaveBeenCalledWith(130);
   });
 
-  it('flushes terminal tool events before finishing a server-ingest run as cancelled', async () => {
-    let sigintHandler: (() => void) | undefined;
+  it('handles IPC cancellation while flushing terminal tool events before heteroFinish', async () => {
+    let ipcMessageHandler: ((message: unknown) => void) | undefined;
     vi.spyOn(process, 'on').mockImplementation(((event: string, listener: () => void) => {
-      if (event === 'SIGINT') sigintHandler = listener;
+      if (event === 'message') ipcMessageHandler = listener;
       return process;
     }) as typeof process.on);
 
@@ -591,9 +591,14 @@ describe('hetero exec command', () => {
       '--render',
       'none',
     ]);
-    for (let i = 0; i < 20 && !sigintHandler; i += 1) await Promise.resolve();
+    for (let i = 0; i < 20 && !ipcMessageHandler; i += 1) await Promise.resolve();
 
-    sigintHandler?.();
+    ipcMessageHandler?.({
+      operationId: 'op-cancel',
+      signal: 'SIGINT',
+      type: 'lobe:hetero-exec:cancel',
+    });
+    for (let i = 0; i < 20 && kill.mock.calls.length === 0; i += 1) await Promise.resolve();
     expect(kill).toHaveBeenCalledWith('SIGINT');
     expect(mockHeteroFinishMutate).not.toHaveBeenCalled();
 
@@ -615,6 +620,212 @@ describe('hetero exec command', () => {
     await command;
 
     expect(callOrder).toEqual(['tool_result', 'tool_end', 'finish:cancelled']);
+    expect(mockHeteroFinishMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ error: undefined, result: 'cancelled' }),
+    );
+  });
+
+  it('latches a SIGINT that arrives before the agent process spawns (Unix device cancel)', async () => {
+    // agentRun.ts cancels Unix wrappers with a direct SIGINT. If it lands
+    // during setup — before runOneAgent installs its handlers — the early
+    // latch must record it so the run still flows through heteroFinish
+    // instead of dying on Node's default signal exit.
+    let earlySigintHandler: (() => void) | undefined;
+    vi.spyOn(process, 'on').mockImplementation(((event: string, listener: () => void) => {
+      if (event === 'SIGINT' && !earlySigintHandler) earlySigintHandler = listener;
+      return process;
+    }) as typeof process.on);
+
+    let resolveSpawn: ((handle: unknown) => void) | undefined;
+    mockSpawnAgent.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSpawn = resolve;
+        }),
+    );
+
+    const command = runCmd([
+      'hetero',
+      'exec',
+      '--type',
+      'codex',
+      '--prompt',
+      'hi',
+      '--topic',
+      'topic-1',
+      '--operation-id',
+      'op-early-cancel',
+      '--render',
+      'none',
+    ]);
+    for (let i = 0; i < 20 && !resolveSpawn; i += 1) await Promise.resolve();
+
+    // Cancellation arrives while spawnAgent is still preparing the process.
+    expect(earlySigintHandler).toBeDefined();
+    earlySigintHandler?.();
+
+    const stderr = new PassThrough();
+    stderr.end();
+    const kill = vi.fn();
+    resolveSpawn?.({
+      events: (async function* () {})(),
+      exit: Promise.resolve({ code: null, signal: 'SIGINT' as NodeJS.Signals }),
+      kill,
+      pid: 4242,
+      stderr,
+    });
+    await command;
+
+    // The latched signal is consumed right after spawn …
+    expect(kill).toHaveBeenCalledWith('SIGINT');
+    // … and the run still settles through the normal cancelled finish leg.
+    expect(mockHeteroFinishMutate).toHaveBeenCalledTimes(1);
+    expect(mockHeteroFinishMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ error: undefined, result: 'cancelled' }),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(130);
+  });
+
+  it('escalates to SIGKILL when the agent ignores the graceful cancellation signal', async () => {
+    // A tool subprocess can swallow SIGINT. The cancel has already been acked
+    // to the server, so the wrapper must bound termination itself: SIGKILL
+    // the tree after the grace window while staying alive for heteroFinish.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      let ipcMessageHandler: ((message: unknown) => void) | undefined;
+      vi.spyOn(process, 'on').mockImplementation(((event: string, listener: () => void) => {
+        if (event === 'message') ipcMessageHandler = listener;
+        return process;
+      }) as typeof process.on);
+
+      let resolveEvents: ((result: IteratorResult<Record<string, unknown>>) => void) | undefined;
+      const events: AsyncIterable<Record<string, unknown>> = {
+        [Symbol.asyncIterator]() {
+          return {
+            next: () =>
+              new Promise<IteratorResult<Record<string, unknown>>>((resolve) => {
+                resolveEvents = resolve;
+              }),
+          };
+        },
+      };
+      let resolveExit: (info: {
+        code: number | null;
+        signal: NodeJS.Signals | null;
+      }) => void = () => {};
+      const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+        (resolve) => {
+          resolveExit = resolve;
+        },
+      );
+      const stderr = new PassThrough();
+      stderr.end();
+      // SIGINT is ignored; only SIGKILL actually terminates the fake agent.
+      const kill = vi.fn((signal: NodeJS.Signals) => {
+        if (signal !== 'SIGKILL') return;
+        resolveEvents?.({ done: true, value: undefined });
+        resolveExit({ code: null, signal: 'SIGKILL' });
+      });
+      mockSpawnAgent.mockResolvedValue({ events, exit, kill, pid: 777, stderr });
+
+      const command = runCmd([
+        'hetero',
+        'exec',
+        '--type',
+        'codex',
+        '--prompt',
+        'hi',
+        '--topic',
+        'topic-1',
+        '--operation-id',
+        'op-stuck',
+        '--render',
+        'none',
+      ]);
+      for (let i = 0; i < 20 && !resolveEvents; i += 1) await Promise.resolve();
+
+      ipcMessageHandler?.({
+        operationId: 'op-stuck',
+        signal: 'SIGINT',
+        type: 'lobe:hetero-exec:cancel',
+      });
+      for (let i = 0; i < 20 && kill.mock.calls.length === 0; i += 1) await Promise.resolve();
+      expect(kill).toHaveBeenCalledWith('SIGINT');
+      expect(kill).not.toHaveBeenCalledWith('SIGKILL');
+
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(kill).toHaveBeenCalledWith('SIGKILL');
+
+      await command;
+      expect(mockHeteroFinishMutate).toHaveBeenCalledTimes(1);
+      expect(mockHeteroFinishMutate).toHaveBeenCalledWith(
+        expect.objectContaining({ error: undefined, result: 'cancelled' }),
+      );
+      expect(exitSpy).toHaveBeenCalledWith(137);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reports IPC cancellation that arrives while the final ingest batch is draining', async () => {
+    let ipcMessageHandler: ((message: unknown) => void) | undefined;
+    vi.spyOn(process, 'on').mockImplementation(((event: string, listener: () => void) => {
+      if (event === 'message') ipcMessageHandler = listener;
+      return process;
+    }) as typeof process.on);
+
+    mockSpawnAgent.mockReturnValue(
+      createFakeHandle({
+        events: [
+          {
+            data: { chunkType: 'text', content: 'done' },
+            operationId: 'op-draining',
+            stepIndex: 0,
+            timestamp: 1,
+            type: 'stream_chunk',
+          },
+        ],
+      }),
+    );
+
+    let markDrainStarted: (() => void) | undefined;
+    const drainStarted = new Promise<void>((resolve) => {
+      markDrainStarted = resolve;
+    });
+    let releaseDrain: (() => void) | undefined;
+    mockHeteroIngestMutate.mockImplementation(
+      () =>
+        new Promise<{ ack: true }>((resolve) => {
+          markDrainStarted?.();
+          releaseDrain = () => resolve({ ack: true });
+        }),
+    );
+
+    const command = runCmd([
+      'hetero',
+      'exec',
+      '--type',
+      'codex',
+      '--prompt',
+      'hi',
+      '--topic',
+      'topic-1',
+      '--operation-id',
+      'op-draining',
+      '--render',
+      'none',
+    ]);
+    await drainStarted;
+
+    ipcMessageHandler?.({
+      operationId: 'op-draining',
+      signal: 'SIGINT',
+      type: 'lobe:hetero-exec:cancel',
+    });
+    releaseDrain?.();
+    await command;
+
+    expect(mockHeteroFinishMutate).toHaveBeenCalledTimes(1);
     expect(mockHeteroFinishMutate).toHaveBeenCalledWith(
       expect.objectContaining({ error: undefined, result: 'cancelled' }),
     );

--- a/apps/cli/src/commands/hetero.ts
+++ b/apps/cli/src/commands/hetero.ts
@@ -12,6 +12,7 @@ import {
 } from '@lobechat/heterogeneous-agents';
 import type { AskUserBridge } from '@lobechat/heterogeneous-agents/askUser';
 import { LobeBuiltinMcpServer } from '@lobechat/heterogeneous-agents/builtinMcp';
+import { isHeteroExecCancelMessage } from '@lobechat/heterogeneous-agents/protocol';
 import { resolveHeteroSpawnCommand } from '@lobechat/heterogeneous-agents/resolveCliCommand';
 import type {
   AgentContentBlock,
@@ -37,6 +38,14 @@ export const SUPPORTED_AGENT_TYPES = new Set<string>(LOCAL_HETEROGENEOUS_AGENT_T
 const SUPPORTED_AGENT_TITLES = HETEROGENEOUS_AGENT_CONFIGS.map(({ title }) => title).join(' / ');
 const CODEX_REASONING_EFFORT_CONFIG_KEY = 'model_reasoning_effort';
 const CODEX_SERVICE_TIER_CONFIG_KEY = 'service_tier';
+
+/**
+ * How long a cancelled agent process gets to exit gracefully (flush its final
+ * stream-json events, restore terminal state) before the wrapper SIGKILLs its
+ * process tree. Must stay well below the caller-side
+ * `HETERO_EXEC_CANCEL_GRACE_MS` (30s) last-resort tree kill.
+ */
+const CANCEL_SIGKILL_GRACE_MS = 5000;
 
 /**
  * Patterns that indicate a `--resume <sessionId>` run should be retried
@@ -339,11 +348,78 @@ class RawStreamDump {
 }
 
 const exec = async (options: ExecOptions): Promise<void> => {
+  let activeAgentKill: ((signal: NodeJS.Signals) => void) | undefined;
+  let ipcCancelSignal: NodeJS.Signals | undefined;
+
+  // A native CLI (or one of its tool subprocesses, e.g. a bash that swallows
+  // SIGINT) can ignore the graceful cancellation signal. The device has
+  // already acknowledged the cancel to the server by then, so nothing
+  // upstream retries — without a bound the agent would keep running and
+  // modifying files indefinitely. Mirror the desktop session path
+  // (cancelSession): escalate to SIGKILL on the agent's process tree after a
+  // short grace, from inside the wrapper so the heteroFinish leg survives.
+  // Kept well below HETERO_EXEC_CANCEL_GRACE_MS (30s) so the caller's
+  // last-resort tree kill only fires when this wrapper itself is wedged.
+  let cancelEscalationTimer: NodeJS.Timeout | undefined;
+  const armCancelEscalation = () => {
+    if (cancelEscalationTimer) return;
+    cancelEscalationTimer = setTimeout(() => {
+      // Reset first so a pre-spawn no-op firing can be re-armed at the
+      // consume point in runOneAgent once the agent process exists.
+      cancelEscalationTimer = undefined;
+      activeAgentKill?.('SIGKILL');
+    }, CANCEL_SIGKILL_GRACE_MS);
+    cancelEscalationTimer.unref();
+  };
+
+  const onIpcMessage = (message: unknown) => {
+    if (
+      !isHeteroExecCancelMessage(message) ||
+      !options.operationId ||
+      message.operationId !== options.operationId ||
+      ipcCancelSignal
+    ) {
+      return;
+    }
+
+    ipcCancelSignal = message.signal;
+    activeAgentKill?.(message.signal);
+    if (activeAgentKill) armCancelEscalation();
+  };
+  process.on('message', onIpcMessage);
+
+  // Device cancellation reaches Unix wrappers as a plain SIGINT (agentRun
+  // signals the child directly; only Windows uses the IPC message), but
+  // runOneAgent installs its SIGINT/SIGTERM handlers only after spawnAgent
+  // resolves. A cancel landing during setup (prompt/image resolution) or the
+  // final drain would hit Node's default signal exit and skip the heteroFinish
+  // leg, leaving the server operation dangling. In server-ingest mode, latch
+  // those signals like an IPC cancel so the normal lifecycle consumes them;
+  // runOneAgent's own per-attempt handlers take precedence mid-run.
+  let agentSignalHandlersInstalled = false;
+  const onLatchedSignal = (signal: NodeJS.Signals) => {
+    if (agentSignalHandlersInstalled || ipcCancelSignal) return;
+    ipcCancelSignal = signal;
+    activeAgentKill?.(signal);
+    if (activeAgentKill) armCancelEscalation();
+  };
+  const onLatchedSigint = () => onLatchedSignal('SIGINT');
+  const onLatchedSigterm = () => onLatchedSignal('SIGTERM');
+  if (options.topic) {
+    process.on('SIGINT', onLatchedSigint);
+    process.on('SIGTERM', onLatchedSigterm);
+  }
+
+  const exitProcess = (code: number): never => {
+    process.off('message', onIpcMessage);
+    process.exit(code);
+  };
+
   if (!isLocalHeterogeneousType(options.type)) {
     log.error(
       `Unsupported --type "${options.type}". Supported: ${[...SUPPORTED_AGENT_TYPES].join(', ')}`,
     );
-    process.exit(2);
+    exitProcess(2);
   }
 
   let resolved: ResolvedPrompt;
@@ -351,14 +427,14 @@ const exec = async (options: ExecOptions): Promise<void> => {
     resolved = await resolvePrompt(options);
   } catch (err) {
     log.error(err instanceof Error ? err.message : String(err));
-    process.exit(2);
+    exitProcess(2);
   }
 
   if (!resolved.describe()) {
     log.error(
       'Empty prompt. Pass --prompt <text>, --image <path>, --input-json <file|->, or pipe content via stdin.',
     );
-    process.exit(2);
+    exitProcess(2);
   }
 
   // Server-ingest mode is active when --topic is provided.
@@ -367,7 +443,7 @@ const exec = async (options: ExecOptions): Promise<void> => {
   const serverIngest = !!options.topic;
   if (serverIngest && !options.operationId) {
     log.error('--operation-id is required when --topic is set (server-ingest mode).');
-    process.exit(2);
+    exitProcess(2);
   }
 
   const operationId = options.operationId || randomUUID();
@@ -610,7 +686,7 @@ const exec = async (options: ExecOptions): Promise<void> => {
           // best-effort; process is exiting anyway
         }
       }
-      process.exit(1);
+      exitProcess(1);
     }
 
     // Always collect stderr — used for resume-error detection AND for
@@ -636,23 +712,33 @@ const exec = async (options: ExecOptions): Promise<void> => {
       return { code: 1, signal: null as NodeJS.Signals | null };
     });
 
+    const killAgent = (signal: NodeJS.Signals) => handle.kill(signal);
+    activeAgentKill = killAgent;
+
     // Ctrl-C → SIGINT to the child's process group.
     // Repeated Ctrl-C escalates to SIGKILL.
-    let interrupted = false;
+    let interrupted = ipcCancelSignal !== undefined;
+    if (ipcCancelSignal) {
+      killAgent(ipcCancelSignal);
+      armCancelEscalation();
+    }
     const onSigint = () => {
       if (interrupted) {
-        handle.kill('SIGKILL');
+        killAgent('SIGKILL');
         return;
       }
       interrupted = true;
-      handle.kill('SIGINT');
+      killAgent('SIGINT');
+      armCancelEscalation();
     };
     const onSigterm = () => {
       interrupted = true;
-      handle.kill('SIGTERM');
+      killAgent('SIGTERM');
+      armCancelEscalation();
     };
     process.on('SIGINT', onSigint);
     process.on('SIGTERM', onSigterm);
+    agentSignalHandlersInstalled = true;
 
     // Stream events. Each event is optionally written as JSONL and pushed
     // into the ingester.  When intercepting resume errors, a matching
@@ -718,13 +804,15 @@ const exec = async (options: ExecOptions): Promise<void> => {
         }
       }
       await dumpAttempt?.close();
-      process.exit(1);
+      exitProcess(1);
     } finally {
       process.off('SIGINT', onSigint);
       process.off('SIGTERM', onSigterm);
+      agentSignalHandlersInstalled = false;
     }
 
     const { code, signal } = await exit;
+    if (activeAgentKill === killAgent) activeAgentKill = undefined;
     await stderrEnded;
     await dumpAttempt?.close();
 
@@ -740,7 +828,7 @@ const exec = async (options: ExecOptions): Promise<void> => {
     }
 
     return {
-      cancelled: interrupted,
+      cancelled: interrupted || ipcCancelSignal !== undefined,
       code,
       ingestError,
       resumeNotFound,
@@ -839,11 +927,16 @@ const exec = async (options: ExecOptions): Promise<void> => {
       result = { ...result, ingestError: true };
     }
 
+    // Cancellation can arrive after the native agent exits while its final
+    // event batch is still draining. Read the live IPC latch here rather than
+    // relying only on runOneAgent's earlier snapshot.
+    const cancelled = result.cancelled || ipcCancelSignal !== undefined;
+
     // CC relays API/rate-limit errors as an in-stream terminal `error` event but
     // still exits 0, so the exit code alone would report `success`. Treat any
     // pushed terminal error as a failed run so the topic/task is marked failed.
     const exitedClean =
-      !result.cancelled &&
+      !cancelled &&
       !result.ingestError &&
       !result.sawTerminalError &&
       (code === 0 || signal === 'SIGTERM');
@@ -862,7 +955,7 @@ const exec = async (options: ExecOptions): Promise<void> => {
     // which would drop `agentType`/`code` and demote the client UI to the
     // generic error card.
     const finishError =
-      result.cancelled || exitedClean
+      cancelled || exitedClean
         ? undefined
         : result.terminalErrorData
           ? {
@@ -877,7 +970,7 @@ const exec = async (options: ExecOptions): Promise<void> => {
     try {
       await sink.finish({
         error: finishError,
-        result: result.cancelled ? 'cancelled' : exitedClean ? 'success' : 'error',
+        result: cancelled ? 'cancelled' : exitedClean ? 'success' : 'error',
         sessionId,
       });
     } catch (err) {
@@ -895,11 +988,11 @@ const exec = async (options: ExecOptions): Promise<void> => {
   }
   if (askMcpConfigPath) await unlink(askMcpConfigPath).catch(() => {});
 
-  if (code !== null) process.exit(result.ingestError ? 1 : code);
-  if (signal === 'SIGINT') process.exit(130);
-  if (signal === 'SIGTERM') process.exit(143);
-  if (signal === 'SIGKILL') process.exit(137);
-  process.exit(1);
+  if (code !== null) exitProcess(result.ingestError ? 1 : code);
+  if (signal === 'SIGINT') exitProcess(130);
+  if (signal === 'SIGTERM') exitProcess(143);
+  if (signal === 'SIGKILL') exitProcess(137);
+  exitProcess(1);
 };
 
 export function registerHeteroCommand(program: Command) {

--- a/apps/cli/src/device/agentRun.test.ts
+++ b/apps/cli/src/device/agentRun.test.ts
@@ -1,17 +1,32 @@
 import { EventEmitter } from 'node:events';
+import * as os from 'node:os';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { spawnHeteroAgentRun } from './agentRun';
+import { cancelHeteroAgentRun, spawnHeteroAgentRun } from './agentRun';
 
 const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
 
 vi.mock('node:child_process', () => ({ spawn: spawnMock }));
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof os>('node:os');
+  return { ...actual, platform: vi.fn(() => 'linux') };
+});
 
-const makeFakeChild = () => {
+const platformMock = vi.mocked(os.platform);
+
+const makeFakeChild = (pid = 9999) => {
   const child = new EventEmitter() as EventEmitter & {
+    connected: boolean;
+    kill: ReturnType<typeof vi.fn>;
+    pid: number;
+    send: ReturnType<typeof vi.fn>;
     stdin: { end: ReturnType<typeof vi.fn>; write: ReturnType<typeof vi.fn> };
   };
+  child.connected = true;
+  child.kill = vi.fn(() => true);
+  child.pid = pid;
+  child.send = vi.fn((_message, callback?: (error: Error | null) => void) => callback?.(null));
   child.stdin = { end: vi.fn(), write: vi.fn() };
   return child;
 };
@@ -26,6 +41,10 @@ const baseParams = {
 };
 
 describe('spawnHeteroAgentRun', () => {
+  beforeEach(() => {
+    platformMock.mockReturnValue('linux');
+  });
+
   afterEach(() => {
     spawnMock.mockReset();
   });
@@ -70,6 +89,7 @@ describe('spawnHeteroAgentRun', () => {
         LOBEHUB_JWT: 'jwt-token',
         LOBEHUB_SERVER: 'https://app.lobehub.com',
       }),
+      stdio: ['pipe', 'inherit', 'inherit', 'ipc'],
     });
 
     // stdin is only written after the child actually spawns.
@@ -154,5 +174,67 @@ describe('spawnHeteroAgentRun', () => {
         { source: { id: 'file-1', type: 'url', url: 'https://signed/a.png' }, type: 'image' },
       ]),
     );
+  });
+
+  it('cancels an active gateway-dispatched wrapper by operation id', async () => {
+    const child = makeFakeChild(4321);
+    spawnMock.mockReturnValue(child);
+    const ackPromise = spawnHeteroAgentRun({ ...baseParams, operationId: 'op-cancel' });
+    child.emit('spawn');
+    await ackPromise;
+
+    expect(cancelHeteroAgentRun('op-cancel', 'SIGINT')).toEqual({ pid: 4321, signal: 'SIGINT' });
+    expect(child.kill).toHaveBeenCalledWith('SIGINT');
+
+    child.emit('exit', 130, 'SIGINT');
+    expect(cancelHeteroAgentRun('op-cancel')).toBeUndefined();
+  });
+
+  it('uses IPC to preserve the wrapper finish path when cancelling on Windows', async () => {
+    platformMock.mockReturnValue('win32');
+    const child = makeFakeChild(4321);
+    spawnMock.mockReturnValue(child);
+    const ackPromise = spawnHeteroAgentRun({ ...baseParams, operationId: 'op-windows' });
+    child.emit('spawn');
+    await ackPromise;
+
+    expect(cancelHeteroAgentRun('op-windows', 'SIGINT')).toEqual({
+      pid: 4321,
+      signal: 'SIGINT',
+    });
+    expect(child.send).toHaveBeenCalledWith(
+      {
+        operationId: 'op-windows',
+        signal: 'SIGINT',
+        type: 'lobe:hetero-exec:cancel',
+      },
+      expect.any(Function),
+    );
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    child.emit('exit', 130, 'SIGINT');
+    expect(cancelHeteroAgentRun('op-windows')).toBeUndefined();
+  });
+
+  it('keeps the Windows force-kill deadline anchored to the first cancellation', async () => {
+    vi.useFakeTimers();
+    const child = makeFakeChild(4321);
+    platformMock.mockReturnValue('win32');
+    spawnMock.mockReturnValue(child);
+    const ackPromise = spawnHeteroAgentRun({ ...baseParams, operationId: 'op-deadline' });
+    child.emit('spawn');
+    await ackPromise;
+
+    cancelHeteroAgentRun('op-deadline');
+    await vi.advanceTimersByTimeAsync(20_000);
+    cancelHeteroAgentRun('op-deadline');
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(spawnMock).toHaveBeenLastCalledWith('taskkill', ['/pid', '4321', '/T', '/F'], {
+      stdio: 'ignore',
+    });
+    child.emit('exit', 130, 'SIGINT');
+    vi.useRealTimers();
   });
 });

--- a/apps/cli/src/device/agentRun.ts
+++ b/apps/cli/src/device/agentRun.ts
@@ -1,7 +1,10 @@
 import { spawn } from 'node:child_process';
+import { platform } from 'node:os';
 
 import {
   buildHeteroExecStdinPayload,
+  HETERO_EXEC_CANCEL_GRACE_MS,
+  type HeteroExecCancelMessage,
   type HeteroExecImageRef,
 } from '@lobechat/heterogeneous-agents/protocol';
 
@@ -29,6 +32,65 @@ export interface AgentRunAckResult {
 interface SpawnHeteroAgentRunLogger {
   error?: (msg: string) => void;
   info?: (msg: string) => void;
+}
+
+interface ActiveAgentRun {
+  child: ReturnType<typeof spawn>;
+  forceKillTimer?: ReturnType<typeof setTimeout>;
+}
+
+/** Active `lh hetero exec` wrappers, keyed by the server operation/task id. */
+const activeAgentRuns = new Map<string, ActiveAgentRun>();
+
+const clearForceKillTimer = (run: ActiveAgentRun): void => {
+  if (!run.forceKillTimer) return;
+  clearTimeout(run.forceKillTimer);
+  run.forceKillTimer = undefined;
+};
+
+const scheduleWindowsForceKill = (run: ActiveAgentRun): void => {
+  if (run.forceKillTimer) return;
+  run.forceKillTimer = setTimeout(() => {
+    const killer = spawn('taskkill', ['/pid', String(run.child.pid), '/T', '/F'], {
+      stdio: 'ignore',
+    });
+    killer.once('error', () => {});
+  }, HETERO_EXEC_CANCEL_GRACE_MS);
+  run.forceKillTimer.unref();
+};
+
+/**
+ * Cancel a gateway-dispatched local CLI run. The wrapper owns SIGINT/SIGTERM
+ * forwarding to the actual agent process tree, so signalling it preserves the
+ * same graceful heteroFinish path as Ctrl-C in `lh hetero exec`.
+ */
+export function cancelHeteroAgentRun(
+  operationId: string,
+  signal: NodeJS.Signals = 'SIGINT',
+): { pid: number; signal: NodeJS.Signals } | undefined {
+  const run = activeAgentRuns.get(operationId);
+  const child = run?.child;
+  if (!child?.pid) return undefined;
+
+  if (platform() === 'win32') {
+    const message: HeteroExecCancelMessage = {
+      operationId,
+      signal: signal === 'SIGTERM' ? 'SIGTERM' : 'SIGINT',
+      type: 'lobe:hetero-exec:cancel',
+    };
+    scheduleWindowsForceKill(run);
+    if (child.connected) {
+      try {
+        child.send(message, () => {});
+      } catch {
+        // The bounded force-kill fallback remains armed.
+      }
+    }
+  } else {
+    child.kill(signal);
+  }
+
+  return { pid: child.pid, signal };
 }
 
 /**
@@ -110,10 +172,11 @@ export function spawnHeteroAgentRun(
         LOBEHUB_JWT: jwt,
         LOBEHUB_SERVER: serverUrl,
       },
-      stdio: ['pipe', 'inherit', 'inherit'],
+      stdio: ['pipe', 'inherit', 'inherit', 'ipc'],
     });
 
     child.once('spawn', () => {
+      if (child.pid) activeAgentRuns.set(operationId, { child });
       // Only safe to write stdin once the process actually started.
       try {
         child.stdin?.write(stdinPayload);
@@ -127,11 +190,21 @@ export function spawnHeteroAgentRun(
     });
 
     child.once('error', (err) => {
+      const run = activeAgentRuns.get(operationId);
+      if (run?.child === child) {
+        clearForceKillTimer(run);
+        activeAgentRuns.delete(operationId);
+      }
       logger?.error?.(`hetero exec spawn failed (op=${operationId}): ${err.message}`);
       settle({ reason: err.message, status: 'rejected' });
     });
 
     child.on('exit', (code, signal) => {
+      const run = activeAgentRuns.get(operationId);
+      if (run?.child === child) {
+        clearForceKillTimer(run);
+        activeAgentRuns.delete(operationId);
+      }
       logger?.info?.(`hetero exec exited (op=${operationId}) code=${code} signal=${signal}`);
     });
   });

--- a/apps/cli/src/tools/__tests__/heteroTask.test.ts
+++ b/apps/cli/src/tools/__tests__/heteroTask.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getTrpcClient } from '../../api/client';
 import { removeTask, saveTask } from '../../daemon/taskRegistry';
-import { runHeteroTask } from '../heteroTask';
+import { cancelHeteroTask, runHeteroTask } from '../heteroTask';
 
 // ─── Mocks ───
 
@@ -10,6 +10,7 @@ const spawnMock = vi.hoisted(() => vi.fn());
 const execFileSyncMock = vi.hoisted(() => vi.fn());
 const fsState = vi.hoisted(() => ({ content: undefined as string | undefined }));
 const notifyMutateMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const cancelHeteroAgentRunMock = vi.hoisted(() => vi.fn());
 
 vi.mock('node:child_process', () => ({
   execFileSync: execFileSyncMock,
@@ -27,6 +28,10 @@ vi.mock('node:fs', () => ({
       fsState.content = content;
     }),
   },
+}));
+
+vi.mock('../../device/agentRun', () => ({
+  cancelHeteroAgentRun: cancelHeteroAgentRunMock,
 }));
 
 // task registry — use real implementation backed by a temporary in-memory map
@@ -377,6 +382,16 @@ describe('runHeteroTask (openclaw)', () => {
     for (const call of getTrpcClientMock.mock.calls) {
       expect(call[0]).toBe('ws-99');
     }
+  });
+
+  it('cancels a gateway-dispatched local CLI wrapper before checking platform tasks', async () => {
+    cancelHeteroAgentRunMock.mockReturnValueOnce({ pid: 4242, signal: 'SIGINT' });
+
+    await expect(cancelHeteroTask({ taskId: 'operation-local' })).resolves.toBe(
+      JSON.stringify({ pid: 4242, signal: 'SIGINT', taskId: 'operation-local' }),
+    );
+
+    expect(cancelHeteroAgentRunMock).toHaveBeenCalledWith('operation-local', 'SIGINT');
   });
 });
 

--- a/apps/cli/src/tools/heteroTask.ts
+++ b/apps/cli/src/tools/heteroTask.ts
@@ -7,6 +7,7 @@ import type { RemoteHeterogeneousAgentType } from '@lobechat/heterogeneous-agent
 
 import { getTrpcClient } from '../api/client';
 import { getTask, listTasks, removeTask, saveTask } from '../daemon/taskRegistry';
+import { cancelHeteroAgentRun } from '../device/agentRun';
 import { log } from '../utils/logger';
 
 // ─── Hermes session persistence ───
@@ -377,6 +378,9 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
 
 export async function cancelHeteroTask(params: CancelHeteroTaskParams): Promise<string> {
   const { signal = 'SIGINT', taskId } = params;
+  const agentRun = cancelHeteroAgentRun(taskId, signal);
+  if (agentRun) return JSON.stringify({ ...agentRun, taskId });
+
   const entry = getTask(taskId);
 
   if (!entry) {

--- a/apps/cli/src/tools/index.test.ts
+++ b/apps/cli/src/tools/index.test.ts
@@ -223,4 +223,14 @@ describe('executeToolCall', () => {
     expect(result.success).toBe(true);
     expect((result.state as { success: boolean }).success).toBe(false);
   });
+
+  it('should expose a rejected heterogeneous cancellation in the tool result', async () => {
+    const result = await executeToolCall(
+      'cancelHeteroTask',
+      JSON.stringify({ taskId: 'nonexistent-operation' }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.state).toEqual(expect.objectContaining({ success: false }));
+  });
 });

--- a/apps/cli/src/tools/index.ts
+++ b/apps/cli/src/tools/index.ts
@@ -70,6 +70,23 @@ export async function executeToolCall(
     const result = await handler(finalArgs);
     const content = typeof result === 'string' ? result : JSON.stringify(result);
 
+    if (apiName === 'cancelHeteroTask') {
+      let state: unknown = result;
+      if (typeof result === 'string') {
+        try {
+          state = JSON.parse(result);
+        } catch {
+          state = undefined;
+        }
+      }
+      const semanticSuccess =
+        state && typeof state === 'object'
+          ? (state as { success?: unknown }).success !== false
+          : true;
+
+      return { content, state, success: semanticSuccess };
+    }
+
     return { content, success: true };
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);

--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -1028,15 +1028,19 @@ export default class GatewayConnectionCtr extends ControllerModule {
   private async cancelHeteroTask(args: { signal?: string; taskId: string }): Promise<string> {
     const { signal = 'SIGINT', taskId } = args;
     const entry = this.platformTasks.get(taskId);
-
-    if (!entry) {
-      return JSON.stringify({ message: `No task found with taskId: ${taskId}`, success: false });
+    if (entry) {
+      // The close handler sends the terminal notify after the whole tree exits.
+      this.killPlatformProcessTree(entry.pid, signal as NodeJS.Signals);
+      return JSON.stringify({ pid: entry.pid, signal, taskId });
     }
 
-    // The close handler sends the terminal notify after the whole tree exits.
-    this.killPlatformProcessTree(entry.pid, signal as NodeJS.Signals);
+    const agentRun = await this.heterogeneousAgentCtr.cancelLhHeteroExec({
+      operationId: taskId,
+      signal: signal as NodeJS.Signals,
+    });
+    if (agentRun) return JSON.stringify({ ...agentRun, taskId });
 
-    return JSON.stringify({ pid: entry.pid, signal, taskId });
+    return JSON.stringify({ message: `No task found with taskId: ${taskId}`, success: false });
   }
 
   /**

--- a/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
@@ -115,4 +115,10 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
       implementation.spawnLhHeteroExec(...args),
     );
   }
+
+  cancelLhHeteroExec(...args: Parameters<Implementation['cancelLhHeteroExec']>) {
+    return this.getImplementation().then((implementation) =>
+      implementation.cancelLhHeteroExec(...args),
+    );
+  }
 }

--- a/apps/desktop/src/main/controllers/HeterogeneousAgentImpl.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentImpl.ts
@@ -3,7 +3,7 @@ import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { existsSync, unlinkSync } from 'node:fs';
 import { access, appendFile, mkdir, unlink, writeFile } from 'node:fs/promises';
-import os from 'node:os';
+import os, { platform } from 'node:os';
 import path from 'node:path';
 import type { Readable, Writable } from 'node:stream';
 import { finished as streamFinished } from 'node:stream/promises';
@@ -29,10 +29,14 @@ import type {
   McpToolResult,
 } from '@lobechat/heterogeneous-agents/builtinMcp';
 import { listHeterogeneousAgentModels } from '@lobechat/heterogeneous-agents/models';
-import type { HeteroExecImageRef } from '@lobechat/heterogeneous-agents/protocol';
+import type {
+  HeteroExecCancelMessage,
+  HeteroExecImageRef,
+} from '@lobechat/heterogeneous-agents/protocol';
 import {
   buildHeteroExecStdinPayload,
   buildHeterogeneousPrompt,
+  HETERO_EXEC_CANCEL_GRACE_MS,
 } from '@lobechat/heterogeneous-agents/protocol';
 import {
   CLAUDE_CODE_QUOTA_FRESH_MS,
@@ -159,6 +163,11 @@ interface StartSessionParams {
   useClaudeCodeSdk?: boolean;
   /** Run Codex prompts through codex app-server instead of one-shot codex exec (lab preference) */
   useCodexAppServer?: boolean;
+}
+
+interface GatewayAgentRun {
+  child: ChildProcess;
+  forceKillTimer?: ReturnType<typeof setTimeout>;
 }
 
 export interface StartSessionResult {
@@ -353,6 +362,8 @@ export default class HeterogeneousAgentCtr {
   }
 
   private sessions = new Map<string, AgentSession>();
+  /** Gateway-dispatched `lh hetero exec` wrappers, keyed by server operation id. */
+  private gatewayAgentRuns = new Map<string, GatewayAgentRun>();
   /**
    * Per-operation AskUserQuestion bridge state. Keyed by `operationId` so the
    * `submitIntervention` IPC can route an answer to the right pending MCP
@@ -1990,6 +2001,49 @@ export default class HeterogeneousAgentCtr {
   }
 
   /**
+   * Cancel a connected-device run started by {@link spawnLhHeteroExec}.
+   * The wrapper forwards the signal to its agent process tree and completes the
+   * normal heteroFinish cancellation path.
+   */
+  cancelLhHeteroExec(params: {
+    operationId: string;
+    signal?: NodeJS.Signals;
+  }): { pid: number; signal: NodeJS.Signals } | undefined {
+    const run = this.gatewayAgentRuns.get(params.operationId);
+    const child = run?.child;
+    if (!child?.pid) return undefined;
+
+    const signal = params.signal ?? 'SIGINT';
+    if (platform() === 'win32') {
+      if (!run.forceKillTimer) {
+        run.forceKillTimer = setTimeout(() => {
+          const killer = spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], {
+            stdio: 'ignore',
+          });
+          killer.once('error', () => {});
+        }, HETERO_EXEC_CANCEL_GRACE_MS);
+        run.forceKillTimer.unref();
+      }
+
+      const message: HeteroExecCancelMessage = {
+        operationId: params.operationId,
+        signal: signal === 'SIGTERM' ? 'SIGTERM' : 'SIGINT',
+        type: 'lobe:hetero-exec:cancel',
+      };
+      if (child.connected) {
+        try {
+          child.send(message, () => {});
+        } catch {
+          // The bounded force-kill fallback remains armed.
+        }
+      }
+    } else {
+      this.killProcessTree(child, signal);
+    }
+    return { pid: child.pid, signal };
+  }
+
+  /**
    * Spawn the embedded CLI's `hetero exec` for gateway-driven agent runs.
    * The bundled CLI handles everything downstream — no local
    * AgentStreamPipeline or IPC broadcast needed. Mirrors
@@ -2082,10 +2136,15 @@ export default class HeterogeneousAgentCtr {
     const child = spawn(process.execPath, [cliScript, ...args], {
       cwd: workDir,
       env,
-      stdio: ['pipe', 'inherit', 'inherit'],
+      stdio: ['pipe', 'inherit', 'inherit', 'ipc'],
     });
 
     child.on('exit', (code, signal) => {
+      const run = this.gatewayAgentRuns.get(operationId);
+      if (run?.child === child) {
+        if (run.forceKillTimer) clearTimeout(run.forceKillTimer);
+        this.gatewayAgentRuns.delete(operationId);
+      }
       logger.info('spawnLhHeteroExec: exited — op=%s code=%s signal=%s', operationId, code, signal);
     });
 
@@ -2107,6 +2166,7 @@ export default class HeterogeneousAgentCtr {
       });
 
       child.once('spawn', () => {
+        if (child.pid) this.gatewayAgentRuns.set(operationId, { child });
         try {
           child.stdin.write(stdinPayload);
           child.stdin.end();
@@ -2123,6 +2183,11 @@ export default class HeterogeneousAgentCtr {
       });
 
       child.once('error', (err) => {
+        const run = this.gatewayAgentRuns.get(operationId);
+        if (run?.child === child) {
+          if (run.forceKillTimer) clearTimeout(run.forceKillTimer);
+          this.gatewayAgentRuns.delete(operationId);
+        }
         logger.error('spawnLhHeteroExec: spawn failed — %s', err.message);
         settle({ reason: err.message, status: 'rejected' });
       });

--- a/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
@@ -247,6 +247,7 @@ const mockShellCommandCtr = {
 } as unknown as ShellCommandCtr;
 
 const mockHeterogeneousAgentCtr = {
+  cancelLhHeteroExec: vi.fn().mockResolvedValue(undefined),
   sendPrompt: vi.fn().mockResolvedValue(undefined),
   spawnLhHeteroExec: vi.fn().mockResolvedValue({ status: 'accepted' }),
   startSession: vi.fn().mockResolvedValue({ sessionId: 'mock-session-id' }),
@@ -978,6 +979,26 @@ describe('GatewayConnectionCtr', () => {
         operationId: 'op-spawn-fail',
         reason: 'spawn EACCES',
         status: 'rejected',
+      });
+    });
+
+    it('routes cancelHeteroTask to a gateway-dispatched local CLI run', async () => {
+      vi.mocked(mockHeterogeneousAgentCtr.cancelLhHeteroExec).mockResolvedValueOnce({
+        pid: 4242,
+        signal: 'SIGINT',
+      });
+      const client = await connectAndOpen();
+
+      client.simulateToolCallRequest(
+        'cancelHeteroTask',
+        { signal: 'SIGINT', taskId: 'op-local' },
+        'req-cancel-local',
+      );
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(mockHeterogeneousAgentCtr.cancelLhHeteroExec).toHaveBeenCalledWith({
+        operationId: 'op-local',
+        signal: 'SIGINT',
       });
     });
   });

--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
@@ -1497,17 +1497,22 @@ describe('HeterogeneousAgentCtr', () => {
       topicId: 'topic-gateway',
     };
 
-    const createGatewayCliProc = () => {
+    const createGatewayCliProc = (pid?: number) => {
       const proc = new EventEmitter() as any;
       const stdin = new EventEmitter() as any;
       stdin.end = vi.fn();
       stdin.write = vi.fn(() => true);
+      proc.connected = true;
+      proc.kill = vi.fn(() => true);
+      proc.pid = pid;
+      proc.send = vi.fn((_message, callback?: (error: Error | null) => void) => callback?.(null));
       proc.stdin = stdin;
       return proc;
     };
 
     beforeEach(() => {
       vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(os.platform).mockReturnValue('linux');
       spawnCalls.length = 0;
       nextFakeProc = null;
     });
@@ -1541,6 +1546,7 @@ describe('HeterogeneousAgentCtr', () => {
           LOBEHUB_SERVER: 'https://server.example.com',
         }),
       );
+      expect(spawnCall.options.stdio).toEqual(['pipe', 'inherit', 'inherit', 'ipc']);
       expect(proc.stdin.write).not.toHaveBeenCalled();
 
       proc.emit('spawn');
@@ -1548,6 +1554,88 @@ describe('HeterogeneousAgentCtr', () => {
       await expect(ack).resolves.toEqual({ status: 'accepted' });
       expect(proc.stdin.write).toHaveBeenCalledOnce();
       expect(proc.stdin.end).toHaveBeenCalledOnce();
+    });
+
+    it('tracks and cancels a connected-device CLI wrapper by operation id', async () => {
+      const proc = createGatewayCliProc(4321);
+      nextFakeProc = proc;
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+      const ctr = new HeterogeneousAgentCtr({
+        appStoragePath,
+        storeManager: { get: vi.fn() },
+      } as any);
+
+      const ack = ctr.spawnLhHeteroExec({ ...params, operationId: 'op-cancel' });
+      proc.emit('spawn');
+      await ack;
+
+      expect(ctr.cancelLhHeteroExec({ operationId: 'op-cancel' })).toEqual({
+        pid: 4321,
+        signal: 'SIGINT',
+      });
+      expect(killSpy).toHaveBeenCalledWith(-4321, 'SIGINT');
+
+      proc.emit('exit', 130, 'SIGINT');
+      expect(ctr.cancelLhHeteroExec({ operationId: 'op-cancel' })).toBeUndefined();
+      killSpy.mockRestore();
+    });
+
+    it('uses IPC to preserve the embedded CLI finish path on Windows cancellation', async () => {
+      vi.mocked(os.platform).mockReturnValue('win32');
+      const proc = createGatewayCliProc(4321);
+      nextFakeProc = proc;
+      const ctr = new HeterogeneousAgentCtr({
+        appStoragePath,
+        storeManager: { get: vi.fn() },
+      } as any);
+
+      const ack = ctr.spawnLhHeteroExec({ ...params, operationId: 'op-windows' });
+      proc.emit('spawn');
+      await ack;
+
+      expect(ctr.cancelLhHeteroExec({ operationId: 'op-windows' })).toEqual({
+        pid: 4321,
+        signal: 'SIGINT',
+      });
+      expect(proc.send).toHaveBeenCalledWith(
+        {
+          operationId: 'op-windows',
+          signal: 'SIGINT',
+          type: 'lobe:hetero-exec:cancel',
+        },
+        expect.any(Function),
+      );
+      expect(proc.kill).not.toHaveBeenCalled();
+
+      proc.emit('exit', 130, 'SIGINT');
+    });
+
+    it('keeps the Windows force-kill deadline anchored to the first cancellation', async () => {
+      vi.useFakeTimers();
+      vi.mocked(os.platform).mockReturnValue('win32');
+      const proc = createGatewayCliProc(4321);
+      nextFakeProc = proc;
+      const ctr = new HeterogeneousAgentCtr({
+        appStoragePath,
+        storeManager: { get: vi.fn() },
+      } as any);
+
+      const ack = ctr.spawnLhHeteroExec({ ...params, operationId: 'op-deadline' });
+      proc.emit('spawn');
+      await ack;
+
+      ctr.cancelLhHeteroExec({ operationId: 'op-deadline' });
+      await vi.advanceTimersByTimeAsync(20_000);
+      ctr.cancelLhHeteroExec({ operationId: 'op-deadline' });
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(spawnCalls.at(-1)).toEqual({
+        args: ['/pid', '4321', '/T', '/F'],
+        command: 'taskkill',
+        options: { stdio: 'ignore' },
+      });
+      proc.emit('exit', 130, 'SIGINT');
+      vi.useRealTimers();
     });
 
     it('rejects the gateway request when the embedded CLI cannot spawn', async () => {

--- a/apps/desktop/src/main/modules/binaries/__tests__/cliAgentBinaries.test.ts
+++ b/apps/desktop/src/main/modules/binaries/__tests__/cliAgentBinaries.test.ts
@@ -36,13 +36,6 @@ const callExecFileError = (err: Error) => {
     return {} as any;
   }) as any);
 };
-const callExec = (stdout: string, stderr = '') => {
-  execMock.mockImplementationOnce(((cmd: string, opts: any, cb: any) => {
-    const callback = typeof opts === 'function' ? opts : cb;
-    callback(noErr, { stdout, stderr });
-    return {} as any;
-  }) as any);
-};
 
 describe('cliAgentBinaries', () => {
   beforeEach(() => {
@@ -59,11 +52,11 @@ describe('cliAgentBinaries', () => {
       platformMock.mockReturnValue('win32');
     });
 
-    it('resolves `claude` to the .cmd path via `where`, then runs it through the shell', async () => {
+    it('resolves `claude` to the .cmd path via `where` without constructing a shell command', async () => {
       // 1) `where claude` → resolves to the .cmd shim under %APPDATA%\npm
       callExecFile('C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude.cmd\r\n');
-      // 2) `cmd /c "...\\claude.cmd" --version` → keyword match
-      callExec('1.2.3 (Claude Code)');
+      // 2) validate the resolved command without interpolating it into a shell string
+      callExecFile('1.2.3 (Claude Code)');
 
       const { claudeCodeBinary } = await import('../cliAgentBinaries');
       const status = await claudeCodeBinary.detect();
@@ -72,11 +65,12 @@ describe('cliAgentBinaries', () => {
       expect(status.path).toBe('C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude.cmd');
       expect(status.version).toBe('1.2.3 (Claude Code)');
 
-      // The validation call must go via `exec` (shell), NOT `execFile`, so
-      // cmd.exe can actually interpret the .cmd shim.
-      expect(execMock).toHaveBeenCalledTimes(1);
-      const execCall = execMock.mock.calls[0]!;
-      expect(execCall[0]).toBe('"C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude.cmd" --version');
+      expect(execMock).not.toHaveBeenCalled();
+      expect(execFileMock).toHaveBeenCalledTimes(2);
+      expect(execFileMock.mock.calls[1]![0]).toBe(
+        'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude.cmd',
+      );
+      expect(execFileMock.mock.calls[1]![1]).toEqual(['--version']);
     });
 
     it('returns unavailable when `where` finds nothing', async () => {
@@ -101,7 +95,7 @@ describe('cliAgentBinaries', () => {
 
     it('fails detection when version output does not match the expected keyword', async () => {
       callExecFile('C:\\some\\other\\claude.cmd\r\n');
-      callExec('this is some other binary v1.0');
+      callExecFile('this is some other binary v1.0');
 
       const { claudeCodeBinary } = await import('../cliAgentBinaries');
       const status = await claudeCodeBinary.detect();
@@ -120,16 +114,18 @@ describe('cliAgentBinaries', () => {
           'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\codex.ps1',
         ].join('\r\n'),
       );
-      callExec('codex 0.130.0');
+      callExecFile('codex 0.130.0');
 
       const { codexBinary } = await import('../cliAgentBinaries');
       const status = await codexBinary.detect();
 
       expect(status.available).toBe(true);
       expect(status.path).toBe('C:\\Users\\Hanam\\AppData\\Roaming\\npm\\codex.cmd');
-      expect(execMock.mock.calls[0]![0]).toBe(
-        '"C:\\Users\\Hanam\\AppData\\Roaming\\npm\\codex.cmd" --version',
+      expect(execMock).not.toHaveBeenCalled();
+      expect(execFileMock.mock.calls[1]![0]).toBe(
+        'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\codex.cmd',
       );
+      expect(execFileMock.mock.calls[1]![1]).toEqual(['--version']);
     });
 
     it('prefers .exe over .cmd when both are present', async () => {
@@ -154,17 +150,18 @@ describe('cliAgentBinaries', () => {
           'C:\\Users\\hp\\.vite-plus\\bin\\claude.exe',
         ].join('\r\n'),
       );
-      callExec('1.2.3 (Claude Code)');
+      callExecFile('1.2.3 (Claude Code)');
 
       const { claudeCodeBinary } = await import('../cliAgentBinaries');
       const status = await claudeCodeBinary.detect();
 
       expect(status.available).toBe(true);
       expect(status.path).toBe('C:\\Users\\hp\\AppData\\Roaming\\npm\\claude.cmd');
-      expect(execMock).toHaveBeenCalledTimes(1);
-      expect(execMock.mock.calls[0]![0]).toBe(
-        '"C:\\Users\\hp\\AppData\\Roaming\\npm\\claude.cmd" --version',
+      expect(execMock).not.toHaveBeenCalled();
+      expect(execFileMock.mock.calls[1]![0]).toBe(
+        'C:\\Users\\hp\\AppData\\Roaming\\npm\\claude.cmd',
       );
+      expect(execFileMock.mock.calls[1]![1]).toEqual(['--version']);
     });
 
     it('reports unavailable when `where` only returns unrunnable matches (.ps1 / extensionless)', async () => {

--- a/apps/server/src/services/agentEvalRun/__tests__/agentEvalRunService.thread.test.ts
+++ b/apps/server/src/services/agentEvalRun/__tests__/agentEvalRunService.thread.test.ts
@@ -136,6 +136,38 @@ describe('AgentEvalRunService', () => {
       expect(rt?.status).toBe('running');
     });
 
+    it('should record an interrupted thread as non-evaluable', async () => {
+      const { run, testCase, threadIds, topic } = await setupMultiThreadEvalChain({
+        assistantOutputs: ['42'],
+        expected: '42',
+        k: 1,
+      });
+
+      const service = new AgentEvalRunService(serverDB, userId);
+      await service.recordThreadCompletion({
+        runId: run.id,
+        status: 'interrupted',
+        telemetry: { completionReason: 'interrupted', duration: 500 },
+        testCaseId: testCase.id,
+        threadId: threadIds[0],
+        topicId: topic.id,
+      });
+
+      const thread = await new ThreadModel(serverDB, userId).findById(threadIds[0]);
+      expect(thread?.metadata).toMatchObject({
+        completionReason: 'interrupted',
+        error: 'Evaluation interrupted',
+        passed: false,
+        score: 0,
+        status: 'error',
+      });
+      const runTopic = await new AgentEvalRunTopicModel(serverDB, userId).findByRunAndTestCase(
+        run.id,
+        testCase.id,
+      );
+      expect(runTopic).toMatchObject({ passed: false, score: 0, status: 'error' });
+    });
+
     it('should aggregate thread results when all K threads complete', async () => {
       const { run, testCase, threadIds, topic } = await setupMultiThreadEvalChain({
         assistantOutputs: ['42', '42'],

--- a/apps/server/src/services/agentEvalRun/__tests__/agentEvalRunService.trajectory.test.ts
+++ b/apps/server/src/services/agentEvalRun/__tests__/agentEvalRunService.trajectory.test.ts
@@ -87,6 +87,33 @@ describe('AgentEvalRunService', () => {
       });
     });
 
+    it('should record an interrupted trajectory as non-evaluable', async () => {
+      const { run, testCase } = await setupEvalChain({
+        assistantOutput: '42',
+        datasetEvalMode: 'contains',
+        expected: '42',
+        totalCases: 1,
+      });
+
+      const service = new AgentEvalRunService(serverDB, userId);
+      await service.recordTrajectoryCompletion({
+        runId: run.id,
+        status: 'interrupted',
+        telemetry: { completionReason: 'interrupted', duration: 500 },
+        testCaseId: testCase.id,
+      });
+
+      const runTopic = await new AgentEvalRunTopicModel(serverDB, userId).findByRunAndTestCase(
+        run.id,
+        testCase.id,
+      );
+      expect(runTopic).toMatchObject({ passed: false, score: 0, status: 'error' });
+      expect(runTopic?.evalResult).toMatchObject({
+        completionReason: 'interrupted',
+        error: 'Evaluation interrupted',
+      });
+    });
+
     it('should persist toolCalls and llmCalls in evalResult', async () => {
       const { run, testCase } = await setupEvalChain({
         assistantOutput: '42',

--- a/apps/server/src/services/agentEvalRun/index.ts
+++ b/apps/server/src/services/agentEvalRun/index.ts
@@ -1658,6 +1658,7 @@ export class AgentEvalRunService {
     topicId: string;
   }): Promise<Record<string, unknown>> {
     const { runId, status, telemetry, testCaseId, threadId } = params;
+    const interrupted = status === 'interrupted' || telemetry.completionReason === 'interrupted';
 
     const baseMeta: Record<string, unknown> = {
       completionReason: telemetry.completionReason,
@@ -1669,15 +1670,17 @@ export class AgentEvalRunService {
       toolCalls: telemetry.toolCalls,
     };
 
-    // Error case — skip evaluation
-    if (status === 'error') {
+    // Error/interruption case — partial output is not eligible for evaluation.
+    if (status === 'error' || interrupted) {
       return {
         ...baseMeta,
-        error:
-          telemetry.errorMessage || `Execution error: ${telemetry.completionReason || 'unknown'}`,
+        error: interrupted
+          ? 'Evaluation interrupted'
+          : telemetry.errorMessage || `Execution error: ${telemetry.completionReason || 'unknown'}`,
         errorDetail: telemetry.errorDetail,
         passed: false,
         score: 0,
+        ...(interrupted && { status: 'error' }),
       };
     }
 
@@ -1824,6 +1827,7 @@ export class AgentEvalRunService {
     const anyPassed = threadResults.some((t) => t.passed === true);
     // pass^k: all threads passed
     const allPassed = threadResults.every((t) => t.passed === true);
+    const allErrored = threadResults.every((t) => t.status === 'error');
 
     // Best score (used as the representative score)
     const scores = threadResults.filter((t) => t.score != null).map((t) => t.score!);
@@ -1849,7 +1853,7 @@ export class AgentEvalRunService {
     const k = threadResults.length;
 
     // The topic-level completionReason: use "completed" if any succeeded
-    const completionReason = anyPassed ? 'completed' : 'failed';
+    const completionReason = anyPassed ? 'completed' : allErrored ? 'error' : 'failed';
 
     // Write aggregated result to RunTopic
     // Primary fields (cost/tokens/duration/steps/llmCalls/toolCalls) = average per execution
@@ -1873,7 +1877,7 @@ export class AgentEvalRunService {
       // pass@k: passed if any thread passed
       passed: anyPassed,
       score: bestScore,
-      status: anyPassed ? 'passed' : 'failed',
+      status: anyPassed ? 'passed' : allErrored ? 'error' : 'failed',
     });
   }
 
@@ -1958,6 +1962,7 @@ export class AgentEvalRunService {
     testCaseId: string;
   }): Promise<{ allDone: boolean; completedCount: number }> {
     const { runId, testCaseId, telemetry, status } = params;
+    const interrupted = status === 'interrupted' || telemetry.completionReason === 'interrupted';
 
     // Write runtime telemetry to RunTopic
     const runTopic = await this.runTopicModel.findByRunAndTestCase(runId, testCaseId);
@@ -1985,14 +1990,15 @@ export class AgentEvalRunService {
           evalResult: evalResultWithTelemetry,
         });
 
-        if (status === 'error') {
-          // Short-circuit: execution error — skip evaluation, write error directly
+        if (status === 'error' || interrupted) {
+          // Short-circuit: execution error/interruption — partial output is not evaluable.
           await this.runTopicModel.updateByRunAndTopic(runTopic.runId, runTopic.topicId, {
             evalResult: {
               ...evalResultWithTelemetry,
-              error:
-                telemetry.errorMessage ||
-                `Execution error: ${telemetry.completionReason || 'unknown'}`,
+              error: interrupted
+                ? 'Evaluation interrupted'
+                : telemetry.errorMessage ||
+                  `Execution error: ${telemetry.completionReason || 'unknown'}`,
               errorDetail: telemetry.errorDetail,
             },
             passed: false,

--- a/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
+++ b/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
@@ -574,7 +574,7 @@ export class CompletionLifecycle {
    */
   async completeOperation(
     input: OperationCompletionInput,
-    reason: 'done' | 'error',
+    reason: 'done' | 'error' | 'interrupted',
     options?: CompleteOperationOptions,
   ): Promise<void> {
     await this.dispatchHooks(input.operationId, this.buildStateFromInput(input), reason, options);

--- a/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
@@ -622,6 +622,46 @@ describe('CompletionLifecycle.dispatchHooks — async-tool park', () => {
   });
 });
 
+describe('CompletionLifecycle.dispatchHooks — interrupted terminal contract', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockNotifyAgentRunCompleted.mockClear();
+  });
+
+  it('persists and dispatches onComplete without success-only terminal effects', async () => {
+    const lifecycle = buildLifecycle();
+    const persistSpy = vi.spyOn(lifecycle as any, 'persistCompletion').mockResolvedValue(undefined);
+    const createVerifySpy = vi
+      .spyOn(lifecycle as any, 'createVerifyMessage')
+      .mockResolvedValue(undefined);
+    const registerWorksSpy = vi.spyOn(lifecycle, 'registerFileWorks').mockResolvedValue(undefined);
+    const dispatchSpy = vi.spyOn(hookDispatcher, 'dispatch').mockResolvedValue(undefined as any);
+    vi.spyOn(hookDispatcher, 'unregister').mockImplementation(() => {});
+    const runVerifySpy = vi
+      .spyOn(verifyServices, 'runVerifyOnCompletion')
+      .mockResolvedValue(undefined);
+    const state = {
+      messages: [{ content: 'partial output', role: 'assistant' }],
+      metadata: { _hooks: [], agentId: 'agt_1', topicId: 'tpc_1' },
+      status: 'interrupted',
+    };
+
+    await lifecycle.dispatchHooks('op-1', state, 'interrupted');
+
+    expect(persistSpy).toHaveBeenCalledWith('op-1', state, 'interrupted');
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'op-1',
+      'onComplete',
+      expect.objectContaining({ reason: 'interrupted' }),
+      [],
+    );
+    expect(mockNotifyAgentRunCompleted).not.toHaveBeenCalled();
+    expect(createVerifySpy).not.toHaveBeenCalled();
+    expect(runVerifySpy).not.toHaveBeenCalled();
+    expect(registerWorksSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe('CompletionLifecycle.dispatchHooks — completion notification', () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
@@ -9,6 +9,7 @@ const {
   mockDispatchAgentRun,
   mockExecuteToolCall,
   mockGetHeterogeneousResumeSessionId,
+  mockInterruptOperation,
   mockMessageCreate,
   mockResolveAttachmentsByFileIds,
   mockSpawnHeteroSandbox,
@@ -23,6 +24,7 @@ const {
   mockExecuteToolCall: vi.fn().mockResolvedValue({ success: true }),
   mockGetHeterogeneousResumeSessionId: vi.fn().mockResolvedValue(undefined),
   mockIngestAttachment: vi.fn(),
+  mockInterruptOperation: vi.fn().mockResolvedValue(true),
   mockMessageCreate: vi.fn(),
   mockPublishAgentRuntimeEnd: vi.fn().mockResolvedValue('end-event-id'),
   mockPublishAgentRuntimeInit: vi.fn().mockResolvedValue('init-event-id'),
@@ -175,7 +177,7 @@ vi.mock('@/server/services/agentRuntime', () => ({
       operationId: 'op-123',
       success: true,
     }),
-    interruptOperation: vi.fn().mockResolvedValue(true),
+    interruptOperation: mockInterruptOperation,
   })),
 }));
 
@@ -216,6 +218,7 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
     mockSpawnHeteroSandbox.mockResolvedValue(undefined);
     mockDispatchAgentRun.mockResolvedValue({ success: true });
     mockExecuteToolCall.mockResolvedValue({ success: true });
+    mockInterruptOperation.mockResolvedValue(true);
     mockGetHeterogeneousResumeSessionId.mockResolvedValue(undefined);
     mockDeviceFindByDeviceId.mockResolvedValue({ defaultCwd: '/Users/alice/repo' });
     mockDeviceFindWorkspaceDeviceById.mockResolvedValue(undefined);
@@ -647,7 +650,7 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
     const findRunningOpSeed = () =>
       topicMock.updateMetadata.mock.calls
         .map((call) => call[1])
-        .find((patch: any) => patch?.runningOperation?.operationId);
+        .findLast((patch: any) => patch?.runningOperation?.operationId);
 
     it('serializes the onComplete webhook hook onto runningOperation (sandbox dispatch)', async () => {
       await service.execAgent({
@@ -740,6 +743,49 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
         expect.any(String),
         expect.objectContaining({ heteroType: 'claude-code' }),
       );
+    });
+
+    it('persists and cancels the connected-device route for OpenCode', async () => {
+      heteroAgentConfig.model = 'opencode';
+      heteroAgentConfig.provider = 'opencode';
+      heteroAgentConfig.agencyConfig = {
+        boundDeviceId: 'device-1',
+        executionTarget: 'device',
+        heterogeneousProvider: { type: 'opencode' },
+      } as any;
+
+      const result = await service.execAgent({
+        agentId: 'agent-1',
+        prompt: 'run OpenCode and let me stop it',
+      } as any);
+      const seed = findRunningOpSeed();
+      expect(seed.runningOperation).toEqual(
+        expect.objectContaining({
+          deviceId: 'device-1',
+          deviceUserId: userId,
+          heteroType: 'opencode',
+          operationId: result.operationId,
+        }),
+      );
+
+      mockExecuteToolCall.mockClear();
+      topicMock.findById.mockResolvedValue({ metadata: seed });
+      mockInterruptOperation.mockResolvedValue(false);
+      const interruptResult = await service.interruptTask({
+        operationId: result.operationId,
+        topicId: 'topic-1',
+      });
+
+      expect(interruptResult).toMatchObject({ success: true });
+      expect(mockExecuteToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: 'device-1', userId }),
+        expect.objectContaining({
+          apiName: 'cancelHeteroTask',
+          arguments: JSON.stringify({ signal: 'SIGINT', taskId: result.operationId }),
+        }),
+        5_000,
+      );
+      expect(mockInterruptOperation).not.toHaveBeenCalled();
     });
 
     it('keeps the conversation workspace separate from a personal platform device scope', async () => {
@@ -836,8 +882,13 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
         },
       });
 
-      await service.interruptTask({ operationId: 'operation-1', topicId: 'topic-1' });
+      mockInterruptOperation.mockResolvedValue(false);
+      const result = await service.interruptTask({
+        operationId: 'operation-1',
+        topicId: 'topic-1',
+      });
 
+      expect(result).toMatchObject({ success: true });
       expect(mockExecuteToolCall).toHaveBeenCalledWith(
         {
           deviceId: 'author-desktop',
@@ -847,6 +898,68 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
         expect.objectContaining({ apiName: 'cancelHeteroTask' }),
         5_000,
       );
+      expect(mockInterruptOperation).not.toHaveBeenCalled();
+    });
+
+    it('reports failure when the owning device rejects cancellation', async () => {
+      topicMock.findById.mockResolvedValue({
+        metadata: {
+          runningOperation: {
+            assistantMessageId: 'assistant-1',
+            deviceId: 'author-desktop',
+            deviceUserId: 'author-user',
+            heteroType: 'openclaw',
+            operationId: 'operation-1',
+          },
+        },
+      });
+      mockExecuteToolCall.mockResolvedValue({
+        state: { success: false },
+        success: true,
+      });
+
+      const result = await service.interruptTask({
+        operationId: 'operation-1',
+        topicId: 'topic-1',
+      });
+
+      expect(result).toMatchObject({ success: false });
+      expect(mockInterruptOperation).not.toHaveBeenCalled();
+    });
+
+    it('reports failure when cancellation cannot reach the owning device', async () => {
+      topicMock.findById.mockResolvedValue({
+        metadata: {
+          runningOperation: {
+            deviceId: 'offline-desktop',
+            deviceUserId: userId,
+            heteroType: 'opencode',
+            operationId: 'operation-1',
+          },
+        },
+      });
+      mockExecuteToolCall.mockRejectedValue(new Error('device disconnected'));
+
+      const result = await service.interruptTask({
+        operationId: 'operation-1',
+        topicId: 'topic-1',
+      });
+
+      expect(result).toMatchObject({ success: false });
+      expect(mockInterruptOperation).not.toHaveBeenCalled();
+    });
+
+    it('keeps in-process interruption owned by the runtime coordinator', async () => {
+      mockInterruptOperation.mockResolvedValue(false);
+
+      const result = await service.interruptTask({
+        operationId: 'operation-1',
+        topicId: 'topic-in-process',
+      });
+
+      expect(result).toMatchObject({ success: false });
+      expect(mockExecuteToolCall).not.toHaveBeenCalled();
+      expect(mockInterruptOperation).toHaveBeenCalledWith('operation-1');
     });
 
     it('recovers the topic from the operation when the cancellation caller omits it', async () => {

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -49,6 +49,7 @@ import type {
   ChatAudioItem,
   ChatFileItem,
   ChatTopicBotContext,
+  ChatTopicMetadata,
   ChatVideoItem,
   ErrorType,
   ExecAgentParams,
@@ -198,6 +199,32 @@ const log = debug('lobe-server:ai-agent-service');
  * it was settled here or by `resolve_aborted_tools`.
  */
 const STOPPED_TOOL_CONTENT = 'Tool execution was aborted by user.';
+
+const isDeviceCancellationAccepted = (
+  result: Awaited<ReturnType<typeof deviceGateway.executeToolCall>>,
+): boolean => {
+  if (!result.success) return false;
+
+  const readSemanticSuccess = (value: unknown): boolean | undefined => {
+    if (!value || typeof value !== 'object') return;
+    const success = (value as { success?: unknown }).success;
+    return typeof success === 'boolean' ? success : undefined;
+  };
+
+  const stateSuccess = readSemanticSuccess(result.state);
+  if (stateSuccess !== undefined) return stateSuccess;
+
+  if (result.content) {
+    try {
+      const contentSuccess = readSemanticSuccess(JSON.parse(result.content));
+      if (contentSuccess !== undefined) return contentSuccess;
+    } catch {
+      // Legacy devices may return a plain-text success payload.
+    }
+  }
+
+  return true;
+};
 
 const createGraphAwareAgentFactory =
   (
@@ -2365,28 +2392,29 @@ export class AiAgentService {
       // delivers the serialized webhooks persisted on runningOperation below.
       if (hooks?.length) hookDispatcher.register(operationId, hooks);
       const serializedHooks = hookDispatcher.getSerializedHooks(operationId);
+      const runningOperation: NonNullable<ChatTopicMetadata['runningOperation']> = {
+        assistantMessageId: assistantMessageRecord.id,
+        hooks: serializedHooks,
+        // Store the device route so interruptTask can cancel a device process.
+        ...(isRemoteHetero && remoteDeviceId
+          ? {
+              deviceId: remoteDeviceId,
+              deviceUserId: remoteDeviceUserId,
+              deviceWorkspaceId: remoteDeviceWorkspaceId,
+              heteroType,
+            }
+          : undefined),
+        operationId,
+        scope: appContext?.scope ?? undefined,
+        threadId: appContext?.threadId ?? undefined,
+      };
 
       // Seed topic.metadata.runningOperation so heteroIngest can validate the
       // operation, and so every terminal site (heteroFinish, agentNotify done,
       // dispatch failure) can re-fire the serialized hooks across a process
       // boundary in queue mode.
       await this.topicModel.updateMetadata(topicId, {
-        runningOperation: {
-          assistantMessageId: assistantMessageRecord.id,
-          hooks: serializedHooks,
-          // Store deviceId + heteroType so interruptTask can cancel remote processes
-          ...(isRemoteHetero && remoteDeviceId
-            ? {
-                deviceId: remoteDeviceId,
-                deviceUserId: remoteDeviceUserId,
-                deviceWorkspaceId: remoteDeviceWorkspaceId,
-                heteroType,
-              }
-            : undefined),
-          operationId,
-          scope: appContext?.scope ?? undefined,
-          threadId: appContext?.threadId ?? undefined,
-        },
+        runningOperation,
       });
 
       // Notify-based platform agents (openclaw / hermes) communicate back via
@@ -2618,6 +2646,17 @@ export class AiAgentService {
             (await deviceModelForCwd.findByDeviceId(dispatchDeviceId)) ??
             (await deviceModelForCwd.findWorkspaceDeviceById(dispatchDeviceId));
           const dispatchWorkspaceId = await this.resolveDeviceWorkspaceId(dispatchDeviceId);
+          // Persist the exact local-CLI device route before dispatch. Both
+          // Desktop and `lh connect` expose cancellation through
+          // cancelHeteroTask(taskId=operationId), so interruptTask can use the
+          // same metadata path as notify-based platform agents.
+          Object.assign(runningOperation, {
+            deviceId: dispatchDeviceId,
+            deviceUserId: this.userId,
+            deviceWorkspaceId: dispatchWorkspaceId,
+            heteroType,
+          });
+          await this.topicModel.updateMetadata(topicId, { runningOperation });
           // Resolve via the shared precedence helper so dispatch, workspace-init,
           // and the new-topic backfill below all agree on the cwd.
           const deviceCwdConfig = resolveDeviceWorkingDirectoryConfig({
@@ -5559,10 +5598,10 @@ export class AiAgentService {
       resolvedTopicId = operation?.topicId ?? undefined;
     }
 
-    // 2. Cancel remote hetero process (openclaw / hermes) if applicable.
-    // Check topic.metadata.runningOperation for device + heteroType info seeded by execAgent.
-    // This runs regardless of whether interruptOperation succeeds — the remote process
-    // is independent of the local operation registry.
+    // 2. Resolve the execution owner and ask that owner to interrupt the run.
+    // Device-backed hetero runs are not registered in the in-process runtime
+    // coordinator, so their acknowledgement must come from cancelHeteroTask.
+    let interrupted: boolean | undefined;
     if (resolvedTopicId) {
       const topic = await this.topicModel.findById(resolvedTopicId);
       const runningOp = (topic?.metadata as any)?.runningOperation as
@@ -5578,19 +5617,18 @@ export class AiAgentService {
       if (
         runningOp?.deviceId &&
         runningOp.heteroType &&
-        runningOp.operationId === resolvedOperationId &&
-        isRemoteHeterogeneousType(runningOp.heteroType)
+        runningOp.operationId === resolvedOperationId
       ) {
         const taskId = runningOp.operationId ?? resolvedOperationId;
         log(
-          'interruptTask: cancelling remote hetero process heteroType=%s deviceId=%s taskId=%s',
+          'interruptTask: cancelling device hetero process heteroType=%s deviceId=%s taskId=%s',
           runningOp.heteroType,
           runningOp.deviceId,
           taskId,
         );
         const cancelWorkspaceId =
           runningOp.deviceWorkspaceId ?? (await this.resolveDeviceWorkspaceId(runningOp.deviceId));
-        await deviceGateway
+        const cancelResult = await deviceGateway
           .executeToolCall(
             {
               deviceId: runningOp.deviceId,
@@ -5604,18 +5642,27 @@ export class AiAgentService {
             },
             5_000,
           )
-          .catch((err) => log('interruptTask: cancelHeteroTask dispatch failed: %O', err));
+          .catch((err) => {
+            log('interruptTask: cancelHeteroTask dispatch failed: %O', err);
+            return { content: '', error: String(err), success: false };
+          });
+        interrupted = isDeviceCancellationAccepted(cancelResult);
+        log(
+          'interruptTask: cancelHeteroTask=%s for operationId=%s',
+          interrupted,
+          resolvedOperationId,
+        );
       }
     }
 
-    // 3. Interrupt the runtime operation first. Only mark the thread cancelled
-    // after the runtime acknowledges the interrupt to avoid unlocking a live task.
-    const interrupted = await this.agentRuntimeService.interruptOperation(resolvedOperationId);
-    log(
-      'interruptTask: interruptOperation=%s for operationId=%s',
-      interrupted,
-      resolvedOperationId,
-    );
+    if (interrupted === undefined) {
+      interrupted = await this.agentRuntimeService.interruptOperation(resolvedOperationId);
+      log(
+        'interruptTask: interruptOperation=%s for operationId=%s',
+        interrupted,
+        resolvedOperationId,
+      );
+    }
 
     if (!interrupted) {
       const alreadyCancelled = thread?.status === ThreadStatus.Cancel;
@@ -5627,7 +5674,7 @@ export class AiAgentService {
       };
     }
 
-    // 4. Update Thread status to cancel
+    // 3. Update Thread status only after the execution owner acknowledges.
     if (thread) {
       await this.threadModel.update(thread.id, {
         metadata: {

--- a/apps/server/src/services/heterogeneousAgent/__tests__/index.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/__tests__/index.test.ts
@@ -9,7 +9,7 @@ import { hookDispatcher } from '@/server/services/agentRuntime/hooks';
 import type { AgentHook, SerializedHook } from '@/server/services/agentRuntime/hooks/types';
 import * as verifyService from '@/server/services/verify';
 
-import type { HeterogeneousPersistenceHandler } from '..';
+import type { HeterogeneousAgentServiceOptions, HeterogeneousPersistenceHandler } from '..';
 import {
   HeterogeneousAgentService,
   normalizeHeterogeneousFinishError,
@@ -76,14 +76,28 @@ const buildEvent = (
   type,
 });
 
-const createService = (overrides: { streamEventManager?: IStreamEventManager } = {}) => {
+const createService = (
+  overrides: {
+    streamEventManager?: IStreamEventManager;
+    topicModel?: HeterogeneousAgentServiceOptions['topicModel'];
+  } = {},
+) => {
   const { manager, published } = createFakeStreamManager();
   const persistenceHandler = createFakePersistenceHandler();
+  const topicModel =
+    overrides.topicModel ??
+    ({
+      findById: vi.fn(async () => ({ metadata: {} })),
+      settleRunningOperation: vi.fn(async (_topicId: string, operationId: string) => ({
+        runningOperation: { operationId },
+      })),
+    } as unknown as NonNullable<HeterogeneousAgentServiceOptions['topicModel']>);
   const service = new HeterogeneousAgentService({} as any, 'user-test', {
     persistenceHandler,
     streamEventManager: overrides.streamEventManager ?? manager,
+    topicModel,
   });
-  return { manager, persistenceHandler, published, service };
+  return { manager, persistenceHandler, published, service, topicModel };
 };
 
 describe('HeterogeneousAgentService', () => {
@@ -462,7 +476,7 @@ describe('HeterogeneousAgentService', () => {
 
       expect(published[0].event.data).toMatchObject({
         operationId: 'op-3',
-        reason: 'cancelled',
+        reason: 'interrupted',
       });
     });
 
@@ -647,9 +661,22 @@ describe('HeterogeneousAgentService', () => {
       dispatchSpy.mockRestore();
     });
 
-    it('does NOT fire hooks on a cancelled run (the real result fires them)', async () => {
-      const { service } = createService();
+    it('normalizes cancellation to interrupted and fires completion hooks', async () => {
+      const metadata = {
+        runningOperation: {
+          assistantMessageId: 'msg-cancelled',
+          operationId: 'op-hook-cancelled',
+        },
+      };
+      const topicModel = {
+        findById: vi.fn().mockResolvedValue({
+          metadata,
+        }),
+        settleRunningOperation: vi.fn().mockResolvedValue(metadata),
+      } as unknown as NonNullable<HeterogeneousAgentServiceOptions['topicModel']>;
+      const { published, service } = createService({ topicModel });
       const { onComplete, onError } = registerHook('op-hook-cancelled');
+      const dispatchSpy = vi.spyOn(CompletionLifecycle.prototype, 'dispatchHooks');
 
       await service.heteroFinish({
         agentType: 'claude-code',
@@ -658,11 +685,53 @@ describe('HeterogeneousAgentService', () => {
         topicId: 'topic-hook-3',
       });
 
-      expect(onComplete).not.toHaveBeenCalled();
+      expect(onComplete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operationId: 'op-hook-cancelled',
+          reason: 'interrupted',
+          topicId: 'topic-hook-3',
+        }),
+      );
       expect(onError).not.toHaveBeenCalled();
-      // Still registered — the subsequent success/error call will dispatch them.
-      expect(hookDispatcher.hasHooks('op-hook-cancelled')).toBe(true);
-      hookDispatcher.unregister('op-hook-cancelled');
+      expect(topicModel.settleRunningOperation).toHaveBeenCalledWith(
+        'topic-hook-3',
+        'op-hook-cancelled',
+        'active',
+      );
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        'op-hook-cancelled',
+        expect.anything(),
+        'interrupted',
+        undefined,
+      );
+      expect(published.at(-1)?.event).toEqual(
+        expect.objectContaining({
+          data: expect.objectContaining({ reason: 'interrupted' }),
+          type: 'agent_runtime_end',
+        }),
+      );
+      expect(hookDispatcher.hasHooks('op-hook-cancelled')).toBe(false);
+    });
+
+    it('ignores a delayed cancellation after the topic starts a newer operation', async () => {
+      const topicModel = {
+        findById: vi.fn().mockResolvedValue({
+          metadata: { runningOperation: { operationId: 'op-new' } },
+        }),
+        settleRunningOperation: vi.fn(),
+      } as unknown as NonNullable<HeterogeneousAgentServiceOptions['topicModel']>;
+      const { manager, persistenceHandler, service } = createService({ topicModel });
+
+      await service.heteroFinish({
+        agentType: 'claude-code',
+        operationId: 'op-old',
+        result: 'cancelled',
+        topicId: 'topic-shared',
+      });
+
+      expect(manager.publishStreamEvent).not.toHaveBeenCalled();
+      expect(persistenceHandler.finish).not.toHaveBeenCalled();
+      expect(topicModel.settleRunningOperation).not.toHaveBeenCalled();
     });
   });
 
@@ -692,14 +761,15 @@ describe('HeterogeneousAgentService', () => {
     };
 
     const makeService = (hooks: SerializedHook[] | undefined) => {
+      const metadata = { runningOperation: { hooks, operationId: 'op-q' } };
       const topicModel = {
         // Mirror what execAgent persisted at dispatch: the serialized hooks live
         // under runningOperation. heteroFinish must read them from here.
         findById: vi.fn(async () => ({
           id: 'topic-q',
-          metadata: { runningOperation: { hooks, operationId: 'op-q' } },
+          metadata,
         })),
-        updateMetadata: vi.fn(async () => {}),
+        settleRunningOperation: vi.fn(async () => metadata),
       } as any;
       const { manager } = createFakeStreamManager();
       const service = new HeterogeneousAgentService({} as any, 'user-test', {
@@ -749,6 +819,25 @@ describe('HeterogeneousAgentService', () => {
       });
     });
 
+    it('delivers device cancellation as interrupted and settles the topic active', async () => {
+      const { service, topicModel } = makeService([taskHook]);
+
+      await service.heteroFinish({
+        agentType: 'claude-code',
+        operationId: 'op-q',
+        result: 'cancelled',
+        topicId: 'topic-q',
+      });
+
+      expect(mockPublishJSON).toHaveBeenCalledTimes(1);
+      expect(mockPublishJSON.mock.calls[0][0].body).toMatchObject({
+        hookId: 'task-on-complete',
+        reason: 'interrupted',
+        taskId: 'task_q',
+      });
+      expect(topicModel.settleRunningOperation).toHaveBeenCalledWith('topic-q', 'op-q', 'active');
+    });
+
     it('negative control: delivers nothing when runningOperation.hooks is empty', async () => {
       const { service } = makeService([]);
 
@@ -795,6 +884,12 @@ describe('HeterogeneousAgentService', () => {
       let meta: Record<string, any> = {};
       const topicModel = {
         findById: vi.fn(async () => ({ id: TOPIC, metadata: meta })),
+        settleRunningOperation: vi.fn(async (_id: string, operationId: string) => {
+          if (meta.runningOperation?.operationId !== operationId) return;
+          const settledMetadata = meta;
+          meta = { ...meta, runningOperation: null };
+          return settledMetadata;
+        }),
         updateMetadata: vi.fn(async (_id: string, patch: Record<string, any>, mergeBase?: any) => {
           meta = { ...(mergeBase ?? meta), ...patch };
         }),

--- a/apps/server/src/services/heterogeneousAgent/__tests__/sessionResume.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/__tests__/sessionResume.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { TopicModel } from '@/database/models/topic';
 import { type IStreamEventManager } from '@/server/modules/AgentRuntime/types';
 
 import { HeterogeneousAgentService, HeterogeneousPersistenceHandler } from '..';
@@ -10,6 +11,24 @@ const createSilentStreamManager = (): IStreamEventManager =>
   ({
     publishStreamEvent: vi.fn(async () => 'ok'),
   }) as unknown as IStreamEventManager;
+
+interface TerminalTopicSnapshot {
+  metadata?: {
+    runningOperation?: { operationId?: string };
+  };
+}
+
+const createTerminalTopicModel = (
+  findById: (id: string) => Promise<null | TerminalTopicSnapshot>,
+): TopicModel =>
+  ({
+    findById,
+    settleRunningOperation: vi.fn(async (topicId: string, operationId: string) => {
+      const topic = await findById(topicId);
+      if (topic?.metadata?.runningOperation?.operationId !== operationId) return;
+      return topic.metadata;
+    }),
+  }) as unknown as TopicModel;
 
 describe('HeterogeneousAgentService — phase 2c session id persistence + resume', () => {
   beforeEach(() => __resetOperationStatesForTesting());
@@ -59,6 +78,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
       const service = new HeterogeneousAgentService({} as any, 'user-1', {
         persistenceHandler: handler,
         streamEventManager: createSilentStreamManager(),
+        topicModel: createTerminalTopicModel(findById),
       });
 
       await service.heteroFinish({
@@ -114,6 +134,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
       const service = new HeterogeneousAgentService({} as any, 'user-1', {
         persistenceHandler: handler,
         streamEventManager: createSilentStreamManager(),
+        topicModel: createTerminalTopicModel(findById),
       });
 
       await service.heteroFinish({
@@ -166,6 +187,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
       const service = new HeterogeneousAgentService({} as any, 'user-1', {
         persistenceHandler: handler,
         streamEventManager: createSilentStreamManager(),
+        topicModel: createTerminalTopicModel(findById),
       });
 
       // Simulate: sandbox was recycled, CC exited before emitting system.init
@@ -222,6 +244,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
       const service = new HeterogeneousAgentService({} as any, 'user-1', {
         persistenceHandler: handler,
         streamEventManager: createSilentStreamManager(),
+        topicModel: createTerminalTopicModel(findById),
       });
 
       await service.heteroFinish({
@@ -282,6 +305,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
       const service = new HeterogeneousAgentService({} as any, 'user-1', {
         persistenceHandler: handler,
         streamEventManager: createSilentStreamManager(),
+        topicModel: createTerminalTopicModel(findById),
       });
 
       await service.heteroFinish({
@@ -346,6 +370,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
       const service = new HeterogeneousAgentService({} as any, 'user-1', {
         persistenceHandler: handler,
         streamEventManager: stream,
+        topicModel: createTerminalTopicModel(findById),
       });
 
       // Should not throw — sessionId persistence is best-effort

--- a/apps/server/src/services/heterogeneousAgent/index.ts
+++ b/apps/server/src/services/heterogeneousAgent/index.ts
@@ -231,6 +231,13 @@ export class HeterogeneousAgentService {
   async heteroFinish(params: HeterogeneousFinishParams): Promise<void> {
     const { agentType, operationId, result, sessionId, topicId } = params;
     const error = normalizeHeterogeneousFinishError(agentType, params.error);
+    const completionReason =
+      result === 'success'
+        ? ('done' as const)
+        : result === 'error'
+          ? ('error' as const)
+          : ('interrupted' as const);
+    const runtimeEndReason = result === 'cancelled' ? 'interrupted' : result;
 
     log(
       'heteroFinish: user=%s topic=%s op=%s type=%s result=%s sessionId=%s',
@@ -253,6 +260,16 @@ export class HeterogeneousAgentService {
       );
     }
 
+    // Reject a delayed finish before it can mutate persistence belonging to a
+    // newer run on the same topic. Missing legacy metadata is allowed through;
+    // the atomic settle below remains the authority for destructive cleanup.
+    const topic = await this.topicModel.findById(topicId);
+    const runningOperation = topic?.metadata?.runningOperation;
+    if (runningOperation && runningOperation.operationId !== operationId) {
+      log('heteroFinish: ignored stale terminal callback for op=%s topic=%s', operationId, topicId);
+      return;
+    }
+
     // Drain any pending state in the persistence handler — flushes trailing
     // accumulated content / reasoning that the in-stream `agent_runtime_end`
     // already wrote (no-op when state is clean), persists the CLI's native
@@ -272,7 +289,7 @@ export class HeterogeneousAgentService {
         agentType,
         error,
         operationId,
-        reason: result,
+        reason: runtimeEndReason,
         sessionId,
       },
       stepIndex: 0,
@@ -285,41 +302,36 @@ export class HeterogeneousAgentService {
     // fire uniformly. The hooks were registered in-memory (local mode) and
     // serialized onto runningOperation (queue mode) at dispatch time.
     //
-    // Skip on `cancelled` — heteroFinish may be called twice: first with
-    // result=cancelled (termination signal) then with result=success/error
-    // (normal process exit). We must NOT clear runningOperation or fire hooks on
-    // cancelled so the subsequent success/error call still finds the hooks +
-    // assistantMessageId and dispatches exactly once. (cancelled→interrupted is a
-    // no-op for the task lifecycle anyway — onTopicComplete has no interrupted
-    // branch — and suppresses a spurious bot "stopped" message before the real
-    // result lands.)
-    if (result === 'cancelled') return;
-
     let serializedHooks: SerializedHook[] | undefined;
     let assistantMessageId: string | undefined;
     let isolationThreadId: string | undefined;
     try {
-      const topic = await this.topicModel.findById(topicId);
-      serializedHooks = topic?.metadata?.runningOperation?.hooks as SerializedHook[] | undefined;
-      isolationThreadId = topic?.metadata?.runningOperation?.threadId ?? undefined;
+      const settledMetadata = await this.topicModel.settleRunningOperation(
+        topicId,
+        operationId,
+        completionReason === 'interrupted' ? 'active' : 'unread',
+      );
+      if (!settledMetadata && runningOperation) {
+        log('heteroFinish: operation ownership changed while settling op=%s', operationId);
+        return;
+      }
+      const metadata = settledMetadata ?? topic?.metadata ?? {};
+
+      serializedHooks = metadata.runningOperation?.hooks as SerializedHook[] | undefined;
+      isolationThreadId = metadata.runningOperation?.threadId ?? undefined;
       // Prefer heteroCurrentMsgId — the persistence handler updates this pointer
       // on every step boundary, so it refers to the LAST assistant message with
       // the complete final content.  Fall back to the initial placeholder id
       // recorded in runningOperation if the pointer is absent or belongs to a
       // different operation (shouldn't happen, but defensive).
-      const currentMsgRef = topic?.metadata?.heteroCurrentMsgId;
+      const currentMsgRef = metadata.heteroCurrentMsgId;
       assistantMessageId =
         currentMsgRef?.operationId === operationId
           ? currentMsgRef.msgId
-          : topic?.metadata?.runningOperation?.assistantMessageId;
-      await this.topicModel.updateMetadata(topicId, { runningOperation: null });
-      // Settle `status: 'running'` for runs with no renderer attached (e.g. a
-      // cron-dispatched scheduled resume) — otherwise nothing ever moves the
-      // topic off `running`. Guarded in the model: an attached client's own
-      // terminal write ('active'/'unread') is never clobbered.
-      await this.topicModel.settleRunningStatus(topicId);
+          : metadata.runningOperation?.assistantMessageId;
     } catch (err) {
-      log('heteroFinish: failed to clear runningOperation (non-fatal): %O', err);
+      log('heteroFinish: failed to settle runningOperation: %O', err);
+      throw err;
     }
 
     // The owning agentId is authoritatively encoded in the operationId
@@ -378,13 +390,10 @@ export class HeterogeneousAgentService {
     }
 
     // Finalize the trace snapshot (uploads it; the terminal op row is written by
-    // CompletionLifecycle.persistCompletion below). Runs on the real terminal only
-    // (cancelled returned above). Aggregates come from the accumulated steps;
+    // CompletionLifecycle.persistCompletion below). Aggregates come from the accumulated steps;
     // missing fields stay null (schema treats null as "not measured"). Kept inside
     // its own try so an upload hiccup never blocks the lifecycle dispatch — verify
     // and hooks still fire, persistCompletion just records null aggregates.
-    // `result` is narrowed to 'success' | 'error' here — 'cancelled' returned above.
-    const completionReason = result === 'success' ? ('done' as const) : ('error' as const);
     let totals: Awaited<ReturnType<HeteroTraceRecorder['finalize']>> | undefined;
     try {
       totals = await this.traceRecorder.finalize(operationId, {

--- a/apps/server/src/services/task/index.test.ts
+++ b/apps/server/src/services/task/index.test.ts
@@ -10,8 +10,9 @@ import type { LobeChatDatabase } from '@/database/type';
 
 import { TaskService } from './index';
 
-const { cancelScheduled, scheduleNextTopic } = vi.hoisted(() => ({
+const { cancelScheduled, interruptTask, scheduleNextTopic } = vi.hoisted(() => ({
   cancelScheduled: vi.fn(),
+  interruptTask: vi.fn(),
   scheduleNextTopic: vi.fn(),
 }));
 
@@ -39,7 +40,7 @@ vi.mock('@/database/models/user', () => ({
 // the running-status branch in updateStatus doesn't drag them in.
 vi.mock('@/server/services/aiAgent', () => ({
   AiAgentService: vi.fn().mockImplementation(() => ({
-    interruptTask: vi.fn(),
+    interruptTask,
   })),
 }));
 
@@ -91,10 +92,13 @@ describe('TaskService', () => {
   const mockTaskTopicModel = {
     cancelIfRunning: vi.fn(),
     findByTaskId: vi.fn(),
+    findByTopicId: vi.fn(),
     findRunningByTaskIds: vi.fn().mockResolvedValue([]),
     findWithHandoff: vi.fn(),
     findWithHandoffByTaskIds: vi.fn().mockResolvedValue([]),
+    remove: vi.fn(),
     timeoutRunning: vi.fn(),
+    updateStatus: vi.fn(),
   };
 
   const mockBriefModel = {
@@ -104,6 +108,7 @@ describe('TaskService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     cancelScheduled.mockResolvedValue(undefined);
+    interruptTask.mockResolvedValue({ success: true });
     scheduleNextTopic.mockResolvedValue('tick-new');
     mockTaskTopicModel.findRunningByTaskIds.mockResolvedValue([]);
     (AgentModel as any).mockImplementation(() => mockAgentModel);
@@ -1354,6 +1359,41 @@ describe('TaskService', () => {
       ...overrides,
     });
 
+    it('aborts the status transition when a topic execution owner rejects interruption', async () => {
+      const prev = baseTask({ automationMode: null, status: 'running' });
+      mockTaskModel.resolve.mockResolvedValue(prev);
+      mockTaskTopicModel.findByTaskId.mockResolvedValue([
+        { operationId: 'op-1', status: 'running', topicId: 'topic-1' },
+      ]);
+      interruptTask.mockResolvedValue({ success: false });
+
+      const service = new TaskService(db, userId);
+      await expect(service.updateStatus({ id: 'T-1', status: 'paused' as any })).rejects.toThrow(
+        /did not acknowledge/i,
+      );
+
+      expect(mockTaskTopicModel.cancelIfRunning).not.toHaveBeenCalled();
+      // The parent task must NOT settle while one of its runs is still live.
+      expect(mockTaskModel.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('aborts the status transition when interrupting a topic throws', async () => {
+      const prev = baseTask({ automationMode: null, status: 'running' });
+      mockTaskModel.resolve.mockResolvedValue(prev);
+      mockTaskTopicModel.findByTaskId.mockResolvedValue([
+        { operationId: 'op-1', status: 'running', topicId: 'topic-1' },
+      ]);
+      interruptTask.mockRejectedValue(new Error('device offline'));
+
+      const service = new TaskService(db, userId);
+      await expect(service.updateStatus({ id: 'T-1', status: 'canceled' as any })).rejects.toThrow(
+        /did not acknowledge/i,
+      );
+
+      expect(mockTaskTopicModel.cancelIfRunning).not.toHaveBeenCalled();
+      expect(mockTaskModel.updateStatus).not.toHaveBeenCalled();
+    });
+
     it('stamps scheduleStartedAt when a user starts a schedule (backlog → scheduled)', async () => {
       const prev = baseTask({ status: 'backlog', automationMode: 'schedule' });
       const next = baseTask({ status: 'scheduled', automationMode: 'schedule' });
@@ -1501,6 +1541,36 @@ describe('TaskService', () => {
       await service.updateStatus({ id: 'T-1', status: 'scheduled' as any });
 
       expect(mockTaskModel.updateContext).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('topic cancellation acknowledgement', () => {
+    const runningTopic = {
+      operationId: 'op-1',
+      status: 'running',
+      taskId: 'task-1',
+      topicId: 'topic-1',
+    };
+
+    it('does not settle a topic when its execution owner rejects interruption', async () => {
+      mockTaskTopicModel.findByTopicId.mockResolvedValue(runningTopic);
+      interruptTask.mockResolvedValue({ success: false });
+
+      const service = new TaskService(db, userId);
+
+      await expect(service.cancelTopic('topic-1')).rejects.toThrow(/did not acknowledge/i);
+      expect(mockTaskTopicModel.updateStatus).not.toHaveBeenCalled();
+      expect(mockTaskModel.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('does not delete a topic when its execution owner rejects interruption', async () => {
+      mockTaskTopicModel.findByTopicId.mockResolvedValue(runningTopic);
+      interruptTask.mockResolvedValue({ success: false });
+
+      const service = new TaskService(db, userId);
+
+      await expect(service.deleteTopic('topic-1')).rejects.toThrow(/did not acknowledge/i);
+      expect(mockTaskTopicModel.remove).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/src/services/task/index.ts
+++ b/apps/server/src/services/task/index.ts
@@ -247,7 +247,13 @@ export class TaskService {
       const aiAgentService = new AiAgentService(this.db, this.userId, {
         workspaceId: this.workspaceId,
       });
-      await aiAgentService.interruptTask({ operationId: target.operationId });
+      const result = await aiAgentService.interruptTask({ operationId: target.operationId });
+      if (!result.success) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'The execution owner did not acknowledge cancellation.',
+        });
+      }
     }
 
     await this.taskTopicModel.updateStatus(target.taskId, topicId, 'canceled');
@@ -266,7 +272,13 @@ export class TaskService {
       const aiAgentService = new AiAgentService(this.db, this.userId, {
         workspaceId: this.workspaceId,
       });
-      await aiAgentService.interruptTask({ operationId: target.operationId });
+      const result = await aiAgentService.interruptTask({ operationId: target.operationId });
+      if (!result.success) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'The execution owner did not acknowledge cancellation.',
+        });
+      }
     }
 
     await this.taskTopicModel.remove(target.taskId, topicId);
@@ -361,18 +373,27 @@ export class TaskService {
       for (const t of topics) {
         if (t.status !== 'running' || !t.topicId) continue;
 
-        // Interrupt the remote operation first; if it fails, skip cancellation
-        // to avoid desynchronizing DB state from a still-running operation.
+        // Interrupt the remote operation first. The whole transition must
+        // abort when any execution owner does not acknowledge — otherwise the
+        // parent task would settle (and e.g. unlock downstream work on
+        // 'completed') while one of its runs is still live.
         if (t.operationId) {
+          let acknowledged = false;
           try {
-            await aiAgentService.interruptTask({ operationId: t.operationId });
+            const result = await aiAgentService.interruptTask({ operationId: t.operationId });
+            acknowledged = result.success;
           } catch (err) {
             console.error(
               '[TaskService.updateStatus] failed to interrupt topic %s:',
               t.topicId,
               err,
             );
-            continue;
+          }
+          if (!acknowledged) {
+            throw new TRPCError({
+              code: 'CONFLICT',
+              message: 'The execution owner did not acknowledge cancellation.',
+            });
           }
         }
 

--- a/apps/server/src/services/taskLifecycle/index.ts
+++ b/apps/server/src/services/taskLifecycle/index.ts
@@ -269,6 +269,15 @@ export class TaskLifecycleService {
           await this.taskModel.updateStatus(taskId, 'paused', { error: null });
         }
       }
+    } else if (reason === 'interrupted') {
+      if (topicId) await this.taskTopicModel.updateStatus(taskId, topicId, 'canceled');
+
+      // Match TaskService.cancelTopic: stopping one run pauses its parent task
+      // so automation cannot immediately start another run. A terminal task
+      // that settled concurrently must not be moved backwards to paused.
+      if (currentTask && !isTerminal(currentTask.status)) {
+        await this.taskModel.pauseUnlessTerminal(taskId);
+      }
     } else if (reason === 'error') {
       if (topicId) await this.taskTopicModel.updateStatus(taskId, topicId, 'failed');
 
@@ -542,6 +551,7 @@ export class TaskLifecycleService {
    *     resolves the urgent error brief)
    */
   private async maybeRearmHeartbeat(task: TaskItem, reason: string): Promise<void> {
+    if (reason === 'interrupted') return;
     if (task.automationMode !== 'heartbeat') return;
     if (!task.heartbeatInterval || task.heartbeatInterval <= 0) return;
     if (isTerminal(task.status)) return;

--- a/apps/server/src/services/taskLifecycle/onTopicComplete.test.ts
+++ b/apps/server/src/services/taskLifecycle/onTopicComplete.test.ts
@@ -53,6 +53,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
   let updateContext: ReturnType<typeof vi.fn>;
   let findById: ReturnType<typeof vi.fn>;
   let updateHeartbeat: ReturnType<typeof vi.fn>;
+  let pauseUnlessTerminal: ReturnType<typeof vi.fn>;
   let updateTopicStatus: ReturnType<typeof vi.fn>;
   let createBrief: ReturnType<typeof vi.fn>;
   let getReviewConfig: ReturnType<typeof vi.fn>;
@@ -66,6 +67,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
     updateContext = vi.fn().mockResolvedValue(null);
     findById = vi.fn();
     updateHeartbeat = vi.fn().mockResolvedValue(undefined);
+    pauseUnlessTerminal = vi.fn().mockResolvedValue(true);
     updateTopicStatus = vi.fn().mockResolvedValue(undefined);
     createBrief = vi.fn().mockResolvedValue(undefined);
     getReviewConfig = vi.fn().mockReturnValue(undefined);
@@ -76,6 +78,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
     taskModel.updateContext = updateContext;
     taskModel.findById = findById;
     taskModel.updateHeartbeat = updateHeartbeat;
+    taskModel.pauseUnlessTerminal = pauseUnlessTerminal;
     taskModel.getReviewConfig = getReviewConfig;
     // Default checkpoint behavior: pause after topic complete
     taskModel.shouldPauseOnTopicComplete = vi.fn().mockReturnValue(true);
@@ -343,6 +346,29 @@ describe('TaskLifecycleService.onTopicComplete', () => {
       });
 
       expect(bridge).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('reason=interrupted', () => {
+    it('cancels the task topic and the owning task without rearming automation', async () => {
+      const runningTask = baseTask({ automationMode: 'heartbeat', status: 'running' });
+      const pausedTask = baseTask({ automationMode: 'heartbeat', status: 'paused' });
+      findById.mockResolvedValueOnce(runningTask).mockResolvedValueOnce(pausedTask);
+      const bridge = vi.spyOn(service as any, 'bridgeResultToCreator').mockResolvedValue(undefined);
+
+      await service.onTopicComplete({
+        operationId: 'op-1',
+        reason: 'interrupted',
+        taskId: 'task-1',
+        taskIdentifier: 'TASK-1',
+        topicId: 'topic-1',
+      });
+
+      expect(updateTopicStatus).toHaveBeenCalledWith('task-1', 'topic-1', 'canceled');
+      expect(pauseUnlessTerminal).toHaveBeenCalledWith('task-1');
+      expect(createBrief).not.toHaveBeenCalled();
+      expect(bridge).toHaveBeenCalledTimes(1);
+      expect(fakeScheduler.scheduleNextTopic).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/database/src/models/__tests__/task.test.ts
+++ b/packages/database/src/models/__tests__/task.test.ts
@@ -602,6 +602,17 @@ describe('TaskModel', () => {
       expect(updated!.status).toBe('running');
       expect(updated!.startedAt).toBeDefined();
     });
+
+    it('pauses a non-terminal task without moving a concurrently completed task backwards', async () => {
+      const model = new TaskModel(serverDB, userId);
+      const running = await model.create({ instruction: 'Running task', status: 'running' });
+      const completed = await model.create({ instruction: 'Completed task', status: 'completed' });
+
+      expect(await model.pauseUnlessTerminal(running.id)).toBe(true);
+      expect(await model.pauseUnlessTerminal(completed.id)).toBe(false);
+      expect((await model.findById(running.id))?.status).toBe('paused');
+      expect((await model.findById(completed.id))?.status).toBe('completed');
+    });
   });
 
   describe('heartbeat', () => {

--- a/packages/database/src/models/__tests__/topic.test.ts
+++ b/packages/database/src/models/__tests__/topic.test.ts
@@ -567,6 +567,51 @@ describe('TopicModel', () => {
     });
   });
 
+  describe('settleRunningOperation', () => {
+    it('atomically settles only the matching operation and returns its metadata snapshot', async () => {
+      const topic = await topicModel.create({
+        metadata: {
+          runningOperation: {
+            assistantMessageId: 'msg-old',
+            operationId: 'op-old',
+          },
+        },
+        status: 'running',
+        title: 'guarded running operation',
+      });
+
+      expect(await topicModel.settleRunningOperation(topic.id, 'op-stale')).toBeUndefined();
+      const unchanged = await topicModel.findById(topic.id);
+      expect(unchanged?.metadata?.runningOperation?.operationId).toBe('op-old');
+      expect(unchanged?.status).toBe('running');
+
+      const metadata = await topicModel.settleRunningOperation(topic.id, 'op-old');
+      expect(metadata?.runningOperation).toMatchObject({
+        assistantMessageId: 'msg-old',
+        operationId: 'op-old',
+      });
+      const settled = await topicModel.findById(topic.id);
+      expect(settled?.metadata?.runningOperation).toBeNull();
+      expect(settled?.status).toBe('unread');
+    });
+
+    it('preserves a status already settled by an attached client', async () => {
+      const topic = await topicModel.create({
+        metadata: {
+          runningOperation: { assistantMessageId: 'msg-client', operationId: 'op-client' },
+        },
+        status: 'active',
+        title: 'client settled operation',
+      });
+
+      await topicModel.settleRunningOperation(topic.id, 'op-client');
+
+      const settled = await topicModel.findById(topic.id);
+      expect(settled?.metadata?.runningOperation).toBeNull();
+      expect(settled?.status).toBe('active');
+    });
+  });
+
   describe('updateMetadata', () => {
     it('merges new metadata into existing metadata', async () => {
       const topic = await topicModel.create({

--- a/packages/database/src/models/task.ts
+++ b/packages/database/src/models/task.ts
@@ -785,6 +785,22 @@ export class TaskModel {
     return this.update(id, { status, ...extra });
   }
 
+  async pauseUnlessTerminal(id: string): Promise<boolean> {
+    const result = await this.db
+      .update(tasks)
+      .set({ status: 'paused', updatedAt: new Date() })
+      .where(
+        and(
+          eq(tasks.id, id),
+          this.ownership(),
+          notInArray(tasks.status, ['canceled', 'completed', 'failed']),
+        ),
+      )
+      .returning({ id: tasks.id });
+
+    return result.length > 0;
+  }
+
   async batchUpdateStatus(ids: string[], status: string): Promise<number> {
     const result = await this.db
       .update(tasks)

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -1208,6 +1208,37 @@ export class TopicModel {
   };
 
   /**
+   * Atomically clear and settle one exact running operation. Returns the
+   * metadata snapshot that owned the operation, or undefined when the topic is
+   * missing, belongs to another user, or has already moved on to another run.
+   */
+  settleRunningOperation = async (
+    id: string,
+    operationId: string,
+    status: TopicItem['status'] = 'unread',
+  ): Promise<ChatTopicMetadata | undefined> => {
+    return this.db.transaction(async (tx) => {
+      const [existing] = await tx
+        .select({ metadata: topics.metadata, status: topics.status })
+        .from(topics)
+        .where(and(eq(topics.id, id), this.ownership()))
+        .for('update');
+      if (existing?.metadata?.runningOperation?.operationId !== operationId) return;
+
+      await tx
+        .update(topics)
+        .set({
+          metadata: { ...existing.metadata, runningOperation: null },
+          ...(existing.status === 'running' && { status }),
+          updatedAt: new Date(),
+        })
+        .where(and(eq(topics.id, id), this.ownership()));
+
+      return existing.metadata;
+    });
+  };
+
+  /**
    * Settle a topic out of `running` once its run has terminated server-side.
    *
    * Guarded on `status = 'running'` so it is race-tolerant with clients: an

--- a/packages/heterogeneous-agents/src/protocol/execStdinPayload.test.ts
+++ b/packages/heterogeneous-agents/src/protocol/execStdinPayload.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildHeteroExecStdinPayload } from './execStdinPayload';
+import { buildHeteroExecStdinPayload, isHeteroExecCancelMessage } from './execStdinPayload';
 
 describe('buildHeteroExecStdinPayload', () => {
   it('returns a plain JSON string when no systemContext or images', () => {
@@ -59,5 +59,24 @@ describe('buildHeteroExecStdinPayload', () => {
         type: 'text',
       },
     ]);
+  });
+});
+
+describe('isHeteroExecCancelMessage', () => {
+  it('accepts the bounded wrapper cancellation protocol only', () => {
+    expect(
+      isHeteroExecCancelMessage({
+        operationId: 'op-1',
+        signal: 'SIGINT',
+        type: 'lobe:hetero-exec:cancel',
+      }),
+    ).toBe(true);
+    expect(
+      isHeteroExecCancelMessage({
+        operationId: 'op-1',
+        signal: 'SIGKILL',
+        type: 'lobe:hetero-exec:cancel',
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/heterogeneous-agents/src/protocol/execStdinPayload.ts
+++ b/packages/heterogeneous-agents/src/protocol/execStdinPayload.ts
@@ -1,5 +1,26 @@
 import { buildHeterogeneousPrompt } from './promptEngine';
 
+export const HETERO_EXEC_CANCEL_GRACE_MS = 30_000;
+
+export type HeteroExecCancelSignal = 'SIGINT' | 'SIGTERM';
+
+export interface HeteroExecCancelMessage {
+  operationId: string;
+  signal: HeteroExecCancelSignal;
+  type: 'lobe:hetero-exec:cancel';
+}
+
+export const isHeteroExecCancelMessage = (message: unknown): message is HeteroExecCancelMessage => {
+  if (!message || typeof message !== 'object') return false;
+
+  const candidate = message as Partial<HeteroExecCancelMessage>;
+  return (
+    candidate.type === 'lobe:hetero-exec:cancel' &&
+    typeof candidate.operationId === 'string' &&
+    (candidate.signal === 'SIGINT' || candidate.signal === 'SIGTERM')
+  );
+};
+
 /**
  * Image attachment reference carried through the hetero dispatch protocols
  * (gateway `agent_run_request`, sandbox runner). The URL must be fetchable by

--- a/packages/heterogeneous-agents/src/protocol/index.ts
+++ b/packages/heterogeneous-agents/src/protocol/index.ts
@@ -7,7 +7,14 @@
  * Executor-side helpers that materialize this contract (`normalizeImage`,
  * `buildAgentInput`, `spawnAgent`, …) live under `./spawn` instead.
  */
-export { buildHeteroExecStdinPayload, type HeteroExecImageRef } from './execStdinPayload';
+export {
+  buildHeteroExecStdinPayload,
+  HETERO_EXEC_CANCEL_GRACE_MS,
+  type HeteroExecCancelMessage,
+  type HeteroExecCancelSignal,
+  type HeteroExecImageRef,
+  isHeteroExecCancelMessage,
+} from './execStdinPayload';
 export {
   buildHeterogeneousPrompt,
   type HeterogeneousPromptContextProvider,

--- a/packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts
@@ -34,8 +34,7 @@ const readFileMock = vi.mocked(fsPromises.readFile);
 const callExecFile = (stdout: string) => {
   execFileMock.mockImplementationOnce(((...args: unknown[]) => {
     const callback = [...args].reverse().find((arg) => typeof arg === 'function') as
-      | ((error: Error | null, stdout: string) => void)
-      | undefined;
+      ((error: Error | null, stdout: string) => void) | undefined;
     callback?.(null, stdout);
     return {} as childProcess.ChildProcess;
   }) as typeof childProcess.execFile);
@@ -225,5 +224,31 @@ describe('cliSpawn', () => {
       args: ['--version'],
       command: shimPath,
     });
+  });
+
+  it('accepts the exact Windows command-line limit and rejects one UTF-16 unit more', async () => {
+    platformMock.mockReturnValue('win32');
+    const command = 'C:\\codex.exe';
+    const { resolveCliSpawnPlan } = await import('./cliSpawn');
+    const exactPrompt = 'a'.repeat(32_767 - command.length - 2);
+
+    await expect(resolveCliSpawnPlan(command, [exactPrompt])).resolves.toEqual({
+      args: [exactPrompt],
+      command,
+    });
+    await expect(resolveCliSpawnPlan(command, [`${exactPrompt}a`])).rejects.toThrow(
+      /Windows command line requires 32768 UTF-16 code units/,
+    );
+  });
+
+  it('counts astral characters as two Windows UTF-16 code units', async () => {
+    platformMock.mockReturnValue('win32');
+    const command = 'C:\\codex.exe';
+    const { resolveCliSpawnPlan } = await import('./cliSpawn');
+    const promptPrefix = 'a'.repeat(32_767 - command.length - 3);
+
+    await expect(resolveCliSpawnPlan(command, [`${promptPrefix}😀`])).rejects.toThrow(
+      /Windows command line requires 32768 UTF-16 code units/,
+    );
   });
 });

--- a/packages/heterogeneous-agents/src/spawn/cliSpawn.ts
+++ b/packages/heterogeneous-agents/src/spawn/cliSpawn.ts
@@ -4,6 +4,7 @@ import { platform } from 'node:os';
 import path from 'node:path';
 
 const WINDOWS_EXE_EXT_PATTERN = /\.exe$/i;
+const WINDOWS_MAX_COMMAND_LINE_LENGTH = 32_767;
 const WINDOWS_NODE_EXE_PATTERN = /(?:^|[\\/])node(?:\.exe)?$/i;
 
 export interface CliSpawnPlan {
@@ -17,6 +18,41 @@ interface WindowsShimTarget {
 }
 
 const isWindows = () => platform() === 'win32';
+
+const quoteWindowsCommandLineArgument = (argument: string): string => {
+  if (argument && !/[\t "]/u.test(argument)) return argument;
+
+  let quoted = '"';
+  let backslashCount = 0;
+
+  for (const character of argument) {
+    if (character === '\\') {
+      backslashCount += 1;
+      continue;
+    }
+
+    if (character === '"') {
+      quoted += `${'\\'.repeat(backslashCount * 2 + 1)}"`;
+    } else {
+      quoted += `${'\\'.repeat(backslashCount)}${character}`;
+    }
+    backslashCount = 0;
+  }
+
+  return `${quoted}${'\\'.repeat(backslashCount * 2)}"`;
+};
+
+const assertWindowsCommandLineFits = ({ args, command }: CliSpawnPlan): void => {
+  const commandLineLength = [command, ...args]
+    .map(quoteWindowsCommandLineArgument)
+    .join(' ').length;
+  const requiredLength = commandLineLength + 1;
+  if (requiredLength <= WINDOWS_MAX_COMMAND_LINE_LENGTH) return;
+
+  throw new Error(
+    `Cannot start CLI because the resolved Windows command line requires ${requiredLength} UTF-16 code units; Windows permits at most ${WINDOWS_MAX_COMMAND_LINE_LENGTH} including the terminator. Shorten the prompt or conversation context and retry.`,
+  );
+};
 
 const isPathLikeCommand = (command: string) =>
   path.win32.isAbsolute(command) || path.posix.isAbsolute(command) || /[\\/]/.test(command);
@@ -229,7 +265,10 @@ export const resolveCliSpawnPlan = async (
     ? await inferWindowsNpmShimTarget(trimmedCommand)
     : await resolveWindowsBareCommand(trimmedCommand);
 
-  if (!target) return { args, command };
+  const spawnPlan = target
+    ? { args: [...(target.argsPrefix ?? []), ...args], command: target.command }
+    : { args, command };
 
-  return { args: [...(target.argsPrefix ?? []), ...args], command: target.command };
+  assertWindowsCommandLineFits(spawnPlan);
+  return spawnPlan;
 };

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
@@ -36,14 +36,6 @@ const callExecFileError = (err: Error) => {
     return {} as any;
   }) as any);
 };
-const callExec = (stdout: string, stderr = '') => {
-  execMock.mockImplementationOnce(((cmd: string, opts: any, cb: any) => {
-    const callback = typeof opts === 'function' ? opts : cb;
-    callback(noErr, { stdout, stderr });
-    return {} as any;
-  }) as any);
-};
-
 const importModule = () => import('./resolveCliCommand');
 
 describe('resolveCliCommand', () => {
@@ -255,18 +247,18 @@ describe('resolveCliCommand', () => {
       platformMock.mockReturnValue('win32');
     });
 
-    it('resolves `codex` to the .cmd shim via `where`, then runs it through the shell', async () => {
+    it('resolves `codex` to the .cmd shim without constructing a shell command', async () => {
       callExecFile('C:\\Users\\x\\AppData\\Roaming\\npm\\codex.cmd\r\n');
-      callExec('codex 0.142.5');
+      callExecFile('codex 0.142.5');
 
       const { detectValidatedCommand } = await importModule();
       const status = await detectValidatedCommand('codex', { validateKeywords: ['codex'] });
 
       expect(status.available).toBe(true);
       expect(status.path).toBe('C:\\Users\\x\\AppData\\Roaming\\npm\\codex.cmd');
-      expect(execMock.mock.calls[0]![0]).toBe(
-        '"C:\\Users\\x\\AppData\\Roaming\\npm\\codex.cmd" --version',
-      );
+      expect(execFileMock.mock.calls[1]![0]).toBe('C:\\Users\\x\\AppData\\Roaming\\npm\\codex.cmd');
+      expect(execFileMock.mock.calls[1]![1]).toEqual(['--version']);
+      expect(execMock).not.toHaveBeenCalled();
     });
 
     it('prefers the .cmd shim when `where` returns multiple PATHEXT matches', async () => {
@@ -277,7 +269,7 @@ describe('resolveCliCommand', () => {
           'C:\\Users\\x\\AppData\\Roaming\\npm\\codex.ps1',
         ].join('\r\n'),
       );
-      callExec('codex 0.142.5');
+      callExecFile('codex 0.142.5');
 
       const { detectValidatedCommand } = await importModule();
       const status = await detectValidatedCommand('codex', { validateKeywords: ['codex'] });
@@ -296,7 +288,7 @@ describe('resolveCliCommand', () => {
           'C:\\Users\\hp\\.vite-plus\\bin\\claude.exe',
         ].join('\r\n'),
       );
-      callExec('1.2.3 (Claude Code)');
+      callExecFile('1.2.3 (Claude Code)');
 
       const { detectValidatedCommand } = await importModule();
       const status = await detectValidatedCommand('claude', {

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
@@ -1,10 +1,11 @@
-import { exec, execFile } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { homedir, platform } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
 import type { LocalHeterogeneousAgentType } from '../config';
 import { HETEROGENEOUS_AGENT_CONFIGS } from '../config';
+import { resolveCliSpawnPlan } from './cliSpawn';
 
 /**
  * Shared resolver for external CLI-agent binaries (Amp / Claude Code / Codex / OpenCode / Pi / Qoder).
@@ -21,7 +22,6 @@ import { HETEROGENEOUS_AGENT_CONFIGS } from '../config';
  */
 
 const execFilePromise = promisify(execFile);
-const execPromise = promisify(exec);
 
 export type HeterogeneousCliAgentType = LocalHeterogeneousAgentType;
 
@@ -58,13 +58,12 @@ interface ResolvedCommand {
 const isWindows = () => platform() === 'win32';
 let shellPathPromise: Promise<string | undefined> | undefined;
 
-// Reject anything that could break out of the `cmd /c "<path>" --version`
-// shell line we build for Windows .cmd shims (see `detectValidatedCommand`).
-// User-supplied custom commands flow through here via `detectHeterogeneousCliCommand`.
+// Reject shell syntax in user-supplied custom commands instead of treating it
+// as part of a command name.
 const WINDOWS_SHELL_METAS = /[&|;<>^`!"]/;
 
-// Extensions we can actually execute on Windows.
-// `.exe` runs directly via `execFile`, `.cmd` / `.bat` runs via `cmd.exe`.
+// Extensions eligible for execution on Windows. `.exe` runs directly, while
+// supported `.cmd` / `.bat` shims are unwrapped by `resolveCliSpawnPlan`.
 // `.ps1` and extensionless wrappers (npm sometimes drops a Unix shell script
 // next to the `.cmd` shim) are deliberately excluded — we can't run them.
 //
@@ -185,6 +184,15 @@ const resolveCommandPath = async (command: string): Promise<ResolvedCommand | un
   return { env: lookupEnv, path: lines[0] };
 };
 
+const execResolvedCommand = async (command: string, args: string[], env?: NodeJS.ProcessEnv) => {
+  const spawnPlan = await resolveCliSpawnPlan(command, args);
+  return execFilePromise(spawnPlan.command, spawnPlan.args, {
+    env,
+    timeout: 5000,
+    windowsHide: true,
+  });
+};
+
 /**
  * Resolve a command via which/where, then confirm it's the binary we expect by
  * matching `--version` output against a keyword or output pattern (avoids
@@ -209,18 +217,7 @@ export const detectValidatedCommand = async (
   const { env, path: resolvedPath } = resolvedCommand;
 
   try {
-    const needsShell = isWindows() && /\.(?:cmd|bat)$/i.test(resolvedPath);
-    const { stderr, stdout } = needsShell
-      ? await execPromise(`"${resolvedPath}" ${validateFlag}`, {
-          env,
-          timeout: 5000,
-          windowsHide: true,
-        })
-      : await execFilePromise(resolvedPath, [validateFlag], {
-          env,
-          timeout: 5000,
-          windowsHide: true,
-        });
+    const { stderr, stdout } = await execResolvedCommand(resolvedPath, [validateFlag], env);
     const output = `${stdout}\n${stderr}`.trim();
     const loweredOutput = output.toLowerCase();
     const matchesKeyword = validateKeywords?.some((keyword) =>

--- a/packages/heterogeneous-agents/src/spawn/spawnAgent.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/spawnAgent.test.ts
@@ -308,6 +308,24 @@ describe('spawnAgent', () => {
     expect(args[0]).toBe('exec');
   });
 
+  it('kills the native agent tree but leaves the wrapper alive on Windows cancellation', async () => {
+    platformMock.mockReturnValue('win32');
+    callExecFile('C:\\Tools\\codex.exe\r\n');
+    const fake = createFakeProc();
+    nextFakeProc = fake.proc;
+
+    const { spawnAgent } = await import('./spawnAgent');
+    const handle = await spawnAgent({ agentType: 'codex', operationId: 'op-1', prompt: 'hi' });
+    handle.kill('SIGINT');
+
+    expect(spawnCalls[1]).toMatchObject({
+      args: ['/pid', '12345', '/T', '/F'],
+      command: 'taskkill',
+      options: { stdio: 'ignore' },
+    });
+    expect(fake.proc.kill).not.toHaveBeenCalled();
+  });
+
   it('uses codex `exec resume` form with thread id + `-` stdin marker on resume', async () => {
     const codexHome = await mkdtemp(path.join(os.tmpdir(), 'lobe-codex-spawn-empty-'));
     tempDirs.push(codexHome);

--- a/packages/heterogeneous-agents/src/spawn/spawnAgent.ts
+++ b/packages/heterogeneous-agents/src/spawn/spawnAgent.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
+import { platform } from 'node:os';
 
 import type { AgentStreamEvent } from '@lobechat/agent-gateway-client';
 
@@ -298,16 +299,18 @@ const buildSpawnArgs = (params: BuildSpawnArgsParams): string[] => {
 const killProcessTree = (proc: ChildProcess, signal: NodeJS.Signals): void => {
   if (!proc.pid || proc.killed) return;
 
-  // On Windows the spawn `detached` flag has different semantics; fall back
-  // to a direct signal. Tree-kill via `taskkill` is what the desktop
-  // controller does for end-user CC, but the CLI's primary use case is
-  // sandbox + Unix dev terminals, so keep this minimal.
-  if (process.platform === 'win32') {
-    try {
-      proc.kill(signal);
-    } catch {
-      // already gone
-    }
+  // Keep the `lh hetero exec` wrapper alive on Windows while terminating the
+  // native agent and its tools. The wrapper must drain pending events and send
+  // the sole heteroFinish terminal callback after this tree exits.
+  if (platform() === 'win32') {
+    const killer = spawn('taskkill', ['/pid', String(proc.pid), '/T', '/F'], { stdio: 'ignore' });
+    killer.once('error', () => {
+      try {
+        proc.kill(signal);
+      } catch {
+        // already gone
+      }
+    });
     return;
   }
 
@@ -361,7 +364,7 @@ export const spawnAgent = async (options: SpawnAgentOptions): Promise<SpawnAgent
   const cliSpawnPlan = await resolveCliSpawnPlan(command, args);
   const proc = spawn(cliSpawnPlan.command, cliSpawnPlan.args, {
     cwd,
-    detached: process.platform !== 'win32',
+    detached: platform() !== 'win32',
     env: childEnv,
     stdio: ['pipe', 'pipe', 'pipe'],
   });

--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -192,13 +192,13 @@ export interface ChatTopicMetadata {
    */
   runningOperation?: {
     assistantMessageId: string;
-    /** Device selected for a notify-based platform task. */
+    /** Device selected for a heterogeneous agent task. */
     deviceId?: string;
     /** Personal-device owner used to route dispatch and cancellation through the same principal. */
     deviceUserId?: string;
     /** Workspace principal used for a workspace-enrolled device. */
     deviceWorkspaceId?: string;
-    /** Notify-based platform type used to select the cancellation protocol. */
+    /** Heterogeneous agent type used to select the cancellation protocol. */
     heteroType?: string;
     /**
      * Serialized lifecycle hooks (onComplete / onError) registered for this run.

--- a/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
@@ -987,25 +987,28 @@ describe('createGatewayEventHandler', () => {
     // the executor's partial-finalize catch is still racing to write the
     // real content, and a fetch here would return placeholder and clobber
     // in-memory streamed content.
-    it('should NOT refetch from DB when reason=interrupted AND stream had progressed', async () => {
-      const store = createMockStore();
-      const handler = createHandler(store);
+    it.each(['interrupted', 'cancelled'])(
+      'should NOT refetch from DB when reason=%s AND stream had progressed',
+      async (reason) => {
+        const store = createMockStore();
+        const handler = createHandler(store);
 
-      // Simulate a stream that had progressed: server-assigned assistant id
-      // arrived via stream_start, then a text chunk landed.
-      handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-server' } }));
-      handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'partial answer' }));
-      await flush();
-      vi.mocked(messageService.getMessages).mockClear();
-      store.replaceMessages.mockClear();
+        // Simulate a stream that had progressed: server-assigned assistant id
+        // arrived via stream_start, then a text chunk landed.
+        handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-server' } }));
+        handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'partial answer' }));
+        await flush();
+        vi.mocked(messageService.getMessages).mockClear();
+        store.replaceMessages.mockClear();
 
-      handler(makeEvent('agent_runtime_end', { reason: 'interrupted' }));
-      await flush();
+        handler(makeEvent('agent_runtime_end', { reason }));
+        await flush();
 
-      expect(store.completeOperation).toHaveBeenCalledWith('op-1');
-      expect(messageService.getMessages).not.toHaveBeenCalled();
-      expect(store.replaceMessages).not.toHaveBeenCalled();
-    });
+        expect(store.completeOperation).toHaveBeenCalledWith('op-1');
+        expect(messageService.getMessages).not.toHaveBeenCalled();
+        expect(store.replaceMessages).not.toHaveBeenCalled();
+      },
+    );
 
     // Reviewer feedback on PR #15173: if cancel arrives BEFORE any
     // stream activity (no server-assigned assistant id, no chunks), the
@@ -1490,7 +1493,7 @@ describe('createGatewayEventHandler', () => {
       );
     });
 
-    it.each(['interrupted', 'waiting_for_async_tool'])(
+    it.each(['interrupted', 'cancelled', 'waiting_for_async_tool'])(
       'agent_runtime_end with reason "%s" completes the op but does NOT mark unread (cancel/park)',
       async (reason) => {
         const store = createMockStore();

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
@@ -34,7 +34,11 @@ import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 // cancel and a deferred-tool park. These must NOT mark the topic unread, and
 // must take the non-success branch in `onSessionComplete` so the run clears
 // back to 'active' rather than persisting as an unread completion.
-const NON_COMPLETION_RUNTIME_END_REASONS = new Set(['interrupted', 'waiting_for_async_tool']);
+const NON_COMPLETION_RUNTIME_END_REASONS = new Set([
+  'cancelled',
+  'interrupted',
+  'waiting_for_async_tool',
+]);
 
 /**
  * Whether an `agent_runtime_end` event represents a clean completion (vs. a
@@ -1121,10 +1125,7 @@ export const createGatewayEventHandler = (
               action: 'gateway/agent_runtime_end',
               context,
             });
-          } else if (
-            (data?.reason === 'interrupted' || data?.reason === 'waiting_for_async_tool') &&
-            hasStreamedContent
-          ) {
+          } else if (!isCompletedRuntimeEnd(data?.reason) && hasStreamedContent) {
             // MID-stream cancel, or a deferred-tool pause
             // (`waiting_for_async_tool`). The server's
             // `AgentRuntimeCoordinator.resolveUiMessages` omits uiMessages


### PR DESCRIPTION
## Summary

Make cancellation of device-backed heterogeneous agents owner-acknowledged, bounded, and lifecycle-complete across CLI, Desktop, Server, Task, Eval, and Gateway consumers.

| Before | After |
| ------ | ----- |
| Device-backed local CLI runs were not owned by the in-process server runtime or the platform-task PID registry | Desktop and `lh connect` track each `lh hetero exec` wrapper by operation ID and acknowledge cancellation from the actual execution owner |
| `cancelled` terminal callbacks skipped completion hooks and could leave task/topic state unsettled | Wire `cancelled` is normalized to canonical `interrupted`, atomically settles the matching operation, and runs interruption cleanup without success-only side effects |

### What changed

- Add the shared `lobe:hetero-exec:cancel` IPC contract
- Track gateway-dispatched wrappers in Desktop and `lh connect`
- Latch early SIGINT/SIGTERM and preserve the final ingest/`heteroFinish` drain
- Escalate ignored graceful cancellation to wrapper-owned process-tree SIGKILL, with an outer fallback deadline
- Route server interruption to the device recorded on `runningOperation`
- Require semantic cancellation acknowledgement before settling Task/Thread state
- Atomically settle only the matching topic operation to reject stale callbacks
- Deliver `onComplete(interrupted)` to Task, bot, and eval cleanup while keeping notifications, verify, Works, evaluation, unread, and heartbeat success paths disabled
- Preserve legacy `cancelled` gateway events as non-success completions

This is PR 2 of 3 split from #18061 and is intentionally based on #18095. After #18095 merges, retarget this PR to `canary`.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation: `bun run check <39 changed files>` — 767 tests passed, lint clean.

#### 🔗 Related Issue

Related to #18061
