### PR TITLE
💄 style(claude-code): drop the max-width cap on inspector recap chips

### DIFF
--- a/packages/builtin-tool-claude-code/src/client/Inspector/ScheduleWakeup.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/ScheduleWakeup.tsx
@@ -16,7 +16,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     align-items: center;
 
     min-width: 0;
-    max-width: 60%;
     margin-inline-start: 6px;
     padding-block: 1px;
     padding-inline: 8px;

--- a/packages/builtin-tool-claude-code/src/client/Inspector/SendMessage.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/SendMessage.tsx
@@ -16,7 +16,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     align-items: center;
 
     min-width: 0;
-    max-width: 70%;
     margin-inline-start: 6px;
     padding-block: 1px;
     padding-inline: 8px;

--- a/packages/builtin-tool-claude-code/src/client/Inspector/TaskOutput.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/TaskOutput.tsx
@@ -16,7 +16,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     align-items: center;
 
     min-width: 0;
-    max-width: 60%;
     margin-inline-start: 6px;
     padding-block: 1px;
     padding-inline: 8px;

--- a/packages/builtin-tool-claude-code/src/client/Inspector/TaskStop.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/TaskStop.tsx
@@ -16,7 +16,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     align-items: center;
 
     min-width: 0;
-    max-width: 60%;
     margin-inline-start: 6px;
     padding-block: 1px;
     padding-inline: 8px;


### PR DESCRIPTION
## 💄 变更说明

Claude Code 内置工具的几个 inspector 行（工具调用那一行的标题）把摘要 chip 限制在整行的 60–70%：`SendMessage` 是 `max-width: 70%`，`TaskOutput` / `ScheduleWakeup` / `TaskStop` 是 `max-width: 60%`。结果像「发送消息: Round 2: verify feedback fixes, ingest into same acc…」这种不长的摘要被提前省略，而右侧大半行是空的。

外层 `inspectorTextStyles.root` 本来就是 `overflow: hidden / min-width: 0 / text-overflow: ellipsis`，chip 自身也是 `flex-shrink: 1; min-width: 0`，所以这里的 max-width 没有必要：去掉后 chip 铺满剩余宽度，只在真正顶到容器边缘时才截断，和旁边 Bash 行的表现一致。

| 文件 | 改动 |
|---|---|
| `packages/builtin-tool-claude-code/src/client/Inspector/SendMessage.tsx` | 删 `max-width: 70%` |
| `.../Inspector/TaskOutput.tsx` / `ScheduleWakeup.tsx` / `TaskStop.tsx` | 删 `max-width: 60%` |

`Worktree.tsx` 的 `max-width: min(420px, 60vw)` 是另一种设计意图，未动。

## 📝 验证

- `bun run check --lint` 四个文件通过。
- 纯样式改动（删一行 CSS），无回归测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)