### PR TITLE
fix(tasks): persist task list view mode

### DIFF
--- a/src/features/AgentTasks/AgentTaskList/AgentTasksPage.tsx
+++ b/src/features/AgentTasks/AgentTaskList/AgentTasksPage.tsx
@@ -10,10 +10,10 @@ import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwar
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { usePermission } from '@/hooks/usePermission';
 import { useGlobalStore } from '@/store/global';
+import type { TaskViewMode } from '@/store/global/initialState';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { useTaskStore } from '@/store/task';
 import { taskListSelectors } from '@/store/task/selectors';
-import type { TaskViewMode } from '@/store/task/slices/list/initialState';
 
 import { createTaskModal } from '../CreateTaskModal';
 import Breadcrumb from '../shared/Breadcrumb';
@@ -81,7 +81,7 @@ const AgentTasksPage = memo<AgentTasksPageProps>(({ agentId, projectId }) => {
   const navigate = useWorkspaceAwareNavigate();
   const isMobile = useIsMobile();
   const { allowed: canCreateTask, reason } = usePermission('create_content');
-  const viewMode = useTaskStore(taskListSelectors.viewMode);
+  const viewMode = useGlobalStore(systemStatusSelectors.taskListViewMode);
   const useFetchTaskList = useTaskStore((s) => s.useFetchTaskList);
   // Keep the SWR handle only for `error` + `mutate` (the error/Retry state).
   const { error, isLoading, mutate } = useFetchTaskList(

--- a/src/features/AgentTasks/AgentTaskList/TasksGroupConfig.tsx
+++ b/src/features/AgentTasks/AgentTaskList/TasksGroupConfig.tsx
@@ -13,8 +13,9 @@ import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
-import { useTaskStore } from '@/store/task';
-import { taskListSelectors } from '@/store/task/selectors';
+import { useGlobalStore } from '@/store/global';
+import type { TaskViewMode } from '@/store/global/initialState';
+import { systemStatusSelectors } from '@/store/global/selectors';
 
 import type { TaskGroupBy, TaskListViewOptions, TaskOrderBy } from './listViewOptions';
 
@@ -37,8 +38,8 @@ const styles = createStaticStyles(({ css, cssVar }) => {
 const TasksGroupConfig = memo<TasksHeaderProps>(({ options, setOptions }) => {
   const [isViewConfigOpen, setIsViewConfigOpen] = useState(false);
   const { t } = useTranslation('chat');
-  const viewMode = useTaskStore(taskListSelectors.viewMode);
-  const setViewMode = useTaskStore((s) => s.setViewMode);
+  const viewMode = useGlobalStore(systemStatusSelectors.taskListViewMode);
+  const updateSystemStatus = useGlobalStore((s) => s.updateSystemStatus);
   const groupingOptions = useMemo<Array<{ label: string; value: TaskGroupBy }>>(
     () => [
       { label: t('taskList.groupBy.none'), value: 'none' },
@@ -173,7 +174,9 @@ const TasksGroupConfig = memo<TasksHeaderProps>(({ options, setOptions }) => {
           list: { display: 'flex', width: '100%' },
           tab: { flex: 1 },
         }}
-        onChange={(key) => setViewMode(key as 'kanban' | 'list')}
+        onChange={(key) =>
+          updateSystemStatus({ taskListViewMode: key as TaskViewMode }, 'updateTaskListViewMode')
+        }
       />
       {viewMode === 'list' && (
         <Form

--- a/src/store/global/actions/__tests__/general.test.ts
+++ b/src/store/global/actions/__tests__/general.test.ts
@@ -77,6 +77,21 @@ describe('generalActionSlice', () => {
       );
     });
 
+    it('should persist the selected task list view mode', () => {
+      const { result } = renderHook(() => useGlobalStore());
+      const saveToLocalStorageSpy = vi.spyOn(result.current.statusStorage, 'saveToLocalStorage');
+
+      act(() => {
+        useGlobalStore.setState({ isStatusInit: true });
+        result.current.updateSystemStatus({ taskListViewMode: 'kanban' });
+      });
+
+      expect(result.current.status.taskListViewMode).toBe('kanban');
+      expect(saveToLocalStorageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ taskListViewMode: 'kanban' }),
+      );
+    });
+
     it('should merge nested objects correctly', () => {
       const { result } = renderHook(() => useGlobalStore());
 

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -138,6 +138,8 @@ export const MODEL_DETAIL_PANEL_EXPANDABLE_KEYS = [
   'config',
 ] as const satisfies readonly ModelDetailPanelExpandedKey[];
 
+export type TaskViewMode = 'kanban' | 'list';
+
 export const DEFAULT_HOME_SIDEBAR_EXPANDED_KEYS = ['recents', 'agent', 'private'];
 
 export interface SystemStatus {
@@ -365,6 +367,11 @@ export interface SystemStatus {
    * Whether the right-side "Hidden columns" panel on the Kanban board is collapsed.
    */
   taskKanbanHiddenPanelCollapsed?: boolean;
+  /**
+   * Display mode for the tasks page. Persisted so a manually selected board or
+   * list view survives navigation and page reloads.
+   */
+  taskListViewMode?: TaskViewMode;
   taskListViewOptions?: {
     groupBy: 'assignee' | 'none' | 'priority' | 'status';
     hideCompleted: boolean;
@@ -513,6 +520,7 @@ export const INITIAL_STATUS = {
     orderDirection: 'asc',
     subGroupBy: 'none',
   },
+  taskListViewMode: 'list' as const,
   taskKanbanHiddenColumns: ['done', 'canceled'],
   taskKanbanHiddenPanelCollapsed: false,
   disabledModelProvidersSortType: 'default',

--- a/src/store/global/selectors/systemStatus.test.ts
+++ b/src/store/global/selectors/systemStatus.test.ts
@@ -175,6 +175,32 @@ describe('systemStatusSelectors', () => {
     });
   });
 
+  describe('taskListViewMode', () => {
+    it('should restore the persisted task board view', () => {
+      const s: GlobalState = {
+        ...initialState,
+        status: {
+          ...initialState.status,
+          taskListViewMode: 'kanban',
+        },
+      };
+
+      expect(systemStatusSelectors.taskListViewMode(s)).toBe('kanban');
+    });
+
+    it('should default legacy status without a task view mode to list', () => {
+      const s: GlobalState = {
+        ...initialState,
+        status: {
+          ...initialState.status,
+          taskListViewMode: undefined,
+        },
+      };
+
+      expect(systemStatusSelectors.taskListViewMode(s)).toBe('list');
+    });
+  });
+
   describe('sidebarItems', () => {
     it('should return DEFAULT_SIDEBAR_ITEMS when no data is set', () => {
       expect(systemStatusSelectors.sidebarItems(null)(initialState)).toEqual(DEFAULT_SIDEBAR_ITEMS);

--- a/src/store/global/selectors/systemStatus.ts
+++ b/src/store/global/selectors/systemStatus.ts
@@ -114,6 +114,8 @@ const taskListViewOptions = (s: GlobalState) =>
     subGroupBy: 'none',
   };
 
+const taskListViewMode = (s: GlobalState) => s.status.taskListViewMode ?? 'list';
+
 // Default the inline composer to collapsed so a populated task list keeps the
 // records at the top of the fold; the empty-state hero still shows the full
 // composer, and the header "+" expands it inline on demand.
@@ -506,6 +508,7 @@ export const systemStatusSelectors = {
   taskCreateInlineCollapsed,
   taskKanbanHiddenColumns,
   taskKanbanHiddenPanelCollapsed,
+  taskListViewMode,
   taskListViewOptions,
   sidebarExpandedKeys,
   agentSidebarSections,

--- a/src/store/task/selectors/listSelectors.test.ts
+++ b/src/store/task/selectors/listSelectors.test.ts
@@ -126,10 +126,6 @@ describe('taskListSelectors', () => {
   });
 
   describe('basic selectors', () => {
-    it('should return viewMode', () => {
-      expect(taskListSelectors.viewMode(createState({ viewMode: 'kanban' }))).toBe('kanban');
-    });
-
     it('should return isTaskListInit', () => {
       expect(taskListSelectors.isTaskListInit(createState({ isTaskListInit: true }))).toBe(true);
     });

--- a/src/store/task/selectors/listSelectors.ts
+++ b/src/store/task/selectors/listSelectors.ts
@@ -13,8 +13,6 @@ const scheduledTaskListTotal = (s: TaskStoreState) => s.scheduledTasksTotal;
 
 const isScheduledTaskListInit = (s: TaskStoreState) => s.isScheduledTaskListInit;
 
-const viewMode = (s: TaskStoreState) => s.viewMode;
-
 const listVisibility = (s: TaskStoreState) => s.listVisibility;
 
 const statusDisplayMap: Record<string, string> = {
@@ -65,5 +63,4 @@ export const taskListSelectors = {
   taskGroups,
   taskList,
   taskListTotal,
-  viewMode,
 };

--- a/src/store/task/slices/list/action.test.ts
+++ b/src/store/task/slices/list/action.test.ts
@@ -24,7 +24,6 @@ beforeEach(() => {
     listQueryVisibility: 'all',
     tasks: [],
     tasksTotal: 0,
-    viewMode: 'list',
   });
 });
 
@@ -39,19 +38,6 @@ describe('TaskListSliceAction', () => {
       useTaskStore.getState().setListAgentId('agt_1');
       useTaskStore.getState().setListAgentId(undefined);
       expect(useTaskStore.getState().listAgentId).toBeUndefined();
-    });
-  });
-
-  describe('setViewMode', () => {
-    it('should toggle to kanban', () => {
-      useTaskStore.getState().setViewMode('kanban');
-      expect(useTaskStore.getState().viewMode).toBe('kanban');
-    });
-
-    it('should toggle back to list', () => {
-      useTaskStore.getState().setViewMode('kanban');
-      useTaskStore.getState().setViewMode('list');
-      expect(useTaskStore.getState().viewMode).toBe('list');
     });
   });
 

--- a/src/store/task/slices/list/action.ts
+++ b/src/store/task/slices/list/action.ts
@@ -6,12 +6,7 @@ import { taskService } from '@/services/task';
 import type { StoreSetter } from '@/store/types';
 
 import type { TaskStore } from '../../store';
-import type {
-  TaskGroupItem,
-  TaskListItem,
-  TaskListVisibilityFilter,
-  TaskViewMode,
-} from './initialState';
+import type { TaskGroupItem, TaskListItem, TaskListVisibilityFilter } from './initialState';
 
 /**
  * Sentinel used as `listAgentId` when the task list is showing tasks across all agents
@@ -123,10 +118,6 @@ export class TaskListSliceActionImpl {
       false,
       'setListVisibility',
     );
-  };
-
-  setViewMode = (mode: TaskViewMode): void => {
-    this.#set({ viewMode: mode }, false, 'setViewMode');
   };
 
   useFetchTaskGroupList = (

--- a/src/store/task/slices/list/initialState.ts
+++ b/src/store/task/slices/list/initialState.ts
@@ -4,8 +4,6 @@ import type { taskService } from '@/services/task';
 export type TaskListItem = Awaited<ReturnType<typeof taskService.list>>['data'][number];
 export type TaskGroupItem = Awaited<ReturnType<typeof taskService.groupList>>['data'][number];
 
-export type TaskViewMode = 'kanban' | 'list';
-
 /**
  * Top-of-list visibility chip selection:
  *   - 'all'       → don't narrow further, show every visible task
@@ -46,7 +44,6 @@ export interface TaskListSliceState {
   taskGroups: TaskGroupItem[];
   tasks: TaskListItem[];
   tasksTotal: number;
-  viewMode: TaskViewMode;
 }
 
 export const initialTaskListSliceState: TaskListSliceState = {
@@ -60,5 +57,4 @@ export const initialTaskListSliceState: TaskListSliceState = {
   taskGroups: [],
   tasks: [],
   tasksTotal: 0,
-  viewMode: 'list',
 };


### PR DESCRIPTION
## Summary

- persist the task page List / Board view choice in global `SystemStatus`
- read and update the persisted preference from the task page, removing the duplicate transient task-store state
- keep List as the fallback for legacy status data and add regression coverage for restore and persistence

## Root cause

The task view mode lived only in the task Zustand slice. A page reload recreated that slice with the default `list` value, while the task page's other display preferences were restored from persisted global status.

## Validation

- `bun run check <11 changed files>` — lint clean, 99 tests passed
- `bun run check --type` — types clean
- `git diff origin/canary...HEAD --check`
- Agent Testing — 4/4 Web acceptance checks passed on `/tasks`
  - Acceptance: https://app.lobehub.com/acceptance/cea43c59-a70b-4d56-93a4-f7c4d40e69b7
  - Verify run: https://app.lobehub.com/verify/0ed38a3d-c5da-4258-9edc-1eec57d49f8f

Fixes LOBE-13087
