### PR TITLE
🐛 fix: prevent agent document edits from clearing content

### DIFF
--- a/apps/server/src/services/agentDocuments/headlessEditor.test.ts
+++ b/apps/server/src/services/agentDocuments/headlessEditor.test.ts
@@ -78,6 +78,21 @@ describe('agent document headless editor', () => {
 
     expect(snapshot.content).toBe('Fallback content\n');
     expect(snapshot.litexml).toContain('Fallback content');
+    expect(snapshot.recoveredFromMarkdown).toBe(true);
+
+    const textId = getSpanId(snapshot.litexml!, 'Fallback content');
+    const modified = await applyLiteXMLOperations({
+      editorData: snapshot.editorData,
+      fallbackContent: snapshot.content,
+      operations: [
+        {
+          action: 'modify',
+          litexml: `<span id="${textId}">Updated after recovery</span>`,
+        },
+      ],
+    });
+
+    expect(modified.content).toBe('Updated after recovery\n');
   });
 
   it('should insert a LiteXML fragment with multiple top-level nodes', async () => {

--- a/apps/server/src/services/agentDocuments/headlessEditor.test.ts
+++ b/apps/server/src/services/agentDocuments/headlessEditor.test.ts
@@ -66,4 +66,77 @@ describe('agent document headless editor', () => {
     // can render a review UI when the user next opens the document.
     expect(hasNodeType(snapshot.editorData, 'diff')).toBe(true);
   });
+
+  it('should fall back to Markdown when valid editor data hydrates to an empty document', async () => {
+    const empty = await createMarkdownEditorSnapshot('');
+
+    const snapshot = await exportEditorDataSnapshot({
+      editorData: empty.editorData,
+      fallbackContent: 'Fallback content',
+      litexml: true,
+    });
+
+    expect(snapshot.content).toBe('Fallback content\n');
+    expect(snapshot.litexml).toContain('Fallback content');
+  });
+
+  it('should insert a LiteXML fragment with multiple top-level nodes', async () => {
+    const initial = await exportEditorDataSnapshot({
+      fallbackContent: 'Original',
+      litexml: true,
+    });
+    const textId = getSpanId(initial.litexml!, 'Original');
+
+    const snapshot = await applyLiteXMLOperations({
+      editorData: initial.editorData,
+      fallbackContent: initial.content,
+      operations: [
+        {
+          action: 'insert',
+          afterId: textId,
+          litexml: '<h2>Evidence</h2><p>Verified</p>',
+        },
+      ],
+    });
+
+    expect(snapshot.content).toContain('## Evidence');
+    expect(snapshot.content).toContain('Verified');
+  });
+
+  it('should reject a node edit that unexpectedly clears a non-empty document', async () => {
+    const initial = await exportEditorDataSnapshot({
+      fallbackContent: 'Original',
+      litexml: true,
+    });
+    const textId = getSpanId(initial.litexml!, 'Original');
+
+    await expect(
+      applyLiteXMLOperations({
+        editorData: initial.editorData,
+        fallbackContent: initial.content,
+        operations: [{ action: 'remove', id: textId }],
+      }),
+    ).rejects.toThrow('unexpectedly produced empty content');
+  });
+
+  it('should reject a node edit that silently makes no change', async () => {
+    const initial = await exportEditorDataSnapshot({
+      fallbackContent: 'Original',
+      litexml: true,
+    });
+
+    await expect(
+      applyLiteXMLOperations({
+        editorData: initial.editorData,
+        fallbackContent: initial.content,
+        operations: [
+          {
+            action: 'insert',
+            afterId: 'missing-node',
+            litexml: '<p>New content</p>',
+          },
+        ],
+      }),
+    ).rejects.toThrow('did not change the document');
+  });
 });

--- a/apps/server/src/services/agentDocuments/headlessEditor.ts
+++ b/apps/server/src/services/agentDocuments/headlessEditor.ts
@@ -43,6 +43,12 @@ const orderLiteXMLOperations = (
   return orderedOperations;
 };
 
+const normalizeLiteXMLFragment = (litexml: string) => {
+  const trimmed = litexml.trim();
+
+  return trimmed.startsWith('<root>') ? trimmed : `<root>${trimmed}</root>`;
+};
+
 const toHeadlessLiteXMLOperation = (
   operation: AgentDocumentLiteXMLOperation,
 ): HeadlessLiteXMLOperation => {
@@ -53,13 +59,13 @@ const toHeadlessLiteXMLOperation = (
             action: 'insert',
             beforeId: operation.beforeId,
             delay: true,
-            litexml: operation.litexml,
+            litexml: normalizeLiteXMLFragment(operation.litexml),
           }
         : {
             action: 'insert',
             afterId: operation.afterId,
             delay: true,
-            litexml: operation.litexml,
+            litexml: normalizeLiteXMLFragment(operation.litexml),
           };
     }
 
@@ -121,21 +127,36 @@ const hydrateMarkdownOrEmptyState = (
   editor.hydrateMarkdown(content, options);
 };
 
-const loadEditorState = (
-  editor: ReturnType<(typeof import('@lobehub/editor/headless'))['createHeadlessEditor']>,
+const createEditorWithState = (
+  createHeadlessEditor: (typeof import('@lobehub/editor/headless'))['createHeadlessEditor'],
   { editorData, fallbackContent = '' }: LoadEditorStateParams,
 ) => {
+  let editor = createHeadlessEditor();
+
   if (isValidEditorData(editorData)) {
-    editor.hydrateEditorData(
-      editorData as unknown as SerializedEditorState<SerializedLexicalNode>,
-      {
-        keepId: true,
-      },
-    );
-    return;
+    try {
+      editor.hydrateEditorData(
+        editorData as unknown as SerializedEditorState<SerializedLexicalNode>,
+        {
+          keepId: true,
+        },
+      );
+
+      const hydratedContent = editor.export().markdown;
+      if (fallbackContent.trim().length === 0 || hydratedContent.trim().length > 0) return editor;
+    } catch (error) {
+      console.error('[AgentDocumentsService] Failed to hydrate editorData:', error);
+    }
+
+    // Some editor schema/version mismatches fail without throwing and leave the
+    // editor at an empty root. Recreate the editor before hydrating Markdown so
+    // no partially parsed Lexical state can leak into the fallback snapshot.
+    editor.destroy();
+    editor = createHeadlessEditor();
   }
 
   hydrateMarkdownOrEmptyState(editor, fallbackContent, { keepId: true });
+  return editor;
 };
 
 export const createMarkdownEditorSnapshot = async (
@@ -156,10 +177,9 @@ export const exportEditorDataSnapshot = async (
   params: LoadEditorStateParams & { litexml?: boolean },
 ): Promise<AgentDocumentEditorSnapshot> => {
   const { createHeadlessEditor } = await import('@lobehub/editor/headless');
-  const editor = createHeadlessEditor();
+  const editor = createEditorWithState(createHeadlessEditor, params);
 
   try {
-    loadEditorState(editor, params);
     return exportSnapshot(editor, params.litexml);
   } finally {
     editor.destroy();
@@ -174,12 +194,26 @@ export const applyLiteXMLOperations = async ({
   operations: AgentDocumentLiteXMLOperation[];
 }): Promise<AgentDocumentEditorSnapshot> => {
   const { createHeadlessEditor } = await import('@lobehub/editor/headless');
-  const editor = createHeadlessEditor();
+  const editor = createEditorWithState(createHeadlessEditor, { editorData, fallbackContent });
 
   try {
-    loadEditorState(editor, { editorData, fallbackContent });
+    const beforeSnapshot = exportSnapshot(editor, true);
     await editor.applyLiteXML(orderLiteXMLOperations(operations).map(toHeadlessLiteXMLOperation));
-    return exportSnapshot(editor, true);
+    const snapshot = exportSnapshot(editor, true);
+
+    if (fallbackContent?.trim().length && snapshot.content.trim().length === 0) {
+      throw new Error('Agent document node edit unexpectedly produced empty content');
+    }
+
+    if (
+      operations.length > 0 &&
+      JSON.stringify(snapshot.editorData) === JSON.stringify(beforeSnapshot.editorData) &&
+      snapshot.litexml === beforeSnapshot.litexml
+    ) {
+      throw new Error('Agent document node edit did not change the document');
+    }
+
+    return snapshot;
   } finally {
     editor.destroy();
   }

--- a/apps/server/src/services/agentDocuments/headlessEditor.ts
+++ b/apps/server/src/services/agentDocuments/headlessEditor.ts
@@ -91,6 +91,11 @@ export interface AgentDocumentEditorSnapshot {
   content: string;
   editorData: AgentDocumentEditorData;
   litexml?: string;
+  recoveredFromMarkdown?: true;
+}
+
+export interface AgentDocumentEditSnapshot extends AgentDocumentEditorSnapshot {
+  previousEditorData: AgentDocumentEditorData;
 }
 
 interface LoadEditorStateParams {
@@ -143,7 +148,9 @@ const createEditorWithState = (
       );
 
       const hydratedContent = editor.export().markdown;
-      if (fallbackContent.trim().length === 0 || hydratedContent.trim().length > 0) return editor;
+      if (fallbackContent.trim().length === 0 || hydratedContent.trim().length > 0) {
+        return { editor, recoveredFromMarkdown: false };
+      }
     } catch (error) {
       console.error('[AgentDocumentsService] Failed to hydrate editorData:', error);
     }
@@ -156,7 +163,7 @@ const createEditorWithState = (
   }
 
   hydrateMarkdownOrEmptyState(editor, fallbackContent, { keepId: true });
-  return editor;
+  return { editor, recoveredFromMarkdown: isValidEditorData(editorData) };
 };
 
 export const createMarkdownEditorSnapshot = async (
@@ -177,10 +184,12 @@ export const exportEditorDataSnapshot = async (
   params: LoadEditorStateParams & { litexml?: boolean },
 ): Promise<AgentDocumentEditorSnapshot> => {
   const { createHeadlessEditor } = await import('@lobehub/editor/headless');
-  const editor = createEditorWithState(createHeadlessEditor, params);
+  const { editor, recoveredFromMarkdown } = createEditorWithState(createHeadlessEditor, params);
 
   try {
-    return exportSnapshot(editor, params.litexml);
+    const snapshot = exportSnapshot(editor, params.litexml);
+
+    return recoveredFromMarkdown ? { ...snapshot, recoveredFromMarkdown: true } : snapshot;
   } finally {
     editor.destroy();
   }
@@ -192,9 +201,9 @@ export const applyLiteXMLOperations = async ({
   operations,
 }: LoadEditorStateParams & {
   operations: AgentDocumentLiteXMLOperation[];
-}): Promise<AgentDocumentEditorSnapshot> => {
+}): Promise<AgentDocumentEditSnapshot> => {
   const { createHeadlessEditor } = await import('@lobehub/editor/headless');
-  const editor = createEditorWithState(createHeadlessEditor, { editorData, fallbackContent });
+  const { editor } = createEditorWithState(createHeadlessEditor, { editorData, fallbackContent });
 
   try {
     const beforeSnapshot = exportSnapshot(editor, true);
@@ -213,7 +222,7 @@ export const applyLiteXMLOperations = async ({
       throw new Error('Agent document node edit did not change the document');
     }
 
-    return snapshot;
+    return { ...snapshot, previousEditorData: beforeSnapshot.editorData };
   } finally {
     editor.destroy();
   }

--- a/apps/server/src/services/agentDocuments/index.test.ts
+++ b/apps/server/src/services/agentDocuments/index.test.ts
@@ -74,8 +74,8 @@ vi.mock('@lobehub/editor/headless', () => ({
         litexml: options?.litexml ? litexml : undefined,
         markdown,
       })),
-      hydrateEditorData: vi.fn(() => {
-        markdown = 'projected';
+      hydrateEditorData: vi.fn((editorData: { root?: { recoverFromMarkdown?: boolean } }) => {
+        markdown = editorData.root?.recoverFromMarkdown ? '' : 'projected';
       }),
       hydrateMarkdown: vi.fn((content: string) => {
         markdown = content;
@@ -569,6 +569,55 @@ describe('AgentDocumentsService', () => {
   });
 
   describe('getDocumentSnapshotById', () => {
+    it('should persist repaired editor data so returned node IDs survive the next modify', async () => {
+      const agentDocumentId = '11111111-1111-4111-8111-111111111111';
+      const staleEditorData = {
+        root: {
+          children: [{ children: [], type: 'paragraph' }],
+          recoverFromMarkdown: true,
+          type: 'root',
+        },
+      };
+      const repairedEditorData = { root: { children: [] } };
+      const staleDocument = {
+        agentId: 'agent-1',
+        content: 'fallback content',
+        documentId: 'documents-1',
+        editorData: staleEditorData,
+        id: agentDocumentId,
+        title: 'Doc',
+      };
+      const repairedDocument = { ...staleDocument, editorData: repairedEditorData };
+      const modifiedDocument = {
+        ...repairedDocument,
+        content: 'xml updated',
+      };
+      mockModel.findById
+        .mockResolvedValueOnce(staleDocument)
+        .mockResolvedValueOnce(repairedDocument)
+        .mockResolvedValueOnce(modifiedDocument);
+
+      const service = new AgentDocumentsService(db, userId);
+      const readResult = await service.getDocumentSnapshotById(agentDocumentId, 'agent-1');
+      const modifyResult = await service.modifyDocumentNodesById(
+        agentDocumentId,
+        [{ action: 'modify', litexml: '<p id="node-1">xml updated</p>' }],
+        'agent-1',
+      );
+
+      expect(mockModel.update).toHaveBeenNthCalledWith(1, agentDocumentId, {
+        content: 'fallback content',
+        editorData: repairedEditorData,
+      });
+      expect(readResult?.editorData).toEqual(repairedEditorData);
+      expect(mockDocumentService.trySaveCurrentDocumentHistory).toHaveBeenCalledWith(
+        'documents-1',
+        'llm_call',
+        repairedEditorData,
+      );
+      expect(modifyResult?.content).toBe('xml updated');
+    });
+
     it('should fall back to markdown content when editor data is empty', async () => {
       const agentDocumentId = '11111111-1111-4111-8111-111111111111';
       mockModel.findById.mockResolvedValue({
@@ -808,6 +857,7 @@ lossless tool result
       expect(mockDocumentService.trySaveCurrentDocumentHistory).toHaveBeenCalledWith(
         'documents-1',
         'llm_call',
+        { root: { children: [] } },
       );
       expect(mockModel.update).toHaveBeenCalledWith('agent-doc-1', {
         content: 'xml updated',

--- a/apps/server/src/services/agentDocuments/index.ts
+++ b/apps/server/src/services/agentDocuments/index.ts
@@ -209,18 +209,20 @@ export class AgentDocumentsService {
       litexml: true,
     });
 
-    // Hydration of stale editorData (older Lexical schemas) can silently fail
-    // and leave the editor empty. When that happens, hydrate from the markdown
-    // column directly so readDocument never returns an empty doc for a row that
-    // actually has content.
-    if (snapshot.content.trim().length === 0 && doc.content.trim().length > 0) {
-      const fromMarkdown = await exportEditorDataSnapshot({
-        editorData: undefined,
-        fallbackContent: doc.content,
-        litexml: true,
+    if (snapshot.recoveredFromMarkdown) {
+      // Persist the repaired snapshot before exposing its LiteXML IDs. A later
+      // node edit must hydrate this exact state or the IDs can no longer target it.
+      await this.agentDocumentModel.update(doc.id, {
+        content: snapshot.content,
+        editorData: snapshot.editorData,
       });
-      const content = fromMarkdown.content.trim().length > 0 ? fromMarkdown.content : doc.content;
-      return { ...doc, content, litexml: fromMarkdown.litexml };
+
+      return {
+        ...doc,
+        content: snapshot.content,
+        editorData: snapshot.editorData,
+        litexml: snapshot.litexml,
+      };
     }
 
     return { ...doc, content: snapshot.content, litexml: snapshot.litexml };
@@ -768,13 +770,19 @@ export class AgentDocumentsService {
     const doc = await this.getDocumentByIdInAgent(documentId, expectedAgentId);
     if (!doc) return undefined;
 
-    await this.documentService.trySaveCurrentDocumentHistory(doc.documentId, 'llm_call');
-
     const snapshot = await applyLiteXMLOperations({
       editorData: doc.editorData,
       fallbackContent: doc.content,
       operations,
     });
+
+    // History must capture the successfully hydrated pre-edit state. Persisted
+    // editorData may be the stale payload that forced Markdown recovery.
+    await this.documentService.trySaveCurrentDocumentHistory(
+      doc.documentId,
+      'llm_call',
+      snapshot.previousEditorData,
+    );
 
     await this.agentDocumentModel.update(documentId, {
       content: snapshot.content,

--- a/apps/server/src/services/document/__tests__/index.test.ts
+++ b/apps/server/src/services/document/__tests__/index.test.ts
@@ -1519,6 +1519,29 @@ describe('DocumentService', () => {
   });
 
   describe('trySaveCurrentDocumentHistory', () => {
+    it('should save an explicit repaired editor state instead of the persisted stale state', async () => {
+      const staleEditorData = {
+        root: { children: [{ children: [], type: 'paragraph' }], type: 'root' },
+      };
+      const repairedEditorData = {
+        root: { children: [{ children: [], id: 'repaired', type: 'paragraph' }], type: 'root' },
+      };
+      mockDocumentModel.findById.mockResolvedValue({
+        editorData: staleEditorData,
+        id: 'doc-1',
+      });
+      mockDocumentHistoryService.createHistory.mockResolvedValue({
+        id: 'history-1',
+        savedAt: new Date(),
+      });
+
+      await service.trySaveCurrentDocumentHistory('doc-1', 'llm_call', repairedEditorData);
+
+      expect(mockDocumentHistoryService.createHistory).toHaveBeenCalledWith(
+        expect.objectContaining({ editorData: repairedEditorData }),
+      );
+    });
+
     it('should create a history entry from the current document editor data', async () => {
       const editorData = {
         root: { children: [{ children: [], type: 'paragraph' }], type: 'root' },

--- a/apps/server/src/services/document/index.ts
+++ b/apps/server/src/services/document/index.ts
@@ -531,10 +531,11 @@ export class DocumentService {
   async trySaveCurrentDocumentHistory(
     documentId: string,
     saveSource: DocumentHistorySaveSource,
+    editorDataOverride?: Record<string, any>,
   ): Promise<SaveDocumentHistoryResult | undefined> {
     try {
       const currentDocument = await this.documentModel.findById(documentId);
-      const editorData = currentDocument?.editorData;
+      const editorData = editorDataOverride ?? currentDocument?.editorData;
       if (!isValidEditorData(editorData)) return undefined;
 
       const normalizedEditorData = normalizeEditorDataDiffNodes(editorData);


### PR DESCRIPTION
## Summary

- normalize multi-root LiteXML insert fragments before applying node operations
- fall back to Markdown when persisted editor data cannot be hydrated into non-empty content
- persist the repaired snapshot before returning LiteXML IDs so read-to-modify targeting remains stable
- save the repaired pre-operation editor state in document history
- reject edits that unexpectedly clear a non-empty document or silently miss every node
- add regression coverage for the complete recovery read-to-modify flow and history restoration state

## Verification

- `@lobehub/editor@4.24.1` (latest)
- 143 Agent Document and Document Service tests passed
- `bun run check` passed for all changed files
- full TypeScript check passed

## Context

The failure previously allowed a structurally unsuccessful headless edit to return success and persist an empty snapshot. Recovery used to exist only in a temporary editor, which also made returned node IDs and history snapshots unreliable. This change persists the recovered state before exposing IDs and passes that same pre-edit state into history creation.