### PR TITLE
🐛 fix(qoder): restore task progress and unify selectors

### DIFF
--- a/packages/heterogeneous-agents/src/adapters/qoder.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/qoder.test.ts
@@ -119,6 +119,95 @@ describe('QoderAdapter', () => {
     });
   });
 
+  it('preserves synthesized todo state from Qoder Task tools', () => {
+    const adapter = new QoderAdapter();
+    adapter.adapt({ subtype: 'init', type: 'system' });
+    adapter.adapt({
+      message: {
+        content: [
+          {
+            id: 'task-create-1',
+            input: {
+              activeForm: 'Adding Qoder todo support',
+              description: 'Keep the synthesized task state for the UI.',
+              subject: 'Add Qoder todo support',
+            },
+            name: 'TaskCreate',
+            type: 'tool_use',
+          },
+        ],
+        id: 'msg-task-create',
+      },
+      type: 'assistant',
+    });
+
+    const events = adapter.adapt({
+      message: {
+        content: [
+          {
+            content: 'Task #1 created successfully: Add Qoder todo support',
+            tool_use_id: 'task-create-1',
+            type: 'tool_result',
+          },
+        ],
+        role: 'user',
+      },
+      type: 'user',
+    });
+    const pluginState = {
+      todos: {
+        items: [{ id: '1', status: 'todo', text: 'Add Qoder todo support' }],
+        updatedAt: expect.any(String),
+      },
+    };
+    expect(events.find((event) => event.type === 'tool_result')?.data.pluginState).toEqual(
+      pluginState,
+    );
+    expect(events.find((event) => event.type === 'tool_end')?.data.result.state).toEqual(
+      pluginState,
+    );
+
+    adapter.adapt({
+      message: {
+        content: [
+          {
+            id: 'task-update-1',
+            input: { status: 'completed', taskId: '1' },
+            name: 'TaskUpdate',
+            type: 'tool_use',
+          },
+        ],
+        id: 'msg-task-update',
+      },
+      type: 'assistant',
+    });
+    const updatedEvents = adapter.adapt({
+      message: {
+        content: [
+          {
+            content: 'Updated task #1 status',
+            tool_use_id: 'task-update-1',
+            type: 'tool_result',
+          },
+        ],
+        role: 'user',
+      },
+      type: 'user',
+    });
+    const updatedPluginState = {
+      todos: {
+        items: [{ id: '1', status: 'completed', text: 'Add Qoder todo support' }],
+        updatedAt: expect.any(String),
+      },
+    };
+    expect(updatedEvents.find((event) => event.type === 'tool_result')?.data.pluginState).toEqual(
+      updatedPluginState,
+    );
+    expect(updatedEvents.find((event) => event.type === 'tool_end')?.data.result.state).toEqual(
+      updatedPluginState,
+    );
+  });
+
   it('preserves Qoder WebSearch structured sources on tool_result and tool_end', () => {
     const adapter = new QoderAdapter();
     adapter.adapt({ subtype: 'init', type: 'system' });

--- a/packages/heterogeneous-agents/src/adapters/qoder.ts
+++ b/packages/heterogeneous-agents/src/adapters/qoder.ts
@@ -4,7 +4,8 @@
  * Qoder's stream-json protocol is intentionally compatible with the
  * assistant/user/result framing used by Claude Code. Reuse that mature state
  * machine, but keep Qoder as a first-class provider: every normalized event,
- * tool payload, error, and usage record is stamped with Qoder's identity.
+ * tool payload, error, and usage record is stamped with Qoder's identity while
+ * shared derived state such as Task tool todos remains intact for the UI.
  */
 
 import { getHeterogeneousAgentConfigOrThrow } from '../config';
@@ -33,7 +34,7 @@ const isQoderAuthAssistant = (raw: unknown): boolean => {
   return QODER_AUTH_REQUIRED_PATTERNS.every((pattern) => pattern.test(text));
 };
 
-const normalizeQoderValue = (value: unknown, key?: string): void => {
+const normalizeQoderValue = (value: unknown): void => {
   if (!value || typeof value !== 'object') return;
 
   if (Array.isArray(value)) {
@@ -62,13 +63,8 @@ const normalizeQoderValue = (value: unknown, key?: string): void => {
       record[childKey] = childValue.replaceAll('Claude Code', 'Qoder');
       continue;
     }
-    normalizeQoderValue(childValue, childKey);
+    normalizeQoderValue(childValue);
   }
-
-  // Qoder's Task tools are not the Claude Code Todo/Task UI contract. Keep
-  // their native tool calls/results, but do not attach Claude-specific derived
-  // todo state to the normalized result.
-  if (key === 'pluginState') delete record.todos;
 };
 
 const normalizeQoderEvents = (events: HeterogeneousAgentEvent[]): HeterogeneousAgentEvent[] => {

--- a/src/features/ChatInput/ControlBar/HeteroModel.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroModel.tsx
@@ -409,7 +409,6 @@ const HeteroModel = memo(() => {
   const { canConfigureResource } = useChatInputResourceAccess();
   const enabled = canCreateContent && canConfigureResource;
   const [open, setOpen] = useState(false);
-  const [effortOpen, setEffortOpen] = useState(false);
 
   const patchProvider = useCallback(
     async (patch: Partial<Pick<HeterogeneousProviderConfig, 'effort' | 'model' | 'speed'>>) => {
@@ -514,7 +513,17 @@ const HeteroModel = memo(() => {
         : HETEROGENEOUS_AGENT_DEFAULT_SELECTION;
     const effort = resolveQoderReasoningEffort(provider);
     const defaultLabel = t('heteroAgent.modelSelector.default');
+    const modelLabel = getModelLabel(model, defaultLabel);
     const effortLabel = t(EFFORT_LABEL_KEYS[effort]);
+    const triggerText = getTriggerText({
+      defaultConfigLabel: t('heteroAgent.modelSelector.defaultConfig'),
+      defaultModelLabel: t('heteroAgent.modelSelector.defaultModel'),
+      defaultReasoningLabel: t('heteroAgent.modelSelector.defaultReasoning'),
+      effort,
+      effortLabel,
+      model,
+      modelLabel,
+    });
     const effortOptions: { label: string; value: HeteroReasoningEffort }[] = [
       { label: defaultLabel, value: HETEROGENEOUS_AGENT_DEFAULT_SELECTION },
       ...QODER_REASONING_EFFORT_LEVELS.map((level) => ({
@@ -524,51 +533,53 @@ const HeteroModel = memo(() => {
     ];
 
     return (
-      <>
-        <HeterogeneousAgentModelSelector
-          agentId={agentId}
-          disabled={false}
-          model={model}
-          permissionReason={reason}
-          type={provider.type}
-          onSelect={(value) => void patchProvider({ model: value })}
-        />
-        <DropdownMenuRoot open={effortOpen} onOpenChange={setEffortOpen}>
-          <DropdownMenuTrigger nativeButton={false}>
-            <div className={styles.trigger}>
-              <span className={styles.label}>{effortLabel}</span>
-              <Icon icon={ChevronDownIcon} size={12} />
-            </div>
-          </DropdownMenuTrigger>
-          <DropdownMenuPortal>
-            <DropdownMenuPositioner placement="topLeft" sideOffset={8}>
-              <DropdownMenuPopup className={styles.popup} style={{ width: 220 }}>
-                <div className={styles.sectionTitle}>
-                  {t('heteroAgent.modelSelector.reasoning')}
-                </div>
-                <div className={styles.scroll}>
-                  {effortOptions.map((option) => (
-                    <DropdownMenuItem
-                      className={styles.option}
-                      data-selected={effort === option.value ? 'true' : undefined}
-                      key={`effort-${option.value}`}
-                      onClick={() => {
-                        setEffortOpen(false);
-                        void patchProvider({ effort: option.value });
-                      }}
-                    >
-                      <span className={styles.optionLabel}>{option.label}</span>
-                      {effort === option.value && (
-                        <Icon className={styles.check} icon={CheckIcon} size={16} />
-                      )}
-                    </DropdownMenuItem>
-                  ))}
-                </div>
-              </DropdownMenuPopup>
-            </DropdownMenuPositioner>
-          </DropdownMenuPortal>
-        </DropdownMenuRoot>
-      </>
+      <DropdownMenuRoot open={open} onOpenChange={setOpen}>
+        <DropdownMenuTrigger nativeButton={false}>
+          <div
+            className={styles.trigger}
+            aria-label={t('heteroAgent.modelSelector.ariaLabel', {
+              model: modelLabel,
+              reasoning: effortLabel,
+            })}
+          >
+            <span className={styles.label}>{triggerText}</span>
+            <Icon icon={ChevronDownIcon} size={12} />
+          </div>
+        </DropdownMenuTrigger>
+        <DropdownMenuPortal>
+          <DropdownMenuPositioner placement="topLeft" sideOffset={8}>
+            <DropdownMenuPopup className={styles.popup} style={{ width: 240 }}>
+              <HeterogeneousAgentModelSelector
+                agentId={agentId}
+                disabled={false}
+                model={model}
+                permissionReason={reason}
+                type={provider.type}
+                variant="submenu"
+                onSelect={selectModel}
+              />
+              <SelectorSubmenu
+                currentValue={effortLabel}
+                label={t('heteroAgent.modelSelector.reasoning')}
+              >
+                {effortOptions.map((option) => (
+                  <DropdownMenuItem
+                    className={styles.option}
+                    data-selected={effort === option.value ? 'true' : undefined}
+                    key={`effort-${option.value}`}
+                    onClick={() => selectReasoningEffort(option.value)}
+                  >
+                    <span className={styles.optionLabel}>{option.label}</span>
+                    {effort === option.value && (
+                      <Icon className={styles.check} icon={CheckIcon} size={16} />
+                    )}
+                  </DropdownMenuItem>
+                ))}
+              </SelectorSubmenu>
+            </DropdownMenuPopup>
+          </DropdownMenuPositioner>
+        </DropdownMenuPortal>
+      </DropdownMenuRoot>
     );
   }
 

--- a/src/features/ChatInput/ControlBar/HeterogeneousAgentModelSelector.tsx
+++ b/src/features/ChatInput/ControlBar/HeterogeneousAgentModelSelector.tsx
@@ -6,16 +6,23 @@ import { ActionIcon, Icon, Input, Tooltip } from '@lobehub/ui';
 import {
   Button,
   DropdownMenuItem,
+  DropdownMenuItemContent,
+  DropdownMenuItemExtra,
+  DropdownMenuItemLabel,
   DropdownMenuPopup,
   DropdownMenuPortal,
   DropdownMenuPositioner,
   DropdownMenuRoot,
+  DropdownMenuSubmenuArrow,
+  DropdownMenuSubmenuRoot,
+  DropdownMenuSubmenuTrigger,
   DropdownMenuTrigger,
 } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import {
   CheckIcon,
   ChevronDownIcon,
+  ChevronRightIcon,
   LoaderCircleIcon,
   RefreshCwIcon,
   SearchIcon,
@@ -125,6 +132,28 @@ const styles = createStaticStyles(({ css }) => ({
   stale: css`
     color: ${cssVar.colorWarning};
   `,
+  submenuMeta: css`
+    overflow: hidden;
+    display: inline-flex;
+    flex: none;
+    align-items: center;
+
+    min-width: 0;
+    max-width: 150px;
+    padding-inline-start: 16px;
+
+    font-size: 14px;
+    color: ${cssVar.colorTextSecondary};
+  `,
+  submenuMetaLabel: css`
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+  submenuTrigger: css`
+    min-height: 36px;
+    padding-inline: 10px;
+  `,
   trigger: css`
     cursor: pointer;
 
@@ -181,10 +210,11 @@ interface HeterogeneousAgentModelSelectorProps {
   onSelect: (model: string) => void;
   permissionReason?: string;
   type: ListHeterogeneousAgentModelsParams['type'];
+  variant?: 'standalone' | 'submenu';
 }
 
 export const HeterogeneousAgentModelSelector = memo<HeterogeneousAgentModelSelectorProps>(
-  ({ agentId, disabled, model, onSelect, permissionReason, type }) => {
+  ({ agentId, disabled, model, onSelect, permissionReason, type, variant = 'standalone' }) => {
     const { t } = useTranslation('chat');
     const agentName = type === 'pi' ? 'Pi' : type === 'qoder' ? 'Qoder' : 'OpenCode';
     const [search, setSearch] = useState('');
@@ -302,6 +332,139 @@ export const HeterogeneousAgentModelSelector = memo<HeterogeneousAgentModelSelec
       );
     }
 
+    const handleModelSelect = variant === 'submenu' ? onSelect : handleSelect;
+    const menu = (
+      <div className={styles.container}>
+        <div className={styles.search}>
+          <Input
+            autoFocus
+            placeholder={t('heteroAgent.cliModel.search')}
+            prefix={<Icon icon={SearchIcon} size={14} />}
+            size="small"
+            value={search}
+            variant="borderless"
+            onChange={(event) => setSearch(event.target.value)}
+            onKeyDown={(event) => event.stopPropagation()}
+          />
+          <ActionIcon
+            aria-label={t('heteroAgent.cliModel.reload')}
+            className={cx(isValidating && styles.spinning)}
+            disabled={!targetReady || isValidating}
+            icon={isValidating ? LoaderCircleIcon : RefreshCwIcon}
+            size="small"
+            title={t('heteroAgent.cliModel.reload')}
+            onClick={() => void mutate()}
+          />
+        </div>
+        <div className={styles.list}>
+          <DropdownMenuItem
+            className={styles.item}
+            onClick={() => handleModelSelect(HETEROGENEOUS_AGENT_DEFAULT_SELECTION)}
+          >
+            <div className={styles.itemBody}>
+              <div className={styles.itemTitle}>{t('heteroAgent.modelSelector.default')}</div>
+              <div className={styles.itemSubtitle}>
+                {t('heteroAgent.cliModel.defaultDesc', { name: agentName })}
+              </div>
+            </div>
+            {currentModel === HETEROGENEOUS_AGENT_DEFAULT_SELECTION && (
+              <Icon className={styles.check} icon={CheckIcon} size={14} />
+            )}
+          </DropdownMenuItem>
+
+          {isLoading && !data && (
+            <div className={styles.empty}>
+              {t('heteroAgent.cliModel.loading', { name: agentName })}
+            </div>
+          )}
+          {!targetReady && (
+            <div className={styles.empty}>{t('heteroAgent.cliModel.targetUnavailable')}</div>
+          )}
+          {error && (
+            <div className={styles.empty}>
+              {t(getCatalogErrorKey(error.name))}
+              <br />
+              <Button size="small" type="text" onClick={() => void mutate()}>
+                {t('heteroAgent.cliModel.retry')}
+              </Button>
+            </div>
+          )}
+          {data && rows.length === 0 && (
+            <div className={styles.empty}>
+              {search.trim()
+                ? t('heteroAgent.cliModel.noMatch')
+                : t('heteroAgent.cliModel.empty', { name: agentName })}
+            </div>
+          )}
+          {Object.entries(groups).map(([providerId, models]) => (
+            <div key={providerId}>
+              <div className={styles.group}>{providerId}</div>
+              {models.map((item) => (
+                <DropdownMenuItem
+                  className={styles.item}
+                  key={item.id}
+                  onClick={() => handleModelSelect(item.id)}
+                >
+                  <div className={styles.itemBody}>
+                    <div className={styles.itemTitle}>{item.label ?? item.modelId}</div>
+                    <div
+                      className={cx(
+                        styles.itemSubtitle,
+                        selectedIsStale && item.id === currentModel && styles.stale,
+                      )}
+                    >
+                      {item.id}
+                      {selectedIsStale && item.id === currentModel
+                        ? ` · ${t('heteroAgent.cliModel.stale')}`
+                        : ''}
+                    </div>
+                  </div>
+                  {item.id === currentModel && (
+                    <Icon className={styles.check} icon={CheckIcon} size={14} />
+                  )}
+                </DropdownMenuItem>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+
+    if (variant === 'submenu') {
+      return (
+        <DropdownMenuSubmenuRoot
+          open={open}
+          onOpenChange={handleOpenChange}
+          onOpenChangeComplete={handleOpenChangeComplete}
+        >
+          <DropdownMenuSubmenuTrigger
+            className={styles.submenuTrigger}
+            label={t('heteroAgent.modelSelector.model')}
+            openOnHover={false}
+          >
+            <DropdownMenuItemContent>
+              <DropdownMenuItemLabel>{t('heteroAgent.modelSelector.model')}</DropdownMenuItemLabel>
+              <DropdownMenuItemExtra className={styles.submenuMeta}>
+                <span className={styles.submenuMetaLabel}>
+                  {currentModel === HETEROGENEOUS_AGENT_DEFAULT_SELECTION
+                    ? t('heteroAgent.modelSelector.default')
+                    : currentModel}
+                </span>
+              </DropdownMenuItemExtra>
+              <DropdownMenuSubmenuArrow>
+                <Icon icon={ChevronRightIcon} size={12} />
+              </DropdownMenuSubmenuArrow>
+            </DropdownMenuItemContent>
+          </DropdownMenuSubmenuTrigger>
+          <DropdownMenuPortal>
+            <DropdownMenuPositioner alignOffset={-4} anchor={null} placement="right" sideOffset={8}>
+              <DropdownMenuPopup>{menu}</DropdownMenuPopup>
+            </DropdownMenuPositioner>
+          </DropdownMenuPortal>
+        </DropdownMenuSubmenuRoot>
+      );
+    }
+
     return (
       <DropdownMenuRoot
         open={open}
@@ -311,106 +474,7 @@ export const HeterogeneousAgentModelSelector = memo<HeterogeneousAgentModelSelec
         <DropdownMenuTrigger nativeButton={false}>{trigger}</DropdownMenuTrigger>
         <DropdownMenuPortal>
           <DropdownMenuPositioner placement="topLeft" sideOffset={8}>
-            <DropdownMenuPopup>
-              <div className={styles.container}>
-                <div className={styles.search}>
-                  <Input
-                    autoFocus
-                    placeholder={t('heteroAgent.cliModel.search')}
-                    prefix={<Icon icon={SearchIcon} size={14} />}
-                    size="small"
-                    value={search}
-                    variant="borderless"
-                    onChange={(event) => setSearch(event.target.value)}
-                    onKeyDown={(event) => event.stopPropagation()}
-                  />
-                  <ActionIcon
-                    aria-label={t('heteroAgent.cliModel.reload')}
-                    className={cx(isValidating && styles.spinning)}
-                    disabled={!targetReady || isValidating}
-                    icon={isValidating ? LoaderCircleIcon : RefreshCwIcon}
-                    size="small"
-                    title={t('heteroAgent.cliModel.reload')}
-                    onClick={() => void mutate()}
-                  />
-                </div>
-                <div className={styles.list}>
-                  <DropdownMenuItem
-                    className={styles.item}
-                    onClick={() => handleSelect(HETEROGENEOUS_AGENT_DEFAULT_SELECTION)}
-                  >
-                    <div className={styles.itemBody}>
-                      <div className={styles.itemTitle}>
-                        {t('heteroAgent.modelSelector.default')}
-                      </div>
-                      <div className={styles.itemSubtitle}>
-                        {t('heteroAgent.cliModel.defaultDesc', { name: agentName })}
-                      </div>
-                    </div>
-                    {currentModel === HETEROGENEOUS_AGENT_DEFAULT_SELECTION && (
-                      <Icon className={styles.check} icon={CheckIcon} size={14} />
-                    )}
-                  </DropdownMenuItem>
-
-                  {isLoading && !data && (
-                    <div className={styles.empty}>
-                      {t('heteroAgent.cliModel.loading', { name: agentName })}
-                    </div>
-                  )}
-                  {!targetReady && (
-                    <div className={styles.empty}>
-                      {t('heteroAgent.cliModel.targetUnavailable')}
-                    </div>
-                  )}
-                  {error && (
-                    <div className={styles.empty}>
-                      {t(getCatalogErrorKey(error.name))}
-                      <br />
-                      <Button size="small" type="text" onClick={() => void mutate()}>
-                        {t('heteroAgent.cliModel.retry')}
-                      </Button>
-                    </div>
-                  )}
-                  {data && rows.length === 0 && (
-                    <div className={styles.empty}>
-                      {search.trim()
-                        ? t('heteroAgent.cliModel.noMatch')
-                        : t('heteroAgent.cliModel.empty', { name: agentName })}
-                    </div>
-                  )}
-                  {Object.entries(groups).map(([providerId, models]) => (
-                    <div key={providerId}>
-                      <div className={styles.group}>{providerId}</div>
-                      {models.map((item) => (
-                        <DropdownMenuItem
-                          className={styles.item}
-                          key={item.id}
-                          onClick={() => handleSelect(item.id)}
-                        >
-                          <div className={styles.itemBody}>
-                            <div className={styles.itemTitle}>{item.label ?? item.modelId}</div>
-                            <div
-                              className={cx(
-                                styles.itemSubtitle,
-                                selectedIsStale && item.id === currentModel && styles.stale,
-                              )}
-                            >
-                              {item.id}
-                              {selectedIsStale && item.id === currentModel
-                                ? ` · ${t('heteroAgent.cliModel.stale')}`
-                                : ''}
-                            </div>
-                          </div>
-                          {item.id === currentModel && (
-                            <Icon className={styles.check} icon={CheckIcon} size={14} />
-                          )}
-                        </DropdownMenuItem>
-                      ))}
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </DropdownMenuPopup>
+            <DropdownMenuPopup>{menu}</DropdownMenuPopup>
           </DropdownMenuPositioner>
         </DropdownMenuPortal>
       </DropdownMenuRoot>


### PR DESCRIPTION
## Summary

- preserve the shared `pluginState.todos` synthesized from Qoder `TaskCreate` and `TaskUpdate` events so task progress renders in chat
- add a Qoder regression scenario covering task creation and completion
- combine Qoder's model and reasoning controls into the same nested selector pattern used by Codex
- retain Qoder's dynamic model search, refresh, loading, stale-model, error, and execution-target states inside the model submenu

| Before | After |
| ------ | ----- |
| Qoder rendered separate model and reasoning controls, and adapter normalization removed synthesized task progress. | Qoder uses one Codex-style model/reasoning selector and preserves task progress for the Todo UI. |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check packages/heterogeneous-agents/src/adapters/qoder.ts packages/heterogeneous-agents/src/adapters/qoder.test.ts src/features/ChatInput/ControlBar/HeteroModel.tsx src/features/ChatInput/ControlBar/HeterogeneousAgentModelSelector.tsx
bun run check --type
```

Results: lint clean, 7 related tests passed, types clean.

#### 🔗 Related Issue

No matching GitHub issue found.
