### PR TITLE
💄 style(self-learning): flow a lit border on the new-domain input while generating

### DIFF
--- a/src/features/SelfLearning/CreateDomainPage.tsx
+++ b/src/features/SelfLearning/CreateDomainPage.tsx
@@ -3,7 +3,7 @@
 import { ActionIcon, Flexbox, Icon, Input, Text, TextArea } from '@lobehub/ui';
 import { Button, Popover, toast } from '@lobehub/ui/base-ui';
 import { Divider } from 'antd';
-import { createStaticStyles, cssVar } from 'antd-style';
+import { createGlobalStyle, createStaticStyles, cssVar } from 'antd-style';
 import {
   AnchorIcon,
   ArrowLeftIcon,
@@ -117,6 +117,67 @@ const styles = createStaticStyles(({ css }) => ({
     overflow: hidden;
     height: 22px;
   `,
+  // Wraps the brief textarea so the loading state can draw the same flowing
+  // border the goal creator uses — the shell owns the ring, not the input.
+  inputShell: css`
+    position: relative;
+    border-radius: 8px;
+  `,
+  // Only while generating: a conic-gradient ring rotated by the animated
+  // --domain-border-angle, masked to a 2px edge so the textarea reads as lit.
+  // `overflow: hidden` lives here, not on the resting shell, so the outlined
+  // textarea's focus glow isn't clipped when the user is typing.
+  inputShellLoading: css`
+    overflow: hidden;
+
+    &::after {
+      pointer-events: none;
+      content: '';
+
+      position: absolute;
+      z-index: 1;
+      inset: 0;
+
+      padding: 2px;
+      border-radius: inherit;
+
+      background: conic-gradient(
+        from var(--domain-border-angle),
+        ${cssVar.colorBorderSecondary} 0deg 210deg,
+        #ff3d8d 238deg,
+        #8b5cf6 258deg,
+        #00c8ff 278deg,
+        #22e6a8 298deg,
+        #ffd43b 318deg,
+        #ff6b35 338deg,
+        ${cssVar.colorBorderSecondary} 360deg
+      );
+
+      mask:
+        linear-gradient(#fff 0 0) content-box,
+        linear-gradient(#fff 0 0);
+
+      animation: domain-input-flow 1.8s linear infinite;
+
+      mask-composite: exclude;
+    }
+
+    @keyframes domain-input-flow {
+      from {
+        --domain-border-angle: 0deg;
+      }
+
+      to {
+        --domain-border-angle: 360deg;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      &::after {
+        animation: none;
+      }
+    }
+  `,
   itemRow: css`
     display: grid;
     grid-template-columns: 32px minmax(0, 1fr) 28px;
@@ -173,6 +234,16 @@ const styles = createStaticStyles(({ css }) => ({
     color: ${cssVar.colorText};
   `,
 }));
+
+// A registered custom property is what lets the conic gradient's angle animate
+// at all — a plain `--domain-border-angle` is an un-typed string CSS can't tween.
+const DomainBorderFlowStyle = createGlobalStyle`
+  @property --domain-border-angle {
+    inherits: false;
+    initial-value: 0deg;
+    syntax: '<angle>';
+  }
+`;
 
 export const formatRemainingTime = (seconds: number) => {
   const minutes = Math.floor(seconds / 60);
@@ -390,6 +461,7 @@ const CreateDomainPage = memo(() => {
 
   return (
     <Flexbox height={'100%'} width={'100%'}>
+      <DomainBorderFlowStyle />
       <NavHeader
         styles={{ left: { paddingInlineStart: 24 } }}
         left={
@@ -435,15 +507,19 @@ const CreateDomainPage = memo(() => {
                     <Text fontSize={12} type={'secondary'}>
                       {t('create.briefHelp')}
                     </Text>
-                    <TextArea
-                      autoFocus
-                      autoSize={{ maxRows: 10, minRows: 5 }}
-                      disabled={step === 'preparing'}
-                      placeholder={t('create.briefPlaceholder')}
-                      value={brief}
-                      variant={'outlined'}
-                      onChange={(e) => setBrief(e.target.value)}
-                    />
+                    <div
+                      className={`${styles.inputShell} ${step === 'preparing' ? styles.inputShellLoading : ''}`}
+                    >
+                      <TextArea
+                        autoFocus
+                        autoSize={{ maxRows: 10, minRows: 5 }}
+                        disabled={step === 'preparing'}
+                        placeholder={t('create.briefPlaceholder')}
+                        value={brief}
+                        variant={step === 'preparing' ? 'borderless' : 'outlined'}
+                        onChange={(e) => setBrief(e.target.value)}
+                      />
+                    </div>
                     {step === 'preparing' ? (
                       <Flexbox
                         horizontal


### PR DESCRIPTION
新建领域（自进化）创建页在生成时，输入框下方有滚动的「生成中…」提示和倒计时，但输入框本身在这 ~90s 里毫无反应——等待没有回落到用户刚填的那个框上。「目标」创建页早已用一圈旋转的锥形渐变边框解决了同样的问题；这里复用那套处理，让两个创建流程读起来是同一套系统。

生成态（`step === 'preparing'`）时，输入框被包进一层 shell，用 mask 描出 2px 的锥形渐变环，由注册过的 `--domain-border-angle` 驱动旋转；同时输入框切成 `borderless`，只留这圈流光。`overflow: hidden` 只挂在生成态类上，常态 outlined 输入框的聚焦光晕不会被裁掉。遵守 `prefers-reduced-motion`。

| 常态 | 生成态（流光） |
| ------ | ----- |
| 原有 outlined 描边，四角完整 | 锥形渐变环绕边框旋转（动效见下方验收页） |

已用 agent-testing 在工作树 SPA 实测并发布验收（含真实动效 GIF：渐变绕边旋转、提示文案滚动、倒计时递减）：

https://app.lobehub.com/acceptance/65b33315-1f8d-4f1e-a4b4-7dbad26d08c2

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

纯视觉/动效改动（CSS + 一个 loading 类切换），`bun run check` lint 干净、`--type` types clean。动效已由验收页的 GIF 佐证，无适合的回归断言。

#### 🔗 Related Issue

无