### PR TITLE
💄 style: show visible ellipsis actions trigger on agent view-all list

### DIFF
--- a/src/features/AgentViewAll/AgentCard.tsx
+++ b/src/features/AgentViewAll/AgentCard.tsx
@@ -144,10 +144,10 @@ const AgentCard = memo<AgentCardProps>(
                   e.stopPropagation();
                 }}
               >
-                {/* Headless: the card's context menu is the only actions entry
-                    (the sidebar toggle folds into it via includeSidebarToggle). */}
+                {/* Visible "…" trigger AND right-click open the same menu — the
+                    context menu alone proved undiscoverable (the sidebar toggle
+                    folds into it via includeSidebarToggle). */}
                 <ItemActions
-                  hideTrigger
                   includeSidebarToggle
                   anchor={anchor}
                   forceActivated={menuActivated}

--- a/src/features/AgentViewAll/AgentCard.tsx
+++ b/src/features/AgentViewAll/AgentCard.tsx
@@ -72,10 +72,25 @@ export const cardStyles = createStaticStyles(({ css, cssVar }) => ({
       grid-template-columns: minmax(0, 1fr);
     }
   `,
+  /* Top-right "…" slot, a SIBLING of the card link (absolutely positioned
+     over it) — nesting an interactive menu trigger inside the <a> would put
+     a button inside a link in the accessibility tree. Aligned with the
+     card's 12px padding so it sits where the header row used to hold it. */
+  actions: css`
+    position: absolute;
+    inset-block-start: 12px;
+    inset-inline-end: 12px;
+  `,
   link: css`
     display: block;
     min-width: 0;
+    height: 100%;
     color: inherit;
+  `,
+  wrapper: css`
+    position: relative;
+    min-width: 0;
+    height: 100%;
   `,
   updatedAt: css`
     flex: none;
@@ -116,84 +131,88 @@ const AgentCard = memo<AgentCardProps>(
 
     return (
       <ContextMenuTrigger items={getContextMenuItems}>
-        <WorkspaceLink
-          aria-label={displayTitle}
-          className={cardStyles.link}
-          ref={setAnchor}
-          to={type === 'group' ? GROUP_CHAT_URL(id) : AGENT_CHAT_URL(id, false)}
-          onPointerEnter={activateMenu}
-        >
-          <Block clickable className={cardStyles.card} height={'100%'} variant={'outlined'}>
-            <Flexbox horizontal align={'center'} gap={8} style={{ minWidth: 0 }}>
-              <AgentAvatar item={item} size={24} />
-              <Flexbox horizontal align={'center'} flex={1} gap={6} style={{ minWidth: 0 }}>
-                <Text ellipsis style={{ minWidth: 0 }} weight={600}>
-                  {displayTitle}
-                </Text>
-                {roleTag ? (
-                  <Tag size={'small'} style={{ flex: 'none' }}>
-                    {roleTag}
-                  </Tag>
-                ) : null}
-              </Flexbox>
+        <div className={cardStyles.wrapper}>
+          <WorkspaceLink
+            aria-label={displayTitle}
+            className={cardStyles.link}
+            ref={setAnchor}
+            to={type === 'group' ? GROUP_CHAT_URL(id) : AGENT_CHAT_URL(id, false)}
+            onPointerEnter={activateMenu}
+          >
+            <Block clickable className={cardStyles.card} height={'100%'} variant={'outlined'}>
+              {/* Right padding reserves the header slot the absolutely
+                  positioned "…" sibling overlays. */}
               <Flexbox
-                flex={'none'}
-                onClick={(e) => {
-                  // Keep the menu from following the card link.
-                  e.preventDefault();
-                  e.stopPropagation();
-                }}
+                horizontal
+                align={'center'}
+                gap={8}
+                style={{ minWidth: 0, paddingInlineEnd: 28 }}
               >
-                {/* Visible "…" trigger AND right-click open the same menu — the
-                    context menu alone proved undiscoverable (the sidebar toggle
-                    folds into it via includeSidebarToggle). */}
-                <ItemActions
-                  includeSidebarToggle
-                  anchor={anchor}
-                  forceActivated={menuActivated}
-                  item={item}
-                  sidebarHidden={sidebarHidden}
-                  onMenuReady={handleMenuReady}
-                  onToggleSidebar={onToggleSidebar}
-                />
-              </Flexbox>
-            </Flexbox>
-            <Text className={cardStyles.description} fontSize={12} type={'secondary'}>
-              {description}
-            </Text>
-            {item.labels?.length ? (
-              <Flexbox horizontal align={'center'} gap={6} wrap={'wrap'}>
-                <LabelTags labels={item.labels} />
-              </Flexbox>
-            ) : null}
-            <Flexbox
-              horizontal
-              align={'center'}
-              gap={8}
-              justify={'space-between'}
-              style={{ marginBlockStart: 'auto' }}
-            >
-              {showAuthor ? (
-                <Flexbox horizontal align={'center'} gap={6} style={{ minWidth: 0 }}>
-                  {author ? (
-                    <Tooltip title={author.name}>
-                      <Avatar avatar={author.avatar || DEFAULT_AVATAR} size={18} />
-                    </Tooltip>
-                  ) : (
-                    <Text fontSize={12} type={'secondary'}>
-                      –
-                    </Text>
-                  )}
+                <AgentAvatar item={item} size={24} />
+                <Flexbox horizontal align={'center'} flex={1} gap={6} style={{ minWidth: 0 }}>
+                  <Text ellipsis style={{ minWidth: 0 }} weight={600}>
+                    {displayTitle}
+                  </Text>
+                  {roleTag ? (
+                    <Tag size={'small'} style={{ flex: 'none' }}>
+                      {roleTag}
+                    </Tag>
+                  ) : null}
                 </Flexbox>
-              ) : (
-                <div />
-              )}
-              <Text className={cardStyles.updatedAt} fontSize={12}>
-                {updatedAt ? formatUpdatedAt(updatedAt) : '–'}
+              </Flexbox>
+              <Text className={cardStyles.description} fontSize={12} type={'secondary'}>
+                {description}
               </Text>
-            </Flexbox>
-          </Block>
-        </WorkspaceLink>
+              {item.labels?.length ? (
+                <Flexbox horizontal align={'center'} gap={6} wrap={'wrap'}>
+                  <LabelTags labels={item.labels} />
+                </Flexbox>
+              ) : null}
+              <Flexbox
+                horizontal
+                align={'center'}
+                gap={8}
+                justify={'space-between'}
+                style={{ marginBlockStart: 'auto' }}
+              >
+                {showAuthor ? (
+                  <Flexbox horizontal align={'center'} gap={6} style={{ minWidth: 0 }}>
+                    {author ? (
+                      <Tooltip title={author.name}>
+                        <Avatar avatar={author.avatar || DEFAULT_AVATAR} size={18} />
+                      </Tooltip>
+                    ) : (
+                      <Text fontSize={12} type={'secondary'}>
+                        –
+                      </Text>
+                    )}
+                  </Flexbox>
+                ) : (
+                  <div />
+                )}
+                <Text className={cardStyles.updatedAt} fontSize={12}>
+                  {updatedAt ? formatUpdatedAt(updatedAt) : '–'}
+                </Text>
+              </Flexbox>
+            </Block>
+          </WorkspaceLink>
+          <span className={cardStyles.actions}>
+            {/* Visible "…" trigger AND right-click open the same menu — the
+                context menu alone proved undiscoverable (the sidebar toggle
+                folds into it via includeSidebarToggle). Rendered as a SIBLING
+                of the link (not inside it) so the menu button isn't a nested
+                interactive control within the card's <a>. */}
+            <ItemActions
+              includeSidebarToggle
+              anchor={anchor}
+              forceActivated={menuActivated}
+              item={item}
+              sidebarHidden={sidebarHidden}
+              onMenuReady={handleMenuReady}
+              onToggleSidebar={onToggleSidebar}
+            />
+          </span>
+        </div>
       </ContextMenuTrigger>
     );
   },

--- a/src/features/AgentViewAll/AgentRow.tsx
+++ b/src/features/AgentViewAll/AgentRow.tsx
@@ -25,8 +25,8 @@ import AgentAvatar from './AgentAvatar';
 import ItemActions from './ItemActions';
 import LabelTags from './LabelTags';
 
-/** Fixed action-column width (sidebar-eye toggle only) so rows stay aligned. */
-export const ACTION_COL_WIDTH = 40;
+/** Fixed action-column width (sidebar-eye toggle + "…" menu) so rows stay aligned. */
+export const ACTION_COL_WIDTH = 64;
 
 /** Author avatar slot — reserved even when the author is unknown. */
 const AUTHOR_COL_WIDTH = 20;
@@ -218,12 +218,11 @@ const AgentRow = memo<AgentRowProps>(
                 onClick={handleToggleSidebar}
               />
             )}
-            {/* Headless: the row's context menu is the only actions entry. It
-              carries the sidebar toggle too — the eye icon above is a fast
-              single-click path, but right-click is where users look for the
-              row's actions, and the toggle went missing there. */}
+            {/* Visible "…" trigger AND right-click open the same menu — the
+              context menu alone proved undiscoverable (users assumed rows had
+              no actions). The menu carries the sidebar toggle too; the eye
+              icon stays as the fast single-click path. */}
             <ItemActions
-              hideTrigger
               anchor={anchor}
               forceActivated={menuActivated}
               includeSidebarToggle={Boolean(onToggleSidebar)}

--- a/src/features/AgentViewAll/ItemActions.tsx
+++ b/src/features/AgentViewAll/ItemActions.tsx
@@ -233,7 +233,10 @@ const ItemActions = memo<ItemActionsProps>((props) => {
         )
       ) : props.hideTrigger ? null : (
         <span onFocus={activateFromFocus} onPointerEnter={activate}>
-          <ActionIcon icon={EllipsisIcon} size={'small'} title={t('more')} />
+          {/* Explicit aria-label: outside a popup trigger, ActionIcon does not
+              derive one from `title`, leaving the focusable placeholder
+              unnamed for screen readers until the real trigger mounts. */}
+          <ActionIcon aria-label={t('more')} icon={EllipsisIcon} size={'small'} title={t('more')} />
         </span>
       )}
     </span>

--- a/src/features/AgentViewAll/ItemActions.tsx
+++ b/src/features/AgentViewAll/ItemActions.tsx
@@ -120,7 +120,7 @@ const ActionsDropdown = memo<ActionsDropdownProps>(
 
     return (
       <DropdownMenu items={items}>
-        <ActionIcon icon={EllipsisIcon} size={'small'} />
+        <ActionIcon icon={EllipsisIcon} size={'small'} title={t('more')} />
       </DropdownMenu>
     );
   },
@@ -204,6 +204,7 @@ GroupItemActions.displayName = 'GroupItemActions';
  * so the real menu is mounted by the time it is needed.
  */
 const ItemActions = memo<ItemActionsProps>((props) => {
+  const { t } = useTranslation('common');
   const [selfActivated, setSelfActivated] = useState(false);
   const activated = selfActivated || props.forceActivated;
   const containerRef = useRef<HTMLSpanElement>(null);
@@ -232,7 +233,7 @@ const ItemActions = memo<ItemActionsProps>((props) => {
         )
       ) : props.hideTrigger ? null : (
         <span onFocus={activateFromFocus} onPointerEnter={activate}>
-          <ActionIcon icon={EllipsisIcon} size={'small'} />
+          <ActionIcon icon={EllipsisIcon} size={'small'} title={t('more')} />
         </span>
       )}
     </span>


### PR DESCRIPTION
The agent view-all list only exposed row/card actions through the right-click context menu, which users don't discover — rows read as having no operations. This shows the existing "…" dropdown trigger (already implemented in `ItemActions`, previously mounted headless) on list rows and cards; right-click keeps working and opens the same menu.

- `AgentRow`: drop `hideTrigger`, widen the fixed action column (40 → 64) for eye toggle + "…".
- `AgentCard`: drop `hideTrigger` — the slot and link-click guards were already in place.
- `SidebarAgentsSection` mini-cards intentionally stay right-click-only (deliberately minimal block; enabling there needs extra link-click guards).

#### Test

- [x] No tests needed (one-prop UI affordance change; menu logic unchanged and already covered)