### PR TITLE
🐛 fix: adapt page actions for document modal

### DIFF
--- a/src/features/DocumentModal/Header.tsx
+++ b/src/features/DocumentModal/Header.tsx
@@ -1,32 +1,47 @@
 'use client';
 
-import { ActionIcon, Avatar, Flexbox, Skeleton, Text } from '@lobehub/ui';
-import { DropdownMenu, useModalContext } from '@lobehub/ui/base-ui';
+import { ActionIcon, Avatar, copyToClipboard, Flexbox, Skeleton, Text } from '@lobehub/ui';
+import { DropdownMenu, toast, useModalContext } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { MoreHorizontal, XIcon } from 'lucide-react';
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import ShareButton from '@/business/client/features/PageShare/ShareButton';
+import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import { DESKTOP_HEADER_ICON_SIZE, DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import { AutoSaveHint } from '@/features/EditorCanvas';
 import { useMenu } from '@/features/PageEditor/Header/useMenu';
 import { usePageAgentPanelControl } from '@/features/PageEditor/RightPanel/OverrideContext';
 import { usePageEditorStore } from '@/features/PageEditor/store';
 import ToggleRightPanelButton from '@/features/RightPanel/ToggleRightPanelButton';
+import { useAppOrigin } from '@/hooks/useAppOrigin';
 import { useDocumentStore } from '@/store/document';
 import { editorSelectors } from '@/store/document/slices/editor';
+
+import { buildDocumentModalUrl } from './url';
 
 const HEADER_HEIGHT = 44;
 
 const DocumentModalHeader = memo(() => {
   const { t } = useTranslation(['file', 'common']);
   const { close } = useModalContext();
+  const activeWorkspaceSlug = useActiveWorkspaceSlug();
+  const appOrigin = useAppOrigin();
 
   const [documentId, emoji, title] = usePageEditorStore((s) => [s.documentId, s.emoji, s.title]);
   const isDocumentLoading = useDocumentStore(editorSelectors.isDocumentLoading(documentId));
   const { expand: showPageAgentPanel, toggle: togglePageAgentPanel } = usePageAgentPanelControl();
-  const { menuItems } = useMenu();
+  const handleCopyLink = useCallback(async () => {
+    if (!documentId) return;
+    await copyToClipboard(buildDocumentModalUrl(appOrigin, documentId, activeWorkspaceSlug));
+    toast.success(t('pageEditor.linkCopied'));
+  }, [activeWorkspaceSlug, appOrigin, documentId, t]);
+  const { menuItems } = useMenu({
+    onCopyLink: handleCopyLink,
+    onDeleted: close,
+    onOpenHistory: () => togglePageAgentPanel(true),
+  });
 
   return (
     <Flexbox

--- a/src/features/DocumentModal/Header.tsx
+++ b/src/features/DocumentModal/Header.tsx
@@ -2,7 +2,7 @@
 
 import { ActionIcon, Avatar, copyToClipboard, Flexbox, Skeleton, Text } from '@lobehub/ui';
 import { DropdownMenu, toast, useModalContext } from '@lobehub/ui/base-ui';
-import { cssVar } from 'antd-style';
+import { createStaticStyles, cssVar } from 'antd-style';
 import { MoreHorizontal, XIcon } from 'lucide-react';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -22,6 +22,14 @@ import { editorSelectors } from '@/store/document/slices/editor';
 import { buildDocumentModalUrl } from './url';
 
 const HEADER_HEIGHT = 44;
+
+const styles = createStaticStyles(({ css }) => ({
+  shareButton: css`
+    & button:not(:hover, :focus-visible) {
+      background: transparent;
+    }
+  `,
+}));
 
 const DocumentModalHeader = memo(() => {
   const { t } = useTranslation(['file', 'common']);
@@ -70,17 +78,21 @@ const DocumentModalHeader = memo(() => {
         {documentId && !isDocumentLoading && (
           <AutoSaveHint documentId={documentId} style={{ marginLeft: 4 }} />
         )}
-      </Flexbox>
-      <Flexbox horizontal align={'center'} gap={4}>
-        {documentId && <ShareButton documentId={documentId} />}
         <DropdownMenu
           iconSpaceMode={'group'}
           items={menuItems}
-          placement={'bottomRight'}
+          placement={'bottomLeft'}
           popupProps={{ style: { minWidth: 200 } }}
         >
           <ActionIcon icon={MoreHorizontal} size={DESKTOP_HEADER_ICON_SMALL_SIZE} />
         </DropdownMenu>
+      </Flexbox>
+      <Flexbox horizontal align={'center'} gap={4}>
+        {documentId && (
+          <span className={styles.shareButton}>
+            <ShareButton documentId={documentId} />
+          </span>
+        )}
         <ToggleRightPanelButton
           expand={showPageAgentPanel}
           showActive={false}

--- a/src/features/DocumentModal/url.test.ts
+++ b/src/features/DocumentModal/url.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildDocumentModalUrl } from './url';
+
+describe('buildDocumentModalUrl', () => {
+  it('builds a canonical personal page URL independently of the current route', () => {
+    expect(buildDocumentModalUrl('https://example.com', 'doc-1')).toBe(
+      'https://example.com/page/doc-1',
+    );
+  });
+
+  it('includes the active workspace slug', () => {
+    expect(buildDocumentModalUrl('https://example.com', 'doc-1', 'acme')).toBe(
+      'https://example.com/acme/page/doc-1',
+    );
+  });
+});

--- a/src/features/DocumentModal/url.ts
+++ b/src/features/DocumentModal/url.ts
@@ -1,0 +1,10 @@
+import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
+
+export const buildDocumentModalUrl = (
+  appOrigin: string,
+  documentId: string,
+  activeWorkspaceSlug?: string | null,
+) => {
+  const path = buildWorkspaceAwarePath(`/page/${documentId}`, activeWorkspaceSlug);
+  return `${appOrigin}${path}`;
+};

--- a/src/features/PageEditor/Header/useMenu.test.tsx
+++ b/src/features/PageEditor/Header/useMenu.test.tsx
@@ -16,6 +16,12 @@ const resourcePermissionMock = vi.hoisted(() => ({
   workspaceId: undefined as string | undefined,
 }));
 const wsNavigateMock = vi.hoisted(() => vi.fn());
+const menuActionMocks = vi.hoisted(() => ({
+  handleCopyLink: vi.fn(),
+  handleDelete: vi.fn(),
+  setRightPanelMode: vi.fn(),
+  togglePageAgentPanel: vi.fn(),
+}));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -141,7 +147,7 @@ vi.mock('@/store/file', () => ({
 vi.mock('@/store/global', () => ({
   useGlobalStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
-      togglePageAgentPanel: vi.fn(),
+      togglePageAgentPanel: menuActionMocks.togglePageAgentPanel,
       toggleWideScreen: vi.fn(),
       wideScreen: false,
     }),
@@ -157,15 +163,15 @@ vi.mock('../store', () => ({
   usePageEditorStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
       documentId: 'doc-1',
-      setRightPanelMode: vi.fn(),
+      setRightPanelMode: menuActionMocks.setRightPanelMode,
     }),
   useStoreApi: () => ({
     getState: () => ({
       editor: {
         getDocument: () => '# Hello',
       },
-      handleCopyLink: vi.fn(),
-      handleDelete: vi.fn(),
+      handleCopyLink: menuActionMocks.handleCopyLink,
+      handleDelete: menuActionMocks.handleDelete,
       title: 'Hello',
     }),
   }),
@@ -180,7 +186,7 @@ describe('PageEditor header menu', () => {
     permissionMock.edit_own_content = true;
     resourcePermissionMock.canManage = false;
     resourcePermissionMock.workspaceId = undefined;
-    wsNavigateMock.mockClear();
+    vi.clearAllMocks();
   });
 
   it('places the member-permission page entry in the overflow menu for managers', () => {
@@ -218,5 +224,25 @@ describe('PageEditor header menu', () => {
     expect(getMenuItem(items, 'copy-link')).not.toMatchObject({ disabled: true });
     expect(getMenuItem(items, 'version-history')).not.toMatchObject({ disabled: true });
     expect(getMenuItem(items, 'export')).not.toMatchObject({ disabled: true });
+  });
+
+  it('uses surface-specific actions when provided', async () => {
+    const onCopyLink = vi.fn();
+    const onDeleted = vi.fn();
+    const onOpenHistory = vi.fn();
+    const { result } = renderHook(() => useMenu({ onCopyLink, onDeleted, onOpenHistory }));
+
+    (getMenuItem(result.current.menuItems, 'copy-link') as { onClick: () => void }).onClick();
+    (getMenuItem(result.current.menuItems, 'version-history') as { onClick: () => void }).onClick();
+    await (
+      getMenuItem(result.current.menuItems, 'delete') as { onClick: () => Promise<void> }
+    ).onClick();
+
+    expect(onCopyLink).toHaveBeenCalledOnce();
+    expect(menuActionMocks.handleCopyLink).not.toHaveBeenCalled();
+    expect(menuActionMocks.setRightPanelMode).toHaveBeenCalledWith('history');
+    expect(onOpenHistory).toHaveBeenCalledOnce();
+    expect(menuActionMocks.togglePageAgentPanel).not.toHaveBeenCalled();
+    expect(menuActionMocks.handleDelete).toHaveBeenCalledWith(expect.any(Function), onDeleted);
   });
 });

--- a/src/features/PageEditor/Header/useMenu.tsx
+++ b/src/features/PageEditor/Header/useMenu.tsx
@@ -38,7 +38,14 @@ import { usePageEditorStore, useStoreApi } from '../store';
 /**
  * Action menu for the page editor.
  */
-export const useMenu = (): { menuItems: any[] } => {
+interface UseMenuOptions {
+  onCopyLink?: () => void;
+  onDeleted?: () => void;
+  onOpenHistory?: () => void;
+}
+
+export const useMenu = (options: UseMenuOptions = {}): { menuItems: any[] } => {
+  const { onCopyLink, onDeleted, onOpenHistory } = options;
   const { i18n, t } = useTranslation(['file', 'common', 'chat', 'setting']);
 
   const storeApi = useStoreApi();
@@ -243,6 +250,10 @@ export const useMenu = (): { menuItems: any[] } => {
         key: 'copy-link',
         label: t('pageEditor.menu.copyLink'),
         onClick: () => {
+          if (onCopyLink) {
+            onCopyLink();
+            return;
+          }
           const state = storeApi.getState();
           state.handleCopyLink(t as any);
         },
@@ -253,7 +264,11 @@ export const useMenu = (): { menuItems: any[] } => {
         label: t('pageEditor.history.title'),
         onClick: () => {
           setRightPanelMode('history');
-          togglePageAgentPanel(true);
+          if (onOpenHistory) {
+            onOpenHistory();
+          } else {
+            togglePageAgentPanel(true);
+          }
         },
       },
       {
@@ -265,7 +280,7 @@ export const useMenu = (): { menuItems: any[] } => {
         onClick: async () => {
           if (!canEditPage) return;
           const state = storeApi.getState();
-          await state.handleDelete(t as any, state.onDelete);
+          await state.handleDelete(t as any, onDeleted ?? state.onDelete);
         },
       },
       {
@@ -343,6 +358,9 @@ export const useMenu = (): { menuItems: any[] } => {
     handleExportMarkdown,
     memberPermissionMenuItem,
     transferMenuItems,
+    onCopyLink,
+    onDeleted,
+    onOpenHistory,
   ]);
 
   return { menuItems };


### PR DESCRIPTION
## Summary

Follow-up to #18331 addressing the Codex review findings after that PR was merged:

- build copied links from the modal document ID and active workspace instead of the underlying route
- open version history through the modal-local panel controller
- close the modal after its document is deleted
- allow the shared Page editor menu to accept surface-specific action handlers

#### Test

- [x] Tested locally (`bun run check src/features/DocumentModal/Header.tsx src/features/DocumentModal/url.ts src/features/DocumentModal/url.test.ts src/features/PageEditor/Header/useMenu.tsx src/features/PageEditor/Header/useMenu.test.tsx`)
- [x] Added/updated tests
- [ ] No tests needed

6 related tests passed.