### PR TITLE
🐛 fix(heterogeneous-agent): spawn Codex quota RPC without retired untrusted flag

### DIFF
--- a/apps/desktop/src/main/modules/heterogeneousAgent/codexQuota.test.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/codexQuota.test.ts
@@ -183,7 +183,7 @@ describe('fetchCodexQuota', () => {
     expect(readFile).toHaveBeenCalledWith('/tmp/codex-home/auth.json', 'utf8');
     expect(spawnMock).toHaveBeenCalledWith(
       '/custom/bin/codex',
-      ['-s', 'read-only', '-a', 'untrusted', 'app-server'],
+      ['app-server'],
       expect.objectContaining({
         env: expect.objectContaining({
           CODEX_HOME: '/tmp/codex-home',

--- a/apps/desktop/src/main/modules/heterogeneousAgent/codexQuota.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/codexQuota.ts
@@ -12,7 +12,7 @@ import type {
   CodexRateLimitResetOutcome,
   CodexRateLimitSnapshot,
 } from '@lobechat/electron-client-ipc';
-import { resolveCliSpawnPlan } from '@lobechat/heterogeneous-agents/spawn';
+import { buildCodexAppServerArgs, resolveCliSpawnPlan } from '@lobechat/heterogeneous-agents/spawn';
 
 const RPC_TIMEOUT_MS = 10_000;
 const CODEX_PRIMARY_WINDOW_MINUTES = 5 * 60;
@@ -438,7 +438,10 @@ const requestViaRpc = async <T>(
     let rpcId = 0;
     let timeout: ReturnType<typeof setTimeout> | undefined;
 
-    const rpcArgs = ['-s', 'read-only', '-a', 'untrusted', 'app-server'];
+    // Headless app-server only. TUI flags such as `-a untrusted` are parsed
+    // before the subcommand, and current Codex CLI rejects `untrusted`
+    // (`--ask-for-approval` accepts only `on-request` and `never`).
+    const rpcArgs = buildCodexAppServerArgs();
 
     const cleanup = (kill: boolean) => {
       if (finished) return false;


### PR DESCRIPTION
<!-- Brief and heads-up -->

Codex CLI 0.149.0 retired `--ask-for-approval untrusted`. Refreshing the Codex quota menu spawned `codex -s read-only -a untrusted app-server`, so clap rejected the process before `app-server` started and the menu showed the raw CLI error.

Those `-a` / `-s` flags are TUI options, not app-server args, and were already ignored after parse. Quota RPC now starts the same `codex app-server` process as live Codex sessions.

<!-- If this PR includes UI changes, please provide screenshots or videos. -->

| Before | After |
| ------ | ----- |
| Quota refresh fails on Codex 0.149+ with `invalid value 'untrusted' for '--ask-for-approval'` | Quota RPC spawns `codex app-server` and reads rate limits as before |

#### Test

<!-- How you tested your changes -->

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Focused tests: `apps/desktop/src/main/modules/heterogeneousAgent/codexQuota.test.ts` (6 passed).

Manual: on Codex CLI 0.149+, open a Codex heterogeneous agent conversation and refresh **Codex quota**. It should load instead of showing the clap `untrusted` error. Older CLI versions still use `app-server` and are unchanged.

#### 🔗 Related Issue

Codex upstream: [openai/codex#39630](https://github.com/openai/codex/pull/39630) (retired `untrusted` in 0.149.0). No matching in-repo GitHub issue.