### PR TITLE
🐛 fix(desktop): keep lone tab title stable on hover

### DIFF
--- a/.agents/skills/deep-review/references/dimensions/logic.md
+++ b/.agents/skills/deep-review/references/dimensions/logic.md
@@ -17,7 +17,7 @@ Does the change do what the requirement asked, and does it hold up under real in
 - Error handling: failure paths that leave state half-mutated or the UI stuck
 - State machines: unreachable/unhandled states after this change
 - Requirement deviation: the diff contradicts the stated need, acceptance criteria, or key decisions recorded in the PR/issue/conversation. Report even when the code is internally correct — the reviewer cannot tell a legitimate mid-implementation adjustment from a forgotten decision (context loss, compaction), so the fix is always two-option: align the implementation with the recorded decision, or update the record to state why the decision changed
-- Bug fixes ship a regression test covering the fixed scenario; new services / store actions / utilities have test coverage; new database Model/Repository ships a sibling `__tests__/<name>.test.ts` incl. user isolation (see `.agents/skills/testing/`)
+- Bug fixes ship a regression test covering the fixed scenario (skip pure style/CSS fixes whose only practical assertion is stylesheet source-string matching — see `.agents/skills/testing/`); new services / store actions / utilities have test coverage; new database Model/Repository ships a sibling `__tests__/<name>.test.ts` incl. user isolation
 
 ## Rule sources (deep mode: read before reviewing)
 
@@ -36,7 +36,7 @@ Does the change do what the requirement asked, and does it hold up under real in
 
 - A concrete input/state sequence produces a wrong result, crash, stuck UI, or half-committed state.
 - The change silently narrows/broadens behavior versus the requirement.
-- A bug fix without a test that would have caught the original bug.
+- A bug fix without a test that would have caught the original bug (except pure style/CSS fixes per the testing skill).
 
 ## Not violations
 

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -43,7 +43,7 @@ cd packages/database && TEST_SERVER_DB=1 bunx vitest run --silent='passed-only' 
 2. **Tests must pass type check** - Run `bun run type-check` after writing tests
 3. **After 1-2 failed fix attempts, stop and ask for help**
 4. **Test behavior, not implementation details**
-5. **Regression tests for bug fixes** - After fixing a bug, add a regression test that fails before the fix and passes after, to prevent recurrence
+5. **Regression tests for bug fixes** - After fixing a bug, add a regression test that fails before the fix and passes after, to prevent recurrence. **Skip** pure style/CSS fixes (selector, hover, mask, spacing, color) when the only practical assertion would be source-string matching on the stylesheet — that is not a regression test worth shipping.
 6. **No new component tests** - Only update existing React component tests. Complex logic should be extracted into hooks and tested there instead
 7. **All source changes before any test changes** - Complete all source file edits first, then update tests in a separate pass. Interleaving disrupts reasoning about the source changes, especially across many files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ Open this URL to develop locally against the production backend (app.lobehub.com
 bun run check [changed-files...]
 ```
 
-- Every bug fix must include a corresponding regression test that fails before the fix and passes after it.
+- Every bug fix must include a corresponding regression test that fails before the fix and passes after it. **Skip** when the fix is pure style/CSS (selector, hover, mask, spacing, color) and the only practical assertion would be source-string matching on the stylesheet — that is not a regression test worth shipping.
 - No selector = **lint + test in a single pass** — run it once; don't fire a separate pass per selector. `--lint` / `--test` / `--type` narrow scope and are composable within one run. Default files = all working-tree changes (staged + unstaged + untracked); explicit paths override.
 - `--lint` auto-fixes the given files and prints the applied fixes as a diff, so you can review what changed.
 - `--test` auto-discovers the related tests for the given source files and runs them under the nearest owning vitest config (e.g. `packages/database`) — no need to `cd` into packages.

--- a/src/features/Electron/titlebar/TabBar/styles.ts
+++ b/src/features/Electron/titlebar/TabBar/styles.ts
@@ -132,14 +132,19 @@ export const useStyles = createStaticStyles(({ css, cssVar }) => ({
        too. The button stays mounted at every tier and fades; unmounting it made it vanish
        mid-pin.
 
-       :has() carries the keyboard path — the button is focusable at these tiers, so
+       A lone tab never mounts the button (the last tab cannot close), so :has([data-
+       tab-close]) keeps the title margin from opening a hole for a control that is not
+       there — which otherwise still ran the mask gradient in as if a close affordance
+       were arriving.
+
+       :has() also carries the keyboard path — the button is focusable at these tiers, so
        without it a tabbing user would land on something invisible.
 
        Reservation is 20px button + 3px inset - the tab's own 6px end padding. Margin
        rather than padding: the mask applies to the padding box, so padding would put the
        gradient inside the reservation instead of at the text's edge. */
-    &[data-tier='full']:hover,
-    &[data-tier='compact']:hover,
+    &[data-tier='full']:hover:has([data-tab-close]),
+    &[data-tier='compact']:hover:has([data-tab-close]),
     &[data-tier='full']:has([data-tab-close]:focus-visible),
     &[data-tier='compact']:has([data-tab-close]:focus-visible) {
       [data-tab-close] {


### PR DESCRIPTION
#### 🐛 Bug Fix / 📝 Docs

| Before | After |
| ------ | ----- |
| Hovering the only desktop tab still reserved 17px title margin for a close button that is not mounted; the fade mask shifted as if a close affordance were arriving | Title / mask stay put when there is only one tab; multi-tab hover close room is unchanged |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Pure stylesheet selector change — no behavior unit test (per updated agent testing guidance).

#### Description of Change

A lone desktop tab never mounts the close button (`totalCount === 1`), but the hover rule still applied `margin-inline-end: 17px` to the title for the close footprint. That reflowed the title mask without any close control.

Gate the hover reservation on `:has([data-tab-close])` so the title only yields space when the button actually exists.

Also documents in `AGENTS.md`, the testing skill, and deep-review logic dimension that pure style/CSS fixes whose only practical assertion is stylesheet source-string matching do not require a regression test.

#### 🔗 Related Issue

N/A