### PR TITLE
✨ feat(topic): default all CLI heterogeneous agents to folder grouping

### DIFF
--- a/packages/types/src/agent/heterogeneousAgent.ts
+++ b/packages/types/src/agent/heterogeneousAgent.ts
@@ -1,3 +1,5 @@
+import type { TopicGroupMode } from '../topic/topic';
+
 export interface HeterogeneousAgentAuthDescriptor {
   docsUrl: string;
   errorMessage: string;
@@ -19,6 +21,13 @@ export interface HeterogeneousAgentInstallDescriptor {
 export interface LocalHeterogeneousAgentDescriptor {
   auth: HeterogeneousAgentAuthDescriptor;
   defaultCommand: string;
+  /**
+   * Topic-list grouping the agent's conversations fall back to when neither the
+   * agent nor the user has pinned an explicit mode. CLI agents run anchored to a
+   * working directory, so folder-based `byProject` grouping is the natural
+   * default for them. Omit to inherit the global user preference.
+   */
+  defaultTopicGroupMode?: TopicGroupMode;
   iconId: string;
   install: HeterogeneousAgentInstallDescriptor;
   kind: 'local-cli';
@@ -50,6 +59,7 @@ export const HETEROGENEOUS_AGENT_CONFIGS = [
       signInCommand: 'amp login',
     },
     defaultCommand: 'amp',
+    defaultTopicGroupMode: 'byProject',
     iconId: 'Amp',
     install: {
       commands: [
@@ -78,6 +88,7 @@ export const HETEROGENEOUS_AGENT_CONFIGS = [
       signInCommand: 'claude',
     },
     defaultCommand: 'claude',
+    defaultTopicGroupMode: 'byProject',
     iconId: 'ClaudeCode',
     install: {
       commands: [
@@ -102,6 +113,7 @@ export const HETEROGENEOUS_AGENT_CONFIGS = [
       signInCommand: 'codex',
     },
     defaultCommand: 'codex',
+    defaultTopicGroupMode: 'byProject',
     iconId: 'Codex',
     install: {
       commands: ['npm install -g @openai/codex', 'brew install --cask codex'],
@@ -127,6 +139,7 @@ export const HETEROGENEOUS_AGENT_CONFIGS = [
       signInCommand: 'opencode auth login',
     },
     defaultCommand: 'opencode',
+    defaultTopicGroupMode: 'byProject',
     iconId: 'OpenCode',
     install: {
       commands: ['curl -fsSL https://opencode.ai/install | bash'],
@@ -150,6 +163,7 @@ export const HETEROGENEOUS_AGENT_CONFIGS = [
       signInCommand: 'pi',
     },
     defaultCommand: 'pi',
+    defaultTopicGroupMode: 'byProject',
     iconId: 'Pi',
     install: {
       commands: ['npm install -g @earendil-works/pi-coding-agent'],
@@ -170,6 +184,7 @@ export const HETEROGENEOUS_AGENT_CONFIGS = [
       signInCommand: 'qodercli login',
     },
     defaultCommand: 'qodercli',
+    defaultTopicGroupMode: 'byProject',
     iconId: 'Qoder',
     install: {
       commands: [

--- a/src/features/AgentSidebar/Topic/utils/topicGroupMode.test.ts
+++ b/src/features/AgentSidebar/Topic/utils/topicGroupMode.test.ts
@@ -21,6 +21,33 @@ describe('resolveAgentTopicGroupMode', () => {
     ).toBe('byProject');
   });
 
+  it.each(['amp', 'opencode', 'pi', 'qoder'] as const)(
+    'defaults %s agents to project grouping',
+    (agentType) => {
+      expect(
+        resolveAgentTopicGroupMode({
+          agentType,
+          globalMode: 'byTime',
+        }),
+      ).toBe('byProject');
+    },
+  );
+
+  it('keeps remote heterogeneous agents on the global default grouping', () => {
+    expect(
+      resolveAgentTopicGroupMode({
+        agentType: 'openclaw',
+        globalMode: 'byTime',
+      }),
+    ).toBe('byTime');
+    expect(
+      resolveAgentTopicGroupMode({
+        agentType: 'hermes',
+        globalMode: 'flat',
+      }),
+    ).toBe('flat');
+  });
+
   it('keeps normal agents on the global default grouping', () => {
     expect(resolveAgentTopicGroupMode({ globalMode: 'byTime' })).toBe('byTime');
   });

--- a/src/features/AgentSidebar/Topic/utils/topicGroupMode.ts
+++ b/src/features/AgentSidebar/Topic/utils/topicGroupMode.ts
@@ -6,22 +6,22 @@ import type { TopicGroupMode } from '@/types/topic';
 type HeterogeneousAgentType = HeterogeneousProviderConfig['type'];
 
 /**
- * CLI agents declared to default to folder/project grouping in the shared
- * descriptor catalog (`defaultTopicGroupMode: 'byProject'`). Derived from the
- * catalog so agents added later inherit the behavior automatically.
+ * Topic-grouping default declared per CLI agent in the shared descriptor
+ * catalog (`defaultTopicGroupMode`). Derived from the catalog so agents added
+ * later inherit the behavior automatically.
  */
-const PROJECT_DEFAULT_HETEROGENEOUS_AGENT_TYPES = new Set<HeterogeneousAgentType>(
-  HETEROGENEOUS_AGENT_CONFIGS.filter(
-    ({ defaultTopicGroupMode }) => defaultTopicGroupMode === 'byProject',
-  ).map(({ type }) => type),
+const DEFAULT_TOPIC_GROUP_MODE_BY_AGENT_TYPE = new Map<HeterogeneousAgentType, TopicGroupMode>(
+  HETEROGENEOUS_AGENT_CONFIGS.flatMap(({ defaultTopicGroupMode, type }) =>
+    defaultTopicGroupMode ? [[type, defaultTopicGroupMode]] : [],
+  ),
 );
 
 export const getDefaultTopicGroupModeByAgentType = (
   fallbackMode: TopicGroupMode,
   agentType?: HeterogeneousAgentType,
 ): TopicGroupMode =>
-  agentType && PROJECT_DEFAULT_HETEROGENEOUS_AGENT_TYPES.has(agentType)
-    ? 'byProject'
+  agentType
+    ? (DEFAULT_TOPIC_GROUP_MODE_BY_AGENT_TYPE.get(agentType) ?? fallbackMode)
     : fallbackMode;
 
 export const resolveAgentTopicGroupMode = ({

--- a/src/features/AgentSidebar/Topic/utils/topicGroupMode.ts
+++ b/src/features/AgentSidebar/Topic/utils/topicGroupMode.ts
@@ -1,13 +1,20 @@
 import type { HeterogeneousProviderConfig } from '@lobechat/types';
+import { HETEROGENEOUS_AGENT_CONFIGS } from '@lobechat/types';
 
 import type { TopicGroupMode } from '@/types/topic';
 
 type HeterogeneousAgentType = HeterogeneousProviderConfig['type'];
 
-const PROJECT_DEFAULT_HETEROGENEOUS_AGENT_TYPES = new Set<HeterogeneousAgentType>([
-  'claude-code',
-  'codex',
-]);
+/**
+ * CLI agents declared to default to folder/project grouping in the shared
+ * descriptor catalog (`defaultTopicGroupMode: 'byProject'`). Derived from the
+ * catalog so agents added later inherit the behavior automatically.
+ */
+const PROJECT_DEFAULT_HETEROGENEOUS_AGENT_TYPES = new Set<HeterogeneousAgentType>(
+  HETEROGENEOUS_AGENT_CONFIGS.filter(
+    ({ defaultTopicGroupMode }) => defaultTopicGroupMode === 'byProject',
+  ).map(({ type }) => type),
+);
 
 export const getDefaultTopicGroupModeByAgentType = (
   fallbackMode: TopicGroupMode,


### PR DESCRIPTION
#### Change Type

- [x] ✨ feat — New feature (non-breaking)

#### Description of Change

The conversation list in the chat sidebar defaults to folder (`byProject`) grouping for Claude Code / Codex agents, but newer heterogeneous CLI agents (Amp, OpenCode, Pi, Qoder) missed it: the default was a hardcoded `claude-code` / `codex` set in `topicGroupMode.ts`.

This makes the behavior data-driven so every CLI agent inherits it automatically:

- Adds an optional `defaultTopicGroupMode` capability to `LocalHeterogeneousAgentDescriptor` in `packages/types`.
- Marks all local CLI agents (`amp`, `claude-code`, `codex`, `opencode`, `pi`, `qoder`) with `defaultTopicGroupMode: 'byProject'` — CLI agents run anchored to a working directory, so folder grouping is the natural default.
- Derives the project-grouping default from the descriptor catalog instead of a hand-maintained type list, so agents added in the future inherit it by simply setting the field.
- Remote heterogeneous agents (`openclaw`, `hermes`) are intentionally left on the global user preference.

#### How to Test

- [x] Tested locally
- [x] Added/updated tests

Added regression coverage in `topicGroupMode.test.ts` asserting Amp / OpenCode / Pi / Qoder default to `byProject`, while remote agents fall back to the global mode.

#### 🔗 Related Issue

No related issue.