### PR TITLE
🐛 fix(agent-runtime): prevent terminal refresh race

### DIFF
--- a/apps/server/src/modules/AgentRuntime/AgentRuntimeCoordinator.ts
+++ b/apps/server/src/modules/AgentRuntime/AgentRuntimeCoordinator.ts
@@ -41,6 +41,12 @@ const hasEnteredStreamEndState = (
 
 export interface AgentRuntimeCoordinatorOptions {
   /**
+   * Runs after terminal state persistence and the authoritative
+   * `agent_runtime_end` event have both completed. Server callers use this
+   * boundary to remove reconnect metadata without opening a refresh race.
+   */
+  onAgentRuntimeEndPublished?: (operationId: string, state: AgentState) => Promise<void>;
+  /**
    * Custom state manager implementation
    * Defaults to automatic selection based on Redis availability
    */
@@ -75,6 +81,10 @@ export interface AgentRuntimeCoordinatorOptions {
  * Supports dependency injection, allowing custom implementations to be passed in
  */
 export class AgentRuntimeCoordinator {
+  private onAgentRuntimeEndPublished?: (
+    operationId: string,
+    state: AgentState,
+  ) => Promise<void>;
   private stateManager: IAgentStateManager;
   private streamEventManager: IStreamEventManager;
   private uiMessagesResolver?: (state: AgentState) => Promise<UIChatMessage[] | undefined>;
@@ -82,6 +92,7 @@ export class AgentRuntimeCoordinator {
   constructor(options?: AgentRuntimeCoordinatorOptions) {
     this.stateManager = options?.stateManager ?? createAgentStateManager();
     this.streamEventManager = options?.streamEventManager ?? createStreamEventManager();
+    this.onAgentRuntimeEndPublished = options?.onAgentRuntimeEndPublished;
     this.uiMessagesResolver = options?.uiMessagesResolver;
   }
 
@@ -190,6 +201,7 @@ export class AgentRuntimeCoordinator {
           stepIndex,
           uiMessages: await this.resolveUiMessages(state),
         });
+        await this.onAgentRuntimeEndPublished?.(operationId, state);
         log('[%s] Agent runtime reached terminal state: %s', operationId, state.status);
       }
     } catch (error) {
@@ -226,6 +238,7 @@ export class AgentRuntimeCoordinator {
           stepIndex,
           uiMessages: await this.resolveUiMessages(stepResult.newState),
         });
+        await this.onAgentRuntimeEndPublished?.(operationId, stepResult.newState);
         log(
           '[%s] Agent runtime reached terminal state after step result: %s',
           operationId,

--- a/apps/server/src/modules/AgentRuntime/AgentRuntimeCoordinator.ts
+++ b/apps/server/src/modules/AgentRuntime/AgentRuntimeCoordinator.ts
@@ -81,10 +81,7 @@ export interface AgentRuntimeCoordinatorOptions {
  * Supports dependency injection, allowing custom implementations to be passed in
  */
 export class AgentRuntimeCoordinator {
-  private onAgentRuntimeEndPublished?: (
-    operationId: string,
-    state: AgentState,
-  ) => Promise<void>;
+  private onAgentRuntimeEndPublished?: (operationId: string, state: AgentState) => Promise<void>;
   private stateManager: IAgentStateManager;
   private streamEventManager: IStreamEventManager;
   private uiMessagesResolver?: (state: AgentState) => Promise<UIChatMessage[] | undefined>;

--- a/apps/server/src/modules/AgentRuntime/GatewayStreamNotifier.ts
+++ b/apps/server/src/modules/AgentRuntime/GatewayStreamNotifier.ts
@@ -17,7 +17,7 @@ const MAX_INFLIGHT = 20; // bounded concurrency
 
 /**
  * Decorator that wraps an IStreamEventManager and additionally
- * pushes events to the Agent Gateway via HTTP (fire-and-forget).
+ * pushes events to the Agent Gateway via HTTP.
  *
  * Redis SSE remains the primary event storage / subscription mechanism.
  * The Gateway is an additional push channel for WebSocket delivery.
@@ -88,7 +88,7 @@ export class GatewayStreamNotifier implements IStreamEventManager {
     chunkData: StreamChunkData,
   ): Promise<string> {
     const result = await this.inner.publishStreamChunk(operationId, stepIndex, chunkData);
-    void this.pushEvent(operationId, {
+    await this.pushEvent(operationId, {
       data: chunkData,
       operationId,
       stepIndex,

--- a/apps/server/src/modules/AgentRuntime/GatewayStreamNotifier.ts
+++ b/apps/server/src/modules/AgentRuntime/GatewayStreamNotifier.ts
@@ -88,7 +88,7 @@ export class GatewayStreamNotifier implements IStreamEventManager {
     chunkData: StreamChunkData,
   ): Promise<string> {
     const result = await this.inner.publishStreamChunk(operationId, stepIndex, chunkData);
-    await this.pushEvent(operationId, {
+    void this.pushEvent(operationId, {
       data: chunkData,
       operationId,
       stepIndex,
@@ -133,7 +133,7 @@ export class GatewayStreamNotifier implements IStreamEventManager {
     const effectiveReasonDetail = reasonDetail || getDefaultReasonDetail(finalState, reason);
     const errorType = finalState?.error?.type || finalState?.error?.errorType;
 
-    void this.pushEvent(operationId, {
+    await this.pushEvent(operationId, {
       // Forward `uiMessages` to the gateway push channel so terminal-state
       // clients consuming /push-event get the canonical UIChatMessage[]
       // snapshot — the final step has no later step_start to carry a fresh

--- a/apps/server/src/modules/AgentRuntime/__tests__/AgentRuntimeCoordinator.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/AgentRuntimeCoordinator.test.ts
@@ -267,6 +267,40 @@ describe('AgentRuntimeCoordinator', () => {
       });
     });
 
+    it('clears reconnect metadata only after terminal state persistence and delivery', async () => {
+      const order: string[] = [];
+      const operationId = 'test-operation-id';
+      const stepResult = {
+        executionTime: 1000,
+        newState: { status: 'done', stepCount: 5 },
+        stepIndex: 5,
+      };
+      const onAgentRuntimeEndPublished = vi.fn(async () => {
+        order.push('clear-running-mark');
+      });
+      mockStateManager.loadAgentState.mockResolvedValue({ status: 'running', stepCount: 4 });
+      mockStateManager.saveStepResult.mockImplementation(async () => {
+        order.push('save-terminal-state');
+      });
+      mockStreamManager.publishAgentRuntimeEnd.mockImplementation(async () => {
+        order.push('publish-runtime-end');
+      });
+      const orderedCoordinator = new AgentRuntimeCoordinator({
+        onAgentRuntimeEndPublished,
+        stateManager: mockStateManager,
+        streamEventManager: mockStreamManager,
+      });
+
+      await orderedCoordinator.saveStepResult(operationId, stepResult as any);
+
+      expect(order).toEqual([
+        'save-terminal-state',
+        'publish-runtime-end',
+        'clear-running-mark',
+      ]);
+      expect(onAgentRuntimeEndPublished).toHaveBeenCalledWith(operationId, stepResult.newState);
+    });
+
     it('should still publish step-result end event when visible output event publish fails', async () => {
       const operationId = 'test-operation-id';
       const stepResult = {

--- a/apps/server/src/modules/AgentRuntime/__tests__/AgentRuntimeCoordinator.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/AgentRuntimeCoordinator.test.ts
@@ -293,11 +293,7 @@ describe('AgentRuntimeCoordinator', () => {
 
       await orderedCoordinator.saveStepResult(operationId, stepResult as any);
 
-      expect(order).toEqual([
-        'save-terminal-state',
-        'publish-runtime-end',
-        'clear-running-mark',
-      ]);
+      expect(order).toEqual(['save-terminal-state', 'publish-runtime-end', 'clear-running-mark']);
       expect(onAgentRuntimeEndPublished).toHaveBeenCalledWith(operationId, stepResult.newState);
     });
 

--- a/apps/server/src/modules/AgentRuntime/__tests__/GatewayStreamNotifier.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/GatewayStreamNotifier.test.ts
@@ -163,11 +163,11 @@ describe('GatewayStreamNotifier', () => {
 
   describe('publishAgentRuntimeEnd', () => {
     it('waits for the terminal gateway push before resolving', async () => {
-      let resolveFetch!: () => void;
-      mockFetch.mockImplementationOnce(
+      let resolvePush!: () => void;
+      vi.spyOn(notifier as any, 'pushEvent').mockImplementationOnce(
         () =>
-          new Promise((resolve) => {
-            resolveFetch = () => resolve({ ok: true, text: () => Promise.resolve('') });
+          new Promise<void>((resolve) => {
+            resolvePush = resolve;
           }),
       );
 
@@ -186,7 +186,7 @@ describe('GatewayStreamNotifier', () => {
       await Promise.resolve();
       expect(resolved).toBe(false);
 
-      resolveFetch();
+      resolvePush();
       await expect(result).resolves.toBe('publishAgentRuntimeEnd-result');
     });
 

--- a/apps/server/src/modules/AgentRuntime/__tests__/GatewayStreamNotifier.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/GatewayStreamNotifier.test.ts
@@ -162,6 +162,34 @@ describe('GatewayStreamNotifier', () => {
   });
 
   describe('publishAgentRuntimeEnd', () => {
+    it('waits for the terminal gateway push before resolving', async () => {
+      let resolveFetch!: () => void;
+      mockFetch.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFetch = () => resolve({ ok: true, text: () => Promise.resolve('') });
+          }),
+      );
+
+      const result = notifier.publishAgentRuntimeEnd({
+        finalState: { status: 'done' },
+        operationId: 'op-1',
+        reason: 'completed',
+        stepIndex: 2,
+      });
+      let resolved = false;
+      void result.then(() => {
+        resolved = true;
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+
+      resolveFetch();
+      await expect(result).resolves.toBe('publishAgentRuntimeEnd-result');
+    });
+
     it('delegates to inner and returns its result', async () => {
       const finalState = { status: 'done' };
 

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -45,6 +45,7 @@ import { type LobeChatDatabase } from '@/database/type';
 import { appEnv } from '@/envs/app';
 import { type AgentRuntimeCoordinatorOptions } from '@/server/modules/AgentRuntime';
 import { AgentRuntimeCoordinator, createStreamEventManager } from '@/server/modules/AgentRuntime';
+import { ServerOperationStore } from '@/server/modules/AgentRuntime/adapters/ServerOperationStore';
 import { formatErrorForState } from '@/server/modules/AgentRuntime/formatErrorForState';
 import { hasNonPersistedMessage } from '@/server/modules/AgentRuntime/messagePersistence';
 import {
@@ -323,6 +324,16 @@ export class AgentRuntimeService {
       createStreamEventManager();
     this.coordinator = new AgentRuntimeCoordinator({
       ...options?.coordinatorOptions,
+      onAgentRuntimeEndPublished: async (operationId, state) => {
+        const metadata = state.metadata ?? {};
+        await new ServerOperationStore(
+          this.serverDB,
+          metadata.userId ?? this.userId,
+          this.workspaceId,
+          metadata.topicId,
+          operationId,
+        ).clearRunningMark();
+      },
       streamEventManager: this.streamManager,
       // Provide the canonical UIChatMessage[] for terminal-state events so
       // the client can use the pushed payload directly instead of refetching

--- a/packages/agent-runtime/src/executors/finish.ts
+++ b/packages/agent-runtime/src/executors/finish.ts
@@ -5,20 +5,15 @@ import type { AgentEvent, AgentInstruction, InstructionExecutor } from '../types
  * `finish` executor — terminates the operation.
  *
  * First executor migrated from the server into this package as part of the
- * agent-runtime IO transport port abstraction: it depends only on
- * the `StreamSink` + `OperationStore` transports and the operation context, so
- * the server just provides those adapters. Behavior mirrors the previous
- * server-local implementation exactly.
+ * agent-runtime IO transport port abstraction: it depends only on the
+ * `StreamSink` transport and the operation context, so the server just provides
+ * those adapters.
  */
 export const finish =
   (host: AgentRuntimeHost): InstructionExecutor =>
   async (instruction, state) => {
     const { reason, reasonDetail } = instruction as Extract<AgentInstruction, { type: 'finish' }>;
     const { operation, transports } = host;
-
-    // Clear the topic's running-operation mark so a reconnect doesn't
-    // re-trigger after completion. Best-effort — the adapter swallows failures.
-    await transports.operationStore?.clearRunningMark();
 
     // Publish the execution-complete stream event. `finalState.messages` +
     // tool-set fields are stripped centrally inside the sink adapter, so this

--- a/packages/agent-runtime/src/executors/registry.test.ts
+++ b/packages/agent-runtime/src/executors/registry.test.ts
@@ -45,12 +45,16 @@ const createState = (stepCount = 0) =>
     },
   }) satisfies AgentState;
 
-const createHost = (stepIndex: number, publishEvent = vi.fn()) =>
+const createHost = (
+  stepIndex: number,
+  publishEvent = vi.fn(),
+  clearRunningMark = vi.fn(),
+) =>
   ({
     operation: { operationId: 'operation-1', stepIndex },
     transports: {
       messages: {},
-      operationStore: { clearRunningMark: vi.fn() },
+      operationStore: { clearRunningMark },
       stream: { publishError: vi.fn(), publishEvent },
     },
   }) as unknown as AgentRuntimeHost;
@@ -78,5 +82,14 @@ describe('createAgentRuntimeExecutors', () => {
 
     expect(resolveHost).toHaveBeenCalledWith(instruction, state, undefined);
     expect(publishEvent).toHaveBeenCalledWith(expect.objectContaining({ stepIndex: 7 }));
+  });
+
+  it('leaves running-mark cleanup to the server terminal lifecycle', async () => {
+    const clearRunningMark = vi.fn();
+    const executors = createAgentRuntimeExecutors(createHost(0, vi.fn(), clearRunningMark));
+
+    await executors.finish!({ reason: 'completed', type: 'finish' }, createState());
+
+    expect(clearRunningMark).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent-runtime/src/executors/registry.test.ts
+++ b/packages/agent-runtime/src/executors/registry.test.ts
@@ -45,11 +45,7 @@ const createState = (stepCount = 0) =>
     },
   }) satisfies AgentState;
 
-const createHost = (
-  stepIndex: number,
-  publishEvent = vi.fn(),
-  clearRunningMark = vi.fn(),
-) =>
+const createHost = (stepIndex: number, publishEvent = vi.fn(), clearRunningMark = vi.fn()) =>
   ({
     operation: { operationId: 'operation-1', stepIndex },
     transports: {

--- a/packages/agent-runtime/src/transport/operation.ts
+++ b/packages/agent-runtime/src/transport/operation.ts
@@ -23,9 +23,9 @@ export interface RuntimeOperationContext {
  * Operation-lifecycle bookkeeping port. Server adapter wraps the topic /
  * operation-state models; the client adapter can be a no-op.
  *
- * Starts minimal — only `clearRunningMark` (used by `finish` to drop the
- * topic's `runningOperation` so a reconnect doesn't re-trigger). `loadState`
- * (interruption guard) joins here when call_tool / call_llm migrate.
+ * Starts minimal — `loadState` supports executor interruption guards.
+ * `clearRunningMark` is retained for the server lifecycle, which must only
+ * drop the reconnect anchor after terminal state persistence and delivery.
  */
 export interface OperationStore {
   /**


### PR DESCRIPTION
## What

- Move `runningOperation` cleanup out of the package-level `finish` executor.
- Clear the reconnect marker only after terminal state persistence and the authoritative `agent_runtime_end` event have completed.
- Await the terminal Agent Gateway push before cleanup.
- Add regression coverage for both cleanup ordering and terminal Gateway delivery.

## Why

On self-hosted deployments using Agent Gateway, the `finish` executor currently clears the topic's `runningOperation` marker before `saveStepResult` persists the terminal state and before `agent_runtime_end` reaches the Gateway.

A refresh in that window sees no reconnect anchor, so the client can settle on a pre-terminal message snapshot even though the final assistant message is subsequently persisted. Changing `AGENT_RUNTIME_MODE` between queue and local does not remove this ordering race.

The equivalent runtime patch has been reproduced successfully on a self-hosted v2.2.13 deployment. This PR replaces the temporary delayed/polling workaround with a deterministic lifecycle boundary.

Related to #17936 and lobehub/lobehub-gateway#9. The Gateway PR adds resume completion signaling, but does not change this server-side cleanup order.

#### Test

- [x] Tested the current canary checkout locally
- [x] Added/updated tests
- [ ] No tests needed

Added tests verify that:

1. `finish` no longer clears reconnect metadata before its result can be persisted.
2. The coordinator orders terminal persistence → terminal delivery → reconnect cleanup.
3. `publishAgentRuntimeEnd` does not resolve before the Gateway accepts the terminal event.

Local verification on the current `canary` base:

- `GatewayStreamNotifier.test.ts` + `AgentRuntimeCoordinator.test.ts`: 74 tests passed
- `registry.test.ts`: 3 tests passed
- Repository check runner: 8 changed files lint-clean
- `git diff --check`: passed
