### PR TITLE
🐛 fix(task): let links in run output be clicked again

### DIFF
--- a/src/features/AgentTasks/AgentTaskDetail/TopicCard.test.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicCard.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import type { TaskDetailActivity } from '@lobechat/types';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import TopicCard from './TopicCard';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/store/task', () => ({
+  useTaskStore: (selector: (state: any) => unknown) =>
+    selector({
+      activeTaskId: 'T-1',
+      addComment: vi.fn(),
+      cancelTopic: vi.fn(),
+      openTopicDrawer: vi.fn(),
+      taskDetailMap: {},
+    }),
+}));
+
+vi.mock('@/hooks/usePermission', () => ({
+  usePermission: () => ({ allowed: true }),
+}));
+
+vi.mock('@/hooks/useActivityTime', () => ({
+  useActivityTime: () => ({ text: '4m ago', title: '4m ago' }),
+}));
+
+// None of these render for this activity; they are stubbed only to keep the
+// reply editor's upload stack and the verify feature out of the module graph.
+vi.mock('./RunReplyEditor', () => ({ default: () => null }));
+vi.mock('./RunVerifyDetail', () => ({ default: () => null }));
+vi.mock('./RunVerifyTag', () => ({ default: () => null }));
+
+vi.mock('@/features/AgentProfileCard/AgentProfilePopup', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+const activity = {
+  content: 'See [primes.py](https://example.com/primes.py) for the script.',
+  id: 'run-1',
+  operationId: 'op-1',
+  status: 'success',
+  time: new Date('2026-08-13T00:00:00.000Z').toISOString(),
+  title: 'Run title',
+  topicId: 'topic-1',
+  type: 'topic',
+} as unknown as TaskDetailActivity;
+
+describe('TopicCard', () => {
+  it('leaves links in the run output clickable', async () => {
+    render(<TopicCard activity={activity} />);
+
+    const link = screen.getByRole('link', { name: 'primes.py' });
+
+    // The run body used to carry `pointer-events: none` so that clicks fell
+    // through to the card behind it. user-event refuses to click through that
+    // rule, which is exactly what a reader hit: a link that ignores the mouse.
+    await expect(userEvent.click(link)).resolves.not.toThrow();
+  });
+});

--- a/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
@@ -54,11 +54,17 @@ const formatDuration = (ms: number): string => {
 // the shared collapse clamps it with a fade and offers "show more", while the
 // run drawer remains available from the explicit overflow action. The preview
 // itself is reading content, not an unlabeled navigation target.
+//
+// It also stays interactive. While the whole card was one big button to the run
+// drawer, the body carried `pointer-events: none` so clicks fell through to it;
+// the card stopped being that button, and the rule was left behind killing every
+// link, code-copy and text selection in the output with nothing to fall through
+// to. Anything added here that swallows clicks has to earn it again.
 const RUN_CONTENT_MAX_HEIGHT = 160;
 
 const RunContent = memo<{ content: string }>(({ content }) => (
   <CollapsibleContent key={content} maxHeight={RUN_CONTENT_MAX_HEIGHT}>
-    <Markdown style={{ overflow: 'unset', pointerEvents: 'none' }} variant={'chat'}>
+    <Markdown style={{ overflow: 'unset' }} variant={'chat'}>
       {content}
     </Markdown>
   </CollapsibleContent>


### PR DESCRIPTION
On the task detail page (`/agent/:aid/task/:taskId`), nothing inside a run's output answered the mouse: links did not open, the code block's copy button did nothing, text could not even be selected. The same content read fine from the run drawer and the share page, which render it through a different path.

`TopicCard` rendered the run body with `pointer-events: none`:

```tsx
<Markdown style={{ overflow: 'unset', pointerEvents: 'none' }} variant={'chat'}>
```

That was correct when it was written (#16724): the whole run card was one big button to the run drawer, so the body had to let every click — links included — fall through to the card behind it. The original comment said as much.

#18041 then dropped the card-level `onClick={activity.id ? handleOpen : undefined}` and made the body plain reading content, with an explicit expand toggle and the drawer reachable from the overflow menu. The `pointer-events: none` stayed behind, now swallowing every click with nothing underneath left to receive it.

Removed, and the comment above `RunContent` now records the history so the rule does not come back without a reason.

| Before | After |
| ------ | ----- |
| Links, code-copy and text selection in the run output are all inert | The run output behaves like the same markdown does everywhere else |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`TopicCard.test.tsx` renders a run whose content holds a markdown link and clicks it with `user-event`, which refuses to click through `pointer-events: none` — the same wall a reader hit. On `canary` it fails with *"Unable to perform pointer interaction as the element inherits `pointer-events: none`"*; it passes with this change.

#### Key Decisions

- Only the rule is removed. The `stopPropagation` wrappers around the header actions are also leftovers from the clickable-card era, but they are harmless and touching them widens the diff past the bug.
- `RunVerifyDetail` / `RunVerifyTag` / `RunReplyEditor` are stubbed in the test purely to keep the verify feature and the upload stack (which reaches `pdfjs-dist`, unloadable under vitest) out of the module graph. `Markdown` and `CollapsibleContent` stay real — they are what the assertion is about.

#### 🔗 Related Issue

Regression from #18041.
