### PR TITLE
🐛 fix(heterogeneous-agent): guard local transport launches

### DIFF
--- a/apps/desktop/src/main/controllers/HeterogeneousAgentImpl.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentImpl.ts
@@ -1728,6 +1728,11 @@ export default class HeterogeneousAgentCtr {
     });
     void this.writeCliTraceFile(traceSession, 'stdin.txt', inputPayload);
 
+    if (session.cancelledByUs) {
+      await this.completeCancelledSessionBeforeLaunch(session);
+      return true;
+    }
+
     const clientOptions = {
       args: appServerArgs.slice(0, -1),
       clientVersion: electronApp.getVersion(),
@@ -1904,6 +1909,12 @@ export default class HeterogeneousAgentCtr {
       stdinPayload: traceInput,
     });
     void this.writeCliTraceFile(traceSession, 'stdin.txt', traceInput);
+
+    if (session.cancelledByUs) {
+      await this.completeCancelledSessionBeforeLaunch(session);
+      return;
+    }
+
     const acpSession = new GrokAcpSession({
       args: session.args,
       clientVersion: electronApp.getVersion(),
@@ -1996,6 +2007,12 @@ export default class HeterogeneousAgentCtr {
       stdinPayload: tracePayload,
     });
     void this.writeCliTraceFile(traceSession, 'stdin.txt', tracePayload);
+
+    if (session.cancelledByUs) {
+      await this.completeCancelledSessionBeforeLaunch(session);
+      return;
+    }
+
     const stderrChunks: string[] = [];
     const intervention = this.setupAcpInterventionForOp(params.operationId, session.sessionId);
     const cursorAcpSession = new CursorAcpSession({
@@ -2088,6 +2105,12 @@ export default class HeterogeneousAgentCtr {
       stdinPayload: tracePayload,
     });
     void this.writeCliTraceFile(traceSession, 'stdin.txt', tracePayload);
+
+    if (session.cancelledByUs) {
+      await this.completeCancelledSessionBeforeLaunch(session);
+      return;
+    }
+
     const stderrChunks: string[] = [];
 
     const traeAcpSession = new TraeAcpSession({

--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
@@ -3091,6 +3091,93 @@ describe('HeterogeneousAgentCtr', () => {
     });
   });
 
+  describe('pre-launch cancellation for local transports', () => {
+    beforeEach(() => {
+      spawnCalls.length = 0;
+      execFileMock.mockReset();
+    });
+
+    it.each([
+      {
+        agentType: 'codex',
+        command: 'codex',
+        constructMock: codexAppServerConstructMock,
+        label: 'Codex app-server',
+        runMock: codexAppServerRunMock,
+        useCodexAppServer: true,
+      },
+      {
+        agentType: 'grok-build',
+        command: 'grok',
+        constructMock: grokAcpSessionConstructMock,
+        label: 'Grok ACP',
+        runMock: grokAcpSessionRunMock,
+        useCodexAppServer: false,
+      },
+      {
+        agentType: 'cursor',
+        command: 'agent',
+        constructMock: cursorAcpSessionConstructMock,
+        label: 'Cursor ACP',
+        runMock: cursorAcpSessionRunMock,
+        useCodexAppServer: false,
+      },
+      {
+        agentType: 'trae',
+        command: 'traecli',
+        constructMock: traeAcpSessionConstructMock,
+        label: 'TRAE ACP',
+        runMock: traeAcpSessionRunMock,
+        useCodexAppServer: false,
+      },
+    ] as const)(
+      'does not start $label when cancelled during transport preparation',
+      async ({ agentType, command, constructMock, runMock, useCodexAppServer }) => {
+        const send = vi.fn();
+        mockGetAllWindows.mockReturnValue([
+          {
+            isDestroyed: () => false,
+            webContents: { send },
+          },
+        ]);
+        const ctr = new HeterogeneousAgentCtr({
+          appStoragePath,
+          storeManager: { get: vi.fn() },
+        } as any);
+        const { sessionId } = await ctr.startSession({
+          agentType,
+          command,
+          useCodexAppServer,
+        });
+        let completePreparation!: () => void;
+        const createTraceSession = vi
+          .spyOn(ctr as any, 'createCliTraceSession')
+          .mockImplementationOnce(
+            () =>
+              new Promise<void>((resolve) => {
+                completePreparation = resolve;
+              }),
+          );
+
+        const sendPrompt = ctr.sendPrompt({
+          operationId: `op-cancel-${agentType}`,
+          prompt: 'work',
+          sessionId,
+        });
+        await vi.waitFor(() => expect(createTraceSession).toHaveBeenCalledOnce());
+
+        await ctr.cancelSession({ sessionId });
+        completePreparation();
+        await sendPrompt;
+
+        expect(constructMock).not.toHaveBeenCalled();
+        expect(runMock).not.toHaveBeenCalled();
+        expect(spawnCalls).toHaveLength(0);
+        expect(send).toHaveBeenCalledWith('heteroAgentSessionComplete', { sessionId });
+      },
+    );
+  });
+
   describe('spawnLhHeteroExec', () => {
     const params = {
       agentType: 'opencode',


### PR DESCRIPTION
Follow-up to #18599 and [its local-transport cancellation review](https://github.com/lobehub/lobehub/pull/18599#discussion_r3836493150).

Local Codex app-server, Grok ACP, Cursor ACP, and TRAE ACP can await input or trace preparation before registering their runtime on the session. A Stop request in that window sets `cancelledByUs`, but `cancelSession` has no runtime to interrupt; without a final guard, preparation resumes and starts the transport after cancellation.

This change rechecks cancellation immediately after each transport's final asynchronous preparation boundary and before constructing or registering its runtime. Cancelled sessions emit completion without constructing or running the transport.

This PR is intentionally stacked on #18599 to reuse its shared pre-launch cancellation completion path. After #18599 merges, this PR should be retargeted to `canary` (GitHub may do this automatically).

No UI changes.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Verified with:

- `bunx vitest run --silent='passed-only' src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts` (110 passed)
- Desktop TypeScript check (`tsgo --noEmit -p apps/desktop/tsconfig.json`)
- `bun run check --lint apps/desktop/src/main/controllers/HeterogeneousAgentImpl.ts apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts`

Regression coverage defers the final preparation step for all four local transports, cancels each run in flight, and verifies that no transport is constructed or run.

#### 🔗 Related Issue

Related to #18599
