### PR TITLE
🐛 fix: prevent Topic Doctor FK errors on compressed topics

### DIFF
--- a/packages/conversation-flow/src/doctor/__tests__/diagnose.test.ts
+++ b/packages/conversation-flow/src/doctor/__tests__/diagnose.test.ts
@@ -431,6 +431,29 @@ describe('diagnoseTopic', () => {
       ]);
     });
 
+    it('uses the last real message behind a compression group as the repair parent', () => {
+      const compressedGroup = {
+        content: 'Earlier conversation summary',
+        createdAt: 10,
+        id: 'mg1',
+        lastMessageId: 'a1',
+        role: 'compressedGroup',
+        updatedAt: 10,
+      } as unknown as Message;
+      const messages = [
+        compressedGroup,
+        ...build([
+          { content: 'question after reconnect', id: 'u2', role: 'user', t: 100 },
+          { content: 'answer after reconnect', id: 'a2', parent: 'u2', role: 'assistant', t: 110 },
+        ]),
+      ];
+
+      const diagnosis = diagnoseTopic(messages);
+
+      expect(diagnosis.patch).toEqual([{ messageId: 'u2', parentId: 'a1', type: 'reparent' }]);
+      expect(diagnoseTopic(applyPatch(messages, diagnosis.patch)).issues).toHaveLength(0);
+    });
+
     it('chains several stranded sections back in time order', () => {
       const three = build([
         { content: 'q1', id: 'u1', role: 'user', t: 0 },

--- a/packages/conversation-flow/src/doctor/diagnose.ts
+++ b/packages/conversation-flow/src/doctor/diagnose.ts
@@ -68,9 +68,22 @@ const isEmptyShell = (message: Message): boolean =>
   !message.usage &&
   !(message.metadata as { usage?: unknown } | null | undefined)?.usage;
 
-/** Mirrors the write-side anchor rule: tool messages and toolless signal turns are never a spine tail. */
-const canAnchor = (message: Message): boolean =>
-  message.role !== 'tool' && !getSignal(message) && !isEmptyShell(message);
+/**
+ * Return the real message id a repair can safely use as a parent.
+ *
+ * Compression groups are synthetic display nodes, but their last message remains a real row
+ * and is the write-side parent for turns that continue after the group. Compare groups have no
+ * single equivalent parent, so they must not be used as repair anchors.
+ */
+const getAnchorId = (message: Message): string | undefined => {
+  if (message.role === 'compressedGroup') {
+    const lastMessageId = (message as Message & { lastMessageId?: unknown }).lastMessageId;
+    return typeof lastMessageId === 'string' ? lastMessageId : undefined;
+  }
+  if (message.role === 'compareGroup') return undefined;
+  if (message.role === 'tool' || getSignal(message) || isEmptyShell(message)) return undefined;
+  return message.id;
+};
 
 const timeSpan = (messages: Message[]): [number, number] => [
   Math.min(...messages.map((m) => m.createdAt)),
@@ -99,12 +112,30 @@ export const diagnoseTopic = (
   const sorted = [...mainFlow].sort((a, b) => a.createdAt - b.createdAt);
   const byId = new Map(sorted.map((m) => [m.id, m]));
 
+  // The renderer redirects children of the last compressed message to the synthetic group.
+  // Mirror that relationship here so a repaired, FK-valid parentId is not diagnosed as a
+  // dangling parent on the next pass.
+  const compressedGroupByLastMessageId = new Map<string, string>();
+  for (const message of sorted) {
+    if (message.role !== 'compressedGroup') continue;
+    const lastMessageId = (message as Message & { lastMessageId?: unknown }).lastMessageId;
+    if (typeof lastMessageId === 'string') {
+      compressedGroupByLastMessageId.set(lastMessageId, message.id);
+    }
+  }
+  const resolveParentId = (parentId?: string | null): string | undefined => {
+    if (!parentId) return undefined;
+    if (byId.has(parentId)) return parentId;
+    return compressedGroupByLastMessageId.get(parentId);
+  };
+
   const childrenOf = new Map<string, Message[]>();
   for (const message of sorted) {
-    if (!message.parentId || !byId.has(message.parentId)) continue;
-    const siblings = childrenOf.get(message.parentId) ?? [];
+    const parentId = resolveParentId(message.parentId);
+    if (!parentId) continue;
+    const siblings = childrenOf.get(parentId) ?? [];
     siblings.push(message);
-    childrenOf.set(message.parentId, siblings);
+    childrenOf.set(parentId, siblings);
   }
 
   const subtreeOf = (rootId: string): Message[] => {
@@ -157,7 +188,7 @@ export const diagnoseTopic = (
   //    message is stranded". It is disjoint from the fork/branch rules by construction: those
   //    walk `childrenOf`, which only links messages to a parent that exists, so a root is
   //    never one of their branches.
-  const roots = sorted.filter((m) => !m.parentId || !byId.has(m.parentId));
+  const roots = sorted.filter((m) => !resolveParentId(m.parentId));
   if (roots.length > 1) {
     // The earliest root is the conversation's real start and stays put; the rest are splits.
     const [, ...strandedRoots] = roots;
@@ -174,9 +205,10 @@ export const diagnoseTopic = (
       // a message inside this very section can't anchor it.
       const sectionIds = new Set(section.map((m) => m.id));
       const anchor = sorted
-        .filter((m) => canAnchor(m) && m.createdAt < root.createdAt && !sectionIds.has(m.id))
+        .filter((m) => getAnchorId(m) && m.createdAt < root.createdAt && !sectionIds.has(m.id))
         .sort((a, b) => b.createdAt - a.createdAt)[0];
-      if (!anchor) continue;
+      const anchorId = anchor && getAnchorId(anchor);
+      if (!anchorId) continue;
 
       report(
         {
@@ -186,7 +218,7 @@ export const diagnoseTopic = (
           reattachedMessageIds: section.map((m) => m.id),
           repairable: true,
         },
-        { messageId: root.id, parentId: anchor.id, type: 'reparent' },
+        { messageId: root.id, parentId: anchorId, type: 'reparent' },
       );
     }
   }
@@ -215,8 +247,9 @@ export const diagnoseTopic = (
         // anchor. The user's message belongs after that run, on the tail of its spine.
         const runIds = new Set(runSubtree.map((m) => m.id));
         const anchor = [...runSubtree]
-          .filter((m) => canAnchor(m))
+          .filter((m) => getAnchorId(m))
           .sort((a, b) => b.createdAt - a.createdAt)[0];
+        const anchorId = anchor && getAnchorId(anchor);
 
         // The shape is wrong, but if the reader still gets everything on screen there is
         // nothing to fix and no reason to rewrite the user's history.
@@ -228,10 +261,10 @@ export const diagnoseTopic = (
             hiddenMessageIds: hiddenHere,
             kind: 'concurrent-fork',
             messageId: parentId,
-            repairable: !!anchor && !runIds.has(userTurn.id),
+            repairable: !!anchorId && !runIds.has(userTurn.id),
           },
-          anchor && !runIds.has(userTurn.id)
-            ? { messageId: userTurn.id, parentId: anchor.id, type: 'reparent' }
+          anchorId && !runIds.has(userTurn.id)
+            ? { messageId: userTurn.id, parentId: anchorId, type: 'reparent' }
             : undefined,
         );
       }

--- a/packages/database/src/repositories/topicDoctor/index.test.ts
+++ b/packages/database/src/repositories/topicDoctor/index.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getTestDB } from '../../core/getTestDB';
+import { messages } from '../../schemas/message';
+import { topics } from '../../schemas/topic';
+import { users } from '../../schemas/user';
+import type { LobeChatDatabase } from '../../type';
+import { TopicDoctorRepo } from './index';
+
+const userId = 'topic-doctor-test-user';
+const topicId = 'topic-doctor-test-topic';
+
+const serverDB: LobeChatDatabase = await getTestDB();
+
+beforeEach(async () => {
+  await serverDB.delete(messages);
+  await serverDB.delete(topics);
+  await serverDB.delete(users);
+  await serverDB.insert(users).values({ id: userId });
+  await serverDB.insert(topics).values({ id: topicId, userId });
+});
+
+describe('TopicDoctorRepo', () => {
+  it('skips a reparent operation whose parent is not a real message in the topic', async () => {
+    await serverDB.insert(messages).values({
+      content: 'stranded question',
+      id: 'u2',
+      role: 'user',
+      topicId,
+      userId,
+    });
+
+    const repo = new TopicDoctorRepo(serverDB, userId);
+    vi.spyOn(repo, 'diagnose').mockResolvedValue({
+      hiddenCount: 0,
+      issues: [
+        {
+          hiddenMessageIds: [],
+          kind: 'segment-split',
+          messageId: 'u2',
+          reattachedMessageIds: ['u2'],
+          repairable: true,
+        },
+      ],
+      patch: [{ messageId: 'u2', parentId: 'mg1', type: 'reparent' }],
+    });
+
+    const result = await repo.repair({ topicId });
+
+    expect(result.applied).toBe(0);
+    const row = await serverDB.query.messages.findFirst({
+      where: (table, { eq }) => eq(table.id, 'u2'),
+    });
+    expect(row?.parentId).toBeNull();
+  });
+
+  it('applies a reparent operation when both messages belong to the topic', async () => {
+    await serverDB.insert(messages).values([
+      { content: 'previous answer', id: 'a1', role: 'assistant', topicId, userId },
+      { content: 'stranded question', id: 'u2', role: 'user', topicId, userId },
+    ]);
+
+    const repo = new TopicDoctorRepo(serverDB, userId);
+    vi.spyOn(repo, 'diagnose').mockResolvedValue({
+      hiddenCount: 0,
+      issues: [
+        {
+          hiddenMessageIds: [],
+          kind: 'segment-split',
+          messageId: 'u2',
+          reattachedMessageIds: ['u2'],
+          repairable: true,
+        },
+      ],
+      patch: [{ messageId: 'u2', parentId: 'a1', type: 'reparent' }],
+    });
+
+    const result = await repo.repair({ topicId });
+
+    expect(result.applied).toBe(1);
+    const row = await serverDB.query.messages.findFirst({
+      where: (table, { eq }) => eq(table.id, 'u2'),
+    });
+    expect(row?.parentId).toBe('a1');
+  });
+});

--- a/packages/database/src/repositories/topicDoctor/index.test.ts
+++ b/packages/database/src/repositories/topicDoctor/index.test.ts
@@ -49,6 +49,7 @@ describe('TopicDoctorRepo', () => {
     const result = await repo.repair({ topicId });
 
     expect(result.applied).toBe(0);
+    expect(result.restoredMessageIds).toEqual([]);
     const row = await serverDB.query.messages.findFirst({
       where: (table, { eq }) => eq(table.id, 'u2'),
     });
@@ -79,6 +80,7 @@ describe('TopicDoctorRepo', () => {
     const result = await repo.repair({ topicId });
 
     expect(result.applied).toBe(1);
+    expect(result.restoredMessageIds).toEqual(['u2']);
     const row = await serverDB.query.messages.findFirst({
       where: (table, { eq }) => eq(table.id, 'u2'),
     });

--- a/packages/database/src/repositories/topicDoctor/index.ts
+++ b/packages/database/src/repositories/topicDoctor/index.ts
@@ -56,6 +56,15 @@ export class TopicDoctorRepo {
     const { patch } = diagnosis;
     if (patch.length === 0) return { applied: 0, restoredMessageIds: [] };
 
+    // `diagnoseTopic()` appends one patch for each repairable issue, in issue order.
+    // Keep them paired so a repair rejected by the write-side validation cannot still be
+    // reported to the client as restored.
+    const repairableIssues = diagnosis.issues.filter((issue) => issue.repairable);
+    if (repairableIssues.length !== patch.length) {
+      throw new Error('Topic Doctor diagnosis returned mismatched issues and repair operations');
+    }
+    const repairs = patch.map((op, index) => ({ issue: repairableIssues[index]!, op }));
+
     // Only ever touch real rows of this topic that the caller owns. The synthetic group
     // nodes `query()` splices into the list are not messages and must never be written to.
     const rowIds = [
@@ -73,12 +82,12 @@ export class TopicDoctorRepo {
       );
 
     const rowById = new Map(rows.map((row) => [row.id, row]));
-    const writable = patch.filter(
-      (op) => rowById.has(op.messageId) && (op.type !== 'reparent' || rowById.has(op.parentId)),
+    const writable = repairs.filter(
+      ({ op }) => rowById.has(op.messageId) && (op.type !== 'reparent' || rowById.has(op.parentId)),
     );
 
     await this.db.transaction(async (tx) => {
-      for (const op of writable) {
+      for (const { op } of writable) {
         const current = rowById.get(op.messageId)!;
         const metadata = (current.metadata ?? {}) as Record<string, any>;
 
@@ -109,7 +118,7 @@ export class TopicDoctorRepo {
     // from the model's context — putting them back in the chain is the point of the fix.
     const restoredMessageIds = [
       ...new Set(
-        diagnosis.issues.flatMap((issue) => [
+        writable.flatMap(({ issue }) => [
           ...issue.hiddenMessageIds,
           ...(issue.reattachedMessageIds ?? []),
         ]),

--- a/packages/database/src/repositories/topicDoctor/index.ts
+++ b/packages/database/src/repositories/topicDoctor/index.ts
@@ -58,26 +58,28 @@ export class TopicDoctorRepo {
 
     // Only ever touch real rows of this topic that the caller owns. The synthetic group
     // nodes `query()` splices into the list are not messages and must never be written to.
-    const targets = await this.db
+    const rowIds = [
+      ...new Set(
+        patch.flatMap((op) =>
+          op.type === 'reparent' ? [op.messageId, op.parentId] : [op.messageId],
+        ),
+      ),
+    ];
+    const rows = await this.db
       .select({ id: messages.id, metadata: messages.metadata, parentId: messages.parentId })
       .from(messages)
       .where(
-        and(
-          eq(messages.topicId, scope.topicId),
-          this.ws(messages),
-          inArray(
-            messages.id,
-            patch.map((op) => op.messageId),
-          ),
-        ),
+        and(eq(messages.topicId, scope.topicId), this.ws(messages), inArray(messages.id, rowIds)),
       );
 
-    const targetById = new Map(targets.map((row) => [row.id, row]));
-    const writable = patch.filter((op) => targetById.has(op.messageId));
+    const rowById = new Map(rows.map((row) => [row.id, row]));
+    const writable = patch.filter(
+      (op) => rowById.has(op.messageId) && (op.type !== 'reparent' || rowById.has(op.parentId)),
+    );
 
     await this.db.transaction(async (tx) => {
       for (const op of writable) {
-        const current = targetById.get(op.messageId)!;
+        const current = rowById.get(op.messageId)!;
         const metadata = (current.metadata ?? {}) as Record<string, any>;
 
         // Keep what the row looked like before, so a bad repair can be walked back.
@@ -107,7 +109,10 @@ export class TopicDoctorRepo {
     // from the model's context — putting them back in the chain is the point of the fix.
     const restoredMessageIds = [
       ...new Set(
-        diagnosis.issues.flatMap((i) => [...i.hiddenMessageIds, ...(i.reattachedMessageIds ?? [])]),
+        diagnosis.issues.flatMap((issue) => [
+          ...issue.hiddenMessageIds,
+          ...(issue.reattachedMessageIds ?? []),
+        ]),
       ),
     ];
 


### PR DESCRIPTION
## Summary

- use a compression group's last real message as the Topic Doctor repair anchor
- mirror the renderer's compressed-parent resolution during diagnosis
- validate reparent targets in the same topic and workspace before database writes

## Why

`MessageModel.query()` replaces compressed messages with a synthetic `compressedGroup`. Topic Doctor could emit that group's ID as `messages.parent_id`, causing a foreign-key failure. This change keeps repair patches backed by real message rows and skips stale or invalid reparent operations at write time.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check packages/conversation-flow/src/doctor/diagnose.ts packages/conversation-flow/src/doctor/__tests__/diagnose.test.ts packages/database/src/repositories/topicDoctor/index.ts packages/database/src/repositories/topicDoctor/index.test.ts` — 26 tests passed.

The targeted TypeScript check for the four changed files also passed.

#### 🔗 Related Issue

Fixes #18582
