### PR TITLE
🔧 chore(orb): preinstall LobeHub CLI

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -75,6 +75,16 @@ corepack install --global "${package_manager}"
 ln -sfn "${node_dir}/bin/pnpm" "${LOCAL_BIN}/pnpm"
 hash -r
 
+echo "==> Installing the latest LobeHub CLI"
+"${node_dir}/bin/npm" install \
+  --global \
+  --prefix "${node_dir}" \
+  "@lobehub/cli@latest"
+for executable in lh lobe lobehub; do
+  ln -sfn "${node_dir}/bin/${executable}" "${LOCAL_BIN}/${executable}"
+done
+hash -r
+
 bun_dir="${TOOLCHAIN_ROOT}/bun-v${BUN_VERSION}"
 if [[ ! -x "${bun_dir}/bun" ]]; then
   echo "==> Installing Bun ${BUN_VERSION}"
@@ -97,6 +107,7 @@ echo "==> Toolchain versions"
 node --version
 pnpm --version
 bun --version
+lh --version
 
 if [[ ! -f .env ]]; then
   echo "==> Creating the local development environment file"


### PR DESCRIPTION
Preinstall the latest published `@lobehub/cli` in every new Amp Orb so `lh`, `lobe`, and `lobehub` are immediately available. The setup also prints the installed CLI version with the other toolchain versions.

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Validation performed:

- `bash -n .agents/setup`
- Installed `@lobehub/cli@latest` into a clean temporary npm prefix and verified all three binaries
- `bun run check .agents/setup`

#### 🔗 Related Issue

None.
