### PR TITLE
🐛 fix(model-runtime): map ZenMux capability metadata to model cards

### DIFF
--- a/packages/model-runtime/src/providers/zenmux/index.test.ts
+++ b/packages/model-runtime/src/providers/zenmux/index.test.ts
@@ -296,6 +296,118 @@ describe('ZenMux Runtime', () => {
         expect(models.length).toBeGreaterThan(0);
       });
 
+      it('should map ZenMux capability metadata onto model cards before processing', async () => {
+        const mockClient = {
+          apiKey: 'test-key',
+          baseURL: 'https://zenmux.ai/api/v1',
+          models: {
+            list: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: 'dots-studio/dots3-note-prev',
+                  object: 'model',
+                  created: 1786962877,
+                  owned_by: 'dots-studio',
+                  display_name: 'Dots Studio: Dots3-Note Preview (Free)',
+                  input_modalities: ['text', 'image', 'video', 'audio'],
+                  output_modalities: ['text'],
+                  capabilities: { reasoning: true },
+                  context_length: 393100,
+                  pricings: {
+                    completion: [{ value: 0, unit: 'perMTokens', currency: 'USD' }],
+                    input_cache_read: [{ value: 0, unit: 'perMTokens', currency: 'USD' }],
+                    prompt: [{ value: 0, unit: 'perMTokens', currency: 'USD' }],
+                  },
+                  publish_time: '2026-08-17',
+                },
+                {
+                  id: 'z-ai/glm-5.3',
+                  object: 'model',
+                  created: 1786609177,
+                  owned_by: 'z-ai',
+                  input_modalities: ['text'],
+                  output_modalities: ['text'],
+                  capabilities: { reasoning: true },
+                  context_length: 1000000,
+                  pricings: {
+                    completion: [
+                      // tiered pricing: first perMTokens entry is the base tier
+                      { value: 4.4, unit: 'perMTokens', currency: 'USD' },
+                      { value: 8.8, unit: 'perMTokens', currency: 'USD', conditions: {} },
+                    ],
+                    prompt: [{ value: 1.4, unit: 'perMTokens', currency: 'USD' }],
+                    web_search: [{ value: 0.01, unit: 'perCount', currency: 'USD' }],
+                  },
+                  publish_time: '2026-08-13',
+                },
+              ],
+            }),
+          },
+        } as any;
+
+        mockProcessMultiProviderModelList.mockResolvedValue([]);
+
+        await params.models({ client: mockClient });
+
+        expect(mockProcessMultiProviderModelList).toHaveBeenCalledWith(
+          [
+            expect.objectContaining({
+              contextWindowTokens: 393100,
+              id: 'dots-studio/dots3-note-prev',
+              pricing: expect.objectContaining({ cachedInput: 0, input: 0, output: 0 }),
+              reasoning: true,
+              releasedAt: '2026-08-17',
+              video: true,
+              vision: true,
+            }),
+            expect.objectContaining({
+              contextWindowTokens: 1000000,
+              id: 'z-ai/glm-5.3',
+              pricing: expect.objectContaining({ input: 1.4, output: 4.4 }),
+              reasoning: true,
+              video: false,
+              vision: false,
+            }),
+          ],
+          'zenmux',
+        );
+      });
+
+      it('should leave capabilities undefined when ZenMux omits metadata fields', async () => {
+        const mockClient = {
+          apiKey: 'test-key',
+          baseURL: 'https://zenmux.ai/api/v1',
+          models: {
+            list: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: 'openai/gpt-4o-mini',
+                  object: 'model',
+                  created: 1755177025,
+                  owned_by: 'openai',
+                },
+              ],
+            }),
+          },
+        } as any;
+
+        mockProcessMultiProviderModelList.mockResolvedValue([]);
+
+        await params.models({ client: mockClient });
+
+        expect(mockProcessMultiProviderModelList).toHaveBeenCalledWith(
+          [
+            expect.objectContaining({
+              id: 'openai/gpt-4o-mini',
+              reasoning: undefined,
+              video: undefined,
+              vision: undefined,
+            }),
+          ],
+          'zenmux',
+        );
+      });
+
       it('should handle empty model list', async () => {
         const mockClient = {
           apiKey: 'test-key',

--- a/packages/model-runtime/src/providers/zenmux/index.ts
+++ b/packages/model-runtime/src/providers/zenmux/index.ts
@@ -5,12 +5,35 @@ import { createRouterRuntime } from '../../core/RouterRuntime';
 import type { CreateRouterRuntimeOptions } from '../../core/RouterRuntime/createRuntime';
 import { detectModelProvider, processMultiProviderModelList } from '../../utils/modelParse';
 
-export interface ZenMuxModelCard {
-  created: number;
-  id: string;
-  object: string;
-  owned_by: string;
+interface ZenMuxPricingEntry {
+  conditions?: Record<string, unknown>;
+  currency: string;
+  unit: string;
+  value: number;
 }
+
+export interface ZenMuxModelCard {
+  capabilities?: {
+    reasoning?: boolean;
+  };
+  context_length?: number;
+  created: number;
+  display_name?: string;
+  id: string;
+  input_modalities?: string[];
+  object: string;
+  output_modalities?: string[];
+  owned_by: string;
+  pricings?: Record<string, ZenMuxPricingEntry[]>;
+  publish_time?: string;
+}
+
+/**
+ * Pricing entries may be tiered by prompt-token conditions; the first `perMTokens`
+ * entry is the base tier, which matches how we surface a single flat rate.
+ */
+const getPerMTokensPrice = (entries?: ZenMuxPricingEntry[]): number | undefined =>
+  entries?.find((entry) => entry.unit === 'perMTokens')?.value;
 
 const DEFAULT_BASE_URL = 'https://zenmux.ai';
 
@@ -43,7 +66,30 @@ export const params = {
     const modelsPage = (await openAIClient.models.list()) as any;
     const modelList: ZenMuxModelCard[] = modelsPage.data || [];
 
-    return processMultiProviderModelList(modelList, 'zenmux');
+    // Map ZenMux's own capability metadata (input_modalities, capabilities, context_length,
+    // pricings) onto the model card before the generic keyword-based inference runs, so
+    // vision/reasoning stay correct for vendors the keyword heuristics don't know about —
+    // otherwise native-vision models get vision=false and are forced through analyzeMedia
+    const formattedModels = modelList.map((model) => {
+      const { capabilities, context_length, input_modalities, pricings, publish_time } = model;
+
+      return {
+        ...model,
+        contextWindowTokens: context_length,
+        pricing: {
+          cachedInput: getPerMTokensPrice(pricings?.input_cache_read),
+          input: getPerMTokensPrice(pricings?.prompt),
+          output: getPerMTokensPrice(pricings?.completion),
+          writeCacheInput: getPerMTokensPrice(pricings?.input_cache_write),
+        },
+        reasoning: capabilities?.reasoning,
+        releasedAt: publish_time,
+        video: input_modalities ? input_modalities.includes('video') : undefined,
+        vision: input_modalities ? input_modalities.includes('image') : undefined,
+      };
+    });
+
+    return processMultiProviderModelList(formattedModels, 'zenmux');
   },
   routers: (options) => {
     const baseURL = options.baseURL || DEFAULT_BASE_URL;


### PR DESCRIPTION
ZenMux's `/api/v1/models` response already carries per-model capability metadata (`input_modalities`, `capabilities.reasoning`, `context_length`, `pricings`, `publish_time`), but the ZenMux adapter discarded everything except `id/created/object/owned_by` and delegated capability inference entirely to the generic keyword heuristics in `processMultiProviderModelList`.

For models from vendors the keyword heuristics don't recognize (e.g. `dots-studio/dots3-note-prev`, `sapiens-ai/agnes-2.5-flash`), `detectModelProvider` falls into the default `openai` bucket whose vision keywords don't match, so natively vision-capable models ended up with `abilities.vision = false`. The context engine then advertised `Native media input capabilities: vision=false` and forced image inputs through the `analyzeMedia` fallback tool, degrading results (reported via Discord on LobeHub v2.2.14).

This change maps ZenMux's own metadata onto the model card before the generic processing runs (same pattern as the OpenRouter adapter):

- `vision` / `video` from `input_modalities`
- `reasoning` from `capabilities.reasoning`
- `contextWindowTokens` from `context_length`
- `pricing` (input / output / cachedInput / writeCacheInput) from the base `perMTokens` tier of `pricings`
- `releasedAt` from `publish_time`

Fields ZenMux omits stay `undefined`, so known-model config and keyword fallbacks still apply.

#### Test

- [x] Tested locally
- [x] Added/updated tests

Regression tests assert the enriched cards passed to `processMultiProviderModelList`: a vision+video model card gets `vision: true` / `video: true`, a text-only card gets `vision: false`, tiered pricing picks the base tier, and cards without metadata keep `undefined` capabilities so heuristic fallbacks remain intact. Verified against ZenMux's live `/api/v1/models` response shape.

#### 🔗 Related Issue

Reported via Discord (ZenMux provider: `dots-studio/dots3-note-prev`, `sapiens-ai/agnes-2.5-flash` detected as `vision=false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)