### PR TITLE
💄 style(i18n): add downgrade failed payment result copy

### DIFF
--- a/locales/en-US/subscription.json
+++ b/locales/en-US/subscription.json
@@ -340,6 +340,8 @@
   "payDiffPrice": "Pay Difference",
   "payDiffPriceApprox": "Approx.",
   "payDiffPriceTip": "Actual amount subject to payment page",
+  "payment.downgradeFailed.desc": "Failed to schedule your downgrade. Please try again later, or contact us via email if the problem persists",
+  "payment.downgradeFailed.title": "Downgrade Failed",
   "payment.error.actions.billing": "Billing Management",
   "payment.error.actions.home": "Back to Home",
   "payment.error.desc": "Subscription ID: {{id}} not found. If you have questions, please contact us via email",

--- a/locales/zh-CN/subscription.json
+++ b/locales/zh-CN/subscription.json
@@ -340,6 +340,8 @@
   "payDiffPrice": "支付差价",
   "payDiffPriceApprox": "约",
   "payDiffPriceTip": "实际金额以支付页面为准",
+  "payment.downgradeFailed.desc": "降级设置失败，请稍后重试；如果问题持续存在，请通过电子邮件联系我们",
+  "payment.downgradeFailed.title": "降级失败",
   "payment.error.actions.billing": "账单管理",
   "payment.error.actions.home": "返回首页",
   "payment.error.desc": "未找到订阅 ID：{{id}}。如有疑问，请通过电子邮件联系我们",

--- a/packages/locales/src/default/subscription.ts
+++ b/packages/locales/src/default/subscription.ts
@@ -400,6 +400,9 @@ export default {
   'payDiffPrice': 'Pay Difference',
   'payDiffPriceApprox': 'Approx.',
   'payDiffPriceTip': 'Actual amount subject to payment page',
+  'payment.downgradeFailed.desc':
+    'Failed to schedule your downgrade. Please try again later, or contact us via email if the problem persists',
+  'payment.downgradeFailed.title': 'Downgrade Failed',
   'payment.error.actions.billing': 'Billing Management',
   'payment.error.actions.home': 'Back to Home',
   'payment.error.desc':


### PR DESCRIPTION
Adds `payment.downgradeFailed.title` / `payment.downgradeFailed.desc` to the `subscription` namespace (default source + en-US mirror + hand-translated zh-CN), used by the payment result flow to surface a downgrade failure instead of reusing the misleading "subscription not found" copy.

#### Test

- [x] No tests needed (locale strings only; consumer lives in the business layer)