### PR TITLE
🐛 fix(billboard): await CTA action so the button shows loading

### DIFF
--- a/src/features/Billboard/Carousel.tsx
+++ b/src/features/Billboard/Carousel.tsx
@@ -161,12 +161,10 @@ const ItemContent = memo<{ billboardSlug: string; item: BillboardItem; position:
       [analytics, billboardSlug, item.id, position],
     );
 
-    const handleActionClick = useCallback(() => {
+    const handleActionClick = useCallback(async () => {
       if (!action) return;
       trackCtaClick({ action });
-      // handlers may be async (e.g. resetOnboarding persists before navigating);
-      // a failed action must never surface as an unhandled rejection on the card
-      void Promise.resolve(runBillboardAction(action)).catch(() => {});
+      await Promise.resolve(runBillboardAction(action)).catch(() => {});
     }, [action, trackCtaClick]);
 
     const handleLinkClick = useCallback(() => {


### PR DESCRIPTION
<!-- Brief and heads-up -->

Billboard custom actions can be async (e.g. `resetOnboarding` persists then navigates). The CTA click handler discarded that promise, so the button never entered loading.

Make `handleActionClick` async and await the action so the button shows loading until the work settles. Failures are still swallowed so they do not surface as unhandled rejections on the card.

| Before | After |
| ------ | ----- |
| Async action click looked idle until navigation | Async action click immediately shows button loading |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Clicking a sync action (`openChangelog` / `openFeedback`) stays instant. Clicking `resetOnboarding` enters loading through persist + refresh, then navigates to `/onboarding`.

#### 🔗 Related Issue

No matching GitHub issue.