### PR TITLE
🐛 fix: stop topics being stranded on status 'running'

### DIFF
--- a/apps/server/src/modules/AgentRuntime/adapters/ServerOperationStore.test.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerOperationStore.test.ts
@@ -6,7 +6,7 @@ import { ServerOperationStore } from './ServerOperationStore';
 
 const topicMock = {
   findById: vi.fn(),
-  takeRunningOperation: vi.fn(),
+  settleRunningOperation: vi.fn(),
 };
 
 vi.mock('@/database/models/topic', () => ({
@@ -28,7 +28,7 @@ const markedWith = (operationId: string) => ({
 describe('ServerOperationStore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    topicMock.takeRunningOperation.mockResolvedValue(undefined);
+    topicMock.settleRunningOperation.mockResolvedValue({ status: 'settled' });
   });
 
   describe('clearRunningMark', () => {
@@ -37,7 +37,28 @@ describe('ServerOperationStore', () => {
 
       await createStore('op-main').clearRunningMark();
 
-      expect(topicMock.takeRunningOperation).toHaveBeenCalledWith('topic-1', 'op-main');
+      expect(topicMock.settleRunningOperation).toHaveBeenCalledWith('topic-1', 'op-main', 'unread');
+    });
+
+    // The bug this adapter caused: `finish` calls clearRunningMark BEFORE it
+    // publishes `execution_complete`, and the client only learns the run ended
+    // from that event — so the client's own settle always arrived to a mark this
+    // method had already dropped and returned 'missing'. Dropping the mark
+    // without writing a status therefore stranded `topics.status` on 'running'
+    // permanently: the one field a later settle matches on was gone. Observed on
+    // a self-hosted deployment as topics stuck 'running' whose
+    // `metadata.runningOperation` was present-and-JSON-null, operation rows
+    // already terminal, and the topic's last write landing ~100ms BEFORE the
+    // operation was finalised — i.e. this very call.
+    it('writes the terminal status with the clear, not just the mark', async () => {
+      topicMock.findById.mockResolvedValue(markedWith('op-main'));
+
+      await createStore('op-main').clearRunningMark();
+
+      // 'unread' is the honest terminal state here: the run finished and nothing
+      // on the server proves the user watched it. The client corrects to
+      // 'active' when it knows better.
+      expect(topicMock.settleRunningOperation).toHaveBeenCalledWith('topic-1', 'op-main', 'unread');
     });
 
     it('leaves the mark alone when it belongs to another operation', async () => {
@@ -50,7 +71,7 @@ describe('ServerOperationStore', () => {
 
       await createStore('op-child').clearRunningMark();
 
-      expect(topicMock.takeRunningOperation).not.toHaveBeenCalled();
+      expect(topicMock.settleRunningOperation).not.toHaveBeenCalled();
     });
 
     it('is a no-op when the topic carries no mark', async () => {
@@ -58,21 +79,21 @@ describe('ServerOperationStore', () => {
 
       await createStore('op-main').clearRunningMark();
 
-      expect(topicMock.takeRunningOperation).not.toHaveBeenCalled();
+      expect(topicMock.settleRunningOperation).not.toHaveBeenCalled();
     });
 
     it('skips the lookup entirely without a topic', async () => {
       await createTopiclessStore().clearRunningMark();
 
       expect(topicMock.findById).not.toHaveBeenCalled();
-      expect(topicMock.takeRunningOperation).not.toHaveBeenCalled();
+      expect(topicMock.settleRunningOperation).not.toHaveBeenCalled();
     });
 
     it('swallows lookup failures — clearing the mark is best-effort', async () => {
       topicMock.findById.mockRejectedValue(new Error('db down'));
 
       await expect(createStore('op-main').clearRunningMark()).resolves.toBeUndefined();
-      expect(topicMock.takeRunningOperation).not.toHaveBeenCalled();
+      expect(topicMock.settleRunningOperation).not.toHaveBeenCalled();
     });
 
     it('takes a matching child marker without clearing its parent', async () => {
@@ -87,7 +108,11 @@ describe('ServerOperationStore', () => {
 
       await createStore('op-child').clearRunningMark();
 
-      expect(topicMock.takeRunningOperation).toHaveBeenCalledWith('topic-1', 'op-child');
+      expect(topicMock.settleRunningOperation).toHaveBeenCalledWith(
+        'topic-1',
+        'op-child',
+        'unread',
+      );
     });
   });
 });

--- a/apps/server/src/modules/AgentRuntime/adapters/ServerOperationStore.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerOperationStore.ts
@@ -45,7 +45,25 @@ export class ServerOperationStore implements OperationStore {
       // No mark (already cleared) or someone else's mark — nothing of ours to drop.
       if (!markedOperationId || (markedOperationId !== this.operationId && !isChild)) return;
 
-      await topicModel.takeRunningOperation(this.topicId, this.operationId!);
+      // Settle rather than merely take: this clears the mark AND writes the
+      // topic's terminal status in one transaction, under the same row lock.
+      //
+      // Taking it alone left `topics.status` on 'running' with the mark — the
+      // only thing a later `settleRunningOperation` can match on — already
+      // gone, so no server path could ever correct it. `finish` runs this
+      // BEFORE publishing `execution_complete`, and the client only learns the
+      // run ended from that event, so its own settle always arrived to a
+      // cleared mark and returned 'missing'. The topic then depended entirely
+      // on a fire-and-forget `markTopicUnread`, and when that did not land the
+      // sidebar spun forever. Observed as topics stuck 'running' whose
+      // `metadata.runningOperation` was present-and-JSON-null with their
+      // operation rows already terminal.
+      //
+      // 'unread' is what the server can honestly assert: the run finished and
+      // nothing here proves the user watched it. Only the client knows that, so
+      // it corrects to 'active' on its own — with a mark-independent write,
+      // since by then this call has legitimately consumed the mark.
+      await topicModel.settleRunningOperation(this.topicId, this.operationId!, 'unread');
     } catch {
       // best-effort — swallow
     }

--- a/apps/server/src/routers/lambda/__tests__/agentNotify.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/agentNotify.test.ts
@@ -16,7 +16,7 @@ vi.mock('@/business/server/trpc-middlewares/rbacPermission', () => ({
 }));
 
 const mockTopicFindById = vi.fn();
-const mockTopicTakeRunningOperation = vi.fn();
+const mockTopicSettleRunningOperation = vi.fn();
 const mockTopicUpdateMetadata = vi.fn();
 const mockTopicRemoveRunningOperationChild = vi.fn();
 const mockMessageFindById = vi.fn();
@@ -40,7 +40,7 @@ vi.mock('@/database/models/topic', () => ({
   TopicModel: vi.fn(() => ({
     findById: mockTopicFindById,
     removeRunningOperationChild: mockTopicRemoveRunningOperationChild,
-    takeRunningOperation: mockTopicTakeRunningOperation,
+    settleRunningOperation: mockTopicSettleRunningOperation,
     updateMetadata: mockTopicUpdateMetadata,
   })),
 }));
@@ -102,8 +102,9 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
         },
       },
     });
-    mockTopicTakeRunningOperation.mockResolvedValue({
+    mockTopicSettleRunningOperation.mockResolvedValue({
       isRoot: true,
+      status: 'settled',
       operation: {
         assistantMessageId: FINAL_MSG_ID,
         hooks: [{ id: 'task-on-complete', type: 'onComplete', webhook: { url: '/wh' } }],
@@ -147,7 +148,7 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
     });
     expect(onError).not.toHaveBeenCalled();
 
-    expect(mockTopicTakeRunningOperation).toHaveBeenCalledWith(TOPIC, OP);
+    expect(mockTopicSettleRunningOperation).toHaveBeenCalledWith(TOPIC, OP, expect.any(String));
   });
 
   it('cancelled terminal signal finalizes the run as interrupted', async () => {
@@ -176,7 +177,7 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
     });
     expect(onError).not.toHaveBeenCalled();
     expect(mockInstantiateVerifyPlan).not.toHaveBeenCalled();
-    expect(mockTopicTakeRunningOperation).toHaveBeenCalledWith(TOPIC, OP);
+    expect(mockTopicSettleRunningOperation).toHaveBeenCalledWith(TOPIC, OP, expect.any(String));
   });
 
   it('uses the marker snapshot read before terminal lifecycle completion', async () => {
@@ -213,7 +214,7 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
     ).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
 
     expect(mockPublishAgentRuntimeEnd).not.toHaveBeenCalled();
-    expect(mockTopicTakeRunningOperation).not.toHaveBeenCalled();
+    expect(mockTopicSettleRunningOperation).not.toHaveBeenCalled();
 
     await expect(
       createCaller().notify({ content: '', done: true, role: 'assistant', topicId: TOPIC }),
@@ -221,7 +222,7 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
 
     expect(completeOperationSpy).toHaveBeenCalledTimes(2);
     expect(mockPublishAgentRuntimeEnd).toHaveBeenCalledTimes(1);
-    expect(mockTopicTakeRunningOperation).toHaveBeenCalledWith(TOPIC, OP);
+    expect(mockTopicSettleRunningOperation).toHaveBeenCalledWith(TOPIC, OP, expect.any(String));
     completeOperationSpy.mockRestore();
   });
 
@@ -235,8 +236,9 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
         metadata: { runningOperation: { operationId: OP, assistantMessageId: FINAL_MSG_ID } },
       })
       .mockResolvedValueOnce({ agentId: 'agent-1', metadata: { runningOperation: null } });
-    mockTopicTakeRunningOperation.mockResolvedValueOnce({
+    mockTopicSettleRunningOperation.mockResolvedValueOnce({
       isRoot: true,
+      status: 'settled',
       operation: { operationId: OP, assistantMessageId: FINAL_MSG_ID },
     });
     mockOpFindById.mockResolvedValue({
@@ -268,7 +270,7 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
 
     expect(completeOperationSpy).toHaveBeenCalledTimes(1);
     expect(mockPublishAgentRuntimeEnd).toHaveBeenCalledTimes(2);
-    expect(mockTopicTakeRunningOperation).toHaveBeenCalledTimes(1);
+    expect(mockTopicSettleRunningOperation).toHaveBeenCalledTimes(1);
     completeOperationSpy.mockRestore();
   });
 
@@ -305,7 +307,7 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
 
     await createCaller().notify({ content: '', done: true, role: 'assistant', topicId: TOPIC });
 
-    expect(mockTopicTakeRunningOperation).toHaveBeenCalledWith(TOPIC, OP);
+    expect(mockTopicSettleRunningOperation).toHaveBeenCalledWith(TOPIC, OP, expect.any(String));
     expect(mockInstantiateVerifyPlan).not.toHaveBeenCalled();
   });
 
@@ -346,8 +348,9 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
         },
       },
     });
-    mockTopicTakeRunningOperation.mockResolvedValue({
+    mockTopicSettleRunningOperation.mockResolvedValue({
       isRoot: false,
+      status: 'settled',
       operation: { operationId: childOperationId, orchestrationRole: 'member' },
     });
 
@@ -362,7 +365,11 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
     expect(mockPublishAgentRuntimeEnd).toHaveBeenCalledWith(
       expect.objectContaining({ operationId: childOperationId, reason: 'success' }),
     );
-    expect(mockTopicTakeRunningOperation).toHaveBeenCalledWith(TOPIC, childOperationId);
+    expect(mockTopicSettleRunningOperation).toHaveBeenCalledWith(
+      TOPIC,
+      childOperationId,
+      expect.any(String),
+    );
     expect(completeOperationSpy).toHaveBeenCalledWith(
       expect.objectContaining({ operationId: childOperationId, orchestrationRole: 'member' }),
       'done',
@@ -388,8 +395,9 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
         },
       },
     });
-    mockTopicTakeRunningOperation.mockResolvedValue({
+    mockTopicSettleRunningOperation.mockResolvedValue({
       isRoot: false,
+      status: 'settled',
       operation: { operationId: childOperationId, orchestrationRole: 'member' },
     });
 
@@ -400,7 +408,11 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
       'done',
       expect.anything(),
     );
-    expect(mockTopicTakeRunningOperation).toHaveBeenCalledWith(TOPIC, childOperationId);
+    expect(mockTopicSettleRunningOperation).toHaveBeenCalledWith(
+      TOPIC,
+      childOperationId,
+      expect.any(String),
+    );
     completeOperationSpy.mockRestore();
   });
 
@@ -422,7 +434,7 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
       createCaller().notify({ content: '', done: true, role: 'assistant', topicId: TOPIC }),
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
 
-    expect(mockTopicTakeRunningOperation).not.toHaveBeenCalled();
+    expect(mockTopicSettleRunningOperation).not.toHaveBeenCalled();
   });
 
   it('ignores a repeated child terminal callback after its marker was removed', async () => {
@@ -448,12 +460,13 @@ describe('agentNotifyRouter.notify — remote hetero terminal signal', () => {
         },
       },
     });
-    mockTopicTakeRunningOperation
+    mockTopicSettleRunningOperation
       .mockResolvedValueOnce({
         isRoot: false,
+        status: 'settled',
         operation: { operationId: childOperationId, orchestrationRole: 'member' },
       })
-      .mockResolvedValueOnce(undefined);
+      .mockResolvedValueOnce({ status: 'missing' });
 
     await createCaller().notify({
       content: '',

--- a/apps/server/src/routers/lambda/agentNotify.ts
+++ b/apps/server/src/routers/lambda/agentNotify.ts
@@ -313,9 +313,18 @@ export const agentNotifyRouter = router({
           // Claim the marker before publishing. A retry after a successful
           // lifecycle can then publish the missing stream event without firing
           // completion hooks a second time.
+          // Settle rather than take, for the same reason as
+          // `ServerOperationStore.clearRunningMark`: dropping the marker on its
+          // own leaves `topics.status` on 'running' with nothing left to match.
+          // `status === 'settled'` carries exactly the claim this used to read
+          // off `takeRunningOperation`'s return.
           if (!terminalRetry) {
-            const claimed = await ctx.topicModel.takeRunningOperation(topicId, remoteOperationId);
-            if (!claimed) return;
+            const settled = await ctx.topicModel.settleRunningOperation(
+              topicId,
+              remoteOperationId,
+              completionReason === 'done' ? 'unread' : 'active',
+            );
+            if (settled.status !== 'settled') return;
           }
 
           const streamReason = completionReason === 'done' ? 'success' : completionReason;

--- a/apps/server/src/routers/lambda/topic.ts
+++ b/apps/server/src/routers/lambda/topic.ts
@@ -1047,6 +1047,20 @@ export const topicRouter = router({
 
       return ctx.topicModel.settleRunningOperation(input.id, input.operationId, input.status);
     }),
+
+  claimRunningStatus: topicProcedure
+    .use(withScopedPermission('topic:update'))
+    .input(
+      z.object({
+        id: z.string(),
+        operationId: z.string(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      await assertCanUseTopicTargets(guardCtx(ctx), [input.id]);
+
+      return ctx.topicModel.claimRunningStatus(input.id, input.operationId);
+    }),
 });
 
 export type TopicRouter = typeof topicRouter;

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -846,10 +846,14 @@ export class AiAgentService {
       log('finalizeHeteroDispatchError: publishAgentRuntimeEnd failed (non-fatal): %O', err);
     }
 
-    // 3. The operation never started — drop the running marker so reconnect /
+    // 3. The operation never started — settle the topic so reconnect /
     //    heteroIngest validation and the next turn don't see a stale operation.
+    //    Settle, not take: dropping the marker alone would strand `status` on
+    //    'running' with nothing left for any later settle to match — see
+    //    `ServerOperationStore.clearRunningMark`. 'active' rather than 'unread'
+    //    because a dispatch that never started produced nothing to read.
     try {
-      await this.topicModel.takeRunningOperation(topicId, operationId);
+      await this.topicModel.settleRunningOperation(topicId, operationId, 'active');
     } catch (err) {
       log('finalizeHeteroDispatchError: clear runningOperation failed (non-fatal): %O', err);
     }

--- a/packages/database/src/models/__tests__/topic.test.ts
+++ b/packages/database/src/models/__tests__/topic.test.ts
@@ -710,6 +710,53 @@ describe('TopicModel', () => {
 
       expect(settled).toEqual({ assistantMessageId: 'msg-current', status: 'missing' });
     });
+
+    // Regression: a brand-new topic's row has no `status` column default (it
+    // is inserted as `null`), and the client's run-start `status: 'running'`
+    // write is fire-and-forget — for a fast reply, this settle can land first
+    // and observe `status: null` rather than `'running'`. Without treating
+    // `null` the same as `'running'`, the settle used to skip the status
+    // write entirely, and the late run-start write would then stamp
+    // `'running'` permanently onto an already-completed topic (nothing left
+    // to ever correct it, since `metadata.runningOperation` is already null).
+    it('settles a brand-new topic whose run-start status write has not landed yet (status still null)', async () => {
+      const topic = await topicModel.create({
+        metadata: {
+          runningOperation: { assistantMessageId: 'msg-old', operationId: 'op-old' },
+        },
+        title: 'fast reply on a brand-new topic',
+      });
+      // Deliberately skip `topicModel.update(topic.id, { status: 'running' })`
+      // — the row's `status` stays at its post-INSERT `null`, simulating the
+      // settle arriving before the fire-and-forget run-start write lands.
+
+      const settled = await topicModel.settleRunningOperation(topic.id, 'op-old', 'active');
+
+      expect(settled).toEqual(
+        expect.objectContaining({ assistantMessageId: 'msg-old', status: 'settled' }),
+      );
+      const row = await topicModel.findById(topic.id);
+      expect(row?.metadata?.runningOperation).toBeNull();
+      expect(row?.status).toBe('active');
+    });
+
+    it('still skips the status write when the topic was explicitly set to a non-running status (e.g. archived)', async () => {
+      const topic = await topicModel.create({
+        metadata: {
+          runningOperation: { assistantMessageId: 'msg-old', operationId: 'op-old' },
+        },
+        title: 'archived mid-run',
+      });
+      await topicModel.update(topic.id, { status: 'archived' });
+
+      const settled = await topicModel.settleRunningOperation(topic.id, 'op-old', 'active');
+
+      expect(settled.status).toBe('settled');
+      const row = await topicModel.findById(topic.id);
+      expect(row?.metadata?.runningOperation).toBeNull();
+      // Not clobbered back to 'active' — the user's archive action wins.
+      expect(row?.status).toBe('archived');
+    });
   });
 
   describe('updateMetadata', () => {

--- a/packages/database/src/models/__tests__/topic.test.ts
+++ b/packages/database/src/models/__tests__/topic.test.ts
@@ -759,6 +759,109 @@ describe('TopicModel', () => {
     });
   });
 
+  describe('claimRunningStatus', () => {
+    it('claims running status when the operation is the current root marker', async () => {
+      const topic = await topicModel.create({
+        metadata: {
+          runningOperation: { assistantMessageId: 'msg-1', operationId: 'op-1' },
+        },
+        title: 'about to run',
+      });
+
+      const claimed = await topicModel.claimRunningStatus(topic.id, 'op-1');
+
+      expect(claimed).toBe(true);
+      const row = await topicModel.findById(topic.id);
+      expect(row?.status).toBe('running');
+    });
+
+    it('claims running status for a matching child operation', async () => {
+      const topic = await topicModel.create({
+        metadata: {
+          runningOperation: {
+            assistantMessageId: 'msg-parent',
+            childOperations: [{ assistantMessageId: 'msg-child', operationId: 'op-child' }],
+            operationId: 'op-parent',
+          },
+        },
+        title: 'child about to run',
+      });
+
+      const claimed = await topicModel.claimRunningStatus(topic.id, 'op-child');
+
+      expect(claimed).toBe(true);
+      const row = await topicModel.findById(topic.id);
+      expect(row?.status).toBe('running');
+    });
+
+    it('is a no-op when already running', async () => {
+      const topic = await topicModel.create({
+        metadata: {
+          runningOperation: { assistantMessageId: 'msg-1', operationId: 'op-1' },
+        },
+        title: 'already running',
+      });
+      await topicModel.update(topic.id, { status: 'running' });
+
+      const claimed = await topicModel.claimRunningStatus(topic.id, 'op-1');
+
+      expect(claimed).toBe(true);
+      const row = await topicModel.findById(topic.id);
+      expect(row?.status).toBe('running');
+    });
+
+    it('does not claim when no marker is present (never started, or already cleared)', async () => {
+      const topic = await topicModel.create({ title: 'no marker' });
+
+      const claimed = await topicModel.claimRunningStatus(topic.id, 'op-1');
+
+      expect(claimed).toBe(false);
+      const row = await topicModel.findById(topic.id);
+      expect(row?.status).toBeNull();
+    });
+
+    it('does not claim when the marker belongs to a different (newer) operation', async () => {
+      const topic = await topicModel.create({
+        metadata: {
+          runningOperation: { assistantMessageId: 'msg-new', operationId: 'op-new' },
+        },
+        title: 'superseded run',
+      });
+
+      const claimed = await topicModel.claimRunningStatus(topic.id, 'op-old');
+
+      expect(claimed).toBe(false);
+      const row = await topicModel.findById(topic.id);
+      expect(row?.status).toBeNull();
+    });
+
+    // The actual regression this method exists to close: a fast reply's
+    // terminal settle can land BEFORE the fire-and-forget run-start
+    // 'running' write does. Without this guard, the late write is a plain
+    // unconditional UPDATE and stamps 'running' back onto an
+    // already-completed topic with nothing left to ever correct it.
+    it('does not clobber a topic settle already resolved before the delayed run-start write lands', async () => {
+      const topic = await topicModel.create({
+        metadata: {
+          runningOperation: { assistantMessageId: 'msg-1', operationId: 'op-1' },
+        },
+        title: 'fast reply beats the running write',
+      });
+
+      // The terminal event arrives and settles the topic first...
+      const settled = await topicModel.settleRunningOperation(topic.id, 'op-1', 'active');
+      expect(settled.status).toBe('settled');
+
+      // ...then the run-start write, delayed behind other client work,
+      // finally lands.
+      const claimed = await topicModel.claimRunningStatus(topic.id, 'op-1');
+
+      expect(claimed).toBe(false);
+      const row = await topicModel.findById(topic.id);
+      expect(row?.status).toBe('active');
+    });
+  });
+
   describe('updateMetadata', () => {
     it('merges new metadata into existing metadata', async () => {
       const topic = await topicModel.create({

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -1376,11 +1376,26 @@ export class TopicModel {
             },
       } as ChatTopicMetadata;
 
+      // The status write only degrades to a no-op when `existing.status` holds
+      // some OTHER meaningful value (archived / completed / scheduled / …) that
+      // this settle must not clobber — `isRoot` (a matching runningOperation
+      // marker) already proves ownership of the run, so this is not an
+      // additional ownership check. `null` is included alongside 'running':
+      // a brand-new topic's row is inserted with no `status` at all (no column
+      // default), and the client's own run-start `status: 'running'` write is
+      // fire-and-forget — for a fast reply, this settle's terminal write can
+      // land before that one, observe `null`, and (without this) skip writing
+      // 'active'/'unread' entirely. The run-start write then lands moments
+      // later, unconditionally stamping 'running' with nothing left to ever
+      // correct it, since `metadata.runningOperation` is already cleared above
+      // and no future settle call has anything left to match against.
+      const statusUnclaimed = existing.status === 'running' || existing.status === null;
+
       await tx
         .update(topics)
         .set({
           metadata,
-          ...(isRoot && existing.status === 'running' ? { status } : {}),
+          ...(isRoot && statusUnclaimed ? { status } : {}),
           updatedAt: new Date(),
         })
         .where(and(eq(topics.id, id), this.ownership()));

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -1415,6 +1415,50 @@ export class TopicModel {
   };
 
   /**
+   * Claim `status = 'running'` for a topic on behalf of the operation that's
+   * about to start it — but only if that operation's marker (root or child)
+   * is still the current `metadata.runningOperation` when this write lands.
+   *
+   * The client's run-start status write is fire-and-forget and, on the
+   * new-topic path, queued behind other awaited client work — it can be
+   * significantly delayed. Without this guard it is a plain unconditional
+   * `UPDATE`, so for a fast reply it can land AFTER `settleRunningOperation`
+   * already correctly resolved the run back to its terminal status,
+   * silently re-stamping `'running'` with nothing left to ever correct it
+   * (the marker is already cleared, so no future settle call has anything
+   * to match against). This is the run-start mirror of the ownership check
+   * `settleRunningOperation` already does on the run-end side.
+   *
+   * A row lock keeps a concurrent settle from clearing the marker between
+   * the read and the write. Returns `true` when the write happened (or the
+   * topic was already `'running'`), `false` when the guard didn't match.
+   */
+  claimRunningStatus = async (id: string, operationId: string): Promise<boolean> => {
+    return this.db.transaction(async (tx) => {
+      const [existing] = await tx
+        .select({ metadata: topics.metadata, status: topics.status })
+        .from(topics)
+        .where(and(eq(topics.id, id), this.ownership()))
+        .for('update');
+
+      const runningOperation = existing?.metadata?.runningOperation;
+      const isCurrent =
+        runningOperation?.operationId === operationId ||
+        runningOperation?.childOperations?.some((child) => child.operationId === operationId);
+
+      if (!isCurrent) return false;
+      if (existing?.status === 'running') return true;
+
+      await tx
+        .update(topics)
+        .set({ status: 'running', updatedAt: new Date() })
+        .where(and(eq(topics.id, id), this.ownership()));
+
+      return true;
+    });
+  };
+
+  /**
    * Move multiple topics (and all their messages) to another agent.
    *
    * Reassigns ownership purely through the `agentId` foreign key (the new data

--- a/src/services/topic/index.ts
+++ b/src/services/topic/index.ts
@@ -167,6 +167,10 @@ export class TopicService {
     return lambdaClient.topic.settleRunningOperation.mutate({ id, operationId, status });
   };
 
+  claimRunningStatus = (id: string, operationId: string) => {
+    return lambdaClient.topic.claimRunningStatus.mutate({ id, operationId });
+  };
+
   getShareInfo = (topicId: string) => {
     return lambdaClient.topic.getShareInfo.query({ topicId });
   };

--- a/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
@@ -1978,14 +1978,14 @@ describe('GatewayActionImpl', () => {
 
     // Captures the onSessionComplete handed to connectToGateway so we can drive
     // both close paths directly. Provides the methods that callback reaches.
-    function createOnSessionCompleteHarness() {
+    function createOnSessionCompleteHarness({ activeTopicId = 'topic-1' } = {}) {
       const captured: { onSessionComplete?: (p: any) => void } = {};
       const completeOperation = vi.fn();
       const updateTopicStatus = vi.fn();
       const startOperation = vi.fn(() => ({ operationId: 'gw-op-reconnect' }));
       const state: Record<string, any> = {
         activeAgentId: 'agent-1',
-        activeTopicId: 'topic-1',
+        activeTopicId,
         gatewayConnections: {},
         messagesMap: { 'agent-1_topic-1': [{ createdAt: 1, id: 'ast-1' }] },
         topicDataMap: {},
@@ -2057,7 +2057,7 @@ describe('GatewayActionImpl', () => {
         topicId: 'topic-1',
       });
 
-      vi.mocked(topicService.updateTopicMetadata)
+      vi.mocked(topicService.settleRunningOperation)
         .mockClear()
         .mockResolvedValue(undefined as never);
       captured.onSessionComplete!({ authFailed: false, succeeded: true, terminalReceived: true });
@@ -2065,9 +2065,13 @@ describe('GatewayActionImpl', () => {
       // The run lifecycle owns completion when a terminal event arrives, so the
       // reconnect path must not double-complete its local op here.
       expect(completeOperation).not.toHaveBeenCalled();
-      expect(topicService.updateTopicMetadata).toHaveBeenCalledWith('topic-1', {
-        runningOperation: null,
-      });
+      // Watching the topic, so the terminal status is 'active' — written by the
+      // same server call that clears the marker.
+      expect(topicService.settleRunningOperation).toHaveBeenCalledWith(
+        'topic-1',
+        'server-op-1',
+        'active',
+      );
     });
 
     // auth_failed (or a failed token refresh) is authoritative that the op is
@@ -2083,15 +2087,61 @@ describe('GatewayActionImpl', () => {
         topicId: 'topic-1',
       });
 
-      vi.mocked(topicService.updateTopicMetadata)
+      vi.mocked(topicService.settleRunningOperation)
         .mockClear()
         .mockResolvedValue(undefined as never);
       captured.onSessionComplete!({ authFailed: true, succeeded: false, terminalReceived: false });
 
       expect(completeOperation).toHaveBeenCalledWith('gw-op-reconnect');
-      expect(topicService.updateTopicMetadata).toHaveBeenCalledWith('topic-1', {
-        runningOperation: null,
+      expect(topicService.settleRunningOperation).toHaveBeenCalledWith(
+        'topic-1',
+        'server-op-1',
+        'active',
+      );
+    });
+
+    // The case that stranded 7 topics on a self-hosted deployment: a run that
+    // finishes cleanly while the user is on a DIFFERENT topic.
+    //
+    // This path used to clear `runningOperation` unconditionally via
+    // `updateTopicMetadata` and skip the status write entirely, delegating it to
+    // `markTopicUnread` — a separate call on a separate guard. When that one did
+    // not land, the topic kept `status: 'running'` forever AND had already lost
+    // the marker, so every later `settleRunningOperation` returned 'missing' and
+    // no server-side path could repair it. The stuck rows all carried
+    // `metadata.runningOperation` present-and-JSON-null, which is what that
+    // unconditional clear leaves behind.
+    //
+    // Reconnect is the path a page refresh takes — hence the symptom always
+    // being "still spinning after a reload".
+    it('settles to unread (not a bare marker clear) when a clean run ends off-topic', async () => {
+      const { action, captured } = createOnSessionCompleteHarness({
+        activeTopicId: 'some-other-topic',
       });
+
+      await action.reconnectToGatewayOperation({
+        assistantMessageId: 'ast-1',
+        operationId: 'server-op-1',
+        topicId: 'topic-1',
+      });
+
+      vi.mocked(topicService.settleRunningOperation)
+        .mockClear()
+        .mockResolvedValue(undefined as never);
+      vi.mocked(topicService.updateTopicMetadata)
+        .mockClear()
+        .mockResolvedValue(undefined as never);
+      captured.onSessionComplete!({ authFailed: false, succeeded: true, terminalReceived: true });
+
+      // One atomic server call carries BOTH the marker clear and the terminal
+      // status, under the topic row lock and compared by operation id.
+      expect(topicService.settleRunningOperation).toHaveBeenCalledWith(
+        'topic-1',
+        'server-op-1',
+        'unread',
+      );
+      // ...and never the unguarded two-step that dropped the status.
+      expect(topicService.updateTopicMetadata).not.toHaveBeenCalled();
     });
 
     // Seeds a topic whose local metadata still carries a runningOperation, wires up

--- a/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
@@ -27,6 +27,7 @@ vi.mock('@/services/message', () => ({
 
 vi.mock('@/services/topic', () => ({
   topicService: {
+    claimRunningStatus: vi.fn().mockResolvedValue(true),
     settleRunningOperation: vi.fn().mockResolvedValue(undefined),
     updateTopicMetadata: vi.fn().mockResolvedValue(undefined),
   },
@@ -169,6 +170,7 @@ describe('GatewayActionImpl', () => {
   beforeEach(() => {
     moveChatContextSelections.mockClear();
     vi.mocked(topicService.settleRunningOperation).mockResolvedValue(undefined as never);
+    vi.mocked(topicService.claimRunningStatus).mockResolvedValue(true);
     mockAgentStore.state = { activeAgentId: undefined, agentMap: {} };
     mockUserDefaultConfig.disableGatewayMode = undefined;
     mockToolInterventionConfig.approvalMode = 'manual';
@@ -539,6 +541,7 @@ describe('GatewayActionImpl', () => {
       const internalReplaceTopicId = vi.fn();
       const onOperationCancel = vi.fn();
       const replaceMessages = vi.fn();
+      const internalPinTopicStatus = vi.fn();
       const refreshTopic = vi.fn().mockResolvedValue(undefined);
       const startOperation = vi.fn(() => ({ operationId: 'gw-op-1' }));
       const switchTopic = vi.fn();
@@ -556,6 +559,7 @@ describe('GatewayActionImpl', () => {
         associateMessageWithOperation,
         connectToGateway,
         internal_dispatchTopic: internalDispatchTopic,
+        internal_pinTopicStatus: internalPinTopicStatus,
         internal_replaceTopicId: internalReplaceTopicId,
         moveQueuedMessages,
         moveVoiceMessages,
@@ -585,6 +589,7 @@ describe('GatewayActionImpl', () => {
         connectToGateway,
         get,
         internalDispatchTopic,
+        internalPinTopicStatus,
         internalReplaceTopicId,
         mockClient,
         moveQueuedMessages,
@@ -670,7 +675,7 @@ describe('GatewayActionImpl', () => {
     });
 
     it('should execute as the target agent while routing messages to the parent conversation', async () => {
-      const { action, moveQueuedMessages, startOperation, updateTopicStatus } =
+      const { action, internalPinTopicStatus, moveQueuedMessages, startOperation } =
         createExecuteTestAction();
       const executionContext = {
         agentId: 'target-agent',
@@ -719,7 +724,7 @@ describe('GatewayActionImpl', () => {
         messageMapKey(messageContext),
         messageMapKey(messageContext),
       );
-      expect(updateTopicStatus).toHaveBeenCalledWith(
+      expect(internalPinTopicStatus).toHaveBeenCalledWith(
         expect.objectContaining({ agentId: 'parent-agent', topicId: 'topic-1' }),
       );
     });

--- a/src/store/chat/slices/agentRun/actions/__tests__/streamingExecutor.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/streamingExecutor.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as toolEngineering from '@/helpers/toolEngineering';
 import { chatService } from '@/services/chat';
 import * as agentConfigResolver from '@/services/chat/mecha/agentConfigResolver';
+import { topicService } from '@/services/topic';
 import { useAgentStore } from '@/store/agent';
 import { useAiInfraStore } from '@/store/aiInfra';
 import { pageAgentRuntime } from '@/store/tool/slices/builtin/executors/pageAgentRuntime';
@@ -271,9 +272,16 @@ describe('StreamingExecutor actions', () => {
       });
 
       const { result } = renderHook(() => useChatStore());
-      const updateTopicStatusSpy = vi
-        .spyOn(result.current, 'updateTopicStatus')
-        .mockResolvedValue(undefined as any);
+      // Run-start persistence now goes through the ownership-guarded
+      // `topicService.claimRunningStatus` instead of `updateTopicStatus`'s
+      // unconditional UPDATE (see `TopicModel.claimRunningStatus`); the local
+      // optimistic dispatch is still `internal_pinTopicStatus`.
+      const pinTopicStatusSpy = vi
+        .spyOn(result.current, 'internal_pinTopicStatus')
+        .mockImplementation(() => {});
+      const claimRunningStatusSpy = vi
+        .spyOn(topicService, 'claimRunningStatus')
+        .mockResolvedValue(true);
 
       const streamSpy = vi
         .spyOn(chatService, 'createAssistantMessageStream')
@@ -298,15 +306,17 @@ describe('StreamingExecutor actions', () => {
         });
       });
 
-      expect(updateTopicStatusSpy).toHaveBeenCalledWith(
+      expect(pinTopicStatusSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           agentId: TEST_IDS.SESSION_ID,
           status: 'running',
           topicId: TEST_IDS.TOPIC_ID,
         }),
       );
+      expect(claimRunningStatusSpy).toHaveBeenCalledWith(TEST_IDS.TOPIC_ID, expect.any(String));
 
-      updateTopicStatusSpy.mockRestore();
+      pinTopicStatusSpy.mockRestore();
+      claimRunningStatusSpy.mockRestore();
       streamSpy.mockRestore();
     });
 
@@ -316,9 +326,12 @@ describe('StreamingExecutor actions', () => {
       });
 
       const { result } = renderHook(() => useChatStore());
-      const updateTopicStatusSpy = vi
-        .spyOn(result.current, 'updateTopicStatus')
-        .mockResolvedValue(undefined as any);
+      const pinTopicStatusSpy = vi
+        .spyOn(result.current, 'internal_pinTopicStatus')
+        .mockImplementation(() => {});
+      const claimRunningStatusSpy = vi
+        .spyOn(topicService, 'claimRunningStatus')
+        .mockResolvedValue(true);
 
       const streamSpy = vi
         .spyOn(chatService, 'createAssistantMessageStream')
@@ -344,11 +357,13 @@ describe('StreamingExecutor actions', () => {
         });
       });
 
-      expect(updateTopicStatusSpy).not.toHaveBeenCalledWith(
+      expect(pinTopicStatusSpy).not.toHaveBeenCalledWith(
         expect.objectContaining({ status: 'running' }),
       );
+      expect(claimRunningStatusSpy).not.toHaveBeenCalled();
 
-      updateTopicStatusSpy.mockRestore();
+      pinTopicStatusSpy.mockRestore();
+      claimRunningStatusSpy.mockRestore();
       streamSpy.mockRestore();
     });
 

--- a/src/store/chat/slices/agentRun/actions/__tests__/streamingExecutor.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/streamingExecutor.test.ts
@@ -272,13 +272,9 @@ describe('StreamingExecutor actions', () => {
       });
 
       const { result } = renderHook(() => useChatStore());
-      // Run-start persistence now goes through the ownership-guarded
-      // `topicService.claimRunningStatus` instead of `updateTopicStatus`'s
-      // unconditional UPDATE (see `TopicModel.claimRunningStatus`); the local
-      // optimistic dispatch is still `internal_pinTopicStatus`.
-      const pinTopicStatusSpy = vi
-        .spyOn(result.current, 'internal_pinTopicStatus')
-        .mockImplementation(() => {});
+      const updateTopicStatusSpy = vi
+        .spyOn(result.current, 'updateTopicStatus')
+        .mockResolvedValue(undefined as any);
       const claimRunningStatusSpy = vi
         .spyOn(topicService, 'claimRunningStatus')
         .mockResolvedValue(true);
@@ -306,17 +302,23 @@ describe('StreamingExecutor actions', () => {
         });
       });
 
-      expect(pinTopicStatusSpy).toHaveBeenCalledWith(
+      expect(updateTopicStatusSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           agentId: TEST_IDS.SESSION_ID,
           status: 'running',
           topicId: TEST_IDS.TOPIC_ID,
         }),
       );
-      expect(claimRunningStatusSpy).toHaveBeenCalledWith(TEST_IDS.TOPIC_ID, expect.any(String));
+      // NOT the gateway transport's ownership-guarded `claimRunningStatus`.
+      // That guard only writes when the operation is still the topic's current
+      // `metadata.runningOperation`, and this transport never publishes such a
+      // marker (`startOperation` is in-memory; `sendMessageInServer` does not
+      // touch topic metadata) — so routing this write through it drops it
+      // silently, and the assertion above would keep passing on a mock.
+      expect(claimRunningStatusSpy).not.toHaveBeenCalled();
 
-      pinTopicStatusSpy.mockRestore();
       claimRunningStatusSpy.mockRestore();
+      updateTopicStatusSpy.mockRestore();
       streamSpy.mockRestore();
     });
 
@@ -326,12 +328,9 @@ describe('StreamingExecutor actions', () => {
       });
 
       const { result } = renderHook(() => useChatStore());
-      const pinTopicStatusSpy = vi
-        .spyOn(result.current, 'internal_pinTopicStatus')
-        .mockImplementation(() => {});
-      const claimRunningStatusSpy = vi
-        .spyOn(topicService, 'claimRunningStatus')
-        .mockResolvedValue(true);
+      const updateTopicStatusSpy = vi
+        .spyOn(result.current, 'updateTopicStatus')
+        .mockResolvedValue(undefined as any);
 
       const streamSpy = vi
         .spyOn(chatService, 'createAssistantMessageStream')
@@ -357,13 +356,11 @@ describe('StreamingExecutor actions', () => {
         });
       });
 
-      expect(pinTopicStatusSpy).not.toHaveBeenCalledWith(
+      expect(updateTopicStatusSpy).not.toHaveBeenCalledWith(
         expect.objectContaining({ status: 'running' }),
       );
-      expect(claimRunningStatusSpy).not.toHaveBeenCalled();
 
-      pinTopicStatusSpy.mockRestore();
-      claimRunningStatusSpy.mockRestore();
+      updateTopicStatusSpy.mockRestore();
       streamSpy.mockRestore();
     });
 

--- a/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
@@ -40,6 +40,7 @@ import { type ResolvedAgentConfig } from '@/services/chat/mecha';
 import { composeEnabledTools, resolveAgentConfig } from '@/services/chat/mecha';
 import { localFileService } from '@/services/electron/localFileService';
 import { messageService } from '@/services/message';
+import { topicService } from '@/services/topic';
 import { getAgentStoreState } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 import { aiModelSelectors } from '@/store/aiInfra/selectors';
@@ -599,15 +600,21 @@ export class StreamingExecutorActionImpl {
     // (markTopicUnread / writeTopicStatus 'active'), with `cleanupStaleRunningTopics`
     // as the backstop if this tab dies mid-run.
     if (topicId && !isSubAgent) {
-      const runningWrite = this.#get().updateTopicStatus?.({
+      // Local optimistic dispatch only — persistence is routed through the
+      // ownership-guarded `claimRunningStatus`, not `updateTopicStatus`'s
+      // unconditional UPDATE. A delayed persist here could otherwise land
+      // AFTER the terminal lifecycle already correctly settled a fast run
+      // back to its terminal status, silently re-stranding surfaces that
+      // read the stored status — see `TopicModel.claimRunningStatus`.
+      this.#get().internal_pinTopicStatus?.({
         agentId,
         groupId,
         ...(scope === 'group' || scope === 'group_agent' ? { scope } : {}),
         status: 'running',
         topicId,
       });
-      void runningWrite?.catch((error) => {
-        console.error('[streamingExecutor] running status write failed:', error);
+      topicService.claimRunningStatus(topicId, operationId).catch((error) => {
+        console.error('[streamingExecutor] running status claim failed:', error);
       });
     }
 

--- a/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
@@ -40,7 +40,6 @@ import { type ResolvedAgentConfig } from '@/services/chat/mecha';
 import { composeEnabledTools, resolveAgentConfig } from '@/services/chat/mecha';
 import { localFileService } from '@/services/electron/localFileService';
 import { messageService } from '@/services/message';
-import { topicService } from '@/services/topic';
 import { getAgentStoreState } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 import { aiModelSelectors } from '@/store/aiInfra/selectors';
@@ -600,21 +599,28 @@ export class StreamingExecutorActionImpl {
     // (markTopicUnread / writeTopicStatus 'active'), with `cleanupStaleRunningTopics`
     // as the backstop if this tab dies mid-run.
     if (topicId && !isSubAgent) {
-      // Local optimistic dispatch only — persistence is routed through the
-      // ownership-guarded `claimRunningStatus`, not `updateTopicStatus`'s
-      // unconditional UPDATE. A delayed persist here could otherwise land
-      // AFTER the terminal lifecycle already correctly settled a fast run
-      // back to its terminal status, silently re-stranding surfaces that
-      // read the stored status — see `TopicModel.claimRunningStatus`.
-      this.#get().internal_pinTopicStatus?.({
+      // Deliberately NOT `claimRunningStatus`, unlike the gateway transport.
+      // That guard only writes when the operation's marker is still the topic's
+      // current `metadata.runningOperation` — and this transport never puts a
+      // marker there. The client run executes in the browser; `startOperation`
+      // mints an in-memory `op_<nanoid>` and `sendMessageInServer` persists
+      // messages without touching topic metadata. Only the server runtime
+      // (`execAgent`) and the hetero path write that marker, so a guarded claim
+      // from here can never match and would silently drop the write entirely,
+      // undoing the very reason this call exists (see the note above).
+      //
+      // The unguarded write's own risk — a delayed persist landing after the
+      // terminal status — is unchanged from before #18685 and has no marker to
+      // fence against; it needs the client path to publish a marker first.
+      const runningWrite = this.#get().updateTopicStatus?.({
         agentId,
         groupId,
         ...(scope === 'group' || scope === 'group_agent' ? { scope } : {}),
         status: 'running',
         topicId,
       });
-      topicService.claimRunningStatus(topicId, operationId).catch((error) => {
-        console.error('[streamingExecutor] running status claim failed:', error);
+      void runningWrite?.catch((error) => {
+        console.error('[streamingExecutor] running status write failed:', error);
       });
     }
 

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -1064,32 +1064,54 @@ export class GatewayActionImpl {
         if (authFailed) this.#get().completeOperation(gatewayOpId);
 
         // Same supersede guard as executeGatewayAgent's onSessionComplete: a
-        // newer run may own this topic by now, and both writes below are
-        // unconditional stomps that would retire it mid-flight.
+        // newer run may own this topic by now, and the settle below would
+        // retire it mid-flight.
         const superseded = this.#isSupersededRunningOperation({
           agentId: context.agentId,
           operationId,
           topicId,
         });
 
-        // See executeGatewayAgent's onSessionComplete: a clean background
-        // completion is left to markTopicUnread (status: 'unread').
+        // Settle through the server exactly as executeGatewayAgent's
+        // onSessionComplete does: ONE call that clears the marker and writes the
+        // terminal status inside the topic row lock, comparing the operation id
+        // so a late close from another tab cannot settle a newer run.
+        //
+        // This was hand-rolled here as two independent fire-and-forget writes: an
+        // UNCONDITIONAL `updateTopicMetadata({ runningOperation: null })` plus an
+        // `updateTopicStatus('active')` that was SKIPPED whenever the run finished
+        // cleanly while the user was on another topic. That case delegated the
+        // status write to `markTopicUnread` — a separate call, on a separate
+        // guard — and when it did not land the topic stayed `running` forever:
+        // the marker was already gone, so every later `settleRunningOperation`
+        // returned `missing` and nothing on the server could repair it. Observed
+        // on a self-hosted deployment as 7 topics stuck `running` whose
+        // `metadata.runningOperation` was present-and-JSON-null (the signature of
+        // that unconditional clear) with their operation rows already terminal.
+        //
+        // Reconnect is the path a page refresh takes, which is why the symptom
+        // was always "still spinning after a reload" — refreshing is what moved
+        // the run off the primary path and onto this one.
         const viewing = this.#get().activeTopicId === topicId;
-        if (!superseded && (viewing || !succeeded)) {
-          void this.#get().updateTopicStatus?.({
-            agentId: context.agentId,
-            status: 'active',
-            topicId,
-          });
-        }
-        // Clear the persisted marker useGatewayReconnect keys off so a dead op
-        // doesn't get reconnected on every reload / task-drawer open.
         if (!superseded) {
-          topicService.updateTopicMetadata(topicId, { runningOperation: null }).catch(() => {});
+          topicService
+            .settleRunningOperation(
+              topicId,
+              operationId,
+              viewing || !succeeded ? 'active' : 'unread',
+            )
+            .catch(console.error);
         }
-        // Mirror the clear into the local store — the server clear above leaves the
-        // Zustand topic map stale, which useGatewayReconnect keys off.
-        this.clearLocalRunningOperation({ agentId: context.agentId, operationId, topicId });
+        // Mirror into the local store — the server settle does NOT touch the
+        // Zustand topic map that useGatewayReconnect (and the sidebar spinner)
+        // read. Status omitted for the unwatched-clean case, which
+        // `markTopicUnread` owns locally; same split as the primary path.
+        this.clearLocalRunningOperation({
+          agentId: context.agentId,
+          operationId,
+          status: viewing || !succeeded ? 'active' : undefined,
+          topicId,
+        });
       },
       operationId,
       resumeOnConnect: true,
@@ -1136,8 +1158,8 @@ export class GatewayActionImpl {
   /**
    * Clear the client-store copy of `topic.metadata.runningOperation`.
    *
-   * The server-side clear (`topicService.updateTopicMetadata(topicId, { runningOperation: null })`)
-   * alone leaves the Zustand store stale: `useGatewayReconnect` keys off the LOCAL
+   * The server-side clear (`topicService.settleRunningOperation`, which nulls the
+   * marker inside the topic row lock) alone leaves the Zustand store stale: `useGatewayReconnect` keys off the LOCAL
    * copy, so after an error run (e.g. insufficient credits) the stale marker keeps
    * firing `aiAgentService.refreshGatewayToken(topicId)`, which the server now answers
    * with NOT_FOUND (404 — the server-side marker is already null). Raw SWR retries the

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -862,11 +862,17 @@ export class GatewayActionImpl {
         // terminal-missing fallback so the op never sticks `running`.
         if (!terminalReceived) this.#get().completeOperation(gatewayOpId);
         if (result.topicId) {
-          // A clean completion the user isn't watching is owned by
-          // `markTopicUnread` (status: 'unread'). Every other case (viewing,
-          // error, abort) settles the running state back to 'active'. The server
-          // compares the operation id under the topic row lock so a late close
-          // from another tab cannot clear or settle a newer run.
+          // The server already settled this topic: the runtime's `finish`
+          // executor settles to 'unread' before it publishes the terminal event
+          // this callback rides on, so by now the mark is legitimately gone and
+          // a settle from here would only ever return 'missing'.
+          //
+          // What the server could NOT know is whether the user is watching. That
+          // is the one correction left to make, and it has to be a
+          // mark-independent write for exactly the reason above. The settle is
+          // still issued as a backstop — `clearRunningMark` is best-effort and
+          // swallows its failures, so on that path the mark is still here and
+          // this is what clears it.
           const viewing = this.#get().activeTopicId === result.topicId;
           topicService
             .settleRunningOperation(
@@ -875,6 +881,29 @@ export class GatewayActionImpl {
               viewing || !succeeded ? 'active' : 'unread',
             )
             .catch(console.error);
+          //
+          // Ownership-checked locally, because `updateTopicStatus` is an
+          // unconditional UPDATE with no server-side compare-and-set: a late
+          // close observing a stale marker would otherwise retire a newer run
+          // that another tab already started on this topic. That is exactly
+          // what routing this through the operation id buys on the settle
+          // above, and the correction must not give it back.
+          if (
+            (viewing || !succeeded) &&
+            !this.#isSupersededRunningOperation({
+              agentId: resolvedMessageContext.agentId,
+              groupId: resolvedMessageContext.groupId,
+              operationId: result.operationId,
+              topicId: result.topicId,
+            })
+          ) {
+            void this.#get().updateTopicStatus?.({
+              agentId: resolvedMessageContext.agentId,
+              groupId: resolvedMessageContext.groupId,
+              status: 'active',
+              topicId: result.topicId,
+            });
+          }
           // Also clear the local store copy — the server settle above does NOT
           // touch the Zustand topic map that useGatewayReconnect (and the sidebar
           // spinner) read. Mirror the same 'active' decision passed to the server
@@ -1101,6 +1130,19 @@ export class GatewayActionImpl {
               viewing || !succeeded ? 'active' : 'unread',
             )
             .catch(console.error);
+          // Mark-independent correction — see executeGatewayAgent's
+          // onSessionComplete: the runtime's `finish` already settled this topic
+          // to 'unread' before the terminal event arrived, so the settle above
+          // finds nothing and only the write below can flip a WATCHED topic
+          // back. Safe to leave unguarded HERE only because the whole branch is
+          // already behind `superseded`, which is the same ownership check.
+          if (viewing || !succeeded) {
+            void this.#get().updateTopicStatus?.({
+              agentId: context.agentId,
+              status: 'active',
+              topicId,
+            });
+          }
         }
         // Mirror into the local store — the server settle does NOT touch the
         // Zustand topic map that useGatewayReconnect (and the sidebar spinner)

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -737,11 +737,22 @@ export class GatewayActionImpl {
     }
 
     if (result.topicId) {
-      void this.#get().updateTopicStatus?.({
+      // Local optimistic dispatch only — persistence is routed through the
+      // ownership-guarded `claimRunningStatus`, not `updateTopicStatus`'s
+      // unconditional UPDATE. This write is fire-and-forget and, on the
+      // new-topic path, queued behind several awaited steps above, so it can
+      // be significantly delayed; an unconditional persist could land AFTER
+      // `settleRunningOperation` already correctly resolved a fast reply back
+      // to its terminal status, silently re-stranding the sidebar spinner —
+      // see `TopicModel.claimRunningStatus`'s doc comment.
+      this.#get().internal_pinTopicStatus?.({
         agentId: messageContext.agentId,
         groupId: messageContext.groupId,
         status: 'running',
         topicId: result.topicId,
+      });
+      topicService.claimRunningStatus(result.topicId, result.operationId).catch((err) => {
+        console.error('[executeGatewayAgent] failed to claim running status: %O', err);
       });
     }
 


### PR DESCRIPTION
<!-- Brief and heads-up -->

A topic can be left on `status: 'running'` for good — the sidebar spinner never stops, and no reload or server-side path ever corrects it.

This started as a follow-up to #18682 (a null-`status` race). Deploying that fix against a real self-hosted deployment did **not** stop the reports, so the branch kept going until the actual cause was pinned down against the live database. **The last commit is the root cause**; the earlier ones are real but adjacent defects found on the way, each reproducible on its own.

> **One design decision needs a maintainer call** — see *Open question* at the end. Everything below it is evidence; that part is a judgement about product behaviour I don't think a contributor should make unilaterally.

## The root cause — the server drops the mark and writes no status

`finish` clears the topic's running mark **before** it publishes the terminal event:

```ts
// packages/agent-runtime/src/executors/finish.ts
await transports.operationStore?.clearRunningMark();
await transports.stream.publishEvent({ /* … 'execution_complete' */ });
```

The client only learns a run ended from that event. So the client's own `settleRunningOperation` **always** arrived to a mark the server had already dropped, hit

```ts
if (!runningOperation) { /* … */ return { status: 'missing' } }
```

and wrote nothing. `ServerOperationStore.clearRunningMark` took the mark without touching `status`, so the topic stayed `'running'` with the one field any later settle matches on already gone — unrepairable by any server path. From there the terminal status rested entirely on the client's fire-and-forget `markTopicUnread`, and when that didn't land, the topic spun forever.

Nothing else recovers it. `finalizeAbandoned` only fires for operations the gateway watchdog reports as silent — a run that finished normally is never abandoned. `cleanupStaleRunningTopics` runs in the browser, only when the sidebar topic section is expanded, and only for rows older than two hours.

### Measured, not inferred

A topic created after deploying the earlier fixes, still stranded:

| | |
|---|---|
| `run_duration` | 6.366s |
| `topics.updated_at` − `agent_operations.completed_at` | **−104ms** |
| `jsonb_typeof(metadata->'runningOperation')` | `'null'` — key present, value JSON null |
| `heteroSessionId` | absent |
| `completion_reason` | `done` |

The −104ms is the whole argument. If the last write to the topic had been the run-start `'running'` write, it would sit ~6.4s before the operation was finalised, not 104ms. `updatedAt` carries `$onUpdate`, so the metadata-only UPDATE inside `takeRunningOperation` still bumps it — that timestamp *is* the `clearRunningMark` write.

Every stuck row on that deployment (14 operations across 7 topics) carried the same signature, including two whose operations ended in `error`.

Three sites dropped the mark without a status; all three now settle:

| Site | Terminal status |
|---|---|
| `ServerOperationStore.clearRunningMark` | `'unread'` |
| `AiAgentService.finalizeHeteroDispatchError` | `'active'` — a dispatch that never started produced nothing to read |
| `agentNotify` remote-hetero terminal | `done ? 'unread' : 'active'`; its claim semantics carry over as `status === 'settled'` |

`'unread'` is what the server can honestly assert: the run finished, and nothing there proves the user watched it. Only the client knows that, so both gateway paths also correct to `'active'` when watching — with a **mark-independent** write, since the mark is legitimately gone by then. That write is ownership-checked locally, because `updateTopicStatus` is an unconditional UPDATE with no server-side compare-and-set and a late close would otherwise retire a newer run another tab had started. An existing test caught exactly that on the first attempt.

## The other three defects

### 1. A null `status` was treated as claimed by someone else

A brand-new topic's row has no `status` column default, so it is inserted `NULL`. The client's run-start `'running'` write is fire-and-forget and, on the new-topic path, queued behind several awaited steps. For a fast reply `settleRunningOperation`'s terminal write can land first, observe `existing.status === null`, and — under the old `isRoot && existing.status === 'running'` guard — skip the status write while still clearing the mark.

Widened to accept `null` alongside `'running'`. `isRoot` already proves ownership; the status check exists only to avoid clobbering a topic deliberately set to something else (archived, completed, …), which a new test confirms still holds.

### 2. …and the run-start write itself was unfenced

Addressing that alone left the other half: the run-start write is a plain unconditional UPDATE, so a fast reply's settle can complete first and then have the late write stamp `'running'` back over it, with the mark already cleared and nothing left to correct it.

`TopicModel.claimRunningStatus(id, operationId)` is the run-start mirror of the run-end ownership check — it writes `'running'` only if the operation's marker is still the topic's current `runningOperation` when the write lands, inside a row-locked transaction.

### 3. That fence was wrong for the client transport

**A correction to commit 2 in this same PR.** The fence is right for the gateway transport, whose marker `execAgent` publishes before returning the operation id. The client transport never publishes one: `startOperation` mints an in-memory `op_<nanoid>` in the store, and `sendMessageInServer` doesn't touch topic metadata. So the claim can never match and the write is dropped entirely — undoing the reason that call exists (a client-driven run being invisible to the home inbox and the sidebar off the active conversation).

This PR's own model test, "does not claim when no marker is present", is exactly that behaviour; nothing connected it to the client transport because the transport's test mocks `claimRunningStatus` and cannot see a real call no-op. It now also asserts `claimRunningStatus` is *not* what that transport calls.

### 4. The gateway reconnect path re-implemented its terminal handling

`reconnectToGatewayOperation`'s `onSessionComplete` hand-rolled what `executeGatewayAgent`'s already does, non-atomically and with the status write made conditional:

```ts
if (!superseded && (viewing || !succeeded))
  void updateTopicStatus({ status: 'active', … });          // skipped on a clean background finish
if (!superseded)
  updateTopicMetadata(topicId, { runningOperation: null }); // unconditional
```

Now it calls `settleRunningOperation` like the primary path: one call that clears the mark and writes the status inside the row lock, comparing the operation id so a late close from another tab cannot settle a newer run — ownership the hand-rolled version had no way to check.

## Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

136 tests across the five affected files, all passing; `tsgo --noEmit` at the repo root exits 0; eslint and prettier clean on every touched file.

Both new regression tests are verified **non-vacuous** — against the pre-fix file each fails on its own assertion, not on a crash:

- `ServerOperationStore`: `expected "spy" to be called with arguments: [ 'topic-1', 'op-main', 'unread' ]`
- gateway reconnect: `expected "spy" to be called with arguments: [ 'topic-1', 'server-op-1', 'unread' ]`

The first PR commit's test was likewise verified to fail against the pre-fix model code and pass with it, on a real PGlite database.

## Open question for maintainers

**Is `'unread'` the right thing for the server to write?**

The server cannot know whether the user is watching, so it writes `'unread'` and the client corrects to `'active'`. The cost is that a run finishing while the user *is* watching briefly shows an unread mark before the client's correction lands.

Two alternatives, both deliberately not taken here:

1. **Thread "is the user watching" down into `finish`.** Cleanest semantically, but it puts a UI concern into the runtime's execution path.
2. **Swap `finish`'s two steps** — publish the terminal event first, clear the mark second. Much smaller, but it only narrows the window: whether the server's clear or the client's settle lands first is still a race, and losing it strands the topic exactly as before.

There is also a naming point: `clearRunningMark` now writes a status too, so the `OperationStore` port would more honestly read `settleRun(terminalStatus)`. That is a public interface change in `packages/agent-runtime` and felt out of scope for a bug fix — happy to do it if you'd prefer the port to say what it does.

## 🔗 Related Issue

Follow-up to #18682.
