### PR TITLE
🐛 fix(chat): anchor tool timer to result message

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/Tool/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/index.tsx
@@ -96,7 +96,9 @@ const Tool = memo<GroupToolProps>(({ assistantMessageId, disableEditing, id }) =
   const looksLikeWaitingForToolResult = !hasError && !isArgumentsStreaming && !hasFinishedResult;
   const isToolCallingFallback = looksLikeWaitingForToolResult && isAssistantMessageBusy;
   const isToolCalling = !hasFinishedResult && (isToolCallingFromOperation || isToolCallingFallback);
-  const toolCallStartTime = useConversationStore(dataSelectors.getToolMessageCreatedAt(id));
+  const toolCallStartTime = useConversationStore(
+    dataSelectors.getToolMessageCreatedAt(toolMessageId),
+  );
 
   const hasCustomRender = !!getBuiltinRender(identifier, apiName);
   // Only allow toggle when has custom render and not in pending/reject/abort state

--- a/src/features/Conversation/store/selectors.test.ts
+++ b/src/features/Conversation/store/selectors.test.ts
@@ -322,12 +322,16 @@ describe('conversationSelectors', () => {
 
 describe('dataSelectors', () => {
   describe('getToolMessageCreatedAt', () => {
-    const createToolMessage = (createdAt: Date | number | string) =>
+    const createToolMessage = (
+      createdAt: Date | number | string,
+      id = 'tool-message-1',
+      toolCallId = 'tool-call-1',
+    ) =>
       ({
         createdAt,
-        id: 'tool-message-1',
+        id,
         role: 'tool',
-        tool_call_id: 'tool-call-1',
+        tool_call_id: toolCallId,
       }) as unknown as State['dbMessages'][number];
 
     it.each([
@@ -336,19 +340,36 @@ describe('dataSelectors', () => {
     ])('normalizes a %s createdAt to epoch milliseconds', (_, createdAt, expected) => {
       const store = createMockState({ dbMessages: [createToolMessage(createdAt)] });
 
-      expect(dataSelectors.getToolMessageCreatedAt('tool-call-1')(store)).toBe(expected);
+      expect(dataSelectors.getToolMessageCreatedAt('tool-message-1')(store)).toBe(expected);
+    });
+
+    it('resolves the current result row when Codex reuses a tool call id', () => {
+      const store = createMockState({
+        dbMessages: [
+          createToolMessage(1000, 'old-result', 'item_1'),
+          createToolMessage(5000, 'current-result', 'item_1'),
+        ],
+      });
+
+      expect(dataSelectors.getToolMessageCreatedAt('current-result')(store)).toBe(5000);
     });
 
     it('returns undefined when the tool message is absent', () => {
       expect(
-        dataSelectors.getToolMessageCreatedAt('tool-call-1')(createMockState()),
+        dataSelectors.getToolMessageCreatedAt('tool-message-1')(createMockState()),
       ).toBeUndefined();
+    });
+
+    it('returns undefined while the result message id is unavailable', () => {
+      const store = createMockState({ dbMessages: [createToolMessage(2000)] });
+
+      expect(dataSelectors.getToolMessageCreatedAt(undefined)(store)).toBeUndefined();
     });
 
     it('returns undefined for an invalid createdAt', () => {
       const store = createMockState({ dbMessages: [createToolMessage('not-a-date')] });
 
-      expect(dataSelectors.getToolMessageCreatedAt('tool-call-1')(store)).toBeUndefined();
+      expect(dataSelectors.getToolMessageCreatedAt('tool-message-1')(store)).toBeUndefined();
     });
   });
 });

--- a/src/features/Conversation/store/slices/data/selectors.ts
+++ b/src/features/Conversation/store/slices/data/selectors.ts
@@ -49,11 +49,11 @@ const toEpochMs = (value: Date | number | string | null | undefined): number | u
 /**
  * `createdAt` of a tool call's result row, normalized to epoch ms.
  *
- * The row is written when the call is issued, so it provides a durable baseline
- * for the elapsed time shown by the tool call.
+ * Resolve the row by its unique message id rather than `tool_call_id`: Codex
+ * reuses item ids such as `item_1` across resumed turns in the same topic.
  */
-const getToolMessageCreatedAt = (toolCallId: string) => (s: State) =>
-  toEpochMs(getDbMessageByToolCallId(toolCallId)(s)?.createdAt);
+const getToolMessageCreatedAt = (resultMessageId: string | undefined) => (s: State) =>
+  resultMessageId ? toEpochMs(getDbMessageById(resultMessageId)(s)?.createdAt) : undefined;
 
 /**
  * Helper to find last message ID in an AssistantContentBlock


### PR DESCRIPTION
## Summary

- anchor tool execution timers to the unique `result_msg_id`
- avoid matching stale tool rows when Codex reuses `item_N` IDs across resumed turns
- add regression coverage for duplicate `tool_call_id` values

## Testing

- `bun run check src/features/Conversation/Messages/AssistantGroup/Tool/index.tsx src/features/Conversation/store/slices/data/selectors.ts src/features/Conversation/store/selectors.test.ts`
- 33 tests passed
- 2 existing lint warnings remain in `Tool/index.tsx`