### PR TITLE
🐛 fix(heterogeneous-agent): load default relay models

### DIFF
--- a/apps/server/src/modules/ModelRuntime/index.test.ts
+++ b/apps/server/src/modules/ModelRuntime/index.test.ts
@@ -36,6 +36,11 @@ import {
 } from './index';
 
 const getServerGlobalConfig = vi.hoisted(() => vi.fn());
+const loadModels = vi.hoisted(() => vi.fn());
+
+vi.mock('@/business/client/model-bank/loadModels', () => ({
+  loadModels,
+}));
 
 vi.mock('@/server/globalConfig', () => ({
   getServerGlobalConfig,
@@ -163,6 +168,42 @@ describe('getServerDefaultHeterogeneousModels', () => {
       'codex': [{ model: 'gpt-5.4' }],
     });
   });
+
+  it('uses the model bank when the deployment has no explicit server model list', async () => {
+    getServerGlobalConfig.mockResolvedValue({
+      aiProvider: {
+        lobehub: { enabled: true, serverModelLists: undefined },
+      },
+    });
+    loadModels.mockResolvedValue([
+      {
+        enabled: true,
+        id: 'claude-sonnet-4-6',
+        providerId: 'lobehub',
+        source: 'builtin',
+        type: 'chat',
+      },
+      {
+        enabled: true,
+        id: 'gpt-5.4',
+        providerId: 'lobehub',
+        source: 'builtin',
+        type: 'chat',
+      },
+      {
+        enabled: true,
+        id: 'claude-opus-4-8',
+        providerId: 'anthropic',
+        source: 'builtin',
+        type: 'chat',
+      },
+    ]);
+
+    await expect(getServerDefaultHeterogeneousModels()).resolves.toEqual({
+      'claude-code': [{ model: 'claude-sonnet-4-6' }],
+      'codex': [{ model: 'gpt-5.4' }],
+    });
+  });
 });
 
 describe('resolveServerDefaultHeterogeneousModel', () => {
@@ -204,6 +245,27 @@ describe('resolveServerDefaultHeterogeneousModel', () => {
     await expect(resolveServerDefaultHeterogeneousModel('codex', 'gpt-4o')).rejects.toThrow(
       'not compatible with this heterogeneous agent',
     );
+  });
+
+  it('resolves a model-bank model when no explicit server model list exists', async () => {
+    getServerGlobalConfig.mockResolvedValue({
+      aiProvider: {
+        lobehub: { enabled: true, serverModelLists: undefined },
+      },
+    });
+    loadModels.mockResolvedValue([
+      {
+        enabled: true,
+        id: 'claude-sonnet-4-6',
+        providerId: 'lobehub',
+        source: 'builtin',
+        type: 'chat',
+      },
+    ]);
+
+    await expect(
+      resolveServerDefaultHeterogeneousModel('claude-code', 'claude-sonnet-4-6'),
+    ).resolves.toEqual({ model: 'claude-sonnet-4-6', provider: 'lobehub' });
   });
 });
 

--- a/apps/server/src/modules/ModelRuntime/index.ts
+++ b/apps/server/src/modules/ModelRuntime/index.ts
@@ -26,6 +26,7 @@ import { ModelProvider } from 'model-bank';
 import { AiProviderBaseURLSchema } from 'model-bank/aiProvider';
 import { DEFAULT_MODEL_PROVIDER_LIST } from 'model-bank/modelProviders';
 
+import { loadModels } from '@/business/client/model-bank/loadModels';
 import { getBusinessModelRuntimeHooks } from '@/business/server/model-runtime';
 import { AiProviderModel } from '@/database/models/aiProvider';
 import { type LobeChatDatabase } from '@/database/type';
@@ -552,17 +553,22 @@ const supportsServerDefaultHeterogeneousAgent = (
     ? parseClaudeModelId(model) !== undefined
     : isResponsesAPIModel(model);
 
+const getEnabledServerChatModels = async (provider: ModelProvider) => {
+  const providerConfig = (await getServerGlobalConfig()).aiProvider[provider];
+  if (!providerConfig?.enabled) return [];
+
+  const models =
+    providerConfig.serverModelLists ??
+    (await loadModels()).filter((model) => model.providerId === provider);
+
+  return models.filter((model) => model.enabled && model.type === 'chat');
+};
+
 /** Return compatible models from the single deployment-owned relay provider. */
 export const getServerDefaultHeterogeneousModels = async () => {
   const models: ServerDefaultHeterogeneousModels = { 'claude-code': [], 'codex': [] };
-  const { aiProvider } = await getServerGlobalConfig();
-  const providerConfig = aiProvider[ModelProvider.LobeHub];
 
-  if (!providerConfig?.enabled) return models;
-
-  for (const model of providerConfig.serverModelLists ?? []) {
-    if (!model.enabled || model.type !== 'chat') continue;
-
+  for (const model of await getEnabledServerChatModels(ModelProvider.LobeHub)) {
     for (const agentType of SERVER_DEFAULT_HETEROGENEOUS_AGENT_TYPES) {
       if (supportsServerDefaultHeterogeneousAgent(agentType, model.id)) {
         models[agentType].push({ model: model.id });
@@ -578,11 +584,10 @@ export const resolveServerModel = async (provider: string, model: string) => {
   if (!Object.values(ModelProvider).includes(provider as ModelProvider)) {
     throw new Error('Deployment-level custom providers are not supported for server agents');
   }
-  const providerConfig = (await getServerGlobalConfig()).aiProvider[provider as ModelProvider];
-  const modelConfig = providerConfig?.serverModelLists?.find(
-    (item) => item.id === model && item.enabled && item.type === 'chat',
+  const modelConfig = (await getEnabledServerChatModels(provider as ModelProvider)).find(
+    (item) => item.id === model,
   );
-  if (!providerConfig?.enabled || !modelConfig) {
+  if (!modelConfig) {
     throw new Error('The selected server model is not available');
   }
   return {


### PR DESCRIPTION
## Description of Change

Fixes server-default heterogeneous capability discovery when the deployment provider uses its model-bank catalog without an explicit `serverModelLists` override.

`serverModelLists` is an optional deployment override. Capability discovery previously treated an absent override as an empty catalog, so no compatible Claude Code or Codex model was advertised even though the enabled provider had compatible model-bank models.

The model runtime now:

- keeps an explicit `serverModelLists` override authoritative, including an explicit empty list;
- falls back to the provider's model-bank models only when the override is absent;
- shares the same enabled chat-model resolution between capability discovery and invocation validation.

## Key Decisions / Non-goals

- Use nullish fallback so an intentional empty override remains empty.
- Keep provider-enabled, model-enabled, chat-type, and protocol compatibility checks unchanged.
- Do not bypass capability validation in the client or widen the supported V1 protocol matrix.

#### Test

- `bun run check lobehub/apps/server/src/modules/ModelRuntime/index.ts lobehub/apps/server/src/modules/ModelRuntime/index.test.ts`
  - lint clean
  - 72 tests passed
- `bun run check --type`
  - types clean

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed
