### PR TITLE
📝 docs(device-gateway): remove stale implementation references

### DIFF
--- a/.agents/skills/project-overview/SKILL.md
+++ b/.agents/skills/project-overview/SKILL.md
@@ -56,7 +56,6 @@ git submodules.
 ├── apps/
 │   ├── cli/                  # LobeHub CLI
 │   ├── desktop/              # Electron desktop app
-│   ├── device-gateway/       # Device gateway service
 │   └── server/               # Next.js-backed server (`@/server/*` alias)
 │       └── src/
 │           ├── router-hono/  # Hono endpoint routers and standalone runtime

--- a/packages/database/src/schemas/device.ts
+++ b/packages/database/src/schemas/device.ts
@@ -11,9 +11,9 @@ import { workspaces } from './workspace';
  *
  * `deviceId` is derived from a machine-level identifier
  * (`sha256(machineUUID + userId + salt)`), so it survives LobeHub reinstalls
- * and desktop upgrades. Online status is NOT stored here — it lives in the
- * DeviceGatewayDO in-memory WS attachments; this table only records "ever
- * seen" so offline devices stay visible and bindable.
+ * and desktop upgrades. Online status is NOT stored here — it belongs to the
+ * device gateway's live connection state; this table only records "ever seen"
+ * so offline devices stay visible and bindable.
  */
 export const devices = pgTable(
   'devices',

--- a/packages/device-gateway-client/src/types.ts
+++ b/packages/device-gateway-client/src/types.ts
@@ -240,8 +240,8 @@ export interface AgentRunRequestMessage {
   /**
    * Full system context used only when native resume fails and the device CLI
    * retries with a fresh session. Optional for compatibility with older
-   * servers and devices. Self-hosted gateways must forward this optional field;
-   * older gateways safely degrade to a fresh retry without recovery history.
+   * servers and devices. The gateway relay must preserve this optional field;
+   * older deployments safely degrade to a fresh retry without recovery history.
    */
   resumeFallbackSystemContext?: string;
   resumeSessionId?: string;


### PR DESCRIPTION
## Description of Change

Remove stale and implementation-specific device gateway references that could mislead maintainers about the current repository layout or gateway ownership:

- remove the deleted `apps/device-gateway` entry from the project overview skill
- describe device online state without referring to the historical `DeviceGatewayDO` implementation
- express optional payload forwarding as a relay protocol requirement rather than a self-hosted implementation detail

No runtime behavior changes.

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Validated with:

```text
bun run check .agents/skills/project-overview/SKILL.md packages/database/src/schemas/device.ts packages/device-gateway-client/src/types.ts
✓ 3 files · lint clean · tests none
```

#### 🔗 Related Issue

No related issue found.
