### PR TITLE
💄 style(heterogeneous-agent): hide quota and compact model picker in API mode

### DIFF
--- a/src/features/HeterogeneousAgent/modelPicker.test.ts
+++ b/src/features/HeterogeneousAgent/modelPicker.test.ts
@@ -1,7 +1,11 @@
 import type { LobeDefaultAiModelListItem } from 'model-bank';
 import { describe, expect, it } from 'vitest';
 
-import { resolveServerDefaultModelMeta } from './modelPicker';
+import {
+  buildServerDefaultModelOptions,
+  compactModelTriggerText,
+  resolveServerDefaultModelMeta,
+} from './modelPicker';
 
 const catalogItem = (partial: {
   displayName?: string;
@@ -30,5 +34,30 @@ describe('resolveServerDefaultModelMeta', () => {
       ])?.displayName,
     ).toBe('OpenAI GPT');
     expect(resolveServerDefaultModelMeta('gpt-5.6-sol', [])).toBeUndefined();
+  });
+});
+
+describe('compactModelTriggerText', () => {
+  it('uses the Select title when present', () => {
+    expect(compactModelTriggerText({ title: 'GPT-5.6', value: 'gpt-5.6' })).toBe('GPT-5.6');
+    expect(
+      compactModelTriggerText({ title: 'Claude Opus 4.1', value: 'anthropic/claude-opus-4-1' }),
+    ).toBe('Claude Opus 4.1');
+  });
+
+  it('falls back to the model id, not a namespaced provider/model value', () => {
+    expect(compactModelTriggerText({ value: 'anthropic/claude-opus-4-1' })).toBe('claude-opus-4-1');
+    expect(compactModelTriggerText({ value: 'gpt-5.6' })).toBe('gpt-5.6');
+  });
+});
+
+describe('buildServerDefaultModelOptions', () => {
+  it('puts the catalog display name on Select title for the closed trigger', () => {
+    const options = buildServerDefaultModelOptions(
+      [{ model: 'gpt-5.6' }],
+      [catalogItem({ displayName: 'GPT-5.6', id: 'gpt-5.6', providerId: 'lobehub' })],
+    );
+
+    expect(options[0]).toMatchObject({ title: 'GPT-5.6', value: 'gpt-5.6' });
   });
 });

--- a/src/features/HeterogeneousAgent/modelPicker.tsx
+++ b/src/features/HeterogeneousAgent/modelPicker.tsx
@@ -5,7 +5,19 @@ import { ModelItemRender, TAG_CLASSNAME } from '@/components/ModelSelect';
 
 export const MODEL_PICKER_STYLE = { minWidth: 200, width: 'initial' } as const;
 
+/** Closed trigger next to the composer send button — hug the label, cap growth. */
+export const COMPACT_MODEL_PICKER_STYLE = { maxWidth: 160, minWidth: 0, width: 'auto' } as const;
+
 export const modelPickerStyles = createStaticStyles(({ css }) => ({
+  compactLabel: css`
+    overflow: hidden;
+
+    min-width: 0;
+    max-width: 100%;
+
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
   picker: css`
     .${TAG_CLASSNAME} {
       display: none;
@@ -28,6 +40,7 @@ export const buildServerDefaultModelOptions = (
     const meta = resolveServerDefaultModelMeta(model, builtinAiModelList);
 
     return {
+      displayName: meta?.displayName ?? model,
       label: (
         <ModelItemRender
           displayName={meta?.displayName}

--- a/src/features/HeterogeneousAgent/modelPicker.tsx
+++ b/src/features/HeterogeneousAgent/modelPicker.tsx
@@ -32,15 +32,22 @@ export const resolveServerDefaultModelMeta = (
   builtinAiModelList.find((item) => item.id === model && item.providerId === 'lobehub') ??
   builtinAiModelList.find((item) => item.id === model);
 
+/** Closed-trigger text. Prefer Select's public `title`, not extra option fields. */
+export const compactModelTriggerText = (option: { title?: string; value?: unknown }) => {
+  const value = String(option.value ?? '');
+  const modelId = value.includes('/') ? value.slice(value.indexOf('/') + 1) : value;
+  return option.title || modelId;
+};
+
 export const buildServerDefaultModelOptions = (
   models: Array<{ model: string }>,
   builtinAiModelList: LobeDefaultAiModelListItem[],
 ) =>
   models.map(({ model }) => {
     const meta = resolveServerDefaultModelMeta(model, builtinAiModelList);
+    const title = meta?.displayName ?? model;
 
     return {
-      displayName: meta?.displayName ?? model,
       label: (
         <ModelItemRender
           displayName={meta?.displayName}
@@ -49,6 +56,7 @@ export const buildServerDefaultModelOptions = (
           showInfoTag={false}
         />
       ),
+      title,
       value: model,
     };
   });

--- a/src/features/ModelSelect/index.tsx
+++ b/src/features/ModelSelect/index.tsx
@@ -79,7 +79,14 @@ interface ModelOption {
 
 interface ModelSelectProps extends Pick<
   SelectProps,
-  'allowClear' | 'disabled' | 'loading' | 'placeholder' | 'size' | 'style' | 'variant'
+  | 'allowClear'
+  | 'disabled'
+  | 'labelRender'
+  | 'loading'
+  | 'placeholder'
+  | 'size'
+  | 'style'
+  | 'variant'
 > {
   defaultValue?: { model: string; provider?: string };
   initialWidth?: boolean;
@@ -107,6 +114,7 @@ const ModelSelect = memo<ModelSelectProps>(
     requiredAbilities,
     loading,
     disabled,
+    labelRender,
     size,
     style,
     variant,
@@ -348,6 +356,7 @@ const ModelSelect = memo<ModelSelectProps>(
           className={styles.select}
           defaultValue={value ? `${value.provider}/${value.model}` : null}
           disabled={disabled}
+          labelRender={labelRender}
           loading={loading || enabling}
           options={finalOptions}
           placeholder={placeholder}

--- a/src/features/ModelSelect/index.tsx
+++ b/src/features/ModelSelect/index.tsx
@@ -155,6 +155,7 @@ const ModelSelect = memo<ModelSelectProps>(
           ...model,
           label: <ModelItemRender {...model} {...model.abilities} showInfoTag={false} />,
           provider: provider.id,
+          title: model.displayName || model.id,
           value: `${provider.id}/${model.id}`,
         }));
       };

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/ApiModeModelBar.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/ApiModeModelBar.tsx
@@ -9,6 +9,7 @@ import { useProviderBindingCompatibleProviders } from '@/features/HeterogeneousA
 import {
   buildServerDefaultModelOptions,
   COMPACT_MODEL_PICKER_STYLE,
+  compactModelTriggerText,
   modelPickerStyles,
 } from '@/features/HeterogeneousAgent/modelPicker';
 import ModelSelect from '@/features/ModelSelect';
@@ -20,11 +21,9 @@ interface ApiModeModelBarProps {
   agentId: string;
 }
 
-const compactTriggerLabel = (option: { displayName?: string; value?: unknown }) => {
-  const value = String(option.value ?? '');
-  const modelId = value.includes('/') ? value.slice(value.indexOf('/') + 1) : value;
-  return <span className={modelPickerStyles.compactLabel}>{option.displayName || modelId}</span>;
-};
+const compactTriggerLabel = (option: { title?: string; value?: unknown }) => (
+  <span className={modelPickerStyles.compactLabel}>{compactModelTriggerText(option)}</span>
+);
 
 const ApiModeModelBar = memo<ApiModeModelBarProps>(({ agentId }) => {
   const agencyConfig = useAgentStore(agentByIdSelectors.getAgencyConfigById(agentId));

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/ApiModeModelBar.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/ApiModeModelBar.tsx
@@ -8,7 +8,7 @@ import { memo, useMemo } from 'react';
 import { useProviderBindingCompatibleProviders } from '@/features/HeterogeneousAgent/hooks/useProviderBinding';
 import {
   buildServerDefaultModelOptions,
-  MODEL_PICKER_STYLE,
+  COMPACT_MODEL_PICKER_STYLE,
   modelPickerStyles,
 } from '@/features/HeterogeneousAgent/modelPicker';
 import ModelSelect from '@/features/ModelSelect';
@@ -19,6 +19,12 @@ import { useAiInfraStore } from '@/store/aiInfra';
 interface ApiModeModelBarProps {
   agentId: string;
 }
+
+const compactTriggerLabel = (option: { displayName?: string; value?: unknown }) => {
+  const value = String(option.value ?? '');
+  const modelId = value.includes('/') ? value.slice(value.indexOf('/') + 1) : value;
+  return <span className={modelPickerStyles.compactLabel}>{option.displayName || modelId}</span>;
+};
 
 const ApiModeModelBar = memo<ApiModeModelBarProps>(({ agentId }) => {
   const agencyConfig = useAgentStore(agentByIdSelectors.getAgencyConfigById(agentId));
@@ -69,12 +75,13 @@ const ApiModeModelBar = memo<ApiModeModelBarProps>(({ agentId }) => {
     return (
       <TooltipGroup>
         <Select
-          popupMatchSelectWidth
           className={modelPickerStyles.picker}
+          labelRender={compactTriggerLabel}
           loading={serverCapability.isLoading}
           options={serverDefaultModelOptions}
+          popupMatchSelectWidth={false}
           size="small"
-          style={MODEL_PICKER_STYLE}
+          style={COMPACT_MODEL_PICKER_STYLE}
           value={serverDefaultApiConfig.model}
           variant="borderless"
           onChange={(model) => {
@@ -87,10 +94,11 @@ const ApiModeModelBar = memo<ApiModeModelBarProps>(({ agentId }) => {
 
   return (
     <ModelSelect
-      initialWidth
+      labelRender={compactTriggerLabel}
       popupWidth={360}
       providerIds={providerIds}
       size="small"
+      style={COMPACT_MODEL_PICKER_STYLE}
       variant="borderless"
       value={
         providerApiConfig

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/HeteroControlBar.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/HeteroControlBar.tsx
@@ -149,12 +149,18 @@ const HeteroControlBar = memo(() => {
     workspaceScoped,
   });
   const isLocalHeteroExecution = executionTarget === 'local';
+  // Subscription windows (5h / weekly) only exist when the CLI is signed into
+  // a Claude / Codex account. API mode bills the bound provider key instead,
+  // so the remaining-quota chip in the corner would be stale or empty.
+  const isSubscriptionAuth = (heteroProvider?.authMode ?? 'subscription') === 'subscription';
   // An explicit bound device (including web's device-upgraded "local" pick)
   // samples quota through the gateway; `auto` has no concrete device to ask
   // and the cloud sandbox has no sampler, so both stay quota-less.
   const quotaDeviceId = executionTarget === 'device' ? agencyConfig?.boundDeviceId : undefined;
   const shouldShowClaudeQuota =
-    heteroProvider?.type === 'claude-code' && (isLocalHeteroExecution || !!quotaDeviceId);
+    isSubscriptionAuth &&
+    heteroProvider?.type === 'claude-code' &&
+    (isLocalHeteroExecution || !!quotaDeviceId);
 
   if (isAccessLoading) return null;
 
@@ -208,7 +214,8 @@ const HeteroControlBar = memo(() => {
   // Codex quota still needs the local CLI (spawned over IPC), so it stays
   // desktop-local; the SDK runtime badge likewise reports this desktop's own
   // in-process runtime, not a remote device's.
-  const shouldShowCodexQuota = heteroProvider?.type === 'codex' && isLocalHeteroExecution;
+  const shouldShowCodexQuota =
+    isSubscriptionAuth && heteroProvider?.type === 'codex' && isLocalHeteroExecution;
   const shouldShowSdkRuntime =
     heteroProvider?.type === 'claude-code' &&
     isLocalHeteroExecution &&

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/QuotaMenu.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/QuotaMenu.test.tsx
@@ -3,6 +3,7 @@
  */
 import type * as LobechatConstModule from '@lobechat/const';
 import type * as ElectronClientIpcModule from '@lobechat/electron-client-ipc';
+import type { HeterogeneousProviderConfig } from '@lobechat/types';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -19,9 +20,12 @@ const mockService = vi.hoisted(() => ({
 
 const effectiveAgencyConfig = vi.hoisted(() => ({
   current: {
-    boundDeviceId: 'personal-device',
+    boundDeviceId: 'personal-device' as string | undefined,
     executionTarget: 'local' as const,
-    heterogeneousProvider: { command: 'codex', type: 'codex' as const },
+    heterogeneousProvider: {
+      command: 'codex',
+      type: 'codex',
+    } as HeterogeneousProviderConfig,
   },
   workspaceScoped: false,
 }));
@@ -38,6 +42,14 @@ vi.mock('@lobechat/electron-client-ipc', async (importOriginal) => ({
 
 vi.mock('@/features/ChatInput/ControlBar/WorkspaceControls', () => ({
   default: () => <div data-testid="workspace-controls" />,
+}));
+
+vi.mock('@/features/ChatInput/ControlBar/HeteroDeviceSwitcher', () => ({
+  default: () => <div data-testid="hetero-device-switcher" />,
+}));
+
+vi.mock('@/features/AgentQuotaCalendar', () => ({
+  openQuotaCalendarModal: vi.fn(),
 }));
 
 vi.mock('@/features/ChatInput/hooks/useAgentId', () => ({ useAgentId: () => 'agent-1' }));
@@ -330,6 +342,32 @@ describe('HeteroControlBar', () => {
 
     expect(screen.queryByRole('button', { name: 'heteroAgent.codexQuota.tooltip' })).toBeNull();
     expect(mockService.getCodexQuota).not.toHaveBeenCalled();
+  });
+
+  it('does not show Codex quota in API mode', () => {
+    effectiveAgencyConfig.current = {
+      boundDeviceId: 'personal-device',
+      executionTarget: 'local',
+      heterogeneousProvider: { authMode: 'api', command: 'codex', type: 'codex' },
+    };
+
+    render(<HeteroControlBar />);
+
+    expect(screen.queryByRole('button', { name: 'heteroAgent.codexQuota.tooltip' })).toBeNull();
+    expect(mockService.getCodexQuota).not.toHaveBeenCalled();
+  });
+
+  it('does not show Claude Code quota in API mode', () => {
+    effectiveAgencyConfig.current = {
+      boundDeviceId: 'personal-device',
+      executionTarget: 'local',
+      heterogeneousProvider: { authMode: 'api', type: 'claude-code' },
+    };
+
+    render(<HeteroControlBar />);
+
+    expect(screen.queryByRole('button', { name: 'heteroAgent.claudeQuota.tooltip' })).toBeNull();
+    expect(mockService.getClaudeCodeQuota).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
<!-- Brief and heads-up -->

When Claude Code / Codex run in API mode, the composer still showed a subscription remaining-quota chip and a 200px+ model trigger next to Send. API mode bills a provider key, so that quota is meaningless; the picker also crowded the send area.

| Before | After |
| ------ | ----- |
| Subscription quota chip in the composer corner on API-mode agents; model trigger min-width 200px and grew with the full model row | Quota chip hidden when `authMode === 'api'`; closed model trigger capped at 160px with an ellipsized name. Dropdown stays full width |

#### Test

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

How to test:

1. Open a Claude Code or Codex agent in **subscription** mode — remaining quota still appears bottom-right.
2. Switch the same agent to **API mode** — the quota chip is gone; the model picker next to Send is compact (max 160px), long names ellipsize, the open dropdown is still readable.
3. Repeat for both Claude Code and Codex.

#### 🔗 Related Issue

<!-- No matching GitHub/Linear issue found for this composer polish. -->