### PR TITLE
✨ feat(heterogeneous-agent): support Cursor model selection

### DIFF
--- a/apps/server/src/routers/lambda/device.ts
+++ b/apps/server/src/routers/lambda/device.ts
@@ -306,7 +306,7 @@ export const deviceRouter = router({
         cwd: z.string().optional(),
         deviceId: z.string(),
         env: z.record(z.string(), z.string()).optional(),
-        type: z.enum(['codebuddy', 'opencode', 'pi', 'qoder']),
+        type: z.enum(['codebuddy', 'cursor', 'opencode', 'pi', 'qoder']),
       }),
     )
     .query(async ({ ctx, input }) =>

--- a/apps/server/src/services/deviceGateway/index.ts
+++ b/apps/server/src/services/deviceGateway/index.ts
@@ -465,7 +465,7 @@ export class DeviceGateway {
     deviceId: string;
     env?: Record<string, string>;
     timeout?: number;
-    type: 'codebuddy' | 'opencode' | 'pi' | 'qoder';
+    type: 'codebuddy' | 'cursor' | 'opencode' | 'pi' | 'qoder';
     userId: string;
     workspaceId?: string;
   }): Promise<HeterogeneousAgentModelCatalog> {

--- a/packages/device-control/src/types.ts
+++ b/packages/device-control/src/types.ts
@@ -241,7 +241,7 @@ export interface ListHeterogeneousAgentModelsParams {
   command?: string;
   cwd?: string;
   env?: Record<string, string>;
-  type: 'codebuddy' | 'opencode' | 'pi' | 'qoder';
+  type: 'codebuddy' | 'cursor' | 'opencode' | 'pi' | 'qoder';
 }
 
 export interface HeterogeneousAgentModelCatalogItem {

--- a/packages/heterogeneous-agents/src/models/index.ts
+++ b/packages/heterogeneous-agents/src/models/index.ts
@@ -1,6 +1,7 @@
 export {
   listHeterogeneousAgentModels,
   parseCodeBuddyModelCatalog,
+  parseCursorModelCatalog,
   parseOpenCodeModelCatalog,
   parsePiModelCatalog,
   parseQoderModelCatalog,

--- a/packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.test.ts
+++ b/packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.test.ts
@@ -199,6 +199,71 @@ describe('heterogeneous agent model discovery', () => {
     expect(performance.now() - startedAt).toBeLessThan(100);
   });
 
+  it('parses and discovers Cursor model slugs and labels', async () => {
+    const stdout = [
+      'Available models',
+      '',
+      'auto (default) - Auto',
+      'claude-sonnet-4-6-thinking - Claude 4.6 Sonnet Thinking',
+      'gpt-5.5-medium-fast (current) - GPT-5.5 Medium Fast',
+      'claude-sonnet-4-6-thinking - Duplicate label',
+      'diagnostic-without-a-label',
+    ].join('\n');
+    resolveExecFile(stdout);
+    const { listHeterogeneousAgentModels, parseCursorModelCatalog } = await importModule();
+
+    expect(parseCursorModelCatalog(stdout)).toEqual([
+      { id: 'auto', label: 'Auto', modelId: 'auto', providerId: 'cursor' },
+      {
+        id: 'claude-sonnet-4-6-thinking',
+        label: 'Claude 4.6 Sonnet Thinking',
+        modelId: 'claude-sonnet-4-6-thinking',
+        providerId: 'cursor',
+      },
+      {
+        id: 'gpt-5.5-medium-fast',
+        label: 'GPT-5.5 Medium Fast',
+        modelId: 'gpt-5.5-medium-fast',
+        providerId: 'cursor',
+      },
+    ]);
+
+    await expect(
+      listHeterogeneousAgentModels({
+        command: '/custom/agent',
+        cwd: '/repo',
+        env: { CURSOR_API_KEY: 'test-key' },
+        type: 'cursor',
+      }),
+    ).resolves.toMatchObject({
+      models: [
+        { id: 'auto', label: 'Auto', modelId: 'auto', providerId: 'cursor' },
+        {
+          id: 'claude-sonnet-4-6-thinking',
+          label: 'Claude 4.6 Sonnet Thinking',
+          modelId: 'claude-sonnet-4-6-thinking',
+          providerId: 'cursor',
+        },
+        {
+          id: 'gpt-5.5-medium-fast',
+          label: 'GPT-5.5 Medium Fast',
+          modelId: 'gpt-5.5-medium-fast',
+          providerId: 'cursor',
+        },
+      ],
+      status: 'success',
+    });
+    expect(execFileMock).toHaveBeenLastCalledWith(
+      '/custom/agent',
+      ['--list-models'],
+      expect.objectContaining({
+        cwd: '/repo',
+        env: { CURSOR_API_KEY: 'test-key' },
+      }),
+      expect.any(Function),
+    );
+  });
+
   it('runs the configured binary with plugins enabled and forwards cwd/env', async () => {
     resolveExecFile('openai/gpt-5.6\nopenrouter/google/gemini-2.5-pro\n');
     const { listHeterogeneousAgentModels } = await importModule();

--- a/packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.ts
+++ b/packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.ts
@@ -18,6 +18,8 @@ const MODEL_CATALOG_MAX_BUFFER = 256 * 1024;
 const MODEL_CATALOG_TIMEOUT_MS = 15_000;
 const CODEBUDDY_MODEL_OPTION = '--model <model>';
 const CODEBUDDY_SUPPORTED_MODELS_LABEL = 'Currently supported:';
+const CURSOR_MODEL_ANNOTATIONS = [' (current)', ' (default)'] as const;
+const CURSOR_MODEL_ID_PATTERN = /^[A-Z0-9][\w./:@+-]*$/i;
 const OPENCODE_MODEL_ID_PATTERN = /^[A-Z0-9][\w.-]*\/[A-Z0-9@][\w./:@+-]*$/i;
 const PI_MODEL_ROW_PATTERN = /^(\S+)\s{2,}(\S+)\s{2,}\S+\s{2,}\S+\s{2,}(?:yes|no)\s{2,}(?:yes|no)$/;
 const QODER_CUSTOM_MODEL_ROW_PATTERN = /^(.+?) \(([^()\s]+)\)$/;
@@ -53,6 +55,29 @@ const parseCodeBuddyModelCatalogResult = (
 /** Parse the model IDs accepted by CodeBuddy's native `--model` option. */
 export const parseCodeBuddyModelCatalog = (output: string): HeterogeneousAgentModel[] =>
   parseCodeBuddyModelCatalogResult(output) ?? [];
+
+/** Parse the `model-slug - Display Label` rows emitted by Cursor Agent. */
+export const parseCursorModelCatalog = (stdout: string): HeterogeneousAgentModel[] => {
+  const seen = new Set<string>();
+  const models: HeterogeneousAgentModel[] = [];
+
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    const separatorIndex = line.indexOf(' - ');
+    if (separatorIndex <= 0) continue;
+
+    let id = line.slice(0, separatorIndex).trim();
+    const annotation = CURSOR_MODEL_ANNOTATIONS.find((item) => id.endsWith(item));
+    if (annotation) id = id.slice(0, -annotation.length);
+    const label = line.slice(separatorIndex + 3).trim();
+    if (!CURSOR_MODEL_ID_PATTERN.test(id) || !label || seen.has(id)) continue;
+
+    seen.add(id);
+    models.push({ id, label, modelId: id, providerId: 'cursor' });
+  }
+
+  return models;
+};
 
 export const parseOpenCodeModelCatalog = (stdout: string): HeterogeneousAgentModel[] => {
   const seen = new Set<string>();
@@ -215,11 +240,13 @@ export const listHeterogeneousAgentModels = async (
 
     return {
       models:
-        params.type === 'pi'
-          ? parsePiModelCatalog(String(stdout))
-          : params.type === 'qoder'
-            ? parseQoderModelCatalog(String(stdout))
-            : parseOpenCodeModelCatalog(String(stdout)),
+        params.type === 'cursor'
+          ? parseCursorModelCatalog(String(stdout))
+          : params.type === 'pi'
+            ? parsePiModelCatalog(String(stdout))
+            : params.type === 'qoder'
+              ? parseQoderModelCatalog(String(stdout))
+              : parseOpenCodeModelCatalog(String(stdout)),
       status: 'success',
       updatedAt,
     };

--- a/packages/types/src/agent/agencyConfig.ts
+++ b/packages/types/src/agent/agencyConfig.ts
@@ -46,7 +46,7 @@ export interface ListHeterogeneousAgentModelsParams {
   command?: string;
   cwd?: string;
   env?: Record<string, string>;
-  type: 'codebuddy' | 'opencode' | 'pi' | 'qoder';
+  type: 'codebuddy' | 'cursor' | 'opencode' | 'pi' | 'qoder';
 }
 
 export interface HeterogeneousAgentModelCatalogSuccess {

--- a/packages/types/src/agent/heteroSelectorCapabilities.test.ts
+++ b/packages/types/src/agent/heteroSelectorCapabilities.test.ts
@@ -14,12 +14,12 @@ describe('selector availability', () => {
     expect(isHeteroSelectorAvailable('claude-code')).toBe(true);
     expect(isHeteroSelectorAvailable('codebuddy')).toBe(true);
     expect(isHeteroSelectorAvailable('codex')).toBe(true);
+    expect(isHeteroSelectorAvailable('cursor')).toBe(true);
     expect(isHeteroSelectorAvailable('opencode')).toBe(true);
     expect(isHeteroSelectorAvailable('pi')).toBe(true);
     expect(isHeteroSelectorAvailable('qoder')).toBe(true);
 
     expect(isHeteroSelectorAvailable('amp')).toBe(false);
-    expect(isHeteroSelectorAvailable('cursor')).toBe(false);
     expect(isHeteroSelectorAvailable('kimi-code')).toBe(false);
     expect(isHeteroSelectorAvailable('openclaw')).toBe(false);
     expect(isHeteroSelectorAvailable(undefined)).toBe(false);
@@ -28,7 +28,7 @@ describe('selector availability', () => {
   it('exposes the dimensions each provider actually supports', () => {
     expect(getHeteroSelectorCapability('claude-code')?.speed).toBeUndefined();
     expect(getHeteroSelectorCapability('codex')?.speed).toBeDefined();
-    expect(getHeteroSelectorCapability('cursor')?.model).toBeUndefined();
+    expect(getHeteroSelectorCapability('cursor')?.model?.source).toBe('catalog');
     expect(getHeteroSelectorCapability('opencode')?.effort).toBeUndefined();
     expect(getHeteroSelectorCapability('qoder')?.effort).toBeDefined();
     expect(getHeteroSelectorCapability('codex')?.model?.source).toBe('static');
@@ -89,6 +89,25 @@ describe('applyHeteroSelection', () => {
       'gpt-5.4',
       '--effort',
       'low',
+    ]);
+  });
+
+  it('clears a hand-authored Cursor model before applying a catalog selection', () => {
+    const provider: HeterogeneousProviderConfig = {
+      args: ['--mode', 'plan', '--model=old-model'],
+      type: 'cursor',
+    };
+    const patch = applyHeteroSelection(provider, { model: 'claude-sonnet-4-6-thinking' });
+
+    expect(patch).toEqual({
+      args: ['--mode', 'plan'],
+      model: 'claude-sonnet-4-6-thinking',
+    });
+    expect(buildHeteroSpawnArgs({ ...provider, ...patch })).toEqual([
+      '--mode',
+      'plan',
+      '--model',
+      'claude-sonnet-4-6-thinking',
     ]);
   });
 

--- a/packages/types/src/agent/heteroSelectorCapabilities.ts
+++ b/packages/types/src/agent/heteroSelectorCapabilities.ts
@@ -312,7 +312,13 @@ export const HETERO_SELECTOR_CAPABILITIES = {
       supported: codexModelSupportsFastSpeed,
     },
   },
-  'cursor': {},
+  'cursor': {
+    model: {
+      encodings: [{ flags: ['--model'], kind: 'flag' }],
+      resolve: resolvePersistedModel,
+      source: 'catalog',
+    },
+  },
   'kimi-code': {},
   'opencode': {
     model: { encodings: [MODEL_FLAGS_ENCODING], resolve: resolvePersistedModel, source: 'catalog' },

--- a/src/features/ChatInput/ControlBar/HeteroModel/useModelCatalog.test.ts
+++ b/src/features/ChatInput/ControlBar/HeteroModel/useModelCatalog.test.ts
@@ -21,7 +21,7 @@ describe('useModelCatalog', () => {
     vi.restoreAllMocks();
   });
 
-  it.each(['codebuddy', 'opencode', 'pi', 'qoder'] as const)(
+  it.each(['codebuddy', 'cursor', 'opencode', 'pi', 'qoder'] as const)(
     'starts loading the %s catalog as soon as the selector mounts',
     async (type) => {
       const pendingCatalog = new Promise<

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/shouldShowHeteroModelSelector.test.ts
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/shouldShowHeteroModelSelector.test.ts
@@ -97,6 +97,31 @@ describe('shouldShowHeteroModelSelector', () => {
     ).toBe(false);
   });
 
+  it('shows Cursor models only on a concrete runtime that can query its CLI', () => {
+    expect(
+      shouldShowHeteroModelSelector({
+        executionTarget: 'local',
+        isDesktopClient: true,
+        providerType: 'cursor',
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowHeteroModelSelector({
+        boundDeviceId: 'remote-device',
+        executionTarget: 'device',
+        isDesktopClient: false,
+        providerType: 'cursor',
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowHeteroModelSelector({
+        executionTarget: 'auto',
+        isDesktopClient: false,
+        providerType: 'cursor',
+      }),
+    ).toBe(false);
+  });
+
   it('shows Pi models for desktop-local execution and an explicit bound device', () => {
     expect(
       shouldShowHeteroModelSelector({


### PR DESCRIPTION
## Brief and heads-up

Enable Cursor heterogeneous agents to discover the account-specific model catalog from the concrete execution host and select a model through the existing catalog selector.

The implementation:

- queries Cursor Agent with `--list-models` on local Desktop or a bound device
- parses model slugs, display labels, and `(default)` / `(current)` annotations
- forwards the selected model through the existing `--model` execution path
- clears conflicting hand-authored model flags when a catalog model is selected
- extends the device RPC contracts and validation to accept Cursor catalogs

| Before | After |
| ------ | ----- |
| Cursor agents did not expose a model selector | Cursor agents expose the existing catalog selector when a concrete runtime is available |

Screenshots are not included because the UI reuses the existing catalog selector and populating it requires an authenticated Cursor CLI on the execution host.

#### Test

- `bun run check <11 changed files>` — lint clean, 173 tests passed
- `bun run check --type` — types clean

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

No matching issue found.
