### PR TITLE
💄 style(goal): improve running progress card

### DIFF
--- a/apps/server/src/services/task/index.test.ts
+++ b/apps/server/src/services/task/index.test.ts
@@ -139,6 +139,7 @@ describe('TaskService', () => {
         name: 'Task One',
         parentTaskId: null,
         priority: 'normal',
+        startedAt: new Date('2024-01-01T00:02:00Z'),
         status: 'todo',
         totalTopics: 0,
       };
@@ -166,6 +167,7 @@ describe('TaskService', () => {
       expect(result?.agentId).toBe('agent-1');
       expect(result?.userId).toBe('user-1');
       expect(result?.createdAt).toBe('2024-01-01T00:00:00.000Z');
+      expect(result?.startedAt).toBe('2024-01-01T00:02:00.000Z');
       expect(result?.subtasks).toEqual([]);
       expect(result?.dependencies).toEqual([]);
       expect(result?.activities).toBeUndefined();

--- a/apps/server/src/services/task/index.ts
+++ b/apps/server/src/services/task/index.ts
@@ -927,6 +927,7 @@ export class TaskService {
               timezone: task.scheduleTimezone,
             }
           : undefined,
+      startedAt: task.startedAt ? new Date(task.startedAt).toISOString() : undefined,
       status: task.status,
       userId: task.assigneeUserId,
       verify: this.taskModel.getVerifyConfig(task),

--- a/packages/types/src/task/index.ts
+++ b/packages/types/src/task/index.ts
@@ -506,6 +506,8 @@ export interface TaskDetailData {
     pattern?: string | null;
     timezone?: string | null;
   };
+  /** When the current task execution started; drives live elapsed-time displays. */
+  startedAt?: string;
   status: string;
   subtasks?: TaskDetailSubtask[];
   topicCount?: number;

--- a/src/features/Conversation/Messages/GoalWorkCard/GoalElapsedTime.tsx
+++ b/src/features/Conversation/Messages/GoalWorkCard/GoalElapsedTime.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { formatElapsedClockTime } from '@lobechat/utils';
+import { Text } from '@lobehub/ui';
+import { memo, useEffect, useState } from 'react';
+
+interface GoalElapsedTimeProps {
+  startedAt?: Date | number | string | null;
+}
+
+const GoalElapsedTime = memo<GoalElapsedTimeProps>(({ startedAt }) => {
+  const startedAtMs = startedAt == null ? undefined : new Date(startedAt).getTime();
+  const hasValidStartTime = startedAtMs !== undefined && Number.isFinite(startedAtMs);
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!hasValidStartTime) return;
+
+    setNow(Date.now());
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+
+    return () => clearInterval(timer);
+  }, [hasValidStartTime, startedAtMs]);
+
+  if (!hasValidStartTime) return null;
+
+  return (
+    <Text
+      fontSize={12}
+      style={{ flex: 'none', fontVariantNumeric: 'tabular-nums' }}
+      type={'secondary'}
+    >
+      {formatElapsedClockTime(now - startedAtMs)}
+    </Text>
+  );
+});
+
+GoalElapsedTime.displayName = 'GoalElapsedTime';
+
+export default GoalElapsedTime;

--- a/src/features/Conversation/Messages/GoalWorkCard/GoalStatusLine.tsx
+++ b/src/features/Conversation/Messages/GoalWorkCard/GoalStatusLine.tsx
@@ -81,15 +81,19 @@ const GoalStatusLine = memo<GoalStatusLineProps>(
 
     return (
       <Flexbox horizontal align={'center'} gap={6}>
-        <Icon
-          className={styles.statusIcon}
-          color={meta.color}
-          icon={meta.icon}
-          size={12}
-          spin={meta.spin}
-        />
-        <Text className={styles.status}>{t(`goalWork.status.${phase}`)}</Text>
-        <Text className={styles.status}>·</Text>
+        {phase !== 'running' && (
+          <>
+            <Icon
+              className={styles.statusIcon}
+              color={meta.color}
+              icon={meta.icon}
+              size={12}
+              spin={meta.spin}
+            />
+            <Text className={styles.status}>{t(`goalWork.status.${phase}`)}</Text>
+            <Text className={styles.status}>·</Text>
+          </>
+        )}
         <Text className={styles.status}>
           {maxRounds
             ? t('goalWork.roundWithBudget', { current: round, total: maxRounds })

--- a/src/features/Conversation/Messages/GoalWorkCard/index.tsx
+++ b/src/features/Conversation/Messages/GoalWorkCard/index.tsx
@@ -1,15 +1,20 @@
 'use client';
 
-import { Center, Flexbox, Icon, Text } from '@lobehub/ui';
+import { Center, Flexbox, Icon, Tag, Text } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { ChevronRightIcon, TargetIcon } from 'lucide-react';
 import { memo } from 'react';
 
+import RingLoadingIcon from '@/components/RingLoading';
 import { useChatStore } from '@/store/chat';
 
 import type { OperationGoal } from './deriveOperationGoals';
+import GoalElapsedTime from './GoalElapsedTime';
 import GoalStatusLine from './GoalStatusLine';
+import type { GoalWorkPhase } from './goalWorkProgress';
 import { useGoalWorkStatus } from './useGoalWorkStatus';
+
+const ACTIVE_PHASES = new Set<GoalWorkPhase>(['repairing', 'running', 'verifying']);
 
 const styles = createStaticStyles(({ css }) => ({
   card: css`
@@ -42,12 +47,6 @@ const styles = createStaticStyles(({ css }) => ({
 
     background: ${cssVar.colorFillTertiary};
   `,
-  identifier: css`
-    flex-shrink: 0;
-    font-family: ${cssVar.fontFamilyCode};
-    font-size: 12px;
-    color: ${cssVar.colorTextTertiary};
-  `,
   title: css`
     min-width: 0;
     font-size: 14px;
@@ -57,13 +56,14 @@ const styles = createStaticStyles(({ css }) => ({
 
 const GoalCard = memo<{ goal: OperationGoal }>(({ goal }) => {
   const openTaskDetail = useChatStore((s) => s.openTaskDetail);
-  const { progress } = useGoalWorkStatus({
+  const { progress, startedAt } = useGoalWorkStatus({
     criteriaCount: goal.criteriaCount,
     goalKnown: true,
     identifier: goal.identifier,
     maxRounds: goal.maxRounds,
     taskId: goal.taskId,
   });
+  const isActive = ACTIVE_PHASES.has(progress.phase);
 
   return (
     <Flexbox
@@ -81,15 +81,26 @@ const GoalCard = memo<{ goal: OperationGoal }>(({ goal }) => {
       }}
     >
       <Center className={styles.icon}>
-        <Icon icon={TargetIcon} size={20} />
+        {isActive ? (
+          <RingLoadingIcon
+            ringColor={cssVar.colorBorder}
+            size={18}
+            style={{ color: cssVar.colorWarning }}
+          />
+        ) : (
+          <Icon icon={TargetIcon} size={20} />
+        )}
       </Center>
       <Flexbox flex={1} gap={2} style={{ minWidth: 0 }}>
-        <Text ellipsis className={styles.title}>
-          {goal.name}
-        </Text>
+        <Flexbox horizontal align={'center'} gap={8}>
+          <Text ellipsis className={styles.title}>
+            {goal.name}
+          </Text>
+          <Tag size={'small'}>{goal.identifier}</Tag>
+        </Flexbox>
         <GoalStatusLine {...progress} />
       </Flexbox>
-      <Text className={styles.identifier}>{goal.identifier}</Text>
+      {isActive && <GoalElapsedTime startedAt={startedAt} />}
       <ChevronRightIcon className={styles.chevron} size={16} />
     </Flexbox>
   );

--- a/src/features/Conversation/Messages/GoalWorkCard/useGoalWorkStatus.test.ts
+++ b/src/features/Conversation/Messages/GoalWorkCard/useGoalWorkStatus.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useGoalWorkStatus } from './useGoalWorkStatus';
 
 const mocks = vi.hoisted(() => ({
-  taskDetailMap: {} as Record<string, { config?: unknown; name?: string }>,
+  taskDetailMap: {} as Record<string, { config?: unknown; name?: string; startedAt?: string }>,
   useAcceptanceBundle: vi.fn(() => ({ data: undefined })),
   useAcceptanceBySubject: vi.fn(() => ({ data: undefined })),
   useFetchTaskDetail: vi.fn(),
@@ -39,11 +39,15 @@ describe('useGoalWorkStatus', () => {
   });
 
   it('polls acceptance after task detail identifies a Goal task', () => {
-    mocks.taskDetailMap['T-2'] = { config: { goal: {} } };
+    mocks.taskDetailMap['T-2'] = {
+      config: { goal: {} },
+      startedAt: '2026-08-14T08:00:00.000Z',
+    };
 
     const { result } = renderHook(() => useGoalWorkStatus({ identifier: 'T-2', taskId: 'task-2' }));
 
     expect(result.current.isGoal).toBe(true);
+    expect(result.current.startedAt).toBe('2026-08-14T08:00:00.000Z');
     expect(mocks.useAcceptanceBySubject).toHaveBeenCalledWith('task', 'task-2');
   });
 

--- a/src/features/Conversation/Messages/GoalWorkCard/useGoalWorkStatus.ts
+++ b/src/features/Conversation/Messages/GoalWorkCard/useGoalWorkStatus.ts
@@ -42,5 +42,10 @@ export const useGoalWorkStatus = ({
     taskStatus: task?.status,
   });
 
-  return { isGoal, progress, taskName: task?.name ?? undefined };
+  return {
+    isGoal,
+    progress,
+    startedAt: task?.startedAt,
+    taskName: task?.name ?? undefined,
+  };
 };


### PR DESCRIPTION
## Summary

- reuse the Topic ring loader for active Goal phases
- move the task identifier beside the Goal title as a tag
- show a live elapsed timer based on the task execution start time
- remove the redundant running label while preserving round and acceptance progress

## Verification

- `bun run check` on the 8 changed files: lint clean, 41 tests passed
- agent-testing Web acceptance: https://app.lobehub.com/acceptance/3335ba8e-e380-492a-a777-eb9ddaba52a3
- follow-up evidence confirms the card renders inside the Topic message area above the composer