### PR TITLE
🐛 fix(heterogeneous-agent): accept namespaced Codex models

### DIFF
--- a/packages/openapi/src/routes/openai.route.ts
+++ b/packages/openapi/src/routes/openai.route.ts
@@ -1,3 +1,4 @@
+import { isServerDefaultHeterogeneousModel } from '@lobechat/types';
 import { isRecord } from '@lobechat/utils/object';
 import type { Context } from 'hono';
 import { Hono } from 'hono';
@@ -18,16 +19,16 @@ const app = new Hono();
 app.post('/v1/responses', requireHeteroModelInvocation, async (c) => {
   const request = await c.req.json().catch(() => null);
   if (!isRecord(request)) throw new HTTPException(400, { message: 'Invalid JSON request' });
-  if (request.model !== SERVER_DEFAULT_MODEL_ALIAS) {
-    throw new HTTPException(400, { message: `model must be ${SERVER_DEFAULT_MODEL_ALIAS}` });
-  }
-  if (request.stream !== true) {
-    throw new HTTPException(400, { message: 'server-default Responses requests must stream' });
-  }
   const context = c as Context;
   const claims = context.get('heteroOperationClaims') as HeteroOperationJwtClaims;
   if (!claims.provider_id || !claims.model) {
     throw new HTTPException(403, { message: 'Operation token has no server model selection' });
+  }
+  if (!isServerDefaultHeterogeneousModel(request.model, claims.model)) {
+    throw new HTTPException(400, { message: 'model must match the server operation selection' });
+  }
+  if (request.stream !== true) {
+    throw new HTTPException(400, { message: 'server-default Responses requests must stream' });
   }
   const workspaceId = context.get('workspaceId');
   const { response } = await invokeServerDefaultModel({

--- a/packages/types/src/agent/agencyConfig.test.ts
+++ b/packages/types/src/agent/agencyConfig.test.ts
@@ -5,6 +5,8 @@ import {
   buildHeteroExecArgs,
   buildHeteroSpawnArgs,
   canPublishAgentTopicLink,
+  formatServerDefaultHeterogeneousModel,
+  isServerDefaultHeterogeneousModel,
   normalizeHeterogeneousProviderConfig,
   pruneWorkingDirByDeviceDeletes,
   resolveAgencyConfig,
@@ -23,6 +25,15 @@ import {
   resolveCodexReasoningEffort,
   resolveCodexSpeedMode,
 } from './heteroSelectorCapabilities';
+
+describe('server-default heterogeneous model request', () => {
+  it('only accepts the namespaced operation model used for CLI metadata', () => {
+    expect(formatServerDefaultHeterogeneousModel('gpt-5.4')).toBe('lobehub/gpt-5.4');
+    expect(isServerDefaultHeterogeneousModel('lobehub/gpt-5.4', 'gpt-5.4')).toBe(true);
+    expect(isServerDefaultHeterogeneousModel('lobehub-default', 'gpt-5.4')).toBe(false);
+    expect(isServerDefaultHeterogeneousModel('lobehub/gpt-5.5', 'gpt-5.4')).toBe(false);
+  });
+});
 
 describe('normalizeHeterogeneousProviderConfig', () => {
   it('recovers a legacy adapterType before considering the command', () => {

--- a/packages/types/src/agent/agencyConfig.ts
+++ b/packages/types/src/agent/agencyConfig.ts
@@ -91,6 +91,13 @@ export interface HeterogeneousApiConfig {
   smallFastModel?: string | null;
 }
 
+export const formatServerDefaultHeterogeneousModel = (model: string): string => `lobehub/${model}`;
+
+export const isServerDefaultHeterogeneousModel = (
+  requestModel: unknown,
+  operationModel: string,
+): boolean => requestModel === formatServerDefaultHeterogeneousModel(operationModel);
+
 /**
  * Heterogeneous agent provider configuration.
  * When set, the assistant delegates execution to an external agent runtime


### PR DESCRIPTION
## Description of Change

Codex resolves local tool/context metadata from the request model slug. The server-default client currently has to send the opaque `lobehub-default` alias, so Codex falls back to unknown-model metadata and warns that execution can be degraded.

This server half changes the Responses ingress contract to accept only a namespaced operation model:

```text
lobehub/<operation-model>
```

The namespace lets Codex reuse metadata for the selected model while the operation JWT remains authoritative. The endpoint verifies that the request suffix exactly matches `claims.model`; clients cannot use the request body to change the server-selected model.

## Key Decisions / Non-goals

- Do not retain `lobehub-default` compatibility for Codex Responses requests. This feature is still under development and has not shipped.
- Keep routing bound to the durable operation/JWT. The namespaced request model is metadata-facing identity, not an alternate provider-selection mechanism.
- The Desktop emitter change will follow on the existing client PR after this server contract lands.

#### Test

- `bun run check --lint --test --type lobehub/packages/openapi/src/routes/openai.route.ts lobehub/packages/types/src/agent/agencyConfig.ts lobehub/packages/types/src/agent/agencyConfig.test.ts`
- 78 related tests passed; lint and full type-check clean.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed