### PR TITLE
🐛 fix(task): clarify topic follow-up action

### DIFF
--- a/src/features/AgentTasks/AgentTaskDetail/TopicCard.test.ts
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicCard.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldShowRunFollowUp } from './shouldShowRunFollowUp';
+
+describe('shouldShowRunFollowUp', () => {
+  it('hides the follow-up action while the topic is running', () => {
+    expect(shouldShowRunFollowUp(true, true)).toBe(false);
+  });
+
+  it('shows the follow-up action after the topic stops running', () => {
+    expect(shouldShowRunFollowUp(true, false)).toBe(true);
+  });
+
+  it('keeps the follow-up action hidden without permission or a task target', () => {
+    expect(shouldShowRunFollowUp(false, false)).toBe(false);
+  });
+});

--- a/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
@@ -20,8 +20,8 @@ import {
   CircleStop,
   Copy,
   ExternalLink,
+  MessageCircle,
   MoreHorizontal,
-  SquarePen,
 } from 'lucide-react';
 import type { KeyboardEvent } from 'react';
 import { memo, useCallback, useEffect, useState } from 'react';
@@ -39,6 +39,7 @@ import { styles } from '../shared/style';
 import RunReplyEditor from './RunReplyEditor';
 import RunVerifyDetail from './RunVerifyDetail';
 import RunVerifyTag from './RunVerifyTag';
+import { shouldShowRunFollowUp } from './shouldShowRunFollowUp';
 import TopicStatusIcon from './TopicStatusIcon';
 
 const formatDuration = (ms: number): string => {
@@ -97,8 +98,9 @@ const TopicCard = memo<TopicCardProps>(({ activity, defaultExpanded = true }) =>
   // active task.
   const runTaskId = activity.sourceTaskId ?? activeTaskId;
   const canFollowUp = canEditTask && !!runTaskId;
+  const showRunFollowUp = shouldShowRunFollowUp(canFollowUp, isRunning);
   const hasBody = Boolean(
-    activity.summary || activity.content || canFollowUp || activity.verify?.total,
+    activity.summary || activity.content || showRunFollowUp || activity.verify?.total,
   );
   // A verdict with no results behind it has nothing to move down to, so it
   // stays in the header no matter what the body is doing.
@@ -334,7 +336,7 @@ const TopicCard = memo<TopicCardProps>(({ activity, defaultExpanded = true }) =>
               />
             </Flexbox>
           )}
-          {canFollowUp &&
+          {showRunFollowUp &&
             (commenting ? (
               <Flexbox onClick={stopPropagation}>
                 <RunReplyEditor
@@ -348,7 +350,7 @@ const TopicCard = memo<TopicCardProps>(({ activity, defaultExpanded = true }) =>
             ) : (
               <Flexbox horizontal justify={'flex-end'} onClick={stopPropagation}>
                 <ActionIcon
-                  icon={SquarePen}
+                  icon={MessageCircle}
                   size={'small'}
                   title={t('taskDetail.runFollowUp')}
                   onClick={() => setCommenting(true)}

--- a/src/features/AgentTasks/AgentTaskDetail/shouldShowRunFollowUp.ts
+++ b/src/features/AgentTasks/AgentTaskDetail/shouldShowRunFollowUp.ts
@@ -1,0 +1,2 @@
+export const shouldShowRunFollowUp = (canFollowUp: boolean, isRunning: boolean) =>
+  canFollowUp && !isRunning;


### PR DESCRIPTION
## Summary

- hide the per-run follow-up action while a task topic is still running
- avoid rendering an empty expanded body for running topics with no output
- replace the ambiguous edit icon with a conversation icon after completion

## Testing

- `bun run check src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx src/features/AgentTasks/AgentTaskDetail/shouldShowRunFollowUp.ts src/features/AgentTasks/AgentTaskDetail/TopicCard.test.ts`
- agent-testing Web acceptance: running and completed topic states visually verified