### PR TITLE
🐛 fix(qq): route group @ events as mentions

### DIFF
--- a/packages/chat-adapter-qq/src/adapter.test.ts
+++ b/packages/chat-adapter-qq/src/adapter.test.ts
@@ -188,8 +188,15 @@ describe('QQAdapter', () => {
       expect(mockChat.processMessage).toHaveBeenCalledTimes(1);
     });
 
-    it('should mark group @ messages as mentions', async () => {
-      const payload = makeWebhookPayload(QQ_EVENT_TYPES.GROUP_AT_MESSAGE_CREATE, {});
+    it.each([
+      ['group', QQ_EVENT_TYPES.GROUP_AT_MESSAGE_CREATE, {}],
+      [
+        'guild',
+        QQ_EVENT_TYPES.AT_MESSAGE_CREATE,
+        { channel_id: 'channel_abc', group_openid: undefined, guild_id: 'guild_abc' },
+      ],
+    ])('should mark %s @ messages as mentions', async (_kind, eventType, data) => {
+      const payload = makeWebhookPayload(eventType, data);
       await adapter.handleWebhook(makeRequest(payload));
 
       const factory = vi.mocked(mockChat.processMessage).mock.calls[0]?.[2];

--- a/packages/chat-adapter-qq/src/adapter.test.ts
+++ b/packages/chat-adapter-qq/src/adapter.test.ts
@@ -188,6 +188,16 @@ describe('QQAdapter', () => {
       expect(mockChat.processMessage).toHaveBeenCalledTimes(1);
     });
 
+    it('should mark group @ messages as mentions', async () => {
+      const payload = makeWebhookPayload(QQ_EVENT_TYPES.GROUP_AT_MESSAGE_CREATE, {});
+      await adapter.handleWebhook(makeRequest(payload));
+
+      const factory = vi.mocked(mockChat.processMessage).mock.calls[0]?.[2];
+      const message = await factory?.();
+
+      expect(message?.isMention).toBe(true);
+    });
+
     it('should skip empty content with no attachments', async () => {
       const payload = makeWebhookPayload(QQ_EVENT_TYPES.GROUP_AT_MESSAGE_CREATE, {
         content: '  ',

--- a/packages/chat-adapter-qq/src/adapter.ts
+++ b/packages/chat-adapter-qq/src/adapter.ts
@@ -339,7 +339,7 @@ export class QQAdapter implements Adapter<QQThreadId, QQRawMessage> {
   private async parseRawEvent(
     data: QQWebhookEventData,
     threadId: string,
-    _eventType: string,
+    eventType: string,
   ): Promise<Message<QQRawMessage>> {
     const content = data.content || '';
     const cleanText = this.formatConverter.cleanMentions(content);
@@ -374,6 +374,9 @@ export class QQAdapter implements Adapter<QQThreadId, QQRawMessage> {
       author,
       formatted,
       id: data.id || '',
+      isMention:
+        eventType === QQ_EVENT_TYPES.GROUP_AT_MESSAGE_CREATE ||
+        eventType === QQ_EVENT_TYPES.AT_MESSAGE_CREATE,
       metadata: {
         dateSent: new Date(data.timestamp || Date.now()),
         edited: false,


### PR DESCRIPTION
QQ GROUP_AT_MESSAGE_CREATE and AT_MESSAGE_CREATE events already reach the message pipeline, but the adapter discarded the event type. Because QQ mention markup is removed while formatting, the resulting Chat SDK message had no mention signal and group mentions stopped after dequeueing.

This keeps the event type and marks only the two explicit QQ @ event types as mentions.

| Before | After |
| ------ | ----- |
| QQ group @ messages are created without isMention | Explicit QQ @ events are created with isMention=true |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Focused validation: packages/chat-adapter-qq/src/adapter.test.ts — 36 passed.

#### 🔗 Related Issue

Fixes #18157