### PR TITLE
🐛 fix(desktop): stop bundling web SPA artifacts into the renderer dist

### DIFF
--- a/apps/desktop/vite.renderer.config.ts
+++ b/apps/desktop/vite.renderer.config.ts
@@ -15,6 +15,7 @@ import {
   sharedRendererDefine,
   sharedRendererPlugins,
 } from '../../plugins/vite/sharedRendererConfig';
+import { spaPublicDirNames } from '../../scripts/copySpaBuildCore';
 import {
   applyDesktopViteConfigExtension,
   CLOUD_ROOT_DIR,
@@ -28,18 +29,19 @@ import {
 } from './vite.shared';
 
 const RENDERER_OUT_DIR = path.resolve(__dirname, 'dist/renderer');
-const WEB_SPA_BUILD_DIRECTORIES = ['_spa', '_spa-auth'];
 
 /**
  * The repository public directory can contain ignored web build outputs after
  * local SPA builds. Vite copies the whole directory by default, so remove only
  * those generated web outputs from the generated desktop renderer directory.
+ * The directory list is derived from the copy script's targets so a newly
+ * added SPA surface cannot silently ride into the desktop bundle again.
  */
 function excludeWebSpaBuildArtifactsPlugin(): PluginOption {
   return {
     async closeBundle() {
       await Promise.all(
-        WEB_SPA_BUILD_DIRECTORIES.map((directory) =>
+        spaPublicDirNames.map((directory) =>
           rm(path.join(RENDERER_OUT_DIR, directory), { force: true, recursive: true }),
         ),
       );

--- a/scripts/copySpaBuild.test.ts
+++ b/scripts/copySpaBuild.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { copySpaBuild } from './copySpaBuildCore';
+import { copySpaBuild, spaPublicDirNames } from './copySpaBuildCore';
 
 const testRoots: string[] = [];
 
@@ -65,6 +65,16 @@ describe('copySpaBuild', () => {
     });
 
     expect(existsSync(path.join(root, 'public/_spa/model-bank/catalog.js'))).toBe(true);
+  });
+
+  // The desktop renderer build copies the repo `public/` wholesale and prunes
+  // these directories afterwards; a target whose publicDir escapes this list
+  // ships its whole SPA inside the Electron asar.
+  it('derives a public dir name for every copy target', () => {
+    expect(spaPublicDirNames.sort()).toEqual(['_spa', '_spa-auth', '_spa-share', '_spa-workbench']);
+    for (const name of spaPublicDirNames) {
+      expect(name).toMatch(/^_spa/);
+    }
   });
 
   it('publishes Workbench chunks under an isolated public asset root', () => {

--- a/scripts/copySpaBuildCore.ts
+++ b/scripts/copySpaBuildCore.ts
@@ -17,6 +17,10 @@ const targets = [
   { distDir: 'share', publicDir: 'public/_spa-share' },
 ] as const;
 
+export const spaPublicDirNames = [
+  ...new Set(targets.map(({ publicDir }) => publicDir.split('/')[1])),
+];
+
 export const copySpaBuild = (root = path.resolve(import.meta.dirname, '..')) => {
   for (const { distDir, publicDir } of targets) {
     const distRoot = path.resolve(root, `dist/${distDir}`);


### PR DESCRIPTION
The desktop renderer Vite build uses the monorepo root as its Vite root, so the repo-level `public/` directory is copied wholesale into `dist/renderer`. The cleanup plugin only pruned a hand-written list (`_spa`, `_spa-auth`), so the later-added `_spa-workbench` (~59MB, including its own full set of shiki chunks) and `_spa-share` outputs from web SPA builds rode into the Electron `app.asar` — the desktop app never references them (verified: zero `workbench` references under `apps/desktop`).

Root fix instead of extending the hand-written list: `scripts/copySpaBuildCore.ts` (the script that publishes SPA builds into `public/`) now exports `spaPublicDirNames` derived from its own copy `targets`, and the desktop cleanup plugin prunes exactly that list. Any newly registered SPA surface is automatically excluded from the desktop bundle — the two lists can no longer drift.

Measured on a local `app.asar`: the embedded `_spa-workbench` accounted for ~59MB of uncompressed asar content.

#### Test

- [x] Tested locally
- [x] Added/updated tests

`bun run check` passes on the touched files (lint clean, 5 tests passed), including a new regression test asserting the derived dir list covers every copy target.