### PR TITLE
💄 style(home): frost the customize button and align task-mode section headers

### DIFF
--- a/src/features/Home/CustomizeButton.tsx
+++ b/src/features/Home/CustomizeButton.tsx
@@ -8,6 +8,11 @@ import { useTranslation } from 'react-i18next';
 import { openHomeCustomizeModal } from './CustomizeModal';
 
 const styles = createStaticStyles(({ css }) => ({
+  // Floats in the page corner where the portrait can stand behind it — frost
+  // what shows through, like the rail cards do.
+  glass: css`
+    backdrop-filter: saturate(150%) blur(12px);
+  `,
   label: css`
     @media (width <= 1100px) {
       display: none;
@@ -22,6 +27,7 @@ const CustomizeButton = memo(() => {
   return (
     <Button
       aria-label={label}
+      className={styles.glass}
       icon={<Icon icon={SlidersHorizontal} size={14} />}
       shape={'round'}
       size={'small'}

--- a/src/features/Home/HomeModeContent.tsx
+++ b/src/features/Home/HomeModeContent.tsx
@@ -602,11 +602,11 @@ const HomeModeContent = memo<HomeModeContentProps>(({ inlineRail, mode, onSugges
     // will happen without me" — the second question only makes sense after the
     // first, so it always sits underneath.
     //
-    // The inline padding keeps the lists from running edge-to-edge with the
-    // composer above: rows carry a -10px hover overhang (see `rowBox`), so
-    // without it the hover pill would reach past the column bounds.
+    // No inline inset: section headers sit flush with the composer edge and the
+    // folded-in inbox sections above, exactly like chat mode — row hover pills
+    // overhang by design (see `rowBox`).
     const taskBlocks = (
-      <Flexbox gap={32} paddingInline={12}>
+      <Flexbox gap={32}>
         {!tasksHidden && <TaskContent />}
         {!scheduledTasksHidden && <ScheduledTaskContent />}
       </Flexbox>


### PR DESCRIPTION
Two small visual fixes on the Home dashboard:

1. **Customize button gets a frosted-glass backdrop.** The button floats in the page's top corner where the portrait can stand right behind it; without a blur the mascot's artwork ran straight under the label. It now carries the same `backdrop-filter: saturate(150%) blur(12px)` treatment the rail cards use, so what shows through reads as a soft silhouette.

2. **Task-mode section headers align with the composer edge.** #18375 gave the recent/scheduled task blocks a 12px inline inset, but the inbox sections folded into the same column (e.g. Daily brief) don't have it, so the two header rows sat 12px apart. The inset is removed: headers sit flush with the composer edge and each other, exactly like chat mode, with row hover pills overhanging by design (`rowBox`'s -10px optical-alignment overhang).

| Before | After |
| ------ | ----- |
| Customize pill shows the mascot un-blurred behind its label | Frosted glass, matching the rail cards |
| "Daily brief" header flush left, "Recent tasks" indented 12px | Both headers flush with the composer edge |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Pure style changes (backdrop-filter + padding removal); per repo guidelines a source-string regression test adds no value here. `bun run check` passes on both files.

#### 🔗 Related Issue

Follow-up to #18375 (the block-layout inset it added is superseded by flush alignment).