### PR TITLE
🐛 fix(desktop): load English locale fallback

### DIFF
--- a/apps/desktop/src/main/core/infrastructure/I18nManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/I18nManager.ts
@@ -170,8 +170,15 @@ export class I18nManager {
 
   private async loadLocale(language: string) {
     logger.debug(`Loading locale for language: ${language}`);
-    // Preload base namespaces
-    await Promise.all(['menu', 'dialog', 'common'].map((ns) => this.loadNamespace(language, ns)));
+    const languages =
+      language === 'en' || language.startsWith('en-') ? [language] : [language, 'en'];
+
+    // Preload base namespaces and the English fallback for non-English locales.
+    await Promise.all(
+      languages.flatMap((lng) =>
+        ['menu', 'dialog', 'common'].map((ns) => this.loadNamespace(lng, ns)),
+      ),
+    );
   }
 
   /**

--- a/apps/desktop/src/main/core/infrastructure/__tests__/I18nManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/I18nManager.test.ts
@@ -357,4 +357,20 @@ describe('I18nManager', () => {
       expect(result).toBe(false);
     });
   });
+
+  describe('loadLocale', () => {
+    beforeEach(async () => {
+      await manager.init();
+      vi.clearAllMocks();
+    });
+
+    it('should load English fallback resources for non-English locales', async () => {
+      await manager['loadLocale']('ru-RU');
+
+      for (const namespace of ['menu', 'dialog', 'common']) {
+        expect(mockLoadResources).toHaveBeenCalledWith('ru-RU', namespace);
+        expect(mockLoadResources).toHaveBeenCalledWith('en', namespace);
+      }
+    });
+  });
 });


### PR DESCRIPTION
Desktop i18n configured English as the fallback language but only loaded resources for the active locale. Missing generated translations therefore surfaced raw keys instead of falling back to English.

This preloads the English desktop namespaces for non-English locales and adds a focused regression test. Generated locale files remain untouched.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bunx vitest run src/main/core/infrastructure/__tests__/I18nManager.test.ts` — 23 passed

`bunx eslint src/main/core/infrastructure/I18nManager.ts src/main/core/infrastructure/__tests__/I18nManager.test.ts`

#### 🔗 Related Issue

Fixes #18208