### PR TITLE
🐛 fix(ci): dispatch renderer OTA before desktop releases

### DIFF
--- a/.github/workflows/release-desktop-beta.yml
+++ b/.github/workflows/release-desktop-beta.yml
@@ -69,6 +69,15 @@ jobs:
           fi
           echo "cloud_ref=$cloud_ref" >> "$GITHUB_OUTPUT"
 
+  renderer-ota:
+    name: Publish Renderer OTA
+    needs: [check-beta]
+    if: needs.check-beta.outputs.is_beta == 'true'
+    uses: ./.github/workflows/release-desktop-renderer-ota.yml
+    with:
+      channel: beta
+    secrets: inherit
+
   test:
     name: Code quality check
     needs: [check-beta]

--- a/.github/workflows/release-desktop-canary.yml
+++ b/.github/workflows/release-desktop-canary.yml
@@ -198,6 +198,15 @@ jobs:
             echo "EOF"
           } >> $GITHUB_OUTPUT
 
+  renderer-ota:
+    name: Publish Renderer OTA
+    needs: [calculate-version]
+    if: needs.calculate-version.outputs.should_build == 'true'
+    uses: ./.github/workflows/release-desktop-renderer-ota.yml
+    with:
+      channel: canary
+    secrets: inherit
+
   # ============================================
   # 代码质量检查
   # ============================================

--- a/.github/workflows/release-desktop-renderer-ota.yml
+++ b/.github/workflows/release-desktop-renderer-ota.yml
@@ -13,6 +13,12 @@ name: Release Desktop Renderer OTA
 # ============================================
 
 on:
+  workflow_call:
+    inputs:
+      channel:
+        description: 'Update channel'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       channel:
@@ -26,7 +32,7 @@ on:
         default: canary
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.channel }}
+  group: desktop-renderer-ota-${{ inputs.channel }}
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -135,6 +135,15 @@ jobs:
           fi
           echo "cloud_ref=$cloud_ref" >> "$GITHUB_OUTPUT"
 
+  renderer-ota:
+    name: Publish Renderer OTA
+    needs: [check-stable]
+    if: ${{ needs.check-stable.outputs.is_stable == 'true' && (github.event_name != 'workflow_dispatch' || !inputs.skip_s3_upload) }}
+    uses: ./.github/workflows/release-desktop-renderer-ota.yml
+    with:
+      channel: stable
+    secrets: inherit
+
   # ============================================
   # 配置构建矩阵 (检查自托管 Runner)
   # ============================================


### PR DESCRIPTION
## Summary

- make the renderer OTA workflow reusable while keeping manual dispatch
- invoke renderer OTA after the Canary, Beta, and Stable release gates without making full builds depend on it
- serialize manual and automatic OTA publishes per channel and respect Stable skip_s3_upload runs

## Test plan

- bun run check on the four changed workflows
- actionlint on the four changed workflows, excluding existing ShellCheck and softprops/action-gh-release v1 warnings
- git diff --check