### PR TITLE
🐛 fix: persist Memory enable switch state

### DIFF
--- a/src/features/Settings/memory/features/Memory.tsx
+++ b/src/features/Settings/memory/features/Memory.tsx
@@ -4,7 +4,6 @@ import { type UserMemoryEffort } from '@lobechat/types';
 import { type FormGroupItemType } from '@lobehub/ui';
 import { Form, Skeleton, Tooltip } from '@lobehub/ui';
 import { Switch } from '@lobehub/ui/base-ui';
-import isEqual from 'fast-deep-equal';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -13,18 +12,19 @@ import { FORM_STYLE } from '@/const/layoutTokens';
 import LevelSlider from '@/features/ModelSwitchPanel/components/ControlsForm/LevelSlider';
 import { usePermission } from '@/hooks/usePermission';
 import { useSaveState } from '@/hooks/useSaveState';
-import { useUserStore } from '@/store/user';
-import { settingsSelectors } from '@/store/user/selectors';
+
+import { useMemorySettings } from './useMemorySettings';
 
 const MEMORY_EFFORT_LEVELS: readonly UserMemoryEffort[] = ['low', 'medium', 'high'];
 
 const MemorySetting = memo(() => {
   const { t } = useTranslation('setting');
   const { allowed: canManageMemory, reason } = usePermission('manage_settings');
-  const [form] = Form.useForm();
-  const { memory } = useUserStore(settingsSelectors.currentSettings, isEqual);
-  const [setSettings, isUserStateInit] = useUserStore((s) => [s.setSettings, s.isUserStateInit]);
   const { status: saveStatus, lastSavedAt, save, retry } = useSaveState();
+  const { effort, enabled, isUserStateInit, setEffort, setEnabled } = useMemorySettings({
+    canManageMemory,
+    save,
+  });
 
   if (!isUserStateInit) return <Skeleton active paragraph={{ rows: 3 }} title={false} />;
 
@@ -33,15 +33,13 @@ const MemorySetting = memo(() => {
       {
         children: (
           <Tooltip title={reason}>
-            <Switch disabled={!canManageMemory} />
+            <Switch checked={enabled} disabled={!canManageMemory} onChange={setEnabled} />
           </Tooltip>
         ),
         desc: t('memory.enabled.desc'),
         label: t('memory.enabled.title'),
         layout: 'horizontal',
         minWidth: undefined,
-        name: 'enabled',
-        valuePropName: 'checked',
       },
       {
         children: (
@@ -51,17 +49,13 @@ const MemorySetting = memo(() => {
               disabled={!canManageMemory}
               levels={MEMORY_EFFORT_LEVELS}
               style={{ minWidth: 160 }}
-              value={memory?.effort ?? 'medium'}
+              value={effort}
               marks={{
                 0: t('memory.effort.level.low'),
                 1: t('memory.effort.level.medium'),
                 2: t('memory.effort.level.high'),
               }}
-              onChange={(value) => {
-                if (!canManageMemory) return;
-
-                save(() => setSettings({ memory: { effort: value } }));
-              }}
+              onChange={setEffort}
             />
           </Tooltip>
         ),
@@ -78,16 +72,9 @@ const MemorySetting = memo(() => {
   return (
     <Form
       collapsible={false}
-      form={form}
-      initialValues={memory}
       items={[memorySettings]}
       itemsType={'group'}
       variant={'filled'}
-      onValuesChange={(values) => {
-        if (!canManageMemory) return;
-
-        save(() => setSettings({ memory: values }));
-      }}
       {...FORM_STYLE}
     />
   );

--- a/src/features/Settings/memory/features/useMemorySettings.test.ts
+++ b/src/features/Settings/memory/features/useMemorySettings.test.ts
@@ -1,0 +1,53 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useUserStore } from '@/store/user';
+
+import { useMemorySettings } from './useMemorySettings';
+
+const initialUserStoreState = useUserStore.getState();
+
+afterEach(() => {
+  cleanup();
+  useUserStore.setState(initialUserStoreState, true);
+});
+
+describe('useMemorySettings', () => {
+  it('defaults to enabled when no user override exists', () => {
+    useUserStore.setState({ isUserStateInit: true, settings: {} });
+
+    const { result } = renderHook(() =>
+      useMemorySettings({ canManageMemory: true, save: vi.fn() }),
+    );
+
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.effort).toBe('medium');
+  });
+
+  it('returns the persisted state and saves both switch values', async () => {
+    const setSettings = vi.fn().mockResolvedValue(undefined);
+    const save = vi.fn(async (task: () => Promise<void>) => task());
+    useUserStore.setState({
+      isUserStateInit: true,
+      setSettings,
+      settings: { memory: { effort: 'low', enabled: false } },
+    });
+
+    const { result } = renderHook(() => useMemorySettings({ canManageMemory: true, save }));
+
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.effort).toBe('low');
+
+    await act(() => result.current.setEnabled(true));
+    expect(setSettings).toHaveBeenLastCalledWith({ memory: { enabled: true } });
+
+    act(() => useUserStore.setState({ settings: { memory: { enabled: true } } }));
+    expect(result.current.enabled).toBe(true);
+
+    await act(() => result.current.setEnabled(false));
+    expect(setSettings).toHaveBeenLastCalledWith({ memory: { enabled: false } });
+
+    await act(() => result.current.setEffort('high'));
+    expect(setSettings).toHaveBeenLastCalledWith({ memory: { effort: 'high' } });
+  });
+});

--- a/src/features/Settings/memory/features/useMemorySettings.ts
+++ b/src/features/Settings/memory/features/useMemorySettings.ts
@@ -1,0 +1,43 @@
+import { type UserMemoryEffort } from '@lobechat/types';
+import isEqual from 'fast-deep-equal';
+import { useCallback } from 'react';
+
+import { type SaveStateHandle } from '@/hooks/useSaveState';
+import { useUserStore } from '@/store/user';
+import { settingsSelectors } from '@/store/user/selectors';
+
+interface UseMemorySettingsOptions {
+  canManageMemory: boolean;
+  save: SaveStateHandle['save'];
+}
+
+export const useMemorySettings = ({ canManageMemory, save }: UseMemorySettingsOptions) => {
+  const memory = useUserStore(settingsSelectors.currentMemorySettings, isEqual);
+  const [setSettings, isUserStateInit] = useUserStore((s) => [s.setSettings, s.isUserStateInit]);
+
+  const setEnabled = useCallback(
+    (enabled: boolean) => {
+      if (!canManageMemory) return;
+
+      return save(() => setSettings({ memory: { enabled } }));
+    },
+    [canManageMemory, save, setSettings],
+  );
+
+  const setEffort = useCallback(
+    (effort: UserMemoryEffort) => {
+      if (!canManageMemory) return;
+
+      return save(() => setSettings({ memory: { effort } }));
+    },
+    [canManageMemory, save, setSettings],
+  );
+
+  return {
+    effort: memory.effort ?? 'medium',
+    enabled: memory.enabled !== false,
+    isUserStateInit,
+    setEffort,
+    setEnabled,
+  };
+};


### PR DESCRIPTION
Fixes the Memory setting toggle no longer persisting after the switch migrated to `@lobehub/ui/base-ui`.

The Form item metadata (`name` and `valuePropName`) does not control an explicitly supplied base-ui Switch, so a click only changed transient UI state. Refreshing the page or changing settings tabs then restored the unchanged persisted value.

This change:

- controls the switch from the merged current Memory settings
- explicitly persists both enabled states through `setSettings` and `useSaveState`
- keeps Memory effort updates on the same tested save path
- extracts the state/save behavior into a hook so it can be regression-tested without adding a component test

| Before | After |
| ------ | ----- |
| The switch changed visually but reverted after navigation or refresh | The switch reads and writes persisted state and remains stable after navigation or refresh |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

- `bun run check src/features/Settings/memory/features/Memory.tsx src/features/Settings/memory/features/useMemorySettings.ts src/features/Settings/memory/features/useMemorySettings.test.ts`
- `bun run type-check`

Also verified on a self-hosted deployment that both `false` and `true` are persisted and survive a settings-tab change and normal reload.