### PR TITLE
🐛 fix(deps): force katex to v0.18 via pnpm overrides to fix math rendering

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,7 @@ onlyBuiltDependencies:
 
 overrides:
   jose: ^6.1.3
+  katex: ^0.18.1
   stylelint-config-clean-order: 7.0.0
   pdfjs-dist: 5.4.530
   react: 19.2.4

--- a/tests/katex-regression.test.ts
+++ b/tests/katex-regression.test.ts
@@ -1,0 +1,33 @@
+import katex from 'katex';
+
+// The KaTeX stylesheet is injected at a fixed version by @lobehub/ui's ThemeProvider
+// (src/ThemeProvider/ThemeProvider.tsx → genCdnUrl({ pkg: 'katex', version: '0.18.1' })).
+// This repo must resolve the *renderer* to the same 0.18.x, enforced by the pnpm override
+// `katex: ^0.18.1` in pnpm-workspace.yaml.
+//
+// Without that override, remark-math@6 → micromark-extension-math@3.1.0 hard-resolves
+// katex to ^0.16 (0.16.47). The renderer then emits pre-0.18 class names (`.sizing`,
+// `.base`) that the 0.18 stylesheet no longer styles — breaking subscripts and large
+// operators exactly as reported. This test guards against that drift being reintroduced
+// by future dependency changes.
+const LOADED_CSS_VERSION = '0.18.1';
+const loadedMajorMinor = LOADED_CSS_VERSION.split('.').slice(0, 2).join('.');
+
+describe('katex renderer / stylesheet alignment', () => {
+  it('resolves a katex version matching the stylesheet @lobehub/ui loads', () => {
+    // Tolerate 0.18.x patch bumps (caret range) but fail if resolution drifts to 0.16.x.
+    expect(katex.version.startsWith(`${loadedMajorMinor}.`)).toBe(true);
+  });
+
+  it('renders subscripts and large operators with v0.18 class names', () => {
+    const html = katex.renderToString('x_i^2 + \\iint_{\\Sigma} f(x,y)\\,dx\\,dy', {
+      displayMode: true,
+      throwOnError: false,
+    });
+
+    // v0.18 prefixes its internal classes (`katex-sizing`, `katex-base`); v0.16 emitted
+    // bare `sizing`/`base` classes that the 0.18 stylesheet no longer matches.
+    expect(html).toContain('katex-sizing');
+    expect(html).not.toMatch(/\bclass="sizing\b/);
+  });
+});


### PR DESCRIPTION
## 问题

https://app.lobehub.com/share/t/oLuHdsuE

<img width="917" height="501" alt="image" src="https://github.com/user-attachments/assets/7d78aeb9-6fa1-4de9-833b-9d60a715a291" />

自托管 LobeHub（`lobehub/lobehub:2.2.13`）中 LaTeX 公式渲染错乱：角标/上下标尺寸异常、二重积分等大型算子符号排版错乱。

## 根因

KaTeX JS 渲染端与 CSS 版本错配：

- `@lobehub/ui` 的 `ThemeProvider` 硬编码加载 **katex 0.18.1** 的 CSS（`registry.npmmirror.com/katex/0.18.1/.../katex.min.css`）。
- 但渲染端 `katex` 走的是 `@lobehub/editor` → `remark-math@6` → `micromark-extension-math@3.1.0` 链路，该链路**硬依赖 `katex ^0.16.0`**，被解析为 `0.16.47`。
- 同一依赖树里同时存在 `katex@0.16.47` 与 `katex@0.18.1`，客户端 bundle 打包了被提升的 `0.16.47`；而 0.18.1 的 CSS 已把类名改为 `.katex-sizing.reset-size6.size3`，0.16.47 渲染出的旧类名 `.sizing.reset-size6.size3` 匹配不到任何字号规则 → 角标/积分排版错乱（两版本字体文件 SHA256 相同，非字体/网络问题）。

## 修复

在 `pnpm-workspace.yaml` 的 `overrides` 中强制 `katex: ^0.18.1`，让整棵依赖树（包括硬依赖 `^0.16` 的 `micromark-extension-math`）统一解析到 katex 0.18.1，CSS 与渲染端天然一致，杜绝版本漂移。

- 与上游 lobe-ui 的官方修复方式一致：commit `9be1bf97`（Innei，2026-07-26「⬆️ fix: upgrade katex to v0.18 and align class names」）在 lobe-ui 仓库中正是通过同样的 `overrides: katex: ^0.18.1` 实现。
- `micromark-extension-math` / `rehype-katex` 只调用 `katex.renderToString`，0.16→0.18 该 API 兼容，升级无破坏性变更。

## 关联

- 上游 lobe-ui 官方 katex 0.18 对齐提交：[`9be1bf97`](https://github.com/lobehub/lobe-ui/commit/9be1bf97ed3804c54e6d0031f39dd413326f48b9)（对应分支 `fix/katex-0.18`）
- 先前在上游 lobe-ui 的尝试（已关闭，改为本下游方案）：[lobehub/lobe-ui#607](https://github.com/lobehub/lobe-ui/pull/607)
- 相关已知问题：[lobehub/lobehub#18045](https://github.com/lobehub/lobehub/issues/18045)（LaTeX 编辑框与对话框渲染不一致）