### PR TITLE
♻️ refactor(agent-signal): drop user-level lab switch for self-iteration

### DIFF
--- a/apps/server/src/services/agentSignal/__tests__/featureGate.test.ts
+++ b/apps/server/src/services/agentSignal/__tests__/featureGate.test.ts
@@ -9,12 +9,6 @@ import {
 
 const mocks = vi.hoisted(() => ({
   getServerFeatureFlagsStateFromRuntimeConfig: vi.fn(),
-  getUserPreference: vi.fn(),
-  UserModel: vi.fn(),
-}));
-
-vi.mock('@/database/models/user', () => ({
-  UserModel: mocks.UserModel,
 }));
 
 vi.mock('@/server/featureFlags', () => ({
@@ -24,14 +18,8 @@ vi.mock('@/server/featureFlags', () => ({
 describe('isAgentSignalEnabledForUser', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.UserModel.mockImplementation(() => ({
-      getUserPreference: mocks.getUserPreference,
-    }));
     mocks.getServerFeatureFlagsStateFromRuntimeConfig.mockResolvedValue({
       enableAgentSelfIteration: true,
-    });
-    mocks.getUserPreference.mockResolvedValue({
-      lab: { enableAgentSelfIteration: false },
     });
   });
 
@@ -39,13 +27,11 @@ describe('isAgentSignalEnabledForUser', () => {
    * @example
    * expect(result).toBe(true).
    */
-  it('uses the feature flag as the user-level Agent Signal gate when lab preference is disabled', async () => {
+  it('uses the feature flag as the user-level Agent Signal gate', async () => {
     const result = await isAgentSignalEnabledForUser({} as never, 'user-1');
 
     expect(result).toBe(true);
     expect(mocks.getServerFeatureFlagsStateFromRuntimeConfig).toHaveBeenCalledWith('user-1');
-    expect(mocks.UserModel).not.toHaveBeenCalled();
-    expect(mocks.getUserPreference).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/server/src/services/agentSignal/services/selfIteration/review/__test__/schedule.test.ts
+++ b/apps/server/src/services/agentSignal/services/selfIteration/review/__test__/schedule.test.ts
@@ -104,6 +104,62 @@ describe('nightlyReviewScheduleService', () => {
       expect(deps.enqueueSource).not.toHaveBeenCalled();
     });
 
+    it('traverses every page of eligible users with a keyset cursor', async () => {
+      const deps = createDeps(new Date('2026-05-03T18:30:00.000Z'));
+      deps.listEligibleUsers
+        .mockResolvedValueOnce([
+          {
+            createdAt: new Date('2026-01-01T00:00:00.000Z'),
+            id: 'user-1',
+            timezone: 'Asia/Shanghai',
+          },
+          {
+            createdAt: new Date('2026-02-01T00:00:00.000Z'),
+            id: 'user-2',
+            timezone: 'Asia/Shanghai',
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            createdAt: new Date('2026-03-01T00:00:00.000Z'),
+            id: 'user-3',
+            timezone: 'Asia/Shanghai',
+          },
+        ])
+        .mockResolvedValueOnce([]);
+      const service = createSelfReviewScheduleService(deps);
+
+      const summary = await service.dispatchNightlyReviewRequests({ limit: 2 });
+
+      expect(summary).toEqual({ enqueued: 3, skipped: 0 });
+      expect(deps.listEligibleUsers).toHaveBeenCalledTimes(3);
+      expect(deps.listEligibleUsers).toHaveBeenNthCalledWith(1, {
+        cursor: undefined,
+        limit: 2,
+        whitelist: undefined,
+      });
+      expect(deps.listEligibleUsers).toHaveBeenNthCalledWith(2, {
+        cursor: { createdAt: new Date('2026-02-01T00:00:00.000Z'), id: 'user-2' },
+        limit: 2,
+        whitelist: undefined,
+      });
+      expect(deps.listEligibleUsers).toHaveBeenNthCalledWith(3, {
+        cursor: { createdAt: new Date('2026-03-01T00:00:00.000Z'), id: 'user-3' },
+        limit: 2,
+        whitelist: undefined,
+      });
+      expect(deps.enqueueSource).toHaveBeenCalledTimes(3);
+    });
+
+    it('stops paginating after the first page when no limit is provided', async () => {
+      const deps = createDeps(new Date('2026-05-03T18:30:00.000Z'));
+      const service = createSelfReviewScheduleService(deps);
+
+      await service.dispatchNightlyReviewRequests();
+
+      expect(deps.listEligibleUsers).toHaveBeenCalledTimes(1);
+    });
+
     it('falls back to UTC for invalid timezone values without throwing', async () => {
       const deps = createDeps(new Date('2026-05-04T02:30:00.000Z'));
       deps.listEligibleUsers.mockResolvedValue([

--- a/apps/server/src/services/agentSignal/services/selfIteration/review/__test__/schedule.test.ts
+++ b/apps/server/src/services/agentSignal/services/selfIteration/review/__test__/schedule.test.ts
@@ -125,13 +125,18 @@ describe('nightlyReviewScheduleService', () => {
             id: 'user-3',
             timezone: 'Asia/Shanghai',
           },
+          {
+            createdAt: new Date('2026-04-01T00:00:00.000Z'),
+            id: 'user-4',
+            timezone: 'Asia/Shanghai',
+          },
         ])
         .mockResolvedValueOnce([]);
       const service = createSelfReviewScheduleService(deps);
 
       const summary = await service.dispatchNightlyReviewRequests({ limit: 2 });
 
-      expect(summary).toEqual({ enqueued: 3, skipped: 0 });
+      expect(summary).toEqual({ enqueued: 4, skipped: 0 });
       expect(deps.listEligibleUsers).toHaveBeenCalledTimes(3);
       expect(deps.listEligibleUsers).toHaveBeenNthCalledWith(1, {
         cursor: undefined,
@@ -144,11 +149,11 @@ describe('nightlyReviewScheduleService', () => {
         whitelist: undefined,
       });
       expect(deps.listEligibleUsers).toHaveBeenNthCalledWith(3, {
-        cursor: { createdAt: new Date('2026-03-01T00:00:00.000Z'), id: 'user-3' },
+        cursor: { createdAt: new Date('2026-04-01T00:00:00.000Z'), id: 'user-4' },
         limit: 2,
         whitelist: undefined,
       });
-      expect(deps.enqueueSource).toHaveBeenCalledTimes(3);
+      expect(deps.enqueueSource).toHaveBeenCalledTimes(4);
     });
 
     it('stops paginating after the first page when no limit is provided', async () => {

--- a/apps/server/src/services/agentSignal/services/selfIteration/review/schedule.ts
+++ b/apps/server/src/services/agentSignal/services/selfIteration/review/schedule.ts
@@ -195,56 +195,77 @@ export const createSelfReviewScheduleService = (
         async (span) => {
           try {
             const now = adapters.now?.() ?? new Date();
-            const users = await adapters.listEligibleUsers({
-              cursor: options.cursor,
-              limit: options.limit,
-              whitelist: options.whitelist,
-            });
             let enqueued = 0;
             let skipped = 0;
             let targetCount = 0;
+            let userCount = 0;
 
-            for (const user of users) {
-              const localWindow = getLocalNightWindow(now, user.timezone);
-
-              if (!localWindow.withinWindow) {
-                skipped += 1;
-                continue;
-              }
-
-              const targets = await adapters.listActiveAgentTargets({
-                limit: options.targetLimit,
-                userId: user.id,
-                windowEnd: localWindow.reviewWindowEnd,
-                windowStart: localWindow.reviewWindowStart,
+            // Traverse every page of eligible users. `listEligibleUsers` is
+            // keyset-paginated (createdAt, id); without a cursor the caller
+            // would repeatedly scan the same oldest `limit` users and never
+            // reach users beyond row `limit` (e.g. when the lab filter was
+            // removed and all users are candidates).
+            let cursor = options.cursor;
+            while (true) {
+              const users = await adapters.listEligibleUsers({
+                cursor,
+                limit: options.limit,
+                whitelist: options.whitelist,
               });
 
-              targetCount += targets.length;
+              if (users.length === 0) break;
+              userCount += users.length;
 
-              for (const target of targets) {
-                await adapters.enqueueSource({
-                  payload: {
-                    agentId: target.agentId,
-                    localDate: localWindow.localDate,
-                    requestedAt: now.toISOString(),
-                    reviewWindowEnd: localWindow.reviewWindowEnd.toISOString(),
-                    reviewWindowStart: localWindow.reviewWindowStart.toISOString(),
-                    timezone: localWindow.timezone,
-                    userId: user.id,
-                  },
-                  sourceId: buildNightlyReviewSourceId({
-                    agentId: target.agentId,
-                    localDate: localWindow.localDate,
-                    userId: user.id,
-                  }),
-                  sourceType: AGENT_SIGNAL_SOURCE_TYPES.agentNightlyReviewRequested,
-                  timestamp: now.getTime(),
+              for (const user of users) {
+                const localWindow = getLocalNightWindow(now, user.timezone);
+
+                if (!localWindow.withinWindow) {
+                  skipped += 1;
+                  continue;
+                }
+
+                const targets = await adapters.listActiveAgentTargets({
+                  limit: options.targetLimit,
+                  userId: user.id,
+                  windowEnd: localWindow.reviewWindowEnd,
+                  windowStart: localWindow.reviewWindowStart,
                 });
-                enqueued += 1;
+
+                targetCount += targets.length;
+
+                for (const target of targets) {
+                  await adapters.enqueueSource({
+                    payload: {
+                      agentId: target.agentId,
+                      localDate: localWindow.localDate,
+                      requestedAt: now.toISOString(),
+                      reviewWindowEnd: localWindow.reviewWindowEnd.toISOString(),
+                      reviewWindowStart: localWindow.reviewWindowStart.toISOString(),
+                      timezone: localWindow.timezone,
+                      userId: user.id,
+                    },
+                    sourceId: buildNightlyReviewSourceId({
+                      agentId: target.agentId,
+                      localDate: localWindow.localDate,
+                      userId: user.id,
+                    }),
+                    sourceType: AGENT_SIGNAL_SOURCE_TYPES.agentNightlyReviewRequested,
+                    timestamp: now.getTime(),
+                  });
+                  enqueued += 1;
+                }
               }
+
+              // Stop when the last page returned fewer rows than the page
+              // size (or when no limit is set and the query is unbounded).
+              if (options.limit === undefined || users.length < options.limit) break;
+
+              const lastUser = users[users.length - 1];
+              if (!lastUser.createdAt) break;
+              cursor = { createdAt: lastUser.createdAt, id: lastUser.id };
             }
 
-            span.setAttribute('agent.signal.nightly.user_count', users.length);
+            span.setAttribute('agent.signal.nightly.user_count', userCount);
             span.setAttribute('agent.signal.nightly.target_count', targetCount);
             span.setAttribute('agent.signal.nightly.enqueued', enqueued);
             span.setAttribute('agent.signal.nightly.skipped', skipped);

--- a/packages/const/src/user.ts
+++ b/packages/const/src/user.ts
@@ -9,7 +9,6 @@ export const DEFAULT_PREFERENCE: UserPreference = {
   },
   lab: {
     enableAgentGraphConfig: false,
-    enableAgentSelfIteration: false,
     enableInputMarkdown: true,
     enableMessageTextSelectionActions: false,
     enableOAuthApps: false,

--- a/packages/database/src/models/agentSignal/__tests__/nightlyReview.test.ts
+++ b/packages/database/src/models/agentSignal/__tests__/nightlyReview.test.ts
@@ -20,22 +20,19 @@ beforeEach(async () => {
 
 describe('AgentSignalNightlyReviewModel', () => {
   describe('listEligibleUsers', () => {
-    it('lists only users with AgentSignal self-iteration enabled', async () => {
+    it('lists all users regardless of the lab opt-in preference', async () => {
       await serverDB.insert(users).values([
         {
           createdAt: new Date('2026-05-01T00:00:00.000Z'),
           id: enabledUserId,
-          preference: { lab: { enableAgentSelfIteration: true } },
         },
         {
           createdAt: new Date('2026-05-02T00:00:00.000Z'),
           id: enabledUserWithoutTimezoneId,
-          preference: { lab: { enableAgentSelfIteration: true } },
         },
         {
           createdAt: new Date('2026-05-03T00:00:00.000Z'),
           id: disabledUserId,
-          preference: { lab: { enableAgentSelfIteration: false } },
         },
       ]);
       await serverDB.insert(userSettings).values({
@@ -58,6 +55,11 @@ describe('AgentSignalNightlyReviewModel', () => {
           id: enabledUserWithoutTimezoneId,
           timezone: 'UTC',
         },
+        {
+          createdAt: new Date('2026-05-03T00:00:00.000Z'),
+          id: disabledUserId,
+          timezone: 'UTC',
+        },
       ]);
     });
 
@@ -66,12 +68,10 @@ describe('AgentSignalNightlyReviewModel', () => {
         {
           createdAt: new Date('2026-05-01T00:00:00.000Z'),
           id: enabledUserId,
-          preference: { lab: { enableAgentSelfIteration: true } },
         },
         {
           createdAt: new Date('2026-05-02T00:00:00.000Z'),
           id: enabledUserWithoutTimezoneId,
-          preference: { lab: { enableAgentSelfIteration: true } },
         },
       ]);
 

--- a/packages/database/src/models/agentSignal/nightlyReview.ts
+++ b/packages/database/src/models/agentSignal/nightlyReview.ts
@@ -98,7 +98,7 @@ export interface AgentSignalNightlyReviewTarget {
  * - Nightly review needs active agent targets for a local-day window
  *
  * Expects:
- * - User-level AgentSignal lab preference is stored on `users.preference.lab`
+ * - Global feature gates are checked by the service layer
  * - Agent-level opt-in is stored on `agents.chatConfig.selfIteration.enabled`
  *
  * Returns:
@@ -112,7 +112,7 @@ export class AgentSignalNightlyReviewModel {
   }
 
   /**
-   * Lists users who opted into AgentSignal self-iteration and have a timezone.
+   * Lists candidate users with a timezone for nightly review scheduling.
    *
    * Use when:
    * - The nightly scheduler needs a stable cursor over possible users
@@ -138,10 +138,6 @@ export class AgentSignalNightlyReviewModel {
         ? inArray(users.id, options.whitelist)
         : undefined;
 
-    const selfIterationEnabledCondition = sql`
-      COALESCE((${users.preference}->'lab'->>'enableAgentSelfIteration')::boolean, false) = true
-    `;
-
     const query = this.db
       .select({
         createdAt: users.createdAt,
@@ -150,7 +146,7 @@ export class AgentSignalNightlyReviewModel {
       })
       .from(users)
       .leftJoin(userSettings, eq(users.id, userSettings.id))
-      .where(and(cursorCondition, whitelistCondition, selfIterationEnabledCondition))
+      .where(and(cursorCondition, whitelistCondition))
       .orderBy(asc(users.createdAt), asc(users.id));
 
     return options.limit !== undefined ? query.limit(options.limit) : query;

--- a/packages/types/src/user/preference.ts
+++ b/packages/types/src/user/preference.ts
@@ -158,10 +158,6 @@ export const UserLabSchema = z.object({
    */
   enableAgentGraphConfig: z.boolean().optional(),
   /**
-   * enable agent self-iteration feedback capture and policy execution
-   */
-  enableAgentSelfIteration: z.boolean().optional(),
-  /**
    * enable artifact deployment features (publish artifacts to a hosted URL)
    */
   enableArtifactDeployment: z.boolean().optional(),

--- a/src/store/chat/slices/agentRun/actions/lifecycle/agentSignalBridge.test.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/agentSignalBridge.test.ts
@@ -35,7 +35,6 @@ describe('emitClientAgentSignalSourceEvent', () => {
 
     vi.mocked(getUserStoreState).mockReturnValue({
       isUserStateInit: true,
-      preference: { lab: { enableAgentSelfIteration: true } },
     } as never);
 
     await emitClientAgentSignalSourceEvent({
@@ -76,7 +75,6 @@ describe('emitClientAgentSignalSourceEvent', () => {
 
     vi.mocked(getUserStoreState).mockReturnValue({
       isUserStateInit: true,
-      preference: { lab: { enableAgentSelfIteration: true } },
     } as never);
 
     await emitClientAgentSignalSourceEvent({
@@ -127,7 +125,6 @@ describe('emitClientAgentSignalSourceEvent', () => {
     });
     vi.mocked(getUserStoreState).mockReturnValue({
       isUserStateInit: true,
-      preference: { lab: { enableAgentSelfIteration: true } },
     } as never);
 
     await emitClientAgentSignalSourceEvent({
@@ -145,14 +142,13 @@ describe('emitClientAgentSignalSourceEvent', () => {
     expect(agentSignalService.emitClientGatewaySourceEvent).not.toHaveBeenCalled();
   });
 
-  it('emits when the feature flag is enabled even if the lab toggle is disabled', async () => {
+  it('emits when the feature flag is enabled and user state is initialized', async () => {
     const { agentSignalService } = await import('@/services/agentSignal');
     const { getUserStoreState } = await import('@/store/user/store');
     const { emitClientAgentSignalSourceEvent } = await import('./agentSignalBridge');
 
     vi.mocked(getUserStoreState).mockReturnValue({
       isUserStateInit: true,
-      preference: { lab: { enableAgentSelfIteration: false } },
     } as never);
 
     await emitClientAgentSignalSourceEvent({
@@ -185,7 +181,6 @@ describe('emitClientAgentSignalSourceEvent', () => {
     });
     vi.mocked(getUserStoreState).mockReturnValue({
       isUserStateInit: false,
-      preference: { lab: { enableAgentSelfIteration: false } },
     } as never);
 
     await emitClientAgentSignalSourceEvent({

--- a/src/store/user/slices/preference/selectors/labPrefer.ts
+++ b/src/store/user/slices/preference/selectors/labPrefer.ts
@@ -7,8 +7,6 @@ export const labPreferSelectors = {
     s.preference.lab?.enableAgentGraphConfig ??
     DEFAULT_PREFERENCE.lab?.enableAgentGraphConfig ??
     false,
-  enableAgentSelfIteration: (s: UserState): boolean =>
-    s.preference.lab?.enableAgentSelfIteration ?? false,
   enableArtifactDeployment: (s: UserState): boolean =>
     s.preference.lab?.enableArtifactDeployment ?? false,
   enableClaudeCodeSdk: (s: UserState): boolean => s.preference.lab?.enableClaudeCodeSdk ?? false,


### PR DESCRIPTION
## Summary

Removes the per-user lab preference gate (`enableAgentSelfIteration`) from Agent Signal nightly review scheduling. Self-iteration capability is now controlled by exactly **two layers**:

1. **Server-side feature flag** (`enableAgentSelfIteration`) — global rollout
2. **Per-agent opt-in** (`agents.chatConfig.selfIteration.enabled`) — per-agent capability

The user-level lab preference duplicated the feature flag and added a third hidden gate that **silently skipped nightly reviews** when unset (dispatch ran, `enqueued: 0`, no error surfaced).

## Changes

### Core

- **`packages/database/src/models/agentSignal/nightlyReview.ts`**: `listEligibleUsers` no longer filters by `users.preference.lab.enableAgentSelfIteration`. User candidate discovery is now purely cursor/whitelist pagination; capability gating is delegated to `listActiveAgentTargets` (agent switch) and `enqueueAgentSignalSourceEvent` (feature flag).

### Cleanup (lab switch had no remaining consumers)

- **`packages/types/src/user/preference.ts`**: removed `enableAgentSelfIteration` from `UserLabSchema`
- **`packages/const/src/user.ts`**: removed `enableAgentSelfIteration` from `DEFAULT_PREFERENCE.lab`
- **`src/store/user/slices/preference/selectors/labPrefer.ts`**: removed unused `enableAgentSelfIteration` selector

### Tests

- **`nightlyReview.test.ts`**: `listEligibleUsers` now returns all users regardless of lab preference; removed lab fields from seed data
- **`featureGate.test.ts`**: removed `UserModel`/lab mocks — the gate depends only on the server feature flag
- **`agentSignalBridge.test.ts`**: removed stale lab preference mocks; renamed test that referenced the removed lab toggle

## Why this is safe

- The enqueue path (`enqueueAgentSignalSourceEvent`) already re-checks `isAgentSignalEnabledForUser` (feature flag only) — the lab switch never influenced execution, only scheduling eligibility.
- `resolveAgentSelfIterationCapability` (used during execution) already checks feature flag + agent switch, not the lab preference.
- Frontend UI gating (`ChatList`, `AgentSettingsContent`, `AgentCategory`, `agentSignalBridge`) reads `featureFlags.enableAgentSelfIteration` (server config), not the lab preference.

## How to Test

```bash
pnpm vitest run packages/database/src/models/agentSignal/__tests__/nightlyReview.test.ts
pnpm vitest run apps/server/src/services/agentSignal/__tests__/featureGate.test.ts
pnpm vitest run src/store/chat/slices/agentRun/actions/lifecycle/agentSignalBridge.test.ts
```

Verify that `listEligibleUsers` returns users regardless of `preference.lab.enableAgentSelfIteration`, while `listActiveAgentTargets` still only returns agents with `chatConfig.selfIteration.enabled = true` (or Lobe AI inbox).