### PR TITLE
🐛 fix(model-switch): commit selection before immediate send

### DIFF
--- a/src/features/ModelSwitchPanel/hooks/usePanelHandlers.test.ts
+++ b/src/features/ModelSwitchPanel/hooks/usePanelHandlers.test.ts
@@ -1,0 +1,48 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { usePanelHandlers } from './usePanelHandlers';
+
+const mocks = vi.hoisted(() => ({
+  allowed: true,
+  updateAgentConfig: vi.fn(),
+}));
+
+vi.mock('@/hooks/usePermission', () => ({
+  usePermission: () => ({ allowed: mocks.allowed }),
+}));
+
+vi.mock('@/store/agent', () => ({
+  useAgentStore: (
+    selector: (state: { updateAgentConfig: typeof mocks.updateAgentConfig }) => unknown,
+  ) => selector({ updateAgentConfig: mocks.updateAgentConfig }),
+}));
+
+describe('usePanelHandlers', () => {
+  beforeEach(() => {
+    mocks.allowed = true;
+    mocks.updateAgentConfig.mockReset();
+  });
+
+  it('commits the selected model before returning so an immediate send observes it', () => {
+    const onModelChange = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => usePanelHandlers({ onModelChange }));
+
+    act(() => result.current.handleModelChange('deepseek-chat', 'deepseek'));
+
+    expect(onModelChange).toHaveBeenCalledWith({
+      model: 'deepseek-chat',
+      provider: 'deepseek',
+    });
+  });
+
+  it('does not update the model without create-content permission', () => {
+    mocks.allowed = false;
+    const onModelChange = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => usePanelHandlers({ onModelChange }));
+
+    act(() => result.current.handleModelChange('deepseek-chat', 'deepseek'));
+
+    expect(onModelChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/ModelSwitchPanel/hooks/usePanelHandlers.ts
+++ b/src/features/ModelSwitchPanel/hooks/usePanelHandlers.ts
@@ -17,18 +17,17 @@ export const usePanelHandlers = ({
 
   const handleModelChange = useCallback(
     (modelId: string, providerId: string) => {
-      // Defer store update so the panel close animation completes
-      // before React re-renders with new data (prevents detail panel flash).
-      setTimeout(() => {
-        if (!canCreateContent) return;
+      if (!canCreateContent) return;
 
-        const params = { model: modelId, provider: providerId };
-        if (onModelChangeProp) {
-          onModelChangeProp(params);
-        } else {
-          updateAgentConfig(params);
-        }
-      }, 150);
+      // Commit the selection synchronously. Conversation sends resolve their
+      // runtime model from the store, so delaying this write lets a quick Enter
+      // after closing the panel run on the previously selected model (#15933).
+      const params = { model: modelId, provider: providerId };
+      if (onModelChangeProp) {
+        void onModelChangeProp(params);
+      } else {
+        void updateAgentConfig(params);
+      }
     },
     [canCreateContent, onModelChangeProp, updateAgentConfig],
   );


### PR DESCRIPTION
## Summary

- commit model selections synchronously instead of deferring the store update by 150 ms
- prevent a quick send after switching models from using the topic's previously pinned model
- add regression coverage for immediate selection visibility and permission gating

## Root cause

The model switch panel delayed `onModelChange` with `setTimeout(150)`. Since #15933 made the topic-pinned model the runtime source of truth, sending during that window resolved the previous topic model (for example Claude) even though the user had just selected DeepSeek. This could route the request to the wrong billed model.

Panel closing remains controlled by the dropdown state; only the business-state mutation is now immediate.

## Test plan

- `bun run check src/features/ModelSwitchPanel/hooks/usePanelHandlers.ts src/features/ModelSwitchPanel/hooks/usePanelHandlers.test.ts`