### PR TITLE
fix(security): remove API key fragments from OpenAPI logs

### DIFF
--- a/packages/openapi/src/middleware/auth.test.ts
+++ b/packages/openapi/src/middleware/auth.test.ts
@@ -21,6 +21,7 @@ const {
   mockAuthEnv,
   mockGetServerDB,
   mockExtractBearerToken,
+  mockDebugLog,
   mockServerDB,
   mockValidateApiKeyFormat,
   mockValidateOIDCJWT,
@@ -31,9 +32,14 @@ const {
   mockAuthEnv: { ENABLE_OIDC: true },
   mockExtractBearerToken: vi.fn(),
   mockGetServerDB: vi.fn(),
+  mockDebugLog: vi.fn(),
   mockServerDB: {},
   mockValidateApiKeyFormat: vi.fn(),
   mockValidateOIDCJWT: vi.fn(),
+}));
+
+vi.mock('debug', () => ({
+  default: vi.fn(() => mockDebugLog),
 }));
 
 vi.mock('@/database/core/db-adaptor', () => ({
@@ -227,5 +233,31 @@ describe('OpenAPI auth middleware', () => {
       ).status,
     ).toBe(401);
     expect(mockApiKeyFindByKey).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not log API Key fragments', async () => {
+    const rawApiKey = 'sk-lh-logregression1';
+    mockExtractBearerToken.mockReturnValue(rawApiKey);
+    mockValidateApiKeyFormat.mockReturnValue(true);
+    mockApiKeyFindByKey.mockResolvedValueOnce({
+      enabled: true,
+      expiresAt: null,
+      id: 'api-key-log',
+      name: 'Log regression key',
+      userId: 'user-log',
+      workspaceId: null,
+    });
+
+    const response = await createApp().request('/protected', {
+      headers: { Authorization: `Bearer ${rawApiKey}` },
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockDebugLog).toHaveBeenCalledWith('Bearer token received: present');
+
+    const leakedPrefix = rawApiKey.slice(0, 10);
+    for (const value of mockDebugLog.mock.calls.flat()) {
+      if (typeof value === 'string') expect(value).not.toContain(leakedPrefix);
+    }
   });
 });

--- a/packages/openapi/src/middleware/auth.ts
+++ b/packages/openapi/src/middleware/auth.ts
@@ -43,7 +43,7 @@ export const userAuthMiddleware = async (c: Context, next: Next) => {
 
   // Try Bearer token authentication - check format first to determine type
   if (bearerToken) {
-    log('Bearer token received: %s...', bearerToken.slice(0, 10));
+    log('Bearer token received: present');
 
     // Check if bearerToken matches API Key format (sk-lh-{16 alphanumeric chars})
     const isApiKeyFormat = validateApiKeyFormat(bearerToken);


### PR DESCRIPTION
> Resubmission of #17552 after the contributor fork was accidentally deleted. Rebased onto the current `canary` branch.

## Summary

- stop logging the first ten characters of bearer credentials
- log only that a bearer token is present
- add a regression test that rejects any leaked API-key prefix in debug-log calls

## Rebase notes

The original PR also hashed keys used by an in-memory validation cache. Current canary has removed that cache and revalidates API-key authorization on every request, so there is no raw credential cache to hash. This resubmission preserves the newer revocation-safe design and applies the remaining log-redaction fix.

## Validation

- unified changed-file check: 2 files lint clean; 6 related tests passed
- `git diff --check` passed
