### PR TITLE
🔒 fix: gate beta LobeHub models in the model picker and text chat

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/aiModel.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiModel.test.ts
@@ -1,15 +1,21 @@
+import { BRANDING_PROVIDER } from '@lobechat/business-const';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AiModelModel } from '@/database/models/aiModel';
+import { UserModel } from '@/database/models/user';
 import { AiInfraRepos } from '@/database/repositories/aiInfra';
 
 import { aiModelRouter } from '../aiModel';
 
 const mockGetHiddenBuiltinModelsForUser = vi.hoisted(() => vi.fn());
+const mockIsLobeHubModelAvailable = vi.hoisted(() => vi.fn());
 
 vi.mock('@/business/server/aiProvider', () => ({
   getHiddenBuiltinModelsForUser: mockGetHiddenBuiltinModelsForUser,
   getModelRedirects: vi.fn(async () => ({})),
+}));
+vi.mock('@lobechat/business-model-bank/model-config', () => ({
+  isLobeHubModelAvailable: mockIsLobeHubModelAvailable,
 }));
 vi.mock('@/database/models/aiModel');
 vi.mock('@/database/models/user');
@@ -36,6 +42,7 @@ describe('aiModelRouter', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetHiddenBuiltinModelsForUser.mockResolvedValue([]);
+    mockIsLobeHubModelAvailable.mockResolvedValue(true);
   });
 
   it('should create ai model', async () => {
@@ -162,6 +169,35 @@ describe('aiModelRouter', () => {
       enabled: undefined,
       limit: undefined,
       offset: undefined,
+    });
+    expect(mockIsLobeHubModelAvailable).not.toHaveBeenCalled();
+  });
+
+  it('should filter out beta-gated LobeHub models the user is not authorized for', async () => {
+    const mockModelList = [
+      { id: 'model-1', type: 'chat' },
+      { id: 'model-2-beta', type: 'chat' },
+    ];
+    const mockGetList = vi.fn().mockResolvedValue(mockModelList);
+    vi.mocked(AiInfraRepos).mockImplementation(
+      () =>
+        ({
+          getAiProviderModelList: mockGetList,
+        }) as any,
+    );
+    vi.mocked(UserModel.findById).mockResolvedValue({ email: 'user@example.com' } as any);
+    mockIsLobeHubModelAvailable.mockImplementation(async (id: string) => id !== 'model-2-beta');
+
+    const caller = aiModelRouter.createCaller(mockCtx);
+
+    const result = await caller.getAiProviderModelList({ id: BRANDING_PROVIDER });
+
+    expect(result).toEqual([{ id: 'model-1', type: 'chat' }]);
+    expect(mockIsLobeHubModelAvailable).toHaveBeenCalledWith('model-1', 'chat', {
+      userEmail: 'user@example.com',
+    });
+    expect(mockIsLobeHubModelAvailable).toHaveBeenCalledWith('model-2-beta', 'chat', {
+      userEmail: 'user@example.com',
     });
   });
 

--- a/apps/server/src/routers/lambda/aiModel.ts
+++ b/apps/server/src/routers/lambda/aiModel.ts
@@ -1,3 +1,5 @@
+import { BRANDING_PROVIDER } from '@lobechat/business-const';
+import { isLobeHubModelAvailable } from '@lobechat/business-model-bank/model-config';
 import { TRPCError } from '@trpc/server';
 import { type AiProviderModelListItem } from 'model-bank';
 import {
@@ -190,9 +192,25 @@ export const aiModelRouter = router({
         type: input.type,
       };
 
-      return getUserScopedAiProviderModelList(ctx.userId, input.id, options, (scopedOptions) =>
-        ctx.aiInfraRepos.getAiProviderModelList(input.id, scopedOptions),
+      const models = await getUserScopedAiProviderModelList(
+        ctx.userId,
+        input.id,
+        options,
+        (scopedOptions) => ctx.aiInfraRepos.getAiProviderModelList(input.id, scopedOptions),
       );
+
+      // Beta-gated LobeHub models (see isLobeHubModelAvailable) must not appear
+      // in an ungranted user's picker at all — not just be blocked at send time,
+      // the way createImage/createVideo already gate on the same function. Scoped
+      // to the branded provider only; every other provider's list is untouched.
+      if (input.id !== BRANDING_PROVIDER) return models;
+
+      const userEmail = (await UserModel.findById(ctx.serverDB, ctx.userId))?.email;
+      const availability = await Promise.all(
+        models.map((model) => isLobeHubModelAvailable(model.id, model.type, { userEmail })),
+      );
+
+      return models.filter((_, index) => availability[index]);
     }),
 
   removeAiModel: aiModelProcedure

--- a/src/app/(backend)/webapi/chat/[provider]/route.test.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.test.ts
@@ -1,13 +1,17 @@
 // @vitest-environment node
+import { BRANDING_PROVIDER } from '@lobechat/business-const';
 import { type LobeRuntimeAI } from '@lobechat/model-runtime';
 import { ModelRuntime } from '@lobechat/model-runtime';
 import { ChatErrorType } from '@lobechat/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { auth } from '@/auth';
+import { UserModel } from '@/database/models/user';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
 
 import { POST } from './route';
+
+const mockIsLobeHubModelAvailable = vi.hoisted(() => vi.fn());
 
 vi.mock('@/app/(backend)/middleware/auth/utils', () => ({
   checkAuthMethod: vi.fn(),
@@ -26,6 +30,14 @@ vi.mock('@/auth', () => ({
   },
 }));
 
+vi.mock('@/database/models/user', () => ({
+  UserModel: { findById: vi.fn() },
+}));
+
+vi.mock('@lobechat/business-model-bank/model-config', () => ({
+  isLobeHubModelAvailable: mockIsLobeHubModelAvailable,
+}));
+
 // 模拟请求和响应
 let request: Request;
 beforeEach(() => {
@@ -39,6 +51,8 @@ beforeEach(() => {
     session: {} as any,
     user: { id: 'test-user-id' } as any,
   });
+
+  mockIsLobeHubModelAvailable.mockResolvedValue(true);
 });
 
 afterEach(() => {
@@ -103,6 +117,12 @@ describe('POST handler', () => {
       expect(response).toEqual(mockChatResponse);
       expect(mockRuntime.chat).toHaveBeenCalledWith(mockChatPayload, {
         user: 'test-user-id',
+        metadata: {
+          provider: 'test-provider',
+          sessionId: undefined,
+          topicId: undefined,
+          trigger: 'chat',
+        },
         signal: expect.anything(),
       });
     });
@@ -142,6 +162,55 @@ describe('POST handler', () => {
         },
         errorType: 500,
       });
+    });
+
+    it('should reject a beta-gated LobeHub model the user is not authorized for', async () => {
+      const mockParams = Promise.resolve({ provider: BRANDING_PROVIDER });
+      request = new Request(new URL('https://test.com'), {
+        method: 'POST',
+        body: JSON.stringify({ model: 'beta-model' }),
+      });
+
+      vi.mocked(UserModel.findById).mockResolvedValue({ email: 'user@example.com' } as any);
+      mockIsLobeHubModelAvailable.mockResolvedValue(false);
+
+      const mockRuntime: LobeRuntimeAI = { baseURL: 'abc', chat: vi.fn() };
+      vi.mocked(initModelRuntimeFromDB).mockResolvedValue(new ModelRuntime(mockRuntime));
+
+      const response = await POST(request as unknown as Request, { params: mockParams });
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        body: {
+          error: { modelType: 'chat', requestedModel: 'beta-model' },
+          provider: BRANDING_PROVIDER,
+        },
+        errorType: ChatErrorType.LobeHubModelDeprecated,
+      });
+      expect(mockRuntime.chat).not.toHaveBeenCalled();
+      expect(mockIsLobeHubModelAvailable).toHaveBeenCalledWith('beta-model', 'chat', {
+        getUserEmail: expect.any(Function),
+      });
+    });
+
+    it('should not gate models for a provider other than the branded one', async () => {
+      const mockParams = Promise.resolve({ provider: 'test-provider' });
+      request = new Request(new URL('https://test.com'), {
+        method: 'POST',
+        body: JSON.stringify({ model: 'some-model' }),
+      });
+
+      const mockChatResponse: any = { success: true };
+      const mockRuntime: LobeRuntimeAI = {
+        baseURL: 'abc',
+        chat: vi.fn().mockResolvedValue(mockChatResponse),
+      };
+      vi.mocked(initModelRuntimeFromDB).mockResolvedValue(new ModelRuntime(mockRuntime));
+
+      const response = await POST(request as unknown as Request, { params: mockParams });
+
+      expect(response).toEqual(mockChatResponse);
+      expect(mockIsLobeHubModelAvailable).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -1,8 +1,11 @@
+import { BRANDING_PROVIDER } from '@lobechat/business-const';
+import { isLobeHubModelAvailable } from '@lobechat/business-model-bank/model-config';
 import { type ChatCompletionErrorPayload } from '@lobechat/model-runtime';
 import { AGENT_RUNTIME_ERROR_SET } from '@lobechat/model-runtime';
 import { ChatErrorType, RequestTrigger } from '@lobechat/types';
 
 import { checkAuth } from '@/app/(backend)/middleware/auth';
+import { UserModel } from '@/database/models/user';
 import { createTraceOptions, initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
 import { type ChatStreamPayload } from '@/types/openai/chat';
 import { createErrorResponse } from '@/utils/errorResponse';
@@ -26,6 +29,22 @@ export const POST = checkAuth(async (req: Request, { params, userId, serverDB })
     // ============  2. create chat completion   ============ //
 
     const data = (await req.json()) as ChatStreamPayload;
+
+    // Same gate createImage/createVideo already apply for beta-gated LobeHub
+    // models (see isLobeHubModelAvailable) — text chat was the one invocation
+    // path that never checked it, so a model hidden from the picker could still
+    // be reached by sending its id directly.
+    if (
+      provider === BRANDING_PROVIDER &&
+      !(await isLobeHubModelAvailable(data.model, 'chat', {
+        getUserEmail: async () => (await UserModel.findById(serverDB, userId))?.email,
+      }))
+    ) {
+      return createErrorResponse(ChatErrorType.LobeHubModelDeprecated, {
+        error: { modelType: 'chat', requestedModel: data.model },
+        provider,
+      });
+    }
 
     const tracePayload = getTracePayload(req);
 


### PR DESCRIPTION
## Summary

The client wants specific users to get access to certain new "overseas" models while everyone else only sees ordinary models. That mechanism already exists (`betaModels`/`betaModelUsers` on the admin-managed model config + `isLobeHubModelAvailable`) and is already fully built on the admin side (`BetaAccessPanel`), but on the chat-app side it was only wired into `createImage`/`createVideo` — not into the model list or text chat.

- **`getAiProviderModelList`** (the model picker's data source): now filters out beta-gated models the current user isn't authorized for, scoped to `BRANDING_PROVIDER` only. Previously an ungranted user could see and select the model; it would only fail once they tried to generate an image/video with it (and not fail at all for text chat — see next point).
- **Text chat completion route** (`webapi/chat/[provider]`): had no gate at all. A beta model was invocable by sending its id directly, regardless of grant.
- Drive-by: fixed a pre-existing test/code mismatch in `route.test.ts` — an earlier canary sync added a `metadata` field to the `chat()` call that the assertion never picked up. Confirmed via `git stash` that this failure predates this branch.

## Test plan

- [x] `bun run check` on all 4 changed files — lint clean, 22 tests passed
- [x] New tests: model list filters out an unauthorized beta model and keeps an authorized one (asserts `isLobeHubModelAvailable` args exactly); non-branded providers are untouched (`isLobeHubModelAvailable` not called)
- [x] New tests: chat route rejects an unauthorized beta model with `LobeHubModelDeprecated` (400) without invoking the runtime; non-branded providers are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)