### PR TITLE
💄 style(project): use a folder icon for project entries

### DIFF
--- a/src/features/HomeSidebar/Body/Project/ProjectItem.tsx
+++ b/src/features/HomeSidebar/Body/Project/ProjectItem.tsx
@@ -3,7 +3,7 @@
 import type { MenuProps } from '@lobehub/ui';
 import { ActionIcon, DropdownMenu, Icon } from '@lobehub/ui';
 import { confirmModal, toast } from '@lobehub/ui/base-ui';
-import { MoreHorizontalIcon, PencilIcon, SquareKanbanIcon, TrashIcon } from 'lucide-react';
+import { FolderClosedIcon, MoreHorizontalIcon, PencilIcon, TrashIcon } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -70,7 +70,7 @@ const ProjectItem = memo<ProjectItemProps>(({ project }) => {
       <NavItem
         contextMenuItems={canManage ? menuItems : undefined}
         disabled={deleting}
-        icon={project.avatar || SquareKanbanIcon}
+        icon={project.avatar || FolderClosedIcon}
         title={project.name}
         actions={
           canManage ? (

--- a/src/features/Projects/List/index.tsx
+++ b/src/features/Projects/List/index.tsx
@@ -15,10 +15,10 @@ import { Button, confirmModal, type DropdownItem, DropdownMenu, toast } from '@l
 import { createStaticStyles } from 'antd-style';
 import dayjs from 'dayjs';
 import {
+  FolderClosedIcon,
   MoreHorizontalIcon,
   PlusIcon,
   SearchXIcon,
-  SquareKanbanIcon,
   TrashIcon,
 } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';
@@ -244,7 +244,7 @@ const ProjectListPage = memo(() => {
           <Center flex={1} padding={48}>
             <Empty
               description={keyword.trim() ? t('list.searchEmpty') : t('list.emptyDescription')}
-              icon={keyword.trim() ? SearchXIcon : SquareKanbanIcon}
+              icon={keyword.trim() ? SearchXIcon : FolderClosedIcon}
             />
           </Center>
         ) : (

--- a/src/features/Projects/routeMeta.ts
+++ b/src/features/Projects/routeMeta.ts
@@ -1,8 +1,8 @@
-import { SquareKanbanIcon } from 'lucide-react';
+import { FolderClosedIcon } from 'lucide-react';
 
 import { routeMeta } from '@/spa/router/routeMeta';
 
 export const projectsRouteMeta = routeMeta({
-  icon: SquareKanbanIcon,
+  icon: FolderClosedIcon,
   titleKey: 'navigation.projects',
 });


### PR DESCRIPTION
Swap the project fallback icon from `SquareKanbanIcon` to `FolderClosedIcon`, so a Project reads as a folder — the same icon the topic list already uses for project groups (`AgentSidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx`).

Three call sites, all the same one-line swap:

| Surface | File | Before | After |
| --- | --- | --- | --- |
| Home sidebar project entry | `src/features/HomeSidebar/Body/Project/ProjectItem.tsx` | `lucide-square-kanban` | `lucide-folder-closed` |
| Desktop tab (route meta) | `src/features/Projects/routeMeta.ts` | `lucide-square-kanban` | `lucide-folder-closed` |
| Projects list empty state | `src/features/Projects/List/index.tsx` | `lucide-square-kanban` | `lucide-folder-closed` |

Projects with a custom avatar are unaffected — the icon is only the `project.avatar || …` fallback.

#### Test

Verified on Web and Electron with before/after screenshots (temporarily reverting each file and recapturing the same viewport, so the "after" is provably produced by this change):

https://app.lobehub.com/acceptance/39280e21-71a6-43a1-b284-3a59a471aa3c

- Home sidebar: 6 project entries render `lucide-folder-closed`, 0 `lucide-square-kanban`. ✅
- Desktop tab: the `项目` tab icon renders `lucide-folder-closed`. ✅
- Projects list empty state: not covered — it only renders with zero projects on the account, and the local verification account has existing project fixtures. Same one-line swap as the two verified sites.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)