### PR TITLE
✅ test: reconcile acceptance-link label assertion after cross-merge

### DIFF
--- a/src/features/DailyBrief/__tests__/BriefCardActions.test.tsx
+++ b/src/features/DailyBrief/__tests__/BriefCardActions.test.tsx
@@ -129,7 +129,7 @@ describe('BriefCardActions', () => {
       />,
     );
 
-    const link = screen.getByRole('button', { name: 'Review delivery' });
+    const link = screen.getByRole('button', { name: 'Review acceptance' });
     expect(link).not.toHaveAttribute(RENDERER_HANDLED_LINK_ATTR);
     expect(fireEvent.click(link)).toBe(true);
   });


### PR DESCRIPTION
Canary is currently red on `Test App`: #18020 and #18281 semantically conflicted in `BriefCardActions.test.tsx` — #18020 added the react-i18next mock and asserted the locale copy (`Review delivery`, action key `review`), while #18281 switched the action to an unmapped key (`reviewAcceptance`) so the server-provided label renders as-is. Squash-merged together, the test now uses the unmapped key but still asserts the locale copy, so the lookup finds nothing.

Reconciles the assertion to `Review acceptance` (label passthrough), matching the unmapped-key intent; the i18n mock from #18020 stays.

#### Test

- [x] Tested locally — `BriefCardActions.test.tsx` 24/24 passes.
- [x] Added/updated tests