### PR TITLE
🐛 fix(hetero): resolve Cursor CLI alias collisions

### DIFF
--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
@@ -217,7 +217,7 @@ describe('resolveCliCommand', () => {
       });
     });
 
-    it("rejects an unrelated `agent` binary and falls back to Cursor's user-local install", async () => {
+    it("falls back to Cursor's unambiguous alias when another CLI owns `agent`", async () => {
       const originalPath = process.env.PATH;
       const originalShell = process.env.SHELL;
       process.env.PATH = '/usr/bin:/bin';
@@ -226,6 +226,7 @@ describe('resolveCliCommand', () => {
       try {
         callExecFile('/Users/x/.grok/bin/agent\n');
         callExecFile('Usage: agent [flags]\nGrok CLI agent');
+        callExecFile('Usage: agent [flags]\nGrok CLI agent');
         callExecFile('Usage: agent [options] [command] [prompt...]\nStart the Cursor Agent');
 
         const { detectHeterogeneousCliCommand } = await importModule();
@@ -233,11 +234,12 @@ describe('resolveCliCommand', () => {
 
         expect(status).toMatchObject({
           available: true,
-          path: path.join(os.homedir(), '.local', 'bin', 'agent'),
+          path: path.join(os.homedir(), '.local', 'bin', 'cursor-agent'),
           version: undefined,
         });
         expect(execFileMock.mock.calls[1]![1]).toEqual(['--help']);
         expect(execFileMock.mock.calls[2]![1]).toEqual(['--help']);
+        expect(execFileMock.mock.calls[3]![1]).toEqual(['--help']);
       } finally {
         process.env.PATH = originalPath;
         if (originalShell === undefined) delete process.env.SHELL;

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
@@ -620,7 +620,12 @@ const getWellKnownCommandPaths = (agentType: HeterogeneousCliAgentType): string[
     }
     case 'cursor': {
       if (platform() !== 'darwin' && platform() !== 'linux') return [];
-      return [path.join(homedir(), '.local', 'bin', 'agent')];
+      return [
+        path.join(homedir(), '.local', 'bin', 'agent'),
+        // Cursor's installer creates both names. Keep the unambiguous legacy
+        // alias as a fallback when another CLI shadows the generic `agent`.
+        path.join(homedir(), '.local', 'bin', 'cursor-agent'),
+      ];
     }
     case 'kimi-code': {
       if (platform() !== 'darwin' && platform() !== 'linux') return [];


### PR DESCRIPTION
### Brief

Cursor's installer creates both `agent` and `cursor-agent`, but LobeHub only checked the generic user-local `agent` fallback. When another CLI such as Grok owned that name, Cursor model discovery could not reach the unambiguous Cursor alias.

This change adds `~/.local/bin/cursor-agent` as a validated fallback while preserving the documented `agent` default. It also updates the collision regression case to cover both generic `agent` locations being owned by another CLI.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation:

- `bun run check packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts --lint --test` — 41 tests passed
- Official Cursor CLI `--list-models` probe in an isolated Grok collision setup — 201 models discovered and parsed

#### 🔗 Related Issue

No matching issue found.
