### PR TITLE
♻️ refactor(heterogeneous-agent): remove redundant API mode guards

### DIFF
--- a/src/routes/(main)/agent/profile/features/ProfileEditor/HeterogeneousAgentStatusCard.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/HeterogeneousAgentStatusCard.tsx
@@ -866,7 +866,7 @@ const HeterogeneousAgentStatusCard = memo<HeterogeneousAgentStatusCardProps>(
               <Text className={styles.detailLabel}>{t('heterogeneousStatus.apiMode.model')}</Text>
               <ModelSelect
                 initialWidth
-                disabled={!canEdit || !apiModeLabEnabled || !apiModeAvailable}
+                disabled={!canEdit || !apiModeAvailable}
                 placeholder={t('heterogeneousStatus.apiMode.modelPlaceholder')}
                 popupWidth={360}
                 providerIds={[providerApiConfig.providerId]}
@@ -890,15 +890,13 @@ const HeterogeneousAgentStatusCard = memo<HeterogeneousAgentStatusCardProps>(
                       : 'heterogeneousStatus.apiMode.noProviders',
                   )}
                 </Text>
-                {apiModeLabEnabled && (
-                  <Text
-                    className={styles.metaText}
-                    style={{ cursor: 'pointer', textDecoration: 'underline' }}
-                    onClick={() => navigate('/settings/provider')}
-                  >
-                    {t('heterogeneousStatus.apiMode.configureProvider')}
-                  </Text>
-                )}
+                <Text
+                  className={styles.metaText}
+                  style={{ cursor: 'pointer', textDecoration: 'underline' }}
+                  onClick={() => navigate('/settings/provider')}
+                >
+                  {t('heterogeneousStatus.apiMode.configureProvider')}
+                </Text>
               </Flexbox>
             </div>
           )}


### PR DESCRIPTION
## Description of Change

- Remove the redundant `apiModeLabEnabled` JSX guard inside `renderApiConfig`, where the entry guard already guarantees the flag is enabled.
- Remove the equivalent unreachable Labs check from the provider model picker's disabled state.
- Preserve the existing runtime and UI behavior.

Follow-up to the code quality review on #18595.

#### Test

- `bun run check 'src/routes/(main)/agent/profile/features/ProfileEditor/HeterogeneousAgentStatusCard.tsx'`
  - lint clean
  - 17 tests passed

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

Related to #18595.
