### PR TITLE
🐛 fix(heterogeneous-agent): block API provider binding for workspace agents

### DIFF
--- a/apps/desktop/src/main/modules/heterogeneousAgent/fileStorePort.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/fileStorePort.ts
@@ -48,8 +48,9 @@ export const callLambdaMutation = async <T>(
 
   // Deliberately no workspace header: every Desktop-main lambda call runs
   // under the personal OIDC identity. Provider binding is personal-agent /
-  // local-execution only (workspace agents never spawn in-process — see
-  // `selectRuntimeType`), so a workspace scope must never leak in here.
+  // local-execution only — `selectRuntimeType` rejects API-mode runs for any
+  // workspace agent (including the author, who otherwise CAN spawn one
+  // in-process) — so a workspace scope must never leak in here.
   const response = await fetch(`${base}/trpc/lambda/${procedure}`, {
     body: JSON.stringify(superjson.serialize(input)),
     headers: {

--- a/apps/server/src/routers/lambda/aiProvider.ts
+++ b/apps/server/src/routers/lambda/aiProvider.ts
@@ -198,7 +198,8 @@ export const aiProviderRouter = router({
    * Narrow credential-bearing endpoint for Desktop-local heterogeneous-agent
    * bindings. Desktop main calls this with the current OIDC identity and no
    * workspace scope — provider binding is personal-agent/local-execution only
-   * (workspace agents never spawn in-process, see `selectRuntimeType`) — and
+   * (`selectRuntimeType` rejects API-mode runs for workspace agents, even for
+   * the author who can spawn them in-process) — and
    * renderer IPC receives only the provider/model reference. `enabledModels`
    * makes Desktop main the authority on model availability instead of the
    * renderer's possibly stale store state.

--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -469,6 +469,7 @@
   "heterogeneousStatus.apiMode.smallFastModel": "Background model",
   "heterogeneousStatus.apiMode.smallFastModelDesc": "Used for session titles, summaries, and other background work. Does not change the main conversation.",
   "heterogeneousStatus.apiMode.smallFastModelPlaceholder": "Same as primary model",
+  "heterogeneousStatus.apiMode.workspaceUnsupported": "Not available for workspace agents",
   "heterogeneousStatus.auth.api": "API",
   "heterogeneousStatus.auth.label": "Auth Method",
   "heterogeneousStatus.auth.subscription": "Subscription",

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -469,6 +469,7 @@
   "heterogeneousStatus.apiMode.smallFastModel": "后台模型",
   "heterogeneousStatus.apiMode.smallFastModelDesc": "Claude Code 用来生成会话标题、摘要等后台任务，不影响主对话。",
   "heterogeneousStatus.apiMode.smallFastModelPlaceholder": "不设置则与主模型相同",
+  "heterogeneousStatus.apiMode.workspaceUnsupported": "工作区 Agent 暂不支持服务商绑定",
   "heterogeneousStatus.auth.api": "API",
   "heterogeneousStatus.auth.label": "认证方式",
   "heterogeneousStatus.auth.subscription": "订阅",

--- a/packages/heterogeneous-agents/src/claudeCodeDirectEnv.ts
+++ b/packages/heterogeneous-agents/src/claudeCodeDirectEnv.ts
@@ -3,6 +3,17 @@ import type { AiProviderSDKType } from '@lobechat/types';
 export const HETEROGENEOUS_PROVIDER_BINDING_LOCAL_ONLY_ERROR =
   'Heterogeneous agent provider binding is only supported for Desktop local execution.';
 
+/**
+ * Desktop main resolves the binding's providerId in the PERSONAL scope only
+ * (deliberately no workspace header — see `providerBindingPort`). A workspace
+ * agent's binding would have been configured against workspace-scoped
+ * providers, so running it locally could silently resolve a personal provider
+ * that shares the same id (builtin ids like `anthropic` collide across scopes)
+ * and bill the wrong account. Blocked before IPC for every entry point.
+ */
+export const HETEROGENEOUS_PROVIDER_BINDING_PERSONAL_ONLY_ERROR =
+  'Heterogeneous agent provider binding is not supported for workspace agents.';
+
 /** @deprecated Use HETEROGENEOUS_PROVIDER_BINDING_LOCAL_ONLY_ERROR. */
 export const CLAUDE_CODE_API_LOCAL_ONLY_ERROR = HETEROGENEOUS_PROVIDER_BINDING_LOCAL_ONLY_ERROR;
 

--- a/packages/heterogeneous-agents/src/index.ts
+++ b/packages/heterogeneous-agents/src/index.ts
@@ -11,6 +11,7 @@ export {
   type BuildClaudeCodeDirectEnvResult,
   CLAUDE_CODE_API_LOCAL_ONLY_ERROR,
   HETEROGENEOUS_PROVIDER_BINDING_LOCAL_ONLY_ERROR,
+  HETEROGENEOUS_PROVIDER_BINDING_PERSONAL_ONLY_ERROR,
   sanitizeClaudeCodeDirectArgs,
   sanitizeClaudeCodeDirectEnv,
 } from './claudeCodeDirectEnv';

--- a/packages/locales/src/default/setting.ts
+++ b/packages/locales/src/default/setting.ts
@@ -415,6 +415,7 @@ export default {
   'heterogeneousStatus.apiMode.smallFastModelDesc':
     'Used for session titles, summaries, and other background work. Does not change the main conversation.',
   'heterogeneousStatus.apiMode.smallFastModelPlaceholder': 'Same as primary model',
+  'heterogeneousStatus.apiMode.workspaceUnsupported': 'Not available for workspace agents',
   'heterogeneousStatus.auth.api': 'API',
   'heterogeneousStatus.auth.label': 'Auth Method',
   'heterogeneousStatus.auth.subscription': 'Subscription',

--- a/src/features/Conversation/store/slices/generation/action.ts
+++ b/src/features/Conversation/store/slices/generation/action.ts
@@ -117,6 +117,8 @@ const getEffectiveAgencyConfig = (agentId: string) => {
       visibility: agent?.visibility,
       workspaceId: agent?.workspaceId,
     }),
+    /** True workspace membership — stays true for the author, unlike `workspaceScoped`. */
+    isWorkspaceAgent: !!agent?.workspaceId,
     workspaceScoped: resolveWorkspaceScoped(usesWorkspaceMemberSelection, deviceOverride),
   };
 };
@@ -373,14 +375,17 @@ const regenerateUserMessageFromSource = async (
     const postSwitchOp = operationSelectors.getOperationById(operationId)(useChatStore.getState());
     if (postSwitchOp && postSwitchOp.status !== 'running') return;
 
-    const { agencyConfig, workspaceScoped } = getEffectiveAgencyConfig(context.agentId);
+    const { agencyConfig, isWorkspaceAgent, workspaceScoped } = getEffectiveAgencyConfig(
+      context.agentId,
+    );
     const heterogeneousProvider = agencyConfig?.heterogeneousProvider;
     const runtimeType = selectRuntimeType({
       boundDeviceId: agencyConfig?.boundDeviceId,
       executionTarget: agencyConfig?.executionTarget,
       heterogeneousProvider,
       isGatewayMode: chatStore.isGatewayModeEnabled(context.agentId),
-      isWorkspaceAgent: workspaceScoped,
+      isWorkspaceAgent,
+      workspaceScoped,
     });
 
     // ── Gateway mode: trigger server-side regeneration ──
@@ -759,13 +764,16 @@ export const generationSlice: StateCreator<
       if (shouldProceed === false) return false;
     }
 
-    const { agencyConfig, workspaceScoped } = getEffectiveAgencyConfig(context.agentId);
+    const { agencyConfig, isWorkspaceAgent, workspaceScoped } = getEffectiveAgencyConfig(
+      context.agentId,
+    );
     const runtimeType = selectRuntimeType({
       boundDeviceId: agencyConfig?.boundDeviceId,
       executionTarget: agencyConfig?.executionTarget,
       heterogeneousProvider: agencyConfig?.heterogeneousProvider,
       isGatewayMode: chatStore.isGatewayModeEnabled(context.agentId),
-      isWorkspaceAgent: workspaceScoped,
+      isWorkspaceAgent,
+      workspaceScoped,
     });
 
     // Hetero CLIs (CC / Codex) have no "continue a cut-off response" primitive
@@ -846,14 +854,17 @@ export const generationSlice: StateCreator<
     // tool/provider error on a grouped reply is not resumable this way.
     if (!isHeterogeneousAgentStatusGuideError(erroredStep.error?.body)) return;
 
-    const { agencyConfig, workspaceScoped } = getEffectiveAgencyConfig(context.agentId);
+    const { agencyConfig, isWorkspaceAgent, workspaceScoped } = getEffectiveAgencyConfig(
+      context.agentId,
+    );
     const heterogeneousProvider = agencyConfig?.heterogeneousProvider;
     const runtimeType = selectRuntimeType({
       boundDeviceId: agencyConfig?.boundDeviceId,
       executionTarget: agencyConfig?.executionTarget,
       heterogeneousProvider,
       isGatewayMode: chatStore.isGatewayModeEnabled(context.agentId),
-      isWorkspaceAgent: workspaceScoped,
+      isWorkspaceAgent,
+      workspaceScoped,
     });
     const agentId = context.agentId;
 

--- a/src/features/Conversation/store/slices/generation/continueHeteroAfterError.test.ts
+++ b/src/features/Conversation/store/slices/generation/continueHeteroAfterError.test.ts
@@ -22,7 +22,7 @@ vi.mock(
 // private local override runs in-process even if the shared workspace row points
 // at the gateway.
 const mockSelectRuntimeType = vi.fn((ctx: any) =>
-  ctx?.executionTarget === 'local' && !ctx?.isWorkspaceAgent ? 'hetero' : 'gateway',
+  ctx?.executionTarget === 'local' && !ctx?.workspaceScoped ? 'hetero' : 'gateway',
 );
 vi.mock('@/store/chat/slices/agentRun/actions/dispatch/agentDispatcher', () => ({
   selectRuntimeType: (ctx: any) => mockSelectRuntimeType(ctx),
@@ -273,7 +273,8 @@ describe('continueHeteroAfterError', () => {
       expect.objectContaining({
         boundDeviceId: 'personal-device',
         executionTarget: 'local',
-        isWorkspaceAgent: false,
+        isWorkspaceAgent: true,
+        workspaceScoped: false,
       }),
     );
     expect(mockUpdateMessage).not.toHaveBeenCalled();
@@ -301,6 +302,7 @@ describe('continueHeteroAfterError', () => {
         boundDeviceId: 'workspace-device',
         executionTarget: 'local',
         isWorkspaceAgent: true,
+        workspaceScoped: true,
       }),
     );
     expect(mockExecuteGatewayAgent).toHaveBeenCalledWith(
@@ -330,7 +332,8 @@ describe('continueHeteroAfterError', () => {
       expect.objectContaining({
         boundDeviceId: 'workspace-device',
         executionTarget: 'device',
-        isWorkspaceAgent: false,
+        isWorkspaceAgent: true,
+        workspaceScoped: false,
       }),
     );
   });

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/HeterogeneousAgentStatusCard.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/HeterogeneousAgentStatusCard.tsx
@@ -219,6 +219,12 @@ const styles = createStaticStyles(({ css }) => ({
 interface HeterogeneousAgentStatusCardProps {
   apiModeAvailable?: boolean;
   apiModeLabEnabled?: boolean;
+  /**
+   * Provider binding is blocked because the agent is workspace-scoped: the
+   * binding UI would offer workspace providers while Desktop main resolves
+   * the reference in the personal scope only.
+   */
+  apiModeWorkspaceBlocked?: boolean;
   onApiConfigChange?: (apiConfig: HeterogeneousApiConfig | undefined) => Promise<void> | void;
   onAuthModeChange?: (authMode: HeterogeneousAuthMode) => Promise<void> | void;
   onCommandChange?: (command: string) => Promise<void> | void;
@@ -229,6 +235,7 @@ const HeterogeneousAgentStatusCard = memo<HeterogeneousAgentStatusCardProps>(
   ({
     apiModeAvailable = false,
     apiModeLabEnabled = false,
+    apiModeWorkspaceBlocked = false,
     provider,
     onApiConfigChange,
     onAuthModeChange,
@@ -597,7 +604,11 @@ const HeterogeneousAgentStatusCard = memo<HeterogeneousAgentStatusCardProps>(
               </>
             ) : !apiModeAvailable ? (
               <Text className={styles.unavailableText}>
-                {t('heterogeneousStatus.apiMode.localOnly')}
+                {t(
+                  apiModeWorkspaceBlocked
+                    ? 'heterogeneousStatus.apiMode.workspaceUnsupported'
+                    : 'heterogeneousStatus.apiMode.localOnly',
+                )}
               </Text>
             ) : null}
           </Flexbox>

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/index.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/index.tsx
@@ -118,8 +118,13 @@ const ProfileEditor = memo(() => {
     isRemoteHeterogeneousType(heterogeneousProvider.type);
   const showCloudHeterogeneousTab = heterogeneousProvider?.type === 'claude-code';
   const apiModeLabEnabled = useUserStore(labPreferSelectors.enableAgentProviderBinding);
+  // Workspace agents are excluded even when the author could spawn them
+  // locally: the binding UI would list workspace-scoped providers, but Desktop
+  // main resolves the reference in the personal scope only (see
+  // `selectRuntimeType`'s personal-scope guard).
   const apiModeAvailable =
     isDesktop &&
+    !isWorkspaceAgent &&
     !!heterogeneousProvider &&
     isHeterogeneousProviderBindingSupported(heterogeneousProvider.type) &&
     resolveExecutionTarget(effectiveAgencyConfig, {
@@ -151,6 +156,7 @@ const ProfileEditor = memo(() => {
             <HeterogeneousAgentStatusCard
               apiModeAvailable={apiModeAvailable}
               apiModeLabEnabled={apiModeLabEnabled}
+              apiModeWorkspaceBlocked={isWorkspaceAgent}
               provider={heterogeneousProvider}
               onApiConfigChange={updateHeterogeneousApiConfig}
               onAuthModeChange={updateHeterogeneousAuthMode}

--- a/src/store/chat/slices/agentRun/actions/__tests__/agentDispatcher.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/agentDispatcher.test.ts
@@ -284,8 +284,64 @@ describe('selectRuntimeType', () => {
     });
   });
 
-  describe('isWorkspaceAgent — workspace agents never spawn in-process on the member desktop', () => {
-    it('routes desktop local / unset targets to gateway for workspace agents', () => {
+  describe('workspaceScoped — unmerged shared configs never spawn in-process on the member desktop', () => {
+    it('routes desktop local / unset targets to gateway for workspace-scoped configs', () => {
+      expect(
+        selectRuntimeType(
+          {
+            executionTarget: 'local',
+            heterogeneousProvider: heteroProvider,
+            isGatewayMode: false,
+            workspaceScoped: true,
+          },
+          { isDesktop: true },
+        ),
+      ).toBe('gateway');
+      expect(
+        selectRuntimeType(
+          { heterogeneousProvider: heteroProvider, isGatewayMode: false, workspaceScoped: true },
+          { isDesktop: true },
+        ),
+      ).toBe('gateway');
+    });
+  });
+
+  describe('isWorkspaceAgent — provider binding resolves credentials in the personal scope only', () => {
+    // Regression: the author of a workspace agent (or a member with an explicit
+    // local override) has workspaceScoped=false and CAN spawn in-process, but
+    // their binding was configured against workspace-scoped providers while
+    // Desktop main resolves the reference in the personal scope. A colliding
+    // personal provider id would silently supply different credentials, so the
+    // run must be rejected before IPC.
+    it('rejects API mode for workspace agents even when the author could run locally', () => {
+      expect(() =>
+        selectRuntimeType(
+          {
+            executionTarget: 'local',
+            heterogeneousProvider: apiHeteroProvider,
+            isGatewayMode: false,
+            isWorkspaceAgent: true,
+            workspaceScoped: false,
+          },
+          { isDesktop: true },
+        ),
+      ).toThrow(/not supported for workspace agents/);
+
+      expect(() =>
+        selectRuntimeType(
+          {
+            executionTarget: 'local',
+            heterogeneousProvider: codexApiHeteroProvider,
+            isGatewayMode: false,
+            isWorkspaceAgent: true,
+            workspaceScoped: false,
+          },
+          { isDesktop: true },
+        ),
+      ).toThrow(/not supported for workspace agents/);
+    });
+
+    it('keeps subscription-auth workspace agents spawnable by their author', () => {
       expect(
         selectRuntimeType(
           {
@@ -293,16 +349,25 @@ describe('selectRuntimeType', () => {
             heterogeneousProvider: heteroProvider,
             isGatewayMode: false,
             isWorkspaceAgent: true,
+            workspaceScoped: false,
           },
           { isDesktop: true },
         ),
-      ).toBe('gateway');
+      ).toBe('hetero');
+    });
+
+    it('keeps API mode working for personal agents', () => {
       expect(
         selectRuntimeType(
-          { heterogeneousProvider: heteroProvider, isGatewayMode: false, isWorkspaceAgent: true },
+          {
+            executionTarget: 'local',
+            heterogeneousProvider: apiHeteroProvider,
+            isGatewayMode: false,
+            isWorkspaceAgent: false,
+          },
           { isDesktop: true },
         ),
-      ).toBe('gateway');
+      ).toBe('hetero');
     });
   });
 

--- a/src/store/chat/slices/agentRun/actions/dispatch/agentDispatcher.ts
+++ b/src/store/chat/slices/agentRun/actions/dispatch/agentDispatcher.ts
@@ -1,6 +1,7 @@
 import { isDesktop as defaultIsDesktop } from '@lobechat/const';
 import {
   HETEROGENEOUS_PROVIDER_BINDING_LOCAL_ONLY_ERROR,
+  HETEROGENEOUS_PROVIDER_BINDING_PERSONAL_ONLY_ERROR,
   isRemoteHeterogeneousType,
 } from '@lobechat/heterogeneous-agents';
 import { type DeviceExecutionTarget, type HeterogeneousProviderConfig } from '@lobechat/types';
@@ -70,11 +71,10 @@ export interface RuntimeSelectionContext {
   /** Result of `chatStore.isGatewayModeEnabled()`. */
   isGatewayMode: boolean;
   /**
-   * The agent is workspace-scoped (`agent.workspaceId` set). Workspace agents
-   * never execute in-process on the current member's own desktop — a
-   * default/stored `local` target coerces to sandbox/device, so the run
-   * routes through the gateway (see `resolveExecutionTarget`'s
-   * `workspaceScoped`).
+   * The agent is workspace-scoped (`agent.workspaceId` set), regardless of
+   * authorship or per-member overrides. Unlike `workspaceScoped`, this stays
+   * true for the agent's author and for members with an explicit local
+   * override — the cases that CAN spawn a workspace agent in-process.
    */
   isWorkspaceAgent?: boolean;
   /**
@@ -86,6 +86,14 @@ export interface RuntimeSelectionContext {
    * stay on Gateway, even if its own agent config would say otherwise.
    */
   parentRuntime?: AgentRuntimeType;
+  /**
+   * The shared-row safety coercion still applies: a member without an explicit
+   * `executionTarget` override never executes the shared config on their own
+   * client (see `resolveWorkspaceScoped` / `resolveExecutionTarget`). False
+   * for the author or an explicitly overriding member even when
+   * `isWorkspaceAgent` is true.
+   */
+  workspaceScoped?: boolean;
 }
 
 interface SelectRuntimeTypeOptions {
@@ -107,6 +115,16 @@ export const selectRuntimeType = (
   { isDesktop = defaultIsDesktop }: SelectRuntimeTypeOptions = {},
 ): AgentRuntimeType => {
   if (ctx.heterogeneousProvider?.authMode === 'api') {
+    // Personal-scope invariant: Desktop main resolves the binding's providerId
+    // with NO workspace header (see `providerBindingPort`), while a workspace
+    // agent's binding was configured against workspace-scoped providers. The
+    // author (or an explicitly overriding member) CAN spawn a workspace agent
+    // in-process — `workspaceScoped` alone does not block them — so a colliding
+    // personal provider id (e.g. builtin `anthropic`) would silently supply
+    // different credentials. Reject before any IPC.
+    if (ctx.isWorkspaceAgent) {
+      throw new Error(HETEROGENEOUS_PROVIDER_BINDING_PERSONAL_ONLY_ERROR);
+    }
     const target = resolveExecutionTarget(
       {
         boundDeviceId: ctx.boundDeviceId,
@@ -116,7 +134,7 @@ export const selectRuntimeType = (
       {
         isHetero: true,
         clientExecutionAvailable: isDesktop,
-        workspaceScoped: ctx.isWorkspaceAgent,
+        workspaceScoped: ctx.workspaceScoped,
       },
     );
     if (target !== 'local' || (ctx.parentRuntime && ctx.parentRuntime !== 'hetero')) {
@@ -149,7 +167,7 @@ export const selectRuntimeType = (
       {
         isHetero: true,
         clientExecutionAvailable: isDesktop,
-        workspaceScoped: ctx.isWorkspaceAgent,
+        workspaceScoped: ctx.workspaceScoped,
       },
     );
     return target === 'local' ? 'hetero' : 'gateway';

--- a/src/store/chat/slices/agentRun/actions/dispatch/nonHeteroSubAgentDispatcher.ts
+++ b/src/store/chat/slices/agentRun/actions/dispatch/nonHeteroSubAgentDispatcher.ts
@@ -31,8 +31,6 @@ export interface NonHeteroSubAgentDispatchContext {
   inPortalThread?: boolean;
   /** Current gateway mode status (`chatStore.isGatewayModeEnabled()`). */
   isGatewayMode: boolean;
-  /** Parent agent is workspace-scoped — see `RuntimeSelectionContext.isWorkspaceAgent`. */
-  isWorkspaceAgent?: boolean;
   /**
    * Messages passed to the client-side runner.
    * Typically the current conversation messages plus a virtual instruction
@@ -50,6 +48,8 @@ export interface NonHeteroSubAgentDispatchContext {
    * the parent's execution environment for the child invocation.
    */
   parentRuntime?: AgentRuntimeType;
+  /** Parent agent's shared-row coercion flag — see `RuntimeSelectionContext.workspaceScoped`. */
+  workspaceScoped?: boolean;
 }
 
 /**
@@ -80,8 +80,8 @@ export async function dispatchNonHeteroSubAgent(
     boundDeviceId: ctx.boundDeviceId,
     heterogeneousProvider: ctx.heterogeneousProvider,
     isGatewayMode: ctx.isGatewayMode,
-    isWorkspaceAgent: ctx.isWorkspaceAgent,
     parentRuntime: ctx.parentRuntime,
+    workspaceScoped: ctx.workspaceScoped,
   });
 
   switch (runtimeType) {

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -411,11 +411,12 @@ export class ConversationLifecycleActionImpl {
       executionTarget: agencyConfig?.executionTarget,
       heterogeneousProvider,
       isGatewayMode,
-      isWorkspaceAgent: workspaceScoped,
+      isWorkspaceAgent: !!agent?.workspaceId,
       // Callers that need to pin the runtime (e.g. task topics that were
       // started server-side via runTask) pass `forceRuntime` to override
       // the agent's local/cloud preference.
       parentRuntime: forceRuntime,
+      workspaceScoped,
     });
 
     // ── Command Bus: extract and process built-in commands from editorData ──


### PR DESCRIPTION
Follow-up to #18531, fixing review issue 2: workspace agent provider bindings are configured against **workspace-scoped** providers, but Desktop main (`providerBindingPort`) resolves the bound `providerId` in the **personal scope** only. A colliding personal provider id (e.g. builtin `anthropic` with keys configured in both scopes) would silently supply the wrong credentials when the author — or a member with an explicit local override — spawns the workspace agent in-process. The old `workspaceScoped` flag cannot block this path: it is `false` exactly for those users.

Strategy: API provider binding is **personal-only** for now.

- `selectRuntimeType` rejects `authMode === 'api'` for any workspace agent (`agent.workspaceId` set) before any IPC, with a new `HETEROGENEOUS_PROVIDER_BINDING_PERSONAL_ONLY_ERROR`
- Split the two semantics that were previously conflated:
  - `isWorkspaceAgent` — true workspace membership; stays true for the author / local-override members; used by the binding guard
  - `workspaceScoped` — shared-row safety coercion; used by normal runtime routing (unchanged behavior)
- ProfileEditor disables API mode for workspace agents and shows a dedicated hint (`heterogeneousStatus.apiMode.workspaceUnsupported`, en-US + zh-CN shipped by hand)
- Fixed stale comments in `fileStorePort.ts` / `aiProvider.ts` claiming workspace agents never spawn locally

Blast radius without this fix is small (labs flag `enableAgentProviderBinding` + desktop + workspace agent + colliding provider id), which is why it lands as a follow-up.

| Before | After |
| ------ | ----- |
| Workspace agent could enable API mode; binding resolved with personal credentials | API mode unavailable for workspace agents (UI hint + runtime guard) |

#### Test

- [x] Tested locally
- [x] Added/updated tests

`agentDispatcher.test.ts`: new hard-block cases for workspace agents with API binding — author (`workspaceScoped=false`), explicit local override, and Codex binding. `continueHeteroAfterError.test.ts`: routing mocks updated to assert both `isWorkspaceAgent` and `workspaceScoped` are threaded through. Focused runs: 106 tests passed; lint clean; no type errors in changed files.

#### 🔗 Related Issue

Related to #18531