### PR TITLE
💄 style(agent): default heterogeneous agent name to owner's product

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -670,6 +670,7 @@
   "heteroAgent.codexQuota.tooltip": "View Codex quota",
   "heteroAgent.codexQuota.totalEarned_one": "{{count}} earned in total",
   "heteroAgent.codexQuota.totalEarned_other": "{{count}} earned in total",
+  "heteroAgent.defaultName": "{{owner}}'s {{product}}",
   "heteroAgent.executionTarget.auto": "Auto",
   "heteroAgent.executionTarget.autoDesc": "Use an online device automatically, picking one when several are available",
   "heteroAgent.executionTarget.downloadDesktop": "Get Desktop App",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -670,6 +670,7 @@
   "heteroAgent.codexQuota.tooltip": "查看 Codex 额度",
   "heteroAgent.codexQuota.totalEarned_one": "累计获得 {{count}} 次",
   "heteroAgent.codexQuota.totalEarned_other": "累计获得 {{count}} 次",
+  "heteroAgent.defaultName": "{{owner}} 的 {{product}}",
   "heteroAgent.executionTarget.auto": "自动",
   "heteroAgent.executionTarget.autoDesc": "自动使用在线设备，有多台时择一使用",
   "heteroAgent.executionTarget.downloadDesktop": "下载桌面端",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -329,6 +329,7 @@ export default {
   'groupWizard.searchTemplates': 'Search templates...',
   'groupWizard.title': 'Create Group',
   'groupWizard.useTemplate': 'Use Template',
+  'heteroAgent.defaultName': "{{owner}}'s {{product}}",
   'heteroAgent.fullAccess.label': 'Full access',
   'heteroAgent.fullAccess.tooltip':
     'The local coding agent runs with full read/write access to the working directory. Switching permission modes is not available yet.',

--- a/packages/types/src/agent/displayName.test.ts
+++ b/packages/types/src/agent/displayName.test.ts
@@ -46,17 +46,28 @@ describe('agentSecondaryDisplayName', () => {
     expect(agentSecondaryDisplayName({ name: '  ', title: 'Pi' })).toBeUndefined();
   });
 
-  it('suppresses a role the primary name already spells out', () => {
+  it('suppresses a role the primary name already spells out as its suffix', () => {
     expect(
       agentSecondaryDisplayName({ name: 'Max 的 Kimi Code', title: 'Kimi Code' }),
     ).toBeUndefined();
     expect(
       agentSecondaryDisplayName({ name: "MaxLiu's Claude Code", title: 'Claude Code' }),
     ).toBeUndefined();
+    expect(
+      agentSecondaryDisplayName({ name: 'Claude Code', title: 'Claude Code' }),
+    ).toBeUndefined();
   });
 
   it('restores the role tag once the name no longer echoes it', () => {
     expect(agentSecondaryDisplayName({ name: '小K', title: 'Kimi Code' })).toBe('Kimi Code');
+  });
+
+  it('keeps the tag when the name merely contains the role as a substring', () => {
+    expect(agentSecondaryDisplayName({ name: 'Arthur', title: 'Art' })).toBe('Art');
+    expect(agentSecondaryDisplayName({ name: 'MozArt', title: 'Art' })).toBe('Art');
+    expect(agentSecondaryDisplayName({ name: 'Claude Code 助手', title: 'Claude Code' })).toBe(
+      'Claude Code',
+    );
   });
 
   it('treats a blank role as absent', () => {

--- a/packages/types/src/agent/displayName.test.ts
+++ b/packages/types/src/agent/displayName.test.ts
@@ -46,6 +46,19 @@ describe('agentSecondaryDisplayName', () => {
     expect(agentSecondaryDisplayName({ name: '  ', title: 'Pi' })).toBeUndefined();
   });
 
+  it('suppresses a role the primary name already spells out', () => {
+    expect(
+      agentSecondaryDisplayName({ name: 'Max 的 Kimi Code', title: 'Kimi Code' }),
+    ).toBeUndefined();
+    expect(
+      agentSecondaryDisplayName({ name: "MaxLiu's Claude Code", title: 'Claude Code' }),
+    ).toBeUndefined();
+  });
+
+  it('restores the role tag once the name no longer echoes it', () => {
+    expect(agentSecondaryDisplayName({ name: '小K', title: 'Kimi Code' })).toBe('Kimi Code');
+  });
+
   it('treats a blank role as absent', () => {
     expect(agentSecondaryDisplayName({ name: 'Alice', title: '   ' })).toBeUndefined();
     expect(agentSecondaryDisplayName({ name: 'Alice' })).toBeUndefined();

--- a/packages/types/src/agent/displayName.ts
+++ b/packages/types/src/agent/displayName.ts
@@ -51,11 +51,17 @@ export function agentDisplayName(
  * renders its title as the primary label, so repeating it would be noise. This
  * is deliberately uniform across every kind of agent, including runtime-backed
  * (heterogeneous) ones: they show their own role rather than their runtime.
+ *
+ * A role the primary label already spells out is suppressed for the same
+ * reason: a heterogeneous agent defaults to "Max 的 Kimi Code", and tagging it
+ * "Kimi Code" again says nothing. Rename it to something that no longer echoes
+ * the role and the tag comes back.
  */
 export const agentSecondaryDisplayName = (
   agent: AgentNameFields | null | undefined,
 ): string | undefined => {
   const role = firstNonBlank(agent?.name) ? firstNonBlank(agent?.title) : undefined;
+  if (!role) return undefined;
 
-  return role === agentDisplayName(agent) ? undefined : role;
+  return agentDisplayName(agent)?.includes(role) ? undefined : role;
 };

--- a/packages/types/src/agent/displayName.ts
+++ b/packages/types/src/agent/displayName.ts
@@ -56,6 +56,12 @@ export function agentDisplayName(
  * reason: a heterogeneous agent defaults to "Max 的 Kimi Code", and tagging it
  * "Kimi Code" again says nothing. Rename it to something that no longer echoes
  * the role and the tag comes back.
+ *
+ * "Spells out" means the role is the name's whole suffix behind a word
+ * boundary — the shape the generated "{owner} 的 {product}" / "{owner}'s
+ * {product}" default produces. A name that merely contains the role as a
+ * substring ("Arthur" / "Art", "MozArt" / "Art") keeps its tag: that overlap
+ * is coincidence, not repetition.
  */
 export const agentSecondaryDisplayName = (
   agent: AgentNameFields | null | undefined,
@@ -63,5 +69,14 @@ export const agentSecondaryDisplayName = (
   const role = firstNonBlank(agent?.name) ? firstNonBlank(agent?.title) : undefined;
   if (!role) return undefined;
 
-  return agentDisplayName(agent)?.includes(role) ? undefined : role;
+  const primary = agentDisplayName(agent);
+  if (!primary) return role;
+  if (primary === role) return undefined;
+
+  if (primary.endsWith(role)) {
+    const boundary = primary[primary.length - role.length - 1];
+    if (!/[\p{L}\p{N}]/u.test(boundary)) return undefined;
+  }
+
+  return role;
 };

--- a/src/features/ConnectAgent/index.tsx
+++ b/src/features/ConnectAgent/index.tsx
@@ -41,6 +41,7 @@ import { useDeviceList } from '@/features/DeviceManager/useDeviceList';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { deviceService } from '@/services/device';
 import { useAgentStore } from '@/store/agent';
+import { heteroAgentDefaultName } from '@/store/agent/utils/heteroAgentDefaultName';
 import { useElectronStore } from '@/store/electron';
 import { useHomeStore } from '@/store/home';
 
@@ -498,7 +499,10 @@ const ConnectAgentContent = memo<ConnectAgentContentProps>(
     const goConfirm = useCallback(() => {
       if (!single) return;
       const profile = isRemoteHeterogeneousType(single.type) ? profiles[single.type] : undefined;
-      setName(profile?.title ?? single.title);
+      const productTitle = profile?.title ?? single.title;
+      // Prefill with the same "{owner}'s {product}" default that createAgent
+      // seeds, so the input shows the name the agent would actually get.
+      setName(heteroAgentDefaultName(productTitle) ?? productTitle);
       setDescription(profile?.description ?? '');
       setStep(2);
     }, [profiles, single]);
@@ -539,7 +543,12 @@ const ConnectAgentContent = memo<ConnectAgentContentProps>(
                 agentId: result.agentId,
                 locationLabel: targetLabel,
                 provider,
-                title: agentDisplayName(params.config, provider.title) ?? provider.title,
+                // Mirror the default-name seeding in createAgent so the done
+                // screen shows the same label the sidebar will.
+                title:
+                  params.config.name?.trim() ||
+                  heteroAgentDefaultName(params.config.title) ||
+                  agentDisplayName(params.config, provider.title),
                 version: scanState.agents?.[provider.type]?.version,
               } satisfies CreatedAgent;
             }),

--- a/src/store/agent/slices/agent/action.test.ts
+++ b/src/store/agent/slices/agent/action.test.ts
@@ -8,6 +8,7 @@ import { agentConfigKeys } from '@/libs/swr/keys';
 import { agentService } from '@/services/agent';
 import { agentDocumentService } from '@/services/agentDocument';
 import { useGlobalStore } from '@/store/global';
+import { useUserStore } from '@/store/user';
 import { type LobeAgentConfig } from '@/types/agent';
 import { withSWR } from '~test-utils';
 
@@ -207,6 +208,56 @@ describe('AgentSlice Actions', () => {
         expect(config.name).toMatch(/^\p{Script=Han}+$/u);
       } finally {
         useGlobalStore.setState({ status });
+      }
+    });
+
+    it('names a heterogeneous agent after its owner instead of a personal name', async () => {
+      vi.mocked(agentService.createAgent).mockResolvedValue({ agentId: 'agent-2' });
+      const userState = useUserStore.getState();
+      useUserStore.setState({
+        isSignedIn: true,
+        user: { fullName: 'Max', id: 'user-1' } as any,
+      });
+      const { result } = renderHook(() => useAgentStore());
+
+      try {
+        await act(async () => {
+          await result.current.createAgent({
+            config: {
+              agencyConfig: { heterogeneousProvider: { command: 'claude', type: 'claude-code' } },
+              title: 'Claude Code',
+            },
+          });
+        });
+
+        // Test i18n serves the default (English) chat resources.
+        expect(vi.mocked(agentService.createAgent).mock.calls[0][0].config?.name).toBe(
+          "Max's Claude Code",
+        );
+      } finally {
+        useUserStore.setState({ isSignedIn: userState.isSignedIn, user: userState.user });
+      }
+    });
+
+    it('leaves a heterogeneous agent unnamed for an anonymous owner', async () => {
+      vi.mocked(agentService.createAgent).mockResolvedValue({ agentId: 'agent-2' });
+      const userState = useUserStore.getState();
+      useUserStore.setState({ isSignedIn: false, user: undefined });
+      const { result } = renderHook(() => useAgentStore());
+
+      try {
+        await act(async () => {
+          await result.current.createAgent({
+            config: {
+              agencyConfig: { heterogeneousProvider: { command: 'claude', type: 'claude-code' } },
+              title: 'Claude Code',
+            },
+          });
+        });
+
+        expect(vi.mocked(agentService.createAgent).mock.calls[0][0].config?.name).toBeUndefined();
+      } finally {
+        useUserStore.setState({ isSignedIn: userState.isSignedIn, user: userState.user });
       }
     });
 

--- a/src/store/agent/slices/agent/action.ts
+++ b/src/store/agent/slices/agent/action.ts
@@ -1,5 +1,6 @@
 import { isDesktop, randomAgentName } from '@lobechat/const';
 import { type AgentContextDocument } from '@lobechat/context-engine';
+import { getHeterogeneousTypeLabel } from '@lobechat/heterogeneous-agents';
 import {
   isChatGroupSessionId,
   type LobeAgentAgencyConfig,
@@ -39,6 +40,7 @@ import type {
 import { merge } from '@/utils/merge';
 
 import type { AgentStore } from '../../store';
+import { heteroAgentDefaultName } from '../../utils/heteroAgentDefaultName';
 import { setLocalAgentWorkingDirectory } from '../../utils/localAgentWorkingDirectoryStorage';
 import type { AgentSliceState, LoadingState, SaveStatus } from './initialState';
 
@@ -152,15 +154,26 @@ export class AgentSliceActionImpl {
   };
 
   createAgent = async (params: CreateAgentParams): Promise<CreateAgentResult> => {
-    // Seed a personal name so a new agent has an identity before the Agent
+    // Seed a default name so a new agent has an identity before the Agent
     // Builder conversation produces one; the builder may replace it later. This
     // lives here rather than in the create endpoint because the language only
     // resolves on the client (`auto` follows the browser). A caller that already
     // carries a name — e.g. a market agent — keeps it.
+    //
+    // A heterogeneous agent never draws a personal name: it is the user's
+    // external tool, not one of our own agents, so its default reads as whose
+    // tool it is — "{owner}'s {product}" (e.g. "Max 的 Claude Code").
+    const heteroProvider = params.config?.agencyConfig?.heterogeneousProvider;
     const locale = globalGeneralSelectors.currentLanguage(useGlobalStore.getState());
     const config = {
       ...params.config,
-      name: params.config?.name || randomAgentName(locale),
+      name:
+        params.config?.name ||
+        (heteroProvider
+          ? heteroAgentDefaultName(
+              params.config?.title || getHeterogeneousTypeLabel(heteroProvider.type),
+            )
+          : randomAgentName(locale)),
     };
 
     const result = await agentService.createAgent({ ...params, config });

--- a/src/store/agent/utils/heteroAgentDefaultName.ts
+++ b/src/store/agent/utils/heteroAgentDefaultName.ts
@@ -1,0 +1,25 @@
+import { t } from 'i18next';
+
+import { getUserStoreState } from '@/store/user';
+import { authSelectors, userProfileSelectors } from '@/store/user/selectors';
+
+/**
+ * Default display name for a heterogeneous (external CLI / platform) agent:
+ * "{owner}'s {product}" (e.g. "Max 的 Claude Code"). Such an agent is the
+ * user's external tool rather than one of our own agents, so its default label
+ * says whose tool it is instead of drawing a personal name.
+ *
+ * Returns undefined when the owner has no usable name (anonymous session), so
+ * the product title stays the primary label.
+ */
+export const heteroAgentDefaultName = (productTitle?: string | null): string | undefined => {
+  const userStore = getUserStoreState();
+  const owner = authSelectors.isLogin(userStore)
+    ? userProfileSelectors.nickName(userStore)?.trim()
+    : undefined;
+  const product = productTitle?.trim();
+
+  if (!owner || !product) return undefined;
+
+  return t('heteroAgent.defaultName', { ns: 'chat', owner, product });
+};


### PR DESCRIPTION
A heterogeneous agent (external CLI like Claude Code / Kimi Code) previously drew a random personal name at creation ("陆令言"), which made it read like an in-house assistant. It is the user's external tool, so its default name now says whose tool it is: **"{owner}'s {product}"** (e.g. "Max 的 Kimi Code" / "Max's Claude Code").

**Changes**

- `createAgent` store funnel: when `agencyConfig.heterogeneousProvider` is present, seed the name via the new `heteroAgentDefaultName()` helper instead of `randomAgentName()`. Anonymous users get no name (product title stays the primary label). Both creation entries (recommendation card + Connect Agent wizard) flow through this funnel.
- New i18n key `heteroAgent.defaultName` (en-US / zh-CN hand-authored; other locales via daily auto-i18n).
- `agentSecondaryDisplayName`: suppress the role tag when the primary name already spells the product out ("Max 的 Kimi Code" no longer gets a redundant "Kimi Code" tag); the tag returns once the user renames the agent.
- Connect Agent wizard: the customize-name input prefills the same default, and the done screen shows the same label the sidebar will.

**Not in scope**: backfill of existing heterogeneous agents' random names; the profile "name it for me" / identity-modal dice buttons still draw personal names.

| Before | After |
| ------ | ----- |
| Hetero agent named "陆令言" with tag "Claude Code" | Named "Max 的 Claude Code", no redundant tag |

#### Test

- [x] Tested locally
- [x] Added/updated tests

Store tests cover the hetero naming path (signed-in and anonymous) and the existing personal-name seeding; displayName tests cover the tag suppression/restore behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)