### PR TITLE
🐛 fix(agent-runtime): support slim compression payloads

### DIFF
--- a/packages/agent-runtime/src/agents/GeneralChatAgent.ts
+++ b/packages/agent-runtime/src/agents/GeneralChatAgent.ts
@@ -911,7 +911,7 @@ export class GeneralChatAgent implements Agent {
               ? { assistantMessageId: seededAssistantMessageId }
               : // Force create new assistant message after compression
                 { createAssistantMessage: true }),
-            messages: compressionPayload.compressedMessages,
+            messages: compressionPayload.compressedMessages ?? state.messages,
             model: this.config.modelRuntimeConfig?.model,
             parentMessageId: compressionPayload.parentMessageId,
             provider: this.config.modelRuntimeConfig?.provider,

--- a/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
+++ b/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
@@ -2102,6 +2102,32 @@ describe('GeneralChatAgent', () => {
       });
     });
 
+    it('should fall back to state messages when a new producer omits compressed messages', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        operationId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+      const compressedMessages = [
+        { content: 'Compressed summary', id: 'group-1', role: 'compressedGroup' },
+        { content: 'Latest user follow-up', role: 'user' },
+      ] as any;
+      const state = createMockState({ messages: compressedMessages });
+      const context = createMockContext('compression_result', {
+        groupId: 'group-1',
+        parentMessageId: 'assistant-msg-after-compression',
+      });
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          payload: expect.objectContaining({ messages: compressedMessages }),
+          type: 'call_llm',
+        }),
+      );
+    });
+
     // High-context tool-first resume: when the first post-tool turn compresses
     // before running, the seeded placeholder must still be reused after
     // compression rather than orphaned by createAssistantMessage.

--- a/packages/agent-runtime/src/types/generalAgent.ts
+++ b/packages/agent-runtime/src/types/generalAgent.ts
@@ -129,7 +129,7 @@ export interface GeneralAgentConfig {
  */
 export interface GeneralAgentCompressionResultPayload {
   /** Compressed messages (summary + pinned + recent) */
-  compressedMessages: any[];
+  compressedMessages?: any[];
   /** Compression group ID in database */
   groupId: string;
   /** Parent message ID for subsequent LLM call (last assistant message before compression) */


### PR DESCRIPTION
## Summary

- make `compressedMessages` optional in the `compression_result` payload contract
- fall back to the persisted `state.messages` when a producer omits the field
- add regression coverage for the mixed producer/consumer contract

## Why

This is phase 1 of the `FUNCTION_PAYLOAD_TOO_LARGE` fix. It preserves the existing producer dual-write so old workers remain compatible during rolling deployment. Once this consumer fallback has been deployed, phase 2 can safely stop embedding the full `compressedMessages` array in QStash requests.

## Testing

- `bun run check packages/agent-runtime/src/types/generalAgent.ts packages/agent-runtime/src/agents/GeneralChatAgent.ts packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts`
- 85 tests passed, lint clean