### PR TITLE
🐛 Fix unstable web document index prompt

### DIFF
--- a/packages/context-engine/src/providers/AgentDocumentInjector/shared.ts
+++ b/packages/context-engine/src/providers/AgentDocumentInjector/shared.ts
@@ -353,7 +353,7 @@ export function combineDocuments(
     const { flat, folders } = partitionFolders(userDocs);
 
     const headerLines: string[] = [
-      `${userDocs.length} user-created doc${userDocs.length === 1 ? '' : 's'}. Use readDocument(id) for full content.`,
+      'User-created docs, when present, are listed below — use readDocument(id) for full content.',
     ];
     if (hasHiddenWebDocs) {
       headerLines.push(

--- a/packages/context-engine/src/providers/AgentDocumentInjector/shared.ts
+++ b/packages/context-engine/src/providers/AgentDocumentInjector/shared.ts
@@ -357,7 +357,7 @@ export function combineDocuments(
     ];
     if (hasHiddenWebDocs) {
       headerLines.push(
-        `Web-crawled docs hidden — call listDocuments(sourceType='web') to see them.`,
+        `Web-crawled docs are available but omitted here — call listDocuments(sourceType='web') to discover them.`,
       );
     }
     if (folders.length > 0) {

--- a/packages/context-engine/src/providers/AgentDocumentInjector/shared.ts
+++ b/packages/context-engine/src/providers/AgentDocumentInjector/shared.ts
@@ -321,7 +321,7 @@ function sortByRecency(docs: AgentContextDocument[]): AgentContextDocument[] {
 /**
  * Combine multiple documents into a single string.
  * Progressive documents are grouped into an `<agent_documents_index>` block
- * (web-crawled docs are hidden behind a count and surfaced via listDocuments);
+ * (web-crawled docs are hidden behind a stable hint and surfaced via listDocuments);
  * full-content documents are formatted individually.
  */
 export function combineDocuments(
@@ -346,7 +346,7 @@ export function combineDocuments(
 
   if (progressiveDocs.length > 0) {
     const userDocs = progressiveDocs.filter((d) => d.sourceType !== 'web');
-    const hiddenWebCount = progressiveDocs.length - userDocs.length;
+    const hasHiddenWebDocs = progressiveDocs.length > userDocs.length;
 
     // Loose docs render as flat rows; docs sharing a folder (≥2) collapse into
     // one summary row so archive-heavy agents don't spend tokens on every entry.
@@ -355,9 +355,9 @@ export function combineDocuments(
     const headerLines: string[] = [
       `${userDocs.length} user-created doc${userDocs.length === 1 ? '' : 's'}. Use readDocument(id) for full content.`,
     ];
-    if (hiddenWebCount > 0) {
+    if (hasHiddenWebDocs) {
       headerLines.push(
-        `${hiddenWebCount} web-crawled doc${hiddenWebCount === 1 ? '' : 's'} hidden — call listDocuments(sourceType='web') to see them.`,
+        `Web-crawled docs hidden — call listDocuments(sourceType='web') to see them.`,
       );
     }
     if (folders.length > 0) {

--- a/packages/context-engine/src/providers/__tests__/AgentDocumentInjector.test.ts
+++ b/packages/context-engine/src/providers/__tests__/AgentDocumentInjector.test.ts
@@ -283,42 +283,43 @@ describe('AgentDocumentInjector', () => {
       expect(result.messages[0].content).not.toContain('empty');
     });
 
-    it('should hide web-crawled docs from the index and surface the count', async () => {
+    it('should hide web-crawled docs behind a stable index hint', async () => {
+      const documents = [
+        {
+          content: 'user note',
+          filename: 'daily-brief.txt',
+          id: '2af6eb88-8bdb-468f-887f-620baa394efa',
+          loadPosition: 'before-first-user',
+          loadRules: { rule: 'always' },
+          policyLoad: 'progressive',
+          sourceType: 'file',
+          title: 'Daily Brief',
+          updatedAt: new Date('2026-04-27T00:00:00.000Z'),
+        },
+        {
+          content: 'gold price page',
+          filename: 'gold-price-1.html',
+          id: 'web-1',
+          loadPosition: 'before-first-user',
+          loadRules: { rule: 'always' },
+          policyLoad: 'progressive',
+          sourceType: 'web',
+          title: 'Gold price',
+        },
+        {
+          content: 'gold news',
+          filename: 'gold-news.html',
+          id: 'web-2',
+          loadPosition: 'before-first-user',
+          loadRules: { rule: 'always' },
+          policyLoad: 'progressive',
+          sourceType: 'web',
+          title: 'Gold news',
+        },
+      ];
       const provider = new AgentDocumentContextInjector({
         currentTime: new Date('2026-04-29T00:00:00.000Z'),
-        documents: [
-          {
-            content: 'user note',
-            filename: 'daily-brief.txt',
-            id: '2af6eb88-8bdb-468f-887f-620baa394efa',
-            loadPosition: 'before-first-user',
-            loadRules: { rule: 'always' },
-            policyLoad: 'progressive',
-            sourceType: 'file',
-            title: 'Daily Brief',
-            updatedAt: new Date('2026-04-27T00:00:00.000Z'),
-          },
-          {
-            content: 'gold price page',
-            filename: 'gold-price-1.html',
-            id: 'web-1',
-            loadPosition: 'before-first-user',
-            loadRules: { rule: 'always' },
-            policyLoad: 'progressive',
-            sourceType: 'web',
-            title: 'Gold price',
-          },
-          {
-            content: 'gold news',
-            filename: 'gold-news.html',
-            id: 'web-2',
-            loadPosition: 'before-first-user',
-            loadRules: { rule: 'always' },
-            policyLoad: 'progressive',
-            sourceType: 'web',
-            title: 'Gold news',
-          },
-        ],
+        documents,
       });
 
       const context = createContext([{ content: 'Hello', id: 'user-1', role: 'user' }]);
@@ -327,7 +328,7 @@ describe('AgentDocumentInjector', () => {
       expect(result.messages[0].content).toMatchInlineSnapshot(`
         "<agent_documents_index>
         1 user-created doc. Use readDocument(id) for full content.
-        2 web-crawled docs hidden — call listDocuments(sourceType='web') to see them.
+        Web-crawled docs hidden — call listDocuments(sourceType='web') to see them.
 
         TITLE        ID                                    SIZE  UPDATED
         Daily Brief  2af6eb88-8bdb-468f-887f-620baa394efa  9     2026-04-27
@@ -335,6 +336,14 @@ describe('AgentDocumentInjector', () => {
       `);
       expect(result.messages[0].content).not.toContain('Gold price');
       expect(result.messages[0].content).not.toContain('Gold news');
+
+      const oneWebDocumentProvider = new AgentDocumentContextInjector({
+        currentTime: new Date('2026-04-29T00:00:00.000Z'),
+        documents: documents.slice(0, 2),
+      });
+      const oneWebDocumentResult = await oneWebDocumentProvider.process(context);
+
+      expect(oneWebDocumentResult.messages[0].content).toBe(result.messages[0].content);
     });
 
     it('should collapse same-folder docs into a summary row and keep root docs flat', async () => {

--- a/packages/context-engine/src/providers/__tests__/AgentDocumentInjector.test.ts
+++ b/packages/context-engine/src/providers/__tests__/AgentDocumentInjector.test.ts
@@ -230,7 +230,7 @@ describe('AgentDocumentInjector', () => {
     // in the index changed the prompt prefix every minute and broke provider-side
     // prompt caching. The index must stay byte-identical as wall-clock time passes.
     it('should render a time-stable index so the prompt cache prefix survives', async () => {
-      const documents = [
+      const documents: AgentContextDocument[] = [
         {
           content: 'note',
           filename: 'note.md',
@@ -337,7 +337,10 @@ describe('AgentDocumentInjector', () => {
       `);
       expect(result.messages[0].content).not.toContain('Gold price');
       expect(result.messages[0].content).not.toContain('Gold news');
-      expect(result.messages[0].content.split("listDocuments(sourceType='web')")).toHaveLength(2);
+      const injectedContent = result.messages[0].content;
+      expect(typeof injectedContent).toBe('string');
+      if (typeof injectedContent !== 'string') throw new TypeError('Expected string content');
+      expect(injectedContent.split("listDocuments(sourceType='web')")).toHaveLength(2);
 
       const oneWebDocumentProvider = new AgentDocumentContextInjector({
         currentTime: new Date('2026-04-29T00:00:00.000Z'),

--- a/packages/context-engine/src/providers/__tests__/AgentDocumentInjector.test.ts
+++ b/packages/context-engine/src/providers/__tests__/AgentDocumentInjector.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { PipelineContext } from '../../types';
+import type { AgentContextDocument } from '../AgentDocumentInjector';
 import {
   AgentDocumentBeforeSystemInjector,
   AgentDocumentContextInjector,
@@ -241,7 +242,7 @@ describe('AgentDocumentInjector', () => {
           title: 'Note',
           updatedAt: new Date('2026-04-28T23:59:00.000Z'),
         },
-      ];
+      ] satisfies AgentContextDocument[];
       const renderAt = async (currentTime: Date) => {
         const provider = new AgentDocumentContextInjector({ currentTime, documents });
         const context = createContext([{ content: 'Hello', id: 'user-1', role: 'user' }]);
@@ -328,7 +329,7 @@ describe('AgentDocumentInjector', () => {
       expect(result.messages[0].content).toMatchInlineSnapshot(`
         "<agent_documents_index>
         User-created docs, when present, are listed below — use readDocument(id) for full content.
-        Web-crawled docs hidden — call listDocuments(sourceType='web') to see them.
+        Web-crawled docs are available but omitted here — call listDocuments(sourceType='web') to discover them.
 
         TITLE        ID                                    SIZE  UPDATED
         Daily Brief  2af6eb88-8bdb-468f-887f-620baa394efa  9     2026-04-27
@@ -336,6 +337,7 @@ describe('AgentDocumentInjector', () => {
       `);
       expect(result.messages[0].content).not.toContain('Gold price');
       expect(result.messages[0].content).not.toContain('Gold news');
+      expect(result.messages[0].content.split("listDocuments(sourceType='web')")).toHaveLength(2);
 
       const oneWebDocumentProvider = new AgentDocumentContextInjector({
         currentTime: new Date('2026-04-29T00:00:00.000Z'),

--- a/packages/context-engine/src/providers/__tests__/AgentDocumentInjector.test.ts
+++ b/packages/context-engine/src/providers/__tests__/AgentDocumentInjector.test.ts
@@ -215,7 +215,7 @@ describe('AgentDocumentInjector', () => {
 
       expect(result.messages[0].content).toMatchInlineSnapshot(`
         "<agent_documents_index>
-        2 user-created docs. Use readDocument(id) for full content.
+        User-created docs, when present, are listed below — use readDocument(id) for full content.
 
         TITLE                     ID                                    SIZE  UPDATED
         Daily Brief 提取框架          2af6eb88-8bdb-468f-887f-620baa394efa  35    2026-04-27
@@ -327,7 +327,7 @@ describe('AgentDocumentInjector', () => {
 
       expect(result.messages[0].content).toMatchInlineSnapshot(`
         "<agent_documents_index>
-        1 user-created doc. Use readDocument(id) for full content.
+        User-created docs, when present, are listed below — use readDocument(id) for full content.
         Web-crawled docs hidden — call listDocuments(sourceType='web') to see them.
 
         TITLE        ID                                    SIZE  UPDATED
@@ -408,7 +408,7 @@ describe('AgentDocumentInjector', () => {
 
       expect(result.messages[0].content).toMatchInlineSnapshot(`
         "<agent_documents_index>
-        4 user-created docs. Use readDocument(id) for full content.
+        User-created docs, when present, are listed below — use readDocument(id) for full content.
         1 folder collapsed (📁) — call listDocuments(parentId=<id>) to list a folder's docs.
 
         TITLE      ID      SIZE  UPDATED
@@ -475,7 +475,7 @@ describe('AgentDocumentInjector', () => {
 
       expect(result.messages[0].content).toMatchInlineSnapshot(`
         "<agent_documents_index>
-        1 user-created doc. Use readDocument(id) for full content.
+        User-created docs, when present, are listed below — use readDocument(id) for full content.
 
         TITLE      ID                                    SIZE   UPDATED
         周报与平台对话分析  d14dca54-7b38-44d5-9bdb-f3fed8c5f947  empty  2026-04-16

--- a/packages/context-engine/src/providers/__tests__/AgentDocumentInjector.test.ts
+++ b/packages/context-engine/src/providers/__tests__/AgentDocumentInjector.test.ts
@@ -317,7 +317,7 @@ describe('AgentDocumentInjector', () => {
           sourceType: 'web',
           title: 'Gold news',
         },
-      ];
+      ] satisfies AgentContextDocument[];
       const provider = new AgentDocumentContextInjector({
         currentTime: new Date('2026-04-29T00:00:00.000Z'),
         documents,


### PR DESCRIPTION
## Summary

- replace changing user-created and web-crawled document counts with stable discovery hints
- preserve `readDocument(id)` and `listDocuments(sourceType='web')` guidance without invalidating the prompt prefix merely because a count changed
- add a regression assertion that one versus multiple hidden web documents produce the same injected index

## Context

`ctx-map` showed `<agent_documents_index>` breaking the cached prefix on 10 of 14 LLM calls in a long-running web research operation. Each successful crawl changed the early prompt from e.g. `19 web-crawled docs` to `23 web-crawled docs`, forcing the full conversation tail to be reprocessed. User-created document counts had the same avoidable instability.

The user-document table remains intentionally dynamic: genuinely adding, removing, renaming, or updating a listed document still changes the index. This patch removes count-only churn without hiding real index changes.

## Verification

- `bun run check packages/context-engine/src/providers/AgentDocumentInjector/shared.ts packages/context-engine/src/providers/__tests__/AgentDocumentInjector.test.ts` — 22 tests passed, lint clean
- full `bun run check --type ...` attempted; blocked by unrelated baseline/cross-worktree dependency resolution errors (including duplicated database types and existing Server/Desktop errors)
