### PR TITLE
📝 docs(readme): fix deployment heading punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You stay in charge — without staying online.
   - [Collaborate: Scale New Forms of Collaboration Networks](#collaborate-scale-new-forms-of-collaboration-networks)
   - [Evolve: Co-evolution of Humans and Agents](#evolve-co-evolution-of-humans-and-agents)
 - [🛳 Self Hosting](#-self-hosting)
-  - [`A` Deploying with Vercel, Zeabur , Sealos or Alibaba Cloud](#a-deploying-with-vercel-zeabur--sealos-or-alibaba-cloud)
+  - [`A` Deploying with Vercel, Zeabur, Sealos or Alibaba Cloud](#a-deploying-with-vercel-zeabur-sealos-or-alibaba-cloud)
   - [`B` Deploying with Docker](#b-deploying-with-docker)
   - [Environment Variable](#environment-variable)
   - [Obtain OpenAI API Key](#obtain-openai-api-key)
@@ -204,7 +204,7 @@ LobeHub provides Self-Hosted Version with Vercel, Alibaba Cloud, and [Docker Ima
 >
 > Learn more about [📘 Build your own LobeHub][docs-self-hosting] by checking it out.
 
-### `A` Deploying with Vercel, Zeabur , Sealos or Alibaba Cloud
+### `A` Deploying with Vercel, Zeabur, Sealos or Alibaba Cloud
 
 "If you want to deploy this service yourself on Vercel, Zeabur or Alibaba Cloud, you can follow these steps:
 
@@ -307,8 +307,8 @@ An API Key is required to chat with LLMs in LobeHub. This section uses the OpenA
 
 If you find signing up for an OpenAI account or binding a foreign-currency credit card troublesome, you can consider using a well-known OpenAI third-party proxy to obtain an API Key, which can effectively lower the barrier to getting one. At the same time, however, once you use a third-party service, you may also need to bear its potential risks — please decide based on your own actual situation. Below is a list of common third-party model proxies for your reference:
 
-|                                                                     | Provider     | Features                                                                                                | Proxy URL                 | Link                              |
-| ------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------- | ------------------------- | --------------------------------- |
+|                                                                     | Provider     | Features                                                                                                                  | Proxy URL                 | Link                                               |
+| ------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------- | ------------------------- | -------------------------------------------------- |
 | <img src="https://resource.aihubmix.com/logo.png?v=1" width="48" /> | **AIHubMix** | Uses the OpenAI enterprise API; all models site-wide at **14% off** the official price (incl. GPT-5.6 and Claude Fable 5) | `https://aihubmix.com/v1` | [Get](https://console.aihubmix.com/token?aff=8DBz) |
 
 > \[!WARNING]


### PR DESCRIPTION
#### Description of Change

- Correct the punctuation in the Zeabur deployment heading and its table-of-contents anchor.
- Apply the repository Markdown formatter's table alignment update.

#### Test

- [x] Tested locally (`bun run check README.md`)
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

None.