### PR TITLE
✨ feat(model-runtime): support MiniMax text-to-audio in the TTS pipeline

### DIFF
--- a/packages/model-bank/src/aiModels/minimax.ts
+++ b/packages/model-bank/src/aiModels/minimax.ts
@@ -1,6 +1,7 @@
 import {
   type AIChatModelCard,
   type AIImageModelCard,
+  type AITTSModelCard,
   type AIVideoModelCard,
 } from '../types/aiModel';
 
@@ -376,6 +377,60 @@ const minimaxImageModels: AIImageModelCard[] = [
   },
 ];
 
+const minimaxTTSModels: AITTSModelCard[] = [
+  {
+    description:
+      'The latest high-fidelity text-to-audio model, tuned for the most natural prosody and expressive delivery.',
+    displayName: 'Speech 2.8 HD',
+    enabled: true,
+    id: 'speech-2.8-hd',
+    type: 'tts',
+  },
+  {
+    description:
+      'The latest text-to-audio model optimized for low latency, for real-time speech synthesis.',
+    displayName: 'Speech 2.8 Turbo',
+    id: 'speech-2.8-turbo',
+    type: 'tts',
+  },
+  {
+    description: 'A high-fidelity text-to-audio model with rich emotional control.',
+    displayName: 'Speech 2.6 HD',
+    id: 'speech-2.6-hd',
+    type: 'tts',
+  },
+  {
+    description: 'A low-latency text-to-audio model with rich emotional control.',
+    displayName: 'Speech 2.6 Turbo',
+    id: 'speech-2.6-turbo',
+    type: 'tts',
+  },
+  {
+    description: 'A high-fidelity text-to-audio model with broad multilingual coverage.',
+    displayName: 'Speech 02 HD',
+    id: 'speech-02-hd',
+    type: 'tts',
+  },
+  {
+    description: 'A low-latency text-to-audio model with broad multilingual coverage.',
+    displayName: 'Speech 02 Turbo',
+    id: 'speech-02-turbo',
+    type: 'tts',
+  },
+  {
+    description: 'A high-fidelity text-to-audio model for general speech synthesis.',
+    displayName: 'Speech 01 HD',
+    id: 'speech-01-hd',
+    type: 'tts',
+  },
+  {
+    description: 'A low-latency text-to-audio model for general speech synthesis.',
+    displayName: 'Speech 01 Turbo',
+    id: 'speech-01-turbo',
+    type: 'tts',
+  },
+];
+
 const minimaxVideoModels: AIVideoModelCard[] = [
   {
     description:
@@ -608,6 +663,11 @@ const minimaxVideoModels: AIVideoModelCard[] = [
   },
 ];
 
-export const allModels = [...minimaxChatModels, ...minimaxImageModels, ...minimaxVideoModels];
+export const allModels = [
+  ...minimaxChatModels,
+  ...minimaxImageModels,
+  ...minimaxTTSModels,
+  ...minimaxVideoModels,
+];
 
 export default allModels;

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -4231,4 +4231,62 @@ describe('LobeOpenAICompatibleFactory', () => {
       await expect(instance.transcribe!({ file, model: 'whisper-1' })).rejects.toBeDefined();
     });
   });
+
+  describe('textToSpeech', () => {
+    const speechPayload = { input: 'hello world', model: 'tts-1', voice: 'alloy' };
+
+    it('should synthesize speech through the OpenAI-compatible endpoint by default', async () => {
+      const speechMock = vi
+        .spyOn(instance['client'].audio.speech, 'create')
+        .mockResolvedValue({ arrayBuffer: async () => new ArrayBuffer(8) } as any);
+
+      const result = await instance.textToSpeech!(speechPayload);
+
+      expect(speechMock).toHaveBeenCalledWith(
+        expect.objectContaining(speechPayload),
+        expect.anything(),
+      );
+      expect(result!.byteLength).toBe(8);
+    });
+
+    it('should use the custom textToSpeech implementation when provided', async () => {
+      const customBuffer = new ArrayBuffer(4);
+      const customTextToSpeech = vi.fn().mockResolvedValue(customBuffer);
+      const LobeCustomSpeechProvider = createOpenAICompatibleRuntime({
+        baseURL: 'https://api.example.com/v1',
+        provider: ModelProvider.Groq,
+        textToSpeech: customTextToSpeech,
+      });
+      const customInstance = new LobeCustomSpeechProvider({ apiKey: 'test' });
+      const speechSpy = vi.spyOn(customInstance['client'].audio.speech, 'create');
+      const requestOptions = { headers: { 'X-Trace': 'trace-1' } };
+
+      const result = await customInstance.textToSpeech!(speechPayload, requestOptions);
+
+      expect(result).toBe(customBuffer);
+      expect(speechSpy).not.toHaveBeenCalled();
+      expect(customTextToSpeech).toHaveBeenCalledWith(
+        speechPayload,
+        expect.objectContaining({
+          apiKey: 'test',
+          baseURL: 'https://api.example.com/v1',
+          provider: ModelProvider.Groq,
+        }),
+        requestOptions,
+      );
+    });
+
+    it('should wrap errors thrown by the custom textToSpeech implementation', async () => {
+      const LobeCustomSpeechProvider = createOpenAICompatibleRuntime({
+        baseURL: 'https://api.example.com/v1',
+        provider: ModelProvider.Groq,
+        textToSpeech: vi.fn().mockRejectedValue(new Error('speech boom')),
+      });
+      const customInstance = new LobeCustomSpeechProvider({ apiKey: 'test' });
+
+      await expect(customInstance.textToSpeech!(speechPayload)).rejects.toEqual(
+        expect.objectContaining({ provider: ModelProvider.Groq }),
+      );
+    });
+  });
 });

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -184,6 +184,13 @@ export type CreateVideoOptions = Omit<ClientOptions, 'apiKey' | 'provider'> &
     provider: string;
   };
 
+// See CreateImageOptions above: drop openai's `provider` so ours stays `string`.
+export type CreateSpeechOptions = Omit<ClientOptions, 'apiKey' | 'provider'> &
+  ModelIdMappingOptions & {
+    apiKey: string;
+    provider: string;
+  };
+
 export interface CustomClientOptions<T extends Record<string, any> = any> {
   createChatCompletionStream?: (
     client: any,
@@ -330,6 +337,16 @@ export interface OpenAICompatibleFactoryOptions<T extends Record<string, any> = 
       payload: ResponseCreateParamsWithPromptCacheKey;
     };
   };
+  /**
+   * Custom text-to-speech implementation, for providers that expose speech
+   * synthesis through their own API instead of the OpenAI-compatible
+   * `/audio/speech` surface.
+   */
+  textToSpeech?: (
+    payload: TextToSpeechPayload,
+    options: CreateSpeechOptions,
+    requestOptions?: TextToSpeechOptions,
+  ) => Promise<ArrayBuffer>;
 }
 
 export const createOpenAICompatibleRuntime = <T extends Record<string, any> = any>({
@@ -349,6 +366,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
   handleCreateVideoWebhook: customHandleCreateVideoWebhook,
   handlePollVideoStatus: customHandlePollVideoStatus,
   generateObject: generateObjectConfig,
+  textToSpeech: customTextToSpeech,
 }: OpenAICompatibleFactoryOptions<T>) => {
   const ErrorType = {
     bizError: errorType?.bizError || AgentRuntimeErrorType.ProviderBizError,
@@ -1322,7 +1340,6 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
 
     async textToSpeech(payload: TextToSpeechPayload, options?: TextToSpeechOptions) {
       const log = debug(`${this.logPrefix}:textToSpeech`);
-      const requestPayload = withMappedModelId(payload, this.modelIdMappingOptions);
       log(
         'textToSpeech called with input length: %d, voice: %s',
         payload.input?.length || 0,
@@ -1330,6 +1347,23 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
       );
 
       try {
+        // If custom textToSpeech implementation is provided, use it
+        if (customTextToSpeech) {
+          log('using custom textToSpeech implementation');
+
+          return await customTextToSpeech(
+            payload,
+            {
+              ...this._options,
+              apiKey: this._options.apiKey!,
+              modelIdMapping: this.modelIdMappingOptions.modelIdMapping,
+              provider,
+            },
+            options,
+          );
+        }
+
+        const requestPayload = withMappedModelId(payload, this.modelIdMappingOptions);
         const mp3 = await this.client.audio.speech.create(requestPayload as any, {
           headers: options?.headers,
           signal: options?.signal,

--- a/packages/model-runtime/src/providers/minimax/createSpeech.test.ts
+++ b/packages/model-runtime/src/providers/minimax/createSpeech.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CreateSpeechOptions } from '../../core/openaiCompatibleFactory';
+import type { TextToSpeechPayload } from '../../types/tts';
+import { createMiniMaxSpeech, resolveMiniMaxSpeechEndpoint } from './createSpeech';
+
+const mockOptions: CreateSpeechOptions = {
+  apiKey: 'test-api-key',
+  baseURL: 'https://api.minimaxi.com/v1',
+  provider: 'minimax',
+};
+
+const payload: TextToSpeechPayload = {
+  input: 'hello world',
+  model: 'speech-2.8-hd',
+  voice: 'test-voice',
+};
+
+// 'ok' encoded as hex
+const audioHex = '6f6b';
+
+const mockJsonResponse = (body: unknown) => {
+  global.fetch = vi.fn().mockResolvedValueOnce({
+    json: async () => body,
+    ok: true,
+  });
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('resolveMiniMaxSpeechEndpoint', () => {
+  it.each([
+    ['https://api.minimaxi.com/v1', 'https://api.minimaxi.com/v1/t2a_v2'],
+    ['https://api.minimax.io/v1', 'https://api.minimax.io/v1/t2a_v2'],
+    ['https://api.minimax.io/anthropic', 'https://api.minimax.io/v1/t2a_v2'],
+    ['https://api.minimax.io/anthropic/v1/messages', 'https://api.minimax.io/v1/t2a_v2'],
+    ['https://proxy.example.com/minimax/v1/', 'https://proxy.example.com/minimax/v1/t2a_v2'],
+  ])('resolves %s to %s', (baseURL, expected) => {
+    expect(resolveMiniMaxSpeechEndpoint(baseURL)).toBe(expected);
+  });
+
+  it('falls back to the default regional endpoint', () => {
+    expect(resolveMiniMaxSpeechEndpoint()).toBe('https://api.minimaxi.com/v1/t2a_v2');
+  });
+});
+
+describe('createMiniMaxSpeech', () => {
+  it('sends the text to audio request and decodes the hex audio', async () => {
+    mockJsonResponse({
+      base_resp: { status_code: 0, status_msg: 'success' },
+      data: { audio: audioHex, status: 2 },
+    });
+
+    const result = await createMiniMaxSpeech(payload, mockOptions);
+
+    expect(fetch).toHaveBeenCalledWith('https://api.minimaxi.com/v1/t2a_v2', {
+      body: JSON.stringify({
+        audio_setting: { format: 'mp3' },
+        model: 'speech-2.8-hd',
+        output_format: 'hex',
+        text: 'hello world',
+        voice_setting: { voice_id: 'test-voice' },
+      }),
+      headers: {
+        'Authorization': 'Bearer test-api-key',
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+      signal: undefined,
+    });
+    expect(Buffer.from(result).toString()).toBe('ok');
+  });
+
+  it('forwards the requested audio format and speed', async () => {
+    mockJsonResponse({
+      base_resp: { status_code: 0, status_msg: 'success' },
+      data: { audio: audioHex, status: 2 },
+    });
+
+    await createMiniMaxSpeech(
+      { ...payload, response_format: 'flac', speed: 1.5 } as TextToSpeechPayload,
+      mockOptions,
+    );
+
+    const body = JSON.parse((fetch as any).mock.calls[0][1].body);
+
+    expect(body.audio_setting).toEqual({ format: 'flac' });
+    expect(body.voice_setting).toEqual({ speed: 1.5, voice_id: 'test-voice' });
+  });
+
+  it('ignores an audio format the speech endpoint does not support', async () => {
+    mockJsonResponse({
+      base_resp: { status_code: 0, status_msg: 'success' },
+      data: { audio: audioHex },
+    });
+
+    await createMiniMaxSpeech(
+      { ...payload, response_format: 'aac' } as TextToSpeechPayload,
+      mockOptions,
+    );
+
+    const body = JSON.parse((fetch as any).mock.calls[0][1].body);
+
+    expect(body.audio_setting).toEqual({ format: 'mp3' });
+  });
+
+  it('applies the model id mapping', async () => {
+    mockJsonResponse({
+      base_resp: { status_code: 0, status_msg: 'success' },
+      data: { audio: audioHex },
+    });
+
+    await createMiniMaxSpeech(payload, {
+      ...mockOptions,
+      modelIdMapping: { 'speech-2.8-hd': 'mapped-speech-model' },
+    });
+
+    const body = JSON.parse((fetch as any).mock.calls[0][1].body);
+
+    expect(body.model).toBe('mapped-speech-model');
+  });
+
+  it('forwards per-request headers and the abort signal', async () => {
+    mockJsonResponse({
+      base_resp: { status_code: 0, status_msg: 'success' },
+      data: { audio: audioHex },
+    });
+
+    const signal = new AbortController().signal;
+
+    await createMiniMaxSpeech(payload, mockOptions, { headers: { 'X-Trace': 'trace-1' }, signal });
+
+    const requestInit = (fetch as any).mock.calls[0][1];
+
+    expect(requestInit.headers['X-Trace']).toBe('trace-1');
+    expect(requestInit.signal).toBe(signal);
+  });
+
+  it('throws when the HTTP request fails', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      text: async () => 'invalid api key',
+    });
+
+    await expect(createMiniMaxSpeech(payload, mockOptions)).rejects.toThrow(
+      'MiniMax API error (401): invalid api key',
+    );
+  });
+
+  it('throws when the response reports a business error', async () => {
+    mockJsonResponse({
+      base_resp: { status_code: 1004, status_msg: 'authentication failed' },
+      data: null,
+    });
+
+    await expect(createMiniMaxSpeech(payload, mockOptions)).rejects.toThrow(
+      'MiniMax API error: authentication failed',
+    );
+  });
+
+  it('throws when the response carries no audio', async () => {
+    mockJsonResponse({ base_resp: { status_code: 0, status_msg: 'success' }, data: {} });
+
+    await expect(createMiniMaxSpeech(payload, mockOptions)).rejects.toThrow(
+      'No audio data in text to audio response',
+    );
+  });
+
+  it('throws when the audio payload is not valid hex', async () => {
+    mockJsonResponse({
+      base_resp: { status_code: 0, status_msg: 'success' },
+      data: { audio: 'not-hex' },
+    });
+
+    await expect(createMiniMaxSpeech(payload, mockOptions)).rejects.toThrow(
+      'MiniMax returned a malformed hex audio payload',
+    );
+  });
+});

--- a/packages/model-runtime/src/providers/minimax/createSpeech.ts
+++ b/packages/model-runtime/src/providers/minimax/createSpeech.ts
@@ -1,0 +1,152 @@
+import createDebug from 'debug';
+
+import type { CreateSpeechOptions } from '../../core/openaiCompatibleFactory';
+import type { TextToSpeechOptions, TextToSpeechPayload } from '../../types/tts';
+import { resolveMappedModelId } from '../../utils/modelIdMapping';
+
+const log = createDebug('lobe-tts:minimax');
+
+const DEFAULT_MINIMAX_SPEECH_ROOT = 'https://api.minimaxi.com';
+const MINIMAX_SPEECH_PATH = '/v1/t2a_v2';
+/**
+ * Strip the API surface suffix (`/v1`, `/anthropic`, `/anthropic/v1/messages`)
+ * from the configured base URL so only the regional root is kept. MiniMax
+ * serves text-to-audio from the same regional host as chat, so deriving the
+ * endpoint from the base URL keeps every regional deployment working without
+ * extra configuration.
+ */
+const MINIMAX_API_SUFFIX_PATTERN = /\/(?:anthropic(?:\/v1\/messages)?|v1)\/?$/;
+
+export const resolveMiniMaxSpeechEndpoint = (baseURL?: string | null) => {
+  const root = (baseURL || DEFAULT_MINIMAX_SPEECH_ROOT)
+    .replace(MINIMAX_API_SUFFIX_PATTERN, '')
+    .replace(/\/$/, '');
+
+  return `${root}${MINIMAX_SPEECH_PATH}`;
+};
+
+/** Audio containers the speech endpoint can encode the synthesized audio into. */
+export const MINIMAX_AUDIO_FORMATS = ['mp3', 'wav', 'flac', 'pcm'] as const;
+
+type MiniMaxAudioFormat = (typeof MINIMAX_AUDIO_FORMATS)[number];
+
+const DEFAULT_AUDIO_FORMAT: MiniMaxAudioFormat = 'mp3';
+
+/**
+ * The shared TTS payload only declares the fields every provider needs; the
+ * OpenAI-compatible request fields callers may add are forwarded as-is, so read
+ * them defensively instead of widening the shared type.
+ */
+type MiniMaxSpeechPayload = TextToSpeechPayload & {
+  response_format?: string;
+  speed?: number;
+};
+
+interface MiniMaxSpeechResponse {
+  base_resp?: {
+    status_code: number;
+    status_msg: string;
+  };
+  data?: {
+    /** Hex-encoded audio, in the container requested via `audio_setting.format`. */
+    audio?: string;
+    /** `1` while synthesizing, `2` once synthesis completed. */
+    status?: number;
+  };
+}
+
+const isSupportedAudioFormat = (format?: string): format is MiniMaxAudioFormat =>
+  !!format && (MINIMAX_AUDIO_FORMATS as readonly string[]).includes(format);
+
+const HEX_PATTERN = /^[\da-f]+$/i;
+
+const hexToArrayBuffer = (hex: string) => {
+  const normalized = hex.trim();
+
+  if (normalized.length === 0 || normalized.length % 2 !== 0 || !HEX_PATTERN.test(normalized)) {
+    throw new Error('MiniMax returned a malformed hex audio payload');
+  }
+
+  const bytes = new Uint8Array(normalized.length / 2);
+
+  for (let index = 0; index < bytes.length; index++) {
+    bytes[index] = Number.parseInt(normalized.slice(index * 2, index * 2 + 2), 16);
+  }
+
+  return bytes.buffer;
+};
+
+/**
+ * Synthesize speech using the MiniMax text-to-audio API.
+ *
+ * The response carries the audio inline as hex, so the buffer is decoded here
+ * and returned directly instead of going through a temporary download URL.
+ */
+export async function createMiniMaxSpeech(
+  payload: TextToSpeechPayload,
+  options: CreateSpeechOptions,
+  requestOptions?: TextToSpeechOptions,
+): Promise<ArrayBuffer> {
+  const { apiKey, baseURL } = options;
+  const { input, voice, response_format, speed } = payload as MiniMaxSpeechPayload;
+  const model = resolveMappedModelId(payload.model, options);
+  const endpoint = resolveMiniMaxSpeechEndpoint(baseURL);
+
+  const format = isSupportedAudioFormat(response_format) ? response_format : DEFAULT_AUDIO_FORMAT;
+  const voiceSetting = {
+    ...(voice ? { voice_id: voice } : {}),
+    ...(typeof speed === 'number' ? { speed } : {}),
+  };
+
+  const requestBody: Record<string, unknown> = {
+    audio_setting: { format },
+    model,
+    // Hex is the only non-streaming output that keeps the audio in the response
+    // body; a URL would expire and require a second round-trip.
+    output_format: 'hex',
+    text: input,
+    ...(Object.keys(voiceSetting).length > 0 ? { voice_setting: voiceSetting } : {}),
+  };
+
+  log('Text to audio request: endpoint=%s model=%s format=%s', endpoint, model, format);
+
+  const response = await fetch(endpoint, {
+    body: JSON.stringify(requestBody),
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      ...requestOptions?.headers,
+    },
+    method: 'POST',
+    signal: requestOptions?.signal,
+  });
+
+  if (!response.ok) {
+    let errorText: string | undefined;
+    try {
+      errorText = await response.text();
+    } catch {
+      // Failed to read the error response body
+    }
+
+    throw new Error(`MiniMax API error (${response.status}): ${errorText || response.statusText}`);
+  }
+
+  const data: MiniMaxSpeechResponse = await response.json();
+
+  if (data.base_resp && data.base_resp.status_code !== 0) {
+    throw new Error(`MiniMax API error: ${data.base_resp.status_msg}`);
+  }
+
+  const audio = data.data?.audio;
+
+  if (!audio) {
+    throw new Error('No audio data in text to audio response');
+  }
+
+  const buffer = hexToArrayBuffer(audio);
+
+  log('Text to audio completed: %d bytes, status=%o', buffer.byteLength, data.data?.status);
+
+  return buffer;
+}

--- a/packages/model-runtime/src/providers/minimax/index.ts
+++ b/packages/model-runtime/src/providers/minimax/index.ts
@@ -16,6 +16,7 @@ import { getModelPropertyWithFallback } from '../../utils/getFallbackModelProper
 import { resolveSafeMaxTokens } from '../../utils/resolveSafeMaxTokens';
 import { sanitizeAnthropicThinkingParts } from '../../utils/sanitizeAnthropicThinkingParts';
 import { createMiniMaxImage } from './createImage';
+import { createMiniMaxSpeech } from './createSpeech';
 import { createMiniMaxVideo } from './createVideo';
 
 const DEFAULT_MINIMAX_BASE_URL = 'https://api.minimaxi.com/v1';
@@ -371,6 +372,7 @@ export const openAIParams = {
     });
   },
   provider: ModelProvider.Minimax,
+  textToSpeech: createMiniMaxSpeech,
 } satisfies OpenAICompatibleFactoryOptions;
 
 export const LobeMinimaxOpenAI = createOpenAICompatibleRuntime(openAIParams);


### PR DESCRIPTION
Reason: MiniMax text-to-audio could not be used because the shared TTS path only spoke the OpenAI-compatible `/audio/speech` protocol.

## What changed

- `openaiCompatibleFactory` gains an optional `textToSpeech` hook (with a `CreateSpeechOptions` type), mirroring the existing `createImage` / `createVideo` custom hooks. Providers without an OpenAI-compatible speech endpoint can now plug in their own implementation; the default `client.audio.speech.create` path is unchanged for every provider that does not set the hook. Errors from a custom implementation go through the same `handleError` wrapper as the default path, and per-request `headers` / `signal` are forwarded so aborts keep working.
- New `createMiniMaxSpeech` implementation for the MiniMax provider:
  - Resolves the `/v1/t2a_v2` endpoint from the configured provider base URL, stripping the `/v1` and Anthropic-compatible suffixes first. Both regional hosts (and proxies in front of them) therefore work without extra configuration.
  - Sends `model`, `text`, `output_format: 'hex'`, `audio_setting.format` and, when present, `voice_setting` (`voice_id`, `speed`).
  - Accepts `mp3`, `wav`, `flac` and `pcm` as audio containers and falls back to `mp3` for anything else.
  - Parses the response: fails on a non-zero `base_resp.status_code`, on a missing `data.audio`, and on a malformed hex payload; otherwise decodes the hex audio into the `ArrayBuffer` the runtime contract expects.
- Registered the implementation on the MiniMax OpenAI-compatible params, and added the eight `speech-*` models to the MiniMax model bank as `tts` cards.

## Checks

- `npx vitest run src/providers/minimax src/core/openaiCompatibleFactory/index.test.ts` in `packages/model-runtime` (215 tests passed)
- `npx vitest run` in `packages/model-bank` (88 tests passed)
- `npx eslint` on the changed files
- `npx tsgo --noEmit` on the changed packages' sources
- `npx prettier --write` on the changed files
