### PR TITLE
💚 ci(workbench): upload CDN assets to R2 before deploying the worker

### DIFF
--- a/.agents/skills/split-micro-app/SKILL.md
+++ b/.agents/skills/split-micro-app/SKILL.md
@@ -73,8 +73,10 @@ Assets follow the cloud convention (`resolveViteBase`): **stable prefix, no vers
 `VITE_CDN_BASE=https://web-assets.lobehub.com/<name>/`; content-hashed filenames make uploads
 incremental and immutable. `bun run deploy` (see `apps/workbench/scripts/deploy.ts`) =
 build with CDN base → upload `build/client/assets` to R2 (`web-assets` bucket, LobeHub
-account) → `wrangler deploy`. R2 creds: 1Password Shared vault item "CI R2 - web-assets", inject via
-`op read`, never echo values.
+account) → `wrangler deploy`. R2 creds: 1Password Shared vault item "CI R2 - web-assets".
+CI injects repo secrets `ASSET_S3_*` (`ACCESS_KEY_ID`, `SECRET_ACCESS_KEY`, `BUCKET`,
+`ENDPOINT`, `REGION`, `PUBLIC_DOMAIN`). Local `bun run deploy` can fall back to `MOBILE_S3_*`.
+Never echo values.
 
 Worker responsibilities beyond SSR: reverse-proxy `/api|/oidc|/trpc|/webapi` to
 `WORKBENCH_API_BASE` (standalone mode; behind the gateway the browser hits the apex and the

--- a/.env.example
+++ b/.env.example
@@ -270,6 +270,19 @@ OPENAI_API_KEY=sk-xxxxxxxxx
 # DOC_S3_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # #######################################
+# ### Web assets CDN (R2 / S3) ##########
+# #######################################
+
+# Shared CDN upload credentials (workbench `bun run deploy`, and other hashed SPA assets).
+# GitHub Actions: repo secrets with the same names.
+# ASSET_S3_ACCESS_KEY_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# ASSET_S3_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# ASSET_S3_BUCKET=web-assets
+# ASSET_S3_ENDPOINT=https://xxxxxxxxxxxxxxxxxxxxxxxxxxxxx.r2.cloudflarestorage.com
+# ASSET_S3_REGION=auto
+# ASSET_S3_PUBLIC_DOMAIN=https://web-assets.lobehub.com
+
+# #######################################
 # ### Mobile SPA S3 Workflow ############
 # #######################################
 

--- a/.github/workflows/deploy-workbench.yml
+++ b/.github/workflows/deploy-workbench.yml
@@ -71,16 +71,17 @@ jobs:
         if: steps.detect.outputs.should_build == 'true'
         run: pnpm install
 
-      - name: Build workbench
-        if: steps.detect.outputs.should_build == 'true'
-        run: bun run build:rr
-        working-directory: apps/workbench
-
-      - name: Deploy to Cloudflare
+      - name: Deploy workbench
         if: steps.detect.outputs.should_build == 'true'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: node_modules/.bin/wrangler deploy --config build/server/wrangler.json
+          ASSET_S3_ACCESS_KEY_ID: ${{ secrets.ASSET_S3_ACCESS_KEY_ID }}
+          ASSET_S3_BUCKET: ${{ secrets.ASSET_S3_BUCKET }}
+          ASSET_S3_ENDPOINT: ${{ secrets.ASSET_S3_ENDPOINT }}
+          ASSET_S3_PUBLIC_DOMAIN: ${{ secrets.ASSET_S3_PUBLIC_DOMAIN }}
+          ASSET_S3_REGION: ${{ secrets.ASSET_S3_REGION }}
+          ASSET_S3_SECRET_ACCESS_KEY: ${{ secrets.ASSET_S3_SECRET_ACCESS_KEY }}
+        run: bun run deploy
         working-directory: apps/workbench
 
       - name: Upload build-inputs manifest

--- a/apps/workbench/scripts/deploy.ts
+++ b/apps/workbench/scripts/deploy.ts
@@ -12,24 +12,28 @@ const assetsDir = resolve(workbenchRoot, 'build/client/assets');
 
 dotenv.config({ path: resolve(repoRoot, '.env') });
 
-const env = (workbenchName: string, mobileName: string) =>
-  process.env[workbenchName] || process.env[mobileName];
+const firstEnv = (...names: string[]) => {
+  for (const name of names) {
+    const value = process.env[name];
+    if (value) return value;
+  }
+  return undefined;
+};
 
-const requireEnv = (workbenchName: string, mobileName: string): string => {
-  const value = env(workbenchName, mobileName);
-  if (!value) throw new Error(`Missing env: ${workbenchName} (or fallback ${mobileName})`);
+const requireEnv = (...names: string[]): string => {
+  const value = firstEnv(...names);
+  if (!value) throw new Error(`Missing env: ${names.join(' / ')}`);
   return value;
 };
 
 async function main() {
-  const publicDomain = new URL(requireEnv('WORKBENCH_S3_PUBLIC_DOMAIN', 'MOBILE_S3_PUBLIC_DOMAIN'))
+  const publicDomain = new URL(requireEnv('ASSET_S3_PUBLIC_DOMAIN', 'MOBILE_S3_PUBLIC_DOMAIN'))
     .origin;
   // Same convention as cloud's resolveViteBase: a stable entry suffix, no version
   // stamp — content-hashed filenames make uploads incremental and cache-immutable.
-  const keyPrefix = (process.env.WORKBENCH_S3_KEY_PREFIX || 'workbench').replaceAll(
-    /^\/+|\/+$/g,
-    '',
-  );
+  const keyPrefix = (
+    firstEnv('ASSET_S3_KEY_PREFIX', 'WORKBENCH_S3_KEY_PREFIX') || 'workbench'
+  ).replaceAll(/^\/+|\/+$/g, '');
   const cdnBase = `${publicDomain}/${keyPrefix}/`;
 
   console.log(`=== Step 1: Build workbench (VITE_CDN_BASE=${cdnBase}) ===`);
@@ -48,13 +52,13 @@ async function main() {
 
   console.log('\n=== Step 2: Upload assets to S3 ===');
   await uploadAssets(assetsDir, {
-    accessKeyId: requireEnv('WORKBENCH_S3_ACCESS_KEY_ID', 'MOBILE_S3_ACCESS_KEY_ID'),
-    bucket: requireEnv('WORKBENCH_S3_BUCKET', 'MOBILE_S3_BUCKET'),
-    endpoint: requireEnv('WORKBENCH_S3_ENDPOINT', 'MOBILE_S3_ENDPOINT'),
+    accessKeyId: requireEnv('ASSET_S3_ACCESS_KEY_ID', 'MOBILE_S3_ACCESS_KEY_ID'),
+    bucket: requireEnv('ASSET_S3_BUCKET', 'MOBILE_S3_BUCKET'),
+    endpoint: requireEnv('ASSET_S3_ENDPOINT', 'MOBILE_S3_ENDPOINT'),
     keyPrefix,
     publicDomain,
-    region: env('WORKBENCH_S3_REGION', 'MOBILE_S3_REGION') || 'auto',
-    secretAccessKey: requireEnv('WORKBENCH_S3_SECRET_ACCESS_KEY', 'MOBILE_S3_SECRET_ACCESS_KEY'),
+    region: firstEnv('ASSET_S3_REGION', 'MOBILE_S3_REGION') || 'auto',
+    secretAccessKey: requireEnv('ASSET_S3_SECRET_ACCESS_KEY', 'MOBILE_S3_SECRET_ACCESS_KEY'),
   });
 
   console.log('\n=== Step 3: Deploy worker ===');


### PR DESCRIPTION
<!-- Brief and heads-up -->

Deploy Workbench was building the worker and running `wrangler deploy` only. Hashed `/workbench/` assets never reached R2, so production HTML 404'd after the last canary deploy. This runs `bun run deploy` (build with `VITE_CDN_BASE` → upload → wrangler) and injects the shared web-assets credentials.

| Before | After |
| ------ | ----- |
| `bun run build:rr` + wrangler only | `bun run deploy` uploads to `web-assets.lobehub.com/workbench/` then deploys the worker |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Verified: repo now has `ASSET_S3_*` Actions secrets (from 1Password Shared `CI R2 - web-assets`). Local `bun run deploy` still falls back to `MOBILE_S3_*`.

#### 🔗 Related Issue

Fixes production workbench asset 404 after canary deploy of #18473.