### PR TITLE
🐛 fix(agent-runtime): re-queue step-lock conflicts instead of dead-lettering them

### DIFF
--- a/apps/server/src/router-hono/agent/handlers/__tests__/runStep.test.ts
+++ b/apps/server/src/router-hono/agent/handlers/__tests__/runStep.test.ts
@@ -191,6 +191,31 @@ describe('runStep handler', () => {
     );
   });
 
+  it('acks without retry when the runtime already re-queued the locked step', async () => {
+    mockGetOperationMetadata.mockResolvedValue({ userId: 'user-1' });
+    mockExecuteStep.mockResolvedValue({
+      locked: true,
+      lockRescheduled: true,
+      nextStepScheduled: true,
+      state: {},
+      success: true,
+    });
+
+    const { ctx, getCaptures } = buildContext({ body: validBody });
+    const res = await runStep(ctx);
+
+    // Must not be retryable: a re-delivery is already scheduled, and letting
+    // QStash retry on top of it is what dead-letters the step.
+    expect(res.status).toBe(200);
+    expect(getCaptures()[0].body).toMatchObject({
+      locked: true,
+      nextStepScheduled: true,
+      operationId: 'op-1',
+      stepIndex: 2,
+      success: true,
+    });
+  });
+
   it('returns 429 with Retry-After header when the step is locked', async () => {
     mockGetOperationMetadata.mockResolvedValue({ userId: 'user-1' });
     mockExecuteStep.mockResolvedValue({

--- a/apps/server/src/router-hono/agent/handlers/runStep.ts
+++ b/apps/server/src/router-hono/agent/handlers/runStep.ts
@@ -90,6 +90,7 @@ export async function runStep(c: Context): Promise<Response> {
       toolMessageId,
       verifyAsyncToolBarrier,
       asyncToolVerifyAttempt,
+      lockRetryAttempt,
     } = { ...body, ...body.payload };
 
     if (!operationId) {
@@ -141,6 +142,7 @@ export async function runStep(c: Context): Promise<Response> {
       humanInput,
       finishAfterAsyncTool,
       groupMemberTimeout,
+      lockRetryAttempt,
       operationId,
       rejectAndContinue,
       rejectionReason,
@@ -151,8 +153,25 @@ export async function runStep(c: Context): Promise<Response> {
     });
 
     // A non-stale lock conflict means another delivery is still executing this
-    // operation. Keep the response retryable so QStash redelivers this step.
+    // operation.
     if (result.locked) {
+      // The runtime already re-queued this step on its own backoff, which can
+      // outlast a step that holds the lock for minutes. ACK so QStash doesn't
+      // retry on top of that and dead-letter the delivery once its (much
+      // shorter) retry budget runs out.
+      if (result.lockRescheduled) {
+        log(`[${operationId}] Step ${stepIndex} locked by another instance, re-queued`);
+        return c.json({
+          locked: true,
+          nextStepScheduled: true,
+          operationId,
+          stepIndex,
+          success: true,
+        });
+      }
+
+      // Backoff exhausted (or re-queueing failed) — fall back to a retryable
+      // response so the delivery still gets whatever retries the queue offers.
       log(`[${operationId}] Step ${stepIndex} locked by another instance, returning 429`);
       return c.json(
         { error: 'Step is currently being executed, retry later', operationId, stepIndex },

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -857,6 +857,14 @@ export class AgentRuntimeService {
       // longer than the budget therefore exhausts it and the delivery is
       // dead-lettered — the step it carried is then never executed. Re-queue a
       // fresh delivery on our own bounded backoff instead, and ACK this one.
+      //
+      // The re-delivery has to carry this delivery's own resume/intervention
+      // payload: a human-intervention resume (`processHumanIntervention`) or an
+      // async-tool resume (`tryResumeParentFromAsyncTool`) can lose the lock
+      // race too, and re-queueing only the retry counter would run a plain step
+      // once the lock clears — silently dropping the approval / human input, or
+      // leaving a parked operation parked forever. Undefined fields drop out of
+      // the JSON body, so unrelated deliveries still send just the counter.
       const nextLockRetryAttempt = lockRetryAttempt + 1;
       if (this.queueService && nextLockRetryAttempt <= STEP_LOCK_RETRY_MAX_ATTEMPTS) {
         const delay = stepLockRetryDelayMs(nextLockRetryAttempt);
@@ -875,7 +883,16 @@ export class AgentRuntimeService {
             delay,
             endpoint: `${this.baseURL}/run`,
             operationId,
-            payload: { lockRetryAttempt: nextLockRetryAttempt },
+            payload: {
+              approvedToolCall,
+              finishAfterAsyncTool,
+              humanInput,
+              lockRetryAttempt: nextLockRetryAttempt,
+              rejectAndContinue,
+              rejectionReason,
+              resumeAsyncTool,
+              toolMessageId,
+            },
             priority: 'high',
             retryDelay:
               typeof currentState?.metadata?.queueRetryDelay === 'string'

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -129,6 +129,31 @@ const STEP_LOCK_TTL_SECONDS = 120;
 const STEP_LOCK_HEARTBEAT_MS = 30_000;
 
 /**
+ * How many times a delivery that lost the operation lock re-queues itself
+ * before giving up and falling back to a retryable response.
+ */
+const STEP_LOCK_RETRY_MAX_ATTEMPTS = 12;
+/** Base delay for the first lock-conflict re-delivery. */
+const STEP_LOCK_RETRY_BASE_DELAY_MS = 15_000;
+/**
+ * Ceiling on a single lock-conflict backoff. Together with the base delay,
+ * {@link STEP_LOCK_RETRY_MAX_ATTEMPTS} attempts span ~20 minutes — comfortably
+ * longer than the platform's hard step ceiling, so a step that legitimately
+ * holds the lock for minutes no longer strands the delivery waiting behind it.
+ */
+const STEP_LOCK_RETRY_MAX_DELAY_MS = 120_000;
+
+/**
+ * Exponential backoff for the Nth (1-based) lock-conflict re-delivery:
+ * 15s, 30s, 60s, 120s, then capped at {@link STEP_LOCK_RETRY_MAX_DELAY_MS}.
+ */
+const stepLockRetryDelayMs = (attempt: number): number =>
+  Math.min(
+    STEP_LOCK_RETRY_BASE_DELAY_MS * 2 ** (Math.max(1, attempt) - 1),
+    STEP_LOCK_RETRY_MAX_DELAY_MS,
+  );
+
+/**
  * Exponential backoff delay for the Nth (1-based) watchdog re-check:
  * 15s, 30s, 60s, 120s, 240s, capped at {@link ASYNC_TOOL_VERIFY_MAX_DELAY_MS}.
  */
@@ -750,6 +775,7 @@ export class AgentRuntimeService {
       verifyAsyncToolBarrier,
       asyncToolVerifyAttempt,
       externalRetryCount = 0,
+      lockRetryAttempt = 0,
     } = params;
 
     // Group member timeout watchdog: enforce a member's deadline without claiming
@@ -820,6 +846,64 @@ export class AgentRuntimeService {
           stepResult: null,
           success: true,
         };
+      }
+
+      // The lock is held by a live step of this operation, and this delivery is
+      // not a stale duplicate — it still has to run once the holder is done.
+      //
+      // Don't lean on the queue's own retry budget for that wait: the lock is
+      // heartbeat-refreshed for as long as the holding step runs (unbounded),
+      // while the budget is a handful of fixed-delay retries. A step that runs
+      // longer than the budget therefore exhausts it and the delivery is
+      // dead-lettered — the step it carried is then never executed. Re-queue a
+      // fresh delivery on our own bounded backoff instead, and ACK this one.
+      const nextLockRetryAttempt = lockRetryAttempt + 1;
+      if (this.queueService && nextLockRetryAttempt <= STEP_LOCK_RETRY_MAX_ATTEMPTS) {
+        const delay = stepLockRetryDelayMs(nextLockRetryAttempt);
+        log(
+          '[%s][%d] Step lock conflict — re-queueing attempt %d/%d in %dms',
+          operationId,
+          stepIndex,
+          nextLockRetryAttempt,
+          STEP_LOCK_RETRY_MAX_ATTEMPTS,
+          delay,
+        );
+
+        try {
+          await this.queueService.scheduleMessage({
+            context,
+            delay,
+            endpoint: `${this.baseURL}/run`,
+            operationId,
+            payload: { lockRetryAttempt: nextLockRetryAttempt },
+            priority: 'high',
+            retryDelay:
+              typeof currentState?.metadata?.queueRetryDelay === 'string'
+                ? currentState.metadata.queueRetryDelay
+                : undefined,
+            retries:
+              typeof currentState?.metadata?.queueRetries === 'number'
+                ? currentState.metadata.queueRetries
+                : undefined,
+            stepIndex,
+          });
+
+          return {
+            locked: true,
+            lockRescheduled: true,
+            nextStepScheduled: true,
+            state: {},
+            success: true,
+          };
+        } catch (error) {
+          // Fall through to the retryable response so the delivery isn't lost.
+          log(
+            '[%s][%d] Failed to re-queue after step lock conflict: %O',
+            operationId,
+            stepIndex,
+            error,
+          );
+        }
       }
 
       log(

--- a/apps/server/src/services/agentRuntime/__tests__/executeStep.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/executeStep.test.ts
@@ -414,6 +414,56 @@ describe('AgentRuntimeService.executeStep - step idempotency (distributed lock)'
     expect(coordinator.releaseStepLock).not.toHaveBeenCalled();
   });
 
+  it('should carry the delivery resume payload into the re-queued lock-conflict message', async () => {
+    const scheduleMessage = vi.fn().mockResolvedValue('msg-1');
+    const service = new AgentRuntimeService({} as any, 'user-1', {
+      queueService: { getImpl: () => ({}), scheduleMessage } as any,
+    });
+    const coordinator = (service as any).coordinator;
+    coordinator.tryClaimStep = vi.fn().mockResolvedValue(false);
+    coordinator.loadAgentState = vi.fn().mockResolvedValue({ status: 'running', stepCount: 5 });
+
+    // A human-intervention resume that lost the lock race. Re-queueing only the
+    // retry counter would run a plain step and drop the approval entirely.
+    await service.executeStep({
+      approvedToolCall: { id: 'call-1' },
+      humanInput: 'approved',
+      operationId: 'op-resume',
+      rejectAndContinue: false,
+      stepIndex: 5,
+      toolMessageId: 'msg-tool-1',
+    });
+
+    expect(scheduleMessage.mock.calls[0][0].payload).toMatchObject({
+      approvedToolCall: { id: 'call-1' },
+      humanInput: 'approved',
+      lockRetryAttempt: 1,
+      rejectAndContinue: false,
+      toolMessageId: 'msg-tool-1',
+    });
+  });
+
+  it('should carry an async-tool resume flag into the re-queued lock-conflict message', async () => {
+    const scheduleMessage = vi.fn().mockResolvedValue('msg-1');
+    const service = new AgentRuntimeService({} as any, 'user-1', {
+      queueService: { getImpl: () => ({}), scheduleMessage } as any,
+    });
+    const coordinator = (service as any).coordinator;
+    coordinator.tryClaimStep = vi.fn().mockResolvedValue(false);
+    coordinator.loadAgentState = vi.fn().mockResolvedValue({ status: 'running', stepCount: 5 });
+
+    await service.executeStep({
+      operationId: 'op-async-resume',
+      resumeAsyncTool: true,
+      stepIndex: 5,
+    });
+
+    expect(scheduleMessage.mock.calls[0][0].payload).toMatchObject({
+      lockRetryAttempt: 1,
+      resumeAsyncTool: true,
+    });
+  });
+
   it('should back off exponentially across successive lock-conflict re-deliveries', async () => {
     const scheduleMessage = vi.fn().mockResolvedValue('msg-1');
     const service = new AgentRuntimeService({} as any, 'user-1', {

--- a/apps/server/src/services/agentRuntime/__tests__/executeStep.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/executeStep.test.ts
@@ -383,6 +383,96 @@ describe('AgentRuntimeService.executeStep - step idempotency (distributed lock)'
     expect(coordinator.releaseStepLock).not.toHaveBeenCalled();
   });
 
+  it('should re-queue the same step on its own backoff for a non-stale lock conflict', async () => {
+    const scheduleMessage = vi.fn().mockResolvedValue('msg-1');
+    const service = new AgentRuntimeService({} as any, 'user-1', {
+      queueService: { getImpl: () => ({}), scheduleMessage } as any,
+    });
+    const coordinator = (service as any).coordinator;
+    coordinator.tryClaimStep = vi.fn().mockResolvedValue(false);
+    coordinator.loadAgentState = vi.fn().mockResolvedValue({
+      status: 'running',
+      stepCount: 5,
+      metadata: { queueRetries: 5, queueRetryDelay: '10000' },
+    });
+
+    const result = await service.executeStep({ operationId: 'op-requeue', stepIndex: 5 });
+
+    expect(result.locked).toBe(true);
+    expect(result.lockRescheduled).toBe(true);
+    // ACK so the queue doesn't retry on top of the re-delivery we just scheduled.
+    expect(result.success).toBe(true);
+    expect(scheduleMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operationId: 'op-requeue',
+        payload: { lockRetryAttempt: 1 },
+        retries: 5,
+        retryDelay: '10000',
+        stepIndex: 5,
+      }),
+    );
+    expect(coordinator.releaseStepLock).not.toHaveBeenCalled();
+  });
+
+  it('should back off exponentially across successive lock-conflict re-deliveries', async () => {
+    const scheduleMessage = vi.fn().mockResolvedValue('msg-1');
+    const service = new AgentRuntimeService({} as any, 'user-1', {
+      queueService: { getImpl: () => ({}), scheduleMessage } as any,
+    });
+    const coordinator = (service as any).coordinator;
+    coordinator.tryClaimStep = vi.fn().mockResolvedValue(false);
+    coordinator.loadAgentState = vi.fn().mockResolvedValue({ status: 'running', stepCount: 5 });
+
+    await service.executeStep({ lockRetryAttempt: 0, operationId: 'op-b', stepIndex: 5 });
+    await service.executeStep({ lockRetryAttempt: 2, operationId: 'op-b', stepIndex: 5 });
+
+    expect(scheduleMessage.mock.calls[0][0]).toMatchObject({
+      delay: 15_000,
+      payload: { lockRetryAttempt: 1 },
+    });
+    expect(scheduleMessage.mock.calls[1][0]).toMatchObject({
+      delay: 60_000,
+      payload: { lockRetryAttempt: 3 },
+    });
+  });
+
+  it('should fall back to a retryable response once the lock-conflict backoff is exhausted', async () => {
+    const scheduleMessage = vi.fn().mockResolvedValue('msg-1');
+    const service = new AgentRuntimeService({} as any, 'user-1', {
+      queueService: { getImpl: () => ({}), scheduleMessage } as any,
+    });
+    const coordinator = (service as any).coordinator;
+    coordinator.tryClaimStep = vi.fn().mockResolvedValue(false);
+    coordinator.loadAgentState = vi.fn().mockResolvedValue({ status: 'running', stepCount: 5 });
+
+    const result = await service.executeStep({
+      lockRetryAttempt: 12,
+      operationId: 'op-exhausted',
+      stepIndex: 5,
+    });
+
+    expect(scheduleMessage).not.toHaveBeenCalled();
+    expect(result.locked).toBe(true);
+    expect(result.lockRescheduled).toBeUndefined();
+    expect(result.success).toBe(false);
+  });
+
+  it('should stay retryable when re-queueing after a lock conflict fails', async () => {
+    const scheduleMessage = vi.fn().mockRejectedValue(new Error('qstash down'));
+    const service = new AgentRuntimeService({} as any, 'user-1', {
+      queueService: { getImpl: () => ({}), scheduleMessage } as any,
+    });
+    const coordinator = (service as any).coordinator;
+    coordinator.tryClaimStep = vi.fn().mockResolvedValue(false);
+    coordinator.loadAgentState = vi.fn().mockResolvedValue({ status: 'running', stepCount: 5 });
+
+    const result = await service.executeStep({ operationId: 'op-schedule-fail', stepIndex: 5 });
+
+    expect(result.locked).toBe(true);
+    expect(result.lockRescheduled).toBeUndefined();
+    expect(result.success).toBe(false);
+  });
+
   it('should ack stale duplicate deliveries even when the stale step lock is held', async () => {
     const service = createService();
     const coordinator = (service as any).coordinator;

--- a/apps/server/src/services/agentRuntime/types.ts
+++ b/apps/server/src/services/agentRuntime/types.ts
@@ -154,6 +154,13 @@ export interface AgentExecutionParams {
    */
   groupMemberTimeout?: GroupMemberTimeoutParams;
   humanInput?: any;
+  /**
+   * 1-based attempt number carried by a re-delivery that a previous attempt
+   * re-queued after losing the operation lock. Lets the bounded backoff stop
+   * after a fixed number of tries instead of re-queueing forever. Absent
+   * (treated as attempt 0) on the original delivery.
+   */
+  lockRetryAttempt?: number;
   operationId: string;
   /**
    * Whether a rejection should resume execution by treating the rejected tool
@@ -192,6 +199,13 @@ export interface AgentExecutionResult {
    * this response retryable so fresh deliveries can run after the lock clears.
    */
   locked?: boolean;
+  /**
+   * Set alongside `locked` when this delivery re-queued itself for a later
+   * attempt. The caller should ACK (2xx) rather than returning a retryable
+   * status: the redelivery is already scheduled, so letting the queue retry on
+   * top of it only amplifies the conflict and burns the retry budget.
+   */
+  lockRescheduled?: boolean;
   nextStepScheduled: boolean;
   state: any;
   stepResult?: any;


### PR DESCRIPTION
### What

A delivery that loses the per-operation lock is answered with a retryable `429` (`runStep.ts`), so the wait for the lock is paid out of **the queue's retry budget**. That budget is a handful of fixed-delay retries — ~`3 × 37s ≈ 111s` for a default op, `150s` for eval — while the lock is **heartbeat-refreshed for as long as the holding step runs**, i.e. unbounded.

So any step that runs longer than the budget exhausts it, and the delivery is dead-lettered. **The step it carried is then never executed.** The stale-lock escape hatch (`state.stepCount > stepIndex`) doesn't help: it only fires once the contended step has already finished, which is exactly not the case while we're waiting on it.

This is not an edge case. Over 45.7k completed operations (last 3 days), the average step is **23s at p50 / 72s at p90**, and **4.4% of operations average more than the entire retry budget per step**.

Observed impact on prod: `/api/agent/run` `429` is ~**89% of the QStash DLQ**, still accumulating at ~**22/hour (~530/day)**. Most are duplicate at-least-once deliveries and harmless — the op runs fine and the loser dies in the DLQ. But when the 429'd delivery is the *only* one, the operation is stranded at `status='running'` with `step_count = NULL` and no trace, forever (there is no sweeper for `agent_operations`). Sample: `op_1786422620245_agt_2XkaGSwTTSQp_tpc_oJGZJkbvAKZ3_aK9K6SCK` — its step-0 message is in the DLQ at `op.started_at + 492ms` with `responseStatus: 429`, and the op never ran a single step.

### What this does *not* change

The per-operation mutex introduced in #16821 stays exactly as is. Putting `stepIndex` back into the lock key would fix the 429s but reintroduce concurrent multi-step redrive of the same operation, which is what that PR deliberately fixed.

### How

Stop leaning on the queue's retry budget for the wait. On a non-stale conflict, re-queue the same step on our own bounded backoff and ACK the current delivery so the queue doesn't retry on top of the re-delivery:

- `15s / 30s / 60s / 120s`, capped, **12 attempts ≈ 20 min** — comfortably past the platform's hard step ceiling
- attempt counter rides in the message `payload` (same pattern as `asyncToolVerifyAttempt`)
- the loop self-terminates: once the holder finishes and advances `stepCount`, the next attempt hits the existing stale-lock escape and ACKs
- falls back to the previous retryable `429` when the backoff is exhausted **or** re-queueing throws, so no delivery is silently lost
- no-op in sync/local mode (`queueService` null) — behaviour there is byte-identical to before

#### Test

- [x] Added/updated tests

`apps/server` — 51 passed:
- re-queues the same `stepIndex` with `payload.lockRetryAttempt`, preserving the op's `queueRetries` / `queueRetryDelay`
- backs off exponentially across successive re-deliveries (15s → 60s)
- stops re-queueing and returns retryable once the backoff is exhausted
- stays retryable when `scheduleMessage` throws
- `runStep` returns `200` (not `429`) when the runtime already re-queued

`bun run type-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)