### PR TITLE
✨ feat: add versioned onboarding metrics

### DIFF
--- a/src/services/onboardingMetrics/index.test.ts
+++ b/src/services/onboardingMetrics/index.test.ts
@@ -7,6 +7,7 @@ import {
   trackOnboardingCompleted,
   trackOnboardingMarketplacePicked,
   trackOnboardingMarketplaceShown,
+  trackOnboardingStarted,
   trackOnboardingStepCompleted,
   trackOnboardingStepViewed,
 } from './index';
@@ -80,6 +81,24 @@ describe('onboardingMetrics', () => {
         spm: ONBOARDING_METRICS_SPM.STEP_VIEWED,
         step: 'telemetry',
         stepIndex: 1,
+      },
+    });
+  });
+
+  it('fires onboarding_started with the versioned session context', () => {
+    trackOnboardingStarted({
+      flow: 'web',
+      onboarding_session_id: 'session-1',
+      onboarding_version: 2,
+    });
+
+    expect(track).toHaveBeenCalledWith({
+      name: ONBOARDING_METRICS_EVENTS.STARTED,
+      properties: {
+        flow: 'web',
+        onboarding_session_id: 'session-1',
+        onboarding_version: 2,
+        spm: ONBOARDING_METRICS_SPM.STARTED,
       },
     });
   });

--- a/src/services/onboardingMetrics/index.test.ts
+++ b/src/services/onboardingMetrics/index.test.ts
@@ -7,9 +7,14 @@ import {
   trackOnboardingCompleted,
   trackOnboardingMarketplacePicked,
   trackOnboardingMarketplaceShown,
+  trackOnboardingProfileConfirmed,
+  trackOnboardingProfileViewed,
   trackOnboardingStarted,
   trackOnboardingStepCompleted,
   trackOnboardingStepViewed,
+  trackOnboardingUnderstandingCompleted,
+  trackOnboardingUnderstandingProgress,
+  trackOnboardingUnderstandingStarted,
 } from './index';
 
 const analyticsMocks = vi.hoisted(() => ({
@@ -140,6 +145,74 @@ describe('onboardingMetrics', () => {
         spm: ONBOARDING_METRICS_SPM.COMPLETED,
         targetUrl: '/',
       },
+    });
+  });
+
+  it('fires understanding lifecycle and profile interaction events without profile content', () => {
+    const context = {
+      flow: 'web' as const,
+      onboarding_session_id: 'onboarding-session-1',
+      onboarding_version: 2,
+      understanding_session_id: 'understanding-session-1',
+    };
+
+    trackOnboardingUnderstandingStarted(context);
+    trackOnboardingUnderstandingProgress({
+      ...context,
+      collect_sources_status: 'completed',
+      detailed_persona_status: 'running',
+      phase: 'generating-detailed-persona',
+      task_recommendations_status: 'pending',
+      understanding_status: 'completed',
+    });
+    trackOnboardingUnderstandingCompleted({
+      ...context,
+      duration_ms: 2400,
+      profile_available: true,
+      source_count: 2,
+      source_failed_count: 0,
+      source_succeeded_count: 2,
+      status: 'completed',
+    });
+    trackOnboardingProfileViewed(context);
+    trackOnboardingProfileConfirmed(context);
+
+    expect(track).toHaveBeenNthCalledWith(1, {
+      name: ONBOARDING_METRICS_EVENTS.UNDERSTANDING_STARTED,
+      properties: { ...context, spm: ONBOARDING_METRICS_SPM.UNDERSTANDING_STARTED },
+    });
+    expect(track).toHaveBeenNthCalledWith(2, {
+      name: ONBOARDING_METRICS_EVENTS.UNDERSTANDING_PROGRESS,
+      properties: {
+        ...context,
+        collect_sources_status: 'completed',
+        detailed_persona_status: 'running',
+        phase: 'generating-detailed-persona',
+        spm: ONBOARDING_METRICS_SPM.UNDERSTANDING_PROGRESS,
+        task_recommendations_status: 'pending',
+        understanding_status: 'completed',
+      },
+    });
+    expect(track).toHaveBeenNthCalledWith(3, {
+      name: ONBOARDING_METRICS_EVENTS.UNDERSTANDING_COMPLETED,
+      properties: {
+        ...context,
+        duration_ms: 2400,
+        profile_available: true,
+        source_count: 2,
+        source_failed_count: 0,
+        source_succeeded_count: 2,
+        spm: ONBOARDING_METRICS_SPM.UNDERSTANDING_COMPLETED,
+        status: 'completed',
+      },
+    });
+    expect(track).toHaveBeenNthCalledWith(4, {
+      name: ONBOARDING_METRICS_EVENTS.PROFILE_VIEWED,
+      properties: { ...context, spm: ONBOARDING_METRICS_SPM.PROFILE_VIEWED },
+    });
+    expect(track).toHaveBeenNthCalledWith(5, {
+      name: ONBOARDING_METRICS_EVENTS.PROFILE_CONFIRMED,
+      properties: { ...context, spm: ONBOARDING_METRICS_SPM.PROFILE_CONFIRMED },
     });
   });
 

--- a/src/services/onboardingMetrics/index.ts
+++ b/src/services/onboardingMetrics/index.ts
@@ -4,6 +4,7 @@ export const ONBOARDING_METRICS_EVENTS = {
   COMPLETED: 'onboarding_completed',
   MARKETPLACE_PICKED: 'onboarding_marketplace_picked',
   MARKETPLACE_SHOWN: 'onboarding_marketplace_shown',
+  STARTED: 'onboarding_started',
   STEP_COMPLETED: 'onboarding_step_completed',
   STEP_VIEWED: 'onboarding_step_viewed',
 } as const;
@@ -12,6 +13,7 @@ export const ONBOARDING_METRICS_SPM = {
   COMPLETED: 'onboarding.completed',
   MARKETPLACE_PICKED: 'onboarding.marketplace.picked',
   MARKETPLACE_SHOWN: 'onboarding.marketplace.shown',
+  STARTED: 'onboarding.started',
   STEP_COMPLETED: 'onboarding.step.completed',
   STEP_VIEWED: 'onboarding.step.viewed',
 } as const;
@@ -57,13 +59,23 @@ export type OnboardingStep =
 
 export interface OnboardingStepPayload extends Record<string, unknown> {
   flow: OnboardingFlow;
+  onboarding_session_id?: string;
+  onboarding_version?: number;
   skipped?: boolean;
   step: OnboardingStep;
   stepIndex?: number;
 }
 
+export interface OnboardingStartedPayload extends Record<string, unknown> {
+  flow: Exclude<OnboardingFlow, 'common'>;
+  onboarding_session_id: string;
+  onboarding_version: number;
+}
+
 export interface OnboardingCompletedPayload extends Record<string, unknown> {
   flow: Exclude<OnboardingFlow, 'common'>;
+  onboarding_session_id?: string;
+  onboarding_version?: number;
   skipped?: boolean;
   targetUrl?: string;
 }
@@ -72,6 +84,13 @@ export const trackOnboardingStepViewed = (payload: OnboardingStepPayload): void 
   emit(ONBOARDING_METRICS_EVENTS.STEP_VIEWED, {
     ...payload,
     spm: ONBOARDING_METRICS_SPM.STEP_VIEWED,
+  });
+};
+
+export const trackOnboardingStarted = (payload: OnboardingStartedPayload): void => {
+  emit(ONBOARDING_METRICS_EVENTS.STARTED, {
+    ...payload,
+    spm: ONBOARDING_METRICS_SPM.STARTED,
   });
 };
 

--- a/src/services/onboardingMetrics/index.ts
+++ b/src/services/onboardingMetrics/index.ts
@@ -4,18 +4,28 @@ export const ONBOARDING_METRICS_EVENTS = {
   COMPLETED: 'onboarding_completed',
   MARKETPLACE_PICKED: 'onboarding_marketplace_picked',
   MARKETPLACE_SHOWN: 'onboarding_marketplace_shown',
+  PROFILE_CONFIRMED: 'onboarding_profile_confirmed',
+  PROFILE_VIEWED: 'onboarding_profile_viewed',
   STARTED: 'onboarding_started',
   STEP_COMPLETED: 'onboarding_step_completed',
   STEP_VIEWED: 'onboarding_step_viewed',
+  UNDERSTANDING_COMPLETED: 'onboarding_understanding_completed',
+  UNDERSTANDING_PROGRESS: 'onboarding_understanding_progress',
+  UNDERSTANDING_STARTED: 'onboarding_understanding_started',
 } as const;
 
 export const ONBOARDING_METRICS_SPM = {
   COMPLETED: 'onboarding.completed',
   MARKETPLACE_PICKED: 'onboarding.marketplace.picked',
   MARKETPLACE_SHOWN: 'onboarding.marketplace.shown',
+  PROFILE_CONFIRMED: 'onboarding.profile.confirmed',
+  PROFILE_VIEWED: 'onboarding.profile.viewed',
   STARTED: 'onboarding.started',
   STEP_COMPLETED: 'onboarding.step.completed',
   STEP_VIEWED: 'onboarding.step.viewed',
+  UNDERSTANDING_COMPLETED: 'onboarding.understanding.completed',
+  UNDERSTANDING_PROGRESS: 'onboarding.understanding.progress',
+  UNDERSTANDING_STARTED: 'onboarding.understanding.started',
 } as const;
 
 interface AnalyticsLike {
@@ -80,6 +90,58 @@ export interface OnboardingCompletedPayload extends Record<string, unknown> {
   targetUrl?: string;
 }
 
+export type OnboardingUnderstandingProgressPhase =
+  | 'collecting-sources'
+  | 'generating-understanding'
+  | 'generating-detailed-persona'
+  | 'recommending-tasks'
+  | 'completed'
+  | 'partial'
+  | 'failed';
+
+export type OnboardingUnderstandingStepStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+export type OnboardingUnderstandingTerminalStatus = 'completed' | 'partial' | 'failed';
+
+export interface OnboardingUnderstandingStartedPayload extends Record<string, unknown> {
+  flow: Exclude<OnboardingFlow, 'common'>;
+  onboarding_session_id: string;
+  onboarding_version: number;
+  understanding_session_id: string;
+}
+
+export interface OnboardingUnderstandingProgressPayload extends Record<string, unknown> {
+  collect_sources_status: OnboardingUnderstandingStepStatus;
+  detailed_persona_status: OnboardingUnderstandingStepStatus;
+  flow: Exclude<OnboardingFlow, 'common'>;
+  onboarding_session_id: string;
+  onboarding_version: number;
+  phase: OnboardingUnderstandingProgressPhase;
+  task_recommendations_status: OnboardingUnderstandingStepStatus;
+  understanding_session_id: string;
+  understanding_status: OnboardingUnderstandingStepStatus;
+}
+
+export interface OnboardingUnderstandingCompletedPayload extends Record<string, unknown> {
+  duration_ms?: number;
+  flow: Exclude<OnboardingFlow, 'common'>;
+  onboarding_session_id: string;
+  onboarding_version: number;
+  profile_available?: boolean;
+  source_count?: number;
+  source_failed_count?: number;
+  source_succeeded_count?: number;
+  status: OnboardingUnderstandingTerminalStatus;
+  understanding_session_id: string;
+}
+
+export interface OnboardingProfilePayload extends Record<string, unknown> {
+  flow: Exclude<OnboardingFlow, 'common'>;
+  onboarding_session_id: string;
+  onboarding_version: number;
+  understanding_session_id: string;
+}
+
 export const trackOnboardingStepViewed = (payload: OnboardingStepPayload): void => {
   emit(ONBOARDING_METRICS_EVENTS.STEP_VIEWED, {
     ...payload,
@@ -105,6 +167,47 @@ export const trackOnboardingCompleted = (payload: OnboardingCompletedPayload): v
   emit(ONBOARDING_METRICS_EVENTS.COMPLETED, {
     ...payload,
     spm: ONBOARDING_METRICS_SPM.COMPLETED,
+  });
+};
+
+export const trackOnboardingUnderstandingStarted = (
+  payload: OnboardingUnderstandingStartedPayload,
+): void => {
+  emit(ONBOARDING_METRICS_EVENTS.UNDERSTANDING_STARTED, {
+    ...payload,
+    spm: ONBOARDING_METRICS_SPM.UNDERSTANDING_STARTED,
+  });
+};
+
+export const trackOnboardingUnderstandingProgress = (
+  payload: OnboardingUnderstandingProgressPayload,
+): void => {
+  emit(ONBOARDING_METRICS_EVENTS.UNDERSTANDING_PROGRESS, {
+    ...payload,
+    spm: ONBOARDING_METRICS_SPM.UNDERSTANDING_PROGRESS,
+  });
+};
+
+export const trackOnboardingUnderstandingCompleted = (
+  payload: OnboardingUnderstandingCompletedPayload,
+): void => {
+  emit(ONBOARDING_METRICS_EVENTS.UNDERSTANDING_COMPLETED, {
+    ...payload,
+    spm: ONBOARDING_METRICS_SPM.UNDERSTANDING_COMPLETED,
+  });
+};
+
+export const trackOnboardingProfileViewed = (payload: OnboardingProfilePayload): void => {
+  emit(ONBOARDING_METRICS_EVENTS.PROFILE_VIEWED, {
+    ...payload,
+    spm: ONBOARDING_METRICS_SPM.PROFILE_VIEWED,
+  });
+};
+
+export const trackOnboardingProfileConfirmed = (payload: OnboardingProfilePayload): void => {
+  emit(ONBOARDING_METRICS_EVENTS.PROFILE_CONFIRMED, {
+    ...payload,
+    spm: ONBOARDING_METRICS_SPM.PROFILE_CONFIRMED,
   });
 };
 


### PR DESCRIPTION
#### Test

- [x] Tested locally
- [x] Added/updated tests

Adds the generic onboarding_started event and versioned session context fields used by the Cloud onboarding analytics dashboard. No Cloud-specific business logic is included in the OSS package.