### PR TITLE
🐛 fix(memory): persist enabled setting

### DIFF
--- a/src/features/Settings/memory/features/Memory.test.tsx
+++ b/src/features/Settings/memory/features/Memory.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { FormInstance } from 'antd';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import MemorySetting from './Memory';
+
+const setSettingsMock = vi.hoisted(() => vi.fn());
+const memorySettingsMock = vi.hoisted(() => ({ value: {} as { enabled?: boolean } }));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/hooks/usePermission', () => ({
+  usePermission: () => ({ allowed: true }),
+}));
+
+vi.mock('@/hooks/useSaveState', () => ({
+  useSaveState: () => ({
+    lastSavedAt: undefined,
+    retry: vi.fn(),
+    save: (callback: () => void) => callback(),
+    status: 'idle',
+  }),
+}));
+
+vi.mock('@/store/user', () => ({
+  useUserStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      isUserStateInit: true,
+      setSettings: setSettingsMock,
+      settings: { memory: memorySettingsMock.value },
+    }),
+}));
+
+vi.mock('@/store/user/selectors', () => ({
+  settingsSelectors: {
+    currentSettings: (state: { settings: unknown }) => state.settings,
+  },
+}));
+
+vi.mock('@/components/Editor/AutoSaveHint', () => ({ default: () => null }));
+vi.mock('@/const/layoutTokens', () => ({ FORM_STYLE: {} }));
+vi.mock('@/features/ModelSwitchPanel/components/ControlsForm/LevelSlider', () => ({
+  default: () => null,
+}));
+
+vi.mock('@lobehub/ui/base-ui', () => ({
+  Switch: ({
+    checked,
+    disabled,
+    onChange,
+  }: {
+    checked?: boolean;
+    disabled?: boolean;
+    onChange?: (checked: boolean) => void;
+  }) => (
+    <button
+      aria-checked={!!checked}
+      disabled={disabled}
+      role="switch"
+      onClick={() => onChange?.(!checked)}
+    />
+  ),
+}));
+
+vi.mock('@lobehub/ui', async () => {
+  const { Form: AntdForm } = await import('antd');
+
+  const Form = Object.assign(
+    ({
+      form,
+      initialValues,
+      items,
+      onValuesChange,
+    }: {
+      form?: FormInstance<Record<string, unknown>>;
+      initialValues: Record<string, unknown>;
+      items: Array<{
+        children: Array<{ children: ReactNode; name?: string; valuePropName?: string }>;
+      }>;
+      onValuesChange: (values: Record<string, unknown>) => void;
+    }) => (
+      <AntdForm form={form} initialValues={initialValues} onValuesChange={onValuesChange}>
+        {items.flatMap((group) =>
+          group.children.flatMap((item) => {
+            if (!item.name) return [];
+
+            return [
+              <AntdForm.Item
+                key={item.name}
+                name={item.name}
+                valuePropName={item.valuePropName}
+              >
+                {item.children}
+              </AntdForm.Item>,
+            ];
+          }),
+        )}
+      </AntdForm>
+    ),
+    { useForm: AntdForm.useForm },
+  );
+
+  return {
+    Form,
+    Skeleton: () => null,
+    Tooltip: ({ children }: { children: ReactNode }) => children,
+  };
+});
+
+describe('MemorySetting', () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    memorySettingsMock.value = {};
+  });
+
+  it('shows memory as enabled when the setting has not been persisted', () => {
+    render(<MemorySetting />);
+
+    const toggle = screen.getByRole('switch');
+    expect(toggle.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('persists toggle changes', () => {
+    memorySettingsMock.value = { enabled: false };
+    render(<MemorySetting />);
+
+    const toggle = screen.getByRole('switch');
+    fireEvent.click(toggle);
+
+    expect(setSettingsMock).toHaveBeenCalledWith({ memory: { enabled: true } });
+  });
+});

--- a/src/features/Settings/memory/features/Memory.tsx
+++ b/src/features/Settings/memory/features/Memory.tsx
@@ -31,13 +31,9 @@ const MemorySetting = memo(() => {
   const memorySettings: FormGroupItemType = {
     children: [
       {
-        children: (
-          <Tooltip title={reason}>
-            <Switch disabled={!canManageMemory} />
-          </Tooltip>
-        ),
+        children: <Switch disabled={!canManageMemory} />,
         desc: t('memory.enabled.desc'),
-        label: t('memory.enabled.title'),
+        label: <Tooltip title={reason}>{t('memory.enabled.title')}</Tooltip>,
         layout: 'horizontal',
         minWidth: undefined,
         name: 'enabled',
@@ -79,7 +75,7 @@ const MemorySetting = memo(() => {
     <Form
       collapsible={false}
       form={form}
-      initialValues={memory}
+      initialValues={{ ...memory, enabled: memory?.enabled !== false }}
       items={[memorySettings]}
       itemsType={'group'}
       variant={'filled'}


### PR DESCRIPTION
The memory enabled switch was wrapped in a Tooltip, so Ant Design Form attached checked/onChange to the wrapper instead of the Switch. Toggle changes therefore never reached onValuesChange or the settings API. Accounts without a persisted enabled value also displayed the switch as off even though memory defaults to enabled.

This makes Switch the direct form control, moves the permission tooltip to the label, and normalizes the displayed default to match the runtime selector.

| Before | After |
| ------ | ----- |
| Toggling only changes local switch state; undefined displays off | Changes reach setSettings; undefined displays enabled |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Focused component validation with the real Ant Design Form: 2 tests passed. Both tests fail against the previous implementation.

#### 🔗 Related Issue

Fixes #18156