### PR TITLE
🐛 fix(heterogeneous-agent): keep server models on LobeHub

### DIFF
--- a/apps/server/src/modules/ModelRuntime/index.test.ts
+++ b/apps/server/src/modules/ModelRuntime/index.test.ts
@@ -129,71 +129,83 @@ describe('resolveServerModel', () => {
 });
 
 describe('getServerDefaultHeterogeneousModels', () => {
-  it('returns only provider-native V1 model paths', async () => {
+  it('returns only compatible V1 models from the LobeHub provider', async () => {
     getServerGlobalConfig.mockResolvedValue({
       aiProvider: {
         anthropic: {
           enabled: true,
-          serverModelLists: [
-            { enabled: true, id: 'claude-server', type: 'chat' },
-            { enabled: false, id: 'claude-disabled', type: 'chat' },
-          ],
+          serverModelLists: [{ enabled: true, id: 'claude-opus-4-8', type: 'chat' }],
         },
-        google: {
+        lobehub: {
           enabled: true,
-          serverModelLists: [{ enabled: true, id: 'gemini-server', type: 'chat' }],
+          serverModelLists: [
+            { enabled: true, id: 'claude-sonnet-4-6', type: 'chat' },
+            { enabled: false, id: 'claude-haiku-4-5', type: 'chat' },
+            { enabled: true, id: 'gpt-5.4', type: 'chat' },
+            { enabled: true, id: 'gpt-4o', type: 'chat' },
+            { enabled: true, id: 'gemini-3.1-pro-preview', type: 'chat' },
+            { enabled: true, id: 'claude-image', type: 'image' },
+          ],
         },
         openai: {
           enabled: true,
-          serverModelLists: [
-            { enabled: true, id: 'gpt-5.4', type: 'chat' },
-            { enabled: true, id: 'gpt-4o', type: 'chat' },
-          ],
+          serverModelLists: [{ enabled: true, id: 'gpt-5.4', type: 'chat' }],
         },
       },
     });
 
     await expect(getServerDefaultHeterogeneousModels()).resolves.toEqual({
-      'claude-code': [{ model: 'claude-server', providerId: 'anthropic' }],
-      'codex': [{ model: 'gpt-5.4', providerId: 'openai' }],
+      'claude-code': [{ model: 'claude-sonnet-4-6', providerId: 'lobehub' }],
+      'codex': [{ model: 'gpt-5.4', providerId: 'lobehub' }],
     });
   });
 });
 
 describe('resolveServerDefaultHeterogeneousModel', () => {
-  it('accepts only the selected agent runtime path', async () => {
+  it('accepts only compatible models routed through the LobeHub provider', async () => {
     getServerGlobalConfig.mockResolvedValue({
       aiProvider: {
         anthropic: {
           enabled: true,
-          serverModelLists: [{ enabled: true, id: 'claude-server', type: 'chat' }],
+          serverModelLists: [{ enabled: true, id: 'claude-sonnet-4-6', type: 'chat' }],
         },
-        openai: {
+        lobehub: {
           enabled: true,
           serverModelLists: [
+            { enabled: true, id: 'claude-sonnet-4-6', type: 'chat' },
             { enabled: true, id: 'gpt-5.4', type: 'chat' },
             { enabled: true, id: 'gpt-4o', type: 'chat' },
           ],
+        },
+        openai: {
+          enabled: true,
+          serverModelLists: [{ enabled: true, id: 'gpt-5.4', type: 'chat' }],
         },
       },
     });
 
     await expect(
-      resolveServerDefaultHeterogeneousModel('claude-code', 'anthropic', 'claude-server'),
-    ).resolves.toMatchObject({ model: 'claude-server', provider: 'anthropic' });
+      resolveServerDefaultHeterogeneousModel('claude-code', 'lobehub', 'claude-sonnet-4-6'),
+    ).resolves.toMatchObject({ model: 'claude-sonnet-4-6', provider: 'lobehub' });
     await expect(
-      resolveServerDefaultHeterogeneousModel('codex', 'openai', 'gpt-5.4'),
-    ).resolves.toMatchObject({ model: 'gpt-5.4', provider: 'openai' });
+      resolveServerDefaultHeterogeneousModel('codex', 'lobehub', 'gpt-5.4'),
+    ).resolves.toMatchObject({ model: 'gpt-5.4', provider: 'lobehub' });
 
     await expect(
-      resolveServerDefaultHeterogeneousModel('codex', 'anthropic', 'claude-server'),
+      resolveServerDefaultHeterogeneousModel('codex', 'lobehub', 'claude-sonnet-4-6'),
     ).rejects.toThrow('not compatible with this heterogeneous agent');
     await expect(
-      resolveServerDefaultHeterogeneousModel('claude-code', 'openai', 'gpt-5.4'),
+      resolveServerDefaultHeterogeneousModel('claude-code', 'lobehub', 'gpt-5.4'),
     ).rejects.toThrow('not compatible with this heterogeneous agent');
     await expect(
-      resolveServerDefaultHeterogeneousModel('codex', 'openai', 'gpt-4o'),
+      resolveServerDefaultHeterogeneousModel('codex', 'lobehub', 'gpt-4o'),
     ).rejects.toThrow('not compatible with this heterogeneous agent');
+    await expect(
+      resolveServerDefaultHeterogeneousModel('codex', 'openai', 'gpt-5.4'),
+    ).rejects.toThrow('use the LobeHub provider');
+    await expect(
+      resolveServerDefaultHeterogeneousModel('claude-code', 'anthropic', 'claude-sonnet-4-6'),
+    ).rejects.toThrow('use the LobeHub provider');
   });
 });
 

--- a/apps/server/src/modules/ModelRuntime/index.ts
+++ b/apps/server/src/modules/ModelRuntime/index.ts
@@ -6,6 +6,7 @@ import {
   ModelRuntime,
   type ModelRuntimeHooks,
 } from '@lobechat/model-runtime';
+import { parseClaudeModelId } from '@lobechat/model-runtime/providers/anthropic/modelId';
 import { isResponsesAPIModel } from '@lobechat/model-runtime/providers/openai/modelId';
 import { LobeVertexAI } from '@lobechat/model-runtime/vertexai';
 import {
@@ -548,38 +549,36 @@ export type ServerDefaultHeterogeneousModels = Record<
 >;
 
 /**
- * V1 deliberately keeps each CLI on its provider-native protocol path:
- * Claude Code -> Anthropic runtime; Codex -> OpenAI Responses runtime.
- * This predicate is the support matrix used by both capability discovery and invocation.
+ * Both CLIs use the LobeHub provider; V1 restricts models by the runtime protocol
+ * selected for that model: Claude Code -> Anthropic, Codex -> OpenAI Responses.
+ * This model predicate is shared by capability discovery and invocation validation.
  *
- * Do not widen this predicate to generic chat/function-calling models. Adding another
- * agent/runtime pair requires lossless continuation-state translation in both directions
- * and a two-turn tool-call E2E covering the new pair before it is exposed in the catalog.
+ * Do not widen this predicate to generic LobeHub chat/function-calling models. Adding
+ * another model/runtime path requires lossless continuation-state translation in both
+ * directions and a two-turn tool-call E2E before it is exposed in the catalog.
  */
 const supportsServerDefaultHeterogeneousAgent = (
   agentType: ServerDefaultHeterogeneousAgentType,
-  provider: string,
   model: string,
 ) =>
   agentType === 'claude-code'
-    ? provider === ModelProvider.Anthropic
-    : provider === ModelProvider.OpenAI && isResponsesAPIModel(model);
+    ? parseClaudeModelId(model) !== undefined
+    : isResponsesAPIModel(model);
 
-/** Return only the deployment models covered by the V1 protocol support matrix. */
+/** Return only LobeHub models covered by the V1 protocol support matrix. */
 export const getServerDefaultHeterogeneousModels = async () => {
   const models: ServerDefaultHeterogeneousModels = { 'claude-code': [], 'codex': [] };
   const { aiProvider } = await getServerGlobalConfig();
+  const providerConfig = aiProvider[ModelProvider.LobeHub];
 
-  for (const [provider, providerConfig] of Object.entries(aiProvider)) {
-    if (!providerConfig?.enabled) continue;
+  if (!providerConfig?.enabled) return models;
 
-    for (const model of providerConfig.serverModelLists ?? []) {
-      if (!model.enabled || model.type !== 'chat') continue;
+  for (const model of providerConfig.serverModelLists ?? []) {
+    if (!model.enabled || model.type !== 'chat') continue;
 
-      for (const agentType of SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES) {
-        if (supportsServerDefaultHeterogeneousAgent(agentType, provider, model.id)) {
-          models[agentType].push({ model: model.id, providerId: provider });
-        }
+    for (const agentType of SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES) {
+      if (supportsServerDefaultHeterogeneousAgent(agentType, model.id)) {
+        models[agentType].push({ model: model.id, providerId: ModelProvider.LobeHub });
       }
     }
   }
@@ -614,8 +613,11 @@ export const resolveServerDefaultHeterogeneousModel = async (
   provider: string,
   model: string,
 ) => {
+  if (provider !== ModelProvider.LobeHub) {
+    throw new Error('Server-default heterogeneous agents use the LobeHub provider');
+  }
   const selection = await resolveServerModel(provider, model);
-  if (!supportsServerDefaultHeterogeneousAgent(agentType, selection.provider, selection.model)) {
+  if (!supportsServerDefaultHeterogeneousAgent(agentType, selection.model)) {
     throw new Error('The selected server model is not compatible with this heterogeneous agent');
   }
 

--- a/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultCapability.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultCapability.test.ts
@@ -14,8 +14,8 @@ describe('resolveServerDefaultHeterogeneousCapability', () => {
   beforeEach(() => {
     vi.stubEnv('ENABLE_SERVER_DEFAULT_HETEROGENEOUS_AGENT', '1');
     getSupportedModels.mockResolvedValue({
-      'claude-code': [{ model: 'claude-server', providerId: 'anthropic' }],
-      'codex': [{ model: 'gpt-5.4', providerId: 'openai' }],
+      'claude-code': [{ model: 'claude-sonnet-4-6', providerId: 'lobehub' }],
+      'codex': [{ model: 'gpt-5.4', providerId: 'lobehub' }],
     });
   });
 
@@ -30,8 +30,8 @@ describe('resolveServerDefaultHeterogeneousCapability', () => {
       enabled: true,
       model: 'lobehub-default',
       models: {
-        'claude-code': [{ model: 'claude-server', providerId: 'anthropic' }],
-        'codex': [{ model: 'gpt-5.4', providerId: 'openai' }],
+        'claude-code': [{ model: 'claude-sonnet-4-6', providerId: 'lobehub' }],
+        'codex': [{ model: 'gpt-5.4', providerId: 'lobehub' }],
       },
     });
 
@@ -40,7 +40,7 @@ describe('resolveServerDefaultHeterogeneousCapability', () => {
 
   it('advertises only agents that have a compatible runtime model', async () => {
     getSupportedModels.mockResolvedValue({
-      'claude-code': [{ model: 'claude-server', providerId: 'anthropic' }],
+      'claude-code': [{ model: 'claude-sonnet-4-6', providerId: 'lobehub' }],
       'codex': [],
     });
 

--- a/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultOperation.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultOperation.test.ts
@@ -49,7 +49,7 @@ describe('server-default heterogeneous operation control', () => {
     agentType: 'codex' as const,
     model: 'gpt-5.4',
     operationId,
-    providerId: 'openai',
+    providerId: 'lobehub',
     topicId,
   });
 
@@ -59,10 +59,10 @@ describe('server-default heterogeneous operation control', () => {
     topicId = await createTestTopic(testDB, userId);
     vi.stubEnv('ENABLE_SERVER_DEFAULT_HETEROGENEOUS_AGENT', '1');
     getSupportedModels.mockResolvedValue({
-      'claude-code': [{ model: 'claude-server', providerId: 'anthropic' }],
-      'codex': [{ model: 'gpt-5.4', providerId: 'openai' }],
+      'claude-code': [{ model: 'claude-sonnet-4-6', providerId: 'lobehub' }],
+      'codex': [{ model: 'gpt-5.4', providerId: 'lobehub' }],
     });
-    resolveModel.mockResolvedValue({ model: 'gpt-5.4', provider: 'openai' });
+    resolveModel.mockResolvedValue({ model: 'gpt-5.4', provider: 'lobehub' });
     initRuntime.mockResolvedValue({});
     signOperationToken.mockResolvedValue('operation-token');
   });
@@ -85,7 +85,7 @@ describe('server-default heterogeneous operation control', () => {
     expect(operation).toMatchObject({
       metadata: { agentType: 'codex', serverDefaultHeterogeneous: true },
       model: 'gpt-5.4',
-      provider: 'openai',
+      provider: 'lobehub',
       status: 'running',
       topicId,
       userId,
@@ -95,14 +95,14 @@ describe('server-default heterogeneous operation control', () => {
       capabilities: ['model:invoke'],
       model: 'gpt-5.4',
       operationId: 'desktop-operation-1',
-      providerId: 'openai',
+      providerId: 'lobehub',
       userId,
       workspaceId: undefined,
     });
-    expect(resolveModel).toHaveBeenCalledWith('codex', 'openai', 'gpt-5.4');
+    expect(resolveModel).toHaveBeenCalledWith('codex', 'lobehub', 'gpt-5.4');
     expect(initRuntime).toHaveBeenCalledWith({
       actorUserId: userId,
-      provider: 'openai',
+      provider: 'lobehub',
       workspaceId: undefined,
     });
   });

--- a/packages/openapi/src/services/heterogeneous-direct.service.test.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.test.ts
@@ -55,8 +55,8 @@ describe('heterogeneous direct invocation protocol', () => {
   it('invokes Claude Code only through its resolved Anthropic runtime model', async () => {
     const chat = vi.fn().mockResolvedValue(new Response('stream'));
     vi.mocked(resolveServerDefaultHeterogeneousModel).mockResolvedValue({
-      model: 'claude-server',
-      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      provider: 'lobehub',
     });
     vi.mocked(initModelRuntimeFromServerConfig).mockResolvedValue({
       chat,
@@ -64,23 +64,23 @@ describe('heterogeneous direct invocation protocol', () => {
 
     const result = await invokeServerDefaultModel({
       agentType: 'claude-code',
-      model: 'claude-server',
+      model: 'claude-sonnet-4-6',
       payload: { messages: [], model: 'lobehub-default', stream: true },
-      provider: 'anthropic',
+      provider: 'lobehub',
       signal: new AbortController().signal,
       userId: 'user-1',
     });
 
-    expect(result.model).toBe('claude-server');
+    expect(result.model).toBe('claude-sonnet-4-6');
     expect(resolveServerDefaultHeterogeneousModel).toHaveBeenCalledWith(
       'claude-code',
-      'anthropic',
-      'claude-server',
+      'lobehub',
+      'claude-sonnet-4-6',
     );
     expect(chat).toHaveBeenCalledWith(
       {
         messages: [],
-        model: 'claude-server',
+        model: 'claude-sonnet-4-6',
         stream: true,
       },
       expect.any(Object),
@@ -92,7 +92,7 @@ describe('heterogeneous direct invocation protocol', () => {
     vi.mocked(resolveServerDefaultHeterogeneousModel).mockResolvedValue({
       deploymentName: 'prod-gpt',
       model: 'gpt-5.4',
-      provider: 'openai',
+      provider: 'lobehub',
     });
     vi.mocked(initModelRuntimeFromServerConfig).mockResolvedValue({
       chat,
@@ -102,7 +102,7 @@ describe('heterogeneous direct invocation protocol', () => {
       agentType: 'codex',
       model: 'gpt-5.4',
       payload: { messages: [], model: 'lobehub-default', stream: true },
-      provider: 'openai',
+      provider: 'lobehub',
       signal: new AbortController().signal,
       userId: 'user-1',
     });
@@ -121,9 +121,9 @@ describe('heterogeneous direct invocation protocol', () => {
     await expect(
       invokeServerDefaultModel({
         agentType: 'codex',
-        model: 'claude-server',
+        model: 'claude-sonnet-4-6',
         payload: { messages: [], model: 'lobehub-default', stream: true },
-        provider: 'anthropic',
+        provider: 'lobehub',
         signal: new AbortController().signal,
         userId: 'user-1',
       }),


### PR DESCRIPTION
## Description of Change

Corrects the provider/model boundary introduced by #18558 for server-default heterogeneous agents.

- Keep `providerId: 'lobehub'` for capability discovery, operation start, and direct invocation.
- Read supported server-default models only from the enabled `aiProvider.lobehub` catalog.
- Restrict Claude Code to Claude model IDs handled by the Anthropic runtime.
- Restrict Codex to model IDs handled by the OpenAI Responses runtime.
- Apply the same compatibility predicate during capability discovery and invocation validation.

This is the V1 support matrix. A source comment records the extension gate: generic chat/function-calling models or another runtime path require lossless continuation-state translation in both directions and a two-turn tool-call E2E before being exposed.

This PR is intentionally server-only. The Desktop/UI client remains in #18568.

#### Test

- `bun run check` over the 5 affected files — lint clean and **97 tests passed**.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Follow-up correction to #18558. Required by #18568.
