### PR TITLE
🐛 fix(chat): prevent tool titles from clipping

### DIFF
--- a/packages/shared-tool-ui/src/components/FilePathDisplay.tsx
+++ b/packages/shared-tool-ui/src/components/FilePathDisplay.tsx
@@ -11,10 +11,8 @@ const styles = createStaticStyles(({ css }) => ({
     margin-inline-end: 4px;
   `,
   text: css`
-    overflow: hidden;
+    padding-block: 1px;
     color: ${cssVar.colorText};
-    text-overflow: ellipsis;
-    white-space: nowrap;
   `,
 }));
 

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ToolTitle.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ToolTitle.tsx
@@ -34,6 +34,8 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 1;
 
+    padding-block: 1px;
+
     color: ${cssVar.colorTextDescription};
   `,
 }));

--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
@@ -469,7 +469,6 @@ const WorkflowCollapse = memo<WorkflowCollapseProps>(
             style={{
               minHeight: WORKFLOW_STREAMING_TITLE_MIN_HEIGHT_PX,
               minWidth: 0,
-              overflow: 'hidden',
             }}
           >
             <div style={{ minWidth: 0, overflow: 'hidden' }}>
@@ -491,6 +490,7 @@ const WorkflowCollapse = memo<WorkflowCollapseProps>(
                     style={{
                       color: pendingInterventionPresent ? cssVar.colorInfo : undefined,
                       overflow: 'hidden',
+                      paddingBlock: 1,
                       textOverflow: 'ellipsis',
                       whiteSpace: 'nowrap',
                     }}
@@ -508,12 +508,13 @@ const WorkflowCollapse = memo<WorkflowCollapseProps>(
             )}
           </Flexbox>
         ) : (
-          <Flexbox horizontal align="center" gap={6} style={{ minWidth: 0, overflow: 'hidden' }}>
+          <Flexbox horizontal align="center" gap={6} style={{ minWidth: 0 }}>
             <Text
               type="secondary"
               style={{
                 minWidth: 0,
                 overflow: 'hidden',
+                paddingBlock: 1,
                 textOverflow: 'ellipsis',
                 whiteSpace: 'nowrap',
               }}


### PR DESCRIPTION
<!-- Brief and heads-up -->

Prevent tool file paths and workflow titles from being visually clipped, while retaining ellipsis behavior for normal workflow status text.

| Before | After |
| ------ | ----- |
| Tool titles could be clipped vertically or horizontally. | Titles have enough vertical room and file paths can wrap when needed. |

#### Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

`bun` is not installed in this environment, so `bun run check --lint` could not run. The commit hook completed stylelint, ESLint, and Prettier successfully.

#### 🔗 Related Issue

<!-- No matching issue found. -->