### PR TITLE
🐛 fix(desktop): add titlebar drag region to AppShell skeleton

### DIFF
--- a/src/spa/BootShell/AppShellSkeleton.tsx
+++ b/src/spa/BootShell/AppShellSkeleton.tsx
@@ -11,6 +11,7 @@ import {
   getOuterCssVariables,
 } from '@/features/DesktopLayoutContainer/cssVariables';
 import { styles as containerStyles } from '@/features/DesktopLayoutContainer/style';
+import { electronStylish } from '@/styles/electron';
 
 import { readBootShellGeometry } from './geometry';
 
@@ -23,6 +24,12 @@ const CSS_VAR_CLASS = 'lobe-vars';
 export const APP_SHELL_FALLBACK_ID = 'app-shell-fallback';
 
 const styles = createStaticStyles(({ css }) => ({
+  dragRegion: css`
+    pointer-events: auto;
+    flex-shrink: 0;
+    width: 100%;
+    height: ${TITLE_BAR_HEIGHT}px;
+  `,
   root: css`
     pointer-events: none;
 
@@ -44,7 +51,7 @@ const AppShellSkeleton = memo<AppShellSkeletonProps>(({ id }) => {
 
   return (
     <div aria-hidden className={`${CSS_VAR_CLASS} ${styles.root}`} id={id}>
-      {isDesktop && <div style={{ flexShrink: 0, height: TITLE_BAR_HEIGHT }} />}
+      {isDesktop && <div className={`${styles.dragRegion} ${electronStylish.draggable}`} />}
       <Flexbox
         horizontal
         height={isDesktop ? `calc(100% - ${TITLE_BAR_HEIGHT}px)` : '100%'}


### PR DESCRIPTION
<!-- Brief and heads-up -->

The desktop AppShell skeleton reserved `TITLE_BAR_HEIGHT` at the top but left that strip non-interactive (`pointer-events: none` on the overlay). During boot / route fallback you could not drag the window from the titlebar area.

| Before | After |
| ------ | ----- |
| Skeleton top spacer only reserved height | Same `TITLE_BAR_HEIGHT` strip is a `-webkit-app-region: drag` region, with `pointer-events: auto` so Electron can receive the drag |

#### Test

<!-- How you tested your changes -->

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Style-only Electron drag-region change; no practical regression assertion beyond matching the existing `TitleBar` drag class.

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

N/A