### PR TITLE
🐛 fix(project): validate route-safe slugs

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/integration/project.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/project.integration.test.ts
@@ -93,4 +93,28 @@ describe('Project Router Integration', () => {
       'Invalid project identifier',
     );
   });
+
+  it.each(['team/launch', 'roadmap?draft', '#plan', 'two--hyphens'])(
+    'rejects the route-unsafe slug %s when creating a project',
+    async (slug) => {
+      await expect(
+        caller.create({ identifier: 'VALID', name: 'Invalid slug', slug }),
+      ).rejects.toThrow('Invalid project slug');
+    },
+  );
+
+  it.each(['team/launch', 'roadmap?draft', '#plan', 'two--hyphens'])(
+    'rejects the route-unsafe slug %s when updating a project',
+    async (slug) => {
+      const project = await caller.create({
+        identifier: 'VALID',
+        name: 'Valid project',
+        slug: 'valid-project',
+      });
+
+      await expect(caller.update({ id: project.data.id, slug })).rejects.toThrow(
+        'Invalid project slug',
+      );
+    },
+  );
 });

--- a/apps/server/src/routers/lambda/__tests__/integration/project.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/project.integration.test.ts
@@ -117,4 +117,16 @@ describe('Project Router Integration', () => {
       );
     },
   );
+
+  it('accepts underscores in project slugs', async () => {
+    const project = await caller.create({
+      identifier: 'VALID',
+      name: 'Valid project',
+      slug: 'team_launch',
+    });
+    expect(project.data.slug).toBe('team_launch');
+
+    const updated = await caller.update({ id: project.data.id, slug: 'team_launch_v2' });
+    expect(updated.data.slug).toBe('team_launch_v2');
+  });
 });

--- a/apps/server/src/routers/lambda/project.ts
+++ b/apps/server/src/routers/lambda/project.ts
@@ -19,7 +19,7 @@ const projectProcedure = wsCompatProcedure.use(serverDatabase).use(async (opts) 
 
 const projectWriteProcedure = projectProcedure.use(withScopedPermission('agent:update'));
 const idInput = z.object({ id: z.string() });
-const PROJECT_SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const PROJECT_SLUG_REGEX = /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/;
 const projectIdentifierInput = z
   .string()
   .trim()

--- a/apps/server/src/routers/lambda/project.ts
+++ b/apps/server/src/routers/lambda/project.ts
@@ -19,11 +19,13 @@ const projectProcedure = wsCompatProcedure.use(serverDatabase).use(async (opts) 
 
 const projectWriteProcedure = projectProcedure.use(withScopedPermission('agent:update'));
 const idInput = z.object({ id: z.string() });
+const PROJECT_SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const projectIdentifierInput = z
   .string()
   .trim()
   .transform((value) => value.toUpperCase())
   .pipe(z.string().regex(PROJECT_IDENTIFIER_REGEX, 'Invalid project identifier'));
+const projectSlugInput = z.string().max(100).regex(PROJECT_SLUG_REGEX, 'Invalid project slug');
 
 function requireResult<T>(result: T | null, message = 'Project not found'): T {
   if (!result) throw new TRPCError({ code: 'NOT_FOUND', message });
@@ -103,7 +105,7 @@ export const projectRouter = router({
         description: z.string().optional(),
         identifier: projectIdentifierInput,
         name: z.string().min(1).max(255),
-        slug: z.string().max(100).optional(),
+        slug: projectSlugInput.optional(),
         visibility: z.enum(PROJECT_VISIBILITIES).optional(),
       }),
     )
@@ -268,7 +270,7 @@ export const projectRouter = router({
         avatar: z.string().nullish(),
         description: z.string().nullish(),
         name: z.string().min(1).max(255).optional(),
-        slug: z.string().max(100).nullish(),
+        slug: projectSlugInput.nullish(),
         visibility: z.enum(PROJECT_VISIBILITIES).optional(),
       }),
     )


### PR DESCRIPTION
## Summary

- validate project slugs at the backend TRPC boundary for both create and update
- allow lowercase alphanumeric segments separated by single hyphens or underscores
- reject slugs that would be parsed as path, query, or hash syntax
- add integration coverage for unsafe values and valid underscore slugs

## Root cause

The project form enforced a route-safe slug format, but the API only enforced a 100-character length. API callers could therefore persist slugs that break project navigation once interpolated into URLs.

## Validation

- project router integration tests: 12 passed
- lint clean
- full TypeScript check passed