### PR TITLE
🐛 fix(billboard): resolve resetOnboarding only on official cloud

### DIFF
--- a/packages/edge-config/src/types.ts
+++ b/packages/edge-config/src/types.ts
@@ -19,8 +19,9 @@ export interface BillboardItem {
    * recognizes, the CTA runs the corresponding in-app logic instead of opening
    * `linkUrl`. Allowed values (defined app-side in `src/features/Billboard/actions.ts`):
    * `openChangelog` (open the changelog modal), `openFeedback` (open the feedback modal),
-   * `resetOnboarding` (web only — reset onboarding progress and re-enter the flow;
-   * desktop clients ignore it and fall back to `linkUrl`).
+   * `resetOnboarding` (reset onboarding and re-enter the flow; only resolved
+   * on official cloud — desktop must be synced to official cloud, web must be
+   * served from the official origin — otherwise the CTA falls back to `linkUrl`).
    * Unrecognized values are ignored by the client and fall back to `linkUrl`.
    */
   action?: string | null;

--- a/src/features/Billboard/actions.test.ts
+++ b/src/features/Billboard/actions.test.ts
@@ -1,4 +1,5 @@
 import type * as LobechatConst from '@lobechat/const';
+import { OFFICIAL_URL } from '@lobechat/const';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -59,9 +60,12 @@ const restoreDesktopMock = () => {
   vi.resetModules();
 };
 
+const originalHref = window.location.href;
+
 beforeEach(() => {
   vi.clearAllMocks();
   electronState.dataSyncConfig = { storageMode: 'cloud' };
+  window.location.href = originalHref;
 });
 
 describe('isBillboardAction', () => {
@@ -86,10 +90,20 @@ describe('isBillboardAction', () => {
 });
 
 describe('resolveBillboardAction', () => {
-  it('should resolve every registered action on web', () => {
+  it('should resolve every registered action on official web', () => {
+    window.location.href = OFFICIAL_URL;
+
     for (const action of BILLBOARD_ACTIONS) {
       expect(resolveBillboardAction(action)).toBe(action);
     }
+  });
+
+  it('should not resolve resetOnboarding on a self-hosted web origin', () => {
+    window.location.href = 'https://chat.example.com/';
+
+    expect(resolveBillboardAction('resetOnboarding')).toBeNull();
+    expect(resolveBillboardAction('openChangelog')).toBe('openChangelog');
+    expect(resolveBillboardAction('openFeedback')).toBe('openFeedback');
   });
 
   it('should return null for unknown values so the CTA falls back to linkUrl', () => {

--- a/src/features/Billboard/actions.ts
+++ b/src/features/Billboard/actions.ts
@@ -22,12 +22,25 @@ export type BillboardAction = (typeof BILLBOARD_ACTIONS)[number];
 export const isBillboardAction = (value: unknown): value is BillboardAction =>
   typeof value === 'string' && (BILLBOARD_ACTIONS as readonly string[]).includes(value);
 
-const isSyncedToOfficialCloud = () => {
+const isOfficialWebOrigin = () => {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.location.origin === new URL(OFFICIAL_URL).origin;
+  } catch {
+    return false;
+  }
+};
+
+const isOnOfficialCloud = () => {
   const state = getElectronStoreState();
-  return (
+  if (
     electronSyncSelectors.isSyncActive(state) &&
     electronSyncSelectors.storageMode(state) === 'cloud'
-  );
+  ) {
+    return true;
+  }
+
+  return isOfficialWebOrigin();
 };
 
 type BillboardActionGuard = (action: BillboardAction) => BillboardAction | null;
@@ -42,12 +55,7 @@ const onlyWhen =
  * may drop it to null (the CTA then falls back to `linkUrl`). Add a guard per
  * constraint instead of branching inside `resolveBillboardAction`.
  */
-const actionGuards: BillboardActionGuard[] = [
-  // The web onboarding flow only exists on the official cloud instance, and
-  // the reset must apply to the same account the external browser will show —
-  // so desktop honors resetOnboarding only when synced to official cloud.
-  onlyWhen('resetOnboarding', () => !isDesktop || isSyncedToOfficialCloud()),
-];
+const actionGuards: BillboardActionGuard[] = [onlyWhen('resetOnboarding', isOnOfficialCloud)];
 
 /**
  * Narrow a platform-configured value to an action this client can actually run:


### PR DESCRIPTION
<!-- Brief and heads-up -->

`resetOnboarding` no longer auto-resolves on every web client. The CTA now requires official cloud: desktop must be synced to official cloud, web must be served from the official origin. Other environments fall back to `linkUrl`.

| Before | After |
| ------ | ----- |
| Web always resolved `resetOnboarding` (`!isDesktop`) | Web only resolves when `window.location.origin` is the official cloud origin |
| Desktop already required official-cloud sync | Unchanged |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

<!-- No matching GitHub/Linear issue found -->