### PR TITLE
✨ feat(settings): reset hotkeys to defaults

### DIFF
--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -467,6 +467,8 @@
   "hotkey.invalidCombination": "The hotkey must include at least one modifier key (Ctrl, Alt, Shift) and one regular key",
   "hotkey.record": "Press a key to record the hotkey",
   "hotkey.reset": "Reset to default hotkeys",
+  "hotkey.resetConfirm": "Reset all hotkeys to their default bindings?",
+  "hotkey.resetSuccess": "Hotkeys reset to defaults",
   "hotkey.title": "Hotkeys",
   "hotkey.updateError": "Failed to update hotkey: Network or system error",
   "hotkey.updateSuccess": "Hotkey updated successfully",

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -467,6 +467,8 @@
   "hotkey.invalidCombination": "快捷键需要至少包含一个修饰键 (Ctrl, Alt, Shift) 和一个常规键",
   "hotkey.record": "按下按键以录制快捷键",
   "hotkey.reset": "重置为默认快捷键",
+  "hotkey.resetConfirm": "要将所有快捷键重置为默认按键吗？",
+  "hotkey.resetSuccess": "快捷键已重置为默认值",
   "hotkey.title": "快捷键",
   "hotkey.updateError": "快捷键更新失败：网络或系统错误",
   "hotkey.updateSuccess": "快捷键更新成功",

--- a/packages/locales/src/default/setting.ts
+++ b/packages/locales/src/default/setting.ts
@@ -614,6 +614,8 @@ export default {
     'The hotkey must include at least one modifier key (Ctrl, Alt, Shift) and one regular key',
   'hotkey.record': 'Press a key to record the hotkey',
   'hotkey.reset': 'Reset to default hotkeys',
+  'hotkey.resetConfirm': 'Reset all hotkeys to their default bindings?',
+  'hotkey.resetSuccess': 'Hotkeys reset to defaults',
   'hotkey.title': 'Hotkeys',
   'hotkey.updateError': 'Failed to update hotkey: Network or system error',
   'hotkey.updateSuccess': 'Hotkey updated successfully',

--- a/src/features/Settings/hotkey/features/Conversation.tsx
+++ b/src/features/Settings/hotkey/features/Conversation.tsx
@@ -4,7 +4,7 @@ import { HotkeyGroupEnum } from '@lobechat/const/hotkeys';
 import { type FormGroupItemType } from '@lobehub/ui';
 import { Form, HotkeyInput, Skeleton } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
-import { memo } from 'react';
+import { memo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import AutoSaveHint from '@/components/Editor/AutoSaveHint';
@@ -25,6 +25,10 @@ const HotkeySetting = memo(() => {
   const { hotkey } = useUserStore(settingsSelectors.currentSettings, isEqual);
   const [setSettings, isUserStateInit] = useUserStore((s) => [s.setSettings, s.isUserStateInit]);
   const { status: saveStatus, lastSavedAt, save, retry } = useSaveState();
+
+  useEffect(() => {
+    form.setFieldsValue(hotkey);
+  }, [form, hotkey]);
 
   if (!isUserStateInit) return <Skeleton active paragraph={{ rows: 5 }} title={false} />;
 

--- a/src/features/Settings/hotkey/features/Desktop.tsx
+++ b/src/features/Settings/hotkey/features/Desktop.tsx
@@ -5,7 +5,7 @@ import { Form, HotkeyInput, Icon, Skeleton } from '@lobehub/ui';
 import { toast } from '@lobehub/ui/base-ui';
 import isEqual from 'fast-deep-equal';
 import { Loader2Icon } from 'lucide-react';
-import { memo, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DESKTOP_HOTKEYS_REGISTRATION } from '@/const/desktopGlobalShortcuts';
@@ -32,6 +32,10 @@ const HotkeySetting = memo(() => {
   useFetchDesktopHotkeys();
 
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    form.setFieldsValue(hotkeys);
+  }, [form, hotkeys]);
 
   if (!isHotkeysInit) return <Skeleton active paragraph={{ rows: 5 }} title={false} />;
 

--- a/src/features/Settings/hotkey/features/Essential.tsx
+++ b/src/features/Settings/hotkey/features/Essential.tsx
@@ -4,7 +4,7 @@ import { HotkeyGroupEnum } from '@lobechat/const/hotkeys';
 import { type FormGroupItemType } from '@lobehub/ui';
 import { Form, HotkeyInput, Skeleton } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
-import { memo } from 'react';
+import { memo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import AutoSaveHint from '@/components/Editor/AutoSaveHint';
@@ -25,6 +25,10 @@ const HotkeySetting = memo(() => {
   const { hotkey } = useUserStore(settingsSelectors.currentSettings, isEqual);
   const [setSettings, isUserStateInit] = useUserStore((s) => [s.setSettings, s.isUserStateInit]);
   const { status: saveStatus, lastSavedAt, save, retry } = useSaveState();
+
+  useEffect(() => {
+    form.setFieldsValue(hotkey);
+  }, [form, hotkey]);
 
   if (!isUserStateInit) return <Skeleton active paragraph={{ rows: 5 }} title={false} />;
 

--- a/src/features/Settings/hotkey/features/ResetHotkeysButton.tsx
+++ b/src/features/Settings/hotkey/features/ResetHotkeysButton.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { DEFAULT_HOTKEY_CONFIG } from '@lobechat/const';
+import { Icon } from '@lobehub/ui';
+import { Button, confirmModal, toast } from '@lobehub/ui/base-ui';
+import { RotateCcw } from 'lucide-react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { isDesktop } from '@/const/version';
+import { useElectronStore } from '@/store/electron';
+import { useUserStore } from '@/store/user';
+
+import { resetDesktopHotkeys } from './resetHotkeys';
+
+export const ResetHotkeysButton = memo(() => {
+  const { t } = useTranslation(['setting', 'common']);
+  const setSettings = useUserStore((s) => s.setSettings);
+  const updateDesktopHotkey = useElectronStore((s) => s.updateDesktopHotkey);
+
+  const resetHotkeys = async () => {
+    try {
+      if (isDesktop) {
+        const result = await resetDesktopHotkeys(updateDesktopHotkey);
+        if (!result.success) {
+          toast.error(t(`hotkey.errors.${result.errorType || 'UNKNOWN'}` as any));
+          return;
+        }
+      }
+
+      await setSettings({ hotkey: DEFAULT_HOTKEY_CONFIG });
+      toast.success(t('hotkey.resetSuccess'));
+    } catch {
+      toast.error(t('hotkey.updateError'));
+    }
+  };
+
+  return (
+    <Button
+      icon={<Icon icon={RotateCcw} />}
+      size={'small'}
+      onClick={() =>
+        confirmModal({
+          cancelText: t('cancel', { ns: 'common' }),
+          content: t('hotkey.resetConfirm'),
+          okText: t('hotkey.reset'),
+          onOk: resetHotkeys,
+          title: t('hotkey.reset'),
+        })
+      }
+    >
+      {t('hotkey.reset')}
+    </Button>
+  );
+});
+
+ResetHotkeysButton.displayName = 'ResetHotkeysButton';

--- a/src/features/Settings/hotkey/features/resetHotkeys.test.ts
+++ b/src/features/Settings/hotkey/features/resetHotkeys.test.ts
@@ -1,0 +1,48 @@
+import type { ShortcutUpdateResult } from '@lobechat/electron-client-ipc';
+import { describe, expect, it, vi } from 'vitest';
+
+import { resetDesktopHotkeys } from './resetHotkeys';
+
+describe('resetDesktopHotkeys', () => {
+  it('restores defaults even when custom bindings are swapped', async () => {
+    const bindings: Record<string, string> = {
+      openSettings: 'ctrl+comma',
+      quickChat: 'alt+shift+space',
+      quickComposer: 'alt+x',
+      showApp: 'ctrl+y',
+    };
+    const updateDesktopHotkey = vi.fn(
+      async (id: string, accelerator: string): Promise<ShortcutUpdateResult> => {
+        const hasConflict = Object.entries(bindings).some(
+          ([otherId, value]) => otherId !== id && accelerator && value === accelerator,
+        );
+        if (hasConflict) return { errorType: 'CONFLICT', success: false };
+
+        bindings[id] = accelerator;
+        return { success: true };
+      },
+    );
+
+    const result = await resetDesktopHotkeys(updateDesktopHotkey);
+
+    expect(result).toEqual({ success: true });
+    expect(bindings).toEqual({
+      openSettings: 'mod+comma',
+      quickChat: '',
+      quickComposer: 'alt+shift+space',
+      showApp: '',
+    });
+  });
+
+  it('returns the first desktop update failure', async () => {
+    const updateDesktopHotkey = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({ errorType: 'SYSTEM_OCCUPIED', success: false });
+
+    const result = await resetDesktopHotkeys(updateDesktopHotkey);
+
+    expect(result).toEqual({ errorType: 'SYSTEM_OCCUPIED', success: false });
+    expect(updateDesktopHotkey).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/features/Settings/hotkey/features/resetHotkeys.ts
+++ b/src/features/Settings/hotkey/features/resetHotkeys.ts
@@ -1,0 +1,23 @@
+import { DESKTOP_HOTKEYS_REGISTRATION } from '@lobechat/const/desktopGlobalShortcuts';
+import type { ShortcutUpdateResult } from '@lobechat/electron-client-ipc';
+
+type UpdateDesktopHotkey = (id: string, accelerator: string) => Promise<ShortcutUpdateResult>;
+
+export const resetDesktopHotkeys = async (
+  updateDesktopHotkey: UpdateDesktopHotkey,
+): Promise<ShortcutUpdateResult> => {
+  // Clear first so swapped custom bindings cannot conflict with the defaults being restored.
+  for (const item of DESKTOP_HOTKEYS_REGISTRATION) {
+    const result = await updateDesktopHotkey(item.id, '');
+    if (!result.success) return result;
+  }
+
+  for (const item of DESKTOP_HOTKEYS_REGISTRATION) {
+    if (!item.keys) continue;
+
+    const result = await updateDesktopHotkey(item.id, item.keys);
+    if (!result.success) return result;
+  }
+
+  return { success: true };
+};

--- a/src/features/Settings/hotkey/index.tsx
+++ b/src/features/Settings/hotkey/index.tsx
@@ -1,3 +1,4 @@
+import { Flexbox } from '@lobehub/ui';
 import { useTranslation } from 'react-i18next';
 
 import { isDesktop } from '@/const/version';
@@ -6,6 +7,7 @@ import SettingHeader from '@/features/Settings/features/SettingHeader';
 import Conversation from './features/Conversation';
 import Desktop from './features/Desktop';
 import Essential from './features/Essential';
+import { ResetHotkeysButton } from './features/ResetHotkeysButton';
 
 interface PageProps {
   showSettingHeader?: boolean;
@@ -13,9 +15,17 @@ interface PageProps {
 
 const Page = ({ showSettingHeader = true }: PageProps) => {
   const { t } = useTranslation('setting');
+  const resetButton = <ResetHotkeysButton />;
+
   return (
     <>
-      {showSettingHeader && <SettingHeader title={t('tab.hotkey')} />}
+      {showSettingHeader ? (
+        <SettingHeader extra={resetButton} title={t('tab.hotkey')} />
+      ) : (
+        <Flexbox horizontal justify={'flex-end'} style={{ marginBottom: 16 }}>
+          {resetButton}
+        </Flexbox>
+      )}
       {isDesktop && <Desktop />}
       <Essential />
       <Conversation />


### PR DESCRIPTION
## Summary

- add a single reset action to Hotkey settings with confirmation and success/error feedback
- restore user hotkeys from the existing `DEFAULT_HOTKEY_CONFIG` on web and mobile
- restore Electron global shortcuts too, clearing current bindings first so swapped custom shortcuts cannot conflict with their defaults
- synchronize all three hotkey forms after the external reset so the restored bindings appear immediately

| Before | After |
| ------ | ----- |
| A cleared binding had no page-level recovery action. | “Reset to default hotkeys” restores all bindings from the existing registries. |

#### Test

- [x] `bun run check` (10 changed files, lint clean, 2 tests passed)
- [x] `bun run type-check`
- [x] Added coverage for swapped desktop bindings and update failures

#### 🔗 Related Issue

Fixes #17398
