### PR TITLE
♻️ refactor(react): remove ineffective memo boundaries

### DIFF
--- a/.agents/skills/react/SKILL.md
+++ b/.agents/skills/react/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react
-description: 'LobeHub React component conventions. Use when editing TSX UI, choosing base-ui vs @lobehub/ui vs antd, styling with antd-style, routing, desktop variants, layouts, or component state.'
+description: 'LobeHub React component conventions. Use when editing TSX UI, choosing base-ui vs @lobehub/ui vs antd, styling with antd-style, routing, desktop variants, layouts, component state, render performance, or memoization.'
 user-invocable: false
 ---
 
@@ -63,6 +63,18 @@ visuals") for the component table and when to use each.
 ## State
 
 When a feature component manages more than 3 pieces of state (`useState`/`useReducer`/derived state), extract the logic into a custom hook (e.g. `useXxx`). Keep the component focused on rendering — the hook holds state and handlers, so logic can be unit-tested without rendering the component.
+
+## Render Performance and Memoization
+
+Treat `memo`, `useMemo`, and `useCallback` as opt-in optimizations, not default component wrappers. Before adding one, identify the actual rerender boundary and prefer structural fixes:
+
+1. Split at the update boundary.
+2. Move transient state to its smallest owner.
+3. Use narrow Zustand selectors and avoid broad subscriptions.
+
+Do not memoize prop-free or trivially rendered components, or a component that normally receives new objects, arrays, functions, or JSX children. Do not use memoization to compensate for state held too high in the tree.
+
+Use memoization only when the subtree is demonstrably expensive or frequently repeated, its relevant inputs are stable during normal parent renders, and profiling or a concrete render-path analysis identifies the avoided work. State that reason in the implementation summary or PR.
 
 ## Layout
 

--- a/.agents/skills/react/SKILL.md
+++ b/.agents/skills/react/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react
-description: 'LobeHub React component conventions. Use when editing TSX UI, choosing base-ui vs @lobehub/ui vs antd, styling with antd-style, routing, desktop variants, layouts, component state, render performance, or memoization.'
+description: 'LobeHub React component conventions. Use when editing TSX UI, choosing base-ui vs @lobehub/ui vs antd, styling with antd-style, component boundaries, local state, layouts, render performance, or memoization.'
 user-invocable: false
 ---
 
@@ -54,15 +54,11 @@ For Modal specifically, see the dedicated **modal** skill — use the imperative
 | Layout       | Center, DraggablePanel, Flexbox, Grid, Header, MaskShadow                             |
 | Navigation   | Burger, Menu, SideNav, Tabs                                                           |
 
-## Loading indicators
-
-**Do NOT use antd `Spin` / `<Spin />`.** Use a project loader
-(`NeuralNetworkLoading`, `DotsLoading`, …) — see the **ux** skill ("Loading
-visuals") for the component table and when to use each.
-
 ## State
 
-When a feature component manages more than 3 pieces of state (`useState`/`useReducer`/derived state), extract the logic into a custom hook (e.g. `useXxx`). Keep the component focused on rendering — the hook holds state and handlers, so logic can be unit-tested without rendering the component.
+Keep transient state in its smallest useful owner. Extract a custom hook when state transitions and handlers obscure rendering or form a reusable unit; do not extract solely because a component has a particular number of hooks.
+
+Split a component only to establish a real state, reuse, or render-update boundary. Do not split solely to make files smaller.
 
 ## Render Performance and Memoization
 
@@ -84,60 +80,9 @@ Use `Flexbox` and `Center` from `@lobehub/ui`. See `references/layout-kit.md` fo
 - Use `flex={1}` to fill available space
 - Nest Flexbox for complex layouts; set `overflow: 'auto'` for scrollable regions
 
-## Navigation
+## Related Skills
 
-**For SPA pages, use `react-router-dom`, NOT `next/link`.**
-
-```tsx
-// ❌ Wrong
-import Link from 'next/link';
-
-// ✅ Correct
-import { Link, useNavigate } from 'react-router-dom';
-```
-
-Access navigate from stores: `useGlobalStore.getState().navigate?.('/settings');`
-
-## Desktop File Sync Rule
-
-Files with a `.desktop.ts(x)` variant must be edited **in sync**. Drift causes blank pages in Electron.
-
-| Base file (web)            | Desktop file (Electron)            |
-| -------------------------- | ---------------------------------- |
-| `desktopRouter.config.tsx` | `desktopRouter.config.desktop.tsx` |
-| `componentMap.ts`          | `componentMap.desktop.ts`          |
-
-**After editing any `.ts`/`.tsx`:** glob for `<filename>.desktop.{ts,tsx}` in the same directory. If found, apply the equivalent sync-import change.
-
-## Routing Architecture
-
-| Route Type         | Use Case   | Implementation                                     |
-| ------------------ | ---------- | -------------------------------------------------- |
-| Next.js App Router | Auth shell | `src/app/spa-auth/` (HTML shell; see spa-routes)   |
-| React Router DOM   | Auth pages | `src/routes/auth/` (signin, signup, oauth, …)      |
-| React Router DOM   | Main SPA   | `desktopRouter.config.tsx` + `.desktop.tsx` (pair) |
-
-Router utilities:
-
-```tsx
-import { dynamicElement, redirectElement, ErrorBoundary } from '@/utils/router';
-element: dynamicElement(() => import('./chat'), 'Desktop > Chat');
-element: redirectElement('/settings/profile');
-errorElement: <ErrorBoundary />;
-```
-
-## Common Mistakes
-
-| Mistake                                                            | Fix                                                                         |
-| ------------------------------------------------------------------ | --------------------------------------------------------------------------- |
-| Using `next/link` in SPA                                           | Use `react-router-dom` `Link`                                               |
-| Using antd directly                                                | Use `@lobehub/ui/base-ui` first, then `@lobehub/ui`                         |
-| antd `Spin` / `<Spin />` for loading                               | Use `NeuralNetworkLoading` / project loaders (see the **ux** skill)         |
-| `import { Select } from '@lobehub/ui'`                             | `import { Select } from '@lobehub/ui/base-ui'`                              |
-| `import { Modal } from '@lobehub/ui'` + `<Modal open>` declarative | `createModal` / `confirmModal` from `@lobehub/ui/base-ui` (see modal skill) |
-| `import { DropdownMenu/Popover/Switch } from '@lobehub/ui'`        | Import same name from `@lobehub/ui/base-ui` instead                         |
-| `createStyles` for static styles                                   | Use `createStaticStyles` + `cssVar`                                         |
-| Editing only `desktopRouter.config.tsx`                            | Must edit both `.tsx` and `.desktop.tsx`                                    |
-| Using `margin` for flex spacing                                    | Use `gap` prop on Flexbox                                                   |
-| Accessing zustand store without selector                           | Use selectors to access store data (see zustand skill)                      |
-| Text or icon-text actions built with `Flexbox`/`Text` + `onClick`  | Use `Button type={'text'} size={'small'}` with `icon` when needed           |
+- **`ux`**: loading visuals and user-facing interaction design. Do not use antd `Spin` / `<Spin />`.
+- **`modal`**: imperative base-ui modal patterns.
+- **`spa-routes`**: SPA navigation, route ownership, router configuration, and `.desktop` variants.
+- **`zustand`**: store structure and selector conventions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,16 @@ Guidelines for using AI coding agents in this opensource LobeHub repository.
 
 - Next.js 16 + React 19 + TypeScript
 - SPA inside Next.js with `react-router-dom`
-- `@lobehub/ui`, antd for components; antd-style for CSS-in-JS — **prefer `createStaticStyles` with `cssVar.*`** (zero-runtime); only fall back to `createStyles` + `token` when styles genuinely need runtime computation. See `.cursor/docs/createStaticStyles_migration_guide.md`.
-- **Component priority**: `@lobehub/ui/base-ui` (headless primitives) **first**, then `@lobehub/ui` root, then antd as last resort. When the component exists in base-ui, use it — never reach for the root or antd counterpart. Base-ui covers `Select`, `Modal` / `createModal` / `confirmModal`, `DropdownMenu`, `ContextMenu`, `Popover`, `ScrollArea`, `Switch`, `Toast`, `FloatingSheet`, `Drawer`. Prefer `@lobehub/ui/base-ui` for new code and migrate root-package call sites opportunistically.
+- `@lobehub/ui`, antd, and antd-style for UI implementation
 - react-i18next for i18n; zustand for state management
 - SWR for data fetching; TRPC for type-safe backend
 - Drizzle ORM with PostgreSQL; Vitest for testing
+
+## Agent Skills
+
+`AGENTS.md` owns repository-wide architecture and workflow. Keep detailed implementation rules in skills so they have one source of truth.
+
+- **React and TSX**: Before editing components, component state, render boundaries, or memoization, read [`.agents/skills/react/SKILL.md`](.agents/skills/react/SKILL.md). It owns component selection, styling, state locality, and render-performance rules.
 
 ## Project Structure
 

--- a/src/business/client/features/FileUploadErrorActions/index.tsx
+++ b/src/business/client/features/FileUploadErrorActions/index.tsx
@@ -1,8 +1,6 @@
-import { memo } from 'react';
-
 interface FileUploadErrorActionsProps {
   code?: string;
   compact?: boolean;
 }
 
-export const FileUploadErrorActions = memo<FileUploadErrorActionsProps>(() => null);
+export const FileUploadErrorActions = (_props: FileUploadErrorActionsProps) => null;

--- a/src/business/client/features/User/UserPanelAccountSection.tsx
+++ b/src/business/client/features/User/UserPanelAccountSection.tsx
@@ -1,5 +1,3 @@
-import { memo } from 'react';
-
 export interface UserPanelAccountSectionProps {
   /** Called right before navigating away, so the host popover can close itself. */
   onNavigate?: () => void;
@@ -9,8 +7,6 @@ export interface UserPanelAccountSectionProps {
  * Bottom slot of the user panel, below the sign-out menu. The community build
  * has no secondary account surface to link to, so it renders nothing.
  */
-const UserPanelAccountSection = memo<UserPanelAccountSectionProps>(() => null);
-
-UserPanelAccountSection.displayName = 'UserPanelAccountSection';
+const UserPanelAccountSection = (_props: UserPanelAccountSectionProps) => null;
 
 export default UserPanelAccountSection;

--- a/src/components/BubblesLoading/index.tsx
+++ b/src/components/BubblesLoading/index.tsx
@@ -1,14 +1,13 @@
 import { Center } from '@lobehub/ui';
 import { LoadingDots } from '@lobehub/ui/chat';
 import { cssVar } from 'antd-style';
-import { memo } from 'react';
 
-const BubblesLoading = memo(() => {
+const BubblesLoading = () => {
   return (
     <Center style={{ height: 24, width: 32 }}>
       <LoadingDots color={cssVar.colorTextSecondary} size={12} variant={'pulse'} />
     </Center>
   );
-});
+};
 
 export default BubblesLoading;

--- a/src/components/NProgress/index.tsx
+++ b/src/components/NProgress/index.tsx
@@ -2,11 +2,10 @@
 
 import { cssVar } from 'antd-style';
 import NextTopLoader from 'nextjs-toploader';
-import { memo } from 'react';
 
 import { isDesktop } from '@/const/version';
 
-const NProgress = memo(() => {
+const NProgress = () => {
   return (
     !isDesktop && (
       <NextTopLoader
@@ -18,6 +17,6 @@ const NProgress = memo(() => {
       />
     )
   );
-});
+};
 
 export default NProgress;

--- a/src/features/AgentDocumentPage/Layout/index.tsx
+++ b/src/features/AgentDocumentPage/Layout/index.tsx
@@ -1,12 +1,11 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { memo } from 'react';
 import { Outlet } from 'react-router';
 
 import AgentDocumentRightPanel from '../RightPanel';
 
-const AgentDocumentLayout = memo(() => (
+const AgentDocumentLayout = () => (
   <Flexbox
     horizontal
     flex={1}
@@ -19,8 +18,6 @@ const AgentDocumentLayout = memo(() => (
     </Flexbox>
     <AgentDocumentRightPanel />
   </Flexbox>
-));
-
-AgentDocumentLayout.displayName = 'AgentDocumentLayout';
+);
 
 export default AgentDocumentLayout;

--- a/src/features/AgentSidebar/Content.tsx
+++ b/src/features/AgentSidebar/Content.tsx
@@ -1,14 +1,10 @@
-import React, { memo } from 'react';
-
 import SideBarLayout from '@/features/NavPanel/SideBarLayout';
 
 import Body from './Body';
 import Header from './Header';
 
-const AgentSidebarContent = memo(() => {
+const AgentSidebarContent = () => {
   return <SideBarLayout body={<Body />} header={<Header />} />;
-});
-
-AgentSidebarContent.displayName = 'AgentSidebarContent';
+};
 
 export default AgentSidebarContent;

--- a/src/features/AgentSidebar/Header/index.tsx
+++ b/src/features/AgentSidebar/Header/index.tsx
@@ -1,20 +1,19 @@
 'use client';
 
 import { type PropsWithChildren } from 'react';
-import { memo } from 'react';
 
 import SideBarHeaderLayout from '@/features/NavPanel/SideBarHeaderLayout';
 
 import Agent from './Agent';
 import Nav from './Nav';
 
-const HeaderInfo = memo<PropsWithChildren>(() => {
+const HeaderInfo = (_props: PropsWithChildren) => {
   return (
     <>
       <SideBarHeaderLayout left={<Agent />} />
       <Nav />
     </>
   );
-});
+};
 
 export default HeaderInfo;

--- a/src/features/AgentSidebar/Topic/TopicListContent/ByProjectMode/index.tsx
+++ b/src/features/AgentSidebar/Topic/TopicListContent/ByProjectMode/index.tsx
@@ -1,12 +1,8 @@
 'use client';
 
-import { memo } from 'react';
-
 import GroupedAccordion from '../GroupedAccordion';
 import GroupItem from './GroupItem';
 
-const ByProjectMode = memo(() => <GroupedAccordion GroupItem={GroupItem} />);
-
-ByProjectMode.displayName = 'ByProjectMode';
+const ByProjectMode = () => <GroupedAccordion GroupItem={GroupItem} />;
 
 export default ByProjectMode;

--- a/src/features/AgentSidebar/Topic/TopicListContent/ByStatusMode/index.tsx
+++ b/src/features/AgentSidebar/Topic/TopicListContent/ByStatusMode/index.tsx
@@ -1,12 +1,8 @@
 'use client';
 
-import { memo } from 'react';
-
 import GroupedAccordion from '../GroupedAccordion';
 import GroupItem from './GroupItem';
 
-const ByStatusMode = memo(() => <GroupedAccordion GroupItem={GroupItem} />);
-
-ByStatusMode.displayName = 'ByStatusMode';
+const ByStatusMode = () => <GroupedAccordion GroupItem={GroupItem} />;
 
 export default ByStatusMode;

--- a/src/features/AgentSidebar/Topic/TopicListContent/ByTimeMode/index.tsx
+++ b/src/features/AgentSidebar/Topic/TopicListContent/ByTimeMode/index.tsx
@@ -1,12 +1,8 @@
 'use client';
 
-import { memo } from 'react';
-
 import GroupedAccordion from '../GroupedAccordion';
 import GroupItem from './GroupItem';
 
-const ByTimeMode = memo(() => <GroupedAccordion GroupItem={GroupItem} />);
-
-ByTimeMode.displayName = 'ByTimeMode';
+const ByTimeMode = () => <GroupedAccordion GroupItem={GroupItem} />;
 
 export default ByTimeMode;

--- a/src/features/AgentSidebar/index.tsx
+++ b/src/features/AgentSidebar/index.tsx
@@ -1,17 +1,13 @@
-import React, { memo } from 'react';
-
 import { NavPanelPortal } from '@/features/NavPanel/NavPanelPortal';
 
 import AgentSidebarContent from './Content';
 
-const Sidebar = memo(() => {
+const Sidebar = () => {
   return (
     <NavPanelPortal navKey="agent">
       <AgentSidebarContent />
     </NavPanelPortal>
   );
-});
-
-Sidebar.displayName = 'ChatSidebar';
+};
 
 export default Sidebar;

--- a/src/features/AgentViewAll/AgentViewAllPage.tsx
+++ b/src/features/AgentViewAll/AgentViewAllPage.tsx
@@ -656,12 +656,10 @@ AgentViewAllPage.displayName = 'AgentViewAllPage';
 // blank-agent creation, and that modal lives in AgentModalContext — normally
 // mounted by the Home layout, which this standalone route is NOT inside. Wrap
 // the page so the "+" menu opens the same create wizard as the sidebar.
-const AgentViewAllPageWithModals = memo(() => (
+const AgentViewAllPageWithModals = () => (
   <AgentModalProvider>
     <AgentViewAllPage />
   </AgentModalProvider>
-));
-
-AgentViewAllPageWithModals.displayName = 'AgentViewAllPageWithModals';
+);
 
 export default AgentViewAllPageWithModals;

--- a/src/features/Auth/OAuthConsent/index.tsx
+++ b/src/features/Auth/OAuthConsent/index.tsx
@@ -84,12 +84,10 @@ const InteractionContent = memo(() => {
 
 InteractionContent.displayName = 'OAuthInteractionContent';
 
-const OAuthConsent = memo(() => (
+const OAuthConsent = () => (
   <OAuthGuard>
     <InteractionContent />
   </OAuthGuard>
-));
-
-OAuthConsent.displayName = 'OAuthConsent';
+);
 
 export default OAuthConsent;

--- a/src/features/Auth/OAuthDevice/DeviceSuccessPage.tsx
+++ b/src/features/Auth/OAuthDevice/DeviceSuccessPage.tsx
@@ -1,16 +1,12 @@
 'use client';
 
-import { memo } from 'react';
-
 import OAuthGuard from '../OAuthGuard';
 import DeviceSuccess from './DeviceSuccess';
 
-const DeviceSuccessPage = memo(() => (
+const DeviceSuccessPage = () => (
   <OAuthGuard>
     <DeviceSuccess />
   </OAuthGuard>
-));
-
-DeviceSuccessPage.displayName = 'DeviceSuccessPage';
+);
 
 export default DeviceSuccessPage;

--- a/src/features/ChatInput/ActionBar/History/Controls.tsx
+++ b/src/features/ChatInput/ActionBar/History/Controls.tsx
@@ -3,7 +3,7 @@ import { Form, SliderWithInput } from '@lobehub/ui';
 import { Switch } from '@lobehub/ui/base-ui';
 import { Form as AntdForm } from 'antd';
 import { debounce } from 'es-toolkit/compat';
-import { memo, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useAgentStore } from '@/store/agent';
@@ -12,13 +12,10 @@ import { chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { useAgentId } from '../../hooks/useAgentId';
 import { useUpdateAgentConfig } from '../../hooks/useUpdateAgentConfig';
 
-interface ControlsProps {
-  setUpdating: (updating: boolean) => void;
-  updating: boolean;
-}
-const Controls = memo<ControlsProps>(({ updating, setUpdating }) => {
+const Controls = () => {
   const { t } = useTranslation('setting');
   const [form] = AntdForm.useForm();
+  const [updating, setUpdating] = useState(false);
   const agentId = useAgentId();
   const { updateAgentChatConfig } = useUpdateAgentConfig();
 
@@ -34,6 +31,21 @@ const Controls = memo<ControlsProps>(({ updating, setUpdating }) => {
       historyCount,
     });
   }, [enableHistoryCount, historyCount, form]);
+
+  const handleValuesChange = useMemo(
+    () =>
+      debounce(async (values) => {
+        setUpdating(true);
+        try {
+          await updateAgentChatConfig(values);
+        } finally {
+          setUpdating(false);
+        }
+      }, 500),
+    [updateAgentChatConfig],
+  );
+
+  useEffect(() => () => handleValuesChange.cancel(), [handleValuesChange]);
 
   const items: FormItemProps[] = [
     {
@@ -80,13 +92,9 @@ const Controls = memo<ControlsProps>(({ updating, setUpdating }) => {
           background: 'transparent',
         },
       }}
-      onValuesChange={debounce(async (values) => {
-        setUpdating(true);
-        await updateAgentChatConfig(values);
-        setUpdating(false);
-      }, 500)}
+      onValuesChange={handleValuesChange}
     />
   );
-});
+};
 
 export default Controls;

--- a/src/features/ChatInput/ActionBar/History/index.tsx
+++ b/src/features/ChatInput/ActionBar/History/index.tsx
@@ -1,5 +1,5 @@
 import { Timer, TimerOff } from 'lucide-react';
-import { memo, useState } from 'react';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useIsMobile } from '@/hooks/useIsMobile';
@@ -18,7 +18,6 @@ const History = memo(() => {
     agentByIdSelectors.isAgentConfigLoadingById(agentId)(s),
     chatConfigByIdSelectors.getChatConfigById(agentId)(s),
   ]);
-  const [updating, setUpdating] = useState(false);
   const { t } = useTranslation('setting');
   const isMobile = useIsMobile();
 
@@ -41,11 +40,10 @@ const History = memo(() => {
   return (
     <ChatInputAction
       icon={enableHistoryCount ? Timer : TimerOff}
-      loading={updating}
       showTooltip={false}
       title={title}
       popover={{
-        content: <Controls setUpdating={setUpdating} updating={updating} />,
+        content: <Controls />,
         minWidth: 240,
         trigger: isMobile ? 'click' : 'hover',
       }}

--- a/src/features/ChatInput/ActionBar/Params/Controls.tsx
+++ b/src/features/ChatInput/ActionBar/Params/Controls.tsx
@@ -34,8 +34,6 @@ import { useUpdateAgentConfig } from '../../hooks/useUpdateAgentConfig';
 import { useParamsModelConfig } from './useParamsModelConfig';
 
 interface ControlsProps {
-  setUpdating: (updating: boolean) => void;
-  updating: boolean;
   variant?: 'popover' | 'sidebar';
 }
 
@@ -470,7 +468,7 @@ interface ControlRowProps {
   tooltip?: string;
 }
 
-const ControlRow = memo<ControlRowProps>(({ action, children, muted, tag, title, tooltip }) => (
+const ControlRow = ({ action, children, muted, tag, title, tooltip }: ControlRowProps) => (
   <Flexbox className={cx('control-row', styles.rowRoot, muted && styles.muted)} gap={10}>
     <Flexbox horizontal align={'center'} gap={12} justify={'space-between'}>
       <ControlLabel tag={tag} title={title} tooltip={tooltip} />
@@ -478,7 +476,7 @@ const ControlRow = memo<ControlRowProps>(({ action, children, muted, tag, title,
     </Flexbox>
     {children && <div className={styles.rowControl}>{children}</div>}
   </Flexbox>
-));
+);
 
 interface SectionHeaderProps {
   onToggle: () => void;
@@ -502,36 +500,46 @@ interface SliderFieldProps extends SliderConfig {
   value?: number;
 }
 
-const SliderField = memo<SliderFieldProps>(
-  ({ value, disabled, onChange, min, max, step, unlimitedInput, inputWidth = 56 }) => (
-    <SliderWithInput
-      changeOnWheel
-      className={styles.slider}
-      controls={false}
-      disabled={disabled}
-      gap={10}
-      max={max}
-      min={min}
-      size={'small'}
-      step={step}
-      style={{ height: 28 }}
-      unlimitedInput={unlimitedInput}
-      value={value}
-      styles={{
-        input: {
-          maxWidth: inputWidth,
-        },
-      }}
-      onChange={onChange}
-    />
-  ),
+const SliderField = ({
+  value,
+  disabled,
+  onChange,
+  min,
+  max,
+  step,
+  unlimitedInput,
+  inputWidth = 56,
+}: SliderFieldProps) => (
+  <SliderWithInput
+    changeOnWheel
+    className={styles.slider}
+    controls={false}
+    disabled={disabled}
+    gap={10}
+    max={max}
+    min={min}
+    size={'small'}
+    step={step}
+    style={{ height: 28 }}
+    unlimitedInput={unlimitedInput}
+    value={value}
+    styles={{
+      input: {
+        maxWidth: inputWidth,
+      },
+    }}
+    onChange={onChange}
+  />
 );
 
-const Controls = memo<ControlsProps>(({ setUpdating, updating, variant = 'popover' }) => {
+const Controls = ({ variant = 'popover' }: ControlsProps) => {
   const { t } = useTranslation(['setting', 'components']);
   const agentId = useAgentId();
   const { updateAgentConfig } = useUpdateAgentConfig();
   const { allowed: canCreate } = usePermission('create_content');
+  // Saving feedback belongs to this form. Keeping it here prevents a write from
+  // re-rendering whichever toolbar or sidebar merely hosts the panel.
+  const [updating, setUpdating] = useState(false);
 
   const config = useAgentStore(
     (s) => agentByIdSelectors.getAgentConfigById(agentId)(s) || DEFAULT_AGENT_CONFIG,
@@ -1132,6 +1140,6 @@ const Controls = memo<ControlsProps>(({ setUpdating, updating, variant = 'popove
       </div>
     </div>
   );
-});
+};
 
 export default Controls;

--- a/src/features/ChatInput/ActionBar/Params/index.tsx
+++ b/src/features/ChatInput/ActionBar/Params/index.tsx
@@ -1,5 +1,5 @@
 import { Settings2Icon } from 'lucide-react';
-import { memo, useState } from 'react';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useAgentStore } from '@/store/agent';
@@ -14,7 +14,6 @@ const Params = memo(() => {
   const [isLoading] = useAgentStore((s) => [
     agentByIdSelectors.isAgentConfigLoadingById(agentId)(s),
   ]);
-  const [updating, setUpdating] = useState(false);
   const { t } = useTranslation('setting');
 
   if (isLoading) return <ChatInputAction disabled icon={Settings2Icon} />;
@@ -25,7 +24,7 @@ const Params = memo(() => {
       showTooltip={false}
       title={t('settingModel.params.title')}
       popover={{
-        content: <Controls setUpdating={setUpdating} updating={updating} />,
+        content: <Controls />,
         maxWidth: 384,
         minWidth: 384,
         styles: {

--- a/src/features/ChatInput/ActionBar/Plus/index.tsx
+++ b/src/features/ChatInput/ActionBar/Plus/index.tsx
@@ -802,7 +802,7 @@ const PlusAction = memo(() => {
 
 PlusAction.displayName = 'PlusAction';
 
-const Plus = memo(() => (
+const Plus = () => (
   <Suspense
     fallback={
       <ChatInputAction
@@ -815,8 +815,6 @@ const Plus = memo(() => (
   >
     <PlusAction />
   </Suspense>
-));
-
-Plus.displayName = 'Plus';
+);
 
 export default Plus;

--- a/src/features/ChatInput/ActionBar/Token/index.tsx
+++ b/src/features/ChatInput/ActionBar/Token/index.tsx
@@ -12,14 +12,12 @@ const Token = memo<PropsWithChildren>(({ children }) => {
   return showTag && children;
 });
 
-const ContextWindow = memo(() => {
+const ContextWindow = () => {
   return (
     <Token>
       <LargeTokenContent />
     </Token>
   );
-});
-
-ContextWindow.displayName = 'ContextWindow';
+};
 
 export default ContextWindow;

--- a/src/features/ChatInput/Desktop/ContextContainer/index.tsx
+++ b/src/features/ChatInput/Desktop/ContextContainer/index.tsx
@@ -1,5 +1,4 @@
 import { Flexbox } from '@lobehub/ui';
-import { memo } from 'react';
 
 import ContextList from './ContextList';
 
@@ -7,12 +6,12 @@ import ContextList from './ContextList';
  * Contains the context item to be attached, such as file, image, text, etc.
  * Note: Drag upload is now handled by DragUploadZone in the parent Desktop component.
  */
-const ContextContainer = memo(() => {
+const ContextContainer = () => {
   return (
     <Flexbox paddingInline={8}>
       <ContextList />
     </Flexbox>
   );
-});
+};
 
 export default ContextContainer;

--- a/src/features/ChatInput/VoiceMessage/index.tsx
+++ b/src/features/ChatInput/VoiceMessage/index.tsx
@@ -375,15 +375,13 @@ export interface VoiceMessageControlProps {
   waveform: number[];
 }
 
-const SendDots = memo(() => (
+const SendDots = () => (
   <span aria-hidden className={styles.sendDots}>
     {Array.from({ length: 4 }, (_, index) => (
       <i key={index} />
     ))}
   </span>
-));
-
-SendDots.displayName = 'VoiceMessageSendDots';
+);
 
 export const VoiceMessageControl = memo<VoiceMessageControlProps>(
   ({

--- a/src/features/CommunitySkillDetail/Header.tsx
+++ b/src/features/CommunitySkillDetail/Header.tsx
@@ -98,7 +98,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
-const MetaDivider = memo(() => <span aria-hidden className={styles.metaDivider} />);
+const MetaDivider = () => <span aria-hidden className={styles.metaDivider} />;
 
 const StatBlock = memo<{
   bordered?: boolean;

--- a/src/features/Conversation/ChatInput/OpStatusTray.tsx
+++ b/src/features/Conversation/ChatInput/OpStatusTray.tsx
@@ -198,14 +198,12 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
-const ActivityGlyph = memo(() => (
+const ActivityGlyph = () => (
   <svg aria-hidden className={styles.activityGlyph} viewBox="0 0 16 16">
     <circle className={styles.glyphOrbit} cx="8" cy="8" r="6.1" />
     <circle className={styles.glyphCore} cx="8" cy="8" r="2.7" />
   </svg>
-));
-
-ActivityGlyph.displayName = 'ActivityGlyph';
+);
 
 const formatTokens = (n: number) => {
   if (n < 1000) return String(n);

--- a/src/features/Conversation/WorkingSidebar/ParamsSection/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/ParamsSection/index.tsx
@@ -1,20 +1,15 @@
-import { memo, useState } from 'react';
-
 import Controls from '@/features/ChatInput/ActionBar/Params/Controls';
 import { createStore, Provider } from '@/features/ChatInput/store';
 import { useAgentStore } from '@/store/agent';
 
-const ParamsSection = memo(() => {
+const ParamsSection = () => {
   const agentId = useAgentStore((s) => s.activeAgentId) || '';
-  const [updating, setUpdating] = useState(false);
 
   return (
     <Provider createStore={() => createStore({ agentId })} key={agentId}>
-      <Controls setUpdating={setUpdating} updating={updating} variant="sidebar" />
+      <Controls variant="sidebar" />
     </Provider>
   );
-});
-
-ParamsSection.displayName = 'AgentWorkingSidebarParamsSection';
+};
 
 export default ParamsSection;

--- a/src/features/DataImporter/Loading.tsx
+++ b/src/features/DataImporter/Loading.tsx
@@ -2,7 +2,6 @@
 
 import { Center } from '@lobehub/ui';
 import { createStaticStyles, keyframes } from 'antd-style';
-import React, { memo } from 'react';
 
 const size = 28;
 
@@ -113,12 +112,12 @@ const styles = createStaticStyles(({ css, cssVar }) => {
   };
 });
 
-const DataLoading = memo(() => {
+const DataLoading = () => {
   return (
     <Center style={{ height: 80 }}>
       <div className={styles.loader} />
     </Center>
   );
-});
+};
 
 export default DataLoading;

--- a/src/features/DevDock/index.tsx
+++ b/src/features/DevDock/index.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { memo } from 'react';
-
 import { registerBusinessDevDockItems } from '@/business/client/registerDevDockItems';
 import FlagOverrideHydrator from '@/features/DevFeatureFlagPanel/Hydrator';
 
@@ -13,7 +11,7 @@ import { registerBuiltinDevDockItems } from './registerBuiltinItems';
 registerBuiltinDevDockItems();
 registerBusinessDevDockItems();
 
-const DevDock = memo(() => {
+const DevDock = () => {
   return (
     <>
       <FlagOverrideHydrator />
@@ -22,8 +20,6 @@ const DevDock = memo(() => {
       <Bar />
     </>
   );
-});
-
-DevDock.displayName = 'DevDock';
+};
 
 export default DevDock;

--- a/src/features/EditorCanvas/DocumentIdMode.tsx
+++ b/src/features/EditorCanvas/DocumentIdMode.tsx
@@ -19,11 +19,11 @@ import UnsavedChangesGuard from './UnsavedChangesGuard';
 /**
  * Loading skeleton for the editor
  */
-const EditorSkeleton = memo(() => (
+const EditorSkeleton = () => (
   <div style={{ paddingBlock: 24 }}>
     <Skeleton active paragraph={{ rows: 8 }} />
   </div>
-));
+);
 
 export interface DocumentIdModeProps extends EditorCanvasProps {
   documentId: string;

--- a/src/features/FloatingChatPanel/ChatBody.tsx
+++ b/src/features/FloatingChatPanel/ChatBody.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { memo } from 'react';
 
 import { ChatList } from '@/features/Conversation';
 
-const ChatBody = memo(() => {
+const ChatBody = () => {
   return (
     <Flexbox
       data-testid="floating-chat-panel-body"
@@ -17,8 +16,6 @@ const ChatBody = memo(() => {
       <ChatList />
     </Flexbox>
   );
-});
-
-ChatBody.displayName = 'FloatingChatPanelBody';
+};
 
 export default ChatBody;

--- a/src/features/HomeSidebar/Content.tsx
+++ b/src/features/HomeSidebar/Content.tsx
@@ -1,19 +1,15 @@
-import { memo } from 'react';
-
 import SideBarLayout from '@/features/NavPanel/SideBarLayout';
 
 import Body from './Body';
 import { AgentModalProvider } from './Body/Agent/ModalProvider';
 import Header from './Header';
 
-const HomeSidebarContent = memo(() => {
+const HomeSidebarContent = () => {
   return (
     <AgentModalProvider>
       <SideBarLayout body={<Body />} header={<Header />} />
     </AgentModalProvider>
   );
-});
-
-HomeSidebarContent.displayName = 'HomeSidebarContent';
+};
 
 export default HomeSidebarContent;

--- a/src/features/HomeSidebar/Header/index.tsx
+++ b/src/features/HomeSidebar/Header/index.tsx
@@ -1,20 +1,18 @@
 'use client';
 
-import { memo } from 'react';
-
 import SideBarHeaderLayout from '@/features/NavPanel/SideBarHeaderLayout';
 
 import InboxButton from './components/InboxButton';
 import Nav from './components/Nav';
 import User from './components/User';
 
-const Header = memo(() => {
+const Header = () => {
   return (
     <>
       <SideBarHeaderLayout left={<User />} right={<InboxButton />} showBack={false} />
       <Nav />
     </>
   );
-});
+};
 
 export default Header;

--- a/src/features/HomeSidebar/index.tsx
+++ b/src/features/HomeSidebar/index.tsx
@@ -1,15 +1,11 @@
-import { memo } from 'react';
-
 import { NavPanelPortal } from '@/features/NavPanel/NavPanelPortal';
 
 import HomeSidebarContent from './Content';
 
-const HomeNavPanelPortal = memo(() => (
+const HomeNavPanelPortal = () => (
   <NavPanelPortal navKey="home">
     <HomeSidebarContent />
   </NavPanelPortal>
-));
-
-HomeNavPanelPortal.displayName = 'HomeNavPanelPortal';
+);
 
 export default HomeNavPanelPortal;

--- a/src/features/LibraryModal/AssignKnowledgeBase/Loading.tsx
+++ b/src/features/LibraryModal/AssignKnowledgeBase/Loading.tsx
@@ -1,12 +1,11 @@
 import { Flexbox, Skeleton } from '@lobehub/ui';
-import { memo } from 'react';
 
-const Loading = memo(() => {
+const Loading = () => {
   return (
     <Flexbox>
       <Skeleton paragraph={{ rows: 8 }} title={false} />
     </Flexbox>
   );
-});
+};
 
 export default Loading;

--- a/src/features/MobileHome/index.tsx
+++ b/src/features/MobileHome/index.tsx
@@ -1,16 +1,14 @@
-import { memo, Suspense } from 'react';
+import { Suspense } from 'react';
 
 import SessionListContent from './SessionListContent';
 import SkeletonList from './SkeletonList';
 
-const Home = memo(() => {
+const Home = () => {
   return (
     <Suspense fallback={<SkeletonList />}>
       <SessionListContent />
     </Suspense>
   );
-});
-
-Home.displayName = 'MobileHome';
+};
 
 export default Home;

--- a/src/features/NavPanel/Shell.tsx
+++ b/src/features/NavPanel/Shell.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { memo } from 'react';
-
 import HomeNavPanelPortal from '@/features/HomeSidebar';
 
 import NavPanel from './index';
@@ -12,13 +10,11 @@ import NavPanel from './index';
 // Home layout only mounts inside a home tab — and `Activity` unmounts effects
 // for inactive tabs. Registering from the route layout leaves those tabs with
 // no `home` entry at all, so the panel is stuck on the loading skeleton.
-const NavPanelShell = memo(() => (
+const NavPanelShell = () => (
   <>
     <HomeNavPanelPortal />
     <NavPanel />
   </>
-));
-
-NavPanelShell.displayName = 'NavPanelShell';
+);
 
 export default NavPanelShell;

--- a/src/features/PageEditor/PageMetaBar.tsx
+++ b/src/features/PageEditor/PageMetaBar.tsx
@@ -1,5 +1,3 @@
-import { memo } from 'react';
-
-const PageMetaBar = memo(() => null);
+const PageMetaBar = () => null;
 
 export default PageMetaBar;

--- a/src/features/Pages/PageLayout/Sidebar.tsx
+++ b/src/features/Pages/PageLayout/Sidebar.tsx
@@ -1,17 +1,13 @@
 'use client';
 
-import { memo } from 'react';
-
 import { NavPanelPortal } from '@/features/NavPanel/NavPanelPortal';
 
 import SidebarContent from './SidebarContent';
 
-const Sidebar = memo(() => (
+const Sidebar = () => (
   <NavPanelPortal navKey="page">
     <SidebarContent />
   </NavPanelPortal>
-));
-
-Sidebar.displayName = 'PageSidebar';
+);
 
 export default Sidebar;

--- a/src/features/Pages/PageLayout/SidebarContent.tsx
+++ b/src/features/Pages/PageLayout/SidebarContent.tsx
@@ -1,14 +1,10 @@
 'use client';
 
-import { memo } from 'react';
-
 import SideBarLayout from '@/features/NavPanel/SideBarLayout';
 
 import Body from './Body';
 import Header from './Header';
 
-const PageSidebarContent = memo(() => <SideBarLayout body={<Body />} header={<Header />} />);
-
-PageSidebarContent.displayName = 'PageSidebarContent';
+const PageSidebarContent = () => <SideBarLayout body={<Body />} header={<Header />} />;
 
 export default PageSidebarContent;

--- a/src/features/Portal/Document/PortalHeader.tsx
+++ b/src/features/Portal/Document/PortalHeader.tsx
@@ -41,8 +41,8 @@ const OpenAsPageAction = memo(() => {
   );
 });
 
-const PortalHeader = memo(() => (
+const PortalHeader = () => (
   <PortalChromeHeader rightExtra={<OpenAsPageAction />} title={<DocumentTitle />} />
-));
+);
 
 export default PortalHeader;

--- a/src/features/Portal/GroupThread/Body/index.tsx
+++ b/src/features/Portal/GroupThread/Body/index.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { memo } from 'react';
 
 import ThreadChatList from './ThreadChatList';
 
-const Body = memo(() => {
+const Body = () => {
   return (
     <Flexbox height={'100%'}>
       <Flexbox flex={1} style={{ overflow: 'hidden', position: 'relative' }}>
@@ -13,6 +12,6 @@ const Body = memo(() => {
       </Flexbox>
     </Flexbox>
   );
-});
+};
 
 export default Body;

--- a/src/features/RecommendTaskTemplates/index.tsx
+++ b/src/features/RecommendTaskTemplates/index.tsx
@@ -1,6 +1,2 @@
-import { memo } from 'react';
-
 /** @deprecated Recommendations render inside Daily brief via `DailyBriefRecommendations`. */
-export const RecommendTaskTemplates = memo(() => null);
-
-RecommendTaskTemplates.displayName = 'RecommendTaskTemplates';
+export const RecommendTaskTemplates = () => null;

--- a/src/features/ResourceHome/Layout/Sidebar.tsx
+++ b/src/features/ResourceHome/Layout/Sidebar.tsx
@@ -1,17 +1,13 @@
 'use client';
 
-import { memo } from 'react';
-
 import { NavPanelPortal } from '@/features/NavPanel/NavPanelPortal';
 
 import SidebarContent from './SidebarContent';
 
-const Sidebar = memo(() => (
+const Sidebar = () => (
   <NavPanelPortal navKey="resource">
     <SidebarContent />
   </NavPanelPortal>
-));
-
-Sidebar.displayName = 'ResourceHomeSidebar';
+);
 
 export default Sidebar;

--- a/src/features/ResourceLibrary/Layout/Sidebar.tsx
+++ b/src/features/ResourceLibrary/Layout/Sidebar.tsx
@@ -1,21 +1,17 @@
 'use client';
 
-import { memo } from 'react';
-
 import { NavPanelPortal } from '@/features/NavPanel/NavPanelPortal';
 import SideBarLayout from '@/features/NavPanel/SideBarLayout';
 import LibraryHierarchy from '@/features/ResourceManager/components/LibraryHierarchy';
 
 import Header from './Header';
 
-const Sidebar = memo(() => {
+const Sidebar = () => {
   return (
     <NavPanelPortal navKey="resourceLibrary">
       <SideBarLayout body={<LibraryHierarchy />} header={<Header />} />
     </NavPanelPortal>
   );
-});
-
-Sidebar.displayName = 'LibrarySidebar';
+};
 
 export default Sidebar;

--- a/src/features/ResourceLibrary/index.tsx
+++ b/src/features/ResourceLibrary/index.tsx
@@ -46,7 +46,7 @@ const MainContent = memo(() => {
 
 MainContent.displayName = 'LibraryMainContent';
 
-const LibraryPage = memo(() => {
+const LibraryPage = () => {
   return (
     <>
       <NProgress />
@@ -55,8 +55,6 @@ const LibraryPage = memo(() => {
       </Container>
     </>
   );
-});
-
-LibraryPage.displayName = 'LibraryPage';
+};
 
 export default LibraryPage;

--- a/src/features/ResourceManager/components/LibraryHierarchy/TreeSkeleton.tsx
+++ b/src/features/ResourceManager/components/LibraryHierarchy/TreeSkeleton.tsx
@@ -47,7 +47,7 @@ const TreeSkeletonItem = memo<TreeSkeletonItemProps>(({ opacity = 1 }) => {
 
 TreeSkeletonItem.displayName = 'TreeSkeletonItem';
 
-const TreeSkeleton = memo(() => {
+const TreeSkeleton = () => {
   const count = 6;
   // Calculate opacity gradient from 100% to 20%
   const getOpacity = (index: number) => 1 - (index / (count - 1)) * 0.8;
@@ -59,8 +59,6 @@ const TreeSkeleton = memo(() => {
       ))}
     </Flexbox>
   );
-});
-
-TreeSkeleton.displayName = 'TreeSkeleton';
+};
 
 export default TreeSkeleton;

--- a/src/features/Settings/Layout/SideBar.tsx
+++ b/src/features/Settings/Layout/SideBar.tsx
@@ -1,17 +1,15 @@
 'use client';
 
-import { memo } from 'react';
-
 import { NavPanelPortal } from '@/features/NavPanel/NavPanelPortal';
 
 import SidebarContent from './SidebarContent';
 
-const Sidebar = memo(() => {
+const Sidebar = () => {
   return (
     <NavPanelPortal navKey="settings">
       <SidebarContent />
     </NavPanelPortal>
   );
-});
+};
 
 export default Sidebar;

--- a/src/features/Settings/Layout/SidebarContent.tsx
+++ b/src/features/Settings/Layout/SidebarContent.tsx
@@ -1,12 +1,10 @@
-import { memo } from 'react';
-
 import SideBarLayout from '@/features/NavPanel/SideBarLayout';
 
 import Body from './Body';
 import Header from './Header';
 
-const SidebarContent = memo(() => {
+const SidebarContent = () => {
   return <SideBarLayout body={<Body />} header={<Header />} />;
-});
+};
 
 export default SidebarContent;

--- a/src/features/Settings/appearance/features/Terminal/index.tsx
+++ b/src/features/Settings/appearance/features/Terminal/index.tsx
@@ -123,10 +123,10 @@ const TerminalSettings = memo(() => {
   );
 });
 
-const Terminal = memo(() => {
+const Terminal = () => {
   if (!isDesktop) return null;
 
   return <TerminalSettings />;
-});
+};
 
 export default Terminal;

--- a/src/features/Settings/connector/index.tsx
+++ b/src/features/Settings/connector/index.tsx
@@ -1,11 +1,7 @@
 'use client';
 
-import { memo } from 'react';
-
 import { ToolSettings } from '@/features/Settings/skill';
 
-const Page = memo(() => <ToolSettings viewMode="connector" />);
-
-Page.displayName = 'ConnectorSettings';
+const Page = () => <ToolSettings viewMode="connector" />;
 
 export default Page;

--- a/src/features/Settings/provider/features/ModelList/SkeletonList.tsx
+++ b/src/features/Settings/provider/features/ModelList/SkeletonList.tsx
@@ -86,12 +86,12 @@ export const Placeholder = memo(() => {
   );
 });
 
-export const SkeletonList = memo(() => (
+export const SkeletonList = () => (
   <Flexbox gap={4} paddingBlock={12}>
     {Array.from({ length: 6 }).map((_, i) => (
       <Placeholder key={i} />
     ))}
   </Flexbox>
-));
+);
 
 export default SkeletonList;

--- a/src/features/Settings/skill/index.tsx
+++ b/src/features/Settings/skill/index.tsx
@@ -112,8 +112,6 @@ export const ToolSettings = memo<ToolSettingsProps>(({ viewMode }) => {
 
 ToolSettings.displayName = 'ToolSettings';
 
-const Page = memo(() => <ToolSettings viewMode="skill" />);
-
-Page.displayName = 'SkillSettings';
+const Page = () => <ToolSettings viewMode="skill" />;
 
 export default Page;

--- a/src/features/Settings/system-tools/features/ShellSection.tsx
+++ b/src/features/Settings/system-tools/features/ShellSection.tsx
@@ -95,9 +95,9 @@ const ShellSection = memo(() => {
   );
 });
 
-const GuardedShellSection = memo(() => {
+const GuardedShellSection = () => {
   if (getPlatform() !== 'Windows') return null;
   return <ShellSection />;
-});
+};
 
 export default GuardedShellSection;

--- a/src/features/SkillStore/SkillDetail/VirtuosoLoading.tsx
+++ b/src/features/SkillStore/SkillDetail/VirtuosoLoading.tsx
@@ -1,14 +1,13 @@
 import { Center, Icon } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { Loader2Icon } from 'lucide-react';
-import { memo } from 'react';
 
-const VirtuosoLoading = memo(() => {
+const VirtuosoLoading = () => {
   return (
     <Center padding={16}>
       <Icon spin color={cssVar.colorTextDescription} icon={Loader2Icon} />
     </Center>
   );
-});
+};
 
 export default VirtuosoLoading;

--- a/src/features/SkillStore/SkillList/Loading.tsx
+++ b/src/features/SkillStore/SkillList/Loading.tsx
@@ -1,12 +1,11 @@
 import { Flexbox, Skeleton } from '@lobehub/ui';
-import { memo } from 'react';
 
-const Loading = memo(() => {
+const Loading = () => {
   return (
     <Flexbox padding={16}>
       <Skeleton active paragraph={{ rows: 8 }} title={false} />
     </Flexbox>
   );
-});
+};
 
 export default Loading;

--- a/src/features/SkillStore/SkillList/VirtuosoLoading.tsx
+++ b/src/features/SkillStore/SkillList/VirtuosoLoading.tsx
@@ -1,14 +1,13 @@
 import { Center, Icon } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { Loader2Icon } from 'lucide-react';
-import { memo } from 'react';
 
-const VirtuosoLoading = memo(() => {
+const VirtuosoLoading = () => {
   return (
     <Center padding={16}>
       <Icon spin color={cssVar.colorTextDescription} icon={Loader2Icon} />
     </Center>
   );
-});
+};
 
 export default VirtuosoLoading;

--- a/src/features/WorkspaceSetting/Layout.tsx
+++ b/src/features/WorkspaceSetting/Layout.tsx
@@ -33,16 +33,14 @@ const COMPACT_HEADER_TABS = new Set<string>([
  * Bare workspace settings shell — sidebar + outlet, no content padding.
  * Use this when a child route owns its own full-bleed layout (e.g. Provider).
  */
-const WorkspaceSettingsLayout: FC = memo(() => {
+const WorkspaceSettingsLayout: FC = () => {
   return (
     <>
       <SideBar />
       <Outlet />
     </>
   );
-});
-
-WorkspaceSettingsLayout.displayName = 'WorkspaceSettingsLayout';
+};
 
 /**
  * Standard workspace settings content layout. Compact-header tabs use the

--- a/src/features/WorkspaceSetting/SideBar/Content.tsx
+++ b/src/features/WorkspaceSetting/SideBar/Content.tsx
@@ -1,16 +1,10 @@
 'use client';
 
-import { memo } from 'react';
-
 import SideBarLayout from '@/features/NavPanel/SideBarLayout';
 
 import Body from './Body';
 import Header from './Header';
 
-const WorkspaceSettingsSideBarContent = memo(() => (
-  <SideBarLayout body={<Body />} header={<Header />} />
-));
-
-WorkspaceSettingsSideBarContent.displayName = 'WorkspaceSettingsSideBarContent';
+const WorkspaceSettingsSideBarContent = () => <SideBarLayout body={<Body />} header={<Header />} />;
 
 export default WorkspaceSettingsSideBarContent;

--- a/src/features/WorkspaceSetting/SideBar/index.tsx
+++ b/src/features/WorkspaceSetting/SideBar/index.tsx
@@ -1,17 +1,15 @@
 'use client';
 
-import { memo } from 'react';
-
 import { NavPanelPortal } from '@/features/NavPanel/NavPanelPortal';
 
 import WorkspaceSettingsSideBarContent from './Content';
 
-const SideBar = memo(() => {
+const SideBar = () => {
   return (
     <NavPanelPortal navKey={'workspace-settings'}>
       <WorkspaceSettingsSideBarContent />
     </NavPanelPortal>
   );
-});
+};
 
 export default SideBar;

--- a/src/layout/GlobalProvider/CmdkLazy.tsx
+++ b/src/layout/GlobalProvider/CmdkLazy.tsx
@@ -1,17 +1,15 @@
 'use client';
 
-import { lazy, memo,Suspense } from 'react';
+import { lazy, Suspense } from 'react';
 
 // Lazy load the CommandMenu component with React lazy
 // This splits the CommandMenu code into a separate chunk that only loads when needed
 const CmdkComponent = lazy(() => import('@/features/CommandMenu'));
 
-const CmdkLazy = memo(() => (
+const CmdkLazy = () => (
   <Suspense fallback={null}>
     <CmdkComponent />
   </Suspense>
-));
-
-CmdkLazy.displayName = 'CmdkLazy';
+);
 
 export default CmdkLazy;

--- a/src/routes/(main)/(create)/image/_layout/Sidebar/index.tsx
+++ b/src/routes/(main)/(create)/image/_layout/Sidebar/index.tsx
@@ -1,17 +1,13 @@
 'use client';
 
-import { memo } from 'react';
-
 import { NavPanelPortal } from '@/features/NavPanel/NavPanelPortal';
 
 import ImageSidebarContent from './Content';
 
-const Sidebar = memo(() => (
+const Sidebar = () => (
   <NavPanelPortal navKey="image">
     <ImageSidebarContent />
   </NavPanelPortal>
-));
-
-Sidebar.displayName = 'ImageSidebar';
+);
 
 export default Sidebar;

--- a/src/routes/(main)/(create)/video/_layout/Sidebar/index.tsx
+++ b/src/routes/(main)/(create)/video/_layout/Sidebar/index.tsx
@@ -1,17 +1,13 @@
 'use client';
 
-import { memo } from 'react';
-
 import { NavPanelPortal } from '@/features/NavPanel/NavPanelPortal';
 
 import VideoSidebarContent from './Content';
 
-const Sidebar = memo(() => (
+const Sidebar = () => (
   <NavPanelPortal navKey="video">
     <VideoSidebarContent />
   </NavPanelPortal>
-));
-
-Sidebar.displayName = 'VideoSidebar';
+);
 
 export default Sidebar;

--- a/src/routes/(main)/[workspaceSlug]/settings/index.tsx
+++ b/src/routes/(main)/[workspaceSlug]/settings/index.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { memo } from 'react';
 import { Navigate } from 'react-router';
 
 import { DEFAULT_WORKSPACE_SETTINGS_TAB } from '@/types/workspaceSettings';
 
-const WorkspaceSettingsIndex = memo(() => <Navigate replace to={DEFAULT_WORKSPACE_SETTINGS_TAB} />);
+const WorkspaceSettingsIndex = () => <Navigate replace to={DEFAULT_WORKSPACE_SETTINGS_TAB} />;
 
 export default WorkspaceSettingsIndex;

--- a/src/routes/(main)/agent/(chat)/_layout/HeaderSlot.tsx
+++ b/src/routes/(main)/agent/(chat)/_layout/HeaderSlot.tsx
@@ -21,12 +21,10 @@ const Provider = memo<{ children: ReactNode }>(({ children }) => {
 
 Provider.displayName = 'HeaderSlotProvider';
 
-const Outlet = memo(() => {
+const Outlet = () => {
   const { setEl } = use(HeaderSlotContext);
   return <span ref={setEl} />;
-});
-
-Outlet.displayName = 'HeaderSlotOutlet';
+};
 
 const HeaderSlot = memo<{ children: ReactNode }>(({ children }) => {
   const { el } = use(HeaderSlotContext);

--- a/src/routes/(main)/agent/channel/index.tsx
+++ b/src/routes/(main)/agent/channel/index.tsx
@@ -175,7 +175,7 @@ const ChannelContent = memo(() => {
   );
 });
 
-const ChannelPage = memo(() => {
+const ChannelPage = () => {
   const { aid } = useParams<{ aid?: string }>();
 
   return (
@@ -187,6 +187,6 @@ const ChannelPage = memo(() => {
       <ChannelContent />
     </ResourceConfigAccessGate>
   );
-});
+};
 
 export default ChannelPage;

--- a/src/routes/(main)/agent/docs/[docId]/index.tsx
+++ b/src/routes/(main)/agent/docs/[docId]/index.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { memo, Suspense } from 'react';
+import { Suspense } from 'react';
 import { useParams } from 'react-router';
 
 import SurfaceSkeleton from '@/components/Skeleton/Surface';
 import AgentDocumentPage from '@/features/AgentDocumentPage';
 import { getIdFromIdentifier } from '@/utils/identifier';
 
-const AgentDocumentRoute = memo(() => {
+const AgentDocumentRoute = () => {
   const { docId } = useParams<{ docId: string }>();
   const documentId = getIdFromIdentifier(docId ?? '', 'docs');
 
@@ -17,8 +17,6 @@ const AgentDocumentRoute = memo(() => {
       <AgentDocumentPage documentId={documentId} key={documentId} />
     </Suspense>
   );
-});
-
-AgentDocumentRoute.displayName = 'AgentDocumentRoute';
+};
 
 export default AgentDocumentRoute;

--- a/src/routes/(main)/agent/index.tsx
+++ b/src/routes/(main)/agent/index.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { memo } from 'react';
 
 import Conversation from './features/Conversation';
 import ChatHydration from './features/Conversation/ChatHydration';
 import TelemetryNotification from './features/TelemetryNotification';
 
-const ChatPage = memo(() => {
+const ChatPage = () => {
   return (
     <>
       <ChatHydration />
@@ -21,6 +20,6 @@ const ChatPage = memo(() => {
       <TelemetryNotification mobile={false} />
     </>
   );
-});
+};
 
 export default ChatPage;

--- a/src/routes/(main)/agent/statistics/index.tsx
+++ b/src/routes/(main)/agent/statistics/index.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import { memo, Suspense } from 'react';
+import { Suspense } from 'react';
 
 import SurfaceSkeleton from '@/components/Skeleton/Surface';
 import AgentUsage from '@/features/AgentUsage';
 
-const AgentStatisticsPage = memo(() => (
+const AgentStatisticsPage = () => (
   <Suspense fallback={<SurfaceSkeleton variant={'grid'} />}>
     <AgentUsage />
   </Suspense>
-));
+);
 
 export default AgentStatisticsPage;

--- a/src/routes/(main)/agent/tasks/index.tsx
+++ b/src/routes/(main)/agent/tasks/index.tsx
@@ -1,16 +1,15 @@
 'use client';
 
-import { memo } from 'react';
 import { useParams } from 'react-router';
 
 import { AgentTasksPage } from '@/features/AgentTasks';
 
-const AgentScopedTasksRoute = memo(() => {
+const AgentScopedTasksRoute = () => {
   const { aid } = useParams<{ aid?: string }>();
 
   if (!aid) return null;
 
   return <AgentTasksPage agentId={aid} />;
-});
+};
 
 export default AgentScopedTasksRoute;

--- a/src/routes/(main)/agent/topics/index.tsx
+++ b/src/routes/(main)/agent/topics/index.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import { memo, Suspense } from 'react';
+import { Suspense } from 'react';
 
 import SurfaceSkeleton from '@/components/Skeleton/Surface';
 import AgentTopicManager from '@/features/AgentTopicManager';
 
-const AgentTopicsPage = memo(() => (
+const AgentTopicsPage = () => (
   <Suspense fallback={<SurfaceSkeleton variant={'list'} />}>
     <AgentTopicManager />
   </Suspense>
-));
+);
 
 export default AgentTopicsPage;

--- a/src/routes/(main)/community/(detail)/agent/index.tsx
+++ b/src/routes/(main)/community/(detail)/agent/index.tsx
@@ -49,8 +49,8 @@ const AssistantDetailPage = memo<AssistantDetailPageProps>(({ mobile }) => {
   );
 });
 
-export const MobileDiscoverAssistantDetailPage = memo<{ mobile?: boolean }>(() => {
+export const MobileDiscoverAssistantDetailPage = (_props: { mobile?: boolean }) => {
   return <AssistantDetailPage mobile={true} />;
-});
+};
 
 export default AssistantDetailPage;

--- a/src/routes/(main)/community/(detail)/mcp/index.tsx
+++ b/src/routes/(main)/community/(detail)/mcp/index.tsx
@@ -44,8 +44,8 @@ const McpDetailPage = memo<McpDetailPageProps>(({ mobile }) => {
   );
 });
 
-export const MobileMcpPage = memo<{ mobile?: boolean }>(() => {
+export const MobileMcpPage = (_props: { mobile?: boolean }) => {
   return <McpDetailPage mobile={true} />;
-});
+};
 
 export default McpDetailPage;

--- a/src/routes/(main)/community/(detail)/model/index.tsx
+++ b/src/routes/(main)/community/(detail)/model/index.tsx
@@ -36,8 +36,8 @@ const ModelDetailPage = memo<ModelDetailPageProps>(({ mobile }) => {
   );
 });
 
-export const MobileModelPage = memo<{ mobile?: boolean }>(() => {
+export const MobileModelPage = (_props: { mobile?: boolean }) => {
   return <ModelDetailPage mobile={true} />;
-});
+};
 
 export default ModelDetailPage;

--- a/src/routes/(main)/community/(detail)/organization/index.tsx
+++ b/src/routes/(main)/community/(detail)/organization/index.tsx
@@ -66,8 +66,8 @@ const OrganizationDetailPage = memo<OrganizationDetailPageProps>(({ mobile }) =>
   );
 });
 
-export const MobileOrganizationDetailPage = memo(() => {
+export const MobileOrganizationDetailPage = () => {
   return <OrganizationDetailPage mobile={true} />;
-});
+};
 
 export default OrganizationDetailPage;

--- a/src/routes/(main)/community/(detail)/provider/index.tsx
+++ b/src/routes/(main)/community/(detail)/provider/index.tsx
@@ -36,8 +36,8 @@ const ProviderDetailPage = memo<ProviderDetailPageProps>(({ mobile }) => {
   );
 });
 
-export const MobileProviderPage = memo<{ mobile?: boolean }>(() => {
+export const MobileProviderPage = (_props: { mobile?: boolean }) => {
   return <ProviderDetailPage mobile={true} />;
-});
+};
 
 export default ProviderDetailPage;

--- a/src/routes/(main)/community/(detail)/skill/index.tsx
+++ b/src/routes/(main)/community/(detail)/skill/index.tsx
@@ -66,8 +66,8 @@ const SkillDetailPage = memo<SkillDetailPageProps>(({ mobile }) => {
   );
 });
 
-export const MobileSkillPage = memo<{ mobile?: boolean }>(() => {
+export const MobileSkillPage = (_props: { mobile?: boolean }) => {
   return <SkillDetailPage mobile={true} />;
-});
+};
 
 export default SkillDetailPage;

--- a/src/routes/(main)/community/(detail)/user/index.tsx
+++ b/src/routes/(main)/community/(detail)/user/index.tsx
@@ -131,8 +131,8 @@ const UserDetailPage = memo<UserDetailPageProps>(({ mobile }) => {
   );
 });
 
-export const MobileUserDetailPage = memo(() => {
+export const MobileUserDetailPage = () => {
   return <UserDetailPage mobile={true} />;
-});
+};
 
 export default UserDetailPage;

--- a/src/routes/(main)/community/(detail)/workspace/index.tsx
+++ b/src/routes/(main)/community/(detail)/workspace/index.tsx
@@ -178,8 +178,8 @@ const WorkspaceDetailPage = memo<WorkspaceDetailPageProps>(({ mobile }) => {
   );
 });
 
-export const MobileWorkspaceDetailPage = memo(() => {
+export const MobileWorkspaceDetailPage = () => {
   return <WorkspaceDetailPage mobile={true} />;
-});
+};
 
 export default WorkspaceDetailPage;

--- a/src/routes/(main)/community/_layout/Sidebar/Content.tsx
+++ b/src/routes/(main)/community/_layout/Sidebar/Content.tsx
@@ -1,13 +1,9 @@
-import { memo } from 'react';
-
 import SideBarLayout from '@/features/NavPanel/SideBarLayout';
 
 import Header from './Header';
 
-const Content = memo(() => {
+const Content = () => {
   return <SideBarLayout header={<Header />} />;
-});
-
-Content.displayName = 'DiscoverSidebarContent';
+};
 
 export default Content;

--- a/src/routes/(main)/community/_layout/Sidebar/index.tsx
+++ b/src/routes/(main)/community/_layout/Sidebar/index.tsx
@@ -1,17 +1,13 @@
-import { memo } from 'react';
-
 import { NavPanelPortal } from '@/features/NavPanel/NavPanelPortal';
 
 import Content from './Content';
 
-const Sidebar = memo(() => {
+const Sidebar = () => {
   return (
     <NavPanelPortal navKey="discover">
       <Content />
     </NavPanelPortal>
   );
-});
-
-Sidebar.displayName = 'DisocverSidebar';
+};
 
 export default Sidebar;

--- a/src/routes/(main)/eval/_layout/Sidebar/Content.tsx
+++ b/src/routes/(main)/eval/_layout/Sidebar/Content.tsx
@@ -1,14 +1,10 @@
 'use client';
 
-import { memo } from 'react';
-
 import SideBarLayout from '@/features/NavPanel/SideBarLayout';
 
 import Body from './Body';
 import Header from './Header';
 
-const EvalSidebarContent = memo(() => <SideBarLayout body={<Body />} header={<Header />} />);
-
-EvalSidebarContent.displayName = 'EvalSidebarContent';
+const EvalSidebarContent = () => <SideBarLayout body={<Body />} header={<Header />} />;
 
 export default EvalSidebarContent;

--- a/src/routes/(main)/eval/_layout/Sidebar/index.tsx
+++ b/src/routes/(main)/eval/_layout/Sidebar/index.tsx
@@ -1,17 +1,13 @@
 'use client';
 
-import { memo } from 'react';
-
 import { NavPanelPortal } from '@/features/NavPanel/NavPanelPortal';
 
 import EvalSidebarContent from './Content';
 
-const Sidebar = memo(() => (
+const Sidebar = () => (
   <NavPanelPortal navKey="eval">
     <EvalSidebarContent />
   </NavPanelPortal>
-));
-
-Sidebar.displayName = 'EvalSidebar';
+);
 
 export default Sidebar;

--- a/src/routes/(main)/eval/bench/[benchmarkId]/_layout/Sidebar/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/_layout/Sidebar/index.tsx
@@ -1,21 +1,17 @@
 'use client';
 
-import { memo } from 'react';
-
 import { NavPanelPortal } from '@/features/NavPanel/NavPanelPortal';
 import SideBarLayout from '@/features/NavPanel/SideBarLayout';
 
 import Body from './Body';
 import Header from './Header';
 
-const Sidebar = memo(() => {
+const Sidebar = () => {
   return (
     <NavPanelPortal navKey="evalBench">
       <SideBarLayout body={<Body />} header={<Header />} />
     </NavPanelPortal>
   );
-});
-
-Sidebar.displayName = 'BenchSidebar';
+};
 
 export default Sidebar;

--- a/src/routes/(main)/group/_layout/Sidebar/Body.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Body.tsx
@@ -1,5 +1,4 @@
 import { Accordion, Flexbox } from '@lobehub/ui';
-import React, { memo } from 'react';
 
 import Members from './Members';
 import Topic from './Topic';
@@ -9,7 +8,7 @@ export enum ChatSidebarKey {
   Topic = 'topic',
 }
 
-const Body = memo(() => {
+const Body = () => {
   return (
     <Flexbox paddingInline={4}>
       <Accordion defaultExpandedKeys={[ChatSidebarKey.Members, ChatSidebarKey.Topic]} gap={8}>
@@ -18,6 +17,6 @@ const Body = memo(() => {
       </Accordion>
     </Flexbox>
   );
-});
+};
 
 export default Body;

--- a/src/routes/(main)/group/_layout/Sidebar/Content.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Content.tsx
@@ -1,14 +1,10 @@
-import React, { memo } from 'react';
-
 import SideBarLayout from '@/features/NavPanel/SideBarLayout';
 
 import Body from './Body';
 import Header from './Header';
 
-const GroupSidebarContent = memo(() => {
+const GroupSidebarContent = () => {
   return <SideBarLayout body={<Body />} header={<Header />} />;
-});
-
-GroupSidebarContent.displayName = 'GroupSidebarContent';
+};
 
 export default GroupSidebarContent;

--- a/src/routes/(main)/group/_layout/Sidebar/Header/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Header/index.tsx
@@ -1,20 +1,19 @@
 'use client';
 
 import { type PropsWithChildren } from 'react';
-import { memo } from 'react';
 
 import SideBarHeaderLayout from '@/features/NavPanel/SideBarHeaderLayout';
 
 import Agent from './Agent';
 import Nav from './Nav';
 
-const HeaderInfo = memo<PropsWithChildren>(() => {
+const HeaderInfo = (_props: PropsWithChildren) => {
   return (
     <>
       <SideBarHeaderLayout left={<Agent />} />
       <Nav />
     </>
   );
-});
+};
 
 export default HeaderInfo;

--- a/src/routes/(main)/group/_layout/Sidebar/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/index.tsx
@@ -1,17 +1,13 @@
-import React, { memo } from 'react';
-
 import { NavPanelPortal } from '@/features/NavPanel/NavPanelPortal';
 
 import GroupSidebarContent from './Content';
 
-const Sidebar = memo(() => {
+const Sidebar = () => {
   return (
     <NavPanelPortal navKey="group">
       <GroupSidebarContent />
     </NavPanelPortal>
   );
-});
-
-Sidebar.displayName = 'ChatSidebar';
+};
 
 export default Sidebar;

--- a/src/routes/(main)/memory/(home)/features/Persona/PersonaHeader.tsx
+++ b/src/routes/(main)/memory/(home)/features/Persona/PersonaHeader.tsx
@@ -1,6 +1,5 @@
 import { Text } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
-import { memo } from 'react';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   title: css`
@@ -11,12 +10,12 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
-const PersonaHeader = memo(() => {
+const PersonaHeader = () => {
   return (
     <Text as={'h1'} className={styles.title}>
       Persona
     </Text>
   );
-});
+};
 
 export default PersonaHeader;

--- a/src/routes/(main)/memory/(home)/features/RoleTagCloud/TagCloudCanvas.tsx
+++ b/src/routes/(main)/memory/(home)/features/RoleTagCloud/TagCloudCanvas.tsx
@@ -267,7 +267,7 @@ const ConnectionLine = memo<ConnectionLineProps>(
   },
 );
 
-const CenterAvatar = memo(() => {
+const CenterAvatar = () => {
   return (
     <Html
       center
@@ -280,7 +280,7 @@ const CenterAvatar = memo(() => {
       <UserAvatar shape={'circle'} size={80} />
     </Html>
   );
-});
+};
 
 interface CloudProps {
   radius?: number;

--- a/src/routes/(main)/memory/_layout/Sidebar/Content.tsx
+++ b/src/routes/(main)/memory/_layout/Sidebar/Content.tsx
@@ -1,11 +1,7 @@
-import { memo } from 'react';
-
 import SideBarLayout from '@/features/NavPanel/SideBarLayout';
 
 import Header from './Header';
 
-const MemorySidebarContent = memo(() => <SideBarLayout header={<Header />} />);
-
-MemorySidebarContent.displayName = 'MemorySidebarContent';
+const MemorySidebarContent = () => <SideBarLayout header={<Header />} />;
 
 export default MemorySidebarContent;

--- a/src/routes/(main)/memory/_layout/Sidebar/index.tsx
+++ b/src/routes/(main)/memory/_layout/Sidebar/index.tsx
@@ -1,15 +1,11 @@
-import React, { memo } from 'react';
-
 import { NavPanelPortal } from '@/features/NavPanel/NavPanelPortal';
 
 import MemorySidebarContent from './Content';
 
-const Sidebar = memo(() => (
+const Sidebar = () => (
   <NavPanelPortal navKey="memory">
     <MemorySidebarContent />
   </NavPanelPortal>
-));
-
-Sidebar.displayName = 'MemorySidebar';
+);
 
 export default Sidebar;

--- a/src/routes/(main)/page/index.tsx
+++ b/src/routes/(main)/page/index.tsx
@@ -1,18 +1,16 @@
 'use client';
 
-import { memo, Suspense } from 'react';
+import { Suspense } from 'react';
 
 import SurfaceSkeleton from '@/components/Skeleton/Surface';
 import PageExplorerPlaceholder from '@/features/PageExplorer/PageExplorerPlaceholder';
 
-const PagesPage = memo(() => {
+const PagesPage = () => {
   return (
     <Suspense fallback={<SurfaceSkeleton variant={'editor'} />}>
       <PageExplorerPlaceholder />
     </Suspense>
   );
-});
-
-PagesPage.displayName = 'PagesPage';
+};
 
 export default PagesPage;

--- a/src/routes/(main)/task/[taskId]/index.tsx
+++ b/src/routes/(main)/task/[taskId]/index.tsx
@@ -1,16 +1,15 @@
 'use client';
 
-import { memo } from 'react';
 import { useParams } from 'react-router';
 
 import { TaskDetailPage } from '@/features/AgentTasks';
 
-const TaskDetailRoute = memo(() => {
+const TaskDetailRoute = () => {
   const { taskId } = useParams<{ taskId?: string }>();
 
   if (!taskId) return null;
 
   return <TaskDetailPage taskId={taskId} />;
-});
+};
 
 export default TaskDetailRoute;

--- a/src/routes/(mobile)/me/(home)/index.tsx
+++ b/src/routes/(mobile)/me/(home)/index.tsx
@@ -1,14 +1,13 @@
 'use client';
 
 import { Center } from '@lobehub/ui';
-import { memo } from 'react';
 
 import BrandWatermark from '@/components/BrandWatermark';
 
 import Category from './features/Category';
 import UserBanner from './features/UserBanner';
 
-const MeHomePage = memo(() => {
+const MeHomePage = () => {
   return (
     <>
       <UserBanner />
@@ -18,8 +17,6 @@ const MeHomePage = memo(() => {
       </Center>
     </>
   );
-});
-
-MeHomePage.displayName = 'MeHomePage';
+};
 
 export default MeHomePage;

--- a/src/routes/(mobile)/me/(home)/layout.tsx
+++ b/src/routes/(mobile)/me/(home)/layout.tsx
@@ -1,16 +1,15 @@
-import { memo } from 'react';
 import { Outlet } from 'react-router';
 
 import MobileContentLayout from '@/components/server/MobileNavLayout';
 
 import Header from './features/Header';
 
-const Layout = memo(() => {
+const Layout = () => {
   return (
     <MobileContentLayout withNav header={<Header />}>
       <Outlet />
     </MobileContentLayout>
   );
-});
+};
 
 export default Layout;

--- a/src/routes/(mobile)/me/profile/index.tsx
+++ b/src/routes/(mobile)/me/profile/index.tsx
@@ -1,13 +1,9 @@
 'use client';
 
-import { memo } from 'react';
-
 import Category from './features/Category';
 
-const MeProfilePage = memo(() => {
+const MeProfilePage = () => {
   return <Category />;
-});
-
-MeProfilePage.displayName = 'MeProfilePage';
+};
 
 export default MeProfilePage;

--- a/src/routes/(mobile)/me/profile/layout.tsx
+++ b/src/routes/(mobile)/me/profile/layout.tsx
@@ -1,16 +1,15 @@
-import { memo } from 'react';
 import { Outlet } from 'react-router';
 
 import MobileContentLayout from '@/components/server/MobileNavLayout';
 
 import Header from './features/Header';
 
-const Layout = memo(() => {
+const Layout = () => {
   return (
     <MobileContentLayout header={<Header />}>
       <Outlet />
     </MobileContentLayout>
   );
-});
+};
 
 export default Layout;

--- a/src/routes/(mobile)/me/settings/index.tsx
+++ b/src/routes/(mobile)/me/settings/index.tsx
@@ -1,13 +1,9 @@
 'use client';
 
-import { memo } from 'react';
-
 import Category from './features/Category';
 
-const MeSettingsPage = memo(() => {
+const MeSettingsPage = () => {
   return <Category />;
-});
-
-MeSettingsPage.displayName = 'MeSettingsPage';
+};
 
 export default MeSettingsPage;

--- a/src/routes/(mobile)/me/settings/layout.tsx
+++ b/src/routes/(mobile)/me/settings/layout.tsx
@@ -1,16 +1,15 @@
-import { memo } from 'react';
 import { Outlet } from 'react-router';
 
 import MobileContentLayout from '@/components/server/MobileNavLayout';
 
 import Header from './features/Header';
 
-const Layout = memo(() => {
+const Layout = () => {
   return (
     <MobileContentLayout withNav header={<Header />}>
       <Outlet />
     </MobileContentLayout>
   );
-});
+};
 
 export default Layout;

--- a/src/routes/(mobile)/settings/_layout/index.tsx
+++ b/src/routes/(mobile)/settings/_layout/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { memo } from 'react';
 import { Outlet } from 'react-router';
 
 import MobileContentLayout from '@/components/server/MobileNavLayout';
@@ -8,7 +7,7 @@ import SettingsContextProvider from '@/features/Settings/Layout/ContextProvider'
 
 import Header from './Header';
 
-const MobileSettingsWrapper = memo(() => {
+const MobileSettingsWrapper = () => {
   return (
     <SettingsContextProvider
       value={{
@@ -21,8 +20,6 @@ const MobileSettingsWrapper = memo(() => {
       </MobileContentLayout>
     </SettingsContextProvider>
   );
-});
-
-MobileSettingsWrapper.displayName = 'MobileSettingsWrapper';
+};
 
 export default MobileSettingsWrapper;


### PR DESCRIPTION
## Summary

- remove ineffective `memo` boundaries from small, prop-free presentation components
- move parameter and history-save state into their owning form components
- remove memoization from children that always receive new JSX or callback props

## Impact

This reduces unnecessary memo comparators and memo wrapper retention without changing user-visible behavior. Meaningful memo boundaries for stable props and expensive subtrees remain unchanged.

## Test

- [x] `bun run check --lint --test` on the repaired public component APIs
- [x] `git diff --check`
- [ ] `bun run check --type` (blocked by pre-existing duplicate `drizzle-orm` type identities in unmodified server paths)

## Related Issue

N/A
