### PR TITLE
🐛 fix(home): make acceptance notices dismissible

### DIFF
--- a/locales/en-US/home.json
+++ b/locales/en-US/home.json
@@ -10,7 +10,7 @@
   "brief.action.feedback": "Feedback",
   "brief.action.ignore": "Ignore",
   "brief.action.retry": "Retry",
-  "brief.action.review": "Review delivery",
+  "brief.action.review": "Go to acceptance",
   "brief.action.upgrade": "Upgrade plan",
   "brief.actionFailed": "That didn't go through. Please try again.",
   "brief.addFeedback": "Share feedback",

--- a/locales/zh-CN/home.json
+++ b/locales/zh-CN/home.json
@@ -10,7 +10,7 @@
   "brief.action.feedback": "反馈",
   "brief.action.ignore": "忽略",
   "brief.action.retry": "重试",
-  "brief.action.review": "验收交付",
+  "brief.action.review": "去验收",
   "brief.action.upgrade": "升级方案",
   "brief.actionFailed": "操作没有成功，请再试一次。",
   "brief.addFeedback": "分享反馈",

--- a/packages/locales/src/default/home.ts
+++ b/packages/locales/src/default/home.ts
@@ -10,7 +10,7 @@ export default {
   'brief.action.confirmDone': 'Confirm complete',
   'brief.action.feedback': 'Feedback',
   'brief.action.ignore': 'Ignore',
-  'brief.action.review': 'Review delivery',
+  'brief.action.review': 'Go to acceptance',
   'brief.action.retry': 'Retry',
   'brief.action.upgrade': 'Upgrade plan',
   'brief.actionFailed': "That didn't go through. Please try again.",

--- a/src/features/DailyBrief/BriefCardActions.tsx
+++ b/src/features/DailyBrief/BriefCardActions.tsx
@@ -111,9 +111,23 @@ const BriefCardActions = memo<BriefCardActionsProps>(
     const resultLabelKey =
       taskStatus === 'scheduled' ? 'brief.action.confirm' : 'brief.action.confirmDone';
 
-    const actions: BriefAction[] = isResult
+    const configuredActions: BriefAction[] = isResult
       ? [{ key: 'approve', label: t(resultLabelKey), type: 'resolve' }]
       : (actionsProp ?? DEFAULT_BRIEF_ACTIONS[briefType] ?? []);
+    // A link only navigates; it does not resolve the brief. Goal-delivery
+    // decisions intentionally point at the acceptance workspace, but older and
+    // current rows would otherwise have no way to leave the "Needs you" queue
+    // without completing that separate workflow. Keep the link primary and add
+    // an explicit neutral escape hatch for any link-only decision payload.
+    const actions =
+      briefType === 'decision' &&
+      configuredActions.some((action) => action.type === 'link') &&
+      configuredActions.every((action) => action.type === 'link')
+        ? [
+            ...configuredActions,
+            { key: 'ignore', label: t('brief.action.ignore'), type: 'resolve' as const },
+          ]
+        : configuredActions;
 
     const getActionLabel = useCallback(
       (action: BriefAction) => {

--- a/src/features/DailyBrief/__tests__/BriefCardActions.test.tsx
+++ b/src/features/DailyBrief/__tests__/BriefCardActions.test.tsx
@@ -141,6 +141,22 @@ describe('BriefCardActions', () => {
     expect(screen.getByText('Approve')).toBeInTheDocument();
   });
 
+  it('adds an ignore action to a link-only decision so it can leave Needs you', async () => {
+    mockResolveBrief.mockResolvedValueOnce(undefined);
+    renderWithRouter(
+      <BriefCardActions
+        actions={[{ key: 'review', label: 'Review delivery', type: 'link', url: '/acceptance/1' }]}
+        briefId="brief-goal"
+        briefType="decision"
+      />,
+    );
+
+    expect(screen.getByText('Review delivery')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('brief.action.ignore'));
+
+    await waitFor(() => expect(mockResolveBrief).toHaveBeenCalledWith('brief-goal', 'ignore'));
+  });
+
   it('should render comment action button', () => {
     const { container } = renderWithRouter(
       <BriefCardActions

--- a/src/features/Home/CustomizeModal/config.ts
+++ b/src/features/Home/CustomizeModal/config.ts
@@ -1,7 +1,6 @@
-// The sections the inbox owns, which is also what the rail can host. Kept apart
-// from the full key list because the main column's own blocks (recents, tasks)
-// never appear in the rail — folding them in would keep the rail alive on the
-// strength of a section it cannot show.
+// The sections HomeInbox owns. Kept apart from the full key list because the
+// main column's standalone blocks (recents, tasks) are rendered by
+// HomeModeContent rather than HomeInbox.
 export const HOME_INBOX_WIDGET_KEYS = [
   'goals',
   'needsYou',
@@ -30,7 +29,7 @@ export type HomeWidgetKey = (typeof HOME_WIDGET_KEYS)[number];
  *
  * That makes membership a fact about the page, not a taste call: the main
  * column carries the agent feeds and the two task blocks, and the rail carries
- * goals, running, news and suggestions (`RAIL_INBOX_PROPS` hides needs-you and
+ * goals, news and suggestions (`RAIL_INBOX_PROPS` hides needs-you, running and
  * unread from the rail; `ownsRailSections` decides the rest). A widget that
  * moves columns must move groups with it.
  *
@@ -38,9 +37,9 @@ export type HomeWidgetKey = (typeof HOME_WIDGET_KEYS)[number];
  * and scanning Home walk the same path.
  */
 export const HOME_WIDGET_GROUPS = [
-  { key: 'agent', widgets: ['recents', 'unread', 'needsYou'] },
+  { key: 'agent', widgets: ['unread', 'needsYou', 'running', 'recents'] },
   { key: 'task', widgets: ['tasks', 'scheduledTasks'] },
-  { key: 'rail', widgets: ['goals', 'running', 'news', 'suggestions'] },
+  { key: 'rail', widgets: ['goals', 'news', 'suggestions'] },
 ] as const satisfies ReadonlyArray<{ key: string; widgets: readonly HomeWidgetKey[] }>;
 
 export type HomeWidgetGroupKey = (typeof HOME_WIDGET_GROUPS)[number]['key'];

--- a/src/features/Home/CustomizeModal/useHomeCustomization.test.ts
+++ b/src/features/Home/CustomizeModal/useHomeCustomization.test.ts
@@ -108,14 +108,14 @@ describe('HOME_WIDGET_GROUPS', () => {
   });
 
   // The groups name where a section sits on Home, so membership is a fact about
-  // the page rather than a taste call. `RAIL_INBOX_PROPS` keeps needs-you and
-  // unread out of the rail, and `ownsRailSections` gives running / news /
-  // suggestions to it; goals renders in the rail card. Move a section between
-  // columns and this test is the thing that says the panel now lies.
+  // the page rather than a taste call. Live running work now sits in the main
+  // agent flow before recents; goals, news and suggestions occupy the rail.
+  // Move a section between columns and this test is the thing that says the
+  // panel now lies.
   it.each([
-    ['agent', ['recents', 'unread', 'needsYou']],
+    ['agent', ['unread', 'needsYou', 'running', 'recents']],
     ['task', ['tasks', 'scheduledTasks']],
-    ['rail', ['goals', 'running', 'news', 'suggestions']],
+    ['rail', ['goals', 'news', 'suggestions']],
   ])('groups %s by where those sections render on Home', (key, widgets) => {
     expect(HOME_WIDGET_GROUPS.find((group) => group.key === key)?.widgets).toEqual(widgets);
   });

--- a/src/features/Home/HomeModeContent.tsx
+++ b/src/features/Home/HomeModeContent.tsx
@@ -101,9 +101,9 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
 interface HomeModeContentProps {
   /**
-   * The rail is folded away, so this column carries the sections it owns: what
-   * is in flight and what happened stay above the recent topics, and the
-   * suggestions — nothing that happened, only what you could do — land after.
+   * The rail is folded away, so this column carries the sections it owns: goals
+   * and reports stay visible, while suggestions — nothing that happened, only
+   * what you could do — land after the recent topics.
    */
   inlineRail?: boolean;
   mode: HomeMode;
@@ -573,8 +573,8 @@ const HomeModeContent = memo<HomeModeContentProps>(({ inlineRail, mode, onSugges
     if (!inlineRail) return <Flexbox gap={32}>{taskBlocks}</Flexbox>;
 
     // The rail's sections sit beside task mode while it is open, so a folded
-    // rail must not take them away here either: in flight and what happened
-    // above the task list, suggestions after it. Unread and needs-you stay
+    // rail must not take them away here either: goals and reports above the
+    // task list, suggestions after it. Unread and needs-you stay
     // hidden — task mode never surfaces them, folded or not.
     return (
       <Flexbox gap={32}>

--- a/src/features/Home/railVisibility.test.ts
+++ b/src/features/Home/railVisibility.test.ts
@@ -41,7 +41,11 @@ describe('resolveRailVisibility', () => {
         hiddenWidgets: ['goals', 'running', 'news', 'suggestions'],
       }),
     ).toBe(false);
-    expect(RAIL_INBOX_PROPS).toEqual({ hideNeedsYou: true, hideUnread: true });
+    expect(RAIL_INBOX_PROPS).toEqual({
+      hideNeedsYou: true,
+      hideRunning: true,
+      hideUnread: true,
+    });
   });
 });
 
@@ -51,7 +55,7 @@ describe('canHostRail', () => {
   });
 
   it('goes false exactly when the rail has no widget left to show', () => {
-    expect(canHostRail(['goals', 'running', 'news', 'suggestions'])).toBe(false);
+    expect(canHostRail(['goals', 'news', 'suggestions'])).toBe(false);
   });
 
   it('stays true while needs-you and unread are the only ones off', () => {

--- a/src/features/Home/railVisibility.ts
+++ b/src/features/Home/railVisibility.ts
@@ -1,6 +1,10 @@
 import { hasVisibleRailWidget } from '@/features/HomeInbox/hiddenWidgets';
 
-export const RAIL_INBOX_PROPS = { hideNeedsYou: true, hideUnread: true } as const;
+export const RAIL_INBOX_PROPS = {
+  hideNeedsYou: true,
+  hideRunning: true,
+  hideUnread: true,
+} as const;
 
 interface RailVisibilityInput {
   hiddenWidgets: string[];

--- a/src/features/HomeInbox/hiddenWidgets.ts
+++ b/src/features/HomeInbox/hiddenWidgets.ts
@@ -11,16 +11,19 @@ export const filterHiddenWidgetSections = <T extends { key: string }>(
 interface ColumnWidgetInput {
   hiddenWidgets: string[];
   hideNeedsYou?: boolean;
+  hideRunning?: boolean;
   hideUnread?: boolean;
 }
 
 export const hasVisibleRailWidget = ({
   hiddenWidgets,
   hideNeedsYou,
+  hideRunning,
   hideUnread,
 }: ColumnWidgetInput): boolean =>
   HOME_INBOX_WIDGET_KEYS.some((key) => {
     if (hideNeedsYou && key === 'needsYou') return false;
+    if (hideRunning && key === 'running') return false;
     if (hideUnread && key === 'unread') return false;
 
     return !hiddenWidgets.includes(key);

--- a/src/features/HomeInbox/index.tsx
+++ b/src/features/HomeInbox/index.tsx
@@ -103,9 +103,11 @@ interface InboxSection {
  */
 interface HomeInboxProps {
   hideNeedsYou?: boolean;
+  /** Running activity belongs in the main column above recent topics. */
+  hideRunning?: boolean;
   hideUnread?: boolean;
   /**
-   * Main column only: the rail is collapsed, so the sections it owns (running,
+   * Main column only: the rail is collapsed, so the sections it owns (goals,
    * news) fold into this column instead of disappearing with it.
    */
   inlineRail?: boolean;
@@ -118,6 +120,7 @@ interface HomeInboxProps {
 const HomeInbox = memo<HomeInboxProps>((props) => {
   const {
     hideNeedsYou,
+    hideRunning,
     hideUnread,
     inlineRail,
     onScopeChange,
@@ -399,8 +402,10 @@ const HomeInbox = memo<HomeInboxProps>((props) => {
     }
   }
 
-  // No title: the card already says "3 tasks running" on its own head.
-  if (showRailSections && runningTopics.length > 0)
+  // No title: the card already says "3 tasks running" on its own head. Keep
+  // this in the main flow immediately before Recent topics; the rail is for
+  // glanceable reports, not live work the user may want to open.
+  if (!hideRunning && !isRail && runningTopics.length > 0)
     sections.push({
       key: 'running',
       node: (

--- a/src/features/HomeInbox/railSectionPlacement.test.ts
+++ b/src/features/HomeInbox/railSectionPlacement.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { ownsRailSections } from './railSectionPlacement';
 
 describe('ownsRailSections', () => {
-  it('leaves running and news to the rail while it is open', () => {
+  it('leaves goals and news to the rail while it is open', () => {
     expect(ownsRailSections({ variant: 'main' })).toBe(false);
     expect(ownsRailSections({ inlineRail: false, variant: 'main' })).toBe(false);
   });

--- a/src/features/HomeInbox/railSectionPlacement.ts
+++ b/src/features/HomeInbox/railSectionPlacement.ts
@@ -5,11 +5,11 @@ interface RailSectionPlacementInput {
 }
 
 /**
- * Whether this column carries the sections the rail owns — running and news.
+ * Whether this column carries the sections the rail owns — goals and news.
  *
  * They live in the rail while it is open; the main column takes them only once
  * it folds away, which is the difference between "collapsed" and "gone": a
- * folded rail must not take what is in flight and what happened off the page.
+ * folded rail must not take long-lived goals and daily reports off the page.
  */
 export const ownsRailSections = ({ inlineRail, variant }: RailSectionPlacementInput): boolean =>
   variant !== 'main' || Boolean(inlineRail);

--- a/src/features/HomeInbox/splitBriefs.test.ts
+++ b/src/features/HomeInbox/splitBriefs.test.ts
@@ -45,6 +45,16 @@ describe('splitBriefs', () => {
     expect(needsYou.map((b) => b.id)).toEqual(['dec', 'err']);
   });
 
+  it('removes an optimistically resolved decision from needsYou immediately', () => {
+    const resolved = {
+      ...brief('resolved', 'decision'),
+      resolvedAction: 'ignore',
+      resolvedAt: '2026-08-15T00:00:00.000Z',
+    } as BriefItem;
+
+    expect(splitBriefs([resolved]).needsYou).toEqual([]);
+  });
+
   it('preserves server order within the same rank', () => {
     const { needsYou } = splitBriefs([
       brief('d1', 'decision'),

--- a/src/features/HomeInbox/splitBriefs.ts
+++ b/src/features/HomeInbox/splitBriefs.ts
@@ -37,7 +37,10 @@ const isNewsBrief = (brief: BriefItem): boolean => NEWS_BRIEF_TYPES.includes(bri
  */
 export const splitBriefs = (briefs: BriefItem[]): SplitBriefs => ({
   needsYou: briefs
-    .filter((brief) => !isNewsBrief(brief))
+    // A successful optimistic resolve stamps the row before the unresolved-list
+    // SWR cache revalidates. Hide it immediately so "Ignore" actually closes the
+    // card instead of leaving a resolved tombstone in the queue until remount.
+    .filter((brief) => !brief.resolvedAt && !isNewsBrief(brief))
     .sort((a, b) => (NEEDS_YOU_ORDER[a.type] ?? 5) - (NEEDS_YOU_ORDER[b.type] ?? 5)),
   news: briefs.filter(isNewsBrief),
 });


### PR DESCRIPTION
## Summary

- rename goal delivery review actions to “Go to acceptance” / “去验收”
- add an Ignore action to link-only decision briefs and immediately remove resolved cards from Needs you
- move running tasks into the main column before Recent topics and align the Home customization order

## Verification

- `bun run check` on all 16 changed files
- 3/3 agent-testing acceptance cases passed with visually reviewed, non-blank screenshots
- Acceptance: https://app.lobehub.com/acceptance/5e2372f1-e4b3-48a2-8d8b-19718a5c33b4