### PR TITLE
🐛 fix(chat): make gateway thread execution race-safe

### DIFF
--- a/apps/cli/src/commands/notify.ts
+++ b/apps/cli/src/commands/notify.ts
@@ -21,6 +21,7 @@ export function registerNotifyCommand(program: Command) {
       '--message-id <messageId>',
       'When --role assistant: update an existing message instead of creating a new one (keeps a single bubble)',
     )
+    .option('--operation-id <operationId>', 'Remote agent operation generation')
     .option(
       '--continue',
       'When --role assistant: trigger a follow-up agent turn after writing the message',
@@ -33,6 +34,7 @@ export function registerNotifyCommand(program: Command) {
         continue?: boolean;
         json?: boolean;
         messageId?: string;
+        operationId?: string;
         role?: 'assistant' | 'user';
         threadId?: string;
         topic: string;
@@ -53,6 +55,7 @@ export function registerNotifyCommand(program: Command) {
             content: options.content,
             continue: options.continue,
             messageId: options.messageId,
+            operationId: options.operationId,
             role: options.role,
             threadId: options.threadId,
             topicId: options.topic,

--- a/apps/cli/src/tools/__tests__/heteroTask.test.ts
+++ b/apps/cli/src/tools/__tests__/heteroTask.test.ts
@@ -126,6 +126,7 @@ describe('runHeteroTask (openclaw)', () => {
 
     expect(messageArg).toContain('what time is it');
     expect(messageArg).toContain('lh notify');
+    expect(messageArg).toContain('--operation-id op-1');
     expect(messageArg).toContain('MSG_ID');
   });
 
@@ -377,6 +378,9 @@ describe('runHeteroTask (openclaw)', () => {
     for (const call of getTrpcClientMock.mock.calls) {
       expect(call[0]).toBe('ws-99');
     }
+    for (const call of notifyMutateMock.mock.calls) {
+      expect(call[0]).toEqual(expect.objectContaining({ operationId: 'op-ws-2' }));
+    }
   });
 });
 
@@ -419,6 +423,7 @@ describe('runHeteroTask (hermes)', () => {
     expect(notifyMutateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         content: 'session_id: part of the final answer\nHello from Hermes',
+        operationId: 'op-hermes-1',
         topicId: 'topic-hermes',
       }),
     );

--- a/apps/cli/src/tools/heteroTask.ts
+++ b/apps/cli/src/tools/heteroTask.ts
@@ -83,7 +83,7 @@ export interface CancelHeteroTaskParams {
 
 async function sendAutoNotify(
   topicId: string,
-  taskId: string,
+  operationId: string,
   text: string,
   agentId?: string,
   workspaceId?: string,
@@ -93,6 +93,7 @@ async function sendAutoNotify(
     await client.agentNotify.notify.mutate({
       agentId,
       content: text,
+      operationId,
       role: 'assistant',
       topicId,
     });
@@ -112,6 +113,7 @@ async function sendAutoNotify(
  */
 async function sendTerminalSignal(
   topicId: string,
+  operationId: string,
   agentId?: string,
   workspaceId?: string,
   error?: { message: string; type?: string },
@@ -123,6 +125,7 @@ async function sendTerminalSignal(
       content: '',
       done: true,
       ...(error ? { error } : {}),
+      operationId,
       role: 'assistant',
       topicId,
     });
@@ -135,7 +138,7 @@ async function sendTerminalSignal(
  * Build the notify protocol injected into the first message of a new hetero-agent session.
  * Tells the agent how to push updates back to the LobeHub user via `lh notify`.
  */
-function buildNotifyProtocol(lhPath: string, topicId: string): string {
+function buildNotifyProtocol(lhPath: string, topicId: string, operationId: string): string {
   return (
     `## Context: This task was dispatched by LobeHub\n\n` +
     `This conversation / task was sent to you by the **LobeHub platform** on behalf of a user. You are running as a background agent; the user is waiting for your response inside the LobeHub chat interface.\n\n` +
@@ -145,15 +148,15 @@ function buildNotifyProtocol(lhPath: string, topicId: string): string {
     `Use the \`${lhPath} notify\` command. All your updates appear as a **single message bubble** in the UI — create it once and update it in place.\n\n` +
     `**Step 1 — Open the bubble on your first meaningful update** (captures the messageId):\n` +
     `\`\`\`\n` +
-    `MSG_ID=$(${lhPath} notify --topic ${topicId} --role assistant --content "Starting..." --json | grep -o '"messageId":"[^"]*"' | cut -d'"' -f4)\n` +
+    `MSG_ID=$(${lhPath} notify --topic ${topicId} --operation-id ${operationId} --role assistant --content "Starting..." --json | grep -o '"messageId":"[^"]*"' | cut -d'"' -f4)\n` +
     `\`\`\`\n\n` +
     `**Step 2 — Update the same bubble as you make progress**:\n` +
     `\`\`\`\n` +
-    `${lhPath} notify --topic ${topicId} --role assistant --message-id "$MSG_ID" --content "Still working..."\n` +
+    `${lhPath} notify --topic ${topicId} --operation-id ${operationId} --role assistant --message-id "$MSG_ID" --content "Still working..."\n` +
     `\`\`\`\n\n` +
     `**Step 3 — Replace with your complete, final response when done**:\n` +
     `\`\`\`\n` +
-    `${lhPath} notify --topic ${topicId} --role assistant --message-id "$MSG_ID" --content "<your full response here>"\n` +
+    `${lhPath} notify --topic ${topicId} --operation-id ${operationId} --role assistant --message-id "$MSG_ID" --content "<your full response here>"\n` +
     `\`\`\`\n\n` +
     `Rules:\n` +
     `- Always use \`--json\` on the first call and capture \`messageId\` from the output.\n` +
@@ -193,7 +196,7 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
     // Always inject the notify protocol so openclaw knows how to report results
     // back to the LobeHub UI — even if the previous turn failed and the session
     // history was not cleanly committed.
-    const enrichedPrompt = `${prompt}\n\n${buildNotifyProtocol(lhPath, topicId)}`;
+    const enrichedPrompt = `${prompt}\n\n${buildNotifyProtocol(lhPath, topicId, operationId)}`;
 
     // Kill any existing openclaw process for this topicId before spawning a new one.
     // openclaw serialises session writes; a concurrent process holding the session
@@ -263,9 +266,10 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
           : `Task failed (exit code: ${code})`;
         // Write the notice bubble first, THEN signal terminal (sequential).
         // Fire-and-forget both, but ensure the terminal signal is always sent.
-        void sendAutoNotify(topicId, taskId, text, agentId, workspaceId).finally(() =>
+        void sendAutoNotify(topicId, operationId, text, agentId, workspaceId).finally(() =>
           sendTerminalSignal(
             topicId,
+            operationId,
             agentId,
             workspaceId,
             cancelled ? undefined : { message: text, type: 'HeteroProcessError' },
@@ -273,7 +277,7 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
         );
       } else {
         // Clean exit — openclaw already sent its final message; just signal done.
-        void sendTerminalSignal(topicId, agentId, workspaceId);
+        void sendTerminalSignal(topicId, operationId, agentId, workspaceId);
       }
     });
 
@@ -342,9 +346,10 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
         const text = cancelled
           ? `Task cancelled (signal: ${signal})`
           : `Task failed (exit code: ${code})`;
-        void sendAutoNotify(topicId, taskId, text, agentId, workspaceId).finally(() =>
+        void sendAutoNotify(topicId, operationId, text, agentId, workspaceId).finally(() =>
           sendTerminalSignal(
             topicId,
+            operationId,
             agentId,
             workspaceId,
             cancelled ? undefined : { message: text, type: 'HeteroProcessError' },
@@ -361,11 +366,11 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
       if (sessionId) saveHermesSessionId(topicId, sessionId);
 
       if (response) {
-        void sendAutoNotify(topicId, taskId, response, agentId, workspaceId).finally(() =>
-          sendTerminalSignal(topicId, agentId, workspaceId),
+        void sendAutoNotify(topicId, operationId, response, agentId, workspaceId).finally(() =>
+          sendTerminalSignal(topicId, operationId, agentId, workspaceId),
         );
       } else {
-        void sendTerminalSignal(topicId, agentId, workspaceId);
+        void sendTerminalSignal(topicId, operationId, agentId, workspaceId);
       }
     });
 

--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -44,7 +44,7 @@ function parseHermesSessionId(stderr: string): string | undefined {
  * Tells the agent binary how to push results back to the LobeHub chat UI via `lh notify`.
  * Ported directly from apps/cli/src/tools/heteroTask.ts so desktop and CLI stay in sync.
  */
-function buildNotifyProtocol(lhPath: string, topicId: string): string {
+function buildNotifyProtocol(lhPath: string, topicId: string, operationId: string): string {
   return (
     `## Context: This task was dispatched by LobeHub\n\n` +
     `This conversation / task was sent to you by the **LobeHub platform** on behalf of a user. You are running as a background agent; the user is waiting for your response inside the LobeHub chat interface.\n\n` +
@@ -54,15 +54,15 @@ function buildNotifyProtocol(lhPath: string, topicId: string): string {
     `Use the \`${lhPath} notify\` command. All your updates appear as a **single message bubble** in the UI — create it once and update it in place.\n\n` +
     `**Step 1 — Open the bubble on your first meaningful update** (captures the messageId):\n` +
     `\`\`\`\n` +
-    `MSG_ID=$(${lhPath} notify --topic ${topicId} --role assistant --content "Starting..." --json | grep -o '"messageId":"[^"]*"' | cut -d'"' -f4)\n` +
+    `MSG_ID=$(${lhPath} notify --topic ${topicId} --operation-id ${operationId} --role assistant --content "Starting..." --json | grep -o '"messageId":"[^"]*"' | cut -d'"' -f4)\n` +
     `\`\`\`\n\n` +
     `**Step 2 — Update the same bubble as you make progress**:\n` +
     `\`\`\`\n` +
-    `${lhPath} notify --topic ${topicId} --role assistant --message-id "$MSG_ID" --content "Still working..."\n` +
+    `${lhPath} notify --topic ${topicId} --operation-id ${operationId} --role assistant --message-id "$MSG_ID" --content "Still working..."\n` +
     `\`\`\`\n\n` +
     `**Step 3 — Replace with your complete, final response when done**:\n` +
     `\`\`\`\n` +
-    `${lhPath} notify --topic ${topicId} --role assistant --message-id "$MSG_ID" --content "<your full response here>"\n` +
+    `${lhPath} notify --topic ${topicId} --operation-id ${operationId} --role assistant --message-id "$MSG_ID" --content "<your full response here>"\n` +
     `\`\`\`\n\n` +
     `Rules:\n` +
     `- Always use \`--json\` on the first call and capture \`messageId\` from the output.\n` +
@@ -737,7 +737,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
       // Always inject the notify protocol so openclaw knows how to report results
       // back to the LobeHub UI — even if the previous turn failed and the session
       // history was not cleanly committed.
-      const enrichedPrompt = `${prompt}\n\n${buildNotifyProtocol(lhPath, topicId)}`;
+      const enrichedPrompt = `${prompt}\n\n${buildNotifyProtocol(lhPath, topicId, operationId)}`;
 
       // Kill any existing openclaw process for this topicId before spawning a new one.
       // openclaw serialises session writes; a concurrent process holding the session
@@ -802,6 +802,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
           void this.sendNotify({
             agentId,
             content: text,
+            operationId,
             role: 'assistant',
             topicId,
             workspaceId,
@@ -810,6 +811,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
               agentId,
               content: '',
               done: true,
+              operationId,
               role: 'assistant',
               topicId,
               workspaceId,
@@ -820,6 +822,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
             agentId,
             content: '',
             done: true,
+            operationId,
             role: 'assistant',
             topicId,
             workspaceId,
@@ -906,6 +909,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
           void this.sendNotify({
             agentId,
             content: text,
+            operationId,
             role: 'assistant',
             topicId,
             workspaceId,
@@ -914,6 +918,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
               agentId,
               content: '',
               done: true,
+              operationId,
               role: 'assistant',
               topicId,
               workspaceId,
@@ -933,6 +938,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
           void this.sendNotify({
             agentId,
             content: response,
+            operationId,
             role: 'assistant',
             topicId,
             workspaceId,
@@ -941,6 +947,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
               agentId,
               content: '',
               done: true,
+              operationId,
               role: 'assistant',
               topicId,
               workspaceId,
@@ -951,6 +958,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
             agentId,
             content: '',
             done: true,
+            operationId,
             role: 'assistant',
             topicId,
             workspaceId,
@@ -1049,6 +1057,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
     agentId?: string;
     content: string;
     done?: boolean;
+    operationId: string;
     role: string;
     topicId: string;
     /**

--- a/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
@@ -1070,6 +1070,7 @@ describe('GatewayConnectionCtr', () => {
       const messageArg = spawnArgs[spawnArgs.indexOf('--message') + 1];
       expect(messageArg).toContain('hello');
       expect(messageArg).toContain('lh notify');
+      expect(messageArg).toContain('--operation-id op-1');
     });
 
     it.each([
@@ -1377,6 +1378,7 @@ describe('GatewayConnectionCtr', () => {
         expect(notifySpy).toHaveBeenCalledWith(
           expect.objectContaining({
             content: 'session_id: part of the final answer\nHello from Hermes',
+            operationId: 'op-hermes-1',
             topicId: 'topic-hermes',
           }),
         );

--- a/apps/server/src/modules/AgentRuntime/adapters/ServerOperationStore.test.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerOperationStore.test.ts
@@ -5,8 +5,7 @@ import type { LobeChatDatabase } from '@/database/type';
 import { ServerOperationStore } from './ServerOperationStore';
 
 const topicMock = {
-  findById: vi.fn(),
-  updateMetadata: vi.fn(),
+  clearRunningOperationIfMatches: vi.fn(),
 };
 
 vi.mock('@/database/models/topic', () => ({
@@ -21,23 +20,17 @@ const createStore = (operationId: string | undefined, topicId: string | undefine
 const createTopiclessStore = () =>
   new ServerOperationStore(db, 'user-1', undefined, undefined, 'op-main');
 
-const markedWith = (operationId: string) => ({
-  metadata: { runningOperation: { assistantMessageId: 'asst-1', operationId } },
-});
-
 describe('ServerOperationStore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    topicMock.updateMetadata.mockResolvedValue(undefined);
+    topicMock.clearRunningOperationIfMatches.mockResolvedValue(true);
   });
 
   describe('clearRunningMark', () => {
     it('clears the mark when this operation owns it', async () => {
-      topicMock.findById.mockResolvedValue(markedWith('op-main'));
-
       await createStore('op-main').clearRunningMark();
 
-      expect(topicMock.updateMetadata).toHaveBeenCalledWith('topic-1', { runningOperation: null });
+      expect(topicMock.clearRunningOperationIfMatches).toHaveBeenCalledWith('topic-1', 'op-main');
     });
 
     it('leaves the mark alone when it belongs to another operation', async () => {
@@ -46,33 +39,23 @@ describe('ServerOperationStore', () => {
       // unconditional clear wiped the parent's reconnect anchor mid-run, so every
       // later client open saw no `runningOperation`, never opened a gateway
       // WebSocket, and rendered a frozen REST snapshot until the run ended.
-      topicMock.findById.mockResolvedValue(markedWith('op-parent'));
+      topicMock.clearRunningOperationIfMatches.mockResolvedValue(false);
 
       await createStore('op-child').clearRunningMark();
 
-      expect(topicMock.updateMetadata).not.toHaveBeenCalled();
+      expect(topicMock.clearRunningOperationIfMatches).toHaveBeenCalledWith('topic-1', 'op-child');
     });
 
-    it('is a no-op when the topic carries no mark', async () => {
-      topicMock.findById.mockResolvedValue({ metadata: {} });
-
-      await createStore('op-main').clearRunningMark();
-
-      expect(topicMock.updateMetadata).not.toHaveBeenCalled();
-    });
-
-    it('skips the lookup entirely without a topic', async () => {
+    it('skips the compare-and-clear entirely without a topic', async () => {
       await createTopiclessStore().clearRunningMark();
 
-      expect(topicMock.findById).not.toHaveBeenCalled();
-      expect(topicMock.updateMetadata).not.toHaveBeenCalled();
+      expect(topicMock.clearRunningOperationIfMatches).not.toHaveBeenCalled();
     });
 
-    it('swallows lookup failures — clearing the mark is best-effort', async () => {
-      topicMock.findById.mockRejectedValue(new Error('db down'));
+    it('swallows compare-and-clear failures — clearing the mark is best-effort', async () => {
+      topicMock.clearRunningOperationIfMatches.mockRejectedValue(new Error('db down'));
 
       await expect(createStore('op-main').clearRunningMark()).resolves.toBeUndefined();
-      expect(topicMock.updateMetadata).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/server/src/modules/AgentRuntime/adapters/ServerOperationStore.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerOperationStore.ts
@@ -33,15 +33,10 @@ export class ServerOperationStore implements OperationStore {
    * (`AbandonOperationService`).
    */
   async clearRunningMark(): Promise<void> {
-    if (!this.topicId || !this.userId) return;
+    if (!this.topicId || !this.userId || !this.operationId) return;
     try {
       const topicModel = new TopicModel(this.serverDB, this.userId, this.workspaceId);
-      const topic = await topicModel.findById(this.topicId);
-      const markedOperationId = topic?.metadata?.runningOperation?.operationId;
-      // No mark (already cleared) or someone else's mark — nothing of ours to drop.
-      if (!markedOperationId || markedOperationId !== this.operationId) return;
-
-      await topicModel.updateMetadata(this.topicId, { runningOperation: null });
+      await topicModel.clearRunningOperationIfMatches(this.topicId, this.operationId);
     } catch {
       // best-effort — swallow
     }

--- a/apps/server/src/routers/lambda/__tests__/agentNotify.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/agentNotify.test.ts
@@ -16,7 +16,7 @@ vi.mock('@/business/server/trpc-middlewares/rbacPermission', () => ({
 }));
 
 const mockTopicFindById = vi.fn();
-const mockTopicUpdateMetadata = vi.fn();
+const mockClearRunningOperationIfMatches = vi.fn();
 const mockMessageFindById = vi.fn();
 const mockMessageUpdate = vi.fn();
 const mockMessageCreate = vi.fn();
@@ -36,8 +36,8 @@ vi.mock('@/server/services/verify', async (orig) => ({
 
 vi.mock('@/database/models/topic', () => ({
   TopicModel: vi.fn(() => ({
+    clearRunningOperationIfMatches: mockClearRunningOperationIfMatches,
     findById: mockTopicFindById,
-    updateMetadata: mockTopicUpdateMetadata,
   })),
 }));
 vi.mock('@/database/models/message', () => ({
@@ -92,6 +92,7 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
       metadata: {
         runningOperation: {
           assistantMessageId: FINAL_MSG_ID,
+          heteroType: 'openclaw',
           hooks: [{ id: 'task-on-complete', type: 'onComplete', webhook: { url: '/wh' } }],
           operationId: OP,
         },
@@ -100,7 +101,7 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
     // The placeholder message holds the agent's final reply (written in-place
     // by earlier `lh notify` calls).
     mockMessageFindById.mockResolvedValue({ content: 'the final reply', topicId: TOPIC });
-    mockTopicUpdateMetadata.mockResolvedValue(undefined);
+    mockClearRunningOperationIfMatches.mockResolvedValue(true);
     // Default: a non-task op so the plan-instantiation guard no-ops unless a
     // test opts into a task-bound op.
     mockOpFindById.mockResolvedValue({ parentOperationId: null, taskId: null });
@@ -114,7 +115,13 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
   it('empty done signal finalizes success AND carries the final reply into the hooks', async () => {
     const { onComplete, onError } = registerHooks();
 
-    await createCaller().notify({ content: '', done: true, role: 'assistant', topicId: TOPIC });
+    await createCaller().notify({
+      content: '',
+      done: true,
+      operationId: OP,
+      role: 'assistant',
+      topicId: TOPIC,
+    });
 
     // Stream closed as success.
     expect(mockPublishAgentRuntimeEnd).toHaveBeenCalledWith(
@@ -135,7 +142,7 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
 
     // Running marker dropped so a duplicate done can't re-fire.
     await vi.waitFor(() =>
-      expect(mockTopicUpdateMetadata).toHaveBeenCalledWith(TOPIC, { runningOperation: null }),
+      expect(mockClearRunningOperationIfMatches).toHaveBeenCalledWith(TOPIC, OP),
     );
   });
 
@@ -148,7 +155,13 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
     const { onComplete } = registerHooks();
     mockOpFindById.mockResolvedValue({ parentOperationId: null, taskId: 'task-9' });
 
-    await createCaller().notify({ content: '', done: true, role: 'assistant', topicId: TOPIC });
+    await createCaller().notify({
+      content: '',
+      done: true,
+      operationId: OP,
+      role: 'assistant',
+      topicId: TOPIC,
+    });
 
     await vi.waitFor(() => expect(mockInstantiateVerifyPlan).toHaveBeenCalledTimes(1));
     // Ensured with the run's own operationId + taskId (3rd arg is the params object).
@@ -170,10 +183,16 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
     // path, not the start-side instantiation.
     mockOpFindById.mockResolvedValue({ parentOperationId: 'parent-op', taskId: 'task-9' });
 
-    await createCaller().notify({ content: '', done: true, role: 'assistant', topicId: TOPIC });
+    await createCaller().notify({
+      content: '',
+      done: true,
+      operationId: OP,
+      role: 'assistant',
+      topicId: TOPIC,
+    });
 
     await vi.waitFor(() =>
-      expect(mockTopicUpdateMetadata).toHaveBeenCalledWith(TOPIC, { runningOperation: null }),
+      expect(mockClearRunningOperationIfMatches).toHaveBeenCalledWith(TOPIC, OP),
     );
     expect(mockInstantiateVerifyPlan).not.toHaveBeenCalled();
   });
@@ -184,6 +203,7 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
     await createCaller().notify({
       content: '',
       error: { message: 'remote crashed', type: 'HeteroProcessError' },
+      operationId: OP,
       role: 'assistant',
       topicId: TOPIC,
     });
@@ -199,5 +219,32 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
       reason: 'error',
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a stale operation before it can overwrite the current placeholder', async () => {
+    await expect(
+      createCaller().notify({
+        content: 'late output',
+        operationId: 'op-stale',
+        role: 'assistant',
+        topicId: TOPIC,
+      }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+
+    expect(mockMessageUpdate).not.toHaveBeenCalled();
+    expect(mockPublishStreamEvent).not.toHaveBeenCalled();
+    expect(mockClearRunningOperationIfMatches).not.toHaveBeenCalled();
+  });
+
+  it('requires an operation generation for remote assistant callbacks', async () => {
+    await expect(
+      createCaller().notify({
+        content: 'unscoped output',
+        role: 'assistant',
+        topicId: TOPIC,
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    expect(mockMessageUpdate).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/routers/lambda/__tests__/aiAgent.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.test.ts
@@ -29,6 +29,10 @@ vi.mock('@/database/core/db-adaptor', () => ({
   getServerDB: vi.fn(() => testDB),
 }));
 
+vi.mock('@/libs/trpc/utils/internalJwt', () => ({
+  signUserJWT: vi.fn(async () => 'test-gateway-token'),
+}));
+
 // Mock AgentRuntimeService since we only want to test the router's business logic
 vi.mock('@/server/services/agentRuntime', () => ({
   AgentRuntimeService: vi.fn().mockImplementation(() => ({
@@ -446,6 +450,161 @@ describe('AI Agent Router Integration Tests', () => {
       // Should have 1 assistant message with parentId pointing to the user message
       expect(assistantMessages).toHaveLength(1);
       expect(assistantMessages[0].parentId).toBe(userMsg.id);
+    });
+  });
+
+  describe('recoverExecAgent', () => {
+    it('recovers only the exact persisted user/assistant pair for the active operation', async () => {
+      const [topic] = await serverDB
+        .insert(topics)
+        .values({
+          agentId: testAgentId,
+          sessionId: testSessionId,
+          title: 'Recovery Topic',
+          userId,
+        })
+        .returning();
+      const [userMessage, unrelatedUserMessage] = (await serverDB
+        .insert(messages)
+        .values([
+          {
+            agentId: testAgentId,
+            content: 'Recover me',
+            role: 'user',
+            topicId: topic.id,
+            userId,
+          },
+          {
+            agentId: testAgentId,
+            content: 'Different turn',
+            role: 'user',
+            topicId: topic.id,
+            userId,
+          },
+        ])
+        .returning()) as (typeof messages.$inferSelect)[];
+      const [assistantMessage] = (await serverDB
+        .insert(messages)
+        .values({
+          agentId: testAgentId,
+          content: '...',
+          parentId: userMessage.id,
+          role: 'assistant',
+          topicId: topic.id,
+          userId,
+        })
+        .returning()) as (typeof messages.$inferSelect)[];
+      await serverDB
+        .update(topics)
+        .set({
+          metadata: {
+            runningOperation: {
+              assistantMessageId: assistantMessage.id,
+              operationId: 'op-recover',
+            },
+          },
+        })
+        .where(eq(topics.id, topic.id));
+
+      const caller = aiAgentRouter.createCaller(createTestContext());
+      await expect(
+        caller.recoverExecAgent({
+          assistantMessageId: assistantMessage.id,
+          userMessageId: unrelatedUserMessage.id,
+        }),
+      ).resolves.toBeNull();
+
+      const recovered = await caller.recoverExecAgent({
+        assistantMessageId: assistantMessage.id,
+        userMessageId: userMessage.id,
+      });
+
+      expect(recovered).toMatchObject({
+        assistantMessageId: assistantMessage.id,
+        autoStarted: true,
+        operationId: 'op-recover',
+        status: 'created',
+        success: true,
+        topicId: topic.id,
+        userMessageId: userMessage.id,
+      });
+      expect(recovered?.token).toBeTruthy();
+    });
+
+    it('verifies the authoritative user thread and source message before recovery', async () => {
+      const [topic] = await serverDB
+        .insert(topics)
+        .values({
+          agentId: testAgentId,
+          sessionId: testSessionId,
+          title: 'Thread Recovery Topic',
+          userId,
+        })
+        .returning();
+      const [sourceMessage] = (await serverDB
+        .insert(messages)
+        .values({
+          agentId: testAgentId,
+          content: 'Branch here',
+          role: 'assistant',
+          topicId: topic.id,
+          userId,
+        })
+        .returning()) as (typeof messages.$inferSelect)[];
+      const [thread] = (await serverDB
+        .insert(threads)
+        .values({
+          agentId: testAgentId,
+          sourceMessageId: sourceMessage.id,
+          topicId: topic.id,
+          type: 'continuation',
+          userId,
+        })
+        .returning()) as (typeof threads.$inferSelect)[];
+      const [userMessage] = (await serverDB
+        .insert(messages)
+        .values({
+          agentId: testAgentId,
+          content: 'Thread turn',
+          role: 'user',
+          threadId: thread.id,
+          topicId: topic.id,
+          userId,
+        })
+        .returning()) as (typeof messages.$inferSelect)[];
+      const [assistantMessage] = (await serverDB
+        .insert(messages)
+        .values({
+          agentId: testAgentId,
+          content: '...',
+          parentId: userMessage.id,
+          role: 'assistant',
+          threadId: thread.id,
+          topicId: topic.id,
+          userId,
+        })
+        .returning()) as (typeof messages.$inferSelect)[];
+
+      const caller = aiAgentRouter.createCaller(createTestContext());
+      await expect(
+        caller.recoverExecAgent({
+          assistantMessageId: assistantMessage.id,
+          newThreadSourceMessageId: userMessage.id,
+          userMessageId: userMessage.id,
+        }),
+      ).resolves.toBeNull();
+
+      const recovered = await caller.recoverExecAgent({
+        assistantMessageId: assistantMessage.id,
+        newThreadSourceMessageId: sourceMessage.id,
+        userMessageId: userMessage.id,
+      });
+      expect(recovered).toMatchObject({
+        createdThreadId: thread.id,
+        status: 'error',
+        success: false,
+        topicId: topic.id,
+      });
     });
   });
 

--- a/apps/server/src/routers/lambda/agentNotify.ts
+++ b/apps/server/src/routers/lambda/agentNotify.ts
@@ -79,6 +79,8 @@ const NotifySchema = z.object({
    * in-place, keeping a single bubble in the UI.
    */
   messageId: z.string().optional(),
+  /** Operation generation assigned by execAgent for remote heterogeneous callbacks. */
+  operationId: z.string().optional(),
   /**
    * Role of the message to write:
    * - 'user' (default): write as user message and trigger the agent to reply
@@ -111,6 +113,7 @@ export const agentNotifyRouter = router({
       done = false,
       error: terminalError,
       messageId,
+      operationId: inputOperationId,
     } = input;
 
     // An error is itself a terminal signal — finalize the run even if the
@@ -139,8 +142,24 @@ export const agentNotifyRouter = router({
 
     // Extract the operationId seeded by execAgent for remote hetero agents.
     // Used to publish notify_update / agent_runtime_end events to the gateway WS.
-    const remoteOperationId = (topic.metadata as any)?.runningOperation?.operationId as
-      string | undefined;
+    const runningOperation = topic.metadata?.runningOperation;
+    const remoteOperationId = runningOperation?.operationId;
+
+    // Remote assistant callbacks must echo the generation assigned at dispatch.
+    // Topic-only identity is insufficient: a delayed callback from operation A
+    // could otherwise overwrite/finalize operation B after B claims the topic.
+    if (inputOperationId && inputOperationId !== remoteOperationId) {
+      throw new TRPCError({
+        code: 'CONFLICT',
+        message: 'Notification belongs to a stale agent operation',
+      });
+    }
+    if (role === 'assistant' && runningOperation && !inputOperationId) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'operationId is required for assistant notifications during an active run',
+      });
+    }
 
     const agentId = inputAgentId ?? topic.agentId;
     if (!agentId) {
@@ -190,8 +209,7 @@ export const agentNotifyRouter = router({
           // (Previously this fired the stripped-down dispatchTerminalHooks, which
           // skipped persist + verify — so openclaw/hermes tasks never auto-verified.)
           // Hooks were serialized onto runningOperation at dispatch time.
-          const serializedHooks = (topic.metadata as any)?.runningOperation?.hooks as
-            SerializedHook[] | undefined;
+          const serializedHooks = runningOperation?.hooks as SerializedHook[] | undefined;
           let lastAssistantContent: string | undefined = content || undefined;
           if (!lastAssistantContent && writtenMessageId) {
             const msg = await ctx.messageModel.findById(writtenMessageId).catch(() => undefined);
@@ -264,7 +282,11 @@ export const agentNotifyRouter = router({
 
           // The operation is finished — drop the running marker so a duplicate
           // terminal signal / reconnect doesn't re-fire the hooks.
-          await ctx.topicModel.updateMetadata(topicId, { runningOperation: null }).catch(() => {});
+          await ctx.topicModel
+            .clearRunningOperationIfMatches(topicId, remoteOperationId)
+            .catch((err) =>
+              log('notify: failed to clear running operation op=%s: %O', remoteOperationId, err),
+            );
         } else {
           // Lightweight invalidation — frontend calls fetchAndReplaceMessages.
           await stream.publishStreamEvent(remoteOperationId, {
@@ -289,8 +311,7 @@ export const agentNotifyRouter = router({
         // 1. Caller-supplied messageId (subsequent notify calls with --message-id)
         // 2. Placeholder assistantMessageId seeded by execAgent (first notify call for remote hetero)
         // Using the placeholder avoids creating a second empty bubble in the UI.
-        const placeholderMessageId = (topic.metadata as any)?.runningOperation
-          ?.assistantMessageId as string | undefined;
+        const placeholderMessageId = runningOperation?.assistantMessageId;
         const resolvedMessageId = messageId ?? placeholderMessageId;
 
         // Update existing message if we have a resolved target

--- a/apps/server/src/routers/lambda/aiAgent.ts
+++ b/apps/server/src/routers/lambda/aiAgent.ts
@@ -4,6 +4,7 @@ import { isFullAccessApiKey } from '@lobechat/const/apiKeyScope';
 import { parse } from '@lobechat/conversation-flow';
 import type { TaskCurrentActivity, TaskStatusResult } from '@lobechat/types';
 import {
+  CreateThreadWithMessageSchema,
   entityIdPattern,
   RequestTrigger,
   ThreadStatus,
@@ -217,6 +218,9 @@ const ExecAgentSchema = z
             workingDirectoryConfig: workingDirConfigSchema.optional(),
           })
           .optional(),
+        newThread: CreateThreadWithMessageSchema.extend({
+          type: z.enum([ThreadType.Continuation, ThreadType.Standalone]),
+        }).optional(),
         /**
          * Group orchestration role of the run, stamped onto the assistant
          * message's `metadata.orchestrationRole` so the supervisor/member
@@ -525,6 +529,12 @@ const InterruptTaskSchema = z
   .refine((data) => data.threadId || data.operationId, {
     message: 'Either threadId or operationId must be provided',
   });
+
+const RecoverExecAgentSchema = z.object({
+  assistantMessageId: z.string().min(1),
+  newThreadSourceMessageId: z.string().min(1).optional(),
+  userMessageId: z.string().min(1),
+});
 
 /**
  * Wire shape of an `AgentStreamEvent` produced by `lh hetero exec`. Mirrors
@@ -1372,6 +1382,12 @@ export const aiAgentRouter = router({
           message: 'Thread not found',
         });
       }
+      if (thread.type !== ThreadType.Isolation) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Thread is not a sub-agent task',
+        });
+      }
 
       // 2. Map Thread status to task status
       const threadStatusToTaskStatus: Record<string, TaskStatusResult['status']> = {
@@ -2006,6 +2022,12 @@ export const aiAgentRouter = router({
             message: 'Thread not found',
           });
         }
+        if (thread.type !== ThreadType.Isolation) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Thread is not a client task',
+          });
+        }
 
         const completedAt = new Date().toISOString();
         const startedAt = thread.metadata?.startedAt;
@@ -2079,6 +2101,89 @@ export const aiAgentRouter = router({
         });
       }
     }),
+
+  /**
+   * Recover an execAgent response whose transport failed after the client-ID
+   * message pair committed. This is an ownership-scoped acceptance probe, not a
+   * retry: callers either receive the exact persisted turn or null.
+   */
+  recoverExecAgent: aiAgentProcedure.input(RecoverExecAgentSchema).query(async ({ input, ctx }) => {
+    const [assistantMessage, userMessage] = await Promise.all([
+      ctx.messageModel.findById(input.assistantMessageId),
+      ctx.messageModel.findById(input.userMessageId),
+    ]);
+
+    if (
+      !assistantMessage ||
+      !userMessage ||
+      assistantMessage.role !== 'assistant' ||
+      userMessage.role !== 'user' ||
+      assistantMessage.parentId !== userMessage.id ||
+      assistantMessage.topicId !== userMessage.topicId ||
+      assistantMessage.threadId !== userMessage.threadId ||
+      !assistantMessage.agentId ||
+      !assistantMessage.topicId
+    ) {
+      return null;
+    }
+
+    let createdThreadId: string | undefined;
+    if (input.newThreadSourceMessageId) {
+      if (!assistantMessage.threadId) return null;
+
+      const thread = await ctx.threadModel.findById(assistantMessage.threadId);
+      if (
+        !thread ||
+        thread.sourceMessageId !== input.newThreadSourceMessageId ||
+        (thread.type !== ThreadType.Continuation && thread.type !== ThreadType.Standalone)
+      ) {
+        return null;
+      }
+      createdThreadId = thread.id;
+    }
+
+    const topic = await ctx.topicModel.findById(assistantMessage.topicId);
+    const runningOperation = topic?.metadata?.runningOperation;
+    const ownsRunningOperation =
+      runningOperation?.assistantMessageId === assistantMessage.id ? runningOperation : undefined;
+    const token = ownsRunningOperation ? await signUserJWT(ctx.userId) : undefined;
+    const timestamp = new Date().toISOString();
+
+    return {
+      agentId: assistantMessage.agentId,
+      assistantMessageId: assistantMessage.id,
+      autoStarted: Boolean(ownsRunningOperation),
+      createdAt: assistantMessage.createdAt?.toISOString() ?? timestamp,
+      createdThreadId,
+      error: ownsRunningOperation ? undefined : 'The run response was lost after persistence',
+      message: ownsRunningOperation
+        ? 'Recovered persisted agent operation'
+        : 'Recovered persisted messages after agent startup failed',
+      operationId: ownsRunningOperation?.operationId ?? `recovered_${assistantMessage.id}`,
+      status: ownsRunningOperation ? ('created' as const) : ('error' as const),
+      success: Boolean(ownsRunningOperation),
+      timestamp,
+      token,
+      topicId: assistantMessage.topicId,
+      userMessageId: userMessage.id,
+    };
+  }),
+
+  clearRunningOperation: aiAgentWriteProcedure
+    .input(
+      z.object({
+        operationId: z.string().min(1),
+        settledStatus: z.enum(['active', 'unread']).optional(),
+        topicId: z.string().min(1),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => ({
+      cleared: await ctx.topicModel.clearRunningOperationIfMatches(
+        input.topicId,
+        input.operationId,
+        input.settledStatus,
+      ),
+    })),
 
   /**
    * Refresh Gateway JWT token for an existing operation.

--- a/apps/server/src/services/agentRuntime/AbandonOperationService.ts
+++ b/apps/server/src/services/agentRuntime/AbandonOperationService.ts
@@ -164,12 +164,7 @@ export class AbandonOperationService {
       if (metadata.topicId) {
         try {
           const topicModel = new TopicModel(this.db, metadata.userId, metadata.workspaceId);
-          const topic = await topicModel.findById(metadata.topicId);
-          const running = topic?.metadata?.runningOperation as
-            { assistantMessageId?: string; operationId?: string } | undefined;
-          if (running?.operationId === operationId) {
-            await topicModel.updateMetadata(metadata.topicId, { runningOperation: null });
-          }
+          await topicModel.clearRunningOperationIfMatches(metadata.topicId, operationId);
         } catch (e) {
           log('[%s] abandoned op runningOperation cleanup failed (non-fatal): %O', operationId, e);
         }
@@ -334,7 +329,10 @@ export class AbandonOperationService {
         if (running?.operationId && running.operationId !== operationId) return undefined;
 
         if (running?.operationId === operationId) {
-          await topicModel.updateMetadata(op.topicId, { runningOperation: null }).catch(() => {});
+          const cleared = await topicModel
+            .clearRunningOperationIfMatches(op.topicId, operationId)
+            .catch(() => false);
+          if (!cleared) return undefined;
           if (running.assistantMessageId) return running.assistantMessageId;
         }
       } catch (e) {

--- a/apps/server/src/services/agentRuntime/__tests__/AbandonOperationService.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/AbandonOperationService.test.ts
@@ -52,11 +52,11 @@ vi.mock('@/database/models/thread', () => ({
 }));
 
 const topicFindByIdMock = vi.fn().mockResolvedValue(null);
-const topicUpdateMetadataMock = vi.fn().mockResolvedValue(undefined);
+const topicClearRunningOperationIfMatchesMock = vi.fn().mockResolvedValue(true);
 vi.mock('@/database/models/topic', () => ({
   TopicModel: vi.fn().mockImplementation(() => ({
+    clearRunningOperationIfMatches: topicClearRunningOperationIfMatchesMock,
     findById: topicFindByIdMock,
-    updateMetadata: topicUpdateMetadataMock,
   })),
 }));
 
@@ -94,7 +94,7 @@ describe('AbandonOperationService', () => {
     recordCompletionMock.mockClear();
     findThreadMock.mockReset().mockResolvedValue(null);
     topicFindByIdMock.mockReset().mockResolvedValue(null);
-    topicUpdateMetadataMock.mockReset().mockResolvedValue(undefined);
+    topicClearRunningOperationIfMatchesMock.mockReset().mockResolvedValue(true);
   });
 
   it('returns found:false when coordinator has no state', async () => {
@@ -162,7 +162,7 @@ describe('AbandonOperationService', () => {
         toolCalls: 0,
       }),
     );
-    expect(topicUpdateMetadataMock).toHaveBeenCalledWith('tpc_x', { runningOperation: null });
+    expect(topicClearRunningOperationIfMatchesMock).toHaveBeenCalledWith('tpc_x', 'op_x');
     expect(messageUpdateMock).toHaveBeenCalledWith('msg_assist_1', {
       content: '',
       error: expect.objectContaining({
@@ -228,7 +228,42 @@ describe('AbandonOperationService', () => {
 
     expect(result.abandoned).toBe(true);
     expect(recordCompletionMock).toHaveBeenCalled();
-    expect(topicUpdateMetadataMock).not.toHaveBeenCalled();
+    expect(topicClearRunningOperationIfMatchesMock).not.toHaveBeenCalled();
+    expect(messageUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('does not update a no-state placeholder when ownership changes before the atomic clear', async () => {
+    const coord = buildCoordinator({ loadAgentState: vi.fn().mockResolvedValue(null) });
+    const store = buildStore();
+    const db = buildDb({
+      operationRow: {
+        agentId: 'agt_x',
+        id: 'op_old',
+        provider: 'claude-code',
+        startedAt: new Date('2026-06-30T11:51:14.745Z'),
+        status: 'running',
+        topicId: 'tpc_x',
+        userId: 'user_x',
+      },
+    });
+    topicFindByIdMock.mockResolvedValue({
+      metadata: {
+        runningOperation: {
+          assistantMessageId: 'msg_old_placeholder',
+          operationId: 'op_old',
+        },
+      },
+    });
+    topicClearRunningOperationIfMatchesMock.mockResolvedValue(false);
+
+    const svc = new AbandonOperationService(db, {
+      coordinator: coord as any,
+      snapshotStore: store as any,
+    });
+    const result = await svc.finalizeAbandoned('op_old', 'inactivity_watchdog');
+
+    expect(result.abandoned).toBe(true);
+    expect(topicClearRunningOperationIfMatchesMock).toHaveBeenCalledWith('tpc_x', 'op_old');
     expect(messageUpdateMock).not.toHaveBeenCalled();
   });
 
@@ -289,7 +324,7 @@ describe('AbandonOperationService', () => {
         type: 'AgentRuntimeError',
       }),
     });
-    expect(topicUpdateMetadataMock).toHaveBeenCalledWith('tpc_x', { runningOperation: null });
+    expect(topicClearRunningOperationIfMatchesMock).toHaveBeenCalledWith('tpc_x', 'op_x');
     expect(dispatchHooksMock).toHaveBeenCalledWith(
       'op_x',
       expect.objectContaining({
@@ -332,7 +367,7 @@ describe('AbandonOperationService', () => {
       const result = await svc.finalizeAbandoned('op_x', 'inactivity_5m');
 
       expect(result.found).toBe(true);
-      expect(topicUpdateMetadataMock).toHaveBeenCalledWith('tpc_x', { runningOperation: null });
+      expect(topicClearRunningOperationIfMatchesMock).toHaveBeenCalledWith('tpc_x', 'op_x');
       expect(dispatchHooksMock).not.toHaveBeenCalled();
     },
   );

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.device.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.device.test.ts
@@ -561,7 +561,7 @@ describe('AiAgentService.execAgent - device auto-activation', () => {
       );
     });
 
-    it('fails before operation creation when the shared fixed device is offline', async () => {
+    it('returns authoritative persisted ids without creating an operation when the fixed device is offline', async () => {
       mockDeviceProxy.isConfigured = true;
       mockDeviceProxy.queryDeviceList.mockResolvedValue([onlineDevice2]);
       await useAgencyConfig({
@@ -571,11 +571,16 @@ describe('AiAgentService.execAgent - device auto-activation', () => {
       });
       service = new AiAgentService(mockDb, userId, { workspaceId: 'workspace-1' });
 
-      await expect(
-        service.execAgent({ agentId: 'agent-1', prompt: 'Run a command' }),
-      ).rejects.toMatchObject({ code: 'PRECONDITION_FAILED' });
+      const result = await service.execAgent({ agentId: 'agent-1', prompt: 'Run a command' });
 
       expect(mockCreateOperation).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        assistantMessageId: 'msg-1',
+        status: 'error',
+        success: false,
+        topicId: 'topic-1',
+        userMessageId: 'msg-1',
+      });
       expect(mockMessageUpdate).toHaveBeenCalledWith(
         'msg-1',
         expect.objectContaining({

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
@@ -10,6 +10,8 @@ const {
   mockExecuteToolCall,
   mockGetHeterogeneousResumeSessionId,
   mockMessageCreate,
+  mockMessageQuery,
+  mockMessageUpdateMetadata,
   mockResolveAttachmentsByFileIds,
   mockSpawnHeteroSandbox,
   mockIngestAttachment,
@@ -24,6 +26,8 @@ const {
   mockGetHeterogeneousResumeSessionId: vi.fn().mockResolvedValue(undefined),
   mockIngestAttachment: vi.fn(),
   mockMessageCreate: vi.fn(),
+  mockMessageQuery: vi.fn(),
+  mockMessageUpdateMetadata: vi.fn(),
   mockPublishAgentRuntimeEnd: vi.fn().mockResolvedValue('end-event-id'),
   mockPublishAgentRuntimeInit: vi.fn().mockResolvedValue('init-event-id'),
   mockResolveAttachmentsByFileIds: vi.fn(),
@@ -75,8 +79,9 @@ vi.mock('@/database/models/message', () => ({
     create: mockMessageCreate,
     getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
     getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
-    query: vi.fn().mockResolvedValue([]),
+    query: mockMessageQuery,
     update: vi.fn().mockResolvedValue({}),
+    updateMetadata: mockMessageUpdateMetadata,
   })),
 }));
 
@@ -121,6 +126,8 @@ vi.mock('@/database/models/plugin', () => ({
 const topicMock = {
   create: vi.fn().mockResolvedValue({ id: 'topic-1', metadata: undefined }),
   findById: vi.fn().mockResolvedValue(undefined),
+  releaseTaskCallbackReservation: vi.fn().mockResolvedValue(true),
+  tryReserveTaskCallback: vi.fn().mockResolvedValue(true),
   updateMetadata: vi.fn().mockResolvedValue(undefined),
 };
 vi.mock('@/database/models/topic', () => ({
@@ -210,8 +217,12 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
     vi.clearAllMocks();
     topicMock.create.mockResolvedValue({ id: 'topic-1', metadata: undefined });
     topicMock.findById.mockResolvedValue(undefined);
+    topicMock.releaseTaskCallbackReservation.mockResolvedValue(true);
+    topicMock.tryReserveTaskCallback.mockResolvedValue(true);
     topicMock.updateMetadata.mockResolvedValue(undefined);
     mockMessageCreate.mockResolvedValue({ id: 'msg-1' });
+    mockMessageQuery.mockResolvedValue([]);
+    mockMessageUpdateMetadata.mockResolvedValue(undefined);
     mockResolveAttachmentsByFileIds.mockResolvedValue({ ...emptyResolvedAttachments });
     mockSpawnHeteroSandbox.mockResolvedValue(undefined);
     mockDispatchAgentRun.mockResolvedValue({ success: true });
@@ -622,6 +633,33 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
         expect.objectContaining({ imageList: undefined }),
       );
     });
+
+    it('loads thread history without a resume token and excludes the fresh turn', async () => {
+      mockMessageQuery.mockResolvedValue([
+        { content: 'Inherited source context', id: 'old-source', role: 'user' },
+        { content: 'Fresh prompt', id: 'msg-1', role: 'user' },
+      ]);
+
+      await service.execAgent({
+        agentId: 'agent-1',
+        appContext: { threadId: 'thread-1', topicId: 'topic-1' },
+        prompt: 'Fresh prompt',
+      });
+
+      expect(mockGetHeterogeneousResumeSessionId).toHaveBeenCalledWith(
+        'topic-1',
+        'thread-1',
+        'msg-1',
+      );
+      expect(mockMessageQuery).toHaveBeenCalledWith({
+        pageSize: 200,
+        threadId: 'thread-1',
+        topicId: 'topic-1',
+      });
+      const systemContext = mockSpawnHeteroSandbox.mock.calls.at(-1)?.[0].systemContext;
+      expect(systemContext).toContain('Inherited source context');
+      expect(systemContext).not.toContain('<user>\nFresh prompt\n</user>');
+    });
   });
 
   // The seed side of the hetero terminal-hook funnel. execAgent runs the hetero
@@ -699,6 +737,31 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
       expect(seed.runningOperation.hooks?.[0]?.id).toBe('task-on-complete');
       expect(seed.runningOperation.hooks?.[0]?.webhook?.url).toBe(
         '/api/workflows/task/on-topic-complete',
+      );
+    });
+
+    it('stores an internal isolation binding on the assistant without claiming the topic marker', async () => {
+      await service.execAgent({
+        agentId: 'agent-1',
+        appContext: {
+          isolationThread: true,
+          threadId: 'thread-internal',
+          topicId: 'topic-1',
+        },
+        hooks: [taskHook],
+        prompt: 'internal hetero task',
+      } as any);
+
+      expect(findRunningOpSeed()).toBeUndefined();
+      expect(mockMessageUpdateMetadata).toHaveBeenCalledWith(
+        'msg-1',
+        expect.objectContaining({
+          heteroOperation: expect.objectContaining({
+            hooks: [expect.objectContaining({ id: 'task-on-complete' })],
+            internalIsolation: true,
+            operationId: expect.any(String),
+          }),
+        }),
       );
     });
 

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.threadId.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.threadId.test.ts
@@ -4,9 +4,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AiAgentService } from '../index';
 
 // Use vi.hoisted to ensure mock functions are available before vi.mock runs
-const { mockMessageCreate, mockTopicUpdateMetadata } = vi.hoisted(() => ({
+const {
+  mockCreateMessagePair,
+  mockMessageCreate,
+  mockMessageFindById,
+  mockThreadCreate,
+  mockTopicUpdateMetadata,
+  mockTryReserveTaskCallback,
+} = vi.hoisted(() => ({
+  mockCreateMessagePair: vi.fn(),
   mockMessageCreate: vi.fn(),
+  mockMessageFindById: vi.fn(),
+  mockThreadCreate: vi.fn(),
   mockTopicUpdateMetadata: vi.fn(),
+  mockTryReserveTaskCallback: vi.fn(),
 }));
 
 // Mock trusted client to avoid server-side env access
@@ -19,6 +30,8 @@ vi.mock('@/libs/trusted-client', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(() => ({
     create: mockMessageCreate,
+    createUserAndAssistantMessages: mockCreateMessagePair,
+    findById: mockMessageFindById,
     getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
     getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
     query: vi.fn().mockResolvedValue([]),
@@ -70,7 +83,7 @@ vi.mock('@/database/models/plugin', () => ({
 vi.mock('@/database/models/topic', () => ({
   TopicModel: vi.fn().mockImplementation(() => ({
     releaseTaskCallbackReservation: vi.fn().mockResolvedValue(undefined),
-    tryReserveTaskCallback: vi.fn().mockResolvedValue(true),
+    tryReserveTaskCallback: mockTryReserveTaskCallback,
     create: vi.fn().mockResolvedValue({ id: 'topic-1' }),
     findById: vi.fn().mockResolvedValue(undefined),
     updateMetadata: mockTopicUpdateMetadata,
@@ -80,7 +93,7 @@ vi.mock('@/database/models/topic', () => ({
 // Mock ThreadModel
 vi.mock('@/database/models/thread', () => ({
   ThreadModel: vi.fn().mockImplementation(() => ({
-    create: vi.fn(),
+    create: mockThreadCreate,
     findById: vi.fn(),
     update: vi.fn(),
   })),
@@ -167,7 +180,10 @@ vi.mock('model-bank', async (importOriginal) => {
 
 describe('AiAgentService.execAgent - threadId handling', () => {
   let service: AiAgentService;
-  const mockDb = {} as any;
+  const transaction = vi.fn(async (callback: (trx: unknown) => Promise<unknown>) =>
+    callback({ transaction: 'trx' }),
+  );
+  const mockDb = { transaction } as any;
   const userId = 'test-user-id';
 
   beforeEach(() => {
@@ -175,6 +191,12 @@ describe('AiAgentService.execAgent - threadId handling', () => {
     // Explicitly clear the shared mock to prevent state pollution between tests
     mockMessageCreate.mockClear();
     mockMessageCreate.mockResolvedValue({ id: 'msg-1' });
+    mockMessageFindById.mockReset();
+    mockThreadCreate.mockReset();
+    mockCreateMessagePair.mockReset();
+    mockTryReserveTaskCallback.mockReset();
+    mockTryReserveTaskCallback.mockResolvedValue(true);
+    transaction.mockClear();
     mockTopicUpdateMetadata.mockClear();
     mockTopicUpdateMetadata.mockResolvedValue(undefined);
 
@@ -187,6 +209,26 @@ describe('AiAgentService.execAgent - threadId handling', () => {
   });
 
   describe('when threadId is provided in appContext', () => {
+    it('serializes ordinary user-thread starts at topic scope', async () => {
+      await service.execAgent({
+        agentId: 'agent-1',
+        appContext: { threadId: 'thread-123', topicId: 'topic-1' },
+        prompt: 'Test prompt',
+      });
+
+      expect(mockTryReserveTaskCallback).toHaveBeenCalled();
+    });
+
+    it('keeps internal isolation-thread guests outside the topic reservation', async () => {
+      await service.execAgent({
+        agentId: 'agent-1',
+        appContext: { isolationThread: true, threadId: 'thread-123', topicId: 'topic-1' },
+        prompt: 'Test prompt',
+      });
+
+      expect(mockTryReserveTaskCallback).not.toHaveBeenCalled();
+    });
+
     it('should pass threadId when creating user message', async () => {
       await service.execAgent({
         agentId: 'agent-1',
@@ -230,6 +272,107 @@ describe('AiAgentService.execAgent - threadId handling', () => {
         threadId: 'thread-123',
         topicId: 'topic-1',
       });
+    });
+  });
+
+  describe('when a new user thread is requested', () => {
+    it('rejects creation without an existing topic', async () => {
+      await expect(
+        service.execAgent({
+          agentId: 'agent-1',
+          appContext: {
+            newThread: { sourceMessageId: 'source-1', type: 'continuation' },
+          },
+          prompt: 'Start a branch',
+        }),
+      ).rejects.toThrow('newThread requires an existing topic');
+
+      expect(transaction).not.toHaveBeenCalled();
+    });
+
+    it('rejects the internal isolation type on the user creation path', async () => {
+      await expect(
+        service.execAgent({
+          agentId: 'agent-1',
+          appContext: {
+            newThread: { sourceMessageId: 'source-1', type: 'isolation' } as any,
+            topicId: 'topic-1',
+          },
+          prompt: 'Start a task thread',
+        }),
+      ).rejects.toThrow('User-created isolation threads are not supported');
+
+      expect(transaction).not.toHaveBeenCalled();
+    });
+
+    it('creates the thread and first message pair in one transaction', async () => {
+      mockMessageFindById.mockResolvedValue({
+        id: 'source-1',
+        threadId: null,
+        topicId: 'topic-1',
+      });
+      mockThreadCreate.mockResolvedValue({ id: 'thread-created' });
+      mockCreateMessagePair.mockResolvedValue({
+        assistantMessage: { id: 'assistant-created' },
+        userMessage: { id: 'user-created' },
+      });
+
+      const result = await service.execAgent({
+        agentId: 'agent-1',
+        appContext: {
+          newThread: { sourceMessageId: 'source-1', type: 'continuation' },
+          topicId: 'topic-1',
+        },
+        clientIds: {
+          assistantMessageId: 'assistant-created',
+          userMessageId: 'user-created',
+        },
+        prompt: 'Start a branch',
+      });
+
+      expect(transaction).toHaveBeenCalledTimes(1);
+      expect(mockThreadCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ sourceMessageId: 'source-1', topicId: 'topic-1' }),
+        { transaction: 'trx' },
+      );
+      expect(mockCreateMessagePair).toHaveBeenCalledWith(
+        {
+          assistantMessage: expect.objectContaining({ threadId: 'thread-created' }),
+          userMessage: expect.objectContaining({
+            parentId: 'source-1',
+            threadId: 'thread-created',
+          }),
+        },
+        expect.objectContaining({
+          ids: {
+            assistantMessageId: 'assistant-created',
+            userMessageId: 'user-created',
+          },
+          trx: { transaction: 'trx' },
+        }),
+      );
+      expect(result.createdThreadId).toBe('thread-created');
+    });
+
+    it('rejects a source message that already belongs to a thread', async () => {
+      mockMessageFindById.mockResolvedValue({
+        id: 'nested-source',
+        threadId: 'existing-thread',
+        topicId: 'topic-1',
+      });
+
+      await expect(
+        service.execAgent({
+          agentId: 'agent-1',
+          appContext: {
+            newThread: { sourceMessageId: 'nested-source', type: 'standalone' },
+            topicId: 'topic-1',
+          },
+          prompt: 'Nested branch',
+        }),
+      ).rejects.toThrow('Nested user threads are not supported');
+
+      expect(transaction).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -54,6 +54,8 @@ import type {
   ChatFileItem,
   ChatTopicBotContext,
   ChatVideoItem,
+  CreateMessageParams,
+  CreateThreadWithMessageParams,
   ErrorType,
   ExecAgentParams,
   ExecAgentResult,
@@ -786,7 +788,7 @@ export class AiAgentService {
     // 3. The operation never started — drop the running marker so reconnect /
     //    heteroIngest validation and the next turn don't see a stale operation.
     try {
-      await this.topicModel.updateMetadata(topicId, { runningOperation: null });
+      await this.topicModel.clearRunningOperationIfMatches(topicId, operationId);
     } catch (err) {
       log('finalizeHeteroDispatchError: clear runningOperation failed (non-fatal): %O', err);
     }
@@ -1240,11 +1242,11 @@ export class AiAgentService {
    */
   async execAgent(params: InternalExecAgentParams): Promise<ExecAgentResult> {
     const topicId = params.appContext?.topicId;
-    // Thread runs are isolated under an explicit parent message and do not
-    // advance the topic's main spine. They may start while their parent
-    // operation owns `runningOperation` (for example callAgent/callSubAgent),
-    // so making them wait for the topic-start claim deadlocks the child start.
-    if (!topicId || params.appContext?.threadId) return this.execAgentWithReservation(params);
+    // Only internal isolation-thread guests may share a topic while their parent
+    // owns `runningOperation`. Ordinary user threads still serialize starts at
+    // topic scope because they share the topic-level running-operation anchor.
+    if (!topicId || params.appContext?.isolationThread)
+      return this.execAgentWithReservation(params);
 
     const reservationId = params.topicStartReservationId ?? `agent-start-${nanoid()}`;
     const reserved = await acquireTopicStartReservation({
@@ -1322,6 +1324,28 @@ export class AiAgentService {
     // rather than trusting every caller to omit them.
     const isResumeLike = !!resume || !!resumeApproval || !!resumeToolResult || !!parentMessageId;
     const clientIds = isResumeLike ? undefined : params.clientIds;
+
+    if (appContext?.newThread && isResumeLike) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'newThread is only supported for a fresh user turn',
+      });
+    }
+    if (appContext?.newThread && !appContext.topicId) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'newThread requires an existing topic',
+      });
+    }
+    if (
+      (appContext?.newThread as CreateThreadWithMessageParams | undefined)?.type ===
+      ThreadType.Isolation
+    ) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'User-created isolation threads are not supported',
+      });
+    }
 
     // Validate that either agentId or slug is provided
     if (!agentId && !slug) {
@@ -2005,6 +2029,43 @@ export class AiAgentService {
 
     await throwIfExecutionAborted('topic setup');
 
+    let executionThreadId = appContext?.threadId ?? undefined;
+    let createdThreadId: string | undefined;
+    const requestedNewThread = appContext?.newThread;
+
+    if (requestedNewThread) {
+      if (runFromHistory || executionThreadId || requestedNewThread.parentThreadId) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Nested or history-only user thread creation is not supported',
+        });
+      }
+
+      if (!requestedNewThread.sourceMessageId) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'newThread.sourceMessageId is required',
+        });
+      }
+
+      const sourceMessage = await this.messageModel.findById(requestedNewThread.sourceMessageId);
+      if (!sourceMessage) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Thread source message not found' });
+      }
+      if (sourceMessage.topicId !== topicId) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Thread source message does not belong to the requested topic',
+        });
+      }
+      if (sourceMessage.threadId) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Nested user threads are not supported',
+        });
+      }
+    }
+
     // Resolve device-tool access ONCE per turn, BEFORE the hetero early exit —
     // hetero dispatch routes the whole run to a user machine, so it must honour
     // the same policy as native device tools. Discord-only flows (no
@@ -2077,7 +2138,9 @@ export class AiAgentService {
       if (runFromHistory) return undefined;
       if (parentMessageId) return parentMessageId;
 
-      const threadId = appContext?.threadId ?? null;
+      if (requestedNewThread?.sourceMessageId) return requestedNewThread.sourceMessageId;
+
+      const threadId = executionThreadId ?? null;
       const spineId = await this.messageModel.getLatestSpineMessageId({ threadId, topicId });
       if (spineId) return spineId;
 
@@ -2092,30 +2155,6 @@ export class AiAgentService {
       return fallbackId;
     };
     const userMessageParentId = await resolveUserMessageParentId();
-    const userMessageRecord = runFromHistory
-      ? undefined
-      : await this.messageModel.create(
-          {
-            agentId: conversationAgentId,
-            content: prompt,
-            files: runAttachments.fileIds,
-            // Group reads filter on messages.groupId (MessageModel.query group
-            // branch), so a group turn must stamp groupId or the message never
-            // shows when the topic is reopened (group topic sidebar + ownership fix).
-            groupId: appContext?.groupId ?? undefined,
-            metadata: requestTriggerMetadata,
-            parentId: userMessageParentId,
-            role: 'user',
-            threadId: appContext?.threadId ?? undefined,
-            topicId,
-          },
-          // The id the client's optimistic user row already renders under.
-          clientIds?.userMessageId,
-        );
-    if (userMessageRecord) {
-      selfMessageIds.add(userMessageRecord.id);
-      log('execAgent: created user message %s', userMessageRecord.id);
-    }
 
     // Snapshot the author's group orchestration role onto the assistant message
     // so the role survives the server round-trip (gateway step_start snapshot /
@@ -2130,34 +2169,88 @@ export class AiAgentService {
         }
       : undefined;
 
-    // Assistant placeholder (shows the spinner in the UI). A hetero run seeds
-    // ONLY the provider — the CLI reports the real model later via `stream_start`
-    // / `turn_metadata` (backfilled by HeterogeneousPersistenceHandler), and
-    // seeding the agent's chat model would leak it into the model tag. A normal
-    // run seeds model + provider as usual.
-    const assistantMessageRecord = await this.messageModel.create(
-      {
-        agentId: assistantAgentId,
-        content: LOADING_FLAT,
-        // Stamp groupId so the assistant turn is visible in the group read path
-        // (MessageModel.query filters group chats by messages.groupId).
-        groupId: appContext?.groupId ?? undefined,
-        metadata: orchestrationMetadata,
-        model: isHeteroAgent ? undefined : model,
-        // Chain onto the user turn we just persisted; `parentMessageId` is the
-        // anchor only on a resume, where no user message is created. A batch
-        // approval overrides it with the assistant that emitted the batch — the
-        // previous LLM call — so the spine stays one node per call and never
-        // depends on which of the batch's tool rows the client sent as anchor.
-        parentId: userMessageRecord?.id ?? batchApprovalAnchorId ?? parentMessageId,
-        provider: isHeteroAgent ? heteroType : provider,
-        role: 'assistant',
-        threadId: appContext?.threadId ?? undefined,
-        topicId,
-      },
-      // The id the client's assistant placeholder already renders under.
-      clientIds?.assistantMessageId,
-    );
+    const buildUserMessage = (threadId?: string): CreateMessageParams => ({
+      agentId: conversationAgentId,
+      content: prompt,
+      files: runAttachments.fileIds,
+      groupId: appContext?.groupId ?? undefined,
+      metadata: requestTriggerMetadata,
+      parentId: userMessageParentId,
+      role: 'user',
+      threadId,
+      topicId,
+    });
+    const buildAssistantMessage = (
+      threadId?: string,
+      messageParentId = batchApprovalAnchorId ?? parentMessageId,
+    ): CreateMessageParams => ({
+      agentId: assistantAgentId,
+      content: LOADING_FLAT,
+      groupId: appContext?.groupId ?? undefined,
+      metadata: orchestrationMetadata,
+      model: isHeteroAgent ? undefined : model,
+      parentId: messageParentId,
+      provider: isHeteroAgent ? heteroType : provider,
+      role: 'assistant',
+      threadId,
+      topicId,
+    });
+
+    let userMessageRecord: Awaited<ReturnType<MessageModel['create']>> | undefined;
+    let assistantMessageRecord: Awaited<ReturnType<MessageModel['create']>>;
+
+    if (runFromHistory) {
+      assistantMessageRecord = await this.messageModel.create(
+        buildAssistantMessage(executionThreadId),
+        clientIds?.assistantMessageId,
+      );
+    } else if (requestedNewThread) {
+      const persisted = await this.db.transaction(async (trx) => {
+        const thread = await this.threadModel.create(
+          {
+            sourceMessageId: requestedNewThread.sourceMessageId,
+            title: requestedNewThread.title,
+            topicId,
+            type: requestedNewThread.type,
+          },
+          trx,
+        );
+        if (!thread) throw new Error('Failed to create thread');
+
+        const pair = await this.messageModel.createUserAndAssistantMessages(
+          {
+            assistantMessage: buildAssistantMessage(thread.id),
+            userMessage: buildUserMessage(thread.id),
+          },
+          {
+            ids: {
+              assistantMessageId: clientIds?.assistantMessageId,
+              userMessageId: clientIds?.userMessageId,
+            },
+            trx,
+          },
+        );
+        return { pair, threadId: thread.id };
+      });
+      executionThreadId = persisted.threadId;
+      createdThreadId = persisted.threadId;
+      userMessageRecord = persisted.pair.userMessage;
+      assistantMessageRecord = persisted.pair.assistantMessage;
+    } else {
+      userMessageRecord = await this.messageModel.create(
+        buildUserMessage(executionThreadId),
+        clientIds?.userMessageId,
+      );
+      assistantMessageRecord = await this.messageModel.create(
+        buildAssistantMessage(executionThreadId, userMessageRecord.id),
+        clientIds?.assistantMessageId,
+      );
+    }
+
+    if (userMessageRecord) {
+      selfMessageIds.add(userMessageRecord.id);
+      log('execAgent: created user message %s', userMessageRecord.id);
+    }
     selfMessageIds.add(assistantMessageRecord.id);
     assistantMessageRef.current = assistantMessageRecord.id;
     log('execAgent: created assistant message %s', assistantMessageRecord.id);
@@ -2177,7 +2270,7 @@ export class AiAgentService {
             agentId: resolvedAgentId,
             message: prompt,
             messageId: userMessageRecord.id,
-            threadId: appContext?.threadId ?? undefined,
+            threadId: executionThreadId,
             topicId,
             trigger,
           },
@@ -2232,7 +2325,7 @@ export class AiAgentService {
           parentOperationId,
           provider: heteroType,
           taskId: operationTaskId ?? null,
-          threadId: appContext?.threadId ?? null,
+          threadId: executionThreadId ?? null,
           topicId,
           trigger,
         });
@@ -2244,7 +2337,11 @@ export class AiAgentService {
       const heteroService = new HeterogeneousAgentService(this.db, this.userId, {
         workspaceId: this.workspaceId,
       });
-      const resumeSessionId = await heteroService.getHeterogeneousResumeSessionId(topicId);
+      const resumeSessionId = await heteroService.getHeterogeneousResumeSessionId(
+        topicId,
+        executionThreadId,
+        assistantMessageRecord.id,
+      );
       // Sign an operation-scoped JWT so the CLI can authenticate against
       // heteroIngest / heteroFinish without full user credentials.
       let operationJwt: string;
@@ -2284,20 +2381,23 @@ export class AiAgentService {
         log('execAgent: failed to resolve GitHub token: %O', err);
       }
 
-      // When resuming, inject the recent conversation turns as context so CC can
-      // orient itself even if the native session file was cleared (sandbox recycled
-      // or context overflow caused the CLI to start a fresh session).
-      // Only fetch when there IS a stored session id — for first-turn runs CC has
-      // no prior history to inject.
+      // Thread runs always need their inherited/source history on the first
+      // native CLI turn. Existing native sessions also receive recent history as
+      // a fallback when their local transcript was recycled.
       let conversationHistory: ConversationHistoryEntry[] | undefined;
-      if (resumeSessionId) {
+      if (resumeSessionId || executionThreadId) {
         try {
-          const recentMsgs = await this.messageModel.query({ topicId, pageSize: 200 });
+          const recentMsgs = await this.messageModel.query({
+            pageSize: 200,
+            threadId: executionThreadId,
+            topicId,
+          });
           const turns = recentMsgs
             .filter(
               (m) =>
                 (m.role === 'user' || m.role === 'assistant') &&
-                !m.threadId &&
+                (executionThreadId ? true : !m.threadId) &&
+                !selfMessageIds.has(m.id) &&
                 m.content &&
                 m.content !== LOADING_FLAT,
             )
@@ -2398,28 +2498,43 @@ export class AiAgentService {
       if (hooks?.length) hookDispatcher.register(operationId, hooks);
       const serializedHooks = hookDispatcher.getSerializedHooks(operationId);
 
+      // Durable operation-scoped binding for heterogeneous callbacks. Internal
+      // isolation guests must not claim their parent's topic-global
+      // runningOperation anchor, so ingest/finish recover their operation,
+      // hooks, and Thread scope from the seeded assistant row instead.
+      await this.messageModel.updateMetadata(assistantMessageRecord.id, {
+        heteroOperation: {
+          hooks: serializedHooks,
+          internalIsolation: !!appContext?.isolationThread,
+          operationId,
+        },
+      });
+
       // Seed topic.metadata.runningOperation so heteroIngest can validate the
       // operation, and so every terminal site (heteroFinish, agentNotify done,
       // dispatch failure) can re-fire the serialized hooks across a process
       // boundary in queue mode.
-      await this.topicModel.updateMetadata(topicId, {
-        runningOperation: {
-          assistantMessageId: assistantMessageRecord.id,
-          hooks: serializedHooks,
-          // Store deviceId + heteroType so interruptTask can cancel remote processes
-          ...(isRemoteHetero && remoteDeviceId
-            ? {
-                deviceId: remoteDeviceId,
-                deviceUserId: remoteDeviceUserId,
-                deviceWorkspaceId: remoteDeviceWorkspaceId,
-                heteroType,
-              }
-            : undefined),
-          operationId,
-          scope: appContext?.scope ?? undefined,
-          threadId: appContext?.threadId ?? undefined,
-        },
-      });
+      if (!appContext?.isolationThread) {
+        await this.topicModel.updateMetadata(topicId, {
+          heteroSessionOperationId: operationId,
+          runningOperation: {
+            assistantMessageId: assistantMessageRecord.id,
+            hooks: serializedHooks,
+            // Store deviceId + heteroType so interruptTask can cancel remote processes
+            ...(isRemoteHetero && remoteDeviceId
+              ? {
+                  deviceId: remoteDeviceId,
+                  deviceUserId: remoteDeviceUserId,
+                  deviceWorkspaceId: remoteDeviceWorkspaceId,
+                  heteroType,
+                }
+              : undefined),
+            operationId,
+            scope: appContext?.scope ?? undefined,
+            threadId: executionThreadId,
+          },
+        });
+      }
 
       // Notify-based platform agents (openclaw / hermes) communicate back via
       // agentNotify.notify. A local run uses the requesting desktop's device ID;
@@ -2448,6 +2563,7 @@ export class AiAgentService {
             assistantMessageId: assistantMessageRecord.id,
             autoStarted: false,
             createdAt: new Date().toISOString(),
+            createdThreadId,
             error: 'Device access denied',
             message: 'Remote hetero agent requires device access',
             operationId,
@@ -2473,6 +2589,7 @@ export class AiAgentService {
             assistantMessageId: assistantMessageRecord.id,
             autoStarted: false,
             createdAt: new Date().toISOString(),
+            createdThreadId,
             error: 'No bound device',
             message: 'Platform agent requires a local or connected device',
             operationId,
@@ -2542,6 +2659,7 @@ export class AiAgentService {
             assistantMessageId: assistantMessageRecord.id,
             autoStarted: false,
             createdAt: new Date().toISOString(),
+            createdThreadId,
             error: result.error,
             message: 'Remote hetero agent dispatch failed',
             operationId,
@@ -2629,6 +2747,7 @@ export class AiAgentService {
               assistantMessageId: assistantMessageRecord.id,
               autoStarted: false,
               createdAt: new Date().toISOString(),
+              createdThreadId,
               error: 'No bound device',
               message: 'Hetero agent requires a bound device',
               operationId,
@@ -2712,6 +2831,7 @@ export class AiAgentService {
               assistantMessageId: assistantMessageRecord.id,
               autoStarted: false,
               createdAt: new Date().toISOString(),
+              createdThreadId,
               error: result.error,
               message: 'Hetero agent device dispatch failed',
               operationId,
@@ -2738,6 +2858,7 @@ export class AiAgentService {
               assistantMessageId: assistantMessageRecord.id,
               autoStarted: false,
               createdAt: new Date().toISOString(),
+              createdThreadId,
               error: message,
               message,
               operationId,
@@ -2807,6 +2928,7 @@ export class AiAgentService {
         assistantMessageId: assistantMessageRecord.id,
         autoStarted: true,
         createdAt: new Date().toISOString(),
+        createdThreadId,
         message: 'Hetero agent dispatched successfully',
         operationId,
         status: 'created',
@@ -2817,6 +2939,11 @@ export class AiAgentService {
         userMessageId: userMessageRecord?.id ?? parentMessageId ?? '',
       };
     }
+
+    // 15. Generate the normal-runtime operation id before device preflight. Even
+    // when preflight fails, the persisted turn returns a complete ExecAgentResult
+    // so clients can reconcile authoritative message and Thread ids.
+    const operationId = `op_${Date.now()}_${resolvedAgentId}_${topicId}_${nanoid(8)}`;
 
     // 4. Fetch user settings (memory config + timezone)
     // Agent-level memory config takes priority; fallback to user-level setting
@@ -2935,11 +3062,11 @@ export class AiAgentService {
     const loadHistoryMessages = async () => {
       if (historyMessagesCache) return historyMessagesCache;
 
-      if (existingMessageIds.length > 0) {
+      if (existingMessageIds.length > 0 && !createdThreadId) {
         const messages = await this.messageModel.query(
           {
             sessionId: appContext?.sessionId,
-            threadId: appContext?.threadId,
+            threadId: executionThreadId,
             topicId: appContext?.topicId ?? undefined,
           },
           { postProcessUrl },
@@ -2954,7 +3081,7 @@ export class AiAgentService {
         const messages = await this.messageModel.query(
           {
             sessionId: appContext?.sessionId,
-            threadId: appContext?.threadId,
+            threadId: executionThreadId,
             topicId: appContext?.topicId,
           },
           { postProcessUrl },
@@ -2992,7 +3119,7 @@ export class AiAgentService {
         appContext?.topicId
       ) {
         const tree = await this.messageModel.queryTopicMessageTree({
-          threadId: appContext.threadId,
+          threadId: executionThreadId,
           topicId: appContext.topicId,
         });
         historyMessagesCache = pruneRegeneratedBranch(historyMessagesCache, tree, parentMessageId);
@@ -3354,8 +3481,11 @@ export class AiAgentService {
         trigger: requestTriggerMetadata?.trigger,
       });
       // A fixed device target must never degrade to the cloud sandbox or a
-      // different device. Persist a visible assistant error and fail the RPC
-      // before tool/runtime preparation so no operation can start elsewhere.
+      // different device. Persist a visible assistant error and return the
+      // authoritative message/thread ids before tool/runtime preparation so no
+      // operation can start elsewhere. Do not reject here: the turn was already
+      // committed above, and a rejected RPC would strand a newly-created thread
+      // under the client's optimistic id with no way to reconcile it.
       if (
         isFixedDeviceTarget &&
         resolveToolMode(agentConfig.chatConfig ?? undefined) !== 'chat' &&
@@ -3374,11 +3504,21 @@ export class AiAgentService {
             type: 'ServerAgentRuntimeError',
           },
         });
-        throw new TRPCError({
-          cause: { data: { code: 'FixedAgentDeviceUnavailable' } },
-          code: 'PRECONDITION_FAILED',
-          message: detail,
-        });
+        return {
+          agentId: resolvedAgentId,
+          assistantMessageId: assistantMessageRecord.id,
+          autoStarted: false,
+          createdAt: new Date().toISOString(),
+          createdThreadId,
+          error: detail,
+          message: 'Fixed agent device unavailable',
+          operationId,
+          status: 'error',
+          success: false,
+          timestamp: new Date().toISOString(),
+          topicId,
+          userMessageId: userMessageRecord?.id ?? parentMessageId ?? '',
+        };
       }
       // Device tools (local-system / remote-device proxy) only exist in a
       // device-capable session — `none` and `sandbox` sessions must never see
@@ -4077,10 +4217,6 @@ export class AiAgentService {
 
     await throwIfExecutionAborted('operation preparation');
 
-    // 15. Generate operation ID: agt_{timestamp}_{agentId}_{topicId}_{random}
-    const timestamp = Date.now();
-    const operationId = `op_${timestamp}_${resolvedAgentId}_${topicId}_${nanoid(8)}`;
-
     // 16. Create initial context
     let initialContext: AgentRuntimeContext = {
       payload: {
@@ -4531,7 +4667,7 @@ export class AiAgentService {
           // loop can stream its running totals down the parent's gateway channel.
           subAgentProgress: appContext?.subAgentProgress,
           taskId: operationTaskId,
-          threadId: appContext?.threadId,
+          threadId: executionThreadId,
           topicId,
           trigger,
         },
@@ -4586,7 +4722,7 @@ export class AiAgentService {
             assistantMessageId: assistantMessageRecord.id,
             operationId,
             scope: appContext?.scope ?? undefined,
-            threadId: appContext?.threadId ?? undefined,
+            threadId: executionThreadId,
           },
         });
       }
@@ -4606,6 +4742,7 @@ export class AiAgentService {
         assistantMessageId: assistantMessageRecord.id,
         autoStarted: result.autoStarted,
         createdAt: new Date().toISOString(),
+        createdThreadId,
         message: 'Agent operation created successfully',
         messageId: result.messageId,
         operationId,
@@ -4648,6 +4785,7 @@ export class AiAgentService {
         assistantMessageId: assistantMessageRecord.id,
         autoStarted: false,
         createdAt: new Date().toISOString(),
+        createdThreadId,
         error: errorMessage,
         message: 'Agent operation failed to start',
         operationId,
@@ -5677,7 +5815,7 @@ export class AiAgentService {
     }
 
     // 4. Update Thread status to cancel
-    if (thread) {
+    if (thread?.type === ThreadType.Isolation) {
       await this.threadModel.update(thread.id, {
         metadata: {
           ...thread.metadata,

--- a/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
+++ b/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
@@ -117,6 +117,8 @@ interface OperationState {
    * Recovered on a cold replica from the current assistant's stamped metadata.
    */
   heteroSessionId: string | undefined;
+  /** Internal isolation guests use their assistant row, never topic-global runtime metadata. */
+  internalIsolation: boolean;
   /** Last DB-confirmed tool-state seq, scoped to this operation. */
   lastAppliedToolStateSeqByCallId: Map<string, number>;
   lastStepIndex: number;
@@ -230,6 +232,7 @@ export class HeterogeneousPersistenceHandler {
       params.topicId,
       params.assistantMessageId,
     );
+    await this.assertOperationCurrent(state);
     const batchMaxStepIndex = Math.max(...params.events.map((event) => event.stepIndex));
 
     // A different Lambda may have already processed `stream_start { newStep }`
@@ -316,14 +319,11 @@ export class HeterogeneousPersistenceHandler {
   }): Promise<void> {
     let state = operationStates.get(params.operationId);
 
-    // A run that died before producing any stream event has no state — but its
-    // terminal error must still land on the assistant message HERE, before the
-    // caller publishes `agent_runtime_end`. The client refetches messages on
-    // that event, so deferring the write to CompletionLifecycle (which runs
-    // after the publish) races the refetch and the error card doesn't render
-    // live. Bootstrap from topic.metadata.runningOperation like ingest does;
-    // a stale/mismatched operation stays a no-op.
-    if (!state && params.result === 'error' && params.error && params.topicId) {
+    // A terminal callback commonly lands on a cold replica. Bootstrap every
+    // result from the producer-supplied durable assistant anchor so successful
+    // runs persist their native session id too; structured errors additionally
+    // need this state to project their error before the terminal publish.
+    if (!state && params.topicId && params.assistantMessageId) {
       try {
         state = await this.loadOrCreateState(
           params.operationId,
@@ -338,15 +338,17 @@ export class HeterogeneousPersistenceHandler {
           params.topicId,
           error,
         );
+        if (error instanceof StaleHeteroOperationError) throw error;
         return;
       }
     }
     if (!state) return;
 
     try {
+      await this.assertOperationCurrent(state, true);
       await this.flushFinalState(state, params.error, params.result);
       if (params.sessionId) {
-        await this.persistSessionId(state.topicId, params.sessionId);
+        await this.persistSessionId(state, params.sessionId);
       } else if (params.result === 'error') {
         // No new session id was produced and the run failed. The most common
         // cause in cloud sandboxes is `--resume <staleId>` failing because the
@@ -357,7 +359,7 @@ export class HeterogeneousPersistenceHandler {
         // When CC ran (system.init was emitted) but produced an error result,
         // `params.sessionId` is set — so this branch is NOT reached and the
         // valid session id is kept for resume on the next turn.
-        await this.clearSessionId(state.topicId);
+        await this.clearSessionId(state);
       }
     } finally {
       operationStates.delete(params.operationId);
@@ -369,12 +371,27 @@ export class HeterogeneousPersistenceHandler {
    * `TopicModel.updateMetadata` merges into existing JSONB so this does NOT
    * clobber `runningOperation` / `workingDirectory` / other peer fields.
    */
-  private async persistSessionId(topicId: string, sessionId: string): Promise<void> {
+  private async persistSessionId(state: OperationState, sessionId: string): Promise<void> {
     try {
-      await this.deps.topicModel.updateMetadata(topicId, { heteroSessionId: sessionId });
-      log('persisted sessionId topic=%s sessionId=%s', topicId, sessionId);
+      if (state.threadId) {
+        await this.deps.messageModel.updateMetadata(state.main.currentAssistantId, {
+          heteroSessionId: sessionId,
+        });
+      } else {
+        await this.deps.topicModel.updateHeterogeneousSessionIfMatches(
+          state.topicId,
+          state.operationId,
+          sessionId,
+        );
+      }
+      log(
+        'persisted sessionId topic=%s thread=%s sessionId=%s',
+        state.topicId,
+        state.threadId ?? 'main',
+        sessionId,
+      );
     } catch (err) {
-      log('persistSessionId failed topic=%s err=%O', topicId, err);
+      log('persistSessionId failed topic=%s thread=%s err=%O', state.topicId, state.threadId, err);
     }
   }
 
@@ -384,16 +401,49 @@ export class HeterogeneousPersistenceHandler {
    * the sandbox was recycled). Prevents the next turn from inheriting a session
    * id that will never succeed.
    */
-  private async clearSessionId(topicId: string): Promise<void> {
+  private async clearSessionId(state: OperationState): Promise<void> {
     try {
-      await this.deps.topicModel.updateMetadata(topicId, { heteroSessionId: undefined });
-      log('cleared stale sessionId topic=%s', topicId);
+      if (state.threadId) {
+        await this.deps.messageModel.removeMetadataKey(
+          state.main.currentAssistantId,
+          'heteroSessionId',
+        );
+      } else {
+        await this.deps.topicModel.updateHeterogeneousSessionIfMatches(
+          state.topicId,
+          state.operationId,
+          undefined,
+        );
+      }
+      log('cleared stale sessionId topic=%s thread=%s', state.topicId, state.threadId ?? 'main');
     } catch (err) {
-      log('clearSessionId failed topic=%s err=%O', topicId, err);
+      log('clearSessionId failed topic=%s thread=%s err=%O', state.topicId, state.threadId, err);
     }
   }
 
   // ─── State management ────────────────────────────────────────────────────
+
+  private async assertOperationCurrent(
+    state: OperationState,
+    allowClearedRunningOperation = false,
+  ): Promise<void> {
+    if (state.internalIsolation) return;
+
+    const topic = await this.deps.topicModel.findById(state.topicId);
+    const runningOperationId = topic?.metadata?.runningOperation?.operationId;
+    const sessionOperationId = topic?.metadata?.heteroSessionOperationId;
+    const isCurrent = runningOperationId === state.operationId;
+    const isClearedCurrent =
+      allowClearedRunningOperation &&
+      !runningOperationId &&
+      sessionOperationId === state.operationId;
+
+    if (!isCurrent && !isClearedCurrent) {
+      throw new StaleHeteroOperationError(
+        `Stale hetero operation ${state.operationId} on topic ${state.topicId}`,
+      );
+    }
+  }
 
   private async loadOrCreateState(
     operationId: string,
@@ -415,18 +465,6 @@ export class HeterogeneousPersistenceHandler {
 
     const topic = await this.deps.topicModel.findById(topicId);
     const running = topic?.metadata?.runningOperation;
-
-    if (!running && !(allowMissingRunningOperation && seedAssistantMessageId)) {
-      throw new StaleHeteroOperationError(
-        `Stale hetero operation ${operationId} on topic ${topicId}; no active runningOperation`,
-      );
-    }
-
-    if (running && running.operationId !== operationId) {
-      throw new StaleHeteroOperationError(
-        `Stale hetero operation ${operationId} on topic ${topicId}; current operation is ${running.operationId}`,
-      );
-    }
 
     // Prefer the assistantMessageId forwarded in the ingest payload (sandbox path).
     // The orchestrator already has it in-memory and passes it through env → CLI → tRPC,
@@ -456,17 +494,51 @@ export class HeterogeneousPersistenceHandler {
       }
     }
 
+    const heteroOperation = baseAssistantMessage?.metadata?.heteroOperation as
+      { internalIsolation?: boolean; operationId?: string } | undefined;
+    const hasOperationBinding = heteroOperation?.operationId === operationId;
+    const hasInternalIsolationBinding =
+      hasOperationBinding && heteroOperation?.internalIsolation === true;
+
+    if (
+      !running &&
+      !hasInternalIsolationBinding &&
+      !(allowMissingRunningOperation && hasOperationBinding)
+    ) {
+      throw new StaleHeteroOperationError(
+        `Stale hetero operation ${operationId} on topic ${topicId}; no active runningOperation`,
+      );
+    }
+
+    if (running && running.operationId !== operationId && !hasInternalIsolationBinding) {
+      throw new StaleHeteroOperationError(
+        `Stale hetero operation ${operationId} on topic ${topicId}; current operation is ${running.operationId}`,
+      );
+    }
+
     // Prefer the latest step's assistant message id (written by handleStepStart)
     // over the initial placeholder — so a new replica after a step boundary uses
     // the correct message rather than the stale initial one.
     // Guard: only use heteroCurrentMsgId when it belongs to THIS operation.
     // A stale value from a previous run must not override the new operation's
     // seeded assistantMessageId (P1 fix).
-    const stored = topic?.metadata?.heteroCurrentMsgId;
-    const currentAssistantMessageId =
+    const stored = hasInternalIsolationBinding ? undefined : topic?.metadata?.heteroCurrentMsgId;
+    let currentAssistantMessageId =
       stored?.operationId === operationId
         ? (stored.msgId ?? baseAssistantMessageId)
         : baseAssistantMessageId;
+    if (
+      hasInternalIsolationBinding &&
+      baseAssistantMessage?.threadId &&
+      baseAssistantMessage.agentId
+    ) {
+      const latest = await this.deps.messageModel.findLatestAssistantMessageByThread({
+        agentId: baseAssistantMessage.agentId,
+        threadId: baseAssistantMessage.threadId,
+        topicId,
+      });
+      currentAssistantMessageId = latest?.id ?? currentAssistantMessageId;
+    }
 
     state = {
       // A direct @Agent run keeps the topic under the conversation owner while
@@ -481,6 +553,7 @@ export class HeterogeneousPersistenceHandler {
       // topic.metadata.heteroSessionId: that holds the id we ASKED CC to resume,
       // which differs from the actual id when a fork/new session occurred.
       heteroSessionId: undefined,
+      internalIsolation: hasInternalIsolationBinding,
       lastStepIndex: 0,
       lastAppliedToolStateSeqByCallId: new Map(),
       main: createMainAgentRunState(currentAssistantMessageId),
@@ -488,7 +561,12 @@ export class HeterogeneousPersistenceHandler {
       processedKeys: new Set(),
       publishedKeys: new Set(),
       toolMsgIdByCallId: new Map(),
-      threadId: running?.threadId ?? undefined,
+      // `runningOperation` may already have been cleared by a concurrent
+      // gateway terminal callback before heteroFinish bootstraps this state.
+      // The seeded assistant row remains a durable, exact-scope authority.
+      threadId: hasInternalIsolationBinding
+        ? (baseAssistantMessage?.threadId ?? undefined)
+        : (running?.threadId ?? baseAssistantMessage?.threadId ?? undefined),
       topicId,
     };
     await this.refreshToolMessageIndex(state);
@@ -796,6 +874,29 @@ export class HeterogeneousPersistenceHandler {
   }
 
   private async syncAssistantPointerForAdvancedStep(state: OperationState): Promise<void> {
+    if (state.internalIsolation && state.threadId && state.agentId) {
+      const latest = await this.deps.messageModel.findLatestAssistantMessageByThread({
+        agentId: state.agentId,
+        threadId: state.threadId,
+        topicId: state.topicId,
+      });
+      if (latest?.id && latest.id !== state.main.currentAssistantId) {
+        state.main = {
+          ...state.main,
+          accContent: '',
+          accReasoning: '',
+          currentAssistantId: latest.id,
+          lastReasoningSnapshotSeq: 0,
+          lastTextSnapshotSeq: 0,
+          toolState: this.createEmptyMainToolState(),
+          turnMetadata: {},
+        };
+        await this.refreshToolMessageIndex(state);
+        await this.refreshMainStateFromDb(state);
+      }
+      return;
+    }
+
     const topic = await this.deps.topicModel.findById(state.topicId);
     const running = topic?.metadata?.runningOperation;
 
@@ -877,7 +978,7 @@ export class HeterogeneousPersistenceHandler {
         // next turn to spawn a fresh CC session and drop all `--resume` history.
         // Writing it here makes resume survive abandon. finish() still overwrites
         // with its own sessionId (or clears a stale one on a resume failure).
-        await this.persistSessionId(state.topicId, sid);
+        await this.persistSessionId(state, sid);
       }
     }
 
@@ -939,9 +1040,11 @@ export class HeterogeneousPersistenceHandler {
           intent.messageId,
         );
 
-        await this.deps.topicModel.updateMetadata(state.topicId, {
-          heteroCurrentMsgId: { msgId: intent.messageId, operationId: state.operationId },
-        });
+        if (!state.internalIsolation) {
+          await this.deps.topicModel.updateMetadata(state.topicId, {
+            heteroCurrentMsgId: { msgId: intent.messageId, operationId: state.operationId },
+          });
+        }
         return;
       }
 

--- a/apps/server/src/services/heterogeneousAgent/__tests__/index.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/__tests__/index.test.ts
@@ -76,15 +76,33 @@ const buildEvent = (
   type,
 });
 
-const createService = (overrides: { streamEventManager?: IStreamEventManager } = {}) => {
+const createService = (
+  overrides: {
+    messageModel?: any;
+    persistenceHandler?: HeterogeneousPersistenceHandler;
+    streamEventManager?: IStreamEventManager;
+    topicModel?: any;
+  } = {},
+) => {
   const { manager, published } = createFakeStreamManager();
-  const persistenceHandler = createFakePersistenceHandler();
+  const persistenceHandler = overrides.persistenceHandler ?? createFakePersistenceHandler();
   const service = new HeterogeneousAgentService({} as any, 'user-test', {
+    messageModel: overrides.messageModel,
     persistenceHandler,
     streamEventManager: overrides.streamEventManager ?? manager,
+    topicModel: overrides.topicModel,
   });
   return { manager, persistenceHandler, published, service };
 };
+
+const createOwnedTopicModel = (operationId: string) =>
+  ({
+    clearRunningOperationIfMatches: vi.fn(async () => true),
+    findById: vi.fn(async () => ({
+      metadata: { runningOperation: { operationId } },
+    })),
+    settleRunningStatus: vi.fn(async () => []),
+  }) as any;
 
 describe('HeterogeneousAgentService', () => {
   describe('normalizeHeterogeneousFinishError', () => {
@@ -384,7 +402,9 @@ describe('HeterogeneousAgentService', () => {
 
   describe('heteroFinish', () => {
     it('publishes a terminal agent_runtime_end with the high-level result', async () => {
-      const { manager, published, service } = createService();
+      const { manager, published, service } = createService({
+        topicModel: createOwnedTopicModel('op-1'),
+      });
 
       await service.heteroFinish({
         agentType: 'claude-code',
@@ -406,7 +426,9 @@ describe('HeterogeneousAgentService', () => {
     });
 
     it('forwards classified error details when the run failed', async () => {
-      const { published, service } = createService();
+      const { published, service } = createService({
+        topicModel: createOwnedTopicModel('op-2'),
+      });
 
       await service.heteroFinish({
         agentType: 'codex',
@@ -425,7 +447,9 @@ describe('HeterogeneousAgentService', () => {
     });
 
     it('persists and publishes a structured auth_required error from a flattened finish', async () => {
-      const { persistenceHandler, published, service } = createService();
+      const { persistenceHandler, published, service } = createService({
+        topicModel: createOwnedTopicModel('op-auth'),
+      });
 
       await service.heteroFinish({
         agentType: 'claude-code',
@@ -451,7 +475,9 @@ describe('HeterogeneousAgentService', () => {
     });
 
     it('handles cancelled runs and runs without sessionId', async () => {
-      const { published, service } = createService();
+      const { published, service } = createService({
+        topicModel: createOwnedTopicModel('op-3'),
+      });
 
       await service.heteroFinish({
         agentType: 'claude-code',
@@ -464,6 +490,22 @@ describe('HeterogeneousAgentService', () => {
         operationId: 'op-3',
         reason: 'cancelled',
       });
+    });
+
+    it('rejects an unbound stale legacy finish before persistence or terminal publication', async () => {
+      const { manager, persistenceHandler, service } = createService({
+        topicModel: createOwnedTopicModel('op-new'),
+      });
+
+      await service.heteroFinish({
+        agentType: 'claude-code',
+        operationId: 'op-old',
+        result: 'success',
+        topicId: 'topic-shared',
+      });
+
+      expect(persistenceHandler.finish).not.toHaveBeenCalled();
+      expect(manager.publishStreamEvent).not.toHaveBeenCalled();
     });
 
     // The unified terminal funnel: heteroFinish must drive the run's lifecycle
@@ -483,7 +525,9 @@ describe('HeterogeneousAgentService', () => {
     };
 
     it('fires onComplete (reason=done) hooks on a successful run', async () => {
-      const { service } = createService();
+      const { service } = createService({
+        topicModel: createOwnedTopicModel('op-hook-success'),
+      });
       const { onComplete, onError } = registerHook('op-hook-success');
 
       await service.heteroFinish({
@@ -504,7 +548,9 @@ describe('HeterogeneousAgentService', () => {
     });
 
     it('fires both onComplete and onError (reason=error) hooks on a failed run', async () => {
-      const { service } = createService();
+      const { service } = createService({
+        topicModel: createOwnedTopicModel('op-hook-error'),
+      });
       const { onComplete, onError } = registerHook('op-hook-error');
 
       await service.heteroFinish({
@@ -525,13 +571,161 @@ describe('HeterogeneousAgentService', () => {
       });
     });
 
+    it('does not consume hooks or clear metadata for a stale operation', async () => {
+      const topicModel = createOwnedTopicModel('op-new');
+      const { manager, persistenceHandler, service } = createService({
+        messageModel: {
+          findById: vi.fn(async () => ({
+            id: 'asst-old',
+            metadata: { heteroOperation: { operationId: 'op-old' } },
+            threadId: 'thread-old',
+            topicId: 'topic-shared',
+          })),
+        },
+        topicModel,
+      });
+      const { onComplete, onError } = registerHook('op-old');
+
+      await service.heteroFinish({
+        agentType: 'claude-code',
+        assistantMessageId: 'asst-old',
+        operationId: 'op-old',
+        result: 'success',
+        topicId: 'topic-shared',
+      });
+
+      expect(onComplete).not.toHaveBeenCalled();
+      expect(onError).not.toHaveBeenCalled();
+      expect(persistenceHandler.finish).not.toHaveBeenCalled();
+      expect(manager.publishStreamEvent).not.toHaveBeenCalled();
+      expect(topicModel.clearRunningOperationIfMatches).not.toHaveBeenCalled();
+      expect(topicModel.settleRunningStatus).not.toHaveBeenCalled();
+      expect(hookDispatcher.hasHooks('op-old')).toBe(true);
+      hookDispatcher.unregister('op-old');
+    });
+
+    it.each([
+      ['Topic', 'topic-other', 'thread-current'],
+      ['Thread', 'topic-shared', 'thread-other'],
+    ])(
+      'rejects a seeded assistant from a different %s before persistence or publication',
+      async (_scope, assistantTopicId, assistantThreadId) => {
+        const topicModel = {
+          clearRunningOperationIfMatches: vi.fn(async () => true),
+          findById: vi.fn(async () => ({
+            id: 'topic-shared',
+            metadata: {
+              runningOperation: {
+                assistantMessageId: 'asst-current',
+                operationId: 'op-current',
+                threadId: 'thread-current',
+              },
+            },
+          })),
+        } as any;
+        const { manager, persistenceHandler, service } = createService({
+          messageModel: {
+            findById: vi.fn(async () => ({
+              id: 'asst-current',
+              metadata: { heteroOperation: { operationId: 'op-current' } },
+              threadId: assistantThreadId,
+              topicId: assistantTopicId,
+            })),
+          },
+          topicModel,
+        });
+
+        await service.heteroFinish({
+          agentType: 'claude-code',
+          assistantMessageId: 'asst-current',
+          operationId: 'op-current',
+          result: 'success',
+          topicId: 'topic-shared',
+        });
+
+        expect(persistenceHandler.finish).not.toHaveBeenCalled();
+        expect(manager.publishStreamEvent).not.toHaveBeenCalled();
+        expect(topicModel.clearRunningOperationIfMatches).not.toHaveBeenCalled();
+      },
+    );
+
+    it('accepts an exact internal-isolation seed alongside the parent Topic operation', async () => {
+      const { manager, persistenceHandler, service } = createService({
+        messageModel: {
+          findById: vi.fn(async () => ({
+            id: 'asst-child',
+            metadata: {
+              heteroOperation: { internalIsolation: true, operationId: 'op-child' },
+            },
+            threadId: 'thread-child',
+            topicId: 'topic-parent',
+          })),
+        },
+        topicModel: createOwnedTopicModel('op-parent'),
+      });
+
+      await service.heteroFinish({
+        agentType: 'claude-code',
+        assistantMessageId: 'asst-child',
+        operationId: 'op-child',
+        result: 'cancelled',
+        topicId: 'topic-parent',
+      });
+
+      expect(persistenceHandler.finish).toHaveBeenCalledTimes(1);
+      expect(manager.publishStreamEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not publish a terminal event when cold persistence rejects a stale finish', async () => {
+      const persistenceHandler = createFakePersistenceHandler();
+      persistenceHandler.finish.mockRejectedValue(
+        new StaleHeteroOperationError('operation was replaced'),
+      );
+      const topicModel = createOwnedTopicModel('op-old');
+      topicModel.findById.mockResolvedValue({
+        id: 'topic-shared',
+        metadata: {
+          runningOperation: {
+            assistantMessageId: 'asst-old',
+            operationId: 'op-old',
+            threadId: 'thread-old',
+          },
+        },
+      });
+      const { manager, service } = createService({
+        messageModel: {
+          findById: vi.fn(async () => ({
+            id: 'asst-old',
+            metadata: { heteroOperation: { operationId: 'op-old' } },
+            threadId: 'thread-old',
+            topicId: 'topic-shared',
+          })),
+        },
+        persistenceHandler,
+        topicModel,
+      });
+
+      await service.heteroFinish({
+        agentType: 'claude-code',
+        assistantMessageId: 'asst-old',
+        operationId: 'op-old',
+        result: 'success',
+        topicId: 'topic-shared',
+      });
+
+      expect(persistenceHandler.finish).toHaveBeenCalledTimes(1);
+      expect(manager.publishStreamEvent).not.toHaveBeenCalled();
+    });
+
     // Verify-lifecycle alignment: heteroFinish must route the terminal transition
     // through CompletionLifecycle (the SAME owner the in-process runtime uses), not
     // a stripped-down funnel. That single funnel is what runs the delivery-checker
     // gate on success — and the gate bails unless op.model/provider are set, so the
     // synthetic state MUST carry the model/provider backfilled from the CLI stream.
     it('routes the terminal transition through CompletionLifecycle with backfilled model/provider', async () => {
-      const { service } = createService();
+      const { service } = createService({
+        topicModel: createOwnedTopicModel('op-verify-align'),
+      });
 
       const finalizeSpy = vi.spyOn(HeteroTraceRecorder.prototype, 'finalize').mockResolvedValue({
         llmCalls: 3,
@@ -582,7 +776,9 @@ describe('HeterogeneousAgentService', () => {
     // must therefore re-run the idempotent durable instantiation and AWAIT it
     // before dispatching the gate.
     it('awaits durable verify-plan instantiation before the completion gate for a task-bound run', async () => {
-      const { service } = createService();
+      const { service } = createService({
+        topicModel: createOwnedTopicModel('op-race-guard'),
+      });
 
       const findByIdSpy = vi
         .spyOn(AgentOperationModel.prototype, 'findById')
@@ -619,7 +815,9 @@ describe('HeterogeneousAgentService', () => {
     });
 
     it('skips verify-plan instantiation for a non-task hetero run', async () => {
-      const { service } = createService();
+      const { service } = createService({
+        topicModel: createOwnedTopicModel('op-no-task'),
+      });
 
       const findByIdSpy = vi
         .spyOn(AgentOperationModel.prototype, 'findById')
@@ -648,7 +846,9 @@ describe('HeterogeneousAgentService', () => {
     });
 
     it('does NOT fire hooks on a cancelled run (the real result fires them)', async () => {
-      const { service } = createService();
+      const { service } = createService({
+        topicModel: createOwnedTopicModel('op-hook-cancelled'),
+      });
       const { onComplete, onError } = registerHook('op-hook-cancelled');
 
       await service.heteroFinish({
@@ -693,12 +893,14 @@ describe('HeterogeneousAgentService', () => {
 
     const makeService = (hooks: SerializedHook[] | undefined) => {
       const topicModel = {
+        clearRunningOperationIfMatches: vi.fn(async () => true),
         // Mirror what execAgent persisted at dispatch: the serialized hooks live
         // under runningOperation. heteroFinish must read them from here.
         findById: vi.fn(async () => ({
           id: 'topic-q',
           metadata: { runningOperation: { hooks, operationId: 'op-q' } },
         })),
+        settleRunningStatus: vi.fn(async () => []),
         updateMetadata: vi.fn(async () => {}),
       } as any;
       const { manager } = createFakeStreamManager();
@@ -794,7 +996,13 @@ describe('HeterogeneousAgentService', () => {
     const makeStore = () => {
       let meta: Record<string, any> = {};
       const topicModel = {
+        clearRunningOperationIfMatches: vi.fn(async (_id: string, operationId: string) => {
+          if (meta.runningOperation?.operationId !== operationId) return false;
+          meta = { ...meta, runningOperation: null };
+          return true;
+        }),
         findById: vi.fn(async () => ({ id: TOPIC, metadata: meta })),
+        settleRunningStatus: vi.fn(async () => []),
         updateMetadata: vi.fn(async (_id: string, patch: Record<string, any>, mergeBase?: any) => {
           meta = { ...(mergeBase ?? meta), ...patch };
         }),

--- a/apps/server/src/services/heterogeneousAgent/__tests__/sessionResume.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/__tests__/sessionResume.test.ts
@@ -15,9 +15,9 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
   beforeEach(() => __resetOperationStatesForTesting());
   afterEach(() => __resetOperationStatesForTesting());
 
-  describe('heteroFinish persists sessionId via TopicModel.updateMetadata', () => {
+  describe('heteroFinish persists an operation-scoped session id', () => {
     it('writes the CLI session id to topic.metadata.heteroSessionId', async () => {
-      const updateMetadata = vi.fn(async () => undefined);
+      const updateHeterogeneousSessionIfMatches = vi.fn(async () => true);
       const findById = vi.fn(async () => ({
         agentId: null,
         id: 'topic-1',
@@ -38,7 +38,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
           update: vi.fn(async () => ({ success: true })),
         } as any,
         threadModel: {} as any,
-        topicModel: { findById, updateMetadata } as any,
+        topicModel: { findById, updateHeterogeneousSessionIfMatches } as any,
       });
 
       // Seed in-memory state by ingesting one event so finish has something to drain
@@ -59,6 +59,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
       const service = new HeterogeneousAgentService({} as any, 'user-1', {
         persistenceHandler: handler,
         streamEventManager: createSilentStreamManager(),
+        topicModel: { findById } as any,
       });
 
       await service.heteroFinish({
@@ -69,13 +70,15 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
         topicId: 'topic-1',
       });
 
-      expect(updateMetadata).toHaveBeenCalledWith('topic-1', {
-        heteroSessionId: 'cc-session-fresh',
-      });
+      expect(updateHeterogeneousSessionIfMatches).toHaveBeenCalledWith(
+        'topic-1',
+        'op-1',
+        'cc-session-fresh',
+      );
     });
 
     it('skips the metadata write when no sessionId is provided on success', async () => {
-      const updateMetadata = vi.fn(async () => undefined);
+      const updateHeterogeneousSessionIfMatches = vi.fn(async () => true);
       const findById = vi.fn(async () => ({
         agentId: null,
         id: 'topic-2',
@@ -95,7 +98,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
           update: vi.fn(async () => ({ success: true })),
         } as any,
         threadModel: {} as any,
-        topicModel: { findById, updateMetadata } as any,
+        topicModel: { findById, updateHeterogeneousSessionIfMatches } as any,
       });
       await handler.ingest({
         events: [
@@ -114,6 +117,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
       const service = new HeterogeneousAgentService({} as any, 'user-1', {
         persistenceHandler: handler,
         streamEventManager: createSilentStreamManager(),
+        topicModel: { findById } as any,
       });
 
       await service.heteroFinish({
@@ -124,11 +128,11 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
         topicId: 'topic-2',
       });
 
-      expect(updateMetadata).not.toHaveBeenCalled();
+      expect(updateHeterogeneousSessionIfMatches).not.toHaveBeenCalled();
     });
 
     it('clears stale heteroSessionId when result=error and no sessionId (sandbox recycled)', async () => {
-      const updateMetadata = vi.fn(async () => undefined);
+      const updateHeterogeneousSessionIfMatches = vi.fn(async () => true);
       const findById = vi.fn(async () => ({
         agentId: null,
         id: 'topic-stale',
@@ -146,7 +150,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
           update: vi.fn(async () => ({ success: true })),
         } as any,
         threadModel: {} as any,
-        topicModel: { findById, updateMetadata } as any,
+        topicModel: { findById, updateHeterogeneousSessionIfMatches } as any,
       });
 
       await handler.ingest({
@@ -166,6 +170,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
       const service = new HeterogeneousAgentService({} as any, 'user-1', {
         persistenceHandler: handler,
         streamEventManager: createSilentStreamManager(),
+        topicModel: { findById } as any,
       });
 
       // Simulate: sandbox was recycled, CC exited before emitting system.init
@@ -179,11 +184,15 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
       });
 
       // Must clear the stale session id so the next turn starts fresh
-      expect(updateMetadata).toHaveBeenCalledWith('topic-stale', { heteroSessionId: undefined });
+      expect(updateHeterogeneousSessionIfMatches).toHaveBeenCalledWith(
+        'topic-stale',
+        'op-stale',
+        undefined,
+      );
     });
 
     it('persists sessionId even when result=error (so the next run can still resume context)', async () => {
-      const updateMetadata = vi.fn(async () => undefined);
+      const updateHeterogeneousSessionIfMatches = vi.fn(async () => true);
       const findById = vi.fn(async () => ({
         agentId: null,
         id: 'topic-3',
@@ -203,7 +212,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
           update: vi.fn(async () => ({ success: true })),
         } as any,
         threadModel: {} as any,
-        topicModel: { findById, updateMetadata } as any,
+        topicModel: { findById, updateHeterogeneousSessionIfMatches } as any,
       });
       await handler.ingest({
         events: [
@@ -222,6 +231,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
       const service = new HeterogeneousAgentService({} as any, 'user-1', {
         persistenceHandler: handler,
         streamEventManager: createSilentStreamManager(),
+        topicModel: { findById } as any,
       });
 
       await service.heteroFinish({
@@ -233,16 +243,15 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
         topicId: 'topic-3',
       });
 
-      expect(updateMetadata).toHaveBeenCalledWith('topic-3', {
-        heteroSessionId: 'cc-session-partial',
-      });
+      expect(updateHeterogeneousSessionIfMatches).toHaveBeenCalledWith(
+        'topic-3',
+        'op-3',
+        'cc-session-partial',
+      );
     });
 
-    it('topic.metadata.runningOperation is preserved (updateMetadata merges, does not replace)', async () => {
-      // This contract is enforced by `TopicModel.updateMetadata` itself
-      // (verified in packages/database tests). We just assert the handler
-      // calls it with a partial — not the full metadata object.
-      const updateMetadata = vi.fn(async () => undefined);
+    it('scopes the session update to the current operation', async () => {
+      const updateHeterogeneousSessionIfMatches = vi.fn(async () => true);
       const findById = vi.fn(async () => ({
         agentId: null,
         id: 'topic-4',
@@ -263,7 +272,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
           update: vi.fn(async () => ({ success: true })),
         } as any,
         threadModel: {} as any,
-        topicModel: { findById, updateMetadata } as any,
+        topicModel: { findById, updateHeterogeneousSessionIfMatches } as any,
       });
       await handler.ingest({
         events: [
@@ -282,6 +291,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
       const service = new HeterogeneousAgentService({} as any, 'user-1', {
         persistenceHandler: handler,
         streamEventManager: createSilentStreamManager(),
+        topicModel: { findById } as any,
       });
 
       await service.heteroFinish({
@@ -292,19 +302,15 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
         topicId: 'topic-4',
       });
 
-      // Critical: passes only the field we want to update; other peers
-      // (runningOperation, workingDirectory) are untouched in the patch
-      // and TopicModel.updateMetadata's merge semantics preserve them.
-      expect(updateMetadata).toHaveBeenCalledTimes(1);
-      const call = updateMetadata.mock.calls[0] as unknown as [string, Record<string, unknown>];
-      const patch = call[1];
-      expect(patch).toEqual({ heteroSessionId: 'cc-session-resume-target' });
-      expect(patch).not.toHaveProperty('runningOperation');
-      expect(patch).not.toHaveProperty('workingDirectory');
+      expect(updateHeterogeneousSessionIfMatches).toHaveBeenCalledWith(
+        'topic-4',
+        'op-4',
+        'cc-session-resume-target',
+      );
     });
 
-    it('updateMetadata failure does not poison heteroFinish (terminal event still publishes)', async () => {
-      const updateMetadata = vi.fn(async () => {
+    it('session persistence failure does not poison heteroFinish (terminal event still publishes)', async () => {
+      const updateHeterogeneousSessionIfMatches = vi.fn(async () => {
         throw new Error('connection lost');
       });
       const findById = vi.fn(async () => ({
@@ -326,7 +332,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
           update: vi.fn(async () => ({ success: true })),
         } as any,
         threadModel: {} as any,
-        topicModel: { findById, updateMetadata } as any,
+        topicModel: { findById, updateHeterogeneousSessionIfMatches } as any,
       });
       await handler.ingest({
         events: [
@@ -346,6 +352,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
       const service = new HeterogeneousAgentService({} as any, 'user-1', {
         persistenceHandler: handler,
         streamEventManager: stream,
+        topicModel: { findById } as any,
       });
 
       // Should not throw — sessionId persistence is best-effort
@@ -365,8 +372,282 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
   });
 
   describe('eager session-id persistence on stream_start (survives watchdog abandon)', () => {
+    it('stores a thread session on its assistant anchor without overwriting the main topic', async () => {
+      const updateTopicMetadata = vi.fn(async () => undefined);
+      const updateMessageMetadata = vi.fn(async () => undefined);
+      const findById = vi.fn(async () => ({
+        agentId: 'agent-1',
+        id: 'asst-thread-a',
+        metadata: null,
+        threadId: 'thread-a',
+        topicId: 'topic-shared',
+      }));
+      const handler = new HeterogeneousPersistenceHandler({
+        messageModel: {
+          findById,
+          getLatestSpineMessageId: vi.fn(async () => null),
+          listMessagePluginsByTopic: vi.fn(async () => []),
+          update: vi.fn(async () => ({ success: true })),
+          updateMetadata: updateMessageMetadata,
+        } as any,
+        threadModel: {} as any,
+        topicModel: {
+          findById: vi.fn(async () => ({
+            agentId: 'agent-1',
+            id: 'topic-shared',
+            metadata: {
+              heteroSessionId: 'main-session',
+              runningOperation: {
+                assistantMessageId: 'asst-thread-a',
+                operationId: 'op-thread-a',
+                threadId: 'thread-a',
+              },
+            },
+          })),
+          updateMetadata: updateTopicMetadata,
+        } as any,
+      });
+
+      await handler.ingest({
+        assistantMessageId: 'asst-thread-a',
+        events: [
+          {
+            data: { sessionId: 'thread-a-session' },
+            operationId: 'op-thread-a',
+            stepIndex: 0,
+            timestamp: 1,
+            type: 'stream_start',
+          },
+        ],
+        operationId: 'op-thread-a',
+        topicId: 'topic-shared',
+      });
+
+      expect(updateMessageMetadata).toHaveBeenCalledWith('asst-thread-a', {
+        heteroSessionId: 'thread-a-session',
+      });
+      expect(updateTopicMetadata).not.toHaveBeenCalled();
+    });
+
+    it('clears only the failed thread anchor session', async () => {
+      const removeMetadataKey = vi.fn(async () => undefined);
+      const updateTopicMetadata = vi.fn(async () => undefined);
+      const handler = new HeterogeneousPersistenceHandler({
+        messageModel: {
+          findById: vi.fn(async () => ({
+            agentId: 'agent-1',
+            id: 'asst-thread-a',
+            metadata: null,
+            threadId: 'thread-a',
+            topicId: 'topic-shared',
+          })),
+          getLatestSpineMessageId: vi.fn(async () => null),
+          listMessagePluginsByTopic: vi.fn(async () => []),
+          removeMetadataKey,
+          update: vi.fn(async () => ({ success: true })),
+        } as any,
+        threadModel: {} as any,
+        topicModel: {
+          findById: vi.fn(async () => ({
+            agentId: 'agent-1',
+            id: 'topic-shared',
+            metadata: {
+              heteroSessionId: 'main-session',
+              runningOperation: {
+                assistantMessageId: 'asst-thread-a',
+                operationId: 'op-thread-a',
+                threadId: 'thread-a',
+              },
+            },
+          })),
+          updateMetadata: updateTopicMetadata,
+        } as any,
+      });
+      await handler.ingest({
+        assistantMessageId: 'asst-thread-a',
+        events: [
+          {
+            data: { chunkType: 'text', content: '' },
+            operationId: 'op-thread-a',
+            stepIndex: 0,
+            timestamp: 1,
+            type: 'stream_chunk',
+          },
+        ],
+        operationId: 'op-thread-a',
+        topicId: 'topic-shared',
+      });
+
+      await handler.finish({
+        operationId: 'op-thread-a',
+        result: 'error',
+        topicId: 'topic-shared',
+      });
+
+      expect(removeMetadataKey).toHaveBeenCalledWith('asst-thread-a', 'heteroSessionId');
+      expect(updateTopicMetadata).not.toHaveBeenCalled();
+    });
+
+    it('recovers thread scope from the seeded assistant after runningOperation was cleared', async () => {
+      const updateMessageMetadata = vi.fn(async () => undefined);
+      const updateTopicMetadata = vi.fn(async () => undefined);
+      const handler = new HeterogeneousPersistenceHandler({
+        messageModel: {
+          findById: vi.fn(async () => ({
+            agentId: 'agent-1',
+            content: '',
+            id: 'asst-thread-race',
+            metadata: { heteroOperation: { operationId: 'op-thread-race' } },
+            threadId: 'thread-race',
+            topicId: 'topic-shared',
+          })),
+          getLatestSpineMessageId: vi.fn(async () => null),
+          listMessagePluginsByTopic: vi.fn(async () => []),
+          update: vi.fn(async () => ({ success: true })),
+          updateMetadata: updateMessageMetadata,
+        } as any,
+        threadModel: {} as any,
+        topicModel: {
+          findById: vi.fn(async () => ({
+            agentId: 'agent-1',
+            id: 'topic-shared',
+            metadata: {
+              heteroSessionId: 'main-session',
+              heteroSessionOperationId: 'op-thread-race',
+              runningOperation: null,
+            },
+          })),
+          updateMetadata: updateTopicMetadata,
+        } as any,
+      });
+
+      await handler.finish({
+        assistantMessageId: 'asst-thread-race',
+        error: { message: 'run failed', type: 'AgentRuntimeError' },
+        operationId: 'op-thread-race',
+        result: 'error',
+        sessionId: 'thread-race-session',
+        topicId: 'topic-shared',
+      });
+
+      expect(updateMessageMetadata).toHaveBeenCalledWith('asst-thread-race', {
+        heteroSessionId: 'thread-race-session',
+      });
+      expect(updateTopicMetadata).not.toHaveBeenCalledWith(
+        'topic-shared',
+        expect.objectContaining({ heteroSessionId: expect.anything() }),
+      );
+    });
+
+    it('persists a successful cold-finish session after runningOperation was cleared', async () => {
+      const updateMessageMetadata = vi.fn(async () => undefined);
+      const updateTopicMetadata = vi.fn(async () => undefined);
+      const handler = new HeterogeneousPersistenceHandler({
+        messageModel: {
+          findById: vi.fn(async () => ({
+            agentId: 'agent-1',
+            content: 'done',
+            id: 'asst-thread-success',
+            metadata: { heteroOperation: { operationId: 'op-thread-success' } },
+            threadId: 'thread-success',
+            topicId: 'topic-shared',
+          })),
+          getLatestSpineMessageId: vi.fn(async () => null),
+          listMessagePluginsByTopic: vi.fn(async () => []),
+          update: vi.fn(async () => ({ success: true })),
+          updateMetadata: updateMessageMetadata,
+        } as any,
+        threadModel: {} as any,
+        topicModel: {
+          findById: vi.fn(async () => ({
+            agentId: 'agent-1',
+            id: 'topic-shared',
+            metadata: {
+              heteroSessionOperationId: 'op-thread-success',
+              runningOperation: null,
+            },
+          })),
+          updateMetadata: updateTopicMetadata,
+        } as any,
+      });
+
+      await handler.finish({
+        assistantMessageId: 'asst-thread-success',
+        operationId: 'op-thread-success',
+        result: 'success',
+        sessionId: 'thread-success-session',
+        topicId: 'topic-shared',
+      });
+
+      expect(updateMessageMetadata).toHaveBeenCalledWith('asst-thread-success', {
+        heteroSessionId: 'thread-success-session',
+      });
+      expect(updateTopicMetadata).not.toHaveBeenCalled();
+    });
+
+    it('uses the durable internal binding without touching a parent running operation', async () => {
+      const updateMessageMetadata = vi.fn(async () => undefined);
+      const updateTopicMetadata = vi.fn(async () => undefined);
+      const handler = new HeterogeneousPersistenceHandler({
+        messageModel: {
+          findById: vi.fn(async () => ({
+            agentId: 'child-agent',
+            content: '',
+            id: 'asst-child',
+            metadata: {
+              heteroOperation: {
+                internalIsolation: true,
+                operationId: 'op-child',
+              },
+            },
+            threadId: 'thread-child',
+            topicId: 'topic-parent',
+          })),
+          findLatestAssistantMessageByThread: vi.fn(async () => ({ id: 'asst-child' })),
+          getLatestSpineMessageId: vi.fn(async () => null),
+          listMessagePluginsByTopic: vi.fn(async () => []),
+          update: vi.fn(async () => ({ success: true })),
+          updateMetadata: updateMessageMetadata,
+        } as any,
+        threadModel: { queryByTopicId: vi.fn(async () => []) } as any,
+        topicModel: {
+          findById: vi.fn(async () => ({
+            agentId: 'parent-agent',
+            id: 'topic-parent',
+            metadata: {
+              runningOperation: {
+                assistantMessageId: 'asst-parent',
+                operationId: 'op-parent',
+              },
+            },
+          })),
+          updateMetadata: updateTopicMetadata,
+        } as any,
+      });
+
+      await handler.ingest({
+        assistantMessageId: 'asst-child',
+        events: [
+          {
+            data: { sessionId: 'child-session' },
+            operationId: 'op-child',
+            stepIndex: 0,
+            timestamp: 1,
+            type: 'stream_start',
+          },
+        ],
+        operationId: 'op-child',
+        topicId: 'topic-parent',
+      });
+
+      expect(updateMessageMetadata).toHaveBeenCalledWith('asst-child', {
+        heteroSessionId: 'child-session',
+      });
+      expect(updateTopicMetadata).not.toHaveBeenCalled();
+    });
+
     it('persists heteroSessionId as soon as stream_start reports it, without waiting for heteroFinish', async () => {
-      const updateMetadata = vi.fn(async () => undefined);
+      const updateHeterogeneousSessionIfMatches = vi.fn(async () => true);
       const findById = vi.fn(async () => ({
         agentId: null,
         id: 'topic-abandon',
@@ -383,7 +664,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
           update: vi.fn(async () => ({ success: true })),
         } as any,
         threadModel: {} as any,
-        topicModel: { findById, updateMetadata } as any,
+        topicModel: { findById, updateHeterogeneousSessionIfMatches } as any,
       });
 
       // Only a stream_start reporting the CC session id — NO heteroFinish. This
@@ -404,13 +685,15 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
       });
 
       // The resume token is already on topic.metadata — the next turn can resume.
-      expect(updateMetadata).toHaveBeenCalledWith('topic-abandon', {
-        heteroSessionId: 'cc-live-session',
-      });
+      expect(updateHeterogeneousSessionIfMatches).toHaveBeenCalledWith(
+        'topic-abandon',
+        'op-abandon',
+        'cc-live-session',
+      );
     });
 
     it('does not re-write when stream_start repeats the same session id', async () => {
-      const updateMetadata = vi.fn(async () => undefined);
+      const updateHeterogeneousSessionIfMatches = vi.fn(async () => true);
       const findById = vi.fn(async () => ({
         agentId: null,
         id: 'topic-dedupe',
@@ -425,7 +708,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
           update: vi.fn(async () => ({ success: true })),
         } as any,
         threadModel: {} as any,
-        topicModel: { findById, updateMetadata } as any,
+        topicModel: { findById, updateHeterogeneousSessionIfMatches } as any,
       });
 
       await handler.ingest({
@@ -449,7 +732,7 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
         topicId: 'topic-dedupe',
       });
 
-      expect(updateMetadata).toHaveBeenCalledTimes(1);
+      expect(updateHeterogeneousSessionIfMatches).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -480,6 +763,32 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
       const sessionId = await service.getHeterogeneousResumeSessionId('topic-resume');
       expect(sessionId).toBe('cc-session-aaaa');
       expect(findById).toHaveBeenCalledWith('topic-resume');
+    });
+
+    it('reads an exact thread session without consulting topic metadata', async () => {
+      const findLatestHeterogeneousSessionId = vi.fn(async () => 'thread-a-session');
+      const findTopicById = vi.fn(async () => ({
+        metadata: { heteroSessionId: 'main-session' },
+      }));
+      const service = new HeterogeneousAgentService({} as any, 'user-1', {
+        messageModel: { findLatestHeterogeneousSessionId } as any,
+        persistenceHandler: {
+          finish: vi.fn(async () => {}),
+          ingest: vi.fn(async () => {}),
+        } as unknown as HeterogeneousPersistenceHandler,
+        streamEventManager: createSilentStreamManager(),
+        topicModel: { findById: findTopicById } as any,
+      });
+
+      await expect(
+        service.getHeterogeneousResumeSessionId('topic-shared', 'thread-a', 'asst-current'),
+      ).resolves.toBe('thread-a-session');
+      expect(findLatestHeterogeneousSessionId).toHaveBeenCalledWith({
+        excludeMessageId: 'asst-current',
+        threadId: 'thread-a',
+        topicId: 'topic-shared',
+      });
+      expect(findTopicById).not.toHaveBeenCalled();
     });
 
     it('returns undefined when no prior run persisted a session id', async () => {

--- a/apps/server/src/services/heterogeneousAgent/index.ts
+++ b/apps/server/src/services/heterogeneousAgent/index.ts
@@ -6,7 +6,7 @@ import {
   isHeteroStatusGuideErrorData,
   type LocalHeterogeneousAgentType,
 } from '@lobechat/heterogeneous-agents';
-import { ThreadStatus } from '@lobechat/types';
+import { ThreadStatus, ThreadType } from '@lobechat/types';
 import debug from 'debug';
 
 import { AgentOperationModel } from '@/database/models/agentOperation';
@@ -66,6 +66,12 @@ export interface HeterogeneousFinishParams {
   topicId: string;
 }
 
+interface PersistedHeterogeneousOperation {
+  hooks?: SerializedHook[];
+  internalIsolation?: boolean;
+  operationId?: string;
+}
+
 type HeterogeneousFinishError = NonNullable<HeterogeneousFinishParams['error']>;
 
 /**
@@ -100,6 +106,8 @@ export const normalizeHeterogeneousFinishError = (
 };
 
 export interface HeterogeneousAgentServiceOptions {
+  /** Inject a pre-built MessageModel (used by tests for thread-scoped resume). */
+  messageModel?: MessageModel;
   /** Inject a pre-built persistence handler (used by tests). */
   persistenceHandler?: HeterogeneousPersistenceHandler;
   /** Inject a snapshot store (used by tests); defaults to the env-resolved store. */
@@ -145,7 +153,7 @@ export class HeterogeneousAgentService {
     this.userId = userId;
     const workspaceId = options.workspaceId;
     this.workspaceId = workspaceId;
-    this.messageModel = new MessageModel(db, userId, workspaceId);
+    this.messageModel = options.messageModel ?? new MessageModel(db, userId, workspaceId);
     this.streamEventManager = options.streamEventManager ?? createStreamEventManager();
     this.topicModel = options.topicModel ?? new TopicModel(db, userId, workspaceId);
     this.traceRecorder = new HeteroTraceRecorder(
@@ -264,6 +272,47 @@ export class HeterogeneousAgentService {
       );
     }
 
+    // Validate the callback's durable ownership before persistence or terminal
+    // publication. A producer-supplied assistant id is authority only when the
+    // owned row binds the same operation and exact Topic/Thread scope. Internal
+    // isolation runs intentionally coexist with their parent's Topic marker;
+    // ordinary runs must own that marker, or the surviving session-generation
+    // marker when a gateway callback already cleared it.
+    let seedAssistantMessage: Awaited<ReturnType<MessageModel['findById']>>;
+    let persistedOperation: PersistedHeterogeneousOperation | undefined;
+    let internalIsolation = false;
+    const topicBeforeFinish = await this.topicModel.findById(topicId);
+    const runningBeforeFinish = topicBeforeFinish?.metadata?.runningOperation;
+    if (!topicBeforeFinish) return;
+    if (seedAssistantMessageId) {
+      seedAssistantMessage = await this.messageModel.findById(seedAssistantMessageId);
+      persistedOperation = seedAssistantMessage?.metadata?.heteroOperation as
+        PersistedHeterogeneousOperation | undefined;
+      const matchesSeedBinding =
+        seedAssistantMessage?.topicId === topicId &&
+        persistedOperation?.operationId === operationId;
+      internalIsolation = matchesSeedBinding && persistedOperation?.internalIsolation === true;
+      const ownsRunningOperation = runningBeforeFinish?.operationId === operationId;
+      const matchesRunningThread =
+        (runningBeforeFinish?.threadId ?? undefined) ===
+        (seedAssistantMessage?.threadId ?? undefined);
+      const ownsClearedGeneration =
+        !runningBeforeFinish &&
+        topicBeforeFinish.metadata?.heteroSessionOperationId === operationId;
+      if (
+        !matchesSeedBinding ||
+        (internalIsolation && !seedAssistantMessage?.threadId) ||
+        (!internalIsolation &&
+          !((ownsRunningOperation && matchesRunningThread) || ownsClearedGeneration))
+      ) {
+        log('heteroFinish: stale seeded operation ignored op=%s topic=%s', operationId, topicId);
+        return;
+      }
+    } else if (runningBeforeFinish?.operationId !== operationId) {
+      log('heteroFinish: unbound stale operation ignored op=%s topic=%s', operationId, topicId);
+      return;
+    }
+
     // Drain any pending state in the persistence handler — flushes trailing
     // accumulated content / reasoning that the in-stream `agent_runtime_end`
     // already wrote (no-op when state is clean), persists the CLI's native
@@ -272,14 +321,22 @@ export class HeterogeneousAgentService {
     // producing any stream event (spawn ENOENT / auth-on-stderr): the terminal
     // error must be written HERE, before the `agent_runtime_end` publish below
     // triggers the client's message refetch.
-    await this.persistenceHandler.finish({
-      assistantMessageId: seedAssistantMessageId,
-      error,
-      operationId,
-      result,
-      sessionId,
-      topicId,
-    });
+    try {
+      await this.persistenceHandler.finish({
+        assistantMessageId: seedAssistantMessageId,
+        error,
+        operationId,
+        result,
+        sessionId,
+        topicId,
+      });
+    } catch (err) {
+      if (err instanceof StaleHeteroOperationError) {
+        log('heteroFinish: stale operation ignored before terminal publish op=%s', operationId);
+        return;
+      }
+      throw err;
+    }
 
     // Always emit a terminal `agent_runtime_end` so renderer subscribers shut
     // down even if the CLI stream missed it (process killed mid-flight,
@@ -315,29 +372,59 @@ export class HeterogeneousAgentService {
 
     let serializedHooks: SerializedHook[] | undefined;
     let assistantMessageId: string | undefined;
-    let isolationThreadId: string | undefined;
+    let executionThreadId: string | undefined;
+    const matchesPersistedOperation = persistedOperation?.operationId === operationId;
     try {
       const topic = await this.topicModel.findById(topicId);
-      serializedHooks = topic?.metadata?.runningOperation?.hooks as SerializedHook[] | undefined;
-      isolationThreadId = topic?.metadata?.runningOperation?.threadId ?? undefined;
+      const runningOperation = topic?.metadata?.runningOperation;
+      const matchesSeedThread =
+        !seedAssistantMessageId ||
+        (runningOperation?.threadId ?? undefined) === (seedAssistantMessage?.threadId ?? undefined);
+      const ownedRunningOperation =
+        runningOperation?.operationId === operationId && matchesSeedThread
+          ? runningOperation
+          : undefined;
+      const acceptsPersistedOperation =
+        matchesPersistedOperation &&
+        (internalIsolation ||
+          (!runningOperation && topic?.metadata?.heteroSessionOperationId === operationId));
+      if (!ownedRunningOperation && !acceptsPersistedOperation) {
+        log('heteroFinish: stale operation ignored op=%s topic=%s', operationId, topicId);
+        return;
+      }
+      serializedHooks = internalIsolation
+        ? persistedOperation?.hooks
+        : ((ownedRunningOperation?.hooks as SerializedHook[] | undefined) ??
+          (acceptsPersistedOperation ? persistedOperation?.hooks : undefined));
+      // The gateway terminal callback can clear runningOperation before the CLI
+      // finish callback arrives. The producer-supplied assistant id points to a
+      // durable row and therefore remains authoritative for Thread scope.
+      executionThreadId = internalIsolation
+        ? (seedAssistantMessage?.threadId ?? undefined)
+        : (ownedRunningOperation?.threadId ??
+          (acceptsPersistedOperation ? seedAssistantMessage?.threadId : undefined) ??
+          undefined);
       // Prefer heteroCurrentMsgId — the persistence handler updates this pointer
       // on every step boundary, so it refers to the LAST assistant message with
       // the complete final content.  Fall back to the initial placeholder id
       // recorded in runningOperation if the pointer is absent or belongs to a
       // different operation (shouldn't happen, but defensive).
       const currentMsgRef = topic?.metadata?.heteroCurrentMsgId;
-      assistantMessageId =
-        currentMsgRef?.operationId === operationId
+      assistantMessageId = internalIsolation
+        ? seedAssistantMessageId
+        : currentMsgRef?.operationId === operationId
           ? currentMsgRef.msgId
-          : topic?.metadata?.runningOperation?.assistantMessageId;
-      await this.topicModel.updateMetadata(topicId, { runningOperation: null });
-      // Settle `status: 'running'` for runs with no renderer attached (e.g. a
-      // cron-dispatched scheduled resume) — otherwise nothing ever moves the
-      // topic off `running`. Guarded in the model: an attached client's own
-      // terminal write ('active'/'unread') is never clobbered.
-      await this.topicModel.settleRunningStatus(topicId);
+          : (ownedRunningOperation?.assistantMessageId ??
+            (acceptsPersistedOperation ? seedAssistantMessageId : undefined));
+      if (!internalIsolation) {
+        const clearedRunningOperation = ownedRunningOperation
+          ? await this.topicModel.clearRunningOperationIfMatches(topicId, operationId, 'unread')
+          : false;
+        if (!clearedRunningOperation && ownedRunningOperation) return;
+      }
     } catch (err) {
-      log('heteroFinish: failed to clear runningOperation (non-fatal): %O', err);
+      log('heteroFinish: failed to validate/clear runningOperation: %O', err);
+      return;
     }
 
     // The owning agentId is authoritatively encoded in the operationId
@@ -352,10 +439,26 @@ export class HeterogeneousAgentService {
     // Still read the assistant message for its content so the bot-callback
     // handler has lastAssistantContent to render.
     let lastAssistantContent: string | undefined;
+    if (internalIsolation && executionThreadId && seedAssistantMessage?.agentId) {
+      try {
+        const latest = await this.messageModel.findLatestAssistantMessageByThread({
+          agentId: seedAssistantMessage.agentId,
+          threadId: executionThreadId,
+          topicId,
+        });
+        assistantMessageId = latest?.id ?? assistantMessageId;
+      } catch (err) {
+        log('heteroFinish: failed to resolve final isolation assistant (non-fatal): %O', err);
+      }
+    }
     if (assistantMessageId) {
       try {
-        const msg = await this.messageModel.findById(assistantMessageId);
+        const msg =
+          assistantMessageId === seedAssistantMessageId
+            ? seedAssistantMessage
+            : await this.messageModel.findById(assistantMessageId);
         lastAssistantContent = msg?.content as string | undefined;
+        executionThreadId ??= msg?.threadId ?? undefined;
       } catch (err) {
         log('heteroFinish: failed to read final assistant message (non-fatal): %O', err);
       }
@@ -365,11 +468,14 @@ export class HeterogeneousAgentService {
     // from the one that registered the in-memory thread hooks. Finalize the
     // isolation thread durably here as well, and project its terminal answer
     // back onto the source assistant in the main conversation.
-    if (isolationThreadId) {
+    if (internalIsolation && executionThreadId) {
       try {
         const threadModel = new ThreadModel(this.db, this.userId, this.workspaceId);
-        const thread = await threadModel.findById(isolationThreadId);
-        if (thread) {
+        const thread = await threadModel.findById(executionThreadId);
+        // User-created continuation/standalone Threads remain active
+        // conversations after one run. Only internal isolation Threads model a
+        // single delegated execution and should be terminally finalized here.
+        if (thread?.type === ThreadType.Isolation) {
           if (lastAssistantContent && thread.sourceMessageId) {
             await this.messageModel.update(thread.sourceMessageId, {
               content: lastAssistantContent,
@@ -379,7 +485,7 @@ export class HeterogeneousAgentService {
           const completedAt = new Date().toISOString();
           const startedAt =
             typeof thread.metadata?.startedAt === 'string' ? thread.metadata.startedAt : undefined;
-          await threadModel.update(isolationThreadId, {
+          await threadModel.update(executionThreadId, {
             metadata: {
               ...thread.metadata,
               completedAt,
@@ -506,7 +612,19 @@ export class HeterogeneousAgentService {
    * Reads the same `topic.metadata.heteroSessionId` the desktop renderer
    * writes, so resume state is shared between desktop and cloud paths.
    */
-  async getHeterogeneousResumeSessionId(topicId: string): Promise<string | undefined> {
+  async getHeterogeneousResumeSessionId(
+    topicId: string,
+    threadId?: string,
+    excludeMessageId?: string,
+  ): Promise<string | undefined> {
+    if (threadId) {
+      return this.messageModel.findLatestHeterogeneousSessionId({
+        excludeMessageId,
+        threadId,
+        topicId,
+      });
+    }
+
     const topic = await this.topicModel.findById(topicId);
     return topic?.metadata?.heteroSessionId;
   }

--- a/packages/database/src/models/__tests__/messages/message.thread-query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.thread-query.test.ts
@@ -820,6 +820,54 @@ describe('MessageModel thread query', () => {
       expect(result[1].id).toBe('msg2');
     });
 
+    it('should exclude non-source siblings that share the source timestamp', async () => {
+      const boundary = new Date('2023-01-02T00:00:00.000Z');
+      await serverDB.transaction(async (trx) => {
+        await trx.insert(sessions).values([{ id: 'session1', userId }]);
+        await trx.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);
+        await trx.insert(messages).values([
+          {
+            content: 'before',
+            createdAt: new Date('2023-01-01'),
+            id: 'msg-before',
+            role: 'user',
+            sessionId: 'session1',
+            threadId: null,
+            topicId: 'topic1',
+            userId,
+          },
+          {
+            content: 'source',
+            createdAt: boundary,
+            id: 'msg-source',
+            role: 'assistant',
+            sessionId: 'session1',
+            threadId: null,
+            topicId: 'topic1',
+            userId,
+          },
+          {
+            content: 'concurrent later sibling',
+            createdAt: boundary,
+            id: 'msg-sibling',
+            role: 'user',
+            sessionId: 'session1',
+            threadId: null,
+            topicId: 'topic1',
+            userId,
+          },
+        ]);
+      });
+
+      const result = await messageModel.getThreadParentMessages({
+        sourceMessageId: 'msg-source',
+        topicId: 'topic1',
+        threadType: 'continuation' as any,
+      });
+
+      expect(result.map((message) => message.id)).toEqual(['msg-before', 'msg-source']);
+    });
+
     it('should exclude messages from other threads in Continuation mode', async () => {
       await serverDB.transaction(async (trx) => {
         await trx.insert(sessions).values([{ id: 'session1', userId }]);
@@ -937,6 +985,59 @@ describe('MessageModel thread query', () => {
       // This tests the fix for microsecond precision issue
       expect(result).toHaveLength(2);
       expect(result.map((m) => m.id)).toEqual(['msg1', 'msg2']);
+    });
+  });
+
+  describe('findLatestHeterogeneousSessionId', () => {
+    it('does not fall back to an older token after a newer failed assistant placeholder', async () => {
+      await serverDB.transaction(async (trx) => {
+        await trx.insert(sessions).values([{ id: 'session1', userId }]);
+        await trx.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);
+        await trx.insert(threads).values({
+          id: 'thread-session',
+          sourceMessageId: 'source-session',
+          topicId: 'topic1',
+          type: 'continuation',
+          userId,
+        });
+        await trx.insert(messages).values([
+          {
+            content: 'previous success',
+            createdAt: new Date('2023-01-01'),
+            id: 'asst-old-session',
+            metadata: { heteroSessionId: 'stale-session' },
+            role: 'assistant',
+            sessionId: 'session1',
+            threadId: 'thread-session',
+            topicId: 'topic1',
+            userId,
+          },
+          {
+            content: '',
+            createdAt: new Date('2023-01-02'),
+            id: 'asst-failed-placeholder',
+            role: 'assistant',
+            sessionId: 'session1',
+            threadId: 'thread-session',
+            topicId: 'topic1',
+            userId,
+          },
+        ]);
+      });
+
+      await expect(
+        messageModel.findLatestHeterogeneousSessionId({
+          threadId: 'thread-session',
+          topicId: 'topic1',
+        }),
+      ).resolves.toBeUndefined();
+      await expect(
+        messageModel.findLatestHeterogeneousSessionId({
+          excludeMessageId: 'asst-failed-placeholder',
+          threadId: 'thread-session',
+          topicId: 'topic1',
+        }),
+      ).resolves.toBe('stale-session');
     });
   });
 });

--- a/packages/database/src/models/__tests__/topics/topic.update.test.ts
+++ b/packages/database/src/models/__tests__/topics/topic.update.test.ts
@@ -125,6 +125,73 @@ describe('TopicModel - Update', () => {
     });
   });
 
+  describe('operation-scoped metadata', () => {
+    it('clears only the matching running operation', async () => {
+      const topicId = 'running-operation-cas';
+      await serverDB.insert(topics).values({
+        id: topicId,
+        metadata: {
+          heteroCurrentMsgId: { msgId: 'assistant-current', operationId: 'operation-current' },
+          model: 'gpt-4',
+          runningOperation: {
+            assistantMessageId: 'assistant-current',
+            operationId: 'operation-current',
+          },
+        },
+        status: 'running',
+        title: 'Test',
+        userId,
+      });
+
+      await expect(
+        topicModel.clearRunningOperationIfMatches(topicId, 'operation-stale'),
+      ).resolves.toBe(false);
+      await expect(
+        topicModel.clearRunningOperationIfMatches(topicId, 'operation-current', 'unread'),
+      ).resolves.toBe(true);
+
+      const topic = await serverDB.query.topics.findFirst({ where: eq(topics.id, topicId) });
+      expect(topic?.metadata).toEqual({ model: 'gpt-4', runningOperation: null });
+      expect(topic?.status).toBe('unread');
+    });
+
+    it('rejects a stale heterogeneous session write after a newer generation starts', async () => {
+      const topicId = 'heterogeneous-session-cas';
+      await serverDB.insert(topics).values({
+        id: topicId,
+        metadata: {
+          heteroSessionId: 'old-session',
+          heteroSessionOperationId: 'operation-new',
+          runningOperation: {
+            assistantMessageId: 'assistant-new',
+            operationId: 'operation-new',
+          },
+        },
+        title: 'Test',
+        userId,
+      });
+
+      await expect(
+        topicModel.updateHeterogeneousSessionIfMatches(topicId, 'operation-stale', 'stale-session'),
+      ).resolves.toBe(false);
+      await expect(
+        topicModel.updateHeterogeneousSessionIfMatches(topicId, 'operation-new', 'new-session'),
+      ).resolves.toBe(true);
+      await expect(
+        topicModel.clearRunningOperationIfMatches(topicId, 'operation-new'),
+      ).resolves.toBe(true);
+      await expect(
+        topicModel.updateHeterogeneousSessionIfMatches(topicId, 'operation-new', undefined),
+      ).resolves.toBe(true);
+
+      const topic = await serverDB.query.topics.findFirst({ where: eq(topics.id, topicId) });
+      expect(topic?.metadata).toEqual({
+        heteroSessionOperationId: 'operation-new',
+        runningOperation: null,
+      });
+    });
+  });
+
   describe('task callback reservation', () => {
     it('reserves only an idle topic and releases only the matching owner', async () => {
       const topicId = 'task-callback-reservation';

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -48,6 +48,7 @@ import {
   inArray,
   isNotNull,
   isNull,
+  lt,
   lte,
   ne,
   not,
@@ -247,6 +248,8 @@ interface CreateUserAndAssistantMessagesOptions {
     userMessageId?: string;
   };
   timing?: ModelTimingContext;
+  /** Reuse an existing transaction when the pair must be atomic with related rows. */
+  trx?: Transaction;
 }
 
 interface CreateMessageInsertParams {
@@ -1817,6 +1820,35 @@ export class MessageModel {
     });
   };
 
+  /**
+   * Return the CLI resume token on the latest assistant in this exact thread.
+   * Exclude only the current turn's newly-inserted placeholder when requested.
+   * Other token-less assistants remain authoritative: a failed prior placeholder
+   * intentionally invalidates an older stale token after a resume failure.
+   */
+  findLatestHeterogeneousSessionId = async (params: {
+    excludeMessageId?: string;
+    threadId: string;
+    topicId: string;
+  }): Promise<string | undefined> => {
+    const [row] = await this.db
+      .select({ sessionId: sql<string>`${messages.metadata}->>'heteroSessionId'` })
+      .from(messages)
+      .where(
+        and(
+          this.ownership(),
+          eq(messages.topicId, params.topicId),
+          eq(messages.threadId, params.threadId),
+          eq(messages.role, 'assistant'),
+          params.excludeMessageId ? ne(messages.id, params.excludeMessageId) : undefined,
+        ),
+      )
+      .orderBy(desc(messages.createdAt))
+      .limit(1);
+
+    return row?.sessionId ?? undefined;
+  };
+
   findByClientId = async (clientId: string) => {
     return this.db.query.messages.findFirst({
       where: and(eq(messages.clientId, clientId), this.ownership()),
@@ -1886,7 +1918,12 @@ export class MessageModel {
     // For Standalone type, only return the source message
     if (threadType === ThreadType.Standalone) {
       const sourceMessage = await this.db.query.messages.findFirst({
-        where: and(eq(messages.id, sourceMessageId), this.ownership()),
+        where: and(
+          eq(messages.id, sourceMessageId),
+          eq(messages.topicId, topicId),
+          isNull(messages.threadId),
+          this.ownership(),
+        ),
       });
 
       return sourceMessage ? [sourceMessage as DBMessageItem] : [];
@@ -1894,7 +1931,12 @@ export class MessageModel {
 
     // For Continuation type, get the source message first to know its createdAt
     const sourceMessage = await this.db.query.messages.findFirst({
-      where: and(eq(messages.id, sourceMessageId), this.ownership()),
+      where: and(
+        eq(messages.id, sourceMessageId),
+        eq(messages.topicId, topicId),
+        isNull(messages.threadId),
+        this.ownership(),
+      ),
     });
 
     if (!sourceMessage) return [];
@@ -1910,13 +1952,14 @@ export class MessageModel {
           this.ownership(),
           eq(messages.topicId, topicId),
           isNull(messages.threadId), // Only main conversation messages (not in any thread)
-          or(
-            lte(messages.createdAt, sourceMessage.createdAt),
-            eq(messages.id, sourceMessageId), // Ensure source message is always included
-          ),
+          // Use an exclusive timestamp boundary plus the exact source row. A
+          // concurrent message can share the source's timestamp but still be a
+          // later sibling; `lte(createdAt)` would leak that future sibling into
+          // the new Thread's inherited history.
+          or(lt(messages.createdAt, sourceMessage.createdAt), eq(messages.id, sourceMessageId)),
         ),
       )
-      .orderBy(asc(messages.createdAt));
+      .orderBy(asc(messages.createdAt), asc(messages.id));
 
     return result as DBMessageItem[];
   };
@@ -2449,7 +2492,7 @@ export class MessageModel {
 
   createUserAndAssistantMessages = async (
     { userMessage, assistantMessage }: CreateUserAndAssistantMessagesParams,
-    { ids, timing }: CreateUserAndAssistantMessagesOptions = {},
+    { ids, timing, trx }: CreateUserAndAssistantMessagesOptions = {},
   ): Promise<{ assistantMessage: DBMessageItem; userMessage: DBMessageItem }> => {
     const userMessageId = ids?.userMessageId ?? this.genId();
     const assistantMessageId = ids?.assistantMessageId ?? this.genId();
@@ -2474,54 +2517,55 @@ export class MessageModel {
       ...new Set([userMessage.topicId, assistantMessage.topicId].filter(Boolean) as string[]),
     ];
 
+    const createPair = async (executor: Transaction) => {
+      const userPayload = this.splitCreateMessageParams(userMessageWithTimestamp);
+      const assistantPayload = this.splitCreateMessageParams(assistantMessageWithParent);
+      const insertedMessages = (await runTimedStage(
+        timing,
+        'db.message.createUserAndAssistant.messages.insert',
+        () =>
+          executor
+            .insert(messages)
+            .values([
+              this.buildMessageInsertValue(userPayload.insert, userMessageId),
+              this.buildMessageInsertValue(assistantPayload.insert, assistantMessageId),
+            ])
+            .returning(),
+        { hasTopicId: topicIds.length > 0, messageCount: 2 },
+      )) as DBMessageItem[];
+      const messageMap = new Map(insertedMessages.map((message) => [message.id, message]));
+
+      await this.insertMessageRelationsInTransaction(
+        executor,
+        userPayload.relations,
+        userPayload.insert.message,
+        userMessageId,
+        timing,
+        'db.message.createUserAndAssistant.user',
+      );
+      await this.insertMessageRelationsInTransaction(
+        executor,
+        assistantPayload.relations,
+        assistantPayload.insert.message,
+        assistantMessageId,
+        timing,
+        'db.message.createUserAndAssistant.assistant',
+      );
+
+      const userMessageItem = messageMap.get(userMessageId);
+      const assistantMessageItem = messageMap.get(assistantMessageId);
+
+      if (!userMessageItem || !assistantMessageItem) {
+        throw new Error('Failed to create user and assistant messages');
+      }
+
+      return { assistantMessage: assistantMessageItem, userMessage: userMessageItem };
+    };
+
     return runTimedStage(
       timing,
       'db.message.createUserAndAssistant.transaction',
-      () =>
-        this.db.transaction(async (trx) => {
-          const userPayload = this.splitCreateMessageParams(userMessageWithTimestamp);
-          const assistantPayload = this.splitCreateMessageParams(assistantMessageWithParent);
-          const insertedMessages = (await runTimedStage(
-            timing,
-            'db.message.createUserAndAssistant.messages.insert',
-            () =>
-              trx
-                .insert(messages)
-                .values([
-                  this.buildMessageInsertValue(userPayload.insert, userMessageId),
-                  this.buildMessageInsertValue(assistantPayload.insert, assistantMessageId),
-                ])
-                .returning(),
-            { hasTopicId: topicIds.length > 0, messageCount: 2 },
-          )) as DBMessageItem[];
-          const messageMap = new Map(insertedMessages.map((message) => [message.id, message]));
-
-          await this.insertMessageRelationsInTransaction(
-            trx,
-            userPayload.relations,
-            userPayload.insert.message,
-            userMessageId,
-            timing,
-            'db.message.createUserAndAssistant.user',
-          );
-          await this.insertMessageRelationsInTransaction(
-            trx,
-            assistantPayload.relations,
-            assistantPayload.insert.message,
-            assistantMessageId,
-            timing,
-            'db.message.createUserAndAssistant.assistant',
-          );
-
-          const userMessageItem = messageMap.get(userMessageId);
-          const assistantMessageItem = messageMap.get(assistantMessageId);
-
-          if (!userMessageItem || !assistantMessageItem) {
-            throw new Error('Failed to create user and assistant messages');
-          }
-
-          return { assistantMessage: assistantMessageItem, userMessage: userMessageItem };
-        }),
+      () => (trx ? createPair(trx) : this.db.transaction(createPair)),
       {
         assistantFileCount: assistantMessage.files?.length ?? 0,
         hasTopicId: topicIds.length > 0,
@@ -2678,6 +2722,13 @@ export class MessageModel {
     return this.db
       .update(messages)
       .set({ metadata: mergedMetadata, ...(usageToWrite && { usage: usageToWrite }) })
+      .where(and(eq(messages.id, id), this.ownership()));
+  };
+
+  removeMetadataKey = async (id: string, key: string) => {
+    return this.db
+      .update(messages)
+      .set({ metadata: sql`COALESCE(${messages.metadata}, '{}'::jsonb) - ${key}` })
       .where(and(eq(messages.id, id), this.ownership()));
   };
 

--- a/packages/database/src/models/thread.ts
+++ b/packages/database/src/models/thread.ts
@@ -4,7 +4,7 @@ import { and, desc, eq, notExists, sql } from 'drizzle-orm';
 
 import type { ThreadItem } from '../schemas';
 import { agentOperations, messages, threads } from '../schemas';
-import type { LobeChatDatabase } from '../type';
+import type { LobeChatDatabase, Transaction } from '../type';
 import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
 
 /**
@@ -87,9 +87,10 @@ export class ThreadModel {
    */
   private mine = () => and(this.ownership(), eq(threads.userId, this.userId));
 
-  create = async (params: CreateThreadParams) => {
+  create = async (params: CreateThreadParams, trx?: Transaction) => {
+    const executor = trx ?? this.db;
     // @ts-ignore
-    const [result] = await this.db
+    const [result] = await executor
       .insert(threads)
       .values(
         buildWorkspacePayload(

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -1418,6 +1418,86 @@ export class TopicModel {
   };
 
   /**
+   * Clear only the running-operation marker still owned by the caller. When a
+   * settled status is supplied, move a still-running topic in the same locked
+   * update so a newer operation cannot be clobbered between clear and settle.
+   */
+  clearRunningOperationIfMatches = async (
+    id: string,
+    operationId: string,
+    settledStatus?: TopicItem['status'],
+  ): Promise<boolean> =>
+    this.db.transaction(async (tx) => {
+      const [existing] = await tx
+        .select({ metadata: topics.metadata, status: topics.status })
+        .from(topics)
+        .where(and(eq(topics.id, id), this.ownership()))
+        .for('update');
+
+      if (existing?.metadata?.runningOperation?.operationId !== operationId) return false;
+
+      const clearsCurrentPointer =
+        existing.metadata.heteroCurrentMsgId?.operationId === operationId;
+      const shouldSettleStatus = settledStatus && existing.status === 'running';
+      await tx
+        .update(topics)
+        .set({
+          metadata: {
+            ...existing.metadata,
+            ...(clearsCurrentPointer ? { heteroCurrentMsgId: undefined } : undefined),
+            runningOperation: null,
+          },
+          ...(shouldSettleStatus ? { status: settledStatus, updatedAt: new Date() } : undefined),
+        })
+        .where(and(eq(topics.id, id), this.ownership()));
+
+      return true;
+    });
+
+  /**
+   * Update the main-topic CLI session only while this operation still owns its
+   * generation. The generation survives runningOperation cleanup, preventing a
+   * delayed finish from overwriting a newer run's resume token.
+   */
+  updateHeterogeneousSessionIfMatches = async (
+    id: string,
+    operationId: string,
+    sessionId?: string,
+  ): Promise<boolean> =>
+    this.db.transaction(async (tx) => {
+      const [existing] = await tx
+        .select({ metadata: topics.metadata })
+        .from(topics)
+        .where(and(eq(topics.id, id), this.ownership()))
+        .for('update');
+
+      if (!existing) return false;
+
+      const runningOperationId = existing.metadata?.runningOperation?.operationId;
+      const sessionOperationId = existing.metadata?.heteroSessionOperationId;
+      if (
+        (runningOperationId && runningOperationId !== operationId) ||
+        (sessionOperationId && sessionOperationId !== operationId) ||
+        (!runningOperationId && !sessionOperationId)
+      ) {
+        return false;
+      }
+
+      await tx
+        .update(topics)
+        .set({
+          metadata: {
+            ...existing.metadata,
+            heteroSessionId: sessionId,
+            heteroSessionOperationId: operationId,
+          },
+        })
+        .where(and(eq(topics.id, id), this.ownership()));
+
+      return true;
+    });
+
+  /**
    * Atomically reserve an idle topic for one task-callback delivery.
    *
    * The topic row lock closes the check/set race between callback workers:

--- a/packages/types/src/agentExecution/index.ts
+++ b/packages/types/src/agentExecution/index.ts
@@ -1,4 +1,5 @@
 import type { LobeAgentChatConfig } from '../agent/chatConfig';
+import type { CreateThreadWithMessageParams } from '../aiChat';
 import type { WorkingDirConfig } from '../device';
 import type { TaskDetail, UIChatMessage } from '../message';
 import type { ChatTopic } from '../topic';
@@ -123,6 +124,10 @@ export interface ExecAgentAppContext {
    * recursive sub-agent dispatch.
    */
   isSubAgent?: boolean;
+  /** Create a user thread for this execution before persisting its first messages. */
+  newThread?: Omit<CreateThreadWithMessageParams, 'type'> & {
+    type: 'continuation' | 'standalone';
+  };
   /**
    * Orchestration role of the agent for this group run. `'supervisor'` for the
    * group's coordinating agent (execGroupAgent), `'member'` for delegated members
@@ -290,6 +295,8 @@ export interface ExecAgentResult {
   autoStarted: boolean;
   /** Timestamp when operation was created */
   createdAt: string;
+  /** The user thread created for this operation, when requested. */
+  createdThreadId?: string;
   /** Error message if operation failed to start */
   error?: string;
   /** Status message */

--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -177,6 +177,8 @@ export interface ChatTopicMetadata {
    * readers; this map lets the UI restore the right id when switching back.
    */
   heteroSessionIdByWorkingDirectory?: Record<string, string>;
+  /** Operation generation that owns the topic-level heterogeneous session pointer. */
+  heteroSessionOperationId?: string;
   /**
    * For topics imported from local CLI transcripts: the source transcript's
    * last message timestamp at import time. The import picker compares it with
@@ -438,6 +440,7 @@ export const chatTopicMetadataUpdateSchema = z.object({
   boundDeviceId: z.string().optional(),
   heteroSessionId: z.string().optional(),
   heteroSessionIdByWorkingDirectory: z.record(z.string(), z.string()).optional(),
+  heteroSessionOperationId: z.string().optional(),
   model: z.string().optional(),
   onboardingFeedback: z
     .object({

--- a/src/features/Conversation/Messages/components/MessageActionBar/actions/branching.test.ts
+++ b/src/features/Conversation/Messages/components/MessageActionBar/actions/branching.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import type { UIChatMessage } from '@lobechat/types';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { branchingAction } from './branching';
+
+const mocks = vi.hoisted(() => ({
+  activeThreadId: undefined as string | undefined,
+  conversationThreadId: null as string | null,
+  openThreadCreator: vi.fn(),
+  portalThreadId: undefined as string | undefined,
+  startToForkThread: false,
+  topicId: 'topic-1' as string | null,
+}));
+
+vi.mock('@/store/chat', () => ({
+  useChatStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      activeThreadId: mocks.activeThreadId,
+      openThreadCreator: mocks.openThreadCreator,
+      portalThreadId: mocks.portalThreadId,
+      startToForkThread: mocks.startToForkThread,
+    }),
+}));
+
+vi.mock('../../../../store', () => ({
+  contextSelectors: {
+    threadId: (state: any) => state.context.threadId,
+    topicId: (state: any) => state.context.topicId,
+  },
+  useConversationStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      context: { threadId: mocks.conversationThreadId, topicId: mocks.topicId },
+    }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const build = (threadId?: string) =>
+  renderHook(() =>
+    branchingAction.useBuild({
+      data: { content: 'Hello', role: 'assistant', threadId } as UIChatMessage,
+      id: 'message-1',
+      role: 'assistant',
+    }),
+  ).result.current;
+
+describe('branchingAction', () => {
+  beforeEach(() => {
+    mocks.activeThreadId = undefined;
+    mocks.conversationThreadId = null;
+    mocks.openThreadCreator.mockReset();
+    mocks.portalThreadId = undefined;
+    mocks.startToForkThread = false;
+    mocks.topicId = 'topic-1';
+  });
+
+  it('is available in the main topic', () => {
+    expect(build()).toMatchObject({ key: 'branching' });
+  });
+
+  it('is absent while the mounted conversation is thread-scoped or creating a thread', () => {
+    mocks.conversationThreadId = 'thread-active';
+    expect(build()).toBeNull();
+
+    mocks.conversationThreadId = null;
+    mocks.startToForkThread = true;
+    expect(build()).toBeNull();
+  });
+
+  it('is absent for persisted thread messages even if shell thread state is clear', () => {
+    expect(build('thread-on-message')).toBeNull();
+  });
+
+  it('ignores unrelated shell thread state when the mounted conversation is the main topic', () => {
+    mocks.activeThreadId = 'thread-in-another-shell';
+    mocks.portalThreadId = 'thread-in-portal';
+    expect(build()).toMatchObject({ key: 'branching' });
+  });
+});

--- a/src/features/Conversation/Messages/components/MessageActionBar/actions/branching.ts
+++ b/src/features/Conversation/Messages/components/MessageActionBar/actions/branching.ts
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useChatStore } from '@/store/chat';
 
+import { contextSelectors, useConversationStore } from '../../../../store';
 import { defineAction } from '../defineAction';
 
 export const branchingAction = defineAction({
@@ -12,22 +13,36 @@ export const branchingAction = defineAction({
   useBuild: (ctx) => {
     const { t } = useTranslation('common');
 
-    const [topic, openThreadCreator] = useChatStore((s) => [s.activeTopicId, s.openThreadCreator]);
+    const [topic, threadId] = useConversationStore((s) => [
+      contextSelectors.topicId(s),
+      contextSelectors.threadId(s),
+    ]);
+    const [startToForkThread, openThreadCreator] = useChatStore((s) => [
+      s.startToForkThread,
+      s.openThreadCreator,
+    ]);
+    // Conversation Provider context is the authority for the mounted surface.
+    // Global active/portal ids describe another shell and may be cleared while a
+    // portal-backed Thread provider remains mounted.
+    const inThread = Boolean(ctx.data.threadId || threadId || startToForkThread);
 
     return useMemo(
-      () => ({
-        handleClick: () => {
-          if (!topic) {
-            toast.warning(t('branchingRequiresSavedTopic'));
-            return;
-          }
-          openThreadCreator(ctx.id);
-        },
-        icon: Split,
-        key: 'branching',
-        label: t('branching'),
-      }),
-      [t, ctx.id, topic, openThreadCreator],
+      () =>
+        inThread
+          ? null
+          : {
+              handleClick: () => {
+                if (!topic) {
+                  toast.warning(t('branchingRequiresSavedTopic'));
+                  return;
+                }
+                openThreadCreator(ctx.id);
+              },
+              icon: Split,
+              key: 'branching',
+              label: t('branching'),
+            },
+      [t, ctx.id, inThread, topic, openThreadCreator],
     );
   },
 });

--- a/src/services/aiAgent.ts
+++ b/src/services/aiAgent.ts
@@ -193,6 +193,22 @@ class AiAgentService {
     return await lambdaClient.aiAgent.execAgent.mutate(params, options);
   }
 
+  async recoverExecAgent(params: {
+    assistantMessageId: string;
+    newThreadSourceMessageId?: string;
+    userMessageId: string;
+  }): Promise<ExecAgentResult | null> {
+    return await lambdaClient.aiAgent.recoverExecAgent.query(params);
+  }
+
+  async clearRunningOperation(params: {
+    operationId: string;
+    settledStatus?: 'active' | 'unread';
+    topicId: string;
+  }) {
+    return await lambdaClient.aiAgent.clearRunningOperation.mutate(params);
+  }
+
   /**
    * Defer an agent run to a future time. Creates an empty `scheduled` topic that
    * the backend cron fires once `runAt` passes; nothing runs now.

--- a/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
@@ -5,7 +5,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as ConstVersion from '@/const/version';
 import { aiAgentService } from '@/services/aiAgent';
 import { messageService } from '@/services/message';
-import { topicService } from '@/services/topic';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 
 import type { GatewayConnection } from '../transports/gateway/gateway';
@@ -13,8 +12,10 @@ import { GatewayActionImpl } from '../transports/gateway/gateway';
 
 vi.mock('@/services/aiAgent', () => ({
   aiAgentService: {
+    clearRunningOperation: vi.fn().mockResolvedValue({ cleared: true }),
     execAgentTask: vi.fn(),
     interruptTask: vi.fn(),
+    recoverExecAgent: vi.fn().mockResolvedValue(null),
     refreshGatewayToken: vi.fn(),
   },
 }));
@@ -22,12 +23,6 @@ vi.mock('@/services/aiAgent', () => ({
 vi.mock('@/services/message', () => ({
   messageService: {
     getMessages: vi.fn().mockResolvedValue([]),
-  },
-}));
-
-vi.mock('@/services/topic', () => ({
-  topicService: {
-    updateTopicMetadata: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -667,6 +662,191 @@ describe('GatewayActionImpl', () => {
       );
     });
 
+    it('forwards newThread and pivots the gateway operation to the persisted thread', async () => {
+      const { action, moveQueuedMessages, startOperation } = createExecuteTestAction();
+      const stagedContext = {
+        agentId: 'agent-1',
+        isNew: true,
+        scope: 'thread' as const,
+        sourceMessageId: 'source-1',
+        topicId: 'topic-1',
+      };
+
+      vi.mocked(aiAgentService.execAgentTask).mockResolvedValue({
+        agentId: 'agent-1',
+        assistantMessageId: 'ast-thread',
+        autoStarted: true,
+        createdAt: new Date().toISOString(),
+        createdThreadId: 'thread-created',
+        message: 'ok',
+        operationId: 'server-op-thread',
+        status: 'created',
+        success: true,
+        timestamp: new Date().toISOString(),
+        token: 'test-token',
+        topicId: 'topic-1',
+        userMessageId: 'usr-thread',
+      });
+
+      const result = await action.executeGatewayAgent({
+        context: stagedContext,
+        message: 'Start a branch',
+        newThread: { sourceMessageId: 'source-1', type: 'continuation' },
+      });
+
+      const persistedContext = {
+        ...stagedContext,
+        isNew: false,
+        threadId: 'thread-created',
+      };
+      expect(aiAgentService.execAgentTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appContext: expect.objectContaining({
+            newThread: { sourceMessageId: 'source-1', type: 'continuation' },
+          }),
+        }),
+        expect.anything(),
+      );
+      expect(startOperation).toHaveBeenCalledWith(
+        expect.objectContaining({ context: persistedContext }),
+      );
+      expect(moveQueuedMessages).toHaveBeenCalledWith(
+        messageMapKey(stagedContext),
+        messageMapKey(persistedContext),
+      );
+      expect(result.createdThreadId).toBe('thread-created');
+    });
+
+    it('reconciles a created thread without opening a gateway when startup failed', async () => {
+      const { action, connectToGateway, replaceMessages, startOperation } =
+        createExecuteTestAction();
+      const stagedContext = {
+        agentId: 'agent-1',
+        isNew: true,
+        scope: 'thread' as const,
+        sourceMessageId: 'source-1',
+        topicId: 'topic-1',
+      };
+
+      vi.mocked(aiAgentService.execAgentTask).mockResolvedValue({
+        agentId: 'agent-1',
+        assistantMessageId: 'ast-thread',
+        autoStarted: false,
+        createdAt: new Date().toISOString(),
+        createdThreadId: 'thread-created',
+        error: 'Device unavailable',
+        message: 'Agent operation failed to start',
+        operationId: 'server-op-thread',
+        status: 'error',
+        success: false,
+        timestamp: new Date().toISOString(),
+        topicId: 'topic-1',
+        userMessageId: 'usr-thread',
+      });
+
+      const result = await action.executeGatewayAgent({
+        context: stagedContext,
+        message: 'Start a branch',
+        newThread: { sourceMessageId: 'source-1', type: 'standalone' },
+      });
+
+      expect(replaceMessages).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({
+          context: expect.objectContaining({ isNew: false, threadId: 'thread-created' }),
+        }),
+      );
+      expect(startOperation).not.toHaveBeenCalled();
+      expect(connectToGateway).not.toHaveBeenCalled();
+      expect(result.createdThreadId).toBe('thread-created');
+    });
+
+    it('recovers a persisted thread when the execAgent response is lost', async () => {
+      const { action, moveQueuedMessages, startOperation } = createExecuteTestAction();
+      const onMessageAccepted = vi.fn();
+      const stagedContext = {
+        agentId: 'agent-1',
+        isNew: true,
+        scope: 'thread' as const,
+        sourceMessageId: 'source-1',
+        topicId: 'topic-1',
+      };
+      vi.mocked(aiAgentService.execAgentTask).mockRejectedValue(new Error('response lost'));
+      vi.mocked(aiAgentService.recoverExecAgent).mockResolvedValue({
+        agentId: 'agent-1',
+        assistantMessageId: 'ast-thread',
+        autoStarted: true,
+        createdAt: new Date().toISOString(),
+        createdThreadId: 'thread-created',
+        message: 'recovered',
+        operationId: 'server-op-thread',
+        status: 'created',
+        success: true,
+        timestamp: new Date().toISOString(),
+        token: 'test-token',
+        topicId: 'topic-1',
+        userMessageId: 'usr-thread',
+      });
+
+      const result = await action.executeGatewayAgent({
+        clientIds: { assistantMessageId: 'ast-thread', userMessageId: 'usr-thread' },
+        context: stagedContext,
+        message: 'Start a branch',
+        newThread: { sourceMessageId: 'source-1', type: 'continuation' },
+        onMessageAccepted,
+      });
+
+      expect(aiAgentService.recoverExecAgent).toHaveBeenCalledWith({
+        assistantMessageId: 'ast-thread',
+        newThreadSourceMessageId: 'source-1',
+        userMessageId: 'usr-thread',
+      });
+      expect(onMessageAccepted).toHaveBeenCalledOnce();
+      expect(moveQueuedMessages).toHaveBeenCalledWith(
+        messageMapKey(stagedContext),
+        messageMapKey({ ...stagedContext, isNew: false, threadId: 'thread-created' }),
+      );
+      expect(startOperation).toHaveBeenCalled();
+      expect(result.createdThreadId).toBe('thread-created');
+    });
+
+    it('refetches an existing topic when startup returns a structured failure', async () => {
+      const { action, connectToGateway, replaceMessages, startOperation } =
+        createExecuteTestAction();
+      vi.mocked(messageService.getMessages).mockResolvedValue([
+        { content: '', error: { type: 'ServerAgentRuntimeError' }, id: 'ast-1', role: 'assistant' },
+      ] as any);
+      vi.mocked(aiAgentService.execAgentTask).mockResolvedValue({
+        agentId: 'agent-1',
+        assistantMessageId: 'ast-1',
+        autoStarted: false,
+        createdAt: new Date().toISOString(),
+        error: 'Fixed device unavailable',
+        message: 'Fixed agent device unavailable',
+        operationId: 'server-op-failed',
+        status: 'error',
+        success: false,
+        timestamp: new Date().toISOString(),
+        topicId: 'topic-1',
+        userMessageId: 'usr-1',
+      });
+
+      await action.executeGatewayAgent({
+        context: { agentId: 'agent-1', scope: 'main', topicId: 'topic-1' },
+        message: 'Run on the fixed device',
+      });
+
+      expect(messageService.getMessages).toHaveBeenCalledWith(
+        expect.objectContaining({ topicId: 'topic-1' }),
+      );
+      expect(replaceMessages).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ id: 'ast-1' })]),
+        expect.objectContaining({ context: expect.objectContaining({ topicId: 'topic-1' }) }),
+      );
+      expect(startOperation).not.toHaveBeenCalled();
+      expect(connectToGateway).not.toHaveBeenCalled();
+    });
+
     it('should execute as the target agent while routing messages to the parent conversation', async () => {
       const { action, moveQueuedMessages, startOperation, updateTopicStatus } =
         createExecuteTestAction();
@@ -1241,7 +1421,7 @@ describe('GatewayActionImpl', () => {
       const { onSessionComplete } = connectToGateway.mock.calls[0][0];
       // Ignore any dispatches from the optimistic-update path during setup.
       internalDispatchTopic.mockClear();
-      vi.mocked(topicService.updateTopicMetadata).mockResolvedValue(undefined as never);
+      vi.mocked(aiAgentService.clearRunningOperation).mockResolvedValue({ cleared: true });
 
       onSessionComplete({ succeeded: false, terminalReceived: true });
 
@@ -1328,7 +1508,7 @@ describe('GatewayActionImpl', () => {
 
       const { onSessionComplete } = connectToGateway.mock.calls[0][0];
       internalDispatchTopic.mockClear();
-      vi.mocked(topicService.updateTopicMetadata).mockResolvedValue(undefined as never);
+      vi.mocked(aiAgentService.clearRunningOperation).mockResolvedValue({ cleared: true });
 
       // The user switched away before the run finished in the background.
       state.activeAgentId = 'agent-2';
@@ -1420,7 +1600,7 @@ describe('GatewayActionImpl', () => {
       const { onSessionComplete } = connectToGateway.mock.calls[0][0];
       // Ignore any dispatches from the optimistic-update path during setup.
       internalDispatchTopic.mockClear();
-      vi.mocked(topicService.updateTopicMetadata).mockResolvedValue(undefined as never);
+      vi.mocked(aiAgentService.clearRunningOperation).mockResolvedValue({ cleared: true });
 
       onSessionComplete({ succeeded: false, terminalReceived: true });
 
@@ -1795,13 +1975,13 @@ describe('GatewayActionImpl', () => {
         topicId: 'topic-1',
       });
 
-      vi.mocked(topicService.updateTopicMetadata)
+      vi.mocked(aiAgentService.clearRunningOperation)
         .mockClear()
-        .mockResolvedValue(undefined as never);
+        .mockResolvedValue({ cleared: true });
       captured.onSessionComplete!({ authFailed: false, succeeded: false, terminalReceived: false });
 
       expect(completeOperation).toHaveBeenCalledWith('gw-op-reconnect');
-      expect(topicService.updateTopicMetadata).not.toHaveBeenCalled();
+      expect(aiAgentService.clearRunningOperation).not.toHaveBeenCalled();
       expect(updateTopicStatus).not.toHaveBeenCalled();
     });
 
@@ -1816,16 +1996,17 @@ describe('GatewayActionImpl', () => {
         topicId: 'topic-1',
       });
 
-      vi.mocked(topicService.updateTopicMetadata)
+      vi.mocked(aiAgentService.clearRunningOperation)
         .mockClear()
-        .mockResolvedValue(undefined as never);
+        .mockResolvedValue({ cleared: true });
       captured.onSessionComplete!({ authFailed: false, succeeded: true, terminalReceived: true });
 
       // The run lifecycle owns completion when a terminal event arrives, so the
       // reconnect path must not double-complete its local op here.
       expect(completeOperation).not.toHaveBeenCalled();
-      expect(topicService.updateTopicMetadata).toHaveBeenCalledWith('topic-1', {
-        runningOperation: null,
+      expect(aiAgentService.clearRunningOperation).toHaveBeenCalledWith({
+        operationId: 'server-op-1',
+        topicId: 'topic-1',
       });
     });
 
@@ -1842,14 +2023,15 @@ describe('GatewayActionImpl', () => {
         topicId: 'topic-1',
       });
 
-      vi.mocked(topicService.updateTopicMetadata)
+      vi.mocked(aiAgentService.clearRunningOperation)
         .mockClear()
-        .mockResolvedValue(undefined as never);
+        .mockResolvedValue({ cleared: true });
       captured.onSessionComplete!({ authFailed: true, succeeded: false, terminalReceived: false });
 
       expect(completeOperation).toHaveBeenCalledWith('gw-op-reconnect');
-      expect(topicService.updateTopicMetadata).toHaveBeenCalledWith('topic-1', {
-        runningOperation: null,
+      expect(aiAgentService.clearRunningOperation).toHaveBeenCalledWith({
+        operationId: 'server-op-1',
+        topicId: 'topic-1',
       });
     });
 
@@ -1972,7 +2154,7 @@ describe('GatewayActionImpl', () => {
       });
 
       internalDispatchTopic.mockClear();
-      vi.mocked(topicService.updateTopicMetadata).mockResolvedValue(undefined as never);
+      vi.mocked(aiAgentService.clearRunningOperation).mockResolvedValue({ cleared: true });
       captured.onSessionComplete!({ authFailed: false, succeeded: false, terminalReceived: true });
 
       expect(internalDispatchTopic).toHaveBeenCalledWith({

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -8,7 +8,6 @@ import { chainCompressContext } from '@lobechat/prompts';
 import type {
   ChatAudioItem,
   ChatImageItem,
-  ChatThreadType,
   ChatTopicMetadata,
   ChatVideoItem,
   ConversationContext,
@@ -21,6 +20,7 @@ import {
   getWorkingDirEffectivePath,
   getWorkingDirSourcePath,
   resolveAgentAgencyConfig,
+  ThreadType,
 } from '@lobechat/types';
 import { generateEntityId, nanoid } from '@lobechat/utils';
 import { toast } from '@lobehub/ui/base-ui';
@@ -335,13 +335,17 @@ export class ConversationLifecycleActionImpl {
     // Use context from params (required)
     // If creating new thread (isNew + scope='thread'), threadId will be created by server
     const isCreatingNewThread = context.isNew && context.scope === 'thread';
+    const newThreadType =
+      context.threadType === ThreadType.Continuation || context.threadType === ThreadType.Standalone
+        ? context.threadType
+        : undefined;
     // Build newThread params for server from new context format
     // Only create newThread if we have both sourceMessageId and threadType
     const newThread =
-      isCreatingNewThread && context.sourceMessageId && context.threadType
+      isCreatingNewThread && context.sourceMessageId && newThreadType
         ? {
             sourceMessageId: context.sourceMessageId,
-            type: context.threadType as ChatThreadType,
+            type: newThreadType,
           }
         : undefined;
 
@@ -1506,6 +1510,7 @@ export class ConversationLifecycleActionImpl {
           fileIds: fileIdList,
           message,
           metadata: requestMetadata,
+          newThread,
           onMessageAccepted: notifyMessageAccepted,
           parentOperationId: operationId,
           optimisticTopic,
@@ -1529,6 +1534,19 @@ export class ConversationLifecycleActionImpl {
         });
         const cancelledAfterPersistence = abortController.signal.aborted;
 
+        if (result.createdThreadId) {
+          this.#get().updateOperationMetadata(operationId, {
+            createdThreadId: result.createdThreadId,
+          });
+          const currentPortalViewType = chatPortalSelectors.currentViewType(this.#get());
+          if (currentPortalViewType === PortalViewType.Thread) {
+            this.#get().openThreadInPortal(result.createdThreadId, context.sourceMessageId);
+          } else {
+            this.#get().syncThreadInPortal(result.createdThreadId, context.sourceMessageId);
+          }
+          void this.#get().refreshThreads();
+        }
+
         // Topic title: gateway-created topics had no LLM-summarized
         // title. executeGatewayAgent has already replaced messages + switched to
         // the new topic, so the shared hook reads the persisted conversation from
@@ -1545,7 +1563,12 @@ export class ConversationLifecycleActionImpl {
             void sendRunLifecycle
               .afterUserMessagePersisted({
                 assistantMessageId: result.assistantMessageId,
-                context: { ...operationContext, topicId: result.topicId },
+                context: {
+                  ...operationContext,
+                  isNew: result.createdThreadId ? false : operationContext.isNew,
+                  threadId: result.createdThreadId ?? operationContext.threadId,
+                  topicId: result.topicId,
+                },
                 isCreateNewTopic: willCreateNewTopic,
                 operationId,
                 runId: operationId,
@@ -1563,6 +1586,8 @@ export class ConversationLifecycleActionImpl {
 
         return {
           assistantMessageId: result.assistantMessageId,
+          createdThreadId: result.createdThreadId,
+          createdTopicId: willCreateNewTopic ? result.topicId : undefined,
           userMessageId: result.userMessageId,
         };
       } catch (e) {

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -8,6 +8,7 @@ import { isRemoteHeterogeneousType } from '@lobechat/heterogeneous-agents';
 import type {
   ChatTopicMetadata,
   ConversationContext,
+  ExecAgentAppContext,
   ExecAgentResult,
   MessageMetadata,
   RuntimeMentionedAgent,
@@ -23,7 +24,6 @@ import {
 } from '@/services/aiAgent';
 import { gatewayConnectionService } from '@/services/electron/gatewayConnection';
 import { messageService } from '@/services/message';
-import { topicService } from '@/services/topic';
 import { getAgentStoreState } from '@/store/agent';
 import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { consumePendingTopicRepos, getPendingTopicRepos } from '@/store/chat/pendingTopicRepos';
@@ -426,6 +426,8 @@ export class GatewayActionImpl {
     messageContext?: ConversationContext;
     /** Request metadata carried from the originating user message. */
     metadata?: Pick<MessageMetadata, 'trigger'>;
+    /** Create the persisted user thread that owns this fresh turn. */
+    newThread?: ExecAgentAppContext['newThread'];
     /** Called as soon as phase-1 returns with a persisted user message. */
     onMessageAccepted?: () => void;
     /** Called when the gateway session completes (agent finished running) */
@@ -495,6 +497,7 @@ export class GatewayActionImpl {
       message,
       messageContext = executionContext,
       metadata,
+      newThread,
       onComplete,
       onMessageAccepted,
       optimisticTopic,
@@ -570,66 +573,87 @@ export class GatewayActionImpl {
       throw abortSignal.reason ?? new DOMException('Aborted', 'AbortError');
     }
 
-    const result = await aiAgentService.execAgentTask(
-      {
-        agentId: executionContext.agentId,
-        // Fresh sends only — resume flows never pass this, and the server drops
-        // it defensively on resume-like params anyway.
-        clientIds,
-        appContext: {
-          agentDocumentId: executionContext.agentDocumentId,
-          ...(messageContext.agentId !== executionContext.agentId && {
-            conversationAgentId: messageContext.agentId,
-          }),
-          defaultTaskAssigneeAgentId: executionContext.defaultTaskAssigneeAgentId,
-          documentId: executionContext.documentId,
-          // When AgentBuilder runs, context.agentId is the builtin builder agent.
-          // The actual editing target is chatStore.activeAgentId (kept in sync by
-          // AgentBuilderProvider). Pass it so the server can route tool calls to
-          // the correct agent rather than the builder itself.
-          ...(executionContext.scope === 'agent_builder' && {
-            editingAgentId: this.#get().activeAgentId ?? undefined,
-          }),
-          // Same shape as `editingAgentId`, for the Group Agent Builder panel on
-          // the group Profile page. The builder conversation is keyed by the
-          // builtin builder agent (no groupId in its ConversationContext, so the
-          // message map key and the group's own chat stay separate), which left
-          // the server runtime with no idea which group it was editing.
-          // The context value wins, and every surface that opens this scope sets
-          // it from its own route/group: it is fixed for the run, so a mid-run
-          // navigation cannot make the server stamp a different group than the
-          // panel is reading from. The `activeGroupId` fallback is a last resort
-          // for a caller that forgot — it is sampled here, AFTER the async
-          // preflight above, so it can already be stale by this point.
-          ...(executionContext.scope === 'group_agent_builder' && {
-            editingGroupId: executionContext.editingGroupId ?? this.#get().activeGroupId,
-          }),
-          groupId: executionContext.groupId,
-          ...(initialTopicMetadata && { initialTopicMetadata }),
-          // Forward the group orchestration role so the server can stamp it onto
-          // the assistant message metadata. Without this the gateway-created
-          // supervisor turn loses its role on the step_start snapshot / refetch
-          // and renders as a generic assistant.
-          orchestrationRole: executionContext.orchestrationRole,
-          scope: executionContext.scope,
-          taskId,
-          threadId: executionContext.threadId,
-          topicId: executionContext.topicId,
+    let result: ExecAgentResult;
+    try {
+      result = await aiAgentService.execAgentTask(
+        {
+          agentId: executionContext.agentId,
+          // Fresh sends only — resume flows never pass this, and the server drops
+          // it defensively on resume-like params anyway.
+          clientIds,
+          appContext: {
+            agentDocumentId: executionContext.agentDocumentId,
+            ...(messageContext.agentId !== executionContext.agentId && {
+              conversationAgentId: messageContext.agentId,
+            }),
+            defaultTaskAssigneeAgentId: executionContext.defaultTaskAssigneeAgentId,
+            documentId: executionContext.documentId,
+            // When AgentBuilder runs, context.agentId is the builtin builder agent.
+            // The actual editing target is chatStore.activeAgentId (kept in sync by
+            // AgentBuilderProvider). Pass it so the server can route tool calls to
+            // the correct agent rather than the builder itself.
+            ...(executionContext.scope === 'agent_builder' && {
+              editingAgentId: this.#get().activeAgentId ?? undefined,
+            }),
+            // Same shape as `editingAgentId`, for the Group Agent Builder panel on
+            // the group Profile page. The builder conversation is keyed by the
+            // builtin builder agent (no groupId in its ConversationContext, so the
+            // message map key and the group's own chat stay separate), which left
+            // the server runtime with no idea which group it was editing.
+            // The context value wins, and every surface that opens this scope sets
+            // it from its own route/group: it is fixed for the run, so a mid-run
+            // navigation cannot make the server stamp a different group than the
+            // panel is reading from. The `activeGroupId` fallback is a last resort
+            // for a caller that forgot — it is sampled here, AFTER the async
+            // preflight above, so it can already be stale by this point.
+            ...(executionContext.scope === 'group_agent_builder' && {
+              editingGroupId: executionContext.editingGroupId ?? this.#get().activeGroupId,
+            }),
+            groupId: executionContext.groupId,
+            ...(initialTopicMetadata && { initialTopicMetadata }),
+            newThread,
+            // Forward the group orchestration role so the server can stamp it onto
+            // the assistant message metadata. Without this the gateway-created
+            // supervisor turn loses its role on the step_start snapshot / refetch
+            // and renders as a generic assistant.
+            orchestrationRole: executionContext.orchestrationRole,
+            scope: executionContext.scope,
+            taskId,
+            threadId: executionContext.threadId,
+            topicId: executionContext.topicId,
+          },
+          ...desktopDeviceHints,
+          fileIds,
+          mentionedAgents,
+          parentMessageId,
+          prompt: message,
+          resumeApproval,
+          resumeApprovals,
+          resumeToolResult,
+          selectedToolIds,
+          trigger: metadata?.trigger,
+          userInterventionConfig,
         },
-        ...desktopDeviceHints,
-        fileIds,
-        mentionedAgents,
-        parentMessageId,
-        prompt: message,
-        resumeApproval,
-        resumeApprovals,
-        resumeToolResult,
-        selectedToolIds,
-        trigger: metadata?.trigger,
-        userInterventionConfig,
-      },
-      { signal: abortSignal },
-    );
+        { signal: abortSignal },
+      );
+    } catch (error) {
+      const assistantMessageId = clientIds?.assistantMessageId;
+      const userMessageId = clientIds?.userMessageId;
+      if (!assistantMessageId || !userMessageId) throw error;
+
+      let recovered: ExecAgentResult | null = null;
+      try {
+        recovered = await aiAgentService.recoverExecAgent({
+          assistantMessageId,
+          newThreadSourceMessageId: newThread?.sourceMessageId,
+          userMessageId,
+        });
+      } catch (recoveryError) {
+        console.error('[Gateway] persisted-message acceptance probe failed:', recoveryError);
+      }
+      if (!recovered) throw error;
+      result = recovered;
+    }
 
     // Persistence is the ownership boundary. Notify before later UI synchronization awaits and
     // before handling a late abort so callers never delete a file already attached server-side.
@@ -658,11 +682,32 @@ export class GatewayActionImpl {
 
     // Keep execution identity separate from the conversation bucket that owns
     // the streamed messages. They differ for callAgent/sub-agent runs.
-    const resolvedExecutionContext = { ...executionContext, topicId: result.topicId };
-    const resolvedMessageContext = { ...messageContext, topicId: result.topicId };
+    const resolvedExecutionContext = {
+      ...executionContext,
+      isNew: result.createdThreadId ? false : executionContext.isNew,
+      threadId: result.createdThreadId ?? executionContext.threadId,
+      topicId: result.topicId,
+    };
+    const resolvedMessageContext = {
+      ...messageContext,
+      isNew: result.createdThreadId ? false : messageContext.isNew,
+      threadId: result.createdThreadId ?? messageContext.threadId,
+      topicId: result.topicId,
+    };
     this.#get().moveVoiceMessages(messageContext, resolvedMessageContext);
+    const previousMessageKey = messageMapKey(messageContext);
+    const resolvedMessageKey = messageMapKey(resolvedMessageContext);
+    if (previousMessageKey !== resolvedMessageKey) {
+      getFileStoreState().moveChatContextSelections(previousMessageKey, resolvedMessageKey);
+    }
 
-    if (!isCreateNewTopic && cancelledAfterPersistence) {
+    if (
+      !isCreateNewTopic &&
+      (cancelledAfterPersistence ||
+        result.createdThreadId ||
+        !result.success ||
+        !result.autoStarted)
+    ) {
       try {
         const messages = await messageService.getMessages(resolvedMessageContext);
         this.#get().replaceMessages(messages, { context: resolvedMessageContext });
@@ -713,20 +758,17 @@ export class GatewayActionImpl {
         .catch((err) => console.error('[Gateway] refreshTopic after topic creation failed:', err));
     }
 
-    this.#get().moveQueuedMessages(
-      messageMapKey(messageContext),
-      messageMapKey(resolvedMessageContext),
-    );
+    this.#get().moveQueuedMessages(previousMessageKey, resolvedMessageKey);
     // Legacy queue location: follow-ups enqueued behind an op still registered
     // under the pre-mint `_new` key.
     if (isCreateNewTopic)
       this.#get().moveQueuedMessages(
         messageMapKey({ ...messageContext, topicId: null }),
-        messageMapKey(resolvedMessageContext),
+        resolvedMessageKey,
       );
     cancelledAfterPersistence = interruptIfCancelledAfterPersistence() || cancelledAfterPersistence;
 
-    if (cancelledAfterPersistence) {
+    if (cancelledAfterPersistence || !result.success || !result.autoStarted) {
       if (parentOperationId) this.#get().completeOperation(parentOperationId);
       return result;
     }
@@ -861,9 +903,9 @@ export class GatewayActionImpl {
           }
           // Clear running operation from topic metadata (best-effort from frontend;
           // if browser was closed, reconnect logic will handle stale entries)
-          topicService
-            .updateTopicMetadata(result.topicId, { runningOperation: null })
-            .catch(() => {});
+          aiAgentService
+            .clearRunningOperation({ operationId: result.operationId, topicId: result.topicId })
+            .catch((error) => console.error('[Gateway] failed to clear running operation:', error));
           // Also clear the local store copy — the server clear above does NOT touch
           // the Zustand topic map that useGatewayReconnect reads.
           this.clearLocalRunningOperation({
@@ -1059,7 +1101,11 @@ export class GatewayActionImpl {
         }
         // Clear the persisted marker useGatewayReconnect keys off so a dead op
         // doesn't get reconnected on every reload / task-drawer open.
-        topicService.updateTopicMetadata(topicId, { runningOperation: null }).catch(() => {});
+        aiAgentService
+          .clearRunningOperation({ operationId, topicId })
+          .catch((error) =>
+            console.error('[Gateway] failed to clear reconnected running operation:', error),
+          );
         // Mirror the clear into the local store — the server clear above leaves the
         // Zustand topic map stale, which useGatewayReconnect keys off.
         this.clearLocalRunningOperation({ agentId: context.agentId, operationId, topicId });
@@ -1109,7 +1155,7 @@ export class GatewayActionImpl {
   /**
    * Clear the client-store copy of `topic.metadata.runningOperation`.
    *
-   * The server-side clear (`topicService.updateTopicMetadata(topicId, { runningOperation: null })`)
+   * The server-side compare-and-clear does not update the local Zustand topic map.
    * alone leaves the Zustand store stale: `useGatewayReconnect` keys off the LOCAL
    * copy, so after an error run (e.g. insufficient credits) the stale marker keeps
    * firing `aiAgentService.refreshGatewayToken(topicId)`, which the server now answers

--- a/src/store/chat/slices/topic/action.test.ts
+++ b/src/store/chat/slices/topic/action.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { LOADING_FLAT } from '@/const/message';
 import { mutate } from '@/libs/swr';
+import { aiAgentService } from '@/services/aiAgent';
 import { chatService } from '@/services/chat';
 import { messageService } from '@/services/message';
 import { topicService } from '@/services/topic';
@@ -29,6 +30,9 @@ vi.mock('@/libs/swr', async () => {
 });
 
 vi.mock('zustand/traditional');
+vi.mock('@/services/aiAgent', () => ({
+  aiAgentService: { clearRunningOperation: vi.fn() },
+}));
 // Mock topicService 和 messageService
 vi.mock('@/services/topic', () => ({
   topicService: {
@@ -74,6 +78,7 @@ vi.mock('i18next', () => ({
 beforeEach(() => {
   // Setup initial state and mocks before each test
   vi.clearAllMocks();
+  vi.mocked(aiAgentService.clearRunningOperation).mockResolvedValue({ cleared: true });
   useChatStore.setState(
     {
       activeAgentId: undefined,
@@ -1771,9 +1776,6 @@ describe('topic action', () => {
 
       vi.spyOn(topicService, 'queryTopics').mockResolvedValue([topic]);
       const updateTopicMock = vi.spyOn(topicService, 'updateTopic').mockResolvedValue([]);
-      const updateTopicMetadataMock = vi
-        .spyOn(topicService, 'updateTopicMetadata')
-        .mockResolvedValue([]);
 
       act(() => {
         useChatStore.setState({
@@ -1804,13 +1806,12 @@ describe('topic action', () => {
         pageSize: 500,
         statuses: ['running'],
       });
-      expect(updateTopicMock).toHaveBeenCalledWith(topicId, { status: 'active' });
-      expect(updateTopicMetadataMock).toHaveBeenCalledWith(topicId, {
-        runningOperation: null,
+      expect(aiAgentService.clearRunningOperation).toHaveBeenCalledWith({
+        operationId: 'server-op-1',
+        settledStatus: 'active',
+        topicId,
       });
-      expect(updateTopicMetadataMock.mock.invocationCallOrder[0]).toBeLessThan(
-        updateTopicMock.mock.invocationCallOrder[0],
-      );
+      expect(updateTopicMock).not.toHaveBeenCalled();
       expect(useChatStore.getState().topicDataMap[key].items[0]).toMatchObject({
         metadata: { runningOperation: null },
         status: 'active',
@@ -1878,7 +1879,7 @@ describe('topic action', () => {
       expect(useChatStore.getState().topicDataMap[groupAgentKey]).toBeUndefined();
     });
 
-    it('should not mark stale topics active when runningOperation metadata cleanup fails', async () => {
+    it('should not mark a newer operation active when compare-and-clear loses ownership', async () => {
       const { result } = renderHook(() => useChatStore());
       const agentId = 'agent-1';
       const topicId = 'topic-1';
@@ -1900,10 +1901,7 @@ describe('topic action', () => {
 
       vi.spyOn(topicService, 'queryTopics').mockResolvedValue([topic]);
       const updateTopicMock = vi.spyOn(topicService, 'updateTopic').mockResolvedValue([]);
-      const updateTopicMetadataMock = vi
-        .spyOn(topicService, 'updateTopicMetadata')
-        .mockRejectedValue(new Error('metadata persist failed'));
-      vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.mocked(aiAgentService.clearRunningOperation).mockResolvedValue({ cleared: false });
 
       act(() => {
         useChatStore.setState({
@@ -1930,11 +1928,299 @@ describe('topic action', () => {
       });
 
       expect(cleaned).toBe(0);
-      expect(updateTopicMetadataMock).toHaveBeenCalledWith(topicId, { runningOperation: null });
+      expect(aiAgentService.clearRunningOperation).toHaveBeenCalledWith({
+        operationId: 'server-op-1',
+        settledStatus: 'active',
+        topicId,
+      });
       expect(updateTopicMock).not.toHaveBeenCalled();
       expect(useChatStore.getState().topicDataMap[key].items[0]).toMatchObject({
         metadata: { runningOperation },
         status: 'running',
+      });
+    });
+
+    it('should not overwrite a newer local generation while the CAS response is in flight', async () => {
+      const { result } = renderHook(() => useChatStore());
+      const agentId = 'agent-1';
+      const topicId = 'topic-1';
+      const key = topicMapKey({ agentId });
+      const oldOperation = {
+        assistantMessageId: 'assistant-old',
+        operationId: 'operation-old',
+      };
+      const newOperation = {
+        assistantMessageId: 'assistant-new',
+        operationId: 'operation-new',
+      };
+      const topic = {
+        agentId,
+        createdAt: Date.now() - 3 * 60 * 60 * 1000,
+        id: topicId,
+        metadata: { runningOperation: oldOperation },
+        sessionId: agentId,
+        status: 'running',
+        title: 'Stale running topic',
+        updatedAt: Date.now() - 3 * 60 * 60 * 1000,
+      } as ChatTopic & { agentId: string };
+      let resolveClear: (value: { cleared: boolean }) => void;
+      vi.mocked(aiAgentService.clearRunningOperation).mockReturnValue(
+        new Promise((resolve) => {
+          resolveClear = resolve;
+        }),
+      );
+      vi.spyOn(topicService, 'queryTopics').mockResolvedValue([topic]);
+
+      act(() => {
+        useChatStore.setState({
+          activeAgentId: agentId,
+          operations: {},
+          topicDataMap: {
+            [key]: {
+              currentPage: 0,
+              hasMore: false,
+              items: [topic],
+              pageSize: 20,
+              total: 1,
+            },
+          },
+        });
+      });
+
+      const cleanupPromise = result.current.cleanupStaleRunningTopics();
+      await waitFor(() => expect(aiAgentService.clearRunningOperation).toHaveBeenCalledTimes(1));
+      act(() => {
+        useChatStore.setState({
+          topicDataMap: {
+            [key]: {
+              currentPage: 0,
+              hasMore: false,
+              items: [{ ...topic, metadata: { runningOperation: newOperation } }],
+              pageSize: 20,
+              total: 1,
+            },
+          },
+        });
+        resolveClear!({ cleared: true });
+      });
+
+      await expect(cleanupPromise).resolves.toBe(0);
+      expect(useChatStore.getState().topicDataMap[key].items[0]).toMatchObject({
+        metadata: { runningOperation: newOperation },
+        status: 'running',
+      });
+    });
+
+    it('should not overwrite a newer generation loaded only in the Agent Topics view', async () => {
+      const { result } = renderHook(() => useChatStore());
+      const agentId = 'agent-1';
+      const topicId = 'topic-1';
+      const key = topicMapKey({ agentId });
+      const oldOperation = {
+        assistantMessageId: 'assistant-old',
+        operationId: 'operation-old',
+      };
+      const newOperation = {
+        assistantMessageId: 'assistant-new',
+        operationId: 'operation-new',
+      };
+      const topic = {
+        agentId,
+        createdAt: Date.now() - 3 * 60 * 60 * 1000,
+        id: topicId,
+        metadata: { runningOperation: oldOperation },
+        sessionId: agentId,
+        status: 'running',
+        title: 'Stale running topic',
+        updatedAt: Date.now() - 3 * 60 * 60 * 1000,
+      } as ChatTopic & { agentId: string };
+      let resolveClear: (value: { cleared: boolean }) => void;
+      vi.mocked(aiAgentService.clearRunningOperation).mockReturnValue(
+        new Promise((resolve) => {
+          resolveClear = resolve;
+        }),
+      );
+      vi.spyOn(topicService, 'queryTopics').mockResolvedValue([topic]);
+
+      act(() => {
+        useChatStore.setState({
+          activeAgentId: agentId,
+          agentTopicsViewMap: {
+            [key]: {
+              currentPage: 0,
+              hasMore: false,
+              items: [topic],
+              pageSize: 20,
+              total: 1,
+            },
+          },
+          operations: {},
+          topicDataMap: {},
+        });
+      });
+
+      const cleanupPromise = result.current.cleanupStaleRunningTopics();
+      await waitFor(() => expect(aiAgentService.clearRunningOperation).toHaveBeenCalledTimes(1));
+      act(() => {
+        useChatStore.setState({
+          agentTopicsViewMap: {
+            [key]: {
+              currentPage: 0,
+              hasMore: false,
+              items: [{ ...topic, metadata: { runningOperation: newOperation } }],
+              pageSize: 20,
+              total: 1,
+            },
+          },
+        });
+        resolveClear!({ cleared: true });
+      });
+
+      await expect(cleanupPromise).resolves.toBe(0);
+      expect(useChatStore.getState().agentTopicsViewMap[key].items[0]).toMatchObject({
+        metadata: { runningOperation: newOperation },
+        status: 'running',
+      });
+    });
+
+    it('should preserve a newer completed generation while the old CAS response is in flight', async () => {
+      const { result } = renderHook(() => useChatStore());
+      const agentId = 'agent-1';
+      const topicId = 'topic-1';
+      const key = topicMapKey({ agentId });
+      const oldOperation = {
+        assistantMessageId: 'assistant-old',
+        operationId: 'operation-old',
+      };
+      const topic = {
+        agentId,
+        createdAt: Date.now() - 3 * 60 * 60 * 1000,
+        id: topicId,
+        metadata: { heteroSessionOperationId: 'operation-old', runningOperation: oldOperation },
+        sessionId: agentId,
+        status: 'running',
+        title: 'Stale running topic',
+        updatedAt: Date.now() - 3 * 60 * 60 * 1000,
+      } as ChatTopic & { agentId: string };
+      let resolveClear: (value: { cleared: boolean }) => void;
+      vi.mocked(aiAgentService.clearRunningOperation).mockReturnValue(
+        new Promise((resolve) => {
+          resolveClear = resolve;
+        }),
+      );
+      vi.spyOn(topicService, 'queryTopics').mockResolvedValue([topic]);
+
+      act(() => {
+        useChatStore.setState({
+          activeAgentId: agentId,
+          agentTopicsViewMap: {
+            [key]: {
+              currentPage: 0,
+              hasMore: false,
+              items: [topic],
+              pageSize: 20,
+              total: 1,
+            },
+          },
+          operations: {},
+          topicDataMap: {
+            [key]: {
+              currentPage: 0,
+              hasMore: false,
+              items: [topic],
+              pageSize: 20,
+              total: 1,
+            },
+          },
+        });
+      });
+
+      const cleanupPromise = result.current.cleanupStaleRunningTopics();
+      await waitFor(() => expect(aiAgentService.clearRunningOperation).toHaveBeenCalledTimes(1));
+      act(() => {
+        useChatStore.setState({
+          agentTopicsViewMap: {
+            [key]: {
+              currentPage: 0,
+              hasMore: false,
+              items: [
+                {
+                  ...topic,
+                  metadata: {
+                    heteroSessionOperationId: 'operation-new',
+                    runningOperation: null,
+                  },
+                  status: 'active',
+                },
+              ],
+              pageSize: 20,
+              total: 1,
+            },
+          },
+        });
+        resolveClear!({ cleared: true });
+      });
+
+      await expect(cleanupPromise).resolves.toBe(0);
+      expect(useChatStore.getState().agentTopicsViewMap[key].items[0]).toMatchObject({
+        metadata: {
+          heteroSessionOperationId: 'operation-new',
+          runningOperation: null,
+        },
+        status: 'active',
+      });
+    });
+
+    it('should settle a locally running row whose matching operation marker is already cleared', async () => {
+      const { result } = renderHook(() => useChatStore());
+      const agentId = 'agent-1';
+      const topicId = 'topic-1';
+      const key = topicMapKey({ agentId });
+      const staleTopic = {
+        agentId,
+        createdAt: Date.now() - 3 * 60 * 60 * 1000,
+        id: topicId,
+        metadata: {
+          heteroSessionOperationId: 'operation-old',
+          runningOperation: {
+            assistantMessageId: 'assistant-old',
+            operationId: 'operation-old',
+          },
+        },
+        sessionId: agentId,
+        status: 'running',
+        title: 'Stale running topic',
+        updatedAt: Date.now() - 3 * 60 * 60 * 1000,
+      } as ChatTopic & { agentId: string };
+      const locallyClearedTopic = {
+        ...staleTopic,
+        metadata: { heteroSessionOperationId: 'operation-old', runningOperation: null },
+      } as ChatTopic & { agentId: string };
+      vi.spyOn(topicService, 'queryTopics').mockResolvedValue([staleTopic]);
+
+      act(() => {
+        useChatStore.setState({
+          activeAgentId: agentId,
+          operations: {},
+          topicDataMap: {
+            [key]: {
+              currentPage: 0,
+              hasMore: false,
+              items: [locallyClearedTopic],
+              pageSize: 20,
+              total: 1,
+            },
+          },
+        });
+      });
+
+      await expect(result.current.cleanupStaleRunningTopics()).resolves.toBe(1);
+      expect(useChatStore.getState().topicDataMap[key].items[0]).toMatchObject({
+        metadata: {
+          heteroSessionOperationId: 'operation-old',
+          runningOperation: null,
+        },
+        status: 'active',
       });
     });
 

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -12,6 +12,7 @@ import useSWR from 'swr';
 import { LOADING_FLAT } from '@/const/message';
 import { mutate, useClientDataSWRWithSync } from '@/libs/swr';
 import { cronKeys, deviceKeys, topicKeys } from '@/libs/swr/keys';
+import { aiAgentService } from '@/services/aiAgent';
 import { chatService } from '@/services/chat';
 import { type GitLinkedPRSummary, gitService } from '@/services/git';
 import { messageService } from '@/services/message';
@@ -615,21 +616,53 @@ export class ChatTopicActionImpl {
   #clearStaleRunningOperationMetadata = async (
     topic: RunningTopicForWatchdog,
     patchScope: TopicPatchScope,
-  ): Promise<void> => {
-    if (!topic.metadata?.runningOperation) return;
+  ): Promise<boolean> => {
+    const operationId = topic.metadata?.runningOperation?.operationId;
+    if (!operationId) return false;
 
+    const { cleared } = await aiAgentService.clearRunningOperation({
+      operationId,
+      settledStatus: 'active',
+      topicId: topic.id,
+    });
+    if (!cleared) return false;
+
+    // The server CAS is authoritative, but a new operation can start while its
+    // response is in flight. Re-check the post-await local generation before
+    // folding A's cleanup into Zustand so it cannot hide a newly-started B.
+    if (this.#hasAliveOperationForTopic(topic.id)) return false;
     const key = topicMapKey(patchScope);
-    const currentTopic = this.#get().topicDataMap[key]?.items.find((item) => item.id === topic.id);
-    const metadata = currentTopic?.metadata ?? topic.metadata;
+    const currentState = this.#get();
+    const currentTopic = currentState.topicDataMap[key]?.items.find((item) => item.id === topic.id);
+    const currentViewTopic = currentState.agentTopicsViewMap[key]?.items.find(
+      (item) => item.id === topic.id,
+    );
+    const loadedTopics = [currentTopic, currentViewTopic].filter(
+      (item): item is ChatTopic => !!item,
+    );
+    if (
+      loadedTopics.some((item) => {
+        const currentOperationId =
+          item.metadata?.runningOperation?.operationId ?? item.metadata?.heteroSessionOperationId;
 
-    await topicService.updateTopicMetadata(topic.id, { runningOperation: null });
+        return currentOperationId && currentOperationId !== operationId;
+      })
+    )
+      return false;
+    if (
+      loadedTopics.length > 0 &&
+      loadedTopics.every((item) => !item.metadata?.runningOperation && item.status !== 'running')
+    )
+      return true;
 
+    const metadata = currentTopic?.metadata ?? currentViewTopic?.metadata ?? topic.metadata;
     this.#get().internal_dispatchTopic({
       ...patchScope,
       id: topic.id,
       type: 'updateTopic',
-      value: { metadata: { ...metadata, runningOperation: null } },
+      value: { metadata: { ...metadata, runningOperation: null }, status: 'active' },
     });
+    return true;
   };
 
   cleanupStaleRunningTopics = async (): Promise<number> => {
@@ -657,13 +690,8 @@ export class ChatTopicActionImpl {
           try {
             const patchScope = this.#getStaleRunningTopicPatchScope(topic);
 
-            await this.#clearStaleRunningOperationMetadata(topic, patchScope);
-
-            await this.updateTopicStatus({
-              ...patchScope,
-              status: 'active',
-              topicId: topic.id,
-            });
+            const cleared = await this.#clearStaleRunningOperationMetadata(topic, patchScope);
+            if (!cleared) return false;
 
             return true;
           } catch (err) {


### PR DESCRIPTION
This supersedes #17450 with a clean implementation on the current Gateway execution contracts.

Gateway-created Threads previously had several ownership gaps: the first turn could be persisted outside the requested Thread, a lost RPC response could roll back already-committed messages, heterogeneous CLI sessions could resume across the wrong Topic/Thread, and delayed terminal callbacks could clear a newer operation.

### What changed

- create continuation/standalone Threads and their client-minted user/assistant pair in one transaction;
- validate the source message belongs to the Topic and is not already inside a Thread, preventing nested user Threads;
- reconcile staged client context to the server-authoritative `createdThreadId`, including messages, files, operations, queued follow-ups, voice state, and the Thread portal;
- recover a lost `execAgent` response only from an exact owned user/assistant pair and Thread source relationship;
- scope heterogeneous resume sessions to the main Topic or exact Thread assistant anchor;
- bind terminal callbacks and notify-based agents to an operation generation, with CAS-based session and running-operation cleanup;
- prevent stale callbacks and the frontend watchdog from overwriting a newer running or completed generation;
- hide the branching action when the mounted conversation is already inside a Thread.

No database migration or visual design change is required.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation:

```text
Core Gateway / Thread / heterogeneous: 15 files, 425 tests passed
CLI heterogeneous notify:              16 tests passed
Desktop Gateway:                       77 tests passed
Database models:                       55 tests passed
Total targeted tests:                 573 passed
Type check:                            clean
Targeted lint (36 files):              clean
git diff --check:                      clean
```

#### 🔗 Related Issue

Supersedes #17450. No matching product issue was found.
