### PR TITLE
🐛 fix(desktop): refresh reopened workspace window bounds

### DIFF
--- a/apps/desktop/src/main/core/browser/BrowserManager.ts
+++ b/apps/desktop/src/main/core/browser/BrowserManager.ts
@@ -370,6 +370,16 @@ export class BrowserManager {
       if (browser.webContents) this.webContentsMap.set(browser.webContents, browser.identifier);
     });
 
+    // Dynamic windows may use a stable identifier (for example, one window per
+    // workspace). Once such a window is closed, discard its Browser wrapper so
+    // reopening it can apply the latest path and inherited dimensions instead
+    // of recreating a BrowserWindow from the wrapper's original options.
+    browser.browserWindow.on('closed', () => {
+      if (!(identifier in appBrowsers) && this.browsers.get(identifier) === browser) {
+        this.browsers.delete(identifier);
+      }
+    });
+
     return browser;
   }
 

--- a/apps/desktop/src/main/core/browser/__tests__/BrowserManager.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/BrowserManager.test.ts
@@ -240,6 +240,35 @@ describe('BrowserManager', () => {
       );
     });
 
+    it('recreates a closed stable-id window with the latest requested size', () => {
+      const first = manager.createMultiInstanceWindow('popup' as any, '/first', 'workspace-1', {
+        height: 700,
+        width: 1000,
+      });
+      const closedCall = vi
+        .mocked(first.browser.browserWindow.on)
+        .mock.calls.find(([event]) => event === 'closed');
+
+      expect(closedCall).toBeDefined();
+      (closedCall?.[1] as () => void)();
+
+      const second = manager.createMultiInstanceWindow('popup' as any, '/second', 'workspace-1', {
+        height: 900,
+        width: 1400,
+      });
+
+      expect(second.browser).not.toBe(first.browser);
+      expect(MockBrowser).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          height: 900,
+          path: '/second',
+          restoreWindowState: false,
+          width: 1400,
+        }),
+        mockApp,
+      );
+    });
+
     it('should throw error for non-existent template', () => {
       expect(() => manager.createMultiInstanceWindow('nonexistent' as any, '/path')).toThrow(
         'Window template nonexistent not found',

--- a/apps/desktop/src/main/core/browser/__tests__/BrowserManager.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/BrowserManager.test.ts
@@ -247,7 +247,7 @@ describe('BrowserManager', () => {
       });
       const closedCall = vi
         .mocked(first.browser.browserWindow.on)
-        .mock.calls.find(([event]) => event === 'closed');
+        .mock.calls.find(([event]) => String(event) === 'closed');
 
       expect(closedCall).toBeDefined();
       (closedCall?.[1] as () => void)();


### PR DESCRIPTION
## Summary

- evict closed dynamic Browser wrappers from BrowserManager
- recreate stable-ID workspace windows with the latest inherited bounds
- add a close-and-reopen regression test

## Verification

- bun run check apps/desktop/src/main/core/browser/BrowserManager.ts apps/desktop/src/main/core/browser/__tests__/BrowserManager.test.ts (48 tests passed)