### PR TITLE
🐛 fix(desktop): detect bare-version Gemini and Qwen CLIs

### DIFF
--- a/apps/desktop/src/main/modules/binaries/__tests__/cliAgentBinaries.test.ts
+++ b/apps/desktop/src/main/modules/binaries/__tests__/cliAgentBinaries.test.ts
@@ -288,6 +288,34 @@ describe('cliAgentBinaries', () => {
       platformMock.mockReturnValue('darwin');
     });
 
+    it('detects Gemini CLI from a bare semantic version banner', async () => {
+      callExecFile('/Users/test/.local/bin/gemini\n');
+      callExecFile('0.55.1');
+
+      const { geminiCliBinary } = await import('../cliAgentBinaries');
+      const status = await geminiCliBinary.detect();
+
+      expect(status).toMatchObject({
+        available: true,
+        path: '/Users/test/.local/bin/gemini',
+        version: '0.55.1',
+      });
+    });
+
+    it('detects Qwen Code from a bare semantic version banner', async () => {
+      callExecFile('/Users/test/.local/bin/qwen\n');
+      callExecFile('0.21.12');
+
+      const { qwenCodeBinary } = await import('../cliAgentBinaries');
+      const status = await qwenCodeBinary.detect();
+
+      expect(status).toMatchObject({
+        available: true,
+        path: '/Users/test/.local/bin/qwen',
+        version: '0.21.12',
+      });
+    });
+
     it('detects OpenCode through the shared command/version probe', async () => {
       callExecFile('/Users/test/.opencode/bin/opencode\n');
       callExecFile('1.18.3');

--- a/apps/desktop/src/main/modules/binaries/cliAgentBinaries.ts
+++ b/apps/desktop/src/main/modules/binaries/cliAgentBinaries.ts
@@ -25,7 +25,10 @@ interface ValidatedBinaryOptions {
   priority: number;
   validateFlag?: string;
   validateKeywords: string[];
+  validatePattern?: RegExp;
 }
+
+const BARE_SEMVER_PATTERN = /^v?\d+\.\d+\.\d+(?:[-+][\dA-Za-z.-]+)?$/;
 
 /**
  * Binary spec that resolves a command path via which/where, then validates
@@ -171,6 +174,7 @@ export const geminiCliBinary: BinarySpec = defineValidatedBinary({
   name: 'gemini',
   priority: 8,
   validateKeywords: ['gemini'],
+  validatePattern: BARE_SEMVER_PATTERN,
 });
 
 /**
@@ -183,6 +187,7 @@ export const qwenCodeBinary: BinarySpec = defineValidatedBinary({
   name: 'qwen',
   priority: 9,
   validateKeywords: ['qwen'],
+  validatePattern: BARE_SEMVER_PATTERN,
 });
 
 /**


### PR DESCRIPTION
Gemini CLI and Qwen Code can return a bare semantic version from `--version`. Their keyword-only validators therefore report installed binaries as unavailable.

This keeps the existing product-keyword checks and adds a strict bare-semver fallback only to those two binary definitions, using the shared resolver’s existing `validatePattern` path.

| Before | After |
| ------ | ----- |
| `0.55.1` / `0.21.12` fail keyword validation | Bare semantic version banners are accepted for Gemini and Qwen |

#### Test

- [x] Tested the strict semver matcher locally against valid and invalid banners
- [x] Added regression coverage for Gemini `0.55.1` and Qwen `0.21.12` banners

The focused Vitest command could not complete locally because both npm registries repeatedly reset TLS connections while downloading the isolated test runner; repository CI is expected to run the committed tests.

#### 🔗 Related Issue

Fixes #18383