### PR TITLE
🐛 fix(home): prevent create Agent modal from closing on outside click

### DIFF
--- a/src/features/HomeSidebar/hooks/useCreateModal.test.tsx
+++ b/src/features/HomeSidebar/hooks/useCreateModal.test.tsx
@@ -735,7 +735,7 @@ describe('CreateAgentModal analytics', () => {
 });
 
 describe('openCreateAgentModal', () => {
-  it('reports the close through onOpenChangeComplete, not onOpenChange', () => {
+  it('prevents outside dismissal and reports close through onOpenChangeComplete', () => {
     // Regression: the in-content close and the post-create path both call the
     // instance's `close()`, which never fires `onOpenChange`. Wiring the
     // provider's `createModalOpen` reset to that callback left it stuck true,
@@ -757,6 +757,7 @@ describe('openCreateAgentModal', () => {
     });
 
     const props = vi.mocked(createModal).mock.calls.at(-1)![0] as Record<string, any>;
+    expect(props.maskClosable).toBe(false);
     expect(props.onOpenChange).toBeUndefined();
     expect(typeof props.onOpenChangeComplete).toBe('function');
 

--- a/src/features/HomeSidebar/hooks/useCreateModal.tsx
+++ b/src/features/HomeSidebar/hooks/useCreateModal.tsx
@@ -640,6 +640,7 @@ export const openCreateAgentModal = ({
       />
     ),
     footer: null,
+    maskClosable: false,
     // NOT `onOpenChange`: that only fires for user dismissal (Escape, backdrop,
     // the header close button). `instance.close()` — which the in-content close
     // and the post-create path both call — just flips the stack entry, so the


### PR DESCRIPTION
Prevent the Home Create Agent modal from being dismissed by accidental backdrop clicks, preserving the user's in-progress creation flow.

| Before | After |
| ------ | ----- |
| Clicking the backdrop closes the Create Agent modal. | Clicking the backdrop keeps the Create Agent modal open. |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bunx vitest run --silent='passed-only' 'src/features/HomeSidebar/hooks/useCreateModal.test.tsx'`
- `bun run check src/features/HomeSidebar/hooks/useCreateModal.tsx src/features/HomeSidebar/hooks/useCreateModal.test.tsx --lint --test`
- `bun run type-check`

Automated regression coverage is included. Manual Windows Electron verification and Before/After media are pending while this PR is in draft.

#### 🔗 Related Issue

Fixes #18201
