### PR TITLE
⚡️ perf(i18n): preload locale bundles on language picker hover

### DIFF
--- a/src/features/Settings/common/features/Common/Common.tsx
+++ b/src/features/Settings/common/features/Common/Common.tsx
@@ -21,6 +21,7 @@ import { systemStatusSelectors } from '@/store/global/selectors';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/selectors';
 import { type LocaleMode } from '@/types/locale';
+import { preloadLang } from '@/utils/client/preloadLang';
 
 const Common = memo(() => {
   const { t } = useTranslation('setting');
@@ -86,6 +87,19 @@ const Common = memo(() => {
           <Flexbox horizontal justify={'flex-end'}>
             <Select
               defaultValue={language}
+              optionRender={(option) => (
+                <span
+                  style={{
+                    flex: 1,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                  onMouseEnter={() => preloadLang(option.value as LocaleMode)}
+                >
+                  {option.label}
+                </span>
+              )}
               options={[
                 { label: t('settingCommon.lang.autoMode'), value: 'auto' },
                 ...localeOptions,

--- a/src/features/User/UserPanel/LangButton.tsx
+++ b/src/features/User/UserPanel/LangButton.tsx
@@ -9,6 +9,7 @@ import { localeOptions } from '@/locales/resources';
 import { useGlobalStore } from '@/store/global';
 import { globalGeneralSelectors } from '@/store/global/selectors';
 import { electronStylish } from '@/styles/electron';
+import { preloadLang } from '@/utils/client/preloadLang';
 
 const LangButton = memo<{ placement?: DropdownMenuProps['placement']; size?: number }>(
   ({ placement, size }) => {
@@ -25,7 +26,7 @@ const LangButton = memo<{ placement?: DropdownMenuProps['placement']; size?: num
         closeOnClick: true,
         key: 'auto',
         label: (
-          <Flexbox gap={4}>
+          <Flexbox gap={4} onMouseEnter={() => preloadLang('auto')}>
             <Text style={{ lineHeight: 1.2 }}>{t('settingCommon.lang.autoMode')}</Text>
             <Text fontSize={12} style={{ lineHeight: 1.2 }} type={'secondary'}>
               {t(`lang.auto` as any, { ns: 'common' })}
@@ -45,7 +46,7 @@ const LangButton = memo<{ placement?: DropdownMenuProps['placement']; size?: num
         closeOnClick: true,
         key: item.value,
         label: (
-          <Flexbox gap={4} key={item.value}>
+          <Flexbox gap={4} key={item.value} onMouseEnter={() => preloadLang(item.value)}>
             <Text style={{ lineHeight: 1.2 }}>{item.label}</Text>
             <Text fontSize={12} style={{ lineHeight: 1.2 }} type={'secondary'}>
               {t(`lang.${item.value}` as any, { ns: 'common' })}

--- a/src/utils/client/preloadLang.test.ts
+++ b/src/utils/client/preloadLang.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { preloadLang } from './preloadLang';
+
+const { getAntdLocale, load } = vi.hoisted(() => ({
+  getAntdLocale: vi.fn(() => Promise.resolve({})),
+  load: vi.fn(),
+}));
+
+vi.mock('i18next', () => ({
+  changeLanguage: vi.fn(),
+  default: {
+    getDataByLanguage: () => ({ chat: {}, setting: {} }),
+    language: 'en-US',
+    options: { ns: ['common', 'chat'] },
+    services: { backendConnector: { load } },
+  },
+}));
+
+vi.mock('@/utils/locale', () => ({ getAntdLocale }));
+
+describe('preloadLang', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('should load the currently used namespaces after the hover intent delay', () => {
+    preloadLang('zh-CN');
+
+    expect(load).not.toHaveBeenCalled();
+
+    vi.runAllTimers();
+
+    expect(load).toHaveBeenCalledWith('zh-CN', ['common', 'chat', 'setting'], expect.any(Function));
+    expect(getAntdLocale).toHaveBeenCalledWith('zh-CN');
+  });
+
+  it('should resolve "auto" to the system language so the preloaded bundle matches switchLang', () => {
+    vi.stubGlobal('lobeEnv', { systemLanguage: 'ja-JP' });
+
+    preloadLang('auto');
+    vi.runAllTimers();
+
+    expect(load).toHaveBeenCalledWith('ja-JP', ['common', 'chat', 'setting'], expect.any(Function));
+
+    vi.unstubAllGlobals();
+  });
+
+  it('should only preload the last hovered locale when moving across items', () => {
+    preloadLang('de-DE');
+    preloadLang('fr-FR');
+    preloadLang('ko-KR');
+
+    vi.runAllTimers();
+
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(load).toHaveBeenCalledWith('ko-KR', ['common', 'chat', 'setting'], expect.any(Function));
+  });
+});

--- a/src/utils/client/preloadLang.ts
+++ b/src/utils/client/preloadLang.ts
@@ -1,0 +1,42 @@
+import i18n from 'i18next';
+
+import { type LocaleMode } from '@/types/locale';
+import { getAntdLocale } from '@/utils/locale';
+
+import { resolveLang } from './switchLang';
+
+const HOVER_INTENT_DELAY = 120;
+
+let intentTimer: ReturnType<typeof setTimeout> | undefined;
+
+// `options.ns` misses the namespaces bundled at init (react-i18next only registers a namespace
+// when it had to be fetched), so the store keys are unioned in to cover them as well.
+const resolveNamespaces = () => {
+  const { ns } = i18n.options;
+  const registered = typeof ns === 'string' ? [ns] : (ns ?? []);
+  const inStore = Object.keys(i18n.getDataByLanguage(i18n.resolvedLanguage || i18n.language) ?? {});
+
+  return [...new Set([...registered, ...inStore])];
+};
+
+const loadNamespaces = (lang: string) => {
+  const backendConnector = i18n.services?.backendConnector;
+  if (!backendConnector) return;
+
+  const namespaces = resolveNamespaces();
+  if (namespaces.length === 0) return;
+
+  // i18next skips (lng, ns) pairs that are already loaded or in flight, so no dedupe cache is needed here
+  backendConnector.load(lang, namespaces, () => {});
+};
+
+export const preloadLang = (locale: LocaleMode) => {
+  clearTimeout(intentTimer);
+
+  intentTimer = setTimeout(() => {
+    const lang = resolveLang(locale);
+
+    loadNamespaces(lang);
+    getAntdLocale(lang).catch(() => {});
+  }, HOVER_INTENT_DELAY);
+};

--- a/src/utils/client/switchLang.ts
+++ b/src/utils/client/switchLang.ts
@@ -5,8 +5,11 @@ import { LOBE_LOCALE_COOKIE } from '@/const/locale';
 import { type LocaleMode } from '@/types/locale';
 import { getSystemLanguage } from '@/utils/client/systemLanguage';
 
+export const resolveLang = (locale: LocaleMode) =>
+  locale === 'auto' ? getSystemLanguage() : locale;
+
 export const switchLang = (locale: LocaleMode) => {
-  const lang = locale === 'auto' ? getSystemLanguage() : locale;
+  const lang = resolveLang(locale);
 
   changeLanguage(lang);
   document.documentElement.lang = lang;


### PR DESCRIPTION
Locale namespaces are loaded through async imports, so today switching language only *starts* fetching the bundles after the click — the UI stays in the old language for as long as the chunks take to arrive. This warms the exact chunks `switchLang` would request as soon as a language item is hovered, so the switch lands inside the hover-to-click gap.

New shared `preloadLang` util, wired into both language pickers:

- **`src/features/User/UserPanel/LangButton.tsx`** — `DropdownMenuCheckboxItem` has no DOM-prop escape hatch, so the handler sits on the custom `label` node; base-ui's label span is `flex: 1`, so it covers the whole row.
- **`src/features/Settings/common/features/Common/Common.tsx`** — via `optionRender`. Passing `optionRender` swaps `Select.ItemText`'s class from `label` to `itemContent`, so the wrapper carries the original ellipsis styles to keep it visually identical.

Implementation notes worth a reviewer's eye:

- **Language resolution is shared with `switchLang`** (extracted `resolveLang`). `auto` must resolve to the raw `getSystemLanguage()` value (e.g. `zh-Hans-CN`), not the normalized one — preloading under a different key would leave i18next's store key mismatched and the click would re-fetch anyway.
- **Uses `backendConnector.load(lang, ns, cb)`** so resources land in i18next's store and `changeLanguage`'s `queueLoad` skips them via `hasResourceBundle`. Deliberately not `i18n.loadLanguages()`: that permanently appends to `options.preload`, which would make every later namespace load also fetch every hovered language.
- **Namespaces = `options.ns` ∪ the store's keys for the current language.** react-i18next only calls `loadNamespaces` when `ready === false`, so the namespaces inlined into `resources` at init (`chat`/`common`/`error`/`home`) never enter `options.ns` — and those are the most visible ones on screen.
- **120ms hover intent**, shared module-level timer. Without it, sweeping the mouse down 18 locales would fan out to 18 × N dynamic imports (zh-CN is ~1.3MB across 52 namespaces).
- Also warms `getAntdLocale(lang)`, the other async import gating the switch in `Locale.tsx`.

`AuthShell`'s `AuthLangButton` is not wired up — it runs on a separate i18n instance (`createAuthI18n`) with a single namespace, so there is little to hide.

| Before | After |
| ------ | ----- |
| Language chunks start loading on click; UI holds the old language until they arrive | Chunks are already in the i18next store by the time the click lands |

#### Test

Unit tests cover the delay gate, `auto` → system-language resolution, and that sweeping across items only preloads the last hovered locale. Lint and type-check are clean for the touched files (the repo's full `--type` run has pre-existing failures from the missing `@lobechat/builtin-tool-goal` workspace package and `.next` route-validator noise, unrelated to this change).

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

N/A