### PR TITLE
💄 style: square off the artifact share header buttons

### DIFF
--- a/apps/share/src/features/artifact/ArtifactShareChrome.tsx
+++ b/apps/share/src/features/artifact/ArtifactShareChrome.tsx
@@ -64,10 +64,10 @@ export const ArtifactShareChrome = ({ title }: ArtifactShareChromeProps) => {
         </Text>
       </Flexbox>
       <Flexbox horizontal align={'center'} flex={1} gap={8} justify={'flex-end'}>
-        <Button shape={'round'} size={'small'} onClick={handleShare}>
+        <Button size={'small'} onClick={handleShare}>
           {t('sharePage.artifact.share')}
         </Button>
-        <Button href={'/'} shape={'round'} size={'small'}>
+        <Button href={'/'} size={'small'} type={'primary'}>
           {t('sharePage.menu.goToLobeHub')}
         </Button>
       </Flexbox>


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

`/share/artifact/:id` 顶栏的两个按钮是 `shape="round"` 的胶囊，且都没有 `type` —— 视觉上是两个同级次要按钮，没有主次。

改成与 workbench acceptance 顶栏（`apps/workbench/src/shell/WorkbenchHeader.tsx`）一致的形态：去掉 `shape="round"`，「前往 LobeHub」作为 CTA 用 `type="primary"`，「分享」保持默认次要样式。

```diff
-<Button shape={'round'} size={'small'} onClick={handleShare}>
+<Button size={'small'} onClick={handleShare}>
   {t('sharePage.artifact.share')}
 </Button>
-<Button href={'/'} shape={'round'} size={'small'}>
+<Button href={'/'} size={'small'} type={'primary'}>
   {t('sharePage.menu.goToLobeHub')}
 </Button>
```

保留 `size="small"`：顶栏高度只有 48px，workbench 的默认尺寸在这里会偏大。

#### 📝 补充信息 | Additional Information

只改了按钮 props，没有改布局或样式表。合并后需要 lobehub-cloud bump submodule 并重新部署 share worker 才会上线。