### PR TITLE
✨ feat(heterogeneous-agent): improve API mode controls

### DIFF
--- a/src/features/ChatInput/ControlBar/HeteroModel/SelectorMenu.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroModel/SelectorMenu.tsx
@@ -29,15 +29,16 @@ interface SelectorMenuProps {
   patch: (selection: HeteroSelection) => Promise<void>;
   permissionReason?: string;
   provider: HeterogeneousProviderConfig;
+  selectedModel?: string;
 }
 
 const SelectorMenu = memo<SelectorMenuProps>(
-  ({ agentId, capability, patch, permissionReason, provider }) => {
+  ({ agentId, capability, patch, permissionReason, provider, selectedModel }) => {
     const { t } = useTranslation('chat');
 
     const view = useMemo(
-      () => buildSelectorView({ capability, provider, t }),
-      [capability, provider, t],
+      () => buildSelectorView({ capability, provider, selectedModel, t }),
+      [capability, provider, selectedModel, t],
     );
 
     const select = useCallback(

--- a/src/features/ChatInput/ControlBar/HeteroModel/index.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroModel/index.tsx
@@ -15,10 +15,17 @@ import SelectorMenu from './SelectorMenu';
 import { resolveSelectorShape } from './selectorView';
 import { useHeteroProviderPatch } from './useHeteroProviderPatch';
 
-const HeteroModel = memo(() => {
-  const agentId = useAgentId();
+interface HeteroModelProps {
+  agentId?: string;
+  effortOnly?: boolean;
+  selectedModel?: string;
+}
+
+const HeteroModel = memo<HeteroModelProps>(({ agentId, effortOnly, selectedModel }) => {
+  const contextAgentId = useAgentId();
+  const resolvedAgentId = agentId ?? contextAgentId;
   const provider = useAgentStore(
-    (s) => agentByIdSelectors.getAgencyConfigById(agentId)(s)?.heterogeneousProvider,
+    (s) => agentByIdSelectors.getAgencyConfigById(resolvedAgentId)(s)?.heterogeneousProvider,
     isEqual,
   );
   const { allowed: canCreateContent, reason } = usePermission('create_content');
@@ -26,16 +33,24 @@ const HeteroModel = memo(() => {
   // the selector when this caller cannot configure that shared resource.
   const { canConfigureResource } = useChatInputResourceAccess();
   const enabled = canCreateContent && canConfigureResource;
-  const patch = useHeteroProviderPatch({ agentId, enabled, provider });
+  const patch = useHeteroProviderPatch({ agentId: resolvedAgentId, enabled, provider });
 
   const shape = resolveSelectorShape(provider, enabled);
 
   if (shape.kind === 'none' || !provider) return null;
 
-  if (shape.kind === 'catalog')
+  const capability = effortOnly
+    ? shape.capability.effort
+      ? { effort: shape.capability.effort }
+      : undefined
+    : shape.capability;
+
+  if (!capability) return null;
+
+  if (!effortOnly && shape.kind === 'catalog')
     return (
       <ModelCatalogSelector
-        agentId={agentId}
+        agentId={resolvedAgentId}
         disabled={false}
         model={shape.capability.model.resolve(provider)}
         permissionReason={reason}
@@ -46,11 +61,12 @@ const HeteroModel = memo(() => {
 
   return (
     <SelectorMenu
-      agentId={agentId}
-      capability={shape.capability}
+      agentId={resolvedAgentId}
+      capability={capability}
       patch={patch}
       permissionReason={reason}
       provider={provider}
+      selectedModel={selectedModel}
     />
   );
 });

--- a/src/features/ChatInput/ControlBar/HeteroModel/selectorView.test.ts
+++ b/src/features/ChatInput/ControlBar/HeteroModel/selectorView.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import type { ModelCapability } from './selectorView';
 import {
   buildSelectorView,
+  resolveModelDependentSelection,
   resolveModelSwitchSelection,
   resolveSelectorShape,
 } from './selectorView';
@@ -186,6 +187,36 @@ describe('current value surfaced on each dimension', () => {
       'Opus 4.8 heteroAgent.modelSelector.defaultReasoning',
     );
   });
+
+  it('renders an effort-only API selector without repeating the adjacent model label', () => {
+    const capability = selectorCapabilityOf('codex');
+    if (!capability.effort) throw new Error('no effort capability for codex');
+
+    const view = buildSelectorView({
+      capability: { effort: capability.effort },
+      provider: { effort: 'ultra', type: 'codex' },
+      selectedModel: 'gpt-5.6-sol',
+      t,
+    });
+
+    expect(view.dimensions.map((dimension) => dimension.key)).toEqual(['reasoning']);
+    expect(view.dimensions[0].options.map((option) => option.value)).toContain('ultra');
+    expect(view.triggerText).toBe('heteroAgent.modelSelector.reasoning.ultra');
+  });
+
+  it('labels the untouched effort-only API selector as the default effort', () => {
+    const capability = selectorCapabilityOf('claude-code');
+    if (!capability.effort) throw new Error('no effort capability for claude-code');
+
+    const view = buildSelectorView({
+      capability: { effort: capability.effort },
+      provider: { type: 'claude-code' },
+      selectedModel: 'claude-sonnet-4-6',
+      t,
+    });
+
+    expect(view.triggerText).toBe('heteroAgent.modelSelector.defaultReasoning');
+  });
 });
 
 describe('resolveModelSwitchSelection', () => {
@@ -229,6 +260,17 @@ describe('resolveModelSwitchSelection', () => {
         value: 'haiku',
       }),
     ).toEqual({ model: 'haiku' });
+  });
+
+  it('resets only the incompatible effort when an API-bound model changes', () => {
+    expect(
+      resolveModelDependentSelection({
+        capability: selectorCapabilityOf('codex'),
+        effort: 'ultra',
+        isFastSpeed: false,
+        value: 'gpt-5.4',
+      }),
+    ).toEqual({ effort: 'default' });
   });
 });
 

--- a/src/features/ChatInput/ControlBar/HeteroModel/selectorView.ts
+++ b/src/features/ChatInput/ControlBar/HeteroModel/selectorView.ts
@@ -70,11 +70,37 @@ export const resolveSelectorShape = (
   return { capability, kind: 'menu' };
 };
 
+interface ModelDependentSelectionParams {
+  capability: HeteroSelectorCapability;
+  effort?: HeterogeneousReasoningEffort;
+  isFastSpeed: boolean;
+  value: string;
+}
+
 /**
  * A dimension the newly picked model cannot serve would otherwise stay persisted
  * and be silently dropped by the CLI, leaving the menu claiming a setting the
  * run never used.
  */
+export const resolveModelDependentSelection = ({
+  capability,
+  effort,
+  isFastSpeed,
+  value,
+}: ModelDependentSelectionParams): HeteroSelection => {
+  const resetSpeed = isFastSpeed && !!capability.speed && !capability.speed.supported(value);
+  const resetEffort =
+    !!effort &&
+    effort !== HETEROGENEOUS_AGENT_DEFAULT_SELECTION &&
+    !!capability.effort &&
+    !capability.effort.levels(value).includes(effort);
+
+  return {
+    ...(resetEffort ? { effort: HETEROGENEOUS_AGENT_DEFAULT_SELECTION } : {}),
+    ...(resetSpeed ? { speed: HETEROGENEOUS_AGENT_DEFAULT_SELECTION } : {}),
+  };
+};
+
 export const resolveModelSwitchSelection = ({
   capability,
   effort,
@@ -86,30 +112,34 @@ export const resolveModelSwitchSelection = ({
   isFastSpeed: boolean;
   value: string;
 }): HeteroSelection => {
-  const resetSpeed = isFastSpeed && !!capability.speed && !capability.speed.supported(value);
-  const resetEffort =
-    !!effort &&
-    effort !== HETEROGENEOUS_AGENT_DEFAULT_SELECTION &&
-    !!capability.effort &&
-    !capability.effort.levels(value).includes(effort);
+  const dependentSelection = resolveModelDependentSelection({
+    capability,
+    effort,
+    isFastSpeed,
+    value,
+  });
 
   return {
-    ...(resetEffort ? { effort: HETEROGENEOUS_AGENT_DEFAULT_SELECTION } : {}),
+    ...dependentSelection,
     model: value,
-    ...(resetSpeed ? { speed: HETEROGENEOUS_AGENT_DEFAULT_SELECTION } : {}),
   };
 };
 
 export const buildSelectorView = ({
   capability,
   provider,
+  selectedModel,
   t,
 }: {
   capability: HeteroSelectorCapability;
   provider: HeterogeneousProviderConfig;
+  selectedModel?: string;
   t: Translate;
 }): SelectorView => {
-  const model = capability.model?.resolve(provider) ?? HETEROGENEOUS_AGENT_DEFAULT_SELECTION;
+  const model =
+    selectedModel?.trim() ||
+    capability.model?.resolve(provider) ||
+    HETEROGENEOUS_AGENT_DEFAULT_SELECTION;
   const effort = capability.effort?.resolve(provider);
   const mode = capability.mode?.resolve(provider);
   const speedSupported = capability.speed?.supported(model) ?? false;
@@ -126,6 +156,8 @@ export const buildSelectorView = ({
   const isCatalogModel = capability.model?.source === 'catalog';
   const isModeOnly =
     !!capability.mode && !capability.model && !capability.effort && !capability.speed;
+  const isEffortOnly =
+    !!capability.effort && !capability.model && !capability.mode && !capability.speed;
 
   const dimensions: SelectorDimension[] = [];
 
@@ -218,14 +250,18 @@ export const buildSelectorView = ({
       ? mode === HETEROGENEOUS_AGENT_DEFAULT_SELECTION
         ? t('heteroAgent.modelSelector.defaultConfig')
         : (modeLabel ?? defaultLabel)
-      : getTriggerText({
-          defaultConfigLabel: t('heteroAgent.modelSelector.defaultConfig'),
-          defaultModelLabel: t('heteroAgent.modelSelector.defaultModel'),
-          defaultReasoningLabel: t('heteroAgent.modelSelector.defaultReasoning'),
-          effort,
-          effortLabel,
-          model,
-          modelLabel,
-        }),
+      : isEffortOnly
+        ? effort === HETEROGENEOUS_AGENT_DEFAULT_SELECTION
+          ? t('heteroAgent.modelSelector.defaultReasoning')
+          : (effortLabel ?? defaultLabel)
+        : getTriggerText({
+            defaultConfigLabel: t('heteroAgent.modelSelector.defaultConfig'),
+            defaultModelLabel: t('heteroAgent.modelSelector.defaultModel'),
+            defaultReasoningLabel: t('heteroAgent.modelSelector.defaultReasoning'),
+            effort,
+            effortLabel,
+            model,
+            modelLabel,
+          }),
   };
 };

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/ApiModeModelBar.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/ApiModeModelBar.tsx
@@ -1,8 +1,12 @@
 'use client';
 
 import type { HeterogeneousApiConfig } from '@lobechat/types';
+import { applyHeteroSelection, getHeteroSelectorCapability } from '@lobechat/types';
+import { Flexbox } from '@lobehub/ui';
 import { memo, useMemo } from 'react';
 
+import HeteroModel from '@/features/ChatInput/ControlBar/HeteroModel';
+import { resolveModelDependentSelection } from '@/features/ChatInput/ControlBar/HeteroModel/selectorView';
 import { useProviderBindingCompatibleProviders } from '@/features/HeterogeneousAgent/hooks/useProviderBinding';
 import ModelSelect from '@/features/ModelSelect';
 import { useAgentStore } from '@/store/agent';
@@ -27,37 +31,60 @@ const ApiModeModelBar = memo<ApiModeModelBarProps>(({ agentId }) => {
     return null;
 
   const persist = async (apiConfig: HeterogeneousApiConfig) => {
+    const capability = getHeteroSelectorCapability(heterogeneousProvider.type);
+    const dependentSelection = capability
+      ? resolveModelDependentSelection({
+          capability,
+          effort: capability.effort?.resolve(heterogeneousProvider),
+          isFastSpeed: false,
+          value: apiConfig.model,
+        })
+      : {};
+
     await updateAgentConfigById(agentId, {
       agencyConfig: {
         ...agencyConfig,
-        heterogeneousProvider: { ...heterogeneousProvider, apiConfig },
+        heterogeneousProvider: {
+          ...heterogeneousProvider,
+          ...applyHeteroSelection(heterogeneousProvider, dependentSelection),
+          apiConfig,
+        },
       },
     });
   };
 
   return (
-    <ModelSelect
-      initialWidth
-      popupWidth={360}
-      providerIds={providerIds}
-      size="small"
-      variant="borderless"
-      value={
-        heterogeneousProvider.apiConfig
-          ? {
-              model: heterogeneousProvider.apiConfig.model,
-              provider: heterogeneousProvider.apiConfig.providerId,
-            }
-          : undefined
-      }
-      onChange={({ model, provider }) => {
-        const smallFastModel =
-          heterogeneousProvider.apiConfig?.providerId === provider
-            ? heterogeneousProvider.apiConfig.smallFastModel
-            : undefined;
-        void persist({ model, providerId: provider, smallFastModel });
-      }}
-    />
+    <Flexbox horizontal align="center" flex="none" gap={4} width="fit-content">
+      <Flexbox flex="none" width={140}>
+        <ModelSelect
+          popupWidth={240}
+          providerIds={providerIds}
+          size="small"
+          style={{ minWidth: 0 }}
+          variant="borderless"
+          value={
+            heterogeneousProvider.apiConfig
+              ? {
+                  model: heterogeneousProvider.apiConfig.model,
+                  provider: heterogeneousProvider.apiConfig.providerId,
+                }
+              : undefined
+          }
+          onChange={({ model, provider }) => {
+            const smallFastModel =
+              heterogeneousProvider.apiConfig?.providerId === provider
+                ? heterogeneousProvider.apiConfig.smallFastModel
+                : undefined;
+            void persist({ model, providerId: provider, smallFastModel });
+          }}
+        />
+      </Flexbox>
+      <HeteroModel
+        effortOnly
+        agentId={agentId}
+        selectedModel={heterogeneousProvider.apiConfig?.model}
+      />
+    </Flexbox>
   );
 });
 

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/HeteroControlBar.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/HeteroControlBar.tsx
@@ -143,6 +143,11 @@ const HeteroControlBar = memo(() => {
   const { agencyConfig, workspaceScoped } = useEffectiveAgencyConfig(agentId);
 
   const heteroProvider = agencyConfig?.heterogeneousProvider;
+  // API mode runs against the bound custom Provider/API key. The local CLI's
+  // subscription windows belong to a different credential source and must not
+  // be displayed or sampled for that run. An omitted authMode is the legacy
+  // subscription default.
+  const subscriptionQuotaApplies = heteroProvider?.authMode !== 'api';
   const executionTarget = resolveExecutionTarget(agencyConfig, {
     clientExecutionAvailable: isDesktop,
     isHetero: !!heteroProvider,
@@ -154,7 +159,9 @@ const HeteroControlBar = memo(() => {
   // and the cloud sandbox has no sampler, so both stay quota-less.
   const quotaDeviceId = executionTarget === 'device' ? agencyConfig?.boundDeviceId : undefined;
   const shouldShowClaudeQuota =
-    heteroProvider?.type === 'claude-code' && (isLocalHeteroExecution || !!quotaDeviceId);
+    subscriptionQuotaApplies &&
+    heteroProvider?.type === 'claude-code' &&
+    (isLocalHeteroExecution || !!quotaDeviceId);
 
   if (isAccessLoading) return null;
 
@@ -208,7 +215,8 @@ const HeteroControlBar = memo(() => {
   // Codex quota still needs the local CLI (spawned over IPC), so it stays
   // desktop-local; the SDK runtime badge likewise reports this desktop's own
   // in-process runtime, not a remote device's.
-  const shouldShowCodexQuota = heteroProvider?.type === 'codex' && isLocalHeteroExecution;
+  const shouldShowCodexQuota =
+    subscriptionQuotaApplies && heteroProvider?.type === 'codex' && isLocalHeteroExecution;
   const shouldShowSdkRuntime =
     heteroProvider?.type === 'claude-code' &&
     isLocalHeteroExecution &&

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/QuotaMenu.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/QuotaMenu.test.tsx
@@ -3,6 +3,7 @@
  */
 import type * as LobechatConstModule from '@lobechat/const';
 import type * as ElectronClientIpcModule from '@lobechat/electron-client-ipc';
+import type { HeterogeneousProviderConfig } from '@lobechat/types';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -17,11 +18,20 @@ const mockService = vi.hoisted(() => ({
   getCodexQuota: vi.fn(),
 }));
 
-const effectiveAgencyConfig = vi.hoisted(() => ({
+interface EffectiveAgencyConfigFixture {
+  current: {
+    boundDeviceId: string;
+    executionTarget: 'local';
+    heterogeneousProvider: Pick<HeterogeneousProviderConfig, 'authMode' | 'command' | 'type'>;
+  };
+  workspaceScoped: boolean;
+}
+
+const effectiveAgencyConfig = vi.hoisted<EffectiveAgencyConfigFixture>(() => ({
   current: {
     boundDeviceId: 'personal-device',
-    executionTarget: 'local' as const,
-    heterogeneousProvider: { command: 'codex', type: 'codex' as const },
+    executionTarget: 'local',
+    heterogeneousProvider: { command: 'codex', type: 'codex' },
   },
   workspaceScoped: false,
 }));
@@ -330,6 +340,32 @@ describe('HeteroControlBar', () => {
 
     expect(screen.queryByRole('button', { name: 'heteroAgent.codexQuota.tooltip' })).toBeNull();
     expect(mockService.getCodexQuota).not.toHaveBeenCalled();
+  });
+
+  it('does not mount Codex subscription quota in API mode', () => {
+    effectiveAgencyConfig.current = {
+      boundDeviceId: 'personal-device',
+      executionTarget: 'local',
+      heterogeneousProvider: { authMode: 'api', command: 'codex', type: 'codex' },
+    };
+
+    render(<HeteroControlBar />);
+
+    expect(screen.queryByRole('button', { name: 'heteroAgent.codexQuota.tooltip' })).toBeNull();
+    expect(mockService.getCodexQuota).not.toHaveBeenCalled();
+  });
+
+  it('does not mount Claude Code subscription quota in API mode', () => {
+    effectiveAgencyConfig.current = {
+      boundDeviceId: 'personal-device',
+      executionTarget: 'local',
+      heterogeneousProvider: { authMode: 'api', command: 'claude', type: 'claude-code' },
+    };
+
+    render(<HeteroControlBar />);
+
+    expect(screen.queryByRole('button', { name: 'heteroAgent.claudeQuota.tooltip' })).toBeNull();
+    expect(mockService.getClaudeCodeQuota).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
<!-- Brief and heads-up -->

Improve the Claude Code and Codex custom Provider/API-key experience:

- expose a reasoning-effort selector beside the API-bound model picker
- use the selected API model to constrain Codex effort levels and reset incompatible saved effort
- compact the model trigger to 140px and its popup to 240px
- hide and stop sampling local subscription quota while API authentication is active

| Before | After |
| ------ | ----- |
| API mode only exposed model selection and could show unrelated subscription quota | API mode exposes model + effort controls and only shows quota for subscription authentication |

#### Test

- `bun run check <changed files>` — lint clean; selector tests passed
- `bun run check --type` — types clean
- targeted Claude Code and Codex provider-binding driver tests passed

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

No matching issue found.