### PR TITLE
🐛 fix(heterogeneous-agent): derive ingest types from registry

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/aiAgent.heteroIngest.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.heteroIngest.test.ts
@@ -3,6 +3,7 @@ import type { AgentStreamEvent } from '@lobechat/agent-gateway-client';
 import { type LobeChatDatabase } from '@lobechat/database';
 import { topics, workspaceMembers, workspaces } from '@lobechat/database/schemas';
 import { getTestDB } from '@lobechat/database/test-utils';
+import { LOCAL_HETEROGENEOUS_AGENT_TYPES } from '@lobechat/types';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -109,8 +110,8 @@ describe('aiAgentRouter.heteroIngest / heteroFinish', () => {
       });
     });
 
-    it.each(['opencode', 'trae'] as const)(
-      'accepts %s event batches from a device CLI',
+    it.each(LOCAL_HETEROGENEOUS_AGENT_TYPES)(
+      'accepts %s event batches from a local CLI',
       async (agentType) => {
         const events = [buildEvent('stream_start', 0)];
 
@@ -277,8 +278,8 @@ describe('aiAgentRouter.heteroIngest / heteroFinish', () => {
       });
     });
 
-    it.each(['opencode', 'trae'] as const)(
-      'accepts a %s session id for subsequent device resume',
+    it.each(LOCAL_HETEROGENEOUS_AGENT_TYPES)(
+      'accepts a %s session id for subsequent local CLI resume',
       async (agentType) => {
         await createCaller().heteroFinish({
           agentType,

--- a/apps/server/src/routers/lambda/aiAgent.ts
+++ b/apps/server/src/routers/lambda/aiAgent.ts
@@ -5,6 +5,7 @@ import { parse } from '@lobechat/conversation-flow';
 import type { TaskCurrentActivity, TaskStatusResult } from '@lobechat/types';
 import {
   entityIdPattern,
+  LocalHeterogeneousAgentTypeSchema,
   RequestTrigger,
   ThreadStatus,
   ThreadType,
@@ -610,18 +611,7 @@ const AgentStreamEventSchema = z.object({
  * → topic reverse-lookup is unreliable per design decision).
  */
 const HeteroIngestSchema = z.object({
-  agentType: z.enum([
-    'amp',
-    'claude-code',
-    'codebuddy',
-    'codex',
-    'cursor',
-    'kimi-code',
-    'opencode',
-    'pi',
-    'qoder',
-    'trae',
-  ]),
+  agentType: LocalHeterogeneousAgentTypeSchema,
   /** Initial assistant placeholder message id forwarded from the sandbox env var.
    * When present, `loadOrCreateState` uses it directly and skips the DB read of
    * topic.metadata.runningOperation, eliminating the replica-lag race condition. */
@@ -638,18 +628,7 @@ const HeteroIngestSchema = z.object({
  * (CC's per-cwd id), kept here so the server can resume next time.
  */
 const HeteroFinishSchema = z.object({
-  agentType: z.enum([
-    'amp',
-    'claude-code',
-    'codebuddy',
-    'codex',
-    'cursor',
-    'kimi-code',
-    'opencode',
-    'pi',
-    'qoder',
-    'trae',
-  ]),
+  agentType: LocalHeterogeneousAgentTypeSchema,
   /** Initial assistant placeholder forwarded by the producer. Unlike the live
    * ingest path, finish may arrive after gateway session completion has already
    * cleared topic.metadata.runningOperation, so this is the durable fallback

--- a/packages/heterogeneous-agents/src/config.ts
+++ b/packages/heterogeneous-agents/src/config.ts
@@ -7,7 +7,11 @@ import type {
   RemoteHeterogeneousAgentDescriptor,
   RemoteHeterogeneousAgentType,
 } from '@lobechat/types';
-import { HETEROGENEOUS_AGENT_CONFIGS, REMOTE_HETEROGENEOUS_AGENT_CONFIGS } from '@lobechat/types';
+import {
+  HETEROGENEOUS_AGENT_CONFIGS,
+  LOCAL_HETEROGENEOUS_AGENT_TYPES,
+  REMOTE_HETEROGENEOUS_AGENT_CONFIGS,
+} from '@lobechat/types';
 
 export type {
   HeterogeneousAgentDescriptor,
@@ -18,14 +22,16 @@ export type {
   RemoteHeterogeneousAgentDescriptor,
   RemoteHeterogeneousAgentType,
 };
-export { HETEROGENEOUS_AGENT_CONFIGS, REMOTE_HETEROGENEOUS_AGENT_CONFIGS };
+export {
+  HETEROGENEOUS_AGENT_CONFIGS,
+  LOCAL_HETEROGENEOUS_AGENT_TYPES,
+  REMOTE_HETEROGENEOUS_AGENT_CONFIGS,
+};
 
 /** @deprecated Use `LocalHeterogeneousAgentDescriptor`. */
 export type HeterogeneousAgentConfig = LocalHeterogeneousAgentDescriptor;
 /** @deprecated Use `RemoteHeterogeneousAgentDescriptor`. */
 export type RemoteHeterogeneousAgentConfig = RemoteHeterogeneousAgentDescriptor;
-
-export const LOCAL_HETEROGENEOUS_AGENT_TYPES = HETEROGENEOUS_AGENT_CONFIGS.map(({ type }) => type);
 
 const LOCAL_HETERO_TYPES = new Set<string>(LOCAL_HETEROGENEOUS_AGENT_TYPES);
 const REMOTE_HETERO_TYPES = new Set<string>(

--- a/packages/types/src/agent/heterogeneousAgent.ts
+++ b/packages/types/src/agent/heterogeneousAgent.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 import type { TopicGroupMode } from '../topic/topic';
 
 export interface HeterogeneousAgentAuthDescriptor {
@@ -331,6 +333,10 @@ export const HETEROGENEOUS_AGENT_CONFIGS = [
     type: 'trae',
   },
 ] as const satisfies readonly LocalHeterogeneousAgentDescriptor[];
+
+export const LOCAL_HETEROGENEOUS_AGENT_TYPES = HETEROGENEOUS_AGENT_CONFIGS.map(({ type }) => type);
+
+export const LocalHeterogeneousAgentTypeSchema = z.enum(LOCAL_HETEROGENEOUS_AGENT_TYPES);
 
 export interface RemoteHeterogeneousAgentDescriptor {
   kind: 'remote-task';


### PR DESCRIPTION
## Description of Change

- derive the local heterogeneous-agent runtime type list and Zod schema from `HETEROGENEOUS_AGENT_CONFIGS`
- reuse the shared schema in both `heteroIngest` and `heteroFinish` instead of maintaining duplicate enums
- re-export the shared type list from `@lobechat/heterogeneous-agents` to preserve the existing API
- exercise both endpoints against every registered local CLI agent, including Grok Build

This fixes Grok Build ingest and finish requests being rejected because its type was missing from the server-side enums, and prevents the same drift when future agents are added.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```text
bun run check packages/types/src/agent/heterogeneousAgent.ts packages/heterogeneous-agents/src/config.ts apps/server/src/routers/lambda/aiAgent.ts apps/server/src/routers/lambda/__tests__/aiAgent.heteroIngest.test.ts
✓ 4 files · lint clean · tests 55 passed
```

#### 🔗 Related Issue

No matching issue found.
