### PR TITLE
✨ feat(home): preview acceptance links in portal

### DIFF
--- a/src/features/Home/AcceptancePortalDrawer.tsx
+++ b/src/features/Home/AcceptancePortalDrawer.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Flexbox } from '@lobehub/ui';
+import { Drawer } from '@lobehub/ui/base-ui';
+import { memo } from 'react';
+
+import { PortalContent } from '@/features/Portal/router';
+import { useChatStore } from '@/store/chat';
+import { chatPortalSelectors } from '@/store/chat/selectors';
+
+import { isAcceptancePortalView } from './acceptancePortalView';
+
+/**
+ * Home has no persistent chat portal column. Internal acceptance links still
+ * use the shared portal stack, so host that content in a right-side drawer and
+ * keep the user anchored in the inbox report they were reading.
+ */
+const AcceptancePortalDrawer = memo(() => {
+  const [viewType, clearPortalStack] = useChatStore((state) => [
+    chatPortalSelectors.currentViewType(state),
+    state.clearPortalStack,
+  ]);
+  const open = isAcceptancePortalView(viewType);
+
+  return (
+    <Drawer
+      noHeader
+      closable={false}
+      containerMaxWidth={'100%'}
+      open={open}
+      placement={'right'}
+      width={'min(960px, 92vw)'}
+      styles={{
+        bodyContent: { height: '100%', minHeight: 0, overflow: 'hidden', padding: 0 },
+      }}
+      onClose={clearPortalStack}
+    >
+      {open && (
+        <Flexbox height={'100%'} style={{ minHeight: 0, overflow: 'hidden' }}>
+          <PortalContent />
+        </Flexbox>
+      )}
+    </Drawer>
+  );
+});
+
+AcceptancePortalDrawer.displayName = 'AcceptancePortalDrawer';
+
+export default AcceptancePortalDrawer;

--- a/src/features/Home/__tests__/portraitVisibility.test.tsx
+++ b/src/features/Home/__tests__/portraitVisibility.test.tsx
@@ -1,8 +1,11 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { PortalViewType } from '@/store/chat/slices/portal/initialState';
+
 interface RenderHomeOptions {
   isLogin?: boolean;
+  portalViewType?: PortalViewType;
   showHomePortrait?: boolean;
 }
 
@@ -12,7 +15,11 @@ function translate() {
   return { i18n: { language: 'en-US' }, t: (key: string) => key };
 }
 
-const renderHome = async ({ isLogin = true, showHomePortrait }: RenderHomeOptions = {}) => {
+const renderHome = async ({
+  isLogin = true,
+  portalViewType,
+  showHomePortrait,
+}: RenderHomeOptions = {}) => {
   vi.resetModules();
 
   vi.doMock('react-i18next', () => ({ useTranslation: translate }));
@@ -21,11 +28,17 @@ const renderHome = async ({ isLogin = true, showHomePortrait }: RenderHomeOption
   vi.doMock('../HomePortrait', () => stub('home-portrait'));
   vi.doMock('../InputArea', () => stub('home-input-area'));
   vi.doMock('../PortraitBubble', () => stub('portrait-bubble'));
+  vi.doMock('../AcceptancePortalDrawer', () => stub('acceptance-portal-drawer'));
   vi.doMock('@/features/HomeInbox', () => stub('home-inbox'));
-  vi.doMock('@/store/chat', () => ({
-    useChatStore: {
-      getState: () => ({ mainInputEditor: undefined }),
-      setState: vi.fn(),
+  function selectFromChatStore(selector: (state: unknown) => unknown) {
+    return selector({ portalViewType });
+  }
+  selectFromChatStore.getState = () => ({ mainInputEditor: undefined });
+  selectFromChatStore.setState = vi.fn();
+  vi.doMock('@/store/chat', () => ({ useChatStore: selectFromChatStore }));
+  vi.doMock('@/store/chat/selectors', () => ({
+    chatPortalSelectors: {
+      currentViewType: (state: { portalViewType?: PortalViewType }) => state.portalViewType ?? null,
     },
   }));
   function selectFromGlobalStore(selector: (state: unknown) => unknown) {
@@ -50,8 +63,10 @@ afterEach(() => {
   vi.doUnmock('../HomePortrait');
   vi.doUnmock('../InputArea');
   vi.doUnmock('../PortraitBubble');
+  vi.doUnmock('../AcceptancePortalDrawer');
   vi.doUnmock('@/features/HomeInbox');
   vi.doUnmock('@/store/chat');
+  vi.doUnmock('@/store/chat/selectors');
   vi.doUnmock('@/store/global');
   vi.doUnmock('@/store/user');
 });
@@ -91,5 +106,17 @@ describe('Home portrait visibility', () => {
 
     expect(screen.queryByTestId('home-portrait')).not.toBeInTheDocument();
     expect(screen.queryByTestId('portrait-bubble')).not.toBeInTheDocument();
+  }, 20000);
+
+  it('loads the acceptance drawer only after an acceptance portal opens', async () => {
+    await renderHome({ portalViewType: PortalViewType.Acceptance });
+
+    expect(await screen.findByTestId('acceptance-portal-drawer')).toBeInTheDocument();
+  }, 20000);
+
+  it('does not load the acceptance drawer for unrelated portal views', async () => {
+    await renderHome({ portalViewType: PortalViewType.TaskDetail });
+
+    expect(screen.queryByTestId('acceptance-portal-drawer')).not.toBeInTheDocument();
   }, 20000);
 });

--- a/src/features/Home/acceptancePortalView.test.ts
+++ b/src/features/Home/acceptancePortalView.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { PortalViewType } from '@/store/chat/slices/portal/initialState';
+
+import { isAcceptancePortalView } from './acceptancePortalView';
+
+describe('isAcceptancePortalView', () => {
+  it.each([PortalViewType.Acceptance, PortalViewType.AcceptanceCheck])(
+    'hosts %s in the Home drawer',
+    (viewType) => {
+      expect(isAcceptancePortalView(viewType)).toBe(true);
+    },
+  );
+
+  it.each([null, PortalViewType.TaskDetail, PortalViewType.VerifyReport])(
+    'leaves unrelated portal view %s to its owning surface',
+    (viewType) => {
+      expect(isAcceptancePortalView(viewType)).toBe(false);
+    },
+  );
+});

--- a/src/features/Home/acceptancePortalView.ts
+++ b/src/features/Home/acceptancePortalView.ts
@@ -1,0 +1,5 @@
+import { PortalViewType } from '@/store/chat/slices/portal/initialState';
+
+/** Portal views that Home can present without navigating away from the inbox. */
+export const isAcceptancePortalView = (viewType: PortalViewType | null) =>
+  viewType === PortalViewType.Acceptance || viewType === PortalViewType.AcceptanceCheck;

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -6,6 +6,7 @@ import { lazy, memo, Suspense, useCallback, useState } from 'react';
 
 import HomeInbox from '@/features/HomeInbox';
 import { useChatStore } from '@/store/chat';
+import { chatPortalSelectors } from '@/store/chat/selectors';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { useTaskStore } from '@/store/task';
@@ -13,6 +14,7 @@ import { taskDetailSelectors } from '@/store/task/selectors';
 import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/slices/auth/selectors';
 
+import { isAcceptancePortalView } from './acceptancePortalView';
 import { isHomeMinimalLayout } from './CustomizeModal/config';
 import HomeHeader from './HomeHeader';
 import HomeModeContent from './HomeModeContent';
@@ -279,10 +281,14 @@ const Home = memo(() => {
   const [inputValue, setInputValue] = useState('');
 
   const drawerTopicId = useTaskStore(taskDetailSelectors.activeTopicDrawerTopicId);
+  const portalViewType = useChatStore(chatPortalSelectors.currentViewType);
+  const acceptancePortalOpen = isAcceptancePortalView(portalViewType);
   // Mount the drawer on first open and keep it mounted afterwards, so its
   // close animation can play instead of the panel vanishing with the state.
   const [drawerMounted, setDrawerMounted] = useState(false);
   if (drawerTopicId && !drawerMounted) setDrawerMounted(true);
+  const [acceptanceDrawerMounted, setAcceptanceDrawerMounted] = useState(false);
+  if (acceptancePortalOpen && !acceptanceDrawerMounted) setAcceptanceDrawerMounted(true);
   const railVisible = resolveRailVisibility({ hiddenWidgets, isLogin, showHomeRail });
   const railCollapsed = !railVisible;
   const portraitVisible = Boolean(isLogin && showHomePortrait);
@@ -376,9 +382,11 @@ const Home = memo(() => {
           <TopicChatDrawer />
         </Suspense>
       )}
-      <Suspense fallback={null}>
-        <AcceptancePortalDrawer />
-      </Suspense>
+      {acceptanceDrawerMounted && (
+        <Suspense fallback={null}>
+          <AcceptancePortalDrawer />
+        </Suspense>
+      )}
     </Flexbox>
   );
 });

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -28,6 +28,7 @@ import type { HomeMode } from './types';
 // no-op. Lazy so the home bundle doesn't pay for the chat stack until a run is
 // actually opened.
 const TopicChatDrawer = lazy(() => import('@/features/AgentTasks/AgentTaskDetail/TopicChatDrawer'));
+const AcceptancePortalDrawer = lazy(() => import('./AcceptancePortalDrawer'));
 
 /** Trailing gutter that keeps the rail's cards off the page's scroll lane. */
 const RAIL_GUTTER = 14;
@@ -375,6 +376,9 @@ const Home = memo(() => {
           <TopicChatDrawer />
         </Suspense>
       )}
+      <Suspense fallback={null}>
+        <AcceptancePortalDrawer />
+      </Suspense>
     </Flexbox>
   );
 });

--- a/src/features/HomeInbox/UnreadTopicList.tsx
+++ b/src/features/HomeInbox/UnreadTopicList.tsx
@@ -17,6 +17,7 @@ import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwar
 import { useChatStore } from '@/store/chat';
 
 import AuthorChip from './AuthorChip';
+import { sanitizeInboxPreview } from './sanitizeInboxPreview';
 import { useHomeInboxMarkdown } from './useHomeInboxMarkdown';
 import { type InboxTopic } from './useHomeInboxTopics';
 
@@ -110,6 +111,7 @@ const UnreadTopicItem = memo<UnreadTopicItemProps>(
     const sendMessage = useChatStore((s) => s.sendMessage);
     const prefetchMessages = useChatStore((s) => s.prefetchMessages);
     const markdownProps = useHomeInboxMarkdown(topic.id);
+    const assistantPreview = sanitizeInboxPreview(topic.lastAssistantMessage ?? '');
 
     const [expanded, setExpanded] = useState(false);
     const [read, setRead] = useState(false);
@@ -206,9 +208,9 @@ const UnreadTopicItem = memo<UnreadTopicItemProps>(
 
         {expanded && (
           <Flexbox className={bare ? styles.bareBody : styles.body} gap={8}>
-            {topic.lastAssistantMessage && (
+            {assistantPreview && (
               <MarkdownMessage {...markdownProps} style={{ overflow: 'unset' }}>
-                {topic.lastAssistantMessage}
+                {assistantPreview}
               </MarkdownMessage>
             )}
 

--- a/src/features/HomeInbox/UnreadTopicList.tsx
+++ b/src/features/HomeInbox/UnreadTopicList.tsx
@@ -1,6 +1,7 @@
 import { AGENT_CHAT_TOPIC_URL } from '@lobechat/const';
-import { agentDisplayName, type ConversationContext } from '@lobechat/types';
-import { Avatar, Flexbox, Icon, Markdown, stopPropagation, Text } from '@lobehub/ui';
+import type { ConversationContext } from '@lobechat/types';
+import { agentDisplayName } from '@lobechat/types';
+import { Avatar, Flexbox, Icon, stopPropagation, Text } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { ChevronDownIcon, ChevronRightIcon, MessageSquarePlus } from 'lucide-react';
@@ -9,6 +10,8 @@ import { useTranslation } from 'react-i18next';
 
 import UnreadDot from '@/components/UnreadDot';
 import { useAgentDisplayMeta } from '@/features/AgentTasks/shared/useAgentDisplayMeta';
+import MarkdownMessage from '@/features/Conversation/Markdown';
+import { useChatMarkdown } from '@/features/Conversation/Messages/useChatMarkdown';
 import { homeType } from '@/features/Home/components/homeType';
 import Time from '@/features/Home/components/Time';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
@@ -106,6 +109,11 @@ const UnreadTopicItem = memo<UnreadTopicItemProps>(
     const updateTopicStatus = useChatStore((s) => s.updateTopicStatus);
     const sendMessage = useChatStore((s) => s.sendMessage);
     const prefetchMessages = useChatStore((s) => s.prefetchMessages);
+    const { drawer, markdownProps } = useChatMarkdown({
+      enableStream: false,
+      id: topic.id,
+      isGenerating: false,
+    });
 
     const [expanded, setExpanded] = useState(false);
     const [read, setRead] = useState(false);
@@ -203,10 +211,12 @@ const UnreadTopicItem = memo<UnreadTopicItemProps>(
         {expanded && (
           <Flexbox className={bare ? styles.bareBody : styles.body} gap={8}>
             {topic.lastAssistantMessage && (
-              <Markdown style={{ overflow: 'unset' }} variant={'chat'}>
+              <MarkdownMessage {...markdownProps} style={{ overflow: 'unset' }}>
                 {topic.lastAssistantMessage}
-              </Markdown>
+              </MarkdownMessage>
             )}
+
+            {drawer}
 
             {replying ? (
               <Flexbox onClick={stopPropagation}>

--- a/src/features/HomeInbox/UnreadTopicList.tsx
+++ b/src/features/HomeInbox/UnreadTopicList.tsx
@@ -11,13 +11,13 @@ import { useTranslation } from 'react-i18next';
 import UnreadDot from '@/components/UnreadDot';
 import { useAgentDisplayMeta } from '@/features/AgentTasks/shared/useAgentDisplayMeta';
 import MarkdownMessage from '@/features/Conversation/Markdown';
-import { useChatMarkdown } from '@/features/Conversation/Messages/useChatMarkdown';
 import { homeType } from '@/features/Home/components/homeType';
 import Time from '@/features/Home/components/Time';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useChatStore } from '@/store/chat';
 
 import AuthorChip from './AuthorChip';
+import { useHomeInboxMarkdown } from './useHomeInboxMarkdown';
 import { type InboxTopic } from './useHomeInboxTopics';
 
 const DOT_WIDTH = 14;
@@ -109,11 +109,7 @@ const UnreadTopicItem = memo<UnreadTopicItemProps>(
     const updateTopicStatus = useChatStore((s) => s.updateTopicStatus);
     const sendMessage = useChatStore((s) => s.sendMessage);
     const prefetchMessages = useChatStore((s) => s.prefetchMessages);
-    const { drawer, markdownProps } = useChatMarkdown({
-      enableStream: false,
-      id: topic.id,
-      isGenerating: false,
-    });
+    const markdownProps = useHomeInboxMarkdown(topic.id);
 
     const [expanded, setExpanded] = useState(false);
     const [read, setRead] = useState(false);
@@ -215,8 +211,6 @@ const UnreadTopicItem = memo<UnreadTopicItemProps>(
                 {topic.lastAssistantMessage}
               </MarkdownMessage>
             )}
-
-            {drawer}
 
             {replying ? (
               <Flexbox onClick={stopPropagation}>

--- a/src/features/HomeInbox/sanitizeInboxPreview.test.ts
+++ b/src/features/HomeInbox/sanitizeInboxPreview.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeInboxPreview } from './sanitizeInboxPreview';
+
+describe('sanitizeInboxPreview', () => {
+  it('removes closed thinking blocks while preserving the answer', () => {
+    expect(sanitizeInboxPreview('<think>private reasoning</think>\nFinal answer')).toBe(
+      'Final answer',
+    );
+  });
+
+  it('removes an unfinished thinking block from a truncated preview', () => {
+    expect(sanitizeInboxPreview('Visible answer\n<think>unfinished reasoning')).toBe(
+      'Visible answer',
+    );
+  });
+
+  it('removes orphan thinking tags without dropping surrounding content', () => {
+    expect(sanitizeInboxPreview('Before </think> after')).toBe('Before  after');
+  });
+
+  it('leaves ordinary Markdown and acceptance links intact', () => {
+    const content = 'Done: [view acceptance](/acceptance/a-1)';
+
+    expect(sanitizeInboxPreview(content)).toBe(content);
+  });
+});

--- a/src/features/HomeInbox/sanitizeInboxPreview.ts
+++ b/src/features/HomeInbox/sanitizeInboxPreview.ts
@@ -1,0 +1,11 @@
+const CLOSED_THINK_BLOCK = /<think\b[^>]*>[\S\s]*?<\/think\s*>/gi;
+const UNCLOSED_THINK_BLOCK = /<think\b[^>]*>[\S\s]*$/gi;
+const ORPHAN_THINK_TAG = /<\/?think\b[^>]*>/gi;
+
+/** Remove model reasoning from the compact Home inbox preview. */
+export const sanitizeInboxPreview = (content: string) =>
+  content
+    .replaceAll(CLOSED_THINK_BLOCK, '')
+    .replaceAll(UNCLOSED_THINK_BLOCK, '')
+    .replaceAll(ORPHAN_THINK_TAG, '')
+    .trim();

--- a/src/features/HomeInbox/useHomeInboxMarkdown.test.ts
+++ b/src/features/HomeInbox/useHomeInboxMarkdown.test.ts
@@ -1,0 +1,16 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import LinkElement from '@/features/Conversation/Markdown/plugins/Link';
+
+import { useHomeInboxMarkdown } from './useHomeInboxMarkdown';
+
+describe('useHomeInboxMarkdown', () => {
+  it('wires only the provider-free link plugin', () => {
+    const { result } = renderHook(() => useHomeInboxMarkdown('message-1'));
+
+    expect(Object.keys(result.current.components ?? {})).toEqual([LinkElement.tag]);
+    expect(result.current.rehypePlugins).toEqual([LinkElement.rehypePlugin]);
+    expect(result.current.remarkPlugins).toBeUndefined();
+  });
+});

--- a/src/features/HomeInbox/useHomeInboxMarkdown.tsx
+++ b/src/features/HomeInbox/useHomeInboxMarkdown.tsx
@@ -1,0 +1,31 @@
+import type { MarkdownProps } from '@lobehub/ui';
+import { useMemo } from 'react';
+
+import LinkElement from '@/features/Conversation/Markdown/plugins/Link';
+
+const rehypePlugins = LinkElement.rehypePlugin ? [LinkElement.rehypePlugin] : [];
+
+/**
+ * Home is not hosted by a ConversationProvider, so inbox previews deliberately
+ * support only the provider-free link plugin. Conversation-only markup remains
+ * readable as plain Markdown instead of mounting components that require chat
+ * context.
+ */
+export const useHomeInboxMarkdown = (messageId: string): Partial<MarkdownProps> => {
+  const components = useMemo(
+    () => ({
+      [LinkElement.tag]: (props: Record<PropertyKey, unknown>) => (
+        <LinkElement.Component {...props} id={messageId} />
+      ),
+    }),
+    [messageId],
+  );
+
+  return useMemo(
+    () => ({
+      components,
+      rehypePlugins,
+    }),
+    [components],
+  );
+};

--- a/src/features/HomeInbox/useHomeInboxMarkdown.tsx
+++ b/src/features/HomeInbox/useHomeInboxMarkdown.tsx
@@ -1,7 +1,9 @@
 import type { MarkdownProps } from '@lobehub/ui';
+import type { FC } from 'react';
 import { useMemo } from 'react';
 
 import LinkElement from '@/features/Conversation/Markdown/plugins/Link';
+import type { MarkdownElementProps } from '@/features/Conversation/Markdown/plugins/type';
 
 const rehypePlugins = LinkElement.rehypePlugin ? [LinkElement.rehypePlugin] : [];
 
@@ -12,14 +14,13 @@ const rehypePlugins = LinkElement.rehypePlugin ? [LinkElement.rehypePlugin] : []
  * context.
  */
 export const useHomeInboxMarkdown = (messageId: string): Partial<MarkdownProps> => {
-  const components = useMemo(
-    () => ({
-      [LinkElement.tag]: (props: Record<PropertyKey, unknown>) => (
-        <LinkElement.Component {...props} id={messageId} />
-      ),
-    }),
-    [messageId],
-  );
+  const components = useMemo(() => {
+    const LinkComponent: FC = (props) => (
+      <LinkElement.Component {...(props as MarkdownElementProps)} id={messageId} />
+    );
+
+    return { [LinkElement.tag]: LinkComponent };
+  }, [messageId]);
 
   return useMemo(
     () => ({


### PR DESCRIPTION
## Summary

- reuse the conversation Markdown plugin pipeline for Home unread replies
- render Acceptance URLs as internal entity links
- open Acceptance and AcceptanceCheck portal views in a right-side Home drawer without leaving the inbox context

## Why

Home unread replies previously used the base Markdown renderer, bypassing the internal-link renderers used by conversations. Acceptance links therefore behaved like ordinary URLs, and Home had no mounted portal surface to display the existing Acceptance portal stack.

## Validation

- `bun run check` on the five changed files: lint clean, 5 tests passed
- focused Vitest run: 26 tests passed
- agent-testing Web run: rich link render, portal drawer open, and drawer close all passed with visual evidence

Acceptance report: https://app.lobehub.com/acceptance/b51937a4-bce0-4cdb-8f15-767a6cba3251