### PR TITLE
💄 feat: make the default assistant name white-label aware

### DIFF
--- a/apps/share/src/features/topic/topicByline.ts
+++ b/apps/share/src/features/topic/topicByline.ts
@@ -1,7 +1,9 @@
+import { DEFAULT_INBOX_TITLE } from '@lobechat/const';
+
 import { type SharedTopicData } from '@/types/topic';
 
 export const buildTopicByline = (data: SharedTopicData) => {
   const isInboxAgent = !data.groupId && data.agentMeta?.slug === 'inbox';
 
-  return data.groupMeta?.title || (isInboxAgent ? 'Lobe AI' : data.agentMeta?.title);
+  return data.groupMeta?.title || (isInboxAgent ? DEFAULT_INBOX_TITLE : data.agentMeta?.title);
 };

--- a/packages/builtin-agents/src/agents/agent-builder/index.ts
+++ b/packages/builtin-agents/src/agents/agent-builder/index.ts
@@ -1,6 +1,6 @@
 import { AgentBuilderIdentifier } from '@lobechat/builtin-tool-agent-builder';
 import { DEFAULT_PROVIDER } from '@lobechat/business-const';
-import { DEFAULT_MODEL } from '@lobechat/const';
+import { DEFAULT_AGENT_BUILDER_AVATAR, DEFAULT_MODEL } from '@lobechat/const';
 
 import type { BuiltinAgentDefinition } from '../../types';
 import { BUILTIN_AGENT_SLUGS } from '../../types';
@@ -41,7 +41,7 @@ const AGENT_BUILDER_CONFLICTING_TOOLS = new Set<string>([
  * Agent Builder - used for configuring AI agents through natural conversation
  */
 export const AGENT_BUILDER: BuiltinAgentDefinition = {
-  avatar: '/avatars/agent-builder.png',
+  avatar: DEFAULT_AGENT_BUILDER_AVATAR,
 
   // Persist config - stored in database
   persist: {

--- a/packages/builtin-agents/src/agents/builtinAvatars.test.ts
+++ b/packages/builtin-agents/src/agents/builtinAvatars.test.ts
@@ -1,0 +1,74 @@
+import type * as BusinessConst from '@lobechat/business-const';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Each case re-imports the agent modules from cold after `vi.resetModules()`,
+// and that graph reaches the builtin-tool packages. The first one routinely
+// exceeds the 5s default while the rest run warm — a timeout here would say
+// nothing about the avatars.
+vi.setConfig({ testTimeout: 30_000 });
+
+/**
+ * Built-in agents must not keep the upstream mascot on a rebranded deployment.
+ *
+ * These avatars were literal `/avatars/*.png` paths, so they survived a rebrand
+ * that had already replaced the inbox agent sitting next to them in the same
+ * picker — the mismatch is only visible when the two are listed together, which
+ * is exactly where users saw it.
+ *
+ * Checked from the agent definitions rather than the constants, because the
+ * defect was never in the constants: it was three call sites not using them.
+ */
+const loadAvatars = async (brandingLogoUrl: string) => {
+  vi.resetModules();
+  vi.doMock('@lobechat/business-const', async (importOriginal) => ({
+    ...(await importOriginal<typeof BusinessConst>()),
+    BRANDING_LOGO_URL: brandingLogoUrl,
+  }));
+
+  const [agentBuilder, groupAgentBuilder, pageAgent, inbox] = await Promise.all([
+    import('./agent-builder'),
+    import('./group-agent-builder'),
+    import('./page-agent'),
+    import('./inbox'),
+  ]);
+
+  return {
+    agentBuilder: agentBuilder.AGENT_BUILDER.avatar,
+    groupAgentBuilder: groupAgentBuilder.GROUP_AGENT_BUILDER.avatar,
+    inbox: inbox.INBOX.avatar,
+    pageAgent: pageAgent.PAGE_AGENT.avatar,
+  };
+};
+
+afterEach(() => {
+  vi.doUnmock('@lobechat/business-const');
+  vi.resetModules();
+});
+
+describe('built-in agent avatars', () => {
+  it('all follow the branded logo when one is configured', async () => {
+    const avatars = await loadAvatars('/branding/logo.png');
+
+    // Including the inbox: the point is that they agree, not that three of them
+    // changed.
+    for (const [agent, avatar] of Object.entries(avatars))
+      expect(avatar, agent).toBe('/branding/logo.png');
+  });
+
+  it('leaves no upstream mascot behind under custom branding', async () => {
+    const avatars = await loadAvatars('/branding/logo.png');
+
+    for (const [agent, avatar] of Object.entries(avatars))
+      expect(avatar, agent).not.toMatch(/\/avatars\//);
+  });
+
+  // Upstream ships no logo, and each agent's own artwork is worth keeping there.
+  it('keeps each agent distinct when no logo is configured', async () => {
+    const avatars = await loadAvatars('');
+
+    expect(avatars.agentBuilder).toBe('/avatars/agent-builder.png');
+    expect(avatars.groupAgentBuilder).toBe('/avatars/agent-builder.png');
+    expect(avatars.pageAgent).toBe('/avatars/doc-copilot.png');
+    expect(avatars.inbox).toBe('/avatars/lobe-ai.png');
+  });
+});

--- a/packages/builtin-agents/src/agents/group-agent-builder/index.ts
+++ b/packages/builtin-agents/src/agents/group-agent-builder/index.ts
@@ -1,6 +1,6 @@
 import { GroupAgentBuilderIdentifier } from '@lobechat/builtin-tool-group-agent-builder';
 import { DEFAULT_PROVIDER } from '@lobechat/business-const';
-import { DEFAULT_MODEL } from '@lobechat/const';
+import { DEFAULT_AGENT_BUILDER_AVATAR, DEFAULT_MODEL } from '@lobechat/const';
 
 import type { BuiltinAgentDefinition } from '../../types';
 import { BUILTIN_AGENT_SLUGS } from '../../types';
@@ -10,7 +10,7 @@ import { systemRoleTemplate } from './systemRole';
  * Group Agent Builder - used for configuring group chat settings and managing group members
  */
 export const GROUP_AGENT_BUILDER: BuiltinAgentDefinition = {
-  avatar: '/avatars/agent-builder.png',
+  avatar: DEFAULT_AGENT_BUILDER_AVATAR,
 
   // Persist config - stored in database
   persist: {

--- a/packages/builtin-agents/src/agents/inbox/index.ts
+++ b/packages/builtin-agents/src/agents/inbox/index.ts
@@ -1,5 +1,6 @@
 import { AgentDocumentsIdentifier } from '@lobechat/builtin-tool-agent-documents';
 import { UserInteractionIdentifier } from '@lobechat/builtin-tool-user-interaction';
+import { DEFAULT_INBOX_AVATAR } from '@lobechat/const';
 
 import type { BuiltinAgentDefinition } from '../../types';
 import { BUILTIN_AGENT_SLUGS } from '../../types';
@@ -11,7 +12,7 @@ import { createSystemRole } from './systemRole';
  * Note: model and provider are intentionally undefined to use user's default settings
  */
 export const INBOX: BuiltinAgentDefinition = {
-  avatar: '/avatars/lobe-ai.png',
+  avatar: DEFAULT_INBOX_AVATAR,
   runtime: (ctx) => ({
     plugins: [AgentDocumentsIdentifier, UserInteractionIdentifier, ...(ctx.plugins || [])],
     systemRole: createSystemRole(ctx.userLocale),

--- a/packages/builtin-agents/src/agents/page-agent/index.ts
+++ b/packages/builtin-agents/src/agents/page-agent/index.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_PROVIDER } from '@lobechat/business-const';
-import { DEFAULT_MODEL } from '@lobechat/const';
+import { DEFAULT_MODEL, DEFAULT_PAGE_AGENT_AVATAR } from '@lobechat/const';
 
 import type { BuiltinAgentDefinition } from '../../types';
 import { BUILTIN_AGENT_SLUGS } from '../../types';
@@ -9,7 +9,7 @@ import { systemRoleTemplate } from './systemRole';
  * Page Agent - used for document editing assistance
  */
 export const PAGE_AGENT: BuiltinAgentDefinition = {
-  avatar: '/avatars/doc-copilot.png',
+  avatar: DEFAULT_PAGE_AGENT_AVATAR,
   // Persist config - stored in database
   persist: {
     model: DEFAULT_MODEL,

--- a/packages/builtin-agents/src/agents/task-agent/index.ts
+++ b/packages/builtin-agents/src/agents/task-agent/index.ts
@@ -1,13 +1,13 @@
 import { TaskIdentifier } from '@lobechat/builtin-tool-task';
 import { DEFAULT_PROVIDER } from '@lobechat/business-const';
-import { DEFAULT_MODEL } from '@lobechat/const';
+import { DEFAULT_INBOX_AVATAR, DEFAULT_MODEL } from '@lobechat/const';
 
 import type { BuiltinAgentDefinition } from '../../types';
 import { BUILTIN_AGENT_SLUGS } from '../../types';
 import { systemRoleTemplate } from './systemRole';
 
 export const TASK_AGENT: BuiltinAgentDefinition = {
-  avatar: '/avatars/lobe-ai.png',
+  avatar: DEFAULT_INBOX_AVATAR,
   persist: {
     model: DEFAULT_MODEL,
     provider: DEFAULT_PROVIDER,

--- a/packages/builtin-agents/src/agents/verify-agent/index.ts
+++ b/packages/builtin-agents/src/agents/verify-agent/index.ts
@@ -1,13 +1,13 @@
 import { VerifyToolIdentifier } from '@lobechat/builtin-tool-verify';
 import { DEFAULT_PROVIDER } from '@lobechat/business-const';
-import { DEFAULT_MODEL } from '@lobechat/const';
+import { DEFAULT_INBOX_AVATAR, DEFAULT_MODEL } from '@lobechat/const';
 
 import type { BuiltinAgentDefinition } from '../../types';
 import { BUILTIN_AGENT_SLUGS } from '../../types';
 import { systemRoleTemplate } from './systemRole';
 
 export const VERIFY_AGENT: BuiltinAgentDefinition = {
-  avatar: '/avatars/lobe-ai.png',
+  avatar: DEFAULT_INBOX_AVATAR,
   persist: {
     // Custom tool mode: the verifier's toolset is EXACTLY its declared plugins
     // (its writeback tool + any investigation tools the run injects), with no

--- a/packages/builtin-agents/src/agents/web-onboarding/index.ts
+++ b/packages/builtin-agents/src/agents/web-onboarding/index.ts
@@ -1,5 +1,6 @@
 import { UserInteractionIdentifier } from '@lobechat/builtin-tool-user-interaction';
 import { DEFAULT_ONBOARDING_MODEL, DEFAULT_ONBOARDING_PROVIDER } from '@lobechat/business-const';
+import { DEFAULT_INBOX_AVATAR } from '@lobechat/const';
 
 import type { BuiltinAgentDefinition } from '../../types';
 import { BUILTIN_AGENT_SLUGS } from '../../types';
@@ -9,7 +10,7 @@ import { createSystemRole } from './systemRole';
 const WebOnboardingIdentifier = 'lobe-web-onboarding';
 
 export const WEB_ONBOARDING: BuiltinAgentDefinition = {
-  avatar: '/avatars/lobe-ai.png',
+  avatar: DEFAULT_INBOX_AVATAR,
   persist: {
     model: DEFAULT_ONBOARDING_MODEL,
     provider: DEFAULT_ONBOARDING_PROVIDER,

--- a/packages/business/const/src/branding.ts
+++ b/packages/business/const/src/branding.ts
@@ -7,6 +7,17 @@ export const LOBE_CHAT_CLOUD = 'LobeHub Cloud';
 export const BRANDING_NAME = 'LobeHub';
 export const BRANDING_LOGO_URL = '';
 
+/**
+ * Display name of the built-in default assistant (the inbox agent).
+ *
+ * Kept separate from `BRANDING_NAME` because it reads as a persona, not a
+ * product: white-label deployments usually want something like
+ * `'<Brand> AI'` rather than the bare product name. Drives
+ * `DEFAULT_INBOX_TITLE` and the i18n brand post-processor, so overriding this
+ * one constant renames the assistant everywhere.
+ */
+export const BRANDING_INBOX_TITLE = 'Lobe AI';
+
 export const ORG_NAME = 'LobeHub';
 
 export const BRANDING_URL = {

--- a/packages/const/src/meta.ts
+++ b/packages/const/src/meta.ts
@@ -1,4 +1,4 @@
-import { BRANDING_LOGO_URL } from '@lobechat/business-const';
+import { BRANDING_INBOX_TITLE, BRANDING_LOGO_URL } from '@lobechat/business-const';
 import type { MetaData } from '@lobechat/types';
 
 export const DEFAULT_AVATAR = '/avatars/agent-default.png';
@@ -7,6 +7,6 @@ export const DEFAULT_SUPERVISOR_AVATAR = '🎙️';
 export const DEFAULT_SUPERVISOR_ID = 'supervisor';
 export const DEFAULT_BACKGROUND_COLOR = undefined;
 export const DEFAULT_AGENT_META: MetaData = {};
-export const DEFAULT_INBOX_TITLE = 'Lobe AI';
+export const DEFAULT_INBOX_TITLE = BRANDING_INBOX_TITLE;
 export const DEFAULT_INBOX_AVATAR = BRANDING_LOGO_URL || '/avatars/lobe-ai.png';
 export const DEFAULT_USER_AVATAR_URL = BRANDING_LOGO_URL || '/app-icons/icon-192x192.png';

--- a/packages/const/src/meta.ts
+++ b/packages/const/src/meta.ts
@@ -10,3 +10,18 @@ export const DEFAULT_AGENT_META: MetaData = {};
 export const DEFAULT_INBOX_TITLE = BRANDING_INBOX_TITLE;
 export const DEFAULT_INBOX_AVATAR = BRANDING_LOGO_URL || '/avatars/lobe-ai.png';
 export const DEFAULT_USER_AVATAR_URL = BRANDING_LOGO_URL || '/app-icons/icon-192x192.png';
+
+/**
+ * Avatars for the remaining built-in agents.
+ *
+ * `/avatars/*.png` are drawings of the LobeHub mascot, and the agents that use
+ * them referenced those paths as literals — so they kept the upstream character
+ * on a distribution that had rebranded everything else, including the agents
+ * sitting next to them in the same picker. Routing them through the same slot as
+ * DEFAULT_INBOX_AVATAR is what makes the branding complete rather than partial.
+ *
+ * Upstream is unaffected: BRANDING_LOGO_URL is empty there, so the fallback
+ * keeps each agent's own artwork.
+ */
+export const DEFAULT_AGENT_BUILDER_AVATAR = BRANDING_LOGO_URL || '/avatars/agent-builder.png';
+export const DEFAULT_PAGE_AGENT_AVATAR = BRANDING_LOGO_URL || '/avatars/doc-copilot.png';

--- a/packages/const/src/version.ts
+++ b/packages/const/src/version.ts
@@ -1,4 +1,4 @@
-import { BRANDING_NAME, ORG_NAME } from '@lobechat/business-const';
+import { BRANDING_NAME, LOBE_CHAT_CLOUD, ORG_NAME } from '@lobechat/business-const';
 
 import pkg from '../../../package.json';
 // type-only: loads ./global.d.ts so `__ELECTRON__` exists even when this
@@ -13,3 +13,9 @@ export const isDesktop = typeof __ELECTRON__ !== 'undefined' && !!__ELECTRON__;
 export const isCustomBranding = BRANDING_NAME !== 'LobeHub';
 // @ts-ignore
 export const isCustomORG = ORG_NAME !== 'LobeHub';
+
+// Re-exported so packages that deliberately do not depend on the business-const
+// slot — @lobechat/locales, which only needs the names to rewrite brand strings
+// baked into translations — can resolve them through the same adaptation layer
+// this package already provides for BRANDING_INBOX_TITLE (see ./meta).
+export { BRANDING_NAME, LOBE_CHAT_CLOUD };

--- a/packages/locales/src/brandPostProcessor.test.ts
+++ b/packages/locales/src/brandPostProcessor.test.ts
@@ -1,0 +1,37 @@
+import { DEFAULT_INBOX_TITLE } from '@lobechat/const';
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyBrandStrings,
+  brandPostProcessor,
+  isBrandPostProcessorEnabled,
+} from './brandPostProcessor';
+
+// These assertions hold under both default and custom branding: with default
+// branding DEFAULT_INBOX_TITLE is 'Lobe AI', so every rewrite is the identity.
+describe('applyBrandStrings', () => {
+  it('rewrites the upstream assistant name to the deployment default', () => {
+    expect(applyBrandStrings('Ask Lobe AI')).toBe(`Ask ${DEFAULT_INBOX_TITLE}`);
+  });
+
+  it('rewrites every occurrence in one string', () => {
+    expect(applyBrandStrings('Lobe AI and Lobe AI')).toBe(
+      `${DEFAULT_INBOX_TITLE} and ${DEFAULT_INBOX_TITLE}`,
+    );
+  });
+
+  it('leaves unrelated copy untouched', () => {
+    expect(applyBrandStrings('Start a new topic')).toBe('Start a new topic');
+  });
+
+  it('is only enabled when the deployment renamed the assistant', () => {
+    expect(isBrandPostProcessorEnabled).toBe(DEFAULT_INBOX_TITLE !== 'Lobe AI');
+  });
+});
+
+describe('brandPostProcessor', () => {
+  it('passes non-string values through untouched', () => {
+    const value = { count: 1 };
+    expect(brandPostProcessor.process(value as never, 'key', {}, {} as never)).toBe(value);
+  });
+});

--- a/packages/locales/src/brandPostProcessor.test.ts
+++ b/packages/locales/src/brandPostProcessor.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_INBOX_TITLE } from '@lobechat/const';
+import { BRANDING_NAME, DEFAULT_INBOX_TITLE, LOBE_CHAT_CLOUD } from '@lobechat/const';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -8,10 +8,37 @@ import {
 } from './brandPostProcessor';
 
 // These assertions hold under both default and custom branding: with default
-// branding DEFAULT_INBOX_TITLE is 'Lobe AI', so every rewrite is the identity.
+// branding every constant still equals the upstream literal, so each rewrite is
+// the identity.
 describe('applyBrandStrings', () => {
   it('rewrites the upstream assistant name to the deployment default', () => {
     expect(applyBrandStrings('Ask Lobe AI')).toBe(`Ask ${DEFAULT_INBOX_TITLE}`);
+  });
+
+  it('rewrites the upstream product name to the deployment brand', () => {
+    expect(applyBrandStrings('Sign in to LobeHub')).toBe(`Sign in to ${BRANDING_NAME}`);
+  });
+
+  it('rewrites the pre-rename product name, still present in stale translations', () => {
+    expect(applyBrandStrings('LobeChat supports custom API keys')).toBe(
+      `${BRANDING_NAME} supports custom API keys`,
+    );
+  });
+
+  it('prefers the hosted-service name over the bare product name', () => {
+    // Longest-first ordering: matching 'LobeHub' first would leave a dangling
+    // ' Cloud' and make LOBE_CHAT_CLOUD unreachable from translated copy.
+    //
+    // A deployment may rename the product but leave the hosted service at the
+    // upstream value; the Cloud pair is then an identity and gets dropped, so
+    // the shorter rule takes over and produces '<brand> Cloud'. Degraded, but
+    // still not a leak — assert that documented fallback rather than failing on
+    // a legitimate config.
+    const cloudRenamed = (LOBE_CHAT_CLOUD as string) !== 'LobeHub Cloud';
+    const brandRenamed = (BRANDING_NAME as string) !== 'LobeHub';
+    const expected = !cloudRenamed && brandRenamed ? `${BRANDING_NAME} Cloud` : LOBE_CHAT_CLOUD;
+
+    expect(applyBrandStrings('or just use LobeHub Cloud')).toBe(`or just use ${expected}`);
   });
 
   it('rewrites every occurrence in one string', () => {
@@ -20,12 +47,27 @@ describe('applyBrandStrings', () => {
     );
   });
 
+  it('leaves social handles alone', () => {
+    // '@LobeHub' is a Slack account that only exists under the upstream brand;
+    // rewriting it would hand the user an address that does not resolve.
+    expect(applyBrandStrings('DM @LobeHub on Slack to link your account')).toBe(
+      'DM @LobeHub on Slack to link your account',
+    );
+  });
+
   it('leaves unrelated copy untouched', () => {
     expect(applyBrandStrings('Start a new topic')).toBe('Start a new topic');
   });
 
-  it('is only enabled when the deployment renamed the assistant', () => {
-    expect(isBrandPostProcessorEnabled).toBe(DEFAULT_INBOX_TITLE !== 'Lobe AI');
+  it('is enabled exactly when the deployment overrode at least one brand name', () => {
+    // Cast away the literal types: under a given branding config tsc knows the
+    // outcome of these comparisons, but the assertion must hold for both.
+    const renamed =
+      (BRANDING_NAME as string) !== 'LobeHub' ||
+      (LOBE_CHAT_CLOUD as string) !== 'LobeHub Cloud' ||
+      (DEFAULT_INBOX_TITLE as string) !== 'Lobe AI';
+
+    expect(isBrandPostProcessorEnabled).toBe(renamed);
   });
 });
 

--- a/packages/locales/src/brandPostProcessor.ts
+++ b/packages/locales/src/brandPostProcessor.ts
@@ -1,23 +1,64 @@
 // Imported via @lobechat/const (already a dependency) rather than
 // @lobechat/business-const, which this package does not depend on.
-import { DEFAULT_INBOX_TITLE } from '@lobechat/const';
+import { BRANDING_NAME, DEFAULT_INBOX_TITLE, LOBE_CHAT_CLOUD } from '@lobechat/const';
 import type { PostProcessorModule } from 'i18next';
 
-/** Upstream's default assistant name, as baked into the locale files. */
-const UPSTREAM_INBOX_TITLE = 'Lobe AI';
+/**
+ * Upstream brand literals baked into the locale files, each paired with the
+ * constant a white-label deployment overrides.
+ *
+ * Several hundred copy strings name the product or the default assistant inline
+ * (`'Ask Lobe AI'`, `'Sign in to LobeHub'`, …) instead of interpolating a brand
+ * variable, across ~18 locales. Rewriting the JSON per deployment would touch a
+ * thousand tracked files and conflict on every upgrade, so white-label
+ * deployments patch the strings as they are translated instead.
+ *
+ * ORDER MATTERS — entries are matched longest-first, so `LobeHub Cloud` has to
+ * come before `LobeHub`, or a deployment that renamed the hosted service could
+ * never see its own LOBE_CHAT_CLOUD in translated copy. A deployment that
+ * renames only BRANDING_NAME drops the (now identity) Cloud pair and falls
+ * through to the shorter rule, yielding `<brand> Cloud` — degraded, but still
+ * not a leak.
+ *
+ * `LobeChat` is the pre-rename product name. It still appears in locales that
+ * have not been retranslated since the rename (ja-JP, ko-KR, zh-TW, …), so a
+ * deployment that rewrote only `LobeHub` would keep leaking it.
+ */
+const BRAND_LITERALS: [from: string, to: string][] = [
+  ['LobeHub Cloud', LOBE_CHAT_CLOUD],
+  ['LobeHub', BRANDING_NAME],
+  ['LobeChat', BRANDING_NAME],
+  ['Lobe AI', DEFAULT_INBOX_TITLE],
+];
+
+/** Only the literals this deployment actually renamed; identity pairs are noise. */
+const replacements = BRAND_LITERALS.filter(([from, to]) => from !== to);
+
+const lookup = new Map(replacements);
 
 /**
- * Literal → replacement map for brand strings baked into the locale files.
- *
- * A handful of copy strings name the default assistant inline (`'Lobe AI will
- * run this task…'`, `'Ask Lobe AI'`, …) instead of interpolating a brand
- * variable, across ~17 locales. Rewriting the JSON per deployment would touch
- * a hundred tracked files and conflict on every upgrade, so white-label
- * deployments patch the strings as they are translated instead.
+ * Every literal above starts with this, which is what makes the pre-filter in
+ * applyBrandStrings sound. Kept beside BRAND_LITERALS so the two cannot drift.
  */
-const replacements = ([[UPSTREAM_INBOX_TITLE, DEFAULT_INBOX_TITLE]] as [string, string][]).filter(
-  ([from, to]) => from !== to,
-);
+const COMMON_PREFIX = 'Lobe';
+
+/**
+ * One alternation covering every active literal, rather than a replaceAll pass
+ * per entry: this runs on every single t() call, so the work has to stay
+ * proportional to the string rather than to the size of the table.
+ *
+ * The `from` values are the literals defined above — letters and spaces only —
+ * so they need no regex escaping.
+ *
+ * `(?<!@)` leaves social handles such as `@LobeHub` alone (see the Slack copy in
+ * messenger.json). A handle names an account that exists under the upstream
+ * brand and has no counterpart in a white-label deployment, so rewriting it
+ * would hand the user an address that does not resolve. Keeping the handle is
+ * the honest failure mode; making it configurable is a separate upstream change.
+ */
+const pattern = replacements.length
+  ? new RegExp(`(?<!@)(${replacements.map(([from]) => from).join('|')})`, 'g')
+  : undefined;
 
 export const isBrandPostProcessorEnabled = replacements.length > 0;
 
@@ -25,9 +66,11 @@ export const BRAND_POST_PROCESSOR = 'brandStrings';
 
 /** Apply the brand rewrites to one translated string. */
 export const applyBrandStrings = (value: string): string => {
-  let output = value;
-  for (const [from, to] of replacements) output = output.replaceAll(from, to);
-  return output;
+  // Fast path: the overwhelming majority of translated strings never mention the
+  // brand, and one substring scan is much cheaper than running the regex.
+  if (!pattern || !value.includes(COMMON_PREFIX)) return value;
+
+  return value.replaceAll(pattern, (match) => lookup.get(match) ?? match);
 };
 
 /**

--- a/packages/locales/src/brandPostProcessor.ts
+++ b/packages/locales/src/brandPostProcessor.ts
@@ -1,0 +1,42 @@
+// Imported via @lobechat/const (already a dependency) rather than
+// @lobechat/business-const, which this package does not depend on.
+import { DEFAULT_INBOX_TITLE } from '@lobechat/const';
+import type { PostProcessorModule } from 'i18next';
+
+/** Upstream's default assistant name, as baked into the locale files. */
+const UPSTREAM_INBOX_TITLE = 'Lobe AI';
+
+/**
+ * Literal → replacement map for brand strings baked into the locale files.
+ *
+ * A handful of copy strings name the default assistant inline (`'Lobe AI will
+ * run this task…'`, `'Ask Lobe AI'`, …) instead of interpolating a brand
+ * variable, across ~17 locales. Rewriting the JSON per deployment would touch
+ * a hundred tracked files and conflict on every upgrade, so white-label
+ * deployments patch the strings as they are translated instead.
+ */
+const replacements = ([[UPSTREAM_INBOX_TITLE, DEFAULT_INBOX_TITLE]] as [string, string][]).filter(
+  ([from, to]) => from !== to,
+);
+
+export const isBrandPostProcessorEnabled = replacements.length > 0;
+
+export const BRAND_POST_PROCESSOR = 'brandStrings';
+
+/** Apply the brand rewrites to one translated string. */
+export const applyBrandStrings = (value: string): string => {
+  let output = value;
+  for (const [from, to] of replacements) output = output.replaceAll(from, to);
+  return output;
+};
+
+/**
+ * Rewrite hardcoded brand strings in translated copy so white-label
+ * deployments never surface the upstream product's names. A no-op (and never
+ * registered) under default branding.
+ */
+export const brandPostProcessor: PostProcessorModule = {
+  name: BRAND_POST_PROCESSOR,
+  process: (value) => (typeof value === 'string' ? applyBrandStrings(value) : value),
+  type: 'postProcessor',
+};

--- a/packages/locales/src/create.ts
+++ b/packages/locales/src/create.ts
@@ -23,6 +23,12 @@ import { isOnServerSide } from '@/utils/env';
 import { unwrapESMModule } from '@/utils/esm/unwrapESMModule';
 import { loadI18nNamespaceModule } from '@/utils/i18n/loadI18nNamespaceModule';
 
+import {
+  BRAND_POST_PROCESSOR,
+  brandPostProcessor,
+  isBrandPostProcessorEnabled,
+} from './brandPostProcessor';
+
 const mergeNamespace = (
   fallbackResources: Record<string, unknown>,
   localeResources: Record<string, unknown>,
@@ -45,7 +51,10 @@ const { I18N_DEBUG, I18N_DEBUG_BROWSER, I18N_DEBUG_SERVER } = getDebugConfig();
 const debugMode = (I18N_DEBUG ?? isOnServerSide) ? I18N_DEBUG_SERVER : I18N_DEBUG_BROWSER;
 
 export const createI18nNext = (lang?: string) => {
-  const instance = i18n
+  let instance = i18n;
+  if (isBrandPostProcessorEnabled) instance = instance.use(brandPostProcessor);
+
+  instance = instance
     .use(initReactI18next)
     .use(LanguageDetector)
     .use(
@@ -109,6 +118,8 @@ export const createI18nNext = (lang?: string) => {
         keySeparator: false,
 
         lng: initialLang,
+        // Rewrite brand strings baked into the locale copy (white-label only).
+        ...(isBrandPostProcessorEnabled ? { postProcess: [BRAND_POST_PROCESSOR] } : {}),
         // Silence the Locize promotional console.info printed on init (i18next >= 25)
         showSupportNotice: false,
       });

--- a/src/features/AgentHome/AgentInfo.tsx
+++ b/src/features/AgentHome/AgentInfo.tsx
@@ -7,7 +7,7 @@ import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import Avatar from '@/components/Avatar';
-import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR } from '@/const/meta';
+import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE } from '@/const/meta';
 import { contextSelectors, useConversationStore } from '@/features/Conversation/store';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, agentSelectors, builtinAgentSelectors } from '@/store/agent/selectors';
@@ -31,7 +31,7 @@ const AgentInfo = memo(() => {
   const fontSize = useUserStore(userGeneralSettingsSelectors.fontSize);
 
   const displayTitle = isInbox
-    ? agentDisplayName(meta, 'Lobe AI')
+    ? agentDisplayName(meta, DEFAULT_INBOX_TITLE)
     : agentDisplayName(meta, t('defaultSession', { ns: 'common' }));
 
   const message = useMemo(() => {

--- a/src/features/AgentSidebar/Header/Agent/index.tsx
+++ b/src/features/AgentSidebar/Header/Agent/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { DEFAULT_INBOX_TITLE } from '@lobechat/const';
 import type { PropsWithChildren } from 'react';
 import React, { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -24,7 +25,7 @@ const Agent = memo<PropsWithChildren>(() => {
   ]);
 
   const displayTitle = isInbox
-    ? title || 'Lobe AI'
+    ? title || DEFAULT_INBOX_TITLE
     : title || t('defaultSession', { ns: 'common' });
 
   if (isLoading) return <SkeletonItem height={32} padding={0} />;

--- a/src/features/AuthShell/createAuthI18n.ts
+++ b/src/features/AuthShell/createAuthI18n.ts
@@ -3,6 +3,11 @@ import resourcesToBackend from 'i18next-resources-to-backend';
 import { initReactI18next } from 'react-i18next';
 
 import { DEFAULT_LANG } from '@/const/locale';
+import {
+  BRAND_POST_PROCESSOR,
+  brandPostProcessor,
+  isBrandPostProcessorEnabled,
+} from '@/locales/brandPostProcessor';
 import defaultAuth from '@/locales/default/auth';
 import defaultAuthError from '@/locales/default/authError';
 import defaultCommon from '@/locales/default/common';
@@ -64,10 +69,10 @@ const loadAuthNamespace = async (lng: string, ns: string) => {
 };
 
 export const createAuthI18n = (lang?: string) => {
-  const instance = i18next
-    .createInstance()
-    .use(initReactI18next)
-    .use(resourcesToBackend(loadAuthNamespace));
+  let instance = i18next.createInstance();
+  if (isBrandPostProcessorEnabled) instance = instance.use(brandPostProcessor);
+
+  instance = instance.use(initReactI18next).use(resourcesToBackend(loadAuthNamespace));
 
   // With ns: [] and the en-US fallback bundled, i18next considers every namespace
   // "loaded" and never asks the backend after a language switch — fetch explicitly.
@@ -94,6 +99,8 @@ export const createAuthI18n = (lang?: string) => {
         // retry of the initial mount re-creates this instance and the auth SPA
         // remounts forever with a blank #root.
         partialBundledLanguages: true,
+        // Rewrite brand strings baked into the locale copy (white-label only).
+        ...(isBrandPostProcessorEnabled ? { postProcess: [BRAND_POST_PROCESSOR] } : {}),
         react: {
           bindI18nStore: 'added',
           useSuspense: false,

--- a/src/features/CommandMenu/AskAIMenu.tsx
+++ b/src/features/CommandMenu/AskAIMenu.tsx
@@ -1,4 +1,4 @@
-import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR } from '@lobechat/const';
+import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE } from '@lobechat/const';
 import { agentDisplayName } from '@lobechat/types';
 import { GroupBotSquareIcon } from '@lobehub/ui/icons';
 import { Command } from 'cmdk';
@@ -63,7 +63,7 @@ const AskAIMenu = memo(() => {
       <Command.Item value="lobe-ai" onSelect={handleAskLobeAI}>
         <Avatar emojiScaleWithBackground avatar={DEFAULT_INBOX_AVATAR} shape="square" size={18} />
         <div className={styles.itemContent}>
-          <div className={styles.itemLabel}>Lobe AI</div>
+          <div className={styles.itemLabel}>{DEFAULT_INBOX_TITLE}</div>
         </div>
       </Command.Item>
       <Command.Item value="agent-builder" onSelect={handleAgentBuilder}>

--- a/src/features/CommandMenu/AskAgentCommands.tsx
+++ b/src/features/CommandMenu/AskAgentCommands.tsx
@@ -1,4 +1,4 @@
-import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR } from '@lobechat/const';
+import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE } from '@lobechat/const';
 import { agentDisplayName } from '@lobechat/types';
 import { preventDefault } from '@lobehub/ui';
 import { Command } from 'cmdk';
@@ -56,21 +56,24 @@ const AskAgentCommands = memo(() => {
   // Only show when user types "@"
   if (!isAtMention) return null;
 
-  // Check if Lobe AI matches the query
-  const showLobeAI = !mentionQuery || 'lobe ai'.includes(mentionQuery);
+  // Check if the default assistant matches the query
+  const showLobeAI =
+    !mentionQuery || DEFAULT_INBOX_TITLE.toLowerCase().includes(mentionQuery.toLowerCase());
 
   return (
     <Command.Group heading={t('cmdk.mentionAgent')}>
-      {/* @Lobe AI option */}
+      {/* @<default assistant> option */}
       {showLobeAI && (
         <Command.Item
           value="@lobe-ai"
           onMouseDown={preventDefault}
-          onSelect={() => handleAgentSelect(inboxAgentId, 'Lobe AI', DEFAULT_INBOX_AVATAR)}
+          onSelect={() =>
+            handleAgentSelect(inboxAgentId, DEFAULT_INBOX_TITLE, DEFAULT_INBOX_AVATAR)
+          }
         >
           <Avatar emojiScaleWithBackground avatar={DEFAULT_INBOX_AVATAR} shape="square" size={18} />
           <div className={styles.itemContent}>
-            <div className={styles.itemLabel}>@Lobe AI</div>
+            <div className={styles.itemLabel}>@{DEFAULT_INBOX_TITLE}</div>
           </div>
         </Command.Item>
       )}

--- a/src/features/Conversation/hooks/useAgentMeta.test.ts
+++ b/src/features/Conversation/hooks/useAgentMeta.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_INBOX_TITLE } from '@lobechat/const';
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -87,7 +88,7 @@ describe('useAgentMeta', () => {
     expect(result.current.description).toBe('Inbox description');
   });
 
-  it('should fallback to Lobe AI title for builtin agent without custom title', () => {
+  it('should fallback to the default inbox title for builtin agent without custom title', () => {
     const mockInboxAgentId = 'inbox-agent-id';
     const mockMeta = {
       avatar: '/icons/icon-lobe.png',
@@ -113,7 +114,7 @@ describe('useAgentMeta', () => {
     const { result } = renderHook(() => useAgentMeta());
 
     expect(result.current.avatar).toBe('/icons/icon-lobe.png');
-    expect(result.current.title).toBe('Lobe AI');
+    expect(result.current.title).toBe(DEFAULT_INBOX_TITLE);
   });
 
   it('should preserve custom title for page agent (builtin)', () => {

--- a/src/features/Conversation/hooks/useAgentMeta.ts
+++ b/src/features/Conversation/hooks/useAgentMeta.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_INBOX_TITLE } from '@lobechat/const';
 import { type MetaData } from '@lobechat/types';
 import { useMemo } from 'react';
 
@@ -6,7 +7,7 @@ import { agentSelectors } from '@/store/agent/selectors';
 
 import { contextSelectors, useConversationStore } from '../store';
 
-const LOBE_AI_TITLE = 'Lobe AI';
+const LOBE_AI_TITLE = DEFAULT_INBOX_TITLE;
 
 /**
  * Hook to get agent meta data for a specific agent or the current conversation.

--- a/src/features/DesktopOnboarding/steps/WelcomeStep.tsx
+++ b/src/features/DesktopOnboarding/steps/WelcomeStep.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { DEFAULT_INBOX_TITLE } from '@lobechat/const';
 import { type IconProps } from '@lobehub/ui';
 import { Block, Flexbox, Icon, Text } from '@lobehub/ui';
 import { TypewriterEffect } from '@lobehub/ui/awesome';
@@ -61,7 +62,7 @@ const WelcomeStep = memo<WelcomeStepProps>(({ onNext }) => {
             pauseDuration={16_000}
             typingSpeed={64}
             sentences={[
-              t('telemetry.title', { name: 'Lobe AI' }),
+              t('telemetry.title', { name: DEFAULT_INBOX_TITLE }),
               t('telemetry.title2'),
               t('telemetry.title3'),
             ]}

--- a/src/features/DevPanel/RenderGallery/fixtures/index.ts
+++ b/src/features/DevPanel/RenderGallery/fixtures/index.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { builtinTools } from '@lobechat/builtin-tools';
-import { DEFAULT_INBOX_AVATAR } from '@lobechat/const';
+import { DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE } from '@lobechat/const';
 import type { BuiltinToolManifest, LobeChatPluginApi } from '@lobechat/types';
 
 import type { ToolRenderFixture } from '../lifecycleMode';
@@ -54,7 +54,7 @@ export const DEVTOOLS_AGENT_ID = 'devtools-render-gallery';
 
 export const DEVTOOLS_AGENT_META = {
   avatar: DEFAULT_INBOX_AVATAR,
-  title: 'Lobe AI',
+  title: DEFAULT_INBOX_TITLE,
 };
 
 export const DEVTOOLS_GROUP_DETAIL = {

--- a/src/features/Electron/ScreenCapture/overlaySnapshot.test.ts
+++ b/src/features/Electron/ScreenCapture/overlaySnapshot.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR } from '@lobechat/const';
+import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE } from '@lobechat/const';
 import { describe, expect, it } from 'vitest';
 
 import { resolveOverlayAgentOptions, resolveOverlayDefaultAgentId } from './overlaySnapshot';
@@ -16,7 +16,7 @@ describe('overlaySnapshot', () => {
         avatar: DEFAULT_INBOX_AVATAR,
         backgroundColor: undefined,
         id: 'inbox-agent',
-        title: 'Lobe AI',
+        title: DEFAULT_INBOX_TITLE,
       },
       {
         avatar: 'A',

--- a/src/features/Electron/ScreenCapture/overlaySnapshot.ts
+++ b/src/features/Electron/ScreenCapture/overlaySnapshot.ts
@@ -1,8 +1,8 @@
-import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR } from '@lobechat/const';
+import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE } from '@lobechat/const';
 import type { ScreenCaptureAgentOption } from '@lobechat/electron-client-ipc';
 import { agentDisplayName } from '@lobechat/types';
 
-const LOBE_AI_TITLE = 'Lobe AI';
+const LOBE_AI_TITLE = DEFAULT_INBOX_TITLE;
 const UNTITLED_AGENT_TITLE = 'Untitled Agent';
 
 interface OverlayAgentSource {

--- a/src/features/HomeSidebar/Body/Agent/List/InboxItem.tsx
+++ b/src/features/HomeSidebar/Body/Agent/List/InboxItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DEFAULT_INBOX_AVATAR } from '@lobechat/const';
+import { DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE } from '@lobechat/const';
 import { agentDisplayName } from '@lobechat/types';
 import { Avatar, Icon } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
@@ -60,7 +60,7 @@ const InboxItem = memo<InboxItemProps>(({ className, style }) => {
     inboxAgentId ? operationSelectors.isAgentVisiblyRunning(inboxAgentId) : () => false,
   );
   const prefetchAgent = usePrefetchAgent();
-  const inboxAgentTitle = agentDisplayName(inboxMeta, 'Lobe AI');
+  const inboxAgentTitle = agentDisplayName(inboxMeta, DEFAULT_INBOX_TITLE);
   const inboxAgentAvatar = inboxMeta.avatar || DEFAULT_INBOX_AVATAR;
   const inboxUrl = usePreservedAgentUrl(inboxRouteAgentId);
 

--- a/src/features/MobileHome/SessionListContent/Inbox/index.tsx
+++ b/src/features/MobileHome/SessionListContent/Inbox/index.tsx
@@ -1,4 +1,4 @@
-import { AGENT_CHAT_URL } from '@lobechat/const';
+import { AGENT_CHAT_URL, DEFAULT_INBOX_TITLE } from '@lobechat/const';
 import { memo } from 'react';
 import { Link } from 'react-router';
 
@@ -22,7 +22,7 @@ const Inbox = memo(() => {
 
   return (
     <Link
-      aria-label={'Lobe AI'}
+      aria-label={DEFAULT_INBOX_TITLE}
       to={AGENT_CHAT_URL(inboxRouteAgentId, mobile)}
       onClick={(e) => {
         e.preventDefault();
@@ -33,7 +33,7 @@ const Inbox = memo(() => {
         active={isInboxActive}
         avatar={DEFAULT_INBOX_AVATAR}
         key={'inbox'}
-        title={'Lobe AI'}
+        title={DEFAULT_INBOX_TITLE}
         styles={{
           container: {
             gap: 12,

--- a/src/features/Onboarding/steps/TelemetryStep.tsx
+++ b/src/features/Onboarding/steps/TelemetryStep.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { BRANDING_NAME } from '@lobechat/business-const';
+import { DEFAULT_INBOX_TITLE } from '@lobechat/const';
 import { type IconProps } from '@lobehub/ui';
 import { Block, Flexbox, Icon, Text } from '@lobehub/ui';
 import { TypewriterEffect } from '@lobehub/ui/awesome';
@@ -71,7 +72,7 @@ const TelemetryStep = memo<TelemetryStepProps>(({ onNext }) => {
             pauseDuration={16_000}
             typingSpeed={64}
             sentences={[
-              t('telemetry.title', { name: 'Lobe AI' }),
+              t('telemetry.title', { name: DEFAULT_INBOX_TITLE }),
               t('telemetry.title2'),
               t('telemetry.title3'),
             ]}

--- a/src/features/ShareModal/ShareImage/Preview.tsx
+++ b/src/features/ShareModal/ShareImage/Preview.tsx
@@ -1,3 +1,4 @@
+import { DEFAULT_INBOX_TITLE } from '@lobechat/const';
 import { agentDisplayName, type ConversationContext, type UIChatMessage } from '@lobechat/types';
 import { ModelTag } from '@lobehub/icons';
 import { Avatar, Flexbox, Markdown, Text } from '@lobehub/ui';
@@ -79,7 +80,7 @@ const Preview = memo<PreviewProps>(
 
     const displayTitle =
       (isHeaderInbox ?? isInbox)
-        ? 'Lobe AI'
+        ? DEFAULT_INBOX_TITLE
         : agentDisplayName(headerMeta) || title || currentTitle;
     const displayAvatar = headerMeta?.avatar || currentAvatar;
     const displayBackgroundColor = headerMeta?.backgroundColor || currentBackgroundColor;

--- a/src/libs/i18n/serverTranslation.ts
+++ b/src/libs/i18n/serverTranslation.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_LANG } from '@/const/locale';
+import { applyBrandStrings } from '@/locales/brandPostProcessor';
 import { type Locales, type NS } from '@/locales/resources';
 import { normalizeLocale } from '@/locales/resources';
 import { unwrapESMModule } from '@/utils/esm/unwrapESMModule';
@@ -52,7 +53,9 @@ export const translation = async (ns: NS = 'common', hl: string) => {
           content = content.replace(`{{${k}}}`, value);
         });
       }
-      return content;
+      // Mirror the client's brand post-processor (packages/locales/src/create.ts)
+      // so SSR copy does not leak the upstream product's names either.
+      return applyBrandStrings(content);
     },
   };
 };

--- a/src/routes/(main)/agent/profile/features/AgentSettings/Content.tsx
+++ b/src/routes/(main)/agent/profile/features/AgentSettings/Content.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { DEFAULT_INBOX_TITLE } from '@lobechat/const';
 import isEqual from 'fast-deep-equal';
 import { ActivityIcon, GitBranchIcon, MessageSquareHeartIcon } from 'lucide-react';
 import { memo, useEffect, useMemo, useState } from 'react';
@@ -81,7 +82,9 @@ const Content = memo(() => {
     [availableTabs, t],
   );
 
-  const displayTitle = isInbox ? 'Lobe AI' : meta.title || t('defaultSession', { ns: 'common' });
+  const displayTitle = isInbox
+    ? DEFAULT_INBOX_TITLE
+    : meta.title || t('defaultSession', { ns: 'common' });
 
   return (
     <SettingsModalLayout

--- a/src/routes/(main)/group/features/Conversation/AgentWelcome/index.tsx
+++ b/src/routes/(main)/group/features/Conversation/AgentWelcome/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { DEFAULT_INBOX_TITLE } from '@lobechat/const';
 import { Flexbox, Markdown, Text } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
 import React, { memo, useMemo } from 'react';
@@ -75,7 +76,9 @@ const InboxWelcome = memo(() => {
         </Text>
         <Flexbox width={'min(100%, 640px)'}>
           <Markdown fontSize={fontSize} variant={'chat'}>
-            {isInbox ? t('guide.defaultMessageWithoutCreate', { appName: 'Lobe AI' }) : message}
+            {isInbox
+              ? t('guide.defaultMessageWithoutCreate', { appName: DEFAULT_INBOX_TITLE })
+              : message}
           </Markdown>
         </Flexbox>
         {openingQuestions.length > 0 && (

--- a/src/routes/(mobile)/chat/features/ChatHeader/ChatHeaderTitle.tsx
+++ b/src/routes/(mobile)/chat/features/ChatHeader/ChatHeaderTitle.tsx
@@ -1,3 +1,4 @@
+import { DEFAULT_INBOX_TITLE } from '@lobechat/const';
 import { ActionIcon, Flexbox } from '@lobehub/ui';
 import { ChatHeader } from '@lobehub/ui/mobile';
 import { cssVar } from 'antd-style';
@@ -26,7 +27,7 @@ const ChatHeaderTitle = memo(() => {
   // id so the title doesn't degrade to the "new topic" placeholder.
   useFetchActiveTopicDetail();
 
-  const displayTitle = isInbox ? 'Lobe AI' : title;
+  const displayTitle = isInbox ? DEFAULT_INBOX_TITLE : title;
 
   return (
     <ChatHeader.Title


### PR DESCRIPTION
`'Lobe AI'` was hardcoded in ~20 components plus the locale files of every language, so white-label deployments surfaced the upstream product's assistant name in the sidebar, message headers, @-mentions, share images and onboarding copy.

Default (non-custom-branding) behaviour is unchanged — `BRANDING_INBOX_TITLE` defaults to `'Lobe AI'`, so every interpolated string renders byte-identical to today.

#### What changed

- Adds `BRANDING_INBOX_TITLE` to the business-const slot (default `'Lobe AI'`) and drives `DEFAULT_INBOX_TITLE` from it
- Replaces the hardcoded `'Lobe AI'` literal across ~20 components (sidebar, command menu, share images, mobile home, agent info card) with `DEFAULT_INBOX_TITLE`
- Adds an i18next post-processor (`packages/locales/src/brandPostProcessor.ts`) for the strings baked into locale JSON (`'Ask Lobe AI'`, `'Lobe AI will run this task…'`, …) — rewriting ~17 locale files per deployment would dirty a hundred tracked files and conflict on every upgrade, so this rewrites at translation time instead, and is only registered when the deployment actually renamed the assistant (default branding takes the exact same code path as before, no static locale JSON was touched). Mirrored in the hand-rolled server-side `t()` so SSR copy matches
- Points the builtin agents' avatar at `DEFAULT_INBOX_AVATAR`/new `DEFAULT_AGENT_BUILDER_AVATAR`/`DEFAULT_PAGE_AGENT_AVATAR` instead of hardcoded `/avatars/*.png` paths, so `BRANDING_LOGO_URL` applies there too (only affects fresh rows — an avatar already persisted to the DB wins)

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [x] `bun run check --lint --test` clean

#### Key Decisions / Non-goals

- Cherry-picked from a downstream private-label branch; canary had moved significantly since the fork (home page rebuild removing `AgentSelect`, several components renamed/restructured). Resolutions kept canary's current structure/wording and applied only the brand-interpolation delta:
  - `src/routes/(main)/home/features/AgentSelect/{AgentList,index}.tsx` no longer exist on canary (replaced by the new home dashboard in #17680) — dropped, nothing to port
  - The equivalent logic in the share page moved to `apps/share/src/features/topic/topicByline.ts` since the fork — applied the `DEFAULT_INBOX_TITLE` fix there instead of the now-dead code path in `SharedTopicBody.client.tsx`
  - Several files had already migrated from `@lobehub/ui`'s `Avatar` to a local `@/components/Avatar`, or from a raw string check to the shared `agentDisplayName(meta, fallback)` helper — kept those, just swapped the literal fallback