### PR TITLE
✨ feat: drive Codex relay support from model capabilities

### DIFF
--- a/apps/desktop/src/main/controllers/HeterogeneousAgentImpl.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentImpl.ts
@@ -1299,6 +1299,29 @@ export default class HeterogeneousAgentCtr {
         return;
       }
 
+      if (session.agentType === 'codex') {
+        // The server re-resolves model compatibility for every operation. Rebuild
+        // the Codex binding only after that authorization succeeds so models.json
+        // is always derived from the operation-scoped catalog snapshot rather
+        // than from persisted agent config or Desktop-side model IDs.
+        await session.hostedProviderBinding?.cleanup();
+        session.hostedProviderBinding = undefined;
+        const hostedProviderBinding = await prepareHostedServerDefaultBinding({
+          agentType: session.agentType,
+          appStoragePath: this.app.appStoragePath,
+          args: session.args,
+          codexModel: operation.codexModel,
+          driver: getHeterogeneousAgentDriver(session.agentType),
+          endpoint: operation.endpoint,
+          env: session.env,
+          model: serverDefaultApiConfig.model,
+          sessionId: session.sessionId,
+        });
+        session.args = hostedProviderBinding.args;
+        session.env = hostedProviderBinding.env;
+        session.hostedProviderBinding = hostedProviderBinding;
+      }
+
       session.serverOperationToken = operation.token;
       await this.sendPromptImpl(params);
       if (!session.cancelledByUs) result = 'done';

--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
@@ -1750,6 +1750,55 @@ describe('HeterogeneousAgentCtr', () => {
       });
     });
 
+    it('rebuilds the Codex profile from operation-scoped model metadata before launch', async () => {
+      beginServerDefaultOperationMock.mockResolvedValueOnce({
+        codexModel: {
+          compatibility: {
+            defaultReasoningEffort: 'high',
+            reasoningEfforts: ['low', 'high', 'max'],
+            runtimeApiMode: 'chatCompletion',
+            toolMode: 'function',
+            truncationMode: 'tokens',
+          },
+          contextWindowTokens: 256_000,
+          description: 'Catalog-owned description',
+          displayName: 'Relay Coding Model',
+        },
+        endpoint: 'https://app.example.com',
+        model: 'lobehub-default',
+        token: 'operation-token',
+      });
+      nextFakeProc = createFakeProc().proc;
+      const ctr = new HeterogeneousAgentCtr({
+        appStoragePath,
+        storeManager: { get: vi.fn() },
+      } as any);
+      const { sessionId } = await ctr.startSession({
+        agentType: 'codex',
+        command: 'codex',
+        providerBinding: {
+          apiConfig: { model: 'relay-coding-model', source: 'server-default' },
+          kind: 'server-default',
+        },
+      });
+
+      await ctr.sendPrompt({
+        operationId: 'op-capability',
+        prompt: 'hello',
+        sessionId,
+        topicId: 'topic-1',
+      });
+
+      expect(spawnCalls[0].args).toEqual(
+        expect.arrayContaining([
+          '--config',
+          expect.stringMatching(/^model_catalog_json=.*models\.json"$/),
+          '--model',
+          'lobehub/relay-coding-model',
+        ]),
+      );
+    });
+
     it('does not launch server-default Codex when cancelled while authorization is pending', async () => {
       let resolveBegin!: (value: {
         endpoint: string;

--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/claudeCode.test.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/claudeCode.test.ts
@@ -27,6 +27,7 @@ describe('claudeCodeDriver', () => {
       env: { ANTHROPIC_AUTH_TOKEN: 'stale' },
       model: 'claude-sonnet-4-6',
       profileDir: '/tmp/profile',
+      runDir: '/tmp/run',
     });
 
     expect(plan.env).toMatchObject({

--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/codex.test.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/codex.test.ts
@@ -36,6 +36,7 @@ describe('codexDriver provider binding', () => {
       env: { LOBEHUB_HETERO_TOKEN: 'stale' },
       model: 'gpt-5.4',
       profileDir: '/tmp/profile',
+      runDir: '/tmp/run',
     });
     const config = plan.profileFiles?.[0]?.content ?? '';
 
@@ -45,6 +46,7 @@ describe('codexDriver provider binding', () => {
     expect(config).toContain('env_key = "LOBEHUB_HETERO_TOKEN"');
     expect(config).not.toContain('model_catalog_json');
     expect(plan.profileFiles).toHaveLength(1);
+    expect(plan.runFiles).toBeUndefined();
     expect(config).not.toContain('stale');
     expect(plan.env.LOBEHUB_HETERO_TOKEN).toBeUndefined();
   });
@@ -57,22 +59,39 @@ describe('codexDriver provider binding', () => {
     'writes a current Codex model catalog for %s',
     async (selectedModel, defaultReasoningLevel, reasoningLevels, truncationMode) => {
       const profileDir = 'C:\\managed\\codex';
+      const runDir = 'C:\\managed\\run';
       const plan = await codexDriver.prepareServerDefaultBinding!({
         args: [],
+        codexModel: {
+          compatibility: {
+            defaultReasoningEffort: defaultReasoningLevel,
+            reasoningEfforts: [...reasoningLevels],
+            runtimeApiMode: 'chatCompletion',
+            toolMode: 'function',
+            truncationMode,
+          },
+          contextWindowTokens: 1_048_576,
+          description: `${selectedModel} catalog description`,
+          displayName: selectedModel,
+        },
         endpoint: 'https://app.example.com',
         env: {},
         model: selectedModel,
         profileDir,
+        runDir,
       });
       const config = plan.profileFiles?.find(({ path }) => path === 'config.toml')?.content ?? '';
-      const catalogContent = plan.profileFiles?.find(({ path }) => path === 'models.json')?.content;
+      const catalogContent = plan.runFiles?.find(({ path }) => path === 'models.json')?.content;
       const catalog = JSON.parse(catalogContent ?? '{}');
       const model = catalog.models?.[0];
 
-      expect(plan.args).toEqual(['--model', `lobehub/${selectedModel}`]);
-      expect(config).toContain(
-        `model_catalog_json = ${JSON.stringify(path.join(profileDir, 'models.json'))}`,
-      );
+      expect(plan.args).toEqual([
+        '--config',
+        `model_catalog_json=${JSON.stringify(path.join(runDir, 'models.json'))}`,
+        '--model',
+        `lobehub/${selectedModel}`,
+      ]);
+      expect(config).not.toContain('model_catalog_json');
       expect(catalog.models).toHaveLength(1);
       expect(model).toMatchObject({
         apply_patch_tool_type: null,

--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/codex.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/codex.ts
@@ -5,12 +5,8 @@ import {
   CODEX_EXECUTION_MODE_FLAGS,
   CODEX_REQUIRED_ARGS,
 } from '@lobechat/heterogeneous-agents/spawn';
-import type { CodexReasoningEffort, CodexServerDefaultCustomModel } from '@lobechat/types';
-import {
-  formatServerDefaultHeterogeneousModel,
-  getCodexReasoningEffortLevels,
-  isCodexServerDefaultCustomModel,
-} from '@lobechat/types';
+import type { CodexReasoningEffort, CodexServerDefaultModelMetadata } from '@lobechat/types';
+import { formatServerDefaultHeterogeneousModel } from '@lobechat/types';
 
 import type { HeterogeneousAgentBuildPlanParams, HeterogeneousAgentDriver } from '../types';
 
@@ -21,38 +17,7 @@ const HOST_PROVIDER_ID = 'lobehub';
 const HOST_API_KEY_ENV = 'LOBEHUB_CODEX_API_KEY';
 const SERVER_TOKEN_ENV = 'LOBEHUB_HETERO_TOKEN';
 const SERVER_DEFAULT_MODEL_CATALOG_FILE = 'models.json';
-
-interface CodexServerDefaultModelMetadata {
-  contextWindow: number;
-  defaultReasoningLevel: CodexReasoningEffort;
-  description: string;
-  displayName: string;
-  truncationMode: 'bytes' | 'tokens';
-}
-
-const CODEX_SERVER_DEFAULT_MODEL_METADATA = {
-  'deepseek-v4-flash': {
-    contextWindow: 1_048_576,
-    defaultReasoningLevel: 'high',
-    description: 'Fast, cost-efficient DeepSeek V4 model for agentic coding.',
-    displayName: 'DeepSeek V4 Flash',
-    truncationMode: 'tokens',
-  },
-  'deepseek-v4-pro': {
-    contextWindow: 1_048_576,
-    defaultReasoningLevel: 'high',
-    description: 'DeepSeek V4 flagship model for complex agentic coding tasks.',
-    displayName: 'DeepSeek V4 Pro',
-    truncationMode: 'tokens',
-  },
-  'glm-5.2': {
-    contextWindow: 1_048_576,
-    defaultReasoningLevel: 'max',
-    description: 'GLM-5.2 flagship model for long-horizon engineering tasks.',
-    displayName: 'GLM-5.2',
-    truncationMode: 'bytes',
-  },
-} as const satisfies Record<CodexServerDefaultCustomModel, CodexServerDefaultModelMetadata>;
+const DEFAULT_CONTEXT_WINDOW_TOKENS = 128_000;
 
 const CODEX_REASONING_LEVEL_DESCRIPTIONS = {
   high: 'Enhanced reasoning for complex tasks',
@@ -112,11 +77,13 @@ const sanitizeCodexProviderBindingEnv = (source: Record<string, string> | undefi
 const tomlString = (value: string): string => JSON.stringify(value);
 
 const buildServerDefaultModelCatalog = (
-  model: CodexServerDefaultCustomModel,
+  model: CodexServerDefaultModelMetadata,
   requestModel: string,
 ) => {
-  const metadata = CODEX_SERVER_DEFAULT_MODEL_METADATA[model];
-  const supportedReasoningLevels = getCodexReasoningEffortLevels(model).map((effort) => ({
+  const { compatibility } = model;
+  const contextWindow = model.contextWindowTokens ?? DEFAULT_CONTEXT_WINDOW_TOKENS;
+  const displayName = model.displayName ?? requestModel;
+  const supportedReasoningLevels = compatibility.reasoningEfforts.map((effort) => ({
     description: CODEX_REASONING_LEVEL_DESCRIPTIONS[effort] ?? `${effort} reasoning`,
     effort,
   }));
@@ -130,16 +97,16 @@ const buildServerDefaultModelCatalog = (
           apply_patch_tool_type: null,
           availability_nux: null,
           base_instructions: CODEX_SERVER_DEFAULT_BASE_INSTRUCTIONS,
-          context_window: metadata.contextWindow,
-          default_reasoning_level: metadata.defaultReasoningLevel,
+          context_window: contextWindow,
+          default_reasoning_level: compatibility.defaultReasoningEffort,
           default_reasoning_summary: 'none',
           default_verbosity: null,
-          description: metadata.description,
-          display_name: metadata.displayName,
+          description: model.description ?? displayName,
+          display_name: displayName,
           effective_context_window_percent: 95,
           experimental_supported_tools: [],
           input_modalities: ['text'],
-          max_context_window: metadata.contextWindow,
+          max_context_window: contextWindow,
           priority: 0,
           shell_type: 'unified_exec',
           slug: requestModel,
@@ -147,7 +114,7 @@ const buildServerDefaultModelCatalog = (
           supported_in_api: true,
           supported_reasoning_levels: supportedReasoningLevels,
           supports_reasoning_summary_parameter: false,
-          truncation_policy: { limit: 10_000, mode: metadata.truncationMode },
+          truncation_policy: { limit: 10_000, mode: compatibility.truncationMode },
           upgrade: null,
           visibility: 'list',
         },
@@ -224,16 +191,14 @@ export const codexDriver: HeterogeneousAgentDriver = {
       profileFiles: [{ content: config, path: 'config.toml' }],
     };
   },
-  prepareServerDefaultBinding({ args, endpoint, env, model, profileDir }) {
+  prepareServerDefaultBinding({ args, codexModel, endpoint, env, model, profileDir, runDir }) {
     const requestModel = formatServerDefaultHeterogeneousModel(model);
-    const customModel = isCodexServerDefaultCustomModel(model) ? model : undefined;
-    const modelCatalogPath = customModel
-      ? path.join(profileDir, SERVER_DEFAULT_MODEL_CATALOG_FILE)
+    const modelCatalogPath = codexModel
+      ? path.join(runDir, SERVER_DEFAULT_MODEL_CATALOG_FILE)
       : undefined;
     const config = [
       `model = ${tomlString(requestModel)}`,
       `model_provider = ${tomlString(HOST_PROVIDER_ID)}`,
-      ...(modelCatalogPath ? [`model_catalog_json = ${tomlString(modelCatalogPath)}`] : []),
       '',
       `[model_providers.${HOST_PROVIDER_ID}]`,
       `name = ${tomlString('LobeHub Server Default')}`,
@@ -245,19 +210,24 @@ export const codexDriver: HeterogeneousAgentDriver = {
       '',
     ].join('\n');
     return {
-      args: [...sanitizeCodexProviderBindingArgs(args), '--model', requestModel],
-      env: { ...sanitizeCodexProviderBindingEnv(env), CODEX_HOME: profileDir },
-      profileFiles: [
-        { content: config, path: 'config.toml' },
-        ...(customModel
-          ? [
-              {
-                content: buildServerDefaultModelCatalog(customModel, requestModel),
-                path: SERVER_DEFAULT_MODEL_CATALOG_FILE,
-              },
-            ]
+      args: [
+        ...sanitizeCodexProviderBindingArgs(args),
+        ...(modelCatalogPath
+          ? ['--config', `model_catalog_json=${tomlString(modelCatalogPath)}`]
           : []),
+        '--model',
+        requestModel,
       ],
+      env: { ...sanitizeCodexProviderBindingEnv(env), CODEX_HOME: profileDir },
+      profileFiles: [{ content: config, path: 'config.toml' }],
+      runFiles: codexModel
+        ? [
+            {
+              content: buildServerDefaultModelCatalog(codexModel, requestModel),
+              path: SERVER_DEFAULT_MODEL_CATALOG_FILE,
+            },
+          ]
+        : undefined,
     };
   },
 };

--- a/apps/desktop/src/main/modules/heterogeneousAgent/providerBindingHost.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/providerBindingHost.ts
@@ -7,6 +7,7 @@ import type {
   HeterogeneousProviderBindingReference,
   HeterogeneousProviderBindingResolution,
 } from '@lobechat/heterogeneous-agents';
+import type { CodexServerDefaultModelMetadata } from '@lobechat/types';
 
 import { HETERO_AGENT_BINDINGS_DIR, HETERO_AGENT_RUNS_DIR } from '@/const/heteroAgent';
 
@@ -137,6 +138,7 @@ export const prepareHostedServerDefaultBinding = async (params: {
   agentType: string;
   appStoragePath: string;
   args: string[];
+  codexModel?: CodexServerDefaultModelMetadata;
   driver: HeterogeneousAgentDriver;
   endpoint: string;
   env?: Record<string, string>;
@@ -171,10 +173,12 @@ export const prepareHostedServerDefaultBinding = async (params: {
   try {
     const plan = await params.driver.prepareServerDefaultBinding({
       args: params.args,
+      codexModel: params.codexModel,
       endpoint: params.endpoint,
       env: params.env,
       model: params.model,
       profileDir,
+      runDir,
     });
     await writeManagedFiles(profileDir, runDir, plan.profileFiles);
     await writeManagedFiles(runDir, runDir, plan.runFiles);

--- a/apps/desktop/src/main/modules/heterogeneousAgent/providerBindingPort.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/providerBindingPort.ts
@@ -2,6 +2,7 @@ import type {
   HeterogeneousProviderBindingReference,
   HeterogeneousProviderBindingRuntime,
 } from '@lobechat/heterogeneous-agents';
+import type { CodexServerDefaultModelMetadata } from '@lobechat/types';
 
 import {
   callLambdaMutation,
@@ -26,6 +27,7 @@ export const getProviderBindingRuntime = async (
 };
 
 export interface ServerDefaultOperationBinding {
+  codexModel?: CodexServerDefaultModelMetadata;
   endpoint: string;
   model: 'lobehub-default';
   token: string;

--- a/apps/desktop/src/main/modules/heterogeneousAgent/types.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/types.ts
@@ -3,6 +3,7 @@ import type {
   HeterogeneousProviderBindingResolution,
 } from '@lobechat/heterogeneous-agents';
 import type { AgentInputPlan, AgentPromptInput } from '@lobechat/heterogeneous-agents/spawn';
+import type { CodexServerDefaultModelMetadata } from '@lobechat/types';
 
 export interface HeterogeneousAgentImageAttachment {
   id: string;
@@ -54,10 +55,12 @@ export interface PrepareProviderBindingContext {
 
 export interface PrepareServerDefaultBindingContext {
   args: string[];
+  codexModel?: CodexServerDefaultModelMetadata;
   endpoint: string;
   env?: Record<string, string>;
   model: string;
   profileDir: string;
+  runDir: string;
 }
 
 export interface ProviderBindingPlan {

--- a/apps/server/src/modules/ModelRuntime/index.test.ts
+++ b/apps/server/src/modules/ModelRuntime/index.test.ts
@@ -23,7 +23,7 @@ import {
 } from '@lobechat/model-runtime';
 import { LobeVertexAI } from '@lobechat/model-runtime/vertexai';
 import { ChatErrorType, type ClientSecretPayload } from '@lobechat/types';
-import { ModelProvider } from 'model-bank';
+import { type CodexAgentCompatibility, ModelProvider } from 'model-bank';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -37,6 +37,14 @@ import {
 
 const getServerGlobalConfig = vi.hoisted(() => vi.fn());
 const loadModels = vi.hoisted(() => vi.fn());
+
+const codexCompatibility: CodexAgentCompatibility = {
+  defaultReasoningEffort: 'high',
+  reasoningEfforts: ['low', 'high', 'max'],
+  runtimeApiMode: 'chatCompletion',
+  toolMode: 'function',
+  truncationMode: 'tokens',
+};
 
 vi.mock('@/business/client/model-bank/loadModels', () => ({
   loadModels,
@@ -205,7 +213,7 @@ describe('getServerDefaultHeterogeneousModels', () => {
     });
   });
 
-  it('offers tool-capable relay models to Claude Code and only explicit custom models to Codex', async () => {
+  it('offers tool-capable relay models to Claude Code and capability-declared models to Codex', async () => {
     getServerGlobalConfig.mockResolvedValue({
       aiProvider: {
         lobehub: {
@@ -214,20 +222,31 @@ describe('getServerDefaultHeterogeneousModels', () => {
             { abilities: { functionCall: true }, enabled: true, id: 'kimi-k2.6', type: 'chat' },
             {
               abilities: { functionCall: true },
+              agentCompatibility: { codex: codexCompatibility },
               enabled: true,
-              id: 'deepseek-v4-flash',
+              id: 'relay-coding-model',
+              type: 'chat',
+            },
+            {
+              abilities: { reasoning: true },
+              agentCompatibility: { codex: codexCompatibility },
+              enabled: true,
+              id: 'metadata-without-tools',
               type: 'chat',
             },
             {
               abilities: { functionCall: true },
+              agentCompatibility: {
+                codex: {
+                  defaultReasoningEffort: 'max',
+                  reasoningEfforts: ['high'],
+                  runtimeApiMode: 'chatCompletion',
+                  toolMode: 'function',
+                  truncationMode: 'tokens',
+                },
+              },
               enabled: true,
-              id: 'deepseek-v4-pro',
-              type: 'chat',
-            },
-            {
-              abilities: { functionCall: true },
-              enabled: true,
-              id: 'glm-5.2',
+              id: 'invalid-codex-metadata',
               type: 'chat',
             },
             {
@@ -247,12 +266,11 @@ describe('getServerDefaultHeterogeneousModels', () => {
     await expect(getServerDefaultHeterogeneousModels()).resolves.toEqual({
       'claude-code': [
         { model: 'kimi-k2.6' },
-        { model: 'deepseek-v4-flash' },
-        { model: 'deepseek-v4-pro' },
-        { model: 'glm-5.2' },
+        { model: 'relay-coding-model' },
+        { model: 'invalid-codex-metadata' },
         { model: 'gemini-3.1-pro-preview' },
       ],
-      'codex': [{ model: 'deepseek-v4-flash' }, { model: 'deepseek-v4-pro' }, { model: 'glm-5.2' }],
+      'codex': [{ model: 'relay-coding-model' }],
     });
   });
 
@@ -338,13 +356,23 @@ describe('resolveServerDefaultHeterogeneousModel', () => {
     ).resolves.toEqual({ model: 'claude-sonnet-4-6', provider: 'lobehub' });
   });
 
-  it('accepts a tool-capable third-party relay model for Claude Code only', async () => {
+  it('requires explicit compatibility metadata for a non-native Codex model', async () => {
     getServerGlobalConfig.mockResolvedValue({
       aiProvider: {
         lobehub: {
           enabled: true,
           serverModelLists: [
             { abilities: { functionCall: true }, enabled: true, id: 'kimi-k2.6', type: 'chat' },
+            {
+              abilities: { functionCall: true },
+              agentCompatibility: { codex: codexCompatibility },
+              contextWindowTokens: 256_000,
+              description: 'Catalog-owned description',
+              displayName: 'Relay Coding Model',
+              enabled: true,
+              id: 'relay-coding-model',
+              type: 'chat',
+            },
             { abilities: { reasoning: true }, enabled: true, id: 'no-tools-model', type: 'chat' },
           ],
         },
@@ -358,6 +386,16 @@ describe('resolveServerDefaultHeterogeneousModel', () => {
     await expect(resolveServerDefaultHeterogeneousModel('codex', 'kimi-k2.6')).rejects.toThrow(
       'not compatible with this heterogeneous agent',
     );
+    await expect(
+      resolveServerDefaultHeterogeneousModel('codex', 'relay-coding-model'),
+    ).resolves.toEqual({
+      codexCompatibility,
+      contextWindowTokens: 256_000,
+      description: 'Catalog-owned description',
+      displayName: 'Relay Coding Model',
+      model: 'relay-coding-model',
+      provider: 'lobehub',
+    });
     await expect(
       resolveServerDefaultHeterogeneousModel('claude-code', 'no-tools-model'),
     ).rejects.toThrow('not compatible with this heterogeneous agent');

--- a/apps/server/src/modules/ModelRuntime/index.ts
+++ b/apps/server/src/modules/ModelRuntime/index.ts
@@ -21,9 +21,8 @@ import {
   type SuperGrokKeyVault,
   type VertexAIKeyVault,
 } from '@lobechat/types';
-import { isCodexServerDefaultCustomModel } from '@lobechat/types';
 import { safeParseJSON } from '@lobechat/utils';
-import { type AiFullModelCard, ModelProvider } from 'model-bank';
+import { type AiFullModelCard, CodexAgentCompatibilitySchema, ModelProvider } from 'model-bank';
 import { AiProviderBaseURLSchema } from 'model-bank/aiProvider';
 import { DEFAULT_MODEL_PROVIDER_LIST } from 'model-bank/modelProviders';
 
@@ -549,19 +548,20 @@ export type ServerDefaultHeterogeneousModels = Record<
  * `parseClaudeModelId` arm keeps Claude ids eligible in deployments whose
  * catalog omits `abilities`.
  *
- * Codex accepts native Responses models plus an explicit set of tool-capable
- * relay models configured through its custom model-catalog path. Keep that set
- * narrow: the CLI branches reasoning and continuation behaviour on model
- * metadata, so function calling alone is not enough to establish compatibility.
+ * Codex accepts native Responses models automatically. Other relay models must
+ * explicitly publish Codex compatibility metadata in the authoritative model
+ * catalog in addition to supporting function tools. The metadata drives both
+ * the Desktop model catalog and the relay's upstream request mode.
  */
 const supportsServerDefaultHeterogeneousAgent = (
   agentType: ServerDefaultHeterogeneousAgentType,
-  model: Pick<AiFullModelCard, 'abilities' | 'id'>,
+  model: Pick<AiFullModelCard, 'abilities' | 'agentCompatibility' | 'id'>,
 ) =>
   agentType === 'claude-code'
     ? parseClaudeModelId(model.id) !== undefined || model.abilities?.functionCall === true
     : isResponsesAPIModel(model.id) ||
-      (isCodexServerDefaultCustomModel(model.id) && model.abilities?.functionCall === true);
+      (model.abilities?.functionCall === true &&
+        CodexAgentCompatibilitySchema.safeParse(model.agentCompatibility?.codex).success);
 
 const getEnabledServerChatModels = async (provider: ModelProvider) => {
   const providerConfig = (await getServerGlobalConfig()).aiProvider[provider];
@@ -588,13 +588,25 @@ const findEnabledServerChatModel = async (provider: string, model: string) => {
   return modelConfig;
 };
 
-const toServerModelSelection = (provider: string, modelConfig: AiFullModelCard) => ({
-  ...(modelConfig.config?.deploymentName && {
-    deploymentName: modelConfig.config.deploymentName,
-  }),
-  model: modelConfig.id,
-  provider,
-});
+const toServerModelSelection = (provider: string, modelConfig: AiFullModelCard) => {
+  const codexCompatibility = CodexAgentCompatibilitySchema.safeParse(
+    modelConfig.agentCompatibility?.codex,
+  );
+
+  return {
+    ...(modelConfig.config?.deploymentName && {
+      deploymentName: modelConfig.config.deploymentName,
+    }),
+    ...(codexCompatibility.success && { codexCompatibility: codexCompatibility.data }),
+    ...(modelConfig.contextWindowTokens && {
+      contextWindowTokens: modelConfig.contextWindowTokens,
+    }),
+    ...(modelConfig.description && { description: modelConfig.description }),
+    ...(modelConfig.displayName && { displayName: modelConfig.displayName }),
+    model: modelConfig.id,
+    provider,
+  };
+};
 
 /** Return compatible models from the single deployment-owned relay provider. */
 export const getServerDefaultHeterogeneousModels = async () => {

--- a/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultOperation.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.serverDefaultOperation.test.ts
@@ -105,6 +105,49 @@ describe('server-default heterogeneous operation control', () => {
     });
   });
 
+  it('returns Codex metadata from the operation-time model resolution without persisting it', async () => {
+    const compatibility = {
+      defaultReasoningEffort: 'high' as const,
+      reasoningEfforts: ['low', 'high', 'max'] as const,
+      runtimeApiMode: 'chatCompletion' as const,
+      toolMode: 'function' as const,
+      truncationMode: 'tokens' as const,
+    };
+    resolveModel.mockResolvedValueOnce({
+      codexCompatibility: compatibility,
+      contextWindowTokens: 256_000,
+      description: 'Catalog-owned description',
+      displayName: 'Relay Coding Model',
+      model: 'relay-coding-model',
+      provider: 'lobehub',
+    });
+
+    await expect(
+      caller().beginServerDefaultHeterogeneousOperation({
+        ...operationInput('desktop-operation-metadata'),
+        model: 'relay-coding-model',
+      }),
+    ).resolves.toMatchObject({
+      codexModel: {
+        compatibility,
+        contextWindowTokens: 256_000,
+        description: 'Catalog-owned description',
+        displayName: 'Relay Coding Model',
+      },
+      model: 'lobehub-default',
+      token: 'operation-token',
+    });
+
+    const [operation] = await testDB
+      .select()
+      .from(agentOperations)
+      .where(eq(agentOperations.id, 'desktop-operation-metadata'));
+    expect(operation.metadata).toEqual({
+      agentType: 'codex',
+      serverDefaultHeterogeneous: true,
+    });
+  });
+
   it('requires a normal user OIDC token for the control plane', async () => {
     await expect(
       caller('hetero-operation').beginServerDefaultHeterogeneousOperation(

--- a/apps/server/src/routers/lambda/aiAgent.ts
+++ b/apps/server/src/routers/lambda/aiAgent.ts
@@ -970,6 +970,15 @@ export const aiAgentRouter = router({
       }
 
       return {
+        ...(input.agentType === 'codex' &&
+          selection.codexCompatibility && {
+            codexModel: {
+              compatibility: selection.codexCompatibility,
+              contextWindowTokens: selection.contextWindowTokens,
+              description: selection.description,
+              displayName: selection.displayName,
+            },
+          }),
         model: 'lobehub-default' as const,
         token: await signHeteroOperationJWT({
           capabilities: ['model:invoke'],

--- a/packages/model-bank/src/aiModels/deepseek.ts
+++ b/packages/model-bank/src/aiModels/deepseek.ts
@@ -8,6 +8,15 @@ const deepseekChatModels: AIChatModelCard[] = [
       reasoning: true,
       structuredOutput: true,
     },
+    agentCompatibility: {
+      codex: {
+        defaultReasoningEffort: 'high',
+        reasoningEfforts: ['low', 'high', 'max'],
+        runtimeApiMode: 'chatCompletion',
+        toolMode: 'function',
+        truncationMode: 'tokens',
+      },
+    },
     contextWindowTokens: 1_048_576,
     description:
       'DeepSeek V4 Flash is the fast, cost-efficient member of the V4 family with a 1M context window and hybrid thinking — one of the cheapest capable models available.',
@@ -36,6 +45,15 @@ const deepseekChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
       structuredOutput: true,
+    },
+    agentCompatibility: {
+      codex: {
+        defaultReasoningEffort: 'high',
+        reasoningEfforts: ['low', 'high', 'max'],
+        runtimeApiMode: 'chatCompletion',
+        toolMode: 'function',
+        truncationMode: 'tokens',
+      },
     },
     contextWindowTokens: 1_048_576,
     description:

--- a/packages/model-bank/src/aiModels/zhipu.ts
+++ b/packages/model-bank/src/aiModels/zhipu.ts
@@ -46,6 +46,15 @@ const zhipuChatModels: AIChatModelCard[] = [
       search: true,
       structuredOutput: true,
     },
+    agentCompatibility: {
+      codex: {
+        defaultReasoningEffort: 'max',
+        reasoningEfforts: ['high', 'max'],
+        runtimeApiMode: 'chatCompletion',
+        toolMode: 'function',
+        truncationMode: 'bytes',
+      },
+    },
     contextWindowTokens: 1_048_576,
     description:
       'GLM-5.2 is Zhipu’s flagship model for the era of long-horizon tasks. It supports a solid 1M context window that can hold project-scale engineering context, with more stable long-horizon execution and more reliable adherence to engineering conventions. A single task can complete the full development path from requirements to multi-platform deployable artifacts.',

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -25,6 +25,45 @@ export const AiModelTypeSchema = z.enum([
 
 export type AiModelType = z.infer<typeof AiModelTypeSchema>;
 
+export const CodexReasoningEffortSchema = z.enum([
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra',
+]);
+
+export type CodexReasoningEffort = z.infer<typeof CodexReasoningEffortSchema>;
+
+export const CodexAgentCompatibilitySchema = z
+  .object({
+    defaultReasoningEffort: CodexReasoningEffortSchema,
+    reasoningEfforts: z.array(CodexReasoningEffortSchema).min(1),
+    runtimeApiMode: z.enum(['chatCompletion', 'responses']),
+    toolMode: z.literal('function'),
+    truncationMode: z.enum(['bytes', 'tokens']),
+  })
+  .passthrough()
+  .refine(
+    ({ defaultReasoningEffort, reasoningEfforts }) =>
+      reasoningEfforts.includes(defaultReasoningEffort),
+    {
+      message: 'defaultReasoningEffort must be included in reasoningEfforts',
+      path: ['defaultReasoningEffort'],
+    },
+  );
+
+export type CodexAgentCompatibility = z.infer<typeof CodexAgentCompatibilitySchema>;
+
+export const AgentCompatibilitySchema = z
+  .object({
+    codex: CodexAgentCompatibilitySchema.optional(),
+  })
+  .passthrough();
+
+export type AgentCompatibility = z.infer<typeof AgentCompatibilitySchema>;
+
 /**
  * The speech-to-text model type was renamed from the legacy `stt` to the
  * standard `asr`. Instead of a bulk DB data migration, persisted rows and
@@ -593,6 +632,7 @@ export const AiModelSettingsSchema = z.object({
 
 export interface AIChatModelCard extends AIBaseModelCard {
   abilities?: ModelAbilities;
+  agentCompatibility?: AgentCompatibility;
   config?: AiModelConfig;
   maxOutput?: number;
   pricing?: Pricing;
@@ -659,6 +699,7 @@ export interface AIRealtimeModelCard extends AIBaseModelCard {
 
 export interface AiFullModelCard extends AIBaseModelCard {
   abilities?: ModelAbilities;
+  agentCompatibility?: AgentCompatibility;
   config?: AiModelConfig;
   contextWindowTokens?: number;
   displayName?: string;
@@ -678,6 +719,7 @@ export interface LobeDefaultAiModelListItem extends AiFullModelCard {
 // create
 export const CreateAiModelSchema = z.object({
   abilities: AiModelAbilitiesSchema.optional(),
+  agentCompatibility: AgentCompatibilitySchema.optional(),
   contextWindowTokens: z.number().optional(),
   displayName: z.string().optional(),
   id: z.string(),
@@ -697,6 +739,7 @@ export type CreateAiModelParams = z.infer<typeof CreateAiModelSchema>;
 
 export interface AiProviderModelListItem {
   abilities?: ModelAbilities;
+  agentCompatibility?: AgentCompatibility;
   config?: AiModelConfig;
   contextWindowTokens?: number;
   description?: string;
@@ -718,6 +761,7 @@ export interface AiProviderModelListItem {
 // Update
 export const UpdateAiModelSchema = z.object({
   abilities: AiModelAbilitiesSchema.optional(),
+  agentCompatibility: AgentCompatibilitySchema.optional(),
   // NOTE: `chatConfig` is deliberately NOT accepted here — model-instance reasoning
   // defaults go through the dedicated updateAiModelReasoningConfig procedure so the
   // generic update path can never carry (and thus never stomp) that namespace.

--- a/packages/openapi/src/services/heterogeneous-direct.service.test.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.test.ts
@@ -122,10 +122,17 @@ describe('heterogeneous direct invocation protocol', () => {
     expect(runtimePayload).not.toHaveProperty('deploymentName');
   });
 
-  it('adapts custom Codex relay models to chat completions with their reasoning effort', async () => {
+  it('uses operation-resolved Codex compatibility to select chat completions and effort', async () => {
     const chat = vi.fn().mockResolvedValue(new Response('stream'));
     vi.mocked(resolveServerDefaultHeterogeneousModel).mockResolvedValue({
-      model: 'deepseek-v4-pro',
+      codexCompatibility: {
+        defaultReasoningEffort: 'high',
+        reasoningEfforts: ['low', 'high', 'max'],
+        runtimeApiMode: 'chatCompletion',
+        toolMode: 'function',
+        truncationMode: 'tokens',
+      },
+      model: 'relay-coding-model',
       provider: 'lobehub',
     });
     vi.mocked(initModelRuntimeFromServerConfig).mockResolvedValue({
@@ -134,7 +141,7 @@ describe('heterogeneous direct invocation protocol', () => {
 
     await invokeServerDefaultModel({
       agentType: 'codex',
-      model: 'deepseek-v4-pro',
+      model: 'relay-coding-model',
       payload: {
         apiMode: 'responses',
         messages: [],
@@ -150,7 +157,7 @@ describe('heterogeneous direct invocation protocol', () => {
     expect(runtimePayload).toMatchObject({
       apiMode: 'chatCompletion',
       messages: [],
-      model: 'deepseek-v4-pro',
+      model: 'relay-coding-model',
       reasoning_effort: 'max',
       stream: true,
     });

--- a/packages/openapi/src/services/heterogeneous-direct.service.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.ts
@@ -5,12 +5,7 @@ import type {
   OpenAIChatMessage,
   UserMessageContentPart,
 } from '@lobechat/model-runtime';
-import type { CodexReasoningEffort } from '@lobechat/types';
-import {
-  getCodexReasoningEffortLevels,
-  isCodexServerDefaultCustomModel,
-  RequestTrigger,
-} from '@lobechat/types';
+import { RequestTrigger } from '@lobechat/types';
 import { isRecord } from '@lobechat/utils/object';
 
 import type { ServerDefaultHeterogeneousAgentType } from '@/server/modules/ModelRuntime';
@@ -828,7 +823,7 @@ export const invokeServerDefaultModel = async (params: {
     params.agentType,
     params.model,
   );
-  const { deploymentName } = resolvedModel;
+  const { codexCompatibility, deploymentName } = resolvedModel;
   const model = deploymentName ?? resolvedModel.model;
   const runtime = await initModelRuntimeFromServerConfig({
     actorUserId: params.userId,
@@ -836,13 +831,13 @@ export const invokeServerDefaultModel = async (params: {
   });
   const { reasoning, ...chatCompletionsPayload } = params.payload;
   const requestedReasoningEffort = reasoning?.effort;
-  const reasoningEffort = getCodexReasoningEffortLevels(params.model).includes(
-    requestedReasoningEffort as CodexReasoningEffort,
+  const reasoningEffort = codexCompatibility?.reasoningEfforts.includes(
+    requestedReasoningEffort as (typeof codexCompatibility.reasoningEfforts)[number],
   )
     ? (requestedReasoningEffort as ChatStreamPayload['reasoning_effort'])
     : undefined;
   const payload =
-    params.agentType === 'codex' && isCodexServerDefaultCustomModel(params.model)
+    params.agentType === 'codex' && codexCompatibility?.runtimeApiMode === 'chatCompletion'
       ? {
           ...chatCompletionsPayload,
           apiMode: 'chatCompletion' as const,

--- a/packages/types/src/agent/agencyConfig.test.ts
+++ b/packages/types/src/agent/agencyConfig.test.ts
@@ -610,12 +610,6 @@ describe('codex reasoning effort capabilities', () => {
     expect(getCodexReasoningEffortLevels('gpt-5.6-luna')).toEqual(maxLevels);
   });
 
-  it('uses the model-specific levels supported by custom server-default models', () => {
-    expect(getCodexReasoningEffortLevels('deepseek-v4-flash')).toEqual(['low', 'high', 'max']);
-    expect(getCodexReasoningEffortLevels('deepseek-v4-pro')).toEqual(['low', 'high', 'max']);
-    expect(getCodexReasoningEffortLevels('glm-5.2')).toEqual(['high', 'max']);
-  });
-
   it('uses conservative common levels for old, unknown, and default models', () => {
     expect(getCodexReasoningEffortLevels('gpt-5.5')).toEqual(commonLevels);
     expect(getCodexReasoningEffortLevels('gpt-5.4-mini')).toEqual(commonLevels);

--- a/packages/types/src/agent/heteroSelectorCapabilities.test.ts
+++ b/packages/types/src/agent/heteroSelectorCapabilities.test.ts
@@ -4,10 +4,8 @@ import type { HeterogeneousProviderConfig } from './agencyConfig';
 import { buildHeteroSpawnArgs } from './agencyConfig';
 import {
   applyHeteroSelection,
-  CODEX_SERVER_DEFAULT_CUSTOM_MODELS,
   getHeteroSelectorCapability,
   HETEROGENEOUS_AGENT_DEFAULT_SELECTION,
-  isCodexServerDefaultCustomModel,
   isHeteroSelectorAvailable,
 } from './heteroSelectorCapabilities';
 
@@ -53,16 +51,6 @@ describe('selector availability', () => {
     expect(getHeteroSelectorCapability('codebuddy')?.model?.source).toBe('catalog');
     expect(getHeteroSelectorCapability('qoder')?.model?.source).toBe('catalog');
     expect(getHeteroSelectorCapability('trae')?.model?.source).toBe('catalog');
-  });
-
-  it('keeps non-OpenAI Codex relay support on an explicit allowlist', () => {
-    expect(CODEX_SERVER_DEFAULT_CUSTOM_MODELS).toEqual([
-      'deepseek-v4-flash',
-      'deepseek-v4-pro',
-      'glm-5.2',
-    ]);
-    expect(isCodexServerDefaultCustomModel('deepseek-v4-pro')).toBe(true);
-    expect(isCodexServerDefaultCustomModel('kimi-k2.6')).toBe(false);
   });
 
   it('reports codex effort levels per model', () => {

--- a/packages/types/src/agent/heteroSelectorCapabilities.ts
+++ b/packages/types/src/agent/heteroSelectorCapabilities.ts
@@ -1,3 +1,5 @@
+import type { CodexAgentCompatibility, CodexReasoningEffort } from 'model-bank';
+
 import {
   getAnyCliFlagValue,
   getCliConfigValue,
@@ -6,6 +8,8 @@ import {
   stripCliFlags,
 } from './heteroCliArgs';
 import type { LocalHeterogeneousAgentType } from './heterogeneousAgent';
+
+export type { CodexReasoningEffort } from 'model-bank';
 
 /**
  * Selector value that means "do not override the underlying CLI".
@@ -51,26 +55,7 @@ const CODEX_REASONING_EFFORT_LEVELS = [
   'ultra',
 ] as const;
 
-export type CodexReasoningEffort = (typeof CODEX_REASONING_EFFORT_LEVELS)[number];
-
 export const CODEX_REASONING_EFFORT_CONFIG_KEY = 'model_reasoning_effort';
-
-/**
- * Non-OpenAI models explicitly supported through a model-specific Codex catalog
- * and the deployment-owned server-default relay. Keep this list explicit: tool
- * support alone does not prove that Codex's request and continuation behavior
- * is compatible.
- */
-export const CODEX_SERVER_DEFAULT_CUSTOM_MODELS = [
-  'deepseek-v4-flash',
-  'deepseek-v4-pro',
-  'glm-5.2',
-] as const;
-
-export type CodexServerDefaultCustomModel = (typeof CODEX_SERVER_DEFAULT_CUSTOM_MODELS)[number];
-
-const CODEX_DEEPSEEK_V4_REASONING_EFFORT_LEVELS = ['low', 'high', 'max'] as const;
-const CODEX_GLM_5_2_REASONING_EFFORT_LEVELS = ['high', 'max'] as const;
 
 const CODEX_MAX_REASONING_EFFORT_LEVELS = [
   ...CODEX_COMMON_REASONING_EFFORT_LEVELS,
@@ -143,11 +128,6 @@ export const isClaudeCodeReasoningEffort = (
 export const isCodexReasoningEffort = (value: string | undefined): value is CodexReasoningEffort =>
   !!value && CODEX_REASONING_EFFORT_LEVELS.includes(value as CodexReasoningEffort);
 
-export const isCodexServerDefaultCustomModel = (
-  model: string,
-): model is CodexServerDefaultCustomModel =>
-  CODEX_SERVER_DEFAULT_CUSTOM_MODELS.includes(model as CodexServerDefaultCustomModel);
-
 export const isGrokBuildReasoningEffort = (
   value: string | undefined,
 ): value is GrokBuildReasoningEffort =>
@@ -166,12 +146,6 @@ export const isCodexFastServiceTier = (value: string | undefined): boolean =>
  * cannot be known until the CLI resolves the model.
  */
 export const getCodexReasoningEffortLevels = (model: string): readonly CodexReasoningEffort[] => {
-  if (model === 'deepseek-v4-flash' || model === 'deepseek-v4-pro') {
-    return CODEX_DEEPSEEK_V4_REASONING_EFFORT_LEVELS;
-  }
-
-  if (model === 'glm-5.2') return CODEX_GLM_5_2_REASONING_EFFORT_LEVELS;
-
   if (
     CODEX_ULTRA_REASONING_MODELS.includes(model as (typeof CODEX_ULTRA_REASONING_MODELS)[number])
   ) {
@@ -184,6 +158,14 @@ export const getCodexReasoningEffortLevels = (model: string): readonly CodexReas
 
   return CODEX_COMMON_REASONING_EFFORT_LEVELS;
 };
+
+/** Model metadata resolved for one server-default Codex operation. */
+export interface CodexServerDefaultModelMetadata {
+  compatibility: CodexAgentCompatibility;
+  contextWindowTokens?: number;
+  description?: string;
+  displayName?: string;
+}
 
 /**
  * Whether the Fast speed toggle applies to a selector model value. `default`


### PR DESCRIPTION
Codex server-default compatibility is now owned by the model catalog instead of a Desktop/server model-ID allowlist.

Non-native Responses models can opt in through the generic `agentCompatibility.codex` contract. The server validates that contract at selection and operation creation, Desktop builds the Codex catalog from the operation-scoped metadata, and the relay selects its upstream API mode from the same capability.

### Key Decisions / Non-goals

- Native Responses models remain automatically compatible.
- Other Codex models require both function-tool support and valid Codex compatibility metadata.
- Compatibility is resolved for every operation and returned transiently with the operation binding; it is not persisted in agent configuration.
- `models.json` is run-scoped while the stable Codex profile remains reusable, avoiding concurrent runs sharing operation-specific catalog paths.
- Claude Code compatibility and runtime behavior are unchanged.
- This PR does not perform real provider-credential E2E calls.

#### Test

- [x] Tested locally
- [x] Added/updated tests

- `bun run check --lint --test --type`
- 346 related tests passed; lint and types are clean.
