### PR TITLE
🐛 fix(vite): dedupe editor context runtime

### DIFF
--- a/apps/desktop/vite.renderer.config.ts
+++ b/apps/desktop/vite.renderer.config.ts
@@ -11,6 +11,7 @@ import {
   createSharedRolldownOutput,
   sharedModulePreload,
   sharedOptimizeDeps,
+  sharedRendererDedupe,
   sharedRendererDefine,
   sharedRendererPlugins,
 } from '../../plugins/vite/sharedRendererConfig';
@@ -253,7 +254,7 @@ export default defineConfig(async (env) => {
       ...(sharedRendererPlugins({ platform: 'desktop' }) as PluginOption[]),
     ],
     resolve: {
-      dedupe: ['react', 'react-dom'],
+      dedupe: sharedRendererDedupe,
       tsconfigPaths: !isCloudDesktop,
     },
     root: ROOT_DIR,

--- a/plugins/vite/sharedRendererConfig.test.ts
+++ b/plugins/vite/sharedRendererConfig.test.ts
@@ -4,6 +4,7 @@ import {
   __testing,
   sharedModulePreload,
   sharedOptimizeDeps,
+  sharedRendererDedupe,
   sharedRendererPlugins,
 } from './sharedRendererConfig';
 
@@ -25,6 +26,12 @@ describe('sharedOptimizeDeps', () => {
     expect(sharedOptimizeDeps.include).toEqual(
       expect.arrayContaining(['@lobehub/ui', '@lobehub/ui/base-ui']),
     );
+  });
+});
+
+describe('sharedRendererDedupe', () => {
+  it('keeps editor entrypoints on one shared context instance', () => {
+    expect(sharedRendererDedupe).toContain('@lobehub/editor');
   });
 });
 

--- a/plugins/vite/sharedRendererConfig.ts
+++ b/plugins/vite/sharedRendererConfig.ts
@@ -428,6 +428,10 @@ export const sharedOptimizeDeps = {
   ],
 };
 
+// Workspace packages can resolve @lobehub/editor through different peer-dependency
+// snapshots. They must still share one LexicalComposerContext at runtime.
+export const sharedRendererDedupe = ['@lobehub/editor', 'react', 'react-dom'];
+
 export const __testing = {
   sharedChunkFileNames,
   sharedManualChunks,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ import {
   sharedOptimizeDeps,
   sharedPwaGlobIgnores,
   sharedPwaRuntimeCaching,
+  sharedRendererDedupe,
   sharedRendererDefine,
   sharedRendererPlugins,
 } from './plugins/vite/sharedRendererConfig';
@@ -144,6 +145,7 @@ export default defineConfig({
     bundledDev: false,
   },
   resolve: {
+    dedupe: sharedRendererDedupe,
     tsconfigPaths: true,
   },
   optimizeDeps: sharedOptimizeDeps,


### PR DESCRIPTION
## Description

Deduplicate `@lobehub/editor` across the shared Web and Electron Vite renderer configurations.

Workspace packages can resolve the editor through different peer-dependency snapshots. Vite then pre-bundles separate copies of the editor's internal `LexicalComposerContext`, causing plugins such as `ReactListPlugin` to fail even when rendered inside `Editor`.

This change centralizes the renderer dedupe list so all editor entrypoints share one runtime context instance.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Verification:

- `bun run check plugins/vite/sharedRendererConfig.ts plugins/vite/sharedRendererConfig.test.ts vite.config.ts apps/desktop/vite.renderer.config.ts`
- Forced a Vite dependency re-optimization and confirmed all `@lobehub/editor` entrypoints resolve through the same peer snapshot and share one `LexicalComposerContext` chunk.

#### 🔗 Related Issue

No matching issue found.
