### PR TITLE
🐛 fix(agent): settle Gateway topic status atomically

### DIFF
--- a/apps/server/src/modules/AgentRuntime/adapters/ServerOperationStore.test.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerOperationStore.test.ts
@@ -5,8 +5,7 @@ import type { LobeChatDatabase } from '@/database/type';
 import { ServerOperationStore } from './ServerOperationStore';
 
 const topicMock = {
-  findById: vi.fn(),
-  takeRunningOperation: vi.fn(),
+  settleRunningOperation: vi.fn(),
 };
 
 vi.mock('@/database/models/topic', () => ({
@@ -21,73 +20,40 @@ const createStore = (operationId: string | undefined, topicId: string | undefine
 const createTopiclessStore = () =>
   new ServerOperationStore(db, 'user-1', undefined, undefined, 'op-main');
 
-const markedWith = (operationId: string) => ({
-  metadata: { runningOperation: { assistantMessageId: 'asst-1', operationId } },
-});
-
 describe('ServerOperationStore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    topicMock.takeRunningOperation.mockResolvedValue(undefined);
+    topicMock.settleRunningOperation.mockResolvedValue(undefined);
   });
 
   describe('clearRunningMark', () => {
-    it('clears the mark when this operation owns it', async () => {
-      topicMock.findById.mockResolvedValue(markedWith('op-main'));
-
+    it('atomically clears and settles the operation', async () => {
       await createStore('op-main').clearRunningMark();
 
-      expect(topicMock.takeRunningOperation).toHaveBeenCalledWith('topic-1', 'op-main');
+      expect(topicMock.settleRunningOperation).toHaveBeenCalledWith('topic-1', 'op-main');
     });
 
-    it('leaves the mark alone when it belongs to another operation', async () => {
+    it('delegates child ownership handling to the atomic model operation', async () => {
       // Regression: a `callSubAgent` / group-member child runs in an isolation
       // thread on its PARENT's topic and finishes minutes before the parent. The
       // unconditional clear wiped the parent's reconnect anchor mid-run, so every
       // later client open saw no `runningOperation`, never opened a gateway
       // WebSocket, and rendered a frozen REST snapshot until the run ended.
-      topicMock.findById.mockResolvedValue(markedWith('op-parent'));
-
       await createStore('op-child').clearRunningMark();
 
-      expect(topicMock.takeRunningOperation).not.toHaveBeenCalled();
-    });
-
-    it('is a no-op when the topic carries no mark', async () => {
-      topicMock.findById.mockResolvedValue({ metadata: {} });
-
-      await createStore('op-main').clearRunningMark();
-
-      expect(topicMock.takeRunningOperation).not.toHaveBeenCalled();
+      expect(topicMock.settleRunningOperation).toHaveBeenCalledWith('topic-1', 'op-child');
     });
 
     it('skips the lookup entirely without a topic', async () => {
       await createTopiclessStore().clearRunningMark();
 
-      expect(topicMock.findById).not.toHaveBeenCalled();
-      expect(topicMock.takeRunningOperation).not.toHaveBeenCalled();
+      expect(topicMock.settleRunningOperation).not.toHaveBeenCalled();
     });
 
-    it('swallows lookup failures — clearing the mark is best-effort', async () => {
-      topicMock.findById.mockRejectedValue(new Error('db down'));
+    it('swallows settlement failures — clearing the mark is best-effort', async () => {
+      topicMock.settleRunningOperation.mockRejectedValue(new Error('db down'));
 
       await expect(createStore('op-main').clearRunningMark()).resolves.toBeUndefined();
-      expect(topicMock.takeRunningOperation).not.toHaveBeenCalled();
-    });
-
-    it('takes a matching child marker without clearing its parent', async () => {
-      topicMock.findById.mockResolvedValue({
-        metadata: {
-          runningOperation: {
-            ...markedWith('op-parent').metadata.runningOperation,
-            childOperations: [{ assistantMessageId: 'asst-child', operationId: 'op-child' }],
-          },
-        },
-      });
-
-      await createStore('op-child').clearRunningMark();
-
-      expect(topicMock.takeRunningOperation).toHaveBeenCalledWith('topic-1', 'op-child');
     });
   });
 });

--- a/apps/server/src/modules/AgentRuntime/adapters/ServerOperationStore.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerOperationStore.ts
@@ -4,8 +4,9 @@ import { TopicModel } from '@/database/models/topic';
 import { type LobeChatDatabase } from '@/database/type';
 
 /**
- * Server {@link OperationStore} adapter. `clearRunningMark` drops the topic's
- * `runningOperation` so a reconnect doesn't re-trigger after completion.
+ * Server {@link OperationStore} adapter. `clearRunningMark` atomically drops
+ * the topic's `runningOperation` and settles its persisted running status so a
+ * reconnect doesn't re-trigger after completion.
  * Best-effort: missing topic/user is a no-op and failures are swallowed
  * (matches the prior server-local `finish` behavior).
  */
@@ -36,16 +37,8 @@ export class ServerOperationStore implements OperationStore {
     if (!this.topicId || !this.userId) return;
     try {
       const topicModel = new TopicModel(this.serverDB, this.userId, this.workspaceId);
-      const topic = await topicModel.findById(this.topicId);
-      const marker = topic?.metadata?.runningOperation;
-      const markedOperationId = marker?.operationId;
-      const isChild = marker?.childOperations?.some(
-        (child) => child.operationId === this.operationId,
-      );
-      // No mark (already cleared) or someone else's mark — nothing of ours to drop.
-      if (!markedOperationId || (markedOperationId !== this.operationId && !isChild)) return;
-
-      await topicModel.takeRunningOperation(this.topicId, this.operationId!);
+      if (!this.operationId) return;
+      await topicModel.settleRunningOperation(this.topicId, this.operationId);
     } catch {
       // best-effort — swallow
     }

--- a/packages/database/src/models/__tests__/topic.test.ts
+++ b/packages/database/src/models/__tests__/topic.test.ts
@@ -621,6 +621,58 @@ describe('TopicModel', () => {
       expect(row?.status).toBe('active');
     });
 
+    it('lets the same client operation refine the server-settled status', async () => {
+      const topic = await topicModel.create({
+        metadata: {
+          runningOperation: { assistantMessageId: 'msg-old', operationId: 'op-old' },
+        },
+        title: 'server finish before client completion',
+      });
+      await topicModel.update(topic.id, { status: 'running' });
+
+      await topicModel.settleRunningOperation(topic.id, 'op-old');
+      await topicModel.settleRunningOperation(topic.id, 'op-old', 'active');
+
+      const row = await topicModel.findById(topic.id);
+      expect(row?.metadata?.lastSettledOperationId).toBe('op-old');
+      expect(row?.metadata?.runningOperation).toBeNull();
+      expect(row?.status).toBe('active');
+    });
+
+    it('keeps a client-refined status when the server settlement retries', async () => {
+      const topic = await topicModel.create({
+        metadata: {
+          runningOperation: { assistantMessageId: 'msg-old', operationId: 'op-old' },
+        },
+        title: 'server settlement retry',
+      });
+      await topicModel.update(topic.id, { status: 'running' });
+
+      await topicModel.settleRunningOperation(topic.id, 'op-old');
+      await topicModel.settleRunningOperation(topic.id, 'op-old', 'active');
+      await topicModel.settleRunningOperation(topic.id, 'op-old');
+
+      const row = await topicModel.findById(topic.id);
+      expect(row?.status).toBe('active');
+    });
+
+    it('does not let an older settled operation overwrite the latest terminal status', async () => {
+      const topic = await topicModel.create({
+        metadata: {
+          lastSettledOperationId: 'op-new',
+          runningOperation: null,
+        },
+        status: 'unread',
+        title: 'newer operation already settled',
+      });
+
+      await topicModel.settleRunningOperation(topic.id, 'op-old', 'active');
+
+      const row = await topicModel.findById(topic.id);
+      expect(row?.metadata?.lastSettledOperationId).toBe('op-new');
+      expect(row?.status).toBe('unread');
+    });
+
     it('atomically removes only a matching child operation', async () => {
       const childHooks = [
         {

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -1326,9 +1326,10 @@ export class TopicModel {
   /**
    * Atomically clear and settle the operation that still owns a topic.
    * A row lock keeps a stale terminal callback from clearing a newer operation
-   * between the ownership check and update. Missing markers are intentionally
-   * not settled because a client-side run can set `status = 'running'` without
-   * an operation marker, so there is no proof that the terminal callback owns it.
+   * between the ownership check and update. A missing marker can only refine
+   * the terminal status when `lastSettledOperationId` proves the same operation
+   * already settled it; otherwise it remains untouched because an unmarked
+   * client-side run provides no ownership proof.
    *
    * The result distinguishes a missing marker from a conflicting operation:
    * some legitimate hetero callbacks arrive after another terminal path has
@@ -1338,7 +1339,7 @@ export class TopicModel {
   settleRunningOperation = async (
     id: string,
     operationId: string,
-    status: TopicItem['status'] = 'unread',
+    status?: TopicItem['status'],
   ) => {
     return this.db.transaction(async (tx) => {
       const [existing] = await tx
@@ -1350,6 +1351,16 @@ export class TopicModel {
       const runningOperation = existing?.metadata?.runningOperation;
       if (!runningOperation) {
         const currentMessage = existing?.metadata?.heteroCurrentMsgId;
+        if (
+          existing?.metadata?.lastSettledOperationId === operationId &&
+          existing.status !== 'running' &&
+          status
+        ) {
+          await tx
+            .update(topics)
+            .set({ status, updatedAt: new Date() })
+            .where(and(eq(topics.id, id), this.ownership()));
+        }
         return {
           assistantMessageId:
             currentMessage?.operationId === operationId ? currentMessage.msgId : undefined,
@@ -1366,6 +1377,7 @@ export class TopicModel {
 
       const metadata = {
         ...existing.metadata,
+        ...(isRoot ? { lastSettledOperationId: operationId } : {}),
         runningOperation: isRoot
           ? null
           : {
@@ -1380,7 +1392,7 @@ export class TopicModel {
         .update(topics)
         .set({
           metadata,
-          ...(isRoot && existing.status === 'running' ? { status } : {}),
+          ...(isRoot && existing.status === 'running' ? { status: status ?? 'unread' } : {}),
           updatedAt: new Date(),
         })
         .where(and(eq(topics.id, id), this.ownership()));

--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -118,8 +118,6 @@ export interface ChatTopicMetadata {
     summarizedAt: string;
     version: number;
   };
-  /** Restored-history tail used as the source message for eval attempt threads. */
-  evalHistoryTailMessageId?: string;
   bot?: ChatTopicBotContext;
   boundDeviceId?: string;
   cronJobId?: string;
@@ -145,6 +143,8 @@ export interface ChatTopicMetadata {
    * written without it can never be attributed afterwards.
    */
   editingGroupId?: string;
+  /** Restored-history tail used as the source message for eval attempt threads. */
+  evalHistoryTailMessageId?: string;
   /**
    * Scoped pointer to the currently active assistant message for a running
    * heterogeneous agent operation. Includes `operationId` so cold-start
@@ -195,6 +195,13 @@ export interface ChatTopicMetadata {
   heteroSourceEndAt?: string;
   /** origin marker for imported topics, e.g. `claude-code-local` / `codex-local` */
   importedFrom?: string;
+  /**
+   * Operation that most recently cleared `runningOperation` while settling the
+   * topic. This is an idempotency/ownership token for a renderer whose terminal
+   * callback arrives after the server-side finish path; it is not a reconnect
+   * marker and must never make a topic look running.
+   */
+  lastSettledOperationId?: string;
   /**
    * Measured dominant model by token volume, written by the usage roll-up
    * (`topicUsage.recompute`). This is an analytics projection of "what actually
@@ -507,6 +514,7 @@ export const chatTopicMetadataUpdateSchema = z.object({
     .optional(),
   provider: z.string().optional(),
   repos: z.array(z.string()).optional(),
+  lastSettledOperationId: z.string().optional(),
   runningOperation: z
     .object({
       assistantMessageId: z.string(),


### PR DESCRIPTION
## Summary

- settle the server-side Gateway running marker and topic status in one operation-owned transaction
- retain a terminal ownership token so a late renderer callback can refine `unread` to `active`
- reject stale terminal callbacks after a newer operation starts or settles
- preserve child-operation ownership without clearing the parent reconnect marker

## Tests

- `bun run check packages/types/src/topic/topic.ts packages/database/src/models/topic.ts packages/database/src/models/__tests__/topic.test.ts apps/server/src/modules/AgentRuntime/adapters/ServerOperationStore.ts apps/server/src/modules/AgentRuntime/adapters/ServerOperationStore.test.ts` (79 passed)
- `bun run check --type` passed in the primary workspace; the isolated canary worktree could not complete it because reused pnpm links resolved workspace packages from two different worktrees

Fixes LOBE-13441