### PR TITLE
📝 docs: clarify S3 setup for self-hosted desktop uploads

### DIFF
--- a/docs/self-hosting/advanced/desktop.mdx
+++ b/docs/self-hosting/advanced/desktop.mdx
@@ -108,11 +108,23 @@ Check if the `APP_URL` environment variable matches the URL you are accessing.
   - Apple Silicon: `LobeHub-Beta-1.83.6-arm64.dmg` or `LobeHub-Beta-1.83.6-arm64-mac.zip`
   - Intel: `LobeHub-Beta-1.83.6-x64.dmg` or `LobeHub-Beta-1.83.6-mac.zip`
 
-### Image Loading Issues
+### Image Loading or Upload Failures
 
-**Issue:** When using a Docker-deployed server, the desktop client cannot load avatars or other image resources after connecting.
+**Issue:** When using a Docker-deployed server, the desktop client cannot load or upload images after connecting.
 
 **Solution:**
 
-- If you are using Minio for storage, ensure that cross-origin requests are allowed in the Minio configuration.
-- Add appropriate CORS settings in your Minio service.
+- `S3_ENDPOINT` must be an HTTPS address that is accessible from both browsers and the desktop client. Do not use container-only addresses such as `http://minio:9000` or `http://rustfs:9000`.
+- Configure CORS for S3, MinIO, or RustFS, allowing both the self-hosted site origin and the desktop client origin, `http://localhost:3015`.
+
+```json
+[
+  {
+    "AllowedOrigins": ["https://lobe.example.com", "http://localhost:3015"],
+    "AllowedMethods": ["GET", "PUT", "HEAD", "POST", "DELETE"],
+    "AllowedHeaders": ["*"]
+  }
+]
+```
+
+Replace `https://lobe.example.com` with the URL used to access LobeHub. See [Configure S3 Storage](/docs/self-hosting/advanced/s3) for more information.

--- a/docs/self-hosting/advanced/desktop.zh-CN.mdx
+++ b/docs/self-hosting/advanced/desktop.zh-CN.mdx
@@ -106,11 +106,23 @@ proxy_busy_buffers_size 32k;
   - Apple Silicon: `LobeHub-Beta-1.83.6-arm64.dmg` 或 `LobeHub-Beta-1.83.6-arm64-mac.zip`
   - Intel: `LobeHub-Beta-1.83.6-x64.dmg` 或 `LobeHub-Beta-1.83.6-mac.zip`
 
-### 图片加载问题
+### 图片加载或上传失败
 
-**问题：** 使用 Docker 部署的服务端，桌面端连接后无法加载头像或其他图片资源。
+**问题：** 使用 Docker 部署的服务端，桌面端连接后无法加载或上传图片。
 
 **解决方案：**
 
-- 如果您使用 Minio 作为存储，需要在 Minio 配置中允许跨域请求
-- 在您的 Minio 服务中添加适当的 CORS 配置
+- `S3_ENDPOINT` 必须是浏览器和桌面端都能访问的 HTTPS 地址。请勿使用 `http://minio:9000`、`http://rustfs:9000` 等仅能在容器网络内访问的地址。
+- 为 S3、MinIO 或 RustFS 配置 CORS，同时允许自部署站点域名和桌面端来源 `http://localhost:3015`。
+
+```json
+[
+  {
+    "AllowedOrigins": ["https://lobe.example.com", "http://localhost:3015"],
+    "AllowedMethods": ["GET", "PUT", "HEAD", "POST", "DELETE"],
+    "AllowedHeaders": ["*"]
+  }
+]
+```
+
+请将 `https://lobe.example.com` 替换为实际访问 LobeHub 的域名。更多信息请参阅[配置 S3 存储服务](/zh/docs/self-hosting/advanced/s3)。


### PR DESCRIPTION
Clarifies the self-hosted desktop troubleshooting guide after the configuration problem reported in #18364.

## Changes

- Updated `docs/self-hosting/advanced/desktop.mdx` with the public `S3_ENDPOINT` requirement.
- Updated `docs/self-hosting/advanced/desktop.zh-CN.mdx` with the matching Chinese guidance.
- Added a concrete CORS example for the self-hosted site origin and the desktop origin, `http://localhost:3015`.
- Clarified that container-only addresses such as `http://minio:9000` and `http://rustfs:9000` cannot be used by browser-side uploads.

| Before | After |
| ------ | ----- |
| The desktop guide only asked users to add an appropriate CORS configuration. | The guide explains the public endpoint requirement and provides a complete CORS example for web and desktop clients. |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Validation:

```bash
bun run check docs/self-hosting/advanced/desktop.mdx docs/self-hosting/advanced/desktop.zh-CN.mdx
git diff --check
```

#### 🔗 Related Issue

Related to #18364