### PR TITLE
🐛 fix: polish task and Home navigation affordances

### DIFF
--- a/apps/server/src/services/verify/__tests__/driveTaskFromVerify.test.ts
+++ b/apps/server/src/services/verify/__tests__/driveTaskFromVerify.test.ts
@@ -47,7 +47,14 @@ vi.mock('../goalLoop', () => ({
   }),
   goalReadyForReviewBriefCopy: (task: any, acceptanceId?: string) => ({
     actions: acceptanceId
-      ? [{ key: 'review', type: 'link', url: `/acceptance/${acceptanceId}` }]
+      ? [
+          {
+            key: 'review',
+            label: 'Review delivery',
+            type: 'link',
+            url: `/acceptance/${acceptanceId}`,
+          },
+        ]
       : [],
     summary: 'ready for your sign-off',
     title: `${task.identifier} goal delivered`,
@@ -397,7 +404,12 @@ describe('driveTaskFromVerify', () => {
       // bypassing the sign-off this branch exists to require.
       expect(brief.type).toBe('decision');
       expect(brief.actions).toEqual([
-        expect.objectContaining({ type: 'link', url: '/acceptance/acc-9' }),
+        expect.objectContaining({
+          key: 'review',
+          label: 'Review delivery',
+          type: 'link',
+          url: '/acceptance/acc-9',
+        }),
       ]);
     });
   });

--- a/apps/server/src/services/verify/goalLoop.ts
+++ b/apps/server/src/services/verify/goalLoop.ts
@@ -99,7 +99,7 @@ export const goalReadyForReviewBriefCopy = (
     ? [
         {
           key: 'review',
-          label: '🔍 Review delivery',
+          label: 'Review delivery',
           type: 'link',
           url: `/acceptance/${acceptanceId}`,
         },

--- a/locales/en-US/home.json
+++ b/locales/en-US/home.json
@@ -10,6 +10,7 @@
   "brief.action.feedback": "Feedback",
   "brief.action.ignore": "Ignore",
   "brief.action.retry": "Retry",
+  "brief.action.review": "Review delivery",
   "brief.action.upgrade": "Upgrade plan",
   "brief.actionFailed": "That didn't go through. Please try again.",
   "brief.addFeedback": "Share feedback",

--- a/locales/zh-CN/home.json
+++ b/locales/zh-CN/home.json
@@ -10,6 +10,7 @@
   "brief.action.feedback": "反馈",
   "brief.action.ignore": "忽略",
   "brief.action.retry": "重试",
+  "brief.action.review": "验收交付",
   "brief.action.upgrade": "升级方案",
   "brief.actionFailed": "操作没有成功，请再试一次。",
   "brief.addFeedback": "分享反馈",

--- a/packages/locales/src/default/home.ts
+++ b/packages/locales/src/default/home.ts
@@ -10,6 +10,7 @@ export default {
   'brief.action.confirmDone': 'Confirm complete',
   'brief.action.feedback': 'Feedback',
   'brief.action.ignore': 'Ignore',
+  'brief.action.review': 'Review delivery',
   'brief.action.retry': 'Retry',
   'brief.action.upgrade': 'Upgrade plan',
   'brief.actionFailed': "That didn't go through. Please try again.",

--- a/packages/shared-tool-ui/src/Inspector/RunCommand/index.tsx
+++ b/packages/shared-tool-ui/src/Inspector/RunCommand/index.tsx
@@ -43,6 +43,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     color: ${cssVar.colorTextDescription};
   `,
   statusIcon: css`
+    flex-shrink: 0;
     margin-inline-start: 4px;
   `,
   terminalIcon: css`

--- a/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
@@ -23,6 +23,7 @@ import {
   MoreHorizontal,
   SquarePen,
 } from 'lucide-react';
+import type { KeyboardEvent } from 'react';
 import { memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -121,8 +122,22 @@ const TopicCard = memo<TopicCardProps>(({ activity, defaultExpanded = true }) =>
   }, [isRunning, activity.time]);
 
   const handleOpen = useCallback(() => {
-    if (activity.id) openTopicDrawer(activity.id);
-  }, [activity.id, openTopicDrawer]);
+    if (!activity.id) return;
+    openTopicDrawer(activity.id, {
+      agentId:
+        activity.author?.type === 'agent' ? activity.author.id : activity.agentId || undefined,
+      title: activity.title,
+    });
+  }, [activity.agentId, activity.author, activity.id, activity.title, openTopicDrawer]);
+
+  const handleTitleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      event.preventDefault();
+      handleOpen();
+    },
+    [handleOpen],
+  );
 
   const handleCopyId = useCallback(() => {
     if (activity.id) void navigator.clipboard.writeText(activity.id);
@@ -236,7 +251,16 @@ const TopicCard = memo<TopicCardProps>(({ activity, defaultExpanded = true }) =>
               {activity.sourceTaskIdentifier}
             </Tag>
           )}
-          <Text ellipsis weight={500}>
+          <Text
+            ellipsis
+            aria-disabled={activity.id ? undefined : true}
+            role={activity.id ? 'button' : undefined}
+            style={{ cursor: activity.id ? 'pointer' : undefined }}
+            tabIndex={activity.id ? 0 : -1}
+            weight={500}
+            onClick={handleOpen}
+            onKeyDown={handleTitleKeyDown}
+          >
             {activity.title}
           </Text>
           {activity.seq != null && (

--- a/src/features/DailyBrief/__tests__/BriefCardActions.test.tsx
+++ b/src/features/DailyBrief/__tests__/BriefCardActions.test.tsx
@@ -23,6 +23,7 @@ vi.mock('react-i18next', () => ({
         'brief.commentSubmit': 'Submit feedback',
         'brief.action.confirm': 'Confirm',
         'brief.action.confirmDone': 'Confirm complete',
+        'brief.action.review': 'Review delivery',
         'brief.editResult': 'Edit',
         'brief.viewRun': 'View run',
       };
@@ -223,6 +224,29 @@ describe('BriefCardActions', () => {
     renderWithRouter(<BriefCardActions actions={null} briefId="brief-2" briefType="decision" />);
 
     expect(screen.getByText('✅ Confirm')).toBeInTheDocument();
+  });
+
+  it('should localize a review link action instead of showing its persisted label', () => {
+    renderWithRouter(
+      <BriefCardActions
+        briefId="brief-review"
+        briefType="decision"
+        actions={[
+          {
+            key: 'review',
+            label: 'Legacy review label',
+            type: 'link',
+            url: '/acceptance/acceptance-1',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Review delivery' })).toHaveAttribute(
+      'href',
+      '/acceptance/acceptance-1',
+    );
+    expect(screen.queryByText('Legacy review label')).not.toBeInTheDocument();
   });
 
   it('should hardcode primary action label to "Confirm complete" for result briefs', () => {

--- a/src/features/Electron/titlebar/TabBar/resolveTab.test.ts
+++ b/src/features/Electron/titlebar/TabBar/resolveTab.test.ts
@@ -14,7 +14,7 @@ const fixtureRoutes: RouteObject[] = [
     children: [
       {
         handle: {
-          meta: { tabTitleKey: 'navigation.newChat', titleKey: 'navigation.home' },
+          meta: { tabTitleKey: 'navigation.home', titleKey: 'navigation.home' },
         },
         index: true,
       },
@@ -100,9 +100,9 @@ describe('resolveTab', () => {
     expect(resolved.meta.title).toBe('navigation.chat');
   });
 
-  it('prefers the Electron tab title over the document title', () => {
+  it('uses Home as the Electron tab title for the Home route', () => {
     const resolved = resolveTab(fixtureRoutes, tab('/'), false, t);
-    expect(resolved.meta.title).toBe('navigation.newChat');
+    expect(resolved.meta.title).toBe('navigation.home');
   });
 
   it('uses the generic fallback when neither snapshot nor static meta exists', () => {

--- a/src/spa/router/desktopRouter.meta.desktop.test.ts
+++ b/src/spa/router/desktopRouter.meta.desktop.test.ts
@@ -11,11 +11,11 @@ import { mainAreaMetaRoutes } from './desktopRouter.config.desktop';
 // meta tree that aliased those stubs would silently degrade every tab title to
 // brand and every icon to the Circle fallback on the packaged app.
 describe('mainAreaMetaRoutes (Electron adapter)', () => {
-  it('uses New Chat for the personal Home tab without changing its document title', () => {
+  it('uses Home for the personal Home tab and document title', () => {
     const { static: staticMeta } = matchRouteMeta(mainAreaMetaRoutes, '/');
 
     expect(staticMeta.icon).toBe(MessageSquarePlus);
-    expect(staticMeta.tabTitleKey).toBe('navigation.newChat');
+    expect(staticMeta.tabTitleKey).toBe('navigation.home');
     expect(staticMeta.titleKey).toBe('navigation.home');
   });
 

--- a/src/spa/router/desktopRouter.shared.tsx
+++ b/src/spa/router/desktopRouter.shared.tsx
@@ -1205,7 +1205,7 @@ const createMainAreaChildrenDefinition = (options: MainAreaRouteOptions = {}): R
     handle: {
       meta: routeMeta({
         icon: MessageSquarePlus,
-        tabTitleKey: 'navigation.newChat',
+        tabTitleKey: 'navigation.home',
         titleKey: 'navigation.home',
       }),
     },


### PR DESCRIPTION
## Summary

- make task topic titles open the run drawer directly, including keyboard access
- preserve topic agent and title metadata when opening the drawer
- label the Electron Home tab as Home instead of New Chat
- keep completed command status icons from shrinking beside long command previews
- remove the emoji from the review-delivery action and localize its label in English and Simplified Chinese

## Testing

- `bun run check src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx`
- `bun run check src/spa/router/desktopRouter.shared.tsx src/spa/router/desktopRouter.meta.desktop.test.ts src/features/Electron/titlebar/TabBar/resolveTab.test.ts`
- `bun run check packages/shared-tool-ui/src/Inspector/RunCommand/index.tsx apps/server/src/services/verify/goalLoop.ts apps/server/src/services/verify/__tests__/driveTaskFromVerify.test.ts packages/locales/src/default/home.ts locales/en-US/home.json locales/zh-CN/home.json src/features/DailyBrief/__tests__/BriefCardActions.test.tsx`
- `git diff --check`