### PR TITLE
✨ feat: add Grok 4.6 reasoning effort support

### DIFF
--- a/locales/en-US/modelProvider.json
+++ b/locales/en-US/modelProvider.json
@@ -237,6 +237,7 @@
   "providerModels.item.modelConfig.extendParams.options.grok4_20ReasoningEffort.hint": "For Grok 4.20 series; controls reasoning intensity. Low/Medium uses 4 agents, High/XHigh uses 16 agents.",
   "providerModels.item.modelConfig.extendParams.options.grok4_3ReasoningEffort.hint": "For Grok 4.3 series; controls reasoning intensity.",
   "providerModels.item.modelConfig.extendParams.options.grok4_5ReasoningEffort.hint": "For Grok 4.5 series; controls reasoning intensity (low/medium/high, default high).",
+  "providerModels.item.modelConfig.extendParams.options.grok4_6ReasoningEffort.hint": "For Grok 4.6 series; controls reasoning intensity (low/medium/high/xhigh, default high). Reasoning cannot be disabled.",
   "providerModels.item.modelConfig.extendParams.options.hy3ReasoningEffort.hint": "For Hy3 models; controls reasoning intensity. no_think (ultra-fast response), low (quick reasoning), and high (deep reasoning)—to accommodate varying latency and depth requirements, from high-frequency interactions to complex engineering tasks.",
   "providerModels.item.modelConfig.extendParams.options.imageAspectRatio.hint": "For Gemini image generation models; controls aspect ratio of generated images.",
   "providerModels.item.modelConfig.extendParams.options.imageAspectRatio2.hint": "For Nano Banana 2; controls aspect ratio of generated images (supports extra-wide 1:4, 4:1, 1:8, 8:1).",

--- a/locales/en-US/models.json
+++ b/locales/en-US/models.json
@@ -860,6 +860,7 @@
   "lobehub.grok-4.20-beta-0309-reasoning.description": "Intelligent, blazing-fast model that reasons before responding",
   "lobehub.grok-4.3.description": "The most truth-seeking large language model in the world",
   "lobehub.grok-4.5.description": "Grok 4.5 delivers performance close to Claude Opus 4.8 with exceptionally fast responses.",
+  "lobehub.grok-4.6.description": "Grok 4.6 builds on Grok 4.5 with a particular focus on long-running agents and more ambitious interactive and visual work.",
   "lobehub.imagen-4.0-fast-generate-001.description": "Imagen 4th generation text-to-image model series",
   "lobehub.imagen-4.0-generate-001.description": "Imagen 4th generation text-to-image model series",
   "lobehub.imagen-4.0-ultra-generate-001.description": "Imagen 4th generation text-to-image model series Ultra version",

--- a/locales/zh-CN/modelProvider.json
+++ b/locales/zh-CN/modelProvider.json
@@ -237,6 +237,7 @@
   "providerModels.item.modelConfig.extendParams.options.grok4_20ReasoningEffort.hint": "适用于 Grok 4.20 系列；控制推理强度。低/中档使用 4 个代理，高/超高使用 16 个代理。",
   "providerModels.item.modelConfig.extendParams.options.grok4_3ReasoningEffort.hint": "适用于 Grok 4.3 系列；控制推理强度。",
   "providerModels.item.modelConfig.extendParams.options.grok4_5ReasoningEffort.hint": "适用于 Grok 4.5 系列；控制推理强度（低/中/高，默认高）。",
+  "providerModels.item.modelConfig.extendParams.options.grok4_6ReasoningEffort.hint": "适用于 Grok 4.6 系列；控制推理强度（低/中/高/xhigh，默认高）。推理无法关闭。",
   "providerModels.item.modelConfig.extendParams.options.hy3ReasoningEffort.hint": "适用于 Hy3 模型；控制推理强度。no_think（超快响应）、low（快速推理）和 high（深度推理）三档，以适应从高频交互到复杂工程任务的不同延迟和深度需求。",
   "providerModels.item.modelConfig.extendParams.options.imageAspectRatio.hint": "适用于 Gemini 图像生成模型；控制生成图像的宽高比。",
   "providerModels.item.modelConfig.extendParams.options.imageAspectRatio2.hint": "适用于 Nano Banana 2；控制生成图像的宽高比（支持超宽 1:4、4:1、1:8、8:1）。",

--- a/locales/zh-CN/models.json
+++ b/locales/zh-CN/models.json
@@ -860,6 +860,7 @@
   "lobehub.grok-4.20-beta-0309-reasoning.description": "智能且极速的模型，在响应前进行推理",
   "lobehub.grok-4.3.description": "世界上最追求真理的大型语言模型",
   "lobehub.grok-4.5.description": "Grok 4.5 提供接近 Claude Opus 4.8 的性能，同时响应速度异常快。",
+  "lobehub.grok-4.6.description": "Grok 4.6 在 Grok 4.5 基础上强化长程 Agent 能力，并更擅长交互式与视觉类工作。",
   "lobehub.imagen-4.0-fast-generate-001.description": "Imagen 第四代文本生成图像模型系列",
   "lobehub.imagen-4.0-generate-001.description": "Imagen 第四代文本生成图像模型系列",
   "lobehub.imagen-4.0-ultra-generate-001.description": "Imagen 第四代文本生成图像模型系列 Ultra 版本",

--- a/packages/locales/src/default/modelProvider.ts
+++ b/packages/locales/src/default/modelProvider.ts
@@ -284,6 +284,8 @@ export default {
     'For Grok 4.3 series; controls reasoning intensity.',
   'providerModels.item.modelConfig.extendParams.options.grok4_5ReasoningEffort.hint':
     'For Grok 4.5 series; controls reasoning intensity (low/medium/high, default high).',
+  'providerModels.item.modelConfig.extendParams.options.grok4_6ReasoningEffort.hint':
+    'For Grok 4.6 series; controls reasoning intensity (low/medium/high/xhigh, default high). Reasoning cannot be disabled.',
   'providerModels.item.modelConfig.extendParams.options.hy3ReasoningEffort.hint':
     'For Hy3 models; controls reasoning intensity. no_think (ultra-fast response), low (quick reasoning), and high (deep reasoning)—to accommodate varying latency and depth requirements, from high-frequency interactions to complex engineering tasks.',
   'providerModels.item.modelConfig.extendParams.options.ring2_6ReasoningEffort.hint':

--- a/packages/locales/src/lobehubOnlineModelDescriptions.test.ts
+++ b/packages/locales/src/lobehubOnlineModelDescriptions.test.ts
@@ -13,6 +13,7 @@ const addedDescriptionKeys = [
   'lobehub.gemini-3.1-flash-image-preview.description',
   'lobehub.gemini-3.1-flash-image-preview:image.description',
   'lobehub.qwen3.8-max.description',
+  'lobehub.grok-4.6.description',
 ] as const;
 
 describe('LobeHub online model descriptions', () => {

--- a/packages/locales/src/lobehubOnlineModelDescriptions.ts
+++ b/packages/locales/src/lobehubOnlineModelDescriptions.ts
@@ -133,6 +133,8 @@ export const lobeHubOnlineModelDescriptions = {
   'lobehub.grok-4.3.description': 'The most truth-seeking large language model in the world',
   'lobehub.grok-4.5.description':
     'Grok 4.5 delivers performance close to Claude Opus 4.8 with exceptionally fast responses.',
+  'lobehub.grok-4.6.description':
+    'Grok 4.6 builds on Grok 4.5 with a particular focus on long-running agents and more ambitious interactive and visual work.',
   'lobehub.imagen-4.0-fast-generate-001.description':
     'Imagen 4th generation text-to-image model series',
   'lobehub.imagen-4.0-generate-001.description': 'Imagen 4th generation text-to-image model series',

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -340,6 +340,7 @@ export interface AiModelReasoningConfig {
   gpt5ReasoningEffort?: 'minimal' | 'low' | 'medium' | 'high';
   grok4_3ReasoningEffort?: 'none' | 'low' | 'medium' | 'high';
   grok4_5ReasoningEffort?: 'low' | 'medium' | 'high';
+  grok4_6ReasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh';
   grok4_20ReasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh';
   hy3ReasoningEffort?: 'no_think' | 'low' | 'high';
   kimiK3ReasoningEffort?: 'low' | 'high' | 'max';
@@ -362,6 +363,7 @@ export const AiModelReasoningConfigSchema = z.object({
   gpt5ReasoningEffort: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
   grok4_3ReasoningEffort: z.enum(['none', 'low', 'medium', 'high']).optional(),
   grok4_5ReasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
+  grok4_6ReasoningEffort: z.enum(['low', 'medium', 'high', 'xhigh']).optional(),
   grok4_20ReasoningEffort: z.enum(['low', 'medium', 'high', 'xhigh']).optional(),
   hy3ReasoningEffort: z.enum(['no_think', 'low', 'high']).optional(),
   kimiK3ReasoningEffort: z.enum(['low', 'high', 'max']).optional(),
@@ -400,6 +402,7 @@ export const MODEL_REASONING_PARAM_LEVELS: {
   gpt5ReasoningEffort: ['minimal', 'low', 'medium', 'high'],
   grok4_3ReasoningEffort: ['none', 'low', 'medium', 'high'],
   grok4_5ReasoningEffort: ['low', 'medium', 'high'],
+  grok4_6ReasoningEffort: ['low', 'medium', 'high', 'xhigh'],
   grok4_20ReasoningEffort: ['low', 'medium', 'high', 'xhigh'],
   hy3ReasoningEffort: ['no_think', 'low', 'high'],
   kimiK3ReasoningEffort: ['low', 'high', 'max'],
@@ -429,6 +432,7 @@ export const MODEL_REASONING_PARAM_DEFAULTS: {
   gpt5ReasoningEffort: 'medium',
   grok4_3ReasoningEffort: 'low',
   grok4_5ReasoningEffort: 'high',
+  grok4_6ReasoningEffort: 'high',
   grok4_20ReasoningEffort: 'medium',
   hy3ReasoningEffort: 'high',
   kimiK3ReasoningEffort: 'max',
@@ -480,6 +484,7 @@ export type ExtendParamsType =
   | 'grok4_20ReasoningEffort'
   | 'grok4_3ReasoningEffort'
   | 'grok4_5ReasoningEffort'
+  | 'grok4_6ReasoningEffort'
   | 'hy3ReasoningEffort'
   | 'kimiK3ReasoningEffort'
   | 'ring2_6ReasoningEffort'
@@ -537,6 +542,7 @@ export const ExtendParamsTypeSchema = z.enum([
   'grok4_20ReasoningEffort',
   'grok4_3ReasoningEffort',
   'grok4_5ReasoningEffort',
+  'grok4_6ReasoningEffort',
   'hy3ReasoningEffort',
   'kimiK3ReasoningEffort',
   'ring2_6ReasoningEffort',

--- a/packages/model-runtime/src/utils/modelExtendParams.test.ts
+++ b/packages/model-runtime/src/utils/modelExtendParams.test.ts
@@ -142,6 +142,16 @@ describe('applyModelExtendParams', () => {
     expect(result.reasoning_effort).toBe('high');
   });
 
+  it('resolves Grok 4.6 xhigh reasoning effort', () => {
+    const result = applyModelExtendParams({
+      chatConfig: chatConfig({ grok4_6ReasoningEffort: 'xhigh' }),
+      extendParams: ['grok4_6ReasoningEffort'],
+      model: 'grok-4.6',
+    });
+
+    expect(result.reasoning_effort).toBe('xhigh');
+  });
+
   it('resolves GPT-5.6 Pro mode independently from reasoning effort', () => {
     const result = applyModelExtendParams({
       chatConfig: chatConfig({

--- a/packages/model-runtime/src/utils/modelExtendParams.ts
+++ b/packages/model-runtime/src/utils/modelExtendParams.ts
@@ -319,6 +319,10 @@ export const applyModelExtendParams = (ctx: ApplyModelExtendParamsContext): Mode
     extendParams.reasoning_effort = chatConfig.grok4_5ReasoningEffort;
   }
 
+  if (modelExtendParams.includes('grok4_6ReasoningEffort') && chatConfig.grok4_6ReasoningEffort) {
+    extendParams.reasoning_effort = chatConfig.grok4_6ReasoningEffort;
+  }
+
   if (modelExtendParams.includes('hy3ReasoningEffort') && chatConfig.hy3ReasoningEffort) {
     extendParams.reasoning_effort = chatConfig.hy3ReasoningEffort;
   }

--- a/packages/types/src/agent/chatConfig.ts
+++ b/packages/types/src/agent/chatConfig.ts
@@ -106,6 +106,7 @@ export interface LobeAgentChatConfig extends AgentMemoryChatConfig, AgentSelfIte
   graph?: null | ReasoningGraph;
   grok4_3ReasoningEffort?: 'none' | 'low' | 'medium' | 'high';
   grok4_5ReasoningEffort?: 'low' | 'medium' | 'high';
+  grok4_6ReasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh';
   grok4_20ReasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh';
   /**
    * Number of historical messages
@@ -265,6 +266,7 @@ export const AgentChatConfigSchema = z
     grok4_20ReasoningEffort: z.enum(['low', 'medium', 'high', 'xhigh']).optional(),
     grok4_3ReasoningEffort: z.enum(['none', 'low', 'medium', 'high']).optional(),
     grok4_5ReasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
+    grok4_6ReasoningEffort: z.enum(['low', 'medium', 'high', 'xhigh']).optional(),
     hy3ReasoningEffort: z.enum(['no_think', 'low', 'high']).optional(),
     kimiK3ReasoningEffort: z.enum(['low', 'high', 'max']).optional(),
     ring2_6ReasoningEffort: z.enum(['high', 'xhigh']).optional(),

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
@@ -32,6 +32,7 @@ import GPT52ReasoningEffortSlider from './GPT52ReasoningEffortSlider';
 import { GPT56ReasoningEffortSlider } from './GPT56ReasoningEffortSlider';
 import Grok43ReasoningEffortSlider from './Grok43ReasoningEffortSlider';
 import Grok45ReasoningEffortSlider from './Grok45ReasoningEffortSlider';
+import Grok46ReasoningEffortSlider from './Grok46ReasoningEffortSlider';
 import Grok420ReasoningEffortSlider from './Grok420ReasoningEffortSlider';
 import Hy3ReasoningEffortSlider from './Hy3ReasoningEffortSlider';
 import ImageAspectRatio2Select from './ImageAspectRatio2Select';
@@ -385,6 +386,16 @@ const ControlsForm = memo<ControlsFormProps>(
         layout: 'vertical',
         minWidth: undefined,
         name: 'grok4_5ReasoningEffort',
+        style: {
+          paddingBottom: 0,
+        },
+      },
+      {
+        children: <Grok46ReasoningEffortSlider />,
+        label: t('extendParams.reasoningEffort.title'),
+        layout: 'vertical',
+        minWidth: undefined,
+        name: 'grok4_6ReasoningEffort',
         style: {
           paddingBottom: 0,
         },

--- a/src/features/ModelSwitchPanel/components/ControlsForm/Grok46ReasoningEffortSlider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/Grok46ReasoningEffortSlider.tsx
@@ -1,0 +1,17 @@
+import { type CreatedLevelSliderProps } from './createLevelSlider';
+import { createLevelSliderComponent } from './createLevelSlider';
+
+// Grok 4.6 reasoning is always on: low/medium/high/xhigh (no 'none'), default high.
+const GROK4_6_REASONING_EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh'] as const;
+type Grok46ReasoningEffort = (typeof GROK4_6_REASONING_EFFORT_LEVELS)[number];
+
+export type Grok46ReasoningEffortSliderProps = CreatedLevelSliderProps<Grok46ReasoningEffort>;
+
+const Grok46ReasoningEffortSlider = createLevelSliderComponent<Grok46ReasoningEffort>({
+  configKey: 'grok4_6ReasoningEffort',
+  defaultValue: 'high',
+  levels: GROK4_6_REASONING_EFFORT_LEVELS,
+  style: { minWidth: 200 },
+});
+
+export default Grok46ReasoningEffortSlider;

--- a/src/features/Settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
+++ b/src/features/Settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
@@ -16,6 +16,7 @@ import GPT52ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/C
 import { GPT56ReasoningEffortSlider } from '@/features/ModelSwitchPanel/components/ControlsForm/GPT56ReasoningEffortSlider';
 import Grok43ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/Grok43ReasoningEffortSlider';
 import Grok45ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/Grok45ReasoningEffortSlider';
+import Grok46ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/Grok46ReasoningEffortSlider';
 import Grok420ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/Grok420ReasoningEffortSlider';
 import Hy3ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/Hy3ReasoningEffortSlider';
 import ImageAspectRatio2Select from '@/features/ModelSwitchPanel/components/ControlsForm/ImageAspectRatio2Select';
@@ -130,6 +131,10 @@ const EXTEND_PARAMS_OPTIONS: ExtendParamsOption[] = [
     key: 'grok4_5ReasoningEffort',
   },
   {
+    hintKey: 'providerModels.item.modelConfig.extendParams.options.grok4_6ReasoningEffort.hint',
+    key: 'grok4_6ReasoningEffort',
+  },
+  {
     hintKey: 'providerModels.item.modelConfig.extendParams.options.hy3ReasoningEffort.hint',
     key: 'hy3ReasoningEffort',
   },
@@ -213,6 +218,7 @@ const TITLE_KEY_ALIASES: Partial<Record<ExtendParamsType, ExtendParamsType>> = {
   grok4_20ReasoningEffort: 'reasoningEffort',
   grok4_3ReasoningEffort: 'reasoningEffort',
   grok4_5ReasoningEffort: 'reasoningEffort',
+  grok4_6ReasoningEffort: 'reasoningEffort',
   hy3ReasoningEffort: 'reasoningEffort',
   kimiK3ReasoningEffort: 'reasoningEffort',
   ring2_6ReasoningEffort: 'reasoningEffort',
@@ -275,6 +281,11 @@ const PREVIEW_META: Partial<Record<ExtendParamsType, PreviewMeta>> = {
   },
   grok4_5ReasoningEffort: {
     labelSuffix: ' (Grok 4.5)',
+    previewWidth: 300,
+    tag: 'reasoning_effort',
+  },
+  grok4_6ReasoningEffort: {
+    labelSuffix: ' (Grok 4.6)',
     previewWidth: 300,
     tag: 'reasoning_effort',
   },
@@ -456,6 +467,7 @@ const ExtendParamsSelect = memo<ExtendParamsSelectProps>(({ value, onChange }) =
       grok4_20ReasoningEffort: <Grok420ReasoningEffortSlider value="medium" />,
       grok4_3ReasoningEffort: <Grok43ReasoningEffortSlider value="low" />,
       grok4_5ReasoningEffort: <Grok45ReasoningEffortSlider value="high" />,
+      grok4_6ReasoningEffort: <Grok46ReasoningEffortSlider value="high" />,
       hy3ReasoningEffort: <Hy3ReasoningEffortSlider value="high" />,
       kimiK3ReasoningEffort: <KimiK3ReasoningEffortSlider value="max" />,
       ring2_6ReasoningEffort: <Ring26ReasoningEffortSlider value="high" />,


### PR DESCRIPTION
## ✨ feat

Add Grok 4.6 reasoning effort (`grok4_6ReasoningEffort`) so the model can expose its official `low` / `medium` / `high` / `xhigh` slider. Reasoning cannot be disabled and defaults to `high`.

#### Test

- [x] Added/updated tests
- [ ] Tested locally
- [ ] No tests needed

`bun run check` on the touched files: lint clean, 47 related tests passed.

#### 🔗 Related Issue

N/A

Official docs:
- https://docs.x.ai/developers/models/grok-4.6
- https://docs.x.ai/developers/model-capabilities/text/reasoning#the-reasoning_effort-parameter
- https://x.ai/news/grok-4-6