### PR TITLE
💄 style: add workspace waitlist landing link copy and official url

### DIFF
--- a/locales/ar/setting.json
+++ b/locales/ar/setting.json
@@ -2799,6 +2799,7 @@
   "workspace.waitlistPage.entryCta": "انضم إلى النسخة التجريبية لمساحة العمل",
   "workspace.waitlistPage.goHome": "العودة إلى LobeHub",
   "workspace.waitlistPage.learnMore": "تعرف على المزيد حول Workspace",
+  "workspace.waitlistPage.learnMoreNewTabHint": "يفتح في علامة تبويب جديدة",
   "workspace.waitlistPage.organizationLabel": "المنظمة / المجموعة (اختياري)",
   "workspace.waitlistPage.organizationPlaceholder": "شركة، مدرسة، أو عائلة...",
   "workspace.waitlistPage.pendingSubtitle": "نقوم بفتح الوصول على دفعات وسنقوم بإعلامك عبر البريد الإلكتروني بمجرد أن يصبح الوصول متاحًا لك.",

--- a/locales/ar/setting.json
+++ b/locales/ar/setting.json
@@ -2798,6 +2798,7 @@
   "workspace.waitlistPage.enabledTitle": "مساحة العمل جاهزة لك",
   "workspace.waitlistPage.entryCta": "انضم إلى النسخة التجريبية لمساحة العمل",
   "workspace.waitlistPage.goHome": "العودة إلى LobeHub",
+  "workspace.waitlistPage.learnMore": "تعرف على المزيد حول Workspace",
   "workspace.waitlistPage.organizationLabel": "المنظمة / المجموعة (اختياري)",
   "workspace.waitlistPage.organizationPlaceholder": "شركة، مدرسة، أو عائلة...",
   "workspace.waitlistPage.pendingSubtitle": "نقوم بفتح الوصول على دفعات وسنقوم بإعلامك عبر البريد الإلكتروني بمجرد أن يصبح الوصول متاحًا لك.",

--- a/locales/bg-BG/setting.json
+++ b/locales/bg-BG/setting.json
@@ -2798,6 +2798,7 @@
   "workspace.waitlistPage.enabledTitle": "Работното пространство е готово за вас",
   "workspace.waitlistPage.entryCta": "Присъединете се към бета версията на Работното пространство",
   "workspace.waitlistPage.goHome": "Обратно към LobeHub",
+  "workspace.waitlistPage.learnMore": "Научете повече за Workspace",
   "workspace.waitlistPage.organizationLabel": "Организация / Група (по избор)",
   "workspace.waitlistPage.organizationPlaceholder": "Компания, училище или семейство…",
   "workspace.waitlistPage.pendingSubtitle": "Отваряме достъпа на етапи и ще ви уведомим по имейл, веднага щом достъпът ви бъде готов.",

--- a/locales/bg-BG/setting.json
+++ b/locales/bg-BG/setting.json
@@ -2799,6 +2799,7 @@
   "workspace.waitlistPage.entryCta": "Присъединете се към бета версията на Работното пространство",
   "workspace.waitlistPage.goHome": "Обратно към LobeHub",
   "workspace.waitlistPage.learnMore": "Научете повече за Workspace",
+  "workspace.waitlistPage.learnMoreNewTabHint": "Отваря се в нов раздел",
   "workspace.waitlistPage.organizationLabel": "Организация / Група (по избор)",
   "workspace.waitlistPage.organizationPlaceholder": "Компания, училище или семейство…",
   "workspace.waitlistPage.pendingSubtitle": "Отваряме достъпа на етапи и ще ви уведомим по имейл, веднага щом достъпът ви бъде готов.",

--- a/locales/de-DE/setting.json
+++ b/locales/de-DE/setting.json
@@ -2799,6 +2799,7 @@
   "workspace.waitlistPage.entryCta": "Am Workspace-Beta teilnehmen",
   "workspace.waitlistPage.goHome": "Zurück zu LobeHub",
   "workspace.waitlistPage.learnMore": "Erfahren Sie mehr über Workspace",
+  "workspace.waitlistPage.learnMoreNewTabHint": "Öffnet in einem neuen Tab",
   "workspace.waitlistPage.organizationLabel": "Organisation / Gruppe (optional)",
   "workspace.waitlistPage.organizationPlaceholder": "Firma, Schule oder Familie…",
   "workspace.waitlistPage.pendingSubtitle": "Wir öffnen den Zugang in Etappen und benachrichtigen Sie per E-Mail, sobald Ihr Zugang bereit ist.",

--- a/locales/de-DE/setting.json
+++ b/locales/de-DE/setting.json
@@ -2798,6 +2798,7 @@
   "workspace.waitlistPage.enabledTitle": "Workspace ist bereit für Sie",
   "workspace.waitlistPage.entryCta": "Am Workspace-Beta teilnehmen",
   "workspace.waitlistPage.goHome": "Zurück zu LobeHub",
+  "workspace.waitlistPage.learnMore": "Erfahren Sie mehr über Workspace",
   "workspace.waitlistPage.organizationLabel": "Organisation / Gruppe (optional)",
   "workspace.waitlistPage.organizationPlaceholder": "Firma, Schule oder Familie…",
   "workspace.waitlistPage.pendingSubtitle": "Wir öffnen den Zugang in Etappen und benachrichtigen Sie per E-Mail, sobald Ihr Zugang bereit ist.",

--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -2799,6 +2799,7 @@
   "workspace.waitlistPage.entryCta": "Join Workspace Beta",
   "workspace.waitlistPage.goHome": "Back to LobeHub",
   "workspace.waitlistPage.learnMore": "Learn more about Workspace",
+  "workspace.waitlistPage.learnMoreNewTabHint": "Opens in a new tab",
   "workspace.waitlistPage.organizationLabel": "Organization / Group (optional)",
   "workspace.waitlistPage.organizationPlaceholder": "Company, school, or family…",
   "workspace.waitlistPage.pendingSubtitle": "We're opening access in batches and will notify you by email as soon as your access is ready.",

--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -2798,6 +2798,7 @@
   "workspace.waitlistPage.enabledTitle": "Workspace is ready for you",
   "workspace.waitlistPage.entryCta": "Join Workspace Beta",
   "workspace.waitlistPage.goHome": "Back to LobeHub",
+  "workspace.waitlistPage.learnMore": "Learn more about Workspace",
   "workspace.waitlistPage.organizationLabel": "Organization / Group (optional)",
   "workspace.waitlistPage.organizationPlaceholder": "Company, school, or family…",
   "workspace.waitlistPage.pendingSubtitle": "We're opening access in batches and will notify you by email as soon as your access is ready.",

--- a/locales/es-ES/setting.json
+++ b/locales/es-ES/setting.json
@@ -2798,6 +2798,7 @@
   "workspace.waitlistPage.enabledTitle": "El espacio de trabajo está listo para ti",
   "workspace.waitlistPage.entryCta": "Únete a la beta de Espacio de trabajo",
   "workspace.waitlistPage.goHome": "Volver a LobeHub",
+  "workspace.waitlistPage.learnMore": "Obtén más información sobre Workspace",
   "workspace.waitlistPage.organizationLabel": "Organización / Grupo (opcional)",
   "workspace.waitlistPage.organizationPlaceholder": "Empresa, escuela o familia…",
   "workspace.waitlistPage.pendingSubtitle": "Estamos abriendo el acceso en lotes y te notificaremos por correo electrónico tan pronto como tu acceso esté listo.",

--- a/locales/es-ES/setting.json
+++ b/locales/es-ES/setting.json
@@ -2799,6 +2799,7 @@
   "workspace.waitlistPage.entryCta": "Únete a la beta de Espacio de trabajo",
   "workspace.waitlistPage.goHome": "Volver a LobeHub",
   "workspace.waitlistPage.learnMore": "Obtén más información sobre Workspace",
+  "workspace.waitlistPage.learnMoreNewTabHint": "Se abre en una nueva pestaña",
   "workspace.waitlistPage.organizationLabel": "Organización / Grupo (opcional)",
   "workspace.waitlistPage.organizationPlaceholder": "Empresa, escuela o familia…",
   "workspace.waitlistPage.pendingSubtitle": "Estamos abriendo el acceso en lotes y te notificaremos por correo electrónico tan pronto como tu acceso esté listo.",

--- a/locales/fa-IR/setting.json
+++ b/locales/fa-IR/setting.json
@@ -2798,6 +2798,7 @@
   "workspace.waitlistPage.enabledTitle": "فضای کاری برای شما آماده است",
   "workspace.waitlistPage.entryCta": "به نسخه بتای فضای کاری بپیوندید",
   "workspace.waitlistPage.goHome": "بازگشت به LobeHub",
+  "workspace.waitlistPage.learnMore": "بیشتر درباره Workspace بدانید",
   "workspace.waitlistPage.organizationLabel": "سازمان / گروه (اختیاری)",
   "workspace.waitlistPage.organizationPlaceholder": "شرکت، مدرسه یا خانواده…",
   "workspace.waitlistPage.pendingSubtitle": "ما دسترسی را به صورت مرحله‌ای باز می‌کنیم و به محض آماده شدن دسترسی شما، از طریق ایمیل اطلاع خواهیم داد.",

--- a/locales/fa-IR/setting.json
+++ b/locales/fa-IR/setting.json
@@ -2799,6 +2799,7 @@
   "workspace.waitlistPage.entryCta": "به نسخه بتای فضای کاری بپیوندید",
   "workspace.waitlistPage.goHome": "بازگشت به LobeHub",
   "workspace.waitlistPage.learnMore": "بیشتر درباره Workspace بدانید",
+  "workspace.waitlistPage.learnMoreNewTabHint": "در یک تب جدید باز می‌شود",
   "workspace.waitlistPage.organizationLabel": "سازمان / گروه (اختیاری)",
   "workspace.waitlistPage.organizationPlaceholder": "شرکت، مدرسه یا خانواده…",
   "workspace.waitlistPage.pendingSubtitle": "ما دسترسی را به صورت مرحله‌ای باز می‌کنیم و به محض آماده شدن دسترسی شما، از طریق ایمیل اطلاع خواهیم داد.",

--- a/locales/fr-FR/setting.json
+++ b/locales/fr-FR/setting.json
@@ -2799,6 +2799,7 @@
   "workspace.waitlistPage.entryCta": "Rejoindre la bêta de l'espace de travail",
   "workspace.waitlistPage.goHome": "Retour à LobeHub",
   "workspace.waitlistPage.learnMore": "En savoir plus sur Workspace",
+  "workspace.waitlistPage.learnMoreNewTabHint": "S'ouvre dans un nouvel onglet",
   "workspace.waitlistPage.organizationLabel": "Organisation / Groupe (facultatif)",
   "workspace.waitlistPage.organizationPlaceholder": "Entreprise, école ou famille…",
   "workspace.waitlistPage.pendingSubtitle": "Nous ouvrons l'accès par vagues et vous informerons par e-mail dès que votre accès sera prêt.",

--- a/locales/fr-FR/setting.json
+++ b/locales/fr-FR/setting.json
@@ -2798,6 +2798,7 @@
   "workspace.waitlistPage.enabledTitle": "L'espace de travail est prêt pour vous",
   "workspace.waitlistPage.entryCta": "Rejoindre la bêta de l'espace de travail",
   "workspace.waitlistPage.goHome": "Retour à LobeHub",
+  "workspace.waitlistPage.learnMore": "En savoir plus sur Workspace",
   "workspace.waitlistPage.organizationLabel": "Organisation / Groupe (facultatif)",
   "workspace.waitlistPage.organizationPlaceholder": "Entreprise, école ou famille…",
   "workspace.waitlistPage.pendingSubtitle": "Nous ouvrons l'accès par vagues et vous informerons par e-mail dès que votre accès sera prêt.",

--- a/locales/it-IT/setting.json
+++ b/locales/it-IT/setting.json
@@ -2799,6 +2799,7 @@
   "workspace.waitlistPage.entryCta": "Unisciti alla Beta di Workspace",
   "workspace.waitlistPage.goHome": "Torna a LobeHub",
   "workspace.waitlistPage.learnMore": "Scopri di più su Workspace",
+  "workspace.waitlistPage.learnMoreNewTabHint": "Si apre in una nuova scheda",
   "workspace.waitlistPage.organizationLabel": "Organizzazione / Gruppo (opzionale)",
   "workspace.waitlistPage.organizationPlaceholder": "Azienda, scuola o famiglia…",
   "workspace.waitlistPage.pendingSubtitle": "Stiamo aprendo l'accesso a gruppi e ti avviseremo via email non appena il tuo accesso sarà pronto.",

--- a/locales/it-IT/setting.json
+++ b/locales/it-IT/setting.json
@@ -2798,6 +2798,7 @@
   "workspace.waitlistPage.enabledTitle": "Workspace è pronto per te",
   "workspace.waitlistPage.entryCta": "Unisciti alla Beta di Workspace",
   "workspace.waitlistPage.goHome": "Torna a LobeHub",
+  "workspace.waitlistPage.learnMore": "Scopri di più su Workspace",
   "workspace.waitlistPage.organizationLabel": "Organizzazione / Gruppo (opzionale)",
   "workspace.waitlistPage.organizationPlaceholder": "Azienda, scuola o famiglia…",
   "workspace.waitlistPage.pendingSubtitle": "Stiamo aprendo l'accesso a gruppi e ti avviseremo via email non appena il tuo accesso sarà pronto.",

--- a/locales/ja-JP/setting.json
+++ b/locales/ja-JP/setting.json
@@ -2798,6 +2798,7 @@
   "workspace.waitlistPage.enabledTitle": "ワークスペースの準備が整いました",
   "workspace.waitlistPage.entryCta": "ワークスペースベータに参加する",
   "workspace.waitlistPage.goHome": "LobeHubに戻る",
+  "workspace.waitlistPage.learnMore": "Workspace について詳しく知る",
   "workspace.waitlistPage.organizationLabel": "組織 / グループ（任意）",
   "workspace.waitlistPage.organizationPlaceholder": "会社、学校、家族など…",
   "workspace.waitlistPage.pendingSubtitle": "アクセスを段階的に開放しており、準備が整い次第メールでお知らせします。",

--- a/locales/ja-JP/setting.json
+++ b/locales/ja-JP/setting.json
@@ -2799,6 +2799,7 @@
   "workspace.waitlistPage.entryCta": "ワークスペースベータに参加する",
   "workspace.waitlistPage.goHome": "LobeHubに戻る",
   "workspace.waitlistPage.learnMore": "Workspace について詳しく知る",
+  "workspace.waitlistPage.learnMoreNewTabHint": "新しいタブで開きます",
   "workspace.waitlistPage.organizationLabel": "組織 / グループ（任意）",
   "workspace.waitlistPage.organizationPlaceholder": "会社、学校、家族など…",
   "workspace.waitlistPage.pendingSubtitle": "アクセスを段階的に開放しており、準備が整い次第メールでお知らせします。",

--- a/locales/ko-KR/setting.json
+++ b/locales/ko-KR/setting.json
@@ -2799,6 +2799,7 @@
   "workspace.waitlistPage.entryCta": "워크스페이스 베타 참여하기",
   "workspace.waitlistPage.goHome": "LobeHub으로 돌아가기",
   "workspace.waitlistPage.learnMore": "Workspace에 대해 자세히 알아보기",
+  "workspace.waitlistPage.learnMoreNewTabHint": "새 탭에서 열립니다",
   "workspace.waitlistPage.organizationLabel": "조직 / 그룹 (선택 사항)",
   "workspace.waitlistPage.organizationPlaceholder": "회사, 학교, 가족 등...",
   "workspace.waitlistPage.pendingSubtitle": "접근 권한을 순차적으로 열고 있으며, 준비가 완료되면 이메일로 알려드리겠습니다.",

--- a/locales/ko-KR/setting.json
+++ b/locales/ko-KR/setting.json
@@ -2798,6 +2798,7 @@
   "workspace.waitlistPage.enabledTitle": "워크스페이스가 준비되었습니다",
   "workspace.waitlistPage.entryCta": "워크스페이스 베타 참여하기",
   "workspace.waitlistPage.goHome": "LobeHub으로 돌아가기",
+  "workspace.waitlistPage.learnMore": "Workspace에 대해 자세히 알아보기",
   "workspace.waitlistPage.organizationLabel": "조직 / 그룹 (선택 사항)",
   "workspace.waitlistPage.organizationPlaceholder": "회사, 학교, 가족 등...",
   "workspace.waitlistPage.pendingSubtitle": "접근 권한을 순차적으로 열고 있으며, 준비가 완료되면 이메일로 알려드리겠습니다.",

--- a/locales/nl-NL/setting.json
+++ b/locales/nl-NL/setting.json
@@ -2798,6 +2798,7 @@
   "workspace.waitlistPage.enabledTitle": "Werkruimte is klaar voor jou",
   "workspace.waitlistPage.entryCta": "Doe mee met Werkruimte Beta",
   "workspace.waitlistPage.goHome": "Terug naar LobeHub",
+  "workspace.waitlistPage.learnMore": "Meer informatie over Workspace",
   "workspace.waitlistPage.organizationLabel": "Organisatie / Groep (optioneel)",
   "workspace.waitlistPage.organizationPlaceholder": "Bedrijf, school of familie…",
   "workspace.waitlistPage.pendingSubtitle": "We openen toegang in batches en laten je per e-mail weten zodra je toegang klaar is.",

--- a/locales/nl-NL/setting.json
+++ b/locales/nl-NL/setting.json
@@ -2799,6 +2799,7 @@
   "workspace.waitlistPage.entryCta": "Doe mee met Werkruimte Beta",
   "workspace.waitlistPage.goHome": "Terug naar LobeHub",
   "workspace.waitlistPage.learnMore": "Meer informatie over Workspace",
+  "workspace.waitlistPage.learnMoreNewTabHint": "Opent in een nieuw tabblad",
   "workspace.waitlistPage.organizationLabel": "Organisatie / Groep (optioneel)",
   "workspace.waitlistPage.organizationPlaceholder": "Bedrijf, school of familie…",
   "workspace.waitlistPage.pendingSubtitle": "We openen toegang in batches en laten je per e-mail weten zodra je toegang klaar is.",

--- a/locales/pl-PL/setting.json
+++ b/locales/pl-PL/setting.json
@@ -2798,6 +2798,7 @@
   "workspace.waitlistPage.enabledTitle": "Workspace jest gotowy dla Ciebie",
   "workspace.waitlistPage.entryCta": "Dołącz do Workspace Beta",
   "workspace.waitlistPage.goHome": "Powrót do LobeHub",
+  "workspace.waitlistPage.learnMore": "Dowiedz się więcej o Workspace",
   "workspace.waitlistPage.organizationLabel": "Organizacja / Grupa (opcjonalne)",
   "workspace.waitlistPage.organizationPlaceholder": "Firma, szkoła lub rodzina…",
   "workspace.waitlistPage.pendingSubtitle": "Udostępniamy dostęp etapami i powiadomimy Cię e-mailem, gdy tylko Twój dostęp będzie gotowy.",

--- a/locales/pl-PL/setting.json
+++ b/locales/pl-PL/setting.json
@@ -2799,6 +2799,7 @@
   "workspace.waitlistPage.entryCta": "Dołącz do Workspace Beta",
   "workspace.waitlistPage.goHome": "Powrót do LobeHub",
   "workspace.waitlistPage.learnMore": "Dowiedz się więcej o Workspace",
+  "workspace.waitlistPage.learnMoreNewTabHint": "Otwiera się w nowej karcie",
   "workspace.waitlistPage.organizationLabel": "Organizacja / Grupa (opcjonalne)",
   "workspace.waitlistPage.organizationPlaceholder": "Firma, szkoła lub rodzina…",
   "workspace.waitlistPage.pendingSubtitle": "Udostępniamy dostęp etapami i powiadomimy Cię e-mailem, gdy tylko Twój dostęp będzie gotowy.",

--- a/locales/pt-BR/setting.json
+++ b/locales/pt-BR/setting.json
@@ -2798,6 +2798,7 @@
   "workspace.waitlistPage.enabledTitle": "O Workspace está pronto para você",
   "workspace.waitlistPage.entryCta": "Participar do Beta do Workspace",
   "workspace.waitlistPage.goHome": "Voltar para o LobeHub",
+  "workspace.waitlistPage.learnMore": "Saiba mais sobre o Workspace",
   "workspace.waitlistPage.organizationLabel": "Organização / Grupo (opcional)",
   "workspace.waitlistPage.organizationPlaceholder": "Empresa, escola ou família…",
   "workspace.waitlistPage.pendingSubtitle": "Estamos liberando o acesso em lotes e notificaremos você por e-mail assim que seu acesso estiver disponível.",

--- a/locales/pt-BR/setting.json
+++ b/locales/pt-BR/setting.json
@@ -2799,6 +2799,7 @@
   "workspace.waitlistPage.entryCta": "Participar do Beta do Workspace",
   "workspace.waitlistPage.goHome": "Voltar para o LobeHub",
   "workspace.waitlistPage.learnMore": "Saiba mais sobre o Workspace",
+  "workspace.waitlistPage.learnMoreNewTabHint": "Abre em uma nova aba",
   "workspace.waitlistPage.organizationLabel": "Organização / Grupo (opcional)",
   "workspace.waitlistPage.organizationPlaceholder": "Empresa, escola ou família…",
   "workspace.waitlistPage.pendingSubtitle": "Estamos liberando o acesso em lotes e notificaremos você por e-mail assim que seu acesso estiver disponível.",

--- a/locales/ru-RU/setting.json
+++ b/locales/ru-RU/setting.json
@@ -2799,6 +2799,7 @@
   "workspace.waitlistPage.entryCta": "Присоединиться к бета-версии Рабочего пространства",
   "workspace.waitlistPage.goHome": "Вернуться в LobeHub",
   "workspace.waitlistPage.learnMore": "Узнать больше о Workspace",
+  "workspace.waitlistPage.learnMoreNewTabHint": "Открывается в новой вкладке",
   "workspace.waitlistPage.organizationLabel": "Организация / Группа (необязательно)",
   "workspace.waitlistPage.organizationPlaceholder": "Компания, школа или семья…",
   "workspace.waitlistPage.pendingSubtitle": "Мы открываем доступ поэтапно и уведомим вас по электронной почте, как только ваш доступ будет готов.",

--- a/locales/ru-RU/setting.json
+++ b/locales/ru-RU/setting.json
@@ -2798,6 +2798,7 @@
   "workspace.waitlistPage.enabledTitle": "Рабочее пространство готово для вас",
   "workspace.waitlistPage.entryCta": "Присоединиться к бета-версии Рабочего пространства",
   "workspace.waitlistPage.goHome": "Вернуться в LobeHub",
+  "workspace.waitlistPage.learnMore": "Узнать больше о Workspace",
   "workspace.waitlistPage.organizationLabel": "Организация / Группа (необязательно)",
   "workspace.waitlistPage.organizationPlaceholder": "Компания, школа или семья…",
   "workspace.waitlistPage.pendingSubtitle": "Мы открываем доступ поэтапно и уведомим вас по электронной почте, как только ваш доступ будет готов.",

--- a/locales/tr-TR/setting.json
+++ b/locales/tr-TR/setting.json
@@ -2799,6 +2799,7 @@
   "workspace.waitlistPage.entryCta": "Çalışma Alanı Beta'ya Katıl",
   "workspace.waitlistPage.goHome": "LobeHub'a Geri Dön",
   "workspace.waitlistPage.learnMore": "Workspace hakkında daha fazla bilgi edinin",
+  "workspace.waitlistPage.learnMoreNewTabHint": "Yeni bir sekmede açılır",
   "workspace.waitlistPage.organizationLabel": "Organizasyon / Grup (isteğe bağlı)",
   "workspace.waitlistPage.organizationPlaceholder": "Şirket, okul veya aile…",
   "workspace.waitlistPage.pendingSubtitle": "Erişimi gruplar halinde açıyoruz ve erişiminiz hazır olduğunda sizi e-posta ile bilgilendireceğiz.",

--- a/locales/tr-TR/setting.json
+++ b/locales/tr-TR/setting.json
@@ -2798,6 +2798,7 @@
   "workspace.waitlistPage.enabledTitle": "Çalışma Alanı sizin için hazır",
   "workspace.waitlistPage.entryCta": "Çalışma Alanı Beta'ya Katıl",
   "workspace.waitlistPage.goHome": "LobeHub'a Geri Dön",
+  "workspace.waitlistPage.learnMore": "Workspace hakkında daha fazla bilgi edinin",
   "workspace.waitlistPage.organizationLabel": "Organizasyon / Grup (isteğe bağlı)",
   "workspace.waitlistPage.organizationPlaceholder": "Şirket, okul veya aile…",
   "workspace.waitlistPage.pendingSubtitle": "Erişimi gruplar halinde açıyoruz ve erişiminiz hazır olduğunda sizi e-posta ile bilgilendireceğiz.",

--- a/locales/vi-VN/setting.json
+++ b/locales/vi-VN/setting.json
@@ -2798,6 +2798,7 @@
   "workspace.waitlistPage.enabledTitle": "Workspace đã sẵn sàng cho bạn",
   "workspace.waitlistPage.entryCta": "Tham gia Workspace Beta",
   "workspace.waitlistPage.goHome": "Quay lại LobeHub",
+  "workspace.waitlistPage.learnMore": "Tìm hiểu thêm về Workspace",
   "workspace.waitlistPage.organizationLabel": "Tổ chức / Nhóm (tùy chọn)",
   "workspace.waitlistPage.organizationPlaceholder": "Công ty, trường học, hoặc gia đình…",
   "workspace.waitlistPage.pendingSubtitle": "Chúng tôi đang mở quyền truy cập theo từng đợt và sẽ thông báo qua email ngay khi quyền truy cập của bạn sẵn sàng.",

--- a/locales/vi-VN/setting.json
+++ b/locales/vi-VN/setting.json
@@ -2799,6 +2799,7 @@
   "workspace.waitlistPage.entryCta": "Tham gia Workspace Beta",
   "workspace.waitlistPage.goHome": "Quay lại LobeHub",
   "workspace.waitlistPage.learnMore": "Tìm hiểu thêm về Workspace",
+  "workspace.waitlistPage.learnMoreNewTabHint": "Mở trong một tab mới",
   "workspace.waitlistPage.organizationLabel": "Tổ chức / Nhóm (tùy chọn)",
   "workspace.waitlistPage.organizationPlaceholder": "Công ty, trường học, hoặc gia đình…",
   "workspace.waitlistPage.pendingSubtitle": "Chúng tôi đang mở quyền truy cập theo từng đợt và sẽ thông báo qua email ngay khi quyền truy cập của bạn sẵn sàng.",

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -2799,6 +2799,7 @@
   "workspace.waitlistPage.entryCta": "申请加入 Workspace 公测",
   "workspace.waitlistPage.goHome": "返回 LobeHub",
   "workspace.waitlistPage.learnMore": "了解 Workspace 功能介绍",
+  "workspace.waitlistPage.learnMoreNewTabHint": "在新标签页打开",
   "workspace.waitlistPage.organizationLabel": "组织 / 团体（选填）",
   "workspace.waitlistPage.organizationPlaceholder": "公司、学校或家庭……",
   "workspace.waitlistPage.pendingSubtitle": "我们正在分批开放公测名额，你的权限就绪后会第一时间通过邮件通知你。",

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -2798,6 +2798,7 @@
   "workspace.waitlistPage.enabledTitle": "Workspace 已就绪",
   "workspace.waitlistPage.entryCta": "申请加入 Workspace 公测",
   "workspace.waitlistPage.goHome": "返回 LobeHub",
+  "workspace.waitlistPage.learnMore": "了解 Workspace 功能介绍",
   "workspace.waitlistPage.organizationLabel": "组织 / 团体（选填）",
   "workspace.waitlistPage.organizationPlaceholder": "公司、学校或家庭……",
   "workspace.waitlistPage.pendingSubtitle": "我们正在分批开放公测名额，你的权限就绪后会第一时间通过邮件通知你。",

--- a/locales/zh-TW/setting.json
+++ b/locales/zh-TW/setting.json
@@ -2798,6 +2798,7 @@
   "workspace.waitlistPage.enabledTitle": "工作空間已為您準備就緒",
   "workspace.waitlistPage.entryCta": "加入工作空間測試版",
   "workspace.waitlistPage.goHome": "返回 LobeHub",
+  "workspace.waitlistPage.learnMore": "了解更多關於 Workspace 的資訊",
   "workspace.waitlistPage.organizationLabel": "組織 / 團體（選填）",
   "workspace.waitlistPage.organizationPlaceholder": "公司、學校或家庭…",
   "workspace.waitlistPage.pendingSubtitle": "我們將分批開放訪問權限，並在您的訪問權限準備就緒時通過電子郵件通知您。",

--- a/locales/zh-TW/setting.json
+++ b/locales/zh-TW/setting.json
@@ -2799,6 +2799,7 @@
   "workspace.waitlistPage.entryCta": "加入工作空間測試版",
   "workspace.waitlistPage.goHome": "返回 LobeHub",
   "workspace.waitlistPage.learnMore": "了解更多關於 Workspace 的資訊",
+  "workspace.waitlistPage.learnMoreNewTabHint": "在新分頁中開啟",
   "workspace.waitlistPage.organizationLabel": "組織 / 團體（選填）",
   "workspace.waitlistPage.organizationPlaceholder": "公司、學校或家庭…",
   "workspace.waitlistPage.pendingSubtitle": "我們將分批開放訪問權限，並在您的訪問權限準備就緒時通過電子郵件通知您。",

--- a/packages/const/src/url.ts
+++ b/packages/const/src/url.ts
@@ -50,6 +50,7 @@ export const MORE_FILE_PREVIEW_REQUEST_URL =
 export const AGENTS_INDEX_GITHUB = 'https://github.com/lobehub/lobe-chat-agents';
 export const AGENTS_INDEX_GITHUB_ISSUE = urlJoin(AGENTS_INDEX_GITHUB, 'issues/new');
 export const AGENTS_OFFICIAL_URL = 'https://lobehub.com/agent';
+export const WORKSPACE_OFFICIAL_URL = 'https://lobehub.com/workspace';
 
 export const AGENT_CHAT_URL = (agentId: string, mobile?: boolean) => {
   if (mobile) return `/agent/${agentId}`;

--- a/packages/locales/src/default/setting.ts
+++ b/packages/locales/src/default/setting.ts
@@ -2848,6 +2848,7 @@ When I am ___, I need ___
   'workspace.waitlistPage.entryCta': 'Join Workspace Beta',
   'workspace.waitlistPage.goHome': 'Back to LobeHub',
   'workspace.waitlistPage.learnMore': 'Learn more about Workspace',
+  'workspace.waitlistPage.learnMoreNewTabHint': 'Opens in a new tab',
   'workspace.waitlistPage.organizationLabel': 'Organization / Group (optional)',
   'workspace.waitlistPage.organizationPlaceholder': 'Company, school, or family…',
   'workspace.waitlistPage.pendingSubtitle':

--- a/packages/locales/src/default/setting.ts
+++ b/packages/locales/src/default/setting.ts
@@ -2847,6 +2847,7 @@ When I am ___, I need ___
   'workspace.waitlistPage.enabledTitle': 'Workspace is ready for you',
   'workspace.waitlistPage.entryCta': 'Join Workspace Beta',
   'workspace.waitlistPage.goHome': 'Back to LobeHub',
+  'workspace.waitlistPage.learnMore': 'Learn more about Workspace',
   'workspace.waitlistPage.organizationLabel': 'Organization / Group (optional)',
   'workspace.waitlistPage.organizationPlaceholder': 'Company, school, or family…',
   'workspace.waitlistPage.pendingSubtitle':


### PR DESCRIPTION
Add the official Workspace landing page URL constant and the waitlist page's "Learn more" copy so the waitlist form can point applicants at the product introduction before they apply.

- `packages/const/src/url.ts` — new `WORKSPACE_OFFICIAL_URL` constant (alongside `AGENTS_OFFICIAL_URL`)
- `packages/locales/src/default/setting.ts` — new `workspace.waitlistPage.learnMore` key
- `locales/en-US|zh-CN/setting.json` — hand-written previews; other locales come from the daily auto-i18n workflow

#### Test

- [x] Tested locally
- [x] No tests needed

Copy/constant only — consumed by the waitlist page, verified end to end there (rendered link with correct href/target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)