### PR TITLE
♻️ refactor: migrate form controls to Base UI

### DIFF
--- a/packages/builtin-tool-claude-code/src/client/Render/Task/index.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Render/Task/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import type { BuiltinRenderProps } from '@lobechat/types';
-import { Block, Checkbox, Icon } from '@lobehub/ui';
+import { Block, Icon } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { CircleArrowRight, CircleCheckBig, CircleX, ListTodo, RotateCcw } from 'lucide-react';
 import { memo, useMemo } from 'react';

--- a/packages/builtin-tool-claude-code/src/client/Render/TodoWrite/index.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Render/TodoWrite/index.tsx
@@ -2,7 +2,8 @@
 
 import { TodoPanelHeader } from '@lobechat/shared-tool-ui/components';
 import type { BuiltinRenderProps } from '@lobechat/types';
-import { Block, Checkbox, Icon } from '@lobehub/ui';
+import { Block, Icon } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { CircleArrowRight } from 'lucide-react';
 import { memo, useMemo } from 'react';

--- a/packages/builtin-tool-lobe-agent/src/client/Intervention/ClearTodos.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Intervention/ClearTodos.tsx
@@ -2,8 +2,7 @@
 
 import type { BuiltinInterventionProps } from '@lobechat/types';
 import { Flexbox } from '@lobehub/ui';
-import type { RadioChangeEvent } from 'antd';
-import { Radio } from 'antd';
+import { RadioGroup } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import { Trash2 } from 'lucide-react';
 import { memo, useCallback, useState } from 'react';
@@ -43,8 +42,8 @@ const ClearTodosIntervention = memo<BuiltinInterventionProps<ClearTodosParams>>(
     const [mode, setMode] = useState<ClearTodosParams['mode']>(args?.mode || 'completed');
 
     const handleModeChange = useCallback(
-      async (e: RadioChangeEvent) => {
-        const newMode = e.target.value as ClearTodosParams['mode'];
+      async (value: string) => {
+        const newMode = value as ClearTodosParams['mode'];
         setMode(newMode);
         await onArgsChange?.({ mode: newMode });
       },
@@ -60,18 +59,28 @@ const ClearTodosIntervention = memo<BuiltinInterventionProps<ClearTodosParams>>(
 
         <Flexbox className={styles.container} gap={8}>
           <span className={styles.label}>{t('lobe-agent.clearTodos.label')}</span>
-          <Radio.Group value={mode} onChange={handleModeChange}>
-            <Flexbox gap={8}>
-              <Radio value="completed">
-                <span className={styles.normalText}>
-                  {t('lobe-agent.clearTodos.option.completed')}
-                </span>
-              </Radio>
-              <Radio value="all">
-                <span className={styles.dangerText}>{t('lobe-agent.clearTodos.option.all')}</span>
-              </Radio>
-            </Flexbox>
-          </Radio.Group>
+          <RadioGroup
+            gap={8}
+            horizontal={false}
+            value={mode}
+            options={[
+              {
+                label: (
+                  <span className={styles.normalText}>
+                    {t('lobe-agent.clearTodos.option.completed')}
+                  </span>
+                ),
+                value: 'completed',
+              },
+              {
+                label: (
+                  <span className={styles.dangerText}>{t('lobe-agent.clearTodos.option.all')}</span>
+                ),
+                value: 'all',
+              },
+            ]}
+            onChange={handleModeChange}
+          />
         </Flexbox>
       </Flexbox>
     );

--- a/packages/builtin-tool-lobe-agent/src/client/Render/TodoList/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Render/TodoList/index.tsx
@@ -2,7 +2,8 @@
 
 import { TodoPanelHeader } from '@lobechat/shared-tool-ui/components';
 import type { BuiltinRenderProps } from '@lobechat/types';
-import { Block, Checkbox, Icon } from '@lobehub/ui';
+import { Block, Icon } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { CircleArrowRight } from 'lucide-react';
 import { memo, useMemo } from 'react';

--- a/packages/builtin-tool-lobe-agent/src/client/components/SortableTodoList/AddItemRow.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/components/SortableTodoList/AddItemRow.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { ActionIcon, Checkbox, Flexbox, Input } from '@lobehub/ui';
+import { ActionIcon, Flexbox, Input } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
 import type { InputRef } from 'antd';
 import { createStaticStyles, cx } from 'antd-style';
 import { Plus } from 'lucide-react';

--- a/packages/builtin-tool-lobe-agent/src/client/components/SortableTodoList/TodoItemRow.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/components/SortableTodoList/TodoItemRow.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { ActionIcon, Checkbox, Flexbox, Icon, SortableList } from '@lobehub/ui';
+import { ActionIcon, Flexbox, Icon, SortableList } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
 import type { InputRef } from 'antd';
 import { Input } from 'antd';
 import { createStaticStyles, cssVar, cx } from 'antd-style';

--- a/packages/builtin-tool-web-browsing/src/client/components/SearchBar.tsx
+++ b/packages/builtin-tool-web-browsing/src/client/components/SearchBar.tsx
@@ -1,14 +1,7 @@
 import type { SearchQuery } from '@lobechat/types';
-import {
-  Block,
-  Checkbox,
-  Flexbox,
-  SearchBar as Search,
-  Segmented,
-  Select,
-  Text,
-  Tooltip,
-} from '@lobehub/ui';
+// eslint-disable-next-line no-restricted-imports -- Base Select does not support multiple selection yet.
+import { Block, Flexbox, SearchBar as Search, Select, Text, Tooltip } from '@lobehub/ui';
+import { CheckboxGroup, Segmented } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import type { ReactNode } from 'react';
 import { memo, useState } from 'react';
@@ -128,7 +121,7 @@ const SearchBar = memo<SearchBarProps>(
               <Text className={styles.textHeader} type={'secondary'}>
                 {t('search.searchEngine.title')}
               </Text>
-              <Checkbox.Group
+              <CheckboxGroup
                 value={engines}
                 options={Object.keys(ENGINE_ICON_MAP).map((item) => ({
                   label: (
@@ -177,7 +170,7 @@ const SearchBar = memo<SearchBarProps>(
               <Text className={styles.textHeader} type={'secondary'}>
                 {t('search.searchCategory.title')}
               </Text>
-              <Checkbox.Group
+              <CheckboxGroup
                 value={categories}
                 options={Object.keys(CATEGORY_ICON_MAP).map((item) => ({
                   label: (

--- a/src/components/ChatGroupWizard/ChatGroupWizard.tsx
+++ b/src/components/ChatGroupWizard/ChatGroupWizard.tsx
@@ -2,7 +2,6 @@
 
 import {
   Avatar,
-  Checkbox,
   Collapse,
   Empty,
   Flexbox,
@@ -12,7 +11,7 @@ import {
   Text,
   Tooltip,
 } from '@lobehub/ui';
-import { Button, Switch } from '@lobehub/ui/base-ui';
+import { Button, Checkbox, Switch } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { omit } from 'es-toolkit/compat';
 import { Users } from 'lucide-react';

--- a/src/components/DiscreteSlider/index.tsx
+++ b/src/components/DiscreteSlider/index.tsx
@@ -1,0 +1,156 @@
+import { Flexbox } from '@lobehub/ui';
+import { Slider, type SliderProps, Tooltip } from '@lobehub/ui/base-ui';
+import { createStaticStyles, cx } from 'antd-style';
+import type { CSSProperties, ReactNode } from 'react';
+import { memo, useMemo } from 'react';
+
+import { findClosestOptionIndex } from './utils';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  label: css`
+    cursor: pointer;
+
+    padding: 0;
+    border: none;
+
+    font: inherit;
+    font-size: 12px;
+    line-height: 16px;
+    color: ${cssVar.colorTextTertiary};
+    text-align: center;
+    overflow-wrap: anywhere;
+
+    background: transparent;
+
+    transition: color 0.2s ease;
+
+    &:hover {
+      color: ${cssVar.colorTextSecondary};
+    }
+
+    &:focus-visible {
+      border-radius: 6px;
+      outline: 1px solid ${cssVar.colorBorder};
+      outline-offset: 2px;
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+    }
+  `,
+  labels: css`
+    display: grid;
+    gap: 8px;
+    width: 100%;
+  `,
+  root: css`
+    width: 100%;
+  `,
+  selectedLabel: css`
+    color: ${cssVar.colorText};
+  `,
+  slider: css`
+    width: 100%;
+    padding-inline: 6px;
+  `,
+}));
+
+export interface DiscreteSliderOption {
+  ariaLabel?: string;
+  label: ReactNode;
+  style?: CSSProperties;
+  value: number;
+}
+
+export interface DiscreteSliderProps extends Omit<
+  SliderProps,
+  'defaultValue' | 'max' | 'min' | 'onChange' | 'onChangeComplete' | 'step' | 'value'
+> {
+  formatTooltip?: (value: number) => ReactNode;
+  onChange?: (value: number) => void;
+  onChangeComplete?: (value: number) => void;
+  options: readonly DiscreteSliderOption[];
+  value: number;
+}
+
+const DiscreteSlider = memo<DiscreteSliderProps>(
+  ({
+    className,
+    disabled,
+    formatTooltip,
+    onChange,
+    onChangeComplete,
+    options,
+    style,
+    value,
+    ...rest
+  }) => {
+    const currentIndex = useMemo(() => findClosestOptionIndex(options, value), [options, value]);
+    const currentOption = options[currentIndex];
+    const gridTemplateColumns =
+      options.length > 1
+        ? [
+            'minmax(0, 0.5fr)',
+            ...Array.from({ length: options.length - 2 }).fill('minmax(0, 1fr)'),
+            'minmax(0, 0.5fr)',
+          ].join(' ')
+        : 'minmax(0, 1fr)';
+
+    const slider = (
+      <div className={styles.slider}>
+        <Slider
+          {...rest}
+          disabled={disabled || options.length === 0}
+          max={Math.max(0, options.length - 1)}
+          min={0}
+          step={1}
+          value={currentIndex}
+          onChange={(index) => {
+            const option = options[index];
+            if (option) onChange?.(option.value);
+          }}
+          onChangeComplete={(index) => {
+            const option = options[index];
+            if (option) onChangeComplete?.(option.value);
+          }}
+        />
+      </div>
+    );
+
+    return (
+      <Flexbox className={cx(styles.root, className)} gap={6} style={style}>
+        {formatTooltip && currentOption ? (
+          <Tooltip title={formatTooltip(currentOption.value)}>{slider}</Tooltip>
+        ) : (
+          slider
+        )}
+        <div className={styles.labels} style={{ gridTemplateColumns }}>
+          {options.map((option, index) => {
+            const isFirst = index === 0;
+            const isLast = index === options.length - 1;
+            const textAlign = isFirst === isLast ? 'center' : isFirst ? 'start' : 'end';
+
+            return (
+              <button
+                aria-current={index === currentIndex ? 'true' : undefined}
+                aria-label={option.ariaLabel}
+                className={cx(styles.label, index === currentIndex && styles.selectedLabel)}
+                disabled={disabled}
+                key={option.value}
+                style={{ textAlign, ...option.style }}
+                type={'button'}
+                onClick={() => onChange?.(option.value)}
+              >
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+      </Flexbox>
+    );
+  },
+);
+
+DiscreteSlider.displayName = 'DiscreteSlider';
+
+export default DiscreteSlider;

--- a/src/components/DiscreteSlider/utils.test.ts
+++ b/src/components/DiscreteSlider/utils.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { findClosestOptionIndex } from './utils';
+
+const options = [{ value: 10 }, { value: 50 }, { value: 100 }];
+
+describe('findClosestOptionIndex', () => {
+  it('maps an intermediate value to its nearest option', () => {
+    expect(findClosestOptionIndex(options, 72)).toBe(1);
+  });
+
+  it('uses the first option for non-finite values', () => {
+    expect(findClosestOptionIndex(options, Number.NaN)).toBe(0);
+  });
+});

--- a/src/components/DiscreteSlider/utils.ts
+++ b/src/components/DiscreteSlider/utils.ts
@@ -1,0 +1,18 @@
+interface NumericOption {
+  value: number;
+}
+
+export const findClosestOptionIndex = (
+  options: readonly NumericOption[],
+  value: number,
+): number => {
+  if (options.length === 0) return 0;
+  if (!Number.isFinite(value)) return 0;
+
+  return options.reduce((closestIndex, option, index) => {
+    const closestDistance = Math.abs(options[closestIndex].value - value);
+    const distance = Math.abs(option.value - value);
+
+    return distance < closestDistance ? index : closestIndex;
+  }, 0);
+};

--- a/src/components/FormInput/FormSliderWithInput.tsx
+++ b/src/components/FormInput/FormSliderWithInput.tsx
@@ -1,5 +1,4 @@
-import { type SliderWithInputProps } from '@lobehub/ui';
-import { SliderWithInput } from '@lobehub/ui';
+import { SliderWithInput, type SliderWithInputProps } from '@lobehub/ui/base-ui';
 import { memo, useEffect, useState } from 'react';
 
 interface FormSliderWithInputProps extends Omit<SliderWithInputProps, 'onChange' | 'value'> {

--- a/src/components/JSONSchemaConfig/ItemRender.tsx
+++ b/src/components/JSONSchemaConfig/ItemRender.tsx
@@ -1,6 +1,5 @@
 import { Input, InputNumber, InputPassword } from '@lobehub/ui';
-import { Select, Switch } from '@lobehub/ui/base-ui';
-import { Slider } from 'antd';
+import { Select, Slider, Switch } from '@lobehub/ui/base-ui';
 import { type JSONSchema7Type } from 'json-schema';
 import { memo } from 'react';
 

--- a/src/components/MCPStdioCommandInput/index.tsx
+++ b/src/components/MCPStdioCommandInput/index.tsx
@@ -6,8 +6,8 @@ import {
   SiPnpm,
   SiPython,
 } from '@icons-pack/react-simple-icons';
-import { type AutoCompleteProps } from '@lobehub/ui';
-import { AutoComplete, Flexbox } from '@lobehub/ui';
+import { Flexbox } from '@lobehub/ui';
+import { AutoComplete, type AutoCompleteProps } from '@lobehub/ui/base-ui';
 import { type FC } from 'react';
 import { memo } from 'react';
 

--- a/src/components/MaxTokenSlider.tsx
+++ b/src/components/MaxTokenSlider.tsx
@@ -1,10 +1,11 @@
 import { Flexbox, InputNumber } from '@lobehub/ui';
-import { Slider } from 'antd';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import useMergeState from 'use-merge-value';
 
 import { useIsMobile } from '@/hooks/useIsMobile';
+
+import DiscreteSlider from './DiscreteSlider';
 
 const Kibi = 1024;
 
@@ -46,40 +47,35 @@ const MaxTokenSlider = memo<MaxTokenSliderProps>(({ value, onChange, defaultValu
 
   const isMobile = useIsMobile();
 
-  const marks = useMemo(() => {
-    return {
-      [exponent(2)]: '0',
-      [exponent(4)]: isMobile ? '4' : '4K', // 4 Kibi = 4096
-      [exponent(8)]: isMobile ? '8' : '8K',
-      [exponent(16)]: isMobile ? '16' : '16K',
-      [exponent(32)]: isMobile ? '32' : '32K',
-      [exponent(64)]: isMobile ? '64' : '64K',
-      [exponent((128 / Kibi) * 1000)]: ' ', // hide tick mark
-      [exponent((200 / Kibi) * 1000)]: isMobile ? '200' : '200k', // 200,000
-      [exponent(Kibi)]: '1M',
-      [exponent(2 * Kibi)]: '2M',
-    };
-  }, [isMobile]);
+  const options = useMemo(
+    () => [
+      { label: '0', value: exponent(2) },
+      { label: isMobile ? '4' : '4K', value: exponent(4) }, // 4 Kibi = 4096
+      { label: isMobile ? '8' : '8K', value: exponent(8) },
+      { label: isMobile ? '16' : '16K', value: exponent(16) },
+      { label: isMobile ? '32' : '32K', value: exponent(32) },
+      { label: isMobile ? '64' : '64K', value: exponent(64) },
+      { ariaLabel: '128k', label: ' ', value: exponent((128 / Kibi) * 1000) }, // hide tick label
+      { label: isMobile ? '200' : '200k', value: exponent((200 / Kibi) * 1000) },
+      { label: '1M', value: exponent(Kibi) },
+      { label: '2M', value: exponent(2 * Kibi) },
+    ],
+    [isMobile],
+  );
 
   return (
     <Flexbox horizontal align={'center'} gap={12}>
       <Flexbox flex={1}>
-        <Slider
-          marks={marks}
-          max={exponent(2 * Kibi)}
-          min={exponent(2)}
-          step={null}
+        <DiscreteSlider
+          options={options}
           value={powValue}
-          tooltip={{
-            formatter: (x) => {
-              if (typeof x === 'undefined') return;
-              if (x <= exponent(2)) return t('MaxTokenSlider.unlimited');
+          formatTooltip={(sliderValue) => {
+            if (sliderValue <= exponent(2)) return t('MaxTokenSlider.unlimited');
 
-              const value = getRealValue(x);
-              if (value < 125) return value.toFixed(0) + 'K';
-              else if (value < Kibi) return ((value * Kibi) / 1000).toFixed(0) + 'k';
-              return (value / Kibi).toFixed(0) + 'M';
-            },
+            const realValue = getRealValue(sliderValue);
+            if (realValue < 125) return realValue.toFixed(0) + 'K';
+            if (realValue < Kibi) return ((realValue * Kibi) / 1000).toFixed(0) + 'k';
+            return (realValue / Kibi).toFixed(0) + 'M';
           }}
           onChange={updateWithPowValue}
         />

--- a/src/components/MemberSelectionModal/MemberSelectionModal.tsx
+++ b/src/components/MemberSelectionModal/MemberSelectionModal.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { agentDisplayName } from '@lobechat/types';
-import { ActionIcon, Avatar, Checkbox, Flexbox, List, SearchBar, Text, Tooltip } from '@lobehub/ui';
-import { Button, Switch } from '@lobehub/ui/base-ui';
+import { ActionIcon, Avatar, Flexbox, List, SearchBar, Text, Tooltip } from '@lobehub/ui';
+import { Button, Checkbox, Switch } from '@lobehub/ui/base-ui';
 import { useHover } from 'ahooks';
 import { List as AntdList } from 'antd';
 import { createStaticStyles, cx } from 'antd-style';

--- a/src/features/AgentTasks/AgentTaskDetail/scheduler/SchedulerForm.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/scheduler/SchedulerForm.tsx
@@ -1,5 +1,5 @@
-import { Accordion, AccordionItem, Checkbox, Flexbox, Icon, InputNumber, Text } from '@lobehub/ui';
-import { Select } from '@lobehub/ui/base-ui';
+import { Accordion, AccordionItem, Flexbox, Icon, InputNumber, Text } from '@lobehub/ui';
+import { Checkbox, Select } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import dayjs, { type Dayjs } from 'dayjs';
 import { Globe, Hash, SlidersHorizontal } from 'lucide-react';

--- a/src/features/AgentTopicManager/TopicCard.tsx
+++ b/src/features/AgentTopicManager/TopicCard.tsx
@@ -2,7 +2,8 @@
 
 import { AGENT_CHAT_TOPIC_URL } from '@lobechat/const';
 import { formatPrice, formatTokenNumber } from '@lobechat/utils/format';
-import { Block, Checkbox, Flexbox, Icon, Tag, Text } from '@lobehub/ui';
+import { Block, Flexbox, Icon, Tag, Text } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { CircleDollarSign, FolderIcon, MessageSquare, Star, Zap } from 'lucide-react';
 import { memo, type MouseEvent, useCallback } from 'react';

--- a/src/features/AgentTopicManager/TopicListView.tsx
+++ b/src/features/AgentTopicManager/TopicListView.tsx
@@ -2,7 +2,8 @@
 
 import { AGENT_CHAT_TOPIC_URL } from '@lobechat/const';
 import type { GroupedTopic } from '@lobechat/types';
-import { ActionIcon, Checkbox, DropdownMenu, Flexbox, Icon, Tag, Text } from '@lobehub/ui';
+import { ActionIcon, DropdownMenu, Flexbox, Icon, Tag, Text } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { FolderIcon, MoreHorizontal, Star } from 'lucide-react';
 import { Fragment, memo, type MouseEvent, useCallback } from 'react';

--- a/src/features/ChatInput/ActionBar/History/Controls.tsx
+++ b/src/features/ChatInput/ActionBar/History/Controls.tsx
@@ -1,6 +1,6 @@
 import { type FormItemProps } from '@lobehub/ui';
-import { Form, SliderWithInput } from '@lobehub/ui';
-import { Switch } from '@lobehub/ui/base-ui';
+import { Form } from '@lobehub/ui';
+import { SliderWithInput, Switch } from '@lobehub/ui/base-ui';
 import { Form as AntdForm } from 'antd';
 import { debounce } from 'es-toolkit/compat';
 import { useEffect, useMemo, useState } from 'react';

--- a/src/features/ChatInput/ActionBar/Params/Controls.tsx
+++ b/src/features/ChatInput/ActionBar/Params/Controls.tsx
@@ -4,8 +4,8 @@ import {
   resolveSubAgentModel,
 } from '@lobechat/const';
 import { resolveEffectiveReasoningChatConfig } from '@lobechat/model-runtime/utils/modelExtendParams';
-import { Flexbox, Icon, SliderWithInput, TextArea } from '@lobehub/ui';
-import { Select, Switch } from '@lobehub/ui/base-ui';
+import { Flexbox, Icon, TextArea } from '@lobehub/ui';
+import { Select, SliderWithInput, Switch } from '@lobehub/ui/base-ui';
 import { Form as AntdForm } from 'antd';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { debounce } from 'es-toolkit/compat';

--- a/src/features/ChatInput/ActionBar/Tools/ComposioServerItem.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/ComposioServerItem.tsx
@@ -1,4 +1,5 @@
-import { Checkbox, Flexbox, Icon, stopPropagation } from '@lobehub/ui';
+import { Flexbox, Icon, stopPropagation } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
 import { Loader2, SquareArrowOutUpRight } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/features/ChatInput/ActionBar/Tools/LobehubSkillServerItem.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/LobehubSkillServerItem.tsx
@@ -1,4 +1,5 @@
-import { Checkbox, Flexbox, Icon, stopPropagation } from '@lobehub/ui';
+import { Flexbox, Icon, stopPropagation } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
 import { Loader2, SquareArrowOutUpRight } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/features/ChatInput/ActionBar/components/CheckboxWithLoading.tsx
+++ b/src/features/ChatInput/ActionBar/components/CheckboxWithLoading.tsx
@@ -1,4 +1,5 @@
-import { Center, Checkbox, Flexbox, Icon } from '@lobehub/ui';
+import { Center, Flexbox, Icon } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
 import { Loader2 } from 'lucide-react';
 import { type CSSProperties, type ReactNode } from 'react';
 import { memo, useState } from 'react';

--- a/src/features/ConnectAgent/index.tsx
+++ b/src/features/ConnectAgent/index.tsx
@@ -12,12 +12,13 @@ import { agentDisplayName } from '@lobechat/types';
 import { Alert, CopyButton, Flexbox, Icon, Input, Text, TextArea, Tooltip } from '@lobehub/ui';
 import {
   Button,
+  Checkbox,
   createModal,
   type ModalInstance,
   ScrollArea,
   useModalContext,
 } from '@lobehub/ui/base-ui';
-import { Checkbox, Typography } from 'antd';
+import { Typography } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { t as i18nT } from 'i18next';
 import {

--- a/src/features/Conversation/TodoProgress/index.tsx
+++ b/src/features/Conversation/TodoProgress/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { type StepContextTodos } from '@lobechat/types';
-import { Checkbox, Flexbox, Icon, Tag } from '@lobehub/ui';
+import { Flexbox, Icon, Tag } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { ChevronDown, ChevronUp, CircleArrowRight } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';

--- a/src/features/Conversation/WorkingSidebar/ProgressSection/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/ProgressSection/index.tsx
@@ -1,4 +1,5 @@
-import { Checkbox, Flexbox, Icon } from '@lobehub/ui';
+import { Flexbox, Icon } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { ChevronDown, ChevronUp, CircleArrowRight } from 'lucide-react';
 import { type KeyboardEvent, memo, useCallback, useId, useMemo, useState } from 'react';

--- a/src/features/DesktopOnboarding/steps/DataModeStep.tsx
+++ b/src/features/DesktopOnboarding/steps/DataModeStep.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Block, Checkbox, Empty, Flexbox, Text } from '@lobehub/ui';
-import { Button } from '@lobehub/ui/base-ui';
+import { Block, Empty, Flexbox, Text } from '@lobehub/ui';
+import { Button, Checkbox } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { HeartHandshake, Undo2Icon } from 'lucide-react';
 import { memo, useCallback, useState } from 'react';

--- a/src/features/HeteroSessionImport/Content.tsx
+++ b/src/features/HeteroSessionImport/Content.tsx
@@ -7,8 +7,8 @@ import type {
   HeteroSessionImportStatus,
 } from '@lobechat/types';
 import { Flexbox, Icon, NeuralNetworkLoading, ScrollShadow, SearchBar, Text } from '@lobehub/ui';
-import { Button, useModalContext } from '@lobehub/ui/base-ui';
-import { Checkbox, Progress } from 'antd';
+import { Button, Checkbox, useModalContext } from '@lobehub/ui/base-ui';
+import { Progress } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { Check, FolderSearch, TriangleAlert, X } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -293,16 +293,13 @@ const Content = memo<ContentProps>(({ agentId }) => {
                 <Checkbox
                   checked={allChecked}
                   indeterminate={!allChecked && someChecked}
-                  onChange={(e) => toggleAll(e.target.checked)}
+                  onChange={toggleAll}
                 >
                   <Text fontSize={13} type="secondary">
                     {t('heteroImport.selectAll')}
                   </Text>
                 </Checkbox>
-                <Checkbox
-                  checked={hideImported}
-                  onChange={(e) => setHideImported(e.target.checked)}
-                >
+                <Checkbox checked={hideImported} onChange={setHideImported}>
                   <Text fontSize={13} type="secondary">
                     {t('heteroImport.hideImported')}
                   </Text>

--- a/src/features/HeteroSessionImport/SessionList.tsx
+++ b/src/features/HeteroSessionImport/SessionList.tsx
@@ -1,8 +1,7 @@
 import type { HeteroSessionDigest } from '@lobechat/types';
 import { ClaudeCode, Codex } from '@lobehub/icons';
 import { Flexbox, Icon, NeuralNetworkLoading, Tag, Text, Tooltip } from '@lobehub/ui';
-import { Button } from '@lobehub/ui/base-ui';
-import { Checkbox } from 'antd';
+import { Button, Checkbox } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';
 import dayjs from 'dayjs';
 import { Check, RotateCcw, X } from 'lucide-react';

--- a/src/features/ModelSwitchPanel/components/ControlsForm/LevelSlider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/LevelSlider.tsx
@@ -1,6 +1,5 @@
 import { Flexbox } from '@lobehub/ui';
-import { Slider } from 'antd';
-import type { SliderSingleProps } from 'antd/es/slider';
+import { Slider } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';
 import type { CSSProperties, ReactNode } from 'react';
 import { memo, useMemo } from 'react';
@@ -48,41 +47,10 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   slider: css`
     width: 100%;
     padding-inline: 6px;
-
-    .ant-slider {
-      margin-block: 2px 0;
-      margin-inline: 0;
-    }
-
-    .ant-slider-rail {
-      background: ${cssVar.colorFillQuaternary};
-    }
-
-    .ant-slider-track {
-      background: ${cssVar.colorTextSecondary};
-    }
-
-    .ant-slider-dot {
-      border-color: ${cssVar.colorTextTertiary};
-      background: ${cssVar.colorBgElevated};
-    }
-
-    .ant-slider-dot-active {
-      border-color: ${cssVar.colorTextSecondary};
-    }
-
-    .ant-slider-handle::after {
-      background: ${cssVar.colorBgElevated};
-      box-shadow: 0 0 0 2px ${cssVar.colorTextSecondary};
-    }
-
-    .ant-slider-handle:hover::after,
-    .ant-slider-handle:focus::after,
-    .ant-slider-handle:active::after {
-      box-shadow: 0 0 0 3px ${cssVar.colorTextSecondary};
-    }
   `,
 }));
+
+export type LevelSliderMark = ReactNode | { label?: ReactNode; style?: CSSProperties };
 
 export interface LevelSliderProps<T extends string = string> {
   /**
@@ -97,7 +65,7 @@ export interface LevelSliderProps<T extends string = string> {
   /**
    * Optional custom marks. If not provided, uses level values as marks.
    */
-  marks?: SliderSingleProps['marks'];
+  marks?: Record<number, LevelSliderMark>;
   /**
    * Callback when value changes
    */
@@ -129,7 +97,7 @@ const getMinimumWidth = (levelCount: number, customMinWidth: CSSProperties['minW
 };
 
 const resolveMark = (
-  mark: NonNullable<SliderSingleProps['marks']>[number] | undefined,
+  mark: LevelSliderMark | undefined,
   fallback: string,
 ): { label: ReactNode; style?: CSSProperties } => {
   if (!mark) return { label: fallback };
@@ -209,12 +177,10 @@ function LevelSlider<T extends string = string>({
     >
       <div className={styles.slider}>
         <Slider
-          dots
           disabled={disabled}
           max={levels.length - 1}
           min={0}
           step={1}
-          tooltip={{ open: false }}
           value={sliderValue}
           onChange={handleChange}
         />

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ReasoningTokenSlider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ReasoningTokenSlider.tsx
@@ -1,7 +1,8 @@
 import { Flexbox, InputNumber } from '@lobehub/ui';
-import { Slider } from 'antd';
 import { memo, useMemo } from 'react';
 import useMergeState from 'use-merge-value';
+
+import DiscreteSlider from '@/components/DiscreteSlider';
 
 const Kibi = 1024;
 const MAX_VALUE = 64 * Kibi; // 65536
@@ -39,17 +40,10 @@ const ReasoningTokenSlider = memo<MaxTokenSliderProps>(({ value, onChange, defau
     setPowValue(exponent(value / Kibi));
   };
 
-  const marks = useMemo(() => {
-    return {
-      [exponent(1)]: '1k',
-      [exponent(2)]: '2k',
-      [exponent(4)]: '4k', // 4 kibi = 4096
-      [exponent(8)]: '8k',
-      [exponent(16)]: '16k',
-      [exponent(32)]: '32k',
-      [exponent(64)]: '64k',
-    };
-  }, []);
+  const options = useMemo(
+    () => [1, 2, 4, 8, 16, 32, 64].map((item) => ({ label: `${item}k`, value: exponent(item) })),
+    [],
+  );
 
   const step = useMemo(() => {
     const current = token ?? 0;
@@ -64,15 +58,7 @@ const ReasoningTokenSlider = memo<MaxTokenSliderProps>(({ value, onChange, defau
   return (
     <Flexbox horizontal align={'center'} gap={12} paddingInline={'4px 0'}>
       <Flexbox flex={1}>
-        <Slider
-          marks={marks}
-          max={exponent(64)}
-          min={exponent(1)}
-          step={null}
-          tooltip={{ open: false }}
-          value={powValue}
-          onChange={updateWithPowValue}
-        />
+        <DiscreteSlider options={options} value={powValue} onChange={updateWithPowValue} />
       </Flexbox>
       <div>
         <InputNumber

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ReasoningTokenSlider32k.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ReasoningTokenSlider32k.tsx
@@ -1,7 +1,8 @@
 import { Flexbox, InputNumber } from '@lobehub/ui';
-import { Slider } from 'antd';
 import { memo, useMemo } from 'react';
 import useMergeState from 'use-merge-value';
+
+import DiscreteSlider from '@/components/DiscreteSlider';
 
 const Kibi = 1024;
 const MAX_VALUE = 32 * Kibi; // 32768
@@ -37,15 +38,10 @@ const ReasoningTokenSlider32k = memo<ReasoningTokenSlider32kProps>(
       value: typeof value === 'undefined' ? 0 : tokenToIndex(value),
     });
 
-    const marks = useMemo(() => {
-      return MARK_TOKENS.reduce(
-        (acc, token, index) => {
-          acc[index] = `${token}k`;
-          return acc;
-        },
-        {} as Record<number, string>,
-      );
-    }, []);
+    const options = useMemo(
+      () => MARK_TOKENS.map((token, index) => ({ label: `${token}k`, value: index })),
+      [],
+    );
 
     const step = useMemo(() => {
       const current = token ?? 0;
@@ -60,12 +56,8 @@ const ReasoningTokenSlider32k = memo<ReasoningTokenSlider32kProps>(
     return (
       <Flexbox horizontal align={'center'} gap={12} paddingInline={'4px 0'}>
         <Flexbox flex={1} style={{ minWidth: 200, maxWidth: 320 }}>
-          <Slider
-            marks={marks}
-            max={MARK_TOKENS.length - 1}
-            min={0}
-            step={null}
-            tooltip={{ open: false }}
+          <DiscreteSlider
+            options={options}
             value={sliderIndex}
             onChange={(v) => {
               setSliderIndex(v);

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ReasoningTokenSlider80k.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ReasoningTokenSlider80k.tsx
@@ -1,7 +1,8 @@
 import { Flexbox, InputNumber } from '@lobehub/ui';
-import { Slider } from 'antd';
 import { memo, useMemo } from 'react';
 import useMergeState from 'use-merge-value';
+
+import DiscreteSlider from '@/components/DiscreteSlider';
 
 const Kibi = 1024;
 const MAX_VALUE = 80 * Kibi; // 81920
@@ -37,15 +38,10 @@ const ReasoningTokenSlider80k = memo<ReasoningTokenSlider80kProps>(
       value: typeof value === 'undefined' ? 0 : tokenToIndex(value),
     });
 
-    const marks = useMemo(() => {
-      return MARK_TOKENS.reduce(
-        (acc, token, index) => {
-          acc[index] = `${token}k`;
-          return acc;
-        },
-        {} as Record<number, string>,
-      );
-    }, []);
+    const options = useMemo(
+      () => MARK_TOKENS.map((token, index) => ({ label: `${token}k`, value: index })),
+      [],
+    );
 
     const step = useMemo(() => {
       const current = token ?? 0;
@@ -60,12 +56,8 @@ const ReasoningTokenSlider80k = memo<ReasoningTokenSlider80kProps>(
     return (
       <Flexbox horizontal align={'center'} gap={12} paddingInline={'4px 0'}>
         <Flexbox flex={1} style={{ minWidth: 200, maxWidth: 320 }}>
-          <Slider
-            marks={marks}
-            max={MARK_TOKENS.length - 1}
-            min={0}
-            step={null}
-            tooltip={{ open: false }}
+          <DiscreteSlider
+            options={options}
             value={sliderIndex}
             onChange={(v) => {
               setSliderIndex(v);

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingBudgetSlider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ThinkingBudgetSlider.tsx
@@ -1,7 +1,8 @@
 import { Flexbox, InputNumber } from '@lobehub/ui';
-import { Slider } from 'antd';
 import { memo, useMemo } from 'react';
 import useMergeState from 'use-merge-value';
+
+import DiscreteSlider from '@/components/DiscreteSlider';
 
 // Define special value mappings
 const SPECIAL_VALUES = {
@@ -89,31 +90,19 @@ const ThinkingBudgetSlider = memo<ThinkingBudgetSliderProps>(
 
     const inputStep = useMemo(() => getStepForValue(budget), [budget]);
 
-    const marks = useMemo(() => {
-      return {
-        0: 'Auto',
-        1: 'OFF',
-        2: '128',
-        3: '512',
-        4: '1K',
-        5: '2K',
-        6: '4K',
-        7: '8K',
-        8: '16K',
-        9: '24K',
-        10: '32K',
-      };
-    }, []);
+    const options = useMemo(
+      () =>
+        ['Auto', 'OFF', '128', '512', '1K', '2K', '4K', '8K', '16K', '24K', '32K'].map(
+          (label, value) => ({ label, value }),
+        ),
+      [],
+    );
 
     return (
       <Flexbox horizontal align={'center'} gap={12} paddingInline={'4px 0'}>
         <Flexbox flex={1}>
-          <Slider
-            marks={marks}
-            max={10}
-            min={0}
-            step={null}
-            tooltip={{ open: false }}
+          <DiscreteSlider
+            options={options}
             value={sliderPosition}
             onChange={updateWithSliderPosition}
           />

--- a/src/features/ModelSwitchPanel/components/ControlsForm/createLevelSlider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/createLevelSlider.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { LobeAgentChatConfig } from '@lobechat/types';
-import type { SliderSingleProps } from 'antd/es/slider';
 import type { CSSProperties } from 'react';
 import { memo } from 'react';
 
@@ -10,7 +9,7 @@ import { useUpdateAgentConfig } from '@/features/ChatInput/hooks/useUpdateAgentC
 import { useAgentStore } from '@/store/agent';
 import { chatConfigByIdSelectors } from '@/store/agent/selectors';
 
-import LevelSlider from './LevelSlider';
+import LevelSlider, { type LevelSliderMark } from './LevelSlider';
 
 export interface LevelSliderConfig<T extends string> {
   /**
@@ -28,7 +27,7 @@ export interface LevelSliderConfig<T extends string> {
   /**
    * Optional custom marks for the slider
    */
-  marks?: SliderSingleProps['marks'];
+  marks?: Record<number, LevelSliderMark>;
   /**
    * Optional style for the slider container
    */

--- a/src/features/Portal/Document/TodoList.tsx
+++ b/src/features/Portal/Document/TodoList.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { AGENT_PLAN_FILE_TYPE } from '@lobechat/const';
-import { Checkbox, Flexbox, Icon, Tag } from '@lobehub/ui';
+import { Flexbox, Icon, Tag } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { ChevronDown, ChevronUp, ListTodo } from 'lucide-react';
 import { memo, useState } from 'react';

--- a/src/features/ResourceManager/components/Explorer/ListView/ListItem/index.test.tsx
+++ b/src/features/ResourceManager/components/Explorer/ListView/ListItem/index.test.tsx
@@ -153,6 +153,6 @@ describe('FileListItem', () => {
   it('disables selection for rows the workspace member did not upload', () => {
     render(<FileListItem {...baseProps} selectable={false} />);
 
-    expect(screen.getByRole('checkbox')).toBeDisabled();
+    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-disabled', 'true');
   });
 });

--- a/src/features/ResourceManager/components/Explorer/ListView/ListItem/index.tsx
+++ b/src/features/ResourceManager/components/Explorer/ListView/ListItem/index.tsx
@@ -1,4 +1,5 @@
-import { Avatar, Center, Checkbox, ContextMenuTrigger, Flexbox, Tooltip } from '@lobehub/ui';
+import { Avatar, Center, ContextMenuTrigger, Flexbox, Tooltip } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { isEqual } from 'es-toolkit';
 import { memo, useCallback } from 'react';

--- a/src/features/ResourceManager/components/Explorer/ListView/ListViewHeader.tsx
+++ b/src/features/ResourceManager/components/Explorer/ListView/ListViewHeader.tsx
@@ -1,4 +1,5 @@
-import { Center, Checkbox, Flexbox } from '@lobehub/ui';
+import { Center, Flexbox } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/features/ResourceManager/components/Explorer/ListView/Skeleton.tsx
+++ b/src/features/ResourceManager/components/Explorer/ListView/Skeleton.tsx
@@ -1,4 +1,5 @@
-import { Center, Checkbox, Flexbox, Skeleton } from '@lobehub/ui';
+import { Center, Flexbox, Skeleton } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 
 import { FILE_DATE_WIDTH, FILE_SIZE_WIDTH, getListViewMinWidth } from './ListItem/constants';

--- a/src/features/ResourceManager/components/Explorer/MasonryView/MasonryItem/index.tsx
+++ b/src/features/ResourceManager/components/Explorer/MasonryView/MasonryItem/index.tsx
@@ -3,7 +3,8 @@ import {
   CUSTOM_FOLDER_FILE_TYPE,
   MARKDOWN_MIME_TYPES,
 } from '@lobechat/const';
-import { Checkbox, stopPropagation } from '@lobehub/ui';
+import { stopPropagation } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/features/ResourceManager/components/Explorer/MasonryView/index.tsx
+++ b/src/features/ResourceManager/components/Explorer/MasonryView/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Center, Checkbox, Flexbox } from '@lobehub/ui';
-import { Button } from '@lobehub/ui/base-ui';
+import { Center, Flexbox } from '@lobehub/ui';
+import { Button, Checkbox } from '@lobehub/ui/base-ui';
 import { VirtuosoMasonry } from '@virtuoso.dev/masonry';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { type UIEvent } from 'react';

--- a/src/features/ResourceManager/components/Explorer/SearchResultsOverlay.tsx
+++ b/src/features/ResourceManager/components/Explorer/SearchResultsOverlay.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Center, Checkbox, Flexbox } from '@lobehub/ui';
+import { Center, Flexbox } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
 import { VirtuosoMasonry } from '@virtuoso.dev/masonry';
 import { cssVar } from 'antd-style';
 import { SearchIcon } from 'lucide-react';

--- a/src/features/Settings/apikey/features/ApiKey.test.tsx
+++ b/src/features/Settings/apikey/features/ApiKey.test.tsx
@@ -38,6 +38,27 @@ vi.mock('@lobehub/ui/base-ui', () => {
     Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
       <button {...props}>{children}</button>
     ),
+    Checkbox: ({
+      checked,
+      children,
+      disabled,
+      onChange,
+    }: {
+      checked?: boolean;
+      children?: ReactNode;
+      disabled?: boolean;
+      onChange?: (checked: boolean) => void;
+    }) => (
+      <label>
+        <input
+          checked={checked}
+          disabled={disabled}
+          type="checkbox"
+          onChange={(event) => onChange?.(event.currentTarget.checked)}
+        />
+        {children}
+      </label>
+    ),
     Drawer: ({
       children,
       onClose,

--- a/src/features/Settings/apikey/features/ApiKeyModal/ScopeSelector.tsx
+++ b/src/features/Settings/apikey/features/ApiKeyModal/ScopeSelector.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { Flexbox, Text } from '@lobehub/ui';
-import { Switch } from '@lobehub/ui/base-ui';
-import { Checkbox } from 'antd';
+import { Checkbox, Switch } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import { Check } from 'lucide-react';
 import type { FC } from 'react';
@@ -217,7 +216,7 @@ const ScopeSelector: FC<ScopeSelectorProps> = ({
                   <Checkbox
                     checked={selectedSet.has(group.read)}
                     disabled={fullAccess}
-                    onChange={(e) => toggle(group.read, e.target.checked)}
+                    onChange={(checked) => toggle(group.read, checked)}
                   >
                     {t('apikey.scopes.read')}
                   </Checkbox>
@@ -225,7 +224,7 @@ const ScopeSelector: FC<ScopeSelectorProps> = ({
                     <Checkbox
                       checked={selectedSet.has(group.write)}
                       disabled={fullAccess}
-                      onChange={(e) => group.write && toggle(group.write, e.target.checked)}
+                      onChange={(checked) => group.write && toggle(group.write, checked)}
                     >
                       {t('apikey.scopes.write')}
                     </Checkbox>
@@ -234,7 +233,7 @@ const ScopeSelector: FC<ScopeSelectorProps> = ({
                     <Checkbox
                       checked={selectedSet.has('model:invoke')}
                       disabled={fullAccess}
-                      onChange={(e) => toggle('model:invoke', e.target.checked)}
+                      onChange={(checked) => toggle('model:invoke', checked)}
                     >
                       {t('apikey.scopes.modelInvoke')}
                     </Checkbox>

--- a/src/features/Settings/chat-appearance/features/ChatAppearance/index.tsx
+++ b/src/features/Settings/chat-appearance/features/ChatAppearance/index.tsx
@@ -1,18 +1,12 @@
 'use client';
 
-import {
-  Flexbox,
-  FormGroup,
-  highlighterThemes,
-  mermaidThemes,
-  Skeleton,
-  SliderWithInput,
-} from '@lobehub/ui';
-import { Select, Switch, Tabs } from '@lobehub/ui/base-ui';
+import { Flexbox, FormGroup, highlighterThemes, mermaidThemes, Skeleton } from '@lobehub/ui';
+import { InputNumber, Select, Switch, Tabs } from '@lobehub/ui/base-ui';
 import isEqual from 'fast-deep-equal';
-import { memo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import DiscreteSlider from '@/components/DiscreteSlider';
 import AutoSaveHint from '@/components/Editor/AutoSaveHint';
 import { SettingsSearchAnchor } from '@/features/SettingsSearch/anchor';
 import { useSaveState } from '@/hooks/useSaveState';
@@ -31,6 +25,27 @@ const ChatAppearance = memo(() => {
   const [setSettings, isUserStateInit] = useUserStore((s) => [s.setSettings, s.isUserStateInit]);
   const { status: saveStatus, lastSavedAt, save, retry } = useSaveState();
   const [savingKey, setSavingKey] = useState<string>();
+  const fontSizeOptions = useMemo(
+    () =>
+      Array.from({ length: 7 }, (_, index) => {
+        const value = index + 12;
+
+        return {
+          ariaLabel: `${value}px`,
+          label:
+            value === 12
+              ? 'A'
+              : value === 14
+                ? t('settingChatAppearance.fontSize.marks.normal')
+                : value === 18
+                  ? 'A'
+                  : ' ',
+          style: { fontSize: value === 14 ? 14 : value },
+          value,
+        };
+      }),
+    [t],
+  );
 
   if (!isUserStateInit) return <Skeleton active paragraph={{ rows: 5 }} title={false} />;
 
@@ -122,39 +137,24 @@ const ChatAppearance = memo(() => {
         extra={
           <Flexbox horizontal align={'center'} gap={8}>
             {renderSaveHint('fontSize')}
-            <SliderWithInput
-              max={18}
-              min={12}
-              step={1}
-              value={general.fontSize}
-              marks={{
-                12: {
-                  label: 'A',
-                  style: {
-                    fontSize: 12,
-                    marginTop: 4,
-                  },
-                },
-                14: {
-                  label: t('settingChatAppearance.fontSize.marks.normal'),
-                  style: {
-                    fontSize: 14,
-                    marginTop: 4,
-                  },
-                },
-                18: {
-                  label: 'A',
-                  style: {
-                    fontSize: 18,
-                    marginTop: 4,
-                  },
-                },
-              }}
-              style={{
-                width: 240,
-              }}
-              onChange={(value) => handleChange('fontSize', value)}
-            />
+            <Flexbox horizontal align={'center'} gap={12} style={{ width: 240 }}>
+              <DiscreteSlider
+                options={fontSizeOptions}
+                style={{ flex: 1 }}
+                value={general.fontSize}
+                onChange={(value) => handleChange('fontSize', value)}
+              />
+              <InputNumber
+                max={18}
+                min={12}
+                step={1}
+                style={{ width: 56 }}
+                value={general.fontSize}
+                onChange={(value) => {
+                  if (value !== null) handleChange('fontSize', value);
+                }}
+              />
+            </Flexbox>
           </Flexbox>
         }
         title={

--- a/src/features/Settings/provider/features/ModelList/CreateNewModelModal/Form.tsx
+++ b/src/features/Settings/provider/features/ModelList/CreateNewModelModal/Form.tsx
@@ -1,7 +1,7 @@
 import { Input } from '@lobehub/ui';
-import { Select } from '@lobehub/ui/base-ui';
+import { Checkbox, Select } from '@lobehub/ui/base-ui';
 import type { FormInstance } from 'antd';
-import { Checkbox, Form } from 'antd';
+import { Form } from 'antd';
 import type { AiModelType } from 'model-bank';
 import { memo, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/features/SharePopover/index.tsx
+++ b/src/features/SharePopover/index.tsx
@@ -1,15 +1,7 @@
 'use client';
 
-import {
-  Checkbox,
-  copyToClipboard,
-  Flexbox,
-  Popover,
-  Skeleton,
-  Text,
-  usePopoverContext,
-} from '@lobehub/ui';
-import { Button, confirmModal, Select, toast } from '@lobehub/ui/base-ui';
+import { copyToClipboard, Flexbox, Popover, Skeleton, Text, usePopoverContext } from '@lobehub/ui';
+import { Button, Checkbox, confirmModal, Select, toast } from '@lobehub/ui/base-ui';
 import { Divider } from 'antd';
 import {
   FileOutputIcon,

--- a/src/features/WorkspaceDeleteAllModal/index.tsx
+++ b/src/features/WorkspaceDeleteAllModal/index.tsx
@@ -1,7 +1,13 @@
 'use client';
 
-import { Checkbox, Flexbox, Text } from '@lobehub/ui';
-import { Button, createModal, type ModalInstance, useModalContext } from '@lobehub/ui/base-ui';
+import { Flexbox, Text } from '@lobehub/ui';
+import {
+  Button,
+  Checkbox,
+  createModal,
+  type ModalInstance,
+  useModalContext,
+} from '@lobehub/ui/base-ui';
 import { memo, useCallback, useState } from 'react';
 
 interface WorkspaceDeleteAllModalContentProps {

--- a/src/layout/AuthProvider/MarketAuth/ClaimResourcesModal.test.tsx
+++ b/src/layout/AuthProvider/MarketAuth/ClaimResourcesModal.test.tsx
@@ -77,9 +77,6 @@ vi.mock('antd', () => {
         },
       }),
     },
-    Checkbox: ({ checked }: { checked?: boolean }) => (
-      <input readOnly checked={checked} role="checkbox" type="checkbox" />
-    ),
     List,
   };
 });
@@ -112,19 +109,19 @@ describe('ClaimResourcesModal', () => {
     );
 
     await waitFor(() => {
-      const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+      const checkboxes = screen.getAllByRole('checkbox');
 
-      expect(checkboxes[0].checked).toBe(true);
-      expect(checkboxes[1].checked).toBe(true);
+      expect(checkboxes[0]).toHaveAttribute('aria-checked', 'true');
+      expect(checkboxes[1]).toHaveAttribute('aria-checked', 'true');
     });
 
     fireEvent.click(screen.getByText('plugin-a'));
 
     await waitFor(() => {
-      const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+      const checkboxes = screen.getAllByRole('checkbox');
 
-      expect(checkboxes[0].checked).toBe(false);
-      expect(checkboxes[1].checked).toBe(true);
+      expect(checkboxes[0]).toHaveAttribute('aria-checked', 'false');
+      expect(checkboxes[1]).toHaveAttribute('aria-checked', 'true');
     });
 
     rerender(
@@ -139,12 +136,12 @@ describe('ClaimResourcesModal', () => {
     );
 
     await waitFor(() => {
-      const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+      const checkboxes = screen.getAllByRole('checkbox');
 
       expect(screen.queryByText('plugin-a')).toBeNull();
       expect(screen.getByText('plugin-b')).toBeTruthy();
-      expect(checkboxes[0].checked).toBe(true);
-      expect(checkboxes[1].checked).toBe(true);
+      expect(checkboxes[0]).toHaveAttribute('aria-checked', 'true');
+      expect(checkboxes[1]).toHaveAttribute('aria-checked', 'true');
     });
   });
 });

--- a/src/layout/AuthProvider/MarketAuth/ClaimResourcesModal.tsx
+++ b/src/layout/AuthProvider/MarketAuth/ClaimResourcesModal.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { Flexbox, Text } from '@lobehub/ui';
-import { toast } from '@lobehub/ui/base-ui';
-import { Checkbox, List } from 'antd';
+import { Checkbox, toast } from '@lobehub/ui/base-ui';
+import { List } from 'antd';
 import { cssVar } from 'antd-style';
 import { Package, Wrench } from 'lucide-react';
 import { memo, useCallback, useEffect, useState } from 'react';

--- a/src/routes/(main)/(create)/image/features/ConfigPanel/components/CfgSliderInput.tsx
+++ b/src/routes/(main)/(create)/image/features/ConfigPanel/components/CfgSliderInput.tsx
@@ -1,4 +1,4 @@
-import { SliderWithInput } from '@lobehub/ui';
+import { SliderWithInput } from '@lobehub/ui/base-ui';
 import { memo } from 'react';
 
 import { useGenerationConfigParam } from '@/store/image/slices/generationConfig/hooks';

--- a/src/routes/(main)/(create)/image/features/ConfigPanel/components/DimensionControlGroup.tsx
+++ b/src/routes/(main)/(create)/image/features/ConfigPanel/components/DimensionControlGroup.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { ActionIcon, Flexbox, SliderWithInput } from '@lobehub/ui';
+import { ActionIcon, Flexbox } from '@lobehub/ui';
+import { SliderWithInput } from '@lobehub/ui/base-ui';
 import { LockIcon, UnlockIcon } from 'lucide-react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/routes/(main)/(create)/image/features/ConfigPanel/components/StepsSliderInput.tsx
+++ b/src/routes/(main)/(create)/image/features/ConfigPanel/components/StepsSliderInput.tsx
@@ -1,4 +1,4 @@
-import { SliderWithInput } from '@lobehub/ui';
+import { SliderWithInput } from '@lobehub/ui/base-ui';
 import { memo } from 'react';
 
 import { useGenerationConfigParam } from '@/store/image/slices/generationConfig/hooks';

--- a/src/routes/(main)/(create)/video/features/PromptInput/index.tsx
+++ b/src/routes/(main)/(create)/video/features/PromptInput/index.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { ModelIcon } from '@lobehub/icons';
-import { ActionIcon, Flexbox, InputNumber, SliderWithInput, Text } from '@lobehub/ui';
-import { Switch, Tabs } from '@lobehub/ui/base-ui';
+import { ActionIcon, Flexbox, InputNumber, Text } from '@lobehub/ui';
+import { SliderWithInput, Switch, Tabs } from '@lobehub/ui/base-ui';
 import { Divider } from 'antd';
 import { Clock3, Dices } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react';

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/QuotaAccountManagerModal.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/QuotaAccountManagerModal.tsx
@@ -2,8 +2,7 @@
 
 import { currentUtilization, isWeeklyAllLimit } from '@lobechat/heterogeneous-agents/quota';
 import { ActionIcon, DropdownMenu, Flexbox, Icon, Input, Text } from '@lobehub/ui';
-import { Button, createModal, type ModalInstance, Switch } from '@lobehub/ui/base-ui';
-import { Radio } from 'antd';
+import { Button, createModal, type ModalInstance, RadioGroup, Switch } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { t as i18nT } from 'i18next';
 import {
@@ -14,7 +13,7 @@ import {
   XIcon,
   ZapIcon,
 } from 'lucide-react';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, type MouseEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { agentQuotaService } from '@/services/agentQuota';
@@ -29,8 +28,22 @@ const styles = createStaticStyles(({ css }) => ({
     font-size: 12px;
     color: ${cssVar.colorTextTertiary};
   `,
+  interactive: css`
+    display: contents;
+  `,
+  radioGroup: css`
+    width: 100%;
+
+    > label {
+      width: 100%;
+    }
+
+    > label > span:last-child {
+      flex: 1;
+      min-width: 0;
+    }
+  `,
   routing: css`
-    margin-inline-start: 26px;
     padding-block: 6px;
     padding-inline: 10px;
     border-radius: ${cssVar.borderRadius};
@@ -199,123 +212,143 @@ const QuotaAccountManager = memo<{ agentId: string }>(({ agentId }) => {
     [editLabel, run],
   );
 
+  const preventRadioSelection = useCallback((event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+  }, []);
+
   return (
     <Flexbox gap={2}>
-      <Radio.Group
-        style={{ width: '100%' }}
+      <RadioGroup
+        className={styles.radioGroup}
+        gap={2}
+        horizontal={false}
         value={selected}
-        onChange={(e) => setPending(e.target.value as string)}
-      >
-        {/* Auto balance is the first option in the pool, not a separate toggle */}
-        <Flexbox className={styles.row} gap={4}>
-          <Radio disabled={busy} value={AUTO}>
-            <Text style={{ fontSize: 13 }}>{t('heteroAgent.claudeQuota.manage.modeAuto')}</Text>
-          </Radio>
-          {selected === AUTO && (
-            <Flexbox horizontal align={'center'} className={styles.routing} gap={6}>
-              <Icon icon={ZapIcon} size={14} />
-              {routeAccount
-                ? t('heteroAgent.claudeQuota.manage.autoRoutingTo', {
-                    account: accountName(routeAccount),
-                  })
-                : t('heteroAgent.claudeQuota.manage.autoNoAccount')}
-            </Flexbox>
-          )}
-        </Flexbox>
-
-        {accounts.map((a) => {
-          const rotate = inRotation(a.id);
-          const weekly = weeklyById[a.id];
-          const isEditing = editingId === a.id;
-          const menuItems = [
-            {
-              icon: <Icon icon={PencilIcon} />,
-              key: 'edit',
-              label: t('heteroAgent.claudeQuota.manage.edit'),
-              onClick: () => startEdit(a),
-            },
-            { type: 'divider' as const },
-            {
-              danger: true,
-              disabled: !bindingOf(a.id),
-              icon: <Icon icon={Trash2Icon} />,
-              key: 'remove',
-              label: t('heteroAgent.claudeQuota.manage.remove'),
-              onClick: () => void remove(a.id),
-            },
-          ];
-
-          return (
-            <Flexbox
-              horizontal
-              align={'center'}
-              className={styles.row}
-              data-off={!rotate}
-              gap={8}
-              key={a.id}
-            >
-              <Radio disabled={busy || !rotate || isEditing} value={a.id} />
-              {isEditing ? (
-                <>
-                  <Input
-                    autoFocus
-                    placeholder={a.email || t('heteroAgent.claudeQuota.manage.labelPlaceholder')}
-                    size={'small'}
-                    style={{ flex: 1 }}
-                    value={editLabel}
-                    onChange={(e) => setEditLabel(e.target.value)}
-                    onPressEnter={() => void saveEdit(a.id)}
-                  />
-                  <ActionIcon
-                    disabled={busy}
-                    icon={CheckIcon}
-                    size={'small'}
-                    onClick={() => void saveEdit(a.id)}
-                  />
-                  <ActionIcon icon={XIcon} size={'small'} onClick={() => setEditingId(null)} />
-                </>
-              ) : (
-                <>
-                  <Flexbox flex={1} gap={0} style={{ minWidth: 0 }}>
-                    <Flexbox horizontal align={'center'} gap={6} style={{ minWidth: 0 }}>
-                      <Text ellipsis style={{ fontSize: 13 }}>
-                        {accountName(a)}
-                      </Text>
-                      {a.planTier && (
-                        <Text style={{ flex: 'none', fontSize: 12 }} type={'secondary'}>
-                          {a.planTier}
-                        </Text>
-                      )}
-                    </Flexbox>
-                    {/* Only a real quota reading gets a subline; a disabled row is
-                        conveyed by the dimmed state, and no-data shows nothing. */}
-                    {rotate && weekly != null && (
-                      <Text style={{ fontSize: 12 }} type={'secondary'}>
-                        {weekly === 0
-                          ? t('heteroAgent.claudeQuota.manage.exhausted')
-                          : t('heteroAgent.claudeQuota.manage.weeklyLeft', { percent: weekly })}
-                      </Text>
-                    )}
+        options={[
+          {
+            disabled: busy,
+            label: (
+              <Flexbox className={styles.row} gap={4}>
+                <Text style={{ fontSize: 13 }}>{t('heteroAgent.claudeQuota.manage.modeAuto')}</Text>
+                {selected === AUTO && (
+                  <Flexbox horizontal align={'center'} className={styles.routing} gap={6}>
+                    <Icon icon={ZapIcon} size={14} />
+                    {routeAccount
+                      ? t('heteroAgent.claudeQuota.manage.autoRoutingTo', {
+                          account: accountName(routeAccount),
+                        })
+                      : t('heteroAgent.claudeQuota.manage.autoNoAccount')}
                   </Flexbox>
-                  <Switch
-                    checked={rotate}
-                    disabled={busy}
-                    size={'small'}
-                    onChange={(v) => void setRotation(a.id, v)}
-                  />
-                  <DropdownMenu items={menuItems} placement={'bottomRight'}>
-                    <ActionIcon
-                      icon={MoreHorizontalIcon}
-                      size={'small'}
-                      title={t('heteroAgent.claudeQuota.manage.more')}
-                    />
-                  </DropdownMenu>
-                </>
-              )}
-            </Flexbox>
-          );
-        })}
-      </Radio.Group>
+                )}
+              </Flexbox>
+            ),
+            value: AUTO,
+          },
+          ...accounts.map((a) => {
+            const rotate = inRotation(a.id);
+            const weekly = weeklyById[a.id];
+            const isEditing = editingId === a.id;
+            const menuItems = [
+              {
+                icon: <Icon icon={PencilIcon} />,
+                key: 'edit',
+                label: t('heteroAgent.claudeQuota.manage.edit'),
+                onClick: () => startEdit(a),
+              },
+              { type: 'divider' as const },
+              {
+                danger: true,
+                disabled: !bindingOf(a.id),
+                icon: <Icon icon={Trash2Icon} />,
+                key: 'remove',
+                label: t('heteroAgent.claudeQuota.manage.remove'),
+                onClick: () => void remove(a.id),
+              },
+            ];
+
+            return {
+              disabled: busy || !rotate || isEditing,
+              label: (
+                <Flexbox
+                  horizontal
+                  align={'center'}
+                  className={styles.row}
+                  data-off={!rotate}
+                  gap={8}
+                >
+                  {isEditing ? (
+                    <>
+                      <Input
+                        autoFocus
+                        size={'small'}
+                        style={{ flex: 1 }}
+                        value={editLabel}
+                        placeholder={
+                          a.email || t('heteroAgent.claudeQuota.manage.labelPlaceholder')
+                        }
+                        onChange={(e) => setEditLabel(e.target.value)}
+                        onPressEnter={() => void saveEdit(a.id)}
+                      />
+                      <ActionIcon
+                        disabled={busy}
+                        icon={CheckIcon}
+                        size={'small'}
+                        onClick={() => void saveEdit(a.id)}
+                      />
+                      <ActionIcon icon={XIcon} size={'small'} onClick={() => setEditingId(null)} />
+                    </>
+                  ) : (
+                    <>
+                      <Flexbox flex={1} gap={0} style={{ minWidth: 0 }}>
+                        <Flexbox horizontal align={'center'} gap={6} style={{ minWidth: 0 }}>
+                          <Text ellipsis style={{ fontSize: 13 }}>
+                            {accountName(a)}
+                          </Text>
+                          {a.planTier && (
+                            <Text style={{ flex: 'none', fontSize: 12 }} type={'secondary'}>
+                              {a.planTier}
+                            </Text>
+                          )}
+                        </Flexbox>
+                        {/* Only a real quota reading gets a subline; a disabled row is
+                            conveyed by the dimmed state, and no-data shows nothing. */}
+                        {rotate && weekly != null && (
+                          <Text style={{ fontSize: 12 }} type={'secondary'}>
+                            {weekly === 0
+                              ? t('heteroAgent.claudeQuota.manage.exhausted')
+                              : t('heteroAgent.claudeQuota.manage.weeklyLeft', {
+                                  percent: weekly,
+                                })}
+                          </Text>
+                        )}
+                      </Flexbox>
+                      <span className={styles.interactive} onClick={preventRadioSelection}>
+                        <Switch
+                          checked={rotate}
+                          disabled={busy}
+                          size={'small'}
+                          onChange={(v) => void setRotation(a.id, v)}
+                        />
+                      </span>
+                      <span className={styles.interactive} onClick={preventRadioSelection}>
+                        <DropdownMenu items={menuItems} placement={'bottomRight'}>
+                          <ActionIcon
+                            icon={MoreHorizontalIcon}
+                            size={'small'}
+                            title={t('heteroAgent.claudeQuota.manage.more')}
+                          />
+                        </DropdownMenu>
+                      </span>
+                    </>
+                  )}
+                </Flexbox>
+              ),
+              value: a.id,
+            };
+          }),
+        ]}
+        onChange={setPending}
+      />
 
       {accounts.length === 0 && (
         <Text className={styles.hint}>{t('heteroAgent.claudeQuota.manage.empty')}</Text>

--- a/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/BatchResumeModal/Content.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/BatchResumeModal/Content.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Badge, Checkbox, Skeleton, Table, Tag, Tooltip, Typography } from 'antd';
+import { Checkbox } from '@lobehub/ui/base-ui';
+import { Badge, Skeleton, Table, Tag, Tooltip, Typography } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { type FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
@@ -101,7 +102,7 @@ const BatchResumeContent: FC<BatchResumeContentProps> = ({
             <Checkbox
               checked={selectedIds.includes(record.testCaseId)}
               disabled={!record.canResume}
-              onChange={(e) => handleToggleRow(record.testCaseId, e.target.checked)}
+              onChange={(checked) => handleToggleRow(record.testCaseId, checked)}
             />
           </Tooltip>
         ),
@@ -110,7 +111,7 @@ const BatchResumeContent: FC<BatchResumeContentProps> = ({
             checked={allSelected}
             disabled={resumableCases.length === 0}
             indeterminate={indeterminate}
-            onChange={(e) => handleToggleAll(e.target.checked)}
+            onChange={handleToggleAll}
           />
         ),
         width: 48,

--- a/src/routes/(main)/eval/features/DatasetImportModal/MappingStep.tsx
+++ b/src/routes/(main)/eval/features/DatasetImportModal/MappingStep.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { Flexbox, Input, Text } from '@lobehub/ui';
-import { Select } from '@lobehub/ui/base-ui';
-import { Checkbox, Table } from 'antd';
+import { Checkbox, Select } from '@lobehub/ui/base-ui';
+import { Table } from 'antd';
 import { cssVar } from 'antd-style';
 import { memo, type ReactNode, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -35,13 +35,7 @@ const CATEGORY_CANDIDATES = new Set(['category', 'topic', 'type', 'subject', 'cl
 const CHOICES_CANDIDATES = new Set(['choices', 'options', 'alternatives', 'candidates']);
 
 type MappingTarget =
-  | 'choices'
-  | 'category'
-  | 'expected'
-  | 'ignore'
-  | 'input'
-  | 'metadata'
-  | 'sortOrder';
+  'choices' | 'category' | 'expected' | 'ignore' | 'input' | 'metadata' | 'sortOrder';
 
 export interface FieldMappingValue {
   category?: string;
@@ -287,7 +281,7 @@ const MappingStep = memo<MappingStepProps>(
               </Flexbox>
             )}
             {hasIgnored && (
-              <Checkbox checked={hideSkipped} onChange={(e) => setHideSkipped(e.target.checked)}>
+              <Checkbox checked={hideSkipped} onChange={setHideSkipped}>
                 <Text fontSize={12} type="secondary">
                   {t('dataset.import.hideSkipped')}
                 </Text>

--- a/src/routes/(main)/group/_layout/Sidebar/AddGroupMemberModal/AgentItem.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/AddGroupMemberModal/AgentItem.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { agentDisplayName } from '@lobechat/types';
-import { Avatar, Checkbox, Flexbox, Text } from '@lobehub/ui';
+import { Avatar, Flexbox, Text } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
 import { useHover } from 'ahooks';
 import { createStaticStyles } from 'antd-style';
 import { X } from 'lucide-react';


### PR DESCRIPTION
## Summary

- Migrate the remaining AutoComplete, Checkbox, Radio, and Slider consumers from Ant Design and the legacy `@lobehub/ui` entry to `@lobehub/ui/base-ui`.
- Add a local `DiscreteSlider` adapter for settings and model controls that depend on discrete option mapping, marks, keyboard input, and numeric synchronization.
- Preserve controlled values, checked states, loading behavior, form integration, and accessible labels across the affected business flows.
- Update focused regression tests for the Base UI event and accessibility contracts.

The completed source scan reports zero legacy imports for all four component families. The remaining Base UI usage covers 1 AutoComplete file, 37 Checkbox files, 4 Radio files, and 10 Slider files.

## UI evidence

| Before | After |
| ------ | ----- |
| Legacy Ant Design controls in downstream business flows | [Actual business UI acceptance — AutoComplete, Checkbox, Radio, and Slider screenshots (4/4 passed)](https://app.lobehub.com/verify/e41ff6c9-89c1-41f5-91eb-267a670594e2) |

The screenshots cover the desktop MCP STDIO command suggestions, API key fine-grained permissions, MCP authentication switching, and Appearance font-size adjustment. No modal was submitted during verification, so no API key or MCP skill was created.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation:

- Migration pre-commit pipeline: Stylelint, ESLint, and Prettier passed for all 59 changed files.
- Slider and Radio focused group: 13 files checked, 8 tests passed.
- Checkbox and AutoComplete focused group: 37 files checked, 6 tests passed.
- `git diff --check origin/canary..HEAD`
- [Business UI acceptance record](https://app.lobehub.com/acceptance/26d1129c-740e-4dce-9f24-d783a65d3bbf)

#### 🔗 Related Issue

- Related component-library enforcement and AutoComplete layer fix: lobehub/lobe-ui#610
