### PR TITLE
🐛 fix(home): use ModelIcon for new-model shortcuts

### DIFF
--- a/src/features/Home/NewModelShortcuts/getShortcutIconModelId.test.ts
+++ b/src/features/Home/NewModelShortcuts/getShortcutIconModelId.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { getShortcutIconModelId } from './getShortcutIconModelId';
+
+describe('getShortcutIconModelId', () => {
+  it('uses the model id so remotely configured shortcuts keep a brand icon', () => {
+    expect(getShortcutIconModelId({ model: 'glm-5.3' })).toBe('glm-5.3');
+    expect(getShortcutIconModelId({ model: 'gemini-3.7-flash' })).toBe('gemini-3.7-flash');
+    expect(getShortcutIconModelId({ model: 'grok-4.6' })).toBe('grok-4.6');
+    expect(getShortcutIconModelId({ model: 'lobehub-kimi-k3-fast' })).toBe('lobehub-kimi-k3-fast');
+  });
+
+  it('prefers iconModel when the server sends an icon alias', () => {
+    expect(
+      getShortcutIconModelId({
+        iconModel: 'kimi-k3',
+        model: 'lobehub-kimi-k3-fast',
+      }),
+    ).toBe('kimi-k3');
+  });
+});

--- a/src/features/Home/NewModelShortcuts/getShortcutIconModelId.ts
+++ b/src/features/Home/NewModelShortcuts/getShortcutIconModelId.ts
@@ -1,0 +1,4 @@
+import type { HomeNewModelItem } from '@/business/client/hooks/useHomeNewModels';
+
+export const getShortcutIconModelId = (item: Pick<HomeNewModelItem, 'iconModel' | 'model'>) =>
+  item.iconModel ?? item.model;

--- a/src/features/Home/NewModelShortcuts/index.tsx
+++ b/src/features/Home/NewModelShortcuts/index.tsx
@@ -1,10 +1,8 @@
-import { Jimeng, Moonshot, OpenAI, ZAI } from '@lobehub/icons';
+import { ModelIcon } from '@lobehub/icons';
 import { Flexbox, Skeleton, Text } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { createStaticStyles, cx } from 'antd-style';
-import { Bot } from 'lucide-react';
-import type { ComponentType } from 'react';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -20,7 +18,7 @@ import { agentByIdSelectors } from '@/store/agent/selectors';
 
 import { useResolvedHomeAgentId } from '../AgentSelect/useResolvedHomeAgentId';
 import { trackHomeModelShortcutClicked } from './analytics';
-import { NEW_GLM_MODEL, NEW_IMAGE_MODEL, NEW_KIMI_MODEL, NEW_VIDEO_MODEL } from './starterModels';
+import { getShortcutIconModelId } from './getShortcutIconModelId';
 import { useStarterModelDefaults } from './useStarterModelDefaults';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
@@ -59,12 +57,6 @@ const getShortcutKey = (item: HomeNewModelItem) => `${item.type}:${item.model}`;
 const getShortcutProvider = (item: HomeNewModelItem, fallbackProvider: string) =>
   item.provider ?? fallbackProvider;
 const skeletonWidths = [112, 150, 126, 138];
-const modelIcons: Record<string, ComponentType<{ size: number }>> = {
-  [NEW_GLM_MODEL]: ZAI.Avatar,
-  [NEW_IMAGE_MODEL]: OpenAI.Avatar,
-  [NEW_KIMI_MODEL]: Moonshot.Avatar,
-  [NEW_VIDEO_MODEL]: Jimeng.Avatar,
-};
 
 export const NewModelShortcuts = () => {
   const { t } = useTranslation('home');
@@ -179,13 +171,12 @@ export const NewModelShortcuts = () => {
             const isCurrent =
               item.type === 'chat' && item.model === currentModel && provider === currentProvider;
             const isSwitching = switchingKey === key;
-            const ModelIcon = modelIcons[item.iconModel ?? item.model] ?? Bot;
             const button = (
               <Button
                 aria-pressed={item.type === 'chat' ? isCurrent : undefined}
                 className={cx(styles.button, isCurrent && styles.active)}
                 disabled={!!switchingKey && !isSwitching}
-                icon={<ModelIcon size={18} />}
+                icon={<ModelIcon model={getShortcutIconModelId(item)} size={18} />}
                 key={key}
                 loading={isSwitching}
                 type={'text'}


### PR DESCRIPTION
<!-- Brief and heads-up -->

Home's marketing shortcut row under the composer was mapping icons from a hardcoded four-model table. Cloud-configured models (GLM-5.3, Gemini 3.7 Flash, Grok 4.6, Kimi K3 Fast, …) all missed and rendered the same generic Bot glyph.

| Before | After |
| ------ | ----- |
| Every shortcut used the Lucide `Bot` fallback whenever the model id was not `glm-5.2` / `kimi-k2.7-code` / `gpt-image-2` / Seedance | `ModelIcon` resolves the brand from `iconModel ?? model`, same mapping the composer model switcher uses |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check --lint --test src/features/Home/NewModelShortcuts/index.tsx src/features/Home/NewModelShortcuts/getShortcutIconModelId.ts src/features/Home/NewModelShortcuts/getShortcutIconModelId.test.ts`

#### 🔗 Related Issue

Related to #18528