### PR TITLE
🐛 fix(context-engine): move TODO context to the virtual tail message

### DIFF
--- a/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -2190,9 +2190,12 @@ describe('RuntimeExecutors', { timeout: 60_000 }, () => {
           state,
         );
 
-        return mockChat.mock.calls[0][0].messages.find(
-          (message: { role?: string }) => message.role === 'user',
-        )?.content as string;
+        // TODO state lands on the virtual tail user message, the original user turn stays
+        // untouched — so assert against every user-role message the request carries.
+        return mockChat.mock.calls[0][0].messages
+          .filter((message: { role?: string }) => message.role === 'user')
+          .map((message: { content?: unknown }) => String(message.content))
+          .join('\n\n') as string;
       };
 
       it('injects the newest valid message TODO state and skips Notebook', async () => {

--- a/apps/server/src/modules/Mecha/ContextEngineering/__tests__/serverMessagesEngine.test.ts
+++ b/apps/server/src/modules/Mecha/ContextEngineering/__tests__/serverMessagesEngine.test.ts
@@ -35,17 +35,20 @@ describe('serverMessagesEngine', () => {
   describe('TODO context', () => {
     const items = [{ status: 'processing' as const, text: 'Keep server context in sync' }];
 
-    it('forwards non-empty planTodo state to MessagesEngine', async () => {
+    it('forwards non-empty planTodo state to the virtual tail message', async () => {
       const result = await serverMessagesEngine({
         messages: createBasicMessages(),
         model: 'gpt-4',
         planTodo: { enabled: true, todos: { items, updatedAt: 'now' } },
         provider: 'openai',
       });
-      const userContent = result.find((message) => message.role === 'user')?.content;
+      const tailContent = result.at(-1)?.content;
 
-      expect(userContent).toContain('<todo_context>');
-      expect(userContent).toContain('Keep server context in sync');
+      expect(result.at(-1)?.role).toBe('user');
+      expect(tailContent).toContain('<todo_context>');
+      expect(tailContent).toContain('Keep server context in sync');
+      // the historical user message keeps its original bytes so the prefix stays cacheable
+      expect(result.find((message) => message.role === 'user')?.content).toBe('Hello');
     });
 
     it('does not inject an empty TODO state', async () => {
@@ -56,7 +59,7 @@ describe('serverMessagesEngine', () => {
         provider: 'openai',
       });
 
-      expect(result.find((message) => message.role === 'user')?.content).not.toContain(
+      expect(result.map((message) => String(message.content)).join('\n')).not.toContain(
         '<todo_context>',
       );
     });
@@ -77,9 +80,13 @@ describe('serverMessagesEngine', () => {
         provider: 'openai',
       });
 
-      expect(serverResult.find((message) => message.role === 'user')?.content).toBe(
-        clientResult.messages.find((message) => message.role === 'user')?.content,
-      );
+      // same content AND same position — both paths must put TODO on the tail
+      const userContents = (messages: { content: any; role: string }[]) =>
+        messages.filter((message) => message.role === 'user').map((message) => message.content);
+
+      expect(userContents(serverResult)).toEqual(userContents(clientResult.messages as any));
+      expect(serverResult.at(-1)?.content).toContain('<todo_context>');
+      expect(clientResult.messages.at(-1)?.content).toContain('<todo_context>');
     });
   });
 

--- a/packages/context-engine/src/base/BaseLastUserContentProvider.ts
+++ b/packages/context-engine/src/base/BaseLastUserContentProvider.ts
@@ -1,6 +1,7 @@
 import type { Message, PipelineContext, ProcessorOptions } from '../types';
 import { BaseProcessor } from './BaseProcessor';
-import { CONTEXT_INSTRUCTION, SYSTEM_CONTEXT_END, SYSTEM_CONTEXT_START } from './constants';
+import { SYSTEM_CONTEXT_END, SYSTEM_CONTEXT_START, VIRTUAL_LAST_USER_MARKER } from './constants';
+import { createContextBlock, wrapWithSystemContext } from './systemContext';
 
 /**
  * Base Provider for appending content to the last user message
@@ -12,13 +13,18 @@ export abstract class BaseLastUserContentProvider extends BaseProcessor {
   }
 
   /**
-   * Find the index of the last user message
+   * Find the index of the last *real* user message.
+   *
+   * Virtual tail messages (injected by `BaseVirtualLastUserContentProvider` subclasses) are
+   * skipped: they are high-churn by design, so appending stable context to them would push
+   * that context outside the provider-side cacheable prefix on every step.
    */
   protected findLastUserMessageIndex(messages: Message[]): number {
     for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i].role === 'user') {
-        return i;
-      }
+      const message = messages[i];
+      if (message.role !== 'user') continue;
+      if (message.meta?.[VIRTUAL_LAST_USER_MARKER] === true) continue;
+      return i;
     }
     return -1;
   }
@@ -148,20 +154,13 @@ export abstract class BaseLastUserContentProvider extends BaseProcessor {
    * Following the format from @lobechat/prompts files/index.ts
    */
   protected wrapWithSystemContext(content: string, contextType: string): string {
-    return `${SYSTEM_CONTEXT_START}
-${CONTEXT_INSTRUCTION}
-<${contextType}>
-${content}
-</${contextType}>
-${SYSTEM_CONTEXT_END}`;
+    return wrapWithSystemContext(content, contextType);
   }
 
   /**
    * Create a context block without the full wrapper (for inserting into existing wrapper)
    */
   protected createContextBlock(content: string, contextType: string): string {
-    return `<${contextType}>
-${content}
-</${contextType}>`;
+    return createContextBlock(content, contextType);
   }
 }

--- a/packages/context-engine/src/base/BaseVirtualLastUserContentProvider.ts
+++ b/packages/context-engine/src/base/BaseVirtualLastUserContentProvider.ts
@@ -1,10 +1,7 @@
 import type { Message, PipelineContext, ProcessorOptions } from '../types';
 import { BaseProcessor } from './BaseProcessor';
-
-/**
- * Marker to identify runtime-injected virtual last-user messages.
- */
-const VIRTUAL_LAST_USER_MARKER = 'virtualLastUser';
+import { VIRTUAL_LAST_USER_MARKER } from './constants';
+import { wrapWithSystemContext } from './systemContext';
 
 /**
  * Base provider for injecting content at the virtual "last user" position.
@@ -23,6 +20,19 @@ export abstract class BaseVirtualLastUserContentProvider extends BaseProcessor {
   }
 
   /**
+   * Whether this provider may append its content to a *real* (user-authored) last message.
+   *
+   * Defaults to `true` for guidance that only ever appears on the turn it is built for.
+   * Providers whose content changes on every step — TODO state, progress counters — must
+   * override this to `false`: on the first turn of a topic the real user message *is* the
+   * last message, so appending there would rewrite a message that the rest of the run wants
+   * to keep byte-identical for prefix caching.
+   */
+  protected get appendToRealLastUser(): boolean {
+    return true;
+  }
+
+  /**
    * Build the content to inject.
    */
   protected abstract buildContent(context: PipelineContext): string | null;
@@ -32,6 +42,25 @@ export abstract class BaseVirtualLastUserContentProvider extends BaseProcessor {
    */
   protected shouldSkip(_context: PipelineContext): boolean {
     return false;
+  }
+
+  /**
+   * Hook invoked after content has been injected, for metadata bookkeeping.
+   */
+  protected onInjected(_context: PipelineContext): void {}
+
+  /**
+   * Whether a message is a synthetic tail message created by this base class.
+   */
+  protected isVirtualLastUserMessage(message: Message | undefined): boolean {
+    return message?.role === 'user' && message.meta?.[VIRTUAL_LAST_USER_MARKER] === true;
+  }
+
+  /**
+   * Wrap content with the shared system-context markers.
+   */
+  protected wrapWithSystemContext(content: string, contextType: string): string {
+    return wrapWithSystemContext(content, contextType);
   }
 
   /**
@@ -112,16 +141,20 @@ export abstract class BaseVirtualLastUserContentProvider extends BaseProcessor {
 
     const clonedContext = this.cloneContext(context);
     const lastMessage = clonedContext.messages.at(-1);
+    const canAppend =
+      lastMessage?.role === 'user' &&
+      (this.appendToRealLastUser || this.isVirtualLastUserMessage(lastMessage));
 
-    if (lastMessage?.role === 'user') {
+    if (canAppend) {
       clonedContext.messages[clonedContext.messages.length - 1] = this.appendToMessage(
-        lastMessage,
+        lastMessage!,
         content,
       );
-      return this.markAsExecuted(clonedContext);
+    } else {
+      clonedContext.messages.push(this.createVirtualLastUserMessage(content));
     }
 
-    clonedContext.messages.push(this.createVirtualLastUserMessage(content));
+    this.onInjected(clonedContext);
 
     return this.markAsExecuted(clonedContext);
   }

--- a/packages/context-engine/src/base/constants.ts
+++ b/packages/context-engine/src/base/constants.ts
@@ -10,6 +10,15 @@ export const SYSTEM_CONTEXT_START = '<!-- SYSTEM CONTEXT (NOT PART OF USER QUERY
 export const SYSTEM_CONTEXT_END = '<!-- END SYSTEM CONTEXT -->';
 
 /**
+ * Marker used on `message.meta` to identify runtime-injected virtual last-user messages.
+ *
+ * Providers that append to a *historical* user message must skip messages carrying this
+ * marker: a virtual tail message is high-churn by design, so folding stable content into
+ * it would drag that content out of the cacheable prefix on every step.
+ */
+export const VIRTUAL_LAST_USER_MARKER = 'virtualLastUser';
+
+/**
  * Context instruction text
  * Provides guidance to the model on how to handle injected context
  */

--- a/packages/context-engine/src/base/systemContext.ts
+++ b/packages/context-engine/src/base/systemContext.ts
@@ -1,0 +1,21 @@
+import { CONTEXT_INSTRUCTION, SYSTEM_CONTEXT_END, SYSTEM_CONTEXT_START } from './constants';
+
+/**
+ * Wrap content with system context markers
+ * Following the format from @lobechat/prompts files/index.ts
+ */
+export const wrapWithSystemContext = (content: string, contextType: string): string =>
+  `${SYSTEM_CONTEXT_START}
+${CONTEXT_INSTRUCTION}
+<${contextType}>
+${content}
+</${contextType}>
+${SYSTEM_CONTEXT_END}`;
+
+/**
+ * Create a context block without the full wrapper (for inserting into an existing wrapper)
+ */
+export const createContextBlock = (content: string, contextType: string): string =>
+  `<${contextType}>
+${content}
+</${contextType}>`;

--- a/packages/context-engine/src/engine/messages/MessagesEngine.ts
+++ b/packages/context-engine/src/engine/messages/MessagesEngine.ts
@@ -418,8 +418,6 @@ export class MessagesEngine {
         contextPrompt: initialContext?.taskManager?.contextPrompt,
         enabled: !!initialContext?.taskManager?.contextPrompt,
       }),
-      // Todo list (at end of last user message)
-      new TodoInjector({ enabled: isTodoEnabled, todos: effectiveTodos }),
       // Topic Reference context (referenced topic summaries to last user message)
       new TopicReferenceContextInjector({
         enabled: !!(topicReferences && topicReferences.length > 0),
@@ -441,6 +439,9 @@ export class MessagesEngine {
         enabled: !!onboardingContext?.phaseGuidance,
         onboardingContext,
       }),
+      // Todo list — rewritten on every create/update/clear, so it belongs on the virtual
+      // tail rather than on the historical user message it used to be appended to.
+      new TodoInjector({ enabled: isTodoEnabled, todos: effectiveTodos }),
       new RuntimeAdditionalContextProvider({ additionalContexts }),
 
       // =============================================

--- a/packages/context-engine/src/engine/messages/__tests__/MessagesEngine.test.ts
+++ b/packages/context-engine/src/engine/messages/__tests__/MessagesEngine.test.ts
@@ -82,13 +82,21 @@ describe('MessagesEngine', () => {
         updatedAt: 'metadata-time',
       };
 
-      it('injects stepContext.todos without a plan configuration', async () => {
+      const allContent = (messages: { content: any }[]) =>
+        messages.map((message) => JSON.stringify(message.content)).join('\n');
+
+      it('injects stepContext.todos into the virtual tail without a plan configuration', async () => {
         const result = await new MessagesEngine(
           createBasicParams({ stepContext: { todos: messageTodos } }),
         ).process();
 
-        expect(result.messages[0].content).toContain('<todo_context>');
-        expect(result.messages[0].content).toContain('Message task');
+        const tail = result.messages.at(-1)!;
+        expect(tail.role).toBe('user');
+        expect(tail.content).toContain('<todo_context>');
+        expect(tail.content).toContain('Message task');
+
+        // the historical user message must stay byte-identical so the prefix stays cacheable
+        expect(result.messages[0].content).toBe('Hello');
       });
 
       it('prefers message state over plan metadata', async () => {
@@ -99,8 +107,8 @@ describe('MessagesEngine', () => {
           }),
         ).process();
 
-        expect(result.messages[0].content).toContain('Message task');
-        expect(result.messages[0].content).not.toContain('Metadata task');
+        expect(result.messages.at(-1)!.content).toContain('Message task');
+        expect(allContent(result.messages)).not.toContain('Metadata task');
       });
 
       it('uses an empty message tombstone to suppress non-empty metadata', async () => {
@@ -111,8 +119,8 @@ describe('MessagesEngine', () => {
           }),
         ).process();
 
-        expect(result.messages[0].content).not.toContain('<todo_context>');
-        expect(result.messages[0].content).not.toContain('Metadata task');
+        expect(allContent(result.messages)).not.toContain('<todo_context>');
+        expect(allContent(result.messages)).not.toContain('Metadata task');
       });
 
       it('falls back to enabled plan metadata when message state is undefined', async () => {
@@ -120,7 +128,8 @@ describe('MessagesEngine', () => {
           createBasicParams({ planTodo: { enabled: true, todos: metadataTodos } }),
         ).process();
 
-        expect(result.messages[0].content).toContain('Metadata task');
+        expect(result.messages.at(-1)!.content).toContain('Metadata task');
+        expect(result.messages[0].content).toBe('Hello');
       });
     });
 

--- a/packages/context-engine/src/providers/TodoInjector.ts
+++ b/packages/context-engine/src/providers/TodoInjector.ts
@@ -1,6 +1,6 @@
 import debug from 'debug';
 
-import { BaseLastUserContentProvider } from '../base/BaseLastUserContentProvider';
+import { BaseVirtualLastUserContentProvider } from '../base/BaseVirtualLastUserContentProvider';
 import type { PipelineContext, ProcessorOptions } from '../types';
 
 declare module '../types' {
@@ -72,10 +72,17 @@ function formatTodos(todos: TodoList): string | null {
 
 /**
  * Todo Injector
- * Responsible for injecting the current todo list at the end of the last user message
- * This provides the AI with real-time awareness of task progress
+ * Responsible for injecting the current todo list as a virtual tail user message.
+ * This provides the AI with real-time awareness of task progress.
+ *
+ * The TODO list is rewritten on every create/update/clear, so it must never touch a
+ * historical message. In a tool loop the "last user message" is the user's original
+ * question (everything after it is assistant/tool), so appending there rewrote the
+ * second message of the payload and knocked the whole assistant/tool history out of
+ * the provider's prefix cache on every TODO change. Keeping the state in a synthetic
+ * tail message confines the churn to the last message.
  */
-export class TodoInjector extends BaseLastUserContentProvider {
+export class TodoInjector extends BaseVirtualLastUserContentProvider {
   readonly name = 'TodoInjector';
 
   constructor(
@@ -85,53 +92,55 @@ export class TodoInjector extends BaseLastUserContentProvider {
     super(options);
   }
 
-  protected async doProcess(context: PipelineContext): Promise<PipelineContext> {
-    log('doProcess called');
-    log('config.enabled:', this.config.enabled);
+  /**
+   * TODO state changes every step, so it must always live in its own synthetic message —
+   * never folded into the user's real message (which is the tail on the first turn).
+   */
+  protected get appendToRealLastUser(): boolean {
+    return false;
+  }
 
-    const clonedContext = this.cloneContext(context);
-
+  protected shouldSkip(context: PipelineContext): boolean {
     if (!this.config.enabled || !this.config.todos) {
       log('Todo not enabled or no todos, skipping injection');
-      return this.markAsExecuted(clonedContext);
+      return true;
     }
 
-    const formattedContent = formatTodos(this.config.todos);
+    // Keep the previous guard: without any user turn there is no conversation to report
+    // progress against.
+    if (!context.messages.some((message) => message.role === 'user')) {
+      log('No user messages found, skipping injection');
+      return true;
+    }
+
+    return false;
+  }
+
+  protected buildContent(_context: PipelineContext): string | null {
+    const formattedContent = formatTodos(this.config.todos!);
 
     if (!formattedContent) {
       log('No todos to inject (empty list)');
-      return this.markAsExecuted(clonedContext);
+      return null;
     }
 
     log('Formatted content length:', formattedContent.length);
 
-    const lastUserIndex = this.findLastUserMessageIndex(clonedContext.messages);
+    return this.wrapWithSystemContext(formattedContent, 'todo_context');
+  }
 
-    log('Last user message index:', lastUserIndex);
+  protected onInjected(context: PipelineContext): void {
+    const { items } = this.config.todos!;
 
-    if (lastUserIndex === -1) {
-      log('No user messages found, skipping injection');
-      return this.markAsExecuted(clonedContext);
-    }
-
-    const hasExistingWrapper = this.hasExistingSystemContext(clonedContext);
-    const contentToAppend = hasExistingWrapper
-      ? this.createContextBlock(formattedContent, 'todo_context')
-      : this.wrapWithSystemContext(formattedContent, 'todo_context');
-
-    this.appendToLastUserMessage(clonedContext, contentToAppend);
-
-    clonedContext.metadata.todoInjected = true;
-    clonedContext.metadata.todoCount = this.config.todos.items.length;
-    clonedContext.metadata.todoCompletedCount = this.config.todos.items.filter(
+    context.metadata.todoInjected = true;
+    context.metadata.todoCount = items.length;
+    context.metadata.todoCompletedCount = items.filter(
       (item) => item.status === 'completed',
     ).length;
-    clonedContext.metadata.todoProcessingCount = this.config.todos.items.filter(
+    context.metadata.todoProcessingCount = items.filter(
       (item) => item.status === 'processing',
     ).length;
 
-    log('Todo context appended to last user message');
-
-    return this.markAsExecuted(clonedContext);
+    log('Todo context injected as virtual tail user message');
   }
 }

--- a/packages/context-engine/src/providers/__tests__/TodoInjector.test.ts
+++ b/packages/context-engine/src/providers/__tests__/TodoInjector.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PipelineContext } from '../../types';
+import { TodoInjector, type TodoList } from '../TodoInjector';
+import { TopicReferenceContextInjector } from '../TopicReferenceContextInjector';
+
+const createContext = (messages: any[]): PipelineContext => ({
+  initialState: { messages: [] },
+  isAborted: false,
+  messages,
+  metadata: {},
+});
+
+const todos = (...items: Array<[string, 'todo' | 'processing' | 'completed']>): TodoList => ({
+  items: items.map(([text, status]) => ({ status, text })),
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+/** `[user, assistant(tool_calls), tool]` — the shape that used to break the prefix cache. */
+const toolLoopMessages = () => [
+  { content: 'system role', role: 'system' },
+  { content: 'help me refactor the parser', id: 'msg-user', role: 'user' },
+  {
+    content: '',
+    id: 'msg-assistant',
+    role: 'assistant',
+    tools: [{ apiName: 'createTodos', identifier: 'lobe-agent' }],
+  },
+  { content: '{"success":true}', id: 'msg-tool', role: 'tool' },
+];
+
+/** Everything a provider actually sends upstream, per message. */
+const payloadSignatures = (messages: any[]) =>
+  messages.map((message) => JSON.stringify({ content: message.content, role: message.role }));
+
+describe('TodoInjector', () => {
+  it('leaves the historical user message untouched and appends a virtual tail message', async () => {
+    const messages = toolLoopMessages();
+    const provider = new TodoInjector({ enabled: true, todos: todos(['write tests', 'todo']) });
+
+    const result = await provider.process(createContext(messages));
+
+    expect(result.messages[1].content).toBe('help me refactor the parser');
+    expect(result.messages).toHaveLength(5);
+
+    const tail = result.messages.at(-1);
+    expect(tail?.role).toBe('user');
+    expect(tail?.meta?.virtualLastUser).toBe(true);
+    expect(tail?.meta?.injectType).toBe('TodoInjector');
+    expect(tail?.content).toContain('<todo_context>');
+    expect(tail?.content).toContain('<todo index="0" status="todo">write tests</todo>');
+    expect(tail?.content).toContain('<progress completed="0" processing="0" total="1" />');
+  });
+
+  it('keeps every preceding message byte-identical across two different todo states', async () => {
+    const first = await new TodoInjector({
+      enabled: true,
+      todos: todos(['read the code', 'processing'], ['write tests', 'todo']),
+    }).process(createContext(toolLoopMessages()));
+
+    const second = await new TodoInjector({
+      enabled: true,
+      todos: todos(
+        ['read the code', 'completed'],
+        ['write tests', 'processing'],
+        ['run the suite', 'todo'],
+      ),
+    }).process(createContext(toolLoopMessages()));
+
+    // Only the tail differs — the whole prefix stays reusable.
+    expect(payloadSignatures(second.messages.slice(0, -1))).toEqual(
+      payloadSignatures(first.messages.slice(0, -1)),
+    );
+    expect(second.messages.at(-1)?.content).not.toBe(first.messages.at(-1)?.content);
+  });
+
+  it('does not fold todo state into the real user message on the first turn', async () => {
+    const messages = [
+      { content: 'system role', role: 'system' },
+      { content: 'plan the migration', id: 'msg-user', role: 'user' },
+    ];
+
+    const result = await new TodoInjector({
+      enabled: true,
+      todos: todos(['plan the migration', 'processing']),
+    }).process(createContext(messages));
+
+    expect(result.messages[1].content).toBe('plan the migration');
+    expect(result.messages).toHaveLength(3);
+    expect(result.messages[2].meta?.virtualLastUser).toBe(true);
+  });
+
+  it('reuses an existing virtual tail message instead of adding another one', async () => {
+    const messages = [
+      ...toolLoopMessages(),
+      {
+        content: '<next_actions>keep going</next_actions>',
+        meta: { injectType: 'OnboardingActionHintInjector', virtualLastUser: true },
+        role: 'user',
+      },
+    ];
+
+    const result = await new TodoInjector({
+      enabled: true,
+      todos: todos(['keep going', 'processing']),
+    }).process(createContext(messages));
+
+    expect(result.messages).toHaveLength(5);
+    expect(result.messages[4].content).toContain('<next_actions>keep going</next_actions>');
+    expect(result.messages[4].content).toContain('<todo_context>');
+    expect(result.messages[1].content).toBe('help me refactor the parser');
+  });
+
+  it('does not let historical-user injectors write into the todo tail message', async () => {
+    const injected = await new TodoInjector({
+      enabled: true,
+      todos: todos(['write tests', 'todo']),
+    }).process(createContext(toolLoopMessages()));
+
+    const result = await new TopicReferenceContextInjector({
+      enabled: true,
+      topicReferences: [
+        { summary: 'we discussed parsers', topicId: 'tpc_1', topicTitle: 'Parser' },
+      ],
+    }).process(injected);
+
+    expect(result.messages.at(-1)?.content).not.toContain('topic_reference_context');
+    expect(result.messages[1].content).toContain('topic_reference_context');
+  });
+
+  it('records todo metadata', async () => {
+    const result = await new TodoInjector({
+      enabled: true,
+      todos: todos(
+        ['read the code', 'completed'],
+        ['write tests', 'processing'],
+        ['run the suite', 'todo'],
+      ),
+    }).process(createContext(toolLoopMessages()));
+
+    expect(result.metadata.todoInjected).toBe(true);
+    expect(result.metadata.todoCount).toBe(3);
+    expect(result.metadata.todoCompletedCount).toBe(1);
+    expect(result.metadata.todoProcessingCount).toBe(1);
+  });
+
+  it('skips injection when disabled, empty, or without any user turn', async () => {
+    const disabled = await new TodoInjector({
+      enabled: false,
+      todos: todos(['x', 'todo']),
+    }).process(createContext(toolLoopMessages()));
+    expect(disabled.messages).toHaveLength(4);
+    expect(disabled.metadata.todoInjected).toBeUndefined();
+
+    const empty = await new TodoInjector({
+      enabled: true,
+      todos: { items: [], updatedAt: '2026-01-01T00:00:00.000Z' },
+    }).process(createContext(toolLoopMessages()));
+    expect(empty.messages).toHaveLength(4);
+
+    const noUser = await new TodoInjector({
+      enabled: true,
+      todos: todos(['x', 'todo']),
+    }).process(createContext([{ content: 'system role', role: 'system' }]));
+    expect(noUser.messages).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
`TodoInjector` appended `<todo_context>` to the last message whose role is `user`. In a tool loop that message is the user's *original* question — everything after it is `assistant` / `tool` — so every `createTodos` / `updateTodos` / `clearTodos` rewrote message 1 of the payload and knocked the entire assistant/tool history out of the provider's prefix cache.

Two production traces measured the cost: three isolated TODO-triggered cache breaks wasted **29,385 tokens** of unchanged history (one call dropped to ~22% cache hit while reprocessing 11,594 tokens, 10,491 of which had not changed). The waste compounds — the longer the tool loop, the more history each TODO update invalidates.

**Fix:** render TODO state as a synthetic tail user message, so a TODO change only ever alters the last message.

```text
before: system → user(+todo_context) → assistant/tool history …   ← prefix dies at message 1
after:  system → user → assistant/tool history → user(todo_context)   ← only the tail is reprocessed
```

#### Key Decisions / Non-goals

- **A superclass swap alone is not enough.** `BaseVirtualLastUserContentProvider` appends to the last message when that message is already a `user` message — which on the first turn of a topic is the *real* user message. Added an `appendToRealLastUser` opt-out (default `true`, so existing subclasses are unaffected) that `TodoInjector` sets to `false`. It still *reuses* an existing virtual tail when one is present, so onboarding hints and TODO state share one tail message rather than stacking two.
- **Ordering is defended twice.** `TodoInjector` moves into pipeline phase 4.5 next to the other tail providers, *and* `BaseLastUserContentProvider.findLastUserMessageIndex` now skips messages marked `meta.virtualLastUser`. The second guard means a future reordering cannot make `TopicReferenceContextInjector` (or any other historical-user injector) write into a virtual tail.
- **`onInjected` hook** on the virtual base rather than a full `doProcess` override in `TodoInjector` — keeps the metadata bookkeeping (`todoInjected` / `todoCount` / …) without duplicating the injection logic.
- **Wrapper semantics kept.** The standalone message always uses the full `wrapWithSystemContext(…, 'todo_context')` form; the "insert into an existing wrapper" branch no longer applies since the tail message is TODO's own. `wrapWithSystemContext` / `createContextBlock` were extracted to `base/systemContext.ts` so both base classes share one implementation.
- **Non-goal:** the other injectors flagged by the same class of bug (documents injection, `{{time}}` / `{{datetime}}` system-prompt placeholders) are out of scope here. A pipeline-level rule that forbids high-churn providers from writing historical positions would be the systemic fix and is worth a follow-up.
- Server and client context building share one `MessagesEngine` pipeline, so placement is identical on both paths — asserted explicitly in `serverMessagesEngine.test.ts`.

#### Test

- [x] Added/updated tests

New `TodoInjector.test.ts` covers the regression directly on the `[user, assistant(tool_calls), tool(pluginState.todos)]` shape:

- the historical user message stays byte-identical after injection
- two different TODO states leave **every** preceding message signature unchanged — only the tail differs
- no folding into the real user message on the first turn
- reuses an existing virtual tail instead of appending a second one
- `TopicReferenceContextInjector` cannot write into the TODO tail
- metadata + skip paths (disabled / empty list / no user turn)

Updated the existing TODO assertions in `MessagesEngine.test.ts`, `serverMessagesEngine.test.ts` and `RuntimeExecutors.test.ts` to look at the tail — and to assert the historical user message is untouched. Full `packages/context-engine` suite (971 tests) plus `RuntimeExecutors.test.ts` (148 tests) pass.

#### 🔗 Related Issue

Fixes LOBE-12971

Related: LOBE-10193 (documents prompt injection preserves context cache), LOBE-12761 (`{{time}}` placeholders invalidate the full prefix cache). Original injection behavior landed in #11029.
