### PR TITLE
🐛 fix(model-runtime): parse xAI reasoning text deltas

### DIFF
--- a/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
@@ -578,6 +578,29 @@ describe('OpenAIResponsesStream', () => {
     expect(chunks.some((c) => c.includes(' the problem...'))).toBe(true);
   });
 
+  it('should handle xAI response.reasoning_text.delta', async () => {
+    const mockOpenAIStream = createReadableStream([
+      {
+        type: 'response.created',
+        response: {
+          id: 'resp_reasoning_text_delta',
+          status: 'in_progress',
+        },
+      },
+      {
+        type: 'response.reasoning_text.delta',
+        item_id: 'reasoning_123',
+        output_index: 0,
+        delta: 'Continued reasoning',
+      },
+    ]);
+
+    const chunks = await readStreamChunk(OpenAIResponsesStream(mockOpenAIStream));
+
+    expect(chunks.some((chunk) => chunk.includes('event: reasoning'))).toBe(true);
+    expect(chunks.some((chunk) => chunk.includes('Continued reasoning'))).toBe(true);
+  });
+
   it('should handle response.output_text.annotation.added', async () => {
     const mockOpenAIStream = createReadableStream([
       {

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.ts
@@ -26,6 +26,11 @@ const transformOpenAIStream = (
   chunk:
     | OpenAI.Responses.ResponseStreamEvent
     | {
+        delta: string;
+        item_id: string;
+        type: 'response.reasoning_text.delta';
+      }
+    | {
         annotation: {
           end_index: number;
           start_index: number;
@@ -128,7 +133,8 @@ const transformOpenAIStream = (
         }
       }
 
-      case 'response.reasoning_summary_text.delta': {
+      case 'response.reasoning_summary_text.delta':
+      case 'response.reasoning_text.delta': {
         return { data: chunk.delta, id: chunk.item_id, type: 'reasoning' };
       }
 


### PR DESCRIPTION
## Description of Change

Handle xAI's `response.reasoning_text.delta` Responses API event as reasoning output, alongside the existing `response.reasoning_summary_text.delta` handling.

Without this event mapping, Grok 4.6 reasoning streams could appear truncated while the final answer continued normally. Providers and models that do not emit this event, including existing Grok 4.5 flows, retain their current behavior.

| Before | After |
| ------ | ----- |
| `response.reasoning_text.delta` was passed through as generic data and omitted from persisted reasoning | Reasoning text deltas are streamed and persisted as reasoning content |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation:

- `bun run check packages/model-runtime/src/core/streams/openai/responsesStream.ts packages/model-runtime/src/core/streams/openai/responsesStream.test.ts` — lint clean, 28 tests passed
- `bun run check --type packages/model-runtime/src/core/streams/openai/responsesStream.ts packages/model-runtime/src/core/streams/openai/responsesStream.test.ts` — types clean

#### 🔗 Related Issue

No matching issue found.
