### PR TITLE
👷 ci: deploy the share worker from canary

### DIFF
--- a/.github/workflows/deploy-share.yml
+++ b/.github/workflows/deploy-share.yml
@@ -1,0 +1,101 @@
+name: Deploy Share
+
+on:
+  push:
+    branches: [canary]
+  workflow_dispatch: {}
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: deploy-share
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve last successful deploy
+        id: base
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          read -r sha run_id < <(gh run list --repo "${{ github.repository }}" \
+            --workflow deploy-share.yml --branch "${{ github.ref_name }}" \
+            --status success --limit 1 --json headSha,databaseId \
+            --jq '.[0] | "\(.headSha) \(.databaseId)"' || true)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+
+      - name: Download last deployed build-inputs manifest
+        id: manifest
+        if: github.event_name == 'push' && steps.base.outputs.run_id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh run download "${{ steps.base.outputs.run_id }}" --repo "${{ github.repository }}" \
+            -n share-build-inputs -D /tmp/share-manifest; then
+            echo "path=/tmp/share-manifest/build-inputs.txt" >> "$GITHUB_OUTPUT"
+          else
+            echo "no manifest artifact on last successful run"
+          fi
+
+      - name: Detect share input changes
+        id: detect
+        env:
+          SHARE_MANIFEST: ${{ steps.manifest.outputs.path }}
+        run: |
+          if [ "${{ github.event_name }}" != "push" ]; then
+            echo "manual dispatch — building"
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          elif [ -z "$SHARE_MANIFEST" ]; then
+            echo "no previous deploy manifest — building"
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          else
+            node apps/share/scripts/should-build.mjs "${{ steps.base.outputs.sha }}" "${{ github.sha }}"
+          fi
+
+      - name: Setup environment
+        if: steps.detect.outputs.should_build == 'true'
+        uses: ./.github/actions/setup-env
+
+      - name: Install deps
+        if: steps.detect.outputs.should_build == 'true'
+        run: pnpm install
+
+      - name: Deploy share
+        if: steps.detect.outputs.should_build == 'true'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          ASSET_S3_ACCESS_KEY_ID: ${{ secrets.ASSET_S3_ACCESS_KEY_ID }}
+          ASSET_S3_BUCKET: ${{ secrets.ASSET_S3_BUCKET }}
+          ASSET_S3_ENDPOINT: ${{ secrets.ASSET_S3_ENDPOINT }}
+          ASSET_S3_PUBLIC_DOMAIN: ${{ secrets.ASSET_S3_PUBLIC_DOMAIN }}
+          ASSET_S3_REGION: ${{ secrets.ASSET_S3_REGION }}
+          ASSET_S3_SECRET_ACCESS_KEY: ${{ secrets.ASSET_S3_SECRET_ACCESS_KEY }}
+        run: bun run deploy
+        working-directory: apps/share
+
+      - name: Upload build-inputs manifest
+        if: steps.detect.outputs.should_build == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: share-build-inputs
+          path: apps/share/build-inputs.txt
+          retention-days: 90
+
+      - name: Carry forward previous manifest
+        if: steps.detect.outputs.should_build != 'true' && steps.manifest.outputs.path != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: share-build-inputs
+          path: ${{ steps.manifest.outputs.path }}
+          retention-days: 90


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

`apps/share` 没有部署 workflow —— 合进 canary 不会推到边缘，`lobehub-share` worker 只能本地 `bun run deploy` 手动发。这导致 `/share/artifact/:id`（#18569）虽然已在 canary，prod 上 worker 仍是旧构建，请求被 fallback 到 `SHARE_APP_HOME`（302 → lobehub.com）。

新增 `.github/workflows/deploy-share.yml`，与 `deploy-workbench.yml` 逐行同构，只做 workbench→share 的替换：

- `push: [canary]` + `workflow_dispatch`
- 变更检测复用已存在的 `apps/share/scripts/should-build.mjs`（读 `SHARE_MANIFEST`）
- manifest artifact 名 `share-build-inputs`，产物由 `apps/share/vite.config.shared.mts` 的 `share-build-inputs-manifest` 插件写出
- 复用 workbench 已配好的 `ASSET_S3_*` / `CLOUDFLARE_API_TOKEN` secrets

#### 📝 补充信息 | Additional Information

`apps/share/scripts/deploy.ts` 的 `SHARE_S3_KEY_PREFIX` 未在 workflow 里传，走默认值 `share` —— 与本地部署一致，静态资源上传到 R2 的 `share/` 前缀，`VITE_CDN_BASE` 由 `ASSET_S3_PUBLIC_DOMAIN` 拼出。若 prod 用的是别的前缀，需要补一个 secret。

首次跑建议用 `workflow_dispatch` 手动触发（无历史 manifest 时也会直接 build）。