### PR TITLE
🐛 fix(desktop): handle mouse navigation commands

### DIFF
--- a/apps/desktop/src/main/core/browser/Browser.ts
+++ b/apps/desktop/src/main/core/browser/Browser.ts
@@ -271,9 +271,25 @@ export default class Browser {
     this.setupCloseListener(browserWindow);
     this.setupFocusListener(browserWindow);
     this.setupFullscreenListener(browserWindow);
+    this.setupAppCommandListener(browserWindow);
     this.setupTopLevelNavigationListener(browserWindow);
     this.setupWillPreventUnloadListener(browserWindow);
     this.setupContextMenu(browserWindow);
+  }
+
+  private setupAppCommandListener(browserWindow: BrowserWindow): void {
+    logger.debug(`[${this.identifier}] Setting up app command listener.`);
+
+    browserWindow.on('app-command', (_event, command) => {
+      if (command === 'browser-backward') {
+        this.broadcast('historyGoBack');
+        return;
+      }
+
+      if (command === 'browser-forward') {
+        this.broadcast('historyGoForward');
+      }
+    });
   }
 
   private setupTopLevelNavigationListener(browserWindow: BrowserWindow): void {

--- a/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
@@ -885,6 +885,23 @@ describe('Browser', () => {
     });
   });
 
+  describe('app command navigation handling', () => {
+    it.each([
+      ['browser-backward', 'historyGoBack'],
+      ['browser-forward', 'historyGoForward'],
+    ])('should broadcast %s as %s', (command, channel) => {
+      const handler = mockBrowserWindow.on.mock.calls.find(
+        (call) => call[0] === 'app-command',
+      )?.[1];
+
+      expect(handler).toBeDefined();
+
+      handler?.({}, command);
+
+      expect(mockBrowserWindow.webContents.send).toHaveBeenCalledWith(channel, undefined);
+    });
+  });
+
   describe('top-level navigation handling', () => {
     let willNavigateHandler: (event: any, url: string) => void;
 


### PR DESCRIPTION
## Changes

- Handle Electron `browser-backward` and `browser-forward` app commands.
- Route mouse navigation through the existing `historyGoBack` and `historyGoForward` broadcasts so the active tab's React Router history is used.
- Add regression coverage for both mouse navigation commands.

| Before | After |
| ------ | ----- |
| Pressing a mouse navigation side button could leave the Electron window on a black screen. | Mouse back and forward commands navigate the active SPA tab history. |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Passed:

```bash
cd apps/desktop
bunx vitest run --silent='passed-only' 'src/main/core/browser/__tests__/Browser.test.ts'

bun run check apps/desktop/src/main/core/browser/Browser.ts apps/desktop/src/main/core/browser/__tests__/Browser.test.ts --lint --test
```

- 57 desktop Browser tests passed.
- Repository check reported 2 files lint-clean and 57 related tests passed.
- Windows mouse hardware verification is still pending.
- Full type-check is left to CI because the isolated worktree reused an older local dependency tree that does not contain the latest canary workspace links.

#### 🔗 Related Issue

Fixes #18202