### PR TITLE
🐛 fix(model-runtime): map PPIO and Qiniu upstream model metadata onto model cards

### DIFF
--- a/packages/model-runtime/src/providers/ppio/__snapshots__/index.test.ts.snap
+++ b/packages/model-runtime/src/providers/ppio/__snapshots__/index.test.ts.snap
@@ -11,6 +11,7 @@ exports[`PPIO > models > should get models 1`] = `
     "id": "deepseek/deepseek-r1/community",
     "reasoning": true,
     "type": "chat",
+    "video": false,
     "vision": false,
   },
   {
@@ -22,7 +23,21 @@ exports[`PPIO > models > should get models 1`] = `
     "id": "deepseek/deepseek-v3/community",
     "reasoning": false,
     "type": "chat",
+    "video": false,
     "vision": false,
+  },
+  {
+    "contextWindowTokens": 131072,
+    "description": "Qwen3.5 VL multimodal instruction model.",
+    "displayName": "Qwen3.5 VL 72B Instruct",
+    "enabled": false,
+    "functionCall": true,
+    "id": "qwen/qwen3.5-vl-72b-instruct",
+    "maxOutput": 32768,
+    "reasoning": true,
+    "type": "chat",
+    "video": true,
+    "vision": true,
   },
 ]
 `;

--- a/packages/model-runtime/src/providers/ppio/fixtures/models.json
+++ b/packages/model-runtime/src/providers/ppio/fixtures/models.json
@@ -32,5 +32,26 @@
     "context_size": 64000,
     "status": 1,
     "display_name": "DeepSeek: DeepSeek V3 (community)"
+  },
+  {
+    "created": 1787107460,
+    "id": "qwen/qwen3.5-vl-72b-instruct",
+    "object": "model",
+    "owned_by": "unknown",
+    "permission": null,
+    "root": "",
+    "parent": "",
+    "input_token_price_per_m": 10000,
+    "output_token_price_per_m": 30000,
+    "title": "qwen/qwen3.5-vl-72b-instruct",
+    "description": "Qwen3.5 VL multimodal instruction model.",
+    "tags": [],
+    "context_size": 131072,
+    "status": 1,
+    "display_name": "Qwen3.5 VL 72B Instruct",
+    "model_type": "chat",
+    "max_output_tokens": 32768,
+    "features": ["serverless", "function-calling", "structured-outputs", "reasoning"],
+    "input_modalities": ["text", "image", "video"]
   }
 ]

--- a/packages/model-runtime/src/providers/ppio/index.ts
+++ b/packages/model-runtime/src/providers/ppio/index.ts
@@ -28,6 +28,9 @@ export const LobePPIOAI = createOpenAICompatibleRuntime({
           (m) => model.id.toLowerCase() === m.id.toLowerCase(),
         );
 
+        // PPIO declares capabilities on the model card itself (`features`,
+        // `input_modalities`); prefer them over known-model / keyword fallbacks so
+        // models outside the curated list keep their native abilities
         return {
           contextWindowTokens: model.context_size,
           description: model.description,
@@ -38,13 +41,20 @@ export const LobePPIOAI = createOpenAICompatibleRuntime({
             model.title ||
             model.id,
           enabled: knownModel?.enabled || false,
-          functionCall: knownModel?.abilities?.functionCall || false,
+          functionCall:
+            model.features?.includes('function-calling') ||
+            knownModel?.abilities?.functionCall ||
+            false,
           id: model.id,
+          ...(model.max_output_tokens ? { maxOutput: model.max_output_tokens } : {}),
           reasoning:
+            model.features?.includes('reasoning') ||
             reasoningKeywords.some((keyword) => model.id.toLowerCase().includes(keyword)) ||
             knownModel?.abilities?.reasoning ||
             false,
+          video: model.input_modalities?.includes('video') || knownModel?.abilities?.video || false,
           vision:
+            model.input_modalities?.includes('image') ||
             model.description.toLowerCase().includes('视觉') ||
             knownModel?.abilities?.vision ||
             false,

--- a/packages/model-runtime/src/providers/ppio/type.ts
+++ b/packages/model-runtime/src/providers/ppio/type.ts
@@ -3,8 +3,13 @@ export interface PPIOModelCard {
   created: number;
   description: string;
   display_name: string;
+  /** e.g. `['serverless', 'function-calling', 'structured-outputs', 'reasoning']` */
+  features?: string[];
   id: string;
+  /** e.g. `['text', 'image', 'video']` */
+  input_modalities?: string[];
   input_token_price_per_m: number;
+  max_output_tokens?: number;
   output_token_price_per_m: number;
   status: number;
   tags: string[];

--- a/packages/model-runtime/src/providers/qiniu/index.test.ts
+++ b/packages/model-runtime/src/providers/qiniu/index.test.ts
@@ -102,6 +102,35 @@ describe('LobeQiniuAI - custom features', () => {
       expect(models).toEqual([]);
     });
 
+    it('should map upstream context_length/max_tokens onto the processed card', async () => {
+      const mockClient = {
+        models: {
+          list: vi.fn().mockResolvedValue({
+            data: [
+              {
+                context_length: 256000,
+                created: 1770370439,
+                id: 'meituan/longcat-flash-lite',
+                max_tokens: 320000,
+                object: 'model',
+                owned_by: 'system',
+              },
+            ],
+          }),
+        },
+      };
+
+      const models = await params.models!({ client: mockClient as any });
+
+      expect(models).toEqual([
+        expect.objectContaining({
+          contextWindowTokens: 256000,
+          id: 'meituan/longcat-flash-lite',
+          maxOutput: 320000,
+        }),
+      ]);
+    });
+
     it('should handle API errors gracefully', async () => {
       const mockClient = {
         models: {

--- a/packages/model-runtime/src/providers/qiniu/index.ts
+++ b/packages/model-runtime/src/providers/qiniu/index.ts
@@ -13,8 +13,14 @@ export const params = {
   models: async ({ client }) => {
     const modelsPage = (await client.models.list()) as any;
     const modelList = modelsPage.data.map((model: any) => {
-      const { created: _created, ...rest } = model;
-      return rest;
+      const { created: _created, context_length, max_tokens, ...rest } = model;
+      // Rename Qiniu's snake_case length fields to the card fields
+      // processMultiProviderModelList actually reads, so they aren't dropped
+      return {
+        ...rest,
+        contextWindowTokens: context_length,
+        maxOutput: max_tokens,
+      };
     });
 
     // Auto-detect the model provider and select the corresponding configuration


### PR DESCRIPTION
Follow-up to #18483 (ZenMux) — a sweep across all provider adapters found the same "upstream capability metadata discarded" pattern in two more providers whose model APIs are publicly verifiable:

### PPIO

PPIO's `/v3/openai/models` returns `features` (`function-calling` / `reasoning` / `structured-outputs`), `input_modalities` (`text` / `image` / `video` / `audio`), and `max_output_tokens` per model, but the adapter ignored all of them:

- `vision` was detected by matching the Chinese keyword `视觉` in the model description
- `functionCall` / `reasoning` relied solely on the curated known-model list (plus a `deepseek-r1` id keyword)

Any capable model outside the curated list got `vision: false` / `functionCall: false`, which downgrades it to the `analyzeMedia` fallback and disables tool calling. Now `features` and `input_modalities` are read first, with the previous description-keyword / known-model checks kept as fallbacks; `max_output_tokens` maps to `maxOutput` and `video` modality is surfaced as well.

### Qiniu

Qiniu's `/v1/models` returns `context_length` and `max_tokens` per model, but the adapter forwarded them under their snake_case names, which `processMultiProviderModelList` never reads — so context-window and max-output info was silently dropped for every Qiniu model. They are now renamed to `contextWindowTokens` / `maxOutput` before processing.

Both upstream response shapes were verified live against the public endpoints (`api.ppinfra.com/v3/openai/models`, `openai.qiniu.com/v1/models`).

#### Test

- [x] Tested locally
- [x] Added/updated tests

- PPIO: added a fixture model carrying `features` / `input_modalities` / `max_output_tokens` (no curated-list entry) and extended the snapshot — it now asserts `vision: true` / `video: true` / `functionCall: true` / `reasoning: true` / `maxOutput` derive from upstream metadata alone.
- Qiniu: added a regression test asserting `context_length` / `max_tokens` surface as `contextWindowTokens` / `maxOutput` on the processed card.

#### 🔗 Related Issue

Same root cause family as #18483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)