### PR TITLE
🐛 fix(heterogeneous-agent): pin server-default provider contract

### DIFF
--- a/apps/server/src/modules/ModelRuntime/index.test.ts
+++ b/apps/server/src/modules/ModelRuntime/index.test.ts
@@ -37,7 +37,6 @@ import {
 const getServerGlobalConfig = vi.hoisted(() => vi.fn());
 
 vi.mock('@/server/globalConfig', () => ({
-  getServerDefaultAgentConfig: () => ({}),
   getServerGlobalConfig,
 }));
 
@@ -129,71 +128,81 @@ describe('resolveServerModel', () => {
 });
 
 describe('getServerDefaultHeterogeneousModels', () => {
-  it('returns only provider-native V1 model paths', async () => {
+  it('returns only compatible V1 models from the LobeHub relay provider', async () => {
     getServerGlobalConfig.mockResolvedValue({
       aiProvider: {
         anthropic: {
           enabled: true,
-          serverModelLists: [
-            { enabled: true, id: 'claude-server', type: 'chat' },
-            { enabled: false, id: 'claude-disabled', type: 'chat' },
-          ],
+          serverModelLists: [{ enabled: true, id: 'claude-opus-4-8', type: 'chat' }],
         },
         google: {
           enabled: true,
           serverModelLists: [{ enabled: true, id: 'gemini-server', type: 'chat' }],
         },
-        openai: {
+        lobehub: {
           enabled: true,
           serverModelLists: [
+            { enabled: true, id: 'claude-sonnet-4-6', type: 'chat' },
+            { enabled: false, id: 'claude-haiku-4-5', type: 'chat' },
             { enabled: true, id: 'gpt-5.4', type: 'chat' },
             { enabled: true, id: 'gpt-4o', type: 'chat' },
+            { enabled: true, id: 'gemini-3.1-pro-preview', type: 'chat' },
+            { enabled: true, id: 'claude-image', type: 'image' },
           ],
+        },
+        openai: {
+          enabled: true,
+          serverModelLists: [{ enabled: true, id: 'gpt-5.4', type: 'chat' }],
         },
       },
     });
 
     await expect(getServerDefaultHeterogeneousModels()).resolves.toEqual({
-      'claude-code': [{ model: 'claude-server', providerId: 'anthropic' }],
-      'codex': [{ model: 'gpt-5.4', providerId: 'openai' }],
+      'claude-code': [{ model: 'claude-sonnet-4-6' }],
+      'codex': [{ model: 'gpt-5.4' }],
     });
   });
 });
 
 describe('resolveServerDefaultHeterogeneousModel', () => {
-  it('accepts only the selected agent runtime path', async () => {
+  it('accepts only protocol-compatible models from the LobeHub relay provider', async () => {
     getServerGlobalConfig.mockResolvedValue({
       aiProvider: {
         anthropic: {
           enabled: true,
-          serverModelLists: [{ enabled: true, id: 'claude-server', type: 'chat' }],
+          serverModelLists: [{ enabled: true, id: 'claude-sonnet-4-6', type: 'chat' }],
         },
-        openai: {
+        lobehub: {
           enabled: true,
           serverModelLists: [
+            { enabled: true, id: 'claude-sonnet-4-6', type: 'chat' },
             { enabled: true, id: 'gpt-5.4', type: 'chat' },
             { enabled: true, id: 'gpt-4o', type: 'chat' },
           ],
+        },
+        openai: {
+          enabled: true,
+          serverModelLists: [{ enabled: true, id: 'gpt-5.4', type: 'chat' }],
         },
       },
     });
 
     await expect(
-      resolveServerDefaultHeterogeneousModel('claude-code', 'anthropic', 'claude-server'),
-    ).resolves.toMatchObject({ model: 'claude-server', provider: 'anthropic' });
-    await expect(
-      resolveServerDefaultHeterogeneousModel('codex', 'openai', 'gpt-5.4'),
-    ).resolves.toMatchObject({ model: 'gpt-5.4', provider: 'openai' });
+      resolveServerDefaultHeterogeneousModel('claude-code', 'claude-sonnet-4-6'),
+    ).resolves.toMatchObject({ model: 'claude-sonnet-4-6', provider: 'lobehub' });
+    await expect(resolveServerDefaultHeterogeneousModel('codex', 'gpt-5.4')).resolves.toMatchObject(
+      { model: 'gpt-5.4', provider: 'lobehub' },
+    );
 
     await expect(
-      resolveServerDefaultHeterogeneousModel('codex', 'anthropic', 'claude-server'),
+      resolveServerDefaultHeterogeneousModel('codex', 'claude-sonnet-4-6'),
     ).rejects.toThrow('not compatible with this heterogeneous agent');
-    await expect(
-      resolveServerDefaultHeterogeneousModel('claude-code', 'openai', 'gpt-5.4'),
-    ).rejects.toThrow('not compatible with this heterogeneous agent');
-    await expect(
-      resolveServerDefaultHeterogeneousModel('codex', 'openai', 'gpt-4o'),
-    ).rejects.toThrow('not compatible with this heterogeneous agent');
+    await expect(resolveServerDefaultHeterogeneousModel('claude-code', 'gpt-5.4')).rejects.toThrow(
+      'not compatible with this heterogeneous agent',
+    );
+    await expect(resolveServerDefaultHeterogeneousModel('codex', 'gpt-4o')).rejects.toThrow(
+      'not compatible with this heterogeneous agent',
+    );
   });
 });
 

--- a/apps/server/src/modules/ModelRuntime/index.ts
+++ b/apps/server/src/modules/ModelRuntime/index.ts
@@ -1,11 +1,11 @@
 import { type GoogleGenAIOptions } from '@google/genai';
-import { DEFAULT_AGENT_CONFIG } from '@lobechat/const';
 import {
   AgentRuntimeError,
   mergeModelRuntimeHooks,
   ModelRuntime,
   type ModelRuntimeHooks,
 } from '@lobechat/model-runtime';
+import { parseClaudeModelId } from '@lobechat/model-runtime/providers/anthropic/modelId';
 import { isResponsesAPIModel } from '@lobechat/model-runtime/providers/openai/modelId';
 import { LobeVertexAI } from '@lobechat/model-runtime/vertexai';
 import {
@@ -21,7 +21,7 @@ import {
   type SuperGrokKeyVault,
   type VertexAIKeyVault,
 } from '@lobechat/types';
-import { merge, safeParseJSON } from '@lobechat/utils';
+import { safeParseJSON } from '@lobechat/utils';
 import { ModelProvider } from 'model-bank';
 import { AiProviderBaseURLSchema } from 'model-bank/aiProvider';
 import { DEFAULT_MODEL_PROVIDER_LIST } from 'model-bank/modelProviders';
@@ -30,7 +30,7 @@ import { getBusinessModelRuntimeHooks } from '@/business/server/model-runtime';
 import { AiProviderModel } from '@/database/models/aiProvider';
 import { type LobeChatDatabase } from '@/database/type';
 import { getLLMConfig } from '@/envs/llm';
-import { getServerDefaultAgentConfig, getServerGlobalConfig } from '@/server/globalConfig';
+import { getServerGlobalConfig } from '@/server/globalConfig';
 import { createLLMGenerationTracingHook } from '@/server/services/llmGenerationTracing/hook';
 import { ensureFreshOAuthToken } from '@/server/services/oauthDeviceFlow/refresh';
 
@@ -520,26 +520,12 @@ export const initModelRuntimeFromDB = async (
   return initModelRuntimeWithUserPayload(provider, payload, { userId }, hooks);
 };
 
-export const resolveServerDefaultModel = () => {
-  const config = merge(DEFAULT_AGENT_CONFIG, getServerDefaultAgentConfig());
-  if (!config.model || !config.provider) {
-    throw new Error('The deployment default model is not configured');
-  }
-  if (!Object.values(ModelProvider).includes(config.provider as ModelProvider)) {
-    throw new Error(
-      'Deployment-level custom providers are not supported for server-default agents',
-    );
-  }
-  return { model: config.model, provider: config.provider };
-};
-
 export const SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES = ['claude-code', 'codex'] as const;
 export type ServerDefaultHeterogeneousAgentType =
   (typeof SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES)[number];
 
 export interface ServerDefaultHeterogeneousModelReference {
   model: string;
-  providerId: string;
 }
 
 export type ServerDefaultHeterogeneousModels = Record<
@@ -548,38 +534,36 @@ export type ServerDefaultHeterogeneousModels = Record<
 >;
 
 /**
- * V1 deliberately keeps each CLI on its provider-native protocol path:
- * Claude Code -> Anthropic runtime; Codex -> OpenAI Responses runtime.
- * This predicate is the support matrix used by both capability discovery and invocation.
+ * Both CLIs use the single LobeHub relay provider. V1 restricts its models by
+ * the protocol required by each CLI: Claude Code -> Anthropic Messages,
+ * Codex -> OpenAI Responses.
  *
- * Do not widen this predicate to generic chat/function-calling models. Adding another
- * agent/runtime pair requires lossless continuation-state translation in both directions
- * and a two-turn tool-call E2E covering the new pair before it is exposed in the catalog.
+ * Do not widen this predicate to generic chat/function-calling models. Adding
+ * another model/protocol path requires lossless continuation-state translation
+ * in both directions and a two-turn tool-call E2E before it is advertised.
  */
 const supportsServerDefaultHeterogeneousAgent = (
   agentType: ServerDefaultHeterogeneousAgentType,
-  provider: string,
   model: string,
 ) =>
   agentType === 'claude-code'
-    ? provider === ModelProvider.Anthropic
-    : provider === ModelProvider.OpenAI && isResponsesAPIModel(model);
+    ? parseClaudeModelId(model) !== undefined
+    : isResponsesAPIModel(model);
 
-/** Return only the deployment models covered by the V1 protocol support matrix. */
+/** Return compatible models from the single deployment-owned relay provider. */
 export const getServerDefaultHeterogeneousModels = async () => {
   const models: ServerDefaultHeterogeneousModels = { 'claude-code': [], 'codex': [] };
   const { aiProvider } = await getServerGlobalConfig();
+  const providerConfig = aiProvider[ModelProvider.LobeHub];
 
-  for (const [provider, providerConfig] of Object.entries(aiProvider)) {
-    if (!providerConfig?.enabled) continue;
+  if (!providerConfig?.enabled) return models;
 
-    for (const model of providerConfig.serverModelLists ?? []) {
-      if (!model.enabled || model.type !== 'chat') continue;
+  for (const model of providerConfig.serverModelLists ?? []) {
+    if (!model.enabled || model.type !== 'chat') continue;
 
-      for (const agentType of SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES) {
-        if (supportsServerDefaultHeterogeneousAgent(agentType, provider, model.id)) {
-          models[agentType].push({ model: model.id, providerId: provider });
-        }
+    for (const agentType of SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES) {
+      if (supportsServerDefaultHeterogeneousAgent(agentType, model.id)) {
+        models[agentType].push({ model: model.id });
       }
     }
   }
@@ -611,11 +595,10 @@ export const resolveServerModel = async (provider: string, model: string) => {
 /** Resolve a model only when it belongs to the selected CLI's V1 runtime path. */
 export const resolveServerDefaultHeterogeneousModel = async (
   agentType: ServerDefaultHeterogeneousAgentType,
-  provider: string,
   model: string,
 ) => {
-  const selection = await resolveServerModel(provider, model);
-  if (!supportsServerDefaultHeterogeneousAgent(agentType, selection.provider, selection.model)) {
+  const selection = await resolveServerModel(ModelProvider.LobeHub, model);
+  if (!supportsServerDefaultHeterogeneousAgent(agentType, selection.model)) {
     throw new Error('The selected server model is not compatible with this heterogeneous agent');
   }
 
@@ -625,26 +608,20 @@ export const resolveServerDefaultHeterogeneousModel = async (
 /** Initialize a deployment-owned runtime without reading user provider rows or keys. */
 export const initModelRuntimeFromServerConfig = async (params: {
   actorUserId: string;
-  provider: string;
   workspaceId?: string;
 }): Promise<ModelRuntime> => {
-  if (!Object.values(ModelProvider).includes(params.provider as ModelProvider)) {
-    throw new Error(
-      'Deployment-level custom providers are not supported for server-default agents',
-    );
-  }
   const businessHooks = getBusinessModelRuntimeHooks(
     params.actorUserId,
-    params.provider,
+    ModelProvider.LobeHub,
     params.workspaceId,
   );
   const tracingHooks = createLLMGenerationTracingHook(
     params.actorUserId,
-    params.provider,
+    ModelProvider.LobeHub,
     params.workspaceId,
   );
   return initModelRuntimeWithUserPayload(
-    params.provider,
+    ModelProvider.LobeHub,
     { userId: params.actorUserId },
     { userId: params.actorUserId },
     mergeModelRuntimeHooks(businessHooks, tracingHooks),

--- a/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultCapability.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultCapability.test.ts
@@ -14,8 +14,8 @@ describe('resolveServerDefaultHeterogeneousCapability', () => {
   beforeEach(() => {
     vi.stubEnv('ENABLE_SERVER_DEFAULT_HETEROGENEOUS_AGENT', '1');
     getSupportedModels.mockResolvedValue({
-      'claude-code': [{ model: 'claude-server', providerId: 'anthropic' }],
-      'codex': [{ model: 'gpt-5.4', providerId: 'openai' }],
+      'claude-code': [{ model: 'claude-sonnet-4-6' }],
+      'codex': [{ model: 'gpt-5.4' }],
     });
   });
 
@@ -30,8 +30,8 @@ describe('resolveServerDefaultHeterogeneousCapability', () => {
       enabled: true,
       model: 'lobehub-default',
       models: {
-        'claude-code': [{ model: 'claude-server', providerId: 'anthropic' }],
-        'codex': [{ model: 'gpt-5.4', providerId: 'openai' }],
+        'claude-code': [{ model: 'claude-sonnet-4-6' }],
+        'codex': [{ model: 'gpt-5.4' }],
       },
     });
 
@@ -40,7 +40,7 @@ describe('resolveServerDefaultHeterogeneousCapability', () => {
 
   it('advertises only agents that have a compatible runtime model', async () => {
     getSupportedModels.mockResolvedValue({
-      'claude-code': [{ model: 'claude-server', providerId: 'anthropic' }],
+      'claude-code': [{ model: 'claude-sonnet-4-6' }],
       'codex': [],
     });
 

--- a/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultOperation.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultOperation.test.ts
@@ -49,7 +49,6 @@ describe('server-default heterogeneous operation control', () => {
     agentType: 'codex' as const,
     model: 'gpt-5.4',
     operationId,
-    providerId: 'openai',
     topicId,
   });
 
@@ -59,10 +58,10 @@ describe('server-default heterogeneous operation control', () => {
     topicId = await createTestTopic(testDB, userId);
     vi.stubEnv('ENABLE_SERVER_DEFAULT_HETEROGENEOUS_AGENT', '1');
     getSupportedModels.mockResolvedValue({
-      'claude-code': [{ model: 'claude-server', providerId: 'anthropic' }],
-      'codex': [{ model: 'gpt-5.4', providerId: 'openai' }],
+      'claude-code': [{ model: 'claude-sonnet-4-6' }],
+      'codex': [{ model: 'gpt-5.4' }],
     });
-    resolveModel.mockResolvedValue({ model: 'gpt-5.4', provider: 'openai' });
+    resolveModel.mockResolvedValue({ model: 'gpt-5.4', provider: 'lobehub' });
     initRuntime.mockResolvedValue({});
     signOperationToken.mockResolvedValue('operation-token');
   });
@@ -85,7 +84,7 @@ describe('server-default heterogeneous operation control', () => {
     expect(operation).toMatchObject({
       metadata: { agentType: 'codex', serverDefaultHeterogeneous: true },
       model: 'gpt-5.4',
-      provider: 'openai',
+      provider: 'lobehub',
       status: 'running',
       topicId,
       userId,
@@ -95,14 +94,13 @@ describe('server-default heterogeneous operation control', () => {
       capabilities: ['model:invoke'],
       model: 'gpt-5.4',
       operationId: 'desktop-operation-1',
-      providerId: 'openai',
+      providerId: 'lobehub',
       userId,
       workspaceId: undefined,
     });
-    expect(resolveModel).toHaveBeenCalledWith('codex', 'openai', 'gpt-5.4');
+    expect(resolveModel).toHaveBeenCalledWith('codex', 'gpt-5.4');
     expect(initRuntime).toHaveBeenCalledWith({
       actorUserId: userId,
-      provider: 'openai',
       workspaceId: undefined,
     });
   });

--- a/apps/server/src/routers/lambda/aiAgent.ts
+++ b/apps/server/src/routers/lambda/aiAgent.ts
@@ -893,7 +893,6 @@ export const aiAgentRouter = router({
         agentId: z.string().optional(),
         model: z.string().min(1),
         operationId: z.string().min(1),
-        providerId: z.string().min(1),
         topicId: z.string().min(1),
       }),
     )
@@ -925,7 +924,6 @@ export const aiAgentRouter = router({
       }
       const selection = await resolveServerDefaultHeterogeneousModel(
         input.agentType,
-        input.providerId,
         input.model,
       ).catch((error) => {
         throw new TRPCError({
@@ -936,7 +934,6 @@ export const aiAgentRouter = router({
       });
       await initModelRuntimeFromServerConfig({
         actorUserId: ctx.userId,
-        provider: selection.provider,
         workspaceId,
       }).catch((error) => {
         log('Selected server model runtime is unavailable: %O', error);

--- a/packages/openapi/src/routes/anthropic.route.ts
+++ b/packages/openapi/src/routes/anthropic.route.ts
@@ -34,7 +34,6 @@ app.post('/v1/messages', requireHeteroModelInvocation, async (c) => {
     agentType: 'claude-code',
     model: claims.model,
     payload: normalizeAnthropicRequest(request, SERVER_DEFAULT_MODEL_ALIAS),
-    provider: claims.provider_id,
     signal: c.req.raw.signal,
     userId: String(context.get('userId')),
     workspaceId: typeof workspaceId === 'string' ? workspaceId : undefined,

--- a/packages/openapi/src/routes/openai.route.ts
+++ b/packages/openapi/src/routes/openai.route.ts
@@ -34,7 +34,6 @@ app.post('/v1/responses', requireHeteroModelInvocation, async (c) => {
     agentType: 'codex',
     model: claims.model,
     payload: normalizeResponsesRequest(request, SERVER_DEFAULT_MODEL_ALIAS),
-    provider: claims.provider_id,
     signal: c.req.raw.signal,
     userId: String(context.get('userId')),
     workspaceId: typeof workspaceId === 'string' ? workspaceId : undefined,

--- a/packages/openapi/src/services/heterogeneous-direct.service.test.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.test.ts
@@ -52,11 +52,11 @@ describe('heterogeneous direct invocation protocol', () => {
     vi.clearAllMocks();
   });
 
-  it('invokes Claude Code only through its resolved Anthropic runtime model', async () => {
+  it('invokes Claude Code through an Anthropic-compatible LobeHub relay model', async () => {
     const chat = vi.fn().mockResolvedValue(new Response('stream'));
     vi.mocked(resolveServerDefaultHeterogeneousModel).mockResolvedValue({
-      model: 'claude-server',
-      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      provider: 'lobehub',
     });
     vi.mocked(initModelRuntimeFromServerConfig).mockResolvedValue({
       chat,
@@ -64,23 +64,21 @@ describe('heterogeneous direct invocation protocol', () => {
 
     const result = await invokeServerDefaultModel({
       agentType: 'claude-code',
-      model: 'claude-server',
+      model: 'claude-sonnet-4-6',
       payload: { messages: [], model: 'lobehub-default', stream: true },
-      provider: 'anthropic',
       signal: new AbortController().signal,
       userId: 'user-1',
     });
 
-    expect(result.model).toBe('claude-server');
+    expect(result.model).toBe('claude-sonnet-4-6');
     expect(resolveServerDefaultHeterogeneousModel).toHaveBeenCalledWith(
       'claude-code',
-      'anthropic',
-      'claude-server',
+      'claude-sonnet-4-6',
     );
     expect(chat).toHaveBeenCalledWith(
       {
         messages: [],
-        model: 'claude-server',
+        model: 'claude-sonnet-4-6',
         stream: true,
       },
       expect.any(Object),
@@ -92,7 +90,7 @@ describe('heterogeneous direct invocation protocol', () => {
     vi.mocked(resolveServerDefaultHeterogeneousModel).mockResolvedValue({
       deploymentName: 'prod-gpt',
       model: 'gpt-5.4',
-      provider: 'openai',
+      provider: 'lobehub',
     });
     vi.mocked(initModelRuntimeFromServerConfig).mockResolvedValue({
       chat,
@@ -102,7 +100,6 @@ describe('heterogeneous direct invocation protocol', () => {
       agentType: 'codex',
       model: 'gpt-5.4',
       payload: { messages: [], model: 'lobehub-default', stream: true },
-      provider: 'openai',
       signal: new AbortController().signal,
       userId: 'user-1',
     });
@@ -121,9 +118,8 @@ describe('heterogeneous direct invocation protocol', () => {
     await expect(
       invokeServerDefaultModel({
         agentType: 'codex',
-        model: 'claude-server',
+        model: 'claude-sonnet-4-6',
         payload: { messages: [], model: 'lobehub-default', stream: true },
-        provider: 'anthropic',
         signal: new AbortController().signal,
         userId: 'user-1',
       }),

--- a/packages/openapi/src/services/heterogeneous-direct.service.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.ts
@@ -815,21 +815,18 @@ export const invokeServerDefaultModel = async (params: {
   agentType: ServerDefaultHeterogeneousAgentType;
   model: string;
   payload: ChatStreamPayload;
-  provider: string;
   signal: AbortSignal;
   userId: string;
   workspaceId?: string;
 }) => {
   const resolvedModel = await resolveServerDefaultHeterogeneousModel(
     params.agentType,
-    params.provider,
     params.model,
   );
-  const { deploymentName, provider } = resolvedModel;
+  const { deploymentName } = resolvedModel;
   const model = deploymentName ?? resolvedModel.model;
   const runtime = await initModelRuntimeFromServerConfig({
     actorUserId: params.userId,
-    provider,
     workspaceId: params.workspaceId,
   });
   const response = await runtime.chat(


### PR DESCRIPTION
## Description of Change

Pins server-default heterogeneous agents to the single LobeHub relay provider while keeping model selection available within that provider.

- Discover compatible models only from the enabled `aiProvider.lobehub` catalog.
- Expose model-only capability entries instead of a redundant `providerId` choice.
- Remove `providerId` from the operation-start contract and resolve it server-side.
- Initialize server-default runtimes with `ModelProvider.LobeHub` internally.
- Stop using operation JWT provider claims as routing input in the Anthropic and OpenAI direct endpoints; the server-generated claim remains bound to durable operation state for authorization.
- Keep the V1 protocol matrix strict: Claude Code accepts Anthropic-compatible Claude models, while Codex accepts OpenAI Responses models.

This supersedes #18579 by encoding the fixed-provider invariant in the API contract rather than accepting a provider argument and validating that it equals `lobehub`. The Desktop/UI client remains in #18568 and must consume the model-only contract.

#### Test

- 117 server tests passed across ModelRuntime, capability/operation control, operation principal, and heterogeneous ingest.
- 16 OpenAPI direct-protocol tests passed, including Responses usage/reasoning continuity coverage.
- `bun run check --lint` passed for all 9 changed files.
- Full type-check remains blocked by the existing duplicate Drizzle peer-instance errors; no errors point to the changed contract lines.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Follow-up correction to #18558. Supersedes #18579. Required by #18568.
