### PR TITLE
💄 style(task): keep the task detail page on a constrained reading column

### DIFF
--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailPage.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailPage.tsx
@@ -104,7 +104,10 @@ const TaskDetailPage = memo<TaskDetailPageProps>(({ taskId, showTaskAgentPanelTo
         }}
       />
       <Flexbox flex={1} style={{ minHeight: 0, overflowY: 'auto' }}>
-        <WideScreenContainer fullWidth paddingInline={16}>
+        {/* Detail is prose — instruction, deliverables, activity — so it keeps the
+            centered reading column rather than the list page's full-bleed rows,
+            whose value is the horizontal room for their metadata columns. */}
+        <WideScreenContainer>
           {isInitialLoading ? <TaskDetailSkeleton /> : <TaskDetailSections />}
         </WideScreenContainer>
       </Flexbox>


### PR DESCRIPTION
#18397 gave the task detail page the same full-bleed layout as the task list. The two pages want opposite things: a list row earns its width from the metadata columns it lines up, while detail is prose — instruction, deliverables, activity. On a wide display the description stretched into a very long measure and the status card was marooned at the far right, far from the title it describes.

This drops `fullWidth` so detail goes back to `WideScreenContainer`'s centered `min(CONVERSATION_MIN_WIDTH, 100%)` column. The explicit `paddingInline={16}` goes with it — the component already applies exactly that in non-full-width mode, so removing both props restores the pre-#18397 rendering byte for byte.

The task **list** page keeps its full-bleed layout; only the detail page changes. Users who have the wide-screen preference on still get 100% width, as before.

| Before | After |
| ------ | ----- |
| Detail content spans the full window; long description lines, status card pinned to the far right | Detail returns to the centered reading column shared with the rest of the app |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Lint is clean on the changed file. No regression test: this is a pure layout-prop change whose only practical assertion would be source-string matching on the rendered style, which is not a test worth shipping (per `AGENTS.md`). I was not able to attach a rendered screenshot — a fresh worktree install could not boot the dev server (unrelated `@aws-sdk/client-s3` / React-dispatcher resolution failures, every route 500) — so the change is verified by lint plus an exact source comparison against the pre-#18397 revision, not by a captured render. Worth a look at the preview deployment before merging.

#### 🔗 Related Issue

Reverts the task-detail half of #18397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)