### PR TITLE
🐛 fix(heterogeneous-agent): persist server-default API binding

### DIFF
--- a/packages/database/src/models/__tests__/agent.test.ts
+++ b/packages/database/src/models/__tests__/agent.test.ts
@@ -1270,6 +1270,38 @@ describe('AgentModel', () => {
       });
     });
 
+    it('should not persist a client-selected provider for the deployment API binding', async () => {
+      const agent = await agentModel.create({
+        agencyConfig: {
+          heterogeneousProvider: {
+            authMode: 'api',
+            type: 'claude-code',
+          },
+        },
+      });
+
+      await agentModel.updateConfig(agent.id, {
+        agencyConfig: {
+          heterogeneousProvider: {
+            apiConfig: {
+              apiKey: 'must-not-persist',
+              model: 'claude-server',
+              providerId: 'must-not-persist',
+              smallFastModel: 'must-not-persist',
+              source: 'server-default',
+            },
+          },
+        },
+      } as any);
+
+      const result = await serverDB.query.agents.findFirst({ where: eq(agents.id, agent.id) });
+
+      expect(result?.agencyConfig?.heterogeneousProvider?.apiConfig).toEqual({
+        model: 'claude-server',
+        source: 'server-default',
+      });
+    });
+
     it('should update updatedAt even when only updating meta fields like avatar', async () => {
       const agent = await serverDB
         .insert(agents)

--- a/packages/database/src/models/__tests__/agent.test.ts
+++ b/packages/database/src/models/__tests__/agent.test.ts
@@ -1270,6 +1270,45 @@ describe('AgentModel', () => {
       });
     });
 
+    it('should preserve omitted API binding fields during same-provider partial updates', async () => {
+      const agent = await agentModel.create({
+        agencyConfig: {
+          heterogeneousProvider: {
+            apiConfig: {
+              model: 'claude-primary',
+              providerId: 'anthropic',
+              smallFastModel: 'claude-fast',
+            },
+            authMode: 'api',
+            type: 'claude-code',
+          },
+        },
+      });
+
+      await agentModel.updateConfig(agent.id, {
+        agencyConfig: {
+          heterogeneousProvider: {
+            apiConfig: { smallFastModel: 'claude-fast-updated' },
+          },
+        },
+      });
+      await agentModel.updateConfig(agent.id, {
+        agencyConfig: {
+          heterogeneousProvider: {
+            apiConfig: { model: 'claude-primary-updated' },
+          },
+        },
+      });
+
+      const result = await serverDB.query.agents.findFirst({ where: eq(agents.id, agent.id) });
+
+      expect(result?.agencyConfig?.heterogeneousProvider?.apiConfig).toEqual({
+        model: 'claude-primary-updated',
+        providerId: 'anthropic',
+        smallFastModel: 'claude-fast-updated',
+      });
+    });
+
     it('should not persist a client-selected provider for the deployment API binding', async () => {
       const agent = await agentModel.create({
         agencyConfig: {

--- a/packages/database/src/models/__tests__/agent.test.ts
+++ b/packages/database/src/models/__tests__/agent.test.ts
@@ -1302,6 +1302,39 @@ describe('AgentModel', () => {
       });
     });
 
+    it('should replace a deployment API binding when switching to a user provider', async () => {
+      const agent = await agentModel.create({
+        agencyConfig: {
+          heterogeneousProvider: {
+            apiConfig: {
+              model: 'claude-server',
+              source: 'server-default',
+            },
+            authMode: 'api',
+            type: 'claude-code',
+          },
+        },
+      } as any);
+
+      await agentModel.updateConfig(agent.id, {
+        agencyConfig: {
+          heterogeneousProvider: {
+            apiConfig: {
+              model: 'claude-primary',
+              providerId: 'anthropic',
+            },
+          },
+        },
+      });
+
+      const result = await serverDB.query.agents.findFirst({ where: eq(agents.id, agent.id) });
+
+      expect(result?.agencyConfig?.heterogeneousProvider?.apiConfig).toEqual({
+        model: 'claude-primary',
+        providerId: 'anthropic',
+      });
+    });
+
     it('should update updatedAt even when only updating meta fields like avatar', async () => {
       const agent = await serverDB
         .insert(agents)

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -1404,6 +1404,20 @@ export class AgentModel {
     }
 
     const mergedValue = merge(agent, restData);
+
+    // API bindings are discriminated snapshots, not partial nested config. Deep-merging a
+    // provider patch into a server-default binding would retain the old `source` discriminator.
+    const heterogeneousProviderPatch = data.agencyConfig?.heterogeneousProvider;
+    if (heterogeneousProviderPatch && Object.hasOwn(heterogeneousProviderPatch, 'apiConfig')) {
+      mergedValue.agencyConfig = {
+        ...mergedValue.agencyConfig,
+        heterogeneousProvider: {
+          ...mergedValue.agencyConfig?.heterogeneousProvider,
+          apiConfig: heterogeneousProviderPatch.apiConfig,
+        },
+      } as AgentItem['agencyConfig'];
+    }
+
     mergedValue.agencyConfig = sanitizeAgentApiConfig(mergedValue.agencyConfig) ?? null;
 
     // The inbox is LobeHub's built-in default cloud agent; it must never be

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_WORKSPACE_AGENT_SELECTION_POLICIES,
   pruneWorkingDirByDeviceDeletes,
 } from '@lobechat/types';
+import { toRecord } from '@lobechat/utils/object';
 import { TRPCError } from '@trpc/server';
 import {
   and,
@@ -1405,17 +1406,17 @@ export class AgentModel {
 
     const mergedValue = merge(agent, restData);
 
-    // API bindings are discriminated snapshots, not partial nested config. Deep-merging a
-    // provider patch into a server-default binding would retain the old `source` discriminator.
-    const heterogeneousProviderPatch = data.agencyConfig?.heterogeneousProvider;
-    if (heterogeneousProviderPatch && Object.hasOwn(heterogeneousProviderPatch, 'apiConfig')) {
-      mergedValue.agencyConfig = {
-        ...mergedValue.agencyConfig,
-        heterogeneousProvider: {
-          ...mergedValue.agencyConfig?.heterogeneousProvider,
-          apiConfig: heterogeneousProviderPatch.apiConfig,
-        },
-      } as AgentItem['agencyConfig'];
+    // API bindings follow updateConfig's partial deep-merge contract. A user-provider patch must
+    // only clear the deployment discriminator retained from a previous server-default binding.
+    const apiConfigPatch = toRecord(data.agencyConfig?.heterogeneousProvider?.apiConfig);
+    const mergedApiConfig = toRecord(mergedValue.agencyConfig?.heterogeneousProvider?.apiConfig);
+    if (
+      apiConfigPatch &&
+      apiConfigPatch.source !== 'server-default' &&
+      typeof apiConfigPatch.providerId === 'string' &&
+      mergedApiConfig
+    ) {
+      delete mergedApiConfig.source;
     }
 
     mergedValue.agencyConfig = sanitizeAgentApiConfig(mergedValue.agencyConfig) ?? null;

--- a/packages/database/src/utils/sanitizeAgentApiConfig.ts
+++ b/packages/database/src/utils/sanitizeAgentApiConfig.ts
@@ -12,18 +12,23 @@ export const sanitizeAgentApiConfig = (
 
   const rawApiConfig = heterogeneousProvider.apiConfig;
   let apiConfig: HeterogeneousApiConfig | undefined;
-  if (
-    isRecord(rawApiConfig) &&
-    typeof rawApiConfig.model === 'string' &&
-    typeof rawApiConfig.providerId === 'string'
-  ) {
-    apiConfig = {
-      model: rawApiConfig.model,
-      providerId: rawApiConfig.providerId,
-      ...(typeof rawApiConfig.smallFastModel === 'string' || rawApiConfig.smallFastModel === null
-        ? { smallFastModel: rawApiConfig.smallFastModel }
-        : {}),
-    };
+  if (isRecord(rawApiConfig) && typeof rawApiConfig.model === 'string') {
+    if (rawApiConfig.source === 'server-default') {
+      // This server compatibility path intentionally lands before clients widen the shared
+      // config union to include the deployment-owned binding shape.
+      apiConfig = {
+        model: rawApiConfig.model,
+        source: 'server-default',
+      } as unknown as HeterogeneousApiConfig;
+    } else if (typeof rawApiConfig.providerId === 'string') {
+      apiConfig = {
+        model: rawApiConfig.model,
+        providerId: rawApiConfig.providerId,
+        ...(typeof rawApiConfig.smallFastModel === 'string' || rawApiConfig.smallFastModel === null
+          ? { smallFastModel: rawApiConfig.smallFastModel }
+          : {}),
+      };
+    }
   }
 
   return {


### PR DESCRIPTION
## Description of Change

Accept and persist the deployment-owned heterogeneous API binding before the client rollout.

- preserve the reference-only `{ model, source: 'server-default' }` shape
- strip client-supplied provider ids, credentials, and fast-model fields from that binding
- clear a stale deployment discriminator when explicitly switching back to a user provider
- preserve the existing partial deep-merge behavior for same-provider API binding updates
- add database regression tests covering persistence, reverse transitions, and partial updates

### Key Decisions / Non-goals

- This is the server-first compatibility step for #18568. The client PR owns the widened shared TypeScript union and UI/runtime consumers, so current `canary` clients remain type-compatible during rollout.
- `apiConfig` follows the existing `updateConfig` partial deep-merge contract. Only an explicit user-provider patch clears a retained `server-default` discriminator.
- No data migration is required; affected clients can save the binding again after this server change is deployed.
- This PR does not change capability discovery or model availability.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check lobehub/packages/database/src/models/agent.ts lobehub/packages/database/src/utils/sanitizeAgentApiConfig.ts lobehub/packages/database/src/models/__tests__/agent.test.ts --lint --test --type`

- lint clean
- 164 tests passed
- types clean

#### 🔗 Related Issue

Related to #18568
