### PR TITLE
🐛 fix(memory): preserve non-Error failure details

### DIFF
--- a/packages/builtin-tool-memory/src/ExecutionRuntime/index.test.ts
+++ b/packages/builtin-tool-memory/src/ExecutionRuntime/index.test.ts
@@ -85,7 +85,9 @@ describe('MemoryExecutionRuntime', () => {
   it.each([
     { detail: 'network unavailable', error: new Error('network unavailable') },
     { detail: 'network unavailable', error: 'network unavailable' },
-    { detail: 'null', error: null },
+    { detail: 'service unavailable', error: { message: 'service unavailable' } },
+    { detail: 'Unknown error', error: Object.assign(new Error('placeholder'), { message: '' }) },
+    { detail: 'Unknown error', error: null },
   ])('preserves thrown error details for $error', async ({ detail, error }) => {
     const searchMemory = vi.fn().mockRejectedValue(error);
     const runtime = new MemoryExecutionRuntime({ service: createService({ searchMemory }) });

--- a/packages/builtin-tool-memory/src/ExecutionRuntime/index.test.ts
+++ b/packages/builtin-tool-memory/src/ExecutionRuntime/index.test.ts
@@ -81,4 +81,20 @@ describe('MemoryExecutionRuntime', () => {
     expect(result.content).toContain('addPreferenceMemory with error detail');
     expect(addPreferenceMemory).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { detail: 'network unavailable', error: new Error('network unavailable') },
+    { detail: 'network unavailable', error: 'network unavailable' },
+    { detail: 'null', error: null },
+  ])('preserves thrown error details for $error', async ({ detail, error }) => {
+    const searchMemory = vi.fn().mockRejectedValue(error);
+    const runtime = new MemoryExecutionRuntime({ service: createService({ searchMemory }) });
+
+    const result = await runtime.searchUserMemory({ queries: ['project'] });
+
+    expect(result).toEqual({
+      content: `searchUserMemory with error detail: ${detail}`,
+      success: false,
+    });
+  });
 });

--- a/packages/builtin-tool-memory/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-memory/src/ExecutionRuntime/index.ts
@@ -62,8 +62,15 @@ const READ_ONLY_RESULT: BuiltinServerRuntimeOutput = {
   success: false,
 };
 
-const getErrorMessage = (error: unknown) =>
-  error instanceof Error ? error.message : String(error);
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === 'string' && error) return error;
+  if (error && typeof error === 'object') {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === 'string' && message) return message;
+  }
+  return 'Unknown error';
+};
 
 export class MemoryExecutionRuntime {
   private service: MemoryRuntimeService;

--- a/packages/builtin-tool-memory/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-memory/src/ExecutionRuntime/index.ts
@@ -62,6 +62,9 @@ const READ_ONLY_RESULT: BuiltinServerRuntimeOutput = {
   success: false,
 };
 
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error);
+
 export class MemoryExecutionRuntime {
   private service: MemoryRuntimeService;
   private toolPermission: MemoryToolPermission;
@@ -89,7 +92,7 @@ export class MemoryExecutionRuntime {
       };
     } catch (e) {
       return {
-        content: `searchUserMemory with error detail: ${(e as Error).message}`,
+        content: `searchUserMemory with error detail: ${getErrorMessage(e)}`,
         success: false,
       };
     }
@@ -108,7 +111,7 @@ export class MemoryExecutionRuntime {
       };
     } catch (e) {
       return {
-        content: `queryTaxonomyOptions with error detail: ${(e as Error).message}`,
+        content: `queryTaxonomyOptions with error detail: ${getErrorMessage(e)}`,
         success: false,
       };
     }
@@ -133,7 +136,7 @@ export class MemoryExecutionRuntime {
       };
     } catch (e) {
       return {
-        content: `addContextMemory with error detail: ${(e as Error).message}`,
+        content: `addContextMemory with error detail: ${getErrorMessage(e)}`,
         success: false,
       };
     }
@@ -158,7 +161,7 @@ export class MemoryExecutionRuntime {
       };
     } catch (e) {
       return {
-        content: `addActivityMemory with error detail: ${(e as Error).message}`,
+        content: `addActivityMemory with error detail: ${getErrorMessage(e)}`,
         success: false,
       };
     }
@@ -183,7 +186,7 @@ export class MemoryExecutionRuntime {
       };
     } catch (e) {
       return {
-        content: `addExperienceMemory with error detail: ${(e as Error).message}`,
+        content: `addExperienceMemory with error detail: ${getErrorMessage(e)}`,
         success: false,
       };
     }
@@ -208,7 +211,7 @@ export class MemoryExecutionRuntime {
       };
     } catch (e) {
       return {
-        content: `addIdentityMemory with error detail: ${(e as Error).message}`,
+        content: `addIdentityMemory with error detail: ${getErrorMessage(e)}`,
         success: false,
       };
     }
@@ -233,7 +236,7 @@ export class MemoryExecutionRuntime {
       };
     } catch (e) {
       return {
-        content: `addPreferenceMemory with error detail: ${(e as Error).message}`,
+        content: `addPreferenceMemory with error detail: ${getErrorMessage(e)}`,
         success: false,
       };
     }
@@ -258,7 +261,7 @@ export class MemoryExecutionRuntime {
       };
     } catch (e) {
       return {
-        content: `updateIdentityMemory with error detail: ${(e as Error).message}`,
+        content: `updateIdentityMemory with error detail: ${getErrorMessage(e)}`,
         success: false,
       };
     }
@@ -283,7 +286,7 @@ export class MemoryExecutionRuntime {
       };
     } catch (e) {
       return {
-        content: `removeIdentityMemory with error detail: ${(e as Error).message}`,
+        content: `removeIdentityMemory with error detail: ${getErrorMessage(e)}`,
         success: false,
       };
     }


### PR DESCRIPTION
## Summary

- preserve useful error details when memory tool services reject with non-`Error` values
- apply the normalized extraction to every `MemoryExecutionRuntime` catch path
- add regression coverage for `Error`, string, and null rejections

Fixes #17399

## Validation

- `pnpm exec vitest run --config packages/builtin-tool-memory/vitest.config.mts packages/builtin-tool-memory`
- `pnpm exec eslint packages/builtin-tool-memory/src/ExecutionRuntime/index.ts packages/builtin-tool-memory/src/ExecutionRuntime/index.test.ts`
- `pnpm exec prettier --check packages/builtin-tool-memory/src/ExecutionRuntime/index.ts packages/builtin-tool-memory/src/ExecutionRuntime/index.test.ts`
