### PR TITLE
🐛 fix(trpc): split message.getMessages out of the initial-load batch

### DIFF
--- a/packages/trpc/src/client/lambda.ts
+++ b/packages/trpc/src/client/lambda.ts
@@ -171,7 +171,14 @@ const linkOptions = {
 
 // Procedures that should skip batching for faster initial load
 const initialLoadProcedures = new Set(['user.getUserState', 'config.getGlobalConfig']);
-const slowProcedures = new Set(['market.getAssistantList']);
+// `message.getMessages` can serialize multi-MB payloads on very long topics and
+// run for tens of seconds when the data is cold. Batched with the rest of the
+// initial load, one slow read delays the whole batch; if it exceeds the upstream
+// request timeout the response comes back as an HTML error page instead of JSON,
+// so every sibling procedure in the batch (e.g. `agent.getAgentConfigById`) fails
+// its `JSON.parse` with `Unexpected token '<'`. Split it out so a slow message
+// read only slows itself. See LOBE-13229.
+const slowProcedures = new Set(['market.getAssistantList', 'message.getMessages']);
 const SKIP_BATCH_PROCEDURES = new Set([...initialLoadProcedures, ...slowProcedures]);
 
 // Queries whose input can exceed the GET URL budget (`maxURLLength` 2083):


### PR DESCRIPTION
On very long topics `message.getMessages` serializes multi-MB payloads and runs for tens of seconds when the data is cold. Because it is batched with the rest of the initial load, one slow read delays the whole batch — and when it exceeds the upstream request timeout the response comes back as an **HTML error page instead of JSON**, so every sibling procedure in the same batch (notably `agent.getAgentConfigById`) fails its `JSON.parse` with `Unexpected token '<'`, surfacing to users as a failure to load agent settings.

This adds `message.getMessages` to `slowProcedures` so it is dispatched on its own request. A slow message read then only slows itself and no longer takes agent settings (and the rest of the initial-load batch) down with it.

| Before | After |
| ------ | ----- |
| Slow `message.getMessages` shares one batched request with `agent.getAgentConfigById` et al.; a timeout returns 524 HTML → the whole batch fails `JSON.parse` → "Failed to load agent settings" | `message.getMessages` is dispatched alone; a slow read no longer drags sibling procedures past the timeout, so agent settings load normally |

No UI change — this only changes tRPC request batching.

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

`bun run check` on the changed file passes (lint clean, 2 existing link tests green). The change is additive: one procedure path added to the batch-skip set; no behavior change for any other procedure.

#### 🔗 Related Issue

Stopgap for **LOBE-13229** (超大 topic 全量拉取又大又慢). This is the batch-drag hotfix that stops "Failed to load agent settings"; the root read-path fix (round-boundary cursor pagination) ships separately.

#### Key Decisions / Non-goals

- **Stopgap, not the root fix.** This only stops a slow message read from failing its batch siblings. `message.getMessages` itself is still a single large full-fetch; making it fast is the separate cursor-pagination change.
- **Additive & low-risk.** Excluding a procedure from batching only sends it as its own HTTP request (it already did so under `httpLink` for the other `slowProcedures`); no query, auth, or return-shape change.