### PR TITLE
🐛 fix(hetero-agent): wait for Pi settlement after compaction

### DIFF
--- a/packages/heterogeneous-agents/src/adapters/pi.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/pi.test.ts
@@ -192,7 +192,7 @@ describe('PiAdapter', () => {
     expect(dataFor(events, 'tool_end')).toHaveLength(1);
   });
 
-  it('maps provider auth failures after Pi confirms it will not retry', () => {
+  it('maps provider auth failures only after the whole Pi run settles', () => {
     const adapter = new PiAdapter();
     const events = [
       ...adapter.adapt({ type: 'turn_start' }),
@@ -209,8 +209,11 @@ describe('PiAdapter', () => {
         type: 'message_update',
       }),
       ...adapter.adapt({ type: 'turn_end' }),
-      ...adapter.adapt({ type: 'agent_end', willRetry: false }),
     ];
+    const agentEndEvents = adapter.adapt({ type: 'agent_end', willRetry: false });
+
+    expect(agentEndEvents).toEqual([]);
+    events.push(...agentEndEvents, ...adapter.adapt({ type: 'agent_settled' }));
 
     expect(dataFor(events, 'error')).toEqual([
       expect.objectContaining({
@@ -227,6 +230,30 @@ describe('PiAdapter', () => {
     ]);
     expect(adapter.adapt({ type: 'agent_settled' })).toEqual([]);
     expect(adapter.flush()).toEqual([]);
+  });
+
+  it('surfaces an overflow when Pi settles without compacting', () => {
+    const adapter = new PiAdapter();
+    const overflowError = {
+      errorMessage: 'Your input exceeds the context window of this model.',
+      model: 'gpt-5.6-luna',
+      provider: 'openai-codex',
+      stopReason: 'error',
+    };
+    const events = [
+      ...adapter.adapt({ type: 'turn_start' }),
+      ...adapter.adapt({ message: { ...overflowError, role: 'assistant' }, type: 'message_end' }),
+      ...adapter.adapt({ type: 'turn_end' }),
+      ...adapter.adapt({ type: 'agent_end', willRetry: false }),
+      ...adapter.adapt({ type: 'agent_settled' }),
+    ];
+
+    expect(dataFor(events, 'agent_runtime_end')).toEqual([]);
+    expect(dataFor(events, 'error')).toEqual([
+      expect.objectContaining({
+        message: 'Your input exceeds the context window of this model.',
+      }),
+    ]);
   });
 
   it('does not emit a terminal error when Pi retries and later succeeds', () => {
@@ -281,6 +308,160 @@ describe('PiAdapter', () => {
       content: 'Recovered',
     });
     expect(dataFor(events, 'agent_runtime_end')).toEqual([{}]);
+  });
+
+  it('waits through overflow compaction and ends successfully after Pi recovers', () => {
+    const adapter = new PiAdapter();
+    const overflowError = {
+      errorMessage: 'Your input exceeds the context window of this model.',
+      model: 'gpt-5.6-luna',
+      provider: 'openai-codex',
+      stopReason: 'error',
+    };
+    const events = [
+      ...adapter.adapt({ type: 'turn_start' }),
+      ...adapter.adapt({ message: { ...overflowError, role: 'assistant' }, type: 'message_end' }),
+      ...adapter.adapt({ type: 'turn_end' }),
+      ...adapter.adapt({ type: 'agent_end', willRetry: false }),
+      ...adapter.adapt({ reason: 'overflow', type: 'compaction_start' }),
+      ...adapter.adapt({
+        aborted: false,
+        reason: 'overflow',
+        result: { estimatedTokensAfter: 1856, tokensBefore: 371_835 },
+        type: 'compaction_end',
+        willRetry: true,
+      }),
+      ...adapter.adapt({ type: 'agent_start' }),
+      ...adapter.adapt({ type: 'turn_start' }),
+      ...adapter.adapt({
+        assistantMessageEvent: { delta: 'Recovered after compaction', type: 'text_delta' },
+        type: 'message_update',
+      }),
+      ...adapter.adapt({
+        message: {
+          content: [{ text: 'Recovered after compaction', type: 'text' }],
+          model: 'gpt-5.6-luna',
+          provider: 'openai-codex',
+          role: 'assistant',
+          stopReason: 'stop',
+          usage: { cacheRead: 0, cacheWrite: 0, input: 10, output: 2, totalTokens: 12 },
+        },
+        type: 'message_end',
+      }),
+      ...adapter.adapt({ type: 'turn_end' }),
+      ...adapter.adapt({ type: 'agent_end', willRetry: false }),
+      ...adapter.adapt({ type: 'agent_settled' }),
+    ];
+
+    expect(dataFor(events, 'error')).toEqual([]);
+    expect(
+      events.filter((event) => event.type === 'stream_start').map((event) => event.stepIndex),
+    ).toEqual([0, 1]);
+    expect(dataFor(events, 'stream_chunk')).toContainEqual({
+      chunkType: 'text',
+      content: 'Recovered after compaction',
+    });
+    expect(dataFor(events, 'agent_runtime_end')).toEqual([{}]);
+  });
+
+  it('surfaces a failed overflow compaction when Pi settles', () => {
+    const adapter = new PiAdapter();
+    const events = [
+      ...adapter.adapt({ type: 'turn_start' }),
+      ...adapter.adapt({
+        message: {
+          errorMessage: 'Your input exceeds the context window of this model.',
+          model: 'gpt-5.6-luna',
+          provider: 'openai-codex',
+          role: 'assistant',
+          stopReason: 'error',
+        },
+        type: 'message_end',
+      }),
+      ...adapter.adapt({ type: 'turn_end' }),
+      ...adapter.adapt({ type: 'agent_end', willRetry: false }),
+      ...adapter.adapt({ reason: 'overflow', type: 'compaction_start' }),
+      ...adapter.adapt({
+        aborted: false,
+        errorMessage: 'Context overflow recovery failed: summary request failed',
+        reason: 'overflow',
+        type: 'compaction_end',
+        willRetry: false,
+      }),
+      ...adapter.adapt({ type: 'agent_settled' }),
+    ];
+
+    expect(dataFor(events, 'agent_runtime_end')).toEqual([]);
+    expect(dataFor(events, 'error')).toEqual([
+      expect.objectContaining({
+        details: {
+          model: 'gpt-5.6-luna',
+          modelProvider: 'openai-codex',
+          stopReason: 'error',
+        },
+        message: 'Context overflow recovery failed: summary request failed',
+      }),
+    ]);
+  });
+
+  it('keeps a successful answer successful when threshold compaction fails', () => {
+    const adapter = new PiAdapter();
+    const events = [
+      ...adapter.adapt({ type: 'turn_start' }),
+      ...adapter.adapt({
+        message: {
+          content: [{ text: 'The answer completed before compaction.', type: 'text' }],
+          model: 'gpt-5.6-luna',
+          provider: 'openai-codex',
+          role: 'assistant',
+          stopReason: 'stop',
+        },
+        type: 'message_end',
+      }),
+      ...adapter.adapt({ type: 'turn_end' }),
+      ...adapter.adapt({ type: 'agent_end', willRetry: false }),
+      ...adapter.adapt({ reason: 'threshold', type: 'compaction_start' }),
+      ...adapter.adapt({
+        aborted: false,
+        errorMessage: 'Auto-compaction failed: summary request failed',
+        reason: 'threshold',
+        type: 'compaction_end',
+        willRetry: false,
+      }),
+      ...adapter.adapt({ type: 'agent_settled' }),
+    ];
+
+    expect(dataFor(events, 'error')).toEqual([]);
+    expect(dataFor(events, 'agent_runtime_end')).toEqual([{}]);
+  });
+
+  it('flushes the pending failure if Pi exits during a retry before settling', () => {
+    const adapter = new PiAdapter();
+    const retryError = {
+      errorMessage: 'Provider overloaded',
+      model: 'claude-sonnet-4-5',
+      provider: 'anthropic',
+      stopReason: 'error',
+    };
+
+    adapter.adapt({ type: 'turn_start' });
+    adapter.adapt({ message: { ...retryError, role: 'assistant' }, type: 'message_end' });
+    adapter.adapt({ type: 'turn_end' });
+    adapter.adapt({ type: 'agent_end', willRetry: true });
+    adapter.adapt({
+      attempt: 1,
+      delayMs: 1000,
+      errorMessage: retryError.errorMessage,
+      maxAttempts: 3,
+      type: 'auto_retry_start',
+    });
+
+    const events = adapter.flush();
+
+    expect(dataFor(events, 'agent_runtime_end')).toEqual([]);
+    expect(dataFor(events, 'error')).toEqual([
+      expect.objectContaining({ message: 'Provider overloaded' }),
+    ]);
   });
 
   it('treats an aborted Pi response as an interrupted outcome, not an error', () => {

--- a/packages/heterogeneous-agents/src/adapters/pi.ts
+++ b/packages/heterogeneous-agents/src/adapters/pi.ts
@@ -130,7 +130,9 @@ export class PiAdapter implements AgentEventAdapter {
         return this.handleMessageEnd(raw.message);
       }
       case 'agent_end': {
-        return this.handleAgentEnd(raw);
+        // Pi emits agent_end before post-run retry/compaction checks. Only
+        // agent_settled means the whole prompt (including recovery) is done.
+        return [];
       }
       case 'tool_execution_start': {
         return this.startTool({
@@ -162,6 +164,20 @@ export class PiAdapter implements AgentEventAdapter {
             provider: PI_IDENTIFIER,
           }),
         ];
+      }
+      case 'compaction_end': {
+        if (
+          this.pendingAssistantError &&
+          typeof raw.errorMessage === 'string' &&
+          raw.errorMessage
+        ) {
+          this.pendingAssistantError = {
+            ...this.pendingAssistantError,
+            errorMessage: raw.errorMessage,
+            stopReason: 'error',
+          };
+        }
+        return [];
       }
       case 'agent_settled': {
         return this.handleSettled();
@@ -291,6 +307,10 @@ export class PiAdapter implements AgentEventAdapter {
     if (message.stopReason === 'error') {
       return [...snapshotEvents, ...this.deferAssistantError(message)];
     }
+
+    // A later successful assistant response supersedes an error from a prior
+    // low-level run (for example, after Pi compacts and retries an overflow).
+    this.pendingAssistantError = undefined;
 
     const model =
       typeof message.responseModel === 'string'
@@ -424,18 +444,6 @@ export class PiAdapter implements AgentEventAdapter {
     if (this.terminalErrorEmitted || this.settled) return [];
     this.pendingAssistantError = message;
     return [];
-  }
-
-  private handleAgentEnd(event: any): HeterogeneousAgentEvent[] {
-    if (!this.pendingAssistantError) return [];
-    if (event.willRetry === true) {
-      this.pendingAssistantError = undefined;
-      return [];
-    }
-
-    const error = this.pendingAssistantError;
-    this.pendingAssistantError = undefined;
-    return this.emitAssistantError(error);
   }
 
   private emitAssistantError(message: any): HeterogeneousAgentEvent[] {


### PR DESCRIPTION
## Summary

- Treat Pi's `agent_settled` event as the definitive prompt terminal instead of `agent_end`, which Pi emits before post-run retry and compaction checks.
- Preserve pending assistant failures until a later successful response supersedes them, so disabled compaction and failed recovery still end as errors.
- Surface overflow compaction failures while keeping already-successful responses successful when threshold compaction fails.
- Keep process-exit flushing as a fallback when Pi exits during recovery before emitting `agent_settled`.

| Before | After |
| ------ | ----- |
| A context overflow emitted a terminal error at `agent_end { willRetry: false }`, even when Pi subsequently compacted, retried, and completed successfully. | LobeHub waits through Pi recovery and emits exactly one terminal event when the prompt settles. |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation:

- `bun run check packages/heterogeneous-agents/src/adapters/pi.ts packages/heterogeneous-agents/src/adapters/pi.test.ts`
- `bun run check --type packages/heterogeneous-agents/src/adapters/pi.ts packages/heterogeneous-agents/src/adapters/pi.test.ts`
- Replayed the 6,037-line production Pi trace: 66 stream starts, final step 65, and exactly one terminal `agent_runtime_end` at `agent_settled`.

#### 🔗 Related Issue

N/A — no matching GitHub issue found.
