### PR TITLE
💄 style(agent-chat): move the terminal button into the header right actions

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/index.test.tsx
@@ -1,24 +1,8 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import HeaderActions from './index';
-
-const { toggleTerminalPanel } = vi.hoisted(() => ({
-  toggleTerminalPanel: vi.fn(),
-}));
-
-vi.mock('@/const/version', () => ({ isDesktop: true }));
-
-vi.mock('@/store/global', () => ({
-  useGlobalStore: (
-    selector: (state: { toggleTerminalPanel: typeof toggleTerminalPanel }) => unknown,
-  ) => selector({ toggleTerminalPanel }),
-}));
-
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
-}));
 
 vi.mock('@lobehub/ui', () => ({
   ActionIcon: ({ title, onClick }: { title?: string; onClick?: () => void }) => (
@@ -54,13 +38,5 @@ describe('Conversation header actions', () => {
     render(<HeaderActions />);
 
     expect(screen.getByTestId('topic-info-header')).toBeInTheDocument();
-  });
-
-  it('opens the terminal directly from the desktop header', () => {
-    render(<HeaderActions />);
-
-    fireEvent.click(screen.getByRole('button', { name: 'terminalPanel.title' }));
-
-    expect(toggleTerminalPanel).toHaveBeenCalledWith(true);
   });
 });

--- a/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/index.tsx
@@ -1,33 +1,19 @@
 'use client';
 
 import { ActionIcon, DropdownMenu } from '@lobehub/ui';
-import { MoreHorizontal, SquareTerminalIcon } from 'lucide-react';
+import { MoreHorizontal } from 'lucide-react';
 import { memo } from 'react';
-import { useTranslation } from 'react-i18next';
 
-import { isDesktop } from '@/const/version';
 import HeaderSlot from '@/routes/(main)/agent/(chat)/_layout/HeaderSlot';
-import { useGlobalStore } from '@/store/global';
 
 import { useMenu } from './useMenu';
 
 const HeaderActions = memo(() => {
-  const { t } = useTranslation('chat');
   const { menuHeader, menuItems } = useMenu();
-  const toggleTerminalPanel = useGlobalStore((s) => s.toggleTerminalPanel);
 
   return (
     <>
       <HeaderSlot.Outlet />
-      {isDesktop && (
-        <ActionIcon
-          icon={SquareTerminalIcon}
-          size={'small'}
-          title={t('terminalPanel.title')}
-          tooltipProps={{ placement: 'bottom' }}
-          onClick={() => toggleTerminalPanel(true)}
-        />
-      )}
       <DropdownMenu header={menuHeader} items={menuItems}>
         <ActionIcon icon={MoreHorizontal} size={'small'} />
       </DropdownMenu>

--- a/src/routes/(main)/agent/features/Conversation/Header/TerminalPanelToggle/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/TerminalPanelToggle/index.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { ActionIcon } from '@lobehub/ui';
+import { SquareTerminalIcon } from 'lucide-react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
+import { isDesktop } from '@/const/version';
+import { useGlobalStore } from '@/store/global';
+
+const TerminalPanelToggle = memo(() => {
+  const { t } = useTranslation('chat');
+  const toggleTerminalPanel = useGlobalStore((s) => s.toggleTerminalPanel);
+
+  if (!isDesktop) return null;
+
+  return (
+    <ActionIcon
+      icon={SquareTerminalIcon}
+      size={DESKTOP_HEADER_ICON_SMALL_SIZE}
+      title={t('terminalPanel.title')}
+      tooltipProps={{ placement: 'bottom' }}
+      onClick={() => toggleTerminalPanel(true)}
+    />
+  );
+});
+
+export default TerminalPanelToggle;

--- a/src/routes/(main)/agent/features/Conversation/Header/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/index.tsx
@@ -17,6 +17,7 @@ import { useElectronStore } from '@/store/electron';
 import HeaderActions from './HeaderActions';
 import ShareButton from './ShareButton';
 import Tags from './Tags';
+import TerminalPanelToggle from './TerminalPanelToggle';
 import WorkingPanelToggle from './WorkingPanelToggle';
 
 // Below this column width the header is a solid in-flow bar with a bottom
@@ -181,6 +182,7 @@ const Header = memo(() => {
             {isLocalSystemEnabled && workingDirectory && (
               <OpenInAppButton workingDirectory={workingDirectory} />
             )}
+            <TerminalPanelToggle />
             <TopicCommentButton />
             <ShareButton />
             <WorkingPanelToggle />


### PR DESCRIPTION
The terminal toggle sat next to the topic title on the left, detached from every other header action. It now lives in the right slot with the IDE / comment / share / panel buttons.

- Extract the `SquareTerminalIcon` button out of `HeaderActions` into its own `TerminalPanelToggle` component.
- Render it in the right slot right after `OpenInAppButton`, so the two local-system entries (open in IDE / open terminal) sit together.
- Use the shared `DESKTOP_HEADER_ICON_SMALL_SIZE` instead of `'small'`, matching `ShareButton` and `WorkingPanelToggle`.
- `HeaderActions` is now just the header slot outlet plus the overflow menu; its unused `isDesktop` / `useTranslation` / `useGlobalStore` imports are dropped.

Desktop-only button — no behavior change, only placement.

| Before | After |
| ------ | ----- |
| Terminal icon next to the topic title (left) | Terminal icon in the right action group |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check` on the touched files: lint clean, tests passing. The terminal case was removed from `HeaderActions/index.test.tsx` along with the button; no new component test was added since the repo forbids new React component tests.

#### 🔗 Related Issue

N/A