### PR TITLE
🐛 fix(agent-runtime): stop sanitizeNullBytes from corrupting escape text

### DIFF
--- a/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
+++ b/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
@@ -52,7 +52,33 @@ describe('formatErrorForState', () => {
 
       expect(result.type).toBe(ChatErrorType.InternalServerError);
       expect(result.message).toBe('boom');
-      expect(result.body).toEqual({ name: 'TypeError' });
+      expect(result.body).toMatchObject({ name: 'TypeError' });
+    });
+
+    it('persists the stack of an unclassified Error so the throw site is locatable', () => {
+      // `name` + `message` alone are useless for a recurring
+      // `SyntaxError: Bad escaped character in JSON at position N` — the only
+      // thing that identifies which `JSON.parse` blew up is the stack.
+      const result = formatErrorForState(new SyntaxError('Bad escaped character in JSON'));
+
+      expect((result.body as { stack?: string }).stack).toContain('formatErrorForState.test');
+    });
+
+    it('truncates an oversized stack instead of storing it whole', () => {
+      const error = new Error('boom');
+      error.stack = 'x'.repeat(10_000);
+
+      const stack = (formatErrorForState(error).body as { stack?: string }).stack;
+
+      expect(stack).toHaveLength(1001);
+      expect(stack?.endsWith('…')).toBe(true);
+    });
+
+    it('omits `stack` when the thrown Error carries none', () => {
+      const error = new Error('boom');
+      error.stack = undefined;
+
+      expect((formatErrorForState(error).body as { stack?: string }).stack).toBeUndefined();
     });
 
     it('falls back to AgentRuntimeError for unknown thrown values', () => {

--- a/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
+++ b/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
@@ -56,11 +56,32 @@ describe('formatErrorForState', () => {
     });
 
     it('persists the stack of an unclassified Error so the throw site is locatable', () => {
-      // `name` + `message` alone are useless for a recurring
-      // `SyntaxError: Bad escaped character in JSON at position N` — the only
-      // thing that identifies which `JSON.parse` blew up is the stack.
-      const result = formatErrorForState(new SyntaxError('Bad escaped character in JSON'));
+      // `name` + `message` alone are useless for a recurring harness 500 — the
+      // only thing that identifies where it blew up is the stack.
+      const result = formatErrorForState(new Error('some opaque internal failure'));
 
+      expect(result.type).toBe(ChatErrorType.InternalServerError);
+      expect((result.body as { stack?: string }).stack).toContain('formatErrorForState.test');
+    });
+
+    it('classifies a harness JSON.parse throw instead of leaving a bare 500', () => {
+      // The production shape: `SyntaxError` out of a harness `JSON.parse`,
+      // previously stored as `{ type: 500, body: { name: 'SyntaxError' } }` with
+      // no attribution, category or failure accounting at all.
+      const result = formatErrorForState(
+        new SyntaxError('Bad escaped character in JSON at position 46269 (line 1 column 46270)'),
+      );
+
+      expect(result.type).toBe(AgentRuntimeErrorType.HarnessJsonParseError);
+      expect(result.attribution).toBe('harness');
+      expect(result.category).toBe('stream');
+      expect(result.numericId).toBe(7008);
+      expect(result.countAsFailure).toBe(true);
+      // Deterministic — the same corrupt payload re-parses to the same failure,
+      // so a transport retry would only re-burn the run's tokens.
+      expect(result.retryable).toBe(false);
+      // Classification must not cost us the throw site.
+      expect((result.body as { name?: string; stack?: string }).name).toBe('SyntaxError');
       expect((result.body as { stack?: string }).stack).toContain('formatErrorForState.test');
     });
 

--- a/apps/server/src/modules/AgentRuntime/formatErrorForState.ts
+++ b/apps/server/src/modules/AgentRuntime/formatErrorForState.ts
@@ -97,6 +97,18 @@ const buildPayloadBody = (
 };
 
 /**
+ * Cap a stack before it lands in `agent_operations.error` / trace snapshots.
+ * The top frames identify the throw site; the rest is runtime plumbing that
+ * would only bloat every stored error row.
+ */
+const STACK_MAX_CHARS = 1000;
+
+const truncateStack = (stack: string | undefined): string | undefined => {
+  if (!stack) return undefined;
+  return stack.length > STACK_MAX_CHARS ? `${stack.slice(0, STACK_MAX_CHARS)}…` : stack;
+};
+
+/**
  * Merge classification metadata from `ERROR_CODE_SPECS` onto a normalized
  * `ChatMessageError`. Codes that aren't in the spec table (fallbacks like
  * `InternalServerError`, or numeric ChatErrorType values) pass through
@@ -208,8 +220,14 @@ export const formatErrorForState = (error: unknown): ChatMessageError => {
       };
     }
 
+    // Unclassified harness throw: nothing upstream recognized it, so `name` +
+    // `message` are all the triage signal there is — and for a `SyntaxError`
+    // out of some `JSON.parse` those two say nothing about WHERE it blew up.
+    // Persist the stack (bounded; frames are what matter, not a runaway trace)
+    // the way the pg branch already persists `pg`, so a recurring 500 is
+    // locatable from the stored operation instead of needing a live repro.
     return enrichWithSpec({
-      body: { name: error.name },
+      body: { name: error.name, stack: truncateStack(error.stack) },
       message: error.message,
       type: ChatErrorType.InternalServerError,
     });

--- a/locales/en-US/modelRuntime.json
+++ b/locales/en-US/modelRuntime.json
@@ -13,6 +13,7 @@
   "ContextEnginePipelineError": "Failed to assemble the conversation context for this request. Please try again; if it persists, contact support.",
   "DatabasePersistError": "A database operation failed while saving or loading this conversation. Please try again; if it persists, contact support.",
   "ExceededContextWindow": "The current request content exceeds the length that the model can handle. Please reduce the amount of content and try again.",
+  "HarnessJsonParseError": "An internal payload could not be read back, so this operation stopped. Retrying the same request will hit the same failure — please start a new message; if it persists, contact support.",
   "InsufficientQuota": "Sorry, the quota for this key has been reached. Please check if your account balance is sufficient or try again after increasing the key's quota.",
   "InvalidBedrockCredentials": "Bedrock authentication failed. Please check the AccessKeyId/SecretAccessKey and retry.",
   "InvalidComfyUIArgs": "Invalid ComfyUI configuration. Please check the settings and try again.",

--- a/locales/zh-CN/modelRuntime.json
+++ b/locales/zh-CN/modelRuntime.json
@@ -13,6 +13,7 @@
   "ContextEnginePipelineError": "组装此请求的对话上下文失败。请重试；如果问题仍然存在，请联系支持。",
   "DatabasePersistError": "保存或加载此对话时数据库操作失败。请重试；如果问题仍然存在，请联系支持。",
   "ExceededContextWindow": "当前请求内容超出了模型可处理的长度。请减少内容量并重试。",
+  "HarnessJsonParseError": "内部数据回读失败，本次操作已中止。重试同一请求会遇到同样的失败，请重新发起一条消息；如果问题仍然存在，请联系支持。",
   "InsufficientQuota": "抱歉，此密钥的配额已用尽。请检查您的账户余额是否充足或在增加密钥配额后重试。",
   "InvalidBedrockCredentials": "Bedrock身份验证失败。请检查AccessKeyId/SecretAccessKey并重试。",
   "InvalidComfyUIArgs": "ComfyUI配置无效。请检查设置并重试。",

--- a/packages/locales/src/default/modelRuntime.ts
+++ b/packages/locales/src/default/modelRuntime.ts
@@ -26,6 +26,8 @@ export default {
     'A database operation failed while saving or loading this conversation. Please try again; if it persists, contact support.',
   ExceededContextWindow:
     'The current request content exceeds the length that the model can handle. Please reduce the amount of content and try again.',
+  HarnessJsonParseError:
+    'An internal payload could not be read back, so this operation stopped. Retrying the same request will hit the same failure — please start a new message; if it persists, contact support.',
   InsufficientQuota:
     "Sorry, the quota for this key has been reached. Please check if your account balance is sufficient or try again after increasing the key's quota.",
   InvalidBedrockCredentials:

--- a/packages/model-runtime/src/errors/patterns.ts
+++ b/packages/model-runtime/src/errors/patterns.ts
@@ -1259,6 +1259,30 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   },
 
   // ─────────────────────────────────────────────────────────────────────────
+  // HarnessJsonParseError — a `JSON.parse` inside the harness threw. Sits after
+  // every provider section so an upstream body that merely quotes a JSON parse
+  // failure is claimed by its provider pattern first, and before the
+  // AgentRuntimeError fallbacks so this class keeps its own code instead of
+  // dissolving into the generic crash bucket.
+  //
+  // V8 phrases every JSON.parse failure one of two ways, so these two patterns
+  // cover the whole family: "Bad escaped character in JSON at position N",
+  // "Unterminated string in JSON at position N", "Unexpected token 'x', … is
+  // not valid JSON", "Expected ',' or '}' after property value in JSON at
+  // position N" — and the position-less "Unexpected end of JSON input".
+  // ─────────────────────────────────────────────────────────────────────────
+  {
+    code: AgentRuntimeErrorType.HarnessJsonParseError,
+    match: sub(' in JSON at position '),
+    note: 'V8 JSON.parse SyntaxError carrying a byte offset.',
+  },
+  {
+    code: AgentRuntimeErrorType.HarnessJsonParseError,
+    match: sub('Unexpected end of JSON input'),
+    note: 'V8 JSON.parse SyntaxError on a truncated payload (no offset).',
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
   // AgentRuntimeError — harness-side JS runtime crashes (V8 TypeError /
   // RangeError). Our bugs, not upstream provider errors, so they stay LAST: a
   // more specific provider/harness pattern above wins first, and only genuine

--- a/packages/model-runtime/src/errors/refine.test.ts
+++ b/packages/model-runtime/src/errors/refine.test.ts
@@ -35,6 +35,38 @@ describe('refineErrorCode', () => {
       ).toBe(AgentRuntimeErrorType.DatabasePersistError);
     });
 
+    it('reclassifies a 500-wrapped V8 JSON.parse throw into HarnessJsonParseError', () => {
+      // The production shape: a `SyntaxError` out of some harness `JSON.parse`,
+      // wrapped as a bare 500 and therefore invisible to every dashboard.
+      expect(
+        refineErrorCode({
+          errorType: String(ChatErrorType.InternalServerError),
+          message: 'Bad escaped character in JSON at position 46269 (line 1 column 46270)',
+        }),
+      ).toBe(AgentRuntimeErrorType.HarnessJsonParseError);
+    });
+
+    it.each([
+      'Unterminated string in JSON at position 12 (line 1 column 13)',
+      "Expected ',' or '}' after property value in JSON at position 23",
+      'Unexpected end of JSON input',
+    ])('covers the other V8 JSON.parse phrasings: %s', (message) => {
+      expect(
+        refineErrorCode({ errorType: String(ChatErrorType.InternalServerError), message }),
+      ).toBe(AgentRuntimeErrorType.HarnessJsonParseError);
+    });
+
+    it('does not claim a JSON-parse phrase coming from a typed provider error', () => {
+      // Only the catch-all wrappers are refinable, so an upstream body that
+      // merely quotes a parse failure keeps its own provider code.
+      expect(
+        refineErrorCode({
+          errorType: AgentRuntimeErrorType.ProviderServiceUnavailable,
+          message: 'upstream said: Unexpected end of JSON input',
+        }),
+      ).toBeUndefined();
+    });
+
     it('leaves a 500 wrapper unrefined when nothing matches', () => {
       expect(
         refineErrorCode({

--- a/packages/model-runtime/src/errors/specs.ts
+++ b/packages/model-runtime/src/errors/specs.ts
@@ -431,6 +431,21 @@ export const ERROR_CODE_SPECS: SpecMap = {
       'State-store (Redis / Upstash) read failed: a blocking read (XREAD / BLPOP) aborted because the caller disconnected ("ERR caller gone"), or the operation\'s agent state could not be loaded ("Agent state not found for operation …"). System-side — counts as a failure.',
   },
 
+  [AgentRuntimeErrorType.HarnessJsonParseError]: {
+    code: AgentRuntimeErrorType.HarnessJsonParseError,
+    numericId: 7008,
+    category: 'stream',
+    severity: 'error',
+    attribution: 'harness',
+    httpStatus: 500,
+    // Deterministic: the same corrupt payload re-parses to the same failure, so
+    // a transport retry only re-burns the run's tokens.
+    retryable: false,
+    countAsFailure: true,
+    description:
+      'A harness-side `JSON.parse` threw on data the harness produced or stored ("… in JSON at position N" / "Unexpected end of JSON input") — a serialization bug, not an upstream response.',
+  },
+
   // ─── 8xxx Provider (catch-all) ────────────────────────────────────────
   [AgentRuntimeErrorType.AgentRuntimeError]: {
     code: AgentRuntimeErrorType.AgentRuntimeError,

--- a/packages/types/src/agentRuntime.ts
+++ b/packages/types/src/agentRuntime.ts
@@ -163,6 +163,16 @@ export const AgentRuntimeErrorType = {
    * to this code in the spec table).
    */
   ContextEnginePipelineError: 'ContextEnginePipelineError',
+  /**
+   * A `JSON.parse` inside the harness threw on data the harness itself
+   * produced, stored or round-tripped — V8 reports it as `SyntaxError: … in
+   * JSON at position N` / `Unexpected end of JSON input`. Always our bug: the
+   * value should have been valid JSON by construction, so a failure means some
+   * serialization step corrupted or truncated it. Kept out of the
+   * `AgentRuntimeError` catch-all so this class stays countable on its own
+   * instead of hiding inside the generic fallback bucket.
+   */
+  HarnessJsonParseError: 'HarnessJsonParseError',
 
   InvalidGithubToken: 'InvalidGithubToken',
   InvalidGithubCopilotToken: 'InvalidGithubCopilotToken',

--- a/packages/utils/src/sanitizeNullBytes.test.ts
+++ b/packages/utils/src/sanitizeNullBytes.test.ts
@@ -65,4 +65,46 @@ describe('sanitizeNullBytes', () => {
     const result = sanitizeNullBytes(arr);
     expect(result).toEqual(['ab', 'cd']);
   });
+
+  // --- regression: text that SPELLS OUT a \u0000 escape must survive ---
+
+  it('should not throw on a string containing a literal \u0000 escape sequence', () => {
+    // Real tool results carry this text verbatim: regex character classes,
+    // `GROUP_KEY_SEP = "\u0000"`, smali metadata, base64 dumps. The old
+    // stringify -> strip -> parse implementation doubled the leading backslash,
+    // matched the needle one character late, ate the escape's own backslash and
+    // died with `Bad escaped character in JSON at position N` — failing the
+    // whole agent operation from the tool-result persist path.
+    const state = { content: "key = x.theme + '\\u0000' + x.category" };
+
+    expect(() => sanitizeNullBytes(state)).not.toThrow();
+    expect(sanitizeNullBytes(state).content).toBe(state.content);
+  });
+
+  it('should preserve a literal \u0000 escape followed by an invalid escape char', () => {
+    // The orphan backslash used to land in front of `U`, which is not a legal
+    // JSON escape — the exact shape reported from Windows agents.
+    const state = { path: 'C:\\u0000Users' };
+
+    expect(sanitizeNullBytes(state).path).toBe('C:\\u0000Users');
+  });
+
+  it('should preserve a literal \u0000 escape at the end of a string', () => {
+    // The orphan backslash used to swallow the closing quote instead.
+    const state = { snippet: 'SEP = "\\u0000"' };
+
+    expect(sanitizeNullBytes(state).snippet).toBe('SEP = "\\u0000"');
+  });
+
+  it('should strip real null bytes while leaving literal escape text alone', () => {
+    const state = { line: 'a\u0000b, literal: \\u0000' };
+
+    expect(sanitizeNullBytes(state).line).toBe('ab, literal: \\u0000');
+  });
+
+  it('should sanitize null bytes in object keys', () => {
+    const obj = { ['a\u0000b']: 1 };
+
+    expect(Object.keys(sanitizeNullBytes(obj))).toEqual(['ab']);
+  });
 });

--- a/packages/utils/src/sanitizeNullBytes.ts
+++ b/packages/utils/src/sanitizeNullBytes.ts
@@ -1,23 +1,54 @@
+/** A real U+0000 character. Built at runtime so no source file carries one. */
+const NUL = String.fromCodePoint(0);
+
 /**
- * Sanitize null bytes (\u0000) from values before PostgreSQL insertion.
- * PostgreSQL cannot store \u0000 in text/jsonb columns.
+ * A NUL immediately followed by two hex digits is a double-decoding artifact:
+ * an `é` that round-tripped as NUL + `e9` instead of `é`. Fold those back into
+ * the character they meant.
+ */
+const CORRUPTED_ESCAPE = new RegExp(`${NUL}([0-9a-f]{2})`, 'gi');
+
+const sanitizeString = (value: string): string =>
+  value.includes(NUL)
+    ? value
+        .replaceAll(CORRUPTED_ESCAPE, (_match, hex: string) =>
+          String.fromCharCode(Number.parseInt(hex, 16)),
+        )
+        .replaceAll(NUL, '')
+    : value;
+
+/**
+ * Sanitize null bytes from values before PostgreSQL insertion — PostgreSQL
+ * cannot store U+0000 in text/jsonb columns.
  *
- * For strings: directly removes null bytes.
- * For objects: serializes to JSON, recovers corrupted Unicode escapes
- * (e.g. \u0000e9 → \u00e9 = é), strips remaining null escapes, then parses back.
+ * Walks the value and rewrites every string in place. It deliberately does NOT
+ * round-trip through `JSON.stringify` -> string surgery -> `JSON.parse`.
+ *
+ * That round trip corrupts any payload whose TEXT spells out a unicode escape
+ * for U+0000 (regex character classes, `GROUP_KEY_SEP` constants, smali /
+ * Kotlin metadata, base64 dumps — everything a coding agent reads out of real
+ * source files). `stringify` doubles that text's leading backslash, so the
+ * six-character needle then matches one character late; stripping it eats the
+ * escape's own backslash and leaves an orphan trailing backslash, and the
+ * re-parse dies with `SyntaxError: Bad escaped character in JSON at position
+ * N`. Thrown from the tool-result persist path, that killed the whole agent
+ * operation. Operating on decoded values can never reach an escape sequence,
+ * so the literal text is left untouched.
+ *
+ * Mirrors `stripNulDeep` in `@lobechat/heterogeneous-agents`, plus the
+ * corrupted-Unicode recovery above.
  */
 export const sanitizeNullBytes = <T>(val: T): T => {
   if (val == null) return val;
 
-  if (typeof val === 'string') {
-    return val.replaceAll('\0', '') as T;
-  }
+  if (typeof val === 'string') return sanitizeString(val) as T;
+
+  if (Array.isArray(val)) return val.map((item) => sanitizeNullBytes(item)) as T;
 
   if (typeof val === 'object') {
-    const json = JSON.stringify(val);
-    // Recover corrupted Unicode: \u0000XX → \u00XX, then strip remaining \u0000
-    const fixed = json.replaceAll(/\\u0000([0-9a-fA-F]{2})/g, '\\u00$1').replaceAll('\\u0000', '');
-    return JSON.parse(fixed);
+    return Object.fromEntries(
+      Object.entries(val).map(([key, value]) => [sanitizeString(key), sanitizeNullBytes(value)]),
+    ) as T;
   }
 
   return val;


### PR DESCRIPTION
`sanitizeNullBytes` round-trips objects through `JSON.stringify` → string surgery → `JSON.parse`:

```ts
const json = JSON.stringify(val);
const fixed = json.replaceAll(/\\^@([0-9a-fA-F]{2})/g, '\\u00$1').replaceAll('\\^@', '');
return JSON.parse(fixed);
```

That is safe only for *real* U+0000 characters. When a payload's **text** spells out a unicode escape for U+0000 — regex character classes, `GROUP_KEY_SEP` constants, smali / Kotlin metadata, base64 dumps, i.e. everything a coding agent reads out of real source files — `stringify` doubles that text's leading backslash, so the six-character needle matches one character late. Stripping it eats the escape's own backslash, leaves an orphan trailing backslash, and the re-parse dies:

```
SyntaxError: Bad escaped character in JSON at position N (line 1 column N+1)
```

It is called on `messagePlugins.state` in the tool-result persist path (`MessageModel.buildMessageInsertValue` / `insertMessageRelationsInTransaction`), so the throw escapes as an unclassified 500 and fails the entire agent operation — after the run has already burned its tokens.

Production impact: **316 failed `agent_operations` across 116 users since 2026-04-30**, still occurring. Provider-agnostic (openrouter / nvidia / volcengine / faro), so it was never an upstream model or gateway problem. Offsets stay fixed per repeated call and scale with payload size (90 → 499151), which is what a deterministic re-parse of the same blob looks like. A sample of the recent 50k persisted `message_plugins` rows shows this content class in the wild, all from `readFile` / `runCommand` / `editFile`.

#### Change

- **`packages/utils/src/sanitizeNullBytes.ts`** — walk the value and rewrite decoded strings, the way `stripNulDeep` in `@lobechat/heterogeneous-agents` already does. Decoded values can never reach an escape sequence, so literal escape text survives untouched. The corrupted-Unicode recovery (NUL + two hex digits → the character it meant, `montée`) is preserved, just applied to string values instead of JSON text. This also removes a silent data-corruption path: the old regex rewrote that pattern inside literal escape text too.
- **`apps/server/src/modules/AgentRuntime/formatErrorForState.ts`** — persist a bounded `stack` (1000 chars) on the unclassified-`Error` branch. `{ name, message }` alone is why four months of this 500 could not be traced to a call site; the pg branch already keeps its extra context, this one dropped everything.

- **`packages/model-runtime/src/errors/`** + `packages/types` + locales — a dedicated code for this class. The `SyntaxError` used to land on the bare `InternalServerError` fallback: no attribution, no category, no severity, no `countAsFailure`, no stable id, so all 316 operations were indistinguishable from any other 500 on the dashboards. New `HarnessJsonParseError` (`E7008`, category `stream`, attribution `harness`, `countAsFailure: true`, `retryable: false`) plus the two V8 phrasings in the pattern registry — `… in JSON at position N` and `Unexpected end of JSON input`. Registered after every provider section so an upstream body quoting a parse failure keeps its provider code, and before the `AgentRuntimeError` crash fallbacks so it does not dissolve into that catch-all. `retryable: false` states the fact rather than changing behavior — nothing in the agent runtime acts on `retryable` today, it is classification metadata.

No behavior change for callers that pass strings (unchanged fast path) or objects without null bytes.

| Before | After |
| ------ | ----- |
| `{ path: 'C:\^@Users' }` (literal escape text) → throws `Bad escaped character in JSON at position 9`, operation fails with a 500 | returned unchanged |
| `{ snippet: 'SEP = "\^@"' }` → throws `Unterminated string in JSON` | returned unchanged |
| unclassified `SyntaxError` stored as `{ type: 500, body: { name: 'SyntaxError' } }` | stores `E7008 HarnessJsonParseError` + `{ name, stack }`, attributed to `harness` and counted as a failure |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Five regression tests in `sanitizeNullBytes.test.ts`; four of them fail on `canary` with the exact production `SyntaxError` and pass after the fix (the fifth is an object-key parity check that passes on both). Three tests cover the stack capture, its truncation, and the stackless case; the classification is covered end-to-end in `formatErrorForState.test.ts` plus four `refine.test.ts` cases (all V8 phrasings, and a negative case proving a typed provider error is not claimed). All 54 tests across the eight touched files pass, plus the full `model-runtime/src/errors` suite (158) and the error-message locale tests (22). Lint and type-check clean.

#### 🔗 Related Issue

Not filed — surfaced from Discord reports plus the production `agent_operations` data above.


