### PR TITLE
🐛 fix: sync page editor document mutations

### DIFF
--- a/package.json
+++ b/package.json
@@ -301,7 +301,7 @@
     "@lobehub/analytics": "^1.6.4",
     "@lobehub/charts": "^5.4.0",
     "@lobehub/desktop-ipc-typings": "workspace:*",
-    "@lobehub/editor": "^4.23.1",
+    "@lobehub/editor": "https://pkg.pr.new/@lobehub/editor@cb7405f",
     "@lobehub/icons": "^5.15.0",
     "@lobehub/market-sdk": "0.39.2",
     "@lobehub/tts": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -301,7 +301,7 @@
     "@lobehub/analytics": "^1.6.4",
     "@lobehub/charts": "^5.4.0",
     "@lobehub/desktop-ipc-typings": "workspace:*",
-    "@lobehub/editor": "https://pkg.pr.new/@lobehub/editor@cb7405f",
+    "@lobehub/editor": "^4.24.0",
     "@lobehub/icons": "^5.15.0",
     "@lobehub/market-sdk": "0.39.2",
     "@lobehub/tts": "^5.1.2",

--- a/packages/builtin-tool-agent-documents/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-agent-documents/src/ExecutionRuntime/index.ts
@@ -7,7 +7,7 @@ import {
   formatReplaceDocumentResult,
   formatUpdateLoadRuleResult,
 } from '@lobechat/prompts';
-import type { BuiltinServerRuntimeOutput } from '@lobechat/types';
+import type { BuiltinServerRuntimeOutput, BuiltinToolResult } from '@lobechat/types';
 
 import type {
   CopyDocumentArgs,
@@ -176,7 +176,7 @@ export interface AgentDocumentsRuntimeOptions {
    * on the gateway and the client service layer (which normally invalidates)
    * never runs. Invoked from the executor's `onAfterCall` lifecycle hook.
    */
-  onDocumentsMutated?: () => MaybePromise<void>;
+  onDocumentsMutated?: (result: BuiltinToolResult) => MaybePromise<void>;
 }
 
 export class AgentDocumentsExecutionRuntime {
@@ -192,8 +192,8 @@ export class AgentDocumentsExecutionRuntime {
    * mutation ran client- or server-side — covering the server-runtime path the
    * inline client service invalidation can't reach.
    */
-  notifyMutated(): Promise<void> {
-    return Promise.resolve(this.options.onDocumentsMutated?.());
+  notifyMutated(result: BuiltinToolResult): Promise<void> {
+    return Promise.resolve(this.options.onDocumentsMutated?.(result));
   }
 
   private resolveAgentId(context?: AgentDocumentOperationContext) {

--- a/packages/builtin-tool-agent-documents/src/executor/index.test.ts
+++ b/packages/builtin-tool-agent-documents/src/executor/index.test.ts
@@ -5,7 +5,7 @@ import { AgentDocumentsExecutionRuntime } from '../ExecutionRuntime';
 import { AgentDocumentsApiName } from '../types';
 import { AgentDocumentsExecutor } from './index';
 
-const makeExecutor = (onDocumentsMutated: () => void) => {
+const makeExecutor = (onDocumentsMutated: (result: ToolAfterCallContext['result']) => void) => {
   // onAfterCall only reaches runtime.notifyMutated → options.onDocumentsMutated,
   // so the service methods are never touched here.
   const runtime = new AgentDocumentsExecutionRuntime({} as never, { onDocumentsMutated });
@@ -17,7 +17,7 @@ const ctx = (apiName: string, success: boolean): ToolAfterCallContext =>
     apiName,
     identifier: 'lobe-agent-documents',
     params: {},
-    result: { success },
+    result: { state: { documentId: 'doc-1' }, success },
     toolCallId: 'call_1',
   }) as ToolAfterCallContext;
 
@@ -35,13 +35,18 @@ describe('AgentDocumentsExecutor.onAfterCall', () => {
     AgentDocumentsApiName.removeDocument,
     AgentDocumentsApiName.renameDocument,
     AgentDocumentsApiName.copyDocument,
+    AgentDocumentsApiName.modifyNodes,
+    AgentDocumentsApiName.replaceDocumentContent,
   ])('notifies for the %s mutation', async (apiName) => {
     const onDocumentsMutated = vi.fn();
     const executor = makeExecutor(onDocumentsMutated);
 
     await executor.onAfterCall(ctx(apiName, true));
 
-    expect(onDocumentsMutated).toHaveBeenCalledTimes(1);
+    expect(onDocumentsMutated).toHaveBeenCalledWith({
+      state: { documentId: 'doc-1' },
+      success: true,
+    });
   });
 
   it('skips notification when the call failed', async () => {
@@ -53,12 +58,11 @@ describe('AgentDocumentsExecutor.onAfterCall', () => {
     expect(onDocumentsMutated).not.toHaveBeenCalled();
   });
 
-  it('skips notification for read-only / content-only calls that leave the list unchanged', async () => {
+  it('skips notification for read-only calls', async () => {
     const onDocumentsMutated = vi.fn();
     const executor = makeExecutor(onDocumentsMutated);
 
     await executor.onAfterCall(ctx(AgentDocumentsApiName.listDocuments, true));
-    await executor.onAfterCall(ctx(AgentDocumentsApiName.replaceDocumentContent, true));
 
     expect(onDocumentsMutated).not.toHaveBeenCalled();
   });

--- a/packages/builtin-tool-agent-documents/src/executor/index.ts
+++ b/packages/builtin-tool-agent-documents/src/executor/index.ts
@@ -20,15 +20,15 @@ import {
   type UpdateLoadRuleArgs,
 } from '../types';
 
-// APIs that change the document set the client list renders (membership or
-// visible title). Content-only edits (replaceDocumentContent / modifyNodes) and
-// read-only calls are excluded — they don't alter the list. Used by
-// `onAfterCall` to decide when to refresh the client-side documents list.
-const LIST_MUTATING_APIS = new Set<string>([
+// Every API that mutates a document. Content-only edits must notify too: their
+// tool result carries the backing document id used to refresh an open editor.
+const DOCUMENT_MUTATING_APIS = new Set<string>([
   AgentDocumentsApiName.createDocument,
   AgentDocumentsApiName.removeDocument,
   AgentDocumentsApiName.renameDocument,
   AgentDocumentsApiName.copyDocument,
+  AgentDocumentsApiName.modifyNodes,
+  AgentDocumentsApiName.replaceDocumentContent,
 ]);
 
 export class AgentDocumentsExecutor extends BaseExecutor<typeof AgentDocumentsApiName> {
@@ -47,8 +47,8 @@ export class AgentDocumentsExecutor extends BaseExecutor<typeof AgentDocumentsAp
   // server-runtime path never touches the client store otherwise, so a created
   // doc wouldn't appear until a manual refresh.
   onAfterCall = async ({ apiName, result }: ToolAfterCallContext): Promise<void> => {
-    if (!LIST_MUTATING_APIS.has(apiName) || !result.success) return;
-    await this.runtime.notifyMutated();
+    if (!DOCUMENT_MUTATING_APIS.has(apiName) || !result.success) return;
+    await this.runtime.notifyMutated(result);
   };
 
   listDocuments = async (

--- a/src/features/ChatInput/InputEditor/plugins.ts
+++ b/src/features/ChatInput/InputEditor/plugins.ts
@@ -18,7 +18,7 @@ type EditorPlugins = NonNullable<Parameters<typeof Editor>[0]['plugins']>;
 
 interface CreateChatInputRichPluginsOptions {
   linkPlugin?: EditorPlugins[number] | false;
-  mathPlugin?: EditorPlugins[number];
+  mathPlugin?: EditorPlugins[number] | false;
 }
 
 export const CHAT_INPUT_EMBED_PLUGINS: EditorPlugins = [
@@ -38,6 +38,6 @@ export const createChatInputRichPlugins = ({
   ReactHRPlugin,
   ...(linkPlugin ? [linkPlugin] : []),
   ReactVirtualBlockPlugin,
-  mathPlugin,
+  ...(mathPlugin ? [mathPlugin] : []),
   ...CHAT_INPUT_EMBED_PLUGINS,
 ];

--- a/src/features/EditorCanvas/EditorCanvas.tsx
+++ b/src/features/EditorCanvas/EditorCanvas.tsx
@@ -37,6 +37,13 @@ interface UnsavedChangesGuardOptions {
 
 export interface EditorCanvasProps {
   /**
+   * Allow block plugins to render outside the editor's normal text column.
+   * Keep disabled for compact editor surfaces; PageEditor enables it for wide
+   * table scroll areas and their resize controls.
+   */
+  allowContentBleed?: boolean;
+
+  /**
    * Whether to enable auto-save in DocumentStore. Defaults to true.
    * Only applies when documentId is provided.
    */
@@ -72,6 +79,13 @@ export interface EditorCanvasProps {
     content?: string;
     editorData?: unknown;
   };
+
+  /**
+   * Convert `$...$` input and Markdown inline-math tokens into formula nodes.
+   * Defaults to true. PageEditor disables this because business documents use
+   * dollar signs far more often than inline formulas.
+   */
+  enableInlineMath?: boolean;
 
   /**
    * Entity ID (e.g., agentId, groupId) to track which entity is being edited.

--- a/src/features/EditorCanvas/InternalEditor.test.tsx
+++ b/src/features/EditorCanvas/InternalEditor.test.tsx
@@ -108,6 +108,45 @@ describe('InternalEditor', () => {
       // The style should include paddingBottom: 32 (default) merged with custom styles
       expect(editorContainer).toBeTruthy();
     });
+
+    it('should allow wide block controls to bleed outside the text column when enabled', async () => {
+      const { container, rerender } = render(<MinimalTestWrapper />);
+
+      await act(async () => {
+        await moment();
+      });
+
+      expect(container.firstElementChild).toHaveStyle({ overflow: 'hidden' });
+
+      rerender(<MinimalTestWrapper allowContentBleed />);
+
+      expect(container.firstElementChild).toHaveStyle({ overflow: 'visible' });
+    });
+
+    it('should keep inline LaTeX as plain text when inline math is disabled', async () => {
+      let editorInstance: IEditor | undefined;
+
+      render(
+        <TestWrapper
+          enableInlineMath={false}
+          onEditorReady={(editor) => {
+            editorInstance = editor;
+          }}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(editorInstance).toBeDefined();
+      });
+
+      await act(async () => {
+        editorInstance!.setDocument('markdown', 'Budget variable: $x$');
+        await moment();
+      });
+
+      expect(editorInstance!.getDocument('text')).toBe('Budget variable: $x$');
+      expect(JSON.stringify(editorInstance!.getDocument('json'))).not.toContain('"type":"math"');
+    });
   });
 
   describe('onInit callback', () => {

--- a/src/features/EditorCanvas/InternalEditor.tsx
+++ b/src/features/EditorCanvas/InternalEditor.tsx
@@ -6,6 +6,7 @@ import {
   ReactImagePlugin,
   ReactLinkPlugin,
   ReactLiteXmlPlugin,
+  ReactMathPlugin,
   ReactTablePlugin,
   ReactToolbarPlugin,
 } from '@lobehub/editor';
@@ -44,7 +45,7 @@ const fileNodeStyles = createStaticStyles(({ css }) => ({
  */
 const STATIC_PLUGINS = [
   ReactLiteXmlPlugin,
-  ...createChatInputRichPlugins({ linkPlugin: ReactLinkPlugin }),
+  ...createChatInputRichPlugins({ linkPlugin: ReactLinkPlugin, mathPlugin: false }),
   ReactTablePlugin,
 ];
 
@@ -98,10 +99,12 @@ export interface InternalEditorProps extends EditorCanvasProps {
  */
 const InternalEditor = memo<InternalEditorProps>(
   ({
+    allowContentBleed,
     contentChangeLockRef,
     disabled,
     editable = true,
     editor,
+    enableInlineMath = true,
     extraPlugins,
     floatingToolbar = true,
     onContentChange,
@@ -137,11 +140,11 @@ const InternalEditor = memo<InternalEditorProps>(
         maxWidth: '100%',
         minWidth: 0,
         opacity: disabled ? 0.65 : undefined,
-        overflow: 'hidden',
+        overflow: allowContentBleed ? 'visible' : 'hidden',
         pointerEvents: disabled ? 'none' : undefined,
         width: '100%',
       }),
-      [disabled],
+      [allowContentBleed, disabled],
     );
 
     // Build plugins array
@@ -160,10 +163,12 @@ const InternalEditor = memo<InternalEditorProps>(
         theme: { file: fileNodeStyles.fileWrapper as unknown as string },
       });
 
+      const mathPlugin = Editor.withProps(ReactMathPlugin, { enableInlineMath });
+
       // Build base plugins with optional extra plugins prepended
       const basePlugins = extraPlugins
-        ? [...extraPlugins, ...STATIC_PLUGINS, imagePlugin, filePlugin]
-        : [...STATIC_PLUGINS, imagePlugin, filePlugin];
+        ? [...extraPlugins, ...STATIC_PLUGINS, mathPlugin, imagePlugin, filePlugin]
+        : [...STATIC_PLUGINS, mathPlugin, imagePlugin, filePlugin];
 
       // Add toolbar only when the editor is actually editable — a locked /
       // read-only page must not surface the floating formatting toolbar on
@@ -191,6 +196,7 @@ const InternalEditor = memo<InternalEditorProps>(
       editable,
       editor,
       editorState,
+      enableInlineMath,
       extraPlugins,
       floatingToolbar,
       handleFileUpload,

--- a/src/features/PageEditor/EditorCanvas/index.tsx
+++ b/src/features/PageEditor/EditorCanvas/index.tsx
@@ -37,9 +37,11 @@ const EditorCanvas = memo<EditorCanvasProps>(({ askCopilotTarget, placeholder, s
 
   return (
     <SharedEditorCanvas
+      allowContentBleed
       documentId={documentId}
       editable={editable}
       editor={editor}
+      enableInlineMath={false}
       extraPlugins={extraPlugins}
       placeholder={placeholder || t('pageEditor.editorPlaceholder')}
       slashItems={slashItems}

--- a/src/store/tool/slices/builtin/executors/__tests__/lobe-agent-documents.test.ts
+++ b/src/store/tool/slices/builtin/executors/__tests__/lobe-agent-documents.test.ts
@@ -1,3 +1,4 @@
+import { AgentDocumentsApiName } from '@lobechat/builtin-tool-agent-documents';
 import type { BuiltinToolContext } from '@lobechat/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -9,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   copyDocument: vi.fn(),
   createDocument: vi.fn(),
   createForTopic: vi.fn(),
+  invalidateDocumentMutation: vi.fn(),
   listDocuments: vi.fn(),
   modifyNodes: vi.fn(),
   readDocument: vi.fn(),
@@ -38,6 +40,10 @@ vi.mock('@/services/agentDocument', () => ({
   },
 }));
 
+vi.mock('@/services/document/invalidation', () => ({
+  invalidateDocumentMutation: mocks.invalidateDocumentMutation,
+}));
+
 vi.mock('@/services/work', () => ({
   workService: {
     refreshConversation: mocks.refreshConversation,
@@ -61,6 +67,7 @@ describe('agentDocumentsExecutor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.refreshConversation.mockResolvedValue(undefined);
+    mocks.invalidateDocumentMutation.mockResolvedValue(undefined);
     // Drain any leftover so the shared per-toolCallId stash starts clean.
     takeWorkIntent('tool-call-1');
   });
@@ -117,5 +124,30 @@ describe('agentDocumentsExecutor', () => {
         type: 'document',
       }),
     );
+  });
+
+  it('refreshes an open document after a server-side content mutation completes', async () => {
+    await agentDocumentsExecutor.onAfterCall({
+      apiName: AgentDocumentsApiName.modifyNodes,
+      identifier: 'lobe-agent-documents',
+      params: {},
+      result: {
+        state: {
+          agentDocumentId: 'agent-document-1',
+          agentId: 'agent-1',
+          documentId: 'document-1',
+        },
+        success: true,
+      },
+      toolCallId: 'tool-call-1',
+      topicId: 'topic-1',
+    });
+
+    expect(mocks.invalidateDocumentMutation).toHaveBeenCalledWith({
+      agentDocumentId: 'agent-document-1',
+      agentId: 'agent-1',
+      cause: 'agent-document',
+      documentId: 'document-1',
+    });
   });
 });

--- a/src/store/tool/slices/builtin/executors/lobe-agent-documents.ts
+++ b/src/store/tool/slices/builtin/executors/lobe-agent-documents.ts
@@ -3,6 +3,7 @@ import { buildAgentDocumentUrl } from '@lobechat/builtin-tool-agent-documents';
 import { AgentDocumentsExecutionRuntime } from '@lobechat/builtin-tool-agent-documents/executionRuntime';
 import { AgentDocumentsExecutor } from '@lobechat/builtin-tool-agent-documents/executor';
 import { isDesktop } from '@lobechat/const';
+import { pickString, toRecord } from '@lobechat/utils/object';
 
 import { getActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import { agentDocumentService } from '@/services/agentDocument';
@@ -269,10 +270,16 @@ const runtime = new AgentDocumentsExecutionRuntime(
     // carries no agentId, so resolve the active chat agent — the one whose run
     // just produced the tool call. Covers the server-runtime path where the
     // client service layer never invalidates.
-    onDocumentsMutated: async () => {
-      const agentId = useAgentStore.getState().activeAgentId;
+    onDocumentsMutated: async (result) => {
+      const state = toRecord(result.state);
+      const agentId = pickString(state?.agentId) ?? useAgentStore.getState().activeAgentId;
       if (!agentId) return;
-      await invalidateDocumentMutation({ agentId, cause: 'agent-document' });
+      await invalidateDocumentMutation({
+        agentDocumentId: pickString(state?.agentDocumentId),
+        agentId,
+        cause: 'agent-document',
+        documentId: pickString(state?.documentId),
+      });
     },
   },
 );


### PR DESCRIPTION
## Summary

- let Page editor table UI bleed beyond the content wrapper so column resize handles remain usable
- disable inline `$...$` parsing in Page documents while retaining block math support
- invalidate the precise open document after agent document content mutations so remote changes rehydrate as editor diffs
- consume the editor PR package that includes configurable inline math and the LiteXML shared-command fix for accept/reject-all

Depends on lobehub/lobe-editor#197. Replace the pkg.pr.new dependency with the released version after that PR merges.

## Verification

- `bun run check <11 affected files>` — 56 tests passed, lint clean
- `bun run check --type` — types clean
- upstream editor math tests and type-check pass
