### PR TITLE
🐛 fix(agent-runtime): apply input templates in server runs

### DIFF
--- a/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -2371,6 +2371,37 @@ describe('RuntimeExecutors', { timeout: 60_000 }, () => {
         );
       });
 
+      it('should apply the agent input template before the server-side model call', async () => {
+        const ctxWithConfig: RuntimeExecutorContext = {
+          ...ctx,
+          agentConfig: {
+            chatConfig: { inputTemplate: 'PREPROCESSED:\n{{text}}' },
+            plugins: [],
+            systemRole: 'test',
+          },
+        };
+        const executors = createRuntimeExecutors(ctxWithConfig);
+
+        await executors.call_llm!(
+          {
+            payload: {
+              messages: [{ content: 'Hello', role: 'user' }],
+              model: 'gpt-4',
+              provider: 'openai',
+            },
+            type: 'call_llm',
+          },
+          createMockState(),
+        );
+
+        expect(engineSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ inputTemplate: 'PREPROCESSED:\n{{text}}' }),
+        );
+        expect(mockChat.mock.calls[0][0].messages.at(-1)).toEqual(
+          expect.objectContaining({ content: 'PREPROCESSED:\nHello', role: 'user' }),
+        );
+      });
+
       it('should forward additional contexts without leaking model parameters', async () => {
         const ctxWithConfig: RuntimeExecutorContext = {
           ...ctx,

--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextBuilder.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextBuilder.ts
@@ -617,6 +617,7 @@ export const buildServerCallLlmContext = async ({
     ...(groupAgentBuilderContext && { groupAgentBuilderContext }),
     historyCount: resolveRuntimeHistoryCount(agentConfig.chatConfig?.historyCount),
     initialContext: (state as any).initialContext?.initialContext,
+    inputTemplate: agentConfig.chatConfig?.inputTemplate ?? undefined,
     knowledge: {
       fileContents: agentConfig.files
         ?.filter((file: { enabled?: boolean | null }) => file.enabled === true)


### PR DESCRIPTION
### What changed

- Forward the agent's `chatConfig.inputTemplate` into the server-side context-engine input.
- Add regression coverage that verifies the template is applied to the latest user message before the model call.

### Why

Gateway execution persists the raw user prompt and rebuilds the model context on the server. Although `serverMessagesEngine` already supports input templates, `serverCallLlmContextBuilder` did not pass the configured template through, so Gateway runs silently ignored **User Input Preprocessing**.

The raw persisted message remains unchanged; only the model-facing context is processed, matching the client runtime behavior.

| Before | After |
| ------ | ----- |
| Gateway runs sent the raw prompt to the model | Gateway runs apply the configured input template before the model call |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextBuilder.ts apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
# ✓ 2 files · lint clean · tests 149 passed
```

#### 🔗 Related Issue

Fixes #18109
