### PR TITLE
🐛 fix(heterogeneous-agent): initialize the deployment relay directly

### DIFF
--- a/apps/server/src/modules/ModelRuntime/index.test.ts
+++ b/apps/server/src/modules/ModelRuntime/index.test.ts
@@ -29,6 +29,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   buildPayloadFromKeyVaults,
   getServerDefaultHeterogeneousModels,
+  initModelRuntimeFromServerConfig,
   initModelRuntimeWithUserPayload,
   resolveServerDefaultHeterogeneousModel,
   resolveServerModel,
@@ -203,6 +204,24 @@ describe('resolveServerDefaultHeterogeneousModel', () => {
     await expect(resolveServerDefaultHeterogeneousModel('codex', 'gpt-4o')).rejects.toThrow(
       'not compatible with this heterogeneous agent',
     );
+  });
+});
+
+describe('initModelRuntimeFromServerConfig', () => {
+  it('initializes the LobeHub router directly without protocol-provider credentials', async () => {
+    const runtime = {} as ModelRuntime;
+    const initialize = vi.spyOn(ModelRuntime, 'initializeWithProvider').mockReturnValue(runtime);
+
+    await expect(
+      initModelRuntimeFromServerConfig({ actorUserId: 'user-1', workspaceId: 'workspace-1' }),
+    ).resolves.toBe(runtime);
+
+    expect(initialize).toHaveBeenCalledWith(
+      ModelProvider.LobeHub,
+      { userId: 'user-1' },
+      expect.anything(),
+    );
+    initialize.mockRestore();
   });
 });
 

--- a/apps/server/src/modules/ModelRuntime/index.ts
+++ b/apps/server/src/modules/ModelRuntime/index.ts
@@ -534,9 +534,11 @@ export type ServerDefaultHeterogeneousModels = Record<
 >;
 
 /**
- * Both CLIs use the single LobeHub relay provider. V1 restricts its models by
- * the protocol required by each CLI: Claude Code -> Anthropic Messages,
- * Codex -> OpenAI Responses.
+ * Both CLIs use the single LobeHub relay provider. `lobehub` is a deployment-
+ * owned router slot, not a hosted-only upstream: official and private
+ * distributions provide their own model catalog and RouterRuntime behind it.
+ * V1 restricts its models by the protocol required by each CLI: Claude Code ->
+ * Anthropic Messages, Codex -> OpenAI Responses.
  *
  * Do not widen this predicate to generic chat/function-calling models. Adding
  * another model/protocol path requires lossless continuation-state translation
@@ -605,7 +607,14 @@ export const resolveServerDefaultHeterogeneousModel = async (
   return selection;
 };
 
-/** Initialize a deployment-owned runtime without reading user provider rows or keys. */
+/**
+ * Initialize the deployment's single relay directly.
+ *
+ * Do not resolve `DEFAULT_AGENT_CONFIG` here or translate this into OpenAI /
+ * Anthropic environment credentials. Those names describe the two CLI ingress
+ * protocols only; the deployment-owned LobeHub RouterRuntime owns the one
+ * upstream endpoint, credentials, model routing, fallback, and billing policy.
+ */
 export const initModelRuntimeFromServerConfig = async (params: {
   actorUserId: string;
   workspaceId?: string;
@@ -620,9 +629,8 @@ export const initModelRuntimeFromServerConfig = async (params: {
     ModelProvider.LobeHub,
     params.workspaceId,
   );
-  return initModelRuntimeWithUserPayload(
+  return ModelRuntime.initializeWithProvider(
     ModelProvider.LobeHub,
-    { userId: params.actorUserId },
     { userId: params.actorUserId },
     mergeModelRuntimeHooks(businessHooks, tracingHooks),
   );


### PR DESCRIPTION
## Description of Change

Hardens the fixed-provider boundary introduced by #18581 for server-default heterogeneous agents.

Claude Code and Codex both use the deployment-owned `lobehub` relay provider. Anthropic Messages and OpenAI Responses are only the two CLI ingress protocols; they are not separate deployment providers and do not require separate `ANTHROPIC_*` / `OPENAI_*` runtime configuration.

- Initialize `ModelProvider.LobeHub` directly instead of passing through generic provider payload/environment resolution.
- Keep the deployment model catalog and RouterRuntime behind the single `lobehub` provider slot.
- Preserve the existing business hooks, tracing, user/workspace attribution, operation JWT binding, and model compatibility checks.
- Document that official and private distributions provide their own catalog and RouterRuntime behind this slot.

For CPC Enterprise, this means both CLIs reuse its existing branded RouterRuntime and `lobehub_router_runtime_config`: one deployment-managed upstream endpoint/key can route all supported Claude and GPT models. The Desktop/CLI still receives only the current LobeHub Server endpoint, `lobehub-default`, and the operation-scoped JWT.

### Test

- 70 ModelRuntime tests passed.
- 32 server-default operation/direct-protocol tests passed.
- Lint passed for both changed files.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### Related

Follow-up to #18581. Server foundation: #18558. Desktop client: #18568.