### PR TITLE
💄 style(tool-ui): use the lucide image icon for image files in tool rows

### DIFF
--- a/packages/shared-tool-ui/src/components/FilePathDisplay.tsx
+++ b/packages/shared-tool-ui/src/components/FilePathDisplay.tsx
@@ -1,9 +1,27 @@
 'use client';
 
-import { MaterialFileTypeIcon, Text } from '@lobehub/ui';
+import { Icon, MaterialFileTypeIcon, Text } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
+import { ImageIcon } from 'lucide-react';
 import path from 'path-browserify-esm';
 import { memo, useMemo } from 'react';
+
+const IMAGE_EXTENSIONS = new Set([
+  '.apng',
+  '.avif',
+  '.bmp',
+  '.gif',
+  '.heic',
+  '.heif',
+  '.ico',
+  '.jpeg',
+  '.jpg',
+  '.png',
+  '.svg',
+  '.tif',
+  '.tiff',
+  '.webp',
+]);
 
 const styles = createStaticStyles(({ css }) => ({
   icon: css`
@@ -22,34 +40,41 @@ interface FilePathDisplayProps {
 }
 
 export const getFilePathDisplayInfo = (filePath: string) => {
-  if (!filePath) return { displayPath: '', name: '' };
+  if (!filePath) return { displayPath: '', isImage: false, name: '' };
 
-  const { base, dir } = path.parse(filePath);
+  const { base, dir, ext } = path.parse(filePath);
   const parentDir = path.basename(dir);
 
   return {
     displayPath: parentDir ? `${parentDir}/${base}` : base,
+    isImage: IMAGE_EXTENSIONS.has(ext.toLowerCase()),
     name: base,
   };
 };
 
 export const FilePathDisplay = memo<FilePathDisplayProps>(({ filePath, isDirectory }) => {
-  const { displayPath, name } = useMemo(() => getFilePathDisplayInfo(filePath), [filePath]);
+  const { displayPath, isImage, name } = useMemo(
+    () => getFilePathDisplayInfo(filePath),
+    [filePath],
+  );
 
   if (!filePath) return null;
 
   return (
     <>
-      {name && (
-        <MaterialFileTypeIcon
-          className={styles.icon}
-          fallbackUnknownType={false}
-          filename={name}
-          size={16}
-          type={isDirectory ? 'folder' : 'file'}
-          variant={'raw'}
-        />
-      )}
+      {name &&
+        (isImage && !isDirectory ? (
+          <Icon className={styles.icon} icon={ImageIcon} size={16} />
+        ) : (
+          <MaterialFileTypeIcon
+            className={styles.icon}
+            fallbackUnknownType={false}
+            filename={name}
+            size={16}
+            type={isDirectory ? 'folder' : 'file'}
+            variant={'raw'}
+          />
+        ))}
       {displayPath && (
         <Text
           className={styles.text}

--- a/src/features/Conversation/Messages/EditedFilesCard/index.test.ts
+++ b/src/features/Conversation/Messages/EditedFilesCard/index.test.ts
@@ -49,7 +49,16 @@ describe('getFilePathDisplayInfo', () => {
   it('keeps the parent directory and basename for long absolute paths', () => {
     expect(getFilePathDisplayInfo('/very/long/workspace/Acceptance/index.tsx')).toEqual({
       displayPath: 'Acceptance/index.tsx',
+      isImage: false,
       name: 'index.tsx',
+    });
+  });
+
+  it('marks image files so they render a lucide image icon instead of a file-type icon', () => {
+    expect(getFilePathDisplayInfo('/workspace/tmp/r24-studio-crop.PNG')).toEqual({
+      displayPath: 'tmp/r24-studio-crop.PNG',
+      isImage: true,
+      name: 'r24-studio-crop.PNG',
     });
   });
 });


### PR DESCRIPTION
Image paths in tool-call rows rendered a colored Material file-type icon that reads as a generic document. `FilePathDisplay` now routes image extensions to lucide's `ImageIcon`; everything else — source files, markdown, directories — keeps `MaterialFileTypeIcon` untouched.

Because `FilePathDisplay` is shared, this covers every tool row that shows a path: Claude Code `Read` / `Write` / `Edit`, `lobe-local-system` read / write / list, `codex` file changes, and cloud-sandbox export.

| Before | After |
| ------ | ----- |
| `.png` / `.webp` / `.jpeg` rows show the colored Material image icon | the same rows show lucide's monochrome frame icon |

Rendered before/after screenshots (same viewport, code A/B) are on the acceptance page: https://app.lobehub.com/acceptance/4e36223d-bb56-49c2-ac4d-26881502517e

Note for review: `.svg` counts as an image here, so SVG files lose their dedicated Material icon. That matches the "image file" reading of the extension, but it is the one judgement call worth a second opinion.

#### Test

Verified on the Web surface against a local full stack: tool rows dispatched into a real conversation, then captured with the working-tree code and again with the component reverted to `HEAD`. `lucide-image` icon count went 0 → 3 across `.png` / `.webp` / `.jpeg`, while `.tsx` / `.md` / `.ts` and the directory row kept their Material icons.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`getFilePathDisplayInfo` now returns `isImage`; its unit test covers both a source file and an uppercase `.PNG` path.

#### 🔗 Related Issue

None.