### PR TITLE
🐛 fix(chat): scope pending composer uploads to their own conversation

### DIFF
--- a/src/components/DragUploadZone/useUploadFiles.ts
+++ b/src/components/DragUploadZone/useUploadFiles.ts
@@ -7,6 +7,12 @@ import { useFileStore } from '@/store/file';
 interface UseUploadFilesOptions {
   /** The conversation's agent id. Decides whether the chat-only file-type whitelist applies. */
   agentId: string;
+  /**
+   * Composer the dropped files belong to. Must be the key that composer READS
+   * (`useConversationContextKey()` inside a conversation), otherwise the drop
+   * lands in a bucket its file list never renders.
+   */
+  contextKey?: string;
   model?: string;
   provider?: string;
 }
@@ -19,7 +25,7 @@ interface UseUploadFilesOptions {
  * @returns handleUploadFiles - Callback to handle file uploads
  */
 export const useUploadFiles = (options: UseUploadFilesOptions) => {
-  const { agentId, model = '', provider = '' } = options;
+  const { agentId, contextKey, model = '', provider = '' } = options;
 
   const { canUploadImage, canUploadVideo, canUploadAudio } = useMediaUploadAbility(
     model,
@@ -42,10 +48,10 @@ export const useUploadFiles = (options: UseUploadFilesOptions) => {
       });
 
       if (filteredFiles.length > 0) {
-        uploadFiles(filteredFiles, agentId);
+        uploadFiles({ agentId, contextKey, files: filteredFiles });
       }
     },
-    [agentId, canUpload, canUploadImage, canUploadVideo, canUploadAudio, uploadFiles],
+    [agentId, contextKey, canUpload, canUploadImage, canUploadVideo, canUploadAudio, uploadFiles],
   );
 
   return { canUploadImage, canUploadVideo, canUploadAudio, handleUploadFiles };

--- a/src/features/AgentBuilder/AgentBuilderConversation.tsx
+++ b/src/features/AgentBuilder/AgentBuilderConversation.tsx
@@ -3,7 +3,7 @@ import { memo } from 'react';
 
 import DragUploadZone, { useUploadFiles } from '@/components/DragUploadZone';
 import { type ActionKeys } from '@/features/ChatInput';
-import { ChatInput, ChatList } from '@/features/Conversation';
+import { ChatInput, ChatList, useConversationContextKey } from '@/features/Conversation';
 import { usePermission } from '@/hooks/usePermission';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
@@ -26,7 +26,8 @@ const AgentBuilderConversation = memo<AgentBuilderConversationProps>(({ agentId 
   // Get agent's model info for vision support check
   const model = useAgentStore((s) => agentByIdSelectors.getAgentModelById(agentId)(s));
   const provider = useAgentStore((s) => agentByIdSelectors.getAgentModelProviderById(agentId)(s));
-  const { handleUploadFiles } = useUploadFiles({ agentId, model, provider });
+  const contextKey = useConversationContextKey();
+  const { handleUploadFiles } = useUploadFiles({ agentId, contextKey, model, provider });
   const { allowed: canCreate } = usePermission('create_content');
 
   // Resolve usage_in_followup / manual_edit feedback when a suggestion-seeded

--- a/src/features/AgentTaskManager/Conversation.tsx
+++ b/src/features/AgentTaskManager/Conversation.tsx
@@ -17,6 +17,7 @@ import {
   ChatInput,
   ChatList,
   conversationSelectors,
+  useConversationContextKey,
   useConversationStore,
 } from '@/features/Conversation';
 import CopilotModelSelect from '@/features/PageEditor/Copilot/CopilotModelSelect';
@@ -55,7 +56,13 @@ const Conversation = memo(() => {
   const provider = useAgentStore((s) =>
     agentByIdSelectors.getAgentModelProviderById(currentAgentId)(s),
   );
-  const { handleUploadFiles } = useUploadFiles({ agentId: currentAgentId, model, provider });
+  const contextKey = useConversationContextKey();
+  const { handleUploadFiles } = useUploadFiles({
+    agentId: currentAgentId,
+    contextKey,
+    model,
+    provider,
+  });
 
   const handleAgentChange = useCallback(
     (id: string) => {

--- a/src/features/ChatInput/ActionBar/Clear/index.tsx
+++ b/src/features/ChatInput/ActionBar/Clear/index.tsx
@@ -9,16 +9,18 @@ import { useChatStore } from '@/store/chat';
 import { useFileStore } from '@/store/file';
 
 import { useChatInputResourceAccess } from '../../hooks/useChatInputResourceAccess';
+import { useChatInputStore } from '../../store';
 import { ChatInputAction } from '../components/ChatInputAction';
 
 export const useClearCurrentMessages = () => {
   const clearMessage = useChatStore((s) => s.clearMessage);
   const clearImageList = useFileStore((s) => s.clearChatUploadFileList);
+  const contextKey = useChatInputStore((s) => s.contextSelectionKey);
 
   return useCallback(async () => {
     await clearMessage();
-    clearImageList();
-  }, [clearImageList, clearMessage]);
+    clearImageList(contextKey);
+  }, [clearImageList, clearMessage, contextKey]);
 };
 
 const Clear = memo(() => {

--- a/src/features/ChatInput/ActionBar/Plus/index.tsx
+++ b/src/features/ChatInput/ActionBar/Plus/index.tsx
@@ -302,6 +302,7 @@ const usePlusMenuItems = ({ close }: { close: () => void }): ActionDropdownMenuI
   const enableTopicAcceptance = useUserStore(labPreferSelectors.enableTopicAcceptance);
 
   const upload = useFileStore((s) => s.uploadChatFiles);
+  const contextKey = useChatInputStore((s) => s.contextSelectionKey);
   const { enableKnowledgeBase } = useServerConfigStore(featureFlagsSelectors);
   const enableGatewayMode = useServerConfigStore(serverConfigSelectors.enableGatewayMode);
   const defaultDisableGatewayMode = useUserStore(
@@ -508,7 +509,7 @@ const usePlusMenuItems = ({ close }: { close: () => void }): ActionDropdownMenuI
               }
               close();
               editor?.focus();
-              await upload([file], agentId);
+              await upload({ agentId, contextKey, files: [file] });
               return false;
             }}
           >
@@ -746,6 +747,7 @@ const usePlusMenuItems = ({ close }: { close: () => void }): ActionDropdownMenuI
     agentId,
     activeSearchOption,
     canConfigureResource,
+    contextKey,
     effortItem,
     enableTopicAcceptance,
     canUploadImage,

--- a/src/features/ChatInput/ActionBar/Upload/index.tsx
+++ b/src/features/ChatInput/ActionBar/Upload/index.tsx
@@ -39,6 +39,7 @@ const FileUpload = memo(() => {
   );
 
   const upload = useFileStore((s) => s.uploadChatFiles);
+  const contextKey = useChatInputStore((s) => s.contextSelectionKey);
   const editor = useChatInputStore((s) => s.editor);
 
   const agentId = useAgentId();
@@ -94,7 +95,7 @@ const FileUpload = memo(() => {
           beforeUpload={async (file) => {
             setDropdownOpen(false);
             editor?.focus();
-            await upload([file], agentId);
+            await upload({ agentId, contextKey, files: [file] });
 
             return false;
           }}
@@ -137,7 +138,7 @@ const FileUpload = memo(() => {
 
             setDropdownOpen(false);
             editor?.focus();
-            await upload([file], agentId);
+            await upload({ agentId, contextKey, files: [file] });
 
             return false;
           }}
@@ -177,7 +178,7 @@ const FileUpload = memo(() => {
 
             setDropdownOpen(false);
             editor?.focus();
-            await upload([file], agentId);
+            await upload({ agentId, contextKey, files: [file] });
 
             return false;
           }}

--- a/src/features/ChatInput/Desktop/ContextContainer/ContextItem/index.tsx
+++ b/src/features/ChatInput/Desktop/ContextContainer/ContextItem/index.tsx
@@ -8,6 +8,7 @@ import { useFileStore } from '@/store/file';
 import { type UploadFileItem } from '@/types/files/upload';
 import { UPLOAD_STATUS_SET } from '@/types/files/upload';
 
+import { useChatInputStore } from '../../../store';
 import Content from './Content';
 import { openFilePreviewModal } from './FilePreviewModal.loader';
 import { getFileBasename } from './utils';
@@ -79,6 +80,7 @@ type FileItemProps = UploadFileItem;
 const ContextItem = memo<FileItemProps>((props) => {
   const { file, id, status, uploadState } = props;
   const [removeChatUploadFile] = useFileStore((s) => [s.removeChatUploadFile]);
+  const contextKey = useChatInputStore((s) => s.contextSelectionKey);
 
   const basename = getFileBasename(file.name);
   const isUploading = UPLOAD_STATUS_SET.has(status);
@@ -89,7 +91,7 @@ const ContextItem = memo<FileItemProps>((props) => {
   });
 
   const handleClose = useEventCallback(() => {
-    removeChatUploadFile(id);
+    removeChatUploadFile({ contextKey, id });
   });
   return (
     <Tag closable size={'large'} onClick={handleClick} onClose={handleClose}>

--- a/src/features/ChatInput/Desktop/ContextContainer/ContextList.tsx
+++ b/src/features/ChatInput/Desktop/ContextContainer/ContextList.tsx
@@ -25,8 +25,10 @@ const styles = createStaticStyles(({ css }) => ({
 
 const ContextList = memo(() => {
   const contextSelectionKey = useChatInputStore((s) => s.contextSelectionKey);
-  const inputFilesList = useFileStore(fileChatSelectors.chatUploadFileList);
-  const showFileList = useFileStore(fileChatSelectors.chatUploadFileListHasItem);
+  const inputFilesList = useFileStore(fileChatSelectors.chatUploadFileList(contextSelectionKey));
+  const showFileList = useFileStore(
+    fileChatSelectors.chatUploadFileListHasItem(contextSelectionKey),
+  );
   const rawSelectionList = useFileStore(
     fileChatSelectors.chatContextSelections(contextSelectionKey),
   );

--- a/src/features/ChatInput/Desktop/FilePreview/FileItem/index.tsx
+++ b/src/features/ChatInput/Desktop/FilePreview/FileItem/index.tsx
@@ -9,6 +9,7 @@ import { useFileStore } from '@/store/file';
 import { type UploadFileItem } from '@/types/files/upload';
 
 import UploadDetail from '../../../components/UploadDetail';
+import { useChatInputStore } from '../../../store';
 import Content from './Content';
 
 const styles = createStaticStyles(({ css }) => ({
@@ -54,6 +55,7 @@ const FileItem = memo<FileItemProps>((props) => {
     s.removeChatUploadFile,
     s.retryChatUploadFile,
   ]);
+  const contextKey = useChatInputStore((s) => s.contextSelectionKey);
 
   return (
     <Block horizontal align={'center'} className={styles.container} variant={'outlined'}>
@@ -86,7 +88,7 @@ const FileItem = memo<FileItemProps>((props) => {
             size={'small'}
             title={t('retry', { ns: 'common' })}
             onClick={() => {
-              void retryChatUploadFile(id);
+              void retryChatUploadFile({ contextKey, id });
             }}
           />
         ) : null}
@@ -96,7 +98,7 @@ const FileItem = memo<FileItemProps>((props) => {
           size={'small'}
           title={t('delete', { ns: 'common' })}
           onClick={() => {
-            void removeChatUploadFile(id);
+            void removeChatUploadFile({ contextKey, id });
           }}
         />
       </Flexbox>

--- a/src/features/ChatInput/Desktop/index.tsx
+++ b/src/features/ChatInput/Desktop/index.tsx
@@ -139,7 +139,7 @@ const DesktopChatInput = memo<DesktopChatInputProps>(
     const hasContextSelections = useFileStore(
       fileChatSelectors.chatContextSelectionHasItem(contextSelectionKey),
     );
-    const hasFiles = useFileStore(fileChatSelectors.chatUploadFileListHasItem);
+    const hasFiles = useFileStore(fileChatSelectors.chatUploadFileListHasItem(contextSelectionKey));
     const [slashMenuRef, expand, showTypoBar, editor, leftActions] = useChatInputStore((s) => [
       s.slashMenuRef,
       s.expand,

--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -230,7 +230,8 @@ const InputEditor = memo<{
     isMentionEnabled &&
     !heterogeneousName &&
     categories.some((category) => category.id === 'agent');
-  const { handleUploadFiles } = useUploadFiles({ agentId, model, provider });
+  const contextKey = useChatInputStore((s) => s.contextSelectionKey);
+  const { handleUploadFiles } = useUploadFiles({ agentId, contextKey, model, provider });
 
   // Listen to editor's paste event for file uploads
   usePasteFile(editor, handleUploadFiles);

--- a/src/features/ChatInput/Mobile/FilePreview/FileItem/index.tsx
+++ b/src/features/ChatInput/Mobile/FilePreview/FileItem/index.tsx
@@ -1,6 +1,7 @@
 import { type CSSProperties } from 'react';
 import { memo } from 'react';
 
+import { useChatInputStore } from '@/features/ChatInput/store';
 import { useFileStore } from '@/store/file';
 import { type UploadFileItem } from '@/types/files';
 
@@ -23,6 +24,7 @@ const FileItem = memo<FileItemProps>((props) => {
     s.removeChatUploadFile,
     s.retryChatUploadFile,
   ]);
+  const contextKey = useChatInputStore((s) => s.contextSelectionKey);
 
   if (file.type.startsWith('image')) {
     return (
@@ -33,10 +35,10 @@ const FileItem = memo<FileItemProps>((props) => {
         loading={status === 'pending'}
         src={previewUrl}
         onRemove={() => {
-          removeFile(id);
+          removeFile({ contextKey, id });
         }}
         onRetry={() => {
-          void retryFile(id);
+          void retryFile({ contextKey, id });
         }}
       />
     );
@@ -45,9 +47,9 @@ const FileItem = memo<FileItemProps>((props) => {
   return (
     <File
       {...props}
-      onRemove={() => removeFile(id)}
+      onRemove={() => removeFile({ contextKey, id })}
       onRetry={() => {
-        void retryFile(id);
+        void retryFile({ contextKey, id });
       }}
     />
   );

--- a/src/features/ChatInput/Mobile/FilePreview/index.tsx
+++ b/src/features/ChatInput/Mobile/FilePreview/index.tsx
@@ -17,7 +17,8 @@ const styles = createStaticStyles(({ css }) => ({
 
 const FilePreview = memo(() => {
   const expand = useChatInputStore((s) => s.expand);
-  const list = useFileStore(filesSelectors.chatUploadFileList, isEqual);
+  const contextKey = useChatInputStore((s) => s.contextSelectionKey);
+  const list = useFileStore(filesSelectors.chatUploadFileList(contextKey), isEqual);
   if (!list || list?.length === 0) return null;
 
   return (

--- a/src/features/Conversation/ChatInput/QueueTray.tsx
+++ b/src/features/Conversation/ChatInput/QueueTray.tsx
@@ -175,7 +175,7 @@ const QueueTray = memo(() => {
       editor?.focus();
       if (msg.filesPreview?.length) {
         const restored = reconstructUploadFilesFromQueue(msg.filesPreview);
-        dispatchChatUploadFileList({ files: restored, type: 'addFiles' });
+        dispatchChatUploadFileList({ contextKey, payload: { files: restored, type: 'addFiles' } });
       }
     },
     [contextKey, dispatchChatUploadFileList, editor, removeQueuedMessage],

--- a/src/features/Conversation/ChatInput/index.tsx
+++ b/src/features/Conversation/ChatInput/index.tsx
@@ -259,9 +259,9 @@ const ChatInput = memo<ChatInputProps>(
     const clearSendMessageError = useChatStore((s) => s.clearSendMessageError);
 
     // File store - for UI state only (disabled button, etc.)
-    const fileList = useFileStore(fileChatSelectors.chatUploadFileList);
+    const fileList = useFileStore(fileChatSelectors.chatUploadFileList(contextKey));
     const contextList = useFileStore(fileChatSelectors.chatContextSelections(contextKey));
-    const isUploadingFiles = useFileStore(fileChatSelectors.isUploadingFiles);
+    const isUploadingFiles = useFileStore(fileChatSelectors.isUploadingFiles(contextKey));
 
     // Queue state
     const hasQueuedMessages = useChatStore(
@@ -310,7 +310,7 @@ const ChatInput = memo<ChatInputProps>(
       if (customDisabled !== undefined) return customDisabled;
 
       const fileStore = useFileStore.getState();
-      if (fileChatSelectors.isUploadingFiles(fileStore)) return true;
+      if (fileChatSelectors.isUploadingFiles(contextKey)(fileStore)) return true;
 
       const { context: liveContext, editor } = storeApi.getState();
       if (
@@ -320,11 +320,11 @@ const ChatInput = memo<ChatInputProps>(
         return true;
 
       const hasText = String(editor?.getMarkdownContent?.() || '').trim().length > 0;
-      const hasFiles = fileChatSelectors.chatUploadFileList(fileStore).length > 0;
+      const hasFiles = fileChatSelectors.chatUploadFileList(contextKey)(fileStore).length > 0;
       const hasContextSelections =
         fileChatSelectors.chatContextSelections(messageMapKey(liveContext))(fileStore).length > 0;
       return !hasText && !hasFiles && !hasContextSelections;
-    }, [customDisabled, disableQueue, disableSend, storeApi]);
+    }, [contextKey, customDisabled, disableQueue, disableSend, storeApi]);
     const shouldUsePlainSendButton = !showSendMenu && !!sendMenu;
     const businessAlerts = useBusinessChatInputAlerts();
     const businessSendAreaPrefix = getBusinessChatInputSendAreaPrefix(sendAreaPrefix);
@@ -338,8 +338,8 @@ const ChatInput = memo<ChatInputProps>(
 
         // Get instant values from stores at trigger time
         const fileStore = useFileStore.getState();
-        const currentFileList = fileChatSelectors.chatUploadFileList(fileStore);
-        const currentIsUploading = fileChatSelectors.isUploadingFiles(fileStore);
+        const currentFileList = fileChatSelectors.chatUploadFileList(contextKey)(fileStore);
+        const currentIsUploading = fileChatSelectors.isUploadingFiles(contextKey)(fileStore);
         const currentContextList = fileChatSelectors.chatContextSelections(contextKey)(fileStore);
 
         if (currentIsUploading) return;
@@ -358,7 +358,7 @@ const ChatInput = memo<ChatInputProps>(
 
         const clearComposer = () => {
           clearContent();
-          fileStore.clearChatUploadFileList();
+          fileStore.clearChatUploadFileList(contextKey);
           fileStore.clearChatContextSelections(contextKey);
         };
 

--- a/src/features/Conversation/Messages/components/MessageActionBar/actions/restoreToInput.test.ts
+++ b/src/features/Conversation/Messages/components/MessageActionBar/actions/restoreToInput.test.ts
@@ -17,8 +17,14 @@ const updateInputMessage = vi.fn();
 const clearChatUploadFileList = vi.fn();
 const dispatchChatUploadFileList = vi.fn();
 
+const CONTEXT = { agentId: 'agt_1', topicId: 'tpc_1' };
+// `main_agt_1_tpc_1` — what `messageMapKey(CONTEXT)` produces, i.e. the bucket
+// THIS conversation's composer renders from.
+const CONTEXT_KEY = 'main_agt_1_tpc_1';
+
 vi.mock('../../../../store', () => ({
-  useConversationStore: (selector: (s: any) => any) => selector({ editor, updateInputMessage }),
+  useConversationStore: (selector: (s: any) => any) =>
+    selector({ context: CONTEXT, editor, updateInputMessage }),
 }));
 
 vi.mock('@/store/file', () => ({
@@ -80,26 +86,35 @@ describe('restoreToInputAction', () => {
       imageList: [{ alt: 'pic', id: 'i1', url: 'u-i1' }],
     })!.handleClick!();
 
-    expect(clearChatUploadFileList).toHaveBeenCalled();
+    // Restoring must target THIS conversation's composer, not whichever other
+    // composer is mounted alongside it.
+    expect(clearChatUploadFileList).toHaveBeenCalledWith(CONTEXT_KEY);
     expect(dispatchChatUploadFileList).toHaveBeenCalledWith({
-      files: [
-        expect.objectContaining({
-          fileUrl: 'u-i1',
-          id: 'i1',
-          previewUrl: 'u-i1',
-          status: 'success',
-        }),
-        expect.objectContaining({
-          fileUrl: 'u-f1',
-          id: 'f1',
-          previewUrl: 'u-f1',
-          status: 'success',
-        }),
-      ],
-      type: 'addFiles',
+      contextKey: CONTEXT_KEY,
+      payload: {
+        files: [
+          expect.objectContaining({
+            fileUrl: 'u-i1',
+            id: 'i1',
+            previewUrl: 'u-i1',
+            status: 'success',
+          }),
+          expect.objectContaining({
+            fileUrl: 'u-f1',
+            id: 'f1',
+            previewUrl: 'u-f1',
+            status: 'success',
+          }),
+        ],
+        type: 'addFiles',
+      },
     });
 
-    const [{ files }] = dispatchChatUploadFileList.mock.calls[0];
+    const [
+      {
+        payload: { files },
+      },
+    ] = dispatchChatUploadFileList.mock.calls[0];
     expect(files[0].file.type).toBe('image/*');
     expect(files[1].file).toMatchObject({ name: 'a.pdf', size: 100, type: 'application/pdf' });
   });
@@ -107,7 +122,7 @@ describe('restoreToInputAction', () => {
   it('clears the upload list but skips dispatch when there are no attachments', () => {
     build({ content: 'no files' })!.handleClick!();
 
-    expect(clearChatUploadFileList).toHaveBeenCalled();
+    expect(clearChatUploadFileList).toHaveBeenCalledWith(CONTEXT_KEY);
     expect(dispatchChatUploadFileList).not.toHaveBeenCalled();
   });
 });

--- a/src/features/Conversation/Messages/components/MessageActionBar/actions/restoreToInput.ts
+++ b/src/features/Conversation/Messages/components/MessageActionBar/actions/restoreToInput.ts
@@ -8,6 +8,7 @@ import { unescapeMarkdown } from '@/store/chat/utils/unescapeMarkdown';
 import { useFileStore } from '@/store/file';
 import { type UploadFileItem } from '@/types/files/upload';
 
+import { useConversationContextKey } from '../../../../hooks/useConversationContextKey';
 import { useConversationStore } from '../../../../store';
 import { defineAction } from '../defineAction';
 
@@ -26,6 +27,9 @@ export const restoreToInputAction = defineAction({
 
     const editor = useConversationStore((s) => s.editor);
     const updateInputMessage = useConversationStore((s) => s.updateInputMessage);
+    // Restoring targets THIS conversation's composer — the same bucket its file
+    // list renders from, not whichever composer happens to be mounted too.
+    const contextKey = useConversationContextKey();
 
     return useMemo(() => {
       // Only user messages carry restorable user input.
@@ -93,9 +97,12 @@ export const restoreToInputAction = defineAction({
           ];
 
           const fileStore = useFileStore.getState();
-          fileStore.clearChatUploadFileList();
+          fileStore.clearChatUploadFileList(contextKey);
           if (restored.length > 0) {
-            fileStore.dispatchChatUploadFileList({ files: restored, type: 'addFiles' });
+            fileStore.dispatchChatUploadFileList({
+              contextKey,
+              payload: { files: restored, type: 'addFiles' },
+            });
           }
 
           editor.focus();
@@ -105,6 +112,6 @@ export const restoreToInputAction = defineAction({
         key: 'restoreToInput',
         label: t('restoreToInput'),
       };
-    }, [t, ctx.role, ctx.data, editor, updateInputMessage]);
+    }, [t, ctx.role, ctx.data, contextKey, editor, updateInputMessage]);
   },
 });

--- a/src/features/Conversation/WorkingSidebar/Browser/index.tsx
+++ b/src/features/Conversation/WorkingSidebar/Browser/index.tsx
@@ -244,8 +244,14 @@ const BrowserPane = memo<BrowserPaneProps>((props) => {
 
       const file = dataUrlToFile(result.dataUrl, buildScreenshotFileName(result.title));
       // The attachment appears in the input immediately (pending state); the
-      // upload itself reports its own progress and errors.
-      void useFileStore.getState().uploadChatFiles([file], agentId);
+      // upload itself reports its own progress and errors. `composerTarget` is
+      // the composer this sidebar writes into (a thread's, when opened from one),
+      // so the screenshot lands in the file list the user is looking at.
+      void useFileStore.getState().uploadChatFiles({
+        agentId,
+        contextKey: composerTarget.writable ? composerTarget.contextKey : undefined,
+        files: [file],
+      });
       toast.success(t('workingPanel.browser.actions.captured'));
       focusChatInput();
     } catch (error) {

--- a/src/features/Conversation/hooks/index.ts
+++ b/src/features/Conversation/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useAgentMeta, useIsBuiltinAgent } from './useAgentMeta';
 export { useClearActiveTopicUnread } from './useClearActiveTopicUnread';
+export { useConversationContextKey } from './useConversationContextKey';
 export { useDoubleClickEdit } from './useDoubleClickEdit';

--- a/src/features/Conversation/hooks/useConversationContextKey.ts
+++ b/src/features/Conversation/hooks/useConversationContextKey.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+
+import { messageMapKey } from '@/store/chat/utils/messageMapKey';
+
+import { useConversationStore } from '../store';
+
+/**
+ * The key this conversation's composer state is filed under — pending uploads
+ * and context selections alike.
+ *
+ * Every host that can put a file into a composer must derive the key from the
+ * SAME context the composer reads, or the upload lands in a bucket nothing
+ * renders. Deriving it here (rather than re-assembling `messageMapKey` at each
+ * call site) is what keeps a drop zone, the editor's paste handler, and the
+ * send path pointed at one bucket.
+ */
+export const useConversationContextKey = (): string => {
+  const context = useConversationStore((s) => s.context);
+
+  return useMemo(() => messageMapKey(context), [context]);
+};

--- a/src/features/Conversation/index.ts
+++ b/src/features/Conversation/index.ts
@@ -1,6 +1,6 @@
 // Re-export types, provider, hooks, store, and components for convenience
 export { ConversationProvider, type ConversationProviderProps } from './ConversationProvider';
-export { useDoubleClickEdit } from './hooks';
+export { useConversationContextKey, useDoubleClickEdit } from './hooks';
 export {
   conversationSelectors,
   type ConversationStore,

--- a/src/features/Home/InputArea/index.tsx
+++ b/src/features/Home/InputArea/index.tsx
@@ -65,7 +65,12 @@ const InputArea = ({ inputValue, mode, onInputValueChange, onModeChange }: Input
   const provider = useAgentStore((s) =>
     agentByIdSelectors.getAgentModelProviderById(resolvedAgentId)(s),
   );
-  const { handleUploadFiles } = useUploadFiles({ agentId: resolvedAgentId, model, provider });
+  const { handleUploadFiles } = useUploadFiles({
+    agentId: resolvedAgentId,
+    contextKey: contextSelectionKey,
+    model,
+    provider,
+  });
 
   // Daily-generated input hint paired with the fixed Home greeting.
   const { currentPair } = useHomeDailyBrief();

--- a/src/features/Home/InputArea/useSend.test.ts
+++ b/src/features/Home/InputArea/useSend.test.ts
@@ -34,7 +34,7 @@ const chatState = vi.hoisted(() => ({
 
 const fileState = vi.hoisted(() => ({
   chatContextSelectionsByContext: {} as Record<string, any[]>,
-  chatUploadFileList: [],
+  chatUploadFileListByContext: {} as Record<string, any[]>,
   clearChatContextSelections: clearChatContextSelectionsMock,
   clearChatUploadFileList: clearChatUploadFileListMock,
   restoreChatContextSelections: restoreChatContextSelectionsMock,
@@ -159,7 +159,8 @@ vi.mock('@/store/file', () => {
     fileChatSelectors: {
       chatContextSelections: (contextKey: string) => (state: typeof fileState) =>
         state.chatContextSelectionsByContext[contextKey] ?? [],
-      chatUploadFileList: (state: typeof fileState) => state.chatUploadFileList,
+      chatUploadFileList: (contextKey: string) => (state: typeof fileState) =>
+        state.chatUploadFileListByContext[contextKey] ?? [],
     },
     useFileStore,
   };
@@ -193,7 +194,7 @@ describe('Home InputArea useSend', () => {
     homeDailyBriefState.currentPair = undefined;
     chatState.inputMessage = 'hello';
     fileState.chatContextSelectionsByContext = {};
-    fileState.chatUploadFileList = [];
+    fileState.chatUploadFileListByContext = {};
     homeState.inputActiveMode = null;
     homeState.ungroupedAgents = [];
     globalState.systemStatus.homeSelectedAgentId = undefined;
@@ -306,7 +307,7 @@ describe('Home InputArea useSend', () => {
   });
 
   it('does not discard attachments that Task mode cannot persist', async () => {
-    fileState.chatUploadFileList = [{ id: 'file-1' }] as any;
+    fileState.chatUploadFileListByContext = { 'home:task:agt_inbox': [{ id: 'file-1' }] } as any;
     const { result } = renderHook(() => useSend('task'));
     const params: Parameters<SendButtonHandler>[0] = {
       clearContent: vi.fn(),
@@ -326,7 +327,7 @@ describe('Home InputArea useSend', () => {
 
   it('explains why an attachment-only Task submission cannot proceed', async () => {
     chatState.inputMessage = '';
-    fileState.chatUploadFileList = [{ id: 'file-1' }] as any;
+    fileState.chatUploadFileListByContext = { 'home:task:agt_inbox': [{ id: 'file-1' }] } as any;
     const { result } = renderHook(() => useSend('task'));
     const params: Parameters<SendButtonHandler>[0] = {
       clearContent: vi.fn(),

--- a/src/features/Home/InputArea/useSend.ts
+++ b/src/features/Home/InputArea/useSend.ts
@@ -97,7 +97,9 @@ export const useSend = (mode: HomeMode = 'chat') => {
       // `onChange`, so a fast type-then-Enter sequence can fire before the
       // cache catches up and the empty-message guard would bail incorrectly.
       const typed = (getMarkdownContent?.() ?? inputMessage ?? '').trim();
-      const fileList = fileChatSelectors.chatUploadFileList(useFileStore.getState());
+      const fileList = fileChatSelectors.chatUploadFileList(contextSelectionKey)(
+        useFileStore.getState(),
+      );
       const contextList = fileChatSelectors.chatContextSelections(contextSelectionKey)(
         useFileStore.getState(),
       );
@@ -262,7 +264,7 @@ export const useSend = (mode: HomeMode = 'chat') => {
         // Preserve the complete draft when creation or execution fails. The
         // editor, files and context are one unit from the user's perspective.
         if (submitted) {
-          clearChatUploadFileList();
+          clearChatUploadFileList(contextSelectionKey);
           clearChatContextSelections(contextSelectionKey);
           mainInputEditor?.clearContent();
         }

--- a/src/features/PageEditor/Copilot/Conversation.tsx
+++ b/src/features/PageEditor/Copilot/Conversation.tsx
@@ -14,6 +14,7 @@ import {
   ChatInput,
   ChatList,
   conversationSelectors,
+  useConversationContextKey,
   useConversationStore,
 } from '@/features/Conversation';
 import { useAgentStore } from '@/store/agent';
@@ -42,7 +43,13 @@ const Conversation = memo(() => {
   const provider = useAgentStore((s) =>
     agentByIdSelectors.getAgentModelProviderById(currentAgentId)(s),
   );
-  const { handleUploadFiles } = useUploadFiles({ agentId: currentAgentId, model, provider });
+  const contextKey = useConversationContextKey();
+  const { handleUploadFiles } = useUploadFiles({
+    agentId: currentAgentId,
+    contextKey,
+    model,
+    provider,
+  });
 
   const handleAgentChange = useCallback(
     (id: string) => {

--- a/src/routes/(main)/agent/features/Conversation/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/index.tsx
@@ -15,6 +15,7 @@ import {
   chatConfigByIdSelectors,
 } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
+import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 
 import ConversationArea from './ConversationArea';
 
@@ -26,7 +27,8 @@ const wrapperStyle: React.CSSProperties = {
 };
 
 const ChatConversation = memo(() => {
-  const { agentId, topicId } = useAgentContext();
+  const context = useAgentContext();
+  const { agentId, topicId } = context;
   const model = useAgentStore(agentByIdSelectors.getAgentModelById(agentId));
   const provider = useAgentStore(agentByIdSelectors.getAgentModelProviderById(agentId));
   const isHeterogeneous = useAgentStore(agentByIdSelectors.isAgentHeterogeneousById(agentId));
@@ -45,7 +47,10 @@ const ChatConversation = memo(() => {
     agentId && agentId !== inboxAgentId && agentVisibility !== 'private' ? agentId : undefined;
   const { canUseResource } = useResourceAccess('agent', gatedResourceId);
 
-  const { handleUploadFiles } = useUploadFiles({ agentId, model, provider });
+  // The SAME context `ConversationArea` hands the provider — a drop must land in
+  // the bucket this conversation's composer reads, not a neighbouring one.
+  const contextKey = messageMapKey(context);
+  const { handleUploadFiles } = useUploadFiles({ agentId, contextKey, model, provider });
   const workingDirectory = useEffectiveWorkingDirectory(agentId, { topicId });
 
   const enableLocalPathReference =

--- a/src/routes/(main)/group/features/Conversation/index.tsx
+++ b/src/routes/(main)/group/features/Conversation/index.tsx
@@ -4,16 +4,21 @@ import { memo } from 'react';
 import DragUploadZone, { useUploadFiles } from '@/components/DragUploadZone';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
+import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 
 import ConversationArea from './ConversationArea';
 import ChatHeader from './Header';
+import { useGroupContext } from './useGroupContext';
 
 const ChatConversation = memo(() => {
   // Get current agent's model info for vision support check
   const agentId = useAgentStore((s) => s.activeAgentId || '');
   const model = useAgentStore(agentSelectors.currentAgentModel);
   const provider = useAgentStore(agentSelectors.currentAgentModelProvider);
-  const { handleUploadFiles } = useUploadFiles({ agentId, model, provider });
+  // The SAME context `ConversationArea` hands the provider — a drop must land in
+  // the bucket this conversation's composer reads, not a neighbouring one.
+  const contextKey = messageMapKey(useGroupContext());
+  const { handleUploadFiles } = useUploadFiles({ agentId, contextKey, model, provider });
 
   return (
     <DragUploadZone style={{ height: '100%', width: '100%' }} onUploadFiles={handleUploadFiles}>

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -995,10 +995,11 @@ export class ConversationLifecycleActionImpl {
         },
         'sendMessage/optimisticCreateTopic',
       );
-      getFileStoreState().moveChatContextSelections(
-        messageMapKey({ ...operationContext, topicId: null }),
-        currentContextKey,
-      );
+      const preMintContextKey = messageMapKey({ ...operationContext, topicId: null });
+      getFileStoreState().moveChatContextSelections(preMintContextKey, currentContextKey);
+      // Attachments still uploading were filed under the pre-mint key — carry
+      // them with the selections or the composer loses sight of its own upload.
+      getFileStoreState().moveChatUploadFileList(preMintContextKey, currentContextKey);
       await this.#get().switchTopic(mintedTopicId, { skipRefreshMessage: true });
     }
 
@@ -1202,10 +1203,9 @@ export class ConversationLifecycleActionImpl {
     const rollbackOptimisticTopic = (action: string) => {
       if (!optimisticTopic || !optimisticTopicActive) return;
 
-      getFileStoreState().moveChatContextSelections(
-        currentContextKey,
-        messageMapKey({ ...operationContext, topicId: null }),
-      );
+      const preMintContextKey = messageMapKey({ ...operationContext, topicId: null });
+      getFileStoreState().moveChatContextSelections(currentContextKey, preMintContextKey);
+      getFileStoreState().moveChatUploadFileList(currentContextKey, preMintContextKey);
       if (this.#get().activeTopicId === optimisticTopic.id) {
         void this.#get().switchTopic(null, { skipRefreshMessage: true });
       }
@@ -1352,6 +1352,7 @@ export class ConversationLifecycleActionImpl {
       const heteroMessageKey = messageMapKey(heteroContext);
       this.#get().moveQueuedMessages(currentContextKey, heteroMessageKey);
       getFileStoreState().moveChatContextSelections(currentContextKey, heteroMessageKey);
+      getFileStoreState().moveChatUploadFileList(currentContextKey, heteroMessageKey);
       // Legacy queue location: follow-ups enqueued behind an op still
       // registered under the pre-mint `_new` key.
       if (willCreateNewTopic)

--- a/src/store/file/slices/chat/action.test.ts
+++ b/src/store/file/slices/chat/action.test.ts
@@ -221,6 +221,49 @@ describe('useFileStore:chat', () => {
     expect(uploads(result.current, 'main_agt_tpc_1')).toEqual([{ id: 'abc' }]);
   });
 
+  // The upload spends its first moments reading/compressing the file, so no
+  // pending item exists yet and the send gate is open. A send in that window
+  // mints the topic and moves the bucket — the add that lands afterwards must
+  // follow it, or the attachment is written to a bucket nothing renders.
+  it('retargets an in-flight upload when the bucket moves mid-upload', async () => {
+    mockAgentMode({ enableAgentMode: true, heterogeneous: false });
+
+    const { result } = renderHook(() => useStore());
+    const uploadWithProgress = vi.fn().mockResolvedValue({ id: 'file-1', url: 'http://x/1' });
+
+    act(() => {
+      useStore.setState({ uploadWithProgress: uploadWithProgress as any });
+    });
+
+    const PRE_MINT = 'main_agent-1_new';
+    const MINTED = 'main_agent-1_tpc_1';
+
+    let uploading!: Promise<void>;
+    act(() => {
+      uploading = result.current.uploadChatFiles({
+        agentId: AGENT_ID,
+        contextKey: PRE_MINT,
+        files: [new File(['x'], 'shot.txt', { type: 'text/plain' })],
+      });
+      // The move lands BEFORE the upload has added anything — the bucket it is
+      // about to write into is still empty.
+      expect(uploads(useStore.getState(), PRE_MINT)).toEqual([]);
+      result.current.moveChatUploadFileList(PRE_MINT, MINTED);
+    });
+
+    await act(async () => {
+      await uploading;
+    });
+
+    expect(uploads(useStore.getState(), MINTED)).toEqual([
+      expect.objectContaining({ id: 'shot.txt' }),
+    ]);
+    expect(uploads(useStore.getState(), PRE_MINT)).toEqual([]);
+    // The session is deregistered once the upload settles, so the next new topic
+    // reusing `main_agent-1_new` is not redirected into the old conversation.
+    expect(useStore.getState().chatUploadSessionContext).toEqual({});
+  });
+
   it('uploadChatFiles should reject unsupported files before upload in chat mode', async () => {
     // chat mode: agent mode disabled and not a heterogeneous agent
     mockAgentMode({ enableAgentMode: false, heterogeneous: false });

--- a/src/store/file/slices/chat/action.test.ts
+++ b/src/store/file/slices/chat/action.test.ts
@@ -9,6 +9,11 @@ import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useFileStore as useStore } from '../../store';
 
 const AGENT_ID = 'agent-1';
+const CONTEXT_KEY = 'main_agent-1_new';
+
+/** Pending uploads filed under one composer's context. */
+const uploads = (store: ReturnType<typeof useStore.getState>, contextKey: string) =>
+  store.chatUploadFileListByContext[contextKey] ?? [];
 
 /** Force the conversation agent into chat / agent / heterogeneous mode for the by-id selectors. */
 const mockAgentMode = ({
@@ -176,20 +181,44 @@ describe('useFileStore:chat', () => {
     });
   });
 
-  it('clearChatUploadFileList should clear the inputFilesList', () => {
+  it('clearChatUploadFileList should clear only the requested conversation', () => {
     const { result } = renderHook(() => useStore());
 
     act(() => {
-      useStore.setState({ chatUploadFileList: [{ id: 'abc' }] as any });
+      useStore.setState({
+        chatUploadFileListByContext: {
+          other: [{ id: 'other' }],
+          topic: [{ id: 'abc' }],
+        } as any,
+      });
     });
 
-    expect(result.current.chatUploadFileList).toEqual([{ id: 'abc' }]);
+    expect(uploads(result.current, 'topic')).toEqual([{ id: 'abc' }]);
 
     act(() => {
-      result.current.clearChatUploadFileList();
+      result.current.clearChatUploadFileList('topic');
     });
 
-    expect(result.current.chatUploadFileList).toEqual([]);
+    expect(uploads(result.current, 'topic')).toEqual([]);
+    // Sending in one composer must not wipe another composer's draft.
+    expect(uploads(result.current, 'other')).toEqual([{ id: 'other' }]);
+  });
+
+  it('moveChatUploadFileList carries pending uploads to the minted topic key', () => {
+    const { result } = renderHook(() => useStore());
+
+    act(() => {
+      useStore.setState({
+        chatUploadFileListByContext: { main_agt_new: [{ id: 'abc' }] } as any,
+      });
+    });
+
+    act(() => {
+      result.current.moveChatUploadFileList('main_agt_new', 'main_agt_tpc_1');
+    });
+
+    expect(uploads(result.current, 'main_agt_new')).toEqual([]);
+    expect(uploads(result.current, 'main_agt_tpc_1')).toEqual([{ id: 'abc' }]);
   });
 
   it('uploadChatFiles should reject unsupported files before upload in chat mode', async () => {
@@ -201,23 +230,24 @@ describe('useFileStore:chat', () => {
 
     act(() => {
       useStore.setState({
-        chatUploadFileList: [],
+        chatUploadFileListByContext: {},
         uploadWithProgress: uploadWithProgress as any,
       });
     });
 
     await act(async () => {
-      await result.current.uploadChatFiles(
-        [
+      await result.current.uploadChatFiles({
+        agentId: AGENT_ID,
+        contextKey: CONTEXT_KEY,
+        files: [
           new File(['<svg />'], 'icon.svg', { type: 'image/svg+xml' }),
           new File(['zip'], 'archive.zip', { type: 'application/zip' }),
         ],
-        AGENT_ID,
-      );
+      });
     });
 
     expect(uploadWithProgress).not.toHaveBeenCalled();
-    expect(result.current.chatUploadFileList).toEqual([]);
+    expect(uploads(result.current, CONTEXT_KEY)).toEqual([]);
     expect(toast.error).toHaveBeenCalledWith(expect.any(String));
   });
 
@@ -229,16 +259,17 @@ describe('useFileStore:chat', () => {
 
     act(() => {
       useStore.setState({
-        chatUploadFileList: [],
+        chatUploadFileListByContext: {},
         uploadWithProgress: uploadWithProgress as any,
       });
     });
 
     await act(async () => {
-      await result.current.uploadChatFiles(
-        [new File(['zip'], 'archive.zip', { type: 'application/zip' })],
-        AGENT_ID,
-      );
+      await result.current.uploadChatFiles({
+        agentId: AGENT_ID,
+        contextKey: CONTEXT_KEY,
+        files: [new File(['zip'], 'archive.zip', { type: 'application/zip' })],
+      });
     });
 
     expect(toast.error).not.toHaveBeenCalled();
@@ -253,16 +284,17 @@ describe('useFileStore:chat', () => {
 
     act(() => {
       useStore.setState({
-        chatUploadFileList: [],
+        chatUploadFileListByContext: {},
         uploadWithProgress: uploadWithProgress as any,
       });
     });
 
     await act(async () => {
-      await result.current.uploadChatFiles(
-        [new File(['profile'], 'Communication_Notifications.provisionprofile')],
-        AGENT_ID,
-      );
+      await result.current.uploadChatFiles({
+        agentId: AGENT_ID,
+        contextKey: CONTEXT_KEY,
+        files: [new File(['profile'], 'Communication_Notifications.provisionprofile')],
+      });
     });
 
     expect(toast.error).not.toHaveBeenCalled();
@@ -281,10 +313,14 @@ describe('useFileStore:chat', () => {
     });
 
     await act(async () => {
-      await result.current.uploadChatFiles([file], AGENT_ID);
+      await result.current.uploadChatFiles({
+        agentId: AGENT_ID,
+        contextKey: CONTEXT_KEY,
+        files: [file],
+      });
     });
 
-    expect(result.current.chatUploadFileList).toEqual([
+    expect(uploads(result.current, CONTEXT_KEY)).toEqual([
       expect.objectContaining({
         agentId: AGENT_ID,
         error: 'You do not have permission to upload files in this workspace.',
@@ -300,14 +336,14 @@ describe('useFileStore:chat', () => {
       const { result } = renderHook(() => useStore());
 
       act(() => {
-        useStore.setState({ chatUploadFileList: [{ id: 'file-1' }] as any });
+        useStore.setState({ chatUploadFileListByContext: { topic: [{ id: 'file-1' }] } as any });
       });
 
       await act(async () => {
-        await result.current.removeChatUploadFile('file-1');
+        await result.current.removeChatUploadFile({ contextKey: 'topic', id: 'file-1' });
       });
 
-      expect(result.current.chatUploadFileList).toEqual([]);
+      expect(uploads(result.current, 'topic')).toEqual([]);
       expect(removeFile).toHaveBeenCalledWith('file-1');
     });
 
@@ -317,17 +353,17 @@ describe('useFileStore:chat', () => {
 
       act(() => {
         useStore.setState({
-          chatUploadFileList: [{ id: 'file-1', skipRemoveFile: true }] as any,
+          chatUploadFileListByContext: { topic: [{ id: 'file-1', skipRemoveFile: true }] } as any,
         });
       });
 
       await act(async () => {
-        await result.current.removeChatUploadFile('file-1');
+        await result.current.removeChatUploadFile({ contextKey: 'topic', id: 'file-1' });
       });
 
       // draft entry is dropped, but the persisted file backing the original
       // message must NOT be deleted
-      expect(result.current.chatUploadFileList).toEqual([]);
+      expect(uploads(result.current, 'topic')).toEqual([]);
       expect(removeFile).not.toHaveBeenCalled();
     });
   });

--- a/src/store/file/slices/chat/action.ts
+++ b/src/store/file/slices/chat/action.ts
@@ -20,6 +20,7 @@ import { sleep } from '@/utils/sleep';
 import { setNamespace } from '@/utils/storeDebug';
 
 import { type FileStore } from '../../store';
+import { chatUploadContextKey } from './selectors';
 import { filterSupportedChatUploadFiles } from './uploadGuard';
 
 const n = setNamespace('chat');
@@ -69,6 +70,10 @@ export class FileActionImpl {
     this.#get = get;
   }
 
+  /** This composer's pending uploads. */
+  #uploadFileList = (contextKey?: string): UploadFileItem[] =>
+    this.#get().chatUploadFileListByContext[chatUploadContextKey(contextKey)] ?? [];
+
   addChatContextSelection = ({
     contextKey,
     selection,
@@ -95,15 +100,59 @@ export class FileActionImpl {
     this.#set({ chatContextSelectionsByContext: nextMap }, false, n('clearChatContextSelections'));
   };
 
-  clearChatUploadFileList = (): void => {
-    this.#set({ chatUploadFileList: [] }, false, n('clearChatUploadFileList'));
+  clearChatUploadFileList = (contextKey?: string): void => {
+    const key = chatUploadContextKey(contextKey);
+    const currentMap = this.#get().chatUploadFileListByContext;
+    if (!(key in currentMap)) return;
+
+    const { [key]: _removed, ...nextMap } = currentMap;
+    this.#set({ chatUploadFileListByContext: nextMap }, false, n('clearChatUploadFileList'));
   };
 
-  dispatchChatUploadFileList = (payload: UploadFileListDispatch): void => {
-    const nextValue = uploadFileListReducer(this.#get().chatUploadFileList, payload);
-    if (nextValue === this.#get().chatUploadFileList) return;
+  dispatchChatUploadFileList = ({
+    contextKey,
+    payload,
+  }: {
+    contextKey?: string;
+    payload: UploadFileListDispatch;
+  }): void => {
+    const key = chatUploadContextKey(contextKey);
+    const currentMap = this.#get().chatUploadFileListByContext;
+    const current = currentMap[key] ?? [];
+    const nextValue = uploadFileListReducer(current, payload);
+    if (nextValue === current) return;
 
-    this.#set({ chatUploadFileList: nextValue }, false, `dispatchChatFileList/${payload.type}`);
+    this.#set(
+      { chatUploadFileListByContext: { ...currentMap, [key]: nextValue } },
+      false,
+      `dispatchChatFileList/${payload.type}`,
+    );
+  };
+
+  /**
+   * Carry pending uploads from one context to another — the composer's own move,
+   * matching {@link moveChatContextSelections}. A first message is composed under
+   * a `topicId: null` key and the run mints the real topic id mid-send, so
+   * without this the attachments the user is watching upload would be stranded
+   * in a bucket nothing renders anymore.
+   */
+  moveChatUploadFileList = (fromContextKey: string, toContextKey: string): void => {
+    if (fromContextKey === toContextKey) return;
+
+    const currentMap = this.#get().chatUploadFileListByContext;
+    const source = currentMap[fromContextKey];
+    if (!source || source.length === 0) return;
+
+    const sourceIds = new Set(source.map((item) => item.id));
+    const target = currentMap[toContextKey] ?? [];
+    const nextTarget = [...source, ...target.filter((item) => !sourceIds.has(item.id))];
+    const { [fromContextKey]: _removed, ...nextMap } = currentMap;
+
+    this.#set(
+      { chatUploadFileListByContext: { ...nextMap, [toContextKey]: nextTarget } },
+      false,
+      n('moveChatUploadFileList'),
+    );
   };
 
   moveChatContextSelections = (fromContextKey: string, toContextKey: string): void => {
@@ -163,27 +212,40 @@ export class FileActionImpl {
     );
   };
 
-  removeChatUploadFile = async (id: string): Promise<void> => {
-    const { chatUploadFileList, dispatchChatUploadFileList } = this.#get();
+  removeChatUploadFile = async ({
+    contextKey,
+    id,
+  }: {
+    contextKey?: string;
+    id: string;
+  }): Promise<void> => {
+    const { dispatchChatUploadFileList } = this.#get();
+    const list = this.#uploadFileList(contextKey);
 
     // Restored entries reference an already-persisted file that still backs the
     // original message — only drop the draft item, never delete the file itself.
-    const skipRemoveFile = chatUploadFileList.find((item) => item.id === id)?.skipRemoveFile;
+    const skipRemoveFile = list.find((item) => item.id === id)?.skipRemoveFile;
 
-    dispatchChatUploadFileList({ id, type: 'removeFile' });
+    dispatchChatUploadFileList({ contextKey, payload: { id, type: 'removeFile' } });
 
     if (skipRemoveFile) return;
 
     await fileService.removeFile(id);
   };
 
-  retryChatUploadFile = async (id: string): Promise<void> => {
-    const { chatUploadFileList, dispatchChatUploadFileList } = this.#get();
-    const item = chatUploadFileList.find((file) => file.id === id);
+  retryChatUploadFile = async ({
+    contextKey,
+    id,
+  }: {
+    contextKey?: string;
+    id: string;
+  }): Promise<void> => {
+    const { dispatchChatUploadFileList } = this.#get();
+    const item = this.#uploadFileList(contextKey).find((file) => file.id === id);
     if (!item?.agentId) return;
 
-    dispatchChatUploadFileList({ id, type: 'removeFile' });
-    await this.uploadChatFiles([item.file], item.agentId);
+    dispatchChatUploadFileList({ contextKey, payload: { id, type: 'removeFile' } });
+    await this.uploadChatFiles({ agentId: item.agentId, contextKey, files: [item.file] });
   };
 
   startAsyncTask = async (
@@ -224,8 +286,18 @@ export class FileActionImpl {
     }
   };
 
-  uploadChatFiles = async (rawFiles: File[], agentId: string): Promise<void> => {
-    const { dispatchChatUploadFileList } = this.#get();
+  uploadChatFiles = async ({
+    agentId,
+    contextKey,
+    files: rawFiles,
+  }: {
+    agentId: string;
+    /** Composer the files belong to — see {@link ImageFileState.chatUploadFileListByContext}. */
+    contextKey?: string;
+    files: File[];
+  }): Promise<void> => {
+    const dispatch = (payload: UploadFileListDispatch) =>
+      this.#get().dispatchChatUploadFileList({ contextKey, payload });
     // 0. skip file in blacklist
     const filteredFiles = rawFiles.filter((file) => !FILE_UPLOAD_BLACKLIST.includes(file.name));
 
@@ -288,7 +360,7 @@ export class FileActionImpl {
       }),
     );
 
-    dispatchChatUploadFileList({ files: uploadFiles, type: 'addFiles' });
+    dispatch({ files: uploadFiles, type: 'addFiles' });
 
     // upload files and process it
     const pools = files.map(async (file) => {
@@ -297,13 +369,13 @@ export class FileActionImpl {
       try {
         fileResult = await this.#get().uploadWithProgress({
           file,
-          onStatusUpdate: dispatchChatUploadFileList,
+          onStatusUpdate: dispatch,
         });
       } catch (error) {
         if (getErrorMessage(error) === 'UNAUTHORIZED') {
-          dispatchChatUploadFileList({ id: file.name, type: 'removeFile' });
+          dispatch({ id: file.name, type: 'removeFile' });
         } else {
-          dispatchChatUploadFileList({
+          dispatch({
             id: file.name,
             type: 'updateFile',
             value: {

--- a/src/store/file/slices/chat/action.ts
+++ b/src/store/file/slices/chat/action.ts
@@ -1,7 +1,9 @@
 import { type ChatContextContent } from '@lobechat/types';
+import { nanoid } from '@lobechat/utils';
 import { COMPRESSIBLE_IMAGE_TYPES, compressImageFile } from '@lobechat/utils/compressImage';
 import { toast } from '@lobehub/ui/base-ui';
 import { Buffer } from 'buffer.js';
+import isEqual from 'fast-deep-equal';
 import { t } from 'i18next';
 
 import { FILE_UPLOAD_BLACKLIST } from '@/const/file';
@@ -112,11 +114,21 @@ export class FileActionImpl {
   dispatchChatUploadFileList = ({
     contextKey,
     payload,
+    uploadSessionId,
   }: {
     contextKey?: string;
     payload: UploadFileListDispatch;
+    /**
+     * Set by an in-flight `uploadChatFiles`. The bucket it writes into is read
+     * back at DISPATCH time, so a topic mint that moves the bucket mid-upload
+     * takes the remaining add / progress / success writes with it.
+     */
+    uploadSessionId?: string;
   }): void => {
-    const key = chatUploadContextKey(contextKey);
+    const sessionKey = uploadSessionId
+      ? this.#get().chatUploadSessionContext[uploadSessionId]
+      : undefined;
+    const key = sessionKey ?? chatUploadContextKey(contextKey);
     const currentMap = this.#get().chatUploadFileListByContext;
     const current = currentMap[key] ?? [];
     const nextValue = uploadFileListReducer(current, payload);
@@ -139,9 +151,25 @@ export class FileActionImpl {
   moveChatUploadFileList = (fromContextKey: string, toContextKey: string): void => {
     if (fromContextKey === toContextKey) return;
 
+    // Retarget uploads still in flight FIRST, and unconditionally: the racy case
+    // is precisely the one with nothing to move yet, where the file is still
+    // being read/compressed and its `addFiles` is about to land.
+    const sessions = this.#get().chatUploadSessionContext;
+    const movedSessions = Object.fromEntries(
+      Object.entries(sessions).map(([id, key]) => [
+        id,
+        key === fromContextKey ? toContextKey : key,
+      ]),
+    );
+
     const currentMap = this.#get().chatUploadFileListByContext;
     const source = currentMap[fromContextKey];
-    if (!source || source.length === 0) return;
+    if (!source || source.length === 0) {
+      if (!isEqual(sessions, movedSessions)) {
+        this.#set({ chatUploadSessionContext: movedSessions }, false, n('moveChatUploadFileList'));
+      }
+      return;
+    }
 
     const sourceIds = new Set(source.map((item) => item.id));
     const target = currentMap[toContextKey] ?? [];
@@ -149,7 +177,10 @@ export class FileActionImpl {
     const { [fromContextKey]: _removed, ...nextMap } = currentMap;
 
     this.#set(
-      { chatUploadFileListByContext: { ...nextMap, [toContextKey]: nextTarget } },
+      {
+        chatUploadFileListByContext: { ...nextMap, [toContextKey]: nextTarget },
+        chatUploadSessionContext: movedSessions,
+      },
       false,
       n('moveChatUploadFileList'),
     );
@@ -296,8 +327,44 @@ export class FileActionImpl {
     contextKey?: string;
     files: File[];
   }): Promise<void> => {
+    // Registered before the first `await` so a move during compression can find
+    // it; unregistered in the `finally` below once nothing else will dispatch.
+    const uploadSessionId = nanoid();
+    this.#set(
+      {
+        chatUploadSessionContext: {
+          ...this.#get().chatUploadSessionContext,
+          [uploadSessionId]: chatUploadContextKey(contextKey),
+        },
+      },
+      false,
+      n('registerChatUpload'),
+    );
     const dispatch = (payload: UploadFileListDispatch) =>
-      this.#get().dispatchChatUploadFileList({ contextKey, payload });
+      this.#get().dispatchChatUploadFileList({ contextKey, payload, uploadSessionId });
+
+    try {
+      await this.#runChatUpload({ agentId, dispatch, rawFiles });
+    } finally {
+      this.#unregisterChatUpload(uploadSessionId);
+    }
+  };
+
+  /** Deregister a finished upload — nothing dispatches under it any more. */
+  #unregisterChatUpload = (uploadSessionId: string): void => {
+    const { [uploadSessionId]: _done, ...rest } = this.#get().chatUploadSessionContext;
+    this.#set({ chatUploadSessionContext: rest }, false, n('unregisterChatUpload'));
+  };
+
+  #runChatUpload = async ({
+    agentId,
+    dispatch,
+    rawFiles,
+  }: {
+    agentId: string;
+    dispatch: (payload: UploadFileListDispatch) => void;
+    rawFiles: File[];
+  }): Promise<void> => {
     // 0. skip file in blacklist
     const filteredFiles = rawFiles.filter((file) => !FILE_UPLOAD_BLACKLIST.includes(file.name));
 

--- a/src/store/file/slices/chat/initialState.ts
+++ b/src/store/file/slices/chat/initialState.ts
@@ -24,11 +24,26 @@ export interface ImageFileState {
    * attachment with their own message, and clear each other's drafts.
    */
   chatUploadFileListByContext: Record<string, UploadFileItem[]>;
+  /**
+   * Which composer each IN-FLIGHT upload is writing into, keyed by a per-call
+   * session id.
+   *
+   * An upload spends its first moments reading and compressing the file, before
+   * any pending item exists — and a send during that window mints the topic and
+   * moves the bucket. A dispatch bound to the key captured at call time would
+   * then land in the abandoned bucket: the attachment disappears, or (when the
+   * move lands between two progress callbacks) a moved item never leaves
+   * `pending` and jams the send button. Redirecting by SESSION rather than by
+   * key is what makes the retarget safe — `main_<agent>_new` is reused by the
+   * next new topic, so a key-to-key redirect would misfile that one instead.
+   */
+  chatUploadSessionContext: Record<string, string>;
   uploadingIds: string[];
 }
 
 export const initialImageFileState: ImageFileState = {
   chatContextSelectionsByContext: {},
   chatUploadFileListByContext: {},
+  chatUploadSessionContext: {},
   uploadingIds: [],
 };

--- a/src/store/file/slices/chat/initialState.ts
+++ b/src/store/file/slices/chat/initialState.ts
@@ -2,14 +2,33 @@ import { type ChatContextContent } from '@lobechat/types';
 
 import { type UploadFileItem } from '@/types/files/upload';
 
+/**
+ * Bucket used when a caller has no context of its own.
+ *
+ * Every chat surface passes the key its composer is scoped to; this only
+ * catches hosts that predate the split, so their drafts stay together in one
+ * bucket instead of vanishing from the UI that uploaded them.
+ */
+export const DEFAULT_CHAT_UPLOAD_CONTEXT = 'default';
+
 export interface ImageFileState {
   chatContextSelectionsByContext: Record<string, ChatContextContent[]>;
-  chatUploadFileList: UploadFileItem[];
+  /**
+   * Pending composer uploads, keyed by the SAME context key as
+   * `chatContextSelectionsByContext` (`messageMapKey({agentId, groupId,
+   * topicId})`, or the home input's own key).
+   *
+   * Keyed rather than flat because a client renders more than one composer at a
+   * time — a split view, a second desktop tab, the portal — and a flat list made
+   * every one of them show the same pending file, send another composer's
+   * attachment with their own message, and clear each other's drafts.
+   */
+  chatUploadFileListByContext: Record<string, UploadFileItem[]>;
   uploadingIds: string[];
 }
 
 export const initialImageFileState: ImageFileState = {
   chatContextSelectionsByContext: {},
-  chatUploadFileList: [],
+  chatUploadFileListByContext: {},
   uploadingIds: [],
 };

--- a/src/store/file/slices/chat/selectors.test.ts
+++ b/src/store/file/slices/chat/selectors.test.ts
@@ -13,9 +13,9 @@ describe('filesSelectors', () => {
     it('should return the chatUploadFileList from state', () => {
       const state = {
         ...initialState,
-        chatUploadFileList: [{ id: '1' }] as UploadFileItem[],
+        chatUploadFileListByContext: { 'topic-a': [{ id: '1' }] as UploadFileItem[] },
       } as FilesStoreState;
-      expect(filesSelectors.chatUploadFileList(state)).toEqual([{ id: '1' }]);
+      expect(filesSelectors.chatUploadFileList('topic-a')(state)).toEqual([{ id: '1' }]);
     });
   });
 
@@ -72,13 +72,15 @@ describe('fileChatSelectors', () => {
   describe('chatRawFileList', () => {
     it('should return a list of raw files', () => {
       const state = {
-        chatUploadFileList: [
-          { file: { name: 'test1.jpg' } },
-          { file: { name: 'test2.jpg' } },
-        ] as UploadFileItem[],
-      } as FilesStoreState;
+        chatUploadFileListByContext: {
+          'topic-a': [
+            { file: { name: 'test1.jpg' } },
+            { file: { name: 'test2.jpg' } },
+          ] as UploadFileItem[],
+        },
+      } as unknown as FilesStoreState;
 
-      expect(fileChatSelectors.chatRawFileList(state)).toEqual([
+      expect(fileChatSelectors.chatRawFileList('topic-a')(state)).toEqual([
         { name: 'test1.jpg' },
         { name: 'test2.jpg' },
       ]);
@@ -86,55 +88,81 @@ describe('fileChatSelectors', () => {
   });
 
   describe('chatUploadFileList', () => {
-    it('should return the chatUploadFileList from state', () => {
+    it('should return only the requested conversation pending uploads', () => {
       const state = {
-        chatUploadFileList: [{ id: '1' }] as UploadFileItem[],
-      } as FilesStoreState;
-      expect(fileChatSelectors.chatUploadFileList(state)).toEqual([{ id: '1' }]);
+        chatUploadFileListByContext: {
+          'topic-a': [{ id: '1' }] as UploadFileItem[],
+          'topic-b': [{ id: '2' }] as UploadFileItem[],
+        },
+      } as unknown as FilesStoreState;
+
+      expect(fileChatSelectors.chatUploadFileList('topic-a')(state)).toEqual([{ id: '1' }]);
+      expect(fileChatSelectors.chatUploadFileList('topic-b')(state)).toEqual([{ id: '2' }]);
+      // A composer with nothing pending must not inherit its neighbour's draft.
+      expect(fileChatSelectors.chatUploadFileList('topic-c')(state)).toEqual([]);
+    });
+
+    it('returns the same empty list for an unknown conversation', () => {
+      const first = fileChatSelectors.chatUploadFileList('topic-a')(initialState);
+      const second = fileChatSelectors.chatUploadFileList('topic-b')(initialState);
+
+      expect(first).toBe(second);
     });
   });
 
   describe('chatUploadFileListHasItem', () => {
     it('should return true if chatUploadFileList has items', () => {
-      const state = { chatUploadFileList: [{ id: '1' }] as UploadFileItem[] } as FilesStoreState;
-      expect(fileChatSelectors.chatUploadFileListHasItem(state)).toBe(true);
+      const state = {
+        chatUploadFileListByContext: { 'topic-a': [{ id: '1' }] as UploadFileItem[] },
+      } as unknown as FilesStoreState;
+      expect(fileChatSelectors.chatUploadFileListHasItem('topic-a')(state)).toBe(true);
     });
 
     it('should return false if chatUploadFileList is empty', () => {
-      const state = { chatUploadFileList: [] as UploadFileItem[] } as FilesStoreState;
-      expect(fileChatSelectors.chatUploadFileListHasItem(state)).toBe(false);
+      const state = {
+        chatUploadFileListByContext: { 'topic-a': [] as UploadFileItem[] },
+      } as unknown as FilesStoreState;
+      expect(fileChatSelectors.chatUploadFileListHasItem('topic-a')(state)).toBe(false);
     });
   });
 
   describe('isUploadingFiles', () => {
     it('should return true if any file is in uploading status', () => {
       const state = {
-        chatUploadFileList: [
-          { status: Array.from(UPLOAD_STATUS_SET)[0] },
-          { status: 'completed' },
-        ] as UploadFileItem[],
-      } as FilesStoreState;
-      expect(fileChatSelectors.isUploadingFiles(state)).toBe(true);
+        chatUploadFileListByContext: {
+          'topic-a': [
+            { status: Array.from(UPLOAD_STATUS_SET)[0] },
+            { status: 'completed' },
+          ] as UploadFileItem[],
+        },
+      } as unknown as FilesStoreState;
+      expect(fileChatSelectors.isUploadingFiles('topic-a')(state)).toBe(true);
+      // Another composer must not be blocked by this one's upload.
+      expect(fileChatSelectors.isUploadingFiles('topic-b')(state)).toBe(false);
     });
 
     it('should return true if any file has unfinished embedding tasks', () => {
       const state = {
-        chatUploadFileList: [
-          { status: 'success', tasks: { finishEmbedding: false } },
-          { status: 'success', tasks: { finishEmbedding: true } },
-        ] as UploadFileItem[],
-      } as FilesStoreState;
-      expect(fileChatSelectors.isUploadingFiles(state)).toBe(true);
+        chatUploadFileListByContext: {
+          'topic-a': [
+            { status: 'success', tasks: { finishEmbedding: false } },
+            { status: 'success', tasks: { finishEmbedding: true } },
+          ] as UploadFileItem[],
+        },
+      } as unknown as FilesStoreState;
+      expect(fileChatSelectors.isUploadingFiles('topic-a')(state)).toBe(true);
     });
 
     it('should return false if no files are uploading or have unfinished tasks', () => {
-      const state: FilesStoreState = {
-        chatUploadFileList: [
-          { status: 'success', tasks: { finishEmbedding: true } },
-          { status: 'success' },
-        ] as UploadFileItem[],
-      } as FilesStoreState;
-      expect(fileChatSelectors.isUploadingFiles(state)).toBe(false);
+      const state = {
+        chatUploadFileListByContext: {
+          'topic-a': [
+            { status: 'success', tasks: { finishEmbedding: true } },
+            { status: 'success' },
+          ] as UploadFileItem[],
+        },
+      } as unknown as FilesStoreState;
+      expect(fileChatSelectors.isUploadingFiles('topic-a')(state)).toBe(false);
     });
   });
 });

--- a/src/store/file/slices/chat/selectors.ts
+++ b/src/store/file/slices/chat/selectors.ts
@@ -1,25 +1,39 @@
 import { type ChatContextContent } from '@lobechat/types';
 
-import { UPLOAD_STATUS_SET } from '@/types/files/upload';
+import { UPLOAD_STATUS_SET, type UploadFileItem } from '@/types/files/upload';
 
 import { type FilesStoreState } from '../../initialState';
+import { DEFAULT_CHAT_UPLOAD_CONTEXT } from './initialState';
 
 const EMPTY_CHAT_CONTEXT_SELECTIONS: ChatContextContent[] = [];
+const EMPTY_CHAT_UPLOAD_FILES: UploadFileItem[] = [];
 
-const chatUploadFileList = (s: FilesStoreState) => s.chatUploadFileList;
+/**
+ * Resolve the bucket a composer reads and writes.
+ *
+ * Shared by every selector and action so a host that has not been given a
+ * context key still reads back exactly what it uploaded.
+ */
+export const chatUploadContextKey = (contextKey?: string): string =>
+  contextKey || DEFAULT_CHAT_UPLOAD_CONTEXT;
+
+const chatUploadFileList = (contextKey?: string) => (s: FilesStoreState) =>
+  s.chatUploadFileListByContext[chatUploadContextKey(contextKey)] ?? EMPTY_CHAT_UPLOAD_FILES;
 const chatContextSelections = (contextKey?: string) => (s: FilesStoreState) =>
   contextKey
     ? (s.chatContextSelectionsByContext[contextKey] ?? EMPTY_CHAT_CONTEXT_SELECTIONS)
     : EMPTY_CHAT_CONTEXT_SELECTIONS;
 const isImageUploading = (s: FilesStoreState) => s.uploadingIds.length > 0;
 
-const chatRawFileList = (s: FilesStoreState) => s.chatUploadFileList.map((item) => item.file);
-const chatUploadFileListHasItem = (s: FilesStoreState) => s.chatUploadFileList.length > 0;
+const chatRawFileList = (contextKey?: string) => (s: FilesStoreState) =>
+  chatUploadFileList(contextKey)(s).map((item) => item.file);
+const chatUploadFileListHasItem = (contextKey?: string) => (s: FilesStoreState) =>
+  chatUploadFileList(contextKey)(s).length > 0;
 const chatContextSelectionHasItem = (contextKey?: string) => (s: FilesStoreState) =>
   contextKey ? (s.chatContextSelectionsByContext[contextKey]?.length ?? 0) > 0 : false;
 
-const isUploadingFiles = (s: FilesStoreState) =>
-  s.chatUploadFileList.some(
+const isUploadingFiles = (contextKey?: string) => (s: FilesStoreState) =>
+  chatUploadFileList(contextKey)(s).some(
     (file) =>
       // is file status in uploading
       UPLOAD_STATUS_SET.has(file.status) ||


### PR DESCRIPTION
`chatUploadFileList` was a single flat array while context selections had already moved to a per-context map, so every mounted composer shared one draft. With two composers on screen (split view, a second desktop tab, the portal):

1. **Display leaks** — both inputs render the same pending file.
2. **Data leaks** — sending from composer B attaches A's file (`handleSend` reads the global list) and `clearChatUploadFileList()` wipes A's draft.
3. **Mutual blocking** — `isUploadingFiles` is global, so A's upload disables B's send button.

#### What changed

- State becomes `chatUploadFileListByContext`, keyed by the SAME context key the selections use (`messageMapKey({agentId, groupId, topicId})`, or the home input's own key). Selectors and actions take that key; a host without one falls back to a single shared bucket, so nothing regresses for surfaces that predate the split.
- Every host that can put a file into a composer now names the composer it targets: the seven drop zones (`useUploadFiles`), the editor's paste handler, the `+` / upload menus, the browser sidebar screenshot (via the existing `composerTarget.contextKey`, so it also lands correctly inside a thread), restore-to-input, and the queue tray's edit.
- New `moveChatUploadFileList` carries the bucket across a topic mint — and its rollback, and the hetero key switch — alongside `moveChatContextSelections`. Without it a first-message attachment is stranded under the pre-mint key while the user watches it upload.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Store selectors/actions now assert per-bucket isolation (one composer's pending upload is invisible to another, clearing one leaves the other intact, `isUploadingFiles` no longer blocks a neighbour) plus the bucket move on topic mint. `restoreToInput` asserts the restore targets its own conversation's key. Ran the ChatInput, Conversation and file-store suites (482 tests) plus a full type-check.