### PR TITLE
✨ feat(heterogeneous-agent): support Grok model and effort selection

### DIFF
--- a/apps/cli/src/commands/hetero.test.ts
+++ b/apps/cli/src/commands/hetero.test.ts
@@ -360,6 +360,30 @@ describe('hetero exec command', () => {
     });
   });
 
+  it('passes Grok Build --model and --effort through as spawnAgent extraArgs', async () => {
+    mockSpawnAgent.mockReturnValue(createFakeHandle());
+
+    await runCmd([
+      'hetero',
+      'exec',
+      '--type',
+      'grok-build',
+      '--prompt',
+      'hi',
+      '--model',
+      'grok-4.6',
+      '--effort',
+      'xhigh',
+    ]);
+
+    expect(mockResolveHeteroSpawnCommand).toHaveBeenCalledWith('grok-build', undefined);
+    expect(mockSpawnAgent.mock.calls[0][0]).toMatchObject({
+      agentType: 'grok-build',
+      command: 'grok',
+      extraArgs: ['--model', 'grok-4.6', '--effort', 'xhigh'],
+    });
+  });
+
   it('translates Codex --effort to native model_reasoning_effort config', async () => {
     mockSpawnAgent.mockReturnValue(createFakeHandle());
 

--- a/apps/cli/src/commands/hetero.ts
+++ b/apps/cli/src/commands/hetero.ts
@@ -146,7 +146,9 @@ const buildExtraArgs = (
                 ? ['-c', `${CODEX_SERVICE_TIER_CONFIG_KEY}="${options.speed}"`]
                 : []),
             ]
-          : options.type === 'claude-code' || options.type === 'codebuddy'
+          : options.type === 'claude-code' ||
+              options.type === 'codebuddy' ||
+              options.type === 'grok-build'
             ? [
                 ...(options.model ? ['--model', options.model] : []),
                 ...(options.effort ? ['--effort', options.effort] : []),

--- a/apps/server/src/routers/lambda/device.ts
+++ b/apps/server/src/routers/lambda/device.ts
@@ -307,7 +307,7 @@ export const deviceRouter = router({
         cwd: z.string().optional(),
         deviceId: z.string(),
         env: z.record(z.string(), z.string()).optional(),
-        type: z.enum(['codebuddy', 'cursor', 'opencode', 'pi', 'qoder', 'trae']),
+        type: z.enum(['codebuddy', 'cursor', 'grok-build', 'opencode', 'pi', 'qoder', 'trae']),
       }),
     )
     .query(async ({ ctx, input }) =>

--- a/apps/server/src/services/deviceGateway/index.ts
+++ b/apps/server/src/services/deviceGateway/index.ts
@@ -466,7 +466,7 @@ export class DeviceGateway {
     deviceId: string;
     env?: Record<string, string>;
     timeout?: number;
-    type: 'codebuddy' | 'cursor' | 'opencode' | 'pi' | 'qoder' | 'trae';
+    type: 'codebuddy' | 'cursor' | 'grok-build' | 'opencode' | 'pi' | 'qoder' | 'trae';
     userId: string;
     workspaceId?: string;
   }): Promise<HeterogeneousAgentModelCatalog> {

--- a/packages/device-control/src/types.ts
+++ b/packages/device-control/src/types.ts
@@ -242,7 +242,7 @@ export interface ListHeterogeneousAgentModelsParams {
   command?: string;
   cwd?: string;
   env?: Record<string, string>;
-  type: 'codebuddy' | 'cursor' | 'opencode' | 'pi' | 'qoder' | 'trae';
+  type: 'codebuddy' | 'cursor' | 'grok-build' | 'opencode' | 'pi' | 'qoder' | 'trae';
 }
 
 export interface HeterogeneousAgentModelCatalogItem {

--- a/packages/heterogeneous-agents/src/models/index.ts
+++ b/packages/heterogeneous-agents/src/models/index.ts
@@ -2,6 +2,7 @@ export {
   listHeterogeneousAgentModels,
   parseCodeBuddyModelCatalog,
   parseCursorModelCatalog,
+  parseGrokBuildModelCatalog,
   parseOpenCodeModelCatalog,
   parsePiModelCatalog,
   parseQoderModelCatalog,

--- a/packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.test.ts
+++ b/packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.test.ts
@@ -273,6 +273,47 @@ describe('heterogeneous agent model discovery', () => {
     );
   });
 
+  it('parses and discovers Grok Build models', async () => {
+    const stdout = [
+      'You are not authenticated.',
+      '',
+      'Default model: grok-4.6',
+      '',
+      'Available models:',
+      '  * grok-4.6 (default)',
+      '  - grok-4.5',
+      '  - grok-4.6',
+    ].join('\n');
+    resolveExecFile(stdout);
+    const { listHeterogeneousAgentModels, parseGrokBuildModelCatalog } = await importModule();
+
+    expect(parseGrokBuildModelCatalog(stdout)).toEqual([
+      { id: 'grok-4.6', modelId: 'grok-4.6', providerId: 'grok-build' },
+      { id: 'grok-4.5', modelId: 'grok-4.5', providerId: 'grok-build' },
+    ]);
+
+    await expect(
+      listHeterogeneousAgentModels({
+        command: '/custom/grok',
+        cwd: '/repo',
+        env: { XAI_API_KEY: 'test-key' },
+        type: 'grok-build',
+      }),
+    ).resolves.toMatchObject({
+      models: [
+        { id: 'grok-4.6', modelId: 'grok-4.6', providerId: 'grok-build' },
+        { id: 'grok-4.5', modelId: 'grok-4.5', providerId: 'grok-build' },
+      ],
+      status: 'success',
+    });
+    expect(execFileMock).toHaveBeenLastCalledWith(
+      '/custom/grok',
+      ['models'],
+      expect.objectContaining({ cwd: '/repo', env: { XAI_API_KEY: 'test-key' } }),
+      expect.any(Function),
+    );
+  });
+
   it('runs the configured binary with plugins enabled and forwards cwd/env', async () => {
     resolveExecFile('openai/gpt-5.6\nopenrouter/google/gemini-2.5-pro\n');
     const { listHeterogeneousAgentModels } = await importModule();

--- a/packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.ts
+++ b/packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.ts
@@ -21,6 +21,7 @@ const CODEBUDDY_MODEL_OPTION = '--model <model>';
 const CODEBUDDY_SUPPORTED_MODELS_LABEL = 'Currently supported:';
 const CURSOR_MODEL_ANNOTATIONS = [' (current)', ' (default)'] as const;
 const CURSOR_MODEL_ID_PATTERN = /^[A-Z0-9][\w./:@+-]*$/i;
+const GROK_MODEL_ID_PATTERN = /^[A-Z0-9][\w./:@+-]*$/i;
 const OPENCODE_MODEL_ID_PATTERN = /^[A-Z0-9][\w.-]*\/[A-Z0-9@][\w./:@+-]*$/i;
 const PI_MODEL_ROW_PATTERN = /^(\S+)\s{2,}(\S+)\s{2,}\S+\s{2,}\S+\s{2,}(?:yes|no)\s{2,}(?:yes|no)$/;
 const QODER_CUSTOM_MODEL_ROW_PATTERN = /^(.+?) \(([^()\s]+)\)$/;
@@ -75,6 +76,38 @@ export const parseCursorModelCatalog = (stdout: string): HeterogeneousAgentModel
 
     seen.add(id);
     models.push({ id, label, modelId: id, providerId: 'cursor' });
+  }
+
+  return models;
+};
+
+/** Parse the model rows emitted by `grok models`. */
+export const parseGrokBuildModelCatalog = (stdout: string): HeterogeneousAgentModel[] => {
+  const seen = new Set<string>();
+  const models: HeterogeneousAgentModel[] = [];
+
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine
+      .trim()
+      .replace(/^[*>•✓-]\s*/, '')
+      .replace(/ \((?:current|default)\)$/, '');
+    const separatorIndex = line.search(/\s{2}/);
+    const id = (separatorIndex < 0 ? line : line.slice(0, separatorIndex)).trim();
+    if (!GROK_MODEL_ID_PATTERN.test(id)) continue;
+
+    if (id.toLowerCase() === 'model' || id.toLowerCase() === 'models' || seen.has(id)) continue;
+
+    const label = (separatorIndex < 0 ? '' : line.slice(separatorIndex).trim())
+      .replaceAll(' (current)', '')
+      .replaceAll(' (default)', '')
+      .trim();
+    seen.add(id);
+    models.push({
+      id,
+      ...(label ? { label } : {}),
+      modelId: id,
+      providerId: 'grok-build',
+    });
   }
 
   return models;
@@ -219,7 +252,7 @@ export const listHeterogeneousAgentModels = async (
     const args =
       params.type === 'codebuddy'
         ? ['--help']
-        : params.type === 'opencode'
+        : params.type === 'grok-build' || params.type === 'opencode'
           ? ['models']
           : ['--list-models'];
     const spawnPlan = await resolveCliSpawnPlan(resolved.command, args);
@@ -254,11 +287,13 @@ export const listHeterogeneousAgentModels = async (
       models:
         params.type === 'cursor'
           ? parseCursorModelCatalog(String(stdout))
-          : params.type === 'pi'
-            ? parsePiModelCatalog(String(stdout))
-            : params.type === 'qoder'
-              ? parseQoderModelCatalog(String(stdout))
-              : parseOpenCodeModelCatalog(String(stdout)),
+          : params.type === 'grok-build'
+            ? parseGrokBuildModelCatalog(String(stdout))
+            : params.type === 'pi'
+              ? parsePiModelCatalog(String(stdout))
+              : params.type === 'qoder'
+                ? parseQoderModelCatalog(String(stdout))
+                : parseOpenCodeModelCatalog(String(stdout)),
       status: 'success',
       updatedAt,
     };

--- a/packages/heterogeneous-agents/src/spawn/grokAcpSession.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/grokAcpSession.test.ts
@@ -115,6 +115,10 @@ const createAcpProcess = ({
             send({ id: message.id, jsonrpc: '2.0', result: {} });
             return;
           }
+          case 'session/set_model': {
+            send({ id: message.id, jsonrpc: '2.0', result: {} });
+            return;
+          }
           case 'session/prompt': {
             promptRequest = message;
             stdout.write('not-json\n');
@@ -374,25 +378,56 @@ describe('GrokAcpSession', () => {
     expect(statuses.map(({ state }) => state)).toEqual(['starting', 'running', 'idle', 'closed']);
   });
 
-  it('loads resumed sessions with noReplay', async () => {
+  it('loads resumed sessions, reapplies model and effort, then prompts', async () => {
     const { child, requests } = createAcpProcess();
     spawnMock.mockReturnValue(child);
     vi.spyOn(process, 'kill').mockImplementation(() => true);
-    const { session, sessionIds } = createSession({ resumeSessionId: 'existing-session' });
+    const { session, sessionIds } = createSession({
+      args: ['--model=grok-4.6', '--reasoning-effort', 'high'],
+      resumeSessionId: 'existing-session',
+    });
 
     await session.run();
 
     expect(requests.map(({ method }) => method).includes('session/new')).toBe(false);
+    expect(
+      requests.map(({ method }) => method).filter((method) => method?.startsWith('session/')),
+    ).toEqual(['session/load', 'session/set_model', 'session/prompt']);
     expect(requests.find(({ method }) => method === 'session/load')?.params).toEqual({
       _meta: { noReplay: true },
       cwd: '/workspace',
       mcpServers: [],
       sessionId: 'existing-session',
     });
+    expect(requests.find(({ method }) => method === 'session/set_model')?.params).toEqual({
+      _meta: { reasoningEffort: 'high' },
+      modelId: 'grok-4.6',
+      sessionId: 'existing-session',
+    });
     expect(requests.find(({ method }) => method === 'session/prompt')?.params).toMatchObject({
       sessionId: 'existing-session',
     });
     expect(sessionIds).toEqual(['existing-session']);
+  });
+
+  it('applies an effort-only override while loading a resumed session', async () => {
+    const { child, requests } = createAcpProcess();
+    spawnMock.mockReturnValue(child);
+    vi.spyOn(process, 'kill').mockImplementation(() => true);
+    const { session } = createSession({
+      args: ['--effort', 'high'],
+      resumeSessionId: 'existing-session',
+    });
+
+    await session.run();
+
+    expect(requests.find(({ method }) => method === 'session/load')?.params).toEqual({
+      _meta: { noReplay: true, reasoningEffort: 'high' },
+      cwd: '/workspace',
+      mcpServers: [],
+      sessionId: 'existing-session',
+    });
+    expect(requests.some(({ method }) => method === 'session/set_model')).toBe(false);
   });
 
   it('falls back to a supported advertised auth method when the default is unsupported', async () => {

--- a/packages/heterogeneous-agents/src/spawn/grokAcpSession.ts
+++ b/packages/heterogeneous-agents/src/spawn/grokAcpSession.ts
@@ -1,6 +1,7 @@
 import { pathToFileURL } from 'node:url';
 
 import type { AgentStreamEvent } from '@lobechat/agent-gateway-client';
+import { getAnyCliFlagValue, GROK_BUILD_REASONING_EFFORT_FLAGS } from '@lobechat/types';
 
 import type { AgentPromptInput } from '../protocol';
 import type { AcpRpcMessage } from './acpStdioClient';
@@ -13,6 +14,7 @@ import { normalizeImage } from './input';
 const ACP_PROTOCOL_VERSION = 1;
 const ACP_CANCEL_GRACE_MS = 2_000;
 const GROK_ACP_TRANSPORT = 'acp-stdio' as const;
+const GROK_MODEL_FLAGS = ['-m', '--model'] as const;
 const SUPPORTED_AUTH_METHODS = ['cached_token', 'xai.api_key'] as const;
 
 interface AcpTextContentBlock {
@@ -173,9 +175,17 @@ export class GrokAcpSession {
       }
 
       let acpSessionId: string;
+      const model = getAnyCliFlagValue(this.options.args, GROK_MODEL_FLAGS)?.trim();
+      const effort = getAnyCliFlagValue(
+        this.options.args,
+        GROK_BUILD_REASONING_EFFORT_FLAGS,
+      )?.trim();
       if (this.options.resumeSessionId) {
         await this.client.request('session/load', {
-          _meta: { noReplay: true },
+          _meta: {
+            noReplay: true,
+            ...(effort && !model ? { reasoningEffort: effort } : {}),
+          },
           cwd: this.options.cwd,
           mcpServers: [],
           sessionId: this.options.resumeSessionId,
@@ -189,6 +199,14 @@ export class GrokAcpSession {
         });
         if (!session.sessionId) throw new Error('Grok Build ACP returned no session id');
         acpSessionId = session.sessionId;
+      }
+
+      if (this.options.resumeSessionId && model) {
+        await this.client.request('session/set_model', {
+          ...(effort ? { _meta: { reasoningEffort: effort } } : {}),
+          modelId: model,
+          sessionId: acpSessionId,
+        });
       }
 
       this.acpSessionId = acpSessionId;

--- a/packages/types/src/agent/agencyConfig.test.ts
+++ b/packages/types/src/agent/agencyConfig.test.ts
@@ -169,6 +169,45 @@ describe('buildHeteroSpawnArgs', () => {
     ).toEqual(['--model', 'gpt-5']);
   });
 
+  it('forwards Grok Build model and effort through direct ACP and device execution', () => {
+    const provider: HeterogeneousProviderConfig = {
+      args: ['--no-subagents'],
+      effort: 'xhigh',
+      model: 'grok-4.6',
+      type: 'grok-build',
+    };
+
+    expect(buildHeteroSpawnArgs(provider)).toEqual([
+      '--no-subagents',
+      '--model',
+      'grok-4.6',
+      '--effort',
+      'xhigh',
+    ]);
+    expect(buildHeteroExecArgs(provider)).toEqual([
+      '--agent-arg=--no-subagents',
+      '--agent-arg=--model',
+      '--agent-arg=grok-4.6',
+      '--agent-arg=--effort',
+      '--agent-arg=xhigh',
+    ]);
+  });
+
+  it('keeps native Grok Build selector flags authoritative', () => {
+    const provider: HeterogeneousProviderConfig = {
+      args: ['-m=grok-build', '--reasoning-effort=low'],
+      effort: 'high',
+      model: 'grok-4.6',
+      type: 'grok-build',
+    };
+
+    expect(buildHeteroSpawnArgs(provider)).toEqual(['-m=grok-build', '--reasoning-effort=low']);
+    expect(buildHeteroExecArgs(provider)).toEqual([
+      '--agent-arg=-m=grok-build',
+      '--agent-arg=--reasoning-effort=low',
+    ]);
+  });
+
   it('keeps TRAE model selection in the wrapper instead of native process arguments', () => {
     const provider: HeterogeneousProviderConfig = {
       args: ['--feature', 'test'],

--- a/packages/types/src/agent/agencyConfig.ts
+++ b/packages/types/src/agent/agencyConfig.ts
@@ -12,6 +12,7 @@ import type {
   ClaudeCodeReasoningEffort,
   CodexReasoningEffort,
   CodexSpeedMode,
+  GrokBuildReasoningEffort,
   HeteroCliEncoding,
   HeterogeneousAgentMode,
   HeterogeneousReasoningEffort,
@@ -21,12 +22,14 @@ import type {
 import {
   CODEX_REASONING_EFFORT_CONFIG_KEY,
   CODEX_SERVICE_TIER_CONFIG_KEY,
+  GROK_BUILD_REASONING_EFFORT_FLAGS,
   HETERO_SELECTOR_CAPABILITIES,
   HETEROGENEOUS_AGENT_DEFAULT_SELECTION,
   isAmpAgentMode,
   isClaudeCodeReasoningEffort,
   isCodexFastServiceTier,
   isCodexReasoningEffort,
+  isGrokBuildReasoningEffort,
   isQoderReasoningEffort,
   QODER_REASONING_EFFORT_FLAG,
 } from './heteroSelectorCapabilities';
@@ -51,7 +54,7 @@ export interface ListHeterogeneousAgentModelsParams {
   command?: string;
   cwd?: string;
   env?: Record<string, string>;
-  type: 'codebuddy' | 'cursor' | 'opencode' | 'pi' | 'qoder' | 'trae';
+  type: 'codebuddy' | 'cursor' | 'grok-build' | 'opencode' | 'pi' | 'qoder' | 'trae';
 }
 
 export interface HeterogeneousAgentModelCatalogSuccess {
@@ -226,6 +229,12 @@ interface CodexSelectionSource {
   speed?: string | null;
 }
 
+interface GrokBuildSelectionSource {
+  args?: string[];
+  effort?: string | null;
+  model?: string | null;
+}
+
 interface QoderSelectionSource {
   args?: string[];
   effort?: string | null;
@@ -234,13 +243,16 @@ interface QoderSelectionSource {
 
 const HETERO_EXEC_AGENT_ARG_FLAG = '--agent-arg';
 
-const modelFlagsOf = (type: 'codex' | 'opencode' | 'pi' | 'qoder'): readonly string[] =>
+const modelFlagsOf = (
+  type: 'codex' | 'grok-build' | 'opencode' | 'pi' | 'qoder',
+): readonly string[] =>
   HETERO_SELECTOR_CAPABILITIES[type].model.encodings.flatMap((encoding: HeteroCliEncoding) =>
     encoding.kind === 'flag' ? encoding.flags : [],
   );
 
 const CODEX_MODEL_FLAGS = modelFlagsOf('codex');
 const CURSOR_MODEL_FLAGS = ['--model'] as const;
+const GROK_BUILD_MODEL_FLAGS = modelFlagsOf('grok-build');
 const OPENCODE_MODEL_FLAGS = modelFlagsOf('opencode');
 const PI_MODEL_FLAGS = modelFlagsOf('pi');
 const QODER_MODEL_FLAGS = modelFlagsOf('qoder');
@@ -278,6 +290,13 @@ const getExplicitCodexReasoningEffort = (
 ): CodexReasoningEffort | undefined => {
   const effort = source?.effort?.trim();
   return isCodexReasoningEffort(effort) ? effort : undefined;
+};
+
+const getExplicitGrokBuildReasoningEffort = (
+  source: GrokBuildSelectionSource | null | undefined,
+): GrokBuildReasoningEffort | undefined => {
+  const effort = source?.effort?.trim();
+  return isGrokBuildReasoningEffort(effort) ? effort : undefined;
 };
 
 const getExplicitQoderReasoningEffort = (
@@ -321,6 +340,7 @@ export const buildHeteroSpawnArgs = (
     provider.type !== 'codebuddy' &&
     provider.type !== 'codex' &&
     provider.type !== 'cursor' &&
+    provider.type !== 'grok-build' &&
     provider.type !== 'kimi-code' &&
     provider.type !== 'opencode' &&
     provider.type !== 'pi' &&
@@ -363,6 +383,21 @@ export const buildHeteroSpawnArgs = (
     const speed = getExplicitCodexSpeedMode(provider);
     if (speed && !hasCliConfigKey(baseArgs, CODEX_SERVICE_TIER_CONFIG_KEY)) {
       extraArgs.push('-c', `${CODEX_SERVICE_TIER_CONFIG_KEY}="${speed}"`);
+    }
+  }
+
+  if (provider.type === 'grok-build') {
+    const model = provider.model?.trim();
+    if (
+      model &&
+      model !== HETEROGENEOUS_AGENT_DEFAULT_SELECTION &&
+      !hasAnyCliFlag(baseArgs, GROK_BUILD_MODEL_FLAGS)
+    ) {
+      extraArgs.push('--model', model);
+    }
+    const effort = getExplicitGrokBuildReasoningEffort(provider);
+    if (effort && !hasAnyCliFlag(baseArgs, GROK_BUILD_REASONING_EFFORT_FLAGS)) {
+      extraArgs.push('--effort', effort);
     }
   }
 
@@ -440,6 +475,7 @@ export const buildHeteroExecArgs = (
     provider.type !== 'codebuddy' &&
     provider.type !== 'codex' &&
     provider.type !== 'cursor' &&
+    provider.type !== 'grok-build' &&
     provider.type !== 'kimi-code' &&
     provider.type !== 'opencode' &&
     provider.type !== 'pi' &&
@@ -496,6 +532,27 @@ export const buildHeteroExecArgs = (
       !hasCliConfigKey(baseArgs, CODEX_SERVICE_TIER_CONFIG_KEY)
     ) {
       selectorArgs.push('--speed', speed);
+    }
+  }
+
+  if (provider.type === 'grok-build') {
+    const model = provider.model?.trim();
+    if (
+      model &&
+      model !== HETEROGENEOUS_AGENT_DEFAULT_SELECTION &&
+      !hasAnyCliFlag(baseArgs, GROK_BUILD_MODEL_FLAGS)
+    ) {
+      wrapperArgs.push(
+        `${HETERO_EXEC_AGENT_ARG_FLAG}=--model`,
+        `${HETERO_EXEC_AGENT_ARG_FLAG}=${model}`,
+      );
+    }
+    const effort = getExplicitGrokBuildReasoningEffort(provider);
+    if (effort && !hasAnyCliFlag(baseArgs, GROK_BUILD_REASONING_EFFORT_FLAGS)) {
+      wrapperArgs.push(
+        `${HETERO_EXEC_AGENT_ARG_FLAG}=--effort`,
+        `${HETERO_EXEC_AGENT_ARG_FLAG}=${effort}`,
+      );
     }
   }
 

--- a/packages/types/src/agent/heteroSelectorCapabilities.test.ts
+++ b/packages/types/src/agent/heteroSelectorCapabilities.test.ts
@@ -16,6 +16,7 @@ describe('selector availability', () => {
     expect(isHeteroSelectorAvailable('codebuddy')).toBe(true);
     expect(isHeteroSelectorAvailable('codex')).toBe(true);
     expect(isHeteroSelectorAvailable('cursor')).toBe(true);
+    expect(isHeteroSelectorAvailable('grok-build')).toBe(true);
     expect(isHeteroSelectorAvailable('opencode')).toBe(true);
     expect(isHeteroSelectorAvailable('pi')).toBe(true);
     expect(isHeteroSelectorAvailable('qoder')).toBe(true);
@@ -37,6 +38,13 @@ describe('selector availability', () => {
     expect(getHeteroSelectorCapability('claude-code')?.speed).toBeUndefined();
     expect(getHeteroSelectorCapability('codex')?.speed).toBeDefined();
     expect(getHeteroSelectorCapability('cursor')?.model?.source).toBe('catalog');
+    expect(getHeteroSelectorCapability('grok-build')?.model?.source).toBe('catalog');
+    expect(getHeteroSelectorCapability('grok-build')?.effort?.levels('grok-4.6')).toEqual([
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+    ]);
     expect(getHeteroSelectorCapability('opencode')?.effort).toBeUndefined();
     expect(getHeteroSelectorCapability('qoder')?.effort).toBeDefined();
     expect(getHeteroSelectorCapability('codex')?.model?.source).toBe('static');
@@ -132,6 +140,27 @@ describe('applyHeteroSelection', () => {
       'plan',
       '--model',
       'claude-sonnet-4-6-thinking',
+    ]);
+  });
+
+  it('clears Grok Build model and effort flags before applying a selection', () => {
+    const provider: HeterogeneousProviderConfig = {
+      args: ['-m', 'old-model', '--reasoning-effort=low', '--no-subagents'],
+      type: 'grok-build',
+    };
+    const patch = applyHeteroSelection(provider, { effort: 'xhigh', model: 'grok-4.6' });
+
+    expect(patch).toEqual({
+      args: ['--no-subagents'],
+      effort: 'xhigh',
+      model: 'grok-4.6',
+    });
+    expect(buildHeteroSpawnArgs({ ...provider, ...patch })).toEqual([
+      '--no-subagents',
+      '--model',
+      'grok-4.6',
+      '--effort',
+      'xhigh',
     ]);
   });
 

--- a/packages/types/src/agent/heteroSelectorCapabilities.ts
+++ b/packages/types/src/agent/heteroSelectorCapabilities.ts
@@ -32,6 +32,13 @@ const CLAUDE_CODE_REASONING_EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', '
 
 export type ClaudeCodeReasoningEffort = (typeof CLAUDE_CODE_REASONING_EFFORT_LEVELS)[number];
 
+/** Grok Build reasoning-effort levels accepted by the CLI's `--effort` flag. */
+const GROK_BUILD_REASONING_EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh'] as const;
+
+export type GrokBuildReasoningEffort = (typeof GROK_BUILD_REASONING_EFFORT_LEVELS)[number];
+
+export const GROK_BUILD_REASONING_EFFORT_FLAGS = ['--effort', '--reasoning-effort'] as const;
+
 /**
  * Codex reasoning-effort levels, mirrored to the CLI config key
  * `model_reasoning_effort`.
@@ -67,7 +74,10 @@ export type QoderReasoningEffort = (typeof QODER_REASONING_EFFORT_LEVELS)[number
 export const QODER_REASONING_EFFORT_FLAG = '--reasoning-effort';
 
 export type HeterogeneousReasoningEffortLevel =
-  ClaudeCodeReasoningEffort | CodexReasoningEffort | QoderReasoningEffort;
+  | ClaudeCodeReasoningEffort
+  | CodexReasoningEffort
+  | GrokBuildReasoningEffort
+  | QoderReasoningEffort;
 
 export type HeterogeneousReasoningEffort =
   HeterogeneousReasoningEffortLevel | HeterogeneousAgentDefaultSelection;
@@ -115,6 +125,11 @@ export const isClaudeCodeReasoningEffort = (
 
 export const isCodexReasoningEffort = (value: string | undefined): value is CodexReasoningEffort =>
   !!value && CODEX_REASONING_EFFORT_LEVELS.includes(value as CodexReasoningEffort);
+
+export const isGrokBuildReasoningEffort = (
+  value: string | undefined,
+): value is GrokBuildReasoningEffort =>
+  !!value && GROK_BUILD_REASONING_EFFORT_LEVELS.includes(value as GrokBuildReasoningEffort);
 
 export const isQoderReasoningEffort = (value: string | undefined): value is QoderReasoningEffort =>
   !!value && QODER_REASONING_EFFORT_LEVELS.includes(value as QoderReasoningEffort);
@@ -214,6 +229,15 @@ export const resolveCodexSpeedMode = (
   )?.trim();
 
   return isCodexFastServiceTier(tier) ? 'fast' : HETEROGENEOUS_AGENT_DEFAULT_SELECTION;
+};
+
+const resolveGrokBuildReasoningEffort = (
+  source: HeteroSelectionSource | null | undefined,
+): GrokBuildReasoningEffort | HeterogeneousAgentDefaultSelection => {
+  const effort = (
+    getAnyCliFlagValue(source?.args, GROK_BUILD_REASONING_EFFORT_FLAGS) ?? source?.effort
+  )?.trim();
+  return isGrokBuildReasoningEffort(effort) ? effort : HETEROGENEOUS_AGENT_DEFAULT_SELECTION;
 };
 
 const resolveQoderReasoningEffort = (
@@ -355,7 +379,18 @@ export const HETERO_SELECTOR_CAPABILITIES = {
       source: 'catalog',
     },
   },
-  'grok-build': {},
+  'grok-build': {
+    effort: {
+      encodings: [{ flags: GROK_BUILD_REASONING_EFFORT_FLAGS, kind: 'flag' }],
+      levels: () => GROK_BUILD_REASONING_EFFORT_LEVELS,
+      resolve: resolveGrokBuildReasoningEffort,
+    },
+    model: {
+      encodings: [MODEL_FLAGS_ENCODING],
+      resolve: resolvePersistedModel,
+      source: 'catalog',
+    },
+  },
   'kimi-code': {},
   'opencode': {
     model: { encodings: [MODEL_FLAGS_ENCODING], resolve: resolvePersistedModel, source: 'catalog' },

--- a/src/features/ChatInput/ControlBar/HeteroModel/useModelCatalog.test.ts
+++ b/src/features/ChatInput/ControlBar/HeteroModel/useModelCatalog.test.ts
@@ -21,7 +21,7 @@ describe('useModelCatalog', () => {
     vi.restoreAllMocks();
   });
 
-  it.each(['codebuddy', 'cursor', 'opencode', 'pi', 'qoder', 'trae'] as const)(
+  it.each(['codebuddy', 'cursor', 'grok-build', 'opencode', 'pi', 'qoder', 'trae'] as const)(
     'starts loading the %s catalog as soon as the selector mounts',
     async (type) => {
       const pendingCatalog = new Promise<


### PR DESCRIPTION
## Description of Change

Add model and reasoning-effort selection for the Grok Build heterogeneous agent.

- Discover available models through `grok models`
- Expose `low`, `medium`, `high`, and `xhigh` reasoning effort options
- Forward selections through local ACP and remote device execution while preserving raw agent arguments as authoritative
- Reapply model and effort overrides when resuming ACP sessions
- Support both `--effort` and the canonical `--reasoning-effort` spelling

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation:

- `bun run check`: 237 tests passed, lint clean
- `bun run check --type`: types clean
- Verified `@xai-official/grok@1.0.5` accepts the generated `--model` and `--effort` arguments

#### 🔗 Related Issue

No matching issue found.
