### PR TITLE
🐛 fix(chat): restore embedded conversation toolbar

### DIFF
--- a/src/features/FloatingChatPanel/index.test.tsx
+++ b/src/features/FloatingChatPanel/index.test.tsx
@@ -154,6 +154,14 @@ vi.mock('@/hooks/useOperationState', () => ({
   useOperationState: () => undefined,
 }));
 
+vi.mock('@/features/PageEditor/Copilot/Toolbar', () => ({
+  default: () => <header data-testid="copilot-toolbar">Standard conversation toolbar</header>,
+}));
+
+vi.mock('@/features/PageEditor/RightPanel/OverrideContext', () => ({
+  PageAgentPanelOverrideProvider: ({ children }: { children?: ReactNode }) => children,
+}));
+
 vi.mock('@/features/Conversation/hooks/useChatFollowUp', () => ({
   useChatFollowUp: () => ({}),
 }));
@@ -285,6 +293,15 @@ describe('FloatingChatPanel', () => {
     expect(panel).toContainElement(getByTestId('chat-input'));
     expect(queryByTestId('floating-panel-shell')).toBeNull();
     expect(queryByTestId('floating-chat-panel-collapse-button')).toBeNull();
+  });
+
+  it('renders the standard conversation toolbar in embedded mode', () => {
+    const { getByTestId, queryByTestId } = render(
+      <FloatingChatPanel agentId="agent-1" mode="embedded" topicId="topic-1" />,
+    );
+
+    expect(getByTestId('copilot-toolbar')).toBeInTheDocument();
+    expect(queryByTestId('floating-panel-shell')).toBeNull();
   });
 
   it('renders a minimal ChatInput while collapsed (no left/right actions)', () => {

--- a/src/features/FloatingChatPanel/index.test.tsx
+++ b/src/features/FloatingChatPanel/index.test.tsx
@@ -82,7 +82,12 @@ vi.mock('@lobehub/ui', () => ({
 }));
 
 const mergedHooksCaptured = vi.hoisted(() => ({
-  current: undefined as undefined | { onBeforeSendMessage?: () => Promise<void> },
+  current: undefined as
+    | undefined
+    | {
+        onBeforeSendMessage?: () => Promise<void>;
+        onTopicCreated?: (topicId: string) => Promise<void>;
+      },
 }));
 
 vi.mock('@/features/Conversation', () => ({
@@ -155,7 +160,22 @@ vi.mock('@/hooks/useOperationState', () => ({
 }));
 
 vi.mock('@/features/PageEditor/Copilot/Toolbar', () => ({
-  default: () => <header data-testid="copilot-toolbar">Standard conversation toolbar</header>,
+  default: ({
+    onTopicChange,
+    topicId,
+  }: {
+    onTopicChange?: (topicId: string | null) => void;
+    topicId?: string | null;
+  }) => (
+    <header data-testid="copilot-toolbar" data-topic-id={topicId ?? 'new'}>
+      <button data-testid="toolbar-new-topic" onClick={() => onTopicChange?.(null)}>
+        New topic
+      </button>
+      <button data-testid="toolbar-history-topic" onClick={() => onTopicChange?.('topic-2')}>
+        History topic
+      </button>
+    </header>
+  ),
 }));
 
 vi.mock('@/features/PageEditor/RightPanel/OverrideContext', () => ({
@@ -295,13 +315,48 @@ describe('FloatingChatPanel', () => {
     expect(queryByTestId('floating-chat-panel-collapse-button')).toBeNull();
   });
 
-  it('renders the standard conversation toolbar in embedded mode', () => {
+  it('binds the embedded toolbar topic selection to the conversation context', () => {
     const { getByTestId, queryByTestId } = render(
       <FloatingChatPanel agentId="agent-1" mode="embedded" topicId="topic-1" />,
     );
 
-    expect(getByTestId('copilot-toolbar')).toBeInTheDocument();
+    expect(getByTestId('copilot-toolbar')).toHaveAttribute('data-topic-id', 'topic-1');
+    expect(JSON.parse(getByTestId('provider').dataset.context!)).toMatchObject({
+      isolatedTopic: true,
+      topicId: 'topic-1',
+    });
+
+    fireEvent.click(getByTestId('toolbar-history-topic'));
+
+    expect(getByTestId('copilot-toolbar')).toHaveAttribute('data-topic-id', 'topic-2');
+    expect(JSON.parse(getByTestId('provider').dataset.context!)).toMatchObject({
+      isolatedTopic: true,
+      topicId: 'topic-2',
+    });
     expect(queryByTestId('floating-panel-shell')).toBeNull();
+  });
+
+  it('keeps a newly created embedded topic bound to the toolbar and conversation', async () => {
+    const { getByTestId } = render(
+      <FloatingChatPanel agentId="agent-1" mode="embedded" topicId="topic-1" />,
+    );
+
+    fireEvent.click(getByTestId('toolbar-new-topic'));
+    expect(getByTestId('copilot-toolbar')).toHaveAttribute('data-topic-id', 'new');
+    expect(JSON.parse(getByTestId('provider').dataset.context!)).toMatchObject({
+      isolatedTopic: true,
+      topicId: null,
+    });
+
+    await act(async () => {
+      await mergedHooksCaptured.current?.onTopicCreated?.('topic-created');
+    });
+
+    expect(getByTestId('copilot-toolbar')).toHaveAttribute('data-topic-id', 'topic-created');
+    expect(JSON.parse(getByTestId('provider').dataset.context!)).toMatchObject({
+      isolatedTopic: true,
+      topicId: 'topic-created',
+    });
   });
 
   it('renders a minimal ChatInput while collapsed (no left/right actions)', () => {

--- a/src/features/FloatingChatPanel/index.tsx
+++ b/src/features/FloatingChatPanel/index.tsx
@@ -149,17 +149,21 @@ const FloatingChatPanel = memo<FloatingChatPanelProps>(
   }) => {
     useSingleInstanceGuard();
     const { t } = useTranslation('chat');
+    const isEmbedded = mode === 'embedded';
+    const [embeddedTopicId, setEmbeddedTopicId] = useState<string | null>(topicId);
+    const activeTopicId = isEmbedded ? embeddedTopicId : topicId;
 
     const context = useMemo<ConversationContext>(
       () => ({
         agentId,
         ...(agentDocumentId ? { agentDocumentId } : {}),
         ...(documentId ? { documentId } : {}),
+        ...(isEmbedded ? { isolatedTopic: true } : {}),
         scope: 'main',
         threadId: null,
-        topicId,
+        topicId: activeTopicId,
       }),
-      [agentId, agentDocumentId, documentId, topicId],
+      [activeTopicId, agentDocumentId, agentId, documentId, isEmbedded],
     );
 
     const chatKey = useMemo(() => messageMapKey(context), [context]);
@@ -182,8 +186,6 @@ const FloatingChatPanel = memo<FloatingChatPanelProps>(
     const operationState = useOperationState(context);
     const defaultActionsBar = useActionsBarConfig();
     const resolvedActionsBar = actionsBar ?? defaultActionsBar;
-    const isEmbedded = mode === 'embedded';
-
     const [isCollapsed, setIsCollapsed] = useState(!defaultOpen);
     const [activeSnapPoint, setActiveSnapPoint] = useState<number>(MID_SNAP_POINT);
 
@@ -219,10 +221,13 @@ const FloatingChatPanel = memo<FloatingChatPanelProps>(
             onBeforeSendMessage: async () => {
               expand();
             },
+            onTopicCreated: (createdTopicId) => {
+              if (isEmbedded) setEmbeddedTopicId(createdTopicId);
+            },
           },
           chatFollowUpHooks,
         ),
-      [hooks, chatFollowUpHooks, expand],
+      [chatFollowUpHooks, expand, hooks, isEmbedded],
     );
 
     const collapseAction = (
@@ -282,7 +287,7 @@ const FloatingChatPanel = memo<FloatingChatPanelProps>(
           {isEmbedded ? (
             <>
               <PageAgentPanelOverrideProvider defaultExpand>
-                <CopilotToolbar />
+                <CopilotToolbar topicId={activeTopicId} onTopicChange={setEmbeddedTopicId} />
               </PageAgentPanelOverrideProvider>
               <ChatBody />
               <InputRow isCollapsed={false} showExpandBar={false} onExpand={expand} />

--- a/src/features/FloatingChatPanel/index.tsx
+++ b/src/features/FloatingChatPanel/index.tsx
@@ -17,6 +17,8 @@ import {
 import { useChatFollowUp } from '@/features/Conversation/hooks/useChatFollowUp';
 import { type ConversationContext, type MessagesChangeMeta } from '@/features/Conversation/types';
 import { mergeConversationHooks } from '@/features/Conversation/utils/mergeConversationHooks';
+import CopilotToolbar from '@/features/PageEditor/Copilot/Toolbar';
+import { PageAgentPanelOverrideProvider } from '@/features/PageEditor/RightPanel/OverrideContext';
 import { useOperationState } from '@/hooks/useOperationState';
 import { useActionsBarConfig } from '@/routes/(main)/agent/features/Conversation/useActionsBarConfig';
 import { useAgentStore } from '@/store/agent';
@@ -279,6 +281,9 @@ const FloatingChatPanel = memo<FloatingChatPanelProps>(
         >
           {isEmbedded ? (
             <>
+              <PageAgentPanelOverrideProvider defaultExpand>
+                <CopilotToolbar />
+              </PageAgentPanelOverrideProvider>
               <ChatBody />
               <InputRow isCollapsed={false} showExpandBar={false} onExpand={expand} />
             </>

--- a/src/features/PageEditor/Copilot/Toolbar.tsx
+++ b/src/features/PageEditor/Copilot/Toolbar.tsx
@@ -12,19 +12,25 @@ import { topicSelectors } from '@/store/chat/slices/topic/selectors';
 import { usePageAgentPanelControl, usePageAgentPanelOverride } from '../RightPanel/OverrideContext';
 import TopicItem from './TopicSelector/TopicItem';
 
-const CopilotToolbar = memo(() => {
+interface CopilotToolbarProps {
+  onTopicChange?: (topicId: string | null) => void;
+  topicId?: string | null;
+}
+
+const CopilotToolbar = memo<CopilotToolbarProps>(({ onTopicChange, topicId }) => {
   const { t } = useTranslation('topic');
   const [topicPopoverOpen, setTopicPopoverOpen] = useState(false);
   const agentId = useConversationStore(conversationSelectors.agentId);
 
   useChatStore((s) => s.useFetchTopics)(true, { agentId });
 
-  const [activeTopicId, switchTopic, topics] = useChatStore((s) => [
+  const [globalActiveTopicId, switchTopic, topics] = useChatStore((s) => [
     s.activeTopicId,
     s.switchTopic,
     topicSelectors.getTopicsByAgentId(agentId)(s),
   ]);
 
+  const activeTopicId = topicId === undefined ? globalActiveTopicId : topicId;
   const currentTopic = topics?.find((topic) => topic.id === activeTopicId);
 
   const { toggle: togglePageAgentPanel } = usePageAgentPanelControl();
@@ -55,7 +61,9 @@ const CopilotToolbar = memo(() => {
             icon={PlusIcon}
             size={DESKTOP_HEADER_ICON_SMALL_SIZE}
             title={t('actions.addNewTopic')}
-            onClick={() => switchTopic(null, { scope: 'page' })}
+            onClick={() =>
+              onTopicChange ? onTopicChange(null) : switchTopic(null, { scope: 'page' })
+            }
           />
           {!hideHistory && (
             <Popover
@@ -82,7 +90,7 @@ const CopilotToolbar = memo(() => {
                       topicId={topic.id}
                       topicTitle={topic.title}
                       onClose={() => setTopicPopoverOpen(false)}
-                      onTopicChange={(id) => switchTopic(id)}
+                      onTopicChange={(id) => (onTopicChange ? onTopicChange(id) : switchTopic(id))}
                     />
                   ))}
                 </Flexbox>

--- a/src/features/PageEditor/Copilot/Toolbar.tsx
+++ b/src/features/PageEditor/Copilot/Toolbar.tsx
@@ -22,10 +22,10 @@ const CopilotToolbar = memo(() => {
   const [activeTopicId, switchTopic, topics] = useChatStore((s) => [
     s.activeTopicId,
     s.switchTopic,
-    topicSelectors.currentTopics(s),
+    topicSelectors.getTopicsByAgentId(agentId)(s),
   ]);
 
-  const currentTopic = useChatStore(topicSelectors.currentActiveTopic);
+  const currentTopic = topics?.find((topic) => topic.id === activeTopicId);
 
   const { toggle: togglePageAgentPanel } = usePageAgentPanelControl();
   const hasOverride = !!usePageAgentPanelOverride();


### PR DESCRIPTION
## What changed

- Render the standard page-agent conversation toolbar in embedded `FloatingChatPanel` mode.
- Keep the embedded panel open through a local panel-control override so the toolbar does not show an irrelevant close action.
- Resolve toolbar topics from the active conversation agent instead of the global active agent, so document chat history and per-topic menus populate correctly.

## Why

The standalone agent document page rendered the embedded conversation directly from the message list, leaving out its title and standard new-topic/history controls. Reusing the toolbar exposed a second boundary issue: its history selector depended on the global active agent, which can differ from the document conversation agent.

## User impact

Document-side conversations now match the standard page-agent panel: users can see the conversation title, start a new topic, open history, and access topic actions.

## Validation

- `bun run check src/features/FloatingChatPanel/index.tsx src/features/FloatingChatPanel/index.test.tsx src/features/PageEditor/Copilot/Toolbar.tsx`
- Web Acceptance run on a real agent document: verified the title, new-topic and history controls, then opened history and a topic's overflow menu.
