### PR TITLE
🐛 fix(tools): recover stale scoped tool calls

### DIFF
--- a/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
+++ b/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
@@ -462,6 +462,44 @@ describe('GeneralChatAgent', () => {
       ]);
     });
 
+    it('should return a recoverable result for a stale dynamic tool call', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        allowedToolNames: ['lobe-activator____activateTools'],
+        operationId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+      const toolCall: ChatToolPayload = {
+        apiName: 'listOnlineDevices',
+        arguments: '{}',
+        id: 'call-1',
+        identifier: 'lobe-remote-device',
+        type: 'builtin',
+      };
+
+      const result = await agent.runner(
+        createMockContext('llm_result', {
+          hasToolsCalling: true,
+          parentMessageId: 'msg-1',
+          toolsCalling: [toolCall],
+        }),
+        createMockState(),
+      );
+
+      expect(result).toEqual([
+        {
+          payload: {
+            blockedContent:
+              'Tool execution blocked because the tool is not allowed in the current execution scope.',
+            blockedReason: 'tool_not_allowed',
+            parentMessageId: 'msg-1',
+            toolsCalling: [toolCall],
+          },
+          type: 'resolve_blocked_tools',
+        },
+      ]);
+    });
+
     it('should execute allowed tools, resolve denied tools, then pause for approval', async () => {
       const agent = new GeneralChatAgent({
         agentConfig: { maxSteps: 100 },

--- a/packages/context-engine/src/engine/tools/ToolNameResolver.ts
+++ b/packages/context-engine/src/engine/tools/ToolNameResolver.ts
@@ -127,9 +127,11 @@ export class ToolNameResolver {
    * @param manifests - Available tool manifests mapped by identifier
    * @param offeredToolNames - Tool names actually sent to the LLM in this turn
    *   (e.g. `lobe-activator____activateTools`). When provided, the
-   *   missing-prefix fallback only considers tools in this list, so a model
-   *   can't trigger tools that weren't enabled for the current call and
-   *   disabled duplicates can't shadow enabled ones.
+   *   missing-prefix fallback only considers tools in this list, so an
+   *   ambiguous bare name cannot resolve to a disabled duplicate. Explicitly
+   *   namespaced, manifest-backed calls are still parsed; the agent's allow-list
+   *   guard turns out-of-scope calls into tool results instead of silently
+   *   dropping them. Unknown namespace/API pairs remain rejected here.
    * @returns Resolved tool payloads
    */
   resolve(
@@ -205,16 +207,13 @@ export class ToolNameResolver {
         const manifest = manifests[identifier];
         const matchedApi = manifest?.api.find((api: LobeChatPluginApi) => api.name === apiName);
 
-        // Explicitly namespaced calls need the same current-turn allowlist check
-        // as the bare-name recovery path. Topic history can contain tools from a
-        // previous operation; accepting a syntactically valid old identifier here
-        // would let it escape an evidence-only or otherwise restricted turn.
-        if (offeredSet) {
-          const directlyOffered = offeredSet.has(toolCall.function.name);
-          if (!directlyOffered) {
-            if (!manifest || !matchedApi) return null;
-            if (!offeredSet.has(this.generate(identifier, apiName, manifest.type))) return null;
-          }
+        // A tool explicitly offered by the server is already authoritative and
+        // may not have a prompt manifest. A stale namespaced call that was not
+        // offered this turn must still match a known manifest entry before it
+        // can be preserved for the downstream scope guard. This prevents a
+        // fabricated namespace/API pair from becoming a synthetic tool result.
+        if (offeredSet && !offeredSet.has(toolCall.function.name) && (!manifest || !matchedApi)) {
+          return null;
         }
 
         const payload: ChatToolPayload = {

--- a/packages/context-engine/src/engine/tools/__tests__/ToolNameResolver.test.ts
+++ b/packages/context-engine/src/engine/tools/__tests__/ToolNameResolver.test.ts
@@ -897,7 +897,7 @@ describe('ToolNameResolver', () => {
         expect(result).toEqual([]);
       });
 
-      it('should drop explicitly namespaced tools that were not offered this turn', () => {
+      it('should drop an explicitly namespaced API missing from its manifest', () => {
         const toolCalls = [
           {
             function: { arguments: '{}', name: 'lobe-local-system____submitEvidence' },
@@ -928,35 +928,41 @@ describe('ToolNameResolver', () => {
         expect(result).toEqual([]);
       });
 
-      it('should drop valid explicitly namespaced tools that were not offered this turn', () => {
+      it('should preserve a manifest-backed stale dynamic tool for downstream scope rejection', () => {
         const toolCalls = [
           {
-            function: { arguments: '{}', name: 'lobe-local-system____runCommand' },
+            function: { arguments: '{}', name: 'lobe-remote-device____listOnlineDevices' },
             id: 'call_1',
             type: 'function',
           },
         ];
 
         const manifests = {
-          'lobe-acceptance-evidence': {
-            api: [{ description: '', name: 'submitEvidence', parameters: {} }],
-            identifier: 'lobe-acceptance-evidence',
+          'lobe-activator': {
+            api: [{ description: '', name: 'activateTools', parameters: {} }],
+            identifier: 'lobe-activator',
             meta: {},
             type: 'builtin' as const,
           },
-          'lobe-local-system': {
-            api: [{ description: '', name: 'runCommand', parameters: {} }],
-            identifier: 'lobe-local-system',
+          'lobe-remote-device': {
+            api: [{ description: '', name: 'listOnlineDevices', parameters: {} }],
+            identifier: 'lobe-remote-device',
             meta: {},
             type: 'builtin' as const,
           },
         };
 
-        const result = resolver.resolve(toolCalls, manifests, [
-          'lobe-acceptance-evidence____submitEvidence',
-        ]);
+        const result = resolver.resolve(toolCalls, manifests, ['lobe-activator____activateTools']);
 
-        expect(result).toEqual([]);
+        expect(result).toEqual([
+          {
+            apiName: 'listOnlineDevices',
+            arguments: '{}',
+            id: 'call_1',
+            identifier: 'lobe-remote-device',
+            type: 'builtin',
+          },
+        ]);
       });
 
       it('should accept an explicitly offered tool when no prompt manifest is available', () => {


### PR DESCRIPTION
<!-- Brief and heads-up -->

Prevent explicitly namespaced tool calls from being silently dropped when they are absent from the current turn allowlist. The resolver now preserves the call so `GeneralChatAgent` can route it through the existing `resolve_blocked_tools` path, return `tool_not_allowed` to the model, and allow recovery through `activateTools`.

This keeps the tool-scope security boundary intact: stale tools are not executed directly. It only replaces the previous empty-assistant + false `done` outcome with a recoverable tool result.

Regression scenario: `lobe-remote-device____listOnlineDevices({})` remained in conversation history but only `lobe-activator____activateTools` was offered in the new operation.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `ToolNameResolver.test.ts`: 54 passed
- `GeneralChatAgent.test.ts`: 86 passed

#### 🔗 Related Issue

Observed in topic `tpc_dAxqJhgvFFN5`.
