### PR TITLE
💄 style(notification): refine inbox item metadata

### DIFF
--- a/src/features/HomeSidebar/Header/components/InboxDrawer/NotificationItem.tsx
+++ b/src/features/HomeSidebar/Header/components/InboxDrawer/NotificationItem.tsx
@@ -133,14 +133,14 @@ const NotificationItem = memo<NotificationItemProps>(
               <Text ellipsis={{ rows: 3 }} title={preview} wordBreak="break-word">
                 {preview}
               </Text>
-              {context && (
-                <Text ellipsis fontSize={12} title={context} type="secondary">
-                  {context}
-                </Text>
-              )}
               <Flexbox horizontal align="center" gap={4}>
+                {context && (
+                  <Text ellipsis fontSize={12} title={context} type="secondary">
+                    {context}
+                  </Text>
+                )}
                 <Icon color={cssVar.colorTextDescription} icon={TypeIcon} size={12} />
-                <Text fontSize={12} type="secondary">
+                <Text fontSize={12} style={{ flexShrink: 0 }} type="secondary">
                   {formatNotificationRelativeTime(createdAt, dateLocale)}
                 </Text>
               </Flexbox>

--- a/src/features/HomeSidebar/Header/components/InboxDrawer/NotificationItem.tsx
+++ b/src/features/HomeSidebar/Header/components/InboxDrawer/NotificationItem.tsx
@@ -134,13 +134,17 @@ const NotificationItem = memo<NotificationItemProps>(
                 {preview}
               </Text>
               <Flexbox horizontal align="center" gap={4}>
+                <Icon color={cssVar.colorTextDescription} icon={TypeIcon} size={12} />
                 {context && (
                   <Text ellipsis fontSize={12} title={context} type="secondary">
                     {context}
                   </Text>
                 )}
-                <Icon color={cssVar.colorTextDescription} icon={TypeIcon} size={12} />
-                <Text fontSize={12} style={{ flexShrink: 0 }} type="secondary">
+                <Text
+                  fontSize={12}
+                  style={{ flexShrink: 0, marginInlineStart: 'auto' }}
+                  type="secondary"
+                >
                   {formatNotificationRelativeTime(createdAt, dateLocale)}
                 </Text>
               </Flexbox>

--- a/src/features/HomeSidebar/Header/components/InboxDrawer/NotificationItem.tsx
+++ b/src/features/HomeSidebar/Header/components/InboxDrawer/NotificationItem.tsx
@@ -27,7 +27,7 @@ const styles = createStaticStyles(({ css }) => ({
     margin-block-start: 7px;
     border-radius: 50%;
 
-    background: ${cssVar.colorPrimary};
+    background: ${cssVar.colorInfo};
   `,
 }));
 
@@ -127,24 +127,19 @@ const NotificationItem = memo<NotificationItemProps>(
           variant="borderless"
           onClick={handleClick}
         >
-          <Flexbox horizontal align="flex-start" gap={8}>
-            <Icon
-              color={cssVar.colorTextDescription}
-              icon={TypeIcon}
-              size={18}
-              style={{ flexShrink: 0, marginTop: 2 }}
-            />
-            <Flexbox horizontal align="flex-start" flex={1} gap={6} style={{ overflow: 'hidden' }}>
-              {!isRead && <span className={styles.unreadDot} />}
-              <Flexbox flex={1} gap={4} style={{ overflow: 'hidden' }}>
-                <Text ellipsis={{ rows: 3 }} title={preview} wordBreak="break-word">
-                  {preview}
+          <Flexbox horizontal align="flex-start" gap={6}>
+            {!isRead && <span className={styles.unreadDot} />}
+            <Flexbox flex={1} gap={4} style={{ overflow: 'hidden' }}>
+              <Text ellipsis={{ rows: 3 }} title={preview} wordBreak="break-word">
+                {preview}
+              </Text>
+              {context && (
+                <Text ellipsis fontSize={12} title={context} type="secondary">
+                  {context}
                 </Text>
-                {context && (
-                  <Text ellipsis fontSize={12} title={context} type="secondary">
-                    {context}
-                  </Text>
-                )}
+              )}
+              <Flexbox horizontal align="center" gap={4}>
+                <Icon color={cssVar.colorTextDescription} icon={TypeIcon} size={12} />
                 <Text fontSize={12} type="secondary">
                   {formatNotificationRelativeTime(createdAt, dateLocale)}
                 </Text>


### PR DESCRIPTION
## Summary

- use the info-blue token for unread notification dots
- move the notification type icon into the metadata row before the type label
- keep the relative timestamp right-aligned on the same row
- render notification previews through the existing plain-text Markdown sanitizer

## Verification

- `bun run check src/features/HomeSidebar/Header/components/InboxDrawer/NotificationItem.tsx src/features/HomeSidebar/Header/components/InboxDrawer/toNotificationPreview.ts src/features/HomeSidebar/Header/components/InboxDrawer/toNotificationPreview.test.ts`
- Agent Testing acceptance: https://lobehub.com/acceptance/e429bade-7824-4e23-b9a9-47e2ab14f267?r=3