### PR TITLE
🐛 fix(opencode): surface todo progress

### DIFF
--- a/packages/heterogeneous-agents/src/adapters/opencode.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/opencode.test.ts
@@ -87,6 +87,45 @@ describe('OpenCodeAdapter', () => {
     expect(adapter.adapt(raw)).toEqual([]);
   });
 
+  it('maps todowrite snapshots into shared todo plugin state', () => {
+    const adapter = new OpenCodeAdapter();
+    const todos = [
+      { content: 'Inspect the pull request', priority: 'high', status: 'completed' },
+      { content: 'Merge the pull request', priority: 'high', status: 'in_progress' },
+      { content: 'Report any blockers', priority: 'medium', status: 'pending' },
+      { content: 'Use the obsolete merge path', priority: 'low', status: 'cancelled' },
+    ];
+
+    const events = adapter.adapt({
+      part: {
+        callID: 'todo-call-1',
+        id: 'todo-part-1',
+        state: {
+          input: { todos },
+          metadata: { todos },
+          output: JSON.stringify(todos),
+          status: 'completed',
+        },
+        tool: 'todowrite',
+        type: 'tool',
+      },
+      sessionID: 'ses-todos',
+      type: 'tool_use',
+    });
+
+    expect(events.find((event) => event.type === 'tool_result')?.data.pluginState).toEqual({
+      todos: {
+        items: [
+          { status: 'completed', text: 'Inspect the pull request' },
+          { status: 'processing', text: 'Merge the pull request' },
+          { status: 'todo', text: 'Report any blockers' },
+          { status: 'todo', text: 'Use the obsolete merge path' },
+        ],
+        updatedAt: expect.any(String),
+      },
+    });
+  });
+
   it('opens a new step for the final answer after a completed tool turn', () => {
     const adapter = new OpenCodeAdapter();
     const firstStart = adapter.adapt({

--- a/packages/heterogeneous-agents/src/adapters/opencode.ts
+++ b/packages/heterogeneous-agents/src/adapters/opencode.ts
@@ -11,6 +11,7 @@ import type {
 } from '../types';
 
 const OPENCODE_IDENTIFIER = 'opencode';
+const OPENCODE_TODO_WRITE_API = 'todowrite';
 const OPENCODE_CLI_INSTALL_DOCS_URL =
   getHeterogeneousAgentConfigOrThrow(OPENCODE_IDENTIFIER).auth.docsUrl;
 const AUTH_REQUIRED_PATTERNS = [
@@ -54,6 +55,31 @@ const isAuthError = (error: any, message: string): boolean =>
   error?.name === 'ProviderAuthError' ||
   error?.data?.statusCode === 401 ||
   AUTH_REQUIRED_PATTERNS.some((pattern) => pattern.test(message));
+
+const synthesizeTodoWritePluginState = (value: unknown) => {
+  if (!Array.isArray(value)) return;
+
+  const items = value.flatMap((todo) => {
+    if (!todo || typeof todo !== 'object') return [];
+
+    const record = todo as Record<string, unknown>;
+    const text = typeof record.content === 'string' ? record.content.trim() : '';
+    if (!text) return [];
+
+    // OpenCode's run renderer treats cancelled and unknown statuses as
+    // unchecked items; the shared Todo UI uses the same three-state alphabet.
+    const status =
+      record.status === 'completed'
+        ? 'completed'
+        : record.status === 'in_progress'
+          ? 'processing'
+          : 'todo';
+
+    return [{ status, text }];
+  });
+
+  return { todos: { items, updatedAt: new Date().toISOString() } };
+};
 
 /** Maps OpenCode's completed-part JSONL protocol into shared stream events. */
 export class OpenCodeAdapter implements AgentEventAdapter {
@@ -173,9 +199,14 @@ export class OpenCodeAdapter implements AgentEventAdapter {
       type: 'default',
     };
     const isError = state.status === 'error';
+    const pluginState =
+      !isError && part.tool === OPENCODE_TODO_WRITE_API
+        ? synthesizeTodoWritePluginState(state.metadata?.todos ?? state.input?.todos)
+        : undefined;
     const result: ToolResultData = {
       content: isError ? String(state.error ?? '') : String(state.output ?? ''),
       isError,
+      ...(pluginState ? { pluginState } : {}),
       toolCallId: callId,
     };
 


### PR DESCRIPTION
## Summary

- synthesize the shared `pluginState.todos` state from successful OpenCode `todowrite` results so Todo progress renders in chat
- read the authoritative `metadata.todos` snapshot with `input.todos` as a compatibility fallback
- map OpenCode statuses into the shared UI vocabulary: `completed` → `completed`, `in_progress` → `processing`, and unchecked states such as `pending` / `cancelled` → `todo`
- add a regression test covering all statuses observed in OpenCode's todo contract

| Before | After |
| ------ | ----- |
| OpenCode persisted `todowrite` as a normal tool result without Todo state, so the progress UI stayed hidden. | Successful `todowrite` calls persist a normalized Todo snapshot consumed by the existing progress UI. |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check packages/heterogeneous-agents/src/adapters/opencode.ts packages/heterogeneous-agents/src/adapters/opencode.test.ts
bun run check --type
```

Results: lint clean, 10 related tests passed, types clean. The latest local OpenCode trace was also replayed through the updated adapter and produced the expected three-item `pluginState.todos` snapshot.

#### 🔗 Related Issue

No matching GitHub issue found.
