### PR TITLE
🐛 fix(home): prevent portrait from blocking clicks

### DIFF
--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -215,6 +215,7 @@ const styles = createStaticStyles(({ css }) => ({
     padding-block-end: ${MINIMAL_LIFT}px;
   `,
   portrait: css`
+    pointer-events: none;
     grid-area: 1 / 2;
     transition: transform ${RAIL_TRANSITION_DURATION}ms ease-out;
 


### PR DESCRIPTION
## Summary

- disable pointer hit-testing on the positioned Home portrait wrapper
- keep the transparent portrait layer from intercepting promo and header controls

## Verification

- bun run check src/features/Home/index.tsx
- git diff --check origin/canary...HEAD