### PR TITLE
ci(workbench): upload a preview version per PR instead of a dry run

### DIFF
--- a/.github/workflows/verify-workbench.yml
+++ b/.github/workflows/verify-workbench.yml
@@ -66,18 +66,47 @@ jobs:
 
       - name: Build workbench
         if: steps.detect.outputs.should_build == 'true'
-        run: bun run build:rr
+        env:
+          # NODE_ENV is load-bearing: vite.config.rr.mts takes its dev branch otherwise and
+          # discards VITE_CDN_BASE without failing. A preview serves its own assets from its
+          # own workers.dev origin, the way production serves them from the CDN — never
+          # same-origin, because the gateway routes /assets to the landing target. Empty on
+          # fork PRs, which have no secrets to upload with and only run the size guard.
+          NODE_ENV: production
+          NODE_OPTIONS: --max-old-space-size=8192
+          VITE_CDN_BASE: >-
+            ${{ github.event.pull_request.head.repo.full_name == github.repository
+            && format('https://pr{0}-lobehub-workbench.lobeobjects-tg.workers.dev/', github.event.pull_request.number)
+            || '' }}
+        run: |
+          bun run build:rr
+          printf '/*\n  Access-Control-Allow-Origin: *\n' > build/client/_headers
         working-directory: apps/workbench
 
-      - name: Validate worker bundle
+      - name: Upload preview version and validate worker bundle
         if: steps.detect.outputs.should_build == 'true'
+        # Explicit `bash` rather than the default shell, whose lack of pipefail would let a
+        # wrangler failure pass as a green step through the `tee`.
+        shell: bash
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PREVIEW_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
+          SAME_REPO: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          PR: ${{ github.event.pull_request.number }}
         run: |
-          node_modules/.bin/wrangler deploy --dry-run \
-            --config build/server/wrangler.json | tee /tmp/dry-run.log
-          gzip_kib=$(grep -Eo 'gzip: [0-9.]+ KiB' /tmp/dry-run.log | grep -Eo '[0-9.]+' | head -1)
+          if [ "$SAME_REPO" = 'true' ]; then
+            set -- --preview-alias "pr${PR}" --message "PR-${PR}"
+          else
+            set -- --dry-run
+          fi
+          node_modules/.bin/wrangler versions upload \
+            --config build/server/wrangler.json "$@" | tee /tmp/upload.log
+          gzip_kib=$(grep -Eo 'gzip: [0-9.]+ KiB' /tmp/upload.log | grep -Eo '[0-9.]+' | head -1)
           echo "worker gzip size: ${gzip_kib} KiB"
           if [ -n "$gzip_kib" ] && [ "$(printf '%.0f' "$gzip_kib")" -gt 8192 ]; then
             echo "::error::worker bundle ${gzip_kib} KiB gzip exceeds the 8 MiB guard (plan limit is 10 MiB)"
             exit 1
+          fi
+          if [ "$SAME_REPO" = 'true' ]; then
+            echo "Preview: https://pr${PR}-lobehub-workbench.lobeobjects-tg.workers.dev" >> "$GITHUB_STEP_SUMMARY"
           fi
         working-directory: apps/workbench

--- a/.github/workflows/verify-workbench.yml
+++ b/.github/workflows/verify-workbench.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   actions: read
   contents: read
+  pull-requests: write
 
 concurrency:
   group: verify-workbench-${{ github.event.pull_request.number }}
@@ -110,3 +111,32 @@ jobs:
             echo "Preview: https://pr${PR}-lobehub-workbench.lobeobjects-tg.workers.dev" >> "$GITHUB_STEP_SUMMARY"
           fi
         working-directory: apps/workbench
+
+      - name: Comment the preview URL
+        if: steps.detect.outputs.should_build == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Matched on a marker rather than `gh pr comment --edit-last`, which edits the
+          # last comment by this actor — and other workflows in this repo comment as the
+          # same bot, so it would rewrite one of theirs.
+          marker='<!-- workbench-preview -->'
+          body="${marker}
+          ### Workbench preview
+
+          <https://pr${PR}-lobehub-workbench.lobeobjects-tg.workers.dev>
+
+          A version, not a deployment: it takes no production traffic. Assets are served
+          from that same origin, so the page also renders through the gateway — point
+          \`workbench\`'s override at that host on staging in 鳥居番, then open
+          <https://gateway-staging.lobehub.com/acceptance>."
+          id=$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+            --jq "map(select(.body | startswith(\"${marker}\"))) | .[0].id // empty")
+          if [ -n "$id" ]; then
+            gh api -X PATCH "repos/${REPO}/issues/comments/${id}" -f body="$body" > /dev/null
+          else
+            gh api -X POST "repos/${REPO}/issues/${PR}/comments" -f body="$body" > /dev/null
+          fi


### PR DESCRIPTION
`verify-workbench.yml` could only ever prove that the worker bundle compiled and fit under the size guard. The first request any workbench bundle ever served was production traffic on `canary`.

The build step is already there and already produces the exact bundle that would ship. This changes the last line from a dry run into a real upload.

## What changes

`wrangler deploy --dry-run` becomes `wrangler versions upload --preview-alias pr<N>`. A version is uploaded and addressable but takes **no production traffic** — deployments are what serve traffic, and none is created here. The result is a real, running instance of the PR's bundle at a stable URL, which is then posted as a PR comment.

The 8 MiB gzip guard is unchanged: `versions upload` prints the same `gzip: N KiB` line the dry run did.

## Assets

The preview build stamps the version's own `workers.dev` origin as `VITE_CDN_BASE`, so the page loads its assets cross-origin from the same preview worker — the same shape production uses with `web-assets.lobehub.com`, and for the same reason: the gateway routes `/assets` elsewhere, so a same-origin asset URL would not resolve behind it. A two-line `_headers` file supplies the CORS header those module scripts need. No S3 credentials are involved.

`NODE_ENV: production` is load-bearing here — `vite.config.rr.mts` takes its dev branch otherwise and discards `VITE_CDN_BASE` silently, producing a build that looks fine and points at nothing.

## Fork PRs

Fork PRs have no secrets, so they keep exactly today's behavior: a dry run and the size guard, no upload. The gate is `github.event.pull_request.head.repo.full_name == github.repository`. `pull_request_target` was deliberately not used — running fork code with a Cloudflare token in a public repository is not a trade worth making for a preview URL.

## Incidental fix

The old step piped `wrangler` into `tee`, and the default GitHub Actions shell has no `pipefail`, so a wrangler failure exited 0 and the step passed green. Adding `shell: bash` fixes that; it is why the step now actually fails when the upload does.

## Verification

The preview URL format was resolved by hand against the real account before this was written: real version prefixes are served by the worker, a non-existent prefix 404s, and Preview URLs are enabled for `lobehub-workbench`.

This PR exercises its own change — its `Verify Workbench` run is the first real test of it. The preview URL it posts below is the artifact to click.
