### PR TITLE
🐛 fix(portal): pass a MigrationTarget to useTopicMigrationPending

### DIFF
--- a/src/features/Portal/Topic/Chat/index.tsx
+++ b/src/features/Portal/Topic/Chat/index.tsx
@@ -81,7 +81,7 @@ const TopicChat = memo(() => {
   // backfill shows a placeholder instead of an empty history and blocks
   // sending — the server could not assemble the missing context anyway.
   const { job: migrationJob, topicPending } = useTopicMigrationPending(
-    activeAgentId,
+    { agentId: activeAgentId },
     portalTopicId,
   );
 


### PR DESCRIPTION
Canary's type-check is currently broken. Two independently green PRs collide:

- #18082 changed `useTopicMigrationPending(agentId, topicId)` to `useTopicMigrationPending(target: MigrationTarget, topicId)` so group conversations can poll by `groupId` (a group's job is registered against the group, not its member agents).
- #18048 added a portal call site still using the old positional `agentId`.

Neither PR could see the other, so both passed and the break only appears on the merge result:

```
src/features/Portal/Topic/Chat/index.tsx(84,5): error TS2559:
  Type 'string' has no properties in common with type 'MigrationTarget'.
```

One-line fix: pass `{ agentId: activeAgentId }`.

I checked every other call site — the rest pass `agentId` as a **prop** (`TopicMigrationPlaceholder`, `TopicMigrationIndicator`, `AgentMigrationBadge`), and those props come from `MigrationTarget` itself, so they still type-check. This hook call was the only positional one.

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

`bun run check --type` is clean after the change (it fails on canary without it). Behaviour is unchanged — same agent id, new argument shape.