### PR TITLE
✨ feat(task): restore agent chat panel on detail page

### DIFF
--- a/src/features/AgentTaskManager/TaskAgentProvider.test.tsx
+++ b/src/features/AgentTaskManager/TaskAgentProvider.test.tsx
@@ -147,16 +147,48 @@ describe('TaskAgentProvider', () => {
 
   it('uses the route agent as the default in an agent-scoped task detail', async () => {
     render(
-      <TaskAgentProvider preferredAgentId="agt_current">
+      <TaskAgentProvider preferredAgentId="agt_current" viewedTaskId="task_1">
         <div>content</div>
       </TaskAgentProvider>,
     );
 
     await waitFor(() => {
-      expect(mocks.providerContexts.at(-1)?.agentId).toBe('agt_current');
+      expect(mocks.providerContexts.at(-1)).toMatchObject({
+        agentId: 'agt_current',
+        viewedTask: { taskId: 'task_1', type: 'detail' },
+      });
     });
     expect(mocks.agentState.setActiveAgentId).toHaveBeenCalledWith('agt_current');
     expect(mocks.chatState.activeAgentId).toBe('agt_current');
+  });
+
+  it('resets a scoped selection when the preferred route agent changes', async () => {
+    const { rerender } = render(
+      <TaskAgentProvider preferredAgentId="agt_route_a">
+        <SelectAgentButton agentId="agt_custom" />
+      </TaskAgentProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mocks.providerContexts.at(-1)?.agentId).toBe('agt_route_a');
+    });
+
+    fireEvent.click(screen.getByText('select agent'));
+
+    await waitFor(() => {
+      expect(mocks.providerContexts.at(-1)?.agentId).toBe('agt_custom');
+    });
+
+    rerender(
+      <TaskAgentProvider preferredAgentId="agt_route_b">
+        <SelectAgentButton agentId="agt_custom" />
+      </TaskAgentProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mocks.providerContexts.at(-1)?.agentId).toBe('agt_route_b');
+    });
+    expect(mocks.agentState.setActiveAgentId).toHaveBeenLastCalledWith('agt_route_b');
   });
 
   it('restores and refreshes the Inbox task topic handed off by the home composer', async () => {

--- a/src/features/AgentTaskManager/TaskAgentProvider.test.tsx
+++ b/src/features/AgentTaskManager/TaskAgentProvider.test.tsx
@@ -145,6 +145,20 @@ describe('TaskAgentProvider', () => {
     expect(mocks.providerContexts.at(-1)?.viewedTask).toEqual({ taskId: 'T-1', type: 'detail' });
   });
 
+  it('uses the route agent as the default in an agent-scoped task detail', async () => {
+    render(
+      <TaskAgentProvider preferredAgentId="agt_current">
+        <div>content</div>
+      </TaskAgentProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mocks.providerContexts.at(-1)?.agentId).toBe('agt_current');
+    });
+    expect(mocks.agentState.setActiveAgentId).toHaveBeenCalledWith('agt_current');
+    expect(mocks.chatState.activeAgentId).toBe('agt_current');
+  });
+
   it('restores and refreshes the Inbox task topic handed off by the home composer', async () => {
     mocks.search = 'agentId=agt_inbox&topicId=tpc_home_task';
     mocks.agentState.activeAgentId = 'agt_inbox';

--- a/src/features/AgentTaskManager/TaskAgentProvider.tsx
+++ b/src/features/AgentTaskManager/TaskAgentProvider.tsx
@@ -18,13 +18,14 @@ import { resolveTaskHandoffTopic } from './taskHandoff';
 
 interface TaskAgentProviderProps {
   children: ReactNode;
+  preferredAgentId?: string;
 }
 
 const TaskAgentSelectionContext = createContext<(agentId: string) => void>(() => {});
 
 export const useTaskAgentSelection = () => use(TaskAgentSelectionContext);
 
-export const TaskAgentProvider = memo<TaskAgentProviderProps>(({ children }) => {
+export const TaskAgentProvider = memo<TaskAgentProviderProps>(({ children, preferredAgentId }) => {
   useInitBuiltinAgent(BUILTIN_AGENT_SLUGS.inbox);
   useInitBuiltinAgent(BUILTIN_AGENT_SLUGS.taskAgent);
 
@@ -37,13 +38,13 @@ export const TaskAgentProvider = memo<TaskAgentProviderProps>(({ children }) => 
   const routedTopicId = searchParams.get('topicId') || undefined;
   const syncedContextRef = useRef<string | undefined>(undefined);
   const [scopedSelectedAgentId, setScopedSelectedAgentId] = useState<string | undefined>(
-    routedAgentId,
+    routedAgentId || preferredAgentId,
   );
 
   const detailMatch = useMatch('/task/:taskId');
   const viewedTaskId = detailMatch?.params.taskId;
 
-  const selectedAgentId = scopedSelectedAgentId || taskAgentId;
+  const selectedAgentId = scopedSelectedAgentId || preferredAgentId || taskAgentId;
 
   const selectTaskAgent = useCallback((agentId: string) => {
     if (!agentId || isChatGroupSessionId(agentId)) return;

--- a/src/features/AgentTaskManager/TaskAgentProvider.tsx
+++ b/src/features/AgentTaskManager/TaskAgentProvider.tsx
@@ -19,13 +19,20 @@ import { resolveTaskHandoffTopic } from './taskHandoff';
 interface TaskAgentProviderProps {
   children: ReactNode;
   preferredAgentId?: string;
+  viewedTaskId?: string;
+}
+
+interface ScopedAgentSelection {
+  agentId?: string;
+  scopeAgentId?: string;
 }
 
 const TaskAgentSelectionContext = createContext<(agentId: string) => void>(() => {});
 
 export const useTaskAgentSelection = () => use(TaskAgentSelectionContext);
 
-export const TaskAgentProvider = memo<TaskAgentProviderProps>(({ children, preferredAgentId }) => {
+export const TaskAgentProvider = memo<TaskAgentProviderProps>((props) => {
+  const { children, preferredAgentId, viewedTaskId } = props;
   useInitBuiltinAgent(BUILTIN_AGENT_SLUGS.inbox);
   useInitBuiltinAgent(BUILTIN_AGENT_SLUGS.taskAgent);
 
@@ -37,19 +44,27 @@ export const TaskAgentProvider = memo<TaskAgentProviderProps>(({ children, prefe
   const routedAgentId = searchParams.get('agentId') || undefined;
   const routedTopicId = searchParams.get('topicId') || undefined;
   const syncedContextRef = useRef<string | undefined>(undefined);
-  const [scopedSelectedAgentId, setScopedSelectedAgentId] = useState<string | undefined>(
-    routedAgentId || preferredAgentId,
-  );
+  const [scopedSelection, setScopedSelection] = useState<ScopedAgentSelection>(() => ({
+    agentId: preferredAgentId || routedAgentId,
+    scopeAgentId: preferredAgentId,
+  }));
 
   const detailMatch = useMatch('/task/:taskId');
-  const viewedTaskId = detailMatch?.params.taskId;
+  const resolvedViewedTaskId = viewedTaskId || detailMatch?.params.taskId;
 
+  const scopedSelectedAgentId =
+    scopedSelection.scopeAgentId === preferredAgentId
+      ? scopedSelection.agentId
+      : preferredAgentId || routedAgentId;
   const selectedAgentId = scopedSelectedAgentId || preferredAgentId || taskAgentId;
 
-  const selectTaskAgent = useCallback((agentId: string) => {
-    if (!agentId || isChatGroupSessionId(agentId)) return;
-    setScopedSelectedAgentId(agentId);
-  }, []);
+  const selectTaskAgent = useCallback(
+    (agentId: string) => {
+      if (!agentId || isChatGroupSessionId(agentId)) return;
+      setScopedSelection({ agentId, scopeAgentId: preferredAgentId });
+    },
+    [preferredAgentId],
+  );
 
   useEffect(() => {
     if (!selectedAgentId) return;
@@ -94,9 +109,11 @@ export const TaskAgentProvider = memo<TaskAgentProviderProps>(({ children, prefe
       defaultTaskAssigneeAgentId: inboxAgentId,
       scope: 'task',
       topicId: activeTopicId,
-      viewedTask: viewedTaskId ? { taskId: viewedTaskId, type: 'detail' } : { type: 'list' },
+      viewedTask: resolvedViewedTaskId
+        ? { taskId: resolvedViewedTaskId, type: 'detail' }
+        : { type: 'list' },
     }),
-    [activeTopicId, inboxAgentId, selectedAgentId, viewedTaskId],
+    [activeTopicId, inboxAgentId, resolvedViewedTaskId, selectedAgentId],
   );
 
   const chatKey = useMemo(() => messageMapKey(context), [context]);

--- a/src/features/AgentTaskManager/index.tsx
+++ b/src/features/AgentTaskManager/index.tsx
@@ -11,7 +11,11 @@ import { systemStatusSelectors } from '@/store/global/selectors';
 import Conversation from './Conversation';
 import { TaskAgentProvider } from './TaskAgentProvider';
 
-const AgentTaskManager = memo(() => {
+interface AgentTaskManagerProps {
+  preferredAgentId?: string;
+}
+
+const AgentTaskManager = memo<AgentTaskManagerProps>(({ preferredAgentId }) => {
   const [expand, toggleTaskAgentPanel] = useGlobalStore((s) => [
     systemStatusSelectors.showTaskAgentPanel(s),
     s.toggleTaskAgentPanel,
@@ -32,7 +36,7 @@ const AgentTaskManager = memo(() => {
       {showAcceptance ? (
         <PortalContent />
       ) : (
-        <TaskAgentProvider>
+        <TaskAgentProvider preferredAgentId={preferredAgentId}>
           <Conversation />
         </TaskAgentProvider>
       )}

--- a/src/features/AgentTaskManager/index.tsx
+++ b/src/features/AgentTaskManager/index.tsx
@@ -13,9 +13,10 @@ import { TaskAgentProvider } from './TaskAgentProvider';
 
 interface AgentTaskManagerProps {
   preferredAgentId?: string;
+  viewedTaskId?: string;
 }
 
-const AgentTaskManager = memo<AgentTaskManagerProps>(({ preferredAgentId }) => {
+const AgentTaskManager = memo<AgentTaskManagerProps>(({ preferredAgentId, viewedTaskId }) => {
   const [expand, toggleTaskAgentPanel] = useGlobalStore((s) => [
     systemStatusSelectors.showTaskAgentPanel(s),
     s.toggleTaskAgentPanel,
@@ -36,7 +37,7 @@ const AgentTaskManager = memo<AgentTaskManagerProps>(({ preferredAgentId }) => {
       {showAcceptance ? (
         <PortalContent />
       ) : (
-        <TaskAgentProvider preferredAgentId={preferredAgentId}>
+        <TaskAgentProvider preferredAgentId={preferredAgentId} viewedTaskId={viewedTaskId}>
           <Conversation />
         </TaskAgentProvider>
       )}

--- a/src/features/AgentTasks/AgentTaskDetail/AgentScopedTaskDetailPage.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/AgentScopedTaskDetailPage.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { Flexbox } from '@lobehub/ui';
+import { memo } from 'react';
+
+import AgentTaskManager from '@/features/AgentTaskManager';
+import MobilePortal from '@/features/Portal/Mobile';
+import { useIsMobile } from '@/hooks/useIsMobile';
+
+import TaskDetailPage from './TaskDetailPage';
+
+interface AgentScopedTaskDetailPageProps {
+  agentId?: string;
+  taskId: string;
+}
+
+const AgentScopedTaskDetailPage = memo<AgentScopedTaskDetailPageProps>(({ agentId, taskId }) => {
+  const isMobile = useIsMobile();
+
+  return (
+    <Flexbox horizontal flex={1} height={'100%'} style={{ minHeight: 0 }} width={'100%'}>
+      <Flexbox flex={1} style={{ minWidth: 0 }}>
+        <TaskDetailPage showTaskAgentPanelToggle={!isMobile} taskId={taskId} />
+      </Flexbox>
+      {isMobile ? (
+        <MobilePortal />
+      ) : (
+        <AgentTaskManager preferredAgentId={agentId} viewedTaskId={taskId} />
+      )}
+    </Flexbox>
+  );
+});
+
+AgentScopedTaskDetailPage.displayName = 'AgentScopedTaskDetailPage';
+
+export default AgentScopedTaskDetailPage;

--- a/src/features/AgentTasks/AgentTaskDetail/index.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/index.tsx
@@ -1,3 +1,4 @@
+export { default as AgentScopedTaskDetailPage } from './AgentScopedTaskDetailPage';
 export { default as TaskDetailPage } from './TaskDetailPage';
 export { default as TaskDetailSections } from './TaskDetailSections';
 export { default as TopicChatDrawer } from './TopicChatDrawer';

--- a/src/features/AgentTasks/index.tsx
+++ b/src/features/AgentTasks/index.tsx
@@ -1,4 +1,5 @@
 export {
+  AgentScopedTaskDetailPage,
   TaskDetailPage,
   TaskDetailSections,
   TopicChatDrawer,

--- a/src/routes/(main)/agent/task/[taskId]/index.tsx
+++ b/src/routes/(main)/agent/task/[taskId]/index.tsx
@@ -1,28 +1,16 @@
 'use client';
 
-import { Flexbox } from '@lobehub/ui';
 import { memo } from 'react';
 import { useParams } from 'react-router';
 
-import AgentTaskManager from '@/features/AgentTaskManager';
-import { TaskDetailPage } from '@/features/AgentTasks';
-import MobilePortal from '@/features/Portal/Mobile';
-import { useIsMobile } from '@/hooks/useIsMobile';
+import { AgentScopedTaskDetailPage } from '@/features/AgentTasks';
 
 const AgentTaskDetailRoute = memo(() => {
-  const isMobile = useIsMobile();
   const { aid, taskId } = useParams<{ aid?: string; taskId?: string }>();
 
   if (!taskId) return null;
 
-  return (
-    <Flexbox horizontal flex={1} height={'100%'} style={{ minHeight: 0 }} width={'100%'}>
-      <Flexbox flex={1} style={{ minWidth: 0 }}>
-        <TaskDetailPage showTaskAgentPanelToggle={!isMobile} taskId={taskId} />
-      </Flexbox>
-      {isMobile ? <MobilePortal /> : <AgentTaskManager preferredAgentId={aid} />}
-    </Flexbox>
-  );
+  return <AgentScopedTaskDetailPage agentId={aid} taskId={taskId} />;
 });
 
 export default AgentTaskDetailRoute;

--- a/src/routes/(main)/agent/task/[taskId]/index.tsx
+++ b/src/routes/(main)/agent/task/[taskId]/index.tsx
@@ -4,23 +4,23 @@ import { Flexbox } from '@lobehub/ui';
 import { memo } from 'react';
 import { useParams } from 'react-router';
 
+import AgentTaskManager from '@/features/AgentTaskManager';
 import { TaskDetailPage } from '@/features/AgentTasks';
-import ChatPortal from '@/routes/(main)/agent/features/Portal';
+import MobilePortal from '@/features/Portal/Mobile';
+import { useIsMobile } from '@/hooks/useIsMobile';
 
 const AgentTaskDetailRoute = memo(() => {
-  const { taskId } = useParams<{ taskId?: string }>();
+  const isMobile = useIsMobile();
+  const { aid, taskId } = useParams<{ aid?: string; taskId?: string }>();
 
   if (!taskId) return null;
 
   return (
     <Flexbox horizontal flex={1} height={'100%'} style={{ minHeight: 0 }} width={'100%'}>
       <Flexbox flex={1} style={{ minWidth: 0 }}>
-        <TaskDetailPage showTaskAgentPanelToggle={false} taskId={taskId} />
+        <TaskDetailPage showTaskAgentPanelToggle={!isMobile} taskId={taskId} />
       </Flexbox>
-      {/* Task detail opens acceptance checks in the portal. This route sits
-        beside the (chat) subtree that normally mounts one, so without its own
-        host every check click pushed a view nothing rendered — a dead click. */}
-      <ChatPortal />
+      {isMobile ? <MobilePortal /> : <AgentTaskManager preferredAgentId={aid} />}
     </Flexbox>
   );
 });


### PR DESCRIPTION
## Summary

- restore the expandable right-side agent conversation panel on agent-scoped task details
- default the conversation to the agent from the current `/agent/:aid` route
- retain the compact mobile portal behavior and acceptance portal rendering

## Verification

- `bun run check` on the 4 changed files
- 10 related tests passed
- Electron acceptance: https://app.lobehub.com/acceptance/a648977f-29ba-44bf-8cc0-127dde244f95
