### PR TITLE
💄 style: tighten refresh error spacing

### DIFF
--- a/src/features/Conversation/ChatList/components/RefreshError.tsx
+++ b/src/features/Conversation/ChatList/components/RefreshError.tsx
@@ -13,7 +13,7 @@ const styles = createStaticStyles(({ css }) => ({
 
     width: 100%;
     min-height: 40px;
-    padding-block: 4px 6px;
+    padding-block: 2px 8px;
     padding-inline: 12px;
     border-block-start: 1px solid ${cssVar.colorBorderSecondary};
 

--- a/src/features/Conversation/ChatList/components/RefreshError.tsx
+++ b/src/features/Conversation/ChatList/components/RefreshError.tsx
@@ -13,7 +13,7 @@ const styles = createStaticStyles(({ css }) => ({
 
     width: 100%;
     min-height: 40px;
-    padding-block: 2px 8px;
+    padding-block: 2px 4px;
     padding-inline: 12px;
     border-block-start: 1px solid ${cssVar.colorBorderSecondary};
 

--- a/src/features/Conversation/ChatList/components/RefreshError.tsx
+++ b/src/features/Conversation/ChatList/components/RefreshError.tsx
@@ -13,7 +13,7 @@ const styles = createStaticStyles(({ css }) => ({
 
     width: 100%;
     min-height: 40px;
-    padding-block: 4px 10px;
+    padding-block: 4px 6px;
     padding-inline: 12px;
     border-block-start: 1px solid ${cssVar.colorBorderSecondary};
 


### PR DESCRIPTION
## Summary

- set the message refresh error row vertical padding to 2px on top and 4px on bottom
- keep the error message and retry action unchanged while tightening the space above the chat input

## Why

The refresh error row occupied slightly too much vertical space between the message list and chat input.

## Verification

- `bun run check --lint src/features/Conversation/ChatList/components/RefreshError.tsx`
- pre-commit stylelint, ESLint, and Prettier checks passed

Acceptance from the initial spacing pass: https://app.lobehub.com/acceptance/ce9da367-8d79-4105-a228-e3dd58240a3e?r=1