### PR TITLE
♻️ refactor(subscription): remove deprecated Zarinpal locale keys

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,18 @@
     // support mdx
     "mdx"
   ],
+  "files.watcherExclude": {
+    "**/.git/objects/**": true,
+    "**/.git/subtree-cache/**": true,
+    "**/.next/**": true,
+    "**/coverage/**": true,
+    "**/dist/**": true,
+    "**/logs/**": true,
+    "**/node_modules/*/**": true,
+    "**/public/_spa-auth/**": true,
+    "**/public/_spa-workbench/**": true,
+    "**/public/_spa/**": true
+  },
   "js/ts.tsdk.path": "node_modules/typescript/lib",
   "npm.packageManager": "pnpm",
   "search.exclude": {

--- a/locales/en-US/subscription.json
+++ b/locales/en-US/subscription.json
@@ -363,7 +363,6 @@
   "plans.btn.noAction": "Plan Locked",
   "plans.btn.payment": "Purchase",
   "plans.btn.paymentDesc": "Supports credit card / Alipay / WeChat Pay",
-  "plans.btn.paymentDescForZarinpal": "Supports credit card",
   "plans.btn.soon": "Coming Soon",
   "plans.cancelDowngrade": "Cancel Scheduled Downgrade",
   "plans.cancelDowngradeSuccess": "Scheduled downgrade has been cancelled",
@@ -633,11 +632,5 @@
   "usage.overview.title": "Overview",
   "usage.remaining": "Remaining",
   "usage.storage.embeddings.used": "Vector Storage",
-  "usage.storage.file.used": "File Usage",
-  "zarinpal.infoModal.desc": "Due to policy requirements, please complete the following personal information before placing an order:",
-  "zarinpal.infoModal.phone.label": "Phone Number",
-  "zarinpal.infoModal.phone.placeholder": "Please enter phone number",
-  "zarinpal.infoModal.phone.rule": "Please enter a valid phone number",
-  "zarinpal.infoModal.submit": "Purchase",
-  "zarinpal.infoModal.title": "Fill in Required Information"
+  "usage.storage.file.used": "File Usage"
 }

--- a/locales/zh-CN/subscription.json
+++ b/locales/zh-CN/subscription.json
@@ -363,7 +363,6 @@
   "plans.btn.noAction": "计划已锁定",
   "plans.btn.payment": "立即购买",
   "plans.btn.paymentDesc": "支持信用卡 / 支付宝 / 微信支付",
-  "plans.btn.paymentDescForZarinpal": "支持信用卡",
   "plans.btn.soon": "即将上线",
   "plans.cancelDowngrade": "取消降级预约",
   "plans.cancelDowngradeSuccess": "降级预约已取消",
@@ -633,11 +632,5 @@
   "usage.overview.title": "总览",
   "usage.remaining": "剩余",
   "usage.storage.embeddings.used": "向量存储",
-  "usage.storage.file.used": "文件使用量",
-  "zarinpal.infoModal.desc": "根据政策要求，请在下单前填写以下个人信息：",
-  "zarinpal.infoModal.phone.label": "手机号",
-  "zarinpal.infoModal.phone.placeholder": "请输入手机号",
-  "zarinpal.infoModal.phone.rule": "请输入有效的手机号",
-  "zarinpal.infoModal.submit": "立即购买",
-  "zarinpal.infoModal.title": "填写必要信息"
+  "usage.storage.file.used": "文件使用量"
 }

--- a/packages/locales/src/default/subscription.ts
+++ b/packages/locales/src/default/subscription.ts
@@ -426,7 +426,6 @@ export default {
   'plans.btn.noAction': 'Plan Locked',
   'plans.btn.payment': 'Purchase',
   'plans.btn.paymentDesc': 'Supports credit card / Alipay / WeChat Pay',
-  'plans.btn.paymentDescForZarinpal': 'Supports credit card',
   'plans.btn.soon': 'Coming Soon',
   'plans.changePlan': 'Choose Plan',
   'plans.cloud.history': 'Unlimited conversation history',
@@ -742,11 +741,4 @@ export default {
   'usage.storage.embeddings.used': 'Vector Storage',
   'usage.storage.file.used': 'File Usage',
   'usage.remaining': 'Remaining',
-  'zarinpal.infoModal.desc':
-    'Due to policy requirements, please complete the following personal information before placing an order:',
-  'zarinpal.infoModal.phone.label': 'Phone Number',
-  'zarinpal.infoModal.phone.placeholder': 'Please enter phone number',
-  'zarinpal.infoModal.phone.rule': 'Please enter a valid phone number',
-  'zarinpal.infoModal.submit': 'Purchase',
-  'zarinpal.infoModal.title': 'Fill in Required Information',
 };


### PR DESCRIPTION
## 💻 Change Type

- [x] ♻️ refactor

## 🔗 Related Links

- Related PRs: N/A

## 🔀 Description of Change

Removes unused Zarinpal-specific subscription locale keys from the default, English, and Simplified Chinese resources.

## 🧭 Key Decisions / Non-goals

- This is locale-only cleanup; it does not change subscription or payment runtime behavior.
- Other subscription copy remains unchanged.

## 🧪 How to Test

- [x] Tested locally
- [x] No tests needed

### Automated Tests

- `bun run check lobehub/locales/en-US/subscription.json lobehub/locales/zh-CN/subscription.json lobehub/packages/locales/src/default/subscription.ts`
