### PR TITLE
🐛 fix(verify): reject mismatched check item ids

### DIFF
--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/verifyResult.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/verifyResult.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { verifyResultRuntime } from '../verifyResult';
+
+const mocks = vi.hoisted(() => ({
+  finalizeVerifyRun: vi.fn(),
+  findOperationById: vi.fn(),
+  findRunByOperation: vi.fn(),
+  recompute: vi.fn(),
+  updateByCheckItem: vi.fn(),
+}));
+
+vi.mock('@/database/models/agentOperation', () => ({
+  AgentOperationModel: vi.fn(() => ({ findById: mocks.findOperationById })),
+}));
+
+vi.mock('@/database/models/verifyCheckResult', () => ({
+  VerifyCheckResultModel: vi.fn(() => ({
+    updateByCheckItem: mocks.updateByCheckItem,
+  })),
+}));
+
+vi.mock('@/database/models/verifyRun', () => ({
+  VerifyRunModel: vi.fn(() => ({ findByOperation: mocks.findRunByOperation })),
+}));
+
+vi.mock('@/server/services/verify', () => ({
+  finalizeVerifyRun: mocks.finalizeVerifyRun,
+  VerifyStatusService: vi.fn(() => ({ recompute: mocks.recompute })),
+}));
+
+describe('verifyResultRuntime', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findOperationById.mockResolvedValue({ parentOperationId: 'parent-op' });
+    mocks.findRunByOperation.mockResolvedValue({ id: 'run-1' });
+    mocks.updateByCheckItem.mockResolvedValue([{ id: 'result-1' }]);
+  });
+
+  it('rejects a checkItemId that does not belong to the verification run', async () => {
+    mocks.updateByCheckItem.mockResolvedValue([]);
+
+    const runtime = verifyResultRuntime.factory({
+      operationId: 'verifier-op',
+      serverDB: {} as never,
+      toolManifestMap: {},
+      userId: 'user-1',
+    });
+
+    const result = await runtime.submitVerifyResult({
+      checkItemId: 'chekc-1',
+      evidence: 'The delivery is complete.',
+      reasoning: 'All requirements are covered.',
+      verdict: 'passed',
+    });
+
+    expect(result).toEqual({
+      content:
+        'Check item "chekc-1" is not part of this verification run. Use the exact checkItemId from the verification prompt.',
+      error: 'CHECK_ITEM_NOT_FOUND',
+      success: false,
+    });
+    expect(mocks.updateByCheckItem).toHaveBeenCalledWith(
+      'run-1',
+      'chekc-1',
+      expect.objectContaining({ status: 'passed', verdict: 'passed' }),
+    );
+    expect(mocks.recompute).not.toHaveBeenCalled();
+    expect(mocks.finalizeVerifyRun).not.toHaveBeenCalled();
+  });
+
+  it('records the verdict when the checkItemId belongs to the verification run', async () => {
+    const runtime = verifyResultRuntime.factory({
+      operationId: 'verifier-op',
+      serverDB: {} as never,
+      toolManifestMap: {},
+      userId: 'user-1',
+    });
+
+    const result = await runtime.submitVerifyResult({
+      checkItemId: 'check-1',
+      evidence: 'The delivery is complete.',
+      reasoning: 'All requirements are covered.',
+      verdict: 'passed',
+    });
+
+    expect(result).toEqual({
+      content: 'Recorded verdict "passed" for the check. Verification complete.',
+      success: true,
+    });
+    expect(mocks.updateByCheckItem).toHaveBeenCalledWith(
+      'run-1',
+      'check-1',
+      expect.objectContaining({ status: 'passed', verdict: 'passed' }),
+    );
+    expect(mocks.recompute).toHaveBeenCalledWith('parent-op');
+    expect(mocks.finalizeVerifyRun).toHaveBeenCalledWith(
+      expect.anything(),
+      'user-1',
+      'parent-op',
+      {},
+      undefined,
+    );
+  });
+});

--- a/apps/server/src/services/toolExecution/serverRuntimes/verifyResult.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/verifyResult.ts
@@ -64,22 +64,27 @@ class VerifyResultExecutionRuntime {
       return { content: 'No verification session for this run.', error: 'NO_RUN', success: false };
     }
 
+    const resultModel = new VerifyCheckResultModel(this.db, this.userId, this.workspaceId);
     const status = params.verdict === 'passed' ? 'passed' : 'failed';
-    await new VerifyCheckResultModel(this.db, this.userId, this.workspaceId).updateByCheckItem(
-      run.id,
-      params.checkItemId,
-      {
-        completedAt: new Date(),
-        status,
-        toulmin: {
-          counterEvidence: params.counterEvidence,
-          evidence: params.evidence,
-          limitation: params.limitation,
-          reasoning: params.reasoning,
-        },
-        verdict: params.verdict,
+    const updated = await resultModel.updateByCheckItem(run.id, params.checkItemId, {
+      completedAt: new Date(),
+      status,
+      toulmin: {
+        counterEvidence: params.counterEvidence,
+        evidence: params.evidence,
+        limitation: params.limitation,
+        reasoning: params.reasoning,
       },
-    );
+      verdict: params.verdict,
+    });
+    if (updated.length === 0) {
+      return {
+        content: `Check item "${params.checkItemId}" is not part of this verification run. Use the exact checkItemId from the verification prompt.`,
+        error: 'CHECK_ITEM_NOT_FOUND',
+        success: false,
+      };
+    }
+
     await new VerifyStatusService(this.db, this.userId, this.workspaceId).recompute(
       targetOperationId,
     );

--- a/packages/database/src/models/__tests__/verifyCheckResult.test.ts
+++ b/packages/database/src/models/__tests__/verifyCheckResult.test.ts
@@ -290,13 +290,14 @@ describe('VerifyCheckResultModel', () => {
     const model = new VerifyCheckResultModel(serverDB, userId);
     await model.create({ checkItemId: 'a', checkItemIndex: 0, verifierType: 'llm', verifyRunId });
 
-    await model.updateByCheckItem(verifyRunId, 'a', {
+    const updated = await model.updateByCheckItem(verifyRunId, 'a', {
       confidence: 0.9,
       status: 'passed',
       toulmin: { evidence: 'tests passed', reasoning: 'covers the goal' },
       verdict: 'passed',
     });
 
+    expect(updated).toEqual([{ id: expect.any(String) }]);
     const [row] = await model.listByRun(verifyRunId);
     expect(row).toMatchObject({ confidence: 0.9, status: 'passed', verdict: 'passed' });
     expect(row.toulmin).toEqual({ evidence: 'tests passed', reasoning: 'covers the goal' });

--- a/packages/database/src/models/verifyCheckResult.ts
+++ b/packages/database/src/models/verifyCheckResult.ts
@@ -172,7 +172,8 @@ export class VerifyCheckResultModel {
           eq(verifyCheckResults.checkItemId, checkItemId),
           this.ownership(),
         ),
-      );
+      )
+      .returning({ id: verifyCheckResults.id });
   };
 
   /**


### PR DESCRIPTION
## Summary

- make `updateByCheckItem` return the affected result row
- reject verifier submissions whose `checkItemId` does not belong to the active verification run
- prevent false `Verification complete` responses and premature run finalization
- add runtime and database regression coverage

## Root cause

A verifier copied one UUID incorrectly (`0a` became `a0`). The database update matched zero rows, but `submitVerifyResult` ignored the affected-row count and returned success. The verifier terminal fallback later found the real check unresolved and marked the run `errored`.

## Impact

Invalid check item IDs now return `CHECK_ITEM_NOT_FOUND`. The verifier can see that the submission failed and correct the ID, while the expected result remains available for the normal terminal fallback if it does not retry.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check` on the four changed files: lint clean, 17 tests passed.

Full type-check was attempted but the isolated worktree reused dependencies from a different checkout and failed on unrelated missing workspace packages and existing cross-worktree module-resolution errors.

#### 🔗 Related Issue

Observed in topic `tpc_ktFnhfeYKAEo`, verifier operation `op_1786934080383_agt_pYECVfoyJEbt_tpc_OgLwGm5QWyJn_LDWB8IST`.
