### PR TITLE
chore: remove internal LOBE-12762 issue reference from code comment

### DIFF
--- a/src/features/EditorCanvas/fileDownload.ts
+++ b/src/features/EditorCanvas/fileDownload.ts
@@ -12,7 +12,7 @@ interface FileDownloadUrlOptions {
 /**
  * The file proxy normally returns an inline preview URL. Opting into its download
  * response lets the browser stream the file and expose native progress instead of
- * waiting for the whole file to become a client-side Blob (LOBE-12762).
+ * waiting for the whole file to become a client-side Blob.
  */
 export const getFileDownloadUrl = (url: string, options: FileDownloadUrlOptions = {}): string => {
   const baseUrl =


### PR DESCRIPTION
## Summary

Daily scan of source code for leftover `LOBE-XXX` markers. This removes one internal issue reference that was left in a code comment.

## Context

The comment in `src/features/EditorCanvas/fileDownload.ts` described why the file proxy opts into the download response (stream the file and expose native browser progress instead of buffering the whole file as a client-side blob), but still carried a trailing internal issue reference.

## Changes

- Removed the trailing `(LOBE-12762)` reference from the JSDoc comment. The surrounding explanation is self-contained and unchanged, so code semantics are preserved.

## Files changed

```
src/features/EditorCanvas/fileDownload.ts
```

Auto-generated on 2026-08-17.