### PR TITLE
🐛 fix(agent): detect installed OpenClaw and Hermes

### DIFF
--- a/apps/cli/src/tools/__tests__/checkPlatformCapability.test.ts
+++ b/apps/cli/src/tools/__tests__/checkPlatformCapability.test.ts
@@ -40,4 +40,17 @@ describe('checkPlatformCapability', () => {
       reason: 'hermes was not found or failed validation',
     });
   });
+
+  it('rejects an unsupported runtime platform', async () => {
+    resolveRemotePlatformCommandMock.mockResolvedValue({
+      available: false,
+      error: 'Unknown platform: future-platform',
+    });
+
+    await expect(checkPlatformCapability({ platform: 'future-platform' })).resolves.toEqual({
+      available: false,
+      reason: 'Unknown platform: future-platform',
+    });
+    expect(resolveRemotePlatformCommandMock).toHaveBeenCalledWith('future-platform');
+  });
 });

--- a/apps/cli/src/tools/__tests__/checkPlatformCapability.test.ts
+++ b/apps/cli/src/tools/__tests__/checkPlatformCapability.test.ts
@@ -1,0 +1,43 @@
+import { resolveRemotePlatformCommand } from '@lobechat/heterogeneous-agents/scanHost';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { checkPlatformCapability } from '../checkPlatformCapability';
+
+vi.mock('@lobechat/heterogeneous-agents/scanHost', () => ({
+  resolveRemotePlatformCommand: vi.fn(),
+}));
+
+const resolveRemotePlatformCommandMock = vi.mocked(resolveRemotePlatformCommand);
+
+describe('checkPlatformCapability', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports the shared resolver result instead of probing a bare command', async () => {
+    resolveRemotePlatformCommandMock.mockResolvedValue({
+      available: true,
+      path: '/Users/x/.openclaw/bin/openclaw',
+      resolvedPathEnv: '/opt/homebrew/bin:/usr/bin:/bin',
+      version: '2026.1.29',
+    });
+
+    await expect(checkPlatformCapability({ platform: 'openclaw' })).resolves.toEqual({
+      available: true,
+      version: '2026.1.29',
+    });
+    expect(resolveRemotePlatformCommandMock).toHaveBeenCalledWith('openclaw');
+  });
+
+  it('preserves the shared validation failure reason', async () => {
+    resolveRemotePlatformCommandMock.mockResolvedValue({
+      available: false,
+      error: 'hermes was not found or failed validation',
+    });
+
+    await expect(checkPlatformCapability({ platform: 'hermes' })).resolves.toEqual({
+      available: false,
+      reason: 'hermes was not found or failed validation',
+    });
+  });
+});

--- a/apps/cli/src/tools/__tests__/getAgentProfile.test.ts
+++ b/apps/cli/src/tools/__tests__/getAgentProfile.test.ts
@@ -1,12 +1,7 @@
-import { execFile } from 'node:child_process';
-
-import { resolveRemotePlatformCommand } from '@lobechat/heterogeneous-agents/scanHost';
-import { resolveCliSpawnPlan } from '@lobechat/heterogeneous-agents/spawn';
+import { resolveRemotePlatformRuntime } from '@lobechat/heterogeneous-agents/scanHost';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getAgentProfile } from '../getAgentProfile';
-
-vi.mock('node:child_process', () => ({ execFile: vi.fn() }));
 
 vi.mock('node:fs', () => ({
   default: {
@@ -16,41 +11,27 @@ vi.mock('node:fs', () => ({
 }));
 
 vi.mock('@lobechat/heterogeneous-agents/scanHost', () => ({
-  resolveRemotePlatformCommand: vi.fn(),
+  resolveRemotePlatformRuntime: vi.fn(),
 }));
 
-vi.mock('@lobechat/heterogeneous-agents/spawn', () => ({
-  resolveCliSpawnPlan: vi.fn(),
-}));
-
-const execFileMock = vi.mocked(execFile);
-const resolveCliSpawnPlanMock = vi.mocked(resolveCliSpawnPlan);
-const resolveRemotePlatformCommandMock = vi.mocked(resolveRemotePlatformCommand);
+const executeMock = vi.fn();
+const resolveRemotePlatformRuntimeMock = vi.mocked(resolveRemotePlatformRuntime);
 
 const queueExecResult = (stdout: string) => {
-  execFileMock.mockImplementationOnce(((
-    _command: string,
-    _args: string[],
-    _options: object,
-    callback: (error: null, result: { stderr: string; stdout: string }) => void,
-  ) => {
-    callback(null, { stderr: '', stdout });
-    return {};
-  }) as never);
+  executeMock.mockResolvedValueOnce({ stderr: '', stdout });
 };
 
 describe('getAgentProfile', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    resolveCliSpawnPlanMock.mockImplementation(async (command, args) => ({ args, command }));
+    resolveRemotePlatformRuntimeMock.mockResolvedValue({
+      available: true,
+      execute: executeMock,
+      prepareSpawn: vi.fn(),
+    });
   });
 
-  it('uses the resolved OpenClaw executable and recovered PATH', async () => {
-    resolveRemotePlatformCommandMock.mockResolvedValue({
-      available: true,
-      path: '/Users/x/.openclaw/bin/openclaw',
-      resolvedPathEnv: '/opt/homebrew/bin:/usr/bin:/bin',
-    });
+  it('uses the shared OpenClaw execution runtime', async () => {
     queueExecResult(
       JSON.stringify([
         {
@@ -67,27 +48,11 @@ describe('getAgentProfile', () => {
       description: undefined,
       title: 'Claw',
     });
-    expect(resolveCliSpawnPlanMock).toHaveBeenCalledWith(
-      '/Users/x/.openclaw/bin/openclaw',
-      ['agents', 'list', '--json'],
-      expect.objectContaining({ PATH: '/opt/homebrew/bin:/usr/bin:/bin' }),
-    );
-    expect(execFileMock).toHaveBeenCalledWith(
-      '/Users/x/.openclaw/bin/openclaw',
-      ['agents', 'list', '--json'],
-      expect.objectContaining({
-        env: expect.objectContaining({ PATH: '/opt/homebrew/bin:/usr/bin:/bin' }),
-      }),
-      expect.any(Function),
-    );
+    expect(resolveRemotePlatformRuntimeMock).toHaveBeenCalledWith('openclaw');
+    expect(executeMock).toHaveBeenCalledWith(['agents', 'list', '--json'], { timeout: 5000 });
   });
 
-  it('uses one resolved Hermes executable and PATH for both profile probes', async () => {
-    resolveRemotePlatformCommandMock.mockResolvedValue({
-      available: true,
-      path: '/Users/x/.local/bin/hermes',
-      resolvedPathEnv: '/Users/x/.local/bin:/opt/homebrew/bin:/usr/bin',
-    });
+  it('uses one shared Hermes runtime for both profile probes', async () => {
     queueExecResult('  ◆default\n');
     queueExecResult('Path: ~/.hermes/profiles/default\n');
 
@@ -96,19 +61,20 @@ describe('getAgentProfile', () => {
       description: 'A careful systems engineer.',
       title: 'default',
     });
-    expect(resolveRemotePlatformCommandMock).toHaveBeenCalledTimes(1);
-    expect(execFileMock).toHaveBeenCalledTimes(2);
-    for (const call of execFileMock.mock.calls) {
-      expect((call[2] as { env: NodeJS.ProcessEnv }).env.PATH).toBe(
-        '/Users/x/.local/bin:/opt/homebrew/bin:/usr/bin',
-      );
-    }
+    expect(resolveRemotePlatformRuntimeMock).toHaveBeenCalledTimes(1);
+    expect(executeMock).toHaveBeenNthCalledWith(1, ['profile', 'list'], { timeout: 5000 });
+    expect(executeMock).toHaveBeenNthCalledWith(2, ['profile', 'show', 'default'], {
+      timeout: 5000,
+    });
   });
 
   it('does not run a bare command when resolution fails', async () => {
-    resolveRemotePlatformCommandMock.mockResolvedValue({ available: false });
+    resolveRemotePlatformRuntimeMock.mockResolvedValue({
+      available: false,
+      error: 'openclaw was not found or failed validation',
+    });
 
     await expect(getAgentProfile({ platform: 'openclaw' })).resolves.toEqual({});
-    expect(execFileMock).not.toHaveBeenCalled();
+    expect(executeMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/cli/src/tools/__tests__/getAgentProfile.test.ts
+++ b/apps/cli/src/tools/__tests__/getAgentProfile.test.ts
@@ -1,0 +1,114 @@
+import { execFile } from 'node:child_process';
+
+import { resolveRemotePlatformCommand } from '@lobechat/heterogeneous-agents/scanHost';
+import { resolveCliSpawnPlan } from '@lobechat/heterogeneous-agents/spawn';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getAgentProfile } from '../getAgentProfile';
+
+vi.mock('node:child_process', () => ({ execFile: vi.fn() }));
+
+vi.mock('node:fs', () => ({
+  default: {
+    existsSync: vi.fn(() => true),
+    readFileSync: vi.fn(() => '# Soul\nA careful systems engineer.'),
+  },
+}));
+
+vi.mock('@lobechat/heterogeneous-agents/scanHost', () => ({
+  resolveRemotePlatformCommand: vi.fn(),
+}));
+
+vi.mock('@lobechat/heterogeneous-agents/spawn', () => ({
+  resolveCliSpawnPlan: vi.fn(),
+}));
+
+const execFileMock = vi.mocked(execFile);
+const resolveCliSpawnPlanMock = vi.mocked(resolveCliSpawnPlan);
+const resolveRemotePlatformCommandMock = vi.mocked(resolveRemotePlatformCommand);
+
+const queueExecResult = (stdout: string) => {
+  execFileMock.mockImplementationOnce(((
+    _command: string,
+    _args: string[],
+    _options: object,
+    callback: (error: null, result: { stderr: string; stdout: string }) => void,
+  ) => {
+    callback(null, { stderr: '', stdout });
+    return {};
+  }) as never);
+};
+
+describe('getAgentProfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveCliSpawnPlanMock.mockImplementation(async (command, args) => ({ args, command }));
+  });
+
+  it('uses the resolved OpenClaw executable and recovered PATH', async () => {
+    resolveRemotePlatformCommandMock.mockResolvedValue({
+      available: true,
+      path: '/Users/x/.openclaw/bin/openclaw',
+      resolvedPathEnv: '/opt/homebrew/bin:/usr/bin:/bin',
+    });
+    queueExecResult(
+      JSON.stringify([
+        {
+          id: 'main',
+          identityEmoji: '🦞',
+          identityName: 'Claw',
+          isDefault: true,
+        },
+      ]),
+    );
+
+    await expect(getAgentProfile({ platform: 'openclaw' })).resolves.toEqual({
+      avatar: '🦞',
+      description: undefined,
+      title: 'Claw',
+    });
+    expect(resolveCliSpawnPlanMock).toHaveBeenCalledWith(
+      '/Users/x/.openclaw/bin/openclaw',
+      ['agents', 'list', '--json'],
+      expect.objectContaining({ PATH: '/opt/homebrew/bin:/usr/bin:/bin' }),
+    );
+    expect(execFileMock).toHaveBeenCalledWith(
+      '/Users/x/.openclaw/bin/openclaw',
+      ['agents', 'list', '--json'],
+      expect.objectContaining({
+        env: expect.objectContaining({ PATH: '/opt/homebrew/bin:/usr/bin:/bin' }),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('uses one resolved Hermes executable and PATH for both profile probes', async () => {
+    resolveRemotePlatformCommandMock.mockResolvedValue({
+      available: true,
+      path: '/Users/x/.local/bin/hermes',
+      resolvedPathEnv: '/Users/x/.local/bin:/opt/homebrew/bin:/usr/bin',
+    });
+    queueExecResult('  ◆default\n');
+    queueExecResult('Path: ~/.hermes/profiles/default\n');
+
+    await expect(getAgentProfile({ platform: 'hermes' })).resolves.toEqual({
+      avatar: '⚡',
+      description: 'A careful systems engineer.',
+      title: 'default',
+    });
+    expect(resolveRemotePlatformCommandMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+    for (const call of execFileMock.mock.calls) {
+      expect((call[2] as { env: NodeJS.ProcessEnv }).env.PATH).toBe(
+        '/Users/x/.local/bin:/opt/homebrew/bin:/usr/bin',
+      );
+    }
+  });
+
+  it('does not run a bare command when resolution fails', async () => {
+    resolveRemotePlatformCommandMock.mockResolvedValue({ available: false });
+
+    await expect(getAgentProfile({ platform: 'openclaw' })).resolves.toEqual({});
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/tools/__tests__/heteroTask.test.ts
+++ b/apps/cli/src/tools/__tests__/heteroTask.test.ts
@@ -10,8 +10,8 @@ const spawnMock = vi.hoisted(() => vi.fn());
 const execFileSyncMock = vi.hoisted(() => vi.fn());
 const fsState = vi.hoisted(() => ({ content: undefined as string | undefined }));
 const notifyMutateMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
-const resolveCliSpawnPlanMock = vi.hoisted(() => vi.fn());
-const resolveRemotePlatformCommandMock = vi.hoisted(() => vi.fn());
+const prepareSpawnMock = vi.hoisted(() => vi.fn());
+const resolveRemotePlatformRuntimeMock = vi.hoisted(() => vi.fn());
 
 vi.mock('node:child_process', () => ({
   execFileSync: execFileSyncMock,
@@ -19,11 +19,7 @@ vi.mock('node:child_process', () => ({
 }));
 
 vi.mock('@lobechat/heterogeneous-agents/scanHost', () => ({
-  resolveRemotePlatformCommand: resolveRemotePlatformCommandMock,
-}));
-
-vi.mock('@lobechat/heterogeneous-agents/spawn', () => ({
-  resolveCliSpawnPlan: resolveCliSpawnPlanMock,
+  resolveRemotePlatformRuntime: resolveRemotePlatformRuntimeMock,
 }));
 
 vi.mock('node:fs', () => ({
@@ -67,15 +63,23 @@ vi.mock('../../utils/logger', () => ({
 }));
 
 beforeEach(() => {
-  resolveRemotePlatformCommandMock.mockImplementation(async (type: 'hermes' | 'openclaw') => ({
-    available: true,
-    path: `/resolved/bin/${type}`,
-    resolvedPathEnv: '/resolved/bin:/runtime/bin:/usr/bin',
-  }));
-  resolveCliSpawnPlanMock.mockImplementation(async (command: string, args: string[]) => ({
-    args,
-    command,
-  }));
+  resolveRemotePlatformRuntimeMock.mockImplementation(
+    async (type: 'hermes' | 'openclaw', baseEnv: NodeJS.ProcessEnv) => ({
+      available: true,
+      execute: vi.fn(),
+      prepareSpawn: (args: string[]) => prepareSpawnMock(type, args, baseEnv),
+    }),
+  );
+  prepareSpawnMock.mockImplementation(
+    async (type: 'hermes' | 'openclaw', args: string[], baseEnv: NodeJS.ProcessEnv) => ({
+      args,
+      command: `/resolved/bin/${type}`,
+      env: {
+        ...baseEnv,
+        PATH: '/resolved/bin:/runtime/bin:/usr/bin',
+      },
+    }),
+  );
 });
 
 // ─── Helpers ───
@@ -360,11 +364,14 @@ describe('runHeteroTask (openclaw)', () => {
       topicId: 'topic-resolved',
     });
 
-    expect(resolveRemotePlatformCommandMock).toHaveBeenCalledWith('openclaw');
-    expect(resolveCliSpawnPlanMock).toHaveBeenCalledWith(
-      '/resolved/bin/openclaw',
+    expect(resolveRemotePlatformRuntimeMock).toHaveBeenCalledWith(
+      'openclaw',
+      expect.objectContaining({ LOBEHUB_OPERATION_ID: 'op-resolved' }),
+    );
+    expect(prepareSpawnMock).toHaveBeenCalledWith(
+      'openclaw',
       expect.any(Array),
-      expect.objectContaining({ PATH: '/resolved/bin:/runtime/bin:/usr/bin' }),
+      expect.objectContaining({ LOBEHUB_OPERATION_ID: 'op-resolved' }),
     );
     expect(spawnMock).toHaveBeenCalledWith(
       '/resolved/bin/openclaw',
@@ -595,11 +602,14 @@ describe('runHeteroTask (hermes)', () => {
       topicId: 'topic-resolved',
     });
 
-    expect(resolveRemotePlatformCommandMock).toHaveBeenCalledWith('hermes');
-    expect(resolveCliSpawnPlanMock).toHaveBeenCalledWith(
-      '/resolved/bin/hermes',
+    expect(resolveRemotePlatformRuntimeMock).toHaveBeenCalledWith(
+      'hermes',
+      expect.objectContaining({ LOBEHUB_OPERATION_ID: 'op-resolved' }),
+    );
+    expect(prepareSpawnMock).toHaveBeenCalledWith(
+      'hermes',
       ['chat', '--query', 'hello', '--quiet', '--accept-hooks'],
-      expect.objectContaining({ PATH: '/resolved/bin:/runtime/bin:/usr/bin' }),
+      expect.objectContaining({ LOBEHUB_OPERATION_ID: 'op-resolved' }),
     );
     expect(spawnMock).toHaveBeenCalledWith(
       '/resolved/bin/hermes',

--- a/apps/cli/src/tools/__tests__/heteroTask.test.ts
+++ b/apps/cli/src/tools/__tests__/heteroTask.test.ts
@@ -10,10 +10,20 @@ const spawnMock = vi.hoisted(() => vi.fn());
 const execFileSyncMock = vi.hoisted(() => vi.fn());
 const fsState = vi.hoisted(() => ({ content: undefined as string | undefined }));
 const notifyMutateMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const resolveCliSpawnPlanMock = vi.hoisted(() => vi.fn());
+const resolveRemotePlatformCommandMock = vi.hoisted(() => vi.fn());
 
 vi.mock('node:child_process', () => ({
   execFileSync: execFileSyncMock,
   spawn: spawnMock,
+}));
+
+vi.mock('@lobechat/heterogeneous-agents/scanHost', () => ({
+  resolveRemotePlatformCommand: resolveRemotePlatformCommandMock,
+}));
+
+vi.mock('@lobechat/heterogeneous-agents/spawn', () => ({
+  resolveCliSpawnPlan: resolveCliSpawnPlanMock,
 }));
 
 vi.mock('node:fs', () => ({
@@ -55,6 +65,18 @@ const getTrpcClientMock = vi.mocked(getTrpcClient);
 vi.mock('../../utils/logger', () => ({
   log: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }));
+
+beforeEach(() => {
+  resolveRemotePlatformCommandMock.mockImplementation(async (type: 'hermes' | 'openclaw') => ({
+    available: true,
+    path: `/resolved/bin/${type}`,
+    resolvedPathEnv: '/resolved/bin:/runtime/bin:/usr/bin',
+  }));
+  resolveCliSpawnPlanMock.mockImplementation(async (command: string, args: string[]) => ({
+    args,
+    command,
+  }));
+});
 
 // ─── Helpers ───
 
@@ -326,6 +348,33 @@ describe('runHeteroTask (openclaw)', () => {
     expect(spawnArgs).toContain('--local');
   });
 
+  it('spawns the resolved OpenClaw executable with its recovered PATH', async () => {
+    const child = makeMockChild();
+    spawnMock.mockReturnValue(child);
+
+    await runHeteroTask({
+      agentType: 'openclaw',
+      operationId: 'op-resolved',
+      prompt: 'hello',
+      taskId: 'task-resolved',
+      topicId: 'topic-resolved',
+    });
+
+    expect(resolveRemotePlatformCommandMock).toHaveBeenCalledWith('openclaw');
+    expect(resolveCliSpawnPlanMock).toHaveBeenCalledWith(
+      '/resolved/bin/openclaw',
+      expect.any(Array),
+      expect.objectContaining({ PATH: '/resolved/bin:/runtime/bin:/usr/bin' }),
+    );
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/resolved/bin/openclaw',
+      expect.any(Array),
+      expect.objectContaining({
+        env: expect.objectContaining({ PATH: '/resolved/bin:/runtime/bin:/usr/bin' }),
+      }),
+    );
+  });
+
   it('removes task and ignores already-exited process when killing concurrent task', async () => {
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
       throw new Error('No such process');
@@ -532,6 +581,33 @@ describe('runHeteroTask (hermes)', () => {
     expect(JSON.parse(fsState.content!)).toEqual({
       'topic-hermes': 'session-continuation',
     });
+  });
+
+  it('spawns the resolved Hermes executable with its recovered PATH', async () => {
+    const child = makeMockChild();
+    spawnMock.mockReturnValue(child);
+
+    await runHeteroTask({
+      agentType: 'hermes',
+      operationId: 'op-resolved',
+      prompt: 'hello',
+      taskId: 'task-resolved',
+      topicId: 'topic-resolved',
+    });
+
+    expect(resolveRemotePlatformCommandMock).toHaveBeenCalledWith('hermes');
+    expect(resolveCliSpawnPlanMock).toHaveBeenCalledWith(
+      '/resolved/bin/hermes',
+      ['chat', '--query', 'hello', '--quiet', '--accept-hooks'],
+      expect.objectContaining({ PATH: '/resolved/bin:/runtime/bin:/usr/bin' }),
+    );
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/resolved/bin/hermes',
+      expect.any(Array),
+      expect.objectContaining({
+        env: expect.objectContaining({ PATH: '/resolved/bin:/runtime/bin:/usr/bin' }),
+      }),
+    );
   });
 
   it('resumes the saved session and replaces it with a continuation id', async () => {

--- a/apps/cli/src/tools/checkPlatformCapability.ts
+++ b/apps/cli/src/tools/checkPlatformCapability.ts
@@ -1,7 +1,7 @@
 import { resolveRemotePlatformCommand } from '@lobechat/heterogeneous-agents/scanHost';
 
 export interface CheckPlatformCapabilityParams {
-  platform: 'hermes' | 'openclaw';
+  platform: string;
 }
 
 export interface CheckPlatformCapabilityResult {

--- a/apps/cli/src/tools/checkPlatformCapability.ts
+++ b/apps/cli/src/tools/checkPlatformCapability.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process';
+import { resolveRemotePlatformCommand } from '@lobechat/heterogeneous-agents/scanHost';
 
 export interface CheckPlatformCapabilityParams {
   platform: 'hermes' | 'openclaw';
@@ -14,48 +14,21 @@ export interface CheckPlatformCapabilityResult {
  * Probe whether a specific agent platform is available on this device.
  * Dispatched by the server via `device.checkCapability` tRPC procedure.
  *
- * - openclaw: runs `openclaw --version` and parses the output
- * - hermes:   hits the gateway health endpoint on the configured port
+ * Uses the same validated executable and PATH recovery as host scanning,
+ * profile lookup, and task execution so these surfaces cannot disagree.
  */
 export async function checkPlatformCapability(
   params: CheckPlatformCapabilityParams,
 ): Promise<CheckPlatformCapabilityResult> {
   const { platform } = params;
+  const status = await resolveRemotePlatformCommand(platform);
 
-  if (platform === 'openclaw') {
-    try {
-      const output = execFileSync('openclaw', ['--version'], {
-        encoding: 'utf8',
-        timeout: 5000,
-      }).trim();
-      // output is typically "openclaw x.y.z"
-      const version = output.split(/\s+/).at(-1);
-      return { available: true, version };
-    } catch (err) {
-      return {
-        available: false,
-        reason: err instanceof Error ? err.message : 'openclaw not found or failed to run',
-      };
-    }
+  if (!status.available) {
+    return {
+      available: false,
+      reason: status.error ?? `${platform} was not found or failed validation`,
+    };
   }
 
-  if (platform === 'hermes') {
-    try {
-      const output = execFileSync('hermes', ['--version'], {
-        encoding: 'utf8',
-        timeout: 5000,
-      }).trim();
-      // output is typically "Hermes Agent vX.Y.Z (...)"
-      const versionMatch = output.match(/v(\d+\.\d+\.\d+)/);
-      const version = versionMatch ? versionMatch[1] : output.split(/\s+/).at(-1);
-      return { available: true, version };
-    } catch (err) {
-      return {
-        available: false,
-        reason: err instanceof Error ? err.message : 'hermes not found or failed to run',
-      };
-    }
-  }
-
-  return { available: false, reason: `Unknown platform: ${platform as string}` };
+  return status.version ? { available: true, version: status.version } : { available: true };
 }

--- a/apps/cli/src/tools/getAgentProfile.ts
+++ b/apps/cli/src/tools/getAgentProfile.ts
@@ -1,14 +1,10 @@
-import { execFile } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { promisify } from 'node:util';
 
 import type { RemoteHeterogeneousAgentType } from '@lobechat/heterogeneous-agents';
-import { resolveRemotePlatformCommand } from '@lobechat/heterogeneous-agents/scanHost';
-import { resolveCliSpawnPlan } from '@lobechat/heterogeneous-agents/spawn';
-
-const execFilePromise = promisify(execFile);
+import type { RemotePlatformCommandRuntime } from '@lobechat/heterogeneous-agents/scanHost';
+import { resolveRemotePlatformRuntime } from '@lobechat/heterogeneous-agents/scanHost';
 
 export interface GetAgentProfileParams {
   /** Agent ID to query (openclaw only). Defaults to the default agent. */
@@ -53,28 +49,23 @@ interface OpenClawAgentEntry {
   workspace?: string;
 }
 
+type AvailableRemotePlatformRuntime = Extract<RemotePlatformCommandRuntime, { available: true }>;
+
 async function runPlatformCommand(
-  command: string,
+  runtime: AvailableRemotePlatformRuntime,
   args: string[],
-  env?: NodeJS.ProcessEnv,
 ): Promise<string> {
-  const spawnPlan = await resolveCliSpawnPlan(command, args, env);
-  const { stdout } = await execFilePromise(spawnPlan.command, spawnPlan.args, {
-    encoding: 'utf8',
-    env,
-    timeout: 5000,
-  });
+  const { stdout } = await runtime.execute(args, { timeout: 5000 });
   return stdout;
 }
 
 async function getOpenClawProfile(
-  command: string,
+  runtime: AvailableRemotePlatformRuntime,
   agentId?: string,
-  env?: NodeJS.ProcessEnv,
 ): Promise<AgentProfileResult> {
   let output: string;
   try {
-    output = await runPlatformCommand(command, ['agents', 'list', '--json'], env);
+    output = await runPlatformCommand(runtime, ['agents', 'list', '--json']);
   } catch {
     return {};
   }
@@ -106,11 +97,10 @@ async function getOpenClawProfile(
  * The active profile is marked with ◆ in the first column.
  */
 async function getActiveHermesProfileName(
-  command: string,
-  env?: NodeJS.ProcessEnv,
+  runtime: AvailableRemotePlatformRuntime,
 ): Promise<string | undefined> {
   try {
-    const output = await runPlatformCommand(command, ['profile', 'list'], env);
+    const output = await runPlatformCommand(runtime, ['profile', 'list']);
     const match = output.match(/◆(\S+)/);
     return match?.[1];
   } catch {
@@ -122,12 +112,11 @@ async function getActiveHermesProfileName(
  * Read the filesystem path of a Hermes profile from `hermes profile show <name>`.
  */
 async function getHermesProfilePath(
-  command: string,
+  runtime: AvailableRemotePlatformRuntime,
   profileName: string,
-  env?: NodeJS.ProcessEnv,
 ): Promise<string | undefined> {
   try {
-    const output = await runPlatformCommand(command, ['profile', 'show', profileName], env);
+    const output = await runPlatformCommand(runtime, ['profile', 'show', profileName]);
     const match = output.match(/^Path:\s+(.+)/m);
     const raw = match?.[1]?.trim();
     // Expand leading `~` — Node does not auto-expand home-dir shorthands.
@@ -166,13 +155,12 @@ function readHermesSoulDescription(soulPath: string): string | undefined {
 }
 
 async function getHermesProfile(
-  command: string,
-  env?: NodeJS.ProcessEnv,
+  runtime: AvailableRemotePlatformRuntime,
 ): Promise<AgentProfileResult> {
-  const profileName = await getActiveHermesProfileName(command, env);
+  const profileName = await getActiveHermesProfileName(runtime);
   if (!profileName) return {};
 
-  const profilePath = await getHermesProfilePath(command, profileName, env);
+  const profilePath = await getHermesProfilePath(runtime, profileName);
   const description = profilePath
     ? readHermesSoulDescription(path.join(profilePath, 'SOUL.md'))
     : undefined;
@@ -194,19 +182,15 @@ async function getHermesProfile(
  */
 export async function getAgentProfile(params: GetAgentProfileParams): Promise<AgentProfileResult> {
   const { platform, agentId } = params;
-  const commandStatus = await resolveRemotePlatformCommand(platform);
-  if (!commandStatus.available || !commandStatus.path) return {};
-
-  const env = commandStatus.resolvedPathEnv
-    ? { ...process.env, PATH: commandStatus.resolvedPathEnv }
-    : undefined;
+  const runtime = await resolveRemotePlatformRuntime(platform);
+  if (!runtime.available) return {};
 
   if (platform === 'openclaw') {
-    return getOpenClawProfile(commandStatus.path, agentId, env);
+    return getOpenClawProfile(runtime, agentId);
   }
 
   if (platform === 'hermes') {
-    return getHermesProfile(commandStatus.path, env);
+    return getHermesProfile(runtime);
   }
 
   return {};

--- a/apps/cli/src/tools/getAgentProfile.ts
+++ b/apps/cli/src/tools/getAgentProfile.ts
@@ -1,9 +1,14 @@
-import { execFileSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { promisify } from 'node:util';
 
 import type { RemoteHeterogeneousAgentType } from '@lobechat/heterogeneous-agents';
+import { resolveRemotePlatformCommand } from '@lobechat/heterogeneous-agents/scanHost';
+import { resolveCliSpawnPlan } from '@lobechat/heterogeneous-agents/spawn';
+
+const execFilePromise = promisify(execFile);
 
 export interface GetAgentProfileParams {
   /** Agent ID to query (openclaw only). Defaults to the default agent. */
@@ -48,13 +53,28 @@ interface OpenClawAgentEntry {
   workspace?: string;
 }
 
-function getOpenClawProfile(agentId?: string): AgentProfileResult {
+async function runPlatformCommand(
+  command: string,
+  args: string[],
+  env?: NodeJS.ProcessEnv,
+): Promise<string> {
+  const spawnPlan = await resolveCliSpawnPlan(command, args, env);
+  const { stdout } = await execFilePromise(spawnPlan.command, spawnPlan.args, {
+    encoding: 'utf8',
+    env,
+    timeout: 5000,
+  });
+  return stdout;
+}
+
+async function getOpenClawProfile(
+  command: string,
+  agentId?: string,
+  env?: NodeJS.ProcessEnv,
+): Promise<AgentProfileResult> {
   let output: string;
   try {
-    output = execFileSync('openclaw', ['agents', 'list', '--json'], {
-      encoding: 'utf8',
-      timeout: 5000,
-    });
+    output = await runPlatformCommand(command, ['agents', 'list', '--json'], env);
   } catch {
     return {};
   }
@@ -85,12 +105,12 @@ function getOpenClawProfile(agentId?: string): AgentProfileResult {
  * Read the active Hermes profile name from `hermes profile list` output.
  * The active profile is marked with ◆ in the first column.
  */
-function getActiveHermesProfileName(): string | undefined {
+async function getActiveHermesProfileName(
+  command: string,
+  env?: NodeJS.ProcessEnv,
+): Promise<string | undefined> {
   try {
-    const output = execFileSync('hermes', ['profile', 'list'], {
-      encoding: 'utf8',
-      timeout: 5000,
-    });
+    const output = await runPlatformCommand(command, ['profile', 'list'], env);
     const match = output.match(/◆(\S+)/);
     return match?.[1];
   } catch {
@@ -101,12 +121,13 @@ function getActiveHermesProfileName(): string | undefined {
 /**
  * Read the filesystem path of a Hermes profile from `hermes profile show <name>`.
  */
-function getHermesProfilePath(profileName: string): string | undefined {
+async function getHermesProfilePath(
+  command: string,
+  profileName: string,
+  env?: NodeJS.ProcessEnv,
+): Promise<string | undefined> {
   try {
-    const output = execFileSync('hermes', ['profile', 'show', profileName], {
-      encoding: 'utf8',
-      timeout: 5000,
-    });
+    const output = await runPlatformCommand(command, ['profile', 'show', profileName], env);
     const match = output.match(/^Path:\s+(.+)/m);
     const raw = match?.[1]?.trim();
     // Expand leading `~` — Node does not auto-expand home-dir shorthands.
@@ -144,11 +165,14 @@ function readHermesSoulDescription(soulPath: string): string | undefined {
   }
 }
 
-function getHermesProfile(): AgentProfileResult {
-  const profileName = getActiveHermesProfileName();
+async function getHermesProfile(
+  command: string,
+  env?: NodeJS.ProcessEnv,
+): Promise<AgentProfileResult> {
+  const profileName = await getActiveHermesProfileName(command, env);
   if (!profileName) return {};
 
-  const profilePath = getHermesProfilePath(profileName);
+  const profilePath = await getHermesProfilePath(command, profileName, env);
   const description = profilePath
     ? readHermesSoulDescription(path.join(profilePath, 'SOUL.md'))
     : undefined;
@@ -170,13 +194,19 @@ function getHermesProfile(): AgentProfileResult {
  */
 export async function getAgentProfile(params: GetAgentProfileParams): Promise<AgentProfileResult> {
   const { platform, agentId } = params;
+  const commandStatus = await resolveRemotePlatformCommand(platform);
+  if (!commandStatus.available || !commandStatus.path) return {};
+
+  const env = commandStatus.resolvedPathEnv
+    ? { ...process.env, PATH: commandStatus.resolvedPathEnv }
+    : undefined;
 
   if (platform === 'openclaw') {
-    return getOpenClawProfile(agentId);
+    return getOpenClawProfile(commandStatus.path, agentId, env);
   }
 
   if (platform === 'hermes') {
-    return getHermesProfile();
+    return getHermesProfile(commandStatus.path, env);
   }
 
   return {};

--- a/apps/cli/src/tools/heteroTask.ts
+++ b/apps/cli/src/tools/heteroTask.ts
@@ -4,8 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import type { RemoteHeterogeneousAgentType } from '@lobechat/heterogeneous-agents';
-import { resolveRemotePlatformCommand } from '@lobechat/heterogeneous-agents/scanHost';
-import { resolveCliSpawnPlan } from '@lobechat/heterogeneous-agents/spawn';
+import { resolveRemotePlatformRuntime } from '@lobechat/heterogeneous-agents/scanHost';
 
 import { getTrpcClient } from '../api/client';
 import { getTask, listTasks, removeTask, saveTask } from '../daemon/taskRegistry';
@@ -198,11 +197,10 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
   const sessionKey = parentOperationId ? operationId : topicId;
 
   if (agentType === 'openclaw') {
-    const commandStatus = await resolveRemotePlatformCommand('openclaw');
-    if (!commandStatus.available || !commandStatus.path) {
+    const runtime = await resolveRemotePlatformRuntime('openclaw', childEnv);
+    if (!runtime.available) {
       throw new Error('OpenClaw executable not found');
     }
-    if (commandStatus.resolvedPathEnv) childEnv.PATH = commandStatus.resolvedPathEnv;
 
     // openclaw agent --local is one-shot: each invocation processes one message and exits.
     // The --session-id links turns into the same conversation history on disk.
@@ -222,7 +220,7 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
       enrichedPrompt,
       '--local',
     ];
-    const spawnPlan = await resolveCliSpawnPlan(commandStatus.path, openclawArgs, childEnv);
+    const spawnPlan = await runtime.prepareSpawn(openclawArgs);
 
     // Top-level turns reuse one topic session and replace an older process. Group
     // members intentionally share a topic, so isolate them by operation instead.
@@ -246,7 +244,7 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
     const child = spawn(spawnPlan.command, spawnPlan.args, {
       cwd: workDir,
       detached: true,
-      env: childEnv,
+      env: spawnPlan.env,
       stdio: 'ignore',
     });
 
@@ -306,11 +304,10 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
   }
 
   if (agentType === 'hermes') {
-    const commandStatus = await resolveRemotePlatformCommand('hermes');
-    if (!commandStatus.available || !commandStatus.path) {
+    const runtime = await resolveRemotePlatformRuntime('hermes', childEnv);
+    if (!runtime.available) {
       throw new Error('Hermes executable not found');
     }
-    if (commandStatus.resolvedPathEnv) childEnv.PATH = commandStatus.resolvedPathEnv;
 
     // Resume the previous session for this topic if one exists.
     const existingSessionId = getHermesSessionId(sessionKey);
@@ -318,7 +315,7 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
     if (existingSessionId) {
       hermesArgs.push('--resume', existingSessionId);
     }
-    const spawnPlan = await resolveCliSpawnPlan(commandStatus.path, hermesArgs, childEnv);
+    const spawnPlan = await runtime.prepareSpawn(hermesArgs);
 
     // Preserve parallel group members; only top-level turns replace the previous
     // topic process, while an exact task retry replaces itself.
@@ -342,7 +339,7 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
     const child = spawn(spawnPlan.command, spawnPlan.args, {
       cwd: workDir,
       detached: true,
-      env: childEnv,
+      env: spawnPlan.env,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 

--- a/apps/cli/src/tools/heteroTask.ts
+++ b/apps/cli/src/tools/heteroTask.ts
@@ -4,6 +4,8 @@ import os from 'node:os';
 import path from 'node:path';
 
 import type { RemoteHeterogeneousAgentType } from '@lobechat/heterogeneous-agents';
+import { resolveRemotePlatformCommand } from '@lobechat/heterogeneous-agents/scanHost';
+import { resolveCliSpawnPlan } from '@lobechat/heterogeneous-agents/spawn';
 
 import { getTrpcClient } from '../api/client';
 import { getTask, listTasks, removeTask, saveTask } from '../daemon/taskRegistry';
@@ -196,15 +198,31 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
   const sessionKey = parentOperationId ? operationId : topicId;
 
   if (agentType === 'openclaw') {
+    const commandStatus = await resolveRemotePlatformCommand('openclaw');
+    if (!commandStatus.available || !commandStatus.path) {
+      throw new Error('OpenClaw executable not found');
+    }
+    if (commandStatus.resolvedPathEnv) childEnv.PATH = commandStatus.resolvedPathEnv;
+
     // openclaw agent --local is one-shot: each invocation processes one message and exits.
     // The --session-id links turns into the same conversation history on disk.
-    // Requires the `openclaw` binary to be on PATH with Node >=22.19.
     const openclawAgent = platformAgentId?.trim() || process.env.OPENCLAW_AGENT_ID || 'main';
 
     // Always inject the notify protocol so openclaw knows how to report results
     // back to the LobeHub UI — even if the previous turn failed and the session
     // history was not cleanly committed.
     const enrichedPrompt = `${prompt}\n\n${buildNotifyProtocol(lhPath, topicId)}`;
+    const openclawArgs = [
+      'agent',
+      '--agent',
+      openclawAgent,
+      '--session-id',
+      sessionKey,
+      '--message',
+      enrichedPrompt,
+      '--local',
+    ];
+    const spawnPlan = await resolveCliSpawnPlan(commandStatus.path, openclawArgs, childEnv);
 
     // Top-level turns reuse one topic session and replace an older process. Group
     // members intentionally share a topic, so isolate them by operation instead.
@@ -225,25 +243,12 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
       }
     }
 
-    const child = spawn(
-      'openclaw',
-      [
-        'agent',
-        '--agent',
-        openclawAgent,
-        '--session-id',
-        sessionKey,
-        '--message',
-        enrichedPrompt,
-        '--local',
-      ],
-      {
-        cwd: workDir,
-        detached: true,
-        env: childEnv,
-        stdio: 'ignore',
-      },
-    );
+    const child = spawn(spawnPlan.command, spawnPlan.args, {
+      cwd: workDir,
+      detached: true,
+      env: childEnv,
+      stdio: 'ignore',
+    });
 
     const pid = child.pid;
     if (pid === undefined) {
@@ -301,6 +306,20 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
   }
 
   if (agentType === 'hermes') {
+    const commandStatus = await resolveRemotePlatformCommand('hermes');
+    if (!commandStatus.available || !commandStatus.path) {
+      throw new Error('Hermes executable not found');
+    }
+    if (commandStatus.resolvedPathEnv) childEnv.PATH = commandStatus.resolvedPathEnv;
+
+    // Resume the previous session for this topic if one exists.
+    const existingSessionId = getHermesSessionId(sessionKey);
+    const hermesArgs: string[] = ['chat', '--query', prompt, '--quiet', '--accept-hooks'];
+    if (existingSessionId) {
+      hermesArgs.push('--resume', existingSessionId);
+    }
+    const spawnPlan = await resolveCliSpawnPlan(commandStatus.path, hermesArgs, childEnv);
+
     // Preserve parallel group members; only top-level turns replace the previous
     // topic process, while an exact task retry replaces itself.
     for (const existing of listTasks()) {
@@ -318,16 +337,9 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
       }
     }
 
-    // Resume the previous session for this topic if one exists.
-    const existingSessionId = getHermesSessionId(sessionKey);
-    const hermesArgs: string[] = ['chat', '--query', prompt, '--quiet', '--accept-hooks'];
-    if (existingSessionId) {
-      hermesArgs.push('--resume', existingSessionId);
-    }
-
     // Hermes keeps stdout response-only in --quiet mode and prints the final
     // session_id to stderr so callers can resume the session on the next turn.
-    const child = spawn('hermes', hermesArgs, {
+    const child = spawn(spawnPlan.command, spawnPlan.args, {
       cwd: workDir,
       detached: true,
       env: childEnv,

--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -542,24 +542,31 @@ export default class GatewayConnectionCtr extends ControllerModule {
     title?: string;
   }> {
     const { platform, agentId } = args;
+    if (platform !== 'openclaw' && platform !== 'hermes') return {};
+
+    const commandStatus = await resolveRemotePlatformCommand(platform);
+    if (!commandStatus.available || !commandStatus.path) return {};
+
+    const env = commandStatus.resolvedPathEnv
+      ? { ...process.env, PATH: commandStatus.resolvedPathEnv }
+      : undefined;
 
     if (platform === 'openclaw') {
-      return this.getOpenClawProfile(agentId);
+      return this.getOpenClawProfile(commandStatus.path, agentId, env);
     }
 
-    if (platform === 'hermes') {
-      return this.getHermesProfile();
-    }
-
-    return {};
+    return this.getHermesProfile(commandStatus.path, env);
   }
 
-  private getHermesProfile(): { avatar?: string; description?: string; title?: string } {
+  private async getHermesProfile(
+    command: string,
+    env?: NodeJS.ProcessEnv,
+  ): Promise<{ avatar?: string; description?: string; title?: string }> {
     // Find the active profile (marked with ◆ in `hermes profile list`).
     let profileName: string | undefined;
     try {
-      const listOutput = execFileSync('hermes', ['profile', 'list'], {
-        encoding: 'utf8',
+      const { stdout: listOutput } = await execa(command, ['profile', 'list'], {
+        env,
         timeout: 5000,
       });
       profileName = listOutput.match(/◆(\S+)/)?.[1];
@@ -571,8 +578,8 @@ export default class GatewayConnectionCtr extends ControllerModule {
     // Get the profile's filesystem path.
     let profilePath: string | undefined;
     try {
-      const showOutput = execFileSync('hermes', ['profile', 'show', profileName], {
-        encoding: 'utf8',
+      const { stdout: showOutput } = await execa(command, ['profile', 'show', profileName], {
+        env,
         timeout: 5000,
       });
       const raw = showOutput.match(/^Path:\s+(.+)/m)?.[1]?.trim();
@@ -612,17 +619,18 @@ export default class GatewayConnectionCtr extends ControllerModule {
     }
   }
 
-  private getOpenClawProfile(agentId?: string): {
-    avatar?: string;
-    description?: string;
-    title?: string;
-  } {
+  private async getOpenClawProfile(
+    command: string,
+    agentId?: string,
+    env?: NodeJS.ProcessEnv,
+  ): Promise<{ avatar?: string; description?: string; title?: string }> {
     let output: string;
     try {
-      output = execFileSync('openclaw', ['agents', 'list', '--json'], {
-        encoding: 'utf8',
+      const result = await execa(command, ['agents', 'list', '--json'], {
+        env,
         timeout: 5000,
       });
+      output = result.stdout;
     } catch {
       return {};
     }

--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -6,9 +6,12 @@ import path from 'node:path';
 import type { DeviceControlDeps } from '@lobechat/device-control';
 import type { AgentRunRequestMessage, GatewayMcpParams } from '@lobechat/device-gateway-client';
 import type { GatewayConnectionStatus } from '@lobechat/electron-client-ipc';
-import { resolveRemotePlatformCommand } from '@lobechat/heterogeneous-agents/scanHost';
+import type { RemotePlatformCommandRuntime } from '@lobechat/heterogeneous-agents/scanHost';
+import {
+  resolveRemotePlatformCommand,
+  resolveRemotePlatformRuntime,
+} from '@lobechat/heterogeneous-agents/scanHost';
 import { type ILocalSystemService, LocalSystemExecutionRuntime } from '@lobechat/tool-runtime';
-import { execa } from 'execa';
 
 import GatewayConnectionService from '@/services/gatewayConnectionSrv';
 import ImessageBridgeService from '@/services/imessageBridgeSrv';
@@ -24,6 +27,8 @@ import RemoteServerConfigCtr from './RemoteServerConfigCtr';
 import ShellCommandCtr from './ShellCommandCtr';
 
 const logger = createLogger('controllers:GatewayConnectionCtr');
+
+type AvailableRemotePlatformRuntime = Extract<RemotePlatformCommandRuntime, { available: true }>;
 
 // Mirror of `BrowserManifest.identifier` from `@lobechat/builtin-tool-browser`.
 // Hardcoded (not imported) so the desktop main process keeps zero builtin-tool
@@ -517,20 +522,12 @@ export default class GatewayConnectionCtr extends ControllerModule {
     platform: string;
   }): Promise<{ available: boolean; reason?: string; version?: string }> {
     const { platform } = args;
-
-    const platformMap: Record<string, 'hermes' | 'openclaw'> = {
-      hermes: 'hermes',
-      openclaw: 'openclaw',
-    };
-
-    const platformType = platformMap[platform];
-    if (!platformType) {
-      return { available: false, reason: `Unknown platform: ${platform}` };
-    }
-
-    const status = await resolveRemotePlatformCommand(platformType);
+    const status = await resolveRemotePlatformCommand(platform);
     if (!status.available) {
-      return { available: false, reason: `${platform} is not installed on this device` };
+      return {
+        available: false,
+        reason: status.error ?? `${platform} is not installed on this device`,
+      };
     }
 
     return status.version ? { available: true, version: status.version } : { available: true };
@@ -544,29 +541,23 @@ export default class GatewayConnectionCtr extends ControllerModule {
     const { platform, agentId } = args;
     if (platform !== 'openclaw' && platform !== 'hermes') return {};
 
-    const commandStatus = await resolveRemotePlatformCommand(platform);
-    if (!commandStatus.available || !commandStatus.path) return {};
-
-    const env = commandStatus.resolvedPathEnv
-      ? { ...process.env, PATH: commandStatus.resolvedPathEnv }
-      : undefined;
+    const runtime = await resolveRemotePlatformRuntime(platform);
+    if (!runtime.available) return {};
 
     if (platform === 'openclaw') {
-      return this.getOpenClawProfile(commandStatus.path, agentId, env);
+      return this.getOpenClawProfile(runtime, agentId);
     }
 
-    return this.getHermesProfile(commandStatus.path, env);
+    return this.getHermesProfile(runtime);
   }
 
   private async getHermesProfile(
-    command: string,
-    env?: NodeJS.ProcessEnv,
+    runtime: AvailableRemotePlatformRuntime,
   ): Promise<{ avatar?: string; description?: string; title?: string }> {
     // Find the active profile (marked with ◆ in `hermes profile list`).
     let profileName: string | undefined;
     try {
-      const { stdout: listOutput } = await execa(command, ['profile', 'list'], {
-        env,
+      const { stdout: listOutput } = await runtime.execute(['profile', 'list'], {
         timeout: 5000,
       });
       profileName = listOutput.match(/◆(\S+)/)?.[1];
@@ -578,8 +569,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
     // Get the profile's filesystem path.
     let profilePath: string | undefined;
     try {
-      const { stdout: showOutput } = await execa(command, ['profile', 'show', profileName], {
-        env,
+      const { stdout: showOutput } = await runtime.execute(['profile', 'show', profileName], {
         timeout: 5000,
       });
       const raw = showOutput.match(/^Path:\s+(.+)/m)?.[1]?.trim();
@@ -620,14 +610,12 @@ export default class GatewayConnectionCtr extends ControllerModule {
   }
 
   private async getOpenClawProfile(
-    command: string,
+    runtime: AvailableRemotePlatformRuntime,
     agentId?: string,
-    env?: NodeJS.ProcessEnv,
   ): Promise<{ avatar?: string; description?: string; title?: string }> {
     let output: string;
     try {
-      const result = await execa(command, ['agents', 'list', '--json'], {
-        env,
+      const result = await runtime.execute(['agents', 'list', '--json'], {
         timeout: 5000,
       });
       output = result.stdout;
@@ -728,11 +716,10 @@ export default class GatewayConnectionCtr extends ControllerModule {
     const sessionKey = parentOperationId ? operationId : topicId;
 
     if (agentType === 'openclaw') {
-      const commandStatus = await resolveRemotePlatformCommand('openclaw');
-      if (!commandStatus.available || !commandStatus.path) {
+      const runtime = await resolveRemotePlatformRuntime('openclaw', childEnv);
+      if (!runtime.available) {
         throw new Error('OpenClaw executable not found');
       }
-      if (commandStatus.resolvedPathEnv) childEnv.PATH = commandStatus.resolvedPathEnv;
       const lhPath = this.resolveLhPath();
       const openclawAgent = platformAgentId?.trim() || process.env['OPENCLAW_AGENT_ID'] || 'main';
 
@@ -765,21 +752,13 @@ export default class GatewayConnectionCtr extends ControllerModule {
         enrichedPrompt,
         '--local',
       ];
-      const child =
-        process.platform === 'win32'
-          ? execa(commandStatus.path, openclawArgs, {
-              cwd: workDir,
-              detached: true,
-              env: childEnv,
-              reject: false,
-              stdio: 'ignore',
-            })
-          : spawn(commandStatus.path, openclawArgs, {
-              cwd: workDir,
-              detached: true,
-              env: childEnv,
-              stdio: 'ignore',
-            });
+      const spawnPlan = await runtime.prepareSpawn(openclawArgs);
+      const child = spawn(spawnPlan.command, spawnPlan.args, {
+        cwd: workDir,
+        detached: true,
+        env: spawnPlan.env,
+        stdio: 'ignore',
+      });
 
       const pid = child.pid;
       if (pid === undefined) throw new Error('Failed to get PID for openclaw process');
@@ -844,11 +823,10 @@ export default class GatewayConnectionCtr extends ControllerModule {
     }
 
     if (agentType === 'hermes') {
-      const commandStatus = await resolveRemotePlatformCommand('hermes');
-      if (!commandStatus.available || !commandStatus.path) {
+      const runtime = await resolveRemotePlatformRuntime('hermes', childEnv);
+      if (!runtime.available) {
         throw new Error('Hermes executable not found');
       }
-      if (commandStatus.resolvedPathEnv) childEnv.PATH = commandStatus.resolvedPathEnv;
       // Kill any existing hermes process for this topicId before spawning a new one.
       for (const [existingTaskId, entry] of this.platformTasks) {
         if (
@@ -870,23 +848,13 @@ export default class GatewayConnectionCtr extends ControllerModule {
 
       // Hermes keeps stdout response-only in --quiet mode and prints the final
       // session_id to stderr so callers can resume the session on the next turn.
-      const child =
-        process.platform === 'win32'
-          ? execa(commandStatus.path, hermesArgs, {
-              cwd: workDir,
-              detached: true,
-              env: childEnv,
-              reject: false,
-              stderr: 'pipe',
-              stdin: 'ignore',
-              stdout: 'pipe',
-            })
-          : spawn(commandStatus.path, hermesArgs, {
-              cwd: workDir,
-              detached: true,
-              env: childEnv,
-              stdio: ['ignore', 'pipe', 'pipe'],
-            });
+      const spawnPlan = await runtime.prepareSpawn(hermesArgs);
+      const child = spawn(spawnPlan.command, spawnPlan.args, {
+        cwd: workDir,
+        detached: true,
+        env: spawnPlan.env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
 
       const pid = child.pid;
       if (pid === undefined) throw new Error('Failed to get PID for hermes process');

--- a/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
@@ -184,9 +184,11 @@ vi.mock('node:crypto', () => ({
 }));
 
 const execFileSyncMock = vi.hoisted(() => vi.fn());
-const execaMock = vi.hoisted(() => vi.fn());
 const spawnMock = vi.hoisted(() => vi.fn());
+const executeRemotePlatformMock = vi.hoisted(() => vi.fn());
+const prepareRemotePlatformSpawnMock = vi.hoisted(() => vi.fn());
 const resolveRemotePlatformCommandMock = vi.hoisted(() => vi.fn());
+const resolveRemotePlatformRuntimeMock = vi.hoisted(() => vi.fn());
 
 vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof ChildProcessModule>();
@@ -195,6 +197,7 @@ vi.mock('node:child_process', async (importOriginal) => {
 
 vi.mock('@lobechat/heterogeneous-agents/scanHost', () => ({
   resolveRemotePlatformCommand: resolveRemotePlatformCommandMock,
+  resolveRemotePlatformRuntime: resolveRemotePlatformRuntimeMock,
 }));
 
 vi.mock('node:os', () => ({
@@ -207,10 +210,6 @@ vi.mock('@lobechat/device-gateway-client', () => ({
 
 vi.mock('@/services/imessageBridgeSrv', () => ({
   default: class ImessageBridgeService {},
-}));
-
-vi.mock('execa', () => ({
-  execa: execaMock,
 }));
 
 vi.mock('fast-glob', () => ({ default: vi.fn().mockResolvedValue([]) }));
@@ -301,7 +300,21 @@ describe('GatewayConnectionCtr', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
-    execaMock.mockResolvedValue({ stderr: '', stdout: '' });
+    resolveRemotePlatformRuntimeMock.mockImplementation(
+      async (type: 'hermes' | 'openclaw', baseEnv: NodeJS.ProcessEnv = process.env) => ({
+        available: true,
+        execute: executeRemotePlatformMock,
+        prepareSpawn: (args: string[]) => prepareRemotePlatformSpawnMock(type, args, baseEnv),
+      }),
+    );
+    prepareRemotePlatformSpawnMock.mockImplementation(
+      async (type: 'hermes' | 'openclaw', args: string[], baseEnv: NodeJS.ProcessEnv) => ({
+        args,
+        command: `/resolved/bin/${type}`,
+        env: { ...baseEnv, PATH: '/resolved/bin:/usr/bin' },
+      }),
+    );
+    executeRemotePlatformMock.mockResolvedValue({ stderr: '', stdout: '' });
     MockGatewayClient.lastInstance = null;
     MockGatewayClient.lastOptions = null;
     mockStoreGet.mockImplementation((key: string) => {
@@ -1054,12 +1067,6 @@ describe('GatewayConnectionCtr', () => {
 
     beforeEach(() => {
       execFileSyncMock.mockReturnValue('/usr/local/bin/lh\n');
-      resolveRemotePlatformCommandMock.mockResolvedValue({
-        available: true,
-        path: '/resolved/bin/openclaw',
-        resolvedPathEnv: '/resolved/bin:/usr/bin',
-        version: '1.2.3',
-      });
       spawnMock.mockReset();
     });
 
@@ -1441,15 +1448,6 @@ describe('GatewayConnectionCtr', () => {
     });
 
     describe('hermes', () => {
-      beforeEach(() => {
-        resolveRemotePlatformCommandMock.mockResolvedValue({
-          available: true,
-          path: '/resolved/bin/hermes',
-          resolvedPathEnv: '/resolved/bin:/usr/bin',
-          version: '0.20.0',
-        });
-      });
-
       it('relays stdout intact and saves the final session id from stderr', async () => {
         const child = makeMockChild();
         const notifySpy = vi.spyOn(ctr as any, 'sendNotify').mockResolvedValue(undefined);
@@ -1659,6 +1657,11 @@ describe('GatewayConnectionCtr', () => {
     });
 
     it('returns available:false for unknown platform', async () => {
+      resolveRemotePlatformCommandMock.mockResolvedValue({
+        available: false,
+        error: 'Unknown platform: unknownBot',
+      });
+
       const client = await connectAndOpen();
       client.simulateToolCallRequest(
         'checkPlatformCapability',
@@ -1678,7 +1681,10 @@ describe('GatewayConnectionCtr', () => {
     });
 
     it('getAgentProfile returns empty object', async () => {
-      resolveRemotePlatformCommandMock.mockResolvedValue({ available: false });
+      resolveRemotePlatformRuntimeMock.mockResolvedValue({
+        available: false,
+        error: 'openclaw was not found or failed validation',
+      });
 
       const client = await connectAndOpen();
       client.simulateToolCallRequest('getAgentProfile', { platform: 'openclaw' }, 'req-profile');
@@ -1692,16 +1698,11 @@ describe('GatewayConnectionCtr', () => {
           success: true,
         },
       });
-      expect(execaMock).not.toHaveBeenCalled();
+      expect(executeRemotePlatformMock).not.toHaveBeenCalled();
     });
 
-    it('uses the resolved OpenClaw executable and PATH to load its profile', async () => {
-      resolveRemotePlatformCommandMock.mockResolvedValue({
-        available: true,
-        path: '/Users/x/.openclaw/bin/openclaw',
-        resolvedPathEnv: '/Users/x/.openclaw/bin:/usr/bin',
-      });
-      execaMock.mockResolvedValueOnce({
+    it('uses the shared OpenClaw runtime to load its profile', async () => {
+      executeRemotePlatformMock.mockResolvedValueOnce({
         stderr: '',
         stdout: JSON.stringify([
           {
@@ -1717,15 +1718,10 @@ describe('GatewayConnectionCtr', () => {
       client.simulateToolCallRequest('getAgentProfile', { platform: 'openclaw' }, 'req-openclaw');
       await vi.advanceTimersByTimeAsync(0);
 
-      expect(resolveRemotePlatformCommandMock).toHaveBeenCalledWith('openclaw');
-      expect(execaMock).toHaveBeenCalledWith(
-        '/Users/x/.openclaw/bin/openclaw',
-        ['agents', 'list', '--json'],
-        {
-          env: expect.objectContaining({ PATH: '/Users/x/.openclaw/bin:/usr/bin' }),
-          timeout: 5000,
-        },
-      );
+      expect(resolveRemotePlatformRuntimeMock).toHaveBeenCalledWith('openclaw');
+      expect(executeRemotePlatformMock).toHaveBeenCalledWith(['agents', 'list', '--json'], {
+        timeout: 5000,
+      });
       expect(client.sendToolCallResponse).toHaveBeenCalledWith({
         requestId: 'req-openclaw',
         result: {
@@ -1736,13 +1732,8 @@ describe('GatewayConnectionCtr', () => {
       });
     });
 
-    it('uses the resolved Hermes executable and PATH to load its profile', async () => {
-      resolveRemotePlatformCommandMock.mockResolvedValue({
-        available: true,
-        path: '/Users/x/.local/bin/hermes',
-        resolvedPathEnv: '/Users/x/.local/bin:/usr/bin',
-      });
-      execaMock
+    it('uses one shared Hermes runtime to load its profile', async () => {
+      executeRemotePlatformMock
         .mockResolvedValueOnce({ stderr: '', stdout: '◆research\n' })
         .mockResolvedValueOnce({ stderr: '', stdout: 'Path: /profiles/research\n' });
 
@@ -1750,24 +1741,14 @@ describe('GatewayConnectionCtr', () => {
       client.simulateToolCallRequest('getAgentProfile', { platform: 'hermes' }, 'req-hermes');
       await vi.advanceTimersByTimeAsync(0);
 
-      expect(resolveRemotePlatformCommandMock).toHaveBeenCalledWith('hermes');
-      expect(execaMock).toHaveBeenNthCalledWith(
-        1,
-        '/Users/x/.local/bin/hermes',
-        ['profile', 'list'],
-        {
-          env: expect.objectContaining({ PATH: '/Users/x/.local/bin:/usr/bin' }),
-          timeout: 5000,
-        },
-      );
-      expect(execaMock).toHaveBeenNthCalledWith(
+      expect(resolveRemotePlatformRuntimeMock).toHaveBeenCalledWith('hermes');
+      expect(executeRemotePlatformMock).toHaveBeenNthCalledWith(1, ['profile', 'list'], {
+        timeout: 5000,
+      });
+      expect(executeRemotePlatformMock).toHaveBeenNthCalledWith(
         2,
-        '/Users/x/.local/bin/hermes',
         ['profile', 'show', 'research'],
-        {
-          env: expect.objectContaining({ PATH: '/Users/x/.local/bin:/usr/bin' }),
-          timeout: 5000,
-        },
+        { timeout: 5000 },
       );
       expect(client.sendToolCallResponse).toHaveBeenCalledWith({
         requestId: 'req-hermes',

--- a/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
@@ -184,6 +184,7 @@ vi.mock('node:crypto', () => ({
 }));
 
 const execFileSyncMock = vi.hoisted(() => vi.fn());
+const execaMock = vi.hoisted(() => vi.fn());
 const spawnMock = vi.hoisted(() => vi.fn());
 const resolveRemotePlatformCommandMock = vi.hoisted(() => vi.fn());
 
@@ -209,7 +210,7 @@ vi.mock('@/services/imessageBridgeSrv', () => ({
 }));
 
 vi.mock('execa', () => ({
-  execa: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+  execa: execaMock,
 }));
 
 vi.mock('fast-glob', () => ({ default: vi.fn().mockResolvedValue([]) }));
@@ -300,6 +301,7 @@ describe('GatewayConnectionCtr', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    execaMock.mockResolvedValue({ stderr: '', stdout: '' });
     MockGatewayClient.lastInstance = null;
     MockGatewayClient.lastOptions = null;
     mockStoreGet.mockImplementation((key: string) => {
@@ -1676,6 +1678,8 @@ describe('GatewayConnectionCtr', () => {
     });
 
     it('getAgentProfile returns empty object', async () => {
+      resolveRemotePlatformCommandMock.mockResolvedValue({ available: false });
+
       const client = await connectAndOpen();
       client.simulateToolCallRequest('getAgentProfile', { platform: 'openclaw' }, 'req-profile');
       await vi.advanceTimersByTimeAsync(0);
@@ -1685,6 +1689,91 @@ describe('GatewayConnectionCtr', () => {
         result: {
           content: JSON.stringify({}),
           state: {},
+          success: true,
+        },
+      });
+      expect(execaMock).not.toHaveBeenCalled();
+    });
+
+    it('uses the resolved OpenClaw executable and PATH to load its profile', async () => {
+      resolveRemotePlatformCommandMock.mockResolvedValue({
+        available: true,
+        path: '/Users/x/.openclaw/bin/openclaw',
+        resolvedPathEnv: '/Users/x/.openclaw/bin:/usr/bin',
+      });
+      execaMock.mockResolvedValueOnce({
+        stderr: '',
+        stdout: JSON.stringify([
+          {
+            id: 'main',
+            identityEmoji: '🦞',
+            identityName: 'Clawd',
+            isDefault: true,
+          },
+        ]),
+      });
+
+      const client = await connectAndOpen();
+      client.simulateToolCallRequest('getAgentProfile', { platform: 'openclaw' }, 'req-openclaw');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(resolveRemotePlatformCommandMock).toHaveBeenCalledWith('openclaw');
+      expect(execaMock).toHaveBeenCalledWith(
+        '/Users/x/.openclaw/bin/openclaw',
+        ['agents', 'list', '--json'],
+        {
+          env: expect.objectContaining({ PATH: '/Users/x/.openclaw/bin:/usr/bin' }),
+          timeout: 5000,
+        },
+      );
+      expect(client.sendToolCallResponse).toHaveBeenCalledWith({
+        requestId: 'req-openclaw',
+        result: {
+          content: JSON.stringify({ avatar: '🦞', title: 'Clawd' }),
+          state: { avatar: '🦞', description: undefined, title: 'Clawd' },
+          success: true,
+        },
+      });
+    });
+
+    it('uses the resolved Hermes executable and PATH to load its profile', async () => {
+      resolveRemotePlatformCommandMock.mockResolvedValue({
+        available: true,
+        path: '/Users/x/.local/bin/hermes',
+        resolvedPathEnv: '/Users/x/.local/bin:/usr/bin',
+      });
+      execaMock
+        .mockResolvedValueOnce({ stderr: '', stdout: '◆research\n' })
+        .mockResolvedValueOnce({ stderr: '', stdout: 'Path: /profiles/research\n' });
+
+      const client = await connectAndOpen();
+      client.simulateToolCallRequest('getAgentProfile', { platform: 'hermes' }, 'req-hermes');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(resolveRemotePlatformCommandMock).toHaveBeenCalledWith('hermes');
+      expect(execaMock).toHaveBeenNthCalledWith(
+        1,
+        '/Users/x/.local/bin/hermes',
+        ['profile', 'list'],
+        {
+          env: expect.objectContaining({ PATH: '/Users/x/.local/bin:/usr/bin' }),
+          timeout: 5000,
+        },
+      );
+      expect(execaMock).toHaveBeenNthCalledWith(
+        2,
+        '/Users/x/.local/bin/hermes',
+        ['profile', 'show', 'research'],
+        {
+          env: expect.objectContaining({ PATH: '/Users/x/.local/bin:/usr/bin' }),
+          timeout: 5000,
+        },
+      );
+      expect(client.sendToolCallResponse).toHaveBeenCalledWith({
+        requestId: 'req-hermes',
+        result: {
+          content: JSON.stringify({ avatar: '⚡', title: 'research' }),
+          state: { avatar: '⚡', description: undefined, title: 'research' },
           success: true,
         },
       });

--- a/apps/desktop/src/main/modules/binaries/__tests__/cliAgentBinaries.test.ts
+++ b/apps/desktop/src/main/modules/binaries/__tests__/cliAgentBinaries.test.ts
@@ -263,20 +263,21 @@ describe('cliAgentBinaries', () => {
     });
 
     it('reports unavailable when `where` only returns unrunnable matches (.ps1 / extensionless)', async () => {
-      callExecFile(
-        [
-          'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude',
-          'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude.ps1',
-        ].join('\r\n'),
-      );
+      const unrunnableMatches = [
+        'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude',
+        'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude.ps1',
+      ];
+      callExecFile(unrunnableMatches.join('\r\n'));
 
       const { claudeCodeBinary } = await import('../cliAgentBinaries');
       const status = await claudeCodeBinary.detect();
 
       expect(status.available).toBe(false);
-      // Must not attempt to invoke the unrunnable matches.
+      // PATH recovery may issue registry queries and retry `where`, but must
+      // never attempt to invoke either unrunnable result.
       expect(execMock).not.toHaveBeenCalled();
-      expect(execFileMock).toHaveBeenCalledTimes(1); // just `where`
+      const invokedFiles = execFileMock.mock.calls.map(([file]) => file);
+      for (const match of unrunnableMatches) expect(invokedFiles).not.toContain(match);
     });
   });
 
@@ -475,8 +476,14 @@ describe('cliAgentBinaries', () => {
       const status = await detectHeterogeneousCliCommand('codex', '/custom/bin/codex');
 
       expect(status.available).toBe(false);
-      // Only the explicit path's --version attempt — no fallback probing.
-      expect(execFileMock).toHaveBeenCalledTimes(1);
+      // PATH recovery may retry the explicit launcher in a second environment,
+      // but every version probe must keep that launcher rather than switching
+      // to a built-in Codex fallback.
+      const versionProbeFiles = execFileMock.mock.calls
+        .filter(([, args]) => Array.isArray(args) && args.includes('--version'))
+        .map(([file]) => file);
+      expect(versionProbeFiles.length).toBeGreaterThan(0);
+      expect(versionProbeFiles).toEqual(versionProbeFiles.map(() => '/custom/bin/codex'));
     });
 
     it('falls back to the login shell PATH for tools installed by shell setup', async () => {

--- a/packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.test.ts
+++ b/packages/heterogeneous-agents/src/models/listHeterogeneousAgentModels.test.ts
@@ -352,11 +352,25 @@ describe('heterogeneous agent model discovery', () => {
   it('keeps the resolver login-shell PATH when the caller also provides PATH', async () => {
     const originalShell = process.env.SHELL;
     process.env.SHELL = '/bin/zsh';
-    rejectExecFile(new Error('not on inherited PATH'));
-    resolveExecFile('/login/bin:/usr/bin');
-    resolveExecFile('/login/bin/opencode\n');
-    resolveExecFile('1.18.3');
-    resolveExecFile('openai/gpt-5.6\n');
+    execFileMock.mockImplementation(((
+      file: string,
+      args: string[],
+      options: any,
+      callback: any,
+    ) => {
+      if (file === '/bin/zsh') {
+        callback(null, { stderr: '', stdout: '/login/bin:/usr/bin' });
+      } else if (file === 'which' && options.env?.PATH?.includes('/login/bin')) {
+        callback(null, { stderr: '', stdout: '/login/bin/opencode\n' });
+      } else if (file === '/login/bin/opencode' && args.includes('--version')) {
+        callback(null, { stderr: '', stdout: '1.18.3' });
+      } else if (file === '/login/bin/opencode' && args.includes('models')) {
+        callback(null, { stderr: '', stdout: 'openai/gpt-5.6\n' });
+      } else {
+        callback(new Error('unavailable in inherited environment'), { stderr: '', stdout: '' });
+      }
+      return {} as any;
+    }) as any);
 
     try {
       const { listHeterogeneousAgentModels } = await importModule();

--- a/packages/heterogeneous-agents/src/scan/scanHost.test.ts
+++ b/packages/heterogeneous-agents/src/scan/scanHost.test.ts
@@ -1,30 +1,49 @@
+import * as childProcess from 'node:child_process';
 import * as os from 'node:os';
 import path from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { probeRemotePlatform, resolveRemotePlatformCommand } from './scanHost';
+import {
+  probeRemotePlatform,
+  resolveRemotePlatformCommand,
+  resolveRemotePlatformRuntime,
+} from './scanHost';
+
+vi.mock('node:child_process', () => ({ execFile: vi.fn() }));
 
 vi.mock('node:os', async () => {
   const actual = await vi.importActual<typeof os>('node:os');
   return { ...actual, platform: vi.fn(() => 'darwin') };
 });
 
-const { detectHeterogeneousCliCommandMock, detectValidatedCommandCandidatesMock } = vi.hoisted(
-  () => ({
-    detectHeterogeneousCliCommandMock: vi.fn(),
-    detectValidatedCommandCandidatesMock: vi.fn(),
-  }),
-);
+const {
+  detectHeterogeneousCliCommandMock,
+  detectValidatedCommandCandidatesMock,
+  resolveCliSpawnPlanMock,
+} = vi.hoisted(() => ({
+  detectHeterogeneousCliCommandMock: vi.fn(),
+  detectValidatedCommandCandidatesMock: vi.fn(),
+  resolveCliSpawnPlanMock: vi.fn(),
+}));
 
 vi.mock('../spawn/resolveCliCommand', () => ({
   detectHeterogeneousCliCommand: detectHeterogeneousCliCommandMock,
   detectValidatedCommandCandidates: detectValidatedCommandCandidatesMock,
 }));
 
+vi.mock('../spawn/cliSpawn', () => ({
+  resolveCliSpawnPlan: resolveCliSpawnPlanMock,
+}));
+
+const platformMock = vi.mocked(os.platform);
+const execFileMock = vi.mocked(childProcess.execFile);
+
 describe('platform command scanning', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    platformMock.mockReturnValue('darwin');
+    resolveCliSpawnPlanMock.mockImplementation(async (command, args) => ({ args, command }));
   });
 
   it('uses the shared PATH and Windows-shim-aware command resolver', async () => {
@@ -65,6 +84,28 @@ describe('platform command scanning', () => {
     await expect(resolveRemotePlatformCommand('openclaw')).resolves.toMatchObject({
       available: true,
       version: '2026.1.29',
+    });
+  });
+
+  it('rejects unsupported platforms before probing any command', async () => {
+    await expect(resolveRemotePlatformCommand('future-platform')).resolves.toEqual({
+      available: false,
+      error: 'Unknown platform: future-platform',
+    });
+    expect(detectValidatedCommandCandidatesMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a Windows shim that cannot produce a shell-free spawn plan', async () => {
+    platformMock.mockReturnValue('win32');
+    detectValidatedCommandCandidatesMock.mockResolvedValue({
+      available: true,
+      path: String.raw`C:\Users\x\AppData\Roaming\npm\openclaw.cmd`,
+      version: '2026.1.29',
+    });
+
+    await expect(resolveRemotePlatformCommand('openclaw')).resolves.toEqual({
+      available: false,
+      error: 'openclaw was not found or failed validation',
     });
   });
 
@@ -113,6 +154,81 @@ describe('platform command scanning', () => {
       available: true,
       version: '0.9.0',
     });
+  });
+
+  it('binds spawn preparation to the validated executable and recovered PATH', async () => {
+    detectValidatedCommandCandidatesMock.mockResolvedValue({
+      available: true,
+      path: '/resolved/bin/openclaw',
+      resolvedPathEnv: '/runtime/bin:/usr/bin',
+      version: '2026.1.29',
+    });
+    const baseEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      AUTH_TOKEN: 'token',
+      PATH: '/stale/bin:/usr/bin',
+    };
+
+    const runtime = await resolveRemotePlatformRuntime('openclaw', baseEnv);
+    expect(runtime.available).toBe(true);
+    if (!runtime.available) return;
+
+    await expect(runtime.prepareSpawn(['agent', '--local'])).resolves.toEqual({
+      args: ['agent', '--local'],
+      command: '/resolved/bin/openclaw',
+      env: expect.objectContaining({
+        AUTH_TOKEN: 'token',
+        PATH: '/runtime/bin:/usr/bin',
+      }),
+    });
+    expect(resolveCliSpawnPlanMock).toHaveBeenCalledWith(
+      '/resolved/bin/openclaw',
+      ['agent', '--local'],
+      expect.objectContaining({
+        AUTH_TOKEN: 'token',
+        PATH: '/runtime/bin:/usr/bin',
+      }),
+    );
+  });
+
+  it('executes one-shot commands through the prepared runtime plan', async () => {
+    detectValidatedCommandCandidatesMock.mockResolvedValue({
+      available: true,
+      path: '/resolved/bin/hermes',
+      resolvedPathEnv: '/runtime/bin:/usr/bin',
+    });
+    resolveCliSpawnPlanMock.mockImplementation(async (command, args) =>
+      args.length === 0
+        ? { args, command }
+        : { args: ['/runtime/hermes.js', ...args], command: '/runtime/node' },
+    );
+    execFileMock.mockImplementationOnce(((
+      _command: string,
+      _args: string[],
+      _options: object,
+      callback: (error: null, stdout: string, stderr: string) => void,
+    ) => {
+      callback(null, '◆default\n', 'diagnostic\n');
+      return {};
+    }) as never);
+
+    const runtime = await resolveRemotePlatformRuntime('hermes');
+    expect(runtime.available).toBe(true);
+    if (!runtime.available) return;
+
+    await expect(runtime.execute(['profile', 'list'], { timeout: 1234 })).resolves.toEqual({
+      stderr: 'diagnostic\n',
+      stdout: '◆default\n',
+    });
+    expect(execFileMock).toHaveBeenCalledWith(
+      '/runtime/node',
+      ['/runtime/hermes.js', 'profile', 'list'],
+      expect.objectContaining({
+        env: expect.objectContaining({ PATH: '/runtime/bin:/usr/bin' }),
+        timeout: 1234,
+      }),
+      expect.any(Function),
+    );
   });
 
   it('surfaces the platform validation failure reason', async () => {

--- a/packages/heterogeneous-agents/src/scan/scanHost.test.ts
+++ b/packages/heterogeneous-agents/src/scan/scanHost.test.ts
@@ -10,14 +10,16 @@ vi.mock('node:os', async () => {
   return { ...actual, platform: vi.fn(() => 'darwin') };
 });
 
-const { detectHeterogeneousCliCommandMock, detectValidatedCommandMock } = vi.hoisted(() => ({
-  detectHeterogeneousCliCommandMock: vi.fn(),
-  detectValidatedCommandMock: vi.fn(),
-}));
+const { detectHeterogeneousCliCommandMock, detectValidatedCommandCandidatesMock } = vi.hoisted(
+  () => ({
+    detectHeterogeneousCliCommandMock: vi.fn(),
+    detectValidatedCommandCandidatesMock: vi.fn(),
+  }),
+);
 
 vi.mock('../spawn/resolveCliCommand', () => ({
   detectHeterogeneousCliCommand: detectHeterogeneousCliCommandMock,
-  detectValidatedCommand: detectValidatedCommandMock,
+  detectValidatedCommandCandidates: detectValidatedCommandCandidatesMock,
 }));
 
 describe('platform command scanning', () => {
@@ -26,7 +28,7 @@ describe('platform command scanning', () => {
   });
 
   it('uses the shared PATH and Windows-shim-aware command resolver', async () => {
-    detectValidatedCommandMock.mockResolvedValue({
+    detectValidatedCommandCandidatesMock.mockResolvedValue({
       available: true,
       path: '/resolved/bin/openclaw',
       resolvedPathEnv: '/resolved/bin:/usr/bin',
@@ -39,15 +41,22 @@ describe('platform command scanning', () => {
       resolvedPathEnv: '/resolved/bin:/usr/bin',
       version: '1.2.3',
     });
-    expect(detectValidatedCommandMock).toHaveBeenCalledWith('openclaw', {
-      validateHelpKeywords: ['Usage: openclaw'],
-      validateKeywords: ['openclaw'],
-      validatePattern: expect.any(RegExp),
-    });
+    expect(detectValidatedCommandCandidatesMock).toHaveBeenCalledWith(
+      [
+        'openclaw',
+        path.join(os.homedir(), '.openclaw', 'bin', 'openclaw'),
+        path.join(os.homedir(), '.local', 'bin', 'openclaw'),
+      ],
+      {
+        validateHelpKeywords: ['Usage: openclaw'],
+        validateKeywords: ['openclaw'],
+        validatePattern: expect.any(RegExp),
+      },
+    );
   });
 
   it('accepts the bare version banner printed by OpenClaw 2026.1.29', async () => {
-    detectValidatedCommandMock.mockImplementation(async (_command, options) => ({
+    detectValidatedCommandCandidatesMock.mockImplementation(async (_commands, options) => ({
       available: options.validatePattern.test('2026.1.29'),
       path: '/resolved/bin/openclaw',
       version: '2026.1.29',
@@ -60,7 +69,7 @@ describe('platform command scanning', () => {
   });
 
   it('falls back to the official OpenClaw managed install path', async () => {
-    detectValidatedCommandMock.mockResolvedValueOnce({ available: false }).mockResolvedValueOnce({
+    detectValidatedCommandCandidatesMock.mockResolvedValue({
       available: true,
       path: path.join(os.homedir(), '.openclaw', 'bin', 'openclaw'),
       version: '2026.1.29',
@@ -70,14 +79,13 @@ describe('platform command scanning', () => {
       available: true,
       version: '2026.1.29',
     });
-    expect(detectValidatedCommandMock.mock.calls.map(([command]) => command)).toEqual([
-      'openclaw',
+    expect(detectValidatedCommandCandidatesMock.mock.calls[0]![0]).toContain(
       path.join(os.homedir(), '.openclaw', 'bin', 'openclaw'),
-    ]);
+    );
   });
 
   it('falls back to the official Hermes user-local install path', async () => {
-    detectValidatedCommandMock.mockResolvedValueOnce({ available: false }).mockResolvedValueOnce({
+    detectValidatedCommandCandidatesMock.mockResolvedValue({
       available: true,
       path: path.join(os.homedir(), '.local', 'bin', 'hermes'),
       version: '0.20.5',
@@ -87,14 +95,14 @@ describe('platform command scanning', () => {
       available: true,
       version: '0.20.5',
     });
-    expect(detectValidatedCommandMock.mock.calls.map(([command]) => command)).toEqual([
+    expect(detectValidatedCommandCandidatesMock.mock.calls[0]![0]).toEqual([
       'hermes',
       path.join(os.homedir(), '.local', 'bin', 'hermes'),
     ]);
   });
 
   it('keeps host scan responses free of executable paths', async () => {
-    detectValidatedCommandMock.mockResolvedValue({
+    detectValidatedCommandCandidatesMock.mockResolvedValue({
       available: true,
       path: '/private/bin/hermes',
       resolvedPathEnv: '/private/bin:/usr/bin',
@@ -108,7 +116,7 @@ describe('platform command scanning', () => {
   });
 
   it('surfaces the platform validation failure reason', async () => {
-    detectValidatedCommandMock.mockResolvedValue({ available: false });
+    detectValidatedCommandCandidatesMock.mockResolvedValue({ available: false });
 
     await expect(probeRemotePlatform('hermes')).resolves.toEqual({
       available: false,

--- a/packages/heterogeneous-agents/src/scan/scanHost.test.ts
+++ b/packages/heterogeneous-agents/src/scan/scanHost.test.ts
@@ -1,6 +1,14 @@
+import * as os from 'node:os';
+import path from 'node:path';
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { probeRemotePlatform, resolveRemotePlatformCommand } from './scanHost';
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof os>('node:os');
+  return { ...actual, platform: vi.fn(() => 'darwin') };
+});
 
 const { detectHeterogeneousCliCommandMock, detectValidatedCommandMock } = vi.hoisted(() => ({
   detectHeterogeneousCliCommandMock: vi.fn(),
@@ -32,8 +40,57 @@ describe('platform command scanning', () => {
       version: '1.2.3',
     });
     expect(detectValidatedCommandMock).toHaveBeenCalledWith('openclaw', {
+      validateHelpKeywords: ['Usage: openclaw'],
       validateKeywords: ['openclaw'],
+      validatePattern: expect.any(RegExp),
     });
+  });
+
+  it('accepts the bare version banner printed by OpenClaw 2026.1.29', async () => {
+    detectValidatedCommandMock.mockImplementation(async (_command, options) => ({
+      available: options.validatePattern.test('2026.1.29'),
+      path: '/resolved/bin/openclaw',
+      version: '2026.1.29',
+    }));
+
+    await expect(resolveRemotePlatformCommand('openclaw')).resolves.toMatchObject({
+      available: true,
+      version: '2026.1.29',
+    });
+  });
+
+  it('falls back to the official OpenClaw managed install path', async () => {
+    detectValidatedCommandMock.mockResolvedValueOnce({ available: false }).mockResolvedValueOnce({
+      available: true,
+      path: path.join(os.homedir(), '.openclaw', 'bin', 'openclaw'),
+      version: '2026.1.29',
+    });
+
+    await expect(resolveRemotePlatformCommand('openclaw')).resolves.toMatchObject({
+      available: true,
+      version: '2026.1.29',
+    });
+    expect(detectValidatedCommandMock.mock.calls.map(([command]) => command)).toEqual([
+      'openclaw',
+      path.join(os.homedir(), '.openclaw', 'bin', 'openclaw'),
+    ]);
+  });
+
+  it('falls back to the official Hermes user-local install path', async () => {
+    detectValidatedCommandMock.mockResolvedValueOnce({ available: false }).mockResolvedValueOnce({
+      available: true,
+      path: path.join(os.homedir(), '.local', 'bin', 'hermes'),
+      version: '0.20.5',
+    });
+
+    await expect(resolveRemotePlatformCommand('hermes')).resolves.toMatchObject({
+      available: true,
+      version: '0.20.5',
+    });
+    expect(detectValidatedCommandMock.mock.calls.map(([command]) => command)).toEqual([
+      'hermes',
+      path.join(os.homedir(), '.local', 'bin', 'hermes'),
+    ]);
   });
 
   it('keeps host scan responses free of executable paths', async () => {
@@ -47,6 +104,15 @@ describe('platform command scanning', () => {
     await expect(probeRemotePlatform('hermes')).resolves.toEqual({
       available: true,
       version: '0.9.0',
+    });
+  });
+
+  it('surfaces the platform validation failure reason', async () => {
+    detectValidatedCommandMock.mockResolvedValue({ available: false });
+
+    await expect(probeRemotePlatform('hermes')).resolves.toEqual({
+      available: false,
+      reason: 'hermes was not found or failed validation',
     });
   });
 });

--- a/packages/heterogeneous-agents/src/scan/scanHost.ts
+++ b/packages/heterogeneous-agents/src/scan/scanHost.ts
@@ -1,8 +1,10 @@
+import { execFile } from 'node:child_process';
 import { homedir, platform } from 'node:os';
 import path from 'node:path';
 
-import type { RemoteHeterogeneousAgentType } from '../config';
+import type { RemoteHeterogeneousAgentDescriptor, RemoteHeterogeneousAgentType } from '../config';
 import { HETEROGENEOUS_AGENT_CONFIGS, REMOTE_HETEROGENEOUS_AGENT_CONFIGS } from '../config';
+import { resolveCliSpawnPlan } from '../spawn/cliSpawn';
 import type { CliCommandStatus } from '../spawn/resolveCliCommand';
 import {
   detectHeterogeneousCliCommand,
@@ -18,49 +20,157 @@ import type { HeterogeneousAgentScanMap, HeterogeneousAgentScanStatus } from './
  * (`@lobechat/heterogeneous-agents/scanHost`), never from a browser bundle.
  */
 
-const BARE_VERSION_PATTERN = /^v?\d+\.\d+\.\d+(?:[-+][\dA-Za-z.-]+)?$/;
+const getRemotePlatformConfig = (type: string): RemoteHeterogeneousAgentDescriptor | undefined =>
+  REMOTE_HETEROGENEOUS_AGENT_CONFIGS.find((config) => config.type === type);
 
-const getRemotePlatformCommandCandidates = (type: RemoteHeterogeneousAgentType): string[] => {
-  if (platform() !== 'darwin' && platform() !== 'linux') return [type];
+const getRemotePlatformCommandCandidates = (
+  config: RemoteHeterogeneousAgentDescriptor,
+): string[] => {
+  if (platform() !== 'darwin' && platform() !== 'linux') return [config.cli.command];
 
-  if (type === 'openclaw') {
-    return [
-      type,
-      path.join(homedir(), '.openclaw', 'bin', 'openclaw'),
-      path.join(homedir(), '.local', 'bin', 'openclaw'),
-    ];
-  }
-
-  return [type, path.join(homedir(), '.local', 'bin', 'hermes')];
+  return [
+    config.cli.command,
+    ...(config.cli.wellKnownHomePaths ?? []).map((relativePath) =>
+      path.join(homedir(), ...relativePath.split('/')),
+    ),
+  ];
 };
+
+const buildRemotePlatformEnvironment = (
+  status: CliCommandStatus,
+  baseEnv: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv => ({
+  ...baseEnv,
+  ...(status.resolvedPathEnv && { PATH: status.resolvedPathEnv }),
+});
+
+const isUnresolvedWindowsShim = (command: string): boolean =>
+  platform() === 'win32' && /\.(?:bat|cmd)$/i.test(command);
 
 /**
  * Resolve and validate a notify-based platform executable using the same
  * login-shell PATH and Windows npm-shim handling as the CLI agent resolver.
- * Spawn sites must use the returned absolute path and `resolvedPathEnv` too;
- * otherwise a packaged Electron app can detect a command that it cannot run.
+ * This is the detection/capability boundary; execution sites must use
+ * `resolveRemotePlatformRuntime` so the validated path and environment cannot
+ * be separated.
  */
-export const resolveRemotePlatformCommand = async (
-  type: RemoteHeterogeneousAgentType,
-): Promise<CliCommandStatus> => {
-  const validation =
-    type === 'openclaw'
-      ? {
-          validateHelpKeywords: ['Usage: openclaw'],
-          validateKeywords: ['openclaw'],
-          validatePattern: BARE_VERSION_PATTERN,
-        }
-      : { validateKeywords: ['hermes'] };
+export const resolveRemotePlatformCommand = async (type: string): Promise<CliCommandStatus> => {
+  const config = getRemotePlatformConfig(type);
+  if (!config) return { available: false, error: `Unknown platform: ${type}` };
+
+  const { helpKeywords, keywords, pattern: validationPattern } = config.cli.validation;
+  const validation = {
+    ...(helpKeywords && { validateHelpKeywords: [...helpKeywords] }),
+    ...(keywords && { validateKeywords: [...keywords] }),
+    ...(validationPattern && { validatePattern: new RegExp(validationPattern) }),
+  };
 
   const status = await detectValidatedCommandCandidates(
-    getRemotePlatformCommandCandidates(type),
+    getRemotePlatformCommandCandidates(config),
     validation,
   );
-  if (status.available) return status;
+  if (status.available && status.path) {
+    try {
+      const spawnPlan = await resolveCliSpawnPlan(
+        status.path,
+        [],
+        buildRemotePlatformEnvironment(status, process.env),
+      );
+      if (!isUnresolvedWindowsShim(spawnPlan.command)) return status;
+    } catch {
+      // A command that validates but cannot produce a shell-free spawn plan is
+      // not executable by a task. Report it unavailable so scan and execution
+      // cannot disagree.
+    }
+  }
 
   return {
     available: false,
     error: `${type} was not found or failed validation`,
+  };
+};
+
+export interface RemotePlatformCommandOutput {
+  stderr: string;
+  stdout: string;
+}
+
+export interface RemotePlatformSpawnPlan {
+  args: string[];
+  command: string;
+  env: NodeJS.ProcessEnv;
+}
+
+export type RemotePlatformCommandRuntime =
+  | {
+      available: false;
+      error: string;
+    }
+  | {
+      available: true;
+      execute: (
+        args: string[],
+        options?: { timeout?: number },
+      ) => Promise<RemotePlatformCommandOutput>;
+      prepareSpawn: (args: string[]) => Promise<RemotePlatformSpawnPlan>;
+      version?: string;
+    };
+
+const executeSpawnPlan = (
+  spawnPlan: RemotePlatformSpawnPlan,
+  timeout = 5000,
+): Promise<RemotePlatformCommandOutput> =>
+  new Promise((resolve, reject) => {
+    execFile(
+      spawnPlan.command,
+      spawnPlan.args,
+      {
+        encoding: 'utf8',
+        env: spawnPlan.env,
+        timeout,
+        windowsHide: true,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve({ stderr: stderr.toString(), stdout: stdout.toString() });
+      },
+    );
+  });
+
+/**
+ * Resolve one validated platform executable and bind every execution to the
+ * exact PATH that validated it. Consumers keep their own task lifecycle, but
+ * cannot accidentally fall back to a bare command or skip Windows shim
+ * expansion when preparing a child process.
+ */
+export const resolveRemotePlatformRuntime = async (
+  type: string,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): Promise<RemotePlatformCommandRuntime> => {
+  const status = await resolveRemotePlatformCommand(type);
+  if (!status.available || !status.path) {
+    return {
+      available: false,
+      error: status.error ?? `${type} was not found or failed validation`,
+    };
+  }
+
+  const validatedPath = status.path;
+  const env = buildRemotePlatformEnvironment(status, baseEnv);
+  const prepareSpawn = async (args: string[]): Promise<RemotePlatformSpawnPlan> => ({
+    ...(await resolveCliSpawnPlan(validatedPath, args, env)),
+    env,
+  });
+
+  return {
+    available: true,
+    execute: async (args, options) => executeSpawnPlan(await prepareSpawn(args), options?.timeout),
+    prepareSpawn,
+    version: status.version,
   };
 };
 

--- a/packages/heterogeneous-agents/src/scan/scanHost.ts
+++ b/packages/heterogeneous-agents/src/scan/scanHost.ts
@@ -1,3 +1,6 @@
+import { homedir, platform } from 'node:os';
+import path from 'node:path';
+
 import type { RemoteHeterogeneousAgentType } from '../config';
 import { HETEROGENEOUS_AGENT_CONFIGS, REMOTE_HETEROGENEOUS_AGENT_CONFIGS } from '../config';
 import type { CliCommandStatus } from '../spawn/resolveCliCommand';
@@ -12,6 +15,22 @@ import type { HeterogeneousAgentScanMap, HeterogeneousAgentScanStatus } from './
  * (`@lobechat/heterogeneous-agents/scanHost`), never from a browser bundle.
  */
 
+const BARE_VERSION_PATTERN = /^v?\d+\.\d+\.\d+(?:[-+][\dA-Za-z.-]+)?$/;
+
+const getRemotePlatformCommandCandidates = (type: RemoteHeterogeneousAgentType): string[] => {
+  if (platform() !== 'darwin' && platform() !== 'linux') return [type];
+
+  if (type === 'openclaw') {
+    return [
+      type,
+      path.join(homedir(), '.openclaw', 'bin', 'openclaw'),
+      path.join(homedir(), '.local', 'bin', 'openclaw'),
+    ];
+  }
+
+  return [type, path.join(homedir(), '.local', 'bin', 'hermes')];
+};
+
 /**
  * Resolve and validate a notify-based platform executable using the same
  * login-shell PATH and Windows npm-shim handling as the CLI agent resolver.
@@ -20,7 +39,26 @@ import type { HeterogeneousAgentScanMap, HeterogeneousAgentScanStatus } from './
  */
 export const resolveRemotePlatformCommand = async (
   type: RemoteHeterogeneousAgentType,
-): Promise<CliCommandStatus> => detectValidatedCommand(type, { validateKeywords: [type] });
+): Promise<CliCommandStatus> => {
+  const validation =
+    type === 'openclaw'
+      ? {
+          validateHelpKeywords: ['Usage: openclaw'],
+          validateKeywords: ['openclaw'],
+          validatePattern: BARE_VERSION_PATTERN,
+        }
+      : { validateKeywords: ['hermes'] };
+
+  for (const command of getRemotePlatformCommandCandidates(type)) {
+    const status = await detectValidatedCommand(command, validation);
+    if (status.available) return status;
+  }
+
+  return {
+    available: false,
+    error: `${type} was not found or failed validation`,
+  };
+};
 
 export const probeRemotePlatform = async (
   type: RemoteHeterogeneousAgentType,
@@ -28,7 +66,7 @@ export const probeRemotePlatform = async (
   const status = await resolveRemotePlatformCommand(type);
   return status.available
     ? { available: true, version: status.version }
-    : { available: false, reason: `${type} not found or failed to run` };
+    : { available: false, reason: status.error };
 };
 
 export const scanHeterogeneousAgentsOnHost = async (): Promise<HeterogeneousAgentScanMap> => {

--- a/packages/heterogeneous-agents/src/scan/scanHost.ts
+++ b/packages/heterogeneous-agents/src/scan/scanHost.ts
@@ -4,7 +4,10 @@ import path from 'node:path';
 import type { RemoteHeterogeneousAgentType } from '../config';
 import { HETEROGENEOUS_AGENT_CONFIGS, REMOTE_HETEROGENEOUS_AGENT_CONFIGS } from '../config';
 import type { CliCommandStatus } from '../spawn/resolveCliCommand';
-import { detectHeterogeneousCliCommand, detectValidatedCommand } from '../spawn/resolveCliCommand';
+import {
+  detectHeterogeneousCliCommand,
+  detectValidatedCommandCandidates,
+} from '../spawn/resolveCliCommand';
 import type { HeterogeneousAgentScanMap, HeterogeneousAgentScanStatus } from './types';
 
 /**
@@ -49,10 +52,11 @@ export const resolveRemotePlatformCommand = async (
         }
       : { validateKeywords: ['hermes'] };
 
-  for (const command of getRemotePlatformCommandCandidates(type)) {
-    const status = await detectValidatedCommand(command, validation);
-    if (status.available) return status;
-  }
+  const status = await detectValidatedCommandCandidates(
+    getRemotePlatformCommandCandidates(type),
+    validation,
+  );
+  if (status.available) return status;
 
   return {
     available: false,

--- a/packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts
@@ -201,6 +201,7 @@ describe('cliSpawn', () => {
     platformMock.mockReturnValue('win32');
     const shimPath = 'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\example-cli.cmd';
     const nodePath = 'C:\\Program Files\\nodejs\\node.exe';
+    const recoveredEnv = { ...process.env, PATH: 'C:\\Program Files\\nodejs;C:\\Windows' };
     const scriptPath =
       'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\node_modules\\example-cli\\bin\\cli.js';
     existingPaths(shimPath, scriptPath);
@@ -208,10 +209,11 @@ describe('cliSpawn', () => {
     readFileMock.mockResolvedValue('node "%dp0%\\node_modules\\example-cli\\bin\\cli.js" %*\r\n');
 
     const { resolveCliSpawnPlan } = await import('./cliSpawn');
-    await expect(resolveCliSpawnPlan(shimPath, ['--help'])).resolves.toEqual({
+    await expect(resolveCliSpawnPlan(shimPath, ['--help'], recoveredEnv)).resolves.toEqual({
       args: [scriptPath, '--help'],
       command: nodePath,
     });
+    expect(execFileMock.mock.calls[0]![2]).toMatchObject({ env: recoveredEnv });
   });
 
   it('resolves the npm generated %_prog% .cmd shim form used by Codex and Gemini', async () => {

--- a/packages/heterogeneous-agents/src/spawn/cliSpawn.ts
+++ b/packages/heterogeneous-agents/src/spawn/cliSpawn.ts
@@ -73,12 +73,16 @@ const fileExists = async (filePath: string): Promise<boolean> => {
   }
 };
 
-const execFileString = async (command: string, args: string[]): Promise<string> =>
+const execFileString = async (
+  command: string,
+  args: string[],
+  env?: NodeJS.ProcessEnv,
+): Promise<string> =>
   new Promise((resolve, reject) => {
     execFile(
       command,
       args,
-      { timeout: 3000, windowsHide: true },
+      { env, timeout: 3000, windowsHide: true },
       (error: Error | null, stdout: string) => {
         if (error) {
           reject(error);
@@ -138,12 +142,15 @@ const getExistingShimPathToken = async (
   return (await fileExists(resolvedPath)) ? resolvedPath : undefined;
 };
 
-const resolveWindowsNodeCommand = async (shimPath: string): Promise<string | undefined> => {
+const resolveWindowsNodeCommand = async (
+  shimPath: string,
+  env?: NodeJS.ProcessEnv,
+): Promise<string | undefined> => {
   const localNodePath = path.win32.join(path.win32.dirname(shimPath), 'node.exe');
   if (await fileExists(localNodePath)) return localNodePath;
 
   try {
-    const stdout = await execFileString('where', ['node']);
+    const stdout = await execFileString('where', ['node'], env);
     const candidates = stdout
       .split(/\r?\n/)
       .map((line) => line.trim())
@@ -155,10 +162,14 @@ const resolveWindowsNodeCommand = async (shimPath: string): Promise<string | und
   }
 };
 
-const getNodeCommand = async (shimPath: string, token: string): Promise<string | undefined> => {
+const getNodeCommand = async (
+  shimPath: string,
+  token: string,
+  env?: NodeJS.ProcessEnv,
+): Promise<string | undefined> => {
   const trimmedToken = token.trim().replaceAll(/^['"]|['"]$/g, '');
   if (/^node(?:\.exe)?$/i.test(trimmedToken) || /^%_prog%$/i.test(trimmedToken)) {
-    return resolveWindowsNodeCommand(shimPath);
+    return resolveWindowsNodeCommand(shimPath, env);
   }
 
   const resolvedPath = await getExistingShimPathToken(shimPath, trimmedToken);
@@ -171,8 +182,9 @@ const getNodeScriptTarget = async (
   shimPath: string,
   nodeToken: string,
   scriptToken: string,
+  env?: NodeJS.ProcessEnv,
 ): Promise<WindowsShimTarget | undefined> => {
-  const command = await getNodeCommand(shimPath, nodeToken);
+  const command = await getNodeCommand(shimPath, nodeToken, env);
   if (!command) return;
 
   const scriptPath = await getExistingShimPathToken(shimPath, scriptToken);
@@ -184,6 +196,7 @@ const getNodeScriptTarget = async (
 const inferWindowsNodeScriptFromShim = async (
   shimPath: string,
   source: string,
+  env?: NodeJS.ProcessEnv,
 ): Promise<WindowsShimTarget | undefined> => {
   const patterns: Array<RegExp | [RegExp, string]> = [
     /exec\s+"(\$basedir[^"]*node(?:\.exe)?)"\s+"([^"]+)"/i,
@@ -202,7 +215,7 @@ const inferWindowsNodeScriptFromShim = async (
     const scriptToken = Array.isArray(pattern) ? match[2] : match[2];
     if (!nodeToken || !scriptToken) continue;
 
-    const target = await getNodeScriptTarget(shimPath, nodeToken, scriptToken);
+    const target = await getNodeScriptTarget(shimPath, nodeToken, scriptToken, env);
     if (target) return target;
   }
 };
@@ -227,6 +240,7 @@ const inferWindowsExecutableFromShim = async (
 
 const inferWindowsNpmShimTarget = async (
   shimPath: string,
+  env?: NodeJS.ProcessEnv,
 ): Promise<WindowsShimTarget | undefined> => {
   if (WINDOWS_EXE_EXT_PATTERN.test(shimPath)) return { command: shimPath };
   if (!(await fileExists(shimPath))) return;
@@ -234,7 +248,7 @@ const inferWindowsNpmShimTarget = async (
   try {
     const source = await readFile(shimPath, 'utf8');
     return (
-      (await inferWindowsNodeScriptFromShim(shimPath, source)) ??
+      (await inferWindowsNodeScriptFromShim(shimPath, source, env)) ??
       (await inferWindowsExecutableFromShim(shimPath, source))
     );
   } catch {
@@ -244,9 +258,10 @@ const inferWindowsNpmShimTarget = async (
 
 const resolveWindowsBareCommand = async (
   command: string,
+  env?: NodeJS.ProcessEnv,
 ): Promise<WindowsShimTarget | undefined> => {
   try {
-    const stdout = await execFileString('where', [command]);
+    const stdout = await execFileString('where', [command], env);
     const candidates = stdout
       .split(/\r?\n/)
       .map((line) => line.trim())
@@ -263,7 +278,7 @@ const resolveWindowsBareCommand = async (
     // breaks CLI launch. Same PATH-order rule already applied to detection
     // candidates in resolveCliCommand.ts (see #17376).
     for (const candidate of candidates) {
-      const target = await inferWindowsNpmShimTarget(candidate);
+      const target = await inferWindowsNpmShimTarget(candidate, env);
       if (target) return target;
     }
 
@@ -276,13 +291,14 @@ const resolveWindowsBareCommand = async (
 export const resolveCliSpawnPlan = async (
   command: string,
   args: string[],
+  env?: NodeJS.ProcessEnv,
 ): Promise<CliSpawnPlan> => {
   const trimmedCommand = command.trim();
   if (!isWindows() || !trimmedCommand) return { args, command };
 
   const target = isPathLikeCommand(trimmedCommand)
-    ? await inferWindowsNpmShimTarget(trimmedCommand)
-    : await resolveWindowsBareCommand(trimmedCommand);
+    ? await inferWindowsNpmShimTarget(trimmedCommand, env)
+    : await resolveWindowsBareCommand(trimmedCommand, env);
 
   const spawnPlan = target
     ? { args: [...(target.argsPrefix ?? []), ...args], command: target.command }

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
@@ -382,6 +382,85 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
       }
     });
 
+    it('prefers the login-PATH command over an inherited absolute fallback', async () => {
+      const originalPath = process.env.PATH;
+      const originalShell = process.env.SHELL;
+      process.env.PATH = '/usr/bin:/bin';
+      process.env.SHELL = '/bin/zsh';
+      const loginPath = '/login/bin:/usr/bin:/bin';
+      const loginCommand = '/login/bin/opencode';
+      const fallbackPath = '/fallback/bin/opencode';
+
+      execFileMock.mockImplementation(((file: string, args: any, opts: any, cb: any) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        if (file === '/bin/zsh') {
+          callback(noErr, { stderr: '', stdout: loginPath });
+        } else if (file === 'which' && opts.env?.PATH === loginPath) {
+          callback(noErr, { stderr: '', stdout: `${loginCommand}\n` });
+        } else if (file === 'which') {
+          callback(new Error('not found'), { stderr: '', stdout: '' });
+        } else if (file === loginCommand || file === fallbackPath) {
+          callback(noErr, { stderr: '', stdout: '1.18.3' });
+        } else {
+          callback(new Error(`unexpected execFile: ${file}`), { stderr: '', stdout: '' });
+        }
+        return {} as any;
+      }) as any);
+
+      try {
+        const { detectValidatedCommandCandidates } = await importModule();
+        const status = await detectValidatedCommandCandidates(['opencode', fallbackPath], {
+          validatePattern: /^v?\d+\.\d+\.\d+$/,
+        });
+
+        expect(status).toMatchObject({
+          available: true,
+          path: loginCommand,
+          resolvedPathEnv: loginPath,
+        });
+        expect(execFileMock.mock.calls.map(([file]) => file)).not.toContain(fallbackPath);
+      } finally {
+        process.env.PATH = originalPath;
+        process.env.SHELL = originalShell;
+      }
+    });
+
+    it('keeps an inherited fallback available when the recovered environment would break it', async () => {
+      const originalPath = process.env.PATH;
+      const originalShell = process.env.SHELL;
+      process.env.PATH = '/usr/bin:/bin';
+      process.env.SHELL = '/bin/zsh';
+      const loginPath = '/broken/bin:/usr/bin:/bin';
+      const fallbackPath = '/fallback/bin/opencode';
+
+      execFileMock.mockImplementation(((file: string, args: any, opts: any, cb: any) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        if (file === '/bin/zsh') {
+          callback(noErr, { stderr: '', stdout: loginPath });
+        } else if (file === 'which') {
+          callback(new Error('not found'), { stderr: '', stdout: '' });
+        } else if (file === fallbackPath && opts.env?.PATH !== loginPath) {
+          callback(noErr, { stderr: '', stdout: '1.18.3' });
+        } else {
+          callback(new Error('broken recovered environment'), { stderr: '', stdout: '' });
+        }
+        return {} as any;
+      }) as any);
+
+      try {
+        const { detectValidatedCommandCandidates } = await importModule();
+        const status = await detectValidatedCommandCandidates(['opencode', fallbackPath], {
+          validatePattern: /^v?\d+\.\d+\.\d+$/,
+        });
+
+        expect(status).toMatchObject({ available: true, path: fallbackPath });
+        expect(status.resolvedPathEnv).toBeUndefined();
+      } finally {
+        process.env.PATH = originalPath;
+        process.env.SHELL = originalShell;
+      }
+    });
+
     it('carries the recovered login PATH into an absolute fallback launcher', async () => {
       const originalPath = process.env.PATH;
       const originalShell = process.env.SHELL;
@@ -392,9 +471,9 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
 
       try {
         callExecFileError(new Error('not found')); // which opencode (inherited PATH)
-        callExecFileError(new Error('node not found')); // fallback under inherited PATH
         callExecFile(loginPath); // login shell PATH contains node, not opencode
         callExecFileError(new Error('not found')); // which opencode (login PATH)
+        callExecFileError(new Error('node not found')); // fallback under inherited PATH
         callExecFile('1.18.3'); // ~/.opencode/bin/opencode --version
 
         const { detectValidatedCommandCandidates } = await importModule();
@@ -461,10 +540,10 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
       try {
         callExecFile('/usr/local/bin/opencode\n'); // inherited PATH finds a stale launcher
         callExecFileError(new Error('stale launcher')); // inherited launcher validation
-        callExecFileError(new Error('node not found')); // fallback under inherited PATH
         callExecFile('/opt/homebrew/bin:/usr/bin:/bin'); // login shell PATH
         callExecFile('/usr/local/bin/opencode\n'); // retry under the merged PATH
         callExecFileError(new Error('stale launcher')); // recovered lookup still resolves stale copy
+        callExecFileError(new Error('node not found')); // fallback under inherited PATH
         callExecFile('1.18.3'); // ~/.opencode/bin/opencode --version
 
         const { detectValidatedCommandCandidates } = await importModule();
@@ -865,6 +944,49 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
       }
     });
 
+    it('prefers a registry-PATH command over an inherited absolute fallback', async () => {
+      const originalPath = process.env.PATH;
+      process.env.PATH = 'C:\\Windows';
+      const registryBin = 'C:\\registry\\bin';
+      const registryCommand = `${registryBin}\\codex.exe`;
+      const fallbackPath = 'C:\\fallback\\codex.exe';
+      existingFiles({ [fallbackPath]: true, [registryCommand]: true });
+
+      execFileMock.mockImplementation(((file: string, args: any, opts: any, cb: any) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        if (file === 'where' && opts.env?.PATH && opts.env.PATH !== process.env.PATH) {
+          callback(noErr, { stderr: '', stdout: `${registryCommand}\r\n` });
+        } else if (file === 'where') {
+          callback(new Error('not found'), { stderr: '', stdout: '' });
+        } else if (file === 'reg' && String(args[1]).includes('HKCU')) {
+          callback(noErr, {
+            stderr: '',
+            stdout: `\r\nHKEY_CURRENT_USER\\Environment\r\n    Path    REG_SZ    ${registryBin}\r\n`,
+          });
+        } else if (file === 'reg') {
+          callback(new Error('no value'), { stderr: '', stdout: '' });
+        } else if (file === registryCommand || file === fallbackPath) {
+          callback(noErr, { stderr: '', stdout: 'codex-cli 0.147.0' });
+        } else {
+          callback(new Error(`unexpected execFile: ${file}`), { stderr: '', stdout: '' });
+        }
+        return {} as any;
+      }) as any);
+
+      try {
+        const { detectValidatedCommandCandidates } = await importModule();
+        const status = await detectValidatedCommandCandidates(['codex', fallbackPath], {
+          validateKeywords: ['codex'],
+        });
+
+        expect(status).toMatchObject({ available: true, path: registryCommand });
+        expect(status.resolvedPathEnv).toContain(registryBin);
+        expect(execFileMock.mock.calls.map(([file]) => file)).not.toContain(fallbackPath);
+      } finally {
+        process.env.PATH = originalPath;
+      }
+    });
+
     it('falls back to the Windows Codex app bundled CLI when nothing is on PATH', async () => {
       const originalLocalAppData = process.env.LOCALAPPDATA;
       const originalPath = process.env.PATH;
@@ -878,6 +1000,8 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
       try {
         existingFiles({ [bundledCli]: true });
         callExecFileError(new Error('not found')); // where codex
+        callExecFileError(new Error('no registry')); // reg query HKLM
+        callExecFileError(new Error('no registry')); // reg query HKCU
         callExecFile('codex-cli 0.147.0'); // the bundled CLI
 
         const { detectHeterogeneousCliCommand } = await importModule();
@@ -903,6 +1027,8 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
       try {
         existingFiles({ [traeCli]: true });
         callExecFileError(new Error('not found')); // where traecli
+        callExecFileError(new Error('no registry')); // reg query HKLM
+        callExecFileError(new Error('no registry')); // reg query HKCU
         callExecFile('traecli 0.201.2 (public edition)');
         callExecFile(TRAE_ACP_HELP);
 
@@ -932,6 +1058,8 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
       try {
         existingFiles({ [traeCli]: true });
         callExecFileError(new Error('not found')); // where traecli
+        callExecFileError(new Error('no registry')); // reg query HKLM
+        callExecFileError(new Error('no registry')); // reg query HKCU
         callExecFileError(new Error('not found')); // current Programs/TraeCLI/bin/traex.exe
         callExecFile('trae-cli version 0.120.52');
         callExecFile(TRAE_ACP_HELP);
@@ -1104,10 +1232,6 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
 
       try {
         callExecFileError(new Error('not found'));
-        callExecFileError(new Error('not found')); // /Applications/ChatGPT.app
-        callExecFileError(new Error('not found')); // ~/Applications/ChatGPT.app
-        callExecFileError(new Error('not found')); // /Applications/Codex.app
-        callExecFileError(new Error('not found')); // ~/Applications/Codex.app
         callExecFile('/opt/homebrew/bin:/usr/bin:/bin');
         callExecFile('/opt/homebrew/bin/codex\n');
         callExecFile('codex-cli 0.142.5');

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
@@ -382,6 +382,37 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
       }
     });
 
+    it('carries the recovered login PATH into an absolute fallback launcher', async () => {
+      const originalPath = process.env.PATH;
+      const originalShell = process.env.SHELL;
+      process.env.PATH = '/usr/bin:/bin';
+      process.env.SHELL = '/bin/zsh';
+      const loginPath = '/opt/homebrew/bin:/usr/bin:/bin';
+
+      try {
+        callExecFileError(new Error('not found')); // which opencode (inherited PATH)
+        callExecFile(loginPath); // login shell PATH contains node, not opencode
+        callExecFileError(new Error('not found')); // which opencode (login PATH)
+        callExecFile('1.18.3'); // ~/.opencode/bin/opencode --version
+
+        const { detectHeterogeneousCliCommand } = await importModule();
+        const status = await detectHeterogeneousCliCommand('opencode', 'opencode');
+
+        expect(status).toMatchObject({
+          available: true,
+          path: path.join(os.homedir(), '.opencode', 'bin', 'opencode'),
+          resolvedPathEnv: loginPath,
+          version: '1.18.3',
+        });
+        expect((execFileMock.mock.calls[3]![2] as { env: NodeJS.ProcessEnv }).env.PATH).toBe(
+          loginPath,
+        );
+      } finally {
+        process.env.PATH = originalPath;
+        process.env.SHELL = originalShell;
+      }
+    });
+
     it('finds Kimi Code in its official user-local install path', async () => {
       const originalPath = process.env.PATH;
       const originalShell = process.env.SHELL;

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
@@ -513,6 +513,40 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
         process.env.SHELL = originalShell;
       }
     });
+
+    it('re-reads the login-shell PATH on a later scan', async () => {
+      const originalPath = process.env.PATH;
+      const originalShell = process.env.SHELL;
+      process.env.PATH = '/usr/bin:/bin';
+      process.env.SHELL = '/bin/zsh';
+
+      try {
+        const { detectValidatedCommand } = await importModule();
+        const options = { validateKeywords: ['new-agent'] };
+
+        callExecFileError(new Error('not found')); // which new-agent
+        callExecFile('/usr/bin:/bin'); // login shell before installation
+        expect((await detectValidatedCommand('new-agent', options)).available).toBe(false);
+
+        callExecFileError(new Error('not found')); // inherited PATH is still stale
+        callExecFile('/Users/x/.local/bin:/usr/bin:/bin'); // shell PATH after installation
+        callExecFile('/Users/x/.local/bin/new-agent\n');
+        callExecFile('new-agent 1.2.3');
+
+        await expect(detectValidatedCommand('new-agent', options)).resolves.toMatchObject({
+          available: true,
+          path: '/Users/x/.local/bin/new-agent',
+          resolvedPathEnv: '/Users/x/.local/bin:/usr/bin:/bin',
+          version: '1.2.3',
+        });
+        expect(execFileMock.mock.calls.filter(([command]) => command === '/bin/zsh')).toHaveLength(
+          2,
+        );
+      } finally {
+        process.env.PATH = originalPath;
+        process.env.SHELL = originalShell;
+      }
+    });
   });
 
   describe('detectValidatedCommand — Windows npm shims', () => {

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
@@ -388,23 +388,60 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
       process.env.PATH = '/usr/bin:/bin';
       process.env.SHELL = '/bin/zsh';
       const loginPath = '/opt/homebrew/bin:/usr/bin:/bin';
+      const fallbackPath = path.join(os.homedir(), '.opencode', 'bin', 'opencode');
 
       try {
         callExecFileError(new Error('not found')); // which opencode (inherited PATH)
+        callExecFileError(new Error('node not found')); // fallback under inherited PATH
         callExecFile(loginPath); // login shell PATH contains node, not opencode
         callExecFileError(new Error('not found')); // which opencode (login PATH)
         callExecFile('1.18.3'); // ~/.opencode/bin/opencode --version
 
-        const { detectHeterogeneousCliCommand } = await importModule();
-        const status = await detectHeterogeneousCliCommand('opencode', 'opencode');
+        const { detectValidatedCommandCandidates } = await importModule();
+        const status = await detectValidatedCommandCandidates(['opencode', fallbackPath], {
+          validatePattern: /^v?\d+\.\d+\.\d+$/,
+        });
 
         expect(status).toMatchObject({
           available: true,
-          path: path.join(os.homedir(), '.opencode', 'bin', 'opencode'),
+          path: fallbackPath,
           resolvedPathEnv: loginPath,
           version: '1.18.3',
         });
-        expect((execFileMock.mock.calls[3]![2] as { env: NodeJS.ProcessEnv }).env.PATH).toBe(
+        expect((execFileMock.mock.calls[4]![2] as { env: NodeJS.ProcessEnv }).env.PATH).toBe(
+          loginPath,
+        );
+      } finally {
+        process.env.PATH = originalPath;
+        process.env.SHELL = originalShell;
+      }
+    });
+
+    it('retries an explicit env-based launcher with the recovered login PATH', async () => {
+      const originalPath = process.env.PATH;
+      const originalShell = process.env.SHELL;
+      process.env.PATH = '/usr/bin:/bin';
+      process.env.SHELL = '/bin/zsh';
+      const commandPath = '/Users/x/.local/bin/opencode';
+      const loginPath = '/opt/homebrew/bin:/usr/bin:/bin';
+
+      try {
+        callExecFileError(new Error('node not found')); // inherited PATH
+        callExecFile(loginPath); // login shell exposes node
+        callExecFile('1.18.3'); // exact same launcher under recovered PATH
+
+        const { detectValidatedCommand } = await importModule();
+        const status = await detectValidatedCommand(commandPath, {
+          validatePattern: /^v?\d+\.\d+\.\d+$/,
+        });
+
+        expect(status).toMatchObject({
+          available: true,
+          path: commandPath,
+          resolvedPathEnv: loginPath,
+          version: '1.18.3',
+        });
+        expect((execFileMock.mock.calls[2]![2] as { env: NodeJS.ProcessEnv }).env.PATH).toBe(
           loginPath,
         );
       } finally {
@@ -419,25 +456,29 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
       process.env.PATH = '/usr/local/bin:/usr/bin:/bin';
       process.env.SHELL = '/bin/zsh';
       const loginPath = '/opt/homebrew/bin:/usr/bin:/bin:/usr/local/bin';
+      const fallbackPath = path.join(os.homedir(), '.opencode', 'bin', 'opencode');
 
       try {
         callExecFile('/usr/local/bin/opencode\n'); // inherited PATH finds a stale launcher
         callExecFileError(new Error('stale launcher')); // inherited launcher validation
+        callExecFileError(new Error('node not found')); // fallback under inherited PATH
         callExecFile('/opt/homebrew/bin:/usr/bin:/bin'); // login shell PATH
         callExecFile('/usr/local/bin/opencode\n'); // retry under the merged PATH
         callExecFileError(new Error('stale launcher')); // recovered lookup still resolves stale copy
         callExecFile('1.18.3'); // ~/.opencode/bin/opencode --version
 
-        const { detectHeterogeneousCliCommand } = await importModule();
-        const status = await detectHeterogeneousCliCommand('opencode', 'opencode');
+        const { detectValidatedCommandCandidates } = await importModule();
+        const status = await detectValidatedCommandCandidates(['opencode', fallbackPath], {
+          validatePattern: /^v?\d+\.\d+\.\d+$/,
+        });
 
         expect(status).toMatchObject({
           available: true,
-          path: path.join(os.homedir(), '.opencode', 'bin', 'opencode'),
+          path: fallbackPath,
           resolvedPathEnv: loginPath,
           version: '1.18.3',
         });
-        expect((execFileMock.mock.calls[5]![2] as { env: NodeJS.ProcessEnv }).env.PATH).toBe(
+        expect((execFileMock.mock.calls[6]![2] as { env: NodeJS.ProcessEnv }).env.PATH).toBe(
           loginPath,
         );
       } finally {
@@ -564,8 +605,8 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
         callExecFile('/Users/x/.local/share/mise/shims/codex\n'); // which codex (login PATH)
         callExecFile('codex-cli 0.142.5');
 
-        const { detectHeterogeneousCliCommand } = await importModule();
-        const status = await detectHeterogeneousCliCommand('codex', 'codex');
+        const { detectValidatedCommand } = await importModule();
+        const status = await detectValidatedCommand('codex', { validateKeywords: ['codex'] });
 
         expect(status.available).toBe(true);
         expect(status.path).toBe('/Users/x/.local/share/mise/shims/codex');
@@ -837,8 +878,6 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
       try {
         existingFiles({ [bundledCli]: true });
         callExecFileError(new Error('not found')); // where codex
-        callExecFileError(new Error('no registry')); // reg query HKLM
-        callExecFileError(new Error('no registry')); // reg query HKCU
         callExecFile('codex-cli 0.147.0'); // the bundled CLI
 
         const { detectHeterogeneousCliCommand } = await importModule();
@@ -864,8 +903,6 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
       try {
         existingFiles({ [traeCli]: true });
         callExecFileError(new Error('not found')); // where traecli
-        callExecFileError(new Error('no registry')); // reg query HKLM
-        callExecFileError(new Error('no registry')); // reg query HKCU
         callExecFile('traecli 0.201.2 (public edition)');
         callExecFile(TRAE_ACP_HELP);
 
@@ -895,8 +932,6 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
       try {
         existingFiles({ [traeCli]: true });
         callExecFileError(new Error('not found')); // where traecli
-        callExecFileError(new Error('no registry')); // reg query HKLM
-        callExecFileError(new Error('no registry')); // reg query HKCU
         callExecFileError(new Error('not found')); // current Programs/TraeCLI/bin/traex.exe
         callExecFile('trae-cli version 0.120.52');
         callExecFile(TRAE_ACP_HELP);
@@ -1069,6 +1104,10 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
 
       try {
         callExecFileError(new Error('not found'));
+        callExecFileError(new Error('not found')); // /Applications/ChatGPT.app
+        callExecFileError(new Error('not found')); // ~/Applications/ChatGPT.app
+        callExecFileError(new Error('not found')); // /Applications/Codex.app
+        callExecFileError(new Error('not found')); // ~/Applications/Codex.app
         callExecFile('/opt/homebrew/bin:/usr/bin:/bin');
         callExecFile('/opt/homebrew/bin/codex\n');
         callExecFile('codex-cli 0.142.5');

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
@@ -353,7 +353,7 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
       const { detectHeterogeneousCliCommand } = await importModule();
       const status = await detectHeterogeneousCliCommand('trae', 'traecli-renamed');
 
-      expect(status).toEqual({ available: false });
+      expect(status.available).toBe(false);
       expect(execFileMock.mock.calls[2]![1]).toEqual(['acp', 'serve', '--help']);
     });
 
@@ -405,6 +405,39 @@ build commit: 6756e52a9238b6d493928e55b05127957dbfefb4`);
           version: '1.18.3',
         });
         expect((execFileMock.mock.calls[3]![2] as { env: NodeJS.ProcessEnv }).env.PATH).toBe(
+          loginPath,
+        );
+      } finally {
+        process.env.PATH = originalPath;
+        process.env.SHELL = originalShell;
+      }
+    });
+
+    it('recovers the login PATH after an inherited command fails validation', async () => {
+      const originalPath = process.env.PATH;
+      const originalShell = process.env.SHELL;
+      process.env.PATH = '/usr/local/bin:/usr/bin:/bin';
+      process.env.SHELL = '/bin/zsh';
+      const loginPath = '/opt/homebrew/bin:/usr/bin:/bin:/usr/local/bin';
+
+      try {
+        callExecFile('/usr/local/bin/opencode\n'); // inherited PATH finds a stale launcher
+        callExecFileError(new Error('stale launcher')); // inherited launcher validation
+        callExecFile('/opt/homebrew/bin:/usr/bin:/bin'); // login shell PATH
+        callExecFile('/usr/local/bin/opencode\n'); // retry under the merged PATH
+        callExecFileError(new Error('stale launcher')); // recovered lookup still resolves stale copy
+        callExecFile('1.18.3'); // ~/.opencode/bin/opencode --version
+
+        const { detectHeterogeneousCliCommand } = await importModule();
+        const status = await detectHeterogeneousCliCommand('opencode', 'opencode');
+
+        expect(status).toMatchObject({
+          available: true,
+          path: path.join(os.homedir(), '.opencode', 'bin', 'opencode'),
+          resolvedPathEnv: loginPath,
+          version: '1.18.3',
+        });
+        expect((execFileMock.mock.calls[5]![2] as { env: NodeJS.ProcessEnv }).env.PATH).toBe(
           loginPath,
         );
       } finally {

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
@@ -527,60 +527,52 @@ const detectValidatedCommandInEnvironment = async (
   return resolvedPathEnv ? { available: false, resolvedPathEnv } : { available: false };
 };
 
-/**
- * Validate an ordered command chain in one exact environment. PATH state does
- * not leak between candidates; every candidate in a pass sees the same PATH.
- */
-const detectValidatedCommandCandidatesInEnvironment = async (
-  commands: string[],
-  options: ValidateOptions,
-  probeEnv?: NodeJS.ProcessEnv,
-): Promise<CliCommandStatus> => {
-  let lastStatus: CliCommandStatus = probeEnv?.PATH
-    ? { available: false, resolvedPathEnv: probeEnv.PATH }
-    : { available: false };
-
-  for (const command of commands) {
-    const status = await detectValidatedCommandInEnvironment(command, options, probeEnv);
-    if (status.available) return status;
-    lastStatus = status;
-  }
-
-  return lastStatus;
+const isProbeableCommand = (command: string): boolean => {
+  const trimmedCommand = command.trim();
+  return trimmedCommand.length > 0 && !(isWindows() && WINDOWS_SHELL_METAS.test(trimmedCommand));
 };
 
 /**
- * Validate the complete ordered candidate chain in at most two environments:
- * first the caller's inherited PATH, then one freshly recovered login-shell or
- * Windows-registry PATH. Both lookup misses and validation failures therefore
- * take the same recovery edge, and absolute fallback launchers receive the
- * interpreter PATH that made the second pass succeed.
+ * Validate an ordered command chain with candidate precedence above environment
+ * precedence: candidate 1 inherited → candidate 1 recovered → candidate 2
+ * inherited → candidate 2 recovered. PATH recovery is attempted at most once
+ * and reused, so lookup misses and validation failures share the same edge
+ * without letting a well-known fallback outrank the user's login-PATH command.
  */
 export const detectValidatedCommandCandidates = async (
   commands: string[],
   options: ValidateOptions,
   probeEnv?: NodeJS.ProcessEnv,
 ): Promise<CliCommandStatus> => {
-  const inheritedStatus = await detectValidatedCommandCandidatesInEnvironment(
-    commands,
-    options,
-    probeEnv,
-  );
-  if (inheritedStatus.available) return inheritedStatus;
+  let lastStatus: CliCommandStatus = { available: false };
+  let recoveryAttempted = false;
+  let recovered: RecoveredProbeEnvironment | undefined;
 
-  // Skip recovery only when there is nothing safe to execute. Absolute
-  // launchers still get the second pass because an `env` shebang may depend on
-  // an interpreter exposed only by the recovered PATH.
-  const hasProbeableCommand = commands.some((command) => {
-    const trimmedCommand = command.trim();
-    return trimmedCommand.length > 0 && !(isWindows() && WINDOWS_SHELL_METAS.test(trimmedCommand));
-  });
-  if (!hasProbeableCommand) return inheritedStatus;
+  for (const command of commands) {
+    const inheritedStatus = await detectValidatedCommandInEnvironment(command, options, probeEnv);
+    if (inheritedStatus.available) return inheritedStatus;
+    lastStatus = inheritedStatus;
 
-  const recovered = await recoverProbeEnvironment(probeEnv);
-  if (!recovered) return inheritedStatus;
+    // Invalid Windows shell expressions must not trigger even the registry
+    // helper processes used for PATH recovery.
+    if (!isProbeableCommand(command)) continue;
 
-  return detectValidatedCommandCandidatesInEnvironment(commands, options, recovered.env);
+    if (!recoveryAttempted) {
+      recoveryAttempted = true;
+      recovered = await recoverProbeEnvironment(probeEnv);
+    }
+    if (!recovered) continue;
+
+    const recoveredStatus = await detectValidatedCommandInEnvironment(
+      command,
+      options,
+      recovered.env,
+    );
+    if (recoveredStatus.available) return recoveredStatus;
+    lastStatus = recoveredStatus;
+  }
+
+  return lastStatus;
 };
 
 export const detectValidatedCommand = async (

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
@@ -62,6 +62,16 @@ interface ResolvedCommand {
   resolvedPathEnv?: string;
 }
 
+interface ResolvedCommandCandidates {
+  candidates: ResolvedCommand[];
+  /**
+   * PATH recovered while looking up a bare command. Keep it even when lookup
+   * found no executable so a subsequent absolute fallback can still run an
+   * env-based launcher with the interpreter PATH that a login shell exposes.
+   */
+  resolvedPathEnv?: string;
+}
+
 const VERSION_PATTERN = /v?(\d+\.\d+\.\d+(?:[-+][\dA-Za-z.-]+)?)/;
 
 const extractVersion = (versionBanner: string): string | undefined =>
@@ -263,18 +273,16 @@ const getCommandPathLines = async (
 const resolveCommandCandidates = async (
   command: string,
   probeEnv?: NodeJS.ProcessEnv,
-): Promise<ResolvedCommand[]> => {
+): Promise<ResolvedCommandCandidates> => {
   const trimmedCommand = command.trim();
-  if (!trimmedCommand) return [];
+  if (!trimmedCommand) return { candidates: [] };
 
   if (isPathLikeCommand(trimmedCommand)) {
-    return [
-      {
-        env: probeEnv,
-        path: trimmedCommand,
-        resolvedPathEnv: probeEnv?.PATH === process.env.PATH ? undefined : probeEnv?.PATH,
-      },
-    ];
+    const resolvedPathEnv = probeEnv?.PATH === process.env.PATH ? undefined : probeEnv?.PATH;
+    return {
+      candidates: [{ env: probeEnv, path: trimmedCommand, resolvedPathEnv }],
+      resolvedPathEnv,
+    };
   }
 
   const whichCommand = isWindows() ? 'where' : 'which';
@@ -297,27 +305,31 @@ const resolveCommandCandidates = async (
         PATH: lookupPath,
       };
       lines = await getCommandPathLines(whichCommand, trimmedCommand, fallbackEnv);
-      if (lines) {
-        lookupEnv = fallbackEnv;
-        resolvedPathEnv = lookupPath;
-      }
+      lookupEnv = fallbackEnv;
+      resolvedPathEnv = lookupPath;
     }
   }
 
-  if (!lines) return [];
+  if (!lines) return { candidates: [], resolvedPathEnv };
 
   // Windows `where` lists every PATHEXT match (e.g. for `codex` npm ships a
   // Unix shell wrapper alongside `codex.cmd` and `codex.ps1`). Keep only the
   // ones we can execute, still in PATH order.
   if (isWindows()) {
-    return pickWindowsRunnables(lines).map((runnablePath) => ({
-      env: lookupEnv,
-      path: runnablePath,
+    return {
+      candidates: pickWindowsRunnables(lines).map((runnablePath) => ({
+        env: lookupEnv,
+        path: runnablePath,
+        resolvedPathEnv,
+      })),
       resolvedPathEnv,
-    }));
+    };
   }
 
-  return [{ env: lookupEnv, path: lines[0], resolvedPathEnv }];
+  return {
+    candidates: [{ env: lookupEnv, path: lines[0], resolvedPathEnv }],
+    resolvedPathEnv,
+  };
 };
 
 const quoteWindowsShellToken = (token: string): string =>
@@ -383,7 +395,7 @@ const execProbe = async (
     });
   }
 
-  const spawnPlan = await resolveCliSpawnPlan(command, args);
+  const spawnPlan = await resolveCliSpawnPlan(command, args, env);
   if (isWindows() && spawnPlan.command === command && isWindowsShimPath(command)) {
     return UNRESOLVED_SHIM;
   }
@@ -421,8 +433,10 @@ export const detectValidatedCommand = async (
   // Resolve via where/which BEFORE invoking. On Windows this is what discovers
   // npm-installed shims like `claude.cmd` under %APPDATA%\npm — `execFile`
   // alone won't apply PATHEXT and can't run .cmd files directly.
-  const candidates = await resolveCommandCandidates(trimmedCommand, probeEnv);
-  if (candidates.length === 0) return { available: false };
+  const { candidates, resolvedPathEnv } = await resolveCommandCandidates(trimmedCommand, probeEnv);
+  if (candidates.length === 0) {
+    return resolvedPathEnv ? { available: false, resolvedPathEnv } : { available: false };
+  }
 
   const validateCandidate = async (
     { env, path: resolvedPath, resolvedPathEnv }: ResolvedCommand,
@@ -525,7 +539,37 @@ export const detectValidatedCommand = async (
     if (status !== UNRESOLVED_SHIM && status.available) return status;
   }
 
-  return { available: false };
+  return resolvedPathEnv ? { available: false, resolvedPathEnv } : { available: false };
+};
+
+/**
+ * Validate an ordered command chain while preserving PATH recovery between
+ * candidates. This is the shared contract for a bare command followed by
+ * well-known absolute install paths: an absolute launcher may live outside
+ * PATH while its `#!/usr/bin/env` interpreter only exists on the login PATH.
+ */
+export const detectValidatedCommandCandidates = async (
+  commands: string[],
+  options: ValidateOptions,
+  probeEnv?: NodeJS.ProcessEnv,
+): Promise<CliCommandStatus> => {
+  let effectiveProbeEnv = probeEnv;
+  let lastStatus: CliCommandStatus = { available: false };
+
+  for (const command of commands) {
+    const status = await detectValidatedCommand(command, options, effectiveProbeEnv);
+    if (status.available) return status;
+
+    lastStatus = status;
+    if (status.resolvedPathEnv && status.resolvedPathEnv !== effectiveProbeEnv?.PATH) {
+      effectiveProbeEnv = {
+        ...(effectiveProbeEnv ?? process.env),
+        PATH: status.resolvedPathEnv,
+      };
+    }
+  }
+
+  return lastStatus;
 };
 
 const HETEROGENEOUS_CLI_AGENT_OPTIONS = {
@@ -750,22 +794,17 @@ export const detectHeterogeneousCliCommand = async (
   const validator = HETEROGENEOUS_CLI_AGENT_OPTIONS[agentType];
   if (!validator) return { available: false };
 
-  const status = await detectValidatedCommand(command, validator, probeEnv);
-  if (status.available) return status;
-
   // The default command missing from PATH may still live at a well-known install
   // location (e.g. the Codex desktop app's bundled CLI). Only probe those for the
   // default command: the well-known paths hold the *default* binary, so applying
   // them to a custom command (e.g. `claude-beta`) would silently resolve it to
   // stock `claude` instead of reporting the configured command as missing.
-  if (command.trim() === DEFAULT_HETERO_COMMAND[agentType]) {
-    for (const candidate of getWellKnownCommandPaths(agentType)) {
-      const fallbackStatus = await detectValidatedCommand(candidate, validator, probeEnv);
-      if (fallbackStatus.available) return fallbackStatus;
-    }
-  }
+  const commands =
+    command.trim() === DEFAULT_HETERO_COMMAND[agentType]
+      ? [command, ...getWellKnownCommandPaths(agentType)]
+      : [command];
 
-  return status;
+  return detectValidatedCommandCandidates(commands, validator, probeEnv);
 };
 
 /**

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
@@ -32,6 +32,7 @@ export type HeterogeneousCliAgentType = LocalHeterogeneousAgentType;
  */
 export interface CliCommandStatus {
   available: boolean;
+  error?: string;
   path?: string;
   /**
    * PATH used to resolve/validate the command, surfaced only when it differs
@@ -138,8 +139,15 @@ const getLoginShellPath = async (): Promise<string | undefined> => {
   }
 };
 
-const getCachedLoginShellPath = async (): Promise<string | undefined> => {
-  shellPathPromise ??= getLoginShellPath();
+/**
+ * Share one login-shell lookup between concurrent probes, but discard it once
+ * settled. A later Rescan must observe PATH edits made by an installer while
+ * the desktop app is already running.
+ */
+const getCurrentLoginShellPath = async (): Promise<string | undefined> => {
+  shellPathPromise ??= getLoginShellPath().finally(() => {
+    shellPathPromise = undefined;
+  });
   return shellPathPromise;
 };
 
@@ -280,7 +288,7 @@ const resolveCommandCandidates = async (
     // creation-time snapshot that never picks up a later install).
     const recoveredPath = isWindows()
       ? await getWindowsRegistryPath()
-      : await getCachedLoginShellPath();
+      : await getCurrentLoginShellPath();
     const lookupPath = mergePathValues(recoveredPath, probeEnv?.PATH ?? process.env.PATH);
 
     if (lookupPath && lookupPath !== (probeEnv?.PATH ?? process.env.PATH)) {

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
@@ -72,6 +72,11 @@ interface ResolvedCommandCandidates {
   resolvedPathEnv?: string;
 }
 
+interface RecoveredProbeEnvironment {
+  env: NodeJS.ProcessEnv;
+  resolvedPathEnv: string;
+}
+
 const VERSION_PATTERN = /v?(\d+\.\d+\.\d+(?:[-+][\dA-Za-z.-]+)?)/;
 
 const extractVersion = (versionBanner: string): string | undefined =>
@@ -239,6 +244,26 @@ const mergePathValues = (...values: Array<string | undefined>): string | undefin
   return segments.length > 0 ? segments.join(path.delimiter) : undefined;
 };
 
+const recoverProbeEnvironment = async (
+  probeEnv?: NodeJS.ProcessEnv,
+): Promise<RecoveredProbeEnvironment | undefined> => {
+  const recoveredPath = isWindows()
+    ? await getWindowsRegistryPath()
+    : await getCurrentLoginShellPath();
+  const currentPath = probeEnv?.PATH ?? process.env.PATH;
+  const resolvedPathEnv = mergePathValues(recoveredPath, currentPath);
+
+  if (!resolvedPathEnv || resolvedPathEnv === currentPath) return;
+
+  return {
+    env: {
+      ...(probeEnv ?? process.env),
+      PATH: resolvedPathEnv,
+    },
+    resolvedPathEnv,
+  };
+};
+
 const getCommandPathLines = async (
   whichCommand: 'where' | 'which',
   command: string,
@@ -294,19 +319,11 @@ const resolveCommandCandidates = async (
     // PATH recovery, per platform: macOS/Linux re-read the login shell's PATH,
     // Windows re-reads the registry environment (the inherited block is a
     // creation-time snapshot that never picks up a later install).
-    const recoveredPath = isWindows()
-      ? await getWindowsRegistryPath()
-      : await getCurrentLoginShellPath();
-    const lookupPath = mergePathValues(recoveredPath, probeEnv?.PATH ?? process.env.PATH);
-
-    if (lookupPath && lookupPath !== (probeEnv?.PATH ?? process.env.PATH)) {
-      const fallbackEnv = {
-        ...(probeEnv ?? process.env),
-        PATH: lookupPath,
-      };
-      lines = await getCommandPathLines(whichCommand, trimmedCommand, fallbackEnv);
-      lookupEnv = fallbackEnv;
-      resolvedPathEnv = lookupPath;
+    const recovered = await recoverProbeEnvironment(probeEnv);
+    if (recovered) {
+      lines = await getCommandPathLines(whichCommand, trimmedCommand, recovered.env);
+      lookupEnv = recovered.env;
+      resolvedPathEnv = recovered.resolvedPathEnv;
     }
   }
 
@@ -537,6 +554,17 @@ export const detectValidatedCommand = async (
   for (const candidate of unresolvedShims) {
     const status = await validateCandidate(candidate, true);
     if (status !== UNRESOLVED_SHIM && status.available) return status;
+  }
+
+  // A stale or unrelated executable on the inherited PATH prevents lookup-time
+  // recovery because `which`/`where` succeeds. Validation failure must trigger
+  // the same recovered-PATH phase before an ordered resolver moves on to its
+  // absolute fallbacks. Retrying here also lets a login-shell command ahead of
+  // the stale inherited candidate win. The recursive call cannot repeat: a
+  // recovered environment always carries `resolvedPathEnv`.
+  if (!resolvedPathEnv && !isPathLikeCommand(trimmedCommand)) {
+    const recovered = await recoverProbeEnvironment(probeEnv);
+    if (recovered) return detectValidatedCommand(trimmedCommand, options, recovered.env);
   }
 
   return resolvedPathEnv ? { available: false, resolvedPathEnv } : { available: false };

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
@@ -62,16 +62,6 @@ interface ResolvedCommand {
   resolvedPathEnv?: string;
 }
 
-interface ResolvedCommandCandidates {
-  candidates: ResolvedCommand[];
-  /**
-   * PATH recovered while looking up a bare command. Keep it even when lookup
-   * found no executable so a subsequent absolute fallback can still run an
-   * env-based launcher with the interpreter PATH that a login shell exposes.
-   */
-  resolvedPathEnv?: string;
-}
-
 interface RecoveredProbeEnvironment {
   env: NodeJS.ProcessEnv;
   resolvedPathEnv: string;
@@ -221,7 +211,7 @@ const readMergedWindowsRegistryPath = async (): Promise<string | undefined> => {
  * answer for the process lifetime would re-create the staleness it fixes: a
  * CLI installed after the first failed scan would stay "not installed" until
  * the app restarted. `reg query` is a couple of short-lived processes, and it
- * only runs when `where` already came up empty.
+ * only runs after the complete inherited-environment pass fails.
  */
 const getWindowsRegistryPath = async (): Promise<string | undefined> => {
   registryPathPromise ??= readMergedWindowsRegistryPath().finally(() => {
@@ -298,55 +288,32 @@ const getCommandPathLines = async (
 const resolveCommandCandidates = async (
   command: string,
   probeEnv?: NodeJS.ProcessEnv,
-): Promise<ResolvedCommandCandidates> => {
+): Promise<ResolvedCommand[]> => {
   const trimmedCommand = command.trim();
-  if (!trimmedCommand) return { candidates: [] };
+  if (!trimmedCommand) return [];
+
+  const resolvedPathEnv = probeEnv?.PATH === process.env.PATH ? undefined : probeEnv?.PATH;
 
   if (isPathLikeCommand(trimmedCommand)) {
-    const resolvedPathEnv = probeEnv?.PATH === process.env.PATH ? undefined : probeEnv?.PATH;
-    return {
-      candidates: [{ env: probeEnv, path: trimmedCommand, resolvedPathEnv }],
-      resolvedPathEnv,
-    };
+    return [{ env: probeEnv, path: trimmedCommand, resolvedPathEnv }];
   }
 
   const whichCommand = isWindows() ? 'where' : 'which';
-  let lines = await getCommandPathLines(whichCommand, trimmedCommand, probeEnv);
-  let lookupEnv = probeEnv;
-  let resolvedPathEnv = probeEnv?.PATH === process.env.PATH ? undefined : probeEnv?.PATH;
-
-  if (!lines) {
-    // PATH recovery, per platform: macOS/Linux re-read the login shell's PATH,
-    // Windows re-reads the registry environment (the inherited block is a
-    // creation-time snapshot that never picks up a later install).
-    const recovered = await recoverProbeEnvironment(probeEnv);
-    if (recovered) {
-      lines = await getCommandPathLines(whichCommand, trimmedCommand, recovered.env);
-      lookupEnv = recovered.env;
-      resolvedPathEnv = recovered.resolvedPathEnv;
-    }
-  }
-
-  if (!lines) return { candidates: [], resolvedPathEnv };
+  const lines = await getCommandPathLines(whichCommand, trimmedCommand, probeEnv);
+  if (!lines) return [];
 
   // Windows `where` lists every PATHEXT match (e.g. for `codex` npm ships a
   // Unix shell wrapper alongside `codex.cmd` and `codex.ps1`). Keep only the
   // ones we can execute, still in PATH order.
   if (isWindows()) {
-    return {
-      candidates: pickWindowsRunnables(lines).map((runnablePath) => ({
-        env: lookupEnv,
-        path: runnablePath,
-        resolvedPathEnv,
-      })),
+    return pickWindowsRunnables(lines).map((runnablePath) => ({
+      env: probeEnv,
+      path: runnablePath,
       resolvedPathEnv,
-    };
+    }));
   }
 
-  return {
-    candidates: [{ env: lookupEnv, path: lines[0], resolvedPathEnv }],
-    resolvedPathEnv,
-  };
+  return [{ env: probeEnv, path: lines[0], resolvedPathEnv }];
 };
 
 const quoteWindowsShellToken = (token: string): string =>
@@ -429,7 +396,7 @@ const execProbe = async (
  * matching `--version` output against a keyword or output pattern (avoids
  * collisions with an unrelated executable of the same name).
  */
-export const detectValidatedCommand = async (
+const detectValidatedCommandInEnvironment = async (
   command: string,
   options: ValidateOptions,
   probeEnv?: NodeJS.ProcessEnv,
@@ -450,7 +417,8 @@ export const detectValidatedCommand = async (
   // Resolve via where/which BEFORE invoking. On Windows this is what discovers
   // npm-installed shims like `claude.cmd` under %APPDATA%\npm — `execFile`
   // alone won't apply PATHEXT and can't run .cmd files directly.
-  const { candidates, resolvedPathEnv } = await resolveCommandCandidates(trimmedCommand, probeEnv);
+  const candidates = await resolveCommandCandidates(trimmedCommand, probeEnv);
+  const resolvedPathEnv = probeEnv?.PATH === process.env.PATH ? undefined : probeEnv?.PATH;
   if (candidates.length === 0) {
     return resolvedPathEnv ? { available: false, resolvedPathEnv } : { available: false };
   }
@@ -556,49 +524,70 @@ export const detectValidatedCommand = async (
     if (status !== UNRESOLVED_SHIM && status.available) return status;
   }
 
-  // A stale or unrelated executable on the inherited PATH prevents lookup-time
-  // recovery because `which`/`where` succeeds. Validation failure must trigger
-  // the same recovered-PATH phase before an ordered resolver moves on to its
-  // absolute fallbacks. Retrying here also lets a login-shell command ahead of
-  // the stale inherited candidate win. The recursive call cannot repeat: a
-  // recovered environment always carries `resolvedPathEnv`.
-  if (!resolvedPathEnv && !isPathLikeCommand(trimmedCommand)) {
-    const recovered = await recoverProbeEnvironment(probeEnv);
-    if (recovered) return detectValidatedCommand(trimmedCommand, options, recovered.env);
-  }
-
   return resolvedPathEnv ? { available: false, resolvedPathEnv } : { available: false };
 };
 
 /**
- * Validate an ordered command chain while preserving PATH recovery between
- * candidates. This is the shared contract for a bare command followed by
- * well-known absolute install paths: an absolute launcher may live outside
- * PATH while its `#!/usr/bin/env` interpreter only exists on the login PATH.
+ * Validate an ordered command chain in one exact environment. PATH state does
+ * not leak between candidates; every candidate in a pass sees the same PATH.
+ */
+const detectValidatedCommandCandidatesInEnvironment = async (
+  commands: string[],
+  options: ValidateOptions,
+  probeEnv?: NodeJS.ProcessEnv,
+): Promise<CliCommandStatus> => {
+  let lastStatus: CliCommandStatus = probeEnv?.PATH
+    ? { available: false, resolvedPathEnv: probeEnv.PATH }
+    : { available: false };
+
+  for (const command of commands) {
+    const status = await detectValidatedCommandInEnvironment(command, options, probeEnv);
+    if (status.available) return status;
+    lastStatus = status;
+  }
+
+  return lastStatus;
+};
+
+/**
+ * Validate the complete ordered candidate chain in at most two environments:
+ * first the caller's inherited PATH, then one freshly recovered login-shell or
+ * Windows-registry PATH. Both lookup misses and validation failures therefore
+ * take the same recovery edge, and absolute fallback launchers receive the
+ * interpreter PATH that made the second pass succeed.
  */
 export const detectValidatedCommandCandidates = async (
   commands: string[],
   options: ValidateOptions,
   probeEnv?: NodeJS.ProcessEnv,
 ): Promise<CliCommandStatus> => {
-  let effectiveProbeEnv = probeEnv;
-  let lastStatus: CliCommandStatus = { available: false };
+  const inheritedStatus = await detectValidatedCommandCandidatesInEnvironment(
+    commands,
+    options,
+    probeEnv,
+  );
+  if (inheritedStatus.available) return inheritedStatus;
 
-  for (const command of commands) {
-    const status = await detectValidatedCommand(command, options, effectiveProbeEnv);
-    if (status.available) return status;
+  // Skip recovery only when there is nothing safe to execute. Absolute
+  // launchers still get the second pass because an `env` shebang may depend on
+  // an interpreter exposed only by the recovered PATH.
+  const hasProbeableCommand = commands.some((command) => {
+    const trimmedCommand = command.trim();
+    return trimmedCommand.length > 0 && !(isWindows() && WINDOWS_SHELL_METAS.test(trimmedCommand));
+  });
+  if (!hasProbeableCommand) return inheritedStatus;
 
-    lastStatus = status;
-    if (status.resolvedPathEnv && status.resolvedPathEnv !== effectiveProbeEnv?.PATH) {
-      effectiveProbeEnv = {
-        ...(effectiveProbeEnv ?? process.env),
-        PATH: status.resolvedPathEnv,
-      };
-    }
-  }
+  const recovered = await recoverProbeEnvironment(probeEnv);
+  if (!recovered) return inheritedStatus;
 
-  return lastStatus;
+  return detectValidatedCommandCandidatesInEnvironment(commands, options, recovered.env);
 };
+
+export const detectValidatedCommand = async (
+  command: string,
+  options: ValidateOptions,
+  probeEnv?: NodeJS.ProcessEnv,
+): Promise<CliCommandStatus> => detectValidatedCommandCandidates([command], options, probeEnv);
 
 const HETEROGENEOUS_CLI_AGENT_OPTIONS = {
   'amp': {

--- a/packages/types/src/agent/heterogeneousAgent.ts
+++ b/packages/types/src/agent/heterogeneousAgent.ts
@@ -338,15 +338,48 @@ export const LOCAL_HETEROGENEOUS_AGENT_TYPES = HETEROGENEOUS_AGENT_CONFIGS.map((
 
 export const LocalHeterogeneousAgentTypeSchema = z.enum(LOCAL_HETEROGENEOUS_AGENT_TYPES);
 
+export interface RemoteHeterogeneousAgentCliDescriptor {
+  command: string;
+  validation: {
+    helpKeywords?: readonly string[];
+    keywords?: readonly string[];
+    pattern?: string;
+  };
+  wellKnownHomePaths?: readonly string[];
+}
+
 export interface RemoteHeterogeneousAgentDescriptor {
+  cli: RemoteHeterogeneousAgentCliDescriptor;
   kind: 'remote-task';
   title: string;
   type: string;
 }
 
 export const REMOTE_HETEROGENEOUS_AGENT_CONFIGS = [
-  { kind: 'remote-task', title: 'OpenClaw', type: 'openclaw' },
-  { kind: 'remote-task', title: 'Hermes', type: 'hermes' },
+  {
+    cli: {
+      command: 'openclaw',
+      validation: {
+        helpKeywords: ['Usage: openclaw'],
+        keywords: ['openclaw'],
+        pattern: '^v?\\d+\\.\\d+\\.\\d+(?:[-+][\\dA-Za-z.-]+)?$',
+      },
+      wellKnownHomePaths: ['.openclaw/bin/openclaw', '.local/bin/openclaw'],
+    },
+    kind: 'remote-task',
+    title: 'OpenClaw',
+    type: 'openclaw',
+  },
+  {
+    cli: {
+      command: 'hermes',
+      validation: { keywords: ['hermes'] },
+      wellKnownHomePaths: ['.local/bin/hermes'],
+    },
+    kind: 'remote-task',
+    title: 'Hermes',
+    type: 'hermes',
+  },
 ] as const satisfies readonly RemoteHeterogeneousAgentDescriptor[];
 
 export type HeterogeneousAgentDescriptor =

--- a/src/features/ConnectAgent/useAgentScan.test.ts
+++ b/src/features/ConnectAgent/useAgentScan.test.ts
@@ -37,6 +37,28 @@ describe('scanLocal', () => {
       command: 'hermes',
     });
   });
+
+  it('preserves detector and IPC failure reasons', async () => {
+    detectHeterogeneousAgentCommand.mockImplementation(async ({ agentType }) => {
+      if (agentType === 'openclaw') {
+        return { available: false, error: 'openclaw failed validation' };
+      }
+      if (agentType === 'hermes') throw new Error('hermes scan timed out');
+      return { available: false };
+    });
+
+    const agents = await scanLocal();
+
+    expect(agents.openclaw).toEqual({
+      available: false,
+      reason: 'openclaw failed validation',
+      version: undefined,
+    });
+    expect(agents.hermes).toEqual({
+      available: false,
+      reason: 'hermes scan timed out',
+    });
+  });
 });
 
 describe('buildPlatformAgencyConfig', () => {

--- a/src/features/ConnectAgent/useAgentScan.ts
+++ b/src/features/ConnectAgent/useAgentScan.ts
@@ -34,9 +34,19 @@ export const scanLocal = async (): Promise<HeterogeneousAgentScanMap> => {
           agentType: provider.type,
           command: provider.command ?? provider.type,
         });
-        return [provider.type, { available: status.available, version: status.version }] as const;
-      } catch {
-        return [provider.type, { available: false }] as const;
+        return [
+          provider.type,
+          {
+            available: status.available,
+            ...(status.error ? { reason: status.error } : undefined),
+            version: status.version,
+          },
+        ] as const;
+      } catch (error) {
+        return [
+          provider.type,
+          { available: false, reason: error instanceof Error ? error.message : String(error) },
+        ] as const;
       }
     }),
   );


### PR DESCRIPTION
Fix false-negative local detection for OpenClaw and Hermes in the Connect Agent wizard.

- accept the bare version banner emitted by OpenClaw 2026.1.29 while capability-checking its help output
- probe the official OpenClaw and Hermes user-local installation paths
- re-read the macOS/Linux login-shell PATH after installation instead of caching the first lookup forever
- recover PATH after either a bare-command lookup miss or validation rejection, then carry it through absolute fallbacks
- support env-based launchers and Windows npm shims with the same recovered environment
- make CLI capability checks, profile probes, and task execution use the same resolved executable and PATH
- reuse the resolved executable and recovered PATH when loading desktop platform profiles
- preserve detector failures so unavailable rows can expose the actual reason

| Before | After |
| ------ | ----- |
| Installed OpenClaw/Hermes could appear as **Not installed**, lose profile metadata, or fail its first CLI-dispatched task when found outside the inherited PATH | Supported installs are detected after Rescan, and capability/profile/task execution all use the validated command and environment |

#### Test

- `bun run check packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts packages/heterogeneous-agents/src/scan/scanHost.ts packages/heterogeneous-agents/src/scan/scanHost.test.ts src/features/ConnectAgent/useAgentScan.ts src/features/ConnectAgent/useAgentScan.test.ts` — 64 tests passed
- `bun run check apps/desktop/src/main/controllers/GatewayConnectionCtr.ts apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts` — 86 tests passed
- `bun run check packages/heterogeneous-agents/src/spawn/cliSpawn.ts packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts packages/heterogeneous-agents/src/scan/scanHost.ts packages/heterogeneous-agents/src/scan/scanHost.test.ts apps/cli/src/tools/heteroTask.ts apps/cli/src/tools/__tests__/heteroTask.test.ts apps/cli/src/tools/getAgentProfile.ts apps/cli/src/tools/__tests__/getAgentProfile.test.ts apps/cli/src/tools/checkPlatformCapability.ts apps/cli/src/tools/__tests__/checkPlatformCapability.test.ts` — 100 tests passed
- `bun run check --type` — types clean

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

No matching issue found.