### PR TITLE
🐛 fix(chat): settle Gateway topics when the runtime ends

### DIFF
--- a/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
@@ -27,7 +27,7 @@ vi.mock('@/services/message', () => ({
 
 vi.mock('@/services/topic', () => ({
   topicService: {
-    settleRunningOperation: vi.fn().mockResolvedValue(undefined),
+    settleRunningOperation: vi.fn().mockResolvedValue({ status: 'settled' }),
     updateTopicMetadata: vi.fn().mockResolvedValue(undefined),
   },
 }));
@@ -168,7 +168,9 @@ function createTestAction() {
 describe('GatewayActionImpl', () => {
   beforeEach(() => {
     moveChatContextSelections.mockClear();
-    vi.mocked(topicService.settleRunningOperation).mockResolvedValue(undefined as never);
+    vi.mocked(topicService.settleRunningOperation).mockResolvedValue({
+      status: 'settled',
+    } as never);
     mockAgentStore.state = { activeAgentId: undefined, agentMap: {} };
     mockUserDefaultConfig.disableGatewayMode = undefined;
     mockToolInterventionConfig.approvalMode = 'manual';
@@ -1243,17 +1245,18 @@ describe('GatewayActionImpl', () => {
       const { onSessionComplete } = connectToGateway.mock.calls[0][0];
       // Ignore any dispatches from the optimistic-update path during setup.
       internalDispatchTopic.mockClear();
-      vi.mocked(topicService.updateTopicMetadata).mockResolvedValue(undefined as never);
-
       onSessionComplete({ succeeded: false, terminalReceived: true });
 
-      expect(internalDispatchTopic).toHaveBeenCalledWith({
-        agentId: 'agent-1',
-        groupId: undefined,
-        id: 'topic-1',
-        type: 'updateTopic',
-        value: { metadata: { model: 'gpt-4', runningOperation: null } },
-      });
+      await vi.waitFor(() =>
+        expect(internalDispatchTopic).toHaveBeenCalledWith({
+          agentId: 'agent-1',
+          groupId: undefined,
+          id: 'topic-1',
+          scope: undefined,
+          type: 'updateTopic',
+          value: { metadata: { model: 'gpt-4', runningOperation: null }, status: 'active' },
+        }),
+      );
     });
 
     // Background completion: the run's owning agent bucket must be targeted even
@@ -1330,21 +1333,22 @@ describe('GatewayActionImpl', () => {
 
       const { onSessionComplete } = connectToGateway.mock.calls[0][0];
       internalDispatchTopic.mockClear();
-      vi.mocked(topicService.updateTopicMetadata).mockResolvedValue(undefined as never);
-
       // The user switched away before the run finished in the background.
       state.activeAgentId = 'agent-2';
       state.activeTopicId = null;
 
       onSessionComplete({ succeeded: false, terminalReceived: true });
 
-      expect(internalDispatchTopic).toHaveBeenCalledWith({
-        agentId: 'agent-1',
-        groupId: undefined,
-        id: 'topic-1',
-        type: 'updateTopic',
-        value: { metadata: { model: 'gpt-4', runningOperation: null } },
-      });
+      await vi.waitFor(() =>
+        expect(internalDispatchTopic).toHaveBeenCalledWith({
+          agentId: 'agent-1',
+          groupId: undefined,
+          id: 'topic-1',
+          scope: undefined,
+          type: 'updateTopic',
+          value: { metadata: { model: 'gpt-4', runningOperation: null }, status: 'active' },
+        }),
+      );
     });
 
     // A late close may observe a stale local marker even after another tab has
@@ -1425,7 +1429,9 @@ describe('GatewayActionImpl', () => {
       internalDispatchTopic.mockClear();
       updateTopicStatus.mockClear();
       vi.mocked(topicService.settleRunningOperation).mockClear();
-      vi.mocked(topicService.settleRunningOperation).mockResolvedValue(undefined as never);
+      vi.mocked(topicService.settleRunningOperation).mockResolvedValue({
+        status: 'conflict',
+      } as never);
 
       onSessionComplete({ succeeded: false, terminalReceived: true });
 
@@ -1827,17 +1833,19 @@ describe('GatewayActionImpl', () => {
         topicId: 'topic-1',
       });
 
-      vi.mocked(topicService.updateTopicMetadata)
-        .mockClear()
-        .mockResolvedValue(undefined as never);
+      vi.mocked(topicService.settleRunningOperation).mockClear();
       captured.onSessionComplete!({ authFailed: false, succeeded: true, terminalReceived: true });
 
       // The run lifecycle owns completion when a terminal event arrives, so the
       // reconnect path must not double-complete its local op here.
       expect(completeOperation).not.toHaveBeenCalled();
-      expect(topicService.updateTopicMetadata).toHaveBeenCalledWith('topic-1', {
-        runningOperation: null,
-      });
+      await vi.waitFor(() =>
+        expect(topicService.settleRunningOperation).toHaveBeenCalledWith(
+          'topic-1',
+          'server-op-1',
+          'active',
+        ),
+      );
     });
 
     // auth_failed (or a failed token refresh) is authoritative that the op is
@@ -1853,15 +1861,17 @@ describe('GatewayActionImpl', () => {
         topicId: 'topic-1',
       });
 
-      vi.mocked(topicService.updateTopicMetadata)
-        .mockClear()
-        .mockResolvedValue(undefined as never);
+      vi.mocked(topicService.settleRunningOperation).mockClear();
       captured.onSessionComplete!({ authFailed: true, succeeded: false, terminalReceived: false });
 
       expect(completeOperation).toHaveBeenCalledWith('gw-op-reconnect');
-      expect(topicService.updateTopicMetadata).toHaveBeenCalledWith('topic-1', {
-        runningOperation: null,
-      });
+      await vi.waitFor(() =>
+        expect(topicService.settleRunningOperation).toHaveBeenCalledWith(
+          'topic-1',
+          'server-op-1',
+          'active',
+        ),
+      );
     });
 
     // Seeds a topic whose local metadata still carries a runningOperation, wires up
@@ -1983,16 +1993,18 @@ describe('GatewayActionImpl', () => {
       });
 
       internalDispatchTopic.mockClear();
-      vi.mocked(topicService.updateTopicMetadata).mockResolvedValue(undefined as never);
       captured.onSessionComplete!({ authFailed: false, succeeded: false, terminalReceived: true });
 
-      expect(internalDispatchTopic).toHaveBeenCalledWith({
-        agentId: 'agent-1',
-        groupId: undefined,
-        id: 'topic-1',
-        type: 'updateTopic',
-        value: { metadata: { model: 'gpt-4', runningOperation: null } },
-      });
+      await vi.waitFor(() =>
+        expect(internalDispatchTopic).toHaveBeenCalledWith({
+          agentId: 'agent-1',
+          groupId: undefined,
+          id: 'topic-1',
+          scope: undefined,
+          type: 'updateTopic',
+          value: { metadata: { model: 'gpt-4', runningOperation: null }, status: 'active' },
+        }),
+      );
     });
 
     // An ambiguous close (no terminal event, no auth failure) must NOT clear the

--- a/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
@@ -78,7 +78,11 @@ function createMockStore() {
 
 function createHandler(
   store: ReturnType<typeof createMockStore>,
-  overrides?: { assistantMessageId?: string; gatewayOperationId?: string },
+  overrides?: {
+    assistantMessageId?: string;
+    gatewayOperationId?: string;
+    onRunTerminal?: (event: { succeeded: boolean }) => Promise<void>;
+  },
 ) {
   const get = vi.fn(() => store) as any;
   const assistantMessageId = overrides?.assistantMessageId ?? 'msg-initial';
@@ -88,6 +92,7 @@ function createHandler(
     context,
     gatewayOperationId: overrides?.gatewayOperationId,
     operationId: 'op-1',
+    onRunTerminal: overrides?.onRunTerminal,
     // The gateway transport injects the shared run lifecycle (built once per run
     // in gateway.ts). Build the real one here so the terminal completeRun /
     // afterRunComplete path under test runs against the mock store.
@@ -1531,6 +1536,17 @@ describe('createGatewayEventHandler', () => {
       );
     });
 
+    it('settles the topic on agent_runtime_end without waiting for the Gateway session to close', async () => {
+      const store = createMockStore();
+      const onRunTerminal = vi.fn().mockResolvedValue(undefined);
+      const handler = createHandler(store, { onRunTerminal });
+
+      handler(makeEvent('agent_runtime_end'));
+      await flush();
+
+      expect(onRunTerminal).toHaveBeenCalledWith({ succeeded: true });
+    });
+
     it.each(['interrupted', 'waiting_for_async_tool'])(
       'agent_runtime_end with reason "%s" completes the op but does NOT mark unread (cancel/park)',
       async (reason) => {
@@ -1544,6 +1560,17 @@ describe('createGatewayEventHandler', () => {
         expect(store.markTopicUnread).not.toHaveBeenCalled();
       },
     );
+
+    it('settles an error terminal as unsuccessful without waiting for session close', async () => {
+      const store = createMockStore();
+      const onRunTerminal = vi.fn().mockResolvedValue(undefined);
+      const handler = createHandler(store, { onRunTerminal });
+
+      handler(makeEvent('error', { message: 'failed' }));
+      await flush();
+
+      expect(onRunTerminal).toHaveBeenCalledWith({ succeeded: false });
+    });
 
     // the agent_runtime_end handler completes the op once via
     // the shared run lifecycle, and gateway.ts onSessionComplete no longer

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -814,6 +814,13 @@ export class GatewayActionImpl {
       // the same WS that gatewayConnections is keyed on.
       gatewayOperationId: result.operationId,
       operationId: gatewayOpId,
+      onRunTerminal: ({ succeeded }) =>
+        this.settleTopicOperation({
+          context: resolvedMessageContext,
+          operationId: result.operationId,
+          succeeded,
+          topicId: result.topicId,
+        }),
       // Shared run lifecycle: drives the terminal completeRun / afterRunComplete
       // for the gateway transport (op completion + unread + queue drain +
       // notification) at `agent_runtime_end` / `error`.
@@ -849,30 +856,12 @@ export class GatewayActionImpl {
         // lifecycle on `agent_runtime_end` / `error`. Only complete here as the
         // terminal-missing fallback so the op never sticks `running`.
         if (!terminalReceived) this.#get().completeOperation(gatewayOpId);
-        if (result.topicId) {
-          // A clean completion the user isn't watching is owned by
-          // `markTopicUnread` (status: 'unread'). Every other case (viewing,
-          // error, abort) settles the running state back to 'active'. The server
-          // compares the operation id under the topic row lock so a late close
-          // from another tab cannot clear or settle a newer run.
-          const viewing = this.#get().activeTopicId === result.topicId;
-          topicService
-            .settleRunningOperation(
-              result.topicId,
-              result.operationId,
-              viewing || !succeeded ? 'active' : 'unread',
-            )
-            .catch(console.error);
-          // Also clear the local store copy — the server clear above does NOT touch
-          // the Zustand topic map that useGatewayReconnect reads. Ownership-guarded
-          // on its own, so it is safe to call either way.
-          this.clearLocalRunningOperation({
-            agentId: resolvedMessageContext.agentId,
-            groupId: resolvedMessageContext.groupId,
-            operationId: result.operationId,
-            topicId: result.topicId,
-          });
-        }
+        void this.settleTopicOperation({
+          context: resolvedMessageContext,
+          operationId: result.operationId,
+          succeeded,
+          topicId: result.topicId,
+        });
         onComplete?.();
       },
       operationId: result.operationId,
@@ -1003,6 +992,8 @@ export class GatewayActionImpl {
       // the same WS that gatewayConnections is keyed on.
       gatewayOperationId: operationId,
       operationId: gatewayOpId,
+      onRunTerminal: ({ succeeded }) =>
+        this.settleTopicOperation({ context, operationId, succeeded, topicId }),
       runLifecycle: buildRunLifecycle(this.#get, {
         context,
         parentMessageId: assistantMessageId,
@@ -1047,33 +1038,7 @@ export class GatewayActionImpl {
         // the local op never sticks `running`.
         if (authFailed) this.#get().completeOperation(gatewayOpId);
 
-        // Same supersede guard as executeGatewayAgent's onSessionComplete: a
-        // newer run may own this topic by now, and both writes below are
-        // unconditional stomps that would retire it mid-flight.
-        const superseded = this.#isSupersededRunningOperation({
-          agentId: context.agentId,
-          operationId,
-          topicId,
-        });
-
-        // See executeGatewayAgent's onSessionComplete: a clean background
-        // completion is left to markTopicUnread (status: 'unread').
-        const viewing = this.#get().activeTopicId === topicId;
-        if (!superseded && (viewing || !succeeded)) {
-          void this.#get().updateTopicStatus?.({
-            agentId: context.agentId,
-            status: 'active',
-            topicId,
-          });
-        }
-        // Clear the persisted marker useGatewayReconnect keys off so a dead op
-        // doesn't get reconnected on every reload / task-drawer open.
-        if (!superseded) {
-          topicService.updateTopicMetadata(topicId, { runningOperation: null }).catch(() => {});
-        }
-        // Mirror the clear into the local store — the server clear above leaves the
-        // Zustand topic map stale, which useGatewayReconnect keys off.
-        this.clearLocalRunningOperation({ agentId: context.agentId, operationId, topicId });
+        void this.settleTopicOperation({ context, operationId, succeeded, topicId });
       },
       operationId,
       resumeOnConnect: true,
@@ -1117,6 +1082,50 @@ export class GatewayActionImpl {
       });
   };
 
+  private settleTopicOperation = async (params: {
+    context: ConversationContext;
+    operationId: string;
+    succeeded: boolean;
+    topicId: string;
+  }): Promise<void> => {
+    const { context, operationId, succeeded, topicId } = params;
+    const status = this.#get().activeTopicId === topicId || !succeeded ? 'active' : 'unread';
+    const result = await topicService
+      .settleRunningOperation(topicId, operationId, status)
+      .catch((error) => {
+        console.error('[Gateway] failed to settle topic operation:', error);
+        return undefined;
+      });
+    if (!result || result.status === 'conflict') return;
+
+    const state = this.#get();
+    const scope =
+      context.scope === 'group' || context.scope === 'group_agent' ? context.scope : undefined;
+    const key = topicMapKey({
+      agentId: context.agentId,
+      groupId: context.groupId,
+      scope,
+    });
+    const topic = state.topicDataMap[key]?.items?.find((item) => item.id === topicId);
+    const localOwner = topic?.metadata?.runningOperation?.operationId;
+    if (!topic || (localOwner && localOwner !== operationId)) return;
+
+    state.internal_dispatchTopic({
+      agentId: context.agentId,
+      groupId: context.groupId,
+      id: topicId,
+      scope,
+      type: 'updateTopic',
+      value: {
+        metadata:
+          localOwner === operationId
+            ? { ...topic.metadata, runningOperation: null }
+            : topic.metadata,
+        status,
+      },
+    });
+  };
+
   /**
    * Clear the client-store copy of `topic.metadata.runningOperation`.
    *
@@ -1138,35 +1147,6 @@ export class GatewayActionImpl {
    * user switched agent/group, when the active-bucket `getTopicById` would miss the topic
    * and leave its marker stale.
    */
-  /**
-   * Whether a DIFFERENT run has since claimed this topic's `runningOperation`.
-   *
-   * Read from the local topic map, which every run's start writes optimistically
-   * — so a session closing after a newer run began can tell "my run ended" from
-   * "the topic is idle" and keep its hands off the newer run's markers.
-   *
-   * Deliberately false when the topic carries no marker at all (not loaded into
-   * `topicDataMap`, or already cleared): there is nothing to protect, and the
-   * caller's clear must still run so a dead marker never survives.
-   */
-  #isSupersededRunningOperation = (params: {
-    agentId?: string;
-    groupId?: string;
-    operationId: string;
-    topicId: string;
-  }): boolean => {
-    const { agentId, groupId, operationId, topicId } = params;
-    const state = this.#get();
-    const key = topicMapKey({
-      agentId: agentId ?? state.activeAgentId,
-      groupId: groupId ?? state.activeGroupId,
-    });
-    const owner = state.topicDataMap[key]?.items?.find((t) => t.id === topicId)?.metadata
-      ?.runningOperation?.operationId;
-
-    return !!owner && owner !== operationId;
-  };
-
   private clearLocalRunningOperation = (params: {
     agentId?: string;
     groupId?: string;

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
@@ -386,6 +386,12 @@ export const createGatewayEventHandler = (
     gatewayOperationId?: string;
     operationId: string;
     /**
+     * Settle the persisted topic row as soon as the runtime terminal arrives.
+     * The Gateway session may stay connected after `agent_runtime_end`, so
+     * waiting for `onSessionComplete` can leave the topic stuck `running`.
+     */
+    onRunTerminal?: (event: { succeeded: boolean }) => Promise<void>;
+    /**
      * Shared run lifecycle for this run, assembled by the caller (gateway.ts).
      * Only the gateway transport supplies it — it drives the terminal lifecycle
      * (completeRun / afterRunComplete) here. hetero reuses this handler ONLY for
@@ -406,7 +412,7 @@ export const createGatewayEventHandler = (
     runtimeType?: 'gateway' | 'hetero';
   },
 ) => {
-  const { context, operationId, runLifecycle } = params;
+  const { context, onRunTerminal, operationId, runLifecycle } = params;
   const gatewayOperationId = params.gatewayOperationId ?? operationId;
   const runtimeType = params.runtimeType ?? 'gateway';
 
@@ -1179,6 +1185,7 @@ export const createGatewayEventHandler = (
               ...lifecycleEventBase,
               status,
             });
+            await onRunTerminal?.({ succeeded: status === 'completed' });
             if (!requeued && status === 'completed') {
               // Notification body, resolved most-authoritative first:
               //
@@ -1259,6 +1266,7 @@ export const createGatewayEventHandler = (
           // legacy completeOperation for any other caller for safety.
           if (runtimeType === 'gateway' && runLifecycle) {
             await runLifecycle.completeRun({ ...lifecycleEventBase, status: 'failed' });
+            await onRunTerminal?.({ succeeded: false });
           } else {
             get().completeOperation(operationId);
           }


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| A normal Gateway reply can finish while the WebSocket session remains open. The local operation completes, but topic settlement waits for `session_complete` / disconnect, so the desktop topic row stays loading; because the persisted topic can remain `running`, restarting the desktop still shows loading. | `agent_runtime_end` / `error` immediately performs the operation-owned topic settlement. The persisted row leaves `running`, and the owning desktop topic row synchronizes to `active` / `unread` without waiting for the socket to close. Session completion remains an idempotent fallback. |

## Why

The runtime terminal event and the Gateway connection lifetime are separate boundaries. Generation completion is authoritative at `agent_runtime_end`, but the renderer previously settled the topic only from `onSessionComplete`. A Gateway session that stayed connected therefore left both the persisted topic status and the desktop row behind the completed run.

This stacks on #18666, which makes the server-side settlement atomic and retains operation ownership after the server finishes first. This PR uses that ownership result to synchronize the desktop store safely:

- settle on clean, cancelled, and failed runtime terminals
- update the owning topic bucket immediately after a successful/missing idempotent settlement
- ignore `conflict` responses and newer local operation markers
- reuse the same method from `onSessionComplete` for terminal-missing/auth-failure fallback

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts` — 153 tests passed, lint clean.

Full `bun run check --type` could not complete in the isolated worktree because the current canary dependency links are incomplete there and report unrelated missing packages / existing implicit-any errors; none of the reported errors reference the four changed files.

#### Dependency

- Stacked on #18666
