### PR TITLE
🔧 fix(topic-auto-summary): make the workflow opt-in and route it through the branded provider

### DIFF
--- a/apps/server/src/services/topicAutoSummary/index.test.ts
+++ b/apps/server/src/services/topicAutoSummary/index.test.ts
@@ -59,7 +59,9 @@ const createDb = () => {
 describe('TopicAutoSummaryService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.getUserSettings.mockResolvedValue({});
+    mocks.getUserSettings.mockResolvedValue({
+      systemAgent: { topicAutoSummary: { enabled: true } },
+    });
     mocks.generateObject.mockResolvedValue({ description: 'Next steps', summary: 'Combined' });
     mocks.updateSummaryIfCurrent.mockResolvedValue(true);
   });
@@ -75,5 +77,27 @@ describe('TopicAutoSummaryService', () => {
       'Previous rolling summary:\nEarlier decision: use PostgreSQL.',
     );
     expect(request.messages[1].content).toContain('Recent conversation:\nUSER: What is next?');
+  });
+
+  it('skips a user who never opted in', async () => {
+    mocks.getUserSettings.mockResolvedValue({});
+    const service = new TopicAutoSummaryService(createDb(), 'user-1');
+
+    const result = await service.summarize('topic-1');
+
+    expect(result).toEqual({ reason: 'disabled', summarized: false });
+    expect(mocks.generateObject).not.toHaveBeenCalled();
+  });
+
+  it('still summarizes an opted-out user when forced', async () => {
+    mocks.getUserSettings.mockResolvedValue({
+      systemAgent: { topicAutoSummary: { enabled: false } },
+    });
+    const service = new TopicAutoSummaryService(createDb(), 'user-1');
+
+    const result = await service.summarize('topic-1', { force: true });
+
+    expect(result).toEqual({ summarized: true });
+    expect(mocks.generateObject).toHaveBeenCalled();
   });
 });

--- a/apps/server/src/services/topicAutoSummary/index.ts
+++ b/apps/server/src/services/topicAutoSummary/index.ts
@@ -57,7 +57,9 @@ export class TopicAutoSummaryService {
     const settings = await new UserModel(this.db, this.userId).getUserSettings();
     const systemAgent = settings?.systemAgent as Partial<UserSystemAgentConfig> | undefined;
     const config = systemAgent?.topicAutoSummary as Partial<SystemAgentItem> | undefined;
-    if (!options.force && config?.enabled === false)
+    // Opt-in, so an absent setting means disabled — the dispatch query filters on
+    // the same default, and this guard also covers replays that skip dispatch.
+    if (!options.force && config?.enabled !== true)
       return { reason: 'disabled', summarized: false };
 
     const ownership = this.workspaceId

--- a/packages/const/src/settings/systemAgent.ts
+++ b/packages/const/src/settings/systemAgent.ts
@@ -39,10 +39,13 @@ export const DEFAULT_FOLLOW_UP_ACTION_SYSTEM_AGENT_ITEM: SystemAgentItem = {
   provider: DEFAULT_MINI_SYSTEM_AGENT_ITEM.provider,
 };
 
+// Opt-in: summarizing runs unattended in the background and spends the user's
+// own budget, so it stays off until they turn it on. Model/provider follow the
+// branded defaults rather than a hardcoded pair, so the deployment's own
+// gateway resolves the credentials instead of a per-provider server env key.
 export const DEFAULT_TOPIC_AUTO_SUMMARY_SYSTEM_AGENT_ITEM: SystemAgentItem = {
-  enabled: true,
-  model: 'deepseek-v4-flash',
-  provider: 'deepseek',
+  ...DEFAULT_SYSTEM_AGENT_ITEM,
+  enabled: false,
 };
 
 export const DEFAULT_USER_MEMORY_EMBEDDING_SYSTEM_AGENT_ITEM: SystemAgentItem = {

--- a/packages/database/src/models/__tests__/topicSummary.test.ts
+++ b/packages/database/src/models/__tests__/topicSummary.test.ts
@@ -11,19 +11,25 @@ const db: LobeChatDatabase = await getTestDB();
 const model = new TopicSummaryModel(db);
 const userId = 'topic-summary-user';
 const otherUserId = 'topic-summary-other';
+// Never touched the setting — the feature is opt-in, so this user stays out.
+const unsetUserId = 'topic-summary-unset';
 const now = new Date('2026-07-31T12:00:00.000Z');
 
 describe('TopicSummaryModel', () => {
   beforeEach(async () => {
     await db.delete(users);
-    await db.insert(users).values([{ id: userId }, { id: otherUserId }]);
+    await db.insert(users).values([{ id: userId }, { id: otherUserId }, { id: unsetUserId }]);
+    await db.insert(userSettings).values({
+      id: userId,
+      systemAgent: { topicAutoSummary: { enabled: true } },
+    });
   });
 
   afterEach(async () => {
     await db.delete(users);
   });
 
-  it('lists only enabled, stale candidates inside the rolling lookback window', async () => {
+  it('lists only opted-in, stale candidates inside the rolling lookback window', async () => {
     await db.insert(userSettings).values({
       id: otherUserId,
       systemAgent: { topicAutoSummary: { enabled: false } },
@@ -32,6 +38,7 @@ describe('TopicSummaryModel', () => {
       { createdAt: new Date('2026-07-31T00:00:00Z'), id: 'eligible', userId },
       { createdAt: new Date('2026-07-29T00:00:00Z'), id: 'too-old', userId },
       { createdAt: new Date('2026-07-31T00:00:00Z'), id: 'disabled', userId: otherUserId },
+      { createdAt: new Date('2026-07-31T00:00:00Z'), id: 'unset', userId: unsetUserId },
       { createdAt: new Date('2026-07-31T00:00:00Z'), id: 'active', status: 'running', userId },
     ]);
     await db.insert(messages).values([
@@ -58,6 +65,14 @@ describe('TopicSummaryModel', () => {
         topicId: 'disabled',
         updatedAt: new Date('2026-07-31T10:00:00Z'),
         userId: otherUserId,
+      },
+      {
+        content: 'c2',
+        id: 'm-unset',
+        role: 'user',
+        topicId: 'unset',
+        updatedAt: new Date('2026-07-31T10:00:00Z'),
+        userId: unsetUserId,
       },
       {
         content: 'd',

--- a/packages/database/src/models/topicSummary.ts
+++ b/packages/database/src/models/topicSummary.ts
@@ -42,7 +42,9 @@ export interface TopicSummaryCandidate {
   workspaceId: string | null;
 }
 
-const isTopicAutoSummaryEnabled = sql<boolean>`COALESCE((${userSettings.systemAgent}->'topicAutoSummary'->>'enabled')::boolean, true) = true`;
+// Mirrors `DEFAULT_TOPIC_AUTO_SUMMARY_SYSTEM_AGENT_ITEM.enabled`: users who have
+// never touched the setting are opted out, so the missing-value default is false.
+const isTopicAutoSummaryEnabled = sql<boolean>`COALESCE((${userSettings.systemAgent}->'topicAutoSummary'->>'enabled')::boolean, false) = true`;
 const SYSTEM_TOPIC_TRIGGERS = ['cron', 'eval', 'task_manager', 'task', 'document'];
 
 export const topicSummaryEligibleMessage = and(

--- a/src/store/user/slices/settings/selectors/__snapshots__/settings.test.ts.snap
+++ b/src/store/user/slices/settings/selectors/__snapshots__/settings.test.ts.snap
@@ -100,7 +100,7 @@ exports[`settingsSelectors > currentSystemAgent > should merge DEFAULT_SYSTEM_AG
     "provider": "openai",
   },
   "topicAutoSummary": {
-    "enabled": true,
+    "enabled": false,
     "model": "deepseek-v4-flash",
     "provider": "deepseek",
   },


### PR DESCRIPTION
Topic auto-summary is not scheduled in production yet. Two things need to change before it can be.

**1. It bypasses the branded provider.** The default was a hardcoded `deepseek` / `deepseek-v4-flash` pair — which happens to be the OSS value of `DEFAULT_PROVIDER` / `DEFAULT_MODEL`, inlined. `initModelRuntimeFromDB` then resolves credentials from the user's own vault, falling back to a `DEEPSEEK_API_KEY` server env key that a branded deploy has no reason to set. Following `DEFAULT_SYSTEM_AGENT_ITEM` instead keeps the OSS values byte-identical while letting a branded build route the call through its own gateway — the same path memory extraction already takes for `provider === 'lobehub'`.

**2. It was enabled by default.** The workflow runs unattended and spends the user's own budget (it goes through `AiGenerationService`, so the usual chat billing applies). Charging every user for a background job they never asked for isn't right, so it's now off until they turn it on. This also lines it up with its siblings in the same settings group — `followUpAction` and `inputCompletion` are both opt-in already.

The switch in `ServiceModel → optional features` already exists and reads this default, so it now renders off with no UI change. A modal explaining what turning it on implies is a follow-up.

#### The three-places trap

The missing-value default lives in three spots that must agree, or the opt-out leaks:

| Where | What it guards |
| --- | --- |
| `DEFAULT_TOPIC_AUTO_SUMMARY_SYSTEM_AGENT_ITEM` | the settings UI + anything reading merged user settings |
| `isTopicAutoSummaryEnabled` (dispatch candidate query) | which topics get scheduled at all |
| `TopicAutoSummaryService.summarize` | replays / direct execute calls that skip dispatch |

Changing only the const would leave the SQL `COALESCE(..., true)` sweeping in every user who has never touched the setting — that is, almost everyone.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `apps/server/src/services/topicAutoSummary/index.test.ts` — 3 passed. Added coverage for "never opted in → skipped" and "opted out but `force: true` → still runs".
- `packages/database/src/models/__tests__/topicSummary.test.ts` — 5 passed. Added a user with no `user_settings` row at all; they must not appear as a candidate.
- `apps/server/src/router-hono/workflows/topic-auto-summary/dispatch.test.ts` — 5 passed, unchanged.
- `bun run type-check` clean.

Measured against production before the change: with the old default, a first run would have swept **3596 topics across 1445 users** in the 24h window, none of whom had opted in.