### PR TITLE
🐛 fix(local-file-shell): report real match count for file-scoped context grep

### DIFF
--- a/packages/local-file-shell/src/contentSearch/__tests__/enginePathParity.test.ts
+++ b/packages/local-file-shell/src/contentSearch/__tests__/enginePathParity.test.ts
@@ -59,6 +59,12 @@ beforeAll(async () => {
   await mkdir(path.join(repo, 'build'), { recursive: true });
   await writeFile(path.join(repo, '.gitignore'), 'dist/\n*.log\n');
   await writeFile(path.join(repo, 'src', 'a.ts'), 'needle\n');
+  await writeFile(
+    path.join(repo, 'src', 'ctx.ts'),
+    ['one', 'two', 'ctxmark first', 'four', 'five', 'six', 'seven', 'ctxmark second', 'nine'].join(
+      '\n',
+    ) + '\n',
+  );
   await writeFile(path.join(repo, 'src', 'noisy.log'), 'needle\n');
   await writeFile(path.join(repo, 'dist', 'b.js'), 'needle\n');
   await writeFile(path.join(repo, 'dist', 'sub', 'c.js'), 'needle\n');
@@ -143,6 +149,29 @@ describe('content search engine parity', () => {
         [...r.matches].sort(),
         `${engine} should search an explicitly scoped ignored dir`,
       ).toEqual([path.join(repo, 'dist', 'b.js'), path.join(repo, 'dist', 'sub', 'c.js')]);
+    }
+  }, 60_000);
+
+  it('reports the real match count for a file-scoped search with context lines', async () => {
+    // Regression: with `-A`/`-B` the match count comes from a second `-c` run,
+    // which used the raw scope as its `cwd`. A file scope made that spawn throw
+    // and the catch silently returned 0 — so the summary said "Found 0 matches"
+    // while the output right below it contained the match lines, and the agent
+    // reading the summary kept retrying with new patterns.
+    const file = path.join(repo, 'src', 'ctx.ts');
+
+    for (const engine of engines) {
+      const r = await search(engine, {
+        '-A': 2,
+        '-B': 2,
+        '-n': true,
+        'output_mode': 'content',
+        'pattern': 'ctxmark',
+        'scope': file,
+      } as GrepContentParams);
+
+      expect(r.total_matches, `${engine} miscounted a file-scoped context search`).toBe(2);
+      expect(r.matches.length, `${engine} should include context lines`).toBeGreaterThan(2);
     }
   }, 60_000);
 

--- a/packages/local-file-shell/src/contentSearch/impl/unix.ts
+++ b/packages/local-file-shell/src/contentSearch/impl/unix.ts
@@ -205,7 +205,12 @@ export abstract class UnixContentSearch extends BaseContentSearch {
           matches = lines;
           const hasContext = params['-A'] || params['-B'] || params['-C'];
           if (hasContext) {
-            totalMatches = await this.getActualMatchCount(tool, params);
+            totalMatches = await this.getActualMatchCount(
+              tool,
+              params,
+              searchRoot,
+              this.searchTarget(searchPath, searchRoot),
+            );
           } else {
             totalMatches = lines.length;
           }
@@ -267,19 +272,32 @@ export abstract class UnixContentSearch extends BaseContentSearch {
     return searchPath === searchRoot ? '.' : `./${path.basename(searchPath)}`;
   }
 
+  /**
+   * `searchRoot`/`target` must be the same pair the main search ran with: a
+   * file-valued `scope` is legal, but execa's `cwd` must be a directory, so
+   * running the count from the raw scope used to throw and silently return 0 —
+   * the summary then said "Found 0 matches" above output that plainly contained
+   * the match lines.
+   */
   protected async getActualMatchCount(
     tool: 'ag' | 'grep' | 'rg',
     params: GrepContentParams,
+    searchRoot: string,
+    target: string,
   ): Promise<number> {
     const countParams = { ...params, '-A': undefined, '-B': undefined, '-C': undefined };
-    const args = this.buildGrepArgs(tool, {
-      ...countParams,
-      output_mode: 'count',
-    } as GrepContentParams);
+    const args = this.buildGrepArgs(
+      tool,
+      {
+        ...countParams,
+        output_mode: 'count',
+      } as GrepContentParams,
+      target,
+    );
 
     try {
       const { stdout } = await execa(tool, args, {
-        cwd: this.resolveSearchPath(params),
+        cwd: searchRoot,
         reject: false,
         stdin: 'ignore',
       });


### PR DESCRIPTION
### 💻 变更类型 | Change Type

- [x] 🐛 fix

### 🔀 变更说明 | Description of Change

When `grepContent` runs in `content` mode with context flags (`-A`/`-B`/`-C`), the real match count comes from a second `-c` pass in `getActualMatchCount`. That second pass spawned the tool with `cwd: resolveSearchPath(params)` — the **raw scope**. A file-valued `scope` is a normal, documented call (the main search path already handles it by running from `path.dirname(scope)`), but for the count pass the spawn threw (`cwd` must be a directory) and the `catch` silently returned `0`.

Result: the tool answered `Found 0 matches in 73 locations` while the output right below the summary plainly contained the match lines. Observed in a production agent trace (`op_1786234989209_..._pn4XyZAW`): the agent trusted the `0 matches` summary and burned 3 extra steps retrying pattern variations against a file that matched all along.

Fix: pass the already-computed `searchRoot` / search target from the main path into `getActualMatchCount`, so the count pass runs from the same directory with the same target — identical to how the main search was fixed for file scopes previously.

Note: the Windows impl has its own `getActualMatchCount` with the same `cwd` shape, but its main search path doesn't handle file-valued scopes at all (fails before reaching the count), so it needs a broader separate fix and is left untouched here.

### 📝 补充信息 | Additional Information

Regression test added in `enginePathParity.test.ts`: a file-scoped `-A 2 -B 2` content search must report `total_matches: 2` (fails with `0` before the fix, for both `rg` and `grep` engines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)