### PR TITLE
✨ feat(database): hide acceptance evidence from the resource library

### DIFF
--- a/packages/database/src/models/__tests__/file.test.ts
+++ b/packages/database/src/models/__tests__/file.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { FilesTabs, SortType } from '@lobechat/types';
+import { FileSource, FilesTabs, SortType } from '@lobechat/types';
 import { eq, inArray } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -779,6 +779,51 @@ describe('FileModel', () => {
       it('should include all files when showFilesInKnowledgeBase is true', async () => {
         const result = await fileModel.query({ showFilesInKnowledgeBase: true });
         expect(result).toHaveLength(2);
+      });
+    });
+
+    describe('Hidden sources', () => {
+      beforeEach(async () => {
+        await serverDB.insert(files).values([
+          {
+            id: 'plain-file',
+            name: 'notes.txt',
+            userId,
+            fileType: 'text/plain',
+            size: 100,
+            url: 'plain-url',
+          },
+          {
+            id: 'acceptance-file',
+            name: 'payload-execution.txt',
+            userId,
+            fileType: 'text/plain',
+            size: 100,
+            source: FileSource.Acceptance,
+            url: 'acceptance-url',
+          },
+          {
+            id: 'generation-file',
+            name: 'generated.png',
+            userId,
+            fileType: 'image/png',
+            size: 100,
+            source: FileSource.ImageGeneration,
+            url: 'generation-url',
+          },
+        ]);
+      });
+
+      it('should exclude acceptance evidence and keep every other source', async () => {
+        const result = await fileModel.query();
+
+        expect(result.map((f) => f.id).sort()).toEqual(['generation-file', 'plain-file']);
+      });
+
+      it('should still find acceptance evidence by id', async () => {
+        const result = await fileModel.findById('acceptance-file');
+
+        expect(result?.name).toBe('payload-execution.txt');
       });
     });
   });

--- a/packages/database/src/models/__tests__/verifyEvidence.test.ts
+++ b/packages/database/src/models/__tests__/verifyEvidence.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { FileSource } from '@lobechat/types';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../core/getTestDB';
@@ -111,6 +112,59 @@ describe('VerifyEvidenceModel', () => {
     const rows = await model.listByCheckResult(checkResultId);
     expect(rows).toHaveLength(2);
     expect(rows.map((r) => r.type).sort()).toEqual(['dom_snapshot', 'screenshot']);
+  });
+
+  it('stamps the backing file as acceptance-sourced so the library hides it', async () => {
+    const model = new VerifyEvidenceModel(serverDB, userId);
+    await model.create({ checkResultId, fileId, type: 'screenshot' });
+
+    const file = await serverDB.query.files.findFirst({ where: (f, { eq }) => eq(f.id, fileId) });
+    expect(file?.source).toBe('acceptance');
+  });
+
+  it('stamps every backing file of a batch, leaving inline rows alone', async () => {
+    const model = new VerifyEvidenceModel(serverDB, userId);
+    const [second] = await serverDB
+      .insert(files)
+      .values({
+        fileType: 'text/plain',
+        name: 'payload-execution.txt',
+        size: 64,
+        url: 's3://evidence/payload-execution.txt',
+        userId,
+      })
+      .returning();
+
+    await model.createMany([
+      { checkResultId, fileId, type: 'screenshot' },
+      { checkResultId, fileId: second.id, type: 'text' },
+      { checkResultId, content: 'dom snapshot', type: 'dom_snapshot' },
+    ]);
+
+    const rows = await serverDB.query.files.findMany();
+    expect(rows.every((f) => f.source === 'acceptance')).toBe(true);
+  });
+
+  it('keeps an existing file source instead of overwriting it', async () => {
+    const model = new VerifyEvidenceModel(serverDB, userId);
+    const [generated] = await serverDB
+      .insert(files)
+      .values({
+        fileType: 'image/png',
+        name: 'generated.png',
+        size: 128,
+        source: FileSource.ImageGeneration,
+        url: 's3://generations/generated.png',
+        userId,
+      })
+      .returning();
+
+    await model.create({ checkResultId, fileId: generated.id, type: 'screenshot' });
+
+    const file = await serverDB.query.files.findFirst({
+      where: (f, { eq }) => eq(f.id, generated.id),
+    });
+    expect(file?.source).toBe('image_generation');
   });
 
   it('deletes an evidence row by id', async () => {

--- a/packages/database/src/models/file.ts
+++ b/packages/database/src/models/file.ts
@@ -1,5 +1,5 @@
 import type { QueryFileListParams } from '@lobechat/types';
-import { FilesTabs, SortType } from '@lobechat/types';
+import { FilesTabs, LIBRARY_HIDDEN_FILE_SOURCES, SortType } from '@lobechat/types';
 import {
   and,
   asc,
@@ -12,6 +12,7 @@ import {
   like,
   ne,
   notExists,
+  notInArray,
   or,
   sql,
   sum,
@@ -375,6 +376,10 @@ export class FileModel {
       q ? ilike(files.name, `%${q}%`) : undefined,
       this.ownership(callerAgentVisibility),
       visibility ? eq(files.visibility, visibility) : undefined,
+      // Artifacts owned by another surface (acceptance evidence) stay reachable
+      // by id, but never appear in a listing. Applied here rather than in
+      // `ownership()` so single-row reads and deletes still resolve them.
+      or(isNull(files.source), notInArray(files.source, LIBRARY_HIDDEN_FILE_SOURCES)),
     );
     if (category && category !== FilesTabs.All && category !== FilesTabs.Home) {
       const categoryFilter = buildFileCategoryFilter(files.fileType, category as FilesTabs);

--- a/packages/database/src/models/verifyEvidence.ts
+++ b/packages/database/src/models/verifyEvidence.ts
@@ -1,6 +1,8 @@
 import type { VerifyEvidence } from '@lobechat/types';
-import { and, asc, eq, inArray } from 'drizzle-orm';
+import { FileSource } from '@lobechat/types';
+import { and, asc, eq, inArray, isNull } from 'drizzle-orm';
 
+import { files } from '../schemas/file';
 import { verifyCheckResults, verifyEvidence } from '../schemas/verify';
 import type { LobeChatDatabase } from '../type';
 import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
@@ -28,11 +30,43 @@ export class VerifyEvidenceModel {
   private ownership = () =>
     buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, verifyEvidence);
 
+  /**
+   * Attribute the backing file rows to the acceptance surface so the resource
+   * library stops listing them.
+   *
+   * Stamped here rather than at upload time on purpose: artifacts reach the
+   * `files` table through the generic `file.createFile` procedure, which every
+   * CLI version and every capturer shares. Tagging at the moment the artifact
+   * becomes evidence is the one funnel all of them pass through, so an outdated
+   * `lh` binary can't keep seeding untagged files into the library.
+   *
+   * Scoped like any other read: workspace mode covers all member files, personal
+   * mode only the caller's. `source IS NULL` keeps a generation-sourced file
+   * (attached as evidence) from losing its original attribution.
+   */
+  private markFilesAsEvidence = async (rows: CreateVerifyEvidence[]) => {
+    const fileIds = [...new Set(rows.map((r) => r.fileId).filter((id): id is string => !!id))];
+    if (fileIds.length === 0) return;
+
+    await this.db
+      .update(files)
+      .set({ source: FileSource.Acceptance })
+      .where(
+        and(
+          inArray(files.id, fileIds),
+          isNull(files.source),
+          buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, files),
+        ),
+      );
+  };
+
   create = async (params: CreateVerifyEvidence) => {
     const [result] = await this.db
       .insert(verifyEvidence)
       .values(buildWorkspacePayload({ userId: this.userId, workspaceId: this.workspaceId }, params))
       .returning();
+
+    await this.markFilesAsEvidence([params]);
 
     return result;
   };
@@ -40,7 +74,7 @@ export class VerifyEvidenceModel {
   /** Batch-insert the artifacts captured by a single probe / verifier run. */
   createMany = async (rows: CreateVerifyEvidence[]) => {
     if (rows.length === 0) return [];
-    return this.db
+    const inserted = await this.db
       .insert(verifyEvidence)
       .values(
         rows.map((r) =>
@@ -48,6 +82,10 @@ export class VerifyEvidenceModel {
         ),
       )
       .returning();
+
+    await this.markFilesAsEvidence(rows);
+
+    return inserted;
   };
 
   findById = async (id: string) => {

--- a/packages/database/src/repositories/knowledge/index.test.ts
+++ b/packages/database/src/repositories/knowledge/index.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { FilesTabs } from '@lobechat/types';
+import { FileSource, FilesTabs } from '@lobechat/types';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../core/getTestDB';
@@ -1302,6 +1302,60 @@ describe('KnowledgeRepo', () => {
       expect(ids).toContain('root-file');
       expect(ids).toContain('folder-1');
       expect(ids).not.toContain('child-file');
+    });
+  });
+
+  describe('acceptance evidence hiding', () => {
+    beforeEach(async () => {
+      await serverDB.insert(files).values([
+        {
+          id: 'library-file',
+          fileType: 'text/plain',
+          name: 'notes.txt',
+          size: 100,
+          url: 'library-url',
+          userId,
+        },
+        {
+          id: 'evidence-file',
+          fileType: 'text/plain',
+          name: 'payload-execution.txt',
+          size: 100,
+          source: FileSource.Acceptance,
+          url: 'evidence-url',
+          userId,
+        },
+        {
+          id: 'generated-file',
+          fileType: 'image/png',
+          name: 'generated.png',
+          size: 100,
+          source: FileSource.ImageGeneration,
+          url: 'generated-url',
+          userId,
+        },
+      ]);
+    });
+
+    it('should hide acceptance evidence from the file list', async () => {
+      const result = await knowledgeRepo.query({ category: FilesTabs.All });
+
+      const ids = result.map((item) => item.fileId);
+      expect(ids).toContain('library-file');
+      expect(ids).toContain('generated-file');
+      expect(ids).not.toContain('evidence-file');
+    });
+
+    it('should hide acceptance evidence from recent items', async () => {
+      const result = await knowledgeRepo.queryRecent(50, 'file');
+
+      expect(result.map((item) => item.fileId)).not.toContain('evidence-file');
+    });
+
+    it('should still resolve acceptance evidence by id', async () => {
+      const result = await knowledgeRepo.findById('evidence-file', 'file');
+
+      expect(result?.name).toBe('payload-execution.txt');
     });
   });
 

--- a/packages/database/src/repositories/knowledge/index.ts
+++ b/packages/database/src/repositories/knowledge/index.ts
@@ -1,7 +1,20 @@
 import { CUSTOM_DOCUMENT_FILE_TYPE, CUSTOM_FOLDER_FILE_TYPE } from '@lobechat/const';
 import type { FileUploader, QueryFileListParams } from '@lobechat/types';
-import { FilesTabs, SortType } from '@lobechat/types';
-import { and, asc, desc, eq, ilike, isNull, ne, notExists, or, type SQL, sql } from 'drizzle-orm';
+import { FilesTabs, LIBRARY_HIDDEN_FILE_SOURCES, SortType } from '@lobechat/types';
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  ilike,
+  isNull,
+  ne,
+  notExists,
+  notInArray,
+  or,
+  type SQL,
+  sql,
+} from 'drizzle-orm';
 import { alias, type AnyPgColumn, unionAll } from 'drizzle-orm/pg-core';
 
 import { DocumentModel } from '../../models/document';
@@ -231,7 +244,17 @@ export class KnowledgeRepo {
 
   private scope = () => ({ userId: this.userId, workspaceId: this.workspaceId });
 
-  private fileScope = () => buildWorkspaceWhere(this.scope(), f);
+  /**
+   * Scope predicate every file listing shares: ownership plus the exclusion of
+   * sources that belong to another surface (acceptance evidence). Kept as one
+   * helper so a new listing can't accidentally pick up ownership alone and
+   * start leaking hundreds of verification artifacts back into the library.
+   */
+  private fileScope = () =>
+    and(
+      buildWorkspaceWhere(this.scope(), f),
+      or(isNull(f.source), notInArray(f.source, LIBRARY_HIDDEN_FILE_SOURCES)),
+    );
 
   private documentScope = () => buildWorkspaceWhere(this.scope(), d);
 

--- a/packages/database/src/repositories/search/index.ts
+++ b/packages/database/src/repositories/search/index.ts
@@ -1,4 +1,17 @@
-import { and, desc, eq, inArray, isNull, ne, type SQL, sql, type SQLWrapper } from 'drizzle-orm';
+import { LIBRARY_HIDDEN_FILE_SOURCES } from '@lobechat/types';
+import {
+  and,
+  desc,
+  eq,
+  inArray,
+  isNull,
+  ne,
+  notInArray,
+  or,
+  type SQL,
+  sql,
+  type SQLWrapper,
+} from 'drizzle-orm';
 import type { AnyPgColumn } from 'drizzle-orm/pg-core';
 
 import {
@@ -837,6 +850,10 @@ export class SearchRepo {
         and(
           this.scanScopeWhere(files),
           ne(files.fileType, 'custom/document'),
+          // Acceptance evidence is hidden from the library, so it must stay out
+          // of search too — otherwise a query for "execution" returns hundreds
+          // of artifacts the user can't find anywhere else in the UI.
+          or(isNull(files.source), notInArray(files.source, LIBRARY_HIDDEN_FILE_SOURCES)),
           sql`${files.name} @@@ ${bm25Query}`,
         ),
       )

--- a/packages/types/src/files/index.ts
+++ b/packages/types/src/files/index.ts
@@ -15,10 +15,25 @@ export enum FilesTabs {
 }
 
 export enum FileSource {
+  /**
+   * Evidence artifact backing an acceptance check — a screenshot, execution log
+   * or DOM snapshot produced by a verification run. Owned by the report, not by
+   * the user's library.
+   */
+  Acceptance = 'acceptance',
   ImageGeneration = 'image_generation',
   PageEditor = 'page-editor',
   VideoGeneration = 'video_generation',
 }
+
+/**
+ * Sources whose files are attachments of some other surface rather than library
+ * resources. They stay fully readable through the surface that owns them (an
+ * acceptance report renders its evidence via `verify_evidence.file_id`), but
+ * never show up in the resource library listings — a single verification run
+ * uploads hundreds of artifacts and would otherwise bury real content.
+ */
+export const LIBRARY_HIDDEN_FILE_SOURCES: FileSource[] = [FileSource.Acceptance];
 
 export interface FileItem {
   content?: string;


### PR DESCRIPTION
A verification run uploads every screenshot, execution log and DOM snapshot through the generic file upload, so the artifacts land in the resource library next to real content. Measured on one production account:

| Tab | Visible now | Acceptance evidence | Share |
| --- | --- | --- | --- |
| Documents | 371 | 300 | **81%** |
| Files | 173 | 146 | **84%** |
| Images | 8812 | 2701 | 31% |

3153 of that account's 9700 files (531 MB); 6331 files across 24 accounts.

`files.source` already exists for exactly this attribution and was only ever written (`image_generation` / `video_generation`), never read by any query. This adds an `acceptance` value, stamps it, and excludes hidden sources from every listing.

**Where the stamp goes.** `VerifyEvidenceModel.create` / `createMany`, not the upload path. Artifacts reach `files` through the generic `file.createFile` procedure that every CLI version and every capturer shares, so the moment a file becomes evidence is the one funnel they all pass through — threading a `source` param through the upload would leave outdated `lh` binaries seeding untagged files forever. The update is guarded by `source IS NULL` so a generation-sourced image attached as evidence keeps its original attribution, and scoped with `buildWorkspaceWhere` like any other write.

**Where the filter goes.** Three read paths: `KnowledgeRepo.fileScope` (shared by the listing, the knowledge-base branch and recents), `FileModel.query`, and `SearchRepo.searchFiles`. Search is included deliberately — a file hidden from the library that still answers a search query is unreachable from anywhere in the UI.

Deliberately **not** in `FileModel.ownership()`: single-row reads, deletes and transfers must still resolve evidence by id. The acceptance report renders its own artifacts through `verify_evidence.file_id` and is unaffected.

`LIBRARY_HIDDEN_FILE_SOURCES` is the list to extend when another agent-artifact source shows up. Emptying it degrades to plain ownership rather than emitting an invalid `NOT IN ()`.

Existing rows are backfilled separately (already run on production):

```sql
UPDATE files SET source = 'acceptance'
FROM (SELECT DISTINCT file_id FROM verify_evidence WHERE file_id IS NOT NULL) ev
WHERE files.id = ev.file_id AND files.source IS NULL;
```

No filename-pattern fallback: the join covers ~3153 of ~3200, and the remaining early orphans sit among real files (`weekly-report.md`, `code-review.md`, `.sql`, `.docx`) where a name rule would do more harm than good.

#### Test

8 new tests. Verified they are real regression tests — emptying `LIBRARY_HIDDEN_FILE_SOURCES` makes the three hiding tests fail, restoring it makes them pass.

- listing / recents hide evidence, `findById` still resolves it
- `FileModel.query` excludes `acceptance` and keeps every other source
- single and batch stamping; inline (file-less) evidence rows are untouched
- an existing `image_generation` source is not overwritten

`SearchRepo`'s suite is `describe.skipIf(!isServerDB)` and does not run locally — that one change is only covered in CI.

- [x] Tested locally
- [x] Added/updated tests

#### 🔗 Related Issue

<!-- none -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
