### PR TITLE
🐛 fix(database): restore imported self-references

### DIFF
--- a/packages/database/src/repositories/dataImporter/__tests__/index.test.ts
+++ b/packages/database/src/repositories/dataImporter/__tests__/index.test.ts
@@ -269,7 +269,81 @@ describe('DataImporter', () => {
   });
 
   describe('import with self-references', () => {
-    it('should nullify self-reference fields (parentId, quotaId)', async () => {
+    it('should restore self-reference fields with the remapped message IDs', async () => {
+      const data: ImportPgDataStructure = {
+        data: {
+          agents: [
+            {
+              id: 'agt_selfref',
+              slug: 'selfref-agent',
+              model: 'gpt-4',
+              provider: 'openai',
+              systemRole: '',
+              createdAt: '2025-01-01T00:00:00Z',
+              updatedAt: '2025-01-01T00:00:00Z',
+            },
+          ],
+          agentsToSessions: [{ agentId: 'agt_selfref', sessionId: 'ssn_selfref' }],
+          sessions: [
+            {
+              id: 'ssn_selfref',
+              slug: 'selfref-session',
+              type: 'agent',
+              createdAt: '2025-01-01T00:00:00Z',
+              updatedAt: '2025-01-01T00:00:00Z',
+            },
+          ],
+          messages: [
+            {
+              id: 'msg_parent',
+              role: 'assistant',
+              content: 'Calling a tool',
+              sessionId: 'ssn_selfref',
+              createdAt: '2025-01-01T00:00:00Z',
+              updatedAt: '2025-01-01T00:00:00Z',
+            },
+            {
+              id: 'msg_quota',
+              role: 'assistant',
+              content: 'Quota source',
+              sessionId: 'ssn_selfref',
+              createdAt: '2025-01-01T00:00:01Z',
+              updatedAt: '2025-01-01T00:00:01Z',
+            },
+            {
+              id: 'msg_child',
+              role: 'tool',
+              content: 'Tool result',
+              sessionId: 'ssn_selfref',
+              parentId: 'msg_parent',
+              quotaId: 'msg_quota',
+              createdAt: '2025-01-01T00:00:02Z',
+              updatedAt: '2025-01-01T00:00:02Z',
+            },
+          ],
+        },
+        mode: 'pglite',
+        schemaHash: 'test',
+      } as any;
+
+      const result = await importer.importPgData(data);
+
+      expect(result.success).toBe(true);
+      expect(result.results.messages).toMatchObject({ added: 3, errors: 0 });
+
+      const messages = await clientDB.query.messages.findMany({
+        where: eq(Schema.messages.userId, userId),
+      });
+      const messageByClientId = Object.fromEntries(
+        messages.map((message) => [message.clientId, message]),
+      );
+
+      expect(messageByClientId.msg_child.parentId).toBe(messageByClientId.msg_parent.id);
+      expect(messageByClientId.msg_child.quotaId).toBe(messageByClientId.msg_quota.id);
+      expect(messageByClientId.msg_child.updatedAt).toEqual(new Date('2025-01-01T00:00:02Z'));
+    });
+
+    it('should nullify dangling self-reference fields', async () => {
       const data: ImportPgDataStructure = {
         data: {
           agents: [
@@ -315,7 +389,6 @@ describe('DataImporter', () => {
       expect(result.success).toBe(true);
       expect(result.results.messages).toMatchObject({ added: 1, errors: 0 });
 
-      // Verify self-reference fields are set to null
       const messages = await clientDB.query.messages.findMany({
         where: eq(Schema.messages.userId, userId),
       });

--- a/packages/database/src/repositories/dataImporter/index.ts
+++ b/packages/database/src/repositories/dataImporter/index.ts
@@ -1,5 +1,5 @@
 import type { ImporterEntryData, ImportPgDataStructure, ImportResultData } from '@lobechat/types';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, sql } from 'drizzle-orm';
 
 import { uuid } from '@/utils/uuid';
 
@@ -44,6 +44,8 @@ interface TableImportConfig {
   // Unique constraint fields
   uniqueConstraints?: string[];
 }
+
+const IMPORT_BATCH_SIZE = 100;
 
 // Import table configuration
 const IMPORT_TABLE_CONFIG: TableImportConfig[] = [
@@ -351,6 +353,56 @@ export class DataImporterRepos {
   }
 
   /**
+   * Restore self-references after all rows have been inserted and their IDs are mapped.
+   */
+  private async restoreSelfReferences(
+    trx: any,
+    table: any,
+    tableName: string,
+    tableData: any[],
+    selfReferences: NonNullable<TableImportConfig['selfReferences']>,
+  ) {
+    if (selfReferences.length === 0) return;
+
+    const idMap = this.idMaps[tableName];
+
+    for (let i = 0; i < tableData.length; i += IMPORT_BATCH_SIZE) {
+      const batch = tableData.slice(i, i + IMPORT_BATCH_SIZE);
+      const idsToUpdate = new Set<string>();
+      const valuesToSet: Record<string, any> = {};
+
+      for (const { field, sourceField = field } of selfReferences) {
+        const cases = batch.flatMap((record) => {
+          const recordId = idMap[record.id] ?? (record.clientId ? idMap[record.clientId] : null);
+          const referencedOriginalId = record[sourceField];
+
+          if (!recordId || referencedOriginalId === undefined) return [];
+
+          idsToUpdate.add(recordId);
+          const referencedId =
+            referencedOriginalId === null ? null : (idMap[referencedOriginalId] ?? null);
+
+          return [sql`WHEN ${table.id} = ${recordId} THEN ${referencedId}`];
+        });
+
+        if (cases.length > 0) {
+          valuesToSet[field] = sql`CASE ${sql.join(cases, sql` `)} ELSE ${table[field]} END`;
+        }
+      }
+
+      if (idsToUpdate.size === 0) continue;
+
+      // Keep imported timestamps stable instead of invoking the column's on-update value.
+      if ('updatedAt' in table) valuesToSet.updatedAt = sql`${table.updatedAt}`;
+
+      await trx
+        .update(table)
+        .set(valuesToSet)
+        .where(inArray(table.id, [...idsToUpdate]));
+    }
+  }
+
+  /**
    * Unified table data import function - Handles all types of tables
    */
   private async importTableData(
@@ -523,7 +575,7 @@ export class DataImporterRepos {
           }
         }
 
-        // Simplified processing of self-reference fields - directly set to null
+        // Temporarily clear self-references until every imported ID has been mapped.
         for (const selfRef of selfReferences) {
           const { field } = selfRef;
           if (newRecord[field] !== undefined) {
@@ -673,10 +725,10 @@ export class DataImporterRepos {
       filteredData.forEach((record) => delete record.newRecord._skip);
 
       // 6. Batch insert data
-      const BATCH_SIZE = 100;
+      const insertedOriginalIds = new Set<string>();
 
-      for (let i = 0; i < filteredData.length; i += BATCH_SIZE) {
-        const batch = filteredData.slice(i, i + BATCH_SIZE).filter(Boolean);
+      for (let i = 0; i < filteredData.length; i += IMPORT_BATCH_SIZE) {
+        const batch = filteredData.slice(i, i + IMPORT_BATCH_SIZE).filter(Boolean);
 
         const itemsToInsert = batch.map((item) => item.newRecord);
         const originalIds = batch.map((item) => item.originalId);
@@ -700,6 +752,7 @@ export class DataImporterRepos {
           }
 
           result.added += insertResult.length;
+          originalIds.forEach((id) => insertedOriginalIds.add(id));
 
           // Establish ID mapping relationship (only for non-composite key tables)
           if (!isCompositeKey) {
@@ -734,6 +787,14 @@ export class DataImporterRepos {
           result.errors += batch.length;
         }
       }
+
+      await this.restoreSelfReferences(
+        trx,
+        table,
+        tableName,
+        tableData.filter((record) => insertedOriginalIds.has(record.id)),
+        selfReferences,
+      );
 
       return result;
     } catch (error) {


### PR DESCRIPTION
Fixes the message self-reference regression described in #18104.

## Summary

- keep configured self-referential foreign keys null during the initial insert, then restore them after every imported ID is known
- remap `messages.parentId` and `messages.quotaId` with batched `CASE` updates while leaving dangling references null
- preserve imported `updatedAt` values during the fix-up update
- add regression coverage for both remapped and dangling message references

## Root cause

The PostgreSQL importer declared `selfReferences`, but only cleared those fields before insertion. Unlike the deprecated importer, it never performed the second-pass update needed to translate exported message IDs to the newly generated database IDs. Tool messages therefore lost their assistant parent and rendered as orphaned calls.

## Scope

This PR addresses the independently actionable self-reference portion of #18104. The agent-slug merge behavior reported in the same issue remains a separate import-policy change.

## Verification

- `cd packages/database && bunx vitest run --config vitest.config.mts src/repositories/dataImporter/__tests__/index.test.ts` (24 passed)
- `bun run check packages/database/src/repositories/dataImporter/index.ts packages/database/src/repositories/dataImporter/__tests__/index.test.ts`
- `bun run type-check`
