### PR TITLE
💄 style: hide idle goal input border

### DIFF
--- a/src/features/AgentGoals/CreateGoalModal/CreateGoalContent.tsx
+++ b/src/features/AgentGoals/CreateGoalModal/CreateGoalContent.tsx
@@ -106,13 +106,11 @@ const styles = createStaticStyles(({ css }) => ({
     overflow: hidden;
 
     min-height: 208px;
-    border-block: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: 8px;
 
     background: ${cssVar.colorBgElevated};
   `,
   inputShellLoading: css`
-    border-color: transparent;
     background: ${cssVar.colorBgElevated};
 
     &::after {


### PR DESCRIPTION
## Summary

- remove the static border from the goal description editor in its idle state
- preserve the animated gradient border while AI is preparing the goal criteria

#### Test

- [x] Tested locally (`bun run check src/features/AgentGoals/CreateGoalModal/CreateGoalContent.tsx`)
- [ ] Added/updated tests
- [x] No tests needed — pure CSS state styling change