### PR TITLE
✨ feat(desktop): inherit size for workspace windows

### DIFF
--- a/apps/desktop/src/main/controllers/BrowserWindowsCtr.ts
+++ b/apps/desktop/src/main/controllers/BrowserWindowsCtr.ts
@@ -197,6 +197,7 @@ export default class BrowserWindowsCtr extends ControllerModule {
    */
   @IpcMethod()
   async createMultiInstanceWindow(params: {
+    inheritCurrentWindowSize?: boolean;
     path: string;
     templateId: WindowTemplateIdentifiers;
     uniqueId?: string;
@@ -204,10 +205,20 @@ export default class BrowserWindowsCtr extends ControllerModule {
     try {
       console.info('[BrowserWindowsCtr] Creating multi-instance window:', params);
 
+      const inheritedWindowSize = params.inheritCurrentWindowSize
+        ? this.withSenderIdentifier((identifier) => {
+            const currentBounds = this.app.browserManager.getWindowSize(identifier);
+            if (!currentBounds) return undefined;
+
+            return { height: currentBounds.height, width: currentBounds.width };
+          })
+        : undefined;
+
       const result = this.app.browserManager.createMultiInstanceWindow(
         params.templateId,
         params.path,
         params.uniqueId,
+        inheritedWindowSize,
       );
 
       // Show the window

--- a/apps/desktop/src/main/controllers/__tests__/BrowserWindowsCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/BrowserWindowsCtr.test.ts
@@ -31,6 +31,12 @@ const mockMaximizeWindow = vi.fn();
 const mockIsWindowMaximized = vi.fn();
 const mockIsWindowFullScreen = vi.fn();
 const mockRetrieveByIdentifier = vi.fn();
+const mockGetWindowSize = vi.fn();
+const mockShowCreatedWindow = vi.fn();
+const mockCreateMultiInstanceWindow = vi.fn(() => ({
+  browser: { show: mockShowCreatedWindow },
+  identifier: 'workspace_workspace-1',
+}));
 const mockStartSession = vi.fn();
 const testSenderIdentifierString: string = 'test-window-event-id';
 
@@ -60,6 +66,8 @@ const mockApp = {
     maximizeWindow: mockMaximizeWindow,
     isWindowMaximized: mockIsWindowMaximized,
     isWindowFullScreen: mockIsWindowFullScreen,
+    getWindowSize: mockGetWindowSize,
+    createMultiInstanceWindow: mockCreateMultiInstanceWindow,
     retrieveByIdentifier: mockRetrieveByIdentifier.mockImplementation(
       (identifier: AppBrowsersIdentifiers | string) => {
         if (identifier === 'some-other-window') {
@@ -179,6 +187,34 @@ describe('BrowserWindowsCtr', () => {
       expect(mockGetIdentifierByWebContents).toHaveBeenCalledWith(context.sender);
       expect(mockIsWindowFullScreen).toHaveBeenCalledWith(testSenderIdentifierString);
       expect(result).toBe(true);
+    });
+  });
+
+  describe('createMultiInstanceWindow', () => {
+    it('should inherit the calling window dimensions when requested', async () => {
+      const sender = {} as any;
+      const context = { sender, event: { sender } as any } as IpcContext;
+      mockGetWindowSize.mockReturnValue({ height: 800, width: 1200, x: 10, y: 20 });
+
+      const result = await runWithIpcContext(context, () =>
+        browserWindowsCtr.createMultiInstanceWindow({
+          inheritCurrentWindowSize: true,
+          path: '/lobe-team',
+          templateId: 'chatSingle',
+          uniqueId: 'workspace_workspace-1',
+        }),
+      );
+
+      expect(mockGetIdentifierByWebContents).toHaveBeenCalledWith(sender);
+      expect(mockGetWindowSize).toHaveBeenCalledWith(testSenderIdentifierString);
+      expect(mockCreateMultiInstanceWindow).toHaveBeenCalledWith(
+        'chatSingle',
+        '/lobe-team',
+        'workspace_workspace-1',
+        { height: 800, width: 1200 },
+      );
+      expect(mockShowCreatedWindow).toHaveBeenCalledOnce();
+      expect(result).toEqual({ success: true, windowId: 'workspace_workspace-1' });
     });
   });
 

--- a/apps/desktop/src/main/core/browser/Browser.ts
+++ b/apps/desktop/src/main/core/browser/Browser.ts
@@ -71,6 +71,7 @@ export interface BrowserWindowOpts extends BrowserWindowConstructorOptions {
   keepAlive?: boolean;
   parentIdentifier?: string;
   path: string;
+  restoreWindowState?: boolean;
   showOnInit?: boolean;
   title?: string;
   width?: number;
@@ -161,6 +162,7 @@ export default class Browser {
       title,
       width,
       height,
+      restoreWindowState = true,
       // Strip platform visual effect props — these are managed exclusively
       // by WindowThemeManager.getPlatformConfig() to prevent config leaking
       // from appBrowsers/windowTemplates into the BrowserWindow constructor.
@@ -170,7 +172,9 @@ export default class Browser {
       ...rest
     } = this.options;
 
-    const resolvedState = this.stateManager.resolveState({ height, width });
+    const resolvedState = restoreWindowState
+      ? this.stateManager.resolveState({ height, width })
+      : { height, width };
     logger.info(`Creating new BrowserWindow instance: ${this.identifier}`);
     logger.debug(`[${this.identifier}] Resolved window state: ${JSON.stringify(resolvedState)}`);
 

--- a/apps/desktop/src/main/core/browser/BrowserManager.ts
+++ b/apps/desktop/src/main/core/browser/BrowserManager.ts
@@ -2,6 +2,7 @@ import type {
   MainBroadcastEventKey,
   MainBroadcastParams,
   TopicPopupInfo,
+  WindowSizeParams,
 } from '@lobechat/electron-client-ipc';
 import type { WebContents } from 'electron';
 
@@ -141,6 +142,7 @@ export class BrowserManager {
     templateId: WindowTemplateIdentifiers,
     path: string,
     uniqueId?: string,
+    windowSize?: WindowSizeParams,
   ) {
     const template = windowTemplates[templateId];
     if (!template) {
@@ -155,8 +157,10 @@ export class BrowserManager {
     // Create browser options from template
     const browserOpts: BrowserWindowOpts = {
       ...template,
+      ...windowSize,
       identifier: windowId,
       path,
+      restoreWindowState: windowSize === undefined,
     };
 
     logger.debug(`Creating multi-instance window: ${windowId} with path: ${path}`);

--- a/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
@@ -353,6 +353,32 @@ describe('Browser', () => {
       );
     });
 
+    it('should prefer the requested initial size when state restoration is disabled', () => {
+      mockStoreManagerGet.mockImplementation((key: string) => {
+        if (key === 'windowSize_test-window') {
+          return { height: 700, width: 900 };
+        }
+        return undefined;
+      });
+
+      new Browser(
+        {
+          ...defaultOptions,
+          height: 954,
+          restoreWindowState: false,
+          width: 1432,
+        },
+        mockApp,
+      );
+
+      expect(MockBrowserWindow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          height: 954,
+          width: 1432,
+        }),
+      );
+    });
+
     it('should restore window position from store and clamp within display', () => {
       mockStoreManagerGet.mockImplementation((key: string) => {
         if (key === 'windowSize_test-window') {

--- a/apps/desktop/src/main/core/browser/__tests__/BrowserManager.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/BrowserManager.test.ts
@@ -223,6 +223,23 @@ describe('BrowserManager', () => {
       expect(result.identifier).toBe('my-custom-id');
     });
 
+    it('should override template dimensions with the requested window size', () => {
+      manager.createMultiInstanceWindow('popup' as any, '/popup/path', undefined, {
+        height: 900,
+        width: 1400,
+      });
+
+      expect(MockBrowser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          height: 900,
+          path: '/popup/path',
+          restoreWindowState: false,
+          width: 1400,
+        }),
+        mockApp,
+      );
+    });
+
     it('should throw error for non-existent template', () => {
       expect(() => manager.createMultiInstanceWindow('nonexistent' as any, '/path')).toThrow(
         'Window template nonexistent not found',


### PR DESCRIPTION
## Summary

- allow callers to pass the current BrowserWindow dimensions into a multi-instance window
- bypass persisted window-state restoration when an explicit inherited size is supplied
- add controller, manager, and Browser regression coverage for the inherited-size path

## Why

The Cloud workspace selector can open a workspace in a dedicated Electron window. Persisted bounds for that workspace previously overrode the caller's dimensions, so a source window at 1432 × 954 could create a 1270 × 864 workspace window.

| Before | After |
| ------ | ----- |
| The saved per-workspace bounds could override the requested dimensions. | The new workspace window uses the caller's width and height; macOS may still choose its position. |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check` on the six changed Desktop files: lint clean, 116 tests passed.

Production-backed Electron acceptance also confirmed source and created windows were both 1432 × 954.

#### 🔗 Related Issue

- Companion Cloud PR: https://github.com/lobehub-biz/lobehub-cloud/pull/1437
- Acceptance evidence: https://app.lobehub.com/acceptance/bbf82abe-0a94-4fbd-8b6f-3bd9e4c1f35c