### PR TITLE
💄 style: merge goal tracker into task callback card

### DIFF
--- a/.agents/acceptance/probe-mock-patterns.md
+++ b/.agents/acceptance/probe-mock-patterns.md
@@ -565,6 +565,7 @@ agent-browser --session "$RUN_SESSION" \
 
 Then assert `get url` and `app-probe.sh auth` on that exact session before
 capturing evidence.
+
 ### Agent-browser navigation hangs after an orphaned Next child keeps the port
 
 **Situation:** an isolated full-stack dev launcher exits, but its Next child
@@ -1174,3 +1175,22 @@ before pushing. Recovery for a mistaken main-repo commit: `git reset --mixed HEA
 restores the user's branch and leaves their working tree as it was (verify against
 the session-start `gitStatus` snapshot); nothing needs force-pushing because the
 wrong-branch push was a no-op.
+
+### Electron dev 的 BackendProxy 指向登录快照里持久化的 server 端口 — 铸会话 + CDP 注入 cookie
+
+**Situation:** worktree 里起 Electron surface 验证纯前端改动，renderer 一切正常但
+`app-probe.sh server-auth` 返回 502，用户状态 `isUserStateInit` 一直 false（受它门控的
+UI—— 如 Labs 分栏 —— 静默不渲染，store 状态看起来 "设置了但没生效"）。
+
+**Doesn't work:** 把 dev server 起在 3010 或 test-env.sh 解析出的动态端口。桌面主进程的
+BackendProxy 目标端口持久化在登录快照的 userData 里（`/tmp/electron-dev.log` 里
+`BackendProxy upstream fetch failed ... http://localhost:<port>` 是唯一真相），与当前
+ports-file 无关。端口对上后若见 401，是快照 cookie 对本地库已失效 —— 重启 Electron 重种快照
+也救不回来。
+
+**Works:** 三步：① 从日志读出 BackendProxy 的目标端口，`PORT=<该端口>` 起 dev server；
+② 用 web-seed 同款 curl 铸 better-auth 会话（`POST /api/auth/sign-in/email`，seeded 用户；
+从 renderer 内 fetch 会因 app\://origin 被 403，必须 curl）；③ 把 `better-auth.session_data`
+/ `better-auth.session_token` 两个 cookie 经 raw CDP `Network.setCookie`（url 填
+`http://localhost:<端口>/`）写进 Electron 的 cookie store，`location.reload()` 后
+server-auth 200、`isUserStateInit` true。

--- a/src/features/Conversation/Messages/GoalWorkCard/GoalStatusLine.tsx
+++ b/src/features/Conversation/Messages/GoalWorkCard/GoalStatusLine.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { Flexbox, Icon, Text } from '@lobehub/ui';
+import { createStaticStyles, cssVar } from 'antd-style';
+import type { TargetIcon } from 'lucide-react';
+import {
+  AlertTriangleIcon,
+  CheckCircle2Icon,
+  CircleSlashIcon,
+  Clock3Icon,
+  LoaderCircleIcon,
+  PauseCircleIcon,
+  RefreshCwIcon,
+  StampIcon,
+} from 'lucide-react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { GoalWorkPhase } from './goalWorkProgress';
+
+const PHASE_META = {
+  achieved: { color: cssVar.colorSuccess, icon: CheckCircle2Icon, spin: false },
+  canceled: { color: cssVar.colorTextTertiary, icon: CircleSlashIcon, spin: false },
+  error: { color: cssVar.colorError, icon: AlertTriangleIcon, spin: false },
+  paused: { color: cssVar.colorTextTertiary, icon: PauseCircleIcon, spin: false },
+  repairing: { color: cssVar.colorWarning, icon: RefreshCwIcon, spin: true },
+  review: { color: cssVar.colorWarning, icon: StampIcon, spin: false },
+  running: { color: cssVar.colorInfo, icon: LoaderCircleIcon, spin: true },
+  verifying: { color: cssVar.colorInfo, icon: LoaderCircleIcon, spin: true },
+  waiting: { color: cssVar.colorTextSecondary, icon: Clock3Icon, spin: false },
+} as const satisfies Record<
+  GoalWorkPhase,
+  { color: string; icon: typeof TargetIcon; spin: boolean }
+>;
+
+const styles = createStaticStyles(({ css }) => ({
+  progress: css`
+    overflow: hidden;
+
+    width: 72px;
+    height: 3px;
+    border-radius: 2px;
+
+    background: ${cssVar.colorFillSecondary};
+  `,
+  progressFill: css`
+    height: 100%;
+    border-radius: inherit;
+    background: ${cssVar.colorSuccess};
+    transition: width 0.25s ease;
+  `,
+  status: css`
+    font-size: 12px;
+    color: ${cssVar.colorTextTertiary};
+  `,
+  statusIcon: css`
+    flex-shrink: 0;
+  `,
+}));
+
+export interface GoalStatusLineProps {
+  maxRounds?: number;
+  passed: number;
+  phase: GoalWorkPhase;
+  progress: number;
+  round: number;
+  total: number;
+}
+
+/**
+ * The live Goal status line — phase icon + round budget + acceptance coverage.
+ * Shared by the running tracker card and the merged task-callback header.
+ * Once the goal is achieved the coverage bar retires: "已达成" already implies
+ * full coverage, so repeating "4/4 项通过" is noise.
+ */
+const GoalStatusLine = memo<GoalStatusLineProps>(
+  ({ maxRounds, passed, phase, progress, round, total }) => {
+    const { t } = useTranslation('chat');
+    const meta = PHASE_META[phase];
+    const showChecks = total > 0 && phase !== 'achieved';
+
+    return (
+      <Flexbox horizontal align={'center'} gap={6}>
+        <Icon
+          className={styles.statusIcon}
+          color={meta.color}
+          icon={meta.icon}
+          size={12}
+          spin={meta.spin}
+        />
+        <Text className={styles.status}>{t(`goalWork.status.${phase}`)}</Text>
+        <Text className={styles.status}>·</Text>
+        <Text className={styles.status}>
+          {maxRounds
+            ? t('goalWork.roundWithBudget', { current: round, total: maxRounds })
+            : t('goalWork.round', { current: round })}
+        </Text>
+        {showChecks && (
+          <>
+            <Text className={styles.status}>·</Text>
+            <div className={styles.progress}>
+              <div className={styles.progressFill} style={{ width: `${progress}%` }} />
+            </div>
+            <Text className={styles.status}>{t('goalWork.checks', { passed, total })}</Text>
+          </>
+        )}
+      </Flexbox>
+    );
+  },
+);
+
+GoalStatusLine.displayName = 'GoalStatusLine';
+
+export default GoalStatusLine;

--- a/src/features/Conversation/Messages/GoalWorkCard/index.tsx
+++ b/src/features/Conversation/Messages/GoalWorkCard/index.tsx
@@ -59,6 +59,7 @@ const GoalCard = memo<{ goal: OperationGoal }>(({ goal }) => {
   const openTaskDetail = useChatStore((s) => s.openTaskDetail);
   const { progress } = useGoalWorkStatus({
     criteriaCount: goal.criteriaCount,
+    goalKnown: true,
     identifier: goal.identifier,
     maxRounds: goal.maxRounds,
     taskId: goal.taskId,

--- a/src/features/Conversation/Messages/GoalWorkCard/index.tsx
+++ b/src/features/Conversation/Messages/GoalWorkCard/index.tsx
@@ -2,42 +2,14 @@
 
 import { Center, Flexbox, Icon, Text } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
-import {
-  AlertTriangleIcon,
-  CheckCircle2Icon,
-  ChevronRightIcon,
-  CircleSlashIcon,
-  Clock3Icon,
-  LoaderCircleIcon,
-  PauseCircleIcon,
-  RefreshCwIcon,
-  StampIcon,
-  TargetIcon,
-} from 'lucide-react';
+import { ChevronRightIcon, TargetIcon } from 'lucide-react';
 import { memo } from 'react';
-import { useTranslation } from 'react-i18next';
 
-import { useAcceptanceBundle, useAcceptanceBySubject } from '@/features/Verify';
 import { useChatStore } from '@/store/chat';
-import { useTaskStore } from '@/store/task';
 
 import type { OperationGoal } from './deriveOperationGoals';
-import { getGoalWorkProgress, type GoalWorkPhase } from './goalWorkProgress';
-
-const PHASE_META = {
-  achieved: { color: cssVar.colorSuccess, icon: CheckCircle2Icon, spin: false },
-  canceled: { color: cssVar.colorTextTertiary, icon: CircleSlashIcon, spin: false },
-  error: { color: cssVar.colorError, icon: AlertTriangleIcon, spin: false },
-  paused: { color: cssVar.colorTextTertiary, icon: PauseCircleIcon, spin: false },
-  repairing: { color: cssVar.colorWarning, icon: RefreshCwIcon, spin: true },
-  review: { color: cssVar.colorWarning, icon: StampIcon, spin: false },
-  running: { color: cssVar.colorInfo, icon: LoaderCircleIcon, spin: true },
-  verifying: { color: cssVar.colorInfo, icon: LoaderCircleIcon, spin: true },
-  waiting: { color: cssVar.colorTextSecondary, icon: Clock3Icon, spin: false },
-} as const satisfies Record<
-  GoalWorkPhase,
-  { color: string; icon: typeof TargetIcon; spin: boolean }
->;
+import GoalStatusLine from './GoalStatusLine';
+import { useGoalWorkStatus } from './useGoalWorkStatus';
 
 const styles = createStaticStyles(({ css }) => ({
   card: css`
@@ -76,28 +48,6 @@ const styles = createStaticStyles(({ css }) => ({
     font-size: 12px;
     color: ${cssVar.colorTextTertiary};
   `,
-  progress: css`
-    overflow: hidden;
-
-    width: 72px;
-    height: 3px;
-    border-radius: 2px;
-
-    background: ${cssVar.colorFillSecondary};
-  `,
-  progressFill: css`
-    height: 100%;
-    border-radius: inherit;
-    background: ${cssVar.colorSuccess};
-    transition: width 0.25s ease;
-  `,
-  statusIcon: css`
-    flex-shrink: 0;
-  `,
-  status: css`
-    font-size: 12px;
-    color: ${cssVar.colorTextTertiary};
-  `,
   title: css`
     min-width: 0;
     font-size: 14px;
@@ -106,23 +56,13 @@ const styles = createStaticStyles(({ css }) => ({
 }));
 
 const GoalCard = memo<{ goal: OperationGoal }>(({ goal }) => {
-  const { t } = useTranslation('chat');
   const openTaskDetail = useChatStore((s) => s.openTaskDetail);
-  const useFetchTaskDetail = useTaskStore((s) => s.useFetchTaskDetail);
-  useFetchTaskDetail(goal.identifier);
-  const task = useTaskStore((s) => s.taskDetailMap[goal.identifier]);
-  const { data: acceptance } = useAcceptanceBySubject('task', goal.taskId);
-  const { data: bundle } = useAcceptanceBundle(acceptance?.id ?? null);
-  const config = task?.config as { goal?: { maxIterations?: number | null } } | undefined;
-  const progress = getGoalWorkProgress({
-    acceptanceStatus: acceptance?.status,
-    checks: bundle?.checks,
+  const { progress } = useGoalWorkStatus({
     criteriaCount: goal.criteriaCount,
-    maxRounds: config?.goal?.maxIterations ?? goal.maxRounds,
-    rounds: task?.topicCount ?? 0,
-    taskStatus: task?.status,
+    identifier: goal.identifier,
+    maxRounds: goal.maxRounds,
+    taskId: goal.taskId,
   });
-  const phase = PHASE_META[progress.phase];
 
   return (
     <Flexbox
@@ -146,36 +86,7 @@ const GoalCard = memo<{ goal: OperationGoal }>(({ goal }) => {
         <Text ellipsis className={styles.title}>
           {goal.name}
         </Text>
-        <Flexbox horizontal align={'center'} gap={6}>
-          <Icon
-            className={styles.statusIcon}
-            color={phase.color}
-            icon={phase.icon}
-            size={12}
-            spin={phase.spin}
-          />
-          <Text className={styles.status}>{t(`goalWork.status.${progress.phase}`)}</Text>
-          <Text className={styles.status}>·</Text>
-          <Text className={styles.status}>
-            {progress.maxRounds
-              ? t('goalWork.roundWithBudget', {
-                  current: progress.round,
-                  total: progress.maxRounds,
-                })
-              : t('goalWork.round', { current: progress.round })}
-          </Text>
-          {progress.total > 0 && (
-            <>
-              <Text className={styles.status}>·</Text>
-              <div className={styles.progress}>
-                <div className={styles.progressFill} style={{ width: `${progress.progress}%` }} />
-              </div>
-              <Text className={styles.status}>
-                {t('goalWork.checks', { passed: progress.passed, total: progress.total })}
-              </Text>
-            </>
-          )}
-        </Flexbox>
+        <GoalStatusLine {...progress} />
       </Flexbox>
       <Text className={styles.identifier}>{goal.identifier}</Text>
       <ChevronRightIcon className={styles.chevron} size={16} />

--- a/src/features/Conversation/Messages/GoalWorkCard/useGoalWorkStatus.test.ts
+++ b/src/features/Conversation/Messages/GoalWorkCard/useGoalWorkStatus.test.ts
@@ -1,0 +1,55 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useGoalWorkStatus } from './useGoalWorkStatus';
+
+const mocks = vi.hoisted(() => ({
+  taskDetailMap: {} as Record<string, { config?: unknown; name?: string }>,
+  useAcceptanceBundle: vi.fn(() => ({ data: undefined })),
+  useAcceptanceBySubject: vi.fn(() => ({ data: undefined })),
+  useFetchTaskDetail: vi.fn(),
+}));
+
+vi.mock('@/features/Verify', () => ({
+  useAcceptanceBundle: mocks.useAcceptanceBundle,
+  useAcceptanceBySubject: mocks.useAcceptanceBySubject,
+}));
+
+vi.mock('@/store/task', () => ({
+  useTaskStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      taskDetailMap: mocks.taskDetailMap,
+      useFetchTaskDetail: mocks.useFetchTaskDetail,
+    }),
+}));
+
+describe('useGoalWorkStatus', () => {
+  beforeEach(() => {
+    mocks.taskDetailMap = {};
+    vi.clearAllMocks();
+  });
+
+  it('does not poll acceptance for a plain task callback', () => {
+    mocks.taskDetailMap['T-1'] = { config: {} };
+
+    const { result } = renderHook(() => useGoalWorkStatus({ identifier: 'T-1', taskId: 'task-1' }));
+
+    expect(result.current.isGoal).toBe(false);
+    expect(mocks.useAcceptanceBySubject).toHaveBeenCalledWith('task', null);
+  });
+
+  it('polls acceptance after task detail identifies a Goal task', () => {
+    mocks.taskDetailMap['T-2'] = { config: { goal: {} } };
+
+    const { result } = renderHook(() => useGoalWorkStatus({ identifier: 'T-2', taskId: 'task-2' }));
+
+    expect(result.current.isGoal).toBe(true);
+    expect(mocks.useAcceptanceBySubject).toHaveBeenCalledWith('task', 'task-2');
+  });
+
+  it('keeps polling for a Goal tracker before task detail loads', () => {
+    renderHook(() => useGoalWorkStatus({ goalKnown: true, identifier: 'T-3', taskId: 'task-3' }));
+
+    expect(mocks.useAcceptanceBySubject).toHaveBeenCalledWith('task', 'task-3');
+  });
+});

--- a/src/features/Conversation/Messages/GoalWorkCard/useGoalWorkStatus.ts
+++ b/src/features/Conversation/Messages/GoalWorkCard/useGoalWorkStatus.ts
@@ -5,6 +5,7 @@ import { getGoalWorkProgress } from './goalWorkProgress';
 
 interface GoalWorkStatusInput {
   criteriaCount?: number;
+  goalKnown?: boolean;
   identifier?: string;
   maxRounds?: number;
   taskId?: string;
@@ -14,11 +15,12 @@ interface GoalWorkStatusInput {
  * Live Goal status for one task pointer (identifier + taskId): task detail +
  * acceptance aggregate → phase / round / checks coverage. Shared by the
  * running tracker card and the merged task-callback header — both only hold
- * the pointer, so everything else is fetched here. Both fetchers no-op when
- * the ids are absent.
+ * the pointer, so everything else is fetched here. Callback cards wait for
+ * task detail to classify the task before starting acceptance polling.
  */
 export const useGoalWorkStatus = ({
   criteriaCount = 0,
+  goalKnown = false,
   identifier,
   maxRounds,
   taskId,
@@ -26,9 +28,10 @@ export const useGoalWorkStatus = ({
   const useFetchTaskDetail = useTaskStore((s) => s.useFetchTaskDetail);
   useFetchTaskDetail(identifier);
   const task = useTaskStore((s) => (identifier ? s.taskDetailMap[identifier] : undefined));
-  const { data: acceptance } = useAcceptanceBySubject('task', taskId ?? null);
-  const { data: bundle } = useAcceptanceBundle(acceptance?.id ?? null);
   const config = task?.config as { goal?: { maxIterations?: number | null } } | undefined;
+  const isGoal = goalKnown || !!config?.goal;
+  const { data: acceptance } = useAcceptanceBySubject('task', isGoal ? (taskId ?? null) : null);
+  const { data: bundle } = useAcceptanceBundle(acceptance?.id ?? null);
 
   const progress = getGoalWorkProgress({
     acceptanceStatus: acceptance?.status,
@@ -39,5 +42,5 @@ export const useGoalWorkStatus = ({
     taskStatus: task?.status,
   });
 
-  return { hasAcceptance: !!acceptance, progress, taskName: task?.name ?? undefined };
+  return { isGoal, progress, taskName: task?.name ?? undefined };
 };

--- a/src/features/Conversation/Messages/GoalWorkCard/useGoalWorkStatus.ts
+++ b/src/features/Conversation/Messages/GoalWorkCard/useGoalWorkStatus.ts
@@ -1,0 +1,43 @@
+import { useAcceptanceBundle, useAcceptanceBySubject } from '@/features/Verify';
+import { useTaskStore } from '@/store/task';
+
+import { getGoalWorkProgress } from './goalWorkProgress';
+
+interface GoalWorkStatusInput {
+  criteriaCount?: number;
+  identifier?: string;
+  maxRounds?: number;
+  taskId?: string;
+}
+
+/**
+ * Live Goal status for one task pointer (identifier + taskId): task detail +
+ * acceptance aggregate → phase / round / checks coverage. Shared by the
+ * running tracker card and the merged task-callback header — both only hold
+ * the pointer, so everything else is fetched here. Both fetchers no-op when
+ * the ids are absent.
+ */
+export const useGoalWorkStatus = ({
+  criteriaCount = 0,
+  identifier,
+  maxRounds,
+  taskId,
+}: GoalWorkStatusInput) => {
+  const useFetchTaskDetail = useTaskStore((s) => s.useFetchTaskDetail);
+  useFetchTaskDetail(identifier);
+  const task = useTaskStore((s) => (identifier ? s.taskDetailMap[identifier] : undefined));
+  const { data: acceptance } = useAcceptanceBySubject('task', taskId ?? null);
+  const { data: bundle } = useAcceptanceBundle(acceptance?.id ?? null);
+  const config = task?.config as { goal?: { maxIterations?: number | null } } | undefined;
+
+  const progress = getGoalWorkProgress({
+    acceptanceStatus: acceptance?.status,
+    checks: bundle?.checks,
+    criteriaCount,
+    maxRounds: config?.goal?.maxIterations ?? maxRounds,
+    rounds: task?.topicCount ?? 0,
+    taskStatus: task?.status,
+  });
+
+  return { hasAcceptance: !!acceptance, progress, taskName: task?.name ?? undefined };
+};

--- a/src/features/Conversation/Messages/GoalWorkCard/useOperationGoals.ts
+++ b/src/features/Conversation/Messages/GoalWorkCard/useOperationGoals.ts
@@ -1,8 +1,23 @@
 import type { AssistantContentBlock } from '@lobechat/types';
+import isEqual from 'fast-deep-equal';
 import { useMemo } from 'react';
 
+import { dataSelectors, useConversationStore } from '../../store';
 import { deriveOperationGoals, type OperationGoal } from './deriveOperationGoals';
 
-/** Display-only Goal artifacts derived from one settled assistant group. */
-export const useOperationGoals = (blocks?: AssistantContentBlock[]): OperationGoal[] =>
-  useMemo(() => deriveOperationGoals(blocks ?? []), [blocks]);
+/**
+ * Display-only Goal artifacts derived from one settled assistant group.
+ *
+ * Goals whose task already delivered its `role='taskCallback'` handoff into
+ * this thread are dropped: the callback card absorbs the Goal status header
+ * and becomes the single surface for that task, so the creating turn's
+ * tracker card retires instead of duplicating it.
+ */
+export const useOperationGoals = (blocks?: AssistantContentBlock[]): OperationGoal[] => {
+  const landedTaskIds = useConversationStore(dataSelectors.taskCallbackTaskIds, isEqual);
+
+  return useMemo(
+    () => deriveOperationGoals(blocks ?? []).filter((goal) => !landedTaskIds.includes(goal.taskId)),
+    [blocks, landedTaskIds],
+  );
+};

--- a/src/features/Conversation/Messages/TaskCallback/index.tsx
+++ b/src/features/Conversation/Messages/TaskCallback/index.tsx
@@ -1,16 +1,24 @@
 'use client';
 
-import { Flexbox, Icon, Markdown, Text } from '@lobehub/ui';
+import { Center, Flexbox, Icon, Markdown, Text } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import isEqual from 'fast-deep-equal';
-import { CircleAlert, CircleCheck, CircleSlash, SquareArrowOutUpRight } from 'lucide-react';
+import {
+  CircleAlert,
+  CircleCheck,
+  CircleSlash,
+  SquareArrowOutUpRight,
+  TargetIcon,
+} from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useChatStore } from '@/store/chat';
 
 import { dataSelectors, useConversationStore } from '../../store';
+import GoalStatusLine from '../GoalWorkCard/GoalStatusLine';
+import { useGoalWorkStatus } from '../GoalWorkCard/useGoalWorkStatus';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   card: css`
@@ -22,6 +30,46 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     border-radius: 16px;
 
     background: ${cssVar.colorBgElevated};
+  `,
+  goalDivider: css`
+    margin-inline: -16px;
+    border-block-start: 1px dashed ${cssVar.colorBorderSecondary};
+  `,
+  // Full-bleed clickable Goal header inside the card: negative margins undo the
+  // card padding so the hover surface reaches the card edges.
+  goalHeader: css`
+    cursor: pointer;
+
+    margin-block: -12px 0;
+    margin-inline: -16px;
+    padding-block: 12px 10px;
+    padding-inline: 16px;
+
+    &:hover {
+      background: ${cssVar.colorFillQuaternary};
+    }
+  `,
+  goalIcon: css`
+    flex-shrink: 0;
+
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+
+    color: ${cssVar.colorTextSecondary};
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+  goalIdentifier: css`
+    flex-shrink: 0;
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+    color: ${cssVar.colorTextTertiary};
+  `,
+  goalTitle: css`
+    min-width: 0;
+    font-size: 14px;
+    font-weight: 500;
   `,
   identifier: css`
     font-family: ${cssVar.fontFamilyCode};
@@ -55,6 +103,11 @@ const reasonMeta: Record<
  * task pointer (identifier / reason / taskId) is carried on
  * `metadata.taskCallback`; the handoff summary lives in the message content.
  * Renders as a standalone card (no avatar bubble), like the verify card.
+ *
+ * For Goal tasks (an acceptance aggregate exists) the card absorbs the Goal
+ * status header — 🎯 title + live phase/round/coverage line — and becomes the
+ * single surface for that task; the creating turn's tracker card retires (see
+ * `useOperationGoals`). Plain tasks keep the simple outcome header.
  */
 const TaskCallbackMessage = memo<TaskCallbackMessageProps>(({ id }) => {
   const { t } = useTranslation('chat');
@@ -64,30 +117,77 @@ const TaskCallbackMessage = memo<TaskCallbackMessageProps>(({ id }) => {
   const item = useConversationStore(dataSelectors.getDisplayMessageById(id), isEqual);
 
   const callback = item?.metadata?.taskCallback;
+  // Hooks stay unconditional — both fetchers no-op on absent ids.
+  const { hasAcceptance, progress, taskName } = useGoalWorkStatus({
+    identifier: callback?.identifier,
+    taskId: callback?.taskId,
+  });
   if (!callback) return null;
 
   const reason = (callback.reason ?? 'done') as CallbackReason;
   const { color, i18nKey, icon } = reasonMeta[reason] ?? reasonMeta.done;
   const content = typeof item?.content === 'string' ? item.content : '';
+  const openTask = () => openTaskDetail(callback.identifier);
+
+  const viewTaskButton = (
+    <Button
+      icon={SquareArrowOutUpRight}
+      size={'small'}
+      type={'text'}
+      onClick={(event) => {
+        event.stopPropagation();
+        openTask();
+      }}
+    >
+      {t('taskCallback.viewTask')}
+    </Button>
+  );
 
   return (
     <Flexbox paddingBlock={8}>
-      <Flexbox className={styles.card} gap={8}>
-        <Flexbox horizontal align={'center'} gap={8} justify={'space-between'}>
-          <Flexbox horizontal align={'center'} gap={8}>
-            <Icon color={cssVar[color]} icon={icon} size={18} />
-            <Text strong>{t(i18nKey)}</Text>
-            <span className={styles.identifier}>{callback.identifier}</span>
+      <Flexbox className={styles.card} gap={hasAcceptance ? 12 : 8}>
+        {hasAcceptance ? (
+          <>
+            <Flexbox
+              horizontal
+              align={'center'}
+              className={styles.goalHeader}
+              gap={10}
+              role={'button'}
+              tabIndex={0}
+              onClick={openTask}
+              onKeyDown={(event) => {
+                if (event.key !== 'Enter' && event.key !== ' ') return;
+                event.preventDefault();
+                openTask();
+              }}
+            >
+              <Center className={styles.goalIcon}>
+                <Icon icon={TargetIcon} size={20} />
+              </Center>
+              <Flexbox flex={1} gap={2} style={{ minWidth: 0 }}>
+                <Flexbox horizontal align={'center'} gap={8}>
+                  <Text ellipsis className={styles.goalTitle}>
+                    {taskName ?? callback.identifier}
+                  </Text>
+                  <span className={styles.goalIdentifier}>{callback.identifier}</span>
+                </Flexbox>
+                <GoalStatusLine {...progress} />
+              </Flexbox>
+              {viewTaskButton}
+            </Flexbox>
+            <div className={styles.goalDivider} />
+          </>
+        ) : (
+          <Flexbox horizontal align={'center'} gap={8} justify={'space-between'}>
+            <Flexbox horizontal align={'center'} gap={8}>
+              <Icon color={cssVar[color]} icon={icon} size={18} />
+              <Text strong>{t(i18nKey)}</Text>
+              <span className={styles.identifier}>{callback.identifier}</span>
+            </Flexbox>
+            {viewTaskButton}
           </Flexbox>
-          <Button
-            icon={SquareArrowOutUpRight}
-            size={'small'}
-            type={'text'}
-            onClick={() => openTaskDetail(callback.identifier)}
-          >
-            {t('taskCallback.viewTask')}
-          </Button>
-        </Flexbox>
+        )}
         {content ? <Markdown variant={'chat'}>{content}</Markdown> : null}
       </Flexbox>
     </Flexbox>

--- a/src/features/Conversation/Messages/TaskCallback/index.tsx
+++ b/src/features/Conversation/Messages/TaskCallback/index.tsx
@@ -38,12 +38,14 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   // Full-bleed clickable Goal header inside the card: negative margins undo the
   // card padding so the hover surface reaches the card edges.
   goalHeader: css`
-    cursor: pointer;
-
     margin-block: -12px 0;
     margin-inline: -16px;
     padding-block: 12px 10px;
     padding-inline: 16px;
+  `,
+  goalHeaderMain: css`
+    cursor: pointer;
+    min-width: 0;
 
     &:hover {
       background: ${cssVar.colorFillQuaternary};
@@ -117,8 +119,9 @@ const TaskCallbackMessage = memo<TaskCallbackMessageProps>(({ id }) => {
   const item = useConversationStore(dataSelectors.getDisplayMessageById(id), isEqual);
 
   const callback = item?.metadata?.taskCallback;
-  // Hooks stay unconditional — both fetchers no-op on absent ids.
-  const { hasAcceptance, progress, taskName } = useGoalWorkStatus({
+  // Hooks stay unconditional; the status hook waits for Goal classification
+  // before enabling acceptance polling.
+  const { isGoal, progress, taskName } = useGoalWorkStatus({
     identifier: callback?.identifier,
     taskId: callback?.taskId,
   });
@@ -130,49 +133,44 @@ const TaskCallbackMessage = memo<TaskCallbackMessageProps>(({ id }) => {
   const openTask = () => openTaskDetail(callback.identifier);
 
   const viewTaskButton = (
-    <Button
-      icon={SquareArrowOutUpRight}
-      size={'small'}
-      type={'text'}
-      onClick={(event) => {
-        event.stopPropagation();
-        openTask();
-      }}
-    >
+    <Button icon={SquareArrowOutUpRight} size={'small'} type={'text'} onClick={openTask}>
       {t('taskCallback.viewTask')}
     </Button>
   );
 
   return (
     <Flexbox paddingBlock={8}>
-      <Flexbox className={styles.card} gap={hasAcceptance ? 12 : 8}>
-        {hasAcceptance ? (
+      <Flexbox className={styles.card} gap={isGoal ? 12 : 8}>
+        {isGoal ? (
           <>
-            <Flexbox
-              horizontal
-              align={'center'}
-              className={styles.goalHeader}
-              gap={10}
-              role={'button'}
-              tabIndex={0}
-              onClick={openTask}
-              onKeyDown={(event) => {
-                if (event.key !== 'Enter' && event.key !== ' ') return;
-                event.preventDefault();
-                openTask();
-              }}
-            >
-              <Center className={styles.goalIcon}>
-                <Icon icon={TargetIcon} size={20} />
-              </Center>
-              <Flexbox flex={1} gap={2} style={{ minWidth: 0 }}>
-                <Flexbox horizontal align={'center'} gap={8}>
-                  <Text ellipsis className={styles.goalTitle}>
-                    {taskName ?? callback.identifier}
-                  </Text>
-                  <span className={styles.goalIdentifier}>{callback.identifier}</span>
+            <Flexbox horizontal align={'center'} className={styles.goalHeader} gap={10}>
+              <Flexbox
+                horizontal
+                align={'center'}
+                className={styles.goalHeaderMain}
+                flex={1}
+                gap={10}
+                role={'button'}
+                tabIndex={0}
+                onClick={openTask}
+                onKeyDown={(event) => {
+                  if (event.key !== 'Enter' && event.key !== ' ') return;
+                  event.preventDefault();
+                  openTask();
+                }}
+              >
+                <Center className={styles.goalIcon}>
+                  <Icon icon={TargetIcon} size={20} />
+                </Center>
+                <Flexbox flex={1} gap={2} style={{ minWidth: 0 }}>
+                  <Flexbox horizontal align={'center'} gap={8}>
+                    <Text ellipsis className={styles.goalTitle}>
+                      {taskName ?? callback.identifier}
+                    </Text>
+                    <span className={styles.goalIdentifier}>{callback.identifier}</span>
+                  </Flexbox>
+                  <GoalStatusLine {...progress} />
                 </Flexbox>
-                <GoalStatusLine {...progress} />
               </Flexbox>
               {viewTaskButton}
             </Flexbox>

--- a/src/features/Conversation/store/slices/data/selectors.test.ts
+++ b/src/features/Conversation/store/slices/data/selectors.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import type { State } from '../../initialState';
+import { dataSelectors } from './selectors';
+
+const stateWith = (displayMessages: unknown[]): State => ({ displayMessages }) as unknown as State;
+
+describe('taskCallbackTaskIds', () => {
+  it('collects task ids from landed taskCallback messages only', () => {
+    const state = stateWith([
+      { id: 'm1', role: 'user' },
+      {
+        id: 'm2',
+        metadata: { taskCallback: { identifier: 'T-262', reason: 'done', taskId: 'task-a' } },
+        role: 'taskCallback',
+      },
+      // Same metadata on a non-callback role must not count.
+      {
+        id: 'm3',
+        metadata: { taskCallback: { identifier: 'T-1', reason: 'done', taskId: 'task-x' } },
+        role: 'assistant',
+      },
+      {
+        id: 'm4',
+        metadata: { taskCallback: { identifier: 'T-263', reason: 'error', taskId: 'task-b' } },
+        role: 'taskCallback',
+      },
+    ]);
+
+    expect(dataSelectors.taskCallbackTaskIds(state)).toEqual(['task-a', 'task-b']);
+  });
+
+  it('skips callback messages without a task pointer', () => {
+    const state = stateWith([
+      { id: 'm1', role: 'taskCallback' },
+      { id: 'm2', metadata: {}, role: 'taskCallback' },
+    ]);
+
+    expect(dataSelectors.taskCallbackTaskIds(state)).toEqual([]);
+  });
+
+  it('returns an empty list when no callbacks landed', () => {
+    expect(dataSelectors.taskCallbackTaskIds(stateWith([{ id: 'm1', role: 'user' }]))).toEqual([]);
+  });
+});

--- a/src/features/Conversation/store/slices/data/selectors.ts
+++ b/src/features/Conversation/store/slices/data/selectors.ts
@@ -225,6 +225,21 @@ const getBlockHasTools =
     return !!tools && tools.length > 0;
   };
 
+/**
+ * Task ids whose `role='taskCallback'` handoff message already landed in this
+ * thread. Drives Goal-card dedupe: once the callback card exists it absorbs
+ * the Goal status header, so the creating turn's tracker card retires.
+ */
+const taskCallbackTaskIds = (s: State): string[] => {
+  const ids: string[] = [];
+  for (const message of s.displayMessages) {
+    if (message.role !== 'taskCallback') continue;
+    const taskId = message.metadata?.taskCallback?.taskId;
+    if (taskId) ids.push(taskId);
+  }
+  return ids;
+};
+
 /** 1-based position of a verify message among all verify messages in the thread. */
 const getVerifyOrdinal = (id: string) => (s: State) => {
   let ordinal = 0;
@@ -257,5 +272,6 @@ export const dataSelectors = {
   messagesInit,
   pendingInterventions,
   skipFetch,
+  taskCallbackTaskIds,
   workSummariesByRootOperationId,
 };


### PR DESCRIPTION
<!-- Brief and heads-up -->

When a Goal task finishes, the conversation used to show **two cards for the same task**: the creating turn's Goal tracker card (title + live phase / round / checks line) and, right below it, the `role='taskCallback'` handoff card ("Task completed · T-xxx" + summary). The status info was duplicated and the two cards read as disconnected blocks.

This PR merges them: once the task callback lands, the callback card **absorbs the Goal status header** and becomes the single surface for that task.

- Extracted the live status line into a shared `GoalStatusLine` component and the task-detail + acceptance fetching into a shared `useGoalWorkStatus` hook (both under `GoalWorkCard/`).
- `TaskCallback` now renders the Goal header (🎯 icon + task name + `T-xxx` + live phase / round / coverage line) above the handoff summary when the task has an acceptance aggregate. The header stays live — accepting the delivery flips it to "achieved" in place. The whole header opens the task detail portal; the "View task" button is kept.
- Plain tasks (no acceptance) keep the existing simple outcome header — unchanged behavior.
- New `dataSelectors.taskCallbackTaskIds` drives dedupe in `useOperationGoals`: goals whose callback already landed in the thread are dropped, so the creating turn's tracker card retires instead of duplicating the merged card. While the task is still running, the tracker card behaves exactly as before.
- Once achieved, the coverage row ("4/4 passed") retires from the status line — "achieved" already implies full coverage.

| Before | After |
| ------ | ----- |
| Goal tracker card (待验收 · 第 1 轮 · 4/4 项通过) **plus** a separate "任务已完成 T-262" summary card | One merged card: Goal header with live status line on top, handoff summary below |

#### Test

- [x] Tested locally
- [x] Added/updated tests

Design was validated with an interactive prototype (real design-system runtime) covering running / pending-review / achieved / failed / plain-task states. Added unit tests for the new `taskCallbackTaskIds` selector; existing `GoalWorkCard` tests (deriveOperationGoals, goalWorkProgress) still pass; lint + full type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)