### PR TITLE
🐛 fix(hetero): keep silent remote operations alive

### DIFF
--- a/apps/cli/src/commands/hetero.ts
+++ b/apps/cli/src/commands/hetero.ts
@@ -32,6 +32,7 @@ import type { Command } from 'commander';
 import { getTrpcClient } from '../api/client';
 import { CoalescingBatchIngester } from '../utils/CoalescingBatchIngester';
 import { log } from '../utils/logger';
+import { createOperationHeartbeat } from '../utils/OperationHeartbeat';
 import { TrpcIngestSink } from '../utils/TrpcIngestSink';
 
 export const SUPPORTED_AGENT_TYPES = new Set<string>(LOCAL_HETEROGENEOUS_AGENT_TYPES);
@@ -459,6 +460,14 @@ const exec = async (options: ExecOptions): Promise<void> => {
     });
   }
 
+  const operationHeartbeat =
+    serverIngester && operationId
+      ? createOperationHeartbeat({
+          operationId,
+          push: (event) => serverIngester.push(event),
+        })
+      : undefined;
+
   // ─── AskUserQuestion MCP — remote Human-in-the-loop ────────────────────────
   //
   // Mount the same `lobe_cc` MCP server the desktop app uses, but resolve the
@@ -740,6 +749,7 @@ const exec = async (options: ExecOptions): Promise<void> => {
           terminalErrorData = isHeteroStatusGuideErrorData(data) ? data : undefined;
         }
         if (emitJsonl) process.stdout.write(`${JSON.stringify(event)}\n`);
+        operationHeartbeat?.observe(event);
         serverIngester?.push(event);
       }
     } catch (err) {
@@ -882,6 +892,7 @@ const exec = async (options: ExecOptions): Promise<void> => {
   const { code, signal, sessionId } = result;
 
   if (serverIngester && sink) {
+    operationHeartbeat?.stop();
     try {
       await serverIngester.drain();
     } catch (err) {

--- a/apps/cli/src/utils/OperationHeartbeat.test.ts
+++ b/apps/cli/src/utils/OperationHeartbeat.test.ts
@@ -1,0 +1,44 @@
+import type { AgentStreamEvent } from '@lobechat/heterogeneous-agents/spawn';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createOperationHeartbeat } from './OperationHeartbeat';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('createOperationHeartbeat', () => {
+  it('renews a silent operation using the latest observed step', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-21T08:00:00.000Z'));
+    const events: AgentStreamEvent[] = [];
+    const heartbeat = createOperationHeartbeat({
+      intervalMs: 1000,
+      operationId: 'op-test',
+      push: (event) => events.push(event),
+    });
+
+    heartbeat.observe({
+      data: {},
+      operationId: 'op-test',
+      stepIndex: 4,
+      timestamp: Date.now(),
+      type: 'stream_chunk',
+    });
+    vi.advanceTimersByTime(1000);
+
+    expect(events).toEqual([
+      {
+        data: { phase: 'operation_heartbeat' },
+        operationId: 'op-test',
+        stepIndex: 4,
+        timestamp: Date.now(),
+        type: 'step_complete',
+      },
+    ]);
+
+    heartbeat.stop();
+    vi.advanceTimersByTime(1000);
+    expect(events).toHaveLength(1);
+  });
+});

--- a/apps/cli/src/utils/OperationHeartbeat.ts
+++ b/apps/cli/src/utils/OperationHeartbeat.ts
@@ -1,0 +1,44 @@
+import type { AgentStreamEvent } from '@lobechat/heterogeneous-agents/spawn';
+
+const DEFAULT_OPERATION_HEARTBEAT_INTERVAL_MS = 30_000;
+
+interface OperationHeartbeatOptions {
+  intervalMs?: number;
+  operationId: string;
+  push: (event: AgentStreamEvent) => void;
+}
+
+/**
+ * Keep a remote heterogeneous operation active while its CLI is legitimately
+ * silent (for example, while a long-running shell command produces no output).
+ *
+ * The heartbeat rides `step_complete` with a dedicated phase because the
+ * gateway worker lives outside this repository. Existing consumers already
+ * ignore unknown phases, while the Redis stream write still renews the
+ * gateway's inactivity watchdog.
+ */
+export const createOperationHeartbeat = ({
+  intervalMs = DEFAULT_OPERATION_HEARTBEAT_INTERVAL_MS,
+  operationId,
+  push,
+}: OperationHeartbeatOptions) => {
+  let lastStepIndex = 0;
+
+  const timer = setInterval(() => {
+    push({
+      data: { phase: 'operation_heartbeat' },
+      operationId,
+      stepIndex: lastStepIndex,
+      timestamp: Date.now(),
+      type: 'step_complete',
+    });
+  }, intervalMs);
+  timer.unref?.();
+
+  return {
+    observe: (event: AgentStreamEvent) => {
+      lastStepIndex = Math.max(lastStepIndex, event.stepIndex);
+    },
+    stop: () => clearInterval(timer),
+  };
+};

--- a/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.eventBranches.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.eventBranches.test.ts
@@ -752,6 +752,7 @@ describe('HeterogeneousPersistenceHandler — event branch coverage', () => {
       ['tool_end', { isSuccess: true, toolCallId: 'tc-1' }],
       ['stream_end', {}],
       ['agent_runtime_init', { state: 'idle' }],
+      ['step_complete', { phase: 'operation_heartbeat' }],
       ['tool_execute', { apiName: 'Read', toolCallId: 'tc-1' }],
       ['stream_retry', { attempt: 1 }],
     ])('drops %s without DB writes', async (type, data) => {

--- a/packages/agent-gateway-client/src/types.ts
+++ b/packages/agent-gateway-client/src/types.ts
@@ -183,6 +183,17 @@ export interface SubAgentProgressData extends StepCompleteData {
 }
 
 /**
+ * A heterogeneous CLI lease renewal carried by `step_complete` while the
+ * underlying process is alive but has no user-visible output. It deliberately
+ * uses a phase instead of a new event type so the out-of-repo gateway worker
+ * can treat the stream write as activity without a coordinated protocol
+ * rollout. UI and persistence consumers ignore this advisory event.
+ */
+export interface OperationHeartbeatData extends StepCompleteData {
+  phase: 'operation_heartbeat';
+}
+
+/**
  * Producer → consumer: structured-input request the user must answer
  * directly (no tool execution involved). The producer's tool handler stays
  * blocked until a matching `agent_intervention_response` (correlated by


### PR DESCRIPTION
## Summary

- renew remote heterogeneous operations every 30 seconds while the CLI process is alive
- carry the lease renewal as a no-op `step_complete` phase so the external gateway protocol needs no coordinated rollout
- stop heartbeats before draining and finishing the operation to prevent terminal-state renewal
- preserve existing stale-operation guards against cross-run writes

## Why

Remote Claude Code/Codex runs can legitimately remain silent while executing a long-running command. The gateway inactivity watchdog currently interprets the missing stream activity as an abandoned operation, clears `runningOperation`, and causes later ingest/finish callbacks from the still-running CLI to be rejected as stale.

## Test plan

- `bun run check apps/cli/src/commands/hetero.ts apps/cli/src/utils/OperationHeartbeat.ts apps/cli/src/utils/OperationHeartbeat.test.ts packages/agent-gateway-client/src/types.ts apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.eventBranches.test.ts`
- 94 related tests passed
- regression coverage verifies periodic renewal, latest-step tracking, timer shutdown, and no DB writes for heartbeat events