### PR TITLE
✨ feat(desktop): support Pi provider bindings

### DIFF
--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/pi.test.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/pi.test.ts
@@ -4,8 +4,9 @@ import { getHeterogeneousAgentDriver } from '../index';
 import type {
   HeterogeneousAgentBuildPlanHelpers,
   HeterogeneousAgentBuildPlanParams,
+  PrepareProviderBindingContext,
 } from '../types';
-import { piDriver } from './pi';
+import { piDriver, sanitizePiProviderBindingArgs } from './pi';
 
 const buildAgentInput = vi.fn(async () => ({
   args: ['@/tmp/image.png'],
@@ -20,6 +21,57 @@ const buildParams = (
   helpers,
   promptInput: 'raw prompt',
   ...overrides,
+});
+
+const bindingContext = (
+  protocol: PrepareProviderBindingContext['resolution']['protocol'] = 'openai-chat-completions',
+): PrepareProviderBindingContext => ({
+  args: [
+    '--provider',
+    'stale-provider',
+    '--model=stale-model',
+    '--models',
+    'other/*',
+    '--api-key=argv-secret',
+    '--session-dir',
+    '/unmanaged/sessions',
+    '--no-session',
+    '--thinking',
+    'high',
+  ],
+  env: {
+    KEEP_ME: 'yes',
+    LOBEHUB_PI_API_KEY: 'stale-key',
+    PI_CODING_AGENT_DIR: '/user/pi',
+    PI_CODING_AGENT_SESSION_DIR: '/user/sessions',
+  },
+  profileDir: '/managed/pi/profile-digest',
+  reference: {
+    apiConfig: { model: 'vendor/model-test', providerId: 'provider-test' },
+    kind: 'provider',
+  },
+  resolution: {
+    agentType: 'pi',
+    apiConfig: { model: 'vendor/model-test', providerId: 'provider-test' },
+    endpoint: 'https://gateway.example.com/v1',
+    modelMetadata: {
+      abilities: { reasoning: true, vision: true },
+      contextWindowTokens: 200_000,
+      displayName: 'Provider model',
+      id: 'vendor/model-test',
+      maxOutput: 32_000,
+      providerId: 'provider-test',
+      type: 'chat',
+    },
+    protocol,
+    providerId: 'provider-test',
+    runtimeConfig: {
+      config: {},
+      keyVaults: { apiKey: 'bound-key', baseURL: 'https://gateway.example.com/v1' },
+      settings: { sdkType: 'openai' },
+    },
+  },
+  runDir: '/managed/run',
 });
 
 describe('piDriver', () => {
@@ -43,5 +95,147 @@ describe('piDriver', () => {
       ],
       stdinPayload: 'raw prompt',
     });
+  });
+
+  it.each([
+    ['openai-chat-completions', 'openai-completions'],
+    ['openai-responses', 'openai-responses'],
+    ['anthropic-messages', 'anthropic-messages'],
+    ['google-generative-ai', 'google-generative-ai'],
+  ] as const)('maps %s to the Pi custom-provider API %s', async (protocol, expectedApi) => {
+    const plan = await piDriver.prepareProviderBinding!(bindingContext(protocol));
+    const config = JSON.parse(plan.profileFiles?.[0]?.content ?? '{}');
+
+    expect(config.providers['lobehub-profile-digest'].api).toBe(expectedApi);
+  });
+
+  it('writes a secret-free managed profile and forces its provider/model through env and argv', async () => {
+    const plan = await piDriver.prepareProviderBinding!(bindingContext());
+    const content = plan.profileFiles?.[0]?.content ?? '';
+    const config = JSON.parse(content);
+    const provider = config.providers['lobehub-profile-digest'];
+
+    expect(plan.args).toEqual([
+      '--provider',
+      'lobehub-profile-digest',
+      '--model',
+      'vendor/model-test',
+      '--thinking',
+      'high',
+    ]);
+    expect(plan.env).toEqual({
+      KEEP_ME: 'yes',
+      LOBEHUB_PI_API_KEY: 'bound-key',
+      PI_CODING_AGENT_DIR: '/managed/pi/profile-digest',
+    });
+    expect(plan.profileFiles?.[0]?.path).toBe('models.json');
+    expect(provider).toMatchObject({
+      api: 'openai-completions',
+      apiKey: '$LOBEHUB_PI_API_KEY',
+      baseUrl: 'https://gateway.example.com/v1',
+      models: [
+        {
+          contextWindow: 200_000,
+          id: 'vendor/model-test',
+          input: ['text', 'image'],
+          maxTokens: 32_000,
+          name: 'Provider model',
+          reasoning: true,
+        },
+      ],
+      name: 'LobeHub Provider',
+    });
+    expect(content).not.toContain('bound-key');
+    expect(content).not.toContain('argv-secret');
+
+    const spawnPlan = await piDriver.buildSpawnPlan(
+      buildParams({ args: plan.args, resumeSessionId: 'pi-session-exact' }),
+    );
+    expect(spawnPlan.args).toEqual([
+      '--mode',
+      'json',
+      '--session-id',
+      'pi-session-exact',
+      '--provider',
+      'lobehub-profile-digest',
+      '--model',
+      'vendor/model-test',
+      '--thinking',
+      'high',
+      '@/tmp/image.png',
+    ]);
+  });
+
+  it('uses conservative Pi metadata defaults when server model metadata is unavailable', async () => {
+    const context = bindingContext();
+    context.resolution.modelMetadata = undefined;
+    const plan = await piDriver.prepareProviderBinding!(context);
+    const config = JSON.parse(plan.profileFiles?.[0]?.content ?? '{}');
+    const model = config.providers['lobehub-profile-digest'].models[0];
+
+    expect(model).toMatchObject({
+      contextWindow: 128_000,
+      input: ['text'],
+      maxTokens: 16_384,
+      reasoning: false,
+    });
+  });
+
+  it('removes binding and session overrides without removing unrelated args', () => {
+    expect(
+      sanitizePiProviderBindingArgs([
+        '--provider=other',
+        '--model',
+        'old',
+        '--models=one,two',
+        '--api-key',
+        'secret',
+        '--session',
+        'other-session',
+        '--session-id=other-id',
+        '--fork',
+        'fork-source',
+        '--session-dir=/tmp/sessions',
+        '--continue',
+        '-c',
+        '--resume',
+        '-r',
+        '--no-session',
+        '--thinking=low',
+      ]),
+    ).toEqual(['--thinking=low']);
+  });
+
+  it('keeps managed routing effective before a caller option terminator', async () => {
+    const context = bindingContext();
+    context.args = ['--', '--provider', 'message-provider'];
+
+    const plan = await piDriver.prepareProviderBinding!(context);
+    const spawnPlan = await piDriver.buildSpawnPlan(buildParams({ args: plan.args }));
+
+    expect(spawnPlan.args).toEqual([
+      '--mode',
+      'json',
+      '--provider',
+      'lobehub-profile-digest',
+      '--model',
+      'vendor/model-test',
+      '--',
+      '@/tmp/image.png',
+    ]);
+  });
+
+  it('rejects a binding without an endpoint or API key', () => {
+    const withoutEndpoint = bindingContext();
+    withoutEndpoint.resolution.endpoint = undefined;
+    expect(() => piDriver.prepareProviderBinding!(withoutEndpoint)).toThrow(
+      'Pi provider binding requires an API endpoint.',
+    );
+
+    const withoutKey = bindingContext();
+    withoutKey.resolution.runtimeConfig.keyVaults = {};
+    expect(() => piDriver.prepareProviderBinding!(withoutKey)).toThrow(
+      'Pi provider binding requires an API key.',
+    );
   });
 });

--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/pi.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/pi.ts
@@ -1,6 +1,62 @@
+import path from 'node:path';
+
+import type { HeterogeneousProviderBindingProtocol } from '@lobechat/heterogeneous-agents';
 import { PI_BASE_ARGS } from '@lobechat/heterogeneous-agents/spawn';
 
 import type { HeterogeneousAgentBuildPlanParams, HeterogeneousAgentDriver } from '../types';
+
+const HOST_API_KEY_ENV = 'LOBEHUB_PI_API_KEY';
+const MODELS_FILE = 'models.json';
+const DEFAULT_CONTEXT_WINDOW = 128_000;
+const DEFAULT_MAX_TOKENS = 16_384;
+
+const PI_API_BY_PROTOCOL = {
+  'anthropic-messages': 'anthropic-messages',
+  'google-generative-ai': 'google-generative-ai',
+  'openai-chat-completions': 'openai-completions',
+  'openai-responses': 'openai-responses',
+} as const satisfies Record<HeterogeneousProviderBindingProtocol, string>;
+
+const CONTROLLED_FLAGS = [
+  '--api-key',
+  '--fork',
+  '--model',
+  '--models',
+  '--provider',
+  '--session',
+  '--session-dir',
+  '--session-id',
+] as const;
+
+const CONTROLLED_BOOLEAN_FLAGS = ['--continue', '-c', '--no-session', '--resume', '-r'] as const;
+
+export const sanitizePiProviderBindingArgs = (source: string[]): string[] => {
+  const args: string[] = [];
+  for (let index = 0; index < source.length; index += 1) {
+    const arg = source[index];
+    const controlledFlag = CONTROLLED_FLAGS.find(
+      (flag) => arg === flag || arg.startsWith(`${flag}=`),
+    );
+    if (controlledFlag) {
+      if (arg === controlledFlag) index += 1;
+      continue;
+    }
+    // Provider-bound sessions are selected exclusively by Desktop. Caller
+    // config cannot continue, resume, fork, replace, or disable that session.
+    if (CONTROLLED_BOOLEAN_FLAGS.includes(arg as (typeof CONTROLLED_BOOLEAN_FLAGS)[number]))
+      continue;
+    args.push(arg);
+  }
+  return args;
+};
+
+const sanitizePiProviderBindingEnv = (source: Record<string, string> | undefined) => {
+  const env = { ...source };
+  delete env[HOST_API_KEY_ENV];
+  delete env.PI_CODING_AGENT_DIR;
+  delete env.PI_CODING_AGENT_SESSION_DIR;
+  return env;
+};
 
 export const piDriver: HeterogeneousAgentDriver = {
   async buildSpawnPlan({
@@ -19,6 +75,55 @@ export const piDriver: HeterogeneousAgentDriver = {
         ...inputPlan.args,
       ],
       stdinPayload: inputPlan.stdin,
+    };
+  },
+  prepareProviderBinding({ args, env, profileDir, resolution }) {
+    if (!resolution.endpoint) throw new Error('Pi provider binding requires an API endpoint.');
+
+    const apiKey = resolution.runtimeConfig.keyVaults.apiKey?.trim();
+    if (!apiKey) throw new Error('Pi provider binding requires an API key.');
+
+    const model = resolution.apiConfig.model;
+    const metadata = resolution.modelMetadata;
+    const providerId = `lobehub-${path.basename(profileDir)}`;
+    const contextWindow =
+      metadata?.contextWindowTokens && metadata.contextWindowTokens > 0
+        ? metadata.contextWindowTokens
+        : DEFAULT_CONTEXT_WINDOW;
+    const maxTokens =
+      metadata?.maxOutput && metadata.maxOutput > 0 ? metadata.maxOutput : DEFAULT_MAX_TOKENS;
+    const modelsConfig = {
+      providers: {
+        [providerId]: {
+          api: PI_API_BY_PROTOCOL[resolution.protocol],
+          apiKey: `$${HOST_API_KEY_ENV}`,
+          baseUrl: resolution.endpoint,
+          models: [
+            {
+              contextWindow,
+              cost: { cacheRead: 0, cacheWrite: 0, input: 0, output: 0 },
+              id: model,
+              input: metadata?.abilities?.vision ? ['text', 'image'] : ['text'],
+              maxTokens,
+              name: metadata?.displayName?.trim() || model,
+              reasoning: metadata?.abilities?.reasoning === true,
+            },
+          ],
+          name: 'LobeHub Provider',
+        },
+      },
+    };
+
+    return {
+      // Keep host-authoritative routing before caller args. In particular, a
+      // caller-provided `--` ends Pi option parsing but cannot hide these flags.
+      args: ['--provider', providerId, '--model', model, ...sanitizePiProviderBindingArgs(args)],
+      env: {
+        ...sanitizePiProviderBindingEnv(env),
+        [HOST_API_KEY_ENV]: apiKey,
+        PI_CODING_AGENT_DIR: profileDir,
+      },
+      profileFiles: [{ content: `${JSON.stringify(modelsConfig, null, 2)}\n`, path: MODELS_FILE }],
     };
   },
 };

--- a/apps/desktop/src/main/modules/heterogeneousAgent/providerBindingHost.test.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/providerBindingHost.test.ts
@@ -59,6 +59,7 @@ describe('prepareHostedProviderBinding', () => {
     };
     const binding = await prepareHostedProviderBinding(await makeParams(driver));
 
+    expect(binding.bindingKey).toMatch(/^provider-binding:v1:/);
     expect((await stat(binding.profileDir)).mode & 0o777).toBe(0o700);
     expect((await stat(binding.runDir)).mode & 0o777).toBe(0o700);
     expect((await stat(path.join(binding.profileDir, 'config.toml'))).mode & 0o777).toBe(0o600);
@@ -85,6 +86,53 @@ describe('prepareHostedProviderBinding', () => {
     await expect(
       stat(path.join(params.appStoragePath, 'heteroAgent', 'runs', params.sessionId)),
     ).rejects.toThrow();
+  });
+
+  it('isolates Pi profiles by model while reusing an identity after API-key rotation', async () => {
+    const driver: HeterogeneousAgentDriver = {
+      buildSpawnPlan: async () => ({ args: [] }),
+      prepareProviderBinding: ({ resolution }) => ({
+        args: [],
+        env: {},
+        profileFiles: [{ content: resolution.apiConfig.model, path: 'models.json' }],
+      }),
+    };
+    const base = await makeParams(driver);
+    const piParams = (model: string, sessionId: string, apiKey = 'secret') => ({
+      ...base,
+      agentType: 'pi',
+      reference: {
+        apiConfig: { model, providerId: 'provider-test' },
+        kind: 'provider' as const,
+      },
+      resolution: {
+        ...base.resolution,
+        agentType: 'pi' as const,
+        apiConfig: { model, providerId: 'provider-test' },
+        protocol: 'openai-chat-completions' as const,
+        runtimeConfig: {
+          ...base.resolution.runtimeConfig,
+          keyVaults: { apiKey, baseURL: 'https://example.com/v1' },
+        },
+      },
+      sessionId,
+    });
+
+    const [first, second] = await Promise.all([
+      prepareHostedProviderBinding(piParams('model-a', 'session-a')),
+      prepareHostedProviderBinding(piParams('model-b', 'session-b')),
+    ]);
+    const rotated = await prepareHostedProviderBinding(
+      piParams('model-a', 'session-c', 'rotated-secret'),
+    );
+
+    expect(first.bindingKey).toMatch(/^provider-binding:v2:/);
+    expect(first.profileDir).not.toBe(second.profileDir);
+    expect(first.bindingKey).not.toBe(second.bindingKey);
+    expect(rotated.profileDir).toBe(first.profileDir);
+    expect(rotated.bindingKey).toBe(first.bindingKey);
+    expect(await readFile(path.join(first.profileDir, 'models.json'), 'utf8')).toBe('model-a');
+    expect(await readFile(path.join(second.profileDir, 'models.json'), 'utf8')).toBe('model-b');
   });
 });
 

--- a/apps/desktop/src/main/modules/heterogeneousAgent/providerBindingHost.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/providerBindingHost.ts
@@ -79,15 +79,21 @@ export const prepareHostedProviderBinding = async (params: {
     throw new Error(`${params.agentType} does not implement LobeHub Provider binding.`);
   }
 
+  // Pi persists its custom model definition in the reusable profile. Include
+  // the selected upstream model so concurrent sessions cannot overwrite one
+  // another's models.json or strand a resumable session without its model.
+  // Other drivers retain their v1 identity and existing resume keys.
+  const identityVersion = params.agentType === 'pi' ? 'v2' : 'v1';
   const identity = [
-    'v1',
+    identityVersion,
     params.agentType,
     params.reference.apiConfig.providerId,
     params.resolution.protocol,
     params.resolution.endpoint ?? '',
+    ...(params.agentType === 'pi' ? [params.resolution.apiConfig.model] : []),
   ].join('\0');
   const digest = hash(identity);
-  const bindingKey = `provider-binding:v1:${digest}`;
+  const bindingKey = `provider-binding:${identityVersion}:${digest}`;
   const profileDir = path.join(
     params.appStoragePath,
     HETERO_AGENT_BINDINGS_DIR,
@@ -203,10 +209,12 @@ const statMtimeMs = async (target: string): Promise<number | undefined> => {
 
 /**
  * Remove binding profiles that have not been used for `maxAgeMs` (default 30
- * days). Stable profiles are keyed by `(agentType, providerId, protocol,
- * endpoint)` and are never cleaned by the per-run cleanup, so deleting a
- * provider, changing its endpoint, or bumping the identity version would
- * otherwise strand them (with transcripts inside) forever.
+ * days). Stable profiles are normally keyed by `(agentType, providerId,
+ * protocol, endpoint)`; Pi profiles additionally include the model because
+ * models.json contains a model-specific catalog entry. Profiles are never
+ * cleaned by the per-run cleanup, so deleting a provider, changing its
+ * endpoint, or bumping the identity version would otherwise strand them (with
+ * transcripts inside) forever.
  *
  * Profiles are considered used when `prepareHostedProviderBinding` or
  * `prepareHostedServerDefaultBinding` touches their marker at session start;

--- a/apps/server/src/routers/lambda/__tests__/aiProvider.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiProvider.test.ts
@@ -226,8 +226,8 @@ describe('aiProviderRouter', () => {
       const result = await caller.getAiProviderRuntimeState({});
 
       expect(result.providerBindingAgentTypes).toEqual({
-        'anthropic-custom': ['claude-code'],
-        'openai': ['codex'],
+        'anthropic-custom': ['claude-code', 'pi'],
+        'openai': ['codex', 'pi'],
       });
       expect(JSON.stringify(result.providerBindingAgentTypes)).not.toContain('secret');
       expect(JSON.stringify(result.providerBindingAgentTypes)).not.toContain('example.com');
@@ -313,7 +313,15 @@ describe('aiProviderRouter', () => {
       vi.mocked(AiInfraRepos).prototype.getAiProviderRuntimeState = vi.fn().mockResolvedValue({
         ...mockRuntimeState,
         enabledAiModels: [
-          { abilities: {}, id: 'claude-test', providerId: mockProviderId, type: 'chat' },
+          {
+            abilities: { reasoning: true, vision: true },
+            contextWindowTokens: 200_000,
+            displayName: 'Claude Test',
+            id: 'claude-test',
+            maxOutput: 32_000,
+            providerId: mockProviderId,
+            type: 'chat',
+          },
           { abilities: {}, id: 'embed-test', providerId: mockProviderId, type: 'embedding' },
           { abilities: {}, id: 'gpt-test', providerId: 'other', type: 'chat' },
         ],
@@ -331,8 +339,24 @@ describe('aiProviderRouter', () => {
       const result = await caller.getProviderBindingRuntime({ id: mockProviderId });
 
       expect(result.enabledModels).toEqual([
-        { id: 'claude-test', providerId: mockProviderId, type: 'chat' },
-        { id: 'embed-test', providerId: mockProviderId, type: 'embedding' },
+        {
+          abilities: { reasoning: true, vision: true },
+          contextWindowTokens: 200_000,
+          displayName: 'Claude Test',
+          id: 'claude-test',
+          maxOutput: 32_000,
+          providerId: mockProviderId,
+          type: 'chat',
+        },
+        {
+          abilities: { reasoning: undefined, vision: undefined },
+          contextWindowTokens: undefined,
+          displayName: undefined,
+          id: 'embed-test',
+          maxOutput: undefined,
+          providerId: mockProviderId,
+          type: 'embedding',
+        },
       ]);
     });
   });

--- a/apps/server/src/routers/lambda/aiProvider.ts
+++ b/apps/server/src/routers/lambda/aiProvider.ts
@@ -214,7 +214,20 @@ export const aiProviderRouter = router({
       const runtimeConfig = state.runtimeConfig[input.id];
       const enabledModels = state.enabledAiModels
         .filter((model) => model.providerId === input.id)
-        .map(({ id, providerId, type }) => ({ id, providerId, type }));
+        .map(
+          ({ abilities, contextWindowTokens, displayName, id, maxOutput, providerId, type }) => ({
+            abilities: {
+              reasoning: abilities.reasoning,
+              vision: abilities.vision,
+            },
+            contextWindowTokens,
+            displayName,
+            id,
+            maxOutput,
+            providerId,
+            type,
+          }),
+        );
 
       if (ctx.apiKeyScopes !== undefined && !isFullAccessApiKey(ctx.apiKeyScopes)) {
         return {

--- a/packages/heterogeneous-agents/src/providerBinding/resolveBinding.test.ts
+++ b/packages/heterogeneous-agents/src/providerBinding/resolveBinding.test.ts
@@ -83,6 +83,117 @@ describe('heterogeneous provider binding protocol resolver', () => {
     });
   });
 
+  it.each([
+    {
+      endpoint: 'https://chat.example.com/v1',
+      expectedEndpoint: 'https://chat.example.com/v1',
+      expectedProtocol: 'openai-chat-completions',
+      providerId: 'custom-chat',
+      sdkType: 'openai',
+    },
+    {
+      endpoint: 'https://responses.example.com/v1/',
+      expectedEndpoint: 'https://responses.example.com/v1',
+      expectedProtocol: 'openai-responses',
+      providerId: 'custom-responses',
+      responses: true,
+      sdkType: 'openai',
+    },
+    {
+      endpoint: 'https://messages.example.com',
+      expectedEndpoint: 'https://messages.example.com',
+      expectedProtocol: 'anthropic-messages',
+      providerId: 'custom-anthropic',
+      sdkType: 'anthropic',
+    },
+    {
+      endpoint: 'https://google.example.com/gemini/',
+      expectedEndpoint: 'https://google.example.com/gemini/v1beta',
+      expectedProtocol: 'google-generative-ai',
+      providerId: 'custom-google',
+      sdkType: 'google',
+    },
+  ] as const)(
+    'binds Pi to $expectedProtocol',
+    ({ endpoint, expectedEndpoint, expectedProtocol, providerId, responses, sdkType }) => {
+      const result = resolveHeterogeneousProviderBinding({
+        agentType: 'pi',
+        apiConfig: { model: 'model-test', providerId },
+        providerEnabled: true,
+        runtimeConfig: runtime(sdkType, {
+          config: responses ? { enableResponseApi: true } : {},
+          keyVaults: { apiKey: 'test-key', baseURL: endpoint },
+          settings: {
+            sdkType,
+            ...(responses ? { supportResponsesApi: true } : {}),
+          },
+        }),
+      });
+
+      expect(result.resolution).toMatchObject({
+        endpoint: expectedEndpoint,
+        protocol: expectedProtocol,
+      });
+    },
+  );
+
+  it.each([
+    ['openai', 'openai', 'openai-responses', 'https://api.openai.com/v1'],
+    ['anthropic', 'anthropic', 'anthropic-messages', 'https://api.anthropic.com'],
+    [
+      'google',
+      'google',
+      'google-generative-ai',
+      'https://generativelanguage.googleapis.com/v1beta',
+    ],
+  ] as const)(
+    'uses the canonical %s endpoint when no provider base URL is configured',
+    (providerId, sdkType, protocol, endpoint) => {
+      const result = resolveHeterogeneousProviderBinding({
+        agentType: 'pi',
+        apiConfig: { model: 'model-test', providerId },
+        providerEnabled: true,
+        runtimeConfig: runtime(sdkType),
+      });
+
+      expect(result.resolution).toMatchObject({ endpoint, protocol });
+    },
+  );
+
+  it('requires a concrete endpoint for non-canonical Pi providers', () => {
+    const result = resolveHeterogeneousProviderBinding({
+      agentType: 'pi',
+      apiConfig: { model: 'model-test', providerId: 'custom-openai' },
+      providerEnabled: true,
+      runtimeConfig: runtime('openai'),
+    });
+
+    expect(result.error).toEqual({ code: 'endpointMissing', providerId: 'custom-openai' });
+  });
+
+  it('carries server-resolved model capabilities into the binding resolution', () => {
+    const modelMetadata = {
+      abilities: { reasoning: true, vision: true },
+      contextWindowTokens: 200_000,
+      displayName: 'Bound model',
+      id: 'model-test',
+      maxOutput: 32_000,
+      providerId: 'custom-openai',
+      type: 'chat',
+    };
+    const result = resolveHeterogeneousProviderBinding({
+      agentType: 'pi',
+      apiConfig: { model: 'model-test', providerId: 'custom-openai' },
+      enabledModels: [modelMetadata],
+      providerEnabled: true,
+      runtimeConfig: runtime('openai', {
+        keyVaults: { apiKey: 'test-key', baseURL: 'https://example.com/v1' },
+      }),
+    });
+
+    expect(result.resolution?.modelMetadata).toEqual(modelMetadata);
+  });
+
   it('validates credentials only inside the trusted host boundary', () => {
     const input = {
       agentType: 'claude-code',
@@ -96,10 +207,19 @@ describe('heterogeneous provider binding protocol resolver', () => {
     ).toBe('credentialsMissing');
   });
 
-  it('rejects API bindings for agents without an implemented driver capability', () => {
+  it('rejects unsupported protocols and agents without an implemented driver capability', () => {
     expect(
       resolveHeterogeneousProviderBinding({
         agentType: 'pi',
+        apiConfig: { model: 'model', providerId: 'bedrock' },
+        providerEnabled: true,
+        runtimeConfig: runtime('bedrock'),
+      }).error?.code,
+    ).toBe('protocolMismatch');
+
+    expect(
+      resolveHeterogeneousProviderBinding({
+        agentType: 'amp',
         apiConfig: { model: 'model', providerId: 'anthropic' },
         providerEnabled: true,
         runtimeConfig: runtime('anthropic'),

--- a/packages/heterogeneous-agents/src/providerBinding/resolveBinding.ts
+++ b/packages/heterogeneous-agents/src/providerBinding/resolveBinding.ts
@@ -3,11 +3,12 @@ import type {
   HeterogeneousProviderBindingCapability,
   HeterogeneousProviderBindingError,
   HeterogeneousProviderBindingProtocol,
+  HeterogeneousProviderBindingResolution,
   ResolveHeterogeneousProviderBindingInput,
   ResolveHeterogeneousProviderBindingResult,
 } from './types';
 
-export const HETEROGENEOUS_PROVIDER_BINDING_AGENT_TYPES = ['claude-code', 'codex'] as const;
+export const HETEROGENEOUS_PROVIDER_BINDING_AGENT_TYPES = ['claude-code', 'codex', 'pi'] as const;
 
 const CAPABILITIES: Partial<
   Record<LocalHeterogeneousAgentType, HeterogeneousProviderBindingCapability>
@@ -20,6 +21,26 @@ const CAPABILITIES: Partial<
     agentType: 'codex',
     protocols: ['openai-responses'],
   },
+  'pi': {
+    agentType: 'pi',
+    protocols: [
+      'openai-responses',
+      'openai-chat-completions',
+      'anthropic-messages',
+      'google-generative-ai',
+    ],
+  },
+};
+
+const DEFAULT_PROVIDER_ENDPOINTS: Partial<
+  Record<HeterogeneousProviderBindingProtocol, Record<string, string>>
+> = {
+  'anthropic-messages': { anthropic: 'https://api.anthropic.com' },
+  'google-generative-ai': {
+    google: 'https://generativelanguage.googleapis.com/v1beta',
+  },
+  'openai-chat-completions': { openai: 'https://api.openai.com/v1' },
+  'openai-responses': { openai: 'https://api.openai.com/v1' },
 };
 
 const nonEmptyString = (value: unknown): string | undefined => {
@@ -33,7 +54,10 @@ const stripTrailingSlashes = (value: string): string => {
   return value.slice(0, end);
 };
 
-const normalizeEndpoint = (value: unknown): string | undefined => {
+const normalizeEndpoint = (
+  value: unknown,
+  protocol: HeterogeneousProviderBindingProtocol,
+): string | undefined => {
   const raw = nonEmptyString(value);
   if (!raw) return;
 
@@ -43,7 +67,14 @@ const normalizeEndpoint = (value: unknown): string | undefined => {
     // User info and query/hash values can contain credentials. They are not a
     // supported provider endpoint shape and must never reach profile files or metadata.
     if (url.username || url.password || url.search || url.hash) return;
-    return stripTrailingSlashes(url.toString());
+    const endpoint = stripTrailingSlashes(url.toString());
+    // LobeHub's Google runtime accepts a host root and lets the SDK append its
+    // default v1beta version. Pi custom providers instead set apiVersion=""
+    // and require the configured baseUrl to include the version path.
+    if (protocol === 'google-generative-ai' && !/\/v\d+(?:beta\d*)?\/?$/.test(url.pathname)) {
+      return `${endpoint}/v1beta`;
+    }
+    return endpoint;
   } catch {
     return;
   }
@@ -89,21 +120,27 @@ export const resolveProviderBindingProtocol = (
 };
 
 const resolveEndpointError = (
+  agentType: string,
   providerId: string,
   rawEndpoint: unknown,
   protocol: HeterogeneousProviderBindingProtocol,
 ): { endpoint?: string; error?: HeterogeneousProviderBindingError } => {
   const raw = nonEmptyString(rawEndpoint);
-  const endpoint = normalizeEndpoint(raw);
+  const endpoint = normalizeEndpoint(raw, protocol);
   if (raw && !endpoint) return { error: { code: 'endpointUnsupported', providerId } };
+  if (endpoint) return { endpoint };
 
-  if (protocol === 'openai-responses') {
-    if (endpoint) return { endpoint };
-    if (providerId === 'openai') return { endpoint: 'https://api.openai.com/v1' };
+  const defaultEndpoint =
+    agentType === 'pi' || protocol === 'openai-responses'
+      ? DEFAULT_PROVIDER_ENDPOINTS[protocol]?.[providerId]
+      : undefined;
+  if (defaultEndpoint) return { endpoint: defaultEndpoint };
+
+  if (protocol === 'openai-responses' || agentType === 'pi') {
     return { error: { code: 'endpointMissing', providerId } };
   }
 
-  return { endpoint };
+  return {};
 };
 
 export const resolveHeterogeneousProviderBinding = ({
@@ -140,12 +177,14 @@ export const resolveHeterogeneousProviderBinding = ({
   }
 
   const endpointResult = resolveEndpointError(
+    agentType,
     apiConfig.providerId,
     runtimeConfig.keyVaults?.baseURL,
     protocol,
   );
   if (endpointResult.error) return { error: endpointResult.error };
 
+  let modelMetadata: HeterogeneousProviderBindingResolution['modelMetadata'];
   if (enabledModels) {
     const boundModels = [apiConfig.model, apiConfig.smallFastModel].filter(
       (model): model is string => !!model,
@@ -168,6 +207,12 @@ export const resolveHeterogeneousProviderBinding = ({
         },
       };
     }
+    modelMetadata = enabledModels.find(
+      (model) =>
+        model.providerId === apiConfig.providerId &&
+        model.id === apiConfig.model &&
+        model.type === 'chat',
+    );
   }
 
   return {
@@ -175,6 +220,7 @@ export const resolveHeterogeneousProviderBinding = ({
       agentType: capability.agentType,
       apiConfig: { ...apiConfig, model: apiConfig.model.trim() },
       endpoint: endpointResult.endpoint,
+      modelMetadata,
       protocol,
       providerId: apiConfig.providerId,
       runtimeConfig,

--- a/packages/heterogeneous-agents/src/providerBinding/types.ts
+++ b/packages/heterogeneous-agents/src/providerBinding/types.ts
@@ -44,6 +44,7 @@ export interface HeterogeneousProviderBindingResolution {
   apiConfig: HeterogeneousProviderApiConfig;
   /** Credential-free endpoint used by the target CLI. */
   endpoint?: string;
+  modelMetadata?: EnabledProviderBindingModelRef;
   protocol: HeterogeneousProviderBindingProtocol;
   providerId: string;
   runtimeConfig: AiProviderRuntimeConfig;
@@ -61,7 +62,14 @@ export type HeterogeneousProviderBindingError =
   | { code: 'providerUnavailable'; providerId: string };
 
 export interface EnabledProviderBindingModelRef {
+  abilities?: {
+    reasoning?: boolean;
+    vision?: boolean;
+  };
+  contextWindowTokens?: number;
+  displayName?: string;
   id: string;
+  maxOutput?: number;
   providerId: string;
   type: string;
 }


### PR DESCRIPTION
## Description of Change

Add LobeHub Provider binding support for the Pi heterogeneous agent.

- Generate a managed, secret-free Pi `models.json` for OpenAI Chat Completions, OpenAI Responses, Anthropic Messages, and Google Generative AI providers.
- Inject provider credentials only through the Pi child-process environment and prevent caller arguments or environment variables from overriding managed routing and session selection.
- Keep resumed sessions pinned to the selected provider/model, isolate reusable Pi profiles by model, and preserve profile identity across API key rotation.
- Pass model capabilities from the server so Pi receives the correct context window, output limit, vision, and reasoning metadata.
- Supply canonical endpoints for OpenAI, Anthropic, and Google while requiring explicit endpoints for custom providers.

#### Test

- `bun run check` — lint clean, 49 tests passed
- `bun run check --type` — types clean
- Verified the generated provider schema with `@earendil-works/pi-coding-agent@0.84.3 --list-models`
- Verified Pi 0.84.3 parses managed provider/model/session arguments before a caller-provided `--`

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

No matching issue found.
