### PR TITLE
🐛 fix(heterogeneous-agents): preserve PATH order when resolving a Windows CLI spawn target

### DIFF
--- a/packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts
@@ -67,18 +67,46 @@ describe('cliSpawn', () => {
     expect(execFileMock).not.toHaveBeenCalled();
   });
 
-  it('prefers a Windows executable returned by where', async () => {
+  it('falls through to a later .exe only when an earlier .cmd shim cannot be unwrapped', async () => {
     platformMock.mockReturnValue('win32');
-    callExecFile(
-      ['C:\\Users\\Hanam\\AppData\\Roaming\\npm\\gemini.cmd', 'C:\\Tools\\gemini.exe'].join('\r\n'),
-    );
+    const shimPath = 'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\gemini.cmd';
+    callExecFile([shimPath, 'C:\\Tools\\gemini.exe'].join('\r\n'));
+    existingPaths(shimPath);
+    // Content that matches none of the known npm-shim patterns (a custom
+    // installer script, not a standard npm cmd-shim).
+    readFileMock.mockResolvedValue('@ECHO off\r\nset SOME_CUSTOM_LAUNCHER=1\r\n');
 
     const { resolveCliSpawnPlan } = await import('./cliSpawn');
     await expect(resolveCliSpawnPlan('gemini', ['--version'])).resolves.toEqual({
       args: ['--version'],
       command: 'C:\\Tools\\gemini.exe',
     });
-    expect(readFileMock).not.toHaveBeenCalled();
+    expect(readFileMock).toHaveBeenCalledWith(shimPath, 'utf8');
+  });
+
+  it('does not skip an earlier resolvable .cmd shim in favour of a later bare .exe', async () => {
+    // Regression test: an MSIX App Execution Alias stub (e.g. the
+    // WindowsApps\...\codex.exe placeholder some MSIX-packaged tools add to
+    // PATH) can appear on PATH after a perfectly usable earlier `.cmd` shim
+    // (e.g. a WinGet-installed `codex.cmd`). Node's execFile/spawn throws
+    // EPERM on that stub, so PATH order must win over "prefer any .exe".
+    platformMock.mockReturnValue('win32');
+    const shimPath = 'C:\\Users\\Hanam\\AppData\\Local\\Microsoft\\WinGet\\Links\\codex.cmd';
+    const exePath =
+      'C:\\Users\\Hanam\\AppData\\Local\\Microsoft\\WinGet\\Packages\\OpenAI.Codex\\codex-x86_64-pc-windows-msvc.exe';
+    const appExecutionAliasStub =
+      'C:\\Users\\Hanam\\AppData\\Local\\Microsoft\\WindowsApps\\OpenAI.Codex_1.0\\app\\resources\\codex.exe';
+    callExecFile([shimPath, appExecutionAliasStub].join('\r\n'));
+    existingPaths(shimPath, exePath);
+    readFileMock.mockResolvedValue(
+      `@ECHO off\r\n"%~dp0..\\Packages\\OpenAI.Codex\\codex-x86_64-pc-windows-msvc.exe" %*\r\n`,
+    );
+
+    const { resolveCliSpawnPlan } = await import('./cliSpawn');
+    await expect(resolveCliSpawnPlan('codex', ['--version'])).resolves.toEqual({
+      args: ['--version'],
+      command: exePath,
+    });
   });
 
   it('resolves Windows npm shell shim to a package executable', async () => {

--- a/packages/heterogeneous-agents/src/spawn/cliSpawn.ts
+++ b/packages/heterogeneous-agents/src/spawn/cliSpawn.ts
@@ -89,9 +89,6 @@ const execFileString = async (command: string, args: string[]): Promise<string> 
     );
   });
 
-const pickWindowsExecutable = (candidates: string[]): string | undefined =>
-  candidates.find((candidate) => WINDOWS_EXE_EXT_PATTERN.test(candidate));
-
 const pickWindowsNodeExecutable = (candidates: string[]): string | undefined =>
   candidates.find(
     (candidate) =>
@@ -255,9 +252,16 @@ const resolveWindowsBareCommand = async (
       .map((line) => line.trim())
       .filter(Boolean);
 
-    const executable = pickWindowsExecutable(candidates);
-    if (executable) return { command: executable };
-
+    // Walk candidates in PATH order — `inferWindowsNpmShimTarget` already
+    // returns a bare `.exe` as-is and unwraps a `.cmd`/`.bat`/extensionless
+    // shim via static parsing. Do NOT pre-scan for any `.exe` first: an
+    // earlier `.cmd` shim that resolves to a real target must win over a
+    // later bare `.exe`, e.g. a WinGet-installed `codex.cmd` ahead of the
+    // `WindowsApps\...` App Execution Alias stub some MSIX-packaged tools
+    // (e.g. the Codex desktop app) also add to PATH — Node's execFile/spawn
+    // throws EPERM on that stub, so picking it over an earlier working shim
+    // breaks CLI launch. Same PATH-order rule already applied to detection
+    // candidates in resolveCliCommand.ts (see #17376).
     for (const candidate of candidates) {
       const target = await inferWindowsNpmShimTarget(candidate);
       if (target) return target;


### PR DESCRIPTION
<!-- Brief and heads-up -->

On Windows, `resolveWindowsBareCommand` picked the **first `.exe`** returned by `where <command>`, ignoring PATH order entirely. When an MSIX App Execution Alias stub (e.g. `WindowsApps\...\codex.exe`, a zero-byte reparse-point placeholder) sits on PATH *after* a perfectly usable earlier `.cmd` shim (e.g. a WinGet-installed `codex.cmd`), that stub got picked over the working shim. Node's `spawn()`/`execFile()` throws `EPERM` trying to launch that stub directly, so `lh hetero exec -t codex` (and the desktop app's Codex launch) failed even though a working binary was available earlier on PATH.

This is the same class of bug already fixed for the *detection* path in `resolveCliCommand.ts` (PATH order must win over "prefer any `.exe`", see #17376) — the *spawn* path in `cliSpawn.ts` hadn't been updated to match.

Fix: walk `where`'s candidates in PATH order and let `inferWindowsNpmShimTarget` decide per-candidate (it already returns a bare `.exe` as-is and unwraps `.cmd`/`.bat`/extensionless shims via static parsing) — remove the eager "find any `.exe` first" pre-scan.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Added a regression test reproducing the exact scenario (`where codex` returning `[working WinGet codex.cmd, broken WindowsApps App Execution Alias codex.exe]` in that order) that fails before this fix and passes after it. Also fixed an existing test (`prefers a Windows executable returned by where`) that had asserted the buggy "skip the earlier .cmd, never even read it" behavior as expected.

`bunx vitest run src/spawn/cliSpawn.test.ts` — 14/14 passing.

Root cause diagnosed via a real Windows machine repro (`lh hetero exec -t codex` → `spawn EPERM`), confirmed with a minimal Node script directly reproducing `resolveWindowsBareCommand`'s candidate selection against the real `where codex` output on that machine.

#### 🔗 Related Issue

N/A