### PR TITLE
✨ feat(devdock): add GPU process readout and GPU status panel

### DIFF
--- a/apps/desktop/src/main/controllers/DevtoolsCtr.ts
+++ b/apps/desktop/src/main/controllers/DevtoolsCtr.ts
@@ -1,6 +1,16 @@
+import type { AppProcessMetrics, GpuStatus } from '@lobechat/electron-client-ipc';
 import { app } from 'electron';
 
 import { ControllerModule, IpcMethod } from './index';
+
+interface CompleteGpuInfo {
+  auxAttributes?: Record<string, unknown>;
+  machineModelName?: string;
+  machineModelVersion?: string;
+}
+
+const readText = (value: unknown): string | null =>
+  typeof value === 'string' && value.length > 0 ? value : null;
 
 export default class DevtoolsCtr extends ControllerModule {
   static override readonly groupName = 'devtools';
@@ -11,10 +21,44 @@ export default class DevtoolsCtr extends ControllerModule {
     devtoolsBrowser.show();
   }
 
+  // percentCPUUsage is measured since the previous getAppMetrics call, so all
+  // readings must come from one call — split this per metric and each caller only
+  // sees the sliver since the other one sampled.
   @IpcMethod()
-  async getAppCpuUsage() {
+  async getAppProcessMetrics(): Promise<AppProcessMetrics> {
     const metrics = app.getAppMetrics();
-    const percent = metrics.reduce((sum, metric) => sum + metric.cpu.percentCPUUsage, 0);
-    return { percent };
+    const gpuProcesses = metrics.filter((metric) => metric.type === 'GPU');
+
+    return {
+      cpuPercent: metrics.reduce((sum, metric) => sum + metric.cpu.percentCPUUsage, 0),
+      gpu:
+        gpuProcesses.length === 0
+          ? null
+          : {
+              cpuPercent: gpuProcesses.reduce((sum, metric) => sum + metric.cpu.percentCPUUsage, 0),
+              memoryMB:
+                gpuProcesses.reduce((sum, metric) => sum + metric.memory.workingSetSize, 0) / 1024,
+            },
+    };
+  }
+
+  @IpcMethod()
+  async getGpuStatus(): Promise<GpuStatus> {
+    const info = (await app.getGPUInfo('complete')) as CompleteGpuInfo;
+    const aux = info?.auxAttributes ?? {};
+
+    return {
+      displayType: readText(aux.displayType),
+      // Electron's GPUFeatureStatus type is stale — it still declares the removed
+      // flash_* keys and misses webgpu / skia_graphite, so trust the runtime record.
+      featureStatus: app.getGPUFeatureStatus() as unknown as Record<string, string>,
+      machineModel: readText(
+        [info?.machineModelName, info?.machineModelVersion].filter(Boolean).join(' '),
+      ),
+      renderer: readText(aux.glRenderer),
+      skiaBackend: readText(aux.skiaBackendType),
+      vendor: readText(aux.glVendor),
+      version: readText(aux.glVersion),
+    };
   }
 }

--- a/apps/desktop/src/main/controllers/__tests__/DevtoolsCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/DevtoolsCtr.test.ts
@@ -4,14 +4,19 @@ import type { App } from '@/core/App';
 
 import DevtoolsCtr from '../DevtoolsCtr';
 
-const { getAppMetricsMock, ipcMainHandleMock } = vi.hoisted(() => ({
-  getAppMetricsMock: vi.fn(),
-  ipcMainHandleMock: vi.fn(),
-}));
+const { getAppMetricsMock, getGPUFeatureStatusMock, getGPUInfoMock, ipcMainHandleMock } =
+  vi.hoisted(() => ({
+    getAppMetricsMock: vi.fn(),
+    getGPUFeatureStatusMock: vi.fn(),
+    getGPUInfoMock: vi.fn(),
+    ipcMainHandleMock: vi.fn(),
+  }));
 
 vi.mock('electron', () => ({
   app: {
     getAppMetrics: getAppMetricsMock,
+    getGPUFeatureStatus: getGPUFeatureStatusMock,
+    getGPUInfo: getGPUInfoMock,
   },
   ipcMain: {
     handle: ipcMainHandleMock,
@@ -55,21 +60,97 @@ describe('DevtoolsCtr', () => {
     });
   });
 
-  describe('getAppCpuUsage', () => {
+  describe('getAppProcessMetrics', () => {
     it('should sum percentCPUUsage across all app processes', async () => {
       getAppMetricsMock.mockReturnValue([
-        { cpu: { percentCPUUsage: 1.5 } },
-        { cpu: { percentCPUUsage: 2.25 } },
-        { cpu: { percentCPUUsage: 0 } },
+        { cpu: { percentCPUUsage: 1.5 }, memory: { workingSetSize: 100 }, type: 'Browser' },
+        { cpu: { percentCPUUsage: 2.25 }, memory: { workingSetSize: 200 }, type: 'Tab' },
+        { cpu: { percentCPUUsage: 0 }, memory: { workingSetSize: 300 }, type: 'Utility' },
       ]);
 
-      await expect(devtoolsCtr.getAppCpuUsage()).resolves.toEqual({ percent: 3.75 });
+      await expect(devtoolsCtr.getAppProcessMetrics()).resolves.toEqual({
+        cpuPercent: 3.75,
+        gpu: null,
+      });
+    });
+
+    it('should report the gpu process usage separately in megabytes', async () => {
+      getAppMetricsMock.mockReturnValue([
+        { cpu: { percentCPUUsage: 1.5 }, memory: { workingSetSize: 1024 }, type: 'Browser' },
+        { cpu: { percentCPUUsage: 2.5 }, memory: { workingSetSize: 65_536 }, type: 'GPU' },
+      ]);
+
+      await expect(devtoolsCtr.getAppProcessMetrics()).resolves.toEqual({
+        cpuPercent: 4,
+        gpu: { cpuPercent: 2.5, memoryMB: 64 },
+      });
+    });
+
+    it('should aggregate multiple gpu processes', async () => {
+      getAppMetricsMock.mockReturnValue([
+        { cpu: { percentCPUUsage: 1 }, memory: { workingSetSize: 1024 }, type: 'GPU' },
+        { cpu: { percentCPUUsage: 3 }, memory: { workingSetSize: 3072 }, type: 'GPU' },
+      ]);
+
+      await expect(devtoolsCtr.getAppProcessMetrics()).resolves.toEqual({
+        cpuPercent: 4,
+        gpu: { cpuPercent: 4, memoryMB: 4 },
+      });
     });
 
     it('should return zero when there are no process metrics', async () => {
       getAppMetricsMock.mockReturnValue([]);
 
-      await expect(devtoolsCtr.getAppCpuUsage()).resolves.toEqual({ percent: 0 });
+      await expect(devtoolsCtr.getAppProcessMetrics()).resolves.toEqual({
+        cpuPercent: 0,
+        gpu: null,
+      });
+    });
+  });
+
+  describe('getGpuStatus', () => {
+    it('should expose the raw feature status record and the gl device attributes', async () => {
+      getGPUFeatureStatusMock.mockReturnValue({
+        gpu_compositing: 'enabled_on',
+        webgpu: 'disabled_off',
+      });
+      getGPUInfoMock.mockResolvedValue({
+        auxAttributes: {
+          displayType: 'ANGLE_METAL',
+          glRenderer: 'ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Max)',
+          glVendor: 'Google Inc. (Apple)',
+          glVersion: 'OpenGL ES 3.0 (ANGLE 2.1)',
+          skiaBackendType: 'GraphiteDawnMetal',
+        },
+        machineModelName: 'Mac',
+        machineModelVersion: '16.9',
+      });
+
+      await expect(devtoolsCtr.getGpuStatus()).resolves.toEqual({
+        displayType: 'ANGLE_METAL',
+        featureStatus: { gpu_compositing: 'enabled_on', webgpu: 'disabled_off' },
+        machineModel: 'Mac 16.9',
+        renderer: 'ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Max)',
+        skiaBackend: 'GraphiteDawnMetal',
+        vendor: 'Google Inc. (Apple)',
+        version: 'OpenGL ES 3.0 (ANGLE 2.1)',
+      });
+      expect(getGPUInfoMock).toHaveBeenCalledWith('complete');
+    });
+
+    it('should null out attributes missing from the platform payload', async () => {
+      getGPUFeatureStatusMock.mockReturnValue({});
+      getGPUInfoMock.mockResolvedValue({});
+
+      await expect(devtoolsCtr.getGpuStatus()).resolves.toEqual({
+        displayType: null,
+        featureStatus: {},
+        machineModel: null,
+        renderer: null,
+        skiaBackend: null,
+        vendor: null,
+        version: null,
+      });
     });
   });
 });

--- a/packages/electron-client-ipc/src/types/devtools.ts
+++ b/packages/electron-client-ipc/src/types/devtools.ts
@@ -1,0 +1,19 @@
+export interface GpuProcessMetrics {
+  cpuPercent: number;
+  memoryMB: number;
+}
+
+export interface AppProcessMetrics {
+  cpuPercent: number;
+  gpu: GpuProcessMetrics | null;
+}
+
+export interface GpuStatus {
+  displayType: string | null;
+  featureStatus: Record<string, string>;
+  machineModel: string | null;
+  renderer: string | null;
+  skiaBackend: string | null;
+  vendor: string | null;
+  version: string | null;
+}

--- a/packages/electron-client-ipc/src/types/index.ts
+++ b/packages/electron-client-ipc/src/types/index.ts
@@ -4,6 +4,7 @@ export * from './browserControl';
 export * from './browserSidebar';
 export * from './contextMenu';
 export * from './dataSync';
+export * from './devtools';
 export * from './git';
 export * from './heterogeneousAgent';
 export * from './imessageBridge';

--- a/src/features/DevDock/registerBuiltinItems.ts
+++ b/src/features/DevDock/registerBuiltinItems.ts
@@ -5,6 +5,7 @@ import {
   Cpu,
   Flag,
   Gauge,
+  Gpu,
   GraduationCap,
   Languages,
   LayoutGrid,
@@ -156,6 +157,22 @@ export const registerBuiltinDevDockItems = () => {
 
   if (isDesktop) {
     items.push(
+      {
+        defaultPinned: true,
+        icon: Gpu,
+        id: 'gpu-process',
+        label: 'GPU proc',
+        load: () => import('./widgets/GpuProcessWidget'),
+        slot: 'right',
+        type: 'readout',
+      },
+      {
+        icon: Gpu,
+        id: 'gpu-status',
+        label: 'GPU Status',
+        load: () => import('@/features/DevPanel/GpuStatus'),
+        type: 'panel',
+      },
       {
         defaultPinned: true,
         icon: AppWindow,

--- a/src/features/DevDock/widgets/GpuProcessWidget.tsx
+++ b/src/features/DevDock/widgets/GpuProcessWidget.tsx
@@ -20,26 +20,26 @@ const styles = createStaticStyles(({ css }) => ({
   `,
 }));
 
-const CpuUsageWidget = memo(() => {
-  const metrics = useAppProcessMetrics();
+const GpuProcessWidget = memo(() => {
+  const gpu = useAppProcessMetrics()?.gpu;
 
-  if (!metrics) return null;
-
-  const percent = metrics.cpuPercent;
+  if (!gpu) return null;
 
   return (
     <span
-      title={'App CPU usage (sum across processes, 100% = one core)'}
       className={cx(
         styles.text,
-        percent >= 200 ? styles.high : percent >= 100 ? styles.mid : undefined,
+        gpu.cpuPercent >= 100 ? styles.high : gpu.cpuPercent >= 50 ? styles.mid : undefined,
       )}
+      title={
+        'GPU process CPU usage and resident memory — Chromium exposes no GPU utilisation figure'
+      }
     >
-      CPU {percent.toFixed(1)}%
+      GPU proc {gpu.cpuPercent.toFixed(1)}% · {Math.round(gpu.memoryMB)} MB
     </span>
   );
 });
 
-CpuUsageWidget.displayName = 'DevDockCpuUsageWidget';
+GpuProcessWidget.displayName = 'DevDockGpuProcessWidget';
 
-export default CpuUsageWidget;
+export default GpuProcessWidget;

--- a/src/features/DevDock/widgets/appProcessMetrics.test.ts
+++ b/src/features/DevDock/widgets/appProcessMetrics.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAppProcessMetrics } from './appProcessMetrics';
+
+const getAppProcessMetricsMock = vi.fn();
+
+vi.mock('@/services/electron/devtools', () => ({
+  electronDevtoolsService: {
+    getAppProcessMetrics: (...args: unknown[]) => getAppProcessMetricsMock(...args),
+  },
+}));
+
+const SAMPLE = { cpuPercent: 12.5, gpu: { cpuPercent: 2, memoryMB: 64 } };
+
+const advance = async (ms: number) => {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+};
+
+describe('useAppProcessMetrics', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    getAppProcessMetricsMock.mockReset();
+    getAppProcessMetricsMock.mockResolvedValue(SAMPLE);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should drop the priming sample and expose the second one', async () => {
+    const { result, unmount } = renderHook(() => useAppProcessMetrics());
+
+    await advance(0);
+    expect(result.current).toBeNull();
+
+    await advance(2000);
+    expect(result.current).toEqual(SAMPLE);
+
+    unmount();
+  });
+
+  it('should sample once for all readers, since cpu usage is relative to the previous call', async () => {
+    const first = renderHook(() => useAppProcessMetrics());
+    const second = renderHook(() => useAppProcessMetrics());
+
+    await advance(4000);
+
+    expect(getAppProcessMetricsMock).toHaveBeenCalledTimes(3);
+    expect(first.result.current).toEqual(SAMPLE);
+    expect(second.result.current).toEqual(SAMPLE);
+
+    first.unmount();
+    second.unmount();
+  });
+
+  it('should stop sampling once the last reader unmounts', async () => {
+    const { unmount } = renderHook(() => useAppProcessMetrics());
+
+    await advance(2000);
+    unmount();
+    getAppProcessMetricsMock.mockClear();
+
+    await advance(6000);
+    expect(getAppProcessMetricsMock).not.toHaveBeenCalled();
+  });
+
+  it('should keep readers hidden when the ipc bridge is missing', async () => {
+    getAppProcessMetricsMock.mockRejectedValue(new Error('electronAPI.invoke not found'));
+    const { result, unmount } = renderHook(() => useAppProcessMetrics());
+
+    await advance(4000);
+    expect(result.current).toBeNull();
+
+    unmount();
+  });
+});

--- a/src/features/DevDock/widgets/appProcessMetrics.ts
+++ b/src/features/DevDock/widgets/appProcessMetrics.ts
@@ -1,0 +1,52 @@
+import type { AppProcessMetrics } from '@lobechat/electron-client-ipc';
+import { useSyncExternalStore } from 'react';
+
+import { electronDevtoolsService } from '@/services/electron/devtools';
+
+const SAMPLE_INTERVAL = 2000;
+
+const listeners = new Set<() => void>();
+
+let snapshot: AppProcessMetrics | null = null;
+let timer: ReturnType<typeof setInterval> | null = null;
+let primed = false;
+
+const sample = async () => {
+  try {
+    const next = await electronDevtoolsService.getAppProcessMetrics();
+    // Electron reports cpu usage since the previous getAppMetrics call, so the
+    // first sample covers an arbitrary window — prime once and drop it.
+    if (!primed) {
+      primed = true;
+      return;
+    }
+    snapshot = next;
+    for (const listener of listeners) listener();
+  } catch {
+    /* ipc unavailable — widgets stay hidden */
+  }
+};
+
+const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  if (!timer) {
+    primed = false;
+    void sample();
+    timer = setInterval(sample, SAMPLE_INTERVAL);
+  }
+
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size > 0 || !timer) return;
+    clearInterval(timer);
+    timer = null;
+    snapshot = null;
+  };
+};
+
+const getSnapshot = () => snapshot;
+
+// Every reader shares this one sampler: cpu usage is relative to the previous
+// getAppMetrics call, so a second independent poller would corrupt both readings.
+export const useAppProcessMetrics = (): AppProcessMetrics | null =>
+  useSyncExternalStore(subscribe, getSnapshot, getSnapshot);

--- a/src/features/DevPanel/GpuStatus/index.tsx
+++ b/src/features/DevPanel/GpuStatus/index.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import type { GpuStatus } from '@lobechat/electron-client-ipc';
+import { Flexbox } from '@lobehub/ui';
+import { createStaticStyles, cssVar, cx } from 'antd-style';
+import { Fragment, memo, useEffect, useState } from 'react';
+
+import { electronDevtoolsService } from '@/services/electron/devtools';
+
+const styles = createStaticStyles(({ css }) => ({
+  device: css`
+    display: grid;
+    grid-template-columns: 96px 1fr;
+    gap: 4px 8px;
+
+    padding-block: 10px;
+    padding-inline: 12px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 11px;
+    color: ${cssVar.colorTextSecondary};
+  `,
+  empty: css`
+    padding: 24px;
+    font-size: 12px;
+    color: ${cssVar.colorTextTertiary};
+    text-align: center;
+  `,
+  error: css`
+    color: ${cssVar.colorError};
+  `,
+  key: css`
+    color: ${cssVar.colorTextQuaternary};
+  `,
+  legend: css`
+    padding-block: 8px 12px;
+    padding-inline: 12px;
+
+    font-size: 10px;
+    line-height: 1.6;
+    color: ${cssVar.colorTextQuaternary};
+  `,
+  muted: css`
+    color: ${cssVar.colorTextTertiary};
+  `,
+  ok: css`
+    color: ${cssVar.colorSuccess};
+  `,
+  row: css`
+    display: grid;
+    grid-template-columns: 1fr 200px;
+    gap: 8px;
+    align-items: center;
+
+    padding-block: 5px;
+    padding-inline: 12px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 11px;
+  `,
+  value: css`
+    overflow-wrap: anywhere;
+  `,
+  warn: css`
+    color: ${cssVar.colorWarning};
+  `,
+}));
+
+const statusClass = (status: string): string => {
+  if (status.startsWith('enabled')) return styles.ok;
+  if (status.includes('software')) return styles.warn;
+  if (status.endsWith('_ok')) return styles.muted;
+  return styles.error;
+};
+
+const DEVICE_LABELS: [label: string, key: keyof Omit<GpuStatus, 'featureStatus'>][] = [
+  ['renderer', 'renderer'],
+  ['vendor', 'vendor'],
+  ['gl version', 'version'],
+  ['display', 'displayType'],
+  ['skia', 'skiaBackend'],
+  ['machine', 'machineModel'],
+];
+
+const GpuStatusPanel = memo(() => {
+  const [status, setStatus] = useState<GpuStatus | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let disposed = false;
+    electronDevtoolsService
+      .getGpuStatus()
+      .then((next) => {
+        if (!disposed) setStatus(next);
+      })
+      .catch(() => {
+        if (!disposed) setFailed(true);
+      });
+    return () => {
+      disposed = true;
+    };
+  }, []);
+
+  if (failed) return <div className={styles.empty}>GPU status unavailable over ipc.</div>;
+  if (!status) return null;
+
+  const features = Object.entries(status.featureStatus).sort(([a], [b]) => a.localeCompare(b));
+
+  return (
+    <Flexbox height={'100%'}>
+      <div className={styles.device}>
+        {DEVICE_LABELS.map(([label, key]) => (
+          <Fragment key={key}>
+            <span className={styles.key}>{label}</span>
+            <span className={cx(styles.value, !status[key] && styles.muted)}>
+              {status[key] ?? '—'}
+            </span>
+          </Fragment>
+        ))}
+      </div>
+      {features.map(([feature, value]) => (
+        <div className={styles.row} key={feature}>
+          <span className={styles.muted}>{feature}</span>
+          <span className={statusClass(value)}>{value}</span>
+        </div>
+      ))}
+      <div className={styles.legend}>
+        `enabled_*` runs on the GPU, `*_software` fell back to the CPU renderer, `*_off_ok` is
+        switched off by design, and anything else is a hard disable worth investigating on
+        chrome://gpu. Read once when the panel opens — reopen it to re-sample.
+      </div>
+    </Flexbox>
+  );
+});
+
+GpuStatusPanel.displayName = 'DevGpuStatusPanel';
+
+export default GpuStatusPanel;

--- a/src/services/electron/__tests__/devtools.test.ts
+++ b/src/services/electron/__tests__/devtools.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { electronDevtoolsService } from '../devtools';
 
-const getAppCpuUsageMock = vi.fn();
+const getAppProcessMetricsMock = vi.fn();
+const getGpuStatusMock = vi.fn();
 const openDevtoolsMock = vi.fn();
 vi.mock('@/utils/electron/ipc', () => ({
   ensureElectronIpc: vi.fn(() => ({
-    devtools: { getAppCpuUsage: getAppCpuUsageMock, openDevtools: openDevtoolsMock },
+    devtools: {
+      getAppProcessMetrics: getAppProcessMetricsMock,
+      getGpuStatus: getGpuStatusMock,
+      openDevtools: openDevtoolsMock,
+    },
   })),
 }));
 const { ensureElectronIpc } = await import('@/utils/electron/ipc');
@@ -37,12 +42,23 @@ describe('DevtoolsService', () => {
     });
   });
 
-  describe('getAppCpuUsage', () => {
-    it('should return the cpu usage reported over ipc', async () => {
-      getAppCpuUsageMock.mockResolvedValueOnce({ percent: 12.5 });
+  describe('getAppProcessMetrics', () => {
+    it('should return the process metrics reported over ipc', async () => {
+      const metrics = { cpuPercent: 12.5, gpu: { cpuPercent: 2, memoryMB: 64 } };
+      getAppProcessMetricsMock.mockResolvedValueOnce(metrics);
 
-      await expect(electronDevtoolsService.getAppCpuUsage()).resolves.toEqual({ percent: 12.5 });
-      expect(getAppCpuUsageMock).toHaveBeenCalled();
+      await expect(electronDevtoolsService.getAppProcessMetrics()).resolves.toEqual(metrics);
+      expect(getAppProcessMetricsMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('getGpuStatus', () => {
+    it('should return the gpu status reported over ipc', async () => {
+      const status = { featureStatus: { webgl: 'enabled_on' }, renderer: 'ANGLE' };
+      getGpuStatusMock.mockResolvedValueOnce(status);
+
+      await expect(electronDevtoolsService.getGpuStatus()).resolves.toEqual(status);
+      expect(getGpuStatusMock).toHaveBeenCalled();
     });
   });
 });

--- a/src/services/electron/devtools.ts
+++ b/src/services/electron/devtools.ts
@@ -1,3 +1,5 @@
+import type { AppProcessMetrics, GpuStatus } from '@lobechat/electron-client-ipc';
+
 import { ensureElectronIpc } from '@/utils/electron/ipc';
 
 class DevtoolsService {
@@ -5,8 +7,12 @@ class DevtoolsService {
     return ensureElectronIpc().devtools.openDevtools();
   }
 
-  async getAppCpuUsage(): Promise<{ percent: number }> {
-    return ensureElectronIpc().devtools.getAppCpuUsage();
+  async getAppProcessMetrics(): Promise<AppProcessMetrics> {
+    return ensureElectronIpc().devtools.getAppProcessMetrics();
+  }
+
+  async getGpuStatus(): Promise<GpuStatus> {
+    return ensureElectronIpc().devtools.getGpuStatus();
   }
 }
 


### PR DESCRIPTION
DevDock could not answer anything about the GPU. Chromium exposes no GPU utilisation figure — not via `getAppMetrics`, not via `getGPUInfo` — so this reports the two things that *are* available and labels them honestly.

**`GPU proc` readout** (bar, Electron only) — the GPU process's CPU share and resident working set, pulled out of `app.getAppMetrics()` by `type === 'GPU'`. Deliberately not called "GPU %": it is the GPU process's CPU cost, not device utilisation.

**`GPU Status` panel** (overflow menu, Electron only) — `app.getGPUFeatureStatus()` colour-coded the way chrome://gpu reads it (`enabled_*` green, `*_software` yellow, `*_off_ok` grey, hard disables red), plus the GL device block from `getGPUInfo('complete')`: renderer, vendor, GL version, ANGLE display type, Skia backend, machine model. This answers the question the dock is usually asked — *did we quietly fall back to software rendering?*

#### Notable change

`devtools.getAppCpuUsage` becomes `devtools.getAppProcessMetrics`, returning app CPU and the GPU process together. This is not cosmetic: `percentCPUUsage` is measured *since the previous `getAppMetrics` call*, so two independent pollers would each see only the sliver since the other sampled and both numbers would be wrong. For the same reason the renderer side gained `appProcessMetrics.ts`, a ref-counted single sampler that `CpuUsageWidget` and `GpuProcessWidget` share.

| Before | After |
| ------ | ----- |
| `CPU 12.4%` · `184 MB · 8.2%` · `60 FPS` | `CPU 12.4%` · `GPU proc 3.1% · 64 MB` · `184 MB · 8.2%` · `60 FPS` |
| no way to see whether compositing/WebGL is hardware-backed | `GPU Status` panel lists every Chromium feature status + GL device |

#### Test

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

The Electron API surface was verified against a real Electron 43 runtime with a throwaway probe app rather than from memory — confirming that `getAppMetrics()` emits a `type: 'GPU'` entry, that `workingSetSize` is in KB, that `getGPUInfo('complete').auxAttributes` carries `glRenderer` / `glVendor` / `glVersion` / `displayType` / `skiaBackendType`, and that the runtime `getGPUFeatureStatus()` record does **not** match Electron's `GPUFeatureStatus` type (it still declares removed `flash_*` keys and misses `webgpu` / `skia_graphite`) — hence the widened `Record<string, string>`.

Unit tests cover GPU-process aggregation and the megabyte conversion, the defensive extraction when a platform omits aux attributes, and the shared sampler: priming drop, one sample shared across readers, teardown on last unmount, and staying hidden when the IPC bridge is absent.

`bun run check` is clean (lint + 16 tests) and `bun run check --type` passes. The dock UI itself has not been exercised in a running desktop build.

#### 🔗 Related Issue

None — DevDock is a dev-only surface.