### PR TITLE
✨ feat(onboarding): run confirmed starter tasks immediately

### DIFF
--- a/apps/server/src/services/taskRecommendation/materializer.test.ts
+++ b/apps/server/src/services/taskRecommendation/materializer.test.ts
@@ -70,10 +70,12 @@ describe('TaskRecommendationMaterializer', () => {
     };
 
     await expect(materializer.materialize(input)).resolves.toEqual({
+      created: true,
       status: 'success',
       taskId: 'task-1',
     });
     await expect(materializer.materialize(input)).resolves.toEqual({
+      created: false,
       status: 'success',
       taskId: 'task-1',
     });

--- a/apps/server/src/services/taskRecommendation/materializer.ts
+++ b/apps/server/src/services/taskRecommendation/materializer.ts
@@ -7,8 +7,17 @@ import type { LobeChatDatabase } from '@/database/type';
 import type { CreateTaskInput } from '@/server/services/task';
 import { TaskService } from '@/server/services/task';
 
+/** Represents the durable outcome of materializing an onboarding task recommendation. */
 export type TaskRecommendationMaterializationResult =
-  { status: 'not-found' } | { status: 'stale' } | { status: 'success'; taskId: string };
+  | { status: 'not-found' }
+  | { status: 'stale' }
+  | {
+      /** Whether this invocation created the task instead of replaying its persisted mapping. */
+      created: boolean;
+      status: 'success';
+      /** Stable task ID persisted for this recommendation. */
+      taskId: string;
+    };
 
 interface MaterializeTaskRecommendationInput {
   assigneeAgentId: string;
@@ -70,7 +79,7 @@ export class TaskRecommendationMaterializer {
       if (parsed.data.id !== input.sessionId) return { status: 'stale' };
 
       const existingTaskId = parsed.data.createdTaskIds[input.recommendationId];
-      if (existingTaskId) return { status: 'success', taskId: existingTaskId };
+      if (existingTaskId) return { created: false, status: 'success', taskId: existingTaskId };
 
       const recommendation = parsed.data.recommendations.find(
         ({ id }) => id === input.recommendationId,
@@ -119,6 +128,6 @@ export class TaskRecommendationMaterializer {
           ),
         );
 
-      return { status: 'success', taskId: task.id };
+      return { created: true, status: 'success', taskId: task.id };
     });
 }

--- a/apps/server/src/services/taskRecommendation/service.test.ts
+++ b/apps/server/src/services/taskRecommendation/service.test.ts
@@ -300,15 +300,22 @@ describe('TaskRecommendationService', () => {
   it('does not create duplicate tasks when materialization is retried', async () => {
     let persisted = structuredClone(session);
     const materialize = vi.fn(async ({ recommendationId }: { recommendationId: string }) => {
+      const created = !persisted.createdTaskIds[recommendationId];
       persisted.createdTaskIds[recommendationId] ??= 'task-1';
-      return { status: 'success' as const, taskId: persisted.createdTaskIds[recommendationId] };
+      return {
+        created,
+        status: 'success' as const,
+        taskId: persisted.createdTaskIds[recommendationId],
+      };
     });
+    const runTask = vi.fn(async () => ({ taskId: 'task-1' }));
     const service = new TaskRecommendationService({
       configurator: new TaskRecommendationConfigurator(),
       connectorData: {},
       materializer: { materialize },
       onboarding: { getInboxAgentId: vi.fn(async () => 'inbox-1') },
       providers: new Map(),
+      runner: { runTask },
       topic: {
         findById: vi.fn(async () => ({
           metadata: { onboardingSession: { taskRecommendations: persisted } },
@@ -337,5 +344,51 @@ describe('TaskRecommendationService', () => {
       topicId: 'topic-1',
     });
     expect(persisted.createdTaskIds).toEqual({ 'recommendation-1': 'task-1' });
+    expect(runTask).toHaveBeenCalledTimes(1);
+    expect(runTask).toHaveBeenCalledWith({ taskId: 'task-1' });
+  });
+
+  /** @example A failed immediate kickoff leaves the durable task available for manual retry. */
+  it('keeps the created task mapping when immediate execution fails', async () => {
+    const persisted = structuredClone(session);
+    const runTask = vi.fn(async () => {
+      throw new Error('QStash unavailable');
+    });
+    const service = new TaskRecommendationService({
+      configurator: new TaskRecommendationConfigurator(),
+      connectorData: {},
+      materializer: {
+        materialize: vi.fn(async ({ recommendationId }: { recommendationId: string }) => {
+          persisted.createdTaskIds[recommendationId] = 'task-1';
+          return { created: true, status: 'success' as const, taskId: 'task-1' };
+        }),
+      },
+      onboarding: { getInboxAgentId: vi.fn(async () => 'inbox-1') },
+      providers: new Map(),
+      runner: { runTask },
+      topic: {
+        findById: vi.fn(async () => ({
+          metadata: { onboardingSession: { taskRecommendations: persisted } },
+        })),
+        updateMetadata: vi.fn(),
+      },
+      writer: {},
+    } as never);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(
+      service.createTasks({
+        recommendationIds: ['recommendation-1'],
+        sessionId: 'session-1',
+        topicId: 'topic-1',
+      }),
+    ).resolves.toEqual({ 'recommendation-1': 'task-1' });
+
+    expect(runTask).toHaveBeenCalledWith({ taskId: 'task-1' });
+    expect(consoleError).toHaveBeenCalledWith(
+      '[TaskRecommendationService] failed to start onboarding task:',
+      expect.any(Error),
+    );
+    consoleError.mockRestore();
   });
 });

--- a/apps/server/src/services/taskRecommendation/service.ts
+++ b/apps/server/src/services/taskRecommendation/service.ts
@@ -24,6 +24,7 @@ import { AiGenerationService } from '@/server/services/aiGeneration';
 import { ConnectorDataService } from '@/server/services/connectorData';
 import { OnboardingService } from '@/server/services/onboarding';
 import { resolveSystemAgentModelConfig } from '@/server/services/systemAgent/modelConfig';
+import { TaskRunnerService } from '@/server/services/taskRunner';
 
 import { TaskRecommendationConfigurator } from './config';
 import { TaskRecommendationMaterializer } from './materializer';
@@ -63,6 +64,7 @@ interface TaskRecommendationServiceDependencies {
   materializer: Pick<TaskRecommendationMaterializer, 'materialize'>;
   onboarding: Pick<OnboardingService, 'getInboxAgentId'>;
   providers: ReadonlyMap<string, TaskRecommendationProvider>;
+  runner: Pick<TaskRunnerService, 'runTask'>;
   topic: Pick<TopicModel, 'findById' | 'updateMetadata'>;
   writer: Pick<TaskRecommendationWriter, 'generate'>;
 }
@@ -375,6 +377,16 @@ export class TaskRecommendationService {
       });
       if (result.status === 'stale') throw new StaleTaskRecommendationSessionError();
       if (result.status === 'not-found') throw new TaskRecommendationNotFoundError();
+      if (result.created) {
+        try {
+          await this.dependencies.runner.runTask({ taskId: result.taskId });
+        } catch (error) {
+          // TaskRunnerService keeps a failed kickoff visible as a paused task with the error
+          // attached. Do not fail onboarding after the durable task and idempotency mapping
+          // have already committed; the user can inspect or retry it from the task list.
+          console.error('[TaskRecommendationService] failed to start onboarding task:', error);
+        }
+      }
     }
     return (await this.get(input.topicId)).createdTaskIds;
   };
@@ -398,6 +410,7 @@ export const createTaskRecommendationService = async ({
     materializer: new TaskRecommendationMaterializer(db, userId),
     onboarding: new OnboardingService(db, userId),
     providers: taskRecommendationProviderMap,
+    runner: new TaskRunnerService(db, userId),
     topic: new TopicModel(db, userId),
     writer: new TaskRecommendationWriter({
       generator: new AiGenerationService(db, userId),

--- a/packages/prompts/src/chains/onboardingTaskRecommendation.test.ts
+++ b/packages/prompts/src/chains/onboardingTaskRecommendation.test.ts
@@ -27,6 +27,10 @@ describe('chainOnboardingTaskRecommendation', () => {
     expect(messages[0].content).toContain('Never comment, submit a review, approve');
     expect(messages[0].content).toContain('Select only the highest-value recommendations');
     expect(messages[0].content).toContain('urgency, recurrence, user impact, and leverage');
+    expect(messages[0].content).toContain(
+      'The selected task will start immediately after onboarding confirmation',
+    );
+    expect(messages[0].content).toContain('without waiting for another user message');
     expect(messages[0].content).toContain('Title: Analyze mobile lifecycle risk');
     expect(messages[1].content).toContain('<connector-evidence provider="github">');
     expect(messages[1].content).toContain('{"pullRequest":1}');

--- a/packages/prompts/src/chains/onboardingTaskRecommendation.ts
+++ b/packages/prompts/src/chains/onboardingTaskRecommendation.ts
@@ -137,6 +137,7 @@ export const DEFAULT_ONBOARDING_TASK_RECOMMENDATION_PROMPT_CONFIG = {
   },
   writing: {
     instructionPrinciples: [
+      'The selected task will start immediately after onboarding confirmation. Write a self-contained first-run instruction that the assigned agent can execute without waiting for another user message.',
       'Write two to four sentences addressed directly to an autonomous agent. State the background work it can perform, the concrete private deliverable it must return, and the completion criteria.',
       'Select only the highest-value recommendations for this provider. Rank evidence by urgency, recurrence, user impact, and leverage; when the limit is two, return the two strongest distinct candidates in that order. Skip low-signal, generic, duplicated, or merely convenient work.',
       'Include enough project, person, or subject context for the Inbox agent to execute the task without guessing which similarly named work item is intended.',


### PR DESCRIPTION
#### Summary

- Tell the recommendation writer that confirmed starter tasks begin immediately and must be self-contained.
- Start each newly materialized onboarding task through the standard TaskRunnerService execution path.
- Preserve recommendation-to-task idempotency so retried submissions do not launch duplicate runs.
- Keep a durably created task available as paused when its immediate kickoff fails.

#### Key Decisions / Non-goals

- Tasks start only after the user confirms their Starter Tasks selection; recommendation generation itself does not bypass confirmation.
- Only the invocation that creates the durable task starts it. Replayed or concurrent materialization requests reuse the persisted mapping without another run.
- A runner kickoff failure does not fail onboarding after task creation has committed. TaskRunnerService records the failure on the paused task so it remains inspectable and retryable.
- This PR reuses the existing task runner and QStash chain; it does not add a separate onboarding execution workflow.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Focused verification:

- 6 changed files lint clean
- 12 focused tests passed
- Prompt scenario verifies immediate-start and self-contained instruction guidance

Full workspace type-check is currently blocked by an existing duplicate drizzle-orm instance mismatch in unrelated files.