### PR TITLE
🔧 chore(orb): add persistent SPA portal

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -121,4 +121,12 @@ pnpm install
 echo "==> Installing the Chromium runtime used by end-to-end tests"
 pnpm exec playwright install --with-deps chromium
 
+if [[ "${AMP_ORB:-}" == "1" ]]; then
+  echo "==> Starting supervised Orb services"
+  # `ensure` reads .amp/services.yaml and creates the authenticated Portal. Amp
+  # supervises declared services across pause/resume, so the resume hook does
+  # not need to start another server.
+  amp orb services ensure
+fi
+
 echo "==> Orb setup complete"

--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -1,0 +1,9 @@
+# Amp injects PORT as the Portal listener. LobeHub's Vite server reads
+# SPA_PORT, while PORT remains its backend proxy target; assigning both avoids
+# proxying API requests back into the SPA server itself.
+services:
+  web-spa:
+    command: 'SPA_PORT="$PORT" PORT=3010 bun run dev:spa'
+    portal:
+      description: LobeHub Web SPA development server
+      title: LobeHub Web SPA

--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -1,9 +1,12 @@
-# Amp injects PORT as the Portal listener. LobeHub's Vite server reads
-# SPA_PORT, while PORT remains its backend proxy target; assigning both avoids
-# proxying API requests back into the SPA server itself.
+# This Portal intentionally runs only the frontend `pnpm dev:spa` workflow; it
+# does not start LobeHub's local backend or its database dependencies. API
+# requests still target port 3010 and require a separately started backend.
+# Amp injects PORT as the Portal listener, but LobeHub's Vite server reads
+# SPA_PORT, so preserve port 3010 as the proxy target to avoid proxying API
+# requests back into the SPA server itself.
 services:
   web-spa:
-    command: 'SPA_PORT="$PORT" PORT=3010 bun run dev:spa'
+    command: 'SPA_PORT="$PORT" PORT=3010 pnpm dev:spa'
     portal:
       description: LobeHub Web SPA development server
       title: LobeHub Web SPA

--- a/.gitignore
+++ b/.gitignore
@@ -157,5 +157,6 @@ docs/superpowers/
 # Kagura agent runtime
 .kagura/
 
-# Amp agent runtime
-.amp/
+# Amp runtime output stays local; only the repository's declarative service config is shared.
+.amp/*
+!.amp/services.yaml

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,10 @@ const isDev = process.env.NODE_ENV !== 'production';
 const isMobileRuntime = isMobile || isWorkbench;
 const platform = isAuth ? 'auth' : isMobileRuntime ? 'mobile' : 'web';
 const enableViteDevTools = process.env.LOBE_VITE_DEVTOOLS === 'true';
+const orbPortalHost =
+  process.env.AMP_ORB === '1' && process.env.PUBLIC_URL
+    ? new URL(process.env.PUBLIC_URL).hostname
+    : undefined;
 
 const resolveCommandExecutable = (cmd: string) => {
   const pathValue = process.env.PATH;
@@ -342,6 +346,11 @@ export default defineConfig({
   ].filter(Boolean) as PluginOption[],
 
   server: {
+    // A portaled Orb reaches Vite through its exact authenticated onamp.dev
+    // hostname and an ephemeral E2B bridge hostname. Keep the public hostname
+    // exact, allow only the bridge's controlled suffix, and leave every
+    // non-Orb developer's existing host policy unchanged.
+    allowedHosts: orbPortalHost ? [orbPortalHost, '.e2b.app'] : undefined,
     cors: true,
     host: true,
     port: isWorkbench


### PR DESCRIPTION
## Description of Change

- Declare the frontend-only `pnpm dev:spa` workflow in `.amp/services.yaml` so Amp can supervise it and expose an authenticated Portal in every Orb.
- Keep backend startup explicitly out of scope: API requests continue to target a separately started backend on port 3010.
- Start declared services from `.agents/setup` only when `AMP_ORB=1`; non-Orb development remains unchanged, and Amp restores the supervised service after pause/resume.
- Keep the Portal's public `onamp.dev` hostname exact while allowing only the controlled `.e2b.app` bridge suffix required by Orb forwarding.
- Preserve generated `.amp` runtime output as ignored while committing only the declarative service configuration.

The inline comments document both boundaries: this is intentionally not a full-stack service, and Amp's injected `PORT` is copied to `SPA_PORT` for Vite to listen on before `PORT` is restored to `3010` as LobeHub's optional backend proxy target. This prevents API requests from being proxied back into the SPA itself.

#### Test

- `bun run check .gitignore .agents/setup .amp/services.yaml vite.config.ts`
- Ran `.agents/setup` twice; both runs converged and `web-spa` remained healthy.
- Restarted the declared service with the exact `pnpm dev:spa` command and confirmed Vite became ready on the sticky Portal port.
- Confirmed the actual authenticated Portal returns HTTP 200.
- Confirmed the exact Portal Host and an E2B bridge Host return HTTP 200, while `untrusted.example` returns HTTP 403.
- Confirmed Vite resolves no extra allowlist outside an Orb and resolves the exact Portal hostname plus `.e2b.app` inside a portaled Orb.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

None.