### PR TITLE
💄 style: lighten AskUserQuestion selected option fill

### DIFF
--- a/packages/shared-tool-ui/src/components/OptionCard.tsx
+++ b/packages/shared-tool-ui/src/components/OptionCard.tsx
@@ -61,11 +61,13 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   optionLabel: css`
     font-weight: 500;
   `,
+  // One step above the hover tint is enough — the checkmark carries the
+  // selection signal, so a heavy fill just reads as a muddy block.
   optionSelected: css`
-    background: ${cssVar.colorFillSecondary};
+    background: ${cssVar.colorFillTertiary};
 
     &:hover {
-      background: ${cssVar.colorFill};
+      background: ${cssVar.colorFillSecondary};
     }
   `,
   recommendedBadge: css`

--- a/packages/shared-tool-ui/src/components/OptionCard.tsx
+++ b/packages/shared-tool-ui/src/components/OptionCard.tsx
@@ -62,13 +62,11 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     font-weight: 500;
   `,
   // One step above the hover tint is enough — the checkmark carries the
-  // selection signal, so a heavy fill just reads as a muddy block.
+  // selection signal, so a heavy fill just reads as a muddy block. No extra
+  // hover darkening on a selected row: the row is already "on", and stacking
+  // another fill step brings back the heavy look.
   optionSelected: css`
     background: ${cssVar.colorFillTertiary};
-
-    &:hover {
-      background: ${cssVar.colorFillSecondary};
-    }
   `,
   recommendedBadge: css`
     flex-shrink: 0;


### PR DESCRIPTION
#### 💄 Change Type

- [x] 💄 style

#### 📝 Description of Change

The selected option row in the shared `OptionCard` (used by the AskUserQuestion intervention card) used `colorFillSecondary` as its background and darkened further to `colorFill` on hover, which reads as a heavy muddy block — reported as too dark and visually ugly.

Lighten the selected fill by one step: `colorFillTertiary` at rest, `colorFillSecondary` on hover. The selection signal is already carried by the trailing checkmark, so the fill only needs to be one step above the unselected hover tint (`colorFillQuaternary`).

#### 🧪 How to Test

- [x] 👀 visual check: trigger an AskUserQuestion intervention card, pick an option, and confirm the selected row is a subtle tint instead of a dark block (both light and dark themes).