### PR TITLE
⚡️ perf(database): resolve hetero tool-call lookup id-first to avoid full plugin scan

### DIFF
--- a/packages/database/src/models/__tests__/messages/message.pluginsForOperation.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.pluginsForOperation.test.ts
@@ -86,16 +86,15 @@ const captureEmittedSql = async (
   return captured;
 };
 
-/** Total rows the executor had to *examine* on the two base tables (output +
- *  filtered-out, times loops) — the signal a full-table scan leaks. */
-const rowsExaminedOnBaseTables = (node: any): number => {
+/** Rows the executor had to *examine* on `relation` (output + filtered-out,
+ *  times loops) — the signal a full-table scan of it leaks. */
+const rowsExaminedOn = (node: any, relation: string): number => {
   let total = 0;
-  const rel = node?.['Relation Name'];
-  if (rel === 'messages' || rel === 'message_plugins') {
+  if (node?.['Relation Name'] === relation) {
     const loops = node['Actual Loops'] ?? 1;
     total += ((node['Actual Rows'] ?? 0) + (node['Rows Removed by Filter'] ?? 0)) * loops;
   }
-  for (const child of node?.Plans ?? []) total += rowsExaminedOnBaseTables(child);
+  for (const child of node?.Plans ?? []) total += rowsExaminedOn(child, relation);
   return total;
 };
 
@@ -229,21 +228,26 @@ describe('MessageModel.listMessagePluginsForOperation', () => {
   });
 
   // Query-plan regression — the accurate guard. It reproduces the actual
-  // degradation (a full scan of the user's whole plugin/message history) on a
-  // seeded skew and asserts the topic-scoped retrieval stays index-served.
+  // degradation (a full scan of the user's whole plugin history) on a seeded skew
+  // and asserts NO branch ever walks more than a handful of the user's plugin
+  // rows. This catches every historical form of the bug: the original
+  // `OR`-ed WHERE, and the later single-JOIN heterogeneous branch — both had the
+  // planner scan/nested-loop all of `message_plugins` (100s+ per call). The fix
+  // keeps `message_plugins` access PK-bounded in both branches (topic window joins
+  // by PK; heterogeneous match resolves message ids first, then fetches by PK).
   //
   // Gated to the server DB (real Postgres): PGlite's planner picks a *different*,
-  // already-fast plan for the OR predicate, so the regression is invisible there
-  // — a plan assertion on PGlite would be a false green. CI runs this suite
-  // against real Postgres via `vitest.config.server.mts` (TEST_SERVER_DB=1).
+  // already-fast plan, so the regression is invisible there — a plan assertion on
+  // PGlite would be a false green. CI runs this suite against real Postgres via
+  // `vitest.config.server.mts` (TEST_SERVER_DB=1).
   //
-  // Why the plan and not the SQL shape: the row results are identical for OR vs.
-  // split, and a "no OR() in the SQL" assertion breaks on innocent rewrites
-  // (UNION/CTE) that are equally fast. Rows-examined is what actually matters.
+  // Why the plan and not the SQL shape: the row results are identical across all
+  // three forms, and a "no OR()/no JOIN" text assertion breaks on innocent
+  // rewrites. Plugin-rows-examined is what actually matters.
   describe.skipIf(!isServerDB)('query-plan regression (real Postgres only)', () => {
     const NOISE = 2000;
 
-    it('keeps the topic-scoped tool-call retrieval index-served instead of scanning the whole user history', async () => {
+    it('never scans the whole plugin history in any branch', async () => {
       // Skew: NOISE plugin rows in a *different* topic (topic2) the query must
       // never touch, plus a few in-window rows and one heterogeneous row far
       // outside the window in the target topic (topic1).
@@ -295,32 +299,33 @@ describe('MessageModel.listMessagePluginsForOperation', () => {
         expect(rows.map((r) => r.id).sort()).toEqual(['hetero', 'in-window', 'in-window-2']);
       });
 
-      // Guard every plugin retrieval that constrains by `topic_id`. The
-      // heterogeneous-only branch carries no `topic_id`, so it is naturally
-      // exempt — it is knowingly an unindexed scan until the partial jsonb index
-      // lands (separate PR). Crucially, the OR regression *does* carry `topic_id`
-      // (alongside the metadata match), so it is caught here by its plan, not by
-      // any assumption about how the SQL is written.
-      const topicScopedPluginScans = statements.filter(
-        (s) =>
-          /"message_plugins"/i.test(s.sql) &&
-          /"messages"/i.test(s.sql) &&
-          /topic_id/i.test(s.sql),
+      // Any statement that JOINs message_plugins to messages must stay bounded —
+      // it must not walk ~all of the user's history on EITHER table. That is the
+      // exact regression: the original OR-ed WHERE and the later single-JOIN
+      // heterogeneous branch both resolved the jsonb match *inside* the plugin
+      // JOIN, so the planner scanned every plugin (or every message) the user owns
+      // — whichever side it chose to drive from. The fix resolves that match in a
+      // messages-ONLY lookup, which is excluded here (it never references
+      // message_plugins) and is the partial index's job in a follow-up; the only
+      // JOINs that remain are keyed by primary key.
+      const joinStatements = statements.filter(
+        (s) => /"message_plugins"/i.test(s.sql) && /"messages"/i.test(s.sql),
       );
       expect(
-        topicScopedPluginScans.length,
-        'no topic-scoped plugin retrieval was emitted — did the method stop querying by topic?',
+        joinStatements.length,
+        'no message_plugins⋈messages statement was emitted — did the method stop returning plugin rows?',
       ).toBeGreaterThan(0);
 
-      for (const statement of topicScopedPluginScans) {
+      for (const statement of joinStatements) {
         const explained = await pool.query({
           text: `EXPLAIN (ANALYZE, FORMAT JSON) ${statement.sql}`,
           values: statement.params,
         });
-        const examined = rowsExaminedOnBaseTables(explained.rows[0]['QUERY PLAN'][0].Plan);
+        const plan = explained.rows[0]['QUERY PLAN'][0].Plan;
+        const examined = rowsExaminedOn(plan, 'messages') + rowsExaminedOn(plan, 'message_plugins');
         expect(
           examined,
-          `the topic-scoped plugin retrieval examined ${examined} rows — it scanned ~all of the user's ${NOISE}-row history instead of using the topic_id index. An unindexable predicate (e.g. an OR with the jsonb metadata match) was folded back into this query.`,
+          `a message_plugins⋈messages statement examined ${examined} rows — it walked ~all of the user's ${NOISE}-row history instead of a bounded/PK access. A jsonb metadata match was resolved inside the plugin JOIN.`,
         ).toBeLessThan(NOISE / 2);
       }
     });

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -2817,18 +2817,23 @@ export class MessageModel {
       lte(messages.createdAt, completedAt),
     );
 
-    const heterogeneousMatch = sql`${messages.metadata}->>'heterogeneousToolStateOperationId' = ${params.operationId}`;
-
-    // Query the two conditions SEPARATELY instead of `OR`-ing them in one WHERE.
-    // A combined `... AND (withinWindow OR heterogeneousMatch)` is unindexable: the
-    // `metadata->>'heterogeneousToolStateOperationId'` branch has no index, so the
-    // planner abandons the `topic_id` index for the whole predicate and scans every
-    // plugin row the user owns (100k+ for heavy users), probing `messages` once per
-    // row — 25s+ per call in the worst case. Splitting lets each branch use its own
-    // index (topic-window range scan vs. the exact jsonb lookup). The branches can
-    // overlap (a heterogeneous row that also falls inside the window), so de-dup by
-    // message id before restoring the `createdAt asc, id asc` order the OR query
-    // produced in SQL.
+    // The two branches are resolved SEPARATELY — never OR-ed into one WHERE (an
+    // `... AND (withinWindow OR heteroMatch)` is unindexable and seq-scans every
+    // plugin row the user owns). They are also SHAPED differently on purpose:
+    //
+    // - Time window: one index-friendly range scan joined to its plugin rows.
+    // - Heterogeneous match: resolved id-FIRST, not as a plugin JOIN. The
+    //   `metadata->>'heterogeneousToolStateOperationId'` predicate carries a 0.5%
+    //   default selectivity estimate, so joining it to `message_plugins` makes the
+    //   planner scan / nested-loop the user's ENTIRE plugin history (100k+ rows,
+    //   100s+ per call for heavy users — it returns ~0 rows but pays the full scan
+    //   every time, since most ops never stamp the key). Looking up the few
+    //   matching message ids in a JOIN-free query first, then fetching those rows
+    //   by primary key, leaves the planner no join to mis-order: the lookup is
+    //   single-table (index-served once the metadata expression is indexed; a
+    //   bounded scan otherwise) and the fetch is a pure PK access. Kept
+    //   topic-agnostic to preserve the prior behaviour exactly — a late CLI row
+    //   can land outside the op's window (and, rarely, its topic).
     const projection = {
       apiName: messagePlugins.apiName,
       arguments: messagePlugins.arguments,
@@ -2856,9 +2861,24 @@ export class MessageModel {
         .innerJoin(messages, eq(messagePlugins.id, messages.id))
         .where(and(this.ownership(), this.pluginsOwnership(), condition));
 
+    const fetchHeterogeneous = async () => {
+      const idRows = await this.db
+        .select({ id: messages.id })
+        .from(messages)
+        .where(
+          and(
+            this.ownership(),
+            sql`${messages.metadata}->>'heterogeneousToolStateOperationId' = ${params.operationId}`,
+          ),
+        );
+      const ids = idRows.map((row) => row.id);
+      if (ids.length === 0) return [];
+      return scan(inArray(messagePlugins.id, ids));
+    };
+
     const [windowRows, heterogeneousRows] = await Promise.all([
       scan(withinWindow),
-      scan(heterogeneousMatch),
+      fetchHeterogeneous(),
     ]);
 
     const byId = new Map<string, (typeof windowRows)[number]>();


### PR DESCRIPTION
#### 💡 Background

Follow-up to #18457 (which split the OR). That split left the **heterogeneous branch** of `listMessagePluginsForOperation` as a single JOIN:

```sql
SELECT mp.*, m.content, m.created_at
FROM message_plugins mp JOIN messages m ON mp.id = m.id
WHERE <ownership> AND m.metadata->>'heterogeneousToolStateOperationId' = $
```

`metadata->>key = $` has a **0.5% default selectivity estimate**, so the planner drives from `message_plugins` (user_id) and scans / nested-loops the user's **entire** plugin history. `EXPLAIN ANALYZE` on a heavy user (335k plugin rows): **105,000 ms** — and it runs once per operation-tree node during work registration, even though in-process ops never stamp the key (returns ~0 rows, pays the full scan every time). In a live `pg_stat_statements` window this branch was ~20% of DB time with a 32s tail.

**An index alone does not fix it** — verified at prod scale (330k): with the partial expression index present, the planner *still* seq-scans `message_plugins`, because the JOIN + the bad estimate keep it driving from the plugin side.

#### 🔨 Change

Resolve the match **id-first**, decoupling the jsonb lookup from the plugin fetch:

1. Look up the few matching message ids in a **JOIN-free** query (`SELECT id FROM messages WHERE <ownership> AND metadata->>key = $`) — single-table, so no join for the planner to mis-order.
2. Fetch those rows by **primary key** (`message_plugins.id IN (ids)`).

Measured (330k prod-scale): **105s → ~10ms**. Kept **topic-agnostic** to preserve behaviour exactly (a late CLI row can land outside the op's window — and, rarely, its topic; 1 op in prod spans topics, so a topic constraint would drop rows).

> Why not a single `MATERIALIZED` CTE: it works, but it fixes the plan by fencing the planner via a keyword — a load-bearing hint that silently regresses if removed. Two explicit queries are correct *by structure*, not by coercion.

> Follow-up (cloud repo migration): a partial expression index on `messages ((metadata->>'heterogeneousToolStateOperationId')) WHERE ... IS NOT NULL` takes the id-lookup itself from a bounded `messages` scan to sub-ms. Not required to remove the catastrophic plugin scan — this PR does that on its own.

#### Test

Extended the existing plan regression (`message.pluginsForOperation.test.ts`, server-DB only) to guard **both** branches: it seeds a skew and asserts that **no `message_plugins ⋈ messages` statement walks ~all of the user's history on either table** (the messages-only id-lookup is naturally excluded and is the index's job). Verified against a local paradedb: **fails on the prior single-JOIN form** (examined 4006 of 2000 rows) and **passes on the id-first fetch**; skips cleanly in the default PGlite suite.

- [x] Tested locally — `tsgo` + eslint clean; 7/7 pass on the fix against real Postgres, regression fails on the pre-fix JOIN; behaviour verified via `EXPLAIN ANALYZE` (105s → ~10ms)
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Follow-up to #18457. Same DB cost / hot-query investigation.