### PR TITLE
✨ feat(model-runtime): add Replicate video generation with prunaai/p-video

### DIFF
--- a/packages/model-bank/src/aiModels/replicate.ts
+++ b/packages/model-bank/src/aiModels/replicate.ts
@@ -107,6 +107,19 @@ const videoModels: AIVideoModelCard[] = [
       resolution: { default: '720p', enum: ['720p', '1080p'] },
       seed: { default: null },
     },
+    pricing: {
+      units: [
+        {
+          lookup: {
+            pricingParams: ['resolution'],
+            prices: { '1080p': 0.04, '720p': 0.02 },
+          },
+          name: 'videoGeneration',
+          strategy: 'lookup',
+          unit: 'second',
+        },
+      ],
+    },
     releasedAt: '2026-08-06',
     type: 'video',
   },

--- a/packages/model-bank/src/aiModels/replicate.ts
+++ b/packages/model-bank/src/aiModels/replicate.ts
@@ -1,4 +1,4 @@
-import type { AIImageModelCard } from '../types';
+import type { AIImageModelCard, AIVideoModelCard } from '../types';
 
 // Replicate image models
 // https://replicate.com/black-forest-labs
@@ -86,6 +86,32 @@ const imageModels: AIImageModelCard[] = [
   },
 ];
 
-export const allModels = [...imageModels];
+// Replicate video models
+// https://replicate.com/prunaai/p-video
+const videoModels: AIVideoModelCard[] = [
+  {
+    description:
+      'Fast video generation with text-to-video and image-to-video in a single endpoint, tuned for rapid creative iteration.',
+    displayName: 'P-Video',
+    enabled: true,
+    id: 'prunaai/p-video',
+    parameters: {
+      aspectRatio: {
+        default: '16:9',
+        enum: ['16:9', '9:16', '4:3', '3:4', '3:2', '2:3', '1:1'],
+      },
+      duration: { default: 5, max: 20, min: 1, step: 1 },
+      endImageUrl: { default: null },
+      imageUrl: { default: null },
+      prompt: { default: '' },
+      resolution: { default: '720p', enum: ['720p', '1080p'] },
+      seed: { default: null },
+    },
+    releasedAt: '2026-08-06',
+    type: 'video',
+  },
+];
+
+export const allModels = [...imageModels, ...videoModels];
 
 export default allModels;

--- a/packages/model-runtime/src/providers/replicate/createVideo.test.ts
+++ b/packages/model-runtime/src/providers/replicate/createVideo.test.ts
@@ -208,6 +208,15 @@ describe('pollReplicateVideoStatus', () => {
     });
   });
 
+  it('reports an aborted prediction as a failure rather than burning the polling budget', async () => {
+    const get = vi.fn().mockResolvedValue({ status: 'aborted' });
+
+    await expect(pollReplicateVideoStatus(buildClient({ get }), 'pred-1')).resolves.toEqual({
+      error: 'Video generation was aborted before it started',
+      status: 'failed',
+    });
+  });
+
   it('reports cancellation as a failure', async () => {
     const get = vi.fn().mockResolvedValue({ status: 'canceled' });
 

--- a/packages/model-runtime/src/providers/replicate/createVideo.test.ts
+++ b/packages/model-runtime/src/providers/replicate/createVideo.test.ts
@@ -2,7 +2,12 @@ import type Replicate from 'replicate';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { CreateVideoPayload } from '../../types';
-import { createReplicateVideo, extractVideoUrl, pollReplicateVideoStatus } from './createVideo';
+import {
+  buildVideoInput,
+  createReplicateVideo,
+  extractVideoUrl,
+  pollReplicateVideoStatus,
+} from './createVideo';
 
 const buildClient = (overrides: {
   create?: ReturnType<typeof vi.fn>;
@@ -47,6 +52,81 @@ describe('extractVideoUrl', () => {
   });
 });
 
+describe('buildVideoInput', () => {
+  const P_VIDEO = 'prunaai/p-video';
+
+  it('maps standard params onto the model input names', () => {
+    expect(
+      buildVideoInput(P_VIDEO, {
+        aspectRatio: '9:16',
+        duration: 10,
+        prompt: 'a cat surfing',
+        resolution: '1080p',
+        seed: 7,
+      }),
+    ).toEqual({
+      aspect_ratio: '9:16',
+      disable_safety_filter: false,
+      duration: 10,
+      prompt: 'a cat surfing',
+      resolution: '1080p',
+      seed: 7,
+    });
+  });
+
+  it('maps image inputs and drops the aspect ratio the model derives from the image', () => {
+    const input = buildVideoInput(P_VIDEO, {
+      aspectRatio: '16:9',
+      endImageUrl: 'https://end.png',
+      imageUrl: 'https://start.png',
+      prompt: 'a cat surfing',
+    });
+
+    expect(input.image).toBe('https://start.png');
+    expect(input.last_frame_image).toBe('https://end.png');
+    expect(input).not.toHaveProperty('aspect_ratio');
+  });
+
+  it('keeps the safety filter enabled even though Replicate defaults it off', () => {
+    expect(buildVideoInput(P_VIDEO, { prompt: 'x' }).disable_safety_filter).toBe(false);
+  });
+
+  it('omits empty optional params rather than sending nulls', () => {
+    expect(
+      buildVideoInput(P_VIDEO, {
+        imageUrl: null,
+        prompt: 'a cat surfing',
+        resolution: undefined,
+        seed: null,
+      }),
+    ).toEqual({ disable_safety_filter: false, prompt: 'a cat surfing' });
+  });
+
+  it('sends seed 0, which is a valid seed rather than an empty value', () => {
+    expect(buildVideoInput(P_VIDEO, { prompt: 'x', seed: 0 }).seed).toBe(0);
+  });
+
+  it('drops params the model does not declare instead of leaking them as inputs', () => {
+    // p-video has no standard-parameter equivalent for its `save_audio` input
+    const input = buildVideoInput(P_VIDEO, { generateAudio: false, prompt: 'x' });
+
+    expect(input).not.toHaveProperty('generateAudio');
+    expect(input).not.toHaveProperty('save_audio');
+  });
+
+  it('resolves the model contract even when the id pins a version', () => {
+    expect(
+      buildVideoInput(`${P_VIDEO}:abc123`, { endImageUrl: 'https://end.png', prompt: 'x' }),
+    ).toHaveProperty('last_frame_image', 'https://end.png');
+  });
+
+  it('falls back to conventional Replicate input names for an unknown model', () => {
+    expect(
+      buildVideoInput('someone/unknown-video', { aspectRatio: '1:1', prompt: 'x', seed: 3 }),
+    ).toEqual({ aspect_ratio: '1:1', prompt: 'x', seed: 3 });
+  });
+});
+
 describe('createReplicateVideo', () => {
   it('submits a prediction and returns its id without waiting for the result', async () => {
     const create = vi.fn().mockResolvedValue({ id: 'pred-1', status: 'starting' });
@@ -68,69 +148,26 @@ describe('createReplicateVideo', () => {
     expect(create.mock.calls[0][0].input.disable_safety_filter).toBe(false);
   });
 
-  it('maps standard params onto Replicate input names', async () => {
+  it('targets the official-model endpoint for a bare model id', async () => {
     const create = vi.fn().mockResolvedValue({ id: 'pred-1' });
 
-    await createReplicateVideo(
-      buildClient({ create }),
-      payload({
-        aspectRatio: '9:16',
-        duration: 10,
-        generateAudio: false,
-        resolution: '1080p',
-        seed: 7,
-      }),
-    );
+    await createReplicateVideo(buildClient({ create }), payload());
 
-    expect(create.mock.calls[0][0].input).toEqual({
-      aspect_ratio: '9:16',
-      disable_safety_filter: false,
-      duration: 10,
-      prompt: 'a cat surfing',
-      resolution: '1080p',
-      save_audio: false,
-      seed: 7,
+    expect(create.mock.calls[0][0]).toMatchObject({ model: 'prunaai/p-video' });
+    expect(create.mock.calls[0][0]).not.toHaveProperty('version');
+  });
+
+  it('targets the versioned endpoint when the model id pins a version', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'pred-1' });
+
+    await createReplicateVideo(buildClient({ create }), {
+      model: 'prunaai/p-video:abc123',
+      params: { prompt: 'a cat surfing' },
     });
-  });
 
-  it('maps image inputs and drops aspect ratio for image-to-video', async () => {
-    const create = vi.fn().mockResolvedValue({ id: 'pred-1' });
-
-    await createReplicateVideo(
-      buildClient({ create }),
-      payload({
-        aspectRatio: '16:9',
-        endImageUrl: 'https://end.png',
-        imageUrl: 'https://start.png',
-      }),
-    );
-
-    const { input } = create.mock.calls[0][0];
-    expect(input.image).toBe('https://start.png');
-    expect(input.last_frame_image).toBe('https://end.png');
-    expect(input).not.toHaveProperty('aspect_ratio');
-  });
-
-  it('omits empty optional params rather than sending nulls', async () => {
-    const create = vi.fn().mockResolvedValue({ id: 'pred-1' });
-
-    await createReplicateVideo(
-      buildClient({ create }),
-      payload({ imageUrl: null, resolution: undefined, seed: null }),
-    );
-
-    expect(create.mock.calls[0][0].input).toEqual({
-      disable_safety_filter: false,
-      prompt: 'a cat surfing',
-    });
-  });
-
-  it('sends seed 0, which is a valid seed rather than an empty value', async () => {
-    const create = vi.fn().mockResolvedValue({ id: 'pred-1' });
-
-    await createReplicateVideo(buildClient({ create }), payload({ seed: 0 }));
-
-    expect(create.mock.calls[0][0].input.seed).toBe(0);
+    // `POST /models/{owner}/{name}/predictions` cannot carry a `:version` suffix
+    expect(create.mock.calls[0][0]).toMatchObject({ version: 'prunaai/p-video:abc123' });
+    expect(create.mock.calls[0][0]).not.toHaveProperty('model');
   });
 
   it('throws when Replicate returns no prediction id', async () => {

--- a/packages/model-runtime/src/providers/replicate/createVideo.test.ts
+++ b/packages/model-runtime/src/providers/replicate/createVideo.test.ts
@@ -1,0 +1,190 @@
+import type Replicate from 'replicate';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { CreateVideoPayload } from '../../types';
+import { createReplicateVideo, extractVideoUrl, pollReplicateVideoStatus } from './createVideo';
+
+const buildClient = (overrides: {
+  create?: ReturnType<typeof vi.fn>;
+  get?: ReturnType<typeof vi.fn>;
+}) =>
+  ({
+    predictions: {
+      create: overrides.create ?? vi.fn(),
+      get: overrides.get ?? vi.fn(),
+    },
+  }) as unknown as Replicate;
+
+const payload = (params: Partial<CreateVideoPayload['params']> = {}): CreateVideoPayload => ({
+  model: 'prunaai/p-video',
+  params: { prompt: 'a cat surfing', ...params },
+});
+
+describe('extractVideoUrl', () => {
+  it('reads a bare URL string', () => {
+    expect(extractVideoUrl('https://replicate.dev/out.mp4')).toBe('https://replicate.dev/out.mp4');
+  });
+
+  it('reads the first URL of an array', () => {
+    expect(extractVideoUrl(['https://a.mp4', 'https://b.mp4'])).toBe('https://a.mp4');
+  });
+
+  it('reads a composite object keyed by media type', () => {
+    expect(extractVideoUrl({ audio: 'https://a.mp3', video: 'https://v.mp4' })).toBe(
+      'https://v.mp4',
+    );
+  });
+
+  it('reads a nested { url } object', () => {
+    expect(extractVideoUrl({ video: { url: 'https://v.mp4' } })).toBe('https://v.mp4');
+  });
+
+  it('returns undefined for empty or unusable output', () => {
+    expect(extractVideoUrl('')).toBeUndefined();
+    expect(extractVideoUrl([])).toBeUndefined();
+    expect(extractVideoUrl(null)).toBeUndefined();
+    expect(extractVideoUrl({ seed: 42 })).toBeUndefined();
+  });
+});
+
+describe('createReplicateVideo', () => {
+  it('submits a prediction and returns its id without waiting for the result', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'pred-1', status: 'starting' });
+
+    const result = await createReplicateVideo(buildClient({ create }), payload());
+
+    expect(result).toEqual({ inferenceId: 'pred-1' });
+    expect(create).toHaveBeenCalledWith({
+      input: { disable_safety_filter: false, prompt: 'a cat surfing' },
+      model: 'prunaai/p-video',
+    });
+  });
+
+  it('keeps the safety filter enabled even though Replicate defaults it off', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'pred-1' });
+
+    await createReplicateVideo(buildClient({ create }), payload());
+
+    expect(create.mock.calls[0][0].input.disable_safety_filter).toBe(false);
+  });
+
+  it('maps standard params onto Replicate input names', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'pred-1' });
+
+    await createReplicateVideo(
+      buildClient({ create }),
+      payload({
+        aspectRatio: '9:16',
+        duration: 10,
+        generateAudio: false,
+        resolution: '1080p',
+        seed: 7,
+      }),
+    );
+
+    expect(create.mock.calls[0][0].input).toEqual({
+      aspect_ratio: '9:16',
+      disable_safety_filter: false,
+      duration: 10,
+      prompt: 'a cat surfing',
+      resolution: '1080p',
+      save_audio: false,
+      seed: 7,
+    });
+  });
+
+  it('maps image inputs and drops aspect ratio for image-to-video', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'pred-1' });
+
+    await createReplicateVideo(
+      buildClient({ create }),
+      payload({
+        aspectRatio: '16:9',
+        endImageUrl: 'https://end.png',
+        imageUrl: 'https://start.png',
+      }),
+    );
+
+    const { input } = create.mock.calls[0][0];
+    expect(input.image).toBe('https://start.png');
+    expect(input.last_frame_image).toBe('https://end.png');
+    expect(input).not.toHaveProperty('aspect_ratio');
+  });
+
+  it('omits empty optional params rather than sending nulls', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'pred-1' });
+
+    await createReplicateVideo(
+      buildClient({ create }),
+      payload({ imageUrl: null, resolution: undefined, seed: null }),
+    );
+
+    expect(create.mock.calls[0][0].input).toEqual({
+      disable_safety_filter: false,
+      prompt: 'a cat surfing',
+    });
+  });
+
+  it('sends seed 0, which is a valid seed rather than an empty value', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'pred-1' });
+
+    await createReplicateVideo(buildClient({ create }), payload({ seed: 0 }));
+
+    expect(create.mock.calls[0][0].input.seed).toBe(0);
+  });
+
+  it('throws when Replicate returns no prediction id', async () => {
+    const create = vi.fn().mockResolvedValue({});
+
+    await expect(createReplicateVideo(buildClient({ create }), payload())).rejects.toThrow(
+      'missing prediction id',
+    );
+  });
+});
+
+describe('pollReplicateVideoStatus', () => {
+  it('returns the video URL once the prediction succeeds', async () => {
+    const get = vi.fn().mockResolvedValue({ output: 'https://v.mp4', status: 'succeeded' });
+
+    await expect(pollReplicateVideoStatus(buildClient({ get }), 'pred-1')).resolves.toEqual({
+      status: 'success',
+      videoUrl: 'https://v.mp4',
+    });
+    expect(get).toHaveBeenCalledWith('pred-1');
+  });
+
+  it('fails when a succeeded prediction carries no URL', async () => {
+    const get = vi.fn().mockResolvedValue({ output: null, status: 'succeeded' });
+
+    await expect(pollReplicateVideoStatus(buildClient({ get }), 'pred-1')).resolves.toEqual({
+      error: 'Prediction succeeded but returned no video URL',
+      status: 'failed',
+    });
+  });
+
+  it('surfaces the provider error message on failure', async () => {
+    const get = vi.fn().mockResolvedValue({ error: 'NSFW content detected', status: 'failed' });
+
+    await expect(pollReplicateVideoStatus(buildClient({ get }), 'pred-1')).resolves.toEqual({
+      error: 'NSFW content detected',
+      status: 'failed',
+    });
+  });
+
+  it('reports cancellation as a failure', async () => {
+    const get = vi.fn().mockResolvedValue({ status: 'canceled' });
+
+    await expect(pollReplicateVideoStatus(buildClient({ get }), 'pred-1')).resolves.toEqual({
+      error: 'Video generation was canceled',
+      status: 'failed',
+    });
+  });
+
+  it.each(['starting', 'processing'])('reports %s as pending', async (status) => {
+    const get = vi.fn().mockResolvedValue({ status });
+
+    await expect(pollReplicateVideoStatus(buildClient({ get }), 'pred-1')).resolves.toEqual({
+      status: 'pending',
+    });
+  });
+});

--- a/packages/model-runtime/src/providers/replicate/createVideo.ts
+++ b/packages/model-runtime/src/providers/replicate/createVideo.ts
@@ -166,7 +166,11 @@ export async function pollReplicateVideoStatus(
 
   log('Prediction %s status: %s', inferenceId, prediction?.status);
 
-  switch (prediction?.status) {
+  // `aborted` is missing from the installed SDK's `Status` union but the API
+  // does return it, so widen before matching to keep it reachable.
+  const status: string | undefined = prediction?.status;
+
+  switch (status) {
     case 'succeeded': {
       const videoUrl = extractVideoUrl(prediction.output);
 
@@ -186,6 +190,12 @@ export async function pollReplicateVideoStatus(
 
     case 'canceled': {
       return { error: 'Video generation was canceled', status: 'failed' };
+    }
+
+    // Terminal: the prediction hit its deadline before it ever started running.
+    // Reporting it as pending would burn the caller's full polling budget first.
+    case 'aborted': {
+      return { error: 'Video generation was aborted before it started', status: 'failed' };
     }
 
     default: {

--- a/packages/model-runtime/src/providers/replicate/createVideo.ts
+++ b/packages/model-runtime/src/providers/replicate/createVideo.ts
@@ -1,9 +1,79 @@
 import createDebug from 'debug';
+import type { RuntimeVideoGenParams } from 'model-bank';
 import type Replicate from 'replicate';
 
 import type { CreateVideoPayload, CreateVideoResponse, PollVideoStatusResult } from '../../types';
 
 const log = createDebug('lobe-video:replicate');
+
+type StandardParam = keyof RuntimeVideoGenParams;
+
+interface ReplicateVideoModel {
+  /**
+   * Standard parameter -> Replicate input name. Acts as an allow list: a
+   * parameter with no entry here is not sent, so a card cannot leak an input
+   * name the model does not declare.
+   */
+  aliases: Partial<Record<StandardParam, string>>;
+  /** Inputs always sent, whatever the user selected. */
+  fixedInput?: Record<string, unknown>;
+  /** Parameters the model derives from the input image and ignores alongside it. */
+  ignoredWithImage?: StandardParam[];
+}
+
+/**
+ * Per-model input contracts, transcribed from each model's OpenAPI schema.
+ * Replicate input names are model-specific, so they belong here rather than in
+ * the generic submission path below.
+ */
+const VIDEO_MODELS: Record<string, ReplicateVideoModel> = {
+  'prunaai/p-video': {
+    aliases: {
+      aspectRatio: 'aspect_ratio',
+      duration: 'duration',
+      endImageUrl: 'last_frame_image',
+      imageUrl: 'image',
+      prompt: 'prompt',
+      resolution: 'resolution',
+      seed: 'seed',
+    },
+    // Replicate defaults this to `true`; keep generations filtered.
+    fixedInput: { disable_safety_filter: false },
+    ignoredWithImage: ['aspectRatio'],
+  },
+};
+
+const DEFAULT_MODEL: ReplicateVideoModel = {
+  aliases: {
+    aspectRatio: 'aspect_ratio',
+    duration: 'duration',
+    imageUrl: 'image',
+    prompt: 'prompt',
+    resolution: 'resolution',
+    seed: 'seed',
+  },
+};
+
+const isEmpty = (value: unknown) =>
+  value === null || value === undefined || value === '' || (Array.isArray(value) && !value.length);
+
+export function buildVideoInput(model: string, params: RuntimeVideoGenParams) {
+  // Strip any `:version` suffix so a pinned version still resolves its contract
+  const [modelId] = model.split(':');
+  const config = VIDEO_MODELS[modelId] ?? DEFAULT_MODEL;
+
+  const input: Record<string, unknown> = { ...config.fixedInput };
+
+  for (const [key, value] of Object.entries(params) as [StandardParam, unknown][]) {
+    const alias = config.aliases[key];
+    if (!alias || isEmpty(value)) continue;
+    if (params.imageUrl && config.ignoredWithImage?.includes(key)) continue;
+
+    input[alias] = value;
+  }
+
+  return input;
+}
 
 /**
  * Replicate returns the generated media in a shape that depends on the model:
@@ -36,21 +106,6 @@ export function extractVideoUrl(output: unknown): string | undefined {
 }
 
 /**
- * Replicate types a prediction error as `unknown`: it may be a plain string or
- * an object carrying a `message`.
- */
-function extractErrorMessage(error: unknown): string | undefined {
-  if (typeof error === 'string') return error || undefined;
-
-  if (error && typeof error === 'object') {
-    const { message } = error as { message?: unknown };
-    if (typeof message === 'string' && message) return message;
-  }
-
-  return undefined;
-}
-
-/**
  * Submit a video generation prediction to Replicate.
  *
  * Uses `predictions.create` rather than `client.run` so the request returns as
@@ -63,27 +118,18 @@ export async function createReplicateVideo(
   payload: CreateVideoPayload,
 ): Promise<CreateVideoResponse> {
   const { model, params } = payload;
-  const { prompt, imageUrl, endImageUrl, aspectRatio, duration, resolution, seed, generateAudio } =
-    params;
 
-  const input: Record<string, unknown> = {
-    prompt,
-    // Replicate defaults this to `true`; generations must stay filtered by default.
-    disable_safety_filter: false,
-  };
-
-  if (imageUrl) input.image = imageUrl;
-  if (endImageUrl) input.last_frame_image = endImageUrl;
-  // `aspect_ratio` is ignored by image-to-video models, which derive it from the input image
-  if (aspectRatio && !imageUrl) input.aspect_ratio = aspectRatio;
-  if (duration !== undefined && duration !== null) input.duration = duration;
-  if (resolution) input.resolution = resolution;
-  if (seed !== undefined && seed !== null) input.seed = seed;
-  if (generateAudio !== undefined) input.save_audio = generateAudio;
+  const input = buildVideoInput(model, params);
 
   log('Creating video prediction - model: %s, input: %O', model, input);
 
-  const prediction = await client.predictions.create({ input, model });
+  // Replicate exposes two prediction endpoints: `POST /predictions`, which takes
+  // a `version` and accepts any model, and `POST /models/{owner}/{name}/predictions`,
+  // which takes a bare model id but only serves official models. A pinned version
+  // cannot go through the latter, since it would land in the URL path.
+  const prediction = model.includes(':')
+    ? await client.predictions.create({ input, version: model })
+    : await client.predictions.create({ input, model });
 
   if (!prediction?.id) {
     throw new Error('Invalid response from Replicate: missing prediction id');
@@ -92,6 +138,21 @@ export async function createReplicateVideo(
   log('Video prediction created: %s (status: %s)', prediction.id, prediction.status);
 
   return { inferenceId: prediction.id };
+}
+
+/**
+ * Replicate types a prediction error as `unknown`: it may be a plain string or
+ * an object carrying a `message`.
+ */
+function extractErrorMessage(error: unknown): string | undefined {
+  if (typeof error === 'string') return error || undefined;
+
+  if (error && typeof error === 'object') {
+    const { message } = error as { message?: unknown };
+    if (typeof message === 'string' && message) return message;
+  }
+
+  return undefined;
 }
 
 /**

--- a/packages/model-runtime/src/providers/replicate/createVideo.ts
+++ b/packages/model-runtime/src/providers/replicate/createVideo.ts
@@ -1,0 +1,134 @@
+import createDebug from 'debug';
+import type Replicate from 'replicate';
+
+import type { CreateVideoPayload, CreateVideoResponse, PollVideoStatusResult } from '../../types';
+
+const log = createDebug('lobe-video:replicate');
+
+/**
+ * Replicate returns the generated media in a shape that depends on the model:
+ * a bare URL string, an array of URL strings, or an object keyed by media type.
+ * Normalise all of them to a single URL.
+ */
+export function extractVideoUrl(output: unknown): string | undefined {
+  if (typeof output === 'string') return output || undefined;
+
+  if (Array.isArray(output)) {
+    const first = output.find((item) => typeof item === 'string' && item);
+    return typeof first === 'string' ? first : undefined;
+  }
+
+  if (output && typeof output === 'object') {
+    const record = output as Record<string, unknown>;
+
+    for (const key of ['video', 'output', 'url']) {
+      const nested = record[key];
+      if (typeof nested === 'string' && nested) return nested;
+      // `video` may itself be a { url } object or an array of URLs
+      if (nested && typeof nested === 'object') {
+        const resolved = extractVideoUrl(nested);
+        if (resolved) return resolved;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Replicate types a prediction error as `unknown`: it may be a plain string or
+ * an object carrying a `message`.
+ */
+function extractErrorMessage(error: unknown): string | undefined {
+  if (typeof error === 'string') return error || undefined;
+
+  if (error && typeof error === 'object') {
+    const { message } = error as { message?: unknown };
+    if (typeof message === 'string' && message) return message;
+  }
+
+  return undefined;
+}
+
+/**
+ * Submit a video generation prediction to Replicate.
+ *
+ * Uses `predictions.create` rather than `client.run` so the request returns as
+ * soon as the prediction is queued: video generation routinely takes minutes,
+ * which does not fit inside a serverless request. The async task pipeline then
+ * polls `pollReplicateVideoStatus` until the prediction settles.
+ */
+export async function createReplicateVideo(
+  client: Replicate,
+  payload: CreateVideoPayload,
+): Promise<CreateVideoResponse> {
+  const { model, params } = payload;
+  const { prompt, imageUrl, endImageUrl, aspectRatio, duration, resolution, seed, generateAudio } =
+    params;
+
+  const input: Record<string, unknown> = {
+    prompt,
+    // Replicate defaults this to `true`; generations must stay filtered by default.
+    disable_safety_filter: false,
+  };
+
+  if (imageUrl) input.image = imageUrl;
+  if (endImageUrl) input.last_frame_image = endImageUrl;
+  // `aspect_ratio` is ignored by image-to-video models, which derive it from the input image
+  if (aspectRatio && !imageUrl) input.aspect_ratio = aspectRatio;
+  if (duration !== undefined && duration !== null) input.duration = duration;
+  if (resolution) input.resolution = resolution;
+  if (seed !== undefined && seed !== null) input.seed = seed;
+  if (generateAudio !== undefined) input.save_audio = generateAudio;
+
+  log('Creating video prediction - model: %s, input: %O', model, input);
+
+  const prediction = await client.predictions.create({ input, model });
+
+  if (!prediction?.id) {
+    throw new Error('Invalid response from Replicate: missing prediction id');
+  }
+
+  log('Video prediction created: %s (status: %s)', prediction.id, prediction.status);
+
+  return { inferenceId: prediction.id };
+}
+
+/**
+ * Map a Replicate prediction status onto the runtime polling contract.
+ */
+export async function pollReplicateVideoStatus(
+  client: Replicate,
+  inferenceId: string,
+): Promise<PollVideoStatusResult> {
+  const prediction = await client.predictions.get(inferenceId);
+
+  log('Prediction %s status: %s', inferenceId, prediction?.status);
+
+  switch (prediction?.status) {
+    case 'succeeded': {
+      const videoUrl = extractVideoUrl(prediction.output);
+
+      if (!videoUrl) {
+        return { error: 'Prediction succeeded but returned no video URL', status: 'failed' };
+      }
+
+      return { status: 'success', videoUrl };
+    }
+
+    case 'failed': {
+      return {
+        error: extractErrorMessage(prediction.error) || 'Video generation failed',
+        status: 'failed',
+      };
+    }
+
+    case 'canceled': {
+      return { error: 'Video generation was canceled', status: 'failed' };
+    }
+
+    default: {
+      return { status: 'pending' };
+    }
+  }
+}

--- a/packages/model-runtime/src/providers/replicate/index.test.ts
+++ b/packages/model-runtime/src/providers/replicate/index.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentRuntimeErrorType } from '../../types/error';
+import { LobeReplicateAI } from './index';
+
+const predictionsCreate = vi.fn();
+const predictionsGet = vi.fn();
+
+vi.mock('replicate', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    predictions: { create: predictionsCreate, get: predictionsGet },
+  })),
+}));
+
+describe('LobeReplicateAI video generation', () => {
+  let instance: LobeReplicateAI;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    instance = new LobeReplicateAI({ apiKey: 'test-token' });
+  });
+
+  it('submits a prediction and returns its inferenceId', async () => {
+    predictionsCreate.mockResolvedValue({ id: 'pred-42', status: 'starting' });
+
+    const result = await instance.createVideo({
+      model: 'prunaai/p-video',
+      params: { prompt: 'a lighthouse in a storm' },
+    });
+
+    expect(result).toEqual({ inferenceId: 'pred-42' });
+    expect(predictionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'prunaai/p-video' }),
+    );
+  });
+
+  it('polls a prediction and returns the video URL', async () => {
+    predictionsGet.mockResolvedValue({ output: 'https://v.mp4', status: 'succeeded' });
+
+    await expect(instance.handlePollVideoStatus('pred-42')).resolves.toEqual({
+      status: 'success',
+      videoUrl: 'https://v.mp4',
+    });
+  });
+
+  it('wraps an invalid token into an InvalidProviderAPIKey runtime error', async () => {
+    predictionsCreate.mockRejectedValue(new Error('You did not pass a valid API token'));
+
+    await expect(
+      instance.createVideo({ model: 'prunaai/p-video', params: { prompt: 'x' } }),
+    ).rejects.toMatchObject({ errorType: AgentRuntimeErrorType.InvalidProviderAPIKey });
+  });
+
+  it('wraps an unknown model into a ModelNotFound runtime error', async () => {
+    predictionsCreate.mockRejectedValue(new Error('model not found'));
+
+    await expect(
+      instance.createVideo({ model: 'nope/nope', params: { prompt: 'x' } }),
+    ).rejects.toMatchObject({ errorType: AgentRuntimeErrorType.ModelNotFound });
+  });
+
+  it('wraps polling failures into a provider error', async () => {
+    predictionsGet.mockRejectedValue(new Error('upstream exploded'));
+
+    await expect(instance.handlePollVideoStatus('pred-42')).rejects.toMatchObject({
+      errorType: AgentRuntimeErrorType.ProviderBizError,
+    });
+  });
+});

--- a/packages/model-runtime/src/providers/replicate/index.ts
+++ b/packages/model-runtime/src/providers/replicate/index.ts
@@ -7,11 +7,15 @@ import type {
   ChatMethodOptions,
   ChatStreamPayload,
   CreateImagePayload,
+  CreateVideoPayload,
+  CreateVideoResponse,
+  PollVideoStatusResult,
 } from '../../types';
 import { AgentRuntimeErrorType } from '../../types/error';
 import { AgentRuntimeError } from '../../utils/createError';
 import { desensitizeUrl } from '../../utils/desensitizeUrl';
 import { MODEL_LIST_CONFIGS, processModelList } from '../../utils/modelParse';
+import { createReplicateVideo, pollReplicateVideoStatus } from './createVideo';
 
 const DEFAULT_BASE_URL = 'https://api.replicate.com';
 
@@ -310,6 +314,28 @@ export class LobeReplicateAI implements LobeRuntimeAI {
         imageUrl: outputImageUrl,
         width,
       };
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /**
+   * Video generation support.
+   *
+   * Submits the prediction and returns immediately; the async task pipeline
+   * drives `handlePollVideoStatus` until the prediction settles.
+   */
+  async createVideo(payload: CreateVideoPayload): Promise<CreateVideoResponse> {
+    try {
+      return await createReplicateVideo(this.client, payload);
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  async handlePollVideoStatus(inferenceId: string): Promise<PollVideoStatusResult> {
+    try {
+      return await pollReplicateVideoStatus(this.client, inferenceId);
     } catch (error) {
       throw this.handleError(error);
     }


### PR DESCRIPTION
Adds video generation support to the Replicate provider, plus the first Replicate video model card (`prunaai/p-video`).

Replicate video predictions routinely run for minutes, so `createVideo` submits via `predictions.create` and returns the prediction id immediately; `handlePollVideoStatus` then maps Replicate's prediction status onto the runtime polling contract. This follows the async pattern already used by the other video providers. A synchronous `client.run` would both block the serverless request and return a `{ inferenceId, videoUrl }` shape that the video lambda router never reads, since it only branches on webhook vs polling.

Replicate exposes two prediction endpoints: `POST /predictions` takes a `version` and accepts any model, while `POST /models/{owner}/{name}/predictions` takes a bare model id but only serves official models and cannot carry a version in its URL path. Submission routes on whether the model id pins a version, so both `owner/name` and `owner/name:version` work and non-official models stay reachable.

Model input names are model-specific on Replicate, so they live in a per-model contract table rather than in the shared submission path. The table doubles as an allow list: a card parameter with no entry is not sent, so a card cannot leak an input name the model does not declare.

Card values are transcribed from the model's live OpenAPI schema rather than assumed: 7 aspect ratios, 720p/1080p, integer duration 1-20s (default 5). `last_frame_image` maps onto the existing `endImageUrl` standard parameter. `disable_safety_filter` defaults to `true` upstream and is forced to `false` so generations stay filtered. Pricing is per second of video and varies by resolution ($0.02/s at 720p, $0.04/s at 1080p), expressed as a lookup unit keyed on `resolution`.

Note that the model's README documents a 1-10s duration range while its OpenAPI schema allows 1-20s. The card follows the schema, since that is what the API validates against.

`createImage` is untouched. It had no test coverage before this branch, and adding a full `createImage` suite felt out of scope for a video PR.

| Before | After |
| ------ | ----- |
| Replicate offered image generation only; no video tab for the provider | Replicate appears as a video provider with `prunaai/p-video` |

#### Test

29 unit tests mock `predictions.create` / `predictions.get` and cover input building (parameter mapping, allow-list filtering, empty-value omission, image-to-video aspect-ratio handling, version-pinned ids, unknown-model fallback), endpoint routing, output URL extraction across the shapes Replicate returns (bare string, array, composite object, nested `{ url }`), prediction status mapping, and runtime error wrapping. `lint`, `tsgo --noEmit` and `lint:circular` are all clean.

Suggested manual test prompts:

- T2V: `a lighthouse in a storm, waves crashing, cinematic` — aspect ratio 16:9, resolution 720p, duration 5s
- I2V: same prompt with a start image attached; `aspect_ratio` should be omitted from the request and derived from the image instead

No real generation has been run against the Replicate API yet (that needs a token and burns credits), so `Tested locally` is intentionally left unchecked.

- [x] Tested locally
- [x] Added/updated tests

#### 🔗 Related Issue

Closes #18274.

Extends the Replicate provider support added for #2451 to the video modality.

