### PR TITLE
💄 style(work): show four columns on wide screens

### DIFF
--- a/src/features/WorkGallery/index.tsx
+++ b/src/features/WorkGallery/index.tsx
@@ -38,6 +38,10 @@ const styles = createStaticStyles(({ css }) => ({
     gap: 16px;
     width: 100%;
 
+    @media (width >= 1600px) {
+      grid-template-columns: repeat(4, minmax(280px, 1fr));
+    }
+
     @media (width <= 920px) {
       grid-template-columns: repeat(2, minmax(280px, 1fr));
     }


### PR DESCRIPTION
### What changed

- display four work cards per row on viewports at least 1600px wide
- preserve the existing three-, two-, and one-column responsive layouts

### Verification

- `bun run check src/features/WorkGallery/index.tsx`