### PR TITLE
✨ feat(gateway): rebuild one host's connections when it announces a restart

### DIFF
--- a/apps/server/src/router-hono/agent/handlers/__tests__/gatewayAnnounce.test.ts
+++ b/apps/server/src/router-hono/agent/handlers/__tests__/gatewayAnnounce.test.ts
@@ -48,7 +48,7 @@ describe('gatewayAnnounce', () => {
     mockEnv.MESSAGE_GATEWAY_ENABLED = '1';
     mockEnv.MESSAGE_GATEWAY_SERVICE_TOKEN = 'shared-token';
     mockRedis.client = null;
-    mockReconcileHost.mockResolvedValue(undefined);
+    mockReconcileHost.mockResolvedValue({ connected: 3, failed: 0, ok: true });
   });
 
   it('rebuilds only the announcing host', async () => {
@@ -77,6 +77,23 @@ describe('gatewayAnnounce', () => {
     expect(r.payload.reconciled).toBe(false);
   });
 
+  it('treats a reconcile that achieved nothing as retryable, not as success', async () => {
+    // GatewayService absorbs an unreachable admin surface into a null
+    // snapshot and resolves normally, so "did not throw" is not the same as
+    // "worked" — the outcome is what tells them apart.
+    mockReconcileHost.mockResolvedValue({
+      connected: 0,
+      failed: 0,
+      ok: false,
+      reason: 'admin snapshot unavailable',
+    });
+
+    const r = await call({ host: 'node' });
+
+    expect(r.status).toBe(503);
+    expect(r.payload.reconciled).toBe(false);
+  });
+
   describe('with redis', () => {
     beforeEach(() => {
       mockRedis.client = {
@@ -98,8 +115,16 @@ describe('gatewayAnnounce', () => {
       expect(mockReconcileHost).not.toHaveBeenCalled();
     });
 
-    it('starts no cooldown when the rebuild failed', async () => {
-      mockReconcileHost.mockRejectedValue(new Error('boom'));
+    it('starts no cooldown when the rebuild achieved nothing', async () => {
+      // Not a thrown error — the shape a swallowed service failure actually
+      // takes. A cooldown here would turn one bad round into a window where
+      // the gateway is refused its retry.
+      mockReconcileHost.mockResolvedValue({
+        connected: 0,
+        failed: 2,
+        ok: false,
+        reason: '2 connection(s) failed',
+      });
 
       await call({ host: 'node' });
 

--- a/apps/server/src/router-hono/agent/handlers/__tests__/gatewayAnnounce.test.ts
+++ b/apps/server/src/router-hono/agent/handlers/__tests__/gatewayAnnounce.test.ts
@@ -143,6 +143,35 @@ describe('gatewayAnnounce', () => {
       expect(mockRedis.client!.eval).toHaveBeenCalledTimes(2);
     });
 
+    it('renews its own lease while the rebuild is still running', async () => {
+      // A rebuild slower than the lease would otherwise have the lock expire
+      // underneath it, letting a waiting caller start a second one alongside.
+      vi.useFakeTimers();
+      let finish: () => void = () => {};
+      mockReconcileHost.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            finish = () => resolve({ connected: 1, failed: 0, ok: true });
+          }),
+      );
+
+      const pending = call({ host: 'node' });
+      await vi.advanceTimersByTimeAsync(25_000);
+
+      const renewals = mockRedis.client!.eval.mock.calls.filter(([script]) =>
+        String(script).includes('expire'),
+      );
+      expect(renewals.length).toBeGreaterThan(0);
+      // Renewal is a compare-and-set on our own token, never a blind extend.
+      expect(renewals[0][3]).toBe(
+        mockRedis.client!.set.mock.calls.find(([key]) => String(key).includes('lock'))?.[1],
+      );
+
+      finish();
+      await pending;
+      vi.useRealTimers();
+    });
+
     it('releases only its own lock, by token', async () => {
       await call({ host: 'node' });
 

--- a/apps/server/src/router-hono/agent/handlers/__tests__/gatewayAnnounce.test.ts
+++ b/apps/server/src/router-hono/agent/handlers/__tests__/gatewayAnnounce.test.ts
@@ -10,7 +10,7 @@ const mockEnv = vi.hoisted(() => ({
 const mockReconcileHost = vi.hoisted(() => vi.fn());
 const mockRedis = vi.hoisted(() => ({
   client: null as null | {
-    del: ReturnType<typeof vi.fn>;
+    eval: ReturnType<typeof vi.fn>;
     set: ReturnType<typeof vi.fn>;
     ttl: ReturnType<typeof vi.fn>;
   },
@@ -97,7 +97,7 @@ describe('gatewayAnnounce', () => {
   describe('with redis', () => {
     beforeEach(() => {
       mockRedis.client = {
-        del: vi.fn().mockResolvedValue(1),
+        eval: vi.fn().mockResolvedValue(1),
         set: vi.fn().mockResolvedValue('OK'),
         ttl: vi.fn().mockResolvedValue(-2),
       };
@@ -136,11 +136,35 @@ describe('gatewayAnnounce', () => {
 
     it('releases the lock whether the rebuild succeeded or not', async () => {
       await call({ host: 'node' });
-      expect(mockRedis.client!.del).toHaveBeenCalledTimes(1);
+      expect(mockRedis.client!.eval).toHaveBeenCalledTimes(1);
 
       mockReconcileHost.mockRejectedValue(new Error('boom'));
       await call({ host: 'node' });
-      expect(mockRedis.client!.del).toHaveBeenCalledTimes(2);
+      expect(mockRedis.client!.eval).toHaveBeenCalledTimes(2);
+    });
+
+    it('releases only its own lock, by token', async () => {
+      await call({ host: 'node' });
+
+      const token = mockRedis.client!.set.mock.calls.find(([key]) =>
+        String(key).includes('lock'),
+      )?.[1];
+      const [script, keyCount, , releasedToken] = mockRedis.client!.eval.mock.calls[0];
+
+      expect(script).toContain('redis.call("get", KEYS[1]) == ARGV[1]');
+      expect(keyCount).toBe(1);
+      expect(releasedToken).toBe(token);
+    });
+
+    it('never releases a lock it failed to acquire', async () => {
+      // A transient redis error lets the rebuild through without the lock;
+      // deleting on the way out would drop whoever actually holds it.
+      mockRedis.client!.ttl.mockRejectedValue(new Error('redis blip'));
+
+      await call({ host: 'node' });
+
+      expect(mockReconcileHost).toHaveBeenCalled();
+      expect(mockRedis.client!.eval).not.toHaveBeenCalled();
     });
 
     it('defers while another rebuild for the same host is in flight', async () => {

--- a/apps/server/src/router-hono/agent/handlers/__tests__/gatewayAnnounce.test.ts
+++ b/apps/server/src/router-hono/agent/handlers/__tests__/gatewayAnnounce.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { gatewayAnnounce } from '../gatewayAnnounce';
+
+const mockEnv = vi.hoisted(() => ({
+  MESSAGE_GATEWAY_ENABLED: '1' as string | undefined,
+  MESSAGE_GATEWAY_SERVICE_TOKEN: 'shared-token' as string | undefined,
+}));
+const mockReconcileHost = vi.hoisted(() => vi.fn());
+const mockRedis = vi.hoisted(() => ({
+  client: null as null | {
+    del: ReturnType<typeof vi.fn>;
+    set: ReturnType<typeof vi.fn>;
+    ttl: ReturnType<typeof vi.fn>;
+  },
+}));
+
+vi.mock('@/envs/gateway', () => ({ gatewayEnv: mockEnv }));
+vi.mock('@/server/modules/AgentRuntime/redis', () => ({
+  getAgentRuntimeRedisClient: () => mockRedis.client,
+}));
+vi.mock('@/server/services/gateway', () => ({
+  GatewayService: class {
+    reconcileHost = mockReconcileHost;
+  },
+}));
+
+const call = async (body: unknown, token = 'shared-token') => {
+  const headers = new Map<string, string>([['authorization', `Bearer ${token}`]]);
+  const res: Record<string, string> = {};
+  const c = {
+    body: (_b: null, status: number) => ({ status, json: async () => null }),
+    header: (k: string, v: string) => (res[k] = v),
+    json: (payload: unknown, status = 200) => ({ headers: res, payload, status }),
+    req: { header: (k: string) => headers.get(k), json: async () => body },
+  };
+  return (await gatewayAnnounce(c as never)) as unknown as {
+    headers: Record<string, string>;
+    payload: Record<string, unknown>;
+    status: number;
+  };
+};
+
+describe('gatewayAnnounce', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnv.MESSAGE_GATEWAY_ENABLED = '1';
+    mockEnv.MESSAGE_GATEWAY_SERVICE_TOKEN = 'shared-token';
+    mockRedis.client = null;
+    mockReconcileHost.mockResolvedValue(undefined);
+  });
+
+  it('rebuilds only the announcing host', async () => {
+    const r = await call({ host: 'node', reason: 'process start' });
+
+    expect(r.status).toBe(200);
+    expect(mockReconcileHost).toHaveBeenCalledWith('node');
+  });
+
+  it('rejects a wrong token', async () => {
+    const r = await call({ host: 'node' }, 'nope');
+
+    expect(r.status).toBe(401);
+    expect(mockReconcileHost).not.toHaveBeenCalled();
+  });
+
+  it('reports a failed rebuild as retryable instead of claiming success', async () => {
+    // The gateway is sitting on an empty registry; telling it "done" here is
+    // how a transient database blip turns into an outage lasting until the
+    // periodic reconcile.
+    mockReconcileHost.mockRejectedValue(new Error('db unavailable'));
+
+    const r = await call({ host: 'node' });
+
+    expect(r.status).toBe(503);
+    expect(r.payload.reconciled).toBe(false);
+  });
+
+  describe('with redis', () => {
+    beforeEach(() => {
+      mockRedis.client = {
+        del: vi.fn().mockResolvedValue(1),
+        set: vi.fn().mockResolvedValue('OK'),
+        ttl: vi.fn().mockResolvedValue(-2),
+      };
+    });
+
+    it('asks a restart inside the cooldown to come back, rather than dropping it', async () => {
+      // The previous rebuild filled a registry that died with the process it
+      // was built for — this restart still needs its own.
+      mockRedis.client!.ttl.mockResolvedValue(30);
+
+      const r = await call({ host: 'node' });
+
+      expect(r.status).toBe(429);
+      expect(r.headers['Retry-After']).toBe('30');
+      expect(mockReconcileHost).not.toHaveBeenCalled();
+    });
+
+    it('starts no cooldown when the rebuild failed', async () => {
+      mockReconcileHost.mockRejectedValue(new Error('boom'));
+
+      await call({ host: 'node' });
+
+      const cooldownWrites = mockRedis.client!.set.mock.calls.filter(([key]) =>
+        String(key).includes('cooldown'),
+      );
+      expect(cooldownWrites).toHaveLength(0);
+    });
+
+    it('releases the lock whether the rebuild succeeded or not', async () => {
+      await call({ host: 'node' });
+      expect(mockRedis.client!.del).toHaveBeenCalledTimes(1);
+
+      mockReconcileHost.mockRejectedValue(new Error('boom'));
+      await call({ host: 'node' });
+      expect(mockRedis.client!.del).toHaveBeenCalledTimes(2);
+    });
+
+    it('defers while another rebuild for the same host is in flight', async () => {
+      mockRedis.client!.set.mockResolvedValue(null);
+
+      const r = await call({ host: 'node' });
+
+      expect(r.status).toBe(429);
+      expect(mockReconcileHost).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/server/src/router-hono/agent/handlers/__tests__/gatewayAnnounce.test.ts
+++ b/apps/server/src/router-hono/agent/handlers/__tests__/gatewayAnnounce.test.ts
@@ -143,6 +143,21 @@ describe('gatewayAnnounce', () => {
       expect(mockRedis.client!.eval).toHaveBeenCalledTimes(2);
     });
 
+    it('defers when a cooldown appears between the first check and the lock', async () => {
+      // Another request finished rebuilding in that gap and wrote the
+      // cooldown. Without the re-read this one would rebuild immediately and
+      // walk past the crash-loop cap.
+      mockRedis.client!.ttl.mockResolvedValueOnce(-2).mockResolvedValueOnce(42);
+
+      const r = await call({ host: 'node' });
+
+      expect(r.status).toBe(429);
+      expect(r.headers['Retry-After']).toBe('42');
+      expect(mockReconcileHost).not.toHaveBeenCalled();
+      // And it hands the lock back rather than sitting on it.
+      expect(mockRedis.client!.eval).toHaveBeenCalled();
+    });
+
     it('renews its own lease while the rebuild is still running', async () => {
       // A rebuild slower than the lease would otherwise have the lock expire
       // underneath it, letting a waiting caller start a second one alongside.

--- a/apps/server/src/router-hono/agent/handlers/gatewayAnnounce.ts
+++ b/apps/server/src/router-hono/agent/handlers/gatewayAnnounce.ts
@@ -113,15 +113,26 @@ export async function gatewayAnnounce(c: Context): Promise<Response> {
   // admin-surface blip into a retry instead of an outage lasting until the
   // periodic reconcile. Scoping keeps this cheap enough to await.
   try {
-    await new GatewayService().reconcileHost(host);
+    const outcome = await new GatewayService().reconcileHost(host);
+
+    // The sync survives partial failure by design — an unreachable admin
+    // surface, a platform that will not load, a connection that will not
+    // build are all absorbed rather than thrown. Awaiting it therefore only
+    // catches setup errors, so the outcome is what actually distinguishes
+    // "your fleet is back" from "this round achieved nothing".
+    if (!outcome.ok) {
+      log('announce: %s host rebuild incomplete (%s)', host, outcome.reason);
+      return c.json({ error: outcome.reason, reconciled: false }, 503);
+    }
+
     if (redis) {
-      // Only a success starts the cooldown.
+      // Only a clean rebuild starts the cooldown.
       await redis
         .set(cooldownKey(host), Date.now().toString(), 'EX', ANNOUNCE_COOLDOWN_SECONDS)
         .catch(() => undefined);
     }
-    log('announce: %s host rebuilt', host);
-    return c.json({ host, reconciled: true });
+    log('announce: %s host rebuilt (connected=%d)', host, outcome.connected);
+    return c.json({ connected: outcome.connected, host, reconciled: true });
   } catch (err) {
     log('announce: %s host rebuild failed: %O', host, err);
     // 503 so the gateway's existing backoff retries; no cooldown was set, so

--- a/apps/server/src/router-hono/agent/handlers/gatewayAnnounce.ts
+++ b/apps/server/src/router-hono/agent/handlers/gatewayAnnounce.ts
@@ -1,0 +1,102 @@
+import debug from 'debug';
+import type { Context } from 'hono';
+import { z } from 'zod';
+
+import { gatewayEnv } from '@/envs/gateway';
+import { getAgentRuntimeRedisClient } from '@/server/modules/AgentRuntime/redis';
+import { GatewayService } from '@/server/services/gateway';
+import type { MessageGatewayHost } from '@/server/services/gateway/MessageGatewayClient';
+import { after } from '@/server/utils/scheduleAfterResponse';
+
+const log = debug('lobe-server:agent:gateway-announce');
+
+const AnnounceSchema = z.object({
+  /** Which gateway is speaking. Only its own connections are rebuilt. */
+  host: z.enum(['default', 'node']),
+  /** Advisory, for logs — the gateway's own view of why it restarted. */
+  reason: z.string().max(200).optional(),
+});
+
+/**
+ * How long one host's announcements collapse into a single reconcile. A
+ * crash-looping gateway would otherwise ask for a rebuild every few seconds;
+ * the loop is the problem to fix, and hammering reconcile does not fix it.
+ * Well under the periodic reconcile interval, so a genuine restart is never
+ * left waiting for a whole cron round.
+ */
+const ANNOUNCE_DEBOUNCE_SECONDS = 60;
+
+const debounceKey = (host: MessageGatewayHost) => `lobehub:gateway:announce:${host}`;
+
+/**
+ * A message gateway announcing that it came up with an empty registry.
+ *
+ * Authenticated with `MESSAGE_GATEWAY_SERVICE_TOKEN` — the same shared token
+ * the gateways already use for state callbacks, so no new secret is
+ * distributed. Responds immediately and reconciles after the response: the
+ * caller is a gateway finishing its own boot, and it should not be held open
+ * for the length of a fleet rebuild.
+ */
+export async function gatewayAnnounce(c: Context): Promise<Response> {
+  // Mirror the state-callback handler: when the gateway feature is off,
+  // connections are managed locally and a stale announcement must not kick
+  // off a reconcile. 204 rather than 401 so an old deployment still shutting
+  // down does not look like an auth failure.
+  if (gatewayEnv.MESSAGE_GATEWAY_ENABLED !== '1') {
+    return c.body(null, 204);
+  }
+
+  const serviceToken = gatewayEnv.MESSAGE_GATEWAY_SERVICE_TOKEN;
+  if (!serviceToken) {
+    return c.json({ error: 'Service not configured' }, 503);
+  }
+  if (c.req.header('authorization') !== `Bearer ${serviceToken}`) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  let parsed;
+  try {
+    parsed = AnnounceSchema.safeParse(await c.req.json());
+  } catch {
+    return c.json({ error: 'Invalid JSON' }, 400);
+  }
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid body', issues: parsed.error.issues }, 400);
+  }
+
+  const { host, reason } = parsed.data;
+
+  // Debounce is best-effort: without Redis a restart still gets its rebuild,
+  // which is the behaviour worth protecting. Only the crash-loop cap is lost.
+  const redis = getAgentRuntimeRedisClient();
+  if (redis) {
+    try {
+      const acquired = await redis.set(
+        debounceKey(host),
+        Date.now().toString(),
+        'EX',
+        ANNOUNCE_DEBOUNCE_SECONDS,
+        'NX',
+      );
+      if (acquired !== 'OK') {
+        log('announce from %s host debounced (reason=%s)', host, reason ?? '-');
+        return c.json({ reconciling: false, reason: 'debounced' });
+      }
+    } catch (err) {
+      log('announce debounce check failed, reconciling anyway: %O', err);
+    }
+  }
+
+  log('announce from %s host, scheduling reconcile (reason=%s)', host, reason ?? '-');
+
+  after(async () => {
+    try {
+      await new GatewayService().reconcileHost(host);
+      log('announce reconcile for %s host complete', host);
+    } catch (err) {
+      log('announce reconcile for %s host failed: %O', host, err);
+    }
+  });
+
+  return c.json({ host, reconciling: true });
+}

--- a/apps/server/src/router-hono/agent/handlers/gatewayAnnounce.ts
+++ b/apps/server/src/router-hono/agent/handlers/gatewayAnnounce.ts
@@ -6,7 +6,6 @@ import { gatewayEnv } from '@/envs/gateway';
 import { getAgentRuntimeRedisClient } from '@/server/modules/AgentRuntime/redis';
 import { GatewayService } from '@/server/services/gateway';
 import type { MessageGatewayHost } from '@/server/services/gateway/MessageGatewayClient';
-import { after } from '@/server/utils/scheduleAfterResponse';
 
 const log = debug('lobe-server:agent:gateway-announce');
 
@@ -18,24 +17,48 @@ const AnnounceSchema = z.object({
 });
 
 /**
- * How long one host's announcements collapse into a single reconcile. A
- * crash-looping gateway would otherwise ask for a rebuild every few seconds;
- * the loop is the problem to fix, and hammering reconcile does not fix it.
- * Well under the periodic reconcile interval, so a genuine restart is never
- * left waiting for a whole cron round.
+ * How long after a SUCCESSFUL rebuild the same host is asked to wait before
+ * requesting another. A crash-looping gateway would otherwise ask for one
+ * every few seconds; the loop is the problem to fix, and rebuilding on every
+ * iteration does not fix it. Only success starts the cooldown — a failed
+ * rebuild must be retryable immediately, or a transient database blip would
+ * strand the gateway until the periodic reconcile.
  */
-const ANNOUNCE_DEBOUNCE_SECONDS = 60;
+const ANNOUNCE_COOLDOWN_SECONDS = 60;
 
-const debounceKey = (host: MessageGatewayHost) => `lobehub:gateway:announce:${host}`;
+/**
+ * Upper bound on how long one rebuild may hold the slot. Only a crashed
+ * invocation reaches it — the lock is released in `finally` — so it exists to
+ * stop a dead process from blocking recovery, not to bound normal work.
+ */
+const ANNOUNCE_LOCK_SECONDS = 180;
+
+const cooldownKey = (host: MessageGatewayHost) => `lobehub:gateway:announce:cooldown:${host}`;
+const lockKey = (host: MessageGatewayHost) => `lobehub:gateway:announce:lock:${host}`;
+
+/**
+ * Ask the caller to come back later rather than dropping its request. The
+ * caller is a gateway sitting on an empty registry: silently discarding its
+ * announcement is how a restart that lands inside the window ends up waiting
+ * for the periodic reconcile, which is the outage this endpoint exists to
+ * prevent.
+ */
+const retryLater = (c: Context, seconds: number, why: string) => {
+  c.header('Retry-After', String(seconds));
+  return c.json({ reason: why, retryAfterSeconds: seconds, reconciled: false }, 429);
+};
 
 /**
  * A message gateway announcing that it came up with an empty registry.
  *
  * Authenticated with `MESSAGE_GATEWAY_SERVICE_TOKEN` — the same shared token
  * the gateways already use for state callbacks, so no new secret is
- * distributed. Responds immediately and reconciles after the response: the
- * caller is a gateway finishing its own boot, and it should not be held open
- * for the length of a fleet rebuild.
+ * distributed.
+ *
+ * The rebuild runs before the response so its outcome reaches the caller: a
+ * gateway told "done" when nothing was rebuilt would sit empty until the
+ * periodic reconcile. Every answer this returns is one the caller can act on
+ * — 200 rebuilt, 429 come back in N seconds, 503 try again, 204/4xx stop.
  */
 export async function gatewayAnnounce(c: Context): Promise<Response> {
   // Mirror the state-callback handler: when the gateway feature is off,
@@ -65,38 +88,46 @@ export async function gatewayAnnounce(c: Context): Promise<Response> {
   }
 
   const { host, reason } = parsed.data;
-
-  // Debounce is best-effort: without Redis a restart still gets its rebuild,
-  // which is the behaviour worth protecting. Only the crash-loop cap is lost.
   const redis = getAgentRuntimeRedisClient();
+
+  // Cooldown and lock are best-effort: without Redis the rebuild still runs,
+  // which is the behaviour worth protecting. Only the crash-loop cap and the
+  // overlap guard are lost.
   if (redis) {
     try {
-      const acquired = await redis.set(
-        debounceKey(host),
-        Date.now().toString(),
-        'EX',
-        ANNOUNCE_DEBOUNCE_SECONDS,
-        'NX',
-      );
-      if (acquired !== 'OK') {
-        log('announce from %s host debounced (reason=%s)', host, reason ?? '-');
-        return c.json({ reconciling: false, reason: 'debounced' });
-      }
+      const cooling = await redis.ttl(cooldownKey(host));
+      if (cooling > 0) return retryLater(c, cooling, 'cooldown');
+
+      const locked = await redis.set(lockKey(host), '1', 'EX', ANNOUNCE_LOCK_SECONDS, 'NX');
+      if (locked !== 'OK') return retryLater(c, 5, 'rebuild in progress');
     } catch (err) {
-      log('announce debounce check failed, reconciling anyway: %O', err);
+      log('announce: redis guard unavailable, rebuilding anyway: %O', err);
     }
   }
 
-  log('announce from %s host, scheduling reconcile (reason=%s)', host, reason ?? '-');
+  log('announce from %s host, rebuilding (reason=%s)', host, reason ?? '-');
 
-  after(async () => {
-    try {
-      await new GatewayService().reconcileHost(host);
-      log('announce reconcile for %s host complete', host);
-    } catch (err) {
-      log('announce reconcile for %s host failed: %O', host, err);
+  // Rebuilt inline, not after the response, so the outcome reaches the caller.
+  // The gateway is holding an empty registry and already retries with
+  // backoff; letting it see a failure is what turns a transient database or
+  // admin-surface blip into a retry instead of an outage lasting until the
+  // periodic reconcile. Scoping keeps this cheap enough to await.
+  try {
+    await new GatewayService().reconcileHost(host);
+    if (redis) {
+      // Only a success starts the cooldown.
+      await redis
+        .set(cooldownKey(host), Date.now().toString(), 'EX', ANNOUNCE_COOLDOWN_SECONDS)
+        .catch(() => undefined);
     }
-  });
-
-  return c.json({ host, reconciling: true });
+    log('announce: %s host rebuilt', host);
+    return c.json({ host, reconciled: true });
+  } catch (err) {
+    log('announce: %s host rebuild failed: %O', host, err);
+    // 503 so the gateway's existing backoff retries; no cooldown was set, so
+    // the retry is not turned away.
+    return c.json({ error: 'Reconcile failed', reconciled: false }, 503);
+  } finally {
+    if (redis) await redis.del(lockKey(host)).catch(() => undefined);
+  }
 }

--- a/apps/server/src/router-hono/agent/handlers/gatewayAnnounce.ts
+++ b/apps/server/src/router-hono/agent/handlers/gatewayAnnounce.ts
@@ -49,7 +49,7 @@ const lockKey = (host: MessageGatewayHost) => `lobehub:gateway:announce:lock:${h
  * holder.
  */
 const releaseLock = (
-  redis: { eval: (...args: unknown[]) => Promise<unknown> },
+  redis: NonNullable<ReturnType<typeof getAgentRuntimeRedisClient>>,
   host: MessageGatewayHost,
   token: string,
 ) =>

--- a/apps/server/src/router-hono/agent/handlers/gatewayAnnounce.ts
+++ b/apps/server/src/router-hono/agent/handlers/gatewayAnnounce.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import debug from 'debug';
 import type { Context } from 'hono';
 import { z } from 'zod';
@@ -93,13 +95,21 @@ export async function gatewayAnnounce(c: Context): Promise<Response> {
   // Cooldown and lock are best-effort: without Redis the rebuild still runs,
   // which is the behaviour worth protecting. Only the crash-loop cap and the
   // overlap guard are lost.
+  // Identifies THIS request's hold on the lock. Without it the release below
+  // could delete a lock this request never acquired — after a transient Redis
+  // error let it through, or after a rebuild outlived the lease and someone
+  // else took over — which would let a crash loop run overlapping rebuilds.
+  const lockToken = randomUUID();
+  let holdsLock = false;
+
   if (redis) {
     try {
       const cooling = await redis.ttl(cooldownKey(host));
       if (cooling > 0) return retryLater(c, cooling, 'cooldown');
 
-      const locked = await redis.set(lockKey(host), '1', 'EX', ANNOUNCE_LOCK_SECONDS, 'NX');
+      const locked = await redis.set(lockKey(host), lockToken, 'EX', ANNOUNCE_LOCK_SECONDS, 'NX');
       if (locked !== 'OK') return retryLater(c, 5, 'rebuild in progress');
+      holdsLock = true;
     } catch (err) {
       log('announce: redis guard unavailable, rebuilding anyway: %O', err);
     }
@@ -139,6 +149,16 @@ export async function gatewayAnnounce(c: Context): Promise<Response> {
     // the retry is not turned away.
     return c.json({ error: 'Reconcile failed', reconciled: false }, 503);
   } finally {
-    if (redis) await redis.del(lockKey(host)).catch(() => undefined);
+    // Compare-and-delete: only ever drop the lock while it is still ours.
+    if (redis && holdsLock) {
+      await redis
+        .eval(
+          `if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end`,
+          1,
+          lockKey(host),
+          lockToken,
+        )
+        .catch(() => undefined);
+    }
   }
 }

--- a/apps/server/src/router-hono/agent/handlers/gatewayAnnounce.ts
+++ b/apps/server/src/router-hono/agent/handlers/gatewayAnnounce.ts
@@ -44,6 +44,25 @@ const cooldownKey = (host: MessageGatewayHost) => `lobehub:gateway:announce:cool
 const lockKey = (host: MessageGatewayHost) => `lobehub:gateway:announce:lock:${host}`;
 
 /**
+ * Compare-and-delete: only ever drop the lock while it is still ours. A lease
+ * that has already passed to someone else must not be released by its former
+ * holder.
+ */
+const releaseLock = (
+  redis: { eval: (...args: unknown[]) => Promise<unknown> },
+  host: MessageGatewayHost,
+  token: string,
+) =>
+  redis
+    .eval(
+      `if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end`,
+      1,
+      lockKey(host),
+      token,
+    )
+    .catch(() => undefined);
+
+/**
  * Ask the caller to come back later rather than dropping its request. The
  * caller is a gateway sitting on an empty registry: silently discarding its
  * announcement is how a restart that lands inside the window ends up waiting
@@ -115,6 +134,18 @@ export async function gatewayAnnounce(c: Context): Promise<Response> {
       const locked = await redis.set(lockKey(host), lockToken, 'EX', ANNOUNCE_LOCK_SECONDS, 'NX');
       if (locked !== 'OK') return retryLater(c, 5, 'rebuild in progress');
       holdsLock = true;
+
+      // The two checks are not one atomic step, so a request that read no
+      // cooldown while another was still rebuilding can arrive here just
+      // after that one finished and wrote it. Without this re-read it would
+      // start a second full rebuild immediately and walk straight past the
+      // crash-loop cap.
+      const settled = await redis.ttl(cooldownKey(host));
+      if (settled > 0) {
+        await releaseLock(redis, host, lockToken);
+        holdsLock = false;
+        return retryLater(c, settled, 'cooldown');
+      }
     } catch (err) {
       log('announce: redis guard unavailable, rebuilding anyway: %O', err);
     }
@@ -173,16 +204,6 @@ export async function gatewayAnnounce(c: Context): Promise<Response> {
     return c.json({ error: 'Reconcile failed', reconciled: false }, 503);
   } finally {
     if (renewer) clearInterval(renewer);
-    // Compare-and-delete: only ever drop the lock while it is still ours.
-    if (redis && holdsLock) {
-      await redis
-        .eval(
-          `if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end`,
-          1,
-          lockKey(host),
-          lockToken,
-        )
-        .catch(() => undefined);
-    }
+    if (redis && holdsLock) await releaseLock(redis, host, lockToken);
   }
 }

--- a/apps/server/src/router-hono/agent/handlers/gatewayAnnounce.ts
+++ b/apps/server/src/router-hono/agent/handlers/gatewayAnnounce.ts
@@ -29,11 +29,16 @@ const AnnounceSchema = z.object({
 const ANNOUNCE_COOLDOWN_SECONDS = 60;
 
 /**
- * Upper bound on how long one rebuild may hold the slot. Only a crashed
- * invocation reaches it — the lock is released in `finally` — so it exists to
- * stop a dead process from blocking recovery, not to bound normal work.
+ * Lease on the lock, renewed while the rebuild is still running. Short so a
+ * crashed invocation stops blocking recovery quickly; renewed so a slow one —
+ * a large fleet, an unhurried database — never has its lease expire out from
+ * under it, which would let a waiting caller start a second rebuild alongside
+ * the first.
  */
-const ANNOUNCE_LOCK_SECONDS = 180;
+const ANNOUNCE_LOCK_SECONDS = 30;
+
+/** Renewal interval, comfortably inside the lease. */
+const ANNOUNCE_LOCK_RENEW_MS = 10_000;
 
 const cooldownKey = (host: MessageGatewayHost) => `lobehub:gateway:announce:cooldown:${host}`;
 const lockKey = (host: MessageGatewayHost) => `lobehub:gateway:announce:lock:${host}`;
@@ -122,6 +127,24 @@ export async function gatewayAnnounce(c: Context): Promise<Response> {
   // backoff; letting it see a failure is what turns a transient database or
   // admin-surface blip into a retry instead of an outage lasting until the
   // periodic reconcile. Scoping keeps this cheap enough to await.
+  // Hold the lease open for as long as the work runs. Only ours is renewed —
+  // the same compare-and-set the release uses — so a lease that already
+  // passed to someone else is never extended.
+  const renewer =
+    redis && holdsLock
+      ? setInterval(() => {
+          void redis
+            .eval(
+              `if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("expire", KEYS[1], ARGV[2]) else return 0 end`,
+              1,
+              lockKey(host),
+              lockToken,
+              String(ANNOUNCE_LOCK_SECONDS),
+            )
+            .catch(() => undefined);
+        }, ANNOUNCE_LOCK_RENEW_MS)
+      : undefined;
+
   try {
     const outcome = await new GatewayService().reconcileHost(host);
 
@@ -149,6 +172,7 @@ export async function gatewayAnnounce(c: Context): Promise<Response> {
     // the retry is not turned away.
     return c.json({ error: 'Reconcile failed', reconciled: false }, 503);
   } finally {
+    if (renewer) clearInterval(renewer);
     // Compare-and-delete: only ever drop the lock while it is still ours.
     if (redis && holdsLock) {
       await redis

--- a/apps/server/src/router-hono/agent/index.ts
+++ b/apps/server/src/router-hono/agent/index.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 import { botCallback } from './handlers/botCallback';
 import { execAgent } from './handlers/execAgent';
 import { finalizeAbandoned } from './handlers/finalizeAbandoned';
+import { gatewayAnnounce } from './handlers/gatewayAnnounce';
 import { gatewayCallback } from './handlers/gatewayCallback';
 import { gatewayCron } from './handlers/gatewayCron';
 import { gatewayStart } from './handlers/gatewayStart';
@@ -66,6 +67,11 @@ app.post(
 // POST /api/agent/gateway/callback — message gateway state-change callbacks
 // (auth is inline so the disabled-feature 204 short-circuits before auth)
 app.post('/gateway/callback', gatewayCallback);
+
+// POST /api/agent/gateway/announce — a gateway reporting it restarted empty,
+// so its own connections get rebuilt now instead of on the next cron round.
+// (auth is inline, same reason as the callback above)
+app.post('/gateway/announce', gatewayAnnounce);
 
 // POST /api/agent/webhooks/bot-callback — agent step/completion webhooks (QStash)
 app.post('/webhooks/bot-callback', qstashAuth(), botCallback);

--- a/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
+++ b/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
@@ -1586,14 +1586,28 @@ describe('GatewayService', () => {
         expect(mockNodeGatewayClient.connect).not.toHaveBeenCalled();
       });
 
-      it('stays out of the way when gateway mode is off', async () => {
+      it('reports retryable, not success, when no gateway host is configured yet', async () => {
+        // Deployments are not atomic: a gateway can come up and announce
+        // before the URL routing to it reaches this side. Answering "fine"
+        // would end the announcement for good and leave it empty.
         mockGatewayClient.isEnabled = false;
         mockGatewayEnv.MESSAGE_GATEWAY_ENABLED = undefined;
 
-        await service.reconcileHost('node');
+        const outcome = await service.reconcileHost('node');
 
+        expect(outcome.ok).toBe(false);
+        expect(outcome.reason).toMatch(/not configured yet/i);
         expect(mockNodeGatewayClient.getStats).not.toHaveBeenCalled();
         expect(mockNodeGatewayClient.connect).not.toHaveBeenCalled();
+      });
+
+      it('reports retryable when the announcing host is not in the configured set', async () => {
+        mockNodeGateway.configured = false;
+
+        const outcome = await service.reconcileHost('node');
+
+        expect(outcome.ok).toBe(false);
+        expect(outcome.reason).toMatch(/not configured yet/i);
       });
     });
 

--- a/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
+++ b/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
@@ -1348,11 +1348,14 @@ describe('GatewayService', () => {
           expect.objectContaining({ connectionId: 'wechat-provider', platform: 'wechat' }),
           { ensure: true },
         );
-        // Not one request to the default host, of any kind.
-        expect(mockGatewayClient.getStats).not.toHaveBeenCalled();
-        expect(mockGatewayClient.getRegisteredIds).not.toHaveBeenCalled();
+        // The default host is read but never acted on. Reading is two admin
+        // requests and wakes nothing; connecting is what wakes a dormant
+        // connection, and that is what must not reach a host which did not
+        // restart. Reading it is what lets this round see connections another
+        // host still owns instead of building duplicates alongside them.
         expect(mockGatewayClient.connect).not.toHaveBeenCalled();
         expect(mockGatewayClient.disconnect).not.toHaveBeenCalled();
+        expect(mockGatewayClient.disconnectAll).not.toHaveBeenCalled();
       });
 
       it('reports failure when the host admin surface is unreachable', async () => {
@@ -1593,6 +1596,54 @@ describe('GatewayService', () => {
 
         expect(outcome.ok).toBe(true);
         expect(outcome.connected).toBe(0);
+      });
+
+      it('does not duplicate connections another host still owns', async () => {
+        // The cutover window: the platform list already routes wechat to node,
+        // the node gateway restarts and announces, and the default host has
+        // not been drained yet. Building here too would have both hosts
+        // polling the same bot until the next full reconcile.
+        mockFindEnabledByPlatform.mockImplementation(async (_db: unknown, platform: string) =>
+          platform === 'wechat'
+            ? [
+                {
+                  applicationId: 'wechat-app',
+                  credentials: { botToken: 'token' },
+                  id: 'wechat-provider',
+                  settings: {},
+                  userId: 'u1',
+                },
+              ]
+            : [],
+        );
+        mockResolveConnectionMode.mockReturnValue('polling');
+        // Still held by the host it is being migrated away from.
+        mockGatewayClient.getRegisteredIds.mockResolvedValue({ ids: ['wechat-provider'] });
+
+        await service.reconcileHost('node');
+
+        expect(mockNodeGatewayClient.connect).not.toHaveBeenCalled();
+        // And the out-of-scope host is left alone rather than drained here.
+        expect(mockGatewayClient.disconnect).not.toHaveBeenCalled();
+      });
+
+      it('does not drain a messenger poller from an out-of-scope host', async () => {
+        mockFindAllLinksByPlatform.mockResolvedValue([
+          {
+            applicationId: 'bot-1@im.bot',
+            credentials: { baseUrl: 'https://ilink.test', botId: 'bot-1', botToken: 'tok' },
+            tenantId: 'alice',
+            userId: 'user-1',
+          },
+        ]);
+        mockGatewayClient.getRegisteredIds.mockResolvedValue({
+          ids: ['messenger:wechat:alice:user-user-1'],
+        });
+
+        await service.reconcileHost('node');
+
+        expect(mockGatewayClient.disconnect).not.toHaveBeenCalled();
+        expect(mockNodeGatewayClient.connect).not.toHaveBeenCalled();
       });
 
       it('loads only the platforms the scoped host owns', async () => {

--- a/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
+++ b/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
@@ -1319,6 +1319,85 @@ describe('GatewayService', () => {
       expect(mockNodeGatewayClient.connect).not.toHaveBeenCalled();
     });
 
+    describe('reconcileHost (scoped restart recovery)', () => {
+      it('rebuilds the node host without touching the default gateway at all', async () => {
+        // The whole point of scoping: a node restart must not ensure-connect
+        // dormant connections on the default host to see if they are alive.
+        // On Cloudflare that wake is billable, and not paying for it is what
+        // this migration is for.
+        mockFindEnabledByPlatform.mockImplementation(async (_db: unknown, platform: string) =>
+          platform === 'wechat'
+            ? [
+                {
+                  applicationId: 'wechat-app',
+                  credentials: { botToken: 'token' },
+                  id: 'wechat-provider',
+                  settings: {},
+                  userId: 'u1',
+                },
+              ]
+            : [],
+        );
+        mockResolveConnectionMode.mockReturnValue('polling');
+        // Node came back empty — this is what a container restart looks like.
+        mockNodeGatewayClient.getRegisteredIds.mockResolvedValue({ ids: [] });
+
+        await service.reconcileHost('node');
+
+        expect(mockNodeGatewayClient.connect).toHaveBeenCalledWith(
+          expect.objectContaining({ connectionId: 'wechat-provider', platform: 'wechat' }),
+          { ensure: true },
+        );
+        // Not one request to the default host, of any kind.
+        expect(mockGatewayClient.getStats).not.toHaveBeenCalled();
+        expect(mockGatewayClient.getRegisteredIds).not.toHaveBeenCalled();
+        expect(mockGatewayClient.connect).not.toHaveBeenCalled();
+        expect(mockGatewayClient.disconnect).not.toHaveBeenCalled();
+      });
+
+      it('loads only the platforms the scoped host owns', async () => {
+        mockFindEnabledByPlatform.mockResolvedValue([]);
+
+        await service.reconcileHost('node');
+
+        // Loading a platform means decrypting its credentials and running a
+        // paid-feature check per provider — never do that for platforms this
+        // round cannot act on.
+        const platformsLoaded = mockFindEnabledByPlatform.mock.calls.map(
+          (call: unknown[]) => call[1] as string,
+        );
+        expect(platformsLoaded).toEqual(['wechat']);
+      });
+
+      it('does not reconcile a messenger platform owned by another host', async () => {
+        mockNodeGateway.platforms = [];
+        mockFindAllLinksByPlatform.mockResolvedValue([
+          {
+            applicationId: 'bot-1@im.bot',
+            credentials: { botToken: 'tok' },
+            tenantId: 'alice',
+            userId: 'user-1',
+          },
+        ]);
+
+        await service.reconcileHost('node');
+
+        // wechat now resolves to the default host, which is out of scope.
+        expect(mockGatewayClient.connect).not.toHaveBeenCalled();
+        expect(mockNodeGatewayClient.connect).not.toHaveBeenCalled();
+      });
+
+      it('stays out of the way when gateway mode is off', async () => {
+        mockGatewayClient.isEnabled = false;
+        mockGatewayEnv.MESSAGE_GATEWAY_ENABLED = undefined;
+
+        await service.reconcileHost('node');
+
+        expect(mockNodeGatewayClient.getStats).not.toHaveBeenCalled();
+        expect(mockNodeGatewayClient.connect).not.toHaveBeenCalled();
+      });
+    });
+
     it('routes per-user messenger registration to the node host', async () => {
       mockResolveMessengerInstallation.mockResolvedValue({
         applicationId: 'bot@im.wechat',

--- a/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
+++ b/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
@@ -1402,6 +1402,36 @@ describe('GatewayService', () => {
         expect(outcome.failed).toBe(1);
       });
 
+      it('reports failure when the messenger link lookup fails', async () => {
+        // The messenger pass runs after the connect phase and swallows this
+        // into a `continue`; if it did not reach the outcome, a restarting
+        // gateway would be told its fleet is back while every per-user poller
+        // stayed offline.
+        mockFindAllLinksByPlatform.mockRejectedValue(new Error('db unavailable'));
+
+        const outcome = await service.reconcileHost('node');
+
+        expect(outcome.ok).toBe(false);
+        expect(outcome.reason).toMatch(/link listing/i);
+      });
+
+      it('reports failure when a messenger poller could not be rebuilt', async () => {
+        mockFindAllLinksByPlatform.mockResolvedValue([
+          {
+            applicationId: 'bot-1@im.bot',
+            credentials: { baseUrl: 'https://ilink.test', botId: 'bot-1', botToken: 'tok' },
+            tenantId: 'alice',
+            userId: 'user-1',
+          },
+        ]);
+        mockNodeGatewayClient.connect.mockRejectedValue(new Error('gateway refused'));
+
+        const outcome = await service.reconcileHost('node');
+
+        expect(outcome.ok).toBe(false);
+        expect(outcome.reason).toMatch(/link\(s\) failed/i);
+      });
+
       it('reports success for a host that legitimately owns nothing', async () => {
         // The pre-cutover shape: node configured, no platform routed to it.
         // Nothing to rebuild is not a failure, and must not make the gateway

--- a/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
+++ b/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
@@ -1475,6 +1475,73 @@ describe('GatewayService', () => {
         expect(outcome.reason).toMatch(/not established/i);
       });
 
+      it('reports failure when the gateway answers with a terminal status', async () => {
+        // `connect` resolves for every outcome, including the ones that mean
+        // it did not work. A resolved `error` is not a rejected promise, so
+        // the rejected-connect tests never covered this.
+        mockFindEnabledByPlatform.mockImplementation(async (_db: unknown, platform: string) =>
+          platform === 'wechat'
+            ? [
+                {
+                  applicationId: 'wechat-app',
+                  credentials: { botToken: 'token' },
+                  id: 'wechat-provider',
+                  settings: {},
+                  userId: 'u1',
+                },
+              ]
+            : [],
+        );
+        mockResolveConnectionMode.mockReturnValue('polling');
+        mockNodeGatewayClient.connect.mockResolvedValue({ status: 'error' });
+
+        const outcome = await service.reconcileHost('node');
+
+        expect(outcome.ok).toBe(false);
+        expect(outcome.reason).toMatch(/not established/i);
+      });
+
+      it('accepts connecting and dormant as established', async () => {
+        // Both mean the connection exists: one is completing asynchronously,
+        // the other is registered and wakes on its own.
+        mockFindEnabledByPlatform.mockImplementation(async (_db: unknown, platform: string) =>
+          platform === 'wechat'
+            ? [
+                {
+                  applicationId: 'wechat-app',
+                  credentials: { botToken: 'token' },
+                  id: 'wechat-provider',
+                  settings: {},
+                  userId: 'u1',
+                },
+              ]
+            : [],
+        );
+        mockResolveConnectionMode.mockReturnValue('polling');
+
+        for (const status of ['connecting', 'dormant'] as const) {
+          mockNodeGatewayClient.connect.mockResolvedValue({ status });
+          const outcome = await service.reconcileHost('node');
+          expect(outcome.ok, `status=${status}`).toBe(true);
+        }
+      });
+
+      it('reports failure when a messenger poller answers with a terminal status', async () => {
+        mockFindAllLinksByPlatform.mockResolvedValue([
+          {
+            applicationId: 'bot-1@im.bot',
+            credentials: { baseUrl: 'https://ilink.test', botId: 'bot-1', botToken: 'tok' },
+            tenantId: 'alice',
+            userId: 'user-1',
+          },
+        ]);
+        mockNodeGatewayClient.connect.mockResolvedValue({ status: 'disconnected' });
+
+        const outcome = await service.reconcileHost('node');
+
+        expect(outcome.ok).toBe(false);
+      });
+
       it('reports success for a host that legitimately owns nothing', async () => {
         // The pre-cutover shape: node configured, no platform routed to it.
         // Nothing to rebuild is not a failure, and must not make the gateway

--- a/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
+++ b/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
@@ -1542,6 +1542,47 @@ describe('GatewayService', () => {
         expect(outcome.ok).toBe(false);
       });
 
+      it('counts an existing connection in error state as present, not as work to redo', async () => {
+        // The connection exists — the gateway is holding it — and the usual
+        // cause is a credential its owner has to renew. Rebuilding it would
+        // recreate a doomed connection every round, and on a gateway that
+        // parks these the ensure-connect answers 409, which reads as failure.
+        // Restart recovery answers "are the connections back", not "is every
+        // remote side healthy".
+        mockFindEnabledByPlatform.mockImplementation(async (_db: unknown, platform: string) =>
+          platform === 'wechat'
+            ? [
+                {
+                  applicationId: 'wechat-app',
+                  credentials: { botToken: 'token' },
+                  id: 'wechat-provider',
+                  settings: {},
+                  userId: 'u1',
+                },
+              ]
+            : [],
+        );
+        mockResolveConnectionMode.mockReturnValue('polling');
+        mockNodeGatewayClient.getStats.mockResolvedValue({
+          byPlatform: { wechat: 1 },
+          connections: [
+            {
+              connectionId: 'wechat-provider',
+              platform: 'wechat',
+              state: { status: 'error' },
+              userId: 'u1',
+            },
+          ],
+          total: 1,
+        });
+        mockNodeGatewayClient.getRegisteredIds.mockResolvedValue({ ids: ['wechat-provider'] });
+
+        const outcome = await service.reconcileHost('node');
+
+        expect(mockNodeGatewayClient.connect).not.toHaveBeenCalled();
+        expect(outcome.ok).toBe(true);
+      });
+
       it('reports success for a host that legitimately owns nothing', async () => {
         // The pre-cutover shape: node configured, no platform routed to it.
         // Nothing to rebuild is not a failure, and must not make the gateway

--- a/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
+++ b/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
@@ -1429,7 +1429,50 @@ describe('GatewayService', () => {
         const outcome = await service.reconcileHost('node');
 
         expect(outcome.ok).toBe(false);
-        expect(outcome.reason).toMatch(/link\(s\) failed/i);
+        expect(outcome.reason).toMatch(/not established/i);
+      });
+
+      it('reports failure when a provider cannot be connected for lack of credentials', async () => {
+        // A key-vault failure decrypts to nothing. The provider stays desired
+        // (so the stale pass leaves it alone) and the connect is skipped —
+        // but skipped is not rebuilt, and a gateway told otherwise stops
+        // retrying with that connection still missing.
+        mockFindEnabledByPlatform.mockImplementation(async (_db: unknown, platform: string) =>
+          platform === 'wechat'
+            ? [
+                {
+                  applicationId: 'wechat-app',
+                  credentials: {},
+                  id: 'wechat-provider',
+                  settings: {},
+                  userId: 'u1',
+                },
+              ]
+            : [],
+        );
+        mockResolveConnectionMode.mockReturnValue('polling');
+
+        const outcome = await service.reconcileHost('node');
+
+        expect(mockNodeGatewayClient.connect).not.toHaveBeenCalled();
+        expect(outcome.ok).toBe(false);
+        expect(outcome.reason).toMatch(/not established/i);
+      });
+
+      it('reports failure when a messenger link has no usable credentials', async () => {
+        mockFindAllLinksByPlatform.mockResolvedValue([
+          {
+            applicationId: 'bot-1@im.bot',
+            credentials: {},
+            tenantId: 'alice',
+            userId: 'user-1',
+          },
+        ]);
+
+        const outcome = await service.reconcileHost('node');
+
+        expect(outcome.ok).toBe(false);
+        expect(outcome.reason).toMatch(/not established/i);
       });
 
       it('reports success for a host that legitimately owns nothing', async () => {

--- a/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
+++ b/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
@@ -1323,8 +1323,8 @@ describe('GatewayService', () => {
       it('rebuilds the node host without touching the default gateway at all', async () => {
         // The whole point of scoping: a node restart must not ensure-connect
         // dormant connections on the default host to see if they are alive.
-        // On Cloudflare that wake is billable, and not paying for it is what
-        // this migration is for.
+        // Waking a connection that was deliberately asleep spends the other
+        // host's resources to answer a question about this one.
         mockFindEnabledByPlatform.mockImplementation(async (_db: unknown, platform: string) =>
           platform === 'wechat'
             ? [

--- a/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
+++ b/apps/server/src/services/gateway/__tests__/GatewayService.test.ts
@@ -1355,6 +1355,65 @@ describe('GatewayService', () => {
         expect(mockGatewayClient.disconnect).not.toHaveBeenCalled();
       });
 
+      it('reports failure when the host admin surface is unreachable', async () => {
+        // The sync absorbs this into a null snapshot and resolves normally —
+        // which is right for the periodic reconcile and wrong for a caller
+        // waiting to hear its fleet is back.
+        mockNodeGatewayClient.getStats.mockRejectedValue(new Error('stats down'));
+        mockNodeGatewayClient.getRegisteredIds.mockRejectedValue(new Error('registry down'));
+
+        const outcome = await service.reconcileHost('node');
+
+        expect(outcome.ok).toBe(false);
+        expect(outcome.reason).toMatch(/snapshot/i);
+      });
+
+      it('reports failure when the registry snapshot is only partial', async () => {
+        // Stats answered but registered-ids did not: absence from the map no
+        // longer proves absence, so missing connections are deferred rather
+        // than rebuilt. Claiming success here would strand them.
+        mockNodeGatewayClient.getRegisteredIds.mockRejectedValue(new Error('registry down'));
+
+        const outcome = await service.reconcileHost('node');
+
+        expect(outcome.ok).toBe(false);
+      });
+
+      it('reports failure when a connection could not be rebuilt', async () => {
+        mockFindEnabledByPlatform.mockImplementation(async (_db: unknown, platform: string) =>
+          platform === 'wechat'
+            ? [
+                {
+                  applicationId: 'wechat-app',
+                  credentials: { botToken: 'token' },
+                  id: 'wechat-provider',
+                  settings: {},
+                  userId: 'u1',
+                },
+              ]
+            : [],
+        );
+        mockResolveConnectionMode.mockReturnValue('polling');
+        mockNodeGatewayClient.connect.mockRejectedValue(new Error('gateway refused'));
+
+        const outcome = await service.reconcileHost('node');
+
+        expect(outcome.ok).toBe(false);
+        expect(outcome.failed).toBe(1);
+      });
+
+      it('reports success for a host that legitimately owns nothing', async () => {
+        // The pre-cutover shape: node configured, no platform routed to it.
+        // Nothing to rebuild is not a failure, and must not make the gateway
+        // retry forever.
+        mockNodeGateway.platforms = [];
+
+        const outcome = await service.reconcileHost('node');
+
+        expect(outcome.ok).toBe(true);
+        expect(outcome.connected).toBe(0);
+      });
+
       it('loads only the platforms the scoped host owns', async () => {
         mockFindEnabledByPlatform.mockResolvedValue([]);
 

--- a/apps/server/src/services/gateway/index.ts
+++ b/apps/server/src/services/gateway/index.ts
@@ -224,9 +224,10 @@ export class GatewayService {
    * fleet back in seconds instead of hours.
    *
    * Scoped on purpose: a full round would ensure-connect dormant connections
-   * on the OTHER hosts to check whether they are still alive, and on the
-   * default host waking a dormant connection is billable. Restart recovery
-   * must not cost anything on a host that never restarted.
+   * on the OTHER hosts to check whether they are still alive, and waking a
+   * connection that was deliberately asleep consumes resources on a host that
+   * had nothing to recover from. One gateway restarting should not disturb
+   * another.
    */
   async reconcileHost(host: MessageGatewayHost): Promise<HostReconcileOutcome> {
     if (!this.useMessageGateway) {
@@ -309,9 +310,9 @@ export class GatewayService {
     // in which a cross-host move can complete, since it needs both the source
     // drain and the destination connect. A scoped round is for the case where
     // one host is known to have lost its connections (a restart) and the
-    // others must not be touched: visiting them would wake dormant
-    // connections that were deliberately asleep, which on the default host is
-    // billable and is exactly what this migration exists to stop paying for.
+    // others must not be touched: visiting them would wake connections that
+    // were deliberately asleep, spending their resources to answer a question
+    // about a host that did not restart.
     const hosts = getConfiguredMessageGatewayHosts().filter(
       (host) => !scope || scope.includes(host),
     );

--- a/apps/server/src/services/gateway/index.ts
+++ b/apps/server/src/services/gateway/index.ts
@@ -324,9 +324,8 @@ export class GatewayService {
     // others must not be touched: visiting them would wake connections that
     // were deliberately asleep, spending their resources to answer a question
     // about a host that did not restart.
-    const hosts = getConfiguredMessageGatewayHosts().filter(
-      (host) => !scope || scope.includes(host),
-    );
+    const configured = getConfiguredMessageGatewayHosts();
+    const hosts = configured.filter((host) => !scope || scope.includes(host));
     if (hosts.length === 0) {
       log('Gateway sync: no configured host matches scope %o, nothing to do', scope);
       return outcomes;
@@ -337,8 +336,16 @@ export class GatewayService {
       gateKeeper,
       hosts,
     );
+
+    // Snapshots come from EVERY configured host, even the ones a scoped round
+    // will not act on. Reading a host's admin surface is two requests to it
+    // and wakes nothing — the waking happens in the connect pass, which is
+    // what stays scoped. Reading only the scoped host would blind this round
+    // to connections another host still owns, and it would then build its own
+    // copies alongside them: during a platform migration that is duplicate
+    // delivery, lasting until the next full reconcile.
     const snapshots = new Map<MessageGatewayHost, ActualConnectionsSnapshot | null>();
-    for (const host of hosts) {
+    for (const host of configured) {
       snapshots.set(host, await this.fetchActualConnections(getMessageGatewayClientForHost(host)));
     }
 
@@ -348,7 +355,7 @@ export class GatewayService {
     // so disconnecting there first would take the platform dark until some
     // later round. Only hosts with a complete snapshot are safe destinations.
     const hostsReadyToReceive = new Set(
-      hosts.filter((host) => snapshots.get(host)?.complete === true),
+      configured.filter((host) => snapshots.get(host)?.complete === true),
     );
 
     // Ids a snapshot shows on a host that no longer owns them — i.e. mid-move.
@@ -432,6 +439,7 @@ export class GatewayService {
       gateKeeper,
       snapshots,
       hostsReadyToReceive,
+      new Set(hosts),
     );
     for (const [host, reason] of messengerProblems) {
       const outcome = outcomes.get(host);
@@ -728,6 +736,7 @@ export class GatewayService {
     gateKeeper: KeyVaultsGateKeeper,
     snapshots: Map<MessageGatewayHost, ActualConnectionsSnapshot | null>,
     hostsReadyToReceive: Set<MessageGatewayHost>,
+    actedOn: Set<MessageGatewayHost>,
   ): Promise<Map<MessageGatewayHost, string>> {
     /** host → why its messenger pass could not finish. */
     const problems = new Map<MessageGatewayHost, string>();
@@ -735,10 +744,9 @@ export class GatewayService {
       if (definition.connectionMode !== 'polling') continue;
       const platform = definition.id;
       const host = resolveMessageGatewayHost(platform);
-      // Out of scope this round — `snapshots` only holds the hosts being
-      // visited, so a platform owned elsewhere has nothing to reconcile
-      // against and must not be touched.
-      if (!snapshots.has(host)) continue;
+      // Out of scope this round: another host owns this platform, so it is
+      // not this round's job to reconcile it.
+      if (!actedOn.has(host)) continue;
       const client = getMessageGatewayClientForHost(host);
       if (!client.isEnabled) continue;
 
@@ -833,6 +841,22 @@ export class GatewayService {
           log(
             'Gateway sync[%s]: %s host has no usable snapshot — leaving %d %s connection(s) on %s host',
             host,
+            host,
+            strayIds.length,
+            platform,
+            otherHost,
+          );
+          continue;
+        }
+
+        // Draining a host this round was told not to act on would be a
+        // mutation outside its scope. Leaving those ids marked is enough: the
+        // connect pass skips them, so nothing is duplicated, and they keep
+        // working where they are until a full round moves them properly.
+        if (!actedOn.has(otherHost)) {
+          strayIds.forEach((id) => stillElsewhere.add(id));
+          log(
+            'Gateway sync[%s]: %d %s connection(s) still on the out-of-scope %s host, deferring',
             host,
             strayIds.length,
             platform,

--- a/apps/server/src/services/gateway/index.ts
+++ b/apps/server/src/services/gateway/index.ts
@@ -125,6 +125,24 @@ interface ActualConnectionsSnapshot {
   connections: Map<string, string | null>;
 }
 
+/**
+ * Whether a scoped round actually did its job.
+ *
+ * The sync is built to survive partial failure: an unreachable admin surface
+ * becomes a null snapshot, a platform that will not load only clears
+ * `desiredComplete`, a connection that will not build is counted and skipped.
+ * That is right for a periodic reconcile, which simply tries again later —
+ * but a caller waiting to be told its fleet is back needs to know the
+ * difference between "nothing to do" and "nothing worked".
+ */
+export interface HostReconcileOutcome {
+  connected: number;
+  failed: number;
+  /** False when anything stopped this round from being authoritative. */
+  ok: boolean;
+  reason?: string;
+}
+
 /** What one host's drain phase removed, carried into its connect-phase log line. */
 interface HostDrainCounts {
   gatedDisconnected: number;
@@ -196,12 +214,18 @@ export class GatewayService {
    * default host waking a dormant connection is billable. Restart recovery
    * must not cost anything on a host that never restarted.
    */
-  async reconcileHost(host: MessageGatewayHost): Promise<void> {
+  async reconcileHost(host: MessageGatewayHost): Promise<HostReconcileOutcome> {
     if (!this.useMessageGateway) {
       log('reconcileHost(%s): gateway mode off, ignoring', host);
-      return;
+      return { connected: 0, failed: 0, ok: true, reason: 'gateway mode off' };
     }
-    await this.syncGatewayConnections([host]);
+
+    const outcomes = await this.syncGatewayConnections([host]);
+    // A host that produced no outcome was filtered out of the round — it is
+    // not configured, so there is nothing to rebuild and nothing went wrong.
+    return (
+      outcomes.get(host) ?? { connected: 0, failed: 0, ok: true, reason: 'host not configured' }
+    );
   }
 
   async ensureRunning(): Promise<void> {
@@ -252,7 +276,10 @@ export class GatewayService {
    *
    * Called from the gateway cron; also recovers connections after restarts.
    */
-  private async syncGatewayConnections(scope?: MessageGatewayHost[]): Promise<void> {
+  private async syncGatewayConnections(
+    scope?: MessageGatewayHost[],
+  ): Promise<Map<MessageGatewayHost, HostReconcileOutcome>> {
+    const outcomes = new Map<MessageGatewayHost, HostReconcileOutcome>();
     const startedAt = Date.now();
     const serverDB = await getServerDB();
     const gateKeeper = await KeyVaultsGateKeeper.initWithEnvKey();
@@ -276,7 +303,7 @@ export class GatewayService {
     );
     if (hosts.length === 0) {
       log('Gateway sync: no configured host matches scope %o, nothing to do', scope);
-      return;
+      return outcomes;
     }
 
     const { desired, desiredComplete, gated } = await this.buildDesiredConnections(
@@ -340,14 +367,30 @@ export class GatewayService {
     }
 
     for (const host of hosts) {
-      await this.connectHostConnections({
+      const snapshot = snapshots.get(host) ?? null;
+      const { connected, failed } = await this.connectHostConnections({
         counts: drainCounts.get(host) ?? { gatedDisconnected: 0, gatedSize: 0, stale: 0 },
         currentlyElsewhere,
         desired,
         drainedThisRound,
         host,
-        snapshot: snapshots.get(host) ?? null,
+        snapshot,
       });
+
+      // Everything that makes this round non-authoritative. The periodic
+      // reconcile shrugs these off and retries later; a caller waiting on a
+      // rebuild must not be told the fleet is back when it is not.
+      const reason = !snapshot
+        ? 'admin snapshot unavailable'
+        : !snapshot.complete
+          ? 'registry snapshot incomplete'
+          : !desiredComplete
+            ? 'desired set incomplete'
+            : failed > 0
+              ? `${failed} connection(s) failed`
+              : undefined;
+
+      outcomes.set(host, { connected, failed, ok: !reason, reason });
     }
 
     await this.syncMessengerPollingConnections(
@@ -364,6 +407,8 @@ export class GatewayService {
       desired.size,
       gated.size,
     );
+
+    return outcomes;
   }
 
   /** Slice of the desired set whose platforms route to `host`. */
@@ -448,7 +493,7 @@ export class GatewayService {
     drainedThisRound: Set<string>;
     host: MessageGatewayHost;
     snapshot: ActualConnectionsSnapshot | null;
-  }): Promise<void> {
+  }): Promise<{ connected: number; failed: number }> {
     const { counts, currentlyElsewhere, drainedThisRound, host, snapshot: actual } = params;
     const client = getMessageGatewayClientForHost(host);
     const desired = this.hostDesiredSlice(params.desired, host);
@@ -600,6 +645,8 @@ export class GatewayService {
       registeredOnlyWakes,
       registeredOnlyDeferred,
     );
+
+    return { connected, failed };
   }
 
   /**

--- a/apps/server/src/services/gateway/index.ts
+++ b/apps/server/src/services/gateway/index.ts
@@ -592,7 +592,17 @@ export class GatewayService {
 
           // Registered ids are the gateway's authoritative existence set. Use
           // the status already present in live stats to recover an explicitly
-          // disconnected connection. Registered-only ids (status null — pruned
+          // disconnected connection.
+          //
+          // `error` deliberately counts as present rather than as something to
+          // rebuild. A connection in that state exists — the gateway is
+          // holding it — and the usual cause is a credential the owner has to
+          // renew, which no amount of reconnecting fixes. Rebuilding it would
+          // recreate a doomed connection on every round, and on a gateway that
+          // parks such connections the ensure-connect answers 409, which
+          // surfaces as a failure. So restart recovery reports success once the
+          // connections are back, not once every remote side is healthy: those
+          // are different questions, and only the first one is ours. Registered-only ids (status null — pruned
           // from stats) get a capped ensure-connect wake instead of a skip:
           // see GATEWAY_SYNC_REGISTERED_ONLY_WAKE_LIMIT. Never probe per-DO
           // status here.
@@ -893,6 +903,9 @@ export class GatewayService {
           // Live and healthy → nothing to do. Registered-only (null) gets an
           // ensure-connect wake (parked connections answer 409 and keep their
           // park); missing from a complete snapshot gets a real connect.
+          // `error` counts as present for the same reason as the bot-provider
+          // pass above: the poller exists, and an expired session is the
+          // owner's to renew.
           if (exists && status !== null && status !== 'disconnected') {
             skipped++;
             return;

--- a/apps/server/src/services/gateway/index.ts
+++ b/apps/server/src/services/gateway/index.ts
@@ -368,7 +368,7 @@ export class GatewayService {
 
     for (const host of hosts) {
       const snapshot = snapshots.get(host) ?? null;
-      const { connected, failed } = await this.connectHostConnections({
+      const { connected, failed, unestablished } = await this.connectHostConnections({
         counts: drainCounts.get(host) ?? { gatedDisconnected: 0, gatedSize: 0, stale: 0 },
         currentlyElsewhere,
         desired,
@@ -377,17 +377,21 @@ export class GatewayService {
         snapshot,
       });
 
-      // Everything that makes this round non-authoritative. The periodic
-      // reconcile shrugs these off and retries later; a caller waiting on a
-      // rebuild must not be told the fleet is back when it is not.
+      // Success is defined positively — every connection this host is
+      // supposed to hold now exists — rather than as a list of known failure
+      // modes. A blacklist has to be extended every time a new way of not
+      // connecting is added (a rejected connect, missing credentials, a
+      // platform that would not load), and each omission silently reports a
+      // rebuild that did not happen. `unestablished` counts desired entries
+      // this round could not turn into a connection, whatever the reason.
       const reason = !snapshot
         ? 'admin snapshot unavailable'
         : !snapshot.complete
           ? 'registry snapshot incomplete'
           : !desiredComplete
             ? 'desired set incomplete'
-            : failed > 0
-              ? `${failed} connection(s) failed`
+            : unestablished > 0
+              ? `${unestablished} connection(s) not established`
               : undefined;
 
       outcomes.set(host, { connected, failed, ok: !reason, reason });
@@ -501,7 +505,7 @@ export class GatewayService {
     drainedThisRound: Set<string>;
     host: MessageGatewayHost;
     snapshot: ActualConnectionsSnapshot | null;
-  }): Promise<{ connected: number; failed: number }> {
+  }): Promise<{ connected: number; failed: number; unestablished: number }> {
     const { counts, currentlyElsewhere, drainedThisRound, host, snapshot: actual } = params;
     const client = getMessageGatewayClientForHost(host);
     const desired = this.hostDesiredSlice(params.desired, host);
@@ -510,6 +514,8 @@ export class GatewayService {
     let deferred = 0;
     let skipped = 0;
     let failed = 0;
+    /** Desired here, but nothing this round could turn into a connection. */
+    let unconnectable = 0;
 
     // Registered-only wake candidates are SAMPLED, not taken head-first: the
     // desired map iterates in a stable order, and parked connections (409,
@@ -538,6 +544,7 @@ export class GatewayService {
           // fail — leave whatever connection state the gateway already holds.
           if (Object.keys(provider.credentials).length === 0) {
             skipped++;
+            unconnectable++;
             log('Gateway sync: %s credentials unavailable, skipping connect', provider.id);
             return;
           }
@@ -654,7 +661,7 @@ export class GatewayService {
       registeredOnlyDeferred,
     );
 
-    return { connected, failed };
+    return { connected, failed, unestablished: failed + unconnectable };
   }
 
   /**
@@ -931,7 +938,13 @@ export class GatewayService {
         failed,
       );
 
-      if (failed > 0) problems.set(host, `${failed} ${platform} link(s) failed`);
+      // Same positive definition as the bot-provider pass: a link that is
+      // desired but has no usable credentials was not rebuilt either, and a
+      // key-vault failure lands every link here rather than in `failed`.
+      const unestablished = failed + unusable.size;
+      if (unestablished > 0) {
+        problems.set(host, `${unestablished} ${platform} link(s) not established`);
+      }
     }
 
     return problems;

--- a/apps/server/src/services/gateway/index.ts
+++ b/apps/server/src/services/gateway/index.ts
@@ -172,6 +172,20 @@ function mapGatewayStatusToRuntimeStatus(
   }
 }
 
+/**
+ * Whether a `connect` response means the connection now exists.
+ *
+ * `connect` resolves for every outcome, including the two that mean it did
+ * not work — a gateway that answers `error` or `disconnected` has told us the
+ * connection is not there. Counting those as established is how a rebuild
+ * reports success while leaving connections offline.
+ *
+ * `connecting` and `dormant` do count: the first completes asynchronously,
+ * the second is a registered connection that wakes on its own.
+ */
+const isEstablished = (status: MessageGatewayConnectionStatus['state']['status']): boolean =>
+  status !== 'error' && status !== 'disconnected';
+
 const log = debug('lobe-server:service:gateway');
 
 /**
@@ -634,7 +648,11 @@ export class GatewayService {
             status: mapGatewayStatusToRuntimeStatus(result.status),
           });
 
-          connected++;
+          if (isEstablished(result.status)) {
+            connected++;
+          } else {
+            unconnectable++;
+          }
           log('Gateway sync: %s %s:%s', result.status, platform, provider.applicationId);
         } catch (err) {
           failed++;
@@ -877,7 +895,7 @@ export class GatewayService {
               botId?: string;
               botToken?: string;
             };
-            await client.connect(
+            const result = await client.connect(
               {
                 applicationId: link.applicationId!,
                 capabilities: { messageMonitoring: { enabled: false } },
@@ -895,7 +913,19 @@ export class GatewayService {
               },
               { ensure: true },
             );
-            connected++;
+            // Same rule as the bot-provider pass: the gateway answering
+            // `error` or `disconnected` means this poller is not running.
+            if (isEstablished(result.status)) {
+              connected++;
+            } else {
+              failed++;
+              log(
+                'Gateway sync[%s]: messenger %s reported %s, not established',
+                host,
+                connectionId,
+                result.status,
+              );
+            }
           } catch (err) {
             failed++;
             log('Gateway sync[%s]: messenger connect failed %s: %O', host, connectionId, err);

--- a/apps/server/src/services/gateway/index.ts
+++ b/apps/server/src/services/gateway/index.ts
@@ -230,17 +230,28 @@ export class GatewayService {
    * another.
    */
   async reconcileHost(host: MessageGatewayHost): Promise<HostReconcileOutcome> {
+    // Reachable only with the gateway feature switched on — the caller
+    // answers a disabled deployment before getting here — so this means the
+    // configuration has not arrived yet, not that there is nothing to do.
+    // Deployments are not atomic: a gateway can come up and announce before
+    // the URL that routes to it reaches this side. Saying "fine" would end
+    // the announcement for good and leave that gateway empty until the
+    // periodic reconcile, so it has to read as retryable.
     if (!this.useMessageGateway) {
-      log('reconcileHost(%s): gateway mode off, ignoring', host);
-      return { connected: 0, failed: 0, ok: true, reason: 'gateway mode off' };
+      log('reconcileHost(%s): no gateway host configured yet', host);
+      return { connected: 0, failed: 0, ok: false, reason: 'gateway not configured yet' };
     }
 
     const outcomes = await this.syncGatewayConnections([host]);
-    // A host that produced no outcome was filtered out of the round — it is
-    // not configured, so there is nothing to rebuild and nothing went wrong.
-    return (
-      outcomes.get(host) ?? { connected: 0, failed: 0, ok: true, reason: 'host not configured' }
-    );
+    // No outcome means this host was filtered out of the round: it is not in
+    // the configured set, which for a host that just announced itself is the
+    // same not-yet-configured race as above.
+    const outcome = outcomes.get(host);
+    if (!outcome) {
+      log('reconcileHost(%s): host is not configured on this side', host);
+      return { connected: 0, failed: 0, ok: false, reason: 'host not configured yet' };
+    }
+    return outcome;
   }
 
   async ensureRunning(): Promise<void> {

--- a/apps/server/src/services/gateway/index.ts
+++ b/apps/server/src/services/gateway/index.ts
@@ -182,6 +182,28 @@ export class GatewayService {
     return isAnyMessageGatewayEnabled();
   }
 
+  /**
+   * Rebuild one host's connections, leaving every other host untouched.
+   *
+   * For a gateway that just lost its connections — a container restart wipes
+   * an in-process registry, unlike a Durable Object, which resurrects itself
+   * from its own storage. The periodic reconcile would fix it too, but only
+   * on its next round, so a gateway that announces its own restart gets its
+   * fleet back in seconds instead of hours.
+   *
+   * Scoped on purpose: a full round would ensure-connect dormant connections
+   * on the OTHER hosts to check whether they are still alive, and on the
+   * default host waking a dormant connection is billable. Restart recovery
+   * must not cost anything on a host that never restarted.
+   */
+  async reconcileHost(host: MessageGatewayHost): Promise<void> {
+    if (!this.useMessageGateway) {
+      log('reconcileHost(%s): gateway mode off, ignoring', host);
+      return;
+    }
+    await this.syncGatewayConnections([host]);
+  }
+
   async ensureRunning(): Promise<void> {
     if (this.useMessageGateway) {
       await this.syncGatewayConnections();
@@ -230,22 +252,38 @@ export class GatewayService {
    *
    * Called from the gateway cron; also recovers connections after restarts.
    */
-  private async syncGatewayConnections(): Promise<void> {
+  private async syncGatewayConnections(scope?: MessageGatewayHost[]): Promise<void> {
     const startedAt = Date.now();
     const serverDB = await getServerDB();
     const gateKeeper = await KeyVaultsGateKeeper.initWithEnvKey();
-
-    const { desired, desiredComplete, gated } = await this.buildDesiredConnections(
-      serverDB,
-      gateKeeper,
-    );
 
     // Each configured host gets its own desired slice and its own actual
     // snapshot, then runs the full diff independently. Cross-host moves fall
     // out of the partition: a platform routed away from a host leaves its ids
     // absent from that host's desired slice → the stale pass disconnects them
     // there while the new host's connect pass builds them up.
-    const hosts = getConfiguredMessageGatewayHosts();
+    //
+    // `scope` narrows the round to specific hosts. The periodic reconcile
+    // passes nothing and visits every configured host — that is the only mode
+    // in which a cross-host move can complete, since it needs both the source
+    // drain and the destination connect. A scoped round is for the case where
+    // one host is known to have lost its connections (a restart) and the
+    // others must not be touched: visiting them would wake dormant
+    // connections that were deliberately asleep, which on the default host is
+    // billable and is exactly what this migration exists to stop paying for.
+    const hosts = getConfiguredMessageGatewayHosts().filter(
+      (host) => !scope || scope.includes(host),
+    );
+    if (hosts.length === 0) {
+      log('Gateway sync: no configured host matches scope %o, nothing to do', scope);
+      return;
+    }
+
+    const { desired, desiredComplete, gated } = await this.buildDesiredConnections(
+      serverDB,
+      gateKeeper,
+      hosts,
+    );
     const snapshots = new Map<MessageGatewayHost, ActualConnectionsSnapshot | null>();
     for (const host of hosts) {
       snapshots.set(host, await this.fetchActualConnections(getMessageGatewayClientForHost(host)));
@@ -593,6 +631,10 @@ export class GatewayService {
       if (definition.connectionMode !== 'polling') continue;
       const platform = definition.id;
       const host = resolveMessageGatewayHost(platform);
+      // Out of scope this round — `snapshots` only holds the hosts being
+      // visited, so a platform owned elsewhere has nothing to reconcile
+      // against and must not be touched.
+      if (!snapshots.has(host)) continue;
       const client = getMessageGatewayClientForHost(host);
       if (!client.isEnabled) continue;
 
@@ -845,6 +887,7 @@ export class GatewayService {
   private async buildDesiredConnections(
     serverDB: Awaited<ReturnType<typeof getServerDB>>,
     gateKeeper: KeyVaultsGateKeeper,
+    hosts: MessageGatewayHost[],
   ): Promise<{
     desired: Map<string, DesiredGatewayConnection>;
     desiredComplete: boolean;
@@ -855,7 +898,15 @@ export class GatewayService {
     let desiredComplete = true;
     const gated = new Map<string, string>();
 
-    for (const definition of platformRegistry.listPlatforms()) {
+    // Only platforms owned by a host in scope. Loading the rest would decrypt
+    // credentials and run a paid-feature check per provider for connections
+    // this round will not look at — pure waste on a scoped round, which by
+    // construction is the common one (every gateway restart triggers it).
+    const platforms = platformRegistry
+      .listPlatforms()
+      .filter((definition) => hosts.includes(resolveMessageGatewayHost(definition.id)));
+
+    for (const definition of platforms) {
       const platform = definition.id;
       try {
         // includeUndecryptable: rows whose credentials can't be decrypted stay

--- a/apps/server/src/services/gateway/index.ts
+++ b/apps/server/src/services/gateway/index.ts
@@ -393,12 +393,20 @@ export class GatewayService {
       outcomes.set(host, { connected, failed, ok: !reason, reason });
     }
 
-    await this.syncMessengerPollingConnections(
+    // Runs after the connect phase, so its problems have to be folded back
+    // into the outcomes rather than reported alongside them — a per-user
+    // poller left offline is exactly the state a restarting gateway is
+    // waiting to hear about.
+    const messengerProblems = await this.syncMessengerPollingConnections(
       serverDB,
       gateKeeper,
       snapshots,
       hostsReadyToReceive,
     );
+    for (const [host, reason] of messengerProblems) {
+      const outcome = outcomes.get(host);
+      if (outcome?.ok) outcomes.set(host, { ...outcome, ok: false, reason });
+    }
 
     log(
       'Gateway sync complete in %dms across %d host(s): desired=%d gated=%d',
@@ -673,7 +681,9 @@ export class GatewayService {
     gateKeeper: KeyVaultsGateKeeper,
     snapshots: Map<MessageGatewayHost, ActualConnectionsSnapshot | null>,
     hostsReadyToReceive: Set<MessageGatewayHost>,
-  ): Promise<void> {
+  ): Promise<Map<MessageGatewayHost, string>> {
+    /** host → why its messenger pass could not finish. */
+    const problems = new Map<MessageGatewayHost, string>();
     for (const definition of messengerPlatformRegistry.listPlatforms()) {
       if (definition.connectionMode !== 'polling') continue;
       const platform = definition.id;
@@ -700,6 +710,7 @@ export class GatewayService {
         );
       } catch (err) {
         log('Gateway sync[%s]: messenger link listing failed for %s: %O', host, platform, err);
+        problems.set(host, `${platform} link listing failed`);
         continue;
       }
 
@@ -919,7 +930,11 @@ export class GatewayService {
         stale,
         failed,
       );
+
+      if (failed > 0) problems.set(host, `${failed} ${platform} link(s) failed`);
     }
+
+    return problems;
   }
 
   /**


### PR DESCRIPTION
A message gateway that keeps its registry in process memory comes up holding nothing after any restart — a deploy, a crash, an OOM, the platform relocating the container. A Durable Object resurrects itself from its own storage; a container cannot. Until now those connections stayed down until the periodic reconcile came around, which on a six-hour cron means hours of silence for every connection that gateway owned.

`POST /api/agent/gateway/announce` lets a gateway say it restarted and get its fleet back in seconds. It is authenticated with `MESSAGE_GATEWAY_SERVICE_TOKEN` — the same shared token the gateways already use for state callbacks — so no new secret is distributed, and it uses the inline-auth shape of the callback handler so a disabled gateway short-circuits to 204 before the auth check.

### The scoping is the substance

The reconcile the announcement triggers visits **only the announcing host**. That is not an optimisation; an unscoped version would have been actively harmful:

`connectHostConnections` ensure-connects registered-only connections to find out whether they are still alive — and registered-only on the default host means a hibernating Durable Object, where that wake is billable (the code already says as much: "The `ensure` connect is that wake"). An unscoped round would therefore have made every restart of one gateway wake up to `GATEWAY_SYNC_REGISTERED_ONLY_WAKE_LIMIT` dormant objects on the other and bill for it — the exact cost these connections are being moved to avoid.

So:

- `syncGatewayConnections(scope?)` filters the hosts it visits. The periodic reconcile passes nothing and behaves exactly as before — and that remains the only mode in which a cross-host move can complete, since a move needs both the source drain and the destination connect.
- `buildDesiredConnections` now receives the hosts in play and loads only the platforms they own. A WeChat-only recovery previously decrypted credentials and ran a paid-feature check for every Telegram, Discord and Slack provider it would never look at.
- The messenger reconcile skips platforms owned by a host outside the round.

### Key decisions

- **Debounced per host via Redis** so a crash-looping gateway cannot turn its own loop into a reconcile loop. Best-effort: without Redis the rebuild still happens and only the cap is lost, because a restart getting its connections back matters more than the cap.
- **Responds before reconciling.** The caller is a gateway finishing its own boot; holding it open for a fleet rebuild would be backwards.
- **Not solved by letting the gateway persist its own registry**, which would also work and is closer to how the Durable Object does it. That would stop the database being the single source of truth: a bot disabled while the gateway was down would come back to life there. That is precisely the zombie class the Cloudflare gateway needs a cleanup pass for, and which a container gateway advertises it does not have (`dormantRegistry: false`, `zombieCleanup: false`) — admin tooling adapts to those flags today.
- **Non-goal**: nothing here changes what the periodic reconcile does, and the announcement cannot move a platform between hosts — a scoped round has only one side of a move.

#### Test

- [x] Tested locally
- [x] Added/updated tests

`bun run check`: lint clean, 57 tests passing. The four new ones cover what scoping has to guarantee: a node-host rebuild issues **no request of any kind to the default host**, only the scoped host's platforms are loaded, a messenger platform owned by another host is left alone, and the whole thing no-ops when gateway mode is off. The 53 pre-existing tests pass unchanged, which is the evidence that the periodic path is untouched.

Counterpart gateway change: lobehub-biz/message-gateway-node#2 (announces on boot). Landing this first is safe — until it exists, the gateway's announcement gets a 404 and it stops retrying.

#### 🔗 Related Issue

Part of LOBE-13278 · Fixes LOBE-13439