### PR TITLE
🐛 fix(topic): stop storing the raw JSON response as the title

### DIFF
--- a/apps/server/src/services/systemAgent/index.test.ts
+++ b/apps/server/src/services/systemAgent/index.test.ts
@@ -1,0 +1,60 @@
+import { TRACING_SCENARIOS } from '@lobechat/const';
+import { TOPIC_TITLE_JSON_SCHEMA, TOPIC_TITLE_PROMPT_VERSION } from '@lobechat/prompts';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SystemAgentService } from './index';
+
+const mocks = vi.hoisted(() => ({
+  generateObject: vi.fn(),
+  getInfoForAIGeneration: vi.fn(),
+  getUserSettings: vi.fn(),
+}));
+
+vi.mock('@/database/models/user', () => ({
+  UserModel: class {
+    static getInfoForAIGeneration = mocks.getInfoForAIGeneration;
+    getUserSettings = mocks.getUserSettings;
+  },
+}));
+vi.mock('@/server/modules/ModelRuntime', () => ({
+  initModelRuntimeFromDB: vi.fn(async () => ({ generateObject: mocks.generateObject })),
+}));
+
+describe('SystemAgentService.generateTopicTitle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getUserSettings.mockResolvedValue({ systemAgent: {} });
+    mocks.getInfoForAIGeneration.mockResolvedValue({ responseLanguage: 'en-US' });
+    mocks.generateObject.mockResolvedValue({ title: 'Account help' });
+  });
+
+  it('pairs the structured prompt with the schema it tells the model to match', async () => {
+    const service = new SystemAgentService({} as never, 'user-1');
+
+    const title = await service.generateTopicTitle({
+      lastAssistantContent: 'Sure, I can help with that.',
+      userPrompt: 'I need help with my account.',
+    });
+
+    expect(title).toBe('Account help');
+    const [request, options] = mocks.generateObject.mock.calls[0];
+    expect(request.schema).toBe(TOPIC_TITLE_JSON_SCHEMA);
+    expect(request.messages[0].content).toContain(
+      '- Return one JSON object with a single "title" string matching the supplied schema',
+    );
+    expect(options.tracing).toEqual({
+      promptVersion: TOPIC_TITLE_PROMPT_VERSION,
+      scenario: TRACING_SCENARIOS.TopicTitle,
+      schemaName: TOPIC_TITLE_JSON_SCHEMA.name,
+    });
+  });
+
+  it('returns null when the model yields no usable title', async () => {
+    mocks.generateObject.mockResolvedValue({ title: '   ' });
+    const service = new SystemAgentService({} as never, 'user-1');
+
+    await expect(
+      service.generateTopicTitle({ lastAssistantContent: 'Sure.', userPrompt: 'Help.' }),
+    ).resolves.toBeNull();
+  });
+});

--- a/apps/server/src/services/systemAgent/index.ts
+++ b/apps/server/src/services/systemAgent/index.ts
@@ -4,7 +4,7 @@ import { TRACING_SCENARIOS } from '@lobechat/const';
 import type { TracingOptions } from '@lobechat/llm-generation-tracing';
 import {
   chainGenerateSkillMeta,
-  chainSummaryTitle,
+  chainSummaryTitleStructured,
   GENERATE_SKILL_META_PROMPT_VERSION,
   GENERATE_SKILL_META_SCHEMA,
   GENERATE_SKILL_META_SCHEMA_NAME,
@@ -65,7 +65,7 @@ export class SystemAgentService {
         { content: lastAssistantContent, role: 'assistant' as const },
       ];
 
-      const payload = chainSummaryTitle(messages, locale);
+      const payload = chainSummaryTitleStructured(messages, locale);
 
       const modelRuntime = await initModelRuntimeFromDB(
         this.db,

--- a/packages/prompts/src/chains/__tests__/__snapshots__/summaryTitle.test.ts.snap
+++ b/packages/prompts/src/chains/__tests__/__snapshots__/summaryTitle.test.ts.snap
@@ -7,8 +7,7 @@ exports[`chainSummaryTitle > should use the default model if the token count is 
       "content": "You are a professional conversation summarizer. Generate a concise title that captures the essence of the conversation.
 
 Rules:
-- Return one JSON object with a single "title" string matching the supplied schema
-- No explanations or additional fields
+- Output ONLY the title text, no explanations or additional context
 - Maximum 15 words
 - Maximum 80 characters
 - No punctuation marks

--- a/packages/prompts/src/chains/__tests__/summaryTitle.test.ts
+++ b/packages/prompts/src/chains/__tests__/summaryTitle.test.ts
@@ -3,17 +3,44 @@ import { describe, expect, it } from 'vitest';
 
 import {
   chainSummaryTitle,
+  chainSummaryTitleStructured,
   TOPIC_TITLE_JSON_SCHEMA,
   TOPIC_TITLE_PROMPT_VERSION,
 } from '../summaryTitle';
 
+const messages: OpenAIChatMessage[] = [
+  { content: 'Hello, how can I assist you?', role: 'assistant' },
+  { content: 'I need help with my account.', role: 'user' },
+];
+
+const SHARED_RULES = [
+  '- Maximum 15 words',
+  '- Maximum 80 characters',
+  '- No punctuation marks',
+  '- Use the language specified by the locale code: zh-CN',
+  '- The title should accurately reflect the main topic of the conversation',
+  '- Keep it short and to the point',
+];
+
+const OUTPUT_RULES = [
+  '- Output ONLY the title text, no explanations or additional context',
+  '- Return one JSON object with a single "title" string matching the supplied schema',
+  '- No explanations or additional fields',
+];
+
+type TitlePayload = { messages: { content: string }[] };
+
+const systemPrompt = (payload: TitlePayload): string => payload.messages[0].content;
+const userPrompt = (payload: TitlePayload): string => payload.messages[1].content;
+const withoutOutputRules = (prompt: string): string =>
+  prompt
+    .split('\n')
+    .filter((line) => !OUTPUT_RULES.includes(line))
+    .join('\n');
+
 describe('chainSummaryTitle', () => {
   it('should use the default model if the token count is below the GPT-3.5 limit', async () => {
     // Arrange
-    const messages: OpenAIChatMessage[] = [
-      { content: 'Hello, how can I assist you?', role: 'assistant' },
-      { content: 'I need help with my account.', role: 'user' },
-    ];
     const currentLanguage = 'en-US';
 
     // Act
@@ -23,5 +50,44 @@ describe('chainSummaryTitle', () => {
     expect(result).toMatchSnapshot();
     expect(TOPIC_TITLE_PROMPT_VERSION).toBe('v1');
     expect(TOPIC_TITLE_JSON_SCHEMA.name).toBe('topic_title');
+  });
+
+  it('asks for plain text, because streaming consumers persist the response verbatim', () => {
+    const prompt = systemPrompt(chainSummaryTitle(messages, 'en-US'));
+
+    expect(prompt).toContain('- Output ONLY the title text, no explanations or additional context');
+    expect(prompt).not.toContain('JSON');
+    expect(prompt).not.toContain('schema');
+  });
+});
+
+describe('chainSummaryTitleStructured', () => {
+  it('asks for the object that TOPIC_TITLE_JSON_SCHEMA describes', () => {
+    const prompt = systemPrompt(chainSummaryTitleStructured(messages, 'en-US'));
+
+    expect(prompt).toContain(
+      '- Return one JSON object with a single "title" string matching the supplied schema',
+    );
+    expect(prompt).toContain('- No explanations or additional fields');
+    expect(prompt).not.toContain('Output ONLY the title text');
+  });
+
+  it('differs from the streaming variant only in the output rule', () => {
+    const streaming = systemPrompt(chainSummaryTitle(messages, 'zh-CN'));
+    const structured = systemPrompt(chainSummaryTitleStructured(messages, 'zh-CN'));
+
+    expect(withoutOutputRules(structured)).toBe(withoutOutputRules(streaming));
+    for (const rule of SHARED_RULES) {
+      expect(streaming).toContain(rule);
+      expect(structured).toContain(rule);
+    }
+  });
+
+  it('serializes every conversation turn identically for both variants', () => {
+    const streaming = userPrompt(chainSummaryTitle(messages, 'en-US'));
+
+    expect(userPrompt(chainSummaryTitleStructured(messages, 'en-US'))).toBe(streaming);
+    expect(streaming).toContain('<assistant>\nHello, how can I assist you?\n</assistant>');
+    expect(streaming).toContain('<user>\nI need help with my account.\n</user>');
   });
 });

--- a/packages/prompts/src/chains/summaryTitle.ts
+++ b/packages/prompts/src/chains/summaryTitle.ts
@@ -15,9 +15,21 @@ export const TOPIC_TITLE_JSON_SCHEMA = {
   strict: true,
 };
 
-export const chainSummaryTitle = (
+/**
+ * The output contract differs by transport. Streaming consumers persist the
+ * response text as the title itself, while `generateObject` consumers supply
+ * TOPIC_TITLE_JSON_SCHEMA and read the parsed `title` field.
+ */
+const PLAIN_TEXT_RULE = '- Output ONLY the title text, no explanations or additional context';
+const JSON_OBJECT_RULE = [
+  '- Return one JSON object with a single "title" string matching the supplied schema',
+  '- No explanations or additional fields',
+].join('\n');
+
+const buildTitleMessages = (
   messages: (UIChatMessage | OpenAIChatMessage)[],
   locale: string,
+  outputRule: string,
 ): { messages: Array<{ content: string; role: 'system' | 'user' }> } => {
   const conversationText = messages
     .map((message) => `<${message.role}>\n${String(message.content ?? '')}\n</${message.role}>`)
@@ -29,8 +41,7 @@ export const chainSummaryTitle = (
         content: `You are a professional conversation summarizer. Generate a concise title that captures the essence of the conversation.
 
 Rules:
-- Return one JSON object with a single "title" string matching the supplied schema
-- No explanations or additional fields
+${outputRule}
 - Maximum 15 words
 - Maximum 80 characters
 - No punctuation marks
@@ -46,3 +57,22 @@ Rules:
     ],
   };
 };
+
+/**
+ * Title prompt for streaming consumers, whose response text is written to the
+ * title verbatim — so it must not be wrapped in an object.
+ */
+export const chainSummaryTitle = (
+  messages: (UIChatMessage | OpenAIChatMessage)[],
+  locale: string,
+): { messages: Array<{ content: string; role: 'system' | 'user' }> } =>
+  buildTitleMessages(messages, locale, PLAIN_TEXT_RULE);
+
+/**
+ * Title prompt for `generateObject` consumers, paired with TOPIC_TITLE_JSON_SCHEMA.
+ */
+export const chainSummaryTitleStructured = (
+  messages: (UIChatMessage | OpenAIChatMessage)[],
+  locale: string,
+): { messages: Array<{ content: string; role: 'system' | 'user' }> } =>
+  buildTitleMessages(messages, locale, JSON_OBJECT_RULE);

--- a/src/store/chat/slices/thread/action.test.ts
+++ b/src/store/chat/slices/thread/action.test.ts
@@ -620,6 +620,51 @@ describe('thread action', () => {
       });
     });
 
+    it('requests a plain-text title, which is what gets persisted', async () => {
+      const { result } = renderHook(() => useChatStore());
+
+      const mockThread: ThreadItem = {
+        createdAt: new Date(),
+        id: 'thread-id',
+        lastActiveAt: new Date(),
+        sourceMessageId: 'msg-1',
+        status: ThreadStatus.Active,
+        title: 'Old Title',
+        topicId: 'test-topic-id',
+        type: ThreadType.Continuation,
+        updatedAt: new Date(),
+        userId: 'user-1',
+      };
+
+      act(() => {
+        useChatStore.setState({
+          portalThreadId: 'thread-id',
+          threadMaps: {
+            'test-topic-id': [mockThread],
+          },
+        });
+      });
+
+      (chatService.fetchPresetTaskResult as Mock).mockImplementation(async ({ onFinish }) => {
+        await onFinish?.('New Generated Title');
+      });
+      const internalUpdateSpy = vi
+        .spyOn(result.current, 'internal_updateThread')
+        .mockResolvedValue(undefined);
+
+      await act(async () => {
+        await result.current.summaryThreadTitle('thread-id', []);
+      });
+
+      // Same contract as the topic path: the streamed text becomes the title as-is.
+      const { params } = (chatService.fetchPresetTaskResult as Mock).mock.calls[0][0];
+      expect(String(params.messages[0].content)).toContain('Output ONLY the title text');
+      expect(String(params.messages[0].content)).not.toContain('JSON');
+      expect(internalUpdateSpy).toHaveBeenCalledWith('thread-id', {
+        title: 'New Generated Title',
+      });
+    });
+
     it('should show loading indicator during generation', async () => {
       const { result } = renderHook(() => useChatStore());
 

--- a/src/store/chat/slices/topic/action.test.ts
+++ b/src/store/chat/slices/topic/action.test.ts
@@ -2649,6 +2649,45 @@ describe('topic action', () => {
       expect(updateTopicTitleInSummarySpy).not.toHaveBeenCalledWith(topicId, 'Partial Title');
       expect(updateTopicSpy).toHaveBeenCalledWith(topicId, { title: 'Summarized Title' });
     });
+
+    it('requests a plain-text title, which is what gets persisted', async () => {
+      const topicId = 'topic-1';
+      const messages = [{ id: 'message-1', content: 'Hello' }] as UIChatMessage[];
+      const topics = [{ id: topicId, title: '' }] as ChatTopic[];
+      const { result } = renderHook(() => useChatStore());
+      await act(async () => {
+        useChatStore.setState({
+          topicDataMap: {
+            [topicMapKey({ agentId: 'test' })]: {
+              items: topics,
+              total: topics.length,
+              currentPage: 0,
+              hasMore: false,
+              pageSize: 20,
+            },
+          },
+          activeAgentId: 'test',
+        });
+      });
+
+      const fetchSpy = vi
+        .spyOn(chatService, 'fetchPresetTaskResult')
+        .mockImplementation(async (params) => {
+          await params?.onFinish?.('Summarized Title', { type: 'done' });
+        });
+      const updateTopicSpy = vi.spyOn(result.current, 'internal_updateTopic');
+
+      await act(async () => {
+        await result.current.summaryTopicTitle(topicId, messages);
+      });
+
+      // This path streams a plain completion and stores the text as the title, so an
+      // instruction to answer with a JSON object would be persisted verbatim.
+      const prompt = String(fetchSpy.mock.calls[0][0].params?.messages?.[0]?.content ?? '');
+      expect(prompt).toContain('Output ONLY the title text');
+      expect(prompt).not.toContain('JSON');
+      expect(updateTopicSpy).toHaveBeenCalledWith(topicId, { title: 'Summarized Title' });
+    });
   });
   describe('createTopic', () => {
     it('should create a new topic and update the store', async () => {


### PR DESCRIPTION
## Problem

Since #18445, a topic or thread title generated on the streaming path is stored as the model's raw response instead of the title text, and persisted — so the sidebar shows the JSON until someone renames the topic. On a self-hosted deployment every topic created after the change was affected.

| Before | After |
| --- | --- |
| `{"title":"Comparing 1M-token pricing across models"}` | `Comparing 1M-token pricing across models` |

## Root cause

- `packages/prompts/src/chains/summaryTitle.ts` — #18445 replaced the output rule `- Output ONLY the title text …` with `- Return one JSON object … matching the supplied schema`.
- `apps/server/.../systemAgent/index.ts:generateTopicTitle` passes `TOPIC_TITLE_JSON_SCHEMA` to `generateObject` and reads `result.title`, so it parses fine.
- `summaryTopicTitle` (`src/store/chat/slices/topic/action.ts`) and `summaryThreadTitle` (`.../thread/action.ts`) send the same chain through `chatService.fetchPresetTaskResult` — a plain streaming completion with no `response_format` — then write `onFinish(text)` into the title unchanged.
- No schema is supplied on those paths, so "the supplied schema" is false there: a compliant model returns the wrapper, and the wrapper becomes the title.

## Fix

Keep one prompt body and select the output rule per transport. `chainSummaryTitle` carries the plain-text rule for the streaming consumers — the pre-#18445 contract, matching sibling streaming chains like `chainSummaryAgentName` — while a new `chainSummaryTitleStructured` carries the unchanged JSON wording for the `generateObject` consumer, as `.agents/skills/llm-generation/SKILL.md` asks ("keep prompt instructions and schema requirements aligned"). Return types are unchanged.

Parsing JSON in the two stores was the alternative, rejected because the sidebar streams the title through `onMessageHandle`: the user would watch raw JSON render before it collapsed, and every title would still pay for a wrapper no consumer needs.

## Scope

- `TOPIC_TITLE_PROMPT_VERSION` stays `v1`: the structured prompt string is byte-identical, so its tracing cohort does not split.
- Titles already persisted as JSON are not rewritten — a migration over user-visible titles is not worth the risk, and the rename action covers them.
- The server consumer was never broken; it moves to the new export only so its prompt keeps naming the schema it supplies.

#### Test

- `packages/prompts/.../summaryTitle.test.ts` — 5 cases: the streaming prompt asks for plain text and names neither JSON nor a schema; the structured one asks for the schema-shaped object; stripping the output rules makes the two equal, both keep all six shared constraints, and both serialize every turn identically.
- `topic/action.test.ts`, `thread/action.test.ts` — 1 case each: the prompt reaching `fetchPresetTaskResult` carries the plain-text rule, and the streamed text lands in the title.
- `apps/server/src/services/systemAgent/index.test.ts` — new suite, 2 cases: the JSON-instructed prompt is paired with `TOPIC_TITLE_JSON_SCHEMA` and the tracing carries `scenario` / `promptVersion` / `schemaName`; an empty title yields `null`.

`npx vitest run` over the store/server paths, plus `--config vitest.config.mts` from `packages/prompts`. Verified on a self-hosted deployment too: new topics are titled in plain text again.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

None — found while operating a self-hosted deployment. Related to #13361 (title polluted by raw model output; closed without a fix).
