### PR TITLE
fix: cancel group generation by conversation key

### DIFF
--- a/src/features/Conversation/store/slices/generation/action.test.ts
+++ b/src/features/Conversation/store/slices/generation/action.test.ts
@@ -6,7 +6,7 @@ import { messageService } from '@/services/message';
 import { agentSelectors } from '@/store/agent/selectors';
 import * as agentDispatcher from '@/store/chat/slices/agentRun/actions/dispatch/agentDispatcher';
 import * as heterogeneousAgentExecutor from '@/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor';
-import { INPUT_LOADING_OPERATION_TYPES } from '@/store/chat/slices/operation/types';
+import type * as OperationSelectorsModule from '@/store/chat/slices/operation/selectors';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 import { useUserStore } from '@/store/user';
 
@@ -30,6 +30,20 @@ const mockFailOperation = vi.fn();
 const mockExecuteClientAgent = vi.fn();
 const mockIsGatewayModeEnabled = vi.fn(() => false);
 const mockExecuteGatewayAgent = vi.fn();
+const operationSelectorMock = vi.hoisted(() => ({
+  getRunningInputLoadingOperationIds: vi.fn(() => () => ['root-op', 'retry-op']),
+}));
+
+vi.mock('@/store/chat/slices/operation/selectors', async (importOriginal) => {
+  const actual = await importOriginal<typeof OperationSelectorsModule>();
+  return {
+    ...actual,
+    operationSelectors: {
+      ...actual.operationSelectors,
+      getRunningInputLoadingOperationIds: operationSelectorMock.getRunningInputLoadingOperationIds,
+    },
+  };
+});
 
 vi.mock('@/store/chat', () => ({
   useChatStore: {
@@ -73,7 +87,7 @@ describe('Generation Actions', () => {
   });
 
   describe('stopGenerating', () => {
-    it('should cancel all running execAgentRuntime operations', () => {
+    it('should cancel every input-loading operation resolved by the conversation key', () => {
       const context: ConversationContext = {
         agentId: 'session-1',
         topicId: 'topic-1',
@@ -86,19 +100,13 @@ describe('Generation Actions', () => {
         store.getState().stopGenerating();
       });
 
-      expect(mockCancelOperations).toHaveBeenCalledWith(
-        {
-          agentId: 'session-1',
-          groupId: undefined,
-          isNew: undefined,
-          scope: undefined,
-          status: 'running',
-          threadId: null,
-          topicId: 'topic-1',
-          type: INPUT_LOADING_OPERATION_TYPES,
-        },
-        expect.any(String),
+      expect(operationSelectorMock.getRunningInputLoadingOperationIds).toHaveBeenCalledWith(
+        context,
       );
+      expect(mockCancelOperation).toHaveBeenCalledTimes(2);
+      expect(mockCancelOperation).toHaveBeenNthCalledWith(1, 'root-op', expect.any(String));
+      expect(mockCancelOperation).toHaveBeenNthCalledWith(2, 'retry-op', expect.any(String));
+      expect(mockCancelOperations).not.toHaveBeenCalled();
     });
 
     it('should isolate a creating thread from the main conversation in the same topic', () => {
@@ -118,16 +126,10 @@ describe('Generation Actions', () => {
         store.getState().stopGenerating();
       });
 
-      expect(mockCancelOperations).toHaveBeenCalledWith(
-        expect.objectContaining({
-          agentId: 'session-1',
-          isNew: true,
-          scope: 'thread',
-          threadId: null,
-          topicId: 'topic-1',
-        }),
-        expect.any(String),
+      expect(operationSelectorMock.getRunningInputLoadingOperationIds).toHaveBeenCalledWith(
+        context,
       );
+      expect(mockCancelOperations).not.toHaveBeenCalled();
       expect(mockCancelSendMessageInServer).toHaveBeenCalledWith(context, editor);
     });
 

--- a/src/features/Conversation/store/slices/generation/action.ts
+++ b/src/features/Conversation/store/slices/generation/action.ts
@@ -35,7 +35,6 @@ import {
   resolveHeteroResume,
 } from '@/store/chat/slices/agentRun/actions/transports/hetero/heteroResume';
 import { operationSelectors } from '@/store/chat/slices/operation/selectors';
-import { INPUT_LOADING_OPERATION_TYPES } from '@/store/chat/slices/operation/types';
 import {
   mergeAgentRuntimeInitialContexts,
   resolveActiveTopicDocumentInitialContext,
@@ -1223,25 +1222,17 @@ export const generationSlice: StateCreator<
   stopGenerating: () => {
     const state = get();
     const { context, editor, hooks } = state;
-    const { agentId, groupId, isNew, scope, threadId, topicId } = context;
 
     const chatStore = useChatStore.getState();
 
-    // Cancel all running operations in this conversation context
-    // Includes sendMessage, AI runtime (client-side and server-side), and agent mode stream
-    chatStore.cancelOperations(
-      {
-        agentId,
-        groupId,
-        isNew,
-        scope,
-        status: 'running',
-        threadId,
-        topicId,
-        type: INPUT_LOADING_OPERATION_TYPES,
-      },
-      MESSAGE_CANCEL_FLAT,
-    );
+    // The loading UI and operation index both use the canonical conversation key.
+    // Reuse it here because a group run can be owned by a member agent and omit an
+    // explicit scope while the visible conversation uses its supervisor and `group`.
+    // Those shapes share one group bucket but do not match raw field-by-field filters.
+    const operationIds = operationSelectors.getRunningInputLoadingOperationIds(context)(chatStore);
+    operationIds.forEach((operationId) => {
+      chatStore.cancelOperation(operationId, MESSAGE_CANCEL_FLAT);
+    });
 
     // Restore editor content if a sendMessage operation was cancelled
     chatStore.cancelSendMessageInServer(context, editor);

--- a/src/store/chat/slices/operation/__tests__/selectors.test.ts
+++ b/src/store/chat/slices/operation/__tests__/selectors.test.ts
@@ -169,6 +169,102 @@ describe('Operation Selectors', () => {
     });
   });
 
+  describe('getRunningInputLoadingOperationIds', () => {
+    it('stops a member-owned group run from the supervisor conversation context', () => {
+      const { result } = renderHook(() => useChatStore());
+      const operationContext = {
+        agentId: 'member-agent',
+        groupId: 'group-1',
+        topicId: 'topic-1',
+      };
+      const visibleContext = {
+        agentId: 'supervisor-agent',
+        groupId: 'group-1',
+        scope: 'group' as const,
+        topicId: 'topic-1',
+      };
+      let rootId = '';
+      let childId = '';
+      let otherTopicId = '';
+      let rootSignal: AbortSignal;
+      let childSignal: AbortSignal;
+
+      act(() => {
+        const root = result.current.startOperation({
+          context: operationContext,
+          type: 'execAgentRuntime',
+        });
+        rootId = root.operationId;
+        rootSignal = root.abortController.signal;
+
+        const child = result.current.startOperation({
+          parentOperationId: rootId,
+          type: 'toolCalling',
+        });
+        childId = child.operationId;
+        childSignal = child.abortController.signal;
+
+        otherTopicId = result.current.startOperation({
+          context: { ...operationContext, topicId: 'topic-2' },
+          type: 'execAgentRuntime',
+        }).operationId;
+      });
+
+      expect(messageMapKey(operationContext)).toBe(messageMapKey(visibleContext));
+
+      // This is the field-by-field filter previously used by stopGenerating.
+      // It misses the operation because agentId and scope differ, even though the
+      // input loading state and operation index resolve both contexts to one bucket.
+      let exactFilterMatches: string[] = [];
+      act(() => {
+        exactFilterMatches = result.current.cancelOperations({
+          agentId: visibleContext.agentId,
+          groupId: visibleContext.groupId,
+          scope: visibleContext.scope,
+          status: 'running',
+          topicId: visibleContext.topicId,
+          type: INPUT_LOADING_OPERATION_TYPES,
+        });
+      });
+      expect(exactFilterMatches).toEqual([]);
+      expect(rootSignal!.aborted).toBe(false);
+
+      const operationIds = operationSelectors.getRunningInputLoadingOperationIds(visibleContext)(
+        result.current,
+      );
+      expect(operationIds).toEqual([rootId]);
+
+      act(() => {
+        operationIds.forEach((operationId) => {
+          result.current.cancelOperation(operationId, 'User stopped generation');
+        });
+      });
+
+      expect(rootSignal!.aborted).toBe(true);
+      expect(childSignal!.aborted).toBe(true);
+      expect(result.current.operations[rootId].status).toBe('cancelled');
+      expect(result.current.operations[childId].status).toBe('cancelled');
+      expect(result.current.operations[otherTopicId].status).toBe('running');
+    });
+
+    it('includes a pending automatic retry', () => {
+      const { result } = renderHook(() => useChatStore());
+      const context = { agentId: 'agent-1', topicId: 'topic-1' };
+      let retryId = '';
+
+      act(() => {
+        retryId = result.current.startOperation({
+          context,
+          type: 'autoRetryPending',
+        }).operationId;
+      });
+
+      expect(
+        operationSelectors.getRunningInputLoadingOperationIds(context)(result.current),
+      ).toEqual([retryId]);
+    });
+  });
+
   describe('getOperationsByType', () => {
     it('should return operations of specific type', () => {
       const { result } = renderHook(() => useChatStore());

--- a/src/store/chat/slices/operation/selectors.ts
+++ b/src/store/chat/slices/operation/selectors.ts
@@ -307,6 +307,23 @@ const isAgentRuntimeVisiblyRunningByContext =
   };
 
 /**
+ * Get all running operations that keep the conversation input in its loading state.
+ *
+ * This deliberately resolves operations through the canonical conversation key rather
+ * than comparing raw context fields. Group operations may be owned by a member agent
+ * while the visible conversation uses the supervisor; the group bucket is still shared.
+ */
+const getRunningInputLoadingOperationIds =
+  (context: MessageMapKeyInput) =>
+  (s: ChatStoreState): string[] => {
+    if (!context.agentId && !context.groupId) return [];
+
+    return getOperationsByContext(context)(s)
+      .filter((op) => INPUT_LOADING_OPERATION_TYPES.includes(op.type) && op.status === 'running')
+      .map((op) => op.id);
+  };
+
+/**
  * All live queue-blocking operation ids in a context (see
  * `isQueueBlockingOperation` — the same predicate the enqueue check uses, so
  * "Send now" cancels exactly what a fresh send would have queued behind and
@@ -932,6 +949,7 @@ export const operationSelectors = {
   getOperationsByMessage,
   getOperationsByType,
   getRunningOperations,
+  getRunningInputLoadingOperationIds,
   getRunningQueueBlockingOperationIds,
   getRunningToolCallStartTime,
   hasAnyRunningOperation,


### PR DESCRIPTION
Fixes a group-chat cancellation mismatch in `stopGenerating`.

Group operations can be started under a member agent with no explicit scope, while the visible conversation uses the supervisor agent and `scope: group`. Both contexts resolve to the same canonical group/topic operation bucket, but the previous field-by-field `cancelOperations` filter matched no running operation. The Stop button therefore left the root AbortController and its child operations running.

This change resolves running input-loading operations through the same canonical conversation key used by the operation index and loading UI, then cancels each root through `cancelOperation` so child operations and their AbortSignals are recursively cancelled.

No visual UI change.

| Before | After |
| ------ | ----- |
| Stop can miss a member-owned group operation when the visible supervisor context has a different `agentId` / `scope` shape. | Stop resolves the shared group/topic bucket and aborts the root and child operations without affecting another topic. |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands:

```bash
bunx vitest run src/features/Conversation/store/slices/generation/action.test.ts src/store/chat/slices/operation/__tests__/selectors.test.ts src/store/chat/slices/agentRun/actions/__tests__/cancel-functionality.test.ts src/store/chat/agents/transports/ClientLLMTransport.test.ts
bunx eslint src/features/Conversation/store/slices/generation/action.ts src/features/Conversation/store/slices/generation/action.test.ts src/store/chat/slices/operation/selectors.ts src/store/chat/slices/operation/__tests__/selectors.test.ts
```

Result: 4 test files passed, 110 tests passed; ESLint passed.

Coverage includes:

- reproducing the old exact-filter miss for member-agent vs supervisor-agent group contexts;
- verifying canonical-key resolution finds the running root operation;
- aborting root and child signals recursively;
- preserving an operation in another topic;
- including pending automatic retries in stoppable input-loading operations.

#### 🔗 Related Issue

No existing issue linked.
