### PR TITLE
💬 i18n: clarify onboarding background completion

### DIFF
--- a/locales/en-US/onboarding.json
+++ b/locales/en-US/onboarding.json
@@ -53,6 +53,7 @@
   "flow.steps.learnYourWorld.retry": "Retry",
   "flow.steps.learnYourWorld.sectionHint": "Analyze your connected data to understand what matters to you…",
   "flow.steps.learnYourWorld.skipAhead": "Skip ahead",
+  "flow.steps.learnYourWorld.skipNotificationHint": "💡 You can skip this step for now — we'll notify you when your profile is ready.",
   "flow.steps.learnYourWorld.title": "Learn your world",
   "flow.steps.messenger.connect": "Connect",
   "flow.steps.messenger.connected": "Connected",

--- a/locales/zh-CN/onboarding.json
+++ b/locales/zh-CN/onboarding.json
@@ -53,6 +53,7 @@
   "flow.steps.learnYourWorld.retry": "重试",
   "flow.steps.learnYourWorld.sectionHint": "分析你已连接的数据，了解你真正在意的事情…",
   "flow.steps.learnYourWorld.skipAhead": "跳过等待",
+  "flow.steps.learnYourWorld.skipNotificationHint": "💡 可以先跳过这一步，画像完成后我们会通知你。",
   "flow.steps.learnYourWorld.title": "了解你的世界",
   "flow.steps.messenger.connect": "连接",
   "flow.steps.messenger.connected": "已连接",

--- a/packages/locales/src/default/onboarding.ts
+++ b/packages/locales/src/default/onboarding.ts
@@ -76,6 +76,8 @@ export default {
   'flow.steps.learnYourWorld.sectionHint':
     'Analyze your connected data to understand what matters to you…',
   'flow.steps.learnYourWorld.skipAhead': 'Skip ahead',
+  'flow.steps.learnYourWorld.skipNotificationHint':
+    "💡 You can skip this step for now — we'll notify you when your profile is ready.",
   'flow.steps.learnYourWorld.title': 'Learn your world',
   'flow.steps.messenger.connect': 'Connect',
   'flow.steps.messenger.connected': 'Connected',


### PR DESCRIPTION
Clarifies the Learn Your World footer copy so users know they may skip the step while profile generation continues and that they will be notified when it is ready.

Keeps the default English source, en-US, and zh-CN resources aligned.

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed