### PR TITLE
🐛 fix(server): apply systemRole in outputJSON instead of dropping it

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/aiChat.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiChat.test.ts
@@ -1144,6 +1144,47 @@ describe('aiChatRouter', () => {
       expect(result.tracingId).toMatch(/^[0-9a-f-]{36}$/);
     });
 
+    it('folds systemRole into messages as a leading system message', async () => {
+      const { initModelRuntimeFromDB } = await import('@/server/modules/ModelRuntime');
+
+      const mockGenerateObject = vi.fn().mockResolvedValue({ ok: true });
+
+      vi.mocked(initModelRuntimeFromDB).mockResolvedValue({
+        generateObject: mockGenerateObject,
+      } as any);
+
+      const caller = aiChatRouter.createCaller({ ...mockCtx, serverDB: {} } as any);
+
+      await caller.outputJSON({
+        messages: [{ content: 'a helpful travel planner', role: 'user' }],
+        model: 'gpt-4o',
+        provider: 'openai',
+        systemRole: 'You are an assistant configuration designer.',
+      });
+
+      expect(mockGenerateObject.mock.calls[0][0].messages).toEqual([
+        { content: 'You are an assistant configuration designer.', role: 'system' },
+        { content: 'a helpful travel planner', role: 'user' },
+      ]);
+    });
+
+    it('leaves messages untouched when no systemRole is passed', async () => {
+      const { initModelRuntimeFromDB } = await import('@/server/modules/ModelRuntime');
+
+      const mockGenerateObject = vi.fn().mockResolvedValue({ ok: true });
+
+      vi.mocked(initModelRuntimeFromDB).mockResolvedValue({
+        generateObject: mockGenerateObject,
+      } as any);
+
+      const caller = aiChatRouter.createCaller({ ...mockCtx, serverDB: {} } as any);
+
+      const messages = [{ content: 'test', role: 'user' }];
+      await caller.outputJSON({ messages, model: 'gpt-4o', provider: 'openai' });
+
+      expect(mockGenerateObject.mock.calls[0][0].messages).toEqual(messages);
+    });
+
     it('maps provider auth runtime errors to UNAUTHORIZED instead of leaking as internal errors', async () => {
       const { initModelRuntimeFromDB } = await import('@/server/modules/ModelRuntime');
       const runtimeError = {

--- a/apps/server/src/routers/lambda/aiChat.ts
+++ b/apps/server/src/routers/lambda/aiChat.ts
@@ -157,6 +157,14 @@ export const aiChatRouter = router({
     // it as UUID, so a malformed value never reaches here.
     const tracingId = input.tracing?.tracingId ?? randomUUID();
 
+    // The runtime has no dedicated system channel — a system prompt only
+    // reaches the model as a `role: 'system'` message. Fold `systemRole` in
+    // here so callers that pass it get the prompt applied (and hashed into
+    // `llm_generation_tracing.prompt_hash`) instead of silently dropped.
+    const messages = input.systemRole
+      ? [{ content: input.systemRole, role: 'system' }, ...input.messages]
+      : input.messages;
+
     // Always stamp a trigger on metadata so cross-cutting hooks (timing,
     // routing) and the tracing registry have a fallback when the caller
     // forgets to set one. `tracing` carries the structured tracing config
@@ -165,7 +173,7 @@ export const aiChatRouter = router({
     try {
       data = await ctx.aiGenerationService.generateObject(
         {
-          messages: input.messages,
+          messages,
           model: input.model,
           provider: input.provider,
           schema: input.schema,

--- a/packages/const/src/llmGenerationTracing.ts
+++ b/packages/const/src/llmGenerationTracing.ts
@@ -7,6 +7,7 @@
  * are dashboard / partition keys.
  */
 export const TRACING_SCENARIOS = {
+  AgentBuilderConfig: 'agent_builder_config',
   AgentSignal: 'agent_signal',
   AgentWelcome: 'agent_welcome',
   BuilderSuggestion: 'builder_suggestion',

--- a/packages/types/src/aiChat.ts
+++ b/packages/types/src/aiChat.ts
@@ -251,6 +251,12 @@ export const StructureOutputSchema = z.object({
   model: z.string(),
   provider: z.string(),
   schema: StructureSchema.optional(),
+  /**
+   * Optional system prompt. The runtime only understands system *messages*, so
+   * the handler folds this into `messages` — keep it in the schema, otherwise
+   * zod strips the key at the tRPC boundary and the prompt silently vanishes.
+   */
+  systemRole: z.string().optional(),
   tools: z
     .array(z.object({ function: LobeUniformToolSchema, type: z.literal('function') }))
     .optional(),
@@ -290,6 +296,7 @@ export interface StructureOutputParams {
   model: string;
   provider: string;
   schema?: IStructureSchema;
+  /** Optional system prompt; folded into `messages` as a system message server-side. */
   systemRole?: string;
   tools?: {
     function: LobeUniformTool;


### PR DESCRIPTION
`aiChat.outputJSON` silently discarded any system prompt a caller passed.

- `StructureOutputParams` (TS interface, `packages/types/src/aiChat.ts`) declares `systemRole?: string`
- `StructureOutputSchema` (zod, same file) never declared it → tRPC strips the key at the boundary
- the handler forwarded only `messages / model / provider / schema / tools` to `generateObject` anyway

The runtime has no dedicated system channel — a system prompt only reaches the model as a `role: 'system'` message. This PR folds `systemRole` into `messages` in the handler and declares it in the zod schema so it survives the boundary.

Side effect worth calling out: the prompt now participates in `llm_generation_tracing.prompt_hash`. For affected callers that hash was pinned to the empty-string hash on every single call, which made prompt-version comparison in the dashboard meaningless for them.

Also registers `agent_builder_config` in `TRACING_SCENARIOS` — the mobile agent builder pipes through the tracing path but had no canonical scenario name, so it resolved to the `unknown` sentinel (1048 rows / 358 users on prod).

Found while triaging the `unknown` scenario bucket in DC observability: the mobile "create an assistant from one sentence" flow has been running its entire configuration-designer prompt into the void since launch — the model only ever saw the JSON schema field descriptions plus the user's one sentence.

| Before | After |
| ------ | ----- |
| `systemRole` stripped by zod, never forwarded; `system_prompt` empty in every tracing payload | folded into `messages` as a leading system message; hashed into `prompt_hash` |

#### Test

`apps/server/src/routers/lambda/__tests__/aiChat.test.ts` — two new cases: `systemRole` is prepended as a leading system message, and `messages` is untouched when it is absent. Full file passes (21 passed), `packages/llm-generation-tracing` suite passes (5 passed), `tsgo --noEmit` clean, eslint clean on touched files.

- [x] Tested locally
- [x] Added/updated tests

#### 🔗 Related Issue

Related to LOBE-13318

🤖 Generated with [Claude Code](https://claude.com/claude-code)
