### PR TITLE
🐛 fix(goal): require confirmation for goal launch even in auto-run mode

### DIFF
--- a/packages/builtin-tool-goal/src/manifest.test.ts
+++ b/packages/builtin-tool-goal/src/manifest.test.ts
@@ -7,7 +7,9 @@ describe('GoalManifest', () => {
   it('exposes only the canonical createGoal workflow', () => {
     expect(GoalManifest.identifier).toBe('lobe-goal');
     expect(GoalManifest.api.map(({ name }) => name)).toEqual([GoalApiName.createGoal]);
-    expect(GoalManifest.api[0].humanIntervention).toBe('required');
+    // 'always' cannot be bypassed by the user's auto-run approval mode —
+    // launching a goal must always pause for the user to review the acceptance plan
+    expect(GoalManifest.api[0].humanIntervention).toBe('always');
     expect(GoalManifest.api[0].work).toBeUndefined();
   });
 });

--- a/packages/builtin-tool-goal/src/manifest.ts
+++ b/packages/builtin-tool-goal/src/manifest.ts
@@ -10,7 +10,7 @@ export const GoalManifest: BuiltinToolManifest = {
     {
       description:
         'Create and immediately start a goal-driven task with an editable acceptance plan. Use this only when the user explicitly starts their request with /goal. The call pauses for confirmation; after approval it creates the underlying task, persists the acceptance criteria, enables bounded automatic repair, and runs the current agent in a separate task topic. Once it succeeds, do not execute or reproduce the work in the current conversation; the live result card is the progress and result entry point.',
-      humanIntervention: 'required',
+      humanIntervention: 'always',
       name: GoalApiName.createGoal,
       parameters: {
         additionalProperties: false,


### PR DESCRIPTION
`/goal` launches (`createGoal`) were silently auto-approved when the user's approval mode was set to auto-run (自动批准), so the goal was created and started without the user ever reviewing the acceptance plan — even though the whole flow (editable acceptance criteria, bounded auto-repair, separate task topic, optional budget) is designed around a pre-launch confirmation, and the tool description itself states "The call pauses for confirmation".

Root cause: the manifest declared `humanIntervention: 'required'`, which by design is bypassable by the user's auto-run approval mode (`GeneralChatAgent` only enforces the `'always'` policy under auto-run). This PR bumps `createGoal` to `humanIntervention: 'always'`, so launching a goal always pauses for user confirmation regardless of approval mode.

#### Test

- [x] Tested locally
- [x] Added/updated tests

Updated the manifest regression test to assert `humanIntervention === 'always'` (fails before the fix, passes after). The runtime enforcement path — `'always'` intercepts under auto-run — is already covered by existing `GeneralChatAgent` intervention tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)