### PR TITLE
♻️ refactor(server): mount tRPC in Hono runtime

### DIFF
--- a/.agents/acceptance/probe-mock-patterns.md
+++ b/.agents/acceptance/probe-mock-patterns.md
@@ -1656,6 +1656,36 @@ delta. Also: read the feed server's 404 line after boot to learn the exact
 
 ### Dev server, install, and ports
 
+#### Next 16 allows one `next dev` per checkout — a second topology needs a worktree
+
+**Situation:** the user's `dev:next` is already listening (3010) and the run needs a
+second Next instance with different env (for example `bun run dev:hono`, which needs
+`LOBE_DEV_TOPOLOGY=hono` at Next start so its `/trpc` rewrite is registered).
+
+**Doesn't work:** starting the second launcher with other ports from the same
+directory. Next 16 refuses with `Another next dev server is already running`
+(lock under `.next/dev`), the launcher then tears its own children down and exits
+143 — it reads like a port clash but no port was shared.
+
+**Works:** `git worktree add --detach ../<name> HEAD && pnpm install` (\~1 min with
+the shared store) and start the stack from there with absolute paths. Point it at
+the managed acceptance DB (`DB_PORT`/`REDIS_PORT` overrides when 5433/6380 are
+taken) instead of copying the user's `.env`, whose database may be behind the
+branch's migrations. Remove the worktree at teardown.
+
+#### `agent-browser cookies set --curl` wants a `Cookie:` header file, not a curl jar
+
+**Situation:** a session cookie obtained with `curl -c jar` from the app's sign-in
+endpoint must be injected into an isolated agent-browser session.
+
+**Doesn't work:** `cookies set --curl jar.txt` — the Netscape jar format yields
+`no cookies found in input`.
+
+**Works:** write one line `Cookie: name=value; name2=value2` and pass that file
+(`--domain localhost`); `cookies get` then lists the HttpOnly session cookie and the
+next `open` lands signed in. Use a dedicated `--session` name so the harness's
+`lobehub-dev` session and its saved state are untouched.
+
 #### A backgrounded `init-dev-env.sh dev` looks dead while the server is alive on a dynamic port
 
 **Situation:** starting the dev server from a harness-managed background command in a

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ docs/superpowers/
 # Amp agent runtime
 .amp/*
 !.amp/settings.json
+!apps/server/Dockerfile.dockerignore

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,0 +1,57 @@
+# Standalone Hono runtime (tRPC + /api/agent + /api/workflows) without Next.js.
+# Build context must be the repository root:
+#   docker build -f apps/server/Dockerfile -t lobehub-hono .
+ARG NODEJS_VERSION="24"
+
+FROM node:${NODEJS_VERSION}-slim AS builder
+
+ARG USE_CN_MIRROR
+ENV NODE_OPTIONS="--max-old-space-size=8192"
+
+WORKDIR /app
+
+COPY package.json pnpm-workspace.yaml .npmrc ./
+COPY packages ./packages
+COPY patches ./patches
+COPY apps/server/package.json ./apps/server/package.json
+COPY apps/desktop/src/main/package.json ./apps/desktop/src/main/package.json
+COPY apps/share/package.json ./apps/share/package.json
+COPY apps/workbench/package.json ./apps/workbench/package.json
+
+RUN set -e && \
+    if [ "${USE_CN_MIRROR:-false}" = "true" ]; then \
+        npm config set registry "https://registry.npmmirror.com/"; \
+    fi && \
+    export COREPACK_NPM_REGISTRY=$(npm config get registry | sed 's/\/$//') && \
+    npm i -g corepack@latest && \
+    corepack enable && \
+    corepack use $(sed -n 's/.*"packageManager": "\(.*\)".*/\1/p' package.json) && \
+    pnpm i
+
+COPY . .
+
+RUN pnpm --filter @lobechat/server build
+
+# The bundle inlines @lobechat/* but leaves third-party packages external, so the runtime
+# image only needs the packages the bundle actually imports, pinned to the builder's versions.
+RUN mkdir -p /deps && \
+    pnpm exec tsx scripts/honoRuntimeDeps.mts --dist apps/server/dist --out /deps && \
+    cp -r patches /deps/patches && \
+    cd /deps && \
+    pnpm i --prod
+
+FROM node:${NODEJS_VERSION}-slim AS app
+
+ENV NODE_ENV="production"
+
+WORKDIR /app
+
+COPY --from=builder /app/apps/server/package.json /app/package.json
+COPY --from=builder /deps/node_modules /app/node_modules
+COPY --from=builder /app/apps/server/dist /app/dist
+
+USER node
+
+EXPOSE 3011/tcp
+
+CMD ["node", "dist/standalone.js"]

--- a/apps/server/Dockerfile.dockerignore
+++ b/apps/server/Dockerfile.dockerignore
@@ -1,0 +1,13 @@
+**/node_modules
+**/.git
+.next
+dist
+public/_spa*
+apps/desktop/dist
+apps/desktop/release
+apps/desktop/out
+apps/server/dist
+apps/share/build
+apps/workbench/build
+e2e
+docs

--- a/apps/server/honoExternals.ts
+++ b/apps/server/honoExternals.ts
@@ -1,0 +1,14 @@
+// Everything else is bundled into dist; only packages with native bindings or bundled
+// binaries stay in node_modules (unresolvable optional peers are listed so rolldown skips them).
+export const honoNativeExternals = [
+  '@napi-rs/canvas',
+  '@react-email/render',
+  'bufferutil',
+  'canvas',
+  'ffmpeg-static',
+  'pg-native',
+  'sharp',
+  'utf-8-validate',
+  'zipfile',
+  'zlib-sync',
+];

--- a/apps/server/railway.json
+++ b/apps/server/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "apps/server/Dockerfile"
+  },
+  "deploy": {
+    "drainingSeconds": 15,
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 120,
+    "restartPolicyMaxRetries": 5,
+    "restartPolicyType": "ON_FAILURE"
+  }
+}

--- a/apps/server/src/router-hono/index.test.ts
+++ b/apps/server/src/router-hono/index.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import app from './index';
+
+vi.mock('./trpc/async', () => ({
+  default: { fetch: () => new Response('async') },
+}));
+vi.mock('./trpc/lambda', () => ({
+  default: { fetch: () => new Response('lambda') },
+}));
+vi.mock('./trpc/mobile', () => ({
+  default: { fetch: () => new Response('mobile') },
+}));
+vi.mock('./trpc/tools', () => ({
+  default: { fetch: () => new Response('tools') },
+}));
+
+describe('standalone Hono routes', () => {
+  it.each([
+    ['/trpc/async/healthcheck', 'async'],
+    ['/trpc/lambda/healthcheck', 'lambda'],
+    ['/trpc/mobile/healthcheck', 'mobile'],
+    ['/trpc/tools/healthcheck', 'tools'],
+  ])('forwards %s to its tRPC app', async (path, expected) => {
+    const response = await app.request(path);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(expected);
+  });
+});

--- a/apps/server/src/router-hono/index.ts
+++ b/apps/server/src/router-hono/index.ts
@@ -1,7 +1,11 @@
 import type { Context } from 'hono';
 import { Hono } from 'hono';
 
+import { nextCompat } from './next-compat/context';
+
 const app = new Hono();
+
+app.use('*', nextCompat());
 
 const fetchWith = async (
   c: Context,

--- a/apps/server/src/router-hono/index.ts
+++ b/apps/server/src/router-hono/index.ts
@@ -1,3 +1,5 @@
+import './polyfills';
+
 import type { Context } from 'hono';
 import { Hono } from 'hono';
 

--- a/apps/server/src/router-hono/index.ts
+++ b/apps/server/src/router-hono/index.ts
@@ -21,5 +21,9 @@ app.all('/api/agent', (c) => fetchWith(c, () => import('./agent')));
 app.all('/api/agent/*', (c) => fetchWith(c, () => import('./agent')));
 app.all('/api/workflows', (c) => fetchWith(c, () => import('./workflows')));
 app.all('/api/workflows/*', (c) => fetchWith(c, () => import('./workflows')));
+app.all('/trpc/async/*', (c) => fetchWith(c, () => import('./trpc/async')));
+app.all('/trpc/lambda/*', (c) => fetchWith(c, () => import('./trpc/lambda')));
+app.all('/trpc/mobile/*', (c) => fetchWith(c, () => import('./trpc/mobile')));
+app.all('/trpc/tools/*', (c) => fetchWith(c, () => import('./trpc/tools')));
 
 export default app;

--- a/apps/server/src/router-hono/next-compat/context.ts
+++ b/apps/server/src/router-hono/next-compat/context.ts
@@ -1,0 +1,73 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+import type { MiddlewareHandler } from 'hono';
+
+export type AfterTask = Promise<unknown> | (() => unknown | Promise<unknown>);
+
+export interface RequestContext {
+  afterTasks: AfterTask[];
+  request: Request;
+  responseHeaders: Headers;
+}
+
+const storage = new AsyncLocalStorage<RequestContext>();
+
+export const getRequestContext = () => storage.getStore();
+
+export const requireRequestContext = (api: string): RequestContext => {
+  const context = storage.getStore();
+  if (!context)
+    throw new Error(
+      `\`${api}\` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context`,
+    );
+
+  return context;
+};
+
+export const runWithRequestContext = <T>(request: Request, fn: () => T): T =>
+  storage.run({ afterTasks: [], request, responseHeaders: new Headers() }, fn);
+
+const pendingAfterTasks = new Set<Promise<void>>();
+
+export const runAfterTask = (task: AfterTask) => {
+  const pending: Promise<void> = Promise.resolve()
+    .then(() => (typeof task === 'function' ? task() : task))
+    .then(
+      () => {},
+      (error) => {
+        console.error('[next-compat] after() task failed:', error);
+      },
+    )
+    .finally(() => pendingAfterTasks.delete(pending));
+  pendingAfterTasks.add(pending);
+
+  return pending;
+};
+
+export const drainAfterTasks = async () => {
+  while (pendingAfterTasks.size > 0) await Promise.allSettled(pendingAfterTasks);
+};
+
+export const nextCompat = (): MiddlewareHandler => async (c, next) => {
+  const context: RequestContext = {
+    afterTasks: [],
+    request: c.req.raw,
+    responseHeaders: new Headers(),
+  };
+
+  await storage.run(context, next);
+
+  const setCookies = context.responseHeaders.getSetCookie();
+  if (setCookies.length > 0) {
+    const response = new Response(c.res.body, c.res);
+    for (const cookie of setCookies) response.headers.append('set-cookie', cookie);
+    c.res = response;
+  }
+
+  if (context.afterTasks.length > 0) {
+    const tasks = context.afterTasks;
+    setImmediate(() => {
+      for (const task of tasks) void runAfterTask(task);
+    });
+  }
+};

--- a/apps/server/src/router-hono/next-compat/headers.ts
+++ b/apps/server/src/router-hono/next-compat/headers.ts
@@ -1,56 +1,63 @@
-import type {
-  RequestCookies as RequestCookiesType,
-  ResponseCookies as ResponseCookiesType,
-} from 'next/dist/compiled/@edge-runtime/cookies';
-import edgeRuntimeCookies from 'next/dist/compiled/@edge-runtime/cookies';
-import type { ReadonlyHeaders } from 'next/dist/server/web/spec-extension/adapters/headers';
-import type { ReadonlyRequestCookies } from 'next/dist/server/web/spec-extension/adapters/request-cookies';
+import type { SerializeOptions } from 'cookie';
+import { parse, serialize } from 'cookie';
 
 import { requireRequestContext } from './context';
 
-const { RequestCookies, ResponseCookies } = edgeRuntimeCookies as {
-  RequestCookies: typeof RequestCookiesType;
-  ResponseCookies: typeof ResponseCookiesType;
-};
+export interface RequestCookie {
+  name: string;
+  value: string;
+}
 
-export const headers = async (): Promise<ReadonlyHeaders> =>
-  new Headers(requireRequestContext('headers').request.headers) as ReadonlyHeaders;
+export type ResponseCookie = RequestCookie & SerializeOptions;
 
-export const cookies = async (): Promise<ReadonlyRequestCookies> => {
+export const headers = async (): Promise<Headers> =>
+  new Headers(requireRequestContext('headers').request.headers);
+
+export const cookies = async () => {
   const { request, responseHeaders } = requireRequestContext('cookies');
-  const requestCookies = new RequestCookies(request.headers);
-  const responseCookies = new ResponseCookies(responseHeaders);
+  const store = new Map<string, string>();
+  for (const [name, value] of Object.entries(parse(request.headers.get('cookie') ?? ''))) {
+    if (value !== undefined) store.set(name, value);
+  }
 
-  const syncReadsWithWrites = () => {
-    for (const cookie of responseCookies.getAll()) {
-      if (cookie.value === '') requestCookies.delete(cookie.name);
-      else requestCookies.set(cookie.name, cookie.value);
-    }
+  const entries = (): RequestCookie[] => [...store].map(([name, value]) => ({ name, value }));
+
+  const write = ({ name, value, ...options }: ResponseCookie) => {
+    responseHeaders.append('set-cookie', serialize(name, value, { path: '/', ...options }));
+    if (value === '') store.delete(name);
+    else store.set(name, value);
+    return compat;
   };
-  syncReadsWithWrites();
 
   const compat = {
-    [Symbol.iterator]: () => requestCookies[Symbol.iterator](),
-    delete: (...args: Parameters<ResponseCookiesType['delete']>) => {
-      responseCookies.delete(...args);
-      syncReadsWithWrites();
-      return compat;
+    [Symbol.iterator]: () => {
+      const pairs = entries().map((cookie) => [cookie.name, cookie] as const);
+      return pairs[Symbol.iterator]();
     },
-    get: (...args: Parameters<RequestCookiesType['get']>) => requestCookies.get(...args),
-    getAll: (...args: Parameters<RequestCookiesType['getAll']>) => requestCookies.getAll(...args),
-    has: (name: string) => requestCookies.has(name),
-    set: (...args: Parameters<ResponseCookiesType['set']>) => {
-      responseCookies.set(...args);
-      syncReadsWithWrites();
-      return compat;
-    },
+    delete: (cookie: string | Partial<ResponseCookie>) =>
+      write({
+        ...(typeof cookie === 'string' ? { name: cookie } : cookie),
+        expires: new Date(0),
+        name: typeof cookie === 'string' ? cookie : (cookie.name ?? ''),
+        value: '',
+      }),
+    get: (name: string): RequestCookie | undefined =>
+      store.has(name) ? { name, value: store.get(name)! } : undefined,
+    getAll: (name?: string) =>
+      name ? entries().filter((cookie) => cookie.name === name) : entries(),
+    has: (name: string) => store.has(name),
+    set: (cookie: string | ResponseCookie, value?: string, options?: SerializeOptions) =>
+      write(typeof cookie === 'string' ? { name: cookie, value: value ?? '', ...options } : cookie),
     get size() {
-      return requestCookies.size;
+      return store.size;
     },
-    toString: () => requestCookies.toString(),
+    toString: () =>
+      entries()
+        .map((cookie) => `${cookie.name}=${cookie.value}`)
+        .join('; '),
   };
 
-  return compat as unknown as ReadonlyRequestCookies;
+  return compat;
 };
 
 export const draftMode = async () => ({

--- a/apps/server/src/router-hono/next-compat/headers.ts
+++ b/apps/server/src/router-hono/next-compat/headers.ts
@@ -1,0 +1,60 @@
+import type {
+  RequestCookies as RequestCookiesType,
+  ResponseCookies as ResponseCookiesType,
+} from 'next/dist/compiled/@edge-runtime/cookies';
+import edgeRuntimeCookies from 'next/dist/compiled/@edge-runtime/cookies';
+import type { ReadonlyHeaders } from 'next/dist/server/web/spec-extension/adapters/headers';
+import type { ReadonlyRequestCookies } from 'next/dist/server/web/spec-extension/adapters/request-cookies';
+
+import { requireRequestContext } from './context';
+
+const { RequestCookies, ResponseCookies } = edgeRuntimeCookies as {
+  RequestCookies: typeof RequestCookiesType;
+  ResponseCookies: typeof ResponseCookiesType;
+};
+
+export const headers = async (): Promise<ReadonlyHeaders> =>
+  new Headers(requireRequestContext('headers').request.headers) as ReadonlyHeaders;
+
+export const cookies = async (): Promise<ReadonlyRequestCookies> => {
+  const { request, responseHeaders } = requireRequestContext('cookies');
+  const requestCookies = new RequestCookies(request.headers);
+  const responseCookies = new ResponseCookies(responseHeaders);
+
+  const syncReadsWithWrites = () => {
+    for (const cookie of responseCookies.getAll()) {
+      if (cookie.value === '') requestCookies.delete(cookie.name);
+      else requestCookies.set(cookie.name, cookie.value);
+    }
+  };
+  syncReadsWithWrites();
+
+  const compat = {
+    [Symbol.iterator]: () => requestCookies[Symbol.iterator](),
+    delete: (...args: Parameters<ResponseCookiesType['delete']>) => {
+      responseCookies.delete(...args);
+      syncReadsWithWrites();
+      return compat;
+    },
+    get: (...args: Parameters<RequestCookiesType['get']>) => requestCookies.get(...args),
+    getAll: (...args: Parameters<RequestCookiesType['getAll']>) => requestCookies.getAll(...args),
+    has: (name: string) => requestCookies.has(name),
+    set: (...args: Parameters<ResponseCookiesType['set']>) => {
+      responseCookies.set(...args);
+      syncReadsWithWrites();
+      return compat;
+    },
+    get size() {
+      return requestCookies.size;
+    },
+    toString: () => requestCookies.toString(),
+  };
+
+  return compat as unknown as ReadonlyRequestCookies;
+};
+
+export const draftMode = async () => ({
+  disable: () => {},
+  enable: () => {},
+  isEnabled: false,
+});

--- a/apps/server/src/router-hono/next-compat/index.test.ts
+++ b/apps/server/src/router-hono/next-compat/index.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { nextCompat, runWithRequestContext } from './context';
 import { cookies, draftMode, headers } from './headers';
-import { after, NextResponse } from './server';
+import { after } from './server';
 
 const createApp = () => new Hono().use('*', nextCompat());
 
@@ -50,6 +50,24 @@ describe('next-compat cookies()', () => {
 
     expect(await response.json()).toEqual({ has: false });
     expect(response.headers.getSetCookie()[0]).toMatch(/^a=; Path=\/; Expires=Thu, 01 Jan 1970/);
+  });
+
+  it('accepts the object form of set() and delete() with cookie options', async () => {
+    const app = createApp().get('/cookie', async (c) => {
+      const store = await cookies();
+      store.set({ httpOnly: true, name: 's', sameSite: 'lax', value: 'v' });
+      store.delete({ name: 'a', path: '/app' });
+
+      return c.json({ all: store.getAll().map((cookie) => cookie.name), text: store.toString() });
+    });
+
+    const response = await app.request('/cookie', { headers: { cookie: 'a=1; z=9' } });
+
+    expect(await response.json()).toEqual({ all: ['z', 's'], text: 'z=9; s=v' });
+    expect(response.headers.getSetCookie()).toEqual([
+      's=v; Path=/; HttpOnly; SameSite=Lax',
+      'a=; Path=/app; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
+    ]);
   });
 
   it('keeps Set-Cookie when the handler response came from a nested app', async () => {
@@ -108,13 +126,5 @@ describe('next-compat after()', () => {
     });
 
     expect(resolved).toBe(true);
-  });
-});
-
-describe('next-compat next/server re-exports', () => {
-  it('keeps the real NextResponse', async () => {
-    const response = NextResponse.json({ ok: true });
-
-    expect(await response.json()).toEqual({ ok: true });
   });
 });

--- a/apps/server/src/router-hono/next-compat/index.test.ts
+++ b/apps/server/src/router-hono/next-compat/index.test.ts
@@ -1,0 +1,120 @@
+import { Hono } from 'hono';
+import { describe, expect, it, vi } from 'vitest';
+
+import { nextCompat, runWithRequestContext } from './context';
+import { cookies, draftMode, headers } from './headers';
+import { after, NextResponse } from './server';
+
+const createApp = () => new Hono().use('*', nextCompat());
+
+describe('next-compat headers()', () => {
+  it('returns the current request headers inside a Hono handler', async () => {
+    const app = createApp().get('/probe', async (c) =>
+      c.text((await headers()).get('x-probe') ?? ''),
+    );
+
+    const response = await app.request('/probe', { headers: { 'x-probe': 'ok' } });
+
+    expect(await response.text()).toBe('ok');
+  });
+
+  it('throws Next.js wording outside a request scope', async () => {
+    await expect(headers()).rejects.toThrow('`headers` was called outside a request scope');
+  });
+});
+
+describe('next-compat cookies()', () => {
+  it('reads request cookies and turns set() into a Set-Cookie header', async () => {
+    const app = createApp().get('/cookie', async (c) => {
+      const store = await cookies();
+      store.set('b', '2', { path: '/' });
+
+      return c.json({ a: store.get('a')?.value, b: store.get('b')?.value, size: store.size });
+    });
+
+    const response = await app.request('/cookie', { headers: { cookie: 'a=1' } });
+
+    expect(await response.json()).toEqual({ a: '1', b: '2', size: 2 });
+    expect(response.headers.getSetCookie()).toEqual(['b=2; Path=/']);
+  });
+
+  it('delete() expires the cookie on the response and hides it from later reads', async () => {
+    const app = createApp().get('/cookie', async (c) => {
+      const store = await cookies();
+      store.delete('a');
+
+      return c.json({ has: store.has('a') });
+    });
+
+    const response = await app.request('/cookie', { headers: { cookie: 'a=1' } });
+
+    expect(await response.json()).toEqual({ has: false });
+    expect(response.headers.getSetCookie()[0]).toMatch(/^a=; Path=\/; Expires=Thu, 01 Jan 1970/);
+  });
+
+  it('keeps Set-Cookie when the handler response came from a nested app', async () => {
+    const inner = new Hono().get('/nested', async (c) => {
+      (await cookies()).set('n', '1');
+      return c.text('inner');
+    });
+    const app = createApp().all('/nested', (c) => inner.fetch(c.req.raw));
+
+    const response = await app.request('/nested');
+
+    expect(await response.text()).toBe('inner');
+    expect(response.headers.getSetCookie()).toEqual(['n=1; Path=/']);
+  });
+
+  it('draftMode() is always disabled', async () => {
+    await expect(draftMode()).resolves.toMatchObject({ isEnabled: false });
+  });
+});
+
+describe('next-compat after()', () => {
+  it('runs the task only after the response was produced', async () => {
+    const task = vi.fn();
+    const app = createApp().get('/after', (c) => {
+      after(task);
+      return c.text('sent');
+    });
+
+    const response = await app.request('/after');
+
+    expect(await response.text()).toBe('sent');
+    expect(task).not.toHaveBeenCalled();
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs immediately when no request scope exists', async () => {
+    const task = vi.fn();
+
+    after(task);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts a pending promise as the task', async () => {
+    let resolved = false;
+    await runWithRequestContext(new Request('http://localhost/'), async () => {
+      after(
+        new Promise<void>((resolve) => {
+          resolved = true;
+          resolve();
+        }),
+      );
+    });
+
+    expect(resolved).toBe(true);
+  });
+});
+
+describe('next-compat next/server re-exports', () => {
+  it('keeps the real NextResponse', async () => {
+    const response = NextResponse.json({ ok: true });
+
+    expect(await response.json()).toEqual({ ok: true });
+  });
+});

--- a/apps/server/src/router-hono/next-compat/server.ts
+++ b/apps/server/src/router-hono/next-compat/server.ts
@@ -1,17 +1,4 @@
-import nextServer from 'next/dist/server/web/exports';
-
 import { type AfterTask, getRequestContext, runAfterTask } from './context';
-
-export const {
-  ImageResponse,
-  NextRequest,
-  NextResponse,
-  URLPattern,
-  userAgent,
-  userAgentFromString,
-} = nextServer;
-
-export type { NextRequest as NextRequestType, NextResponse as NextResponseType } from 'next/server';
 
 export const connection = async () => {};
 

--- a/apps/server/src/router-hono/next-compat/server.ts
+++ b/apps/server/src/router-hono/next-compat/server.ts
@@ -1,0 +1,26 @@
+import nextServer from 'next/dist/server/web/exports';
+
+import { type AfterTask, getRequestContext, runAfterTask } from './context';
+
+export const {
+  ImageResponse,
+  NextRequest,
+  NextResponse,
+  URLPattern,
+  userAgent,
+  userAgentFromString,
+} = nextServer;
+
+export type { NextRequest as NextRequestType, NextResponse as NextResponseType } from 'next/server';
+
+export const connection = async () => {};
+
+export const after = (task: AfterTask): void => {
+  const context = getRequestContext();
+  if (context) {
+    context.afterTasks.push(task);
+    return;
+  }
+
+  void runAfterTask(task);
+};

--- a/apps/server/src/router-hono/polyfills.ts
+++ b/apps/server/src/router-hono/polyfills.ts
@@ -1,0 +1,8 @@
+import 'reflect-metadata';
+
+import { installDomMatrixPolyfill } from '@lobechat/file-loaders';
+
+// In the bundled runtime these polyfills must land before any other module evaluates:
+// tsyringe (via @peculiar/x509) checks Reflect.getMetadata in its module body, and pdfjs-dist
+// runs `new DOMMatrix()` in its module body while officeparser requires it eagerly.
+installDomMatrixPolyfill();

--- a/apps/server/src/router-hono/standalone.ts
+++ b/apps/server/src/router-hono/standalone.ts
@@ -1,87 +1,14 @@
-import type { IncomingMessage, Server, ServerResponse } from 'node:http';
-import { createServer } from 'node:http';
-import { Readable } from 'node:stream';
+import type { Server } from 'node:http';
 
 import honoApp from './index';
+import { createStandaloneServer, resolveStandaloneOptions } from './standaloneServer';
 
 type HonoStandaloneGlobal = typeof globalThis & {
   __lobeHonoStandaloneServer?: Server;
+  __lobeHonoStandaloneSignalHandler?: (signal: NodeJS.Signals) => void;
 };
 
-const DEFAULT_HOST = 'localhost';
-const DEFAULT_PORT = 3011;
-
-const resolvePort = () => {
-  const parsed = Number.parseInt(process.env.HONO_PORT ?? process.env.PORT ?? '', 10);
-
-  return Number.isNaN(parsed) ? DEFAULT_PORT : parsed;
-};
-
-const createRequest = (request: IncomingMessage) => {
-  const headers = new Headers();
-
-  for (const [key, value] of Object.entries(request.headers)) {
-    if (Array.isArray(value)) {
-      for (const item of value) headers.append(key, item);
-    } else if (value !== undefined) {
-      headers.set(key, value);
-    }
-  }
-
-  const protocol = headers.get('x-forwarded-proto') || 'http';
-  const host = headers.get('host') || `${DEFAULT_HOST}:${resolvePort()}`;
-  const url = new URL(request.url || '/', `${protocol}://${host}`);
-
-  const init: RequestInit & { duplex?: 'half' } = {
-    headers,
-    method: request.method,
-  };
-
-  if (request.method !== 'GET' && request.method !== 'HEAD') {
-    init.body = Readable.toWeb(request) as ReadableStream<Uint8Array>;
-    init.duplex = 'half';
-  }
-
-  return new Request(url, init);
-};
-
-const writeResponse = async (response: Response, outgoing: ServerResponse) => {
-  outgoing.statusCode = response.status;
-  outgoing.statusMessage = response.statusText;
-
-  const setCookie = (
-    response.headers as Headers & {
-      getSetCookie?: () => string[];
-    }
-  ).getSetCookie?.();
-
-  response.headers.forEach((value, key) => {
-    if (key.toLowerCase() === 'set-cookie' && setCookie?.length) return;
-    outgoing.setHeader(key, value);
-  });
-  if (setCookie?.length) outgoing.setHeader('set-cookie', setCookie);
-
-  if (!response.body) {
-    outgoing.end();
-    return;
-  }
-
-  Readable.fromWeb(response.body).pipe(outgoing);
-};
-
-const host = process.env.HONO_HOST || DEFAULT_HOST;
-const port = resolvePort();
-const server = createServer((request, response) => {
-  void (async () => {
-    try {
-      await writeResponse(await honoApp.fetch(createRequest(request)), response);
-    } catch (error) {
-      console.error('Hono standalone request failed:', error);
-      response.statusCode = 500;
-      response.end('Internal Server Error');
-    }
-  })();
-});
+const SHUTDOWN_SIGNALS: NodeJS.Signals[] = ['SIGTERM', 'SIGINT'];
 
 const closePreviousServer = (previousServer: Server | undefined) =>
   new Promise<void>((resolve) => {
@@ -95,14 +22,36 @@ const closePreviousServer = (previousServer: Server | undefined) =>
 
 const startServer = async () => {
   const standaloneGlobal = globalThis as HonoStandaloneGlobal;
+  const options = resolveStandaloneOptions();
+  const { close, listen, server } = createStandaloneServer(honoApp, options);
 
   await closePreviousServer(standaloneGlobal.__lobeHonoStandaloneServer);
   standaloneGlobal.__lobeHonoStandaloneServer = server;
 
-  process.title = `lobe-dev-hono-${port}`;
-  server.listen(port, host, () => {
-    console.info(`Hono runtime ready at http://${host}:${port}`);
-  });
+  const previousHandler = standaloneGlobal.__lobeHonoStandaloneSignalHandler;
+  let shuttingDown = false;
+  const onSignal = (signal: NodeJS.Signals) => {
+    if (shuttingDown) process.exit(1);
+    shuttingDown = true;
+    console.info(`Hono runtime received ${signal}, draining in-flight requests and after() tasks`);
+    void close().then((result) => {
+      console.info(
+        result === 'closed'
+          ? 'Hono runtime stopped'
+          : `Hono runtime shutdown timed out after ${options.shutdownTimeoutMs}ms`,
+      );
+      process.exit(result === 'closed' ? 0 : 1);
+    });
+  };
+  for (const signal of SHUTDOWN_SIGNALS) {
+    if (previousHandler) process.off(signal, previousHandler);
+    process.on(signal, onSignal);
+  }
+  standaloneGlobal.__lobeHonoStandaloneSignalHandler = onSignal;
+
+  process.title = `lobe-dev-hono-${options.port}`;
+  await listen();
+  console.info(`Hono runtime ready at http://${options.host}:${options.port}`);
 };
 
 void startServer().catch((error) => {

--- a/apps/server/src/router-hono/standaloneServer.test.ts
+++ b/apps/server/src/router-hono/standaloneServer.test.ts
@@ -1,0 +1,119 @@
+import { Hono } from 'hono';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { nextCompat } from './next-compat/context';
+import { after } from './next-compat/server';
+import { createStandaloneServer, resolveStandaloneOptions } from './standaloneServer';
+
+const baseOptions = {
+  host: '127.0.0.1',
+  keepAliveTimeoutMs: 65_000,
+  port: 0,
+  shutdownTimeoutMs: 2000,
+};
+const servers: Array<{ close: () => Promise<unknown> }> = [];
+
+const start = async (app: Hono, overrides: Partial<typeof baseOptions> = {}) => {
+  const instance = createStandaloneServer(app, { ...baseOptions, ...overrides });
+  await instance.listen();
+  servers.push(instance);
+  const address = instance.server.address();
+  const port = typeof address === 'object' && address ? address.port : 0;
+
+  return { ...instance, url: `http://127.0.0.1:${port}` };
+};
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((s) => s.close()));
+});
+
+describe('resolveStandaloneOptions', () => {
+  it('binds all interfaces only in production by default', () => {
+    expect(resolveStandaloneOptions({ NODE_ENV: 'production' }).host).toBe('0.0.0.0');
+    expect(resolveStandaloneOptions({ NODE_ENV: 'development' }).host).toBe('localhost');
+    expect(resolveStandaloneOptions({ HONO_HOST: '::', NODE_ENV: 'production' }).host).toBe('::');
+  });
+
+  it('reads timeouts and port from env with sane fallbacks', () => {
+    expect(resolveStandaloneOptions({})).toMatchObject({
+      keepAliveTimeoutMs: 65_000,
+      port: 3011,
+      shutdownTimeoutMs: 10_000,
+    });
+    expect(
+      resolveStandaloneOptions({
+        HONO_KEEP_ALIVE_TIMEOUT_MS: '120000',
+        HONO_PORT: '4000',
+        HONO_SHUTDOWN_TIMEOUT_MS: 'nope',
+        PORT: '5000',
+      }),
+    ).toMatchObject({ keepAliveTimeoutMs: 120_000, port: 4000, shutdownTimeoutMs: 10_000 });
+  });
+});
+
+describe('createStandaloneServer', () => {
+  it('applies keep-alive timeouts to the node server and advertises them', async () => {
+    const { server, url } = await start(
+      new Hono().get('/', (c) => c.text('ok')),
+      {
+        keepAliveTimeoutMs: 70_000,
+      },
+    );
+
+    expect(server.keepAliveTimeout).toBe(70_000);
+    expect(server.headersTimeout).toBe(71_000);
+    const response = await fetch(`${url}/`);
+    expect(response.headers.get('keep-alive')).toBe('timeout=70');
+  });
+
+  it('fills x-forwarded-for from the socket only when the proxy did not set it', async () => {
+    const app = new Hono().get('/ip', (c) => c.text(c.req.header('x-forwarded-for') ?? 'none'));
+    const { url } = await start(app);
+
+    expect(await (await fetch(`${url}/ip`)).text()).toBe('127.0.0.1');
+    expect(
+      await (
+        await fetch(`${url}/ip`, { headers: { 'x-forwarded-for': '203.0.113.9, 10.0.0.1' } })
+      ).text(),
+    ).toBe('203.0.113.9, 10.0.0.1');
+  });
+
+  it('close() waits for after() tasks scheduled by finished requests', async () => {
+    let release!: () => void;
+    let finished = false;
+    const app = new Hono().use('*', nextCompat()).get('/work', (c) => {
+      after(
+        new Promise<void>((resolve) => {
+          release = () => {
+            finished = true;
+            resolve();
+          };
+        }),
+      );
+      return c.text('queued');
+    });
+    const { close, url } = await start(app);
+    await fetch(`${url}/work`);
+
+    let result: string | undefined;
+    const closing = close().then((r) => (result = r));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(result).toBeUndefined();
+
+    release();
+    await closing;
+    expect(finished).toBe(true);
+    expect(result).toBe('closed');
+  });
+
+  it('close() gives up after the shutdown timeout', async () => {
+    const app = new Hono().use('*', nextCompat()).get('/stuck', (c) => {
+      after(new Promise<void>(() => {}));
+      return c.text('queued');
+    });
+    const { close, url } = await start(app, { shutdownTimeoutMs: 100 });
+    await fetch(`${url}/stuck`);
+
+    await expect(close()).resolves.toBe('timeout');
+  });
+});

--- a/apps/server/src/router-hono/standaloneServer.ts
+++ b/apps/server/src/router-hono/standaloneServer.ts
@@ -1,0 +1,130 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { createServer } from 'node:http';
+import { Readable } from 'node:stream';
+
+import type { Hono } from 'hono';
+
+import { drainAfterTasks } from './next-compat/context';
+
+const DEFAULT_PORT = 3011;
+
+export interface StandaloneOptions {
+  host: string;
+  keepAliveTimeoutMs: number;
+  port: number;
+  shutdownTimeoutMs: number;
+}
+
+const parseInteger = (value: string | undefined, fallback: number) => {
+  const parsed = Number.parseInt(value ?? '', 10);
+
+  return Number.isNaN(parsed) || parsed < 0 ? fallback : parsed;
+};
+
+export const resolveStandaloneOptions = (
+  env: Record<string, string | undefined> = process.env,
+): StandaloneOptions => ({
+  host: env.HONO_HOST || (env.NODE_ENV === 'production' ? '0.0.0.0' : 'localhost'),
+  keepAliveTimeoutMs: parseInteger(env.HONO_KEEP_ALIVE_TIMEOUT_MS, 65_000),
+  port: parseInteger(env.HONO_PORT ?? env.PORT, DEFAULT_PORT),
+  shutdownTimeoutMs: parseInteger(env.HONO_SHUTDOWN_TIMEOUT_MS, 10_000),
+});
+
+const normalizeRemoteAddress = (address: string | undefined) => address?.replace(/^::ffff:/, '');
+
+const createRequest = (request: IncomingMessage, fallbackHost: string) => {
+  const headers = new Headers();
+
+  for (const [key, value] of Object.entries(request.headers)) {
+    if (Array.isArray(value)) {
+      for (const item of value) headers.append(key, item);
+    } else if (value !== undefined) {
+      headers.set(key, value);
+    }
+  }
+
+  const remoteAddress = normalizeRemoteAddress(request.socket.remoteAddress);
+  if (!headers.has('x-forwarded-for') && remoteAddress) {
+    headers.set('x-forwarded-for', remoteAddress);
+  }
+
+  const protocol = headers.get('x-forwarded-proto') || 'http';
+  const host = headers.get('host') || fallbackHost;
+  const url = new URL(request.url || '/', `${protocol}://${host}`);
+
+  const init: RequestInit & { duplex?: 'half' } = {
+    headers,
+    method: request.method,
+  };
+
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    init.body = Readable.toWeb(request) as ReadableStream<Uint8Array>;
+    init.duplex = 'half';
+  }
+
+  return new Request(url, init);
+};
+
+const writeResponse = async (response: Response, outgoing: ServerResponse) => {
+  outgoing.statusCode = response.status;
+  outgoing.statusMessage = response.statusText;
+
+  const setCookie = response.headers.getSetCookie();
+
+  response.headers.forEach((value, key) => {
+    if (key.toLowerCase() === 'set-cookie' && setCookie.length > 0) return;
+    outgoing.setHeader(key, value);
+  });
+  if (setCookie.length > 0) outgoing.setHeader('set-cookie', setCookie);
+
+  if (!response.body) {
+    outgoing.end();
+    return;
+  }
+
+  Readable.fromWeb(response.body).pipe(outgoing);
+};
+
+export type ShutdownResult = 'closed' | 'timeout';
+
+export const createStandaloneServer = (app: Hono, options: StandaloneOptions) => {
+  const fallbackHost = `${options.host}:${options.port}`;
+  const server = createServer((request, response) => {
+    void (async () => {
+      try {
+        await writeResponse(await app.fetch(createRequest(request, fallbackHost)), response);
+      } catch (error) {
+        console.error('Hono standalone request failed:', error);
+        response.statusCode = 500;
+        response.end('Internal Server Error');
+      }
+    })();
+  });
+
+  server.keepAliveTimeout = options.keepAliveTimeoutMs;
+  server.headersTimeout = options.keepAliveTimeoutMs + 1000;
+
+  let closing: Promise<ShutdownResult> | undefined;
+
+  const close = () => {
+    closing ??= new Promise<ShutdownResult>((resolve) => {
+      const timer = setTimeout(() => resolve('timeout'), options.shutdownTimeoutMs);
+      server.close(() => {
+        void drainAfterTasks().then(() => {
+          clearTimeout(timer);
+          resolve('closed');
+        });
+      });
+      server.closeIdleConnections();
+    });
+
+    return closing;
+  };
+
+  const listen = () =>
+    new Promise<void>((resolve) => {
+      server.listen(options.port, options.host, () => resolve());
+    });
+
+  return { close, listen, server };
+};

--- a/apps/server/src/router-hono/trpc/async.ts
+++ b/apps/server/src/router-hono/trpc/async.ts
@@ -1,0 +1,21 @@
+import { createAsyncRouteContext } from '@/libs/trpc/async/context';
+import { createResponseMeta } from '@/libs/trpc/utils/responseMeta';
+import { asyncRouter } from '@/server/routers/async';
+
+import { createTRPCApp, createTRPCHandler } from './createHandler';
+
+export const asyncTRPCHandler = createTRPCHandler({
+  // Avoid interference between requests
+  // https://github.com/lobehub/lobe-chat/discussions/7442#discussioncomment-13658563
+  allowBatching: false,
+  createContext: createAsyncRouteContext,
+  endpoint: '/trpc/async',
+  onError: ({ error, path, type }) => {
+    console.info(`Error in tRPC handler (async) on path: ${path}, type: ${type}`);
+    console.error(error);
+  },
+  responseMeta: createResponseMeta,
+  router: asyncRouter,
+});
+
+export default createTRPCApp('/trpc/async', asyncTRPCHandler);

--- a/apps/server/src/router-hono/trpc/createHandler.test.ts
+++ b/apps/server/src/router-hono/trpc/createHandler.test.ts
@@ -1,0 +1,27 @@
+import { initTRPC } from '@trpc/server';
+import { describe, expect, it } from 'vitest';
+
+import { createTRPCApp, createTRPCHandler } from './createHandler';
+
+const trpc = initTRPC.context<{ requestUrl: string }>().create();
+const testRouter = trpc.router({
+  requestUrl: trpc.procedure.query(({ ctx }) => ctx.requestUrl),
+});
+
+describe('Hono tRPC handler', () => {
+  it('serves a tRPC procedure through a Hono route', async () => {
+    const handler = createTRPCHandler({
+      createContext: async (request: Request) => ({ requestUrl: request.url }),
+      endpoint: '/trpc/test',
+      router: testRouter,
+    });
+    const app = createTRPCApp('/trpc/test', handler);
+
+    const response = await app.request('http://localhost/trpc/test/requestUrl');
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      result: { data: 'http://localhost/trpc/test/requestUrl' },
+    });
+  });
+});

--- a/apps/server/src/router-hono/trpc/createHandler.ts
+++ b/apps/server/src/router-hono/trpc/createHandler.ts
@@ -1,0 +1,25 @@
+import type { AnyRouter } from '@trpc/server';
+import type { FetchCreateContextFn, FetchHandlerRequestOptions } from '@trpc/server/adapters/fetch';
+import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
+import { Hono } from 'hono';
+
+import { prepareRequestForTRPC } from '@/libs/trpc/utils/request-adapter';
+
+type CreateTRPCHandlerOptions<TRouter extends AnyRouter> = Omit<
+  FetchHandlerRequestOptions<TRouter>,
+  'createContext' | 'req'
+> & {
+  createContext: (request: Request) => ReturnType<FetchCreateContextFn<TRouter>>;
+};
+
+export const createTRPCHandler =
+  <TRouter extends AnyRouter>({ createContext, ...options }: CreateTRPCHandlerOptions<TRouter>) =>
+  (request: Request): Promise<Response> =>
+    fetchRequestHandler({
+      ...options,
+      createContext: () => createContext(request),
+      req: prepareRequestForTRPC(request),
+    });
+
+export const createTRPCApp = (basePath: string, handler: (request: Request) => Promise<Response>) =>
+  new Hono().basePath(basePath).all('/*', (c) => handler(c.req.raw));

--- a/apps/server/src/router-hono/trpc/lambda.ts
+++ b/apps/server/src/router-hono/trpc/lambda.ts
@@ -1,0 +1,17 @@
+import { createLambdaContext } from '@/libs/trpc/lambda/context';
+import { createTRPCErrorLogger } from '@/libs/trpc/utils/errorLogger';
+import { createResponseMeta } from '@/libs/trpc/utils/responseMeta';
+import { lambdaRouter } from '@/server/routers/lambda';
+
+import { createTRPCApp, createTRPCHandler } from './createHandler';
+
+export const lambdaTRPCHandler = createTRPCHandler({
+  allowMethodOverride: true,
+  createContext: createLambdaContext,
+  endpoint: '/trpc/lambda',
+  onError: createTRPCErrorLogger('lambda'),
+  responseMeta: createResponseMeta,
+  router: lambdaRouter,
+});
+
+export default createTRPCApp('/trpc/lambda', lambdaTRPCHandler);

--- a/apps/server/src/router-hono/trpc/mobile.ts
+++ b/apps/server/src/router-hono/trpc/mobile.ts
@@ -1,0 +1,16 @@
+import { createLambdaContext } from '@/libs/trpc/lambda/context';
+import { createTRPCErrorLogger } from '@/libs/trpc/utils/errorLogger';
+import { createResponseMeta } from '@/libs/trpc/utils/responseMeta';
+import { mobileRouter } from '@/server/routers/mobile';
+
+import { createTRPCApp, createTRPCHandler } from './createHandler';
+
+export const mobileTRPCHandler = createTRPCHandler({
+  createContext: createLambdaContext,
+  endpoint: '/trpc/mobile',
+  onError: createTRPCErrorLogger('mobile'),
+  responseMeta: createResponseMeta,
+  router: mobileRouter,
+});
+
+export default createTRPCApp('/trpc/mobile', mobileTRPCHandler);

--- a/apps/server/src/router-hono/trpc/tools.ts
+++ b/apps/server/src/router-hono/trpc/tools.ts
@@ -1,0 +1,16 @@
+import { createLambdaContext } from '@/libs/trpc/lambda/context';
+import { createTRPCErrorLogger } from '@/libs/trpc/utils/errorLogger';
+import { createResponseMeta } from '@/libs/trpc/utils/responseMeta';
+import { toolsRouter } from '@/server/routers/tools';
+
+import { createTRPCApp, createTRPCHandler } from './createHandler';
+
+export const toolsTRPCHandler = createTRPCHandler({
+  createContext: createLambdaContext,
+  endpoint: '/trpc/tools',
+  onError: createTRPCErrorLogger('tools'),
+  responseMeta: createResponseMeta,
+  router: toolsRouter,
+});
+
+export default createTRPCApp('/trpc/tools', toolsTRPCHandler);

--- a/apps/server/src/services/webhookUser/index.ts
+++ b/apps/server/src/services/webhookUser/index.ts
@@ -1,6 +1,5 @@
 import { type LobeChatDatabase } from '@lobechat/database';
 import { and, eq } from 'drizzle-orm';
-import { NextResponse } from 'next/server';
 
 import { UserModel } from '@/database/models/user';
 import { type UserItem } from '@/database/schemas';
@@ -76,7 +75,7 @@ export class WebhookUserService {
       );
     }
 
-    return NextResponse.json({ message: 'user updated', success: true }, { status: 200 });
+    return Response.json({ message: 'user updated', success: true }, { status: 200 });
   };
 
   /**
@@ -101,6 +100,6 @@ export class WebhookUserService {
       );
     }
 
-    return NextResponse.json({ message: 'user signed out', success: true }, { status: 200 });
+    return Response.json({ message: 'user signed out', success: true }, { status: 200 });
   };
 }

--- a/apps/server/src/utils/scheduleAfterResponse.ts
+++ b/apps/server/src/utils/scheduleAfterResponse.ts
@@ -1,4 +1,5 @@
 import debug from 'debug';
+import { after as nextAfter } from 'next/server';
 
 const log = debug('lobe-server:schedule-after-response');
 
@@ -14,20 +15,10 @@ const runWork = async (work: ScheduleAfterResponseWork) => {
 
 export const after = (work: ScheduleAfterResponseWork): void => {
   try {
-    const nextServer = require('next/server') as {
-      after?: (work: () => Promise<void>) => void;
-    };
-
-    if (typeof nextServer.after === 'function') {
-      try {
-        nextServer.after(() => runWork(work));
-        return;
-      } catch (error) {
-        log('next/server after() unavailable, falling back: %O', error);
-      }
-    }
-  } catch {
-    // next/server is not available in standalone Hono.
+    nextAfter(() => runWork(work));
+    return;
+  } catch (error) {
+    log('after() unavailable outside a request scope, running inline: %O', error);
   }
 
   void runWork(work);

--- a/apps/server/viteHonoBuild.config.ts
+++ b/apps/server/viteHonoBuild.config.ts
@@ -2,7 +2,7 @@ import { fileURLToPath } from 'node:url';
 
 import { defineConfig } from 'vite';
 
-import { honoServerDedupe, honoServerPlugins } from './viteNodeServer.config';
+import { honoServerAlias, honoServerDedupe, honoServerPlugins } from './viteNodeServer.config';
 
 const serverRoot = fileURLToPath(new URL('.', import.meta.url));
 const entry = (file: string) =>
@@ -29,6 +29,7 @@ export default defineConfig({
   },
   plugins: honoServerPlugins(),
   resolve: {
+    alias: honoServerAlias,
     dedupe: honoServerDedupe,
   },
   root: serverRoot,

--- a/apps/server/viteHonoBuild.config.ts
+++ b/apps/server/viteHonoBuild.config.ts
@@ -1,42 +1,67 @@
+import { cpSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import type { Plugin } from 'vite';
 import { defineConfig } from 'vite';
 
+import { honoNativeExternals } from './honoExternals';
 import { honoServerAlias, honoServerDedupe, honoServerPlugins } from './viteNodeServer.config';
 
 const serverRoot = fileURLToPath(new URL('.', import.meta.url));
+const outDir = path.join(serverRoot, 'dist');
 const entry = (file: string) =>
   fileURLToPath(new URL(`./src/router-hono/${file}`, import.meta.url));
+const require = createRequire(import.meta.url);
+
+// pdfkit reads its AFM font metrics from `__dirname + '/data'` at runtime
+const pdfkitFontsPlugin: Plugin = {
+  closeBundle() {
+    cpSync(path.join(path.dirname(require.resolve('pdfkit')), 'data'), path.join(outDir, 'data'), {
+      recursive: true,
+    });
+  },
+  name: 'lobe-hono-pdfkit-fonts',
+};
 
 export default defineConfig({
   build: {
     emptyOutDir: true,
     minify: false,
-    outDir: fileURLToPath(new URL('./dist', import.meta.url)),
+    outDir,
     rollupOptions: {
+      external: honoNativeExternals,
       input: {
         index: entry('index.ts'),
         standalone: entry('standalone.ts'),
       },
       output: {
         chunkFileNames: 'chunks/[name]-[hash].js',
-        // rolldown's default splitting makes the S3 and file chunks import each other, and the
-        // S3 chunk then evaluates before the shared `__esmMin` helper exists (500 on every lambda call)
-        codeSplitting: { groups: [{ name: 'server', test: /./ }] },
+        codeSplitting: {
+          // rolldown's default splitting makes the S3 and file chunks import each other, and the
+          // S3 chunk then evaluates before the shared `__esmMin` helper exists (500 on every lambda call)
+          groups: [{ name: 'server', test: /./ }],
+        },
         entryFileNames: '[name].js',
         format: 'es',
       },
+      // @peculiar/x509 imports the reflect-metadata polyfill for tsyringe; rolldown drops that
+      // bare side-effect import unless the module is marked as effectful
+      treeshake: { moduleSideEffects: [{ sideEffects: true, test: /reflect-metadata/ }] },
     },
     ssr: true,
     target: 'node24',
   },
-  plugins: honoServerPlugins(),
+  // CommonJS dependencies inlined into the ESM bundle still reference __dirname / __filename
+  define: { __dirname: 'import.meta.dirname', __filename: 'import.meta.filename' },
+  plugins: [...honoServerPlugins(), pdfkitFontsPlugin],
   resolve: {
     alias: honoServerAlias,
     dedupe: honoServerDedupe,
   },
   root: serverRoot,
   ssr: {
-    noExternal: [/^@lobechat\//],
+    noExternal: true,
   },
 });

--- a/apps/server/viteHonoBuild.config.ts
+++ b/apps/server/viteHonoBuild.config.ts
@@ -20,6 +20,9 @@ export default defineConfig({
       },
       output: {
         chunkFileNames: 'chunks/[name]-[hash].js',
+        // rolldown's default splitting makes the S3 and file chunks import each other, and the
+        // S3 chunk then evaluates before the shared `__esmMin` helper exists (500 on every lambda call)
+        codeSplitting: { groups: [{ name: 'server', test: /./ }] },
         entryFileNames: '[name].js',
         format: 'es',
       },

--- a/apps/server/viteNodeServer.config.ts
+++ b/apps/server/viteNodeServer.config.ts
@@ -30,9 +30,17 @@ export const honoServerPlugins = () => [
 
 export const honoServerDedupe = ['@lobehub/editor'];
 
+const nextCompatDir = path.resolve(SERVER_CONFIG_DIR, 'src/router-hono/next-compat');
+
+export const honoServerAlias = [
+  { find: /^next\/headers$/, replacement: path.join(nextCompatDir, 'headers.ts') },
+  { find: /^next\/server$/, replacement: path.join(nextCompatDir, 'server.ts') },
+];
+
 export default defineConfig({
   plugins: honoServerPlugins(),
   resolve: {
+    alias: honoServerAlias,
     dedupe: honoServerDedupe,
   },
 });

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from './src/libs/next/config/define-config';
 
 const isVercel = !!process.env.VERCEL_ENV;
+const isHonoDevTopology =
+  process.env.NODE_ENV !== 'production' && process.env.LOBE_DEV_TOPOLOGY === 'hono';
+const honoDevTarget = `http://localhost:${process.env.HONO_PORT || 3011}`;
 
 const vercelConfig = {
   // Vercel serverless optimization: exclude musl binaries from all routes
@@ -20,6 +23,16 @@ const vercelConfig = {
 };
 const nextConfig = defineConfig({
   ...(isVercel ? vercelConfig : {}),
+  rewrites: isHonoDevTopology
+    ? async () => ({
+        beforeFiles: [
+          {
+            destination: `${honoDevTarget}/trpc/:path*`,
+            source: '/trpc/:path*',
+          },
+        ],
+      })
+    : undefined,
 });
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
     "dev:docker": "docker compose -f docker-compose/dev/docker-compose.yml up -d --wait postgresql redis rustfs searxng",
     "dev:docker:down": "docker compose -f docker-compose/dev/docker-compose.yml down",
     "dev:docker:reset": "docker compose -f docker-compose/dev/docker-compose.yml down -v && rm -rf docker-compose/dev/data && npm run dev:docker && pnpm db:migrate",
+    "dev:hono": "cross-env LOBE_DEV_TOPOLOGY=hono tsx scripts/devStartupSequence.mts",
+    "dev:hono:server": "pnpm --filter @lobechat/server dev",
     "dev:next": "next dev -p 3010",
     "dev:spa": "vite",
     "dev:spa:auth": "cross-env AUTH=true vite",
@@ -575,6 +577,7 @@
     "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0",
     "vite": "8.0.16",
+    "vite-node": "^6.0.0",
     "vite-plugin-pwa": "^1.3.0",
     "vite-tsconfig-paths": "^6.1.1",
     "vitest": "3.2.6"

--- a/package.json
+++ b/package.json
@@ -447,6 +447,7 @@
     "react-scan": "^0.5.7",
     "react-virtuoso": "^4.18.11",
     "react-wrap-balancer": "^1.1.1",
+    "reflect-metadata": "^0.2.2",
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1",
     "remark-html": "^16.0.1",

--- a/packages/file-loaders/src/index.ts
+++ b/packages/file-loaders/src/index.ts
@@ -1,6 +1,7 @@
 export * from './blackList';
-export * from './loadFile';
 export { convertIpynbToMarkdown, scrubIpynbFallbackText } from './loaders/ipynb';
+export { installDomMatrixPolyfill } from './loaders/pdf/domMatrix';
+export * from './loadFile';
 export * from './types';
 export * from './utils/isBinaryContent';
 export * from './utils/isTextReadableFile';

--- a/packages/trpc/src/async/context.ts
+++ b/packages/trpc/src/async/context.ts
@@ -1,6 +1,5 @@
 import { type LobeChatDatabase } from '@lobechat/database';
 import debug from 'debug';
-import { type NextRequest } from 'next/server';
 
 import { LOBE_CHAT_AUTH_HEADER } from '@/envs/auth';
 import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
@@ -27,7 +26,7 @@ export const createAsyncContextInner = async (params?: {
 
 export type AsyncContext = Awaited<ReturnType<typeof createAsyncContextInner>>;
 
-export const createAsyncRouteContext = async (request: NextRequest): Promise<AsyncContext> => {
+export const createAsyncRouteContext = async (request: Request): Promise<AsyncContext> => {
   // for API-response caching see https://trpc.io/docs/v11/caching
 
   log('Creating async route context');

--- a/packages/trpc/src/lambda/context.ts
+++ b/packages/trpc/src/lambda/context.ts
@@ -4,7 +4,6 @@ import type { ClientMetadata } from '@lobechat/utils/server';
 import { parseClientMetadata } from '@lobechat/utils/server';
 import { parse } from 'cookie';
 import debug from 'debug';
-import { type NextRequest } from 'next/server';
 
 import { auth } from '@/auth';
 import { canUseWorkspaceApiKeys } from '@/business/server/workspaceApiKey';
@@ -23,7 +22,7 @@ import { HETERO_OPERATION_JWT_PURPOSE } from '../utils/internalJwt';
 const log = debug('lobe-trpc:lambda:context');
 const LOBE_CHAT_API_KEY_HEADER = 'X-API-Key';
 
-const extractClientIp = (request: NextRequest): string | undefined => {
+const extractClientIp = (request: Request): string | undefined => {
   const forwardedFor = request.headers.get('x-forwarded-for');
   if (forwardedFor) {
     const ip = forwardedFor.split(',')[0]?.trim();
@@ -145,7 +144,7 @@ export type LambdaContext = Awaited<ReturnType<typeof createContextInner>>;
  * Creates context for an incoming request
  * @link https://trpc.io/docs/v11/context
  */
-export const createLambdaContext = async (request: NextRequest): Promise<LambdaContext> => {
+export const createLambdaContext = async (request: Request): Promise<LambdaContext> => {
   const clientMetadata = parseClientMetadata(request.headers);
 
   // we have a special header to debug the api endpoint in development mode

--- a/packages/trpc/src/utils/request-adapter.ts
+++ b/packages/trpc/src/utils/request-adapter.ts
@@ -1,5 +1,3 @@
-import { type NextRequest } from 'next/server';
-
 /**
  * Prepare Request object for tRPC fetchRequestHandler
  *
@@ -13,7 +11,7 @@ import { type NextRequest } from 'next/server';
  * @param req - The original NextRequest object
  * @returns A cloned Request object with an independent body stream
  */
-export function prepareRequestForTRPC(req: NextRequest): Request {
+export function prepareRequestForTRPC(req: Request): Request {
   // Clone the Request to create an independent body stream
   // This ensures tRPC can read the body even if the original request's body was disturbed
   return req.clone();

--- a/scripts/devStartupSequence.mts
+++ b/scripts/devStartupSequence.mts
@@ -48,7 +48,9 @@ const findFreePort = async (startPort: number): Promise<number> => {
   for (let port = startPort; port < startPort + MAX_PORT_SCAN_ATTEMPTS; port++) {
     if (await isPortFree(port)) return port;
   }
-  throw new Error(`No free port found in range ${startPort}-${startPort + MAX_PORT_SCAN_ATTEMPTS - 1}`);
+  throw new Error(
+    `No free port found in range ${startPort}-${startPort + MAX_PORT_SCAN_ATTEMPTS - 1}`,
+  );
 };
 
 /**
@@ -91,8 +93,10 @@ const packageScriptCommand = 'bun';
 
 let nextPort = 3010;
 let nextRootUrl = `http://${NEXT_HOST}:${nextPort}/`;
+let honoProcess: ChildProcess | undefined;
 let nextProcess: ChildProcess | undefined;
 let viteProcess: ChildProcess | undefined;
+let honoHandle: DevProcessHandle | undefined;
 let nextHandle: DevProcessHandle | undefined;
 let viteHandle: DevProcessHandle | undefined;
 let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
@@ -235,11 +239,13 @@ const runNextBackgroundTasks = () => {
 };
 
 const terminateChildren = () => {
+  sendSignalToDevProcess(honoHandle, 'SIGTERM');
   sendSignalToDevProcess(viteHandle, 'SIGTERM');
   sendSignalToDevProcess(nextHandle, 'SIGTERM');
 };
 
 const forceKillChildren = () => {
+  sendSignalToDevProcess(honoHandle, 'SIGKILL');
   sendSignalToDevProcess(viteHandle, 'SIGKILL');
   sendSignalToDevProcess(nextHandle, 'SIGKILL');
 };
@@ -255,7 +261,8 @@ const hasChildSettled = (child?: ChildProcess) =>
 
 const clearForceKillTimerWhenChildrenSettle = () => {
   if (!shuttingDown) return;
-  if (hasChildSettled(nextProcess) && hasChildSettled(viteProcess)) clearForceKillTimer();
+  if (hasChildSettled(honoProcess) && hasChildSettled(nextProcess) && hasChildSettled(viteProcess))
+    clearForceKillTimer();
 };
 
 const shutdownAll = (signal: NodeJS.Signals) => {
@@ -275,7 +282,7 @@ const shutdownAll = (signal: NodeJS.Signals) => {
   }, FORCE_KILL_TIMEOUT_MS);
 };
 
-const watchChildExit = (child: ChildProcess, name: 'next' | 'vite') => {
+const watchChildExit = (child: ChildProcess, name: 'hono' | 'next' | 'vite') => {
   child.once('exit', (code, signal) => {
     if (shuttingDown) {
       clearForceKillTimerWhenChildrenSettle();
@@ -293,9 +300,13 @@ const main = async () => {
   loadEnv();
   nextPort = await resolveNextPort();
   process.env.PORT = String(nextPort);
+  const isHonoTopology = process.env.LOBE_DEV_TOPOLOGY === 'hono';
+  if (isHonoTopology) process.env.HONO_PORT ||= nextPort === 3011 ? '3012' : '3011';
   nextRootUrl = `http://${NEXT_HOST}:${nextPort}/`;
   const vitePort = await resolveVitePortEnv();
-  console.log(`🔌 dev ports — next: ${nextPort}, vite: ${vitePort}`);
+  console.log(
+    `🔌 dev ports — next: ${nextPort}, vite: ${vitePort}${isHonoTopology ? `, hono: ${process.env.HONO_PORT}` : ''}`,
+  );
 
   const forwardedSignals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGHUP'];
   for (const sig of forwardedSignals) {
@@ -316,6 +327,12 @@ const main = async () => {
     forceKillChildren();
   });
 
+  if (isHonoTopology) {
+    honoProcess = runPackageScript('dev:hono:server');
+    honoHandle = createDevProcessHandle({ isWindows, pid: honoProcess.pid });
+    watchChildExit(honoProcess, 'hono');
+  }
+
   nextProcess = spawn('bunx', ['next', 'dev', '-p', String(nextPort)], {
     detached: !isWindows,
     env: process.env,
@@ -331,6 +348,7 @@ const main = async () => {
   runNextBackgroundTasks();
 
   await Promise.race([
+    ...(honoProcess ? [new Promise((resolve) => honoProcess?.once('exit', resolve))] : []),
     new Promise((resolve) => nextProcess?.once('exit', resolve)),
     new Promise((resolve) => viteProcess?.once('exit', resolve)),
   ]);

--- a/scripts/honoRuntimeDeps.mts
+++ b/scripts/honoRuntimeDeps.mts
@@ -1,30 +1,8 @@
 import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { builtinModules } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const BUILTINS = new Set(builtinModules);
-const SPECIFIER_RE =
-  /^\s*import\b[^;'"]*["']([^"'\s./][^"'\s]*)["']|\b(?:import|__require|require)\(\s*["']([^"'\s./][^"'\s]*)["']\s*\)/gm;
-
-export const packageNameOf = (specifier: string): string | undefined => {
-  if (specifier.startsWith('node:')) return;
-  const segments = specifier.split('/');
-  const name = specifier.startsWith('@') ? segments.slice(0, 2).join('/') : segments[0];
-  if (!name || BUILTINS.has(name)) return;
-  return name;
-};
-
-export const collectExternals = (sources: string[]): string[] => {
-  const names = new Set<string>();
-  for (const source of sources) {
-    for (const match of source.matchAll(SPECIFIER_RE)) {
-      const name = packageNameOf(match[1] ?? match[2]);
-      if (name) names.add(name);
-    }
-  }
-  return [...names].sort();
-};
+import { honoNativeExternals } from '../apps/server/honoExternals';
 
 export const resolveInstalledVersion = (name: string, fromDir: string): string | undefined => {
   let dir = fromDir;
@@ -85,18 +63,15 @@ export interface RuntimeManifest {
 }
 
 export const buildRuntimeManifest = (
-  distDir: string,
+  externals: string[],
+  fromDir: string,
   patchesDir: string,
   workspaceFile: string,
 ): RuntimeManifest => {
-  const sources = readdirSync(distDir, { recursive: true, withFileTypes: true })
-    .filter((entry) => entry.isFile() && entry.name.endsWith('.js'))
-    .map((entry) => readFileSync(path.join(entry.parentPath, entry.name), 'utf8'));
-
   const dependencies: Record<string, string> = {};
   const missing: string[] = [];
-  for (const name of collectExternals(sources)) {
-    const version = resolveInstalledVersion(name, distDir);
+  for (const name of [...externals].sort()) {
+    const version = resolveInstalledVersion(name, fromDir);
     if (version) dependencies[name] = version;
     else missing.push(name);
   }
@@ -125,7 +100,7 @@ if (isMain) {
   const workspaceFile = path.resolve(option('--workspace') ?? 'pnpm-workspace.yaml');
 
   const { dependencies, missing, onlyBuiltDependencies, packageManager, patchedDependencies } =
-    buildRuntimeManifest(distDir, patchesDir, workspaceFile);
+    buildRuntimeManifest(honoNativeExternals, distDir, patchesDir, workspaceFile);
   writeFileSync(
     path.join(outDir, 'package.json'),
     JSON.stringify(

--- a/scripts/honoRuntimeDeps.mts
+++ b/scripts/honoRuntimeDeps.mts
@@ -1,0 +1,151 @@
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { builtinModules } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const BUILTINS = new Set(builtinModules);
+const SPECIFIER_RE =
+  /^\s*import\b[^;'"]*["']([^"'\s./][^"'\s]*)["']|\b(?:import|__require|require)\(\s*["']([^"'\s./][^"'\s]*)["']\s*\)/gm;
+
+export const packageNameOf = (specifier: string): string | undefined => {
+  if (specifier.startsWith('node:')) return;
+  const segments = specifier.split('/');
+  const name = specifier.startsWith('@') ? segments.slice(0, 2).join('/') : segments[0];
+  if (!name || BUILTINS.has(name)) return;
+  return name;
+};
+
+export const collectExternals = (sources: string[]): string[] => {
+  const names = new Set<string>();
+  for (const source of sources) {
+    for (const match of source.matchAll(SPECIFIER_RE)) {
+      const name = packageNameOf(match[1] ?? match[2]);
+      if (name) names.add(name);
+    }
+  }
+  return [...names].sort();
+};
+
+export const resolveInstalledVersion = (name: string, fromDir: string): string | undefined => {
+  let dir = fromDir;
+  for (;;) {
+    const manifest = path.join(dir, 'node_modules', name, 'package.json');
+    if (existsSync(manifest)) {
+      const installed = JSON.parse(readFileSync(manifest, 'utf8')) as {
+        name: string;
+        version: string;
+      };
+      return installed.name === name
+        ? installed.version
+        : `npm:${installed.name}@${installed.version}`;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return;
+    dir = parent;
+  }
+};
+
+export const patchedDependenciesFor = (names: Set<string>, patchesDir: string) => {
+  const patched: Record<string, string> = {};
+  if (!existsSync(patchesDir)) return patched;
+  for (const file of readdirSync(patchesDir)) {
+    if (!file.endsWith('.patch')) continue;
+    const name = file.slice(0, -'.patch'.length).replace('__', '/');
+    if (names.has(name)) patched[name] = `patches/${file}`;
+  }
+  return patched;
+};
+
+export const onlyBuiltDependenciesFor = (names: Set<string>, workspaceFile: string) => {
+  if (!existsSync(workspaceFile)) return [];
+  const lines = readFileSync(workspaceFile, 'utf8').split('\n');
+  const start = lines.indexOf('onlyBuiltDependencies:');
+  if (start === -1) return [];
+  const listed: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    const match = line.match(/^\s+-\s*['"]?([^\s'"]+)/);
+    if (!match) break;
+    listed.push(match[1]);
+  }
+  return listed.filter((name) => names.has(name));
+};
+
+export const packageManagerOf = (workspaceFile: string): string | undefined => {
+  const rootManifest = path.join(path.dirname(workspaceFile), 'package.json');
+  if (!existsSync(rootManifest)) return;
+  return JSON.parse(readFileSync(rootManifest, 'utf8')).packageManager as string | undefined;
+};
+
+export interface RuntimeManifest {
+  dependencies: Record<string, string>;
+  missing: string[];
+  onlyBuiltDependencies: string[];
+  packageManager?: string;
+  patchedDependencies: Record<string, string>;
+}
+
+export const buildRuntimeManifest = (
+  distDir: string,
+  patchesDir: string,
+  workspaceFile: string,
+): RuntimeManifest => {
+  const sources = readdirSync(distDir, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.js'))
+    .map((entry) => readFileSync(path.join(entry.parentPath, entry.name), 'utf8'));
+
+  const dependencies: Record<string, string> = {};
+  const missing: string[] = [];
+  for (const name of collectExternals(sources)) {
+    const version = resolveInstalledVersion(name, distDir);
+    if (version) dependencies[name] = version;
+    else missing.push(name);
+  }
+
+  const names = new Set(Object.keys(dependencies));
+  return {
+    dependencies,
+    missing,
+    onlyBuiltDependencies: onlyBuiltDependenciesFor(names, workspaceFile),
+    packageManager: packageManagerOf(workspaceFile),
+    patchedDependencies: patchedDependenciesFor(names, patchesDir),
+  };
+};
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isMain) {
+  const args = process.argv.slice(2);
+  const option = (flag: string) => {
+    const index = args.indexOf(flag);
+    return index === -1 ? undefined : args[index + 1];
+  };
+  const distDir = path.resolve(option('--dist') ?? 'apps/server/dist');
+  const outDir = path.resolve(option('--out') ?? 'apps/server/runtime');
+  const patchesDir = path.resolve(option('--patches') ?? 'patches');
+  const workspaceFile = path.resolve(option('--workspace') ?? 'pnpm-workspace.yaml');
+
+  const { dependencies, missing, onlyBuiltDependencies, packageManager, patchedDependencies } =
+    buildRuntimeManifest(distDir, patchesDir, workspaceFile);
+  writeFileSync(
+    path.join(outDir, 'package.json'),
+    JSON.stringify(
+      { name: 'lobe-hono-runtime', private: true, type: 'module', packageManager, dependencies },
+      null,
+      2,
+    ) + '\n',
+  );
+  writeFileSync(
+    path.join(outDir, 'pnpm-workspace.yaml'),
+    [
+      'onlyBuiltDependencies:',
+      ...onlyBuiltDependencies.map((name) => `  - '${name}'`),
+      'patchedDependencies:',
+      ...Object.entries(patchedDependencies).map(([name, file]) => `  '${name}': ${file}`),
+      '',
+    ].join('\n'),
+  );
+
+  const count = Object.keys(dependencies).length;
+  console.log(`hono runtime deps: ${count} packages → ${path.join(outDir, 'package.json')}`);
+  if (missing.length > 0) console.warn(`not installed, skipped: ${missing.join(', ')}`);
+}

--- a/scripts/honoRuntimeDeps.test.ts
+++ b/scripts/honoRuntimeDeps.test.ts
@@ -1,0 +1,83 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { buildRuntimeManifest, collectExternals } from './honoRuntimeDeps.mts';
+
+const testRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of testRoots.splice(0)) rmSync(root, { force: true, recursive: true });
+});
+
+describe('collectExternals', () => {
+  it('keeps bare package names and drops builtins, relative and node: specifiers', () => {
+    const source = `
+      import "./chunks/a.js";
+      import "node:fs";
+      import { x } from "drizzle-orm/pg-core";
+      import * as y from '@aws-sdk/client-s3';
+      import "path";
+      const z = await import("hono/streaming");
+      __require("ffmpeg-static");
+      require("replicate");
+    `;
+
+    expect(collectExternals([source])).toEqual([
+      '@aws-sdk/client-s3',
+      'drizzle-orm',
+      'ffmpeg-static',
+      'hono',
+      'replicate',
+    ]);
+  });
+});
+
+describe('buildRuntimeManifest', () => {
+  it('pins installed versions, reports missing packages and maps pnpm patches', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'hono-runtime-deps-'));
+    testRoots.push(root);
+    const distDir = path.join(root, 'apps/server/dist');
+    mkdirSync(distDir, { recursive: true });
+    writeFileSync(
+      path.join(distDir, 'index.js'),
+      'import "hono";\nimport "@upstash/qstash";\nimport "buffer.js";\nimport "not-installed";',
+    );
+    for (const [dirName, name, version] of [
+      ['hono', 'hono', '4.1.0'],
+      ['@upstash/qstash', '@upstash/qstash', '2.0.0'],
+      ['buffer.js', 'buffer', '6.0.3'],
+    ]) {
+      const dir = path.join(root, 'node_modules', dirName);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name, version }));
+    }
+    const patchesDir = path.join(root, 'patches');
+    mkdirSync(patchesDir);
+    writeFileSync(path.join(patchesDir, '@upstash__qstash.patch'), '');
+    writeFileSync(path.join(patchesDir, 'unrelated.patch'), '');
+    const workspaceFile = path.join(root, 'pnpm-workspace.yaml');
+    writeFileSync(
+      path.join(root, 'package.json'),
+      JSON.stringify({ packageManager: 'pnpm@10.0.0' }),
+    );
+    writeFileSync(
+      workspaceFile,
+      "packages:\n  - .\n\nonlyBuiltDependencies:\n  - 'hono'\n  - '@lobehub/editor'\n\noverrides:\n  jose: ^6\n",
+    );
+
+    expect(buildRuntimeManifest(distDir, patchesDir, workspaceFile)).toEqual({
+      dependencies: {
+        '@upstash/qstash': '2.0.0',
+        'buffer.js': 'npm:buffer@6.0.3',
+        'hono': '4.1.0',
+      },
+      missing: ['not-installed'],
+      onlyBuiltDependencies: ['hono'],
+      packageManager: 'pnpm@10.0.0',
+      patchedDependencies: { '@upstash/qstash': 'patches/@upstash__qstash.patch' },
+    });
+  });
+});

--- a/scripts/honoRuntimeDeps.test.ts
+++ b/scripts/honoRuntimeDeps.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { buildRuntimeManifest, collectExternals } from './honoRuntimeDeps.mts';
+import { buildRuntimeManifest } from './honoRuntimeDeps.mts';
 
 const testRoots: string[] = [];
 
@@ -12,41 +12,14 @@ afterEach(() => {
   for (const root of testRoots.splice(0)) rmSync(root, { force: true, recursive: true });
 });
 
-describe('collectExternals', () => {
-  it('keeps bare package names and drops builtins, relative and node: specifiers', () => {
-    const source = `
-      import "./chunks/a.js";
-      import "node:fs";
-      import { x } from "drizzle-orm/pg-core";
-      import * as y from '@aws-sdk/client-s3';
-      import "path";
-      const z = await import("hono/streaming");
-      __require("ffmpeg-static");
-      require("replicate");
-    `;
-
-    expect(collectExternals([source])).toEqual([
-      '@aws-sdk/client-s3',
-      'drizzle-orm',
-      'ffmpeg-static',
-      'hono',
-      'replicate',
-    ]);
-  });
-});
-
 describe('buildRuntimeManifest', () => {
-  it('pins installed versions, reports missing packages and maps pnpm patches', () => {
+  it('pins installed externals, skips missing ones and carries pnpm settings over', () => {
     const root = mkdtempSync(path.join(tmpdir(), 'hono-runtime-deps-'));
     testRoots.push(root);
     const distDir = path.join(root, 'apps/server/dist');
     mkdirSync(distDir, { recursive: true });
-    writeFileSync(
-      path.join(distDir, 'index.js'),
-      'import "hono";\nimport "@upstash/qstash";\nimport "buffer.js";\nimport "not-installed";',
-    );
     for (const [dirName, name, version] of [
-      ['hono', 'hono', '4.1.0'],
+      ['sharp', 'sharp', '0.34.5'],
       ['@upstash/qstash', '@upstash/qstash', '2.0.0'],
       ['buffer.js', 'buffer', '6.0.3'],
     ]) {
@@ -65,17 +38,24 @@ describe('buildRuntimeManifest', () => {
     );
     writeFileSync(
       workspaceFile,
-      "packages:\n  - .\n\nonlyBuiltDependencies:\n  - 'hono'\n  - '@lobehub/editor'\n\noverrides:\n  jose: ^6\n",
+      "packages:\n  - .\n\nonlyBuiltDependencies:\n  - 'sharp'\n  - '@lobehub/editor'\n\noverrides:\n  jose: ^6\n",
     );
 
-    expect(buildRuntimeManifest(distDir, patchesDir, workspaceFile)).toEqual({
+    expect(
+      buildRuntimeManifest(
+        ['sharp', 'buffer.js', '@upstash/qstash', 'pg-native'],
+        distDir,
+        patchesDir,
+        workspaceFile,
+      ),
+    ).toEqual({
       dependencies: {
         '@upstash/qstash': '2.0.0',
         'buffer.js': 'npm:buffer@6.0.3',
-        'hono': '4.1.0',
+        'sharp': '0.34.5',
       },
-      missing: ['not-installed'],
-      onlyBuiltDependencies: ['hono'],
+      missing: ['pg-native'],
+      onlyBuiltDependencies: ['sharp'],
       packageManager: 'pnpm@10.0.0',
       patchedDependencies: { '@upstash/qstash': 'patches/@upstash__qstash.patch' },
     });

--- a/src/app/(backend)/trpc/async/[trpc]/route.ts
+++ b/src/app/(backend)/trpc/async/[trpc]/route.ts
@@ -1,37 +1,5 @@
-import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
-import { type NextRequest } from 'next/server';
+import app from '@/server/router-hono/trpc/async';
 
-import { createAsyncRouteContext } from '@/libs/trpc/async/context';
-import { prepareRequestForTRPC } from '@/libs/trpc/utils/request-adapter';
-import { createResponseMeta } from '@/libs/trpc/utils/responseMeta';
-import { asyncRouter } from '@/server/routers/async';
-
-const handler = (req: NextRequest) => {
-  // Clone the request to avoid "Response body object should not be disturbed or locked" error
-  // in Next.js 16 when the body stream has been consumed by Next.js internal mechanisms
-  const preparedReq = prepareRequestForTRPC(req);
-
-  return fetchRequestHandler({
-    // Avoid interference between requests
-    // https://github.com/lobehub/lobe-chat/discussions/7442#discussioncomment-13658563
-    allowBatching: false,
-
-    /**
-     * @link https://trpc.io/docs/v11/context
-     */
-    createContext: () => createAsyncRouteContext(req),
-
-    endpoint: '/trpc/async',
-
-    onError: ({ error, path, type }) => {
-      console.info(`Error in tRPC handler (async) on path: ${path}, type: ${type}`);
-      console.error(error);
-    },
-
-    req: preparedReq,
-    responseMeta: createResponseMeta,
-    router: asyncRouter,
-  });
-};
+const handler = (request: Request) => app.fetch(request);
 
 export { handler as GET, handler as POST };

--- a/src/app/(backend)/trpc/lambda/[trpc]/route.ts
+++ b/src/app/(backend)/trpc/lambda/[trpc]/route.ts
@@ -1,35 +1,5 @@
-import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
-import { type NextRequest } from 'next/server';
+import app from '@/server/router-hono/trpc/lambda';
 
-import { createLambdaContext } from '@/libs/trpc/lambda/context';
-import { createTRPCErrorLogger } from '@/libs/trpc/utils/errorLogger';
-import { prepareRequestForTRPC } from '@/libs/trpc/utils/request-adapter';
-import { createResponseMeta } from '@/libs/trpc/utils/responseMeta';
-import { lambdaRouter } from '@/server/routers/lambda';
-
-const handler = (req: NextRequest) => {
-  // Clone the request to avoid "Response body object should not be disturbed or locked" error
-  // in Next.js 16 when the body stream has been consumed by Next.js internal mechanisms
-  const preparedReq = prepareRequestForTRPC(req);
-
-  return fetchRequestHandler({
-    // Large-input queries (see the client's LARGE_INPUT_QUERY_PROCEDURES) are
-    // sent as POST to dodge the GET URL length budget — let tRPC accept them.
-    allowMethodOverride: true,
-
-    /**
-     * @link https://trpc.io/docs/v11/context
-     */
-    createContext: () => createLambdaContext(req),
-
-    endpoint: '/trpc/lambda',
-
-    onError: createTRPCErrorLogger('lambda'),
-
-    req: preparedReq,
-    responseMeta: createResponseMeta,
-    router: lambdaRouter,
-  });
-};
+const handler = (request: Request) => app.fetch(request);
 
 export { handler as GET, handler as POST };

--- a/src/app/(backend)/trpc/mobile/[trpc]/route.ts
+++ b/src/app/(backend)/trpc/mobile/[trpc]/route.ts
@@ -1,31 +1,5 @@
-import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
-import { type NextRequest } from 'next/server';
+import app from '@/server/router-hono/trpc/mobile';
 
-import { createLambdaContext } from '@/libs/trpc/lambda/context';
-import { createTRPCErrorLogger } from '@/libs/trpc/utils/errorLogger';
-import { prepareRequestForTRPC } from '@/libs/trpc/utils/request-adapter';
-import { createResponseMeta } from '@/libs/trpc/utils/responseMeta';
-import { mobileRouter } from '@/server/routers/mobile';
-
-const handler = (req: NextRequest) => {
-  // Clone the request to avoid "Response body object should not be disturbed or locked" error
-  // in Next.js 16 when the body stream has been consumed by Next.js internal mechanisms
-  const preparedReq = prepareRequestForTRPC(req);
-
-  return fetchRequestHandler({
-    /**
-     * @link https://trpc.io/docs/v11/context
-     */
-    createContext: () => createLambdaContext(req),
-
-    endpoint: '/trpc/mobile',
-
-    onError: createTRPCErrorLogger('mobile'),
-
-    req: preparedReq,
-    responseMeta: createResponseMeta,
-    router: mobileRouter,
-  });
-};
+const handler = (request: Request) => app.fetch(request);
 
 export { handler as GET, handler as POST };

--- a/src/app/(backend)/trpc/tools/[trpc]/route.ts
+++ b/src/app/(backend)/trpc/tools/[trpc]/route.ts
@@ -1,31 +1,5 @@
-import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
-import { type NextRequest } from 'next/server';
+import app from '@/server/router-hono/trpc/tools';
 
-import { createLambdaContext } from '@/libs/trpc/lambda/context';
-import { createTRPCErrorLogger } from '@/libs/trpc/utils/errorLogger';
-import { prepareRequestForTRPC } from '@/libs/trpc/utils/request-adapter';
-import { createResponseMeta } from '@/libs/trpc/utils/responseMeta';
-import { toolsRouter } from '@/server/routers/tools';
-
-const handler = (req: NextRequest) => {
-  // Clone the request to avoid "Response body object should not be disturbed or locked" error
-  // in Next.js 16 when the body stream has been consumed by Next.js internal mechanisms
-  const preparedReq = prepareRequestForTRPC(req);
-
-  return fetchRequestHandler({
-    /**
-     * @link https://trpc.io/docs/v11/context
-     */
-    createContext: () => createLambdaContext(req),
-
-    endpoint: '/trpc/tools',
-
-    onError: createTRPCErrorLogger('tools'),
-
-    req: preparedReq,
-    responseMeta: createResponseMeta,
-    router: toolsRouter,
-  });
-};
+const handler = (request: Request) => app.fetch(request);
 
 export { handler as GET, handler as POST };

--- a/src/libs/next/config/define-config.ts
+++ b/src/libs/next/config/define-config.ts
@@ -10,6 +10,7 @@ interface CustomNextConfig {
   outputFileTracingExcludes?: NextConfig['outputFileTracingExcludes'];
   outputFileTracingIncludes?: NextConfig['outputFileTracingIncludes'];
   redirects?: Redirect[];
+  rewrites?: NextConfig['rewrites'];
   serverExternalPackages?: NextConfig['serverExternalPackages'];
   turbopack?: NextConfig['turbopack'];
 }
@@ -351,6 +352,7 @@ export function defineConfig(config: CustomNextConfig) {
       },
       ...(config.redirects ?? []),
     ],
+    rewrites: config.rewrites,
     // when external packages in dev mode with turbopack, this config will lead to bundle error
     serverExternalPackages: config.serverExternalPackages ?? [
       'pdfkit',


### PR DESCRIPTION
## Summary

- mount the async, lambda, mobile, and tools tRPC namespaces in the standalone Hono server
- delegate the existing Next.js tRPC route shells to the same Hono apps
- restore a dev:hono topology that starts Next.js, Vite, and the standalone Hono runtime, with /trpc forwarded to Hono

## Validation

- bun run check (73 tests passed)
- pnpm --filter @lobechat/server build
- bun run dev:hono
- verified /trpc/tools/healthcheck directly on port 3011 and through the Next.js entry on port 3010

## Follow-up: make the standalone runtime production-ready behind a gateway

- **Next request API compat** — `next/headers` (`headers`, `cookies`, `draftMode`) and `next/server` (`after`) are aliased to `apps/server/src/router-hono/next-compat/` in the Hono dev and build configs, backed by an AsyncLocalStorage the root Hono app populates per request. `getSessionUser()`, the logto/casdoor webhook validators and `scheduleAfterResponse` now work on the standalone runtime; the Next.js runtime is untouched.
- **Production bundle fix** — rolldown's default splitting produced two chunks importing each other, so every `/trpc/lambda/*` on `node dist/standalone.js` died with `__esmMin is not a function`. The build now emits a single server chunk.
- **Runtime hardening** — `HONO_KEEP_ALIVE_TIMEOUT_MS` (default 65s, headersTimeout above it), `HONO_HOST` defaults to `0.0.0.0` in production, `x-forwarded-for` falls back to the socket address, and SIGTERM/SIGINT drain in-flight requests plus `after()` tasks within `HONO_SHUTDOWN_TIMEOUT_MS` (default 10s).

Verified on the built bundle (`Keep-Alive: timeout=65`, session-cookie lambda calls 200, clean SIGTERM drain) and on vite-node dev. Acceptance round for the tRPC-in-Hono flows: https://app.lobehub.com/acceptance/26c6f1ab-a57f-4afb-b599-d27ea3dc93c1

## Follow-up: Docker image + Railway config for the standalone runtime

- `apps/server/Dockerfile` (context = repo root) builds the Hono bundle and ships it without Next. The build inlines **every JS dependency**; only native bindings / bundled binaries listed in `apps/server/honoExternals.ts` stay external, and `scripts/honoRuntimeDeps.mts` installs just those (pinned to the builder's versions, with `patchedDependencies` / `onlyBuiltDependencies` / `packageManager` carried over). Runtime image = `dist` (50 MB, single chunk + pdfkit AFM fonts) + `node_modules` with `sharp` and `ffmpeg-static` (20 MB): **318 MB**, down from 1.56 GB with externalised deps.
- Making the single-chunk bundle boot needed three module-order fixes, all in `router-hono/polyfills.ts` + the build config: `reflect-metadata` and the DOMMatrix polyfill load before anything else (tsyringe via `@peculiar/x509` and pdfjs-dist check them in their module bodies, officeparser requires pdfjs eagerly), rolldown is told `reflect-metadata` has side effects (it dropped x509's bare import), and resend's optional `@react-email/render` stays external so its lazy import rejects at call time instead of Vite's stub throwing at startup. `__dirname` / `__filename` map to `import.meta.*` for inlined CommonJS.
- No `next` at runtime: the shim no longer borrows `NextResponse` / the edge-runtime cookie store from `next/dist`; `cookies()` sits on the `cookie` package, `next/server` only exports `after()` / `connection()`, and the two `NextResponse.json` callers use `Response.json`.
- `apps/server/railway.json` is Railway config-as-code for that image (`DOCKERFILE` builder, `/health` healthcheck, `ON_FAILURE` restarts, 15 s drain). Point the service's config-as-code path at `/apps/server/railway.json`; `PORT` is injected by Railway (`HONO_HOST` already defaults to `0.0.0.0` in production).
- Scope reminder: the image serves `/health`, `/trpc/{async,lambda,mobile,tools}/*`, `/api/agent*`, `/api/workflows*` only. Auth, `/webapi/*`, OIDC and the SPA shell still need Next behind the same gateway.

Verified on the built image against the acceptance Postgres/Redis: `/health` 200, `/trpc/tools/healthcheck` 200, `user.getUserRegistrationDuration` with `X-API-Key` 200 (DB-backed), unauthenticated lambda 401, `Keep-Alive: timeout=65`, `docker stop` → clean SIGTERM drain, exit 0.

Cloud mirror: lobehub-biz/lobehub-cloud#1590.

https://claude.ai/code/session_01CGKMwHWDMEdPLrN4NwihrJ



