### PR TITLE
📝 docs(acceptance): normalize the acceptance living logs

### DIFF
--- a/.agents/acceptance/common-mistakes.md
+++ b/.agents/acceptance/common-mistakes.md
@@ -6,7 +6,16 @@ confused with the generic `M` catalogue.
 
 Keep this file at the level of durable LobeHub product and environment invariants.
 Exact copy, pixel values, component slot order, and one-off review directions belong
-in feature specifications or historical field notes, not in this living checklist.
+in feature specifications or in
+[the field notes](./references/common-mistakes-field-notes.md), not in this living
+checklist — the field notes keep the detailed incident narratives available without
+making them mandatory reading for every Acceptance run.
+
+Every entry lives under one of the three categories below, and its id prefix names
+that category: `L-E*` evidence and publication, `L-D*` product and interaction
+contracts, `L-S*` environment safety. Append a new entry inside the category it
+belongs to, with the next free number of that prefix — never after the last entry of
+the file.
 
 ## Evidence and publication
 
@@ -258,14 +267,24 @@ gateway/device route, then assert the complete persisted tree: original owner
 user, target assistant/tool call, tool result, and target final response. Also
 assert there is no owner assistant, `callAgent`, or synthetic target-user row.
 
-### L-E18 — 从「没有默认导入」推断某个 composer 表面是死代码
+### L-E18 — Concluding a composer surface is dead code because nothing imports it
 
-**Wrong approach:** 改动技能行这类被 ActionBar 复用的组件后，grep `ActionBar/Tools` 的默认导入没有命中，就断定该表面未挂载，只验证 `+` 菜单一条路径。
+**Wrong approach:** after changing a component the ActionBar reuses (a skill row, for
+instance), grep for a default import of `ActionBar/Tools`, find no hit, conclude the
+surface is not mounted, and verify only the `+` menu path.
 
-**Why it fails:** ActionBar 的表面不是靠直接 import 挂载的，而是靠 action key 注册表 + 各路由自己的 `leftActions` 数组启用。`ActionBar/config` 里 `tools: Tools` 一直注册着，真正决定它是否渲染的是
-`src/routes/(main)/**/MainChatInput` 里的 `leftActions`—— 群聊 composer 就启用了 `'tools'`，走的是 `PopoverContent → ToolsList` 这条与 `+` 菜单不同的组合路径。漏掉它会让一次绿色的验证只覆盖一半用户可见面。
+**Why it fails:** ActionBar surfaces are not mounted by a direct import. They are
+enabled by an action-key registry plus each route's own `leftActions` array.
+`ActionBar/config` registers `tools: Tools` at all times; what actually decides
+whether it renders is `leftActions` in `src/routes/(main)/**/MainChatInput` — the
+group-chat composer enables `'tools'` and reaches the component through
+`PopoverContent → ToolsList`, a different composition path from the `+` menu. Missing
+it makes a green verification cover only half of what users can see.
 
-**Correct approach:** 改动任何被 ActionBar 复用的组件后，先枚举 action key 的真实启用点（grep 各路由的 `leftActions` 数组，而不是组件的 import），对每个启用该 key 的表面分别取证；确实不打算验的表面要显式标记未测。
+**Correct approach:** after changing any component the ActionBar reuses, enumerate
+where the action key is actually enabled (grep each route's `leftActions` array, not
+the component's imports) and capture evidence for every surface that enables it. Mark
+any surface you deliberately skip as untested.
 
 ## Product and interaction contracts
 
@@ -377,6 +396,35 @@ the envelope so the target assistant reply remains independently visible.
 Never infer authorship from agent-id differences or a parent tool call: a real
 cross-Agent user follow-up can have the same tree shape.
 
+### L-D9 — A Project conversation must preserve Project identity across routing and history
+
+**Wrong approach:** implement Project chat by navigating users to the Project coordinator's
+ordinary `/agent/:agentId/:topicId` surface and present that Agent's topic list as the Project
+history.
+
+**Why it fails:** the coordinator is an implementation detail. Leaving the Project route changes
+the visible owner and navigation contract, so users reasonably read the conversation as belonging
+to an Agent rather than to the Project that provides its tasks, goals, resources, and history.
+
+**Correct approach:** keep creation, topic selection, and resumed conversations under the Project
+route and Project sidebar. The coordinator may still execute the conversation internally, but the
+visible URL, active list, empty state, and navigation must consistently identify the Project.
+
+### L-D10 — Long `confirmModal` bodies overlay the footer
+
+**Wrong approach:** put a long list into `confirmModal({ content })` and assume the
+library pins Cancel / OK below a scroll area.
+
+**Why it fails:** `confirmModal` renders `ConfirmBody` (content + footer) inside
+`ModalContent`, which is itself `overflow: auto`. A tall list makes the dialog
+scroll as one column, or the footer paints over the last rows. Callers cannot pass
+content styles to change that.
+
+**Correct approach:** for any confirm body that can exceed a few lines, use
+`createModal` with a height-capped `ScrollArea` as `content` and put the actions in
+the modal `footer` slot. Assert `footer.top === scroller.bottom` at both ends of the
+list, not just that the dialog opened.
+
 ## Environment safety
 
 ### L-S0 — Concluding a dependency moved from the root manifest alone
@@ -472,6 +520,21 @@ the user's LobeHub instance may expose no debugging port at all.
 renderer marker before collecting evidence. If needed, start an isolated pool
 instance on a distinct port rather than guessing.
 
+**Same failure, second shape — the instance is LobeHub, but a different worktree.**
+A product-level marker passes for every worktree, so it cannot answer the question
+that matters: does this renderer serve _my_ working tree? Sibling worktrees each run
+their own `electron-dev.sh` legacy instance, and the first one started owns the
+default CDP 9222 and Vite 5173. Ask the renderer for the absolute source path of a
+module the change touches — the dev transform embeds it — and require both the
+worktree path and a marker unique to the change:
+
+```bash
+agent-browser --cdp 9222 eval "(async()=>{const t=await (await fetch('app://renderer/<repo-relative>.tsx')).text();return t.match(/_jsxFileName = \"[^\"]*\"/)[0]+' '+t.includes('<CHANGE_MARKER>')})()"
+```
+
+A wrong-worktree hit means the instance is someone else's session: do not restart or
+reuse it, start a pool instance (`electron-dev.sh start <id>`) or switch surface.
+
 ### L-S6 — Reading or writing the url from a portal'd sidebar on desktop
 
 **Wrong approach:** use `useSearchParams`, `useQueryState`, `useParams`,
@@ -554,20 +617,6 @@ to the code. Never attribute it to the change under test without that A/B — an
 note that `electron-dev.sh start` reports "Ready" even when the renderer never
 became interactive, so its own readiness line is not the gate.
 
-### L-P1 — A Project conversation must preserve Project identity across routing and history
-
-**Wrong approach:** implement Project chat by navigating users to the Project coordinator's
-ordinary `/agent/:agentId/:topicId` surface and present that Agent's topic list as the Project
-history.
-
-**Why it fails:** the coordinator is an implementation detail. Leaving the Project route changes
-the visible owner and navigation contract, so users reasonably read the conversation as belonging
-to an Agent rather than to the Project that provides its tasks, goals, resources, and history.
-
-**Correct approach:** keep creation, topic selection, and resumed conversations under the Project
-route and Project sidebar. The coordinator may still execute the conversation internally, but the
-visible URL, active list, empty state, and navigation must consistently identify the Project.
-
 ### L-S9 — Trusting "migration pass" on the shared acceptance Postgres
 
 **Wrong approach:** run `init-dev-env.sh migrate` in a worktree whose branch adds a
@@ -614,22 +663,7 @@ input timing confirmed in a foreground tab — the user's window, or a screensho
 check that tolerates a frozen transition. A negative result from a hidden tab is not
 evidence of a defect.
 
-### L-S11 — Long `confirmModal` bodies overlay the footer
-
-**Wrong approach:** put a long list into `confirmModal({ content })` and assume the
-library pins Cancel / OK below a scroll area.
-
-**Why it fails:** `confirmModal` renders `ConfirmBody` (content + footer) inside
-`ModalContent`, which is itself `overflow: auto`. A tall list makes the dialog
-scroll as one column, or the footer paints over the last rows. Callers cannot pass
-content styles to change that.
-
-**Correct approach:** for any confirm body that can exceed a few lines, use
-`createModal` with a height-capped `ScrollArea` as `content` and put the actions in
-the modal `footer` slot. Assert `footer.top === scroller.bottom` at both ends of the
-list, not just that the dialog opened.
-
-### L-S12 — Bundled SPA HTML is not the whole site
+### L-S11 — Bundled SPA HTML is not the whole site
 
 **Wrong approach:** collect only tags and CSS `url()` from `index.html`, then treat
 a Vite/webpack `dist` as publishable.
@@ -645,7 +679,7 @@ references also cannot be inlined as data URIs: `import.meta.url` and SVG
 are under the inline size limit. Judge a Vite publish by the running page
 (images, icons, counter), not by whether `index.html` listed three tags.
 
-### L-S13 — macOS `/tmp` and `/private/tmp` are the same workspace
+### L-S12 — macOS `/tmp` and `/private/tmp` are the same workspace
 
 **Wrong approach:** treat a Files-tree path and the topic working directory as
 outside each other when one string starts with `/tmp` and the other with
@@ -661,8 +695,26 @@ containment. Prove a publish by fetching the public HTML (data URIs or 200
 sidecars) and opening the live page — in-app preview of the local file does not
 prove the hosted assets.
 
-## Historical source
+### L-S13 — Treating a workspace another session has rewritten as your own code
 
-Detailed incident narratives and retired pixel- or component-specific directions
-belong in [the field notes](./references/common-mistakes-field-notes.md), where they
-remain available without becoming mandatory rules for every Acceptance run.
+**Wrong approach:** edit and verify in place in this repo, and when the screenshots
+stop matching the source, suspect the Vite cache or your own CSS — restarting the
+dev server, adding more changes, and capturing again.
+
+**Why it fails:** a second session can be working on the same worktree. Its rebase
+helper stashes the **entire working tree** (stash message shaped like
+`pre-rebase2-<pr>-<sha>`), rebases the branch, and pops later; a conflicted pop
+leaves `<<<<<<<` markers inside the other session's files and breaks the whole SPA
+build. Both phases point away from the real cause: first "my change is written but
+has no effect" (the file was actually reverted to its HEAD version), then "the app
+will not open" (a conflict marker in someone else's file). Either one sends you
+debugging code you never broke.
+
+**Correct approach:** confirm your change is still on the tree both before and after
+capturing evidence — the file appears in `git status` and a marker unique to your
+change greps. On a mismatch, read `git stash list` timestamps and `git reflog`
+before suspecting the build cache. When your work has been stashed, recover only
+your own file with `git checkout stash@{n} -- <your file>`; **never pop or drop the
+whole stash** — it belongs to the other session, and popping it is that session's
+own action. When you find conflict markers in someone else's file, wait for them to
+resolve it rather than resolving it for them.

--- a/.agents/acceptance/probe-mock-patterns.md
+++ b/.agents/acceptance/probe-mock-patterns.md
@@ -64,60 +64,12 @@ HttpOnly, so an empty `document.cookie` does not establish signed-out state.
 
 ## Project-specific recipes
 
-### Structured generation through the local OpenAI-compatible stub
+Recipes are grouped by what you are trying to do. Add a new one inside the group it
+belongs to, above `Detailed references`.
 
-**Situation:** a real product path uses non-streaming `chat/completions` for
-`generateObject`, while ordinary agent turns use streaming completions against the
-same local provider stub.
+### Probing app state
 
-**Doesn't work:** returning SSE chunks for every `chat/completions` request. The
-model runtime expects a normal `choices[0].message.content` response when
-`stream: false`, so the request reaches the stub but structured generation crashes
-before schema parsing.
-
-**Works:** branch on the request's `stream` field. Keep SSE for streaming turns and
-return a standard JSON chat completion for `stream: false`; set `STUB_TEXT` to the
-schema-valid JSON required by the check.
-
-### Task CLI polling with seeded API-key auth
-
-**Situation:** A local acceptance run is driven through `lh task run` with the
-seeded `LOBEHUB_CLI_API_KEY`, and the test needs to observe the asynchronous
-repair lifecycle.
-
-**Doesn't work:** `lh task run <id> --follow` switches to `/webapi/*`, which
-requires OIDC and rejects API-key auth after the task has already started.
-Likewise, `lh acceptance view task:T-N` does not currently resolve a task
-identifier to its internal subject id.
-
-**Works:** Start the task without `--follow`, poll with `lh task view T-N`, and
-query the aggregate with `lh acceptance view task:<internal-task-id>`. The start
-response and task activity expose the operation and topic ids; the Acceptance
-bundle exposes the repair round and final rollup.
-
-The same identifier/internal-id gap exists on the WRITE path: a local
-`acceptance run ingest --subject task:T-N` stores the literal `T-N` as
-`acceptance_subjects.subject_id`, while task/goal detail pages resolve the
-acceptance by the task's INTERNAL id — the page then renders an empty state even
-though ingest succeeded. Use the internal id in `--subject` (or fix the
-`subject_id` row afterwards) when the evidence must render in the local app UI.
-
-### Message-attached heterogeneous-agent errors
-
-Inject a temporary assistant message through
-`chat().internal_dispatchMessage`, then attach an `AgentRuntimeError`. Supported
-guide codes are `auth_required`, `cli_not_found`, `overloaded`, and `rate_limit`;
-other values follow the generic error path. Use a unique content marker, verify the
-real rendered card, and delete the temporary message afterward.
-
-### Infinite-scroll failure states
-
-When the fixture is too short for the observer to fire, call the real load-more
-store action rather than pretending to scroll. This covers the request, catch
-path, and rendered retry row; it does not prove the observer gate itself. Use a
-scrollable fixture when the observer behavior is the claim.
-
-### Store exposure
+#### Store exposure
 
 `window.__LOBE_STORES.<name>` is a function returning the current state. Call it:
 
@@ -129,7 +81,7 @@ It intentionally does not expose Zustand's `getState` or `setState`. If a test
 repeatedly needs mutation, add a dev-only supported action or fixture command
 instead of normalizing temporary `setState` HMR patches.
 
-### In-SPA navigation that preserves instrumentation
+#### In-SPA navigation that preserves instrumentation
 
 `app-probe.sh goto` and `location.assign("app://renderer/…")` perform a FULL
 reload — any `window.fetch` wrapper or debug global installed via `eval` is
@@ -145,24 +97,54 @@ This remounts the route component (SWR revalidates, list fetch observable by the
 wrapper) without recreating the JS context. Leave-and-return with this pattern is
 the way to capture a page's first-load request after installing a fetch wrapper.
 
-### Safe mutation-error injection against a real (cloud) account
-
-To exercise a mutation error branch when the app points at the user's real cloud
-backend, replace the react-query `mutationFn` body with an immediate
-`Promise.reject(...)` via HMR — the mutation then fails before ANY network call,
-so clicking a real row (even the user's own data) has zero server effect. Switch
-error shapes through a window flag (e.g. plain `Error` vs
-`{ data: { code: 'FORBIDDEN' } }`) and prove HMR liveness with a module-level
-marker before clicking. Snapshot the dirty file first and restore byte-identically
-(cmp), never `git checkout --`.
-
-### Runtime proof
+#### Runtime proof
 
 Client and server agent runtimes can produce the same visible result. Prove the
 runtime with a server-only artifact: operation row, queue step, or enabled
 main/server log namespace. Renderer state alone is not sufficient.
 
-### A new module needs a renderer reload, not HMR, before probing the fix
+#### `eval` declarations persist in the page global scope
+
+**Situation:** running several `agent-browser eval` payloads against one renderer.
+
+**Doesn't work:** a bare top-level `const els = …` in a second payload fails with
+`SyntaxError: Identifier 'els' has already been declared`, because each `eval`
+shares the page's global scope.
+
+**Works:** wrap every payload in an IIFE (`(() => { … })()`), or attach state to a
+single namespaced `window.__X` object.
+
+#### Shared agent-browser session names can cross-wire concurrent acceptance runs
+
+**Situation:** a Web acceptance run uses the adapter's default `lobehub-dev`
+session while another local run is active against a different port.
+
+**Doesn't work:** reusing `lobehub-dev` and trusting the URL printed immediately
+after `open`. Another process can steer the same session between commands, so a
+later click or screenshot lands on a different acceptance and port.
+
+**Works:** create a run-specific session name and load the seeded auth state
+directly:
+
+```bash
+RUN_SESSION=visualization-acceptance
+agent-browser --session "$RUN_SESSION" \
+  --state ~/.lobehub-agent-testing/web-state.json open "$SERVER_URL/acceptance"
+```
+
+Then assert `get url` and `app-probe.sh auth` on that exact session before
+capturing evidence.
+
+A cross-wired session can also look perfectly healthy while running STALE code:
+if the other instance's Vite has since died, the browser keeps serving its last
+bundle from disk cache — every probe answers, `innerText` is full, and only the
+rendered copy (an old i18n string, a pre-change label) betrays it. Before any
+assertion about working-tree code, read `location.origin` AND the page's script
+`src` origins, and require both to match the ports this run's `test-env.sh` /
+`.records/runtime` resolved. A dead script origin that still renders = disk
+cache, not your build.
+
+#### A new module needs a renderer reload, not HMR, before probing the fix
 
 **Situation:** verifying a source fix in the running Electron dev instance
 (`electron-dev.sh`) right after editing.
@@ -178,7 +160,7 @@ adding or moving a module, then re-probe. Confirm the new code is live by a
 structural signal (a renamed component in the fiber chain, a new class in the
 computed cascade) before concluding anything about behavior.
 
-### Production debug proxy stays on the development loading shell in an isolated browser
+#### Production debug proxy stays on the development loading shell in an isolated browser
 
 **Situation:** verifying a public SPA route with local frontend code against the
 production backend through `/_dangerous_local_dev_proxy`.
@@ -194,96 +176,7 @@ Acceptance fixture through the local CLI, and capture the same route in separate
 authenticated and storage-empty browser contexts. This proves both owner and
 shared-viewer rendering without depending on production browser cookies.
 
-### Which entry the dev Electron main window loads is NOT stable — measure it, never assume
-
-**Situation:** verifying anything that lives in `src/spa/entry.desktop.tsx` (bootstrap
-identity, adapter registration, boot marks) on an `electron-dev.sh` instance.
-
-**Doesn't work:** assuming any particular entry, in either direction. This has now been
-measured with two different results on the same helper:
-
-- Earlier: the main window's entry script was `app://renderer/src/spa/entry.web.tsx`
-  while the topicPopup window in the same instance loaded `entry.popup.tsx` — so the
-  main window fell through to the root `index.html`. Consequence at the time:
-  desktop-entry boot code never executed in dev, and a deletion there passed every dev
-  smoke test, which is how one such call was lost for a whole release.
-- 2026-08-05, on `feat/home-customize-modal`: the main window loaded
-  **`app://renderer/src/spa/entry.desktop.tsx`** — the fall-through did not reproduce.
-
-Mechanism not established in either direction, and no bisect was done, so do not
-assume the newer reading is permanent either. Treat the loaded entry as an unknown to
-be measured per run — that is the durable rule; the specific value is not.
-
-**Works:** before claiming anything about a desktop entry, read the loaded entry script
-and branch on it:
-
-```js
-[...document.querySelectorAll('script')].map((s) => s.src).find((s) => s.includes('entry.'));
-```
-
-If it is not the entry you are testing, the surface cannot prove your claim — fall back to
-a source-order regression test, and say in the report that the runtime path needs a
-packaged build (`DESKTOP_RENDERER_STATIC` / `resolveRendererFilePath` maps
-`apps/desktop/index.html`, `popup.html`, `overlay.html`).
-
-### Measuring production-bundle startup behavior without packaging the app
-
-**Situation:** a claim depends on the built renderer (chunk splitting, lazy-route
-boundaries, startup paint timing), which dev-mode Vite cannot reproduce.
-
-**Doesn't work:** measuring in the dev instance (unbundled modules make lazy vs
-eager indistinguishable), or trusting `performance.getEntriesByType('resource')`
-to identify what loaded — the `app://` protocol emits no resource-timing entries
-at all (0 JS resources on a fully loaded page).
-
-**Works:** build the renderer (`cd apps/desktop && vite build --config
-vite.renderer.config.ts`), then launch a pool instance with the static override:
-
-```bash
-DESKTOP_RENDERER_STATIC=1 .agents/acceptance/scripts/electron-dev.sh start 1
-```
-
-The dev main process serves `apps/desktop/dist/renderer` over `app://renderer/`
-with the seeded login. Prove which build is loaded via the modulepreload hashes
-in the live DOM, not resource timing:
-
-```js
-[...document.querySelectorAll('link[rel=modulepreload]')]
-  .map((l) => l.href)
-  .find((h) => h.includes('<chunk-under-test>'));
-```
-
-Paint metrics survive post-hoc collection: a buffered
-`PerformanceObserver({ type: 'largest-contentful-paint', buffered: true })` plus
-`performance.getEntriesByType('paint')` read after load give FCP/DCL and the full
-LCP-candidate timeline. `restart 1` re-seeds userData, so each restart is a
-comparable cold start; `location.reload()` gives low-variance warm samples. For
-A/B builds, swap `dist/renderer` directories between restarts — remote-image LCP
-entries are network-noisy, so compare text-paint candidates and DCL across ≥5
-cold samples per variant before attributing a delta.
-
-### Driving and probing a real Electron popup window
-
-**Situation:** verifying `entry.popup.tsx` behavior (its own HTML shell, no `BootShell`).
-
-**Works:** open the real window from the renderer store, then attach raw CDP to the
-popup's own target — the agent-browser daemon holds the main window's target, and one
-page target accepts only one websocket:
-
-```bash
-agent-browser --cdp 9222 eval '(async () => {
-  await window.__LOBE_STORES.global().openTopicInNewWindow("inbox","verify-popup");
-  return "requested"; })()'
-curl -s http://127.0.0.1:9222/json/list # pick the target whose url contains /popup/
-```
-
-Any `(agentId, topicId)` pair works — the popup boots regardless of whether the route
-resolves data, which is what makes this usable on a signed-out instance. For overlay
-claims, measure rather than eyeball: `getComputedStyle` for `pointer-events` / background
-alpha plus `document.elementFromPoint(x, y)` — a 50%-alpha scrim looks like a cosmetic
-tint in a screenshot while actually swallowing every click.
-
-### The debug proxy cannot reach a settled app — workspace `packages/*` dynamic imports fail cross-origin
+#### The debug proxy cannot reach a settled app — workspace `packages/*` dynamic imports fail cross-origin
 
 **Situation:** verifying frontend work through `/_dangerous_local_dev_proxy` (production
 page + production login + local Vite modules), needing a screenshot of the app after it
@@ -307,7 +200,159 @@ no session, so it ends in the same error for a different reason. See also the tw
 neighbouring entries on this proxy (loading-shell in an isolated context; no seeded
 agent-browser session).
 
-### The composer's slash menu needs real key events — `keyboard type` never opens it
+### Seeding fixtures
+
+#### Structured generation through the local OpenAI-compatible stub
+
+**Situation:** a real product path uses non-streaming `chat/completions` for
+`generateObject`, while ordinary agent turns use streaming completions against the
+same local provider stub.
+
+**Doesn't work:** returning SSE chunks for every `chat/completions` request. The
+model runtime expects a normal `choices[0].message.content` response when
+`stream: false`, so the request reaches the stub but structured generation crashes
+before schema parsing.
+
+**Works:** branch on the request's `stream` field. Keep SSE for streaming turns and
+return a standard JSON chat completion for `stream: false`; set `STUB_TEXT` to the
+schema-valid JSON required by the check.
+
+#### A CLI-created topic has no trigger/status and is filtered out of the Agent paged view
+
+**Situation:** building a topic fixture with `lh topic create`, writing fields such as
+`workingDirectoryConfig` into `metadata` with SQL, then opening the UI to verify.
+
+**Doesn't work:** navigating straight to `/agent/<agentId>/<topicId>`. The route and
+`activeTopicId` are both correct, yet `app-probe.sh topic` keeps reporting
+`active topic not found in the agent paged view` and `topicDataMap['agent_<id>'].total`
+stays 0 — so `currentTopicMetadata` is undefined and any UI reading topic metadata
+never sees the fixture, which looks like a product defect. The CLI-created row has
+NULL `trigger` and NULL `status`, while the paged query carries `excludeTriggers`
+(cron/document/eval/task) and `excludeStatuses` (completed); in SQL `NULL NOT IN (...)`
+evaluates to NULL, i.e. false, and the whole row is dropped. `lh topic list` runs a
+different query and returns it as usual, so the "visible to the CLI, invisible to the
+UI" split is especially misleading.
+
+**Works:** right after writing the metadata, also run
+`update topics set status='active', trigger='chat'`, then `app-probe.sh goto` once
+more. Keep the assertion order from M19: confirm `app-probe.sh topic` returns the
+metadata before asserting anything in the UI.
+
+#### `agent.updateAgentConfig` silently drops `agencyConfig.heterogeneousProvider`
+
+**Situation:** turning a test agent into a CLI-agent shape (Claude Code / Codex) so
+the heterogeneous chat input and its quota badges render.
+
+**Doesn't work:** `updateAgentConfigById(id, { agencyConfig: { heterogeneousProvider:
+{ type: 'claude-code', command: 'claude' } } })`. The store's optimistic write makes
+it look applied — reading `agentMap[id].agencyConfig` back returns the provider — but
+the DB row keeps only the sibling keys (`executionTarget` persists, the provider does
+not), so the next full reload drops it and the plain chat input comes back. Reads as
+"the agent isn't hetero" with no error anywhere.
+
+**Works:** seed the shape directly (public API first is the rule; this is the
+documented exception where the write path does not carry the field):
+
+```bash
+docker exec lobehub-agent-testing-postgres psql -U postgres -d postgres -tAc \
+  "update agents set agency_config = '{\"executionTarget\":\"local\",\"heterogeneousProvider\":{\"type\":\"claude-code\",\"command\":\"claude\"}}'::jsonb where id='<agentId>';"
+```
+
+Then cold-load: a plain reload keeps serving the agent config from the tiered SWR
+cache, so the renderer still shows the pre-write value (generic M18). Clear
+`lobechat-swr-cache*` + `lobehub-local-data` through
+`Page.addScriptToEvaluateOnNewDocument` and reload (see "Cold SWR cache" above),
+then assert `agentMap[id].agencyConfig` before drawing any conclusion.
+
+#### Day-scoped fixtures must use the browser's measured timezone, not an assumed one
+
+**Situation:** seeding backdated rows (briefs, activity, digests) whose UI grouping is
+by the viewer's _local calendar day_ (`dayjs().startOf('day')` on the client).
+
+**Doesn't work:** computing the day boundaries from an assumed timezone (the user's
+usual locale, the server tz, or the shell's). On this harness the agent-browser
+Chromium reports `America/Los_Angeles`, so a "today 14:00 CST" timestamp lands on the
+browser's _yesterday_ — the day view renders empty and reads exactly like the
+feature not fetching, while the server endpoint returns the rows when probed with
+the "correct" (assumed-tz) window.
+
+**Works:** before seeding, read the tz the grouping actually uses —
+`agent-browser eval 'Intl.DateTimeFormat().resolvedOptions().timeZone'` — and derive
+every `[startAt, endAt)` from that. When a day view comes back empty, diff the
+client's real request window (fetch wrapper on the batch URL) against the seeded
+timestamps before suspecting the query.
+
+#### Cold SWR cache: clearing then reloading is undone by the outgoing page
+
+**Situation:** forcing a first-load / skeleton state for anything backed by the
+tiered SWR cache (`recent:*`, `topic:*`, `message:*`, …).
+
+**Doesn't work:** clearing `localStorage['lobechat-swr-cache:<scope>']` (and the
+`lobehub-local-data` IndexedDB) in the current document, then reloading. The cache
+provider registers `flushAll()` on `visibilitychange` and `pagehide`, so the reload
+itself makes the outgoing page write its in-memory cache straight back. The next
+document hydrates from a repopulated tier and renders settled data — which reads as
+"the loading state never happens" and can be mistaken for a product bug.
+
+```
+1. before clear      : true
+2. right after clear : false
+3. after reload      : true   <- the outgoing page re-flushed on pagehide
+```
+
+**Works:** clear at document start in the NEW document, before the provider
+hydrates:
+
+```js
+Page.addScriptToEvaluateOnNewDocument({
+  source: `Object.keys(localStorage).filter(k=>k.startsWith('lobechat-swr-cache'))
+             .forEach(k=>localStorage.removeItem(k));
+           indexedDB.deleteDatabase('lobehub-local-data');`,
+});
+```
+
+Assert the clear actually ran in the new document (set a flag in that script and
+read it back) rather than trusting the removal.
+
+**The same cache tier inverts _request-gating_ assertions, not just rendered values.**
+When a component decides whether to fire a secondary query from data it reads out of
+the portrait/list query (`useX(shouldFetch ? id : undefined)`), the hydrated cache is
+what the gate sees on the mount frame. Change the underlying state with raw SQL and
+the gate still fires off the stale cached copy, so a correct gate measures as broken —
+and the reverse can hide a broken one. Drive the state change through the product
+write path (whose success handler revalidates), or re-measure after the list query has
+resolved once and the cache is reconciled; report the steady state, and record the
+stale frame separately if you observed it. Pair it with a warm control run: if
+the warm run renders data while the request is held paused and the cold run shows
+the skeleton, the cache tier is proven to be what the render reads.
+
+#### Reaching the Goals page: nested route plus a Labs toggle
+
+**Situation:** accepting goal-related functionality requires opening the Goals page.
+
+**Doesn't work:** opening `/agent/goals` directly. The goals route is nested under
+`/agent/:aid/goals`, so `goals` is parsed as an agentId and the page reports
+"assistant unavailable". The page is also gated behind the Labs toggle
+`enableTopicAcceptance`; while it is off, the route silently replaces back to
+`/agent/:aid`.
+
+**Works:** look up the seeded user's agentId
+(`select id from agents where user_id=...`), then turn the Labs toggle on through the
+public store action (it persists to user preferences and applies for the whole
+session):
+
+```js
+window.__LOBE_STORES.user().updateLab({ enableTopicAcceptance: true });
+```
+
+Then open `/agent/<agentId>/goals`. In the create-Goal dialog, "start from blank"
+skips AI generation of the acceptance criteria (required when there is no local LLM
+key); the criteria editor and budget field are ordinary inputs, while the goal
+description is contenteditable (use `fill`; `type` does not support contenteditable).
+
+### Driving the UI
+
+#### The composer's slash menu needs real key events — `keyboard type` never opens it
 
 **Situation:** driving the chat composer's `/` slash menu (or anything else gated on
 a Lexical `KEY_DOWN_COMMAND`) through agent-browser.
@@ -337,119 +382,278 @@ Confirm the mechanism rather than assuming a menu is missing:
 agent-browser --session "$RS" eval '(() => { window.__KD=[]; document.addEventListener("keydown", e => window.__KD.push(e.key), true); return "installed"; })()'
 ```
 
-### Reading a transitioned CSS property immediately after focus/hover
+#### An `ActionIcon` is not a `<button>` — select it by its lucide class, click through agent-browser
 
-**Situation:** asserting that a `:focus-within` / `:hover` rule reveals a
-control.
+**Situation:** driving an icon-only affordance inside a popover or panel (`ActionIcon`
+from `@lobehub/ui`: refresh, calendar, more, …).
 
-**Doesn't work:** `getComputedStyle(el).opacity` read in the same tick as the
-focus call, or in a separate `agent-browser eval` that races the re-render which
-mounts the control. Both return the pre-transition `0` while the rule is in fact
-matching.
+**Doesn't work:** three separate near-misses, each of which reads as "the affordance
+does not exist" rather than as a driving error:
 
-**Works:** focus and read inside one `eval`, wait past the transition duration,
-and assert the untransitioned property too (`width`) plus
-`el.matches('<selector>:focus-within')` so a mid-transition value cannot be
-mistaken for a non-matching rule.
+- `pop.querySelectorAll('button')` misses it. `ActionIcon` renders a `div`/`span`
+  wrapper (`class="lobe-flex …"` around `span.anticon`), so a button-only sweep of a
+  popover reports zero controls and invites the wrong conclusion that the entry was
+  never rendered.
+- `el.click()` on that wrapper `div` resolves and returns, but no handler runs — the
+  React `onClick` sits on an inner node, so the tab-clicking recipe above does not
+  transfer to icon buttons.
+- `agent-browser click --x <n> --y <n>` is not a thing; `click` only takes a CSS
+  selector, XPath, or an `@eN` snapshot ref, and coordinates fail with the generic
+  `Element not found`, which reads as a missing element rather than a bad invocation.
 
-### Locale regression tests and desktop resource scanning
+**Works:** find the icon by its lucide class, tag it, and let agent-browser do the
+real click:
 
-**Situation:** a locale-copy change needs a focused regression assertion while
-the Electron dev renderer imports locale resources from the default resource tree.
-
-**Doesn't work:** placing `*.test.ts` beside files in
-`packages/locales/src/default/`. The desktop resource scan can include that module
-in the renderer graph, which makes Vite optimize and execute `vitest` in the app.
-
-**Works:** keep the assertion under the consuming feature's test directory and
-import the locale resource there. Restart the isolated Electron instance after a
-bad scan because the optimized dependency graph can remain poisoned.
-
-### Desktop tab switching is not `activateTab` alone — drive the real tab element
-
-**Situation:** benchmarking or driving a desktop tab switch from an `eval`
-payload, using `window.__LOBE_STORES.electron().activateTab(id)`.
-
-**Doesn't work:** on the single-router shell, `activateTab` only writes
-`activeTabId`; navigation is a second step performed by the TabBar
-(`handleActivate` = `activateTab(id)` + `startTransition(navigate(url))`). Calling
-the store action alone leaves `location.pathname` on the previous route, so the
-run measures a no-op — visible as a tiny settle time, \~4 DOM mutations, and zero
-long tasks, which reads like an impossibly fast surface rather than a broken
-probe. The per-tab-router shell does switch content from the store action alone,
-so the same payload is a real switch on one build and a no-op on the other:
-any A/B built on it is invalid.
-
-**Works:** drive the tab element the user actually clicks, and assert the
-navigation happened.
-
-```js
-const all = [...document.querySelectorAll('[data-insp-path*="TabBar/TabItem.tsx"]')].filter(
-  (e) => e.getBoundingClientRect().width > 100,
-);
-// two nested nodes per tab match — keep only the outermost
-const roots = all
-  .filter((e) => !all.some((o) => o !== e && o.contains(e)))
-  .sort((a, b) => a.getBoundingClientRect().x - b.getBoundingClientRect().x);
-// roots[i] aligns 1:1 with store tabs[i]; verify roots.length === tabs.length
-roots[idx].click();
+```bash
+agent-browser --cdp 9222 eval '(() => {
+  const pop = [...document.querySelectorAll("[role=dialog]")].pop();
+  pop.querySelector("svg.lucide-calendar-days").setAttribute("data-qc", "entry");
+  return "tagged";
+})()'
+agent-browser --cdp 9222 click "[data-qc=entry]"
 ```
 
-`el.click()` reaches the React `onClick` here (this is not a controlled input, so
-the generic D11 trusted-input caveat does not apply). Always record
-`location.pathname` before and after and keep a `navigated` flag on every sample —
-that flag is what catches a payload that silently stopped switching.
+Enumerate candidates with `pop.querySelectorAll("button,[role=button],span[role]")`
+and read each node's `svg` class when the icon's identity is unknown. **The class is
+the icon's _rendered_ lucide name, not the React symbol you imported** — a component
+imported as `MoreHorizontalIcon` renders `svg.lucide-ellipsis`, so a selector guessed
+from the import name matches nothing and reads as "the affordance was never rendered".
+Enumerate the classes present, then disambiguate duplicates by geometry (a header
+control is the top-most, right-most non-zero rect) rather than by DOM order. Two follow-ons
+worth knowing: a stray click on a tagged text node can dismiss the popover (re-open
+and re-tag rather than assuming the control vanished), and a `Tooltip`-wrapped cell
+needs a real pointer move (`Input.dispatchMouseEvent` over several coordinates, or a
+dispatched `pointerover`+`mouseover` pair) before its content mounts.
 
-### Clicking an already-active tab is a no-op — a desynced tab can never be re-entered by clicking
+#### A node reference captured before a re-render is silently dead — re-query per assertion
 
-**Situation:** a probe adds a tab with `addTab(url)` and then clicks it to enter that route.
+**Situation:** asserting several tab-strip interactions (close, pin, switch) in one
+`agent-browser eval` payload, reusing the element list collected at the top.
 
-**Doesn't work:** `addTab` already activates the new tab, so the later click lands on the _active_ tab
-and the shell does nothing. On the single-router shell this can leave `activeTabId` pointing at a tab
-whose URL names one topic while `location.pathname` and `chat().activeTopicId` still name another —
-after which no amount of clicking recovers it, and every downstream assertion reads the wrong page.
-Symptom: the probe's final `location.pathname` is not the tab you clicked, with no error anywhere.
+**Doesn't work:** collecting `roots` once and then acting on `roots[0]`, `roots[1]`, …
+in sequence. Each action that mutates the tab list re-renders the strip, so every
+reference collected earlier now points at a detached node. Dispatching to a detached
+node throws nothing and changes nothing — React never sees it — so the assertion reads
+as "this interaction does not work". In this catalogue's first occurrence it produced a
+confident "middle-click does not close a pinned tab" that was purely an artefact of the
+stale reference, and it survived review because the number looked plausible.
 
-**Works:** after `addTab`, enter the route with a full navigation
-(`app-probe.sh goto <url>`) before starting the trials, and assert the three values agree before
-measuring:
+**Works:** one assertion per `eval`, re-querying the strip each time. When several must
+share a payload, re-query between actions and assert `el.isConnected` before dispatch.
+The same applies to any probe whose own action re-renders the tree it is measuring.
+
+#### Anchor nav-panel assertions on `#nav-panel-drawer`, not a `data-insp-path` match
+
+**Situation:** asserting what the left nav panel renders on a given route.
+
+**Doesn't work:** `document.querySelector('[data-insp-path*="NavPanelDraggable"]')`.
+It resolves during a settled render but returns `null` in the seconds after a full
+reload, and the usual `|| document.body` fallback then reads
+`document.body.innerText === ''` (generic C4) — which looks exactly like an empty
+panel and turns a normal loading window into a false regression.
+
+**Works:** the panel is the `<aside>` sibling of the stable drawer anchor:
 
 ```js
-const st = window.__LOBE_STORES.electron();
-const chat = window.__LOBE_STORES.chat();
-const tab = (st.tabs || []).find((t) => t.id === st.activeTabId);
-// tab.url, location.pathname and chat.activeTopicId must all point at the same topic
+const drawer = document.getElementById('nav-panel-drawer');
+const aside = drawer && [...drawer.parentElement.children].find((c) => c.tagName === 'ASIDE');
 ```
 
-### Attributing switch work to hidden keep-alive trees — classify on BOTH sides of the action
+Then assert on `aside.innerText` line count plus a count of text-free rounded boxes
+(the skeleton rows). Distinguish the two skeleton states explicitly: a text-free panel
+carrying `[data-testid="nav-sidebar-skeleton"]` is the nav-panel fallback, while fixed
+items present with only the list area shimmering is ordinary data loading. Do NOT
+identify the fallback by a row count — it is shaped per navKey now
+(`NAV_SKELETON_SHAPES`), so memory/discover render header plus a nav list and no body
+at all, while settings renders a search box plus four accordion groups.
 
-**Situation:** measuring what a per-tab keep-alive shell costs while a tab is hidden.
+#### Park a route's lazy chunk to hold its pending sidebar on screen
 
-**Doesn't work:** collecting the hidden slots (the `display: none` children of the TabHost root) _before_
-the switch and classifying every mutation against that list. The switch is precisely what makes the
-target tab visible, and that tab was hidden when the list was captured — so the incoming tab's own
-render, which is necessary user-visible work, is counted as hidden-tree work. This produced a confident
-"\~44% of switch work happens off-screen" that was pure artefact, and it survived review because the
-number looked plausible.
+**Situation:** verifying what a route's `NavPanel` fallback (or any `dynamicElement`
+Suspense fallback) actually renders. The pending state lasts a few hundred ms, so no
+screenshot or `agent-browser eval` catches it.
 
-**Works:** classify against the intersection — slots hidden **before** the switch that are **still
-hidden after** it:
+**Doesn't work:** network throttling, or adding a debug flag that force-renders the
+fallback. Throttling does not bound the module fetch predictably, and a force-render
+flag proves the component renders, not that the product path reaches it.
+
+**Works:** raw CDP `Fetch.enable` intercepts `app://renderer/...` module requests in
+the Electron renderer. Park the route's layout chunk and the portal never registers,
+so the fallback stays up indefinitely — measure and screenshot at leisure, then kill
+the CDP connection to release the request and measure the settled sidebar in the same
+session.
 
 ```js
-const before = hiddenSlots(); // display:none children of the TabHost root
-/* click the tab, observe mutations */
-const after = hiddenSlots();
-const stillHidden = before.filter((s) => after.includes(s));
+Fetch.enable({ patterns: [{ requestStage: 'Request', urlPattern: '*settings/_layout*' }] });
+// on Fetch.requestPaused: keep the requestId, never continueRequest
+// [paused] app://renderer/src/routes/(main)/settings/_layout/index.tsx?t=1785957215039
 ```
 
-Measured this way, still-hidden slots produced **0** mutations in 6/6 switches: React
-`<Activity mode="hidden">` keeps state, tears down effects, and commits nothing while hidden.
+Two traps. The pattern must name the **layout** chunk only: a broad `*settings*`
+also parks `store/user/slices/settings/*` and the router's own `routeMeta`, which
+stalls boot instead of the route. And the layout module is not always under the path
+you guess — the agent sidebar registers from `(main)/agent/_layout`, not
+`(main)/agent/(chat)/_layout`; when the measurement comes back `mode: real`, the
+pattern missed, it is not a product finding.
 
-**General rule:** when a measurement classifies work by a property that the measured action itself
-changes (visible/hidden, active/inactive, mounted/unmounted), capture the classification on both sides
-and use the intersection. Otherwise the action's own effect lands in the wrong bucket.
+Drive the navigation with `app-probe.sh goto <route>` (a full reload, so the module
+is re-requested and re-parked).
 
-### Agent Mock playback leaves `pluginState` empty — backfill it before capturing pluginState-driven renders
+#### Document-tree evidence: seed fixtures by path, drive through the shadow DOM, and note that heterogeneous Agents have no Documents tab
+
+**Situation:** verifying how `DocumentExplorerTree` renders (the left column of
+`/agent/:id/docs`, and the Documents tab of the conversation's right-hand working
+sidebar), which needs a document tree with real nesting.
+
+**Doesn't work:** three separate things that each send you the wrong way.
+
+- Building the fixture with `agentDocument.createDocument`. Its input is only
+  `agentId/title/content` — no `parentId`, no `isFolder` — so it can only produce a
+  flat list and never exercises hierarchy.
+- Clicking tree rows with `agent-browser click '<selector>'`. pierre/trees is a web
+  component and every row lives inside the shadowRoot of `file-tree-container`, so
+  document-level selectors match nothing, which reads as "those rows do not exist".
+- Looking for the Documents tab inside a heterogeneous Agent's conversation (Claude
+  Code and friends). `WorkingSidebar`'s tabs are
+  `['skills', ...(isHetero ? [] : ['documents', 'web'])]`, so a heterogeneous Agent
+  only has the Skills tab: `setWorkingSidebarTab('documents')` is written to the store
+  but has no panel behind it, and
+  `document.querySelectorAll('file-tree-container').length` stays 0.
+
+**Works:**
+
+1. Write through the VFS by path — `recursive: true` creates the whole nested
+   directory in one call (hit the local tRPC directly with a better-auth cookie minted
+   the same way `web-seed` does):
+
+```bash
+curl -s -b "$JAR" -H 'Content-Type: application/json' -X POST \
+  "$BASE/trpc/lambda/agentDocument.mkdirDocumentByPath" \
+  --data '{"json":{"agentId":"'"$A"'","path":"pitchdeck/archive/positioning","recursive":true}}'
+curl -s -b "$JAR" -H 'Content-Type: application/json' -X POST \
+  "$BASE/trpc/lambda/agentDocument.writeDocumentByPath" \
+  --data '{"json":{"agentId":"'"$A"'","path":"pitchdeck/archive/x.md","content":"# x","createMode":"if-missing"}}'
+```
+
+2. The stable handle for a row is `data-item-path` (directories carry a trailing `/`),
+   and `el.click()` is enough to expand it — pierre listens on native DOM rather than
+   being a controlled React component, so the general "trusted events only" rule (D11)
+   does not apply here. The criterion is `aria-expanded` flipping from `false` to
+   `true`:
+
+```js
+const sr = document.querySelector('file-tree-container').shadowRoot;
+const el = sr.querySelector('[data-type=item][data-item-path="pitchdeck/archive/"]');
+if (el.getAttribute('aria-expanded') === 'false') el.click();
+```
+
+3. To verify the second rendering surface, switch to a non-heterogeneous Agent and
+   call `toggleRightPanel()` before `setWorkingSidebarTab('documents')`; the latter
+   alone does not open the panel.
+
+4. Do not measure layout from the `innerText` of `[data-item-section=content]` — it
+   holds several measurement copies produced by `MiddleTruncate`, so the text repeats
+   and every copy contains `…`; counting truncated rows that way always matches
+   everything. To decide whether a row is really truncated, take the `…` node whose
+   `width > 0` and whose `checkVisibility()` is true, and confirm visually against the
+   screenshot. For indentation, read the content-box `x` and diff it level by level —
+   that difference is the real step.
+
+#### Restyling ExplorerTree: pierre's focus state and truncation mask have two counter-intuitive contracts
+
+**Situation:** tuning `ExplorerTree` (pierre/trees) appearance through `unsafeCSS` /
+`--trees-*` variables — removing the focus highlight, changing truncation behaviour,
+recolouring row states.
+
+**Doesn't work:**
+
+- Using `:not(:focus-visible)` to "drop the focus ring for mouse only, keep it for the
+  keyboard". pierre calls `focus()` on a row when it is clicked, and Chromium still
+  treats that row as `:focus-visible` on this path (measured:
+  `el.matches(':focus-visible')` is `true`), so the suppression rule never matches and
+  the border appears as before. The screenshot looks like "the change had no effect"
+  when in fact the selector simply did not apply.
+- Setting the row background to `transparent` (to let the panel colour show through)
+  without also handling truncation. pierre's ellipsis is **absolutely positioned on top
+  of the characters it replaces** and relies on
+  `--truncate-marker-background-color` to mask them, which defaults to `--trees-bg`.
+  Make the row transparent and the mask has no colour to paint, so the ellipsis sits
+  directly on the text — it renders as "the text is hard-clipped with no ellipsis" and
+  is easily misread as broken truncation logic.
+- Fixing the previous point by hard-coding the mask to one design token. The two host
+  panels of the document tree do not share a background: the docs-page left column
+  measures `rgb(0,0,0)` (colorBgLayout) while the conversation's right-hand working
+  sidebar measures `rgb(13,13,13)` (colorBgContainer). Pick either one and the other
+  surface gets a visible colour block behind its ellipsis.
+- Trying to "reserve a column" for the ellipsis to avoid overlapping glyphs
+  (`grid-template-columns: minmax(0,max-content) 1.25em`). That column applies to
+  **every** row, and `MiddleTruncate` renders the title as two segments, so every title
+  gets a hole punched in the middle (`pitch    deck`) — for names without an extension
+  the split point is the midpoint, so the hole lands mid-word.
+
+**Works:**
+
+- Focus ring: set `outline: none` in every state and restore keyboard visibility with a
+  background instead
+  (`[data-item-focused='true']:not([data-item-selected='true'])` gets `--trees-bg-muted`).
+- Mask colour: at runtime, walk up from the container to the first non-transparent
+  `backgroundColor` and write it into your own variable rather than using a fixed token
+  (`usePanelBackground`). A third host panel then needs no further change.
+- Truncation direction: `FileTreeView` hard-codes `MiddleTruncate split:"extension"`
+  and `FileTreeOptions` exposes no truncation option, so the only lever is the two flex
+  weights in its own styles — `[data-truncate-segment-priority='1'|'2']` are "shrink
+  last" and "shrink first". Swap them and the stem segment keeps its width and shows
+  its own trailing ellipsis while the extension segment is squeezed to 0, turning a long
+  title from `… carrying md` into `… carrying…`. One residue to watch: when the overflow
+  is smaller than the extension's width the extension is only partly squeezed, and
+  because it is laid out rtl its last character leaks through — cover it by pulling that
+  segment's mask to `inset: 0` inside pierre's own overflow container query
+  (`@container measure (height > 1lh)`).
+- To actually remove the indent guides, set
+  `--trees-indent-guide-bg-override` to `transparent`; setting `spacing-item`'s
+  `opacity` to 0 is not enough — pierre has two more rules ("reveal on tree hover" and
+  "highlight the focused row's ancestors") that push the opacity back to 1.
+
+#### Skill-menu interaction bugs depend on the shape of the user's data — foreground the MCP window and reproduce with zero-write clicks
+
+**Situation:** reproducing a row-level interaction defect in the `+` menu / skills
+submenu (hover detail card, the `...` policy menu, the uninstall confirmation). The
+local seeded full stack survives the entire gesture matrix (rapid policy switching,
+popover switching, disabling, the uninstall dialog, an injected 700ms server delay),
+while the user's environment triggers it immediately.
+
+**Doesn't work:** enumerating gesture permutations locally. The row shape that
+triggers the defect exists only in real account data — an expired-authorization
+Composio row (Gmail re-authorization), for example, renders through `PopoverLabel`
+rather than `SkillRow`, and a local seeded account only has builtin rows, so the
+detail card never even mounts. Do not draw conclusions from a background MCP tab
+either (L-S10): popovers freeze at `data-starting-style`, coordinate clicks do
+nothing, and timers are clamped to 1s.
+
+**Works:** three things together. (1) Have the user bring the Chrome window the
+extension opened to the foreground, and only drive it once
+`document.visibilityState === 'visible'` and DevDock shows 60 FPS — a foregrounded MCP
+tab is a fully trustworthy interaction surface. (2) Reproduce on the production
+account with zero writes: in the policy menu click only the **already-selected** item
+(`updateSkillPolicy` returns early when `currentMode === mode` and sends no request),
+always dismiss confirmation dialogs with Cancel, and rely on the fact that opening and
+closing menus writes nothing. (3) Attribute the mechanism with in-page event evidence
+— record a profile of each pointer/focus event target at the document capture phase
+(`closest` role, `inDialog`, `isConnected`) into a `window.__AGENT_LOGS` ring buffer,
+and record the close reason directly from `onOpenChange(details.reason)`; screenshots
+alone cannot separate outside-press from focus-out from hover-out.
+
+### Rendering messages and tool calls
+
+#### Message-attached heterogeneous-agent errors
+
+Inject a temporary assistant message through
+`chat().internal_dispatchMessage`, then attach an `AgentRuntimeError`. Supported
+guide codes are `auth_required`, `cli_not_found`, `overloaded`, and `rate_limit`;
+other values follow the generic error path. Use a unique content marker, verify the
+real rendered card, and delete the temporary message afterward.
+
+#### Agent Mock playback leaves `pluginState` empty — backfill it before capturing pluginState-driven renders
 
 **Situation:** verifying a builtin-tool Render/Inspector (lobe-agent todos, plans —
 anything reading `message.pluginState`) with DevDock → Agent Mock case playback as
@@ -491,7 +695,7 @@ is what selects the Render component) and the tool message (`updateMessagePlugin
   (NOT `lobe-claude-code`) and PascalCase `apiName` (`TodoWrite`). All of this is
   in-memory only — a reload clears it; delete the temp topic at teardown.
 
-### Verifying a builtin-tool Render with no provider key — dispatch a fresh assistant+tool pair
+#### Verifying a builtin-tool Render with no provider key — dispatch a fresh assistant+tool pair
 
 **Situation:** verifying a builtin tool's Render / Streaming component when the local
 env has no LLM provider key, so no real model can be made to emit that tool call
@@ -552,98 +756,66 @@ Toggling the row's first action button flips `showCustomToolRender`, which drops
 to `FallbackArgumentRender` — the same branch an unregistered tool takes, so it is a
 faithful "before this change" contrast shot.
 
-### Desktop theme follows the system appearance, not `settings.general.themeMode`
+Three more things decide whether the **Inspector line itself** is even on screen —
+they bite when the assertion is about the inspector row, not the Render card:
 
-**Situation:** capturing dark-mode evidence for a desktop UI change.
+- **The AssistantGroup collapse hides the whole inspector line**, one layer above the
+  Render's own collapse. A settled group renders as a summary chip (`共运行 N 步`,
+  or `N 次调用：…` once several tools share one assistant) and `innerText` then has
+  no trace of the tool name at all — reading as "the dispatch never rendered". Click
+  the summary chip first, then wait for the expand transition to settle: an
+  immediate screenshot catches the first row half-slid under the sticky summary.
+- **One assistant with N `tools[]` entries is the shape worth dispatching.** N
+  separate assistant messages give N single-step groups, each needing its own click
+  and each rendering its own avatar row; one assistant carrying all the tool calls
+  reproduces the real multi-tool step layout in a single expandable group.
+- **The expanded group gets its own inner scroller** (roughly 230px). The last rows
+  sit below its fold while the page around it still has empty space, so evidence
+  needs one capture per scroll position — set `scrollTop` on every element whose
+  `scrollHeight > clientHeight`, not just the message list.
 
-**Doesn't work:** `window.__LOBE_STORES.user().updateGeneralConfig({ themeMode: 'dark' })`.
-The setting persists (reading it back returns `dark`, and it survives a restart),
-but `document.documentElement.dataset.theme` stays `light` and every token keeps its
-light value. Restarting the instance does not apply it either. Treating the stored
-setting as proof of the rendered theme yields evidence captured in the wrong theme.
+Finally, an HMR update to any module in the rendered chain **wipes the in-memory
+fixture** and drops the conversation back to its welcome state. For a before/after
+code A/B, re-dispatch after each edit rather than expecting react-refresh to keep
+the messages — and re-run the identical dispatch + expand + scroll sequence on both
+sides so the two frames differ only by the change.
 
-**Works:** assert `document.documentElement.dataset.theme` — never the stored
-setting — before capturing any theme-dependent evidence. The renderer tracks the OS
-appearance, so switching it means changing the user's macOS system setting, which is
-outside the harness's remit: mark the dark case untested and say why, rather than
-flipping a device-level preference. Note the setting write is not free — it syncs to
-the account and affects other surfaces; restore it (`auto`) at teardown if you set it.
+#### Infinite-scroll failure states
 
-### A node reference captured before a re-render is silently dead — re-query per assertion
+When the fixture is too short for the observer to fire, call the real load-more
+store action rather than pretending to scroll. This covers the request, catch
+path, and rendered retry row; it does not prove the observer gate itself. Use a
+scrollable fixture when the observer behavior is the claim.
 
-**Situation:** asserting several tab-strip interactions (close, pin, switch) in one
-`agent-browser eval` payload, reusing the element list collected at the top.
+#### Safe mutation-error injection against a real (cloud) account
 
-**Doesn't work:** collecting `roots` once and then acting on `roots[0]`, `roots[1]`, …
-in sequence. Each action that mutates the tab list re-renders the strip, so every
-reference collected earlier now points at a detached node. Dispatching to a detached
-node throws nothing and changes nothing — React never sees it — so the assertion reads
-as "this interaction does not work". In this catalogue's first occurrence it produced a
-confident "middle-click does not close a pinned tab" that was purely an artefact of the
-stale reference, and it survived review because the number looked plausible.
+To exercise a mutation error branch when the app points at the user's real cloud
+backend, replace the react-query `mutationFn` body with an immediate
+`Promise.reject(...)` via HMR — the mutation then fails before ANY network call,
+so clicking a real row (even the user's own data) has zero server effect. Switch
+error shapes through a window flag (e.g. plain `Error` vs
+`{ data: { code: 'FORBIDDEN' } }`) and prove HMR liveness with a module-level
+marker before clicking. Snapshot the dirty file first and restore byte-identically
+(cmp), never `git checkout --`.
 
-**Works:** one assertion per `eval`, re-querying the strip each time. When several must
-share a payload, re-query between actions and assert `el.isConnected` before dispatch.
-The same applies to any probe whose own action re-renders the tree it is measuring.
+### Capturing and publishing evidence
 
-### `eval` declarations persist in the page global scope
+#### Reading a transitioned CSS property immediately after focus/hover
 
-**Situation:** running several `agent-browser eval` payloads against one renderer.
+**Situation:** asserting that a `:focus-within` / `:hover` rule reveals a
+control.
 
-**Doesn't work:** a bare top-level `const els = …` in a second payload fails with
-`SyntaxError: Identifier 'els' has already been declared`, because each `eval`
-shares the page's global scope.
+**Doesn't work:** `getComputedStyle(el).opacity` read in the same tick as the
+focus call, or in a separate `agent-browser eval` that races the re-render which
+mounts the control. Both return the pre-transition `0` while the rule is in fact
+matching.
 
-**Works:** wrap every payload in an IIFE (`(() => { … })()`), or attach state to a
-single namespaced `window.__X` object.
+**Works:** focus and read inside one `eval`, wait past the transition duration,
+and assert the untransitioned property too (`width`) plus
+`el.matches('<selector>:focus-within')` so a mid-transition value cannot be
+mistaken for a non-matching rule.
 
-### Shared agent-browser session names can cross-wire concurrent acceptance runs
-
-**Situation:** a Web acceptance run uses the adapter's default `lobehub-dev`
-session while another local run is active against a different port.
-
-**Doesn't work:** reusing `lobehub-dev` and trusting the URL printed immediately
-after `open`. Another process can steer the same session between commands, so a
-later click or screenshot lands on a different acceptance and port.
-
-**Works:** create a run-specific session name and load the seeded auth state
-directly:
-
-```bash
-RUN_SESSION=visualization-acceptance
-agent-browser --session "$RUN_SESSION" \
-  --state ~/.lobehub-agent-testing/web-state.json open "$SERVER_URL/acceptance"
-```
-
-Then assert `get url` and `app-probe.sh auth` on that exact session before
-capturing evidence.
-
-A cross-wired session can also look perfectly healthy while running STALE code:
-if the other instance's Vite has since died, the browser keeps serving its last
-bundle from disk cache — every probe answers, `innerText` is full, and only the
-rendered copy (an old i18n string, a pre-change label) betrays it. Before any
-assertion about working-tree code, read `location.origin` AND the page's script
-`src` origins, and require both to match the ports this run's `test-env.sh` /
-`.records/runtime` resolved. A dead script origin that still renders = disk
-cache, not your build.
-
-### Agent-browser navigation hangs after an orphaned Next child keeps the port
-
-**Situation:** an isolated full-stack dev launcher exits, but its Next child
-continues listening without returning HTTP responses. `agent-browser open`,
-`get url`, and even session close can then appear to hang because navigation
-never settles.
-
-**Doesn't work:** repeatedly recreating browser sessions or assuming the
-browser daemon is the root cause while `curl --max-time` to the target route
-also receives zero bytes.
-
-**Works:** inspect the exact listener with `lsof`, confirm its command and
-working tree, terminate only that run-owned process tree, then restart through
-`init-dev-env.sh dev` and reseed the isolated browser auth. A successful HTTP
-probe must precede browser assertions.
-
-### Leftover React Scan instrumentation poisons every screenshot
+#### Leftover React Scan instrumentation poisons every screenshot
 
 **Situation:** capturing UI evidence in a dev instance the user (or an earlier
 round) had DevTools / the DevDock open on.
@@ -662,26 +834,7 @@ survives re-creation, touches no product code or styles, and disappears on
 reload. Remove it at teardown. Disclose it in the report: it suppresses a dev
 overlay, which is a capture-time adjustment a reviewer should know about.
 
-### Production-backend web runs have no seeded agent-browser session
-
-**Situation:** verifying frontend-only work against real production data through
-`bun run dev:spa`'s `_dangerous_local_dev_proxy` URL.
-
-**Doesn't work:** the adapter's Web evidence path (`agent-browser --session
-lobehub-dev` seeded by `setup-auth.sh web-seed`) authenticates against the LOCAL
-server. There is no sanctioned way to give that session a production login —
-`setup-auth.sh web`'s Chrome-cookie injection is explicitly forbidden against
-production.
-
-**Works:** drive the proxy in the user's already-authenticated Chrome (the
-`claude-in-chrome` tooling), and compensate for the weaker evidence channel with
-DOM measurements (`getBoundingClientRect` / `getComputedStyle`) alongside every
-screenshot, plus an independent server-side check through `lh` in a clean env.
-Prove the working-tree bundle is actually live first — read back a string that
-exists only in the working tree (e.g. a changed placeholder), never assume HMR
-applied.
-
-### Counting section instances across the Home rail collapse needs real visibility, not a rect
+#### Counting section instances across the Home rail collapse needs real visibility, not a rect
 
 **Situation:** asserting that a Home section moved between the rail and the main
 column rather than being duplicated or lost.
@@ -712,206 +865,7 @@ if (!el.checkVisibility({ checkOpacity: true, checkVisibilityCSS: true })) conti
 Assert both columns in the same pass — a claim about _moving_ is only settled by
 observing the source column go empty and the destination fill in one snapshot.
 
-### A worktree Electron run leaves a second `@types/react` that fails the worktree type-check
-
-**Situation:** running the Electron surface from a git worktree, which requires
-the `apps/desktop` standalone install (adapter §1), then running `bun run check --type`.
-
-**Doesn't work:** treating the resulting type errors as the branch's own. The
-desktop install brings its own `@types/react` (e.g. `19.2.18`) alongside the
-root's (`19.2.13`), and the two identities collide on every `lucide-react` icon
-`ref`, producing a cluster of "Two different types with this name exist, but they
-are unrelated" errors in files the branch never touched.
-
-**Works:** intersect the erroring files with the branch's changed-file list before
-drawing any conclusion, and confirm causality by A/B — moving
-`apps/desktop/node_modules` aside makes the cluster vanish. At teardown, remove
-`apps/desktop/node_modules` and re-run the root `pnpm install` to restore a clean
-`✓ types clean` baseline. **Do not run the A/B while the instance is live** — the
-Electron binary runs out of that directory, so parking it kills the instance;
-capture all UI evidence first.
-
-### Managed command runners can reap `electron-dev.sh start` children after the helper returns
-
-**Situation:** `electron-dev.sh start` (legacy and pool forms) reports that CDP
-and the renderer are ready, but the CDP port closes immediately after the helper
-command returns. The Electron log contains a normal renderer mount and no crash;
-changing from the saved login snapshot to the fresh golden profile does not alter
-the exit. The cause is not established.
-
-**Doesn't work:** retrying the helper with another pool id or changing the auth
-seed. Both instances become interactive during the helper's readiness loop and
-are gone before the next command can connect.
-
-**Works:** use the documented multi-instance Model B command in a long-lived PTY
-with the same isolated userData, Vite port, IPC id, and CDP port:
-
-```bash
-LOBE_DESKTOP_VITE_PORT=5175 \
-  LOBE_DESKTOP_USER_DATA_DIR=/tmp/lobe-electron-pool/ud-2 \
-  LOBE_IPC_ID=lobehub-desktop-dev-2 \
-  pnpm -C apps/desktop dev -- --remote-debugging-port=9224
-```
-
-Keep that command session open for the run. Confirm the CDP endpoint, project
-process path, `app-probe.sh ready`, renderer auth, server auth, and a raw-CDP
-screenshot before collecting evidence.
-
-### `acceptance run ingest` is creative — re-running it to re-read its output mints a duplicate round
-
-**Situation:** after a successful ingest, wanting to re-check a field from its JSON
-output (evidence count, acceptanceId).
-
-**Doesn't work:** running the same `ingest` command again "just to see the output".
-Every invocation creates a new immutable round on the acceptance — the re-run
-publishes a byte-identical duplicate round that reviewers then see twice.
-
-**Works:** re-read state with the read-only commands — `acceptance run list`,
-`acceptance run get <runId>`, `acceptance view <id> --json`. If a duplicate was
-minted by mistake, `acceptance run delete <runId> --yes` (newest timestamp = the
-accident) restores the round history; this is data correction of an operator
-error, distinct from the forbidden overwrite-a-real-round.
-
-### A backgrounded `init-dev-env.sh dev` looks dead while the server is alive on a dynamic port
-
-**Situation:** starting the dev server from a harness-managed background command in a
-worktree, then waiting for readiness.
-
-**Doesn't work:** trusting the background task's captured output (it can stay 0 bytes
-while the detached process tree lives on), or polling the default port. Worktrees
-allocate dynamic ports, so probing `localhost:3010` waits forever while the server is
-already up elsewhere; a retry then fails with "an owned dev server is already running".
-
-**Works:** treat `.records/runtime/` as the source of truth — it records `PID`,
-`SERVER_PORT` and `SPA_PORT` for the owned instance. Read the port from there and poll
-that. For a long-lived start prefer a detached `screen -dmS <name> … >> .records/logs/x.log`
-so the log lands in a stable file; `stop-dev` still stops the recorded PID tree either way.
-
-### Cold SWR cache: clearing then reloading is undone by the outgoing page
-
-**Situation:** forcing a first-load / skeleton state for anything backed by the
-tiered SWR cache (`recent:*`, `topic:*`, `message:*`, …).
-
-**Doesn't work:** clearing `localStorage['lobechat-swr-cache:<scope>']` (and the
-`lobehub-local-data` IndexedDB) in the current document, then reloading. The cache
-provider registers `flushAll()` on `visibilitychange` and `pagehide`, so the reload
-itself makes the outgoing page write its in-memory cache straight back. The next
-document hydrates from a repopulated tier and renders settled data — which reads as
-"the loading state never happens" and can be mistaken for a product bug.
-
-```
-1. before clear      : true
-2. right after clear : false
-3. after reload      : true   <- the outgoing page re-flushed on pagehide
-```
-
-**Works:** clear at document start in the NEW document, before the provider
-hydrates:
-
-```js
-Page.addScriptToEvaluateOnNewDocument({
-  source: `Object.keys(localStorage).filter(k=>k.startsWith('lobechat-swr-cache'))
-             .forEach(k=>localStorage.removeItem(k));
-           indexedDB.deleteDatabase('lobehub-local-data');`,
-});
-```
-
-Assert the clear actually ran in the new document (set a flag in that script and
-read it back) rather than trusting the removal.
-
-**The same cache tier inverts _request-gating_ assertions, not just rendered values.**
-When a component decides whether to fire a secondary query from data it reads out of
-the portrait/list query (`useX(shouldFetch ? id : undefined)`), the hydrated cache is
-what the gate sees on the mount frame. Change the underlying state with raw SQL and
-the gate still fires off the stale cached copy, so a correct gate measures as broken —
-and the reverse can hide a broken one. Drive the state change through the product
-write path (whose success handler revalidates), or re-measure after the list query has
-resolved once and the cache is reconciled; report the steady state, and record the
-stale frame separately if you observed it. Pair it with a warm control run: if
-the warm run renders data while the request is held paused and the cold run shows
-the skeleton, the cache tier is proven to be what the render reads.
-
-### `app-probe.sh goto /` cannot reach the desktop Home route — seed the tab first
-
-**Situation:** driving the Electron shell to the Home route (`/`) to check the nav
-panel there.
-
-**Doesn't work:** `app-probe.sh goto /` prints `"/"` but the renderer stays on the
-previous route. `goto` is a full reload, and the desktop shell restores the active
-tab's persisted url on boot — every non-root route survives that restore, so `goto`
-appears to work for `/tasks`, `/agents`, `/settings` and silently fails only for
-`/`. The follow-up probe then describes the old page with no error anywhere.
-
-**Works:** create and activate a Home tab first, then navigate:
-
-```js
-window.__LOBE_STORES.electron().addTab('/'); // addTab also activates it
-```
-
-```bash
-.agents/acceptance/scripts/app-probe.sh goto /
-```
-
-Assert `location.pathname` after the reload rather than trusting `goto`'s echo.
-
-### Anchor nav-panel assertions on `#nav-panel-drawer`, not a `data-insp-path` match
-
-**Situation:** asserting what the left nav panel renders on a given route.
-
-**Doesn't work:** `document.querySelector('[data-insp-path*="NavPanelDraggable"]')`.
-It resolves during a settled render but returns `null` in the seconds after a full
-reload, and the usual `|| document.body` fallback then reads
-`document.body.innerText === ''` (generic C4) — which looks exactly like an empty
-panel and turns a normal loading window into a false regression.
-
-**Works:** the panel is the `<aside>` sibling of the stable drawer anchor:
-
-```js
-const drawer = document.getElementById('nav-panel-drawer');
-const aside = drawer && [...drawer.parentElement.children].find((c) => c.tagName === 'ASIDE');
-```
-
-Then assert on `aside.innerText` line count plus a count of text-free rounded boxes
-(the skeleton rows). Distinguish the two skeleton states explicitly: a text-free panel
-carrying `[data-testid="nav-sidebar-skeleton"]` is the nav-panel fallback, while fixed
-items present with only the list area shimmering is ordinary data loading. Do NOT
-identify the fallback by a row count — it is shaped per navKey now
-(`NAV_SKELETON_SHAPES`), so memory/discover render header plus a nav list and no body
-at all, while settings renders a search box plus four accordion groups.
-
-### Park a route's lazy chunk to hold its pending sidebar on screen
-
-**Situation:** verifying what a route's `NavPanel` fallback (or any `dynamicElement`
-Suspense fallback) actually renders. The pending state lasts a few hundred ms, so no
-screenshot or `agent-browser eval` catches it.
-
-**Doesn't work:** network throttling, or adding a debug flag that force-renders the
-fallback. Throttling does not bound the module fetch predictably, and a force-render
-flag proves the component renders, not that the product path reaches it.
-
-**Works:** raw CDP `Fetch.enable` intercepts `app://renderer/...` module requests in
-the Electron renderer. Park the route's layout chunk and the portal never registers,
-so the fallback stays up indefinitely — measure and screenshot at leisure, then kill
-the CDP connection to release the request and measure the settled sidebar in the same
-session.
-
-```js
-Fetch.enable({ patterns: [{ requestStage: 'Request', urlPattern: '*settings/_layout*' }] });
-// on Fetch.requestPaused: keep the requestId, never continueRequest
-// [paused] app://renderer/src/routes/(main)/settings/_layout/index.tsx?t=1785957215039
-```
-
-Two traps. The pattern must name the **layout** chunk only: a broad `*settings*`
-also parks `store/user/slices/settings/*` and the router's own `routeMeta`, which
-stalls boot instead of the route. And the layout module is not always under the path
-you guess — the agent sidebar registers from `(main)/agent/_layout`, not
-`(main)/agent/(chat)/_layout`; when the measurement comes back `mode: real`, the
-pattern missed, it is not a product finding.
-
-Drive the navigation with `app-probe.sh goto <route>` (a full reload, so the module
-is re-requested and re-parked).
-
-### Boot-phase UI cannot be observed by CDP polling — sample in-page, and mirror the timer
+#### Boot-phase UI cannot be observed by CDP polling — sample in-page, and mirror the timer
 
 **Situation:** asserting whether a transient boot-phase surface (a splash, a skeleton,
 a first-paint gate) appears between React's first commit and the app painting.
@@ -947,7 +901,343 @@ them turns a clean boot into a false "the logo flashed"); and record the max gap
 consecutive ticks — LobeHub's boot routinely shows a single 0.6–1.1s blocking task, so a
 phase with no sample inside it is a blocked window, not a missing state.
 
-### A global `indexedDB.open` stall holds the boot on web but kills the Electron renderer
+#### Asserting a modal's exit window: `data-ending-style` is never set, and `record-gif.sh` is far too slow
+
+**Situation:** proving what a base-ui modal does during its \~120ms exit — typically that the body
+stays mounted while the panel fades, rather than blanking at the start of the animation.
+
+**Doesn't work:** three separate traps.
+
+- Gating on `panel.hasAttribute("data-ending-style")`. `base-ui/Modal/style.mjs` does carry a
+  `[data-ending-style]` rule, but the imperative host animates through motion/react, so the
+  attribute stays absent for the whole exit. Filtering samples on it yields an empty set and reads
+  as "the exit never happened".
+- Polling the state from the driver. A `Runtime.evaluate` round trip is the same order of magnitude
+  as the window itself, so the driver only ever observes before and after.
+- `scripts/record-gif.sh`. Its own header caps effective rate at 1–2 fps; a 120ms window gets at
+  most one frame.
+
+**Works:** sample inside the page and capture frames from the compositor.
+
+```js
+// exit-window signal = opacity decay on popupInner ([role=dialog] > :first-child)
+const tick = () =>
+  samples.push({
+    t: performance.now() - t0,
+    connected: panel.isConnected,
+    opacity: getComputedStyle(panel).opacity,
+    panelH: panel.getBoundingClientRect().height,
+    contentKids: content.children.length,
+    contentTextLen: content.innerText.length,
+  });
+setInterval(tick, 8);
+```
+
+A body that survives the exit holds `contentTextLen` / `contentKids` constant while opacity decays,
+and the panel shrinks only \~1.5% (the `scale(0.98)` exit transform) instead of collapsing to the
+56px header. For the visual half, drive raw CDP `Page.startScreencast` (frames land only when the
+compositor paints, so they cluster inside the animation — \~9 frames in the 120ms window) and replay
+those unmodified frames slowly with ffmpeg. Do not slow the product's own transition: the exit is a
+JS animation, so a CSS `transition-duration` override does nothing anyway.
+
+#### Switching web-session theme for dark-mode evidence needs no UI — next-themes reads `localStorage.theme`
+
+**Situation:** capturing light- and dark-mode evidence in the seeded `agent-browser`
+web session (settings UI navigation is slow and the theme control moved between
+releases; an earlier round wrongly concluded the web session "cannot switch to
+dark").
+
+**Doesn't work:** driving the settings UI to flip appearance, or editing user
+settings server-side (the provider is `next-themes` with `defaultTheme="system"` —
+the server does not own it).
+
+**Works:** set the next-themes key directly, then reload the target route in the
+same session:
+
+```bash
+agent-browser --session lobehub-dev eval "localStorage.setItem('theme','dark')"
+agent-browser --session lobehub-dev open "$SERVER_URL/<route>" # re-render applies html[data-theme]
+```
+
+`'light'` / removal (`localStorage.removeItem('theme')` → back to system) work the
+same way. Restore BEFORE stopping the dev server — once the server is down the
+document becomes sourceless and `localStorage` access throws SecurityError, so the
+override stays behind for the next run. Assert the applied theme via
+`document.documentElement.dataset.theme`, not the storage value.
+
+#### Workspace HTML publish: prove the hosted page, not the local preview
+
+**Situation:** after publishing workspace HTML, checking whether CSS/SVG/images
+actually load on the public Artifact URL.
+
+**Doesn't work:** grepping the in-app HTML preview, or treating `app.css` /
+`dot.svg` HTTP 404 on the host as failure after a successful inline publish.
+Those paths are not uploaded when files are inlined. Opening a relative
+`index.html` tab (instead of the Files-tree absolute path) also fails to load
+and hides the publish control.
+
+**Works:** click the Files-tree row so `openLocalFiles[].filePath` is the
+Electron absolute path (on macOS often `/private/tmp/...`). After publish,
+`curl` the public URL and assert the HTML no longer contains `./app.css`. Then
+open that URL and assert computed CSS plus `img.naturalWidth > 0`. If the hosted
+`<img>` is a data URI with `text/plain`, the image is broken even though it is
+not a 404.
+
+#### `acceptance run ingest` is creative — re-running it to re-read its output mints a duplicate round
+
+**Situation:** after a successful ingest, wanting to re-check a field from its JSON
+output (evidence count, acceptanceId).
+
+**Doesn't work:** running the same `ingest` command again "just to see the output".
+Every invocation creates a new immutable round on the acceptance — the re-run
+publishes a byte-identical duplicate round that reviewers then see twice.
+
+**Works:** re-read state with the read-only commands — `acceptance run list`,
+`acceptance run get <runId>`, `acceptance view <id> --json`. If a duplicate was
+minted by mistake, `acceptance run delete <runId> --yes` (newest timestamp = the
+accident) restores the round history; this is data correction of an operator
+error, distinct from the forbidden overwrite-a-real-round.
+
+### Electron and the desktop shell
+
+#### Which entry the dev Electron main window loads is NOT stable — measure it, never assume
+
+**Situation:** verifying anything that lives in `src/spa/entry.desktop.tsx` (bootstrap
+identity, adapter registration, boot marks) on an `electron-dev.sh` instance.
+
+**Doesn't work:** assuming any particular entry, in either direction. This has now been
+measured with two different results on the same helper:
+
+- Earlier: the main window's entry script was `app://renderer/src/spa/entry.web.tsx`
+  while the topicPopup window in the same instance loaded `entry.popup.tsx` — so the
+  main window fell through to the root `index.html`. Consequence at the time:
+  desktop-entry boot code never executed in dev, and a deletion there passed every dev
+  smoke test, which is how one such call was lost for a whole release.
+- 2026-08-05, on `feat/home-customize-modal`: the main window loaded
+  **`app://renderer/src/spa/entry.desktop.tsx`** — the fall-through did not reproduce.
+
+Mechanism not established in either direction, and no bisect was done, so do not
+assume the newer reading is permanent either. Treat the loaded entry as an unknown to
+be measured per run — that is the durable rule; the specific value is not.
+
+**Works:** before claiming anything about a desktop entry, read the loaded entry script
+and branch on it:
+
+```js
+[...document.querySelectorAll('script')].map((s) => s.src).find((s) => s.includes('entry.'));
+```
+
+If it is not the entry you are testing, the surface cannot prove your claim — fall back to
+a source-order regression test, and say in the report that the runtime path needs a
+packaged build (`DESKTOP_RENDERER_STATIC` / `resolveRendererFilePath` maps
+`apps/desktop/index.html`, `popup.html`, `overlay.html`).
+
+#### Measuring production-bundle startup behavior without packaging the app
+
+**Situation:** a claim depends on the built renderer (chunk splitting, lazy-route
+boundaries, startup paint timing), which dev-mode Vite cannot reproduce.
+
+**Doesn't work:** measuring in the dev instance (unbundled modules make lazy vs
+eager indistinguishable), or trusting `performance.getEntriesByType('resource')`
+to identify what loaded — the `app://` protocol emits no resource-timing entries
+at all (0 JS resources on a fully loaded page).
+
+**Works:** build the renderer (`cd apps/desktop && vite build --config
+vite.renderer.config.ts`), then launch a pool instance with the static override:
+
+```bash
+DESKTOP_RENDERER_STATIC=1 .agents/acceptance/scripts/electron-dev.sh start 1
+```
+
+The dev main process serves `apps/desktop/dist/renderer` over `app://renderer/`
+with the seeded login. Prove which build is loaded via the modulepreload hashes
+in the live DOM, not resource timing:
+
+```js
+[...document.querySelectorAll('link[rel=modulepreload]')]
+  .map((l) => l.href)
+  .find((h) => h.includes('<chunk-under-test>'));
+```
+
+Paint metrics survive post-hoc collection: a buffered
+`PerformanceObserver({ type: 'largest-contentful-paint', buffered: true })` plus
+`performance.getEntriesByType('paint')` read after load give FCP/DCL and the full
+LCP-candidate timeline. `restart 1` re-seeds userData, so each restart is a
+comparable cold start; `location.reload()` gives low-variance warm samples. For
+A/B builds, swap `dist/renderer` directories between restarts — remote-image LCP
+entries are network-noisy, so compare text-paint candidates and DCL across ≥5
+cold samples per variant before attributing a delta.
+
+#### Driving and probing a real Electron popup window
+
+**Situation:** verifying `entry.popup.tsx` behavior (its own HTML shell, no `BootShell`).
+
+**Works:** open the real window from the renderer store, then attach raw CDP to the
+popup's own target — the agent-browser daemon holds the main window's target, and one
+page target accepts only one websocket:
+
+```bash
+agent-browser --cdp 9222 eval '(async () => {
+  await window.__LOBE_STORES.global().openTopicInNewWindow("inbox","verify-popup");
+  return "requested"; })()'
+curl -s http://127.0.0.1:9222/json/list # pick the target whose url contains /popup/
+```
+
+Any `(agentId, topicId)` pair works — the popup boots regardless of whether the route
+resolves data, which is what makes this usable on a signed-out instance. For overlay
+claims, measure rather than eyeball: `getComputedStyle` for `pointer-events` / background
+alpha plus `document.elementFromPoint(x, y)` — a 50%-alpha scrim looks like a cosmetic
+tint in a screenshot while actually swallowing every click.
+
+#### Desktop tab switching is not `activateTab` alone — drive the real tab element
+
+**Situation:** benchmarking or driving a desktop tab switch from an `eval`
+payload, using `window.__LOBE_STORES.electron().activateTab(id)`.
+
+**Doesn't work:** on the single-router shell, `activateTab` only writes
+`activeTabId`; navigation is a second step performed by the TabBar
+(`handleActivate` = `activateTab(id)` + `startTransition(navigate(url))`). Calling
+the store action alone leaves `location.pathname` on the previous route, so the
+run measures a no-op — visible as a tiny settle time, \~4 DOM mutations, and zero
+long tasks, which reads like an impossibly fast surface rather than a broken
+probe. The per-tab-router shell does switch content from the store action alone,
+so the same payload is a real switch on one build and a no-op on the other:
+any A/B built on it is invalid.
+
+**Works:** drive the tab element the user actually clicks, and assert the
+navigation happened.
+
+```js
+const all = [...document.querySelectorAll('[data-insp-path*="TabBar/TabItem.tsx"]')].filter(
+  (e) => e.getBoundingClientRect().width > 100,
+);
+// two nested nodes per tab match — keep only the outermost
+const roots = all
+  .filter((e) => !all.some((o) => o !== e && o.contains(e)))
+  .sort((a, b) => a.getBoundingClientRect().x - b.getBoundingClientRect().x);
+// roots[i] aligns 1:1 with store tabs[i]; verify roots.length === tabs.length
+roots[idx].click();
+```
+
+`el.click()` reaches the React `onClick` here (this is not a controlled input, so
+the generic D11 trusted-input caveat does not apply). Always record
+`location.pathname` before and after and keep a `navigated` flag on every sample —
+that flag is what catches a payload that silently stopped switching.
+
+#### Clicking an already-active tab is a no-op — a desynced tab can never be re-entered by clicking
+
+**Situation:** a probe adds a tab with `addTab(url)` and then clicks it to enter that route.
+
+**Doesn't work:** `addTab` already activates the new tab, so the later click lands on the _active_ tab
+and the shell does nothing. On the single-router shell this can leave `activeTabId` pointing at a tab
+whose URL names one topic while `location.pathname` and `chat().activeTopicId` still name another —
+after which no amount of clicking recovers it, and every downstream assertion reads the wrong page.
+Symptom: the probe's final `location.pathname` is not the tab you clicked, with no error anywhere.
+
+**Works:** after `addTab`, enter the route with a full navigation
+(`app-probe.sh goto <url>`) before starting the trials, and assert the three values agree before
+measuring:
+
+```js
+const st = window.__LOBE_STORES.electron();
+const chat = window.__LOBE_STORES.chat();
+const tab = (st.tabs || []).find((t) => t.id === st.activeTabId);
+// tab.url, location.pathname and chat.activeTopicId must all point at the same topic
+```
+
+#### Attributing switch work to hidden keep-alive trees — classify on BOTH sides of the action
+
+**Situation:** measuring what a per-tab keep-alive shell costs while a tab is hidden.
+
+**Doesn't work:** collecting the hidden slots (the `display: none` children of the TabHost root) _before_
+the switch and classifying every mutation against that list. The switch is precisely what makes the
+target tab visible, and that tab was hidden when the list was captured — so the incoming tab's own
+render, which is necessary user-visible work, is counted as hidden-tree work. This produced a confident
+"\~44% of switch work happens off-screen" that was pure artefact, and it survived review because the
+number looked plausible.
+
+**Works:** classify against the intersection — slots hidden **before** the switch that are **still
+hidden after** it:
+
+```js
+const before = hiddenSlots(); // display:none children of the TabHost root
+/* click the tab, observe mutations */
+const after = hiddenSlots();
+const stillHidden = before.filter((s) => after.includes(s));
+```
+
+Measured this way, still-hidden slots produced **0** mutations in 6/6 switches: React
+`<Activity mode="hidden">` keeps state, tears down effects, and commits nothing while hidden.
+
+**General rule:** when a measurement classifies work by a property that the measured action itself
+changes (visible/hidden, active/inactive, mounted/unmounted), capture the classification on both sides
+and use the intersection. Otherwise the action's own effect lands in the wrong bucket.
+
+#### Desktop theme follows the system appearance, not `settings.general.themeMode`
+
+**Situation:** capturing dark-mode evidence for a desktop UI change.
+
+**Doesn't work:** `window.__LOBE_STORES.user().updateGeneralConfig({ themeMode: 'dark' })`.
+The setting persists (reading it back returns `dark`, and it survives a restart),
+but `document.documentElement.dataset.theme` stays `light` and every token keeps its
+light value. Restarting the instance does not apply it either. Treating the stored
+setting as proof of the rendered theme yields evidence captured in the wrong theme.
+
+**Works:** assert `document.documentElement.dataset.theme` — never the stored
+setting — before capturing any theme-dependent evidence. The renderer tracks the OS
+appearance, so switching it means changing the user's macOS system setting, which is
+outside the harness's remit: mark the dark case untested and say why, rather than
+flipping a device-level preference. Note the setting write is not free — it syncs to
+the account and affects other surfaces; restore it (`auto`) at teardown if you set it.
+
+#### `app-probe.sh goto /` cannot reach the desktop Home route — seed the tab first
+
+**Situation:** driving the Electron shell to the Home route (`/`) to check the nav
+panel there.
+
+**Doesn't work:** `app-probe.sh goto /` prints `"/"` but the renderer stays on the
+previous route. `goto` is a full reload, and the desktop shell restores the active
+tab's persisted url on boot — every non-root route survives that restore, so `goto`
+appears to work for `/tasks`, `/agents`, `/settings` and silently fails only for
+`/`. The follow-up probe then describes the old page with no error anywhere.
+
+**Works:** create and activate a Home tab first, then navigate:
+
+```js
+window.__LOBE_STORES.electron().addTab('/'); // addTab also activates it
+```
+
+```bash
+.agents/acceptance/scripts/app-probe.sh goto /
+```
+
+Assert `location.pathname` after the reload rather than trusting `goto`'s echo.
+
+#### The dev Electron instance may be a thin client on PRODUCTION — read `dataSyncConfig` before any write
+
+**Situation:** starting `electron-dev.sh` to verify a frontend change, then driving flows that
+create or mutate product objects (labels, groups, agents, forwarded topics, saved edits).
+
+**Doesn't work:** assuming the instance talks to a local backend because the run also started one.
+The seeded login snapshot carries its own target, and `{"storageMode":"cloud","active":true}` means
+the renderer runs your working-tree code while every request goes to `app.lobehub.com` with the
+user's real account. `app-probe.sh server-auth` returns 200, which reads as "the local stack is
+wired up" and encourages exactly the writes that then land in production. The local dev server the
+run started sits unused.
+
+**Works:** read the target first and let it decide the test's write budget.
+
+```bash
+agent-browser --cdp 9222 eval '(() => JSON.stringify(window.__LOBE_STORES.electron().dataSyncConfig))()'
+# {"storageMode":"cloud","active":true}   -> production account; keep the run read-only
+# {"storageMode":"selfHost","remoteServerUrl":"http://localhost:3111", ...} -> local backend
+```
+
+On `cloud`, verify open / render / close only, treat every submit as a user-owned decision, and
+prove afterwards that nothing was written (re-read the relevant store count). Note this also makes
+the whole local-server bring-up unnecessary — check the target before spending minutes on it.
+
+#### A global `indexedDB.open` stall holds the boot on web but kills the Electron renderer
 
 **Situation:** needing to freeze the boot at a pre-app phase long enough to capture it,
 by keeping the SWR cache hydration from ever completing.
@@ -966,7 +1256,64 @@ in-page sampler above. Either way, disarm with
 `Page.removeScriptToEvaluateOnNewDocument` and reload before capturing the settled
 state, or the comparison shot is taken against a still-crippled runtime.
 
-### The desktop instance pins a previous run's server port, and its saved OAuth login expires
+#### Locale regression tests and desktop resource scanning
+
+**Situation:** a locale-copy change needs a focused regression assertion while
+the Electron dev renderer imports locale resources from the default resource tree.
+
+**Doesn't work:** placing `*.test.ts` beside files in
+`packages/locales/src/default/`. The desktop resource scan can include that module
+in the renderer graph, which makes Vite optimize and execute `vitest` in the app.
+
+**Works:** keep the assertion under the consuming feature's test directory and
+import the locale resource there. Restart the isolated Electron instance after a
+bad scan because the optimized dependency graph can remain poisoned.
+
+### Auth and session state
+
+#### Task CLI polling with seeded API-key auth
+
+**Situation:** A local acceptance run is driven through `lh task run` with the
+seeded `LOBEHUB_CLI_API_KEY`, and the test needs to observe the asynchronous
+repair lifecycle.
+
+**Doesn't work:** `lh task run <id> --follow` switches to `/webapi/*`, which
+requires OIDC and rejects API-key auth after the task has already started.
+Likewise, `lh acceptance view task:T-N` does not currently resolve a task
+identifier to its internal subject id.
+
+**Works:** Start the task without `--follow`, poll with `lh task view T-N`, and
+query the aggregate with `lh acceptance view task:<internal-task-id>`. The start
+response and task activity expose the operation and topic ids; the Acceptance
+bundle exposes the repair round and final rollup.
+
+The same identifier/internal-id gap exists on the WRITE path: a local
+`acceptance run ingest --subject task:T-N` stores the literal `T-N` as
+`acceptance_subjects.subject_id`, while task/goal detail pages resolve the
+acceptance by the task's INTERNAL id — the page then renders an empty state even
+though ingest succeeded. Use the internal id in `--subject` (or fix the
+`subject_id` row afterwards) when the evidence must render in the local app UI.
+
+#### Production-backend web runs have no seeded agent-browser session
+
+**Situation:** verifying frontend-only work against real production data through
+`bun run dev:spa`'s `_dangerous_local_dev_proxy` URL.
+
+**Doesn't work:** the adapter's Web evidence path (`agent-browser --session
+lobehub-dev` seeded by `setup-auth.sh web-seed`) authenticates against the LOCAL
+server. There is no sanctioned way to give that session a production login —
+`setup-auth.sh web`'s Chrome-cookie injection is explicitly forbidden against
+production.
+
+**Works:** drive the proxy in the user's already-authenticated Chrome (the
+`claude-in-chrome` tooling), and compensate for the weaker evidence channel with
+DOM measurements (`getBoundingClientRect` / `getComputedStyle`) alongside every
+screenshot, plus an independent server-side check through `lh` in a clean env.
+Prove the working-tree bundle is actually live first — read back a string that
+exists only in the working tree (e.g. a changed placeholder), never assume HMR
+applied.
+
+#### The desktop instance pins a previous run's server port, and its saved OAuth login expires
 
 **Situation:** starting an Electron dev instance for a surface that needs the local
 backend (any tRPC-backed panel), in a fresh worktree.
@@ -989,6 +1336,12 @@ agent-browser --cdp 9222 eval '(() => JSON.stringify(window.__LOBE_STORES.electr
 SERVER_PORT=3111 .agents/acceptance/scripts/init-dev-env.sh dev-next
 ```
 
+It must be `SERVER_PORT=`, not `PORT=`. The last line of `cmd_dev_next` is
+`exec pnpm exec next dev -p "$SERVER_PORT"`, and `SERVER_PORT` falls back to the
+ports-file allocation only when it is not passed explicitly. `PORT=` is exported but
+never reaches `-p`, so the server still comes up on the ports-file port: the log
+looks entirely normal and only BackendProxy keeps returning 502.
+
 For the expired login, do **not** drive the OAuth flow. The proxy forwards the
 Electron session's cookies alongside its `Oidc-Auth` header, and the server accepts
 a better-auth session cookie — so mint one for the seeded user and inject it over
@@ -1005,33 +1358,104 @@ curl -c cookie.jar -H 'Content-Type: application/json' -X POST \
 Gate on `app-probe.sh server-auth` returning `{"authenticated":true,"status":200}` —
 renderer `isSignedIn` alone never proves the server accepted anything.
 
-### `agent.updateAgentConfig` silently drops `agencyConfig.heterogeneousProvider`
+#### A pool instance seeded from the login snapshot can boot signed out — `safeStorage` cannot decrypt the copied token
 
-**Situation:** turning a test agent into a CLI-agent shape (Claude Code / Codex) so
-the heterogeneous chat input and its quota badges render.
+**Situation:** `electron-dev.sh start <id>` in a worktree; the helper reports the
+renderer ready and the seeded login is present on disk.
 
-**Doesn't work:** `updateAgentConfigById(id, { agencyConfig: { heterogeneousProvider:
-{ type: 'claude-code', command: 'claude' } } })`. The store's optimistic write makes
-it look applied — reading `agentMap[id].agencyConfig` back returns the provider — but
-the DB row keeps only the sibling keys (`executionTarget` persists, the provider does
-not), so the next full reload drops it and the plain chat input comes back. Reads as
-"the agent isn't hetero" with no error anywhere.
+**Doesn't work:** trusting `login-status`'s "refresh token PRESENT" as proof the
+instance will come up authenticated. The pool's copied userData can fail to decrypt
+its access token — `/tmp/lobe-electron-pool/instance-<id>.log` repeats
+`Failed to decrypt access token: Error while decrypting the ciphertext provided to
+safeStorage.decryptString` — and the app boots signed out (`app-probe.sh auth` →
+`isSignedIn: false`) with a near-blank shell that reads like a broken route tree.
+Cause not established; re-seeding and restarting the same pool id does not help.
 
-**Works:** seed the shape directly (public API first is the rule; this is the
-documented exception where the write path does not carry the field):
+**Works:** fall back to the legacy single instance (`electron-dev.sh start`, no id),
+which runs on the golden profile in place and decrypts normally. It boots on the
+loading shell once, so reload once before probing (see L-S8). Gate on
+`app-probe.sh auth` AND `server-auth`, never on the helper's "Ready" line.
 
-```bash
-docker exec lobehub-agent-testing-postgres psql -U postgres -d postgres -tAc \
-  "update agents set agency_config = '{\"executionTarget\":\"local\",\"heterogeneousProvider\":{\"type\":\"claude-code\",\"command\":\"claude\"}}'::jsonb where id='<agentId>';"
-```
+#### Electron dev's BackendProxy targets the server port persisted in the login snapshot — mint a session and inject the cookie over CDP
 
-Then cold-load: a plain reload keeps serving the agent config from the tiered SWR
-cache, so the renderer still shows the pre-write value (generic M18). Clear
-`lobechat-swr-cache*` + `lobehub-local-data` through
-`Page.addScriptToEvaluateOnNewDocument` and reload (see "Cold SWR cache" above),
-then assert `agentMap[id].agencyConfig` before drawing any conclusion.
+**Situation:** starting the Electron surface inside a worktree to verify a pure
+frontend change; the renderer looks fine, but `app-probe.sh server-auth` returns 502
+and `isUserStateInit` stays false (UI gated on it — the Labs section, for instance —
+silently does not render, so the store state reads as "set but not taking effect").
 
-### An unconverged lockfile puts two copies of a dep in the graph — every route using it dies at the ErrorBoundary
+**Doesn't work:** starting the dev server on 3010 or on the dynamic port `test-env.sh`
+resolves. The desktop main process persists the BackendProxy target port in the login
+snapshot's userData; `BackendProxy upstream fetch failed ... http://localhost:<port>`
+in `/tmp/electron-dev.log` is the only source of truth, and it has nothing to do with
+the current ports-file. If a 401 appears once the port matches, the snapshot cookie is
+no longer valid against the local database — restarting Electron to re-seed the
+snapshot does not recover it.
+
+**Works:** three steps. (1) Read the BackendProxy target port from the log and start
+the dev server with `PORT=<that port>`. (2) Mint a better-auth session with the same
+curl `web-seed` uses (`POST /api/auth/sign-in/email` as the seeded user; fetching from
+inside the renderer is rejected 403 because of the `app://` origin, so it must be
+curl). (3) Write both `better-auth.session_data` and `better-auth.session_token` into
+Electron's cookie store through raw CDP `Network.setCookie` (with `url` set to
+`http://localhost:<port>/`); after `location.reload()`, `server-auth` returns 200 and
+`isUserStateInit` is true.
+
+#### A pool instance's BackendProxy port also comes from the login snapshot, and its log is `instance-<id>.log`
+
+**Situation:** starting a pool instance with `electron-dev.sh start <id>` to verify a
+pure frontend change; `auth` and `server-auth` both pass, but the content area shows
+"failed to load" with `sessions: 0` and `isSessionsFirstFetchFinished: false`.
+
+**Doesn't work:** starting the dev server on the port `test-env.sh` resolves (the
+ports-file one). Do not go looking in `/tmp/electron-dev.log` either — pool instances
+never write that file, so grepping it for BackendProxy finds nothing and reads as
+"there are no proxy errors". Note also that a 200 from `server-auth` does not prove
+the data layer works: it does not take the same route as tRPC.
+
+**Works:** read
+`BackendProxy upstream fetch failed ... http://localhost:<port>/trpc/...` from
+`/tmp/lobe-electron-pool/instance-<id>.log`, start the dev server on that port
+(`PORT=<port> APP_URL=http://localhost:<port> init-dev-env.sh dev`), then restart that
+pool instance. The criterion is that `topicDataMap` actually holds items, not the
+helper's Ready line. Beware that `init-dev-env.sh dev` / `stop-dev` can SIGTERM the
+pool instance along the way (the log shows
+`GPU process exited unexpectedly: exit_code=15`), so the order is: fix the port and
+start the server first, then start Electron.
+
+### Dev server, install, and ports
+
+#### A backgrounded `init-dev-env.sh dev` looks dead while the server is alive on a dynamic port
+
+**Situation:** starting the dev server from a harness-managed background command in a
+worktree, then waiting for readiness.
+
+**Doesn't work:** trusting the background task's captured output (it can stay 0 bytes
+while the detached process tree lives on), or polling the default port. Worktrees
+allocate dynamic ports, so probing `localhost:3010` waits forever while the server is
+already up elsewhere; a retry then fails with "an owned dev server is already running".
+
+**Works:** treat `.records/runtime/` as the source of truth — it records `PID`,
+`SERVER_PORT` and `SPA_PORT` for the owned instance. Read the port from there and poll
+that. For a long-lived start prefer a detached `screen -dmS <name> … >> .records/logs/x.log`
+so the log lands in a stable file; `stop-dev` still stops the recorded PID tree either way.
+
+#### Agent-browser navigation hangs after an orphaned Next child keeps the port
+
+**Situation:** an isolated full-stack dev launcher exits, but its Next child
+continues listening without returning HTTP responses. `agent-browser open`,
+`get url`, and even session close can then appear to hang because navigation
+never settles.
+
+**Doesn't work:** repeatedly recreating browser sessions or assuming the
+browser daemon is the root cause while `curl --max-time` to the target route
+also receives zero bytes.
+
+**Works:** inspect the exact listener with `lsof`, confirm its command and
+working tree, terminate only that run-owned process tree, then restart through
+`init-dev-env.sh dev` and reseed the isolated browser auth. A successful HTTP
+probe must precede browser assertions.
+
+#### An unconverged lockfile puts two copies of a dep in the graph — every route using it dies at the ErrorBoundary
 
 **Situation:** after rebasing onto a canary that bumped a shared UI dependency and
 running `pnpm install`, every route rendering the rich-text editor (agent profile,
@@ -1073,7 +1497,7 @@ checkout and appears right after a rebase that bumps the root range. Do not repo
 as a defect of the branch or of the base ref; note it as an environment finding and
 move on. Back up the lockfile before `dedupe` anyway — it is the only copy.
 
-### A fresh worktree installed with `--ignore-scripts` returns 500 on every `/trpc/lambda/*`
+#### A fresh worktree installed with `--ignore-scripts` returns 500 on every `/trpc/lambda/*`
 
 **Situation:** bootstrapping a new git worktree for a run — `pnpm install` at the root,
 then `init-dev-env.sh dev`.
@@ -1096,170 +1520,107 @@ rm -rf .next && pnpm install # no --ignore-scripts
 .agents/acceptance/scripts/init-dev-env.sh dev
 ```
 
+**Same persisted cache, second shape — a startup panic, no install involved.** A dev
+start can also die before serving anything with
+`panicked at turbo-tasks-backend/.../operation/mod.rs: Restore of All for task TaskId <n> failed in another thread: restoring failed`, followed by `next exited unexpectedly`
+and a `dev` exit 143. The install is fine here; the corruption is in `.next`'s persisted
+turbo-tasks cache from an earlier run that was killed mid-write. It reads like a
+Turbopack bug worth reporting upstream (the panic message says so itself) and invites a
+dependency hunt, but for a local run it is disposable state: `stop-dev`, `rm -rf .next`,
+start again — no reinstall needed. Treat any turbo-tasks panic naming cache
+restore/persist as the same disposable-state class, and do not attribute it to the branch
+under test.
+
 Gate on a real authenticated TRPC call rather than on the page rendering: a 200 from
 `$SERVER_URL/` proves nothing about the lambda routes. Remember `apps/cli` and
 `apps/desktop` are standalone installs (PROJECT.md §1), so each also needs its own
 `pnpm install` in a fresh worktree.
 
-### The dev Electron instance may be a thin client on PRODUCTION — read `dataSyncConfig` before any write
+#### A worktree Electron run leaves a second `@types/react` that fails the worktree type-check
 
-**Situation:** starting `electron-dev.sh` to verify a frontend change, then driving flows that
-create or mutate product objects (labels, groups, agents, forwarded topics, saved edits).
+**Situation:** running the Electron surface from a git worktree, which requires
+the `apps/desktop` standalone install (adapter §1), then running `bun run check --type`.
 
-**Doesn't work:** assuming the instance talks to a local backend because the run also started one.
-The seeded login snapshot carries its own target, and `{"storageMode":"cloud","active":true}` means
-the renderer runs your working-tree code while every request goes to `app.lobehub.com` with the
-user's real account. `app-probe.sh server-auth` returns 200, which reads as "the local stack is
-wired up" and encourages exactly the writes that then land in production. The local dev server the
-run started sits unused.
+**Doesn't work:** treating the resulting type errors as the branch's own. The
+desktop install brings its own `@types/react` (e.g. `19.2.18`) alongside the
+root's (`19.2.13`), and the two identities collide on every `lucide-react` icon
+`ref`, producing a cluster of "Two different types with this name exist, but they
+are unrelated" errors in files the branch never touched.
 
-**Works:** read the target first and let it decide the test's write budget.
+**Works:** intersect the erroring files with the branch's changed-file list before
+drawing any conclusion, and confirm causality by A/B — moving
+`apps/desktop/node_modules` aside makes the cluster vanish. At teardown, remove
+`apps/desktop/node_modules` and re-run the root `pnpm install` to restore a clean
+`✓ types clean` baseline. **Do not run the A/B while the instance is live** — the
+Electron binary runs out of that directory, so parking it kills the instance;
+capture all UI evidence first.
 
-```bash
-agent-browser --cdp 9222 eval '(() => JSON.stringify(window.__LOBE_STORES.electron().dataSyncConfig))()'
-# {"storageMode":"cloud","active":true}   -> production account; keep the run read-only
-# {"storageMode":"selfHost","remoteServerUrl":"http://localhost:3111", ...} -> local backend
-```
+#### Managed command runners can reap `electron-dev.sh start` children after the helper returns
 
-On `cloud`, verify open / render / close only, treat every submit as a user-owned decision, and
-prove afterwards that nothing was written (re-read the relevant store count). Note this also makes
-the whole local-server bring-up unnecessary — check the target before spending minutes on it.
+**Situation:** `electron-dev.sh start` (legacy and pool forms) reports that CDP
+and the renderer are ready, but the CDP port closes immediately after the helper
+command returns. The Electron log contains a normal renderer mount and no crash;
+changing from the saved login snapshot to the fresh golden profile does not alter
+the exit. The cause is not established.
 
-### Asserting a modal's exit window: `data-ending-style` is never set, and `record-gif.sh` is far too slow
+**Doesn't work:** retrying the helper with another pool id or changing the auth
+seed. Both instances become interactive during the helper's readiness loop and
+are gone before the next command can connect.
 
-**Situation:** proving what a base-ui modal does during its \~120ms exit — typically that the body
-stays mounted while the panel fades, rather than blanking at the start of the animation.
-
-**Doesn't work:** three separate traps.
-
-- Gating on `panel.hasAttribute("data-ending-style")`. `base-ui/Modal/style.mjs` does carry a
-  `[data-ending-style]` rule, but the imperative host animates through motion/react, so the
-  attribute stays absent for the whole exit. Filtering samples on it yields an empty set and reads
-  as "the exit never happened".
-- Polling the state from the driver. A `Runtime.evaluate` round trip is the same order of magnitude
-  as the window itself, so the driver only ever observes before and after.
-- `scripts/record-gif.sh`. Its own header caps effective rate at 1–2 fps; a 120ms window gets at
-  most one frame.
-
-**Works:** sample inside the page and capture frames from the compositor.
-
-```js
-// exit-window signal = opacity decay on popupInner ([role=dialog] > :first-child)
-const tick = () =>
-  samples.push({
-    t: performance.now() - t0,
-    connected: panel.isConnected,
-    opacity: getComputedStyle(panel).opacity,
-    panelH: panel.getBoundingClientRect().height,
-    contentKids: content.children.length,
-    contentTextLen: content.innerText.length,
-  });
-setInterval(tick, 8);
-```
-
-A body that survives the exit holds `contentTextLen` / `contentKids` constant while opacity decays,
-and the panel shrinks only \~1.5% (the `scale(0.98)` exit transform) instead of collapsing to the
-56px header. For the visual half, drive raw CDP `Page.startScreencast` (frames land only when the
-compositor paints, so they cluster inside the animation — \~9 frames in the 120ms window) and replay
-those unmodified frames slowly with ffmpeg. Do not slow the product's own transition: the exit is a
-JS animation, so a CSS `transition-duration` override does nothing anyway.
-
-### Day-scoped fixtures must use the browser's measured timezone, not an assumed one
-
-**Situation:** seeding backdated rows (briefs, activity, digests) whose UI grouping is
-by the viewer's _local calendar day_ (`dayjs().startOf('day')` on the client).
-
-**Doesn't work:** computing the day boundaries from an assumed timezone (the user's
-usual locale, the server tz, or the shell's). On this harness the agent-browser
-Chromium reports `America/Los_Angeles`, so a "today 14:00 CST" timestamp lands on the
-browser's _yesterday_ — the day view renders empty and reads exactly like the
-feature not fetching, while the server endpoint returns the rows when probed with
-the "correct" (assumed-tz) window.
-
-**Works:** before seeding, read the tz the grouping actually uses —
-`agent-browser eval 'Intl.DateTimeFormat().resolvedOptions().timeZone'` — and derive
-every `[startAt, endAt)` from that. When a day view comes back empty, diff the
-client's real request window (fetch wrapper on the batch URL) against the seeded
-timestamps before suspecting the query.
-
-### An `ActionIcon` is not a `<button>` — select it by its lucide class, click through agent-browser
-
-**Situation:** driving an icon-only affordance inside a popover or panel (`ActionIcon`
-from `@lobehub/ui`: refresh, calendar, more, …).
-
-**Doesn't work:** three separate near-misses, each of which reads as "the affordance
-does not exist" rather than as a driving error:
-
-- `pop.querySelectorAll('button')` misses it. `ActionIcon` renders a `div`/`span`
-  wrapper (`class="lobe-flex …"` around `span.anticon`), so a button-only sweep of a
-  popover reports zero controls and invites the wrong conclusion that the entry was
-  never rendered.
-- `el.click()` on that wrapper `div` resolves and returns, but no handler runs — the
-  React `onClick` sits on an inner node, so the tab-clicking recipe above does not
-  transfer to icon buttons.
-- `agent-browser click --x <n> --y <n>` is not a thing; `click` only takes a CSS
-  selector, XPath, or an `@eN` snapshot ref, and coordinates fail with the generic
-  `Element not found`, which reads as a missing element rather than a bad invocation.
-
-**Works:** find the icon by its lucide class, tag it, and let agent-browser do the
-real click:
+**Works:** use the documented multi-instance Model B command in a long-lived PTY
+with the same isolated userData, Vite port, IPC id, and CDP port:
 
 ```bash
-agent-browser --cdp 9222 eval '(() => {
-  const pop = [...document.querySelectorAll("[role=dialog]")].pop();
-  pop.querySelector("svg.lucide-calendar-days").setAttribute("data-qc", "entry");
-  return "tagged";
-})()'
-agent-browser --cdp 9222 click "[data-qc=entry]"
+LOBE_DESKTOP_VITE_PORT=5175 \
+  LOBE_DESKTOP_USER_DATA_DIR=/tmp/lobe-electron-pool/ud-2 \
+  LOBE_IPC_ID=lobehub-desktop-dev-2 \
+  pnpm -C apps/desktop dev -- --remote-debugging-port=9224
 ```
 
-Enumerate candidates with `pop.querySelectorAll("button,[role=button],span[role]")`
-and read each node's `svg` class when the icon's identity is unknown. **The class is
-the icon's _rendered_ lucide name, not the React symbol you imported** — a component
-imported as `MoreHorizontalIcon` renders `svg.lucide-ellipsis`, so a selector guessed
-from the import name matches nothing and reads as "the affordance was never rendered".
-Enumerate the classes present, then disambiguate duplicates by geometry (a header
-control is the top-most, right-most non-zero rect) rather than by DOM order. Two follow-ons
-worth knowing: a stray click on a tagged text node can dismiss the popover (re-open
-and re-tag rather than assuming the control vanished), and a `Tooltip`-wrapped cell
-needs a real pointer move (`Input.dispatchMouseEvent` over several coordinates, or a
-dispatched `pointerover`+`mouseover` pair) before its content mounts.
+Keep that command session open for the run. Confirm the CDP endpoint, project
+process path, `app-probe.sh ready`, renderer auth, server auth, and a raw-CDP
+screenshot before collecting evidence.
 
-### A pool instance seeded from the login snapshot can boot signed out — `safeStorage` cannot decrypt the copied token
+#### A reset shell cwd silently retargets git commits at the main repo's checked-out branch
 
-**Situation:** `electron-dev.sh start <id>` in a worktree; the helper reports the
-renderer ready and the seeded login is present on disk.
+**Situation:** a long worktree-based session where the harness occasionally resets the
+shell cwd back to the main repo root (e.g. after a `cd /tmp` in a compound command).
 
-**Doesn't work:** trusting `login-status`'s "refresh token PRESENT" as proof the
-instance will come up authenticated. The pool's copied userData can fail to decrypt
-its access token — `/tmp/lobe-electron-pool/instance-<id>.log` repeats
-`Failed to decrypt access token: Error while decrypting the ciphertext provided to
-safeStorage.decryptString` — and the app boots signed out (`app-probe.sh auth` →
-`isSignedIn: false`) with a near-blank shell that reads like a broken route tree.
-Cause not established; re-seeding and restarting the same pool id does not help.
+**Doesn't work:** running `git add -A && git commit` (or `bun run check`) without an
+explicit `cd` into the worktree. The commands succeed against the MAIN repo — the
+commit lands on whatever branch the user has checked out there, staging their
+unrelated dirty files, while the intended worktree change stays uncommitted. The
+only tell is an unexpected diffstat / parent commit; `push <branch>` then reports
+"Everything up-to-date" because the worktree branch ref never moved.
 
-**Works:** fall back to the legacy single instance (`electron-dev.sh start`, no id),
-which runs on the golden profile in place and decrypts normally. It boots on the
-loading shell once, so reload once before probing (see L-S8). Gate on
-`app-probe.sh auth` AND `server-auth`, never on the helper's "Ready" line.
+**Works:** in any worktree session, prefix every git/check command with an explicit
+`cd <worktree> &&`, and read the commit output's diffstat + `git log -1` parent
+before pushing. Recovery for a mistaken main-repo commit: `git reset --mixed HEAD~1`
+restores the user's branch and leaves their working tree as it was (verify against
+the session-start `gitStatus` snapshot); nothing needs force-pushing because the
+wrong-branch push was a no-op.
 
-### Workspace HTML publish: prove the hosted page, not the local preview
+#### Server-side reads of local S3 evidence are blocked by SSRF protection — private IPs must be allowed explicitly
 
-**Situation:** after publishing workspace HTML, checking whether CSS/SVG/images
-actually load on the public Artifact URL.
+**Situation:** verifying any capability where the **server** reads back an uploaded
+file (multimodal image judging, thumbnail processing, feeding a screenshot to a
+model). Locally the server always reads through `s3rver`, i.e. a presigned
+`http://127.0.0.1:29000/...` URL. The symptom is a silent whole-feature failure: the
+endpoint returns normally, the business counter is 0, and the log carries neither a
+model error nor an auth error — it looks exactly like the model deciding there was
+nothing to do.
 
-**Doesn't work:** grepping the in-app HTML preview, or treating `app.css` /
-`dot.svg` HTTP 404 on the host as failure after a successful inline publish.
-Those paths are not uploaded when files are inlined. Opening a relative
-`index.html` tab (instead of the Files-tree absolute path) also fails to load
-and hides the publish control.
+**Doesn't work:** investigating the model side, checking the provider key, confirming
+the evidence row and its `fileId` exist. All of that checks out, because the request
+was never sent — the failure is in the server's own fetch of the image.
 
-**Works:** click the Files-tree row so `openLocalFiles[].filePath` is the
-Electron absolute path (on macOS often `/private/tmp/...`). After publish,
-`curl` the public URL and assert the HTML no longer contains `./app.css`. Then
-open that URL and assert computed CSS plus `img.naturalWidth > 0`. If the hosted
-`<img>` is a data URI with `text/plain`, the image is broken even though it is
-not a 404.
+**Works:** add `SSRF_ALLOW_PRIVATE_IP_ADDRESS=1` to the dev server environment. The
+criterion is the log pair
+`SSRF protection blocked request: ... DNS lookup 127.0.0.1 ... is not allowed. Because, It is private IP address.`
+followed by `Error converting image to base64`. Production uses a real object-storage
+domain and is unaffected, so this is purely a local verification-environment gate and
+not a product defect — do not report it as a bug, and do not work around it by
+switching to inline base64, which would verify a path the product never takes.
 
 ## Detailed references
 
@@ -1281,120 +1642,5 @@ not a 404.
   work / Works and evidence for every mechanism claim.
 - Promote product-independent findings to the generic skill layer rather than
   duplicating them here.
-
-### Switching web-session theme for dark-mode evidence needs no UI — next-themes reads `localStorage.theme`
-
-**Situation:** capturing light- and dark-mode evidence in the seeded `agent-browser`
-web session (settings UI navigation is slow and the theme control moved between
-releases; an earlier round wrongly concluded the web session "cannot switch to
-dark").
-
-**Doesn't work:** driving the settings UI to flip appearance, or editing user
-settings server-side (the provider is `next-themes` with `defaultTheme="system"` —
-the server does not own it).
-
-**Works:** set the next-themes key directly, then reload the target route in the
-same session:
-
-```bash
-agent-browser --session lobehub-dev eval "localStorage.setItem('theme','dark')"
-agent-browser --session lobehub-dev open "$SERVER_URL/<route>" # re-render applies html[data-theme]
-```
-
-`'light'` / removal (`localStorage.removeItem('theme')` → back to system) work the
-same way. Restore BEFORE stopping the dev server — once the server is down the
-document becomes sourceless and `localStorage` access throws SecurityError, so the
-override stays behind for the next run. Assert the applied theme via
-`document.documentElement.dataset.theme`, not the storage value.
-
-### A reset shell cwd silently retargets git commits at the main repo's checked-out branch
-
-**Situation:** a long worktree-based session where the harness occasionally resets the
-shell cwd back to the main repo root (e.g. after a `cd /tmp` in a compound command).
-
-**Doesn't work:** running `git add -A && git commit` (or `bun run check`) without an
-explicit `cd` into the worktree. The commands succeed against the MAIN repo — the
-commit lands on whatever branch the user has checked out there, staging their
-unrelated dirty files, while the intended worktree change stays uncommitted. The
-only tell is an unexpected diffstat / parent commit; `push <branch>` then reports
-"Everything up-to-date" because the worktree branch ref never moved.
-
-**Works:** in any worktree session, prefix every git/check command with an explicit
-`cd <worktree> &&`, and read the commit output's diffstat + `git log -1` parent
-before pushing. Recovery for a mistaken main-repo commit: `git reset --mixed HEAD~1`
-restores the user's branch and leaves their working tree as it was (verify against
-the session-start `gitStatus` snapshot); nothing needs force-pushing because the
-wrong-branch push was a no-op.
-
-### Electron dev 的 BackendProxy 指向登录快照里持久化的 server 端口 — 铸会话 + CDP 注入 cookie
-
-**Situation:** worktree 里起 Electron surface 验证纯前端改动，renderer 一切正常但
-`app-probe.sh server-auth` 返回 502，用户状态 `isUserStateInit` 一直 false（受它门控的
-UI—— 如 Labs 分栏 —— 静默不渲染，store 状态看起来 "设置了但没生效"）。
-
-**Doesn't work:** 把 dev server 起在 3010 或 test-env.sh 解析出的动态端口。桌面主进程的
-BackendProxy 目标端口持久化在登录快照的 userData 里（`/tmp/electron-dev.log` 里
-`BackendProxy upstream fetch failed ... http://localhost:<port>` 是唯一真相），与当前
-ports-file 无关。端口对上后若见 401，是快照 cookie 对本地库已失效 —— 重启 Electron 重种快照
-也救不回来。
-
-**Works:** 三步：① 从日志读出 BackendProxy 的目标端口，`PORT=<该端口>` 起 dev server；
-② 用 web-seed 同款 curl 铸 better-auth 会话（`POST /api/auth/sign-in/email`，seeded 用户；
-从 renderer 内 fetch 会因 app\://origin 被 403，必须 curl）；③ 把 `better-auth.session_data`
-/ `better-auth.session_token` 两个 cookie 经 raw CDP `Network.setCookie`（url 填
-`http://localhost:<端口>/`）写进 Electron 的 cookie store，`location.reload()` 后
-server-auth 200、`isUserStateInit` true。
-
-### 技能菜单交互 bug 依赖用户数据形态 — 前台化 MCP 窗口 + 零写入点击在生产环境复现
-
-**Situation:** 复现「+」菜单 / 技能子菜单里的行级交互缺陷 (hover 详情卡、「...」策略菜单、
-卸载确认)。本地 seeded 全栈环境跑遍手势矩阵 (连续策略切换、popover 切换、禁用、卸载弹窗、
-注入 700ms 服务端延迟) 全部存活，而用户环境一触即发。
-
-**Doesn't work:** 在本地环境穷举手势排列。触发缺陷的行形态只存在于真实账号数据 —— 例如
-过期授权的 Composio 行 (Gmail 重新授权) 走的是与 SkillRow 不同的 `PopoverLabel` 渲染路径；
-本地 seeded 账号只有 builtin 行，detail card 甚至从不挂载。也不要在后台 MCP 标签页下结论
-(L-S10):popover 冻结在 data-starting-style、坐标点击失效、计时器被钳到 1s。
-
-**Works:** 三件套。① 让用户把扩展新建的 Chrome 窗口切到前台，`document.visibilityState === 'visible'` 且 DevDock 显示 60 FPS 后再驱动 —— 前台化后的 MCP 标签页是完全可信的交互
-表面；② 生产账号上的零写入复现：策略菜单只点击**当前已勾选项**(`updateSkillPolicy` 对
-currentMode === mode 提前返回，不发请求), 确认弹窗一律 Cancel, 菜单开合本身无写入；
-③ 机制归因用页面内事件取证 (document 捕获层记录 pointer/focus 事件的目标画像:closest
-role、inDialog、isConnected, 写入 `window.__AGENT_LOGS` 环形缓冲), 关闭原因用
-`onOpenChange(details.reason)` 直接记录 —— 单靠截图无法区分 outside-press /focus-out/
-hover-out。
-
-### 服务端读取本地 S3 证据会被 SSRF 拦下 — 需显式放行私有 IP
-
-**Situation:** 验证任何「服务端把已上传的证据 / 文件再读回来」的能力时（多模态判图、
-缩略图处理、把截图喂给模型），本地环境下服务端读文件必然走 `s3rver`
-（`http://127.0.0.1:29000/...` 的预签名 URL）。表现是功能整体静默失败：接口正常返回、
-业务计数是 0，日志里既没有模型报错也没有鉴权报错，很像模型判定为「无需处理」。
-
-**Doesn't work:** 排查模型侧、检查 provider key、确认证据行和 fileId 都在。这些都会正常，
-因为请求根本没发出去 —— 失败点在服务端 fetch 图片那一步。
-
-**Works:** 在 dev server 环境里加 `SSRF_ALLOW_PRIVATE_IP_ADDRESS=1`。判据是日志里的
-`SSRF protection blocked request: ... DNS lookup 127.0.0.1 ... is not allowed. Because,
-It is private IP address.` 与紧随其后的 `Error converting image to base64`。
-生产用真实对象存储域名，不受影响，所以这纯粹是本地验证环境的门槛，不是产品缺陷 ——
-不要把它当 bug 报上去，也不要为了绕开它改用 inline base64 从而验证了一条产品不会走的路径。
-
-### Goals 页面入口与 Labs 开关
-
-**Situation:** 验收 goal (目标) 相关功能需要进入 Goals 页面。
-
-**Doesn't work:** 直接打开 `/agent/goals` —— goals 路由嵌套在 `/agent/:aid/goals`
-下，`goals` 会被当成 agentId 解析成「助理不可用」; 页面还门控在 Labs 开关
-`enableTopicAcceptance` 后面，关闭时路由静默 replace 回 `/agent/:aid`。
-
-**Works:** 先查 seeded 用户的 agentId (`select id from agents where user_id=...`),
-用公开 store action 打开 Labs 开关 (持久化到用户偏好，全会话生效):
-
-```js
-window.__LOBE_STORES.user().updateLab({ enableTopicAcceptance: true });
-```
-
-再开 `/agent/<agentId>/goals`。创建 Goal 弹窗中「从空白开始」可跳过 AI 生成验收
-标准 (本地无 LLM key 时必用); 标准编辑、预算输入均为普通 input, 目标描述为
-contenteditable (用 `fill`,`type` 不支持 contenteditable)。
+- Put a new recipe inside the `Project-specific recipes` group it belongs to, above
+  `Detailed references` — never after the closing sections, or the taxonomy drifts.


### PR DESCRIPTION
Both project-layer living logs under `.agents/acceptance/` had drifted, in three ways at once: new entries kept getting appended *after* the files' closing meta sections, several entries were written in Chinese while the files are otherwise English, and two mistakes sat under a category they do not belong to.

#### `common-mistakes.md`

- `## Historical source` was a trailing section holding only a pointer to the field notes — exactly the thing later entries kept landing behind. Folded into the intro, so every entry now lives under one of the three categories.
- Moved two misfiled entries into **Product and interaction contracts**: the Project-identity contract (`L-P1` → `L-D9`) and the long-`confirmModal` footer overlay (`L-S11` → `L-D10`). Environment entries renumbered contiguously to close the gap.
- Translated `L-E18` (ActionBar action-key registration) to English.
- The intro now states the id scheme — `L-E*` evidence and publication, `L-D*` product and interaction contracts, `L-S*` environment safety — and where a new entry goes.

Result: 42 entries, `L-E1..L-E18` / `L-D1..L-D10` / `L-S0..L-S13`, sorted, no gaps. The ids are only referenced inside these files, so renumbering breaks nothing.

#### `probe-mock-patterns.md`

- The recipes section was one flat list of 60 entries. Grouped into eight task-oriented sections: Probing app state, Seeding fixtures, Driving the UI, Rendering messages and tool calls, Capturing and publishing evidence, Electron and the desktop shell, Auth and session state, Dev server / install / ports.
- Six recipes had been appended after `Detailed references` / `Adding a new learning`; moved back into the list, and `Adding a new learning` now says where a new recipe goes.
- Translated the four remaining Chinese recipes (Electron dev BackendProxy port + CDP cookie injection, skill-menu bugs that depend on real account data, SSRF blocking server-side reads of local S3, the Goals page's nested route and Labs toggle).

Chinese product UI strings quoted inside English entries (`页面暂时不可用`, `登录已过期`, `共运行 N 步`, `N 次调用`) are kept as-is — they are the identifiers used to locate elements, and translating them would make them unfindable.

#### Test

Documentation only, no runtime code. Verified mechanically that the reorganization dropped nothing: 42 mistakes and 60 recipes before and after, no `###` entry left without a parent section, and no Chinese headings remain.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

`bun run check` on both files: lint clean.

#### 🔗 Related Issue

None.