### PR TITLE
🐛 fix(model-bank): align Gemini -latest alias pricing and Gemini 2.5 cache-read rates

### DIFF
--- a/packages/model-bank/src/aiModels/__tests__/index.test.ts
+++ b/packages/model-bank/src/aiModels/__tests__/index.test.ts
@@ -226,6 +226,24 @@ describe('Google rolling model aliases', () => {
     expect(flashLiteLatest?.pricing).toEqual(flashLite?.pricing);
     expect(flashLiteLatest?.settings?.disabledParams).toEqual(['temperature', 'top_p']);
   });
+
+  // Every `-latest` alias must be priced as the model its description points to.
+  // Asserting it generically means repointing an alias without repricing it fails here.
+  it.each([['gemini-pro-latest'], ['gemini-flash-latest'], ['gemini-flash-lite-latest']])(
+    'prices %s the same as the model it points to',
+    (aliasId) => {
+      const googleModels = LOBE_DEFAULT_MODEL_LIST.filter((model) => model.providerId === 'google');
+      const alias = googleModels.find((model) => model.id === aliasId);
+
+      expect(alias).toBeDefined();
+
+      const targetId = alias?.description?.replace('Points to ', '');
+      const target = googleModels.find((model) => model.id === targetId);
+
+      expect(target).toBeDefined();
+      expect(alias?.pricing).toEqual(target?.pricing);
+    },
+  );
 });
 
 describe('Google Gemini 3.1 Flash Image models', () => {

--- a/packages/model-bank/src/aiModels/google.ts
+++ b/packages/model-bank/src/aiModels/google.ts
@@ -30,14 +30,16 @@ const googleChatModels: AIChatModelCard[] = [
     id: 'gemini-pro-latest',
     knowledgeCutoff: '2025-01',
     maxOutput: 65_536,
+    // Mirrors gemini-3.1-pro-preview, the model this alias points to.
+    // See https://ai.google.dev/gemini-api/docs/pricing
     pricing: {
       units: [
         {
           name: 'textInput_cacheRead',
           strategy: 'tiered',
           tiers: [
-            { rate: 0.31, upTo: 200_000 },
-            { rate: 0.625, upTo: 'infinity' },
+            { rate: 0.2, upTo: 200_000 },
+            { rate: 0.4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
         },
@@ -45,8 +47,35 @@ const googleChatModels: AIChatModelCard[] = [
           name: 'textInput',
           strategy: 'tiered',
           tiers: [
-            { rate: 1.25, upTo: 200_000 },
-            { rate: 2.5, upTo: 'infinity' },
+            { rate: 2, upTo: 200_000 },
+            { rate: 4, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'imageInput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 2, upTo: 200_000 },
+            { rate: 4, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'videoInput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 2, upTo: 200_000 },
+            { rate: 4, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'audioInput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 2, upTo: 200_000 },
+            { rate: 4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
         },
@@ -54,9 +83,15 @@ const googleChatModels: AIChatModelCard[] = [
           name: 'textOutput',
           strategy: 'tiered',
           tiers: [
-            { rate: 10, upTo: 200_000 },
-            { rate: 15, upTo: 'infinity' },
+            { rate: 12, upTo: 200_000 },
+            { rate: 18, upTo: 'infinity' },
           ],
+          unit: 'millionTokens',
+        },
+        {
+          lookup: { prices: { '1h': 4.5 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
           unit: 'millionTokens',
         },
       ],
@@ -85,16 +120,20 @@ const googleChatModels: AIChatModelCard[] = [
     id: 'gemini-flash-latest',
     knowledgeCutoff: '2026-03',
     maxOutput: 65_536,
+    // Mirrors gemini-3.7-flash, the model this alias points to.
+    // Introductory pricing, in effect through 2026-12-31. From 2027-01-01 standard rates apply:
+    // input 1.5 / output 7.5 / cacheRead 0.15 / cacheWrite lookup { '1h': 1 } (per million tokens).
+    // See https://ai.google.dev/gemini-api/docs/pricing
     pricing: {
       units: [
-        { name: 'textInput_cacheRead', rate: 0.15, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'imageInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'videoInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'audioInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 7.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.075, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.75, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageInput', rate: 0.75, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'videoInput', rate: 0.75, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'audioInput', rate: 0.75, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 3.75, strategy: 'fixed', unit: 'millionTokens' },
         {
-          lookup: { prices: { '1h': 1 }, pricingParams: ['ttl'] },
+          lookup: { prices: { '1h': 0.5 }, pricingParams: ['ttl'] },
           name: 'textInput_cacheWrite',
           strategy: 'lookup',
           unit: 'millionTokens',
@@ -757,8 +796,8 @@ const googleChatModels: AIChatModelCard[] = [
           name: 'textInput_cacheRead',
           strategy: 'tiered',
           tiers: [
-            { rate: 0.31, upTo: 200_000 },
-            { rate: 0.625, upTo: 'infinity' },
+            { rate: 0.125, upTo: 200_000 },
+            { rate: 0.25, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
         },
@@ -842,7 +881,7 @@ const googleChatModels: AIChatModelCard[] = [
     maxOutput: 65_536,
     pricing: {
       units: [
-        { name: 'textInput_cacheRead', rate: 0.075, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.03, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'imageInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'videoInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
@@ -907,7 +946,7 @@ const googleChatModels: AIChatModelCard[] = [
     maxOutput: 65_536,
     pricing: {
       units: [
-        { name: 'textInput_cacheRead', rate: 0.025, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.01, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 0.1, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 0.4, strategy: 'fixed', unit: 'millionTokens' },
       ],

--- a/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.test.ts
+++ b/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.test.ts
@@ -292,8 +292,8 @@ describe('computeChatPricing', () => {
       // Verify cached tokens
       const cached = breakdown.find((item) => item.unit.name === 'textInput_cacheRead');
       expect(cached?.quantity).toBe(253_891);
-      expect(cached?.credits).toBe(158_682); // ceil(253891 * 0.625) = 158682
-      expect(cached?.segments).toEqual([{ quantity: 253_891, rate: 0.625, credits: 158_681.875 }]);
+      expect(cached?.credits).toBe(63_473); // ceil(253891 * 0.25) = 63473
+      expect(cached?.segments).toEqual([{ quantity: 253_891, rate: 0.25, credits: 63_472.75 }]);
 
       // Verify input cache miss tokens
       const input = breakdown.find((item) => item.unit.name === 'textInput');
@@ -308,8 +308,8 @@ describe('computeChatPricing', () => {
       expect(output?.segments).toEqual([{ quantity: 3_063, rate: 15, credits: 45_945 }]);
 
       // Verify totals
-      expect(totalCredits).toBe(215_315); // 158682 + 10688 + 45945 = 215315
-      expect(totalCost).toBeCloseTo(0.215315, 6);
+      expect(totalCredits).toBe(120_106); // 63473 + 10688 + 45945 = 120106
+      expect(totalCost).toBeCloseTo(0.120106, 6);
     });
 
     it('supports multi-modal fixed units for Gemini 2.5 Flash Image Preview', () => {
@@ -864,8 +864,8 @@ describe('computeChatPricing', () => {
       // Verify cached tokens
       const cached = breakdown.find((item) => item.unit.name === 'textInput_cacheRead');
       expect(cached?.quantity).toBe(257_955);
-      expect(cached?.credits).toBe(161_222); // ceil(257955 * 0.625) = 161222
-      expect(cached?.segments).toEqual([{ quantity: 257_955, rate: 0.625, credits: 161_221.875 }]);
+      expect(cached?.credits).toBe(64_489); // ceil(257955 * 0.25) = 64489
+      expect(cached?.segments).toEqual([{ quantity: 257_955, rate: 0.25, credits: 64_488.75 }]);
 
       // Verify input cache miss tokens
       const input = breakdown.find((item) => item.unit.name === 'textInput');
@@ -880,8 +880,8 @@ describe('computeChatPricing', () => {
       expect(output?.segments).toEqual([{ quantity: 1_744, rate: 15, credits: 26_160 }]);
 
       // Verify totals
-      expect(totalCredits).toBe(199_895); // 161222 + 12513 + 26160 = 199895
-      expect(totalCost).toBeCloseTo(0.199895, 6);
+      expect(totalCredits).toBe(103_162); // 64489 + 12513 + 26160 = 103162
+      expect(totalCost).toBeCloseTo(0.103162, 6);
     });
 
     it('bills tool-use (grounding) tokens at textInput rate when no explicit cache', () => {


### PR DESCRIPTION
### What

Three Gemini price rows in `packages/model-bank/src/aiModels/google.ts` disagree either with
Google's published rate card or with the row they say they mirror. All three make LobeHub's
displayed cost roughly **2x too high** for cache-heavy traffic.

Every number below is from https://ai.google.dev/gemini-api/docs/pricing, checked today.

#### 1. `gemini-flash-latest` is priced at the 2027 rate

`#18289` repointed this alias from `gemini-3.6-flash` to `gemini-3.7-flash` and updated its
`extendParams`, but left the `pricing` block untouched. In the same PR, `gemini-3.6-flash` was
repriced down to the introductory rate — with a comment that spells out exactly what the alias
is now carrying:

```ts
// Introductory pricing, in effect through 2026-12-31. From 2027-01-01 standard rates apply:
// input 1.5 / output 7.5 / cacheRead 0.15 / cacheWrite lookup { '1h': 1 } (per million tokens).
```

| | input | output | cacheRead | cacheWrite 1h |
| --- | --- | --- | --- | --- |
| `gemini-3.7-flash` (target) | 0.75 | 3.75 | 0.075 | 0.5 |
| `gemini-flash-latest` (alias, today) | **1.5** | **7.5** | **0.15** | **1** |

Exactly 2x, on every unit, until 2027-01-01.

#### 2. `gemini-pro-latest` still carries Gemini 2.5 Pro's rate card

Its description says `Points to gemini-3.1-pro-preview`, but its numbers are 2.5 Pro's:

| | input ≤200k / >200k | output | cacheRead |
| --- | --- | --- | --- |
| `gemini-3.1-pro-preview` (target) | 2 / 4 | 12 / 18 | 0.2 / 0.4 |
| `gemini-pro-latest` (alias, today) | **1.25 / 2.5** | **10 / 15** | **0.31 / 0.625** |

Input is 1.6x low, output 1.2x low, cache read 1.55x high. It is also missing the
`imageInput` / `videoInput` / `audioInput` / `textInput_cacheWrite` units the target has, so
multi-modal input on this alias currently bills at nothing.

The third alias, `gemini-flash-lite-latest`, matches its target exactly — that is the intended
convention, and it is the one the existing test happens to pin.

#### 3. Gemini 2.5 cache reads are at the retired 2.0 ratio

Google charges 10% of input for context caching on 2.5. These rows use 25%, which was the
Gemini 2.0 rate:

| model | cacheRead today | Google publishes |
| --- | --- | --- |
| `gemini-2.5-pro` | 0.31 / 0.625 | **0.125 / 0.25** |
| `gemini-2.5-flash` | 0.075 | **0.03** |
| `gemini-2.5-flash-lite` | 0.025 | **0.01** |

This is specifically a 2.5 problem: every 3.x row in the file already uses 10%, and the 2.0 and
1.5 rows correctly use 25% because that *was* the rate then, which is why it doesn't read as
wrong at a glance.

### Impact

Priced at a coding agent's token mix — 95.6% cache read, 4.1% cache miss, 0.3% output, measured
over 8.04B tokens — per 1M tokens:

| model | LobeHub shows | should be | |
| --- | --- | --- | --- |
| `gemini-flash-latest` | $0.2274 | $0.1137 | 2.00x |
| `gemini-2.5-flash-lite` | $0.0292 | $0.0149 | 1.97x |
| `gemini-2.5-pro` (>200k) | $0.7450 | $0.3865 | 1.93x |
| `gemini-2.5-flash` | $0.0915 | $0.0485 | 1.89x |
| `gemini-pro-latest` (≤200k) | $0.3776 | $0.3092 | 1.22x |

`gemini-pro-latest` is the mixed one: over-billed on cache reads, under-billed on input and
output, so a short uncached prompt is reported *cheaper* than it is.

### Test

`Google rolling model aliases` already asserts `flashLiteLatest.pricing === flashLite.pricing`,
but only for that one pair — which is why the other two drifted. I replaced the one-off check
with a generic one that reads each alias's own `description` and compares against the model it
names, so repointing an alias without repricing it fails here:

```ts
it.each([
  ['gemini-pro-latest'],
  ['gemini-flash-latest'],
  ['gemini-flash-lite-latest'],
])('prices %s the same as the model it points to', (aliasId) => {
```

Two `computeChatCost` cases read `gemini-2.5-pro`'s real pricing and had the old 0.625 baked
into their expected credits; those are updated with the arithmetic shown in the comments.

### Not changed here

The same two rows exist elsewhere and I left them alone rather than guess:

- `vertexai.ts` prices `gemini-3.6-flash` and `gemini-3.7-flash` at **1.5 / 7.5 / 0.15** — the
  post-2027 numbers — while `google.ts` has 0.75 / 3.75 / 0.075 for the same models. Same PR
  added both. I could not load Vertex's own pricing table to confirm Vertex mirrors AI Studio
  here, and `gemini-2.0-flash` is already priced differently in the two files (0.15 vs 0.10), so
  I did not assume it. Happy to include it if you confirm the direction.
- `vertexai.ts` and `aihubmix.ts` carry the same 25% cache-read ratio on their Gemini 2.5 rows.
  `aihubmix.ts` mirrors google.ts exactly on every 3.x row, so those two rows are very likely the
  same defect — say the word and I'll add them to this PR.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```
pnpm --filter model-bank    exec vitest run   →  8 files, 91 passed
pnpm --filter model-runtime exec vitest run   →  186 files, 4644 passed, 1 skipped
npx tsgo --noEmit                             →  exit 0
npx prettier --check <the 3 files>            →  clean
```

Negative control for the new assertion: with only `gemini-flash-latest`'s pricing reverted to
its current values, `prices gemini-flash-latest the same as the model it points to` fails and
the other 16 still pass — so the test is pinning the thing it claims to pin.

#### 🔗 Related Issue

None — found while diffing the catalog against Google's rate card. Related to #18289, which is
where the `gemini-flash-latest` alias was repointed.
