### PR TITLE
🔧 chore: disable Amp-Thread and Co-authored-by trailers in orb commits

### DIFF
--- a/.amp/settings.json
+++ b/.amp/settings.json
@@ -1,0 +1,4 @@
+{
+  "amp.git.commit.ampThread.enabled": false,
+  "amp.git.commit.coauthor.enabled": false
+}

--- a/.gitignore
+++ b/.gitignore
@@ -158,4 +158,5 @@ docs/superpowers/
 .kagura/
 
 # Amp agent runtime
-.amp/
+.amp/*
+!.amp/settings.json


### PR DESCRIPTION
 Disable `Amp-Thread` and `Co-authored-by: Amp` git commit trailers for commits made by the agent in Amp orbs.

This is configured via Amp workspace settings (`.amp/settings.json`), which orb threads pick up automatically when cloning the repository. The `.gitignore` is updated to allow only `.amp/settings.json` to be tracked while keeping the rest of `.amp/` ignored.

| Before | After |
| ------ | ----- |
| Orb commits include `Amp-Thread: <url>` and `Co-authored-by: Amp <amp@ampcode.com>` trailers | Orb commits are clean, no Amp metadata trailers |

#### Test

- [x] No tests needed — configuration-only change

#### 🔗 Related Issue

N/A
