### PR TITLE
chore: remove internal LOBE-XXX issue references from code comments

### DIFF
--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextBuilder.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextBuilder.ts
@@ -487,7 +487,7 @@ export const buildServerCallLlmContext = async ({
   // Group Agent Builder — mirrors the block above for the group Profile panel.
   // Without this the model has no idea which group it is editing, so it cannot
   // address members by id (updateAgentPrompt) and falls back to telling the user
-  // to wire the group up by hand (LOBE-12941).
+  // to wire the group up by hand, which left built-in group agents out of the member list.
   let groupAgentBuilderContext: GroupAgentBuilderContext | undefined;
   const editingGroupId = state.metadata?.editingGroupId;
   if (editingGroupId && ctx.serverDB && ctx.userId) {

--- a/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
@@ -185,7 +185,7 @@ describe('createServerToolsEngine', () => {
     expect(availablePlugins).toContain('test-plugin');
   });
 
-  it('drops manifests without an api array instead of crashing the tools build (LOBE-12528)', () => {
+  it('drops manifests without an api array instead of crashing the tools build', () => {
     // A DB plugin row whose manifest jsonb lacks `api` used to crash
     // ToolsEngine.convertManifestsToTools (`manifest.api.map`) and with it
     // every execAgent call of the affected user.

--- a/apps/server/src/routers/lambda/__tests__/messenger.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/messenger.test.ts
@@ -338,8 +338,9 @@ describe('messengerRouter.listMyInstallations', () => {
   // Telegram is an env/DB-backed singleton with no `messenger_installations`
   // row, and it stays absent here on purpose: this procedure doubles as
   // send-target discovery for the client tool adapter, which cannot act on a
-  // `messengerInstallationId` (LOBE-12706). Surfacing the singleton would let
-  // the model pick a target that then fails with `No enabled bot found for
+  // `messengerInstallationId` (sends cannot route through a System Bot
+  // installation). Surfacing the singleton would let the model pick a target
+  // that then fails with `No enabled bot found for
   // platform "telegram"`. Reaching the user themselves goes through
   // `sendMessengerPush` and never consults this list.
   it('omits Telegram even when the deployment is configured and the user has linked', async () => {

--- a/apps/server/src/routers/lambda/__tests__/workspaceUserSettings.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/workspaceUserSettings.test.ts
@@ -60,7 +60,7 @@ describe('workspaceUserSettingsRouter.updatePreference', () => {
     mockChatGroupUpdate.mockResolvedValue({ id: 'cg_1' });
   });
 
-  describe('legacy sidebarGroupAssignments compat (LOBE-12860)', () => {
+  describe('legacy sidebarGroupAssignments compat for workspace members', () => {
     it('translates a pre-shared-sidebar move into the shared sessionGroupId write', async () => {
       // A client from before the shared-sidebar change still sends its
       // "Move to Category" through this per-member map, which the sidebar no

--- a/apps/server/src/routers/lambda/messenger.ts
+++ b/apps/server/src/routers/lambda/messenger.ts
@@ -974,8 +974,9 @@ export const messengerRouter = router({
     // Telegram is deliberately absent here even though the account link makes it
     // reachable. This list doubles as send-target discovery for the client tool
     // adapter, which resolves a per-agent `botId` from `platform` and ignores
-    // `messengerInstallationId` (see LOBE-12706). Surfacing the synthetic
-    // singleton would turn a clean "I can't reach Telegram" into a confusing
+    // `messengerInstallationId` (it cannot route a send through a System Bot
+    // installation). Surfacing the synthetic singleton would turn a clean
+    // "I can't reach Telegram" into a confusing
     // `No enabled bot found for platform "telegram"` for anyone who linked the
     // System Bot but has no per-agent Telegram provider. Reaching the user
     // themselves does not need this list at all — that is `sendMessengerPush`,

--- a/apps/server/src/services/agent/index.test.ts
+++ b/apps/server/src/services/agent/index.test.ts
@@ -516,7 +516,7 @@ describe('AgentService', () => {
 
     // Builtin agent rows are provisioned without avatar; the client replaces its
     // cached entry with this snapshot, so the snapshot must carry the builtin
-    // avatar or the UI degrades to the default robot avatar (LOBE-12876)
+    // avatar or the UI degrades to the default robot avatar
     it('should fall back to the builtin avatar when a builtin agent row has none', async () => {
       const mockAgent = {
         avatar: null,

--- a/apps/server/src/services/toolExecution/serverRuntimes/groupAgentBuilder.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/groupAgentBuilder.ts
@@ -7,7 +7,7 @@
  * `toolExecution/builtin.ts` throws `Builtin tool "lobe-group-agent-builder" is
  * not implemented` and *every* member/config mutation fails — the model then
  * falls back to generic agent creation, which spawns standalone agents outside
- * the group (LOBE-12941).
+ * the group.
  *
  * The edited group rides on `ctx.editingGroupId` (see `ExecAgentAppContext`),
  * NOT `ctx.groupId`: the builder conversation is owned by the builtin builder

--- a/apps/server/src/services/verify/prompts.ts
+++ b/apps/server/src/services/verify/prompts.ts
@@ -221,7 +221,7 @@ export interface ReviewPredictPromptInput {
 }
 
 /**
- * The offline baseline (LOBE-13035, 187 real samples across kimi-k3,
+ * The offline baseline (187 real samples across kimi-k3,
  * gemini-3.6-flash and gemini-3.1-pro) shaped every rule below. Two findings did
  * most of the shaping:
  *

--- a/packages/builtin-tool-activator/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-activator/src/ExecutionRuntime/index.ts
@@ -109,7 +109,7 @@ export class ActivatorExecutionRuntime {
         // manifest (systemRole + API schemas) injected into the system prompt
         // from the next LLM call onwards, so the result only needs to list the
         // newly callable APIs — returning the full docs here would double-carry
-        // them in every subsequent payload (LOBE-5684).
+        // them in every subsequent payload.
         const apiNames = manifests.flatMap((manifest) =>
           manifest.apiDescriptions.length > 0
             ? manifest.apiDescriptions.map((api) => `${manifest.identifier}.${api.name}`)

--- a/packages/builtin-tool-local-system/src/__tests__/systemRole.test.ts
+++ b/packages/builtin-tool-local-system/src/__tests__/systemRole.test.ts
@@ -12,7 +12,7 @@ describe('systemRole templates', () => {
    * `.desktop` variant is a client-only vite module swap. Keep the environment
    * facts in sync: a placeholder present only in the desktop variant means
    * gateway prompts silently lose information the local prompt has (this is
-   * how gateway runs ended up without the known-locations list, LOBE-12692).
+   * how gateway runs ended up without the known-locations list).
    */
   it('generic template carries every placeholder the desktop variant has', () => {
     const generic = extractPlaceholders(genericPrompt);

--- a/packages/builtin-tool-local-system/src/shellSyntaxGuidance.ts
+++ b/packages/builtin-tool-local-system/src/shellSyntaxGuidance.ts
@@ -3,7 +3,7 @@
  * the local-system system role, so the model only ever sees instructions for
  * the shell `runCommand` actually spawns. The previous prompt always carried
  * the PowerShell 5.1 guidance, which anchored models into emitting PowerShell
- * commands even when the user had selected Git Bash (LOBE-12692).
+ * commands even when the user had selected Git Bash.
  *
  * Matching is by the human-readable shell names produced by `getShellInfo()`
  * in `@lobechat/local-file-shell` ("Git Bash", "PowerShell 7+ (pwsh)",

--- a/packages/const/src/apiKeyScope.ts
+++ b/packages/const/src/apiKeyScope.ts
@@ -282,7 +282,7 @@ export const TRPC_NAMESPACE_API_KEY_RULES: Record<string, TrpcNamespaceScopeRule
  * retrieval/indexing infrastructure owned by their domain scope, their
  * per-call cost is marginal, and file-upload pipelines trigger the same
  * embedding work outside this guard anyway. Whether embeddings deserve their
- * own scope (e.g. `model:embed`) is tracked in LOBE-12910.
+ * own scope (e.g. `model:embed`) is an open product decision.
  */
 const AGENT_RUN_SCOPES: ApiKeyScope[] = ['chat:write', 'model:invoke'];
 

--- a/packages/const/src/rbac.test.ts
+++ b/packages/const/src/rbac.test.ts
@@ -56,7 +56,7 @@ describe('workspace built-in roles', () => {
   });
 });
 
-describe('personal default permissions (LOBE-12892)', () => {
+describe('personal default permissions', () => {
   it('grants only :owner codes plus the shared-registry :all resources', () => {
     for (const code of PERSONAL_DEFAULT_PERMISSIONS) {
       const [resource, , scope] = [code.split(':')[0], code.split(':')[1], code.split(':')[2]];

--- a/packages/const/src/rbac.ts
+++ b/packages/const/src/rbac.ts
@@ -628,7 +628,7 @@ export const getWorkspaceRolePermissionCodes = (role: string): readonly string[]
  * Default permission codes every authenticated user holds over their OWN data
  * in personal (non-workspace) context.
  *
- * Why this exists (LOBE-12892): ordinary accounts have no `rbac_user_roles`
+ * Why this exists: ordinary accounts have no `rbac_user_roles`
  * rows — roles are only assigned via the admin backend — so any personal-mode
  * check that consulted the DB alone returned 403 for every registered user,
  * making the OpenAPI surface admin-only in practice. Personal data is already

--- a/packages/const/src/verify.ts
+++ b/packages/const/src/verify.ts
@@ -235,7 +235,7 @@ export const acceptanceCheckReviewActions = ['accept', 'ignore', 'reject'] as co
 export type AcceptanceCheckReviewAction = (typeof acceptanceCheckReviewActions)[number];
 
 /**
- * Why a reviewer rejected a check. The offline baseline (LOBE-13035) found that
+ * Why a reviewer rejected a check. The offline baseline found that
  * three different models converged on the same "wrong" answer for 24 of the
  * checks a human had rejected — because the reject button is the only outbound
  * channel on the page, so it carries three unrelated jobs at once. Only `unmet`

--- a/packages/context-engine/src/engine/messages/MessagesEngine.ts
+++ b/packages/context-engine/src/engine/messages/MessagesEngine.ts
@@ -231,7 +231,7 @@ export class MessagesEngine {
     // (enable flags + FC support + the shared select predicates) so
     // ActivationResultTrimProcessor only trims activation tool results whose full
     // documentation is confirmed to be injected into the system prompt for this
-    // request — see LOBE-5684.
+    // request.
     const canUseFC = capabilities?.isCanUseFC || (() => true);
     const injectedActivatedSkills =
       isAgentMode && (skillsConfig?.enabledSkills?.length ?? 0) > 0

--- a/packages/context-engine/src/engine/messages/__tests__/MessagesEngine.activationResultTrim.test.ts
+++ b/packages/context-engine/src/engine/messages/__tests__/MessagesEngine.activationResultTrim.test.ts
@@ -8,7 +8,7 @@ import { MessagesEngine } from '../MessagesEngine';
 import type { MessagesEngineParams } from '../types';
 
 /**
- * Regression tests for LOBE-5684: after dynamic activation, the full tool
+ * Regression tests: after dynamic activation, the full tool
  * systemRole / skill content must reach the final LLM payload exactly once —
  * either via the system prompt injection OR via the activation tool result,
  * never both.
@@ -134,7 +134,7 @@ const countInPayload = (messages: any[], needle: string) => {
   return haystack.split(needle).length - 1;
 };
 
-describe('MessagesEngine — activation result trimming (LOBE-5684)', () => {
+describe('MessagesEngine — activation result trimming', () => {
   describe('activateTools', () => {
     it('should carry an activated manifest systemRole exactly once when injected', async () => {
       const engine = new MessagesEngine(

--- a/packages/context-engine/src/processors/ActivationResultTrim.ts
+++ b/packages/context-engine/src/processors/ActivationResultTrim.ts
@@ -62,7 +62,7 @@ export interface ActivationResultTrimConfig {
  * injected into the system prompt, so each activated tool/skill document
  * reaches the LLM payload exactly once.
  *
- * Background (LOBE-5684): `activateTools` used to write the manifest
+ * Background: `activateTools` used to write the manifest
  * systemRole + API descriptions into its `role=tool` result, and once
  * activated the same manifest enters ToolSystemRoleProvider's system-prompt
  * injection on every subsequent request — permanently double-carrying the

--- a/packages/conversation-flow/src/parse.ts
+++ b/packages/conversation-flow/src/parse.ts
@@ -143,7 +143,7 @@ export function parse(messages: Message[], messageGroups?: MessageGroupMetadata[
     return next;
   });
 
-  // Historical LOBE-12497 data can contain a taskCallback and a tool result as
+  // Historical data can contain a taskCallback and a tool result as
   // sibling branches under the same assistant tool-use shell. Normal branch
   // resolution must keep choosing one conversational continuation, but hiding
   // the inactive callback also hides the only user-visible record that a task

--- a/packages/database/src/models/__tests__/agentCopyJob.test.ts
+++ b/packages/database/src/models/__tests__/agentCopyJob.test.ts
@@ -338,7 +338,7 @@ describe('AgentCopyJobModel', () => {
     await expect(agentModel.delete(source.id)).rejects.toThrow(AGENT_COPY_IN_PROGRESS);
   });
 
-  // LOBE-12922: copy sits on the ordinary user path, so a pending copy job
+  // Copy sits on the ordinary user path, so a pending copy job
   // must never wedge an owner's workspace/account deletion the way a pending
   // transfer does — the cloud delete flows cancel Stripe and wipe the billing
   // rows BEFORE they reach these guards.
@@ -379,10 +379,10 @@ describe('AgentCopyJobModel', () => {
     expect(await serverDB.query.users.findFirst({ where: eq(users.id, userId) })).toBeUndefined();
   });
 
-  // LOBE-12935: a copy drives the SAME migration UI as a transfer (progress
+  // A copy drives the SAME migration UI as a transfer (progress
   // badge, topic gray-out, open-to-prioritize) and shares the same crash-
   // recovery net. Every query behind those must stay type-agnostic; only the
-  // owner-delete guards (LOBE-12922) and the per-type drains filter by type.
+  // owner-delete guards and the per-type drains filter by type.
   it('stays visible to the shared migration queries while pending', async () => {
     const source = await seedSourceAgent();
     const { jobId, newAgent, topicPairs } = await seedTargetShells(source.id);

--- a/packages/database/src/models/__tests__/rbac.test.ts
+++ b/packages/database/src/models/__tests__/rbac.test.ts
@@ -387,7 +387,7 @@ describe('RbacModel — back-compat: no workspaceId', () => {
   });
 });
 
-describe('RbacModel — personal mode implicit baseline (LOBE-12892)', () => {
+describe('RbacModel — personal mode implicit baseline', () => {
   it('grants the :owner content baseline to a user with NO rbac_user_roles rows', async () => {
     const rbac = new RbacModel(serverDB, userId);
 

--- a/packages/database/src/models/agentTransferJob.ts
+++ b/packages/database/src/models/agentTransferJob.ts
@@ -236,7 +236,7 @@ export const remapResidualMessageAgentIds = async (
  * Blocking on copy jobs is therefore pure cost: copy sits on the ordinary user
  * path (importing a heavy agent into a workspace), so it would let any member
  * wedge an owner's workspace/account deletion — after the caller has already
- * cancelled Stripe and wiped the billing rows. See LOBE-12922.
+ * cancelled Stripe and wiped the billing rows.
  */
 const isPendingTransfer = () =>
   and(eq(agentHistoryJobs.status, 'pending'), eq(agentHistoryJobs.type, 'transfer'));
@@ -350,7 +350,7 @@ export class AgentTransferJobModel {
    * agent is exactly the one a concurrent transfer must not move: the copy's
    * drain keeps writing history into the scope the transfer just rewrote, so
    * the conversation ends up split across both scopes. Exempting `copy` from
-   * the OWNER-DELETE guards (LOBE-12922) is a separate judgement — it does not
+   * the OWNER-DELETE guards is a separate judgement — it does not
    * extend to agent mutations.
    */
   static hasPendingJobForAgents = async (

--- a/packages/database/src/models/rbac.ts
+++ b/packages/database/src/models/rbac.ts
@@ -233,7 +233,7 @@ export class RbacModel {
       );
 
     // Personal mode: every authenticated user implicitly holds the `:owner`
-    // baseline over their own data (LOBE-12892) — ordinary accounts have no
+    // baseline over their own data — ordinary accounts have no
     // `rbac_user_roles` rows, and resource queries are `user_id`-isolated
     // anyway. DB grants (super_admin etc.) union on top.
     // De-dupe — the same code can come from multiple roles (e.g. owner +
@@ -315,7 +315,7 @@ export class RbacModel {
     }
 
     // Personal mode: the implicit `:owner` baseline settles most checks with
-    // zero DB queries (LOBE-12892). Workspace mode above is untouched — the
+    // zero DB queries. Workspace mode above is untouched — the
     // membership-role matrix stays the single source of truth there.
     if (permissionCodes.some((code) => PERSONAL_DEFAULT_PERMISSIONS.includes(code))) {
       return true;

--- a/packages/database/src/repositories/search/index.test.ts
+++ b/packages/database/src/repositories/search/index.test.ts
@@ -1328,7 +1328,7 @@ describe.skipIf(!isServerDB)('SearchRepo', () => {
     });
   });
 
-  // Regression guard for LOBE-12379: the BM25 scans were split into an inner
+  // Regression guard: the BM25 scans were split into an inner
   // single-table subquery (so ParadeDB can pick its TopN custom scan) with the
   // joins and — in personal mode — the `workspace_id IS NULL` check moved above
   // it. These tests pin the two things that split could break: rows leaking
@@ -1545,7 +1545,7 @@ describe.skipIf(!isServerDB)('SearchRepo', () => {
       if (hit?.type === 'file') expect(hit.knowledgeBaseId).toBe(base.id);
     });
   });
-  // Regression guard for LOBE-12575: the agent filter on topics/messages moved
+  // Regression guard: the agent filter on topics/messages moved
   // from inside the BM25 scan to above it (over-fetching through a deep
   // candidate pool). These tests pin the result semantics that move could
   // break: rows leaking across agents, and the filter being lost entirely.
@@ -1629,7 +1629,7 @@ describe.skipIf(!isServerDB)('SearchRepo', () => {
 
   // The workspace-scoping tests above pin *results*, and this change is
   // deliberately result-neutral — they pass against the pre-fix implementation
-  // too. What actually fixes LOBE-12379 is the *shape* of the emitted SQL, so
+  // too. What actually fixes the latency regression is the *shape* of the emitted SQL, so
   // it needs its own guard: ParadeDB only picks `TopNScanExecState` when the
   // scan node itself carries the whole `ORDER BY paradedb.score() LIMIT n`.
   //
@@ -1768,7 +1768,7 @@ describe.skipIf(!isServerDB)('SearchRepo', () => {
       }
     });
 
-    // Guard for LOBE-12575: `agent_id` is not a BM25 field either — inside the
+    // Guard: `agent_id` is not a BM25 field either — inside the
     // scan it costs TopN and, on production pg_search 0.15.26, NULLs out every
     // score (arbitrary order, flat relevance 3). The agent filter must sit
     // above the scan, backed by a deepened candidate pool.

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.test.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.test.ts
@@ -24,7 +24,7 @@ describe('Anthropic generateObject', () => {
     );
   });
 
-  it('should strip trailing assistant messages for models without prefill support (LOBE-12572)', async () => {
+  it('should strip trailing assistant messages for models without prefill support', async () => {
     const { requestParams } = await buildAnthropicGenerateObjectRequest({
       messages: [
         { content: 'Generate data', role: 'user' as const },

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.test.ts
@@ -424,7 +424,7 @@ describe('createAnthropicCompatibleRuntime', () => {
   it('should strip trailing assistant prefill when a logical id maps to a Claude 5 model', async () => {
     // The prefill strip inside handlePayload sees the logical id; when the
     // mapping only later resolves to a Claude 4.6+/5 upstream id, chat() must
-    // re-strip against the model actually sent (LOBE-12572).
+    // re-strip against the model actually sent.
     const messagesCreate = vi.fn().mockResolvedValue({ content: [] });
     const Runtime = createAnthropicCompatibleRuntime({
       chatCompletion: {

--- a/packages/openapi/src/controllers/user.controller.test.ts
+++ b/packages/openapi/src/controllers/user.controller.test.ts
@@ -15,7 +15,7 @@ const { UserController } = await import('./user.controller');
 
 /**
  * `/me` is open to any authenticated caller so a key can resolve its own
- * identity (LOBE-12934), which makes `messageCount` the one field on it that
+ * identity, which makes `messageCount` the one field on it that
  * still needs gating — it is chat-usage metadata, not identity.
  */
 describe('UserController.getCurrentUser', () => {

--- a/packages/openapi/src/controllers/user.controller.ts
+++ b/packages/openapi/src/controllers/user.controller.ts
@@ -26,7 +26,7 @@ export class UserController extends BaseController {
 
   /**
    * `/me` is reachable by every authenticated caller so a key can resolve its
-   * own identity — `lh login` depends on it (LOBE-12934). What it *returns*
+   * own identity — `lh login` depends on it. What it *returns*
    * is still scoped, because identity bootstrap needs an id, not a profile:
    *
    * - without `user:read` the response is narrowed to the id, keeping the

--- a/packages/openapi/src/routes/users.route.test.ts
+++ b/packages/openapi/src/routes/users.route.test.ts
@@ -22,7 +22,7 @@ const { default: UserRoutes } = await import('./users.route');
 /**
  * A key minted with narrow scopes still has to be able to identify itself, or
  * `lh login` cannot resolve a userId from it. Guarding this route on
- * `user:read` stranded such keys outside the product — see LOBE-12934.
+ * `user:read` stranded such keys outside the product.
  */
 describe('GET /users/me', () => {
   const requestAs = (apiKeyScopes: string[]) => {

--- a/packages/openapi/src/routes/users.route.ts
+++ b/packages/openapi/src/routes/users.route.ts
@@ -36,7 +36,7 @@ UserRoutes.get(
   // Reachability is not disclosure: the payload is scoped inside
   // `UserController.getCurrentUser` — a key without `user:read` receives only
   // `{ id }`, and `messageCount` additionally needs `chat:read`. Widen there,
-  // under a scope check, rather than by gating the route. See LOBE-12934.
+  // under a scope check, rather than by gating the route.
   async (c) => {
     const userController = new UserController();
     return await userController.getCurrentUser(c);

--- a/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.test.tsx
+++ b/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.test.tsx
@@ -112,7 +112,7 @@ describe('useBuilderSuggestions', () => {
     expect(result.current.suggestions[0]?.title).toBe('second title');
   });
 
-  // Regression for LOBE-12895: suggestions are persisted via the tiered SWR
+  // Regression: suggestions are persisted via the tiered SWR
   // cache provider. A cache hit (e.g. hydrated from localStorage on a revisit)
   // must render directly without paying another LLM generation.
   it('serves a persisted cache hit without regenerating', async () => {


### PR DESCRIPTION
## Summary

This PR removes internal `LOBE-XXX` Linear issue references from code comments across the codebase.

Since LobeHub is an open-source project, internal issue tracker IDs (`LOBE-XXXXX`) are meaningless to external contributors. Each reference was rewritten to describe the underlying scenario or rationale it was pointing at, in plain English, so the comments remain self-contained and useful.

No code behavior changes — these are comment-only edits.

## Changes

- Rewrote 39 comment references across 31 files, replacing `LOBE-XXX` IDs with an inline description of the bug/scenario they referenced.
- Removed `LOBE-XXX` suffixes from test `describe`/`it` names where the surrounding comment already explained the context.

## Changed files

```
apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextBuilder.ts
apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
apps/server/src/routers/lambda/__tests__/messenger.test.ts
apps/server/src/routers/lambda/__tests__/workspaceUserSettings.test.ts
apps/server/src/routers/lambda/messenger.ts
apps/server/src/services/agent/index.test.ts
apps/server/src/services/toolExecution/serverRuntimes/groupAgentBuilder.ts
apps/server/src/services/verify/prompts.ts
packages/builtin-tool-activator/src/ExecutionRuntime/index.ts
packages/builtin-tool-local-system/src/__tests__/systemRole.test.ts
packages/builtin-tool-local-system/src/shellSyntaxGuidance.ts
packages/const/src/apiKeyScope.ts
packages/const/src/rbac.test.ts
packages/const/src/rbac.ts
packages/const/src/verify.ts
packages/context-engine/src/engine/messages/MessagesEngine.ts
packages/context-engine/src/engine/messages/__tests__/MessagesEngine.activationResultTrim.test.ts
packages/context-engine/src/processors/ActivationResultTrim.ts
packages/conversation-flow/src/parse.ts
packages/database/src/models/__tests__/agentCopyJob.test.ts
packages/database/src/models/__tests__/rbac.test.ts
packages/database/src/models/agentTransferJob.ts
packages/database/src/models/rbac.ts
packages/database/src/repositories/search/index.test.ts
packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.test.ts
packages/model-runtime/src/core/anthropicCompatibleFactory/index.test.ts
packages/openapi/src/controllers/user.controller.test.ts
packages/openapi/src/controllers/user.controller.ts
packages/openapi/src/routes/users.route.test.ts
packages/openapi/src/routes/users.route.ts
src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.test.tsx
```
