### PR TITLE
🐛 fix(python-interpreter): run the worker as classic, and publish workers where a page can load them

### DIFF
--- a/packages/python-interpreter/src/interpreter.ts
+++ b/packages/python-interpreter/src/interpreter.ts
@@ -21,10 +21,12 @@ export const getPythonInterpreter = (): Comlink.Remote<PythonWorkerType> | undef
 
     if (typeof Worker !== 'undefined') {
       try {
+        // Classic, not a module worker: `worker.ts` loads Pyodide through
+        // `importScripts`, and that call throws "Module scripts don't support
+        // importScripts()" under `type: 'module'`. The bundler emits this worker as
+        // an IIFE anyway, so the module type was never matched by the output.
         interpreter = Comlink.wrap<PythonWorkerType>(
-          new Worker(new URL('worker.ts', import.meta.url), {
-            type: 'module',
-          }),
+          new Worker(new URL('worker.ts', import.meta.url)),
         );
       } catch (error) {
         constructionError = error;

--- a/scripts/copySpaBuild.test.ts
+++ b/scripts/copySpaBuild.test.ts
@@ -31,6 +31,26 @@ describe('copySpaBuild', () => {
     }
   });
 
+  // `new Worker` only accepts a same-origin script, so these are requested from the
+  // page's own origin rather than the asset host — which means they have to reach
+  // `public/`, and at its root, because that is the path the build emits.
+  it('publishes workers to the public root, outside the per-variant directories', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'copy-spa-build-workers-'));
+    testRoots.push(root);
+
+    for (const variant of ['desktop', 'workbench']) {
+      const sourceDir = path.join(root, `dist/${variant}/app-workers`);
+      mkdirSync(sourceDir, { recursive: true });
+      writeFileSync(path.join(sourceDir, 'worker-abc.js'), 'self.onmessage = () => {};');
+    }
+
+    copySpaBuild(root);
+
+    expect(existsSync(path.join(root, 'public/app-workers/worker-abc.js'))).toBe(true);
+    expect(existsSync(path.join(root, 'public/_spa/app-workers'))).toBe(false);
+    expect(existsSync(path.join(root, 'public/_spa-workbench/app-workers'))).toBe(false);
+  });
+
   it('runs through the production Node entrypoint', () => {
     const root = mkdtempSync(path.join(tmpdir(), 'copy-spa-build-entry-'));
     testRoots.push(root);

--- a/scripts/copySpaBuildCore.ts
+++ b/scripts/copySpaBuildCore.ts
@@ -2,6 +2,12 @@ import { cpSync, existsSync, mkdirSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 const copyDirs = ['assets', 'devtools', 'i18n', 'model-bank', 'shiki', 'vendor'] as const;
+
+// Workers are requested root-relative, not from under the entry prefix, because
+// `new Worker` needs a same-origin script and the file is byte-identical across
+// variants. So this one lands in `public/` itself rather than in each SPA
+// directory — a single copy behind a single path.
+const rootCopyDirs = ['app-workers'] as const;
 const copyRootFilePatterns = [/^favicon.*\.ico$/, /^apple-touch-icon\.png$/] as const;
 const targets = [
   { distDir: 'desktop', publicDir: 'public/_spa' },
@@ -24,6 +30,15 @@ export const copySpaBuild = (root = path.resolve(import.meta.dirname, '..')) => 
 
       cpSync(sourceDir, targetDir, { recursive: true });
       console.log(`Copied dist/${distDir}/${dir} -> ${publicDir}/${dir}`);
+    }
+
+    for (const dir of rootCopyDirs) {
+      const sourceDir = path.resolve(distRoot, dir);
+
+      if (!existsSync(sourceDir)) continue;
+
+      cpSync(sourceDir, path.resolve(root, 'public', dir), { recursive: true });
+      console.log(`Copied dist/${distDir}/${dir} -> public/${dir}`);
     }
 
     if (!existsSync(distRoot)) continue;


### PR DESCRIPTION
Two fixes that only surface once you try to actually use a web worker. Follow-up to #18271, which stopped a failed worker from taking the app down — this is the failure it was papering over, plus the one behind it.

## 1. The worker was declared a module and built as a script

```ts
new Worker(new URL("worker.ts", import.meta.url), { type: "module" })
```

The bundler emits it as an **IIFE** — `worker.format` defaults to `iife` — so the declared type never matched the output. And `worker.ts` loads Pyodide through `importScripts`, which a module worker refuses:

```
TypeError: Failed to execute 'importScripts' on 'WorkerGlobalScope':
Module scripts don't support importScripts().
```

The call lives inside `init()`, so nothing surfaces at construction — the worker starts fine and the interpreter fails on its first real use. Dropping the option makes the construction agree with the output.

A probe confirms the constraint rather than trusting folklore:

```
new Worker(blobUrl, { type: "module" })  →  importScripts(...)
TypeError: Module scripts don't support importScripts().
```

## 2. Workers never reached anywhere a page could load them

`new Worker(url)` only accepts a **same-origin** script. `Access-Control-Allow-Origin` does not lift that, unlike `<script crossorigin>`. So when the SPA's assets move to an asset host, workers are the one thing that has to stay behind and be served from the page's own origin.

The build emits them into `app-workers/`, but `copyDirs` in `copySpaBuildCore.ts` is an **allowlist** and did not carry that directory across. The files reached neither `public/` nor the asset upload, so the emitted URL resolved to nothing.

They now go to `public/app-workers/` rather than into each SPA directory — the files are byte-identical across variants, so one path keeps one copy and gives the origin a single prefix to recognise.

## Verified end to end

Against the built worker in a browser, not just unit tests:

```json
{"output":[{"data":"hello from emscripten","type":"stdout"}],"result":"42","success":true}
```

Pyodide loaded over `importScripts`, `print("hello from", sys.platform)` wrote `hello from emscripten`, and `6*7` returned `42`.

Served from two origins to mirror the asset-host setup, the cross-origin copy reproduces the browser's refusal and the same-origin copy constructs:

```
SecurityError: Failed to construct 'Worker': Script at 'http://localhost:8788/…'
cannot be accessed from origin 'http://localhost:8787'.
```

Both `desktop` and `workbench` variants build and land a single shared copy in `public/app-workers/`.

`packages/python-interpreter` 22 tests, `scripts/copySpaBuild` 4 tests.

## How it surfaced

Found while moving static assets to a CDN in `lobehub-cloud`. Neither fix is CDN-specific — the first is live today and breaks the code interpreter on first use.