### PR TITLE
🐛 fix(codex): normalize app-server file diffs

### DIFF
--- a/packages/heterogeneous-agents/src/adapters/codexAppServer.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/codexAppServer.test.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 
+import { parsePatch } from 'diff';
 import { describe, expect, it } from 'vitest';
 
 import { CodexAdapter } from './codex';
@@ -156,6 +157,64 @@ describe('CodexAppServerAdapter', () => {
     expect(result.content).toHaveLength(25_078);
     expect(result.pluginState.output).toBe(result.content);
     expect(result.pluginState.stdout).toBe(result.content);
+  });
+
+  it('normalizes native file changes into complete single-file patches', () => {
+    const adapter = new CodexAppServerAdapter();
+    const events = adapter.adapt('item/completed', {
+      completedAtMs: 2,
+      item: {
+        changes: [
+          {
+            diff: '@@ -1 +1 @@\n-old\n+new\n',
+            kind: { move_path: null, type: 'update' },
+            path: '/workspace/updated.ts',
+          },
+          {
+            diff: 'first\nsecond\n',
+            kind: { type: 'add' },
+            path: 'src/added.ts',
+          },
+          {
+            diff: 'removed\n',
+            kind: { type: 'delete' },
+            path: 'src/deleted.ts',
+          },
+          {
+            diff: '@@ -1 +1 @@\n-before\n+after\n\n\nMoved to: src/after.ts',
+            kind: { move_path: 'src/after.ts', type: 'update' },
+            path: 'src/before.ts',
+          },
+        ],
+        id: 'file-change-1',
+        status: 'completed',
+        type: 'fileChange',
+      },
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+    });
+    const changes = events.find(({ type }) => type === 'tool_result')?.data.pluginState
+      ?.changes as Array<{ diffText: string; kind: string }>;
+
+    expect(changes.map(({ kind }) => kind)).toEqual(['update', 'add', 'delete', 'rename']);
+    expect(changes[0].diffText).toContain(
+      'diff --git a/workspace/updated.ts b/workspace/updated.ts\n--- a/workspace/updated.ts\n+++ b/workspace/updated.ts\n@@ -1 +1 @@',
+    );
+    expect(changes[1].diffText).toContain('--- /dev/null');
+    expect(changes[1].diffText).toContain('+++ b/src/added.ts');
+    expect(changes[1].diffText).toContain('+first\n+second');
+    expect(changes[2].diffText).toContain('--- a/src/deleted.ts');
+    expect(changes[2].diffText).toContain('+++ /dev/null');
+    expect(changes[2].diffText).toContain('-removed');
+    expect(changes[3].diffText).toContain('diff --git a/src/before.ts b/src/after.ts');
+    expect(changes[3].diffText).not.toContain('Moved to:');
+
+    for (const { diffText } of changes) {
+      const parsed = parsePatch(diffText);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].oldFileName).toBeTypeOf('string');
+      expect(parsed[0].newFileName).toBeTypeOf('string');
+    }
   });
 
   it.each([

--- a/packages/heterogeneous-agents/src/adapters/codexAppServer.ts
+++ b/packages/heterogeneous-agents/src/adapters/codexAppServer.ts
@@ -1,3 +1,5 @@
+import { formatPatch, structuredPatch } from 'diff';
+
 import type {
   AgentMessageDeltaNotification,
   CodexErrorInfo,
@@ -120,9 +122,44 @@ const toToolPayload = (item: ToolItem): ToolCallPayload => ({
   type: 'default',
 });
 
+const toGitDiffPath = (prefix: 'a' | 'b', filePath: string): string =>
+  filePath.startsWith('/') ? `${prefix}${filePath}` : `${prefix}/${filePath}`;
+
+// App-server sends raw content for add/delete and headerless hunks for update.
+// Normalize both forms to the complete single-file patch expected by PatchDiff.
+const toCompleteFileDiff = (change: FileUpdateChange): string => {
+  const sourcePath = toGitDiffPath('a', change.path);
+  const destinationPath = toGitDiffPath(
+    'b',
+    change.kind.type === 'update' && change.kind.move_path ? change.kind.move_path : change.path,
+  );
+  const gitHeader = `diff --git ${sourcePath} ${destinationPath}`;
+
+  if (change.kind.type === 'add' || change.kind.type === 'delete') {
+    const patch = structuredPatch(
+      change.kind.type === 'add' ? '/dev/null' : sourcePath,
+      change.kind.type === 'delete' ? '/dev/null' : destinationPath,
+      change.kind.type === 'delete' ? change.diff : '',
+      change.kind.type === 'add' ? change.diff : '',
+    );
+    return `${gitHeader}\n${formatPatch(patch)}`;
+  }
+
+  const movePath = change.kind.move_path;
+  const moveSuffix = movePath ? `\n\nMoved to: ${movePath}` : '';
+  const hunks =
+    moveSuffix && change.diff.endsWith(moveSuffix)
+      ? change.diff.slice(0, -moveSuffix.length)
+      : change.diff;
+
+  return [gitHeader, `--- ${sourcePath}`, `+++ ${destinationPath}`, hunks]
+    .filter(Boolean)
+    .join('\n');
+};
+
 const toFileChangeState = (changes: FileUpdateChange[]) => ({
   changes: changes.map((change) => ({
-    diffText: change.diff,
+    diffText: toCompleteFileDiff(change),
     kind: change.kind.type === 'update' && change.kind.move_path ? 'rename' : change.kind.type,
     path: change.path,
   })),


### PR DESCRIPTION
## Summary

- normalize Codex app-server add/delete content and update hunks into complete single-file patches
- preserve move destinations while removing the app-server-only `Moved to:` trailer
- prevent the edited-files card from crashing when users expand native Codex file changes

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check packages/heterogeneous-agents/src/adapters/codexAppServer.ts packages/heterogeneous-agents/src/adapters/codexAppServer.test.ts`
- Replayed the latest real Codex trace through `@pierre/diffs`; all 26 completed file changes parsed successfully.

#### 🔗 Related Issue

No matching issue found.