### PR TITLE
✨ feat(agent): let the last working sidebar tab close the panel

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -2128,6 +2128,7 @@
   "workingPanel.tabs.close": "Close tab",
   "workingPanel.tabs.closeLeft": "Close tabs to the left",
   "workingPanel.tabs.closeOthers": "Close other tabs",
+  "workingPanel.tabs.closePanel": "Close panel",
   "workingPanel.tabs.closeRight": "Close tabs to the right",
   "workingPanel.tabs.pin": "Pin tab",
   "workingPanel.tabs.pinned": "Pinned tab",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -2128,6 +2128,7 @@
   "workingPanel.tabs.close": "关闭标签页",
   "workingPanel.tabs.closeLeft": "关闭左侧标签页",
   "workingPanel.tabs.closeOthers": "关闭其他标签页",
+  "workingPanel.tabs.closePanel": "关闭面板",
   "workingPanel.tabs.closeRight": "关闭右侧标签页",
   "workingPanel.tabs.pin": "固定标签页",
   "workingPanel.tabs.pinned": "已固定标签页",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -2297,6 +2297,7 @@ export default {
   'workingPanel.tabs.close': 'Close tab',
   'workingPanel.tabs.closeLeft': 'Close tabs to the left',
   'workingPanel.tabs.closeOthers': 'Close other tabs',
+  'workingPanel.tabs.closePanel': 'Close panel',
   'workingPanel.tabs.closeRight': 'Close tabs to the right',
   'workingPanel.tabs.pin': 'Pin tab',
   'workingPanel.tabs.pinned': 'Pinned tab',

--- a/src/features/Conversation/WorkingSidebar/WorkspaceTab.tsx
+++ b/src/features/Conversation/WorkingSidebar/WorkspaceTab.tsx
@@ -115,7 +115,6 @@ interface WorkspaceTabProps {
   active: boolean;
   closeLabel?: string;
   contextMenuItems?: ContextMenuItem[];
-  fixed?: boolean;
   icon: IconProps['icon'];
   iconNode?: ReactNode;
   label: ReactNode;
@@ -131,7 +130,6 @@ const WorkspaceTab = memo<WorkspaceTabProps>(
     active,
     closeLabel,
     contextMenuItems,
-    fixed,
     icon,
     iconNode,
     label,
@@ -148,7 +146,7 @@ const WorkspaceTab = memo<WorkspaceTabProps>(
       >
         <button
           aria-pressed={active}
-          className={`${styles.tab} ${!fixed && (onClose || pinned) ? styles.tabClosable : ''}`}
+          className={`${styles.tab} ${onClose || pinned ? styles.tabClosable : ''}`}
           data-tab-key={tabKey}
           type="button"
           onClick={onSelect}
@@ -158,11 +156,11 @@ const WorkspaceTab = memo<WorkspaceTabProps>(
             <span className={styles.label}>{label}</span>
           </span>
         </button>
-        {!fixed && pinned ? (
+        {pinned ? (
           <span aria-label={pinnedLabel} className={styles.pinned} role="img">
             <Icon icon={PinIcon} size={12} />
           </span>
-        ) : !fixed && onClose ? (
+        ) : onClose ? (
           <button
             data-tab-close
             aria-label={closeLabel}

--- a/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
+++ b/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
@@ -969,6 +969,48 @@ describe('AgentWorkingSidebar — tab strip', () => {
     expect(globalStore.setWorkingSidebarTab).toHaveBeenCalledWith('overview');
   });
 
+  it('collapses the panel when the last remaining tab is closed', () => {
+    agentStore.activeAgentId = 'agent';
+    reviewState.repoType = 'git';
+    reviewState.workingDirectory = '/repo';
+    localStorageState.openTabsByContext = { 'draft:agent:/repo': ['review'] };
+    globalStore.status.workingSidebarTab = 'review';
+
+    render(<AgentWorkingSidebar />);
+    expect(
+      screen.queryByRole('button', { name: 'workingPanel.tabs.closePanel' }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'workingPanel.tabs.close' }));
+    fireEvent.click(screen.getByRole('button', { name: 'workingPanel.tabs.closePanel' }));
+
+    expect(globalStore.toggleRightPanel).toHaveBeenCalledWith(false);
+  });
+
+  it('keeps the last tab closable from its context menu', () => {
+    localStorageState.openTabsByContext = {};
+    globalStore.status.workingSidebarTab = 'overview';
+
+    render(<AgentWorkingSidebar />);
+    fireEvent.contextMenu(screen.getByRole('button', { name: 'workingPanel.overview.title' }));
+    fireEvent.click(screen.getByText('workingPanel.tabs.closePanel'));
+
+    expect(globalStore.toggleRightPanel).toHaveBeenCalledWith(false);
+  });
+
+  it('leaves a pinned tab standing instead of collapsing the panel', () => {
+    agentStore.activeAgentId = 'agent';
+    localStorageState.openTabsByContext = {};
+    localStorageState.pinnedTabsByAgent = { agent: ['works'] };
+    globalStore.status.workingSidebarTab = 'overview';
+
+    render(<AgentWorkingSidebar />);
+
+    expect(
+      screen.queryByRole('button', { name: 'workingPanel.tabs.closePanel' }),
+    ).not.toBeInTheDocument();
+  });
+
   it('reopens a closed tab when the same external target is requested again', async () => {
     agentStore.activeAgentId = 'agent';
     reviewState.repoType = undefined;

--- a/src/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/index.tsx
@@ -570,6 +570,9 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
       };
     })
     .filter((tab): tab is SidebarTabDescriptor => Boolean(tab));
+  // Overview is the only tab that always exists, so once it stands alone the
+  // strip has nothing left to close — closing it collapses the whole panel.
+  const isOverviewOnlyTab = displayedTabs.length === 0;
   const createTabContextMenuItems = useCallback(
     (tab: string, index: number): NativeContextMenuItem[] => {
       const pinned = pinnedTabsSet.has(tab);
@@ -623,6 +626,17 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
   );
   const overviewContextMenuItems = useMemo<NativeContextMenuItem[]>(
     () => [
+      ...(isOverviewOnlyTab
+        ? [
+            {
+              icon: XIcon,
+              key: 'closePanel',
+              label: t('workingPanel.tabs.closePanel'),
+              onClick: () => toggleRightPanel(false),
+            } as NativeContextMenuItem,
+            { type: 'divider' as const },
+          ]
+        : []),
       {
         disabled: !openedTabs.some((tab) => !pinnedTabsSet.has(tab)),
         key: 'closeOthers',
@@ -630,7 +644,7 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
         onClick: () => closeTabs(openedTabs),
       },
     ],
-    [closeTabs, openedTabs, pinnedTabsSet, t],
+    [closeTabs, isOverviewOnlyTab, openedTabs, pinnedTabsSet, t, toggleRightPanel],
   );
   const tabsRef = useRef<HTMLDivElement>(null);
   const pendingTabFocusRef = useRef<string | undefined>(undefined);
@@ -845,12 +859,13 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
           <div className={styles.tabsArea}>
             <div className={styles.tabs} ref={tabsRef}>
               <WorkspaceTab
-                fixed
                 active={activeTab === 'overview'}
+                closeLabel={t('workingPanel.tabs.closePanel')}
                 contextMenuItems={overviewContextMenuItems}
                 icon={LayoutDashboardIcon}
                 label={t('workingPanel.overview.title')}
                 tabKey={'overview'}
+                onClose={isOverviewOnlyTab ? () => toggleRightPanel(false) : undefined}
                 onSelect={() => openTab('overview')}
               />
               {displayedTabs.map((tab, index) => (


### PR DESCRIPTION
Overview is the only always-present tab in the working sidebar, so once every other tab is closed the strip has nothing left to close — the panel could only be dismissed from the header icon.

Overview now shows the same close affordance as any other tab **when it stands alone**, and using it collapses the working sidebar. While other tabs (including pinned ones) are open it stays uncloseable, so the fixed tab can't be dismissed by accident. The same action is available from its context menu as "Close panel".

| Before | After |
| ------ | ----- |
| Last remaining tab (Overview) has no close button; the panel can only be closed from the header icon | Hovering the sole Overview tab reveals ×; clicking it closes the working sidebar |

Implementation note: `WorkspaceTab` lost its `fixed` prop — it existed only to suppress the close/pin affordances on Overview, which is now driven by whether `onClose` / `pinned` are passed.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check` on the touched files: lint clean, 39 tests passed. New regression tests cover: closing the last remaining tab collapses the panel, the same action from the Overview context menu, and a pinned tab keeping the panel uncloseable.

#### 🔗 Related Issue

None