### PR TITLE
✨ feat(subscription): add plansModal messengerWechat copy

### DIFF
--- a/locales/en-US/subscription.json
+++ b/locales/en-US/subscription.json
@@ -480,6 +480,8 @@
   "plansModal.default.title": "Upgrade your plan",
   "plansModal.fileStorageLimit.desc": "Your file storage is full. Upgrade to keep uploading, or delete unused files on the <1>Resources page</1> to free up space.",
   "plansModal.fileStorageLimit.title": "Storage limit reached",
+  "plansModal.messengerWechat.desc": "The WeChat System Bot is available on paid personal plans. Upgrade to connect and use it.",
+  "plansModal.messengerWechat.title": "Connect WeChat after upgrading",
   "plansModal.modelAccess.desc": "This model is available on paid plans. Upgrade to use the full model lineup.",
   "plansModal.modelAccess.title": "Unlock all models",
   "qa.desc": "If your question is not answered, check <1>Product Documentation</1> for more FAQs, or contact us.",

--- a/locales/zh-CN/subscription.json
+++ b/locales/zh-CN/subscription.json
@@ -480,6 +480,8 @@
   "plansModal.default.title": "升级方案",
   "plansModal.fileStorageLimit.desc": "文件存储已达上限，升级以继续上传，或前往<1>「资源」页面</1>删除不需要的文件以释放空间。",
   "plansModal.fileStorageLimit.title": "存储空间不足",
+  "plansModal.messengerWechat.desc": "微信 System Bot 仅面向个人付费方案开放，升级后即可连接并使用。",
+  "plansModal.messengerWechat.title": "升级后连接微信",
   "plansModal.modelAccess.desc": "该模型为付费方案专享，升级即可使用全部模型。",
   "plansModal.modelAccess.title": "解锁全部模型",
   "qa.desc": "如果您的问题未被解答，请查看 <1>产品文档</1> 获取更多常见问题，或联系我们。",

--- a/packages/locales/src/default/subscription.ts
+++ b/packages/locales/src/default/subscription.ts
@@ -555,6 +555,9 @@ export default {
   'plansModal.fileStorageLimit.desc':
     'Your file storage is full. Upgrade to keep uploading, or delete unused files on the <1>Resources page</1> to free up space.',
   'plansModal.fileStorageLimit.title': 'Storage limit reached',
+  'plansModal.messengerWechat.desc':
+    'The WeChat System Bot is available on paid personal plans. Upgrade to connect and use it.',
+  'plansModal.messengerWechat.title': 'Connect WeChat after upgrading',
   'plansModal.modelAccess.desc':
     'This model is available on paid plans. Upgrade to use the full model lineup.',
   'plansModal.modelAccess.title': 'Unlock all models',


### PR DESCRIPTION
Adds `plansModal.messengerWechat.*` copy for the plans modal's contextual header (en default source + hand-mirrored en-US/zh-CN; other locales via the daily auto-i18n workflow), backing the cloud onboarding upgrade funnel (lobehub-biz/lobehub-cloud#1382): the onboarding WeChat paid-block now opens the plans modal in place with this reason copy.

An earlier revision also deferred the onboarding redirect for `/subscription`; that was needed only while the upgrade CTA opened `/subscription/plans` in a new tab. The cloud side now opens the plans modal directly (no navigation), so the defer commit was dropped from this PR.

#### Test

- [x] Tested locally

Verified in a dev instance: the plans modal renders the new WeChat header copy in both en-US and zh-CN.