### PR TITLE
💄 style(ui): align loading skeletons with page layouts

### DIFF
--- a/.agents/skills/agent-testing/SKILL.md
+++ b/.agents/skills/agent-testing/SKILL.md
@@ -482,6 +482,10 @@ Hard rules worth front-loading:
 - **Time-based behavior needs a GIF, not a screenshot.** Streaming output, a
   ticking timer, loading states, animations — record with `scripts/record-gif.sh`
   and attach the GIF as that case's evidence; a static screenshot cannot prove it.
+  Keep the captured resolution by default. Before publishing, inspect the first,
+  middle, and final frames at readable size and reject evidence with colored
+  quantization noise, blurred text, or illegible one-pixel borders. Set
+  `GIF_WIDTH` only when the resulting dimensions are genuinely too large.
 - **A deliverable the user hears needs `audio`.** TTS output, a voice reply, an
   alert tone: attach the clip the feature produced so the page renders a player.
   Prose about a sound, or a screenshot of a waveform, proves nothing —

--- a/.agents/skills/agent-testing/references/common-mistakes.md
+++ b/.agents/skills/agent-testing/references/common-mistakes.md
@@ -298,7 +298,25 @@ the case's `observation` so the viewer is told before they see it.
 
 ---
 
-## M14 — Verifying only the entry surface when a shared component also renders deeper
+## M14 — Downscaling a neutral UI into one global GIF palette destroys the evidence
+
+**Wrong approach**: downscale high-resolution screenshots by default and encode the
+whole recording with one shared 256-color palette and ordinary dithering.
+
+**Why it's wrong**: pale skeletons and thin borders need many nearby neutral tones.
+A shared palette converts them into colored speckles, while downscaling blurs text and
+one-pixel geometry. The GIF then documents encoder artifacts instead of the product.
+
+**What it breaks**: reviewers cannot reliably judge alignment, visual weight, or
+loading continuity, even though the source PNG frames are clear.
+
+**Correct approach**: keep source resolution by default, generate palettes per frame,
+disable dithering for neutral application UI, and inspect the first, middle, and final
+frames at readable size before publishing. Downscale only when file size requires it.
+
+---
+
+## M15 — Verifying only the entry surface when a shared component also renders deeper
 
 **Wrong approach**: after changing a shared UI component, publishing a passing report
 from one surface only, even though the same component also renders on other pages.
@@ -317,7 +335,7 @@ skipped surface explicitly blocked or untested.
 
 ---
 
-## M15 — Verifying a UI change only in its default state, not its collapsed/overflow state
+## M16 — Verifying a UI change only in its default state, not its collapsed/overflow state
 
 **Wrong approach**: after changing something inside an action bar / toolbar / list
 row, checking only the normal expanded state and publishing, without forcing the
@@ -336,7 +354,7 @@ verify both the default and the collapsed/overflow state, with evidence for each
 
 ---
 
-## M16 — Publishing a component harness when the user asked for full product verification
+## M17 — Publishing a component harness when the user asked for full product verification
 
 **Wrong approach**: when the product surface hit friction once, declaring it blocked
 and publishing a narrow component harness as the main answer — even though another
@@ -358,7 +376,7 @@ after every known path is measured.
 
 ---
 
-## M17 — Turning a feature verification into an unbounded environment repair
+## M18 — Turning a feature verification into an unbounded environment repair
 
 **Wrong approach**: after the normal surface fails to boot, repeatedly modifying
 shared dev configuration, reinstalling the whole workspace, and chasing unrelated
@@ -379,7 +397,7 @@ without direction.
 
 ---
 
-## M18 — Probing the wrong layer: asserting a fixture landed because the write succeeded
+## M19 — Probing the wrong layer: asserting a fixture landed because the write succeeded
 
 **Wrong approach**: writing a fixture directly to the database, reloading the page, and
 reading what the UI shows — then treating a stale value as a product bug.
@@ -399,7 +417,7 @@ is where the behavior _reads_ it — verify at the layer the behavior reads. See
 
 ---
 
-## M19 — Building an elaborate mock before checking whether the env already has the real thing
+## M20 — Building an elaborate mock before checking whether the env already has the real thing
 
 **Wrong approach**: needing a capability (a working provider key, a service) and,
 finding none in the shell env, building a mock server and seeding it — then watching
@@ -421,7 +439,7 @@ path_ — everything "verified" through it is unverified.
 
 ---
 
-## M20 — Bare invocation: narrating skill setup, then asking an open "what should I test?"
+## M21 — Bare invocation: narrating skill setup, then asking an open "what should I test?"
 
 **Wrong approach**: invoked with no test target, the agent announces "I'm loading the
 mandatory living logs first", reads both logs in full, then asks an open "what should I
@@ -443,7 +461,7 @@ skill-internal setup.
 
 ---
 
-## M21 — A status badge is not proof the error message rendered
+## M22 — A status badge is not proof the error message rendered
 
 **Wrong approach**: marking an error-state UI case passed because the page showed a
 `Failed` badge, while the screenshot did not actually contain the error alert or its
@@ -463,7 +481,7 @@ assertion.
 
 ---
 
-## M22 — Coordinator hand-driving a broken flow instead of re-delegating
+## M23 — Coordinator hand-driving a broken flow instead of re-delegating
 
 **Wrong approach**: after a delegated verification subagent dies mid-case, the
 coordinator takes over and drives the remaining flow inline — dozens of small steps
@@ -484,7 +502,7 @@ diagnosing shared infrastructure.
 
 ---
 
-## M23 — Stopping after a fix without publishing the next verification round
+## M24 — Stopping after a fix without publishing the next verification round
 
 **Wrong approach**: implementing and locally validating a requested iteration, then
 ending the task without committing, pushing, or publishing a fresh immutable acceptance run
@@ -505,7 +523,7 @@ production link.
 
 ---
 
-## M24 — Labeling sequential flow steps as a before/after comparison
+## M25 — Labeling sequential flow steps as a before/after comparison
 
 **Wrong approach**: attaching two sequential steps of one flow as a `comparison`
 pair with `before` and `after` roles.
@@ -518,7 +536,7 @@ flow steps as ordinary ordered evidence with a caption naming each step.
 
 ---
 
-## M25 — Publishing locally because the acceptance subject exists only locally
+## M26 — Publishing locally because the acceptance subject exists only locally
 
 **Wrong approach**: ingesting the primary report into a local instance because
 its task or topic is absent from production.
@@ -533,7 +551,7 @@ supplement the run, but never replace the production deliverable.
 
 ---
 
-## M26 — Creating an acceptance without its requirement
+## M27 — Creating an acceptance without its requirement
 
 **Wrong approach**: using a bare subject string on the first ingest and assuming
 the acceptance goal is inferred automatically.
@@ -546,7 +564,7 @@ first ingest. State the cross-round business goal, not the current round's scope
 
 ---
 
-## M27 — Treating explanation and raw output as interchangeable text evidence
+## M28 — Treating explanation and raw output as interchangeable text evidence
 
 **Wrong approach**: attaching only a polished explanation with no concrete
 observations, attaching only a green test transcript and expecting the reviewer
@@ -572,7 +590,7 @@ every follow-up round so the round remains self-contained.
 
 ---
 
-## M28 — Writing a report field from the router's summary instead of opening the linked schema
+## M29 — Writing a report field from the router's summary instead of opening the linked schema
 
 **Wrong approach**: reading SKILL.md's Step 5, seeing that it describes `result.json`
 and links the format reference, and then writing the file from that summary plus
@@ -600,7 +618,7 @@ suspect your own metadata shape before the renderer.
 
 ---
 
-## M29 — Using a full-page browser screenshot for an Electron window
+## M30 — Using a full-page browser screenshot for an Electron window
 
 **Wrong approach**: capturing Electron evidence with `agent-browser screenshot --full` and publishing it because the target UI is technically visible in the
 top-left corner.

--- a/.agents/skills/agent-testing/references/report.md
+++ b/.agents/skills/agent-testing/references/report.md
@@ -72,7 +72,11 @@ table — those double up on the page. It carries only the non-duplicate narrati
      wait $GIF_PID
      ```
 
-     Verify at least the first/last frames visually (Read the GIF) before citing.
+     Keep source resolution unless file size requires an explicit `GIF_WIDTH`.
+     The recorder uses per-frame palettes without dithering so neutral loading
+     surfaces do not acquire colored noise. Verify the first, middle, and final
+     frames visually at readable size before citing; reject blurred text, noisy
+     grays, or lost one-pixel borders.
 
    - UI (before/after comparison): capture and visually verify both original
      screenshots. Do not compose them into a new image. In the case's `evidence`

--- a/.agents/skills/agent-testing/scripts/record-gif.sh
+++ b/.agents/skills/agent-testing/scripts/record-gif.sh
@@ -12,7 +12,7 @@
 #
 #   AB_TARGET="--cdp 9222"             # Electron (default; CDP_PORT honored)
 #   AB_TARGET="--session your-session" # web agent-browser session
-#   GIF_WIDTH=960                      # output width (px), default 960
+#   GIF_WIDTH=1280                     # optional output width; default keeps source resolution
 #
 # Requires ffmpeg (`brew install ffmpeg`). Effective fps is capped by
 # screenshot latency (~0.3-0.5s per frame); 1-2 fps is the realistic range.
@@ -29,7 +29,7 @@ OUT="${1:?Usage: record-gif.sh <output.gif> <duration_seconds> [fps]}"
 DUR="${2:?Usage: record-gif.sh <output.gif> <duration_seconds> [fps]}"
 FPS="${3:-2}"
 AB_TARGET="${AB_TARGET:---cdp ${CDP_PORT:-9222}}"
-GIF_WIDTH="${GIF_WIDTH:-960}"
+GIF_WIDTH="${GIF_WIDTH:-}"
 
 command -v ffmpeg > /dev/null || {
   echo "ffmpeg not found — install with: brew install ffmpeg" >&2
@@ -54,8 +54,17 @@ CAPTURED=$(find "$TMP" -name 'frame-*.png' | wc -l | tr -d ' ')
   exit 1
 }
 
+SCALE_FILTER=''
+if [ -n "$GIF_WIDTH" ]; then
+  SCALE_FILTER="scale=$GIF_WIDTH:-1:flags=lanczos,"
+fi
+
+# Generate a palette for every frame and disable dithering. A single global
+# 256-color palette turns subtle neutral skeletons into colored noise; scaling
+# them down by default also makes labels and one-pixel borders illegible.
 ffmpeg -y -loglevel error -framerate "$FPS" -pattern_type glob -i "$TMP/frame-*.png" \
-  -vf "fps=$FPS,scale=$GIF_WIDTH:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse" \
+  -filter_complex \
+  "fps=$FPS,${SCALE_FILTER}split[s0][s1];[s0]palettegen=stats_mode=single:max_colors=256:reserve_transparent=0[p];[s1][p]paletteuse=new=1:dither=none" \
   "$OUT"
 
 echo "$OUT ($CAPTURED frames @ ${FPS}fps)"

--- a/src/components/Skeleton/Goal.tsx
+++ b/src/components/Skeleton/Goal.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { Flexbox } from '@lobehub/ui';
+import { createStaticStyles, cssVar } from 'antd-style';
+
+import NavHeader from '@/features/NavHeader';
+import WideScreenContainer from '@/features/WideScreenContainer';
+
+import SkeletonBar from './Bar';
+
+const styles = createStaticStyles(({ css }) => ({
+  listRows: css`
+    display: flex;
+    flex-direction: column;
+    border-block: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+}));
+
+interface GoalSkeletonProps {
+  showHeader?: boolean;
+}
+
+const GoalSkeleton = ({ showHeader = true }: GoalSkeletonProps) => (
+  <Flexbox aria-busy flex={1} height={'100%'}>
+    {showHeader && <NavHeader />}
+    <WideScreenContainer
+      flex={1}
+      gap={20}
+      paddingBlock={16}
+      wrapperStyle={{ flex: 1, overflowY: 'auto' }}
+    >
+      <Flexbox horizontal align={'center'} justify={'space-between'} paddingBlock={'6px 18px'}>
+        <Flexbox gap={6}>
+          <SkeletonBar height={20} width={160} />
+          <SkeletonBar height={14} width={280} />
+        </Flexbox>
+        <Flexbox horizontal gap={20}>
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Flexbox gap={5} key={index} width={88}>
+              <SkeletonBar height={20} width={32} />
+              <SkeletonBar height={12} width={56} />
+            </Flexbox>
+          ))}
+        </Flexbox>
+      </Flexbox>
+      <Flexbox gap={10}>
+        <Flexbox horizontal align={'center'} justify={'space-between'}>
+          <SkeletonBar height={18} width={112} />
+          <Flexbox horizontal gap={8}>
+            <SkeletonBar height={28} width={112} />
+            <SkeletonBar height={28} width={64} />
+          </Flexbox>
+        </Flexbox>
+        <Flexbox className={styles.listRows}>
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Flexbox horizontal align={'center'} gap={12} key={index} paddingBlock={14}>
+              <SkeletonBar height={20} radius={'50%'} width={20} />
+              <Flexbox flex={1} gap={7}>
+                <SkeletonBar height={16} width={`${36 + index * 8}%`} />
+                <SkeletonBar height={12} width={`${54 + index * 6}%`} />
+              </Flexbox>
+              <SkeletonBar height={24} width={72} />
+            </Flexbox>
+          ))}
+        </Flexbox>
+      </Flexbox>
+    </WideScreenContainer>
+  </Flexbox>
+);
+
+export default GoalSkeleton;

--- a/src/components/Skeleton/GoalDetail.tsx
+++ b/src/components/Skeleton/GoalDetail.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { Flexbox } from '@lobehub/ui';
+import { cssVar } from 'antd-style';
+
+import NavHeader from '@/features/NavHeader';
+import WideScreenContainer from '@/features/WideScreenContainer';
+
+import SkeletonBar from './Bar';
+
+interface GoalDetailSkeletonProps {
+  showHeader?: boolean;
+}
+
+const GoalDetailContentSkeleton = () => (
+  <Flexbox aria-busy gap={20} paddingBlock={8}>
+    <Flexbox gap={10}>
+      <SkeletonBar height={28} width={'52%'} />
+      <SkeletonBar height={14} width={'78%'} />
+    </Flexbox>
+    <Flexbox horizontal gap={18}>
+      {Array.from({ length: 4 }).map((_, index) => (
+        <Flexbox gap={6} key={index} width={112}>
+          <SkeletonBar height={22} width={index === 0 ? 68 : 52} />
+          <SkeletonBar height={12} width={76} />
+        </Flexbox>
+      ))}
+    </Flexbox>
+    <SkeletonBar height={96} radius={cssVar.borderRadiusLG} />
+    <Flexbox gap={12}>
+      <SkeletonBar height={18} width={128} />
+      <SkeletonBar height={42} radius={cssVar.borderRadiusLG} />
+      <SkeletonBar height={42} radius={cssVar.borderRadiusLG} />
+      <SkeletonBar height={42} radius={cssVar.borderRadiusLG} />
+    </Flexbox>
+  </Flexbox>
+);
+
+const GoalDetailSkeleton = ({ showHeader = true }: GoalDetailSkeletonProps) => (
+  <Flexbox flex={1} height={'100%'}>
+    {showHeader && <NavHeader />}
+    <Flexbox flex={1} style={{ overflowY: 'auto' }}>
+      <WideScreenContainer gap={20} paddingBlock={16}>
+        <GoalDetailContentSkeleton />
+      </WideScreenContainer>
+    </Flexbox>
+  </Flexbox>
+);
+
+export default GoalDetailSkeleton;

--- a/src/components/Skeleton/GroupLayout.tsx
+++ b/src/components/Skeleton/GroupLayout.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useLocation } from 'react-router';
+
+import ConversationLayoutSkeleton from './Conversation/Layout';
+import ProfileSkeleton from './Profile';
+import SurfaceSkeleton from './Surface';
+
+const GroupLayoutSkeleton = () => {
+  const { pathname } = useLocation();
+  const leaf = pathname.split('/').findLast(Boolean);
+
+  if (leaf === 'profile') return <ProfileSkeleton variant={'group'} />;
+  if (leaf === 'permission') return <SurfaceSkeleton variant={'form'} />;
+
+  return <ConversationLayoutSkeleton />;
+};
+
+export default GroupLayoutSkeleton;

--- a/src/components/Skeleton/Memory.tsx
+++ b/src/components/Skeleton/Memory.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { Flexbox } from '@lobehub/ui';
+
+import NavHeader from '@/features/NavHeader';
+import WideScreenContainer from '@/features/WideScreenContainer';
+
+import SkeletonBar from './Bar';
+
+const MemorySkeleton = () => (
+  <Flexbox aria-busy flex={1} height={'100%'}>
+    <NavHeader />
+    <Flexbox height={'100%'} style={{ overflow: 'hidden' }} width={'100%'}>
+      <WideScreenContainer gap={32} paddingBlock={48}>
+        <Flexbox align={'center'} gap={16} paddingBlock={'18vh 0'}>
+          <SkeletonBar height={44} radius={'50%'} width={44} />
+          <Flexbox align={'center'} gap={10} width={'min(520px, 80%)'}>
+            <SkeletonBar height={24} width={132} />
+            <SkeletonBar height={14} width={'88%'} />
+            <SkeletonBar height={14} width={'64%'} />
+            <SkeletonBar height={32} width={128} />
+          </Flexbox>
+        </Flexbox>
+      </WideScreenContainer>
+    </Flexbox>
+  </Flexbox>
+);
+
+export default MemorySkeleton;

--- a/src/components/Skeleton/Profile.tsx
+++ b/src/components/Skeleton/Profile.tsx
@@ -52,7 +52,7 @@ const EditorPlaceholder = () => (
 
 const AgentProfileSkeleton = () => (
   <WideScreenContainer>
-    <Flexbox marginBottom={28}>
+    <Flexbox style={{ marginBottom: 28 }}>
       <Flexbox paddingBlock={'0 16px'} style={{ marginInline: -16 }}>
         <div className={styles.cover} />
         <Flexbox
@@ -63,7 +63,7 @@ const AgentProfileSkeleton = () => (
           style={{ marginTop: -36 }}
         >
           <SkeletonBar height={72} radius={cssVar.borderRadiusLG} width={72} />
-          <Flexbox gap={8} paddingBottom={4} style={{ minWidth: 0 }}>
+          <Flexbox gap={8} style={{ minWidth: 0, paddingBottom: 4 }}>
             <SkeletonBar height={36} width={220} />
             <SkeletonBar height={14} width={156} />
           </Flexbox>
@@ -93,7 +93,7 @@ const GroupProfileSkeleton = () => (
       <SkeletonBar height={72} radius={cssVar.borderRadiusLG} width={72} />
       <SkeletonBar height={36} width={240} />
     </Flexbox>
-    <Flexbox horizontal gap={8} marginBlock={'16px 28px'}>
+    <Flexbox horizontal gap={8} style={{ marginBlock: '16px 28px' }}>
       <SkeletonBar height={32} width={132} />
       <SkeletonBar height={32} width={96} />
     </Flexbox>

--- a/src/components/Skeleton/Profile.tsx
+++ b/src/components/Skeleton/Profile.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { Flexbox } from '@lobehub/ui';
+import { createStaticStyles, cssVar } from 'antd-style';
+
+import WideScreenContainer from '@/features/WideScreenContainer';
+
+import SkeletonBar from './Bar';
+
+type ProfileSkeletonVariant = 'agent' | 'group';
+
+interface ProfileSkeletonProps {
+  variant?: ProfileSkeletonVariant;
+}
+
+const styles = createStaticStyles(({ css }) => ({
+  configPanel: css`
+    padding: 24px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadiusLG};
+    background: ${cssVar.colorFillQuaternary};
+  `,
+  cover: css`
+    width: calc(100% + 32px);
+    height: 80px;
+    margin-inline: -16px;
+    background: ${cssVar.colorFillQuaternary};
+  `,
+  divider: css`
+    width: 100%;
+    height: 1px;
+    background: ${cssVar.colorBorderSecondary};
+  `,
+  editor: css`
+    padding-block: 24px 96px;
+  `,
+  header: css`
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+}));
+
+const NavigationSkeleton = () => <Flexbox className={styles.header} flex={'none'} height={44} />;
+
+const EditorPlaceholder = () => (
+  <Flexbox className={styles.editor} gap={14}>
+    <SkeletonBar height={18} width={120} />
+    <SkeletonBar height={14} width={'92%'} />
+    <SkeletonBar height={14} width={'84%'} />
+    <SkeletonBar height={14} width={'66%'} />
+  </Flexbox>
+);
+
+const AgentProfileSkeleton = () => (
+  <WideScreenContainer>
+    <Flexbox marginBottom={28}>
+      <Flexbox paddingBlock={'0 16px'} style={{ marginInline: -16 }}>
+        <div className={styles.cover} />
+        <Flexbox
+          horizontal
+          align={'flex-end'}
+          gap={16}
+          paddingInline={24}
+          style={{ marginTop: -36 }}
+        >
+          <SkeletonBar height={72} radius={cssVar.borderRadiusLG} width={72} />
+          <Flexbox gap={8} paddingBottom={4} style={{ minWidth: 0 }}>
+            <SkeletonBar height={36} width={220} />
+            <SkeletonBar height={14} width={156} />
+          </Flexbox>
+        </Flexbox>
+      </Flexbox>
+      <Flexbox className={styles.configPanel} gap={14}>
+        <Flexbox horizontal align={'center'} justify={'space-between'}>
+          <SkeletonBar height={12} width={96} />
+          <SkeletonBar height={12} width={72} />
+        </Flexbox>
+        <Flexbox horizontal gap={8}>
+          <SkeletonBar height={32} width={196} />
+          <SkeletonBar height={32} width={112} />
+        </Flexbox>
+      </Flexbox>
+    </Flexbox>
+    <EditorPlaceholder />
+  </WideScreenContainer>
+);
+
+const GroupProfileSkeleton = () => (
+  <WideScreenContainer>
+    <Flexbox height={66} justify={'center'}>
+      <SkeletonBar height={14} width={96} />
+    </Flexbox>
+    <Flexbox gap={16} paddingBlock={16}>
+      <SkeletonBar height={72} radius={cssVar.borderRadiusLG} width={72} />
+      <SkeletonBar height={36} width={240} />
+    </Flexbox>
+    <Flexbox horizontal gap={8} marginBlock={'16px 28px'}>
+      <SkeletonBar height={32} width={132} />
+      <SkeletonBar height={32} width={96} />
+    </Flexbox>
+    <div className={styles.divider} />
+    <EditorPlaceholder />
+  </WideScreenContainer>
+);
+
+const ProfileSkeleton = ({ variant = 'agent' }: ProfileSkeletonProps) => (
+  <Flexbox aria-busy flex={1} height={'100%'} style={{ minHeight: 0, overflow: 'hidden' }}>
+    <NavigationSkeleton />
+    <Flexbox flex={1} style={{ minHeight: 0, overflow: 'hidden', overflowY: 'auto' }}>
+      {variant === 'agent' ? <AgentProfileSkeleton /> : <GroupProfileSkeleton />}
+    </Flexbox>
+  </Flexbox>
+);
+
+export default ProfileSkeleton;

--- a/src/components/Skeleton/RouteSegment.tsx
+++ b/src/components/Skeleton/RouteSegment.tsx
@@ -3,6 +3,10 @@
 import { useLocation } from 'react-router';
 
 import ConversationLayoutSkeleton from './Conversation/Layout';
+import GoalSkeleton from './Goal';
+import GoalDetailSkeleton from './GoalDetail';
+import MemorySkeleton from './Memory';
+import ProfileSkeleton from './Profile';
 import SettingsPageSkeleton from './Settings/Page';
 import SurfaceSkeleton, { type SurfaceSkeletonVariant } from './Surface';
 
@@ -40,9 +44,17 @@ const isConversationPath = (pathname: string) => {
  */
 const RouteSegmentSkeleton = () => {
   const { pathname } = useLocation();
+  const segments = pathname.split('/').filter(Boolean);
 
   if (pathname.startsWith('/settings/')) return <SettingsPageSkeleton />;
   if (isConversationPath(pathname)) return <ConversationLayoutSkeleton />;
+  if (segments[0] === 'memory' && segments.length === 1) return <MemorySkeleton />;
+  if (segments[0] === 'agent' && segments[2] === 'goals') return <GoalSkeleton />;
+  if (segments[0] === 'agent' && segments[2] === 'goal') return <GoalDetailSkeleton />;
+  if (segments[0] === 'agent' && segments[2] === 'profile') return <ProfileSkeleton />;
+  if (segments[0] === 'group' && segments[2] === 'profile') {
+    return <ProfileSkeleton variant={'group'} />;
+  }
 
   return <SurfaceSkeleton variant={getSurfaceVariant(pathname)} />;
 };

--- a/src/features/AgentGoals/AgentGoalsPage.tsx
+++ b/src/features/AgentGoals/AgentGoalsPage.tsx
@@ -7,7 +7,7 @@ import { LayoutGridIcon, ListIcon, PlusIcon, RefreshCwIcon } from 'lucide-react'
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
+import GoalSkeleton from '@/components/Skeleton/Goal';
 import AgentBreadcrumb from '@/features/AgentBreadcrumb';
 import NavHeader from '@/features/NavHeader';
 import WideScreenContainer from '@/features/WideScreenContainer';
@@ -144,9 +144,7 @@ const AgentGoalsPage = memo<AgentGoalsPageProps>(({ agentId, projectId }) => {
         wrapperStyle={{ flex: 1, overflowY: 'auto' }}
       >
         {isLoading && !isInitialized ? (
-          <Flexbox align={'center'} flex={1} justify={'center'}>
-            <NeuralNetworkLoading />
-          </Flexbox>
+          <GoalSkeleton showHeader={false} />
         ) : error ? (
           <Block padding={32} variant={'outlined'}>
             <Flexbox align={'center'} gap={12}>

--- a/src/features/AgentGoals/GoalDetailPage.tsx
+++ b/src/features/AgentGoals/GoalDetailPage.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next';
 import NotFound from '@/components/404';
 import AsyncError from '@/components/AsyncError';
 import { TASK_STATUS_VISUALS } from '@/components/ExecutionStatus';
-import SurfaceSkeleton from '@/components/Skeleton/Surface';
+import GoalDetailSkeleton from '@/components/Skeleton/GoalDetail';
 import AgentBreadcrumb from '@/features/AgentBreadcrumb';
 import { useActiveTaskDetail } from '@/features/AgentTasks/AgentTaskDetail';
 import TaskDetailTitleInput from '@/features/AgentTasks/AgentTaskDetail/TaskDetailTitleInput';
@@ -190,7 +190,7 @@ const GoalDetailPage = memo<GoalDetailPageProps>(({ agentId, goalId }) => {
       <Flexbox flex={1} style={{ overflowY: 'auto' }}>
         <WideScreenContainer gap={20} paddingBlock={16}>
           {isInitialLoading || !task ? (
-            <SurfaceSkeleton header={false} variant={'editor'} />
+            <GoalDetailSkeleton showHeader={false} />
           ) : (
             <>
               <Flexbox className={styles.header} gap={8}>

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailPage.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailPage.tsx
@@ -7,7 +7,6 @@ import { Link } from 'react-router';
 import NotFound from '@/components/404';
 import AsyncError from '@/components/AsyncError';
 import AutoSaveHint from '@/components/Editor/AutoSaveHint';
-import SurfaceSkeleton from '@/components/Skeleton/Surface';
 import NavHeader from '@/features/NavHeader';
 import ToggleRightPanelButton from '@/features/RightPanel/ToggleRightPanelButton';
 import WideScreenContainer from '@/features/WideScreenContainer';
@@ -19,6 +18,7 @@ import { taskDetailSelectors } from '@/store/task/selectors';
 import Breadcrumb from '../shared/Breadcrumb';
 import TaskDetailHeaderActions from './TaskDetailHeaderActions';
 import TaskDetailSections from './TaskDetailSections';
+import TaskDetailSkeleton from './TaskDetailSkeleton';
 import TopicChatDrawer from './TopicChatDrawer';
 import { useActiveTaskDetail } from './useActiveTaskDetail';
 
@@ -105,11 +105,7 @@ const TaskDetailPage = memo<TaskDetailPageProps>(({ taskId, showTaskAgentPanelTo
       />
       <Flexbox flex={1} style={{ minHeight: 0, overflowY: 'auto' }}>
         <WideScreenContainer>
-          {isInitialLoading ? (
-            <SurfaceSkeleton header={false} variant={'editor'} />
-          ) : (
-            <TaskDetailSections />
-          )}
+          {isInitialLoading ? <TaskDetailSkeleton /> : <TaskDetailSections />}
         </WideScreenContainer>
       </Flexbox>
       <TopicChatDrawer />

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailSkeleton.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailSkeleton.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { Flexbox } from '@lobehub/ui';
+import { createStaticStyles, cssVar } from 'antd-style';
+import { memo } from 'react';
+
+import SkeletonBar from '@/components/Skeleton/Bar';
+
+const styles = createStaticStyles(({ css }) => ({
+  acceptance: css`
+    overflow: hidden;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadiusLG};
+  `,
+  divider: css`
+    width: 100%;
+    height: 1px;
+    background: ${cssVar.colorBorderSecondary};
+  `,
+  control: css`
+    height: 32px;
+    padding-inline: 10px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadiusLG};
+
+    background: ${cssVar.colorBgContainer};
+  `,
+  propertyCard: css`
+    flex: none;
+
+    width: 200px;
+    height: 108px;
+    padding-block: 8px;
+    padding-inline: 12px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadiusLG};
+  `,
+}));
+
+const TaskDetailSkeleton = memo(() => (
+  <Flexbox aria-busy flex={1}>
+    <Flexbox gap={4} style={{ paddingBlock: '24px 44px' }}>
+      <Flexbox style={{ paddingBottom: 33, paddingTop: 5 }}>
+        <SkeletonBar height={24} width={'min(520px, 56%)'} />
+      </Flexbox>
+      <Flexbox horizontal align={'flex-start'} gap={16} justify={'space-between'} wrap={'wrap'}>
+        <Flexbox align={'flex-start'} flex={1} gap={16} style={{ minWidth: 240 }}>
+          <Flexbox horizontal gap={8} wrap={'wrap'}>
+            <Flexbox horizontal align={'center'} className={styles.control} gap={8} width={96}>
+              <SkeletonBar height={16} radius={'50%'} width={16} />
+              <SkeletonBar height={10} width={48} />
+            </Flexbox>
+            <Flexbox horizontal align={'center'} className={styles.control} gap={8} width={176}>
+              <SkeletonBar height={16} radius={'50%'} width={16} />
+              <SkeletonBar height={10} width={116} />
+            </Flexbox>
+          </Flexbox>
+          <Flexbox horizontal align={'center'} className={styles.control} gap={8} width={76}>
+            <SkeletonBar height={12} radius={3} width={12} />
+            <SkeletonBar height={10} width={36} />
+          </Flexbox>
+        </Flexbox>
+        <Flexbox className={styles.propertyCard} gap={8}>
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Flexbox horizontal align={'center'} gap={10} key={index}>
+              <SkeletonBar height={16} radius={4} width={16} />
+              <SkeletonBar height={14} width={index === 1 ? 80 : 68} />
+            </Flexbox>
+          ))}
+        </Flexbox>
+      </Flexbox>
+    </Flexbox>
+
+    <Flexbox gap={24} style={{ paddingBottom: 120 }}>
+      <Flexbox gap={12}>
+        <SkeletonBar height={14} width={'94%'} />
+        <SkeletonBar height={14} width={'88%'} />
+        <SkeletonBar height={14} width={'72%'} />
+      </Flexbox>
+
+      <Flexbox gap={12}>
+        <Flexbox horizontal align={'center'} gap={8}>
+          <SkeletonBar height={16} radius={'50%'} width={16} />
+          <SkeletonBar height={18} width={112} />
+        </Flexbox>
+        <Flexbox className={styles.acceptance}>
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Flexbox key={index}>
+              {index > 0 && <div className={styles.divider} />}
+              <Flexbox horizontal align={'center'} gap={10} padding={'12px'}>
+                <SkeletonBar height={16} radius={'50%'} width={16} />
+                <SkeletonBar height={12} width={24} />
+                <SkeletonBar height={14} width={`${58 + index * 9}%`} />
+              </Flexbox>
+            </Flexbox>
+          ))}
+        </Flexbox>
+      </Flexbox>
+    </Flexbox>
+  </Flexbox>
+));
+
+TaskDetailSkeleton.displayName = 'TaskDetailSkeleton';
+
+export default TaskDetailSkeleton;

--- a/src/features/AgentTasks/AgentTaskDetail/index.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/index.tsx
@@ -1,5 +1,6 @@
 export { default as AgentScopedTaskDetailPage } from './AgentScopedTaskDetailPage';
 export { default as TaskDetailPage } from './TaskDetailPage';
 export { default as TaskDetailSections } from './TaskDetailSections';
+export { default as TaskDetailSkeleton } from './TaskDetailSkeleton';
 export { default as TopicChatDrawer } from './TopicChatDrawer';
 export { useActiveTaskDetail } from './useActiveTaskDetail';

--- a/src/features/AgentTasks/index.tsx
+++ b/src/features/AgentTasks/index.tsx
@@ -2,6 +2,7 @@ export {
   AgentScopedTaskDetailPage,
   TaskDetailPage,
   TaskDetailSections,
+  TaskDetailSkeleton,
   TopicChatDrawer,
   useActiveTaskDetail,
 } from './AgentTaskDetail';

--- a/src/features/Portal/TaskDetail/Body.tsx
+++ b/src/features/Portal/TaskDetail/Body.tsx
@@ -4,8 +4,12 @@ import { useTranslation } from 'react-i18next';
 
 import NotFound from '@/components/404';
 import AsyncError from '@/components/AsyncError';
-import SurfaceSkeleton from '@/components/Skeleton/Surface';
-import { TaskDetailSections, TopicChatDrawer, useActiveTaskDetail } from '@/features/AgentTasks';
+import {
+  TaskDetailSections,
+  TaskDetailSkeleton,
+  TopicChatDrawer,
+  useActiveTaskDetail,
+} from '@/features/AgentTasks';
 import { useChatStore } from '@/store/chat';
 import { chatPortalSelectors } from '@/store/chat/selectors';
 
@@ -43,11 +47,7 @@ const Body = memo(() => {
       paddingInline={16}
       style={{ minHeight: 0, overflowY: 'auto' }}
     >
-      {isInitialLoading ? (
-        <SurfaceSkeleton header={false} variant={'editor'} />
-      ) : (
-        <TaskDetailSections />
-      )}
+      {isInitialLoading ? <TaskDetailSkeleton /> : <TaskDetailSections />}
       <TopicChatDrawer />
     </Flexbox>
   );

--- a/src/features/ResourcePermission/ResourceConfigAccessGate.test.tsx
+++ b/src/features/ResourcePermission/ResourceConfigAccessGate.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ResourceConfigAccessGate from './ResourceConfigAccessGate';
 
 const mocks = vi.hoisted(() => ({
+  accessResolved: true,
   canEditContent: true,
   canEditResource: false,
   navigate: vi.fn(),
@@ -14,7 +15,15 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@lobehub/ui/base-ui', () => ({ toast: { info: mocks.toastInfo } }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('@/components/AsyncBoundary', () => ({
-  default: ({ children }: { children: ReactNode }) => children,
+  default: ({
+    children,
+    isLoading,
+    loading,
+  }: {
+    children: ReactNode;
+    isLoading: boolean;
+    loading: ReactNode;
+  }) => (isLoading ? loading : children),
 }));
 vi.mock('@/components/Skeleton/Surface', () => ({ default: () => null }));
 vi.mock('@/features/Workspace/useWorkspaceAwareNavigate', () => ({
@@ -27,15 +36,16 @@ vi.mock('./useResourceAccess', () => ({
   useResourceAccess: () => ({
     accessError: undefined,
     canEditResource: mocks.canEditResource,
-    isAccessResolved: true,
+    isAccessResolved: mocks.accessResolved,
     isLoading: false,
     retryAccess: vi.fn(),
   }),
 }));
 
-const renderGate = (resourceType: 'agent' | 'agentGroup' = 'agent') =>
+const renderGate = (resourceType: 'agent' | 'agentGroup' = 'agent', loading?: ReactNode) =>
   render(
     <ResourceConfigAccessGate
+      loading={loading}
       redirectPath="/agent/agent-1"
       resourceId="agent-1"
       resourceType={resourceType}
@@ -49,6 +59,7 @@ describe('ResourceConfigAccessGate', () => {
     vi.clearAllMocks();
     mocks.canEditContent = true;
     mocks.canEditResource = false;
+    mocks.accessResolved = true;
   });
 
   it('uses workspace-aware navigation when returning a chat-only collaborator to chat', async () => {
@@ -90,5 +101,13 @@ describe('ResourceConfigAccessGate', () => {
     await waitFor(() => {
       expect(mocks.toastInfo).toHaveBeenCalledWith('permission.configAccess.groupChatOnly');
     });
+  });
+
+  it('uses the surface-specific loading state while access is resolving', () => {
+    mocks.accessResolved = false;
+
+    const { getByText } = renderGate('agent', <div>Profile loading</div>);
+
+    expect(getByText('Profile loading')).toBeInTheDocument();
   });
 });

--- a/src/features/ResourcePermission/ResourceConfigAccessGate.tsx
+++ b/src/features/ResourcePermission/ResourceConfigAccessGate.tsx
@@ -13,13 +13,14 @@ import { useResourceAccess } from './useResourceAccess';
 
 interface ResourceConfigAccessGateProps {
   children: ReactNode;
+  loading?: ReactNode;
   redirectPath: string;
   resourceId?: string;
   resourceType: 'agent' | 'agentGroup';
 }
 
 const ResourceConfigAccessGate = memo<ResourceConfigAccessGateProps>(
-  ({ children, redirectPath, resourceId, resourceType }) => {
+  ({ children, loading, redirectPath, resourceId, resourceType }) => {
     const { t } = useTranslation('chat');
     const navigate = useWorkspaceAwareNavigate();
     const hasRedirected = useRef(false);
@@ -66,10 +67,10 @@ const ResourceConfigAccessGate = memo<ResourceConfigAccessGateProps>(
         error={accessError}
         errorVariant={'page'}
         isLoading={!accessReady && !accessError}
-        loading={<SurfaceSkeleton variant={'form'} />}
+        loading={loading ?? <SurfaceSkeleton variant={'form'} />}
         onRetry={() => void retryAccess()}
       >
-        {canConfigure ? children : <SurfaceSkeleton variant={'form'} />}
+        {canConfigure ? children : (loading ?? <SurfaceSkeleton variant={'form'} />)}
       </AsyncBoundary>
     );
   },

--- a/src/routes/(main)/agent/profile/index.tsx
+++ b/src/routes/(main)/agent/profile/index.tsx
@@ -6,7 +6,7 @@ import { memo, Suspense } from 'react';
 import { useParams } from 'react-router';
 
 import AsyncBoundary from '@/components/AsyncBoundary';
-import SurfaceSkeleton from '@/components/Skeleton/Surface';
+import ProfileSkeleton from '@/components/Skeleton/Profile';
 import AgentBuilder from '@/features/AgentBuilder';
 import ResourceConfigAccessGate from '@/features/ResourcePermission/ResourceConfigAccessGate';
 import WideScreenContainer from '@/features/WideScreenContainer';
@@ -62,7 +62,7 @@ const ProfileArea = memo(() => {
           // gate on `!configError` so under loading→error precedence the loading
           // branch yields to the error state instead of spinning forever.
           isLoading={isAgentConfigLoading && !configError}
-          loading={<SurfaceSkeleton variant={'editor'} />}
+          loading={<ProfileSkeleton />}
           onRetry={() => retryAgentConfigFetch()}
         >
           <Header />
@@ -103,8 +103,9 @@ const AgentProfile: FC = () => {
   const { aid } = useParams<{ aid: string }>();
 
   return (
-    <Suspense fallback={<SurfaceSkeleton variant={'editor'} />}>
+    <Suspense fallback={<ProfileSkeleton />}>
       <ResourceConfigAccessGate
+        loading={<ProfileSkeleton />}
         redirectPath={`/agent/${aid ?? ''}`}
         resourceId={aid}
         resourceType="agent"

--- a/src/routes/(main)/group/profile/index.tsx
+++ b/src/routes/(main)/group/profile/index.tsx
@@ -5,7 +5,7 @@ import { type FC } from 'react';
 import { memo, Suspense } from 'react';
 import { useParams } from 'react-router';
 
-import SurfaceSkeleton from '@/components/Skeleton/Surface';
+import ProfileSkeleton from '@/components/Skeleton/Profile';
 import ResourceConfigAccessGate from '@/features/ResourcePermission/ResourceConfigAccessGate';
 import WideScreenContainer from '@/features/WideScreenContainer';
 import { useAgentGroupStore } from '@/store/agentGroup';
@@ -28,7 +28,7 @@ const ProfileArea = memo(() => {
   return (
     <Flexbox flex={1} height={'100%'} style={{ minWidth: 0, overflow: 'hidden' }}>
       {isGroupsLoading ? (
-        <SurfaceSkeleton variant={'editor'} />
+        <ProfileSkeleton variant={'group'} />
       ) : (
         <>
           <Header />
@@ -55,8 +55,9 @@ const GroupProfile: FC = () => {
   const { gid } = useParams<{ gid: string }>();
 
   return (
-    <Suspense fallback={<SurfaceSkeleton variant={'editor'} />}>
+    <Suspense fallback={<ProfileSkeleton variant={'group'} />}>
       <ResourceConfigAccessGate
+        loading={<ProfileSkeleton variant={'group'} />}
         redirectPath={`/group/${gid ?? ''}`}
         resourceId={gid}
         resourceType="agentGroup"

--- a/src/routes/(main)/memory/(home)/index.tsx
+++ b/src/routes/(main)/memory/(home)/index.tsx
@@ -3,7 +3,7 @@ import { Flexbox } from '@lobehub/ui';
 import { type FC } from 'react';
 
 import AsyncBoundary from '@/components/AsyncBoundary';
-import SurfaceSkeleton from '@/components/Skeleton/Surface';
+import MemorySkeleton from '@/components/Skeleton/Memory';
 import NavHeader from '@/features/NavHeader';
 import WideScreenContainer from '@/features/WideScreenContainer';
 import WideScreenButton from '@/features/WideScreenContainer/WideScreenButton';
@@ -31,7 +31,7 @@ const Home: FC = () => {
   } = useFetchPersona();
   // const { EditorModalElement, openEditor } = usePersonaEditor();
 
-  if (isTagsLoading || isPersonaLoading) return <SurfaceSkeleton variant={'editor'} />;
+  if (isTagsLoading || isPersonaLoading) return <MemorySkeleton />;
 
   // Persona / tags feed the store, so a failed fetch left the render falling
   // through to the "analyze to get started" onboarding — telling the user they

--- a/src/spa/router/desktopRouter.shared.tsx
+++ b/src/spa/router/desktopRouter.shared.tsx
@@ -26,6 +26,11 @@ import {
 import BrandTextLoading from '@/components/Loading/BrandTextLoading';
 import ConversationLayoutSkeleton from '@/components/Skeleton/Conversation/Layout';
 import ConversationSegmentSkeleton from '@/components/Skeleton/Conversation/Segment';
+import GoalSkeleton from '@/components/Skeleton/Goal';
+import GoalDetailSkeleton from '@/components/Skeleton/GoalDetail';
+import GroupLayoutSkeleton from '@/components/Skeleton/GroupLayout';
+import MemorySkeleton from '@/components/Skeleton/Memory';
+import ProfileSkeleton from '@/components/Skeleton/Profile';
 import RouteSegmentSkeleton from '@/components/Skeleton/RouteSegment';
 import SettingsPageSkeleton from '@/components/Skeleton/Settings/Page';
 import { agentDocumentRouteMeta } from '@/features/AgentDocumentPage/routeMeta';
@@ -160,6 +165,7 @@ export const sharedMainAreaChildren: RouteObject[] = [
             element: dynamicElement(
               () => import('@/routes/(main)/agent/goals'),
               'Desktop > Chat > Goals',
+              { fallback: <GoalSkeleton /> },
             ),
             handle: { meta: goalsRouteMeta },
             path: 'goals',
@@ -168,6 +174,7 @@ export const sharedMainAreaChildren: RouteObject[] = [
             element: dynamicElement(
               () => import('@/routes/(main)/agent/goal/[goalId]'),
               'Desktop > Chat > Goal Detail',
+              { fallback: <GoalDetailSkeleton /> },
             ),
             handle: { meta: goalsRouteMeta },
             path: 'goal/:goalId',
@@ -176,6 +183,7 @@ export const sharedMainAreaChildren: RouteObject[] = [
             element: dynamicElement(
               () => import('@/routes/(main)/agent/profile'),
               'Desktop > Chat > Profile',
+              { fallback: <ProfileSkeleton /> },
             ),
             handle: { meta: agentProfileRouteMeta },
             path: 'profile',
@@ -305,6 +313,7 @@ export const sharedMainAreaChildren: RouteObject[] = [
             element: dynamicElement(
               () => import('@/routes/(main)/group/profile'),
               'Desktop > Agent Group > Profile',
+              { fallback: <ProfileSkeleton variant={'group'} /> },
             ),
             handle: { meta: groupProfileRouteMeta },
             path: 'profile',
@@ -326,7 +335,7 @@ export const sharedMainAreaChildren: RouteObject[] = [
         element: dynamicLayout(
           () => import('@/routes/(main)/group/_layout'),
           'Desktop > Group > Layout',
-          { preloadId: 'group' },
+          { fallback: <GroupLayoutSkeleton />, preloadId: 'group' },
         ),
         errorElement: <ErrorBoundary />,
         path: ':gid',
@@ -646,7 +655,7 @@ export const sharedMainAreaChildren: RouteObject[] = [
         element: dynamicElement(
           () => import('@/routes/(main)/memory/(home)'),
           'Desktop > Memory > Home',
-          { preloadId: 'memory' },
+          { fallback: <MemorySkeleton />, preloadId: 'memory' },
         ),
         handle: {
           meta: routeMeta({ icon: BrainCircuit, titleKey: 'navigation.memory' }),

--- a/src/spa/router/desktopRouter.sync.test.tsx
+++ b/src/spa/router/desktopRouter.sync.test.tsx
@@ -9,6 +9,11 @@ import { describe, expect, it, vi } from 'vitest';
 import BrandTextLoading from '@/components/Loading/BrandTextLoading';
 import ConversationLayoutSkeleton from '@/components/Skeleton/Conversation/Layout';
 import ConversationSegmentSkeleton from '@/components/Skeleton/Conversation/Segment';
+import GoalSkeleton from '@/components/Skeleton/Goal';
+import GoalDetailSkeleton from '@/components/Skeleton/GoalDetail';
+import GroupLayoutSkeleton from '@/components/Skeleton/GroupLayout';
+import MemorySkeleton from '@/components/Skeleton/Memory';
+import ProfileSkeleton from '@/components/Skeleton/Profile';
 import RouteSegmentSkeleton from '@/components/Skeleton/RouteSegment';
 import SettingsPageSkeleton from '@/components/Skeleton/Settings/Page';
 import { WORKSPACE_SETTINGS_TABS } from '@/features/Workspace/workspaceAwarePath';
@@ -281,6 +286,11 @@ describe('desktop router shared definition', () => {
           RouteSegmentSkeleton,
           ConversationLayoutSkeleton,
           ConversationSegmentSkeleton,
+          GoalSkeleton,
+          GoalDetailSkeleton,
+          GroupLayoutSkeleton,
+          MemorySkeleton,
+          ProfileSkeleton,
           SettingsPageSkeleton,
         ]),
       );
@@ -298,7 +308,7 @@ describe('desktop router shared definition', () => {
           '/agent/agent-1/topic-1',
           [RouteSegmentSkeleton, ConversationLayoutSkeleton, ConversationSegmentSkeleton],
         ],
-        ['/group/group-1/topic-1', [RouteSegmentSkeleton, ConversationLayoutSkeleton]],
+        ['/group/group-1/topic-1', [GroupLayoutSkeleton, ConversationLayoutSkeleton]],
       ] as const) {
         const matches = matchRoutes(createRuntimeRoutes(pathname), pathname);
         const fallbackTypes = matches
@@ -315,6 +325,27 @@ describe('desktop router shared definition', () => {
       }
     },
   );
+
+  it.each([
+    ['Web', (_pathname: string) => webDesktopRoutes],
+    ['Electron', (pathname: string) => createTabRouter(pathname).routes],
+  ])('%s keeps profile and goal detail route boundaries on semantic skeletons', (_, getRoutes) => {
+    for (const [pathname, expectedFallbacks] of [
+      ['/group/group-1/profile', [GroupLayoutSkeleton, ProfileSkeleton]],
+      ['/agent/agent-1/goal/goal-1', [RouteSegmentSkeleton, GoalDetailSkeleton]],
+    ] as const) {
+      const matches = matchRoutes(getRoutes(pathname), pathname);
+      const fallbackTypes = matches
+        ?.map(
+          ({ route }) =>
+            (route.element as ReactElement<{ fallback?: ReactElement }> | undefined)?.props.fallback
+              ?.type,
+        )
+        .filter(Boolean);
+
+      expect(fallbackTypes?.slice(-expectedFallbacks.length), pathname).toEqual(expectedFallbacks);
+    }
+  });
 
   it.each([
     ['Web', (_pathname: string) => webDesktopRoutes],


### PR DESCRIPTION
## Summary

- replace generic loading placeholders with task, profile, memory, goal list, and goal detail skeletons
- keep route-level and data-level loading boundaries on the same semantic structure
- improve agent-testing GIF capture by preserving source resolution and using per-frame palettes without dithering

## Why

Several routes briefly rendered generic form or editor cards before their page-specific loading state. This caused large layout shifts and misleading visual hierarchy. GIF evidence also lost clarity because it was downscaled and encoded with one global palette.

## Verification

- bun run check on 20 affected UI files: 38 tests passed
- agent-testing skill validation passed
- record-gif.sh shell syntax validation passed
- visual loading transitions verified through Acceptance rounds 1–6