### PR TITLE
🐛 fix(heterogeneous-agent): reject missing Amp terminal result

### DIFF
--- a/apps/cli/src/commands/hetero.test.ts
+++ b/apps/cli/src/commands/hetero.test.ts
@@ -584,6 +584,32 @@ describe('hetero exec command', () => {
     expect(exitSpy).toHaveBeenCalledWith(7);
   });
 
+  it('exits non-zero when a terminal protocol error is emitted despite a clean child exit', async () => {
+    mockSpawnAgent.mockReturnValue(
+      createFakeHandle({
+        events: [
+          {
+            data: {
+              agentType: 'amp',
+              code: 'protocol_error',
+              message: 'Amp stream ended without the required terminal `result` event.',
+            },
+            operationId: 'op-amp',
+            stepIndex: 0,
+            timestamp: 1,
+            type: 'error',
+          },
+        ],
+        exitCode: 0,
+      }),
+    );
+
+    await runCmd(['hetero', 'exec', '--type', 'amp', '--prompt', 'hi']);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('"code":"protocol_error"'));
+  });
+
   it('maps SIGINT (code === null) to POSIX exit code 130', async () => {
     mockSpawnAgent.mockReturnValue(createFakeHandle({ exitCode: null, signal: 'SIGINT' }));
 

--- a/apps/cli/src/commands/hetero.ts
+++ b/apps/cli/src/commands/hetero.ts
@@ -906,7 +906,10 @@ const exec = async (options: ExecOptions): Promise<void> => {
   }
   if (askMcpConfigPath) await unlink(askMcpConfigPath).catch(() => {});
 
-  if (code !== null) process.exit(result.ingestError ? 1 : code);
+  if (code !== null) {
+    const hasRunError = result.ingestError || (!result.cancelled && result.sawTerminalError);
+    process.exit(hasRunError ? 1 : code);
+  }
   if (signal === 'SIGINT') process.exit(130);
   if (signal === 'SIGTERM') process.exit(143);
   if (signal === 'SIGKILL') process.exit(137);

--- a/apps/desktop/src/main/controllers/HeterogeneousAgentImpl.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentImpl.ts
@@ -1732,6 +1732,7 @@ export default class HeterogeneousAgentCtr {
           }
 
           if (code === 0) {
+            broadcastStreamEvents(pipeline.validateCompletion());
             this.broadcast('heteroAgentSessionComplete', { sessionId: session.sessionId });
             resolve();
           } else {

--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
@@ -1947,6 +1947,48 @@ describe('HeterogeneousAgentCtr', () => {
       expect(toolEnds.length).toBeGreaterThan(0);
     });
 
+    it('broadcasts an Amp protocol error before completion when exit zero has no result', async () => {
+      const initLine = `${JSON.stringify({
+        session_id: 'T-amp-missing-result',
+        subtype: 'init',
+        type: 'system',
+      })}\n`;
+      const assistantLine = `${JSON.stringify({
+        message: {
+          content: [{ text: 'Incomplete answer', type: 'text' }],
+          role: 'assistant',
+        },
+        type: 'assistant',
+      })}\n`;
+      nextFakeProc = createFakeProc({ stdoutLines: [initLine, assistantLine] }).proc;
+
+      const ctr = new HeterogeneousAgentCtr({
+        appStoragePath,
+        storeManager: { get: vi.fn() },
+      } as any);
+      const { sessionId } = await ctr.startSession({ agentType: 'amp', command: 'amp' });
+      await ctr.sendPrompt({ operationId: 'op-test', prompt: 'hello', sessionId });
+
+      const errorIdx = broadcasts.findIndex(
+        (broadcast) =>
+          broadcast.channel === 'heteroAgentEvent' &&
+          (broadcast.data as any)?.event?.type === 'error' &&
+          (broadcast.data as any)?.event?.data?.code === 'protocol_error',
+      );
+      const completeIdx = broadcasts.findIndex(
+        (broadcast) => broadcast.channel === 'heteroAgentSessionComplete',
+      );
+      const runtimeEnd = broadcasts.find(
+        (broadcast) =>
+          broadcast.channel === 'heteroAgentEvent' &&
+          (broadcast.data as any)?.event?.type === 'agent_runtime_end',
+      );
+
+      expect(errorIdx).toBeGreaterThan(-1);
+      expect(errorIdx).toBeLessThan(completeIdx);
+      expect(runtimeEnd).toBeUndefined();
+    });
+
     it('delivers late final Codex stdout chunks BEFORE heteroAgentSessionComplete', async () => {
       const threadStarted = `${JSON.stringify({ thread_id: 't1', type: 'thread.started' })}\n`;
       const turnStarted = `${JSON.stringify({ type: 'turn.started' })}\n`;

--- a/packages/heterogeneous-agents/src/adapters/amp.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/amp.test.ts
@@ -53,6 +53,7 @@ describe('AmpAdapter', () => {
       'visible_output_end',
       'agent_runtime_end',
     ]);
+    expect(adapter.validateCompletion()).toEqual([]);
   });
 
   it('keeps tool lifecycle and the post-tool assistant in separate steps', () => {
@@ -191,6 +192,32 @@ describe('AmpAdapter', () => {
       error: 'Invalid JSON input on stdin',
       message: 'Invalid JSON input on stdin',
     });
+  });
+
+  it('emits a protocol error when a successful process exit has no terminal result', () => {
+    const adapter = new AmpAdapter();
+    adapter.adapt(init);
+    adapter.adapt(assistant([{ text: 'partial answer', type: 'text' }]));
+
+    const events = adapter.validateCompletion();
+
+    expect(events.map((event) => event.type)).toEqual([
+      'stream_end',
+      'visible_output_end',
+      'error',
+    ]);
+    expect(events.at(-1)?.data).toEqual({
+      agentType: 'amp',
+      clearEchoedContent: true,
+      code: 'protocol_error',
+      details: {
+        expectedEventType: 'result',
+        sessionId: 'T-amp-123',
+      },
+      error: 'Amp stream ended without the required terminal `result` event.',
+      message: 'Amp stream ended without the required terminal `result` event.',
+    });
+    expect(adapter.validateCompletion()).toEqual([]);
   });
 
   it('routes subagent events with synthetic turn ids and one-time spawn metadata', () => {

--- a/packages/heterogeneous-agents/src/adapters/amp.ts
+++ b/packages/heterogeneous-agents/src/adapters/amp.ts
@@ -17,6 +17,7 @@ import type {
 
 const AMP_IDENTIFIER = 'amp';
 const AMP_DOCS_URL = getHeterogeneousAgentConfigOrThrow(AMP_IDENTIFIER).auth.docsUrl;
+const AMP_MISSING_RESULT_MESSAGE = 'Amp stream ended without the required terminal `result` event.';
 
 interface AmpUsage {
   cache_creation_input_tokens?: number;
@@ -226,6 +227,33 @@ export class AmpAdapter implements AgentEventAdapter {
 
   flush(): HeterogeneousAgentEvent[] {
     return this.drainPendingToolEndEvents();
+  }
+
+  validateCompletion(): HeterogeneousAgentEvent[] {
+    if (this.terminalEmitted) return [];
+    this.terminalEmitted = true;
+
+    const events = this.drainPendingToolEndEvents();
+    if (this.started) {
+      events.push(this.makeEvent('stream_end', {}));
+      events.push(this.makeEvent('visible_output_end', {}));
+    }
+    events.push(
+      this.makeEvent('error', {
+        agentType: AMP_IDENTIFIER,
+        clearEchoedContent: true,
+        code: 'protocol_error',
+        details: {
+          expectedEventType: 'result',
+          ...(this.sessionId ? { sessionId: this.sessionId } : {}),
+        },
+        error: AMP_MISSING_RESULT_MESSAGE,
+        message: AMP_MISSING_RESULT_MESSAGE,
+      } satisfies HeterogeneousTerminalErrorData),
+    );
+    this.clearRunState();
+
+    return events;
   }
 
   private captureSessionId(raw: Record<string, unknown>): void {

--- a/packages/heterogeneous-agents/src/spawn/agentStreamPipeline.ts
+++ b/packages/heterogeneous-agents/src/spawn/agentStreamPipeline.ts
@@ -130,6 +130,14 @@ export class AgentStreamPipeline {
     ]);
   }
 
+  /**
+   * Validate provider-specific terminal contracts after a successful process
+   * exit. Call only after {@link flush} has drained the full stdout stream.
+   */
+  validateCompletion(): AgentStreamEvent[] {
+    return this.toStreamEvents(this.adapter.validateCompletion?.() ?? []);
+  }
+
   private async processPayloads(payloads: unknown[]): Promise<AgentStreamEvent[]> {
     const out: AgentStreamEvent[] = this.drainQueuedEvents();
 

--- a/packages/heterogeneous-agents/src/spawn/spawnAgent.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/spawnAgent.test.ts
@@ -327,6 +327,53 @@ describe('spawnAgent', () => {
     });
   });
 
+  it('emits a protocol error when AMP exits zero without a terminal result', async () => {
+    const fake = createFakeProc({ stdoutChunks: [ccInit, ccText] });
+    nextFakeProc = fake.proc;
+    const { spawnAgent } = await import('./spawnAgent');
+    const handle = await spawnAgent({
+      agentType: 'amp',
+      operationId: 'op-amp',
+      prompt: 'hello',
+    });
+    fake.start();
+
+    const events: any[] = [];
+    for await (const event of handle.events) events.push(event);
+    await handle.exit;
+
+    expect(events.some((event) => event.type === 'agent_runtime_end')).toBe(false);
+    expect(events.at(-1)).toMatchObject({
+      data: {
+        agentType: 'amp',
+        code: 'protocol_error',
+        details: { expectedEventType: 'result', sessionId: 'cc-1' },
+      },
+      operationId: 'op-amp',
+      type: 'error',
+    });
+  });
+
+  it('does not classify a user-killed AMP process as a missing-result protocol error', async () => {
+    const fake = createFakeProc({ stdoutChunks: [ccInit] });
+    nextFakeProc = fake.proc;
+    const { spawnAgent } = await import('./spawnAgent');
+    const handle = await spawnAgent({
+      agentType: 'amp',
+      operationId: 'op-amp-cancelled',
+      prompt: 'hello',
+    });
+
+    handle.kill();
+    fake.start();
+
+    const events: any[] = [];
+    for await (const event of handle.events) events.push(event);
+    await handle.exit;
+
+    expect(events.some((event) => event.data?.code === 'protocol_error')).toBe(false);
+  });
+
   it('uses `threads continue <id>` before AMP execution flags on resume', async () => {
     nextFakeProc = createFakeProc().proc;
     const { spawnAgent } = await import('./spawnAgent');

--- a/packages/heterogeneous-agents/src/spawn/spawnAgent.ts
+++ b/packages/heterogeneous-agents/src/spawn/spawnAgent.ts
@@ -471,6 +471,7 @@ export const spawnAgent = async (options: SpawnAgentOptions): Promise<SpawnAgent
   // wakeup promise — keeps backpressure simple and avoids a third-party
   // dependency.
   const queue: AgentStreamEvent[] = [];
+  let killedByUs = false;
   let streamEnded = false;
   let streamError: Error | undefined;
   let wakeup: (() => void) | undefined;
@@ -538,6 +539,10 @@ export const spawnAgent = async (options: SpawnAgentOptions): Promise<SpawnAgent
       try {
         const events = await pipeline.flush();
         for (const event of events) queue.push(event);
+        const { code } = await exit;
+        if (code === 0 && !killedByUs) {
+          for (const event of pipeline.validateCompletion()) queue.push(event);
+        }
       } catch (err) {
         streamError = err instanceof Error ? err : new Error(String(err));
       } finally {
@@ -594,7 +599,10 @@ export const spawnAgent = async (options: SpawnAgentOptions): Promise<SpawnAgent
   return {
     events,
     exit,
-    kill: (signal: NodeJS.Signals = 'SIGINT') => killProcessTree(proc, signal),
+    kill: (signal: NodeJS.Signals = 'SIGINT') => {
+      killedByUs = true;
+      killProcessTree(proc, signal);
+    },
     pid: proc.pid,
     get sessionId() {
       return pipeline.sessionId;

--- a/packages/heterogeneous-agents/src/types.ts
+++ b/packages/heterogeneous-agents/src/types.ts
@@ -392,6 +392,12 @@ export interface AgentEventAdapter {
 
   /** The session ID extracted from the agent's init event (for multi-turn resume). */
   sessionId?: string;
+
+  /**
+   * Validate provider-specific terminal contracts after stdout has drained and
+   * the upstream process has reported a successful exit.
+   */
+  validateCompletion?: () => HeterogeneousAgentEvent[];
 }
 
 // ─── Agent Process Config ───


### PR DESCRIPTION
## Description of Change

Treat Amp's terminal `result` event as a required success contract.

When Amp exits with code zero after stdout has fully drained but no `result` was observed, the adapter now emits a structured `protocol_error` before the session-complete notification instead of allowing the renderer to synthesize a successful `agent_runtime_end`.

Completion validation is shared by the desktop controller and `spawnAgent`. Valid terminal results, non-zero exits, and user-initiated cancellation keep their existing behavior.

#### Test

- `bun run check packages/heterogeneous-agents/src/types.ts packages/heterogeneous-agents/src/adapters/amp.ts packages/heterogeneous-agents/src/adapters/amp.test.ts packages/heterogeneous-agents/src/spawn/agentStreamPipeline.ts packages/heterogeneous-agents/src/spawn/spawnAgent.ts packages/heterogeneous-agents/src/spawn/spawnAgent.test.ts apps/desktop/src/main/controllers/HeterogeneousAgentImpl.ts apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts`
- `bun run check --type`

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

No matching issue found.
