### PR TITLE
💄 style(verify): tile portrait acceptance screenshots

### DIFF
--- a/src/features/Verify/Acceptance/CheckList.tsx
+++ b/src/features/Verify/Acceptance/CheckList.tsx
@@ -73,6 +73,7 @@ import { openGroupFeedbackModal } from './modals';
 import type { CheckProposal } from './proposal';
 import { classifyProposalEdit } from './proposal';
 import ProposalCard from './ProposalCard';
+import { ScreenshotTiles } from './ScreenshotTiles';
 
 export type AcceptanceCheck = AcceptanceBundle['checks'][number];
 export type AcceptanceCheckState = AcceptanceCheck['state'];
@@ -415,17 +416,28 @@ const imageRatio = (item: AcceptanceEvidence): string | undefined =>
   item.fileWidth && item.fileHeight ? `${item.fileWidth} / ${item.fileHeight}` : undefined;
 
 /** Flat media for a comparison side — the card frames it, so no own border/radius. */
-const comparisonContent = (item: AcceptanceEvidence) =>
-  item.type === 'video' ? (
-    <video controls src={item.fileUrl!} style={{ display: 'block', width: '100%' }} />
-  ) : item.type === 'audio' ? (
-    <AudioPlayer
-      fullWidth
-      alt={item.description ?? item.fileName ?? item.type}
-      downloadFileName={item.fileName ?? 'audio'}
-      url={item.fileUrl!}
-    />
-  ) : (
+const comparisonContent = (item: AcceptanceEvidence) => {
+  if (item.type === 'video')
+    return <video controls src={item.fileUrl!} style={{ display: 'block', width: '100%' }} />;
+  if (item.type === 'audio')
+    return (
+      <AudioPlayer
+        fullWidth
+        alt={item.description ?? item.fileName ?? item.type}
+        downloadFileName={item.fileName ?? 'audio'}
+        url={item.fileUrl!}
+      />
+    );
+  if (item.type === 'screenshot' && item.fileUrl)
+    return (
+      <ScreenshotTiles
+        alt={item.description ?? item.fileName ?? item.type}
+        fileHeight={item.fileHeight}
+        fileWidth={item.fileWidth}
+        src={item.fileUrl}
+      />
+    );
+  return (
     <Image
       preview
       alt={item.description ?? item.fileName ?? item.type}
@@ -435,6 +447,7 @@ const comparisonContent = (item: AcceptanceEvidence) =>
       variant={'borderless'}
     />
   );
+};
 
 const EvidenceList = memo<{
   evidence: AcceptanceEvidence[];
@@ -478,9 +491,12 @@ const EvidenceList = memo<{
     content: comparisonContent(item),
   });
 
+  const consumedScreenshotIds = new Set<string>();
+
   return (
     <Flexbox gap={12}>
       {sorted.map((item) => {
+        if (consumedScreenshotIds.has(item.id)) return null;
         if (pairedIds.has(item.id)) {
           const comparison = readEvidenceComparison(item.metadata)!;
           // The pair renders once, anchored at its `before` half.
@@ -524,56 +540,85 @@ const EvidenceList = memo<{
             </Flexbox>
           );
         const overlay = overlays?.get(item.id);
-        if (item.fileUrl && IMAGE_EVIDENCE.has(item.type) && overlay?.length)
+        if (item.fileUrl && item.type === 'screenshot') {
+          const run = [item];
+          const start = sorted.indexOf(item);
+          for (let index = start + 1; index < sorted.length; index++) {
+            const next = sorted[index]!;
+            if (pairedIds.has(next.id) || !next.fileUrl || next.type !== 'screenshot') break;
+            run.push(next);
+            consumedScreenshotIds.add(next.id);
+          }
           return (
-            <Flexbox gap={4} key={item.id} style={{ maxWidth: '100%', width: 'fit-content' }}>
-              {/* Comments stay off here — the proposal card already lists them
-                  against the same badge numbers. */}
-              <AnnotatedImage
-                annotations={overlay}
-                showComments={false}
-                src={item.fileUrl}
-                imageStyle={
-                  item.fileWidth && item.fileHeight
-                    ? { aspectRatio: imageRatio(item), maxWidth: '100%', width: item.fileWidth }
-                    : undefined
-                }
-              />
-              {caption}
+            <Flexbox
+              horizontal
+              align={'flex-start'}
+              gap={12}
+              key={item.id}
+              style={{ maxWidth: '100%' }}
+              wrap={'wrap'}
+            >
+              {run.map((shot) => {
+                const shotCaption = meaningfulEvidenceCaption(shot.description);
+                return (
+                  <ScreenshotTiles
+                    alt={shot.description ?? shot.fileName ?? shot.type}
+                    annotations={overlays?.get(shot.id)}
+                    fileHeight={shot.fileHeight}
+                    fileWidth={shot.fileWidth}
+                    key={shot.id}
+                    src={shot.fileUrl!}
+                    caption={
+                      shotCaption ? (
+                        <span className={styles.caption}>{shotCaption}</span>
+                      ) : undefined
+                    }
+                  />
+                );
+              })}
             </Flexbox>
           );
-        if (item.fileUrl && IMAGE_EVIDENCE.has(item.type))
+        }
+        if (item.fileUrl && IMAGE_EVIDENCE.has(item.type)) {
           return (
             <Flexbox gap={4} key={item.id} style={{ maxWidth: '100%', width: 'fit-content' }}>
-              {/* The frame owns the border — the inner Image must not draw its
-                  own, or the two 1px borders stack visibly. The frame also
-                  reserves the aspect ratio so the row's height is settled
-                  before the image loads (no expand jump). */}
-              <Flexbox
-                className={styles.evidenceImage}
-                style={
-                  item.fileWidth && item.fileHeight
-                    ? { aspectRatio: imageRatio(item), maxWidth: '100%', width: item.fileWidth }
-                    : undefined
-                }
-              >
-                <Image
-                  alt={item.description ?? item.fileName ?? item.type}
-                  loading={'lazy'}
+              {overlay?.length ? (
+                <AnnotatedImage
+                  annotations={overlay}
+                  showComments={false}
                   src={item.fileUrl}
-                  variant={'borderless'}
-                  style={{
-                    borderRadius: 0,
-                    maxWidth: '100%',
-                    // Fill the ratio-reserving frame; without known dimensions
-                    // the image keeps its intrinsic size (legacy evidence).
-                    width: item.fileWidth && item.fileHeight ? '100%' : undefined,
-                  }}
+                  imageStyle={
+                    item.fileWidth && item.fileHeight
+                      ? { aspectRatio: imageRatio(item), maxWidth: '100%', width: item.fileWidth }
+                      : undefined
+                  }
                 />
-              </Flexbox>
+              ) : (
+                <Flexbox
+                  className={styles.evidenceImage}
+                  style={
+                    item.fileWidth && item.fileHeight
+                      ? { aspectRatio: imageRatio(item), maxWidth: '100%', width: item.fileWidth }
+                      : undefined
+                  }
+                >
+                  <Image
+                    alt={item.description ?? item.fileName ?? item.type}
+                    loading={'lazy'}
+                    src={item.fileUrl}
+                    variant={'borderless'}
+                    style={{
+                      borderRadius: 0,
+                      maxWidth: '100%',
+                      width: item.fileWidth && item.fileHeight ? '100%' : undefined,
+                    }}
+                  />
+                </Flexbox>
+              )}
               {caption}
             </Flexbox>
           );
+        }
         if (item.content && markdownTextEvidenceTypes.has(item.type))
           return (
             <Flexbox gap={4} key={item.id}>

--- a/src/features/Verify/Acceptance/ScreenshotTiles.tsx
+++ b/src/features/Verify/Acceptance/ScreenshotTiles.tsx
@@ -209,9 +209,7 @@ export const ScreenshotTiles = memo<ScreenshotTilesProps>(
               width: `${annotation.rect.width * 100}%`,
             }}
           >
-            {numbered && (
-              <span className={styles.badge}>{annotation.label ?? annotation.index + 1}</span>
-            )}
+            {numbered && <span className={styles.badge}>{annotation.label ?? index + 1}</span>}
           </div>
         ))}
       </div>,

--- a/src/features/Verify/Acceptance/ScreenshotTiles.tsx
+++ b/src/features/Verify/Acceptance/ScreenshotTiles.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import type { AcceptanceReviewAnnotation } from '@lobechat/types';
+import { Flexbox, Image } from '@lobehub/ui';
+import { createStaticStyles, cssVar } from 'antd-style';
+import { memo, type ReactNode, useState } from 'react';
+
+import {
+  annotationInSlice,
+  isPortraitScreenshot,
+  screenshotSliceObjectPosition,
+  screenshotSlices,
+  screenshotTileWidth,
+} from './screenshotSlices';
+
+type Rect = AcceptanceReviewAnnotation['rect'];
+
+const styles = createStaticStyles(({ css }) => ({
+  badge: css`
+    position: absolute;
+    inset-block-start: -9px;
+    inset-inline-start: -9px;
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1;
+    color: #fff;
+
+    background: ${cssVar.colorError};
+  `,
+  frame: css`
+    position: relative;
+
+    overflow: hidden;
+    flex: none;
+
+    max-width: 100%;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadiusLG};
+  `,
+  rect: css`
+    pointer-events: none;
+
+    position: absolute;
+
+    border: 2px solid ${cssVar.colorError};
+    border-radius: 4px;
+
+    box-shadow: 0 0 0 1px rgb(0 0 0 / 25%);
+  `,
+}));
+
+interface ScreenshotTilesProps {
+  alt: string;
+  annotations?: { comment?: string; label?: number; rect: Rect }[];
+  caption?: ReactNode;
+  fileHeight?: number | null;
+  fileWidth?: number | null;
+  src: string;
+}
+
+export const ScreenshotTiles = memo<ScreenshotTilesProps>(
+  ({ alt, annotations, caption, fileHeight, fileWidth, src }) => {
+    const [natural, setNatural] = useState(
+      fileWidth && fileHeight ? { height: fileHeight, width: fileWidth } : undefined,
+    );
+
+    const slices = natural ? screenshotSlices(natural.width, natural.height) : undefined;
+    const numbered =
+      (annotations?.length ?? 0) > 1 || annotations?.some((item) => item.label !== undefined);
+
+    const rememberSize = (event: { currentTarget: HTMLImageElement }) => {
+      if (natural) return;
+      setNatural({
+        height: event.currentTarget.naturalHeight,
+        width: event.currentTarget.naturalWidth,
+      });
+    };
+
+    const shell = (width: string | number, body: ReactNode) => (
+      <Flexbox gap={4} style={{ maxWidth: '100%', width }}>
+        {body}
+        {caption}
+      </Flexbox>
+    );
+
+    if (!natural) {
+      return shell(
+        '100%',
+        <div className={styles.frame} style={{ maxWidth: '100%', width: '100%' }}>
+          <Image
+            alt={alt}
+            loading={'lazy'}
+            src={src}
+            variant={'borderless'}
+            width={'100%'}
+            onLoad={rememberSize}
+          />
+        </div>,
+      );
+    }
+
+    if (slices) {
+      return shell(
+        '100%',
+        <Flexbox horizontal align={'flex-start'} gap={12} wrap={'wrap'}>
+          {slices.map((slice) => {
+            const local = annotations
+              ?.map((annotation, index) => {
+                const rect = annotationInSlice(annotation.rect, slice, natural.height);
+                if (!rect) return;
+                return { ...annotation, index, rect };
+              })
+              .filter((item) => item !== undefined);
+
+            return (
+              <div
+                className={styles.frame}
+                key={slice.index}
+                style={{
+                  aspectRatio: `${natural.width} / ${slice.height}`,
+                  width: screenshotTileWidth(natural.width),
+                }}
+              >
+                <Image
+                  alt={alt}
+                  height={'100%'}
+                  loading={'lazy'}
+                  maxHeight={'none'}
+                  maxWidth={'none'}
+                  objectFit={'cover'}
+                  src={src}
+                  style={{ height: '100%', width: '100%' }}
+                  variant={'borderless'}
+                  width={'100%'}
+                  styles={{
+                    image: {
+                      height: '100%',
+                      objectPosition: screenshotSliceObjectPosition(slice, natural.height),
+                      width: '100%',
+                    },
+                    wrapper: { height: '100%', width: '100%' },
+                  }}
+                />
+                {local?.map((annotation) => (
+                  <div
+                    className={styles.rect}
+                    key={annotation.index}
+                    style={{
+                      height: `${annotation.rect.height * 100}%`,
+                      left: `${annotation.rect.x * 100}%`,
+                      top: `${annotation.rect.y * 100}%`,
+                      width: `${annotation.rect.width * 100}%`,
+                    }}
+                  >
+                    {numbered && (
+                      <span className={styles.badge}>
+                        {annotation.label ?? annotation.index + 1}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            );
+          })}
+        </Flexbox>,
+      );
+    }
+
+    const portrait = isPortraitScreenshot(natural.width, natural.height);
+
+    return shell(
+      portrait ? screenshotTileWidth(natural.width) : '100%',
+      <div
+        className={styles.frame}
+        style={{
+          aspectRatio: `${natural.width} / ${natural.height}`,
+          maxWidth: '100%',
+          width: '100%',
+        }}
+      >
+        <Image
+          alt={alt}
+          loading={'lazy'}
+          maxHeight={'none'}
+          maxWidth={'none'}
+          objectFit={'contain'}
+          src={src}
+          style={{ width: '100%' }}
+          variant={'borderless'}
+          width={'100%'}
+        />
+        {annotations?.map((annotation, index) => (
+          <div
+            className={styles.rect}
+            key={index}
+            style={{
+              height: `${annotation.rect.height * 100}%`,
+              left: `${annotation.rect.x * 100}%`,
+              top: `${annotation.rect.y * 100}%`,
+              width: `${annotation.rect.width * 100}%`,
+            }}
+          >
+            {numbered && (
+              <span className={styles.badge}>{annotation.label ?? annotation.index + 1}</span>
+            )}
+          </div>
+        ))}
+      </div>,
+    );
+  },
+);
+
+ScreenshotTiles.displayName = 'AcceptanceScreenshotTiles';

--- a/src/features/Verify/Acceptance/screenshotSlices.test.ts
+++ b/src/features/Verify/Acceptance/screenshotSlices.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  annotationInSlice,
+  isPortraitScreenshot,
+  SCREENSHOT_SLICE_ASPECT,
+  screenshotSliceObjectPosition,
+  screenshotSlices,
+} from './screenshotSlices';
+
+describe('screenshotSlices', () => {
+  it('returns nothing without intrinsic size', () => {
+    expect(screenshotSlices()).toBeUndefined();
+    expect(screenshotSlices(390, null)).toBeUndefined();
+    expect(screenshotSlices(0, 2412)).toBeUndefined();
+  });
+
+  it('keeps a single phone screen as one image', () => {
+    expect(screenshotSlices(390, 844)).toBeUndefined();
+    expect(screenshotSlices(390, 1687)).toBeUndefined();
+    expect(screenshotSlices(1206, 2622)).toBeUndefined();
+  });
+
+  it('splits a long mobile capture into phone-screen tiles', () => {
+    expect(screenshotSlices(390, 2412)).toEqual([
+      { height: 844, index: 0, top: 0 },
+      { height: 844, index: 1, top: 844 },
+      { height: 724, index: 2, top: 1688 },
+    ]);
+  });
+
+  it('uses the same screen aspect on a 3x capture', () => {
+    const width = 1170;
+    const slice = Math.round(width * SCREENSHOT_SLICE_ASPECT);
+    const slices = screenshotSlices(width, slice * 2 + 100);
+    expect(slices).toEqual([
+      { height: slice, index: 0, top: 0 },
+      { height: slice, index: 1, top: slice },
+      { height: 100, index: 2, top: slice * 2 },
+    ]);
+  });
+});
+
+describe('isPortraitScreenshot', () => {
+  it('treats an iPhone capture as portrait', () => {
+    expect(isPortraitScreenshot(1206, 2622)).toBe(true);
+  });
+
+  it('leaves landscape desktop captures alone', () => {
+    expect(isPortraitScreenshot(1280, 720)).toBe(false);
+  });
+
+  it('leaves a wide header crop alone', () => {
+    expect(isPortraitScreenshot(1206, 570)).toBe(false);
+    expect(isPortraitScreenshot(1206, 385)).toBe(false);
+  });
+});
+
+describe('screenshotSliceObjectPosition', () => {
+  it('pins the first slice to the top and the last slice to the bottom', () => {
+    const slices = screenshotSlices(390, 2412)!;
+    expect(screenshotSliceObjectPosition(slices[0]!, 2412)).toBe('0 0%');
+    expect(screenshotSliceObjectPosition(slices[2]!, 2412)).toBe('0 100%');
+  });
+});
+
+describe('annotationInSlice', () => {
+  const slices = screenshotSlices(390, 2412)!;
+
+  it('maps a rect onto the slice that contains it', () => {
+    const rect = annotationInSlice({ height: 0.04, width: 0.2, x: 0.7, y: 0.72 }, slices[2]!, 2412);
+    expect(rect?.width).toBe(0.2);
+    expect(rect?.x).toBe(0.7);
+    expect(rect?.height).toBeCloseTo((0.04 * 2412) / 724);
+    expect(rect?.y).toBeCloseTo((0.72 * 2412 - 1688) / 724);
+  });
+
+  it('ignores a rect that lives on another slice', () => {
+    expect(
+      annotationInSlice({ height: 0.04, width: 0.2, x: 0.7, y: 0.72 }, slices[0]!, 2412),
+    ).toBeUndefined();
+  });
+
+  it('clips a rect that crosses a slice edge', () => {
+    const y = (844 - 20) / 2412;
+    const height = 40 / 2412;
+    const first = annotationInSlice({ height, width: 0.3, x: 0.1, y }, slices[0]!, 2412);
+    const second = annotationInSlice({ height, width: 0.3, x: 0.1, y }, slices[1]!, 2412);
+    expect(first?.y).toBeCloseTo(824 / 844);
+    expect(first?.height).toBeCloseTo(20 / 844);
+    expect(second?.y).toBeCloseTo(0);
+    expect(second?.height).toBeCloseTo(20 / 844);
+  });
+});

--- a/src/features/Verify/Acceptance/screenshotSlices.ts
+++ b/src/features/Verify/Acceptance/screenshotSlices.ts
@@ -1,0 +1,69 @@
+import type { AcceptanceReviewAnnotation } from '@lobechat/types';
+
+type Rect = AcceptanceReviewAnnotation['rect'];
+
+export const SCREENSHOT_SLICE_ASPECT = 844 / 390;
+export const SCREENSHOT_TILE_MAX_WIDTH = 280;
+
+export interface ScreenshotSlice {
+  height: number;
+  index: number;
+  top: number;
+}
+
+export const screenshotSlices = (
+  fileWidth?: number | null,
+  fileHeight?: number | null,
+): ScreenshotSlice[] | undefined => {
+  if (!fileWidth || !fileHeight || fileWidth <= 0 || fileHeight <= 0) return;
+
+  const sliceHeight = Math.round(fileWidth * SCREENSHOT_SLICE_ASPECT);
+  if (sliceHeight <= 0 || fileHeight < sliceHeight * 2) return;
+
+  const slices: ScreenshotSlice[] = [];
+  let top = 0;
+  let index = 0;
+  while (top < fileHeight) {
+    const height = Math.min(sliceHeight, fileHeight - top);
+    slices.push({ height, index, top });
+    top += height;
+    index += 1;
+  }
+  return slices;
+};
+
+export const SCREENSHOT_PORTRAIT_ASPECT = 1.6;
+
+export const screenshotTileWidth = (fileWidth: number) =>
+  Math.min(fileWidth, SCREENSHOT_TILE_MAX_WIDTH);
+
+export const isPortraitScreenshot = (fileWidth: number, fileHeight: number) =>
+  fileWidth > 0 && fileHeight / fileWidth >= SCREENSHOT_PORTRAIT_ASPECT;
+
+export const screenshotSliceObjectPosition = (slice: ScreenshotSlice, fileHeight: number) => {
+  const overflow = fileHeight - slice.height;
+  if (overflow <= 0) return '0 0';
+  return `0 ${(slice.top / overflow) * 100}%`;
+};
+
+export const annotationInSlice = (
+  rect: Rect,
+  slice: ScreenshotSlice,
+  fileHeight: number,
+): Rect | undefined => {
+  if (fileHeight <= 0 || slice.height <= 0) return;
+
+  const top = rect.y * fileHeight;
+  const bottom = (rect.y + rect.height) * fileHeight;
+  const sliceBottom = slice.top + slice.height;
+  if (bottom <= slice.top || top >= sliceBottom) return;
+
+  const clippedTop = Math.max(top, slice.top);
+  const clippedBottom = Math.min(bottom, sliceBottom);
+  return {
+    height: (clippedBottom - clippedTop) / slice.height,
+    width: rect.width,
+    x: rect.x,
+    y: (clippedTop - slice.top) / slice.height,
+  };
+};


### PR DESCRIPTION
<!-- Brief and heads-up -->

Portrait acceptance screenshots were rendered at content width, so a phone capture (for example 1206×2622) became a ~1500px-tall strip and pushed the rest of the checklist off screen. Wide crops of a toolbar or header were also forced into a phone frame.

| Before | After |
| ------ | ----- |
| Phone screenshot fills the pane and is very tall | Portrait shots render at 280px and sit in a row with 12px gaps |
| Wide header crops treated as phone frames | Landscape / short crops stay full width and stack |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

How to test:

1. Open an acceptance whose checks attach **portrait** phone screenshots (no stored `fileWidth`/`fileHeight` is fine). Confirm each image is compact (~280px) and several shots in one check sit in a horizontal row with gaps.
2. Open an acceptance with **wide, short** crops (e.g. a collapsed/expanded header strip). Confirm they stay full-width and stacked, not squeezed into a phone frame.
3. A capture taller than two phone screens should split into screen-sized tiles.

#### 🔗 Related Issue

N/A — UI polish from acceptance review.