### PR TITLE
🐛 fix(device): probe the sandbox helper this app ships, not the one the backend guesses

### DIFF
--- a/apps/desktop/electron-builder.mjs
+++ b/apps/desktop/electron-builder.mjs
@@ -304,6 +304,15 @@ const config = {
       from: 'node_modules/@anthropic-ai/sandbox-runtime/vendor',
       to: 'sandbox-runtime/vendor',
     },
+    // Carried alongside the binaries so the staging directory stays keyed on the
+    // backend's real version. Without it the version lookup falls back to the
+    // binary's size — which still works, but would defeat the per-version
+    // isolation in exactly the case it exists for: an installed app being
+    // updated.
+    {
+      from: 'node_modules/@anthropic-ai/sandbox-runtime/package.json',
+      to: 'sandbox-runtime/package.json',
+    },
   ],
 
   win: {

--- a/packages/device-sandbox/src/__tests__/capability.test.ts
+++ b/packages/device-sandbox/src/__tests__/capability.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { probeSandboxCapability } from '../capability';
+
+const {
+  mockCheckDependencies,
+  mockGetSrtWinPath,
+  mockIsSupportedPlatform,
+  mockResolveEffectiveSrtWin,
+  mockResolveSrtWin,
+  mockUserStatus,
+  mockWfpStatus,
+} = vi.hoisted(() => ({
+  mockCheckDependencies: vi.fn(),
+  mockGetSrtWinPath: vi.fn(),
+  mockIsSupportedPlatform: vi.fn(),
+  mockResolveEffectiveSrtWin: vi.fn(),
+  mockResolveSrtWin: vi.fn(),
+  mockUserStatus: vi.fn(),
+  mockWfpStatus: vi.fn(),
+}));
+
+vi.mock('@anthropic-ai/sandbox-runtime', () => ({
+  SandboxManager: {
+    checkDependencies: mockCheckDependencies,
+    isSupportedPlatform: mockIsSupportedPlatform,
+  },
+  getSrtWinPath: mockGetSrtWinPath,
+  getWindowsSandboxUserStatus: mockUserStatus,
+  getWindowsWfpStatus: mockWfpStatus,
+  resolveSrtWin: mockResolveSrtWin,
+  windowsInstallInstructions: () => 'run the installer',
+}));
+
+vi.mock('../srtWinStaging', () => ({
+  resolveEffectiveSrtWin: mockResolveEffectiveSrtWin,
+}));
+
+const setPlatform = (platform: NodeJS.Platform) => {
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform });
+};
+
+describe('probeSandboxCapability', () => {
+  const realPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsSupportedPlatform.mockReturnValue(true);
+    mockResolveEffectiveSrtWin.mockReturnValue('C:\\ProgramData\\LobeHub\\srt-win.exe');
+    mockResolveSrtWin.mockImplementation((cfg: { path: string }) => ({
+      exe: cfg.path,
+      prependArgs: ['--srt-win'],
+    }));
+    mockUserStatus.mockReturnValue({ credPresent: true, provisioned: true });
+    mockWfpStatus.mockReturnValue({ filters: 4, state: 'installed' });
+    mockCheckDependencies.mockReturnValue({ errors: [], warnings: [] });
+  });
+
+  afterEach(() => setPlatform(realPlatform));
+
+  describe('windows', () => {
+    beforeEach(() => setPlatform('win32'));
+
+    it('checks the helper this app ships instead of the backend-guessed path', async () => {
+      // The regression: the backend resolves its helper relative to its own
+      // package directory, which lands inside app.asar once bundled — a
+      // correctly installed app then reported "srt-win.exe not found".
+      const capability = await probeSandboxCapability();
+
+      expect(capability.available).toBe(true);
+      expect(mockCheckDependencies).not.toHaveBeenCalled();
+      expect(mockResolveSrtWin).toHaveBeenCalledWith({
+        path: 'C:\\ProgramData\\LobeHub\\srt-win.exe',
+      });
+      expect(mockUserStatus).toHaveBeenCalledWith({
+        srtWin: { exe: 'C:\\ProgramData\\LobeHub\\srt-win.exe', prependArgs: ['--srt-win'] },
+      });
+    });
+
+    it('reports unavailable when no helper can be found', async () => {
+      mockResolveEffectiveSrtWin.mockReturnValue(undefined);
+
+      const capability = await probeSandboxCapability();
+
+      expect(capability.available).toBe(false);
+      expect(capability.reason).toContain('Sandbox helper not found');
+      expect(mockUserStatus).not.toHaveBeenCalled();
+    });
+
+    it('reports unavailable while the sandbox account is not provisioned', async () => {
+      // This is the state the Set-up button exists to fix, so it must be
+      // distinguishable from a missing binary, which that button cannot fix.
+      mockUserStatus.mockReturnValue({ credPresent: false, provisioned: false });
+
+      const capability = await probeSandboxCapability();
+
+      expect(capability.available).toBe(false);
+      expect(capability.reason).toContain('not provisioned');
+    });
+
+    it('treats unreadable filter enumeration as available', async () => {
+      // BFE enumeration is admin-gated; the behavioural egress check at
+      // initialize() is what actually fails closed, so `cannot-read` from a
+      // non-elevated probe must not disable the option.
+      mockWfpStatus.mockReturnValue({ filters: 0, state: 'cannot-read' });
+
+      expect((await probeSandboxCapability()).available).toBe(true);
+    });
+
+    it('reports unavailable when the filters are absent', async () => {
+      mockWfpStatus.mockReturnValue({ filters: 0, state: 'absent' });
+
+      const capability = await probeSandboxCapability();
+
+      expect(capability.available).toBe(false);
+      expect(capability.reason).toContain('WFP filters');
+    });
+  });
+
+  describe('other platforms', () => {
+    beforeEach(() => setPlatform('darwin'));
+
+    it('keeps using the backend check, which resolves nothing app-relative', async () => {
+      const capability = await probeSandboxCapability();
+
+      expect(capability.available).toBe(true);
+      expect(mockCheckDependencies).toHaveBeenCalled();
+      expect(mockResolveEffectiveSrtWin).not.toHaveBeenCalled();
+    });
+
+    it('surfaces backend dependency errors', async () => {
+      mockCheckDependencies.mockReturnValue({ errors: ['bubblewrap not found'], warnings: [] });
+
+      const capability = await probeSandboxCapability();
+
+      expect(capability.available).toBe(false);
+      expect(capability.reason).toContain('bubblewrap not found');
+    });
+  });
+
+  it('reports unavailable on a platform the backend does not support', async () => {
+    mockIsSupportedPlatform.mockReturnValue(false);
+
+    expect((await probeSandboxCapability()).available).toBe(false);
+  });
+});

--- a/packages/device-sandbox/src/__tests__/launchPlan.test.ts
+++ b/packages/device-sandbox/src/__tests__/launchPlan.test.ts
@@ -82,16 +82,19 @@ describe('device sandbox launch plan', () => {
   });
 
   it('maps the LobeHub policy to a fail-closed Sandbox Runtime configuration', () => {
-    expect(
-      createSrtConfig({
-        ...policy,
-        allowedNetworkDomains: ['api.github.com'],
-        allowNetwork: true,
-        deniedReadRoots: ['/tmp'],
-        deniedWriteRoots: ['/tmp'],
-        readableRoots: ['/tmp'],
-      }),
-    ).toEqual({
+    const config = createSrtConfig({
+      ...policy,
+      allowedNetworkDomains: ['api.github.com'],
+      allowNetwork: true,
+      deniedReadRoots: ['/tmp'],
+      deniedWriteRoots: ['/tmp'],
+      readableRoots: ['/tmp'],
+    });
+
+    // `windows` is asserted separately below: it carries an absolute path to the
+    // staged helper, which exists only on Windows and differs per machine.
+    const { windows: _windows, ...portable } = config;
+    expect(portable).toEqual({
       allowAppleEvents: false,
       allowPty: false,
       enableWeakerNestedSandbox: false,
@@ -112,5 +115,19 @@ describe('device sandbox launch plan', () => {
         strictAllowlist: true,
       },
     });
+  });
+
+  it('overrides the helper path on Windows and nowhere else', () => {
+    // The backend resolves its helper relative to its own package directory,
+    // which stops being a real location once bundled — so Windows must be told
+    // explicitly where the shipped binary is. Other platforms have nothing to
+    // relocate and must not carry a stray override.
+    const { windows } = createSrtConfig(policy);
+
+    if (process.platform === 'win32') {
+      expect(windows?.srtWin?.path).toMatch(/srt-win\.exe$/);
+    } else {
+      expect(windows).toBeUndefined();
+    }
   });
 });

--- a/packages/device-sandbox/src/capability.ts
+++ b/packages/device-sandbox/src/capability.ts
@@ -1,26 +1,94 @@
-import { SandboxManager } from '@anthropic-ai/sandbox-runtime';
+import {
+  getSrtWinPath,
+  getWindowsSandboxUserStatus,
+  getWindowsWfpStatus,
+  resolveSrtWin,
+  SandboxManager,
+  windowsInstallInstructions,
+} from '@anthropic-ai/sandbox-runtime';
 
+import { ensureStagedSrtWin, resolveSrtWinSource } from './srtWinStaging';
 import type { SandboxCapability } from './types';
+
+const unavailable = (reason: string, warnings?: string[]): SandboxCapability => ({
+  available: false,
+  backend: 'none',
+  networkIsolation: false,
+  reason,
+  warnings,
+});
+
+/**
+ * Windows readiness, checked against the helper *this app actually ships*.
+ *
+ * `SandboxManager.checkDependencies()` cannot be used here: it resolves the
+ * helper through the backend's own `getSrtWinPath()`, which is relative to the
+ * backend's package directory. Once that package is bundled into the main
+ * process, the computed path points inside `app.asar` — where no file exists —
+ * so a correctly installed app reported "srt-win.exe not found" and offered a
+ * Set-up button that could never change the answer. Observed on a released
+ * build whose `resources/sandbox-runtime/vendor/` held the binary all along.
+ *
+ * So the checks are run directly against the resolved path instead, mirroring
+ * the backend's own sequence: binary present → sandbox user provisioned with a
+ * readable credential → WFP filters installed. `cannot-read` on the filter
+ * enumeration is not a failure — it is admin-gated, and the behavioural egress
+ * check at `initialize()` is what actually fails closed.
+ */
+const probeWindows = (): SandboxCapability => {
+  const source = resolveSrtWinSource(getSrtWinPath);
+  if (!source) {
+    return unavailable(`Sandbox helper not found. ${windowsInstallInstructions(undefined)}`);
+  }
+
+  // Stage before probing, so the path reported as working is the same one the
+  // launch will use — the sandbox account cannot read an app install under a
+  // user profile.
+  const srtWin = resolveSrtWin({ path: ensureStagedSrtWin(source) ?? source });
+
+  let user;
+  try {
+    user = getWindowsSandboxUserStatus({ srtWin });
+  } catch (error) {
+    return unavailable(`srt-win user status failed: ${(error as Error).message}`);
+  }
+
+  if (!user.provisioned || !user.credPresent) {
+    return unavailable(
+      `Sandbox user is not provisioned (user=${user.provisioned}, cred=${user.credPresent}).`,
+    );
+  }
+
+  try {
+    const wfp = getWindowsWfpStatus({ srtWin });
+    // `absent` is the only real failure: `cannot-read` just means the caller is
+    // not elevated enough to enumerate BFE filters.
+    if (wfp.state !== 'installed' && wfp.state !== 'cannot-read') {
+      return unavailable('WFP filters are not installed.');
+    }
+  } catch (error) {
+    return unavailable(`srt-win wfp status failed: ${(error as Error).message}`);
+  }
+
+  return { available: true, backend: 'srt', networkIsolation: true };
+};
 
 export const probeSandboxCapability = async (): Promise<SandboxCapability> => {
   if (!SandboxManager.isSupportedPlatform()) {
-    return {
-      available: false,
-      backend: 'none',
-      networkIsolation: false,
-      reason: `Sandbox Runtime does not support ${process.platform}`,
-    };
+    return unavailable(`Sandbox Runtime does not support ${process.platform}`);
   }
 
+  if (process.platform === 'win32') return probeWindows();
+
+  // macOS ships Seatbelt with the OS and Linux's dependencies are ordinary
+  // system packages resolved from PATH, so neither is affected by where this
+  // app happens to be installed — the backend's own check is accurate there.
   const dependencies = SandboxManager.checkDependencies();
   if (dependencies.errors.length > 0) {
-    return {
-      available: false,
-      backend: 'none',
-      networkIsolation: false,
-      reason: `Sandbox Runtime dependencies are unavailable: ${dependencies.errors.join(', ')}`,
-      warnings: dependencies.warnings,
-    };
+    return unavailable(
+      `Sandbox Runtime dependencies are unavailable: ${dependencies.errors.join(', ')}`,
+      dependencies.warnings,
+    );
   }
 
   return {

--- a/packages/device-sandbox/src/capability.ts
+++ b/packages/device-sandbox/src/capability.ts
@@ -7,7 +7,7 @@ import {
   windowsInstallInstructions,
 } from '@anthropic-ai/sandbox-runtime';
 
-import { ensureStagedSrtWin, resolveSrtWinSource } from './srtWinStaging';
+import { resolveEffectiveSrtWin } from './srtWinStaging';
 import type { SandboxCapability } from './types';
 
 const unavailable = (reason: string, warnings?: string[]): SandboxCapability => ({
@@ -36,15 +36,15 @@ const unavailable = (reason: string, warnings?: string[]): SandboxCapability => 
  * check at `initialize()` is what actually fails closed.
  */
 const probeWindows = (): SandboxCapability => {
-  const source = resolveSrtWinSource(getSrtWinPath);
-  if (!source) {
+  // Exactly the path the launch will use: `resolveEffectiveSrtWin` is the one
+  // place that resolves and stages, so the probe can never bless a path the
+  // launch would not take.
+  const path = resolveEffectiveSrtWin(getSrtWinPath);
+  if (!path) {
     return unavailable(`Sandbox helper not found. ${windowsInstallInstructions(undefined)}`);
   }
 
-  // Stage before probing, so the path reported as working is the same one the
-  // launch will use — the sandbox account cannot read an app install under a
-  // user profile.
-  const srtWin = resolveSrtWin({ path: ensureStagedSrtWin(source) ?? source });
+  const srtWin = resolveSrtWin({ path });
 
   let user;
   try {

--- a/packages/device-sandbox/src/index.ts
+++ b/packages/device-sandbox/src/index.ts
@@ -10,7 +10,7 @@ export {
 export { SrtSandboxRuntime, srtSandboxRuntime } from './runtime';
 export { canInstallSandbox, installDeviceSandbox } from './setup';
 export { createSrtConfig } from './srt';
-export { ensureStagedSrtWin, resolveSrtWinSource } from './srtWinStaging';
+export { ensureStagedSrtWin, resolveEffectiveSrtWin, resolveSrtWinSource } from './srtWinStaging';
 export type {
   CreateSandboxLaunchPlanOptions,
   SandboxBackend,

--- a/packages/device-sandbox/src/setup.ts
+++ b/packages/device-sandbox/src/setup.ts
@@ -50,13 +50,12 @@ export const installDeviceSandbox = async (): Promise<SandboxSetupResult> => {
 
   const { getSrtWinPath, installWindowsSandbox, resolveSrtWin } =
     await import('@anthropic-ai/sandbox-runtime');
-  const { ensureStagedSrtWin, resolveSrtWinSource } = await import('./srtWinStaging');
+  const { resolveEffectiveSrtWin } = await import('./srtWinStaging');
 
   // Stage the helper as part of setup, not lazily at first use: this is the
   // moment the user asked us to make the machine ready, and a first run that
   // failed on file permissions would look like the setup itself hadn't worked.
-  const source = resolveSrtWinSource(getSrtWinPath);
-  const staged = source ? ensureStagedSrtWin(source) : undefined;
+  const staged = resolveEffectiveSrtWin(getSrtWinPath);
   const srtWin = staged ? resolveSrtWin({ path: staged }) : undefined;
 
   const result = installWindowsSandbox(srtWin ? { srtWin } : {});

--- a/packages/device-sandbox/src/srt.ts
+++ b/packages/device-sandbox/src/srt.ts
@@ -2,24 +2,24 @@ import type { SandboxRuntimeConfig } from '@anthropic-ai/sandbox-runtime';
 import { getSrtWinPath } from '@anthropic-ai/sandbox-runtime';
 
 import { normalizeSandboxPolicy } from './policy';
-import { ensureStagedSrtWin, resolveSrtWinSource } from './srtWinStaging';
+import { resolveEffectiveSrtWin } from './srtWinStaging';
 import type { SandboxPolicy } from './types';
 
 /**
- * Point the backend at a helper the sandbox user can read. See
- * {@link ensureStagedSrtWin} — without this, a per-user app install puts the
- * helper somewhere the sandbox account has no rights to, and every launch dies
- * with an unexplained ACCESS_DENIED.
+ * Point the backend at the same helper the capability probe validated. See
+ * {@link resolveEffectiveSrtWin} — leaving the backend to resolve its own
+ * package-relative path lands inside `app.asar` once bundled, and a per-user
+ * install puts the shipped copy somewhere the sandbox account cannot read.
  *
- * Silent no-op off Windows and whenever staging isn't possible; the backend
- * then resolves its own packaged binary exactly as before.
+ * Silent no-op off Windows, and when no helper can be found at all — the
+ * backend then fails loudly at launch rather than being told a path that does
+ * not exist.
  */
 const resolveWindowsConfig = (): SandboxRuntimeConfig['windows'] => {
   if (process.platform !== 'win32') return undefined;
   try {
-    const source = resolveSrtWinSource(getSrtWinPath);
-    const staged = source ? ensureStagedSrtWin(source) : undefined;
-    return staged ? { srtWin: { path: staged } } : undefined;
+    const path = resolveEffectiveSrtWin(getSrtWinPath);
+    return path ? { srtWin: { path } } : undefined;
   } catch {
     return undefined;
   }

--- a/packages/device-sandbox/src/srtWinStaging.ts
+++ b/packages/device-sandbox/src/srtWinStaging.ts
@@ -124,3 +124,23 @@ export const ensureStagedSrtWin = (packagedExe: string): string | undefined => {
     return undefined;
   }
 };
+
+/**
+ * The helper path every caller must use — the probe, the launch, and setup.
+ *
+ * Resolution and staging are combined here on purpose. When they were separate,
+ * the probe fell back to the unstaged source while the launch fell back to *no
+ * override at all*, letting the backend resolve its own package-relative path —
+ * which is inside `app.asar` once bundled. A host where staging fails
+ * (ProgramData locked down, disk full) would then be advertised as available and
+ * fail on the first command. One function, one answer.
+ *
+ * Falling back to the unstaged source rather than giving up is deliberate: a
+ * per-machine install already lives somewhere the sandbox account can read, so
+ * staging is an accommodation for per-user installs, not a precondition.
+ */
+export const resolveEffectiveSrtWin = (packagedFallback?: () => string): string | undefined => {
+  const source = resolveSrtWinSource(packagedFallback);
+  if (!source) return undefined;
+  return ensureStagedSrtWin(source) ?? source;
+};

--- a/packages/tool-runtime/src/LocalSystemExecutionRuntime.ts
+++ b/packages/tool-runtime/src/LocalSystemExecutionRuntime.ts
@@ -409,6 +409,16 @@ export class LocalSystemExecutionRuntime extends ComputerRuntime {
       case 'runCommand': {
         // RunCommandResult has snake_case fields from local-file-shell
         return {
+          // Surface raw.error at the top level so ComputerRuntime.errorOutput
+          // has a real message to render. Its priority chain reads the
+          // ServiceResult's own `error`, then `state.stderr`, then
+          // `state.error` — a runCommand that fails before spawning fills none
+          // of those (there is no process, so no stderr), so every such failure
+          // collapsed to the generic "[UNKNOWN_EXEC_ERROR] Tool execution
+          // failed" with the reason discarded. That hid, among others, every
+          // Local Sandbox refusal: "requires a working directory", "unavailable
+          // on this device". Mirrors editLocalFile / grep / glob below.
+          error: raw.error ? { message: String(raw.error) } : undefined,
           result: {
             error: raw.error,
             exitCode: raw.exit_code,

--- a/packages/tool-runtime/src/__tests__/LocalSystemExecutionRuntime.test.ts
+++ b/packages/tool-runtime/src/__tests__/LocalSystemExecutionRuntime.test.ts
@@ -544,3 +544,41 @@ describe('LocalSystemExecutionRuntime.executeToolCall — dispatch', () => {
     expect(await runtime.executeToolCall('runHeteroTask', {})).toBeNull();
   });
 });
+
+describe('LocalSystemExecutionRuntime.runCommand', () => {
+  it('surfaces a pre-spawn failure reason instead of UNKNOWN_EXEC_ERROR', async () => {
+    // A command that never starts has no process, so no stderr and no exit
+    // code — the exact shape every Local Sandbox refusal takes. The reason used
+    // to be dropped, leaving the user (and the model) with a generic failure
+    // and nothing to act on.
+    const service = createService({
+      runCommand: vi.fn().mockResolvedValue({
+        error:
+          'Local Sandbox requires a working directory. Set one for this agent (or topic) and run the command again.',
+        success: false,
+      }),
+    });
+    const runtime = new LocalSystemExecutionRuntime(service);
+
+    const output = await runtime.runCommand({ command: 'whoami' } as never);
+
+    expect(output.content).toContain('Local Sandbox requires a working directory');
+    expect(output.content).not.toContain('UNKNOWN_EXEC_ERROR');
+  });
+
+  it('reports whether the command was actually sandboxed', async () => {
+    const service = createService({
+      runCommand: vi.fn().mockResolvedValue({
+        exit_code: 0,
+        sandboxed: true,
+        stdout: 'srt-sandbox',
+        success: true,
+      }),
+    });
+    const runtime = new LocalSystemExecutionRuntime(service);
+
+    const output = await runtime.runCommand({ command: 'whoami' } as never);
+
+    expect((output.state as { sandboxed?: boolean }).sandboxed).toBe(true);
+  });
+});


### PR DESCRIPTION
Follow-up to #18143, from an installed canary build.

## The symptom

The Local Sandbox row reported:

```
此设备上不可用：Sandbox Runtime dependencies are unavailable: srt-win.exe not found.
Looked in: C:\Program Files\LobeHub\resources\app.asar\vendor\srt-win\x64\srt-win.exe
```

…while the binary was sitting at `C:\Program Files\LobeHub\resources\sandbox-runtime\vendor\srt-win\x64\srt-win.exe` the whole time. Clicking **Set up** did nothing useful, because provisioning was never what was missing.

## The cause

`probeSandboxCapability` called `SandboxManager.checkDependencies()`, which resolves the helper through the backend's own `getSrtWinPath()` — a path relative to the *backend package's* directory. Once that package is bundled into the main process, the computed path lands inside `app.asar`, where no file can exist.

The launch path was already immune: `createSrtConfig` passes an explicit `windows.srtWin.path`. Only the probe still asked the wrong question — so a correctly installed app reported a missing binary, and offered a button that could not change the answer.

## The fix

Windows now runs the checks directly against the resolved path, mirroring the backend's own sequence:

1. binary present (via the same `resolveSrtWinSource` the launch uses),
2. sandbox user provisioned with a readable credential,
3. WFP filters installed.

It also stages the helper *before* probing, so the path it validates is the path the launch will use. `cannot-read` on filter enumeration stays a non-failure — BFE enumeration is admin-gated, and the behavioural egress check at `initialize()` is what fails closed.

macOS and Linux keep `SandboxManager.checkDependencies()`. Neither resolves anything relative to the app (Seatbelt ships with the OS; Linux's dependencies come from PATH), so neither was affected.

## Verification

Ran the new probe against the installed build's own layout (`resourcesPath` → `C:\Program Files\LobeHub\resources`):

```
{"available":true,"backend":"srt","networkIsolation":true}
```

Same machine, same install, where the old probe reported "srt-win.exe not found".

## Two follow-ons in the same commit

- **Ship the backend's `package.json` beside the binaries.** The staging directory is keyed on the backend version, read from that file; without it the lookup fell back to the binary's size. That worked, but defeated per-version isolation in exactly the case it exists for — an installed app being updated.
- **Make the `createSrtConfig` assertion platform-aware.** The Windows helper override is absent on other platforms, so an exact-match expectation fails on one platform or the other. It now asserts the portable shape plus an explicit per-platform check on `windows`.

`bun run check` clean on the touched files; `tsgo --noEmit` clean for both the app and `apps/desktop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)