### PR TITLE
🐛 fix(spa): show agents without sessions in sidebar

### DIFF
--- a/packages/database/src/models/__tests__/session.test.ts
+++ b/packages/database/src/models/__tests__/session.test.ts
@@ -115,6 +115,24 @@ describe('SessionModel', () => {
       expect(result.sessionGroups).toHaveLength(0);
     });
 
+    it('should include non-virtual agents without a linked session', async () => {
+      await serverDB.insert(agents).values([
+        { id: 'orphan-agent', title: 'Orphan Agent', userId, model: 'gpt-4' },
+        { id: 'virtual-agent', title: 'Virtual Agent', userId, virtual: true },
+      ]);
+
+      const result = await sessionModel.queryWithGroups();
+
+      expect(result.sessions).toHaveLength(1);
+      expect(result.sessions[0]).toMatchObject({
+        config: { id: 'orphan-agent', title: 'Orphan Agent' },
+        id: 'orphan-agent',
+        meta: { title: 'Orphan Agent' },
+        model: 'gpt-4',
+        type: 'agent',
+      });
+    });
+
     it('should map group sessions with members correctly', async () => {
       // Create a group session with multiple agents
       await serverDB.transaction(async (trx) => {

--- a/packages/database/src/models/session.ts
+++ b/packages/database/src/models/session.ts
@@ -98,8 +98,9 @@ export class SessionModel {
     // items so the sidebar shows the same set of agents as desktop's
     // `getSidebarAgentList`. The route uses `agentId` (not sessionId) anyway.
     const orphanAgents = await this.findAgentsWithoutSession();
+    const visibleGroupIds = new Set(groups.map((group) => group.id));
     const orphanSessions = orphanAgents.map((agent) =>
-      this.buildVirtualSessionForAgent(agent),
+      this.buildVirtualSessionForAgent(agent, visibleGroupIds),
     );
 
     const allSessions = [...mappedSessions, ...orphanSessions].sort(
@@ -142,12 +143,19 @@ export class SessionModel {
    * agent's id as the virtual session id; the SPA route only relies on
    * `agentId` for navigation, so this stays consistent.
    */
-  private buildVirtualSessionForAgent = (agent: AgentItem): LobeAgentSession => {
+  private buildVirtualSessionForAgent = (
+    agent: AgentItem,
+    visibleGroupIds?: Set<string>,
+  ): LobeAgentSession => {
     return {
       config: agent as any,
       createdAt: agent.createdAt as any,
-      group: agent.sessionGroupId ?? undefined,
+      group:
+        agent.sessionGroupId && (!visibleGroupIds || visibleGroupIds.has(agent.sessionGroupId))
+          ? agent.sessionGroupId
+          : undefined,
       id: agent.id,
+      isVirtualSession: true,
       meta: {
         avatar: agent.avatar ?? undefined,
         backgroundColor: agent.backgroundColor ?? undefined,
@@ -172,7 +180,11 @@ export class SessionModel {
 
     const data = await this.findSessionsByKeywords({ keyword: keywordLowerCase });
 
-    return data.map((item) => this.mapSessionItem(item as any));
+    return data.map((item) =>
+      (item as LobeAgentSession).isVirtualSession
+        ? (item as LobeAgentSession)
+        : this.mapSessionItem(item as any),
+    );
   };
 
   findByIdOrSlug = async (
@@ -687,13 +699,12 @@ export class SessionModel {
       });
 
       // Filter and map results, ensuring valid session associations
-      return (
-        results
-          .filter((item) => item.agentsToSessions && item.agentsToSessions.length > 0)
-          // @ts-expect-error
-          .map((item) => item.agentsToSessions[0].session)
-          .filter((session) => session !== null && session !== undefined)
-      );
+      return results.flatMap((item) => {
+        const linkedSession = item.agentsToSessions?.[0]?.session;
+        if (linkedSession) return [linkedSession];
+        if (item.virtual) return [];
+        return [this.buildVirtualSessionForAgent(item as AgentItem)];
+      });
     } catch (e) {
       console.error('findSessionsByKeywords error:', e, { keyword });
       return [];

--- a/packages/database/src/models/session.ts
+++ b/packages/database/src/models/session.ts
@@ -700,7 +700,9 @@ export class SessionModel {
 
       // Filter and map results, ensuring valid session associations
       return results.flatMap((item) => {
-        const linkedSession = item.agentsToSessions?.[0]?.session;
+        const linkedSession =
+          (item.agentsToSessions as Array<{ session?: SessionItem | null }> | undefined)?.[0]
+            ?.session;
         if (linkedSession) return [linkedSession];
         if (item.virtual) return [];
         return [this.buildVirtualSessionForAgent(item as AgentItem)];

--- a/packages/database/src/models/session.ts
+++ b/packages/database/src/models/session.ts
@@ -83,7 +83,7 @@ export class SessionModel {
   };
 
   queryWithGroups = async (): Promise<ChatSessionList> => {
-    // Query all sessions
+    // Query all sessions (each session is joined with its agent)
     const result = await this.query();
 
     const groups = await this.db.query.sessionGroups.findMany({
@@ -93,10 +93,76 @@ export class SessionModel {
 
     const mappedSessions = result.map((item) => this.mapSessionItem(item as any));
 
+    // Backfill: agents that have no session attached are invisible to mobile/SPA
+    // because the query above is `from(sessions)`. Wrap them as virtual session
+    // items so the sidebar shows the same set of agents as desktop's
+    // `getSidebarAgentList`. The route uses `agentId` (not sessionId) anyway.
+    const orphanAgents = await this.findAgentsWithoutSession();
+    const orphanSessions = orphanAgents.map((agent) =>
+      this.buildVirtualSessionForAgent(agent),
+    );
+
+    const allSessions = [...mappedSessions, ...orphanSessions].sort(
+      (a, b) =>
+        new Date((b as any).updatedAt).getTime() - new Date((a as any).updatedAt).getTime(),
+    );
+
     return {
       sessionGroups: groups as unknown as ChatSessionList['sessionGroups'],
-      sessions: mappedSessions,
+      sessions: allSessions,
     };
+  };
+
+  /**
+   * Find agents owned by current user/workspace that are NOT linked to any
+   * session via `agentsToSessions`. Used to backfill the mobile sidebar so
+   * orphan agents are still listed.
+   */
+  private findAgentsWithoutSession = async (): Promise<AgentItem[]> => {
+    const rows = await this.db
+      .select({ agent: agents })
+      .from(agents)
+      .leftJoin(agentsToSessions, eq(agents.id, agentsToSessions.agentId))
+      .where(
+        and(
+          this.agentsOwnership(),
+          not(eq(agents.virtual, true)),
+          sql`${agentsToSessions.agentId} IS NULL`,
+        ),
+      )
+      .orderBy(desc(agents.updatedAt));
+
+    return rows.map((r) => r.agent);
+  };
+
+  /**
+   * Build a virtual `LobeAgentSession` payload for an agent that has no real
+   * session row. The returned object mirrors the shape produced by
+   * `mapSessionItem` so the frontend can treat it uniformly. We reuse the
+   * agent's id as the virtual session id; the SPA route only relies on
+   * `agentId` for navigation, so this stays consistent.
+   */
+  private buildVirtualSessionForAgent = (agent: AgentItem): LobeAgentSession => {
+    return {
+      config: agent as any,
+      createdAt: agent.createdAt as any,
+      group: agent.sessionGroupId ?? undefined,
+      id: agent.id,
+      meta: {
+        avatar: agent.avatar ?? undefined,
+        backgroundColor: agent.backgroundColor ?? undefined,
+        description: agent.description ?? undefined,
+        marketIdentifier: agent.marketIdentifier ?? undefined,
+        tags: (agent.tags as string[] | undefined) ?? undefined,
+        title: agent.title ?? undefined,
+      },
+      model: agent.model ?? '',
+      pinned: agent.pinned ?? false,
+      slug: agent.slug ?? undefined,
+      type: 'agent',
+      updatedAt: agent.updatedAt as any,
+      userId: this.userId,
+    } as unknown as LobeAgentSession;
   };
 
   queryByKeyword = async (keyword: string) => {

--- a/packages/types/src/session/agentSession.ts
+++ b/packages/types/src/session/agentSession.ts
@@ -25,6 +25,8 @@ export interface LobeAgentSession {
   createdAt: Date;
   group?: string;
   id: string;
+  /** True when this entry represents an agent without a persisted session row. */
+  isVirtualSession?: boolean;
   /** Market agent identifier for published agents */
   marketIdentifier?: string;
   meta: MetaData;

--- a/src/features/MobileHome/SessionListContent/List/Item/Actions.tsx
+++ b/src/features/MobileHome/SessionListContent/List/Item/Actions.tsx
@@ -29,7 +29,7 @@ import { isForbiddenError, isOwnerOnlyForbiddenError } from '@/utils/forbiddenEr
 interface ActionProps {
   group: string | undefined;
   id: string;
-  openCreateGroupModal: () => void;
+  openCreateGroupModal: (isVirtualAgent: boolean) => void;
   parentType: 'agent' | 'group';
   setOpen: (open: boolean) => void;
 }
@@ -156,7 +156,7 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType
                 onClick: ({ domEvent }) => {
                   domEvent.stopPropagation();
                   if (!canCreate) return;
-                  openCreateGroupModal();
+                  openCreateGroupModal(isVirtualAgent);
                 },
               },
             ],

--- a/src/features/MobileHome/SessionListContent/List/Item/Actions.tsx
+++ b/src/features/MobileHome/SessionListContent/List/Item/Actions.tsx
@@ -42,10 +42,11 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType
   const openAgentInNewWindow = useGlobalStore((s) => s.openAgentInNewWindow);
 
   const sessionCustomGroups = useSessionStore(sessionGroupSelectors.sessionGroupItems, isEqual);
-  const [pin, removeSession, pinSession, sessionType, duplicateSession, updateSessionGroup] =
+  const [session, pin, removeSession, pinSession, sessionType, duplicateSession, updateSessionGroup] =
     useSessionStore((s) => {
       const session = sessionSelectors.getSessionById(id)(s);
       return [
+        session,
         sessionHelpers.getSessionPinned(session),
         s.removeSession,
         s.pinSession,
@@ -55,10 +56,17 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType
       ];
     });
 
-  const [pinAgentGroup, removeAgentGroup] = useHomeStore((s) => [
-    s.pinAgentGroup,
-    s.removeAgentGroup,
-  ]);
+  const [pinAgentGroup, removeAgentGroup, pinAgent, duplicateAgent, removeAgent, updateAgentGroup] =
+    useHomeStore((s) => [
+      s.pinAgentGroup,
+      s.removeAgentGroup,
+      s.pinAgent,
+      s.duplicateAgent,
+      s.removeAgent,
+      s.updateAgentGroup,
+    ]);
+
+  const isVirtualAgent = sessionType === 'agent' && (session as any)?.isVirtualSession === true;
 
   const isDefault = group === SessionDefaultGroup.Default;
 
@@ -77,7 +85,7 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType
               if (parentType === 'group') {
                 pinAgentGroup(id, !pin);
               } else {
-                pinSession(id, !pin);
+                isVirtualAgent ? pinAgent(id, !pin) : pinSession(id, !pin);
               }
             },
           },
@@ -91,7 +99,7 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType
               domEvent.stopPropagation();
               if (!canCreate) return;
 
-              duplicateSession(id);
+              isVirtualAgent ? duplicateAgent(id) : duplicateSession(id);
             },
           },
           ...(isDesktop
@@ -120,7 +128,7 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType
                 title: editReason,
                 onClick: () => {
                   if (!canEdit) return;
-                  updateSessionGroup(id, groupId);
+                  isVirtualAgent ? updateAgentGroup(id, groupId) : updateSessionGroup(id, groupId);
                 },
               })),
               {
@@ -131,7 +139,9 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType
                 title: editReason,
                 onClick: () => {
                   if (!canEdit) return;
-                  updateSessionGroup(id, SessionDefaultGroup.Default);
+                  isVirtualAgent
+                    ? updateAgentGroup(id, SessionDefaultGroup.Default)
+                    : updateSessionGroup(id, SessionDefaultGroup.Default);
                 },
               },
               {
@@ -177,7 +187,7 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType
                       await removeAgentGroup(id);
                       toast.success(t('confirmRemoveGroupSuccess'));
                     } else {
-                      await removeSession(id);
+                      await (isVirtualAgent ? removeAgent(id) : removeSession(id));
                       toast.success(t('confirmRemoveSessionSuccess'));
                     }
                   } catch (error) {
@@ -220,6 +230,11 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType
       sessionType,
       t,
       updateSessionGroup,
+      isVirtualAgent,
+      pinAgent,
+      duplicateAgent,
+      removeAgent,
+      updateAgentGroup,
     ],
   );
 

--- a/src/features/MobileHome/SessionListContent/List/Item/index.tsx
+++ b/src/features/MobileHome/SessionListContent/List/Item/index.tsx
@@ -78,7 +78,7 @@ const SessionItem = memo<SessionItemProps>(({ id }) => {
       <Actions
         group={group}
         id={id}
-        openCreateGroupModal={() => openCreateGroupModal(id)}
+        openCreateGroupModal={(isVirtualAgent) => openCreateGroupModal(id, isVirtualAgent)}
         parentType={sessionType}
         setOpen={setOpen}
       />

--- a/src/features/MobileHome/SessionListContent/Modals/CreateGroupModal.tsx
+++ b/src/features/MobileHome/SessionListContent/Modals/CreateGroupModal.tsx
@@ -6,13 +6,15 @@ import { useTranslation } from 'react-i18next';
 
 import { usePermission } from '@/hooks/usePermission';
 import { useGlobalStore } from '@/store/global';
+import { useHomeStore } from '@/store/home';
 import { useSessionStore } from '@/store/session';
 
 interface CreateGroupContentProps {
   id: string;
+  isVirtualAgent?: boolean;
 }
 
-const CreateGroupContent = memo<CreateGroupContentProps>(({ id }) => {
+const CreateGroupContent = memo<CreateGroupContentProps>(({ id, isVirtualAgent }) => {
   const { t } = useTranslation(['chat', 'common']);
   const { close } = useModalContext();
   const { allowed: canCreate } = usePermission('create_content');
@@ -22,6 +24,7 @@ const CreateGroupContent = memo<CreateGroupContentProps>(({ id }) => {
     s.updateSessionGroupId,
     s.addSessionGroup,
   ]);
+  const updateAgentGroup = useHomeStore((s) => s.updateAgentGroup);
 
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
@@ -37,7 +40,7 @@ const CreateGroupContent = memo<CreateGroupContentProps>(({ id }) => {
     setLoading(true);
     try {
       const groupId = await addCustomGroup(input);
-      await updateSessionGroup(id, groupId);
+      await (isVirtualAgent ? updateAgentGroup(id, groupId) : updateSessionGroup(id, groupId));
       toggleExpandSessionGroup(groupId, true);
       toast.success(t('sessionGroup.createSuccess'));
       close();
@@ -70,9 +73,9 @@ const CreateGroupContent = memo<CreateGroupContentProps>(({ id }) => {
 
 CreateGroupContent.displayName = 'MobileCreateGroupContent';
 
-export const openCreateGroupModal = (id: string) =>
+export const openCreateGroupModal = (id: string, isVirtualAgent?: boolean) =>
   createModal({
-    content: <CreateGroupContent id={id} />,
+    content: <CreateGroupContent id={id} isVirtualAgent={isVirtualAgent} />,
     footer: null,
     styles: { content: { padding: 0 } },
     title: translate('sessionGroup.createGroup', { ns: 'chat' }),

--- a/src/store/home/slices/sidebarUI/action.test.ts
+++ b/src/store/home/slices/sidebarUI/action.test.ts
@@ -4,6 +4,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { getActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
 import { INBOX_SESSION_ID } from '@/const/session';
+import { mutate } from '@/libs/swr';
+import { sessionKeys } from '@/libs/swr/keys';
 import { agentService } from '@/services/agent';
 import { chatGroupService } from '@/services/chatGroup';
 import { homeService } from '@/services/home';
@@ -58,6 +60,8 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+vi.mock('@/libs/swr', () => ({ mutate: vi.fn() }));
+
 describe('createSidebarUISlice', () => {
   // ========== Agent Operations ==========
   describe('pinAgent', () => {
@@ -74,6 +78,7 @@ describe('createSidebarUISlice', () => {
 
       expect(agentService.updateAgentPinned).toHaveBeenCalledWith(mockAgentId, true);
       expect(spyOnRefresh).toHaveBeenCalled();
+      expect(mutate).toHaveBeenCalledWith(sessionKeys.list(true));
     });
 
     it('should unpin an agent and refresh agent list', async () => {
@@ -181,6 +186,7 @@ describe('createSidebarUISlice', () => {
 
       expect(agentService.removeAgent).toHaveBeenCalledWith(mockAgentId);
       expect(spyOnRefresh).toHaveBeenCalled();
+      expect(mutate).toHaveBeenCalledWith(sessionKeys.list(true));
     });
 
     it('should switch to inbox when removing the active session', async () => {
@@ -228,6 +234,7 @@ describe('createSidebarUISlice', () => {
 
       expect(agentService.duplicateAgent).toHaveBeenCalledWith(mockAgentId, 'Copied Agent');
       expect(spyOnRefresh).toHaveBeenCalled();
+      expect(mutate).toHaveBeenCalledWith(sessionKeys.list(true));
       expect(mockSetActiveAgentId).toHaveBeenCalledWith(mockNewAgentId);
     });
 
@@ -283,6 +290,7 @@ describe('createSidebarUISlice', () => {
 
       expect(homeService.updateAgentSessionGroupId).toHaveBeenCalledWith(mockAgentId, mockGroupId);
       expect(spyOnRefresh).toHaveBeenCalled();
+      expect(mutate).toHaveBeenCalledWith(sessionKeys.list(true));
     });
 
     it('should set group to default when groupId is null', async () => {

--- a/src/store/home/slices/sidebarUI/action.ts
+++ b/src/store/home/slices/sidebarUI/action.ts
@@ -1,6 +1,8 @@
 import { toast } from '@lobehub/ui/base-ui';
 import { t } from 'i18next';
 
+import { mutate } from '@/libs/swr';
+import { sessionKeys } from '@/libs/swr/keys';
 import { agentService } from '@/services/agent';
 import { chatGroupService } from '@/services/chatGroup';
 import { homeService } from '@/services/home';
@@ -28,6 +30,10 @@ export class SidebarUIActionImpl {
     this.#get = get;
   }
 
+  #refreshSidebar = async (): Promise<void> => {
+    await Promise.all([this.#get().refreshAgentList(), mutate(sessionKeys.list(true))]);
+  };
+
   duplicateAgent = async (agentId: string, newTitle?: string): Promise<void> => {
     const loadingToast = toast.loading(t('duplicateSession.loading', { ns: 'chat' }));
 
@@ -39,7 +45,7 @@ export class SidebarUIActionImpl {
       return;
     }
 
-    await this.#get().refreshAgentList();
+    await this.#refreshSidebar();
     loadingToast.close();
     toast.success(t('duplicateSession.success', { ns: 'chat' }));
 
@@ -74,7 +80,7 @@ export class SidebarUIActionImpl {
   // want an item in their own sidebar hides it instead (personal layer).
   pinAgent = async (agentId: string, pinned: boolean): Promise<void> => {
     await agentService.updateAgentPinned(agentId, pinned);
-    await this.#get().refreshAgentList();
+    await this.#refreshSidebar();
   };
 
   pinAgentGroup = async (groupId: string, pinned: boolean): Promise<void> => {
@@ -84,7 +90,7 @@ export class SidebarUIActionImpl {
 
   removeAgent = async (agentId: string): Promise<void> => {
     await agentService.removeAgent(agentId);
-    await this.#get().refreshAgentList();
+    await this.#refreshSidebar();
     // deleting an agent cascade-deletes its topics + messages on the server; drop
     // their message cache too so it doesn't orphan in IndexedDB (never expires)
     void evictMessageCache((ctx) => ctx.agentId === agentId);
@@ -114,7 +120,7 @@ export class SidebarUIActionImpl {
   updateAgentGroup = async (agentId: string, groupId: string | null): Promise<void> => {
     const normalized = groupId === 'default' ? null : groupId;
     await homeService.updateAgentSessionGroupId(agentId, normalized);
-    await this.#get().refreshAgentList();
+    await this.#refreshSidebar();
   };
 
   addGroup = async (name: string, visibility?: 'private' | 'public'): Promise<string> => {


### PR DESCRIPTION
## 🐛 Bug Fixes

- Fix agents created from the web or desktop client not appearing in the SPA sidebar.

## Details

- Include non-virtual user and workspace agents that do not yet have an associated session.
- Return them as agent sessions so existing SPA rendering and navigation work as expected.

## Validation

Tested on my own build.