### PR TITLE
🐛 fix: forward input tokens on Anthropic relay usage

### DIFF
--- a/packages/openapi/src/services/heterogeneous-direct.service.test.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.test.ts
@@ -362,7 +362,35 @@ describe('heterogeneous direct invocation protocol', () => {
     expect(events.filter(({ type }) => type === 'message_stop')).toHaveLength(1);
     expect(events.at(-2)?.data).toMatchObject({
       delta: { stop_reason: 'end_turn' },
-      usage: { output_tokens: 4 },
+    });
+    expect(events.at(-2)?.data.usage).toEqual({ input_tokens: 7, output_tokens: 4 });
+  });
+
+  it('forwards Anthropic cache-split input on message_delta without double-counting', async () => {
+    const output = await readText(
+      encodeAnthropicStream(
+        protocolStream([
+          { data: 'hello', type: 'text' },
+          {
+            data: {
+              inputCachedTokens: 10,
+              inputCacheMissTokens: 90,
+              inputWriteCacheTokens: 20,
+              totalInputTokens: 120,
+              totalOutputTokens: 5,
+            },
+            type: 'usage',
+          },
+        ]),
+      ),
+    );
+
+    const delta = parseSseEvents(output).find(({ type }) => type === 'message_delta');
+    expect(delta?.data.usage).toEqual({
+      cache_creation_input_tokens: 20,
+      cache_read_input_tokens: 10,
+      input_tokens: 90,
+      output_tokens: 5,
     });
   });
 

--- a/packages/openapi/src/services/heterogeneous-direct.service.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.ts
@@ -325,6 +325,40 @@ const parseProtocolStream = (stream: ReadableStream<Uint8Array>) => {
 
 const sse = (event: string, data: unknown) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
 
+const nonNegativeNumber = (value: unknown): number | undefined => {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return undefined;
+  return value;
+};
+
+interface AnthropicStreamUsage {
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+  input_tokens: number;
+  output_tokens: number;
+}
+
+/**
+ * Map a LobeHub protocol `usage` event onto Anthropic `message_delta.usage`.
+ * `message_start` is emitted before upstream usage exists, so Claude Code treats
+ * this snapshot as the final turn total (input + cache + output).
+ */
+const toAnthropicStreamUsage = (data: Record<string, unknown>): AnthropicStreamUsage => {
+  const cached = nonNegativeNumber(data.inputCachedTokens);
+  const written = nonNegativeNumber(data.inputWriteCacheTokens);
+  const totalInput = nonNegativeNumber(data.totalInputTokens) ?? 0;
+  const miss = nonNegativeNumber(data.inputCacheMissTokens);
+  const hasCache = (cached ?? 0) > 0 || (written ?? 0) > 0;
+
+  return {
+    ...(written ? { cache_creation_input_tokens: written } : {}),
+    ...(cached ? { cache_read_input_tokens: cached } : {}),
+    input_tokens: hasCache
+      ? (miss ?? Math.max(0, totalInput - (cached ?? 0) - (written ?? 0)))
+      : totalInput,
+    output_tokens: nonNegativeNumber(data.totalOutputTokens) ?? 0,
+  };
+};
+
 export const encodeAnthropicStream = (source: ReadableStream<Uint8Array>) => {
   const messageId = `msg_${randomUUID().replaceAll('-', '')}`;
   let finalized = false;
@@ -332,7 +366,7 @@ export const encodeAnthropicStream = (source: ReadableStream<Uint8Array>) => {
   let stopReason: string | undefined;
   let textIndex: number | undefined;
   let thinkingIndex: number | undefined;
-  let usage = { input_tokens: 0, output_tokens: 0 };
+  let usage: AnthropicStreamUsage = { input_tokens: 0, output_tokens: 0 };
   const tools = new Map<number, { blockIndex: number; id: string; name: string }>();
   const closeTextBlocks = (controller: TransformStreamDefaultController<string>) => {
     for (const index of [textIndex, thinkingIndex]) {
@@ -362,7 +396,7 @@ export const encodeAnthropicStream = (source: ReadableStream<Uint8Array>) => {
           stop_sequence: null,
         },
         type: 'message_delta',
-        usage: { output_tokens: usage.output_tokens },
+        usage,
       }),
     );
     controller.enqueue(sse('message_stop', { type: 'message_stop' }));
@@ -454,10 +488,7 @@ export const encodeAnthropicStream = (source: ReadableStream<Uint8Array>) => {
                 );
             }
           } else if (event.type === 'usage' && isRecord(event.data)) {
-            usage = {
-              input_tokens: Number(event.data.totalInputTokens || 0),
-              output_tokens: Number(event.data.totalOutputTokens || 0),
-            };
+            usage = toAnthropicStreamUsage(event.data);
           } else if (event.type === 'stop') {
             const reason = typeof event.data === 'string' ? event.data : undefined;
             if (!stopReason && reason && reason !== 'message_stop') stopReason = reason;


### PR DESCRIPTION
The Anthropic Messages relay for server-default Claude Code dropped input usage on the wire.

`encodeAnthropicStream` already stored `totalInputTokens` from the protocol `usage` event, but `message_delta` only emitted `output_tokens`. Claude Code treats `message_delta.usage` as the authoritative turn snapshot, so the CLI and topic token counts showed `input=0`.

`message_start` still reports `input_tokens: 0` because the stream opens before upstream usage exists. Buffering the whole turn to fill `message_start` would delay first token, so the full snapshot is sent on `message_delta` instead.

When cache breakdown is present, `input_tokens` is the cache-miss count and cache fields are emitted separately so Claude Code does not double-count.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check` on the two changed files: lint clean, related tests passed.

#### 🔗 Related Issue

N/A