### PR TITLE
🐛 fix(heterogeneous-agent): remove local workspace prompt

### DIFF
--- a/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
@@ -494,7 +494,7 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
     expect(mockSpawnHeteroSandbox).not.toHaveBeenCalled();
   });
 
-  it('does not reinject the device workspace note when resuming a native session', async () => {
+  it('resumes a native device session with device-specific context', async () => {
     mockGetHeterogeneousResumeSessionId.mockResolvedValue('native-session-existing');
     heteroAgentConfig.agencyConfig = {
       boundDeviceId: 'device-1',
@@ -507,9 +507,6 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
       prompt: 'Continue on my device',
     });
 
-    expect(mockBuildRemoteDeviceHeteroContext).toHaveBeenCalledWith(
-      expect.objectContaining({ cwd: undefined }),
-    );
     expect(mockDispatchAgentRun).toHaveBeenCalledWith(
       expect.objectContaining({
         resumeSessionId: 'native-session-existing',

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -2716,16 +2716,12 @@ export class AiAgentService {
             });
           }
 
-          // A device is the user's own persistent machine — build a
-          // device-specific context instead of reusing the cloud-sandbox one
-          // (which describes an ephemeral /workspace + pre-cloned repos and
-          // would mislead the agent).
+          // Build only device-relevant context instead of reusing the cloud-sandbox one
+          // (which describes an ephemeral /workspace + pre-cloned repos and would mislead
+          // the agent). The spawned CLI already receives deviceCwd as its actual cwd.
           const deviceSystemContext = buildRemoteDeviceHeteroContext({
             agentSystemContext: agentConfig.agencyConfig?.heterogeneousProvider?.systemContext,
             conversationHistory,
-            // The native CLI session already knows its cwd. Keep the explanatory workspace note
-            // on the first turn only so persistent resumed sessions do not accumulate duplicates.
-            cwd: resumeSessionId ? undefined : deviceCwd,
           });
 
           const result = await deviceGateway.dispatchAgentRun({

--- a/apps/server/src/services/heterogeneousAgent/remoteDeviceHeteroContext.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/remoteDeviceHeteroContext.test.ts
@@ -14,20 +14,6 @@ describe('buildRemoteDeviceHeteroContext', () => {
     expect(result).toBe('Follow the repo rules.');
   });
 
-  it('describes the working directory without cloud-sandbox boilerplate', () => {
-    const result = buildRemoteDeviceHeteroContext({ cwd: '/Users/alice/projects/app' });
-    expect(result).toContain('/Users/alice/projects/app');
-    expect(result).toContain("user's own machine");
-    // Must NOT leak the cloud-sandbox context.
-    expect(result).not.toContain('/workspace');
-    expect(result).not.toContain('ephemeral');
-    expect(result).not.toContain('cloud sandbox');
-  });
-
-  it('trims a blank cwd instead of emitting an empty workspace note', () => {
-    expect(buildRemoteDeviceHeteroContext({ cwd: '   ' })).toBeUndefined();
-  });
-
   it('appends and truncates prior conversation turns', () => {
     const result = buildRemoteDeviceHeteroContext({
       conversationHistory: [
@@ -40,13 +26,12 @@ describe('buildRemoteDeviceHeteroContext', () => {
     expect(result).toContain('short reply');
   });
 
-  it('orders sections: agent context → workspace → history', () => {
+  it('orders the agent context before conversation history without workspace boilerplate', () => {
     const result = buildRemoteDeviceHeteroContext({
       agentSystemContext: 'AGENT_CTX',
       conversationHistory: [{ content: 'HIST', role: 'user' }],
-      cwd: '/repo',
     })!;
-    expect(result.indexOf('AGENT_CTX')).toBeLessThan(result.indexOf('/repo'));
-    expect(result.indexOf('/repo')).toBeLessThan(result.indexOf('<previous_conversation>'));
+    expect(result.indexOf('AGENT_CTX')).toBeLessThan(result.indexOf('<previous_conversation>'));
+    expect(result).not.toContain('## Workspace');
   });
 });

--- a/apps/server/src/services/heterogeneousAgent/remoteDeviceHeteroContext.ts
+++ b/apps/server/src/services/heterogeneousAgent/remoteDeviceHeteroContext.ts
@@ -7,9 +7,8 @@ import type { ConversationHistoryEntry } from './cloudHeteroContext';
  *
  * Unlike {@link buildCloudHeteroContext}, this deliberately strips all the
  * cloud-sandbox boilerplate (ephemeral `/workspace`, pre-cloned repo list,
- * "commit-or-lose-your-work" warnings, injected GITHUB_TOKEN). A device is the
- * user's own persistent machine with their real filesystem and credentials, so
- * none of that applies — injecting it would actively mislead the agent.
+ * "commit-or-lose-your-work" warnings, injected GITHUB_TOKEN). None of that
+ * applies to a device run, so injecting it would actively mislead the agent.
  *
  * What remains is only what's genuinely useful on a device:
  * - the agent-level static context (workspace conventions / rules), and
@@ -27,28 +26,14 @@ export function buildRemoteDeviceHeteroContext(params: {
    * context is unavailable (e.g. a fresh CLI process on the device).
    */
   conversationHistory?: ConversationHistoryEntry[];
-  /** Working directory the agent will run in, surfaced so it can orient itself. */
-  cwd?: string;
 }): string | undefined {
-  const { agentSystemContext, conversationHistory, cwd } = params;
+  const { agentSystemContext, conversationHistory } = params;
 
   const parts: string[] = [];
 
   // --- Agent-level static context (highest priority, goes first) ---
   if (agentSystemContext?.trim()) {
     parts.push(agentSystemContext.trim());
-  }
-
-  // --- Device workspace note (minimal — it's the user's real machine) ---
-  if (cwd?.trim()) {
-    parts.push(
-      [
-        '## Workspace',
-        `You are running on the user's own machine. Your working directory is \`${cwd.trim()}\`.`,
-        'This is a persistent local filesystem — changes are not lost when the task ends, so',
-        'there is no need to commit or push purely to preserve your work.',
-      ].join('\n'),
-    );
   }
 
   // --- Previous conversation context (injected when session was reset) ---

--- a/packages/heterogeneous-agents/src/transcript/claudeCode.test.ts
+++ b/packages/heterogeneous-agents/src/transcript/claudeCode.test.ts
@@ -341,9 +341,28 @@ describe('parseClaudeCodeSessionDigest', () => {
     expect(digest.tokens).toBe(60);
   });
 
-  it('strips the injected Workspace preamble from title fallbacks', () => {
+  it('strips the historical local Workspace preamble from title fallbacks', () => {
     const preambled =
       "## Workspace\nYou are running on the user's own machine. Your working directory is `/repo`.帮我修个 bug";
+    const transcript = [
+      userRecord('u1', null, preambled),
+      assistantRecord('a1', 'u1', 'msg_1', { text: 'ok', type: 'text' }),
+    ].join('\n');
+
+    const digest = parseClaudeCodeSessionDigest(transcript, '/tmp/x.jsonl')!;
+    expect(digest.firstPrompt).toBe('帮我修个 bug');
+    expect(digest.title).toBe('帮我修个 bug');
+  });
+
+  it('strips the complete historical remote-device Workspace preamble', () => {
+    const preambled = [
+      '## Workspace',
+      "You are running on the user's own machine. Your working directory is `/repo`.",
+      'This is a persistent local filesystem — changes are not lost when the task ends, so',
+      'there is no need to commit or push purely to preserve your work.',
+      '',
+      '帮我修个 bug',
+    ].join('\n');
     const transcript = [
       userRecord('u1', null, preambled),
       assistantRecord('a1', 'u1', 'msg_1', { text: 'ok', type: 'text' }),

--- a/packages/heterogeneous-agents/src/transcript/claudeCode.ts
+++ b/packages/heterogeneous-agents/src/transcript/claudeCode.ts
@@ -73,10 +73,12 @@ const textOfContent = (content: any, img?: ImageStats): string => {
 };
 
 /**
- * Claude Code prepends an injected `## Workspace` preamble to the first user
- * message; strip it when the message doubles as the title / prompt preview.
+ * Older LobeHub versions prepended an injected `## Workspace` preamble to the
+ * first user message; strip both historical variants when that message doubles
+ * as the title / prompt preview.
  */
-const CC_PREAMBLE_RE = /^##\s*workspace\b[\S\s]+?working directory is[^\n]*?\.\s*/i;
+const CC_PREAMBLE_RE =
+  /^##\s*workspace\s*\nYou are running on the user's own machine\. Your working directory is `[^`\n]*`\.\s*(?:This is a persistent local filesystem — changes are not lost when the task ends, so\s*\nthere is no need to commit or push purely to preserve your work\.\s*)?/i;
 const stripCcPreamble = (text: string): string => {
   if (!/^##\s*workspace\b/i.test(text)) return text;
   const stripped = text.replace(CC_PREAMBLE_RE, '').trim();

--- a/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
@@ -1741,7 +1741,7 @@ describe('heterogeneousAgentExecutor DB persistence', () => {
       });
     });
 
-    it('should inject local workspace context only when starting a native session', async () => {
+    it('should not inject local workspace context into native sessions', async () => {
       const store = createMockStore();
       const get = vi.fn(() => store);
       const params = {
@@ -1756,9 +1756,7 @@ describe('heterogeneousAgentExecutor DB persistence', () => {
 
       await executeHeterogeneousAgent(get, params);
 
-      expect(mockSendPrompt.mock.calls[0][0].systemContext).toContain(
-        "You are running on the user's own machine. Your working directory is `/Users/me/repo`.",
-      );
+      expect(mockSendPrompt.mock.calls[0][0].systemContext).toBe('Follow the agent rules.');
 
       await executeHeterogeneousAgent(get, {
         ...params,

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
@@ -226,25 +226,14 @@ const buildLocalHeterogeneousSystemContext = ({
   agentSystemContext,
   contextSelections,
   pageSelections,
-  workingDirectory,
 }: {
   agentSystemContext?: string;
   contextSelections?: ContextSelection[];
   pageSelections?: PageSelection[];
-  workingDirectory?: string;
 }): string | undefined => {
   const parts: string[] = [];
 
   if (agentSystemContext?.trim()) parts.push(agentSystemContext.trim());
-
-  if (workingDirectory?.trim()) {
-    parts.push(
-      [
-        '## Workspace',
-        `You are running on the user's own machine. Your working directory is \`${workingDirectory.trim()}\`.`,
-      ].join('\n'),
-    );
-  }
 
   const selectionContext =
     contextSelections && contextSelections.length > 0
@@ -2312,9 +2301,6 @@ export const executeHeterogeneousAgent = async (
       agentSystemContext: heterogeneousProvider.systemContext,
       contextSelections,
       pageSelections,
-      // The native CLI session already retains its workspace context. Reinjecting this note on
-      // every resumed turn makes it accumulate in persistent Codex/Claude conversations.
-      workingDirectory: resumeSessionId ? undefined : workingDirectory,
     });
 
     // When resuming, hand main the prior turns so it can rebuild a Claude Code


### PR DESCRIPTION
## Description of Change

Remove the injected `## Workspace` preamble from local desktop and remote-device heterogeneous agent runs. The spawned CLI already receives the selected directory as its actual `cwd`, so repeating it inside the user prompt pollutes native session history and generated titles without affecting execution.

This keeps agent-level context, code/page selections, and conversation-history recovery intact. Cloud sandbox context is unchanged.

The historical Claude Code transcript parser continues to recognize old preambles and now removes the complete four-line remote-device variant instead of leaving persistence guidance in title fallbacks.

#### Test

- `bun run check <8 changed files>` — lint clean, 167 tests passed
- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

No matching issue found.
