### PR TITLE
✨ feat(home): support image URLs for model shortcuts

### DIFF
--- a/src/business/client/hooks/useHomeNewModels.ts
+++ b/src/business/client/hooks/useHomeNewModels.ts
@@ -2,6 +2,8 @@ export type HomeNewModelType = 'chat' | 'image' | 'video';
 
 export interface HomeNewModelItem {
   iconModel?: string;
+  /** Optional image URL rendered instead of the model icon mapping. */
+  iconUrl?: string;
   model: string;
   provider?: string;
   title: string;

--- a/src/features/Home/NewModelShortcuts/index.tsx
+++ b/src/features/Home/NewModelShortcuts/index.tsx
@@ -1,5 +1,5 @@
 import { ModelIcon } from '@lobehub/icons';
-import { Flexbox, Skeleton, Text } from '@lobehub/ui';
+import { Avatar, Flexbox, Skeleton, Text } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { createStaticStyles, cx } from 'antd-style';
@@ -176,10 +176,16 @@ export const NewModelShortcuts = () => {
                 aria-pressed={item.type === 'chat' ? isCurrent : undefined}
                 className={cx(styles.button, isCurrent && styles.active)}
                 disabled={!!switchingKey && !isSwitching}
-                icon={<ModelIcon model={getShortcutIconModelId(item)} size={18} />}
                 key={key}
                 loading={isSwitching}
                 type={'text'}
+                icon={
+                  item.iconUrl ? (
+                    <Avatar alt={''} avatar={item.iconUrl} size={18} />
+                  ) : (
+                    <ModelIcon model={getShortcutIconModelId(item)} size={18} />
+                  )
+                }
                 onClick={() => handleClick(item)}
               >
                 {item.title}


### PR DESCRIPTION
## 🔗 Related Issue

N/A

## 📝 Additional Information

Adds an optional image URL to home model shortcut items. When present, the shortcut renders the image through the shared Avatar component; otherwise it preserves the existing `iconModel` and model-ID mapping behavior.

### Key Decisions / Non-goals

- The field is optional and backward compatible with every existing shortcut.
- The capability is limited to the home shortcut surface; it does not change global `ModelIcon` resolution.
- The contract is generic and contains no deployment- or provider-specific behavior.

#### Test

- [x] Tested locally
- [x] Added/updated tests in the consuming Cloud implementation
- `bun run check <changed-files> --lint --test`
- `bun run check --type`
