### PR TITLE
⚡️ perf(desktop): prewarm local database after navigation

### DIFF
--- a/apps/desktop/src/main/core/App.ts
+++ b/apps/desktop/src/main/core/App.ts
@@ -25,6 +25,7 @@ import {
 import { generateCliWrapper, getCliWrapperDir } from '@/modules/cliEmbedding';
 import { ScreenCaptureManager } from '@/modules/screenCapture/ScreenCaptureManager';
 import type { IServiceModule, ServiceLifecycle, ServiceModule } from '@/services';
+import LocalDatabaseService from '@/services/LocalDatabaseSrv';
 import { createLogger } from '@/utils/logger';
 import * as electronIs from '@/utils/platform';
 import { refreshShellPath } from '@/utils/shellPath';
@@ -251,6 +252,7 @@ export class App {
     // native menus, local-file services, tray and updater initialization.
     await this.makeAppReady();
     await this.browserManager.initializeBrowsers();
+    this.prewarmLocalDatabaseAfterNavigation();
     await this.runControllerHooks('afterAppReady');
 
     const initializeNativeShell = async () => {
@@ -330,6 +332,25 @@ export class App {
     this.screenCaptureManager.prewarmPermissionCheck();
 
     logger.info('Post-first-frame initialization completed');
+  };
+
+  private prewarmLocalDatabaseAfterNavigation = () => {
+    // BrowserManager starts the initial loadURL call while constructing the main
+    // window. Yield one event-loop turn so Chromium can begin serving navigation
+    // requests before node:sqlite performs its synchronous open and migrations.
+    setImmediate(() => {
+      if (this.isQuiting) return;
+
+      const startedAt = performance.now();
+      try {
+        this.getService(LocalDatabaseService).initialize();
+        logger.debug(
+          `Local database prewarm completed in ${(performance.now() - startedAt).toFixed(2)}ms`,
+        );
+      } catch (error) {
+        logger.warn('Local database prewarm failed:', error);
+      }
+    });
   };
 
   getService<T>(serviceClass: Class<T>): T {

--- a/apps/desktop/src/main/core/__tests__/App.test.ts
+++ b/apps/desktop/src/main/core/__tests__/App.test.ts
@@ -143,6 +143,7 @@ vi.mock('../browser/BrowserManager', () => ({
   BrowserManager: vi.fn().mockImplementation(() => ({
     initializeBrowsers: vi.fn(),
     getIdentifierByWebContents: vi.fn(),
+    waitForMainWindowFirstFrame: vi.fn(() => new Promise(() => {})),
   })),
 }));
 
@@ -206,6 +207,24 @@ describe('App', () => {
       beforeQuitHandler();
 
       expect(destroy).toHaveBeenCalledOnce();
+    });
+
+    it('prewarms the local database after browser initialization yields to the event loop', async () => {
+      appInstance = new App();
+      const databaseService = appInstance.getService(LocalDatabaseService);
+      const initialize = vi.spyOn(databaseService, 'initialize').mockImplementation(() => {});
+
+      await appInstance.bootstrap();
+
+      expect(appInstance.browserManager.initializeBrowsers).toHaveBeenCalledOnce();
+      expect(initialize).not.toHaveBeenCalled();
+
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(initialize).toHaveBeenCalledOnce();
+      expect(
+        vi.mocked(appInstance.browserManager.initializeBrowsers).mock.invocationCallOrder[0],
+      ).toBeLessThan(initialize.mock.invocationCallOrder[0]);
     });
   });
 


### PR DESCRIPTION
## Summary

- prewarm the Electron local SQLite runtime one event-loop turn after the initial BrowserWindow navigation starts
- keep the synchronous `node:sqlite` open and migrations out of the later renderer cache-hydration path
- skip prewarming while quitting and retain lazy initialization as the failure fallback
- add a behavior test covering the deferred ordering after browser initialization

## Motivation

The Electron adapter currently opens the database lazily on the renderer's first cache request. In the measured startup path, that happened 466–498 ms after `BrowserWindow.loadURL()`, or 154–162 ms after `ready-to-show`.

`node:sqlite` exposes a synchronous `DatabaseSync` API, so this change does not pretend to make the open asynchronous. Instead, it schedules the existing initialization with `setImmediate` after `BrowserManager.initializeBrowsers()`, allowing the initial navigation to start before the main process performs the short synchronous operation.

## Startup measurements

Environment: macOS arm64 Electron development build, representative 2.7 MiB local database snapshot. Warm-path numbers use three launches per variant; empty-database migration numbers use three fresh profiles.

| Metric | Lazy baseline | Navigation prewarm |
| --- | ---: | ---: |
| DB available after `loadURL` | 466–498 ms | 22–31 ms |
| `loadURL` → `ready-to-show` | 312–339 ms, avg. ~322 ms | 311–334 ms, avg. ~323 ms |
| Warm DB open/configure/migration validation | not isolated | 2.03–2.23 ms |
| Fresh empty DB with all migrations | on-demand later | 11.98–12.28 ms |

Interpretation:

- database availability moves approximately 450 ms earlier, but that is not equivalent to a 450 ms UI improvement
- the steady-state synchronous work removed from later hydration is approximately 2 ms
- no measurable `ready-to-show` regression appeared in the three-run warm sample
- a future large migration can still block the main process; true off-main execution would require a worker or utility-process database owner rather than wrapping `DatabaseSync` in a Promise

## Validation

```text
bun run check apps/desktop/src/main/core/App.ts apps/desktop/src/main/core/__tests__/App.test.ts --lint --test --type
✓ 2 files · lint clean · tests 4 passed · types clean
```

The startup comparison additionally covered three baseline launches, three warm prewarm launches, and three fresh-profile migration launches.
