### PR TITLE
🐛 fix(agents): handle missing CodeBuddy model catalogs

### DIFF
--- a/packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.test.ts
+++ b/packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.test.ts
@@ -121,6 +121,58 @@ describe('heterogeneous agent model discovery', () => {
     );
   });
 
+  it('fails discovery when CodeBuddy exits successfully without reporting a model catalog', async () => {
+    resolveExecFile(
+      [
+        'Usage: codebuddy [options]',
+        '  --model <model>  Model for the current session. Please provide the model ID.',
+      ].join('\n'),
+    );
+    const { listHeterogeneousAgentModels } = await importModule();
+
+    await expect(
+      listHeterogeneousAgentModels({
+        command: '/custom/codebuddy',
+        env: { CODEBUDDY_DISABLE_BUILTIN_MODELS: '1' },
+        type: 'codebuddy',
+      }),
+    ).resolves.toMatchObject({
+      error: { code: 'command_failed' },
+      status: 'error',
+    });
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('parses a CodeBuddy model catalog written to stderr', async () => {
+    resolveExecFile(
+      '',
+      [
+        'Usage: codebuddy [options]',
+        '  --model <model>  Model for the current session. Currently supported: (default-model,',
+        '                   gpt-5.4)',
+      ].join('\n'),
+    );
+    const { listHeterogeneousAgentModels } = await importModule();
+
+    await expect(
+      listHeterogeneousAgentModels({ command: '/custom/codebuddy', type: 'codebuddy' }),
+    ).resolves.toMatchObject({
+      models: [{ id: 'gpt-5.4', modelId: 'gpt-5.4', providerId: 'codebuddy' }],
+      status: 'success',
+    });
+  });
+
+  it('accepts an explicit CodeBuddy catalog containing only the default model', async () => {
+    resolveExecFile(
+      '  --model <model>  Model for the current session. Currently supported: (default-model)',
+    );
+    const { listHeterogeneousAgentModels } = await importModule();
+
+    await expect(
+      listHeterogeneousAgentModels({ command: '/custom/codebuddy', type: 'codebuddy' }),
+    ).resolves.toMatchObject({ models: [], status: 'success' });
+  });
+
   it('parses adversarial CodeBuddy help output without polynomial backtracking', async () => {
     const stdout = `${'--model <model>'.repeat(1000)}${'Currently supported:(('.repeat(1000)}`;
     const { parseCodeBuddyModelCatalog } = await importModule();

--- a/packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.test.ts
+++ b/packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.test.ts
@@ -173,6 +173,23 @@ describe('heterogeneous agent model discovery', () => {
     ).resolves.toMatchObject({ models: [], status: 'success' });
   });
 
+  it.each([
+    ['an empty body', '()'],
+    ['comma-only entries', '(, ,)'],
+  ])('rejects a CodeBuddy catalog containing %s', async (_, catalog) => {
+    resolveExecFile(
+      `  --model <model>  Model for the current session. Currently supported: ${catalog}`,
+    );
+    const { listHeterogeneousAgentModels } = await importModule();
+
+    await expect(
+      listHeterogeneousAgentModels({ command: '/custom/codebuddy', type: 'codebuddy' }),
+    ).resolves.toMatchObject({
+      error: { code: 'command_failed' },
+      status: 'error',
+    });
+  });
+
   it('parses adversarial CodeBuddy help output without polynomial backtracking', async () => {
     const stdout = `${'--model <model>'.repeat(1000)}${'Currently supported:(('.repeat(1000)}`;
     const { parseCodeBuddyModelCatalog } = await importModule();

--- a/packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.ts
+++ b/packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.ts
@@ -22,30 +22,35 @@ const OPENCODE_MODEL_ID_PATTERN = /^[A-Z0-9][\w.-]*\/[A-Z0-9@][\w./:@+-]*$/i;
 const PI_MODEL_ROW_PATTERN = /^(\S+)\s{2,}(\S+)\s{2,}\S+\s{2,}\S+\s{2,}(?:yes|no)\s{2,}(?:yes|no)$/;
 const QODER_CUSTOM_MODEL_ROW_PATTERN = /^(.+?) \(([^()\s]+)\)$/;
 
-/** Parse the model IDs accepted by CodeBuddy's native `--model` option. */
-export const parseCodeBuddyModelCatalog = (stdout: string): HeterogeneousAgentModel[] => {
-  const modelOptionIndex = stdout.indexOf(CODEBUDDY_MODEL_OPTION);
-  if (modelOptionIndex < 0) return [];
+const parseCodeBuddyModelCatalogResult = (
+  output: string,
+): HeterogeneousAgentModel[] | undefined => {
+  const modelOptionIndex = output.indexOf(CODEBUDDY_MODEL_OPTION);
+  if (modelOptionIndex < 0) return;
 
-  const labelStart = stdout.indexOf(
+  const labelStart = output.indexOf(
     CODEBUDDY_SUPPORTED_MODELS_LABEL,
     modelOptionIndex + CODEBUDDY_MODEL_OPTION.length,
   );
-  if (labelStart < 0) return [];
+  if (labelStart < 0) return;
 
   const labelEnd = labelStart + CODEBUDDY_SUPPORTED_MODELS_LABEL.length;
-  const modelsStart = stdout.indexOf('(', labelEnd);
-  if (modelsStart < 0 || stdout.slice(labelEnd, modelsStart).trim()) return [];
+  const modelsStart = output.indexOf('(', labelEnd);
+  if (modelsStart < 0 || output.slice(labelEnd, modelsStart).trim()) return;
 
-  const modelsEnd = stdout.indexOf(')', modelsStart + 1);
-  if (modelsEnd < 0) return [];
+  const modelsEnd = output.indexOf(')', modelsStart + 1);
+  if (modelsEnd < 0) return;
 
-  const supportedModels = stdout.slice(modelsStart + 1, modelsEnd);
+  const supportedModels = output.slice(modelsStart + 1, modelsEnd);
 
   return [...new Set(supportedModels.split(',').map((model) => model.trim()))]
     .filter((id) => id && id !== 'default-model')
     .map((id) => ({ id, modelId: id, providerId: 'codebuddy' }));
 };
+
+/** Parse the model IDs accepted by CodeBuddy's native `--model` option. */
+export const parseCodeBuddyModelCatalog = (output: string): HeterogeneousAgentModel[] =>
+  parseCodeBuddyModelCatalogResult(output) ?? [];
 
 export const parseOpenCodeModelCatalog = (stdout: string): HeterogeneousAgentModel[] => {
   const seen = new Set<string>();
@@ -179,7 +184,7 @@ export const listHeterogeneousAgentModels = async (
   };
 
   try {
-    const { stdout } = await execFilePromise(spawnPlan.command, spawnPlan.args, {
+    const { stderr, stdout } = await execFilePromise(spawnPlan.command, spawnPlan.args, {
       cwd: params.cwd,
       encoding: 'utf8',
       env: env as NodeJS.ProcessEnv,
@@ -188,15 +193,31 @@ export const listHeterogeneousAgentModels = async (
       windowsHide: true,
     });
 
+    if (params.type === 'codebuddy') {
+      const models =
+        parseCodeBuddyModelCatalogResult(String(stdout)) ??
+        parseCodeBuddyModelCatalogResult(String(stderr));
+      if (!models) {
+        return {
+          error: {
+            code: 'command_failed',
+            message: getCatalogErrorMessage('command_failed', params.type),
+          },
+          status: 'error',
+          updatedAt,
+        };
+      }
+
+      return { models, status: 'success', updatedAt };
+    }
+
     return {
       models:
-        params.type === 'codebuddy'
-          ? parseCodeBuddyModelCatalog(String(stdout))
-          : params.type === 'pi'
-            ? parsePiModelCatalog(String(stdout))
-            : params.type === 'qoder'
-              ? parseQoderModelCatalog(String(stdout))
-              : parseOpenCodeModelCatalog(String(stdout)),
+        params.type === 'pi'
+          ? parsePiModelCatalog(String(stdout))
+          : params.type === 'qoder'
+            ? parseQoderModelCatalog(String(stdout))
+            : parseOpenCodeModelCatalog(String(stdout)),
       status: 'success',
       updatedAt,
     };

--- a/packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.ts
+++ b/packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.ts
@@ -42,9 +42,11 @@ const parseCodeBuddyModelCatalogResult = (
   if (modelsEnd < 0) return;
 
   const supportedModels = output.slice(modelsStart + 1, modelsEnd);
+  const modelIds = supportedModels.split(',').map((model) => model.trim());
+  if (modelIds.some((id) => !id)) return;
 
-  return [...new Set(supportedModels.split(',').map((model) => model.trim()))]
-    .filter((id) => id && id !== 'default-model')
+  return [...new Set(modelIds)]
+    .filter((id) => id !== 'default-model')
     .map((id) => ({ id, modelId: id, providerId: 'codebuddy' }));
 };
 


### PR DESCRIPTION
Fix CodeBuddy model discovery when `codebuddy --help` exits successfully without appending its dynamically generated model catalog.

The discovery layer now treats a missing or malformed catalog as `command_failed` instead of caching a successful empty list, allowing the existing retry flow to recover from transient CodeBuddy initialization failures. It also accepts catalogs written to stderr while preserving a valid default-only catalog.

| Before | After |
| ------ | ----- |
| Missing dynamic help text returned `success` with no models | Missing catalog returns a retryable discovery error |
| Only stdout was inspected | stdout and stderr are supported |

#### Test

- `bun run check packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.ts packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.test.ts`
- Real CodeBuddy 2.135.0 smoke test: normal catalog returns 14 models; disabled catalog returns `command_failed`

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

No matching issue found.
