### PR TITLE
🐛 fix(task): auto-complete successful subtasks

### DIFF
--- a/apps/server/src/services/taskLifecycle/index.ts
+++ b/apps/server/src/services/taskLifecycle/index.ts
@@ -277,7 +277,14 @@ export class TaskLifecycleService {
           await this.recordAutomationRecovery(currentTask);
           await this.taskModel.updateStatus(taskId, 'scheduled', { error: null });
         } else if (!verifyBound && currentTask.parentTaskId) {
-          await this.completeSubtask(currentTask);
+          const checkpoint = this.taskModel.getCheckpointConfig(currentTask);
+          if (checkpoint.topic?.after) {
+            await this.taskModel.updateStatusIfCurrent(taskId, 'running', 'paused', {
+              error: null,
+            });
+          } else {
+            await this.completeSubtask(currentTask);
+          }
         } else if (!verifyBound && this.taskModel.shouldPauseOnTopicComplete(currentTask)) {
           await this.taskModel.updateStatus(taskId, 'paused', { error: null });
         }
@@ -511,12 +518,21 @@ export class TaskLifecycleService {
    * initialization while preserving the runner's single cascade implementation.
    */
   private async completeSubtask(task: TaskItem): Promise<void> {
-    await this.taskModel.updateStatus(task.id, 'completed', {
-      completedAt: new Date(),
-      error: null,
-    });
+    const completedTask = await this.taskModel.updateStatusIfCurrent(
+      task.id,
+      'running',
+      'completed',
+      {
+        completedAt: new Date(),
+        error: null,
+      },
+    );
+    if (!completedTask) {
+      log('subtask=%s no longer running — skipping completion cascade', task.identifier);
+      return;
+    }
 
-    const parentTask = await this.taskModel.findById(task.parentTaskId!);
+    const parentTask = await this.taskModel.findById(completedTask.parentTaskId!);
     if (parentTask && this.taskModel.shouldPauseAfterComplete(parentTask, task.identifier)) {
       await this.taskModel.updateStatus(parentTask.id, 'paused');
     }

--- a/apps/server/src/services/taskLifecycle/index.ts
+++ b/apps/server/src/services/taskLifecycle/index.ts
@@ -239,11 +239,12 @@ export class TaskLifecycleService {
       //      'scheduled' to wait for the next tick. They never auto-pause
       //      on success — only `reason === 'error'` below puts them in
       //      'paused' for human attention.
-      //    - Non-automation tasks fall back to the legacy "pause for user
-      //      review" behavior: a 'result' brief from the agent is a
-      //      *proposal* of completion, and the user must explicitly approve
-      //      via the brief action to transition to 'completed'. Auto-complete
-      //      only happens via the Judge path above.
+      //    - Subtasks complete immediately. Their parent owns the broader
+      //      delivery decision, so pausing every successful child for a second
+      //      user review stalls an otherwise autonomous task graph. Completing
+      //      the child also unlocks its downstream siblings.
+      //    - Root non-automation tasks keep the legacy "pause for user review"
+      //      behavior: their result is the user-facing delivery boundary.
       // "Let go" for verify-bound runs: when a confirmed verify plan exists for
       // this op, delivery acceptance is decided asynchronously by Verify
       // (driveTaskFromVerify completes / pauses the task on settle), so we must
@@ -275,6 +276,8 @@ export class TaskLifecycleService {
           // failed — the live `error` alone would silently self-heal.
           await this.recordAutomationRecovery(currentTask);
           await this.taskModel.updateStatus(taskId, 'scheduled', { error: null });
+        } else if (!verifyBound && currentTask.parentTaskId) {
+          await this.completeSubtask(currentTask);
         } else if (!verifyBound && this.taskModel.shouldPauseOnTopicComplete(currentTask)) {
           await this.taskModel.updateStatus(taskId, 'paused', { error: null });
         }
@@ -497,6 +500,31 @@ export class TaskLifecycleService {
     // next tick.
     const finalTask = await this.taskModel.findById(taskId);
     if (finalTask) await this.maybeRearmHeartbeat(finalTask, reason);
+  }
+
+  /**
+   * Settle a successful child task and advance its sibling dependency graph.
+   *
+   * This mirrors the completion side effects of TaskService.updateStatus
+   * without importing TaskService here (TaskRunner already depends on this
+   * lifecycle service). The dynamic import keeps that module cycle out of
+   * initialization while preserving the runner's single cascade implementation.
+   */
+  private async completeSubtask(task: TaskItem): Promise<void> {
+    await this.taskModel.updateStatus(task.id, 'completed', {
+      completedAt: new Date(),
+      error: null,
+    });
+
+    const parentTask = await this.taskModel.findById(task.parentTaskId!);
+    if (parentTask && this.taskModel.shouldPauseAfterComplete(parentTask, task.identifier)) {
+      await this.taskModel.updateStatus(parentTask.id, 'paused');
+    }
+
+    const { TaskRunnerService } = await import('@/server/services/taskRunner');
+    await new TaskRunnerService(this.db, this.userId, this.workspaceId).cascadeOnCompletion(
+      task.id,
+    );
   }
 
   /**

--- a/apps/server/src/services/taskLifecycle/onTopicComplete.test.ts
+++ b/apps/server/src/services/taskLifecycle/onTopicComplete.test.ts
@@ -9,6 +9,14 @@ const fakeScheduler = {
   scheduleNextTopic: vi.fn().mockResolvedValue('msg-new'),
 };
 
+const { cascadeOnCompletion } = vi.hoisted(() => ({
+  cascadeOnCompletion: vi.fn().mockResolvedValue({ failed: [], paused: [], started: [] }),
+}));
+
+vi.mock('@/server/services/taskRunner', () => ({
+  TaskRunnerService: vi.fn(() => ({ cascadeOnCompletion })),
+}));
+
 vi.mock('@/server/services/taskScheduler', () => ({
   createTaskSchedulerModule: () => fakeScheduler,
 }));
@@ -78,6 +86,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
     fakeScheduler.scheduleNextTopic.mockClear().mockResolvedValue('msg-new');
     notifyCompleted.mockReset().mockResolvedValue(undefined);
     notifyFailed.mockReset().mockResolvedValue(undefined);
+    cascadeOnCompletion.mockReset().mockResolvedValue({ failed: [], paused: [], started: [] });
 
     service = new TaskLifecycleService({} as any, 'user-1');
 
@@ -256,6 +265,56 @@ describe('TaskLifecycleService.onTopicComplete', () => {
 
       expect(updateStatus).toHaveBeenCalledWith('task-1', 'paused', { error: null });
       expect(updateStatus).not.toHaveBeenCalledWith('task-1', 'scheduled', expect.anything());
+    });
+
+    it('successful subtask → completes and unlocks downstream tasks instead of pausing', async () => {
+      const task = baseTask({ automationMode: null, parentTaskId: 'parent-task' });
+      const parentTask = baseTask({ id: 'parent-task', identifier: 'TASK-0' });
+      findById
+        .mockResolvedValueOnce(task)
+        .mockResolvedValueOnce(parentTask)
+        .mockResolvedValue(task);
+      (service as any).taskModel.shouldPauseAfterComplete = vi.fn().mockReturnValue(false);
+
+      await service.onTopicComplete({
+        operationId: 'op-1',
+        reason: 'done',
+        taskId: 'task-1',
+        taskIdentifier: 'TASK-1',
+        topicId: 'topic-1',
+      });
+
+      expect(updateStatus).toHaveBeenCalledWith('task-1', 'completed', {
+        completedAt: expect.any(Date),
+        error: null,
+      });
+      expect(updateStatus).not.toHaveBeenCalledWith('task-1', 'paused', expect.anything());
+      expect(cascadeOnCompletion).toHaveBeenCalledWith('task-1');
+    });
+
+    it('successful subtask still honors an explicit parent after-completion checkpoint', async () => {
+      const task = baseTask({ automationMode: null, parentTaskId: 'parent-task' });
+      const parentTask = baseTask({ id: 'parent-task', identifier: 'TASK-0' });
+      findById
+        .mockResolvedValueOnce(task)
+        .mockResolvedValueOnce(parentTask)
+        .mockResolvedValue(task);
+      (service as any).taskModel.shouldPauseAfterComplete = vi.fn().mockReturnValue(true);
+
+      await service.onTopicComplete({
+        operationId: 'op-1',
+        reason: 'done',
+        taskId: 'task-1',
+        taskIdentifier: 'TASK-1',
+        topicId: 'topic-1',
+      });
+
+      expect(updateStatus).toHaveBeenCalledWith('task-1', 'completed', {
+        completedAt: expect.any(Date),
+        error: null,
+      });
+      expect(updateStatus).toHaveBeenCalledWith('parent-task', 'paused');
+      expect(cascadeOnCompletion).toHaveBeenCalledWith('task-1');
     });
 
     it('non-automation task with shouldPauseOnTopicComplete=false → no status update', async () => {

--- a/apps/server/src/services/taskLifecycle/onTopicComplete.test.ts
+++ b/apps/server/src/services/taskLifecycle/onTopicComplete.test.ts
@@ -75,6 +75,7 @@ const baseTask = (overrides: Partial<TaskItem> = {}): TaskItem =>
 describe('TaskLifecycleService.onTopicComplete', () => {
   let service: TaskLifecycleService;
   let updateStatus: ReturnType<typeof vi.fn>;
+  let updateStatusIfCurrent: ReturnType<typeof vi.fn>;
   let updateContext: ReturnType<typeof vi.fn>;
   let findById: ReturnType<typeof vi.fn>;
   let updateHeartbeat: ReturnType<typeof vi.fn>;
@@ -91,6 +92,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
     service = new TaskLifecycleService({} as any, 'user-1');
 
     updateStatus = vi.fn().mockResolvedValue(null);
+    updateStatusIfCurrent = vi.fn();
     updateContext = vi.fn().mockResolvedValue(null);
     findById = vi.fn();
     updateHeartbeat = vi.fn().mockResolvedValue(undefined);
@@ -101,10 +103,12 @@ describe('TaskLifecycleService.onTopicComplete', () => {
 
     const taskModel = (service as any).taskModel;
     taskModel.updateStatus = updateStatus;
+    taskModel.updateStatusIfCurrent = updateStatusIfCurrent;
     taskModel.updateContext = updateContext;
     taskModel.findById = findById;
     taskModel.updateHeartbeat = updateHeartbeat;
     taskModel.getReviewConfig = getReviewConfig;
+    taskModel.getCheckpointConfig = vi.fn().mockReturnValue({});
     // Default checkpoint behavior: pause after topic complete
     taskModel.shouldPauseOnTopicComplete = vi.fn().mockReturnValue(true);
     // Avoid generateHandoff side effects by skipping when lastAssistantContent is undefined
@@ -270,6 +274,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
     it('successful subtask → completes and unlocks downstream tasks instead of pausing', async () => {
       const task = baseTask({ automationMode: null, parentTaskId: 'parent-task' });
       const parentTask = baseTask({ id: 'parent-task', identifier: 'TASK-0' });
+      updateStatusIfCurrent.mockResolvedValue(task);
       findById
         .mockResolvedValueOnce(task)
         .mockResolvedValueOnce(parentTask)
@@ -284,7 +289,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
         topicId: 'topic-1',
       });
 
-      expect(updateStatus).toHaveBeenCalledWith('task-1', 'completed', {
+      expect(updateStatusIfCurrent).toHaveBeenCalledWith('task-1', 'running', 'completed', {
         completedAt: expect.any(Date),
         error: null,
       });
@@ -295,6 +300,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
     it('successful subtask still honors an explicit parent after-completion checkpoint', async () => {
       const task = baseTask({ automationMode: null, parentTaskId: 'parent-task' });
       const parentTask = baseTask({ id: 'parent-task', identifier: 'TASK-0' });
+      updateStatusIfCurrent.mockResolvedValue(task);
       findById
         .mockResolvedValueOnce(task)
         .mockResolvedValueOnce(parentTask)
@@ -309,12 +315,53 @@ describe('TaskLifecycleService.onTopicComplete', () => {
         topicId: 'topic-1',
       });
 
-      expect(updateStatus).toHaveBeenCalledWith('task-1', 'completed', {
+      expect(updateStatusIfCurrent).toHaveBeenCalledWith('task-1', 'running', 'completed', {
         completedAt: expect.any(Date),
         error: null,
       });
       expect(updateStatus).toHaveBeenCalledWith('parent-task', 'paused');
       expect(cascadeOnCompletion).toHaveBeenCalledWith('task-1');
+    });
+
+    it('successful subtask with an explicit topic-after checkpoint → pauses for review', async () => {
+      const task = baseTask({ automationMode: null, parentTaskId: 'parent-task' });
+      findById.mockResolvedValue(task);
+      (service as any).taskModel.getCheckpointConfig = vi
+        .fn()
+        .mockReturnValue({ topic: { after: true } });
+
+      await service.onTopicComplete({
+        operationId: 'op-1',
+        reason: 'done',
+        taskId: 'task-1',
+        taskIdentifier: 'TASK-1',
+        topicId: 'topic-1',
+      });
+
+      expect(updateStatusIfCurrent).toHaveBeenCalledWith('task-1', 'running', 'paused', {
+        error: null,
+      });
+      expect(cascadeOnCompletion).not.toHaveBeenCalled();
+    });
+
+    it('late successful callback does not overwrite a child that is no longer running', async () => {
+      const task = baseTask({ automationMode: null, parentTaskId: 'parent-task' });
+      findById.mockResolvedValue(task);
+      updateStatusIfCurrent.mockResolvedValue(null);
+
+      await service.onTopicComplete({
+        operationId: 'op-1',
+        reason: 'done',
+        taskId: 'task-1',
+        taskIdentifier: 'TASK-1',
+        topicId: 'topic-1',
+      });
+
+      expect(updateStatusIfCurrent).toHaveBeenCalledWith('task-1', 'running', 'completed', {
+        completedAt: expect.any(Date),
+        error: null,
+      });
+      expect(cascadeOnCompletion).not.toHaveBeenCalled();
     });
 
     it('non-automation task with shouldPauseOnTopicComplete=false → no status update', async () => {

--- a/packages/database/src/models/__tests__/task.test.ts
+++ b/packages/database/src/models/__tests__/task.test.ts
@@ -736,6 +736,21 @@ describe('TaskModel', () => {
       expect(updated!.status).toBe('running');
       expect(updated!.startedAt).toBeDefined();
     });
+
+    it('should update status only when the current status matches', async () => {
+      const model = new TaskModel(serverDB, userId);
+      const task = await model.create({ instruction: 'Test' });
+      await model.updateStatus(task.id, 'running');
+
+      const completed = await model.updateStatusIfCurrent(task.id, 'running', 'completed', {
+        completedAt: new Date(),
+      });
+      const staleUpdate = await model.updateStatusIfCurrent(task.id, 'running', 'failed');
+
+      expect(completed?.status).toBe('completed');
+      expect(staleUpdate).toBeNull();
+      expect((await model.findById(task.id))?.status).toBe('completed');
+    });
   });
 
   describe('heartbeat', () => {

--- a/packages/database/src/models/task.ts
+++ b/packages/database/src/models/task.ts
@@ -898,6 +898,22 @@ export class TaskModel {
     return this.update(id, { status, ...extra });
   }
 
+  /** Atomically transition a task only while it still has the expected status. */
+  async updateStatusIfCurrent(
+    id: string,
+    currentStatus: string,
+    status: string,
+    extra?: { completedAt?: Date; error?: string | null; startedAt?: Date },
+  ): Promise<TaskItem | null> {
+    const [task] = await this.db
+      .update(tasks)
+      .set({ status, updatedAt: new Date(), ...extra })
+      .where(and(eq(tasks.id, id), eq(tasks.status, currentStatus), this.ownership()))
+      .returning();
+
+    return task ?? null;
+  }
+
   async batchUpdateStatus(ids: string[], status: string): Promise<number> {
     const result = await this.db
       .update(tasks)


### PR DESCRIPTION
## Summary

- complete successful child tasks immediately instead of parking them in `paused`
- trigger the existing task dependency cascade so newly unlocked siblings continue automatically
- preserve explicit child topic-after and parent after-completion checkpoints
- atomically require the child to remain `running`, so late callbacks cannot overwrite pause/cancel decisions
- preserve the root-task review boundary and Verify-owned completion behavior

## Why

A successful child task currently inherits the legacy root-task review behavior and becomes `paused`. This interrupts autonomous parent/child task execution and requires unnecessary human intervention between ordinary subtasks.

## Test plan

- targeted lint and tests — 176 tests passed
- full TypeScript check — clean

## Behavior

- successful running subtask → `completed` → dependency cascade
- explicit child `checkpoint.topic.after` → `paused`, no cascade
- late completion callback after pause/cancel → no state overwrite, no cascade
- successful root task → existing review behavior
- explicit parent `tasks.afterIds` checkpoint → parent pauses as configured
