### PR TITLE
🐛 fix(chat): move voice dictation to left actions

### DIFF
--- a/src/features/ChatInput/ActionBar/filterChatOnlyActions.ts
+++ b/src/features/ChatInput/ActionBar/filterChatOnlyActions.ts
@@ -13,6 +13,7 @@ const CHAT_ONLY_ACTIONS = new Set<ActionKey>([
   'plus',
   'promptTransform',
   'typo',
+  'voiceDictation',
 ]);
 
 /**

--- a/src/features/ChatInput/ActionBar/index.test.ts
+++ b/src/features/ChatInput/ActionBar/index.test.ts
@@ -71,10 +71,11 @@ describe('filterChatOnlyActions', () => {
         'memory',
         'fileUpload',
         'tools',
+        'voiceDictation',
         '---',
         ['typo', 'params', 'clear'],
       ]),
-    ).toEqual(['agentMode', 'model', 'fileUpload', '---', ['typo', 'clear']]);
+    ).toEqual(['agentMode', 'model', 'fileUpload', 'voiceDictation', '---', ['typo', 'clear']]);
   });
 
   it('keeps the icon model trigger for chat-only members instead of degrading to the text label', () => {

--- a/src/features/ChatInput/SendArea/index.tsx
+++ b/src/features/ChatInput/SendArea/index.tsx
@@ -36,14 +36,14 @@ const SendArea = memo<SendAreaProps>(({ hideContextWindow = true }) => {
     () =>
       canShowControls
         ? mapActionsToItems(
-            audioInputActive
-              ? ([
-                  activeAudioInputMode === 'dictation' ? 'voiceDictation' : 'voiceMessage',
-                ] as ActionKey[])
-              : resolveSendAreaActionKeys(rightActions as ActionKey[], hideContextWindow),
+            resolveSendAreaActionKeys(
+              rightActions as ActionKey[],
+              hideContextWindow,
+              activeAudioInputMode,
+            ),
           )
         : [],
-    [activeAudioInputMode, audioInputActive, canShowControls, hideContextWindow, rightActions],
+    [activeAudioInputMode, canShowControls, hideContextWindow, rightActions],
   );
 
   return (

--- a/src/features/ChatInput/SendArea/resolveActionKeys.test.ts
+++ b/src/features/ChatInput/SendArea/resolveActionKeys.test.ts
@@ -19,6 +19,13 @@ describe('resolveSendAreaActionKeys', () => {
     ).toEqual(['promptTransform', 'contextWindow']);
   });
 
+  it('omits an active audio control when its action belongs to another region', () => {
+    expect(resolveSendAreaActionKeys(['voiceMessage'], true, 'dictation')).toEqual([]);
+    expect(resolveSendAreaActionKeys(['voiceMessage'], true, 'voiceMessage')).toEqual([
+      'voiceMessage',
+    ]);
+  });
+
   it('handles undefined rightActions', () => {
     expect(resolveSendAreaActionKeys(undefined, true)).toEqual([]);
     expect(resolveSendAreaActionKeys(undefined, false)).toEqual([]);

--- a/src/features/ChatInput/SendArea/resolveActionKeys.ts
+++ b/src/features/ChatInput/SendArea/resolveActionKeys.ts
@@ -1,4 +1,5 @@
-import { type ActionKey } from '../ActionBar/config';
+import type { ActionKey } from '../ActionBar/config';
+import type { State } from '../store/initialState';
 
 /**
  * Resolve which right actions the SendArea itself renders.
@@ -7,11 +8,24 @@ import { type ActionKey } from '../ActionBar/config';
  * so the SendArea strips it to avoid a double render. Composers without a
  * ControlBar (mobile, floating panel) have no other host, so they keep it
  * beside the Send button.
+ *
+ * Active audio controls stay in the region where their action is configured.
+ * If dictation is a left action, SendArea must not render a duplicate copy on
+ * the right while the session is active.
  */
 export const resolveSendAreaActionKeys = (
   rightActions: ActionKey[] | undefined,
   hideContextWindow: boolean,
+  activeAudioInputMode?: State['activeAudioInputMode'],
 ): ActionKey[] => {
   const keys = rightActions || [];
+
+  if (activeAudioInputMode) {
+    const activeActionKey =
+      activeAudioInputMode === 'dictation' ? 'voiceDictation' : 'voiceMessage';
+
+    return keys.includes(activeActionKey) ? [activeActionKey] : [];
+  }
+
   return hideContextWindow ? keys.filter((actionKey) => actionKey !== 'contextWindow') : keys;
 };

--- a/src/features/Portal/Thread/Chat/index.tsx
+++ b/src/features/Portal/Thread/Chat/index.tsx
@@ -99,8 +99,8 @@ const ThreadChatContent = memo<ThreadChatContentProps>(
         {composerWritable && inputMode === 'heterogeneous' && <HeterogeneousChatInput />}
         {composerWritable && inputMode === 'default' && (
           <ChatInput
-            leftActions={['typo']}
-            rightActions={['voiceDictation', 'voiceMessage', 'contextWindow']}
+            leftActions={['typo', 'voiceDictation']}
+            rightActions={['voiceMessage', 'contextWindow']}
           />
         )}
       </>

--- a/src/routes/(main)/agent/features/Conversation/MainChatInput/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/MainChatInput/index.tsx
@@ -15,10 +15,9 @@ import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 import AgentConfigError from './AgentConfigError';
 import { useSendMenuItems } from './useSendMenuItems';
 
-const contextWindowRightActions: ActionKeys[] = ['voiceDictation', 'voiceMessage', 'contextWindow'];
+const contextWindowRightActions: ActionKeys[] = ['voiceMessage', 'contextWindow'];
 const promptTransformRightActions: ActionKeys[] = [
   'promptTransform',
-  'voiceDictation',
   'voiceMessage',
   'contextWindow',
 ];
@@ -46,7 +45,7 @@ const MainChatInput = memo(() => {
 
   // Reasoning effort lives inside the "+" menu (Plus → 推理强度) rather than as
   // a standalone action — per the effort parameter refactoring.
-  const leftActions: ActionKeys[] = useMemo(() => ['model', 'plus'], []);
+  const leftActions: ActionKeys[] = useMemo(() => ['model', 'plus', 'voiceDictation'], []);
 
   return (
     <>

--- a/src/routes/(main)/group/features/Conversation/MainChatInput/index.tsx
+++ b/src/routes/(main)/group/features/Conversation/MainChatInput/index.tsx
@@ -15,11 +15,12 @@ const leftActions: ActionKeys[] = [
   'memory',
   'fileUpload',
   'tools',
+  'voiceDictation',
   '---',
   ['typo', 'params', 'clear'],
 ];
 
-const rightActions: ActionKeys[] = ['voiceDictation', 'voiceMessage', 'contextWindow'];
+const rightActions: ActionKeys[] = ['voiceMessage', 'contextWindow'];
 
 /**
  * MainChatInput


### PR DESCRIPTION
Moves ASR voice dictation from the right-side send area to the left action bar, matching the WeChat-style layout while keeping voice messages and Send on the right.

The change covers Agent, Group, and Portal Thread composers. Active audio controls now remain in the region where their action is configured, preventing a second dictation control from appearing on the right while recording.

| Before | After |
| ------ | ----- |
| Dictation was grouped with voice message and Send on the right. [Current layout and WeChat reference](https://linear.app/lobehub/issue/LOBE-13531) | Dictation is on the left in Agent, Group, and Portal Thread. [Agent-testing evidence](https://app.lobehub.com/acceptance/e2e7d618-ae96-4127-aaa7-6a78d488dacd) |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check <8 changed files>` — lint clean, 7 related tests passed
- agent-testing — 4/4 scenarios passed: Agent default, Agent narrow, Group, Portal Thread
- `git diff --check` — passed
- `bun run check --type` — blocked by the local root / `apps/desktop` duplicate React and antd type trees; all reported errors are in unchanged files

#### 🔗 Related Issue

Fixes LOBE-13531
