### PR TITLE
🐛 fix(verify): stop acceptanceBySubject from polling forever after acceptance removal

### DIFF
--- a/src/features/Verify/hooks.test.ts
+++ b/src/features/Verify/hooks.test.ts
@@ -83,6 +83,46 @@ describe('Verify data hooks', () => {
     expect(getAcceptanceBySubjectRefreshInterval({ id: 'a1', status: 'closed' })).toBe(0);
   });
 
+  it('stops polling once a previously-seen acceptance is removed, instead of treating it as still discovering', () => {
+    // Never seen: keep discovering fast — this is the pre-existing behaviour.
+    expect(getAcceptanceBySubjectRefreshInterval(undefined, false)).toBe(2000);
+    expect(getAcceptanceBySubjectRefreshInterval(null, false)).toBe(2000);
+    // Seen once, now null: the aggregate existed and was deleted (e.g. via
+    // "Remove acceptance"). The endpoint cannot tell this apart from
+    // "never created" — the caller-supplied flag is what breaks the tie.
+    expect(getAcceptanceBySubjectRefreshInterval(undefined, true)).toBe(0);
+    expect(getAcceptanceBySubjectRefreshInterval(null, true)).toBe(0);
+  });
+
+  it('flips useAcceptanceBySubject to stop polling after the aggregate is removed', async () => {
+    const getAcceptanceBySubject = vi.spyOn(verifyService, 'getAcceptanceBySubject');
+    getAcceptanceBySubject.mockResolvedValueOnce({
+      id: 'acceptance-1',
+      status: 'verifying',
+    } as never);
+
+    const { rerender, result } = renderHook(
+      ({ subjectId }: { subjectId: string | null }) => useAcceptanceBySubject('task', subjectId),
+      { initialProps: { subjectId: 'T-231' }, wrapper: createSWRWrapper(new Map()) },
+    );
+
+    await waitFor(() =>
+      expect(result.current.data).toEqual({ id: 'acceptance-1', status: 'verifying' }),
+    );
+
+    // The task's acceptance config was removed server-side: the endpoint now
+    // reports null for the same subject, same shape as "never created".
+    getAcceptanceBySubject.mockResolvedValue(null);
+    await result.current.mutate();
+    await waitFor(() => expect(result.current.data).toBeNull());
+
+    // A different subject that has never had an aggregate must still poll
+    // fast — the sticky flag is per-subject, not global.
+    getAcceptanceBySubject.mockResolvedValue(null);
+    rerender({ subjectId: 'T-999' });
+    await waitFor(() => expect(result.current.data).toBeUndefined());
+  });
+
   it('does not request rubrics while rubric authoring is inactive', async () => {
     const listRubrics = vi.spyOn(verifyService, 'listRubrics').mockResolvedValue([]);
 

--- a/src/features/Verify/hooks.ts
+++ b/src/features/Verify/hooks.ts
@@ -1,5 +1,5 @@
 import type { AcceptanceSubjectType } from '@lobechat/types';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import useSWRInfinite from 'swr/infinite';
 
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
@@ -35,8 +35,21 @@ const ACCEPTANCE_BUNDLE_SWR_CONFIG = {
  */
 const TERMINAL_ACCEPTANCE_STATUSES = new Set(['accepted', 'closed']);
 
-export const getAcceptanceBySubjectRefreshInterval = (acceptance: unknown) => {
-  if (!acceptance) return 2000;
+/**
+ * `hasExisted` disambiguates the two reasons `getBySubject` returns null: a
+ * subject that has never had an aggregate created (still discovering — poll
+ * fast) versus one whose aggregate existed and was since removed
+ * (`acceptance.remove`, e.g. "Remove acceptance" in the task detail panel).
+ * The endpoint itself cannot tell these apart — both read as a plain `null` —
+ * so a caller that once observed a non-null aggregate for this subject must
+ * pass `true` once it flips back to null, or the fastest "still discovering"
+ * interval fires forever and the tab polls every 2s indefinitely.
+ */
+export const getAcceptanceBySubjectRefreshInterval = (
+  acceptance: unknown,
+  hasExisted = false,
+) => {
+  if (!acceptance) return hasExisted ? 0 : 2000;
   const status = (acceptance as { status?: string }).status;
   return status && TERMINAL_ACCEPTANCE_STATUSES.has(status) ? 0 : 5000;
 };
@@ -73,18 +86,35 @@ export const useAcceptanceBundle = (acceptanceId: string | null) =>
 export const useAcceptanceBySubject = (
   subjectType: AcceptanceSubjectType,
   subjectId: string | null,
-) =>
-  useClientDataSWR(
+) => {
+  // Sticky per-subject "was this ever non-null" flag — see
+  // getAcceptanceBySubjectRefreshInterval's `hasExisted` doc. Resets when the
+  // caller points the hook at a different subject.
+  const hasExistedRef = useRef(false);
+  const trackedSubjectIdRef = useRef(subjectId);
+  if (trackedSubjectIdRef.current !== subjectId) {
+    trackedSubjectIdRef.current = subjectId;
+    hasExistedRef.current = false;
+  }
+
+  return useClientDataSWR(
     subjectId ? verifyKeys.acceptanceBySubject(subjectType, subjectId) : null,
     () => verifyService.getAcceptanceBySubject(subjectType, subjectId!),
     {
       ...ACCEPTANCE_BUNDLE_SWR_CONFIG,
+      onSuccess: (data) => {
+        if (data) hasExistedRef.current = true;
+      },
       // A task can mount before its first Verify Run creates the aggregate.
       // Discover that server-side transition without requiring focus/reload,
-      // then stop polling as soon as the Acceptance exists.
-      refreshInterval: getAcceptanceBySubjectRefreshInterval,
+      // then stop polling as soon as the Acceptance exists — or, once it
+      // existed and was removed, stop immediately instead of re-entering the
+      // fastest "still discovering" interval forever.
+      refreshInterval: (latestData: unknown) =>
+        getAcceptanceBySubjectRefreshInterval(latestData, hasExistedRef.current),
     },
   );
+};
 
 /** The caller's recent acceptance aggregates (with subject headers) — the list panel. */
 export const useAcceptanceList = (enabled: boolean) =>


### PR DESCRIPTION
## Bug

Opening a Task/Topic page that has (or ever had) an Acceptance keeps the browser polling `acceptance.getBySubject` every 2 seconds forever, even after the Acceptance is removed and `verify.enabled` is `false`.

Root cause: `getAcceptanceBySubjectRefreshInterval` only handled the "still discovering" case — a `null` aggregate always fell back to the fastest 2s interval, on the assumption the aggregate had simply not been created yet.

That assumption breaks once an aggregate is deleted. `acceptance.remove` (wired up from Task detail's "Remove acceptance" action, and used when clearing a topic acceptance in the Verify Tray) hard-deletes the row, and `getBySubject` returns the exact same plain `null` for "never created" as it does for "existed, then removed" — there is no tombstone. The refresh-interval function has no way to distinguish the two, so it keeps assuming discovery is still in progress and polls at the fastest interval indefinitely.

## Fix

`useAcceptanceBySubject` now tracks a sticky, per-subject "has this ever resolved to a non-null aggregate" flag and passes it into `getAcceptanceBySubjectRefreshInterval` as a second argument:

- Never seen a non-null aggregate for this subject → keep the original fast-discovery behavior (2s).
- Seen one, now `null` → the aggregate existed and was removed; stop polling (0) instead of re-entering the discovery interval.
- The flag is keyed to the current `subjectId` and resets whenever the hook is pointed at a different subject, so it can't leak state across tasks/topics.

No server/API changes — this only affects client-side polling cadence.

## Tests

- Extended `getAcceptanceBySubjectRefreshInterval` unit tests with the new `hasExisted` argument (both `true`/`false` branches).
- Added a hook-level test for `useAcceptanceBySubject` asserting polling stops after a previously-observed aggregate flips to `null`, while confirming a different, never-seen subject is unaffected.

## How this was found

Reported in-house: a task page kept firing `acceptance.getBySubject` continuously even with delivery-verify disabled and the acceptance record removed. Traced to the refresh-interval helper always defaulting `null` → 2000ms regardless of prior history.