### PR TITLE
🐛 fix(topic): respect configured drawer page size

### DIFF
--- a/src/features/AgentSidebar/Topic/AllTopicsDrawer/Content.tsx
+++ b/src/features/AgentSidebar/Topic/AllTopicsDrawer/Content.tsx
@@ -11,8 +11,11 @@ import SkeletonList from '@/features/NavPanel/components/SkeletonList';
 import TopicEmpty from '@/features/TopicEmpty';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
+import { useGlobalStore } from '@/store/global';
+import { systemStatusSelectors } from '@/store/global/selectors';
 
 import TopicItem from '../List/Item';
+import { backfillTopicPages } from './pagination';
 
 const ITEM_HEIGHT = 36; // Each topic item height (NavItem height, no vertical padding)
 
@@ -67,6 +70,7 @@ const Content = memo<ContentProps>(({ open, searchKeyword }) => {
   const searchResults = useChatStore(topicSelectors.searchTopics, isEqual);
   const allTopicList = useChatStore(topicSelectors.displayTopics, isEqual);
   const isSearchingTopic = useChatStore(topicSelectors.isSearchingTopic);
+  const topicPageSize = useGlobalStore(systemStatusSelectors.topicPageSize);
 
   // Use search results if searching, otherwise use regular list
   const activeTopicList = isSearching ? searchResults : allTopicList;
@@ -96,22 +100,33 @@ const Content = memo<ContentProps>(({ open, searchKeyword }) => {
       if (count < itemsNeeded && hasMore) {
         fetchedCountRef.current = count;
 
-        // Calculate pages needed and load once
-        const itemsToLoad = itemsNeeded - count;
-        const pagesNeeded = Math.ceil(itemsToLoad / 20); // Assume 20 items per page
-
         // Load the required pages
-        const loadPages = async () => {
-          for (let i = 0; i < pagesNeeded && hasMore; i++) {
-            await loadMoreTopics();
-          }
-        };
-        loadPages();
+        void backfillTopicPages({
+          canLoadMore: () => {
+            const state = useChatStore.getState();
+            return (
+              topicSelectors.hasMoreTopics(state) && !topicSelectors.loadMoreTopicsError(state)
+            );
+          },
+          count,
+          itemsNeeded,
+          loadMore: loadMoreTopics,
+          pageSize: topicPageSize,
+        });
       }
     }, 100);
 
     return () => clearTimeout(timer);
-  }, [open, count, hasMore, loadMoreTopics, isLoadingMore, loadMoreError, isSearching]);
+  }, [
+    open,
+    count,
+    hasMore,
+    loadMoreTopics,
+    isLoadingMore,
+    loadMoreError,
+    isSearching,
+    topicPageSize,
+  ]);
 
   // Reset initialized flag when drawer closes
   useEffect(() => {

--- a/src/features/AgentSidebar/Topic/AllTopicsDrawer/pagination.test.ts
+++ b/src/features/AgentSidebar/Topic/AllTopicsDrawer/pagination.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { backfillTopicPages } from './pagination';
+
+describe('backfillTopicPages', () => {
+  it('uses the configured topic page size to fill the viewport', async () => {
+    const loadMore = vi.fn().mockResolvedValue(undefined);
+
+    await backfillTopicPages({
+      canLoadMore: () => true,
+      count: 0,
+      itemsNeeded: 31,
+      loadMore,
+      pageSize: 10,
+    });
+
+    expect(loadMore).toHaveBeenCalledTimes(4);
+  });
+
+  it('stops loading when the latest topic state is exhausted', async () => {
+    let hasMore = true;
+    const loadMore = vi.fn(async () => {
+      if (loadMore.mock.calls.length === 2) hasMore = false;
+    });
+
+    await backfillTopicPages({
+      canLoadMore: () => hasMore,
+      count: 0,
+      itemsNeeded: 50,
+      loadMore,
+      pageSize: 10,
+    });
+
+    expect(loadMore).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/features/AgentSidebar/Topic/AllTopicsDrawer/pagination.ts
+++ b/src/features/AgentSidebar/Topic/AllTopicsDrawer/pagination.ts
@@ -1,0 +1,22 @@
+interface BackfillTopicPagesOptions {
+  canLoadMore: () => boolean;
+  count: number;
+  itemsNeeded: number;
+  loadMore: () => Promise<void>;
+  pageSize: number;
+}
+
+export const backfillTopicPages = async ({
+  canLoadMore,
+  count,
+  itemsNeeded,
+  loadMore,
+  pageSize,
+}: BackfillTopicPagesOptions) => {
+  const pagesNeeded = Math.ceil(Math.max(itemsNeeded - count, 0) / pageSize);
+
+  for (let page = 0; page < pagesNeeded; page++) {
+    if (!canLoadMore()) break;
+    await loadMore();
+  }
+};


### PR DESCRIPTION
### Summary

- calculate initial viewport backfill from the configured topic page size instead of a hardcoded 20
- re-read live pagination and error state between page loads so the loop stops when data is exhausted or a request fails
- add focused regression coverage for non-default page sizes and stale pagination state

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `npm exec --yes --package=vitest@3.2.6 -- vitest run src/features/AgentSidebar/Topic/AllTopicsDrawer/pagination.test.ts --config /dev/null --reporter=verbose` (2 passed)
- `git diff --check`

#### 🔗 Related Issue

Closes #18583