### PR TITLE
🐛 fix(chat): enable document selection in mobile attachment picker

### DIFF
--- a/e2e/src/features/home/chat-input.feature
+++ b/e2e/src/features/home/chat-input.feature
@@ -12,3 +12,9 @@ Feature: Home 页面默认 Chat Input 发送链路
     And 用户按 Enter 从 Home 默认输入发送
     Then 页面应该跳转到新建 Topic 对话页面
     And 用户消息 "cold route home message" 应该保留在对话中
+
+  @HOME-CHAT-UPLOAD-001 @P1
+  Scenario: 聊天附件选择器应向移动宿主声明通用文件类型
+    Given 用户打开 Home 页面
+    When 用户打开聊天输入框的附件菜单
+    Then 文件选择控件应声明接受所有文件类型

--- a/e2e/src/steps/home/chat-input.steps.ts
+++ b/e2e/src/steps/home/chat-input.steps.ts
@@ -46,10 +46,12 @@ Given('用户打开 Home 页面', async function (this: CustomWorld) {
 
 When('用户打开聊天输入框的附件菜单', async function (this: CustomWorld) {
   const chatInput = this.page.locator('[data-testid="chat-input"]').first();
-  const plusButton = chatInput.locator('button:has(svg.lucide-plus)').first();
+  const plusAction = chatInput
+    .locator('[role="button"][aria-haspopup="menu"]:has(svg.lucide-plus)')
+    .first();
 
-  await expect(plusButton).toBeVisible({ timeout: WAIT_TIMEOUT });
-  await plusButton.click();
+  await expect(plusAction).toBeVisible({ timeout: WAIT_TIMEOUT });
+  await plusAction.click();
 
   const menu = this.page.locator('[role="menu"]').first();
   await expect(menu).toBeVisible({ timeout: WAIT_TIMEOUT });

--- a/e2e/src/steps/home/chat-input.steps.ts
+++ b/e2e/src/steps/home/chat-input.steps.ts
@@ -36,6 +36,44 @@ const focusHomeChatInput = async (world: CustomWorld): Promise<void> => {
   throw new Error('Could not find a visible Home chat input to focus');
 };
 
+Given('用户打开 Home 页面', async function (this: CustomWorld) {
+  await this.page.goto('/');
+
+  await expect(this.page.locator('[data-testid="chat-input"]').first()).toBeVisible({
+    timeout: WAIT_TIMEOUT,
+  });
+});
+
+When('用户打开聊天输入框的附件菜单', async function (this: CustomWorld) {
+  const chatInput = this.page.locator('[data-testid="chat-input"]').first();
+  const plusButton = chatInput.locator('button:has(svg.lucide-plus)').first();
+
+  await expect(plusButton).toBeVisible({ timeout: WAIT_TIMEOUT });
+  await plusButton.click();
+
+  const menu = this.page.locator('[role="menu"]').first();
+  await expect(menu).toBeVisible({ timeout: WAIT_TIMEOUT });
+
+  const fileInput = this.page.locator('[role="menu"] input[type="file"]');
+
+  if ((await fileInput.count()) === 0) {
+    const attachmentsItem = this.page
+      .locator('[role="menuitem"]:has(svg.lucide-library-big)')
+      .first();
+
+    await expect(attachmentsItem).toBeVisible({ timeout: WAIT_TIMEOUT });
+    await attachmentsItem.hover();
+  }
+});
+
+Then('文件选择控件应声明接受所有文件类型', async function (this: CustomWorld) {
+  const fileInput = this.page.locator('[role="menu"] input[type="file"]').first();
+
+  await expect(fileInput).toHaveAttribute('accept', '*/*', {
+    timeout: WAIT_TIMEOUT,
+  });
+});
+
 Given(
   '用户在冷启动 Home 页面并延迟 Agent 路由加载',
   { timeout: 45_000 },

--- a/src/features/ChatInput/ActionBar/Plus/index.tsx
+++ b/src/features/ChatInput/ActionBar/Plus/index.tsx
@@ -480,6 +480,7 @@ const usePlusMenuItems = ({ close }: { close: () => void }): ActionDropdownMenuI
         label: (
           <Upload
             multiple
+            accept={'*/*'}
             showUploadList={false}
             beforeUpload={async (file) => {
               if (file.type.startsWith('image') && !canUploadImage) return false;


### PR DESCRIPTION
Explicitly declare a generic MIME type on the chat attachment upload input so native iOS and Android WebViews can expose the system file picker instead of limiting users to media sources. Existing upload validation remains unchanged.

| Before | After |
| ------ | ----- |
| Mobile native clients may only expose photo/media sources for chat attachments. | The upload input declares `*/*`, allowing the native host to expose its general document picker. |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation performed:

- `bun run check src/features/ChatInput/ActionBar/Plus/index.tsx e2e/src/features/home/chat-input.feature e2e/src/steps/home/chat-input.steps.ts --lint --test`
- `bun run build:spa:mobile`
- `bunx cucumber-js --config cucumber.config.js --tags '@HOME-CHAT-UPLOAD-001' --dry-run`
- `cd e2e && bun run test:unit` (6 tests passed)

Pending before marking ready:

- Verify the native document picker on physical iOS and Android clients.
- Full `bun run type-check` is currently blocked locally by pre-existing workspace dependency/generated-type errors unrelated to these files; the mobile production build succeeds.

#### 🔗 Related Issue

Fixes #18127
