### PR TITLE
💄 fix(home): remove double hover highlight on compact recommendation rows

### DIFF
--- a/src/features/RecommendTaskTemplates/style.ts
+++ b/src/features/RecommendTaskTemplates/style.ts
@@ -37,6 +37,12 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     border: 0;
 
     text-align: start;
+
+    /* compactRow owns the hover highlight; the selector mirrors base-ui's
+       variantText hover rule so it can outrank its fill */
+    &:hover:not(:disabled, [aria-disabled='true']) {
+      background: none;
+    }
   `,
   compactTitle: css`
     min-width: 0;

--- a/src/features/Recommendations/style.ts
+++ b/src/features/Recommendations/style.ts
@@ -23,7 +23,9 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
 
     transition: background ${cssVar.motionDurationFast};
 
-    &:hover {
+    /* the selector mirrors base-ui's variantText hover rule so the row tint
+       can outrank its brighter fill */
+    &:hover:not(:disabled, [aria-disabled='true']) {
       background: ${cssVar.colorFillQuaternary};
     }
   `,


### PR DESCRIPTION
<!-- Brief and heads-up -->

Hovering a compact recommendation row on the home page (rail/main variants) showed **two stacked highlights**: a brighter box over the icon+title area (ending before the dismiss ×) plus a fainter tint over the whole row.

Root cause: the compact row is a wrapper `Flexbox` (row-level `hover → colorFillQuaternary`) containing a base-ui `type='text'` Button, whose built-in `variantText` hover fill (`colorFillSecondary`) also fires. The two backgrounds stack.

Fix — the row wrapper owns the single hover highlight:

- `RecommendTaskTemplates/style.ts`: suppress the inner text button's own hover fill in `compactMain`. The selector mirrors base-ui's `&:hover:not(:disabled, [aria-disabled='true'])` rule, since a plain `&:hover` loses the specificity contest against it.
- `Recommendations/style.ts`: the sibling `RecommendationCard` compact row had the same specificity problem in the other direction — its intended `colorFillQuaternary` hover was silently outranked by the library's brighter `colorFillSecondary`. Upgraded the selector so both row types now hover with the same `colorFillQuaternary` tint.

| Before | After |
| ------ | ----- |
| Two stacked highlights: bright inner box ending before ×, faint full-row tint | Single full-row `colorFillQuaternary` highlight, consistent across action rows and task-template rows |

#### Test

Pure hover-style fix; the only possible assertion would be source-string matching on the stylesheet.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

None