### PR TITLE
🐛 fix: correct BriefCardActions test assertion for fallback label

### DIFF
--- a/src/features/DailyBrief/__tests__/BriefCardActions.test.tsx
+++ b/src/features/DailyBrief/__tests__/BriefCardActions.test.tsx
@@ -129,7 +129,7 @@ describe('BriefCardActions', () => {
       />,
     );
 
-    const link = screen.getByRole('button', { name: 'Review delivery' });
+    const link = screen.getByRole('button', { name: 'Review acceptance' });
     expect(link).not.toHaveAttribute(RENDERER_HANDLED_LINK_ATTR);
     expect(fireEvent.click(link)).toBe(true);
   });


### PR DESCRIPTION
## Problem

The test `should leave a taskless acceptance link to the desktop preload interceptor` in `BriefCardActions.test.tsx` was failing on `canary` (and consequently blocking CI on PR #18292).

### Root cause

The test constructs a brief action with:
- `key: 'reviewAcceptance'`
- `label: 'Review acceptance'`

Since there is no `brief.action.reviewAcceptance` locale entry, `BriefCardActions.getActionLabel` falls back to the server-provided `label` — rendering **"Review acceptance"**.

However, the assertion incorrectly expected **"Review delivery"** (which is the translation for `brief.action.review`, a *different* key). The test was introduced in #18254 and was broken from the start.

## Fix

Correct the assertion to expect `"Review acceptance"`, matching the actual fallback label rendered by the component.

## Verification

```bash
bunx vitest run src/features/DailyBrief/__tests__/BriefCardActions.test.tsx
# Tests  24 passed (24)
```