### PR TITLE
✨ feat: consolidate Home promo surfaces

### DIFF
--- a/src/business/client/features/useHomePromoLine.ts
+++ b/src/business/client/features/useHomePromoLine.ts
@@ -1,9 +1,6 @@
 import type { ReactNode } from 'react';
 
 /**
- * The time-sensitive promotion shown in Home's header. Returning a node lets
- * the Home layout know whether a campaign is live, so it can keep the Agent's
- * daily-brief bubble out of the same attention lane until the campaign is
- * dismissed or expires.
+ * The time-sensitive promotion spoken by Home's portrait.
  */
 export const useHomePromoLine = (): ReactNode | undefined => undefined;

--- a/src/features/Home/HomeHeader.tsx
+++ b/src/features/Home/HomeHeader.tsx
@@ -1,6 +1,5 @@
 import { Flexbox, Text } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
-import type { ReactNode } from 'react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -27,37 +26,10 @@ const styles = createStaticStyles(({ css }) => ({
     line-height: 1.4;
     letter-spacing: -0.01em;
   `,
-  promo: css`
-    overflow: hidden;
-    justify-self: center;
-
-    min-width: 0;
-    max-width: 100%;
-
-    white-space: nowrap;
-
-    @container home (width <= 720px) {
-      justify-self: end;
-      max-width: 280px;
-    }
-  `,
-  spacer: css`
-    @container home (width <= 720px) {
-      display: none;
-    }
-  `,
   toolbar: css`
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 480px) minmax(0, 1fr);
-    align-items: center;
-
     width: 100%;
     min-width: 0;
     min-height: 48px;
-
-    @container home (width <= 720px) {
-      grid-template-columns: minmax(0, 1fr) auto;
-    }
   `,
 }));
 
@@ -69,10 +41,9 @@ const getGreetingKey = (hour: number): 'afternoon' | 'evening' | 'morning' => {
 
 interface HomeHeaderProps {
   centered?: boolean;
-  promo?: ReactNode;
 }
 
-const HomeHeader = memo<HomeHeaderProps>(({ centered, promo }) => {
+const HomeHeader = memo<HomeHeaderProps>(({ centered }) => {
   const { t } = useTranslation('home');
   const displayName = useUserStore(userProfileSelectors.displayUserName);
   const isLogin = useUserStore(authSelectors.isLogin);
@@ -91,11 +62,9 @@ const HomeHeader = memo<HomeHeaderProps>(({ centered, promo }) => {
       {centered ? (
         <AgentSelect />
       ) : (
-        <div className={styles.toolbar}>
+        <Flexbox horizontal align={'center'} className={styles.toolbar}>
           <AgentSelect />
-          {promo && <div className={styles.promo}>{promo}</div>}
-          <div aria-hidden className={styles.spacer} />
-        </div>
+        </Flexbox>
       )}
       <Text as={'h1'} className={styles.greeting} weight={600}>
         {greeting}

--- a/src/features/Home/InputArea/InputBanner.tsx
+++ b/src/features/Home/InputArea/InputBanner.tsx
@@ -1,0 +1,95 @@
+import { ActionIcon } from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
+import { X } from 'lucide-react';
+import type { MouseEvent, MouseEventHandler, ReactNode } from 'react';
+import { useCallback } from 'react';
+
+import { useGlobalStore } from '@/store/global';
+import { systemStatusSelectors } from '@/store/global/selectors';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  banner: css`
+    position: relative;
+    z-index: 0;
+
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    justify-content: space-between;
+
+    min-width: 0;
+    margin-block: -44px -6px;
+    padding-block: 42px 10px;
+    padding-inline: 16px 12px;
+    border: 1px solid ${cssVar.colorFillSecondary};
+    border-radius: 20px;
+
+    background: color-mix(in srgb, ${cssVar.colorFillQuaternary} 50%, ${cssVar.colorBgContainer});
+
+    &[data-clickable='true'] {
+      cursor: pointer;
+    }
+  `,
+  queue: css`
+    display: contents;
+
+    & > [data-home-input-banner] ~ [data-home-input-banner] {
+      display: none;
+    }
+  `,
+}));
+
+interface InputBannerProps {
+  children: ReactNode;
+  dismissId: string;
+  dismissTitle: string;
+  onClick?: MouseEventHandler<HTMLDivElement>;
+  testId: string;
+}
+
+export const InputBanner = ({
+  children,
+  dismissId,
+  dismissTitle,
+  onClick,
+  testId,
+}: InputBannerProps) => {
+  const updateSystemStatus = useGlobalStore((state) => state.updateSystemStatus);
+
+  const handleDismiss = useCallback(
+    (event: MouseEvent) => {
+      event.stopPropagation();
+      const current = useGlobalStore.getState().status.dismissedBannerIds || [];
+      if (current.includes(dismissId)) return;
+      updateSystemStatus({ dismissedBannerIds: [...current, dismissId] });
+    },
+    [dismissId, updateSystemStatus],
+  );
+
+  return (
+    <div
+      data-home-input-banner
+      className={styles.banner}
+      data-clickable={Boolean(onClick)}
+      data-testid={testId}
+      onClick={onClick}
+    >
+      {children}
+      <ActionIcon icon={X} size={'small'} title={dismissTitle} onClick={handleDismiss} />
+    </div>
+  );
+};
+
+interface InputBannerSegmentProps {
+  children: ReactNode;
+  dismissId: string;
+}
+
+export const InputBannerSegment = ({ children, dismissId }: InputBannerSegmentProps) => {
+  const dismissed = useGlobalStore(systemStatusSelectors.isBannerDismissed(dismissId));
+  return dismissed ? null : children;
+};
+
+export const InputBannerQueue = ({ children }: { children: ReactNode }) => (
+  <div className={styles.queue}>{children}</div>
+);

--- a/src/features/Home/InputArea/MessengerBanner.tsx
+++ b/src/features/Home/InputArea/MessengerBanner.tsx
@@ -1,15 +1,16 @@
 'use client';
 
-import { ActionIcon, Flexbox, Icon } from '@lobehub/ui';
+import { Flexbox, Icon } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
-import { MessageCircleIcon, X } from 'lucide-react';
+import { MessageCircleIcon } from 'lucide-react';
 import type { FC } from 'react';
-import React, { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { getPlatformIcon } from '@/routes/(main)/agent/channel/const';
-import { useGlobalStore } from '@/store/global';
+
+import { InputBanner } from './InputBanner';
 
 // Bump this id when the banner content changes so dismissing the old
 // variant does not hide the new one.
@@ -37,27 +38,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
       0 0 8px -2px rgb(0 0 0 / 5%),
       0 0 0 1px ${cssVar.colorFillTertiary};
   `,
-  banner: css`
-    cursor: pointer;
-
-    position: absolute;
-    z-index: 0;
-    inset-block-end: 0;
-    inset-inline: 0;
-
-    display: flex;
-    gap: 12px;
-    align-items: center;
-    justify-content: space-between;
-
-    margin-block-end: -6px;
-    padding-block: 42px 10px;
-    padding-inline: 16px 12px;
-    border: 1px solid ${cssVar.colorFillSecondary};
-    border-radius: 20px;
-
-    background: color-mix(in srgb, ${cssVar.colorFillQuaternary} 50%, ${cssVar.colorBgContainer});
-  `,
   icon: css`
     color: ${cssVar.colorTextSecondary};
   `,
@@ -74,8 +54,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 const MessengerBanner = memo(() => {
   const { t } = useTranslation('common');
   const navigate = useWorkspaceAwareNavigate();
-
-  const updateSystemStatus = useGlobalStore((s) => s.updateSystemStatus);
 
   const platformIcons = useMemo(() => {
     const icons: Array<{ Icon: FC<any>; key: string }> = [];
@@ -97,29 +75,18 @@ const MessengerBanner = memo(() => {
     navigate('/settings/messenger');
   }, [navigate]);
 
-  const handleDismiss = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      const current = useGlobalStore.getState().status.dismissedBannerIds || [];
-      if (current.includes(MESSENGER_BANNER_ID)) return;
-      updateSystemStatus({
-        dismissedBannerIds: [...current, MESSENGER_BANNER_ID],
-      });
-    },
-    [updateSystemStatus],
-  );
-
   return (
-    <div
-      className={styles.banner}
-      data-testid="messenger-banner"
+    <InputBanner
+      dismissId={MESSENGER_BANNER_ID}
+      dismissTitle={t('messengerBanner.dismiss')}
+      testId={'messenger-banner'}
       onClick={handleNavigateToMessenger}
     >
-      <Flexbox horizontal align="center" gap={8}>
-        <Icon className={styles.icon} icon={MessageCircleIcon} size={18} />
-        <span className={styles.text}>{t('messengerBanner.title')}</span>
-      </Flexbox>
-      <Flexbox horizontal align="center" gap={8}>
+      <Flexbox horizontal align={'center'} flex={1} gap={8} justify={'space-between'}>
+        <Flexbox horizontal align={'center'} gap={8}>
+          <Icon className={styles.icon} icon={MessageCircleIcon} size={18} />
+          <span className={styles.text}>{t('messengerBanner.title')}</span>
+        </Flexbox>
         {platformIcons.length > 0 && (
           <div className={styles.iconGroup}>
             {platformIcons.map(({ Icon: PlatformIcon, key }, index) => (
@@ -133,14 +100,8 @@ const MessengerBanner = memo(() => {
             ))}
           </div>
         )}
-        <ActionIcon
-          icon={X}
-          size="small"
-          title={t('messengerBanner.dismiss')}
-          onClick={handleDismiss}
-        />
       </Flexbox>
-    </div>
+    </InputBanner>
   );
 });
 

--- a/src/features/Home/InputArea/index.tsx
+++ b/src/features/Home/InputArea/index.tsx
@@ -11,10 +11,12 @@ import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 
+import { HOME_NEW_MODELS_BANNER_ID, NewModelShortcuts } from '../NewModelShortcuts';
 import type { HomeMode } from '../types';
 import { HOME_INPUT_RESERVED_HEIGHT } from './constants';
 import { EditorSlot } from './EditorSlot';
 import { stripMarkdownLinks } from './hintFormat';
+import { InputBannerQueue, InputBannerSegment } from './InputBanner';
 import InputDragUpload from './InputDragUpload';
 import MessengerBanner, { MESSENGER_BANNER_ID } from './MessengerBanner';
 import { useSend } from './useSend';
@@ -31,9 +33,16 @@ interface InputAreaProps {
   mode: HomeMode;
   onInputValueChange: (value: string) => void;
   onModeChange: (mode: HomeMode) => void;
+  showNewModelShortcuts?: boolean;
 }
 
-const InputArea = ({ inputValue, mode, onInputValueChange, onModeChange }: InputAreaProps) => {
+const InputArea = ({
+  inputValue,
+  mode,
+  onInputValueChange,
+  onModeChange,
+  showNewModelShortcuts,
+}: InputAreaProps) => {
   const { t } = useTranslation('home');
   const { agentId, contextSelectionKey, loading, send } = useSend(mode);
   // Subscribe to the SWR key so `internal_refreshAgentConfig`'s `mutate(...)`
@@ -47,15 +56,12 @@ const InputArea = ({ inputValue, mode, onInputValueChange, onModeChange }: Input
   const isAgentConfigLoading = useAgentStore((s) =>
     agentByIdSelectors.isAgentConfigLoadingById(agentId ?? '')(s),
   );
-  const isMessengerBannerDismissed = useGlobalStore(
-    systemStatusSelectors.isBannerDismissed(MESSENGER_BANNER_ID),
-  );
   // Wait for the persisted status to hydrate so users who already dismissed
   // the banner never see it flash on mount.
   const isStatusInit = useGlobalStore(systemStatusSelectors.isStatusInit);
   const chatInputRef = useRef<HTMLDivElement>(null);
 
-  const showMessengerBanner = mode === 'chat' && isStatusInit && !isMessengerBannerDismissed;
+  const showInputBanners = mode === 'chat' && isStatusInit;
 
   // Get agent's model info for vision support check. Falls back to an empty
   // id while the agent id resolves; the selectors return DEFAULT_MODEL /
@@ -94,11 +100,7 @@ const InputArea = ({ inputValue, mode, onInputValueChange, onModeChange }: Input
 
   return (
     <Flexbox>
-      <Flexbox
-        ref={chatInputRef}
-        style={{ paddingBottom: showMessengerBanner ? 32 : 0, position: 'relative' }}
-      >
-        {showMessengerBanner && <MessengerBanner />}
+      <Flexbox ref={chatInputRef}>
         {mode === 'chat' ? (
           <InputDragUpload
             radius={20}
@@ -109,6 +111,18 @@ const InputArea = ({ inputValue, mode, onInputValueChange, onModeChange }: Input
           </InputDragUpload>
         ) : (
           editorSlot
+        )}
+        {showInputBanners && (
+          <InputBannerQueue>
+            {showNewModelShortcuts && (
+              <InputBannerSegment dismissId={HOME_NEW_MODELS_BANNER_ID}>
+                <NewModelShortcuts />
+              </InputBannerSegment>
+            )}
+            <InputBannerSegment dismissId={MESSENGER_BANNER_ID}>
+              <MessengerBanner />
+            </InputBannerSegment>
+          </InputBannerQueue>
         )}
       </Flexbox>
     </Flexbox>

--- a/src/features/Home/NewModelShortcuts/index.tsx
+++ b/src/features/Home/NewModelShortcuts/index.tsx
@@ -17,9 +17,12 @@ import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 
 import { useResolvedHomeAgentId } from '../AgentSelect/useResolvedHomeAgentId';
+import { InputBanner } from '../InputArea/InputBanner';
 import { trackHomeModelShortcutClicked } from './analytics';
 import { getShortcutIconModelId } from './getShortcutIconModelId';
 import { useStarterModelDefaults } from './useStarterModelDefaults';
+
+export const HOME_NEW_MODELS_BANNER_ID = 'home-new-models-v1';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   active: css`
@@ -27,11 +30,12 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     background: ${cssVar.colorFillSecondary};
   `,
   button: css`
-    height: 40px;
-    padding-inline: 12px;
+    height: 24px;
+    padding-inline: 8px;
     border: 0;
     border-radius: ${cssVar.borderRadius};
 
+    font-size: 13px;
     color: ${cssVar.colorTextSecondary};
 
     background: transparent;
@@ -43,8 +47,10 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     }
   `,
   container: css`
-    flex-wrap: wrap;
-    min-height: 40px;
+    overflow: hidden;
+    flex: 1;
+    min-width: 0;
+    height: 24px;
   `,
   label: css`
     flex: none;
@@ -56,7 +62,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 const getShortcutKey = (item: HomeNewModelItem) => `${item.type}:${item.model}`;
 const getShortcutProvider = (item: HomeNewModelItem, fallbackProvider: string) =>
   item.provider ?? fallbackProvider;
-const skeletonWidths = [112, 150, 126, 138];
+const skeletonWidths = [96, 120, 104, 112];
 
 export const NewModelShortcuts = () => {
   const { t } = useTranslation('home');
@@ -150,50 +156,56 @@ export const NewModelShortcuts = () => {
   if (!canCreateContent || (!isLoading && items.length === 0)) return null;
 
   return (
-    <Flexbox horizontal align={'center'} className={styles.container} gap={8} justify={'center'}>
-      <Text className={styles.label}>{t('starter.newLabel')}</Text>
-      {isLoading
-        ? defaultHomeNewModels.map((item, index) => (
-            <Skeleton.Button
-              active
-              key={getShortcutKey(item)}
-              style={{
-                borderRadius: 8,
-                height: 40,
-                width: skeletonWidths[index] ?? 126,
-              }}
-            />
-          ))
-        : items.map((item) => {
-            const key = getShortcutKey(item);
-            const provider =
-              item.type === 'chat' ? getShortcutProvider(item, fallbackChatProvider) : undefined;
-            const isCurrent =
-              item.type === 'chat' && item.model === currentModel && provider === currentProvider;
-            const isSwitching = switchingKey === key;
-            const button = (
-              <Button
-                aria-pressed={item.type === 'chat' ? isCurrent : undefined}
-                className={cx(styles.button, isCurrent && styles.active)}
-                disabled={!!switchingKey && !isSwitching}
-                key={key}
-                loading={isSwitching}
-                type={'text'}
-                icon={
-                  item.iconUrl ? (
-                    <Avatar alt={''} avatar={item.iconUrl} size={18} />
-                  ) : (
-                    <ModelIcon model={getShortcutIconModelId(item)} size={18} />
-                  )
-                }
-                onClick={() => handleClick(item)}
-              >
-                {item.title}
-              </Button>
-            );
+    <InputBanner
+      dismissId={HOME_NEW_MODELS_BANNER_ID}
+      dismissTitle={t('homePromoBanner.dismiss')}
+      testId={'home-new-model-banner'}
+    >
+      <Flexbox horizontal align={'center'} className={styles.container} gap={4}>
+        <Text className={styles.label}>{t('starter.newLabel')}</Text>
+        {isLoading
+          ? defaultHomeNewModels.map((item, index) => (
+              <Skeleton.Button
+                active
+                key={getShortcutKey(item)}
+                style={{
+                  borderRadius: 8,
+                  height: 24,
+                  width: skeletonWidths[index] ?? 104,
+                }}
+              />
+            ))
+          : items.map((item) => {
+              const key = getShortcutKey(item);
+              const provider =
+                item.type === 'chat' ? getShortcutProvider(item, fallbackChatProvider) : undefined;
+              const isCurrent =
+                item.type === 'chat' && item.model === currentModel && provider === currentProvider;
+              const isSwitching = switchingKey === key;
+              const button = (
+                <Button
+                  aria-pressed={item.type === 'chat' ? isCurrent : undefined}
+                  className={cx(styles.button, isCurrent && styles.active)}
+                  disabled={!!switchingKey && !isSwitching}
+                  key={key}
+                  loading={isSwitching}
+                  type={'text'}
+                  icon={
+                    item.iconUrl ? (
+                      <Avatar alt={''} avatar={item.iconUrl} size={16} />
+                    ) : (
+                      <ModelIcon model={getShortcutIconModelId(item)} size={16} />
+                    )
+                  }
+                  onClick={() => handleClick(item)}
+                >
+                  {item.title}
+                </Button>
+              );
 
-            return button;
-          })}
-    </Flexbox>
+              return button;
+            })}
+      </Flexbox>
+    </InputBanner>
   );
 };

--- a/src/features/Home/PortraitBubble/index.tsx
+++ b/src/features/Home/PortraitBubble/index.tsx
@@ -1,4 +1,5 @@
 import { createStaticStyles } from 'antd-style';
+import type { ReactNode } from 'react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -65,7 +66,11 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
-const PortraitBubble = memo(() => {
+interface PortraitBubbleProps {
+  promo?: ReactNode;
+}
+
+const PortraitBubble = memo<PortraitBubbleProps>(({ promo }) => {
   const { t } = useTranslation('home');
   const { currentPair } = useHomeDailyBrief();
 
@@ -73,9 +78,11 @@ const PortraitBubble = memo(() => {
 
   return (
     <div className={styles.bubble}>
-      <div className={styles.line}>
-        {parsed?.plain ? <GreetingLine parsed={parsed} /> : t('dashboard.greeting.subtitle')}
-      </div>
+      {promo ?? (
+        <div className={styles.line}>
+          {parsed?.plain ? <GreetingLine parsed={parsed} /> : t('dashboard.greeting.subtitle')}
+        </div>
+      )}
     </div>
   );
 });

--- a/src/features/Home/__tests__/portraitVisibility.test.tsx
+++ b/src/features/Home/__tests__/portraitVisibility.test.tsx
@@ -1,10 +1,11 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { PortalViewType } from '@/store/chat/slices/portal/initialState';
 
 interface RenderHomeOptions {
+  hiddenWidgets?: string[];
   isLogin?: boolean;
   portalViewType?: PortalViewType;
   promo?: ReactNode;
@@ -16,12 +17,22 @@ const stub = (testId: string) => ({ default: () => <div data-testid={testId} /> 
 const modeStub = (testId: string) => ({
   default: ({ mode }: { mode?: string }) => <div data-mode={mode} data-testid={testId} />,
 });
-const homeHeaderStub = {
-  default: ({ promo }: { promo?: ReactNode }) => (
-    <div data-testid={'home-header'}>
-      {promo && <div data-testid={'home-header-promo'}>{promo}</div>}
+const inputAreaStub = {
+  default: ({
+    mode,
+    showNewModelShortcuts,
+  }: {
+    mode?: string;
+    showNewModelShortcuts?: boolean;
+  }) => (
+    <div data-mode={mode} data-testid={'home-input-area'}>
+      {mode === 'chat' && showNewModelShortcuts && <div data-testid={'new-model-shortcuts'} />}
     </div>
   ),
+};
+const homeHeaderStub = stub('home-header');
+const portraitBubbleStub = {
+  default: ({ promo }: { promo?: ReactNode }) => <div data-testid={'portrait-bubble'}>{promo}</div>,
 };
 
 function translate() {
@@ -29,6 +40,7 @@ function translate() {
 }
 
 const renderHome = async ({
+  hiddenWidgets = [],
   isLogin = true,
   portalViewType,
   promo,
@@ -42,11 +54,8 @@ const renderHome = async ({
   vi.doMock('../HomeHeader', () => homeHeaderStub);
   vi.doMock('../HomeModeContent', () => modeStub('home-mode-content'));
   vi.doMock('../HomePortrait', () => stub('home-portrait'));
-  vi.doMock('../InputArea', () => modeStub('home-input-area'));
-  vi.doMock('../NewModelShortcuts', () => ({
-    NewModelShortcuts: () => <div data-testid={'new-model-shortcuts'} />,
-  }));
-  vi.doMock('../PortraitBubble', () => stub('portrait-bubble'));
+  vi.doMock('../InputArea', () => inputAreaStub);
+  vi.doMock('../PortraitBubble', () => portraitBubbleStub);
   vi.doMock('../AcceptancePortalDrawer', () => stub('acceptance-portal-drawer'));
   vi.doMock('@/business/client/features/useHomePromoLine', () => ({
     useHomePromoLine: vi.fn(() => promo),
@@ -64,7 +73,7 @@ const renderHome = async ({
     },
   }));
   function selectFromGlobalStore(selector: (state: unknown) => unknown) {
-    return selector({ status: { showHomePortrait } });
+    return selector({ status: { hiddenHomeWidgets: hiddenWidgets, showHomePortrait } });
   }
   vi.doMock('@/store/global', () => ({ useGlobalStore: selectFromGlobalStore }));
   function selectFromUserStore(selector: (state: unknown) => unknown) {
@@ -85,7 +94,6 @@ afterEach(() => {
   vi.doUnmock('../HomeModeContent');
   vi.doUnmock('../HomePortrait');
   vi.doUnmock('../InputArea');
-  vi.doUnmock('../NewModelShortcuts');
   vi.doUnmock('../PortraitBubble');
   vi.doUnmock('../AcceptancePortalDrawer');
   vi.doUnmock('@/business/client/features/useHomePromoLine');
@@ -111,12 +119,26 @@ describe('Home portrait visibility', () => {
     expect(screen.getByTestId('portrait-bubble')).toBeInTheDocument();
   }, 20000);
 
-  it('shows a live promotion in the header without competing with the portrait bubble', async () => {
+  it('lets a live model promotion speak through the portrait without changing its shortcuts', async () => {
     await renderHome({ promo: <span>Campaign</span> });
 
-    expect(screen.getByTestId('home-header-promo')).toHaveTextContent('Campaign');
     expect(screen.getByTestId('home-portrait')).toBeInTheDocument();
+    expect(within(screen.getByTestId('portrait-bubble')).getByText('Campaign')).toBeInTheDocument();
+    expect(screen.getByTestId('new-model-shortcuts')).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('home-header')).queryByText('Campaign'),
+    ).not.toBeInTheDocument();
+  }, 20000);
+
+  it('does not move the promotion elsewhere when the portrait is hidden', async () => {
+    await renderHome({
+      promo: <span>Campaign</span>,
+      showHomePortrait: false,
+    });
+
     expect(screen.queryByTestId('portrait-bubble')).not.toBeInTheDocument();
+    expect(screen.queryByText('Campaign')).not.toBeInTheDocument();
+    expect(screen.getByTestId('new-model-shortcuts')).toBeInTheDocument();
   }, 20000);
 
   it('takes the bubble down with the portrait when the preference is off', async () => {
@@ -151,6 +173,24 @@ describe('Home portrait visibility', () => {
     expect(window.location.search).toBe('');
   }, 20000);
 
+  it('keeps model shortcuts out of the minimal layout', async () => {
+    await renderHome({
+      hiddenWidgets: [
+        'goals',
+        'needsYou',
+        'unread',
+        'running',
+        'news',
+        'suggestions',
+        'recents',
+        'tasks',
+      ],
+      showHomePortrait: false,
+    });
+
+    expect(screen.queryByTestId('new-model-shortcuts')).not.toBeInTheDocument();
+  }, 20000);
+
   it('shows no portrait to a signed-out visitor even with the preference on', async () => {
     await renderHome({ isLogin: false, showHomePortrait: true });
 
@@ -169,4 +209,48 @@ describe('Home portrait visibility', () => {
 
     expect(screen.queryByTestId('acceptance-portal-drawer')).not.toBeInTheDocument();
   }, 20000);
+});
+
+describe('Home input banner queue', () => {
+  it('reveals the next available segment after dismissing the current one', async () => {
+    vi.resetModules();
+    const { useGlobalStore } = await import('@/store/global');
+    const originalDismissedIds = useGlobalStore.getState().status.dismissedBannerIds;
+    const originalStatusInit = useGlobalStore.getState().isStatusInit;
+    useGlobalStore.setState((state) => ({
+      isStatusInit: true,
+      status: { ...state.status, dismissedBannerIds: [] },
+    }));
+
+    try {
+      const { InputBanner, InputBannerQueue, InputBannerSegment } =
+        await import('../InputArea/InputBanner');
+      const { container } = render(
+        <InputBannerQueue>
+          <InputBannerSegment dismissId={'first'}>
+            <InputBanner dismissId={'first'} dismissTitle={'Dismiss first'} testId={'first'}>
+              First
+            </InputBanner>
+          </InputBannerSegment>
+          <InputBannerSegment dismissId={'second'}>
+            <InputBanner dismissId={'second'} dismissTitle={'Dismiss second'} testId={'second'}>
+              Second
+            </InputBanner>
+          </InputBannerSegment>
+        </InputBannerQueue>,
+      );
+
+      expect(container.querySelector('[data-home-input-banner]')).toHaveTextContent('First');
+      expect(screen.getByTestId('first')).toBeVisible();
+      expect(screen.getByTestId('second')).not.toBeVisible();
+      fireEvent.click(within(screen.getByTestId('first')).getByRole('button'));
+      expect(container.querySelector('[data-home-input-banner]')).toHaveTextContent('Second');
+      expect(screen.getByTestId('second')).toBeVisible();
+    } finally {
+      useGlobalStore.setState((state) => ({
+        isStatusInit: originalStatusInit,
+        status: { ...state.status, dismissedBannerIds: originalDismissedIds },
+      }));
+    }
+  });
 });

--- a/src/features/Home/__tests__/portraitVisibility.test.tsx
+++ b/src/features/Home/__tests__/portraitVisibility.test.tsx
@@ -252,5 +252,5 @@ describe('Home input banner queue', () => {
         status: { ...state.status, dismissedBannerIds: originalDismissedIds },
       }));
     }
-  });
+  }, 20000);
 });

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -21,7 +21,6 @@ import HomeHeader from './HomeHeader';
 import HomeModeContent from './HomeModeContent';
 import HomePortrait from './HomePortrait';
 import InputArea from './InputArea';
-import { NewModelShortcuts } from './NewModelShortcuts';
 import PortraitBubble from './PortraitBubble';
 import { RAIL_INBOX_PROPS, resolveRailVisibility } from './railVisibility';
 import type { HomeMode } from './types';
@@ -67,7 +66,7 @@ const COLLAPSED_CONTENT_GAIN = 140;
 const COLLAPSED_CONTENT_OFFSET = (RAIL_RECLAIMED_WIDTH - COLLAPSED_CONTENT_GAIN) / 2;
 /** Portrait width plus its inline inset and the gap the bubble keeps from it. */
 const PORTRAIT_LANE = 152 + 12 + 16;
-const BUBBLE_MAX_WIDTH = 336;
+const BUBBLE_MAX_WIDTH = 360;
 const BUBBLE_GAP = 16;
 /**
  * What the greeting must leave alone so the bubble never lands on it, measured
@@ -319,7 +318,6 @@ const Home = memo(() => {
   const railVisible = resolveRailVisibility({ hiddenWidgets, isLogin, showHomeRail });
   const railCollapsed = !railVisible;
   const portraitVisible = Boolean(isLogin && showHomePortrait);
-  const promoVisible = Boolean(promo);
 
   useEffect(() => {
     clearOnboardingHomeModeParam();
@@ -359,14 +357,12 @@ const Home = memo(() => {
   return (
     <Flexbox className={styles.grid}>
       <div className={cx(styles.header, styles.content, railCollapsed && styles.contentCollapsed)}>
-        <HomeHeader promo={promo} />
-        {/* A campaign and the Agent's brief are both sentence-like floating
-            content in the same attention lane. They take turns instead of
-            competing; dismissing or expiring the campaign hands the lane back
-            to the portrait without changing the campaign's Cloud-owned policy. */}
-        {portraitVisible && !promoVisible && (
+        <HomeHeader />
+        {/* The portrait has one voice: a live campaign temporarily speaks in
+            place of the daily brief, which returns when the campaign leaves. */}
+        {portraitVisible && (
           <div className={cx(styles.bubbleSlot, railCollapsed && styles.bubbleSlotCollapsed)}>
-            <PortraitBubble />
+            <PortraitBubble promo={promo} />
           </div>
         )}
       </div>
@@ -384,12 +380,12 @@ const Home = memo(() => {
       >
         <Flexbox className={styles.inputArea} gap={12}>
           <InputArea
+            showNewModelShortcuts
             inputValue={inputValue}
             mode={mode}
             onInputValueChange={handleInputValueChange}
             onModeChange={setMode}
           />
-          {mode === 'chat' && <NewModelShortcuts />}
         </Flexbox>
         <HomeModeContent
           inlineRail={railCollapsed && isLogin}


### PR DESCRIPTION
## Summary

- move the active Home campaign into the portrait bubble and hide it with the portrait
- reuse the attached input footer as a dismissible queue for new-model shortcuts and Messenger
- keep the compact footer height stable and let the decorative portrait layer pass pointer events through

## Verification

- `bun run check` (9 files, 13 tests passed)
- Electron UI: New Models and Messenger both measure 78px; promo CTA is the hit target beneath the portrait layer