### PR TITLE
✨ feat(billboard): open web onboarding for resetOnboarding action on desktop

### DIFF
--- a/src/features/Billboard/actions.test.ts
+++ b/src/features/Billboard/actions.test.ts
@@ -99,7 +99,7 @@ describe('resolveBillboardAction', () => {
   });
 
   it('should not resolve resetOnboarding on desktop in local mode', async () => {
-    electronState.dataSyncConfig = { active: false, storageMode: 'selfHost' };
+    electronState.dataSyncConfig = { active: false, storageMode: 'cloud' };
 
     try {
       const desktopActions = await importDesktopActions();
@@ -110,7 +110,22 @@ describe('resolveBillboardAction', () => {
     }
   });
 
-  it('should resolve resetOnboarding on desktop when remote sync is active', async () => {
+  it('should not resolve resetOnboarding on desktop synced to a self-host server', async () => {
+    electronState.dataSyncConfig = {
+      active: true,
+      remoteServerUrl: 'https://my-server.example.com',
+      storageMode: 'selfHost',
+    };
+
+    try {
+      const desktopActions = await importDesktopActions();
+      expect(desktopActions.resolveBillboardAction('resetOnboarding')).toBeNull();
+    } finally {
+      restoreDesktopMock();
+    }
+  });
+
+  it('should resolve resetOnboarding on desktop synced to official cloud', async () => {
     electronState.dataSyncConfig = { active: true, storageMode: 'cloud' };
 
     try {
@@ -144,7 +159,7 @@ describe('runBillboardAction', () => {
     expect(openExternalLink).not.toHaveBeenCalled();
   });
 
-  it('should reset then open the web onboarding externally on desktop cloud mode', async () => {
+  it('should reset then open the official web onboarding externally on desktop', async () => {
     electronState.dataSyncConfig = { active: true, storageMode: 'cloud' };
 
     try {
@@ -153,23 +168,6 @@ describe('runBillboardAction', () => {
 
       expect(resetOnboarding).toHaveBeenCalledTimes(1);
       expect(openExternalLink).toHaveBeenCalledWith('https://app.lobehub.com/onboarding');
-    } finally {
-      restoreDesktopMock();
-    }
-  });
-
-  it('should open the configured self-host server onboarding on desktop', async () => {
-    electronState.dataSyncConfig = {
-      active: true,
-      remoteServerUrl: 'https://my-server.example.com',
-      storageMode: 'selfHost',
-    };
-
-    try {
-      const desktopActions = await importDesktopActions();
-      await desktopActions.runBillboardAction('resetOnboarding');
-
-      expect(openExternalLink).toHaveBeenCalledWith('https://my-server.example.com/onboarding');
     } finally {
       restoreDesktopMock();
     }

--- a/src/features/Billboard/actions.test.ts
+++ b/src/features/Billboard/actions.test.ts
@@ -8,11 +8,20 @@ import {
   runBillboardAction,
 } from './actions';
 
-const { openChangelogModal, openFeedbackModal, resetOnboarding } = vi.hoisted(() => ({
-  openChangelogModal: vi.fn(),
-  openFeedbackModal: vi.fn(),
-  resetOnboarding: vi.fn(),
-}));
+const { openChangelogModal, openFeedbackModal, resetOnboarding, openExternalLink, electronState } =
+  vi.hoisted(() => ({
+    electronState: {
+      dataSyncConfig: { storageMode: 'cloud' } as {
+        active?: boolean;
+        remoteServerUrl?: string;
+        storageMode: 'cloud' | 'selfHost';
+      },
+    },
+    openChangelogModal: vi.fn(),
+    openExternalLink: vi.fn(),
+    openFeedbackModal: vi.fn(),
+    resetOnboarding: vi.fn(),
+  }));
 
 vi.mock('@/components/ChangelogModal', () => ({
   default: openChangelogModal,
@@ -28,8 +37,31 @@ vi.mock('@/store/user', () => ({
   getUserStoreState: () => ({ resetOnboarding }),
 }));
 
+vi.mock('@/store/electron', () => ({
+  getElectronStoreState: () => electronState,
+}));
+
+vi.mock('@/services/electron/system', () => ({
+  electronSystemService: { openExternalLink },
+}));
+
+const importDesktopActions = async () => {
+  vi.resetModules();
+  vi.doMock('@lobechat/const', async (importOriginal) => ({
+    ...((await importOriginal()) as typeof LobechatConst),
+    isDesktop: true,
+  }));
+  return import('./actions');
+};
+
+const restoreDesktopMock = () => {
+  vi.doUnmock('@lobechat/const');
+  vi.resetModules();
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
+  electronState.dataSyncConfig = { storageMode: 'cloud' };
 });
 
 describe('isBillboardAction', () => {
@@ -66,20 +98,26 @@ describe('resolveBillboardAction', () => {
     expect(resolveBillboardAction(undefined)).toBeNull();
   });
 
-  it('should not resolve web-only actions on desktop', async () => {
-    vi.resetModules();
-    vi.doMock('@lobechat/const', async (importOriginal) => ({
-      ...((await importOriginal()) as typeof LobechatConst),
-      isDesktop: true,
-    }));
+  it('should not resolve resetOnboarding on desktop in local mode', async () => {
+    electronState.dataSyncConfig = { active: false, storageMode: 'selfHost' };
 
     try {
-      const desktopActions = await import('./actions');
+      const desktopActions = await importDesktopActions();
       expect(desktopActions.resolveBillboardAction('resetOnboarding')).toBeNull();
       expect(desktopActions.resolveBillboardAction('openChangelog')).toBe('openChangelog');
     } finally {
-      vi.doUnmock('@lobechat/const');
-      vi.resetModules();
+      restoreDesktopMock();
+    }
+  });
+
+  it('should resolve resetOnboarding on desktop when remote sync is active', async () => {
+    electronState.dataSyncConfig = { active: true, storageMode: 'cloud' };
+
+    try {
+      const desktopActions = await importDesktopActions();
+      expect(desktopActions.resolveBillboardAction('resetOnboarding')).toBe('resetOnboarding');
+    } finally {
+      restoreDesktopMock();
     }
   });
 });
@@ -103,6 +141,38 @@ describe('runBillboardAction', () => {
     await runBillboardAction('resetOnboarding');
 
     expect(resetOnboarding).toHaveBeenCalledTimes(1);
+    expect(openExternalLink).not.toHaveBeenCalled();
+  });
+
+  it('should reset then open the web onboarding externally on desktop cloud mode', async () => {
+    electronState.dataSyncConfig = { active: true, storageMode: 'cloud' };
+
+    try {
+      const desktopActions = await importDesktopActions();
+      await desktopActions.runBillboardAction('resetOnboarding');
+
+      expect(resetOnboarding).toHaveBeenCalledTimes(1);
+      expect(openExternalLink).toHaveBeenCalledWith('https://app.lobehub.com/onboarding');
+    } finally {
+      restoreDesktopMock();
+    }
+  });
+
+  it('should open the configured self-host server onboarding on desktop', async () => {
+    electronState.dataSyncConfig = {
+      active: true,
+      remoteServerUrl: 'https://my-server.example.com',
+      storageMode: 'selfHost',
+    };
+
+    try {
+      const desktopActions = await importDesktopActions();
+      await desktopActions.runBillboardAction('resetOnboarding');
+
+      expect(openExternalLink).toHaveBeenCalledWith('https://my-server.example.com/onboarding');
+    } finally {
+      restoreDesktopMock();
+    }
   });
 
   it('should have a runnable handler for every registered action', async () => {

--- a/src/features/Billboard/actions.ts
+++ b/src/features/Billboard/actions.ts
@@ -22,28 +22,43 @@ export type BillboardAction = (typeof BILLBOARD_ACTIONS)[number];
 export const isBillboardAction = (value: unknown): value is BillboardAction =>
   typeof value === 'string' && (BILLBOARD_ACTIONS as readonly string[]).includes(value);
 
-/**
- * Narrow a platform-configured value to an action this client can actually run:
- * unknown values and actions unavailable on the current platform both return
- * null, so the CTA falls back to `linkUrl`.
- *
- * `resetOnboarding` targets the web onboarding flow, which only exists on the
- * official cloud instance. Desktop honors it only when synced to official
- * cloud (the reset then applies to that account and the flow opens at
- * OFFICIAL_URL in the external browser); local and self-host modes keep it
- * disabled since their reset would not match what the browser shows.
- */
-export const resolveBillboardAction = (value: unknown): BillboardAction | null => {
-  if (!isBillboardAction(value)) return null;
-  if (value === 'resetOnboarding' && isDesktop && !isSyncedToOfficialCloud()) return null;
-  return value;
-};
-
 const isSyncedToOfficialCloud = () => {
   const state = getElectronStoreState();
   return (
     electronSyncSelectors.isSyncActive(state) &&
     electronSyncSelectors.storageMode(state) === 'cloud'
+  );
+};
+
+type BillboardActionGuard = (action: BillboardAction) => BillboardAction | null;
+
+const onlyWhen =
+  (target: BillboardAction, available: () => boolean): BillboardActionGuard =>
+  (action) =>
+    action !== target || available() ? action : null;
+
+/**
+ * Availability pipeline: the action flows through each guard, and any guard
+ * may drop it to null (the CTA then falls back to `linkUrl`). Add a guard per
+ * constraint instead of branching inside `resolveBillboardAction`.
+ */
+const actionGuards: BillboardActionGuard[] = [
+  // The web onboarding flow only exists on the official cloud instance, and
+  // the reset must apply to the same account the external browser will show —
+  // so desktop honors resetOnboarding only when synced to official cloud.
+  onlyWhen('resetOnboarding', () => !isDesktop || isSyncedToOfficialCloud()),
+];
+
+/**
+ * Narrow a platform-configured value to an action this client can actually run:
+ * unknown values and actions unavailable on the current platform both return
+ * null, so the CTA falls back to `linkUrl`.
+ */
+export const resolveBillboardAction = (value: unknown): BillboardAction | null => {
+  if (!isBillboardAction(value)) return null;
+  return actionGuards.reduce<BillboardAction | null>(
+    (action, guard) => (action ? guard(action) : null),
+    value,
   );
 };
 

--- a/src/features/Billboard/actions.ts
+++ b/src/features/Billboard/actions.ts
@@ -1,7 +1,11 @@
 import { isDesktop } from '@lobechat/const';
+import urlJoin from 'url-join';
 
 import { openChangelogModal } from '@/components/ChangelogModal';
 import { openFeedbackModal } from '@/components/FeedbackModal';
+import { electronSystemService } from '@/services/electron/system';
+import { getElectronStoreState } from '@/store/electron';
+import { electronSyncSelectors } from '@/store/electron/selectors';
 import { getUserStoreState } from '@/store/user';
 
 /**
@@ -15,9 +19,6 @@ export const BILLBOARD_ACTIONS = ['openChangelog', 'openFeedback', 'resetOnboard
 
 export type BillboardAction = (typeof BILLBOARD_ACTIONS)[number];
 
-/** Actions only meaningful on the web SPA (desktop has its own onboarding flow). */
-const WEB_ONLY_ACTIONS: readonly BillboardAction[] = ['resetOnboarding'];
-
 export const isBillboardAction = (value: unknown): value is BillboardAction =>
   typeof value === 'string' && (BILLBOARD_ACTIONS as readonly string[]).includes(value);
 
@@ -25,10 +26,21 @@ export const isBillboardAction = (value: unknown): value is BillboardAction =>
  * Narrow a platform-configured value to an action this client can actually run:
  * unknown values and actions unavailable on the current platform both return
  * null, so the CTA falls back to `linkUrl`.
+ *
+ * `resetOnboarding` targets the web onboarding flow. Desktop can only honor it
+ * when synced to a remote server (the reset then applies to that account and
+ * the flow opens in the external browser); in local mode the reset would hit
+ * the local DB while the browser shows a different account, so it stays
+ * disabled there.
  */
 export const resolveBillboardAction = (value: unknown): BillboardAction | null => {
   if (!isBillboardAction(value)) return null;
-  if (isDesktop && WEB_ONLY_ACTIONS.includes(value)) return null;
+  if (
+    value === 'resetOnboarding' &&
+    isDesktop &&
+    !electronSyncSelectors.isSyncActive(getElectronStoreState())
+  )
+    return null;
   return value;
 };
 
@@ -41,6 +53,13 @@ const billboardActionHandlers: Record<BillboardAction, () => Promise<void> | voi
   },
   resetOnboarding: async () => {
     await getUserStoreState().resetOnboarding();
+
+    if (isDesktop) {
+      const remoteServerUrl = electronSyncSelectors.remoteServerUrl(getElectronStoreState());
+      await electronSystemService.openExternalLink(urlJoin(remoteServerUrl, '/onboarding'));
+      return;
+    }
+
     window.location.href = '/onboarding';
   },
 };

--- a/src/features/Billboard/actions.ts
+++ b/src/features/Billboard/actions.ts
@@ -1,4 +1,4 @@
-import { isDesktop } from '@lobechat/const';
+import { isDesktop, OFFICIAL_URL } from '@lobechat/const';
 import urlJoin from 'url-join';
 
 import { openChangelogModal } from '@/components/ChangelogModal';
@@ -27,21 +27,24 @@ export const isBillboardAction = (value: unknown): value is BillboardAction =>
  * unknown values and actions unavailable on the current platform both return
  * null, so the CTA falls back to `linkUrl`.
  *
- * `resetOnboarding` targets the web onboarding flow. Desktop can only honor it
- * when synced to a remote server (the reset then applies to that account and
- * the flow opens in the external browser); in local mode the reset would hit
- * the local DB while the browser shows a different account, so it stays
- * disabled there.
+ * `resetOnboarding` targets the web onboarding flow, which only exists on the
+ * official cloud instance. Desktop honors it only when synced to official
+ * cloud (the reset then applies to that account and the flow opens at
+ * OFFICIAL_URL in the external browser); local and self-host modes keep it
+ * disabled since their reset would not match what the browser shows.
  */
 export const resolveBillboardAction = (value: unknown): BillboardAction | null => {
   if (!isBillboardAction(value)) return null;
-  if (
-    value === 'resetOnboarding' &&
-    isDesktop &&
-    !electronSyncSelectors.isSyncActive(getElectronStoreState())
-  )
-    return null;
+  if (value === 'resetOnboarding' && isDesktop && !isSyncedToOfficialCloud()) return null;
   return value;
+};
+
+const isSyncedToOfficialCloud = () => {
+  const state = getElectronStoreState();
+  return (
+    electronSyncSelectors.isSyncActive(state) &&
+    electronSyncSelectors.storageMode(state) === 'cloud'
+  );
 };
 
 const billboardActionHandlers: Record<BillboardAction, () => Promise<void> | void> = {
@@ -55,8 +58,7 @@ const billboardActionHandlers: Record<BillboardAction, () => Promise<void> | voi
     await getUserStoreState().resetOnboarding();
 
     if (isDesktop) {
-      const remoteServerUrl = electronSyncSelectors.remoteServerUrl(getElectronStoreState());
-      await electronSystemService.openExternalLink(urlJoin(remoteServerUrl, '/onboarding'));
+      await electronSystemService.openExternalLink(urlJoin(OFFICIAL_URL, '/onboarding'));
       return;
     }
 

--- a/src/store/electron/selectors/sync.ts
+++ b/src/store/electron/selectors/sync.ts
@@ -2,7 +2,7 @@ import { OFFICIAL_URL } from '@lobechat/const';
 
 import { type ElectronState } from '../initialState';
 
-const isSyncActive = (s: ElectronState) => s.dataSyncConfig.active;
+const isSyncActive = (s: ElectronState) => s.dataSyncConfig.active ?? false;
 
 const storageMode = (s: ElectronState) => s.dataSyncConfig.storageMode;
 


### PR DESCRIPTION
Previously the `resetOnboarding` billboard CTA was hard-disabled on desktop (listed in `WEB_ONLY_ACTIONS`), so ops-configured billboard items with this action silently fell back to `linkUrl`. This PR adapts the action for desktop: it resets the onboarding state on the connected cloud account, then opens the web onboarding flow in the system browser.

The web onboarding flow only exists on the official cloud instance, so the action is enabled on desktop **only when synced to official cloud** (`storageMode === 'cloud'` with sync active):

- `resolveBillboardAction`: on desktop, `resetOnboarding` resolves only when synced to official cloud. Local and self-host modes still resolve to `null` — their reset would not match what the browser shows — so the CTA keeps falling back to `linkUrl` there.
- `resetOnboarding` handler: after `resetOnboarding()` persists to the cloud account, desktop opens `https://app.lobehub.com/onboarding` (`OFFICIAL_URL`) via `electronSystemService.openExternalLink()`. Web behavior is unchanged (`window.location.href = '/onboarding'`).

Note: the user needs to be signed into the same account in their default browser for the web onboarding to reflect the reset — inherent to the external-link approach; the reset itself is applied to the cloud account either way.

#### Test

- [x] Added/updated tests

`bun run check src/features/Billboard/actions.ts src/features/Billboard/actions.test.ts` — lint clean, 13 tests passed. New cases: desktop local mode and self-host mode keep the action unresolved; desktop synced to official cloud resolves it and opens `https://app.lobehub.com/onboarding` externally after resetting.

#### 🔗 Related Issue

None.