### PR TITLE
🐛 fix(settings): restore form control bindings

### DIFF
--- a/src/features/Settings/image/features/Image.tsx
+++ b/src/features/Settings/image/features/Image.tsx
@@ -2,7 +2,7 @@
 
 import { type UserImageConfig } from '@lobechat/types';
 import { type FormGroupItemType } from '@lobehub/ui';
-import { Form, Icon, Skeleton, Tooltip } from '@lobehub/ui';
+import { Form, Icon, Skeleton } from '@lobehub/ui';
 import { Loader2Icon } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -33,18 +33,17 @@ const ImageSettings = memo(() => {
       children: [
         {
           children: (
-            <Tooltip title={reason}>
-              <FormSliderWithInput
-                disabled={isUpdating || !canManageServiceModel}
-                max={MAX_DEFAULT_IMAGE_NUM}
-                min={MIN_DEFAULT_IMAGE_NUM}
-                step={1}
-              />
-            </Tooltip>
+            <FormSliderWithInput
+              disabled={isUpdating || !canManageServiceModel}
+              max={MAX_DEFAULT_IMAGE_NUM}
+              min={MIN_DEFAULT_IMAGE_NUM}
+              step={1}
+            />
           ),
           desc: t('settingImage.defaultCount.desc'),
           label: t('settingImage.defaultCount.label'),
           name: 'defaultImageNum',
+          tooltip: reason,
         },
       ],
       extra: isUpdating ? (

--- a/src/features/Settings/memory/features/Memory.test.tsx
+++ b/src/features/Settings/memory/features/Memory.test.tsx
@@ -91,11 +91,7 @@ vi.mock('@lobehub/ui', async () => {
             if (!item.name) return [];
 
             return [
-              <AntdForm.Item
-                key={item.name}
-                name={item.name}
-                valuePropName={item.valuePropName}
-              >
+              <AntdForm.Item key={item.name} name={item.name} valuePropName={item.valuePropName}>
                 {item.children}
               </AntdForm.Item>,
             ];

--- a/src/features/Settings/memory/features/Memory.test.tsx
+++ b/src/features/Settings/memory/features/Memory.test.tsx
@@ -31,16 +31,11 @@ vi.mock('@/hooks/useSaveState', () => ({
 vi.mock('@/store/user', () => ({
   useUserStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
+      defaultSettings: {},
       isUserStateInit: true,
       setSettings: setSettingsMock,
       settings: { memory: memorySettingsMock.value },
     }),
-}));
-
-vi.mock('@/store/user/selectors', () => ({
-  settingsSelectors: {
-    currentSettings: (state: { settings: unknown }) => state.settings,
-  },
 }));
 
 vi.mock('@/components/Editor/AutoSaveHint', () => ({ default: () => null }));

--- a/src/features/Settings/memory/features/Memory.test.tsx
+++ b/src/features/Settings/memory/features/Memory.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { FormInstance } from 'antd';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import MemorySetting from './Memory';
+
+const setSettingsMock = vi.hoisted(() => vi.fn());
+const memorySettingsMock = vi.hoisted(() => ({ value: {} as { enabled?: boolean } }));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/hooks/usePermission', () => ({
+  usePermission: () => ({ allowed: true }),
+}));
+
+vi.mock('@/hooks/useSaveState', () => ({
+  useSaveState: () => ({
+    lastSavedAt: undefined,
+    retry: vi.fn(),
+    save: (callback: () => void) => callback(),
+    status: 'idle',
+  }),
+}));
+
+vi.mock('@/store/user', () => ({
+  useUserStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      isUserStateInit: true,
+      setSettings: setSettingsMock,
+      settings: { memory: memorySettingsMock.value },
+    }),
+}));
+
+vi.mock('@/store/user/selectors', () => ({
+  settingsSelectors: {
+    currentSettings: (state: { settings: unknown }) => state.settings,
+  },
+}));
+
+vi.mock('@/components/Editor/AutoSaveHint', () => ({ default: () => null }));
+vi.mock('@/const/layoutTokens', () => ({ FORM_STYLE: {} }));
+vi.mock('@/features/ModelSwitchPanel/components/ControlsForm/LevelSlider', () => ({
+  default: () => null,
+}));
+
+vi.mock('@lobehub/ui/base-ui', () => ({
+  Switch: ({
+    checked,
+    disabled,
+    onChange,
+  }: {
+    checked?: boolean;
+    disabled?: boolean;
+    onChange?: (checked: boolean) => void;
+  }) => (
+    <button
+      aria-checked={!!checked}
+      disabled={disabled}
+      role="switch"
+      onClick={() => onChange?.(!checked)}
+    />
+  ),
+}));
+
+vi.mock('@lobehub/ui', async () => {
+  const { Form: AntdForm } = await import('antd');
+
+  const Form = Object.assign(
+    ({
+      form,
+      initialValues,
+      items,
+      onValuesChange,
+    }: {
+      form?: FormInstance<Record<string, unknown>>;
+      initialValues: Record<string, unknown>;
+      items: Array<{
+        children: Array<{ children: ReactNode; name?: string; valuePropName?: string }>;
+      }>;
+      onValuesChange: (values: Record<string, unknown>) => void;
+    }) => (
+      <AntdForm form={form} initialValues={initialValues} onValuesChange={onValuesChange}>
+        {items.flatMap((group) =>
+          group.children.flatMap((item) => {
+            if (!item.name) return [];
+
+            return [
+              <AntdForm.Item
+                key={item.name}
+                name={item.name}
+                valuePropName={item.valuePropName}
+              >
+                {item.children}
+              </AntdForm.Item>,
+            ];
+          }),
+        )}
+      </AntdForm>
+    ),
+    { useForm: AntdForm.useForm },
+  );
+
+  return {
+    Form,
+    Skeleton: () => null,
+    Tooltip: ({ children }: { children: ReactNode }) => children,
+  };
+});
+
+describe('MemorySetting', () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    memorySettingsMock.value = {};
+  });
+
+  it('shows memory as enabled when the setting has not been persisted', () => {
+    render(<MemorySetting />);
+
+    const toggle = screen.getByRole('switch');
+    expect(toggle.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('persists toggle changes', () => {
+    memorySettingsMock.value = { enabled: false };
+    render(<MemorySetting />);
+
+    const toggle = screen.getByRole('switch');
+    fireEvent.click(toggle);
+
+    expect(setSettingsMock).toHaveBeenCalledWith({ memory: { enabled: true } });
+  });
+});

--- a/src/features/Settings/memory/features/Memory.tsx
+++ b/src/features/Settings/memory/features/Memory.tsx
@@ -31,13 +31,9 @@ const MemorySetting = memo(() => {
   const memorySettings: FormGroupItemType = {
     children: [
       {
-        children: (
-          <Tooltip title={reason}>
-            <Switch disabled={!canManageMemory} />
-          </Tooltip>
-        ),
+        children: <Switch disabled={!canManageMemory} />,
         desc: t('memory.enabled.desc'),
-        label: t('memory.enabled.title'),
+        label: <Tooltip title={reason}>{t('memory.enabled.title')}</Tooltip>,
         layout: 'horizontal',
         minWidth: undefined,
         name: 'enabled',
@@ -79,7 +75,7 @@ const MemorySetting = memo(() => {
     <Form
       collapsible={false}
       form={form}
-      initialValues={memory}
+      initialValues={{ ...memory, enabled: memory?.enabled !== false }}
       items={[memorySettings]}
       itemsType={'group'}
       variant={'filled'}

--- a/src/features/Settings/memory/features/Memory.tsx
+++ b/src/features/Settings/memory/features/Memory.tsx
@@ -33,10 +33,11 @@ const MemorySetting = memo(() => {
       {
         children: <Switch disabled={!canManageMemory} />,
         desc: t('memory.enabled.desc'),
-        label: <Tooltip title={reason}>{t('memory.enabled.title')}</Tooltip>,
+        label: t('memory.enabled.title'),
         layout: 'horizontal',
         minWidth: undefined,
         name: 'enabled',
+        tooltip: reason,
         valuePropName: 'checked',
       },
       {

--- a/src/features/Settings/memory/features/Memory.tsx
+++ b/src/features/Settings/memory/features/Memory.tsx
@@ -22,7 +22,8 @@ const MemorySetting = memo(() => {
   const { t } = useTranslation('setting');
   const { allowed: canManageMemory, reason } = usePermission('manage_settings');
   const [form] = Form.useForm();
-  const { memory } = useUserStore(settingsSelectors.currentSettings, isEqual);
+  const memory = useUserStore(settingsSelectors.currentMemorySettings, isEqual);
+  const memoryEnabled = useUserStore(settingsSelectors.memoryEnabled);
   const [setSettings, isUserStateInit] = useUserStore((s) => [s.setSettings, s.isUserStateInit]);
   const { status: saveStatus, lastSavedAt, save, retry } = useSaveState();
 
@@ -48,7 +49,7 @@ const MemorySetting = memo(() => {
               disabled={!canManageMemory}
               levels={MEMORY_EFFORT_LEVELS}
               style={{ minWidth: 160 }}
-              value={memory?.effort ?? 'medium'}
+              value={memory.effort}
               marks={{
                 0: t('memory.effort.level.low'),
                 1: t('memory.effort.level.medium'),
@@ -76,7 +77,7 @@ const MemorySetting = memo(() => {
     <Form
       collapsible={false}
       form={form}
-      initialValues={{ ...memory, enabled: memory?.enabled !== false }}
+      initialValues={{ ...memory, enabled: memoryEnabled }}
       items={[memorySettings]}
       itemsType={'group'}
       variant={'filled'}

--- a/src/features/Settings/tts/features/OpenAI.tsx
+++ b/src/features/Settings/tts/features/OpenAI.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { type FormGroupItemType } from '@lobehub/ui';
-import { Form, Icon, Skeleton, Tooltip } from '@lobehub/ui';
+import { Form, Icon, Skeleton } from '@lobehub/ui';
 import { Select } from '@lobehub/ui/base-ui';
 import isEqual from 'fast-deep-equal';
 import { Loader2Icon } from 'lucide-react';
@@ -32,13 +32,11 @@ const OpenAI = memo(() => {
       {
         className: serviceModelFormStyles.centeredLabel,
         children: (
-          <Tooltip title={reason}>
-            <Select
-              disabled={!canManageServiceModel}
-              options={opeanaiTTSOptions}
-              style={{ width: 'min(100%, 448px)' }}
-            />
-          </Tooltip>
+          <Select
+            disabled={!canManageServiceModel}
+            options={opeanaiTTSOptions}
+            style={{ width: 'min(100%, 448px)' }}
+          />
         ),
         label: (
           <SettingsSearchAnchor id={'service-model-tts'}>
@@ -46,6 +44,7 @@ const OpenAI = memo(() => {
           </SettingsSearchAnchor>
         ),
         name: ['openAI', 'ttsModel'],
+        tooltip: reason,
       },
     ],
     extra: loading && <Icon spin icon={Loader2Icon} size={16} style={{ opacity: 0.5 }} />,

--- a/src/features/Settings/tts/features/OpenAI.tsx
+++ b/src/features/Settings/tts/features/OpenAI.tsx
@@ -21,7 +21,7 @@ const OpenAI = memo(() => {
   const { t } = useTranslation('setting');
   const { allowed: canManageServiceModel, reason } = usePermission('manage_settings');
   const [form] = Form.useForm();
-  const { tts } = useUserStore(settingsSelectors.currentSettings, isEqual);
+  const tts = useUserStore(settingsSelectors.currentTTS, isEqual);
   const [setSettings, isUserStateInit] = useUserStore((s) => [s.setSettings, s.isUserStateInit]);
   const [loading, setLoading] = useState(false);
 


### PR DESCRIPTION
<!-- Brief and heads-up -->

Integrates the community fix from #18189 with its original commit and authorship preserved, then applies the same root-cause fix to every other affected settings form.

Form-managed controls must be direct children of `Form.Item`; wrapping them in `Tooltip` prevented Ant Design Form from injecting values and change handlers. The memory switch therefore displayed an incorrect default and did not persist changes. The OpenAI TTS selector and the image default-count slider had the same disconnected binding.

Changes:
- Preserve @ump45nose's original `df3caf6d` memory fix and regression tests from #18189.
- Restore Form binding for the OpenAI TTS selector and the image default-count slider (`defaultImageNum`), moving permission guidance to the form item's native `tooltip`.
- Bind displayed defaults to the runtime selectors (`memoryEnabled` / `currentMemorySettings` / `currentTTS`) instead of inline fallbacks, so the settings UI matches effective runtime behavior by construction in any deployment (including server-provided defaults). Thanks @6e6p1k for diagnosing the display-default mismatch in #18156.
- The Memory regression tests now run the real settings selectors instead of mocked ones.

| Before | After |
| ------ | ----- |
| Memory, TTS, and image controls could be disconnected from Form state | Controls receive Form values and persist user changes; displayed defaults match runtime behavior |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check` — lint clean, 2 regression tests passed. Both tests fail against the pre-fix implementation.

Note: `check` emits an advisory that `Memory.test.tsx` is a new React component test (testing skill: "no new component tests"). Kept deliberately: the bug is a component-composition defect (`Tooltip` blocking `Form.Item` prop injection), which cannot be reproduced by extracting logic into a hook. Happy to restructure if maintainers prefer.

#### 🔗 Related Issue

Fixes #18156
Includes #18189 with its original community commit and author attribution preserved — maintainers: please close #18189 manually after this merges (GitHub closing keywords don't auto-close PRs).
