### PR TITLE
🐛 fix(heterogeneous-agent): detect TRAE CLI on Windows

### DIFF
--- a/packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts
@@ -117,6 +117,21 @@ describe('cliSpawn', () => {
     expect(execFileMock).not.toHaveBeenCalled();
   });
 
+  it('resolves the TRAE Windows shim that uses the native %~dp0 batch expansion', async () => {
+    platformMock.mockReturnValue('win32');
+    const shimPath = 'C:\\Users\\Hanam\\AppData\\Local\\Programs\\TraeCLI\\bin\\traecli.cmd';
+    const exePath = 'C:\\Users\\Hanam\\AppData\\Local\\Programs\\TraeCLI\\bin\\traex.exe';
+    existingPaths(shimPath, exePath);
+    readFileMock.mockResolvedValue('@echo off\r\n"%~dp0traex.exe" %*\r\n');
+
+    const { resolveCliSpawnPlan } = await import('./cliSpawn');
+    await expect(resolveCliSpawnPlan(shimPath, ['acp', 'serve'])).resolves.toEqual({
+      args: ['acp', 'serve'],
+      command: exePath,
+    });
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
   it('resolves a .cmd npm shim that invokes node.exe plus a JS bin', async () => {
     platformMock.mockReturnValue('win32');
     const shimPath = 'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\gemini.cmd';

--- a/packages/heterogeneous-agents/src/spawn/cliSpawn.ts
+++ b/packages/heterogeneous-agents/src/spawn/cliSpawn.ts
@@ -115,8 +115,16 @@ const resolveShimPathToken = (shimPath: string, token: string): string | undefin
     );
   }
 
-  if (lowerToken.startsWith('%dp0%')) {
-    return joinShimRelativePath(shimPath, trimmedToken.slice('%dp0%'.length).replace(/^[\\/]/, ''));
+  const shimDirectoryPrefix = lowerToken.startsWith('%~dp0')
+    ? '%~dp0'
+    : lowerToken.startsWith('%dp0%')
+      ? '%dp0%'
+      : undefined;
+  if (shimDirectoryPrefix) {
+    return joinShimRelativePath(
+      shimPath,
+      trimmedToken.slice(shimDirectoryPrefix.length).replace(/^[\\/]/, ''),
+    );
   }
 
   if (path.win32.isAbsolute(trimmedToken)) return trimmedToken;
@@ -183,7 +191,7 @@ const inferWindowsNodeScriptFromShim = async (
   const patterns: Array<RegExp | [RegExp, string]> = [
     /exec\s+"(\$basedir[^"]*node(?:\.exe)?)"\s+"([^"]+)"/i,
     /exec\s+(node(?:\.exe)?)\s+"([^"]+)"/i,
-    /"(%dp0%[^"]*node(?:\.exe)?)"\s+"([^"]+)"/i,
+    /"(%(?:~dp0|dp0%)[^"]*node(?:\.exe)?)"\s+"([^"]+)"/i,
     /"(%_prog%)"\s+"([^"]+)"/i,
     [/(?:^|\r?\n)\s*(node(?:\.exe)?)\s+"([^"]+)"/i, 'node'],
   ];
@@ -208,7 +216,7 @@ const inferWindowsExecutableFromShim = async (
 ): Promise<WindowsShimTarget | undefined> => {
   const matches = [
     ...source.matchAll(/\$basedir[\\/]([^"\s]+?\.exe)/gi),
-    ...source.matchAll(/%dp0%\\([^"\r\n]+?\.exe)/gi),
+    ...source.matchAll(/%(?:~dp0|dp0%)[\\/]?([^"\r\n]+?\.exe)/gi),
   ];
 
   for (const match of matches) {

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
@@ -755,7 +755,38 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
       }
     });
 
-    it('finds TRAE in its official Windows install directory when PATH is missing it', async () => {
+    it('finds the current TRAE public CLI executable when PATH is missing it', async () => {
+      const originalLocalAppData = process.env.LOCALAPPDATA;
+      const originalPath = process.env.PATH;
+      const localAppData = 'C:\\Users\\x\\AppData\\Local';
+      const traeCli = `${localAppData}\\Programs\\TraeCLI\\bin\\traex.exe`;
+      process.env.LOCALAPPDATA = localAppData;
+      process.env.PATH = 'C:\\Windows';
+
+      try {
+        existingFiles({ [traeCli]: true });
+        callExecFileError(new Error('not found')); // where traecli
+        callExecFileError(new Error('no registry')); // reg query HKLM
+        callExecFileError(new Error('no registry')); // reg query HKCU
+        callExecFile('traecli 0.201.2 (public edition)');
+        callExecFile(TRAE_ACP_HELP);
+
+        const { detectHeterogeneousCliCommand } = await importModule();
+        const status = await detectHeterogeneousCliCommand('trae', 'traecli');
+
+        expect(status).toMatchObject({
+          available: true,
+          path: traeCli,
+          version: '0.201.2',
+        });
+      } finally {
+        process.env.PATH = originalPath;
+        if (originalLocalAppData === undefined) delete process.env.LOCALAPPDATA;
+        else process.env.LOCALAPPDATA = originalLocalAppData;
+      }
+    });
+
+    it('still finds TRAE in its legacy Windows install directory', async () => {
       const originalLocalAppData = process.env.LOCALAPPDATA;
       const originalPath = process.env.PATH;
       const localAppData = 'C:\\Users\\x\\AppData\\Local';
@@ -768,6 +799,7 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
         callExecFileError(new Error('not found')); // where traecli
         callExecFileError(new Error('no registry')); // reg query HKLM
         callExecFileError(new Error('no registry')); // reg query HKCU
+        callExecFileError(new Error('not found')); // current Programs/TraeCLI/bin/traex.exe
         callExecFile('trae-cli version 0.120.52');
         callExecFile(TRAE_ACP_HELP);
 

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
@@ -713,8 +713,13 @@ const getWellKnownCommandPaths = (agentType: HeterogeneousCliAgentType): string[
         const localAppData = process.env.LOCALAPPDATA;
         if (!localAppData) return [];
 
-        const binDir = path.win32.join(localAppData, 'trae-cli', 'bin');
-        return [path.win32.join(binDir, 'traecli.exe'), path.win32.join(binDir, 'trae-cli.exe')];
+        const currentBinDir = path.win32.join(localAppData, 'Programs', 'TraeCLI', 'bin');
+        const legacyBinDir = path.win32.join(localAppData, 'trae-cli', 'bin');
+        return [
+          path.win32.join(currentBinDir, 'traex.exe'),
+          path.win32.join(legacyBinDir, 'traecli.exe'),
+          path.win32.join(legacyBinDir, 'trae-cli.exe'),
+        ];
       }
       if (platform() !== 'darwin' && platform() !== 'linux') return [];
 


### PR DESCRIPTION
## Brief

Fix TRAE CLI detection and launching for the current Windows public distribution.

- Resolve TRAE's `traecli.cmd` / `trae-cli.cmd` wrappers that use the native `%~dp0traex.exe` batch expansion to the underlying executable, without routing agent arguments through `cmd.exe`.
- Probe `%LOCALAPPDATA%\Programs\TraeCLI\bin\traex.exe` when TRAE is not discoverable on `PATH`.
- Preserve the legacy `%LOCALAPPDATA%\trae-cli\bin` fallback paths.

No UI changes.

#### Test

```text
bun run check packages/heterogeneous-agents/src/spawn/cliSpawn.ts packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
✓ 4 files · lint clean · tests 63 passed
```

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

None.
