### PR TITLE
🐛 fix(model-runtime): strip Kimi K3 sampling params

### DIFF
--- a/packages/model-runtime/src/providers/opencodeCodingPlan/index.test.ts
+++ b/packages/model-runtime/src/providers/opencodeCodingPlan/index.test.ts
@@ -310,6 +310,24 @@ describe('buildOpenAIPayload Kimi thinking semantics', () => {
   });
 
   describe('native-thinking K3 models (kimi-k3)', () => {
+    it('should omit fixed sampling parameters', async () => {
+      await instance.chat({
+        frequency_penalty: 0.2,
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'kimi-k3',
+        presence_penalty: 0.3,
+        temperature: 0.7,
+        top_p: 0.8,
+      } as any);
+
+      const payload = getLastRequestPayload();
+
+      expect(payload).not.toHaveProperty('frequency_penalty');
+      expect(payload).not.toHaveProperty('presence_penalty');
+      expect(payload).not.toHaveProperty('temperature');
+      expect(payload).not.toHaveProperty('top_p');
+    });
+
     it("should drop a saved thinking:disabled and keep reasoning_effort 'max' + forced reasoning_content", async () => {
       await instance.chat({
         messages: [

--- a/packages/model-runtime/src/providers/opencodeCodingPlan/index.ts
+++ b/packages/model-runtime/src/providers/opencodeCodingPlan/index.ts
@@ -382,6 +382,14 @@ const buildOpenAIPayload = (
   });
 
   const { reasoning_effort, thinking, ...restPayload } = payload;
+  const {
+    frequency_penalty: _frequencyPenalty,
+    presence_penalty: _presencePenalty,
+    temperature: _temperature,
+    top_p: _topP,
+    ...kimiRestPayload
+  } = restPayload;
+  const sanitizedPayload = isKimiReasoningEffortModel(model) ? kimiRestPayload : restPayload;
 
   // Sanitize response_format for Kimi models
   const response_format =
@@ -413,7 +421,7 @@ const buildOpenAIPayload = (
       : restPayload.tools;
 
   return {
-    ...restPayload,
+    ...sanitizedPayload,
     messages,
     response_format,
     tools,


### PR DESCRIPTION
OpenCode Go currently forwards saved sampling parameters to Kimi K3, although K3 fixes those values server-side and rejects unsupported values such as `top_p`. This makes the automatically discovered model unusable when cross-model settings are present.

This change mirrors the existing Moonshot K3 payload behavior by removing `temperature`, `top_p`, `frequency_penalty`, and `presence_penalty` only for K3+ models. K2.x and non-Kimi payloads are unchanged.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- `pnpm --dir packages/model-runtime exec vitest run --silent=passed-only src/providers/opencodeCodingPlan/index.test.ts` — 18 passed
- production file ESLint — passed
- package TypeScript check was attempted with 2 GB and 4 GB heaps; both exhausted memory without reporting a type diagnostic, and `tsgo --noEmit` was killed by the host

#### 🔗 Related Issue

Fixes #18172