### PR TITLE
🐛 fix(heterogeneous-agent): preserve Grok post-tool stream order

### DIFF
--- a/packages/heterogeneous-agents/src/adapters/grokBuild.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/grokBuild.test.ts
@@ -66,6 +66,8 @@ describe('GrokBuildAdapter', () => {
       'tool_start',
       'tool_result',
       'tool_end',
+      'stream_end',
+      'stream_start',
       'stream_chunk',
     ]);
     expect(events.find(({ type }) => type === 'tool_start')?.data).toMatchObject({
@@ -295,6 +297,45 @@ describe('GrokBuildAdapter', () => {
     expect(adapter.adapt(secondResponse)).toEqual([]);
     expect(secondTool[0]).toMatchObject({
       data: { toolsCalling: [{ id: 'call-b' }] },
+      stepIndex: 1,
+      type: 'stream_chunk',
+    });
+  });
+
+  it('opens a new step for post-tool text when response completion omits tool_use', () => {
+    const adapter = new GrokBuildAdapter();
+    adapter.adapt(
+      update({
+        rawInput: { path: 'README.md' },
+        sessionUpdate: 'tool_call',
+        title: 'Read',
+        toolCallId: 'call-1',
+      }),
+    );
+    adapter.adapt(
+      update({
+        content: [{ text: 'file body', type: 'text' }],
+        sessionUpdate: 'tool_call_update',
+        status: 'completed',
+        toolCallId: 'call-1',
+      }),
+    );
+
+    const events = adapter.adapt(
+      update({
+        content: { text: 'Final answer', type: 'text' },
+        sessionUpdate: 'agent_message_chunk',
+      }),
+    );
+
+    expect(events.map(({ type }) => type)).toEqual(['stream_end', 'stream_start', 'stream_chunk']);
+    expect(events[1]).toMatchObject({
+      data: { newStep: true },
+      stepIndex: 1,
+      type: 'stream_start',
+    });
+    expect(events[2]).toMatchObject({
+      data: { chunkType: 'text', content: 'Final answer' },
       stepIndex: 1,
       type: 'stream_chunk',
     });

--- a/packages/heterogeneous-agents/src/adapters/grokBuild.ts
+++ b/packages/heterogeneous-agents/src/adapters/grokBuild.ts
@@ -270,6 +270,12 @@ export class GrokBuildAdapter implements AgentEventAdapter {
     if (!tool) return [];
 
     this.completedToolCallIds.add(toolCallId);
+    // ACP providers do not consistently report `tool_use` on the preceding
+    // response_completed update. A model chunk emitted after a completed tool
+    // necessarily belongs to the next model round, so keep that boundary here
+    // as well. `ensureStream(false)` leaves it pending through the remaining
+    // parallel tool updates; the next text/thought chunk consumes it.
+    this.pendingStepBoundary = true;
     const isError = update.status === 'failed';
     const content = toolResultContent(resultState);
     const result: ToolResultData = { content, isError, toolCallId };


### PR DESCRIPTION
<!-- Brief and heads-up -->

Grok Build ACP does not consistently report `tool_use` on the preceding `response_completed` update. This could leave post-tool answer chunks attached to the tool-bearing assistant step while streaming, rendering the final answer above the tools until terminal reconciliation.

This change treats a completed or failed tool as a pending model-step boundary. Remaining parallel tool updates stay in the current step, while the next text or reasoning chunk opens a new assistant step.

| Before | After |
| ------ | ----- |
| Post-tool answer could temporarily render above tool calls while streaming | Post-tool answer streams in a new step after the tool workflow |

#### Test

- Added a regression test covering post-tool text when `response_completed` omits `tool_use`
- Audited all registered heterogeneous-agent adapters for equivalent boundary handling
- Ran `bun run check packages/heterogeneous-agents/src/adapters/grokBuild.ts packages/heterogeneous-agents/src/adapters/grokBuild.test.ts`
- Ran all heterogeneous adapter tests: 12 files, 264 tests passed

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

No matching issue found.
