### PR TITLE
💄 style(chat): collapse ChatInputNotice to a tooltip on narrow screens

### DIFF
--- a/src/features/ChatInput/ChatInputNotice/index.tsx
+++ b/src/features/ChatInput/ChatInputNotice/index.tsx
@@ -1,14 +1,51 @@
 'use client';
 
-import { Alert } from '@lobehub/ui/base-ui';
-import { createStaticStyles, cx } from 'antd-style';
+import { Icon, Tooltip } from '@lobehub/ui';
+import { Alert, type AlertType } from '@lobehub/ui/base-ui';
+import { createStaticStyles, cssVar, cx } from 'antd-style';
+import { AlertTriangle, CheckCircle, Info, XCircle } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useChatInputNotice } from './useChatInputNotice';
 
+// Mirrors `@lobehub/ui` Alert's own per-type icon fallback, so the narrow-screen
+// compact icon never disagrees with the icon the full Alert would have shown
+// for the same notice.
+const typeIcons: Record<AlertType, typeof AlertTriangle> = {
+  error: XCircle,
+  info: Info,
+  secondary: AlertTriangle,
+  success: CheckCircle,
+  warning: AlertTriangle,
+};
+
+// Mirrors the accent color each Alert tone applies via `--lobe-alert-accent`, so
+// the compact icon still reads with the right semantic color once it's on its
+// own, outside the Alert that would normally set that CSS variable.
+const typeColor: Record<AlertType, string> = {
+  error: cssVar.colorError,
+  info: cssVar.colorInfo,
+  secondary: cssVar.colorTextSecondary,
+  success: cssVar.colorSuccess,
+  warning: cssVar.colorWarning,
+};
+
+// Below this the leftSlot no longer has room for icon + single-line title
+// without wrapping — collapse to an icon-only trigger and move the message
+// into a tooltip instead of fighting for space inline.
+const COMPACT_BREAKPOINT = 200;
+
 const styles = createStaticStyles(({ css, cssVar }) => ({
-  alert: css`
+  alertContent: css`
+    min-width: 0;
+  `,
+  alertIcon: css`
+    flex: none;
+    height: 18px !important;
+    margin-inline-end: 0 !important;
+  `,
+  alertRoot: css`
     flex: 0 1 auto;
 
     /* The Alert root already flex-gaps icon and content; without zeroing the
@@ -24,29 +61,45 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     padding-inline: 8px 10px !important;
     border-radius: ${cssVar.borderRadius};
 
-    .ant-alert-content {
-      min-width: 0;
-    }
-
-    .ant-alert-message,
-    .ant-alert-title {
-      overflow: hidden;
-
-      font-size: 12px;
-      line-height: 18px !important;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    .ant-alert-icon {
-      flex: none;
-      height: 18px !important;
-      margin-inline-end: 0 !important;
+    @container chat-input-notice (width < ${COMPACT_BREAKPOINT}px) {
+      display: none;
     }
 
     @media (width <= 768px) {
       max-width: 100%;
     }
+  `,
+  alertTitle: css`
+    overflow: hidden;
+
+    font-size: 12px;
+    line-height: 18px !important;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+  compactTrigger: css`
+    display: none;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+
+    width: 22px;
+    height: 18px;
+    border-radius: ${cssVar.borderRadius};
+
+    cursor: default;
+
+    @container chat-input-notice (width < ${COMPACT_BREAKPOINT}px) {
+      display: inline-flex;
+    }
+  `,
+  container: css`
+    container: chat-input-notice / inline-size;
+
+    display: flex;
+    flex: 0 1 auto;
+    align-items: center;
+    min-width: 0;
   `,
 }));
 
@@ -56,14 +109,29 @@ const ChatInputNotice = memo(() => {
 
   if (!notice) return null;
 
+  const message = t(notice.key);
+  const NoticeIcon = typeIcons[notice.type];
+
   return (
-    <Alert
-      classNames={{ alert: cx(styles.alert) }}
-      style={{ fontSize: 12 }}
-      title={t(notice.key)}
-      type={notice.type}
-      variant={'borderless'}
-    />
+    <div className={styles.container}>
+      <Alert
+        classNames={{
+          content: styles.alertContent,
+          icon: styles.alertIcon,
+          root: cx(styles.alertRoot),
+          title: styles.alertTitle,
+        }}
+        style={{ fontSize: 12 }}
+        title={message}
+        type={notice.type}
+        variant={'borderless'}
+      />
+      <Tooltip title={message}>
+        <span className={styles.compactTrigger} style={{ color: typeColor[notice.type] }}>
+          <Icon icon={NoticeIcon} size={14} />
+        </span>
+      </Tooltip>
+    </div>
   );
 });
 


### PR DESCRIPTION
## Background

`ChatInputNotice` (the model-unavailable / view-only banner shown next to the ChatInput action bar) always rendered as an inline Alert with icon + single-line title. On narrow layouts — mobile width, split panels, the floating chat panel, or a resized workspace pane — there isn't enough room for that combo without wrapping, so the banner either got clipped or pushed the rest of the toolbar out.

## What changed

- Wrapped the Alert in a size-container (`chat-input-notice`, via CSS `container-type: inline-size`, same pattern already used by `OpStatusTray` / `HeteroControlBar`).
- Added an icon-only compact trigger that swaps in once the container drops below 200px of available width.
- The compact trigger shows the exact same notice message via a `Tooltip` on hover/focus, so no information is lost — it's just presented differently at narrow widths instead of forcing the full inline banner.
- Icon + accent color per notice type mirror `@lobehub/ui`'s own Alert type→icon/color mapping, so the compact icon never disagrees with what the full Alert would have shown for the same notice.

| Before (narrow) | After (narrow) |
| --- | --- |
| Alert clipped / crowds other controls | Icon-only trigger + Tooltip with full message |

#### Test

- [x] Reviewed against existing container-query patterns in the codebase (`OpStatusTray.tsx`, `HeteroControlBar.tsx`)
- [ ] Tested locally (sandbox disk constraints prevented a full `pnpm install`/dev server run in this environment — please verify visually before merge)
- [ ] No behavior change at normal/desktop widths (same Alert markup/styling, just re-scoped classNames)

#### 🔗 Related Issue

Reported in team chat: at narrow ChatInput widths the "当前模型已下线" (model unavailable) notice needs a compact tooltip-based fallback instead of the full inline banner.