### PR TITLE
💄 style(todo): keep one todo per row in the progress lists

### DIFF
--- a/src/features/Conversation/TodoProgress/index.tsx
+++ b/src/features/Conversation/TodoProgress/index.tsx
@@ -77,6 +77,13 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   listContainer: css`
     overflow: hidden;
 
+    /* The rows are Base UI Checkbox labels, which are inline-flex. In a plain
+       block container they lay out as INLINE boxes — two or three short todos
+       share a line and the list wraps like prose. A column flex container
+       blockifies them, so one todo is one row again. */
+    display: flex;
+    flex-direction: column;
+
     margin-block-start: 8px;
     padding-block: 4px;
     border-block-start: 1px solid ${cssVar.colorBorderSecondary};

--- a/src/features/Conversation/WorkingSidebar/ProgressSection/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/ProgressSection/index.tsx
@@ -87,7 +87,11 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
       padding 0.2s ${cssVar.motionEaseInOut};
   `,
   listInner: css`
+    /* Blockify the inline-flex Base UI Checkbox labels — without this the todo
+       rows flow inline and wrap several per line. */
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
     min-height: 0;
   `,
   processingRow: css`

--- a/src/features/Portal/Document/TodoList.tsx
+++ b/src/features/Portal/Document/TodoList.tsx
@@ -79,6 +79,11 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   listContainer: css`
     overflow-x: hidden;
 
+    /* Blockify the inline-flex Base UI Checkbox labels — without this the todo
+       rows flow inline and wrap several per line. */
+    display: flex;
+    flex-direction: column;
+
     margin-block-start: 8px;
     padding-block: 4px;
     border-block-start: 1px solid ${cssVar.colorBorderSecondary};


### PR DESCRIPTION
The todo lists stopped stacking: two or three short todos share a line and the list wraps like prose, each row keeping its own dashed underline (so the last line's underline stops mid-panel).

#### Root cause

The Base UI migration (#18296) swapped the Checkbox wrapper from a block-level flex row (`FlexBasic`) to a `<label>` that is `display: inline-flex`. The three todo lists whose row container is a plain block `div` therefore turned their rows into INLINE boxes, which flow and wrap like text.

The tool-render todo panels (`claude-code/TodoWrite`, `lobe-agent/TodoList`) are unaffected: their parent is a `Block`, i.e. a column flex container, which blockifies the labels.

#### What changed

Made the three affected row containers column flex, which blockifies the labels the same way `Block` does:

- `Conversation/TodoProgress` — the collapsible panel above the composer (the one in the report)
- `Portal/Document/TodoList`
- `Conversation/WorkingSidebar/ProgressSection` — on `listInner`, leaving the outer grid expand animation untouched

| Before | After |
| ------ | ----- |
| 8 todos wrapped across 4 lines | one todo per row |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Pure CSS fix — per AGENTS.md the regression-test requirement is waived when the only practical assertion would be source-string matching on the stylesheet. Verified the DOM/CSS shape by rendering the component and reading back the merged class (`display: inline-flex` on the label) before and after.