### PR TITLE
🐛 fix(chat): drop a recorded worktree whose directory no longer exists

### DIFF
--- a/packages/local-file-shell/src/shell/__tests__/runner.test.ts
+++ b/packages/local-file-shell/src/shell/__tests__/runner.test.ts
@@ -105,7 +105,11 @@ describe('runCommand', () => {
       expect(result.stdout).toContain('/tmp');
     });
 
-    it('should report the real spawn error when cwd does not exist', async () => {
+    // The raw spawn failure for a missing cwd is `spawn /bin/sh ENOENT`, which
+    // reads as a broken shell. The injected cwd (agent working directory, or a
+    // recorded worktree that has since been deleted) is the real culprit, so it
+    // has to be named — the agent can rebind, but it cannot fix `/bin/sh`.
+    it('should report the missing directory when cwd does not exist', async () => {
       const missingCwd = path.join(tmpDir, 'missing-worktree');
       const result = await runCommand(
         { command: 'echo unreachable', cwd: missingCwd },
@@ -114,8 +118,7 @@ describe('runCommand', () => {
 
       expect(result.success).toBe(false);
       expect(result.exit_code).toBeUndefined();
-      expect(result.error).toContain(`working directory: ${missingCwd}`);
-      expect(result.error).toContain('ENOENT');
+      expect(result.error).toBe(`Working directory does not exist: ${missingCwd}`);
     });
 
     it('should merge env into child process environment', async () => {

--- a/packages/local-file-shell/src/shell/runner.ts
+++ b/packages/local-file-shell/src/shell/runner.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
 
 import type { SandboxPolicy } from '@lobechat/device-sandbox';
 
@@ -42,6 +43,15 @@ export async function runCommand(
 ): Promise<RunCommandResult> {
   if (!command) {
     return { error: 'command is required', success: false };
+  }
+
+  // A cwd that no longer exists surfaces from `spawn` as `spawn /bin/sh ENOENT`,
+  // which reads as "the shell is missing" and sends the agent hunting for a
+  // broken PATH. The cwd is injected (agent working directory / recorded
+  // worktree), never typed by the model, so the honest report is that the
+  // directory is gone — the caller can then rebind instead of retrying.
+  if (cwd && !existsSync(cwd)) {
+    return { error: `Working directory does not exist: ${cwd}`, success: false };
   }
 
   const logPrefix = `[runCommand: ${description || command.slice(0, 50)}]`;

--- a/src/helpers/workingDirectoryPath.test.ts
+++ b/src/helpers/workingDirectoryPath.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyWorktreeExitToConfig } from './workingDirectoryPath';
+
+describe('applyWorktreeExitToConfig', () => {
+  it('drops the worktree override and the branch context taken inside it', () => {
+    const next = applyWorktreeExitToConfig(
+      {
+        git: {
+          activeWorktree: '/repo-feat',
+          branch: 'feat/x',
+          github: { pullRequestStatus: 'ok' },
+          isWorktree: true,
+          upstream: { branch: 'feat/x', remote: 'origin' },
+        },
+        path: '/repo',
+        repoType: 'github',
+      },
+      '/repo',
+    );
+
+    expect(next).toEqual({ git: { isWorktree: false }, path: '/repo', repoType: 'github' });
+  });
+
+  // Topics recorded before `isWorktree` existed carry only `{ activeWorktree,
+  // branch, … }`. Gating the cleanup on the flag left them labelled with the
+  // abandoned worktree's branch and PR while pointing at the source repo.
+  it('drops the branch context for a pre-flag config that has no isWorktree', () => {
+    const next = applyWorktreeExitToConfig(
+      {
+        git: {
+          activeWorktree: '/tmp/wt-legacy',
+          branch: 'fix/x',
+          github: { pullRequestStatus: 'ok' },
+          upstream: { branch: 'fix/x', remote: 'origin' },
+        },
+        path: '/repo',
+      },
+      '/repo',
+    );
+
+    expect(next).toEqual({ git: { isWorktree: false }, path: '/repo' });
+  });
+
+  // Nothing was overridden, so the recorded branch is the source repo's own.
+  it('keeps the branch when the config was never in a worktree', () => {
+    const next = applyWorktreeExitToConfig({ git: { branch: 'canary' }, path: '/repo' }, '/repo');
+
+    expect(next).toEqual({ git: { branch: 'canary', isWorktree: false }, path: '/repo' });
+  });
+});

--- a/src/helpers/workingDirectoryPath.ts
+++ b/src/helpers/workingDirectoryPath.ts
@@ -54,3 +54,39 @@ export const isWorktreeCheckout = ({
   sourcePath?: string;
 }): boolean =>
   !!git?.isWorktree || (!!sourcePath && !!effectivePath && effectivePath !== sourcePath);
+
+/**
+ * The effective checkout is back to the source repo: drop the worktree
+ * override. `branch`, its `upstream` ref and the linked `github` PR described
+ * the worktree's branch, not the source repo's, so they are dropped rather than
+ * left pointing at a branch the topic is no longer on — the source branch is
+ * unknown until the next `git switch` / `checkout` refreshes it.
+ *
+ * The single funnel for un-setting a worktree, shared by the `ExitWorktree`
+ * recorder (the session walked out of it) and the run-start prune (the
+ * directory was deleted underneath it), so the two cannot drift into recording
+ * different shapes for the same state.
+ */
+export const applyWorktreeExitToConfig = (
+  currentConfig: WorkingDirConfig | undefined,
+  source: string,
+): WorkingDirConfig => {
+  const git: NonNullable<WorkingDirConfig['git']> = {
+    ...currentConfig?.git,
+    isWorktree: false,
+  };
+
+  delete git.activeWorktree;
+  if (currentConfig?.git?.isWorktree) {
+    delete git.branch;
+    delete git.github;
+    delete git.upstream;
+  }
+
+  return {
+    ...currentConfig,
+    git,
+    path: source,
+    ...(currentConfig?.repoType ? { repoType: currentConfig.repoType } : {}),
+  };
+};

--- a/src/helpers/workingDirectoryPath.ts
+++ b/src/helpers/workingDirectoryPath.ts
@@ -71,13 +71,21 @@ export const applyWorktreeExitToConfig = (
   currentConfig: WorkingDirConfig | undefined,
   source: string,
 ): WorkingDirConfig => {
-  const git: NonNullable<WorkingDirConfig['git']> = {
-    ...currentConfig?.git,
-    isWorktree: false,
-  };
+  const currentGit = currentConfig?.git;
+  const git: NonNullable<WorkingDirConfig['git']> = { ...currentGit, isWorktree: false };
+
+  // `isWorktree` is only stamped by the newer snapshot writer, so a topic
+  // recorded before it carries `{ activeWorktree, branch, github }` and nothing
+  // else. Keying the cleanup off that flag alone left those configs pointing at
+  // the source repo while still advertising the abandoned worktree's branch and
+  // PR — the same pre-flag shape `staleSnapshot` already reads by comparing
+  // paths. Leaving the override is what makes it a worktree, flag or not.
+  const wasWorktree =
+    !!currentGit?.isWorktree ||
+    (!!currentGit?.activeWorktree && currentGit.activeWorktree !== source);
 
   delete git.activeWorktree;
-  if (currentConfig?.git?.isWorktree) {
+  if (wasWorktree) {
     delete git.branch;
     delete git.github;
     delete git.upstream;

--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
@@ -8,6 +8,7 @@ import { aiAgentService } from '@/services/aiAgent';
 import { aiChatService } from '@/services/aiChat';
 import { chatService } from '@/services/chat';
 import * as skillPreload from '@/services/chat/mecha/skillPreload';
+import { deviceService } from '@/services/device';
 import { messageService } from '@/services/message';
 import * as agentGroupStore from '@/store/agentGroup';
 import { setPendingTopicRepos } from '@/store/chat/pendingTopicRepos';
@@ -18,6 +19,7 @@ import type {
 } from '@/store/chat/slices/voiceMessage/action';
 import { LOCAL_MESSAGE_SCOPE } from '@/store/chat/utils/localMessages';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
+import { clearWorktreeProbeCache } from '@/store/chat/utils/pruneMissingWorktree';
 import { topicMapKey } from '@/store/chat/utils/topicMapKey';
 import { useDeviceStore } from '@/store/device';
 import { fileChatSelectors, useFileStore } from '@/store/file';
@@ -1822,6 +1824,107 @@ describe('ConversationLifecycle actions', () => {
           expect.objectContaining({ metadata: expectedMetadata }),
         );
         // Rides along to the server, which owns the real topic row.
+        expect(executeGatewayAgentSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            optimisticTopic: expect.objectContaining({ metadata: expectedMetadata }),
+          }),
+        );
+
+        await act(async () => {
+          resolveGateway();
+          await sendPromise;
+        });
+      });
+
+      // A worktree recorded on the agent outlives the directory: `git worktree
+      // remove` (or a cleanup pass) leaves the override behind and every NEW
+      // topic used to inherit that dead path as its cwd — the picker still
+      // reads "lobehub" (it shows the SOURCE repo), while every tool call
+      // spawns in a directory that no longer exists.
+      it('should not bind a new topic to a recorded worktree that no longer exists', async () => {
+        mockConstEnv.isDesktop = true;
+        const deviceId = 'device-1';
+        const sourcePath = '/repo/lobehub';
+        const missingWorktree = '/repo/lobehub-wt-deleted';
+        clearWorktreeProbeCache();
+        vi.spyOn(deviceService, 'statPath').mockImplementation(
+          async (_deviceId: string, path: string) =>
+            ({ exists: path !== missingWorktree, isDirectory: path !== missingWorktree }) as any,
+        );
+        setupMockSelectors({
+          agentConfig: {
+            agencyConfig: {
+              boundDeviceId: deviceId,
+              executionTarget: 'local',
+              workingDirByDevice: {
+                [deviceId]: {
+                  git: { activeWorktree: missingWorktree },
+                  path: sourcePath,
+                  repoType: 'github',
+                },
+              },
+            },
+          },
+        });
+
+        const { result } = renderHook(() => useChatStore());
+        const agentId = TEST_IDS.SESSION_ID;
+        const topicKey = topicMapKey({ agentId });
+        let resolveGateway!: () => void;
+        const gatewayPromise = new Promise<any>((resolve) => {
+          resolveGateway = () =>
+            resolve({
+              assistantMessageId: TEST_IDS.ASSISTANT_MESSAGE_ID,
+              operationId: 'gateway-op-dead-worktree',
+              topicId: TEST_IDS.NEW_TOPIC_ID,
+              userMessageId: TEST_IDS.USER_MESSAGE_ID,
+            });
+        });
+        const executeGatewayAgentSpy = vi.fn().mockReturnValue(gatewayPromise);
+
+        act(() => {
+          useChatStore.setState({
+            activeAgentId: agentId,
+            activeTopicId: undefined,
+            executeGatewayAgent: executeGatewayAgentSpy,
+            isGatewayModeEnabled: () => true,
+            topicDataMap: {
+              [topicKey]: {
+                currentPage: 0,
+                hasMore: false,
+                isExpandingPageSize: false,
+                isLoadingMore: false,
+                items: [],
+                pageSize: 20,
+                total: 0,
+              },
+            },
+          });
+        });
+
+        let sendPromise!: ReturnType<typeof result.current.sendMessage>;
+        act(() => {
+          sendPromise = result.current.sendMessage({
+            context: { agentId, threadId: null, topicId: null },
+            message: 'Where do I run?',
+          });
+        });
+
+        await waitFor(() => expect(executeGatewayAgentSpy).toHaveBeenCalled());
+
+        // The run falls back to the source repo — the same directory the
+        // ControlBar has been displaying all along.
+        const expectedMetadata = {
+          workingDirectory: sourcePath,
+          workingDirectoryConfig: {
+            git: { isWorktree: false },
+            path: sourcePath,
+            repoType: 'github',
+          },
+        };
+        expect(useChatStore.getState().topicDataMap[topicKey]?.items[0]).toEqual(
+          expect.objectContaining({ metadata: expectedMetadata }),
+        );
         expect(executeGatewayAgentSpy).toHaveBeenCalledWith(
           expect.objectContaining({
             optimisticTopic: expect.objectContaining({ metadata: expectedMetadata }),

--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
@@ -10,6 +10,7 @@ import { chatService } from '@/services/chat';
 import * as skillPreload from '@/services/chat/mecha/skillPreload';
 import { deviceService } from '@/services/device';
 import { messageService } from '@/services/message';
+import { topicService } from '@/services/topic';
 import * as agentGroupStore from '@/store/agentGroup';
 import { setPendingTopicRepos } from '@/store/chat/pendingTopicRepos';
 import { operationSelectors } from '@/store/chat/slices/operation/selectors';
@@ -1934,6 +1935,174 @@ describe('ConversationLifecycle actions', () => {
         await act(async () => {
           resolveGateway();
           await sendPromise;
+        });
+      });
+
+      // The corrected config does NOT ride along with an existing topic's request
+      // — only a NEW topic's metadata does — so the server re-resolves the cwd
+      // from the topic row. Dispatching before the repair lands lets this very
+      // turn resolve the dead path again.
+      it('should persist the repaired topic cwd before dispatching the run', async () => {
+        mockConstEnv.isDesktop = true;
+        const deviceId = 'device-1';
+        const sourcePath = '/repo/lobehub';
+        const missingWorktree = '/repo/lobehub-wt-deleted';
+        clearWorktreeProbeCache();
+        vi.spyOn(deviceService, 'statPath').mockImplementation(
+          async (_deviceId: string, path: string) =>
+            ({ exists: path !== missingWorktree, isDirectory: path !== missingWorktree }) as any,
+        );
+        // The write is gated so the assertion is about COMPLETION, not call
+        // order: a fire-and-forget repair also "calls" the service first, and
+        // then dispatches while it is still in flight.
+        let commitRepair!: () => void;
+        const repairWrite = new Promise<void>((resolve) => {
+          commitRepair = () => resolve();
+        });
+        const updateTopicMetadataSpy = vi
+          .spyOn(topicService, 'updateTopicMetadata')
+          .mockReturnValue(repairWrite as any);
+        setupMockSelectors({
+          agentConfig: {
+            agencyConfig: { boundDeviceId: deviceId, executionTarget: 'local' },
+          },
+        });
+
+        const { result } = renderHook(() => useChatStore());
+        const agentId = TEST_IDS.SESSION_ID;
+        const topicKey = topicMapKey({ agentId });
+        const executeGatewayAgentSpy = vi.fn().mockResolvedValue({
+          assistantMessageId: TEST_IDS.ASSISTANT_MESSAGE_ID,
+          operationId: 'gateway-op-repair',
+          topicId: TEST_IDS.TOPIC_ID,
+          userMessageId: TEST_IDS.USER_MESSAGE_ID,
+        });
+
+        act(() => {
+          useChatStore.setState({
+            activeAgentId: agentId,
+            activeTopicId: TEST_IDS.TOPIC_ID,
+            executeGatewayAgent: executeGatewayAgentSpy,
+            isGatewayModeEnabled: () => true,
+            topicDataMap: {
+              [topicKey]: {
+                currentPage: 0,
+                hasMore: false,
+                isExpandingPageSize: false,
+                isLoadingMore: false,
+                items: [
+                  {
+                    id: TEST_IDS.TOPIC_ID,
+                    metadata: {
+                      workingDirectory: missingWorktree,
+                      workingDirectoryConfig: {
+                        git: { activeWorktree: missingWorktree },
+                        path: sourcePath,
+                        repoType: 'github',
+                      },
+                    },
+                    title: 'existing',
+                  },
+                ] as any,
+                pageSize: 20,
+                total: 1,
+              },
+            },
+          });
+        });
+
+        let sendPromise!: ReturnType<typeof result.current.sendMessage>;
+        act(() => {
+          sendPromise = result.current.sendMessage({
+            context: { agentId, threadId: null, topicId: TEST_IDS.TOPIC_ID },
+            message: 'Where do I run?',
+          });
+        });
+
+        await waitFor(() => expect(updateTopicMetadataSpy).toHaveBeenCalled());
+        expect(updateTopicMetadataSpy).toHaveBeenCalledWith(TEST_IDS.TOPIC_ID, {
+          workingDirectory: sourcePath,
+          workingDirectoryConfig: {
+            git: { isWorktree: false },
+            path: sourcePath,
+            repoType: 'github',
+          },
+        });
+        // Still in flight — the run must not have been dispatched yet.
+        expect(executeGatewayAgentSpy).not.toHaveBeenCalled();
+
+        await act(async () => {
+          commitRepair();
+          await sendPromise;
+        });
+
+        expect(executeGatewayAgentSpy).toHaveBeenCalled();
+      });
+
+      // The topic list store is paginated, so a deep-linked older topic is
+      // resolved from the server and never enters it — and `updateTopicMetadata`
+      // returns early for a topic it doesn't hold, writing nothing at all.
+      it('should persist the repair for a topic the paginated store never loaded', async () => {
+        mockConstEnv.isDesktop = true;
+        const deviceId = 'device-1';
+        const sourcePath = '/repo/lobehub';
+        const missingWorktree = '/repo/lobehub-wt-deleted';
+        clearWorktreeProbeCache();
+        vi.spyOn(deviceService, 'statPath').mockImplementation(
+          async (_deviceId: string, path: string) =>
+            ({ exists: path !== missingWorktree, isDirectory: path !== missingWorktree }) as any,
+        );
+        const updateTopicMetadataSpy = vi
+          .spyOn(topicService, 'updateTopicMetadata')
+          .mockResolvedValue(undefined as any);
+        vi.spyOn(topicService, 'getTopicDetail').mockResolvedValue({
+          id: TEST_IDS.TOPIC_ID,
+          metadata: {
+            workingDirectory: missingWorktree,
+            workingDirectoryConfig: {
+              git: { activeWorktree: missingWorktree },
+              path: sourcePath,
+              repoType: 'github',
+            },
+          },
+        } as any);
+        setupMockSelectors({
+          agentConfig: {
+            agencyConfig: {
+              boundDeviceId: deviceId,
+              executionTarget: 'local',
+              heterogeneousProvider: { command: 'codex', type: 'codex' },
+            },
+          },
+        });
+        executeHeterogeneousAgentMock.mockResolvedValue(undefined);
+        vi.spyOn(aiChatService, 'sendMessageInServer').mockResolvedValue({
+          assistantMessageId: TEST_IDS.ASSISTANT_MESSAGE_ID,
+          messages: [
+            createMockMessage({ id: TEST_IDS.USER_MESSAGE_ID, role: 'user' }),
+            createMockMessage({ id: TEST_IDS.ASSISTANT_MESSAGE_ID, role: 'assistant' }),
+          ],
+          topicId: TEST_IDS.TOPIC_ID,
+          topics: [],
+          userMessageId: TEST_IDS.USER_MESSAGE_ID,
+        } as any);
+
+        const { result } = renderHook(() => useChatStore());
+
+        await act(async () => {
+          await result.current.sendMessage({
+            context: { agentId: TEST_IDS.SESSION_ID, threadId: null, topicId: TEST_IDS.TOPIC_ID },
+            message: 'Where do I run?',
+          });
+        });
+
+        expect(updateTopicMetadataSpy).toHaveBeenCalledWith(TEST_IDS.TOPIC_ID, {
+          workingDirectory: sourcePath,
+          workingDirectoryConfig: {
+            git: { isWorktree: false },
+            path: sourcePath,
+            repoType: 'github',
+          },
         });
       });
 

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -29,7 +29,6 @@ import { t } from 'i18next';
 
 import { type ChatInputEditor } from '@/features/ChatInput';
 import {
-  resolveAgentWorkingDirectory,
   resolveAgentWorkingDirectoryConfig,
   resolveTargetDeviceId,
 } from '@/helpers/agentWorkingDirectory';
@@ -88,6 +87,7 @@ import {
 } from '@/store/chat/utils/compression';
 import { isLocalOnlyMessage } from '@/store/chat/utils/localMessages';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
+import { pruneMissingWorktree } from '@/store/chat/utils/pruneMissingWorktree';
 import { snapshotAgentModel } from '@/store/chat/utils/snapshotAgentModel';
 import { topicMapKey } from '@/store/chat/utils/topicMapKey';
 import { deviceSelectors, getDeviceStoreState } from '@/store/device';
@@ -1072,12 +1072,39 @@ export class ConversationLifecycleActionImpl {
           workspaceScoped,
         }
       : undefined;
-    const agentWorkingDirectory = runCwdParams
-      ? resolveAgentWorkingDirectory(runCwdParams)
-      : undefined;
-    const agentWorkingDirectoryConfig = runCwdParams
-      ? resolveAgentWorkingDirectoryConfig(runCwdParams)
-      : undefined;
+    // A recorded worktree can be deleted out from under both levels of config
+    // (`git worktree remove`, a cleanup pass, a wiped branch folder). Nothing
+    // else notices: the picker shows the SOURCE repo either way, so the bar
+    // reads healthy while every tool call spawns in a directory that is gone —
+    // and an agent-level override hands that dead path to every NEW topic. Drop
+    // it here, at the moment of use, so the run falls back to the source repo.
+    // Costs nothing when no worktree is recorded (no probe, no round-trip).
+    const agentWorkingDirectoryConfig = await pruneMissingWorktree({
+      config: runCwdParams ? resolveAgentWorkingDirectoryConfig(runCwdParams) : undefined,
+      deviceId: runCwdDeviceId,
+    });
+    const agentWorkingDirectory = getWorkingDirEffectivePath(agentWorkingDirectoryConfig);
+    const topicWorkingDirectoryConfig = await pruneMissingWorktree({
+      config: existingTopic?.metadata?.workingDirectoryConfig,
+      deviceId: runCwdDeviceId,
+    });
+    // The topic keeps the dead worktree on its row until something rewrites it,
+    // and the SERVER re-resolves from that row on every later turn (task
+    // callbacks, cron runs, a resumed operation) — so the correction has to be
+    // persisted, not just applied to this run.
+    if (
+      existingTopic &&
+      topicWorkingDirectoryConfig !== existingTopic.metadata?.workingDirectoryConfig
+    ) {
+      void this.#get()
+        .updateTopicMetadata(existingTopic.id, {
+          workingDirectory: getWorkingDirEffectivePath(topicWorkingDirectoryConfig),
+          workingDirectoryConfig: topicWorkingDirectoryConfig,
+        })
+        .catch(() => {
+          // Metadata bookkeeping must never fail a run that is otherwise fine.
+        });
+    }
     // Heterogeneous CLI agents (Claude Code, Codex, …) store sessions per-cwd
     // (`~/.claude/projects/<encoded-cwd>/`). Anchor their session cwd to the
     // SOURCE repo, NOT the selected worktree, so switching worktree keeps cwd +
@@ -1093,11 +1120,11 @@ export class ConversationLifecycleActionImpl {
       ? getWorkingDirSourcePath
       : getWorkingDirEffectivePath;
     const workingDirectory =
-      resolveWorkingDirPath(existingTopic?.metadata?.workingDirectoryConfig) ??
+      resolveWorkingDirPath(topicWorkingDirectoryConfig) ??
       existingTopic?.metadata?.workingDirectory ??
       agentWorkingDirectory;
     const workingDirectoryConfig =
-      existingTopic?.metadata?.workingDirectoryConfig ??
+      topicWorkingDirectoryConfig ??
       (existingTopic?.metadata?.workingDirectory
         ? { path: existingTopic.metadata.workingDirectory }
         : agentWorkingDirectoryConfig);

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -1089,21 +1089,31 @@ export class ConversationLifecycleActionImpl {
       deviceId: runCwdDeviceId,
     });
     // The topic keeps the dead worktree on its row until something rewrites it,
-    // and the SERVER re-resolves from that row on every later turn (task
-    // callbacks, cron runs, a resumed operation) — so the correction has to be
-    // persisted, not just applied to this run.
+    // and the SERVER re-resolves the cwd from that row — for an existing topic
+    // the corrected config does NOT ride along with the request (only a NEW
+    // topic's metadata does), so the row is the only channel this run has.
+    // Hence AWAIT, not fire-and-forget: dispatching first would race the write
+    // and let this very turn resolve the dead path again.
     if (
       existingTopic &&
       topicWorkingDirectoryConfig !== existingTopic.metadata?.workingDirectoryConfig
     ) {
-      void this.#get()
-        .updateTopicMetadata(existingTopic.id, {
-          workingDirectory: getWorkingDirEffectivePath(topicWorkingDirectoryConfig),
-          workingDirectoryConfig: topicWorkingDirectoryConfig,
-        })
-        .catch(() => {
-          // Metadata bookkeeping must never fail a run that is otherwise fine.
-        });
+      const repairedMetadata = {
+        workingDirectory: getWorkingDirEffectivePath(topicWorkingDirectoryConfig),
+        workingDirectoryConfig: topicWorkingDirectoryConfig,
+      };
+      try {
+        // `updateTopicMetadata` returns early for a topic the paginated store
+        // doesn't hold — exactly the deep-linked case `resolveExistingTopicForRun`
+        // fetched from the server — so persist directly for those instead of
+        // silently writing nothing.
+        await (topicSelectors.getTopicById(existingTopic.id)(this.#get())
+          ? this.#get().updateTopicMetadata(existingTopic.id, repairedMetadata)
+          : topicService.updateTopicMetadata(existingTopic.id, repairedMetadata));
+      } catch {
+        // Metadata bookkeeping must never fail a run that is otherwise fine —
+        // the shell still reports the missing directory by name.
+      }
     }
     // Heterogeneous CLI agents (Claude Code, Codex, …) store sessions per-cwd
     // (`~/.claude/projects/<encoded-cwd>/`). Anchor their session cwd to the

--- a/src/store/chat/utils/pruneMissingWorktree.test.ts
+++ b/src/store/chat/utils/pruneMissingWorktree.test.ts
@@ -1,0 +1,125 @@
+import type { WorkingDirConfig } from '@lobechat/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { deviceService } from '@/services/device';
+
+import { clearWorktreeProbeCache, pruneMissingWorktree } from './pruneMissingWorktree';
+
+vi.mock('@/services/device', () => ({
+  deviceService: { statPath: vi.fn() },
+}));
+
+const statPath = vi.mocked(deviceService.statPath);
+
+const DEVICE_ID = 'device-1';
+const SOURCE = '/repo/lobehub';
+const WORKTREE = '/repo/lobehub-wt-project';
+
+const config: WorkingDirConfig = {
+  git: { activeWorktree: WORKTREE },
+  path: SOURCE,
+  repoType: 'github',
+};
+
+const stat = (exists: boolean) => ({ exists, isDirectory: exists });
+
+describe('pruneMissingWorktree', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearWorktreeProbeCache();
+  });
+
+  it('should drop a worktree override whose directory is gone', async () => {
+    statPath.mockImplementation(async (_deviceId, path) => stat(path !== WORKTREE) as any);
+
+    const result = await pruneMissingWorktree({ config, deviceId: DEVICE_ID });
+
+    expect(result).toEqual({ git: { isWorktree: false }, path: SOURCE, repoType: 'github' });
+  });
+
+  it('should drop the branch snapshot taken inside the deleted worktree', async () => {
+    statPath.mockImplementation(async (_deviceId, path) => stat(path !== WORKTREE) as any);
+
+    const result = await pruneMissingWorktree({
+      config: {
+        git: {
+          activeWorktree: WORKTREE,
+          branch: 'feat/x',
+          github: { pullRequestStatus: 'ok' },
+          isWorktree: true,
+          upstream: { branch: 'feat/x', remote: 'origin' },
+        },
+        path: SOURCE,
+      },
+      deviceId: DEVICE_ID,
+    });
+
+    expect(result).toEqual({ git: { isWorktree: false }, path: SOURCE });
+  });
+
+  it('should keep a worktree that still exists', async () => {
+    statPath.mockResolvedValue(stat(true) as any);
+
+    const result = await pruneMissingWorktree({ config, deviceId: DEVICE_ID });
+
+    expect(result).toBe(config);
+  });
+
+  // An offline device answers `null` for every path — indistinguishable from a
+  // deleted directory if we treated it as evidence, which would strip a live
+  // worktree off the topic the moment the laptop sleeps.
+  it('should keep the override when the device cannot be reached', async () => {
+    statPath.mockResolvedValue(null);
+
+    const result = await pruneMissingWorktree({ config, deviceId: DEVICE_ID });
+
+    expect(result).toBe(config);
+  });
+
+  it('should keep the override when the source repo is gone too', async () => {
+    statPath.mockResolvedValue(stat(false) as any);
+
+    const result = await pruneMissingWorktree({ config, deviceId: DEVICE_ID });
+
+    expect(result).toBe(config);
+  });
+
+  it('should not probe when no worktree is recorded', async () => {
+    const plain: WorkingDirConfig = { path: SOURCE };
+
+    const result = await pruneMissingWorktree({ config: plain, deviceId: DEVICE_ID });
+
+    expect(result).toBe(plain);
+    expect(statPath).not.toHaveBeenCalled();
+  });
+
+  // The probe runs on the send path; a client whose device RPC is unavailable
+  // (throwing, not answering `null`) must not take the message down with it.
+  it('should keep the override when the probe throws', async () => {
+    statPath.mockImplementation(() => {
+      throw new TypeError('device client unavailable');
+    });
+
+    const result = await pruneMissingWorktree({ config, deviceId: DEVICE_ID });
+
+    expect(result).toBe(config);
+  });
+
+  it('should not probe without a device to ask', async () => {
+    const result = await pruneMissingWorktree({ config });
+
+    expect(result).toBe(config);
+    expect(statPath).not.toHaveBeenCalled();
+  });
+
+  // The probe rides on the send path, so a worktree-bound conversation must not
+  // pay a gateway round-trip per message.
+  it('should reuse a cached probe result across calls', async () => {
+    statPath.mockResolvedValue(stat(true) as any);
+
+    await pruneMissingWorktree({ config, deviceId: DEVICE_ID });
+    await pruneMissingWorktree({ config, deviceId: DEVICE_ID });
+
+    expect(statPath).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/store/chat/utils/pruneMissingWorktree.ts
+++ b/src/store/chat/utils/pruneMissingWorktree.ts
@@ -1,0 +1,83 @@
+import type { WorkingDirConfig } from '@lobechat/types';
+
+import { applyWorktreeExitToConfig } from '@/helpers/workingDirectoryPath';
+import { deviceService } from '@/services/device';
+
+/**
+ * Probe results, keyed by `deviceId::path`.
+ *
+ * A worktree that exists is re-probed rarely (the answer only changes when the
+ * user deletes it, and the next run picks that up after the TTL); a worktree
+ * that is gone is re-probed on the same cadence so recreating it recovers on
+ * its own. Both directions are cached because the probe is a gateway
+ * round-trip on the SEND path — paying it once per run would be a visible
+ * latency tax on every message of a worktree-bound conversation.
+ */
+const CACHE_TTL = 60_000;
+
+const probeCache = new Map<string, { at: number; exists: boolean }>();
+
+/** Exposed for tests — module state would otherwise leak between cases. */
+export const clearWorktreeProbeCache = () => probeCache.clear();
+
+const directoryExists = async (deviceId: string, path: string): Promise<boolean | undefined> => {
+  const key = `${deviceId}::${path}`;
+  const cached = probeCache.get(key);
+  if (cached && Date.now() - cached.at < CACHE_TTL) return cached.exists;
+
+  // `null` = the device could not be reached, which is NOT evidence that the
+  // directory is gone — an offline laptop would otherwise have every worktree
+  // override stripped off its topics. Leave it unverified and unchanged. The
+  // try/catch covers a THROWN probe as the same "unverified": this sits on the
+  // send path, where a failed lookup must never take the message down with it.
+  let result: Awaited<ReturnType<typeof deviceService.statPath>>;
+  try {
+    result = await deviceService.statPath(deviceId, path);
+  } catch {
+    return undefined;
+  }
+  if (!result) return undefined;
+
+  const exists = result.exists && result.isDirectory;
+  probeCache.set(key, { at: Date.now(), exists });
+  return exists;
+};
+
+/**
+ * Drop a `git.activeWorktree` override whose directory no longer exists.
+ *
+ * A worktree recorded on a topic (or on the agent's per-device pick) outlives
+ * the directory itself: `git worktree remove`, a cleanup script, or a deleted
+ * branch folder leaves the override behind, and every later run still resolves
+ * its cwd to that dead path. Tools then fail with a spawn error for a directory
+ * the user cannot see anywhere in the UI — the picker deliberately shows the
+ * SOURCE repo, so the bar reads "lobehub" while the run executes nowhere. Worse,
+ * an agent-level override is inherited by every NEW topic, so each fresh
+ * conversation is born broken.
+ *
+ * Falling back to the source repo is exactly what the stale-snapshot menu's
+ * "back to source" action does; the difference is that this runs at the moment
+ * of use, where the alternative is a run that cannot execute at all.
+ *
+ * No probe happens on the common path: a config without a worktree override —
+ * or one whose override IS the source path — returns untouched and synchronously.
+ */
+export const pruneMissingWorktree = async (params: {
+  config?: WorkingDirConfig;
+  deviceId?: string;
+}): Promise<WorkingDirConfig | undefined> => {
+  const { config, deviceId } = params;
+  const worktree = config?.git?.activeWorktree;
+  if (!config || !worktree || !deviceId || worktree === config.path) return config;
+
+  const exists = await directoryExists(deviceId, worktree);
+  if (exists !== false) return config;
+
+  // The source repo has to be there to fall back to. When it is gone too the
+  // whole binding is dead and there is nothing better to offer than the
+  // recorded state — the shell reports the missing directory by name.
+  const sourceExists = await directoryExists(deviceId, config.path);
+  if (sourceExists === false) return config;
+
+  return applyWorktreeExitToConfig(config, config.path);
+};

--- a/src/store/tool/slices/builtin/executors/worktreeDetection.ts
+++ b/src/store/tool/slices/builtin/executors/worktreeDetection.ts
@@ -7,6 +7,7 @@ import type {
 import { getWorkingDirSourcePath } from '@lobechat/types';
 import isEqual from 'fast-deep-equal';
 
+import { applyWorktreeExitToConfig } from '@/helpers/workingDirectoryPath';
 import { mutate } from '@/libs/swr';
 import { deviceKeys } from '@/libs/swr/keys';
 import { gitService } from '@/services/git';
@@ -653,37 +654,6 @@ const applyWorktreeAddToConfig = (
 
   if (info.branch) delete git.detached;
   if (branchChanged) {
-    delete git.github;
-    delete git.upstream;
-  }
-
-  return {
-    ...currentConfig,
-    git,
-    path: source,
-    ...(currentConfig?.repoType ? { repoType: currentConfig.repoType } : {}),
-  };
-};
-
-/**
- * The session left the worktree and is back in the source repo. `branch`, its
- * `upstream` ref and the linked `github` PR described the worktree's branch, not the
- * source repo's, so they are dropped rather than left pointing at a branch the topic
- * is no longer on — the source branch is unknown until the next `git switch` /
- * `checkout` refreshes it.
- */
-const applyWorktreeExitToConfig = (
-  currentConfig: WorkingDirConfig | undefined,
-  source: string,
-): WorkingDirConfig => {
-  const git: NonNullable<WorkingDirConfig['git']> = {
-    ...currentConfig?.git,
-    isWorktree: false,
-  };
-
-  delete git.activeWorktree;
-  if (currentConfig?.git?.isWorktree) {
-    delete git.branch;
     delete git.github;
     delete git.upstream;
   }


### PR DESCRIPTION
A worktree recorded on a topic (or on the agent's per-device pick) outlives the directory itself: `git worktree remove` or a cleanup pass leaves `git.activeWorktree` behind, and every later run still resolves its cwd to that dead path.

Nothing surfaced it. The directory picker deliberately shows the SOURCE repo, so the control bar reads "lobehub" while every tool call spawns in a directory that is gone — and the stale-snapshot recovery menu only renders when the recorded git state carries a `branch`, which a bare `{ activeWorktree }` does not. Worse, an agent-level override is inherited by every NEW topic, so each fresh conversation is born broken with `spawn /bin/sh ENOENT` on the first command.

#### What changed

- `pruneMissingWorktree` drops the override at run start (agent-level and topic-level alike) when the target device reports the directory missing, falling back to the source repo. No probe and no round-trip when no worktree is recorded; the probe result is cached for 60s because it sits on the send path.
- An unreachable device (or a throwing probe) counts as "unverified", never as "deleted" — an offline laptop must not have live worktrees stripped off its topics.
- The corrected topic config is persisted, because the server re-resolves the cwd from that row on every later turn (task callbacks, cron runs, resumed operations).
- The shell runner now names the missing directory (`Working directory does not exist: <path>`) instead of surfacing `spawn /bin/sh ENOENT`, which reads as a broken shell and sends the agent hunting for a broken PATH.

Reuses the existing `applyWorktreeExitToConfig` funnel (moved to `@/helpers/workingDirectoryPath`) so the run-start prune and the `ExitWorktree` recorder cannot drift into recording different shapes for the same state.

#### Not covered

The server resolves the same configs independently (`execAgent`, hetero dispatch). A conversation opened in any client heals its topic row, so only a purely server-triggered run on a never-opened topic can still hit the dead path — where the runner's error now says so by name. Adding the same prune behind `resolveDeviceWorkingDirectoryConfig`'s three call sites is a separate PR.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`pruneMissingWorktree` unit tests (kept / dropped / unreachable device / throwing probe / source also gone / no-probe fast paths / probe caching) plus an end-to-end regression in `conversationLifecycle`: a new topic on an agent whose recorded worktree is gone must be born bound to the source repo. The regression fails without the prune.