### PR TITLE
chore: remove LOBE-13477 marker from regression guard comment

### DIFF
--- a/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
@@ -1465,7 +1465,7 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
       expect(mockExecuteToolCall).not.toHaveBeenCalled();
     });
 
-    // Regression guard for LOBE-13477: a callAgent/callSubAgent-spawned hetero
+    // Regression guard: a callAgent/callSubAgent-spawned hetero
     // child (isolation-thread, no topicStartOwnerOperationId) must still get
     // its userId/workspaceId written to the state-manager metadata store —
     // subAgentCallback reads it to authorize resuming the parked parent


### PR DESCRIPTION
## Summary

Automated daily scan of the `canary` branch for `LOBE-XXX` markers in source code comments.

## Change

Removed a stale `LOBE-13477` reference from a regression-guard comment in `execAgent.heteroFiles.test.ts`. The underlying fix (PR #18668) has already merged, and the comment now describes the scenario inline without relying on the internal issue marker.

### Changed files

```
apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
```

## Notes

- The `LOBE-13364` marker in `loadAttachmentBuffer.ts` is already handled by open PR #18661 and was intentionally left untouched.
- `locales/*/project.json` and `packages/locales/src/default/project.ts` contain `LOBE-123` as user-facing example copy, not internal markers, so they were not modified.