### PR TITLE
🐛 fix(task): skeletonize kanban column headers while grouping

### DIFF
--- a/src/features/AgentTasks/AgentTaskList/KanbanColumn.tsx
+++ b/src/features/AgentTasks/AgentTaskList/KanbanColumn.tsx
@@ -1,6 +1,6 @@
 import { useDndContext, useDraggable, useDroppable } from '@dnd-kit/core';
 import type { TaskStatus } from '@lobechat/types';
-import { ActionIcon, type DropdownItem, DropdownMenu, Icon, Text } from '@lobehub/ui';
+import { ActionIcon, type DropdownItem, DropdownMenu, Icon, Skeleton, Text } from '@lobehub/ui';
 import { createStaticStyles, cx } from 'antd-style';
 import { EyeOff, MoreHorizontal, Plus } from 'lucide-react';
 import { memo, useMemo } from 'react';
@@ -11,6 +11,7 @@ import type { TaskKanbanGroupBy, TaskListItem } from '@/store/task/slices/list/i
 import type { TaskItemRouteScope } from '../features/AgentTaskItem';
 import AgentTaskItem from '../features/AgentTaskItem';
 import TaskStatusIcon from '../features/TaskStatusIcon';
+import { getKanbanColumnHeaderVariant } from './kanbanBoardModel';
 import type { TaskGroupMeta } from './listViewOptions';
 import TaskGroupLabel from './TaskGroupLabel';
 import TaskItemSkeleton from './TaskItemSkeleton';
@@ -207,6 +208,10 @@ const KanbanColumn = memo<KanbanColumnProps>(
     const statusIcon = COLUMN_STATUS_ICON[columnKey];
     const i18nKey = COLUMN_I18N_KEYS[columnKey];
     const label = i18nKey ? t(i18nKey as any) : t(`taskList.groupBy.${groupBy}` as any);
+    const headerVariant = getKanbanColumnHeaderVariant({
+      hasGroupMeta: !!groupMeta,
+      loading,
+    });
     const isDragActive = !!active;
 
     // Don't highlight if dragging a card that's already in this column
@@ -241,18 +246,32 @@ const KanbanColumn = memo<KanbanColumnProps>(
         )}
       >
         <div className={styles.header}>
-          {groupMeta ? (
-            <TaskGroupLabel group={groupMeta} />
+          {headerVariant === 'loading' ? (
+            <>
+              <Skeleton.Avatar
+                active
+                shape={'square'}
+                size={16}
+                style={{ borderRadius: 4, flex: 'none' }}
+              />
+              <Skeleton.Button active style={{ height: 14, minWidth: 64, width: 64 }} />
+              <Skeleton.Button active style={{ height: 12, minWidth: 20, width: 20 }} />
+            </>
+          ) : headerVariant === 'group' && groupMeta ? (
+            <>
+              <TaskGroupLabel group={groupMeta} />
+              <Text fontSize={12} type={'secondary'}>
+                {total}
+              </Text>
+            </>
           ) : (
             <>
               {statusIcon && <TaskStatusIcon size={18} status={statusIcon} />}
               <Text weight={500}>{label}</Text>
+              <Text fontSize={12} type={'secondary'}>
+                {total}
+              </Text>
             </>
-          )}
-          {!loading && (
-            <Text fontSize={12} type={'secondary'}>
-              {total}
-            </Text>
           )}
           <div className={cx(styles.headerActions, 'kanban-col-action')}>
             {menuItems.length > 0 && (

--- a/src/features/AgentTasks/AgentTaskList/kanbanBoardModel.test.ts
+++ b/src/features/AgentTasks/AgentTaskList/kanbanBoardModel.test.ts
@@ -6,6 +6,7 @@ import {
   buildKanbanColumns,
   canDropTaskIntoKanbanColumn,
   getKanbanAssigneeUpdate,
+  getKanbanColumnHeaderVariant,
   getKanbanTaskPatch,
   moveTaskBetweenKanbanGroups,
   normalizeKanbanGroupBy,
@@ -52,6 +53,13 @@ describe('kanbanBoardModel', () => {
     expect(normalizeKanbanGroupBy('assignee')).toBe('assignee');
     expect(normalizeKanbanGroupBy('priority')).toBe('priority');
     expect(normalizeKanbanGroupBy('none')).toBe('status');
+  });
+
+  it('keeps the column header in skeleton mode for every loading group shape', () => {
+    expect(getKanbanColumnHeaderVariant({ hasGroupMeta: false, loading: true })).toBe('loading');
+    expect(getKanbanColumnHeaderVariant({ hasGroupMeta: true, loading: true })).toBe('loading');
+    expect(getKanbanColumnHeaderVariant({ hasGroupMeta: true })).toBe('group');
+    expect(getKanbanColumnHeaderVariant({ hasGroupMeta: false })).toBe('fallback');
   });
 
   it('builds assignee columns including the unassigned group', () => {

--- a/src/features/AgentTasks/AgentTaskList/kanbanBoardModel.ts
+++ b/src/features/AgentTasks/AgentTaskList/kanbanBoardModel.ts
@@ -25,6 +25,19 @@ export interface KanbanAssigneeUpdate {
   assigneeUserId: string | null;
 }
 
+export type KanbanColumnHeaderVariant = 'fallback' | 'group' | 'loading';
+
+export const getKanbanColumnHeaderVariant = ({
+  hasGroupMeta,
+  loading,
+}: {
+  hasGroupMeta: boolean;
+  loading?: boolean;
+}): KanbanColumnHeaderVariant => {
+  if (loading) return 'loading';
+  return hasGroupMeta ? 'group' : 'fallback';
+};
+
 export const STATUS_KANBAN_COLUMNS: KanbanColumnDefinition[] = [
   { droppable: true, key: 'backlog', targetStatus: 'backlog' },
   { droppable: false, key: 'running', targetStatus: null },


### PR DESCRIPTION
## Summary

- render icon, title, and count skeletons in Kanban column headers while grouped data is loading
- prioritize the loading header state over existing group metadata so assignee and priority switches do not retain stale labels
- cover loading headers with and without group metadata

## Validation

- [x] `bun run check src/features/AgentTasks/AgentTaskList/KanbanColumn.tsx src/features/AgentTasks/AgentTaskList/kanbanBoardModel.ts src/features/AgentTasks/AgentTaskList/kanbanBoardModel.test.ts` — 3 files, lint clean, 8 tests passed
- [x] Debug Proxy + local Vite HMR — verified Assignee and Priority switches against real `task.groupList` responses
- [x] GIF evidence attached inline to LOBE-13521
- [ ] `bun run check --type` — blocked by existing workspace issues in `.next/dev/types` plus duplicate Drizzle/Dayjs type identities; no errors were reported in the changed files

Fixes LOBE-13521