### PR TITLE
chore: remove internal LOBE-13229 issue reference from code comment

### DIFF
--- a/packages/trpc/src/client/lambda.ts
+++ b/packages/trpc/src/client/lambda.ts
@@ -177,7 +177,7 @@ const initialLoadProcedures = new Set(['user.getUserState', 'config.getGlobalCon
 // request timeout the response comes back as an HTML error page instead of JSON,
 // so every sibling procedure in the batch (e.g. `agent.getAgentConfigById`) fails
 // its `JSON.parse` with `Unexpected token '<'`. Split it out so a slow message
-// read only slows itself. See LOBE-13229.
+// read only slows itself.
 const slowProcedures = new Set(['market.getAssistantList', 'message.getMessages']);
 const SKIP_BATCH_PROCEDURES = new Set([...initialLoadProcedures, ...slowProcedures]);
 


### PR DESCRIPTION
## Summary

Removes an internal `LOBE-13229` issue reference from a code comment, preserving the technical explanation.

## Context

The comment in `packages/trpc/src/client/lambda.ts` explains why `message.getMessages` is excluded from the tRPC batch: very long topics serialize multi-MB payloads and can take tens of seconds on a cold read, which delays the entire batch and causes sibling procedures to fail `JSON.parse` with `Unexpected token '<'`. Since the full scenario is already written out in the comment, the trailing internal issue reference (`See LOBE-13229.`) is removed without losing any context.

## Changed files

- `packages/trpc/src/client/lambda.ts`
