### PR TITLE
🐛 fix(heterogeneous-agent): handle Windows Claude SDK shims

### DIFF
--- a/packages/heterogeneous-agents/src/spawn/claudeAgentSdkSession.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/claudeAgentSdkSession.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resolveClaudeSdkExecutablePath } from './claudeAgentSdkSession';
+
+const resolveCliSpawnPlanMock = vi.hoisted(() => vi.fn());
+
+vi.mock('./cliSpawn', () => ({ resolveCliSpawnPlan: resolveCliSpawnPlanMock }));
+
+describe('resolveClaudeSdkExecutablePath', () => {
+  beforeEach(() => {
+    resolveCliSpawnPlanMock.mockReset();
+  });
+
+  it.each(['C:\\Users\\user\\AppData\\Roaming\\npm\\claude.cmd', 'C:\\tools\\claude.BAT'])(
+    'unwraps a Windows Node shim for the Agent SDK: %s',
+    async (commandPath) => {
+      const scriptPath =
+        'C:\\Users\\user\\AppData\\Roaming\\npm\\node_modules\\@anthropic-ai\\claude-code\\cli.js';
+      resolveCliSpawnPlanMock.mockResolvedValue({
+        args: [scriptPath],
+        command: 'C:\\Program Files\\nodejs\\node.exe',
+      });
+
+      await expect(resolveClaudeSdkExecutablePath(commandPath, process.env, 'win32')).resolves.toBe(
+        scriptPath,
+      );
+      expect(resolveCliSpawnPlanMock).toHaveBeenCalledWith(commandPath, [], process.env);
+    },
+  );
+
+  it('uses a native executable targeted by a Windows shim', async () => {
+    const commandPath = 'C:\\tools\\claude.cmd';
+    const executablePath = 'C:\\tools\\claude.exe';
+    resolveCliSpawnPlanMock.mockResolvedValue({ args: [], command: executablePath });
+
+    await expect(resolveClaudeSdkExecutablePath(commandPath, process.env, 'win32')).resolves.toBe(
+      executablePath,
+    );
+  });
+
+  it('reports an unresolved Windows shim before the SDK tries to spawn it', async () => {
+    const commandPath = 'C:\\tools\\claude.cmd';
+    resolveCliSpawnPlanMock.mockResolvedValue({ args: [], command: commandPath });
+
+    await expect(resolveClaudeSdkExecutablePath(commandPath, process.env, 'win32')).rejects.toThrow(
+      'Unable to resolve the Claude Code Windows shim',
+    );
+  });
+
+  it('keeps a native Windows executable', async () => {
+    const commandPath = 'C:\\tools\\claude.exe';
+
+    await expect(resolveClaudeSdkExecutablePath(commandPath, process.env, 'win32')).resolves.toBe(
+      commandPath,
+    );
+    expect(resolveCliSpawnPlanMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps the detected executable on other platforms', async () => {
+    const commandPath = '/opt/homebrew/bin/claude';
+
+    await expect(resolveClaudeSdkExecutablePath(commandPath, process.env, 'darwin')).resolves.toBe(
+      commandPath,
+    );
+    expect(resolveCliSpawnPlanMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/heterogeneous-agents/src/spawn/claudeAgentSdkSession.ts
+++ b/packages/heterogeneous-agents/src/spawn/claudeAgentSdkSession.ts
@@ -7,6 +7,7 @@ import type {
 import type { AgentStreamEvent } from '@lobechat/agent-gateway-client';
 
 import { AgentStreamPipeline, type UploadHeterogeneousImage } from './agentStreamPipeline';
+import { resolveCliSpawnPlan } from './cliSpawn';
 
 const CLAUDE_SDK_DISALLOWED_TOOLS = ['AskUserQuestion', 'Monitor', 'ScheduleWakeup'] as const;
 const DEFAULT_INACTIVITY_TIMEOUT_MS = 5 * 60 * 1000;
@@ -24,6 +25,24 @@ const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve,
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
+
+export const resolveClaudeSdkExecutablePath = async (
+  commandPath: string,
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform = process.platform,
+): Promise<string> => {
+  if (platform !== 'win32' || !/\.(?:bat|cmd)$/i.test(commandPath)) return commandPath;
+
+  // The Agent SDK spawns native paths directly and runs JavaScript paths with
+  // Node. Reuse the CLI launcher's shell-free shim parser so a detected npm
+  // wrapper becomes its real `cli.js`, which packaged builds can still access.
+  const spawnPlan = await resolveCliSpawnPlan(commandPath, [], env);
+  if (spawnPlan.command === commandPath) {
+    throw new Error(`Unable to resolve the Claude Code Windows shim: ${commandPath}`);
+  }
+
+  return spawnPlan.args[0] ?? spawnPlan.command;
+};
 
 const hasContentMessage = (value: unknown): value is SDKUserMessage => {
   if (!isObject(value)) return false;
@@ -170,7 +189,7 @@ export class ClaudeAgentSdkSession {
       const userMessage = buildClaudeSdkUserMessageFromStreamJson(this.options.stdinPayload);
 
       this.queryHandle = query({
-        options: this.buildQueryOptions(),
+        options: await this.buildQueryOptions(),
         prompt: this.createInputStream(userMessage),
       });
 
@@ -217,8 +236,12 @@ export class ClaudeAgentSdkSession {
     this.queryHandle?.close();
   }
 
-  private buildQueryOptions(): ClaudeAgentSdkOptions {
+  private async buildQueryOptions(): Promise<ClaudeAgentSdkOptions> {
     const argOptions = parseClaudeSdkExtraArgs(this.options.args);
+    const executablePath = await resolveClaudeSdkExecutablePath(
+      this.options.commandPath,
+      this.options.env,
+    );
 
     return {
       allowDangerouslySkipPermissions: true,
@@ -227,7 +250,7 @@ export class ClaudeAgentSdkSession {
       disallowedTools: [...CLAUDE_SDK_DISALLOWED_TOOLS],
       env: this.options.env,
       includePartialMessages: true,
-      pathToClaudeCodeExecutable: this.options.commandPath,
+      pathToClaudeCodeExecutable: executablePath,
       permissionMode: 'bypassPermissions',
       ...(this.options.resumeSessionId ? { resume: this.options.resumeSessionId } : {}),
       ...argOptions,


### PR DESCRIPTION
## Summary

- unwrap Windows npm `.cmd`/`.bat` shims with the existing shell-free `resolveCliSpawnPlan` path before invoking the Claude Agent SDK
- pass the resolved `cli.js` (which the SDK runs through Node) or native `.exe` instead of asking `spawn` to execute a batch file
- keep native Windows executables and non-Windows command paths unchanged, and report unsupported shim shapes before launch

This uses the user's validated Claude Code installation, so the packaged desktop app does not depend on the Agent SDK's optional native CLI being present inside the app bundle.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```text
cd packages/heterogeneous-agents && bunx vitest run
# 53 test files passed · 838 tests passed

bunx vitest run src/spawn/claudeAgentSdkSession.test.ts src/spawn/cliSpawn.test.ts
# 2 test files passed · 20 tests passed

bun run type-check
# types clean

bunx eslint packages/heterogeneous-agents/src/spawn/claudeAgentSdkSession.ts packages/heterogeneous-agents/src/spawn/claudeAgentSdkSession.test.ts
bunx prettier --check packages/heterogeneous-agents/src/spawn/claudeAgentSdkSession.ts packages/heterogeneous-agents/src/spawn/claudeAgentSdkSession.test.ts
# lint and formatting clean
```

#### 🔗 Related Issue

Fixes #18493
