### PR TITLE
🐛 fix(chat): align terminal panel controls

### DIFF
--- a/locales/en-US/hotkey.json
+++ b/locales/en-US/hotkey.json
@@ -44,5 +44,7 @@
   "toggleLeftPanel.desc": "Show or hide the left panel",
   "toggleLeftPanel.title": "Toggle Left Panel",
   "toggleRightPanel.desc": "Show or hide the right panel",
-  "toggleRightPanel.title": "Toggle Right Panel"
+  "toggleRightPanel.title": "Toggle Right Panel",
+  "toggleTerminalPanel.desc": "Show or hide the bottom terminal panel",
+  "toggleTerminalPanel.title": "Toggle Terminal Panel"
 }

--- a/locales/zh-CN/hotkey.json
+++ b/locales/zh-CN/hotkey.json
@@ -45,6 +45,8 @@
   "toggleLeftPanel.title": "显示/隐藏左侧面板",
   "toggleRightPanel.desc": "显示或隐藏右侧面板",
   "toggleRightPanel.title": "显示/隐藏右侧面板",
+  "toggleTerminalPanel.desc": "显示或隐藏底部终端面板",
+  "toggleTerminalPanel.title": "显示/隐藏终端面板",
   "toggleZenMode.desc": "专注模式下，只显示当前会话，隐藏其他 UI",
   "toggleZenMode.title": "切换专注模式"
 }

--- a/packages/const/src/hotkeys.ts
+++ b/packages/const/src/hotkeys.ts
@@ -59,6 +59,7 @@ export const HotkeyEnum = {
   SwitchTab: 'switchTab',
   ToggleLeftPanel: 'toggleLeftPanel',
   ToggleRightPanel: 'toggleRightPanel',
+  ToggleTerminalPanel: 'toggleTerminalPanel',
 } as const satisfies Record<string, HotkeyId>;
 
 export const HotkeyGroupEnum = {
@@ -119,7 +120,7 @@ export const HOTKEYS_REGISTRATION: HotkeyRegistration = [
   {
     group: HotkeyGroupEnum.Essential,
     id: HotkeyEnum.NavigateToChat,
-    keys: combineKeys([KeyEnum.Ctrl, KeyEnum.Backquote]),
+    keys: combineKeys([KeyEnum.Ctrl, KeyEnum.Shift, KeyEnum.Backquote]),
     scopes: [HotkeyScopeEnum.Global],
   },
   {
@@ -141,6 +142,12 @@ export const HOTKEYS_REGISTRATION: HotkeyRegistration = [
     scopes: [HotkeyScopeEnum.Global],
   },
   // Chat
+  {
+    group: HotkeyGroupEnum.Conversation,
+    id: HotkeyEnum.ToggleTerminalPanel,
+    keys: combineKeys([KeyEnum.Ctrl, KeyEnum.Backquote]),
+    scopes: [HotkeyScopeEnum.Chat],
+  },
   {
     group: HotkeyGroupEnum.Conversation,
     id: HotkeyEnum.OpenChatSettings,

--- a/packages/locales/src/default/hotkey.ts
+++ b/packages/locales/src/default/hotkey.ts
@@ -48,4 +48,6 @@ export default {
   'toggleLeftPanel.title': 'Toggle Left Panel',
   'toggleRightPanel.desc': 'Show or hide the right panel',
   'toggleRightPanel.title': 'Toggle Right Panel',
+  'toggleTerminalPanel.desc': 'Show or hide the bottom terminal panel',
+  'toggleTerminalPanel.title': 'Toggle Terminal Panel',
 };

--- a/packages/types/src/hotkey.ts
+++ b/packages/types/src/hotkey.ts
@@ -17,7 +17,8 @@ export type HotkeyId =
   | 'switchAgent'
   | 'switchTab'
   | 'toggleLeftPanel'
-  | 'toggleRightPanel';
+  | 'toggleRightPanel'
+  | 'toggleTerminalPanel';
 
 export type HotkeyGroupId = 'conversation' | 'essential';
 

--- a/src/features/ChatTerminal/index.tsx
+++ b/src/features/ChatTerminal/index.tsx
@@ -5,6 +5,7 @@ import { DraggablePanel } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { lazy, memo, Suspense, useEffect, useState } from 'react';
 
+import { useToggleTerminalPanelHotkey } from '@/hooks/useHotkeys';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 
@@ -32,6 +33,8 @@ const COLLAPSE_UNMOUNT_DELAY = 300;
  * with per-topic tab groups. Desktop-only.
  */
 const ChatTerminalPanel = memo(() => {
+  useToggleTerminalPanelHotkey();
+
   const [show, height, updateSystemStatus] = useGlobalStore((s) => [
     systemStatusSelectors.showTerminalPanel(s),
     systemStatusSelectors.terminalPanelHeight(s),

--- a/src/hooks/useHotkeys/chatScope.test.ts
+++ b/src/hooks/useHotkeys/chatScope.test.ts
@@ -1,0 +1,67 @@
+import { HotkeyEnum, HotkeyGroupEnum, HotkeyScopeEnum } from '@lobechat/const/hotkeys';
+import type { HotkeyId } from '@lobechat/types';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { HOTKEYS_REGISTRATION } from '@/const/hotkeys';
+
+import { useToggleTerminalPanelHotkey } from './chatScope';
+
+const mocks = vi.hoisted(() => ({
+  hotkeyCallback: undefined as (() => void) | undefined,
+  toggleTerminalPanel: vi.fn(),
+  useHotkeyById: vi.fn(),
+}));
+
+vi.mock('@lobechat/const', async (importOriginal) => ({
+  ...(await importOriginal()),
+  isDesktop: true,
+}));
+
+vi.mock('@/store/global', () => ({
+  useGlobalStore: (selector: (state: { toggleTerminalPanel: () => void }) => unknown) =>
+    selector({ toggleTerminalPanel: mocks.toggleTerminalPanel }),
+}));
+
+vi.mock('./useHotkeyById', () => ({
+  useHotkeyById: (id: HotkeyId, callback: () => void) => {
+    mocks.hotkeyCallback = callback;
+    mocks.useHotkeyById(id, callback);
+    return { id };
+  },
+}));
+
+describe('useToggleTerminalPanelHotkey', () => {
+  beforeEach(() => {
+    mocks.hotkeyCallback = undefined;
+    mocks.toggleTerminalPanel.mockReset();
+    mocks.useHotkeyById.mockReset();
+  });
+
+  it('toggles the terminal panel when its hotkey is invoked', () => {
+    renderHook(() => useToggleTerminalPanelHotkey());
+
+    act(() => {
+      mocks.hotkeyCallback?.();
+    });
+
+    expect(mocks.useHotkeyById).toHaveBeenCalledWith(
+      HotkeyEnum.ToggleTerminalPanel,
+      expect.any(Function),
+      {
+        enableOnContentEditable: true,
+        enabled: true,
+      },
+    );
+    expect(mocks.toggleTerminalPanel).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the VS Code Ctrl+` binding in the chat scope', () => {
+    expect(HOTKEYS_REGISTRATION).toContainEqual({
+      group: HotkeyGroupEnum.Conversation,
+      id: HotkeyEnum.ToggleTerminalPanel,
+      keys: 'ctrl+backquote',
+      scopes: [HotkeyScopeEnum.Chat],
+    });
+  });
+});

--- a/src/hooks/useHotkeys/chatScope.ts
+++ b/src/hooks/useHotkeys/chatScope.ts
@@ -1,3 +1,4 @@
+import { isDesktop } from '@lobechat/const';
 import { HotkeyEnum, HotkeyScopeEnum } from '@lobechat/const/hotkeys';
 import { useEffect } from 'react';
 import { useHotkeysContext } from 'react-hotkeys-hook';
@@ -6,6 +7,7 @@ import { useOpenChatSettings } from '@/hooks/useInterceptingRoutes';
 import { useActionSWR } from '@/libs/swr';
 import { topicActionKeys } from '@/libs/swr/keys';
 import { useChatStore } from '@/store/chat';
+import { useGlobalStore } from '@/store/global';
 
 import { useHotkeyById } from './useHotkeyById';
 
@@ -18,6 +20,15 @@ export const useSaveTopicHotkey = () => {
 export const useOpenChatSettingsHotkey = () => {
   const openChatSettings = useOpenChatSettings();
   return useHotkeyById(HotkeyEnum.OpenChatSettings, openChatSettings);
+};
+
+export const useToggleTerminalPanelHotkey = () => {
+  const toggleTerminalPanel = useGlobalStore((s) => s.toggleTerminalPanel);
+
+  return useHotkeyById(HotkeyEnum.ToggleTerminalPanel, () => toggleTerminalPanel(), {
+    enableOnContentEditable: true,
+    enabled: isDesktop,
+  });
 };
 
 // Note: useRegenerateMessageHotkey has been moved to ConversationStore

--- a/src/routes/(main)/agent/features/Conversation/Header/TerminalPanelToggle/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/TerminalPanelToggle/index.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import TerminalPanelToggle from './index';
+
+const mocks = vi.hoisted(() => ({
+  showTerminalPanel: false,
+  toggleTerminalPanel: vi.fn(),
+}));
+
+vi.mock('@lobehub/ui', () => ({
+  ActionIcon: ({ active, onClick }: { active?: boolean; onClick?: () => void }) => (
+    <button data-active={String(active)} data-testid="terminal-panel-toggle" onClick={onClick} />
+  ),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/const/version', () => ({ isDesktop: true }));
+
+vi.mock('@/store/global', () => ({
+  useGlobalStore: (
+    selector: (state: {
+      status: { showTerminalPanel: boolean };
+      toggleTerminalPanel: () => void;
+    }) => unknown,
+  ) =>
+    selector({
+      status: { showTerminalPanel: mocks.showTerminalPanel },
+      toggleTerminalPanel: mocks.toggleTerminalPanel,
+    }),
+}));
+
+vi.mock('@/store/global/selectors', () => ({
+  systemStatusSelectors: {
+    showTerminalPanel: (s: { status: { showTerminalPanel: boolean } }) =>
+      s.status.showTerminalPanel,
+  },
+}));
+
+vi.mock('@/store/user', () => ({
+  useUserStore: (selector: (state: object) => unknown) => selector({}),
+}));
+
+vi.mock('@/store/user/selectors', () => ({
+  settingsSelectors: {
+    getHotkeyById: () => () => 'ctrl+backquote',
+  },
+}));
+
+describe('TerminalPanelToggle', () => {
+  beforeEach(() => {
+    mocks.showTerminalPanel = false;
+    mocks.toggleTerminalPanel.mockReset();
+  });
+
+  it('toggles the panel and reflects its active state', () => {
+    const { rerender } = render(<TerminalPanelToggle />);
+
+    expect(screen.getByTestId('terminal-panel-toggle')).toHaveAttribute('data-active', 'false');
+
+    fireEvent.click(screen.getByTestId('terminal-panel-toggle'));
+    expect(mocks.toggleTerminalPanel).toHaveBeenCalledTimes(1);
+    expect(mocks.toggleTerminalPanel).toHaveBeenCalledWith();
+
+    mocks.showTerminalPanel = true;
+    rerender(<TerminalPanelToggle />);
+
+    expect(screen.getByTestId('terminal-panel-toggle')).toHaveAttribute('data-active', 'true');
+  });
+});

--- a/src/routes/(main)/agent/features/Conversation/Header/TerminalPanelToggle/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/TerminalPanelToggle/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { HotkeyEnum } from '@lobechat/const/hotkeys';
 import { ActionIcon } from '@lobehub/ui';
 import { SquareTerminalIcon } from 'lucide-react';
 import { memo } from 'react';
@@ -8,20 +9,28 @@ import { useTranslation } from 'react-i18next';
 import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import { isDesktop } from '@/const/version';
 import { useGlobalStore } from '@/store/global';
+import { systemStatusSelectors } from '@/store/global/selectors';
+import { useUserStore } from '@/store/user';
+import { settingsSelectors } from '@/store/user/selectors';
 
 const TerminalPanelToggle = memo(() => {
   const { t } = useTranslation('chat');
-  const toggleTerminalPanel = useGlobalStore((s) => s.toggleTerminalPanel);
+  const [showTerminalPanel, toggleTerminalPanel] = useGlobalStore((s) => [
+    systemStatusSelectors.showTerminalPanel(s),
+    s.toggleTerminalPanel,
+  ]);
+  const hotkey = useUserStore(settingsSelectors.getHotkeyById(HotkeyEnum.ToggleTerminalPanel));
 
   if (!isDesktop) return null;
 
   return (
     <ActionIcon
+      active={showTerminalPanel}
       icon={SquareTerminalIcon}
       size={DESKTOP_HEADER_ICON_SMALL_SIZE}
       title={t('terminalPanel.title')}
-      tooltipProps={{ placement: 'bottom' }}
-      onClick={() => toggleTerminalPanel(true)}
+      tooltipProps={{ hotkey, placement: 'bottom' }}
+      onClick={() => toggleTerminalPanel()}
     />
   );
 });


### PR DESCRIPTION
## Summary

- Register the VS Code `Ctrl+`` shortcut to toggle the bottom terminal panel.
- Move the conflicting default chat-navigation shortcut to `Ctrl+Shift+``.
- Make the Terminal header action toggle the panel and reflect its active state.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check packages/types/src/hotkey.ts packages/const/src/hotkeys.ts src/hooks/useHotkeys/chatScope.ts src/hooks/useHotkeys/chatScope.test.ts src/features/ChatTerminal/index.tsx src/routes/(main)/agent/features/Conversation/Header/TerminalPanelToggle/index.tsx src/routes/(main)/agent/features/Conversation/Header/TerminalPanelToggle/index.test.tsx packages/locales/src/default/hotkey.ts locales/en-US/hotkey.json locales/zh-CN/hotkey.json`