### PR TITLE
✨ feat(heterogeneous-agent): add server-default operation auth (server half)

### DIFF
--- a/.agents/acceptance/references/probe-field-notes.md
+++ b/.agents/acceptance/references/probe-field-notes.md
@@ -731,10 +731,10 @@ executionTarget: 'local'` in `agencyConfig`) + one message per case asking CC to
   Run it with `eval "$(init-dev-env.sh env)" && bunx tsx ./scripts/<probe>.mts`, then read the outcome from **DB side effects**, not the HTTP body — QStash swallows the response. (A claim/lease row, a status transition, or new message rows are all observable; the handler's JSON return is not.)
 - **Time-travel a schedule instead of waiting**: for a "runs at T" feature, `UPDATE ... SET metadata = jsonb_set(metadata, '{...,runAt}', '"<past ISO>"')` and then fire the dispatcher. Cheaper and more deterministic than sleeping until the real due time.
 
-### E22. Local dev env has no `JWKS_KEY` — every hetero agent run dies at `signOperationJwt`
+### E22. Local dev env has no `JWKS_KEY` — every hetero agent run dies at `signHeteroOperationJWT`
 
 - **Situation**: a real Claude Code / Codex run in the local no-`.env` env fails immediately with `Failed to sign operation JWT for hetero agent` (`apps/server/src/services/aiAgent/index.ts`). Nothing in the UI explains it; the topic just fails.
-- **Cause**: `signOperationJwt` → `getSigningKey()` → `getJwksKey()` needs the `JWKS_KEY` RSA JWK.
+- **Cause**: `signHeteroOperationJWT` → `getSigningKey()` → `getJwksKey()` needs the `JWKS_KEY` RSA JWK.
 - **Fixed in the bootstrap**: `init-dev-env.sh` now generates one on first use and persists it at `.records/env/agent-testing-jwks.json`, then exports `JWKS_KEY` from `apply_env`. A server started any other way still needs it explicitly — `JWKS_KEY="$(node scripts/generate-oidc-jwk.mjs)" …` — and it must be present at dev-server **start** (read from `process.env`), so a running server has to be restarted.
 - **Note the failure is downstream-honest**: with `JWKS_KEY` set, the run proceeds and then fails at the hetero _sandbox_ (`Hetero sandbox spawn failed / unauthorized`) unless the agent has a real Claude Code token. Those are two different walls — don't read the second as the first.
 - **Same wall, other feature**: any async-task dispatch needs it too. Image generation (`lambda/image.createImage` → `createAsyncCaller`) records the task as `error` with `start async task error: JWKS_KEY environment variable is not set`, which surfaces in the UI only as a generic 「暂时无法生成图片，请重试」 — read `async_tasks.error` rather than the toast.
@@ -909,13 +909,23 @@ nodeintegration, plugins, disablewebsecurity, allowpopups, preload, …`). The h
   (`packages/trpc/src/lambda/middleware/heteroOperationAuth.ts`) — an API key never populates it, so
   `heteroFinish` 401s. Also note the local no-`.env` env has no `JWKS_KEY` (E22), so the server
   cannot even validate a JWT until restarted with one.
-- **Works** — production-shape auth in three steps:
+- **Works** — production-shape auth in four steps:
   1. `node scripts/generate-oidc-jwk.mjs > /tmp/jwks.json`
   2. restart the dev server with `JWKS_KEY="$(cat /tmp/jwks.json)"` (must be present at start)
-  3. sign a 4h `hetero-operation` JWT with the SAME key via `signOperationJwt(<userId>)`
-     (`packages/trpc/src/utils/internalJwt.ts`; run a small `.mts` inside the repo with `bunx tsx`),
-     then run the CLI with `LOBEHUB_JWT=<token> LOBEHUB_SERVER=<app-url>` — the CLI forwards it as
-     the `Oidc-Auth` header.
+  3. create a real `agent_operations` row with the exact operation id, user id, workspace id (if
+     scoped), and `status = 'running'`; the strict callback principal validates this durable row.
+  4. sign a 4h `hetero-operation` JWT with the SAME key via `signHeteroOperationJWT`
+     (`packages/trpc/src/utils/internalJwt.ts`; run a small `.mts` inside the repo with `bunx tsx`):
+     ```ts
+     signHeteroOperationJWT({
+       capabilities: ['hetero:ingest', 'hetero:finish', 'hetero:intervention:read'],
+       operationId,
+       userId,
+       workspaceId,
+     });
+     ```
+     The JWT's operation/user/workspace values must match the row from step 3. Then run the CLI with
+     `LOBEHUB_JWT=<token> LOBEHUB_SERVER=<app-url>` — the CLI forwards it as the `Oidc-Auth` header.
      The fixture side needs `topics.metadata.runningOperation = { operationId, assistantMessageId }`
      seeded, and the operationId must embed real ids (`op_<ts>_agt_<id>_tpc_<id>_<suffix>`).
 - **Bonus trap**: under bun, a spawn failure reads `ENOENT: no such file or directory,

--- a/apps/server/src/modules/ModelRuntime/index.test.ts
+++ b/apps/server/src/modules/ModelRuntime/index.test.ts
@@ -101,6 +101,30 @@ describe('resolveServerModel', () => {
       'selected server model is not available',
     );
   });
+
+  it('preserves a deployment-owned model mapping', async () => {
+    getServerGlobalConfig.mockResolvedValue({
+      aiProvider: {
+        azure: {
+          enabled: true,
+          serverModelLists: [
+            {
+              config: { deploymentName: 'prod-gpt' },
+              enabled: true,
+              id: 'gpt-4o',
+              type: 'chat',
+            },
+          ],
+        },
+      },
+    });
+
+    await expect(resolveServerModel('azure', 'gpt-4o')).resolves.toEqual({
+      deploymentName: 'prod-gpt',
+      model: 'gpt-4o',
+      provider: 'azure',
+    });
+  });
 });
 
 describe('hasAvailableServerModel', () => {

--- a/apps/server/src/modules/ModelRuntime/index.test.ts
+++ b/apps/server/src/modules/ModelRuntime/index.test.ts
@@ -28,8 +28,9 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   buildPayloadFromKeyVaults,
-  hasAvailableServerModel,
+  getServerDefaultHeterogeneousModels,
   initModelRuntimeWithUserPayload,
+  resolveServerDefaultHeterogeneousModel,
   resolveServerModel,
 } from './index';
 
@@ -127,36 +128,72 @@ describe('resolveServerModel', () => {
   });
 });
 
-describe('hasAvailableServerModel', () => {
-  it('requires an enabled provider with an enabled chat model', async () => {
+describe('getServerDefaultHeterogeneousModels', () => {
+  it('returns only provider-native V1 model paths', async () => {
     getServerGlobalConfig.mockResolvedValue({
       aiProvider: {
         anthropic: {
-          enabled: false,
-          serverModelLists: [{ enabled: true, id: 'claude-server', type: 'chat' }],
+          enabled: true,
+          serverModelLists: [
+            { enabled: true, id: 'claude-server', type: 'chat' },
+            { enabled: false, id: 'claude-disabled', type: 'chat' },
+          ],
+        },
+        google: {
+          enabled: true,
+          serverModelLists: [{ enabled: true, id: 'gemini-server', type: 'chat' }],
         },
         openai: {
           enabled: true,
           serverModelLists: [
-            { enabled: true, id: 'image-server', type: 'image' },
-            { enabled: false, id: 'gpt-disabled', type: 'chat' },
+            { enabled: true, id: 'gpt-5.4', type: 'chat' },
+            { enabled: true, id: 'gpt-4o', type: 'chat' },
           ],
         },
       },
     });
 
-    await expect(hasAvailableServerModel()).resolves.toBe(false);
+    await expect(getServerDefaultHeterogeneousModels()).resolves.toEqual({
+      'claude-code': [{ model: 'claude-server', providerId: 'anthropic' }],
+      'codex': [{ model: 'gpt-5.4', providerId: 'openai' }],
+    });
+  });
+});
 
+describe('resolveServerDefaultHeterogeneousModel', () => {
+  it('accepts only the selected agent runtime path', async () => {
     getServerGlobalConfig.mockResolvedValue({
       aiProvider: {
+        anthropic: {
+          enabled: true,
+          serverModelLists: [{ enabled: true, id: 'claude-server', type: 'chat' }],
+        },
         openai: {
           enabled: true,
-          serverModelLists: [{ enabled: true, id: 'gpt-server', type: 'chat' }],
+          serverModelLists: [
+            { enabled: true, id: 'gpt-5.4', type: 'chat' },
+            { enabled: true, id: 'gpt-4o', type: 'chat' },
+          ],
         },
       },
     });
 
-    await expect(hasAvailableServerModel()).resolves.toBe(true);
+    await expect(
+      resolveServerDefaultHeterogeneousModel('claude-code', 'anthropic', 'claude-server'),
+    ).resolves.toMatchObject({ model: 'claude-server', provider: 'anthropic' });
+    await expect(
+      resolveServerDefaultHeterogeneousModel('codex', 'openai', 'gpt-5.4'),
+    ).resolves.toMatchObject({ model: 'gpt-5.4', provider: 'openai' });
+
+    await expect(
+      resolveServerDefaultHeterogeneousModel('codex', 'anthropic', 'claude-server'),
+    ).rejects.toThrow('not compatible with this heterogeneous agent');
+    await expect(
+      resolveServerDefaultHeterogeneousModel('claude-code', 'openai', 'gpt-5.4'),
+    ).rejects.toThrow('not compatible with this heterogeneous agent');
+    await expect(
+      resolveServerDefaultHeterogeneousModel('codex', 'openai', 'gpt-4o'),
+    ).rejects.toThrow('not compatible with this heterogeneous agent');
   });
 });
 

--- a/apps/server/src/modules/ModelRuntime/index.test.ts
+++ b/apps/server/src/modules/ModelRuntime/index.test.ts
@@ -26,7 +26,19 @@ import { ChatErrorType, type ClientSecretPayload } from '@lobechat/types';
 import { ModelProvider } from 'model-bank';
 import { describe, expect, it, vi } from 'vitest';
 
-import { buildPayloadFromKeyVaults, initModelRuntimeWithUserPayload } from './index';
+import {
+  buildPayloadFromKeyVaults,
+  hasAvailableServerModel,
+  initModelRuntimeWithUserPayload,
+  resolveServerModel,
+} from './index';
+
+const getServerGlobalConfig = vi.hoisted(() => vi.fn());
+
+vi.mock('@/server/globalConfig', () => ({
+  getServerDefaultAgentConfig: () => ({}),
+  getServerGlobalConfig,
+}));
 
 interface InspectableBedrockRuntime {
   client: {
@@ -66,6 +78,63 @@ vi.mock('@/envs/llm', () => ({
     STEPFUN_API_KEY: 'test-stepfun-key',
   })),
 }));
+
+describe('resolveServerModel', () => {
+  it('accepts only an enabled deployment-owned chat model', async () => {
+    getServerGlobalConfig.mockResolvedValue({
+      aiProvider: {
+        openai: {
+          enabled: true,
+          serverModelLists: [
+            { enabled: true, id: 'gpt-server', type: 'chat' },
+            { enabled: false, id: 'gpt-disabled', type: 'chat' },
+          ],
+        },
+      },
+    });
+
+    await expect(resolveServerModel('openai', 'gpt-server')).resolves.toEqual({
+      model: 'gpt-server',
+      provider: 'openai',
+    });
+    await expect(resolveServerModel('openai', 'gpt-disabled')).rejects.toThrow(
+      'selected server model is not available',
+    );
+  });
+});
+
+describe('hasAvailableServerModel', () => {
+  it('requires an enabled provider with an enabled chat model', async () => {
+    getServerGlobalConfig.mockResolvedValue({
+      aiProvider: {
+        anthropic: {
+          enabled: false,
+          serverModelLists: [{ enabled: true, id: 'claude-server', type: 'chat' }],
+        },
+        openai: {
+          enabled: true,
+          serverModelLists: [
+            { enabled: true, id: 'image-server', type: 'image' },
+            { enabled: false, id: 'gpt-disabled', type: 'chat' },
+          ],
+        },
+      },
+    });
+
+    await expect(hasAvailableServerModel()).resolves.toBe(false);
+
+    getServerGlobalConfig.mockResolvedValue({
+      aiProvider: {
+        openai: {
+          enabled: true,
+          serverModelLists: [{ enabled: true, id: 'gpt-server', type: 'chat' }],
+        },
+      },
+    });
+
+    await expect(hasAvailableServerModel()).resolves.toBe(true);
+  });
+});
 
 /**
  * Test cases for function initModelRuntimeWithUserPayload

--- a/apps/server/src/modules/ModelRuntime/index.ts
+++ b/apps/server/src/modules/ModelRuntime/index.ts
@@ -554,7 +554,13 @@ export const resolveServerModel = async (provider: string, model: string) => {
   if (!providerConfig?.enabled || !modelConfig) {
     throw new Error('The selected server model is not available');
   }
-  return { model: modelConfig.id, provider };
+  return {
+    ...(modelConfig.config?.deploymentName && {
+      deploymentName: modelConfig.config.deploymentName,
+    }),
+    model: modelConfig.id,
+    provider,
+  };
 };
 
 /** Initialize a deployment-owned runtime without reading user provider rows or keys. */

--- a/apps/server/src/modules/ModelRuntime/index.ts
+++ b/apps/server/src/modules/ModelRuntime/index.ts
@@ -1,4 +1,5 @@
 import { type GoogleGenAIOptions } from '@google/genai';
+import { DEFAULT_AGENT_CONFIG } from '@lobechat/const';
 import {
   AgentRuntimeError,
   mergeModelRuntimeHooks,
@@ -19,7 +20,7 @@ import {
   type SuperGrokKeyVault,
   type VertexAIKeyVault,
 } from '@lobechat/types';
-import { safeParseJSON } from '@lobechat/utils';
+import { merge, safeParseJSON } from '@lobechat/utils';
 import { ModelProvider } from 'model-bank';
 import { AiProviderBaseURLSchema } from 'model-bank/aiProvider';
 import { DEFAULT_MODEL_PROVIDER_LIST } from 'model-bank/modelProviders';
@@ -28,6 +29,7 @@ import { getBusinessModelRuntimeHooks } from '@/business/server/model-runtime';
 import { AiProviderModel } from '@/database/models/aiProvider';
 import { type LobeChatDatabase } from '@/database/type';
 import { getLLMConfig } from '@/envs/llm';
+import { getServerDefaultAgentConfig, getServerGlobalConfig } from '@/server/globalConfig';
 import { createLLMGenerationTracingHook } from '@/server/services/llmGenerationTracing/hook';
 import { ensureFreshOAuthToken } from '@/server/services/oauthDeviceFlow/refresh';
 
@@ -515,4 +517,71 @@ export const initModelRuntimeFromDB = async (
 
   // 6. Initialize ModelRuntime with the payload and hooks
   return initModelRuntimeWithUserPayload(provider, payload, { userId }, hooks);
+};
+
+export const resolveServerDefaultModel = () => {
+  const config = merge(DEFAULT_AGENT_CONFIG, getServerDefaultAgentConfig());
+  if (!config.model || !config.provider) {
+    throw new Error('The deployment default model is not configured');
+  }
+  if (!Object.values(ModelProvider).includes(config.provider as ModelProvider)) {
+    throw new Error(
+      'Deployment-level custom providers are not supported for server-default agents',
+    );
+  }
+  return { model: config.model, provider: config.provider };
+};
+
+/** Whether the deployment exposes at least one enabled chat model. */
+export const hasAvailableServerModel = async () => {
+  const { aiProvider } = await getServerGlobalConfig();
+  return Object.values(aiProvider).some(
+    (providerConfig) =>
+      providerConfig?.enabled &&
+      providerConfig.serverModelLists?.some((model) => model.enabled && model.type === 'chat'),
+  );
+};
+
+/** Resolve a user selection against the deployment-owned, enabled chat model catalog. */
+export const resolveServerModel = async (provider: string, model: string) => {
+  if (!Object.values(ModelProvider).includes(provider as ModelProvider)) {
+    throw new Error('Deployment-level custom providers are not supported for server agents');
+  }
+  const providerConfig = (await getServerGlobalConfig()).aiProvider[provider as ModelProvider];
+  const modelConfig = providerConfig?.serverModelLists?.find(
+    (item) => item.id === model && item.enabled && item.type === 'chat',
+  );
+  if (!providerConfig?.enabled || !modelConfig) {
+    throw new Error('The selected server model is not available');
+  }
+  return { model: modelConfig.id, provider };
+};
+
+/** Initialize a deployment-owned runtime without reading user provider rows or keys. */
+export const initModelRuntimeFromServerConfig = async (params: {
+  actorUserId: string;
+  provider: string;
+  workspaceId?: string;
+}): Promise<ModelRuntime> => {
+  if (!Object.values(ModelProvider).includes(params.provider as ModelProvider)) {
+    throw new Error(
+      'Deployment-level custom providers are not supported for server-default agents',
+    );
+  }
+  const businessHooks = getBusinessModelRuntimeHooks(
+    params.actorUserId,
+    params.provider,
+    params.workspaceId,
+  );
+  const tracingHooks = createLLMGenerationTracingHook(
+    params.actorUserId,
+    params.provider,
+    params.workspaceId,
+  );
+  return initModelRuntimeWithUserPayload(
+    params.provider,
+    { userId: params.actorUserId },
+    { userId: params.actorUserId },
+    mergeModelRuntimeHooks(businessHooks, tracingHooks),
+  );
 };

--- a/apps/server/src/modules/ModelRuntime/index.ts
+++ b/apps/server/src/modules/ModelRuntime/index.ts
@@ -6,6 +6,7 @@ import {
   ModelRuntime,
   type ModelRuntimeHooks,
 } from '@lobechat/model-runtime';
+import { isResponsesAPIModel } from '@lobechat/model-runtime/providers/openai/modelId';
 import { LobeVertexAI } from '@lobechat/model-runtime/vertexai';
 import {
   type AWSBedrockKeyVault,
@@ -532,14 +533,58 @@ export const resolveServerDefaultModel = () => {
   return { model: config.model, provider: config.provider };
 };
 
-/** Whether the deployment exposes at least one enabled chat model. */
-export const hasAvailableServerModel = async () => {
+export const SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES = ['claude-code', 'codex'] as const;
+export type ServerDefaultHeterogeneousAgentType =
+  (typeof SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES)[number];
+
+export interface ServerDefaultHeterogeneousModelReference {
+  model: string;
+  providerId: string;
+}
+
+export type ServerDefaultHeterogeneousModels = Record<
+  ServerDefaultHeterogeneousAgentType,
+  ServerDefaultHeterogeneousModelReference[]
+>;
+
+/**
+ * V1 deliberately keeps each CLI on its provider-native protocol path:
+ * Claude Code -> Anthropic runtime; Codex -> OpenAI Responses runtime.
+ * This predicate is the support matrix used by both capability discovery and invocation.
+ *
+ * Do not widen this predicate to generic chat/function-calling models. Adding another
+ * agent/runtime pair requires lossless continuation-state translation in both directions
+ * and a two-turn tool-call E2E covering the new pair before it is exposed in the catalog.
+ */
+const supportsServerDefaultHeterogeneousAgent = (
+  agentType: ServerDefaultHeterogeneousAgentType,
+  provider: string,
+  model: string,
+) =>
+  agentType === 'claude-code'
+    ? provider === ModelProvider.Anthropic
+    : provider === ModelProvider.OpenAI && isResponsesAPIModel(model);
+
+/** Return only the deployment models covered by the V1 protocol support matrix. */
+export const getServerDefaultHeterogeneousModels = async () => {
+  const models: ServerDefaultHeterogeneousModels = { 'claude-code': [], 'codex': [] };
   const { aiProvider } = await getServerGlobalConfig();
-  return Object.values(aiProvider).some(
-    (providerConfig) =>
-      providerConfig?.enabled &&
-      providerConfig.serverModelLists?.some((model) => model.enabled && model.type === 'chat'),
-  );
+
+  for (const [provider, providerConfig] of Object.entries(aiProvider)) {
+    if (!providerConfig?.enabled) continue;
+
+    for (const model of providerConfig.serverModelLists ?? []) {
+      if (!model.enabled || model.type !== 'chat') continue;
+
+      for (const agentType of SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES) {
+        if (supportsServerDefaultHeterogeneousAgent(agentType, provider, model.id)) {
+          models[agentType].push({ model: model.id, providerId: provider });
+        }
+      }
+    }
+  }
+
+  return models;
 };
 
 /** Resolve a user selection against the deployment-owned, enabled chat model catalog. */
@@ -561,6 +606,20 @@ export const resolveServerModel = async (provider: string, model: string) => {
     model: modelConfig.id,
     provider,
   };
+};
+
+/** Resolve a model only when it belongs to the selected CLI's V1 runtime path. */
+export const resolveServerDefaultHeterogeneousModel = async (
+  agentType: ServerDefaultHeterogeneousAgentType,
+  provider: string,
+  model: string,
+) => {
+  const selection = await resolveServerModel(provider, model);
+  if (!supportsServerDefaultHeterogeneousAgent(agentType, selection.provider, selection.model)) {
+    throw new Error('The selected server model is not compatible with this heterogeneous agent');
+  }
+
+  return selection;
 };
 
 /** Initialize a deployment-owned runtime without reading user provider rows or keys. */

--- a/apps/server/src/routers/lambda/__tests__/aiAgent.heteroIngest.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.heteroIngest.test.ts
@@ -75,7 +75,7 @@ describe('aiAgentRouter.heteroIngest / heteroFinish', () => {
     return aiAgentRouter.createCaller({
       jwtPayload: { userId: authUserId },
       oidcAuth: {
-        ...(params.authKind === 'user' ? {} : { purpose: 'hetero-operation' }),
+        ...(params.authKind === 'operation' ? { purpose: 'hetero-operation' } : {}),
         sub: authUserId,
       },
       userId: authUserId,

--- a/apps/server/src/routers/lambda/__tests__/aiAgent.heteroIntervention.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.heteroIntervention.test.ts
@@ -69,12 +69,29 @@ describe('aiAgentRouter — remote Human-in-the-loop', () => {
 
   // Browser leg: user JWT.
   const userCaller = () => aiAgentRouter.createCaller({ jwtPayload: { userId }, userId } as any);
-  // Exec leg: hetero-operation JWT (server-minted, ownership-exempt).
-  const heteroCaller = () =>
+  // Exec leg: operation-bound JWT claims produced by the server signer.
+  const heteroCaller = (operationId: string) =>
     aiAgentRouter.createCaller({
       jwtPayload: { userId },
-      oidcAuth: { purpose: 'hetero-operation', sub: userId },
+      oidcAuth: {
+        aud: 'urn:lobehub:hetero-operation',
+        capabilities: ['hetero:intervention:read'],
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iat: Math.floor(Date.now() / 1000),
+        iss: 'urn:lobehub:internal',
+        jti: `jti-${operationId}`,
+        operation_id: operationId,
+        purpose: 'hetero-operation',
+        sub: userId,
+      },
       userId,
+    } as any);
+  // Exec leg from a token minted before operation-bound claims were deployed.
+  const legacyHeteroCaller = (sub: string) =>
+    aiAgentRouter.createCaller({
+      jwtPayload: { userId: sub },
+      oidcAuth: { purpose: 'hetero-operation', sub },
+      userId: sub,
     } as any);
   // Exec leg via an owner OIDC token (a desktop reusing its own session): a
   // normal token whose `purpose` is NOT `hetero-operation` → heteroAuthKind
@@ -92,15 +109,17 @@ describe('aiAgentRouter — remote Human-in-the-loop', () => {
   };
 
   it('submit → wait round-trips a structured answer, filtered to the response', async () => {
+    const operationId = 'op-roundtrip';
+    await insertOperation(operationId, userId);
     await userCaller().submitHeteroIntervention({
-      operationId: 'op-1',
+      operationId,
       result: { 'Which env?': 'prod' },
       toolCallId: 't1',
     });
 
-    const res = await heteroCaller().waitInterventionResponse({
+    const res = await heteroCaller(operationId).waitInterventionResponse({
       lastEventId: '0',
-      operationId: 'op-1',
+      operationId,
     });
 
     expect(res.events).toHaveLength(1);
@@ -113,16 +132,18 @@ describe('aiAgentRouter — remote Human-in-the-loop', () => {
   });
 
   it('cancel clears the result and defaults the reason', async () => {
+    const operationId = 'op-cancel';
+    await insertOperation(operationId, userId);
     await userCaller().submitHeteroIntervention({
       cancelled: true,
-      operationId: 'op-1',
+      operationId,
       result: { should: 'be dropped' },
       toolCallId: 't2',
     });
 
-    const res = await heteroCaller().waitInterventionResponse({
+    const res = await heteroCaller(operationId).waitInterventionResponse({
       lastEventId: '0',
-      operationId: 'op-1',
+      operationId,
     });
 
     expect(res.events[0].data).toMatchObject({
@@ -134,24 +155,57 @@ describe('aiAgentRouter — remote Human-in-the-loop', () => {
   });
 
   it('waitInterventionResponse ignores non-intervention events on the stream', async () => {
+    const operationId = 'op-ignore-non-intervention';
+    await insertOperation(operationId, userId);
     // A plain stream event lands on the op's stream but is not an answer.
     store.events.push({
       data: {},
       id: String(++store.seq),
-      operationId: 'op-1',
+      operationId,
       stepIndex: 0,
       type: 'stream_chunk',
     });
 
-    const res = await heteroCaller().waitInterventionResponse({
+    const res = await heteroCaller(operationId).waitInterventionResponse({
       lastEventId: '0',
-      operationId: 'op-1',
+      operationId,
     });
 
     expect(res.events).toHaveLength(0);
   });
 
   describe('waitInterventionResponse ownership guard', () => {
+    it('lets a pre-deploy operation token read an operation owned by its subject', async () => {
+      await insertOperation('op-legacy-owned', userId);
+      await userCaller().submitHeteroIntervention({
+        operationId: 'op-legacy-owned',
+        result: { answer: 'yes' },
+        toolCallId: 't-legacy-own',
+      });
+
+      const res = await legacyHeteroCaller(userId).waitInterventionResponse({
+        lastEventId: '0',
+        operationId: 'op-legacy-owned',
+      });
+
+      expect(res.events).toHaveLength(1);
+      expect(res.events[0].data).toMatchObject({ toolCallId: 't-legacy-own' });
+    });
+
+    it("rejects a pre-deploy operation token reading another user's operation", async () => {
+      const otherUserId = await createTestUser(serverDB);
+      await insertOperation('op-legacy-others', otherUserId);
+
+      await expect(
+        legacyHeteroCaller(userId).waitInterventionResponse({
+          lastEventId: '0',
+          operationId: 'op-legacy-others',
+        }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+      await cleanupTestUser(serverDB, otherUserId);
+    });
+
     it('lets an owner token read its own operation', async () => {
       await insertOperation('op-owned', userId);
       await userCaller().submitHeteroIntervention({
@@ -199,15 +253,13 @@ describe('aiAgentRouter — remote Human-in-the-loop', () => {
       ).rejects.toMatchObject({ code: 'FORBIDDEN' });
     });
 
-    it('exempts the server-minted operation token from the ownership lookup', async () => {
-      // No agent_operations row exists for this id; the operation-token path
-      // must still succeed (it's trusted as server-minted).
-      const res = await heteroCaller().waitInterventionResponse({
-        lastEventId: '0',
-        operationId: 'op-no-row',
-      });
-
-      expect(res.events).toHaveLength(0);
+    it('rejects a server-minted token when its durable operation row is missing', async () => {
+      await expect(
+        heteroCaller('op-no-row').waitInterventionResponse({
+          lastEventId: '0',
+          operationId: 'op-no-row',
+        }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
     });
   });
 });

--- a/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultCapability.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultCapability.test.ts
@@ -3,16 +3,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { resolveServerDefaultHeterogeneousCapability } from '../aiAgent';
 
-const hasAvailableModel = vi.hoisted(() => vi.fn());
+const getSupportedModels = vi.hoisted(() => vi.fn());
 
 vi.mock('@/server/modules/ModelRuntime', () => ({
-  hasAvailableServerModel: hasAvailableModel,
+  getServerDefaultHeterogeneousModels: getSupportedModels,
+  SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES: ['claude-code', 'codex'],
 }));
 
 describe('resolveServerDefaultHeterogeneousCapability', () => {
   beforeEach(() => {
     vi.stubEnv('ENABLE_SERVER_DEFAULT_HETEROGENEOUS_AGENT', '1');
-    hasAvailableModel.mockResolvedValue(true);
+    getSupportedModels.mockResolvedValue({
+      'claude-code': [{ model: 'claude-server', providerId: 'anthropic' }],
+      'codex': [{ model: 'gpt-5.4', providerId: 'openai' }],
+    });
   });
 
   afterEach(() => {
@@ -25,9 +29,25 @@ describe('resolveServerDefaultHeterogeneousCapability', () => {
       agents: ['claude-code', 'codex'],
       enabled: true,
       model: 'lobehub-default',
+      models: {
+        'claude-code': [{ model: 'claude-server', providerId: 'anthropic' }],
+        'codex': [{ model: 'gpt-5.4', providerId: 'openai' }],
+      },
     });
 
-    expect(hasAvailableModel).toHaveBeenCalledOnce();
+    expect(getSupportedModels).toHaveBeenCalledOnce();
+  });
+
+  it('advertises only agents that have a compatible runtime model', async () => {
+    getSupportedModels.mockResolvedValue({
+      'claude-code': [{ model: 'claude-server', providerId: 'anthropic' }],
+      'codex': [],
+    });
+
+    await expect(resolveServerDefaultHeterogeneousCapability()).resolves.toMatchObject({
+      agents: ['claude-code'],
+      enabled: true,
+    });
   });
 
   it('does not read the model catalog when the deployment feature is disabled', async () => {
@@ -37,11 +57,11 @@ describe('resolveServerDefaultHeterogeneousCapability', () => {
       enabled: false,
       reason: 'disabled',
     });
-    expect(hasAvailableModel).not.toHaveBeenCalled();
+    expect(getSupportedModels).not.toHaveBeenCalled();
   });
 
   it('reports an invalid configuration when the server catalog has no models', async () => {
-    hasAvailableModel.mockResolvedValue(false);
+    getSupportedModels.mockResolvedValue({ 'claude-code': [], 'codex': [] });
 
     await expect(resolveServerDefaultHeterogeneousCapability()).resolves.toMatchObject({
       enabled: false,
@@ -50,7 +70,7 @@ describe('resolveServerDefaultHeterogeneousCapability', () => {
   });
 
   it('reports an invalid configuration when the server catalog cannot be loaded', async () => {
-    hasAvailableModel.mockRejectedValue(new Error('invalid model catalog'));
+    getSupportedModels.mockRejectedValue(new Error('invalid model catalog'));
 
     await expect(resolveServerDefaultHeterogeneousCapability()).resolves.toMatchObject({
       enabled: false,

--- a/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultCapability.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultCapability.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resolveServerDefaultHeterogeneousCapability } from '../aiAgent';
+
+const hasAvailableModel = vi.hoisted(() => vi.fn());
+
+vi.mock('@/server/modules/ModelRuntime', () => ({
+  hasAvailableServerModel: hasAvailableModel,
+}));
+
+describe('resolveServerDefaultHeterogeneousCapability', () => {
+  beforeEach(() => {
+    vi.stubEnv('ENABLE_SERVER_DEFAULT_HETEROGENEOUS_AGENT', '1');
+    hasAvailableModel.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it('reports the shared deployment model alias when the server catalog has a model', async () => {
+    await expect(resolveServerDefaultHeterogeneousCapability()).resolves.toEqual({
+      agents: ['claude-code', 'codex'],
+      enabled: true,
+      model: 'lobehub-default',
+    });
+
+    expect(hasAvailableModel).toHaveBeenCalledOnce();
+  });
+
+  it('does not read the model catalog when the deployment feature is disabled', async () => {
+    vi.stubEnv('ENABLE_SERVER_DEFAULT_HETEROGENEOUS_AGENT', '0');
+
+    await expect(resolveServerDefaultHeterogeneousCapability()).resolves.toMatchObject({
+      enabled: false,
+      reason: 'disabled',
+    });
+    expect(hasAvailableModel).not.toHaveBeenCalled();
+  });
+
+  it('reports an invalid configuration when the server catalog has no models', async () => {
+    hasAvailableModel.mockResolvedValue(false);
+
+    await expect(resolveServerDefaultHeterogeneousCapability()).resolves.toMatchObject({
+      enabled: false,
+      reason: 'invalidConfiguration',
+    });
+  });
+
+  it('reports an invalid configuration when the server catalog cannot be loaded', async () => {
+    hasAvailableModel.mockRejectedValue(new Error('invalid model catalog'));
+
+    await expect(resolveServerDefaultHeterogeneousCapability()).resolves.toMatchObject({
+      enabled: false,
+      reason: 'invalidConfiguration',
+    });
+  });
+});

--- a/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultOperation.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultOperation.test.ts
@@ -12,8 +12,8 @@ import { cleanupTestUser, createTestTopic, createTestUser } from './integration/
 
 let testDB: LobeChatDatabase;
 
-const { hasAvailableModel, initRuntime, resolveModel, signOperationToken } = vi.hoisted(() => ({
-  hasAvailableModel: vi.fn(),
+const { getSupportedModels, initRuntime, resolveModel, signOperationToken } = vi.hoisted(() => ({
+  getSupportedModels: vi.fn(),
   initRuntime: vi.fn(),
   resolveModel: vi.fn(),
   signOperationToken: vi.fn(),
@@ -24,9 +24,10 @@ vi.mock('@/database/core/db-adaptor', () => ({
 }));
 
 vi.mock('@/server/modules/ModelRuntime', () => ({
-  hasAvailableServerModel: hasAvailableModel,
+  getServerDefaultHeterogeneousModels: getSupportedModels,
   initModelRuntimeFromServerConfig: initRuntime,
-  resolveServerModel: resolveModel,
+  resolveServerDefaultHeterogeneousModel: resolveModel,
+  SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES: ['claude-code', 'codex'],
 }));
 
 vi.mock('@/libs/trpc/utils/internalJwt', async (importOriginal) => ({
@@ -45,7 +46,8 @@ describe('server-default heterogeneous operation control', () => {
       userId,
     } as any);
   const operationInput = (operationId: string) => ({
-    model: 'deployment-model',
+    agentType: 'codex' as const,
+    model: 'gpt-5.4',
     operationId,
     providerId: 'openai',
     topicId,
@@ -56,8 +58,11 @@ describe('server-default heterogeneous operation control', () => {
     userId = await createTestUser(testDB);
     topicId = await createTestTopic(testDB, userId);
     vi.stubEnv('ENABLE_SERVER_DEFAULT_HETEROGENEOUS_AGENT', '1');
-    hasAvailableModel.mockResolvedValue(true);
-    resolveModel.mockResolvedValue({ model: 'deployment-model', provider: 'openai' });
+    getSupportedModels.mockResolvedValue({
+      'claude-code': [{ model: 'claude-server', providerId: 'anthropic' }],
+      'codex': [{ model: 'gpt-5.4', providerId: 'openai' }],
+    });
+    resolveModel.mockResolvedValue({ model: 'gpt-5.4', provider: 'openai' });
     initRuntime.mockResolvedValue({});
     signOperationToken.mockResolvedValue('operation-token');
   });
@@ -78,8 +83,8 @@ describe('server-default heterogeneous operation control', () => {
       .from(agentOperations)
       .where(eq(agentOperations.id, 'desktop-operation-1'));
     expect(operation).toMatchObject({
-      metadata: { serverDefaultHeterogeneous: true },
-      model: 'deployment-model',
+      metadata: { agentType: 'codex', serverDefaultHeterogeneous: true },
+      model: 'gpt-5.4',
       provider: 'openai',
       status: 'running',
       topicId,
@@ -88,12 +93,13 @@ describe('server-default heterogeneous operation control', () => {
     });
     expect(signOperationToken).toHaveBeenCalledWith({
       capabilities: ['model:invoke'],
-      model: 'deployment-model',
+      model: 'gpt-5.4',
       operationId: 'desktop-operation-1',
       providerId: 'openai',
       userId,
       workspaceId: undefined,
     });
+    expect(resolveModel).toHaveBeenCalledWith('codex', 'openai', 'gpt-5.4');
     expect(initRuntime).toHaveBeenCalledWith({
       actorUserId: userId,
       provider: 'openai',
@@ -142,6 +148,24 @@ describe('server-default heterogeneous operation control', () => {
     expect(signOperationToken).not.toHaveBeenCalled();
   });
 
+  it('does not persist or mint for an agent/runtime pair outside the V1 support matrix', async () => {
+    resolveModel.mockRejectedValueOnce(new Error('unsupported agent/runtime pair'));
+
+    await expect(
+      caller().beginServerDefaultHeterogeneousOperation({
+        ...operationInput('desktop-operation-unsupported'),
+        agentType: 'claude-code',
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    const operations = await testDB
+      .select()
+      .from(agentOperations)
+      .where(eq(agentOperations.id, 'desktop-operation-unsupported'));
+    expect(operations).toHaveLength(0);
+    expect(signOperationToken).not.toHaveBeenCalled();
+  });
+
   it('settles idempotently and does not remint a token for a reused operation id', async () => {
     const operationId = 'desktop-operation-4';
     await caller().beginServerDefaultHeterogeneousOperation(operationInput(operationId));
@@ -168,7 +192,7 @@ describe('server-default heterogeneous operation control', () => {
     const operationId = 'unrelated-operation';
     await testDB.insert(agentOperations).values({
       id: operationId,
-      model: 'deployment-model',
+      model: 'gpt-5.4',
       provider: 'openai',
       status: 'running',
       topicId,

--- a/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultOperation.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultOperation.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment node
+import type { LobeChatDatabase } from '@lobechat/database';
+import { agentOperations } from '@lobechat/database/schemas';
+import { getTestDB } from '@lobechat/database/test-utils';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as InternalJwtModule from '@/libs/trpc/utils/internalJwt';
+
+import { aiAgentRouter } from '../aiAgent';
+import { cleanupTestUser, createTestTopic, createTestUser } from './integration/setup';
+
+let testDB: LobeChatDatabase;
+
+const { hasAvailableModel, initRuntime, resolveModel, signOperationToken } = vi.hoisted(() => ({
+  hasAvailableModel: vi.fn(),
+  initRuntime: vi.fn(),
+  resolveModel: vi.fn(),
+  signOperationToken: vi.fn(),
+}));
+
+vi.mock('@/database/core/db-adaptor', () => ({
+  getServerDB: vi.fn(() => testDB),
+}));
+
+vi.mock('@/server/modules/ModelRuntime', () => ({
+  hasAvailableServerModel: hasAvailableModel,
+  initModelRuntimeFromServerConfig: initRuntime,
+  resolveServerModel: resolveModel,
+}));
+
+vi.mock('@/libs/trpc/utils/internalJwt', async (importOriginal) => ({
+  ...(await importOriginal<typeof InternalJwtModule>()),
+  signHeteroOperationJWT: signOperationToken,
+}));
+
+describe('server-default heterogeneous operation control', () => {
+  let topicId: string;
+  let userId: string;
+
+  const caller = (purpose?: string) =>
+    aiAgentRouter.createCaller({
+      jwtPayload: { userId },
+      oidcAuth: { purpose, sub: userId },
+      userId,
+    } as any);
+  const operationInput = (operationId: string) => ({
+    model: 'deployment-model',
+    operationId,
+    providerId: 'openai',
+    topicId,
+  });
+
+  beforeEach(async () => {
+    testDB = await getTestDB();
+    userId = await createTestUser(testDB);
+    topicId = await createTestTopic(testDB, userId);
+    vi.stubEnv('ENABLE_SERVER_DEFAULT_HETEROGENEOUS_AGENT', '1');
+    hasAvailableModel.mockResolvedValue(true);
+    resolveModel.mockResolvedValue({ model: 'deployment-model', provider: 'openai' });
+    initRuntime.mockResolvedValue({});
+    signOperationToken.mockResolvedValue('operation-token');
+  });
+
+  afterEach(async () => {
+    await cleanupTestUser(testDB, userId);
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it('persists the scoped operation before minting a model-invocation token', async () => {
+    await expect(
+      caller().beginServerDefaultHeterogeneousOperation(operationInput('desktop-operation-1')),
+    ).resolves.toMatchObject({ model: 'lobehub-default', token: 'operation-token' });
+
+    const [operation] = await testDB
+      .select()
+      .from(agentOperations)
+      .where(eq(agentOperations.id, 'desktop-operation-1'));
+    expect(operation).toMatchObject({
+      metadata: { serverDefaultHeterogeneous: true },
+      model: 'deployment-model',
+      provider: 'openai',
+      status: 'running',
+      topicId,
+      userId,
+      workspaceId: null,
+    });
+    expect(signOperationToken).toHaveBeenCalledWith({
+      capabilities: ['model:invoke'],
+      model: 'deployment-model',
+      operationId: 'desktop-operation-1',
+      providerId: 'openai',
+      userId,
+      workspaceId: undefined,
+    });
+    expect(initRuntime).toHaveBeenCalledWith({
+      actorUserId: userId,
+      provider: 'openai',
+      workspaceId: undefined,
+    });
+  });
+
+  it('requires a normal user OIDC token for the control plane', async () => {
+    await expect(
+      caller('hetero-operation').beginServerDefaultHeterogeneousOperation(
+        operationInput('desktop-operation-2'),
+      ),
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    expect(signOperationToken).not.toHaveBeenCalled();
+  });
+
+  it('does not persist or mint when the deployment capability is disabled', async () => {
+    vi.stubEnv('ENABLE_SERVER_DEFAULT_HETEROGENEOUS_AGENT', '0');
+
+    await expect(
+      caller().beginServerDefaultHeterogeneousOperation(operationInput('desktop-operation-3')),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+    const operations = await testDB
+      .select()
+      .from(agentOperations)
+      .where(eq(agentOperations.id, 'desktop-operation-3'));
+    expect(operations).toHaveLength(0);
+    expect(signOperationToken).not.toHaveBeenCalled();
+  });
+
+  it('does not persist or mint when the selected provider runtime is unavailable', async () => {
+    initRuntime.mockRejectedValueOnce(new Error('missing selected provider credentials'));
+
+    await expect(
+      caller().beginServerDefaultHeterogeneousOperation(
+        operationInput('desktop-operation-runtime'),
+      ),
+    ).rejects.toMatchObject({ code: 'PRECONDITION_FAILED' });
+
+    const operations = await testDB
+      .select()
+      .from(agentOperations)
+      .where(eq(agentOperations.id, 'desktop-operation-runtime'));
+    expect(operations).toHaveLength(0);
+    expect(signOperationToken).not.toHaveBeenCalled();
+  });
+
+  it('settles idempotently and does not remint a token for a reused operation id', async () => {
+    const operationId = 'desktop-operation-4';
+    await caller().beginServerDefaultHeterogeneousOperation(operationInput(operationId));
+
+    await expect(
+      caller().finishServerDefaultHeterogeneousOperation({ operationId, result: 'done' }),
+    ).resolves.toEqual({ success: true });
+    await expect(
+      caller().finishServerDefaultHeterogeneousOperation({ operationId, result: 'done' }),
+    ).resolves.toEqual({ success: true });
+    await expect(
+      caller().beginServerDefaultHeterogeneousOperation(operationInput(operationId)),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+
+    const [operation] = await testDB
+      .select({ status: agentOperations.status })
+      .from(agentOperations)
+      .where(eq(agentOperations.id, operationId));
+    expect(operation.status).toBe('done');
+    expect(signOperationToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not settle an unrelated operation owned by the same user', async () => {
+    const operationId = 'unrelated-operation';
+    await testDB.insert(agentOperations).values({
+      id: operationId,
+      model: 'deployment-model',
+      provider: 'openai',
+      status: 'running',
+      topicId,
+      userId,
+    });
+
+    await expect(
+      caller().finishServerDefaultHeterogeneousOperation({ operationId, result: 'done' }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+    const [operation] = await testDB
+      .select({ status: agentOperations.status })
+      .from(agentOperations)
+      .where(eq(agentOperations.id, operationId));
+    expect(operation.status).toBe('running');
+  });
+});

--- a/apps/server/src/routers/lambda/aiAgent.ts
+++ b/apps/server/src/routers/lambda/aiAgent.ts
@@ -20,6 +20,7 @@ import { z } from 'zod';
 
 import { withScopedPermission } from '@/business/server/trpc-middlewares/rbacPermission';
 import { wsCompatProcedure } from '@/business/server/trpc-middlewares/workspaceAuth';
+import { AgentOperationModel } from '@/database/models/agentOperation';
 import { MessageModel } from '@/database/models/message';
 import { ThreadModel } from '@/database/models/thread';
 import { TopicModel } from '@/database/models/topic';
@@ -28,9 +29,14 @@ import { agentOperations, topics, workspaceMembers } from '@/database/schemas';
 import type { LobeChatDatabase } from '@/database/type';
 import { heteroAuthedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
-import { signUserJWT } from '@/libs/trpc/utils/internalJwt';
+import { signHeteroOperationJWT, signUserJWT } from '@/libs/trpc/utils/internalJwt';
 import { createStreamEventManager } from '@/server/modules/AgentRuntime/factory';
 import { unwrapPgError } from '@/server/modules/AgentRuntime/pgError';
+import {
+  hasAvailableServerModel,
+  initModelRuntimeFromServerConfig,
+  resolveServerModel,
+} from '@/server/modules/ModelRuntime';
 import {
   assertCanUseMessageTargets,
   assertCanUseTopicTargets,
@@ -41,6 +47,10 @@ import { AiAgentService } from '@/server/services/aiAgent';
 import { AiChatService } from '@/server/services/aiChat';
 import { getFileProxyUrl } from '@/server/services/file';
 import { HeterogeneousAgentService } from '@/server/services/heterogeneousAgent';
+import {
+  HeteroOperationPrincipalError,
+  resolveActiveHeteroOperationPrincipal,
+} from '@/server/services/heterogeneousAgent/operationPrincipal';
 
 const log = debug('lobe-server:ai-agent-router');
 
@@ -685,7 +695,9 @@ const SubmitHeteroInterventionSchema = z.object({
   toolCallId: z.string().min(1),
 });
 
-const aiAgentProcedure = wsCompatProcedure.use(serverDatabase).use(async (opts) => {
+const aiAgentBaseProcedure = wsCompatProcedure.use(serverDatabase);
+
+const aiAgentProcedure = aiAgentBaseProcedure.use(async (opts) => {
   const { ctx } = opts;
   const wsId = ctx.workspaceId ?? undefined;
 
@@ -722,17 +734,272 @@ const aiAgentProcedure = wsCompatProcedure.use(serverDatabase).use(async (opts) 
   });
 });
 
-// Dedicated procedure for hetero-agent ingest/finish endpoints.
-// Requires a `hetero-operation` JWT (4h expiry) — normal user tokens are rejected,
-// so only the sandbox/device that received the JWT from execAgent can call these.
-//
-// The workspace header is optional because older gateways may not forward it.
-// Handlers resolve the authoritative scope from `topicId`, then verify the token
-// subject owns the personal topic or is an active member of its workspace.
+// Dedicated procedure for hetero-agent callbacks. Narrow operation tokens are
+// re-authorized against durable operation state; pre-deploy operation tokens and
+// normal user OIDC tokens go through the legacy ownership guards.
 const heteroAgentProcedure = heteroAuthedProcedure.use(serverDatabase);
 const aiAgentWriteProcedure = aiAgentProcedure.use(withScopedPermission('message:create'));
 
+const authorizeOperationCallback = async (
+  ctx: {
+    heteroAuthKind: string;
+    heteroOperation?: NonNullable<
+      Parameters<typeof resolveActiveHeteroOperationPrincipal>[0]['claims']
+    > | null;
+    serverDB: LobeChatDatabase;
+  },
+  operationId: string,
+  capability: 'hetero:finish' | 'hetero:ingest' | 'hetero:intervention:read',
+) => {
+  if (ctx.heteroAuthKind !== 'operation') return;
+  if (!ctx.heteroOperation) throw new TRPCError({ code: 'UNAUTHORIZED' });
+  try {
+    await resolveActiveHeteroOperationPrincipal({
+      capability,
+      claims: ctx.heteroOperation,
+      db: ctx.serverDB,
+      operationId,
+    });
+  } catch (error) {
+    if (!(error instanceof HeteroOperationPrincipalError)) throw error;
+    throw new TRPCError({
+      cause: error,
+      code: error.status === 401 ? 'UNAUTHORIZED' : error.status === 409 ? 'CONFLICT' : 'FORBIDDEN',
+      message: error.message,
+    });
+  }
+};
+
+const assertServerDefaultControlAuth = (oidcAuth: Record<string, unknown> | null | undefined) => {
+  if (!oidcAuth || oidcAuth.purpose) {
+    throw new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: 'Server-default operations require Desktop OIDC authentication',
+    });
+  }
+};
+
+export const resolveServerDefaultHeterogeneousCapability = async () => {
+  const base = {
+    agents: ['claude-code', 'codex'] as const,
+    model: 'lobehub-default' as const,
+  };
+  if (process.env.ENABLE_SERVER_DEFAULT_HETEROGENEOUS_AGENT === '0') {
+    return { ...base, enabled: false as const, reason: 'disabled' as const };
+  }
+
+  try {
+    if (!(await hasAvailableServerModel())) {
+      return { ...base, enabled: false as const, reason: 'invalidConfiguration' as const };
+    }
+    return { ...base, enabled: true as const };
+  } catch (error) {
+    log('Server-default heterogeneous capability is unavailable: %O', error);
+    return { ...base, enabled: false as const, reason: 'invalidConfiguration' as const };
+  }
+};
+
+const resolveServerDefaultControlOperation = async (params: {
+  db: LobeChatDatabase;
+  operationId: string;
+  userId: string;
+}) => {
+  const [operation] = await params.db
+    .select({
+      metadata: agentOperations.metadata,
+      model: agentOperations.model,
+      provider: agentOperations.provider,
+      status: agentOperations.status,
+      workspaceId: agentOperations.workspaceId,
+    })
+    .from(agentOperations)
+    .where(
+      and(eq(agentOperations.id, params.operationId), eq(agentOperations.userId, params.userId)),
+    )
+    .limit(1);
+
+  if (!operation || operation.metadata?.serverDefaultHeterogeneous !== true) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'Operation is outside the caller scope' });
+  }
+
+  if (operation.workspaceId) {
+    const [membership] = await params.db
+      .select({ userId: workspaceMembers.userId })
+      .from(workspaceMembers)
+      .where(
+        and(
+          eq(workspaceMembers.workspaceId, operation.workspaceId),
+          eq(workspaceMembers.userId, params.userId),
+          isNull(workspaceMembers.deletedAt),
+        ),
+      )
+      .limit(1);
+    if (!membership) {
+      throw new TRPCError({ code: 'FORBIDDEN', message: 'Operation is outside the caller scope' });
+    }
+  }
+
+  return {
+    model: new AgentOperationModel(params.db, params.userId, operation.workspaceId ?? undefined),
+    operation,
+  };
+};
+
+const settleServerDefaultControlOperation = async (params: {
+  currentStatus: string;
+  model: AgentOperationModel;
+  operationId: string;
+  targetStatus: 'done' | 'error' | 'interrupted';
+}) => {
+  if (params.currentStatus === params.targetStatus) return;
+  if (params.currentStatus !== 'running') {
+    throw new TRPCError({ code: 'CONFLICT', message: 'Operation has already ended' });
+  }
+
+  if (await params.model.settleRunning(params.operationId, params.targetStatus)) return;
+
+  // Another terminal request won the CAS after the scope read. Treat an
+  // identical terminal result as idempotent and reject a conflicting result.
+  const current = await params.model.findById(params.operationId);
+  if (current?.status !== params.targetStatus) {
+    throw new TRPCError({ code: 'CONFLICT', message: 'Operation has already ended' });
+  }
+};
+
 export const aiAgentRouter = router({
+  getServerDefaultHeterogeneousCapability: aiAgentBaseProcedure.query(() =>
+    resolveServerDefaultHeterogeneousCapability(),
+  ),
+
+  beginServerDefaultHeterogeneousOperation: aiAgentBaseProcedure
+    .input(
+      z.object({
+        agentId: z.string().optional(),
+        model: z.string().min(1),
+        operationId: z.string().min(1),
+        providerId: z.string().min(1),
+        topicId: z.string().min(1),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      assertServerDefaultControlAuth(ctx.oidcAuth);
+      const workspaceId = await resolveHeteroTopicWorkspace({
+        db: ctx.serverDB,
+        requestedWorkspaceId: ctx.workspaceId,
+        topicId: input.topicId,
+        userId: ctx.userId,
+      });
+      if (workspaceId && input.agentId) {
+        await assertCanUseWorkspaceAgent({
+          agentId: input.agentId,
+          db: ctx.serverDB,
+          userId: ctx.userId,
+          workspaceId,
+        });
+      }
+      const capability = await resolveServerDefaultHeterogeneousCapability();
+      if (!capability.enabled) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message:
+            capability.reason === 'disabled'
+              ? 'Server-default agents are disabled'
+              : 'No server model is available',
+        });
+      }
+      const selection = await resolveServerModel(input.providerId, input.model).catch((error) => {
+        throw new TRPCError({
+          cause: error,
+          code: 'BAD_REQUEST',
+          message: 'The selected server model is not available',
+        });
+      });
+      await initModelRuntimeFromServerConfig({
+        actorUserId: ctx.userId,
+        provider: selection.provider,
+        workspaceId,
+      }).catch((error) => {
+        log('Selected server model runtime is unavailable: %O', error);
+        throw new TRPCError({
+          cause: error,
+          code: 'PRECONDITION_FAILED',
+          message: 'The selected server model runtime is unavailable',
+        });
+      });
+
+      const model = new AgentOperationModel(ctx.serverDB, ctx.userId, workspaceId);
+      await model.recordStart({
+        agentId: input.agentId,
+        metadata: { serverDefaultHeterogeneous: true },
+        model: selection.model,
+        operationId: input.operationId,
+        provider: selection.provider,
+        topicId: input.topicId,
+        trigger: RequestTrigger.Chat,
+      });
+      const operation = await model.findById(input.operationId);
+      if (
+        !operation ||
+        operation.userId !== ctx.userId ||
+        operation.workspaceId !== (workspaceId ?? null) ||
+        operation.status !== 'running' ||
+        operation.topicId !== input.topicId ||
+        operation.agentId !== (input.agentId ?? null) ||
+        operation.model !== selection.model ||
+        operation.provider !== selection.provider
+      ) {
+        throw new TRPCError({ code: 'CONFLICT', message: 'Operation id is already in use' });
+      }
+
+      return {
+        model: 'lobehub-default' as const,
+        token: await signHeteroOperationJWT({
+          capabilities: ['model:invoke'],
+          model: selection.model,
+          operationId: input.operationId,
+          providerId: selection.provider,
+          userId: ctx.userId,
+          workspaceId,
+        }),
+      };
+    }),
+
+  finishServerDefaultHeterogeneousOperation: aiAgentBaseProcedure
+    .input(z.object({ operationId: z.string().min(1), result: z.enum(['done', 'error']) }))
+    .mutation(async ({ input, ctx }) => {
+      assertServerDefaultControlAuth(ctx.oidcAuth);
+      const { model, operation } = await resolveServerDefaultControlOperation({
+        db: ctx.serverDB,
+        operationId: input.operationId,
+        userId: ctx.userId,
+      });
+      await settleServerDefaultControlOperation({
+        currentStatus: operation.status,
+        model,
+        operationId: input.operationId,
+        targetStatus: input.result,
+      });
+      return { success: true as const };
+    }),
+
+  cancelServerDefaultHeterogeneousOperation: aiAgentBaseProcedure
+    .input(z.object({ operationId: z.string().min(1) }))
+    .mutation(async ({ input, ctx }) => {
+      assertServerDefaultControlAuth(ctx.oidcAuth);
+      const { model, operation } = await resolveServerDefaultControlOperation({
+        db: ctx.serverDB,
+        operationId: input.operationId,
+        userId: ctx.userId,
+      });
+      await settleServerDefaultControlOperation({
+        currentStatus: operation.status,
+        model,
+        operationId: input.operationId,
+        targetStatus: 'interrupted',
+      });
+      return { success: true as const };
+    }),
+
   /**
    * Create Thread for client-side task execution in Group mode
    *
@@ -1705,6 +1972,8 @@ export const aiAgentRouter = router({
   heteroIngest: heteroAgentProcedure.input(HeteroIngestSchema).mutation(async ({ input, ctx }) => {
     const { agentType, assistantMessageId, events, operationId, topicId } = input;
 
+    await authorizeOperationCallback(ctx, operationId, 'hetero:ingest');
+
     log(
       'heteroIngest: topic=%s op=%s type=%s count=%d',
       topicId,
@@ -1756,6 +2025,8 @@ export const aiAgentRouter = router({
    */
   heteroFinish: heteroAgentProcedure.input(HeteroFinishSchema).mutation(async ({ input, ctx }) => {
     const { agentType, assistantMessageId, error, operationId, result, sessionId, topicId } = input;
+
+    await authorizeOperationCallback(ctx, operationId, 'hetero:finish');
 
     log('heteroFinish: topic=%s op=%s type=%s result=%s', topicId, operationId, agentType, result);
 
@@ -1813,16 +2084,18 @@ export const aiAgentRouter = router({
     .query(async ({ input, ctx }) => {
       const { operationId, lastEventId, blockMs } = input;
 
+      await authorizeOperationCallback(ctx, operationId, 'hetero:intervention:read');
+
       // Ownership guard, mirroring heteroIngest / heteroFinish. The op stream is
       // read by `operationId` alone, so an owner-token caller (a logged-in
       // desktop reusing its own OIDC session) must prove it owns THIS operation
       // — otherwise any signed-in user could long-poll another run's
       // `agent_intervention_response` payloads by id. Bind the guard to the
       // operation row directly (tighter than the topic-level guard the write
-      // paths use, since the read has no topicId to key on). The operation-token
-      // path is exempt: it's server-minted and handed only to the sandbox /
-      // device running this op.
-      if (ctx.heteroAuthKind === 'user') {
+      // paths use, since the read has no topicId to key on). Strict operation-token
+      // callers already passed the durable principal check above; user tokens and
+      // pre-deploy operation tokens use the legacy ownership lookup.
+      if (ctx.heteroAuthKind !== 'operation') {
         const [operationRow] = await ctx.serverDB
           .select({ userId: agentOperations.userId })
           .from(agentOperations)

--- a/apps/server/src/routers/lambda/aiAgent.ts
+++ b/apps/server/src/routers/lambda/aiAgent.ts
@@ -33,9 +33,10 @@ import { signHeteroOperationJWT, signUserJWT } from '@/libs/trpc/utils/internalJ
 import { createStreamEventManager } from '@/server/modules/AgentRuntime/factory';
 import { unwrapPgError } from '@/server/modules/AgentRuntime/pgError';
 import {
-  hasAvailableServerModel,
+  getServerDefaultHeterogeneousModels,
   initModelRuntimeFromServerConfig,
-  resolveServerModel,
+  resolveServerDefaultHeterogeneousModel,
+  SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES,
 } from '@/server/modules/ModelRuntime';
 import {
   assertCanUseMessageTargets,
@@ -781,21 +782,35 @@ const assertServerDefaultControlAuth = (oidcAuth: Record<string, unknown> | null
 
 export const resolveServerDefaultHeterogeneousCapability = async () => {
   const base = {
-    agents: ['claude-code', 'codex'] as const,
     model: 'lobehub-default' as const,
   };
   if (process.env.ENABLE_SERVER_DEFAULT_HETEROGENEOUS_AGENT === '0') {
-    return { ...base, enabled: false as const, reason: 'disabled' as const };
+    return { ...base, agents: [], enabled: false as const, reason: 'disabled' as const };
   }
 
   try {
-    if (!(await hasAvailableServerModel())) {
-      return { ...base, enabled: false as const, reason: 'invalidConfiguration' as const };
+    const models = await getServerDefaultHeterogeneousModels();
+    const agents = SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES.filter(
+      (agentType) => models[agentType].length > 0,
+    );
+    if (agents.length === 0) {
+      return {
+        ...base,
+        agents,
+        enabled: false as const,
+        models,
+        reason: 'invalidConfiguration' as const,
+      };
     }
-    return { ...base, enabled: true as const };
+    return { ...base, agents, enabled: true as const, models };
   } catch (error) {
     log('Server-default heterogeneous capability is unavailable: %O', error);
-    return { ...base, enabled: false as const, reason: 'invalidConfiguration' as const };
+    return {
+      ...base,
+      agents: [],
+      enabled: false as const,
+      reason: 'invalidConfiguration' as const,
+    };
   }
 };
 
@@ -874,6 +889,7 @@ export const aiAgentRouter = router({
   beginServerDefaultHeterogeneousOperation: aiAgentBaseProcedure
     .input(
       z.object({
+        agentType: z.enum(SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES),
         agentId: z.string().optional(),
         model: z.string().min(1),
         operationId: z.string().min(1),
@@ -907,11 +923,15 @@ export const aiAgentRouter = router({
               : 'No server model is available',
         });
       }
-      const selection = await resolveServerModel(input.providerId, input.model).catch((error) => {
+      const selection = await resolveServerDefaultHeterogeneousModel(
+        input.agentType,
+        input.providerId,
+        input.model,
+      ).catch((error) => {
         throw new TRPCError({
           cause: error,
           code: 'BAD_REQUEST',
-          message: 'The selected server model is not available',
+          message: 'The selected server model is not available for this heterogeneous agent',
         });
       });
       await initModelRuntimeFromServerConfig({
@@ -930,7 +950,7 @@ export const aiAgentRouter = router({
       const model = new AgentOperationModel(ctx.serverDB, ctx.userId, workspaceId);
       await model.recordStart({
         agentId: input.agentId,
-        metadata: { serverDefaultHeterogeneous: true },
+        metadata: { agentType: input.agentType, serverDefaultHeterogeneous: true },
         model: selection.model,
         operationId: input.operationId,
         provider: selection.provider,
@@ -946,7 +966,8 @@ export const aiAgentRouter = router({
         operation.topicId !== input.topicId ||
         operation.agentId !== (input.agentId ?? null) ||
         operation.model !== selection.model ||
-        operation.provider !== selection.provider
+        operation.provider !== selection.provider ||
+        operation.metadata?.agentType !== input.agentType
       ) {
         throw new TRPCError({ code: 'CONFLICT', message: 'Operation id is already in use' });
       }

--- a/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
+++ b/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
@@ -142,13 +142,16 @@ export class CompletionLifecycle {
 
   /**
    * Persist the initial `agent_operations` row when an operation is created.
-   * Fire-and-forget: a DB outage here must never block the runtime startup
-   * path — `dispatchHooks` will still finalize the row if one was written.
+   * Returns whether the row write succeeded so security-sensitive callers can
+   * require durable state before dispatch. Other runtime paths may preserve
+   * the historical non-blocking behavior by ignoring the result.
    */
-  async recordStart(params: RecordOperationStartParams): Promise<void> {
+  async recordStart(params: RecordOperationStartParams): Promise<boolean> {
+    let persisted = true;
     try {
       await this.agentOperationModel.recordStart(params);
     } catch (error) {
+      persisted = false;
       log('[%s] Failed to record operation start (non-fatal): %O', params.operationId, error);
     }
 
@@ -170,6 +173,8 @@ export class CompletionLifecycle {
         ),
       );
     }
+
+    return persisted;
   }
 
   /**

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
@@ -1,4 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import { CompletionLifecycle } from '@/server/services/agentRuntime/CompletionLifecycle';
 
 import { AiAgentService } from '../index';
 
@@ -72,7 +74,7 @@ vi.mock('@/libs/trusted-client', () => ({
 }));
 
 vi.mock('@/libs/trpc/utils/internalJwt', () => ({
-  signOperationJwt: vi.fn().mockResolvedValue('op-jwt'),
+  signHeteroOperationJWT: vi.fn().mockResolvedValue('op-jwt'),
   signUserJWT: vi.fn().mockResolvedValue('user-jwt'),
 }));
 
@@ -212,11 +214,13 @@ vi.mock('@/server/services/heterogeneousAgent/remoteDeviceHeteroContext', () => 
 
 describe('AiAgentService.execAgent - hetero early-exit file attachments', () => {
   let service: AiAgentService;
+  let recordStartSpy: MockInstance<CompletionLifecycle['recordStart']>;
   const mockDb = {} as any;
   const userId = 'test-user-id';
 
   beforeEach(() => {
     vi.clearAllMocks();
+    recordStartSpy = vi.spyOn(CompletionLifecycle.prototype, 'recordStart').mockResolvedValue(true);
     topicMock.appendRunningOperationChild.mockResolvedValue(true);
     topicMock.create.mockResolvedValue({ id: 'topic-1', metadata: undefined });
     topicMock.findById.mockResolvedValue(undefined);
@@ -249,11 +253,23 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
   });
 
   afterEach(() => {
+    recordStartSpy.mockRestore();
     vi.clearAllMocks();
   });
 
   const findUserMessageCreate = () =>
     mockMessageCreate.mock.calls.find((call) => call[0].role === 'user');
+
+  it('does not dispatch a heterogeneous run when its durable operation row fails', async () => {
+    recordStartSpy.mockResolvedValueOnce(false);
+
+    await expect(
+      service.execAgent({ agentId: 'agent-1', prompt: 'Run the build' }),
+    ).rejects.toThrow('Failed to persist heterogeneous agent operation');
+
+    expect(mockDispatchAgentRun).not.toHaveBeenCalled();
+    expect(mockSpawnHeteroSandbox).not.toHaveBeenCalled();
+  });
 
   it('should attach fileIds to the user message (SPA gateway device/sandbox mode)', async () => {
     // regression: the hetero early exit used to create the user message

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -129,7 +129,7 @@ import {
 import { shouldEnableBuiltinSkill } from '@/helpers/skillFilters';
 import { buildConnectorManifests } from '@/libs/mcp/buildConnectorManifests';
 import { patchManifestWithPermissions } from '@/libs/mcp/connectorPermissionCheck';
-import { signOperationJwt, signUserJWT } from '@/libs/trpc/utils/internalJwt';
+import { signHeteroOperationJWT, signUserJWT } from '@/libs/trpc/utils/internalJwt';
 import {
   createAgentStateManager,
   createStreamEventManager,
@@ -2323,41 +2323,28 @@ export class AiAgentService {
       // generated here (authoritative) and flows through to heteroIngest /
       // heteroFinish unchanged. Without this row the run is invisible to the
       // operation lifecycle: verify (ensureForOperation), repair (parent chain),
-      // judge (op.model/provider) and tracing all key off it. Terminal state +
-      // the trace snapshot are written back in heteroFinish. Non-fatal: a
-      // tracing/op-row insert hiccup must never fail the user's run.
-      try {
-        // Route through CompletionLifecycle — NOT the raw operation model — so the
-        // hetero run is a first-class lifecycle peer of the in-process runtime.
-        // recordStart additionally instantiates the task's verify plan when this
-        // is a top-level task op (taskId && !parentOperationId); the hetero finish
-        // side (heteroFinish → CompletionLifecycle.dispatchHooks) then runs the
-        // delivery-checker gate against that plan. Calling the bare operation model
-        // here is exactly what silently degraded verify to off for every hetero
-        // task run (the plan was never created at start).
-        await new CompletionLifecycle(this.db, this.userId, this.workspaceId).recordStart({
-          agentId: persistAgentId,
-          chatGroupId: appContext?.groupId ?? null,
-          maxSteps,
-          // Seed the heterogeneous provider (claude-code / codex / …), NOT the
-          // agent's configured chat provider — the run executes on the CLI, so
-          // `provider` (e.g. `lobehub`) and `model` (e.g. `deepseek-v4-pro`) are
-          // irrelevant. `model` is intentionally left unset: the real executed
-          // model arrives mid-stream and is backfilled by heteroFinish. Mirrors the
-          // assistant-message seeding above (provider: heteroType, model: undefined).
-          operationId,
-          // Top-level dispatch carries no parent; pass it through so the verify
-          // plan gate (taskId && !parentOperationId) reads the real lineage and a
-          // repair/verifier sub-run never re-instantiates its own plan here.
-          parentOperationId,
-          provider: heteroType,
-          taskId: operationTaskId ?? null,
-          threadId: appContext?.threadId ?? null,
-          topicId,
-          trigger,
-        });
-      } catch (err) {
-        log('execAgent: hetero recordStart failed (non-fatal): %O', err);
+      // judge (op.model/provider) and tracing all key off it. The durable row is
+      // also an authentication prerequisite: every callback
+      // re-authorizes its operation token against this exact principal. Do not
+      // mint a token or dispatch/spawn when persistence fails.
+      const operationPersisted = await new CompletionLifecycle(
+        this.db,
+        this.userId,
+        this.workspaceId,
+      ).recordStart({
+        agentId: persistAgentId,
+        chatGroupId: appContext?.groupId ?? null,
+        maxSteps,
+        operationId,
+        parentOperationId,
+        provider: heteroType,
+        taskId: operationTaskId ?? null,
+        threadId: appContext?.threadId ?? null,
+        topicId,
+        trigger,
+      });
+      if (!operationPersisted) {
+        throw new Error('Failed to persist heterogeneous agent operation');
       }
 
       // Read resume session id for next-turn continuity.
@@ -2369,7 +2356,12 @@ export class AiAgentService {
       // heteroIngest / heteroFinish without full user credentials.
       let operationJwt: string;
       try {
-        operationJwt = await signOperationJwt(this.userId);
+        operationJwt = await signHeteroOperationJWT({
+          capabilities: ['hetero:ingest', 'hetero:finish', 'hetero:intervention:read'],
+          operationId,
+          userId: this.userId,
+          workspaceId: this.workspaceId,
+        });
       } catch (err) {
         log('execAgent: failed to sign operation JWT for hetero run: %O', err);
         throw new Error('Failed to sign operation JWT for hetero agent', { cause: err });

--- a/apps/server/src/services/heterogeneousAgent/operationPrincipal.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/operationPrincipal.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { LobeChatDatabase } from '@/database/type';
+import type { HeteroOperationJwtClaims } from '@/libs/trpc/utils/internalJwt';
+
+import {
+  HeteroOperationPrincipalError,
+  resolveActiveHeteroOperationPrincipal,
+} from './operationPrincipal';
+
+const { activeUser, hasMembership, hasPermission } = vi.hoisted(() => ({
+  activeUser: vi.fn(),
+  hasMembership: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+vi.mock('@/libs/oidc-provider/access-control', () => ({ assertOIDCUserActive: activeUser }));
+vi.mock('@/database/models/workspace', () => ({
+  hasActiveWorkspaceMembership: hasMembership,
+}));
+vi.mock('@/database/models/rbac', () => ({
+  RbacModel: class {
+    hasAnyPermission = hasPermission;
+  },
+}));
+vi.mock('@/utils/rbac', () => ({ getScopePermissions: () => ['permission'] }));
+
+const claims: HeteroOperationJwtClaims = {
+  aud: 'urn:lobehub:hetero-operation',
+  capabilities: ['model:invoke'],
+  exp: 2,
+  iat: 1,
+  iss: 'urn:lobehub:internal',
+  jti: 'jti-1',
+  operation_id: 'op-1',
+  purpose: 'hetero-operation',
+  sub: 'user-1',
+};
+
+const dbWithOperation = (operation: unknown) => {
+  const query = {
+    from: vi.fn(() => query),
+    limit: vi.fn(async () => (operation ? [operation] : [])),
+    where: vi.fn(() => query),
+  };
+  return { select: vi.fn(() => query) } as unknown as LobeChatDatabase;
+};
+
+describe('resolveActiveHeteroOperationPrincipal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    activeUser.mockResolvedValue(undefined);
+    hasMembership.mockResolvedValue(true);
+    hasPermission.mockResolvedValue(true);
+  });
+
+  it('re-authorizes the durable running operation on each request', async () => {
+    const principal = await resolveActiveHeteroOperationPrincipal({
+      capability: 'model:invoke',
+      claims,
+      db: dbWithOperation({ id: 'op-1', status: 'running', userId: 'user-1', workspaceId: null }),
+      operationId: 'op-1',
+    });
+
+    expect(principal).toEqual({ operationId: 'op-1', userId: 'user-1', workspaceId: undefined });
+    expect(activeUser).toHaveBeenCalledWith(expect.anything(), 'user-1');
+    expect(hasPermission).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a token that does not grant the requested operation', async () => {
+    await expect(
+      resolveActiveHeteroOperationPrincipal({
+        capability: 'model:invoke',
+        claims,
+        db: dbWithOperation(null),
+        operationId: 'other',
+      }),
+    ).rejects.toMatchObject({ status: 403 });
+    expect(activeUser).not.toHaveBeenCalled();
+  });
+
+  it('rejects a settled operation', async () => {
+    await expect(
+      resolveActiveHeteroOperationPrincipal({
+        capability: 'model:invoke',
+        claims,
+        db: dbWithOperation({ id: 'op-1', status: 'done', userId: 'user-1', workspaceId: null }),
+        operationId: 'op-1',
+      }),
+    ).rejects.toEqual(new HeteroOperationPrincipalError('Operation has already ended', 409));
+  });
+
+  it('rejects a model selection that no longer matches the operation', async () => {
+    await expect(
+      resolveActiveHeteroOperationPrincipal({
+        capability: 'model:invoke',
+        claims: { ...claims, model: 'model-a', provider_id: 'openai' },
+        db: dbWithOperation({
+          id: 'op-1',
+          model: 'model-b',
+          provider: 'openai',
+          status: 'running',
+          userId: 'user-1',
+          workspaceId: null,
+        }),
+        operationId: 'op-1',
+      }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('rechecks workspace membership and RBAC', async () => {
+    hasMembership.mockResolvedValue(false);
+    const workspaceClaims = { ...claims, workspace_id: 'workspace-1' };
+    const db = dbWithOperation({
+      id: 'op-1',
+      status: 'running',
+      userId: 'user-1',
+      workspaceId: 'workspace-1',
+    });
+
+    await expect(
+      resolveActiveHeteroOperationPrincipal({
+        capability: 'model:invoke',
+        claims: workspaceClaims,
+        db,
+        operationId: 'op-1',
+      }),
+    ).rejects.toMatchObject({ status: 403 });
+
+    hasMembership.mockResolvedValue(true);
+    hasPermission.mockResolvedValue(false);
+    await expect(
+      resolveActiveHeteroOperationPrincipal({
+        capability: 'model:invoke',
+        claims: workspaceClaims,
+        db,
+        operationId: 'op-1',
+      }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+});

--- a/apps/server/src/services/heterogeneousAgent/operationPrincipal.ts
+++ b/apps/server/src/services/heterogeneousAgent/operationPrincipal.ts
@@ -1,0 +1,89 @@
+import { eq } from 'drizzle-orm';
+
+import { RbacModel } from '@/database/models/rbac';
+import { hasActiveWorkspaceMembership } from '@/database/models/workspace';
+import { agentOperations } from '@/database/schemas';
+import type { LobeChatDatabase } from '@/database/type';
+import { assertOIDCUserActive } from '@/libs/oidc-provider/access-control';
+import type {
+  HeteroOperationCapability,
+  HeteroOperationJwtClaims,
+} from '@/libs/trpc/utils/internalJwt';
+import { getScopePermissions } from '@/utils/rbac';
+
+export class HeteroOperationPrincipalError extends Error {
+  constructor(
+    message: string,
+    readonly status: 401 | 403 | 409,
+  ) {
+    super(message);
+    this.name = 'HeteroOperationPrincipalError';
+  }
+}
+
+export interface ActiveHeteroOperationPrincipal {
+  operationId: string;
+  userId: string;
+  workspaceId?: string;
+}
+
+/** Resolve and re-authorize an operation token against current durable state. */
+export const resolveActiveHeteroOperationPrincipal = async (params: {
+  capability: HeteroOperationCapability;
+  claims: HeteroOperationJwtClaims;
+  db: LobeChatDatabase;
+  operationId: string;
+}): Promise<ActiveHeteroOperationPrincipal> => {
+  const { capability, claims, db, operationId } = params;
+  if (claims.operation_id !== operationId || !claims.capabilities.includes(capability)) {
+    throw new HeteroOperationPrincipalError('Operation token does not grant this request', 403);
+  }
+
+  await assertOIDCUserActive(db, claims.sub).catch(() => {
+    throw new HeteroOperationPrincipalError('Operation user is no longer active', 401);
+  });
+
+  const [operation] = await db
+    .select({
+      id: agentOperations.id,
+      model: agentOperations.model,
+      provider: agentOperations.provider,
+      status: agentOperations.status,
+      userId: agentOperations.userId,
+      workspaceId: agentOperations.workspaceId,
+    })
+    .from(agentOperations)
+    .where(eq(agentOperations.id, operationId))
+    .limit(1);
+
+  if (
+    !operation ||
+    operation.userId !== claims.sub ||
+    operation.workspaceId !== (claims.workspace_id ?? null) ||
+    (claims.model !== undefined && operation.model !== claims.model) ||
+    (claims.provider_id !== undefined && operation.provider !== claims.provider_id)
+  ) {
+    throw new HeteroOperationPrincipalError('Operation is outside the token scope', 403);
+  }
+  if (operation.status !== 'running') {
+    throw new HeteroOperationPrincipalError('Operation has already ended', 409);
+  }
+
+  const workspaceId = operation.workspaceId ?? undefined;
+  if (
+    workspaceId &&
+    !(await hasActiveWorkspaceMembership(db, { userId: claims.sub, workspaceId }))
+  ) {
+    throw new HeteroOperationPrincipalError('Workspace membership is no longer active', 403);
+  }
+
+  const permitted = await new RbacModel(db, claims.sub).hasAnyPermission(
+    getScopePermissions('AI_MODEL_INVOKE', ['ALL', 'OWNER']),
+    { userId: claims.sub, workspaceId },
+  );
+  if (!permitted) {
+    throw new HeteroOperationPrincipalError('Model invocation is no longer permitted', 403);
+  }
+
+  return { operationId, userId: claims.sub, workspaceId };
+};

--- a/packages/database/src/models/agentOperation.ts
+++ b/packages/database/src/models/agentOperation.ts
@@ -196,6 +196,29 @@ export class AgentOperationModel {
       .where(and(eq(agentOperations.id, operationId), this.ownership()));
   }
 
+  /** Idempotently settle a running operation without rewriting an existing terminal outcome. */
+  async settleRunning(
+    operationId: string,
+    status: 'done' | 'error' | 'interrupted',
+  ): Promise<boolean> {
+    const [row] = await this.db
+      .update(agentOperations)
+      .set({
+        completedAt: new Date(),
+        completionReason: status === 'interrupted' ? 'interrupted' : status,
+        status,
+      })
+      .where(
+        and(
+          eq(agentOperations.id, operationId),
+          eq(agentOperations.status, 'running'),
+          this.ownership(),
+        ),
+      )
+      .returning({ id: agentOperations.id });
+    return Boolean(row);
+  }
+
   /**
    * Sum the terminal usage of every child operation forked from `parentOperationId`
    * (`callSubAgent` children, isolated group members).

--- a/packages/model-runtime/src/core/contextBuilders/anthropic.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/anthropic.test.ts
@@ -576,6 +576,24 @@ describe('anthropicHelpers', () => {
       });
     });
 
+    it('should preserve redacted thinking in assistant history', async () => {
+      const message: OpenAIChatMessage = {
+        content: [
+          { data: 'encrypted-thinking', type: 'redacted_thinking' },
+          { text: 'Here is my response.', type: 'text' },
+        ],
+        role: 'assistant',
+      };
+
+      await expect(buildAnthropicMessage(message)).resolves.toEqual({
+        content: [
+          { data: 'encrypted-thinking', type: 'redacted_thinking' },
+          { text: 'Here is my response.', type: 'text' },
+        ],
+        role: 'assistant',
+      });
+    });
+
     it('should return undefined for assistant message with empty array content', async () => {
       const message: OpenAIChatMessage = {
         content: [],

--- a/packages/model-runtime/src/core/contextBuilders/anthropic.ts
+++ b/packages/model-runtime/src/core/contextBuilders/anthropic.ts
@@ -45,9 +45,10 @@ export const buildAnthropicBlock = async (
   Anthropic.ContentBlock | Anthropic.ImageBlockParam | AnthropicVideoBlockParam | undefined
 > => {
   switch (content.type) {
+    case 'redacted_thinking':
     case 'thinking': {
       // just pass-through the content
-      return content as any;
+      return content;
     }
 
     case 'text': {

--- a/packages/model-runtime/src/types/chat.ts
+++ b/packages/model-runtime/src/types/chat.ts
@@ -27,6 +27,10 @@ interface UserMessageContentPartThinking {
   thinking: string;
   type: 'thinking';
 }
+interface UserMessageContentPartRedactedThinking {
+  data: string;
+  type: 'redacted_thinking';
+}
 interface UserMessageContentPartText {
   text: string;
   type: 'text';
@@ -59,7 +63,8 @@ export type UserMessageContentPart =
   | UserMessageContentPartImage
   | UserMessageContentPartVideo
   | UserMessageContentPartAudio
-  | UserMessageContentPartThinking;
+  | UserMessageContentPartThinking
+  | UserMessageContentPartRedactedThinking;
 
 export interface OpenAIChatMessage {
   content: string | UserMessageContentPart[];

--- a/packages/openapi/src/middleware/auth.test.ts
+++ b/packages/openapi/src/middleware/auth.test.ts
@@ -121,6 +121,20 @@ describe('OpenAPI auth middleware', () => {
     expect(mockAssertOIDCUserActive).toHaveBeenCalledWith(mockServerDB, 'oidc-user');
   });
 
+  it('does not accept an operation token on ordinary OpenAPI routes', async () => {
+    mockValidateOIDCJWT.mockResolvedValueOnce({
+      tokenData: { purpose: 'hetero-operation', sub: 'oidc-user' },
+      userId: 'oidc-user',
+    });
+
+    const response = await createApp().request('/protected', {
+      headers: { Authorization: 'Bearer operation-token' },
+    });
+
+    expect(response.status).toBe(401);
+    expect(mockAssertOIDCUserActive).not.toHaveBeenCalled();
+  });
+
   it('should reject an inactive OIDC bearer token without authenticating the request', async () => {
     const app = createApp();
     const inactiveError = Object.assign(new Error('OIDC user is no longer active'), {

--- a/packages/openapi/src/middleware/auth.ts
+++ b/packages/openapi/src/middleware/auth.ts
@@ -102,6 +102,9 @@ export const userAuthMiddleware = async (c: Context, next: Next) => {
       try {
         // Use direct JWT validation instead of OIDCService
         const tokenInfo = await validateOIDCJWT(bearerToken);
+        if (tokenInfo.tokenData?.purpose === 'hetero-operation') {
+          throw new Error('Operation tokens are only accepted by heterogeneous model endpoints');
+        }
         const db = await getServerDB();
         await assertOIDCUserActive(db, tokenInfo.userId);
 

--- a/packages/openapi/src/middleware/hetero-operation-auth.test.ts
+++ b/packages/openapi/src/middleware/hetero-operation-auth.test.ts
@@ -1,0 +1,89 @@
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { requireHeteroModelInvocation } from './hetero-operation-auth';
+
+const {
+  mockExtractBearerToken,
+  mockGetServerDB,
+  mockResolveActiveHeteroOperationPrincipal,
+  mockValidateHeteroOperationJWT,
+} = vi.hoisted(() => ({
+  mockExtractBearerToken: vi.fn(),
+  mockGetServerDB: vi.fn(),
+  mockResolveActiveHeteroOperationPrincipal: vi.fn(),
+  mockValidateHeteroOperationJWT: vi.fn(),
+}));
+
+vi.mock('@/database/core/db-adaptor', () => ({ getServerDB: mockGetServerDB }));
+vi.mock('@/libs/trpc/utils/internalJwt', () => ({
+  validateHeteroOperationJWT: mockValidateHeteroOperationJWT,
+}));
+vi.mock('@/server/services/heterogeneousAgent/operationPrincipal', () => ({
+  HeteroOperationPrincipalError: class extends Error {},
+  resolveActiveHeteroOperationPrincipal: mockResolveActiveHeteroOperationPrincipal,
+}));
+vi.mock('@/utils/server/auth', () => ({ extractBearerToken: mockExtractBearerToken }));
+
+const createApp = () => {
+  const app = new Hono();
+  app.onError((error) =>
+    error instanceof HTTPException ? error.getResponse() : new Response(null, { status: 500 }),
+  );
+  app.use('*', requireHeteroModelInvocation);
+  app.get('/invoke', (c) =>
+    c.json({ userId: c.get('userId' as never), workspaceId: c.get('workspaceId' as never) }),
+  );
+  return app;
+};
+
+describe('heterogeneous operation auth middleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('ENABLE_SERVER_DEFAULT_HETEROGENEOUS_AGENT', '1');
+    mockExtractBearerToken.mockReturnValue('operation-token');
+    mockValidateHeteroOperationJWT.mockResolvedValue({
+      capabilities: ['model:invoke'],
+      operation_id: 'operation-1',
+      sub: 'user-1',
+    });
+    mockGetServerDB.mockResolvedValue({});
+    mockResolveActiveHeteroOperationPrincipal.mockResolvedValue({
+      userId: 'user-1',
+      workspaceId: 'workspace-1',
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('authorizes an active operation while server-default agents are enabled', async () => {
+    const response = await createApp().request('/invoke', {
+      headers: { Authorization: 'Bearer operation-token' },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      userId: 'user-1',
+      workspaceId: 'workspace-1',
+    });
+    expect(mockResolveActiveHeteroOperationPrincipal).toHaveBeenCalledWith(
+      expect.objectContaining({ capability: 'model:invoke', operationId: 'operation-1' }),
+    );
+  });
+
+  it('rejects previously issued tokens when server-default agents are disabled', async () => {
+    vi.stubEnv('ENABLE_SERVER_DEFAULT_HETEROGENEOUS_AGENT', '0');
+
+    const response = await createApp().request('/invoke', {
+      headers: { Authorization: 'Bearer operation-token' },
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.text()).resolves.toContain('Server-default agents are disabled');
+    expect(mockValidateHeteroOperationJWT).not.toHaveBeenCalled();
+    expect(mockGetServerDB).not.toHaveBeenCalled();
+  });
+});

--- a/packages/openapi/src/middleware/hetero-operation-auth.ts
+++ b/packages/openapi/src/middleware/hetero-operation-auth.ts
@@ -1,0 +1,35 @@
+import type { Context, Next } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+
+import { getServerDB } from '@/database/core/db-adaptor';
+import type { HeteroOperationJwtClaims } from '@/libs/trpc/utils/internalJwt';
+import { validateHeteroOperationJWT } from '@/libs/trpc/utils/internalJwt';
+import {
+  HeteroOperationPrincipalError,
+  resolveActiveHeteroOperationPrincipal,
+} from '@/server/services/heterogeneousAgent/operationPrincipal';
+import { extractBearerToken } from '@/utils/server/auth';
+
+export const requireHeteroModelInvocation = async (c: Context, next: Next) => {
+  const token = extractBearerToken(c.req.header('Authorization'));
+  const claims = token ? await validateHeteroOperationJWT(token) : null;
+  if (!claims) throw new HTTPException(401, { message: 'Invalid operation token' });
+
+  try {
+    const principal = await resolveActiveHeteroOperationPrincipal({
+      capability: 'model:invoke',
+      claims,
+      db: await getServerDB(),
+      operationId: claims.operation_id,
+    });
+    c.set('heteroOperationClaims', claims satisfies HeteroOperationJwtClaims);
+    c.set('userId', principal.userId);
+    c.set('workspaceId', principal.workspaceId);
+  } catch (error) {
+    if (error instanceof HeteroOperationPrincipalError) {
+      throw new HTTPException(error.status, { message: error.message });
+    }
+    throw error;
+  }
+  return next();
+};

--- a/packages/openapi/src/middleware/hetero-operation-auth.ts
+++ b/packages/openapi/src/middleware/hetero-operation-auth.ts
@@ -11,6 +11,10 @@ import {
 import { extractBearerToken } from '@/utils/server/auth';
 
 export const requireHeteroModelInvocation = async (c: Context, next: Next) => {
+  if (process.env.ENABLE_SERVER_DEFAULT_HETEROGENEOUS_AGENT === '0') {
+    throw new HTTPException(403, { message: 'Server-default agents are disabled' });
+  }
+
   const token = extractBearerToken(c.req.header('Authorization'));
   const claims = token ? await validateHeteroOperationJWT(token) : null;
   if (!claims) throw new HTTPException(401, { message: 'Invalid operation token' });

--- a/packages/openapi/src/routes/anthropic.route.ts
+++ b/packages/openapi/src/routes/anthropic.route.ts
@@ -1,0 +1,46 @@
+import { isRecord } from '@lobechat/utils/object';
+import type { Context } from 'hono';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+
+import type { HeteroOperationJwtClaims } from '@/libs/trpc/utils/internalJwt';
+
+import { requireHeteroModelInvocation } from '../middleware/hetero-operation-auth';
+import {
+  encodeAnthropicStream,
+  invokeServerDefaultModel,
+  normalizeAnthropicRequest,
+  SERVER_DEFAULT_MODEL_ALIAS,
+} from '../services/heterogeneous-direct.service';
+
+const app = new Hono();
+
+app.post('/v1/messages', requireHeteroModelInvocation, async (c) => {
+  const request = await c.req.json().catch(() => null);
+  if (!isRecord(request)) throw new HTTPException(400, { message: 'Invalid JSON request' });
+  if (request.model !== SERVER_DEFAULT_MODEL_ALIAS) {
+    throw new HTTPException(400, { message: `model must be ${SERVER_DEFAULT_MODEL_ALIAS}` });
+  }
+  if (request.stream !== true) {
+    throw new HTTPException(400, { message: 'server-default Anthropic requests must stream' });
+  }
+  const context = c as Context;
+  const claims = context.get('heteroOperationClaims') as HeteroOperationJwtClaims;
+  if (!claims.provider_id || !claims.model) {
+    throw new HTTPException(403, { message: 'Operation token has no server model selection' });
+  }
+  const workspaceId = context.get('workspaceId');
+  const { response } = await invokeServerDefaultModel({
+    model: claims.model,
+    payload: normalizeAnthropicRequest(request, SERVER_DEFAULT_MODEL_ALIAS),
+    provider: claims.provider_id,
+    signal: c.req.raw.signal,
+    userId: String(context.get('userId')),
+    workspaceId: typeof workspaceId === 'string' ? workspaceId : undefined,
+  });
+  return new Response(encodeAnthropicStream(response.body!), {
+    headers: { 'Cache-Control': 'no-cache', 'Content-Type': 'text/event-stream' },
+  });
+});
+
+export default app;

--- a/packages/openapi/src/routes/anthropic.route.ts
+++ b/packages/openapi/src/routes/anthropic.route.ts
@@ -31,6 +31,7 @@ app.post('/v1/messages', requireHeteroModelInvocation, async (c) => {
   }
   const workspaceId = context.get('workspaceId');
   const { response } = await invokeServerDefaultModel({
+    agentType: 'claude-code',
     model: claims.model,
     payload: normalizeAnthropicRequest(request, SERVER_DEFAULT_MODEL_ALIAS),
     provider: claims.provider_id,

--- a/packages/openapi/src/routes/index.ts
+++ b/packages/openapi/src/routes/index.ts
@@ -1,5 +1,6 @@
 import AgentGroupsRoutes from './agent-groups.route';
 import AgentsRoutes from './agents.route';
+import AnthropicRoutes from './anthropic.route';
 import ApiKeysRoutes from './api-keys.route';
 import ChatRoutes from './chat.route';
 import EvalRoutes from './eval.route';
@@ -9,6 +10,7 @@ import McpServersRoutes from './mcp-servers.route';
 import MessageTranslationsRoutes from './message-translations.route';
 import MessagesRoutes from './messages.route';
 import ModelsRoutes from './models.route';
+import OpenAIRoutes from './openai.route';
 import PermissionsRoutes from './permissions.route';
 import ProvidersRoutes from './providers.route';
 import ResponsesRoutes from './responses.route';
@@ -20,6 +22,7 @@ import UsersRoutes from './users.route';
 export default {
   'agent-groups': AgentGroupsRoutes,
   'agents': AgentsRoutes,
+  'anthropic': AnthropicRoutes,
   'api-keys': ApiKeysRoutes,
   'chat': ChatRoutes,
   'eval': EvalRoutes,
@@ -29,6 +32,7 @@ export default {
   'message-translations': MessageTranslationsRoutes,
   'messages': MessagesRoutes,
   'models': ModelsRoutes,
+  'openai': OpenAIRoutes,
   'permissions': PermissionsRoutes,
   'providers': ProvidersRoutes,
   'responses': ResponsesRoutes,

--- a/packages/openapi/src/routes/openai.route.ts
+++ b/packages/openapi/src/routes/openai.route.ts
@@ -31,6 +31,7 @@ app.post('/v1/responses', requireHeteroModelInvocation, async (c) => {
   }
   const workspaceId = context.get('workspaceId');
   const { response } = await invokeServerDefaultModel({
+    agentType: 'codex',
     model: claims.model,
     payload: normalizeResponsesRequest(request, SERVER_DEFAULT_MODEL_ALIAS),
     provider: claims.provider_id,

--- a/packages/openapi/src/routes/openai.route.ts
+++ b/packages/openapi/src/routes/openai.route.ts
@@ -1,0 +1,46 @@
+import { isRecord } from '@lobechat/utils/object';
+import type { Context } from 'hono';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+
+import type { HeteroOperationJwtClaims } from '@/libs/trpc/utils/internalJwt';
+
+import { requireHeteroModelInvocation } from '../middleware/hetero-operation-auth';
+import {
+  encodeResponsesStream,
+  invokeServerDefaultModel,
+  normalizeResponsesRequest,
+  SERVER_DEFAULT_MODEL_ALIAS,
+} from '../services/heterogeneous-direct.service';
+
+const app = new Hono();
+
+app.post('/v1/responses', requireHeteroModelInvocation, async (c) => {
+  const request = await c.req.json().catch(() => null);
+  if (!isRecord(request)) throw new HTTPException(400, { message: 'Invalid JSON request' });
+  if (request.model !== SERVER_DEFAULT_MODEL_ALIAS) {
+    throw new HTTPException(400, { message: `model must be ${SERVER_DEFAULT_MODEL_ALIAS}` });
+  }
+  if (request.stream !== true) {
+    throw new HTTPException(400, { message: 'server-default Responses requests must stream' });
+  }
+  const context = c as Context;
+  const claims = context.get('heteroOperationClaims') as HeteroOperationJwtClaims;
+  if (!claims.provider_id || !claims.model) {
+    throw new HTTPException(403, { message: 'Operation token has no server model selection' });
+  }
+  const workspaceId = context.get('workspaceId');
+  const { response } = await invokeServerDefaultModel({
+    model: claims.model,
+    payload: normalizeResponsesRequest(request, SERVER_DEFAULT_MODEL_ALIAS),
+    provider: claims.provider_id,
+    signal: c.req.raw.signal,
+    userId: String(context.get('userId')),
+    workspaceId: typeof workspaceId === 'string' ? workspaceId : undefined,
+  });
+  return new Response(encodeResponsesStream(response.body!), {
+    headers: { 'Cache-Control': 'no-cache', 'Content-Type': 'text/event-stream' },
+  });
+});
+
+export default app;

--- a/packages/openapi/src/services/heterogeneous-direct.service.test.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  encodeAnthropicStream,
+  encodeResponsesStream,
+  normalizeAnthropicRequest,
+  normalizeResponsesRequest,
+} from './heterogeneous-direct.service';
+
+vi.mock('@/server/modules/ModelRuntime', () => ({
+  initModelRuntimeFromServerConfig: vi.fn(),
+  resolveServerModel: vi.fn(),
+}));
+
+const protocolStream = (events: Array<{ data: unknown; type: string }>) => {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(
+          encoder.encode(`event: ${event.type}\ndata: ${JSON.stringify(event.data)}\n\n`),
+        );
+      }
+      controller.close();
+    },
+  });
+};
+
+const readText = async (stream: ReadableStream<Uint8Array>) => new Response(stream).text();
+
+describe('heterogeneous direct invocation protocol', () => {
+  it('normalizes Anthropic images, tool calls, and tool results', () => {
+    const payload = normalizeAnthropicRequest(
+      {
+        messages: [
+          {
+            content: [
+              { text: 'look', type: 'text' },
+              { source: { data: 'abc', media_type: 'image/png', type: 'base64' }, type: 'image' },
+            ],
+            role: 'user',
+          },
+          {
+            content: [{ id: 'call-1', input: { path: '/tmp' }, name: 'read', type: 'tool_use' }],
+            role: 'assistant',
+          },
+          {
+            content: [
+              {
+                content: [
+                  { text: 'done', type: 'text' },
+                  {
+                    source: { data: 'result-image', media_type: 'image/jpeg', type: 'base64' },
+                    type: 'image',
+                  },
+                ],
+                tool_use_id: 'call-1',
+                type: 'tool_result',
+              },
+            ],
+            role: 'user',
+          },
+        ],
+        model: 'lobehub-default',
+        system: [{ text: 'system', type: 'text' }],
+      },
+      'lobehub-default',
+    );
+
+    expect(payload.messages[0]).toEqual({ content: 'system', role: 'system' });
+    expect(payload.messages[1].content).toEqual([
+      { text: 'look', type: 'text' },
+      { image_url: { url: 'data:image/png;base64,abc' }, type: 'image_url' },
+    ]);
+    expect(payload.messages[2].tool_calls?.[0]).toMatchObject({ id: 'call-1' });
+    expect(payload.messages[3]).toEqual({
+      content: [
+        { text: 'done', type: 'text' },
+        { image_url: { url: 'data:image/jpeg;base64,result-image' }, type: 'image_url' },
+      ],
+      role: 'tool',
+      tool_call_id: 'call-1',
+    });
+  });
+
+  it('normalizes two-round Responses reasoning and function call continuity', () => {
+    const firstReasoning = {
+      encrypted_content: 'encrypted-first',
+      id: 'reasoning-1',
+      status: 'completed',
+      summary: [{ text: 'first thought', type: 'summary_text' }],
+      type: 'reasoning',
+    };
+    const secondReasoning = {
+      encrypted_content: 'encrypted-second',
+      id: 'reasoning-2',
+      status: 'completed',
+      summary: [],
+      type: 'reasoning',
+    };
+    const payload = normalizeResponsesRequest(
+      {
+        input: [
+          firstReasoning,
+          { arguments: '{"q":"x"}', call_id: 'call-1', name: 'search', type: 'function_call' },
+          { call_id: 'call-1', output: 'result', type: 'function_call_output' },
+          secondReasoning,
+          {
+            content: [{ text: 'answer', type: 'output_text' }],
+            role: 'assistant',
+            type: 'message',
+          },
+        ],
+        instructions: 'system',
+      },
+      'lobehub-default',
+    );
+
+    expect(payload.messages.map(({ role }) => role)).toEqual([
+      'system',
+      'assistant',
+      'tool',
+      'assistant',
+    ]);
+    expect(payload.messages[1].reasoning?.responseItems).toEqual([firstReasoning]);
+    expect(payload.messages[2].tool_call_id).toBe('call-1');
+    expect(payload.messages[3].reasoning?.responseItems).toEqual([secondReasoning]);
+  });
+
+  it('parses the final protocol event without a trailing newline', async () => {
+    const encoder = new TextEncoder();
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('event: text\ndata: "tail"'));
+        controller.close();
+      },
+    });
+
+    await expect(readText(encodeAnthropicStream(source))).resolves.toContain(
+      '"text":"tail","type":"text_delta"',
+    );
+  });
+
+  it('encodes Anthropic reasoning and parallel tool argument deltas', async () => {
+    const output = await readText(
+      encodeAnthropicStream(
+        protocolStream([
+          { data: 'thinking', type: 'reasoning' },
+          {
+            data: [
+              { function: { arguments: '{', name: 'one' }, id: 'call-1', index: 0 },
+              { function: { arguments: '{', name: 'two' }, id: 'call-2', index: 1 },
+            ],
+            type: 'tool_calls',
+          },
+          { data: 'tool_calls', type: 'stop' },
+        ]),
+      ),
+    );
+
+    expect(output).toContain('"type":"thinking_delta"');
+    expect(output).toContain('"id":"call-1"');
+    expect(output).toContain('"id":"call-2"');
+    expect(output).toContain('"stop_reason":"tool_use"');
+  });
+
+  it('preserves Anthropic terminal cumulative usage', async () => {
+    const output = await readText(
+      encodeAnthropicStream(
+        protocolStream([
+          { data: { totalInputTokens: 7, totalOutputTokens: 4 }, type: 'usage' },
+          { data: 'stop', type: 'stop' },
+        ]),
+      ),
+    );
+
+    const messageDeltas = [...output.matchAll(/event: message_delta\ndata: ([^\n]+)/g)].map(
+      (match) => JSON.parse(match[1]),
+    );
+    expect(messageDeltas.at(-1).usage).toEqual({ output_tokens: 4 });
+  });
+
+  it('encodes Responses text, usage, and terminal events', async () => {
+    const output = await readText(
+      encodeResponsesStream(
+        protocolStream([
+          { data: 'hello', type: 'text' },
+          { data: { totalInputTokens: 2, totalOutputTokens: 1 }, type: 'usage' },
+          { data: 'stop', type: 'stop' },
+        ]),
+      ),
+    );
+
+    expect(output).toContain('event: response.output_text.delta');
+    expect(output).toContain('event: response.content_part.done');
+    expect(output).toContain('event: response.output_item.done');
+    expect(output).toContain('"usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}');
+    expect(output).not.toContain('totalInputTokens');
+    expect(output).toContain('event: response.completed');
+    expect(output).toContain('"output":[{"content":[{"annotations":[],"text":"hello"');
+    expect(output).toContain('data: [DONE]');
+  });
+
+  it('encodes Responses incomplete and failed terminal lifecycle events', async () => {
+    const incomplete = await readText(
+      encodeResponsesStream(
+        protocolStream([
+          { data: 'partial', type: 'text' },
+          { data: 'max_tokens', type: 'stop' },
+        ]),
+      ),
+    );
+    expect(incomplete).toContain('event: response.incomplete');
+    expect(incomplete).toContain('"status":"incomplete"');
+    expect(incomplete).toContain('"incomplete_details":{"reason":"max_output_tokens"}');
+    expect(incomplete).not.toContain('event: response.completed');
+
+    const failed = await readText(
+      encodeResponsesStream(
+        protocolStream([{ data: { message: 'provider unavailable' }, type: 'error' }]),
+      ),
+    );
+    expect(failed).toContain('event: response.failed');
+    expect(failed).toContain('"error":{"code":"server_error","message":"provider unavailable"}');
+    expect(failed).toContain('data: [DONE]');
+  });
+
+  it('assigns distinct Responses output indexes to reasoning, text, and tools', async () => {
+    const output = await readText(
+      encodeResponsesStream(
+        protocolStream([
+          { data: 'think', type: 'reasoning' },
+          { data: 'answer', type: 'text' },
+          {
+            data: [{ function: { arguments: '{}', name: 'search' }, id: 'call-1', index: 0 }],
+            type: 'tool_calls',
+          },
+          { data: 'tool_calls', type: 'stop' },
+        ]),
+      ),
+    );
+    const indexes = [
+      ...output.matchAll(/event: response\.output_item\.added\ndata: ([^\n]+)/g),
+    ].map((match) => JSON.parse(match[1]).output_index);
+
+    expect(indexes).toEqual([0, 1, 2]);
+    expect(output).toContain('event: response.reasoning_summary_text.done');
+  });
+
+  it('completes replayed encrypted reasoning response items', async () => {
+    const reasoningItem = {
+      encrypted_content: 'encrypted-history',
+      id: 'reasoning-history',
+      status: 'completed',
+      summary: [],
+      type: 'reasoning',
+    };
+    const output = await readText(
+      encodeResponsesStream(
+        protocolStream([
+          { data: reasoningItem, type: 'reasoning_response_item' },
+          { data: 'stop', type: 'stop' },
+        ]),
+      ),
+    );
+    const doneItems = [
+      ...output.matchAll(/event: response\.output_item\.done\ndata: ([^\n]+)/g),
+    ].map((match) => JSON.parse(match[1]).item);
+
+    expect(doneItems).toContainEqual(reasoningItem);
+  });
+});

--- a/packages/openapi/src/services/heterogeneous-direct.service.test.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.test.ts
@@ -28,6 +28,17 @@ const protocolStream = (events: Array<{ data: unknown; type: string }>) => {
 
 const readText = async (stream: ReadableStream<Uint8Array>) => new Response(stream).text();
 
+const parseSseEvents = (output: string) =>
+  output
+    .split('\n\n')
+    .filter(Boolean)
+    .map((block) => {
+      const lines = block.split('\n');
+      const data = lines.find((line) => line.startsWith('data: '))?.slice(6);
+      const type = lines.find((line) => line.startsWith('event: '))?.slice(7);
+      return { data: data === '[DONE]' ? data : JSON.parse(data || 'null'), type };
+    });
+
 describe('heterogeneous direct invocation protocol', () => {
   it('normalizes Anthropic images, tool calls, and tool results', () => {
     const payload = normalizeAnthropicRequest(
@@ -164,41 +175,85 @@ describe('heterogeneous direct invocation protocol', () => {
     expect(output).toContain('"stop_reason":"tool_use"');
   });
 
-  it('preserves Anthropic terminal cumulative usage', async () => {
+  it('finalizes Anthropic stop, usage, and message_stop exactly once', async () => {
     const output = await readText(
       encodeAnthropicStream(
         protocolStream([
+          { data: 'hello', type: 'text' },
+          { data: 'end_turn', type: 'stop' },
           { data: { totalInputTokens: 7, totalOutputTokens: 4 }, type: 'usage' },
-          { data: 'stop', type: 'stop' },
+          { data: 'message_stop', type: 'stop' },
         ]),
       ),
     );
 
-    const messageDeltas = [...output.matchAll(/event: message_delta\ndata: ([^\n]+)/g)].map(
-      (match) => JSON.parse(match[1]),
-    );
-    expect(messageDeltas.at(-1).usage).toEqual({ output_tokens: 4 });
+    const events = parseSseEvents(output);
+    expect(events.slice(-3).map(({ type }) => type)).toEqual([
+      'content_block_stop',
+      'message_delta',
+      'message_stop',
+    ]);
+    expect(events.filter(({ type }) => type === 'content_block_stop')).toHaveLength(1);
+    expect(events.filter(({ type }) => type === 'message_delta')).toHaveLength(1);
+    expect(events.filter(({ type }) => type === 'message_stop')).toHaveLength(1);
+    expect(events.at(-2)?.data).toMatchObject({
+      delta: { stop_reason: 'end_turn' },
+      usage: { output_tokens: 4 },
+    });
   });
 
-  it('encodes Responses text, usage, and terminal events', async () => {
-    const output = await readText(
-      encodeResponsesStream(
-        protocolStream([
-          { data: 'hello', type: 'text' },
-          { data: { totalInputTokens: 2, totalOutputTokens: 1 }, type: 'usage' },
-          { data: 'stop', type: 'stop' },
-        ]),
-      ),
+  it.each([
+    {
+      events: [
+        { data: 'hello', type: 'text' },
+        { data: { totalInputTokens: 2, totalOutputTokens: 1 }, type: 'usage' },
+      ],
+      name: 'usage without stop',
+    },
+    {
+      events: [
+        { data: 'hello', type: 'text' },
+        { data: 'stop', type: 'stop' },
+        { data: { totalInputTokens: 2, totalOutputTokens: 1 }, type: 'usage' },
+      ],
+      name: 'stop before usage',
+    },
+    {
+      events: [
+        { data: 'hello', type: 'text' },
+        { data: 'end_turn', type: 'stop' },
+        { data: { totalInputTokens: 2, totalOutputTokens: 1 }, type: 'usage' },
+        { data: 'message_stop', type: 'stop' },
+      ],
+      name: 'duplicate stop sentinels',
+    },
+  ])('finalizes Responses $name exactly once', async ({ events: protocolEvents }) => {
+    const output = await readText(encodeResponsesStream(protocolStream(protocolEvents)));
+    const events = parseSseEvents(output);
+    const nativeEvents = events.filter(({ type }) => type);
+    const terminalEvents = nativeEvents.filter(({ type }) =>
+      ['response.completed', 'response.failed', 'response.incomplete'].includes(type!),
     );
 
     expect(output).toContain('event: response.output_text.delta');
     expect(output).toContain('event: response.content_part.done');
     expect(output).toContain('event: response.output_item.done');
-    expect(output).toContain('"usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}');
     expect(output).not.toContain('totalInputTokens');
-    expect(output).toContain('event: response.completed');
     expect(output).toContain('"output":[{"content":[{"annotations":[],"text":"hello"');
-    expect(output).toContain('data: [DONE]');
+    expect(terminalEvents).toHaveLength(1);
+    expect(terminalEvents[0]).toMatchObject({
+      data: {
+        response: { usage: { input_tokens: 2, output_tokens: 1, total_tokens: 3 } },
+        type: 'response.completed',
+      },
+      type: 'response.completed',
+    });
+    expect(nativeEvents.map(({ data }) => data.sequence_number)).toEqual(
+      nativeEvents.map((_, index) => index),
+    );
+    expect(events.slice(events.indexOf(terminalEvents[0]) + 1)).toEqual([
+      { data: '[DONE]', type: undefined },
+    ]);
   });
 
   it('encodes Responses incomplete and failed terminal lifecycle events', async () => {
@@ -223,6 +278,8 @@ describe('heterogeneous direct invocation protocol', () => {
     expect(failed).toContain('event: response.failed');
     expect(failed).toContain('"error":{"code":"server_error","message":"provider unavailable"}');
     expect(failed).toContain('data: [DONE]');
+    const failedEvents = parseSseEvents(failed).filter(({ type }) => type);
+    expect(failedEvents.map(({ data }) => data.sequence_number)).toEqual([0, 1]);
   });
 
   it('assigns distinct Responses output indexes to reasoning, text, and tools', async () => {

--- a/packages/openapi/src/services/heterogeneous-direct.service.test.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.test.ts
@@ -1,8 +1,14 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  initModelRuntimeFromServerConfig,
+  resolveServerModel,
+} from '@/server/modules/ModelRuntime';
 
 import {
   encodeAnthropicStream,
   encodeResponsesStream,
+  invokeServerDefaultModel,
   normalizeAnthropicRequest,
   normalizeResponsesRequest,
 } from './heterogeneous-direct.service';
@@ -40,6 +46,66 @@ const parseSseEvents = (output: string) =>
     });
 
 describe('heterogeneous direct invocation protocol', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes Azure deployment names without replacing the logical model', async () => {
+    const chat = vi.fn().mockResolvedValue(new Response('stream'));
+    vi.mocked(resolveServerModel).mockResolvedValue({
+      deploymentName: 'prod-gpt',
+      model: 'gpt-4o',
+      provider: 'azure',
+    });
+    vi.mocked(initModelRuntimeFromServerConfig).mockResolvedValue({
+      chat,
+    } as unknown as Awaited<ReturnType<typeof initModelRuntimeFromServerConfig>>);
+
+    const result = await invokeServerDefaultModel({
+      model: 'gpt-4o',
+      payload: { messages: [], model: 'lobehub-default', stream: true },
+      provider: 'azure',
+      signal: new AbortController().signal,
+      userId: 'user-1',
+    });
+
+    expect(result.model).toBe('gpt-4o');
+    expect(chat).toHaveBeenCalledWith(
+      {
+        deploymentName: 'prod-gpt',
+        messages: [],
+        model: 'gpt-4o',
+        stream: true,
+      },
+      expect.any(Object),
+    );
+  });
+
+  it('uses deployment names as model IDs for runtimes without a dedicated field', async () => {
+    const chat = vi.fn().mockResolvedValue(new Response('stream'));
+    vi.mocked(resolveServerModel).mockResolvedValue({
+      deploymentName: 'prod-gpt',
+      model: 'gpt-4o',
+      provider: 'openai',
+    });
+    vi.mocked(initModelRuntimeFromServerConfig).mockResolvedValue({
+      chat,
+    } as unknown as Awaited<ReturnType<typeof initModelRuntimeFromServerConfig>>);
+
+    const result = await invokeServerDefaultModel({
+      model: 'gpt-4o',
+      payload: { messages: [], model: 'lobehub-default', stream: true },
+      provider: 'openai',
+      signal: new AbortController().signal,
+      userId: 'user-1',
+    });
+
+    const runtimePayload = chat.mock.calls[0][0];
+    expect(result.model).toBe('prod-gpt');
+    expect(runtimePayload).toMatchObject({ messages: [], model: 'prod-gpt', stream: true });
+    expect(runtimePayload).not.toHaveProperty('deploymentName');
+  });
+
   it('normalizes Anthropic images, tool calls, and tool results', () => {
     const payload = normalizeAnthropicRequest(
       {

--- a/packages/openapi/src/services/heterogeneous-direct.service.test.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.test.ts
@@ -18,13 +18,15 @@ vi.mock('@/server/modules/ModelRuntime', () => ({
   resolveServerModel: vi.fn(),
 }));
 
-const protocolStream = (events: Array<{ data: unknown; type: string }>) => {
+const protocolStream = (events: Array<{ data: unknown; id?: string; type: string }>) => {
   const encoder = new TextEncoder();
   return new ReadableStream<Uint8Array>({
     start(controller) {
       for (const event of events) {
         controller.enqueue(
-          encoder.encode(`event: ${event.type}\ndata: ${JSON.stringify(event.data)}\n\n`),
+          encoder.encode(
+            `${event.id ? `id: ${event.id}\n` : ''}event: ${event.type}\ndata: ${JSON.stringify(event.data)}\n\n`,
+          ),
         );
       }
       controller.close();
@@ -157,6 +159,36 @@ describe('heterogeneous direct invocation protocol', () => {
       ],
       role: 'tool',
       tool_call_id: 'call-1',
+    });
+  });
+
+  it('preserves Anthropic thinking history across tool rounds', () => {
+    const payload = normalizeAnthropicRequest(
+      {
+        messages: [
+          {
+            content: [
+              { signature: 'signed-thinking', thinking: 'private thought', type: 'thinking' },
+              { data: 'encrypted-redacted-thought', type: 'redacted_thinking' },
+              { text: 'I will inspect it.', type: 'text' },
+              { id: 'call-1', input: { path: '/tmp' }, name: 'read', type: 'tool_use' },
+            ],
+            role: 'assistant',
+          },
+        ],
+      },
+      'lobehub-default',
+    );
+
+    expect(payload.messages[0]).toMatchObject({
+      content: [
+        { signature: 'signed-thinking', thinking: 'private thought', type: 'thinking' },
+        { data: 'encrypted-redacted-thought', type: 'redacted_thinking' },
+        { text: 'I will inspect it.', type: 'text' },
+      ],
+      provider: 'anthropic',
+      role: 'assistant',
+      tool_calls: [{ id: 'call-1' }],
     });
   });
 
@@ -391,5 +423,44 @@ describe('heterogeneous direct invocation protocol', () => {
     ].map((match) => JSON.parse(match[1]).item);
 
     expect(doneItems).toContainEqual(reasoningItem);
+  });
+
+  it('completes streamed reasoning with its encrypted response item only once', async () => {
+    const reasoningItem = {
+      encrypted_content: 'encrypted-current',
+      id: 'reasoning-current',
+      status: 'completed',
+      summary: [{ text: 'thinking', type: 'summary_text' }],
+      type: 'reasoning',
+    };
+    const events = parseSseEvents(
+      await readText(
+        encodeResponsesStream(
+          protocolStream([
+            { data: 'thinking', id: 'reasoning-current', type: 'reasoning' },
+            {
+              data: reasoningItem,
+              id: 'reasoning-current',
+              type: 'reasoning_response_item',
+            },
+            { data: 'stop', type: 'stop' },
+          ]),
+        ),
+      ),
+    );
+    const reasoningAdded = events.filter(
+      ({ data, type }) => type === 'response.output_item.added' && data.item.type === 'reasoning',
+    );
+    const reasoningDone = events.filter(
+      ({ data, type }) => type === 'response.output_item.done' && data.item.type === 'reasoning',
+    );
+    const completed = events.find(({ type }) => type === 'response.completed');
+
+    expect(reasoningAdded).toHaveLength(1);
+    expect(reasoningDone).toHaveLength(1);
+    expect(reasoningAdded[0].data.output_index).toBe(reasoningDone[0].data.output_index);
+    expect(reasoningAdded[0].data.item.id).toBe('reasoning-current');
+    expect(reasoningDone[0].data.item).toEqual(reasoningItem);
+    expect(completed?.data.response.output).toEqual([reasoningItem]);
   });
 });

--- a/packages/openapi/src/services/heterogeneous-direct.service.test.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   initModelRuntimeFromServerConfig,
-  resolveServerModel,
+  resolveServerDefaultHeterogeneousModel,
 } from '@/server/modules/ModelRuntime';
 
 import {
@@ -15,7 +15,7 @@ import {
 
 vi.mock('@/server/modules/ModelRuntime', () => ({
   initModelRuntimeFromServerConfig: vi.fn(),
-  resolveServerModel: vi.fn(),
+  resolveServerDefaultHeterogeneousModel: vi.fn(),
 }));
 
 const protocolStream = (events: Array<{ data: unknown; id?: string; type: string }>) => {
@@ -52,31 +52,35 @@ describe('heterogeneous direct invocation protocol', () => {
     vi.clearAllMocks();
   });
 
-  it('passes Azure deployment names without replacing the logical model', async () => {
+  it('invokes Claude Code only through its resolved Anthropic runtime model', async () => {
     const chat = vi.fn().mockResolvedValue(new Response('stream'));
-    vi.mocked(resolveServerModel).mockResolvedValue({
-      deploymentName: 'prod-gpt',
-      model: 'gpt-4o',
-      provider: 'azure',
+    vi.mocked(resolveServerDefaultHeterogeneousModel).mockResolvedValue({
+      model: 'claude-server',
+      provider: 'anthropic',
     });
     vi.mocked(initModelRuntimeFromServerConfig).mockResolvedValue({
       chat,
     } as unknown as Awaited<ReturnType<typeof initModelRuntimeFromServerConfig>>);
 
     const result = await invokeServerDefaultModel({
-      model: 'gpt-4o',
+      agentType: 'claude-code',
+      model: 'claude-server',
       payload: { messages: [], model: 'lobehub-default', stream: true },
-      provider: 'azure',
+      provider: 'anthropic',
       signal: new AbortController().signal,
       userId: 'user-1',
     });
 
-    expect(result.model).toBe('gpt-4o');
+    expect(result.model).toBe('claude-server');
+    expect(resolveServerDefaultHeterogeneousModel).toHaveBeenCalledWith(
+      'claude-code',
+      'anthropic',
+      'claude-server',
+    );
     expect(chat).toHaveBeenCalledWith(
       {
-        deploymentName: 'prod-gpt',
         messages: [],
-        model: 'gpt-4o',
+        model: 'claude-server',
         stream: true,
       },
       expect.any(Object),
@@ -85,9 +89,9 @@ describe('heterogeneous direct invocation protocol', () => {
 
   it('uses deployment names as model IDs for runtimes without a dedicated field', async () => {
     const chat = vi.fn().mockResolvedValue(new Response('stream'));
-    vi.mocked(resolveServerModel).mockResolvedValue({
+    vi.mocked(resolveServerDefaultHeterogeneousModel).mockResolvedValue({
       deploymentName: 'prod-gpt',
-      model: 'gpt-4o',
+      model: 'gpt-5.4',
       provider: 'openai',
     });
     vi.mocked(initModelRuntimeFromServerConfig).mockResolvedValue({
@@ -95,7 +99,8 @@ describe('heterogeneous direct invocation protocol', () => {
     } as unknown as Awaited<ReturnType<typeof initModelRuntimeFromServerConfig>>);
 
     const result = await invokeServerDefaultModel({
-      model: 'gpt-4o',
+      agentType: 'codex',
+      model: 'gpt-5.4',
       payload: { messages: [], model: 'lobehub-default', stream: true },
       provider: 'openai',
       signal: new AbortController().signal,
@@ -106,6 +111,24 @@ describe('heterogeneous direct invocation protocol', () => {
     expect(result.model).toBe('prod-gpt');
     expect(runtimePayload).toMatchObject({ messages: [], model: 'prod-gpt', stream: true });
     expect(runtimePayload).not.toHaveProperty('deploymentName');
+  });
+
+  it('fails closed before runtime initialization for an unsupported direct protocol route', async () => {
+    vi.mocked(resolveServerDefaultHeterogeneousModel).mockRejectedValue(
+      new Error('unsupported agent/runtime pair'),
+    );
+
+    await expect(
+      invokeServerDefaultModel({
+        agentType: 'codex',
+        model: 'claude-server',
+        payload: { messages: [], model: 'lobehub-default', stream: true },
+        provider: 'anthropic',
+        signal: new AbortController().signal,
+        userId: 'user-1',
+      }),
+    ).rejects.toThrow('unsupported agent/runtime pair');
+    expect(initModelRuntimeFromServerConfig).not.toHaveBeenCalled();
   });
 
   it('normalizes Anthropic images, tool calls, and tool results', () => {

--- a/packages/openapi/src/services/heterogeneous-direct.service.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.ts
@@ -9,6 +9,8 @@ import {
   resolveServerModel,
 } from '@/server/modules/ModelRuntime';
 
+import type { BaseStreamEvent } from '../types/responses.type';
+
 export const SERVER_DEFAULT_MODEL_ALIAS = 'lobehub-default';
 
 const textFromParts = (content: unknown): string => {
@@ -266,7 +268,9 @@ const sse = (event: string, data: unknown) => `event: ${event}\ndata: ${JSON.str
 
 export const encodeAnthropicStream = (source: ReadableStream<Uint8Array>) => {
   const messageId = `msg_${randomUUID().replaceAll('-', '')}`;
+  let finalized = false;
   let nextIndex = 0;
+  let stopReason: string | undefined;
   let textIndex: number | undefined;
   let thinkingIndex: number | undefined;
   let usage = { input_tokens: 0, output_tokens: 0 };
@@ -278,6 +282,31 @@ export const encodeAnthropicStream = (source: ReadableStream<Uint8Array>) => {
     }
     textIndex = undefined;
     thinkingIndex = undefined;
+  };
+  const finalize = (controller: TransformStreamDefaultController<string>) => {
+    if (finalized) return;
+    finalized = true;
+    closeTextBlocks(controller);
+    for (const { blockIndex } of tools.values()) {
+      controller.enqueue(
+        sse('content_block_stop', { index: blockIndex, type: 'content_block_stop' }),
+      );
+    }
+    controller.enqueue(
+      sse('message_delta', {
+        delta: {
+          stop_reason: tools.size
+            ? 'tool_use'
+            : stopReason === 'max_tokens'
+              ? 'max_tokens'
+              : 'end_turn',
+          stop_sequence: null,
+        },
+        type: 'message_delta',
+        usage: { output_tokens: usage.output_tokens },
+      }),
+    );
+    controller.enqueue(sse('message_stop', { type: 'message_stop' }));
   };
   return parseProtocolStream(source)
     .pipeThrough(
@@ -299,6 +328,7 @@ export const encodeAnthropicStream = (source: ReadableStream<Uint8Array>) => {
           );
         },
         transform(event, controller) {
+          if (finalized) return;
           if (event.type === 'text' || event.type === 'reasoning') {
             const isThinking = event.type === 'reasoning';
             let index = isThinking ? thinkingIndex : textIndex;
@@ -369,36 +399,11 @@ export const encodeAnthropicStream = (source: ReadableStream<Uint8Array>) => {
               input_tokens: Number(event.data.totalInputTokens || 0),
               output_tokens: Number(event.data.totalOutputTokens || 0),
             };
-            controller.enqueue(
-              sse('message_delta', {
-                delta: {},
-                type: 'message_delta',
-                usage,
-              }),
-            );
           } else if (event.type === 'stop') {
-            closeTextBlocks(controller);
-            for (const { blockIndex } of tools.values()) {
-              controller.enqueue(
-                sse('content_block_stop', { index: blockIndex, type: 'content_block_stop' }),
-              );
-            }
-            controller.enqueue(
-              sse('message_delta', {
-                delta: {
-                  stop_reason: tools.size
-                    ? 'tool_use'
-                    : event.data === 'max_tokens'
-                      ? 'max_tokens'
-                      : 'end_turn',
-                  stop_sequence: null,
-                },
-                type: 'message_delta',
-                usage: { output_tokens: usage.output_tokens },
-              }),
-            );
-            controller.enqueue(sse('message_stop', { type: 'message_stop' }));
+            const reason = typeof event.data === 'string' ? event.data : undefined;
+            if (!stopReason && reason && reason !== 'message_stop') stopReason = reason;
           } else if (event.type === 'error') {
+            finalized = true;
             controller.enqueue(
               sse('error', {
                 error: {
@@ -412,6 +417,9 @@ export const encodeAnthropicStream = (source: ReadableStream<Uint8Array>) => {
             );
           }
         },
+        flush(controller) {
+          finalize(controller);
+        },
       }),
     )
     .pipeThrough(new TextEncoderStream());
@@ -419,10 +427,13 @@ export const encodeAnthropicStream = (source: ReadableStream<Uint8Array>) => {
 
 export const encodeResponsesStream = (source: ReadableStream<Uint8Array>) => {
   const responseId = `resp_${randomUUID().replaceAll('-', '')}`;
+  let finalized = false;
   let nextOutputIndex = 0;
   const outputItems: unknown[] = [];
   let reasoningOutputIndex: number | undefined;
   let reasoningText = '';
+  let sequenceNumber = 0;
+  let stopReason: unknown;
   let textOutputIndex: number | undefined;
   let outputText = '';
   let usage: { input_tokens: number; output_tokens: number; total_tokens: number } | undefined;
@@ -441,19 +452,137 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>) => {
     output: [],
     status: 'in_progress',
   };
+  const responseSse = (
+    event: BaseStreamEvent['type'],
+    data: Omit<BaseStreamEvent, 'sequence_number'> & Record<string, unknown>,
+  ) => {
+    const sequencedData = {
+      ...data,
+      sequence_number: sequenceNumber++,
+    } satisfies BaseStreamEvent;
+    return sse(event, sequencedData);
+  };
+  const finalize = (controller: TransformStreamDefaultController<string>) => {
+    if (finalized) return;
+    finalized = true;
+    if (reasoningOutputIndex !== undefined) {
+      const item = {
+        id: `rs_${responseId}`,
+        status: 'completed',
+        summary: [{ text: reasoningText, type: 'summary_text' }],
+        type: 'reasoning',
+      };
+      outputItems[reasoningOutputIndex] = item;
+      controller.enqueue(
+        responseSse('response.reasoning_summary_text.done', {
+          item_id: `rs_${responseId}`,
+          output_index: reasoningOutputIndex,
+          summary_index: 0,
+          text: reasoningText,
+          type: 'response.reasoning_summary_text.done',
+        }),
+      );
+      controller.enqueue(
+        responseSse('response.output_item.done', {
+          item,
+          output_index: reasoningOutputIndex,
+          type: 'response.output_item.done',
+        }),
+      );
+    }
+    if (textOutputIndex !== undefined) {
+      const item = {
+        content: [{ annotations: [], text: outputText, type: 'output_text' }],
+        id: `msg_${responseId}`,
+        role: 'assistant',
+        status: 'completed',
+        type: 'message',
+      };
+      outputItems[textOutputIndex] = item;
+      controller.enqueue(
+        responseSse('response.output_text.done', {
+          content_index: 0,
+          item_id: `msg_${responseId}`,
+          output_index: textOutputIndex,
+          text: outputText,
+          type: 'response.output_text.done',
+        }),
+      );
+      controller.enqueue(
+        responseSse('response.content_part.done', {
+          content_index: 0,
+          item_id: `msg_${responseId}`,
+          output_index: textOutputIndex,
+          part: { annotations: [], text: outputText, type: 'output_text' },
+          type: 'response.content_part.done',
+        }),
+      );
+      controller.enqueue(
+        responseSse('response.output_item.done', {
+          item,
+          output_index: textOutputIndex,
+          type: 'response.output_item.done',
+        }),
+      );
+    }
+    for (const tool of toolItems.values()) {
+      const item = {
+        arguments: tool.arguments,
+        call_id: tool.callId,
+        id: tool.id,
+        name: tool.name,
+        status: 'completed',
+        type: 'function_call',
+      };
+      outputItems[tool.outputIndex] = item;
+      controller.enqueue(
+        responseSse('response.function_call_arguments.done', {
+          arguments: tool.arguments,
+          item_id: tool.id,
+          output_index: tool.outputIndex,
+          type: 'response.function_call_arguments.done',
+        }),
+      );
+      controller.enqueue(
+        responseSse('response.output_item.done', {
+          item,
+          output_index: tool.outputIndex,
+          type: 'response.output_item.done',
+        }),
+      );
+    }
+    const incomplete = stopReason === 'max_tokens';
+    const type = incomplete ? 'response.incomplete' : 'response.completed';
+    controller.enqueue(
+      responseSse(type, {
+        response: {
+          ...response,
+          incomplete_details: incomplete ? { reason: 'max_output_tokens' } : null,
+          output: outputItems.filter(Boolean),
+          status: incomplete ? 'incomplete' : 'completed',
+          usage,
+        },
+        type,
+      }),
+    );
+    controller.enqueue('data: [DONE]\n\n');
+  };
   return parseProtocolStream(source)
     .pipeThrough(
       new TransformStream<ProtocolEvent, string>({
         start(controller) {
-          controller.enqueue(sse('response.created', { response, type: 'response.created' }));
+          controller.enqueue(
+            responseSse('response.created', { response, type: 'response.created' }),
+          );
         },
         transform(event, controller) {
+          if (finalized) return;
           if (event.type === 'text') {
             outputText += String(event.data);
             if (textOutputIndex === undefined) {
               textOutputIndex = nextOutputIndex++;
               controller.enqueue(
-                sse('response.output_item.added', {
+                responseSse('response.output_item.added', {
                   item: {
                     content: [],
                     id: `msg_${responseId}`,
@@ -466,7 +595,7 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>) => {
                 }),
               );
               controller.enqueue(
-                sse('response.content_part.added', {
+                responseSse('response.content_part.added', {
                   content_index: 0,
                   item_id: `msg_${responseId}`,
                   output_index: textOutputIndex,
@@ -476,7 +605,7 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>) => {
               );
             }
             controller.enqueue(
-              sse('response.output_text.delta', {
+              responseSse('response.output_text.delta', {
                 content_index: 0,
                 delta: String(event.data),
                 item_id: `msg_${responseId}`,
@@ -489,7 +618,7 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>) => {
             if (reasoningOutputIndex === undefined) {
               reasoningOutputIndex = nextOutputIndex++;
               controller.enqueue(
-                sse('response.output_item.added', {
+                responseSse('response.output_item.added', {
                   item: {
                     id: `rs_${responseId}`,
                     status: 'in_progress',
@@ -502,7 +631,7 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>) => {
               );
             }
             controller.enqueue(
-              sse('response.reasoning_summary_text.delta', {
+              responseSse('response.reasoning_summary_text.delta', {
                 delta: String(event.data),
                 item_id: `rs_${responseId}`,
                 output_index: reasoningOutputIndex,
@@ -515,14 +644,14 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>) => {
             const item = isRecord(event.data) ? { ...event.data, status: 'completed' } : event.data;
             outputItems[outputIndex] = item;
             controller.enqueue(
-              sse('response.output_item.added', {
+              responseSse('response.output_item.added', {
                 item: isRecord(event.data) ? { ...event.data, status: 'in_progress' } : event.data,
                 output_index: outputIndex,
                 type: 'response.output_item.added',
               }),
             );
             controller.enqueue(
-              sse('response.output_item.done', {
+              responseSse('response.output_item.done', {
                 item,
                 output_index: outputIndex,
                 type: 'response.output_item.done',
@@ -543,7 +672,7 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>) => {
                 };
                 toolItems.set(chunk.index, tool);
                 controller.enqueue(
-                  sse('response.output_item.added', {
+                  responseSse('response.output_item.added', {
                     item: {
                       arguments: '',
                       call_id: tool.callId,
@@ -560,7 +689,7 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>) => {
               if (typeof fn.arguments === 'string') {
                 tool.arguments += fn.arguments;
                 controller.enqueue(
-                  sse('response.function_call_arguments.delta', {
+                  responseSse('response.function_call_arguments.delta', {
                     delta: fn.arguments,
                     item_id: tool.id,
                     output_index: tool.outputIndex,
@@ -578,112 +707,14 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>) => {
               total_tokens: inputTokens + outputTokens,
             };
           } else if (event.type === 'stop') {
-            if (reasoningOutputIndex !== undefined) {
-              const item = {
-                id: `rs_${responseId}`,
-                status: 'completed',
-                summary: [{ text: reasoningText, type: 'summary_text' }],
-                type: 'reasoning',
-              };
-              outputItems[reasoningOutputIndex] = item;
-              controller.enqueue(
-                sse('response.reasoning_summary_text.done', {
-                  item_id: `rs_${responseId}`,
-                  output_index: reasoningOutputIndex,
-                  summary_index: 0,
-                  text: reasoningText,
-                  type: 'response.reasoning_summary_text.done',
-                }),
-              );
-              controller.enqueue(
-                sse('response.output_item.done', {
-                  item,
-                  output_index: reasoningOutputIndex,
-                  type: 'response.output_item.done',
-                }),
-              );
-            }
-            if (textOutputIndex !== undefined) {
-              const item = {
-                content: [{ annotations: [], text: outputText, type: 'output_text' }],
-                id: `msg_${responseId}`,
-                role: 'assistant',
-                status: 'completed',
-                type: 'message',
-              };
-              outputItems[textOutputIndex] = item;
-              controller.enqueue(
-                sse('response.output_text.done', {
-                  content_index: 0,
-                  item_id: `msg_${responseId}`,
-                  output_index: textOutputIndex,
-                  text: outputText,
-                  type: 'response.output_text.done',
-                }),
-              );
-              controller.enqueue(
-                sse('response.content_part.done', {
-                  content_index: 0,
-                  item_id: `msg_${responseId}`,
-                  output_index: textOutputIndex,
-                  part: { annotations: [], text: outputText, type: 'output_text' },
-                  type: 'response.content_part.done',
-                }),
-              );
-              controller.enqueue(
-                sse('response.output_item.done', {
-                  item,
-                  output_index: textOutputIndex,
-                  type: 'response.output_item.done',
-                }),
-              );
-            }
-            for (const tool of toolItems.values()) {
-              const item = {
-                arguments: tool.arguments,
-                call_id: tool.callId,
-                id: tool.id,
-                name: tool.name,
-                status: 'completed',
-                type: 'function_call',
-              };
-              outputItems[tool.outputIndex] = item;
-              controller.enqueue(
-                sse('response.function_call_arguments.done', {
-                  arguments: tool.arguments,
-                  item_id: tool.id,
-                  output_index: tool.outputIndex,
-                  type: 'response.function_call_arguments.done',
-                }),
-              );
-              controller.enqueue(
-                sse('response.output_item.done', {
-                  item,
-                  output_index: tool.outputIndex,
-                  type: 'response.output_item.done',
-                }),
-              );
-            }
-            const incomplete = event.data === 'max_tokens';
-            controller.enqueue(
-              sse(incomplete ? 'response.incomplete' : 'response.completed', {
-                response: {
-                  ...response,
-                  incomplete_details: incomplete ? { reason: 'max_output_tokens' } : null,
-                  output: outputItems.filter(Boolean),
-                  status: incomplete ? 'incomplete' : 'completed',
-                  usage,
-                },
-                type: incomplete ? 'response.incomplete' : 'response.completed',
-              }),
-            );
-            controller.enqueue('data: [DONE]\n\n');
+            if (stopReason === undefined && event.data) stopReason = event.data;
           } else if (event.type === 'error') {
             const message = isRecord(event.data)
               ? String(event.data.message || 'Model request failed')
               : String(event.data);
+            finalized = true;
             controller.enqueue(
-              sse('response.failed', {
+              responseSse('response.failed', {
                 response: {
                   ...response,
                   error: { code: 'server_error', message },
@@ -695,6 +726,9 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>) => {
             );
             controller.enqueue('data: [DONE]\n\n');
           }
+        },
+        flush(controller) {
+          finalize(controller);
         },
       }),
     )

--- a/packages/openapi/src/services/heterogeneous-direct.service.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.ts
@@ -8,9 +8,10 @@ import type {
 import { RequestTrigger } from '@lobechat/types';
 import { isRecord } from '@lobechat/utils/object';
 
+import type { ServerDefaultHeterogeneousAgentType } from '@/server/modules/ModelRuntime';
 import {
   initModelRuntimeFromServerConfig,
-  resolveServerModel,
+  resolveServerDefaultHeterogeneousModel,
 } from '@/server/modules/ModelRuntime';
 
 import type { BaseStreamEvent } from '../types/responses.type';
@@ -811,6 +812,7 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>) => {
 };
 
 export const invokeServerDefaultModel = async (params: {
+  agentType: ServerDefaultHeterogeneousAgentType;
   model: string;
   payload: ChatStreamPayload;
   provider: string;
@@ -818,12 +820,13 @@ export const invokeServerDefaultModel = async (params: {
   userId: string;
   workspaceId?: string;
 }) => {
-  const resolvedModel = await resolveServerModel(params.provider, params.model);
+  const resolvedModel = await resolveServerDefaultHeterogeneousModel(
+    params.agentType,
+    params.provider,
+    params.model,
+  );
   const { deploymentName, provider } = resolvedModel;
-  // Mirrors the field-vs-model split in src/services/chat/index.ts. The server's Azure
-  // runtime consumes deploymentName in both API modes, so its logical model ID stays intact.
-  const shouldUseDeploymentField = provider === 'azure' || provider === 'spark';
-  const model = deploymentName && !shouldUseDeploymentField ? deploymentName : resolvedModel.model;
+  const model = deploymentName ?? resolvedModel.model;
   const runtime = await initModelRuntimeFromServerConfig({
     actorUserId: params.userId,
     provider,
@@ -832,9 +835,6 @@ export const invokeServerDefaultModel = async (params: {
   const response = await runtime.chat(
     {
       ...params.payload,
-      ...(shouldUseDeploymentField &&
-        deploymentName &&
-        deploymentName !== model && { deploymentName }),
       model,
       stream: true,
     },

--- a/packages/openapi/src/services/heterogeneous-direct.service.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.ts
@@ -743,14 +743,26 @@ export const invokeServerDefaultModel = async (params: {
   userId: string;
   workspaceId?: string;
 }) => {
-  const { model, provider } = await resolveServerModel(params.provider, params.model);
+  const resolvedModel = await resolveServerModel(params.provider, params.model);
+  const { deploymentName, provider } = resolvedModel;
+  // Mirrors the field-vs-model split in src/services/chat/index.ts. The server's Azure
+  // runtime consumes deploymentName in both API modes, so its logical model ID stays intact.
+  const shouldUseDeploymentField = provider === 'azure' || provider === 'spark';
+  const model = deploymentName && !shouldUseDeploymentField ? deploymentName : resolvedModel.model;
   const runtime = await initModelRuntimeFromServerConfig({
     actorUserId: params.userId,
     provider,
     workspaceId: params.workspaceId,
   });
   const response = await runtime.chat(
-    { ...params.payload, model, stream: true },
+    {
+      ...params.payload,
+      ...(shouldUseDeploymentField &&
+        deploymentName &&
+        deploymentName !== model && { deploymentName }),
+      model,
+      stream: true,
+    },
     { metadata: { trigger: RequestTrigger.Api }, signal: params.signal, user: params.userId },
   );
   if (!response.body) throw new Error('Model runtime returned an empty stream');

--- a/packages/openapi/src/services/heterogeneous-direct.service.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from 'node:crypto';
 
-import type { ChatStreamPayload, OpenAIChatMessage } from '@lobechat/model-runtime';
+import type {
+  ChatStreamPayload,
+  OpenAIChatMessage,
+  UserMessageContentPart,
+} from '@lobechat/model-runtime';
 import { RequestTrigger } from '@lobechat/types';
 import { isRecord } from '@lobechat/utils/object';
 
@@ -52,6 +56,38 @@ const contentWithImages = (content: unknown): OpenAIChatMessage['content'] => {
   return images.length > 0 ? [...(text ? [{ text, type: 'text' as const }] : []), ...images] : text;
 };
 
+const anthropicThinkingParts = (content: unknown): UserMessageContentPart[] => {
+  if (!Array.isArray(content)) return [];
+  return content.flatMap<UserMessageContentPart>((part) => {
+    if (!isRecord(part)) return [];
+    if (
+      part.type === 'thinking' &&
+      typeof part.thinking === 'string' &&
+      typeof part.signature === 'string'
+    ) {
+      return [{ signature: part.signature, thinking: part.thinking, type: 'thinking' as const }];
+    }
+    if (part.type === 'redacted_thinking' && typeof part.data === 'string') {
+      return [{ data: part.data, type: 'redacted_thinking' as const }];
+    }
+    return [];
+  });
+};
+
+const contentWithAnthropicThinking = (content: unknown): OpenAIChatMessage['content'] => {
+  const thinking = anthropicThinkingParts(content);
+  if (thinking.length === 0) return contentWithImages(content);
+  const visible = contentWithImages(content);
+  return [
+    ...thinking,
+    ...(typeof visible === 'string'
+      ? visible
+        ? [{ text: visible, type: 'text' as const }]
+        : []
+      : visible),
+  ];
+};
+
 export const normalizeAnthropicRequest = (request: Record<string, unknown>, model: string) => {
   const messages: OpenAIChatMessage[] = [];
   const system = textFromParts(request.system);
@@ -94,8 +130,16 @@ export const normalizeAnthropicRequest = (request: Record<string, unknown>, mode
       if (remaining.length) messages.push({ content: remaining, role: 'user' });
       continue;
     }
+    const normalizedContent =
+      role === 'assistant' ? contentWithAnthropicThinking(content) : contentWithImages(content);
+    const hasAnthropicThinking =
+      Array.isArray(normalizedContent) &&
+      normalizedContent.some(
+        (part) => part.type === 'thinking' || part.type === 'redacted_thinking',
+      );
     messages.push({
-      content: contentWithImages(content),
+      content: normalizedContent,
+      ...(hasAnthropicThinking ? { provider: 'anthropic' } : {}),
       role,
       ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
     });
@@ -219,20 +263,29 @@ export const normalizeResponsesRequest = (request: Record<string, unknown>, mode
 
 interface ProtocolEvent {
   data: unknown;
+  id?: string;
   type: string;
 }
 
 const parseProtocolStream = (stream: ReadableStream<Uint8Array>) => {
   let buffer = '';
+  let eventId = '';
   let eventType = '';
   const decoder = new TextDecoder();
   const processLine = (
     line: string,
     controller: TransformStreamDefaultController<ProtocolEvent>,
   ) => {
+    if (line.startsWith('id:')) eventId = line.slice(3).trim();
     if (line.startsWith('event:')) eventType = line.slice(6).trim();
     if (line.startsWith('data:')) {
-      controller.enqueue({ data: JSON.parse(line.slice(5).trim()), type: eventType });
+      controller.enqueue({
+        data: JSON.parse(line.slice(5).trim()),
+        ...(eventId ? { id: eventId } : {}),
+        type: eventType,
+      });
+      eventId = '';
+      eventType = '';
     }
   };
   return stream
@@ -430,6 +483,7 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>) => {
   let finalized = false;
   let nextOutputIndex = 0;
   const outputItems: unknown[] = [];
+  let reasoningItemId: string | undefined;
   let reasoningOutputIndex: number | undefined;
   let reasoningText = '';
   let sequenceNumber = 0;
@@ -462,34 +516,70 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>) => {
     } satisfies BaseStreamEvent;
     return sse(event, sequencedData);
   };
-  const finalize = (controller: TransformStreamDefaultController<string>) => {
-    if (finalized) return;
-    finalized = true;
-    if (reasoningOutputIndex !== undefined) {
-      const item = {
-        id: `rs_${responseId}`,
-        status: 'completed',
-        summary: [{ text: reasoningText, type: 'summary_text' }],
-        type: 'reasoning',
-      };
-      outputItems[reasoningOutputIndex] = item;
+  const completeReasoning = (
+    controller: TransformStreamDefaultController<string>,
+    responseItem?: unknown,
+  ) => {
+    if (reasoningOutputIndex === undefined) {
+      if (responseItem === undefined) return;
+      const outputIndex = nextOutputIndex++;
+      const item = isRecord(responseItem) ? { ...responseItem, status: 'completed' } : responseItem;
+      outputItems[outputIndex] = item;
       controller.enqueue(
-        responseSse('response.reasoning_summary_text.done', {
-          item_id: `rs_${responseId}`,
-          output_index: reasoningOutputIndex,
-          summary_index: 0,
-          text: reasoningText,
-          type: 'response.reasoning_summary_text.done',
+        responseSse('response.output_item.added', {
+          item: isRecord(responseItem) ? { ...responseItem, status: 'in_progress' } : responseItem,
+          output_index: outputIndex,
+          type: 'response.output_item.added',
         }),
       );
       controller.enqueue(
         responseSse('response.output_item.done', {
           item,
-          output_index: reasoningOutputIndex,
+          output_index: outputIndex,
           type: 'response.output_item.done',
         }),
       );
+      return;
     }
+
+    const outputIndex = reasoningOutputIndex;
+    const itemId =
+      isRecord(responseItem) && typeof responseItem.id === 'string'
+        ? responseItem.id
+        : reasoningItemId || `rs_${responseId}`;
+    const item = isRecord(responseItem)
+      ? { ...responseItem, status: 'completed' }
+      : {
+          id: itemId,
+          status: 'completed',
+          summary: [{ text: reasoningText, type: 'summary_text' }],
+          type: 'reasoning',
+        };
+    outputItems[outputIndex] = item;
+    controller.enqueue(
+      responseSse('response.reasoning_summary_text.done', {
+        item_id: itemId,
+        output_index: outputIndex,
+        summary_index: 0,
+        text: reasoningText,
+        type: 'response.reasoning_summary_text.done',
+      }),
+    );
+    controller.enqueue(
+      responseSse('response.output_item.done', {
+        item,
+        output_index: outputIndex,
+        type: 'response.output_item.done',
+      }),
+    );
+    reasoningItemId = undefined;
+    reasoningOutputIndex = undefined;
+    reasoningText = '';
+  };
+  const finalize = (controller: TransformStreamDefaultController<string>) => {
+    if (finalized) return;
+    finalized = true;
+    completeReasoning(controller);
     if (textOutputIndex !== undefined) {
       const item = {
         content: [{ annotations: [], text: outputText, type: 'output_text' }],
@@ -616,11 +706,12 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>) => {
           } else if (event.type === 'reasoning') {
             reasoningText += String(event.data);
             if (reasoningOutputIndex === undefined) {
+              reasoningItemId = event.id || `rs_${responseId}`;
               reasoningOutputIndex = nextOutputIndex++;
               controller.enqueue(
                 responseSse('response.output_item.added', {
                   item: {
-                    id: `rs_${responseId}`,
+                    id: reasoningItemId,
                     status: 'in_progress',
                     summary: [],
                     type: 'reasoning',
@@ -633,30 +724,14 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>) => {
             controller.enqueue(
               responseSse('response.reasoning_summary_text.delta', {
                 delta: String(event.data),
-                item_id: `rs_${responseId}`,
+                item_id: reasoningItemId,
                 output_index: reasoningOutputIndex,
                 summary_index: 0,
                 type: 'response.reasoning_summary_text.delta',
               }),
             );
           } else if (event.type === 'reasoning_response_item') {
-            const outputIndex = nextOutputIndex++;
-            const item = isRecord(event.data) ? { ...event.data, status: 'completed' } : event.data;
-            outputItems[outputIndex] = item;
-            controller.enqueue(
-              responseSse('response.output_item.added', {
-                item: isRecord(event.data) ? { ...event.data, status: 'in_progress' } : event.data,
-                output_index: outputIndex,
-                type: 'response.output_item.added',
-              }),
-            );
-            controller.enqueue(
-              responseSse('response.output_item.done', {
-                item,
-                output_index: outputIndex,
-                type: 'response.output_item.done',
-              }),
-            );
+            completeReasoning(controller, event.data);
           } else if (event.type === 'tool_calls' && Array.isArray(event.data)) {
             for (const chunk of event.data) {
               if (!isRecord(chunk) || typeof chunk.index !== 'number') continue;

--- a/packages/openapi/src/services/heterogeneous-direct.service.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.ts
@@ -1,0 +1,724 @@
+import { randomUUID } from 'node:crypto';
+
+import type { ChatStreamPayload, OpenAIChatMessage } from '@lobechat/model-runtime';
+import { RequestTrigger } from '@lobechat/types';
+import { isRecord } from '@lobechat/utils/object';
+
+import {
+  initModelRuntimeFromServerConfig,
+  resolveServerModel,
+} from '@/server/modules/ModelRuntime';
+
+export const SERVER_DEFAULT_MODEL_ALIAS = 'lobehub-default';
+
+const textFromParts = (content: unknown): string => {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((part) =>
+      isRecord(part) &&
+      typeof part.text === 'string' &&
+      ['text', 'input_text', 'output_text'].includes(String(part.type))
+        ? part.text
+        : '',
+    )
+    .join('');
+};
+
+const imageParts = (content: unknown) => {
+  if (!Array.isArray(content)) return [];
+  return content.flatMap((part) => {
+    if (!isRecord(part) || !['image', 'input_image'].includes(String(part.type))) return [];
+    if (typeof part.image_url === 'string') {
+      return [{ image_url: { url: part.image_url }, type: 'image_url' as const }];
+    }
+    const source = part.source;
+    if (!isRecord(source)) return [];
+    const url =
+      source.type === 'base64' && typeof source.data === 'string'
+        ? `data:${String(source.media_type || 'image/png')};base64,${source.data}`
+        : typeof source.url === 'string'
+          ? source.url
+          : undefined;
+    return url ? [{ image_url: { url }, type: 'image_url' as const }] : [];
+  });
+};
+
+const contentWithImages = (content: unknown): OpenAIChatMessage['content'] => {
+  const images = imageParts(content);
+  const text = textFromParts(content);
+  return images.length > 0 ? [...(text ? [{ text, type: 'text' as const }] : []), ...images] : text;
+};
+
+export const normalizeAnthropicRequest = (request: Record<string, unknown>, model: string) => {
+  const messages: OpenAIChatMessage[] = [];
+  const system = textFromParts(request.system);
+  if (system) messages.push({ content: system, role: 'system' });
+
+  for (const rawMessage of Array.isArray(request.messages) ? request.messages : []) {
+    if (!isRecord(rawMessage) || !['assistant', 'user'].includes(String(rawMessage.role))) continue;
+    const content = rawMessage.content;
+    const role = rawMessage.role as 'assistant' | 'user';
+    const toolCalls = Array.isArray(content)
+      ? content.flatMap((part) =>
+          isRecord(part) &&
+          part.type === 'tool_use' &&
+          typeof part.id === 'string' &&
+          typeof part.name === 'string'
+            ? [
+                {
+                  function: { arguments: JSON.stringify(part.input ?? {}), name: part.name },
+                  id: part.id,
+                  type: 'function' as const,
+                },
+              ]
+            : [],
+        )
+      : [];
+    const toolResults = Array.isArray(content)
+      ? content.filter((part) => isRecord(part) && part.type === 'tool_result')
+      : [];
+    if (toolResults.length > 0) {
+      for (const result of toolResults) {
+        messages.push({
+          content: contentWithImages(result.content),
+          role: 'tool',
+          tool_call_id: String(result.tool_use_id),
+        });
+      }
+      const remaining = contentWithImages(
+        (content as unknown[]).filter((part) => !isRecord(part) || part.type !== 'tool_result'),
+      );
+      if (remaining.length) messages.push({ content: remaining, role: 'user' });
+      continue;
+    }
+    messages.push({
+      content: contentWithImages(content),
+      role,
+      ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
+    });
+  }
+
+  const tools = Array.isArray(request.tools)
+    ? request.tools.flatMap((tool) =>
+        isRecord(tool) && typeof tool.name === 'string'
+          ? [
+              {
+                function: {
+                  description: typeof tool.description === 'string' ? tool.description : undefined,
+                  name: tool.name,
+                  parameters: isRecord(tool.input_schema) ? tool.input_schema : {},
+                },
+                type: 'function' as const,
+              },
+            ]
+          : [],
+      )
+    : undefined;
+  const thinking = isRecord(request.thinking) ? request.thinking : undefined;
+  return {
+    max_tokens: typeof request.max_tokens === 'number' ? request.max_tokens : undefined,
+    messages,
+    model,
+    stream: true,
+    temperature: typeof request.temperature === 'number' ? request.temperature : undefined,
+    thinking: thinking as ChatStreamPayload['thinking'],
+    tools,
+    top_p: typeof request.top_p === 'number' ? request.top_p : undefined,
+  } satisfies ChatStreamPayload;
+};
+
+export const normalizeResponsesRequest = (request: Record<string, unknown>, model: string) => {
+  const messages: OpenAIChatMessage[] = [];
+  let pendingReasoningItems: NonNullable<OpenAIChatMessage['reasoning']>['responseItems'] = [];
+  const takePendingReasoning = () => {
+    if (!pendingReasoningItems?.length) return {};
+    const reasoning = { reasoning: { responseItems: pendingReasoningItems } };
+    pendingReasoningItems = [];
+    return reasoning;
+  };
+  if (typeof request.instructions === 'string') {
+    messages.push({ content: request.instructions, role: 'system' });
+  }
+  if (typeof request.input === 'string') {
+    messages.push({ content: request.input, role: 'user' });
+  } else if (Array.isArray(request.input)) {
+    for (const item of request.input) {
+      if (!isRecord(item)) continue;
+      if (item.type === 'reasoning' && typeof item.id === 'string' && Array.isArray(item.summary)) {
+        pendingReasoningItems?.push(
+          item as unknown as NonNullable<
+            NonNullable<OpenAIChatMessage['reasoning']>['responseItems']
+          >[number],
+        );
+      } else if (item.type === 'function_call' && typeof item.call_id === 'string') {
+        messages.push({
+          content: '',
+          role: 'assistant',
+          ...takePendingReasoning(),
+          tool_calls: [
+            {
+              function: { arguments: String(item.arguments || ''), name: String(item.name || '') },
+              id: item.call_id,
+              type: 'function',
+            },
+          ],
+        });
+      } else if (item.type === 'function_call_output' && typeof item.call_id === 'string') {
+        messages.push({
+          content: String(item.output || ''),
+          role: 'tool',
+          tool_call_id: item.call_id,
+        });
+      } else if (
+        item.type === 'message' &&
+        ['assistant', 'developer', 'system', 'user'].includes(String(item.role))
+      ) {
+        messages.push({
+          content: contentWithImages(item.content),
+          role: item.role === 'developer' ? 'system' : (item.role as OpenAIChatMessage['role']),
+          ...(item.role === 'assistant' ? takePendingReasoning() : {}),
+        });
+      }
+    }
+  }
+  if (pendingReasoningItems?.length) {
+    messages.push({ content: '', role: 'assistant', ...takePendingReasoning() });
+  }
+  const tools = Array.isArray(request.tools)
+    ? request.tools.flatMap((tool) =>
+        isRecord(tool) && tool.type === 'function' && typeof tool.name === 'string'
+          ? [
+              {
+                function: {
+                  description: typeof tool.description === 'string' ? tool.description : undefined,
+                  name: tool.name,
+                  parameters: isRecord(tool.parameters) ? tool.parameters : {},
+                },
+                type: 'function' as const,
+              },
+            ]
+          : [],
+      )
+    : undefined;
+  return {
+    apiMode: 'responses',
+    max_tokens:
+      typeof request.max_output_tokens === 'number' ? request.max_output_tokens : undefined,
+    messages,
+    model,
+    reasoning: isRecord(request.reasoning) ? request.reasoning : undefined,
+    stream: true,
+    temperature: typeof request.temperature === 'number' ? request.temperature : undefined,
+    tools,
+    top_p: typeof request.top_p === 'number' ? request.top_p : undefined,
+  } satisfies ChatStreamPayload;
+};
+
+interface ProtocolEvent {
+  data: unknown;
+  type: string;
+}
+
+const parseProtocolStream = (stream: ReadableStream<Uint8Array>) => {
+  let buffer = '';
+  let eventType = '';
+  const decoder = new TextDecoder();
+  const processLine = (
+    line: string,
+    controller: TransformStreamDefaultController<ProtocolEvent>,
+  ) => {
+    if (line.startsWith('event:')) eventType = line.slice(6).trim();
+    if (line.startsWith('data:')) {
+      controller.enqueue({ data: JSON.parse(line.slice(5).trim()), type: eventType });
+    }
+  };
+  return stream
+    .pipeThrough(
+      new TransformStream<Uint8Array, string>({
+        flush(controller) {
+          const tail = decoder.decode();
+          if (tail) controller.enqueue(tail);
+        },
+        transform(chunk, controller) {
+          controller.enqueue(decoder.decode(chunk, { stream: true }));
+        },
+      }),
+    )
+    .pipeThrough(
+      new TransformStream<string, ProtocolEvent>({
+        flush(controller) {
+          if (buffer.trim()) processLine(buffer, controller);
+        },
+        transform(chunk, controller) {
+          buffer += chunk;
+          const lines = buffer.split('\n');
+          buffer = lines.pop() ?? '';
+          for (const line of lines) {
+            processLine(line, controller);
+          }
+        },
+      }),
+    );
+};
+
+const sse = (event: string, data: unknown) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+
+export const encodeAnthropicStream = (source: ReadableStream<Uint8Array>) => {
+  const messageId = `msg_${randomUUID().replaceAll('-', '')}`;
+  let nextIndex = 0;
+  let textIndex: number | undefined;
+  let thinkingIndex: number | undefined;
+  let usage = { input_tokens: 0, output_tokens: 0 };
+  const tools = new Map<number, { blockIndex: number; id: string; name: string }>();
+  const closeTextBlocks = (controller: TransformStreamDefaultController<string>) => {
+    for (const index of [textIndex, thinkingIndex]) {
+      if (index !== undefined)
+        controller.enqueue(sse('content_block_stop', { index, type: 'content_block_stop' }));
+    }
+    textIndex = undefined;
+    thinkingIndex = undefined;
+  };
+  return parseProtocolStream(source)
+    .pipeThrough(
+      new TransformStream<ProtocolEvent, string>({
+        start(controller) {
+          controller.enqueue(
+            sse('message_start', {
+              message: {
+                content: [],
+                id: messageId,
+                model: SERVER_DEFAULT_MODEL_ALIAS,
+                role: 'assistant',
+                stop_reason: null,
+                type: 'message',
+                usage: { input_tokens: 0, output_tokens: 0 },
+              },
+              type: 'message_start',
+            }),
+          );
+        },
+        transform(event, controller) {
+          if (event.type === 'text' || event.type === 'reasoning') {
+            const isThinking = event.type === 'reasoning';
+            let index = isThinking ? thinkingIndex : textIndex;
+            if (index === undefined) {
+              closeTextBlocks(controller);
+              index = nextIndex++;
+              controller.enqueue(
+                sse('content_block_start', {
+                  content_block: isThinking
+                    ? { signature: '', thinking: '', type: 'thinking' }
+                    : { text: '', type: 'text' },
+                  index,
+                  type: 'content_block_start',
+                }),
+              );
+              if (isThinking) thinkingIndex = index;
+              else textIndex = index;
+            }
+            controller.enqueue(
+              sse('content_block_delta', {
+                delta: isThinking
+                  ? { thinking: String(event.data), type: 'thinking_delta' }
+                  : { text: String(event.data), type: 'text_delta' },
+                index,
+                type: 'content_block_delta',
+              }),
+            );
+          } else if (event.type === 'reasoning_signature' && thinkingIndex !== undefined) {
+            controller.enqueue(
+              sse('content_block_delta', {
+                delta: { signature: String(event.data), type: 'signature_delta' },
+                index: thinkingIndex,
+                type: 'content_block_delta',
+              }),
+            );
+          } else if (event.type === 'tool_calls' && Array.isArray(event.data)) {
+            closeTextBlocks(controller);
+            for (const chunk of event.data) {
+              if (!isRecord(chunk) || typeof chunk.index !== 'number') continue;
+              const fn = isRecord(chunk.function) ? chunk.function : {};
+              let tool = tools.get(chunk.index);
+              if (!tool) {
+                tool = {
+                  blockIndex: nextIndex++,
+                  id: String(chunk.id || `tool_${randomUUID()}`),
+                  name: String(fn.name || ''),
+                };
+                tools.set(chunk.index, tool);
+                controller.enqueue(
+                  sse('content_block_start', {
+                    content_block: { id: tool.id, input: {}, name: tool.name, type: 'tool_use' },
+                    index: tool.blockIndex,
+                    type: 'content_block_start',
+                  }),
+                );
+              }
+              if (typeof fn.arguments === 'string' && fn.arguments)
+                controller.enqueue(
+                  sse('content_block_delta', {
+                    delta: { partial_json: fn.arguments, type: 'input_json_delta' },
+                    index: tool.blockIndex,
+                    type: 'content_block_delta',
+                  }),
+                );
+            }
+          } else if (event.type === 'usage' && isRecord(event.data)) {
+            usage = {
+              input_tokens: Number(event.data.totalInputTokens || 0),
+              output_tokens: Number(event.data.totalOutputTokens || 0),
+            };
+            controller.enqueue(
+              sse('message_delta', {
+                delta: {},
+                type: 'message_delta',
+                usage,
+              }),
+            );
+          } else if (event.type === 'stop') {
+            closeTextBlocks(controller);
+            for (const { blockIndex } of tools.values()) {
+              controller.enqueue(
+                sse('content_block_stop', { index: blockIndex, type: 'content_block_stop' }),
+              );
+            }
+            controller.enqueue(
+              sse('message_delta', {
+                delta: {
+                  stop_reason: tools.size
+                    ? 'tool_use'
+                    : event.data === 'max_tokens'
+                      ? 'max_tokens'
+                      : 'end_turn',
+                  stop_sequence: null,
+                },
+                type: 'message_delta',
+                usage: { output_tokens: usage.output_tokens },
+              }),
+            );
+            controller.enqueue(sse('message_stop', { type: 'message_stop' }));
+          } else if (event.type === 'error') {
+            controller.enqueue(
+              sse('error', {
+                error: {
+                  message: isRecord(event.data)
+                    ? String(event.data.message || 'Model request failed')
+                    : String(event.data),
+                  type: 'api_error',
+                },
+                type: 'error',
+              }),
+            );
+          }
+        },
+      }),
+    )
+    .pipeThrough(new TextEncoderStream());
+};
+
+export const encodeResponsesStream = (source: ReadableStream<Uint8Array>) => {
+  const responseId = `resp_${randomUUID().replaceAll('-', '')}`;
+  let nextOutputIndex = 0;
+  const outputItems: unknown[] = [];
+  let reasoningOutputIndex: number | undefined;
+  let reasoningText = '';
+  let textOutputIndex: number | undefined;
+  let outputText = '';
+  let usage: { input_tokens: number; output_tokens: number; total_tokens: number } | undefined;
+  const toolItems = new Map<
+    number,
+    { arguments: string; callId: string; id: string; name: string; outputIndex: number }
+  >();
+  const response = {
+    created_at: Math.floor(Date.now() / 1000),
+    error: null,
+    id: responseId,
+    incomplete_details: null,
+    instructions: null,
+    model: SERVER_DEFAULT_MODEL_ALIAS,
+    object: 'response',
+    output: [],
+    status: 'in_progress',
+  };
+  return parseProtocolStream(source)
+    .pipeThrough(
+      new TransformStream<ProtocolEvent, string>({
+        start(controller) {
+          controller.enqueue(sse('response.created', { response, type: 'response.created' }));
+        },
+        transform(event, controller) {
+          if (event.type === 'text') {
+            outputText += String(event.data);
+            if (textOutputIndex === undefined) {
+              textOutputIndex = nextOutputIndex++;
+              controller.enqueue(
+                sse('response.output_item.added', {
+                  item: {
+                    content: [],
+                    id: `msg_${responseId}`,
+                    role: 'assistant',
+                    status: 'in_progress',
+                    type: 'message',
+                  },
+                  output_index: textOutputIndex,
+                  type: 'response.output_item.added',
+                }),
+              );
+              controller.enqueue(
+                sse('response.content_part.added', {
+                  content_index: 0,
+                  item_id: `msg_${responseId}`,
+                  output_index: textOutputIndex,
+                  part: { annotations: [], text: '', type: 'output_text' },
+                  type: 'response.content_part.added',
+                }),
+              );
+            }
+            controller.enqueue(
+              sse('response.output_text.delta', {
+                content_index: 0,
+                delta: String(event.data),
+                item_id: `msg_${responseId}`,
+                output_index: textOutputIndex,
+                type: 'response.output_text.delta',
+              }),
+            );
+          } else if (event.type === 'reasoning') {
+            reasoningText += String(event.data);
+            if (reasoningOutputIndex === undefined) {
+              reasoningOutputIndex = nextOutputIndex++;
+              controller.enqueue(
+                sse('response.output_item.added', {
+                  item: {
+                    id: `rs_${responseId}`,
+                    status: 'in_progress',
+                    summary: [],
+                    type: 'reasoning',
+                  },
+                  output_index: reasoningOutputIndex,
+                  type: 'response.output_item.added',
+                }),
+              );
+            }
+            controller.enqueue(
+              sse('response.reasoning_summary_text.delta', {
+                delta: String(event.data),
+                item_id: `rs_${responseId}`,
+                output_index: reasoningOutputIndex,
+                summary_index: 0,
+                type: 'response.reasoning_summary_text.delta',
+              }),
+            );
+          } else if (event.type === 'reasoning_response_item') {
+            const outputIndex = nextOutputIndex++;
+            const item = isRecord(event.data) ? { ...event.data, status: 'completed' } : event.data;
+            outputItems[outputIndex] = item;
+            controller.enqueue(
+              sse('response.output_item.added', {
+                item: isRecord(event.data) ? { ...event.data, status: 'in_progress' } : event.data,
+                output_index: outputIndex,
+                type: 'response.output_item.added',
+              }),
+            );
+            controller.enqueue(
+              sse('response.output_item.done', {
+                item,
+                output_index: outputIndex,
+                type: 'response.output_item.done',
+              }),
+            );
+          } else if (event.type === 'tool_calls' && Array.isArray(event.data)) {
+            for (const chunk of event.data) {
+              if (!isRecord(chunk) || typeof chunk.index !== 'number') continue;
+              const fn = isRecord(chunk.function) ? chunk.function : {};
+              let tool = toolItems.get(chunk.index);
+              if (!tool) {
+                tool = {
+                  arguments: '',
+                  callId: String(chunk.id || `call_${randomUUID()}`),
+                  id: `fc_${randomUUID()}`,
+                  name: String(fn.name || ''),
+                  outputIndex: nextOutputIndex++,
+                };
+                toolItems.set(chunk.index, tool);
+                controller.enqueue(
+                  sse('response.output_item.added', {
+                    item: {
+                      arguments: '',
+                      call_id: tool.callId,
+                      id: tool.id,
+                      name: tool.name,
+                      status: 'in_progress',
+                      type: 'function_call',
+                    },
+                    output_index: tool.outputIndex,
+                    type: 'response.output_item.added',
+                  }),
+                );
+              }
+              if (typeof fn.arguments === 'string') {
+                tool.arguments += fn.arguments;
+                controller.enqueue(
+                  sse('response.function_call_arguments.delta', {
+                    delta: fn.arguments,
+                    item_id: tool.id,
+                    output_index: tool.outputIndex,
+                    type: 'response.function_call_arguments.delta',
+                  }),
+                );
+              }
+            }
+          } else if (event.type === 'usage' && isRecord(event.data)) {
+            const inputTokens = Number(event.data.totalInputTokens || 0);
+            const outputTokens = Number(event.data.totalOutputTokens || 0);
+            usage = {
+              input_tokens: inputTokens,
+              output_tokens: outputTokens,
+              total_tokens: inputTokens + outputTokens,
+            };
+          } else if (event.type === 'stop') {
+            if (reasoningOutputIndex !== undefined) {
+              const item = {
+                id: `rs_${responseId}`,
+                status: 'completed',
+                summary: [{ text: reasoningText, type: 'summary_text' }],
+                type: 'reasoning',
+              };
+              outputItems[reasoningOutputIndex] = item;
+              controller.enqueue(
+                sse('response.reasoning_summary_text.done', {
+                  item_id: `rs_${responseId}`,
+                  output_index: reasoningOutputIndex,
+                  summary_index: 0,
+                  text: reasoningText,
+                  type: 'response.reasoning_summary_text.done',
+                }),
+              );
+              controller.enqueue(
+                sse('response.output_item.done', {
+                  item,
+                  output_index: reasoningOutputIndex,
+                  type: 'response.output_item.done',
+                }),
+              );
+            }
+            if (textOutputIndex !== undefined) {
+              const item = {
+                content: [{ annotations: [], text: outputText, type: 'output_text' }],
+                id: `msg_${responseId}`,
+                role: 'assistant',
+                status: 'completed',
+                type: 'message',
+              };
+              outputItems[textOutputIndex] = item;
+              controller.enqueue(
+                sse('response.output_text.done', {
+                  content_index: 0,
+                  item_id: `msg_${responseId}`,
+                  output_index: textOutputIndex,
+                  text: outputText,
+                  type: 'response.output_text.done',
+                }),
+              );
+              controller.enqueue(
+                sse('response.content_part.done', {
+                  content_index: 0,
+                  item_id: `msg_${responseId}`,
+                  output_index: textOutputIndex,
+                  part: { annotations: [], text: outputText, type: 'output_text' },
+                  type: 'response.content_part.done',
+                }),
+              );
+              controller.enqueue(
+                sse('response.output_item.done', {
+                  item,
+                  output_index: textOutputIndex,
+                  type: 'response.output_item.done',
+                }),
+              );
+            }
+            for (const tool of toolItems.values()) {
+              const item = {
+                arguments: tool.arguments,
+                call_id: tool.callId,
+                id: tool.id,
+                name: tool.name,
+                status: 'completed',
+                type: 'function_call',
+              };
+              outputItems[tool.outputIndex] = item;
+              controller.enqueue(
+                sse('response.function_call_arguments.done', {
+                  arguments: tool.arguments,
+                  item_id: tool.id,
+                  output_index: tool.outputIndex,
+                  type: 'response.function_call_arguments.done',
+                }),
+              );
+              controller.enqueue(
+                sse('response.output_item.done', {
+                  item,
+                  output_index: tool.outputIndex,
+                  type: 'response.output_item.done',
+                }),
+              );
+            }
+            const incomplete = event.data === 'max_tokens';
+            controller.enqueue(
+              sse(incomplete ? 'response.incomplete' : 'response.completed', {
+                response: {
+                  ...response,
+                  incomplete_details: incomplete ? { reason: 'max_output_tokens' } : null,
+                  output: outputItems.filter(Boolean),
+                  status: incomplete ? 'incomplete' : 'completed',
+                  usage,
+                },
+                type: incomplete ? 'response.incomplete' : 'response.completed',
+              }),
+            );
+            controller.enqueue('data: [DONE]\n\n');
+          } else if (event.type === 'error') {
+            const message = isRecord(event.data)
+              ? String(event.data.message || 'Model request failed')
+              : String(event.data);
+            controller.enqueue(
+              sse('response.failed', {
+                response: {
+                  ...response,
+                  error: { code: 'server_error', message },
+                  output: outputItems.filter(Boolean),
+                  status: 'failed',
+                },
+                type: 'response.failed',
+              }),
+            );
+            controller.enqueue('data: [DONE]\n\n');
+          }
+        },
+      }),
+    )
+    .pipeThrough(new TextEncoderStream());
+};
+
+export const invokeServerDefaultModel = async (params: {
+  model: string;
+  payload: ChatStreamPayload;
+  provider: string;
+  signal: AbortSignal;
+  userId: string;
+  workspaceId?: string;
+}) => {
+  const { model, provider } = await resolveServerModel(params.provider, params.model);
+  const runtime = await initModelRuntimeFromServerConfig({
+    actorUserId: params.userId,
+    provider,
+    workspaceId: params.workspaceId,
+  });
+  const response = await runtime.chat(
+    { ...params.payload, model, stream: true },
+    { metadata: { trigger: RequestTrigger.Api }, signal: params.signal, user: params.userId },
+  );
+  if (!response.body) throw new Error('Model runtime returned an empty stream');
+  return { model, response };
+};

--- a/packages/trpc/src/lambda/context.ts
+++ b/packages/trpc/src/lambda/context.ts
@@ -17,6 +17,8 @@ import { assertOIDCUserActive, isOIDCUserInactiveError } from '@/libs/oidc-provi
 import { validateOIDCJWT } from '@/libs/oidc-provider/jwt';
 import { isApiKeyExpired, validateApiKeyFormat } from '@/utils/apiKey';
 
+import { HETERO_OPERATION_JWT_PURPOSE } from '../utils/internalJwt';
+
 // Create context logger namespace
 const log = debug('lobe-trpc:lambda:context');
 const LOBE_CHAT_API_KEY_HEADER = 'X-API-Key';
@@ -284,9 +286,21 @@ export const createLambdaContext = async (request: NextRequest): Promise<LambdaC
         // so banned/deleted accounts cannot keep using an already-issued token.
         const tokenInfo = await validateOIDCJWT(oidcAuthToken);
 
+        const operationClaims =
+          tokenInfo.tokenData.purpose === HETERO_OPERATION_JWT_PURPOSE
+            ? {
+                capabilities: tokenInfo.payload.capabilities,
+                iss: tokenInfo.payload.iss,
+                model: tokenInfo.payload.model,
+                operation_id: tokenInfo.payload.operation_id,
+                provider_id: tokenInfo.payload.provider_id,
+                workspace_id: tokenInfo.payload.workspace_id,
+              }
+            : undefined;
         oidcAuth = {
           payload: tokenInfo.tokenData,
           ...tokenInfo.tokenData, // Spread payload into oidcAuth
+          ...operationClaims,
           sub: tokenInfo.userId, // Use tokenData as payload
         };
         userId = tokenInfo.userId;

--- a/packages/trpc/src/lambda/middleware/__tests__/heteroOperationAuth.test.ts
+++ b/packages/trpc/src/lambda/middleware/__tests__/heteroOperationAuth.test.ts
@@ -17,12 +17,49 @@ const createCaller = createCallerFactory(testRouter);
 describe('heteroOperationAuth middleware', () => {
   it('accepts a hetero-operation token as kind "operation"', async () => {
     const caller = createCaller({
-      oidcAuth: { purpose: 'hetero-operation', sub: 'user-abc' },
+      oidcAuth: {
+        aud: 'urn:lobehub:hetero-operation',
+        capabilities: ['hetero:ingest'],
+        exp: 2,
+        iat: 1,
+        iss: 'urn:lobehub:internal',
+        jti: 'jti-1',
+        operation_id: 'op-1',
+        purpose: 'hetero-operation',
+        sub: 'user-abc',
+      },
     } as any);
 
     const result = await caller.ping();
 
     expect(result).toEqual({ kind: 'operation', userId: 'user-abc' });
+  });
+
+  it('accepts a pre-deploy operation token through the legacy ownership path', async () => {
+    const caller = createCaller({
+      oidcAuth: {
+        purpose: 'hetero-operation',
+        sub: 'user-abc',
+        workspace_id: 'workspace-123',
+      },
+    } as any);
+
+    await expect(caller.ping()).resolves.toEqual({
+      kind: 'legacy-operation',
+      userId: 'user-abc',
+    });
+  });
+
+  it('does not downgrade a partially populated strict token to legacy auth', async () => {
+    const caller = createCaller({
+      oidcAuth: {
+        operation_id: 'op-1',
+        purpose: 'hetero-operation',
+        sub: 'user-abc',
+      },
+    } as any);
+
+    await expect(caller.ping()).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 
   it('accepts a normal user OIDC token (no purpose) as kind "user"', async () => {

--- a/packages/trpc/src/lambda/middleware/__tests__/heteroOperationAuth.test.ts
+++ b/packages/trpc/src/lambda/middleware/__tests__/heteroOperationAuth.test.ts
@@ -1,38 +1,102 @@
-import { describe, expect, it } from 'vitest';
+import { exportJWK, generateKeyPair } from 'jose';
+import { NextRequest } from 'next/server';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 
-import { createCallerFactory } from '@/libs/trpc/lambda';
-import { trpc } from '@/libs/trpc/lambda/init';
+import { createCallerFactory, heteroAuthedProcedure, router } from '@/libs/trpc/lambda';
 
-import { heteroOperationAuth } from '../heteroOperationAuth';
+import { signHeteroOperationJWT } from '../../../utils/internalJwt';
+import { createLambdaContext } from '../../context';
+
+const { mockAuthEnv } = vi.hoisted(() => ({
+  mockAuthEnv: {
+    ENABLE_OIDC: true,
+    JWKS_KEY: '',
+  },
+}));
+
+vi.mock('@/auth', () => ({
+  auth: { api: { getSession: vi.fn() } },
+}));
+
+vi.mock('@/business/server/workspaceApiKey', () => ({
+  canUseWorkspaceApiKeys: vi.fn(),
+}));
+
+vi.mock('@/database/core/db-adaptor', () => ({
+  getServerDB: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@/database/models/apiKey', () => ({
+  ApiKeyModel: vi.fn(),
+}));
+
+vi.mock('@/database/models/workspace', () => ({
+  hasActiveWorkspaceMembership: vi.fn(),
+}));
+
+vi.mock('@/envs/auth', () => ({
+  LOBE_CHAT_OIDC_AUTH_HEADER: 'Oidc-Auth',
+  authEnv: mockAuthEnv,
+}));
+
+vi.mock('@/libs/observability/traceparent', () => ({
+  extractTraceContext: vi.fn(),
+  injectSpanTraceHeaders: vi.fn(),
+}));
+
+vi.mock('@/libs/oidc-provider/access-control', () => ({
+  assertOIDCUserActive: vi.fn(),
+  isOIDCUserInactiveError: vi.fn().mockReturnValue(false),
+}));
 
 // Minimal router that exercises heteroOperationAuth
-const testRouter = trpc.router({
-  ping: trpc.procedure
-    .use(heteroOperationAuth)
-    .query(({ ctx }) => ({ kind: (ctx as any).heteroAuthKind, userId: ctx.userId })),
+const testRouter = router({
+  ping: heteroAuthedProcedure.query(({ ctx }) => ({
+    kind: ctx.heteroAuthKind,
+    operation: ctx.heteroOperation,
+    userId: ctx.userId,
+  })),
 });
 
 const createCaller = createCallerFactory(testRouter);
 
 describe('heteroOperationAuth middleware', () => {
+  beforeAll(async () => {
+    const { privateKey } = await generateKeyPair('RS256', { extractable: true });
+    const privateJwk = await exportJWK(privateKey);
+    mockAuthEnv.JWKS_KEY = JSON.stringify({
+      keys: [{ ...privateJwk, alg: 'RS256', kid: 'test-kid', use: 'sig' }],
+    });
+  });
+
   it('accepts a hetero-operation token as kind "operation"', async () => {
-    const caller = createCaller({
-      oidcAuth: {
-        aud: 'urn:lobehub:hetero-operation',
-        capabilities: ['hetero:ingest'],
-        exp: 2,
-        iat: 1,
-        iss: 'urn:lobehub:internal',
-        jti: 'jti-1',
-        operation_id: 'op-1',
-        purpose: 'hetero-operation',
-        sub: 'user-abc',
-      },
-    } as any);
+    const token = await signHeteroOperationJWT({
+      capabilities: ['model:invoke'],
+      model: 'gpt-server',
+      operationId: 'op-1',
+      providerId: 'openai',
+      userId: 'user-abc',
+      workspaceId: 'workspace-123',
+    });
+    const request = new NextRequest('https://example.com/trpc/lambda', {
+      headers: { 'Oidc-Auth': token },
+    });
+    const caller = createCaller(await createLambdaContext(request));
 
     const result = await caller.ping();
 
-    expect(result).toEqual({ kind: 'operation', userId: 'user-abc' });
+    expect(result).toEqual({
+      kind: 'operation',
+      operation: expect.objectContaining({
+        capabilities: ['model:invoke'],
+        iss: 'urn:lobehub:internal',
+        model: 'gpt-server',
+        operation_id: 'op-1',
+        provider_id: 'openai',
+        workspace_id: 'workspace-123',
+      }),
+      userId: 'user-abc',
+    });
   });
 
   it('accepts a pre-deploy operation token through the legacy ownership path', async () => {
@@ -40,12 +104,12 @@ describe('heteroOperationAuth middleware', () => {
       oidcAuth: {
         purpose: 'hetero-operation',
         sub: 'user-abc',
-        workspace_id: 'workspace-123',
       },
     } as any);
 
     await expect(caller.ping()).resolves.toEqual({
       kind: 'legacy-operation',
+      operation: null,
       userId: 'user-abc',
     });
   });
@@ -69,7 +133,7 @@ describe('heteroOperationAuth middleware', () => {
 
     const result = await caller.ping();
 
-    expect(result).toEqual({ kind: 'user', userId: 'user-abc' });
+    expect(result).toEqual({ kind: 'user', operation: undefined, userId: 'user-abc' });
   });
 
   it('accepts a cli-sandbox token as kind "user"', async () => {
@@ -79,7 +143,7 @@ describe('heteroOperationAuth middleware', () => {
 
     const result = await caller.ping();
 
-    expect(result).toEqual({ kind: 'user', userId: 'user-abc' });
+    expect(result).toEqual({ kind: 'user', operation: undefined, userId: 'user-abc' });
   });
 
   it('rejects when oidcAuth is absent', async () => {

--- a/packages/trpc/src/lambda/middleware/heteroOperationAuth.ts
+++ b/packages/trpc/src/lambda/middleware/heteroOperationAuth.ts
@@ -1,13 +1,18 @@
 import { TRPCError } from '@trpc/server';
 
+import { validateHeteroOperationClaims } from '../../utils/internalJwt';
 import { trpc } from '../init';
+
+const STRICT_OPERATION_CLAIMS = ['aud', 'capabilities', 'iss', 'jti', 'operation_id'] as const;
 
 /**
  * Auth middleware for hetero-agent ingest/finish endpoints. Accepts two callers:
  *
  * - A `hetero-operation` token (4h expiry) — the narrow, server-minted JWT
- *   issued by execAgent for the cloud sandbox / workspace device. Its `sub` may
- *   be a userId or, for workspace runs, a workspaceId. Behaves exactly as before.
+ *   issued by execAgent for the cloud sandbox / workspace device. Its `sub` is
+ *   the user principal and workspace runs carry a separate `workspace_id` claim.
+ * - A legacy `hetero-operation` token minted before operation-bound claims were
+ *   deployed — accepted temporarily so an already-running job can finish.
  * - A normal user OIDC token — a logged-in desktop reusing its own session for a
  *   remote run dispatched to it, so the spawned `lh hetero exec` can stream
  *   results back without a server round-trip to mint a dedicated token.
@@ -28,9 +33,24 @@ export const heteroOperationAuth = trpc.middleware(async (opts) => {
     });
   }
 
-  const heteroAuthKind = ctx.oidcAuth.purpose === 'hetero-operation' ? 'operation' : 'user';
+  const isOperation = ctx.oidcAuth.purpose === 'hetero-operation';
+  const heteroOperation = isOperation
+    ? validateHeteroOperationClaims(ctx.oidcAuth as Record<string, unknown>)
+    : undefined;
+  // A partially populated strict contract must not fall back to the broader
+  // ownership path. Only the purpose/sub-only shape issued by old pods qualifies.
+  const isLegacyOperation =
+    isOperation && STRICT_OPERATION_CLAIMS.every((claim) => ctx.oidcAuth?.[claim] === undefined);
+  if (isOperation && !heteroOperation && !isLegacyOperation) {
+    throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Invalid heterogeneous operation token' });
+  }
+  const heteroAuthKind = heteroOperation
+    ? 'operation'
+    : isLegacyOperation
+      ? 'legacy-operation'
+      : 'user';
 
   return next({
-    ctx: { heteroAuthKind, oidcAuth: ctx.oidcAuth, userId: sub },
+    ctx: { heteroAuthKind, heteroOperation, oidcAuth: ctx.oidcAuth, userId: sub },
   });
 });

--- a/packages/trpc/src/utils/__tests__/internalJwt.test.ts
+++ b/packages/trpc/src/utils/__tests__/internalJwt.test.ts
@@ -30,20 +30,29 @@ vi.mock('@/envs/auth', () => ({
 // so the chain (.setProtectedHeader().setSubject()…) doesn't break.
 const signMock = vi.fn().mockResolvedValue('signed.jwt.token');
 const setExpirationTimeMock = vi.fn();
+const setAudienceMock = vi.fn();
+const setIssuerMock = vi.fn();
 const setIssuedAtMock = vi.fn();
+const setJtiMock = vi.fn();
 const setSubjectMock = vi.fn();
 const setProtectedHeaderMock = vi.fn();
 
 const buildSignJWTChain = () => {
   const chain = {
+    setAudience: setAudienceMock.mockReturnValue(undefined as any),
     setExpirationTime: setExpirationTimeMock.mockReturnValue(undefined as any),
+    setIssuer: setIssuerMock.mockReturnValue(undefined as any),
     setIssuedAt: setIssuedAtMock.mockReturnValue(undefined as any),
+    setJti: setJtiMock.mockReturnValue(undefined as any),
     setProtectedHeader: setProtectedHeaderMock.mockReturnValue(undefined as any),
     setSubject: setSubjectMock.mockReturnValue(undefined as any),
     sign: signMock,
   };
   // Make every setter return the same chain object so .method().method() works.
   setProtectedHeaderMock.mockReturnValue(chain);
+  setAudienceMock.mockReturnValue(chain);
+  setIssuerMock.mockReturnValue(chain);
+  setJtiMock.mockReturnValue(chain);
   setSubjectMock.mockReturnValue(chain);
   setIssuedAtMock.mockReturnValue(chain);
   setExpirationTimeMock.mockReturnValue(chain);
@@ -108,22 +117,62 @@ describe('internalJwt', () => {
   });
 
   describe('signOperationJwt', () => {
+    it('binds a server model selection into the operation token', async () => {
+      const { signHeteroOperationJWT } = await import('../internalJwt');
+
+      await signHeteroOperationJWT({
+        capabilities: ['model:invoke'],
+        model: 'gpt-server',
+        operationId: 'op-server',
+        providerId: 'openai',
+        userId: 'user-456',
+      });
+
+      expect(SignJWTMock).toHaveBeenCalledWith({
+        capabilities: ['model:invoke'],
+        model: 'gpt-server',
+        operation_id: 'op-server',
+        provider_id: 'openai',
+        purpose: 'hetero-operation',
+      });
+    });
+
     it('signs a JWT with 4-hour expiry and hetero-operation purpose', async () => {
       const { signOperationJwt } = await import('../internalJwt');
 
-      const token = await signOperationJwt('user-456');
+      const token = await signOperationJwt('user-456', 'op-123');
 
       expect(token).toBe('signed.jwt.token');
-      expect(SignJWTMock).toHaveBeenCalledWith({ purpose: 'hetero-operation' });
+      expect(SignJWTMock).toHaveBeenCalledWith({
+        capabilities: ['hetero:ingest', 'hetero:finish', 'hetero:intervention:read'],
+        operation_id: 'op-123',
+        purpose: 'hetero-operation',
+      });
+      expect(setAudienceMock).toHaveBeenCalledWith('urn:lobehub:hetero-operation');
+      expect(setIssuerMock).toHaveBeenCalledWith('urn:lobehub:internal');
+      expect(setJtiMock).toHaveBeenCalled();
       expect(setSubjectMock).toHaveBeenCalledWith('user-456');
       expect(setExpirationTimeMock).toHaveBeenCalledWith('4h');
       expect(signMock).toHaveBeenCalledWith('mock-crypto-key');
     });
 
+    it('binds a workspace operation token to the durable workspace principal', async () => {
+      const { signOperationJwt } = await import('../internalJwt');
+
+      await signOperationJwt('user-456', 'op-workspace', 'workspace-123');
+
+      expect(SignJWTMock).toHaveBeenCalledWith({
+        capabilities: ['hetero:ingest', 'hetero:finish', 'hetero:intervention:read'],
+        operation_id: 'op-workspace',
+        purpose: 'hetero-operation',
+        workspace_id: 'workspace-123',
+      });
+    });
+
     it('sets the protected header with RS256 and the key id', async () => {
       const { signOperationJwt } = await import('../internalJwt');
 
-      await signOperationJwt('user-456');
+      await signOperationJwt('user-456', 'op-header');
 
       expect(setProtectedHeaderMock).toHaveBeenCalledWith({ alg: 'RS256', kid: 'test-kid' });
     });
@@ -131,7 +180,7 @@ describe('internalJwt', () => {
     it('calls setIssuedAt to stamp the creation time', async () => {
       const { signOperationJwt } = await import('../internalJwt');
 
-      await signOperationJwt('user-456');
+      await signOperationJwt('user-456', 'op-issued-at');
 
       expect(setIssuedAtMock).toHaveBeenCalled();
     });
@@ -142,12 +191,39 @@ describe('internalJwt', () => {
       await signUserJWT('user-a');
       const userExpiry = setExpirationTimeMock.mock.calls.at(-1)?.[0];
 
-      await signOperationJwt('user-b');
+      await signOperationJwt('user-b', 'op-expiry');
       const opExpiry = setExpirationTimeMock.mock.calls.at(-1)?.[0];
 
       expect(userExpiry).toBe('5m');
       expect(opExpiry).toBe('4h');
     });
+  });
+
+  describe('validateHeteroOperationClaims', () => {
+    const validClaims = {
+      aud: 'urn:lobehub:hetero-operation',
+      capabilities: ['model:invoke'],
+      exp: 2,
+      iat: 1,
+      iss: 'urn:lobehub:internal',
+      jti: 'jti-1',
+      operation_id: 'op-1',
+      purpose: 'hetero-operation',
+      sub: 'user-1',
+    };
+
+    it('accepts the typed operation contract', async () => {
+      const { validateHeteroOperationClaims } = await import('../internalJwt');
+      expect(validateHeteroOperationClaims(validClaims)).toEqual(validClaims);
+    });
+
+    it.each(['aud', 'iss', 'purpose', 'operation_id', 'capabilities'])(
+      'rejects invalid %s',
+      async (field) => {
+        const { validateHeteroOperationClaims } = await import('../internalJwt');
+        expect(validateHeteroOperationClaims({ ...validClaims, [field]: undefined })).toBeNull();
+      },
+    );
   });
 
   describe('signInternalJWT', () => {

--- a/packages/trpc/src/utils/internalJwt.ts
+++ b/packages/trpc/src/utils/internalJwt.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import debug from 'debug';
 import { importJWK, jwtVerify, SignJWT } from 'jose';
 
@@ -6,6 +8,27 @@ import { authEnv } from '@/envs/auth';
 const log = debug('lobe-internal-jwt');
 
 const INTERNAL_JWT_PURPOSE = 'lobe-internal-call';
+export const HETERO_OPERATION_JWT_ISSUER = 'urn:lobehub:internal';
+export const HETERO_OPERATION_JWT_AUDIENCE = 'urn:lobehub:hetero-operation';
+export const HETERO_OPERATION_JWT_PURPOSE = 'hetero-operation';
+
+export type HeteroOperationCapability =
+  'hetero:finish' | 'hetero:ingest' | 'hetero:intervention:read' | 'model:invoke';
+
+export interface HeteroOperationJwtClaims {
+  aud: typeof HETERO_OPERATION_JWT_AUDIENCE;
+  capabilities: HeteroOperationCapability[];
+  exp: number;
+  iat: number;
+  iss: typeof HETERO_OPERATION_JWT_ISSUER;
+  jti: string;
+  model?: string;
+  operation_id: string;
+  provider_id?: string;
+  purpose: typeof HETERO_OPERATION_JWT_PURPOSE;
+  sub: string;
+  workspace_id?: string;
+}
 
 /**
  * Get RSA key pair from JWKS_KEY environment variable
@@ -110,15 +133,87 @@ export const signUserJWT = async (
  * Claude Code / Codex tasks can run for hours; this 4-hour token prevents
  * heteroIngest / heteroFinish from returning 401 mid-execution.
  */
-export const signOperationJwt = async (userId: string): Promise<string> => {
+export const signHeteroOperationJWT = async (params: {
+  capabilities: HeteroOperationCapability[];
+  model?: string;
+  operationId: string;
+  providerId?: string;
+  userId: string;
+  workspaceId?: string;
+}): Promise<string> => {
   const { key, kid } = await getSigningKey();
 
-  return new SignJWT({ purpose: 'hetero-operation' })
+  return new SignJWT({
+    capabilities: params.capabilities,
+    ...(params.model ? { model: params.model } : {}),
+    operation_id: params.operationId,
+    ...(params.providerId ? { provider_id: params.providerId } : {}),
+    purpose: HETERO_OPERATION_JWT_PURPOSE,
+    ...(params.workspaceId ? { workspace_id: params.workspaceId } : {}),
+  })
     .setProtectedHeader({ alg: 'RS256', kid })
-    .setSubject(userId)
+    .setIssuer(HETERO_OPERATION_JWT_ISSUER)
+    .setAudience(HETERO_OPERATION_JWT_AUDIENCE)
+    .setSubject(params.userId)
+    .setJti(randomUUID())
     .setIssuedAt()
     .setExpirationTime('4h')
     .sign(key);
+};
+
+/** @deprecated Use the operation-bound signer. */
+export const signOperationJwt = async (userId: string, operationId: string, workspaceId?: string) =>
+  signHeteroOperationJWT({
+    capabilities: ['hetero:ingest', 'hetero:finish', 'hetero:intervention:read'],
+    operationId,
+    userId,
+    workspaceId,
+  });
+
+export const validateHeteroOperationClaims = (
+  payload: Record<string, unknown>,
+): HeteroOperationJwtClaims | null => {
+  const capabilities = payload.capabilities;
+  if (
+    payload.iss !== HETERO_OPERATION_JWT_ISSUER ||
+    payload.aud !== HETERO_OPERATION_JWT_AUDIENCE ||
+    payload.purpose !== HETERO_OPERATION_JWT_PURPOSE ||
+    typeof payload.sub !== 'string' ||
+    typeof payload.operation_id !== 'string' ||
+    typeof payload.jti !== 'string' ||
+    typeof payload.iat !== 'number' ||
+    typeof payload.exp !== 'number' ||
+    !Array.isArray(capabilities) ||
+    !capabilities.every((capability) =>
+      ['model:invoke', 'hetero:ingest', 'hetero:finish', 'hetero:intervention:read'].includes(
+        capability as string,
+      ),
+    ) ||
+    (payload.model !== undefined && typeof payload.model !== 'string') ||
+    (payload.provider_id !== undefined && typeof payload.provider_id !== 'string') ||
+    (payload.workspace_id !== undefined && typeof payload.workspace_id !== 'string')
+  ) {
+    return null;
+  }
+
+  return payload as unknown as HeteroOperationJwtClaims;
+};
+
+export const validateHeteroOperationJWT = async (
+  token: string,
+): Promise<HeteroOperationJwtClaims | null> => {
+  try {
+    const publicKey = await getVerificationKey();
+    const { payload } = await jwtVerify(token, publicKey, {
+      algorithms: ['RS256'],
+      audience: HETERO_OPERATION_JWT_AUDIENCE,
+      issuer: HETERO_OPERATION_JWT_ISSUER,
+    });
+    return validateHeteroOperationClaims(payload);
+  } catch (error) {
+    log('Heterogeneous operation JWT validation failed: %O', error);
+    return null;
+  }
 };
 
 /**
@@ -152,16 +247,17 @@ export const signWorkspaceDeviceToken = async (workspaceId: string): Promise<str
  * Mirrors {@link signOperationJwt} but carries `workspace_id` so the device's
  * gateway callbacks resolve to the workspace principal.
  */
-export const signWorkspaceOperationJwt = async (workspaceId: string): Promise<string> => {
-  const { key, kid } = await getSigningKey();
-
-  return new SignJWT({ purpose: 'hetero-operation', workspace_id: workspaceId })
-    .setProtectedHeader({ alg: 'RS256', kid })
-    .setSubject(workspaceId)
-    .setIssuedAt()
-    .setExpirationTime('4h')
-    .sign(key);
-};
+export const signWorkspaceOperationJwt = async (
+  workspaceId: string,
+  userId: string,
+  operationId: string,
+): Promise<string> =>
+  signHeteroOperationJWT({
+    capabilities: ['hetero:ingest', 'hetero:finish', 'hetero:intervention:read'],
+    operationId,
+    userId,
+    workspaceId,
+  });
 
 /**
  * Validate internal JWT from lambda → async calls

--- a/packages/types/src/serverConfig.ts
+++ b/packages/types/src/serverConfig.ts
@@ -1,6 +1,6 @@
+import type { AiFullModelCard } from 'model-bank';
 import type { PartialDeep } from 'type-fest';
 
-import type { ChatModelCard } from './llm';
 import type {
   GlobalLLMProviderKey,
   UserDefaultAgent,
@@ -80,7 +80,7 @@ export interface ServerModelProviderConfig {
   /**
    * the model lists defined in server
    */
-  serverModelLists?: ChatModelCard[];
+  serverModelLists?: AiFullModelCard[];
 }
 
 export type ServerLanguageModel = Partial<Record<GlobalLLMProviderKey, ServerModelProviderConfig>>;


### PR DESCRIPTION
## Description of Change

**Part 1 of 2 — server layer only.** This PR carries the server half of server-default heterogeneous execution so it can merge, deploy, and be verified before any client enables it. The Desktop + UI half is stacked on top in #18568 and must not merge first.

Nothing user-visible turns on here: no client sends `authMode: 'server'`, and the new direct model endpoints only accept operation-scoped tokens that only the new procedures mint.

### V1 support matrix (intentional scope)

V1 supports exactly two provider-native paths:

- Claude Code → Anthropic runtime
- Codex → OpenAI Responses runtime

Other agent/provider/model combinations are not deferred to best-effort protocol translation: they are omitted from capability discovery and rejected again when an operation begins and when a direct model endpoint is invoked. The capability returns compatible deployment models grouped by agent, and `beginServerDefaultHeterogeneousOperation` requires the caller's `agentType`.

The support-matrix source of truth documents the extension gate: a new pair must first implement lossless continuation-state translation in both directions and pass a two-turn tool-call E2E before it can be advertised.

### Operation principal and token binding

- Bind heterogeneous operation JWTs to issuer, audience, user, durable operation, optional workspace, and explicit capabilities (`hetero:ingest`, `hetero:finish`, `hetero:intervention:read`, `model:invoke`).
- Revalidate operation state, user status, workspace membership, model/provider binding, and model-invocation RBAC on every direct model request.
- Reauthorize `heteroIngest`, `heteroFinish`, and intervention polling against the durable operation principal.
- Require a persisted `agent_operations` row before minting a token or dispatching a hetero run — `CompletionLifecycle.recordStart` now reports whether the row was written, and `execAgent` fails the run instead of continuing tokenless.
- Require deprecated `signOperationJwt` callers to pass the real operation ID, user ID, and workspace scope, so a stale caller fails at compile time rather than minting an unusable token.

### Server-default operations

- `aiAgent.getServerDefaultHeterogeneousCapability` exposes only enabled server models covered by the V1 support matrix.
- `aiAgent.beginServerDefaultHeterogeneousOperation` validates `agentType` plus the exact catalog entry, then initializes that provider runtime *before* writing the operation row or minting the token; an unavailable provider fails with `PRECONDITION_FAILED`.
- `finish` / `cancel` settle the operation idempotently through a CAS on `status = 'running'` (`AgentOperationModel.settleRunning`), rejecting a conflicting terminal result.
- All three require a Desktop OIDC session (a purpose-scoped token is refused).

### Protocol-native direct model endpoints

- `POST /api/v1/anthropic/v1/messages` is bound to Claude Code + Anthropic.
- `POST /api/v1/openai/v1/responses` is bound to Codex + OpenAI Responses.
- Anthropic Messages and OpenAI Responses streams are adapted independently: reasoning, images, tools, parallel calls, incremental arguments, usage, errors, abort signals, and a final protocol event even when the upstream stream closes without a trailing newline.
- No topic/message/agent persistence on these endpoints; operation lifecycle records are preserved.

### Deployment and rollback

- `ENABLE_SERVER_DEFAULT_HETEROGENEOUS_AGENT=0` is the opt-out; without that exact value the endpoints and procedures are enabled.
- Rolling deployment is callback-safe: pre-deploy purpose-only operation tokens continue through the legacy ownership checks until their existing 4-hour expiry. Partially populated strict tokens are rejected rather than downgraded to that path.
- Rollback is clean while this PR is alone on the trunk — no client depends on the new surface yet.

#### Test

- Latest V1 scope change: `bun run check` over its 9 changed files — lint clean and **113 tests passed**.
- Full local type-check is still blocked by duplicate Drizzle ORM type identities in the installed dependency tree (many untouched files); CI type-check remains required before merge.
- Real Claude Code / Codex E2E is exercised from the stacked client PR, not here.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

No matching issue found.
