### PR TITLE
✨ feat(daily brief): add action link component

### DIFF
--- a/src/features/DailyBrief/BriefActionLink.tsx
+++ b/src/features/DailyBrief/BriefActionLink.tsx
@@ -39,7 +39,7 @@ interface BriefActionLinkProps {
  * `RENDERER_HANDLED_LINK_ATTR` tells the desktop preload interceptor this
  * click is already claimed.
  */
-const BriefActionLink = memo<BriefActionLinkProps>(
+export const BriefActionLink = memo<BriefActionLinkProps>(
   ({ agentId, children, className, primary, taskId, url }) => {
     const navigate = useWorkspaceAwareNavigate();
     const workspaces = useWorkspaces();
@@ -51,11 +51,16 @@ const BriefActionLink = memo<BriefActionLinkProps>(
       typeof window === 'undefined' ? undefined : window.location.origin,
       workspaces.map((workspace) => workspace.slug),
     );
+    const isTasklessDesktopAcceptance = isDesktop && reference?.type === 'acceptance' && !taskId;
+    const isRendererHandled = !!reference && !isTasklessDesktopAcceptance;
 
     const handleClick = useCallback(
       (event: MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => {
         // External destinations (billing, docs) stay plain anchors.
         if (!reference) return;
+        // Electron has no standalone acceptance route. Without a task there is
+        // no panel destination either, so leave the link to the preload layer.
+        if (isTasklessDesktopAcceptance) return;
         if (event.button !== 0) return;
 
         // On the web a modifier-click means "open in a new tab", so let the
@@ -81,12 +86,20 @@ const BriefActionLink = memo<BriefActionLinkProps>(
           'workspaceSlug' in reference && reference.workspaceSlug ? { escape: true } : undefined,
         );
       },
-      [agentId, navigate, openAcceptance, reference, taskId, toggleTaskAgentPanel],
+      [
+        agentId,
+        isTasklessDesktopAcceptance,
+        navigate,
+        openAcceptance,
+        reference,
+        taskId,
+        toggleTaskAgentPanel,
+      ],
     );
 
     return (
       <Button
-        {...(reference ? { [RENDERER_HANDLED_LINK_ATTR]: 'true' } : {})}
+        {...(isRendererHandled ? { [RENDERER_HANDLED_LINK_ATTR]: 'true' } : {})}
         className={className}
         href={url}
         shape={'round'}
@@ -100,5 +113,3 @@ const BriefActionLink = memo<BriefActionLinkProps>(
 );
 
 BriefActionLink.displayName = 'BriefActionLink';
-
-export default BriefActionLink;

--- a/src/features/DailyBrief/BriefActionLink.tsx
+++ b/src/features/DailyBrief/BriefActionLink.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { isDesktop } from '@lobechat/const';
+import { RENDERER_HANDLED_LINK_ATTR } from '@lobechat/desktop-bridge';
+import { Button } from '@lobehub/ui/base-ui';
+import type { MouseEvent, ReactNode } from 'react';
+import { memo, useCallback } from 'react';
+
+import { useWorkspaces } from '@/business/client/hooks/useWorkspaces';
+import { taskDetailPath } from '@/features/AgentTasks/shared/taskDetailPath';
+import { parseInternalLink } from '@/features/Conversation/Markdown/plugins/Link/internalLink';
+import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
+import { useChatStore } from '@/store/chat';
+import { useGlobalStore } from '@/store/global';
+
+interface BriefActionLinkProps {
+  /** Agent owning the brief's task — keeps the task detail path agent-scoped. */
+  agentId?: string | null;
+  children: ReactNode;
+  className?: string;
+  /** Renders the filled primary variant used for a card's leading action. */
+  primary?: boolean;
+  taskId?: string | null;
+  url?: string;
+}
+
+/**
+ * A `type: 'link'` brief action.
+ *
+ * A bare `<a href>` is a document navigation: on the web it throws away the
+ * whole SPA, and in Electron it hands `app://renderer/<path>` to a router that
+ * never registered the target (acceptance is web-only — see
+ * `desktopRouter.config.tsx`), so the button reads as dead. Internal
+ * destinations therefore route through React Router instead, and acceptance —
+ * which has no standalone desktop route at all — opens in the task-agent panel
+ * beside its task, the same surface `TaskAcceptance` / `RunVerifyTag` use.
+ *
+ * The `href` stays on the anchor so middle-click / copy-link still work, and
+ * `RENDERER_HANDLED_LINK_ATTR` tells the desktop preload interceptor this
+ * click is already claimed.
+ */
+const BriefActionLink = memo<BriefActionLinkProps>(
+  ({ agentId, children, className, primary, taskId, url }) => {
+    const navigate = useWorkspaceAwareNavigate();
+    const workspaces = useWorkspaces();
+    const openAcceptance = useChatStore((s) => s.openAcceptance);
+    const toggleTaskAgentPanel = useGlobalStore((s) => s.toggleTaskAgentPanel);
+
+    const reference = parseInternalLink(
+      url,
+      typeof window === 'undefined' ? undefined : window.location.origin,
+      workspaces.map((workspace) => workspace.slug),
+    );
+
+    const handleClick = useCallback(
+      (event: MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => {
+        // External destinations (billing, docs) stay plain anchors.
+        if (!reference) return;
+        if (event.button !== 0) return;
+
+        // On the web a modifier-click means "open in a new tab", so let the
+        // browser handle it. Desktop has no tabs for it to open.
+        const modifierClick = event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
+        if (!isDesktop && modifierClick) return;
+
+        event.preventDefault();
+
+        if (reference.type === 'acceptance' && taskId) {
+          // Arm the panel before navigating, the same handoff
+          // `Home/InputArea/useSend` performs — the panel mounts with the task
+          // page and reads this state on its first render.
+          toggleTaskAgentPanel(true);
+          openAcceptance(reference.acceptanceId);
+          navigate(taskDetailPath(taskId, agentId ?? undefined));
+          return;
+        }
+
+        // A path that already carries its workspace slug must not be prefixed twice.
+        navigate(
+          reference.pathname,
+          'workspaceSlug' in reference && reference.workspaceSlug ? { escape: true } : undefined,
+        );
+      },
+      [agentId, navigate, openAcceptance, reference, taskId, toggleTaskAgentPanel],
+    );
+
+    return (
+      <Button
+        {...(reference ? { [RENDERER_HANDLED_LINK_ATTR]: 'true' } : {})}
+        className={className}
+        href={url}
+        shape={'round'}
+        type={primary ? 'primary' : 'default'}
+        onClick={handleClick}
+      >
+        {children}
+      </Button>
+    );
+  },
+);
+
+BriefActionLink.displayName = 'BriefActionLink';
+
+export default BriefActionLink;

--- a/src/features/DailyBrief/BriefCardActions.tsx
+++ b/src/features/DailyBrief/BriefCardActions.tsx
@@ -10,6 +10,7 @@ import { shallow } from 'zustand/shallow';
 import { useBriefStore } from '@/store/brief';
 import { useTaskStore } from '@/store/task';
 
+import { BriefActionLink } from './BriefActionLink';
 import CommentInput from './CommentInput';
 import { styles } from './style';
 
@@ -262,14 +263,15 @@ const BriefCardActions = memo<BriefCardActionsProps>(
           {otherActions.map((action) => {
             if (action.type === 'link') {
               return (
-                <Button
+                <BriefActionLink
+                  agentId={agentId}
                   className={styles.actionBtn}
-                  href={action.url}
                   key={action.key}
-                  shape={'round'}
+                  taskId={taskId}
+                  url={action.url}
                 >
                   {getActionLabel(action)}
-                </Button>
+                </BriefActionLink>
               );
             }
 
@@ -300,14 +302,15 @@ const BriefCardActions = memo<BriefCardActionsProps>(
               // A link primary (e.g. the budget-error "Upgrade" remedy) navigates
               // to its url instead of resolving the brief; render it as a filled
               // primary so the fix is the clear call to action.
-              <Button
+              <BriefActionLink
+                primary
+                agentId={agentId}
                 className={styles.actionBtnPrimary}
-                href={primaryActions.url}
-                shape={'round'}
-                type={'primary'}
+                taskId={taskId}
+                url={primaryActions.url}
               >
                 {getActionLabel(primaryActions)}
-              </Button>
+              </BriefActionLink>
             ) : (
               <Button
                 className={styles.actionBtnPrimary}

--- a/src/features/DailyBrief/__tests__/BriefCardActions.test.tsx
+++ b/src/features/DailyBrief/__tests__/BriefCardActions.test.tsx
@@ -1,3 +1,5 @@
+import type * as LobechatConst from '@lobechat/const';
+import { RENDERER_HANDLED_LINK_ATTR } from '@lobechat/desktop-bridge';
 import type { BriefAction } from '@lobechat/types';
 import { toast } from '@lobehub/ui/base-ui';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -11,6 +13,11 @@ import { useTaskStore } from '@/store/task';
 import BriefCardActions from '../BriefCardActions';
 
 const renderWithRouter = (ui: ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+vi.mock('@lobechat/const', async (importOriginal) => ({
+  ...(await importOriginal<typeof LobechatConst>()),
+  isDesktop: true,
+}));
 
 // Mock i18n
 vi.mock('react-i18next', () => ({
@@ -77,6 +84,53 @@ beforeEach(() => {
 });
 
 describe('BriefCardActions', () => {
+  it('should route primary and secondary link actions through BriefActionLink', () => {
+    const actions: BriefAction[] = [
+      { key: 'primary', label: 'Primary link', type: 'link', url: '/settings/profile' },
+      { key: 'secondary', label: 'Secondary link', type: 'link', url: '/settings/common' },
+    ];
+
+    renderWithRouter(
+      <BriefCardActions
+        actions={actions}
+        agentId="agent-1"
+        briefId="brief-links"
+        briefType="decision"
+        taskId="task-1"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Primary link' })).toHaveAttribute(
+      RENDERER_HANDLED_LINK_ATTR,
+      'true',
+    );
+    expect(screen.getByRole('button', { name: 'Secondary link' })).toHaveAttribute(
+      RENDERER_HANDLED_LINK_ATTR,
+      'true',
+    );
+  });
+
+  it('should leave a taskless acceptance link to the desktop preload interceptor', () => {
+    renderWithRouter(
+      <BriefCardActions
+        briefId="brief-acceptance"
+        briefType="decision"
+        actions={[
+          {
+            key: 'review',
+            label: 'Review acceptance',
+            type: 'link',
+            url: '/acceptance/acceptance-1',
+          },
+        ]}
+      />,
+    );
+
+    const link = screen.getByRole('button', { name: 'Review acceptance' });
+    expect(link).not.toHaveAttribute(RENDERER_HANDLED_LINK_ATTR);
+    expect(fireEvent.click(link)).toBe(true);
+  });
+
   it('should render resolve action buttons from actions prop', () => {
     renderWithRouter(
       <BriefCardActions actions={sampleActions} briefId="brief-1" briefType="decision" />,


### PR DESCRIPTION
### Summary

- add a reusable Daily Brief action-link button
- route internal destinations through the workspace-aware SPA navigator
- open acceptance actions in the task-agent panel while preserving external-link behavior
- mark handled links for the desktop preload interceptor

### Testing

- `bun run check src/features/DailyBrief/BriefActionLink.tsx`