### PR TITLE
fix(model-runtime): preserve UTF-8 and split SSE lines across chunk boundaries

### DIFF
--- a/packages/model-runtime/src/core/streams/protocol.test.ts
+++ b/packages/model-runtime/src/core/streams/protocol.test.ts
@@ -99,6 +99,45 @@ describe('createSSEDataExtractor', () => {
     expect(results).toEqual([{ message: 'hello' }]);
   });
 
+  // Helper to feed several byte-level chunks (as they arrive from the
+  // network) through the same transformer instance.
+  const processChunks = async (transformer: TransformStream, chunks: Uint8Array[]) => {
+    const results: any[] = [];
+    const readable = new ReadableStream({
+      start(controller) {
+        for (const c of chunks) controller.enqueue(c);
+        controller.close();
+      },
+    });
+    const writable = new WritableStream({
+      write(chunk) {
+        results.push(chunk);
+      },
+    });
+    await readable.pipeThrough(transformer).pipeTo(writable);
+    return results;
+  };
+
+  it('should handle a multibyte utf8 char split across chunks', async () => {
+    const transformer = createSSEDataExtractor();
+    const full = stringToUint8Array('data: {"message": "\u{1F60A}"}\n');
+    // Split inside the 4-byte emoji so each chunk holds a partial sequence.
+    const splitAt = full.indexOf(0xf0) + 2;
+    const results = await processChunks(transformer, [full.slice(0, splitAt), full.slice(splitAt)]);
+
+    expect(results).toEqual([{ message: '\u{1F60A}' }]);
+  });
+
+  it('should handle a data line split across chunks', async () => {
+    const transformer = createSSEDataExtractor();
+    const results = await processChunks(transformer, [
+      stringToUint8Array('data: {"message": "hel'),
+      stringToUint8Array('lo"}\n'),
+    ]);
+
+    expect(results).toEqual([{ message: 'hello' }]);
+  });
+
   it('should process large chunks of data correctly', async () => {
     const transformer = createSSEDataExtractor();
     const messages = Array.from({ length: 100 })

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -687,36 +687,61 @@ export const createFirstErrorHandleTransformer = (
 /**
  * create a transformer to remove SSE format data
  */
-export const createSSEDataExtractor = () =>
-  new TransformStream({
+export const createSSEDataExtractor = () => {
+  // A single decoder instance is reused across chunks so a multi-byte UTF-8
+  // character split over a network chunk boundary is buffered (via
+  // `stream: true`) instead of being decoded into replacement characters.
+  const decoder = new TextDecoder();
+  // Holds the trailing partial line until its terminating newline arrives in
+  // a later chunk, so a `data:` line split across chunks is not dropped.
+  let buffer = '';
+
+  const processLine = (line: string, controller: TransformStreamDefaultController) => {
+    // Only process lines starting with "data: "
+    if (!line.startsWith('data: ')) return;
+
+    // Extract the actual data after "data: "
+    const jsonText = line.slice(6);
+
+    // Skip heartbeat messages
+    if (jsonText === '[DONE]') return;
+
+    try {
+      // Parse JSON data
+      const data = JSON.parse(jsonText);
+      // Pass parsed data to the next processor
+      controller.enqueue(data);
+    } catch {
+      console.warn('Failed to parse SSE data:', jsonText);
+    }
+  };
+
+  return new TransformStream({
+    flush(controller) {
+      // Flush any bytes still buffered in the decoder, then process the final
+      // line, which may not be newline-terminated.
+      buffer += decoder.decode();
+      if (buffer) processLine(buffer, controller);
+      buffer = '';
+    },
     transform(chunk: Uint8Array, controller) {
-      // Convert Uint8Array to string
-      const text = new TextDecoder().decode(chunk, { stream: true });
+      // Convert Uint8Array to string, buffering incomplete multi-byte sequences
+      buffer += decoder.decode(chunk, { stream: true });
 
-      // Handle multi-line data case
-      const lines = text.split('\n');
+      // Only process complete (newline-terminated) lines; keep the remainder
+      // buffered until the rest of that line arrives in a later chunk.
+      const lastNewline = buffer.lastIndexOf('\n');
+      if (lastNewline === -1) return;
 
-      for (const line of lines) {
-        // Only process lines starting with "data: "
-        if (line.startsWith('data: ')) {
-          // Extract the actual data after "data: "
-          const jsonText = line.slice(6);
+      const completeLines = buffer.slice(0, lastNewline);
+      buffer = buffer.slice(lastNewline + 1);
 
-          // Skip heartbeat messages
-          if (jsonText === '[DONE]') continue;
-
-          try {
-            // Parse JSON data
-            const data = JSON.parse(jsonText);
-            // Pass parsed data to the next processor
-            controller.enqueue(data);
-          } catch {
-            console.warn('Failed to parse SSE data:', jsonText);
-          }
-        }
+      for (const line of completeLines.split('\n')) {
+        processLine(line, controller);
       }
     },
   });
+};
 
 export const TOKEN_SPEED_CHUNK_ID = 'output_speed';
 


### PR DESCRIPTION
`createSSEDataExtractor()` in `packages/model-runtime/src/core/streams/protocol.ts` (used by the azureai provider) had two chunk-boundary bugs:

1. It created `new TextDecoder().decode(chunk, { stream: true })` **per chunk**, discarding the streaming buffer — a multibyte UTF-8 character split across two network chunks decoded to U+FFFD (corruption).
2. It ran `text.split("\n")` on each chunk in isolation — a `data: {...}` line split across chunks failed `JSON.parse` and was silently dropped.

Both are triggered by ordinary TCP fragmentation of the provider stream (no attacker needed; a reliability defect). Fix: a single persistent `TextDecoder` plus buffering of the trailing partial line until its newline arrives, with a flush for a final newline-less line.

RED/GREEN with the repo runner (vitest): the two new tests fail before the fix (replacement chars; dropped line) and pass after. Full `core/streams` + `azureai` suites: 274/274, azure snapshot unchanged.