### PR TITLE
💄 style(hetero-model): keep the selector menu open while switching model settings

### DIFF
--- a/src/features/ArtworkStudio/Content.tsx
+++ b/src/features/ArtworkStudio/Content.tsx
@@ -6,8 +6,8 @@ import {
   type AgentArtworkStyle,
   DEFAULT_AGENT_ARTWORK_STYLE,
 } from '@lobechat/prompts';
-import { Alert, Avatar, Center, Flexbox, Icon, Tag, Text } from '@lobehub/ui';
-import { Button, useModalContext } from '@lobehub/ui/base-ui';
+import { Avatar, Center, Flexbox, Icon, Tag, Text } from '@lobehub/ui';
+import { Alert, Button, useModalContext } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { Check, SettingsIcon, UploadIcon, WandSparkles } from 'lucide-react';
 import { memo, useCallback, useRef, useState } from 'react';

--- a/src/features/ChatInput/ControlBar/HeteroModel/ModelCatalogSelector.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroModel/ModelCatalogSelector.tsx
@@ -279,6 +279,7 @@ export const ModelCatalogSelector = memo<ModelCatalogSelectorProps>(
     }
 
     const handleModelSelect = variant === 'submenu' ? onSelect : handleSelect;
+    const closeOnSelect = variant !== 'submenu';
     const menu = (
       <>
         <DropdownMenuHeader className={styles.search}>
@@ -305,6 +306,7 @@ export const ModelCatalogSelector = memo<ModelCatalogSelectorProps>(
         <DropdownMenuScrollViewport>
           <DropdownMenuItem
             className={styles.item}
+            closeOnClick={closeOnSelect}
             onClick={() => handleModelSelect(HETEROGENEOUS_AGENT_DEFAULT_SELECTION)}
           >
             <DropdownMenuItemContent>
@@ -357,6 +359,7 @@ export const ModelCatalogSelector = memo<ModelCatalogSelectorProps>(
                 return (
                   <DropdownMenuItem
                     className={styles.item}
+                    closeOnClick={closeOnSelect}
                     key={item.id}
                     onClick={() => handleModelSelect(item.id)}
                   >

--- a/src/features/ChatInput/ControlBar/HeteroModel/SelectorMenu.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroModel/SelectorMenu.tsx
@@ -15,7 +15,7 @@ import {
   DropdownMenuTrigger,
   renderDropdownMenuItems,
 } from '@lobehub/ui/base-ui';
-import { memo, useCallback, useMemo, useState } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { buildSelectorSubmenu } from './buildSelectorSubmenu';
@@ -34,7 +34,6 @@ interface SelectorMenuProps {
 const SelectorMenu = memo<SelectorMenuProps>(
   ({ agentId, capability, patch, permissionReason, provider }) => {
     const { t } = useTranslation('chat');
-    const [open, setOpen] = useState(false);
 
     const view = useMemo(
       () => buildSelectorView({ capability, provider, t }),
@@ -43,8 +42,6 @@ const SelectorMenu = memo<SelectorMenuProps>(
 
     const select = useCallback(
       (key: string, value: string) => {
-        setOpen(false);
-
         if (key === 'model' && capability.model)
           return void patch(
             resolveModelSwitchSelection({
@@ -74,12 +71,15 @@ const SelectorMenu = memo<SelectorMenuProps>(
     );
 
     return (
-      <DropdownMenuRoot open={open} onOpenChange={setOpen}>
+      <DropdownMenuRoot>
         <DropdownMenuTrigger nativeButton={false}>
           <Trigger ariaLabel={view.ariaLabel} fast={view.isFastSpeed} text={view.triggerText} />
         </DropdownMenuTrigger>
         <DropdownMenuPortal>
-          <DropdownMenuPositioner placement="topLeft" sideOffset={8}>
+          {/* The trigger label changes width as selections change, and it sits in the
+              right-anchored send area — only its right edge holds still. Aligning to
+              the left edge drags the open popup sideways on every pick. */}
+          <DropdownMenuPositioner placement="topRight" sideOffset={8}>
             <DropdownMenuPopup style={{ width: 240 }}>
               {view.isCatalogModel && (
                 <ModelCatalogSelector

--- a/src/features/ChatInput/ControlBar/HeteroModel/buildSelectorSubmenu.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroModel/buildSelectorSubmenu.tsx
@@ -41,6 +41,7 @@ export const buildSelectorSubmenu = <T extends string>({
   valueLabel: string;
 }): SelectorSubmenuItem => ({
   children: options.map((option) => ({
+    closeOnClick: false,
     desc: option.desc,
     extra: current === option.value ? checkIcon : undefined,
     key: `${label}-${option.value}`,


### PR DESCRIPTION
The heterogeneous agent model selector (the chip next to Send) closed its whole menu on every pick, so adjusting model → speed → reasoning effort meant reopening it three times.

Menu items now keep the menu open, and the popup is re-anchored so it stops drifting while it stays open.

| Before | After |
| ------ | ----- |
| Picking any value closes the menu; the next dimension needs a reopen | Picking a value only patches the config; the checkmark updates in place and the menu stays open until outside click / Esc |
| With the menu held open, each pick resized the trigger label and dragged the popup sideways | Popup is aligned to the trigger's right edge, which does not move, so it stays put |

#### What changed

- `buildSelectorSubmenu.tsx` — dimension options (mode / speed / effort / model switch) set `closeOnClick: false`.
- `ModelCatalogSelector.tsx` — model rows set `closeOnClick={false}` **only** in the `submenu` variant. The `standalone` variant keeps closing on click, because it defers the selection through `useMenuContentLifecycle` (`onOpenChangeComplete` fires the actual `onSelect`) and would never commit if the menu never closed.
- `SelectorMenu.tsx` — dropped `setOpen(false)` from `select()`; the remaining `open` / `onOpenChange` pair was a pure passthrough, so the controlled state is gone and `DropdownMenuRoot` is uncontrolled. Placement moved from `topLeft` to `topRight` (`{side: 'top', align: 'end'}`): `HeteroModel` renders in the right-anchored send-area prefix, where the trigger's right edge is the only stable one — the label width varies with the selected model name.

`disableAnchorTracking` was deliberately not used; freezing the anchor would also stop legitimate repositioning on window resize or composer growth.

#### Test

- `bun run check` on the three touched files: lint clean, no related tests.
- `bun run check --type`: no errors in these files (the remaining failures are pre-existing, unrelated drizzle duplicate-instance noise elsewhere in the repo).
- Not driven in a running app — the drift fix is positioning-only and was reasoned from the layout, so a quick manual look at the chip is worth it before merge.

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

None — no matching open issue found.