### PR TITLE
🐛 fix(chat): remove warm-cache loading flash

### DIFF
--- a/src/features/AgentSidebar/Topic/List/TopicListSkeleton.tsx
+++ b/src/features/AgentSidebar/Topic/List/TopicListSkeleton.tsx
@@ -5,8 +5,7 @@ import { cssVar } from 'antd-style';
 import { memo } from 'react';
 
 // Mirrors the grouped topic list frame (12px group caption + icon-led 36px
-// rows) so the deferred-mount frame reads as the layout it resolves into,
-// unlike the avatar-style generic SkeletonList.
+// rows) while the current container has no settled topic data.
 const GROUPS = [
   { header: 44, rows: ['82%', '58%', '70%'] },
   { header: 60, rows: ['64%', '76%', '48%', '68%'] },

--- a/src/features/AgentSidebar/Topic/List/index.test.tsx
+++ b/src/features/AgentSidebar/Topic/List/index.test.tsx
@@ -2,6 +2,7 @@
  * @vitest-environment happy-dom
  */
 import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import TopicList from './index';
@@ -54,6 +55,12 @@ vi.mock('@/features/NavPanel/components/SkeletonList', () => ({
 
 vi.mock('@/hooks/useFetchChatTopics', () => ({
   useFetchChatTopics: vi.fn(),
+}));
+
+// Freeze deferred work at its initial value so the test observes the first
+// committed navigation frame rather than React's follow-up render.
+vi.mock('@/hooks/useDeferredMount', () => ({
+  useDeferredMount: () => false,
 }));
 
 vi.mock('@/hooks/usePermission', () => ({
@@ -131,6 +138,19 @@ vi.mock('./Item', () => ({
   default: () => <div data-testid="topic-item" />,
 }));
 
+vi.mock('./TopicListSkeleton', () => ({
+  default: () => <div data-testid="topic-list-skeleton" />,
+}));
+
+// Partial mock: keep every real export (e.g. `lobeStaticStylish`, which
+// `createStaticStyles` reads at import time in transitively-loaded modules like
+// ShareModal/useContainerStyles) and override only Flexbox. A full mock returning
+// just Flexbox drops those exports and crashes collection whenever the suite's
+// module graph evaluates one of them.
+vi.mock('@lobehub/ui', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  Flexbox: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
 describe('Agent topic list', () => {
   beforeEach(() => {
     pushMock.mockReset();
@@ -138,8 +158,24 @@ describe('Agent topic list', () => {
     permissionMock.create_content = true;
     chatStoreStateMock.hasMore = true;
     chatStoreStateMock.isExpandingPageSize = false;
+    chatStoreStateMock.isUndefinedTopics = false;
     chatStoreStateMock.topicLength = 0;
     chatStoreStateMock.topics = [];
+  });
+
+  it('renders settled topic data in the first navigation frame', () => {
+    render(<TopicList />);
+
+    expect(screen.queryByTestId('topic-list-skeleton')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'actions.addNewTopic' })).toBeInTheDocument();
+  });
+
+  it('renders a skeleton when the current topic data is unavailable', () => {
+    chatStoreStateMock.isUndefinedTopics = true;
+
+    render(<TopicList />);
+
+    expect(screen.getByTestId('topic-list-skeleton')).toBeInTheDocument();
   });
 
   it('opens the agent chat route from the empty start topic entry', () => {

--- a/src/features/AgentSidebar/Topic/List/index.tsx
+++ b/src/features/AgentSidebar/Topic/List/index.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
 import EmptyNavItem from '@/features/NavPanel/components/EmptyNavItem';
-import { useDeferredMount } from '@/hooks/useDeferredMount';
 import { useFetchChatTopics } from '@/hooks/useFetchChatTopics';
 import { usePermission } from '@/hooks/usePermission';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
@@ -37,13 +36,8 @@ const TopicList = memo(() => {
 
   useFetchChatTopics();
 
-  // Route transitions must paint instantly: the mount commit shows a skeleton
-  // frame and the real list renders in a deferred (interruptible) follow-up
-  // pass, off the navigation's critical path.
-  const listReady = useDeferredMount();
-
   // Show skeleton when current session's topic data is not yet loaded
-  if (isUndefinedTopics || !listReady) return <TopicListSkeleton />;
+  if (isUndefinedTopics) return <TopicListSkeleton />;
 
   return (
     <>

--- a/src/features/Conversation/ConversationProvider.test.tsx
+++ b/src/features/Conversation/ConversationProvider.test.tsx
@@ -3,7 +3,7 @@
  */
 import type { ConversationContext, UIChatMessage } from '@lobechat/types';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import type { ReactNode } from 'react';
+import { type ReactNode, useLayoutEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
@@ -159,6 +159,17 @@ const OverlayHeightSetter = () => {
   return <button onClick={() => setChatInputOverlayHeight(48)}>set overlay height</button>;
 };
 
+const HydratedProjection = ({ messages }: { messages: UIChatMessage[] }) => {
+  const storeApi = useConversationStoreApi();
+
+  useLayoutEffect(() => {
+    storeApi.getState().replaceMessages(messages, { skipOnMessagesChange: true });
+    storeApi.setState({ messagesInit: true });
+  }, [messages, storeApi]);
+
+  return null;
+};
+
 const renderChatList = (messages?: UIChatMessage[]) =>
   render(
     <ConversationProvider
@@ -302,6 +313,18 @@ describe('ConversationProvider', () => {
     renderChatList();
 
     expect(screen.getByTestId('skeleton-list')).toBeInTheDocument();
+  });
+
+  it('preserves a hydrated cache projection while the parent message bucket is one render behind', () => {
+    render(
+      <ConversationProvider context={oldContext} hasInitMessages={false}>
+        <HydratedProjection messages={oldMessages} />
+        <ChatList welcome={<div>WELCOME</div>} />
+      </ConversationProvider>,
+    );
+
+    expect(screen.queryByTestId('skeleton-list')).not.toBeInTheDocument();
+    expect(screen.getByTestId('virtualized-list')).toHaveTextContent('msg_old');
   });
 
   it('renders a retryable full-surface error when the first request fails', () => {

--- a/src/features/Conversation/StoreUpdater.tsx
+++ b/src/features/Conversation/StoreUpdater.tsx
@@ -84,9 +84,6 @@ const StoreUpdater = memo<StoreUpdaterProps>(
     useStoreUpdater('operationState', operationState!);
     useStoreUpdater('skipFetch', skipFetch!);
 
-    // When external messages are provided, mark as initialized
-    useStoreUpdater('messagesInit', skipFetch ? true : (hasInitMessages ?? false));
-
     // Reset store state before paint when context changes.
     // useLayoutEffect fires after commit but before browser paint, and React processes
     // store updates triggered here synchronously — so subscribers re-render before paint.
@@ -116,6 +113,19 @@ const StoreUpdater = memo<StoreUpdaterProps>(
         }
       }
     }, [contextKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    // Initialization is a one-way settled-data signal within a conversation.
+    // A hydrated SWR snapshot may set it to true in a child layout effect while
+    // the parent ChatStore projection is still one render behind. Mirroring a
+    // stale `hasInitMessages=false` back into the store would then erase that
+    // cache hit and paint a skeleton. Context changes reset it explicitly in
+    // the layout effect above; external data only needs to promote it to true.
+    useLayoutEffect(() => {
+      if (!skipFetch && !hasInitMessages) return;
+      if (storeApi.getState().messagesInit) return;
+
+      storeApi.setState({ messagesInit: true });
+    }, [hasInitMessages, skipFetch, storeApi]);
 
     // Sync external messages into store
     useEffect(() => {

--- a/src/features/Conversation/store/action.ts
+++ b/src/features/Conversation/store/action.ts
@@ -57,8 +57,8 @@ export interface CreateStoreParams {
    * context — StoreUpdater resets state in place instead), so this only covers
    * genuine mounts: first navigation to a surface, or hosts that key the whole
    * provider themselves (e.g. eval bench). Without a seed such a mount starts
-   * `messagesInit: false` and only gets populated by a post-paint effect — one
-   * blank frame, i.e. the "message disappears then reappears" flicker.
+   * `messagesInit: false`; a hydrated SWR snapshot is projected before paint,
+   * while a real cache miss remains loading until its request settles.
    * `undefined` means "not fetched yet" (stay uninitialized); `[]` means
    * "loaded, empty".
    */

--- a/src/features/Conversation/store/slices/data/action.test.ts
+++ b/src/features/Conversation/store/slices/data/action.test.ts
@@ -720,6 +720,52 @@ describe('DataSlice', () => {
       expect(onMessagesChange).not.toHaveBeenCalled();
     });
 
+    it('accepts hydrated data after the store switches to the requested conversation', () => {
+      vi.mocked(messageService.getMessages).mockReturnValue(new Promise<never>(() => {}));
+
+      const previousContext = {
+        agentId: 'test-session',
+        threadId: null,
+        topicId: 'topic-previous',
+      };
+      const requestedContext = {
+        agentId: 'test-session',
+        threadId: null,
+        topicId: 'topic-requested',
+      };
+      const cachedMessages: UIChatMessage[] = [
+        {
+          content: 'hydrated topic history',
+          createdAt: 1000,
+          id: 'msg-cached',
+          role: 'user',
+          updatedAt: 1000,
+        },
+      ];
+      const store = createStore({ context: previousContext });
+
+      store.getState().useFetchMessages(requestedContext);
+      const options = vi.mocked(useClientDataSWRWithSync).mock.calls.at(-1)?.[2] as
+        | {
+            onData?: (data: UIChatMessage[]) => boolean | void;
+            syncBeforePaint?: boolean;
+          }
+        | undefined;
+
+      const deferred = options?.onData?.(cachedMessages);
+
+      expect(deferred).toBe(false);
+      expect(store.getState().dbMessages).toEqual([]);
+      expect(store.getState().messagesInit).toBe(false);
+
+      store.setState({ context: requestedContext, messagesInit: false });
+      options?.onData?.(cachedMessages);
+
+      expect(options?.syncBeforePaint).toBe(true);
+      expect(store.getState().dbMessages).toEqual(cachedMessages);
+      expect(store.getState().messagesInit).toBe(true);
+    });
+
     it('should pass null threadId when provided as null', async () => {
       const mockMessages: UIChatMessage[] = [
         {

--- a/src/features/Conversation/store/slices/data/action.ts
+++ b/src/features/Conversation/store/slices/data/action.ts
@@ -250,7 +250,6 @@ export const dataSlice: StateCreator<
     // only local optimistic updates. Fetching would return empty array and overwrite local data.
     const shouldFetch = !skipFetch && !!context.agentId && !!context.topicId;
     const contextKey = messageMapKey(context);
-    const storeContextKeyAtRequest = messageMapKey(get().context);
     const onMessagesChange = get().onMessagesChange;
 
     log(
@@ -272,21 +271,22 @@ export const dataSlice: StateCreator<
         // Fresh in-memory or prefetched data can render without an immediate
         // switch-time revalidation. Missing cache data still fetches because
         // SWR always loads when `data` is undefined.
+        syncBeforePaint: true,
         onData: (data) => {
           if (!data) return;
           if (!context.topicId) return;
 
           const storeContextKey = messageMapKey(get().context);
-          if (storeContextKeyAtRequest !== storeContextKey) {
+          if (contextKey !== storeContextKey) {
             log(
-              '[useFetchMessages] dropped stale result | requestStoreContextKey=%s | storeContextKey=%s',
-              storeContextKeyAtRequest,
+              '[useFetchMessages] deferred result until context switch | requestContextKey=%s | storeContextKey=%s',
+              contextKey,
               storeContextKey,
             );
-            return;
+            return false;
           }
 
-          // Defense-in-depth gate: drop any SWR onData while the
+          // Defense-in-depth gate: defer any SWR onData while the
           // topic is streaming. DB fan-out for chunk writes is async and lags
           // the WS push by anywhere from 100ms to several seconds; an SWR
           // refetch that lands inside that window returns the assistant row
@@ -300,7 +300,7 @@ export const dataSlice: StateCreator<
           // updatedAt comparison degenerates when server's pushed snapshot
           // carries a DB updatedAt equal to a later stale fetch's row.
           if (operationSelectors.isAgentRuntimeRunningByContext(context)(getChatStoreState()))
-            return;
+            return false;
 
           const prevDbMessages = get().dbMessages;
           const activeVoiceMessageIds = new Set(

--- a/src/features/Conversation/useAgentContext.test.tsx
+++ b/src/features/Conversation/useAgentContext.test.tsx
@@ -12,14 +12,22 @@ import { initialEditorState } from '@/store/document/slices/editor';
 import { useAgentContext } from './useAgentContext';
 
 const activeWorkspaceSlugMock = vi.hoisted(() => ({ value: null as string | null }));
+const coordinateMock = vi.hoisted(
+  () => ['agt_1', 'tpc_1', null] as [string, string | null, string | null],
+);
 
 vi.mock('@/business/client/hooks/useActiveWorkspaceSlug', () => ({
   useActiveWorkspaceSlug: () => activeWorkspaceSlugMock.value,
 }));
 
+vi.mock('./useAgentConversationCoordinate', () => ({
+  useAgentConversationCoordinate: () => coordinateMock,
+}));
+
 describe('useAgentContext', () => {
   beforeEach(() => {
     activeWorkspaceSlugMock.value = null;
+    coordinateMock.splice(0, coordinateMock.length, 'agt_1', 'tpc_1', null);
     useChatStore.setState(
       {
         ...initialChatState,

--- a/src/features/Conversation/useAgentConversationCoordinate.test.ts
+++ b/src/features/Conversation/useAgentConversationCoordinate.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { initialState as initialChatState } from '@/store/chat/initialState';
+import { useChatStore } from '@/store/chat/store';
+
+import { useAgentConversationCoordinate } from './useAgentConversationCoordinate';
+
+const route = vi.hoisted(() => ({
+  params: { aid: 'agent-route', topicId: 'topic-route' } as {
+    aid?: string;
+    topicId?: string;
+  },
+  search: new URLSearchParams('thread=thread-route'),
+}));
+
+vi.mock('react-router', () => ({
+  useParams: () => route.params,
+  useSearchParams: () => [route.search, vi.fn()],
+}));
+
+describe('useAgentConversationCoordinate', () => {
+  beforeEach(() => {
+    route.params = { aid: 'agent-route', topicId: 'topic-route' };
+    route.search = new URLSearchParams('thread=thread-route');
+    useChatStore.setState(
+      {
+        ...initialChatState,
+        activeAgentId: 'agent-global',
+        activeThreadId: 'thread-global',
+        activeTopicId: 'topic-global',
+      },
+      false,
+    );
+  });
+
+  it('uses the route coordinate before the global chat pointer catches up', () => {
+    const { result } = renderHook(() => useAgentConversationCoordinate());
+
+    expect(result.current).toEqual(['agent-route', 'topic-route', 'thread-route']);
+  });
+
+  it('does not inherit the previous global topic for a blank conversation route', () => {
+    route.params = { aid: 'agent-route' };
+    route.search = new URLSearchParams();
+
+    const { result } = renderHook(() => useAgentConversationCoordinate());
+
+    expect(result.current).toEqual(['agent-route', null, null]);
+  });
+});

--- a/src/features/Conversation/useAgentConversationCoordinate.ts
+++ b/src/features/Conversation/useAgentConversationCoordinate.ts
@@ -1,7 +1,11 @@
-import { useChatStore } from '@/store/chat';
+import { useParams, useSearchParams } from 'react-router';
 
-export const useAgentConversationCoordinate = () =>
-  useChatStore(
-    (state) =>
-      [state.activeAgentId, state.activeTopicId ?? null, state.activeThreadId ?? null] as const,
-  );
+import { useResolvedAgentRouteId } from '@/features/AgentRoute/useResolvedAgentRouteId';
+
+export const useAgentConversationCoordinate = () => {
+  const params = useParams<{ aid?: string; topicId?: string }>();
+  const [searchParams] = useSearchParams();
+  const { agentId } = useResolvedAgentRouteId(params.aid);
+
+  return [agentId, params.topicId ?? null, searchParams.get('thread')] as const;
+};

--- a/src/libs/swr/useClientDataSWRWithSync.test.ts
+++ b/src/libs/swr/useClientDataSWRWithSync.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { renderHook } from '@testing-library/react';
+import { createElement, type PropsWithChildren, useLayoutEffect } from 'react';
+import { type Cache, SWRConfig, unstable_serialize } from 'swr';
+import { describe, expect, it } from 'vitest';
+
+import { useClientDataSWRWithSync } from './useClientDataSWRWithSync';
+
+const KEY_A = ['test:sync', 'a'] as const;
+const KEY_B = ['test:sync', 'b'] as const;
+const CACHED_A = [{ id: 'cached-a' }];
+const CACHED_B = [{ id: 'cached-b' }];
+
+const createWrapper = () => {
+  const cache = new Map([
+    [unstable_serialize(KEY_A), { data: CACHED_A }],
+    [unstable_serialize(KEY_B), { data: CACHED_B }],
+  ]);
+
+  return ({ children }: PropsWithChildren) =>
+    createElement(SWRConfig, { value: { provider: () => cache as unknown as Cache } }, children);
+};
+
+describe('useClientDataSWRWithSync', () => {
+  it('projects hydrated cache before later layout consumers observe the frame', () => {
+    let projected: typeof CACHED_A | undefined;
+    const layoutObservations: Array<typeof CACHED_A | undefined> = [];
+
+    renderHook(
+      () => {
+        useClientDataSWRWithSync<{ id: string }[]>(KEY_A, null, {
+          onData: (data) => {
+            projected = data;
+          },
+          syncBeforePaint: true,
+        });
+
+        useLayoutEffect(() => {
+          layoutObservations.push(projected);
+        }, []);
+      },
+      { wrapper: createWrapper() },
+    );
+
+    expect(layoutObservations).toEqual([CACHED_A]);
+  });
+
+  it('synchronizes each cache key once when the consumer switches keys', () => {
+    const synchronizedIds: string[] = [];
+    const { rerender } = renderHook(
+      ({ cacheKey, revision }: { cacheKey: readonly string[]; revision: number }) => {
+        void revision;
+        useClientDataSWRWithSync<{ id: string }[]>(cacheKey, null, {
+          onData: (data) => {
+            synchronizedIds.push(data[0].id);
+          },
+          syncBeforePaint: true,
+        });
+      },
+      {
+        initialProps: { cacheKey: KEY_A as readonly string[], revision: 0 },
+        wrapper: createWrapper(),
+      },
+    );
+
+    rerender({ cacheKey: KEY_A, revision: 1 });
+    rerender({ cacheKey: KEY_B, revision: 2 });
+
+    expect(synchronizedIds).toEqual(['cached-a', 'cached-b']);
+  });
+
+  it('retries a hydrated snapshot when the destination initially rejects it', () => {
+    const attempts: boolean[] = [];
+    let projected: typeof CACHED_A | undefined;
+    const { rerender } = renderHook(
+      ({ ready }: { ready: boolean }) => {
+        useClientDataSWRWithSync<{ id: string }[]>(KEY_A, null, {
+          onData: (data) => {
+            attempts.push(ready);
+            if (!ready) return false;
+
+            projected = data;
+          },
+          syncBeforePaint: true,
+        });
+      },
+      { initialProps: { ready: false }, wrapper: createWrapper() },
+    );
+
+    expect(attempts).toEqual([false]);
+    expect(projected).toBeUndefined();
+
+    rerender({ ready: true });
+
+    expect(attempts).toEqual([false, true]);
+    expect(projected).toBe(CACHED_A);
+  });
+});

--- a/src/libs/swr/useClientDataSWRWithSync.ts
+++ b/src/libs/swr/useClientDataSWRWithSync.ts
@@ -9,8 +9,8 @@
  * SWR key — consumers never need to opt in per call.
  */
 
-import { useEffect, useRef } from 'react';
-import { type SWRConfiguration, type SWRResponse } from 'swr';
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import { type SWRConfiguration, type SWRResponse, unstable_serialize } from 'swr';
 
 import { useClientDataSWR } from './index';
 
@@ -20,12 +20,22 @@ interface UseClientDataSWRWithSyncOptions<T> extends SWRConfiguration<T> {
   /**
    * Data sync callback, called when data is available (both cached and fresh data)
    * Used to sync data to Zustand store
+   *
+   * Return `false` when the destination is temporarily unable to consume the
+   * snapshot. The same key/data pair will then be retried on a later render.
    */
-  onData?: (data: T) => void;
+  onData?: (data: T) => boolean | void;
   /**
    * Whether to skip sync (optional, for conditional skipping)
    */
   skipSync?: boolean;
+  /**
+   * Synchronize cached data before browser paint.
+   *
+   * Use this when the Zustand projection controls the first-load surface and
+   * a passive effect would otherwise paint a stale loading state for one frame.
+   */
+  syncBeforePaint?: boolean;
 }
 
 /**
@@ -55,8 +65,24 @@ export function useClientDataSWRWithSync<T>(
   fetcher: (() => Promise<T>) | null,
   options?: UseClientDataSWRWithSyncOptions<T>,
 ): SWRResponse<T> {
-  const { onData, skipSync, onSuccess, ...swrOptions } = options || {};
-  const hasSyncedRef = useRef(false);
+  const { onData, skipSync, syncBeforePaint, onSuccess, ...swrOptions } = options || {};
+  const serializedKey = unstable_serialize(key);
+  const lastSyncedRef = useRef<{ data: T; key: string } | undefined>(undefined);
+
+  const syncData = useCallback(
+    (data: T) => {
+      if (!serializedKey || !onData || skipSync) return;
+
+      const lastSynced = lastSyncedRef.current;
+      if (lastSynced?.key === serializedKey && Object.is(lastSynced.data, data)) return;
+
+      const consumed = onData(data);
+      if (consumed === false) return;
+
+      lastSyncedRef.current = { data, key: serializedKey };
+    },
+    [onData, serializedKey, skipSync],
+  );
 
   const response = useClientDataSWR<T>(key, fetcher, {
     ...swrOptions,
@@ -64,27 +90,27 @@ export function useClientDataSWRWithSync<T>(
       // Call original onSuccess
       onSuccess?.(data, key, config);
       // Also sync via onData
-      if (onData && !skipSync) {
-        onData(data);
-        hasSyncedRef.current = true;
-      }
+      syncData(data);
     },
   });
 
   const { data } = response;
 
-  // When cached data is available, sync to store immediately
-  useEffect(() => {
-    if (data && onData && !skipSync && !hasSyncedRef.current) {
-      onData(data);
-      hasSyncedRef.current = true;
-    }
-  }, [data, onData, skipSync]);
+  // Loading projections that own the first-paint state consume hydrated cache
+  // data in the layout phase so a cache hit never paints as a loading frame.
+  useLayoutEffect(() => {
+    if (!syncBeforePaint || data === undefined) return;
 
-  // Reset sync state when key changes
+    syncData(data);
+  }, [data, syncBeforePaint, syncData]);
+
+  // Other projections retain passive synchronization to keep non-critical
+  // cached-data processing off the initial render path.
   useEffect(() => {
-    hasSyncedRef.current = false;
-  }, [key?.toString()]);
+    if (syncBeforePaint || data === undefined) return;
+
+    syncData(data);
+  }, [data, syncBeforePaint, syncData]);
 
   return response;
 }

--- a/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
@@ -38,6 +38,7 @@ import MainChatInput from './MainChatInput';
 import MessageFromUrl from './MainChatInput/MessageFromUrl';
 import ThreadHydration from './ThreadHydration';
 import { useActionsBarConfig } from './useActionsBarConfig';
+import { useHydratedConversationMessages } from './useHydratedConversationMessages';
 
 const log = debug('lobe-render:agent:ConversationArea');
 
@@ -68,12 +69,9 @@ const Conversation = memo(() => {
 
   // Get raw dbMessages from ChatStore for this context
   // ConversationStore will parse them internally to generate displayMessages
-  const chatKey = useMemo(
-    () => messageMapKey(context),
-    [context.agentId, context.topicId, context.threadId],
-  );
+  const chatKey = messageMapKey(context);
   const replaceMessages = useChatStore((s) => s.replaceMessages);
-  const messages = useChatStore((s) => s.dbMessagesMap[chatKey]);
+  const messages = useHydratedConversationMessages(context);
 
   log('contextKey %s: %o', chatKey, messages);
 

--- a/src/routes/(main)/agent/features/Conversation/useHydratedConversationMessages.test.ts
+++ b/src/routes/(main)/agent/features/Conversation/useHydratedConversationMessages.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import type { ConversationContext, UIChatMessage } from '@lobechat/types';
+import { renderHook } from '@testing-library/react';
+import { createElement, type PropsWithChildren } from 'react';
+import { type Cache, SWRConfig, unstable_serialize } from 'swr';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { messageListKey } from '@/services/message/cache';
+import { initialState as initialChatState } from '@/store/chat/initialState';
+import { useChatStore } from '@/store/chat/store';
+import { messageMapKey } from '@/store/chat/utils/messageMapKey';
+
+import { useHydratedConversationMessages } from './useHydratedConversationMessages';
+
+const context: ConversationContext = {
+  agentId: 'agent-1',
+  scope: 'main',
+  threadId: null,
+  topicId: 'topic-1',
+};
+const hydratedMessages = [{ content: 'cached', id: 'cached', role: 'user' }] as UIChatMessage[];
+const liveMessages = [{ content: 'streaming', id: 'live', role: 'assistant' }] as UIChatMessage[];
+
+const createWrapper = () => {
+  const cache = new Map([
+    [unstable_serialize(messageListKey(context)), { data: hydratedMessages }],
+  ]);
+
+  return ({ children }: PropsWithChildren) =>
+    createElement(SWRConfig, { value: { provider: () => cache as unknown as Cache } }, children);
+};
+
+describe('useHydratedConversationMessages', () => {
+  beforeEach(() => {
+    useChatStore.setState({ ...initialChatState }, false);
+  });
+
+  it('returns the hydrated SWR snapshot before ChatStore has projected it', () => {
+    const { result } = renderHook(() => useHydratedConversationMessages(context), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current).toBe(hydratedMessages);
+  });
+
+  it('prefers live ChatStore messages over persisted cache data', () => {
+    useChatStore.setState({
+      dbMessagesMap: { [messageMapKey(context)]: liveMessages },
+    });
+
+    const { result } = renderHook(() => useHydratedConversationMessages(context), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current).toBe(liveMessages);
+  });
+});

--- a/src/routes/(main)/agent/features/Conversation/useHydratedConversationMessages.ts
+++ b/src/routes/(main)/agent/features/Conversation/useHydratedConversationMessages.ts
@@ -1,0 +1,23 @@
+import type { ConversationContext, UIChatMessage } from '@lobechat/types';
+
+import { useClientDataSWR } from '@/libs/swr';
+import { messageListKey } from '@/services/message/cache';
+import { useChatStore } from '@/store/chat';
+import { messageMapKey } from '@/store/chat/utils/messageMapKey';
+
+/**
+ * Resolve the first render's message snapshot without waiting for the
+ * ConversationStore to project the same hydrated SWR entry back to ChatStore.
+ * Live ChatStore state always wins so persisted data cannot replace optimistic
+ * or streaming messages.
+ */
+export const useHydratedConversationMessages = (context: ConversationContext) => {
+  const chatKey = messageMapKey(context);
+  const storeMessages = useChatStore((s) => s.dbMessagesMap[chatKey]);
+  const { data: hydratedMessages } = useClientDataSWR<UIChatMessage[]>(
+    context.agentId && context.topicId ? messageListKey(context) : null,
+    null,
+  );
+
+  return storeMessages ?? hydratedMessages;
+};

--- a/src/store/chat/slices/topic/action.test.ts
+++ b/src/store/chat/slices/topic/action.test.ts
@@ -2,11 +2,14 @@ import { DEFAULT_MODEL, DEFAULT_PROVIDER } from '@lobechat/business-const';
 import { TOPIC_TITLE_JSON_SCHEMA } from '@lobechat/prompts';
 import type { LobeUser, UIChatMessage } from '@lobechat/types';
 import { act, renderHook, waitFor } from '@testing-library/react';
+import { createElement, type PropsWithChildren, useLayoutEffect } from 'react';
+import { type Cache, SWRConfig, unstable_serialize } from 'swr';
 import { type Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { LOADING_FLAT } from '@/const/message';
 import { mutate } from '@/libs/swr';
+import { topicKeys } from '@/libs/swr/keys';
 import { aiChatService } from '@/services/aiChat';
 import { chatService } from '@/services/chat';
 import { messageService } from '@/services/message';
@@ -642,6 +645,38 @@ describe('topic action', () => {
   });
 
   describe('useFetchTopics', () => {
+    it('projects a hydrated topic list before the first layout frame', () => {
+      const agentId = 'hydrated-agent';
+      const containerKey = topicMapKey({ agentId });
+      const cachedTopics = [{ id: 'topic-cached', title: 'Cached Topic' }] as ChatTopic[];
+      const cacheKey = topicKeys.list(containerKey, { isInbox: undefined, pageSize: 20 });
+      const cache = new Map([
+        [unstable_serialize(cacheKey), { data: { items: cachedTopics, total: 1 } }],
+      ]);
+      const layoutObservations: Array<ChatTopic[] | undefined> = [];
+      const wrapper = ({ children }: PropsWithChildren) =>
+        createElement(
+          SWRConfig,
+          { value: { provider: () => cache as unknown as Cache } },
+          children,
+        );
+      (topicService.getTopics as Mock).mockReturnValue(new Promise<never>(() => {}));
+
+      const result = renderHook(
+        () => {
+          useChatStore.getState().useFetchTopics(true, { agentId });
+
+          useLayoutEffect(() => {
+            layoutObservations.push(useChatStore.getState().topicDataMap[containerKey]?.items);
+          }, []);
+        },
+        { wrapper },
+      );
+
+      expect(layoutObservations).toEqual([cachedTopics]);
+      result.unmount();
+    });
+
     it('should fetch topics for a given session id', async () => {
       const sessionId = 'test-session-id';
       const topics = [{ id: 'topic-id', title: 'Test Topic' }];

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -932,6 +932,7 @@ export class ChatTopicActionImpl {
       },
       {
         // onData: responsible for state updates (fires for both cached and fresh data)
+        syncBeforePaint: true,
         onData: (result) => {
           if (!hasValidContainer) return;
 


### PR DESCRIPTION
## Summary

- hydrate the conversation store from the IndexedDB-backed SWR snapshot while continuing to prioritize live ChatStore messages
- derive the web conversation coordinate directly from the route on first render, avoiding stale topic/thread state during navigation
- project cached topic and message state before paint and preserve settled initialization state, removing repeated warm-cache loading flashes
- add regression coverage for cached topic lists, conversation coordinates, hydrated messages, and initialization state

## Verification

- bun run check on 18 changed files on the reproduction baseline: lint clean, 160 tests passed
- rebased cleanly onto latest canary; final-baseline lint is clean and 17 runnable tests pass
- 5 final-baseline suites are currently blocked before collection because the reused workspace dependencies do not yet expose @lobechat/utils/mcpIpcPayload required by latest canary; there were no assertion failures
- repeated local SPA home to same-topic navigation: no conversation skeleton in 5/5 warm-cache reopen cycles
- Acceptance report: https://app.lobehub.com/acceptance/615f462e-3ae5-4bf8-b942-a9865906115d