### PR TITLE
🐛 fix(onboarding): handle connector permission failures

### DIFF
--- a/apps/server/src/routers/lambda/user.ts
+++ b/apps/server/src/routers/lambda/user.ts
@@ -116,6 +116,28 @@ const retryOnboardingUnderstandingSourceInputSchema = z
     topicId: understandingIdSchema,
   })
   .strict() satisfies z.ZodType<RetryOnboardingUnderstandingProviderInput>;
+const reconcileOnboardingUnderstandingProvidersInputSchema = z
+  .object({
+    providerIds: z
+      .array(
+        z
+          .string()
+          .trim()
+          .min(1)
+          .max(64)
+          .regex(/^[\w-]+$/),
+      )
+      .max(16),
+    responseLanguage: z
+      .string()
+      .trim()
+      .min(2)
+      .max(64)
+      .regex(/^[A-Z]{2,3}(?:-[A-Z0-9]{2,8})*$/i),
+    sessionId: understandingIdSchema,
+    topicId: understandingIdSchema,
+  })
+  .strict();
 const confirmOnboardingUnderstandingInputSchema = z
   .object({
     resultId: understandingIdSchema,
@@ -508,6 +530,12 @@ export const userRouter = router({
   resetSettings: userProcedure.mutation(async ({ ctx }) => {
     return ctx.userModel.deleteSetting();
   }),
+
+  reconcileOnboardingUnderstandingProviders: understandingServiceProcedure
+    .input(reconcileOnboardingUnderstandingProvidersInputSchema)
+    .mutation(async ({ ctx, input }): Promise<OnboardingUnderstandingPollingResult> => {
+      return ctx.understandingService.reconcileProviders(input);
+    }),
 
   reviseOnboardingUnderstanding: understandingServiceProcedure
     .input(reviseOnboardingUnderstandingInputSchema)

--- a/apps/server/src/services/understanding/providers/gmail.test.ts
+++ b/apps/server/src/services/understanding/providers/gmail.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { gmailUnderstandingProvider } from './gmail';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('gmailUnderstandingProvider', () => {
+  /** @example A Gmail account without read scopes is skipped before evidence searches run. */
+  it('persists a non-retryable diagnostic when Gmail read permission is missing', async () => {
+    // ROOT CAUSE:
+    //
+    // Connector availability only proves that an OAuth account exists. A user can finish Gmail
+    // OAuth without granting read access, which previously caused every profile search to fail and
+    // obscured the actionable permission problem behind a generic collection failure.
+    //
+    // We fixed this by checking the owned account scopes before issuing any Gmail search request.
+    const searchMessages = vi.fn();
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const result = await gmailUnderstandingProvider.collect({
+      connectorData: {
+        getGmailClient: vi.fn(async () => ({
+          getAccount: vi.fn(async () => ({
+            externalAccountId: 'gmail-account',
+            scopes: ['openid', 'email'],
+          })),
+          searchMessages,
+        })),
+      } as never,
+      userId: 'user-id',
+    });
+
+    expect(searchMessages).not.toHaveBeenCalled();
+    expect(warning).toHaveBeenCalledWith(
+      '[understanding:gmail] skipped because Gmail read permission is missing',
+    );
+    expect(result).toEqual({
+      context: '',
+      diagnostics: {
+        errors: [
+          {
+            code: 'GMAIL_READ_PERMISSION_REQUIRED',
+            message: 'Gmail read permission is required to collect Understanding evidence',
+            operation: 'permission',
+            provider: 'gmail',
+            retryable: false,
+          },
+        ],
+        evidenceCount: 0,
+        failedCount: 1,
+        succeededCount: 0,
+      },
+      sourceCount: 0,
+    });
+  });
+});

--- a/apps/server/src/services/understanding/providers/gmail.ts
+++ b/apps/server/src/services/understanding/providers/gmail.ts
@@ -18,6 +18,13 @@ const GMAIL_PROFILE_SEARCHES = [
 const MAX_CONTEXT_MESSAGES = 32;
 const MAX_CONTEXT_MESSAGES_PER_SENDER_DOMAIN = 6;
 
+const hasGmailReadPermission = (scopes: readonly string[]) =>
+  scopes.some((scope) =>
+    ['gmail.modify', 'gmail.readonly', 'mail.google.com/'].some((permission) =>
+      scope.endsWith(permission),
+    ),
+  );
+
 const evidencePriority = ({ labels }: GmailMessage) => {
   const normalized = new Set(labels.map((label) => label.toUpperCase()));
   if (normalized.has('CATEGORY_PROMOTIONS')) return 2;
@@ -78,6 +85,28 @@ export const gmailUnderstandingProvider: UnderstandingProvider = {
   id: 'gmail',
   collect: async ({ connectorData }) => {
     const client = await connectorData.getGmailClient();
+    const account = await client.getAccount();
+    if (!hasGmailReadPermission(account.scopes)) {
+      console.warn('[understanding:gmail] skipped because Gmail read permission is missing');
+      return {
+        context: '',
+        diagnostics: {
+          errors: [
+            {
+              code: 'GMAIL_READ_PERMISSION_REQUIRED',
+              message: 'Gmail read permission is required to collect Understanding evidence',
+              operation: 'permission',
+              provider: 'gmail',
+              retryable: false,
+            },
+          ],
+          evidenceCount: 0,
+          failedCount: 1,
+          succeededCount: 0,
+        },
+        sourceCount: 0,
+      };
+    }
     const settled = await Promise.allSettled(
       GMAIL_PROFILE_SEARCHES.map(({ query }) => client.searchMessages({ query })),
     );

--- a/apps/server/src/services/understanding/service.test.ts
+++ b/apps/server/src/services/understanding/service.test.ts
@@ -98,6 +98,8 @@ const storedContext = (
   sourceCount: 3,
 });
 
+const providerAttempts = (...attempts: Array<{ id: string; revision: number }>) => attempts;
+
 const createHarness = (initialSession?: OnboardingUnderstandingSession) => {
   let session = initialSession;
   let latestAssistant:
@@ -211,7 +213,7 @@ const createHarness = (initialSession?: OnboardingUnderstandingSession) => {
       };
       return { revision };
     }),
-    reconcileProviders: vi.fn(async () => ({ attempts: [], session: session! })),
+    reconcileProviders: vi.fn(async () => ({ attempts: providerAttempts(), session: session! })),
     prepareWriting: vi.fn(async ({ sourceFingerprint, threadId }) => {
       const feedbackRevision = session?.feedback?.revision ?? 0;
       const generationRevision = (session?.generationRevision ?? 0) + 1;
@@ -522,7 +524,7 @@ describe('UnderstandingService', () => {
     const harness = createHarness(createSession({ gmail }));
     harness.repository.reconcileProviders.mockImplementationOnce(async () => {
       harness.setSession(next);
-      return { attempts: [{ id: 'github', revision: 1 }], session: next };
+      return { attempts: providerAttempts({ id: 'github', revision: 1 }), session: next };
     });
 
     await expect(
@@ -540,6 +542,37 @@ describe('UnderstandingService', () => {
       expect.objectContaining({ providers: [{ id: 'github', revision: 1 }] }),
       expect.any(Object),
     );
+  });
+
+  /** @example Failed reconciliation compensation is logged before the trigger error is rethrown. */
+  it('reports failed provider compensation when workflow dispatch fails', async () => {
+    const next = createSession({ github: providerState('running', 1) });
+    const harness = createHarness(createSession({}));
+    const triggerError = new Error('workflow dispatch failed');
+    const compensationError = new Error('database unavailable');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    harness.repository.reconcileProviders.mockImplementationOnce(async () => {
+      harness.setSession(next);
+      return { attempts: providerAttempts({ id: 'github', revision: 1 }), session: next };
+    });
+    harness.repository.failProvider.mockRejectedValueOnce(compensationError);
+    mockTriggerProviders.mockRejectedValueOnce(triggerError);
+
+    await expect(
+      harness.service.reconcileProviders({
+        providerIds: ['github'],
+        responseLanguage: 'zh-CN',
+        sessionId: 'session-1',
+        topicId: 'topic-1',
+      }),
+    ).rejects.toBe(triggerError);
+
+    expect(consoleError).toHaveBeenCalledWith('[understanding:reconcileCompensation]', {
+      errorName: 'Error',
+      providerId: 'github',
+      revision: 1,
+    });
+    consoleError.mockRestore();
   });
 
   /**

--- a/apps/server/src/services/understanding/service.test.ts
+++ b/apps/server/src/services/understanding/service.test.ts
@@ -211,6 +211,7 @@ const createHarness = (initialSession?: OnboardingUnderstandingSession) => {
       };
       return { revision };
     }),
+    reconcileProviders: vi.fn(async () => ({ attempts: [], session: session! })),
     prepareWriting: vi.fn(async ({ sourceFingerprint, threadId }) => {
       const feedbackRevision = session?.feedback?.revision ?? 0;
       const generationRevision = (session?.generationRevision ?? 0) + 1;
@@ -491,6 +492,52 @@ describe('UnderstandingService', () => {
       expect.objectContaining({
         providers: [{ id: 'github', revision: 1 }],
       }),
+      expect.any(Object),
+    );
+  });
+
+  /** @example Reconciliation dispatches only GitHub after Gmail fails for missing permission. */
+  it('dispatches only provider attempts selected by atomic reconciliation', async () => {
+    // ROOT CAUSE:
+    //
+    // Retrying a failed Understanding session operated only on its original provider manifest, so
+    // a GitHub connection added after navigating backward was never dispatched. Retrying each failed
+    // source independently also repeated non-retryable Gmail permission failures.
+    //
+    // We fixed this by letting the repository return the exact running revisions to dispatch.
+    const gmail = {
+      ...providerState('failed', 1),
+      errors: [
+        {
+          code: 'GMAIL_READ_PERMISSION_REQUIRED',
+          message: 'Gmail read permission is required',
+          operation: 'permission',
+          provider: 'gmail',
+          retryable: false,
+        },
+      ],
+      failedCount: 1,
+    };
+    const next = createSession({ github: providerState('running', 1), gmail });
+    const harness = createHarness(createSession({ gmail }));
+    harness.repository.reconcileProviders.mockImplementationOnce(async () => {
+      harness.setSession(next);
+      return { attempts: [{ id: 'github', revision: 1 }], session: next };
+    });
+
+    await expect(
+      harness.service.reconcileProviders({
+        providerIds: ['gmail', 'github'],
+        responseLanguage: 'zh-CN',
+        sessionId: 'session-1',
+        topicId: 'topic-1',
+      }),
+    ).resolves.toMatchObject({
+      sources: { github: { status: 'running' }, gmail: { status: 'failed' } },
+    });
+
+    expect(mockTriggerProviders).toHaveBeenCalledWith(
+      expect.objectContaining({ providers: [{ id: 'github', revision: 1 }] }),
       expect.any(Object),
     );
   });

--- a/apps/server/src/services/understanding/service.ts
+++ b/apps/server/src/services/understanding/service.ts
@@ -399,7 +399,7 @@ export class UnderstandingService {
         },
       );
     } catch (triggerError) {
-      await Promise.allSettled(
+      const compensationResults = await Promise.allSettled(
         attempts.map(({ id, revision }) =>
           this.failProvider({
             providerId: id,
@@ -409,6 +409,14 @@ export class UnderstandingService {
           }),
         ),
       );
+      compensationResults.forEach((result, index) => {
+        if (result.status === 'fulfilled') return;
+        console.error('[understanding:reconcileCompensation]', {
+          errorName: result.reason instanceof Error ? result.reason.name : 'UnknownError',
+          providerId: attempts[index].id,
+          revision: attempts[index].revision,
+        });
+      });
       throw triggerError;
     }
 

--- a/apps/server/src/services/understanding/service.ts
+++ b/apps/server/src/services/understanding/service.ts
@@ -75,6 +75,13 @@ interface ProcessCollectedInput {
   topicId: string;
 }
 
+interface ReconcileProvidersInput {
+  providerIds: string[];
+  responseLanguage: string;
+  sessionId: string;
+  topicId: string;
+}
+
 type UnderstandingRepository = Pick<
   OnboardingUnderstandingRepository,
   | 'commitWriting'
@@ -90,6 +97,7 @@ type UnderstandingRepository = Pick<
   | 'initialize'
   | 'markProviderRunning'
   | 'prepareWriting'
+  | 'reconcileProviders'
 >;
 
 type UnderstandingContexts = Pick<UnderstandingSourceStore, 'get' | 'put'>;
@@ -333,6 +341,80 @@ export class UnderstandingService {
     );
   };
 
+  /**
+   * Reconciles the current connector selection with an active Understanding session.
+   *
+   * Use when:
+   * - The user returns from connector setup after adding another provider
+   * - Retryable provider failures should be resumed without repeating permission failures
+   *
+   * Expects:
+   * - Provider IDs come from the current onboarding connector selection
+   * - The referenced session belongs to the active onboarding topic
+   *
+   * Returns:
+   * - The latest polling result after newly added and retryable providers are dispatched
+   */
+  reconcileProviders = async (
+    input: ReconcileProvidersInput,
+  ): Promise<OnboardingUnderstandingPollingResult> => {
+    const { OnboardingUnderstandingWorkflow } =
+      await import('@/server/workflows/onboardingUnderstanding');
+    OnboardingUnderstandingWorkflow.assertAvailable();
+    await this.activeSession(input.topicId, input.sessionId);
+
+    const requestedProviderIds = [...new Set(input.providerIds)].sort();
+    if (requestedProviderIds.some((providerId) => !this.dependencies.providers.has(providerId))) {
+      throw new UnderstandingResourceNotFoundError('session');
+    }
+    const availableProviderIds = new Set(await this.listSourceProviderIds());
+    const providerIds = requestedProviderIds.filter((providerId) =>
+      availableProviderIds.has(providerId),
+    );
+    const { attempts } = await this.dependencies.repository.reconcileProviders({
+      providerIds,
+      sessionId: input.sessionId,
+      topicId: input.topicId,
+    });
+    if (attempts.length === 0) return this.get(input.topicId);
+
+    try {
+      // Dispatch only the revisions transitioned to running by the atomic database mutation.
+      await OnboardingUnderstandingWorkflow.triggerProviders(
+        {
+          providers: attempts,
+          responseLanguage: input.responseLanguage,
+          sessionId: input.sessionId,
+          startedAt: Date.now(),
+          topicId: input.topicId,
+          userId: this.dependencies.userId,
+        },
+        {
+          workflowRunId: `onboarding-understanding-reconcile-${createHash('sha256')
+            .update(input.sessionId)
+            .update('\0')
+            .update(attempts.map(({ id, revision }) => `${id}-${revision}`).join(','))
+            .digest('hex')
+            .slice(0, 32)}`,
+        },
+      );
+    } catch (triggerError) {
+      await Promise.allSettled(
+        attempts.map(({ id, revision }) =>
+          this.failProvider({
+            providerId: id,
+            revision,
+            sessionId: input.sessionId,
+            topicId: input.topicId,
+          }),
+        ),
+      );
+      throw triggerError;
+    }
+
+    return this.get(input.topicId);
+  };
+
   revise = async (
     input: ReviseOnboardingUnderstandingInput,
   ): Promise<OnboardingUnderstandingPollingResult> => {
@@ -479,6 +561,7 @@ export class UnderstandingService {
     if (state.status !== 'failed') {
       throw new UnderstandingPreconditionError('source_not_retryable');
     }
+    if (!state.errors.some(({ retryable }) => retryable)) return this.get(input.topicId);
     const availableProviderIds = await this.dependencies.connectorData.listAvailableProviderIds([
       input.providerId,
     ]);

--- a/packages/const/src/apiKeyScope.test.ts
+++ b/packages/const/src/apiKeyScope.test.ts
@@ -129,6 +129,11 @@ describe('requiredApiKeyScopeForTrpc', () => {
     expect(requiredApiKeyScopeForTrpc('user.startOnboardingUnderstanding', 'mutation')).toEqual({
       scopes: ['user:write', 'model:invoke'],
     });
+    expect(
+      requiredApiKeyScopeForTrpc('user.reconcileOnboardingUnderstandingProviders', 'mutation'),
+    ).toEqual({
+      scopes: ['user:write', 'model:invoke'],
+    });
     // sibling procedures in the namespace are untouched
     expect(requiredApiKeyScopeForTrpc('agentDocument.createDocument', 'mutation')).toEqual({
       scopes: ['knowledge:write'],

--- a/packages/const/src/apiKeyScope.ts
+++ b/packages/const/src/apiKeyScope.ts
@@ -357,6 +357,7 @@ export const TRPC_PROCEDURE_EXTRA_SCOPES: Record<string, ApiKeyScope[]> = {
   'user.resetSettings': ['model:write'],
   // onboarding understanding triggers enqueue generation workflows
   // (persona / task-recommendation `generateObject` steps run async via QStash)
+  'user.reconcileOnboardingUnderstandingProviders': ['model:invoke'],
   'user.retryOnboardingUnderstandingSource': ['model:invoke'],
   'user.reviseOnboardingUnderstanding': ['model:invoke'],
   'user.startOnboardingUnderstanding': ['model:invoke'],

--- a/packages/database/src/repositories/onboardingUnderstanding/repository.test.ts
+++ b/packages/database/src/repositories/onboardingUnderstanding/repository.test.ts
@@ -313,6 +313,53 @@ describe('OnboardingUnderstandingRepository', () => {
     ).rejects.toThrow('feedback is no longer active');
   });
 
+  /** @example A newly connected GitHub source runs while a Gmail permission failure stays failed. */
+  it('adds new providers without retrying non-retryable provider failures', async () => {
+    // ROOT CAUSE:
+    //
+    // The original session manifest was immutable during retry. Returning to connector setup and
+    // adding GitHub therefore retried only the existing Gmail failure, while GitHub never entered
+    // the session. Permission failures were also retried even though the OAuth grant had not changed.
+    //
+    // We fixed this with one locked mutation that adds new providers and restarts only failures whose
+    // persisted diagnostics explicitly allow retry.
+    await repository.initialize(topicId, sessionId, ['gmail']);
+    const { revision } = await repository.markProviderRunning(topicId, sessionId, 'gmail');
+    await repository.failProvider({
+      errors: [
+        {
+          code: 'GMAIL_READ_PERMISSION_REQUIRED',
+          message: 'Gmail read permission is required',
+          operation: 'permission',
+          provider: 'gmail',
+          retryable: false,
+        },
+      ],
+      failedCount: 1,
+      providerId: 'gmail',
+      revision,
+      sessionId,
+      succeededCount: 0,
+      topicId,
+    });
+
+    const reconciled = await repository.reconcileProviders({
+      providerIds: ['gmail', 'github'],
+      sessionId,
+      topicId,
+    });
+
+    expect(reconciled.attempts).toEqual([{ id: 'github', revision: 1 }]);
+    expect(reconciled.session.sources).toMatchObject({
+      github: { errors: [], revision: 1, status: 'running' },
+      gmail: {
+        errors: [expect.objectContaining({ code: 'GMAIL_READ_PERMISSION_REQUIRED' })],
+        revision: 1,
+        status: 'failed',
+      },
+    });
+  });
+
   /**
    * @example
    * expect(stale.published).toBe(false);

--- a/packages/database/src/repositories/onboardingUnderstanding/repository.ts
+++ b/packages/database/src/repositories/onboardingUnderstanding/repository.ts
@@ -115,6 +115,17 @@ interface ExtendSessionInput {
   topicId: string;
 }
 
+interface ReconcileProvidersInput {
+  providerIds: string[];
+  sessionId: string;
+  topicId: string;
+}
+
+interface ReconcileProvidersResult {
+  attempts: Array<{ id: string; revision: number }>;
+  session: OnboardingUnderstandingSession;
+}
+
 interface CommitWritingInput {
   assistantMessageId: string;
   feedbackRevision: number;
@@ -370,6 +381,75 @@ export class OnboardingUnderstandingRepository {
 
         const nextSession = parseSession({ ...session, feedback: nextFeedback, sources });
         return { nextSession, result: nextSession, write: true };
+      }),
+    );
+  };
+
+  /**
+   * Atomically adds newly connected providers and restarts retryable provider failures.
+   *
+   * Use when:
+   * - The user returns from connector setup with a changed provider selection
+   * - An interrupted collection should resume without retrying permission failures
+   *
+   * Expects:
+   * - Provider IDs were validated against the runtime provider registry and connector availability
+   * - The session is active and unconfirmed
+   *
+   * Returns:
+   * - The updated session and exact running provider revisions that should be dispatched
+   */
+  reconcileProviders = async ({
+    providerIds,
+    sessionId,
+    topicId,
+  }: ReconcileProvidersInput): Promise<ReconcileProvidersResult> => {
+    providerIds.forEach(assertProviderId);
+    return this.db.transaction((tx) =>
+      mutateTopicSession(tx, this.userId, topicId, (persisted) => {
+        const session = requireSession(topicId, sessionId, persisted);
+        if (session.confirmedAt) throw new UnderstandingPreconditionError('session_confirmed');
+
+        const sources = { ...session.sources };
+        const attempts: ReconcileProvidersResult['attempts'] = [];
+        for (const providerId of [...new Set(providerIds)].sort()) {
+          const current = sources[providerId];
+          if (!current) {
+            sources[providerId] = {
+              ...initialProviderState(),
+              revision: 1,
+              status: 'running',
+            };
+            attempts.push({ id: providerId, revision: 1 });
+            continue;
+          }
+          if (current.status !== 'failed' || !current.errors.some(({ retryable }) => retryable)) {
+            continue;
+          }
+
+          const revision = current.revision + 1;
+          sources[providerId] = {
+            ...current,
+            completedAt: undefined,
+            errors: [],
+            failedCount: 0,
+            revision,
+            status: 'running',
+            succeededCount: 0,
+          };
+          attempts.push({ id: providerId, revision });
+        }
+        if (attempts.length === 0) {
+          return { nextSession: session, result: { attempts, session }, write: false };
+        }
+
+        const nextSession = parseSession({ ...session, sources });
+        return {
+          clearTaskRecommendations: true,
+          nextSession,
+          result: { attempts, session: nextSession },
+          write: true,
+        };
       }),
     );
   };

--- a/src/services/user/index.test.ts
+++ b/src/services/user/index.test.ts
@@ -11,6 +11,7 @@ const mockLambdaClient = vi.hoisted(() => ({
     getUserRegistrationDuration: { query: vi.fn() },
     getUserState: { query: vi.fn() },
     getUserSSOProviders: { query: vi.fn() },
+    reconcileOnboardingUnderstandingProviders: { mutate: vi.fn() },
     retryOnboardingUnderstandingSource: { mutate: vi.fn() },
     reviseOnboardingUnderstanding: { mutate: vi.fn() },
     startOnboardingUnderstanding: { mutate: vi.fn() },
@@ -50,6 +51,9 @@ describe('UserService', () => {
     const pollingResult = { id: 'session-1', sources: {}, status: 'pending' };
     mockLambdaClient.user.startOnboardingUnderstanding.mutate.mockResolvedValueOnce(pollingResult);
     mockLambdaClient.user.getOnboardingUnderstanding.query.mockResolvedValueOnce(pollingResult);
+    mockLambdaClient.user.reconcileOnboardingUnderstandingProviders.mutate.mockResolvedValueOnce(
+      pollingResult,
+    );
     mockLambdaClient.user.reviseOnboardingUnderstanding.mutate.mockResolvedValueOnce(pollingResult);
     mockLambdaClient.user.retryOnboardingUnderstandingSource.mutate.mockResolvedValueOnce(
       pollingResult,
@@ -64,6 +68,12 @@ describe('UserService', () => {
       topicId: 'topic-1',
     });
     await userService.getOnboardingUnderstanding('topic-1');
+    await userService.reconcileOnboardingUnderstandingProviders({
+      providerIds: ['github'],
+      responseLanguage: 'en-US',
+      sessionId: 'session-1',
+      topicId: 'topic-1',
+    });
     await userService.reviseOnboardingUnderstanding({
       expectedFeedbackRevision: 0,
       feedback: 'Focus on infrastructure.',
@@ -90,6 +100,14 @@ describe('UserService', () => {
       topicId: 'topic-1',
     });
     expect(mockLambdaClient.user.getOnboardingUnderstanding.query).toHaveBeenCalledWith({
+      topicId: 'topic-1',
+    });
+    expect(
+      mockLambdaClient.user.reconcileOnboardingUnderstandingProviders.mutate,
+    ).toHaveBeenCalledWith({
+      providerIds: ['github'],
+      responseLanguage: 'en-US',
+      sessionId: 'session-1',
       topicId: 'topic-1',
     });
     expect(mockLambdaClient.user.reviseOnboardingUnderstanding.mutate).toHaveBeenCalledWith({

--- a/src/services/user/index.ts
+++ b/src/services/user/index.ts
@@ -77,6 +77,29 @@ export class UserService {
     return lambdaClient.user.readOnboardingDocument.query({ type });
   };
 
+  /**
+   * Reconciles live connector selections with an active onboarding Understanding session.
+   *
+   * Use when:
+   * - A user returns from connector setup after adding a source
+   * - Retryable provider failures should resume without retrying permanent permission failures
+   *
+   * Expects:
+   * - Provider IDs reflect the caller's current connector selection
+   * - The session belongs to the active onboarding topic
+   *
+   * Returns:
+   * - The latest Understanding polling state after reconciliation is dispatched
+   */
+  reconcileOnboardingUnderstandingProviders = async (input: {
+    providerIds: string[];
+    responseLanguage: string;
+    sessionId: string;
+    topicId: string;
+  }): Promise<OnboardingUnderstandingPollingResult> => {
+    return lambdaClient.user.reconcileOnboardingUnderstandingProviders.mutate(input);
+  };
+
   updateOnboardingDocument = async (type: 'soul' | 'persona', content: string) => {
     return lambdaClient.user.updateOnboardingDocument.mutate({ content, type });
   };


### PR DESCRIPTION
Handle incomplete connector grants without trapping onboarding Understanding in a failed retry loop.

- Check Gmail read scopes before issuing evidence searches.
- Persist a non-retryable permission diagnostic and emit a warning when access is insufficient.
- Atomically add newly connected providers and retry only failures marked retryable.
- Expose provider reconciliation through the authenticated user router.

#### Key Decisions / Non-goals

- A missing Gmail read grant fails only the Gmail source; it does not prevent newly connected sources such as GitHub from running.
- Provider state and workflow revisions are reconciled in one locked database mutation before dispatch.
- This PR does not add a Gmail reauthorization UI; callers can present the persisted diagnostic separately.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation: 7 changed files lint clean; 69 related tests passed.