### PR TITLE
🐛 fix(agent-signal): stop the nightly self-review cron from hanging into a silent 524

### DIFF
--- a/apps/server/src/router-hono/workflows/agent-signal/handlers/__tests__/scheduleNightlyReview.test.ts
+++ b/apps/server/src/router-hono/workflows/agent-signal/handlers/__tests__/scheduleNightlyReview.test.ts
@@ -4,12 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { scheduleNightlyReview } from '../scheduleNightlyReview';
 
 const mocks = vi.hoisted(() => ({
-  triggerPaginateUsers: vi.fn(),
+  publishPaginateUsersEntry: vi.fn(),
 }));
 
 vi.mock('@/server/workflows/agentSignal/nightlyReview', () => ({
   AgentSignalNightlyReviewWorkflow: {
-    triggerPaginateUsers: mocks.triggerPaginateUsers,
+    publishPaginateUsersEntry: mocks.publishPaginateUsersEntry,
   },
 }));
 
@@ -26,7 +26,7 @@ describe('scheduleNightlyReview', () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-03T18:30:00.000Z'));
-    mocks.triggerPaginateUsers.mockResolvedValue({ workflowRunId: 'nightly-page-1' });
+    mocks.publishPaginateUsersEntry.mockResolvedValue({ messageId: 'nightly-message-1' });
   });
 
   afterEach(() => {
@@ -46,9 +46,9 @@ describe('scheduleNightlyReview', () => {
     await expect(response.json()).resolves.toEqual({
       scheduled: true,
       success: true,
-      workflowRunId: 'nightly-page-1',
+      messageId: 'nightly-message-1',
     });
-    expect(mocks.triggerPaginateUsers).toHaveBeenCalledWith({
+    expect(mocks.publishPaginateUsersEntry).toHaveBeenCalledWith({
       cursor: undefined,
       pageSize: 50,
       requestedAt: '2026-05-03T18:30:00.000Z',
@@ -77,14 +77,36 @@ describe('scheduleNightlyReview', () => {
     await expect(response.json()).resolves.toEqual({
       scheduled: true,
       success: true,
-      workflowRunId: 'nightly-page-1',
+      messageId: 'nightly-message-1',
     });
-    expect(mocks.triggerPaginateUsers).toHaveBeenCalledWith({
+    expect(mocks.publishPaginateUsersEntry).toHaveBeenCalledWith({
       cursor: { createdAt: '2026-05-04T00:00:00.000Z', id: 'user-1' },
       pageSize: 100,
       requestedAt: '2026-05-03T18:30:00.000Z',
       targetLimit: 5,
       whitelist: ['user-1'],
+    });
+  });
+
+  it('reports a failed publish as 500 so the error reaches the DLQ', async () => {
+    /**
+     * Regression: the publish used to stall until Cloudflare returned 524 with an empty body, so
+     * every failed tick landed in the DLQ carrying no diagnosis at all.
+     *
+     * @example
+     * expect(response.status).toBe(500);
+     */
+    mocks.publishPaginateUsersEntry.mockRejectedValue(
+      new Error('nightly review cron publish timed out after 10000ms'),
+    );
+
+    const response = await createApp().request('/cron-hourly-nightly-self-review', {
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: 'nightly review cron publish timed out after 10000ms',
     });
   });
 });

--- a/apps/server/src/router-hono/workflows/agent-signal/handlers/scheduleNightlyReview.ts
+++ b/apps/server/src/router-hono/workflows/agent-signal/handlers/scheduleNightlyReview.ts
@@ -127,16 +127,20 @@ export async function scheduleNightlyReview(c: Context) {
           : {}),
       });
 
-      const result = await AgentSignalNightlyReviewWorkflow.triggerPaginateUsers(options);
+      const startedAt = Date.now();
+      const result = await AgentSignalNightlyReviewWorkflow.publishPaginateUsersEntry(options);
 
       span.setAttributes({
+        'agent.signal.cron.publish_duration_ms': Date.now() - startedAt,
         'agent.signal.cron.success': true,
-        'agent.signal.cron.workflow_run_id': result.workflowRunId,
+        'agent.signal.cron.message_id': result.messageId,
       });
       span.setStatus({ code: SpanStatusCode.OK });
 
-      return c.json({ scheduled: true, success: true, workflowRunId: result.workflowRunId }, 202);
+      return c.json({ messageId: result.messageId, scheduled: true, success: true }, 202);
     } catch (error) {
+      // This log is the only trace a failed tick leaves behind: a stalled publish used to be
+      // killed by Cloudflare at 100s, which produced a 524 with no body and nothing on the server.
       console.error('[agent-signal/cron-hourly-nightly-self-review] Error:', error);
       span.setAttribute('agent.signal.cron.success', false);
       span.setStatus({

--- a/apps/server/src/workflows/agentSignal/__tests__/nightlyReview.test.ts
+++ b/apps/server/src/workflows/agentSignal/__tests__/nightlyReview.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   injectActiveTraceHeaders: vi.fn((headers: Headers) => {
     headers.set('traceparent', '00-trace-parent');
   }),
+  publishJSON: vi.fn(),
   trigger: vi.fn(),
 }));
 
@@ -22,6 +23,9 @@ vi.mock('@/libs/observability/traceparent', () => ({
 }));
 
 vi.mock('@/libs/qstash', () => ({
+  qstashClient: {
+    publishJSON: mocks.publishJSON,
+  },
   workflowClient: {
     trigger: mocks.trigger,
   },
@@ -30,6 +34,96 @@ vi.mock('@/libs/qstash', () => ({
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.trigger.mockResolvedValue({ workflowRunId: 'workflow-1' });
+  mocks.publishJSON.mockResolvedValue({ messageId: 'message-1' });
+});
+
+describe('AgentSignalNightlyReviewWorkflow cron entry', () => {
+  const payload = {
+    pageSize: 50,
+    requestedAt: '2026-05-03T18:30:00.000Z',
+    targetLimit: 20,
+  };
+
+  it('publishes the cron entry through the qstash client', async () => {
+    /**
+     * @example
+     * expect(publishJSON).toHaveBeenCalledWith(expect.objectContaining({ flowControl }));
+     */
+    await expect(
+      AgentSignalNightlyReviewWorkflow.publishPaginateUsersEntry(payload),
+    ).resolves.toEqual({ messageId: 'message-1' });
+
+    expect(mocks.publishJSON).toHaveBeenCalledWith({
+      body: payload,
+      flowControl: {
+        key: 'agent-signal.nightly-review.paginate-users',
+        parallelism: 1,
+      },
+      headers: { traceparent: '00-trace-parent' },
+      url: 'https://internal.example.com/api/workflows/agent-signal/paginate-nightly-review-users',
+    });
+  });
+
+  it('fails fast instead of hanging when the outbound publish stalls', async () => {
+    /**
+     * Regression: a stalled publish used to keep the handler open until Cloudflare returned 524,
+     * which left no error anywhere and silently killed nightly review for months.
+     *
+     * @example
+     * await expect(publishPaginateUsersEntry(payload)).rejects.toThrow('timed out');
+     */
+    vi.useFakeTimers();
+    mocks.publishJSON.mockReturnValue(new Promise(() => {}));
+
+    try {
+      const assertion = expect(
+        AgentSignalNightlyReviewWorkflow.publishPaginateUsersEntry(payload),
+      ).rejects.toThrow('nightly review cron publish timed out after 10000ms');
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps a late failure on the abandoned publish from going unhandled', async () => {
+    /**
+     * `Promise.race` cannot cancel the publish, so the orphan needs its own rejection handler.
+     *
+     * @example
+     * expect(unhandled).not.toHaveBeenCalled();
+     */
+    vi.useFakeTimers();
+
+    let rejectPublish: ((error: Error) => void) | undefined;
+    mocks.publishJSON.mockReturnValue(
+      new Promise((_, reject) => {
+        rejectPublish = reject;
+      }),
+    );
+
+    const unhandled = vi.fn();
+    process.on('unhandledRejection', unhandled);
+
+    try {
+      const assertion = expect(
+        AgentSignalNightlyReviewWorkflow.publishPaginateUsersEntry(payload),
+      ).rejects.toThrow('timed out');
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      await assertion;
+
+      rejectPublish?.(new Error('late qstash failure'));
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.resolve();
+
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', unhandled);
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('AgentSignalNightlyReviewWorkflow', () => {

--- a/apps/server/src/workflows/agentSignal/nightlyReview.ts
+++ b/apps/server/src/workflows/agentSignal/nightlyReview.ts
@@ -3,9 +3,20 @@ import debug from 'debug';
 
 import { appEnv } from '@/envs/app';
 import { injectActiveTraceHeaders } from '@/libs/observability/traceparent';
-import { workflowClient } from '@/libs/qstash';
+import { qstashClient, workflowClient } from '@/libs/qstash';
 
 const log = debug('lobe-server:workflows:agent-signal:nightly-review');
+
+/**
+ * Hard ceiling for every outbound publish in the nightly review chain.
+ *
+ * The QStash SDK retries five times with `exp(n) * 50ms` backoff and the underlying `fetch` has
+ * no timeout of its own, so a stalled outbound connection keeps the cron handler open until
+ * Cloudflare cuts the origin off at 100s — which surfaces as a 524 with an empty body and no
+ * server-side log at all. Failing fast here turns that silent black hole into a 500 whose error
+ * message reaches the QStash DLQ.
+ */
+export const NIGHTLY_REVIEW_PUBLISH_TIMEOUT_MS = 10_000;
 
 const WORKFLOW_PATHS = {
   executeUser: '/api/workflows/agent-signal/execute-nightly-review-user',
@@ -106,6 +117,34 @@ const getTriggerHeaders = (): Record<string, string> => {
 };
 
 /**
+ * Races an outbound publish against {@link NIGHTLY_REVIEW_PUBLISH_TIMEOUT_MS}.
+ *
+ * The abandoned publish keeps running — `Promise.race` cannot cancel it — so it gets its own
+ * no-op rejection handler: without one, a late failure on the orphaned promise surfaces as an
+ * unhandled rejection and can take the worker down.
+ */
+const withPublishTimeout = async <T>(publish: Promise<T>, label: string): Promise<T> => {
+  publish.catch(() => undefined);
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      publish,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(new Error(`${label} timed out after ${NIGHTLY_REVIEW_PUBLISH_TIMEOUT_MS}ms`)),
+          NIGHTLY_REVIEW_PUBLISH_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/**
  * Triggers the cursor-pagination and single-user layers of nightly review scheduling.
  *
  * Use when:
@@ -128,6 +167,34 @@ const getTriggerHeaders = (): Record<string, string> => {
  *         -> executeNightlyReviewUser
  */
 export class AgentSignalNightlyReviewWorkflow {
+  /**
+   * Starts the pagination tree from the hourly cron entry.
+   *
+   * Publishes through `@upstash/qstash` rather than the workflow client's `trigger()`: `serve()`
+   * treats a plain POST as a first invocation, and this is the publish path the task crons have
+   * been running in production without ever landing in the DLQ. The timeout keeps the cron
+   * handler inside Cloudflare's 100s origin budget no matter how the outbound call behaves.
+   */
+  static publishPaginateUsersEntry(payload: PaginateNightlyReviewUsersPayload) {
+    log('Publishing nightly review cron entry payload=%O', {
+      pageSize: payload.pageSize,
+      whitelist: payload.whitelist?.length ?? 0,
+    });
+
+    return withPublishTimeout(
+      qstashClient.publishJSON({
+        body: payload,
+        flowControl: {
+          key: NIGHTLY_REVIEW_PAGINATE_FLOW_CONTROL_KEY,
+          parallelism: 1,
+        } satisfies FlowControl,
+        headers: getTriggerHeaders(),
+        url: getWorkflowUrl(WORKFLOW_PATHS.paginateUsers),
+      }),
+      'nightly review cron publish',
+    );
+  }
+
   /** Triggers one database page or one bounded fan-out chunk. */
   static triggerPaginateUsers(payload: PaginateNightlyReviewUsersPayload) {
     log('Triggering nightly review user pagination payload=%O', {
@@ -136,29 +203,35 @@ export class AgentSignalNightlyReviewWorkflow {
       users: payload.users?.length ?? 0,
     });
 
-    return workflowClient.trigger({
-      body: payload,
-      flowControl: {
-        key: NIGHTLY_REVIEW_PAGINATE_FLOW_CONTROL_KEY,
-        parallelism: 1,
-      } satisfies FlowControl,
-      headers: getTriggerHeaders(),
-      url: getWorkflowUrl(WORKFLOW_PATHS.paginateUsers),
-    });
+    return withPublishTimeout(
+      workflowClient.trigger({
+        body: payload,
+        flowControl: {
+          key: NIGHTLY_REVIEW_PAGINATE_FLOW_CONTROL_KEY,
+          parallelism: 1,
+        } satisfies FlowControl,
+        headers: getTriggerHeaders(),
+        url: getWorkflowUrl(WORKFLOW_PATHS.paginateUsers),
+      }),
+      'nightly review pagination trigger',
+    );
   }
 
   /** Triggers one workflow that processes exactly one user. */
   static triggerExecuteUser(payload: ExecuteNightlyReviewUserPayload) {
     log('Triggering nightly review execution userId=%s', payload.user.id);
 
-    return workflowClient.trigger({
-      body: payload,
-      flowControl: {
-        key: NIGHTLY_REVIEW_EXECUTE_FLOW_CONTROL_KEY,
-        parallelism: 5,
-      } satisfies FlowControl,
-      headers: getTriggerHeaders(),
-      url: getWorkflowUrl(WORKFLOW_PATHS.executeUser),
-    });
+    return withPublishTimeout(
+      workflowClient.trigger({
+        body: payload,
+        flowControl: {
+          key: NIGHTLY_REVIEW_EXECUTE_FLOW_CONTROL_KEY,
+          parallelism: 5,
+        } satisfies FlowControl,
+        headers: getTriggerHeaders(),
+        url: getWorkflowUrl(WORKFLOW_PATHS.executeUser),
+      }),
+      'nightly review execution trigger',
+    );
   }
 }


### PR DESCRIPTION
#### Brief

The hourly nightly self-review cron has been silently failing for months — nightly review has produced **no Daily Brief since 2026-06-01** while the QStash schedule kept firing every hour. In the production DLQ this route shows up as **524 (Cloudflare origin timeout) with an empty body and no server-side log**, so nothing surfaced.

**Root cause.** `scheduleNightlyReview` publishes to QStash **synchronously inside the HTTP handler**, via `workflowClient.trigger()`, with **no timeout anywhere on the path** — the QStash SDK's underlying `fetch` has no timeout of its own and only does 5 retries with `exp(n)*50ms` backoff. When that outbound publish stalls, the handler stays open until Cloudflare cuts the origin off at 100s → 524 → QStash retries exhaust → DLQ, carrying zero diagnosis. That is why it could stay broken for two and a half months unnoticed.

The failure was isolated to this one entry publish (everything else was ruled out): routing + `qstashAuth` return in ~1.2s when probed, `injectActiveTraceHeaders` is fully synchronous, and the downstream `paginate` / `execute` workflow endpoints appear **0 times** in a 2000-entry DLQ sample — they were never reached, so the wall is the cron entry, not the pipeline logic (which produced briefs fine until 06-01).

#### What this changes

- Publish the cron entry through `qstashClient.publishJSON` — the exact publish path the **task cron runs in production without ever landing in the DLQ** (production is `AGENT_RUNTIME_MODE=queue`, so that path is genuinely exercised).
- Bound **every** outbound publish in the nightly-review chain by a **10s timeout**, so a failed tick now returns **500 with a real error message into the DLQ** instead of a silent 524.
- Give the abandoned publish its own rejection handler — `Promise.race` can't cancel it, and without a handler a late failure on the orphaned promise would surface as an unhandled rejection.

This is a transport-layer fix. It guarantees "succeed, or fail fast with a diagnosable error" — it does **not** by itself prove the outbound publish will now go through in production; if the next real tick lands a 500 + timeout in the DLQ, that error message is the next lead. The instrumentation (`publish_duration_ms` span attribute) is added for exactly that.

> **Note:** briefs stopped on 06-01, which coincides with the execAgent self-iteration migration — a **downstream** change, separate from this transport fix. Once the cron publishes again and the downstream runs, an end-to-end verification (targeted `whitelist` trigger) is still needed to confirm the migrated review path still emits briefs.

#### Test

- [x] Added/updated tests — new regression cases: a stalled publish fails fast at 10s instead of hanging; a late failure on the abandoned publish does not go unhandled; a failed publish is reported as 500 so the error reaches the DLQ.
- Checks: lint clean · 8 tests passed · types clean.

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

<!-- no matching GitHub/Linear issue -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)