### PR TITLE
🐛 fix(codex): improve quota endpoint error guidance

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -649,6 +649,8 @@
   "heteroAgent.cloudRepo.notSet": "No repo selected",
   "heteroAgent.cloudRepo.sectionTitle": "Repositories",
   "heteroAgent.codexQuota.doesNotExpire": "Does not expire",
+  "heteroAgent.codexQuota.errorConnection": "Couldn't reach the Codex quota endpoint. Check your network or LobeHub proxy settings.",
+  "heteroAgent.codexQuota.errorGeneric": "Couldn't load Codex quota. Try again later.",
   "heteroAgent.codexQuota.expiresIn": "Expires in {{duration}}",
   "heteroAgent.codexQuota.expiresSoon": "Expires soon",
   "heteroAgent.codexQuota.fiveHour": "5-hour",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -649,6 +649,8 @@
   "heteroAgent.cloudRepo.notSet": "未选择仓库",
   "heteroAgent.cloudRepo.sectionTitle": "代码仓库",
   "heteroAgent.codexQuota.doesNotExpire": "永不过期",
+  "heteroAgent.codexQuota.errorConnection": "无法访问 Codex 额度接口，请检查网络或 LobeHub 代理设置。",
+  "heteroAgent.codexQuota.errorGeneric": "无法获取 Codex 额度，请稍后重试。",
   "heteroAgent.codexQuota.expiresIn": "{{duration}}后过期",
   "heteroAgent.codexQuota.expiresSoon": "即将过期",
   "heteroAgent.codexQuota.fiveHour": "5 小时",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -422,6 +422,9 @@ export default {
   'heteroAgent.claudeSdkRuntime.state.starting': 'SDK starting',
   'heteroAgent.claudeSdkRuntime.tooltip': '{{state}}. Active background tasks: {{count}}.',
   'heteroAgent.codexQuota.doesNotExpire': 'Does not expire',
+  'heteroAgent.codexQuota.errorConnection':
+    "Couldn't reach the Codex quota endpoint. Check your network or LobeHub proxy settings.",
+  'heteroAgent.codexQuota.errorGeneric': "Couldn't load Codex quota. Try again later.",
   'heteroAgent.codexQuota.expiresIn': 'Expires in {{duration}}',
   'heteroAgent.codexQuota.expiresSoon': 'Expires soon',
   'heteroAgent.codexQuota.fiveHour': '5-hour',

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/CodexQuotaMenu.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/CodexQuotaMenu.tsx
@@ -23,6 +23,11 @@ const WEEKLY_WINDOW_MINUTES = 7 * 24 * 60;
 const MONTHLY_WINDOW_MIN_MINUTES = 28 * 24 * 60;
 const MONTHLY_WINDOW_MAX_MINUTES = 31 * 24 * 60;
 
+const isConnectionError = (quota: CodexQuotaSnapshot) =>
+  /error sending request for url|fetch failed|\b(?:ECONNREFUSED|ENOTFOUND|ETIMEDOUT)\b/i.test(
+    quota.error ?? '',
+  );
+
 const styles = createStaticStyles(({ css }) => ({
   credit: css`
     min-width: 0;
@@ -213,6 +218,14 @@ const CodexQuotaMenu = memo<CodexQuotaMenuProps>(({ command, env }) => {
   const hasExtraData = useCallback(
     (quota: CodexQuotaSnapshot) => !!quota.rateLimitResetCredits,
     [],
+  );
+
+  const getErrorText = useCallback(
+    (quota: CodexQuotaSnapshot) =>
+      isConnectionError(quota)
+        ? t('heteroAgent.codexQuota.errorConnection')
+        : t('heteroAgent.codexQuota.errorGeneric'),
+    [t],
   );
 
   const consumeReset = useCallback(
@@ -442,6 +455,8 @@ const CodexQuotaMenu = memo<CodexQuotaMenuProps>(({ command, env }) => {
       contentWidth={360}
       createErrorSnapshot={createErrorSnapshot}
       fetchQuota={fetchQuota}
+      getErrorText={getErrorText}
+      getRefreshErrorText={getErrorText}
       getWindows={getWindows}
       hasExtraData={hasExtraData}
       renderFooter={renderFooter}

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/QuotaMenu.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/QuotaMenu/QuotaMenu.test.tsx
@@ -975,6 +975,21 @@ describe('ClaudeCodeQuotaMenu', () => {
 });
 
 describe('CodexQuotaMenu', () => {
+  it.each([
+    [
+      'failed to fetch codex rate limits: error sending request for url (https://chatgpt.com/backend-api/wham/usage)',
+      'heteroAgent.codexQuota.errorConnection',
+    ],
+    ['unexpected RPC failure', 'heteroAgent.codexQuota.errorGeneric'],
+  ])('shows a friendly error instead of exposing %s', async (error, expectedMessage) => {
+    mockService.getCodexQuota.mockResolvedValue(codexSnapshot({ error, status: 'error' }));
+
+    render(<CodexQuotaMenu command="codex" />);
+
+    expect(await screen.findByText(expectedMessage)).toBeTruthy();
+    expect(screen.queryByText(error)).toBeNull();
+  });
+
   it('renders windows and the reset-credits footer', async () => {
     const resetsAt = Date.now() + 60 * 60_000;
     mockService.getCodexQuota.mockResolvedValue(


### PR DESCRIPTION
<!-- Brief and heads-up -->

Codex quota transport failures currently expose the raw app-server error and backend URL in the quota popover. This change maps network-level failures to localized, actionable guidance while keeping a generic fallback for other failures.

- Detect transport failures reported by the Codex app-server quota RPC.
- Show endpoint/network/proxy guidance instead of raw provider diagnostics.
- Apply the friendly message to both initial loads and refresh failures.
- Add English and Chinese locale copy plus regression coverage.

| Before | After |
| ------ | ----- |
| `failed to fetch codex rate limits: error sending request for url (...)` | `Couldn't reach the Codex quota endpoint. Check your network or LobeHub proxy settings.` |

#### Test

- `bun run check <changed files>` — lint clean, 39 tests passed

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

None found.
