### PR TITLE
🐛 fix(avatar): show name initials instead of "UN" when an avatar image is missing

### DIFF
--- a/src/components/Avatar/fallback.test.ts
+++ b/src/components/Avatar/fallback.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+
+import { getAvatarBackground, getAvatarInitials, remoteAvatarSrc, resolveAvatar } from './fallback';
+
+describe('getAvatarInitials', () => {
+  it('returns nothing for a missing name', () => {
+    expect(getAvatarInitials()).toBe('');
+    expect(getAvatarInitials(null)).toBe('');
+    expect(getAvatarInitials('   ')).toBe('');
+  });
+
+  it('keeps a single glyph for ideographic names', () => {
+    expect(getAvatarInitials('贺素青')).toBe('贺');
+    expect(getAvatarInitials('验证-存活 worktree 对话')).toBe('验');
+    expect(getAvatarInitials('ミク')).toBe('ミ');
+    expect(getAvatarInitials('한국어')).toBe('한');
+  });
+
+  it('takes the initials of the first two words for latin names', () => {
+    expect(getAvatarInitials('Claude Code')).toBe('CC');
+    expect(getAvatarInitials('agent-default')).toBe('AD');
+    expect(getAvatarInitials('data_science.helper')).toBe('DS');
+  });
+
+  it('takes the first two letters of a single word', () => {
+    expect(getAvatarInitials('lobehub')).toBe('LO');
+    expect(getAvatarInitials('x')).toBe('X');
+  });
+
+  it('keeps a leading emoji so the avatar can render it as an emoji', () => {
+    expect(getAvatarInitials('🤖 helper')).toBe('🤖');
+  });
+});
+
+describe('getAvatarBackground', () => {
+  it('returns nothing without a seed', () => {
+    expect(getAvatarBackground()).toBeUndefined();
+    expect(getAvatarBackground('  ')).toBeUndefined();
+  });
+
+  it('is stable for the same seed', () => {
+    expect(getAvatarBackground('贺素青')).toBe(getAvatarBackground('贺素青'));
+    expect(getAvatarBackground('Claude Code')).toBe(getAvatarBackground('Claude Code'));
+  });
+
+  it('spreads different seeds across the palette', () => {
+    const seeds = ['贺素青', 'Claude Code', 'lobehub', 'agent-default', 'Verify', 'Inbox'];
+    const colors = new Set(seeds.map((seed) => getAvatarBackground(seed)));
+
+    expect(colors.size).toBeGreaterThan(1);
+  });
+});
+
+describe('resolveAvatar', () => {
+  it('keeps a working avatar and its background untouched', () => {
+    expect(
+      resolveAvatar({ avatar: 'https://example.com/a.png', background: '#123456', name: '贺素青' }),
+    ).toEqual({ avatar: 'https://example.com/a.png', background: '#123456' });
+  });
+
+  it('falls back to the name initials when the image is broken', () => {
+    const { avatar, background } = resolveAvatar({
+      avatar: 'https://example.com/gone.png',
+      isBroken: true,
+      name: '贺素青',
+    });
+
+    expect(avatar).toBe('贺');
+    expect(background).toBe(getAvatarBackground('贺素青'));
+  });
+
+  it('falls back when there is no avatar at all', () => {
+    expect(resolveAvatar({ title: 'Claude Code' }).avatar).toBe('CC');
+  });
+
+  it('renders an empty tile rather than "UN" or a URL fragment when unnamed', () => {
+    expect(resolveAvatar({}).avatar).toBe('');
+
+    const broken = resolveAvatar({ avatar: '/avatars/agent-default.png', isBroken: true });
+    expect(broken.avatar).toBe('');
+    // The URL still seeds a color, so unnamed avatars aren't all the same grey.
+    expect(broken.background).toBe(getAvatarBackground('/avatars/agent-default.png'));
+  });
+
+  it('keeps an explicitly chosen background even when the image is broken', () => {
+    expect(
+      resolveAvatar({ avatar: '/gone.png', background: '#abcdef', isBroken: true, name: 'Verify' })
+        .background,
+    ).toBe('#abcdef');
+  });
+
+  it('prefers `name` over `title` as the seed', () => {
+    expect(resolveAvatar({ name: 'Verify Runner', title: 'open the verify runner' }).avatar).toBe(
+      'VR',
+    );
+  });
+});
+
+describe('remoteAvatarSrc', () => {
+  it('only matches URLs, not emoji or nodes', () => {
+    expect(remoteAvatarSrc('https://example.com/a.png')).toBe('https://example.com/a.png');
+    expect(remoteAvatarSrc('/avatars/agent-default.png')).toBe('/avatars/agent-default.png');
+    expect(remoteAvatarSrc('🤖')).toBeUndefined();
+    expect(remoteAvatarSrc(undefined)).toBeUndefined();
+  });
+});
+
+describe('resolveAvatar background sentinels', () => {
+  it('treats a transparent background as unset when falling back', () => {
+    const { background } = resolveAvatar({
+      avatar: '/gone.png',
+      background: 'transparent',
+      isBroken: true,
+      name: '林知微',
+    });
+
+    expect(background).toBe(getAvatarBackground('林知微'));
+  });
+
+  it('also ignores rgba(0, 0, 0, 0)', () => {
+    expect(resolveAvatar({ background: 'rgba(0, 0, 0, 0)', name: 'Verify' }).background).toBe(
+      getAvatarBackground('Verify'),
+    );
+  });
+
+  it('keeps a transparent background behind a working image', () => {
+    expect(
+      resolveAvatar({ avatar: 'https://example.com/a.png', background: 'transparent' }).background,
+    ).toBe('transparent');
+  });
+});

--- a/src/components/Avatar/fallback.ts
+++ b/src/components/Avatar/fallback.ts
@@ -1,0 +1,103 @@
+import { primaryColorsSwatches } from '@lobehub/ui';
+
+/**
+ * Characters that already read as a whole word on their own — one of them is
+ * enough for an avatar, two would be unreadable at 16px.
+ */
+const IDEOGRAPH = /[\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uAC00-\uD7AF\uF900-\uFAFF]/;
+const WORD_SEPARATOR = /[\s_\-–—./\\|:,()[\]{}]+/;
+const LATIN_LETTER = /[a-z]/i;
+
+/**
+ * Pick the glyphs that stand in for a missing image: the leading ideograph for
+ * CJK names, the initials of the first two words for latin ones, and the
+ * leading emoji when the name starts with one (the Avatar renders it as a
+ * fluent emoji instead of text).
+ */
+export const getAvatarInitials = (name?: string | null): string => {
+  const text = name?.trim();
+  if (!text) return '';
+
+  const [first] = [...text];
+  if (IDEOGRAPH.test(first)) return first;
+  if (!LATIN_LETTER.test(first) && !/\d/.test(first)) return first;
+
+  const words = text.split(WORD_SEPARATOR).filter(Boolean);
+  if (words.length > 1) return (words[0][0] + words[1][0]).toUpperCase();
+
+  return words[0].slice(0, 2).toUpperCase();
+};
+
+/**
+ * Deterministic FNV-1a so the same name always lands on the same swatch — an
+ * agent keeps its color across sessions, devices and list positions.
+ */
+const hash = (seed: string): number => {
+  let value = 0x81_1c_9d_c5;
+  for (let i = 0; i < seed.length; i++) {
+    value ^= seed.codePointAt(i)!;
+    value = Math.imul(value, 0x01_00_01_93);
+  }
+  return Math.abs(value);
+};
+
+export const getAvatarBackground = (seed?: string | null): string | undefined => {
+  const text = seed?.trim();
+  if (!text) return undefined;
+
+  return primaryColorsSwatches[hash(text) % primaryColorsSwatches.length];
+};
+
+/**
+ * Selectors hand a literal `'transparent'` (or `rgba(0,0,0,0)`) down as "no
+ * color chosen". Behind a real image that is correct; behind fallback initials
+ * it renders unreadable text on the page background, so it counts as absent.
+ */
+const BLANK_BACKGROUNDS = new Set(['transparent', 'rgba(0,0,0,0)', 'none']);
+
+const usableBackground = (background?: string): string | undefined => {
+  const value = background?.trim();
+  if (!value) return undefined;
+
+  return BLANK_BACKGROUNDS.has(value.replaceAll(' ', '').toLowerCase()) ? undefined : value;
+};
+
+const REMOTE_AVATAR = /^(?:https?:|\/|data:|blob:|file:|app:)/;
+
+/** The avatar URL we have to probe, if the avatar is one at all. */
+export const remoteAvatarSrc = (avatar: unknown): string | undefined =>
+  typeof avatar === 'string' && REMOTE_AVATAR.test(avatar) ? avatar : undefined;
+
+interface ResolveAvatarParams<T> {
+  avatar?: T;
+  background?: string;
+  /** The avatar is a URL and the browser failed to load it. */
+  isBroken?: boolean;
+  name?: string;
+  title?: string;
+}
+
+/**
+ * Decide what the Avatar actually renders. A missing or broken image falls back
+ * to the name's initials over a hashed background, so the avatar still carries
+ * the identity instead of collapsing into an anonymous grey box.
+ */
+export const resolveAvatar = <T>({
+  avatar,
+  background,
+  isBroken,
+  name,
+  title,
+}: ResolveAvatarParams<T>): { avatar: T | string; background?: string } => {
+  if (avatar && !isBroken) return { avatar, background };
+
+  const label = name || title;
+
+  return {
+    // Only a real name makes initials; a URL would render as its own first
+    // character ("/"), which says even less than an empty tile.
+    avatar: getAvatarInitials(label),
+    background:
+      usableBackground(background) || getAvatarBackground(label || remoteAvatarSrc(avatar)),
+  };
+};

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { Avatar as LobeAvatar, type AvatarProps as LobeAvatarProps } from '@lobehub/ui';
-import { memo, useState } from 'react';
+import { memo } from 'react';
 
 import { remoteAvatarSrc, resolveAvatar } from './fallback';
+import { useBrokenSrc } from './useBrokenSrc';
 
 export interface AvatarProps extends LobeAvatarProps {
   /**
@@ -29,9 +30,7 @@ export interface AvatarProps extends LobeAvatarProps {
 const Avatar = memo<AvatarProps>(
   ({ alt, avatar, background, name, size = 48, title, unoptimized, ...rest }) => {
     const src = remoteAvatarSrc(avatar);
-    // Keyed by url, so switching to a different avatar retries on its own.
-    const [brokenSrc, setBrokenSrc] = useState<string>();
-    const isBroken = !!src && brokenSrc === src;
+    const [isBroken, markBroken] = useBrokenSrc(src);
 
     const imgAlt = alt || name || title || 'avatar';
     const resolved = resolveAvatar({
@@ -44,7 +43,7 @@ const Avatar = memo<AvatarProps>(
             loading={'lazy'}
             src={src}
             width={size}
-            onError={() => setBrokenSrc(src)}
+            onError={markBroken}
           />
         ) : (
           avatar

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { Avatar as LobeAvatar, type AvatarProps as LobeAvatarProps } from '@lobehub/ui';
+import { memo, useState } from 'react';
+
+import { remoteAvatarSrc, resolveAvatar } from './fallback';
+
+export interface AvatarProps extends LobeAvatarProps {
+  /**
+   * Seed for the fallback initials and background color. Defaults to `title`;
+   * pass it when the visible name differs from the tooltip title.
+   */
+  name?: string;
+}
+
+/**
+ * Avatar with an identity-preserving fallback.
+ *
+ * `@lobehub/ui`'s Avatar falls back to `String(title).slice(0, 2)`, which
+ * renders a literal "UN" — the first letters of `"undefined"` — whenever the
+ * image 404s and no title was passed. This wrapper derives the initials and a
+ * stable hashed background from the name instead, so a missing image still
+ * reads as *this* agent rather than as a broken one.
+ *
+ * The image element is rendered here rather than left to the library so this
+ * component owns the `error` event. Probing the URL separately would let the
+ * two disagree, and on disagreement the library's own "UN" fallback wins.
+ */
+const Avatar = memo<AvatarProps>(
+  ({ alt, avatar, background, name, size = 48, title, unoptimized, ...rest }) => {
+    const src = remoteAvatarSrc(avatar);
+    // Keyed by url, so switching to a different avatar retries on its own.
+    const [brokenSrc, setBrokenSrc] = useState<string>();
+    const isBroken = !!src && brokenSrc === src;
+
+    const imgAlt = alt || name || title || 'avatar';
+    const resolved = resolveAvatar({
+      avatar:
+        src && !isBroken ? (
+          <img
+            alt={imgAlt}
+            draggable={false}
+            height={size}
+            loading={'lazy'}
+            src={src}
+            width={size}
+            onError={() => setBrokenSrc(src)}
+          />
+        ) : (
+          avatar
+        ),
+      background,
+      isBroken,
+      name,
+      title,
+    });
+
+    return (
+      <LobeAvatar
+        {...rest}
+        alt={imgAlt}
+        avatar={resolved.avatar}
+        background={resolved.background}
+        size={size}
+        title={title}
+        unoptimized={unoptimized}
+      />
+    );
+  },
+);
+
+Avatar.displayName = 'Avatar';
+
+export default Avatar;

--- a/src/components/Avatar/useBrokenSrc.test.ts
+++ b/src/components/Avatar/useBrokenSrc.test.ts
@@ -1,0 +1,53 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useBrokenSrc } from './useBrokenSrc';
+
+describe('useBrokenSrc', () => {
+  it('starts unbroken', () => {
+    const { result } = renderHook(() => useBrokenSrc('https://example.com/a.png'));
+
+    expect(result.current[0]).toBe(false);
+  });
+
+  it('remembers a failure for the same url', () => {
+    const { rerender, result } = renderHook(({ src }) => useBrokenSrc(src), {
+      initialProps: { src: 'https://example.com/a.png' },
+    });
+
+    act(() => result.current[1]());
+    expect(result.current[0]).toBe(true);
+
+    rerender({ src: 'https://example.com/a.png' });
+    expect(result.current[0]).toBe(true);
+  });
+
+  it('retries a new url', () => {
+    const { rerender, result } = renderHook(({ src }) => useBrokenSrc(src), {
+      initialProps: { src: 'https://example.com/a.png' },
+    });
+
+    act(() => result.current[1]());
+    rerender({ src: 'https://example.com/b.png' });
+
+    expect(result.current[0]).toBe(false);
+  });
+
+  it('retries the original url after it comes back — a repaired upload keeps its url', () => {
+    const { rerender, result } = renderHook(({ src }) => useBrokenSrc(src), {
+      initialProps: { src: 'https://example.com/a.png' },
+    });
+
+    act(() => result.current[1]());
+    rerender({ src: 'https://example.com/b.png' });
+    rerender({ src: 'https://example.com/a.png' });
+
+    expect(result.current[0]).toBe(false);
+  });
+
+  it('is never broken without a url', () => {
+    const { result } = renderHook(() => useBrokenSrc(undefined));
+
+    expect(result.current[0]).toBe(false);
+  });
+});

--- a/src/components/Avatar/useBrokenSrc.ts
+++ b/src/components/Avatar/useBrokenSrc.ts
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+
+/**
+ * Remembers that *this* url failed to load, and forgets it the moment the url
+ * changes.
+ *
+ * The memory has to be scoped to the url rather than to the component: an
+ * avatar that is repaired (re-uploaded, or an edit reverted) can come back on
+ * the exact same url, and a mounted tab or sidebar row would otherwise keep
+ * showing initials for the rest of its life. The state is adjusted during
+ * render rather than in an effect, so a changed url never paints the stale
+ * fallback first.
+ */
+export const useBrokenSrc = (src?: string): [boolean, () => void] => {
+  const [state, setState] = useState<{ broken: boolean; src?: string }>({ broken: false, src });
+
+  const current = state.src === src ? state : { broken: false, src };
+  if (current !== state) setState(current);
+
+  return [!!src && current.broken, () => setState({ broken: true, src })];
+};

--- a/src/features/AgentHome/AgentInfo.tsx
+++ b/src/features/AgentHome/AgentInfo.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { agentDisplayName } from '@lobechat/types';
-import { Avatar, Flexbox, Markdown, Skeleton, Text } from '@lobehub/ui';
+import { Flexbox, Markdown, Skeleton, Text } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import Avatar from '@/components/Avatar';
 import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR } from '@/const/meta';
 import { contextSelectors, useConversationStore } from '@/features/Conversation/store';
 import { useAgentStore } from '@/store/agent';
@@ -57,6 +58,7 @@ const AgentInfo = memo(() => {
       <Avatar
         avatar={isInbox ? meta.avatar || DEFAULT_INBOX_AVATAR : meta.avatar || DEFAULT_AVATAR}
         background={meta.backgroundColor}
+        name={displayTitle}
         shape={'square'}
         size={64}
       />

--- a/src/features/AgentSidebar/Header/Agent/index.tsx
+++ b/src/features/AgentSidebar/Header/Agent/index.tsx
@@ -34,6 +34,7 @@ const Agent = memo<PropsWithChildren>(() => {
       <SidebarHeaderSelectTrigger
         avatar={isInbox ? avatar || DEFAULT_INBOX_AVATAR : avatar || DEFAULT_AVATAR}
         background={backgroundColor || undefined}
+        name={displayTitle}
         title={displayTitle}
       />
     </SwitchPanel>

--- a/src/features/AgentViewAll/AgentAvatar.tsx
+++ b/src/features/AgentViewAll/AgentAvatar.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { DEFAULT_AVATAR } from '@lobechat/const';
-import { type SidebarAgentItem } from '@lobechat/types';
-import { Avatar } from '@lobehub/ui';
+import { agentDisplayName, type SidebarAgentItem } from '@lobechat/types';
 import { memo } from 'react';
 
+import Avatar from '@/components/Avatar';
 import AgentGroupAvatar from '@/features/AgentGroupAvatar';
 
 interface AgentAvatarProps {
@@ -28,6 +28,7 @@ const AgentAvatar = memo<AgentAvatarProps>(({ item, size }) => {
       emojiScaleWithBackground
       avatar={typeof avatar === 'string' ? avatar : DEFAULT_AVATAR}
       background={backgroundColor || undefined}
+      name={agentDisplayName(item)}
       shape={'square'}
       size={size}
     />

--- a/src/features/CommandMenu/AskAIMenu.tsx
+++ b/src/features/CommandMenu/AskAIMenu.tsx
@@ -1,12 +1,12 @@
 import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR } from '@lobechat/const';
 import { agentDisplayName } from '@lobechat/types';
-import { Avatar } from '@lobehub/ui';
 import { GroupBotSquareIcon } from '@lobehub/ui/icons';
 import { Command } from 'cmdk';
 import { Bot, Image } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import Avatar from '@/components/Avatar';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useHomeStore } from '@/store/home';
 import { homeAgentListSelectors } from '@/store/home/selectors';
@@ -96,6 +96,7 @@ const AskAIMenu = memo(() => {
             <Avatar
               emojiScaleWithBackground
               avatar={typeof agent.avatar === 'string' ? agent.avatar : DEFAULT_AVATAR}
+              name={agentDisplayName(agent, t('defaultAgent'))}
               shape="square"
               size={18}
             />

--- a/src/features/CommandMenu/AskAgentCommands.tsx
+++ b/src/features/CommandMenu/AskAgentCommands.tsx
@@ -1,10 +1,11 @@
 import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR } from '@lobechat/const';
 import { agentDisplayName } from '@lobechat/types';
-import { Avatar, preventDefault } from '@lobehub/ui';
+import { preventDefault } from '@lobehub/ui';
 import { Command } from 'cmdk';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import Avatar from '@/components/Avatar';
 import { useAgentStore } from '@/store/agent';
 import { builtinAgentSelectors } from '@/store/agent/selectors/builtinAgentSelectors';
 import { useHomeStore } from '@/store/home';
@@ -91,6 +92,7 @@ const AskAgentCommands = memo(() => {
           <Avatar
             emojiScaleWithBackground
             avatar={typeof agent.avatar === 'string' ? agent.avatar : DEFAULT_AVATAR}
+            name={agentDisplayName(agent, t('defaultAgent'))}
             shape="square"
             size={18}
           />

--- a/src/features/CommandMenu/SearchResults.tsx
+++ b/src/features/CommandMenu/SearchResults.tsx
@@ -5,7 +5,7 @@ import {
   GROUP_CHAT_URL,
 } from '@lobechat/const';
 import { agentDisplayName } from '@lobechat/types';
-import { Avatar, Flexbox } from '@lobehub/ui';
+import { Flexbox } from '@lobehub/ui';
 import { Command } from 'cmdk';
 import dayjs from 'dayjs';
 import {
@@ -25,6 +25,7 @@ import {
 import { memo, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import Avatar from '@/components/Avatar';
 import { type SearchResult } from '@/database/repositories/search';
 import { useCommandMenuContext } from '@/features/CommandMenu/CommandMenuContext';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
@@ -270,6 +271,7 @@ const SearchResults = memo<SearchResultsProps>(
             <Avatar
               avatar={result.agent.avatar || DEFAULT_AVATAR}
               background={result.agent.backgroundColor || undefined}
+              name={agentDisplayName(result.agent, t('defaultAgent'))}
               size={14}
             />
             <span style={{ flex: 'none' }}>

--- a/src/features/CommandMenu/components/CommandInput.tsx
+++ b/src/features/CommandMenu/components/CommandInput.tsx
@@ -1,11 +1,12 @@
 import { DEFAULT_AVATAR } from '@lobechat/const';
 import { agentDisplayName } from '@lobechat/types';
-import { Avatar, Tag } from '@lobehub/ui';
+import { Tag } from '@lobehub/ui';
 import { Command } from 'cmdk';
 import { ArrowLeft, X } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import Avatar from '@/components/Avatar';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 
@@ -68,6 +69,7 @@ const CommandInput = memo(() => {
                   emojiScaleWithBackground
                   avatar={activeAgentMeta?.avatar || DEFAULT_AVATAR}
                   background={activeAgentMeta?.backgroundColor}
+                  name={agentDisplayName(activeAgentMeta, t('defaultAgent'))}
                   shape="square"
                   size={14}
                 />
@@ -100,6 +102,7 @@ const CommandInput = memo(() => {
               <Avatar
                 emojiScaleWithBackground
                 avatar={selectedAgent.avatar}
+                name={agentDisplayName(selectedAgent)}
                 shape="square"
                 size={14}
               />

--- a/src/features/Conversation/ChatItem/components/Avatar.tsx
+++ b/src/features/Conversation/ChatItem/components/Avatar.tsx
@@ -1,7 +1,8 @@
 import { agentDisplayName } from '@lobechat/types';
-import { Avatar as A } from '@lobehub/ui';
 import { type CSSProperties } from 'react';
 import { memo } from 'react';
+
+import A from '@/components/Avatar';
 
 import { type ChatItemProps } from '../type';
 
@@ -17,16 +18,19 @@ export interface AvatarProps {
 
 const Avatar = memo<AvatarProps>(
   ({ loading, avatar, unoptimized, onClick, size = 28, style, alt }) => {
+    const displayName = agentDisplayName(avatar);
+
     return (
       <A
-        alt={alt || agentDisplayName(avatar)}
+        alt={alt || displayName}
         animation={loading}
         avatar={avatar.avatar}
         background={avatar.backgroundColor}
+        name={displayName}
         shape={'square'}
         size={size}
         style={style}
-        title={agentDisplayName(avatar)}
+        title={displayName}
         unoptimized={unoptimized}
         onClick={onClick}
       />

--- a/src/features/Electron/titlebar/TabBar/TabItem.tsx
+++ b/src/features/Electron/titlebar/TabBar/TabItem.tsx
@@ -1,14 +1,7 @@
 'use client';
 
 import { useSortable } from '@dnd-kit/sortable';
-import {
-  ActionIcon,
-  Avatar,
-  ContextMenuTrigger,
-  type GenericItemType,
-  Icon,
-  Tooltip,
-} from '@lobehub/ui';
+import { ActionIcon, ContextMenuTrigger, type GenericItemType, Icon, Tooltip } from '@lobehub/ui';
 import { cx } from 'antd-style';
 import { X } from 'lucide-react';
 import { useMotionValue, useSpring, useTransform } from 'motion/react';
@@ -16,6 +9,7 @@ import * as m from 'motion/react-m';
 import { memo, useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import Avatar from '@/components/Avatar';
 import { electronStylish } from '@/styles/electron';
 
 import { type ResolvedTab } from './hooks/useResolvedTabs';
@@ -211,6 +205,7 @@ const TabItem = memo<TabItemProps>(
             emojiScaleWithBackground
             avatar={meta.avatar}
             background={meta.backgroundColor}
+            name={meta.title}
             shape="square"
             size={16}
           />

--- a/src/features/Home/AgentSelect/AgentList.tsx
+++ b/src/features/Home/AgentSelect/AgentList.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { ActionIcon, Avatar, Block, Flexbox, Text } from '@lobehub/ui';
+import { ActionIcon, Block, Flexbox, Text } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { PinIcon } from 'lucide-react';
 import { memo, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import AsyncBoundary from '@/components/AsyncBoundary';
+import Avatar from '@/components/Avatar';
 import { DEFAULT_AVATAR } from '@/const/meta';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
 import { useHomeStore } from '@/store/home';
@@ -78,6 +79,7 @@ const AgentList = memo<AgentListProps>(({ activeAgentId, error, onRetry, onSelec
         <Avatar
           avatar={row.avatar || DEFAULT_AVATAR}
           background={row.backgroundColor}
+          name={row.title}
           shape={'square'}
           size={24}
         />

--- a/src/features/Home/AgentSelect/index.tsx
+++ b/src/features/Home/AgentSelect/index.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { agentDisplayName } from '@lobechat/types';
-import { Avatar, Text } from '@lobehub/ui';
+import { Text } from '@lobehub/ui';
 import { Button, Popover } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import { ChevronsUpDownIcon } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import Avatar from '@/components/Avatar';
 import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR } from '@/const/meta';
 import { useFetchAgentList } from '@/hooks/useFetchAgentList';
 import { agentService } from '@/services/agent';
@@ -112,6 +113,7 @@ const AgentSelect = memo(() => {
         <Avatar
           avatar={displayAvatar}
           background={displayMeta?.backgroundColor || undefined}
+          name={displayTitle}
           shape={'square'}
           size={24}
         />

--- a/src/features/HomeSidebar/Body/Agent/List/AgentItem/Avatar.tsx
+++ b/src/features/HomeSidebar/Body/Agent/List/AgentItem/Avatar.tsx
@@ -1,18 +1,21 @@
 import { DEFAULT_AVATAR } from '@lobechat/const';
-import { Avatar } from '@lobehub/ui';
 import { memo } from 'react';
+
+import Avatar from '@/components/Avatar';
 
 interface AgentAvatarProps {
   avatar?: string;
   avatarBackground?: string;
+  title?: string;
 }
 
-const AgentAvatar = memo<AgentAvatarProps>(({ avatar, avatarBackground }) => {
+const AgentAvatar = memo<AgentAvatarProps>(({ avatar, avatarBackground, title }) => {
   return (
     <Avatar
       emojiScaleWithBackground
       avatar={avatar || DEFAULT_AVATAR}
       background={avatarBackground}
+      name={title}
       shape={'square'}
       size={22}
     />

--- a/src/features/HomeSidebar/Body/Agent/List/AgentItem/index.tsx
+++ b/src/features/HomeSidebar/Body/Agent/List/AgentItem/index.tsx
@@ -153,6 +153,7 @@ const AgentItem = memo<AgentItemProps>(({ item, style, className, onNavigate, se
       <Avatar
         avatar={typeof avatar === 'string' ? avatar : undefined}
         avatarBackground={backgroundColor || undefined}
+        title={displayTitle}
       />
     );
 
@@ -177,7 +178,7 @@ const AgentItem = memo<AgentItemProps>(({ item, style, className, onNavigate, se
     }
 
     return avatarNode;
-  }, [isUpdating, isLoading, avatar, backgroundColor, unreadCount]);
+  }, [isUpdating, isLoading, avatar, backgroundColor, displayTitle, unreadCount]);
 
   const dropdownMenu = useAgentDropdownMenu({
     anchor,

--- a/src/features/NavPanel/SidebarHeaderSelect.tsx
+++ b/src/features/NavPanel/SidebarHeaderSelect.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import type { BlockProps } from '@lobehub/ui';
-import { ActionIcon, Avatar, Block, Popover, Text } from '@lobehub/ui';
+import { ActionIcon, Block, Popover, Text } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { ChevronsUpDownIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { memo } from 'react';
 
+import Avatar from '@/components/Avatar';
 import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
@@ -51,11 +52,13 @@ export const SidebarHeaderSelectPopover = memo<SidebarHeaderSelectPopoverProps>(
 interface SidebarHeaderSelectTriggerProps extends Omit<BlockProps, 'children' | 'title'> {
   avatar?: ReactNode | string;
   background?: string;
+  /** Plain-text name behind `title`, seeding the avatar fallback. */
+  name?: string;
   title: ReactNode;
 }
 
 export const SidebarHeaderSelectTrigger = memo<SidebarHeaderSelectTriggerProps>(
-  ({ avatar, background, className, style, title, ...rest }) => (
+  ({ avatar, background, className, name, style, title, ...rest }) => (
     <Block
       clickable
       horizontal
@@ -67,7 +70,7 @@ export const SidebarHeaderSelectTrigger = memo<SidebarHeaderSelectTriggerProps>(
       variant={'borderless'}
       {...rest}
     >
-      <Avatar avatar={avatar} background={background} shape={'square'} size={28} />
+      <Avatar avatar={avatar} background={background} name={name} shape={'square'} size={28} />
       <Text ellipsis weight={500}>
         {title}
       </Text>

--- a/src/features/Portal/AgentDetail/Body.tsx
+++ b/src/features/Portal/AgentDetail/Body.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { agentDisplayName } from '@lobechat/types';
-import { Avatar, Flexbox, Markdown, Text } from '@lobehub/ui';
+import { Flexbox, Markdown, Text } from '@lobehub/ui';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import AsyncError from '@/components/AsyncError';
+import Avatar from '@/components/Avatar';
 import SurfaceSkeleton from '@/components/Skeleton/Surface';
 import { AgentNotFound } from '@/features/AgentNotFound';
 import { useAgentStore } from '@/store/agent';
@@ -23,6 +24,7 @@ const Body = memo(() => {
     (s) => agentSelectors.getAgentConfigById(agentId)(s)?.openingMessage,
   );
   const isNotFound = useAgentStore(agentByIdSelectors.isAgentNotFoundById(agentId));
+  const displayName = agentDisplayName(meta, t('defaultSession', { ns: 'common' }));
 
   if (!agentId) return null;
 
@@ -48,9 +50,15 @@ const Body = memo(() => {
 
   return (
     <Flexbox align="center" flex={1} gap={16} padding={32} style={{ overflowY: 'auto' }}>
-      <Avatar avatar={meta.avatar} background={meta.backgroundColor} shape="square" size={80} />
+      <Avatar
+        avatar={meta.avatar}
+        background={meta.backgroundColor}
+        name={displayName}
+        shape="square"
+        size={80}
+      />
       <Text align="center" fontSize={24} weight="bold">
-        {agentDisplayName(meta, t('defaultSession', { ns: 'common' }))}
+        {displayName}
       </Text>
       {meta.description && (
         <Text align="center" type="secondary">

--- a/src/features/Portal/AgentDetail/Title.tsx
+++ b/src/features/Portal/AgentDetail/Title.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { agentDisplayName } from '@lobechat/types';
-import { Avatar, Flexbox, Text } from '@lobehub/ui';
+import { Flexbox, Text } from '@lobehub/ui';
 import { memo } from 'react';
 
+import Avatar from '@/components/Avatar';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
@@ -12,12 +13,19 @@ import { chatPortalSelectors } from '@/store/chat/selectors';
 const Title = memo(() => {
   const agentId = useChatStore(chatPortalSelectors.agentDetailId);
   const meta = useAgentStore(agentSelectors.getAgentMetaById(agentId || ''));
+  const displayName = agentDisplayName(meta, agentId ?? '');
 
   return (
     <Flexbox horizontal align="center" gap={8} style={{ minWidth: 0 }}>
-      <Avatar avatar={meta.avatar} background={meta.backgroundColor} shape="square" size={24} />
+      <Avatar
+        avatar={meta.avatar}
+        background={meta.backgroundColor}
+        name={displayName}
+        shape="square"
+        size={24}
+      />
       <Text ellipsis weight={500}>
-        {agentDisplayName(meta, agentId ?? '')}
+        {displayName}
       </Text>
     </Flexbox>
   );

--- a/src/features/Projects/Layout/ProjectHeader.tsx
+++ b/src/features/Projects/Layout/ProjectHeader.tsx
@@ -60,6 +60,7 @@ const ProjectHeader = memo<ProjectHeaderProps>(({ project }) => {
         >
           <SidebarHeaderSelectTrigger
             avatar={project?.avatar || project?.name || t('sidebar.title')}
+            name={project?.name || t('sidebar.title')}
             title={project?.name || t('sidebar.title')}
           />
         </SidebarHeaderSelectPopover>


### PR DESCRIPTION
"UN" is not a placeholder — it is the first two letters of `"undefined"`.

`@lobehub/ui`'s Avatar computes its fallback text as
`String(isDefaultAntAvatar ? title : avatar).toUpperCase().slice(0, 2)`. When the image 404s and no `title` was passed, that expression is `String(undefined)`. Only 4 of ~330 call sites in this repo pass a `title`, so any dead avatar URL — an expired presigned S3 link, a deleted upload, an unreachable host — renders a grey `UN` tile: agent tabs, the conversation welcome card, message bubbles, the sidebar.

| Before | After |
| ------ | ----- |
| Grey `UN` tile wherever the avatar image fails to load | Name initials on a stable, name-derived color |

Rendered evidence (tab bar / sidebar header / welcome card at 16px, 28px and 64px) is on the acceptance page linked below.

#### What this does

Adds `src/components/Avatar`, a drop-in wrapper around the library Avatar with one extra prop (`name`, the seed; defaults to `title`):

- **It renders the `<img>` itself** so it owns the `error` event. An earlier revision probed the URL with a separate `new Image()`; the probe and the real element can disagree, and on disagreement the library's own `UN` fallback wins — which is exactly what showed up when this was driven in the desktop app.
- **Initials**: one glyph for CJK (`贺素青` → `贺`; two glyphs are unreadable at 16px), the first two word initials for latin (`Claude Code` → `CC`), and a leading emoji passed straight through so FluentEmoji renders it.
- **Background**: FNV-1a over the name into `primaryColorsSwatches` — the same 12 brand colors users pick from — so an agent keeps its color across sessions, devices and list positions. An explicitly chosen `backgroundColor` still wins. Text contrast is the library's `safeReadableColor`.

Two details worth calling out:

- A background of `'transparent'` is a sentinel, not a color: `currentAgentBackgroundColor` returns it for "not set", and `safeReadableColor('transparent')` computes white — white text on a white page. The fallback treats it as absent; a real image still keeps it.
- Initials are derived only from a real name. Seeding them from the avatar URL would render its first character (`/`), which says less than an empty tile — the URL still seeds the *color*, so unnamed avatars aren't all the same grey.

Wired into the desktop surfaces that carry agent identity: tab bar, welcome card, message bubbles, sidebar list, sidebar header / agent switcher, project header, agent list, agent select, portal agent detail, command menu.

#### Not in this PR

~170 call sites still import Avatar directly from `@lobehub/ui` and will keep falling back to `UN` if their image dies without a `title`. The durable fix is upstream — the `String(undefined)` line in `@lobehub/ui` — which would need no call-site changes at all. This PR covers the surfaces users actually hit today.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`src/components/Avatar/fallback.test.ts` — 18 cases covering initials (CJK / latin / single word / leading emoji / blank), color stability and spread, the `transparent` sentinel, and that a nameless avatar renders an empty tile rather than `UN` or a URL fragment.

Driven end to end in the desktop app against fixture agents with a real S3 404, an unresolvable host, no avatar at all, and a working image. Both defects named above were found that way, not by the unit tests. Six routes swept for `UN`: zero across 12–13 rendered avatars each.

Acceptance report with screenshots: https://app.lobehub.com/acceptance/abd97ade-cafd-479f-bf2f-35f15868e7a2

Not verified: message-bubble avatars (the fixture environment had no usable model, so no real conversation could be produced) and dark theme.

#### 🔗 Related Issue

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)