### PR TITLE
🐛 fix(acceptance): pin review predictions to a vision-capable model

### DIFF
--- a/apps/server/src/routers/lambda/acceptance.ts
+++ b/apps/server/src/routers/lambda/acceptance.ts
@@ -31,8 +31,8 @@ import {
   buildCheckReviewOverlay,
   createEvidenceFileResolver,
   mapWithConcurrency,
-  resolveVerifyModelConfig,
   REVIEW_PREDICT_CONCURRENCY,
+  REVIEW_PREDICT_MODEL_CONFIG,
   shouldSurfaceProposal,
   VerifyReviewPredictorService,
 } from '@/server/services/verify';
@@ -701,12 +701,9 @@ export const acceptanceRouter = router({
         runs.map((run) => ({ results: resultsByRun.get(run.id) ?? [], run })),
       );
 
-      const modelConfig = await resolveVerifyModelConfig(
-        ctx.serverDB,
-        acceptance.userId,
-        { verifierAgentId: acceptance.config?.verifierAgentId },
-        acceptance.workspaceId ?? undefined,
-      );
+      // Pinned, never the verifier's own model: the predictor reads screenshots,
+      // and a text-only verifier model silently judges frames it cannot see.
+      const modelConfig = REVIEW_PREDICT_MODEL_CONFIG;
 
       const predictor = new VerifyReviewPredictorService(
         ctx.serverDB,

--- a/apps/server/src/services/verify/__tests__/modelConfig.test.ts
+++ b/apps/server/src/services/verify/__tests__/modelConfig.test.ts
@@ -3,7 +3,11 @@ import { DEFAULT_PROVIDER } from '@lobechat/business-const';
 import { DEFAULT_MODEL } from '@lobechat/const';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { isHeterogeneousVerifyProvider, resolveVerifyModelConfig } from '../modelConfig';
+import {
+  isHeterogeneousVerifyProvider,
+  resolveVerifyModelConfig,
+  REVIEW_PREDICT_MODEL_CONFIG,
+} from '../modelConfig';
 
 const { getAgentModelConfigMock, getBuiltinAgentMock } = vi.hoisted(() => ({
   getAgentModelConfigMock: vi.fn(),
@@ -120,5 +124,27 @@ describe('resolveVerifyModelConfig', () => {
         parentProvider: null,
       }),
     ).resolves.toEqual({ model: DEFAULT_MODEL, provider: DEFAULT_PROVIDER });
+  });
+});
+
+describe('REVIEW_PREDICT_MODEL_CONFIG', () => {
+  /**
+   * Regression: in production the predictor once inherited the verifier's text
+   * model (deepseek-v4-pro). The channel stripped the screenshots, the model
+   * "accepted on missing evidence" for every check, and no proposal ever
+   * surfaced. The pinned model must be able to actually see the frames.
+   */
+  it('pins a model that model-bank says can read images', async () => {
+    const { google } = await import('model-bank');
+
+    const card = google.find(
+      (model) => model.id === REVIEW_PREDICT_MODEL_CONFIG.model && model.type === 'chat',
+    );
+    expect(REVIEW_PREDICT_MODEL_CONFIG.provider).toBe('google');
+    expect(
+      card,
+      `${REVIEW_PREDICT_MODEL_CONFIG.model} is not in model-bank's google chat list`,
+    ).toBeDefined();
+    expect(card!.type === 'chat' && card!.abilities?.vision).toBe(true);
   });
 });

--- a/apps/server/src/services/verify/__tests__/modelConfig.test.ts
+++ b/apps/server/src/services/verify/__tests__/modelConfig.test.ts
@@ -135,16 +135,18 @@ describe('REVIEW_PREDICT_MODEL_CONFIG', () => {
    * surfaced. The pinned model must be able to actually see the frames.
    */
   it('pins a model that model-bank says can read images', async () => {
-    const { google } = await import('model-bank');
+    const { LOBE_DEFAULT_MODEL_LIST } = await import('model-bank');
 
-    const card = google.find(
-      (model) => model.id === REVIEW_PREDICT_MODEL_CONFIG.model && model.type === 'chat',
+    const card = LOBE_DEFAULT_MODEL_LIST.find(
+      (model) =>
+        model.id === REVIEW_PREDICT_MODEL_CONFIG.model &&
+        model.providerId === REVIEW_PREDICT_MODEL_CONFIG.provider &&
+        model.type === 'chat',
     );
-    expect(REVIEW_PREDICT_MODEL_CONFIG.provider).toBe('google');
     expect(
       card,
-      `${REVIEW_PREDICT_MODEL_CONFIG.model} is not in model-bank's google chat list`,
+      `${REVIEW_PREDICT_MODEL_CONFIG.provider}/${REVIEW_PREDICT_MODEL_CONFIG.model} is not a chat model in model-bank`,
     ).toBeDefined();
-    expect(card!.type === 'chat' && card!.abilities?.vision).toBe(true);
+    expect(card!.abilities?.vision).toBe(true);
   });
 });

--- a/apps/server/src/services/verify/index.ts
+++ b/apps/server/src/services/verify/index.ts
@@ -28,7 +28,11 @@ export {
   syncGoalToolState,
 } from './goalLoop';
 export { runVerifyOnCompletion } from './lifecycle';
-export { isHeterogeneousVerifyProvider, resolveVerifyModelConfig } from './modelConfig';
+export {
+  isHeterogeneousVerifyProvider,
+  resolveVerifyModelConfig,
+  REVIEW_PREDICT_MODEL_CONFIG,
+} from './modelConfig';
 export { type GeneratePlanParams, VerifyPlanGeneratorService } from './planGenerator';
 export { instantiateVerifyPlanOnStart } from './planInstantiation';
 export {

--- a/apps/server/src/services/verify/modelConfig.ts
+++ b/apps/server/src/services/verify/modelConfig.ts
@@ -29,6 +29,24 @@ const HETEROGENEOUS_PROVIDER_IDS = new Set([
 export const isHeterogeneousVerifyProvider = (provider?: string | null): boolean =>
   Boolean(provider && HETEROGENEOUS_PROVIDER_IDS.has(provider));
 
+/**
+ * The model the review predictor judges evidence screenshots with.
+ *
+ * Deliberately NOT `resolveVerifyModelConfig`: that chain follows the verifier
+ * agent's chat model, which is chosen for text and may not read images at all.
+ * A text-only model never errors here — the channel strips the image parts, the
+ * model "accepts on missing evidence" at floor confidence, and no proposal ever
+ * surfaces. Predictions are also compared across acceptances, so one pinned
+ * vision model keeps the agreement stats about the model, not about whichever
+ * verifier each run happened to use.
+ *
+ * The pinned model MUST have `vision: true` in model-bank; a test guards this.
+ */
+export const REVIEW_PREDICT_MODEL_CONFIG: VerifyModelConfig = {
+  model: 'gemini-3.6-flash',
+  provider: 'google',
+};
+
 const isUsableVerifyModelConfig = (
   config?: { model?: string | null; provider?: string | null } | null,
 ): config is VerifyModelConfig =>

--- a/apps/server/src/services/verify/modelConfig.ts
+++ b/apps/server/src/services/verify/modelConfig.ts
@@ -1,5 +1,9 @@
 import { BUILTIN_AGENT_SLUGS } from '@lobechat/builtin-agents';
-import { DEFAULT_PROVIDER } from '@lobechat/business-const';
+import {
+  DEFAULT_PROVIDER,
+  DEFAULT_REVIEW_PREDICT_MODEL,
+  DEFAULT_REVIEW_PREDICT_PROVIDER,
+} from '@lobechat/business-const';
 import { DEFAULT_MODEL } from '@lobechat/const';
 
 import { AgentModel } from '@/database/models/agent';
@@ -41,10 +45,12 @@ export const isHeterogeneousVerifyProvider = (provider?: string | null): boolean
  * verifier each run happened to use.
  *
  * The pinned model MUST have `vision: true` in model-bank; a test guards this.
+ * The values live in `@lobechat/business-const` so the cloud build can override
+ * them without touching this service.
  */
 export const REVIEW_PREDICT_MODEL_CONFIG: VerifyModelConfig = {
-  model: 'gemini-3.6-flash',
-  provider: 'google',
+  model: DEFAULT_REVIEW_PREDICT_MODEL,
+  provider: DEFAULT_REVIEW_PREDICT_PROVIDER,
 };
 
 const isUsableVerifyModelConfig = (

--- a/packages/business/const/src/llm.ts
+++ b/packages/business/const/src/llm.ts
@@ -7,3 +7,12 @@ export const DEFAULT_MINI_PROVIDER = 'openai';
 
 export const DEFAULT_ONBOARDING_MODEL = 'gemini-3-flash-preview';
 export const DEFAULT_ONBOARDING_PROVIDER = 'google';
+
+/**
+ * The model Acceptance review predictions judge evidence screenshots with.
+ * MUST be vision-capable — a text-only model silently "accepts on missing
+ * evidence" for every check and no proposal ever surfaces (a model-bank
+ * test in apps/server guards this).
+ */
+export const DEFAULT_REVIEW_PREDICT_MODEL = 'gemini-3.6-flash';
+export const DEFAULT_REVIEW_PREDICT_PROVIDER = 'google';


### PR DESCRIPTION
### 问题

Acceptance 的 review prediction（模型预标注 feedback）上线后在生产"没效果"：点了生成、`after()` 批次正常执行、LLM 调用全部成功落库，但界面永远不出卡片。

从 `dc gen-tracing`（scenario `review_predict`）拉到的线上证据：

- 实际使用的模型是 `deepseek-v4-pro@lobehub` —— 来自 `resolveVerifyModelConfig` 复用 verifier 的 chat 模型，而它在 model-bank 里没有 `vision` 能力
- 渠道把图片部分替换成了 "Unsupported Image" 占位（input tokens 仅 ~1.2k，纯文本量），模型看不到任何截图
- prompt 规则"证据缺失不算 reject，accept 并降置信度"生效 → 三条全部 `action: accept`（confidence 0.15–0.25，comment 明说"附图无法查看"）
- UI 只为 `action === 'reject'` 渲染卡片 → 表现为零效果

### 修复

- 在 `@lobechat/business-const` 新增 `DEFAULT_REVIEW_PREDICT_MODEL = gemini-3.6-flash` / `DEFAULT_REVIEW_PREDICT_PROVIDER = google`（与 `DEFAULT_ONBOARDING_MODEL` 同模式，cloud 侧换掉 business stub 包即可 override）；离线跑批评分用的就是 gemini-3.6-flash，vision 输入 \$1.5/M，比 kimi-k3 便宜约 13 倍
- verify 服务导出 `REVIEW_PREDICT_MODEL_CONFIG` 引用这组常量；`predictReviews` 不再走 `resolveVerifyModelConfig`
- 固定模型同时保证 agreement 统计的可比性：预测结果不再随各 acceptance 的 verifier 配置漂移
- 回归测试：在 `LOBE_DEFAULT_MODEL_LIST` 里按 provider+model 查到 chat 卡并断言 `vision: true`（常量换成任何文本模型都会失败，且不锁死 provider）

### 验证

- `bun run check`：lint clean，7 tests passed
- `bun run check --type`：clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)