### PR TITLE
🐛 fix(heterogeneous-agent): scope models to topics

### DIFF
--- a/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
@@ -313,15 +313,54 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
     expect(userCall![0].files).toEqual(['file-1', 'file-2']);
   });
 
-  it('should pin the runtime type — not the agent chat model — on a server-created topic', async () => {
-    // regression: the topic-scoped model snapshot pinned the agent's chat
-    // model/provider, so a Gateway-created hetero topic came back from the
-    // server tagged with the default chat provider instead of the CLI runtime.
+  it('should pin the CLI default selection and runtime type on a server-created topic', async () => {
     await service.execAgent({ agentId: 'agent-1', prompt: 'Run the build' });
 
     expect(topicMock.create).toHaveBeenCalledWith(
-      expect.objectContaining({ model: undefined, provider: 'claude-code' }),
+      expect.objectContaining({ model: 'default', provider: 'claude-code' }),
       undefined,
+    );
+  });
+
+  it('should snapshot and execute a selected heterogeneous model on a server-created topic', async () => {
+    heteroAgentConfig.agencyConfig.heterogeneousProvider = {
+      model: 'opus',
+      type: 'claude-code',
+    } as any;
+
+    await service.execAgent({ agentId: 'agent-1', prompt: 'Run with Opus' });
+
+    expect(topicMock.create).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'opus', provider: 'claude-code' }),
+      undefined,
+    );
+    expect(mockSpawnHeteroSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({ args: ['--model', 'opus'] }),
+    );
+  });
+
+  it('should execute an existing topic with its pinned heterogeneous model', async () => {
+    heteroAgentConfig.agencyConfig.heterogeneousProvider = {
+      args: ['--model', 'stale-arg-model'],
+      model: 'agent-model',
+      type: 'claude-code',
+    } as any;
+    topicMock.findById.mockResolvedValue({
+      id: 'topic-existing',
+      metadata: undefined,
+      model: 'topic-model',
+      provider: 'claude-code',
+    });
+
+    await service.execAgent({
+      agentId: 'agent-1',
+      appContext: { topicId: 'topic-existing' },
+      prompt: 'Continue with the topic model',
+    } as any);
+
+    expect(topicMock.create).not.toHaveBeenCalled();
+    expect(mockSpawnHeteroSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({ args: ['--model', 'topic-model'] }),
     );
   });
 
@@ -457,6 +496,13 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
           status: 'error',
           success: false,
         }),
+      );
+      expect(topicMock.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: type === 'codex' ? 'gpt-test' : 'claude-test',
+          provider: type === 'codex' ? 'openai' : 'anthropic',
+        }),
+        undefined,
       );
       expect(mockSpawnHeteroSandbox).not.toHaveBeenCalled();
       expect(mockDispatchAgentRun).not.toHaveBeenCalled();

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -68,6 +68,7 @@ import type {
   ExecSubAgentParams,
   ExecSubAgentResult,
   ExecVirtualSubAgentParams,
+  HeterogeneousTopicModel,
   LobeAgentAgencyConfig,
   LobeAgentChatConfig,
   LobeAgentConfig,
@@ -81,6 +82,7 @@ import type {
 } from '@lobechat/types';
 import {
   AgentGraphSchema,
+  applyTopicModelToHeterogeneousProvider,
   buildHeteroExecArgs,
   ChatErrorType,
   getActivePluginIds,
@@ -89,6 +91,7 @@ import {
   RequestTrigger,
   resolveAgentAgencyConfig,
   resolveAgentModelConfig,
+  resolveHeterogeneousProviderTopicModel,
   ThreadStatus,
   ThreadType,
 } from '@lobechat/types';
@@ -2035,6 +2038,11 @@ export class AiAgentService {
     // getTopicModelById).
     let model = agentConfig.model!;
     let provider = agentConfig.provider!;
+    const heterogeneousProvider = agentConfig.agencyConfig?.heterogeneousProvider;
+    const heterogeneousTopicModelSnapshot = heterogeneousProvider
+      ? resolveHeterogeneousProviderTopicModel(heterogeneousProvider)
+      : undefined;
+    let pinnedHeterogeneousTopicModel: HeterogeneousTopicModel | undefined;
 
     if (!topicId) {
       if (resume) {
@@ -2077,16 +2085,12 @@ export class AiAgentService {
           : undefined;
 
       const fallbackTitleSource = markdownToTxt(prompt);
-      // A heterogeneous agent has no chat model to snapshot: the external CLI
-      // owns model selection, so `model` here is a stale agent default and
-      // `provider` is NULL (defaulted to the platform chat provider) on every
-      // agent created before the runtime type was stamped on the agent row.
-      // Pin the runtime type and leave the model to the per-run backfill — the
-      // same rule the assistant placeholder below and the client's
-      // `snapshotAgentModel` follow. Detection mirrors the hetero early exit.
+      // Heterogeneous topics use the same snapshot rule as the client: persist
+      // the selected CLI model (including `default`) or user-provider API binding.
+      // Runtimes without a model selector, legacy rows, and Agent-scoped
+      // server-default API configs still pin only the runtime type.
       const heteroSnapshotType =
-        agentConfig.agencyConfig?.heterogeneousProvider?.type ??
-        (isHeterogeneousAgentModelId(model) ? model : undefined);
+        heterogeneousProvider?.type ?? (isHeterogeneousAgentModelId(model) ? model : undefined);
       // Second argument: the id the client already rendered this topic under
       // (sidebar row, message bucket). Absent → the model mints one as before.
       const newTopic = await this.topicModel.create(
@@ -2102,8 +2106,8 @@ export class AiAgentService {
           groupId: appContext?.groupId,
           metadata,
           // Snapshot the effective model as the topic's pinned model (config).
-          model: heteroSnapshotType ? undefined : model,
-          provider: heteroSnapshotType ?? provider,
+          model: heterogeneousTopicModelSnapshot?.model ?? (heteroSnapshotType ? undefined : model),
+          provider: heterogeneousTopicModelSnapshot?.provider ?? heteroSnapshotType ?? provider,
           title:
             title !== undefined
               ? title
@@ -2133,6 +2137,7 @@ export class AiAgentService {
       if (pinnedModel) {
         model = modelOverride || pinnedModel;
         provider = providerOverride || existingTopic?.provider || provider;
+        pinnedHeterogeneousTopicModel = { model, provider };
         log(
           'execAgent: using topic-pinned model=%s provider=%s for topic %s',
           model,
@@ -2471,8 +2476,11 @@ export class AiAgentService {
           : undefined;
       const heteroExecArgs = isLocalHeterogeneousType(heteroType)
         ? buildHeteroExecArgs(
-            agentConfig.agencyConfig?.heterogeneousProvider?.type === heteroType
-              ? agentConfig.agencyConfig.heterogeneousProvider
+            heterogeneousProvider?.type === heteroType
+              ? applyTopicModelToHeterogeneousProvider(
+                  heterogeneousProvider,
+                  pinnedHeterogeneousTopicModel,
+                )
               : { type: heteroType },
           )
         : undefined;

--- a/packages/types/src/agent/agencyConfig.test.ts
+++ b/packages/types/src/agent/agencyConfig.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { HeterogeneousProviderConfig } from './agencyConfig';
 import {
+  applyTopicModelToHeterogeneousProvider,
   buildHeteroExecArgs,
   buildHeteroSpawnArgs,
   canPublishAgentTopicLink,
@@ -12,6 +13,7 @@ import {
   resolveAgencyConfig,
   resolveAgentAgencyConfig,
   resolveAgentTopicSharePolicy,
+  resolveHeterogeneousProviderTopicModel,
   unwrapServerDefaultHeterogeneousModel,
 } from './agencyConfig';
 import {
@@ -113,6 +115,72 @@ describe('pruneWorkingDirByDeviceDeletes', () => {
     expect(() =>
       pruneWorkingDirByDeviceDeletes(undefined, { workingDirByDevice: { 'device-a': undefined } }),
     ).not.toThrow();
+  });
+});
+
+describe('heterogeneous topic models', () => {
+  it('snapshots the persisted selector and Default', () => {
+    expect(
+      resolveHeterogeneousProviderTopicModel({
+        args: ['--model', 'cursor-arg-model'],
+        model: 'stale-structured-model',
+        type: 'cursor',
+      }),
+    ).toEqual({ model: 'stale-structured-model', provider: 'cursor' });
+    expect(resolveHeterogeneousProviderTopicModel({ type: 'cursor' })).toEqual({
+      model: HETEROGENEOUS_AGENT_DEFAULT_SELECTION,
+      provider: 'cursor',
+    });
+  });
+
+  it('overrides a CLI model without retaining a conflicting global flag', () => {
+    const effective = applyTopicModelToHeterogeneousProvider(
+      {
+        args: ['--model', 'global-model', '--mode', 'plan'],
+        model: 'global-model',
+        type: 'cursor',
+      },
+      { model: 'topic-model', provider: 'cursor' },
+    );
+
+    expect(effective).toEqual({
+      args: ['--mode', 'plan'],
+      model: 'topic-model',
+      type: 'cursor',
+    });
+    expect(buildHeteroSpawnArgs(effective)).toEqual(['--mode', 'plan', '--model', 'topic-model']);
+  });
+
+  it('overrides an API binding and drops a provider-specific fast model', () => {
+    expect(
+      applyTopicModelToHeterogeneousProvider(
+        {
+          apiConfig: {
+            model: 'global-model',
+            providerId: 'openai',
+            smallFastModel: 'gpt-4.1-mini',
+          },
+          authMode: 'api',
+          type: 'cursor',
+        },
+        { model: 'topic-model', provider: 'anthropic' },
+      ),
+    ).toMatchObject({
+      apiConfig: { model: 'topic-model', providerId: 'anthropic' },
+      authMode: 'api',
+      type: 'cursor',
+    });
+  });
+
+  it('ignores a topic model pinned for another heterogeneous runtime', () => {
+    const config = { model: 'global-model', type: 'cursor' } as const;
+
+    expect(
+      applyTopicModelToHeterogeneousProvider(config, {
+        model: 'codex-topic-model',
+        provider: 'codex',
+      }),
+    ).toBe(config);
   });
 });
 

--- a/packages/types/src/agent/agencyConfig.test.ts
+++ b/packages/types/src/agent/agencyConfig.test.ts
@@ -133,6 +133,22 @@ describe('heterogeneous topic models', () => {
     });
   });
 
+  it('keeps server-default API models Agent-scoped and ignores stale topic bindings', () => {
+    const config = {
+      apiConfig: { model: 'server-model', source: 'server-default' },
+      authMode: 'api',
+      type: 'claude-code',
+    } as const;
+
+    expect(resolveHeterogeneousProviderTopicModel(config)).toBeUndefined();
+    expect(
+      applyTopicModelToHeterogeneousProvider(config, {
+        model: 'stale-topic-model',
+        provider: 'anthropic',
+      }),
+    ).toBe(config);
+  });
+
   it('overrides a CLI model without retaining a conflicting global flag', () => {
     const effective = applyTopicModelToHeterogeneousProvider(
       {

--- a/packages/types/src/agent/agencyConfig.ts
+++ b/packages/types/src/agent/agencyConfig.ts
@@ -20,8 +20,10 @@ import type {
   QoderReasoningEffort,
 } from './heteroSelectorCapabilities';
 import {
+  applyHeteroSelection,
   CODEX_REASONING_EFFORT_CONFIG_KEY,
   CODEX_SERVICE_TIER_CONFIG_KEY,
+  getHeteroSelectorCapability,
   GROK_BUILD_REASONING_EFFORT_FLAGS,
   HETERO_SELECTOR_CAPABILITIES,
   HETEROGENEOUS_AGENT_DEFAULT_SELECTION,
@@ -215,6 +217,50 @@ export interface HeterogeneousProviderConfig {
   /** Agent runtime type, derived from the shared heterogeneous-agent descriptor catalog. */
   type: HeterogeneousAgentType;
 }
+
+export interface HeterogeneousTopicModel {
+  model: string;
+  provider: string;
+}
+
+export const resolveHeterogeneousProviderTopicModel = (
+  config: HeterogeneousProviderConfig,
+): HeterogeneousTopicModel | undefined => {
+  if (config.authMode === 'api') {
+    if (!config.apiConfig || config.apiConfig.source === 'server-default') return undefined;
+    return { model: config.apiConfig.model, provider: config.apiConfig.providerId };
+  }
+
+  const model = getHeteroSelectorCapability(config.type)?.model?.resolve(config);
+  return model ? { model, provider: config.type } : undefined;
+};
+
+export const applyTopicModelToHeterogeneousProvider = (
+  config: HeterogeneousProviderConfig,
+  topicModel: HeterogeneousTopicModel | undefined,
+): HeterogeneousProviderConfig => {
+  if (!topicModel?.model) return config;
+
+  if (config.authMode === 'api') {
+    if (!topicModel.provider || topicModel.provider === config.type) return config;
+    return {
+      ...config,
+      apiConfig: {
+        model: topicModel.model,
+        providerId: topicModel.provider,
+        ...(config.apiConfig?.providerId === topicModel.provider
+          ? { smallFastModel: config.apiConfig.smallFastModel }
+          : {}),
+      },
+    };
+  }
+
+  if (topicModel.provider !== config.type) return config;
+  return {
+    ...config,
+    ...applyHeteroSelection(config, { model: topicModel.model }),
+  };
+};
 
 const HETEROGENEOUS_AGENT_TYPES = new Set<string>([
   ...HETEROGENEOUS_AGENT_CONFIGS.map(({ type }) => type),

--- a/packages/types/src/agent/agencyConfig.ts
+++ b/packages/types/src/agent/agencyConfig.ts
@@ -223,6 +223,14 @@ export interface HeterogeneousTopicModel {
   provider: string;
 }
 
+/**
+ * Resolve the topic-level model snapshot for a heterogeneous provider.
+ *
+ * Server-default API models intentionally remain Agent-scoped: unlike a user-provider
+ * binding, their deployment-owned provider identity cannot be represented by the topic's
+ * model/provider pair. Their topic execution therefore ignores any stale pin from another
+ * auth mode and follows the current Agent config.
+ */
 export const resolveHeterogeneousProviderTopicModel = (
   config: HeterogeneousProviderConfig,
 ): HeterogeneousTopicModel | undefined => {
@@ -242,14 +250,18 @@ export const applyTopicModelToHeterogeneousProvider = (
   if (!topicModel?.model) return config;
 
   if (config.authMode === 'api') {
+    const apiConfig = config.apiConfig;
+    // Server-default is Agent-scoped. In particular, do not turn it back into a
+    // user-provider binding when this topic retains a pin from an earlier auth mode.
+    if (apiConfig?.source === 'server-default') return config;
     if (!topicModel.provider || topicModel.provider === config.type) return config;
     return {
       ...config,
       apiConfig: {
         model: topicModel.model,
         providerId: topicModel.provider,
-        ...(config.apiConfig?.providerId === topicModel.provider
-          ? { smallFastModel: config.apiConfig.smallFastModel }
+        ...(apiConfig?.providerId === topicModel.provider
+          ? { smallFastModel: apiConfig.smallFastModel }
           : {}),
       },
     };

--- a/src/features/ChatInput/ControlBar/HeteroModel/index.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroModel/index.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import type { ListHeterogeneousAgentModelsParams } from '@lobechat/types';
+import { applyTopicModelToHeterogeneousProvider } from '@lobechat/types';
 import isEqual from 'fast-deep-equal';
 import { memo } from 'react';
 
 import { usePermission } from '@/hooks/usePermission';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
+import { useChatStore } from '@/store/chat';
+import { topicSelectors } from '@/store/chat/slices/topic/selectors';
 
 import { useAgentId } from '../../hooks/useAgentId';
 import { useChatInputResourceAccess } from '../../hooks/useChatInputResourceAccess';
@@ -22,24 +25,28 @@ const HeteroModel = memo(() => {
     isEqual,
   );
   const { allowed: canCreateContent, reason } = usePermission('create_content');
-  // Model/effort picks write the shared heterogeneous-provider config. Hide
-  // the selector when this caller cannot configure that shared resource.
+  // Model picks are topic-scoped once a topic exists; the remaining dimensions
+  // still write the shared heterogeneous-provider config.
   const { canConfigureResource } = useChatInputResourceAccess();
   const enabled = canCreateContent && canConfigureResource;
   const patch = useHeteroProviderPatch({ agentId, enabled, provider });
+  const topicModel = useChatStore(topicSelectors.activeTopicModel);
+  const effectiveProvider = provider
+    ? applyTopicModelToHeterogeneousProvider(provider, topicModel)
+    : undefined;
 
-  const shape = resolveSelectorShape(provider, enabled);
+  const shape = resolveSelectorShape(effectiveProvider, enabled);
 
-  if (shape.kind === 'none' || !provider) return null;
+  if (shape.kind === 'none' || !effectiveProvider) return null;
 
   if (shape.kind === 'catalog')
     return (
       <ModelCatalogSelector
         agentId={agentId}
         disabled={false}
-        model={shape.capability.model.resolve(provider)}
+        model={shape.capability.model.resolve(effectiveProvider)}
         permissionReason={reason}
-        type={provider.type as ListHeterogeneousAgentModelsParams['type']}
+        type={effectiveProvider.type as ListHeterogeneousAgentModelsParams['type']}
         onSelect={(value) => void patch({ model: value })}
       />
     );
@@ -50,7 +57,7 @@ const HeteroModel = memo(() => {
       capability={shape.capability}
       patch={patch}
       permissionReason={reason}
-      provider={provider}
+      provider={effectiveProvider}
     />
   );
 });

--- a/src/features/ChatInput/ControlBar/HeteroModel/useHeteroProviderPatch.test.ts
+++ b/src/features/ChatInput/ControlBar/HeteroModel/useHeteroProviderPatch.test.ts
@@ -1,0 +1,88 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useHeteroProviderPatch } from './useHeteroProviderPatch';
+
+const state = vi.hoisted(() => ({
+  agent: { updateAgentConfigById: vi.fn() },
+  chat: {
+    activeTopicId: 'topic-a' as string | null,
+    updateTopicModel: vi.fn(),
+  },
+}));
+
+vi.mock('@/store/agent', () => ({
+  useAgentStore: (selector: (value: typeof state.agent) => unknown) => selector(state.agent),
+}));
+
+vi.mock('@/store/chat', () => ({
+  useChatStore: (selector: (value: typeof state.chat) => unknown) => selector(state.chat),
+}));
+
+describe('useHeteroProviderPatch', () => {
+  beforeEach(() => {
+    state.agent.updateAgentConfigById.mockReset();
+    state.chat.activeTopicId = 'topic-a';
+    state.chat.updateTopicModel.mockReset();
+  });
+
+  it('writes a model selection to the active topic without changing the Agent default', async () => {
+    const { result } = renderHook(() =>
+      useHeteroProviderPatch({
+        agentId: 'agent-a',
+        enabled: true,
+        provider: { model: 'global-model', type: 'cursor' },
+      }),
+    );
+
+    await act(() => result.current({ model: 'topic-model' }));
+
+    expect(state.chat.updateTopicModel).toHaveBeenCalledWith('topic-a', {
+      model: 'topic-model',
+      provider: 'cursor',
+    });
+    expect(state.agent.updateAgentConfigById).not.toHaveBeenCalled();
+  });
+
+  it('keeps non-model compatibility resets global when selecting a topic model', async () => {
+    const { result } = renderHook(() =>
+      useHeteroProviderPatch({
+        agentId: 'agent-a',
+        enabled: true,
+        provider: { effort: 'high', model: 'global-model', type: 'codex' },
+      }),
+    );
+
+    await act(() => result.current({ effort: 'default', model: 'topic-model' }));
+
+    expect(state.chat.updateTopicModel).toHaveBeenCalledWith('topic-a', {
+      model: 'topic-model',
+      provider: 'codex',
+    });
+    expect(state.agent.updateAgentConfigById).toHaveBeenCalledWith('agent-a', {
+      agencyConfig: {
+        heterogeneousProvider: { args: undefined, effort: 'default' },
+      },
+    });
+  });
+
+  it('updates the Agent default when there is no active topic', async () => {
+    state.chat.activeTopicId = null;
+    const { result } = renderHook(() =>
+      useHeteroProviderPatch({
+        agentId: 'agent-a',
+        enabled: true,
+        provider: { model: 'global-model', type: 'cursor' },
+      }),
+    );
+
+    await act(() => result.current({ model: 'next-default' }));
+
+    expect(state.chat.updateTopicModel).not.toHaveBeenCalled();
+    expect(state.agent.updateAgentConfigById).toHaveBeenCalledWith('agent-a', {
+      agencyConfig: {
+        heterogeneousProvider: { args: undefined, model: 'next-default' },
+      },
+    });
+  });
+});

--- a/src/features/ChatInput/ControlBar/HeteroModel/useHeteroProviderPatch.ts
+++ b/src/features/ChatInput/ControlBar/HeteroModel/useHeteroProviderPatch.ts
@@ -3,6 +3,7 @@ import { applyHeteroSelection } from '@lobechat/types';
 import { useCallback } from 'react';
 
 import { useAgentStore } from '@/store/agent';
+import { useChatStore } from '@/store/chat';
 
 export const useHeteroProviderPatch = ({
   agentId,
@@ -14,15 +15,27 @@ export const useHeteroProviderPatch = ({
   provider: HeterogeneousProviderConfig | undefined;
 }) => {
   const updateAgentConfigById = useAgentStore((s) => s.updateAgentConfigById);
+  const activeTopicId = useChatStore((s) => s.activeTopicId);
+  const updateTopicModel = useChatStore((s) => s.updateTopicModel);
 
   return useCallback(
     async (selection: HeteroSelection) => {
-      if (!enabled || !agentId) return;
+      if (!enabled || !agentId || !provider) return;
 
+      const { model, ...agentSelection } = selection;
+      if (activeTopicId && model !== undefined) {
+        await updateTopicModel(activeTopicId, { model, provider: provider.type });
+        if (Object.keys(agentSelection).length === 0) return;
+      }
       await updateAgentConfigById(agentId, {
-        agencyConfig: { heterogeneousProvider: applyHeteroSelection(provider, selection) },
+        agencyConfig: {
+          heterogeneousProvider: applyHeteroSelection(
+            provider,
+            activeTopicId ? agentSelection : selection,
+          ),
+        },
       });
     },
-    [agentId, enabled, provider, updateAgentConfigById],
+    [activeTopicId, agentId, enabled, provider, updateAgentConfigById, updateTopicModel],
   );
 };

--- a/src/features/Conversation/store/slices/generation/action.test.ts
+++ b/src/features/Conversation/store/slices/generation/action.test.ts
@@ -1773,6 +1773,36 @@ describe('Generation Actions', () => {
       );
     });
 
+    it('regenerates with the topic-pinned heterogeneous model', async () => {
+      await setupHeteroChatStore({
+        topicDataMap: {
+          test: {
+            items: [{ id: 'topic-1', model: 'opus', provider: 'claude-code' }],
+          },
+        },
+      });
+      const context: ConversationContext = {
+        agentId: 'session-1',
+        threadId: null,
+        topicId: 'topic-1',
+      };
+      const store = createStore({ context });
+      store.setState({
+        displayMessages: [{ content: 'Retry with the pinned model', id: 'msg-1', role: 'user' }],
+      } as any);
+
+      await act(async () => {
+        await store.getState().regenerateUserMessage('msg-1');
+      });
+
+      expect(executeHeterogeneousAgentSpy).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          heterogeneousProvider: expect.objectContaining({ model: 'opus', type: 'claude-code' }),
+        }),
+      );
+    });
+
     it('preserves a legacy subscription resume when the Provider Binding Lab is enabled', async () => {
       const previousLab = useUserStore.getState().preference.lab;
       useUserStore.setState((state) => ({

--- a/src/features/Conversation/store/slices/generation/action.ts
+++ b/src/features/Conversation/store/slices/generation/action.ts
@@ -7,7 +7,7 @@ import type {
   ConversationContext,
   HeterogeneousProviderConfig,
 } from '@lobechat/types';
-import { resolveAgentAgencyConfig } from '@lobechat/types';
+import { applyTopicModelToHeterogeneousProvider, resolveAgentAgencyConfig } from '@lobechat/types';
 import { toast } from '@lobehub/ui/base-ui';
 import { t } from 'i18next';
 import { type StateCreator } from 'zustand';
@@ -213,6 +213,14 @@ const runHeterogeneousFromExistingMessage = async (
   else if (reason === 'binding_changed')
     toast.info(t('heteroAgent.resumeReset.bindingChanged', { ns: 'chat' }));
 
+  const topicModel = context.topicId
+    ? topicSelectors.getTopicModelById(context.topicId)(chatStore)
+    : undefined;
+  const effectiveHeterogeneousProvider = applyTopicModelToHeterogeneousProvider(
+    heterogeneousProvider,
+    topicModel,
+  );
+
   const assistantMsg = await messageService.createMessage({
     agentId,
     content: LOADING_FLAT,
@@ -243,7 +251,7 @@ const runHeterogeneousFromExistingMessage = async (
   await executeHeterogeneousAgent(() => useChatStore.getState(), {
     assistantMessageId: assistantMsg.id,
     context,
-    heterogeneousProvider,
+    heterogeneousProvider: effectiveHeterogeneousProvider,
     imageList: imageList?.length ? imageList : undefined,
     message: prompt,
     operationId: heteroOpId,

--- a/src/features/Conversation/store/slices/generation/continueHeteroAfterError.test.ts
+++ b/src/features/Conversation/store/slices/generation/continueHeteroAfterError.test.ts
@@ -33,6 +33,7 @@ let mockAgentVisibility: 'private' | 'public' = 'public';
 let mockIsWorkspaceAgent = false;
 let mockSharedExecutionTarget: 'device' | 'local' = 'local';
 let mockWorkspaceOverride: { boundDeviceId: string; executionTarget: 'local' } | undefined;
+let mockTopic: { id: string; model?: string; provider?: string } | undefined;
 vi.mock(
   '@/store/chat/slices/agentRun/actions/transports/hetero/heteroResume',
   async (importOriginal) => ({
@@ -92,7 +93,11 @@ vi.mock('@/store/agent/selectors', () => ({
 }));
 
 vi.mock('@/store/chat/selectors', () => ({
-  topicSelectors: { getTopicById: () => () => undefined },
+  topicSelectors: {
+    getTopicById: () => () => mockTopic,
+    getTopicModelById: () => () =>
+      mockTopic?.model ? { model: mockTopic.model, provider: mockTopic.provider || '' } : undefined,
+  },
 }));
 
 vi.mock('@/store/electron', () => ({
@@ -171,6 +176,7 @@ describe('continueHeteroAfterError', () => {
     mockResumeSessionId = 'sess-1';
     mockIsWorkspaceAgent = false;
     mockSharedExecutionTarget = 'local';
+    mockTopic = undefined;
     mockWorkspaceOverride = undefined;
   });
 
@@ -200,6 +206,23 @@ describe('continueHeteroAfterError', () => {
     });
     expect(executorParams().message).toContain('Continue the task from where it stopped');
     expect(executorParams().message).not.toBe(USER_MESSAGE.content);
+  });
+
+  it('continues with the topic-pinned heterogeneous model', async () => {
+    mockTopic = { id: 'topic-1', model: 'opus', provider: 'claude-code' };
+    const store = buildGroupStore([
+      { content: 'looking', id: 'step-1', tools: [{ id: 'call-1' }] },
+      { content: '', error: HETERO_RATE_LIMIT, id: 'step-2', tools: [{ id: 'call-2' }] },
+    ]);
+
+    await act(async () => {
+      await store.getState().continueHeteroAfterError('step-1');
+    });
+
+    expect(executorParams().heterogeneousProvider).toMatchObject({
+      model: 'opus',
+      type: 'claude-code',
+    });
   });
 
   it('drops an error-only tail step and chains the continuation onto its parent', async () => {

--- a/src/features/Conversation/store/slices/generation/regenerateHeteroImages.test.ts
+++ b/src/features/Conversation/store/slices/generation/regenerateHeteroImages.test.ts
@@ -68,7 +68,10 @@ vi.mock('@/store/agent/selectors', () => ({
 }));
 
 vi.mock('@/store/chat/selectors', () => ({
-  topicSelectors: { getTopicById: () => () => undefined },
+  topicSelectors: {
+    getTopicById: () => () => undefined,
+    getTopicModelById: () => () => undefined,
+  },
 }));
 
 vi.mock('@/store/electron', () => ({

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/ApiModeModelBar.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/ApiModeModelBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { HeterogeneousApiConfig } from '@lobechat/types';
+import { applyTopicModelToHeterogeneousProvider } from '@lobechat/types';
 import { TooltipGroup } from '@lobehub/ui';
 import { Select } from '@lobehub/ui/base-ui';
 import { memo, useMemo } from 'react';
@@ -16,6 +17,8 @@ import ModelSelect from '@/features/ModelSelect';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useAiInfraStore } from '@/store/aiInfra';
+import { useChatStore } from '@/store/chat';
+import { topicSelectors } from '@/store/chat/slices/topic/selectors';
 
 interface ApiModeModelBarProps {
   agentId: string;
@@ -29,6 +32,9 @@ const ApiModeModelBar = memo<ApiModeModelBarProps>(({ agentId }) => {
   const agencyConfig = useAgentStore(agentByIdSelectors.getAgencyConfigById(agentId));
   const updateAgentConfigById = useAgentStore((state) => state.updateAgentConfigById);
   const heterogeneousProvider = agencyConfig?.heterogeneousProvider;
+  const activeTopicId = useChatStore((state) => state.activeTopicId);
+  const topicModel = useChatStore(topicSelectors.activeTopicModel);
+  const updateTopicModel = useChatStore((state) => state.updateTopicModel);
   const { providers } = useProviderBindingCompatibleProviders(heterogeneousProvider?.type);
   const providerIds = useMemo(() => providers.map(({ id }) => id), [providers]);
   const serverDefaultAgentType =
@@ -61,7 +67,20 @@ const ApiModeModelBar = memo<ApiModeModelBarProps>(({ agentId }) => {
   )
     return null;
 
+  const effectiveProvider = applyTopicModelToHeterogeneousProvider(
+    heterogeneousProvider,
+    topicModel,
+  );
+
   const persist = async (apiConfig: HeterogeneousApiConfig) => {
+    if (activeTopicId && apiConfig.source !== 'server-default' && apiConfig.providerId) {
+      await updateTopicModel(activeTopicId, {
+        model: apiConfig.model,
+        provider: apiConfig.providerId,
+      });
+      return;
+    }
+
     await updateAgentConfigById(agentId, {
       agencyConfig: {
         ...agencyConfig,
@@ -100,10 +119,10 @@ const ApiModeModelBar = memo<ApiModeModelBarProps>(({ agentId }) => {
       style={COMPACT_MODEL_PICKER_STYLE}
       variant="borderless"
       value={
-        providerApiConfig
+        effectiveProvider.apiConfig
           ? {
-              model: providerApiConfig.model,
-              provider: providerApiConfig.providerId,
+              model: effectiveProvider.apiConfig.model,
+              provider: effectiveProvider.apiConfig.providerId,
             }
           : undefined
       }

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/ApiModeModelBar.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/ApiModeModelBar.tsx
@@ -71,6 +71,9 @@ const ApiModeModelBar = memo<ApiModeModelBarProps>(({ agentId }) => {
     heterogeneousProvider,
     topicModel,
   );
+  const effectiveApiConfig = effectiveProvider.apiConfig;
+  const effectiveProviderApiConfig =
+    effectiveApiConfig?.source !== 'server-default' ? effectiveApiConfig : undefined;
 
   const persist = async (apiConfig: HeterogeneousApiConfig) => {
     if (activeTopicId && apiConfig.source !== 'server-default' && apiConfig.providerId) {
@@ -119,10 +122,10 @@ const ApiModeModelBar = memo<ApiModeModelBarProps>(({ agentId }) => {
       style={COMPACT_MODEL_PICKER_STYLE}
       variant="borderless"
       value={
-        effectiveProvider.apiConfig
+        effectiveProviderApiConfig
           ? {
-              model: effectiveProvider.apiConfig.model,
-              provider: effectiveProvider.apiConfig.providerId,
+              model: effectiveProviderApiConfig.model,
+              provider: effectiveProviderApiConfig.providerId,
             }
           : undefined
       }

--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
@@ -3563,6 +3563,87 @@ describe('ConversationLifecycle actions', () => {
           }),
           expect.any(AbortController),
         );
+        expect(sendMessageInServerSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            newTopic: expect.objectContaining({ model: 'default', provider: 'codex' }),
+          }),
+          expect.any(AbortController),
+        );
+      });
+
+      it('overrides the heterogeneous runtime with the active topic model', async () => {
+        mockConstEnv.isDesktop = true;
+        setupMockSelectors({
+          agentConfig: {
+            agencyConfig: {
+              heterogeneousProvider: {
+                args: ['--model', 'global-model', '--mode', 'plan'],
+                model: 'global-model',
+                type: 'cursor',
+              },
+            },
+          },
+        });
+        const context = {
+          agentId: TEST_IDS.SESSION_ID,
+          threadId: null,
+          topicId: TEST_IDS.TOPIC_ID,
+        };
+        const topicKey = topicMapKey({ agentId: TEST_IDS.SESSION_ID });
+        act(() => {
+          useChatStore.setState({
+            activeAgentId: TEST_IDS.SESSION_ID,
+            activeTopicId: TEST_IDS.TOPIC_ID,
+            topicDataMap: {
+              [topicKey]: {
+                currentPage: 0,
+                hasMore: false,
+                items: [
+                  {
+                    createdAt: Date.now(),
+                    id: TEST_IDS.TOPIC_ID,
+                    model: 'topic-model',
+                    provider: 'cursor',
+                    title: 'Topic A',
+                    updatedAt: Date.now(),
+                  },
+                ],
+                pageSize: 20,
+                total: 1,
+              },
+            },
+          });
+        });
+        vi.spyOn(aiChatService, 'sendMessageInServer').mockResolvedValue({
+          assistantMessageId: TEST_IDS.ASSISTANT_MESSAGE_ID,
+          messages: [
+            createMockMessage({ id: TEST_IDS.USER_MESSAGE_ID, role: 'user' }),
+            createMockMessage({ id: TEST_IDS.ASSISTANT_MESSAGE_ID, role: 'assistant' }),
+          ],
+          topicId: TEST_IDS.TOPIC_ID,
+          topics: [],
+          userMessageId: TEST_IDS.USER_MESSAGE_ID,
+        } as any);
+        executeHeterogeneousAgentMock.mockResolvedValue(undefined);
+        const { result } = renderHook(() => useChatStore());
+
+        await act(async () => {
+          await result.current.sendMessage({
+            context,
+            message: TEST_CONTENT.USER_MESSAGE,
+          });
+        });
+
+        expect(executeHeterogeneousAgentMock).toHaveBeenCalledWith(
+          expect.any(Function),
+          expect.objectContaining({
+            heterogeneousProvider: {
+              args: ['--mode', 'plan'],
+              model: 'topic-model',
+              type: 'cursor',
+            },
+          }),
+        );
       });
 
       it('routes a legacy bare Qoder model to the desktop heterogeneous runtime without gateway mode', async () => {

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -18,6 +18,7 @@ import type {
   UIChatMessage,
 } from '@lobechat/types';
 import {
+  applyTopicModelToHeterogeneousProvider,
   getWorkingDirEffectivePath,
   getWorkingDirSourcePath,
   resolveAgentAgencyConfig,
@@ -1562,12 +1563,16 @@ export class ConversationLifecycleActionImpl {
         } else if (reason === 'binding_changed') {
           toast.info(t('heteroAgent.resumeReset.bindingChanged', { ns: 'chat' }));
         }
+        const effectiveHeterogeneousProvider = applyTopicModelToHeterogeneousProvider(
+          heterogeneousProvider,
+          topic?.model ? { model: topic.model, provider: topic.provider || '' } : undefined,
+        );
 
         await executeHeterogeneousAgent(() => this.#get(), {
           assistantMessageId: heteroExecutionAssistantId,
           context: heteroExecutionContext,
           contextSelections: effectiveContextSelections,
-          heterogeneousProvider,
+          heterogeneousProvider: effectiveHeterogeneousProvider,
           imageList: persistedImageList?.length ? persistedImageList : undefined,
           message,
           operationId: heteroOpId,

--- a/src/store/chat/utils/snapshotAgentModel.test.ts
+++ b/src/store/chat/utils/snapshotAgentModel.test.ts
@@ -33,15 +33,12 @@ describe('snapshotAgentModel', () => {
     expect(snapshotAgentModel(id)).toEqual({ model: DEFAULT_MODEL, provider: DEFAULT_PROVIDER });
   });
 
-  it('pins the runtime type — not the chat defaults — for a heterogeneous agent', () => {
+  it('snapshots the CLI default selection for a heterogeneous agent', () => {
     const id = seedAgent('hetero', {
       agencyConfig: { heterogeneousProvider: { command: 'claude', type: 'claude-code' } },
     });
 
-    // `model` stays unset: the CLI owns model selection and reports the real
-    // model per run. Falling back to DEFAULT_MODEL/DEFAULT_PROVIDER here is what
-    // pinned `<default provider>` onto CLI topics.
-    expect(snapshotAgentModel(id)).toEqual({ provider: 'claude-code' });
+    expect(snapshotAgentModel(id)).toEqual({ model: 'default', provider: 'claude-code' });
   });
 
   it('ignores a stale agent model when the agent is heterogeneous', () => {
@@ -51,7 +48,38 @@ describe('snapshotAgentModel', () => {
       provider: DEFAULT_PROVIDER,
     });
 
-    expect(snapshotAgentModel(id)).toEqual({ provider: 'codex' });
+    expect(snapshotAgentModel(id)).toEqual({ model: 'default', provider: 'codex' });
+  });
+
+  it('snapshots the persisted heterogeneous selector instead of legacy native args', () => {
+    const id = seedAgent('cursor-with-model-arg', {
+      agencyConfig: {
+        heterogeneousProvider: {
+          args: ['--model', 'composer-2'],
+          model: 'stale-model',
+          type: 'cursor',
+        },
+      },
+    });
+
+    expect(snapshotAgentModel(id)).toEqual({ model: 'stale-model', provider: 'cursor' });
+  });
+
+  it('snapshots a heterogeneous API binding', () => {
+    const id = seedAgent('cursor-api', {
+      agencyConfig: {
+        heterogeneousProvider: {
+          apiConfig: { model: 'claude-sonnet-4-6', providerId: 'anthropic' },
+          authMode: 'api',
+          type: 'cursor',
+        },
+      },
+    });
+
+    expect(snapshotAgentModel(id)).toEqual({
+      model: 'claude-sonnet-4-6',
+      provider: 'anthropic',
+    });
   });
 
   it('pins nothing when a heterogeneous config carries no type', () => {

--- a/src/store/chat/utils/snapshotAgentModel.test.ts
+++ b/src/store/chat/utils/snapshotAgentModel.test.ts
@@ -82,6 +82,20 @@ describe('snapshotAgentModel', () => {
     });
   });
 
+  it('keeps a server-default API model Agent-scoped', () => {
+    const id = seedAgent('claude-server-default', {
+      agencyConfig: {
+        heterogeneousProvider: {
+          apiConfig: { model: 'claude-sonnet-4-6', source: 'server-default' },
+          authMode: 'api',
+          type: 'claude-code',
+        },
+      },
+    });
+
+    expect(snapshotAgentModel(id)).toEqual({ provider: 'claude-code' });
+  });
+
   it('pins nothing when a heterogeneous config carries no type', () => {
     const id = seedAgent('hetero-untyped', {
       agencyConfig: { heterogeneousProvider: { command: 'claude' } },

--- a/src/store/chat/utils/snapshotAgentModel.ts
+++ b/src/store/chat/utils/snapshotAgentModel.ts
@@ -1,3 +1,5 @@
+import { resolveHeterogeneousProviderTopicModel } from '@lobechat/types';
+
 import { getAgentStoreState } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 
@@ -16,19 +18,16 @@ export const snapshotAgentModel = (
 
   const agentState = getAgentStoreState();
 
-  // Heterogeneous agents (Claude Code, Codex, …) delegate model selection to an
-  // external CLI, so neither agent column can be snapshotted: `model` is
-  // deliberately left unset at creation (the CLI reports the real model per run
-  // and it is backfilled onto the messages), and `provider` is NULL on every
-  // agent created before the runtime type started being stamped there. Both
-  // model/provider selectors below substitute the platform chat defaults for a
-  // blank, which would pin `<default provider>/<default model>` onto a topic
-  // that never ran either. Pin the runtime type — the one fact we do know — and
-  // leave `model` to the per-run backfill.
+  // Heterogeneous topics snapshot the selector value that will be passed to the
+  // CLI (including `default`) or the bound API model. This keeps a topic stable
+  // when the Agent default changes later.
   const heterogeneousProvider =
     agentByIdSelectors.getAgencyConfigById(agentId)(agentState)?.heterogeneousProvider;
   if (heterogeneousProvider) {
-    return heterogeneousProvider.type ? { provider: heterogeneousProvider.type } : {};
+    return (
+      resolveHeterogeneousProviderTopicModel(heterogeneousProvider) ??
+      (heterogeneousProvider.type ? { provider: heterogeneousProvider.type } : {})
+    );
   }
 
   // Non-hetero: the effective model IS the agent default when nothing is pinned,


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| Switching a heterogeneous Agent model rewrote the Agent default, so every topic shared the last pick. | Model picks write `topics.model` / `topics.provider`. The active topic model is shown in the control, snapshotted on topic create, and overlaid onto CLI/API execution. Effort / mode / speed stay global. |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Desktop (unsigned local `lobehub-desktop-dev.app`) against Official Cloud:

- Switch model on topic A, then topic B; A keeps its own model
- Heterogeneous model control shows the active topic model
- New topic snapshots the effective heterogeneous model (`default` and API bindings included)
- Send uses the topic model and drops conflicting global CLI model flags
- Effort / mode / speed stay on the Agent; a topic model pinned for another heterogeneous runtime is ignored

#### 🔗 Related Issue

Related to #18657 (item 1 only: topic-scoped model). Thinking display and token/cost stats are not in this PR.

Made with [Cursor](https://cursor.com)