### PR TITLE
🐛 fix(userMemories): return capturedAt in list queries

### DIFF
--- a/packages/database/src/models/userMemory/__tests__/model.test.ts
+++ b/packages/database/src/models/userMemory/__tests__/model.test.ts
@@ -531,12 +531,11 @@ describe('UserMemoryModel', () => {
 
         const result = await memoryModel.queryMemories({ layer: LayersEnum.Context });
 
-        expect(result.items).toMatchObject([
-          {
-            context: { capturedAt },
-            layer: LayersEnum.Context,
-          },
-        ]);
+        const [item] = result.items;
+        expect(item?.layer).toBe(LayersEnum.Context);
+        if (item?.layer === LayersEnum.Context) {
+          expect(item.context.capturedAt).toEqual(capturedAt);
+        }
       });
 
       // BM25 search requires pg_search extension (ParadeDB), not available in PGlite
@@ -589,12 +588,11 @@ describe('UserMemoryModel', () => {
 
         const result = await memoryModel.queryMemories({ layer: LayersEnum.Experience });
 
-        expect(result.items).toMatchObject([
-          {
-            experience: { capturedAt },
-            layer: LayersEnum.Experience,
-          },
-        ]);
+        const [item] = result.items;
+        expect(item?.layer).toBe(LayersEnum.Experience);
+        if (item?.layer === LayersEnum.Experience) {
+          expect(item.experience.capturedAt).toEqual(capturedAt);
+        }
       });
     });
 
@@ -625,12 +623,11 @@ describe('UserMemoryModel', () => {
 
         const result = await memoryModel.queryMemories({ layer: LayersEnum.Preference });
 
-        expect(result.items).toMatchObject([
-          {
-            layer: LayersEnum.Preference,
-            preference: { capturedAt },
-          },
-        ]);
+        const [item] = result.items;
+        expect(item?.layer).toBe(LayersEnum.Preference);
+        if (item?.layer === LayersEnum.Preference) {
+          expect(item.preference.capturedAt).toEqual(capturedAt);
+        }
       });
     });
 

--- a/packages/database/src/models/userMemory/__tests__/model.test.ts
+++ b/packages/database/src/models/userMemory/__tests__/model.test.ts
@@ -87,6 +87,7 @@ async function createIdentityPair(opts: {
 // Helper to create a base memory + experience pair
 async function createExperiencePair(opts?: {
   action?: string;
+  capturedAt?: Date;
   possibleOutcome?: string;
   reasoning?: string;
   tags?: string[];
@@ -112,6 +113,7 @@ async function createExperiencePair(opts?: {
     .insert(userMemoriesExperiences)
     .values({
       action: opts?.action ?? 'did something',
+      capturedAt: opts?.capturedAt,
       keyLearning: 'learned stuff',
       possibleOutcome: opts?.possibleOutcome ?? 'better outcomes',
       reasoning: opts?.reasoning ?? 'careful reasoning',
@@ -128,6 +130,7 @@ async function createExperiencePair(opts?: {
 
 // Helper to create a base memory + preference pair
 async function createPreferencePair(opts?: {
+  capturedAt?: Date;
   conclusionDirectives?: string;
   suggestions?: string;
   tags?: string[];
@@ -152,6 +155,7 @@ async function createPreferencePair(opts?: {
   const [pref] = await serverDB
     .insert(userMemoriesPreferences)
     .values({
+      capturedAt: opts?.capturedAt,
       conclusionDirectives: opts?.conclusionDirectives ?? 'use dark mode',
       suggestions: opts?.suggestions ?? 'keep it concise',
       tags: opts?.tags,
@@ -215,6 +219,7 @@ async function createActivityPair(opts?: {
 async function createContextPair(opts?: {
   associatedObjectName?: string;
   associatedSubjectName?: string;
+  capturedAt?: Date;
   description?: string;
   tags?: string[];
   title?: string;
@@ -245,6 +250,7 @@ async function createContextPair(opts?: {
       associatedSubjects: opts?.associatedSubjectName
         ? [{ name: opts.associatedSubjectName, type: 'person' }]
         : [],
+      capturedAt: opts?.capturedAt,
       description: opts?.description ?? 'A context description',
       tags: opts?.tags,
       title: opts?.title ?? 'A context',
@@ -519,6 +525,20 @@ describe('UserMemoryModel', () => {
         expect(result.total).toBe(2);
       });
 
+      it('should return context capturedAt', async () => {
+        const capturedAt = new Date('2024-01-15T10:00:00.000Z');
+        await createContextPair({ capturedAt });
+
+        const result = await memoryModel.queryMemories({ layer: LayersEnum.Context });
+
+        expect(result.items).toMatchObject([
+          {
+            context: { capturedAt },
+            layer: LayersEnum.Context,
+          },
+        ]);
+      });
+
       // BM25 search requires pg_search extension (ParadeDB), not available in PGlite
       const isServerDB = process.env.TEST_SERVER_DB === '1';
       it.skipIf(!isServerDB)('should filter by text query', async () => {
@@ -562,6 +582,20 @@ describe('UserMemoryModel', () => {
         expect(result.items.length).toBe(1);
         expect(result.total).toBe(1);
       });
+
+      it('should return experience capturedAt', async () => {
+        const capturedAt = new Date('2024-01-16T10:00:00.000Z');
+        await createExperiencePair({ capturedAt });
+
+        const result = await memoryModel.queryMemories({ layer: LayersEnum.Experience });
+
+        expect(result.items).toMatchObject([
+          {
+            experience: { capturedAt },
+            layer: LayersEnum.Experience,
+          },
+        ]);
+      });
     });
 
     describe('identity layer', () => {
@@ -583,6 +617,20 @@ describe('UserMemoryModel', () => {
 
         expect(result.items.length).toBe(1);
         expect(result.total).toBe(1);
+      });
+
+      it('should return preference capturedAt', async () => {
+        const capturedAt = new Date('2024-01-17T10:00:00.000Z');
+        await createPreferencePair({ capturedAt });
+
+        const result = await memoryModel.queryMemories({ layer: LayersEnum.Preference });
+
+        expect(result.items).toMatchObject([
+          {
+            layer: LayersEnum.Preference,
+            preference: { capturedAt },
+          },
+        ]);
       });
     });
 

--- a/packages/database/src/models/userMemory/model.ts
+++ b/packages/database/src/models/userMemory/model.ts
@@ -1091,6 +1091,7 @@ export class UserMemoryModel {
           .select({
             context: {
               accessedAt: userMemoriesContexts.accessedAt,
+              capturedAt: userMemoriesContexts.capturedAt,
               createdAt: userMemoriesContexts.createdAt,
               currentStatus: userMemoriesContexts.currentStatus,
               description: userMemoriesContexts.description,
@@ -1306,6 +1307,7 @@ export class UserMemoryModel {
             experience: {
               accessedAt: userMemoriesExperiences.accessedAt,
               action: userMemoriesExperiences.action,
+              capturedAt: userMemoriesExperiences.capturedAt,
               createdAt: userMemoriesExperiences.createdAt,
               id: userMemoriesExperiences.id,
               keyLearning: userMemoriesExperiences.keyLearning,
@@ -1498,6 +1500,7 @@ export class UserMemoryModel {
             memory: baseSelection,
             preference: {
               accessedAt: userMemoriesPreferences.accessedAt,
+              capturedAt: userMemoriesPreferences.capturedAt,
               conclusionDirectives: userMemoriesPreferences.conclusionDirectives,
               createdAt: userMemoriesPreferences.createdAt,
               id: userMemoriesPreferences.id,

--- a/packages/types/src/userMemory/identity.ts
+++ b/packages/types/src/userMemory/identity.ts
@@ -48,7 +48,8 @@ export interface UserMemoryIdentity {
 
 export type UserMemoryIdentityWithoutVectors = Omit<UserMemoryIdentity, 'descriptionVector'>;
 
-export type UserMemoryIdentitiesListItem = UserMemoryIdentityWithoutVectors;
+export type UserMemoryIdentitiesListItem = UserMemoryIdentityWithoutVectors &
+  Pick<BaseListItem, 'capturedAt'>;
 
 export interface NewUserMemoryIdentity {
   description?: string;

--- a/packages/types/src/userMemory/layers.ts
+++ b/packages/types/src/userMemory/layers.ts
@@ -1,3 +1,5 @@
+import type { BaseListItem } from './shared';
+
 export interface UserMemoryTimestamps {
   accessedAt: Date;
   createdAt: Date;
@@ -80,7 +82,8 @@ export type UserMemoryContextWithoutVectors = Omit<
 export type UserMemoryContextsListItem = Omit<
   UserMemoryContextWithoutVectors,
   'associatedObjects' | 'associatedSubjects'
->;
+> &
+  Pick<BaseListItem, 'capturedAt'>;
 
 export interface UserMemoryExperience extends UserMemoryTimestamps {
   action: string | null;
@@ -108,7 +111,8 @@ export type UserMemoryExperienceWithoutVectors = Omit<
 export type UserMemoryExperiencesListItem = Omit<
   UserMemoryExperienceWithoutVectors,
   'possibleOutcome' | 'reasoning'
->;
+> &
+  Pick<BaseListItem, 'capturedAt'>;
 
 export interface UserMemoryPreference extends UserMemoryTimestamps {
   conclusionDirectives: string | null;
@@ -128,7 +132,11 @@ export type UserMemoryPreferenceWithoutVectors = Omit<
   'conclusionDirectivesVector'
 >;
 
-export type UserMemoryPreferencesListItem = Omit<UserMemoryPreferenceWithoutVectors, 'suggestions'>;
+export type UserMemoryPreferencesListItem = Omit<
+  UserMemoryPreferenceWithoutVectors,
+  'suggestions'
+> &
+  Pick<BaseListItem, 'capturedAt'>;
 
 export interface UserMemoryActivity extends UserMemoryTimestamps {
   associatedLocations: UserMemoryAssociatedLocation[] | null;
@@ -159,4 +167,5 @@ export type UserMemoryActivityWithoutVectors = Omit<
 export type UserMemoryActivitiesListItem = Omit<
   UserMemoryActivityWithoutVectors,
   'feedback' | 'narrative' | 'notes'
->;
+> &
+  Pick<BaseListItem, 'capturedAt'>;


### PR DESCRIPTION
Fixes #18148

## Changes

- Return `capturedAt` from the context branch of `UserMemoryModel.queryMemories`.
- Return `capturedAt` from the preference branch of `UserMemoryModel.queryMemories`.
- Return `capturedAt` from the experience branch for consistency with its list UI and sorting behavior.
- Add database regression tests with historical capture timestamps for all three layers.

This prevents memory cards from falling back to their update or batch-insertion dates when the original capture time is available.

| Before | After |
| ------ | ----- |
| Context, preference, and experience list responses omitted the layer-level `capturedAt`. | List responses include the stored layer-level `capturedAt`. |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd packages/database
bunx vitest run --silent='passed-only' 'src/models/userMemory/__tests__/model.test.ts'

cd ../..
bun run check packages/database/src/models/userMemory/model.ts packages/database/src/models/userMemory/__tests__/model.test.ts
bun run check --type
```

#### 🔗 Related Issue

Fixes #18148