### PR TITLE
fix: map Feishu reaction emojis to platform identifiers

### DIFF
--- a/apps/server/src/services/bot/platforms/feishu/client.test.ts
+++ b/apps/server/src/services/bot/platforms/feishu/client.test.ts
@@ -3,11 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const mockCreateLarkAdapter = vi.hoisted(() => vi.fn());
 const mockDownloadMediaFromRawMessage = vi.hoisted(() => vi.fn());
 const mockGetTenantAccessToken = vi.hoisted(() => vi.fn().mockResolvedValue('tok'));
+const mockAddReaction = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 
 vi.mock('@lobechat/chat-adapter-feishu', () => ({
   createLarkAdapter: mockCreateLarkAdapter,
   downloadMediaFromRawMessage: mockDownloadMediaFromRawMessage,
   LarkApiClient: vi.fn().mockImplementation(() => ({
+    addReaction: mockAddReaction,
     getTenantAccessToken: mockGetTenantAccessToken,
   })),
 }));
@@ -194,5 +196,44 @@ describe('FeishuWebhookClient.extractFiles', () => {
     expect(result).toEqual([
       { buffer, mimeType: 'image/jpeg', name: 'image.jpg', size: undefined },
     ]);
+  });
+});
+
+describe('FeishuClient reactions', () => {
+  const createClient = () =>
+    new FeishuClientFactory().createClient(
+      {
+        applicationId: 'cli_test_app',
+        credentials: { appSecret: 'sec', encryptKey: 'enc' },
+        platform: 'feishu',
+        settings: {},
+      },
+      { appUrl: 'https://example.com' },
+    );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('maps shared status emojis to Feishu reaction identifiers', async () => {
+    const messenger = createClient().getMessenger('lark:p2p:oc_test');
+
+    await messenger.addReaction?.('om_test', '👀');
+    await messenger.replaceReaction?.('om_test', '👀', '🤔');
+    await messenger.replaceReaction?.('om_test', '🤔', '⚡');
+
+    expect(mockAddReaction.mock.calls).toEqual([
+      ['om_test', 'Get'],
+      ['om_test', 'THINKING'],
+      ['om_test', 'OnIt'],
+    ]);
+  });
+
+  it('skips status emojis without a Feishu identifier', async () => {
+    const messenger = createClient().getMessenger('lark:p2p:oc_test');
+
+    await messenger.replaceReaction?.('om_test', null, '🎉');
+
+    expect(mockAddReaction).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/services/bot/platforms/feishu/client.ts
+++ b/apps/server/src/services/bot/platforms/feishu/client.ts
@@ -28,12 +28,17 @@ import {
 } from '../types';
 import { formatUsageStats } from '../utils';
 import { FeishuWSConnection } from './gateway';
+import { FEISHU_REACTION_TYPES } from './const';
 import { sendFeishuAttachments } from './sendAttachments';
 
 const log = debug('bot-platform:feishu:client');
 
 const CONNECTED_STATUS_TTL_BUFFER_MS = 60 * 1000;
 const DEFAULT_DURATION_MS = 8 * 60 * 60 * 1000; // 8 hours
+
+function toFeishuReactionType(emoji: string): string | undefined {
+  return FEISHU_REACTION_TYPES[emoji];
+}
 
 export interface GatewayListenerOptions {
   durationMs?: number;
@@ -63,7 +68,10 @@ function createMessenger(
   const api = new LarkApiClient(config.applicationId, config.credentials.appSecret, domain);
   const chatId = extractChatId(platformThreadId);
   return {
-    addReaction: (messageId, emoji) => api.addReaction(messageId, emoji).then(() => {}),
+    addReaction: async (messageId, emoji) => {
+      const reactionType = toFeishuReactionType(emoji);
+      if (reactionType) await api.addReaction(messageId, reactionType);
+    },
     createMessage: async (content) => {
       const text = messengerContentText(content);
       const attachments = typeof content === 'string' ? undefined : content.attachments;
@@ -84,7 +92,10 @@ function createMessenger(
       if (prevEmoji === nextEmoji) return;
       // No remove API upstream — we can only add. Step swaps therefore stack
       // emoji on the user's message. Final cleanup is a no-op.
-      if (nextEmoji) await api.addReaction(messageId, nextEmoji);
+      if (nextEmoji) {
+        const reactionType = toFeishuReactionType(nextEmoji);
+        if (reactionType) await api.addReaction(messageId, reactionType);
+      }
     },
   };
 }

--- a/apps/server/src/services/bot/platforms/feishu/const.ts
+++ b/apps/server/src/services/bot/platforms/feishu/const.ts
@@ -2,3 +2,10 @@
 export const MAX_FEISHU_HISTORY_LIMIT = 50;
 
 export const DEFAULT_FEISHU_CONNECTION_MODE = 'websocket';
+
+/** Shared status emojis mapped to Feishu/Lark reaction identifiers. */
+export const FEISHU_REACTION_TYPES: Record<string, string> = {
+  '👀': 'Get',
+  '🤔': 'THINKING',
+  '⚡': 'OnIt',
+};

--- a/apps/server/src/services/bot/platforms/feishu/service.ts
+++ b/apps/server/src/services/bot/platforms/feishu/service.ts
@@ -41,7 +41,7 @@ import { DEFAULT_BOT_HISTORY_LIMIT } from '@lobechat/const';
 import type { MessageRuntimeService } from '@/server/services/toolExecution/serverRuntimes/message/adapters/types';
 import { PlatformUnsupportedError } from '@/server/services/toolExecution/serverRuntimes/message/PlatformUnsupportedError';
 
-import { MAX_FEISHU_HISTORY_LIMIT } from './const';
+import { FEISHU_REACTION_TYPES, MAX_FEISHU_HISTORY_LIMIT } from './const';
 import { sendFeishuAttachments } from './sendAttachments';
 
 /**
@@ -136,7 +136,8 @@ export class FeishuMessageService implements MessageRuntimeService {
   // ==================== Reactions ====================
 
   reactToMessage = async (params: ReactToMessageParams): Promise<ReactToMessageState> => {
-    await this.api.addReaction(params.messageId, params.emoji);
+    const reactionType = FEISHU_REACTION_TYPES[params.emoji];
+    if (reactionType) await this.api.addReaction(params.messageId, reactionType);
     return { messageId: params.messageId, success: true };
   };
 


### PR DESCRIPTION
## Summary

Fixes #18551.

Feishu/Lark reaction APIs require platform emoji identifiers rather than Unicode characters. This change maps the shared status reactions (`👀`, `🤔`, `⚡`) to `Get`, `THINKING`, and `OnIt` across messenger and message-service reaction paths. Unsupported status values are skipped instead of sending an invalid request.

## Testing

- `git diff --check`
- Added focused Vitest coverage for supported and unsupported reaction mappings.
- Full Vitest execution is deferred to CI because dependencies are not installed in this checkout.
