### PR TITLE
🐛 fix(work): polish work card display details from acceptance findings

### DIFF
--- a/src/features/Portal/LocalFile/Body.tsx
+++ b/src/features/Portal/LocalFile/Body.tsx
@@ -494,11 +494,16 @@ const ActiveFileView = memo<ActiveFileViewProps>(
     if (preview.type === 'document') {
       return (
         <Suspense fallback={<Loading />}>
+          {/* Key by source + path: without a remount, switching between two files of
+              the same document type reuses the pane instance, whose local
+              loading/parse state isn't reset on blob change — the previous file's
+              rendered content lingers until the new one finishes (LOBE-13010). */}
           <DocumentPreview
             blob={preview.blob}
             contentType={preview.contentType}
             filePath={filePath}
             isLocalFile={!sandboxTopicId && !deviceId && isDesktop}
+            key={`${sandboxTopicId ?? deviceId ?? 'local'}:${filePath}`}
           />
         </Suspense>
       );

--- a/src/features/Work/WorkSummaryCard.tsx
+++ b/src/features/Work/WorkSummaryCard.tsx
@@ -39,6 +39,10 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     min-width: 0;
     color: ${cssVar.colorTextTertiary};
   `,
+  identifier: css`
+    flex-shrink: 0;
+    color: ${cssVar.colorTextTertiary};
+  `,
   icon: css`
     flex-shrink: 0;
 
@@ -75,6 +79,12 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   inlineDescription: css`
     min-width: 0;
+    font-size: 11px;
+    color: ${cssVar.colorTextTertiary};
+  `,
+  inlineIdentifier: css`
+    flex-shrink: 0;
+    font-family: ${cssVar.fontFamilyCode};
     font-size: 11px;
     color: ${cssVar.colorTextTertiary};
   `,
@@ -129,6 +139,11 @@ const WorkSummaryCard = memo<WorkSummaryCardProps>(
       descriptor.getIdentifier(item) ||
       item.resourceId ||
       item.id;
+    // Mirrors WorkVersionHistoryCard's label: surface the resource identifier
+    // (e.g. `QA-1989`, `owner/repo#2`) on the card itself, unless the title
+    // already fell back to it.
+    const identifier = descriptor.getIdentifier(item);
+    const showIdentifier = !!identifier && identifier !== title;
     const description = descriptor.getDescription(item);
     const openTarget = descriptor.getOpenTarget(item);
     // The backing task was deleted outside the tool path: the Work lingers as an
@@ -180,6 +195,7 @@ const WorkSummaryCard = memo<WorkSummaryCardProps>(
               <Text ellipsis className={styles.inlineTitle}>
                 {title}
               </Text>
+              {showIdentifier && <span className={styles.inlineIdentifier}>{identifier}</span>}
               {taskDeleted && (
                 <Tag color={'warning'} icon={<Trash2Icon size={12} />} size={'small'}>
                   {t('workingPanel.works.taskDeleted')}
@@ -218,6 +234,11 @@ const WorkSummaryCard = memo<WorkSummaryCardProps>(
               <Text ellipsis className={styles.title}>
                 {title}
               </Text>
+              {showIdentifier && (
+                <Text code className={styles.identifier} fontSize={12}>
+                  {identifier}
+                </Text>
+              )}
               {taskDeleted && (
                 <Tag color={'warning'} icon={<Trash2Icon size={12} />} size={'small'}>
                   {t('workingPanel.works.taskDeleted')}

--- a/src/utils/workVersionCost.test.ts
+++ b/src/utils/workVersionCost.test.ts
@@ -3,9 +3,14 @@ import { describe, expect, it } from 'vitest';
 import { computeWorkVersionCostDeltas, formatWorkVersionCost } from './workVersionCost';
 
 describe('formatWorkVersionCost', () => {
-  it('hides missing or zero cost', () => {
+  it('hides unknown cost but renders known-zero as $0.00', () => {
     expect(formatWorkVersionCost(null)).toBeNull();
-    expect(formatWorkVersionCost(0)).toBeNull();
+    expect(formatWorkVersionCost(undefined)).toBeNull();
+    expect(formatWorkVersionCost(0)).toBe('$0.00');
+  });
+
+  it('hides negative cost defensively', () => {
+    expect(formatWorkVersionCost(-0.01)).toBeNull();
   });
 
   it('keeps small cumulative costs visible', () => {

--- a/src/utils/workVersionCost.ts
+++ b/src/utils/workVersionCost.ts
@@ -1,7 +1,10 @@
 export const formatWorkVersionCost = (cost?: number | null): string | null => {
-  if (!cost || cost <= 0) return null;
+  // null/undefined means the cost is unknown (no snapshot recorded) — hide it.
+  // A literal 0 is a known-zero spend (e.g. a same-operation version whose
+  // cumulative snapshot didn't advance) and must render as $0.00, not blank.
+  if (cost === null || cost === undefined || cost < 0) return null;
 
-  if (cost < 0.01) return `$${cost.toFixed(4)}`;
+  if (cost > 0 && cost < 0.01) return `$${cost.toFixed(4)}`;
 
   return `$${cost.toFixed(2)}`;
 };


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Part of LOBE-13010

#### 📝 Description of Change

Three small display fixes for Agent Work cards found during online acceptance:

1. **Zero version cost hidden instead of rendered** — `formatWorkVersionCost` treated `0` as falsy and returned `null`, so a version whose spend is a known zero (e.g. a same-operation version whose cumulative snapshot didn't advance) showed nothing. Now only `null`/`undefined` (unknown cost) stays hidden; `0` renders as `$0.00`. This also benefits `WorkSummaryCard`, which shares the formatter.
2. **Work summary card missing resource identifier** — `WorkSummaryCard` never rendered `descriptor.getIdentifier(item)` (e.g. `QA-1989`, `owner/repo#2`) even though the sidebar's `WorkVersionHistoryCard` does. Both `card` and `inline` variants now show the identifier next to the title, skipped when the title already fell back to it.
3. **Stale document preview when switching files** — `<DocumentPreview>` in `Portal/LocalFile/Body.tsx` had no `key`, so switching between two files of the same document type (e.g. pptx → pptx across topics) reused the pane instance whose internal loading/parse state isn't reset on blob change, leaving the previous file's content visible. Keyed by source + path to force a clean remount, matching the sibling `InlineHtmlPreview` which is already keyed for the same reason.

#### 🧪 How to Test

- [x] Unit tests updated: `formatWorkVersionCost` now asserts `0 → "$0.00"`, `null`/`undefined`/negative → hidden (`src/utils/workVersionCost.test.ts`)
- [x] `bun run check` on changed files: lint clean, 11 tests passed