### PR TITLE
🐛 fix(hetero): avoid killing silent Claude SDK runs

### DIFF
--- a/packages/heterogeneous-agents/src/spawn/claudeAgentSdkSession.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/claudeAgentSdkSession.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ClaudeAgentSdkSession } from './claudeAgentSdkSession';
+
+const { closeQuery, query } = vi.hoisted(() => ({
+  closeQuery: vi.fn(),
+  query: vi.fn(),
+}));
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({ query }));
+
+describe('ClaudeAgentSdkSession', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubEnv('LOBE_CLAUDE_CODE_SDK_INACTIVITY_TIMEOUT_MS', '10');
+    closeQuery.mockReset();
+    query.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+  });
+
+  it('reports a silent query as stale without terminating it', async () => {
+    let resolveNext: ((result: IteratorResult<unknown>) => void) | undefined;
+    const next = vi.fn(
+      () =>
+        new Promise<IteratorResult<unknown>>((resolve) => {
+          resolveNext = resolve;
+        }),
+    );
+    closeQuery.mockImplementation(() => resolveNext?.({ done: true, value: undefined }));
+    query.mockReturnValue({
+      [Symbol.asyncIterator]: () => ({ next }),
+      close: closeQuery,
+    });
+
+    const statuses: string[] = [];
+    const session = new ClaudeAgentSdkSession({
+      args: [],
+      commandPath: '/usr/local/bin/claude',
+      cwd: '/tmp',
+      env: {},
+      onEvents: vi.fn(),
+      onRawMessage: vi.fn(),
+      onRuntimeStatus: ({ state }) => statuses.push(state),
+      onSessionId: vi.fn(),
+      onStderr: vi.fn(),
+      operationId: 'op-test',
+      sessionId: 'session-test',
+      stdinPayload: '{"type":"user","message":{"role":"user","content":"test"}}',
+    });
+
+    const run = session.run();
+    await vi.waitFor(() => expect(query).toHaveBeenCalledOnce());
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(statuses).toContain('stale');
+    expect(closeQuery).not.toHaveBeenCalled();
+
+    session.close();
+    await run;
+    expect(closeQuery).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/heterogeneous-agents/src/spawn/claudeAgentSdkSession.ts
+++ b/packages/heterogeneous-agents/src/spawn/claudeAgentSdkSession.ts
@@ -143,7 +143,6 @@ export class ClaudeAgentSdkSession {
   private readonly abortController = new AbortController();
   private activeTasks = new Map<string, TrackedTask>();
   private closeInput = false;
-  private closeReason: Error | undefined;
   private closedByHost = false;
   private inactivityTimer: NodeJS.Timeout | undefined;
   private lastEventAt = Date.now();
@@ -182,7 +181,6 @@ export class ClaudeAgentSdkSession {
 
       await this.flushPipeline();
 
-      if (this.closeReason) throw this.closeReason;
       if (!this.sawErrorEvent) {
         await this.options.onEvents(
           this.pipeline.completeRuntime({
@@ -199,9 +197,8 @@ export class ClaudeAgentSdkSession {
         return;
       }
 
-      const normalizedError = this.closeReason ?? error;
       this.emitStatus('error');
-      throw normalizedError;
+      throw error;
     } finally {
       this.clearInactivityTimer();
       this.closeInput = true;
@@ -369,11 +366,12 @@ export class ClaudeAgentSdkSession {
   private armInactivityTimer(): void {
     this.clearInactivityTimer();
     this.inactivityTimer = setTimeout(() => {
-      this.closeReason = new Error(
-        `Claude SDK session produced no messages for ${this.inactivityTimeoutMs}ms`,
-      );
+      // Silence is not proof that the SDK query died: a foreground Bash/tool
+      // call can legitimately produce no SDK messages for many minutes. Keep
+      // the process alive and surface `stale` as an advisory host status. A
+      // later SDK message re-arms this timer and restores running/monitoring;
+      // explicit user stop, SDK completion, and real errors still terminate.
       this.emitStatus('stale');
-      this.close();
     }, this.inactivityTimeoutMs);
     this.inactivityTimer.unref?.();
   }


### PR DESCRIPTION
## Summary

- treat the Claude SDK inactivity threshold as an advisory stale signal instead of a terminal failure
- keep silent foreground tools and long-running Bash commands alive after the five-minute threshold
- preserve explicit user stop, normal SDK completion, and real error termination behavior
- add regression coverage proving a stale session remains active until explicitly closed

## Why

The desktop-local Claude SDK transport previously closed the SDK query after five minutes without an SDK message. A healthy foreground tool can legitimately remain silent longer than that, so inactivity alone cannot distinguish a long-running command from a dead process. The forced close could therefore discard an otherwise successful local heterogeneous-agent run.

## Test plan

- `bun run check packages/heterogeneous-agents/src/spawn/claudeAgentSdkSession.ts packages/heterogeneous-agents/src/spawn/claudeAgentSdkSession.test.ts`
- regression test verifies that the session reports `stale` without closing the query, then still responds to an explicit host close