### PR TITLE
🐛 fix(desktop): keep browser sidebar resizable

### DIFF
--- a/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
+++ b/src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
@@ -18,6 +18,7 @@ interface CapturedRightPanelProps {
   expand?: boolean;
   maxWidth?: number | string;
   onSizeChange?: (size?: { height?: number | string; width?: number | string }) => void;
+  onSizeDragging?: () => void;
   width?: number | string;
 }
 
@@ -84,6 +85,8 @@ const dropdownMenuState = vi.hoisted(() => ({
 
 const workspace = vi.hoisted(() => ({ id: undefined as string | undefined }));
 
+const webviewInteraction = vi.hoisted(() => ({ setInteractionEnabled: vi.fn() }));
+
 const chatStore = vi.hoisted(() => ({
   activeAgentId: undefined as string | undefined,
   activeGroupId: undefined as string | undefined,
@@ -115,6 +118,10 @@ vi.mock('@/features/RightPanel', () => ({
     rightPanel.current = props;
     return <div data-testid="right-panel">{props.children}</div>;
   },
+}));
+
+vi.mock('@/services/electron/browserWebviewRegistry', () => ({
+  browserWebviewRegistry: webviewInteraction,
 }));
 
 // ─── stub every downstream dependency so the sidebar renders deterministically ──
@@ -460,6 +467,16 @@ describe('AgentWorkingSidebar — controlled panel width', () => {
     unmount();
     render(<AgentWorkingSidebar />);
     expect(rightPanel.current?.width).toBe(500);
+  });
+
+  it('keeps the browser webview from stealing pointer events during panel resize', () => {
+    render(<AgentWorkingSidebar />);
+
+    act(() => rightPanel.current?.onSizeDragging?.());
+    expect(webviewInteraction.setInteractionEnabled).toHaveBeenLastCalledWith(false);
+
+    act(() => rightPanel.current?.onSizeChange?.({ width: 500 }));
+    expect(webviewInteraction.setInteractionEnabled).toHaveBeenLastCalledWith(true);
   });
 
   // Regression: dragging the panel wide persisted a width that immediately

--- a/src/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/index.tsx
@@ -54,6 +54,7 @@ import { useEffectiveAgencyConfig } from '@/hooks/useEffectiveAgencyConfig';
 import { useEffectiveWorkingDirectory } from '@/hooks/useEffectiveWorkingDirectory';
 import { useLocalStorageState } from '@/hooks/useLocalStorageState';
 import type { NativeContextMenuItem } from '@/libs/contextMenu/types';
+import { browserWebviewRegistry } from '@/services/electron/browserWebviewRegistry';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
@@ -824,12 +825,18 @@ const AgentWorkingSidebar = memo<AgentWorkingSidebarProps>(({ availableWidth }) 
       minWidth={MIN_PANEL_WIDTH}
       width={renderWidth}
       onSizeChange={(size) => {
+        browserWebviewRegistry.setInteractionEnabled(true);
         if (!size?.width) return;
         // DraggablePanel emits width as a `"420px"` string on drag-stop; parse it so
         // the controlled width actually updates (otherwise the panel snaps back).
         const w = typeof size.width === 'string' ? Number.parseInt(size.width) : size.width;
         if (!Number.isFinite(w) || w === storedWidth) return;
         updateSystemStatus({ workingSidebarWidth: w });
+      }}
+      onSizeDragging={() => {
+        // The retained Electron guest follows the panel bounds. Without disabling
+        // hit-testing it moves under the cursor and steals the remaining drag events.
+        browserWebviewRegistry.setInteractionEnabled(false);
       }}
     >
       <Flexbox height={'100%'} width={'100%'}>

--- a/src/services/electron/browserWebviewRegistry.test.ts
+++ b/src/services/electron/browserWebviewRegistry.test.ts
@@ -120,6 +120,27 @@ describe('browserWebviewRegistry', () => {
     vi.useRealTimers();
   });
 
+  it('temporarily removes visible webviews from pointer hit-testing', async () => {
+    const { browserWebviewRegistry } = await import('./browserWebviewRegistry');
+    const viewport = document.createElement('div');
+    document.body.append(viewport);
+
+    const attaching = browserWebviewRegistry.attach('dragging-topic', viewport);
+    const webview = document.querySelector<HTMLElement>('webview');
+    webview?.dispatchEvent(new Event('dom-ready'));
+    await attaching;
+
+    expect(webview?.style.pointerEvents).toBe('auto');
+
+    browserWebviewRegistry.setInteractionEnabled(false);
+    expect(webview?.style.pointerEvents).toBe('none');
+
+    browserWebviewRegistry.setInteractionEnabled(true);
+    expect(webview?.style.pointerEvents).toBe('auto');
+
+    await browserWebviewRegistry.detach('dragging-topic', viewport);
+  });
+
   it('does not evict a recently touched hidden webview', async () => {
     let now = 0;
     vi.spyOn(Date, 'now').mockImplementation(() => now);

--- a/src/services/electron/browserWebviewRegistry.ts
+++ b/src/services/electron/browserWebviewRegistry.ts
@@ -52,6 +52,18 @@ const getHiddenHost = () => {
 class BrowserWebviewRegistry {
   private retained = new Map<string, RetainedWebview>();
 
+  /**
+   * Electron webviews own a separate guest surface and can steal the pointer from
+   * a resize handle as their projected bounds move underneath the cursor. Keep
+   * visible guests out of hit-testing for the duration of a surrounding drag.
+   */
+  setInteractionEnabled(enabled: boolean): void {
+    for (const retained of this.retained.values()) {
+      if (!retained.visible) continue;
+      retained.webview.style.pointerEvents = enabled ? 'auto' : 'none';
+    }
+  }
+
   async attach(sessionId: string, host: HTMLElement): Promise<BrowserWebviewElement> {
     const webview = await this.ensure(sessionId);
     const retained = this.retained.get(sessionId);


### PR DESCRIPTION
## Summary

- disable pointer hit-testing on visible retained browser webviews while the working sidebar is being resized
- restore webview interaction as soon as the resize completes
- cover both the webview registry behavior and the working-sidebar drag lifecycle with regression tests

## Root cause

The Electron browser webview follows the sidebar's projected bounds during a drag. As the left edge moves beneath the cursor, the guest surface can capture the remaining pointer events before `DraggablePanel` receives them, making the sidebar appear impossible to resize.

## User impact

The working sidebar remains continuously resizable while an in-app Browser tab is open, without changing normal browser interaction outside a drag.

## Validation

- `bun run check src/features/Conversation/WorkingSidebar/index.tsx src/features/Conversation/WorkingSidebar/__tests__/index.test.tsx src/services/electron/browserWebviewRegistry.ts src/services/electron/browserWebviewRegistry.test.ts`
- 41 related tests passed
