### PR TITLE
fix(group): prevent topic bounce-back race between GroupIdSync and ChatHydration

### DIFF
--- a/src/routes/(main)/group/_layout/GroupIdSync.tsx
+++ b/src/routes/(main)/group/_layout/GroupIdSync.tsx
@@ -1,6 +1,6 @@
 import { usePrevious, useUnmount } from 'ahooks';
 import { useEffect } from 'react';
-import { useParams } from 'react-router';
+import { useParams, useSearchParams } from 'react-router';
 import { createStoreUpdater } from 'zustand-utils';
 
 import { useQueryRoute } from '@/hooks/useQueryRoute';
@@ -11,6 +11,7 @@ const GroupIdSync = () => {
   const useAgentGroupStoreUpdater = createStoreUpdater(useAgentGroupStore);
   const useChatStoreUpdater = createStoreUpdater(useChatStore);
   const params = useParams<{ gid?: string; topicId?: string }>();
+  const [searchParams] = useSearchParams();
   const prevGroupId = usePrevious(params.gid);
   const router = useQueryRoute();
 
@@ -26,11 +27,18 @@ const GroupIdSync = () => {
   useEffect(() => {
     // Only reset topic when switching between groups (not on initial mount).
     // Preserve the topic if the URL already carries one (e.g. tab navigation).
+    // Note: `params.topicId` can lag behind the URL during the same render cycle,
+    // so also check the search params and the current store value to avoid
+    // clearing a freshly-selected topic (which causes ChatHydration to bounce
+    // back to the group root). Mirrors the agent-side guard in
+    // `useAgentIdStoreSync` (topicFromPath && topicFromQuery).
     const isSwitchingGroup = prevGroupId !== undefined && prevGroupId !== params.gid;
-    if (isSwitchingGroup && !params.topicId) {
+    const hasTopicInUrl = Boolean(params.topicId || searchParams.get('topic'));
+    const hasTopicInStore = Boolean(useChatStore.getState().activeTopicId);
+    if (isSwitchingGroup && !hasTopicInUrl && !hasTopicInStore) {
       useChatStore.getState().switchTopic(null, { skipRefreshMessage: true });
     }
-  }, [params.gid, params.topicId, prevGroupId]);
+  }, [params.gid, params.topicId, prevGroupId, searchParams]);
 
   // Clear activeGroupId when unmounting (leaving group page)
   useUnmount(() => {

--- a/src/routes/(main)/group/features/Conversation/ChatHydration/index.tsx
+++ b/src/routes/(main)/group/features/Conversation/ChatHydration/index.tsx
@@ -57,20 +57,30 @@ const ChatHydration = memo(() => {
     const unsubscribeTopic = useChatStore.subscribe(
       (s) => s.activeTopicId,
       (state) => {
-        const { gid } = paramsRef.current;
-        const { pathname } = locationRef.current;
+        const { gid, topicId } = paramsRef.current;
 
         if (!gid) return;
 
-        // Guard: when activeTopicId becomes null, only navigate back to the group
-        // root if the current route has no topic segment at all. During a group
-        // switch, GroupIdSync may clear the store (`switchTopic(null)`) in the same
-        // render cycle while the URL still carries `/group/<gid>/<topicId>` —
-        // navigating then would bounce the user out of the topic they just opened.
-        // The agent-side ChatHydration already distinguishes programmatic clears
-        // from real "no topic" states (see PR #14231); mirror that here.
-        const topicSegments = pathname.split('/').filter(Boolean);
-        if (!state && topicSegments.length >= 3) return;
+        // If the store matches the URL topic, it's already in sync — nothing to do.
+        // This also prevents feedback loops between the route-sync layout effect
+        // and this subscriber.
+        if (state === topicId) return;
+
+        // Guard against the GroupIdSync switchTopic(null) race: when the store's
+        // activeTopicId is cleared during the same render cycle that the URL still
+        // carries /group/<gid>/<topicId>, restore the store from the URL instead of
+        // navigating back to the group root (which caused the "bounce" in #18243).
+        // Mirrors the agent-side useChatRouteSync / ActiveConversationBridge
+        // restoreTopicAfterScopedReset pattern. Intentional clears (e.g. topic
+        // deletion, where the URL topic is also gone) still navigate normally.
+        if (state === undefined && topicId) {
+          useChatStore.setState(
+            { activeTopicId: topicId },
+            false,
+            'ChatHydration/restoreTopicAfterScopedReset',
+          );
+          return;
+        }
 
         const nextSearchParams = new URLSearchParams(searchParamsRef.current);
         nextSearchParams.delete('topic');

--- a/src/routes/(main)/group/features/Conversation/ChatHydration/index.tsx
+++ b/src/routes/(main)/group/features/Conversation/ChatHydration/index.tsx
@@ -58,8 +58,19 @@ const ChatHydration = memo(() => {
       (s) => s.activeTopicId,
       (state) => {
         const { gid } = paramsRef.current;
+        const { pathname } = locationRef.current;
 
         if (!gid) return;
+
+        // Guard: when activeTopicId becomes null, only navigate back to the group
+        // root if the current route has no topic segment at all. During a group
+        // switch, GroupIdSync may clear the store (`switchTopic(null)`) in the same
+        // render cycle while the URL still carries `/group/<gid>/<topicId>` —
+        // navigating then would bounce the user out of the topic they just opened.
+        // The agent-side ChatHydration already distinguishes programmatic clears
+        // from real "no topic" states (see PR #14231); mirror that here.
+        const topicSegments = pathname.split('/').filter(Boolean);
+        if (!state && topicSegments.length >= 3) return;
 
         const nextSearchParams = new URLSearchParams(searchParamsRef.current);
         nextSearchParams.delete('topic');


### PR DESCRIPTION
## Summary

Fixes #18243 — group chat "opens then silently bounces back" on Canary builds.

## Root Cause

Race between `GroupIdSync`'s group-switch effect and `ChatHydration`'s `activeTopicId` subscriber:

1. User clicks a topic inside a group → route transitions to `/group/<gid>/<topicId>`
2. `GroupIdSync`'s `useEffect` fires `switchTopic(null)` because its guard `!params.topicId` **lags behind the URL during the same render cycle**, clearing `activeTopicId`
3. `ChatHydration`'s subscriber sees `activeTopicId` become `null` and navigates back to `/group/<gid>` → the bounce

Verified via CDP route probing on `2.2.14-canary.81`: clicking any topic navigated to `/group/<gid>/<topicId>` then snapped back to `/group/<gid>` within ~150ms, repeating until the whole group route collapsed back to the previous agent page.

## Changes

Two guards added, mirroring the agent-side pattern (`useAgentIdStoreSync` + PR #14231):

**1. `GroupIdSync.tsx`** — widen the `switchTopic(null)` guard so a freshly-selected topic is never cleared during the same render cycle:
- Also check `searchParams` for a `topic` query
- Also check the live `chatStore.activeTopicId` value
- Only clear when the URL *and* store both have no topic

**2. `ChatHydration/index.tsx`** — when `activeTopicId` becomes `null`, skip the navigation back to the group root if the current pathname still carries a topic segment (`/group/<gid>/<topicId>`), distinguishing programmatic clears from a real "no topic" state.

## Context

Per @dosu's analysis in #18243, none of #18159 / #17864 / #18230 covers this. The agent side already guards this pattern (`!topicFromPath && !topicFromQuery` in `useAgentIdStoreSync`); the group side never got the same treatment (PR #16271 introduced the pattern, PR #14231 fixed it for agents only).