### PR TITLE
🐛 fix: preserve session on provider key errors

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/verify.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/verify.test.ts
@@ -1,3 +1,4 @@
+import { getHTTPStatusCodeFromError } from '@trpc/server/http';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { verifyRouter } from '@/server/routers/lambda/verify';
@@ -87,15 +88,21 @@ describe('verifyRouter', () => {
   });
 
   describe('generateCriteria', () => {
-    it('preserves InvalidProviderAPIKey as an actionable client error', async () => {
+    it('preserves InvalidProviderAPIKey without returning a session-expired HTTP status', async () => {
       modelMocks.generateCriteria.mockRejectedValueOnce({ errorType: 'InvalidProviderAPIKey' });
 
-      await expect(
-        createCaller().generateCriteria({
+      const error = await createCaller()
+        .generateCriteria({
           goal: 'Ship a responsive task board',
           modelConfig: { model: 'claude-sonnet-4-6', provider: 'anthropic' },
-        }),
-      ).rejects.toMatchObject({ code: 'UNAUTHORIZED', message: 'InvalidProviderAPIKey' });
+        })
+        .catch((error) => error);
+
+      expect(error).toMatchObject({
+        code: 'PRECONDITION_FAILED',
+        message: 'InvalidProviderAPIKey',
+      });
+      expect(getHTTPStatusCodeFromError(error)).toBe(412);
     });
 
     it('does not rewrite unrelated generation failures', async () => {

--- a/apps/server/src/routers/lambda/__tests__/verify.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/verify.test.ts
@@ -1,6 +1,7 @@
 import { getHTTPStatusCodeFromError } from '@trpc/server/http';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { createTRPCErrorLogger } from '@/libs/trpc/utils/errorLogger';
 import { verifyRouter } from '@/server/routers/lambda/verify';
 import { FileService } from '@/server/services/file';
 import type * as VerifyServiceModule from '@/server/services/verify';
@@ -103,6 +104,16 @@ describe('verifyRouter', () => {
         message: 'InvalidProviderAPIKey',
       });
       expect(getHTTPStatusCodeFromError(error)).toBe(412);
+
+      const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      createTRPCErrorLogger('/api/trpc')({
+        error,
+        path: 'verify.generateCriteria',
+        type: 'mutation',
+      });
+      expect(infoSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
     });
 
     it('does not rewrite unrelated generation failures', async () => {

--- a/apps/server/src/routers/lambda/verify.ts
+++ b/apps/server/src/routers/lambda/verify.ts
@@ -498,7 +498,7 @@ export const verifyRouter = router({
         if (errorType === AgentRuntimeErrorType.InvalidProviderAPIKey) {
           throw new TRPCError({
             cause: error,
-            code: 'UNAUTHORIZED',
+            code: 'PRECONDITION_FAILED',
             message: AgentRuntimeErrorType.InvalidProviderAPIKey,
           });
         }

--- a/apps/server/src/routers/lambda/verify.ts
+++ b/apps/server/src/routers/lambda/verify.ts
@@ -38,6 +38,7 @@ import {
 import { isUuid } from '@/database/utils/uuid';
 import { publicProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
+import { markSilentTRPCErrorLog } from '@/libs/trpc/utils/errorLogger';
 import {
   AcceptanceService,
   createEvidenceFileResolver,
@@ -496,11 +497,15 @@ export const verifyRouter = router({
       } catch (error) {
         const errorType = (error as { errorType?: unknown } | null)?.errorType;
         if (errorType === AgentRuntimeErrorType.InvalidProviderAPIKey) {
-          throw new TRPCError({
+          const trpcError = new TRPCError({
             cause: error,
             code: 'PRECONDITION_FAILED',
             message: AgentRuntimeErrorType.InvalidProviderAPIKey,
           });
+          // Runtime errors are plain payloads, so tRPC normalizes them into an Error cause.
+          // Mark the normalized cause that the shared handler actually receives.
+          markSilentTRPCErrorLog(trpcError.cause);
+          throw trpcError;
         }
 
         throw error;


### PR DESCRIPTION
## Summary

- return provider API key failures as `PRECONDITION_FAILED` instead of session-level `UNAUTHORIZED`
- verify the serialized tRPC HTTP status is 412 so the shared lambda client does not log users out

## Testing

- `bun run check apps/server/src/routers/lambda/verify.ts apps/server/src/routers/lambda/__tests__/verify.test.ts`
- 31 tests passed