### PR TITLE
chore: remove internal LOBE issue references from code comments

### DIFF
--- a/apps/server/src/services/workRegistration/localRunWorkRegistration.ts
+++ b/apps/server/src/services/workRegistration/localRunWorkRegistration.ts
@@ -33,7 +33,7 @@ export interface LocalRunShellWorksResult {
  * Those runs never reach `registerWorksForOperation` — the sole caller of the
  * shell scan — because they create no server operation and never call
  * `heteroFinish`; their `gh pr create` output lands as plain persisted tool
- * messages that nothing inspects (LOBE-12514). The client executor therefore
+ * messages that nothing inspects. The client executor therefore
  * reports the run's persisted tool message ids at clean completion, and this
  * service replays the SAME scan engine over those rows:
  *

--- a/src/features/Portal/LocalFile/Body.tsx
+++ b/src/features/Portal/LocalFile/Body.tsx
@@ -497,7 +497,7 @@ const ActiveFileView = memo<ActiveFileViewProps>(
           {/* Key by source + path: without a remount, switching between two files of
               the same document type reuses the pane instance, whose local
               loading/parse state isn't reset on blob change — the previous file's
-              rendered content lingers until the new one finishes (LOBE-13010). */}
+              rendered content lingers until the new one finishes. */}
           <DocumentPreview
             blob={preview.blob}
             contentType={preview.contentType}


### PR DESCRIPTION
## Summary

Removes two remaining internal `LOBE-XXX` issue references from code comments. Each comment already explains its rationale in plain language, so only the opaque citations are dropped — code semantics are unchanged.

## Changed files

- `apps/server/src/services/workRegistration/localRunWorkRegistration.ts` — dropped `(LOBE-12514)` from the desktop-local heterogeneous run shell-scan comment.
- `src/features/Portal/LocalFile/Body.tsx` — dropped `(LOBE-13010)` from the document-preview remount comment.

## Context

- `LOBE-12514` — validating hetero agent shell `gh` command → GitHub work-card registration.
- `LOBE-13010` — aggregated acceptance findings; the cited case is the stale preview-portal content when switching files.

## Not touched

- `packages/trpc/src/client/lambda.ts` (`LOBE-13229`) — already handled by open PR #18482.
- `src/features/EditorCanvas/fileDownload.ts` (`LOBE-12762`) — already handled by open PR #18399.
- `packages/locales/.../project.ts` (`LOBE-123`) — user-facing locale example, not a code comment.
