### PR TITLE
🐛 fix(topic): generate the auto title as JSON instead of a streamed completion

### DIFF
--- a/src/store/chat/slices/thread/action.test.ts
+++ b/src/store/chat/slices/thread/action.test.ts
@@ -1,9 +1,11 @@
+import { LOADING_FLAT } from '@lobechat/const';
 import { type UIChatMessage } from '@lobechat/types';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { type Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { mutate } from '@/libs/swr';
+import { aiChatService } from '@/services/aiChat';
 import { chatService } from '@/services/chat';
 import { threadService } from '@/services/thread';
 import { type ThreadItem } from '@/types/topic';
@@ -42,6 +44,12 @@ vi.mock('@/services/thread', () => ({
 vi.mock('@/services/chat', () => ({
   chatService: {
     fetchPresetTaskResult: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/aiChat', () => ({
+  aiChatService: {
+    generateJSON: vi.fn(),
   },
 }));
 
@@ -597,14 +605,10 @@ describe('thread action', () => {
         },
       ];
 
-      (chatService.fetchPresetTaskResult as Mock).mockImplementation(
-        async ({ onMessageHandle, onFinish }) => {
-          await onMessageHandle?.({ text: 'New', type: 'text' });
-          await onMessageHandle?.({ text: ' Generated', type: 'text' });
-          await onMessageHandle?.({ text: ' Title', type: 'text' });
-          await onFinish?.('New Generated Title');
-        },
-      );
+      (aiChatService.generateJSON as Mock).mockResolvedValue({
+        data: { title: 'New Generated Title' },
+        tracingId: 'tracing-1',
+      });
 
       const internalUpdateSpy = vi
         .spyOn(result.current, 'internal_updateThread')
@@ -614,7 +618,13 @@ describe('thread action', () => {
         await result.current.summaryThreadTitle('thread-id', messages);
       });
 
-      expect(chatService.fetchPresetTaskResult).toHaveBeenCalled();
+      // Structured generation, not a chat completion — the raw text used to be
+      // written straight to the title, which leaked `{"title":"..."}`.
+      expect(chatService.fetchPresetTaskResult).not.toHaveBeenCalled();
+      expect((aiChatService.generateJSON as Mock).mock.calls[0][0]).toMatchObject({
+        schema: { name: 'topic_title' },
+        tracing: { scenario: 'topic_title' },
+      });
       expect(internalUpdateSpy).toHaveBeenCalledWith('thread-id', {
         title: 'New Generated Title',
       });
@@ -645,13 +655,11 @@ describe('thread action', () => {
         });
       });
 
-      (chatService.fetchPresetTaskResult as Mock).mockImplementation(
-        async ({ onLoadingChange, onFinish }) => {
-          await onLoadingChange?.(true);
-          await onFinish?.('Title');
-          await onLoadingChange?.(false);
-        },
-      );
+      const loadingSpy = vi.spyOn(result.current, 'internal_updateThreadLoading');
+      (aiChatService.generateJSON as Mock).mockResolvedValue({
+        data: { title: 'Title' },
+        tracingId: 'tracing-1',
+      });
 
       vi.spyOn(result.current, 'internal_updateThread').mockResolvedValue(undefined);
 
@@ -659,7 +667,8 @@ describe('thread action', () => {
         await result.current.summaryThreadTitle('thread-id', []);
       });
 
-      expect(chatService.fetchPresetTaskResult).toHaveBeenCalled();
+      expect(loadingSpy).toHaveBeenNthCalledWith(1, 'thread-id', true);
+      expect(loadingSpy).toHaveBeenLastCalledWith('thread-id', false);
     });
 
     it('should revert title on error', async () => {
@@ -687,9 +696,9 @@ describe('thread action', () => {
         });
       });
 
-      (chatService.fetchPresetTaskResult as Mock).mockImplementation(async ({ onError }) => {
-        await onError?.();
-      });
+      const titleSpy = vi.spyOn(result.current, 'internal_updateThreadTitleInSummary');
+      (aiChatService.generateJSON as Mock).mockRejectedValue(new Error('provider down'));
+      vi.spyOn(console, 'error').mockImplementation(() => {});
 
       vi.spyOn(result.current, 'internal_updateThread').mockResolvedValue(undefined);
 
@@ -697,8 +706,9 @@ describe('thread action', () => {
         await result.current.summaryThreadTitle('thread-id', []);
       });
 
-      // Should have called with LOADING_FLAT first, then reverted to old title on error
-      expect(chatService.fetchPresetTaskResult).toHaveBeenCalled();
+      // LOADING_FLAT first, then reverted to the old title on error
+      expect(titleSpy).toHaveBeenNthCalledWith(1, 'thread-id', LOADING_FLAT);
+      expect(titleSpy).toHaveBeenLastCalledWith('thread-id', 'Old Title');
     });
 
     it('should not run if no portal thread found', async () => {

--- a/src/store/chat/slices/thread/action.ts
+++ b/src/store/chat/slices/thread/action.ts
@@ -1,6 +1,10 @@
 // Disable the auto sort key eslint rule to make the code more logic and readable
-import { LOADING_FLAT } from '@lobechat/const';
-import { chainSummaryTitle } from '@lobechat/prompts';
+import { LOADING_FLAT, TRACING_SCENARIOS } from '@lobechat/const';
+import {
+  chainSummaryTitle,
+  TOPIC_TITLE_JSON_SCHEMA,
+  TOPIC_TITLE_PROMPT_VERSION,
+} from '@lobechat/prompts';
 import {
   type CreateMessageParams,
   type IThreadType,
@@ -12,7 +16,7 @@ import { type SWRResponse } from 'swr';
 
 import { mutate, useClientDataSWR } from '@/libs/swr';
 import { threadKeys } from '@/libs/swr/keys';
-import { chatService } from '@/services/chat';
+import { aiChatService } from '@/services/aiChat';
 import { threadService } from '@/services/thread';
 import { threadSelectors } from '@/store/chat/selectors';
 import { type ChatStore } from '@/store/chat/store';
@@ -20,7 +24,6 @@ import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 import { type StoreSetter } from '@/store/types';
 import { useUserStore } from '@/store/user';
 import { systemAgentSelectors, userGeneralSettingsSelectors } from '@/store/user/selectors';
-import { merge } from '@/utils/merge';
 import { setNamespace } from '@/utils/storeDebug';
 
 import { PortalViewType } from '../portal/initialState';
@@ -203,36 +206,43 @@ export class ChatThreadActionImpl {
 
     internal_updateThreadTitleInSummary(threadId, LOADING_FLAT);
 
-    let output = '';
-    const threadConfig = systemAgentSelectors.thread(useUserStore.getState());
+    const { model, provider } = systemAgentSelectors.thread(useUserStore.getState());
 
-    await chatService.fetchPresetTaskResult({
-      onError: () => {
-        internal_updateThreadTitleInSummary(threadId, portalThread.title);
-      },
-      onFinish: async (text) => {
-        await this.#get().internal_updateThread(threadId, { title: text });
-      },
-      onLoadingChange: (loading) => {
-        internal_updateThreadLoading(threadId, loading);
-      },
-      onMessageHandle: (chunk) => {
-        switch (chunk.type) {
-          case 'text': {
-            output += chunk.text;
-          }
-        }
+    const restorePreviousTitle = () => {
+      internal_updateThreadTitleInSummary(threadId, portalThread.title);
+    };
 
-        internal_updateThreadTitleInSummary(threadId, output);
-      },
-      params: merge(
-        threadConfig,
-        chainSummaryTitle(
-          messages,
-          userGeneralSettingsSelectors.currentResponseLanguage(useUserStore.getState()),
-        ),
-      ),
-    });
+    // Structured generation, same as `summaryTopicTitle` — see the note there.
+    internal_updateThreadLoading(threadId, true);
+    try {
+      const { data } = await aiChatService.generateJSON(
+        {
+          ...chainSummaryTitle(
+            messages,
+            userGeneralSettingsSelectors.currentResponseLanguage(useUserStore.getState()),
+          ),
+          model,
+          provider,
+          schema: TOPIC_TITLE_JSON_SCHEMA,
+          tracing: {
+            promptVersion: TOPIC_TITLE_PROMPT_VERSION,
+            scenario: TRACING_SCENARIOS.TopicTitle,
+            schemaName: TOPIC_TITLE_JSON_SCHEMA.name,
+          },
+        },
+        new AbortController(),
+      );
+
+      const title = (data as { title?: string } | undefined)?.title?.trim();
+      if (!title) return restorePreviousTitle();
+
+      await this.#get().internal_updateThread(threadId, { title });
+    } catch (error) {
+      console.error('[summaryThreadTitle] failed to generate a title:', error);
+      restorePreviousTitle();
+    } finally {
+      internal_updateThreadLoading(threadId, false);
+    }
   };
 
   internal_updateThreadTitleInSummary = (id: string, title: string): void => {

--- a/src/store/chat/slices/topic/action.test.ts
+++ b/src/store/chat/slices/topic/action.test.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from '@lobechat/business-const';
+import { TOPIC_TITLE_JSON_SCHEMA } from '@lobechat/prompts';
 import type { LobeUser, UIChatMessage } from '@lobechat/types';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { type Mock } from 'vitest';
@@ -6,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { LOADING_FLAT } from '@/const/message';
 import { mutate } from '@/libs/swr';
+import { aiChatService } from '@/services/aiChat';
 import { chatService } from '@/services/chat';
 import { messageService } from '@/services/message';
 import { topicService } from '@/services/topic';
@@ -2590,13 +2592,10 @@ describe('topic action', () => {
       );
       const refreshTopicSpy = vi.spyOn(result.current, 'refreshTopic');
 
-      // Mock the `chatService.fetchPresetTaskResult` to simulate the AI response
-      vi.spyOn(chatService, 'fetchPresetTaskResult').mockImplementation((params) => {
-        if (params) {
-          params.onFinish?.('Summarized Title', { type: 'done' });
-        }
-        return Promise.resolve(undefined);
-      });
+      vi.spyOn(aiChatService, 'generateJSON').mockResolvedValue({
+        data: { title: 'Summarized Title' },
+        tracingId: 'tracing-1',
+      } as any);
 
       await act(async () => {
         await result.current.summaryTopicTitle(topicId, messages);
@@ -2605,8 +2604,6 @@ describe('topic action', () => {
       // Verify that the title was updated and the topic was refreshed
       expect(updateTopicTitleInSummarySpy).toHaveBeenCalledWith(topicId, LOADING_FLAT);
       expect(refreshTopicSpy).toHaveBeenCalled();
-
-      // TODO: need to test with fetchPresetTaskResult
     });
 
     it('should keep an optimistic title visible until the summarized title is ready', async () => {
@@ -2636,18 +2633,113 @@ describe('topic action', () => {
       );
       const updateTopicSpy = vi.spyOn(result.current, 'internal_updateTopic');
 
-      vi.spyOn(chatService, 'fetchPresetTaskResult').mockImplementation(async (params) => {
-        params?.onMessageHandle?.({ type: 'text', text: 'Partial Title' } as any);
-        await params?.onFinish?.('Summarized Title', { type: 'done' });
-      });
+      vi.spyOn(aiChatService, 'generateJSON').mockResolvedValue({
+        data: { title: 'Summarized Title' },
+        tracingId: 'tracing-1',
+      } as any);
 
       await act(async () => {
         await result.current.summaryTopicTitle(topicId, messages);
       });
 
       expect(updateTopicTitleInSummarySpy).not.toHaveBeenCalledWith(topicId, LOADING_FLAT);
-      expect(updateTopicTitleInSummarySpy).not.toHaveBeenCalledWith(topicId, 'Partial Title');
       expect(updateTopicSpy).toHaveBeenCalledWith(topicId, { title: 'Summarized Title' });
+    });
+
+    describe('structured generation', () => {
+      const topicId = 'topic-1';
+      const messages = [{ id: 'message-1', content: 'Hello' }] as UIChatMessage[];
+
+      const seedTopic = async (title: string) => {
+        const topics = [{ id: topicId, title }] as ChatTopic[];
+        const { result } = renderHook(() => useChatStore());
+
+        await act(async () => {
+          useChatStore.setState({
+            topicDataMap: {
+              [topicMapKey({ agentId: 'test' })]: {
+                items: topics,
+                total: topics.length,
+                currentPage: 0,
+                hasMore: false,
+                pageSize: 20,
+              },
+            },
+            activeAgentId: 'test',
+          });
+        });
+
+        return result;
+      };
+
+      it('generates against the topic-title schema instead of a chat completion', async () => {
+        const result = await seedTopic('');
+        const generateSpy = vi.spyOn(aiChatService, 'generateJSON').mockResolvedValue({
+          data: { title: '简单问候' },
+          tracingId: 'tracing-1',
+        } as any);
+        const completionSpy = vi.spyOn(chatService, 'fetchPresetTaskResult');
+
+        await act(async () => {
+          await result.current.summaryTopicTitle(topicId, messages);
+        });
+
+        expect(completionSpy).not.toHaveBeenCalled();
+        expect(generateSpy.mock.calls[0][0]).toMatchObject({
+          schema: TOPIC_TITLE_JSON_SCHEMA,
+          tracing: { scenario: 'topic_title', topicId },
+        });
+      });
+
+      it('reads the title off the parsed object', async () => {
+        const result = await seedTopic('');
+        const updateTopicSpy = vi.spyOn(result.current, 'internal_updateTopic');
+
+        vi.spyOn(aiChatService, 'generateJSON').mockResolvedValue({
+          data: { title: '简单问候' },
+          tracingId: 'tracing-1',
+        } as any);
+
+        await act(async () => {
+          await result.current.summaryTopicTitle(topicId, messages);
+        });
+
+        expect(updateTopicSpy).toHaveBeenCalledWith(topicId, { title: '简单问候' });
+      });
+
+      it('restores the previous title when generation returns nothing', async () => {
+        const result = await seedTopic('');
+        const updateTopicSpy = vi.spyOn(result.current, 'internal_updateTopic');
+        const updateTitleSpy = vi.spyOn(result.current, 'internal_updateTopicTitleInSummary');
+
+        vi.spyOn(aiChatService, 'generateJSON').mockResolvedValue({
+          data: { title: '  ' },
+          tracingId: 'tracing-1',
+        } as any);
+
+        await act(async () => {
+          await result.current.summaryTopicTitle(topicId, messages);
+        });
+
+        expect(updateTopicSpy).not.toHaveBeenCalled();
+        expect(updateTitleSpy).toHaveBeenLastCalledWith(topicId, '');
+      });
+
+      it('restores the previous title when generation throws', async () => {
+        const result = await seedTopic('');
+        const updateTopicSpy = vi.spyOn(result.current, 'internal_updateTopic');
+        const updateTitleSpy = vi.spyOn(result.current, 'internal_updateTopicTitleInSummary');
+
+        vi.spyOn(aiChatService, 'generateJSON').mockRejectedValue(new Error('provider down'));
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        await act(async () => {
+          await result.current.summaryTopicTitle(topicId, messages);
+        });
+
+        expect(updateTopicSpy).not.toHaveBeenCalled();
+        expect(updateTitleSpy).toHaveBeenLastCalledWith(topicId, '');
+      });
     });
   });
   describe('createTopic', () => {

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -1,8 +1,12 @@
 // Note: To make the code more logic and readable, we just disable the auto sort key eslint rule
 // DON'T REMOVE THE FIRST LINE
-import { chainSummaryTitle } from '@lobechat/prompts';
+import { TRACING_SCENARIOS } from '@lobechat/const';
+import {
+  chainSummaryTitle,
+  TOPIC_TITLE_JSON_SCHEMA,
+  TOPIC_TITLE_PROMPT_VERSION,
+} from '@lobechat/prompts';
 import { type ChatTopicMetadata, type MessageMapScope, type UIChatMessage } from '@lobechat/types';
-import { TraceNameMap } from '@lobechat/types';
 import { toast } from '@lobehub/ui/base-ui';
 import isEqual from 'fast-deep-equal';
 import { t } from 'i18next';
@@ -12,7 +16,7 @@ import useSWR from 'swr';
 import { LOADING_FLAT } from '@/const/message';
 import { mutate, useClientDataSWRWithSync } from '@/libs/swr';
 import { cronKeys, deviceKeys, topicKeys } from '@/libs/swr/keys';
-import { chatService } from '@/services/chat';
+import { aiChatService } from '@/services/aiChat';
 import { type GitLinkedPRSummary, gitService } from '@/services/git';
 import { messageService } from '@/services/message';
 import type { TopicBatchDeleteScope } from '@/services/topic';
@@ -44,7 +48,6 @@ import {
   type CreateTopicParams,
   type TopicQuerySortBy,
 } from '@/types/topic';
-import { merge } from '@/utils/merge';
 import { setNamespace } from '@/utils/storeDebug';
 
 import { displayMessageSelectors } from '../message/selectors';
@@ -289,44 +292,51 @@ export class ChatTopicActionImpl {
 
     // Keep an optimistic title like "阅读下面..." stable while AI rename runs;
     // otherwise the sidebar flickers `title -> ... -> final title`.
-    const shouldStreamSummaryTitle = !topic.title || topic.title === LOADING_FLAT;
+    const shouldShowPlaceholder = !topic.title || topic.title === LOADING_FLAT;
 
-    if (shouldStreamSummaryTitle) internal_updateTopicTitleInSummary(topicId, LOADING_FLAT);
+    if (shouldShowPlaceholder) internal_updateTopicTitleInSummary(topicId, LOADING_FLAT);
 
-    let output = '';
+    const restorePreviousTitle = () => {
+      if (shouldShowPlaceholder) internal_updateTopicTitleInSummary(topicId, topic.title);
+    };
 
     // Get current agent for topic
-    const topicConfig = systemAgentSelectors.topic(useUserStore.getState());
+    const { model, provider } = systemAgentSelectors.topic(useUserStore.getState());
 
-    // Automatically summarize the topic title
-    await chatService.fetchPresetTaskResult({
-      onError: () => {
-        if (shouldStreamSummaryTitle) internal_updateTopicTitleInSummary(topicId, topic.title);
-      },
-      onFinish: async (text) => {
-        await this.#get().internal_updateTopic(topicId, { title: text });
-      },
-      onMessageHandle: (chunk) => {
-        switch (chunk.type) {
-          case 'text': {
-            output += chunk.text;
-          }
-        }
+    // Structured generation, the same way `SystemAgentService.generateTopicTitle`
+    // does it: the chain asks for `TOPIC_TITLE_JSON_SCHEMA`, so read the title
+    // off the parsed object. Streaming a completion here used to write the raw
+    // answer to `topic.title`, which named topics `{"title":"简单问候"}`.
+    try {
+      const { data } = await aiChatService.generateJSON(
+        {
+          ...chainSummaryTitle(
+            messages,
+            userGeneralSettingsSelectors.currentResponseLanguage(useUserStore.getState()),
+          ),
+          model,
+          provider,
+          schema: TOPIC_TITLE_JSON_SCHEMA,
+          tracing: {
+            promptVersion: TOPIC_TITLE_PROMPT_VERSION,
+            scenario: TRACING_SCENARIOS.TopicTitle,
+            schemaName: TOPIC_TITLE_JSON_SCHEMA.name,
+            topicId,
+          },
+        },
+        new AbortController(),
+      );
 
-        if (shouldStreamSummaryTitle) internal_updateTopicTitleInSummary(topicId, output);
-      },
-      params: merge(
-        topicConfig,
-        chainSummaryTitle(
-          messages,
-          userGeneralSettingsSelectors.currentResponseLanguage(useUserStore.getState()),
-        ),
-      ),
-      trace: this.#get().getCurrentTracePayload({
-        traceName: TraceNameMap.SummaryTopicTitle,
-        topicId,
-      }),
-    });
+      const title = (data as { title?: string } | undefined)?.title?.trim();
+      // An empty result must not blank the title — the placeholder would
+      // otherwise stay in the sidebar forever.
+      if (!title) return restorePreviousTitle();
+
+      await this.#get().internal_updateTopic(topicId, { title });
+    } catch (error) {
+      console.error('[summaryTopicTitle] failed to generate a title:', error);
+      restorePreviousTitle();
+    }
   };
 
   markTopicCompleted = async (id: string): Promise<void> => {


### PR DESCRIPTION
## 💻 变更类型 | Change Type

- [x] 🐛 fix

## 🔀 变更说明 | Description of Change

新话题的自动总结标题变成了 `{"title":"简单问候"}`。

根因是 #18445 把 `chainSummaryTitle` 的输出规则改成了「Return one JSON object with a single "title" string matching the supplied schema」。这条 chain 有三个调用方，但只有一个是结构化生成：

| 调用方 | 方式 | 结果 |
| --- | --- | --- |
| `SystemAgentService.generateTopicTitle` | `generateObject` + `TOPIC_TITLE_JSON_SCHEMA` | ✅ 取 `.title` |
| `summaryTopicTitle` | 流式补全 | ❌ 原始文本直接写进 `topic.title` |
| `summaryThreadTitle` | 流式补全 | ❌ 同上 |

后两者把模型吐的原文直接当标题写库，模型照着新指令输出 JSON，于是标题就成了那串 blob。

**prompt 不动**，把两个补全调用方改成跟结构化那个一样的生成方式：一次 `aiChatService.generateJSON`（→ `aiChat.outputJSON` → `generateObject`），带 `TOPIC_TITLE_JSON_SCHEMA`，直接读返回对象上的 `title`。

顺带拿到的好处：

- 走上了补全路径一直没有的结构化输出兜底 —— provider 拒绝 `response_format: json_schema`（DeepSeek 系）时退回 forced tool calling。
- 去掉逐 chunk 写标题。既然 prompt 要的是 JSON 对象，流式就等于把 `{"title":` 连同里面每个半截词画进侧边栏，还要挂满整个请求时长。
- 空结果不再把标题清空，而是恢复原标题 —— 否则 `...` 占位会永远留在侧边栏。

## 📝 补充信息 | Additional Information

- tracing 从 langfuse 的 `SummaryTopicTitle` trace tag 换成了 `llm_generation_tracing` 的 `topic_title` scenario，跟服务端那个调用方一致（`outputJSON` 只接 `tracing`，接不了 trace payload）。
- 改动只剩 4 个文件，`packages/prompts` 完全回到 canary 原样。
- 回归测试：topic 4 例（走 schema 不走补全 / 读解析后的对象 / 空结果 / 抛错），thread 3 例（同上 + loading 生命周期）。
- `bun run check` lint clean、115 tests passed、types clean。
- 存量已经被命名成 JSON 的话题不会自动修正，需要的话可以另开一个回填。

🤖 Generated with [Claude Code](https://claude.com/claude-code)