### PR TITLE
🐛 fix: sanitize adaptive thinking for relay models

### DIFF
--- a/apps/server/src/modules/ModelRuntime/index.test.ts
+++ b/apps/server/src/modules/ModelRuntime/index.test.ts
@@ -328,6 +328,7 @@ describe('resolveServerDefaultHeterogeneousModel', () => {
         enabled: true,
         id: 'claude-sonnet-4-6',
         providerId: 'lobehub',
+        settings: { extendParams: ['enableAdaptiveThinking'] },
         source: 'builtin',
         type: 'chat',
       },
@@ -335,7 +336,11 @@ describe('resolveServerDefaultHeterogeneousModel', () => {
 
     await expect(
       resolveServerDefaultHeterogeneousModel('claude-code', 'claude-sonnet-4-6'),
-    ).resolves.toEqual({ model: 'claude-sonnet-4-6', provider: 'lobehub' });
+    ).resolves.toEqual({
+      model: 'claude-sonnet-4-6',
+      provider: 'lobehub',
+      supportsAdaptiveThinking: true,
+    });
   });
 
   it('accepts a tool-capable third-party relay model for Claude Code only', async () => {
@@ -353,7 +358,11 @@ describe('resolveServerDefaultHeterogeneousModel', () => {
 
     await expect(
       resolveServerDefaultHeterogeneousModel('claude-code', 'kimi-k2.6'),
-    ).resolves.toEqual({ model: 'kimi-k2.6', provider: 'lobehub' });
+    ).resolves.toEqual({
+      model: 'kimi-k2.6',
+      provider: 'lobehub',
+      supportsAdaptiveThinking: false,
+    });
 
     await expect(resolveServerDefaultHeterogeneousModel('codex', 'kimi-k2.6')).rejects.toThrow(
       'not compatible with this heterogeneous agent',
@@ -387,6 +396,7 @@ describe('resolveServerDefaultHeterogeneousModel', () => {
       deploymentName: 'kimi-prod',
       model: 'kimi-k2.6',
       provider: 'lobehub',
+      supportsAdaptiveThinking: false,
     });
   });
 });

--- a/apps/server/src/modules/ModelRuntime/index.ts
+++ b/apps/server/src/modules/ModelRuntime/index.ts
@@ -625,7 +625,11 @@ export const resolveServerDefaultHeterogeneousModel = async (
     throw new Error('The selected server model is not compatible with this heterogeneous agent');
   }
 
-  return toServerModelSelection(ModelProvider.LobeHub, modelConfig);
+  return {
+    ...toServerModelSelection(ModelProvider.LobeHub, modelConfig),
+    supportsAdaptiveThinking:
+      modelConfig.settings?.extendParams?.includes('enableAdaptiveThinking') === true,
+  };
 };
 
 /**

--- a/packages/openapi/src/services/heterogeneous-direct.service.test.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.test.ts
@@ -65,6 +65,7 @@ describe('heterogeneous direct invocation protocol', () => {
     vi.mocked(resolveServerDefaultHeterogeneousModel).mockResolvedValue({
       model: 'claude-sonnet-4-6',
       provider: 'lobehub',
+      supportsAdaptiveThinking: true,
     });
     vi.mocked(initModelRuntimeFromServerConfig).mockResolvedValue({
       chat,
@@ -73,7 +74,12 @@ describe('heterogeneous direct invocation protocol', () => {
     const result = await invokeServerDefaultModel({
       agentType: 'claude-code',
       model: 'claude-sonnet-4-6',
-      payload: { messages: [], model: 'lobehub-default', stream: true },
+      payload: {
+        messages: [],
+        model: 'lobehub-default',
+        stream: true,
+        thinking: { type: 'adaptive' },
+      },
       signal: new AbortController().signal,
       userId: 'user-1',
     });
@@ -88,9 +94,43 @@ describe('heterogeneous direct invocation protocol', () => {
         messages: [],
         model: 'claude-sonnet-4-6',
         stream: true,
+        thinking: { type: 'adaptive' },
       },
       expect.any(Object),
     );
+  });
+
+  it('drops adaptive thinking for Claude Code relay models without declared support', async () => {
+    const chat = vi.fn().mockResolvedValue(new Response('stream'));
+    vi.mocked(resolveServerDefaultHeterogeneousModel).mockResolvedValue({
+      model: 'doubao-seed-2.1-pro',
+      provider: 'lobehub',
+      supportsAdaptiveThinking: false,
+    });
+    vi.mocked(initModelRuntimeFromServerConfig).mockResolvedValue({
+      chat,
+    } as unknown as Awaited<ReturnType<typeof initModelRuntimeFromServerConfig>>);
+
+    await invokeServerDefaultModel({
+      agentType: 'claude-code',
+      model: 'doubao-seed-2.1-pro',
+      payload: {
+        messages: [],
+        model: 'lobehub-default',
+        stream: true,
+        thinking: { type: 'adaptive' },
+      },
+      signal: new AbortController().signal,
+      userId: 'user-1',
+    });
+
+    const runtimePayload = chat.mock.calls[0][0];
+    expect(runtimePayload).toMatchObject({
+      messages: [],
+      model: 'doubao-seed-2.1-pro',
+      stream: true,
+    });
+    expect(runtimePayload).not.toHaveProperty('thinking');
   });
 
   it('uses deployment names as model IDs for runtimes without a dedicated field', async () => {
@@ -99,6 +139,7 @@ describe('heterogeneous direct invocation protocol', () => {
       deploymentName: 'prod-gpt',
       model: 'gpt-5.4',
       provider: 'lobehub',
+      supportsAdaptiveThinking: false,
     });
     vi.mocked(initModelRuntimeFromServerConfig).mockResolvedValue({
       chat,
@@ -135,6 +176,7 @@ describe('heterogeneous direct invocation protocol', () => {
     vi.mocked(resolveServerDefaultHeterogeneousModel).mockResolvedValue({
       model: 'deepseek-v4-pro',
       provider: 'lobehub',
+      supportsAdaptiveThinking: false,
     });
     vi.mocked(initModelRuntimeFromServerConfig).mockResolvedValue({
       chat,

--- a/packages/openapi/src/services/heterogeneous-direct.service.ts
+++ b/packages/openapi/src/services/heterogeneous-direct.service.ts
@@ -860,13 +860,21 @@ export const invokeServerDefaultModel = async (params: {
     params.agentType,
     params.model,
   );
-  const { deploymentName } = resolvedModel;
+  const { deploymentName, supportsAdaptiveThinking } = resolvedModel;
   const model = deploymentName ?? resolvedModel.model;
   const runtime = await initModelRuntimeFromServerConfig({
     actorUserId: params.userId,
     workspaceId: params.workspaceId,
   });
-  const { reasoning, ...chatCompletionsPayload } = params.payload;
+  const normalizedPayload = { ...params.payload };
+  if (
+    params.agentType === 'claude-code' &&
+    normalizedPayload.thinking?.type === 'adaptive' &&
+    !supportsAdaptiveThinking
+  ) {
+    delete normalizedPayload.thinking;
+  }
+  const { reasoning, ...chatCompletionsPayload } = normalizedPayload;
   const requestedReasoningEffort = reasoning?.effort;
   const reasoningEffort = getCodexReasoningEffortLevels(params.model).includes(
     requestedReasoningEffort as CodexReasoningEffort,
@@ -878,9 +886,9 @@ export const invokeServerDefaultModel = async (params: {
       ? {
           ...chatCompletionsPayload,
           apiMode: 'chatCompletion' as const,
-          reasoning_effort: params.payload.reasoning_effort ?? reasoningEffort,
+          reasoning_effort: normalizedPayload.reasoning_effort ?? reasoningEffort,
         }
-      : params.payload;
+      : normalizedPayload;
   const response = await runtime.chat(
     {
       ...payload,


### PR DESCRIPTION
## Summary

- expose whether a selected server-default relay model declares adaptive-thinking support
- remove Claude Code's `thinking: { type: "adaptive" }` before runtime invocation when the target model does not declare that capability
- preserve adaptive thinking for models that explicitly support it

## Key Decisions / Non-goals

- The relay only performs a safe compatibility downgrade for the Anthropic `adaptive` value; provider adapters remain responsible for translating model-specific reasoning controls.
- Other thinking modes and Codex requests are intentionally unchanged.

#### Test

- [x] Tested locally
- [x] Added/updated tests

`bun run check --lint --test --type lobehub/apps/server/src/modules/ModelRuntime/index.ts lobehub/apps/server/src/modules/ModelRuntime/index.test.ts lobehub/packages/openapi/src/services/heterogeneous-direct.service.ts lobehub/packages/openapi/src/services/heterogeneous-direct.service.test.ts`

Result: lint clean, types clean, 96 tests passed.
