### PR TITLE
🐛 fix(desktop): 继承 Claude Code Bedrock 环境变量

### DIFF
--- a/apps/desktop/src/main/core/App.ts
+++ b/apps/desktop/src/main/core/App.ts
@@ -295,7 +295,7 @@ export class App {
   private initializeAfterFirstFrame = async (initializeNativeShell: () => Promise<void>) => {
     await this.browserManager.waitForMainWindowFirstFrame();
 
-    // GUI 启动的应用不会继承登录 shell 的 PATH 和 Claude Code Bedrock 配置。
+    // GUI 启动的应用不会继承 shell 的 PATH 和 Claude Code Bedrock 配置。
     // 首帧后再读取，避免 shell 初始化阻塞主进程到渲染进程的导航关键路径。
     void refreshShellEnvironment().catch((error) => {
       logger.warn('从登录 shell 刷新环境变量失败：', error);

--- a/apps/desktop/src/main/core/App.ts
+++ b/apps/desktop/src/main/core/App.ts
@@ -28,7 +28,7 @@ import type { IServiceModule, ServiceLifecycle, ServiceModule } from '@/services
 import LocalDatabaseService from '@/services/LocalDatabaseSrv';
 import { createLogger } from '@/utils/logger';
 import * as electronIs from '@/utils/platform';
-import { refreshShellPath } from '@/utils/shellPath';
+import { refreshShellEnvironment } from '@/utils/shellPath';
 
 import { BrowserManager } from './browser/BrowserManager';
 import { backendProxyProtocolManager } from './infrastructure/BackendProxyProtocolManager';
@@ -295,11 +295,10 @@ export class App {
   private initializeAfterFirstFrame = async (initializeNativeShell: () => Promise<void>) => {
     await this.browserManager.waitForMainWindowFirstFrame();
 
-    // GUI-launched apps do not inherit the user's login-shell PATH. Resolve it
-    // asynchronously after the first frame so shell startup never blocks the
-    // main process -> renderer navigation critical path.
-    void refreshShellPath().catch((error) => {
-      logger.warn('Failed to refresh PATH from the login shell:', error);
+    // GUI 启动的应用不会继承登录 shell 的 PATH 和 Claude Code Bedrock 配置。
+    // 首帧后再读取，避免 shell 初始化阻塞主进程到渲染进程的导航关键路径。
+    void refreshShellEnvironment().catch((error) => {
+      logger.warn('从登录 shell 刷新环境变量失败：', error);
     });
 
     await Promise.all([initializeNativeShell(), this.runControllerHooks('afterFirstFrame')]);

--- a/apps/desktop/src/main/core/App.ts
+++ b/apps/desktop/src/main/core/App.ts
@@ -295,8 +295,8 @@ export class App {
   private initializeAfterFirstFrame = async (initializeNativeShell: () => Promise<void>) => {
     await this.browserManager.waitForMainWindowFirstFrame();
 
-    // GUI 启动的应用不会继承 shell 的 PATH 和 Claude Code Bedrock 配置。
-    // 首帧后再读取，避免 shell 初始化阻塞主进程到渲染进程的导航关键路径。
+    // GUI-launched apps do not inherit shell PATH or Claude Code Bedrock settings.
+    // Resolve them after the first frame so shell startup does not block initial navigation.
     void refreshShellEnvironment().catch((error) => {
       logger.warn('从登录 shell 刷新环境变量失败：', error);
     });

--- a/apps/desktop/src/main/utils/shellPath.test.ts
+++ b/apps/desktop/src/main/utils/shellPath.test.ts
@@ -1,38 +1,49 @@
 import { execFile } from 'node:child_process';
 
+import { detectWindowsShell } from '@lobechat/local-file-shell/shell';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { refreshShellEnvironment } from './shellPath';
 
 vi.mock('node:child_process', () => ({ execFile: vi.fn() }));
+vi.mock('@lobechat/local-file-shell/shell', () => ({ detectWindowsShell: vi.fn() }));
 
 const execFileMock = vi.mocked(execFile) as unknown as ReturnType<typeof vi.fn>;
+const detectWindowsShellMock = vi.mocked(detectWindowsShell);
 
 describe('refreshShellEnvironment', () => {
+  const originalPlatform = process.platform;
   const originalPath = process.env.PATH;
   const originalShell = process.env.SHELL;
   const originalAwsBearerTokenBedrock = process.env.AWS_BEARER_TOKEN_BEDROCK;
   const originalAwsProfile = process.env.AWS_PROFILE;
   const originalClaudeCodeUseBedrock = process.env.CLAUDE_CODE_USE_BEDROCK;
+  const originalShellFixture = process.env.AWS_LOBEHUB_SHELL_FIXTURE;
   const originalUnrelatedSecret = process.env.UNRELATED_SECRET;
 
   beforeEach(() => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' });
     process.env.PATH = '/usr/bin:/bin';
     process.env.SHELL = '/bin/zsh';
     delete process.env.AWS_BEARER_TOKEN_BEDROCK;
     delete process.env.AWS_PROFILE;
+    delete process.env.AWS_LOBEHUB_SHELL_FIXTURE;
     delete process.env.CLAUDE_CODE_USE_BEDROCK;
     delete process.env.UNRELATED_SECRET;
     execFileMock.mockReset();
+    detectWindowsShellMock.mockReset();
   });
 
   afterEach(() => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform });
     process.env.PATH = originalPath;
     process.env.SHELL = originalShell;
     if (originalAwsBearerTokenBedrock === undefined) delete process.env.AWS_BEARER_TOKEN_BEDROCK;
     else process.env.AWS_BEARER_TOKEN_BEDROCK = originalAwsBearerTokenBedrock;
     if (originalAwsProfile === undefined) delete process.env.AWS_PROFILE;
     else process.env.AWS_PROFILE = originalAwsProfile;
+    if (originalShellFixture === undefined) delete process.env.AWS_LOBEHUB_SHELL_FIXTURE;
+    else process.env.AWS_LOBEHUB_SHELL_FIXTURE = originalShellFixture;
     if (originalClaudeCodeUseBedrock === undefined) delete process.env.CLAUDE_CODE_USE_BEDROCK;
     else process.env.CLAUDE_CODE_USE_BEDROCK = originalClaudeCodeUseBedrock;
     if (originalUnrelatedSecret === undefined) delete process.env.UNRELATED_SECRET;
@@ -57,6 +68,9 @@ describe('refreshShellEnvironment', () => {
       expect.objectContaining({ timeout: 5000 }),
       expect.any(Function),
     );
+    const shellScript = execFileMock.mock.calls[0][1][1];
+    expect(shellScript).not.toContain('env -0');
+    expect(shellScript).not.toMatch(/;\s*exit\b/);
   });
 
   it('imports Claude Code Bedrock settings from the login shell', async () => {
@@ -66,7 +80,10 @@ describe('refreshShellEnvironment', () => {
         [
           'shell startup output',
           '__LOBE_SHELL_PATH__/opt/homebrew/bin:/usr/bin__LOBE_SHELL_PATH__',
-          '__LOBE_SHELL_ENV__AWS_BEARER_TOKEN_BEDROCK=bedrock-token\0AWS_PROFILE=bedrock-dev\0CLAUDE_CODE_USE_BEDROCK=1\0UNRELATED_SECRET=do-not-import\0__LOBE_SHELL_ENV__',
+          '__LOBE_SHELL_ENV__AWS_BEARER_TOKEN_BEDROCK=bedrock-token',
+          '__LOBE_SHELL_ENV__AWS_PROFILE=bedrock-dev',
+          '__LOBE_SHELL_ENV__CLAUDE_CODE_USE_BEDROCK=1',
+          '__LOBE_SHELL_ENV__UNRELATED_SECRET=do-not-import',
         ].join('\n'),
         '',
       );
@@ -78,6 +95,78 @@ describe('refreshShellEnvironment', () => {
     expect(process.env.AWS_PROFILE).toBe('bedrock-dev');
     expect(process.env.CLAUDE_CODE_USE_BEDROCK).toBe('1');
     expect(process.env.UNRELATED_SECRET).toBeUndefined();
+  });
+
+  it.skipIf(originalPlatform === 'win32')(
+    'reads Bedrock settings through the real platform env command',
+    async () => {
+      const { execFile: actualExecFile } = (await vi.importActual('node:child_process')) as {
+        execFile: typeof execFile;
+      };
+      process.env.SHELL = '/bin/sh';
+      process.env.AWS_LOBEHUB_SHELL_FIXTURE = 'fixture-value';
+      process.env.UNRELATED_SECRET = 'must-not-import';
+      execFileMock.mockImplementation((...args) => {
+        delete process.env.AWS_LOBEHUB_SHELL_FIXTURE;
+        delete process.env.UNRELATED_SECRET;
+        return actualExecFile(...args);
+      });
+
+      await refreshShellEnvironment();
+
+      expect(process.env.AWS_LOBEHUB_SHELL_FIXTURE).toBe('fixture-value');
+      expect(process.env.UNRELATED_SECRET).toBeUndefined();
+    },
+  );
+
+  it('imports Bedrock settings from the Windows user environment and PowerShell Profile', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' });
+    detectWindowsShellMock.mockResolvedValue({
+      displayName: 'PowerShell 7+ (pwsh)',
+      path: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+      type: 'pwsh',
+    });
+    execFileMock.mockImplementation((_file, _args, _options, callback) => {
+      callback(
+        null,
+        [
+          'PowerShell profile output',
+          '__LOBE_SHELL_ENV__',
+          '{"AWS_BEARER_TOKEN_BEDROCK":"bedrock-token","AWS_REGION":"us-east-1","CLAUDE_CODE_USE_BEDROCK":"1","UNRELATED_SECRET":"do-not-import"}',
+          '__LOBE_SHELL_ENV__',
+        ].join('\r\n'),
+        '',
+      );
+    });
+
+    await refreshShellEnvironment();
+
+    expect(process.env.AWS_BEARER_TOKEN_BEDROCK).toBe('bedrock-token');
+    expect(process.env.AWS_REGION).toBe('us-east-1');
+    expect(process.env.CLAUDE_CODE_USE_BEDROCK).toBe('1');
+    expect(process.env.UNRELATED_SECRET).toBeUndefined();
+    expect(execFileMock).toHaveBeenCalledWith(
+      'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+      expect.arrayContaining(['-NoProfile', '-NonInteractive', '-Command']),
+      expect.objectContaining({ timeout: 5000 }),
+      expect.any(Function),
+    );
+    const powerShellScript = execFileMock.mock.calls[0][1].at(-1);
+    expect(powerShellScript).toContain('$PROFILE.CurrentUserAllHosts');
+    expect(powerShellScript).toContain("GetEnvironmentVariables('User')");
+  });
+
+  it('keeps the inherited environment when Windows has no PowerShell', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' });
+    detectWindowsShellMock.mockResolvedValue({
+      displayName: 'cmd.exe',
+      path: 'cmd.exe',
+      type: 'cmd',
+    });
+
+    await refreshShellEnvironment();
+
+    expect(execFileMock).not.toHaveBeenCalled();
   });
 
   it('preserves PATH when the login shell returns no delimited value', async () => {

--- a/apps/desktop/src/main/utils/shellPath.test.ts
+++ b/apps/desktop/src/main/utils/shellPath.test.ts
@@ -2,25 +2,41 @@ import { execFile } from 'node:child_process';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { refreshShellPath } from './shellPath';
+import { refreshShellEnvironment } from './shellPath';
 
 vi.mock('node:child_process', () => ({ execFile: vi.fn() }));
 
 const execFileMock = vi.mocked(execFile) as unknown as ReturnType<typeof vi.fn>;
 
-describe('refreshShellPath', () => {
+describe('refreshShellEnvironment', () => {
   const originalPath = process.env.PATH;
   const originalShell = process.env.SHELL;
+  const originalAwsBearerTokenBedrock = process.env.AWS_BEARER_TOKEN_BEDROCK;
+  const originalAwsProfile = process.env.AWS_PROFILE;
+  const originalClaudeCodeUseBedrock = process.env.CLAUDE_CODE_USE_BEDROCK;
+  const originalUnrelatedSecret = process.env.UNRELATED_SECRET;
 
   beforeEach(() => {
     process.env.PATH = '/usr/bin:/bin';
     process.env.SHELL = '/bin/zsh';
+    delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+    delete process.env.AWS_PROFILE;
+    delete process.env.CLAUDE_CODE_USE_BEDROCK;
+    delete process.env.UNRELATED_SECRET;
     execFileMock.mockReset();
   });
 
   afterEach(() => {
     process.env.PATH = originalPath;
     process.env.SHELL = originalShell;
+    if (originalAwsBearerTokenBedrock === undefined) delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+    else process.env.AWS_BEARER_TOKEN_BEDROCK = originalAwsBearerTokenBedrock;
+    if (originalAwsProfile === undefined) delete process.env.AWS_PROFILE;
+    else process.env.AWS_PROFILE = originalAwsProfile;
+    if (originalClaudeCodeUseBedrock === undefined) delete process.env.CLAUDE_CODE_USE_BEDROCK;
+    else process.env.CLAUDE_CODE_USE_BEDROCK = originalClaudeCodeUseBedrock;
+    if (originalUnrelatedSecret === undefined) delete process.env.UNRELATED_SECRET;
+    else process.env.UNRELATED_SECRET = originalUnrelatedSecret;
   });
 
   it('updates PATH from the login shell output', async () => {
@@ -32,7 +48,7 @@ describe('refreshShellPath', () => {
       );
     });
 
-    await refreshShellPath();
+    await refreshShellEnvironment();
 
     expect(process.env.PATH).toBe('/opt/homebrew/bin:/usr/bin');
     expect(execFileMock).toHaveBeenCalledWith(
@@ -43,12 +59,33 @@ describe('refreshShellPath', () => {
     );
   });
 
+  it('imports Claude Code Bedrock settings from the login shell', async () => {
+    execFileMock.mockImplementation((_file, _args, _options, callback) => {
+      callback(
+        null,
+        [
+          'shell startup output',
+          '__LOBE_SHELL_PATH__/opt/homebrew/bin:/usr/bin__LOBE_SHELL_PATH__',
+          '__LOBE_SHELL_ENV__AWS_BEARER_TOKEN_BEDROCK=bedrock-token\0AWS_PROFILE=bedrock-dev\0CLAUDE_CODE_USE_BEDROCK=1\0UNRELATED_SECRET=do-not-import\0__LOBE_SHELL_ENV__',
+        ].join('\n'),
+        '',
+      );
+    });
+
+    await refreshShellEnvironment();
+
+    expect(process.env.AWS_BEARER_TOKEN_BEDROCK).toBe('bedrock-token');
+    expect(process.env.AWS_PROFILE).toBe('bedrock-dev');
+    expect(process.env.CLAUDE_CODE_USE_BEDROCK).toBe('1');
+    expect(process.env.UNRELATED_SECRET).toBeUndefined();
+  });
+
   it('preserves PATH when the login shell returns no delimited value', async () => {
     execFileMock.mockImplementation((_file, _args, _options, callback) => {
       callback(null, 'shell startup output only', '');
     });
 
-    await refreshShellPath();
+    await refreshShellEnvironment();
 
     expect(process.env.PATH).toBe('/usr/bin:/bin');
   });
@@ -58,7 +95,7 @@ describe('refreshShellPath', () => {
       callback(new Error('shell failed'), '', '');
     });
 
-    await expect(refreshShellPath()).rejects.toThrow('shell failed');
+    await expect(refreshShellEnvironment()).rejects.toThrow('shell failed');
     expect(process.env.PATH).toBe('/usr/bin:/bin');
   });
 });

--- a/apps/desktop/src/main/utils/shellPath.test.ts
+++ b/apps/desktop/src/main/utils/shellPath.test.ts
@@ -106,10 +106,10 @@ describe('refreshShellEnvironment', () => {
       process.env.SHELL = '/bin/sh';
       process.env.AWS_LOBEHUB_SHELL_FIXTURE = 'fixture-value';
       process.env.UNRELATED_SECRET = 'must-not-import';
-      execFileMock.mockImplementation((...args) => {
+      execFileMock.mockImplementation((file, args, options, callback) => {
         delete process.env.AWS_LOBEHUB_SHELL_FIXTURE;
         delete process.env.UNRELATED_SECRET;
-        return actualExecFile(...args);
+        return actualExecFile(file, args, options, callback);
       });
 
       await refreshShellEnvironment();

--- a/apps/desktop/src/main/utils/shellPath.ts
+++ b/apps/desktop/src/main/utils/shellPath.ts
@@ -1,5 +1,7 @@
 import { execFile } from 'node:child_process';
 
+import { detectWindowsShell } from '@lobechat/local-file-shell/shell';
+
 const SHELL_PATH_DELIMITER = '__LOBE_SHELL_PATH__';
 const SHELL_ENV_DELIMITER = '__LOBE_SHELL_ENV__';
 const SHELL_PATH_TIMEOUT_MS = 5000;
@@ -12,14 +14,24 @@ const shouldImportClaudeCodeBedrockEnv = (key: string) =>
   key === 'ANTHROPIC_SMALL_FAST_MODEL' ||
   /^ANTHROPIC_DEFAULT_.*_MODEL$/.test(key);
 
-const runLoginShell = (shell: string): Promise<string> =>
+const importClaudeCodeBedrockEnv = (env: Record<string, string>) => {
+  for (const [key, value] of Object.entries(env)) {
+    if (shouldImportClaudeCodeBedrockEnv(key)) process.env[key] = value;
+  }
+};
+
+const parseEnvEntry = (entry: string): [string, string] | undefined => {
+  const separatorIndex = entry.indexOf('=');
+  if (separatorIndex <= 0) return;
+
+  return [entry.slice(0, separatorIndex), entry.slice(separatorIndex + 1)];
+};
+
+const runCommand = (command: string, args: string[]): Promise<string> =>
   new Promise((resolve, reject) => {
     execFile(
-      shell,
-      [
-        '-ilc',
-        `printf '${SHELL_PATH_DELIMITER}%s${SHELL_PATH_DELIMITER}' "$PATH"; printf '${SHELL_ENV_DELIMITER}'; env -0; printf '${SHELL_ENV_DELIMITER}'; exit`,
-      ],
+      command,
+      args,
       {
         encoding: 'utf8',
         env: {
@@ -41,27 +53,69 @@ const runLoginShell = (shell: string): Promise<string> =>
     );
   });
 
+const runLoginShell = (shell: string): Promise<string> =>
+  runCommand(shell, [
+    '-ilc',
+    `printf '${SHELL_PATH_DELIMITER}%s${SHELL_PATH_DELIMITER}\n' "$PATH"; env | while IFS= read -r env_entry; do case "$env_entry" in AWS_*=*|CLAUDE_CODE_USE_BEDROCK=*|CLAUDE_CODE_SKIP_BEDROCK_AUTH=*|ANTHROPIC_MODEL=*|ANTHROPIC_SMALL_FAST_MODEL=*|ANTHROPIC_DEFAULT_*_MODEL=*) printf '${SHELL_ENV_DELIMITER}%s\n' "$env_entry" ;; esac; done`,
+  ]);
+
+const parseLoginShellEnv = (stdout: string): Record<string, string> => {
+  const env: Record<string, string> = {};
+
+  for (const segment of stdout.split(SHELL_ENV_DELIMITER).slice(1)) {
+    const parsed = parseEnvEntry(segment.split(/\r?\n/, 1)[0]);
+    if (parsed) env[parsed[0]] = parsed[1];
+  }
+
+  return env;
+};
+
+const runWindowsShell = async (): Promise<string | undefined> => {
+  const shell = await detectWindowsShell();
+  if (shell.type !== 'powershell' && shell.type !== 'pwsh') return;
+
+  const script = [
+    "$userEnv = [Environment]::GetEnvironmentVariables('User')",
+    "foreach ($entry in $userEnv.GetEnumerator()) { [Environment]::SetEnvironmentVariable([string]$entry.Key, [string]$entry.Value, 'Process') }",
+    '$profilePaths = @($PROFILE.CurrentUserAllHosts, $PROFILE.CurrentUserCurrentHost) | Select-Object -Unique',
+    'foreach ($profilePath in $profilePaths) { if (Test-Path -LiteralPath $profilePath) { . $profilePath } }',
+    '$envMap = @{}',
+    "Get-ChildItem Env: | Where-Object { $_.Name -like 'AWS_*' -or $_.Name -eq 'CLAUDE_CODE_USE_BEDROCK' -or $_.Name -eq 'CLAUDE_CODE_SKIP_BEDROCK_AUTH' -or $_.Name -eq 'ANTHROPIC_MODEL' -or $_.Name -eq 'ANTHROPIC_SMALL_FAST_MODEL' -or $_.Name -like 'ANTHROPIC_DEFAULT_*_MODEL' } | ForEach-Object { $envMap[$_.Name] = $_.Value }",
+    `Write-Output '${SHELL_ENV_DELIMITER}'`,
+    '$envMap | ConvertTo-Json -Compress',
+    `Write-Output '${SHELL_ENV_DELIMITER}'`,
+  ].join('; ');
+
+  return runCommand(shell.path, ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script]);
+};
+
+const parseWindowsShellEnv = (stdout: string): Record<string, string> => {
+  const [, serializedEnv] = stdout.split(SHELL_ENV_DELIMITER);
+  if (!serializedEnv?.trim()) return {};
+
+  const parsed = JSON.parse(serializedEnv) as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.entries(parsed).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string',
+    ),
+  );
+};
+
 /**
- * 从登录 shell 恢复 GUI 应用缺失的 PATH 与 Claude Code Bedrock 环境变量。
+ * 从用户 shell 恢复 GUI 应用缺失的 PATH 与 Claude Code Bedrock 环境变量。
  * shell 无法读取或没有返回有效值时保留进程中的现有配置。
  */
 export const refreshShellEnvironment = async (): Promise<void> => {
-  if (process.platform === 'win32') return;
+  if (process.platform === 'win32') {
+    const stdout = await runWindowsShell();
+    if (stdout) importClaudeCodeBedrockEnv(parseWindowsShellEnv(stdout));
+    return;
+  }
 
   const shell = process.env.SHELL || (process.platform === 'darwin' ? '/bin/zsh' : '/bin/sh');
   const stdout = await runLoginShell(shell);
   const [, shellPath] = stdout.split(SHELL_PATH_DELIMITER);
-  const [, shellEnv] = stdout.split(SHELL_ENV_DELIMITER);
 
   if (shellPath?.trim()) process.env.PATH = shellPath.trim();
-
-  for (const entry of shellEnv?.split('\0') ?? []) {
-    const separatorIndex = entry.indexOf('=');
-    if (separatorIndex <= 0) continue;
-
-    const key = entry.slice(0, separatorIndex);
-    if (shouldImportClaudeCodeBedrockEnv(key)) {
-      process.env[key] = entry.slice(separatorIndex + 1);
-    }
-  }
+  importClaudeCodeBedrockEnv(parseLoginShellEnv(stdout));
 };

--- a/apps/desktop/src/main/utils/shellPath.ts
+++ b/apps/desktop/src/main/utils/shellPath.ts
@@ -102,8 +102,8 @@ const parseWindowsShellEnv = (stdout: string): Record<string, string> => {
 };
 
 /**
- * 从用户 shell 恢复 GUI 应用缺失的 PATH 与 Claude Code Bedrock 环境变量。
- * shell 无法读取或没有返回有效值时保留进程中的现有配置。
+ * Restore PATH and Claude Code Bedrock variables that GUI-launched apps do not inherit.
+ * Preserve the current process environment when the user shell returns no usable value.
  */
 export const refreshShellEnvironment = async (): Promise<void> => {
   if (process.platform === 'win32') {

--- a/apps/desktop/src/main/utils/shellPath.ts
+++ b/apps/desktop/src/main/utils/shellPath.ts
@@ -1,13 +1,25 @@
 import { execFile } from 'node:child_process';
 
 const SHELL_PATH_DELIMITER = '__LOBE_SHELL_PATH__';
+const SHELL_ENV_DELIMITER = '__LOBE_SHELL_ENV__';
 const SHELL_PATH_TIMEOUT_MS = 5000;
+
+const shouldImportClaudeCodeBedrockEnv = (key: string) =>
+  key.startsWith('AWS_') ||
+  key === 'CLAUDE_CODE_USE_BEDROCK' ||
+  key === 'CLAUDE_CODE_SKIP_BEDROCK_AUTH' ||
+  key === 'ANTHROPIC_MODEL' ||
+  key === 'ANTHROPIC_SMALL_FAST_MODEL' ||
+  /^ANTHROPIC_DEFAULT_.*_MODEL$/.test(key);
 
 const runLoginShell = (shell: string): Promise<string> =>
   new Promise((resolve, reject) => {
     execFile(
       shell,
-      ['-ilc', `printf '${SHELL_PATH_DELIMITER}%s${SHELL_PATH_DELIMITER}' "$PATH"; exit`],
+      [
+        '-ilc',
+        `printf '${SHELL_PATH_DELIMITER}%s${SHELL_PATH_DELIMITER}' "$PATH"; printf '${SHELL_ENV_DELIMITER}'; env -0; printf '${SHELL_ENV_DELIMITER}'; exit`,
+      ],
       {
         encoding: 'utf8',
         env: {
@@ -30,16 +42,26 @@ const runLoginShell = (shell: string): Promise<string> =>
   });
 
 /**
- * Refresh PATH from the user's login shell without blocking Electron's main
- * thread. The existing PATH is retained when the shell cannot be resolved or
- * returns no usable value.
+ * 从登录 shell 恢复 GUI 应用缺失的 PATH 与 Claude Code Bedrock 环境变量。
+ * shell 无法读取或没有返回有效值时保留进程中的现有配置。
  */
-export const refreshShellPath = async (): Promise<void> => {
+export const refreshShellEnvironment = async (): Promise<void> => {
   if (process.platform === 'win32') return;
 
   const shell = process.env.SHELL || (process.platform === 'darwin' ? '/bin/zsh' : '/bin/sh');
   const stdout = await runLoginShell(shell);
   const [, shellPath] = stdout.split(SHELL_PATH_DELIMITER);
+  const [, shellEnv] = stdout.split(SHELL_ENV_DELIMITER);
 
   if (shellPath?.trim()) process.env.PATH = shellPath.trim();
+
+  for (const entry of shellEnv?.split('\0') ?? []) {
+    const separatorIndex = entry.indexOf('=');
+    if (separatorIndex <= 0) continue;
+
+    const key = entry.slice(0, separatorIndex);
+    if (shouldImportClaudeCodeBedrockEnv(key)) {
+      process.env[key] = entry.slice(separatorIndex + 1);
+    }
+  }
 };


### PR DESCRIPTION
## 问题

从 Finder、Windows Explorer 等 GUI 入口启动桌面应用时，不会加载用户 shell 中配置的环境变量。通过环境变量配置 AWS Bedrock 的 Claude Code 因此无法获得 `AWS_BEARER_TOKEN_BEDROCK`、`AWS_REGION` 等配置，最终报错 `Could not load credentials from any providers`。

## 改动

- macOS/Linux 使用 POSIX shell 循环读取 Bedrock 白名单变量，不依赖 GNU `env -0`
- Windows 复用现有 shell 检测，支持 PowerShell 7 和 Windows PowerShell 5.1
- Windows 先读取持久化用户环境，再加载当前用户 PowerShell Profile
- 导入 `AWS_*`、明确的 Claude Code Bedrock 开关及 Anthropic 模型选择变量
- 不导入其他无关 shell 环境变量，避免扩大凭证暴露范围
- 移除会掩盖 shell 命令失败的尾部裸 `exit`

## 验证

- `apps/desktop/src/main/utils/shellPath.test.ts`：7/7 通过
- `bun run check`：本次文件 lint clean，目标回归测试通过
- 完整 type-check 通过
- 使用真实系统 shell 和 `env` 命令验证变量恢复，不只依赖 mock 输出
- 使用清除 AWS 变量后的进程调用真实登录 shell，成功恢复 `AWS_BEARER_TOKEN_BEDROCK` 和 `AWS_REGION`；验证过程中未输出凭证值
