### PR TITLE
📝 docs(acceptance): prefer native data visualizations

### DIFF
--- a/.agents/skills/agent-testing/SKILL.md
+++ b/.agents/skills/agent-testing/SKILL.md
@@ -459,6 +459,20 @@ Hard rules worth front-loading:
 - **Visual evidence lives in `result.json`, NOT in `report.md`.** Attach each
   screenshot/GIF to its case via `cases[].evidence`; the page renders it next to
   the check. Do NOT embed images/GIFs in `report.md`.
+- **Structured data uses native Acceptance visualizations by default (hard
+  rule).** When a result contains metrics, time series, before/after model or
+  benchmark comparisons, distributions, matrices, or tabular data, encode the
+  review-sized values in `cases[].datasets` and declare the corresponding view
+  in `cases[].visualizations`. Keep the raw CSV/JSON, benchmark output, trace,
+  profile, or vectors in `evidence` so the chart remains auditable. Do NOT render
+  those values into a PNG/GIF yourself when a supported native renderer can
+  express them; static generated charts lose structured values, accessibility,
+  theme adaptation, and consistent comparison semantics. Generate a static
+  chart only when none of the supported renderers can faithfully represent the
+  result, and explain that limitation in the case observation. Supported views:
+  `metric-comparison`, `line-chart`, `bar-chart`, `scatter-plot`, `heatmap`, and
+  `table`. See
+  [references/report.md](./references/report.md#structured-visualizations).
 - **Non-visual behavioral claims use dual text evidence.** Attach two separate
   text artifacts to the same case: a reviewer-facing **reasoning** document and
   an audit-facing **execution** document. The reasoning artifact explains the

--- a/.agents/skills/agent-testing/references/report.md
+++ b/.agents/skills/agent-testing/references/report.md
@@ -54,6 +54,25 @@ table — those double up on the page. It carries only the non-duplicate narrati
 
 2. **Collect evidence as you test** — every asserted behavior gets one evidence
    item in `$DIR/assets/`:
+
+   - Structured data (metrics, time series, before/after model or benchmark
+     comparisons, distributions, matrices, and tables): **use native Acceptance
+     visualizations by default.** Put review-sized values in the case's
+     `datasets[]`, declare their presentation in `visualizations[]`, and attach
+     the raw CSV/JSON, benchmark output, trace, profile, or vectors as
+     `evidence`. The structured view is the reviewer-facing decision aid; the raw
+     artifact is the audit trail.
+
+     Do **not** generate a PNG/GIF of data that `metric-comparison`, `line-chart`,
+     `bar-chart`, `scatter-plot`, `heatmap`, or `table` can faithfully express.
+     A static chart discards machine-readable values, accessibility, theme
+     adaptation, and consistent comparison semantics. Generate a static chart
+     only when no supported renderer can represent the result, and state that
+     limitation in the case observation. Do not merely upload a CSV and expect
+     the page to infer a chart: define both `datasets[]` and
+     `visualizations[]` explicitly. See
+     [Structured visualizations](#structured-visualizations) for the schema.
+
    - UI (static state): `agent-browser screenshot` or `capture-app-window.sh`, then
      **verify the screenshot with the Read tool before citing it** — never cite an
      image you haven't looked at.

--- a/.agents/skills/agent-testing/references/report.md
+++ b/.agents/skills/agent-testing/references/report.md
@@ -535,6 +535,100 @@ harness, fixture, environment, warm-up policy, statistic, and sample window. If
 those differ, use separate series or mark the case uncertain instead of presenting
 a misleading delta.
 
+Every visualization requires unique non-empty `id`, `type`, `dataset`, and
+`version: 1`; `dataset` must reference a declared dataset id. `title` and
+`context` are optional non-empty strings. Every encoding field name below must
+reference a field declared by that dataset.
+
+| Renderer            | Required encoding                                              | Optional encoding                                                                         |
+| ------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `metric-comparison` | `label`, `before`, `after`                                     | `beforeSamples`, `afterSamples`, `direction`, `statistic`, `target`, `unit`               |
+| `line-chart`        | `x`, non-empty `series[]`; each series requires `field`        | series `label`, series `style` (`muted` \| `primary` \| `accent`), `xLabel`, `yLabel`     |
+| `bar-chart`         | `category`, non-empty `series[]`; each series requires `field` | series `label`, `valueLabel`                                                              |
+| `scatter-plot`      | `x`, `y`                                                       | `color`, `label`, `xLabel`, `yLabel`                                                      |
+| `heatmap`           | `x`, `y`, `value`                                              | none                                                                                      |
+| `table`             | none; `encoding` itself may be omitted                         | non-empty `columns[]`; `highlights[]` entries require `field` and `mode` (`min` \| `max`) |
+
+Minimal valid encoding examples (replace every field-name string with a key
+declared in the referenced dataset):
+
+```json
+[
+  {
+    "id": "quality-delta",
+    "type": "metric-comparison",
+    "version": 1,
+    "dataset": "metrics",
+    "encoding": { "label": "metric", "before": "baseline", "after": "candidate" }
+  },
+  {
+    "id": "loss-over-time",
+    "type": "line-chart",
+    "version": 1,
+    "dataset": "training",
+    "encoding": {
+      "x": "step",
+      "series": [
+        { "field": "baselineLoss", "label": "Baseline", "style": "muted" },
+        { "field": "candidateLoss", "label": "Candidate", "style": "primary" }
+      ],
+      "xLabel": "Step",
+      "yLabel": "Loss"
+    }
+  },
+  {
+    "id": "scores-by-model",
+    "type": "bar-chart",
+    "version": 1,
+    "dataset": "scores",
+    "encoding": {
+      "category": "model",
+      "series": [{ "field": "score", "label": "Score" }],
+      "valueLabel": "Accuracy"
+    }
+  },
+  {
+    "id": "latency-quality",
+    "type": "scatter-plot",
+    "version": 1,
+    "dataset": "runs",
+    "encoding": {
+      "x": "latency",
+      "y": "quality",
+      "color": "model",
+      "label": "run",
+      "xLabel": "Latency (ms)",
+      "yLabel": "Quality"
+    }
+  },
+  {
+    "id": "error-matrix",
+    "type": "heatmap",
+    "version": 1,
+    "dataset": "errors",
+    "encoding": { "x": "predicted", "y": "actual", "value": "count" }
+  },
+  {
+    "id": "benchmark-table",
+    "type": "table",
+    "version": 1,
+    "dataset": "benchmarks",
+    "encoding": {
+      "columns": ["model", "latency", "score"],
+      "highlights": [
+        { "field": "latency", "mode": "min" },
+        { "field": "score", "mode": "max" }
+      ]
+    }
+  }
+]
+```
+
+Dataset field `type` is one of `boolean`, `category`, `number`, `string`, or
+`temporal`; field keys and dataset/view ids must be unique. Rows may contain only
+declared keys with string, number, boolean, or null values. The combined inline
+row limit is 10,000.
+
 `pullRequest` is optional: when absent, the ingest asks `gh` for the PR of `branch`
 and fills it in. Write it explicitly only when the report verifies a PR that isn't
 the branch's own.

--- a/packages/builtin-skills/src/acceptance/SKILL.md
+++ b/packages/builtin-skills/src/acceptance/SKILL.md
@@ -181,6 +181,14 @@ Rules of thumb:
 
 - **Don't open a browser for a backend change.** If a criterion is satisfied by a
   command's output, capture that as `text` — it's the strongest, cheapest proof.
+- **Structured data uses native Acceptance visualizations by default.** Metrics,
+  time series, model or benchmark comparisons, distributions, matrices, and
+  tables belong in `cases[].datasets` plus `cases[].visualizations`; keep the raw
+  CSV/JSON, benchmark output, trace, profile, or vectors as `evidence`. Do not
+  generate a PNG/GIF when a supported renderer can faithfully express the data.
+  Static charts are only a fallback when no native renderer fits, and that
+  limitation must be stated in the case observation. See
+  [references/report.md](references/report.md#structured-visualizations).
 - **A deliverable the user hears needs `audio`.** TTS output, a voice reply, an
   alert tone: upload the clip itself so the page renders a player. Prose about a
   sound, or a screenshot of a waveform, proves nothing.

--- a/packages/builtin-skills/src/acceptance/references/report.md
+++ b/packages/builtin-skills/src/acceptance/references/report.md
@@ -93,11 +93,15 @@ supersedes? }`.
    plan a programmatic gate (tests / type-check / lint / build) as a check —
    ingest drops them, and a gates-only round fails to publish. See
    [what is not an acceptance check](#hard-rule--what-is-not-an-acceptance-check).
-2. **Collect evidence into `assets/` as you test.** Screenshots/charts must be
+2. **Collect evidence into `assets/` as you test.** Screenshots must be
    **visually verified with the Read tool before being cited** — never cite an
-   image you haven't looked at. Numeric results worth seeing (loss curves,
-   latency distributions) should ship as a rendered chart image, not only a
-   table of digits.
+   image you haven't looked at. For metrics, time series, model or benchmark
+   comparisons, distributions, matrices, and tables, use native Acceptance
+   structured visualizations: put review-sized values in `cases[].datasets`,
+   declare the view in `cases[].visualizations`, and retain the raw CSV/JSON,
+   benchmark output, trace, profile, or vectors in `evidence`. Do not generate a
+   PNG/GIF when a supported renderer can faithfully express the data. See
+   [Structured visualizations](#structured-visualizations).
 3. **Fill `cases[]` as you go** — one entry per tested behavior
    (`{ id, name, category, surface, status, observation, evidence }`), reusing
    the plan item's `id`. `status`: `pass` / `fail` / `blocked` (couldn't run —
@@ -141,6 +145,40 @@ supersedes? }`.
       "status": "pass",
       "observation": "root returned 3 nested children, depth 2",
       "evidence": ["assets/task-tree.txt"]
+    },
+    {
+      "id": "2",
+      "category": "Model quality",
+      "name": "candidate model improves average precision",
+      "surface": "cli",
+      "status": "pass",
+      "observation": "average precision improved from 0.742 to 0.796",
+      "evidence": ["assets/evaluation.json"],
+      "datasets": [
+        {
+          "id": "model-metrics",
+          "fields": [
+            { "key": "metric", "type": "string" },
+            { "key": "baseline", "type": "number" },
+            { "key": "candidate", "type": "number" }
+          ],
+          "rows": [{ "metric": "Average precision", "baseline": 0.742, "candidate": 0.796 }]
+        }
+      ],
+      "visualizations": [
+        {
+          "id": "model-comparison",
+          "type": "metric-comparison",
+          "version": 1,
+          "dataset": "model-metrics",
+          "title": "Model quality comparison",
+          "encoding": {
+            "label": "metric",
+            "before": "baseline",
+            "after": "candidate"
+          }
+        }
+      ]
     }
   ],
   "createdAt": "2026-06-11T15:30:00+08:00",
@@ -173,6 +211,25 @@ Optional fields: `branch` / `commit` / `pullRequest` (provenance line; when
 `branch` is set without `pullRequest`, ingest asks `gh` for the PR),
 `summary.score` (0–100, only when the verdict has a subjective component),
 `subject` (usually passed via `--subject` instead).
+
+### Structured visualizations
+
+A case containing reviewable structured data should provide `datasets[]` plus
+`visualizations[]`. Supported version-1 renderers are `metric-comparison`,
+`line-chart`, `bar-chart`, `scatter-plot`, `heatmap`, and `table`. Each
+visualization references one dataset by `id` and maps declared fields through
+`encoding`.
+
+Inline datasets use declared `fields[]` and object `rows[]`; keep them to a
+review-sized summary. Retain raw benchmark results, CSV/JSON, traces, profiles,
+and vectors in `evidence`: the visualization is a decision aid, not a replacement
+for the audit trail. Do not merely upload a data file and expect Acceptance to
+infer a chart; declare both the dataset and visualization explicitly.
+
+Native renderers are the default because they preserve machine-readable values,
+accessibility, theme adaptation, and consistent comparison semantics. Generate a
+static chart only when none of the supported renderers can faithfully represent
+the result, and explain that limitation in the case observation.
 
 ### Closed vocabularies — the pipeline acts on these, they are not labels
 

--- a/packages/builtin-skills/src/acceptance/references/report.md
+++ b/packages/builtin-skills/src/acceptance/references/report.md
@@ -231,6 +231,100 @@ accessibility, theme adaptation, and consistent comparison semantics. Generate a
 static chart only when none of the supported renderers can faithfully represent
 the result, and explain that limitation in the case observation.
 
+Every visualization requires unique non-empty `id`, `type`, `dataset`, and
+`version: 1`; `dataset` must reference a declared dataset id. `title` and
+`context` are optional non-empty strings. Every encoding field name below must
+reference a field declared by that dataset.
+
+| Renderer            | Required encoding                                              | Optional encoding                                                                         |
+| ------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `metric-comparison` | `label`, `before`, `after`                                     | `beforeSamples`, `afterSamples`, `direction`, `statistic`, `target`, `unit`               |
+| `line-chart`        | `x`, non-empty `series[]`; each series requires `field`        | series `label`, series `style` (`muted` \| `primary` \| `accent`), `xLabel`, `yLabel`     |
+| `bar-chart`         | `category`, non-empty `series[]`; each series requires `field` | series `label`, `valueLabel`                                                              |
+| `scatter-plot`      | `x`, `y`                                                       | `color`, `label`, `xLabel`, `yLabel`                                                      |
+| `heatmap`           | `x`, `y`, `value`                                              | none                                                                                      |
+| `table`             | none; `encoding` itself may be omitted                         | non-empty `columns[]`; `highlights[]` entries require `field` and `mode` (`min` \| `max`) |
+
+Minimal valid encoding examples (replace every field-name string with a key
+declared in the referenced dataset):
+
+```json
+[
+  {
+    "id": "quality-delta",
+    "type": "metric-comparison",
+    "version": 1,
+    "dataset": "metrics",
+    "encoding": { "label": "metric", "before": "baseline", "after": "candidate" }
+  },
+  {
+    "id": "loss-over-time",
+    "type": "line-chart",
+    "version": 1,
+    "dataset": "training",
+    "encoding": {
+      "x": "step",
+      "series": [
+        { "field": "baselineLoss", "label": "Baseline", "style": "muted" },
+        { "field": "candidateLoss", "label": "Candidate", "style": "primary" }
+      ],
+      "xLabel": "Step",
+      "yLabel": "Loss"
+    }
+  },
+  {
+    "id": "scores-by-model",
+    "type": "bar-chart",
+    "version": 1,
+    "dataset": "scores",
+    "encoding": {
+      "category": "model",
+      "series": [{ "field": "score", "label": "Score" }],
+      "valueLabel": "Accuracy"
+    }
+  },
+  {
+    "id": "latency-quality",
+    "type": "scatter-plot",
+    "version": 1,
+    "dataset": "runs",
+    "encoding": {
+      "x": "latency",
+      "y": "quality",
+      "color": "model",
+      "label": "run",
+      "xLabel": "Latency (ms)",
+      "yLabel": "Quality"
+    }
+  },
+  {
+    "id": "error-matrix",
+    "type": "heatmap",
+    "version": 1,
+    "dataset": "errors",
+    "encoding": { "x": "predicted", "y": "actual", "value": "count" }
+  },
+  {
+    "id": "benchmark-table",
+    "type": "table",
+    "version": 1,
+    "dataset": "benchmarks",
+    "encoding": {
+      "columns": ["model", "latency", "score"],
+      "highlights": [
+        { "field": "latency", "mode": "min" },
+        { "field": "score", "mode": "max" }
+      ]
+    }
+  }
+]
+```
+
+Dataset field `type` is one of `boolean`, `category`, `number`, `string`, or
+`temporal`; field keys and dataset/view ids must be unique. Rows may contain only
+declared keys with string, number, boolean, or null values. The combined inline
+row limit is 10,000.
+
 ### Closed vocabularies — the pipeline acts on these, they are not labels
 
 | field                           | values                                                                                                | what it does                                                                                                         |


### PR DESCRIPTION
## Summary

- make native Acceptance visualizations the default for structured verification data in both the builtin `acceptance` skill and repo-local `agent-testing` skill
- keep raw benchmark and dataset files as auditable evidence
- replace the builtin guidance that recommended rendered chart images
- add a complete `datasets[]` + `visualizations[]` example and clarify that CSV uploads do not infer charts automatically

## Verification

- `git diff --check`
- `bun run check .agents/skills/agent-testing/SKILL.md .agents/skills/agent-testing/references/report.md`
- `bun run check packages/builtin-skills/src/acceptance/SKILL.md packages/builtin-skills/src/acceptance/references/report.md`