### PR TITLE
🐛 fix(ci): strip checkout extraheader when resolving cloud revision

### DIFF
--- a/.github/workflows/release-desktop-beta.yml
+++ b/.github/workflows/release-desktop-beta.yml
@@ -61,7 +61,8 @@ jobs:
           CLOUD_TOKEN: ${{ secrets.LOBEHUB_CLOUD_TOKEN }}
         run: |
           set -euo pipefail
-          cloud_ref=$(git ls-remote "https://x-access-token:${CLOUD_TOKEN}@github.com/lobehub/lobehub-cloud.git" HEAD | cut -f1)
+          # checkout persist-credentials extraheader would send GITHUB_TOKEN and 404 the private cloud repo
+          cloud_ref=$(git -c http.https://github.com/.extraheader= ls-remote "https://x-access-token:${CLOUD_TOKEN}@github.com/lobehub/lobehub-cloud.git" HEAD | cut -f1)
           if [[ ! "$cloud_ref" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Unable to resolve Cloud revision"
             exit 1

--- a/.github/workflows/release-desktop-canary.yml
+++ b/.github/workflows/release-desktop-canary.yml
@@ -130,7 +130,8 @@ jobs:
           CLOUD_TOKEN: ${{ secrets.LOBEHUB_CLOUD_TOKEN }}
         run: |
           set -euo pipefail
-          cloud_ref=$(git ls-remote "https://x-access-token:${CLOUD_TOKEN}@github.com/lobehub/lobehub-cloud.git" HEAD | cut -f1)
+          # checkout persist-credentials extraheader would send GITHUB_TOKEN and 404 the private cloud repo
+          cloud_ref=$(git -c http.https://github.com/.extraheader= ls-remote "https://x-access-token:${CLOUD_TOKEN}@github.com/lobehub/lobehub-cloud.git" HEAD | cut -f1)
           if [[ ! "$cloud_ref" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Unable to resolve Cloud revision"
             exit 1

--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -127,7 +127,8 @@ jobs:
           CLOUD_TOKEN: ${{ secrets.LOBEHUB_CLOUD_TOKEN }}
         run: |
           set -euo pipefail
-          cloud_ref=$(git ls-remote "https://x-access-token:${CLOUD_TOKEN}@github.com/lobehub/lobehub-cloud.git" HEAD | cut -f1)
+          # checkout persist-credentials extraheader would send GITHUB_TOKEN and 404 the private cloud repo
+          cloud_ref=$(git -c http.https://github.com/.extraheader= ls-remote "https://x-access-token:${CLOUD_TOKEN}@github.com/lobehub/lobehub-cloud.git" HEAD | cut -f1)
           if [[ ! "$cloud_ref" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Unable to resolve Cloud revision"
             exit 1


### PR DESCRIPTION
<!-- Brief and heads-up -->

Canary desktop releases have been red since renderer OTA (#18648). `Resolve Cloud revision` runs `git ls-remote` inside the `actions/checkout` worktree, so persist-credentials extraheader sends `GITHUB_TOKEN` instead of `LOBEHUB_CLOUD_TOKEN` and GitHub 404s the private cloud repo.

Example: https://github.com/lobehub/lobehub/actions/runs/32847571171/job/97800742882

| Before | After |
| ------ | ----- |
| `git ls-remote` uses checkout extraheader (`GITHUB_TOKEN`) → 404 | `git -c http.https://github.com/.extraheader=` so `LOBEHUB_CLOUD_TOKEN` is used |

#### Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Next canary push that matches the build prefix will exercise `Resolve Cloud revision`. Same one-liner is in beta and stable so those cuts do not hit the same 404.

#### 🔗 Related Issue

Related to #18648