### PR TITLE
🐛 fix: keep SSE streams alive during long model responses

### DIFF
--- a/packages/model-runtime/src/utils/response.test.ts
+++ b/packages/model-runtime/src/utils/response.test.ts
@@ -1,21 +1,32 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { StreamingResponse } from './response';
+import { SSE_HEARTBEAT_INTERVAL_MS, StreamingResponse } from './response';
+
+const createClosedStream = () =>
+  new ReadableStream({
+    start(controller) {
+      controller.close();
+    },
+  });
 
 describe('StreamingResponse', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('should create Response with default headers', () => {
-    const mockStream = new ReadableStream();
+    const mockStream = createClosedStream();
     const response = StreamingResponse(mockStream);
 
     expect(response).toBeInstanceOf(Response);
-    expect(response.body).toBe(mockStream);
+    expect(response.body).toBeInstanceOf(ReadableStream);
     expect(response.headers.get('Cache-Control')).toBe('no-cache');
     expect(response.headers.get('Content-Type')).toBe('text/event-stream');
     expect(response.headers.get('X-Accel-Buffering')).toBe('no');
   });
 
   it('should create Response with custom headers', () => {
-    const mockStream = new ReadableStream();
+    const mockStream = createClosedStream();
     const customHeaders = {
       'Custom-Header': 'custom-value',
       'Authorization': 'Bearer token',
@@ -24,7 +35,7 @@ describe('StreamingResponse', () => {
     const response = StreamingResponse(mockStream, { headers: customHeaders });
 
     expect(response).toBeInstanceOf(Response);
-    expect(response.body).toBe(mockStream);
+    expect(response.body).toBeInstanceOf(ReadableStream);
 
     // Default headers should still be present
     expect(response.headers.get('Cache-Control')).toBe('no-cache');
@@ -37,7 +48,7 @@ describe('StreamingResponse', () => {
   });
 
   it('should allow custom headers to override default headers', () => {
-    const mockStream = new ReadableStream();
+    const mockStream = createClosedStream();
     const overrideHeaders = {
       'Content-Type': 'application/json',
       'Cache-Control': 'max-age=3600',
@@ -51,22 +62,22 @@ describe('StreamingResponse', () => {
   });
 
   it('should handle empty options object', () => {
-    const mockStream = new ReadableStream();
+    const mockStream = createClosedStream();
     const response = StreamingResponse(mockStream, {});
 
     expect(response).toBeInstanceOf(Response);
-    expect(response.body).toBe(mockStream);
+    expect(response.body).toBeInstanceOf(ReadableStream);
     expect(response.headers.get('Cache-Control')).toBe('no-cache');
     expect(response.headers.get('Content-Type')).toBe('text/event-stream');
     expect(response.headers.get('X-Accel-Buffering')).toBe('no');
   });
 
   it('should handle options with empty headers', () => {
-    const mockStream = new ReadableStream();
+    const mockStream = createClosedStream();
     const response = StreamingResponse(mockStream, { headers: {} });
 
     expect(response).toBeInstanceOf(Response);
-    expect(response.body).toBe(mockStream);
+    expect(response.body).toBeInstanceOf(ReadableStream);
     expect(response.headers.get('Cache-Control')).toBe('no-cache');
     expect(response.headers.get('Content-Type')).toBe('text/event-stream');
     expect(response.headers.get('X-Accel-Buffering')).toBe('no');
@@ -87,5 +98,32 @@ describe('StreamingResponse', () => {
     const responseText = await response.text();
 
     expect(responseText).toBe(testData);
+  });
+
+  it('should emit heartbeat events while the upstream stream is idle', async () => {
+    vi.useFakeTimers();
+
+    const upstream = new ReadableStream<Uint8Array>();
+    const response = StreamingResponse(upstream);
+    const reader = response.body!.getReader();
+    const heartbeatPromise = reader.read();
+
+    await vi.advanceTimersByTimeAsync(SSE_HEARTBEAT_INTERVAL_MS);
+
+    const heartbeat = await heartbeatPromise;
+    expect(heartbeat.done).toBe(false);
+    expect(new TextDecoder().decode(heartbeat.value)).toBe('event: heartbeat\ndata: {}\n\n');
+
+    await reader.cancel();
+  });
+
+  it('should cancel the upstream stream when the response body is canceled', async () => {
+    const cancel = vi.fn();
+    const upstream = new ReadableStream<Uint8Array>({ cancel });
+    const response = StreamingResponse(upstream);
+
+    await response.body!.cancel('user abort');
+
+    expect(cancel).toHaveBeenCalledWith('user abort');
   });
 });

--- a/packages/model-runtime/src/utils/response.ts
+++ b/packages/model-runtime/src/utils/response.ts
@@ -1,8 +1,76 @@
+export const SSE_HEARTBEAT_INTERVAL_MS = 15_000;
+
+const SSE_HEARTBEAT_EVENT = new TextEncoder().encode('event: heartbeat\ndata: {}\n\n');
+
+const withSSEHeartbeat = (stream: ReadableStream) => {
+  const reader = stream.getReader();
+
+  let closed = false;
+  let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+  let readerReleased = false;
+
+  const clearHeartbeat = () => {
+    if (heartbeatTimer === undefined) return;
+
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = undefined;
+  };
+
+  const releaseReader = () => {
+    if (readerReleased) return;
+
+    reader.releaseLock();
+    readerReleased = true;
+  };
+
+  const finish = () => {
+    closed = true;
+    clearHeartbeat();
+    releaseReader();
+  };
+
+  return new ReadableStream({
+    async cancel(reason) {
+      closed = true;
+      clearHeartbeat();
+      try {
+        await reader.cancel(reason);
+      } finally {
+        releaseReader();
+      }
+    },
+    async pull(controller) {
+      if (heartbeatTimer === undefined) {
+        heartbeatTimer = setInterval(() => {
+          if (!closed) controller.enqueue(SSE_HEARTBEAT_EVENT);
+        }, SSE_HEARTBEAT_INTERVAL_MS);
+      }
+
+      try {
+        const { done, value } = await reader.read();
+
+        if (done) {
+          finish();
+          controller.close();
+          return;
+        }
+
+        controller.enqueue(value);
+      } catch (error) {
+        if (closed) return;
+
+        finish();
+        controller.error(error);
+      }
+    },
+  });
+};
+
 export const StreamingResponse = (
   stream: ReadableStream,
   options?: { headers?: Record<string, string> },
 ) => {
-  return new Response(stream, {
+  return new Response(withSSEHeartbeat(stream), {
     headers: {
       'Cache-Control': 'no-cache',
       'Content-Type': 'text/event-stream',


### PR DESCRIPTION
This PR keeps server-side SSE connections alive while waiting for long-running model responses. `StreamingResponse` now emits a heartbeat event every 15 seconds and cleans up its timer and upstream reader when the stream closes, errors, or is canceled.

| Before | After |
| ------ | ----- |
| An SSE connection could remain idle while waiting for the first model token and be closed by an intermediary. | The server periodically emits a heartbeat event so the connection remains active without changing chat content. |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check --lint --test packages/model-runtime/src/utils/response.ts packages/model-runtime/src/utils/response.test.ts
```

Result: lint clean, 8 tests passed.

#### 🔗 Related Issue

Fixes #18378
