### PR TITLE
🐛 fix(agent-runtime): remove compressed messages from queue payload

### DIFF
--- a/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -1567,11 +1567,12 @@ describe('RuntimeExecutors', { timeout: 60_000 }, () => {
       expect(mockFinalizeCompression).toHaveBeenCalledTimes(1);
       expect(mockChat).toHaveBeenCalledTimes(1);
       expect(result.nextContext?.phase).toBe('compression_result');
-      expect((result.nextContext?.payload as any).compressedMessages[0]).toEqual({
+      expect(result.newState.messages[0]).toEqual({
         content: 'summary',
         id: 'group-123',
         role: 'compressedGroup',
       });
+      expect((result.nextContext?.payload as any).compressedMessages).toBeUndefined();
       expect((result.nextContext?.payload as any).parentMessageId).toBe('assistant-existing');
       expect(result.events).toContainEqual({
         groupId: 'group-123',
@@ -1630,8 +1631,8 @@ describe('RuntimeExecutors', { timeout: 60_000 }, () => {
       const result = await executors.compress_context!(instruction, state);
 
       expect(mockCreateCompressionGroup).not.toHaveBeenCalled();
+      expect(result.newState.messages).toEqual(state.messages);
       expect(result.nextContext?.payload as any).toMatchObject({
-        compressedMessages: state.messages,
         groupId: '',
         parentMessageId: undefined,
         skipped: true,
@@ -1656,8 +1657,8 @@ describe('RuntimeExecutors', { timeout: 60_000 }, () => {
 
       expect(mockCreateCompressionGroup).not.toHaveBeenCalled();
       expect(mockFinalizeCompression).not.toHaveBeenCalled();
+      expect(result.newState.messages).toEqual([{ content: 'history', role: 'user' }]);
       expect(result.nextContext?.payload as any).toMatchObject({
-        compressedMessages: [{ content: 'history', role: 'user' }],
         parentMessageId: 'assistant-existing',
         skipped: true,
       });
@@ -1723,7 +1724,7 @@ describe('RuntimeExecutors', { timeout: 60_000 }, () => {
         ['msg-history', 'assistant-existing'],
         expect.any(Object),
       );
-      expect((result.nextContext?.payload as any).compressedMessages).toEqual([
+      expect(result.newState.messages).toEqual([
         { content: 'summary', id: 'group-123', role: 'compressedGroup' },
         { content: 'continue with this exact instruction', role: 'user' },
       ]);
@@ -1759,7 +1760,7 @@ describe('RuntimeExecutors', { timeout: 60_000 }, () => {
 
       const result = await executors.compress_context!(instruction, state);
 
-      expect((result.nextContext?.payload as any).compressedMessages).toEqual([
+      expect(result.newState.messages).toEqual([
         { content: 'history', id: 'msg-history', role: 'user' },
       ]);
     });
@@ -1804,7 +1805,7 @@ describe('RuntimeExecutors', { timeout: 60_000 }, () => {
 
       const result = await executors.compress_context!(instruction, state);
 
-      expect((result.nextContext?.payload as any).compressedMessages).toEqual([
+      expect(result.newState.messages).toEqual([
         { content: 'summary', id: 'group-123', role: 'compressedGroup' },
         preservedMessage,
       ]);

--- a/packages/agent-runtime/src/executors/compressContext.test.ts
+++ b/packages/agent-runtime/src/executors/compressContext.test.ts
@@ -212,10 +212,11 @@ describe('compressContext executor', () => {
         topicId: 'topic-123',
       }),
     );
-    expect((result.nextContext?.payload as any).compressedMessages).toEqual([
+    expect(result.newState.messages).toEqual([
       { content: 'summary', id: 'group-123', role: 'compressedGroup' },
       preservedMessage,
     ]);
+    expect((result.nextContext?.payload as any).compressedMessages).toBeUndefined();
     expect((result.nextContext?.payload as any).parentMessageId).toBe('assistant-existing');
     expect(result.events).toContainEqual({
       groupId: 'group-123',
@@ -331,7 +332,7 @@ describe('compressContext executor', () => {
         sourceGroupIds: ['source-group-1', 'source-group-2'],
       }),
     );
-    expect((result.nextContext?.payload as any).compressedMessages).toEqual([
+    expect(result.newState.messages).toEqual([
       { content: 'combined summary', id: 'group-123', role: 'compressedGroup' },
     ]);
     expect((result.nextContext?.payload as any).parentMessageId).toBe('assistant-recent');
@@ -434,10 +435,8 @@ describe('compressContext executor', () => {
       }),
     );
     expect(compressionFinalizeGroup).not.toHaveBeenCalled();
-    expect(result.nextContext?.payload as any).toMatchObject({
-      compressedMessages: expect.arrayContaining([sourceGroup]),
-      skipped: true,
-    });
+    expect(result.newState.messages).toEqual(expect.arrayContaining([sourceGroup]));
+    expect(result.nextContext?.payload as any).toMatchObject({ skipped: true });
   });
 
   it('rolls back instead of finalizing when the compression signal is aborted', async () => {

--- a/packages/agent-runtime/src/executors/compressContext.ts
+++ b/packages/agent-runtime/src/executors/compressContext.ts
@@ -61,16 +61,12 @@ export const compressContext =
       preservedMessages.map((message) => message.id).filter((id): id is string => Boolean(id)),
     );
     const messagesToCompress = preservedMessages.length > 0 ? messages.slice(0, -1) : messages;
-    const compressedMessagesFallback = [...messagesToCompress, ...preservedMessages];
-
     const createNextContext = ({
-      compressedMessages,
       groupId,
       parentMessageId,
       skipped,
     }: GeneralAgentCompressionResultPayload) => ({
       payload: {
-        compressedMessages,
         groupId,
         parentMessageId,
         skipped,
@@ -88,7 +84,6 @@ export const compressContext =
       events,
       newState,
       nextContext: createNextContext({
-        compressedMessages: compressedMessagesFallback,
         groupId: '',
         parentMessageId,
         skipped: true,
@@ -284,7 +279,6 @@ export const compressContext =
         newState,
         nextContext: {
           ...createNextContext({
-            compressedMessages,
             groupId: compressionResult.messageGroupId,
             parentMessageId,
           }),


### PR DESCRIPTION
## Summary

- stop embedding the full `compressedMessages` array in `compression_result` queue contexts
- keep compressed messages in persisted agent state and pass only control fields to the next QStash step
- update success, skipped-compression, and fallback regression coverage

## Why

Large conversations could make the QStash `/run` request exceed the serverless function payload limit before application code ran, returning `413 FUNCTION_PAYLOAD_TOO_LARGE`.

This is phase 2 of the rollout. Phase 1 (#18587) has already landed and makes consumers fall back to persisted `state.messages`, so removing the producer field is safe across rolling deployments.

## Testing

- agent-runtime targeted check: 9 tests passed, lint clean
- the complete affected set previously passed 277 tests in the primary workspace
- temporary-worktree server test startup is blocked by Vite resolving the shared `node_modules` real path into the primary worktree (`@/config/db` alias); CI will run with native dependencies