### PR TITLE
🐛 fix(model-runtime): classify media request errors

### DIFF
--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.test.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.test.ts
@@ -917,6 +917,39 @@ describe('createRouterRuntime', () => {
       expect(mockChatFail).toHaveBeenCalledTimes(1);
     });
 
+    it('should not retry an InvalidRequestFormat media download failure', async () => {
+      const invalidRequestError = {
+        error: { message: 'failed to download or process media content' },
+        errorType: AgentRuntimeErrorType.InvalidRequestFormat,
+        provider: 'test',
+      };
+
+      const mockChatFail = vi.fn().mockRejectedValue(invalidRequestError);
+
+      class FailRuntime implements LobeRuntimeAI {
+        chat = mockChatFail;
+      }
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            models: ['mimo-v2.5'],
+            options: [{ apiKey: 'key-1' }, { apiKey: 'key-2' }],
+            runtime: FailRuntime as any,
+          },
+        ],
+      });
+
+      const runtime = new Runtime();
+      await expect(
+        runtime.chat({ model: 'mimo-v2.5', messages: [], temperature: 0.7 }),
+      ).rejects.toEqual(invalidRequestError);
+
+      expect(mockChatFail).toHaveBeenCalledTimes(1);
+    });
+
     it('should not retry when the response_format schema is invalid', async () => {
       const invalidSchemaError = {
         errorType: AgentRuntimeErrorType.ProviderBizError,

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -1345,6 +1345,34 @@ describe('LobeOpenAICompatibleFactory', () => {
         }
       });
 
+      it('should classify media download failures as InvalidRequestFormat', async () => {
+        const apiError = new OpenAI.APIError(
+          400,
+          {
+            error: {
+              message: 'failed to download or process media content',
+              type: 'invalid_request_error',
+            },
+            status: 400,
+          },
+          'failed to download or process media content',
+          new Headers(),
+        );
+
+        vi.spyOn(instance['client'].chat.completions, 'create').mockRejectedValue(apiError);
+
+        await expect(
+          instance.chat({
+            messages: [{ content: 'Describe this image', role: 'user' }],
+            model: 'mimo-v2.5',
+            temperature: 0,
+          }),
+        ).rejects.toMatchObject({
+          errorType: AgentRuntimeErrorType.InvalidRequestFormat,
+          provider,
+        });
+      });
+
       it('should throw AgentRuntimeError with invalidErrorType if no apiKey is provided', async () => {
         try {
           new LobeMockProvider({});

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -8,7 +8,7 @@ import type { ClientOptions } from 'openai';
 import OpenAI from 'openai';
 import type { Stream } from 'openai/streaming';
 
-import { ErrorClassifier } from '../../errors';
+import { ErrorClassifier, refineErrorCode } from '../../errors';
 import {
   isGPT5ProResponsesModel,
   isResponsesAPIModel,
@@ -1520,11 +1520,18 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         });
       }
 
+      const fallbackErrorType = RuntimeError || ErrorType.bizError;
+      const refinedErrorType = refineErrorCode({
+        errorType: String(fallbackErrorType),
+        message: typeof errorMsg === 'string' ? errorMsg : undefined,
+        provider: this.id,
+      });
+
       log('returning generic error');
       return AgentRuntimeError.chat({
         endpoint: desensitizedEndpoint,
         error: errorResult,
-        errorType: RuntimeError || ErrorType.bizError,
+        errorType: refinedErrorType ?? fallbackErrorType,
         message,
         provider: this.id,
       });

--- a/packages/model-runtime/src/errors/patterns.ts
+++ b/packages/model-runtime/src/errors/patterns.ts
@@ -1105,6 +1105,10 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   },
   {
     code: AgentRuntimeErrorType.InvalidRequestFormat,
+    match: sub('failed to download or process media content', { caseInsensitive: true }),
+  },
+  {
+    code: AgentRuntimeErrorType.InvalidRequestFormat,
     match: sub('Unable to download the file. Please verify the URL and try again.'),
   },
   {

--- a/packages/model-runtime/src/errors/refine.test.ts
+++ b/packages/model-runtime/src/errors/refine.test.ts
@@ -65,6 +65,16 @@ describe('refineErrorCode', () => {
   });
 
   describe('message-pattern pass', () => {
+    it('classifies media download failures as InvalidRequestFormat', () => {
+      expect(
+        refineErrorCode({
+          errorType: AgentRuntimeErrorType.ProviderBizError,
+          httpStatus: 400,
+          message: 'failed to download or process media content',
+        }),
+      ).toBe(AgentRuntimeErrorType.InvalidRequestFormat);
+    });
+
     it('reclassifies a rate-limit message into RateLimitExceeded', () => {
       expect(
         refineErrorCode({

--- a/packages/model-runtime/src/utils/isNonRetryableRequestError.ts
+++ b/packages/model-runtime/src/utils/isNonRetryableRequestError.ts
@@ -5,6 +5,7 @@ import { isErrorCausedByContentFilter } from './isErrorCausedByContentFilter';
 
 const NON_RETRYABLE_ERROR_TYPES = new Set<string>([
   AgentRuntimeErrorType.ExceededContextWindow,
+  AgentRuntimeErrorType.InvalidRequestFormat,
   AgentRuntimeErrorType.ProviderContentPolicyViolation,
   AgentRuntimeErrorType.ProviderNoImageGenerated,
 ]);


### PR DESCRIPTION
## 💻 Change Type

- [x] 🐛 fix

## 🔗 Related Links

- Linear / GitHub issue: N/A
- Related PRs: N/A
- Reference docs / code / articles: N/A

## 🔀 Description of Change

Classify recognized media download and processing failures as InvalidRequestFormat before OpenAI-compatible errors reach RouterRuntime. Canonical invalid-request errors are terminal, so RouterRuntime preserves the original request error instead of trying unrelated fallback channels.

## 🧭 Key Decisions / Non-goals

- Match the known media failure message through the shared error-pattern registry.
- Keep unknown provider 4xx errors on the existing fallback path; this PR does not classify every HTTP 400 as a user request error.
- Preserve the original provider error payload while refining only its canonical error type.

## 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

### Automated Tests

- bun run check --lint --test
- 283 related tests passed from the cloud superproject after rebasing onto the latest canary.

## 🚀 Rollout / Deployment Checklist

- [x] Environment variables: N/A
- [x] Redis / Edge Config / feature flags: N/A
- [x] Database migration or data backfill: N/A
- [x] Third-party console changes: N/A
- [x] Rollback plan: Revert this PR to restore the previous classification and fallback behavior.