### PR TITLE
✨ feat(auth): support custom cookie prefixes

### DIFF
--- a/docs/self-hosting/environment-variables/auth.mdx
+++ b/docs/self-hosting/environment-variables/auth.mdx
@@ -25,6 +25,13 @@ LobeHub provides a complete authentication service capability when deployed. The
 - Default: `-`
 - Example: `Tfhi2t2pelSMEA8eaV61KaqPNEndFFdMIxDaJnS1CUI=`
 
+#### `AUTH_COOKIE_PREFIX`
+
+- Type: Optional
+- Description: Prefix applied to every Better Auth cookie name. Configure a unique value when multiple deployments can write cookies on the same parent domain. Changing this value invalidates existing sessions for this deployment unless they are migrated separately.
+- Default: `better-auth`
+- Example: `my-lobehub`
+
 #### `AUTH_EMAIL_VERIFICATION`
 
 - Type: Optional

--- a/docs/self-hosting/environment-variables/auth.zh-CN.mdx
+++ b/docs/self-hosting/environment-variables/auth.zh-CN.mdx
@@ -23,6 +23,13 @@ LobeHub 在部署时提供了完善的身份验证服务能力，以下是相关
 - 默认值：`-`
 - 示例：`Tfhi2t2pelSMEA8eaV61KaqPNEndFFdMIxDaJnS1CUI=`
 
+#### `AUTH_COOKIE_PREFIX`
+
+- 类型：可选
+- 描述：应用于所有 Better Auth cookie 名称的前缀。当多个部署可能在同一父域名下写入 cookie 时，应为每个部署配置唯一值。修改此值会使当前部署的已有会话失效，除非另行迁移这些会话。
+- 默认值：`better-auth`
+- 示例：`my-lobehub`
+
 #### `AUTH_EMAIL_VERIFICATION`
 
 - 类型：可选

--- a/packages/env/src/__tests__/auth.test.ts
+++ b/packages/env/src/__tests__/auth.test.ts
@@ -1,0 +1,20 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('getAuthConfig', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should expose a custom Better Auth cookie prefix', async () => {
+    vi.stubEnv('AUTH_COOKIE_PREFIX', 'lobehub-oss');
+
+    const { getAuthConfig } = await import('../auth');
+
+    expect(getAuthConfig().AUTH_COOKIE_PREFIX).toBe('lobehub-oss');
+  });
+});

--- a/packages/env/src/auth.ts
+++ b/packages/env/src/auth.ts
@@ -36,42 +36,44 @@ declare global {
       AUTH_COGNITO_SECRET?: string;
 
       AUTH_COGNITO_USERPOOL_ID?: string;
+      // ===== Better Auth ===== //
+      /** Namespace every Better Auth cookie. Defaults to `better-auth`. */
+      AUTH_COOKIE_PREFIX?: string;
       AUTH_DISABLE_EMAIL_PASSWORD?: string;
-      AUTH_EMAIL_VERIFICATION?: string;
 
+      AUTH_EMAIL_VERIFICATION?: string;
       AUTH_ENABLE_MAGIC_LINK?: string;
       AUTH_FEISHU_APP_ID?: string;
-      AUTH_FEISHU_APP_SECRET?: string;
 
+      AUTH_FEISHU_APP_SECRET?: string;
       AUTH_GENERIC_OIDC_ID?: string;
       AUTH_GENERIC_OIDC_ISSUER?: string;
-      AUTH_GENERIC_OIDC_SECRET?: string;
 
+      AUTH_GENERIC_OIDC_SECRET?: string;
       AUTH_GITHUB_ID?: string;
       AUTH_GITHUB_SECRET?: string;
+
       // ===== Auth Provider Credentials ===== //
       AUTH_GOOGLE_ID?: string;
-
       AUTH_GOOGLE_SECRET?: string;
       AUTH_KEYCLOAK_ID?: string;
+
       AUTH_KEYCLOAK_ISSUER?: string;
-
       AUTH_KEYCLOAK_SECRET?: string;
-      AUTH_LOGTO_ID?: string;
 
+      AUTH_LOGTO_ID?: string;
       AUTH_LOGTO_ISSUER?: string;
       AUTH_LOGTO_SECRET?: string;
-      AUTH_MICROSOFT_AUTHORITY_URL?: string;
 
+      AUTH_MICROSOFT_AUTHORITY_URL?: string;
       AUTH_MICROSOFT_ID?: string;
       AUTH_MICROSOFT_SECRET?: string;
-      AUTH_MICROSOFT_TENANT_ID?: string;
 
+      AUTH_MICROSOFT_TENANT_ID?: string;
       AUTH_OKTA_ID?: string;
       AUTH_OKTA_ISSUER?: string;
-      AUTH_OKTA_SECRET?: string;
 
-      // ===== Better Auth ===== //
+      AUTH_OKTA_SECRET?: string;
       AUTH_SECRET?: string;
       AUTH_SSO_PROVIDERS?: string;
       AUTH_TRUSTED_ORIGINS?: string;
@@ -109,6 +111,7 @@ export const getAuthConfig = () => {
     clientPrefix: 'NEXT_PUBLIC_',
     client: {},
     server: {
+      AUTH_COOKIE_PREFIX: z.string().optional(),
       AUTH_SECRET: z.string().optional(),
       AUTH_SSO_PROVIDERS: z.string().optional().default(''),
       AUTH_TRUSTED_ORIGINS: z.string().optional(),
@@ -199,6 +202,7 @@ export const getAuthConfig = () => {
     },
 
     runtimeEnv: {
+      AUTH_COOKIE_PREFIX: process.env.AUTH_COOKIE_PREFIX,
       AUTH_EMAIL_VERIFICATION: process.env.AUTH_EMAIL_VERIFICATION === '1',
       AUTH_ENABLE_MAGIC_LINK: process.env.AUTH_ENABLE_MAGIC_LINK === '1',
       AUTH_SECRET: process.env.AUTH_SECRET,

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  authEnv: { AUTH_COOKIE_PREFIX: undefined as string | undefined },
+  defineConfig: vi.fn((config: unknown) => config),
+}));
+
+vi.mock('@/envs/auth', () => ({
+  authEnv: mocks.authEnv,
+}));
+
+vi.mock('@/libs/better-auth/define-config', () => ({
+  defineConfig: mocks.defineConfig,
+}));
+
+vi.unmock('@/auth');
+
+describe('auth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mocks.authEnv.AUTH_COOKIE_PREFIX = undefined;
+  });
+
+  it('keeps Better Auth default cookie prefix when no override is configured', async () => {
+    await import('./auth');
+
+    expect(mocks.defineConfig).toHaveBeenCalledWith({ plugins: [] });
+  });
+
+  it('uses the configured Better Auth cookie prefix', async () => {
+    mocks.authEnv.AUTH_COOKIE_PREFIX = 'lobehub-oss';
+
+    await import('./auth');
+
+    expect(mocks.defineConfig).toHaveBeenCalledWith({
+      cookiePrefix: 'lobehub-oss',
+      plugins: [],
+    });
+  });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,5 +1,7 @@
+import { authEnv } from '@/envs/auth';
 import { defineConfig } from '@/libs/better-auth/define-config';
 
 export const auth = defineConfig({
+  ...(authEnv.AUTH_COOKIE_PREFIX && { cookiePrefix: authEnv.AUTH_COOKIE_PREFIX }),
   plugins: [],
 });

--- a/src/libs/better-auth/define-config.test.ts
+++ b/src/libs/better-auth/define-config.test.ts
@@ -229,6 +229,15 @@ describe('defineConfig', () => {
     expect(options.advanced.crossSubDomainCookies).toBeUndefined();
   });
 
+  it('should namespace every Better Auth cookie with the configured prefix', async () => {
+    const { defineConfig } = await import('./define-config');
+
+    defineConfig({ cookiePrefix: 'example-app', plugins: [] });
+    const [options] = mocks.betterAuth.mock.lastCall!;
+
+    expect(options.advanced.cookiePrefix).toBe('example-app');
+  });
+
   it.each([['https://app.example.com'], ['https://example.com']])(
     'should share auth cookies across subdomains when APP_URL %s is under the cookie domain',
     async (appUrl) => {

--- a/src/libs/better-auth/define-config.ts
+++ b/src/libs/better-auth/define-config.ts
@@ -128,6 +128,8 @@ interface CustomBetterAuthOptions {
    * Omit to keep cookies host-only.
    */
   cookieDomain?: string;
+  /** Namespace every Better Auth cookie so colocated deployments cannot overwrite each other. */
+  cookiePrefix?: string;
   plugins: BetterAuthPlugin[];
 }
 
@@ -296,6 +298,7 @@ export function defineConfig(customOptions: CustomBetterAuthOptions) {
       ...(cookieDomain && {
         crossSubDomainCookies: { domain: cookieDomain, enabled: true },
       }),
+      ...(customOptions.cookiePrefix && { cookiePrefix: customOptions.cookiePrefix }),
       database: {
         /**
          * Align Better Auth user IDs with our shared idGenerator for consistency.


### PR DESCRIPTION
Expose an optional `cookiePrefix` argument on the shared Better Auth configuration and forward it to `advanced.cookiePrefix`.

Self-hosted deployments can set `AUTH_COOKIE_PREFIX` to isolate their auth cookies when multiple deployments share a parent domain. Existing deployments keep Better Auth's default `better-auth` prefix when the variable is not configured.

The self-hosting environment-variable documentation includes the configuration and warns that changing a deployed prefix invalidates that deployment's existing sessions unless they are migrated separately.

#### Test

- [x] Added regression coverage for custom prefix forwarding
- [x] Added environment-schema coverage for `AUTH_COOKIE_PREFIX`
- [x] Covered both default and custom self-host auth configuration
- [x] `bun run check`

#### 🔗 Related Issue

N/A
