### PR TITLE
💄 fix: de-hardcode the brand from auth emails and the passkey prompt

### DIFF
--- a/src/libs/better-auth/define-config.ts
+++ b/src/libs/better-auth/define-config.ts
@@ -1,5 +1,6 @@
 import { expo } from '@better-auth/expo';
 import { passkey } from '@better-auth/passkey';
+import { BRANDING_NAME } from '@lobechat/business-const';
 import { createNanoId, idGenerator, serverDB } from '@lobechat/database';
 import * as schema from '@lobechat/database/schemas';
 import bcrypt from 'bcryptjs';
@@ -352,7 +353,10 @@ export function defineConfig(customOptions: CustomBetterAuthOptions) {
         },
       }),
       passkey({
-        rpName: 'LobeHub',
+        // Surfaced by the browser/OS passkey prompt ("Create a passkey for …"),
+        // so a hardcoded value leaks the upstream brand into native UI that no
+        // amount of in-app theming can reach.
+        rpName: BRANDING_NAME,
         // Extract rpID from auth URL (e.g., 'lobehub.com' from 'https://lobehub.com')
         // Returns undefined if AUTH_URL is not set (e.g., in e2e tests)
         rpID: getPasskeyRpID(),

--- a/src/libs/better-auth/email-templates/change-email.ts
+++ b/src/libs/better-auth/email-templates/change-email.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME, COPYRIGHT_FULL } from '@lobechat/business-const';
+
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
 /**
@@ -35,7 +37,7 @@ export const getChangeEmailVerificationTemplate = (params: {
     <div style="text-align: center; margin-bottom: 32px;">
       <div style="display: inline-flex; align-items: center; justify-content: center; background-color: #ffffff; border-radius: 12px; padding: 8px 16px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
         <span style="font-size: 24px; line-height: 1; margin-right: 10px;">🤯</span>
-        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">LobeHub</span>
+        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">${BRANDING_NAME}</span>
       </div>
     </div>
 
@@ -57,7 +59,7 @@ export const getChangeEmailVerificationTemplate = (params: {
         ${userName ? `<p style="margin: 0 0 16px 0;">Hi <strong>${userName}</strong>,</p>` : ''}
 
         <p style="margin: 0 0 24px 0;">
-          We received a request to change your LobeHub account email to this address. Please confirm by clicking the button below.
+          We received a request to change your ${BRANDING_NAME} account email to this address. Please confirm by clicking the button below.
         </p>
 
         <!-- Button -->
@@ -100,14 +102,14 @@ export const getChangeEmailVerificationTemplate = (params: {
         ${getEmailSupportHtml()}
       </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
-        © 2026 LobeHub. All rights reserved.
+        ${COPYRIGHT_FULL}
       </p>
     </div>
   </div>
 </body>
 </html>
     `,
-    subject: 'Confirm Your New Email - LobeHub',
-    text: `You requested to change your LobeHub account email. Please confirm by clicking this link: ${url}\n\nThis link will expire in ${expirationText}.\n\nIf you didn't request this change, you can safely ignore this email.\n\n${getEmailSupportText()}`,
+    subject: `Confirm Your New Email - ${BRANDING_NAME}`,
+    text: `You requested to change your ${BRANDING_NAME} account email. Please confirm by clicking this link: ${url}\n\nThis link will expire in ${expirationText}.\n\nIf you didn't request this change, you can safely ignore this email.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/magic-link.ts
+++ b/src/libs/better-auth/email-templates/magic-link.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME, COPYRIGHT_FULL } from '@lobechat/business-const';
+
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
 /**
@@ -20,7 +22,7 @@ export const getMagicLinkEmailTemplate = (params: { expiresInSeconds: number; ur
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Sign in to LobeHub</title>
+  <title>Sign in to ${BRANDING_NAME}</title>
 </head>
 <body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f4f4f5; color: #1a1a1a;">
   <!-- Container -->
@@ -30,7 +32,7 @@ export const getMagicLinkEmailTemplate = (params: { expiresInSeconds: number; ur
     <div style="text-align: center; margin-bottom: 32px;">
       <div style="display: inline-flex; align-items: center; justify-content: center; background-color: #ffffff; border-radius: 12px; padding: 8px 16px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
         <span style="font-size: 24px; line-height: 1; margin-right: 10px;">🤯</span>
-        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">LobeHub</span>
+        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">${BRANDING_NAME}</span>
       </div>
     </div>
 
@@ -40,7 +42,7 @@ export const getMagicLinkEmailTemplate = (params: { expiresInSeconds: number; ur
       <!-- Header -->
       <div style="text-align: center; margin-bottom: 32px;">
         <h1 style="color: #111827; font-size: 24px; font-weight: 700; margin: 0 0 12px 0; letter-spacing: -0.5px;">
-          Sign in to LobeHub
+          Sign in to ${BRANDING_NAME}
         </h1>
         <p style="color: #6b7280; font-size: 16px; margin: 0; line-height: 1.5;">
           Click the link below to sign in to your account.
@@ -90,14 +92,14 @@ export const getMagicLinkEmailTemplate = (params: { expiresInSeconds: number; ur
         ${getEmailSupportHtml()}
       </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
-        © ${new Date().getFullYear()} LobeHub. All rights reserved.
+        ${COPYRIGHT_FULL}
       </p>
     </div>
   </div>
 </body>
 </html>
     `,
-    subject: 'Your LobeHub sign-in link',
+    subject: `Your ${BRANDING_NAME} sign-in link`,
     text: `Use this link to sign in: ${url}\n\nThis link expires in ${expirationText}.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/reset-password.ts
+++ b/src/libs/better-auth/email-templates/reset-password.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME, COPYRIGHT_FULL } from '@lobechat/business-const';
+
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
 /**
@@ -24,7 +26,7 @@ export const getResetPasswordEmailTemplate = (params: { url: string }) => {
     <div style="text-align: center; margin-bottom: 32px;">
       <div style="display: inline-flex; align-items: center; justify-content: center; background-color: #ffffff; border-radius: 12px; padding: 8px 16px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
         <span style="font-size: 24px; line-height: 1; margin-right: 10px;">🤯</span>
-        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">LobeHub</span>
+        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">${BRANDING_NAME}</span>
       </div>
     </div>
 
@@ -44,7 +46,7 @@ export const getResetPasswordEmailTemplate = (params: { url: string }) => {
       <!-- Content -->
       <div style="color: #374151; font-size: 16px; line-height: 1.6;">
         <p style="margin: 0 0 24px 0; text-align: center;">
-          You recently requested to reset your password for your LobeHub account. Click the button below to proceed.
+          You recently requested to reset your password for your ${BRANDING_NAME} account. Click the button below to proceed.
         </p>
 
         <!-- Button -->
@@ -83,14 +85,14 @@ export const getResetPasswordEmailTemplate = (params: { url: string }) => {
         ${getEmailSupportHtml()}
       </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
-        © ${new Date().getFullYear()} LobeHub. All rights reserved.
+        ${COPYRIGHT_FULL}
       </p>
     </div>
   </div>
 </body>
 </html>
     `,
-    subject: 'Reset Your Password - LobeHub',
+    subject: `Reset Your Password - ${BRANDING_NAME}`,
     text: `Reset your password by clicking this link: ${url}\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/verification-otp.ts
+++ b/src/libs/better-auth/email-templates/verification-otp.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME, COPYRIGHT_FULL } from '@lobechat/business-const';
+
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
 /**
@@ -35,7 +37,7 @@ export const getVerificationOTPEmailTemplate = (params: {
     <div style="text-align: center; margin-bottom: 32px;">
       <div style="display: inline-flex; align-items: center; justify-content: center; background-color: #ffffff; border-radius: 12px; padding: 8px 16px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
         <span style="font-size: 24px; line-height: 1; margin-right: 10px;">🤯</span>
-        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">LobeHub</span>
+        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">${BRANDING_NAME}</span>
       </div>
     </div>
 
@@ -57,7 +59,7 @@ export const getVerificationOTPEmailTemplate = (params: {
         ${userName ? `<p style="margin: 0 0 16px 0;">Hi <strong>${userName}</strong>,</p>` : ''}
 
         <p style="margin: 0 0 24px 0;">
-          Thanks for creating an account with LobeHub. To verify your email address, please use the verification code below:
+          Thanks for creating an account with ${BRANDING_NAME}. To verify your email address, please use the verification code below:
         </p>
 
         <!-- OTP Code Box -->
@@ -98,14 +100,14 @@ export const getVerificationOTPEmailTemplate = (params: {
         ${getEmailSupportHtml()}
       </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
-        © 2026 LobeHub. All rights reserved.
+        ${COPYRIGHT_FULL}
       </p>
     </div>
   </div>
 </body>
 </html>
     `,
-    subject: 'Verify Your Email - LobeHub',
+    subject: `Verify Your Email - ${BRANDING_NAME}`,
     text: `Your verification code is: ${otp}\n\nThis code will expire in ${expirationText}.\n\nIf you didn't request this code, you can safely ignore this email.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/verification.ts
+++ b/src/libs/better-auth/email-templates/verification.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME, COPYRIGHT_FULL } from '@lobechat/business-const';
+
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
 /**
@@ -35,7 +37,7 @@ export const getVerificationEmailTemplate = (params: {
     <div style="text-align: center; margin-bottom: 32px;">
       <div style="display: inline-flex; align-items: center; justify-content: center; background-color: #ffffff; border-radius: 12px; padding: 8px 16px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
         <span style="font-size: 24px; line-height: 1; margin-right: 10px;">🤯</span>
-        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">LobeHub</span>
+        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">${BRANDING_NAME}</span>
       </div>
     </div>
 
@@ -57,7 +59,7 @@ export const getVerificationEmailTemplate = (params: {
         ${userName ? `<p style="margin: 0 0 16px 0;">Hi <strong>${userName}</strong>,</p>` : ''}
         
         <p style="margin: 0 0 24px 0;">
-          Thanks for creating an account with LobeHub. To access your account, please verify your email address by clicking the button below.
+          Thanks for creating an account with ${BRANDING_NAME}. To access your account, please verify your email address by clicking the button below.
         </p>
 
         <!-- Button -->
@@ -100,14 +102,14 @@ export const getVerificationEmailTemplate = (params: {
         ${getEmailSupportHtml()}
       </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
-        © 2026 LobeHub. All rights reserved.
+        ${COPYRIGHT_FULL}
       </p>
     </div>
   </div>
 </body>
 </html>
     `,
-    subject: 'Verify Your Email - LobeHub',
+    subject: `Verify Your Email - ${BRANDING_NAME}`,
     text: `Please verify your email by clicking this link: ${url}\n\nThis link will expire in ${expirationText}.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/workspace-invite.ts
+++ b/src/libs/better-auth/email-templates/workspace-invite.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
+
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
 /**
@@ -17,7 +19,7 @@ export const getWorkspaceInviteEmailTemplate = (params: {
   const inviterLabel = inviterName || inviterEmail || 'A teammate';
   const inviterByline =
     inviterEmail && inviterName ? `${inviterName} (${inviterEmail})` : inviterLabel;
-  const subject = `${inviterLabel} invited you to join ${workspaceName} on LobeHub`;
+  const subject = `${inviterLabel} invited you to join ${workspaceName} on ${BRANDING_NAME}`;
   const roleLabel = role.charAt(0).toUpperCase() + role.slice(1);
 
   return {
@@ -36,7 +38,7 @@ export const getWorkspaceInviteEmailTemplate = (params: {
     <div style="text-align: center; margin-bottom: 32px;">
       <div style="display: inline-flex; align-items: center; justify-content: center; background-color: #ffffff; border-radius: 12px; padding: 8px 16px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
         <span style="font-size: 24px; line-height: 1; margin-right: 10px;">🤯</span>
-        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">LobeHub</span>
+        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">${BRANDING_NAME}</span>
       </div>
     </div>
 
@@ -46,7 +48,7 @@ export const getWorkspaceInviteEmailTemplate = (params: {
       <!-- Header -->
       <div style="text-align: center; margin-bottom: 32px;">
         <h1 style="color: #111827; font-size: 24px; font-weight: 700; margin: 0 0 12px 0; letter-spacing: -0.5px;">
-          Join <strong>${workspaceName}</strong> on LobeHub
+          Join <strong>${workspaceName}</strong> on ${BRANDING_NAME}
         </h1>
         <p style="color: #6b7280; font-size: 16px; margin: 0;">
           You've been invited as a <strong>${roleLabel}</strong>.
@@ -57,7 +59,7 @@ export const getWorkspaceInviteEmailTemplate = (params: {
       <div style="color: #374151; font-size: 16px; line-height: 1.6;">
         <p style="margin: 0 0 24px 0;">
           <strong>${inviterByline}</strong> has invited you to collaborate inside the
-          <strong>${workspaceName}</strong> workspace on LobeHub.
+          <strong>${workspaceName}</strong> workspace on ${BRANDING_NAME}.
         </p>
 
         <!-- Button -->
@@ -76,7 +78,7 @@ export const getWorkspaceInviteEmailTemplate = (params: {
         </div>
 
         <p style="color: #6b7280; font-size: 15px; margin: 0;">
-          If you don't have a LobeHub account yet, you'll be guided through a quick signup before joining the workspace.
+          If you don't have a ${BRANDING_NAME} account yet, you'll be guided through a quick signup before joining the workspace.
         </p>
       </div>
 
@@ -108,6 +110,6 @@ export const getWorkspaceInviteEmailTemplate = (params: {
 </html>
     `,
     subject,
-    text: `${inviterByline} has invited you to join the "${workspaceName}" workspace on LobeHub as ${roleLabel}.\n\nAccept the invitation: ${url}\n\nThis invitation will expire in ${expiresInDays} day${expiresInDays > 1 ? 's' : ''}.\n\nIf you weren't expecting this invitation, you can safely ignore this email.\n\n${getEmailSupportText()}`,
+    text: `${inviterByline} has invited you to join the "${workspaceName}" workspace on ${BRANDING_NAME} as ${roleLabel}.\n\nAccept the invitation: ${url}\n\nThis invitation will expire in ${expiresInDays} day${expiresInDays > 1 ? 's' : ''}.\n\nIf you weren't expecting this invitation, you can safely ignore this email.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/workspace-member-removed.ts
+++ b/src/libs/better-auth/email-templates/workspace-member-removed.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
+
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
 export const getWorkspaceMemberRemovedEmailTemplate = (params: {
@@ -9,8 +11,8 @@ export const getWorkspaceMemberRemovedEmailTemplate = (params: {
   const isDowngrade = reason === 'downgrade';
 
   const subject = isDowngrade
-    ? `You have been removed from ${workspaceName} on LobeHub`
-    : `You have been removed from ${workspaceName} on LobeHub`;
+    ? `You have been removed from ${workspaceName} on ${BRANDING_NAME}`
+    : `You have been removed from ${workspaceName} on ${BRANDING_NAME}`;
 
   const heading = isDowngrade
     ? `Removed from <strong>${workspaceName}</strong>`
@@ -36,7 +38,7 @@ export const getWorkspaceMemberRemovedEmailTemplate = (params: {
     <div style="text-align: center; margin-bottom: 32px;">
       <div style="display: inline-flex; align-items: center; justify-content: center; background-color: #ffffff; border-radius: 12px; padding: 8px 16px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
         <span style="font-size: 24px; line-height: 1; margin-right: 10px;">🤯</span>
-        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">LobeHub</span>
+        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">${BRANDING_NAME}</span>
       </div>
     </div>
 
@@ -70,7 +72,7 @@ export const getWorkspaceMemberRemovedEmailTemplate = (params: {
       <!-- Footer note -->
       <div style="text-align: center;">
         <p style="color: #9ca3af; font-size: 13px; margin: 0;">
-          You can continue using LobeHub with your personal workspace.
+          You can continue using ${BRANDING_NAME} with your personal workspace.
         </p>
       </div>
     </div>
@@ -81,7 +83,7 @@ export const getWorkspaceMemberRemovedEmailTemplate = (params: {
         ${getEmailSupportHtml()}
       </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
-        This is an automated message from LobeHub.
+        This is an automated message from ${BRANDING_NAME}.
       </p>
     </div>
   </div>


### PR DESCRIPTION
better-auth's email templates and the passkey/WebAuthn RP name had `LobeHub` baked directly into the copy users actually receive, so a custom-branding deployment still sent password-reset/magic-link/invite emails signed by, and browser passkey prompts naming, the upstream product.

Default (non-custom-branding) behaviour is unchanged — `BRANDING_NAME` defaults to `'LobeHub'`, so every interpolated string renders byte-identical to today.

#### What changed

- `src/libs/better-auth/define-config.ts`: the WebAuthn relying-party name (shown in the browser's native passkey prompt) now follows `BRANDING_NAME`
- All 7 email templates (change-email, magic-link, reset-password, verification-otp, verification, workspace-invite, workspace-member-removed) interpolate `BRANDING_NAME` wherever the copy names the product

#### Test

- [x] Tested locally
- [x] `bun run check --lint --test` clean, no leftover hardcoded brand strings in the touched files

#### Key Decisions / Non-goals

- Clean cherry-pick, no conflicts — this file set wasn't touched by canary since the branch diverged.