### PR TITLE
🐛 fix(agent-runtime): compress on window headroom and keep the recent tail

### DIFF
--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -3497,20 +3497,32 @@ export class AgentRuntimeService {
     stepIndex: number;
     tracingContextEngine?: (input: unknown, output: unknown) => void;
   }) {
-    const contextWindowTokens =
-      metadata?.modelRuntimeConfig?.model && metadata?.modelRuntimeConfig?.provider
-        ? await getModelPropertyWithFallback<number | undefined>(
+    const hasModelIdentity = Boolean(
+      metadata?.modelRuntimeConfig?.model && metadata?.modelRuntimeConfig?.provider,
+    );
+    // Both feed the compression threshold: the window is the budget, maxOutput
+    // sizes the room reserved for the summary the compression call emits.
+    const [contextWindowTokens, maxOutputTokens] = hasModelIdentity
+      ? await Promise.all([
+          getModelPropertyWithFallback<number | undefined>(
             metadata.modelRuntimeConfig.model,
             'contextWindowTokens',
             metadata.modelRuntimeConfig.provider,
-          )
-        : undefined;
+          ),
+          getModelPropertyWithFallback<number | undefined>(
+            metadata.modelRuntimeConfig.model,
+            'maxOutput',
+            metadata.modelRuntimeConfig.provider,
+          ),
+        ])
+      : [undefined, undefined];
 
     // Create Agent instance — use custom factory if provided, otherwise default to GeneralChatAgent
     const generalConfig = {
       agentConfig: metadata?.agentConfig,
       compressionConfig: {
         enabled: metadata?.agentConfig?.chatConfig?.enableContextCompression ?? true,
+        maxOutputToken: maxOutputTokens ?? undefined,
         maxWindowToken: contextWindowTokens ?? undefined,
       },
       dynamicInterventionAudits,

--- a/packages/agent-runtime/src/agents/GeneralChatAgent.ts
+++ b/packages/agent-runtime/src/agents/GeneralChatAgent.ts
@@ -25,6 +25,7 @@ import {
   type SubAgentResultPayload,
   type SubAgentsBatchResultPayload,
 } from '../types';
+import { getTailPreserveBudget } from '../utils/preserveTail';
 import { shouldCompress } from '../utils/tokenCounter';
 
 const TOOL_NOT_ALLOWED_CONTENT =
@@ -33,8 +34,6 @@ const TOOL_NOT_ALLOWED_REASON = 'tool_not_allowed';
 // Leave 35% of the model window for server-side context engineering (system
 // role, knowledge, memories, skills, etc.) and the model's completion. The
 // initial 50% threshold still supplies the lower side of the hysteresis band.
-const DEFAULT_RECOMPRESSION_THRESHOLD_RATIO = 0.65;
-
 /**
  * ChatAgent - The "Brain" of the chat agent
  *
@@ -542,15 +541,23 @@ export class GeneralChatAgent implements Agent {
    * makes one small tool result trigger another compression before the model can
    * act on it. Keep the initial threshold conservative, then allow the compressed
    * context to grow to a higher watermark before compressing it again.
+   *
+   * The watermark itself is resolved in `getCompressionThreshold`, which layers
+   * it over the headroom budget rather than substituting for it.
    */
-  private getCompressionThresholdRatio(messages: any[]): number | undefined {
-    const initialRatio = this.config.compressionConfig?.thresholdRatio;
-    if (!this.findExistingSummary(messages)) return initialRatio;
-
-    const configuredRecompressionRatio = this.config.compressionConfig?.recompressionThresholdRatio;
-    if (configuredRecompressionRatio !== undefined) return configuredRecompressionRatio;
-
-    return Math.max(initialRatio ?? 0, DEFAULT_RECOMPRESSION_THRESHOLD_RATIO);
+  private buildCompressionOptions(messages: any[], tools: any[] | undefined) {
+    return {
+      // Drives the recompression hysteresis inside `getCompressionThreshold`,
+      // where it is applied over the window's headroom budget instead of
+      // replacing it. Collapsing it to a ratio here (the previous shape) would
+      // drag a large window back down to 65% and undo the headroom budget.
+      hasExistingSummary: Boolean(this.findExistingSummary(messages)),
+      maxOutputToken: this.config.compressionConfig?.maxOutputToken,
+      maxWindowToken: this.config.compressionConfig?.maxWindowToken,
+      recompressionThresholdRatio: this.config.compressionConfig?.recompressionThresholdRatio,
+      thresholdRatio: this.config.compressionConfig?.thresholdRatio,
+      tools,
+    };
   }
 
   /**
@@ -569,11 +576,10 @@ export class GeneralChatAgent implements Agent {
     // executor strips all tools via buildStepToolDelta (deactivatedToolIds: ['*']),
     // so they must not count against the compression budget either — otherwise
     // we'd burn an extra summarization pass on tool tokens that won't be sent.
-    const compressionOptions = {
-      maxWindowToken: this.config.compressionConfig?.maxWindowToken,
-      thresholdRatio: this.getCompressionThresholdRatio(payloadWithAllowedToolNames.messages),
-      tools: state.forceFinish ? undefined : payloadWithAllowedToolNames.tools,
-    };
+    const compressionOptions = this.buildCompressionOptions(
+      payloadWithAllowedToolNames.messages,
+      state.forceFinish ? undefined : payloadWithAllowedToolNames.tools,
+    );
 
     if (compressionEnabled) {
       const messages = payloadWithAllowedToolNames.messages;
@@ -585,6 +591,7 @@ export class GeneralChatAgent implements Agent {
             currentTokenCount: compressionCheck.currentTokenCount,
             existingSummary: this.findExistingSummary(messages),
             messages,
+            preserveTailTokens: getTailPreserveBudget(compressionCheck.threshold),
           },
           type: 'compress_context',
         };
@@ -640,22 +647,23 @@ export class GeneralChatAgent implements Agent {
         const compressionEnabled = this.config.compressionConfig?.enabled ?? true; // Default to enabled
         // Mirror RuntimeExecutors.callLlm: force-finish steps ship without tools,
         // so they must not count against the compression budget here either.
-        const compressionOptions = {
-          maxWindowToken: this.config.compressionConfig?.maxWindowToken,
-          thresholdRatio: this.getCompressionThresholdRatio(state.messages),
-          tools: state.forceFinish ? undefined : this.getTools(state),
-        };
+        const compressionOptions = this.buildCompressionOptions(
+          state.messages,
+          state.forceFinish ? undefined : this.getTools(state),
+        );
 
         if (compressionEnabled) {
           const compressionCheck = shouldCompress(state.messages, compressionOptions);
 
           if (compressionCheck.needsCompression) {
-            // Context exceeds threshold, compress ALL messages into a single summary
+            // Context exceeds threshold — summarize history, keeping the most
+            // recent messages verbatim beside the summary.
             return {
               payload: {
                 currentTokenCount: compressionCheck.currentTokenCount,
                 existingSummary: this.findExistingSummary(state.messages),
                 messages: state.messages,
+                preserveTailTokens: getTailPreserveBudget(compressionCheck.threshold),
               },
               type: 'compress_context',
             } as AgentInstructionCompressContext;

--- a/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
+++ b/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
@@ -74,6 +74,7 @@ describe('GeneralChatAgent', () => {
       currentTokenCount: expect.any(Number),
       existingSummary: undefined,
       messages,
+      preserveTailTokens: expect.any(Number),
     },
   });
 
@@ -219,6 +220,7 @@ describe('GeneralChatAgent', () => {
           currentTokenCount: expect.any(Number),
           existingSummary: 'Outdated decisions\n\nEarlier decisions and constraints',
           messages: state.messages,
+          preserveTailTokens: expect.any(Number),
         },
         type: 'compress_context',
       });
@@ -1038,6 +1040,7 @@ describe('GeneralChatAgent', () => {
           currentTokenCount: expect.any(Number),
           existingSummary: 'Existing summary',
           messages: state.messages,
+          preserveTailTokens: expect.any(Number),
         },
         type: 'compress_context',
       });

--- a/packages/agent-runtime/src/executors/compressContext.test.ts
+++ b/packages/agent-runtime/src/executors/compressContext.test.ts
@@ -62,10 +62,14 @@ const createState = (overrides?: Partial<AgentState>): AgentState => ({
   ...overrides,
 });
 
-const createInstruction = (messages: any[]): AgentInstructionCompressContext => ({
+const createInstruction = (
+  messages: any[],
+  preserveTailTokens?: number,
+): AgentInstructionCompressContext => ({
   payload: {
     currentTokenCount: 5000,
     messages,
+    preserveTailTokens,
   },
   type: 'compress_context',
 });
@@ -278,6 +282,158 @@ describe('compressContext executor', () => {
       { content: 'historical summary', id: 'group-123', role: 'compressedGroup' },
       activeContract,
     ]);
+  });
+
+  /** ~1 token per 2 chars under tokenx — big enough to sit outside the tail budget. */
+  const bulk = (tokens: number) => 'a '.repeat(tokens * 2);
+
+  // Compressing mid-loop used to keep only the latest user turn, so an agent
+  // that compacted between tool calls lost the results it was working from and
+  // went back to re-reading the same files. The tail budget keeps the whole
+  // trailing round verbatim beside the summary.
+  it('keeps a whole trailing tool round out of the compressed group', async () => {
+    const history = [
+      { content: bulk(5000), id: 'msg-uold', role: 'user' },
+      { content: bulk(5000), id: 'msg-aold', role: 'assistant' },
+    ];
+    const tail = [
+      { content: 'latest instruction', id: 'msg-ulatest', role: 'user' },
+      { content: 'read the config', id: 'msg-a1', role: 'assistant' },
+      { content: 'file contents', id: 'msg-t1', role: 'tool', tool_call_id: 'call-1' },
+      { content: 'now editing', id: 'msg-a2', role: 'assistant' },
+    ];
+    const rawRows = [...history, ...tail];
+
+    messagesQuery.mockResolvedValue(rawRows);
+    compressionCreateGroup.mockResolvedValue({
+      messageGroupId: 'group-123',
+      messagesToSummarize: history,
+    });
+    llmStream.mockResolvedValue({ content: 'summary' });
+    compressionFinalizeGroup.mockResolvedValue({
+      messages: [{ content: 'summary', id: 'group-123', role: 'compressedGroup' }, ...tail],
+    });
+
+    const state = createState({ messages: rawRows as any });
+    const result = await compressContext(host)(createInstruction(state.messages, 2_000), state);
+
+    // Only the pre-tail history is folded into the group.
+    expect(compressionCreateGroup).toHaveBeenCalledWith(
+      expect.objectContaining({ messageIds: ['msg-uold', 'msg-aold'] }),
+    );
+    expect(result.newState.messages.map((m: any) => m.id)).toEqual([
+      'group-123',
+      'msg-ulatest',
+      'msg-a1',
+      'msg-t1',
+      'msg-a2',
+    ]);
+  });
+
+  // Server runs rehydrate `state.messages` through conversation-flow, so a tool
+  // chain arrives as ONE virtual `assistantGroup` whose id is only its first
+  // assistant, while this executor filters raw DB rows. Without expanding the
+  // folded child ids, the child assistants and tool rows are compressed away
+  // and the preserved round is gutted — the opposite of what the tail is for.
+  it('protects folded assistantGroup children from the compression group', async () => {
+    const history = [
+      { content: bulk(5000), id: 'msg-uold', role: 'user' },
+      { content: bulk(5000), id: 'msg-aold', role: 'assistant' },
+    ];
+    const latestUser = { content: 'latest instruction', id: 'msg-ulatest', role: 'user' };
+    const foldedGroup = {
+      children: [
+        {
+          content: '',
+          id: 'msg-a1',
+          tools: [{ id: 'call-1', result: { id: 'msg-t1' }, result_msg_id: 'msg-t1' }],
+        },
+        { content: 'now editing', id: 'msg-a2' },
+      ],
+      content: '',
+      // The wrapper inherits the FIRST assistant's id.
+      id: 'msg-a1',
+      role: 'assistantGroup',
+    };
+    const rawTail = [
+      latestUser,
+      { content: '', id: 'msg-a1', role: 'assistant' },
+      { content: 'file contents', id: 'msg-t1', role: 'tool', tool_call_id: 'call-1' },
+      { content: 'now editing', id: 'msg-a2', role: 'assistant' },
+    ];
+
+    messagesQuery.mockResolvedValue([...history, ...rawTail]);
+    compressionCreateGroup.mockResolvedValue({
+      messageGroupId: 'group-123',
+      messagesToSummarize: history,
+    });
+    llmStream.mockResolvedValue({ content: 'summary' });
+    compressionFinalizeGroup.mockResolvedValue({
+      messages: [{ content: 'summary', id: 'group-123', role: 'compressedGroup' }, ...rawTail],
+    });
+
+    const state = createState({ messages: [...history, latestUser, foldedGroup] as any });
+    const result = await compressContext(host)(createInstruction(state.messages, 2_000), state);
+
+    // msg-a1 / msg-t1 / msg-a2 all belong to the preserved round.
+    expect(compressionCreateGroup).toHaveBeenCalledWith(
+      expect.objectContaining({ messageIds: ['msg-uold', 'msg-aold'] }),
+    );
+    expect(result.newState.messages.map((m: any) => m.id)).toEqual([
+      'group-123',
+      'msg-ulatest',
+      'msg-a1',
+      'msg-t1',
+      'msg-a2',
+    ]);
+  });
+
+  // `tasks` / `agentCouncil` / `compare` wrappers carry a SYNTHETIC id
+  // (`tasks-<parent>-<childIds>`) that matches no persisted row, so a
+  // top-level id check re-appends the wrapper on top of the raw child rows the
+  // DB already returned and the next LLM call sees the task output twice.
+  it('does not re-append a synthetic container wrapper over its raw children', async () => {
+    const history = [
+      { content: bulk(5000), id: 'msg-uold', role: 'user' },
+      { content: bulk(5000), id: 'msg-aold', role: 'assistant' },
+    ];
+    const latestUser = { content: 'latest instruction', id: 'msg-ulatest', role: 'user' };
+    const tasksWrapper = {
+      content: '',
+      id: 'tasks-msg-parent-msg-task1,msg-task2',
+      role: 'tasks',
+      tasks: [
+        { content: 'task one', id: 'msg-task1', role: 'task' },
+        { content: 'task two', id: 'msg-task2', role: 'task' },
+      ],
+    };
+    const rawTail = [
+      latestUser,
+      { content: 'task one', id: 'msg-task1', role: 'task' },
+      { content: 'task two', id: 'msg-task2', role: 'task' },
+    ];
+
+    messagesQuery.mockResolvedValue([...history, ...rawTail]);
+    compressionCreateGroup.mockResolvedValue({
+      messageGroupId: 'group-123',
+      messagesToSummarize: history,
+    });
+    llmStream.mockResolvedValue({ content: 'summary' });
+    compressionFinalizeGroup.mockResolvedValue({
+      messages: [{ content: 'summary', id: 'group-123', role: 'compressedGroup' }, ...rawTail],
+    });
+
+    const state = createState({ messages: [...history, latestUser, tasksWrapper] as any });
+    const result = await compressContext(host)(createInstruction(state.messages, 2_000), state);
+
+    // The children survive exactly once, as raw rows — no duplicated wrapper.
+    expect(result.newState.messages.map((m: any) => m.id)).toEqual([
+      'group-123',
+      'msg-ulatest',
+      'msg-task1',
+      'msg-task2',
+    ]);
+    expect(result.newState.messages.some((m: any) => m.role === 'tasks')).toBe(false);
   });
 
   it('skips without compression side effects when topic context is missing', async () => {

--- a/packages/agent-runtime/src/executors/compressContext.ts
+++ b/packages/agent-runtime/src/executors/compressContext.ts
@@ -7,6 +7,7 @@ import type {
   GeneralAgentCompressionResultPayload,
   InstructionExecutor,
 } from '../types';
+import { collectPreservedMessageIds, selectPreservedTail } from '../utils/preserveTail';
 
 const getErrorMessage = (error: unknown): string => {
   if (error instanceof Error && error.message) return error.message;
@@ -42,7 +43,7 @@ export const compressContext =
   (host: AgentRuntimeHost): InstructionExecutor =>
   async (instruction, state) => {
     const { payload } = instruction as Extract<AgentInstruction, { type: 'compress_context' }>;
-    const { messages, currentTokenCount, existingSummary } = payload;
+    const { messages, currentTokenCount, existingSummary, preserveTailTokens } = payload;
     const { operation, transports } = host;
     const { operationId, stepIndex, userId } = operation;
     const events: AgentEvent[] = [];
@@ -54,18 +55,33 @@ export const compressContext =
     const threadId = operation.threadId ?? state.metadata?.threadId;
     const compression = transports.compression;
     const llm = transports.llm;
-    // The latest user turn is the active contract even after assistant/tool steps have followed it.
-    // Keep it verbatim and re-inject it after the summary so compression can never demote a Task's
-    // Current Work instruction into historical prose or reactivate an older objective.
+    // Preservation is the UNION of two independent rules:
+    //
+    // 1. The latest user turn is the active contract even after assistant/tool
+    //    steps have followed it — keeping it verbatim stops compression from
+    //    demoting a Task's Current Work instruction into historical prose or
+    //    reactivating an older objective. It is found by scanning backwards, so
+    //    it may sit BEFORE the trailing slice.
+    // 2. The trailing slice within `preserveTailTokens` — without it a
+    //    mid-loop compaction drops the tool results and edits the model is
+    //    actively working from, and it goes back to re-reading the same files.
+    //
+    // Neither subsumes the other, and the union is not necessarily a contiguous
+    // suffix, so membership (not slicing) decides what gets compressed.
+    const preservedTail = selectPreservedTail(messages, preserveTailTokens ?? 0);
     const latestUserMessage =
       messages.length > 1 ? messages.findLast((message) => message.role === 'user') : undefined;
-    const preservedMessages = latestUserMessage ? [latestUserMessage] : [];
-    const preservedMessageIds = new Set(
-      preservedMessages.map((message) => message.id).filter((id): id is string => Boolean(id)),
-    );
-    const messagesToCompress = latestUserMessage
-      ? messages.filter((message) => message !== latestUserMessage)
-      : messages;
+
+    const preservedSet = new Set(preservedTail);
+    if (latestUserMessage) preservedSet.add(latestUserMessage);
+
+    // Filter the source array so both lists keep their original order.
+    const preservedMessages = messages.filter((message) => preservedSet.has(message));
+    const messagesToCompress = messages.filter((message) => !preservedSet.has(message));
+    // Expands folded containers: on the server path a preserved tool round is
+    // one virtual `assistantGroup`, and its child rows must be protected from
+    // the raw-row filter below by their own ids, not the wrapper's.
+    const preservedMessageIds = collectPreservedMessageIds(preservedMessages);
     const createNextContext = ({
       groupId,
       parentMessageId,
@@ -229,17 +245,24 @@ export const compressContext =
         compressionResult.messagesToSummarize;
       const compressedMessages = [...compressedMessagesBase];
 
+      // Persisted rows already represented in the compressed list. Compared on
+      // expanded ids because a container's synthetic wrapper id (`tasks-*`,
+      // `agentCouncil-*`, `compare-*`) matches no row: a top-level id check
+      // would re-append the wrapper on top of the raw children the DB just
+      // returned, and the next LLM call would see that task / council output
+      // twice. An `assistantGroup` dedupes either way — its id is its first
+      // assistant's — so this keeps every container on the same rule.
+      const presentRowIds = collectPreservedMessageIds(compressedMessages);
+
       for (const preservedMessage of preservedMessages) {
-        if (
-          !compressedMessages.some(
-            (message) =>
-              message === preservedMessage ||
-              (Boolean(message.id) &&
-                Boolean(preservedMessage.id) &&
-                message.id === preservedMessage.id),
-          )
-        ) {
+        const rowIds = collectPreservedMessageIds([preservedMessage]);
+        const alreadyPresent =
+          compressedMessages.includes(preservedMessage) ||
+          [...rowIds].some((id) => presentRowIds.has(id));
+
+        if (!alreadyPresent) {
           compressedMessages.push(preservedMessage);
+          for (const id of rowIds) presentRowIds.add(id);
         }
       }
 

--- a/packages/agent-runtime/src/types/generalAgent.ts
+++ b/packages/agent-runtime/src/types/generalAgent.ts
@@ -90,11 +90,23 @@ export interface GeneralAgentConfig {
   compressionConfig?: {
     /** Whether context compression is enabled (default: true) */
     enabled?: boolean;
+    /**
+     * Model's max output token count. Reserves room for the summary the
+     * compression call itself emits (capped at 20k).
+     */
+    maxOutputToken?: number;
     /** Model's max context window token count (default: 128k) */
     maxWindowToken?: number;
-    /** Explicit threshold after a compression summary exists; default 0.65 reserves prompt headroom. */
+    /**
+     * Explicit recompression watermark once a summary exists. Defaults to
+     * `DEFAULT_RECOMPRESSION_THRESHOLD_RATIO` (0.65). Can only raise the
+     * threshold, never lower it below the window's headroom budget.
+     */
     recompressionThresholdRatio?: number;
-    /** Threshold ratio for triggering compression (default: 0.5) */
+    /**
+     * Explicit threshold ratio override. Unset by default — the threshold is
+     * derived from the window's headroom instead.
+     */
     thresholdRatio?: number;
   };
   /**

--- a/packages/agent-runtime/src/types/instruction.ts
+++ b/packages/agent-runtime/src/types/instruction.ts
@@ -384,6 +384,11 @@ export interface AgentInstructionCompressContext extends AgentInstructionBase {
     existingSummary?: string;
     /** Messages to compress */
     messages: any[];
+    /**
+     * Token budget for the trailing messages kept verbatim beside the summary.
+     * Omitted / `0` preserves only a trailing user message.
+     */
+    preserveTailTokens?: number;
   };
   type: 'compress_context';
 }

--- a/packages/agent-runtime/src/utils/index.ts
+++ b/packages/agent-runtime/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './llmErrorClassifier';
 export * from './messageSelectors';
+export * from './preserveTail';
 export * from './replay';
 export * from './runtimeRetry';
 export * from './status';

--- a/packages/agent-runtime/src/utils/preserveTail.test.ts
+++ b/packages/agent-runtime/src/utils/preserveTail.test.ts
@@ -1,0 +1,189 @@
+import type { UIChatMessage } from '@lobechat/types';
+import { describe, expect, it } from 'vitest';
+
+import {
+  collectPreservedMessageIds,
+  DEFAULT_TAIL_PRESERVE_RATIO,
+  getTailPreserveBudget,
+  MAX_TAIL_PRESERVE_TOKENS,
+  selectPreservedTail,
+} from './preserveTail';
+
+const mkMsg = (id: string, role: UIChatMessage['role'], content = ''): UIChatMessage =>
+  ({ content, createdAt: 0, id, role, updatedAt: 0 }) as UIChatMessage;
+
+/** ~1 token per 4 chars of ASCII under tokenx. */
+const filler = (tokens: number) => 'a '.repeat(tokens * 2);
+
+describe('getTailPreserveBudget', () => {
+  it('should take a fraction of the threshold', () => {
+    expect(getTailPreserveBudget(100_000)).toBe(100_000 * DEFAULT_TAIL_PRESERVE_RATIO);
+  });
+
+  it('should cap the tail so huge windows do not carry raw history forever', () => {
+    // 1M window -> 1.015M threshold -> 203k at the raw ratio, capped to 32k
+    expect(getTailPreserveBudget(1_015_576)).toBe(MAX_TAIL_PRESERVE_TOKENS);
+  });
+
+  it('should accept a ratio override', () => {
+    expect(getTailPreserveBudget(100_000, 0.1)).toBe(10_000);
+  });
+});
+
+describe('selectPreservedTail', () => {
+  it('should return nothing when there is at most one message', () => {
+    expect(selectPreservedTail([], 10_000)).toEqual([]);
+    expect(selectPreservedTail([mkMsg('a', 'user')], 10_000)).toEqual([]);
+  });
+
+  // Guards the pre-change contract for callers that do not pass a budget.
+  it('should fall back to the trailing user message with no budget', () => {
+    const messages = [mkMsg('a', 'user'), mkMsg('b', 'assistant'), mkMsg('c', 'user')];
+
+    expect(selectPreservedTail(messages, 0).map((m) => m.id)).toEqual(['c']);
+  });
+
+  it('should preserve nothing with no budget when the tail is not a user message', () => {
+    const messages = [mkMsg('a', 'user'), mkMsg('b', 'assistant')];
+
+    expect(selectPreservedTail(messages, 0)).toEqual([]);
+  });
+
+  it('should keep the longest suffix that fits the budget', () => {
+    const messages = [
+      mkMsg('a', 'user', filler(5_000)),
+      mkMsg('b', 'assistant', filler(5_000)),
+      mkMsg('c', 'user', filler(400)),
+      mkMsg('d', 'assistant', filler(400)),
+    ];
+
+    // 800 tokens of tail fits a 2k budget; adding 'b' (5k) would not.
+    expect(selectPreservedTail(messages, 2_000).map((m) => m.id)).toEqual(['c', 'd']);
+  });
+
+  // Without this the model loses the tool results it is mid-way through using,
+  // which is what sends it back to re-reading the same files after a compaction.
+  it('should keep a whole trailing tool round rather than only the last message', () => {
+    const messages = [
+      mkMsg('old', 'user', filler(5_000)),
+      mkMsg('a1', 'assistant', filler(100)),
+      mkMsg('t1', 'tool', filler(100)),
+      mkMsg('a2', 'assistant', filler(100)),
+    ];
+
+    expect(selectPreservedTail(messages, 2_000).map((m) => m.id)).toEqual(['a1', 't1', 'a2']);
+  });
+
+  // A `tool` message whose assistant tool_calls were summarized away is an
+  // orphaned pairing that most providers reject outright.
+  it('should never start the preserved segment on a tool message', () => {
+    const messages = [
+      mkMsg('u', 'user', filler(5_000)),
+      mkMsg('a1', 'assistant', filler(5_000)),
+      mkMsg('t1', 'tool', filler(100)),
+      mkMsg('t2', 'tool', filler(100)),
+      mkMsg('a2', 'assistant', filler(100)),
+    ];
+
+    // Budget fits t1/t2/a2 but not a1 — the orphaned results must be dropped.
+    const tail = selectPreservedTail(messages, 1_000);
+
+    expect(tail.map((m) => m.id)).toEqual(['a2']);
+    expect(tail[0]?.role).not.toBe('tool');
+  });
+
+  it('should always leave at least one message to compress', () => {
+    const messages = [mkMsg('a', 'user', 'hi'), mkMsg('b', 'assistant', 'yo')];
+
+    const tail = selectPreservedTail(messages, 1_000_000);
+
+    expect(tail.map((m) => m.id)).toEqual(['b']);
+    expect(tail.length).toBeLessThan(messages.length);
+  });
+
+  // The message that triggered this turn must survive even when it alone is
+  // bigger than the whole tail budget.
+  it('should keep an oversized trailing user message anyway', () => {
+    const messages = [
+      mkMsg('a', 'user', filler(100)),
+      mkMsg('b', 'assistant', filler(100)),
+      mkMsg('c', 'user', filler(50_000)),
+    ];
+
+    expect(selectPreservedTail(messages, 1_000).map((m) => m.id)).toEqual(['c']);
+  });
+
+  it('should return a contiguous suffix of the input', () => {
+    const messages = [
+      mkMsg('a', 'user', filler(5_000)),
+      mkMsg('b', 'assistant', filler(200)),
+      mkMsg('c', 'user', filler(200)),
+    ];
+
+    const tail = selectPreservedTail(messages, 2_000);
+
+    expect(messages.slice(messages.length - tail.length)).toEqual(tail);
+  });
+});
+
+describe('collectPreservedMessageIds', () => {
+  it('should collect plain message ids', () => {
+    const ids = collectPreservedMessageIds([mkMsg('a', 'user'), mkMsg('b', 'assistant')]);
+
+    expect([...ids].sort()).toEqual(['a', 'b']);
+  });
+
+  // The compression executor filters raw DB rows, but the server hands it a
+  // conversation-flow projection where a whole tool chain is one wrapper whose
+  // id is only its first assistant.
+  it('should expand folded assistantGroup children and their tool rows', () => {
+    const folded = {
+      children: [
+        { content: '', id: 'msg-a1', tools: [{ id: 'call-1', result_msg_id: 'msg-t1' }] },
+        { content: '', id: 'msg-a2', tools: [{ id: 'call-2', result_msg_id: 'msg-t2' }] },
+      ],
+      content: '',
+      id: 'msg-a1',
+      role: 'assistantGroup',
+    } as unknown as UIChatMessage;
+
+    const ids = collectPreservedMessageIds([folded]);
+
+    expect([...ids].sort()).toEqual(['msg-a1', 'msg-a2', 'msg-t1', 'msg-t2']);
+  });
+
+  it('should expand supervisor, agentCouncil, tasks and compare containers', () => {
+    const messages = [
+      { children: [{ id: 'sup-child' }], id: 'sup', role: 'supervisor' },
+      { id: 'council-wrapper', members: [{ id: 'member-1' }], role: 'agentCouncil' },
+      { id: 'tasks-wrapper', role: 'tasks', tasks: [{ id: 'task-1' }] },
+      { columns: [[{ id: 'col-1' }], [{ id: 'col-2' }]], id: 'cmp', role: 'compare' },
+    ] as unknown as UIChatMessage[];
+
+    const ids = collectPreservedMessageIds(messages);
+
+    for (const id of ['sup-child', 'member-1', 'task-1', 'col-1', 'col-2']) {
+      expect(ids.has(id)).toBe(true);
+    }
+  });
+
+  it('should recurse into an in-bubble council block', () => {
+    const folded = {
+      children: [{ council: [{ id: 'broadcast-member' }], id: 'council-msg-a1' }],
+      id: 'msg-a1',
+      role: 'assistantGroup',
+    } as unknown as UIChatMessage;
+
+    expect(collectPreservedMessageIds([folded]).has('broadcast-member')).toBe(true);
+  });
+
+  it('should tolerate missing ids and non-array children', () => {
+    const messages = [
+      { children: undefined, role: 'assistantGroup' },
+      { id: '', role: 'user' },
+      { id: 'real', role: 'user', tools: [{ id: 'call-x' }] },
+    ] as unknown as UIChatMessage[];
+
+    expect([...collectPreservedMessageIds(messages)]).toEqual(['real']);
+  });
+});

--- a/packages/agent-runtime/src/utils/preserveTail.ts
+++ b/packages/agent-runtime/src/utils/preserveTail.ts
@@ -1,0 +1,127 @@
+import { countContextTokens } from '@lobechat/context-engine';
+import type { UIChatMessage } from '@lobechat/types';
+
+/**
+ * Fraction of the compression threshold the preserved tail may occupy.
+ *
+ * Small enough that compression still frees the bulk of the window, large
+ * enough that the model keeps the step it was in the middle of — the tool
+ * results and edits it just produced, which a prose summary reliably loses.
+ */
+export const DEFAULT_TAIL_PRESERVE_RATIO = 0.2;
+
+/**
+ * Absolute cap on the preserved tail. Without it a 1M-token window would carry
+ * ~180k of raw history past every compaction, which defeats the point.
+ */
+export const MAX_TAIL_PRESERVE_TOKENS = 32_000;
+
+/**
+ * Token budget for the preserved tail, derived from the compression threshold.
+ */
+export const getTailPreserveBudget = (
+  threshold: number,
+  ratio: number = DEFAULT_TAIL_PRESERVE_RATIO,
+): number => Math.min(Math.floor(threshold * ratio), MAX_TAIL_PRESERVE_TOKENS);
+
+/**
+ * The message that triggered this turn must never be summarized away, even
+ * when it alone blows the budget.
+ */
+const lastUserMessageOnly = (messages: UIChatMessage[]): UIChatMessage[] => {
+  const last = messages.at(-1);
+  return last?.role === 'user' ? [last] : [];
+};
+
+/**
+ * Pick the longest suffix of `messages` that fits in `maxTokens`.
+ *
+ * Compression replaces history with a summary; whatever this returns is kept
+ * verbatim alongside it. Preserving the tail is what lets the model continue
+ * the step it was in rather than restarting from a paraphrase — without it,
+ * an agent that compresses mid-loop loses every tool result it just gathered
+ * and goes back to re-reading the same files.
+ *
+ * Two invariants:
+ * - at least one message is always left to compress, so the pass is never a
+ *   no-op that re-triggers on the next step;
+ * - the segment never *starts* on a `tool` message, whose originating
+ *   assistant `tool_calls` would have been summarized away — most providers
+ *   reject that orphaned pairing.
+ */
+export function selectPreservedTail(messages: UIChatMessage[], maxTokens: number): UIChatMessage[] {
+  if (messages.length <= 1) return [];
+  if (maxTokens <= 0) return lastUserMessageOnly(messages);
+
+  const { messages: breakdown } = countContextTokens({ messages });
+
+  // Walk backwards while the suffix still fits. `i >= 1` keeps index 0 out of
+  // the tail so there is always something left to summarize.
+  let start = messages.length;
+  let used = 0;
+  for (let i = messages.length - 1; i >= 1; i--) {
+    const cost = breakdown[i]?.total ?? 0;
+    if (used + cost > maxTokens) break;
+    used += cost;
+    start = i;
+  }
+
+  // Drop orphaned tool results at the head of the segment.
+  while (start < messages.length && messages[start]?.role === 'tool') start++;
+
+  const tail = messages.slice(start);
+
+  return tail.length > 0 ? tail : lastUserMessageOnly(messages);
+}
+
+/**
+ * Container roles whose real conversation rows are folded into a child array.
+ * `assistantGroup` / `supervisor` use `children`, `agentCouncil` uses `members`,
+ * `tasks` / `groupTasks` use `tasks`. `compare` nests one level deeper.
+ */
+const CONTAINER_CHILD_KEYS = ['children', 'members', 'tasks', 'council'] as const;
+
+const collectRowIds = (node: unknown, into: Set<string>): void => {
+  if (!node || typeof node !== 'object') return;
+  const record = node as Record<string, unknown>;
+
+  if (typeof record.id === 'string' && record.id) into.add(record.id);
+
+  // A folded tool entry carries the id of its own persisted `tool` row.
+  if (Array.isArray(record.tools)) {
+    for (const tool of record.tools) {
+      const resultId = (tool as { result_msg_id?: unknown })?.result_msg_id;
+      if (typeof resultId === 'string' && resultId) into.add(resultId);
+    }
+  }
+
+  for (const key of CONTAINER_CHILD_KEYS) {
+    const children = record[key];
+    if (Array.isArray(children)) for (const child of children) collectRowIds(child, into);
+  }
+
+  // `compare` holds Message[][]
+  if (Array.isArray(record.columns)) {
+    for (const column of record.columns) {
+      if (Array.isArray(column)) for (const entry of column) collectRowIds(entry, into);
+    }
+  }
+};
+
+/**
+ * Every persisted row id the preserved messages stand for.
+ *
+ * On the server path `state.messages` is a conversation-flow projection, so a
+ * whole tool chain arrives as one virtual `assistantGroup` whose `id` is just
+ * its *first* assistant — the child assistants and tool rows live in
+ * `children[]`. The compression executor filters raw DB rows, so taking only
+ * top-level `message.id` would leave every folded child unprotected and fold
+ * the exact tool round the tail preservation is meant to keep. Synthetic
+ * wrapper ids (`tasks`, `agentCouncil`, `council-*`) match no row and are
+ * harmless to include.
+ */
+export function collectPreservedMessageIds(messages: UIChatMessage[]): Set<string> {
+  const ids = new Set<string>();
+  for (const message of messages) collectRowIds(message, ids);
+  return ids;
+}

--- a/packages/agent-runtime/src/utils/tokenCounter.test.ts
+++ b/packages/agent-runtime/src/utils/tokenCounter.test.ts
@@ -2,9 +2,12 @@ import type { UIChatMessage } from '@lobechat/types';
 import { describe, expect, it } from 'vitest';
 
 import {
+  COMPRESSION_BUFFER_TOKENS,
   DEFAULT_MAX_CONTEXT,
-  DEFAULT_THRESHOLD_RATIO,
+  DEFAULT_RECOMPRESSION_THRESHOLD_RATIO,
   getCompressionThreshold,
+  MAX_OUTPUT_RESERVE_TOKENS,
+  MIN_THRESHOLD_RATIO,
   shouldCompress,
 } from './tokenCounter';
 
@@ -20,28 +23,129 @@ const mkMsg = (m: Partial<UIChatMessage> & { role: UIChatMessage['role'] }): UIC
 
 describe('tokenCounter', () => {
   describe('getCompressionThreshold', () => {
-    it('should use default values', () => {
+    it('should reserve output room + buffer from the default window', () => {
       const threshold = getCompressionThreshold();
-      expect(threshold).toBe(Math.floor(DEFAULT_MAX_CONTEXT * DEFAULT_THRESHOLD_RATIO));
-      expect(threshold).toBe(64_000); // 128k * 0.5
+
+      // 128k - min(unknown, 20k) - 13k = 95k
+      expect(threshold).toBe(
+        DEFAULT_MAX_CONTEXT - MAX_OUTPUT_RESERVE_TOKENS - COMPRESSION_BUFFER_TOKENS,
+      );
+      expect(threshold).toBe(95_000);
     });
 
-    it('should use custom maxWindowToken', () => {
-      const threshold = getCompressionThreshold({ maxWindowToken: 200_000 });
-      expect(threshold).toBe(100_000); // 200k * 0.5
+    it('should scale with the window rather than a flat fraction of it', () => {
+      expect(getCompressionThreshold({ maxWindowToken: 200_000 })).toBe(167_000);
+      expect(getCompressionThreshold({ maxWindowToken: 1_048_576 })).toBe(1_015_576);
     });
 
-    it('should use custom thresholdRatio', () => {
-      const threshold = getCompressionThreshold({ thresholdRatio: 0.5 });
-      expect(threshold).toBe(64_000); // 128k * 0.5
-    });
-
-    it('should use both custom values', () => {
+    // The regression this exists for: doubao-seed-1.6 has a 256k window, and the
+    // old `window x 0.5` threshold summarized the entire history at ~102k raw
+    // tokens (128k adjusted) - less than half way through the window.
+    it('should let a 256k window run to ~87% before compressing', () => {
       const threshold = getCompressionThreshold({
-        maxWindowToken: 100_000,
-        thresholdRatio: 0.8,
+        maxOutputToken: 32_000,
+        maxWindowToken: 256_000,
       });
-      expect(threshold).toBe(80_000); // 100k * 0.8
+
+      // 256k - min(32k, 20k) - 13k = 223k, vs 128k under the old ratio
+      expect(threshold).toBe(223_000);
+      expect(threshold / 256_000).toBeGreaterThan(0.85);
+    });
+
+    it('should reserve only what a low-maxOutput model can actually emit', () => {
+      // maxOutput below the 20k cap reserves the real number, freeing the rest
+      expect(getCompressionThreshold({ maxOutputToken: 4_096, maxWindowToken: 128_000 })).toBe(
+        110_904,
+      );
+    });
+
+    it('should cap the reserve for models with huge maxOutput', () => {
+      // 128k maxOutput must not eat the entire window
+      expect(getCompressionThreshold({ maxOutputToken: 128_000, maxWindowToken: 256_000 })).toBe(
+        223_000,
+      );
+    });
+
+    // A non-positive threshold reads as "always compress" and loops forever.
+    it('should floor small windows instead of going non-positive', () => {
+      expect(getCompressionThreshold({ maxWindowToken: 32_000 })).toBe(
+        Math.floor(32_000 * MIN_THRESHOLD_RATIO),
+      );
+      expect(getCompressionThreshold({ maxWindowToken: 8_000 })).toBe(4_000);
+      expect(getCompressionThreshold({ maxWindowToken: 8_000 })).toBeGreaterThan(0);
+    });
+
+    it('should honour an explicit thresholdRatio override exactly', () => {
+      expect(getCompressionThreshold({ thresholdRatio: 0.5 })).toBe(64_000); // 128k * 0.5
+      expect(getCompressionThreshold({ maxWindowToken: 100_000, thresholdRatio: 0.8 })).toBe(
+        80_000,
+      );
+    });
+
+    it('should let an explicit ratio bypass the headroom floor', () => {
+      // Explicit means explicit - callers opting into early compression are not
+      // second-guessed by MIN_THRESHOLD_RATIO.
+      expect(getCompressionThreshold({ maxWindowToken: 100_000, thresholdRatio: 0.1 })).toBe(
+        10_000,
+      );
+    });
+
+    // Hysteresis (#18626): a freshly compressed context sits just below the
+    // ordinary threshold, so reusing it lets one small tool result trigger
+    // another compression before the model can act on the summary.
+    describe('recompression hysteresis', () => {
+      it('should raise a ratio-configured threshold once a summary exists', () => {
+        const initial = getCompressionThreshold({ maxWindowToken: 64_000, thresholdRatio: 0.5 });
+        const after = getCompressionThreshold({
+          hasExistingSummary: true,
+          maxWindowToken: 64_000,
+          thresholdRatio: 0.5,
+        });
+
+        expect(initial).toBe(32_000);
+        expect(after).toBe(64_000 * DEFAULT_RECOMPRESSION_THRESHOLD_RATIO);
+        expect(after).toBeGreaterThan(initial);
+      });
+
+      // The whole point of the headroom budget is that a 256k model runs to
+      // ~87%. A 0.65 watermark would drag it back to 166k, so the default
+      // hysteresis may only ever push the threshold later.
+      it('should never drag a headroom threshold down to the watermark', () => {
+        const options = { maxOutputToken: 32_000, maxWindowToken: 256_000 };
+
+        expect(getCompressionThreshold(options)).toBe(223_000);
+        expect(getCompressionThreshold({ ...options, hasExistingSummary: true })).toBe(223_000);
+      });
+
+      it('should not apply the watermark before any summary exists', () => {
+        expect(getCompressionThreshold({ maxWindowToken: 64_000, thresholdRatio: 0.5 })).toBe(
+          32_000,
+        );
+      });
+
+      // Explicit config is an override, not a clamp — callers use it to
+      // compress a summarized context EARLIER than the initial threshold.
+      it('should honour an explicit watermark below the initial threshold', () => {
+        expect(
+          getCompressionThreshold({
+            hasExistingSummary: true,
+            maxWindowToken: 64_000,
+            recompressionThresholdRatio: 0.6,
+            thresholdRatio: 0.8,
+          }),
+        ).toBe(38_400);
+      });
+
+      it('should honour an explicit watermark above the headroom budget', () => {
+        expect(
+          getCompressionThreshold({
+            hasExistingSummary: true,
+            maxOutputToken: 32_000,
+            maxWindowToken: 256_000,
+            recompressionThresholdRatio: 0.95,
+          }),
+        ).toBe(243_200);
+      });
     });
 
     it('should floor the result', () => {
@@ -59,20 +163,20 @@ describe('tokenCounter', () => {
 
       expect(result.needsCompression).toBe(false);
       expect(result.currentTokenCount).toBeGreaterThan(0);
-      expect(result.threshold).toBe(64_000); // 128k * 0.5
+      expect(result.threshold).toBe(95_000); // 128k - 20k - 13k
     });
 
     it('should return needsCompression=true when over threshold', () => {
       const result = shouldCompress([
         mkMsg({
           role: 'assistant',
-          metadata: { usage: { totalOutputTokens: 70_000 } as any } as any,
+          metadata: { usage: { totalOutputTokens: 90_000 } as any } as any,
         }),
       ]);
 
       expect(result.needsCompression).toBe(true);
-      expect(result.currentTokenCount).toBe(70_000);
-      expect(result.threshold).toBe(64_000); // 128k * 0.5
+      expect(result.currentTokenCount).toBe(90_000);
+      expect(result.threshold).toBe(95_000); // 128k - 20k - 13k
     });
 
     it('should return needsCompression=true when raw count is at threshold (drift pushes over)', () => {
@@ -82,12 +186,12 @@ describe('tokenCounter', () => {
       const result = shouldCompress([
         mkMsg({
           role: 'assistant',
-          metadata: { usage: { totalOutputTokens: 64_000 } as any } as any,
+          metadata: { usage: { totalOutputTokens: 95_000 } as any } as any,
         }),
       ]);
 
       expect(result.needsCompression).toBe(true);
-      expect(result.currentTokenCount).toBe(64_000);
+      expect(result.currentTokenCount).toBe(95_000);
     });
 
     it('should NOT trigger at threshold when driftMultiplier is 1', () => {
@@ -96,14 +200,14 @@ describe('tokenCounter', () => {
         [
           mkMsg({
             role: 'assistant',
-            metadata: { usage: { totalOutputTokens: 64_000 } as any } as any,
+            metadata: { usage: { totalOutputTokens: 95_000 } as any } as any,
           }),
         ],
         { driftMultiplier: 1 },
       );
 
       expect(result.needsCompression).toBe(false);
-      expect(result.currentTokenCount).toBe(64_000);
+      expect(result.currentTokenCount).toBe(95_000);
     });
 
     it('should use custom options', () => {

--- a/packages/agent-runtime/src/utils/tokenCounter.ts
+++ b/packages/agent-runtime/src/utils/tokenCounter.ts
@@ -10,9 +10,29 @@ export interface TokenCountOptions {
    * Default {@link DEFAULT_DRIFT_MULTIPLIER} (1.25).
    */
   driftMultiplier?: number;
+  /**
+   * `true` once a compression summary already exists in the conversation.
+   * Enables the recompression hysteresis — see {@link getCompressionThreshold}.
+   */
+  hasExistingSummary?: boolean;
+  /**
+   * Model's max output token count. Used to reserve room for the summary the
+   * compression call itself has to produce — see {@link getCompressionThreshold}.
+   */
+  maxOutputToken?: number;
   /** Model's max context window token count */
   maxWindowToken?: number;
-  /** Threshold ratio for triggering compression, default 0.5 */
+  /**
+   * Ratio applied instead of {@link DEFAULT_RECOMPRESSION_THRESHOLD_RATIO} once
+   * a summary exists. Only ever raises the threshold, never lowers it.
+   */
+  recompressionThresholdRatio?: number;
+  /**
+   * Explicit ratio override. When set, the threshold is exactly
+   * `maxWindowToken × thresholdRatio` and the headroom formula is bypassed.
+   * Leave unset unless a caller genuinely wants to compress earlier than the
+   * window requires.
+   */
   thresholdRatio?: number;
   /**
    * Optional top-level tool definitions for the upcoming LLM call. When
@@ -26,16 +46,94 @@ export interface TokenCountOptions {
 /** Default max context window (128k tokens) */
 export const DEFAULT_MAX_CONTEXT = 128_000;
 
-/** Default threshold ratio (50% of max context) */
-export const DEFAULT_THRESHOLD_RATIO = 0.5;
+/**
+ * Upper bound on the room reserved for the compression summary's own output.
+ * A model that can emit 128k tokens will never spend anywhere near that on a
+ * summary, so reserving its full `maxOutput` would waste most of the window.
+ */
+export const MAX_OUTPUT_RESERVE_TOKENS = 20_000;
 
 /**
- * Calculate the compression threshold based on max context window
+ * Safety buffer on top of the reserved output room, covering the drift between
+ * our estimate and the provider's tokenizer plus the system prompt / tool
+ * definitions that get appended after the check runs.
+ */
+export const COMPRESSION_BUFFER_TOKENS = 13_000;
+
+/**
+ * Floor for the headroom formula, as a fraction of the window. Small-window
+ * models (≤ 32k) would otherwise produce a zero or negative threshold, which
+ * reads as "always compress" and loops forever.
+ */
+export const MIN_THRESHOLD_RATIO = 0.5;
+
+/**
+ * Hysteresis watermark applied once a summary exists.
+ *
+ * A freshly compressed context can sit just below the ordinary threshold, so
+ * applying the same threshold again lets one small tool result trigger another
+ * compression before the model can act on the summary. Letting the compressed
+ * context grow to a higher watermark first breaks that loop.
+ */
+export const DEFAULT_RECOMPRESSION_THRESHOLD_RATIO = 0.65;
+
+/**
+ * Calculate the compression threshold for a model's context window.
+ *
+ * The budget is headroom-based, not a flat fraction: compression only needs to
+ * fire late enough that the *next* request still fits, so we reserve room for
+ * the summary output plus a safety buffer and let the conversation use
+ * everything below that.
+ *
+ * ```text
+ * threshold = maxWindowToken − min(maxOutputToken, 20k) − 13k
+ * ```
+ *
+ * A flat ratio wastes most of a large window — at the previous 0.5 default a
+ * 256k model compressed its whole history at ~102k raw tokens (40% of the
+ * window, once the 1.25 drift multiplier is applied), then had to re-read
+ * everything it had just summarized away.
+ *
+ * `thresholdRatio` remains available as an explicit override for callers that
+ * deliberately want to compress earlier. Once a summary exists,
+ * `hasExistingSummary` layers the recompression hysteresis on top — it can only
+ * raise the result, never lower it.
  */
 export function getCompressionThreshold(options: TokenCountOptions = {}): number {
   const maxContext = options.maxWindowToken ?? DEFAULT_MAX_CONTEXT;
-  const ratio = options.thresholdRatio ?? DEFAULT_THRESHOLD_RATIO;
-  return Math.floor(maxContext * ratio);
+
+  // Explicit ratio wins outright over the headroom formula — it's an opt-in
+  // override, not a cap. Hysteresis still applies on top of it below.
+  const base =
+    options.thresholdRatio === undefined
+      ? Math.max(
+          maxContext -
+            // Unknown maxOutput reserves the full cap: over-reserving costs a
+            // little window, under-reserving costs a failed request.
+            Math.min(
+              options.maxOutputToken ?? MAX_OUTPUT_RESERVE_TOKENS,
+              MAX_OUTPUT_RESERVE_TOKENS,
+            ) -
+            COMPRESSION_BUFFER_TOKENS,
+          Math.floor(maxContext * MIN_THRESHOLD_RATIO),
+        )
+      : Math.floor(maxContext * options.thresholdRatio);
+
+  if (!options.hasExistingSummary) return base;
+
+  // An explicitly configured watermark wins outright in BOTH directions — same
+  // contract as `thresholdRatio`. Callers use it to compress a summarized
+  // context *earlier* than the initial threshold, so clamping it would break
+  // that escape hatch.
+  if (options.recompressionThresholdRatio !== undefined) {
+    return Math.floor(maxContext * options.recompressionThresholdRatio);
+  }
+
+  // The DEFAULT hysteresis may only push the threshold LATER. Taking the max
+  // keeps the headroom budget intact on large windows (a 256k model stays at
+  // 223k instead of being dragged down to 166k) while still raising a
+  // ratio-configured threshold the way the recompression fix intends.
+  return Math.max(base, Math.floor(maxContext * DEFAULT_RECOMPRESSION_THRESHOLD_RATIO));
 }
 
 /**
@@ -54,7 +152,7 @@ export interface CompressionCheckResult {
    * upstream tokenizers actually overflow the model's context window.
    */
   needsCompression: boolean;
-  /** Compression threshold (`maxWindowToken × thresholdRatio`) */
+  /** Compression threshold — see {@link getCompressionThreshold} */
   threshold: number;
 }
 

--- a/src/store/aiInfra/slices/aiModel/selectors.ts
+++ b/src/store/aiInfra/slices/aiModel/selectors.ts
@@ -105,6 +105,12 @@ const modelContextWindowTokens = (id: string, provider: string) => (s: AIProvide
   return model?.contextWindowTokens;
 };
 
+const modelMaxOutput = (id: string, provider: string) => (s: AIProviderStoreState) => {
+  const model = getEnabledModelById(id, provider)(s);
+
+  return model?.maxOutput;
+};
+
 const modelExtendParams = (id: string, provider: string) => (s: AIProviderStoreState) => {
   const model = getEnabledModelById(id, provider)(s);
 
@@ -224,6 +230,7 @@ export const aiModelSelectors = {
   modelContextWindowTokens,
   modelDisabledParams,
   modelExtendParams,
+  modelMaxOutput,
   modelReasoningConfig,
   modelReasoningExtendParams,
   totalAiProviderModelList,

--- a/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
@@ -673,15 +673,18 @@ export class StreamingExecutorActionImpl {
     // ===========================================
     log('[executeClientAgent] Creating agent runtime with config', modelRuntimeConfig);
 
+    const aiInfraState = getAiInfraStoreState();
     const contextWindowTokens = aiModelSelectors.modelContextWindowTokens(
       model,
       provider!,
-    )(getAiInfraStoreState());
+    )(aiInfraState);
+    const maxOutputTokens = aiModelSelectors.modelMaxOutput(model, provider!)(aiInfraState);
 
     const agent = new GeneralChatAgent({
       agentConfig: { maxSteps: 1000 },
       compressionConfig: {
         enabled: agentConfigData.chatConfig?.enableContextCompression ?? true, // Default to enabled
+        maxOutputToken: maxOutputTokens ?? undefined,
         maxWindowToken: contextWindowTokens ?? undefined,
       },
       dynamicInterventionAudits,


### PR DESCRIPTION
Reported on #dev: long-horizon tasks lose important information partway through, and doubao in particular only behaves "with compression fully off and history unlimited" — once compression is on, the agent spends the session re-reading the same documents over and over.

Rebased onto canary and merged with #18626, which attacked the same re-compression loop from a different angle. **Both mechanisms are kept** — see "Merging with #18626" below.

#### 1. The threshold was a flat fraction of the window

`getCompressionThreshold` returned `maxWindowToken × 0.5`, and no caller ever passed `thresholdRatio`, so 0.5 was the production value. The 1.25 drift multiplier applied to the estimate pulls the real trigger down further:

| model | window | old raw trigger | new threshold |
| --- | --- | --- | --- |
| `doubao-seed-1.6` | 256k | ~102k (40%) | 223k (87%) |
| 200k-class | 200k | ~80k (40%) | 167k |
| default (unknown) | 128k | ~51k (40%) | 95k |

Compression only has to fire late enough that the *next* request still fits, so the budget is now headroom-based:

```
threshold = maxWindowToken − min(maxOutputToken, 20k) − 13k
```

`maxOutput` is capped at 20k because a model that *can* emit 128k will never spend that on a summary. It is read from the model bank on both paths (`getModelPropertyWithFallback` server-side, a new `modelMaxOutput` selector client-side); unknown reserves the full cap, since over-reserving costs a little window and under-reserving costs a failed request.

#### 2. Compression kept almost nothing of the working set

`preservedMessages` was the latest user turn only. Compression during an agent loop happens when the last message is a **tool result**, so every tool result and edit the model was working from was replaced by a prose summary.

That is the re-reading loop: the model no longer knows which files it has read, reads them again, tokens climb back to the threshold, compression fires again. At a 40% threshold the loop was cheap to enter and hard to leave, which is why turning compression off looked like the only fix.

A token-budgeted trailing slice (20% of the threshold, capped at 32k) is now kept verbatim beside the summary.

#### Merging with #18626

That PR fixed the same symptom with hysteresis (a 0.65 recompression watermark) and latest-user-turn preservation. Both are kept, layered rather than replaced:

- **Threshold.** Collapsing the watermark to a ratio in the agent — the previous shape — would drag a 256k window from 223k back down to 166k and undo the headroom budget. The DEFAULT 0.65 watermark is therefore applied as `max(headroom, watermark)`: it can only push the threshold *later*, which is exactly its stated purpose. An explicitly configured `recompressionThresholdRatio` still wins outright in **both** directions, because callers use it to compress a summarized context *earlier* than the initial threshold (`should honor an explicit recompression threshold below the initial threshold` covers this).
- **Preservation.** The union of both rules. The latest user turn is found by scanning backwards so it may sit *before* the trailing slice; the trailing slice covers the mid-loop tool round that the user turn alone misses. Neither subsumes the other, and the union is not necessarily a contiguous suffix, so membership — not slicing — decides what gets compressed.

#### Key decisions

- **`thresholdRatio` is an explicit override, not a default.** When set it bypasses the headroom formula. It stays unset everywhere in production.
- **A `MIN_THRESHOLD_RATIO` floor guards small windows.** A 32k model yields `32k − 33k < 0` under the headroom formula, and a non-positive threshold reads as "always compress" — an infinite compaction loop.
- **The preserved slice never starts on a `tool` message.** Its originating assistant `tool_calls` would have been summarized away, and most providers reject that orphaned pairing.
- **Preserved ids are expanded through folded containers.** On the server path a preserved tool round arrives as one virtual `assistantGroup` whose id is only its first assistant (`createAssistantGroupMessage` spreads `...firstAssistant`), while the executor filters raw DB rows — a top-level id check left every child unprotected. The re-append guard compares on the same expanded ids, because a `tasks` / `agentCouncil` / `compare` wrapper's synthetic id matches no row and would otherwise be appended on top of the raw children the DB already returned, showing the model that output twice. Both defects were found by Codex review on this PR.
- **Non-goal: post-compaction working-set restoration.** Re-injecting recently read files, active skills and the current plan (Claude Code's `createPostCompactFileAttachments`) is the more complete answer to the re-reading loop and needs its own design. Preserving the tail addresses the mid-loop case.
- **Non-goal: reactive compaction on `prompt-too-long`.** `llmErrorClassifier` still classifies context-overflow as `stop`, and `compressContext` still has no failure counter, so a failed compaction re-triggers on the next step. Worth fixing separately, ideally against a captured trace of the reported failures rather than a guess.

#### Test

- [x] Added/updated tests
- [ ] Tested locally against a real long-horizon doubao run

309 tests pass in `packages/agent-runtime`, including #18626's three recompression tests unchanged.

`getCompressionThreshold` (headroom math, the doubao 256k case, `maxOutput` cap and low-`maxOutput` reserve, small-window floor, explicit-ratio override, and five hysteresis-interaction cases). `selectPreservedTail` (budget fit, whole trailing tool round, orphaned-tool-head rejection, oversized trailing user message, always-something-to-compress, suffix contiguity). `collectPreservedMessageIds` across every container shape. Three `compressContext` executor tests covering the trailing tool round, the folded `assistantGroup`, and the synthetic wrapper — each verified to fail against the previous implementation.

The remaining checkbox is deliberate: the threshold change is verified by unit tests, but "does doubao actually stop re-reading documents" needs a real long session to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)