### PR TITLE
chore: remove LOBE-13364 marker from loadAttachmentBuffer comment

### DIFF
--- a/apps/server/src/services/bot/platforms/loadAttachmentBuffer.ts
+++ b/apps/server/src/services/bot/platforms/loadAttachmentBuffer.ts
@@ -19,9 +19,9 @@ const MB = 1024 * 1024;
  * The agent-facing `botMessage` procedures do NOT go through that pass: the
  * router hands raw attachments straight to the platform services. There, an
  * oversized body is refused here and the sender skips the attachment, which
- * means it is dropped without a fallback link. That gap is tracked separately
- * (see LOBE-13364) — routing those sends through the budget pass is a change
- * to the agent tool contract, not something to bolt on inside this loader.
+ * means it is dropped without a fallback link. That gap is tracked separately —
+ * routing those sends through the budget pass is a change to the agent tool
+ * contract, not something to bolt on inside this loader.
  */
 export const MAX_IN_MEMORY_ATTACHMENT_BYTES = 50 * MB;
 


### PR DESCRIPTION
## Summary

Removed a `LOBE-13364` Linear-issue reference from a source comment in `loadAttachmentBuffer.ts`. The comment already described the underlying scenario in full, so the inline issue reference was redundant noise for an open-source codebase.

The scenario (kept intact): agent-facing `botMessage` procedures bypass the `prepareAttachmentsForBudget` pass, so an oversized attachment is refused by `loadAttachmentBuffer` and dropped without a fallback link. Routing those sends through the budget pass is an agent tool-contract change that is tracked separately.

## Changed files

- `apps/server/src/services/bot/platforms/loadAttachmentBuffer.ts`

## Notes

- Comment-only change; no code semantics altered.
- Locale files (`locales/*/project.json`, `packages/locales/src/default/project.ts`) were intentionally left untouched — the `LOBE-123` there is user-facing UI copy explaining the task-identifier prefix format, not a code marker.
