### PR TITLE
🐛 fix(acceptance): open origin topic in the ledger rail

### DIFF
--- a/src/features/Portal/Acceptance/Body.test.tsx
+++ b/src/features/Portal/Acceptance/Body.test.tsx
@@ -40,11 +40,6 @@ vi.mock('@/features/Verify', () => ({
   OriginConversationProvider: ({ children }: { children?: React.ReactNode }) => children,
 }));
 
-vi.mock('@/store/task', () => ({
-  useTaskStore: (selector: (s: unknown) => unknown) =>
-    selector({ closeTopicDrawer: () => {}, openTopicDrawer: () => {} }),
-}));
-
 vi.mock('@/features/Verify/Acceptance/TopicPanel', () => ({ default: () => null }));
 
 describe('Portal Acceptance Body — draftToComposer via the global bus', () => {

--- a/src/features/Portal/Acceptance/Body.tsx
+++ b/src/features/Portal/Acceptance/Body.tsx
@@ -1,25 +1,13 @@
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 
 import { draftToMainComposer } from '@/features/Conversation/composerDraftBus';
-import {
-  AcceptanceViewer,
-  OriginConversationProvider,
-  type OriginConversationSlot,
-} from '@/features/Verify';
+import { AcceptanceViewer, OriginConversationProvider } from '@/features/Verify';
 import TopicPanel from '@/features/Verify/Acceptance/TopicPanel';
 import { useChatStore } from '@/store/chat';
 import { chatPortalSelectors } from '@/store/chat/selectors';
-import { useTaskStore } from '@/store/task';
 
 const Body = memo(() => {
   const acceptanceId = useChatStore(chatPortalSelectors.acceptancePortalId);
-  const openTopicDrawer = useTaskStore((s) => s.openTopicDrawer);
-  const closeTopicDrawer = useTaskStore((s) => s.closeTopicDrawer);
-
-  const originConversation = useMemo<OriginConversationSlot>(
-    () => ({ TopicPanel, closeTopicDrawer, openTopicDrawer }),
-    [closeTopicDrawer, openTopicDrawer],
-  );
 
   // The portal pane is a layout SIBLING of the conversation column, not a
   // descendant of its ConversationProvider — reading useConversationStore here
@@ -27,7 +15,7 @@ const Body = memo(() => {
   // go through the global composerDraftBus; ComposerDraftReceiver applies them
   // inside the provider (setDocument + inputMessage sync + focus).
   return (
-    <OriginConversationProvider value={originConversation}>
+    <OriginConversationProvider TopicPanel={TopicPanel}>
       <AcceptanceViewer acceptanceId={acceptanceId} onDraftToComposer={draftToMainComposer} />
     </OriginConversationProvider>
   );

--- a/src/features/Verify/Acceptance/AcceptanceLedgerRail.tsx
+++ b/src/features/Verify/Acceptance/AcceptanceLedgerRail.tsx
@@ -13,7 +13,7 @@ import { resolveRoundParam } from '../utils';
 import { useAcceptanceScope } from './AcceptanceScope';
 import { checkFilterState } from './CheckList';
 import LedgerPanel, { type AcceptanceRound } from './LedgerPanel';
-import { useOriginConversation } from './originConversation';
+import { originTopicPanelProps, useOriginConversation } from './originConversation';
 import { useAcceptanceBundle } from './useAcceptanceBundle';
 import { canViewAcceptanceHistory } from './visibility';
 
@@ -43,8 +43,8 @@ const AcceptanceLedgerRail = () => {
   const { acceptanceId, embedded } = useAcceptanceScope();
   const { data } = useAcceptanceBundle(acceptanceId);
   const originConversation = useOriginConversation();
+  const originTopicOpen = Boolean(originConversation?.isOpen);
   const [expand, setExpand] = useState(!embedded);
-  const [topicPanelOpen, setTopicPanelOpen] = useState(false);
   const highlightRound = null;
   const focused = Boolean(params.checkId);
 
@@ -55,6 +55,10 @@ const AcceptanceLedgerRail = () => {
   useEffect(() => {
     if (focused) setExpand(false);
   }, [focused]);
+
+  useEffect(() => {
+    if (originTopicOpen && !focused) setExpand(true);
+  }, [focused, originTopicOpen]);
 
   if (!data || !canViewAcceptanceHistory(data.isOwner)) return null;
 
@@ -88,18 +92,19 @@ const AcceptanceLedgerRail = () => {
   };
 
   const TopicPanel = originConversation?.TopicPanel;
-  const origin = data.origin;
+  const topicProps = originTopicPanelProps({
+    isOpen: originTopicOpen,
+    origin: data.origin,
+    subjectTitle: data.subject.title,
+  });
   const topic =
-    topicPanelOpen && origin?.agent?.id && origin.topic && TopicPanel ? (
+    topicProps && TopicPanel ? (
       <TopicPanel
-        agentId={origin.agent.id}
-        title={origin.topic.title ?? data.subject.title ?? origin.topic.id}
-        topicId={origin.topic.id}
+        agentId={topicProps.agentId}
+        title={topicProps.title}
+        topicId={topicProps.topicId}
+        onBack={() => originConversation?.closeTopicDrawer()}
         onCollapse={() => setExpand(false)}
-        onBack={() => {
-          setTopicPanelOpen(false);
-          originConversation?.closeTopicDrawer();
-        }}
       />
     ) : null;
 

--- a/src/features/Verify/Acceptance/AcceptanceOriginTopic.tsx
+++ b/src/features/Verify/Acceptance/AcceptanceOriginTopic.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { Flexbox, Icon } from '@lobehub/ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
+import { MessagesSquare } from 'lucide-react';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -16,7 +18,7 @@ const styles = createStaticStyles(({ css }) => ({
     border: 0;
 
     font: inherit;
-    font-size: 12px;
+    font-size: 14px;
     color: ${cssVar.colorTextSecondary};
 
     background: none;
@@ -50,7 +52,10 @@ const AcceptanceOriginTopic = () => {
       type={'button'}
       onClick={openTopic}
     >
-      {data.origin.topic.title ?? data.subject.title ?? data.origin.topic.id}
+      <Flexbox horizontal align={'center'} gap={4}>
+        <Icon icon={MessagesSquare} size={13} />
+        {data.origin.topic.title ?? data.subject.title ?? data.origin.topic.id}
+      </Flexbox>
     </button>
   );
 };

--- a/src/features/Verify/Acceptance/originConversation.test.ts
+++ b/src/features/Verify/Acceptance/originConversation.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import type { OriginTopicPanelProps } from './originConversation';
+import {
+  OriginConversationProvider,
+  originTopicPanelProps,
+  useOriginConversation,
+} from './originConversation';
+
+const TopicPanel = (_props: OriginTopicPanelProps) => null;
+
+const wrapper = ({ children }: { children?: ReactNode }) =>
+  createElement(OriginConversationProvider, { TopicPanel }, children);
+
+describe('originTopicPanelProps', () => {
+  const origin = {
+    agent: { id: 'agent-1' },
+    topic: { id: 'topic-1', title: 'Origin topic' },
+  };
+
+  it('stays closed until the origin topic is opened', () => {
+    expect(
+      originTopicPanelProps({
+        isOpen: false,
+        origin,
+        subjectTitle: 'Subject',
+      }),
+    ).toBeNull();
+  });
+
+  it('returns the rail panel props after openTopicDrawer', () => {
+    expect(
+      originTopicPanelProps({
+        isOpen: true,
+        origin,
+        subjectTitle: 'Subject',
+      }),
+    ).toEqual({
+      agentId: 'agent-1',
+      title: 'Origin topic',
+      topicId: 'topic-1',
+    });
+  });
+
+  it('falls back to the subject title when the topic has no title', () => {
+    expect(
+      originTopicPanelProps({
+        isOpen: true,
+        origin: { agent: { id: 'agent-1' }, topic: { id: 'topic-1', title: null } },
+        subjectTitle: 'Subject',
+      }),
+    ).toEqual({
+      agentId: 'agent-1',
+      title: 'Subject',
+      topicId: 'topic-1',
+    });
+  });
+
+  it('does not open without an origin agent and topic', () => {
+    expect(
+      originTopicPanelProps({
+        isOpen: true,
+        origin: { agent: null, topic: { id: 'topic-1', title: 'Origin topic' } },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('OriginConversationProvider', () => {
+  it('opens the origin topic panel from the chip action instead of a disconnected rail flag', () => {
+    const { result } = renderHook(() => useOriginConversation(), { wrapper });
+
+    expect(result.current?.isOpen).toBe(false);
+
+    act(() => {
+      result.current?.openTopicDrawer('topic-1', { agentId: 'agent-1', title: 'Origin topic' });
+    });
+
+    expect(result.current?.isOpen).toBe(true);
+    expect(result.current?.TopicPanel).toBe(TopicPanel);
+
+    act(() => {
+      result.current?.closeTopicDrawer();
+    });
+
+    expect(result.current?.isOpen).toBe(false);
+  });
+
+  it('stays hidden when the host never injects the conversation seam', () => {
+    const { result } = renderHook(() => useOriginConversation());
+
+    expect(result.current).toBeNull();
+  });
+});

--- a/src/features/Verify/Acceptance/originConversation.test.ts
+++ b/src/features/Verify/Acceptance/originConversation.test.ts
@@ -16,7 +16,7 @@ import {
 const TopicPanel = (_props: OriginTopicPanelProps) => null;
 
 const wrapper = ({ children }: { children?: ReactNode }) =>
-  createElement(OriginConversationProvider, { TopicPanel }, children);
+  createElement(OriginConversationProvider, { TopicPanel, children });
 
 describe('originTopicPanelProps', () => {
   const origin = {

--- a/src/features/Verify/Acceptance/originConversation.tsx
+++ b/src/features/Verify/Acceptance/originConversation.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { type ComponentType, createContext, use } from 'react';
+import type { ComponentType, ReactNode } from 'react';
+import { createContext, use, useMemo, useState } from 'react';
 
-// Seam that keeps the acceptance viewer free of the conversation universe
-// (TopicChatDrawer, task store): hosts that can show the origin conversation
-// (the app portal) inject it; hosts that cannot (workbench) leave it null and
-// every origin-conversation affordance stays hidden.
+// Host seam: inject TopicPanel (conversation graph). Workbench omits the
+// provider so origin-conversation affordances stay hidden. Open state lives
+// here — not the task-store topic drawer, which is unmounted on this page.
 export interface OriginTopicPanelProps {
   agentId: string;
   onBack: () => void;
@@ -16,12 +16,52 @@ export interface OriginTopicPanelProps {
 
 export interface OriginConversationSlot {
   closeTopicDrawer: () => void;
+  isOpen: boolean;
   openTopicDrawer: (topicId: string, topic?: { agentId?: string; title?: string }) => void;
   TopicPanel: ComponentType<OriginTopicPanelProps>;
 }
 
+export const originTopicPanelProps = ({
+  isOpen,
+  origin,
+  subjectTitle,
+}: {
+  isOpen: boolean;
+  origin?: {
+    agent?: { id: string } | null;
+    topic?: { id: string; title?: string | null } | null;
+  } | null;
+  subjectTitle?: string | null;
+}): Omit<OriginTopicPanelProps, 'onBack' | 'onCollapse'> | null => {
+  if (!isOpen || !origin?.agent?.id || !origin.topic) return null;
+  return {
+    agentId: origin.agent.id,
+    title: origin.topic.title ?? subjectTitle ?? origin.topic.id,
+    topicId: origin.topic.id,
+  };
+};
+
 const OriginConversationContext = createContext<OriginConversationSlot | null>(null);
 
-export const OriginConversationProvider = OriginConversationContext.Provider;
+export const OriginConversationProvider = ({
+  TopicPanel,
+  children,
+}: {
+  TopicPanel: ComponentType<OriginTopicPanelProps>;
+  children: ReactNode;
+}) => {
+  const [isOpen, setOpen] = useState(false);
+  const value = useMemo<OriginConversationSlot>(
+    () => ({
+      TopicPanel,
+      isOpen,
+      closeTopicDrawer: () => setOpen(false),
+      openTopicDrawer: () => setOpen(true),
+    }),
+    [TopicPanel, isOpen],
+  );
+
+  return <OriginConversationContext value={value}>{children}</OriginConversationContext>;
+};
 
 export const useOriginConversation = () => use(OriginConversationContext);

--- a/src/routes/acceptance/[acceptanceId]/index.tsx
+++ b/src/routes/acceptance/[acceptanceId]/index.tsx
@@ -1,25 +1,11 @@
 'use client';
 
-import { useMemo } from 'react';
-
-import {
-  AcceptanceViewer,
-  OriginConversationProvider,
-  type OriginConversationSlot,
-} from '@/features/Verify';
+import { AcceptanceViewer, OriginConversationProvider } from '@/features/Verify';
 import TopicPanel from '@/features/Verify/Acceptance/TopicPanel';
-import { useTaskStore } from '@/store/task';
 
 export default function AcceptanceRoute() {
-  const openTopicDrawer = useTaskStore((s) => s.openTopicDrawer);
-  const closeTopicDrawer = useTaskStore((s) => s.closeTopicDrawer);
-  const originConversation = useMemo<OriginConversationSlot>(
-    () => ({ TopicPanel, closeTopicDrawer, openTopicDrawer }),
-    [closeTopicDrawer, openTopicDrawer],
-  );
-
   return (
-    <OriginConversationProvider value={originConversation}>
+    <OriginConversationProvider TopicPanel={TopicPanel}>
       <AcceptanceViewer />
     </OriginConversationProvider>
   );


### PR DESCRIPTION
<!-- Brief and heads-up -->

Clicking the origin topic next to Codex on `/acceptance/:id` did nothing. The chip wrote into the task-store topic drawer, which is not mounted on this page, while the ledger rail kept a local `topicPanelOpen` flag that was never set to true.

| Before | After |
| ------ | ----- |
| Origin topic title looks like static text; click has no effect | Click opens the origin conversation in the right rail; back returns to runs |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check --lint --test` on the touched files: 9 tests passed.

#### 🔗 Related Issue

N/A

#### Description of Change

- Own origin-conversation open state in `OriginConversationProvider` instead of forwarding `useTaskStore.openTopicDrawer`
- Drive the ledger rail from that `isOpen` flag and expand the rail when the topic opens
- Add a topic icon on the chip so it reads as a control
- Regression coverage for `originTopicPanelProps` and the provider open/close contract