### PR TITLE
🐛 fix: use lobehub/model for Claude Code server-default

### DIFF
--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/claudeCode.test.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/claudeCode.test.ts
@@ -20,7 +20,7 @@ const buildParams = (
 });
 
 describe('claudeCodeDriver', () => {
-  it('prepares server-default aliases without persisting the operation token', async () => {
+  it('prepares the namespaced server-default model without persisting the operation token', async () => {
     const plan = await claudeCodeDriver.prepareServerDefaultBinding!({
       args: [],
       endpoint: 'https://app.example.com',
@@ -29,11 +29,12 @@ describe('claudeCodeDriver', () => {
       profileDir: '/tmp/profile',
     });
 
+    expect(plan.args).toEqual(expect.arrayContaining(['--model', 'lobehub/claude-sonnet-4-6']));
     expect(plan.env).toMatchObject({
       ANTHROPIC_BASE_URL: 'https://app.example.com/api/v1/anthropic',
-      ANTHROPIC_MODEL: 'lobehub-default',
-      ANTHROPIC_SMALL_FAST_MODEL: 'lobehub-default',
-      CLAUDE_CODE_SUBAGENT_MODEL: 'lobehub-default',
+      ANTHROPIC_MODEL: 'lobehub/claude-sonnet-4-6',
+      ANTHROPIC_SMALL_FAST_MODEL: 'lobehub/claude-sonnet-4-6',
+      CLAUDE_CODE_SUBAGENT_MODEL: 'lobehub/claude-sonnet-4-6',
     });
     expect(plan.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
   });

--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/claudeCode.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/claudeCode.ts
@@ -4,6 +4,7 @@ import {
   sanitizeClaudeCodeDirectEnv,
 } from '@lobechat/heterogeneous-agents';
 import { CLAUDE_CODE_BASE_ARGS } from '@lobechat/heterogeneous-agents/spawn';
+import { formatServerDefaultHeterogeneousModel } from '@lobechat/types';
 
 import type { HeterogeneousAgentBuildPlanParams, HeterogeneousAgentDriver } from '../types';
 
@@ -63,15 +64,16 @@ export const claudeCodeDriver: HeterogeneousAgentDriver = {
       },
     };
   },
-  prepareServerDefaultBinding({ args, endpoint, env, profileDir }) {
+  prepareServerDefaultBinding({ args, endpoint, env, model, profileDir }) {
+    const requestModel = formatServerDefaultHeterogeneousModel(model);
     return {
-      args: [...sanitizeClaudeCodeDirectArgs(args), '--model', 'lobehub-default'],
+      args: [...sanitizeClaudeCodeDirectArgs(args), '--model', requestModel],
       env: {
         ...sanitizeClaudeCodeDirectEnv(env),
         ANTHROPIC_BASE_URL: `${endpoint}/api/v1/anthropic`,
-        ANTHROPIC_MODEL: 'lobehub-default',
-        ANTHROPIC_SMALL_FAST_MODEL: 'lobehub-default',
-        CLAUDE_CODE_SUBAGENT_MODEL: 'lobehub-default',
+        ANTHROPIC_MODEL: requestModel,
+        ANTHROPIC_SMALL_FAST_MODEL: requestModel,
+        CLAUDE_CODE_SUBAGENT_MODEL: requestModel,
         CLAUDE_CONFIG_DIR: profileDir,
       },
     };

--- a/apps/server/src/modules/ModelRuntime/index.ts
+++ b/apps/server/src/modules/ModelRuntime/index.ts
@@ -542,12 +542,12 @@ export type ServerDefaultHeterogeneousModels = Record<
  *
  * Claude Code reaches the relay through the Anthropic Messages ingress, which
  * translates the wire protocol in both directions rather than proxying it
- * (`normalizeAnthropicRequest` / `encodeAnthropicStream`). The CLI never names
- * the upstream model — it always sends the `lobehub-default` alias and the real
- * model comes from the operation token — so the upstream only has to be able to
- * call tools. Any tool-capable chat model in the relay catalog qualifies; the
- * `parseClaudeModelId` arm keeps Claude ids eligible in deployments whose
- * catalog omits `abilities`.
+ * (`normalizeAnthropicRequest` / `encodeAnthropicStream`). Both CLIs address
+ * the relay as `lobehub/${catalogId}`; the operation token is still the source
+ * of truth and the request must match that selection. The upstream only has to
+ * be able to call tools. Any tool-capable chat model in the relay catalog
+ * qualifies; the `parseClaudeModelId` arm keeps Claude ids eligible in
+ * deployments whose catalog omits `abilities`.
  *
  * Codex accepts native Responses models plus an explicit set of tool-capable
  * relay models configured through its custom model-catalog path. Keep that set

--- a/packages/openapi/src/routes/anthropic.route.ts
+++ b/packages/openapi/src/routes/anthropic.route.ts
@@ -1,3 +1,7 @@
+import {
+  formatServerDefaultHeterogeneousModel,
+  isServerDefaultHeterogeneousModel,
+} from '@lobechat/types';
 import { isRecord } from '@lobechat/utils/object';
 import type { Context } from 'hono';
 import { Hono } from 'hono';
@@ -18,18 +22,19 @@ const app = new Hono();
 app.post('/v1/messages', requireHeteroModelInvocation, async (c) => {
   const request = await c.req.json().catch(() => null);
   if (!isRecord(request)) throw new HTTPException(400, { message: 'Invalid JSON request' });
-  if (request.model !== SERVER_DEFAULT_MODEL_ALIAS) {
-    throw new HTTPException(400, { message: `model must be ${SERVER_DEFAULT_MODEL_ALIAS}` });
-  }
-  if (request.stream !== true) {
-    throw new HTTPException(400, { message: 'server-default Anthropic requests must stream' });
-  }
   const context = c as Context;
   const claims = context.get('heteroOperationClaims') as HeteroOperationJwtClaims;
   if (!claims.provider_id || !claims.model) {
     throw new HTTPException(403, { message: 'Operation token has no server model selection' });
   }
+  if (!isServerDefaultHeterogeneousModel(request.model, claims.model)) {
+    throw new HTTPException(400, { message: 'model must match the server operation selection' });
+  }
+  if (request.stream !== true) {
+    throw new HTTPException(400, { message: 'server-default Anthropic requests must stream' });
+  }
   const workspaceId = context.get('workspaceId');
+  const requestModel = formatServerDefaultHeterogeneousModel(claims.model);
   const { response } = await invokeServerDefaultModel({
     agentType: 'claude-code',
     model: claims.model,
@@ -38,7 +43,7 @@ app.post('/v1/messages', requireHeteroModelInvocation, async (c) => {
     userId: String(context.get('userId')),
     workspaceId: typeof workspaceId === 'string' ? workspaceId : undefined,
   });
-  return new Response(encodeAnthropicStream(response.body!), {
+  return new Response(encodeAnthropicStream(response.body!, requestModel), {
     headers: { 'Cache-Control': 'no-cache', 'Content-Type': 'text/event-stream' },
   });
 });

--- a/packages/openapi/src/routes/openai.route.ts
+++ b/packages/openapi/src/routes/openai.route.ts
@@ -1,4 +1,7 @@
-import { isServerDefaultHeterogeneousModel } from '@lobechat/types';
+import {
+  formatServerDefaultHeterogeneousModel,
+  isServerDefaultHeterogeneousModel,
+} from '@lobechat/types';
 import { isRecord } from '@lobechat/utils/object';
 import type { Context } from 'hono';
 import { Hono } from 'hono';
@@ -31,6 +34,7 @@ app.post('/v1/responses', requireHeteroModelInvocation, async (c) => {
     throw new HTTPException(400, { message: 'server-default Responses requests must stream' });
   }
   const workspaceId = context.get('workspaceId');
+  const requestModel = formatServerDefaultHeterogeneousModel(claims.model);
   const { response } = await invokeServerDefaultModel({
     agentType: 'codex',
     model: claims.model,
@@ -39,7 +43,7 @@ app.post('/v1/responses', requireHeteroModelInvocation, async (c) => {
     userId: String(context.get('userId')),
     workspaceId: typeof workspaceId === 'string' ? workspaceId : undefined,
   });
-  return new Response(encodeResponsesStream(response.body!), {
+  return new Response(encodeResponsesStream(response.body!, requestModel), {
     headers: { 'Cache-Control': 'no-cache', 'Content-Type': 'text/event-stream' },
   });
 });

--- a/packages/openapi/src/services/heterogeneous-direct.service.test.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.test.ts
@@ -34,7 +34,15 @@ const protocolStream = (events: Array<{ data: unknown; id?: string; type: string
   });
 };
 
+const ANTHROPIC_STREAM_MODEL = 'lobehub/claude-sonnet-4-6';
+const RESPONSES_STREAM_MODEL = 'lobehub/gpt-5.4';
+
 const readText = async (stream: ReadableStream<Uint8Array>) => new Response(stream).text();
+
+const anthropicSse = (source: ReadableStream<Uint8Array>) =>
+  encodeAnthropicStream(source, ANTHROPIC_STREAM_MODEL);
+const responsesSse = (source: ReadableStream<Uint8Array>) =>
+  encodeResponsesStream(source, RESPONSES_STREAM_MODEL);
 
 const parseSseEvents = (output: string) =>
   output
@@ -311,14 +319,14 @@ describe('heterogeneous direct invocation protocol', () => {
       },
     });
 
-    await expect(readText(encodeAnthropicStream(source))).resolves.toContain(
+    await expect(readText(anthropicSse(source))).resolves.toContain(
       '"text":"tail","type":"text_delta"',
     );
   });
 
   it('encodes Anthropic reasoning and parallel tool argument deltas', async () => {
     const output = await readText(
-      encodeAnthropicStream(
+      anthropicSse(
         protocolStream([
           { data: 'thinking', type: 'reasoning' },
           {
@@ -341,7 +349,7 @@ describe('heterogeneous direct invocation protocol', () => {
 
   it('finalizes Anthropic stop, usage, and message_stop exactly once', async () => {
     const output = await readText(
-      encodeAnthropicStream(
+      anthropicSse(
         protocolStream([
           { data: 'hello', type: 'text' },
           { data: 'end_turn', type: 'stop' },
@@ -368,7 +376,7 @@ describe('heterogeneous direct invocation protocol', () => {
 
   it('forwards Anthropic cache-split input on message_delta without double-counting', async () => {
     const output = await readText(
-      encodeAnthropicStream(
+      anthropicSse(
         protocolStream([
           { data: 'hello', type: 'text' },
           {
@@ -392,6 +400,26 @@ describe('heterogeneous direct invocation protocol', () => {
       input_tokens: 90,
       output_tokens: 5,
     });
+  });
+
+  it('echoes the namespaced catalog model on Anthropic message_start and Responses objects', async () => {
+    const anthropic = parseSseEvents(
+      await readText(
+        encodeAnthropicStream(
+          protocolStream([{ data: 'hi', type: 'text' }]),
+          ANTHROPIC_STREAM_MODEL,
+        ),
+      ),
+    );
+    expect(anthropic[0]).toMatchObject({
+      data: { message: { model: ANTHROPIC_STREAM_MODEL } },
+      type: 'message_start',
+    });
+
+    const responses = await readText(
+      encodeResponsesStream(protocolStream([{ data: 'hi', type: 'text' }]), RESPONSES_STREAM_MODEL),
+    );
+    expect(responses).toContain(`"model":"${RESPONSES_STREAM_MODEL}"`);
   });
 
   it.each([
@@ -420,7 +448,7 @@ describe('heterogeneous direct invocation protocol', () => {
       name: 'duplicate stop sentinels',
     },
   ])('finalizes Responses $name exactly once', async ({ events: protocolEvents }) => {
-    const output = await readText(encodeResponsesStream(protocolStream(protocolEvents)));
+    const output = await readText(responsesSse(protocolStream(protocolEvents)));
     const events = parseSseEvents(output);
     const nativeEvents = events.filter(({ type }) => type);
     const terminalEvents = nativeEvents.filter(({ type }) =>
@@ -450,7 +478,7 @@ describe('heterogeneous direct invocation protocol', () => {
 
   it('encodes Responses incomplete and failed terminal lifecycle events', async () => {
     const incomplete = await readText(
-      encodeResponsesStream(
+      responsesSse(
         protocolStream([
           { data: 'partial', type: 'text' },
           { data: 'max_tokens', type: 'stop' },
@@ -463,9 +491,7 @@ describe('heterogeneous direct invocation protocol', () => {
     expect(incomplete).not.toContain('event: response.completed');
 
     const failed = await readText(
-      encodeResponsesStream(
-        protocolStream([{ data: { message: 'provider unavailable' }, type: 'error' }]),
-      ),
+      responsesSse(protocolStream([{ data: { message: 'provider unavailable' }, type: 'error' }])),
     );
     expect(failed).toContain('event: response.failed');
     expect(failed).toContain('"error":{"code":"server_error","message":"provider unavailable"}');
@@ -476,7 +502,7 @@ describe('heterogeneous direct invocation protocol', () => {
 
   it('assigns distinct Responses output indexes to reasoning, text, and tools', async () => {
     const output = await readText(
-      encodeResponsesStream(
+      responsesSse(
         protocolStream([
           { data: 'think', type: 'reasoning' },
           { data: 'answer', type: 'text' },
@@ -505,7 +531,7 @@ describe('heterogeneous direct invocation protocol', () => {
       type: 'reasoning',
     };
     const output = await readText(
-      encodeResponsesStream(
+      responsesSse(
         protocolStream([
           { data: reasoningItem, type: 'reasoning_response_item' },
           { data: 'stop', type: 'stop' },
@@ -529,7 +555,7 @@ describe('heterogeneous direct invocation protocol', () => {
     };
     const events = parseSseEvents(
       await readText(
-        encodeResponsesStream(
+        responsesSse(
           protocolStream([
             { data: 'thinking', id: 'reasoning-current', type: 'reasoning' },
             {

--- a/packages/openapi/src/services/heterogeneous-direct.service.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.ts
@@ -10,6 +10,7 @@ import {
   getCodexReasoningEffortLevels,
   isCodexServerDefaultCustomModel,
   RequestTrigger,
+  SERVER_DEFAULT_HETEROGENEOUS_MODEL_ALIAS,
 } from '@lobechat/types';
 import { isRecord } from '@lobechat/utils/object';
 
@@ -21,7 +22,7 @@ import {
 
 import type { BaseStreamEvent } from '../types/responses.type';
 
-export const SERVER_DEFAULT_MODEL_ALIAS = 'lobehub-default';
+export const SERVER_DEFAULT_MODEL_ALIAS = SERVER_DEFAULT_HETEROGENEOUS_MODEL_ALIAS;
 
 const textFromParts = (content: unknown): string => {
   if (typeof content === 'string') return content;
@@ -359,7 +360,7 @@ const toAnthropicStreamUsage = (data: Record<string, unknown>): AnthropicStreamU
   };
 };
 
-export const encodeAnthropicStream = (source: ReadableStream<Uint8Array>) => {
+export const encodeAnthropicStream = (source: ReadableStream<Uint8Array>, model: string) => {
   const messageId = `msg_${randomUUID().replaceAll('-', '')}`;
   let finalized = false;
   let nextIndex = 0;
@@ -410,7 +411,7 @@ export const encodeAnthropicStream = (source: ReadableStream<Uint8Array>) => {
               message: {
                 content: [],
                 id: messageId,
-                model: SERVER_DEFAULT_MODEL_ALIAS,
+                model,
                 role: 'assistant',
                 stop_reason: null,
                 type: 'message',
@@ -515,7 +516,7 @@ export const encodeAnthropicStream = (source: ReadableStream<Uint8Array>) => {
     .pipeThrough(new TextEncoderStream());
 };
 
-export const encodeResponsesStream = (source: ReadableStream<Uint8Array>) => {
+export const encodeResponsesStream = (source: ReadableStream<Uint8Array>, model: string) => {
   const responseId = `resp_${randomUUID().replaceAll('-', '')}`;
   let finalized = false;
   let nextOutputIndex = 0;
@@ -538,7 +539,7 @@ export const encodeResponsesStream = (source: ReadableStream<Uint8Array>) => {
     id: responseId,
     incomplete_details: null,
     instructions: null,
-    model: SERVER_DEFAULT_MODEL_ALIAS,
+    model,
     object: 'response',
     output: [],
     status: 'in_progress',

--- a/packages/types/src/agent/agencyConfig.test.ts
+++ b/packages/types/src/agent/agencyConfig.test.ts
@@ -12,6 +12,7 @@ import {
   resolveAgencyConfig,
   resolveAgentAgencyConfig,
   resolveAgentTopicSharePolicy,
+  unwrapServerDefaultHeterogeneousModel,
 } from './agencyConfig';
 import {
   AMP_AGENT_MODES,
@@ -32,6 +33,23 @@ describe('server-default heterogeneous model request', () => {
     expect(isServerDefaultHeterogeneousModel('lobehub/gpt-5.4', 'gpt-5.4')).toBe(true);
     expect(isServerDefaultHeterogeneousModel('lobehub-default', 'gpt-5.4')).toBe(false);
     expect(isServerDefaultHeterogeneousModel('lobehub/gpt-5.5', 'gpt-5.4')).toBe(false);
+  });
+
+  it('unwraps namespaced CLI reports and the legacy Claude Code alias', () => {
+    expect(unwrapServerDefaultHeterogeneousModel('lobehub/claude-sonnet-4-6')).toBe(
+      'claude-sonnet-4-6',
+    );
+    expect(unwrapServerDefaultHeterogeneousModel('lobehub/gpt-5.4', 'ignored')).toBe('gpt-5.4');
+    expect(unwrapServerDefaultHeterogeneousModel('lobehub-default', 'claude-sonnet-4-6')).toBe(
+      'claude-sonnet-4-6',
+    );
+    expect(unwrapServerDefaultHeterogeneousModel('lobehub-default')).toBe('lobehub-default');
+    expect(unwrapServerDefaultHeterogeneousModel('claude-opus-4-6', 'claude-sonnet-4-6')).toBe(
+      'claude-opus-4-6',
+    );
+    expect(unwrapServerDefaultHeterogeneousModel(undefined, 'claude-sonnet-4-6')).toBe(
+      'claude-sonnet-4-6',
+    );
   });
 });
 

--- a/packages/types/src/agent/agencyConfig.ts
+++ b/packages/types/src/agent/agencyConfig.ts
@@ -93,12 +93,45 @@ export interface HeterogeneousProviderApiConfig {
   source?: 'provider';
 }
 
-export const formatServerDefaultHeterogeneousModel = (model: string): string => `lobehub/${model}`;
+/** Legacy Claude Code request alias. Current CLIs send `lobehub/${catalogId}`. */
+export const SERVER_DEFAULT_HETEROGENEOUS_MODEL_ALIAS = 'lobehub-default';
+
+const SERVER_DEFAULT_HETEROGENEOUS_MODEL_NAMESPACE = 'lobehub/';
+
+export const formatServerDefaultHeterogeneousModel = (model: string): string =>
+  `${SERVER_DEFAULT_HETEROGENEOUS_MODEL_NAMESPACE}${model}`;
 
 export const isServerDefaultHeterogeneousModel = (
   requestModel: unknown,
   operationModel: string,
 ): boolean => requestModel === formatServerDefaultHeterogeneousModel(operationModel);
+
+/**
+ * Map a CLI-reported server-default model back to the catalog id.
+ *
+ * Both CLIs request `lobehub/${catalogId}`. Older Claude Code sessions used
+ * {@link SERVER_DEFAULT_HETEROGENEOUS_MODEL_ALIAS}. Neither is the catalog id
+ * the user picked.
+ */
+export const unwrapServerDefaultHeterogeneousModel = (
+  reportedModel: string | undefined,
+  configuredModel?: string,
+): string | undefined => {
+  const configured = configuredModel?.trim() || undefined;
+
+  if (!reportedModel) return configured;
+
+  if (reportedModel === SERVER_DEFAULT_HETEROGENEOUS_MODEL_ALIAS) {
+    return configured ?? reportedModel;
+  }
+
+  if (reportedModel.startsWith(SERVER_DEFAULT_HETEROGENEOUS_MODEL_NAMESPACE)) {
+    const unwrapped = reportedModel.slice(SERVER_DEFAULT_HETEROGENEOUS_MODEL_NAMESPACE.length);
+    return unwrapped || reportedModel;
+  }
+
+  return reportedModel;
+};
 
 /** Deployment-owned API binding whose provider and credentials stay on the server. */
 export interface HeterogeneousServerDefaultApiConfig {

--- a/src/features/Conversation/Messages/components/Extras/Usage/index.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/index.tsx
@@ -2,7 +2,8 @@ import {
   HETEROGENEOUS_TYPE_LABELS,
   isRemoteHeterogeneousType,
 } from '@lobechat/heterogeneous-agents';
-import { type ModelPerformance, type ModelUsage } from '@lobechat/types';
+import type { ModelPerformance, ModelUsage } from '@lobechat/types';
+import { unwrapServerDefaultHeterogeneousModel } from '@lobechat/types';
 import { ModelIcon } from '@lobehub/icons';
 import { Center, Flexbox, Icon, Tooltip } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
@@ -12,7 +13,7 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useAgentStore } from '@/store/agent';
-import { builtinAgentSelectors } from '@/store/agent/selectors';
+import { agentByIdSelectors, builtinAgentSelectors } from '@/store/agent/selectors';
 import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
@@ -46,16 +47,37 @@ const Usage = memo<UsageProps>(({ model, usage, performance, provider }) => {
   const { t } = useTranslation('chat');
   const onboardingAgentId = useAgentStore(builtinAgentSelectors.webOnboardingAgentId);
   const conversationAgentId = useConversationStore(contextSelectors.agentId);
+  const serverDefaultConfiguredModel = useAgentStore((s) => {
+    if (!conversationAgentId) return undefined;
+    const apiConfig =
+      agentByIdSelectors.getAgencyConfigById(conversationAgentId)(s)?.heterogeneousProvider
+        ?.apiConfig;
+    return apiConfig?.source === 'server-default' ? apiConfig.model : undefined;
+  });
   // Credit mode already expresses cost in credits — showing USD alongside would conflict.
   const isShowCredit = useGlobalStore(systemStatusSelectors.isShowCredit);
-  const modelCard = useAiInfraStore(aiModelSelectors.getModelCard(model, provider));
+  const displayModel =
+    unwrapServerDefaultHeterogeneousModel(model, serverDefaultConfiguredModel) ?? model;
+  const modelCard = useAiInfraStore((s) => {
+    const exact = aiModelSelectors.getModelCard(displayModel, provider)(s);
+    if (exact || !serverDefaultConfiguredModel) return exact;
+    // Server-default messages keep provider as the CLI type (`claude-code` /
+    // `codex`), so the catalog card lives under the relay provider id.
+    return (
+      s.enabledAiModels?.find((item) => item.id === displayModel) ||
+      s.builtinAiModelList.find((item) => item.id === displayModel)
+    );
+  });
+  const displayProvider = modelCard?.providerId ?? provider;
 
   if (!isDev && onboardingAgentId && conversationAgentId === onboardingAgentId) return null;
 
   // Only remote platform agents (openclaw, hermes) replace the model name with
   // the brand label — they don't expose a real model id. Local CLI agents
   // (claude-code, codex) report their actual model on `turn_metadata` and
-  // should keep showing it.
+  // should keep showing it. Server-default bindings report `lobehub/${id}`
+  // (or the legacy `lobehub-default` alias); unwrap to the catalog id so this
+  // footer matches what the user selected.
   const heteroName =
     provider && isRemoteHeterogeneousType(provider)
       ? HETEROGENEOUS_TYPE_LABELS[provider]
@@ -79,8 +101,8 @@ const Usage = memo<UsageProps>(({ model, usage, performance, provider }) => {
         <Center horizontal gap={4}>
           {heteroName || (
             <>
-              <ModelIcon model={model as string} type={'mono'} />
-              {modelCard?.displayName || model}
+              <ModelIcon model={displayModel} type={'mono'} />
+              {modelCard?.displayName || displayModel}
             </>
           )}
         </Center>
@@ -112,9 +134,9 @@ const Usage = memo<UsageProps>(({ model, usage, performance, provider }) => {
       <Center horizontal gap={8}>
         {!!usage?.totalTokens && (
           <TokenDetail
-            model={model as string}
+            model={displayModel}
             performance={performance}
-            provider={provider}
+            provider={displayProvider}
             usage={usage}
           />
         )}

--- a/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
@@ -764,6 +764,34 @@ describe('heterogeneousAgentExecutor DB persistence', () => {
       expect(mockGetClaudeCodeIdentity).not.toHaveBeenCalled();
     });
 
+    it.each(['lobehub/claude-server', 'lobehub-default'])(
+      'persists the catalog model instead of the CLI report %s',
+      async (reportedModel) => {
+        await runWithEvents(
+          [
+            { ...ccInit(), model: reportedModel },
+            ccMessageStart('msg_01', reportedModel),
+            ccAssistant('msg_01', [{ text: 'Hello', type: 'text' }], { model: reportedModel }),
+            ccMessageDelta({ input_tokens: 10, output_tokens: 5 }),
+            ccResult(),
+          ],
+          { params: { heterogeneousProvider: serverDefaultApiProvider } },
+        );
+
+        expect(
+          mockUpdateMessage.mock.calls.some(
+            ([id, val]: any) => id === 'ast-initial' && val.model === 'claude-server',
+          ),
+        ).toBe(true);
+        expect(
+          mockUpdateMessage.mock.calls.every(
+            ([, val]: any) =>
+              val.model !== 'lobehub/claude-server' && val.model !== 'lobehub-default',
+          ),
+        ).toBe(true);
+      },
+    );
+
     it('blocks the deployment provider before spawn when the Labs experiment is disabled', async () => {
       setClaudeCodeApiModeLab(false);
       const store = createMockStore();

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
@@ -42,6 +42,7 @@ import {
   normalizeHeterogeneousProviderConfig,
   ThreadStatus,
   ThreadType,
+  unwrapServerDefaultHeterogeneousModel,
 } from '@lobechat/types';
 import { createNanoId } from '@lobechat/utils';
 import { toast } from '@lobehub/ui/base-ui';
@@ -473,6 +474,11 @@ export const executeHeterogeneousAgent = async (
     persistedHeterogeneousProvider,
   );
   const adapterType = heterogeneousProvider.type;
+  const serverDefaultConfiguredModel =
+    heterogeneousProvider.authMode === 'api' &&
+    heterogeneousProvider.apiConfig?.source === 'server-default'
+      ? heterogeneousProvider.apiConfig.model.trim() || undefined
+      : undefined;
 
   // Which real provider account this run consumes, resolved once after spawn
   // from the FINAL env (so an agent-env override is attributed correctly, not
@@ -1789,6 +1795,19 @@ export const executeHeterogeneousAgent = async (
    * matches arrival.
    */
   const reduceAndApplyMain = async (event: AgentStreamEvent) => {
+    // Server-default CLIs report `lobehub/${catalogId}` (older Claude Code
+    // sessions used `lobehub-default`). Stamp the catalog id onto the message
+    // so the usage footer and model-card lookup resolve the real model.
+    if (serverDefaultConfiguredModel) {
+      const reported = event.data?.model;
+      if (typeof reported === 'string') {
+        const model = unwrapServerDefaultHeterogeneousModel(reported, serverDefaultConfiguredModel);
+        if (model && model !== reported) {
+          event = { ...event, data: { ...event.data, model } };
+        }
+      }
+    }
+
     // Capture the CC-native session id off the stream_start stream so every
     // message persisted below carries the session it belongs to (mirrors the
     // server handler). Stable per run; the copy makes a mid-topic fork visible.


### PR DESCRIPTION
<!-- Brief and heads-up -->

Claude Code server-default bindings now request `lobehub/${catalogId}` like Codex, instead of the shared `lobehub-default` alias. The message usage footer shows the real catalog model.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check` on the changed files: lint clean, 301 tests passed (including the Anthropic usage encoder cases already on canary).

#### 🔗 Related Issue

N/A