### PR TITLE
🐛 fix(stats): show the product logo for the provider a build brands as its own

### DIFF
--- a/src/components/Branding/ProviderIcon/index.test.tsx
+++ b/src/components/Branding/ProviderIcon/index.test.tsx
@@ -1,0 +1,60 @@
+import { BRANDING_PROVIDER } from '@lobechat/business-const';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProviderIcon } from './index';
+
+const branding = { isCustomBranding: true };
+
+vi.mock('@/const/version', () => ({
+  get isCustomBranding() {
+    return branding.isCustomBranding;
+  },
+}));
+
+vi.mock('@/components/Branding/ProductLogo', () => ({
+  ProductLogo: ({ size }: { size?: number }) => <div data-size={size} data-testid="product-logo" />,
+}));
+
+vi.mock('@lobehub/icons', () => ({
+  ProviderIcon: ({ provider, size }: { provider?: string; size?: number }) => (
+    <div data-provider={provider} data-size={size} data-testid="vendor-icon" />
+  ),
+}));
+
+beforeEach(() => {
+  branding.isCustomBranding = true;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Branding ProviderIcon', () => {
+  it('renders the product logo for the provider this distribution brands as its own', () => {
+    render(<ProviderIcon provider={BRANDING_PROVIDER} size={18} />);
+
+    // Stored usage rows carry the upstream provider id, so without this the
+    // spend table labels our own models with LobeHub's mark.
+    expect(screen.getByTestId('product-logo')).toHaveAttribute('data-size', '18');
+    expect(screen.queryByTestId('vendor-icon')).not.toBeInTheDocument();
+  });
+
+  it('leaves every other provider to its vendor icon', () => {
+    render(<ProviderIcon provider="anthropic" size={18} />);
+
+    expect(screen.getByTestId('vendor-icon')).toHaveAttribute('data-provider', 'anthropic');
+    expect(screen.queryByTestId('product-logo')).not.toBeInTheDocument();
+  });
+
+  it('substitutes nothing on an unbranded build', () => {
+    branding.isCustomBranding = false;
+
+    render(<ProviderIcon provider={BRANDING_PROVIDER} size={18} />);
+
+    // Upstream the two resolve to the same mark anyway; keeping the vendor icon
+    // means this component changes nothing for builds that did not rebrand.
+    expect(screen.getByTestId('vendor-icon')).toHaveAttribute('data-provider', BRANDING_PROVIDER);
+    expect(screen.queryByTestId('product-logo')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Branding/ProviderIcon/index.tsx
+++ b/src/components/Branding/ProviderIcon/index.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { BRANDING_PROVIDER } from '@lobechat/business-const';
+import { type ProviderIconProps } from '@lobehub/icons';
+import { ProviderIcon as VendorProviderIcon } from '@lobehub/icons';
+import { memo } from 'react';
+
+import { ProductLogo } from '@/components/Branding/ProductLogo';
+import { isCustomBranding } from '@/const/version';
+
+/**
+ * `ProviderIcon` keyed by provider id, except that the id this distribution
+ * serves as its own resolves to the product logo instead of to LobeHub's mark.
+ *
+ * The branded provider keeps the upstream id in the catalogue and therefore in
+ * every spend row and usage aggregate, so an unqualified `<ProviderIcon />`
+ * renders the LobeHub logo beside our own product name — the one place in the
+ * app still visibly attributing the models to someone else. The provider list
+ * and the model picker already make this substitution inline; this is the same
+ * one, for the surfaces that render a provider id straight from stored usage
+ * data.
+ *
+ * Falls through to the vendor icon for every other provider, and for upstream
+ * builds, where the two render the same logo anyway.
+ */
+export const ProviderIcon = memo<ProviderIconProps>(({ provider, size, style, ...rest }) =>
+  isCustomBranding && provider === BRANDING_PROVIDER ? (
+    <ProductLogo size={size} style={style} type={'flat'} />
+  ) : (
+    <VendorProviderIcon provider={provider} size={size} style={style} {...rest} />
+  ),
+);

--- a/src/components/Branding/index.ts
+++ b/src/components/Branding/index.ts
@@ -1,2 +1,3 @@
 export { OrgBrand } from './OrgBrand';
 export { ProductLogo } from './ProductLogo';
+export { ProviderIcon } from './ProviderIcon';

--- a/src/features/Settings/stats/features/usage/UsageCards/ActiveModels/ModelTable.tsx
+++ b/src/features/Settings/stats/features/usage/UsageCards/ActiveModels/ModelTable.tsx
@@ -1,10 +1,11 @@
 import { CategoryBar, useThemeColorRange } from '@lobehub/charts';
-import { ModelIcon, ProviderIcon } from '@lobehub/icons';
+import { ModelIcon } from '@lobehub/icons';
 import { Avatar, Collapse, Flexbox, Skeleton, Tag } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ProviderIcon } from '@/components/Branding';
 import InlineTable from '@/components/InlineTable';
 import { type UsageLog, type UsageRecordItem } from '@/types/usage/usageRecord';
 import { formatPrice } from '@/utils/format';

--- a/src/features/Settings/stats/features/usage/UsageCards/ActiveModels/index.test.tsx
+++ b/src/features/Settings/stats/features/usage/UsageCards/ActiveModels/index.test.tsx
@@ -18,6 +18,12 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('@lobehub/icons', () => ({
   ModelIcon: ({ model }: { model: string }) => <span>{model}</span>,
+}));
+
+// Stubbed for the same reason as the vendor icons above: the real one reaches
+// the branding logo, and through it `@lobehub/ui/brand`, which this file's
+// deliberately narrow `@lobehub/icons` stub cannot satisfy.
+vi.mock('@/components/Branding', () => ({
   ProviderIcon: ({ provider }: { provider: string }) => <span>{provider}</span>,
 }));
 

--- a/src/features/Settings/stats/features/usage/UsageCards/ActiveModels/index.tsx
+++ b/src/features/Settings/stats/features/usage/UsageCards/ActiveModels/index.tsx
@@ -1,10 +1,11 @@
-import { ModelIcon, ProviderIcon } from '@lobehub/icons';
+import { ModelIcon } from '@lobehub/icons';
 import { ActionIcon, Avatar, Flexbox } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { MaximizeIcon } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ProviderIcon } from '@/components/Branding';
 import ImperativeModal from '@/components/ImperativeModal';
 import StatisticCard from '@/components/StatisticCard';
 import TitleWithPercentage from '@/components/StatisticCard/TitleWithPercentage';

--- a/src/features/Settings/stats/features/usage/UsageTable.tsx
+++ b/src/features/Settings/stats/features/usage/UsageTable.tsx
@@ -1,10 +1,10 @@
-import { ProviderIcon } from '@lobehub/icons';
 import { Flexbox, Text, Tooltip } from '@lobehub/ui';
 import { type TableColumnType } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { memo, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ProviderIcon } from '@/components/Branding';
 import InlineTable from '@/components/InlineTable';
 import SpendType, { type SpendTypeValue } from '@/components/SpendType';
 import TablePagination from '@/components/TablePagination';


### PR DESCRIPTION
The usage-stats spend table and active-models cards render a provider's icon by provider id, so the first-party `lobehub` provider always drew the upstream LobeHub mark — the one place a custom-branding deployment's own usage dashboard still showed the vendor's logo instead of the deployment's own.

Default (non-custom-branding) behaviour is unchanged.

#### What changed

- Adds `src/components/Branding/ProviderIcon` — a small wrapper that resolves the `lobehub` provider id to the product logo (branding-aware) instead of the hardcoded upstream mark, and passes every other provider through to the existing icon resolution unchanged
- Wires it into `UsageTable.tsx` and `ActiveModels/{ModelTable,index}.tsx`

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [x] `bun run check --lint --test` clean

#### Key Decisions / Non-goals

- Clean cherry-pick, no conflicts.