### PR TITLE
🐛 fix(agent): resume parked parent operation after a callAgent hetero child completes

### DIFF
--- a/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
@@ -1443,7 +1443,11 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
       expect(call?.[1]).not.toHaveProperty('mirrorToOperationId');
     });
 
-    it('does not clobber the topic running-operation marker for an isolation-thread child', async () => {
+    it('nests an isolation-thread child under the parent marker instead of claiming topic root', async () => {
+      // heteroIngest/heteroFinish resolve an operationId via
+      // topic.metadata.runningOperation (root or childOperations) — a plain
+      // updateMetadata() here would clobber the parent's own root marker
+      // instead of nesting under it.
       await service.execAgent({
         agentId: 'agent-1',
         appContext: { isolationThread: true, topicId: 'topic-1' },
@@ -1451,7 +1455,28 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
         prompt: 'do the task as a callAgent child',
       } as any);
 
+      expect(topicMock.appendRunningOperationChild).toHaveBeenCalledWith(
+        'topic-1',
+        'parent-operation',
+        expect.objectContaining({ operationId: expect.stringContaining('op_') }),
+      );
+      // Not claimed as the topic's own root marker.
       expect(findRunningOpSeed()).toBeUndefined();
+    });
+
+    it('falls back to claiming the topic marker when the parent is not the current root (e.g. nested isolation chain)', async () => {
+      topicMock.appendRunningOperationChild.mockResolvedValueOnce(false);
+
+      await service.execAgent({
+        agentId: 'agent-1',
+        appContext: { isolationThread: true, topicId: 'topic-1' },
+        parentOperationId: 'parent-operation',
+        prompt: 'do the task as a callAgent child',
+      } as any);
+
+      // Otherwise this child would never be recognized by
+      // heteroIngest/heteroFinish at all.
+      expect(findRunningOpSeed()).toBeDefined();
     });
   });
 });

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
@@ -1418,5 +1418,40 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
 
       expect(mockExecuteToolCall).not.toHaveBeenCalled();
     });
+
+    // Regression guard for LOBE-13477: a callAgent/callSubAgent-spawned hetero
+    // child (isolation-thread, no topicStartOwnerOperationId) must still get
+    // its userId/workspaceId written to the state-manager metadata store —
+    // subAgentCallback reads it to authorize resuming the parked parent
+    // operation. Without it, the completion webhook 401s, the parent is
+    // never resumed, and it stays parked until the inactivity watchdog
+    // abandons it ~10 minutes later.
+    it('persists userId/workspaceId metadata for a callAgent-spawned hetero child', async () => {
+      await service.execAgent({
+        agentId: 'agent-1',
+        appContext: { isolationThread: true, topicId: 'topic-1' },
+        parentOperationId: 'parent-operation',
+        prompt: 'do the task as a callAgent child',
+      } as any);
+
+      const call = mockCreateOperationMetadata.mock.calls.find(
+        ([, data]) => data.userId === 'test-user-id',
+      );
+      expect(call).toBeDefined();
+      // No topic-owner mirror target on this path — mirrorToOperationId must
+      // stay unset rather than being derived from parentOperationId.
+      expect(call?.[1]).not.toHaveProperty('mirrorToOperationId');
+    });
+
+    it('does not clobber the topic running-operation marker for an isolation-thread child', async () => {
+      await service.execAgent({
+        agentId: 'agent-1',
+        appContext: { isolationThread: true, topicId: 'topic-1' },
+        parentOperationId: 'parent-operation',
+        prompt: 'do the task as a callAgent child',
+      } as any);
+
+      expect(findRunningOpSeed()).toBeUndefined();
+    });
   });
 });

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -2591,13 +2591,30 @@ export class AiAgentService {
             userMessageId: userMessageRecord?.id ?? parentMessageId ?? '',
           };
         }
-      } else if (!appContext?.isolationThread) {
+      } else if (appContext?.isolationThread && parentOperationId) {
         // Isolation-thread children (callAgent / callSubAgent) run on the
-        // SPAWNER's topic and finish long before it does — see the parity
-        // comment on the standard (non-hetero) branch below. Claiming the
-        // topic-level marker here would clobber the parent's own marker and
-        // then null it out again once this child settles, even though the
-        // parent operation is still running.
+        // SPAWNER's topic and finish long before it does. heteroIngest and
+        // heteroFinish both require this child's operationId to resolve via
+        // topic.metadata.runningOperation (root or childOperations) — see
+        // the comment above childOperation — or every streamed batch is
+        // dropped as stale and the terminal onComplete hooks (including the
+        // callAgent resume bridge) never fire. Nest under the parent's own
+        // marker instead of claiming the topic-level root outright, so the
+        // parent's marker survives for the rest of its still-running turn.
+        const attachedToParent = await this.topicModel.appendRunningOperationChild(
+          topicId,
+          parentOperationId,
+          childOperation,
+        );
+        if (!attachedToParent) {
+          // Parent isn't (or is no longer) the topic's current root marker —
+          // e.g. a nested isolation chain, or the parent already settled.
+          // Fall back to claiming the marker directly so this child is still
+          // discoverable by its own operationId, rather than permanently
+          // unrecognized by heteroIngest/heteroFinish.
+          await this.topicModel.updateMetadata(topicId, { runningOperation: childOperation });
+        }
+      } else if (!appContext?.isolationThread) {
         await this.topicModel.updateMetadata(topicId, { runningOperation: childOperation });
       }
 

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -2591,20 +2591,35 @@ export class AiAgentService {
             userMessageId: userMessageRecord?.id ?? parentMessageId ?? '',
           };
         }
-      } else {
+      } else if (!appContext?.isolationThread) {
+        // Isolation-thread children (callAgent / callSubAgent) run on the
+        // SPAWNER's topic and finish long before it does — see the parity
+        // comment on the standard (non-hetero) branch below. Claiming the
+        // topic-level marker here would clobber the parent's own marker and
+        // then null it out again once this child settles, even though the
+        // parent operation is still running.
         await this.topicModel.updateMetadata(topicId, { runningOperation: childOperation });
       }
 
-      const persistMirrorTarget = async () => {
-        if (!params.topicStartOwnerOperationId) return;
+      // Always persist operation metadata (userId/workspaceId) to the state
+      // manager, not just for topic-owner-mirrored runs. `subAgentCallback`
+      // (the QStash-delivered completion bridge for callAgent/callSubAgent
+      // children) resolves `userId` from this same store to authorize
+      // resuming the parent — without it, a hetero child spawned via
+      // callAgent has no metadata row, the callback 401s, and the parent
+      // operation is never resumed (stays parked until the inactivity
+      // watchdog abandons it).
+      const persistOperationMetadata = async () => {
         try {
           await createAgentStateManager().createOperationMetadata(operationId, {
-            mirrorToOperationId: params.topicStartOwnerOperationId,
+            ...(params.topicStartOwnerOperationId && {
+              mirrorToOperationId: params.topicStartOwnerOperationId,
+            }),
             userId: this.userId,
             workspaceId: this.workspaceId,
           });
         } catch (err) {
-          log('execAgent: failed to persist hetero mirror target: %O', err);
+          log('execAgent: failed to persist hetero operation metadata: %O', err);
         }
       };
 
@@ -2698,7 +2713,7 @@ export class AiAgentService {
 
         // Open the stream channel so the gateway WS subscription can receive
         // notify_update events published by agentNotify.notify.
-        await persistMirrorTarget();
+        await persistOperationMetadata();
         const streamManager = createStreamEventManager();
         await streamManager
           .publishAgentRuntimeInit(operationId, {
@@ -2801,7 +2816,7 @@ export class AiAgentService {
         // the init only powers reconnect, not the run. `createStreamEventManager`
         // probes Redis synchronously, so guard construction too, not just publish.
         try {
-          await persistMirrorTarget();
+          await persistOperationMetadata();
           await createStreamEventManager().publishAgentRuntimeInit(operationId, {
             agentId: resolvedAgentId,
             assistantMessageId: assistantMessageRecord.id,


### PR DESCRIPTION
<!-- Brief and heads-up -->

A `callAgent`/`callSubAgent`-spawned heterogeneous sub-agent (isolation-thread, no `topicStartOwnerOperationId`) never got its `userId`/`workspaceId` persisted to the state-manager metadata store, because `persistMirrorTarget()` gated the entire write behind `topicStartOwnerOperationId`, which only the in-group member path sets.

Without that metadata, `subAgentCallback`'s auth check (`metadata?.userId`) always 401s on the child's completion webhook, so `completeSubAgentBridge`/`tryResumeParentFromAsyncTool` never runs and the parent operation stays parked — until the inactivity watchdog abandons it ~10 minutes later — even though the child finished successfully in seconds. Confirmed against a real production incident: the child `agent_operations` row shows `status: done` after 23s, while the parent row shows `status: error, error: "Operation abandoned: inactivity_watchdog"` ~10 minutes later.

Also fixes a related bug in the same branch: it was missing the `!appContext?.isolationThread` guard the standard (non-hetero) branch already has, so it unconditionally overwrote `topic.metadata.runningOperation` for isolation-thread children instead of leaving the still-running parent's marker alone.

#### Test

- [x] Added/updated tests
- [ ] Tested locally (no repro environment for the live hetero dispatch + QStash webhook chain; verified via the new regression tests, which fail without the fix and pass with it — see commit)

#### 🔗 Related Issue

Fixes LOBE-13477