### PR TITLE
✨ feat(hetero-agent): support Qoder reasoning effort

### DIFF
--- a/apps/cli/src/commands/hetero.test.ts
+++ b/apps/cli/src/commands/hetero.test.ts
@@ -212,7 +212,7 @@ describe('hetero exec command', () => {
     expect(call.operationId).toMatch(/^[0-9a-f-]{36}$/i);
   });
 
-  it('runs Qoder with its default command and forwards model but not effort', async () => {
+  it('runs Qoder with its default command and forwards model and effort', async () => {
     mockSpawnAgent.mockReturnValue(createFakeHandle());
 
     await runCmd([
@@ -233,7 +233,7 @@ describe('hetero exec command', () => {
       expect.objectContaining({
         agentType: 'qoder',
         command: 'qodercli',
-        extraArgs: ['--model', 'Claude Sonnet 4.5'],
+        extraArgs: ['--model', 'Claude Sonnet 4.5', '--reasoning-effort', 'high'],
         prompt: 'do thing',
       }),
     );

--- a/apps/cli/src/commands/hetero.ts
+++ b/apps/cli/src/commands/hetero.ts
@@ -139,7 +139,10 @@ const buildExtraArgs = (
             : options.type === 'pi'
               ? [...(options.model ? ['--model', options.model] : [])]
               : options.type === 'qoder'
-                ? [...(options.model ? ['--model', options.model] : [])]
+                ? [
+                    ...(options.model ? ['--model', options.model] : []),
+                    ...(options.effort ? ['--reasoning-effort', options.effort] : []),
+                  ]
                 : [];
   const extraArgs = [...(options.agentArg ?? []), ...selectorArgs];
 

--- a/packages/types/src/agent/agencyConfig.test.ts
+++ b/packages/types/src/agent/agencyConfig.test.ts
@@ -112,7 +112,7 @@ describe('buildHeteroSpawnArgs', () => {
     expect(buildHeteroExecArgs(provider)).toEqual(['--agent-arg=--mode', '--agent-arg=high']);
   });
 
-  it('forwards Qoder native args and model while leaving effort to the CLI default', () => {
+  it('forwards Qoder native args, model, and reasoning effort', () => {
     const provider: HeterogeneousProviderConfig = {
       args: ['--verbose'],
       effort: 'high',
@@ -120,15 +120,23 @@ describe('buildHeteroSpawnArgs', () => {
       type: 'qoder',
     };
 
-    expect(buildHeteroSpawnArgs(provider)).toEqual(['--verbose', '--model', 'qoder-model']);
+    expect(buildHeteroSpawnArgs(provider)).toEqual([
+      '--verbose',
+      '--model',
+      'qoder-model',
+      '--reasoning-effort',
+      'high',
+    ]);
     expect(buildHeteroExecArgs(provider)).toEqual([
       '--agent-arg=--verbose',
       '--model',
       'qoder-model',
+      '--effort',
+      'high',
     ]);
   });
 
-  it('preserves a Qoder model from native args and does not inject Default', () => {
+  it('preserves Qoder model and reasoning effort from native args without injecting duplicates', () => {
     expect(
       buildHeteroSpawnArgs({
         args: ['-m', 'native-model'],
@@ -143,6 +151,20 @@ describe('buildHeteroSpawnArgs', () => {
         type: 'qoder',
       }),
     ).toEqual(['--agent-arg=--model=native-model']);
+    expect(
+      buildHeteroSpawnArgs({
+        args: ['--reasoning-effort', 'max'],
+        effort: 'high',
+        type: 'qoder',
+      }),
+    ).toEqual(['--reasoning-effort', 'max']);
+    expect(
+      buildHeteroExecArgs({
+        args: ['--reasoning-effort=max'],
+        effort: 'high',
+        type: 'qoder',
+      }),
+    ).toEqual(['--agent-arg=--reasoning-effort=max']);
     expect(
       buildHeteroSpawnArgs({
         model: HETEROGENEOUS_AGENT_DEFAULT_SELECTION,

--- a/packages/types/src/agent/agencyConfig.ts
+++ b/packages/types/src/agent/agencyConfig.ts
@@ -99,8 +99,21 @@ const CODEX_MAX_REASONING_EFFORT_LEVELS = [
 const CODEX_ULTRA_REASONING_MODELS = ['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra'] as const;
 const CODEX_MAX_REASONING_MODELS = ['gpt-5.6-luna'] as const;
 
+/**
+ * Qoder reasoning-effort levels, mirrored 1:1 with the CLI's
+ * `--reasoning-effort <level>` flag.
+ */
+export const QODER_REASONING_EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
+
+export type QoderReasoningEffort = (typeof QODER_REASONING_EFFORT_LEVELS)[number];
+
+export const QODER_REASONING_EFFORT_FLAG = '--reasoning-effort';
+
 export type HeterogeneousReasoningEffort =
-  ClaudeCodeReasoningEffort | CodexReasoningEffort | HeterogeneousAgentDefaultSelection;
+  | ClaudeCodeReasoningEffort
+  | CodexReasoningEffort
+  | QoderReasoningEffort
+  | HeterogeneousAgentDefaultSelection;
 
 /**
  * Codex speed modes, mirrored to the CLI config key `service_tier`.
@@ -279,6 +292,12 @@ interface CodexSelectionSource {
   speed?: string | null;
 }
 
+interface QoderSelectionSource {
+  args?: string[];
+  effort?: string | null;
+  model?: string | null;
+}
+
 const CODEX_CONFIG_FLAGS = ['-c', '--config'] as const;
 const CODEX_MODEL_FLAGS = ['-m', '--model'] as const;
 const HETERO_EXEC_AGENT_ARG_FLAG = '--agent-arg';
@@ -377,6 +396,9 @@ const isClaudeCodeReasoningEffort = (
 const isCodexReasoningEffort = (value: string | undefined): value is CodexReasoningEffort =>
   !!value && CODEX_REASONING_EFFORT_LEVELS.includes(value as CodexReasoningEffort);
 
+const isQoderReasoningEffort = (value: string | undefined): value is QoderReasoningEffort =>
+  !!value && QODER_REASONING_EFFORT_LEVELS.includes(value as QoderReasoningEffort);
+
 /**
  * Reasoning-effort levels exposed by a Codex model. Unknown and default model
  * selections use the conservative common set because their actual capability
@@ -465,6 +487,22 @@ const getExplicitCodexReasoningEffort = (
 ): CodexReasoningEffort | undefined => {
   const effort = source?.effort?.trim();
   return isCodexReasoningEffort(effort) ? effort : undefined;
+};
+
+export const resolveQoderReasoningEffort = (
+  source: QoderSelectionSource | null | undefined,
+): QoderReasoningEffort | HeterogeneousAgentDefaultSelection => {
+  const effort = (
+    getCliFlagValue(source?.args, QODER_REASONING_EFFORT_FLAG) ?? source?.effort
+  )?.trim();
+  return isQoderReasoningEffort(effort) ? effort : HETEROGENEOUS_AGENT_DEFAULT_SELECTION;
+};
+
+const getExplicitQoderReasoningEffort = (
+  source: QoderSelectionSource | null | undefined,
+): QoderReasoningEffort | undefined => {
+  const effort = source?.effort?.trim();
+  return isQoderReasoningEffort(effort) ? effort : undefined;
 };
 
 const isCodexFastServiceTier = (value: string | undefined): boolean =>
@@ -590,6 +628,10 @@ export const buildHeteroSpawnArgs = (
     ) {
       extraArgs.push('--model', model);
     }
+    const effort = getExplicitQoderReasoningEffort(provider);
+    if (effort && !hasCliFlag(baseArgs, QODER_REASONING_EFFORT_FLAG)) {
+      extraArgs.push(QODER_REASONING_EFFORT_FLAG, effort);
+    }
   }
 
   if (extraArgs.length === 0) return provider.args;
@@ -691,6 +733,10 @@ export const buildHeteroExecArgs = (
       !hasAnyCliFlag(baseArgs, QODER_MODEL_FLAGS)
     ) {
       selectorArgs.push('--model', model);
+    }
+    const effort = getExplicitQoderReasoningEffort(provider);
+    if (effort && !hasCliFlag(baseArgs, QODER_REASONING_EFFORT_FLAG)) {
+      selectorArgs.push('--effort', effort);
     }
   }
 

--- a/src/features/ChatInput/ControlBar/HeteroModel.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroModel.tsx
@@ -6,6 +6,7 @@ import type {
   HeterogeneousAgentDefaultSelection,
   HeterogeneousProviderConfig,
   HeterogeneousSpeedMode,
+  QoderReasoningEffort,
 } from '@lobechat/types';
 import {
   CLAUDE_CODE_REASONING_EFFORT_LEVELS,
@@ -15,11 +16,14 @@ import {
   codexModelSupportsReasoningEffort,
   getCodexReasoningEffortLevels,
   HETEROGENEOUS_AGENT_DEFAULT_SELECTION,
+  QODER_REASONING_EFFORT_FLAG,
+  QODER_REASONING_EFFORT_LEVELS,
   resolveClaudeCodeModel,
   resolveClaudeCodeReasoningEffort,
   resolveCodexModel,
   resolveCodexReasoningEffort,
   resolveCodexSpeedMode,
+  resolveQoderReasoningEffort,
 } from '@lobechat/types';
 import { Icon } from '@lobehub/ui';
 import {
@@ -52,7 +56,10 @@ import { useChatInputResourceAccess } from '../hooks/useChatInputResourceAccess'
 import { HeterogeneousAgentModelSelector } from './HeterogeneousAgentModelSelector';
 
 type HeteroReasoningEffort =
-  ClaudeCodeReasoningEffort | CodexReasoningEffort | HeterogeneousAgentDefaultSelection;
+  | ClaudeCodeReasoningEffort
+  | CodexReasoningEffort
+  | QoderReasoningEffort
+  | HeterogeneousAgentDefaultSelection;
 
 type SelectableHeteroProviderType = 'claude-code' | 'codex' | 'opencode' | 'pi' | 'qoder';
 
@@ -402,6 +409,7 @@ const HeteroModel = memo(() => {
   const { canConfigureResource } = useChatInputResourceAccess();
   const enabled = canCreateContent && canConfigureResource;
   const [open, setOpen] = useState(false);
+  const [effortOpen, setEffortOpen] = useState(false);
 
   const patchProvider = useCallback(
     async (patch: Partial<Pick<HeterogeneousProviderConfig, 'effort' | 'model' | 'speed'>>) => {
@@ -423,7 +431,15 @@ const HeteroModel = memo(() => {
           const sourceArgs = nextPatch.args ?? provider?.args;
           nextPatch.args = stripCodexConfigKey(sourceArgs, CODEX_SERVICE_TIER_CONFIG_KEY);
         }
-      } else if (providerType === 'opencode' || providerType === 'pi' || providerType === 'qoder') {
+      } else if (providerType === 'qoder') {
+        if ('model' in patch) {
+          nextPatch.args = stripCliFlags(provider?.args, ['--model', '-m']);
+        }
+        if ('effort' in patch) {
+          const sourceArgs = nextPatch.args ?? provider?.args;
+          nextPatch.args = stripCliFlags(sourceArgs, [QODER_REASONING_EFFORT_FLAG]);
+        }
+      } else if (providerType === 'opencode' || providerType === 'pi') {
         if ('model' in patch) {
           nextPatch.args = stripCliFlags(
             provider?.args,
@@ -491,7 +507,72 @@ const HeteroModel = memo(() => {
   if (!isSelectableProviderType(provider?.type)) return null;
   if (!enabled) return null;
 
-  if (provider.type === 'opencode' || provider.type === 'pi' || provider.type === 'qoder') {
+  if (provider.type === 'qoder') {
+    const model =
+      provider.model && provider.model !== HETEROGENEOUS_AGENT_DEFAULT_SELECTION
+        ? provider.model
+        : HETEROGENEOUS_AGENT_DEFAULT_SELECTION;
+    const effort = resolveQoderReasoningEffort(provider);
+    const defaultLabel = t('heteroAgent.modelSelector.default');
+    const effortLabel = t(EFFORT_LABEL_KEYS[effort]);
+    const effortOptions: { label: string; value: HeteroReasoningEffort }[] = [
+      { label: defaultLabel, value: HETEROGENEOUS_AGENT_DEFAULT_SELECTION },
+      ...QODER_REASONING_EFFORT_LEVELS.map((level) => ({
+        label: t(EFFORT_LABEL_KEYS[level]),
+        value: level,
+      })),
+    ];
+
+    return (
+      <>
+        <HeterogeneousAgentModelSelector
+          agentId={agentId}
+          disabled={false}
+          model={model}
+          permissionReason={reason}
+          type={provider.type}
+          onSelect={(value) => void patchProvider({ model: value })}
+        />
+        <DropdownMenuRoot open={effortOpen} onOpenChange={setEffortOpen}>
+          <DropdownMenuTrigger nativeButton={false}>
+            <div className={styles.trigger}>
+              <span className={styles.label}>{effortLabel}</span>
+              <Icon icon={ChevronDownIcon} size={12} />
+            </div>
+          </DropdownMenuTrigger>
+          <DropdownMenuPortal>
+            <DropdownMenuPositioner placement="topLeft" sideOffset={8}>
+              <DropdownMenuPopup className={styles.popup} style={{ width: 220 }}>
+                <div className={styles.sectionTitle}>
+                  {t('heteroAgent.modelSelector.reasoning')}
+                </div>
+                <div className={styles.scroll}>
+                  {effortOptions.map((option) => (
+                    <DropdownMenuItem
+                      className={styles.option}
+                      data-selected={effort === option.value ? 'true' : undefined}
+                      key={`effort-${option.value}`}
+                      onClick={() => {
+                        setEffortOpen(false);
+                        void patchProvider({ effort: option.value });
+                      }}
+                    >
+                      <span className={styles.optionLabel}>{option.label}</span>
+                      {effort === option.value && (
+                        <Icon className={styles.check} icon={CheckIcon} size={16} />
+                      )}
+                    </DropdownMenuItem>
+                  ))}
+                </div>
+              </DropdownMenuPopup>
+            </DropdownMenuPositioner>
+          </DropdownMenuPortal>
+        </DropdownMenuRoot>
+      </>
+    );
+  }
+
+  if (provider.type === 'opencode' || provider.type === 'pi') {
     const model =
       provider.model && provider.model !== HETEROGENEOUS_AGENT_DEFAULT_SELECTION
         ? provider.model


### PR DESCRIPTION
Qoder exposes a native `--reasoning-effort` option, but LobeHub previously treated effort as a CLI default and neither forwarded configured values nor exposed them in the chat input.

### What changed

- define Qoder's supported reasoning-effort levels (`low`, `medium`, `high`, `xhigh`, and `max`) in the shared heterogeneous-agent configuration types;
- resolve native `--reasoning-effort` arguments as the source of truth and avoid injecting duplicate flags;
- forward configured effort through `lh hetero exec --effort` and translate it to Qoder's native flag;
- add a reasoning-effort selector next to the Qoder model selector in the chat input;
- clear conflicting native model/effort flags when the user chooses an explicit UI value;
- cover spawn arguments, wrapper arguments, native overrides, and CLI forwarding with regression tests.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation:

```text
5 files · lint clean · 102 related tests passed
Full type check clean
git diff --check clean
```

#### 🔗 Related Issue

No matching issue found.

#### Screenshots

Not included. The new control reuses the existing heterogeneous reasoning-effort dropdown beside the model selector.
