### PR TITLE
📝 docs(agent-runtime): replace stale hook example reference

### DIFF
--- a/.agents/skills/agent-runtime-hooks/SKILL.md
+++ b/.agents/skills/agent-runtime-hooks/SKILL.md
@@ -204,6 +204,7 @@ Note: CallAgent hooks require `parentOperationId` in `ExecSubAgentTaskParams`.
 - **Scoped per operation**: Auto-cleaned via `hookDispatcher.unregister()` on completion.
 - **Sandbox/MCP**: No separate hooks — they go through `executeTool`, so `beforeToolCall`/`afterToolCall` cover them. Use `event.identifier` to filter.
 
-## Real-World Example: agent-evals
+## Repository Examples
 
-See `devtools/agent-evals/helpers/runner.ts` — `createEvalHooks()` uses `afterStep`, `onComplete`, `afterToolCall`, and `beforeToolCall` (for mock).
+- `apps/server/src/services/agentRuntime/hooks/__tests__/HookDispatcher.test.ts` covers hook registration, lifecycle dispatch, and `beforeToolCall` mocking.
+- `apps/server/src/services/agentRuntime/__tests__/hooksIntegration.test.ts` covers step presentation data and terminal lifecycle events.


### PR DESCRIPTION
## Summary

- replace the stale `devtools/agent-evals/helpers/runner.ts` reference, which no longer exists on `canary`
- point the Agent Runtime hooks skill to repository-local unit and integration test examples

#### Test

- [x] No tests needed (documentation-only)
- [x] `git diff --check`
- [x] Remark and Prettier checks
- [x] Verified both replacement paths exist on `canary`

#### 🔗 Related Issue

N/A