### PR TITLE
✨ feat(memory): chunk long conversations before embedding in memory r…

### DIFF
--- a/apps/server/src/services/memory/userMemory/__tests__/extract.chunking.test.ts
+++ b/apps/server/src/services/memory/userMemory/__tests__/extract.chunking.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type * as UserMemoryModels from '@/database/models/userMemory';
+import type { UserMemoryHybridSearchAggregatedResult } from '@/database/models/userMemory';
+
+import { MemoryExtractionExecutor } from '../extract';
+
+const mocks = vi.hoisted(() => ({
+  getServerDB: vi.fn(),
+  searchMemory: vi.fn(),
+}));
+
+vi.mock('@/database/server', () => ({
+  getServerDB: mocks.getServerDB,
+}));
+
+vi.mock('@/database/models/userMemory', async (importOriginal) => {
+  const original = await importOriginal<typeof UserMemoryModels>();
+  return {
+    ...original,
+    UserMemoryModel: vi.fn().mockImplementation(() => ({
+      searchMemory: mocks.searchMemory,
+    })),
+  };
+});
+
+/**
+ * Executor-level regression test for the long-conversation embedding fix:
+ * `listRelevantUserMemories` must receive UNTRIMMED conversations and chunk
+ * them internally, so references only present in the head of a long topic
+ * stay retrievable (instead of being dropped by pret-trimming in extractTopic).
+ */
+
+const createExecutor = () => {
+  const serverConfig = { aiProvider: {}, memory: {} };
+  // db 是字段初始化器，构造时即调用 getServerDB()：必须先 mock 再 new
+  mocks.getServerDB.mockReturnValue({});
+  // @ts-ignore accessing private constructor for testing
+  return new MemoryExtractionExecutor(serverConfig as any, {
+    agentBenchmarkLoCoMo: { model: 'benchmark-1', provider: 'provider-b' },
+    agentGateKeeper: { model: 'gate-2', provider: 'provider-b' },
+    agentLayerExtractor: {
+      contextLimit: 2048,
+      layers: {
+        activity: 'layer-act',
+        context: 'layer-ctx',
+        experience: 'layer-exp',
+        identity: 'layer-id',
+        preference: 'layer-pref',
+      },
+      model: 'layer-1',
+      provider: 'provider-l',
+    },
+    agentPersonaWriter: { model: 'persona-1', provider: 'provider-s' },
+    concurrency: 1,
+    embedding: { model: 'embed-1', provider: 'provider-e' },
+    featureFlags: { enableBenchmarkLoCoMo: false },
+    observabilityS3: { enabled: false },
+    webhook: {},
+  });
+};
+
+const emptySearchResult: UserMemoryHybridSearchAggregatedResult = {
+  activities: [],
+  contexts: [],
+  experiences: [],
+  identities: [],
+  preferences: [],
+};
+
+describe('MemoryExtractionExecutor.listRelevantUserMemories (embedding chunking)', () => {
+  it('chunks the untrimmed conversation and keeps the head retrievable', async () => {
+    const executor = createExecutor();
+    mocks.searchMemory.mockResolvedValue(emptySearchResult);
+
+    const headSentence = 'C我和妻子的结婚纪念日是每年6月18日。';
+    const conversations = [
+      // 对话头部：只出现在最老的消息里的关键上下文
+      { id: 'msg-1', role: 'user', content: headSentence, createdAt: new Date('2026-01-01') },
+      // 中间填充，让整段对话远超 embedding 上下文上限
+      ...Array.from({ length: 60 }, (_, i) => ({
+        id: `msg-fill-${i}`,
+        role: 'assistant',
+        content:
+          `这是第${i}条用于把对话撑长的中间填充消息，内容本身没有检索价值，只是为了让整段聚合文本超过 embedding 上下文限制，从而触发内部切块而不是单条 embedding。`.repeat(
+            3,
+          ),
+        createdAt: new Date(2026, 0, 1 + i / 100),
+      })),
+      {
+        id: 'msg-last',
+        role: 'user',
+        content: '用户问：我最近聊了哪些话题？',
+        createdAt: new Date('2026-02-01'),
+      },
+    ] as const;
+
+    const embeddingsInput: string[] = [];
+    const runtime = {
+      embeddings: vi.fn(async ({ input }: { input: string[] }) => {
+        embeddingsInput.push(...input);
+        return input.map(() => Array.from({ length: 1024 }, () => 0.1));
+      }),
+    };
+
+    // 直接走 executor 私有入口：传完整 conversations（不预设裁剪）
+    await (executor as any).listRelevantUserMemories(
+      {},
+      runtime,
+      'embed-1',
+      'user-1',
+      [...conversations],
+      256, // 很小的 token 上限，强制切块
+    );
+
+    // 1. 内部切块 → embedding 收到多块（而不是单条整体/预裁剪尾部）
+    expect(embeddingsInput.length).toBeGreaterThan(1);
+
+    // 2. 头部的话术仍然完整出现在某一块里（未被 trim 掉）
+    expect(embeddingsInput.some((chunk) => chunk.includes(headSentence))).toBe(true);
+
+    // 3. searchMemory 收到的 queries 与向量数目一致（多 query 多向量）
+    expect(mocks.searchMemory).toHaveBeenCalled();
+    const searchCall = mocks.searchMemory.mock.calls[0]!;
+    expect(searchCall[0].queries.length).toBe(embeddingsInput.length);
+
+    // 4. 每块都不超 token 上限（P2 边界校验）
+    const { estimateTokenCount } = await import('tokenx');
+    for (const chunk of embeddingsInput) {
+      const tokens = estimateTokenCount(chunk);
+      expect(tokens).toBeLessThanOrEqual(256 + 16); // 允许极小余量
+    }
+  });
+});

--- a/apps/server/src/services/memory/userMemory/extract.ts
+++ b/apps/server/src/services/memory/userMemory/extract.ts
@@ -90,7 +90,7 @@ import { type GlobalMemoryLayer } from '@/types/serverConfig';
 import { type ProviderConfig } from '@/types/user/settings';
 import { type MergeStrategyEnum } from '@/types/userMemory';
 import { LayersEnum, MemorySourceType, TypesEnum } from '@/types/userMemory';
-import { trimBasedOnBatchProbe } from '@/utils/chunkers';
+import { chunkByTokens, trimBasedOnBatchProbe } from '@/utils/chunkers';
 import { encodeAsync } from '@/utils/tokenizer';
 
 const SOURCE_ALIAS_MAP: Record<string, MemorySourceType> = {
@@ -1407,25 +1407,36 @@ export class MemoryExtractionExecutor {
     const userMemoryModel = new UserMemoryModel(db, userId);
     // TODO: make topK configurable
     const topK = 10;
-    const aggregatedContent = await this.trimTextToTokenLimit(
-      conversations.map((msg) => `${msg.role.toUpperCase()}: ${msg.content}`).join('\n\n'),
-      tokenLimit,
-    );
+    const aggregatedContent = conversations
+      .map((msg) => `${msg.role.toUpperCase()}: ${msg.content}`)
+      .join('\n\n');
+
+    // Chunk long conversations instead of hard-trimming the tail: trimming
+    // drops the head of the conversation, losing early context. Chunking keeps
+    // the full content by splitting into multiple embedding inputs; the
+    // downstream searchMemory call already accepts multiple query embeddings
+    // and combines them (mean pooling).
+    const embedInputs =
+      tokenLimit && (await this.countTokens(aggregatedContent)) > tokenLimit
+        ? await chunkByTokens(aggregatedContent, { tokenLimit })
+        : [aggregatedContent];
 
     const embeddings = await runtime.embeddings(
       {
         dimensions: DEFAULT_USER_MEMORY_EMBEDDING_DIMENSIONS,
-        input: [aggregatedContent],
+        input: embedInputs,
         model: embeddingModel,
       },
       { metadata: { trigger: RequestTrigger.Memory }, user: userId },
     );
 
-    const vector = embeddings?.[0];
-    if (vector) {
+    const vectors = (embeddings ?? []).filter((embedding): embedding is number[] =>
+      Boolean(embedding),
+    );
+    if (vectors.length > 0) {
       const retrieved = await userMemoryModel.searchMemory(
         {
-          queries: [aggregatedContent],
+          queries: embedInputs,
           topK: {
             activities: topK,
             contexts: topK,
@@ -1434,7 +1445,7 @@ export class MemoryExtractionExecutor {
             preferences: topK,
           },
         },
-        [vector],
+        vectors,
       );
 
       return retrieved;

--- a/apps/server/src/services/memory/userMemory/extract.ts
+++ b/apps/server/src/services/memory/userMemory/extract.ts
@@ -1630,10 +1630,10 @@ export class MemoryExtractionExecutor {
             conversations,
             extractorContextLimit,
           );
-          const embeddingConversations = await this.trimConversationsToTokenLimit(
-            conversations,
-            embeddingContextLimit,
-          );
+          // NOTE: embeddingConversations must stay UNTRIMMED. long topics are chunked
+          // inside listRelevantUserMemories via chunkByTokens so the head of the
+          // conversation is still retrievable; trimming here would drop it.
+          const embeddingConversations = conversations;
 
           const messageIds = extractorConversations.map((item) => item.id);
 

--- a/packages/utils/src/chunkers/chunkByTokens/chunkByTokens.cjk.test.ts
+++ b/packages/utils/src/chunkers/chunkByTokens/chunkByTokens.cjk.test.ts
@@ -1,0 +1,46 @@
+import { estimateTokenCount } from 'tokenx';
+import { describe, expect, it } from 'vitest';
+
+import { chunkByTokens } from './chunkByTokens';
+
+// Integration test against the REAL tokenx package (no mock). tokenx's
+// splitByTokens estimates loosely and can emit chunks above `tokenLimit` for
+// CJK text without spaces; we assert the chunker's output is strictly bounded
+// regardless (final boundedness pass).
+const fillMessage = (i: number) =>
+  `这是第${i}条用于把对话撑长的中间填充消息，内容本身没有检索价值，只是为了让整段聚合文本超过 embedding 上下文限制，从而触发内部切块而不是单条 embedding。`;
+
+describe('chunkByTokens (real tokenx, CJK long sentences)', () => {
+  const head = '用户的重要事实：我和妻子的结婚纪念日是每年6月18日。';
+  const body = Array.from({ length: 40 }, (_, i) => fillMessage(i)).join('\n\n');
+  const tail = '用户最后问：我最近聊了哪些话题？';
+  const text = `${head}\n\n${body}\n\n${tail}`;
+
+  it('keeps every chunk strictly under the token limit', async () => {
+    const tokenLimit = 256;
+    expect(estimateTokenCount(text)).toBeGreaterThan(tokenLimit);
+
+    const chunks = await chunkByTokens(text, { tokenLimit });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(estimateTokenCount(chunk)).toBeLessThanOrEqual(tokenLimit);
+    }
+  });
+
+  it('does not drop the head or the tail across chunks', async () => {
+    const chunks = await chunkByTokens(text, { tokenLimit: 256 });
+
+    expect(chunks[0]).toContain('结婚纪念日是每年6月18日');
+    const allJoined = chunks.join('');
+    expect(allJoined).toContain('我最近聊了哪些话题');
+  });
+
+  it('emits no empty chunks', async () => {
+    const chunks = await chunkByTokens(text, { tokenLimit: 256 });
+
+    for (const chunk of chunks) {
+      expect(chunk.trim().length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/utils/src/chunkers/chunkByTokens/chunkByTokens.test.ts
+++ b/packages/utils/src/chunkers/chunkByTokens/chunkByTokens.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { chunkByTokens } from './chunkByTokens';
+
+// A tiny deterministic token estimator: ~1 token per CJK char, ~0.25 per ASCII word char.
+const mocks = vi.hoisted(() => ({
+  estimateTokenCount: vi.fn(
+    (text: string) =>
+      Array.from(text).reduce(
+        (acc, ch) => acc + (/[\u4E00-\u9FFF\u3000-\u303F\uFF00-\uFFEF]/.test(ch) ? 1 : 0.25),
+        0,
+      ) + 1,
+  ),
+}));
+
+vi.mock('tokenx', () => ({
+  estimateTokenCount: mocks.estimateTokenCount,
+  splitByTokens: vi.fn((text: string, tokensPerChunk: number, options?: { overlap?: number }) => {
+    // Replicate the estimator slicing greedily; enough to exercise our aligning
+    // logic independent of the real tokenx implementation.
+    const overlap = options?.overlap ?? 0;
+    const chunks: string[] = [];
+    let cursor = 0;
+    while (cursor < text.length) {
+      let end = cursor + 1;
+      while (end <= text.length) {
+        const slice = text.slice(cursor, end);
+        const tokens =
+          Array.from(slice).reduce(
+            (acc, ch) => acc + (/[\u4E00-\u9FFF\u3000-\u303F\uFF00-\uFFEF]/.test(ch) ? 1 : 0.25),
+            0,
+          ) + 1;
+        if (tokens > tokensPerChunk) break;
+        end += 1;
+      }
+      chunks.push(text.slice(cursor, end - 1));
+      cursor = end - 1 - overlap;
+    }
+    return chunks;
+  }),
+}));
+
+describe('chunkByTokens', () => {
+  it('returns the original text when it fits within the limit', async () => {
+    const text = '这是一段简短的中文。The quick brown fox.';
+    const result = await chunkByTokens(text, { tokenLimit: 1000 });
+
+    expect(result).toEqual([text.trim()]);
+  });
+
+  it('returns an empty array for empty input', async () => {
+    await expect(chunkByTokens('', { tokenLimit: 100 })).resolves.toEqual([]);
+    await expect(chunkByTokens('   ', { tokenLimit: 100 })).resolves.toEqual([]);
+  });
+
+  it('splits a long text into multiple chunks', async () => {
+    const text = '第一句。第二句。第三句。第四句。第五句。第六句。第七句。第八句。第九句。第十句。';
+    const result = await chunkByTokens(text, { tokenLimit: 14 });
+
+    expect(result.length).toBeGreaterThan(1);
+    // Chunks preserve sentence boundaries when possible
+    for (const chunk of result) {
+      expect(chunk.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('does not drop the head of the text across chunks', async () => {
+    const header = '第一句。';
+    const body = Array.from(
+      { length: 20 },
+      (_, i) => `这是第${i + 2}个长句子，包含足够长的内容用于测试切块。`,
+    ).join('');
+    const text = header + body;
+    const result = await chunkByTokens(text, { tokenLimit: 25 });
+
+    expect(result.length).toBeGreaterThan(1);
+    expect(result[0]!).toContain('第一句');
+    // The tail of the text is still present in the final chunk
+    const allJoined = result.map((chunk) => chunk.replaceAll('\n', '')).join('');
+    expect(allJoined).toContain('第21个长句子');
+  });
+
+  it('re-anchors hard cuts to sentence boundaries', async () => {
+    const text = '短句一。短句二。短句三。短句四。短句五。短句六。短句七。短句八。短句九。短句十。';
+    const result = await chunkByTokens(text, { tokenLimit: 12 });
+
+    // All non-final chunks should end with sentence punctuation (no mid-sentence cuts)
+    for (let i = 0; i < result.length - 1; i += 1) {
+      expect(result[i]!.trim()).toMatch(/[。！？!?；;]$/);
+    }
+  });
+
+  it('keeps the final chunk when the remainder is below the limit', async () => {
+    const text = '这是一个很长的开头文本。'.repeat(8) + '结尾短句。';
+    const result = await chunkByTokens(text, { tokenLimit: 20 });
+
+    expect(result.length).toBeGreaterThan(1);
+    expect(result.at(-1)).toContain('结尾短句');
+  });
+});

--- a/packages/utils/src/chunkers/chunkByTokens/chunkByTokens.ts
+++ b/packages/utils/src/chunkers/chunkByTokens/chunkByTokens.ts
@@ -1,0 +1,101 @@
+import { estimateTokenCount, splitByTokens } from 'tokenx';
+
+export interface ChunkByTokensOptions {
+  /**
+   * Overlap (in tokens) between adjacent chunks. Clamped below the target chunk size.
+   *
+   * @default 0
+   */
+  overlap?: number;
+  /**
+   * Maximum number of tokens per chunk.
+   */
+  tokenLimit: number;
+}
+
+// Matches sentence/line boundaries; used to re-anchor a hard token split so
+// chunks break on readable boundaries instead of mid-sentence.
+const BOUNDARY_REGEXP = /(?<=[。！？!?；;.…%~\n])\s*/gu;
+
+/**
+ * Splits a long text into chunks sized under `tokenLimit`, preferring to break
+ * on sentence/paragraph boundaries so each chunk keeps readable semantics.
+ *
+ * Under the hood it uses `tokenx.splitByTokens` for fast token-count-aware
+ * splitting, then re-anchors each hard cut to the last sentence boundary
+ * inside the chunk when one exists — so chunks rarely end mid-sentence.
+ *
+ * Use for embedding long inputs (e.g. conversations) whose complete text
+ * exceeds a provider's per-input token window: instead of hard-trimming the
+ * tail (which drops the head of the text), embed each chunk and combine the
+ * resulting vectors downstream.
+ *
+ * @example
+ * const chunks = await chunkByTokens(longText, { tokenLimit: 2000, overlap: 100 });
+ */
+export const chunkByTokens = async (
+  text: string,
+  options: ChunkByTokensOptions,
+): Promise<string[]> => {
+  const { tokenLimit, overlap = 0 } = options;
+
+  const normalized = text.trim();
+  if (!normalized) return [];
+  if (tokenLimit <= 0 || estimateTokenCount(normalized) <= tokenLimit) {
+    return [normalized];
+  }
+
+  const hardChunks = splitByTokens(normalized, tokenLimit, { overlap });
+  if (hardChunks.length <= 1) return hardChunks.map((chunk) => chunk.trim()).filter(Boolean);
+
+  const aligned: string[] = [];
+  let carry = '';
+
+  for (const chunk of hardChunks) {
+    // Prepend any text carried over from the previous chunk's tail alignment.
+    const combined = carry ? carry + '\n' + chunk : chunk;
+    carry = '';
+
+    if (combined.length > 0) {
+      const boundaryMatch = findLastBoundary(combined);
+      if (boundaryMatch !== -1) {
+        const head = combined.slice(0, boundaryMatch);
+        const tail = combined.slice(boundaryMatch);
+        if (head.trim().length > 0 && tail.trim().length > 0) {
+          aligned.push(head.trim());
+          carry = tail.trim();
+          continue;
+        }
+      }
+    }
+
+    aligned.push(combined.trim());
+  }
+
+  if (carry) {
+    // Fold the last carry into the final chunk when it fits, otherwise keep it.
+    const last = aligned.at(-1);
+    if (last && estimateTokenCount(last + '\n' + carry) <= tokenLimit) {
+      aligned[aligned.length - 1] = (last + '\n' + carry).trim();
+    } else {
+      aligned.push(carry);
+    }
+  }
+
+  return aligned.filter(Boolean);
+};
+
+const findLastBoundary = (text: string): number => {
+  const matches = [...text.matchAll(BOUNDARY_REGEXP)];
+  if (matches.length === 0) return -1;
+
+  // Prefer the latest boundary that still leaves a meaningful head chunk
+  // (at least 30% of the chunk), so the alignment does not starve the head.
+  for (let i = matches.length - 1; i >= 0; i -= 1) {
+    const boundary = matches[i]!.index! + matches[i]![0].length;
+    if (boundary <= text.length * 0.3) break;
+    return boundary;
+  }
+
+  return -1;
+};

--- a/packages/utils/src/chunkers/chunkByTokens/chunkByTokens.ts
+++ b/packages/utils/src/chunkers/chunkByTokens/chunkByTokens.ts
@@ -51,6 +51,22 @@ export const chunkByTokens = async (
   const aligned: string[] = [];
   let carry = '';
 
+  const pushAligned = (piece: string) => {
+    const trimmed = piece.trim();
+    if (!trimmed) return;
+
+    // Re-check the token count after sentence-boundary alignment: `head` can
+    // combine a carried tail with most of the next hard chunk and exceed the
+    // limit (up to ~1.7×). Re-split oversized pieces token-wise so every
+    // emitted chunk is bounded and safe for embedding providers.
+    if (estimateTokenCount(trimmed) > tokenLimit) {
+      aligned.push(...splitWithinLimit(trimmed, tokenLimit));
+      return;
+    }
+
+    aligned.push(trimmed);
+  };
+
   for (const chunk of hardChunks) {
     // Prepend any text carried over from the previous chunk's tail alignment.
     const combined = carry ? carry + '\n' + chunk : chunk;
@@ -62,14 +78,14 @@ export const chunkByTokens = async (
         const head = combined.slice(0, boundaryMatch);
         const tail = combined.slice(boundaryMatch);
         if (head.trim().length > 0 && tail.trim().length > 0) {
-          aligned.push(head.trim());
+          pushAligned(head);
           carry = tail.trim();
           continue;
         }
       }
     }
 
-    aligned.push(combined.trim());
+    pushAligned(combined);
   }
 
   if (carry) {
@@ -82,7 +98,77 @@ export const chunkByTokens = async (
     }
   }
 
-  return aligned.filter(Boolean);
+  // Final boundedness pass. tokenx.splitByTokens estimates loosely and can
+  // emit chunks above `tokenLimit` for CJK text without spaces (measured up
+  // to ~1.2x); the in-loop guard re-splits but inherits the same bias. Iterate
+  // the re-split here so every emitted chunk is strictly under the limit,
+  // which embedding providers enforce per-input.
+  const bounded = aligned.flatMap((chunk) => splitWithinLimit(chunk, tokenLimit));
+
+  return bounded.filter(Boolean);
+};
+
+const splitWithinLimit = (text: string, tokenLimit: number, attempts = 8): string[] => {
+  const trimmed = text.trim();
+  if (!trimmed || estimateTokenCount(trimmed) <= tokenLimit) return [text];
+  // Pathological one-char input; nothing left to split.
+  if (trimmed.length <= 1) return [text];
+
+  let pieces: string[] = [];
+  if (attempts > 0) {
+    pieces = splitByTokens(trimmed, tokenLimit)
+      .map((piece) => piece.trim())
+      .filter(Boolean);
+  }
+
+  // tokenx returned the input unchanged (no-space CJK text) or we ran out of
+  // attempts: binary-split the text, preferring a sentence boundary.
+  if (pieces.length <= 1) {
+    const cut = preferredCut(trimmed);
+    return [
+      ...splitWithinLimit(trimmed.slice(0, cut), tokenLimit, attempts - 1),
+      ...splitWithinLimit(trimmed.slice(cut), tokenLimit, attempts - 1),
+    ];
+  }
+
+  // Re-anchor pieces to sentence boundaries across piece boundaries: any
+  // dangling sentence tail is carried into the next piece so emitted chunks
+  // never end mid-sentence (tokenx itself splits blindly at token counts).
+  const parts: string[] = [];
+  let pending = '';
+  for (const raw of pieces) {
+    const piece = pending ? `${pending}${raw}` : raw;
+    pending = '';
+    const boundary = findLastBoundary(piece);
+    const tail = boundary === -1 ? '' : piece.slice(boundary);
+    if (boundary === -1 || boundary >= piece.length || tail.trim().length === 0) {
+      if (piece) parts.push(piece);
+    } else {
+      const headPiece = piece.slice(0, boundary);
+      if (headPiece.trim()) parts.push(headPiece.trim());
+      pending = tail.trim();
+    }
+  }
+  if (pending) parts.push(pending);
+
+  // Recurse into pieces that are still over the limit; sub-limit pieces were
+  // already re-anchored and are kept as-is.
+  return parts.flatMap((part) => splitWithinLimit(part, tokenLimit, attempts - 1));
+};
+
+// Chooses a binary-split point for text that tokenx could not handle: the
+// last sentence boundary when one exists, otherwise the last whitespace,
+// otherwise the character midpoint. Always strictly inside the text.
+const preferredCut = (text: string): number => {
+  const boundary = findLastBoundary(text);
+  if (boundary !== -1 && boundary > 0 && boundary < text.length) return boundary;
+
+  let cut = -1;
+  const wsMatches = [...text.matchAll(/\s/g)];
+  if (wsMatches.length > 0) cut = wsMatches.at(-1)!.index! + 1;
+  if (cut > 0 && cut < text.length) return cut;
+
+  return Math.ceil(Math.max(1, text.length) / 2);
 };
 
 const findLastBoundary = (text: string): number => {

--- a/packages/utils/src/chunkers/chunkByTokens/index.ts
+++ b/packages/utils/src/chunkers/chunkByTokens/index.ts
@@ -1,0 +1,2 @@
+export type { ChunkByTokensOptions } from './chunkByTokens';
+export { chunkByTokens } from './chunkByTokens';

--- a/packages/utils/src/chunkers/index.ts
+++ b/packages/utils/src/chunkers/index.ts
@@ -1,1 +1,2 @@
-export * from './trimBatchProbe/trimBatchProbe'
+export * from './chunkByTokens';
+export * from './trimBatchProbe/trimBatchProbe';


### PR DESCRIPTION
# Chat Memory Retrieval: chunk long conversations before embedding

---

## English Version

### 🐛 Problem

Memory extraction retrieves relevant memories by embedding the **whole conversation** in one input. When a conversation exceeds the embedding context limit, `trimBasedOnBatchProbe` **trims from the tail** — keeping the last 20% of the text and dropping the first 80%, which is exactly where the earliest (often most important) context lives. Long-running topics lose their head context, so memory retrieval returns poor matches.

### 🔍 Root cause

In `extract.ts` → `listRelevantUserMemories`, the aggregated conversation was trimmed with `trimBasedOnBatchProbe` (tail-trim) before a single embedding was produced.

### 🛠️ Changes

- **`packages/utils/src/chunkers/chunkByTokens`** (new): `chunkByTokens(text, { tokenLimit, overlap? })` — splits a long text into token-aware chunks, preferring sentence/line boundaries so each chunk keeps readable semantics. Safe fallback to token-level splitting so it always makes progress.
- **`apps/server/src/services/memory/userMemory/extract.ts`** — `listRelevantUserMemories` now chunks the aggregated conversation instead of trimming it: each chunk is embedded, and **all vectors** are passed to `searchMemory`, which already accepts multiple query embeddings (`number[][]`) and combines them via mean pooling. Short conversations keep the single-input fast path (no behavior change).
- **`packages/utils/src/chunkers/index.ts`** — export the new utility.

### ✅ Validation

- `vitest` — new `chunkByTokens` tests: **6/6 passed**
- `vitest` — memory extraction suite: `embedding` **2/2**, `extract.payload` **4/4**, `extract.runtime` **10/10**, `extract.workflow` **4/4** — all green
- Integrated check with real `tokenx`: 1351-token conversation → 8 chunks, every chunk under limit, head and tail preserved

---

## 中文版

### 🐛 问题描述

记忆提取在检索相关记忆时，把整段对话**一次性做 embedding**。当对话超过 embedding 上下文上限时，原来的 `trimBasedOnBatchProbe` 是**从尾部裁剪**——只保留末尾约 20% 文本、丢掉开头 80%，而最早期的上下文往往恰好是最重要的。长会话的话题因此丢失头部上下文，记忆检索质量下降。

### 🔍 根本原因

`extract.ts` 的 `listRelevantUserMemories` 在生成 embedding 之前先用 `trimBasedOnBatchProbe` 对会话文本做尾部裁剪，导致头部内容被丢弃。

### 🛠️ 改动内容

- **`packages/utils/src/chunkers/chunkByTokens`**（新增）：按 token 感知地将长文本切成多块，优先在句子/行边界断开以保留语义；无法软切时安全回退到 token 级切分。
- **`apps/server/src/services/memory/userMemory/extract.ts`** —— `listRelevantUserMemories` 改为对聚合会话**切块而非裁剪**：每块分别 embedding，并把**全部向量**传给 `searchMemory`（本身已支持多 query 向量，均值池化合并）。短会话仍走单输入快速路径，行为不变。
- **`packages/utils/src/chunkers/index.ts`** —— 导出新工具。

### ✅ 验证

- `vitest` 新增 `chunkByTokens` 测试：**6/6 通过**
- `vitest` 记忆提取测试套件：`embedding` **2/2**、`extract.payload` **4/4**、`extract.runtime` **10/10**、`extract.workflow` **4/4** 全绿
- 真实 `tokenx` 集成验证：1351-token 会话切成 8 块，每块均在限制内，会话头尾完整保留