### PR TITLE
🐛 fix: validate custom provider base URLs

### DIFF
--- a/apps/server/src/modules/ModelRuntime/index.test.ts
+++ b/apps/server/src/modules/ModelRuntime/index.test.ts
@@ -22,7 +22,7 @@ import {
   ModelRuntime,
 } from '@lobechat/model-runtime';
 import { LobeVertexAI } from '@lobechat/model-runtime/vertexai';
-import { type ClientSecretPayload } from '@lobechat/types';
+import { ChatErrorType, type ClientSecretPayload } from '@lobechat/types';
 import { ModelProvider } from 'model-bank';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -78,12 +78,30 @@ describe('initModelRuntimeWithUserPayload method', () => {
     it('OpenAI provider: with apikey and endpoint', async () => {
       const jwtPayload: ClientSecretPayload = {
         apiKey: 'user-openai-key',
-        baseURL: 'user-endpoint',
+        baseURL: 'https://user-endpoint.test/v1',
       };
       const runtime = await initModelRuntimeWithUserPayload(ModelProvider.OpenAI, jwtPayload);
       expect(runtime).toBeInstanceOf(ModelRuntime);
       expect(runtime['_runtime']).toBeInstanceOf(LobeOpenAI);
       expect(runtime['_runtime'].baseURL).toBe(jwtPayload.baseURL);
+    });
+
+    it('rejects an invalid user baseURL as a bad request before SDK initialization', () => {
+      let thrownError: unknown;
+
+      try {
+        initModelRuntimeWithUserPayload(ModelProvider.OpenAI, {
+          apiKey: 'user-openai-key',
+          baseURL: 'https://api.example.com /v1/chat/completions',
+        });
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toEqual({
+        error: { message: 'Invalid provider baseURL' },
+        errorType: ChatErrorType.BadRequest,
+      });
     });
 
     it('Azure AI provider: with apikey, endpoint and apiversion', async () => {
@@ -354,7 +372,7 @@ describe('initModelRuntimeWithUserPayload method', () => {
     it('Unknown Provider: with apikey and endpoint, should initialize to OpenAi', async () => {
       const jwtPayload: ClientSecretPayload = {
         apiKey: 'user-unknown-key',
-        baseURL: 'user-unknown-endpoint',
+        baseURL: 'https://user-unknown-endpoint.test/v1',
       };
       const runtime = await initModelRuntimeWithUserPayload('unknown', jwtPayload);
       expect(runtime).toBeInstanceOf(ModelRuntime);

--- a/apps/server/src/modules/ModelRuntime/index.ts
+++ b/apps/server/src/modules/ModelRuntime/index.ts
@@ -1,5 +1,6 @@
 import { type GoogleGenAIOptions } from '@google/genai';
 import {
+  AgentRuntimeError,
   mergeModelRuntimeHooks,
   ModelRuntime,
   type ModelRuntimeHooks,
@@ -8,6 +9,7 @@ import { LobeVertexAI } from '@lobechat/model-runtime/vertexai';
 import {
   type AWSBedrockKeyVault,
   type AzureOpenAIKeyVault,
+  ChatErrorType,
   type ClientSecretPayload,
   type CloudflareKeyVault,
   type ComfyUIKeyVault,
@@ -19,6 +21,7 @@ import {
 } from '@lobechat/types';
 import { safeParseJSON } from '@lobechat/utils';
 import { ModelProvider } from 'model-bank';
+import { AiProviderBaseURLSchema } from 'model-bank/aiProvider';
 import { DEFAULT_MODEL_PROVIDER_LIST } from 'model-bank/modelProviders';
 
 import { getBusinessModelRuntimeHooks } from '@/business/server/model-runtime';
@@ -410,6 +413,17 @@ export const initModelRuntimeWithUserPayload = (
   hooks?: ModelRuntimeHooks,
 ) => {
   const runtimeProvider = payload.runtimeProvider ?? provider;
+
+  /**
+   * User-configured endpoints can come from older clients or persisted rows that predate
+   * input validation. Reject them before an SDK appends a request path and throws an
+   * unclassified ERR_INVALID_URL, which would otherwise surface as a server-side 500.
+   */
+  if (payload.baseURL && !AiProviderBaseURLSchema.safeParse(payload.baseURL).success) {
+    throw AgentRuntimeError.createError(ChatErrorType.BadRequest, {
+      message: 'Invalid provider baseURL',
+    });
+  }
 
   if (runtimeProvider === ModelProvider.VertexAI) {
     const vertexOptions = buildVertexOptions(payload, params);

--- a/packages/model-bank/src/types/aiProvider.test.ts
+++ b/packages/model-bank/src/types/aiProvider.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AiProviderBaseURLSchema,
+  CreateAiProviderSchema,
+  UpdateAiProviderConfigSchema,
+} from './aiProvider';
+
+const invalidBaseURL = 'https://api.example.com /v1/chat/completions';
+
+describe('AiProviderBaseURLSchema', () => {
+  it('accepts HTTP endpoints', () => {
+    expect(AiProviderBaseURLSchema.safeParse('https://api.example.com/v1').success).toBe(true);
+    expect(AiProviderBaseURLSchema.safeParse('http://localhost:11434').success).toBe(true);
+  });
+
+  it('rejects malformed and non-HTTP endpoints', () => {
+    expect(AiProviderBaseURLSchema.safeParse(invalidBaseURL).success).toBe(false);
+    expect(AiProviderBaseURLSchema.safeParse('ftp://api.example.com/v1').success).toBe(false);
+  });
+});
+
+describe('AI provider input schemas', () => {
+  it('rejects an invalid baseURL when creating a provider', () => {
+    const result = CreateAiProviderSchema.safeParse({
+      id: 'custom-provider',
+      keyVaults: { baseURL: invalidBaseURL },
+      name: 'Custom Provider',
+      source: 'custom',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0].path).toEqual(['keyVaults', 'baseURL']);
+  });
+
+  it('rejects an invalid baseURL when updating provider config', () => {
+    const result = UpdateAiProviderConfigSchema.safeParse({
+      keyVaults: { baseURL: invalidBaseURL },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0].path).toEqual(['keyVaults', 'baseURL']);
+  });
+
+  it('keeps empty endpoints and nested custom headers compatible', () => {
+    expect(
+      UpdateAiProviderConfigSchema.safeParse({
+        keyVaults: { baseURL: '', customHeaders: { 'X-Custom': 'value' } },
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/packages/model-bank/src/types/aiProvider.ts
+++ b/packages/model-bank/src/types/aiProvider.ts
@@ -264,12 +264,32 @@ export interface AiProviderConfig {
   enableResponseApi?: boolean;
 }
 
+export const AiProviderBaseURLSchema = z.url({ protocol: /^https?$/ });
+
+/** Provider vaults support scalar secrets and string-valued custom header maps. */
+const AiProviderKeyVaultValueSchema = z
+  .union([z.string(), z.record(z.string(), z.string())])
+  .optional();
+
+const AiProviderKeyVaultsSchema = z
+  .record(z.string(), AiProviderKeyVaultValueSchema)
+  .superRefine((keyVaults, ctx) => {
+    const baseURL = keyVaults.baseURL;
+    if (!baseURL || AiProviderBaseURLSchema.safeParse(baseURL).success) return;
+
+    ctx.addIssue({
+      code: 'custom',
+      message: 'Invalid baseURL',
+      path: ['baseURL'],
+    });
+  });
+
 // create
 export const CreateAiProviderSchema = z.object({
   config: z.object({}).passthrough().optional(),
   description: z.string().optional(),
   id: z.string(),
-  keyVaults: z.any().optional(),
+  keyVaults: AiProviderKeyVaultsSchema.optional(),
   logo: z.string().optional(),
   name: z.string(),
   sdkType: z.enum(AiProviderSdkTypes).optional(),
@@ -368,15 +388,7 @@ export const UpdateAiProviderConfigSchema = z.object({
     })
     .optional(),
   fetchOnClient: z.boolean().nullish(),
-  keyVaults: z
-    .record(
-      z.string(),
-      z.union([
-        z.string().optional(),
-        z.record(z.string(), z.string()).optional(), // Support nested objects, e.g. customHeaders
-      ]),
-    )
-    .optional(),
+  keyVaults: AiProviderKeyVaultsSchema.optional(),
 });
 
 export type UpdateAiProviderConfigParams = z.infer<typeof UpdateAiProviderConfigSchema>;

--- a/src/app/(backend)/webapi/models/[provider]/route.test.ts
+++ b/src/app/(backend)/webapi/models/[provider]/route.test.ts
@@ -200,6 +200,23 @@ describe('GET handler', () => {
       expect(responseBody.body.provider).toBe('githubcopilot');
     });
 
+    it('should return bad request for a persisted invalid provider baseURL', async () => {
+      const mockParams = Promise.resolve({ provider: 'custom-provider' });
+
+      vi.mocked(initModelRuntimeFromDB).mockRejectedValue({
+        error: { message: 'Invalid provider baseURL' },
+        errorType: ChatErrorType.BadRequest,
+      });
+
+      const response = await GET(request, { params: mockParams });
+      const responseBody = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(responseBody.errorType).toBe(ChatErrorType.BadRequest);
+      expect(responseBody.body.message).toBe('Invalid provider baseURL');
+      expect(responseBody.body.provider).toBe('custom-provider');
+    });
+
     it('should include provider in error response', async () => {
       const mockParams = Promise.resolve({ provider: 'openai' });
 

--- a/src/features/Settings/provider/features/CreateNewProvider/Content.tsx
+++ b/src/features/Settings/provider/features/CreateNewProvider/Content.tsx
@@ -4,6 +4,7 @@ import { ProviderIcon } from '@lobehub/icons';
 import { Flexbox, Input, InputPassword, Text, TextArea } from '@lobehub/ui';
 import { Button, Select, toast, useModalContext } from '@lobehub/ui/base-ui';
 import { Form } from 'antd';
+import { AiProviderBaseURLSchema } from 'model-bank/aiProvider';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -149,8 +150,16 @@ const CreateNewProviderContent = memo(() => {
         <Form.Item
           label={t('createNewAiProvider.proxyUrl.title')}
           name={[KeyVaultsConfigKey, LLMProviderBaseUrlKey]}
-          rules={[{ message: t('createNewAiProvider.proxyUrl.required'), required: true }]}
           style={itemStyle}
+          rules={[
+            { message: t('createNewAiProvider.proxyUrl.required'), required: true },
+            {
+              validator: (_, value: string) =>
+                !value || AiProviderBaseURLSchema.safeParse(value).success
+                  ? Promise.resolve()
+                  : Promise.reject(t('providerModels.config.baseURL.invalid')),
+            },
+          ]}
         >
           <Input
             allowClear

--- a/src/features/Settings/provider/features/ProviderConfig/Checker.tsx
+++ b/src/features/Settings/provider/features/ProviderConfig/Checker.tsx
@@ -66,7 +66,7 @@ interface ConnectionCheckerProps {
   checkErrorRender?: CheckErrorRender;
   model: string;
   onAfterCheck: () => Promise<void>;
-  onBeforeCheck: () => Promise<void>;
+  onBeforeCheck: () => Promise<boolean>;
   provider: string;
 }
 
@@ -236,8 +236,10 @@ const Checker = memo<ConnectionCheckerProps>(
             onClick={async () => {
               if (!canManageProvider) return;
 
-              await onBeforeCheck();
               try {
+                const shouldCheck = await onBeforeCheck();
+                if (!shouldCheck) return;
+
                 await checkConnection();
               } finally {
                 await onAfterCheck();

--- a/src/features/Settings/provider/features/ProviderConfig/index.tsx
+++ b/src/features/Settings/provider/features/ProviderConfig/index.tsx
@@ -19,11 +19,11 @@ import { useDebounceFn } from 'ahooks';
 import { Form as AntdForm } from 'antd';
 import { createStaticStyles, cssVar, cx, responsive } from 'antd-style';
 import { InfoIcon, Loader2Icon, LockIcon } from 'lucide-react';
+import { AiProviderBaseURLSchema } from 'model-bank/aiProvider';
 import { type ReactNode } from 'react';
 import { memo, useCallback, useLayoutEffect, useRef } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
-import { z } from 'zod';
 
 import { FormInput, FormPassword } from '@/components/FormInput';
 import { SkeletonInput, SkeletonSwitch } from '@/components/Skeleton';
@@ -270,9 +270,8 @@ const ProviderConfig = memo<ProviderConfigProps>(
       [normalizeConfigValues],
     );
 
-    const { run: debouncedHandleValueChange } = useDebounceFn(handleValueChange, {
-      wait: 500,
-    });
+    const { cancel: cancelDebouncedHandleValueChange, run: debouncedHandleValueChange } =
+      useDebounceFn(handleValueChange, { wait: 500 });
 
     const isCustom = source === AiProviderSourceEnum.Custom;
 
@@ -374,7 +373,7 @@ const ProviderConfig = memo<ProviderConfigProps>(
               validator: (_: any, value: string) => {
                 if (!value) return;
 
-                return z.string().url().safeParse(value).error
+                return AiProviderBaseURLSchema.safeParse(value).error
                   ? Promise.reject(t('providerModels.config.baseURL.invalid'))
                   : Promise.resolve();
               },
@@ -436,10 +435,18 @@ const ProviderConfig = memo<ProviderConfigProps>(
                   isCheckingConnection.current = false;
                 }}
                 onBeforeCheck={async () => {
+                  try {
+                    await form.validateFields();
+                  } catch {
+                    return false;
+                  }
+
                   // Set connection test state to prevent duplicate requests from onValuesChange
                   isCheckingConnection.current = true;
                   // Proactively save the latest form values to ensure fetchAiProviderRuntimeState retrieves up-to-date data
                   await updateAiProviderConfig(id, normalizeValues(form.getFieldsValue()));
+
+                  return true;
                 }}
               />
             ),
@@ -570,6 +577,11 @@ const ProviderConfig = memo<ProviderConfigProps>(
             variant={'borderless'}
             onValuesChange={(_, values) => {
               if (!canManageProvider) return;
+
+              cancelDebouncedHandleValueChange();
+              const baseURL = values.keyVaults?.baseURL;
+              if (baseURL && !AiProviderBaseURLSchema.safeParse(baseURL).success) return;
+
               debouncedHandleValueChange(id, normalizeValues(values));
             }}
             {...FORM_STYLE}


### PR DESCRIPTION
## 📝 Additional Information

Reject malformed custom provider Base URLs before they reach an OpenAI-compatible SDK and surface as an unclassified server error.

### Key Decisions / Non-goals

- Reuse one HTTP(S)-only URL schema across create, update, and settings forms.
- Keep empty Base URLs valid so providers can continue using their default endpoints.
- Add runtime validation as a compatibility guard for previously persisted configurations; no data migration is required.
- Return a structured Bad Request for invalid persisted endpoints instead of handling unrelated SDK errors.

#### Test

- [x] Tested locally
- [x] Added/updated tests

`bun run check --lint --test lobehub/packages/model-bank/src/types/aiProvider.ts lobehub/packages/model-bank/src/types/aiProvider.test.ts lobehub/apps/server/src/modules/ModelRuntime/index.ts lobehub/apps/server/src/modules/ModelRuntime/index.test.ts lobehub/src/app/\(backend\)/webapi/models/\[provider\]/route.test.ts lobehub/src/features/Settings/provider/features/CreateNewProvider/Content.tsx lobehub/src/features/Settings/provider/features/ProviderConfig/index.tsx lobehub/src/features/Settings/provider/features/ProviderConfig/Checker.tsx`

Result: 8 files lint clean, 80 tests passed.

#### 🔗 Related Issue

Fixes LOBE-12905