### PR TITLE
💄 style(workbench): align mobile padding baseline on acceptance detail

### DIFF
--- a/apps/workbench/src/features/acceptance/AcceptanceDetail.tsx
+++ b/apps/workbench/src/features/acceptance/AcceptanceDetail.tsx
@@ -43,6 +43,11 @@ const styles = createStaticStyles(({ css }) => ({
     margin-inline: auto;
     padding-block: 20px;
     padding-inline: 24px;
+
+    @media (width <= 768px) {
+      padding-block: 16px;
+      padding-inline: 12px;
+    }
   `,
 }));
 


### PR DESCRIPTION
The acceptance detail page in the workbench app used `padding-inline: 24px` for the report body while the header uses `12px`, so on mobile the header avatar / "Go to LobeHub" button and the page content sat on different horizontal baselines.

Added a `width <= 768px` media query that drops the report body to `padding-inline: 12px` (and `padding-block: 16px`) to match the header. Desktop layout unchanged.

| Before | After |
| ------ | ----- |
| header at 12px, content at 24px — misaligned edges on mobile | header and content share the 12px baseline |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Pure CSS spacing change; no regression test per repo policy.