### PR TITLE
✅ test: repair terminal panel tests after cross-PR semantic conflict

### DIFF
--- a/src/features/ChatTerminal/index.test.tsx
+++ b/src/features/ChatTerminal/index.test.tsx
@@ -24,6 +24,12 @@ vi.mock('./Content', () => ({
   default: () => <div data-testid="terminal-content" />,
 }));
 
+// The panel registers its toggle hotkey on mount; the real hook reaches into
+// user/server-config stores that this store-level test doesn't provide.
+vi.mock('@/hooks/useHotkeys', () => ({
+  useToggleTerminalPanelHotkey: vi.fn(),
+}));
+
 const setShow = (showTerminalPanel: boolean) =>
   act(() => {
     useGlobalStore.setState({

--- a/src/hooks/useHotkeys/chatScope.test.ts
+++ b/src/hooks/useHotkeys/chatScope.test.ts
@@ -24,9 +24,9 @@ vi.mock('@/store/global', () => ({
 }));
 
 vi.mock('./useHotkeyById', () => ({
-  useHotkeyById: (id: HotkeyId, callback: () => void) => {
+  useHotkeyById: (id: HotkeyId, callback: () => void, options?: unknown) => {
     mocks.hotkeyCallback = callback;
-    mocks.useHotkeyById(id, callback);
+    mocks.useHotkeyById(id, callback, options);
     return { id };
   },
 }));

--- a/src/routes/(main)/agent/features/Conversation/Header/TerminalPanelToggle/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/TerminalPanelToggle/index.test.tsx
@@ -66,7 +66,9 @@ describe('TerminalPanelToggle', () => {
     expect(mocks.toggleTerminalPanel).toHaveBeenCalledWith();
 
     mocks.showTerminalPanel = true;
-    rerender(<TerminalPanelToggle />);
+    // Key change forces a remount: the component is memoized and the mocked
+    // store is not reactive, so a plain rerender would be skipped by memo.
+    rerender(<TerminalPanelToggle key={'after-toggle'} />);
 
     expect(screen.getByTestId('terminal-panel-toggle')).toHaveAttribute('data-active', 'true');
   });


### PR DESCRIPTION
Canary CI (Test App / Test Web App) has been red since #18193 merged: its tests were written against a pre-#18162 tree, and the two PRs merged around the same time without a combined CI run. Every open PR now inherits the failures. Test-only fixes:

- `chatScope.test.ts`: the `useHotkeyById` mock forwarded only `(id, callback)` to the spy while the assertion expects the options object — forward `options` through.
- `ChatTerminal/index.test.tsx`: `ChatTerminalPanel` now registers the toggle hotkey on mount (#18193), and the real hook reads user/server-config stores this store-level test doesn't provide — mock `@/hooks/useHotkeys`.
- `TerminalPanelToggle/index.test.tsx`: the component is memoized and the mocked store is not reactive, so the post-toggle `rerender` was skipped by `memo` and `data-active` never updated — force a remount via `key`.

No production code changes.

#### Test

- [x] All three files pass locally (5 tests)