### PR TITLE
🐛 fix(chat-input): stop deleting unsent composer drafts

### DIFF
--- a/src/features/ChatInput/draftStorage.ts
+++ b/src/features/ChatInput/draftStorage.ts
@@ -100,16 +100,20 @@ export const useHasDraft = (key: string | undefined): boolean =>
     () => false,
   );
 
-export const getDraft = (key: string): Record<string, unknown> | undefined => {
+export const getDraftEntry = (key: string): ChatInputDraftEntry | undefined => {
   if (!key) return undefined;
-  return readAll()[key]?.json;
+  return readAll()[key];
 };
 
-export const saveDraft = (key: string, json: Record<string, unknown>): void => {
+export const getDraft = (key: string): Record<string, unknown> | undefined =>
+  getDraftEntry(key)?.json;
+
+export const saveDraft = (key: string, json: Record<string, unknown>): number | undefined => {
   if (!key) return;
 
   const map = readAll();
-  map[key] = { json, updatedAt: Date.now() };
+  const updatedAt = Math.max(Date.now(), (map[key]?.updatedAt ?? 0) + 1);
+  map[key] = { json, updatedAt };
 
   const keys = Object.keys(map);
   if (keys.length > MAX_DRAFTS) {
@@ -121,8 +125,9 @@ export const saveDraft = (key: string, json: Record<string, unknown>): void => {
       });
   }
 
-  writeAll(map);
+  if (!writeAll(map)) return;
   syncDraftKeys(map);
+  return updatedAt;
 };
 
 export const removeDraft = (key: string): void => {
@@ -134,4 +139,21 @@ export const removeDraft = (key: string): void => {
   delete map[key];
   writeAll(map);
   syncDraftKeys(map);
+};
+
+export const removeDraftIfUnchanged = (
+  key: string,
+  expectedUpdatedAt: number | undefined,
+): boolean => {
+  if (!key) return false;
+
+  const map = readAll();
+  const entry = map[key];
+  if (entry?.updatedAt !== expectedUpdatedAt) return false;
+  if (!entry) return true;
+
+  delete map[key];
+  if (!writeAll(map)) return false;
+  syncDraftKeys(map);
+  return true;
 };

--- a/src/features/ChatInput/hooks/useChatInputDraft.test.tsx
+++ b/src/features/ChatInput/hooks/useChatInputDraft.test.tsx
@@ -7,6 +7,26 @@ import { getDraft, saveDraft } from '../draftStorage';
 import { createStore, Provider } from '../store';
 import { useChatInputDraft } from './useChatInputDraft';
 
+const createFakeEditor = () => {
+  let json: Record<string, unknown> | undefined;
+
+  return {
+    cleanDocument: vi.fn(() => {
+      json = undefined;
+    }),
+    focus: vi.fn(),
+    getDocument: vi.fn((type: string) =>
+      type === 'markdown' ? ((json?.text as string) ?? '') : json,
+    ),
+    get isEmpty() {
+      return !json?.text;
+    },
+    setDocument: vi.fn((_type: string, content: Record<string, unknown>) => {
+      json = content;
+    }),
+  } as unknown as IEditor;
+};
+
 describe('useChatInputDraft', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -39,6 +59,53 @@ describe('useChatInputDraft', () => {
     unmount();
 
     expect(getDraft('main_agent_topic')).toEqual(draftJson);
+  });
+
+  it('persists live editor content on unmount when no save is pending yet', () => {
+    const editor = createFakeEditor();
+    const store = createStore({ draftKey: 'main_agt_a_tpc_1', editor });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <Provider createStore={() => store}>{children}</Provider>
+    );
+
+    const { result, unmount } = renderHook(() => useChatInputDraft(), { wrapper });
+
+    act(() => {
+      result.current.restoreDraft(editor);
+      // the editor's own change notification is debounced, so text typed right
+      // before the composer unmounts has not scheduled a save yet
+      editor.setDocument('json', { text: 'typed right before leaving' });
+    });
+
+    unmount();
+
+    expect(getDraft('main_agt_a_tpc_1')).toEqual({ text: 'typed right before leaving' });
+  });
+
+  it('restores input the previous composer instance persisted on unmount', () => {
+    const editor = createFakeEditor();
+    const store = createStore({ draftKey: 'main_agt_a_tpc_1', editor });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <Provider createStore={() => store}>{children}</Provider>
+    );
+
+    const first = renderHook(() => useChatInputDraft(), { wrapper });
+    act(() => {
+      first.result.current.restoreDraft(editor);
+      editor.setDocument('json', { text: 'typed a moment before remount' });
+    });
+    first.unmount();
+
+    // remounting the composer re-seeds the editor from the empty `content`
+    // prop, so the text can only come back through the stored draft
+    editor.cleanDocument();
+
+    const second = renderHook(() => useChatInputDraft(), { wrapper });
+    act(() => {
+      second.result.current.restoreDraft(editor);
+    });
+
+    expect(editor.getDocument('markdown')).toBe('typed a moment before remount');
   });
 
   it('restores a draft when the editor is empty', () => {
@@ -155,26 +222,64 @@ describe('useChatInputDraft', () => {
   });
 
   it('removes the old draft when leaving with an emptied editor', () => {
-    const editor = {
-      cleanDocument: vi.fn(),
-      focus: vi.fn(),
-      getDocument: vi.fn((type: string) => (type === 'markdown' ? '' : undefined)),
-      isEmpty: true,
-      setDocument: vi.fn(),
-    } as unknown as IEditor;
+    const editor = createFakeEditor();
     const store = createStore({ draftKey: 'main_agt_a_tpc_1', editor });
     const wrapper = ({ children }: { children: ReactNode }) => (
       <Provider createStore={() => store}>{children}</Provider>
     );
-    saveDraft('main_agt_a_tpc_1', { root: { children: [{ text: 'stale' }] } });
+    saveDraft('main_agt_a_tpc_1', { text: 'stale' });
 
-    renderHook(() => useChatInputDraft(), { wrapper });
+    const { result } = renderHook(() => useChatInputDraft(), { wrapper });
+
+    act(() => {
+      result.current.restoreDraft(editor);
+      editor.cleanDocument();
+    });
 
     act(() => {
       store.setState({ draftKey: 'main_agt_a_tpc_2' });
     });
 
     expect(getDraft('main_agt_a_tpc_1')).toBeUndefined();
+  });
+
+  it('keeps a draft the editor has not loaded yet when the draft key changes', () => {
+    const editor = createFakeEditor();
+    const store = createStore({ draftKey: 'main_agt_a_tpc_1', editor });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <Provider createStore={() => store}>{children}</Provider>
+    );
+    saveDraft('main_agt_a_tpc_1', { text: 'unsent draft' });
+
+    // no restoreDraft: mirrors the window between mount and the restore frame,
+    // where the editor is empty simply because nothing loaded it yet
+    renderHook(() => useChatInputDraft(), { wrapper });
+
+    act(() => {
+      store.setState({ draftKey: 'main_agt_a_tpc_2' });
+    });
+
+    expect(getDraft('main_agt_a_tpc_1')).toEqual({ text: 'unsent draft' });
+  });
+
+  it('keeps a draft the editor has not loaded yet when the debounced save runs', () => {
+    const editor = createFakeEditor();
+    const store = createStore({ draftKey: 'main_agt_a_tpc_1', editor });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <Provider createStore={() => store}>{children}</Provider>
+    );
+    saveDraft('main_agt_a_tpc_1', { text: 'unsent draft' });
+
+    const { result } = renderHook(() => useChatInputDraft(), { wrapper });
+
+    // the editor reports every commit, selection-only ones included, so a save
+    // can be scheduled before the restore frame lands
+    act(() => {
+      result.current.saveDraftDebounced();
+      vi.runAllTimers();
+    });
+
+    expect(getDraft('main_agt_a_tpc_1')).toEqual({ text: 'unsent draft' });
   });
 
   it('does not overwrite current editor input when restoring a draft', () => {

--- a/src/features/ChatInput/hooks/useChatInputDraft.test.tsx
+++ b/src/features/ChatInput/hooks/useChatInputDraft.test.tsx
@@ -108,6 +108,39 @@ describe('useChatInputDraft', () => {
     expect(editor.getDocument('markdown')).toBe('typed a moment before remount');
   });
 
+  it('keeps a draft saved by another composer when an untouched empty instance unmounts', () => {
+    const draftKey = 'main_agt_a_tpc_shared';
+    const emptyEditor = createFakeEditor();
+    const writerEditor = createFakeEditor();
+    const emptyStore = createStore({ draftKey, editor: emptyEditor });
+    const writerStore = createStore({ draftKey, editor: writerEditor });
+    const emptyWrapper = ({ children }: { children: ReactNode }) => (
+      <Provider createStore={() => emptyStore}>{children}</Provider>
+    );
+    const writerWrapper = ({ children }: { children: ReactNode }) => (
+      <Provider createStore={() => writerStore}>{children}</Provider>
+    );
+
+    const emptyComposer = renderHook(() => useChatInputDraft(), { wrapper: emptyWrapper });
+    const writerComposer = renderHook(() => useChatInputDraft(), { wrapper: writerWrapper });
+
+    act(() => {
+      emptyComposer.result.current.restoreDraft(emptyEditor);
+      writerComposer.result.current.restoreDraft(writerEditor);
+      writerEditor.setDocument('json', { text: 'draft from the other tab' });
+      writerComposer.result.current.saveDraftDebounced();
+      vi.runAllTimers();
+    });
+
+    expect(getDraft(draftKey)).toEqual({ text: 'draft from the other tab' });
+
+    emptyComposer.unmount();
+
+    expect(getDraft(draftKey)).toEqual({ text: 'draft from the other tab' });
+
+    writerComposer.unmount();
+  });
+
   it('restores a draft when the editor is empty', () => {
     const draftJson = { root: { children: [{ text: 'draft' }] } };
     const setDocument = vi.fn();

--- a/src/features/ChatInput/hooks/useChatInputDraft.test.tsx
+++ b/src/features/ChatInput/hooks/useChatInputDraft.test.tsx
@@ -108,7 +108,7 @@ describe('useChatInputDraft', () => {
     expect(editor.getDocument('markdown')).toBe('typed a moment before remount');
   });
 
-  it('keeps a draft saved by another composer when an untouched empty instance unmounts', () => {
+  it('keeps a newer draft when an empty composer flushes a pending save on unmount', () => {
     const draftKey = 'main_agt_a_tpc_shared';
     const emptyEditor = createFakeEditor();
     const writerEditor = createFakeEditor();
@@ -127,9 +127,10 @@ describe('useChatInputDraft', () => {
     act(() => {
       emptyComposer.result.current.restoreDraft(emptyEditor);
       writerComposer.result.current.restoreDraft(writerEditor);
+      emptyComposer.result.current.saveDraftDebounced();
       writerEditor.setDocument('json', { text: 'draft from the other tab' });
       writerComposer.result.current.saveDraftDebounced();
-      vi.runAllTimers();
+      writerComposer.result.current.saveDraftDebounced.flush();
     });
 
     expect(getDraft(draftKey)).toEqual({ text: 'draft from the other tab' });
@@ -139,6 +140,30 @@ describe('useChatInputDraft', () => {
     expect(getDraft(draftKey)).toEqual({ text: 'draft from the other tab' });
 
     writerComposer.unmount();
+  });
+
+  it('removes its unchanged draft when flushing a pending clear on unmount', () => {
+    const draftKey = 'main_agt_a_tpc_owned';
+    const editor = createFakeEditor();
+    const store = createStore({ draftKey, editor });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <Provider createStore={() => store}>{children}</Provider>
+    );
+    saveDraft(draftKey, { text: 'draft to clear' });
+
+    const { result, unmount } = renderHook(() => useChatInputDraft(), { wrapper });
+
+    act(() => {
+      result.current.restoreDraft(editor);
+      editor.cleanDocument();
+      result.current.saveDraftDebounced();
+    });
+
+    expect(getDraft(draftKey)).toEqual({ text: 'draft to clear' });
+
+    unmount();
+
+    expect(getDraft(draftKey)).toBeUndefined();
   });
 
   it('restores a draft when the editor is empty', () => {

--- a/src/features/ChatInput/hooks/useChatInputDraft.ts
+++ b/src/features/ChatInput/hooks/useChatInputDraft.ts
@@ -17,12 +17,12 @@ export const useChatInputDraft = () => {
   const loadedDraftKeyRef = useRef<string | undefined>(undefined);
 
   const persistDraftFor = useCallback(
-    (draftKey: string) => {
+    (draftKey: string, removeEmpty = true) => {
       const { editor, getMarkdownContent, getJSONState } = storeApi.getState();
       if (!editor) return;
 
       if (getMarkdownContent().trim().length === 0) {
-        if (loadedDraftKeyRef.current === draftKey) removeDraft(draftKey);
+        if (removeEmpty && loadedDraftKeyRef.current === draftKey) removeDraft(draftKey);
         return;
       }
 
@@ -44,14 +44,16 @@ export const useChatInputDraft = () => {
     [persistDraftFor, storeApi],
   );
 
-  // Persist the live document rather than flushing the pending save: the
-  // editor's own change notification is debounced too, so text typed in the
-  // last moment before unmount has not scheduled anything to flush.
+  // Flush locally scheduled work first so an intentional clear still removes
+  // its draft. Then save live non-empty content that may not have reached the
+  // debounce yet. The unconditional pass must not remove an empty draft: a
+  // different composer instance may have written the shared key since this
+  // instance restored it as empty.
   useEffect(
     () => () => {
-      saveDraftDebounced.cancel();
+      saveDraftDebounced.flush();
       const { draftKey } = storeApi.getState();
-      if (draftKey) persistDraftFor(draftKey);
+      if (draftKey) persistDraftFor(draftKey, false);
     },
     [persistDraftFor, saveDraftDebounced, storeApi],
   );

--- a/src/features/ChatInput/hooks/useChatInputDraft.ts
+++ b/src/features/ChatInput/hooks/useChatInputDraft.ts
@@ -2,19 +2,19 @@ import type { IEditor } from '@lobehub/editor';
 import { debounce } from 'es-toolkit/compat';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 
-import { getDraft, removeDraft, saveDraft } from '../draftStorage';
+import { getDraftEntry, removeDraftIfUnchanged, saveDraft } from '../draftStorage';
 import { useStoreApi } from '../store';
 
 const SAVE_DEBOUNCE_MS = 500;
 
 export const useChatInputDraft = () => {
   const storeApi = useStoreApi();
-  // The key whose document the editor is currently carrying. An empty editor
-  // only means "the user emptied it" once this matches; before the restore
-  // lands (it is deferred a frame, and never runs at all while frames are
-  // starved) an empty editor just means the draft has not been loaded, and
-  // treating that as a clear would delete unsent input the user never saw.
-  const loadedDraftKeyRef = useRef<string | undefined>(undefined);
+  // The storage revision whose document the editor is currently carrying. An
+  // empty editor may remove only that revision: before restore it owns none,
+  // and after another composer writes the same key its revision is stale.
+  const loadedDraftRef = useRef<{ draftKey: string; updatedAt: number | undefined } | undefined>(
+    undefined,
+  );
 
   const persistDraftFor = useCallback(
     (draftKey: string, removeEmpty = true) => {
@@ -22,14 +22,21 @@ export const useChatInputDraft = () => {
       if (!editor) return;
 
       if (getMarkdownContent().trim().length === 0) {
-        if (removeEmpty && loadedDraftKeyRef.current === draftKey) removeDraft(draftKey);
+        const loadedDraft = loadedDraftRef.current;
+        if (
+          removeEmpty &&
+          loadedDraft?.draftKey === draftKey &&
+          removeDraftIfUnchanged(draftKey, loadedDraft.updatedAt)
+        ) {
+          loadedDraftRef.current = { draftKey, updatedAt: undefined };
+        }
         return;
       }
 
       const json = getJSONState();
       if (json) {
-        saveDraft(draftKey, json);
-        loadedDraftKeyRef.current = draftKey;
+        const updatedAt = saveDraft(draftKey, json);
+        if (updatedAt !== undefined) loadedDraftRef.current = { draftKey, updatedAt };
       }
     },
     [storeApi],
@@ -45,10 +52,9 @@ export const useChatInputDraft = () => {
   );
 
   // Flush locally scheduled work first so an intentional clear still removes
-  // its draft. Then save live non-empty content that may not have reached the
-  // debounce yet. The unconditional pass must not remove an empty draft: a
-  // different composer instance may have written the shared key since this
-  // instance restored it as empty.
+  // the revision this editor owns. Then save live non-empty content that may
+  // not have reached the debounce yet. The unconditional pass must not remove
+  // an empty draft: a different composer may have written the shared key.
   useEffect(
     () => () => {
       saveDraftDebounced.flush();
@@ -63,12 +69,12 @@ export const useChatInputDraft = () => {
       const { draftKey } = storeApi.getState();
       if (!draftKey) return;
 
-      loadedDraftKeyRef.current = draftKey;
+      const draft = getDraftEntry(draftKey);
+      loadedDraftRef.current = { draftKey, updatedAt: draft?.updatedAt };
 
       if (!editor.isEmpty) return;
 
-      const draft = getDraft(draftKey);
-      if (draft) editor.setDocument('json', draft);
+      if (draft) editor.setDocument('json', draft.json);
     },
     [storeApi],
   );

--- a/src/features/ChatInput/hooks/useChatInputDraft.ts
+++ b/src/features/ChatInput/hooks/useChatInputDraft.ts
@@ -1,6 +1,6 @@
 import type { IEditor } from '@lobehub/editor';
 import { debounce } from 'es-toolkit/compat';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { getDraft, removeDraft, saveDraft } from '../draftStorage';
 import { useStoreApi } from '../store';
@@ -9,6 +9,12 @@ const SAVE_DEBOUNCE_MS = 500;
 
 export const useChatInputDraft = () => {
   const storeApi = useStoreApi();
+  // The key whose document the editor is currently carrying. An empty editor
+  // only means "the user emptied it" once this matches; before the restore
+  // lands (it is deferred a frame, and never runs at all while frames are
+  // starved) an empty editor just means the draft has not been loaded, and
+  // treating that as a clear would delete unsent input the user never saw.
+  const loadedDraftKeyRef = useRef<string | undefined>(undefined);
 
   const persistDraftFor = useCallback(
     (draftKey: string) => {
@@ -16,12 +22,15 @@ export const useChatInputDraft = () => {
       if (!editor) return;
 
       if (getMarkdownContent().trim().length === 0) {
-        removeDraft(draftKey);
+        if (loadedDraftKeyRef.current === draftKey) removeDraft(draftKey);
         return;
       }
 
       const json = getJSONState();
-      if (json) saveDraft(draftKey, json);
+      if (json) {
+        saveDraft(draftKey, json);
+        loadedDraftKeyRef.current = draftKey;
+      }
     },
     [storeApi],
   );
@@ -35,12 +44,24 @@ export const useChatInputDraft = () => {
     [persistDraftFor, storeApi],
   );
 
-  useEffect(() => () => saveDraftDebounced.flush(), [saveDraftDebounced]);
+  // Persist the live document rather than flushing the pending save: the
+  // editor's own change notification is debounced too, so text typed in the
+  // last moment before unmount has not scheduled anything to flush.
+  useEffect(
+    () => () => {
+      saveDraftDebounced.cancel();
+      const { draftKey } = storeApi.getState();
+      if (draftKey) persistDraftFor(draftKey);
+    },
+    [persistDraftFor, saveDraftDebounced, storeApi],
+  );
 
   const restoreDraft = useCallback(
     (editor: IEditor) => {
       const { draftKey } = storeApi.getState();
       if (!draftKey) return;
+
+      loadedDraftKeyRef.current = draftKey;
 
       if (!editor.isEmpty) return;
 

--- a/src/features/ChatInput/store/action.test.ts
+++ b/src/features/ChatInput/store/action.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAgentStore } from '@/store/agent';
 import { systemAgentSelectors } from '@/store/user/selectors';
 
+import { getDraft, saveDraft } from '../draftStorage';
 import { getInputHistory } from '../inputHistoryStorage';
 import { createStore, selectors } from '.';
 
@@ -50,6 +51,46 @@ describe('ChatInput store actions', () => {
       json: editorData,
       markdown: 'Hello',
     });
+  });
+
+  it('drops the stored draft once the send handler clears the composer', () => {
+    const editor = {
+      cleanDocument: vi.fn(),
+      focus: vi.fn(),
+      getDocument: vi.fn((type: string) => (type === 'markdown' ? 'Hello' : { text: 'Hello' })),
+    };
+    saveDraft('main_agt_a_tpc_1', { text: 'Hello' });
+    const store = createStore({
+      draftKey: 'main_agt_a_tpc_1',
+      editor: editor as unknown as IEditor,
+      onSend: ({ clearContent }) => {
+        clearContent();
+      },
+    });
+
+    store.getState().handleSendButton();
+
+    expect(getDraft('main_agt_a_tpc_1')).toBeUndefined();
+  });
+
+  it('keeps the stored draft when the send handler declines to clear the composer', () => {
+    const editor = {
+      cleanDocument: vi.fn(),
+      focus: vi.fn(),
+      getDocument: vi.fn((type: string) => (type === 'markdown' ? 'Hello' : { text: 'Hello' })),
+    };
+    saveDraft('main_agt_a_tpc_1', { text: 'Hello' });
+    const store = createStore({
+      draftKey: 'main_agt_a_tpc_1',
+      editor: editor as unknown as IEditor,
+      // a scheduled send that the server rejects leaves the text in the
+      // composer, so the draft behind it must survive
+      onSend: () => {},
+    });
+
+    store.getState().handleSendButton();
+
+    expect(getDraft('main_agt_a_tpc_1')).toEqual({ text: 'Hello' });
   });
 
   it('records sent input in the active agent history when no agent id is provided', () => {

--- a/src/features/ChatInput/store/action.ts
+++ b/src/features/ChatInput/store/action.ts
@@ -86,9 +86,16 @@ export const store: CreateStore = (publicState) => (set, get) => ({
         }
       : undefined;
 
+    // Tie the draft's fate to the composer actually being cleared: a host may
+    // decline the send after the fact (a rejected scheduled send keeps the text
+    // on screen), and the key is captured here because committing the send can
+    // move the conversation to a freshly created topic.
+    const sentDraftKey = get().draftKey;
+
     onSend?.({
       clearContent: () => {
         editor?.cleanDocument();
+        if (sentDraftKey) removeDraft(sentDraftKey);
         set({ goalMode: false });
       },
       editor: editor!,
@@ -102,9 +109,6 @@ export const store: CreateStore = (publicState) => (set, get) => ({
     if (historySnapshot) {
       addInputHistory(historySnapshot);
     }
-
-    const { draftKey } = get();
-    if (draftKey) removeDraft(draftKey);
 
     if (get().expand) {
       set({ _savedEditorState: undefined, expand: false });


### PR DESCRIPTION
Unsent composer drafts could be deleted from `localStorage` without the user ever clearing the input. `persistDraftFor` treats an empty editor as "the user emptied the composer" and calls `removeDraft`, but an empty editor also means "the draft has not been loaded yet" — the mount-time restore is deferred one `requestAnimationFrame`, so anything that changed `draftKey` before that frame (topic hydration on a cold load, agent slug → id resolution, the transient `activeAgentId/activeTopicId: undefined` windows) made the transition subscriber delete a draft the editor had never carried. Before #17991 un-keyed `ConversationProvider`, a topic switch never deleted a stored draft; the in-place handoff made every key change able to.

| Before | After |
| ------ | ----- |
| A draft key that settles right after mount deletes the previous key's draft (`main_<agent>_new` is exactly the pre-hydration key, so an unsent new-topic draft could vanish on navigating to any topic) | An empty editor only counts as "cleared" once the editor is known to be carrying that key's document |
| Text typed in the last ~100 ms before the composer remounts is lost — unmount only flushes a *pending* debounce, and the editor's own change notification is debounced too, so nothing was queued yet | Unmount persists the live document, so the text comes back through the restore |
| Sending removes the draft unconditionally after `onSend`, so a host that declines the send (a rejected scheduled send keeps the text on screen) loses the draft behind it | The draft is removed inside `clearContent`, keyed on the send-time draft key |

Three changes, all in the composer draft path:

- `useChatInputDraft` tracks which key's document the editor is carrying (`loadedDraftKeyRef`) and only removes a draft when it matches.
- The unmount cleanup persists the live editor document instead of flushing `saveDraftDebounced`.
- `handleSendButton` moves `removeDraft` into the `clearContent` callback, capturing the draft key at trigger time (committing a send can move the conversation to a freshly created topic).

Reviewer heads-up: the existing test `removes the old draft when leaving with an emptied editor` had its setup changed. It used to assert deletion from a state where the editor had *never* loaded the draft — the exact ambiguity behind this bug — so it now restores the draft first and then empties the editor, which is what "the user cleared the composer" actually looks like. The assertion is unchanged.

Not addressed here: `FloatingChatPanel` builds the same `messageMapKey` as the main conversation, so two composers can share one draft entry. This fix removes the worst case (an unloaded composer can no longer delete it), but if both load the same key they still overwrite each other.

#### Test

Five regression tests, each written first and watched fail against the old code:

| Test | Failure before the fix |
| ---- | ---------------------- |
| `keeps a draft the editor has not loaded yet when the draft key changes` | `expected undefined to deeply equal { text: 'unsent draft' }` |
| `keeps a draft the editor has not loaded yet when the debounced save runs` | same |
| `persists live editor content on unmount when no save is pending yet` | `expected undefined to deeply equal { text: 'typed right before leaving' }` |
| `restores input the previous composer instance persisted on unmount` | `expected '' to be 'typed a moment before remount'` |
| `keeps the stored draft when the send handler declines to clear the composer` | `expected undefined to deeply equal { text: 'Hello' }` |

`bun run check` on the touched files is clean (lint + 24 tests); 36 tests pass across the draft/store/StoreUpdater files. The type-check reports no errors in the touched files.

The fix was additionally verified against the real `@lobehub/editor` kernel (real `useEditor()`, real `<Editor>`, real `StoreUpdater`): the typing → remount round trip came back empty before the fix and intact after. That harness was not kept, since new React component tests are not allowed here — the same round-trip assertion now lives in the hook test file.

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Not verified in a running app — the behaviour was reproduced and fixed at the unit/kernel level only. An e2e scenario is feasible and send-free (auth is seeded, the LLM is mocked in-browser); it needs three new steps (assert composer text, read the draft map with `expect.poll`, switch back to the first topic) and is best driven by URL rather than sidebar clicks so it also covers the cold-load hydration path. Happy to add it as a follow-up.

#### 🔗 Related Issue

Related to #14939 (same symptom class — unsent input disappearing — fixed for tab switches in #14992)