### PR TITLE
🐛 fix(home): exclude live schedules from recent tasks and align the block layout

### DIFF
--- a/src/features/Home/HomeModeContent.tsx
+++ b/src/features/Home/HomeModeContent.tsx
@@ -41,6 +41,7 @@ import { markdownToTxt } from '@/utils/markdownToTxt';
 
 import GroupBlock from './components/GroupBlock';
 import { homeType } from './components/homeType';
+import RunningGlyph from './components/RunningGlyph';
 import Time from './components/Time';
 import { isHomeWidgetHidden } from './CustomizeModal/config';
 import EmptySuggestions from './EmptySuggestions';
@@ -308,13 +309,23 @@ const TaskRow = memo<{ showTrigger?: boolean; task: TaskListItem }>(
   ({ showTrigger = true, task }) => {
     const title = task.name?.trim() || task.identifier;
     const description = useMemo(() => resolveTaskSummaryLine(task, title), [task, title]);
+    const status = normalizeTaskStatus(task.status);
 
     return (
       <Row
         description={description}
         href={taskDetailPath(task.identifier)}
-        icon={<TaskStatusIcon size={16} status={normalizeTaskStatus(task.status)} />}
         title={title}
+        // A row that is executing right now wears the shared animated running
+        // mark instead of the static glyph — the same liveness signal running
+        // topics and the home rail cards already use.
+        icon={
+          status === 'running' ? (
+            <RunningGlyph size={16} />
+          ) : (
+            <TaskStatusIcon size={16} status={status} />
+          )
+        }
         // The identifier is how the task is referred to everywhere else, so it
         // belongs beside the name rather than in the sentence slot below it.
         titleExtra={

--- a/src/features/Home/HomeModeContent.tsx
+++ b/src/features/Home/HomeModeContent.tsx
@@ -161,6 +161,14 @@ export const resolveTaskSummaryLine = (
 const normalizeTaskStatus = (status: string): TaskStatus =>
   TASK_STATUSES.has(status as TaskStatus) ? (status as TaskStatus) : 'backlog';
 
+/**
+ * Reserved width for the trailing timestamp. Relative and absolute forms differ
+ * in width ("4 分钟前" vs "8月13日"), and without a shared column each row's
+ * avatar drifts to wherever its own time happens to start — the right side of
+ * the list reads as ragged instead of as a column.
+ */
+const TIME_COLUMN_WIDTH = 56;
+
 const Row = memo<RowProps>(({ description, href, icon, title, titleExtra, trailing }) => (
   <WorkspaceLink className={cx(styles.rowBox, styles.row)} to={href}>
     <Flexbox horizontal align={'flex-start'} gap={12}>
@@ -218,7 +226,7 @@ const RecentTopicRow = memo<{ showAuthor?: boolean; topic: RecentItem }>(
         trailing={
           <Flexbox horizontal align={'center'} flex={'none'} gap={8}>
             {showAuthor && <AuthorChip userId={topic.userId} />}
-            <Time date={topic.updatedAt} />
+            <Time date={topic.updatedAt} minWidth={TIME_COLUMN_WIDTH} />
           </Flexbox>
         }
       />
@@ -287,50 +295,63 @@ const LoadingRows = memo<{ avatarSize?: number; withTime?: boolean }>(
 
 /**
  * A task in the home list carries the same right-hand read as the Tasks page:
- * how it is triggered, who runs it, when it last moved. Without that a task row
- * is indistinguishable from a topic row, and the section reads as another feed
- * rather than as work with an owner.
+ * who runs it, when it last moved — plus how it is triggered, but only in the
+ * scheduled block, where the trigger is the point. The recent block hides it:
+ * the runnable schedules are filtered out of that list anyway, and the ones
+ * that slip through are terminal leftovers whose schedule no longer fires, so
+ * printing it would claim an automation that is not there.
  */
-const TaskRow = memo<{ task: TaskListItem }>(({ task }) => {
-  const title = task.name?.trim() || task.identifier;
-  const description = useMemo(() => resolveTaskSummaryLine(task, title), [task, title]);
+const TaskRow = memo<{ showTrigger?: boolean; task: TaskListItem }>(
+  ({ showTrigger = true, task }) => {
+    const title = task.name?.trim() || task.identifier;
+    const description = useMemo(() => resolveTaskSummaryLine(task, title), [task, title]);
 
-  return (
-    <Row
-      description={description}
-      href={taskDetailPath(task.identifier)}
-      icon={<TaskStatusIcon size={16} status={normalizeTaskStatus(task.status)} />}
-      title={title}
-      // The identifier is how the task is referred to everywhere else, so it
-      // belongs beside the name rather than in the sentence slot below it.
-      titleExtra={
-        title === task.identifier ? undefined : (
-          <Text className={cx(homeType.meta, styles.identifier)}>{task.identifier}</Text>
-        )
-      }
-      trailing={
-        <Flexbox horizontal align={'center'} flex={'none'} gap={8}>
-          <TaskTriggerTag
-            automationMode={task.automationMode}
-            heartbeatInterval={task.heartbeatInterval}
-            schedulePattern={task.schedulePattern}
-            scheduleTimezone={task.scheduleTimezone}
-          />
-          <AssigneeAvatar agentId={task.assigneeAgentId} size={20} />
-          <Time date={task.updatedAt || task.createdAt} />
-        </Flexbox>
-      }
-    />
-  );
-});
+    return (
+      <Row
+        description={description}
+        href={taskDetailPath(task.identifier)}
+        icon={<TaskStatusIcon size={16} status={normalizeTaskStatus(task.status)} />}
+        title={title}
+        // The identifier is how the task is referred to everywhere else, so it
+        // belongs beside the name rather than in the sentence slot below it.
+        titleExtra={
+          title === task.identifier ? undefined : (
+            <Text className={cx(homeType.meta, styles.identifier)}>{task.identifier}</Text>
+          )
+        }
+        trailing={
+          <Flexbox horizontal align={'center'} flex={'none'} gap={8}>
+            {showTrigger && (
+              <TaskTriggerTag
+                automationMode={task.automationMode}
+                heartbeatInterval={task.heartbeatInterval}
+                schedulePattern={task.schedulePattern}
+                scheduleTimezone={task.scheduleTimezone}
+              />
+            )}
+            <AssigneeAvatar agentId={task.assigneeAgentId} size={20} />
+            <Time date={task.updatedAt || task.createdAt} minWidth={TIME_COLUMN_WIDTH} />
+          </Flexbox>
+        }
+      />
+    );
+  },
+);
 
 const TaskContent = memo(() => {
   const { t } = useTranslation('home');
   const useFetchTaskList = useTaskStore((s) => s.useFetchTaskList);
   // Home is an overview, not a continuation of the Task page's last-used
   // filter. It must always show the complete task set — ordered by activity,
-  // because this block calls itself "recent" and prints the same timestamp.
-  const tasksSWR = useFetchTaskList({ allAgents: true, orderBy: 'updatedAt', visibility: 'all' });
+  // because this block calls itself "recent" and prints the same timestamp —
+  // minus live schedules and heartbeats (`automated: false`), which belong to
+  // the scheduled block below and would otherwise print twice on one page.
+  const tasksSWR = useFetchTaskList({
+    allAgents: true,
+    automated: false,
+    orderBy: 'updatedAt',
+    visibility: 'all',
+  });
   const tasks = useTaskStore(taskListSelectors.taskList);
   const tasksTotal = useTaskStore(taskListSelectors.taskListTotal);
   const tasksInit = useTaskStore(taskListSelectors.isTaskListInit);
@@ -362,7 +383,7 @@ const TaskContent = memo(() => {
       ) : (
         <Flexbox gap={4}>
           {shown.map((task) => (
-            <TaskRow key={task.identifier} task={task} />
+            <TaskRow key={task.identifier} showTrigger={false} task={task} />
           ))}
         </Flexbox>
       )}
@@ -563,14 +584,18 @@ const HomeModeContent = memo<HomeModeContentProps>(({ inlineRail, mode, onSugges
     // Recent tasks answer "what is going on"; the scheduled block answers "what
     // will happen without me" — the second question only makes sense after the
     // first, so it always sits underneath.
+    //
+    // The inline padding keeps the lists from running edge-to-edge with the
+    // composer above: rows carry a -10px hover overhang (see `rowBox`), so
+    // without it the hover pill would reach past the column bounds.
     const taskBlocks = (
-      <>
+      <Flexbox gap={32} paddingInline={12}>
         {!tasksHidden && <TaskContent />}
         {!scheduledTasksHidden && <ScheduledTaskContent />}
-      </>
+      </Flexbox>
     );
 
-    if (!inlineRail) return <Flexbox gap={32}>{taskBlocks}</Flexbox>;
+    if (!inlineRail) return taskBlocks;
 
     // The rail's sections sit beside task mode while it is open, so a folded
     // rail must not take them away here either: goals and reports above the

--- a/src/features/Home/HomeModeContent.tsx
+++ b/src/features/Home/HomeModeContent.tsx
@@ -1,3 +1,4 @@
+import { TASK_STATUSES } from '@lobechat/builtin-tool-task';
 import type { TaskStatus } from '@lobechat/types';
 import { agentDisplayName } from '@lobechat/types';
 import type { FlexboxProps } from '@lobehub/ui';
@@ -120,15 +121,17 @@ interface RowProps {
   trailing?: ReactNode;
 }
 
-const TASK_STATUSES = new Set<TaskStatus>([
-  'backlog',
-  'canceled',
-  'completed',
-  'failed',
-  'paused',
-  'running',
-  'scheduled',
-]);
+const TASK_STATUS_SET = new Set<TaskStatus>(TASK_STATUSES);
+
+/**
+ * What the recent block lists: everything that is not finished work. Derived
+ * from the canonical status set (not hand-listed) so a status added later shows
+ * up here by default instead of silently vanishing from Home.
+ */
+export const RECENT_TASK_STATUSES: TaskStatus[] = TASK_STATUSES.filter(
+  (status) => status !== 'completed',
+);
+
 export const HOME_TOPIC_RECENT_LIMIT = 15;
 
 const FLEX_MIN_WIDTH_0 = { minWidth: 0 };
@@ -159,7 +162,7 @@ export const resolveTaskSummaryLine = (
 };
 
 const normalizeTaskStatus = (status: string): TaskStatus =>
-  TASK_STATUSES.has(status as TaskStatus) ? (status as TaskStatus) : 'backlog';
+  TASK_STATUS_SET.has(status as TaskStatus) ? (status as TaskStatus) : 'backlog';
 
 /**
  * Reserved width for the trailing timestamp. Relative and absolute forms differ
@@ -342,14 +345,17 @@ const TaskContent = memo(() => {
   const { t } = useTranslation('home');
   const useFetchTaskList = useTaskStore((s) => s.useFetchTaskList);
   // Home is an overview, not a continuation of the Task page's last-used
-  // filter. It must always show the complete task set — ordered by activity,
+  // filter. It must always show the ongoing task set — ordered by activity,
   // because this block calls itself "recent" and prints the same timestamp —
   // minus live schedules and heartbeats (`automated: false`), which belong to
-  // the scheduled block below and would otherwise print twice on one page.
+  // the scheduled block below and would otherwise print twice on one page,
+  // and minus completed tasks: finished work is history for the Tasks page,
+  // not part of "what is going on".
   const tasksSWR = useFetchTaskList({
     allAgents: true,
     automated: false,
     orderBy: 'updatedAt',
+    statuses: RECENT_TASK_STATUSES,
     visibility: 'all',
   });
   const tasks = useTaskStore(taskListSelectors.taskList);

--- a/src/features/Home/Recents/Item.tsx
+++ b/src/features/Home/Recents/Item.tsx
@@ -5,6 +5,7 @@ import { memo, useCallback, useState } from 'react';
 
 import InlineRename from '@/components/InlineRename';
 import TaskStatusIcon from '@/features/AgentTasks/features/TaskStatusIcon';
+import RunningGlyph from '@/features/Home/components/RunningGlyph';
 import NavItem from '@/features/NavPanel/components/NavItem';
 import { usePrefetchAgent } from '@/hooks/usePrefetchAgent';
 import { usePrefetchPage } from '@/hooks/usePrefetchPage';
@@ -58,6 +59,9 @@ const RecentListItem = memo<RecentItem>((item) => {
         }
         icon={(() => {
           if (type === 'task') {
+            // Same liveness signal as running topics: an executing task wears
+            // the animated running mark, not the static status glyph.
+            if (status === 'running') return <RunningGlyph size={16} />;
             return <TaskStatusIcon size={16} status={status ?? 'backlog'} />;
           }
 

--- a/src/features/Home/__tests__/recentTaskStatuses.test.ts
+++ b/src/features/Home/__tests__/recentTaskStatuses.test.ts
@@ -1,0 +1,19 @@
+import { TASK_STATUSES } from '@lobechat/builtin-tool-task';
+import { describe, expect, it } from 'vitest';
+
+import { RECENT_TASK_STATUSES } from '../HomeModeContent';
+
+// The recent block shows ongoing work: completed tasks are history for the
+// Tasks page and stay out of Home.
+describe('RECENT_TASK_STATUSES', () => {
+  it('hides finished work from the recent block', () => {
+    expect(RECENT_TASK_STATUSES).not.toContain('completed');
+  });
+
+  // Derived, not hand-listed: a status added to the canonical set later must
+  // show up on Home by default instead of silently vanishing.
+  it('keeps every other canonical status', () => {
+    expect(RECENT_TASK_STATUSES).toEqual(TASK_STATUSES.filter((s) => s !== 'completed'));
+    expect(RECENT_TASK_STATUSES).toHaveLength(TASK_STATUSES.length - 1);
+  });
+});

--- a/src/features/Home/components/Time.tsx
+++ b/src/features/Home/components/Time.tsx
@@ -5,11 +5,25 @@ import { useActivityTime } from '@/hooks/useActivityTime';
 
 import { homeType } from './homeType';
 
-export const Time = memo<{ date: string | number | Date }>(({ date }) => {
+interface TimeProps {
+  date: string | number | Date;
+  /**
+   * Reserve a fixed slot and right-align the text in it, so a list of rows
+   * shows one straight time column even though relative and absolute forms
+   * differ in width. Wider-than-slot text still lays out normally.
+   */
+  minWidth?: number;
+}
+
+export const Time = memo<TimeProps>(({ date, minWidth }) => {
   const { text, title } = useActivityTime(date);
   if (!text) return null;
   return (
-    <Text className={homeType.meta} style={{ flex: 'none' }} title={title}>
+    <Text
+      className={homeType.meta}
+      style={{ flex: 'none', minWidth, textAlign: minWidth === undefined ? undefined : 'end' }}
+      title={title}
+    >
       {text}
     </Text>
   );

--- a/src/libs/swr/keys.ts
+++ b/src/libs/swr/keys.ts
@@ -262,6 +262,16 @@ export const recentKeys = {
 };
 
 // ---- task ---------------------------------------------------------------
+/**
+ * SWR `mutate` matcher for every cached `task:list` variant — any agent scope,
+ * visibility chip, ordering, or automation filter. A task edit can move a row
+ * across each of those boundaries at once (reassigning, sharing, touching its
+ * `updatedAt`, attaching a schedule), so refresh invalidates by key root
+ * instead of enumerating variants.
+ */
+export const isTaskListKey = (key: unknown): boolean =>
+  Array.isArray(key) && key[0] === 'task:list';
+
 export const taskKeys = {
   detail: def('task:detail', (taskId: string) => ['task:detail', taskId]),
   groupList: def(
@@ -290,10 +300,16 @@ export const taskKeys = {
       // page orders by creation, and they read the same store field.
       orderBy: 'createdAt' | 'updatedAt' = 'createdAt',
       projectId?: string,
-    ) =>
-      projectId
+      // Same reasoning as `orderBy`: Home's recent block excludes live
+      // automation server-side while the Tasks page fetches everything, and a
+      // shared entry would serve one surface the other's filter.
+      automated?: boolean,
+    ) => {
+      const key = projectId
         ? ['task:list', agentKey, visibility, orderBy, projectId]
-        : ['task:list', agentKey, visibility, orderBy],
+        : ['task:list', agentKey, visibility, orderBy];
+      return automated === undefined ? key : [...key, automated];
+    },
   ),
   /**
    * Home's automated-task roll-up: the tasks that fire on a schedule or a

--- a/src/libs/swr/keys.ts
+++ b/src/libs/swr/keys.ts
@@ -301,14 +301,28 @@ export const taskKeys = {
       orderBy: 'createdAt' | 'updatedAt' = 'createdAt',
       projectId?: string,
       // Same reasoning as `orderBy`: Home's recent block excludes live
-      // automation server-side while the Tasks page fetches everything, and a
-      // shared entry would serve one surface the other's filter.
-      automated?: boolean,
+      // automation and finished statuses server-side while the Tasks page
+      // fetches everything, and a shared entry would serve one surface the
+      // other's filter. Folded into one trailing slot (appended only when a
+      // filter is actually set) so unfiltered keys keep their shape.
+      filters?: { automated?: boolean; statuses?: readonly string[] },
     ) => {
       const key = projectId
         ? ['task:list', agentKey, visibility, orderBy, projectId]
         : ['task:list', agentKey, visibility, orderBy];
-      return automated === undefined ? key : [...key, automated];
+      const automated = filters?.automated;
+      // Order-insensitive: the same status set must hash to the same key.
+      const statuses = filters?.statuses?.length
+        ? [...filters.statuses].sort().join(',')
+        : undefined;
+      if (automated === undefined && statuses === undefined) return key;
+      return [
+        ...key,
+        {
+          ...(automated === undefined ? {} : { automated }),
+          ...(statuses === undefined ? {} : { statuses }),
+        },
+      ];
     },
   ),
   /**

--- a/src/store/task/slices/list/action.test.ts
+++ b/src/store/task/slices/list/action.test.ts
@@ -20,6 +20,7 @@ beforeEach(() => {
   useTaskStore.setState({
     isTaskListInit: false,
     listAgentId: undefined,
+    listQueryAutomated: undefined,
     listQueryVisibility: 'all',
     tasks: [],
     tasksTotal: 0,
@@ -55,7 +56,11 @@ describe('TaskListSliceAction', () => {
   });
 
   describe('refreshTaskList', () => {
-    it('should call mutate with correct key including visibility filter', async () => {
+    // An edit can move a task across every list boundary at once — reorder it
+    // by `updatedAt`, change its visibility, attach a schedule that flips
+    // Home's automation filter — so refresh matches every `task:list` variant
+    // by key root instead of enumerating them.
+    it('invalidates every cached list variant by key root', async () => {
       const { mutate } = await import('@/libs/swr');
       useTaskStore.setState({
         listAgentId: 'agt_1',
@@ -65,23 +70,18 @@ describe('TaskListSliceAction', () => {
 
       await useTaskStore.getState().refreshTaskList();
 
-      expect(mutate).toHaveBeenCalledWith(['task:list', 'agt_1', 'private', 'createdAt']);
-    });
-
-    // Home reads the same list under a different ordering. An edit is exactly
-    // what moves a task in that ordering, so refreshing one and not the other
-    // leaves Home showing a stale order with no way to notice.
-    it('should invalidate both orderings of the list', async () => {
-      const { mutate } = await import('@/libs/swr');
-      useTaskStore.setState({
-        listAgentId: 'agt_1',
-        listQueryVisibility: 'private',
-        listVisibility: 'private',
-      });
-
-      await useTaskStore.getState().refreshTaskList();
-
-      expect(mutate).toHaveBeenCalledWith(['task:list', 'agt_1', 'private', 'updatedAt']);
+      const matcher = vi
+        .mocked(mutate)
+        .mock.calls.map(([arg]) => arg)
+        .find((arg): arg is (key: unknown) => boolean => typeof arg === 'function');
+      expect(matcher).toBeDefined();
+      // The Tasks page's entry, Home's activity-ordered automation-filtered
+      // entry, and a project-scoped entry all match…
+      expect(matcher!(['task:list', 'agt_1', 'private', 'createdAt'])).toBe(true);
+      expect(matcher!(['task:list', '__all__', 'all', 'updatedAt', false])).toBe(true);
+      expect(matcher!(['task:list', '__project__:p1', 'all', 'createdAt', 'p1'])).toBe(true);
+      // …while other task caches are refreshed through their own keys.
+      expect(matcher!(['task:groupList', 'agt_1', 'private'])).toBe(false);
     });
   });
 
@@ -134,6 +134,54 @@ describe('TaskListSliceAction', () => {
         expect.any(Function),
         expect.any(Object),
       );
+    });
+
+    // Home's recent block excludes live schedules server-side. The filter has
+    // to reach the request and the cache key, or Home and the Tasks page would
+    // serve each other's list from one shared entry.
+    it('passes the automation filter to the server and keys the cache by it', async () => {
+      const { useClientDataSWR } = await import('@/libs/swr');
+      const { taskService } = await import('@/services/task');
+
+      useTaskStore.getState().useFetchTaskList({
+        allAgents: true,
+        automated: false,
+        orderBy: 'updatedAt',
+        visibility: 'all',
+      });
+
+      expect(useClientDataSWR).toHaveBeenCalledWith(
+        ['task:list', '__all__', 'all', 'updatedAt', false],
+        expect.any(Function),
+        expect.any(Object),
+      );
+      const fetcher = vi.mocked(useClientDataSWR).mock.calls[0][1] as (
+        key: unknown[],
+      ) => Promise<unknown>;
+      await fetcher(['task:list', '__all__', 'all', 'updatedAt', false]);
+      expect(taskService.list).toHaveBeenCalledWith(expect.objectContaining({ automated: false }));
+    });
+
+    it('resets stale task data when the automation filter changes the query scope', () => {
+      useTaskStore.setState({
+        isTaskListInit: true,
+        listAgentId: '__all__',
+        listQueryAutomated: undefined,
+        listQueryVisibility: 'all',
+        listVisibility: 'all',
+        tasks: [{ id: 'cron-task' }] as any,
+        tasksTotal: 1,
+      });
+
+      useTaskStore
+        .getState()
+        .useFetchTaskList({ allAgents: true, automated: false, visibility: 'all' });
+
+      const state = useTaskStore.getState();
+      expect(state.listQueryAutomated).toBe(false);
+      expect(state.tasks).toEqual([]);
+      expect(state.tasksTotal).toBe(0);
+      expect(state.isTaskListInit).toBe(false);
     });
 
     it('resets stale task data when an embedded visibility override changes the query scope', () => {

--- a/src/store/task/slices/list/action.test.ts
+++ b/src/store/task/slices/list/action.test.ts
@@ -75,10 +75,12 @@ describe('TaskListSliceAction', () => {
         .mock.calls.map(([arg]) => arg)
         .find((arg): arg is (key: unknown) => boolean => typeof arg === 'function');
       expect(matcher).toBeDefined();
-      // The Tasks page's entry, Home's activity-ordered automation-filtered
-      // entry, and a project-scoped entry all match…
+      // The Tasks page's entry, Home's activity-ordered filtered entry, and a
+      // project-scoped entry all match…
       expect(matcher!(['task:list', 'agt_1', 'private', 'createdAt'])).toBe(true);
-      expect(matcher!(['task:list', '__all__', 'all', 'updatedAt', false])).toBe(true);
+      expect(matcher!(['task:list', '__all__', 'all', 'updatedAt', { automated: false }])).toBe(
+        true,
+      );
       expect(matcher!(['task:list', '__project__:p1', 'all', 'createdAt', 'p1'])).toBe(true);
       // …while other task caches are refreshed through their own keys.
       expect(matcher!(['task:groupList', 'agt_1', 'private'])).toBe(false);
@@ -136,10 +138,11 @@ describe('TaskListSliceAction', () => {
       );
     });
 
-    // Home's recent block excludes live schedules server-side. The filter has
-    // to reach the request and the cache key, or Home and the Tasks page would
-    // serve each other's list from one shared entry.
-    it('passes the automation filter to the server and keys the cache by it', async () => {
+    // Home's recent block excludes live schedules and finished statuses
+    // server-side. Both filters have to reach the request and the cache key, or
+    // Home and the Tasks page would serve each other's list from one shared
+    // entry.
+    it('passes the automation and status filters to the server and keys the cache by them', async () => {
       const { useClientDataSWR } = await import('@/libs/swr');
       const { taskService } = await import('@/services/task');
 
@@ -147,19 +150,29 @@ describe('TaskListSliceAction', () => {
         allAgents: true,
         automated: false,
         orderBy: 'updatedAt',
+        statuses: ['running', 'backlog'],
         visibility: 'all',
       });
 
       expect(useClientDataSWR).toHaveBeenCalledWith(
-        ['task:list', '__all__', 'all', 'updatedAt', false],
+        // The key's status signature is order-insensitive.
+        [
+          'task:list',
+          '__all__',
+          'all',
+          'updatedAt',
+          { automated: false, statuses: 'backlog,running' },
+        ],
         expect.any(Function),
         expect.any(Object),
       );
       const fetcher = vi.mocked(useClientDataSWR).mock.calls[0][1] as (
         key: unknown[],
       ) => Promise<unknown>;
-      await fetcher(['task:list', '__all__', 'all', 'updatedAt', false]);
-      expect(taskService.list).toHaveBeenCalledWith(expect.objectContaining({ automated: false }));
+      await fetcher(['task:list', '__all__', 'all', 'updatedAt', {}]);
+      expect(taskService.list).toHaveBeenCalledWith(
+        expect.objectContaining({ automated: false, statuses: ['running', 'backlog'] }),
+      );
     });
 
     it('resets stale task data when the automation filter changes the query scope', () => {
@@ -179,6 +192,28 @@ describe('TaskListSliceAction', () => {
 
       const state = useTaskStore.getState();
       expect(state.listQueryAutomated).toBe(false);
+      expect(state.tasks).toEqual([]);
+      expect(state.tasksTotal).toBe(0);
+      expect(state.isTaskListInit).toBe(false);
+    });
+
+    it('resets stale task data when the status filter changes the query scope', () => {
+      useTaskStore.setState({
+        isTaskListInit: true,
+        listAgentId: '__all__',
+        listQueryStatuses: undefined,
+        listQueryVisibility: 'all',
+        listVisibility: 'all',
+        tasks: [{ id: 'completed-task' }] as any,
+        tasksTotal: 1,
+      });
+
+      useTaskStore
+        .getState()
+        .useFetchTaskList({ allAgents: true, statuses: ['running', 'backlog'], visibility: 'all' });
+
+      const state = useTaskStore.getState();
+      expect(state.listQueryStatuses).toBe('backlog,running');
       expect(state.tasks).toEqual([]);
       expect(state.tasksTotal).toBe(0);
       expect(state.isTaskListInit).toBe(false);

--- a/src/store/task/slices/list/action.ts
+++ b/src/store/task/slices/list/action.ts
@@ -1,5 +1,5 @@
 import { mutate, useClientDataSWR } from '@/libs/swr';
-import { taskKeys } from '@/libs/swr/keys';
+import { isTaskListKey, taskKeys } from '@/libs/swr/keys';
 import { taskService } from '@/services/task';
 import type { StoreSetter } from '@/store/types';
 
@@ -89,14 +89,14 @@ export class TaskListSliceActionImpl {
     taskService.list(params);
 
   refreshTaskList = async (): Promise<void> => {
-    const { listAgentId, listQueryVisibility, listVisibility } = this.#get();
+    const { listAgentId, listVisibility } = this.#get();
     const projectId = projectIdFromListKey(listAgentId);
     await Promise.all([
-      // Both orderings of the same list: the Tasks page holds the createdAt
-      // entry and Home the updatedAt one, and an edit invalidates both — an
-      // edit is exactly what moves a task in the updatedAt ordering.
-      mutate(taskKeys.list(listAgentId, listQueryVisibility, 'createdAt', projectId)),
-      mutate(taskKeys.list(listAgentId, listQueryVisibility, 'updatedAt', projectId)),
+      // Every cached variant of the list — both orderings, any visibility chip
+      // or automation filter — an edit can move a task across each of those
+      // boundaries (touching reorders `updatedAt`, scheduling flips the
+      // automation filter), so they are invalidated by root, not enumerated.
+      mutate(isTaskListKey),
       mutate(taskKeys.groupList(listAgentId, listVisibility, projectId)),
       // A schedule can be attached, changed or removed from any task edit, so
       // the automated roll-up has to be revalidated alongside the main list.
@@ -209,6 +209,14 @@ export class TaskListSliceActionImpl {
     options: {
       agentId?: string;
       allAgents?: boolean;
+      /**
+       * Server-side automation filter: `false` excludes the tasks that still
+       * fire on their own (Home's recent block — those live in the scheduled
+       * roll-up), `true` is that roll-up's own side, undefined applies no
+       * filter. Part of the cache key and the scope reset for the same reason
+       * as `orderBy` and `visibility`.
+       */
+      automated?: boolean;
       enabled?: boolean;
       /**
        * Newest-first by creation unless a caller asks otherwise. A block that
@@ -223,23 +231,38 @@ export class TaskListSliceActionImpl {
       visibility?: TaskListVisibilityFilter;
     } = {},
   ) => {
-    const { agentId, allAgents = false, enabled = true, orderBy, projectId, visibility } = options;
+    const {
+      agentId,
+      allAgents = false,
+      automated,
+      enabled = true,
+      orderBy,
+      projectId,
+      visibility,
+    } = options;
     const effectiveKey = projectId
       ? `${PROJECT_LIST_KEY_PREFIX}${projectId}`
       : allAgents
         ? ALL_AGENTS_LIST_KEY
         : agentId;
     const listVisibility = visibility ?? this.#get().listVisibility;
-    const { listAgentId, listQueryVisibility } = this.#get();
+    const { listAgentId, listQueryAutomated, listQueryVisibility } = this.#get();
 
     // `tasks` is shared by the full Tasks page and embedded overviews. Reset it
-    // when either part of the effective query changes so an `all` override does
-    // not temporarily inherit a previously initialized private/workspace list.
-    if (effectiveKey && (listAgentId !== effectiveKey || listQueryVisibility !== listVisibility)) {
+    // when any part of the effective query changes so an `all` override does
+    // not temporarily inherit a previously initialized private/workspace list,
+    // nor the Tasks page a list narrowed by Home's automation filter.
+    if (
+      effectiveKey &&
+      (listAgentId !== effectiveKey ||
+        listQueryVisibility !== listVisibility ||
+        listQueryAutomated !== automated)
+    ) {
       this.#set(
         {
           ...scopeChangeResetState,
           listAgentId: effectiveKey,
+          listQueryAutomated: automated,
           listQueryVisibility: listVisibility,
         },
         false,
@@ -249,11 +272,12 @@ export class TaskListSliceActionImpl {
 
     return useClientDataSWR(
       enabled && effectiveKey
-        ? taskKeys.list(effectiveKey, listVisibility, orderBy, projectId)
+        ? taskKeys.list(effectiveKey, listVisibility, orderBy, projectId, automated)
         : null,
       async ([, id]: [string, string]) => {
         return this.fetchTaskList({
           ...(allAgents || projectId ? {} : { assigneeAgentId: id }),
+          automated,
           hasGoal: false,
           orderBy,
           projectId,

--- a/src/store/task/slices/list/action.ts
+++ b/src/store/task/slices/list/action.ts
@@ -1,3 +1,5 @@
+import type { TaskStatus } from '@lobechat/types';
+
 import { mutate, useClientDataSWR } from '@/libs/swr';
 import { isTaskListKey, taskKeys } from '@/libs/swr/keys';
 import { taskService } from '@/services/task';
@@ -227,6 +229,12 @@ export class TaskListSliceActionImpl {
        */
       orderBy?: 'createdAt' | 'updatedAt';
       projectId?: string;
+      /**
+       * Server-side status narrowing (include-list). Home's recent block uses
+       * it to drop finished work; the Tasks page omits it. Same key/scope
+       * treatment as `automated`.
+       */
+      statuses?: readonly TaskStatus[];
       /** Override the Task page's persisted filter for embedded consumers. */
       visibility?: TaskListVisibilityFilter;
     } = {},
@@ -238,6 +246,7 @@ export class TaskListSliceActionImpl {
       enabled = true,
       orderBy,
       projectId,
+      statuses,
       visibility,
     } = options;
     const effectiveKey = projectId
@@ -246,23 +255,27 @@ export class TaskListSliceActionImpl {
         ? ALL_AGENTS_LIST_KEY
         : agentId;
     const listVisibility = visibility ?? this.#get().listVisibility;
-    const { listAgentId, listQueryAutomated, listQueryVisibility } = this.#get();
+    // Order-insensitive signature, only for change detection in the scope guard.
+    const statusesSignature = statuses?.length ? [...statuses].sort().join(',') : undefined;
+    const { listAgentId, listQueryAutomated, listQueryStatuses, listQueryVisibility } = this.#get();
 
     // `tasks` is shared by the full Tasks page and embedded overviews. Reset it
     // when any part of the effective query changes so an `all` override does
     // not temporarily inherit a previously initialized private/workspace list,
-    // nor the Tasks page a list narrowed by Home's automation filter.
+    // nor the Tasks page a list narrowed by Home's automation/status filters.
     if (
       effectiveKey &&
       (listAgentId !== effectiveKey ||
         listQueryVisibility !== listVisibility ||
-        listQueryAutomated !== automated)
+        listQueryAutomated !== automated ||
+        listQueryStatuses !== statusesSignature)
     ) {
       this.#set(
         {
           ...scopeChangeResetState,
           listAgentId: effectiveKey,
           listQueryAutomated: automated,
+          listQueryStatuses: statusesSignature,
           listQueryVisibility: listVisibility,
         },
         false,
@@ -272,7 +285,7 @@ export class TaskListSliceActionImpl {
 
     return useClientDataSWR(
       enabled && effectiveKey
-        ? taskKeys.list(effectiveKey, listVisibility, orderBy, projectId, automated)
+        ? taskKeys.list(effectiveKey, listVisibility, orderBy, projectId, { automated, statuses })
         : null,
       async ([, id]: [string, string]) => {
         return this.fetchTaskList({
@@ -281,6 +294,7 @@ export class TaskListSliceActionImpl {
           hasGoal: false,
           orderBy,
           projectId,
+          statuses: statuses?.length ? [...statuses] : undefined,
           visibility: filterToServerVisibility(listVisibility),
         });
       },

--- a/src/store/task/slices/list/initialState.ts
+++ b/src/store/task/slices/list/initialState.ts
@@ -21,6 +21,14 @@ export interface TaskListSliceState {
   isTaskGroupListInit: boolean;
   isTaskListInit: boolean;
   listAgentId?: string;
+  /**
+   * Automation filter of the task data currently stored in `tasks` — `false`
+   * for Home's recent block (live schedules excluded server-side), undefined
+   * for the unfiltered Tasks page. Tracked like `listQueryVisibility` so a
+   * scope change resets the shared field instead of rendering the other
+   * surface's filter.
+   */
+  listQueryAutomated?: boolean;
   /** Effective visibility of the task data currently stored in `tasks`. */
   listQueryVisibility: TaskListVisibilityFilter;
   /** Defaults to 'all' so the Tasks top entry shows every visible task

--- a/src/store/task/slices/list/initialState.ts
+++ b/src/store/task/slices/list/initialState.ts
@@ -29,6 +29,12 @@ export interface TaskListSliceState {
    * surface's filter.
    */
   listQueryAutomated?: boolean;
+  /**
+   * Status narrowing of the data in `tasks`, as an order-insensitive signature
+   * (sorted, comma-joined) — undefined when the query is unnarrowed. Tracked
+   * for the same scope-reset reason as `listQueryAutomated`.
+   */
+  listQueryStatuses?: string;
   /** Effective visibility of the task data currently stored in `tasks`. */
   listQueryVisibility: TaskListVisibilityFilter;
   /** Defaults to 'all' so the Tasks top entry shows every visible task


### PR DESCRIPTION
### What & Why

Three fixes to the Home task-mode overview, plus a follow-up:

1. **Recent tasks no longer duplicate live schedules.** The recent-tasks block used to list cron/heartbeat tasks that already have their own "Scheduled" block below, so every active schedule printed twice on one page. `useFetchTaskList` now accepts an `automated` option that is forwarded to the server (`automated: false` → `RUNNABLE_AUTOMATION IS NOT TRUE` at the model layer, the exact complement of the scheduled roll-up). Non-completed terminal automation leftovers (a canceled/failed cron task) stay in the recent list as ordinary history, and the recent block hides the trigger tag (`showTrigger={false}`) so a dead schedule isn't advertised as live.
2. **Recent tasks hide finished work.** The block also narrows the request to non-completed statuses — finished tasks are history for the Tasks page, not part of "what is going on". The include-list is derived from the canonical `TASK_STATUSES` set (`RECENT_TASK_STATUSES`), so a status added later shows up on Home by default instead of silently vanishing. Both filters live in one trailing cache-key slot and in the shared-list scope reset, so Home and the Tasks page can't serve each other's filtered list; `refreshTaskList` invalidates `task:list` variants by key root (`isTaskListKey`).
3. **Block padding.** The recent + scheduled blocks share a 12px inline inset, so row hover pills (which overhang by -10px) stay inside the column instead of reaching past the composer's edge.
4. **Time column alignment.** Row timestamps get a fixed 56px right-aligned slot (`Time` gains a `minWidth` prop), so relative ("4 分钟前") and absolute ("8月13日") forms produce one straight time column, and the avatar column aligns with it.

#### Test

- [x] Tested locally
- [x] Added/updated tests

Store-level regression tests cover the new behavior: the `automated` + `statuses` filters reach the service call and the cache key, a filter change resets the shared list scope, the refresh matcher hits every `task:list` variant without touching other caches, and `RECENT_TASK_STATUSES` is asserted to be the canonical set minus `completed`. Verified end-to-end against a local full-stack dev server with seeded data (live cron ×2, terminal cron leftover ×1, plain tasks incl. completed): the batched TRPC call carries the filters, DB complement counts close exactly, and DOM measurements confirm the 12px inset and the single right edge across all time cells.