### PR TITLE
💄 style(task): use full-width page layouts

### DIFF
--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailPage.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailPage.tsx
@@ -104,7 +104,7 @@ const TaskDetailPage = memo<TaskDetailPageProps>(({ taskId, showTaskAgentPanelTo
         }}
       />
       <Flexbox flex={1} style={{ minHeight: 0, overflowY: 'auto' }}>
-        <WideScreenContainer>
+        <WideScreenContainer fullWidth paddingInline={16}>
           {isInitialLoading ? <TaskDetailSkeleton /> : <TaskDetailSections />}
         </WideScreenContainer>
       </Flexbox>

--- a/src/features/AgentTasks/AgentTaskList/AgentTasksPage.tsx
+++ b/src/features/AgentTasks/AgentTaskList/AgentTasksPage.tsx
@@ -191,8 +191,10 @@ const AgentTasksPage = memo<AgentTasksPageProps>(({ agentId, projectId }) => {
         </Flexbox>
       ) : (
         <WideScreenContainer
+          fullWidth
           gap={16}
           paddingBlock={16}
+          paddingInline={16}
           wrapperStyle={{ flex: 1, overflowY: 'auto' }}
         >
           {!inlineCollapsed && (

--- a/src/features/AgentTasks/AgentTaskList/EmptyState.tsx
+++ b/src/features/AgentTasks/AgentTaskList/EmptyState.tsx
@@ -13,7 +13,6 @@ import WideScreenContainer from '@/features/WideScreenContainer';
 
 import CreateTaskInlineEntry from './CreateTaskInlineEntry';
 
-const HERO_MAX_WIDTH = 960;
 const EMPTY_STATE_RECOMMEND_COUNT = 10;
 
 const styles = createStaticStyles(({ css }) => ({
@@ -41,9 +40,10 @@ const EmptyState = memo<EmptyStateProps>(({ agentId, projectId }) => {
 
   return (
     <WideScreenContainer
+      fullWidth
       gap={32}
-      minWidth={HERO_MAX_WIDTH}
       paddingBlock={48}
+      paddingInline={16}
       wrapperStyle={{ flex: 1, overflowY: 'auto' }}
     >
       <Flexbox align={'center'}>


### PR DESCRIPTION
## What changed

- make the task list use the full available page width
- make task detail content use the full available page width
- remove the task empty state's 960px width cap
- preserve 16px horizontal page padding across these surfaces

## Why

Task pages were inheriting the centered conversation-width constraint from `WideScreenContainer`, leaving excessive unused space on wide screens. Task management surfaces benefit from using the full workspace width, especially for long lists and detail content.

## Impact

All global, agent-scoped, and project-scoped task list/detail surfaces now expand to the available content width while retaining comfortable edge padding.

## Validation

- `bun run check src/features/AgentTasks/AgentTaskList/AgentTasksPage.tsx src/features/AgentTasks/AgentTaskList/EmptyState.tsx src/features/AgentTasks/AgentTaskDetail/TaskDetailPage.tsx`
- 3 files lint clean
- 6 related tests passed
