### PR TITLE
⚡️ perf(dictation): streamline realtime ASR admission

### DIFF
--- a/src/features/ChatInput/Dictation/client.test.ts
+++ b/src/features/ChatInput/Dictation/client.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { RealtimeAudioCapture } from './audio';
-import { type RealtimeAsrWebSocket, RealtimeDictationClient } from './client';
+import type { RealtimeAsrWebSocket, RealtimeDictationTiming } from './client';
+import { REALTIME_DICTATION_PERFORMANCE_MARKS, RealtimeDictationClient } from './client';
 import {
   REALTIME_ASR_AUDIO,
   REALTIME_ASR_LIMITS,
@@ -10,6 +11,15 @@ import {
   RealtimeDictationError,
 } from './contract';
 import type { DictationEditorAdapter } from './editor';
+
+const SESSION_ID = '00000000-0000-4000-8000-000000000001';
+const OLD_SESSION_ID = '00000000-0000-4000-8000-000000000002';
+const FRESH_SESSION_ID = '00000000-0000-4000-8000-000000000003';
+const TEST_JWT = [
+  'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9',
+  'eyJzdWIiOiJ1c2VyLTEifQ',
+  'c2lnbmF0dXJl',
+].join('.');
 
 class FakeSocket {
   binaryType: BinaryType = 'blob';
@@ -32,9 +42,9 @@ class FakeSocket {
     this.sent.push(data);
   }
 
-  close() {
+  close = vi.fn(() => {
     this.readyState = 3;
-  }
+  });
 
   open() {
     this.readyState = 1;
@@ -55,22 +65,28 @@ class FakeSocket {
   }
 }
 
-const session = (): RealtimeAsrSessionResponse => ({
-  audio: REALTIME_ASR_AUDIO,
-  expiresAt: new Date(Date.now() + 30_000).toISOString(),
-  limits: REALTIME_ASR_LIMITS,
-  protocolVersion: 1,
-  sessionId: 'session-1',
-  token: 'a'.repeat(43),
-  websocketUrl: 'wss://asr.example.test/v1/session',
-});
+const session = (
+  overrides: Partial<RealtimeAsrSessionResponse> = {},
+): RealtimeAsrSessionResponse => {
+  const sessionId = overrides.sessionId ?? SESSION_ID;
+  return {
+    audio: REALTIME_ASR_AUDIO,
+    expiresAt: new Date(Date.now() + 30_000).toISOString(),
+    limits: REALTIME_ASR_LIMITS,
+    protocolVersion: 1,
+    sessionId,
+    token: TEST_JWT,
+    websocketUrl: `wss://asr.example.test/api/v1/realtime/ws?sessionId=${sessionId}`,
+    ...overrides,
+  };
+};
 
 const ready = (sequence = 1): RealtimeAsrServerEvent => ({
   audio: REALTIME_ASR_AUDIO,
   limits: REALTIME_ASR_LIMITS,
   protocolVersion: 1,
   sequence,
-  sessionId: 'session-1',
+  sessionId: SESSION_ID,
   type: 'session.ready',
 });
 
@@ -125,9 +141,13 @@ const createFixture = () => {
 };
 
 describe('RealtimeDictationClient', () => {
-  afterEach(() => vi.useRealTimers());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
 
-  it('starts audio initialization and session admission together after permission', async () => {
+  it('starts permission and Admission together but waits for capture before opening the WS', async () => {
+    let resolvePermission!: (stream: MediaStream) => void;
     let resolveCapture!: (capture: RealtimeAudioCapture) => void;
     let resolveSession!: (session: RealtimeAsrSessionResponse) => void;
     const capture: RealtimeAudioCapture = {
@@ -141,8 +161,62 @@ describe('RealtimeDictationClient', () => {
     const sessionPromise = new Promise<RealtimeAsrSessionResponse>((resolve) => {
       resolveSession = resolve;
     });
+    const permissionPromise = new Promise<MediaStream>((resolve) => {
+      resolvePermission = resolve;
+    });
     const createCapture = vi.fn(() => capturePromise);
     const createSession = vi.fn(() => sessionPromise);
+    const createWebSocket = vi.fn(() => new FakeSocket() as unknown as RealtimeAsrWebSocket);
+    const stream = { getTracks: () => [] } as unknown as MediaStream;
+    const client = new RealtimeDictationClient({
+      createCapture,
+      createSession,
+      createWebSocket,
+      editor: {
+        begin: vi.fn(() => ({ anchor: 0, prefix: '', suffix: '' })),
+        dispose: vi.fn(),
+        finalize: vi.fn(),
+        render: vi.fn(),
+      },
+      requestMicrophone: vi.fn(() => permissionPromise),
+    });
+
+    const startPromise = client.start();
+    await vi.waitFor(() => {
+      expect(createSession).toHaveBeenCalledOnce();
+      expect(client.getSnapshot().status).toBe('requesting_permission');
+    });
+    expect(createCapture).not.toHaveBeenCalled();
+    expect(createWebSocket).not.toHaveBeenCalled();
+
+    resolveSession(session());
+    await vi.waitFor(() => expect(createSession).toHaveBeenCalledOnce());
+    expect(createWebSocket).not.toHaveBeenCalled();
+
+    resolvePermission(stream);
+    await vi.waitFor(() => expect(createCapture).toHaveBeenCalledOnce());
+    expect(createWebSocket).not.toHaveBeenCalled();
+
+    resolveCapture(capture);
+    await startPromise;
+
+    expect(createWebSocket).toHaveBeenCalledOnce();
+    expect(capture.start).not.toHaveBeenCalled();
+    expect(client.getSnapshot().status).toBe('connecting');
+  });
+
+  it('aborts Admission and stops a late microphone stream when cancelled during permission', async () => {
+    let admissionSignal!: AbortSignal;
+    let resolvePermission!: (stream: MediaStream) => void;
+    let resolveSession!: (session: RealtimeAsrSessionResponse) => void;
+    const track = { stop: vi.fn() };
+    const createCapture = vi.fn();
+    const createSession = vi.fn((signal: AbortSignal) => {
+      admissionSignal = signal;
+      return new Promise<RealtimeAsrSessionResponse>((resolve) => {
+        resolveSession = resolve;
+      });
+    });
     const createWebSocket = vi.fn(() => new FakeSocket() as unknown as RealtimeAsrWebSocket);
     const client = new RealtimeDictationClient({
       createCapture,
@@ -154,23 +228,65 @@ describe('RealtimeDictationClient', () => {
         finalize: vi.fn(),
         render: vi.fn(),
       },
-      requestMicrophone: vi
-        .fn()
-        .mockResolvedValue({ getTracks: () => [] } as unknown as MediaStream),
+      requestMicrophone: vi.fn(
+        () =>
+          new Promise<MediaStream>((resolve) => {
+            resolvePermission = resolve;
+          }),
+      ),
     });
 
     const startPromise = client.start();
-    await vi.waitFor(() => {
-      expect(createCapture).toHaveBeenCalledOnce();
-      expect(createSession).toHaveBeenCalledOnce();
-    });
+    await vi.waitFor(() => expect(createSession).toHaveBeenCalledOnce());
 
-    resolveCapture(capture);
+    await client.cancel();
+    expect(admissionSignal.aborted).toBe(true);
+    expect(client.getSnapshot().status).toBe('idle');
+
     resolveSession(session());
+    resolvePermission({ getTracks: () => [track] } as unknown as MediaStream);
     await startPromise;
 
-    expect(createWebSocket).toHaveBeenCalledOnce();
-    expect(client.getSnapshot().status).toBe('connecting');
+    expect(track.stop).toHaveBeenCalledOnce();
+    expect(createCapture).not.toHaveBeenCalled();
+    expect(createWebSocket).not.toHaveBeenCalled();
+  });
+
+  it('handles a late Admission after permission is denied without opening the WS', async () => {
+    let resolveSession!: (session: RealtimeAsrSessionResponse) => void;
+    const sessionPromise = new Promise<RealtimeAsrSessionResponse>((resolve) => {
+      resolveSession = resolve;
+    });
+    const createSession = vi.fn(() => sessionPromise);
+    const createWebSocket = vi.fn(() => new FakeSocket() as unknown as RealtimeAsrWebSocket);
+    const client = new RealtimeDictationClient({
+      createCapture: vi.fn(),
+      createSession,
+      createWebSocket,
+      editor: {
+        begin: vi.fn(() => ({ anchor: 0, prefix: '', suffix: '' })),
+        dispose: vi.fn(),
+        finalize: vi.fn(),
+        render: vi.fn(),
+      },
+      requestMicrophone: vi
+        .fn()
+        .mockRejectedValue(new DOMException('Permission denied', 'NotAllowedError')),
+    });
+
+    await client.start();
+
+    expect(createSession).toHaveBeenCalledOnce();
+    expect(client.getSnapshot()).toMatchObject({
+      errorCode: 'MICROPHONE_PERMISSION_DENIED',
+      retryable: true,
+      status: 'error',
+    });
+    expect(createWebSocket).not.toHaveBeenCalled();
+
+    resolveSession(session());
+    await Promise.resolve();
+    expect(createWebSocket).not.toHaveBeenCalled();
   });
 
   it('releases a late audio capture when concurrent session admission fails', async () => {
@@ -218,20 +334,20 @@ describe('RealtimeDictationClient', () => {
 
     expect(JSON.parse(fixture.socket.sent[0] as string)).toEqual({
       protocolVersion: 1,
-      token: 'a'.repeat(43),
+      token: TEST_JWT,
       type: 'session.auth',
     });
     fixture.socket.serverEvent({
       segmentId: 'segment-1',
       sequence: 2,
-      sessionId: 'session-1',
+      sessionId: SESSION_ID,
       text: 'hel',
       type: 'transcript.partial',
     });
     fixture.socket.serverEvent({
       segmentId: 'segment-1',
       sequence: 3,
-      sessionId: 'session-1',
+      sessionId: SESSION_ID,
       text: 'hello',
       type: 'transcript.final',
     });
@@ -244,12 +360,214 @@ describe('RealtimeDictationClient', () => {
     fixture.socket.serverEvent({
       forwardedAudioMs: 200,
       sequence: 4,
-      sessionId: 'session-1',
+      sessionId: SESSION_ID,
       type: 'session.completed',
     });
     await vi.waitFor(() => expect(fixture.client.getSnapshot().status).toBe('idle'));
     expect(fixture.editor.finalize).toHaveBeenCalledOnce();
     expect(fixture.editor.finalize).toHaveBeenCalledWith('hello');
+  });
+
+  it('refreshes an Admission that became too close to expiry while permission was pending', async () => {
+    let resolvePermission!: (stream: MediaStream) => void;
+    let timingNow = 0;
+    let wallClockNow = 100_000;
+    const timings: RealtimeDictationTiming[] = [];
+    const socket = new FakeSocket();
+    const firstSession = session({
+      expiresAt: new Date(130_000).toISOString(),
+      sessionId: OLD_SESSION_ID,
+      token: 'old.header.signature',
+    });
+    const freshSession = session({
+      expiresAt: new Date(160_000).toISOString(),
+      sessionId: FRESH_SESSION_ID,
+      token: 'fresh.header.signature',
+    });
+    const createSession = vi
+      .fn()
+      .mockResolvedValueOnce(firstSession)
+      .mockResolvedValueOnce(freshSession);
+    const createWebSocket = vi.fn(() => socket as unknown as RealtimeAsrWebSocket);
+    const client = new RealtimeDictationClient({
+      createCapture: vi.fn().mockResolvedValue({
+        cancel: vi.fn().mockResolvedValue(undefined),
+        start: vi.fn().mockResolvedValue(undefined),
+        stop: vi.fn().mockResolvedValue(undefined),
+      }),
+      createSession,
+      createWebSocket,
+      editor: {
+        begin: vi.fn(() => ({ anchor: 0, prefix: '', suffix: '' })),
+        dispose: vi.fn(),
+        finalize: vi.fn(),
+        render: vi.fn(),
+      },
+      now: () => timingNow,
+      onTiming: (timing) => timings.push(timing),
+      requestMicrophone: vi.fn(
+        () =>
+          new Promise<MediaStream>((resolve) => {
+            resolvePermission = resolve;
+          }),
+      ),
+      wallClockNow: () => wallClockNow,
+    });
+
+    const startPromise = client.start();
+    await vi.waitFor(() => expect(createSession).toHaveBeenCalledOnce());
+    expect(createWebSocket).not.toHaveBeenCalled();
+
+    wallClockNow = 129_500;
+    timingNow = 40;
+    resolvePermission({ getTracks: () => [] } as unknown as MediaStream);
+    await startPromise;
+
+    expect(createSession).toHaveBeenCalledTimes(2);
+    expect(createWebSocket).toHaveBeenCalledOnce();
+    expect(createWebSocket).toHaveBeenCalledWith(freshSession.websocketUrl);
+    expect(timings.filter(({ stage }) => stage.startsWith('admission'))).toEqual([
+      { durationMs: 0, stage: 'admission' },
+      { durationMs: 40, stage: 'admission_refresh' },
+    ]);
+    socket.open();
+    expect(JSON.parse(socket.sent[0] as string)).toMatchObject({ token: freshSession.token });
+  });
+
+  it('fails without opening the WS when the single refreshed Admission is still expiring', async () => {
+    const capture: RealtimeAudioCapture = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const staleSession = session({ expiresAt: new Date(100_500).toISOString() });
+    const createSession = vi.fn().mockResolvedValue(staleSession);
+    const createWebSocket = vi.fn(() => new FakeSocket() as unknown as RealtimeAsrWebSocket);
+    const client = new RealtimeDictationClient({
+      createCapture: vi.fn().mockResolvedValue(capture),
+      createSession,
+      createWebSocket,
+      editor: {
+        begin: vi.fn(() => ({ anchor: 0, prefix: '', suffix: '' })),
+        dispose: vi.fn(),
+        finalize: vi.fn(),
+        render: vi.fn(),
+      },
+      requestMicrophone: vi
+        .fn()
+        .mockResolvedValue({ getTracks: () => [] } as unknown as MediaStream),
+      wallClockNow: () => 100_000,
+    });
+
+    await client.start();
+
+    expect(createSession).toHaveBeenCalledTimes(2);
+    expect(createWebSocket).not.toHaveBeenCalled();
+    expect(capture.cancel).toHaveBeenCalledOnce();
+    expect(client.getSnapshot()).toEqual({
+      errorCode: 'SESSION_EXPIRED',
+      retryable: true,
+      status: 'error',
+    });
+  });
+
+  it('reports content-free stage timings relative to start and emits fixed performance marks', async () => {
+    let clock = 100;
+    let resolveCapture!: (capture: RealtimeAudioCapture) => void;
+    let resolvePermission!: (stream: MediaStream) => void;
+    let resolveSession!: (session: RealtimeAsrSessionResponse) => void;
+    const timings: RealtimeDictationTiming[] = [];
+    const socket = new FakeSocket();
+    const capture: RealtimeAudioCapture = {
+      cancel: vi.fn().mockResolvedValue(undefined),
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const markSpy = vi.spyOn(performance, 'mark');
+    const client = new RealtimeDictationClient({
+      createCapture: vi.fn(
+        () =>
+          new Promise<RealtimeAudioCapture>((resolve) => {
+            resolveCapture = resolve;
+          }),
+      ),
+      createSession: vi.fn(
+        () =>
+          new Promise<RealtimeAsrSessionResponse>((resolve) => {
+            resolveSession = resolve;
+          }),
+      ),
+      createWebSocket: vi.fn(() => socket as unknown as RealtimeAsrWebSocket),
+      editor: {
+        begin: vi.fn(() => ({ anchor: 0, prefix: '', suffix: '' })),
+        dispose: vi.fn(),
+        finalize: vi.fn(),
+        render: vi.fn(),
+      },
+      now: () => clock,
+      onTiming: (timing) => timings.push(timing),
+      requestMicrophone: vi.fn(
+        () =>
+          new Promise<MediaStream>((resolve) => {
+            resolvePermission = resolve;
+          }),
+      ),
+    });
+
+    const startPromise = client.start();
+    await vi.waitFor(() => expect(resolveSession).toBeTypeOf('function'));
+
+    clock = 120;
+    resolveSession(session());
+    await vi.waitFor(() => expect(timings).toEqual([{ durationMs: 20, stage: 'admission' }]));
+
+    clock = 140;
+    resolvePermission({ getTracks: () => [] } as unknown as MediaStream);
+    await vi.waitFor(() =>
+      expect(timings).toEqual([
+        { durationMs: 20, stage: 'admission' },
+        { durationMs: 40, stage: 'permission' },
+      ]),
+    );
+
+    clock = 160;
+    resolveCapture(capture);
+    await startPromise;
+    expect(timings.at(-1)).toEqual({ durationMs: 60, stage: 'capture' });
+
+    socket.open();
+    clock = 200;
+    socket.serverEvent(ready());
+    await vi.waitFor(() => expect(client.getSnapshot().status).toBe('listening'));
+
+    expect(timings).toEqual([
+      { durationMs: 20, stage: 'admission' },
+      { durationMs: 40, stage: 'permission' },
+      { durationMs: 60, stage: 'capture' },
+      { durationMs: 100, stage: 'ws_ready' },
+    ]);
+    expect(markSpy.mock.calls.map(([mark]) => mark)).toEqual([
+      REALTIME_DICTATION_PERFORMANCE_MARKS.start,
+      REALTIME_DICTATION_PERFORMANCE_MARKS.admission,
+      REALTIME_DICTATION_PERFORMANCE_MARKS.permission,
+      REALTIME_DICTATION_PERFORMANCE_MARKS.capture,
+      REALTIME_DICTATION_PERFORMANCE_MARKS.ws_ready,
+    ]);
+  });
+
+  it('closes an open pre-ready socket without sending cancel or waiting for a terminal event', async () => {
+    const fixture = createFixture();
+    await fixture.client.start();
+    fixture.socket.open();
+
+    expect(fixture.client.getSnapshot().status).toBe('connecting');
+    expect(fixture.socket.sent).toHaveLength(1);
+
+    await fixture.client.cancel();
+
+    expect(fixture.client.getSnapshot().status).toBe('idle');
+    expect(fixture.socket.sent).toHaveLength(1);
+    expect(fixture.socket.close).toHaveBeenCalledWith(1000, 'dictation_finished');
   });
 
   it('keeps final text and drops only partial text on cancel', async () => {
@@ -258,14 +576,14 @@ describe('RealtimeDictationClient', () => {
     fixture.socket.serverEvent({
       segmentId: 'segment-1',
       sequence: 2,
-      sessionId: 'session-1',
+      sessionId: SESSION_ID,
       text: 'confirmed',
       type: 'transcript.final',
     });
     fixture.socket.serverEvent({
       segmentId: 'segment-2',
       sequence: 3,
-      sessionId: 'session-1',
+      sessionId: SESSION_ID,
       text: 'temporary',
       type: 'transcript.partial',
     });
@@ -277,10 +595,39 @@ describe('RealtimeDictationClient', () => {
       reason: 'user_cancelled',
       type: 'session.cancel',
     });
+    expect(fixture.client.getSnapshot().status).toBe('finalizing');
+    expect(fixture.socket.close).not.toHaveBeenCalled();
     fixture.socket.serverEvent({
       forwardedAudioMs: 400,
       sequence: 4,
-      sessionId: 'session-1',
+      sessionId: SESSION_ID,
+      type: 'session.cancelled',
+    });
+    await vi.waitFor(() => expect(fixture.client.getSnapshot().status).toBe('idle'));
+    expect(fixture.socket.close).toHaveBeenCalledWith(1000, 'dictation_finished');
+  });
+
+  it('keeps the ready session finalizing when cancel replaces an in-flight end', async () => {
+    const fixture = createFixture();
+    await fixture.start();
+    await fixture.client.stop();
+
+    expect(fixture.client.getSnapshot().status).toBe('finalizing');
+    expect(JSON.parse(fixture.socket.sent.at(-1) as string)).toEqual({ type: 'session.end' });
+
+    await fixture.client.cancel('audio_interruption');
+
+    expect(fixture.client.getSnapshot().status).toBe('finalizing');
+    expect(JSON.parse(fixture.socket.sent.at(-1) as string)).toEqual({
+      reason: 'audio_interruption',
+      type: 'session.cancel',
+    });
+    expect(fixture.socket.close).not.toHaveBeenCalled();
+
+    fixture.socket.serverEvent({
+      forwardedAudioMs: 0,
+      sequence: 2,
+      sessionId: SESSION_ID,
       type: 'session.cancelled',
     });
     await vi.waitFor(() => expect(fixture.client.getSnapshot().status).toBe('idle'));
@@ -292,28 +639,28 @@ describe('RealtimeDictationClient', () => {
     fixture.socket.serverEvent({
       segmentId: 'segment-1',
       sequence: 2,
-      sessionId: 'old-session',
+      sessionId: OLD_SESSION_ID,
       text: 'old',
       type: 'transcript.partial',
     });
     fixture.socket.serverEvent({
       segmentId: 'segment-1',
       sequence: 3,
-      sessionId: 'session-1',
+      sessionId: SESSION_ID,
       text: 'new',
       type: 'transcript.partial',
     });
     fixture.socket.serverEvent({
       segmentId: 'segment-1',
       sequence: 3,
-      sessionId: 'session-1',
+      sessionId: SESSION_ID,
       text: 'duplicate',
       type: 'transcript.partial',
     });
     fixture.socket.serverEvent({
       segmentId: 'segment-1',
       sequence: 2,
-      sessionId: 'session-1',
+      sessionId: SESSION_ID,
       text: 'out-of-order',
       type: 'transcript.final',
     });
@@ -328,7 +675,7 @@ describe('RealtimeDictationClient', () => {
     fixture.socket.serverEvent({
       segmentId: 'segment-1',
       sequence: 2,
-      sessionId: 'session-1',
+      sessionId: SESSION_ID,
       text: 'confirmed',
       type: 'transcript.final',
     });
@@ -350,7 +697,7 @@ describe('RealtimeDictationClient', () => {
     fixture.socket.serverEvent({
       segmentId: 'segment-1',
       sequence: 2,
-      sessionId: 'session-1',
+      sessionId: SESSION_ID,
       text: 'confirmed',
       type: 'transcript.final',
     });
@@ -370,7 +717,7 @@ describe('RealtimeDictationClient', () => {
     fixture.socket.serverEvent({
       segmentId: 'segment-1',
       sequence: 2,
-      sessionId: 'session-1',
+      sessionId: SESSION_ID,
       text: 'temporary',
       type: 'transcript.partial',
     });
@@ -378,7 +725,7 @@ describe('RealtimeDictationClient', () => {
       code: 'PROVIDER_CAPACITY',
       retryable: true,
       sequence: 3,
-      sessionId: 'session-1',
+      sessionId: SESSION_ID,
       type: 'session.error',
     });
 

--- a/src/features/ChatInput/Dictation/client.ts
+++ b/src/features/ChatInput/Dictation/client.ts
@@ -1,17 +1,36 @@
 import type { RealtimeAudioCapture } from './audio';
+import type {
+  RealtimeAsrSessionResponse,
+  RealtimeDictationErrorCode,
+  RealtimeDictationSnapshot,
+} from './contract';
 import {
   parseRealtimeAsrServerEvent,
   REALTIME_ASR_PROTOCOL_VERSION,
-  type RealtimeAsrSessionResponse,
   RealtimeDictationError,
-  type RealtimeDictationErrorCode,
-  type RealtimeDictationSnapshot,
 } from './contract';
-import { type DictationEditorAdapter } from './editor';
+import type { DictationEditorAdapter } from './editor';
 import { BoundedWebSocketFrameQueue } from './frameQueue';
 import { DictationTranscript } from './transcript';
 
 export type DictationCancelReason = 'audio_interruption' | 'network_change' | 'user_cancelled';
+
+export type RealtimeDictationTimingStage =
+  'admission' | 'admission_refresh' | 'capture' | 'permission' | 'ws_ready';
+
+export interface RealtimeDictationTiming {
+  durationMs: number;
+  stage: RealtimeDictationTimingStage;
+}
+
+export const REALTIME_DICTATION_PERFORMANCE_MARKS = {
+  admission: 'lobe:voice-dictation:admission',
+  admission_refresh: 'lobe:voice-dictation:admission_refresh',
+  capture: 'lobe:voice-dictation:capture',
+  permission: 'lobe:voice-dictation:permission',
+  start: 'lobe:voice-dictation:start',
+  ws_ready: 'lobe:voice-dictation:ws_ready',
+} as const;
 
 export interface RealtimeAsrWebSocket {
   addEventListener: ((type: 'close' | 'error' | 'open', listener: () => void) => void) &
@@ -30,7 +49,10 @@ export interface RealtimeDictationDependencies {
   createSession: (signal: AbortSignal) => Promise<RealtimeAsrSessionResponse>;
   createWebSocket: (url: string) => RealtimeAsrWebSocket;
   editor: DictationEditorAdapter;
+  now?: () => number;
+  onTiming?: (timing: RealtimeDictationTiming) => void;
   requestMicrophone: () => Promise<MediaStream>;
+  wallClockNow?: () => number;
 }
 
 const IDLE_SNAPSHOT: RealtimeDictationSnapshot = {
@@ -40,6 +62,36 @@ const IDLE_SNAPSHOT: RealtimeDictationSnapshot = {
 
 const SOCKET_CONNECTING = 0;
 const SOCKET_OPEN = 1;
+const ADMISSION_EXPIRY_SAFETY_MS = 1000;
+
+const getMonotonicNow = () => (typeof performance === 'undefined' ? Date.now() : performance.now());
+
+const clearPerformanceMarks = () => {
+  if (typeof performance === 'undefined' || typeof performance.clearMarks !== 'function') return;
+
+  try {
+    for (const mark of Object.values(REALTIME_DICTATION_PERFORMANCE_MARKS)) {
+      performance.clearMarks(mark);
+    }
+  } catch (error) {
+    void error;
+  }
+};
+
+const markPerformance = (stage: RealtimeDictationTimingStage | 'start') => {
+  if (typeof performance === 'undefined' || typeof performance.mark !== 'function') return;
+
+  const mark = REALTIME_DICTATION_PERFORMANCE_MARKS[stage];
+  try {
+    performance.mark(mark);
+  } catch (error) {
+    void error;
+  }
+};
+
+const stopMediaStream = (stream: MediaStream) => {
+  for (const track of stream.getTracks()) track.stop();
+};
 
 const toClientError = (error: unknown): RealtimeDictationError => {
   if (error instanceof RealtimeDictationError) return error;
@@ -70,11 +122,13 @@ export class RealtimeDictationClient {
   #editorFinalized = false;
   #finalTimer?: ReturnType<typeof setTimeout>;
   #lifecycleCleanup?: () => void;
+  #microphoneStream?: MediaStream;
   #queue?: BoundedWebSocketFrameQueue;
   #runId = 0;
   #session?: RealtimeAsrSessionResponse;
   #snapshot = IDLE_SNAPSHOT;
   #socket?: RealtimeAsrWebSocket;
+  #startedAt?: number;
   #terminalTransition = false;
   #transcript?: DictationTranscript;
 
@@ -92,7 +146,11 @@ export class RealtimeDictationClient {
   async start() {
     if (this.#snapshot.status !== 'idle' && this.#snapshot.status !== 'error') return;
 
+    const startedAt = this.#now();
+    clearPerformanceMarks();
+    markPerformance('start');
     await this.#releaseResources();
+    this.#startedAt = startedAt;
     const runId = ++this.#runId;
     this.#editorFinalized = false;
     this.#terminalTransition = false;
@@ -109,34 +167,21 @@ export class RealtimeDictationClient {
     this.#abortController = abortController;
 
     try {
-      const stream = await this.#dependencies.requestMicrophone();
-      if (runId !== this.#runId) {
-        for (const track of stream.getTracks()) track.stop();
-        return;
-      }
-
-      this.#setSnapshot({ retryable: false, status: 'connecting' });
-      const capturePromise = this.#dependencies.createCapture(stream).then(
-        async (capture) => {
-          if (runId === this.#runId) {
-            this.#capture = capture;
-          } else {
-            await capture.cancel().catch(() => undefined);
-          }
-          return capture;
-        },
-        (error) => {
-          abortController.abort();
-          throw error;
-        },
-      );
-      const [capture, session] = await Promise.all([
-        capturePromise,
-        this.#dependencies.createSession(abortController.signal),
-      ]);
+      const capturePromise = this.#prepareCapture(runId, abortController);
+      const admissionPromise = this.#createSession(runId, abortController.signal);
+      const [capture, initialSession] = await Promise.all([capturePromise, admissionPromise]);
       if (runId !== this.#runId) {
         await capture.cancel().catch(() => undefined);
         return;
+      }
+
+      let session = initialSession;
+      if (this.#isAdmissionExpiring(session)) {
+        session = await this.#createSession(runId, abortController.signal, 'admission_refresh');
+        if (runId !== this.#runId) return;
+        if (this.#isAdmissionExpiring(session)) {
+          throw new RealtimeDictationError('SESSION_EXPIRED', true);
+        }
       }
 
       this.#session = session;
@@ -179,10 +224,16 @@ export class RealtimeDictationClient {
   }
 
   async cancel(reason: DictationCancelReason = 'user_cancelled') {
-    if (this.#snapshot.status === 'idle') return;
+    const statusBeforeCancel = this.#snapshot.status;
+    if (statusBeforeCancel === 'idle') return;
 
     this.#finalizeEditor();
     this.#acceptingAudio = false;
+    if (statusBeforeCancel !== 'listening' && statusBeforeCancel !== 'finalizing') {
+      await this.#complete();
+      return;
+    }
+
     this.#setSnapshot({ retryable: false, status: 'finalizing' });
     await this.#capture?.cancel().catch(() => undefined);
     this.#queue?.dispose();
@@ -228,6 +279,7 @@ export class RealtimeDictationClient {
     switch (event.type) {
       case 'session.ready': {
         if (this.#snapshot.status !== 'connecting' || !this.#socket || !this.#session) return;
+        this.#recordTiming('ws_ready');
         if (this.#connectTimer) clearTimeout(this.#connectTimer);
         this.#connectTimer = undefined;
         this.#queue = new BoundedWebSocketFrameQueue(this.#socket, {
@@ -306,6 +358,70 @@ export class RealtimeDictationClient {
     this.#finalTimer = setTimeout(() => void this.#fail('FINAL_TIMEOUT', true), timeoutMs);
   }
 
+  async #createSession(
+    runId: number,
+    signal: AbortSignal,
+    timingStage: 'admission' | 'admission_refresh' = 'admission',
+  ) {
+    const session = await this.#dependencies.createSession(signal);
+    if (runId === this.#runId) this.#recordTiming(timingStage);
+    return session;
+  }
+
+  #isAdmissionExpiring(session: RealtimeAsrSessionResponse) {
+    const expiresAt = Date.parse(session.expiresAt);
+    const now = this.#dependencies.wallClockNow?.() ?? Date.now();
+    return !Number.isFinite(expiresAt) || expiresAt - now <= ADMISSION_EXPIRY_SAFETY_MS;
+  }
+
+  #now() {
+    return this.#dependencies.now?.() ?? getMonotonicNow();
+  }
+
+  async #prepareCapture(runId: number, abortController: AbortController) {
+    const stream = await this.#dependencies.requestMicrophone();
+    if (runId !== this.#runId) {
+      stopMediaStream(stream);
+      throw new Error('dictation_start_cancelled');
+    }
+
+    this.#microphoneStream = stream;
+    this.#recordTiming('permission');
+    this.#setSnapshot({ retryable: false, status: 'connecting' });
+
+    let capture: RealtimeAudioCapture;
+    try {
+      capture = await this.#dependencies.createCapture(stream);
+    } catch (error) {
+      abortController.abort();
+      throw error;
+    }
+
+    if (runId === this.#runId) {
+      this.#microphoneStream = undefined;
+      this.#capture = capture;
+      this.#recordTiming('capture');
+    } else {
+      await capture.cancel().catch(() => undefined);
+    }
+    return capture;
+  }
+
+  #recordTiming(stage: RealtimeDictationTimingStage) {
+    if (this.#startedAt === undefined) return;
+
+    markPerformance(stage);
+    const timing = {
+      durationMs: Math.max(0, Math.round(this.#now() - this.#startedAt)),
+      stage,
+    } satisfies RealtimeDictationTiming;
+    try {
+      this.#dependencies.onTiming?.(timing);
+    } catch (error) {
+      void error;
+    }
+  }
+
   async #fail(code: RealtimeDictationErrorCode, retryable: boolean) {
     if (this.#terminalTransition) return;
     this.#terminalTransition = true;
@@ -335,6 +451,8 @@ export class RealtimeDictationClient {
     this.#lifecycleCleanup = undefined;
     this.#queue?.dispose();
     this.#queue = undefined;
+    if (this.#microphoneStream) stopMediaStream(this.#microphoneStream);
+    this.#microphoneStream = undefined;
     await this.#capture?.cancel().catch(() => undefined);
     this.#capture = undefined;
     if (this.#socket) {
@@ -351,6 +469,7 @@ export class RealtimeDictationClient {
       this.#closingSocket = false;
     }
     this.#session = undefined;
+    this.#startedAt = undefined;
     this.#transcript = undefined;
   }
 

--- a/src/features/ChatInput/Dictation/contract.test.ts
+++ b/src/features/ChatInput/Dictation/contract.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  parseRealtimeAsrServerEvent,
+  parseRealtimeAsrSessionResponse,
+  REALTIME_ASR_AUDIO,
+  REALTIME_ASR_LIMITS,
+} from './contract';
+
+const SESSION_ID = '00000000-0000-4000-8000-000000000001';
+const TEST_JWT = [
+  'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9',
+  'eyJzdWIiOiJ1c2VyLTEifQ',
+  'c2lnbmF0dXJl',
+].join('.');
+
+const sessionResponse = (token: string) => ({
+  audio: REALTIME_ASR_AUDIO,
+  expiresAt: '2026-08-21T12:00:30.000Z',
+  limits: REALTIME_ASR_LIMITS,
+  protocolVersion: 1,
+  sessionId: SESSION_ID,
+  token,
+  websocketUrl: `wss://asr.example.test/api/v1/realtime/ws?sessionId=${SESSION_ID}`,
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('parseRealtimeAsrSessionResponse', () => {
+  it('accepts the frozen v1 response with a three-segment JWT', () => {
+    const response = sessionResponse(TEST_JWT);
+
+    expect(parseRealtimeAsrSessionResponse(response)).toEqual(response);
+  });
+
+  it('accepts a JWT at the 4096-character boundary', () => {
+    const token = `aa.bb.${'c'.repeat(4090)}`;
+
+    expect(parseRealtimeAsrSessionResponse(sessionResponse(token)).token).toBe(token);
+  });
+
+  it('allows insecure WebSockets only for loopback development gateways', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    expect(
+      parseRealtimeAsrSessionResponse({
+        ...sessionResponse(TEST_JWT),
+        websocketUrl: `ws://127.0.0.1:8787/api/v1/realtime/ws?sessionId=${SESSION_ID}`,
+      }).websocketUrl,
+    ).toBe(`ws://127.0.0.1:8787/api/v1/realtime/ws?sessionId=${SESSION_ID}`);
+    expect(() =>
+      parseRealtimeAsrSessionResponse({
+        ...sessionResponse(TEST_JWT),
+        websocketUrl: `ws://asr.example.test/api/v1/realtime/ws?sessionId=${SESSION_ID}`,
+      }),
+    ).toThrowError(expect.objectContaining({ code: 'PROTOCOL_ERROR' }));
+  });
+
+  it('rejects insecure loopback WebSockets outside development', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+
+    expect(() =>
+      parseRealtimeAsrSessionResponse({
+        ...sessionResponse(TEST_JWT),
+        websocketUrl: `ws://localhost:8787/api/v1/realtime/ws?sessionId=${SESSION_ID}`,
+      }),
+    ).toThrowError(expect.objectContaining({ code: 'PROTOCOL_ERROR' }));
+  });
+
+  it.each([
+    ['an opaque id', 'session-1'],
+    ['an uppercase UUID', 'a0000000-b000-4c00-8d00-e00000000001'.toUpperCase()],
+    ['a non-v4 UUID', '00000000-0000-1000-8000-000000000001'],
+    ['a UUID without an RFC4122 variant', '00000000-0000-4000-7000-000000000001'],
+  ])('rejects %s as the session id in responses and events', (_case, sessionId) => {
+    expect(() =>
+      parseRealtimeAsrSessionResponse({ ...sessionResponse(TEST_JWT), sessionId }),
+    ).toThrowError(expect.objectContaining({ code: 'PROTOCOL_ERROR' }));
+    expect(() =>
+      parseRealtimeAsrServerEvent({
+        audio: REALTIME_ASR_AUDIO,
+        limits: REALTIME_ASR_LIMITS,
+        protocolVersion: 1,
+        sequence: 1,
+        sessionId,
+        type: 'session.ready',
+      }),
+    ).toThrowError(expect.objectContaining({ code: 'PROTOCOL_ERROR' }));
+  });
+
+  it.each([
+    ['the legacy opaque token', 'a'.repeat(43)],
+    ['an empty header', `.payload.signature`],
+    ['an empty payload', `header..signature`],
+    ['an empty signature', `header.payload.`],
+    ['two segments', `header.payload`],
+    ['four segments', `header.payload.signature.extra`],
+    ['non-base64url characters', `header.pay+load.signature`],
+    ['base64 padding', `header.payload.signature=`],
+    ['a token longer than 4096 characters', `aa.bb.${'c'.repeat(4091)}`],
+  ])('rejects %s', (_case, token) => {
+    expect(() => parseRealtimeAsrSessionResponse(sessionResponse(token))).toThrowError(
+      expect.objectContaining({ code: 'PROTOCOL_ERROR', retryable: false }),
+    );
+  });
+
+  it.each([
+    [
+      'a token in the query',
+      `wss://asr.example.test/api/v1/realtime/ws?sessionId=${SESSION_ID}&token=credential`,
+    ],
+    [
+      'a mismatched session id',
+      'wss://asr.example.test/api/v1/realtime/ws?sessionId=00000000-0000-4000-8000-000000000002',
+    ],
+    ['the wrong path', `wss://asr.example.test/realtime/ws?sessionId=${SESSION_ID}`],
+    [
+      'an extra query parameter',
+      `wss://asr.example.test/api/v1/realtime/ws?sessionId=${SESSION_ID}&debug=1`,
+    ],
+    [
+      'a duplicate session id parameter',
+      `wss://asr.example.test/api/v1/realtime/ws?sessionId=${SESSION_ID}&sessionId=${SESSION_ID}`,
+    ],
+    [
+      'URL credentials',
+      `wss://user:password@asr.example.test/api/v1/realtime/ws?sessionId=${SESSION_ID}`,
+    ],
+    [
+      'a URL fragment',
+      `wss://asr.example.test/api/v1/realtime/ws?sessionId=${SESSION_ID}#fragment`,
+    ],
+  ])('rejects a websocket URL with %s', (_case, websocketUrl) => {
+    expect(() =>
+      parseRealtimeAsrSessionResponse({ ...sessionResponse(TEST_JWT), websocketUrl }),
+    ).toThrowError(expect.objectContaining({ code: 'PROTOCOL_ERROR' }));
+  });
+
+  it('rejects extra top-level response keys', () => {
+    expect(() =>
+      parseRealtimeAsrSessionResponse({ ...sessionResponse(TEST_JWT), provider: 'upstream' }),
+    ).toThrowError(expect.objectContaining({ code: 'PROTOCOL_ERROR' }));
+  });
+
+  it('rejects extra keys in frozen audio and limits objects', () => {
+    const response = sessionResponse(TEST_JWT);
+
+    expect(() =>
+      parseRealtimeAsrSessionResponse({
+        ...response,
+        audio: { ...response.audio, providerSampleRate: 16_000 },
+      }),
+    ).toThrowError(expect.objectContaining({ code: 'PROTOCOL_ERROR' }));
+    expect(() =>
+      parseRealtimeAsrSessionResponse({
+        ...response,
+        limits: { ...response.limits, providerTimeoutMs: 10_000 },
+      }),
+    ).toThrowError(expect.objectContaining({ code: 'PROTOCOL_ERROR' }));
+  });
+});
+
+describe('parseRealtimeAsrServerEvent', () => {
+  const terminalEvent = {
+    sequence: 1,
+    sessionId: SESSION_ID,
+    type: 'session.completed' as const,
+  };
+
+  it('accepts integral forwarded audio through the maximum session duration', () => {
+    expect(
+      parseRealtimeAsrServerEvent({
+        ...terminalEvent,
+        forwardedAudioMs: REALTIME_ASR_LIMITS.maxSessionMs,
+      }),
+    ).toMatchObject({ forwardedAudioMs: REALTIME_ASR_LIMITS.maxSessionMs });
+  });
+
+  it.each([-1, 0.5, REALTIME_ASR_LIMITS.maxSessionMs + 1, Number.MAX_SAFE_INTEGER + 1])(
+    'rejects invalid forwarded audio duration %s',
+    (forwardedAudioMs) => {
+      expect(() =>
+        parseRealtimeAsrServerEvent({ ...terminalEvent, forwardedAudioMs }),
+      ).toThrowError(expect.objectContaining({ code: 'PROTOCOL_ERROR' }));
+    },
+  );
+});

--- a/src/features/ChatInput/Dictation/contract.ts
+++ b/src/features/ChatInput/Dictation/contract.ts
@@ -107,7 +107,19 @@ export interface RealtimeDictationSnapshot {
 }
 
 const OPAQUE_ID_PATTERN = /^[\w-]+$/;
-const TOKEN_PATTERN = /^[\w-]{43}$/;
+const SESSION_ID_PATTERN = /^[\da-f]{8}-[\da-f]{4}-4[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$/;
+const JWT_PATTERN = /^[\w-]+\.[\w-]+\.[\w-]+$/;
+const MAX_JWT_LENGTH = 4096;
+const REALTIME_ASR_WEBSOCKET_PATH = '/api/v1/realtime/ws';
+const SESSION_RESPONSE_KEYS = [
+  'audio',
+  'expiresAt',
+  'limits',
+  'protocolVersion',
+  'sessionId',
+  'token',
+  'websocketUrl',
+];
 const ERROR_CODES = new Set<RealtimeAsrErrorCode>([
   'AUDIO_FORMAT_INVALID',
   'AUTH_FAILED',
@@ -129,14 +141,51 @@ const ERROR_CODES = new Set<RealtimeAsrErrorCode>([
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 
+const hasExactKeys = (value: Record<string, unknown>, expectedKeys: string[]) => {
+  const actualKeys = Object.keys(value);
+  return (
+    actualKeys.length === expectedKeys.length &&
+    expectedKeys.every((key) => Object.hasOwn(value, key))
+  );
+};
+
 const isOpaqueId = (value: unknown): value is string =>
   typeof value === 'string' &&
   value.length > 0 &&
   value.length <= 128 &&
   OPAQUE_ID_PATTERN.test(value);
 
+const isSessionId = (value: unknown): value is string =>
+  typeof value === 'string' && SESSION_ID_PATTERN.test(value);
+
+const isLoopbackHostname = (hostname: string) =>
+  hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
+
+const isValidWebsocketUrl = (value: unknown, sessionId: string): value is string => {
+  if (typeof value !== 'string') return false;
+
+  try {
+    const websocketUrl = new URL(value);
+    const allowsInsecureDevelopmentSocket =
+      process.env.NODE_ENV === 'development' &&
+      websocketUrl.protocol === 'ws:' &&
+      isLoopbackHostname(websocketUrl.hostname);
+    return (
+      (websocketUrl.protocol === 'wss:' || allowsInsecureDevelopmentSocket) &&
+      !websocketUrl.username &&
+      !websocketUrl.password &&
+      websocketUrl.pathname === REALTIME_ASR_WEBSOCKET_PATH &&
+      !websocketUrl.hash &&
+      websocketUrl.search === `?sessionId=${sessionId}`
+    );
+  } catch {
+    return false;
+  }
+};
+
 const isExactAudio = (value: unknown): value is typeof REALTIME_ASR_AUDIO =>
   isRecord(value) &&
+  hasExactKeys(value, Object.keys(REALTIME_ASR_AUDIO)) &&
   value.channels === REALTIME_ASR_AUDIO.channels &&
   value.encoding === REALTIME_ASR_AUDIO.encoding &&
   value.frameBytes === REALTIME_ASR_AUDIO.frameBytes &&
@@ -145,12 +194,15 @@ const isExactAudio = (value: unknown): value is typeof REALTIME_ASR_AUDIO =>
 
 const isExactLimits = (value: unknown): value is typeof REALTIME_ASR_LIMITS =>
   isRecord(value) &&
+  hasExactKeys(value, Object.keys(REALTIME_ASR_LIMITS)) &&
   Object.entries(REALTIME_ASR_LIMITS).every(([key, expected]) => value[key] === expected);
 
 const hasValidEnvelope = (
   value: Record<string, unknown>,
 ): value is Record<string, unknown> & ServerEventBase =>
-  isOpaqueId(value.sessionId) && Number.isSafeInteger(value.sequence) && Number(value.sequence) > 0;
+  isSessionId(value.sessionId) &&
+  Number.isSafeInteger(value.sequence) &&
+  Number(value.sequence) > 0;
 
 export class RealtimeDictationError extends Error {
   constructor(
@@ -165,12 +217,13 @@ export class RealtimeDictationError extends Error {
 export const parseRealtimeAsrSessionResponse = (value: unknown): RealtimeAsrSessionResponse => {
   if (
     !isRecord(value) ||
+    !hasExactKeys(value, SESSION_RESPONSE_KEYS) ||
     value.protocolVersion !== REALTIME_ASR_PROTOCOL_VERSION ||
-    !isOpaqueId(value.sessionId) ||
+    !isSessionId(value.sessionId) ||
     typeof value.token !== 'string' ||
-    !TOKEN_PATTERN.test(value.token) ||
-    typeof value.websocketUrl !== 'string' ||
-    !value.websocketUrl.startsWith('wss://') ||
+    value.token.length > MAX_JWT_LENGTH ||
+    !JWT_PATTERN.test(value.token) ||
+    !isValidWebsocketUrl(value.websocketUrl, value.sessionId) ||
     typeof value.expiresAt !== 'string' ||
     !Number.isFinite(Date.parse(value.expiresAt)) ||
     !isExactAudio(value.audio) ||
@@ -216,7 +269,11 @@ export const parseRealtimeAsrServerEvent = (raw: unknown): RealtimeAsrServerEven
     }
     case 'session.completed':
     case 'session.cancelled': {
-      if (Number.isSafeInteger(value.forwardedAudioMs) && Number(value.forwardedAudioMs) >= 0) {
+      if (
+        Number.isSafeInteger(value.forwardedAudioMs) &&
+        Number(value.forwardedAudioMs) >= 0 &&
+        Number(value.forwardedAudioMs) <= REALTIME_ASR_LIMITS.maxSessionMs
+      ) {
         return value as unknown as RealtimeAsrCompletedEvent | RealtimeAsrCancelledEvent;
       }
       break;

--- a/src/features/ChatInput/Dictation/service.test.ts
+++ b/src/features/ChatInput/Dictation/service.test.ts
@@ -7,14 +7,21 @@ vi.mock('@/business/client/trpc-headers', () => ({
   getBusinessTrpcHeaders: vi.fn().mockResolvedValue({ 'X-Test-Scope': 'scope-1' }),
 }));
 
+const SESSION_ID = '00000000-0000-4000-8000-000000000001';
+const TEST_JWT = [
+  'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9',
+  'eyJzdWIiOiJ1c2VyLTEifQ',
+  'c2lnbmF0dXJl',
+].join('.');
+
 const responseBody = {
   audio: REALTIME_ASR_AUDIO,
   expiresAt: '2026-08-10T04:00:00.000Z',
   limits: REALTIME_ASR_LIMITS,
   protocolVersion: 1,
-  sessionId: 'session-1',
-  token: 'a'.repeat(43),
-  websocketUrl: 'wss://asr.example.test/v1/session',
+  sessionId: SESSION_ID,
+  token: TEST_JWT,
+  websocketUrl: `wss://asr.example.test/api/v1/realtime/ws?sessionId=${SESSION_ID}`,
 };
 
 describe('createRealtimeAsrSession', () => {
@@ -56,9 +63,25 @@ describe('createRealtimeAsrSession', () => {
     ).rejects.toMatchObject({ code: 'PROTOCOL_ERROR', retryable: false });
   });
 
+  it('reports a malformed Admission token as a non-retryable protocol error', async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ...responseBody, token: 'a'.repeat(43) }), {
+        headers: { 'Content-Type': 'application/json' },
+        status: 200,
+      }),
+    );
+
+    await expect(
+      createRealtimeAsrSession(new AbortController().signal, fetcher),
+    ).rejects.toMatchObject({ code: 'PROTOCOL_ERROR', retryable: false });
+  });
+
   it.each([
+    [400, 'SESSION_CREATE_FAILED', false],
     [401, 'AUTH_FAILED', false],
     [402, 'PROVIDER_BILLING_BLOCKED', false],
+    [403, 'AUTH_FAILED', false],
+    [404, 'PROVIDER_NOT_CONFIGURED', false],
     [429, 'SESSION_LIMIT_EXCEEDED', true],
     [503, 'PROVIDER_UNAVAILABLE', true],
   ])('maps HTTP %i to stable error %s', async (status, code, retryable) => {


### PR DESCRIPTION
Speed up realtime dictation startup by overlapping independent admission and microphone work instead of waiting for them serially.

- request microphone capture and the ASR session in parallel
- validate the protocol-v1 UUID, compact admission JWT, expiry, and WebSocket URL
- refresh admission when it is too close to expiry before opening the socket
- expose separate admission, refresh, permission, capture, and WebSocket-ready timings
- keep cancellation and late async completions bounded to the active run

#### Key Decisions / Non-goals

- Protocol version remains `1`; no opaque-token fallback is introduced.
- This does not keep an ASR socket alive or reuse a completed Provider connection.
- Transcript editing, send behavior, and visible UI are unchanged.
- Client timing hooks are observational and do not affect connection decisions.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check src/features/ChatInput/Dictation/client.test.ts src/features/ChatInput/Dictation/client.ts src/features/ChatInput/Dictation/contract.test.ts src/features/ChatInput/Dictation/contract.ts src/features/ChatInput/Dictation/service.test.ts`
- 58 related tests passed
- `git diff --check`

#### Screenshots / Videos

N/A — connection sequencing changed without a visible UI change.

#### 🔗 Related Issue

Related to [LOBE-13025](https://linear.app/lobehub/issue/LOBE-13025)
