### PR TITLE
💄 style: brand the loading screen and LobeHub provider card via the business slot

### DIFF
--- a/packages/business/const/package.json
+++ b/packages/business/const/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./branding": "./src/branding.ts"
   },
   "main": "./src/index.ts"
 }

--- a/packages/model-bank/src/modelProviders/lobehub.ts
+++ b/packages/model-bank/src/modelProviders/lobehub.ts
@@ -1,20 +1,34 @@
+import { BRANDING_NAME } from '@lobechat/business-const/branding';
+
 import type { ModelProviderCard } from '../types';
+
+/**
+ * The branded first-party provider. Display metadata follows the business
+ * branding slot: OSS/cloud keep the LobeHub identity, while custom-branding
+ * distributions (BRANDING_NAME override) get their own name and drop the
+ * LobeHub marketing copy/links automatically.
+ */
+const isCustomBranding = BRANDING_NAME !== 'LobeHub';
 
 const LobeHub: ModelProviderCard = {
   chatModels: [],
-  description:
-    'LobeHub Cloud uses official APIs to access AI models and measures usage with Credits tied to model tokens.',
+  ...(isCustomBranding
+    ? {}
+    : {
+        description:
+          'LobeHub Cloud uses official APIs to access AI models and measures usage with Credits tied to model tokens.',
+        modelsUrl: 'https://lobehub.com/zh/docs/usage/subscription/model-pricing',
+      }),
   enabled: true,
   id: 'lobehub',
-  modelsUrl: 'https://lobehub.com/zh/docs/usage/subscription/model-pricing',
-  name: 'LobeHub',
+  name: BRANDING_NAME,
   settings: {
     modelEditable: false,
     showAddNewModel: false,
     showModelFetcher: false,
   },
   showConfig: false,
-  url: 'https://lobehub.com',
+  url: isCustomBranding ? '' : 'https://lobehub.com',
 };
 
 export default LobeHub;

--- a/packages/model-bank/src/modelProviders/lobehub.ts
+++ b/packages/model-bank/src/modelProviders/lobehub.ts
@@ -1,4 +1,4 @@
-import { BRANDING_NAME } from '@lobechat/business-const/branding';
+import { BRANDING_NAME } from '@lobechat/business-const';
 
 import type { ModelProviderCard } from '../types';
 

--- a/plugins/vite/customBrandingLoadingScreen.test.ts
+++ b/plugins/vite/customBrandingLoadingScreen.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const SAMPLE_HTML = `<body>
+    <div id="loading-screen">
+      <div id="loading-brand" aria-label="Loading" role="status">
+        <svg fill="currentColor" height="40" viewBox="0 0 940 320" xmlns="http://www.w3.org/2000/svg">
+          <title>LobeHub</title>
+          <path d="M15 240.035V87.172h39.24V205.75h66.192v34.285H15z" />
+        </svg>
+      </div>
+    </div>
+    <div id="root" style="height: 100%"></div>
+  </body>`;
+
+const loadHandler = async () => {
+  const { customBrandingLoadingScreen } = await import('./customBrandingLoadingScreen');
+  const plugin = customBrandingLoadingScreen();
+  return (plugin.transformIndexHtml as { handler: (html: string) => string }).handler;
+};
+
+describe('customBrandingLoadingScreen', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('keeps the default LobeHub wordmark untouched', async () => {
+    vi.doMock('@lobechat/business-const', () => ({ BRANDING_NAME: 'LobeHub' }));
+    const handler = await loadHandler();
+
+    expect(handler(SAMPLE_HTML)).toBe(SAMPLE_HTML);
+  });
+
+  it('replaces the wordmark with the custom brand name', async () => {
+    vi.doMock('@lobechat/business-const', () => ({ BRANDING_NAME: 'AI Workstation' }));
+    const handler = await loadHandler();
+
+    const result = handler(SAMPLE_HTML);
+    expect(result).not.toContain('<svg');
+    expect(result).not.toContain('LobeHub');
+    expect(result).toContain('AI Workstation');
+    expect(result).toContain('id="loading-brand"');
+    // the rest of the document is preserved
+    expect(result).toContain('<div id="root" style="height: 100%"></div>');
+  });
+
+  it('escapes HTML-sensitive characters in the brand name', async () => {
+    vi.doMock('@lobechat/business-const', () => ({ BRANDING_NAME: 'A<B>&"C' }));
+    const handler = await loadHandler();
+
+    const result = handler(SAMPLE_HTML);
+    expect(result).toContain('A&lt;B&gt;&amp;&quot;C');
+    expect(result).not.toContain('A<B>');
+  });
+});

--- a/plugins/vite/customBrandingLoadingScreen.test.ts
+++ b/plugins/vite/customBrandingLoadingScreen.test.ts
@@ -24,14 +24,14 @@ describe('customBrandingLoadingScreen', () => {
   });
 
   it('keeps the default LobeHub wordmark untouched', async () => {
-    vi.doMock('@lobechat/business-const', () => ({ BRANDING_NAME: 'LobeHub' }));
+    vi.doMock('@lobechat/business-const/branding', () => ({ BRANDING_NAME: 'LobeHub' }));
     const handler = await loadHandler();
 
     expect(handler(SAMPLE_HTML)).toBe(SAMPLE_HTML);
   });
 
   it('replaces the wordmark with the custom brand name', async () => {
-    vi.doMock('@lobechat/business-const', () => ({ BRANDING_NAME: 'AI Workstation' }));
+    vi.doMock('@lobechat/business-const/branding', () => ({ BRANDING_NAME: 'AI Workstation' }));
     const handler = await loadHandler();
 
     const result = handler(SAMPLE_HTML);
@@ -44,7 +44,7 @@ describe('customBrandingLoadingScreen', () => {
   });
 
   it('escapes HTML-sensitive characters in the brand name', async () => {
-    vi.doMock('@lobechat/business-const', () => ({ BRANDING_NAME: 'A<B>&"C' }));
+    vi.doMock('@lobechat/business-const/branding', () => ({ BRANDING_NAME: 'A<B>&"C' }));
     const handler = await loadHandler();
 
     const result = handler(SAMPLE_HTML);

--- a/plugins/vite/customBrandingLoadingScreen.ts
+++ b/plugins/vite/customBrandingLoadingScreen.ts
@@ -1,4 +1,8 @@
-import { BRANDING_NAME } from '@lobechat/business-const';
+// Deep import on purpose: the package root barrel uses extensionless relative
+// imports that Node's type-stripping loader (which evaluates externalized
+// config-time imports) cannot resolve. branding.ts is a dependency-free leaf
+// exposed via the './branding' subpath — keep it import-free.
+import { BRANDING_NAME } from '@lobechat/business-const/branding';
 import type { Plugin } from 'vite';
 
 const LOADING_BRAND_BLOCK = /<div id="loading-brand"[^>]*>[\S\s]*?<\/div>/;

--- a/plugins/vite/customBrandingLoadingScreen.ts
+++ b/plugins/vite/customBrandingLoadingScreen.ts
@@ -1,0 +1,34 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
+import type { Plugin } from 'vite';
+
+const LOADING_BRAND_BLOCK = /<div id="loading-brand"[^>]*>[\S\s]*?<\/div>/;
+
+const escapeHtml = (value: string) =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+
+/**
+ * Replace the hardcoded LobeHub wordmark in the static loading screen with the
+ * custom brand name, so white-label deployments (BRANDING_NAME !== 'LobeHub')
+ * never flash the LobeHub logo before the SPA boots. No-op for the default
+ * branding.
+ */
+export const customBrandingLoadingScreen = (): Plugin => ({
+  name: 'custom-branding-loading-screen',
+  transformIndexHtml: {
+    handler(html) {
+      if (BRANDING_NAME === 'LobeHub') return html;
+
+      return html.replace(
+        LOADING_BRAND_BLOCK,
+        `<div id="loading-brand" aria-label="Loading" role="status" style="font-size: 26px; font-weight: 700; letter-spacing: 0.02em;">${escapeHtml(
+          BRANDING_NAME,
+        )}</div>`,
+      );
+    },
+    order: 'pre',
+  },
+});

--- a/src/features/Settings/provider/(list)/ProviderGrid/Card.tsx
+++ b/src/features/Settings/provider/(list)/ProviderGrid/Card.tsx
@@ -104,7 +104,7 @@ const ProviderCard = memo<ProviderCardProps>(
               >
                 {source === 'custom'
                   ? description
-                  : t(`${id}.description`, { defaultValue: description })}
+                  : description && t(`${id}.description`, { defaultValue: description })}
               </Text>
             </Flexbox>
           </div>

--- a/src/routes/(main)/community/(detail)/model/features/Sidebar/RelatedProviders/Item.tsx
+++ b/src/routes/(main)/community/(detail)/model/features/Sidebar/RelatedProviders/Item.tsx
@@ -48,7 +48,7 @@ const RelatedItem = memo<DiscoverModelDetailProviderItem>(({ description, id, na
             rows: 2,
           }}
         >
-          {t(`${id}.description`, { defaultValue: description })}
+          {description && t(`${id}.description`, { defaultValue: description })}
         </Text>
       </Flexbox>
     </Block>

--- a/src/routes/(main)/community/(detail)/provider/features/Header.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Header.tsx
@@ -73,7 +73,7 @@ const Header = memo<{ mobile?: boolean }>(({ mobile: isMobile }) => {
           color: cssVar.colorTextSecondary,
         }}
       >
-        {t(`${identifier}.description`, { defaultValue: description })}
+        {description && t(`${identifier}.description`, { defaultValue: description })}
       </Flexbox>
     </Flexbox>
   );

--- a/src/routes/(main)/community/(detail)/provider/features/Sidebar/ActionButton/ProviderConfig.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Sidebar/ActionButton/ProviderConfig.tsx
@@ -52,7 +52,7 @@ const ProviderConfig = memo(() => {
 
   if (!items || items?.length === 0)
     return (
-      <Button block size={'large'} style={{ flex: 1 }} type={'primary'}>
+      <Button block size={'large'} style={{ flex: 1 }} type={'primary'} onClick={openSettings}>
         {t('providers.config')}
       </Button>
     );

--- a/src/routes/(main)/community/(detail)/provider/features/Sidebar/ActionButton/index.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Sidebar/ActionButton/index.tsx
@@ -21,7 +21,9 @@ const ActionButton = memo(() => {
       <ShareButton
         meta={{
           avatar: <ProviderIcon provider={identifier} size={64} type={'avatar'} />,
-          desc: t(`${identifier}.description`, { defaultValue: description }),
+          desc: description
+            ? t(`${identifier}.description`, { defaultValue: description })
+            : undefined,
           tags: (
             <Flexbox horizontal align={'center'} gap={4} justify={'center'} wrap={'wrap'}>
               {models

--- a/src/routes/(main)/community/(detail)/provider/features/Sidebar/Related/Item.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Sidebar/Related/Item.tsx
@@ -48,7 +48,7 @@ const RelatedItem = memo<DiscoverProviderItem>(({ description, identifier, name 
             rows: 2,
           }}
         >
-          {t(`${identifier}.description`, { defaultValue: description })}
+          {description && t(`${identifier}.description`, { defaultValue: description })}
         </Text>
       </Flexbox>
     </Block>

--- a/src/routes/(main)/community/(detail)/provider/features/Sidebar/RelatedModels/Item.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Sidebar/RelatedModels/Item.tsx
@@ -48,7 +48,7 @@ const RelatedItem = memo<DiscoverProviderDetailModelItem>(({ description, id, di
             rows: 2,
           }}
         >
-          {t(`${id}.description`, { defaultValue: description })}
+          {description && t(`${id}.description`, { defaultValue: description })}
         </Text>
       </Flexbox>
     </Block>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ import type { PluginOption, ViteDevServer } from 'vite';
 import { defineConfig, loadEnv } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
 
+import { customBrandingLoadingScreen } from './plugins/vite/customBrandingLoadingScreen';
 import { viteEnvRestartKeys } from './plugins/vite/envRestartKeys';
 import {
   createSharedRolldownOutput,
@@ -151,6 +152,7 @@ export default defineConfig({
         },
       },
     vercelSkewProtection(),
+    customBrandingLoadingScreen(),
     viteEnvRestartKeys(['APP_URL']),
     enableViteDevTools &&
       DevTools({


### PR DESCRIPTION
Two UI surfaces still hardcoded the LobeHub identity where everything else already reads it from `@lobechat/business-const`: the static loading screen's wordmark (baked into the SPA entry HTML, so it flashes before the bundle boots) and the built-in LobeHub provider card's copy/links.

Both default to upstream's current appearance — this PR does not change default behaviour.

#### What changed

- `plugins/vite/customBrandingLoadingScreen.ts` (new): a `transformIndexHtml` Vite plugin that swaps the hardcoded `#loading-brand` wordmark SVG for `BRANDING_NAME` when custom branding is active (`BRANDING_NAME !== 'LobeHub'`); no-op otherwise. Wired into `vite.config.ts`.
- `packages/business/const/package.json`: adds a `./branding` subpath pointing at `src/branding.ts`. Needed because importing the package root from `vite.config.ts` fails under Node's type-stripping loader (the barrel uses extensionless relative imports) — `branding.ts` is a dependency-free leaf, so the subpath sidesteps that. `branding.ts` must stay import-free for this to keep working.
- `packages/model-bank/src/modelProviders/lobehub.ts`: the built-in provider card's `name`/`description`/`modelsUrl`/`url` now follow `BRANDING_NAME` — custom-branding distributions drop the LobeHub marketing copy and links entirely; OSS and cloud keep the exact previous card.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [x] `bun run check --lint --test` clean on all touched files (3 tests passing)
- [x] `bun run check --type` shows no new type errors

#### Key Decisions / Non-goals

- Every constant this PR reads (`BRANDING_NAME`) already exists in both the OSS and cloud `business-const` packages today — this isn't introducing a new slot, so (unlike #18637) there's no runtime fallback to design here.
- **Companion change needed before any downstream sync**: any deployment that fully replaces `packages/business/const` (rather than re-exporting upstream's module) needs to add the same `"./branding": "./src/branding.ts"` entry to its own `package.json` `exports` map, or the Vite config fails to resolve at startup — this is a module-resolution failure, not something a runtime fallback can paper over. Flagging explicitly, same as the API key prefix slot in #18637.