### PR TITLE
🐛 fix: refine topic open interactions

### DIFF
--- a/src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.test.tsx
+++ b/src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.test.tsx
@@ -119,8 +119,6 @@ describe('useTopicItemDropdownMenu', () => {
     const items = result.current.dropdownMenu();
 
     expect(items.map((item) => (item && 'key' in item ? item.key : 'divider'))).toEqual([
-      'openOnRight',
-      'divider',
       'markCompleted',
       'favorite',
       'divider',
@@ -129,6 +127,7 @@ describe('useTopicItemDropdownMenu', () => {
       'diagnose',
       'divider',
       'openInNewTab',
+      'openOnRight',
       'openInNewWindow',
       'divider',
       'copySessionId',

--- a/src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.tsx
+++ b/src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.tsx
@@ -98,17 +98,6 @@ export const useTopicItemDropdownMenu = ({
 
     return [
       {
-        icon: <Icon icon={PanelRight} />,
-        key: 'openOnRight',
-        label: t('openOnRight', { ns: 'common' }),
-        onClick: () => {
-          openTopicInPortal(id);
-        },
-      },
-      {
-        type: 'divider' as const,
-      },
-      {
         disabled: !canEditTopic,
         icon: <Icon icon={isCompleted ? ArchiveRestore : Archive} />,
         key: 'markCompleted',
@@ -199,6 +188,18 @@ export const useTopicItemDropdownMenu = ({
                 navigate(url, { escape: true });
               },
             },
+          ]
+        : []),
+      {
+        icon: <Icon icon={PanelRight} />,
+        key: 'openOnRight',
+        label: t('openOnRight', { ns: 'common' }),
+        onClick: () => {
+          openTopicInPortal(id);
+        },
+      },
+      ...(isDesktop
+        ? [
             {
               icon: <Icon icon={ExternalLink} />,
               key: 'openInNewWindow',
@@ -211,7 +212,7 @@ export const useTopicItemDropdownMenu = ({
               type: 'divider' as const,
             },
           ]
-        : []),
+        : [{ type: 'divider' as const }]),
       {
         icon: <Icon icon={Hash} />,
         key: 'copySessionId',

--- a/src/features/Conversation/SplitDropZone/index.tsx
+++ b/src/features/Conversation/SplitDropZone/index.tsx
@@ -26,6 +26,7 @@ const styles = createStaticStyles(({ css }) => ({
     position: relative;
     flex: 1;
     min-height: 0;
+    margin-block-end: 8px;
   `,
 }));
 

--- a/src/features/Conversation/SplitDropZone/useConversationPanelDrop.test.ts
+++ b/src/features/Conversation/SplitDropZone/useConversationPanelDrop.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest';
+
+import { isChatInputDropTarget } from './useConversationPanelDrop';
+
+describe('isChatInputDropTarget', () => {
+  it('keeps drops inside the chat input out of the split-view target', () => {
+    const chatInput = document.createElement('div');
+    chatInput.dataset.testid = 'chat-input';
+    const editor = document.createElement('div');
+    chatInput.append(editor);
+
+    expect(isChatInputDropTarget(editor)).toBe(true);
+  });
+
+  it('allows drops in the chat list to open the split view', () => {
+    const chatList = document.createElement('div');
+
+    expect(isChatInputDropTarget(chatList)).toBe(false);
+  });
+});

--- a/src/features/Conversation/SplitDropZone/useConversationPanelDrop.ts
+++ b/src/features/Conversation/SplitDropZone/useConversationPanelDrop.ts
@@ -8,6 +8,9 @@ import { useChatStore } from '@/store/chat';
 
 export type PanelDragKind = 'topic' | 'thread';
 
+export const isChatInputDropTarget = (target: EventTarget | null): boolean =>
+  target instanceof Element && Boolean(target.closest('[data-testid="chat-input"]'));
+
 const resolveDragKind = (types: readonly string[]): PanelDragKind | null => {
   if (types.includes(TOPIC_DRAG_MIME)) return 'topic';
   if (types.includes(THREAD_DRAG_MIME)) return 'thread';
@@ -71,7 +74,7 @@ export const useConversationPanelDrop = (): UseConversationPanelDropResult => {
   const onDrop = useCallback(
     (event: React.DragEvent) => {
       const kind = resolveDragKind(event.dataTransfer.types);
-      if (!kind) return;
+      if (!kind || isChatInputDropTarget(event.target)) return;
 
       event.preventDefault();
       event.stopPropagation();

--- a/src/features/GlobalApprovalNotification/useGlobalPendingApprovals.test.ts
+++ b/src/features/GlobalApprovalNotification/useGlobalPendingApprovals.test.ts
@@ -76,6 +76,22 @@ describe('collectGlobalApprovals', () => {
     expect(groups).toHaveLength(0);
   });
 
+  it('excludes a conversation visible in the side-by-side topic portal', () => {
+    const primaryContext = { agentId: 'agt_a', topicId: 'tpc_primary' };
+    const portalContext = { agentId: 'agt_a', scope: 'main' as const, topicId: 'tpc_portal' };
+    const primaryKey = messageMapKey(primaryContext);
+    const portalKey = messageMapKey(portalContext);
+
+    const groups = collectGlobalApprovals(
+      { [portalKey]: [pendingToolMessage('msg_1', 'call_1')] },
+      { op_1: op(portalContext) },
+      primaryKey,
+      portalKey,
+    );
+
+    expect(groups).toHaveLength(0);
+  });
+
   it('skips buckets that resolve to neither an operation nor message fields', () => {
     const ctx = { agentId: 'agt_a', topicId: 'tpc_1' };
     const key = messageMapKey(ctx);

--- a/src/features/GlobalApprovalNotification/useGlobalPendingApprovals.ts
+++ b/src/features/GlobalApprovalNotification/useGlobalPendingApprovals.ts
@@ -8,7 +8,7 @@ import {
 } from '@/features/Conversation/store/slices/data/pendingInterventions';
 import { type ConversationContext } from '@/features/Conversation/types';
 import { useChatStore } from '@/store/chat';
-import { displayMessageSelectors } from '@/store/chat/selectors';
+import { chatPortalSelectors, displayMessageSelectors } from '@/store/chat/selectors';
 import { type Operation } from '@/store/chat/slices/operation/types';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 
@@ -63,6 +63,7 @@ export const collectGlobalApprovals = (
   dbMessagesMap: Record<string, UIChatMessage[]>,
   operations: Record<string, Operation>,
   activeKey: string | null,
+  portalKey?: string,
 ): GlobalApprovalGroup[] => {
   // Build the authoritative bucketKey → context map from in-flight runs.
   const contextByKey = new Map<string, ConversationContext>();
@@ -75,8 +76,10 @@ export const collectGlobalApprovals = (
 
   const groups: GlobalApprovalGroup[] = [];
   for (const [key, messages] of Object.entries(dbMessagesMap)) {
-    // Skip the conversation already on screen — InterventionBar owns it.
-    if (key === activeKey) continue;
+    // Skip conversations already on screen — their in-place InterventionBars own
+    // approvals. This includes both the primary chat and a topic opened in the
+    // side-by-side portal.
+    if (key === activeKey || key === portalKey) continue;
     if (!messages?.length) continue;
 
     const interventions = getPendingInterventions(messages);
@@ -99,19 +102,28 @@ export const collectGlobalApprovals = (
  * `InterventionBar` already handles that one).
  */
 export const useGlobalPendingApprovals = (): GlobalApprovalGroup[] => {
-  const { dbMessagesMap, operations } = useChatStore(
+  const { activeAgentId, dbMessagesMap, operations, portalTopicId } = useChatStore(
     useShallow((s) => ({
+      activeAgentId: s.activeAgentId,
       dbMessagesMap: s.dbMessagesMap,
       operations: s.operations,
+      portalTopicId: chatPortalSelectors.portalTopicId(s),
     })),
   );
   // Active conversation's bucket key — built from the full scoped context
   // (agent / topic / thread / group) so a pending approval in the on-screen
   // group/thread conversation is excluded, not duplicated.
   const activeKey = useChatStore(displayMessageSelectors.currentDisplayChatKey);
+  const portalKey = useMemo(
+    () =>
+      activeAgentId && portalTopicId
+        ? messageMapKey({ agentId: activeAgentId, scope: 'main', topicId: portalTopicId })
+        : undefined,
+    [activeAgentId, portalTopicId],
+  );
 
   return useMemo(
-    () => collectGlobalApprovals(dbMessagesMap, operations, activeKey),
-    [dbMessagesMap, operations, activeKey],
+    () => collectGlobalApprovals(dbMessagesMap, operations, activeKey, portalKey),
+    [dbMessagesMap, operations, activeKey, portalKey],
   );
 };

--- a/src/routes/(main)/agent/(chat)/_layout/index.tsx
+++ b/src/routes/(main)/agent/(chat)/_layout/index.tsx
@@ -7,7 +7,6 @@ import { memo, useRef } from 'react';
 import { Outlet } from 'react-router';
 
 import ChatTerminalPanel from '@/features/ChatTerminal';
-import SplitDropZone from '@/features/Conversation/SplitDropZone';
 import AgentWorkingSidebar from '@/features/Conversation/WorkingSidebar';
 import ChatHeader from '@/routes/(main)/agent/features/Conversation/Header';
 import Portal from '@/routes/(main)/agent/features/Portal';
@@ -47,9 +46,7 @@ const ChatLayout = memo(() => {
             style={{ minHeight: 0, minWidth: 0 }}
           >
             <ChatHeader />
-            <SplitDropZone>
-              <Outlet />
-            </SplitDropZone>
+            <Outlet />
           </Flexbox>
           <Portal />
           <AgentWorkingSidebar availableWidth={rowSize?.width} />

--- a/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
@@ -20,6 +20,7 @@ import {
   ForwardMessageDispatcher,
   MessageForwardFooter,
 } from '@/features/Conversation/MessageForward';
+import SplitDropZone from '@/features/Conversation/SplitDropZone';
 import { useAgentContext } from '@/features/Conversation/useAgentContext';
 import { mergeConversationHooks } from '@/features/Conversation/utils/mergeConversationHooks';
 import { useGatewayReconnect } from '@/hooks/useGatewayReconnect';
@@ -141,46 +142,48 @@ const Conversation = memo(() => {
         replaceMessages(messages, { context: ctx, source: meta?.source });
       }}
     >
-      <Flexbox
-        flex={1}
-        width={'100%'}
-        style={{
-          overflowX: 'hidden',
-          overflowY: 'auto',
-          position: 'relative',
-        }}
-      >
-        {topicPending ? (
-          <TopicMigrationPlaceholder agentId={context.agentId} topicId={context.topicId} />
-        ) : (
-          <ChatList
-            defaultWorkflowExpandLevel={isHeterogeneousAgent ? { streaming: 'full' } : undefined}
-            headerSlot={<div aria-hidden className={styles.floatingHeaderSpacer} />}
-            welcome={<AgentHome />}
-            footerSlot={
-              isSubagentThread ? (
-                <Flexbox
-                  horizontal
-                  align={'center'}
-                  justify={'center'}
-                  paddingBlock={6}
-                  paddingInline={16}
-                >
-                  <span
-                    style={{
-                      color: cssVar.colorTextDescription,
-                      fontSize: 12,
-                      textAlign: 'center',
-                    }}
+      <SplitDropZone>
+        <Flexbox
+          flex={1}
+          width={'100%'}
+          style={{
+            overflowX: 'hidden',
+            overflowY: 'auto',
+            position: 'relative',
+          }}
+        >
+          {topicPending ? (
+            <TopicMigrationPlaceholder agentId={context.agentId} topicId={context.topicId} />
+          ) : (
+            <ChatList
+              defaultWorkflowExpandLevel={isHeterogeneousAgent ? { streaming: 'full' } : undefined}
+              headerSlot={<div aria-hidden className={styles.floatingHeaderSpacer} />}
+              welcome={<AgentHome />}
+              footerSlot={
+                isSubagentThread ? (
+                  <Flexbox
+                    horizontal
+                    align={'center'}
+                    justify={'center'}
+                    paddingBlock={6}
+                    paddingInline={16}
                   >
-                    {t('thread.subagentReadOnlyHint')}
-                  </span>
-                </Flexbox>
-              ) : undefined
-            }
-          />
-        )}
-      </Flexbox>
+                    <span
+                      style={{
+                        color: cssVar.colorTextDescription,
+                        fontSize: 12,
+                        textAlign: 'center',
+                      }}
+                    >
+                      {t('thread.subagentReadOnlyHint')}
+                    </span>
+                  </Flexbox>
+                ) : undefined
+              }
+            />
+          )}
+        </Flexbox>
+      </SplitDropZone>
       {!isSubagentThread && !topicPending && (
         <MessageForwardFooter>
           {isHeterogeneousAgent ? <HeterogeneousChatInput /> : <MainChatInput />}


### PR DESCRIPTION
## Summary

- move “Open on Right” into the topic opening-actions group
- place it immediately above “Open in New Window”
- scope the split-view drop target to the chat list
- keep drops on ChatInput routed to topic context insertion
- add regression coverage for the drop-target boundary

## Testing

- `bun run check src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.tsx src/features/AgentSidebar/Topic/List/Item/useDropdownMenu.test.tsx`
- `bun run check src/features/Conversation/SplitDropZone/useConversationPanelDrop.ts src/features/Conversation/SplitDropZone/useConversationPanelDrop.test.ts "src/routes/(main)/agent/(chat)/_layout/index.tsx" "src/routes/(main)/agent/features/Conversation/ConversationArea.tsx"`